### PR TITLE
✨ (entity selector) keep selected entities in options list

### DIFF
--- a/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.scss
+++ b/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.scss
@@ -208,6 +208,8 @@
                 color: $gray-60;
                 white-space: nowrap;
                 margin-left: 12px;
+                padding-top: 9px;
+                padding-right: 8px;
             }
 
             .bar {

--- a/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.scss
+++ b/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.scss
@@ -175,17 +175,32 @@
         }
 
         .selectable-entity {
-            padding: 9px 8px 9px 16px;
             display: flex;
             justify-content: space-between;
             position: relative;
-            cursor: pointer;
 
-            &.hovered {
+            .checkbox,
+            .radio {
+                width: 100%;
+            }
+
+            label {
+                display: block;
+                padding: 9px 8px 9px 16px;
+                cursor: pointer;
+            }
+
+            .custom,
+            .outer {
+                left: 16px;
+                top: 9px;
+            }
+
+            &:hover {
                 background: rgba(219, 229, 240, 0.4);
             }
 
-            &--with-bar.hovered {
+            &--with-bar:hover {
                 background: rgba(219, 229, 240, 0.6);
             }
 
@@ -226,10 +241,6 @@
             position: relative;
             z-index: 0;
             background: #fff;
-
-            &.most-recently-selected {
-                z-index: 1;
-            }
         }
 
         ul {

--- a/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
+++ b/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
@@ -837,7 +837,7 @@ export class EntitySelector extends React.Component<{
 
     private renderAllEntitiesInMultiMode(): React.ReactElement {
         const { sortedAvailableEntities } = this
-        const { selected, unselected } = this.partitionedAvailableEntities
+        const { selected } = this.partitionedAvailableEntities
 
         return (
             <Flipper
@@ -876,13 +876,11 @@ export class EntitySelector extends React.Component<{
                 </div>
 
                 <div className="entity-section">
-                    {selected.length > 0 && unselected.length > 0 && (
-                        <Flipped flipId="__available" translate opacity>
-                            <div className="entity-section__title grapher_body-3-medium-italic grapher_light">
-                                {capitalize(this.entityTypePlural)}
-                            </div>
-                        </Flipped>
-                    )}
+                    <Flipped flipId="__available" translate opacity>
+                        <div className="entity-section__title grapher_body-3-medium-italic grapher_light">
+                            {capitalize(this.entityTypePlural)}
+                        </div>
+                    </Flipped>
 
                     <ul>
                         {sortedAvailableEntities.map((entity, entityIndex) => (
@@ -1042,7 +1040,7 @@ function FlippedListItem({
                 damping: 33,
             }}
         >
-            <li className={cx("flipped")}>{children}</li>
+            <li className="flipped">{children}</li>
         </Flipped>
     )
 }


### PR DESCRIPTION
Resolves #3920

Keeps selected and unselected entities both in the list of entities to choose from.

I didn't remove the animation library because the animations make it look a bit smoother when the list of selected entities is in view.

Browsers like Chrome and Firefox are smart enough not to do a layout shift when a new entity is selected while the list of selected entities is not currently in view. But in other browsers like Safari, selecting a new entity always leads to a layout shift. The animation also helps here to make the layout shift a bit less jarring. 

Marcel's point below is addressed :)