### PR TITLE
🎉 (static charts) add output channel for social media / TAS-639

### DIFF
--- a/adminSiteClient/EditorExportTab.tsx
+++ b/adminSiteClient/EditorExportTab.tsx
@@ -160,45 +160,58 @@ export class EditorExportTab<
     }
 
     @action.bound private onDownloadDesktopSVG() {
-        void this.download(
-            `${this.baseFilename}-desktop.svg`,
-            GrapherStaticFormat.landscape
-        )
+        void this.download(`${this.baseFilename}-desktop.svg`, {
+            format: GrapherStaticFormat.landscape,
+        })
     }
 
     @action.bound private onDownloadDesktopPNG() {
-        void this.download(
-            `${this.baseFilename}-desktop.png`,
-            GrapherStaticFormat.landscape
-        )
+        void this.download(`${this.baseFilename}-desktop.png`, {
+            format: GrapherStaticFormat.landscape,
+        })
     }
 
     @action.bound private onDownloadMobileSVG() {
-        void this.download(
-            `${this.baseFilename}-mobile.svg`,
-            GrapherStaticFormat.square
-        )
+        void this.download(`${this.baseFilename}-mobile.svg`, {
+            format: GrapherStaticFormat.square,
+        })
     }
 
     @action.bound private onDownloadMobilePNG() {
-        void this.download(
-            `${this.baseFilename}-mobile.png`,
-            GrapherStaticFormat.square
-        )
+        void this.download(`${this.baseFilename}-mobile.png`, {
+            format: GrapherStaticFormat.square,
+        })
+    }
+
+    @action.bound private onDownloadMobileSVGForSocialMedia() {
+        void this.download(`${this.baseFilename}-instagram.svg`, {
+            format: GrapherStaticFormat.square,
+            isSocialMediaExport: true,
+        })
     }
 
     private async download(
         filename: ExportFilename,
-        format: GrapherStaticFormat
+        {
+            format,
+            isSocialMediaExport = false,
+        }: {
+            format: GrapherStaticFormat
+            isSocialMediaExport?: boolean
+        }
     ) {
         try {
             let grapher = this.grapher
-            if (this.grapher.staticFormat !== format) {
+            if (
+                this.grapher.staticFormat !== format ||
+                this.grapher.isSocialMediaExport !== isSocialMediaExport
+            ) {
                 grapher = new Grapher({
                     ...this.grapher,
                     staticFormat: format,
                     selectedEntityNames:
                         this.grapher.selection.selectedEntityNames,
+                    isSocialMediaExport,
                 })
             }
             const { blob: pngBlob, svgBlob } = await grapher.rasterize()
@@ -320,6 +333,12 @@ export class EditorExportTab<
                             onClick={this.onDownloadMobileSVG}
                         >
                             Download Mobile SVG
+                        </button>
+                        <button
+                            className="btn btn-primary"
+                            onClick={this.onDownloadMobileSVGForSocialMedia}
+                        >
+                            Download Mobile SVG for Social Media
                         </button>
                     </div>
                 </Section>

--- a/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChart.tsx
@@ -547,7 +547,10 @@ export class DiscreteBarChart
                                 opacity={GRAPHER_AREA_OPACITY_DEFAULT}
                                 style={{ transition: "height 200ms ease" }}
                             />
-                            <Halo id={series.seriesName + "-label"}>
+                            <Halo
+                                id={series.seriesName + "-label"}
+                                background={this.manager.backgroundColor}
+                            >
                                 <text
                                     x={0}
                                     y={0}

--- a/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
@@ -20,6 +20,7 @@ import {
     Patterns,
     STATIC_EXPORT_DETAIL_SPACING,
     DEFAULT_GRAPHER_FRAME_PADDING,
+    GRAPHER_BACKGROUND_DEFAULT,
 } from "../core/GrapherConstants"
 import { MapChartManager } from "../mapCharts/MapChartConstants"
 import { ChartManager } from "../chart/ChartManager"
@@ -36,6 +37,7 @@ import {
     FacetStrategy,
     GrapherTabOption,
     RelatedQuestionsConfig,
+    Color,
 } from "@ourworldindata/types"
 import { DataTable, DataTableManager } from "../dataTable/DataTable"
 import {
@@ -66,12 +68,13 @@ export interface CaptionedChartManager
     staticBounds?: Bounds
     staticBoundsWithDetails?: Bounds
 
-    // layout
+    // layout & style
     isSmall?: boolean
     isMedium?: boolean
     framePaddingHorizontal?: number
     framePaddingVertical?: number
     fontSize?: number
+    backgroundColor?: string
 
     // state
     tab?: GrapherTabOption
@@ -80,6 +83,7 @@ export interface CaptionedChartManager
     type: ChartTypeName
     typeExceptWhenLineChartAndSingleTimeThenWillBeBarChart?: ChartTypeName
     showEntitySelectionToggle?: boolean
+    isExportingForSocialMedia?: boolean
 
     // timeline
     hasTimeline?: boolean
@@ -403,7 +407,12 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
         //    #5 Footer
         //    #6 [Related question]
         return (
-            <div className="CaptionedChart">
+            <div
+                className="CaptionedChart"
+                style={{
+                    backgroundColor: this.backgroundColor,
+                }}
+            >
                 {/* #1 Header */}
                 <Header manager={this.manager} maxWidth={this.maxWidth} />
                 <VerticalSpace height={this.verticalPadding} />
@@ -435,6 +444,10 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
         )
     }
 
+    @computed protected get backgroundColor(): Color {
+        return this.manager.backgroundColor ?? GRAPHER_BACKGROUND_DEFAULT
+    }
+
     @computed protected get svgProps(): React.SVGProps<SVGSVGElement> {
         return {
             xmlns: "http://www.w3.org/2000/svg",
@@ -443,7 +456,8 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
                 fontFamily:
                     "Lato, 'Helvetica Neue', Helvetica, Arial, 'Liberation Sans', sans-serif",
                 fontSize: this.manager.fontSize ?? BASE_FONT_SIZE,
-                backgroundColor: "white",
+                // needs to be set here or else pngs will have a black background
+                backgroundColor: this.backgroundColor,
                 textRendering: "geometricPrecision",
                 WebkitFontSmoothing: "antialiased",
             },
@@ -571,12 +585,14 @@ export class StaticCaptionedChart extends CaptionedChart {
             >
                 {this.fonts}
                 {this.patterns}
-                <rect
-                    className="background-fill"
-                    fill="white"
-                    width={width}
-                    height={height}
-                />
+                {!this.manager.isExportingForSocialMedia && (
+                    <rect
+                        className="background-fill"
+                        fill={this.backgroundColor}
+                        width={width}
+                        height={height}
+                    />
+                )}
                 <StaticHeader
                     manager={manager}
                     maxWidth={maxWidth}

--- a/packages/@ourworldindata/grapher/src/chart/ChartManager.ts
+++ b/packages/@ourworldindata/grapher/src/chart/ChartManager.ts
@@ -11,6 +11,7 @@ import {
     ColorSchemeName,
     EntityName,
     DetailsMarker,
+    Color,
 } from "@ourworldindata/types"
 import { TooltipManager } from "../tooltip/TooltipProps"
 import { OwidTable, CoreColumn } from "@ourworldindata/core-table"
@@ -95,7 +96,9 @@ export interface ChartManager {
     isStatic?: boolean
     isSemiNarrow?: boolean
     isStaticAndSmall?: boolean
+    isExportingForSocialMedia?: boolean
     secondaryColorInStaticCharts?: string
+    backgroundColor?: Color
 
     detailsOrderedByReference?: string[]
     detailsMarkerInSvg?: DetailsMarker

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -104,6 +104,7 @@ import {
     DetailDictionary,
     GrapherWindowType,
     MultiDimDataPageProps,
+    Color,
 } from "@ourworldindata/types"
 import {
     BlankOwidTable,
@@ -126,6 +127,8 @@ import {
     GRAPHER_LOADED_EVENT_NAME,
     isContinentsVariableId,
     isPopulationVariableETLPath,
+    GRAPHER_BACKGROUND_BEIGE,
+    GRAPHER_BACKGROUND_DEFAULT,
 } from "../core/GrapherConstants"
 import { defaultGrapherConfig } from "../schema/defaultGrapherConfig"
 import { loadVariableDataAndMetadata } from "./loadVariable"
@@ -848,6 +851,7 @@ export class Grapher
 
     @observable.ref renderToStatic = false
     @observable.ref isExportingToSvgOrPng = false
+    @observable.ref isSocialMediaExport = false
 
     tooltips?: TooltipManager["tooltips"] = observable.map({}, { deep: false })
     @observable isPlaying = false
@@ -2903,8 +2907,22 @@ export class Grapher
         return staticPixelCount < 0.66 * idealPixelCount
     }
 
-    @computed get secondaryColorInStaticCharts(): string {
+    @computed get secondaryColorInStaticCharts(): Color {
         return this.isStaticAndSmall ? GRAPHER_LIGHT_TEXT : GRAPHER_DARK_TEXT
+    }
+
+    @computed get isExportingForSocialMedia(): boolean {
+        return (
+            this.isExportingToSvgOrPng &&
+            this.isStaticAndSmall &&
+            this.isSocialMediaExport
+        )
+    }
+
+    @computed get backgroundColor(): Color {
+        return this.isExportingForSocialMedia
+            ? GRAPHER_BACKGROUND_BEIGE
+            : GRAPHER_BACKGROUND_DEFAULT
     }
 
     // Binds chart properties to global window title and URL. This should only

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -305,6 +305,7 @@ export interface GrapherProgrammaticInterface extends GrapherInterface {
     hideShareButton?: boolean
     hideExploreTheDataButton?: boolean
     hideRelatedQuestion?: boolean
+    isSocialMediaExport?: boolean
 
     getGrapherInstance?: (instance: Grapher) => void
 

--- a/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
@@ -20,6 +20,9 @@ export const DEFAULT_GRAPHER_HEIGHT = 600
 export const DEFAULT_GRAPHER_FRAME_PADDING = 16
 export const STATIC_EXPORT_DETAIL_SPACING = 8
 
+export const GRAPHER_BACKGROUND_DEFAULT = "#ffffff"
+export const GRAPHER_BACKGROUND_BEIGE = "#fffbf5"
+
 export const GRAPHER_DARK_TEXT = "#5b5b5b"
 export const GRAPHER_LIGHT_TEXT = "#858585"
 

--- a/packages/@ourworldindata/grapher/src/facetChart/FacetChart.tsx
+++ b/packages/@ourworldindata/grapher/src/facetChart/FacetChart.tsx
@@ -263,6 +263,7 @@ export class FacetChart
             startTime,
             endTime,
             missingDataStrategy,
+            backgroundColor,
         } = manager
 
         // Use compact labels, e.g. 50k instead of 50,000.
@@ -316,6 +317,7 @@ export class FacetChart
                 startTime,
                 endTime,
                 missingDataStrategy,
+                backgroundColor,
                 ...series.manager,
                 xAxisConfig: {
                     ...globalXAxisConfig,

--- a/packages/@ourworldindata/grapher/src/halo/Halo.tsx
+++ b/packages/@ourworldindata/grapher/src/halo/Halo.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { Color } from "@ourworldindata/types"
 
 const defaultHaloStyle: React.CSSProperties = {
     fill: "#fff",
@@ -12,10 +13,19 @@ const defaultHaloStyle: React.CSSProperties = {
 export function Halo(props: {
     id: React.Key
     children: React.ReactElement
+    background?: Color
     style?: React.CSSProperties
 }): React.ReactElement {
+    const defaultStyle = {
+        ...defaultHaloStyle,
+        fill: props.background ?? defaultHaloStyle.fill,
+        stroke: props.background ?? defaultHaloStyle.stroke,
+    }
     const halo = React.cloneElement(props.children, {
-        style: { ...defaultHaloStyle, ...props.style },
+        style: {
+            ...defaultStyle,
+            ...props.style,
+        },
     })
     return (
         <React.Fragment key={props.id}>

--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
@@ -62,6 +62,7 @@ import {
     GRAPHER_AXIS_LINE_WIDTH_THICK,
     GRAPHER_AXIS_LINE_WIDTH_DEFAULT,
     BASE_FONT_SIZE,
+    GRAPHER_BACKGROUND_DEFAULT,
 } from "../core/GrapherConstants"
 import { ColorSchemes } from "../color/ColorSchemes"
 import { AxisConfig, AxisManager } from "../axis/AxisConfig"
@@ -101,8 +102,6 @@ import {
     HorizontalNumericColorLegend,
 } from "../horizontalColorLegend/HorizontalColorLegends"
 
-// background
-const BACKGROUND_COLOR = "#fff"
 // line color
 const BLUR_LINE_COLOR = "#eee"
 const DEFAULT_LINE_COLOR = "#000"
@@ -207,7 +206,9 @@ class Lines extends React.Component<LinesProps> {
                                     "outline",
                                     series.seriesName
                                 ),
-                                stroke: BACKGROUND_COLOR,
+                                stroke:
+                                    this.props.backgroundColor ??
+                                    GRAPHER_BACKGROUND_DEFAULT,
                                 strokeWidth:
                                     this.strokeWidth +
                                     this.lineOutlineWidth * 2,
@@ -585,7 +586,10 @@ export class LineChart
                                       )
                                     : series.color
                             }
-                            stroke="#fff"
+                            stroke={
+                                this.manager.backgroundColor ??
+                                GRAPHER_BACKGROUND_DEFAULT
+                            }
                             strokeWidth={0.5}
                         />
                     )
@@ -854,7 +858,9 @@ export class LineChart
         const lineWidth = manager.isStaticAndSmall
             ? GRAPHER_AXIS_LINE_WIDTH_THICK
             : GRAPHER_AXIS_LINE_WIDTH_DEFAULT
-        const dashPattern = manager.isStaticAndSmall ? "7, 7" : undefined
+        const dashPattern = manager.isExportingForSocialMedia
+            ? "7, 7"
+            : undefined
 
         return (
             <DualAxisComponent
@@ -887,6 +893,7 @@ export class LineChart
                         dualAxis={this.dualAxis}
                         comparisonLine={line}
                         baseFontSize={this.fontSize}
+                        backgroundColor={this.manager.backgroundColor}
                     />
                 ))}
                 {manager.showLegend && <LineLegend manager={this} />}
@@ -898,6 +905,7 @@ export class LineChart
                     focusedSeriesNames={this.focusedSeriesNames}
                     lineStrokeWidth={this.lineStrokeWidth}
                     lineOutlineWidth={this.lineOutlineWidth}
+                    backgroundColor={this.manager.backgroundColor}
                     markerRadius={this.markerRadius}
                     isStatic={manager.isStatic}
                 />
@@ -1067,10 +1075,13 @@ export class LineChart
     }
 
     numericBinSize = 6
-    numericBinStroke = BACKGROUND_COLOR
     numericBinStrokeWidth = 1
     legendTextColor = "#555"
     legendTickSize = 1
+
+    @computed get numericBinStroke(): Color {
+        return this.manager.backgroundColor ?? GRAPHER_BACKGROUND_DEFAULT
+    }
 
     @computed get numericLegend(): HorizontalNumericColorLegend | undefined {
         return this.hasColorScale && this.manager.showLegend

--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChartConstants.ts
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChartConstants.ts
@@ -36,6 +36,7 @@ export interface LinesProps {
     markerRadius?: number
     isStatic?: boolean
     multiColor?: boolean
+    backgroundColor?: string
 }
 
 export interface LineChartManager extends ChartManager {

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
@@ -39,6 +39,7 @@ export interface DownloadModalManager {
     isOnChartOrMapTab?: boolean
     framePaddingVertical?: number
     showAdminControls?: boolean
+    isSocialMediaExport?: boolean
 }
 
 interface DownloadModalProps {
@@ -61,6 +62,10 @@ export class DownloadModal extends React.Component<DownloadModalProps> {
 
     @computed private get isExportingSquare(): boolean {
         return this.manager.staticFormat === GrapherStaticFormat.square
+    }
+
+    @computed private get isSocialMediaExport(): boolean {
+        return this.manager.isSocialMediaExport ?? false
     }
 
     @computed private get shouldIncludeDetails(): boolean {
@@ -204,6 +209,10 @@ export class DownloadModal extends React.Component<DownloadModalProps> {
             : GrapherStaticFormat.square
     }
 
+    @action.bound private toggleExportForUseInSocialMedia(): void {
+        this.manager.isSocialMediaExport = !this.isSocialMediaExport
+    }
+
     @action.bound private toggleIncludeDetails(): void {
         this.manager.shouldIncludeDetailsInStaticExport =
             !this.manager.shouldIncludeDetailsInStaticExport
@@ -295,11 +304,37 @@ export class DownloadModal extends React.Component<DownloadModalProps> {
                                     <Checkbox
                                         checked={this.isExportingSquare}
                                         label="Square format"
-                                        onChange={(): void => {
+                                        onChange={action((): void => {
                                             this.reset()
                                             this.toggleExportFormat()
+
+                                            if (!this.isExportingSquare) {
+                                                this.manager.isSocialMediaExport =
+                                                    false
+                                            }
+
                                             this.export()
-                                        }}
+                                        })}
+                                    />
+                                )}
+                                {this.manager.showAdminControls && (
+                                    <Checkbox
+                                        checked={this.isSocialMediaExport}
+                                        label="For use in social media (internal)"
+                                        onChange={action((): void => {
+                                            this.reset()
+                                            this.toggleExportForUseInSocialMedia()
+
+                                            // set reasonable defaults for social media exports
+                                            if (this.isSocialMediaExport) {
+                                                this.manager.staticFormat =
+                                                    GrapherStaticFormat.square
+                                                this.manager.shouldIncludeDetailsInStaticExport =
+                                                    false
+                                            }
+
+                                            this.export()
+                                        })}
                                     />
                                 )}
                             </div>

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ComparisonLine.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ComparisonLine.tsx
@@ -11,7 +11,7 @@ import { observer } from "mobx-react"
 import { DualAxis } from "../axis/Axis"
 import { generateComparisonLinePoints } from "./ComparisonLineGenerator"
 import { Halo } from "../halo/Halo"
-import { ComparisonLineConfig } from "@ourworldindata/types"
+import { Color, ComparisonLineConfig } from "@ourworldindata/types"
 import { GRAPHER_FONT_SCALE_10_5 } from "../core/GrapherConstants"
 
 @observer
@@ -19,6 +19,7 @@ export class ComparisonLine extends React.Component<{
     dualAxis: DualAxis
     comparisonLine: ComparisonLineConfig
     baseFontSize: number
+    backgroundColor?: Color
 }> {
     private renderUid = guid()
 
@@ -122,7 +123,10 @@ export class ComparisonLine extends React.Component<{
                         }}
                         clipPath={`url(#axisBounds-${renderUid})`}
                     >
-                        <Halo id={`path-${renderUid}`}>
+                        <Halo
+                            id={`path-${renderUid}`}
+                            background={this.props.backgroundColor}
+                        >
                             <textPath
                                 baselineShift="-0.2rem"
                                 href={`#path-${renderUid}`}

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
@@ -638,6 +638,7 @@ export class ScatterPlotChart
                 onMouseLeave={this.onScatterMouseLeave}
                 onClick={this.onScatterClick}
                 quadtree={this.quadtree}
+                backgroundColor={this.manager.backgroundColor}
             />
         )
     }
@@ -789,6 +790,7 @@ export class ScatterPlotChart
                             dualAxis={dualAxis}
                             comparisonLine={line}
                             baseFontSize={this.fontSize}
+                            backgroundColor={this.manager.backgroundColor}
                         />
                     ))}
                 {this.points}

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChartConstants.ts
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChartConstants.ts
@@ -135,6 +135,7 @@ export interface ScatterPointsWithLabelsProps {
     disableIntroAnimation?: boolean
     hideScatterLabels?: boolean
     quadtree: Quadtree<ScatterPointQuadtreeNode>
+    backgroundColor?: Color
 }
 
 export const SCATTER_QUADTREE_SAMPLING_DISTANCE = 10

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPointsWithLabels.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPointsWithLabels.tsx
@@ -425,6 +425,7 @@ export class ScatterPointsWithLabels extends React.Component<ScatterPointsWithLa
                             <Halo
                                 key={series.displayKey + "-endLabel"}
                                 id={series.displayKey + "-endLabel"}
+                                background={this.props.backgroundColor}
                             >
                                 <text
                                     id={makeIdForHumanConsumption(
@@ -560,6 +561,7 @@ export class ScatterPointsWithLabels extends React.Component<ScatterPointsWithLa
                     <Halo
                         key={`${series.displayKey}-label-${index}`}
                         id={`${series.displayKey}-label-${index}`}
+                        background={this.props.backgroundColor}
                     >
                         <text
                             id={makeIdForHumanConsumption(

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterSizeLegend.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterSizeLegend.tsx
@@ -3,6 +3,7 @@ import { computed } from "mobx"
 import { scaleLinear, ScaleLinear } from "d3-scale"
 import { TextWrap } from "@ourworldindata/components"
 import {
+    Color,
     first,
     last,
     makeIdForHumanConsumption,
@@ -10,6 +11,7 @@ import {
 } from "@ourworldindata/utils"
 import {
     BASE_FONT_SIZE,
+    GRAPHER_BACKGROUND_DEFAULT,
     GRAPHER_DARK_TEXT,
     GRAPHER_FONT_SCALE_10,
     GRAPHER_FONT_SCALE_11,
@@ -32,6 +34,7 @@ export interface ScatterSizeLegendManager {
     sizeScale: ScaleLinear<number, number>
     fontSize?: number
     tooltipSeries?: ScatterSeries
+    backgroundColor?: Color
 }
 
 const LEGEND_PADDING = 3
@@ -190,6 +193,7 @@ export class ScatterSizeLegend {
                             }
                             labelFontSize={this.fontSizeFromRadius(radius)}
                             labelFill={highlight ? "#bbb" : LEGEND_VALUE_COLOR}
+                            backgroundColor={this.manager.backgroundColor}
                         />
                     )
                 })}
@@ -214,6 +218,7 @@ export class ScatterSizeLegend {
                         labelFill={darkenColorForText(highlight.color)}
                         labelFontWeight={700}
                         outsideLabel={true}
+                        backgroundColor={this.manager.backgroundColor}
                     />
                 )}
             </React.Fragment>
@@ -271,6 +276,7 @@ const LegendItem = ({
     labelFontSize,
     labelFontWeight = 400,
     outsideLabel = false,
+    backgroundColor = GRAPHER_BACKGROUND_DEFAULT,
 }: {
     label: string
     cx: number
@@ -284,6 +290,7 @@ const LegendItem = ({
     labelFontSize: number
     labelFontWeight?: number
     outsideLabel?: boolean
+    backgroundColor?: Color
 }): React.ReactElement => {
     const style: React.CSSProperties = {
         fontSize: labelFontSize,
@@ -301,7 +308,11 @@ const LegendItem = ({
                 strokeWidth={circleStrokeWidth}
                 opacity={circleOpacity}
             />
-            <Halo id={label} style={{ ...style, strokeWidth: 3.5 }}>
+            <Halo
+                id={label}
+                background={backgroundColor}
+                style={{ ...style, strokeWidth: 3.5 }}
+            >
                 <text
                     x={cx}
                     y={cy - circleRadius}

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBarChart.tsx
@@ -666,7 +666,10 @@ export class StackedDiscreteBarChart
                         />
                     ))}
                     {this.showTotalValueLabel && (
-                        <Halo id={entityName + "-value-label"}>
+                        <Halo
+                            id={entityName + "-value-label"}
+                            background={this.manager.backgroundColor}
+                        >
                             <text
                                 id={makeIdForHumanConsumption(
                                     "total",


### PR DESCRIPTION
Adds a flag to download a static chart optimised for social media / Instagram. The option is accessible from Grapher's download menu and is only available for staff members who are logged in.

This is how the social media export is currently different from the ordinary export:
1. Background is beige (+ line outlines etc are also beige)
2. Background `<rect />` not needed in Figma is removed
3. Dash pattern of grid lines is set to `7 7` (Lucas prefers this)

To be honest, I'm not sure if adding a flag for this special behaviour is worth it. Alternatively, we could allow to customize Grapher's background colour. Maybe that's nicer? We could also do none of these things and that would be fine as well! Curious what you think, @danyx23 

SVG tester changes come from the previous PR

<img width="838" alt="Screenshot 2024-10-03 at 14 45 51" src="https://github.com/user-attachments/assets/0d0d97b2-5e03-47dd-9126-910b25d8b200">
