### PR TITLE
enhance(search): add global `/` shortcut to focus search bar

### DIFF
--- a/site/search/Autocomplete.tsx
+++ b/site/search/Autocomplete.tsx
@@ -326,9 +326,14 @@ export function Autocomplete({
     // Register a global shortcut to open the search box on typing "/"
     useEffect(() => {
         if (!search) return
+
         Mousetrap.bind("/", (e) => {
             e.preventDefault() // don't type "/" into input
             search.setIsOpen(true)
+
+            const input =
+                containerRef.current?.querySelector<HTMLInputElement>("input")
+            input?.focus()
         })
 
         return () => {


### PR DESCRIPTION
Anywhere the `<Autocomplete>` component is mounted, you can press `/` to focus it.

`/` is also used by GitHub and YouTube. Unlike YouTube, Mousetrap ensures this also works on a German keyboard.

Mousetrap takes care that this _doesn't_ happen when some textfield is currently focused.

This will save me _seconds_!