### PR TITLE
Redesigned download modal, with enhanced data download options

### DIFF
--- a/packages/@ourworldindata/components/src/CodeSnippet/code-snippet.scss
+++ b/packages/@ourworldindata/components/src/CodeSnippet/code-snippet.scss
@@ -26,6 +26,7 @@
     }
 
     .wp-code-snippet__code {
+        font-family: $monospace-font-stack;
         word-break: break-word;
     }
 

--- a/packages/@ourworldindata/components/src/ExpandableToggle/ExpandableToggle.tsx
+++ b/packages/@ourworldindata/components/src/ExpandableToggle/ExpandableToggle.tsx
@@ -33,17 +33,20 @@ export const ExpandableToggle = ({
             })}
         >
             <button className="ExpandableToggle__button" onClick={toggle}>
-                <h4 className="ExpandableToggle__title">{label}</h4>
+                <div>
+                    <h4 className="ExpandableToggle__title">{label}</h4>
+                    {alwaysVisibleDescription && (
+                        <div className="ExpandableToggle__description">
+                            {alwaysVisibleDescription}
+                        </div>
+                    )}
+                </div>
                 <FontAwesomeIcon
                     className="ExpandableToggle__icon"
                     icon={!isOpen ? faPlus : faMinus}
                 />
             </button>
-            {alwaysVisibleDescription && (
-                <div className="ExpandableToggle__description">
-                    {alwaysVisibleDescription}
-                </div>
-            )}
+
             <div className="ExpandableToggle__content">{content}</div>
         </div>
     )

--- a/packages/@ourworldindata/components/src/ExpandableToggle/ExpandableToggle.tsx
+++ b/packages/@ourworldindata/components/src/ExpandableToggle/ExpandableToggle.tsx
@@ -6,12 +6,14 @@ import cx from "classnames"
 export const ExpandableToggle = ({
     label,
     content,
+    alwaysVisibleDescription,
     isExpandedDefault = false,
     isStacked = false,
     hasTeaser = false,
 }: {
     label: string
     content?: React.ReactNode
+    alwaysVisibleDescription?: React.ReactNode
     isExpandedDefault?: boolean
     isStacked?: boolean
     hasTeaser?: boolean
@@ -37,6 +39,11 @@ export const ExpandableToggle = ({
                     icon={!isOpen ? faPlus : faMinus}
                 />
             </button>
+            {alwaysVisibleDescription && (
+                <div className="ExpandableToggle__description">
+                    {alwaysVisibleDescription}
+                </div>
+            )}
             <div className="ExpandableToggle__content">{content}</div>
         </div>
     )

--- a/packages/@ourworldindata/components/src/styles/typography.scss
+++ b/packages/@ourworldindata/components/src/styles/typography.scss
@@ -2,7 +2,7 @@ $sans-serif-font-stack: Lato, "Helvetica Neue", Helvetica, Arial,
     "Liberation Sans", sans-serif;
 $serif-font-stack: "Playfair Display", Georgia, "Times New Roman",
     "Liberation Serif", serif;
-$monospace-font-stack: "Courier New", Courier, monospace; // only to be used for code blocks
+$monospace-font-stack: "Menlo", "Courier New", Courier, monospace; // only to be used for code blocks
 $default-font-features: "liga", "kern", "calt";
 
 //

--- a/packages/@ourworldindata/components/src/styles/typography.scss
+++ b/packages/@ourworldindata/components/src/styles/typography.scss
@@ -2,6 +2,7 @@ $sans-serif-font-stack: Lato, "Helvetica Neue", Helvetica, Arial,
     "Liberation Sans", sans-serif;
 $serif-font-stack: "Playfair Display", Georgia, "Times New Roman",
     "Liberation Serif", serif;
+$monospace-font-stack: "Courier New", Courier, monospace; // only to be used for code blocks
 $default-font-features: "liga", "kern", "calt";
 
 //

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -1809,7 +1809,7 @@ export class Grapher
     }
 
     // todo: remove when we remove dimensions
-    @computed private get yColumnsFromDimensionsOrSlugsOrAuto(): CoreColumn[] {
+    @computed get yColumnsFromDimensionsOrSlugsOrAuto(): CoreColumn[] {
         return this.yColumnsFromDimensions.length
             ? this.yColumnsFromDimensions
             : this.table.getColumns(autoDetectYColumnSlugs(this))

--- a/packages/@ourworldindata/grapher/src/core/typography.scss
+++ b/packages/@ourworldindata/grapher/src/core/typography.scss
@@ -90,6 +90,21 @@
     @include grapher_body-2-semibold;
 }
 
+@mixin grapher_body-2-medium {
+    display: block;
+    margin: 0;
+
+    font-family: $sans-serif-font-stack;
+    font-size: 16px;
+    font-weight: 500;
+    line-height: 1.5;
+    letter-spacing: 0;
+}
+
+.grapher_body-2-medium {
+    @include grapher_body-2-medium;
+}
+
 @mixin grapher_body-3-medium {
     display: block;
     margin: 0;

--- a/packages/@ourworldindata/grapher/src/core/typography.scss
+++ b/packages/@ourworldindata/grapher/src/core/typography.scss
@@ -142,6 +142,21 @@
     @include grapher_label-1-medium;
 }
 
+@mixin grapher_label-1-regular {
+    display: block;
+    margin: 0;
+
+    font-family: $sans-serif-font-stack;
+    font-size: 14px;
+    font-weight: 400;
+    line-height: 1.2;
+    letter-spacing: 0;
+}
+
+.grapher_label-1-regular {
+    @include grapher_label-1-regular;
+}
+
 @mixin grapher_label-2-regular {
     display: block;
     margin: 0;

--- a/packages/@ourworldindata/grapher/src/modal/DownloadIcons.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadIcons.tsx
@@ -1,0 +1,41 @@
+import React from "react"
+
+export const DownloadIconFullDataset = () => (
+    <svg
+        width="34"
+        height="24"
+        viewBox="0 0 34 24"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+    >
+        <rect y="1" width="10" height="6" rx="3" fill="#577291" />
+        <rect x="12" y="1" width="10" height="6" rx="3" fill="#577291" />
+        <rect x="24" y="1" width="10" height="6" rx="3" fill="#577291" />
+        <rect y="9" width="10" height="6" rx="3" fill="#577291" />
+        <rect x="12" y="9" width="10" height="6" rx="3" fill="#577291" />
+        <rect x="24" y="9" width="10" height="6" rx="3" fill="#577291" />
+        <rect y="17" width="10" height="6" rx="3" fill="#577291" />
+        <rect x="12" y="17" width="10" height="6" rx="3" fill="#577291" />
+        <rect x="24" y="17" width="10" height="6" rx="3" fill="#577291" />
+    </svg>
+)
+
+export const DownloadIconSelected = () => (
+    <svg
+        width="34"
+        height="24"
+        viewBox="0 0 34 24"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+    >
+        <rect y="1" width="10" height="6" rx="3" fill="#577291" />
+        <rect x="12" y="1" width="10" height="6" rx="3" fill="#577291" />
+        <rect x="24" y="1" width="10" height="6" rx="3" fill="#A4B6CA" />
+        <rect y="9" width="10" height="6" rx="3" fill="#577291" />
+        <rect x="12" y="9" width="10" height="6" rx="3" fill="#577291" />
+        <rect x="24" y="9" width="10" height="6" rx="3" fill="#A4B6CA" />
+        <rect y="17" width="10" height="6" rx="3" fill="#A4B6CA" />
+        <rect x="12" y="17" width="10" height="6" rx="3" fill="#A4B6CA" />
+        <rect x="24" y="17" width="10" height="6" rx="3" fill="#A4B6CA" />
+    </svg>
+)

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
@@ -9,6 +9,8 @@
         flex-shrink: 0;
     }
 
+    margin-bottom: 24px;
+
     .padded {
         padding: 0 var(--modal-padding);
     }
@@ -128,13 +130,11 @@
 }
 
 .static-exports-options {
-    margin: 16px 0 24px;
-    padding-bottom: 24px;
-    border-bottom: 1px solid $gray-10;
+    margin: 16px 0 0;
 
-    > .checkbox + .checkbox {
-        margin-top: 8px;
-    }
+    gap: 8px;
+    display: flex;
+    flex-direction: column;
 }
 
 &.GrapherComponentSmall .download-modal-content {

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
@@ -1,7 +1,7 @@
 .download-modal-content {
     $ruler-border: 1px solid $gray-10;
     $download-button-fill: $blue-5;
-    $hover-fill: $blue-10;
+    $hover-fill: $accent-pale-blue;
     $active-fill: $blue-20;
 
     color: $dark-text;
@@ -53,10 +53,6 @@
         + .download-modal__data-section {
             border-top: $ruler-border;
             padding-top: 16px;
-        }
-
-        h3 {
-            margin-bottom: 4px; // 4px margin + 8px gap
         }
 
         &:last-child {
@@ -173,10 +169,11 @@
         line-height: 1.3;
     }
 
-    .download-modal__citation-guidance {
+    .download-modal__data-sources {
         line-height: 1.4;
+        margin-bottom: 4px; // 4px margin + 8px gap
 
-        .download-modal__citation-guidance-list {
+        .download-modal__data-sources-list {
             display: inline;
             list-style: none;
 

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
@@ -54,7 +54,7 @@
         }
 
         h3 {
-            margin-bottom: 8px; // 8px margin + 8px gap
+            margin-bottom: 4px; // 4px margin + 8px gap
         }
 
         &:last-child {
@@ -241,7 +241,7 @@
         }
     }
 
-    .download-modal__section-code {
+    .download-modal__heading-with-caption {
         h3 {
             margin-bottom: 4px;
         }
@@ -249,7 +249,7 @@
         p {
             color: $gray-60;
             margin: 0;
-            margin-bottom: 16px;
+            margin-bottom: 4px;
         }
     }
 }

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
@@ -85,6 +85,11 @@
             margin-top: 2px;
         }
 
+        .download-modal__option-icon {
+            margin-right: 12px;
+            display: flex;
+        }
+
         .download-modal__download-preview-img img {
             display: block;
             box-shadow:

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
@@ -133,6 +133,12 @@
             color: $gray-70;
             padding: 2px 4px;
             font-family: "Courier New", Courier, monospace;
+
+            white-space: normal;
+
+            // Make it so we get nice paddings around line breaks
+            -webkit-box-decoration-break: clone;
+            box-decoration-break: clone;
         }
 
         .label {

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
@@ -226,8 +226,9 @@
         }
 
         ul {
-            margin: 6px 0 0;
-            padding-left: 22px;
+            margin: 0;
+            padding-left: 18px;
+            line-height: 1.5;
         }
 
         a {

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
@@ -176,13 +176,17 @@
         }
     }
 
+    .download-modal__sources {
+        font-size: 15px;
+        line-height: 1.3;
+    }
+
     .download-modal__citation-guidance {
-        font-size: 14px;
+        line-height: 1.4;
 
         .download-modal__citation-guidance-list {
             display: inline;
             list-style: none;
-            line-height: 1.4;
 
             li {
                 display: inline;

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
@@ -177,7 +177,7 @@
     }
 
     .download-modal__sources {
-        font-size: 15px;
+        font-size: 14px;
         line-height: 1.3;
     }
 

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
@@ -9,11 +9,15 @@
         flex-shrink: 0;
     }
 
+    .padded {
+        padding: 0 var(--modal-padding);
+    }
+
     .scrollable {
         flex: 1 1 auto;
         overflow-y: auto;
-        padding: 0 var(--modal-padding) var(--modal-padding);
-        width: 100%;
+
+        margin-top: var(--modal-padding);
 
         // needed for the loading indicator
         position: relative;
@@ -116,6 +120,10 @@
                 text-decoration: none;
             }
         }
+    }
+
+    .Tabs__tab {
+        flex-basis: 100%;
     }
 }
 

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
@@ -1,5 +1,8 @@
 .download-modal-content {
     $ruler-border: 1px solid $gray-10;
+    $download-button-fill: $blue-5;
+    $hover-fill: $blue-10;
+    $active-fill: $blue-20;
 
     color: $dark-text;
 
@@ -64,7 +67,7 @@
         flex-direction: row;
         align-items: center;
         color: $blue-90;
-        background-color: $blue-5;
+        background-color: $download-button-fill;
         position: relative;
         width: 100%;
         padding: 16px;
@@ -107,13 +110,6 @@
             padding: 0 8px 0 16px;
             font-size: 16px;
         }
-    }
-
-    // TODO remove
-    hr {
-        margin: 16px 0;
-        padding: 0;
-        color: $gray-10;
     }
 
     .download-modal__config-list {

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
@@ -157,8 +157,9 @@
     }
 
     .download-modal__api-urls {
-        border-top: $ruler-border;
-        padding-top: 16px;
+        border-bottom: $ruler-border;
+        padding-bottom: 16px;
+        margin-bottom: 8px;
 
         display: flex;
         flex-direction: column;
@@ -234,7 +235,6 @@
         display: flex;
         flex-direction: column;
         gap: 16px;
-        padding-top: 16px;
 
         h4 {
             margin-bottom: 8px;
@@ -249,6 +249,7 @@
         p {
             color: $gray-60;
             margin: 0;
+            margin-bottom: 16px;
         }
     }
 }

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
@@ -156,6 +156,15 @@
         }
     }
 
