### PR TITLE
✨ (grapher) show facets when multiple entities are selected in single-entity mode

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -2584,6 +2584,13 @@ export class Grapher
         )
             return this.selectedFacetStrategy
 
+        if (
+            this.addCountryMode === EntitySelectionMode.SingleEntity &&
+            this.selection.selectedEntityNames.length > 1
+        ) {
+            return FacetStrategy.entity
+        }
+
         return firstOfNonEmptyArray(this.availableFacetStrategies)
     }
 


### PR DESCRIPTION
Resoles #3965

Show facets when multiple entities are selected in single-entity mode.

To do:
- What about Graphers that have entity selection disabled?
- Do thumbnails in search ever try to render countries that don't exist in the data? If yes, then faceting is not a good approach
- Should we just dismiss invalid countries when reading get params?