### PR TITLE
🐛 fix PNG assumption in AtomArticleBlocks

### DIFF
--- a/site/gdocs/components/AtomArticleBlocks.tsx
+++ b/site/gdocs/components/AtomArticleBlocks.tsx
@@ -94,7 +94,10 @@ function Image({
         ? Math.round(LARGEST_IMAGE_WIDTH / aspectRatio)
         : undefined
 
-    const extension = getFilenameExtension(image.filename)
+    // If we're using a resized image (i.e. it has a width suffix), the file extension is ALWAYS png
+    // If we're using the original image, we need to check the original file extension (which SHOULD be png, but might not be)
+    const extension = widthSuffix ? "png" : getFilenameExtension(filename)
+
     return (
         <img
             src={`${BAKED_BASE_URL}${IMAGES_DIRECTORY}${filenameWithoutExtension}${widthSuffix}.${extension}`}


### PR DESCRIPTION
Today, a data insight was published using JPEGs instead of PNGs which exposed a buggy assumption we were making when rendering the data insight atom feed.

This PR fixes that assumption by making sure we only assume the extension is a PNG when we're rendering a resized version of the image. (See this [resize code for context](https://github.com/owid/owid-grapher/blob/20f9ea4b6522b6c74f605180d51023617e7174ea/baker/GDriveImagesBaker.tsx#L109))

In a followup PR we should make sure authors only use PNGs for data insights because JPEGs aren't the best format for data viz graphics, and converting them to PNG in the resize process adds artifacts

![Screenshot 2024-09-06 at 11 49 53](https://github.com/user-attachments/assets/80754805-25f9-485c-b70e-33f3f5c1ddde)
From [this image](https://ourworldindata.org/images/published/di-annual-reported-passenger-kilometers-mobile2_1350.png)
