### PR TITLE
2714 & 3817: Fix tooltip layout with long lines

### DIFF
--- a/packages/@ourworldindata/grapher/src/tooltip/Tooltip.scss
+++ b/packages/@ourworldindata/grapher/src/tooltip/Tooltip.scss
@@ -227,6 +227,7 @@
             }
 
             td.time-notice {
+                white-space: nowrap;
                 font-weight: $medium;
                 text-indent: 20px;
                 text-align: right;


### PR DESCRIPTION
## Description

* Fixes: https://github.com/owid/owid-grapher/issues/2714 long line length - note that I think these will still wrap as the only change is the date nowrap addition.
* This will be why I opted for `vw` unit to minimise the long line outcome.
* The same line fixes the problem Lucas was having in https://github.com/owid/owid-grapher/issues/3817: wrapping dates.

[OUT OF DATE]