### PR TITLE
DB dots stop and interface appears

### DIFF
--- a/devTools/docker/wait-for-mysql.sh
+++ b/devTools/docker/wait-for-mysql.sh
@@ -15,8 +15,10 @@ fi
 : "${GRAPHER_DB_PORT:?Need to set GRAPHER_DB_PORT non-empty}"
 
 printf 'Waiting for MySQL to come up...'
-while ! mysql -u$GRAPHER_DB_USER -p$GRAPHER_DB_PASS -h $GRAPHER_DB_HOST --port=$GRAPHER_DB_PORT -e 'select 1' $GRAPHER_DB_NAME &>/dev/null; do
+while ! mysqlsh; do
     printf '.'
     sleep 1
+    if [ mysqlsh -u$GRAPHER_DB_USER -p$GRAPHER_DB_PASS -h $GRAPHER_DB_HOST --port=$GRAPHER_DB_PORT -e 'select 1' $GRAPHER_DB_NAME ]; then
+        break;
+    fi
 done
-printf 'ok\n'

--- a/devTools/docker/wait-for-tests-mysql.sh
+++ b/devTools/docker/wait-for-tests-mysql.sh
@@ -15,8 +15,10 @@ fi
 : "${GRAPHER_TEST_DB_PORT:?Need to set GRAPHER_TEST_DB_PORT non-empty}"
 
 printf 'Waiting for MySQL to come up...'
-while ! mysql -u$GRAPHER_TEST_DB_USER -p$GRAPHER_TEST_DB_PASS -h $GRAPHER_TEST_DB_HOST --port=$GRAPHER_TEST_DB_PORT -e 'select 1 from _test_db_ready' $GRAPHER_TEST_DB_NAME &>/dev/null; do
+while ! mysqlsh; do
     printf '.'
     sleep 1
+    if [ mysql -u$GRAPHER_TEST_DB_USER -p$GRAPHER_TEST_DB_PASS -h $GRAPHER_TEST_DB_HOST --port=$GRAPHER_TEST_DB_PORT -e 'select 1 from _test_db_ready' $GRAPHER_TEST_DB_NAME ]; then
+        break;
+    fi
 done
-printf 'ok\n'


### PR DESCRIPTION
## Description

I mentioned the DB dots. A while back I opened a PR to collect some newbie errors and see if they were worth keeeping.
[
The TMux stuff made it](https://github.com/owid/owid-grapher/pull/3841/files), but I should have made two PRs.

### I did thus

* `&>/dev/` removed that because I think it's swalllowing everything and returning true
* removeing _just_ that makes this happen: `.devTools/docker/wait-for-mysql.sh: line 18: mysql: command not found` until the connection is made
* I first just check for the [shell, 8.0, some details here](https://dev.mysql.com/doc/mysql-shell/8.0/en/).
* Then do dots
* And finally use the rest of the condition with `break;`

### Problem: Shell

Never gets as far as the dots

### Problem: Connection

Dots go on, looking broken.

### No Problem: An SQL Prompt

<img width="1007" alt="image" src="https://github.com/user-attachments/assets/f0f3b80d-5939-4b9d-b2b5-46c99b7abf7c">

## Impact

When everyone knows, great. 

1000 open source folk come, that's going to say "the DB hasn't finish running". 

After giving it 20 mins, open Docker now; and no free charity UI. It's hard work to push through this. It isn't amateur or junior. I think I've done it but it's probably close to 20 hours once I factor in all the Docker refreshes, etc etc. I'm not an expert. My first bug-fix was diagnosed in the browser.

### Possibly fixes:

https://github.com/owid/owid-grapher/discussions/3075
https://github.com/owid/owid-grapher/discussions/3122

And this maybe:

https://github.com/owid/owid-grapher/discussions/1963