### PR TITLE
✨ (scatter) don't animate as a time scatter

### DIFF
--- a/packages/@ourworldindata/grapher/src/chart/ChartManager.ts
+++ b/packages/@ourworldindata/grapher/src/chart/ChartManager.ts
@@ -102,4 +102,8 @@ export interface ChartManager {
 
     detailsOrderedByReference?: string[]
     detailsMarkerInSvg?: DetailsMarker
+
+    isTimelineAnimationActive?: boolean
+    animationStartTime?: number
+    animationEndTime?: number
 }

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -855,7 +855,10 @@ export class Grapher
     @observable.ref isSocialMediaExport = false
 
     tooltips?: TooltipManager["tooltips"] = observable.map({}, { deep: false })
-    @observable isPlaying = false
+
+    @observable.ref isPlaying = false
+    @observable.ref isTimelineAnimationActive = false // true if the timeline animation is either playing or paused but not finished
+    @observable.ref animationStartTime: Time | undefined = undefined
 
     @observable.ref isEntitySelectorModalOrDrawerOpen = false
 
@@ -1195,6 +1198,10 @@ export class Grapher
     }
 
     @computed private get onlySingleTimeSelectionPossible(): boolean {
+        // scatter plots should not be animated as time scatter
+        if (this.isPlaying && this.isScatter && !this.isRelativeMode)
+            return true
+
         return (
             this.isDiscreteBar ||
             this.isStackedDiscreteBar ||
@@ -3268,6 +3275,17 @@ export class Grapher
 
     @computed get disablePlay(): boolean {
         return this.isSlopeChart
+    }
+
+    @computed get animationEndTime(): Time {
+        const { timeColumn } = this.tableAfterAuthorTimelineFilter
+        if (this.timelineMaxTime) {
+            return (
+                findClosestTime(timeColumn.uniqValues, this.timelineMaxTime) ??
+                timeColumn.maxTime
+            )
+        }
+        return timeColumn.maxTime
     }
 
     formatTime(value: Time): string {

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
@@ -639,12 +639,7 @@ export class DataTable extends React.Component<{
     @computed get autoSelectedStartTime(): number | undefined {
         let autoSelectedStartTime: number | undefined = undefined
 
-        if (
-            // this.grapher.userHasSetTimeline ||
-            //this.initialTimelineStartTimeSpecified ||
-            !this.loadedWithData
-        )
-            return undefined
+        if (!this.loadedWithData) return undefined
 
         const numEntitiesInTable = this.entityNames.length
 

--- a/packages/@ourworldindata/grapher/src/timeline/TimelineComponent.stories.tsx
+++ b/packages/@ourworldindata/grapher/src/timeline/TimelineComponent.stories.tsx
@@ -6,7 +6,6 @@ import { TimelineController, TimelineManager } from "./TimelineController"
 
 class TimelineManagerMock implements TimelineManager {
     @observable isPlaying = false
-    @observable userHasSetTimeline = true
     @observable times = range(1900, 2021)
 
     @observable protected _endTime = 2020

--- a/packages/@ourworldindata/grapher/src/timeline/TimelineComponent.tsx
+++ b/packages/@ourworldindata/grapher/src/timeline/TimelineComponent.tsx
@@ -75,7 +75,7 @@ export class TimelineComponent extends React.Component<{
     }
 
     @action.bound private onDrag(inputTime: number): void {
-        if (!this.manager.isPlaying) this.manager.userHasSetTimeline = true
+        this.controller.onDrag()
         this.dragTarget = this.controller.dragHandleToTime(
             this.dragTarget!,
             inputTime


### PR DESCRIPTION
Animates a scatter as a cloud of moving dots and keeps the axes fixed. The axes are fixed for the particular time range that is animated. 

At the animation's beginning and end, the view "jumps" to the new axis domains. The same happens when an animation is paused and the user starts dragging one of the sliders.

The animation in relative mode is unchanged. Getting the right axis domain doesn't seem trivial to me unless I'm missing something, so it's not worth doing at this point IMO.

In a follow-up PR, I'll also look into fixing the size domain.