### PR TITLE
✨ (discrete bar) fix inconsistent spacing

### DIFF
--- a/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChart.tsx
@@ -234,14 +234,11 @@ export class DiscreteBarChart
     @computed private get leftValueLabelWidth(): number {
         if (!this.hasNegative) return 0
 
-        const labelAndValueWidths = this.series
-            .filter((d) => d.value < 0)
-            .map((d) => {
-                const labelWidth = Bounds.forText(
-                    d.seriesName,
-                    this.legendLabelStyle
-                ).width
-                const valueWidth = this.formatValue(d).width
+        const labelAndValueWidths = this.sizedSeries
+            .filter((s) => s.value < 0)
+            .map((s) => {
+                const labelWidth = s.label?.width ?? 0
+                const valueWidth = this.formatValue(s).width
                 return labelWidth + valueWidth + labelToTextPadding
             })
 


### PR DESCRIPTION
I stumbled over this chart that had inconsistent spacing across facets:

| Before  | After  |
| ------- | ------ |
| <img width="1077" alt="Screenshot 2024-08-20 at 15 04 35" src="https://github.com/user-attachments/assets/d1ec8075-7da2-4359-80f7-212372c7b6ee">| <img width="1077" alt="Screenshot 2024-08-20 at 15 04 15" src="https://github.com/user-attachments/assets/2e9c4ab4-e5f1-46f1-bdb7-ce8ab2271ae6"> |