### PR TITLE
🔨 add bugsnag logging to explorer-views indexing script

### DIFF
--- a/baker/algolia/indexExplorerViewsToAlgolia.ts
+++ b/baker/algolia/indexExplorerViewsToAlgolia.ts
@@ -7,13 +7,18 @@ import {
 } from "../../explorer/ExplorerConstants.js"
 import { GridBoolean } from "../../gridLang/GridLangConstants.js"
 import { getAnalyticsPageviewsByUrlObj } from "../../db/model/Pageview.js"
-import { ALGOLIA_INDEXING } from "../../settings/serverSettings.js"
+import {
+    ALGOLIA_INDEXING,
+    BUGSNAG_NODE_API_KEY,
+} from "../../settings/serverSettings.js"
 import { getAlgoliaClient } from "./configureAlgolia.js"
 import { getIndexName } from "../../site/search/searchClient.js"
 import { SearchIndexName } from "../../site/search/searchTypes.js"
 import { groupBy, keyBy, orderBy } from "lodash"
 import { MarkdownTextWrap } from "@ourworldindata/components"
 import { DbRawVariable } from "@ourworldindata/utils"
+import { logErrorAndMaybeSendToBugsnag } from "../../serverUtils/errorLog.js"
+import Bugsnag from "@bugsnag/js"
 
 export type ExplorerBlockGraphers = {
     type: "graphers"
@@ -267,6 +272,16 @@ const getExplorerViewRecordsForExplorerSlug = async (
     // Drop any views where we couldn't obtain a title, for whatever reason
     records = records.filter((record) => record.viewTitle !== undefined)
 
+    const recordsWithNoViewTitle = records.filter(
+        (record) => record.viewTitle === undefined
+    )
+    for (const record of recordsWithNoViewTitle) {
+        await logErrorAndMaybeSendToBugsnag({
+            name: "ExplorerViewTitleMissing",
+            message: `Explorer ${slug} has a view with no title: ${record.viewQueryParams}.`,
+        })
+    }
+
     // Remove Markdown from viewSubtitle; do this after fetching grapher info above, as it might also contain Markdown
     const recordsWithTitleLength = records.map((record) => {
         if (record.viewSubtitle) {
@@ -344,10 +359,17 @@ const getExplorerViewRecords = async (
 
 const indexExplorerViewsToAlgolia = async () => {
     if (!ALGOLIA_INDEXING) return
-
+    if (BUGSNAG_NODE_API_KEY) {
+        Bugsnag.start({
+            apiKey: BUGSNAG_NODE_API_KEY,
+            context: "index-explorer-views-to-algolia",
+            autoTrackSessions: false,
+        })
+    }
     const client = getAlgoliaClient()
+
     if (!client) {
-        console.error(
+        await logErrorAndMaybeSendToBugsnag(
             `Failed indexing explorer views (Algolia client not initialized)`
         )
         return
@@ -364,7 +386,10 @@ const indexExplorerViewsToAlgolia = async () => {
         )
         await index.replaceAllObjects(records)
     } catch (e) {
-        console.log("Error indexing explorer views to Algolia:", e)
+        await logErrorAndMaybeSendToBugsnag({
+            name: `IndexExplorerViewsToAlgoliaError`,
+            message: `${e}`,
+        })
     }
 }
 


### PR DESCRIPTION
We've been indexing explorer views with no titles, which is resulting in crashes on prod where we try to call a string method on the null value.

https://github.com/owid/owid-grapher/blob/1644711a245882ab45559a04c6c03ffda573fac7/site/search/SearchPanel.tsx#L343

This PR adds logging to Bugsnag in the indexing script, and omits such records from the index until we can fix their data.