### PR TITLE
🐛 (data table) small improvements

### DIFF
--- a/packages/@ourworldindata/core-table/src/CoreTableColumns.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTableColumns.ts
@@ -247,7 +247,8 @@ export abstract class AbstractCoreColumn<JS_TYPE extends PrimitiveType> {
     }
 
     @imemo get unit(): string | undefined {
-        return this.display?.unit ?? this.def.unit
+        const unit = this.display?.unit ?? this.def.unit
+        return unit?.trim()
     }
 
     @imemo get shortUnit(): string | undefined {

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
@@ -789,15 +789,18 @@ export class DataTable extends React.Component<{
         targetTimes: number[]
         targetTimeMode: TargetTimeMode
     }): DimensionColumn[] {
-        // Inject delta columns if we have start & end values to compare in the table.
-        // One column for absolute difference, another for % difference.
+        // Inject delta columns if the data is numerical and we have start & end
+        // values to compare in the table. One column for absolute difference,
+        // another for % difference.
         const deltaColumns: DimensionColumn[] = []
-        if (targetTimeMode === TargetTimeMode.range) {
-            const { tableDisplay = {} } = sourceColumn.display ?? {}
-            if (!tableDisplay.hideAbsoluteChange)
-                deltaColumns.push({ key: RangeValueKey.delta })
-            if (!tableDisplay.hideRelativeChange)
-                deltaColumns.push({ key: RangeValueKey.deltaRatio })
+        if (sourceColumn.hasNumberFormatting) {
+            if (targetTimeMode === TargetTimeMode.range) {
+                const { tableDisplay = {} } = sourceColumn.display ?? {}
+                if (!tableDisplay.hideAbsoluteChange)
+                    deltaColumns.push({ key: RangeValueKey.delta })
+                if (!tableDisplay.hideRelativeChange)
+                    deltaColumns.push({ key: RangeValueKey.deltaRatio })
+            }
         }
 
         const valueColumns = targetTimes.map((targetTime, index) => ({


### PR DESCRIPTION
Two minor improvements to Grapher's data table:

In cases where the unit was an empty string, the data table showed an unnecessary separator:
<img width="1077" alt="Screenshot 2024-08-20 at 14 19 10" src="https://github.com/user-attachments/assets/beae54c8-59f4-410c-9a5d-dde00280afc3">

Now that we have better type information I think it makes sense to hide the change columns if we're dealing with non-numerical data:

<img width="1327" alt="Screenshot 2024-08-20 at 17 20 37" src="https://github.com/user-attachments/assets/3a3782ab-09cb-47c3-a814-e73d649558ce">