+    .download-modal__api-urls {
+        border-top: $ruler-border;
+        padding-top: 16px;
+
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+    }
+
     .ExpandableToggle {
         --expandable-toggle-border: transparent;
         --expandable-toggle-button: #{$gray-80};

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
@@ -237,12 +237,13 @@
 
         h4 {
             margin-bottom: 8px;
+            font-size: 14px;
         }
     }
 
     .download-modal__heading-with-caption {
         h3 {
-            margin-bottom: 4px;
+            margin-bottom: 6px;
         }
 
         p {

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
@@ -155,9 +155,8 @@
     }
 
     .download-modal__api-urls {
-        border-bottom: $ruler-border;
-        padding-bottom: 16px;
-        margin-bottom: 8px;
+        border-top: $ruler-border;
+        padding-top: 16px;
 
         display: flex;
         flex-direction: column;
@@ -242,6 +241,8 @@
     }
 
     .download-modal__heading-with-caption {
+        margin-bottom: 8px;
+
         h3 {
             margin-bottom: 6px;
         }
@@ -249,7 +250,6 @@
         p {
             color: $gray-60;
             margin: 0;
-            margin-bottom: 4px;
         }
 
         a {

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
@@ -11,6 +11,8 @@
     flex-direction: column;
 
     .download-modal__tab-list {
+        --tabs-font-size: 14px;
+
         padding: 0 var(--modal-padding);
 
         .Tabs__tab {

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
@@ -7,6 +7,11 @@
 
     .download-modal__tab-list {
         padding: 0 var(--modal-padding);
+
+        .Tabs__tab {
+            // Tabs should fill the whole available width
+            flex-basis: 100%;
+        }
     }
 
     .download-modal__tab-panel {
@@ -32,21 +37,17 @@
         flex-direction: column;
         gap: 8px;
 
+        + .download-modal__data-section {
+            border-top: 1px solid $gray-10;
+            padding-top: 16px;
+        }
+
         h3 {
             margin-bottom: 8px; // 8px margin + 8px gap
         }
     }
 
-    .download-modal__data-section + .download-modal__data-section {
-        border-top: 1px solid $gray-10;
-        padding-top: 16px;
-    }
-
-    .grouped-menu-item + .grouped-menu-item {
-        margin-top: 4px;
-    }
-
-    .grouped-menu-item {
+    .download-modal__download-button {
         display: flex;
         flex-direction: row;
         align-items: center;
@@ -66,25 +67,34 @@
         &:active {
             background-color: $active-fill;
         }
-    }
 
-    .grouped-menu-icon img {
-        display: block;
-        box-shadow:
-            0px 0px 0px 0px rgba(49, 37, 2, 0.03),
-            0px 6px 13px 0px rgba(49, 37, 2, 0.03),
-            0px 93px 37px 0px rgba(49, 37, 2, 0.01),
-            0px 145px 41px 0px rgba(49, 37, 2, 0);
-        padding: 0;
-        margin: 0 24px 0 0;
-    }
+        + .download-modal__download-button {
+            margin-top: 4px;
+        }
 
-    .grouped-menu-content {
-        flex: 1;
-    }
+        .download-modal__download-preview-img img {
+            display: block;
+            box-shadow:
+                0px 0px 0px 0px rgba(49, 37, 2, 0.03),
+                0px 6px 13px 0px rgba(49, 37, 2, 0.03),
+                0px 93px 37px 0px rgba(49, 37, 2, 0.01),
+                0px 145px 41px 0px rgba(49, 37, 2, 0);
+            padding: 0;
+            margin: 0 24px 0 0;
+        }
 
-    .grouped-menu-content-description {
-        color: $bluish-grey-text-color;
+        .download-modal__download-button-content {
+            flex: 1;
+        }
+
+        .download-modal__download-button-description {
+            color: $bluish-grey-text-color;
+        }
+
+        .download-modal__download-icon {
+            padding: 0 8px 0 16px;
+            font-size: 16px;
+        }
     }
 
     hr {
@@ -169,17 +179,15 @@
     }
 
     .download-icon {
-        padding: 0 8px 0 16px;
-        font-size: 16px;
     }
 
     .grouped-menu-item:hover .download-icon {
         opacity: 1;
     }
 
-    .grouped-menu-callout {
-        border-radius: 8px;
+    .download-modal__callout {
         border: 1px solid $gray-20;
+        border-radius: 8px;
         background: $gray-5;
         padding: 16px;
 
@@ -205,10 +213,6 @@
         a {
             @include owid-link-60;
         }
-    }
-
-    .Tabs__tab {
-        flex-basis: 100%;
     }
 }
 

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
@@ -165,31 +165,6 @@
         gap: 16px;
     }
 
-    .ExpandableToggle {
-        --expandable-toggle-border: transparent;
-        --expandable-toggle-button: #{$gray-80};
-        --expandable-toggle-button-hover: #{$gray-90};
-        --expandable-toggle-title-size: 18px;
-        --expandable-toggle-content: currentColor;
-
-        .ExpandableToggle__button {
-            padding-top: 0;
-            padding-bottom: 2px;
-        }
-
-        .ExpandableToggle__content {
-            padding: 0;
-        }
-
-        .ExpandableToggle__description {
-            p {
-                margin: 0;
-                @include grapher_label-1-regular;
-                color: $gray-60;
-            }
-        }
-    }
-
     .download-modal__sources {
         font-size: 14px;
         line-height: 1.3;
@@ -254,7 +229,8 @@
         }
     }
 
-    .data-modal__code-examples {
+    .download-modal__code-blocks,
+    .download-modal__api-urls {
         display: flex;
         flex-direction: column;
         gap: 16px;
@@ -262,6 +238,17 @@
 
         h4 {
             margin-bottom: 8px;
+        }
+    }
+
+    .download-modal__section-code {
+        h3 {
+            margin-bottom: 4px;
+        }
+
+        p {
+            color: $gray-60;
+            margin: 0;
         }
     }
 }

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
@@ -1,4 +1,6 @@
 .download-modal-content {
+    $ruler-border: 1px solid $gray-10;
+
     color: $dark-text;
 
     // necessary for scrolling
@@ -30,6 +32,12 @@
         padding: 0 var(--modal-padding);
     }
 
+    .download-modal__vis-section {
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+    }
+
     .download-modal__data-section {
         padding-bottom: 16px;
 
@@ -38,7 +46,7 @@
         gap: 8px;
 
         + .download-modal__data-section {
-            border-top: 1px solid $gray-10;
+            border-top: $ruler-border;
             padding-top: 16px;
         }
 
@@ -116,7 +124,7 @@
         padding-bottom: 8px; // 8px padding + 8px gap
 
         + .download-modal__config-list {
-            border-top: 1px solid $gray-10;
+            border-top: $ruler-border;
             padding-top: 16px;
         }
 
@@ -132,7 +140,7 @@
             background-color: $gray-10;
             color: $gray-70;
             padding: 2px 4px;
-            font-family: "Courier New", Courier, monospace;
+            font-family: $monospace-font-stack;
 
             white-space: normal;
 
@@ -238,14 +246,6 @@
             margin-bottom: 8px;
         }
     }
-}
-
-.static-exports-options {
-    margin: 16px 0 0;
-
-    gap: 8px;
-    display: flex;
-    flex-direction: column;
 }
 
 &.GrapherComponentSmall .download-modal-content {

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
@@ -28,7 +28,7 @@
 
         // needed for the loading indicator
         position: relative;
-        min-height: 45px;
+        min-height: 100px;
     }
 
     .download-modal__tab {
@@ -239,25 +239,14 @@
         gap: 16px;
         padding-top: 16px;
         h4 {
+            font-weight: 500;
             margin-bottom: 8px;
         }
     }
 }
 
-&.GrapherComponentSmall .download-modal-content {
-    .grouped-menu-item h4,
-    .grouped-menu-callout h4 {
-        font-size: 14px;
-    }
-
-    .grouped-menu-item p,
-    .grouped-menu-callout p {
-        font-size: 13px;
-    }
-}
-
 &.GrapherComponentNarrow .download-modal-content {
-    .grouped-menu-icon img {
+    .download-modal__download-preview-img img {
         display: none;
     }
 }

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
@@ -82,8 +82,60 @@
         color: $bluish-grey-text-color;
     }
 
-    .grouped-menu-section-data .grouped-menu-content {
-        padding-left: 0;
+    hr {
+        margin: 16px 0;
+        padding: 0;
+        color: $gray-10;
+    }
+
+    .grouped-menu-section-data {
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+
+        .label {
+            @include grapher_label-1-regular;
+        }
+
+        p {
+            margin-top: 8px;
+            margin-bottom: 8px;
+            margin-left: 24px;
+            font-size: 12pt;
+        }
+
+        code {
+            background-color: $gray-10;
+            color: $gray-70;
+            padding: 2px 4px;
+            font-family: "Courier New", Courier, monospace;
+            line-height: 1.4;
+        }
+    }
+
+    .ExpandableToggle {
+        --border: transparent;
+    }
+
+    .ExpandableToggle {
+        --expandable-toggle-button: $gray-80;
+        --expandable-toggle-button-hover: $gray-60;
+        --title-size: 18px;
+        --expandable-toggle-content: currentColor;
+    }
+
+    .ExpandableToggle__button {
+        padding-bottom: 2px;
+    }
+
+    .ExpandableToggle__description {
+        margin: 0;
+
+        p {
+            margin: 0;
+            @include grapher_label-1-regular;
+            color: $gray-60;
+        }
     }
 
     .download-icon {

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
@@ -250,6 +250,11 @@
             margin: 0;
             margin-bottom: 4px;
         }
+
+        a {
+            @include owid-link-90;
+            color: $gray-70;
+        }
     }
 }
 

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
@@ -45,6 +45,10 @@
         h3 {
             margin-bottom: 8px; // 8px margin + 8px gap
         }
+
+        &:last-child {
+            padding-bottom: 0;
+        }
     }
 
     .download-modal__download-button {
@@ -97,25 +101,31 @@
         }
     }
 
+    // TODO remove
     hr {
         margin: 16px 0;
         padding: 0;
         color: $gray-10;
     }
 
