### PR TITLE
🐛 (grapher) delete stackMode=null from chart configs

### DIFF
--- a/db/migration/1725540224795-CleanUpChartConfigStackMode.ts
+++ b/db/migration/1725540224795-CleanUpChartConfigStackMode.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class CleanUpChartConfigStackMode1725540224795
+    implements MigrationInterface
+{
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`-- sql
+          UPDATE chart_configs cc
+          JOIN charts c ON c.configId = cc.id
+          SET
+              -- remove NULLs from the patch config
+              cc.patch = JSON_REMOVE(cc.patch, '$.stackMode'),
+              -- replace NULLs with the default value in the full config
+              cc.full = JSON_REPLACE(cc.full, '$.stackMode', 'absolute')
+          WHERE cc.patch ->> '$.stackMode' = 'null'
+      `)
+    }
+
+    // eslint-disable-next-line
+    public async down(queryRunner: QueryRunner): Promise<void> {}
+}

--- a/devTools/schemaProcessor/columns.json
+++ b/devTools/schemaProcessor/columns.json
@@ -653,10 +653,10 @@
         "editor": "checkbox"
     },
     {
-        "type": ["string", "null"],
+        "type": "string",
         "pointer": "/stackMode",
         "editor": "textfield",
-        "enumOptions": ["absolute", "relative", "grouped", "stacked", null]
+        "enumOptions": ["absolute", "relative"]
     },
     {
         "type": ["string", "number"],


### PR DESCRIPTION
In #3793, I removed `null` as an option from the Grapher schema. I thought I checked that we didn't have any nulls in the database, but apparently, I was wrong (see [the validation error in Slack](https://owid.slack.com/archives/C5JJW19PS/p1725531937760169)). This PR writes a migration to remove nulls from the database. I'm only doing this for chart configs since none of our indicator charts has the `stackMode` set to null.

I don't think null values currently have a way to get into the database. But if it happens, the validator will warn us again, and we can act then.