### PR TITLE
🐛 fix duplicate indicators in indicator-based explorers

### DIFF
--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -589,13 +589,18 @@ export class Explorer
         // set given variable IDs as dimensions to make Grapher
         // download the data and metadata for these variables
         const dimensions = config.dimensions ?? []
-
-        yVariableIdsList.forEach((yVariableId) => {
-            dimensions.push({
+        const variablesToLoad = yVariableIdsList
+            // Filter out variableIds that are already present in the dimensions array
+            .filter(
+                (yVariableId) =>
+                    !dimensions.some((d) => d.variableId === yVariableId)
+            )
+            .map((yVariableId) => ({
                 variableId: yVariableId,
                 property: DimensionProperty.y,
-            })
-        })
+            }))
+        dimensions.push(...variablesToLoad)
+
         if (xVariableId) {
             const maybeXVariableId = parseIntOrUndefined(xVariableId)
             if (maybeXVariableId !== undefined)

--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -593,7 +593,11 @@ export class Explorer
             // Filter out variableIds that are already present in the dimensions array
             .filter(
                 (yVariableId) =>
-                    !dimensions.some((d) => d.variableId === yVariableId)
+                    !dimensions.some(
+                        (d) =>
+                            d.property === DimensionProperty.y &&
+                            d.variableId === yVariableId
+                    )
             )
             .map((yVariableId) => ({
                 variableId: yVariableId,


### PR DESCRIPTION
A naive potential fix for https://github.com/owid/owid-grapher/issues/3943

I don't understand the Explorer data model well enough to know why `explorerProgram.grapherConfig` has the `yVariableIds`that it does - but it seems this line of code that inserts extra variables into the grapher config to get it to load the indicator data and metadata was assuming there'd be no duplicates.

There's almost certainly a better upstream fix for this, but this can fix the issue in the meantime until someone who understands explorers better can work things out.