### PR TITLE
perf: simple Grapher & CoreTable perf improvements

### DIFF
--- a/packages/@ourworldindata/core-table/src/CoreTableColumns.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTableColumns.ts
@@ -24,6 +24,8 @@ import {
     imemo,
     ToleranceStrategy,
     IndicatorTitleWithFragments,
+    max,
+    min,
 } from "@ourworldindata/utils"
 import { CoreTable } from "./CoreTable.js"
 import {
@@ -499,12 +501,12 @@ export abstract class AbstractCoreColumn<JS_TYPE extends PrimitiveType> {
 
     // todo: remove. should not be on coretable
     @imemo get maxTime(): Time {
-        return last(this.uniqTimesAsc) as Time
+        return max(this.allTimes) as Time
     }
 
     // todo: remove. should not be on coretable
     @imemo get minTime(): Time {
-        return this.uniqTimesAsc[0]
+        return min(this.allTimes) as Time
     }
 
     // todo: remove? Should not be on CoreTable

--- a/packages/@ourworldindata/core-table/src/CoreTableUtils.test.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTableUtils.test.ts
@@ -379,11 +379,24 @@ describe(trimEmptyRows, () => {
 
 describe(sortColumnStore, () => {
     it("can sort", () => {
-        const result = sortColumnStore(
-            { countries: ["usa", "can", "mex"], pops: [123, 21, 99] },
-            ["pops"]
-        )
+        const columnStore = {
+            countries: ["usa", "can", "mex"],
+            pops: [123, 21, 99],
+        }
+        const result = sortColumnStore(columnStore, ["pops"])
         expect(result["pops"]).toEqual([21, 99, 123])
+        expect(result["countries"]).toEqual(["can", "mex", "usa"])
+        expect(result).not.toBe(columnStore)
+    })
+
+    it("can detect a sorted array and leave it untouched", () => {
+        const columnStore = {
+            countries: ["usa", "can", "mex"],
+            pops: [21, 99, 123],
+        }
+        const result = sortColumnStore(columnStore, ["pops"])
+        expect(result["pops"]).toEqual([21, 99, 123])
+        expect(result).toBe(columnStore)
     })
 })
 

--- a/packages/@ourworldindata/core-table/src/CoreTableUtils.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTableUtils.ts
@@ -604,7 +604,7 @@ export const sortColumnStore = (
     // Check if column store is already sorted (which is the case if newOrder is equal to range(0, startLen)).
     // If it's not sorted, we will detect that within the first few iterations usually.
     let isSorted = true
-    for (let i = 0; i <= len; i++) {
+    for (let i = 0; i < len; i++) {
         if (newOrder[i] !== i) {
             isSorted = false
             break
@@ -624,14 +624,15 @@ const makeSortByFn = (
     columnStore: CoreColumnStore,
     columnSlugs: ColumnSlug[]
 ): ((indexA: number, indexB: number) => 1 | 0 | -1) => {
-    const numSlugs = columnSlugs.length
+    const cols = columnSlugs.map((slug) => columnStore[slug])
+
     return (indexA: number, indexB: number): 1 | 0 | -1 => {
         const nodeAFirst = -1
         const nodeBFirst = 1
 
-        for (let slugIndex = 0; slugIndex < numSlugs; slugIndex++) {
-            const slug = columnSlugs[slugIndex]
-            const col = columnStore[slug]
+        // eslint-disable-next-line @typescript-eslint/prefer-for-of
+        for (let colIndex = 0; colIndex < cols.length; colIndex++) {
+            const col = cols[colIndex]
             const av = col[indexA]
             const bv = col[indexB]
             if (av < bv) return nodeAFirst

--- a/packages/@ourworldindata/core-table/src/CoreTableUtils.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTableUtils.ts
@@ -335,13 +335,15 @@ export function toleranceInterpolation(
 }
 
 // A dumb function for making a function that makes a key for a row given certain columns.
-export const makeKeyFn =
-    (columnStore: CoreColumnStore, columnSlugs: ColumnSlug[]) =>
-    (rowIndex: number): string =>
+export const makeKeyFn = (
+    columnStore: CoreColumnStore,
+    columnSlugs: ColumnSlug[]
+): ((rowIndex: number) => string) => {
+    const cols = columnSlugs.map((slug) => columnStore[slug])
+    return (rowIndex: number): string =>
         // toString() handles `undefined` and `null` values, which can be in the table.
-        columnSlugs
-            .map((slug) => toString(columnStore[slug][rowIndex]))
-            .join(" ")
+        cols.map((col) => toString(col[rowIndex])).join(" ")
+}
 
 const getColumnStoreLength = (store: CoreColumnStore): number => {
     return max(Object.values(store).map((v) => v.length)) ?? 0

--- a/packages/@ourworldindata/core-table/src/OwidTable.ts
+++ b/packages/@ourworldindata/core-table/src/OwidTable.ts
@@ -6,7 +6,6 @@ import {
     sumBy,
     uniq,
     sortNumeric,
-    last,
     groupBy,
     isNumber,
     isEmpty,
@@ -100,10 +99,6 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
         ) as Map<string, string>
     }
 
-    @imemo get maxTime(): number | undefined {
-        return last(this.allTimes)
-    }
-
     @imemo get entityIdColumn(): CoreColumn {
         return (
             this.getFirstColumnWithType(ColumnTypeNames.EntityId) ??
@@ -126,11 +121,15 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
     }
 
     @imemo get minTime(): Time {
-        return this.allTimes[0]
+        return min(this.allTimes) as Time
+    }
+
+    @imemo get maxTime(): number | undefined {
+        return max(this.allTimes)
     }
 
     @imemo private get allTimes(): Time[] {
-        return this.sortedByTime.get(this.timeColumn.slug).values
+        return this.get(this.timeColumn.slug).values
     }
 
     @imemo get rowIndicesByEntityName(): Map<string, number[]> {

--- a/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.ts
+++ b/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.ts
@@ -36,6 +36,7 @@ import {
     EPOCH_DATE,
     OwidChartDimensionInterface,
     OwidVariableType,
+    memoize,
 } from "@ourworldindata/utils"
 import { isContinentsVariableId } from "./GrapherConstants"
 
@@ -261,12 +262,13 @@ export const legacyToOwidTableAndDimensions = (
         const daysColumn = variablesJoinedByDay.getColumns([
             OwidTableSlugs.day,
         ])[0]
-        const yearsForDaysValues = []
-        for (const dayValue of daysColumn.values) {
-            yearsForDaysValues.push(
-                getYearFromISOStringAndDayOffset(EPOCH_DATE, dayValue as number)
-            )
-        }
+        const getYearFromISOStringMemoized = memoize((dayValue: number) =>
+            getYearFromISOStringAndDayOffset(EPOCH_DATE, dayValue)
+        )
+        const yearsForDaysValues = daysColumn.values.map((dayValue) =>
+            getYearFromISOStringMemoized(dayValue as number)
+        )
+
         const newYearColumn = {
             ...daysColumn,
             slug: OwidTableSlugs.year,


### PR DESCRIPTION
These are some easy changes that don't change Table method behaviour in any way, but for some of our most complex charts (read: covid scatters) these can shave off close to a second of processing time.