### PR TITLE
🐛 replace spaces in element IDs for Figma

### DIFF
--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -307,6 +307,10 @@ export const makeSafeForCSS = (name: string): string =>
         return "__" + ("000" + char.toString(16)).slice(-4)
     })
 
+function makeSafeForFigma(name: string): string {
+    return name.replace(/\s/g, "-")
+}
+
 /**
  * Make a human-readable string meant to be be used as the ID of a SVG chart
  * element. This is useful when a static chart is manually edited in a SVG
@@ -316,7 +320,7 @@ export const makeSafeForCSS = (name: string): string =>
  * Note that these IDs are not meant to be used in CSS!
  */
 export function makeIdForHumanConsumption(...unsafeKeys: string[]): string {
-    return unsafeKeys.join("__")
+    return makeSafeForFigma(unsafeKeys.join("__"))
 }
 
 export function formatDay(


### PR DESCRIPTION
Figma shows element IDs as labels. We used to make those IDs "CSS safe," which sometimes led to ugly, difficult-to-read IDs. That's why, in a recent PR, I just assigned names as is to element IDs (including CSS unsafe stuff like spaces and %, etc). I didn't notice anything weird at the time, so I thought Figma would be ok with this. Now we're dealing with a weird Figma issue where lines show up but are not coloured. We can't repro the bug, so not sure this fix helps, but it's our best guess atm.