### PR TITLE
🐛 slide-in drawer should open within the Grapher frame

### DIFF
--- a/packages/@ourworldindata/grapher/src/slideInDrawer/SlideInDrawer.scss
+++ b/packages/@ourworldindata/grapher/src/slideInDrawer/SlideInDrawer.scss
@@ -1,6 +1,6 @@
 .drawer {
     .drawer-contents {
-        position: fixed;
+        position: absolute;
         right: 0;
         top: 0;
         width: 300px;
@@ -10,7 +10,7 @@
     }
 
     .drawer-backdrop {
-        position: fixed;
+        position: absolute;
         top: 0;
         left: 0;
         right: 0;


### PR DESCRIPTION
I noticed that the entity selector is outside of the Grapher frame. It shouldn't be. There is an obvious fix, but I don't understand what changed or why the code as-is ever worked.