### PR TITLE
🐛 (tooltip): add explanation test for tolerance notice

### DIFF
--- a/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChart.tsx
@@ -52,6 +52,7 @@ import {
     TooltipValue,
     TooltipState,
     makeTooltipRoundingNotice,
+    makeTooltipToleranceNotice,
 } from "../tooltip/Tooltip"
 import {
     HorizontalCategoricalColorLegend,
@@ -992,7 +993,10 @@ export class MarimekkoChart
                 ? timeColumn.formatValue(endTime)
                 : undefined
         const toleranceNotice = targetNotice
-            ? { icon: TooltipFooterIcon.notice, text: targetNotice }
+            ? {
+                  icon: TooltipFooterIcon.notice,
+                  text: makeTooltipToleranceNotice(targetNotice),
+              }
             : undefined
 
         const columns = excludeUndefined([xColumn, yColumn])

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBarChart.tsx
@@ -56,6 +56,7 @@ import {
     TooltipState,
     TooltipTable,
     makeTooltipRoundingNotice,
+    makeTooltipToleranceNotice,
 } from "../tooltip/Tooltip"
 import { StackedPoint, StackedSeries } from "./StackedConstants"
 import { ColorSchemes } from "../color/ColorSchemes"
@@ -813,7 +814,10 @@ export class StackedDiscreteBarChart
                 : undefined
 
         const toleranceNotice = targetNotice
-            ? { icon: TooltipFooterIcon.notice, text: targetNotice }
+            ? {
+                  icon: TooltipFooterIcon.notice,
+                  text: makeTooltipToleranceNotice(targetNotice),
+              }
             : undefined
         const roundingNotice = this.formatColumn.roundsToSignificantFigures
             ? {


### PR DESCRIPTION
I noticed that some of the tooltip footers didn't have a proper explanation text for tolerance.

| Before  | After  |
| ------- | ------ |
| <img width="1078" alt="Screenshot 2024-09-02 at 13 08 44" src="https://github.com/user-attachments/assets/3ffb40b1-7224-4f08-80c9-8816ce8910de">  | <img width="1078" alt="Screenshot 2024-09-02 at 13 09 18" src="https://github.com/user-attachments/assets/5af390bd-c1f2-4ed7-aba0-77a66a5f1abd"> |