### PR TITLE
mdd: fetch variable-level config by uuid

### DIFF
--- a/db/model/Variable.ts
+++ b/db/model/Variable.ts
@@ -52,6 +52,25 @@ interface VariableWithGrapherConfigs {
     etl?: ChartConfigPair
 }
 
+type VariableWithGrapherConfigIds = Pick<
+    DbRawVariable,
+    "id" | "grapherConfigIdAdmin" | "grapherConfigIdETL"
+>
+export async function getGrapherConfigIdsForVariables(
+    knex: db.KnexReadonlyTransaction,
+    variableIds: number[]
+): Promise<VariableWithGrapherConfigIds[]> {
+    const rows: VariableWithGrapherConfigIds[] = await knex(VariablesTableName)
+        .select([
+            "id",
+            "grapherConfigIdAdmin",
+            "grapherConfigIdETL",
+        ] as (keyof DbRawVariable)[])
+        .whereIn("id", variableIds)
+
+    return rows
+}
+
 export async function getGrapherConfigsForVariable(
     knex: db.KnexReadonlyTransaction,
     variableId: number

--- a/packages/@ourworldindata/types/src/siteTypes/MultiDimDataPage.ts
+++ b/packages/@ourworldindata/types/src/siteTypes/MultiDimDataPage.ts
@@ -28,7 +28,7 @@ export interface Dimension {
     name: string
     group?: string
     description?: string
-    multi_select?: boolean
+    // multi_select?: boolean
     choices: Choice[]
 }
 
@@ -83,6 +83,7 @@ export interface MultiDimDataPageProps {
     tagToSlugMap?: Record<string, string>
     faqEntries?: FaqEntryKeyedByGdocIdAndFragmentId
     primaryTopic?: PrimaryTopic | undefined
+    variableIdToGrapherConfigMap?: Record<number, string | null>
 
     initialQueryStr?: string
     canonicalUrl?: string


### PR DESCRIPTION
This is currently quite painful to test -- sorry!

During the bake, a `variableIdToGrapherConfigMap` is written into the HTML.
It maps primary variable IDs to their respective `grapherConfigIdAdmin ?? grapherConfigIdETL ?? null`.

If such a UUID is present, then the config is fetched at runtime.
It is currently a bit hard to make grapher wait for this grapher config to arrive - it displays an empty screen during the loading, rather than a loading indicator of some sort.
We can tweak this later on, but we don't want grapher to render _before_ the config override has been fetched, otherwise we're flash-rendering twice with different FAUST.