### PR TITLE
fix: propagate display.color as var display color

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.ts
+++ b/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.ts
@@ -631,7 +631,7 @@ const columnDefFromOwidVariable = (
     return {
         name,
         slug,
-        isDailyMeasurement: variable.display?.yearIsDay,
+        isDailyMeasurement: display?.yearIsDay,
         unit,
         shortUnit,
         description,
@@ -643,6 +643,7 @@ const columnDefFromOwidVariable = (
         datasetId,
         datasetName,
         display,
+        color: display?.color,
         nonRedistributable,
         sourceLink: source?.link,
         sourceName: source?.name,


### PR DESCRIPTION
Fixes [this issue brought up on Slack](https://owid.slack.com/archives/C0193RW5E2J/p1724158333414259).

Don't quite know why it works, but it does?


## Before / After

<table>
<tr><th>Before <th>After
<tr>
<td>

![CleanShot 2024-08-21 at 14 01 36](https://github.com/user-attachments/assets/5dc069b5-77b9-4849-a34a-4af23783334d)


<td>

![CleanShot 2024-08-21 at 13 59 59](https://github.com/user-attachments/assets/d120f314-7933-48ba-a29e-0848b6008200)

