### PR TITLE
✨ (discrete bar) optimise static version for Figma / TAS-644

### DIFF
--- a/packages/@ourworldindata/grapher/src/axis/AxisViews.tsx
+++ b/packages/@ourworldindata/grapher/src/axis/AxisViews.tsx
@@ -155,23 +155,15 @@ export class HorizontalAxisZeroLine extends React.Component<{
         const x = axis.place(0) + offset
 
         return (
-            <g
+            <line
                 id={makeIdForHumanConsumption("vertical-zero-line")}
-                className={classNames(
-                    "AxisGridLines",
-                    "verticalLines",
-                    "zeroLine"
-                )}
-            >
-                <line
-                    x1={x.toFixed(2)}
-                    y1={bounds.bottom.toFixed(2)}
-                    x2={x.toFixed(2)}
-                    y2={bounds.top.toFixed(2)}
-                    stroke={SOLID_TICK_COLOR}
-                    strokeWidth={strokeWidth}
-                />
-            </g>
+                x1={x.toFixed(2)}
+                y1={bounds.bottom.toFixed(2)}
+                x2={x.toFixed(2)}
+                y2={bounds.top.toFixed(2)}
+                stroke={SOLID_TICK_COLOR}
+                strokeWidth={strokeWidth}
+            />
         )
     }
 }

--- a/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChartConstants.ts
+++ b/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChartConstants.ts
@@ -14,6 +14,17 @@ export interface DiscreteBarSeries extends ChartSeries {
     label?: TextWrap
 }
 
