### PR TITLE
🐛 disaggregate site-baker bugsnag errors

### DIFF
--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -646,7 +646,9 @@ export class SiteBaker {
                         ? `Error baking "${publishedGdoc.slug}"`
                         : `Warning baking "${publishedGdoc.slug}"`
                 await logErrorAndMaybeSendToBugsnag(
-                    `${announcement}: ${errorOrWarning.message}`
+                    `${announcement}: ${errorOrWarning.message}`,
+                    undefined,
+                    errorOrWarning.message
                 )
             }
             try {
@@ -889,17 +891,15 @@ export class SiteBaker {
             dataInsight.latestDataInsights = latestDataInsights
 
             await dataInsight.validate(knex)
-            if (
-                dataInsight.errors.filter(
-                    (e) => e.type === OwidGdocErrorMessageType.Error
-                ).length
-            ) {
+            for (const errorOrWarning of dataInsight.errors) {
+                const announcement =
+                    errorOrWarning.type === OwidGdocErrorMessageType.Error
+                        ? `Error baking "data-insight/${dataInsight.slug}"`
+                        : `Warning baking "data-insight/${dataInsight.slug}"`
                 await logErrorAndMaybeSendToBugsnag(
-                    `Error(s) baking data insight "${
-                        dataInsight.slug
-                    }" :\n  ${dataInsight.errors
-                        .map((error) => error.message)
-                        .join("\n  ")}`
+                    `${announcement}: ${errorOrWarning.message}`,
+                    undefined,
+                    errorOrWarning.message
                 )
             }
             try {

--- a/serverUtils/errorLog.ts
+++ b/serverUtils/errorLog.ts
@@ -1,11 +1,19 @@
 import Bugsnag from "@bugsnag/js"
 
-export const logErrorAndMaybeSendToBugsnag = async (err: any, req?: any) => {
+export const logErrorAndMaybeSendToBugsnag = async (
+    err: any,
+    req?: any,
+    // Sometimes Bugsnag's default grouping algorithm gets it wrong (e.g. all SiteBaker errors get grouped together).
+    // Set a hash here to ensure that errors with the same hash will be grouped together / excluded from group they would otherwise be in.
+    groupingHash?: string
+) => {
     console.error(err)
     if (req) {
         req.bugsnag.notify(err)
     } else {
-        Bugsnag.notify(err)
+        Bugsnag.notify(err, (event) => {
+            if (groupingHash) event.groupingHash = groupingHash
+        })
     }
 }
 


### PR DESCRIPTION
Bugsnag is currently grouping _all_ errors occurring during baking as of https://github.com/owid/owid-grapher/pull/4005 being merged.

https://app.bugsnag.com/our-world-in-data/grapher-admin/errors/66d0c35a0ab81c7871ff95d5?filters[event.since]=30d&filters[error.status]=ignored

This PR allows us to set a custom `groupingHash` which overrides Bugsnag's default grouping heuristic. I've set it for gdocs baking on the specific error message so that all instances of e.g. `Author "Our World in Data team" does not exist or is not published` get grouped and can be ignored permanently, but `Author "Mxa Rsero" does not exist or is not published` would still get logged.