### PR TITLE
🔨 correctly initialize bugsnag in SiteBaker

### DIFF
--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -1,5 +1,6 @@
 import fs from "fs-extra"
 import path from "path"
+import Bugsnag from "@bugsnag/js"
 import { glob } from "glob"
 import { keyBy, without, uniq, mapValues, pick, chunk } from "lodash"
 import ProgressBar from "progress"
@@ -10,6 +11,7 @@ import {
     GDOCS_DETAILS_ON_DEMAND_ID,
     BAKED_GRAPHER_URL,
     FEATURE_FLAGS,
+    BUGSNAG_NODE_API_KEY,
 } from "../settings/serverSettings.js"
 
 import {
@@ -202,6 +204,13 @@ export class SiteBaker {
             }
         )
         this.explorerAdminServer = new ExplorerAdminServer(GIT_CMS_DIR)
+        if (BUGSNAG_NODE_API_KEY) {
+            Bugsnag.start({
+                apiKey: BUGSNAG_NODE_API_KEY,
+                context: "site-baker",
+                autoTrackSessions: false,
+            })
+        }
     }
 
     private async bakeEmbeds(knex: db.KnexReadonlyTransaction) {


### PR DESCRIPTION
Errors in the site baker that are called with `logErrorAndMaybeSendToBugsnag` haven't been logging to Bugsnag this whole time because the client wasn't being initialized before we started the bake process. 🫠 

This PR fixes that, and also fixes #3019

We have 7 errors across 16 published articles in the site baker at the moment that will start coming through once we merge this:

| error                                                                                 | source(s)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
|---------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| Explorer chart with slug coronavirus-data-explorer does not exist or is not published | "pandemics", "influenza", "covid-testing-data-archived", "the-future-is-vast", "metrics-explained-covid19-stringency-index", "covid-exemplar-germany", "covid-exemplar-vietnam", "covid-exemplar-south-korea", "covid-sweden-death-reporting", "covid-health-economy", "whats-new-june-july-2020", "covid-exemplar-vietnam-2020", "covid-exemplar-south-korea-2020", "covid-exemplar-germany-2020", "identify-covid-exemplars","covid-excess-mortality" |
| Article has no tags set. We won't be able to connect this article to datapages        | "the-future-is-vast", "metrics-explained-covid19-stringency-index", "covid-exemplar-germany", "covid-exemplar-vietnam", "covid-exemplar-south-korea", "covid-health-economy", "whats-new-june-july-2020", "covid-exemplar-vietnam-2020", "covid-exemplar-south-korea-2020", "covid-exemplar-germany-2020", "identify-covid-exemplars"                                                                                                                               |
| Author "Cameron Appel" does not exist or is not published                             | "covid-testing-data-archived"                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
| Author "Guest Authors" does not exist or is not published                             | "covid-exemplar-germany", "covid-exemplar-vietnam", "covid-exemplar-south-korea", "covid-exemplar-vietnam-2020", "covid-exemplar-south-korea-2020", "covid-exemplar-germany-2020", "identify-covid-exemplars"                                                                                                                                                                                                                                                                       |
| Author "Ernst van Woerden" does not exist or is not published                         | "whats-new-june-july-2020"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
| Author "Janine Aron" does not exist or is not published                               | "covid-excess-mortality"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
| Author "John Muellbauer" does not exist or is not published                           | "covid-excess-mortality"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |

**Thoughts on how to resolve these:**
- The explorer error isn't taking into account that we have a redirect set up. Gdoc link explorer validation should check for redirects.
- The missing tags warnings shouldn't be logged, though some of these articles we might want to add tags to. 
- The missing author errors should probably stay errors, but ignored in bugsnag, so that if new ones come through (e.g. someone misspells Hannah's name) we'll be notified and can fix it.