-    .grouped-menu-section-data {
+    .download-modal__config-list {
         display: flex;
         flex-direction: column;
+        gap: 16px;
 
-        .label {
-            @include grapher_label-1-regular;
+        padding-bottom: 8px; // 8px padding + 8px gap
+
+        + .download-modal__config-list {
+            border-top: 1px solid $gray-10;
+            padding-top: 16px;
         }
 
         p {
-            margin-top: 8px;
-            margin-bottom: 8px;
+            margin-top: 4px;
+            margin-bottom: 0;
             margin-left: 24px;
-            font-size: 12pt;
+            font-size: 13px;
+            line-height: 1.3;
         }
 
         code {
@@ -123,32 +133,37 @@
             color: $gray-70;
             padding: 2px 4px;
             font-family: "Courier New", Courier, monospace;
-            line-height: 1.4;
+        }
+
+        .label {
+            @include grapher_label-1-regular;
         }
     }
 
     .ExpandableToggle {
         --border: transparent;
-    }
-
-    .ExpandableToggle {
         --expandable-toggle-button: $gray-80;
         --expandable-toggle-button-hover: $gray-60;
         --title-size: 18px;
         --expandable-toggle-content: currentColor;
-    }
 
-    .ExpandableToggle__button {
-        padding-bottom: 2px;
-    }
+        .ExpandableToggle__button {
+            padding-top: 0;
+            padding-bottom: 2px;
+        }
 
-    .ExpandableToggle__description {
-        margin: 0;
+        .ExpandableToggle__content {
+            padding: 0;
+        }
 
-        p {
+        .ExpandableToggle__description {
             margin: 0;
-            @include grapher_label-1-regular;
-            color: $gray-60;
+
+            p {
+                margin: 0;
+                @include grapher_label-1-regular;
+                color: $gray-60;
+            }
         }
     }
 
@@ -178,13 +193,6 @@
         }
     }
 
-    .download-icon {
-    }
-
-    .grouped-menu-item:hover .download-icon {
-        opacity: 1;
-    }
-
     .download-modal__callout {
         border: 1px solid $gray-20;
         border-radius: 8px;
@@ -212,6 +220,16 @@
 
         a {
             @include owid-link-60;
+        }
+    }
+
+    .data-modal__code-examples {
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+        padding-top: 16px;
+        h4 {
+            margin-bottom: 8px;
         }
     }
 }

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
@@ -114,13 +114,13 @@
             font-size: 14px;
         }
 
-        a {
-            color: inherit;
-            text-decoration: underline;
+        ul {
+            margin: 6px 0 0;
+            padding-left: 22px;
+        }
 
-            &:hover {
-                text-decoration: none;
-            }
+        a {
+            @include owid-link-60;
         }
     }
 

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
@@ -138,6 +138,31 @@
         }
     }
 
