### PR TITLE
perf: sort table less often & re-use `columnStore` if unchanged

### DIFF
--- a/packages/@ourworldindata/core-table/src/OwidTable.ts
+++ b/packages/@ourworldindata/core-table/src/OwidTable.ts
@@ -106,12 +106,12 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
         return min(this.allTimes) as Time
     }
 
-    @imemo get maxTime(): number | undefined {
-        return max(this.allTimes)
+    @imemo get maxTime(): Time {
+        return max(this.allTimes) as Time
     }
 
     @imemo private get allTimes(): Time[] {
-        return this.get(this.timeColumn.slug).values.slice().sort()
+        return this.get(this.timeColumn.slug).values
     }
 
     @imemo get rowIndicesByEntityName(): Map<string, number[]> {

--- a/packages/@ourworldindata/core-table/src/OwidTable.ts
+++ b/packages/@ourworldindata/core-table/src/OwidTable.ts
@@ -201,7 +201,7 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
     }
 
     // Does a stable sort by time. You can refer to this table for fast time filtering.
-    @imemo private get sortedByTime(): this {
+    @imemo get sortedByTime(): this {
         if (this.timeColumn.isMissing) return this
         return this.sortBy([this.timeColumn.slug])
     }

--- a/packages/@ourworldindata/core-table/src/OwidTable.ts
+++ b/packages/@ourworldindata/core-table/src/OwidTable.ts
@@ -111,7 +111,7 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
     }
 
     @imemo private get allTimes(): Time[] {
-        return this.get(this.timeColumn.slug).values
+        return this.get(this.timeColumn.slug).values.slice().sort()
     }
 
     @imemo get rowIndicesByEntityName(): Map<string, number[]> {
@@ -214,7 +214,7 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
         const timeColumnSlug = this.timeColumn?.slug || OwidTableSlugs.time
         // Sorting by time, because incidentally some parts of the code depended on this method
         // returning sorted rows.
-        return this.sortedByTime.columnFilter(
+        return this.columnFilter(
             timeColumnSlug,
             (time) =>
                 (time as number) >= adjustedStart &&

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -1030,7 +1030,7 @@ export class Grapher
                 table.get(this.yColumnSlugs[0]).tolerance
             )
 
-        return table.filterByTimeRange(startTime, endTime)
+        return table.filterByTimeRange(startTime, endTime).sortedByTime
     }
 
     @computed get transformedTable(): OwidTable {


### PR DESCRIPTION
I'm curious about the SVG Tester runs here 👀 

These improvements should make a sizeable perf & memory consumption improvement, and _ideally_ not break things. We'll see :)


I tested these on https://ourworldindata.org/grapher/covid-daily-vs-total-cases-per-million.