### PR TITLE
✨ (grapher) show facets when multiple entities are selected in single-entity mode

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -2584,6 +2584,13 @@ export class Grapher
         )
             return this.selectedFacetStrategy
 
+        if (
+            this.addCountryMode === EntitySelectionMode.SingleEntity &&
+            this.selection.selectedEntityNames.length > 1
+        ) {
+            return FacetStrategy.entity
+        }
+
         return firstOfNonEmptyArray(this.availableFacetStrategies)
     }
 


### PR DESCRIPTION
Resolves #3965

Show facets when multiple entities are selected in single-entity mode.

#### Failing charts

- [x] costs-of-polio-vaccines-in-low-income-countries: fixed by disabling entity selection
- [x] perceived-comfort-speaking-anxiety-depression: fixed by allowing multi-entity selection
- [ ] fossil-fuel-price-index: not sure how to fix, but Pablo R is on it