### PR TITLE
Update cache control

### DIFF
--- a/adminSiteServer/authentication.tsx
+++ b/adminSiteServer/authentication.tsx
@@ -183,7 +183,7 @@ export async function authMiddleware(
     }
 
     // Authed urls shouldn't be cached
-    res.set("Cache-Control", "public, max-age=0, must-revalidate")
+    res.set("Cache-Control", "public, no-cache")
 
     if (user?.isActive) {
         res.locals.session = session

--- a/adminSiteServer/authentication.tsx
+++ b/adminSiteServer/authentication.tsx
@@ -183,7 +183,7 @@ export async function authMiddleware(
     }
 
     // Authed urls shouldn't be cached
-    res.set("Cache-Control", "public, no-cache")
+    res.set("Cache-Control", "private, no-cache")
 
     if (user?.isActive) {
         res.locals.session = session

--- a/functions/_common/reusableHandlers.ts
+++ b/functions/_common/reusableHandlers.ts
@@ -26,12 +26,8 @@ export async function handleThumbnailRequest(
     }
     const resp = await fetchAndRenderGrapher(id, searchParams, extension, env)
     if (shouldCache) {
-        resp.headers.set("Cache-Control", "public, s-maxage=3600, max-age=3600")
+        resp.headers.set("Cache-Control", "s-maxage=3600, max-age=3600")
         ctx.waitUntil(caches.default.put(ctx.request, resp.clone()))
-    } else
-        resp.headers.set(
-            "Cache-Control",
-            "public, s-maxage=0, max-age=0, must-revalidate"
-        )
+    } else resp.headers.set("Cache-Control", "no-cache")
     return resp
 }

--- a/functions/grapher/[slug].ts
+++ b/functions/grapher/[slug].ts
@@ -174,8 +174,8 @@ async function handleConfigRequest(
     }
 
     const cacheControl = shouldCache
-        ? "public, s-maxage=3600, max-age=0, must-revalidate"
-        : "public, s-maxage=0, max-age=0, must-revalidate"
+        ? "s-maxage=3600, max-age=0, must-revalidate"
+        : "no-cache"
 
     //grapherPageResp.headers.set("Cache-Control", cacheControl)
     return new Response(grapherPageResp.body as any, {

--- a/functions/grapher/by-uuid/[uuid].ts
+++ b/functions/grapher/by-uuid/[uuid].ts
@@ -82,8 +82,8 @@ async function handleConfigRequest(
     console.log("Grapher page response", grapherPageResp.grapherConfig.title)
 
     const cacheControl = shouldCache
-        ? "public, s-maxage=3600, max-age=0, must-revalidate"
-        : "public, s-maxage=0, max-age=0, must-revalidate"
+        ? "s-maxage=3600, max-age=0, must-revalidate"
+        : "no-cache"
 
     return Response.json(grapherPageResp.grapherConfig, {
         headers: {

--- a/functions/grapher/thumbnail/[slug].ts
+++ b/functions/grapher/thumbnail/[slug].ts
@@ -56,16 +56,9 @@ export const onRequestGet: PagesFunction = async (ctx) => {
         .fetch(request, url, { ...env, url }, ctx)
         .then((resp: Response) => {
             if (shouldCache) {
-                resp.headers.set(
-                    "Cache-Control",
-                    "public, s-maxage=3600, max-age=3600"
-                )
+                resp.headers.set("Cache-Control", "s-maxage=3600, max-age=3600")
                 ctx.waitUntil(caches.default.put(request, resp.clone()))
-            } else
-                resp.headers.set(
-                    "Cache-Control",
-                    "public, s-maxage=0, max-age=0, must-revalidate"
-                )
+            } else resp.headers.set("Cache-Control", "no-cache")
             return resp
         })
         .catch((e) => error(500, e))

--- a/public/_headers
+++ b/public/_headers
@@ -1,5 +1,5 @@
 /*
-    Cache-Control: public, max-age=0, must-revalidate
+    Cache-Control: no-cache
     Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
     Access-Control-Allow-Origin: https://owid.cloud
 


### PR DESCRIPTION
A small follow-up to our call.

* `no-cache` is equivalent to `max-age=0, must-revalidate` and recommended being used instead, see
  https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching#force_revalidation
* Authenticated responses should use private cache only
