### PR TITLE
🐛 fix query pointing to charts.config / TAS-614

### DIFF
--- a/baker/algolia/indexExplorerViewsToAlgolia.ts
+++ b/baker/algolia/indexExplorerViewsToAlgolia.ts
@@ -172,14 +172,15 @@ const getExplorerViewRecordsForExplorerSlug = async (
             `Fetching grapher configs from ${grapherIds.length} graphers for explorer ${slug}`
         )
         const grapherIdToTitle = await trx
-            .table("charts")
             .select(
-                "id",
-                trx.raw("config->>'$.title' as title"),
-                trx.raw("config->>'$.subtitle' as subtitle")
+                trx.raw("charts.id as id"),
+                trx.raw("chart_configs.full->>'$.title' as title"),
+                trx.raw("chart_configs.full->>'$.subtitle' as subtitle")
             )
-            .whereIn("id", grapherIds)
-            .andWhereRaw("config->>'$.isPublished' = 'true'")
+            .from("charts")
+            .join("chart_configs", { "charts.configId": "chart_configs.id" })
+            .whereIn("charts.id", grapherIds)
+            .andWhereRaw("chart_configs.full->>'$.isPublished' = 'true'")
             .then((rows) => keyBy(rows, "id"))
 
         for (const record of records) {


### PR DESCRIPTION
Fixes https://owid.slack.com/archives/C5JJW19PS/p1726254980391989

A query tried to access `charts.config` in the indexing step. I haven't tested this locally (I didn't know how), but the CI built the search index successfully in the baking step. There is another error about missing grapher IDs for one explorer that I think is unrelated.