### PR TITLE
Change URLs from OurWorldInData to OurWorldinData in chart footers

### DIFF
--- a/packages/@ourworldindata/grapher/src/footer/Footer.tsx
+++ b/packages/@ourworldindata/grapher/src/footer/Footer.tsx
@@ -142,7 +142,7 @@ export class Footer<
 
         const url = parseUrl(originUrl)
         return `${url.hostname}${url.pathname}`
-            .replace("ourworldindata.org", "OurWorldInData.org")
+            .replace("ourworldindata.org", "OurWorldinData.org")
             .replace(/\/$/, "") // remove trailing slash
     }
 

--- a/site/LongFormPage.tsx
+++ b/site/LongFormPage.tsx
@@ -96,7 +96,7 @@ export const LongFormPage = (props: {
     const citationText = `${formatAuthors({
         authors: citationAuthors,
         requireMax: true,
-    })} (${citationPublishedYear}) - "${citationTitle}". Published online at OurWorldInData.org. Retrieved from: '${citationCanonicalUrl}' [Online Resource]`
+    })} (${citationPublishedYear}) - "${citationTitle}". Published online at OurWorldinData.org. Retrieved from: '${citationCanonicalUrl}' [Online Resource]`
 
     const bibtex = `@article{owid${citationSlug.replace(/-/g, "")},
     author = {${formatAuthors({

--- a/site/gdocs/pages/GdocPost.tsx
+++ b/site/gdocs/pages/GdocPost.tsx
@@ -58,7 +58,7 @@ export function GdocPost({
         content.title ?? "",
         publishedAt
     )
-    const citationText = `${shortPageCitation} Published online at OurWorldInData.org. Retrieved from: '${`${BAKED_BASE_URL}/${slug}`}' [Online Resource]`
+    const citationText = `${shortPageCitation} Published online at OurWorldinData.org. Retrieved from: '${`${BAKED_BASE_URL}/${slug}`}' [Online Resource]`
     const hasSidebarToc = content["sidebar-toc"]
     const isDeprecated =
         postType === OwidGdocType.Article &&


### PR DESCRIPTION
We've decided to change the URL's capitalization in our chart footers from `OurWorldInData.org` to `OurWorldinData.org` to make them easier to read.