### PR TITLE
Fix details on demand container styling in admin

### DIFF
--- a/packages/@ourworldindata/components/src/styles/mixins.scss
+++ b/packages/@ourworldindata/components/src/styles/mixins.scss
@@ -36,6 +36,23 @@
     }
 }
 
+@mixin dod-container {
+    padding: 16px;
+    max-height: 300px;
+    overflow-y: auto;
+    scrollbar-width: thin;
+
+    > p.article-block__text:first-child {
+        font-weight: bold;
+        font-size: 1rem;
+    }
+
+    > p.article-block__text:not(:first-child) {
+        margin-top: 8px;
+        font-size: 0.875rem;
+    }
+}
+
 @mixin dod-span {
     border-bottom: 1px dotted $blue-90;
     cursor: help;

--- a/packages/@ourworldindata/grapher/src/core/grapher.scss
+++ b/packages/@ourworldindata/grapher/src/core/grapher.scss
@@ -247,3 +247,7 @@ $zindex-controls-drawer: 150;
         @include dod-span;
     }
 }
+
+.dod-container {
+    @include dod-container;
+}

--- a/site/detailsOnDemand.scss
+++ b/site/detailsOnDemand.scss
@@ -1,18 +1,5 @@
 .dod-container {
-    padding: 16px;
-    max-height: 300px;
-    overflow-y: auto;
-    scrollbar-width: thin;
-
-    > p.article-block__text:first-child {
-        font-weight: bold;
-        font-size: 1rem;
-    }
-
-    > p.article-block__text:not(:first-child) {
-        margin-top: 8px;
-        font-size: 0.875rem;
-    }
+    @include dod-container;
 }
 
 .dod-span {


### PR DESCRIPTION
DoDs in Grapher got their styling from the site, which isn't present in the admin. Move the styles to a mixin that is used both on the site and in Grapher.