### PR TITLE
🐛 (explorer) remove duplicate columns / TAS-613

### DIFF
--- a/baker/siteRenderers.tsx
+++ b/baker/siteRenderers.tsx
@@ -811,7 +811,13 @@ export const renderExplorerPage = async (
                       config: row.grapherConfigETL as string,
                   })
                 : {}
-            return mergeGrapherConfigs(etlConfig, adminConfig)
+            const mergedConfig = mergeGrapherConfigs(etlConfig, adminConfig)
+            // explorers set their own dimensions, so we don't need to include them here
+            const mergedConfigWithoutDimensions = lodash.omit(
+                mergedConfig,
+                "dimensions"
+            )
+            return mergedConfigWithoutDimensions
         })
 
     const wpContent = transformedProgram.wpBlockId

--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -588,22 +588,13 @@ export class Explorer
 
         // set given variable IDs as dimensions to make Grapher
         // download the data and metadata for these variables
-        const dimensions = config.dimensions ?? []
-        const variablesToLoad = yVariableIdsList
-            // Filter out variableIds that are already present in the dimensions array
-            .filter(
-                (yVariableId) =>
-                    !dimensions.some(
-                        (d) =>
-                            d.property === DimensionProperty.y &&
-                            d.variableId === yVariableId
-                    )
-            )
-            .map((yVariableId) => ({
+        const dimensions = config.dimensions?.slice() ?? []
+        yVariableIdsList.forEach((yVariableId) => {
+            dimensions.push({
                 variableId: yVariableId,
                 property: DimensionProperty.y,
-            }))
-        dimensions.push(...variablesToLoad)
+            })
+        })
 
         if (xVariableId) {
             const maybeXVariableId = parseIntOrUndefined(xVariableId)


### PR DESCRIPTION
Fixes #3943

In #3793, we added a `dimensions` field to all existing ETL-authored indicator configs, but explorers don't expect partial grapher configs to come with dimensions.

Explorers specify their own dimensions, which led to the indicator of the partial grapher config being added twice. What made this worse is that the `dimensions` array of the partial grapher config got mutated every time a different view was selected, which led to dimensions being added multiple times to the same Grapher.