### PR TITLE
✨ (related charts) prevent layout shifts when navigating

### DIFF
--- a/site/blocks/RelatedCharts.tsx
+++ b/site/blocks/RelatedCharts.tsx
@@ -96,7 +96,7 @@ export const RelatedCharts = ({
                     className="related-charts__chart span-cols-7 span-md-cols-12"
                     ref={refChartContainer}
                 >
-                    {figure}
+                    <div className="related-charts__figure">{figure}</div>
                     <div className="gallery-navigation">
                         <GalleryArrow
                             disabled={isFirstSlideActive}

--- a/site/blocks/related-charts.scss
+++ b/site/blocks/related-charts.scss
@@ -101,8 +101,14 @@
 }
 
 .related-charts__chart {
+    .related-charts__figure {
+        height: $grapher-height;
+        margin-bottom: 1rem;
+    }
+
     figure {
         @include figure-grapher-reset;
+        margin-bottom: 0;
     }
 
     .gallery-navigation {


### PR DESCRIPTION
The navigation buttons in the related charts block jump to the top while the new chart is loading:

https://github.com/user-attachments/assets/b609bdac-516b-4449-9022-831a353adf7a