+export interface PlacedDiscreteBarSeries extends DiscreteBarSeries {
+    // data bar
+    barX: number
+    barY: number
+    barWidth: number
+
+    // entity and value labels
+    entityLabelX: number
+    valueLabelX: number
+}
+
 export interface DiscreteBarChartManager extends ChartManager {
     showYearLabels?: boolean
     endTime?: Time

--- a/packages/@ourworldindata/grapher/src/horizontalColorLegend/HorizontalColorLegends.tsx
+++ b/packages/@ourworldindata/grapher/src/horizontalColorLegend/HorizontalColorLegends.tsx
@@ -842,6 +842,7 @@ export class HorizontalCategoricalColorLegend extends HorizontalColorLegend {
 
                     return (
                         <rect
+                            id={makeIdForHumanConsumption(mark.label.text)}
                             key={`${mark.label}-${index}`}
                             x={this.legendX + mark.x}
                             y={this.categoryLegendY + mark.y}

--- a/packages/@ourworldindata/grapher/src/horizontalColorLegend/HorizontalColorLegends.tsx
+++ b/packages/@ourworldindata/grapher/src/horizontalColorLegend/HorizontalColorLegends.tsx
@@ -93,6 +93,7 @@ export interface HorizontalColorLegendManager {
     onLegendClick?: (d: ColorScaleBin) => void
     activeColors?: string[]
     focusColors?: string[]
+    isStatic?: boolean
 }
 
 const DEFAULT_NUMERIC_BIN_SIZE = 10
@@ -686,6 +687,9 @@ const NumericBinRect = (props: NumericBinRectProps) => {
 
 @observer
 export class HorizontalCategoricalColorLegend extends HorizontalColorLegend {
+    private rectPadding = 5
+    private markPadding = 5
+
     @computed get width(): number {
         return this.manager.legendWidth ?? this.manager.legendMaxWidth ?? 200
     }
@@ -701,8 +705,6 @@ export class HorizontalCategoricalColorLegend extends HorizontalColorLegend {
     @computed private get markLines(): MarkLine[] {
         const fontSize = this.fontSize * GRAPHER_FONT_SCALE_12_8
         const rectSize = this.fontSize * 0.75
-        const rectPadding = 5
-        const markPadding = 5
 
         const lines: MarkLine[] = []
         let marks: CategoricalMark[] = []
@@ -711,13 +713,19 @@ export class HorizontalCategoricalColorLegend extends HorizontalColorLegend {
         this.visibleCategoricalBins.forEach((bin) => {
             const labelBounds = Bounds.forText(bin.text, { fontSize })
             const markWidth =
-                rectSize + rectPadding + labelBounds.width + markPadding
+                rectSize +
+                this.rectPadding +
+                labelBounds.width +
+                this.markPadding
 
             if (xOffset + markWidth > this.width && marks.length > 0) {
-                lines.push({ totalWidth: xOffset - markPadding, marks: marks })
+                lines.push({
+                    totalWidth: xOffset - this.markPadding,
+                    marks: marks,
+                })
                 marks = []
                 xOffset = 0
-                yOffset += rectSize + rectPadding
+                yOffset += rectSize + this.rectPadding
             }
 
             const markX = xOffset
@@ -726,7 +734,7 @@ export class HorizontalCategoricalColorLegend extends HorizontalColorLegend {
             const label = {
                 text: bin.text,
                 bounds: labelBounds.set({
-                    x: markX + rectSize + rectPadding,
+                    x: markX + rectSize + this.rectPadding,
                     y: markY + rectSize / 2,
                 }),
                 fontSize,
@@ -745,7 +753,7 @@ export class HorizontalCategoricalColorLegend extends HorizontalColorLegend {
         })
 
         if (marks.length > 0)
-            lines.push({ totalWidth: xOffset - markPadding, marks: marks })
+            lines.push({ totalWidth: xOffset - this.markPadding, marks: marks })
 
         return lines
     }
@@ -787,87 +795,128 @@ export class HorizontalCategoricalColorLegend extends HorizontalColorLegend {
         return max(this.marks.map((mark) => mark.y + mark.rectSize)) ?? 0
     }
 
-    render(): React.ReactElement {
+    renderLabels(): React.ReactElement {
         const { manager, marks } = this
-        const { activeColors, focusColors } = manager
+        const { focusColors } = manager
 
         return (
-            <g
-                id={makeIdForHumanConsumption("categorical-color-legend")}
-                className="categoricalColorLegend"
-            >
+            <g id={makeIdForHumanConsumption("labels")}>
                 {marks.map((mark, index) => {
-                    const isActive = activeColors?.includes(mark.bin.color)
                     const isFocus = focusColors?.includes(mark.bin.color)
 
-                    const fill = mark.bin.patternRef
+                    return (
+                        <text
+                            key={`${mark.label}-${index}`}
+                            x={this.legendX + mark.label.bounds.x}
+                            y={this.categoryLegendY + mark.label.bounds.y}
+                            // we can't use dominant-baseline to do proper alignment since our svg-to-png library Sharp
+                            // doesn't support that (https://github.com/lovell/sharp/issues/1996), so we'll have to make
+                            // do with some rough positioning.
+                            dy={dyFromAlign(VerticalAlign.middle)}
+                            fontSize={mark.label.fontSize}
+                            fontWeight={isFocus ? "bold" : undefined}
+                        >
+                            {mark.label.text}
+                        </text>
+                    )
+                })}
+            </g>
+        )
+    }
+
+    renderSwatches(): React.ReactElement {
+        const { manager, marks } = this
+        const { activeColors } = manager
+
+        return (
+            <g id={makeIdForHumanConsumption("swatches")}>
+                {marks.map((mark, index) => {
+                    const isActive = activeColors?.includes(mark.bin.color)
+
+                    const color = mark.bin.patternRef
                         ? `url(#${mark.bin.patternRef})`
                         : mark.bin.color
 
+                    const fill =
+                        isActive || activeColors === undefined ? color : "#ccc"
+
+                    return (
+                        <rect
+                            key={`${mark.label}-${index}`}
+                            x={this.legendX + mark.x}
+                            y={this.categoryLegendY + mark.y}
+                            width={mark.rectSize}
+                            height={mark.rectSize}
+                            fill={fill}
+                            stroke={manager.categoricalBinStroke}
+                            strokeWidth={0.4}
+                            opacity={manager.legendOpacity}
+                        />
+                    )
+                })}
+            </g>
+        )
+    }
+
+    renderInteractiveElements(): React.ReactElement {
+        const { manager, marks } = this
+
+        return (
+            <g>
+                {marks.map((mark, index) => {
+                    const mouseOver = (): void =>
+                        manager.onLegendMouseOver
+                            ? manager.onLegendMouseOver(mark.bin)
+                            : undefined
+                    const mouseLeave = (): void =>
+                        manager.onLegendMouseLeave
+                            ? manager.onLegendMouseLeave()
+                            : undefined
+                    const click = manager.onLegendClick
+                        ? (): void => manager.onLegendClick?.(mark.bin)
+                        : undefined
+
+                    const cursor = click ? "pointer" : "default"
+
                     return (
                         <g
-                            id={makeIdForHumanConsumption(
-                                "mark",
-                                mark.label.text
-                            )}
-                            key={index}
-                            onMouseOver={(): void =>
-                                manager.onLegendMouseOver
-                                    ? manager.onLegendMouseOver(mark.bin)
-                                    : undefined
-                            }
-                            onMouseLeave={(): void =>
-                                manager.onLegendMouseLeave
-                                    ? manager.onLegendMouseLeave()
-                                    : undefined
-                            }
-                            onClick={(): void =>
-                                manager.onLegendClick
-                                    ? manager.onLegendClick(mark.bin)
-                                    : undefined
-                            }
-                            style={{ cursor: "default" }}
+                            key={`${mark.label}-${index}`}
+                            onMouseOver={mouseOver}
+                            onMouseLeave={mouseLeave}
+                            onClick={click}
+                            style={{ cursor }}
                         >
                             {/* for hover interaction */}
                             <rect
                                 x={this.legendX + mark.x}
-                                y={this.categoryLegendY + mark.y}
-                                height={mark.rectSize}
+                                y={
+                                    this.categoryLegendY +
+                                    mark.y -
+                                    this.rectPadding / 2
+                                }
+                                height={mark.rectSize + this.rectPadding}
                                 width={
                                     mark.width + SPACE_BETWEEN_CATEGORICAL_BINS
                                 }
                                 fill="#fff"
                                 opacity={0}
                             />
-                            <rect
-                                x={this.legendX + mark.x}
-                                y={this.categoryLegendY + mark.y}
-                                width={mark.rectSize}
-                                height={mark.rectSize}
-                                fill={
-                                    isActive || activeColors === undefined
-                                        ? fill
-                                        : "#ccc"
-                                }
-                                stroke={manager.categoricalBinStroke}
-                                strokeWidth={0.4}
-                                opacity={manager.legendOpacity} // defaults to undefined which removes the prop
-                            />
-                            <text
-                                x={this.legendX + mark.label.bounds.x}
-                                y={this.categoryLegendY + mark.label.bounds.y}
-                                // we can't use dominant-baseline to do proper alignment since our svg-to-png library Sharp
-                                // doesn't support that (https://github.com/lovell/sharp/issues/1996), so we'll have to make
-                                // do with some rough positioning.
-                                dy={dyFromAlign(VerticalAlign.middle)}
-                                fontSize={mark.label.fontSize}
-                                fontWeight={isFocus ? "bold" : undefined}
-                            >
-                                {mark.label.text}
-                            </text>
                         </g>
                     )
                 })}
+            </g>
+        )
+    }
+
+    render(): React.ReactElement {
+        return (
+            <g
+                id={makeIdForHumanConsumption("categorical-color-legend")}
+                className="categoricalColorLegend"
+            >
+                {this.renderSwatches()}
+                {this.renderLabels()}
+                {!this.manager.isStatic && this.renderInteractiveElements()}
             </g>
         )
     }

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
@@ -570,6 +570,10 @@ export class MapChart
         return 0
     }
 
+    @computed get isStatic(): boolean {
+        return this.manager.isStatic ?? false
+    }
+
     renderMapLegend(): React.ReactElement {
         const { numericLegend, categoryLegend } = this
 

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
@@ -116,6 +116,10 @@ export class SlopeChart
         return this.props.bounds ?? DEFAULT_BOUNDS
     }
 
+    @computed get isStatic(): boolean {
+        return this.manager.isStatic ?? false
+    }
+
     @computed get fontSize() {
         return this.manager.fontSize ?? BASE_FONT_SIZE
     }

--- a/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChart.tsx
@@ -21,6 +21,8 @@ import {
     ColorSchemeName,
     EntitySelectionMode,
     makeIdForHumanConsumption,
+    getCountryByName,
+    dyFromAlign,
 } from "@ourworldindata/utils"
 import { action, computed, observable } from "mobx"
 import { observer } from "mobx-react"
@@ -40,6 +42,7 @@ import {
     OwidVariableRow,
     OwidTableSlugs,
     colorScaleConfigDefaults,
+    VerticalAlign,
 } from "@ourworldindata/types"
 import { OwidTable, CoreColumn } from "@ourworldindata/core-table"
 import {
@@ -1156,7 +1159,7 @@ export class MarimekkoChart
                     opacity={1}
                     fontSize={GRAPHER_FONT_SCALE_12 * fontSize}
                     textAnchor="middle"
-                    dominantBaseline="middle"
+                    dy={dyFromAlign(VerticalAlign.middle)}
                     style={{ pointerEvents: "none" }}
                 >
                     no data
@@ -1748,7 +1751,7 @@ export class MarimekkoChart
                         opacity={1}
                         fontSize={this.entityLabelFontSize}
                         textAnchor="right"
-                        dominantBaseline="middle"
+                        dy={dyFromAlign(VerticalAlign.middle)}
                         onMouseOver={(): void =>
                             this.onEntityMouseOver(candidate.item.entityName)
                         }

--- a/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChart.tsx
@@ -21,7 +21,6 @@ import {
     ColorSchemeName,
     EntitySelectionMode,
     makeIdForHumanConsumption,
-    getCountryByName,
     dyFromAlign,
 } from "@ourworldindata/utils"
 import { action, computed, observable } from "mobx"
@@ -564,6 +563,10 @@ export class MarimekkoChart
             .padBottom(labelLinesHeight)
             .padTop(this.legend.height + this.legendPaddingTop)
             .padLeft(marginToEnsureWidestEntityLabelFitsEvenIfAtX0)
+    }
+
+    @computed get isStatic(): boolean {
+        return this.manager.isStatic ?? false
     }
 
     @computed private get baseFontSize(): number {

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBarChart.tsx
@@ -19,6 +19,7 @@ import {
     EntityName,
     getRelativeMouse,
     makeIdForHumanConsumption,
+    dyFromAlign,
 } from "@ourworldindata/utils"
 import { action, computed, observable } from "mobx"
 import { observer } from "mobx-react"
@@ -27,6 +28,7 @@ import {
     FacetStrategy,
     MissingDataStrategy,
     SeriesName,
+    VerticalAlign,
 } from "@ourworldindata/types"
 import {
     BASE_FONT_SIZE,
@@ -218,6 +220,10 @@ export class StackedDiscreteBarChart
 
     @computed private get baseFontSize(): number {
         return this.manager.fontSize ?? BASE_FONT_SIZE
+    }
+
+    @computed get isStatic(): boolean {
+        return this.manager.isStatic ?? false
     }
 
     @computed private get showLegend(): boolean {
@@ -678,7 +684,7 @@ export class StackedDiscreteBarChart
                                 transform={`translate(${
                                     yAxis.place(totalValue) + labelToBarPadding
                                 }, 0)`}
-                                dominantBaseline="middle"
+                                dy={dyFromAlign(VerticalAlign.middle)}
                                 {...this.totalValueLabelStyle}
                             >
                                 {totalLabel}
@@ -747,6 +753,15 @@ export class StackedDiscreteBarChart
                 {this.Tooltip}
             </g>
         )
+    }
+
+    @computed get activeColors(): string[] | undefined {
+        const { focusSeriesName } = this
+        if (!focusSeriesName) return undefined
+        const activeColors = this.series
+            .filter((series) => series.seriesName === focusSeriesName)
+            .map((series) => series.color)
+        return activeColors.length === 0 ? undefined : activeColors
     }
 
     private static Bar(props: {
@@ -818,7 +833,7 @@ export class StackedDiscreteBarChart
                         opacity={isFaint ? 0 : 1}
                         fontSize={labelFontSize}
                         textAnchor="middle"
-                        dominantBaseline="middle"
+                        dy={dyFromAlign(VerticalAlign.middle)}
                     >
                         {barLabel}
                     </text>

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBarChart.tsx
@@ -79,7 +79,6 @@ import { HashMap, NodeGroup } from "react-move"
 import { easeQuadOut } from "d3-ease"
 import { bind } from "decko"
 import { CategoricalColorAssigner } from "../color/CategoricalColorAssigner.js"
-import { Halo } from "../halo/Halo"
 import { TextWrap } from "@ourworldindata/components"
 
 // if an entity name exceeds this width, we use the short name instead (if available)
@@ -606,10 +605,14 @@ export class StackedDiscreteBarChart
                 />
             )
 
-        const { manager, bounds, yAxis, innerBounds } = this
+        return this.manager.isStatic
+            ? this.renderStatic()
+            : this.renderInteractive()
+    }
 
-        const chartContext: StackedBarChartContext = {
-            yAxis,
+    @computed get chartContext(): StackedBarChartContext {
+        return {
+            yAxis: this.yAxis,
             targetTime: this.manager.endTime,
             timeColumn: this.inputTable.timeColumn,
             formatColumn: this.formatColumn,
@@ -621,98 +624,76 @@ export class StackedDiscreteBarChart
             x0: this.x0,
             baseFontSize: this.baseFontSize,
         }
+    }
 
-        const handlePositionUpdate = (d: PlacedItem): HashMap => ({
-            translateY: [d.yPosition],
-            timing: { duration: 350, ease: easeQuadOut },
-        })
+    renderRow({
+        data,
+        state,
+    }: {
+        data: PlacedItem
+        state: { translateY: number }
+    }): React.ReactElement {
+        const { yAxis } = this
+        const { entityName, label, bars, totalValue } = data
 
-        const renderRow = ({
-            data,
-            state,
-        }: {
-            data: PlacedItem
-            state: { translateY: number }
-        }): React.ReactElement => {
-            const { entityName, label, bars, totalValue } = data
+        const totalLabel = this.formatValueForLabel(totalValue)
+        const showLabelInsideBar = bars.length > 1
 
-            const totalLabel = this.formatValueForLabel(totalValue)
-            const showLabelInsideBar = bars.length > 1
+        return (
+            <g
+                key={entityName}
+                id={makeIdForHumanConsumption(entityName)}
+                className="bar"
+                transform={`translate(0, ${state.translateY ?? 0})`}
+            >
+                {bars.map((bar) => (
+                    <StackedDiscreteBarChart.Bar
+                        key={bar.seriesName}
+                        entity={entityName}
+                        bar={bar}
+                        chartContext={this.chartContext}
+                        showLabelInsideBar={showLabelInsideBar}
+                        onMouseEnter={this.onEntityMouseEnter}
+                        onMouseLeave={this.onEntityMouseLeave}
+                    />
+                ))}
+                {label.render(
+                    yAxis.place(this.x0) - labelToBarPadding,
+                    -label.height / 2,
+                    {
+                        textProps: {
+                            textAnchor: "end",
+                            fill: "#555",
+                            onMouseEnter: (): void =>
+                                this.onEntityMouseEnter(label.text),
+                            onMouseLeave: this.onEntityMouseLeave,
+                        },
+                    }
+                )}
+                {this.showTotalValueLabel && (
+                    <text
+                        transform={`translate(${
+                            yAxis.place(totalValue) + labelToBarPadding
+                        }, 0)`}
+                        dy={dyFromAlign(VerticalAlign.middle)}
+                        {...this.totalValueLabelStyle}
+                    >
+                        {totalLabel}
+                    </text>
+                )}
+            </g>
+        )
+    }
 
-            return (
-                <g
-                    key={entityName}
-                    id={makeIdForHumanConsumption("bar", entityName)}
-                    className="bar"
-                    transform={`translate(0, ${state.translateY})`}
-                >
-                    {label.render(
-                        yAxis.place(this.x0) - labelToBarPadding,
-                        -label.height / 2,
-                        {
-                            textProps: {
-                                textAnchor: "end",
-                                fill: "#555",
-                                onMouseEnter: (): void =>
-                                    this.onEntityMouseEnter(label.text),
-                                onMouseLeave: this.onEntityMouseLeave,
-                            },
-                        }
-                    )}
-
-                    {bars.map((bar) => (
-                        <StackedDiscreteBarChart.Bar
-                            key={bar.seriesName}
-                            entity={entityName}
-                            bar={bar}
-                            chartContext={chartContext}
-                            showLabelInsideBar={showLabelInsideBar}
-                            onMouseEnter={this.onEntityMouseEnter}
-                            onMouseLeave={this.onEntityMouseLeave}
-                        />
-                    ))}
-                    {this.showTotalValueLabel && (
-                        <Halo
-                            id={entityName + "-value-label"}
-                            background={this.manager.backgroundColor}
-                        >
-                            <text
-                                id={makeIdForHumanConsumption(
-                                    "total",
-                                    entityName
-                                )}
-                                transform={`translate(${
-                                    yAxis.place(totalValue) + labelToBarPadding
-                                }, 0)`}
-                                dy={dyFromAlign(VerticalAlign.middle)}
-                                {...this.totalValueLabelStyle}
-                            >
-                                {totalLabel}
-                            </text>
-                        </Halo>
-                    )}
-                </g>
-            )
-        }
+    renderAxis(): React.ReactElement {
+        const { manager, bounds, yAxis, innerBounds } = this
 
         const axisLineWidth = manager.isStaticAndSmall
             ? GRAPHER_AXIS_LINE_WIDTH_THICK
             : GRAPHER_AXIS_LINE_WIDTH_DEFAULT
 
         return (
-            <g
-                ref={this.base}
-                className="StackedDiscreteBarChart"
-                onMouseMove={this.onMouseMove}
-            >
-                <rect
-                    x={bounds.left}
-                    y={bounds.top}
-                    width={bounds.width}
-                    height={bounds.height}
-                    opacity={0}
-                    fill="rgba(255,255,255,0)"
-                />
+            <>
                 {this.showHorizontalAxis && (
                     <>
                         <HorizontalAxisComponent
@@ -737,9 +718,60 @@ export class StackedDiscreteBarChart
                     // overlap with the bars
                     align={HorizontalAlign.right}
                 />
-                {this.showLegend && (
-                    <HorizontalCategoricalColorLegend manager={this} />
-                )}
+            </>
+        )
+    }
+
+    renderLegend(): React.ReactElement | void {
+        if (!this.showLegend) return
+        return <HorizontalCategoricalColorLegend manager={this} />
+    }
+
+    renderStatic(): React.ReactElement {
+        return (
+            <>
+                {this.renderAxis()}
+                {this.renderLegend()}
+                <g id={makeIdForHumanConsumption("bars")}>
+                    {this.placedItems.map((item) =>
+                        this.renderRow({
+                            data: item,
+                            state: { translateY: item.yPosition },
+                        })
+                    )}
+                </g>
+            </>
+        )
+    }
+
+    renderInteractive(): React.ReactElement {
+        const { bounds } = this
+
+        const handlePositionUpdate = (d: PlacedItem): HashMap => ({
+            translateY: [d.yPosition],
+            timing: { duration: 350, ease: easeQuadOut },
+        })
+
+        // needs to be referenced here, otherwise it's not updated in the renderRow function
+        // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+        this.focusSeriesName
+
+        return (
+            <g
+                ref={this.base}
+                className="StackedDiscreteBarChart"
+                onMouseMove={this.onMouseMove}
+            >
+                <rect
+                    x={bounds.left}
+                    y={bounds.top}
+                    width={bounds.width}
+                    height={bounds.height}
+                    opacity={0}
+                    fill="rgba(255,255,255,0)"
+                />
+                {this.renderAxis()}
+                {this.renderLegend()}
                 <NodeGroup
                     data={this.placedItems}
                     keyAccessor={(d: PlacedItem): string => d.entityName}
@@ -747,21 +779,12 @@ export class StackedDiscreteBarChart
                     update={handlePositionUpdate}
                 >
                     {(nodes): React.ReactElement => (
-                        <g>{nodes.map((node) => renderRow(node))}</g>
+                        <g>{nodes.map((node) => this.renderRow(node))}</g>
                     )}
                 </NodeGroup>
-                {this.Tooltip}
+                {this.tooltip}
             </g>
         )
-    }
-
-    @computed get activeColors(): string[] | undefined {
-        const { focusSeriesName } = this
-        if (!focusSeriesName) return undefined
-        const activeColors = this.series
-            .filter((series) => series.seriesName === focusSeriesName)
-            .map((series) => series.color)
-        return activeColors.length === 0 ? undefined : activeColors
     }
 
     private static Bar(props: {
@@ -799,13 +822,14 @@ export class StackedDiscreteBarChart
 
         return (
             <g
-                id={makeIdForHumanConsumption("stacked-bar", bar.seriesName)}
+                id={makeIdForHumanConsumption(bar.seriesName)}
                 onMouseEnter={(): void =>
                     props?.onMouseEnter(entity, bar.seriesName)
                 }
                 onMouseLeave={props?.onMouseLeave}
             >
                 <rect
+                    id={makeIdForHumanConsumption("bar")}
                     x={0}
                     y={0}
                     transform={`translate(${barX}, ${-barHeight / 2})`}
@@ -842,7 +866,7 @@ export class StackedDiscreteBarChart
         )
     }
 
-    @computed private get Tooltip(): React.ReactElement | undefined {
+    @computed private get tooltip(): React.ReactElement | undefined {
         const {
                 tooltipState: { target, position, fading },
                 formatColumn: { unit, shortUnit },

--- a/packages/@ourworldindata/grapher/src/verticalColorLegend/VerticalColorLegend.tsx
+++ b/packages/@ourworldindata/grapher/src/verticalColorLegend/VerticalColorLegend.tsx
@@ -183,6 +183,7 @@ export class VerticalColorLegend extends React.Component<{
 
                     return (
                         <rect
+                            id={makeIdForHumanConsumption(series.textWrap.text)}
                             key={index}
                             x={this.legendX}
                             y={renderedTextPosition[1] - rectSize}

--- a/packages/@ourworldindata/grapher/src/verticalColorLegend/VerticalColorLegend.tsx
+++ b/packages/@ourworldindata/grapher/src/verticalColorLegend/VerticalColorLegend.tsx
@@ -21,6 +21,7 @@ export interface VerticalColorLegendManager {
     legendY?: number
     activeColors: Color[]
     focusColors?: Color[]
+    isStatic?: boolean
 }
 
 export interface LegendItem {
@@ -35,6 +36,7 @@ interface SizedLegendSeries {
     color: Color
     width: number
     height: number
+    yOffset: number
 }
 
 @observer
@@ -78,10 +80,17 @@ export class VerticalColorLegend extends React.Component<{
     }
 
     @computed private get series(): SizedLegendSeries[] {
-        const { manager, fontSize, rectSize, rectPadding } = this
+        const {
+            manager,
+            fontSize,
+            rectSize,
+            rectPadding,
+            titleHeight,
+            lineHeight,
+        } = this
 
         return manager.legendItems
-            .map((series) => {
+            .map((series, index) => {
                 let label = series.label
                 // infer label for numeric bins
                 if (!label && series.minText && series.maxText) {
@@ -93,11 +102,15 @@ export class VerticalColorLegend extends React.Component<{
                     lineHeight: 1,
                     text: label ?? "",
                 })
+                const width = rectSize + rectPadding + textWrap.width
+                const height = Math.max(textWrap.height, rectSize)
+                const yOffset = titleHeight + index * (height + lineHeight)
                 return {
                     textWrap,
                     color: series.color,
-                    width: rectSize + rectPadding + textWrap.width,
-                    height: Math.max(textWrap.height, rectSize),
+                    width,
+                    height,
+                    yOffset,
                 }
             })
             .filter((v) => !!v) as SizedLegendSeries[]
@@ -117,106 +130,132 @@ export class VerticalColorLegend extends React.Component<{
         )
     }
 
-    render(): React.ReactElement {
-        const {
-            title,
-            titleHeight,
-            series,
-            rectSize,
-            rectPadding,
-            lineHeight,
-            manager,
-        } = this
-        const {
-            focusColors,
-            activeColors,
-            onLegendMouseOver,
-            onLegendMouseLeave,
-            onLegendClick,
-        } = manager
+    @computed get legendX(): number {
+        return this.manager.legendX ?? 0
+    }
 
-        const x = manager.legendX ?? 0
-        const y = manager.legendY ?? 0
+    @computed get legendY(): number {
+        return this.manager.legendY ?? 0
+    }
 
-        let markOffset = titleHeight
+    renderLabels(): React.ReactElement {
+        const { series, manager, rectSize, rectPadding } = this
+        const { focusColors } = manager
 
         return (
-            <>
-                {title &&
-                    title.render(x, y, { textProps: { fontWeight: 700 } })}
-                <g
-                    id={makeIdForHumanConsumption("vertical-color-legend")}
-                    className="ScatterColorLegend clickable"
-                    style={{ cursor: "pointer" }}
-                >
-                    {series.map((series, index) => {
-                        const isActive = activeColors.includes(series.color)
-                        const isFocus =
-                            focusColors?.includes(series.color) ?? false
-                        const mouseOver = onLegendMouseOver
-                            ? (): void => onLegendMouseOver(series.color)
+            <g id={makeIdForHumanConsumption("labels")}>
+                {series.map((series) => {
+                    const isFocus = focusColors?.includes(series.color) ?? false
+
+                    const textX = this.legendX + rectSize + rectPadding
+                    const textY = this.legendY + series.yOffset
+
+                    return series.textWrap.render(
+                        textX,
+                        textY,
+                        isFocus
+                            ? {
+                                  textProps: {
+                                      style: { fontWeight: "bold" },
+                                  },
+                              }
                             : undefined
-                        const mouseLeave = onLegendMouseLeave || undefined
-                        const click = onLegendClick
-                            ? (): void => onLegendClick(series.color)
-                            : undefined
+                    )
+                })}
+            </g>
+        )
+    }
 
-                        const textX = x + rectSize + rectPadding
-                        const textY = y + markOffset
+    renderSwatches(): React.ReactElement {
+        const { manager, series, rectSize, rectPadding } = this
+        const { activeColors } = manager
 
-                        const renderedTextPosition =
-                            series.textWrap.getPositionForSvgRendering(
-                                textX,
-                                textY
-                            )
+        return (
+            <g>
+                {series.map((series, index) => {
+                    const isActive = activeColors.includes(series.color)
 
-                        const result = (
-                            <g
-                                key={index}
-                                id={makeIdForHumanConsumption(
-                                    "mark",
-                                    series.textWrap.text
-                                )}
-                                className="legendMark"
-                                onMouseOver={mouseOver}
-                                onMouseLeave={mouseLeave}
-                                onClick={click}
-                                fill={!isActive ? "#ccc" : undefined}
-                            >
-                                <rect
-                                    x={x}
-                                    y={y + markOffset - lineHeight / 2}
-                                    width={series.width}
-                                    height={series.height + lineHeight}
-                                    fill="#fff"
-                                    opacity={0}
-                                />
-                                <rect
-                                    x={x}
-                                    y={renderedTextPosition[1] - rectSize}
-                                    width={rectSize}
-                                    height={rectSize}
-                                    fill={isActive ? series.color : undefined}
-                                />
-                                {series.textWrap.render(
-                                    textX,
-                                    textY,
-                                    isFocus
-                                        ? {
-                                              textProps: {
-                                                  style: { fontWeight: "bold" },
-                                              },
-                                          }
-                                        : undefined
-                                )}
-                            </g>
-                        )
+                    const textX = this.legendX + rectSize + rectPadding
+                    const textY = this.legendY + series.yOffset
 
-                        markOffset += series.height + lineHeight
-                        return result
+                    const renderedTextPosition =
+                        series.textWrap.getPositionForSvgRendering(textX, textY)
+
+                    return (
+                        <rect
+                            key={index}
+                            x={this.legendX}
+                            y={renderedTextPosition[1] - rectSize}
+                            width={rectSize}
+                            height={rectSize}
+                            fill={isActive ? series.color : "#ccc"}
+                        />
+                    )
+                })}
+            </g>
+        )
+    }
+
+    renderInteractiveElements(): React.ReactElement {
+        const { series, manager, lineHeight } = this
+        const { onLegendClick, onLegendMouseOver, onLegendMouseLeave } = manager
+        return (
+            <g>
+                {series.map((series, index) => {
+                    const mouseOver = onLegendMouseOver
+                        ? (): void => onLegendMouseOver(series.color)
+                        : undefined
+                    const mouseLeave = onLegendMouseLeave || undefined
+                    const click = onLegendClick
+                        ? (): void => onLegendClick(series.color)
+                        : undefined
+
+                    const cursor = click ? "pointer" : "default"
+
+                    return (
+                        <g
+                            key={index}
+                            className="legendMark"
+                            onMouseOver={mouseOver}
+                            onMouseLeave={mouseLeave}
+                            onClick={click}
+                            style={{ cursor }}
+                        >
+                            <rect
+                                x={this.legendX}
+                                y={
+                                    this.legendY +
+                                    series.yOffset -
+                                    lineHeight / 2
+                                }
+                                width={series.width}
+                                height={series.height + lineHeight}
+                                fill="#fff"
+                                fillOpacity={0}
+                            />
+                        </g>
+                    )
+                })}
+            </g>
+        )
+    }
+
+    render(): React.ReactElement {
+        return (
+            <g
+                id={makeIdForHumanConsumption("vertical-color-legend")}
+                className="ScatterColorLegend clickable"
+            >
+                {this.title &&
+                    this.title.render(this.legendX, this.legendY, {
+                        textProps: {
+                            fontWeight: 700,
+                        },
                     })}
-                </g>
-            </>
+                {this.renderLabels()}
+                {this.renderSwatches()}
+                {!this.manager.isStatic && this.renderInteractiveElements()}
+            </g>
         )
     }
 }


### PR DESCRIPTION
Makes the static export of a discrete bar chart a bit nicer to work with in Figma:
- Removes unnecessary groups and elements
- Group elements by type (e.g. group all line labels together) 

The changes happen to make animation on iOS smoother ([example](http://staging-site-figma-discrete-bar/grapher/female-population-by-age-group?time=1976))