### PR TITLE
🧹(grapher) remove backgroundSeriesLimit from scatters

### DIFF
--- a/explorer/GrapherGrammar.ts
+++ b/explorer/GrapherGrammar.ts
@@ -143,12 +143,6 @@ export const GrapherGrammar: Grammar = {
             }
         },
     },
-    backgroundSeriesLimit: {
-        ...IntegerCellDef,
-        description:
-            "Set this to limit the number of background series shown on ScatterPlots.",
-        keyword: "backgroundSeriesLimit",
-    },
     yScaleToggle: {
         ...BooleanCellDef,
         keyword: "yScaleToggle",

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -408,7 +408,6 @@ export class Grapher
     @observable colorSlug?: ColumnSlug = undefined
     @observable sizeSlug?: ColumnSlug = undefined
     @observable tableSlugs?: ColumnSlugs = undefined
-    @observable backgroundSeriesLimit?: number = undefined
 
     @observable selectedEntityColors: {
         [entityName: string]: string | undefined

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.stories.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.stories.tsx
@@ -78,14 +78,6 @@ export const WithComparisonLinesAndSelection = (): React.ReactElement => {
             <svg {...size}>
                 <ScatterPlotChart manager={manager} />
             </svg>
-            <svg {...size}>
-                <ScatterPlotChart
-                    manager={{
-                        ...manager,
-                        backgroundSeriesLimit: 10,
-                    }}
-                />
-            </svg>
         </>
     )
 }

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
@@ -33,7 +33,6 @@ import {
     lowerCaseFirstLetterUnlessAbbreviation,
     exposeInstanceOnWindow,
     groupBy,
-    sampleFrom,
     min,
     max,
     PointVector,
@@ -156,12 +155,8 @@ export class ScatterPlotChart
     }
 
     transformTable(table: OwidTable): OwidTable {
-        const {
-            backgroundSeriesLimit,
-            includedEntities,
-            excludedEntities,
-            addCountryMode,
-        } = this.manager
+        const { includedEntities, excludedEntities, addCountryMode } =
+            this.manager
 
         if (
             addCountryMode === EntitySelectionMode.Disabled ||
@@ -174,30 +169,6 @@ export class ScatterPlotChart
 
         if (excludedEntities || includedEntities) {
             table = this.filterManuallySelectedEntities(table)
-        }
-
-        // Allow authors to limit the # of background entities to get better perf and clearer charts.
-        if (backgroundSeriesLimit) {
-            const selectedSeriesNames = new Set<SeriesName>(
-                this.selectionArray.selectedEntityNames
-            )
-            // Todo: implement a better strategy for picking the entities to show for context. Maybe a couple per decile?
-            const backgroundSeriesNames = new Set<SeriesName>(
-                sampleFrom(
-                    table.availableEntityNames.filter(
-                        (name) => !selectedSeriesNames.has(name)
-                    ),
-                    backgroundSeriesLimit,
-                    123
-                )
-            )
-            table = table.columnFilter(
-                table.entityNameSlug,
-                (name) =>
-                    selectedSeriesNames.has(name as string) ||
-                    backgroundSeriesNames.has(name as string),
-                `Capped background series at ${backgroundSeriesLimit}`
-            )
         }
 
         if (this.xScaleType === ScaleType.log && this.xColumnSlug)

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChartConstants.ts
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChartConstants.ts
@@ -32,7 +32,6 @@ export interface ScatterPlotManager extends ChartManager {
     tableAfterAuthorTimelineAndActiveChartTransform?: OwidTable
     includedEntities?: EntityId[]
     excludedEntities?: EntityId[]
-    backgroundSeriesLimit?: number
     startTime?: Time
     endTime?: Time
     hasTimeline?: boolean


### PR DESCRIPTION
Scatter plots respect a `backgroundSeriesLimit` that limits the number of background series plotted. It's not used by any of our charts and only comes up once for an [unpublished test explorer](https://github.com/search?q=repo:owid/owid-content%20backgroundSeriesLimit&type=code).

The SVG tester differences are spurious.