### PR TITLE
Add overrides for indicator metadata

### DIFF
--- a/packages/@ourworldindata/types/src/siteTypes/MultiDimDataPage.ts
+++ b/packages/@ourworldindata/types/src/siteTypes/MultiDimDataPage.ts
@@ -1,11 +1,16 @@
 import { OwidEnrichedGdocBlock } from "../gdocTypes/ArchieMlComponents.js"
 import { PrimaryTopic } from "../gdocTypes/Datapage.js"
 import { GrapherInterface } from "../grapherTypes/GrapherTypes.js"
-import { IndicatorTitleWithFragments } from "../OwidVariable.js"
+import {
+    IndicatorTitleWithFragments,
+    OwidVariableWithSource,
+} from "../OwidVariable.js"
 
 // Indicator ID, catalog path, or maybe an array of those
 export type IndicatorEntryBeforePreProcessing = string | number | undefined
 export type IndicatorEntryAfterPreProcessing = number | undefined // catalog paths have been resolved to indicator IDs
+
+type Metadata = Omit<OwidVariableWithSource, "id">
 
 interface MultiDimDataPageConfigType<
     IndicatorType extends Record<string, any>,
@@ -16,6 +21,7 @@ interface MultiDimDataPageConfigType<
     // commonIndicatorPathPrefix?: string
     dimensions: Dimension[]
     views: View<IndicatorType>[]
+    metadata?: Metadata
 }
 
 export type MultiDimDataPageConfigRaw =
@@ -66,6 +72,7 @@ export interface View<IndicatorsType extends Record<string, any>> {
     dimensions: MultiDimDimensionChoices
     indicators: IndicatorsType
     config?: GrapherInterface
+    metadata?: Metadata
 }
 export type MultiDimDimensionChoices = Record<string, string> // Keys: dimension slugs, values: choice slugs
 


### PR DESCRIPTION
Another place where we show the metadata is in the sources modal, triggered by clicking on "Learn more about this data" when embedded. This should only scroll to the metadata section on the mdim page, except we currently set `isEmbeddedInAnOwidPage: true`, so it opens the modal even there.

We display a list of indicators and their sources there, even for the "all" view of the poverty mdim, which contains all the indicators. I think it means we don't have a place to show the global override for metadata there, but we should still override the per indicator metadata. Is that correct?