### PR TITLE
Fix potential source of gdoc.publishedAt being incorrect

### DIFF
--- a/db/model/Gdoc/GdocFactory.ts
+++ b/db/model/Gdoc/GdocFactory.ts
@@ -62,9 +62,9 @@ export function gdocFromJSON(
         )
     }
 
-    json.createdAt = new Date(json.createdAt)
+    json.createdAt = json.createdAt ? new Date(json.createdAt) : null
     json.publishedAt = json.publishedAt ? new Date(json.publishedAt) : null
-    json.updatedAt = new Date(json.updatedAt)
+    json.updatedAt = json.updatedAt ? new Date(json.updatedAt) : null
 
     return match(type)
         .with(
@@ -211,7 +211,7 @@ export async function getAllMinimalGdocBaseObjects(
                 content ->> '$.subtitle' as subtitle,
                 content ->> '$.excerpt' as excerpt,
                 type,
-                CASE 
+                CASE
                     WHEN content ->> '$."deprecation-notice"' IS NOT NULL THEN '${ARCHVED_THUMBNAIL_FILENAME}'
                     ELSE content ->> '$."featured-image"'
                 END as "featured-image"

--- a/db/model/Post.ts
+++ b/db/model/Post.ts
@@ -330,7 +330,9 @@ export const mapGdocsToWordpressPosts = (
         slug: gdoc.slug,
         type: gdoc.content.type,
         date: gdoc.publishedAt as Date,
-        modifiedDate: gdoc.updatedAt as Date,
+        modifiedDate: gdoc.updatedAt
+            ? new Date(gdoc.updatedAt)
+            : new Date(gdoc.publishedAt as Date),
         authors: gdoc.content.authors,
         excerpt: gdoc.content["atom-excerpt"] || gdoc.content.excerpt,
         imageUrl: getGdocThumbnail(gdoc),
@@ -636,7 +638,7 @@ export const getLatestWorkByAuthor = async (
             pg.content->>'$.subtitle' AS subtitle,
             pg.content->>'$.authors' AS authors,
             pg.publishedAt,
-            CASE 
+            CASE
                 WHEN content ->> '$."deprecation-notice"' IS NOT NULL THEN '${ARCHVED_THUMBNAIL_FILENAME}'
                 ELSE content ->> '$."featured-image"'
             END as "featured-image"


### PR DESCRIPTION
20 gdocs in the DB had `updatedAt` as the start of the UNIX epoch, i.e. `new Date(null)`.

Any other ideas what might have caused it?