+    .download-modal__citation-guidance-list {
+        display: inline;
+        list-style: none;
+        line-height: 1.4;
+
+        li {
+            display: inline;
+
+            &::after {
+                display: inline-block;
+                white-space: pre;
+                content: "; ";
+            }
+
+            &:last-child::after {
+                content: none;
+            }
+
+            a {
+                @include owid-link-90;
+                color: $gray-80;
+            }
+        }
+    }
+
     .download-icon {
         padding: 0 8px 0 16px;
         font-size: 16px;

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
@@ -4,37 +4,42 @@
     // necessary for scrolling
     display: flex;
     flex-direction: column;
-    height: 100%;
-    > * {
-        flex-shrink: 0;
-    }
 
-    margin-bottom: 24px;
-
-    .padded {
+    .download-modal__tab-list {
         padding: 0 var(--modal-padding);
     }
 
-    .scrollable {
+    .download-modal__tab-panel {
+        padding-bottom: 24px;
+        margin-top: 16px;
+
         flex: 1 1 auto;
         overflow-y: auto;
-
-        margin-top: var(--modal-padding);
-        padding-bottom: 1px; // makes scrollbar disappear when not needed
 
         // needed for the loading indicator
         position: relative;
         min-height: 45px;
     }
 
-    .grouped-menu-section {
+    .download-modal__tab {
+        padding: 0 var(--modal-padding);
+    }
+
+    .download-modal__data-section {
+        padding-bottom: 16px;
+
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+
         h3 {
-            margin-bottom: 16px;
+            margin-bottom: 8px; // 8px margin + 8px gap
         }
     }
 
-    .grouped-menu-section + .grouped-menu-section {
-        margin-top: 24px;
+    .download-modal__data-section + .download-modal__data-section {
+        border-top: 1px solid $gray-10;
+        padding-top: 16px;
     }
 
     .grouped-menu-item + .grouped-menu-item {
@@ -91,7 +96,6 @@
     .grouped-menu-section-data {
         display: flex;
         flex-direction: column;
-        gap: 16px;
 
         .label {
             @include grapher_label-1-regular;
@@ -139,6 +143,7 @@
     }
 
     .download-modal__citation-guidance-list {
+        font-size: 14px;
         display: inline;
         list-style: none;
         line-height: 1.4;
@@ -174,7 +179,7 @@
 
     .grouped-menu-callout {
         border-radius: 8px;
-        border: 1px solid $gray-30;
+        border: 1px solid $gray-20;
         background: $gray-5;
         padding: 16px;
 

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
@@ -38,8 +38,8 @@
         display: flex;
         flex-direction: row;
         align-items: center;
-        color: $dark-text;
-        background-color: $gray-5;
+        color: $blue-90;
+        background-color: $blue-5;
         position: relative;
         width: 100%;
         padding: 16px;
@@ -69,6 +69,10 @@
 
     .grouped-menu-content {
         flex: 1;
+    }
+
+    .grouped-menu-content-description {
+        color: $bluish-grey-text-color;
     }
 
     .grouped-menu-section-data .grouped-menu-content {

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
@@ -20,7 +20,6 @@
     }
 
     .download-modal__tab-panel {
-        padding-bottom: 24px;
         margin-top: 16px;
 
         flex: 1 1 auto;
@@ -31,8 +30,9 @@
         min-height: 100px;
     }
 
-    .download-modal__tab {
+    .download-modal__tab-content {
         padding: 0 var(--modal-padding);
+        margin-bottom: 24px;
     }
 
     .download-modal__vis-section {
@@ -68,14 +68,12 @@
         align-items: center;
         color: $blue-90;
         background-color: $download-button-fill;
-        position: relative;
         width: 100%;
         padding: 16px;
-        overflow: hidden;
         text-align: left;
+        cursor: pointer;
 
         &:hover {
-            cursor: pointer;
             background-color: $hover-fill;
         }
 
@@ -84,7 +82,7 @@
         }
 
         + .download-modal__download-button {
-            margin-top: 4px;
+            margin-top: 2px;
         }
 
         .download-modal__download-preview-img img {
@@ -124,6 +122,12 @@
             padding-top: 16px;
         }
 
+        // Radio label
+        .label {
+            @include grapher_label-1-regular;
+        }
+
+        // "Example" label
         p {
             margin-top: 4px;
             margin-bottom: 0;
@@ -132,6 +136,7 @@
             line-height: 1.3;
         }
 
+        // Example column name
         code {
             background-color: $gray-10;
             color: $gray-70;
@@ -144,17 +149,13 @@
             -webkit-box-decoration-break: clone;
             box-decoration-break: clone;
         }
-
-        .label {
-            @include grapher_label-1-regular;
-        }
     }
 
     .ExpandableToggle {
-        --border: transparent;
-        --expandable-toggle-button: $gray-80;
-        --expandable-toggle-button-hover: $gray-60;
-        --title-size: 18px;
+        --expandable-toggle-border: transparent;
+        --expandable-toggle-button: #{$gray-80};
+        --expandable-toggle-button-hover: #{$gray-90};
+        --expandable-toggle-title-size: 18px;
         --expandable-toggle-content: currentColor;
 
         .ExpandableToggle__button {
@@ -167,8 +168,6 @@
         }
 
         .ExpandableToggle__description {
-            margin: 0;
-
             p {
                 margin: 0;
                 @include grapher_label-1-regular;
@@ -177,28 +176,31 @@
         }
     }
 
-    .download-modal__citation-guidance-list {
+    .download-modal__citation-guidance {
         font-size: 14px;
-        display: inline;
-        list-style: none;
-        line-height: 1.4;
 
-        li {
+        .download-modal__citation-guidance-list {
             display: inline;
+            list-style: none;
+            line-height: 1.4;
 
-            &::after {
-                display: inline-block;
-                white-space: pre;
-                content: "; ";
-            }
+            li {
+                display: inline;
 
-            &:last-child::after {
-                content: none;
-            }
+                &::after {
+                    display: inline-block;
+                    white-space: pre;
+                    content: "; ";
+                }
 
-            a {
-                @include owid-link-90;
-                color: $gray-80;
+                &:last-child::after {
+                    content: none;
+                }
+
+                a {
+                    @include owid-link-90;
+                    color: $gray-80;
+                }
             }
         }
     }
@@ -238,8 +240,8 @@
         flex-direction: column;
         gap: 16px;
         padding-top: 16px;
+
         h4 {
-            font-weight: 500;
             margin-bottom: 8px;
         }
     }

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
@@ -20,6 +20,7 @@
         overflow-y: auto;
 
         margin-top: var(--modal-padding);
+        padding-bottom: 1px; // makes scrollbar disappear when not needed
 
         // needed for the loading indicator
         position: relative;

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.test.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.test.tsx
@@ -2,7 +2,7 @@
 
 import { ColumnTypeNames } from "@ourworldindata/types"
 import { OwidTable } from "@ourworldindata/core-table"
-import { DownloadModal } from "./DownloadModal"
+import { getNonRedistributableInfo } from "./DownloadModal"
 
 const getTable = (options: { nonRedistributable: boolean }): OwidTable => {
     return new OwidTable(
@@ -30,26 +30,12 @@ const getTable = (options: { nonRedistributable: boolean }): OwidTable => {
     )
 }
 
-it("correctly passes non-redistributable flag", () => {
+it("correctly works with non-redistributable flag", () => {
     const tableFalse = getTable({ nonRedistributable: false })
-    const viewFalse = new DownloadModal({
-        manager: {
-            // eslint-disable-next-line @typescript-eslint/no-empty-function
-            rasterize: () => new Promise(() => {}),
-            displaySlug: "",
-            table: tableFalse,
-        },
-    })
-    expect(viewFalse["nonRedistributable"]).toBeFalsy()
+    const info1 = getNonRedistributableInfo(tableFalse)
+    expect(info1.cols).toBeUndefined()
 
     const tableTrue = getTable({ nonRedistributable: true })
-    const viewTrue = new DownloadModal({
-        manager: {
-            // eslint-disable-next-line @typescript-eslint/no-empty-function
-            rasterize: () => new Promise(() => {}),
-            displaySlug: "",
-            table: tableTrue,
-        },
-    })
-    expect(viewTrue["nonRedistributable"]).toBeTruthy()
+    const info2 = getNonRedistributableInfo(tableTrue)
+    expect(info2.cols).toHaveLength(1)
 })

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
@@ -442,7 +442,7 @@ const getDownloadUrl = (
     return `${ctx.baseUrl}.${extension}` + (searchStr ? `?${searchStr}` : "")
 }
 
-const getNonRedistributableInfo = (
+export const getNonRedistributableInfo = (
     table: OwidTable | undefined
 ): { cols: CoreColumn[] | undefined; sourceLinks: string[] | undefined } => {
     if (!table) return { cols: undefined, sourceLinks: undefined }

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
@@ -77,6 +77,9 @@ export const DownloadModal = (
 
     const [activeTabIndex, setActiveTabIndex] = useState(0)
 
+    const isVisTabActive = activeTabIndex === 0
+    const isDataTabActive = activeTabIndex === 1
+
     return (
         <Modal bounds={modalBounds} onDismiss={onDismiss}>
             <div
@@ -95,16 +98,19 @@ export const DownloadModal = (
                         setActiveIndex={setActiveTabIndex}
                     />
                 </div>
-                <div className="scrollable padded">
-                    <DownloadModalVisTab
-                        {...props}
-                        visible={activeTabIndex === 0}
-                    />
-
-                    <DownloadModalDataTab
-                        {...props}
-                        visible={activeTabIndex === 1}
-                    />
+                <div
+                    className="scrollable padded"
+                    style={{ display: isVisTabActive ? undefined : "none" }}
+                    aria-hidden={!isVisTabActive}
+                >
+                    <DownloadModalVisTab {...props} />
+                </div>
+                <div
+                    className="scrollable padded"
+                    style={{ display: isDataTabActive ? undefined : "none" }}
+                    aria-hidden={!isDataTabActive}
+                >
+                    <DownloadModalDataTab {...props} />
                 </div>
             </div>
         </Modal>
@@ -112,9 +118,7 @@ export const DownloadModal = (
 }
 
 @observer
-export class DownloadModalVisTab extends React.Component<
-    DownloadModalProps & { visible: boolean }
-> {
+export class DownloadModalVisTab extends React.Component<DownloadModalProps> {
     @computed private get staticBounds(): Bounds {
         return this.manager.staticBounds ?? DEFAULT_BOUNDS
     }
@@ -246,10 +250,7 @@ export class DownloadModalVisTab extends React.Component<
     }
 
     render(): React.ReactElement {
-        if (!this.isReady) {
-            if (this.props.visible) return <LoadingIndicator color="#000" />
-            else return <></>
-        }
+        if (!this.isReady) return <LoadingIndicator color="#000" />
 
         const {
             manager,
@@ -289,10 +290,7 @@ export class DownloadModalVisTab extends React.Component<
         }
 
         return (
-            <div
-                className="grouped-menu"
-                style={{ display: this.props.visible ? undefined : "none" }}
-            >
+            <div className="grouped-menu">
                 {manager.isOnChartOrMapTab ? (
                     <div className="grouped-menu-section">
                         <div className="grouped-menu-list">
@@ -494,9 +492,7 @@ metadata = requests.get("${props.metadataUrl}").json()`,
     )
 }
 
-export const DownloadModalDataTab = (
-    props: DownloadModalProps & { visible: boolean }
-) => {
+export const DownloadModalDataTab = (props: DownloadModalProps) => {
     const { yColumnsFromDimensions } = props.manager
 
     const [onlyVisible, setOnlyVisible] = useState(false)
@@ -571,7 +567,7 @@ export const DownloadModalDataTab = (
         }
     }, [downloadCtx, serverSideDownloadAvailable])
 
-    if (nonRedistributableCols?.length && props.visible) {
+    if (nonRedistributableCols?.length) {
         return (
             <div className="grouped-menu-section grouped-menu-section-data">
                 <Callout
@@ -613,7 +609,7 @@ export const DownloadModalDataTab = (
     const exShortName = firstYColDef?.shortName
 
     return (
-        <div style={{ display: props.visible ? undefined : "none" }}>
+        <div>
             <div>
                 <h2>Download options</h2>
                 <section>

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
@@ -495,17 +495,19 @@ metadata = requests.get("${props.metadataUrl}").json()`,
         <ExpandableToggle
             label="Code examples"
             alwaysVisibleDescription={
-                <p>
+                <p className="grapher_label-1-regular">
                     Examples of how to load this data into different data
                     analysis tools.
                 </p>
             }
             content={
                 <>
-                    <div>
+                    <div className="data-modal__code-examples">
                         {Object.entries(code).map(([name, snippet]) => (
                             <div key={name}>
-                                <h2>{name}</h2>
+                                <h4 className="grapher_body-2-semibold">
+                                    {name}
+                                </h4>
                                 <CodeSnippet code={snippet} />
                             </div>
                         ))}
@@ -556,7 +558,7 @@ const SourceAndCitationSection = ({ table }: { table?: OwidTable }) => {
     )
 
     return (
-        <div className="grouped-menu-section grouped-menu-section-data download-modal__data-section">
+        <div className="grouped-menu-section download-modal__data-section">
             <h3 className="grapher_h3-semibold">Source and citation</h3>
             <Callout
                 title="Data citation"
@@ -654,7 +656,7 @@ export const DownloadModalDataTab = (props: DownloadModalProps) => {
 
     if (nonRedistributableCols?.length) {
         return (
-            <div className="grouped-menu-section grouped-menu-section-data">
+            <div className="grouped-menu-section">
                 <Callout
                     title="The data in this chart is not available to download"
                     icon={<FontAwesomeIcon icon={faInfoCircle} />}
@@ -698,7 +700,7 @@ export const DownloadModalDataTab = (props: DownloadModalProps) => {
             <SourceAndCitationSection table={props.manager.table} />
             <div className="grouped-menu-section download-modal__data-section">
                 <h3 className="grapher_h3-semibold">Download options</h3>
-                <section className="grouped-menu-section-data">
+                <section className="download-modal__config-list">
                     <RadioButton
                         label="Download the full dataset used in this chart"
                         group="onlyVisible"
@@ -712,9 +714,8 @@ export const DownloadModalDataTab = (props: DownloadModalProps) => {
                         onChange={() => setOnlyVisible(true)}
                     />
                 </section>
-                <hr />
                 {shortNamesAvailable && (
-                    <section className="grouped-menu-section-data">
+                    <section className="download-modal__config-list">
                         <div>
                             <RadioButton
                                 label="Verbose column names"
@@ -734,7 +735,10 @@ export const DownloadModalDataTab = (props: DownloadModalProps) => {
                                 onChange={() => setShortColNames(true)}
                             />
                             <p>
-                                e.g. <code>{exShortName}</code>
+                                e.g.{" "}
+                                <code style={{ wordBreak: "break-all" }}>
+                                    {exShortName}
+                                </code>
                             </p>
                         </div>
                     </section>

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
@@ -493,10 +493,10 @@ metadata = requests.get("${props.metadataUrl}").json()`,
     }
 
     return (
-        <div className="download-modal__data-section download-modal__section-code">
-            <div>
-                <h3 className="grapher_h3-semibold">Code Examples</h3>
-                <p className="grapher_label-1-regular">
+        <div className="download-modal__data-section">
+            <div className="download-modal__heading-with-caption">
+                <h3 className="grapher_h3-semibold">Code examples</h3>
+                <p className="grapher_label-2-regular">
                     Examples of how to load this data into different data
                     analysis tools.
                 </p>
@@ -633,7 +633,14 @@ const ApiAndCodeExamplesSection = (props: {
     return (
         <>
             <div className="download-modal__data-section">
-                <h3 className="grapher_h3-semibold">Data API</h3>
+                <div className="download-modal__heading-with-caption">
+                    <h3 className="grapher_h3-semibold">Data API</h3>
+                    <p className="grapher_label-2-regular">
+                        Use these URLs for programmatic use of this chart's
+                        data, and configure what you want to get using the
+                        options below. See also the code examples below.
+                    </p>
+                </div>
                 <section className="download-modal__api-urls">
                     <div>
                         <h4 className="grapher_body-2-medium">
@@ -795,17 +802,15 @@ export const DownloadModalDataTab = (props: DownloadModalProps) => {
 
     const downloadHelpText = serverSideDownloadAvailable ? (
         <p className="grapher_label-2-regular">
-            Download the data used to create this chart. The data is provided as
-            a ZIP archive containing the data in CSV format, metadata
-            information in JSON format, and a README file. The CSV file can be
-            easily imported into Excel, Google Sheets, and other data analysis
-            software.
+            Download the data shown in this chart as a ZIP file containing a CSV
+            file, metadata in JSON format, and a README. The CSV file can be
+            easily opened in Excel, Google Sheets, and other analysis tools.
         </p>
     ) : (
         <p className="grapher_label-2-regular">
             Download the data used to create this chart. The data is provided in
-            CSV format, which can be easily imported into Excel, Google Sheets,
-            or other data analysis software.
+            CSV format, which can be easily opened in Excel, Google Sheets, and
+            other data analysis tools.
         </p>
     )
 
@@ -815,7 +820,10 @@ export const DownloadModalDataTab = (props: DownloadModalProps) => {
         <>
             <SourceAndCitationSection table={props.manager.table} />
             <div className="download-modal__data-section">
-                <h3 className="grapher_h3-semibold">Quick download</h3>
+                <div className="download-modal__heading-with-caption">
+                    <h3 className="grapher_h3-semibold">Quick download</h3>
+                    {downloadHelpText}
+                </div>
                 <div>
                     <DownloadButton
                         title="Download full data"
@@ -832,7 +840,6 @@ export const DownloadModalDataTab = (props: DownloadModalProps) => {
                         }
                     />
                 </div>
-                {downloadHelpText}
             </div>
             {serverSideDownloadAvailable && (
                 <ApiAndCodeExamplesSection

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
@@ -412,38 +412,33 @@ export const DownloadModalDataTab = (
     if (nonRedistributableCols?.length && props.visible) {
         return (
             <div className="grouped-menu-section grouped-menu-section-data">
-                <div className="grouped-menu-callout">
-                    <div className="grouped-menu-callout-content">
-                        <h4 className="title grapher_h4-semibold">
-                            <FontAwesomeIcon icon={faInfoCircle} />
-                            The data in this chart is not available to download
-                        </h4>
-                        <p className="grapher_body-3-medium grapher_light">
-                            The data is published under a license that doesn't
-                            allow us to redistribute it.
-                            {sourceLinks?.length && (
-                                <>
-                                    {" "}
-                                    Please visit the data publisher's website(s)
-                                    for more details:
-                                    <ul>
-                                        {sourceLinks.map((link, i) => (
-                                            <li key={i}>
-                                                <a
-                                                    href={link}
-                                                    target="_blank"
-                                                    rel="noopener"
-                                                >
-                                                    {link}
-                                                </a>
-                                            </li>
-                                        ))}
-                                    </ul>
-                                </>
-                            )}
-                        </p>
-                    </div>
-                </div>
+                <Callout
+                    title="The data in this chart is not available to download"
+                    icon={<FontAwesomeIcon icon={faInfoCircle} />}
+                >
+                    The data is published under a license that doesn't allow us
+                    to redistribute it.
+                    {sourceLinks?.length && (
+                        <>
+                            {" "}
+                            Please visit the data publisher's website(s) for
+                            more details:
+                            <ul>
+                                {sourceLinks.map((link, i) => (
+                                    <li key={i}>
+                                        <a
+                                            href={link}
+                                            target="_blank"
+                                            rel="noopener"
+                                        >
+                                            {link}
+                                        </a>
+                                    </li>
+                                ))}
+                            </ul>
+                        </>
+                    )}
+                </Callout>
             </div>
         )
     }
@@ -559,5 +554,29 @@ function DownloadButton(props: DownloadButtonProps): React.ReactElement {
                 </span>
             </div>
         </button>
+    )
+}
+
+interface CalloutProps {
+    title?: React.ReactNode
+    icon?: React.ReactElement
+    children: React.ReactNode
+}
+
+function Callout(props: CalloutProps): React.ReactElement {
+    return (
+        <div className="grouped-menu-callout">
+            <div className="grouped-menu-callout-content">
+                {props.title && (
+                    <h4 className="title grapher_h4-semibold">
+                        {props.icon}
+                        {props.title}
+                    </h4>
+                )}
+                <p className="grapher_body-3-medium grapher_light">
+                    {props.children}
+                </p>
+            </div>
+        </div>
     )
 }

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
@@ -451,7 +451,7 @@ const getDownloadUrl = (
     ctx: DataDownloadContext
 ) => {
     const searchParams = getDownloadSearchParams(ctx)
-    const searchStr = searchParams.toString()
+    const searchStr = searchParams.toString().replaceAll("%7E", "~")
     return `${ctx.baseUrl}.${extension}` + (searchStr ? `?${searchStr}` : "")
 }
 
@@ -598,7 +598,7 @@ export const DownloadModalDataTab = (props: DownloadModalProps) => {
             shortColNames,
 
             slug: props.manager.displaySlug,
-            searchParams: new URLSearchParams(),
+            searchParams: new URLSearchParams(props.manager.queryStr),
             baseUrl:
                 props.manager.baseUrl ??
                 `/grapher/${props.manager.displaySlug}`,
@@ -611,6 +611,7 @@ export const DownloadModalDataTab = (props: DownloadModalProps) => {
             onlyVisible,
             props.manager.baseUrl,
             props.manager.displaySlug,
+            props.manager.queryStr,
             props.manager.table,
             props.manager.transformedTable,
             shortColNames,

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
@@ -15,7 +15,7 @@ import {
 } from "@ourworldindata/components"
 import { LoadingIndicator } from "../loadingIndicator/LoadingIndicator"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
-import { faDownload, faInfoCircle } from "@fortawesome/free-solid-svg-icons"
+import { faDownload } from "@fortawesome/free-solid-svg-icons"
 import { OwidColumnDef, GrapherStaticFormat } from "@ourworldindata/types"
 import {
     BlankOwidTable,
@@ -330,7 +330,6 @@ export class DownloadModalVisTab extends React.Component<
             >
                 {manager.isOnChartOrMapTab && (
                     <div className="grouped-menu-section">
-                        <h3 className="grapher_h3-semibold">Visualization</h3>
                         <div className="grouped-menu-list">
                             <DownloadButton
                                 title="Image (PNG)"
@@ -403,48 +402,6 @@ export class DownloadModalVisTab extends React.Component<
                         )}
                     </div>
                 )}
-                <div className="grouped-menu-section grouped-menu-section-data">
-                    <h3 className="grapher_h3-semibold">Data</h3>
-                    {this.nonRedistributable ? (
-                        <div className="grouped-menu-callout">
-                            <div className="grouped-menu-callout-content">
-                                <h4 className="title grapher_h4-semibold">
-                                    <FontAwesomeIcon icon={faInfoCircle} />
-                                    The data in this chart is not available to
-                                    download
-                                </h4>
-                                <p className="grapher_body-3-medium grapher_light">
-                                    The data is published under a license that
-                                    doesn't allow us to redistribute it.
-                                    {this.nonRedistributableSourceLink && (
-                                        <>
-                                            {" "}
-                                            Please visit the{" "}
-                                            <a
-                                                href={
-                                                    this
-                                                        .nonRedistributableSourceLink
-                                                }
-                                            >
-                                                data publisher's website
-                                            </a>{" "}
-                                            for more details.
-                                        </>
-                                    )}
-                                </p>
-                            </div>
-                        </div>
-                    ) : (
-                        <div className="grouped-menu-list">
-                            <DownloadButton
-                                title="Full data (CSV)"
-                                description="The full dataset used in this chart."
-                                onClick={this.onCsvDownload}
-                                tracking="chart_download_csv"
-                            />
-                        </div>
-                    )}
-                </div>
             </div>
         )
     }
@@ -558,7 +515,7 @@ function DownloadButton(props: DownloadButtonProps): React.ReactElement {
             )}
             <div className="grouped-menu-content">
                 <h4 className="grapher_body-2-semibold">{props.title}</h4>
-                <p className="grapher_label-1-medium grouped-menu-content-description">
+                <p className="grapher_label-2-regular grouped-menu-content-description">
                     {props.description}
                 </p>
             </div>

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
@@ -12,6 +12,7 @@ import {
 import {
     Checkbox,
     CodeSnippet,
+    ExpandableToggle,
     OverlayHeader,
     RadioButton,
 } from "@ourworldindata/components"
@@ -471,24 +472,27 @@ metadata = requests.get("${props.metadataUrl}").json()`,
     }
 
     return (
-        <details>
-            <summary>
-                <h1>Code examples</h1>
+        <ExpandableToggle
+            label="Code examples"
+            alwaysVisibleDescription={
                 <p>
                     Examples of how to load this data into different data
                     analysis tools.
                 </p>
-            </summary>
-
-            <div>
-                {Object.entries(code).map(([name, snippet]) => (
-                    <div key={name}>
-                        <h2>{name}</h2>
-                        <CodeSnippet code={snippet} />
+            }
+            content={
+                <>
+                    <div>
+                        {Object.entries(code).map(([name, snippet]) => (
+                            <div key={name}>
+                                <h2>{name}</h2>
+                                <CodeSnippet code={snippet} />
+                            </div>
+                        ))}
                     </div>
-                ))}
-            </div>
-        </details>
+                </>
+            }
+        />
     )
 }
 
@@ -610,9 +614,9 @@ export const DownloadModalDataTab = (props: DownloadModalProps) => {
 
     return (
         <div>
-            <div>
-                <h2>Download options</h2>
-                <section>
+            <div className="grouped-menu-section">
+                <h3 className="grapher_h3-semibold">Download options</h3>
+                <section className="grouped-menu-section-data">
                     <RadioButton
                         label="Download the full dataset used in this chart"
                         group="onlyVisible"
@@ -627,7 +631,7 @@ export const DownloadModalDataTab = (props: DownloadModalProps) => {
                     />
                 </section>
                 <hr />
-                <section>
+                <section className="grouped-menu-section-data">
                     <div>
                         <RadioButton
                             label="Verbose column names"

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
@@ -106,6 +106,13 @@ export const DownloadModal = (
                         setActiveIndex={setActiveTabIndex}
                     />
                 </div>
+
+                {/* Tabs */}
+                {/**
+                 * We only hide the inactive tab with display: none and don't unmount it,
+                 * so that the tab state (selected radio buttons, scroll position, etc) is preserved
+                 * when switching between tabs.
+                 */}
                 <div
                     className="scrollable padded"
                     style={{ display: isVisTabActive ? undefined : "none" }}
@@ -504,6 +511,7 @@ metadata = requests.get("${props.metadataUrl}").json()`,
 }
 
 const SourceAndCitationSection = ({ table }: { table?: OwidTable }) => {
+    // Sources can come either from origins (new format) or from the source field of the column (old format)
     const origins =
         table?.defs
             .flatMap((def) => def.origins ?? [])
@@ -784,7 +792,7 @@ function DownloadButton(props: DownloadButtonProps): React.ReactElement {
 }
 
 interface CalloutProps {
-    title?: React.ReactNode
+    title: React.ReactNode
     icon?: React.ReactElement
     children: React.ReactNode
 }

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
@@ -51,14 +51,13 @@ export interface DownloadModalManager {
     table?: OwidTable
     transformedTable?: OwidTable
     yColumnsFromDimensionsOrSlugsOrAuto?: CoreColumn[]
-    externalCsvLink?: string // Todo: we can ditch this once rootTable === externalCsv (currently not quite the case for Covid Explorer)
+    externalCsvLink?: string // TODO: do we want to drop this feature?
     shouldIncludeDetailsInStaticExport?: boolean
     detailsOrderedByReference?: string[]
     isDownloadModalOpen?: boolean
     frameBounds?: Bounds
     captionedChartBounds?: Bounds
     isOnChartOrMapTab?: boolean
-    framePaddingVertical?: number
     showAdminControls?: boolean
     isSocialMediaExport?: boolean
     isPublished?: boolean
@@ -202,13 +201,6 @@ export class DownloadModalVisTab extends React.Component<DownloadModalProps> {
             })
     }
 
-    @computed private get csvBlob(): Blob {
-        const csv = this.inputTable.toPrettyCsv()
-        return new Blob([csv], {
-            type: "text/csv;charset=utf-8",
-        })
-    }
-
     @action.bound private markAsReady(): void {
         this.isReady = true
     }
@@ -222,10 +214,6 @@ export class DownloadModalVisTab extends React.Component<DownloadModalProps> {
     }
     @computed private get baseFilename(): string {
         return this.manager.displaySlug
-    }
-
-    @computed private get inputTable(): OwidTable {
-        return this.manager.table ?? BlankOwidTable()
     }
 
     @action.bound private onPngDownload(): void {
@@ -705,6 +693,7 @@ export const DownloadModalDataTab = (props: DownloadModalProps) => {
     const exLongName = firstYColDef?.name
     const exShortName = firstYColDef?.shortName
 
+    // Some charts, like pre-ETL ones or csv-based explorers, don't have short names available for their variables
     const shortNamesAvailable = !!exShortName
 
     return (

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
@@ -578,9 +578,9 @@ const SourceAndCitationSection = ({ table }: { table?: OwidTable }) => {
         <div className="download-modal__data-section download-modal__sources">
             <h3 className="grapher_h3-semibold">Source and citation</h3>
             {sourceLinks.length > 0 && (
-                <div className="download-modal__citation-guidance">
+                <div className="download-modal__data-sources">
                     <strong>Data sources:</strong>{" "}
-                    <ul className="download-modal__citation-guidance-list">
+                    <ul className="download-modal__data-sources-list">
                         {sourceLinks}
                     </ul>
                     {fullProcessingPhrase}

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
@@ -107,6 +107,29 @@ export const DownloadModalDataTab = (props: DownloadModalProps) => {
                     </div>
                 </section>
             </div>
+            <div className="grouped-menu-list">
+                <DownloadButton
+                    title="Data and metadata (ZIP)"
+                    description="Download the data CSV, metadata JSON, and a README file as a ZIP archive."
+                    onClick={() => void 0}
+                    tracking="chart_download_zip"
+                />
+                <DownloadButton
+                    title="Data only (CSV)"
+                    description="Download only the data in CSV format."
+                    onClick={() => void 0}
+                    tracking="chart_download_csv"
+                />
+            </div>
+            <details>
+                <summary>
+                    <h1>Code examples</h1>
+                    <p>
+                        Examples of how to load this data into different data
+                        analysis tools.
+                    </p>
+                </summary>
+            </details>
         </div>
     )
 }
@@ -508,7 +531,7 @@ function DownloadButton(props: DownloadButtonProps): React.ReactElement {
             )}
             <div className="grouped-menu-content">
                 <h4 className="grapher_body-2-semibold">{props.title}</h4>
-                <p className="grapher_label-1-medium grapher_light">
+                <p className="grapher_label-1-medium grouped-menu-content-description">
                     {props.description}
                 </p>
             </div>

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
@@ -489,7 +489,13 @@ df = pd.read_csv("${props.csvUrl}")
 
 # Fetch the metadata
 metadata = requests.get("${props.metadataUrl}").json()`,
-        R: `df <- read.csv("${props.csvUrl}")`,
+        R: `library(jsonlite)
+
+# Fetch the data
+df <- read.csv("${props.csvUrl}")
+
+# Fetch the metadata
+metadata <- fromJSON("${props.metadataUrl}")`,
     }
 
     return (
@@ -602,7 +608,7 @@ const ApiAndCodeExamplesSection = (props: {
     firstYColDef?: OwidColumnDef
 }) => {
     const [onlyVisible, setOnlyVisible] = useState(false)
-    const [shortColNames, setShortColNames] = useState(false)
+    const [shortColNames, setShortColNames] = useState(true)
 
     const exLongName = props.firstYColDef?.name
     const exShortName = props.firstYColDef?.shortName
@@ -636,21 +642,25 @@ const ApiAndCodeExamplesSection = (props: {
                 <div className="download-modal__heading-with-caption">
                     <h3 className="grapher_h3-semibold">Data API</h3>
                     <p className="grapher_label-2-regular">
-                        Use these URLs for programmatic use of this chart's
-                        data, and configure what you want to get using the
-                        options below. See also the code examples below.
+                        Use these URLs to programmatically access this chart's
+                        data and configure your requests with the options below.{" "}
+                        <a href="https://docs.owid.io/projects/etl/api/">
+                            Our documentation provides more information
+                        </a>{" "}
+                        on how to use the API, and you can find a few code
+                        examples below.
                     </p>
                 </div>
                 <section className="download-modal__api-urls">
                     <div>
                         <h4 className="grapher_body-2-medium">
-                            URL to fetch the data from (CSV format)
+                            Data URL (CSV format)
                         </h4>
                         <CodeSnippet code={csvUrl} />
                     </div>
                     <div>
                         <h4 className="grapher_body-2-medium">
-                            URL to fetch the metadata from (JSON format)
+                            Metadata URL (JSON format)
                         </h4>
                         <CodeSnippet code={metadataUrl} />
                     </div>
@@ -804,13 +814,13 @@ export const DownloadModalDataTab = (props: DownloadModalProps) => {
         <p className="grapher_label-2-regular">
             Download the data shown in this chart as a ZIP file containing a CSV
             file, metadata in JSON format, and a README. The CSV file can be
-            easily opened in Excel, Google Sheets, and other analysis tools.
+            opened in Excel, Google Sheets, and other analysis tools.
         </p>
     ) : (
         <p className="grapher_label-2-regular">
             Download the data used to create this chart. The data is provided in
-            CSV format, which can be easily opened in Excel, Google Sheets, and
-            other data analysis tools.
+            CSV format, which can be opened in Excel, Google Sheets, and other
+            data analysis tools.
         </p>
     )
 
@@ -832,7 +842,7 @@ export const DownloadModalDataTab = (props: DownloadModalProps) => {
                         onClick={() => onDownloadClick(CsvDownloadType.Full)}
                     />
                     <DownloadButton
-                        title="Download only visible data"
+                        title="Download displayed data"
                         description="Includes only the entities and time points currently visible in the chart."
                         icon={<DownloadIconSelected />}
                         onClick={() =>

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
@@ -104,8 +104,20 @@ export const DownloadModal = (
                     <Tabs
                         variant="slim"
                         labels={[
-                            { element: <>Visualization</> },
-                            { element: <>Data</> },
+                            {
+                                element: <>Visualization</>,
+                                buttonProps: {
+                                    "data-track-note":
+                                        "chart_download_modal_tab_visualization",
+                                } as any,
+                            },
+                            {
+                                element: <>Data</>,
+                                buttonProps: {
+                                    "data-track-note":
+                                        "chart_download_modal_tab_data",
+                                } as any,
+                            },
                         ]}
                         activeIndex={activeTabIndex}
                         setActiveIndex={setActiveTabIndex}
@@ -650,7 +662,10 @@ const ApiAndCodeExamplesSection = (props: {
                     <p className="grapher_label-2-regular">
                         Use these URLs to programmatically access this chart's
                         data and configure your requests with the options below.{" "}
-                        <a href="https://docs.owid.io/projects/etl/api/">
+                        <a
+                            href="https://docs.owid.io/projects/etl/api/"
+                            data-track-note="chart_download_modal_api_docs"
+                        >
                             Our documentation provides more information
                         </a>{" "}
                         on how to use the API, and you can find a few code
@@ -847,6 +862,12 @@ export const DownloadModalDataTab = (props: DownloadModalProps) => {
                         description="Includes all entities and time points."
                         icon={<DownloadIconFullDataset />}
                         onClick={() => onDownloadClick(CsvDownloadType.Full)}
+                        tracking={
+                            "chart_download_full_data--" +
+                            serverSideDownloadAvailable
+                                ? "server"
+                                : "client"
+                        }
                     />
                     <DownloadButton
                         title="Download displayed data"
@@ -854,6 +875,12 @@ export const DownloadModalDataTab = (props: DownloadModalProps) => {
                         icon={<DownloadIconSelected />}
                         onClick={() =>
                             onDownloadClick(CsvDownloadType.CurrentSelection)
+                        }
+                        tracking={
+                            "chart_download_filtered_data--" +
+                            serverSideDownloadAvailable
+                                ? "server"
+                                : "client"
                         }
                     />
                 </div>

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
@@ -494,29 +494,23 @@ metadata = requests.get("${props.metadataUrl}").json()`,
     }
 
     return (
-        <ExpandableToggle
-            label="Code examples"
-            alwaysVisibleDescription={
+        <div className="download-modal__data-section download-modal__section-code">
+            <div>
+                <h3 className="grapher_h3-semibold">Code Examples</h3>
                 <p className="grapher_label-1-regular">
                     Examples of how to load this data into different data
                     analysis tools.
                 </p>
-            }
-            content={
-                <>
-                    <div className="data-modal__code-examples">
-                        {Object.entries(code).map(([name, snippet]) => (
-                            <div key={name}>
-                                <h4 className="grapher_body-2-medium">
-                                    {name}
-                                </h4>
-                                <CodeSnippet code={snippet} />
-                            </div>
-                        ))}
+            </div>
+            <div className="download-modal__code-blocks">
+                {Object.entries(code).map(([name, snippet]) => (
+                    <div key={name}>
+                        <h4 className="grapher_body-2-medium">{name}</h4>
+                        <CodeSnippet code={snippet} />
                     </div>
-                </>
-            }
-        />
+                ))}
+            </div>
+        </div>
     )
 }
 
@@ -700,9 +694,7 @@ const ApiAndCodeExamplesSection = (props: {
                 </section>
             </div>
 
-            <div className="download-modal__data-section">
-                <CodeExamplesBlock csvUrl={csvUrl} metadataUrl={metadataUrl} />
-            </div>
+            <CodeExamplesBlock csvUrl={csvUrl} metadataUrl={metadataUrl} />
         </>
     )
 }

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
@@ -505,7 +505,7 @@ metadata = requests.get("${props.metadataUrl}").json()`,
                     <div className="data-modal__code-examples">
                         {Object.entries(code).map(([name, snippet]) => (
                             <div key={name}>
-                                <h4 className="grapher_body-2-semibold">
+                                <h4 className="grapher_body-2-medium">
                                     {name}
                                 </h4>
                                 <CodeSnippet code={snippet} />

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
@@ -779,25 +779,23 @@ interface DownloadButtonProps {
 function DownloadButton(props: DownloadButtonProps): React.ReactElement {
     return (
         <button
-            className="grouped-menu-item"
+            className="download-modal__download-button"
             onClick={props.onClick}
             data-track-note={props.tracking}
         >
             {props.previewImageUrl && (
-                <div className="grouped-menu-icon">
+                <div className="download-modal__download-preview-img">
                     <img src={props.previewImageUrl} style={props.imageStyle} />
                 </div>
             )}
-            <div className="grouped-menu-content">
+            <div className="download-modal__download-button-content">
                 <h4 className="grapher_body-2-semibold">{props.title}</h4>
-                <p className="grapher_label-2-regular grouped-menu-content-description">
+                <p className="grapher_label-1-regular download-modal__download-button-description">
                     {props.description}
                 </p>
             </div>
-            <div className="grouped-menu-icon">
-                <span className="download-icon">
-                    <FontAwesomeIcon icon={faDownload} />
-                </span>
+            <div className="download-modal__download-icon">
+                <FontAwesomeIcon icon={faDownload} />
             </div>
         </button>
     )
@@ -811,18 +809,16 @@ interface CalloutProps {
 
 function Callout(props: CalloutProps): React.ReactElement {
     return (
-        <div className="grouped-menu-callout">
-            <div className="grouped-menu-callout-content">
-                {props.title && (
-                    <h4 className="title grapher_body-2-semibold">
-                        {props.icon}
-                        {props.title}
-                    </h4>
-                )}
-                <p className="grapher_label-2-regular grapher_light">
-                    {props.children}
-                </p>
-            </div>
+        <div className="download-modal__callout">
+            {props.title && (
+                <h4 className="title grapher_body-2-semibold">
+                    {props.icon}
+                    {props.title}
+                </h4>
+            )}
+            <p className="grapher_label-2-regular grapher_light">
+                {props.children}
+            </p>
         </div>
     )
 }

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
@@ -446,6 +446,7 @@ const createCsvBlobLocally = async (ctx: DataDownloadContextClientSide) => {
 
 const getDownloadSearchParams = (ctx: DataDownloadContextServerSide) => {
     const searchParams = new URLSearchParams()
+    searchParams.set("v", "1") // API versioning
     searchParams.set(
         "csvType",
         match(ctx.csvDownloadType)

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
@@ -61,6 +61,7 @@ export interface DownloadModalManager {
     framePaddingVertical?: number
     showAdminControls?: boolean
     isSocialMediaExport?: boolean
+    isPublished?: boolean
 }
 
 interface DownloadModalProps {
@@ -590,7 +591,12 @@ export const DownloadModalDataTab = (props: DownloadModalProps) => {
     const { cols: nonRedistributableCols, sourceLinks } =
         getNonRedistributableInfo(props.manager.table)
 
-    const serverSideDownloadAvailable = true // TODO
+    // Server-side download is not necessarily available for:
+    // - Explorers
+    // - Mdims
+    // - Charts authored/changed in the admin (incl. unpublished charts)
+    const serverSideDownloadAvailable =
+        !!props.manager.isPublished && window.admin === undefined
 
     const downloadCtx: DataDownloadContext = useMemo(
         (): DataDownloadContext => ({
@@ -750,12 +756,14 @@ export const DownloadModalDataTab = (props: DownloadModalProps) => {
                     </section>
                 )}
                 <div>
-                    <DownloadButton
-                        title="Data and metadata (ZIP)"
-                        description="Download the data CSV, metadata JSON, and a README file as a ZIP archive."
-                        onClick={onZipDownload}
-                        tracking="chart_download_zip"
-                    />
+                    {serverSideDownloadAvailable && (
+                        <DownloadButton
+                            title="Data and metadata (ZIP)"
+                            description="Download the data CSV, metadata JSON, and a README file as a ZIP archive."
+                            onClick={onZipDownload}
+                            tracking="chart_download_zip"
+                        />
+                    )}
                     <DownloadButton
                         title="Data only (CSV)"
                         description="Download only the data in CSV format."

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
@@ -16,7 +16,11 @@ import {
 } from "@ourworldindata/components"
 import { LoadingIndicator } from "../loadingIndicator/LoadingIndicator"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
-import { faDownload, faInfoCircle } from "@fortawesome/free-solid-svg-icons"
+import {
+    faCircleExclamation,
+    faDownload,
+    faInfoCircle,
+} from "@fortawesome/free-solid-svg-icons"
 import { OwidColumnDef, GrapherStaticFormat } from "@ourworldindata/types"
 import {
     BlankOwidTable,
@@ -297,7 +301,7 @@ export class DownloadModalVisTab extends React.Component<
                 className="grouped-menu"
                 style={{ display: this.props.visible ? undefined : "none" }}
             >
-                {manager.isOnChartOrMapTab && (
+                {manager.isOnChartOrMapTab ? (
                     <div className="grouped-menu-section">
                         <div className="grouped-menu-list">
                             <DownloadButton
@@ -370,6 +374,17 @@ export class DownloadModalVisTab extends React.Component<
                             </div>
                         )}
                     </div>
+                ) : (
+                    <Callout
+                        title="Chart can't currently be exported to image"
+                        icon={<FontAwesomeIcon icon={faCircleExclamation} />}
+                    >
+                        Try switching to the "Chart" or "Map" tab to download a
+                        static image of this chart.
+                        <br />
+                        You can also download the data used in this chart by
+                        navigating to the "Data" tab.
+                    </Callout>
                 )}
             </div>
         )

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
@@ -16,7 +16,6 @@ import {
 import {
     Checkbox,
     CodeSnippet,
-    ExpandableToggle,
     OverlayHeader,
     RadioButton,
 } from "@ourworldindata/components"
@@ -635,9 +634,23 @@ const ApiAndCodeExamplesSection = (props: {
         <>
             <div className="download-modal__data-section">
                 <h3 className="grapher_h3-semibold">Data API</h3>
+                <section className="download-modal__api-urls">
+                    <div>
+                        <h4 className="grapher_body-2-medium">
+                            URL to fetch the data from (CSV format)
+                        </h4>
+                        <CodeSnippet code={csvUrl} />
+                    </div>
+                    <div>
+                        <h4 className="grapher_body-2-medium">
+                            URL to fetch the metadata from (JSON format)
+                        </h4>
+                        <CodeSnippet code={metadataUrl} />
+                    </div>
+                </section>
                 <section className="download-modal__config-list">
                     <RadioButton
-                        label="Download the full dataset used in this chart"
+                        label="Download full data, including all entities and time points"
                         group="onlyVisible"
                         checked={!onlyVisible}
                         onChange={() => setOnlyVisible(false)}
@@ -678,20 +691,6 @@ const ApiAndCodeExamplesSection = (props: {
                         </div>
                     </section>
                 )}
-                <section className="download-modal__api-urls">
-                    <div>
-                        <h4 className="grapher_body-2-medium">
-                            URL to fetch the data from (CSV format)
-                        </h4>
-                        <CodeSnippet code={csvUrl} />
-                    </div>
-                    <div>
-                        <h4 className="grapher_body-2-medium">
-                            URL to fetch the metadata from (JSON format)
-                        </h4>
-                        <CodeSnippet code={metadataUrl} />
-                    </div>
-                </section>
             </div>
 
             <CodeExamplesBlock csvUrl={csvUrl} metadataUrl={metadataUrl} />
@@ -819,7 +818,7 @@ export const DownloadModalDataTab = (props: DownloadModalProps) => {
                 <h3 className="grapher_h3-semibold">Quick download</h3>
                 <div>
                     <DownloadButton
-                        title="Download full dataset"
+                        title="Download full data"
                         description="Includes all entities and time points."
                         icon={<DownloadIconFullDataset />}
                         onClick={() => onDownloadClick(CsvDownloadType.Full)}

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
@@ -666,8 +666,11 @@ export const DownloadModalDataTab = (props: DownloadModalProps) => {
                     {sourceLinks?.length && (
                         <>
                             {" "}
-                            Please visit the data publisher's website(s) for
-                            more details:
+                            Please visit the
+                            {sourceLinks.length > 1
+                                ? " data publishers' websites "
+                                : " data publisher's website "}
+                            for more details:
                             <ul>
                                 {sourceLinks.map((link, i) => (
                                     <li key={i}>

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useState } from "react"
 import { observable, computed, action } from "mobx"
 import { observer } from "mobx-react"
 import {
@@ -8,7 +8,11 @@ import {
     triggerDownloadFromBlob,
     triggerDownloadFromUrl,
 } from "@ourworldindata/utils"
-import { Checkbox, OverlayHeader } from "@ourworldindata/components"
+import {
+    Checkbox,
+    OverlayHeader,
+    RadioButton,
+} from "@ourworldindata/components"
 import { LoadingIndicator } from "../loadingIndicator/LoadingIndicator"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
 import { faDownload, faInfoCircle } from "@fortawesome/free-solid-svg-icons"
@@ -30,6 +34,7 @@ export interface DownloadModalManager {
     baseUrl?: string
     queryStr?: string
     table?: OwidTable
+    yColumnsFromDimensions?: CoreColumn[]
     externalCsvLink?: string // Todo: we can ditch this once rootTable === externalCsv (currently not quite the case for Covid Explorer)
     shouldIncludeDetailsInStaticExport?: boolean
     detailsOrderedByReference?: string[]
@@ -44,6 +49,66 @@ export interface DownloadModalManager {
 
 interface DownloadModalProps {
     manager: DownloadModalManager
+}
+
+export const DownloadModalDataTab = (props: DownloadModalProps) => {
+    const { yColumnsFromDimensions } = props.manager
+    const [onlyVisible, setOnlyVisible] = useState(false)
+    const [shortColNames, setShortColNames] = useState(false)
+
+    const firstYColDef = yColumnsFromDimensions?.[0].def as
+        | OwidColumnDef
+        | undefined
+
+    const exLongName = firstYColDef?.name
+    const exShortName = firstYColDef?.shortName
+
+    return (
+        <div>
+            <div>
+                <h2>Download options</h2>
+                <section>
+                    <RadioButton
+                        label="Download the full dataset used in this chart"
+                        group="onlyVisible"
+                        checked={!onlyVisible}
+                        onChange={() => setOnlyVisible(false)}
+                    />
+                    <RadioButton
+                        label="Download only the currently selected data visible in the chart"
+                        group="onlyVisible"
+                        checked={onlyVisible}
+                        onChange={() => setOnlyVisible(true)}
+                    />
+                </section>
+                <hr />
+                <section>
+                    <div>
+                        <RadioButton
+                            label="Verbose column names"
+                            group="shortColNames"
+                            checked={!shortColNames}
+                            onChange={() => setShortColNames(false)}
+                        />
+                        <p>
+                            e.g. <code>{exLongName}</code>
+                        </p>
+                    </div>
+                    <div>
+                        <RadioButton
+                            label="Short column names"
+                            group="shortColNames"
+                            checked={shortColNames}
+                            onChange={() => setShortColNames(true)}
+                        />
+                        <p>
+                            e.g. <code>{exShortName}</code>
+                        </p>
+                    </div>
+                </section>
+            </div>
+        </div>
+    )
 }
 
 @observer
@@ -266,6 +331,7 @@ export class DownloadModal extends React.Component<DownloadModalProps> {
 
         return (
             <div className="grouped-menu">
+                <DownloadModalDataTab manager={manager} />
                 {manager.isOnChartOrMapTab && (
                     <div className="grouped-menu-section">
                         <h3 className="grapher_h3-semibold">Visualization</h3>

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
@@ -738,7 +738,7 @@ export const DownloadModalDataTab = (props: DownloadModalProps) => {
                     <section className="download-modal__config-list">
                         <div>
                             <RadioButton
-                                label="Verbose column names"
+                                label="Long column names"
                                 group="shortColNames"
                                 checked={!shortColNames}
                                 onChange={() => setShortColNames(false)}
@@ -749,7 +749,7 @@ export const DownloadModalDataTab = (props: DownloadModalProps) => {
                         </div>
                         <div>
                             <RadioButton
-                                label="Short column names"
+                                label="Shortened column names"
                                 group="shortColNames"
                                 checked={shortColNames}
                                 onChange={() => setShortColNames(true)}

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
@@ -562,9 +562,12 @@ const SourceAndCitationSection = ({ table }: { table?: OwidTable }) => {
     const processingLevelPhrase = !sourceIsOwid
         ? getPhraseForProcessingLevel(owidProcessingLevel)
         : undefined
-    const fullProcessingPhrase = processingLevelPhrase
-        ? ` – ${processingLevelPhrase} by Our World In Data`
-        : ""
+    const fullProcessingPhrase = processingLevelPhrase ? (
+        <>
+            {" "}
+            – <i>{processingLevelPhrase} by Our World In Data</i>
+        </>
+    ) : undefined
 
     return (
         <div className="download-modal__data-section download-modal__sources">

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
@@ -5,6 +5,7 @@ import {
     Bounds,
     DEFAULT_BOUNDS,
     getOriginAttributionFragments,
+    getPhraseForProcessingLevel,
     isEmpty,
     triggerDownloadFromBlob,
     triggerDownloadFromUrl,
@@ -546,26 +547,44 @@ const SourceAndCitationSection = ({ table }: { table?: OwidTable }) => {
         }
     )
 
-    return (
-        <div className="download-modal__data-section">
-            <h3 className="grapher_h3-semibold">Source and citation</h3>
-            <Callout
-                title="Data citation"
-                icon={<FontAwesomeIcon icon={faInfoCircle} />}
-            >
-                Whenever you use this data, it is your responsibility to ensure
-                to credit the original source and to verify that your use is
-                permitted as per the source's license.
-            </Callout>
+    // Find the highest processing level of all columns
+    const owidProcessingLevel = table?.columnsAsArray
+        .map((col) => (col.def as OwidColumnDef).owidProcessingLevel)
+        .reduce((prev, curr) => {
+            if (prev === "major" || curr === "major") return "major" as const
+            if (prev === "minor" || curr === "minor") return "minor" as const
+            return undefined
+        }, undefined)
 
+    const sourceIsOwid =
+        attributions.length === 1 &&
+        attributions[0].toLowerCase() === "our world in data"
+    const processingLevelPhrase = !sourceIsOwid
+        ? getPhraseForProcessingLevel(owidProcessingLevel)
+        : undefined
+    const fullProcessingPhrase = processingLevelPhrase
+        ? ` – ${processingLevelPhrase} by Our World In Data`
+        : ""
+
+    return (
+        <div className="download-modal__data-section download-modal__sources">
+            <h3 className="grapher_h3-semibold">Source and citation</h3>
             {sourceLinks.length > 0 && (
                 <div className="download-modal__citation-guidance">
-                    <strong>Data sources and citation guidance:</strong>{" "}
+                    <strong>Data sources:</strong>{" "}
                     <ul className="download-modal__citation-guidance-list">
                         {sourceLinks}
                     </ul>
+                    {fullProcessingPhrase}
                 </div>
             )}
+            <div>
+                <strong>Citation guidance:</strong> Please credit all sources
+                listed above. Data provided by third-party sources through Our
+                World in Data remains subject to the original{" "}
+                {sourceLinks.length === 1 ? "provider's" : "providers'"} license
+                terms.
+            </div>
         </div>
     )
 }

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
@@ -115,7 +115,7 @@ export const DownloadModal = (
                  */}
                 <div className="download-modal__tab-panel" role="tabpanel">
                     <div
-                        className="download-modal__tab"
+                        className="download-modal__tab-content"
                         style={{ display: isVisTabActive ? undefined : "none" }}
                         role="tab"
                         aria-hidden={!isVisTabActive}
@@ -123,7 +123,7 @@ export const DownloadModal = (
                         <DownloadModalVisTab {...props} />
                     </div>
                     <div
-                        className="download-modal__tab"
+                        className="download-modal__tab-content"
                         style={{
                             display: isDataTabActive ? undefined : "none",
                         }}
@@ -570,10 +570,12 @@ const SourceAndCitationSection = ({ table }: { table?: OwidTable }) => {
             </Callout>
 
             {sourceLinks.length > 0 && (
-                <ul className="download-modal__citation-guidance-list">
+                <div className="download-modal__citation-guidance">
                     <strong>Data sources and citation guidance:</strong>{" "}
-                    {sourceLinks}
-                </ul>
+                    <ul className="download-modal__citation-guidance-list">
+                        {sourceLinks}
+                    </ul>
+                </div>
             )}
         </div>
     )

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
@@ -95,7 +95,7 @@ export const DownloadModal = (
                 style={{ maxHeight: modalBounds.height }}
             >
                 <OverlayHeader title="Download" onDismiss={onDismiss} />
-                <div className="padded">
+                <div className="download-modal__tab-list">
                     <Tabs
                         variant="slim"
                         labels={[
@@ -110,22 +110,28 @@ export const DownloadModal = (
                 {/* Tabs */}
                 {/**
                  * We only hide the inactive tab with display: none and don't unmount it,
-                 * so that the tab state (selected radio buttons, scroll position, etc) is preserved
+                 * so that the tab state (selected radio buttons, etc) is preserved
                  * when switching between tabs.
                  */}
-                <div
-                    className="scrollable padded"
-                    style={{ display: isVisTabActive ? undefined : "none" }}
-                    aria-hidden={!isVisTabActive}
-                >
-                    <DownloadModalVisTab {...props} />
-                </div>
-                <div
-                    className="scrollable padded"
-                    style={{ display: isDataTabActive ? undefined : "none" }}
-                    aria-hidden={!isDataTabActive}
-                >
-                    <DownloadModalDataTab {...props} />
+                <div className="download-modal__tab-panel" role="tabpanel">
+                    <div
+                        className="download-modal__tab"
+                        style={{ display: isVisTabActive ? undefined : "none" }}
+                        role="tab"
+                        aria-hidden={!isVisTabActive}
+                    >
+                        <DownloadModalVisTab {...props} />
+                    </div>
+                    <div
+                        className="download-modal__tab"
+                        style={{
+                            display: isDataTabActive ? undefined : "none",
+                        }}
+                        role="tab"
+                        aria-hidden={!isDataTabActive}
+                    >
+                        <DownloadModalDataTab {...props} />
+                    </div>
                 </div>
             </div>
         </Modal>
@@ -550,7 +556,7 @@ const SourceAndCitationSection = ({ table }: { table?: OwidTable }) => {
     )
 
     return (
-        <div className="grouped-menu-section grouped-menu-section-data">
+        <div className="grouped-menu-section grouped-menu-section-data download-modal__data-section">
             <h3 className="grapher_h3-semibold">Source and citation</h3>
             <Callout
                 title="Data citation"
@@ -688,9 +694,9 @@ export const DownloadModalDataTab = (props: DownloadModalProps) => {
     const shortNamesAvailable = !!exShortName
 
     return (
-        <div>
+        <>
             <SourceAndCitationSection table={props.manager.table} />
-            <div className="grouped-menu-section">
+            <div className="grouped-menu-section download-modal__data-section">
                 <h3 className="grapher_h3-semibold">Download options</h3>
                 <section className="grouped-menu-section-data">
                     <RadioButton
@@ -733,25 +739,31 @@ export const DownloadModalDataTab = (props: DownloadModalProps) => {
                         </div>
                     </section>
                 )}
+                <div className="grouped-menu-list">
+                    <DownloadButton
+                        title="Data and metadata (ZIP)"
+                        description="Download the data CSV, metadata JSON, and a README file as a ZIP archive."
+                        onClick={onZipDownload}
+                        tracking="chart_download_zip"
+                    />
+                    <DownloadButton
+                        title="Data only (CSV)"
+                        description="Download only the data in CSV format."
+                        onClick={onCsvDownload}
+                        tracking="chart_download_csv"
+                    />
+                </div>
             </div>
-            <div className="grouped-menu-list">
-                <DownloadButton
-                    title="Data and metadata (ZIP)"
-                    description="Download the data CSV, metadata JSON, and a README file as a ZIP archive."
-                    onClick={onZipDownload}
-                    tracking="chart_download_zip"
-                />
-                <DownloadButton
-                    title="Data only (CSV)"
-                    description="Download only the data in CSV format."
-                    onClick={onCsvDownload}
-                    tracking="chart_download_csv"
-                />
-            </div>
+
             {serverSideDownloadAvailable && (
-                <CodeExamplesBlock csvUrl={csvUrl} metadataUrl={metadataUrl} />
+                <div className="download-modal__data-section">
+                    <CodeExamplesBlock
+                        csvUrl={csvUrl}
+                        metadataUrl={metadataUrl}
+                    />
+                </div>
             )}
-        </div>
+        </>
     )
 }
 
@@ -802,12 +814,12 @@ function Callout(props: CalloutProps): React.ReactElement {
         <div className="grouped-menu-callout">
             <div className="grouped-menu-callout-content">
                 {props.title && (
-                    <h4 className="title grapher_h4-semibold">
+                    <h4 className="title grapher_body-2-semibold">
                         {props.icon}
                         {props.title}
                     </h4>
                 )}
-                <p className="grapher_body-3-medium grapher_light">
+                <p className="grapher_label-2-regular grapher_light">
                     {props.children}
                 </p>
             </div>

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
@@ -43,6 +43,7 @@ import {
     DownloadIconFullDataset,
     DownloadIconSelected,
 } from "./DownloadIcons.js"
+import { match } from "ts-pattern"
 
 export interface DownloadModalManager {
     displaySlug: string
@@ -433,11 +434,16 @@ const createCsvBlobLocally = async (ctx: DataDownloadContextClientSide) => {
 
 const getDownloadSearchParams = (ctx: DataDownloadContextServerSide) => {
     const searchParams = new URLSearchParams()
-    if (ctx.shortColNames) searchParams.set("useColumnShortNames", "true")
+    searchParams.set(
+        "csvType",
+        match(ctx.csvDownloadType)
+            .with(CsvDownloadType.CurrentSelection, () => "filtered")
+            .with(CsvDownloadType.Full, () => "full")
+            .exhaustive()
+    )
+    searchParams.set("useColumnShortNames", ctx.shortColNames.toString())
 
     if (ctx.csvDownloadType === CsvDownloadType.CurrentSelection) {
-        searchParams.set("csvType", "filtered")
-
         // Append all the current selection filters to the download URL, e.g.: ?time=2020&selection=~USA
         for (const [key, value] of ctx.searchParams.entries()) {
             searchParams.set(key, value)
@@ -814,7 +820,7 @@ export const DownloadModalDataTab = (props: DownloadModalProps) => {
         <p className="grapher_label-2-regular">
             Download the data shown in this chart as a ZIP file containing a CSV
             file, metadata in JSON format, and a README. The CSV file can be
-            opened in Excel, Google Sheets, and other analysis tools.
+            opened in Excel, Google Sheets, and other data analysis tools.
         </p>
     ) : (
         <p className="grapher_label-2-regular">

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
@@ -311,10 +311,10 @@ export class DownloadModalVisTab extends React.Component<DownloadModalProps> {
         }
 
         return (
-            <div className="grouped-menu">
+            <div>
                 {manager.isOnChartOrMapTab ? (
-                    <div className="grouped-menu-section">
-                        <div className="grouped-menu-list">
+                    <div className="download-modal__vis-section">
+                        <div>
                             <DownloadButton
                                 title="Image (PNG)"
                                 description="Suitable for most uses, widely compatible."
@@ -333,7 +333,7 @@ export class DownloadModalVisTab extends React.Component<DownloadModalProps> {
                             />
                         </div>
                         {this.showExportControls && (
-                            <div className="static-exports-options">
+                            <>
                                 {this.hasDetails && (
                                     <Checkbox
                                         checked={this.shouldIncludeDetails}
@@ -382,7 +382,7 @@ export class DownloadModalVisTab extends React.Component<DownloadModalProps> {
                                         })}
                                     />
                                 )}
-                            </div>
+                            </>
                         )}
                     </div>
                 ) : (
@@ -558,7 +558,7 @@ const SourceAndCitationSection = ({ table }: { table?: OwidTable }) => {
     )
 
     return (
-        <div className="grouped-menu-section download-modal__data-section">
+        <div className="download-modal__data-section">
             <h3 className="grapher_h3-semibold">Source and citation</h3>
             <Callout
                 title="Data citation"
@@ -656,7 +656,7 @@ export const DownloadModalDataTab = (props: DownloadModalProps) => {
 
     if (nonRedistributableCols?.length) {
         return (
-            <div className="grouped-menu-section">
+            <div>
                 <Callout
                     title="The data in this chart is not available to download"
                     icon={<FontAwesomeIcon icon={faInfoCircle} />}
@@ -698,7 +698,7 @@ export const DownloadModalDataTab = (props: DownloadModalProps) => {
     return (
         <>
             <SourceAndCitationSection table={props.manager.table} />
-            <div className="grouped-menu-section download-modal__data-section">
+            <div className="download-modal__data-section">
                 <h3 className="grapher_h3-semibold">Download options</h3>
                 <section className="download-modal__config-list">
                     <RadioButton
@@ -743,7 +743,7 @@ export const DownloadModalDataTab = (props: DownloadModalProps) => {
                         </div>
                     </section>
                 )}
-                <div className="grouped-menu-list">
+                <div>
                     <DownloadButton
                         title="Data and metadata (ZIP)"
                         description="Download the data CSV, metadata JSON, and a README file as a ZIP archive."

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
@@ -657,20 +657,7 @@ const ApiAndCodeExamplesSection = (props: {
                         examples below.
                     </p>
                 </div>
-                <section className="download-modal__api-urls">
-                    <div>
-                        <h4 className="grapher_body-2-medium">
-                            Data URL (CSV format)
-                        </h4>
-                        <CodeSnippet code={csvUrl} />
-                    </div>
-                    <div>
-                        <h4 className="grapher_body-2-medium">
-                            Metadata URL (JSON format)
-                        </h4>
-                        <CodeSnippet code={metadataUrl} />
-                    </div>
-                </section>
+
                 <section className="download-modal__config-list">
                     <RadioButton
                         label="Download full data, including all entities and time points"
@@ -714,6 +701,20 @@ const ApiAndCodeExamplesSection = (props: {
                         </div>
                     </section>
                 )}
+                <section className="download-modal__api-urls">
+                    <div>
+                        <h4 className="grapher_body-2-medium">
+                            Data URL (CSV format)
+                        </h4>
+                        <CodeSnippet code={csvUrl} />
+                    </div>
+                    <div>
+                        <h4 className="grapher_body-2-medium">
+                            Metadata URL (JSON format)
+                        </h4>
+                        <CodeSnippet code={metadataUrl} />
+                    </div>
+                </section>
             </div>
 
             <CodeExamplesBlock csvUrl={csvUrl} metadataUrl={metadataUrl} />

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
@@ -94,7 +94,7 @@ export const DownloadModal = (
     const isDataTabActive = activeTabIndex === 1
 
     return (
-        <Modal bounds={modalBounds} onDismiss={onDismiss}>
+        <Modal bounds={modalBounds} onDismiss={onDismiss} alignVertical="top">
             <div
                 className="download-modal-content"
                 style={{ maxHeight: modalBounds.height }}

--- a/packages/@ourworldindata/grapher/src/modal/Modal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/Modal.tsx
@@ -9,7 +9,7 @@ export class Modal extends React.Component<{
     onDismiss: () => void
     children?: React.ReactNode
     isHeightFixed?: boolean // by default, the modal height is not fixed but fits to the content
-    alignVertical?: "center" | "bottom"
+    alignVertical?: "top" | "center" | "bottom"
 }> {
     contentRef: React.RefObject<HTMLDivElement> = React.createRef()
 
@@ -21,7 +21,7 @@ export class Modal extends React.Component<{
         return this.props.isHeightFixed ?? false
     }
 
-    @computed private get alignVertical(): "center" | "bottom" {
+    @computed private get alignVertical(): "top" | "center" | "bottom" {
         return this.props.alignVertical ?? "center"
     }
 
@@ -69,6 +69,8 @@ export class Modal extends React.Component<{
 
         if (this.alignVertical === "bottom") {
             contentStyle.bottom = bounds.y
+        } else if (this.alignVertical === "top") {
+            contentStyle.top = bounds.y
         } else {
             contentStyle.top = "50%"
             contentStyle.transform = "translateY(-50%)"

--- a/packages/@ourworldindata/grapher/src/tabs/Tabs.scss
+++ b/packages/@ourworldindata/grapher/src/tabs/Tabs.scss
@@ -41,7 +41,7 @@
     // Variant: slim
     &.Tabs--variant-slim {
         // keep in sync with variables in ContentSwitchers.tsx
-        $font-size: 13px;
+        $font-size: var(--tabs-font-size, 13px);
         --outer-padding: 16px;
 
         $light-stroke: $gray-20;


### PR DESCRIPTION
Implements #4015.

## Open questions for review:
- [x] (Design) Given that the code examples block is usually below-the-fold anyways, does it being expandable/collapsible even make sense?
- [x] (Design) Should we show [csv](https://fontawesome.com/icons/file-csv?s=solid)/[zip](https://fontawesome.com/icons/file-zipper?s=solid) icons next to the download button as a visual aid?
- [x] (Design) Should there be an easy way to see/copy the csv and metadata link?
- [ ] Should we restore explorer `downloadDataLink` functionality? ([see Slack](https://owid.slack.com/archives/CQQUA2C2U/p1729854635599149))
	- [ ] If not, get rid of `downloadDataLink` / `externalCsvLink` code
- [x] Have P&D proof-read all the copy contained in the modal

## TODOs

- [x] Make Modal less jumpy when switching tabs / loading
- [x] Redesigned Source citation section, including different copy
- [x] Place copy-able csv/metadata links atop the code examples section
- [x] (Potentially) remove collapse/expand from code examples
- [x] (Potentially) show icon next to button
- [x] Move download options into code examples section
- [x] Make DL buttons download ZIP file for full/current data
- [x] Este's suggestion: "Full/Long" and "short/abbreviated" column names, rather than "verbose"
- [x] Include link to Data API documentation
- [x] Incorporate Slack design feedback
- [x] Incorporate API versioning?
- [x] Check font weights - especially download button descriptions look way heavier than in the design
- [x] Check analytics instrumentation: Make sure we track every interesting click

---

There's quite a large state space, which I want to illustrate here to some degree:

<table>
<tr><th>Description <th>Screenshot <th>Example URL
<tr><td>"Normal" vis tab <td>

![CleanShot 2024-10-25 at 13 50 57](https://github.com/user-attachments/assets/2bf38351-4372-4c4a-bb73-eb00548b605f)

<td>

http://staging-site-download-tab-redesign/grapher/life-expectancy

<tr>
<td>"Normal" data tab
<td>

![CleanShot 2024-10-25 at 13 51 40](https://github.com/user-attachments/assets/fa408036-eb56-4493-a828-b5448239ee16)

<td>

http://staging-site-download-tab-redesign/grapher/life-expectancy

http://staging-site-download-tab-redesign/grapher/electricity-prod-source-stacked?country=~DEU

<tr>
<td>Short names not available (pre-ETL dataset or csv-based explorer)
<td>

![CleanShot 2024-10-25 at 13 52 40](https://github.com/user-attachments/assets/ce8c6207-4f37-4161-99bf-10a505f11cf2)


<td>

http://staging-site-download-tab-redesign/grapher/mode-of-reporting-literacy-rates

http://staging-site-download-tab-redesign/explorers/migration-flows

<tr>
<td>Vis download not possible, because on table tab
<td>

![CleanShot 2024-10-25 at 13 53 00](https://github.com/user-attachments/assets/24835474-2e07-4294-ba7a-ab05c4db9311)


<td>

http://staging-site-download-tab-redesign/grapher/life-expectancy?tab=table

<tr>
<td>Data is non-redistributable
<td>

![CleanShot 2024-10-25 at 13 53 20](https://github.com/user-attachments/assets/f04d6f9f-dca2-4bb4-8148-eb3b7ef84039)


<td>

http://staging-site-download-tab-redesign/explorers/covid?Metric=Variants&Interval=Cumulative&Relative+to+population=true

http://staging-site-download-tab-redesign/grapher/suicide-vs-violent-deaths

<tr>
<td>Server-side csv not available
<td><img src="https://github.com/user-attachments/assets/c83b78ec-2fc1-4112-b672-03e72d397d52">
<td>

http://staging-site-download-tab-redesign/explorers/covid

</table>