### PR TITLE
✨ add autofocus to homepage search and data catalog

### DIFF
--- a/site/DataCatalog/DataCatalog.tsx
+++ b/site/DataCatalog/DataCatalog.tsx
@@ -100,6 +100,7 @@ const DataCatalogSearchInput = ({
                 }}
             >
                 <input
+                    autoFocus
                     type="text"
                     className="data-catalog-search-input body-3-regular"
                     ref={inputRef}


### PR DESCRIPTION
Implements https://github.com/owid/owid-grapher/issues/3982

Avoids the issue of having to recreate the google.com behaviour on the homepage search by disabling the dropdown panel until there the user has typed something.