### PR TITLE
✨ remove `rel="noreferrer"` from site `<a>` tags

### DIFF
--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -863,7 +863,7 @@ export class Explorer
                     <a
                         href={this.explorerProgram.downloadDataLink}
                         target="_blank"
-                        rel="noopener noreferrer"
+                        rel="noopener"
                         className="ExplorerDownloadLink"
                     >
                         Download this dataset

--- a/packages/@ourworldindata/components/src/IndicatorKeyData/IndicatorKeyData.tsx
+++ b/packages/@ourworldindata/components/src/IndicatorKeyData/IndicatorKeyData.tsx
@@ -93,11 +93,7 @@ export const makeLinks = ({ link }: { link?: string }): React.ReactNode => {
             <React.Fragment key={urlOrText}>
                 <span>
                     {isUrl ? (
-                        <a
-                            href={urlOrText}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                        >
+                        <a href={urlOrText} target="_blank" rel="noopener">
                             {urlOrText}
                         </a>
                     ) : (

--- a/packages/@ourworldindata/components/src/IndicatorProcessing/IndicatorProcessing.tsx
+++ b/packages/@ourworldindata/components/src/IndicatorProcessing/IndicatorProcessing.tsx
@@ -30,7 +30,7 @@ export const IndicatorProcessing = (props: IndicatorProcessingProps) => {
             <a
                 href="https://docs.owid.io/projects/etl/"
                 target="_blank"
-                rel="nopener noreferrer"
+                rel="noopener"
                 className="indicator-processing__link"
             >
                 Read about our data pipeline

--- a/packages/@ourworldindata/components/src/MarkdownTextWrap/MarkdownTextWrap.tsx
+++ b/packages/@ourworldindata/components/src/MarkdownTextWrap/MarkdownTextWrap.tsx
@@ -278,12 +278,7 @@ export class IRLink extends IRElement {
     }
     toHTML(key?: React.Key): React.ReactElement {
         return (
-            <a
-                key={key}
-                href={this.href}
-                target="_blank"
-                rel="noopener noreferrer"
-            >
+            <a key={key} href={this.href} target="_blank" rel="noopener">
                 {this.children.map((child, i) => child.toHTML(i))}
             </a>
         )
@@ -295,7 +290,7 @@ export class IRLink extends IRElement {
                 href={this.href}
                 target="_blank"
                 style={{ textDecoration: "underline" }}
-                rel="noopener noreferrer"
+                rel="noopener"
             >
                 {this.children.map((child, i) => child.toSVG(i))}
             </a>

--- a/packages/@ourworldindata/grapher/src/controls/ShareMenu.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/ShareMenu.tsx
@@ -203,7 +203,7 @@ export class ShareMenu extends React.Component<ShareMenuProps, ShareMenuState> {
                     title="Tweet a link"
                     data-track-note="chart_share_twitter"
                     href={twitterHref}
-                    rel="noreferrer noopener"
+                    rel="noopener"
                 >
                     <span className="icon">
                         <FontAwesomeIcon icon={faXTwitter} />
@@ -215,7 +215,7 @@ export class ShareMenu extends React.Component<ShareMenuProps, ShareMenuState> {
                     title="Share on Facebook"
                     data-track-note="chart_share_facebook"
                     href={facebookHref}
-                    rel="noreferrer noopener"
+                    rel="noopener"
                 >
                     <span className="icon">
                         <FontAwesomeIcon icon={faFacebook} />
@@ -262,7 +262,7 @@ export class ShareMenu extends React.Component<ShareMenuProps, ShareMenuState> {
                         target="_blank"
                         title="Edit chart"
                         href={editUrl}
-                        rel="noreferrer noopener"
+                        rel="noopener"
                     >
                         <span className="icon">
                             <FontAwesomeIcon icon={faEdit} />

--- a/packages/@ourworldindata/grapher/src/header/Header.tsx
+++ b/packages/@ourworldindata/grapher/src/header/Header.tsx
@@ -235,7 +235,7 @@ export class Header<
                 <a
                     href={manager.canonicalUrl}
                     target="_blank"
-                    rel="noopener noreferrer"
+                    rel="noopener"
                     data-track-note="chart_click_title"
                 >
                     <h1 style={this.title.htmlStyle}>
@@ -251,7 +251,7 @@ export class Header<
                 <a
                     href={manager.canonicalUrl}
                     target="_blank"
-                    rel="noopener noreferrer"
+                    rel="noopener"
                     data-track-note="chart_click_title"
                 >
                     {this.title.renderHTML()}

--- a/site/Feedback.tsx
+++ b/site/Feedback.tsx
@@ -72,7 +72,7 @@ const vaccineNotice = (
         key="vaccineNotice"
         href={`${BAKED_BASE_URL}/covid-vaccinations#frequently-asked-questions`}
         target="_blank"
-        rel="noreferrer"
+        rel="noopener"
     >
         Covid Vaccines Questions
     </a>
@@ -83,7 +83,7 @@ const copyrightNotice = (
         key="copyrightNotice"
         href={`${BAKED_BASE_URL}/faqs#how-is-your-work-copyrighted`}
         target="_blank"
-        rel="noreferrer"
+        rel="noopener"
     >
         Copyright Queries
     </a>
@@ -93,7 +93,7 @@ const citationNotice = (
         key="citationNotice"
         href={`${BAKED_BASE_URL}/faqs#how-should-i-cite-your-work`}
         target="_blank"
-        rel="noreferrer"
+        rel="noopener"
     >
         How to Cite our Work
     </a>
@@ -103,7 +103,7 @@ const translateNotice = (
         key="translateNotice"
         href={`${BAKED_BASE_URL}/faqs#can-i-translate-your-work-into-another-language`}
         target="_blank"
-        rel="noreferrer"
+        rel="noopener"
     >
         Translating our work
     </a>
@@ -210,7 +210,7 @@ export class FeedbackForm extends React.Component<{
                         <a
                             href={`${BAKED_BASE_URL}/faqs`}
                             target="_blank"
-                            rel="noreferrer"
+                            rel="noopener"
                         >
                             <strong>General FAQ</strong>
                         </a>{" "}
@@ -218,7 +218,7 @@ export class FeedbackForm extends React.Component<{
                         <a
                             href={`${BAKED_BASE_URL}/covid-vaccinations#frequently-asked-questions`}
                             target="_blank"
-                            rel="noreferrer"
+                            rel="noopener"
                         >
                             <strong>Vaccinations FAQ</strong>
                         </a>

--- a/site/LongFormPage.tsx
+++ b/site/LongFormPage.tsx
@@ -352,7 +352,7 @@ export const LongFormPage = (props: {
                                                             <a
                                                                 href="https://creativecommons.org/licenses/by/4.0/"
                                                                 target="_blank"
-                                                                rel="noopener noreferrer"
+                                                                rel="noopener"
                                                             >
                                                                 Creative Commons
                                                                 BY license

--- a/site/MetadataSection.tsx
+++ b/site/MetadataSection.tsx
@@ -155,7 +155,7 @@ export default function MetadataSection({
                                 <a
                                     href="https://creativecommons.org/licenses/by/4.0/"
                                     target="_blank"
-                                    rel="noopener noreferrer"
+                                    rel="noopener"
                                     className="reuse__link"
                                 >
                                     Creative Commons BY license

--- a/site/SiteFooter.tsx
+++ b/site/SiteFooter.tsx
@@ -243,7 +243,7 @@ export const SiteFooter = (props: SiteFooterProps) => (
                                 <a
                                     href="https://creativecommons.org/licenses/by/4.0/"
                                     target="_blank"
-                                    rel="noopener noreferrer"
+                                    rel="noopener"
                                 >
                                     Creative Commons BY license
                                 </a>
@@ -256,7 +256,7 @@ export const SiteFooter = (props: SiteFooterProps) => (
                                 <a
                                     href="https://github.com/owid/owid-grapher/blob/master/LICENSE.md "
                                     target="_blank"
-                                    rel="noopener noreferrer"
+                                    rel="noopener"
                                 >
                                     MIT license
                                 </a>

--- a/site/gdocs/components/ProminentLink.tsx
+++ b/site/gdocs/components/ProminentLink.tsx
@@ -80,9 +80,7 @@ export const ProminentLink = (props: {
     }
 
     const anchorTagProps =
-        linkType === "url"
-            ? { target: "_blank", rel: "noopener noreferrer" }
-            : undefined
+        linkType === "url" ? { target: "_blank", rel: "noopener" } : undefined
 
     const textContainerClassName = thumbnail
         ? "col-sm-start-4 col-md-start-3 col-start-2 col-end-limit"

--- a/site/gdocs/components/ResearchAndWriting.tsx
+++ b/site/gdocs/components/ResearchAndWriting.tsx
@@ -87,7 +87,7 @@ function ResearchAndWritingLink(
                 className
             )}
             target="_blank"
-            rel="noopener noreferrer"
+            rel="noopener"
         >
             {filename && !shouldHideThumbnail ? (
                 <figure>

--- a/site/gdocs/components/Socials.tsx
+++ b/site/gdocs/components/Socials.tsx
@@ -35,7 +35,7 @@ function SocialLink({ url, text, type }: EnrichedSocialLink) {
     return (
         <li className="article-block__social-link">
             <FontAwesomeIcon icon={type ? typeToIcon[type] : faLink} />
-            <a key={url} href={url} target="_blank" rel="noopener noreferrer">
+            <a key={url} href={url} target="_blank" rel="noopener">
                 {text}
             </a>
         </li>

--- a/site/gdocs/components/TopicPageIntro.tsx
+++ b/site/gdocs/components/TopicPageIntro.tsx
@@ -43,7 +43,7 @@ export function TopicPageIntro(props: TopicPageIntroProps) {
                         <a
                             href={props.downloadButton.url}
                             target="_blank"
-                            rel="noopener noreferrer"
+                            rel="noopener"
                         >
                             {props.downloadButton.text}
                         </a>

--- a/site/gdocs/pages/GdocPost.tsx
+++ b/site/gdocs/pages/GdocPost.tsx
@@ -191,7 +191,7 @@ export function GdocPost({
                         <a
                             href="https://creativecommons.org/licenses/by/4.0/"
                             target="_blank"
-                            rel="noopener noreferrer"
+                            rel="noopener"
                         >
                             Creative Commons BY license
                         </a>

--- a/site/gdocs/pages/Homepage.tsx
+++ b/site/gdocs/pages/Homepage.tsx
@@ -46,7 +46,7 @@ const SocialSection = () => {
                             className="list-item"
                             title="X"
                             target="_blank"
-                            rel="noopener noreferrer"
+                            rel="noopener"
                             data-track-note="homepage_follow_us"
                         >
                             <span className="icon">
@@ -61,7 +61,7 @@ const SocialSection = () => {
                             className="list-item"
                             title="Facebook"
                             target="_blank"
-                            rel="noopener noreferrer"
+                            rel="noopener"
                             data-track-note="homepage_follow_us"
                         >
                             <span className="icon">
@@ -76,7 +76,7 @@ const SocialSection = () => {
                             className="list-item"
                             title="Instagram"
                             target="_blank"
-                            rel="noopener noreferrer"
+                            rel="noopener"
                             data-track-note="homepage_follow_us"
                         >
                             <span className="icon">
@@ -91,7 +91,7 @@ const SocialSection = () => {
                             className="list-item"
                             title="Threads"
                             target="_blank"
-                            rel="noopener noreferrer"
+                            rel="noopener"
                             data-track-note="homepage_follow_us"
                         >
                             <span className="icon">

--- a/site/gdocs/utils.tsx
+++ b/site/gdocs/utils.tsx
@@ -150,7 +150,7 @@ const LinkedA = ({ span }: { span: SpanLink }): React.ReactElement => {
     if (linkType === "url") {
         // Don't open in new tab if it's an anchor link
         const linkProps = !span.url.startsWith("#")
-            ? { target: "_blank", rel: "noopener noreferrer" }
+            ? { target: "_blank", rel: "noopener" }
             : {}
         return (
             <a href={span.url} className="span-link" {...linkProps}>


### PR DESCRIPTION
## Context
We've had an unspoken convention here to omit referrer information from our links in many places throughout the codebase.

Specifically in gdocs pages, it's worked 3 ways:
1. gdoc links (linking to another article via its gdoc URL): **referrer information included**
2. grapher/explorer links (linking via a grapher/explorer url): **referrer information included**
3. url links (when we write out the complete URL): **referrer information omitted**

When linking to an OWID resource that isn't a grapher/explorer/gdoc page, we have to use url links, e.g https://ourworldindata.org/data and so this unspoken convention has hurt our ability to understand how users are navigating our site.

## Change
This PR removes the `noreferrer` attribute from url links in gdoc articles (see: the `LinkedA` component, and the `ProminentLink` component) but also in all other <a> tags on the site to prevent confusion about what our convention is.

`target="_blank"` is still present to open the links in new tabs, and `rel="noopener"` is still present because, even though it's redundant as of 2024 (see [`target="_blank" implies rel="noopener" behavior`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#browser_compatibility)), eslint is still requiring us to set both.