### PR TITLE
✨ (admin) allow to overwrite parent values with automatic defaults / TAS-624

### DIFF
--- a/adminSiteClient/EditorCustomizeTab.tsx
+++ b/adminSiteClient/EditorCustomizeTab.tsx
@@ -17,6 +17,7 @@ import {
     TextField,
     Button,
     RadioGroup,
+    BindAutoFloatExt,
 } from "./Forms.js"
 import {
     debounce,
@@ -27,6 +28,8 @@ import {
     SortOrder,
     SortBy,
     SortConfig,
+    minTimeBoundFromJSONOrNegativeInfinity,
+    maxTimeBoundFromJSONOrPositiveInfinity,
 } from "@ourworldindata/utils"
 import { faPlus, faMinus } from "@fortawesome/free-solid-svg-icons"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
@@ -41,6 +44,73 @@ import { ErrorMessages } from "./ChartEditorTypes.js"
 
 const debounceOnLeadingEdge = (fn: (...args: any[]) => void) =>
     debounce(fn, 0, { leading: true, trailing: false })
+
+@observer
+class TimeField<
+    T extends { [field: string]: any },
+    K extends Extract<keyof T, string>,
+> extends React.Component<{
+    field: K
+    store: T
+    label: string
+    defaultValue: number
+    parentValue: number
+    isInherited: boolean
+    allowLinking: boolean
+}> {
+    private setValue(value: number) {
+        this.props.store[this.props.field] = value as any
+    }
+
+    @computed get currentValue(): number | undefined {
+        return this.props.store[this.props.field]
+    }
+
+    @action.bound onChange(value: number | undefined) {
+        this.setValue(value ?? this.props.defaultValue)
+    }
+
+    @action.bound onBlur() {
+        if (this.currentValue === undefined) {
+            this.setValue(this.props.defaultValue)
+        }
+    }
+
+    render() {
+        const { label, field, defaultValue } = this.props
+
+        // the reset button resets the value to its default
+        const resetButton = {
+            onClick: action(() => this.setValue(defaultValue)),
+            disabled: this.currentValue === defaultValue,
+        }
+
+        return this.props.allowLinking ? (
+            <BindAutoFloatExt
+                label={label}
+                readFn={(store) => store[field]}
+                writeFn={(store, newVal) =>
+                    (store[this.props.field] = newVal as any)
+                }
+                auto={this.props.parentValue}
+                isAuto={this.props.isInherited}
+                store={this.props.store}
+                onBlur={this.onBlur}
+                resetButton={resetButton}
+            />
+        ) : (
+            <NumberField
+                label={label}
+                value={this.currentValue}
+                // invoke on the leading edge to avoid interference with onBlur
+                onValue={debounceOnLeadingEdge(this.onChange)}
+                onBlur={this.onBlur}
+                allowNegative
+                resetButton={resetButton}
+            />
+        )
+    }
+}
 
 @observer
 export class ColorSchemeSelector extends React.Component<{
@@ -310,60 +380,6 @@ class TimelineSection<
         return this.props.editor.grapher
     }
 
-    @computed get minTime() {
-        return this.grapher.minTime
-    }
-    @computed get maxTime() {
-        return this.grapher.maxTime
-    }
-
-    @computed get timelineMinTime() {
-        return this.grapher.timelineMinTime
-    }
-    @computed get timelineMaxTime() {
-        return this.grapher.timelineMaxTime
-    }
-
-    @action.bound onMinTime(value: number | undefined) {
-        this.grapher.minTime = value ?? TimeBoundValue.negativeInfinity
-    }
-
-    @action.bound onMaxTime(value: number | undefined) {
-        this.grapher.maxTime = value ?? TimeBoundValue.positiveInfinity
-    }
-
-    @action.bound onBlurMinTime() {
-        if (this.minTime === undefined) {
-            this.grapher.minTime = TimeBoundValue.negativeInfinity
-        }
-    }
-
-    @action.bound onBlurMaxTime() {
-        if (this.maxTime === undefined) {
-            this.grapher.maxTime = TimeBoundValue.positiveInfinity
-        }
-    }
-
-    @action.bound onTimelineMinTime(value: number | undefined) {
-        this.grapher.timelineMinTime = value
-    }
-
-    @action.bound onBlurTimelineMinTime() {
-        if (this.grapher.timelineMinTime === undefined) {
-            this.grapher.timelineMinTime = TimeBoundValue.negativeInfinity
-        }
-    }
-
-    @action.bound onTimelineMaxTime(value: number | undefined) {
-        this.grapher.timelineMaxTime = value
-    }
-
-    @action.bound onBlurTimelineMaxTime() {
-        if (this.grapher.timelineMaxTime === undefined) {
-            this.grapher.timelineMaxTime = TimeBoundValue.positiveInfinity
-        }
-    }
-
     @action.bound onToggleHideTimeline(value: boolean) {
         this.grapher.hideTimeline = value || undefined
     }
@@ -373,56 +389,77 @@ class TimelineSection<
     }
 
     render() {
-        const { features } = this.props.editor
+        const { editor } = this.props
+        const { features } = editor
         const { grapher } = this
 
         return (
             <Section name="Timeline selection">
                 <FieldsRow>
                     {features.timeDomain && (
-                        <NumberField
+                        <TimeField
+                            store={this.grapher}
+                            field="minTime"
                             label="Selection start"
-                            value={this.minTime}
-                            // invoke on the leading edge to avoid interference with onBlur
-                            onValue={debounceOnLeadingEdge(this.onMinTime)}
-                            onBlur={this.onBlurMinTime}
-                            allowNegative
+                            defaultValue={TimeBoundValue.negativeInfinity}
+                            parentValue={minTimeBoundFromJSONOrNegativeInfinity(
+                                editor.activeParentConfig?.minTime
+                            )}
+                            isInherited={editor.isPropertyInherited("minTime")}
+                            allowLinking={editor.couldPropertyBeInherited(
+                                "minTime"
+                            )}
                         />
                     )}
-                    <NumberField
+                    <TimeField
+                        store={this.grapher}
+                        field="maxTime"
                         label={
                             features.timeDomain
                                 ? "Selection end"
                                 : "Selected year"
                         }
-                        value={this.maxTime}
-                        // invoke on the leading edge to avoid interference with onBlur
-                        onValue={debounceOnLeadingEdge(this.onMaxTime)}
-                        onBlur={this.onBlurMaxTime}
-                        allowNegative
+                        defaultValue={TimeBoundValue.positiveInfinity}
+                        parentValue={maxTimeBoundFromJSONOrPositiveInfinity(
+                            editor.activeParentConfig?.maxTime
+                        )}
+                        isInherited={editor.isPropertyInherited("maxTime")}
+                        allowLinking={editor.couldPropertyBeInherited(
+                            "maxTime"
+                        )}
                     />
                 </FieldsRow>
                 {features.timelineRange && (
                     <FieldsRow>
-                        <NumberField
+                        <TimeField
+                            store={this.grapher}
+                            field="timelineMinTime"
                             label="Timeline min"
-                            value={this.timelineMinTime}
-                            // invoke on the leading edge to avoid interference with onBlur
-                            onValue={debounceOnLeadingEdge(
-                                this.onTimelineMinTime
+                            defaultValue={TimeBoundValue.negativeInfinity}
+                            parentValue={minTimeBoundFromJSONOrNegativeInfinity(
+                                editor.activeParentConfig?.timelineMinTime
                             )}
-                            onBlur={this.onBlurTimelineMinTime}
-                            allowNegative
+                            isInherited={editor.isPropertyInherited(
+                                "timelineMinTime"
+                            )}
+                            allowLinking={editor.couldPropertyBeInherited(
+                                "timelineMinTime"
+                            )}
                         />
-                        <NumberField
+                        <TimeField
+                            store={this.grapher}
+                            field="timelineMaxTime"
                             label="Timeline max"
-                            value={this.timelineMaxTime}
-                            // invoke on the leading edge to avoid interference with onBlur
-                            onValue={debounceOnLeadingEdge(
-                                this.onTimelineMaxTime
+                            defaultValue={TimeBoundValue.positiveInfinity}
+                            parentValue={maxTimeBoundFromJSONOrPositiveInfinity(
+                                editor.activeParentConfig?.timelineMaxTime
                             )}
-                            onBlur={this.onBlurTimelineMaxTime}
-                            allowNegative
+                            isInherited={editor.isPropertyInherited(
+                                "timelineMaxTime"
+                            )}
+                            allowLinking={editor.couldPropertyBeInherited(
+                                "timelineMaxTime"
+                            )}
                         />
                     </FieldsRow>
                 )}
@@ -538,6 +575,12 @@ export class EditorCustomizeTab<
                                         onValue={(value) =>
                                             (yAxisConfig.min = value)
                                         }
+                                        resetButton={{
+                                            onClick: () =>
+                                                (yAxisConfig.min = undefined),
+                                            disabled:
+                                                yAxisConfig.min === undefined,
+                                        }}
                                         allowDecimal
                                         allowNegative
                                     />
@@ -547,6 +590,12 @@ export class EditorCustomizeTab<
                                         onValue={(value) =>
                                             (yAxisConfig.max = value)
                                         }
+                                        resetButton={{
+                                            onClick: () =>
+                                                (yAxisConfig.max = undefined),
+                                            disabled:
+                                                yAxisConfig.max === undefined,
+                                        }}
                                         allowDecimal
                                         allowNegative
                                     />
@@ -611,6 +660,12 @@ export class EditorCustomizeTab<
                                         onValue={(value) =>
                                             (xAxisConfig.min = value)
                                         }
+                                        resetButton={{
+                                            onClick: () =>
+                                                (xAxisConfig.min = undefined),
+                                            disabled:
+                                                xAxisConfig.min === undefined,
+                                        }}
                                         allowDecimal
                                         allowNegative
                                     />
@@ -620,6 +675,12 @@ export class EditorCustomizeTab<
                                         onValue={(value) =>
                                             (xAxisConfig.max = value)
                                         }
+                                        resetButton={{
+                                            onClick: () =>
+                                                (xAxisConfig.max = undefined),
+                                            disabled:
+                                                xAxisConfig.max === undefined,
+                                        }}
                                         allowDecimal
                                         allowNegative
                                     />

--- a/adminSiteClient/EditorTextTab.tsx
+++ b/adminSiteClient/EditorTextTab.tsx
@@ -93,11 +93,9 @@ export class EditorTextTab<
                 <Section name="Header">
                     <BindAutoStringExt
                         label="Title"
-                        readFn={({ grapher }) => grapher.displayTitle}
-                        writeFn={({ grapher }, newVal) =>
-                            (grapher.title = newVal)
-                        }
-                        readAutoFn={({ editor }) =>
+                        readFn={(grapher) => grapher.displayTitle}
+                        writeFn={(grapher, newVal) => (grapher.title = newVal)}
+                        auto={
                             editor.couldPropertyBeInherited("title")
                                 ? editor.activeParentConfig!.title
                                 : undefined
@@ -106,7 +104,7 @@ export class EditorTextTab<
                             editor.isPropertyInherited("title") ||
                             grapher.title === undefined
                         }
-                        store={{ grapher, editor }}
+                        store={grapher}
                         softCharacterLimit={100}
                     />
                     {features.showEntityAnnotationInTitleToggle && (
@@ -156,11 +154,11 @@ export class EditorTextTab<
                     />
                     <BindAutoStringExt
                         label="Subtitle"
-                        readFn={({ grapher }) => grapher.currentSubtitle}
-                        writeFn={({ grapher }, newVal) =>
+                        readFn={(grapher) => grapher.currentSubtitle}
+                        writeFn={(grapher, newVal) =>
                             (grapher.subtitle = newVal)
                         }
-                        readAutoFn={({ editor }) =>
+                        auto={
                             editor.couldPropertyBeInherited("subtitle")
                                 ? editor.activeParentConfig!.subtitle
                                 : undefined
@@ -169,7 +167,7 @@ export class EditorTextTab<
                             editor.isPropertyInherited("subtitle") ||
                             grapher.subtitle === undefined
                         }
-                        store={{ grapher, editor }}
+                        store={grapher}
                         placeholder="Briefly describe the context of the data. It's best to avoid duplicating any information which can be easily inferred from other visual elements of the chart."
                         textarea
                         softCharacterLimit={280}
@@ -192,11 +190,11 @@ export class EditorTextTab<
                 <Section name="Footer">
                     <BindAutoStringExt
                         label="Source"
-                        readFn={({ grapher }) => grapher.sourcesLine}
-                        writeFn={({ grapher }, newVal) =>
+                        readFn={(grapher) => grapher.sourcesLine}
+                        writeFn={(grapher, newVal) =>
                             (grapher.sourceDesc = newVal)
                         }
-                        readAutoFn={({ editor }) =>
+                        auto={
                             editor.couldPropertyBeInherited("sourceDesc")
                                 ? editor.activeParentConfig!.sourceDesc
                                 : undefined
@@ -205,7 +203,7 @@ export class EditorTextTab<
                             editor.isPropertyInherited("sourceDesc") ||
                             grapher.sourceDesc === undefined
                         }
-                        store={{ grapher, editor }}
+                        store={grapher}
                         helpText="Short comma-separated list of source names"
                         softCharacterLimit={60}
                     />
@@ -233,9 +231,16 @@ export class EditorTextTab<
                             </div>
                         )}
 
-                    <BindString
+                    <BindAutoStringExt
                         label="Footer note"
-                        field="note"
+                        readFn={(grapher) => grapher.note ?? ""}
+                        writeFn={(grapher, newVal) => (grapher.note = newVal)}
+                        auto={
+                            editor.couldPropertyBeInherited("note")
+                                ? editor.activeParentConfig?.note
+                                : undefined
+                        }
+                        isAuto={editor.isPropertyInherited("note")}
                         store={grapher}
                         helpText="Any important clarification needed to avoid miscommunication"
                         softCharacterLimit={140}

--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -647,6 +647,35 @@ $nav-height: 45px;
     }
 }
 
+.WithResetButton {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+
+    .form-group {
+        margin-bottom: 0;
+        width: 100%;
+    }
+
+    .ResetToDefaultButton {
+        padding: 0;
+        font-size: 0.8em;
+        color: inherit;
+
+        &:disabled {
+            font-style: italic;
+        }
+
+        &:not(:disabled) {
+            text-decoration: underline;
+        }
+
+        &:hover {
+            text-decoration: none;
+        }
+    }
+}
+
 .ColorBox {
     width: 2em;
     height: 2em;

--- a/db/migration/1726819761333-AddExplicitAutoValuesToChartConfigs.ts
+++ b/db/migration/1726819761333-AddExplicitAutoValuesToChartConfigs.ts
@@ -1,0 +1,68 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class AddExplicitAutoValuesToChartConfigs1726819761333
+    implements MigrationInterface
+{
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const addExplicitAutoValueToFullChartConfigs = async (
+            jsonPath: string,
+            defaultValue: string
+        ): Promise<void> => {
+            await queryRunner.query(
+                `
+                -- sql
+                    UPDATE chart_configs cc
+                    -- the join is necessary to limit the update to charts only
+                    JOIN charts c ON c.configId = cc.id
+                    SET cc.full = JSON_SET(cc.full, ?, ?)
+                    WHERE cc.full ->> ? IS NULL
+                `,
+                [jsonPath, defaultValue, jsonPath]
+            )
+        }
+
+        await addExplicitAutoValueToFullChartConfigs(
+            "$.timelineMinTime",
+            "earliest"
+        )
+        await addExplicitAutoValueToFullChartConfigs(
+            "$.timelineMaxTime",
+            "latest"
+        )
+        await addExplicitAutoValueToFullChartConfigs("$.yAxis.min", "auto")
+        await addExplicitAutoValueToFullChartConfigs("$.yAxis.max", "auto")
+        await addExplicitAutoValueToFullChartConfigs("$.xAxis.min", "auto")
+        await addExplicitAutoValueToFullChartConfigs("$.xAxis.max", "auto")
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        const removeExplicitAutoValueFromFullChartConfigs = async (
+            jsonPath: string,
+            defaultValue: string
+        ): Promise<void> => {
+            await queryRunner.query(
+                `
+                    -- sql
+                    UPDATE chart_configs cc
+                    JOIN charts c ON c.configId = cc.id
+                    SET cc.full = JSON_REMOVE(cc.full, ?)
+                    WHERE JSON_EXTRACT(cc.full, ?) = ?
+                `,
+                [jsonPath, jsonPath, defaultValue]
+            )
+        }
+
+        await removeExplicitAutoValueFromFullChartConfigs(
+            "$.timelineMinTime",
+            "earliest"
+        )
+        await removeExplicitAutoValueFromFullChartConfigs(
+            "$.timelineMaxTime",
+            "latest"
+        )
+        await removeExplicitAutoValueFromFullChartConfigs("$.yAxis.min", "auto")
+        await removeExplicitAutoValueFromFullChartConfigs("$.yAxis.max", "auto")
+        await removeExplicitAutoValueFromFullChartConfigs("$.xAxis.min", "auto")
+        await removeExplicitAutoValueFromFullChartConfigs("$.xAxis.max", "auto")
+    }
+}

--- a/devTools/schemaProcessor/columns.json
+++ b/devTools/schemaProcessor/columns.json
@@ -207,9 +207,9 @@
         "editor": "textfield"
     },
     {
-        "type": "number",
+        "type": ["string", "number"],
         "pointer": "/yAxis/min",
-        "editor": "numeric"
+        "editor": "textfield"
     },
     {
         "type": "string",
@@ -219,9 +219,9 @@
         "enumOptions": ["linear", "log"]
     },
     {
-        "type": "number",
+        "type": ["string", "number"],
         "pointer": "/yAxis/max",
-        "editor": "numeric"
+        "editor": "textfield"
     },
     {
         "type": "boolean",
@@ -267,9 +267,9 @@
         "editor": "checkbox"
     },
     {
-        "type": "integer",
+        "type": ["string", "number"],
         "pointer": "/timelineMinTime",
-        "editor": "numeric"
+        "editor": "textfield"
     },
     {
         "type": "string",
@@ -686,9 +686,9 @@
         "editor": "textfield"
     },
     {
-        "type": "number",
+        "type": ["string", "number"],
         "pointer": "/xAxis/min",
-        "editor": "numeric"
+        "editor": "textfield"
     },
     {
         "type": "string",
@@ -698,9 +698,9 @@
         "enumOptions": ["linear", "log"]
     },
     {
-        "type": "number",
+        "type": ["string", "number"],
         "pointer": "/xAxis/max",
-        "editor": "numeric"
+        "editor": "textfield"
     },
     {
         "type": "boolean",
@@ -715,9 +715,9 @@
         "enumOptions": ["independent", "shared"]
     },
     {
-        "type": "integer",
+        "type": ["string", "number"],
         "pointer": "/timelineMaxTime",
-        "editor": "numeric"
+        "editor": "textfield"
     },
     {
         "type": "boolean",

--- a/packages/@ourworldindata/grapher/src/axis/AxisConfig.test.ts
+++ b/packages/@ourworldindata/grapher/src/axis/AxisConfig.test.ts
@@ -3,6 +3,20 @@
 import { AxisConfig } from "../axis/AxisConfig"
 import { ScaleType } from "@ourworldindata/types"
 
+it("serializes max to 'auto' if undefined", () => {
+    const axis = new AxisConfig({ min: 1 })
+    const obj = axis.toObject()
+    expect(obj.min).toBe(1)
+    expect(obj.max).toBe("auto")
+})
+
+it("serializes min to 'auto' if undefined", () => {
+    const axis = new AxisConfig({ max: 0 })
+    const obj = axis.toObject()
+    expect(obj.max).toBe(0)
+    expect(obj.min).toBe("auto")
+})
+
 it("can create an axis, clone and modify the clone without affecting the original", () => {
     const axis = new AxisConfig({ scaleType: ScaleType.linear })
     expect(axis.scaleType).toEqual(ScaleType.linear)

--- a/packages/@ourworldindata/grapher/src/axis/AxisConfig.ts
+++ b/packages/@ourworldindata/grapher/src/axis/AxisConfig.ts
@@ -11,6 +11,7 @@ import {
 import { observable, computed } from "mobx"
 import { HorizontalAxis, VerticalAxis } from "./Axis"
 import {
+    AxisMinMaxValueStr,
     AxisConfigInterface,
     FacetAxisDomain,
     ScaleType,
@@ -44,6 +45,13 @@ class AxisConfigDefaults implements AxisConfigInterface {
     @observable.ref domainValues?: number[] = undefined
 }
 
+function parseAutoOrNumberFromJSON(
+    value: AxisMinMaxValueStr.auto | number | undefined
+): number | undefined {
+    if (value === AxisMinMaxValueStr.auto) return undefined
+    return value
+}
+
 export class AxisConfig
     extends AxisConfigDefaults
     implements AxisConfigInterface, Persistable
@@ -59,6 +67,8 @@ export class AxisConfig
     // todo: test/refactor
     updateFromObject(props?: AxisConfigInterface): void {
         if (props) extend(this, props)
+        if (props?.min) this.min = parseAutoOrNumberFromJSON(props?.min)
+        if (props?.max) this.max = parseAutoOrNumberFromJSON(props?.max)
     }
 
     toObject(): AxisConfigInterface {
@@ -82,9 +92,12 @@ export class AxisConfig
             ticks: this.ticks,
             singleValueAxisPointAlign: this.singleValueAxisPointAlign,
             domainValues: this.domainValues,
-        })
+        }) as AxisConfigInterface
 
         deleteRuntimeAndUnchangedProps(obj, new AxisConfigDefaults())
+
+        if (obj.min === undefined) obj.min = AxisMinMaxValueStr.auto
+        if (obj.max === undefined) obj.max = AxisMinMaxValueStr.auto
 
         return obj
     }

--- a/packages/@ourworldindata/grapher/src/core/Grapher.jsdom.test.ts
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.jsdom.test.ts
@@ -62,7 +62,8 @@ const TestGrapherConfig = (): {
 it("regression fix: container options are not serialized", () => {
     const grapher = new Grapher({ xAxis: { min: 1 } })
     const obj = grapher.toObject().xAxis!
-    expect(obj.max).toBe(undefined)
+    expect(obj.min).toBe(1)
+    expect(obj.scaleType).toBe(undefined)
     expect((obj as any).containerOptions).toBe(undefined) // Regression test: should never be a containerOptions
 })
 

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -545,6 +545,11 @@ export class Grapher
         if (obj.minTime) obj.minTime = minTimeToJSON(this.minTime) as any
         if (obj.maxTime) obj.maxTime = maxTimeToJSON(this.maxTime) as any
 
+        if (obj.timelineMinTime)
+            obj.timelineMinTime = minTimeToJSON(this.timelineMinTime) as any
+        if (obj.timelineMaxTime)
+            obj.timelineMaxTime = maxTimeToJSON(this.timelineMaxTime) as any
+
         // todo: remove dimensions concept
         // if (this.legacyConfigAsAuthored?.dimensions)
         //     obj.dimensions = this.legacyConfigAsAuthored.dimensions
@@ -574,6 +579,13 @@ export class Grapher
         // JSON doesn't support Infinity, so we use strings instead.
         this.minTime = minTimeBoundFromJSONOrNegativeInfinity(obj.minTime)
         this.maxTime = maxTimeBoundFromJSONOrPositiveInfinity(obj.maxTime)
+
+        this.timelineMinTime = minTimeBoundFromJSONOrNegativeInfinity(
+            obj.timelineMinTime
+        )
+        this.timelineMaxTime = maxTimeBoundFromJSONOrPositiveInfinity(
+            obj.timelineMaxTime
+        )
 
         // Todo: remove once we are more RAII.
         if (obj?.dimensions?.length)

--- a/packages/@ourworldindata/grapher/src/schema/defaultGrapherConfig.ts
+++ b/packages/@ourworldindata/grapher/src/schema/defaultGrapherConfig.ts
@@ -23,7 +23,9 @@ export const defaultGrapherConfig = {
     maxTime: "latest",
     yAxis: {
         removePointsOutsideDomain: false,
+        min: "auto",
         scaleType: "linear",
+        max: "auto",
         canChangeScaleType: false,
         facetDomain: "shared",
     },
@@ -32,6 +34,7 @@ export const defaultGrapherConfig = {
     hasChartTab: true,
     hideLegend: false,
     hideLogo: false,
+    timelineMinTime: "earliest",
     hideTimeline: false,
     colorScale: {
         equalSizeBins: true,
@@ -60,10 +63,13 @@ export const defaultGrapherConfig = {
     },
     xAxis: {
         removePointsOutsideDomain: false,
+        min: "auto",
         scaleType: "linear",
+        max: "auto",
         canChangeScaleType: false,
         facetDomain: "shared",
     },
+    timelineMaxTime: "latest",
     hideConnectedScatterLines: false,
     showNoDataArea: true,
     zoomToSelection: false,

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.005.yaml
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.005.yaml
@@ -134,10 +134,15 @@ properties:
         type: boolean
         default: false
     timelineMinTime:
-        type: integer
         description: |
             The lowest year to show in the timeline. If this is set then the user is not able to see
-            any data before this year. Inferred from data if not provided.
+            any data before this year. If set to "earliest", then the earliest year in the data is used.
+        default: earliest
+        oneOf:
+            - type: number
+            - type: string
+              enum:
+                  - earliest
     variantName:
         type: string
         description: Optional internal variant name for distinguishing charts with the same title
@@ -423,10 +428,15 @@ properties:
     xAxis:
         $ref: "#/$defs/axis"
     timelineMaxTime:
-        type: integer
         description: |
             The highest year to show in the timeline. If this is set then the user is not able to see
-            any data after this year. Inferred from data if not provided.
+            any data after this year. If set to "latest", then the latest year in the data is used.
+        default: latest
+        oneOf:
+            - type: number
+            - type: string
+              enum:
+                  - latest
     hideConnectedScatterLines:
         type: boolean
         default: false
@@ -504,8 +514,13 @@ $defs:
                 type: string
                 description: Axis label
             min:
-                type: number
-                description: Minimum domain value of the axis. Inferred from data if not provided.
+                description: Minimum domain value of the axis. Inferred from data if set to "auto".
+                default: auto
+                oneOf:
+                    - type: number
+                    - type: string
+                      enum:
+                          - auto
             scaleType:
                 type: string
                 description: Toggle linear/logarithmic
@@ -514,8 +529,13 @@ $defs:
                     - linear
                     - log
             max:
-                type: number
-                description: Maximum domain value of the axis. Inferred from data if not provided.
+                description: Maximum domain value of the axis. Inferred from data if set to "auto".
+                default: auto
+                oneOf:
+                    - type: number
+                    - type: string
+                      enum:
+                          - auto
             canChangeScaleType:
                 type: boolean
                 description: Allow user to change lin/log

--- a/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
+++ b/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
@@ -132,6 +132,10 @@ export enum ChartTypeName {
     WorldMap = "WorldMap",
 }
 
+export enum AxisMinMaxValueStr {
+    auto = "auto",
+}
+
 // We currently have the notion of "modes", where you can either select 1 entity, or select multiple entities, or not change the selection at all.
 // Todo: can we remove?
 export enum EntitySelectionMode {
@@ -222,8 +226,8 @@ export interface TickFormattingOptions {
 export interface AxisConfigInterface {
     scaleType?: ScaleType
     label?: string
-    min?: number
-    max?: number
+    min?: number | AxisMinMaxValueStr.auto
+    max?: number | AxisMinMaxValueStr.auto
     canChangeScaleType?: boolean
     removePointsOutsideDomain?: boolean
     hideAxis?: boolean
@@ -535,8 +539,8 @@ export interface GrapherInterface extends SortConfig {
     hideAnnotationFieldsInTitle?: AnnotationFieldsInTitle
     minTime?: TimeBound | TimeBoundValueStr
     maxTime?: TimeBound | TimeBoundValueStr
-    timelineMinTime?: Time
-    timelineMaxTime?: Time
+    timelineMinTime?: Time | TimeBoundValueStr
+    timelineMaxTime?: Time | TimeBoundValueStr
     dimensions?: OwidChartDimensionInterface[]
     addCountryMode?: EntitySelectionMode
     comparisonLines?: ComparisonLineConfig[]

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -99,6 +99,7 @@ export {
     type ChartRedirect,
     type DetailsMarker,
     GrapherWindowType,
+    AxisMinMaxValueStr,
 } from "./grapherTypes/GrapherTypes.js"
 
 export {


### PR DESCRIPTION
### Background

Grapher sometimes assigns meaning to config values being `undefined`. For example, if `timelineMaxTime` is undefined, Grapher uses the latest year in the data. This is problematic in an inheritance model since `undefined` can't be used to overwrite values. As a result, it's currently not possible to overwrite custom parent values with the automatic-default option for the following properties:

- `timelineMinTime` and `timelineMaxTime`
- `yAxis.min`, `yAxis.max`, `xAxis.min`, `xAxis.max`
- `baseColorScheme`
- `yAxis.label` and `xAxis.label`
- `map.columnSlug`

### Summary

Instead of relying on `undefined` to have a value derived from the data, this PR adds a new value, like `"auto"` or `"latest"`, to make the behaviour explicit.

This is done for:
- `timelineMinTime` and `timelineMaxTime` (`"earliest"` and `"latest"` respectively)
- `yAxis.min`, `yAxis.max`, `xAxis.min`, `xAxis.max` (`"auto"`)

But not for:
- `map.columnSlug`
    - Unlikely that someone wishes to restore the default behaviour if the parent specifies a better default
- `yAxis.label` and `xAxis.label`
    - Unlikely that someone wants to restore the default label when a parent specifies a better one (if an author really wants the original default value, they can of course type it in manually and overwrite the parent value like that)
- `baseColorScheme`
    - Since the default is just a particular scheme picked for you, an author can pick that scheme manually as well.

### Other changes

- Adds a link/unlink button to the "Note" field
- Adds link/unlink buttons to time selection fields (`minTime`, `maxTime`, `timelineMinTime`, `timelineMaxTime`)
- Adds a reset-to-default button to the time selection fields and axis min/max fields 
- Tightens the UI around the link/unlink button
    - If currently linked, the unlink button is disabled
    - Adds a more obvious tooltip that explains the behaviour of the link/unlink button