### PR TITLE
🐛 fix global entity selector

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -65,6 +65,7 @@ import {
     getOriginAttributionFragments,
     sortBy,
     extractDetailsFromSyntax,
+    omit,
 } from "@ourworldindata/utils"
 import {
     MarkdownTextWrap,
@@ -505,7 +506,14 @@ export class Grapher
 
         if (props) this.setAuthoredVersion(props)
 
-        this.updateFromObject(props)
+        // prefer the manager's selection over the config's selectedEntityNames
+        // if both are passed in and the manager's selection is not empty.
+        // this is necessary for the global entity selector to work correctly.
+        if (props.manager?.selection?.hasSelection) {
+            this.updateFromObject(omit(props, "selectedEntityNames"))
+        } else {
+            this.updateFromObject(props)
+        }
 
         if (!props.table) this.downloadData()
 


### PR DESCRIPTION
Fixes #3931 

The global entity selector manages the selection of a chart from outside by passing in its own `selection` object, which should take precedence over the config's `selectedEntityNames`.  

In #3793, Grapher's `updateFromObject` method was updated to also change the current selection if `selectedEntityNames` is given. That's sensible (and is needed in the admin), but `updateFromObject` is also called in the constructor. If `selectedEntityNames` and `selection` both are given then `selectedEntityNames` always won, which broke the global entity selector (since it relies on `selection` being respected).

I think it's sensible to apply the passed-in selection only if it's non-empty, but this leads to funny behaviour of the global entity selector if the selection happens to be empty (e.g., http://staging-site-fix-global-entity-selector/energy/country/spain?country=). But, apparently, even before #3793, the global entity selector has behaved weirdly for empty selections (e.g., https://e7fd384b.owid.pages.dev/energy/country/spain?country=). It's not ideal, but I don't think it's too bad.