### PR TITLE
fix: use correct, absolute URL for grapher exports

### DIFF
--- a/baker/GrapherBaker.tsx
+++ b/baker/GrapherBaker.tsx
@@ -15,7 +15,7 @@ import {
 } from "@ourworldindata/utils"
 import fs from "fs-extra"
 import * as lodash from "lodash"
-import { bakeGraphersToPngs } from "./GrapherImageBaker.js"
+import { bakeGrapherToSvgAndPng } from "./GrapherImageBaker.js"
 import {
     OPTIMIZE_SVG_EXPORTS,
     BAKED_BASE_URL,
@@ -397,7 +397,7 @@ const bakeGrapherPageAndVariablesPngAndSVGIfChanged = async (
         const variableDataMedadataMap = new Map(
             variableDataMetadata.map((item) => [item.metadata.id, item])
         )
-        await bakeGraphersToPngs(
+        await bakeGrapherToSvgAndPng(
             `${bakedSiteDir}/grapher/exports`,
             grapher,
             variableDataMedadataMap,

--- a/baker/GrapherImageBaker.tsx
+++ b/baker/GrapherImageBaker.tsx
@@ -16,6 +16,7 @@ import {
     grapherUrlToSlugAndQueryStr,
 } from "./GrapherBakingUtils.js"
 import pMap from "p-map"
+import { BAKED_GRAPHER_URL } from "../settings/clientSettings.js"
 
 interface SvgFilenameFragments {
     slug: string
@@ -25,15 +26,13 @@ interface SvgFilenameFragments {
     queryStr?: string
 }
 
-export async function bakeGraphersToPngs(
+export async function bakeGrapherToSvgAndPng(
     outDir: string,
     jsonConfig: GrapherInterface,
     vardata: MultipleOwidVariableDataDimensionsMap,
     optimizeSvgs = false
 ) {
-    const grapher = new Grapher({ ...jsonConfig, manuallyProvideData: true })
-    grapher.isExportingToSvgOrPng = true
-    grapher.shouldIncludeDetailsInStaticExport = false
+    const grapher = initGrapherForSvgExport(jsonConfig)
     grapher.receiveOwidData(vardata)
     const outPath = path.join(outDir, grapher.slug as string)
 
@@ -132,6 +131,7 @@ export function initGrapherForSvgExport(
     queryStr: string = ""
 ) {
     const grapher = new Grapher({
+        bakedGrapherURL: BAKED_GRAPHER_URL,
         ...jsonConfig,
         manuallyProvideData: true,
         queryStr,

--- a/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
@@ -540,7 +540,8 @@ export class StaticCaptionedChart extends CaptionedChart {
     @computed private get fonts(): React.ReactElement {
         let origin = ""
         try {
-            origin = new URL(this.manager.bakedGrapherURL!).origin
+            if (this.manager.bakedGrapherURL)
+                origin = new URL(this.manager.bakedGrapherURL).origin
         } catch (e) {}
         const css = `@import url(${origin}/fonts.css)`
         return (


### PR DESCRIPTION
Fixes #3881.

I also renamed that method, so that it now actually says what it does.