### PR TITLE
🐛 (legend) fix vertical positioning

### DIFF
--- a/packages/@ourworldindata/grapher/src/verticalColorLegend/VerticalColorLegend.tsx
+++ b/packages/@ourworldindata/grapher/src/verticalColorLegend/VerticalColorLegend.tsx
@@ -89,31 +89,33 @@ export class VerticalColorLegend extends React.Component<{
             lineHeight,
         } = this
 
-        return manager.legendItems
-            .map((series, index) => {
-                let label = series.label
-                // infer label for numeric bins
-                if (!label && series.minText && series.maxText) {
-                    label = `${series.minText} – ${series.maxText}`
-                }
-                const textWrap = new TextWrap({
-                    maxWidth: this.maxLegendWidth,
-                    fontSize,
-                    lineHeight: 1,
-                    text: label ?? "",
-                })
-                const width = rectSize + rectPadding + textWrap.width
-                const height = Math.max(textWrap.height, rectSize)
-                const yOffset = titleHeight + index * (height + lineHeight)
-                return {
-                    textWrap,
-                    color: series.color,
-                    width,
-                    height,
-                    yOffset,
-                }
+        let runningYOffset = titleHeight
+        return manager.legendItems.map((series) => {
+            let label = series.label
+            // infer label for numeric bins
+            if (!label && series.minText && series.maxText) {
+                label = `${series.minText} – ${series.maxText}`
+            }
+            const textWrap = new TextWrap({
+                maxWidth: this.maxLegendWidth,
+                fontSize,
+                lineHeight: 1,
+                text: label ?? "",
             })
-            .filter((v) => !!v) as SizedLegendSeries[]
+            const width = rectSize + rectPadding + textWrap.width
+            const height = Math.max(textWrap.height, rectSize)
+            const yOffset = runningYOffset
+
+            runningYOffset += height + lineHeight
+
+            return {
+                textWrap,
+                color: series.color,
+                width,
+                height,
+                yOffset,
+            }
+        })
     }
 
     @computed get width(): number {


### PR DESCRIPTION
Items in the vertical colour legend are sometimes incorrectly positioned. This is a result of an oversight when I refactored the legend. 

I'm not fully back until tomorrow. @marcelgerber, if this looks ok to you, can you merge it in? Also feel free to commit to this branch if you want to change something. 

Example: https://ourworldindata.org/grapher/cardiovascular-death-rate-vs-gdp-per-capita