### PR TITLE
:sparkles: Enable explorers on staging servers

### DIFF
--- a/gitCms/GitCmsConstants.ts
+++ b/gitCms/GitCmsConstants.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs"
 
 export const GIT_CMS_DEFAULT_BRANCH =
     process.env.GIT_CMS_DEFAULT_BRANCH ?? "master"
+
 export const GIT_CMS_READ_ROUTE = "/git-cms-read"
 export const GIT_CMS_WRITE_ROUTE = "/git-cms-write"
 export const GIT_CMS_DELETE_ROUTE = "/git-cms-delete"

--- a/gitCms/GitCmsConstants.ts
+++ b/gitCms/GitCmsConstants.ts
@@ -1,7 +1,8 @@
 import * as path from "path"
 import * as fs from "node:fs"
 
-export const GIT_CMS_DEFAULT_BRANCH = "master"
+export const GIT_CMS_DEFAULT_BRANCH =
+    process.env.GIT_CMS_DEFAULT_BRANCH ?? "master"
 export const GIT_CMS_READ_ROUTE = "/git-cms-read"
 export const GIT_CMS_WRITE_ROUTE = "/git-cms-write"
 export const GIT_CMS_DELETE_ROUTE = "/git-cms-delete"


### PR DESCRIPTION
Load `GIT_CMS_DEFAULT_BRANCH` from env if available. This will be useful for explorers on staging servers.