### PR TITLE
✨ (line chart) improve static version for Figma / TAS-628

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/grapher.scss
+++ b/packages/@ourworldindata/grapher/src/core/grapher.scss
@@ -146,25 +146,6 @@ $zindex-controls-drawer: 150;
         cursor: pointer;
     }
 
-    /* Make World line slightly thicker */
-    svg .key-World_0 polyline {
-        stroke-width: 2 !important;
-    }
-
-    .projection .nv-line {
-        stroke-dasharray: 3, 3;
-    }
-
-    .projection .nv-point {
-        fill: #fff;
-        stroke-width: 1;
-        opacity: 0.5;
-    }
-
-    .projection .nv-point.hover {
-        stroke-width: 4;
-    }
-
     .DataTableContainer {
         z-index: $zindex-table;
     }

--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChartConstants.ts
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChartConstants.ts
@@ -14,6 +14,7 @@ export interface PlacedPoint {
     x: number
     y: number
     color: Color
+    time: number
 }
 
 export interface LineChartSeries extends ChartSeries {
@@ -33,6 +34,8 @@ export interface LinesProps {
     lineStrokeWidth?: number
     lineOutlineWidth?: number
     markerRadius?: number
+    isStatic?: boolean
+    multiColor?: boolean
 }
 
 export interface LineChartManager extends ChartManager {

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -312,16 +312,11 @@ export const makeSafeForCSS = (name: string): string =>
  * element. This is useful when a static chart is manually edited in a SVG
  * editor since SVG manipulation software like Figma often show the element's
  * id as its title.
+ *
+ * Note that these IDs are not meant to be used in CSS!
  */
-export function makeIdForHumanConsumption(
-    name: string,
-    unsafeKey?: string
-): string {
-    let id = name
-    if (unsafeKey) {
-        id += "__" + makeSafeForCSS(unsafeKey)
-    }
-    return id
+export function makeIdForHumanConsumption(...unsafeKeys: string[]): string {
+    return unsafeKeys.join("__")
 }
 
 export function formatDay(


### PR DESCRIPTION
Makes line charts a bit nicer to work with in Figma. In particular:
- Simplifies/flattens the hierarchy
- Removes groups and elements that are unnecessary for a static export
- Groups elements by type more often

I find grouping elements by type a bit un-elegant in code tbh. But if it helps our authors edit charts in Figma, it's a small price to pay, I guess :)

#### Screenshots (Figma)

| Before  | After  |
| ------- | ------ |
| <img width="333" alt="Screenshot 2024-10-07 at 13 52 38" src="https://github.com/user-attachments/assets/ed85d96b-c00d-4e06-bbd5-d20f60998c1c">  | <img width="333" alt="Screenshot 2024-10-07 at 13 52 52" src="https://github.com/user-attachments/assets/27684c02-c67a-40fe-92e5-525ef337c20b"> |