### PR TITLE
Stop showing variable ID as a grapher title

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -1513,6 +1513,7 @@ export class Grapher
 
     @computed get currentTitle(): string {
         let text = this.displayTitle.trim()
+        if (text.length === 0) return text
 
         // helper function to add an annotation fragment to the title
         // only adds a comma if the text does not end with a question mark
@@ -1820,7 +1821,9 @@ export class Grapher
     }
 
     @computed get displayTitle(): string {
-        return this.title ?? this.defaultTitle
+        if (this.title) return this.title
+        if (this.isReady) return this.defaultTitle
+        return ""
     }
 
     // Returns an object ready to be serialized to JSON


### PR DESCRIPTION
When everything hasn't loaded yet, `defaultTitle` may contain variable IDs.

I tried changing how `defaultTitle` works to avoid it ever returning a title with variable IDs, which would be possible if we made `titlePublicOrDisplayName` return an empty string instead of variable ID, which we could do if we changed `AbstractCoreColumn.name` to return an empty string instead of a slug (which is the variableId), but that breaks assumptions in other places where `titlePublicOrDisplayName` is used.