### PR TITLE
✨ (map) optimise static version for Figma

### DIFF
--- a/packages/@ourworldindata/grapher/src/horizontalColorLegend/HorizontalColorLegends.tsx
+++ b/packages/@ourworldindata/grapher/src/horizontalColorLegend/HorizontalColorLegends.tsx
@@ -562,72 +562,83 @@ export class HorizontalNumericColorLegend extends HorizontalColorLegend {
                 id={makeIdForHumanConsumption("numeric-color-legend")}
                 className="numericColorLegend"
             >
-                {numericLabels.map((label, index) => (
-                    <line
-                        key={index}
-                        x1={label.bounds.x + label.bounds.width / 2}
-                        y1={bottomY - numericBinSize}
-                        x2={label.bounds.x + label.bounds.width / 2}
-                        y2={bottomY + label.bounds.y + label.bounds.height}
-                        // if we use a light color for stroke (e.g. white), we want it to stay
-                        // "invisible", except for raised labels, where we want *some* contrast.
-                        stroke={
-                            label.raised ? darkenColorForLine(stroke) : stroke
-                        }
-                        strokeWidth={strokeWidth}
-                    />
-                ))}
-                {sortBy(
-                    positionedBins.map((positionedBin, index) => {
-                        const bin = positionedBin.bin
-                        const isFocus =
-                            numericFocusBracket &&
-                            bin.equals(numericFocusBracket)
-                        return (
-                            <NumericBinRect
-                                key={index}
-                                x={positionedBin.x}
-                                y={bottomY - numericBinSize}
-                                width={positionedBin.width}
-                                height={numericBinSize}
-                                fill={
-                                    bin.patternRef
-                                        ? `url(#${bin.patternRef})`
-                                        : bin.color
-                                }
-                                opacity={manager.legendOpacity} // defaults to undefined which removes the prop
-                                stroke={isFocus ? FOCUS_BORDER_COLOR : stroke}
-                                strokeWidth={isFocus ? 2 : strokeWidth}
-                                isOpenLeft={
-                                    bin instanceof NumericBin
-                                        ? bin.props.isOpenLeft
-                                        : false
-                                }
-                                isOpenRight={
-                                    bin instanceof NumericBin
-                                        ? bin.props.isOpenRight
-                                        : false
-                                }
-                            />
-                        )
-                    }),
-                    (rect) => rect.props["strokeWidth"]
-                )}
-                {numericLabels.map((label, index) => (
-                    <text
-                        key={index}
-                        x={label.bounds.x}
-                        y={bottomY + label.bounds.y}
-                        // we can't use dominant-baseline to do proper alignment since our svg-to-png library Sharp
-                        // doesn't support that (https://github.com/lovell/sharp/issues/1996), so we'll have to make
-                        // do with some rough positioning.
-                        dy={dyFromAlign(VerticalAlign.bottom)}
-                        fontSize={label.fontSize}
-                        fill={this.legendTextColor}
-                    >
-                        {label.text}
-                    </text>
-                ))}
+                <g id={makeIdForHumanConsumption("lines")}>
+                    {numericLabels.map((label, index) => (
+                        <line
+                            key={index}
+                            id={makeIdForHumanConsumption(label.text)}
+                            x1={label.bounds.x + label.bounds.width / 2}
+                            y1={bottomY - numericBinSize}
+                            x2={label.bounds.x + label.bounds.width / 2}
+                            y2={bottomY + label.bounds.y + label.bounds.height}
+                            // if we use a light color for stroke (e.g. white), we want it to stay
+                            // "invisible", except for raised labels, where we want *some* contrast.
+                            stroke={
+                                label.raised
+                                    ? darkenColorForLine(stroke)
+                                    : stroke
+                            }
+                            strokeWidth={strokeWidth}
+                        />
+                    ))}
+                </g>
+                <g id={makeIdForHumanConsumption("swatches")}>
+                    {sortBy(
+                        positionedBins.map((positionedBin, index) => {
+                            const bin = positionedBin.bin
+                            const isFocus =
+                                numericFocusBracket &&
+                                bin.equals(numericFocusBracket)
+                            return (
+                                <NumericBinRect
+                                    key={index}
+                                    x={positionedBin.x}
+                                    y={bottomY - numericBinSize}
+                                    width={positionedBin.width}
+                                    height={numericBinSize}
+                                    fill={
+                                        bin.patternRef
+                                            ? `url(#${bin.patternRef})`
+                                            : bin.color
+                                    }
+                                    opacity={manager.legendOpacity} // defaults to undefined which removes the prop
+                                    stroke={
+                                        isFocus ? FOCUS_BORDER_COLOR : stroke
+                                    }
+                                    strokeWidth={isFocus ? 2 : strokeWidth}
+                                    isOpenLeft={
+                                        bin instanceof NumericBin
+                                            ? bin.props.isOpenLeft
+                                            : false
+                                    }
+                                    isOpenRight={
+                                        bin instanceof NumericBin
+                                            ? bin.props.isOpenRight
+                                            : false
+                                    }
+                                />
+                            )
+                        }),
+                        (rect) => rect.props["strokeWidth"]
+                    )}
+                </g>
+                <g id={makeIdForHumanConsumption("labels")}>
+                    {numericLabels.map((label, index) => (
+                        <text
+                            key={index}
+                            x={label.bounds.x}
+                            y={bottomY + label.bounds.y}
+                            // we can't use dominant-baseline to do proper alignment since our svg-to-png library Sharp
+                            // doesn't support that (https://github.com/lovell/sharp/issues/1996), so we'll have to make
+                            // do with some rough positioning.
+                            dy={dyFromAlign(VerticalAlign.bottom)}
+                            fontSize={label.fontSize}
+                            fill={this.legendTextColor}
+                        >
+                            {label.text}
+                        </text>
+                    ))}
+                </g>
                 {this.legendTitle?.render(
                     this.x,
                     // Align legend title baseline with bottom of color bins

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
@@ -12,6 +12,7 @@ import {
     Color,
     HorizontalAlign,
     PrimitiveType,
+    makeIdForHumanConsumption,
 } from "@ourworldindata/utils"
 import { observable, computed, action } from "mobx"
 import { observer } from "mobx-react"
@@ -574,16 +575,73 @@ export class MapChart
         return this.manager.isStatic ?? false
     }
 
+    @computed get renderUid(): number {
+        return guid()
+    }
+
+    @computed get clipPath(): { id: string; element: React.ReactElement } {
+        return makeClipPath(this.renderUid, this.choroplethMapBounds)
+    }
+
     renderMapLegend(): React.ReactElement {
         const { numericLegend, categoryLegend } = this
 
         return (
-            <g>
+            <>
                 {numericLegend && (
                     <HorizontalNumericColorLegend manager={this} />
                 )}
                 {categoryLegend && (
                     <HorizontalCategoricalColorLegend manager={this} />
+                )}
+            </>
+        )
+    }
+
+    renderStatic(): React.ReactElement {
+        return (
+            <>
+                {/* Clipping the chart area is only necessary when the map is
+                    zoomed in. If it isn't, then we don't add a clipping element
+                    since it introduces noise in SVG editing programs like Figma. */}
+                {this.projection === MapProjectionName.World ? (
+                    <ChoroplethMap manager={this} />
+                ) : (
+                    <>
+                        {this.clipPath.element}
+                        <g clipPath={this.clipPath.id}>
+                            <ChoroplethMap manager={this} />
+                        </g>
+                    </>
+                )}
+                {this.renderMapLegend()}
+            </>
+        )
+    }
+
+    renderInteractive(): React.ReactElement {
+        const { tooltipState } = this
+
+        return (
+            <g
+                ref={this.base}
+                className="mapTab"
+                onMouseMove={this.onMapMouseMove}
+            >
+                {this.clipPath.element}
+                <g clipPath={this.clipPath.id}>
+                    <ChoroplethMap manager={this} />
+                </g>
+                {this.renderMapLegend()}
+                {tooltipState.target && (
+                    <MapTooltip
+                        tooltipState={tooltipState}
+                        timeSeriesTable={this.inputTable}
+                        formatValueIfCustom={this.formatTooltipValueIfCustom}
+                        manager={this.manager}
+                        colorScaleManager={this}
+                        targetTime={this.targetTime}
+                    />
                 )}
             </g>
         )
@@ -599,28 +657,7 @@ export class MapChart
                 />
             )
 
-        const { tooltipState } = this
-
-        return (
-            <g
-                ref={this.base}
-                className="mapTab"
-                onMouseMove={this.onMapMouseMove}
-            >
-                <ChoroplethMap manager={this} />
-                {this.renderMapLegend()}
-                {tooltipState.target && (
-                    <MapTooltip
-                        tooltipState={tooltipState}
-                        timeSeriesTable={this.inputTable}
-                        formatValueIfCustom={this.formatTooltipValueIfCustom}
-                        manager={this.manager}
-                        colorScaleManager={this}
-                        targetTime={this.targetTime}
-                    />
-                )}
-            </g>
-        )
+        return this.isStatic ? this.renderStatic() : this.renderInteractive()
     }
 }
 
@@ -632,9 +669,15 @@ class ChoroplethMap extends React.Component<{
 }> {
     base: React.RefObject<SVGGElement> = React.createRef()
 
-    @computed private get uid(): number {
-        return guid()
-    }
+    private focusStrokeColor = "#111"
+
+    private defaultStrokeWidth = 0.3
+    private focusStrokeWidth = 1.5
+    private selectedStrokeWidth = 1
+    private patternStrokeWidth = 0.7
+
+    private blurFillOpacity = 0.2
+    private blurStrokeOpacity = 0.5
 
     @computed private get manager(): ChoroplethMapManager {
         return this.props.manager
@@ -827,39 +870,186 @@ class ChoroplethMap extends React.Component<{
     // If true selected countries will have an outline
     @observable private showSelectedStyle = false
 
-    // SVG layering is based on order of appearance in the element tree (later elements rendered on top)
-    // The ordering here is quite careful
-    render(): React.ReactElement {
-        const {
-            uid,
-            bounds,
-            choroplethData,
-            defaultFill,
-            matrixTransform,
-            viewportScale,
-            featuresOutsideProjection,
-            featuresWithNoData,
-            featuresWithData,
-        } = this
-        const focusStrokeColor = "#111"
-        const defaultStrokeWidth = 0.3
-        const focusStrokeWidth = 1.5
-        const selectedStrokeWidth = 1
-        const patternStrokeWidth = 0.7
+    renderFeaturesOutsideProjection(): React.ReactElement | void {
+        if (this.featuresOutsideProjection.length === 0) return
 
-        const blurFillOpacity = 0.2
-        const blurStrokeOpacity = 0.5
+        const strokeWidth = this.defaultStrokeWidth / this.viewportScale
 
-        const clipPath = makeClipPath(uid, bounds)
+        return (
+            <g
+                id={makeIdForHumanConsumption("countries-outside-selection")}
+                className="nonProjectionFeatures"
+            >
+                {this.featuresOutsideProjection.map((feature) => (
+                    <path
+                        key={feature.id}
+                        id={makeIdForHumanConsumption(feature.id)}
+                        d={feature.path}
+                        strokeWidth={strokeWidth}
+                        stroke="#aaa"
+                        fill="#fff"
+                    />
+                ))}
+            </g>
+        )
+    }
+
+    renderFeaturesWithoutData(): React.ReactElement | void {
+        if (this.featuresWithNoData.length === 0) return
+        return (
+            <g
+                id={makeIdForHumanConsumption("countries-without-data")}
+                className="noDataFeatures"
+            >
+                <defs>
+                    <pattern
+                        // Ids should be unique per document (!) not just a grapher instance -
+                        // we disregard this for other patterns that are defined the same everywhere
+                        // because id collisions there are benign but here the pattern will be different
+                        // depending on the projection so we include this in the id
+                        id={`${Patterns.noDataPatternForMapChart}-${this.manager.projection}`}
+                        key={Patterns.noDataPatternForMapChart}
+                        patternUnits="userSpaceOnUse"
+                        width="4"
+                        height="4"
+                        patternTransform={`rotate(-45 2 2) scale(${
+                            1 / this.viewportScale
+                        })`} // <-- This scale here is crucial and map specific
+                    >
+                        <path
+                            d="M -1,2 l 6,0"
+                            stroke="#ccc"
+                            strokeWidth={this.patternStrokeWidth}
+                        />
+                    </pattern>
+                </defs>
+
+                {this.featuresWithNoData.map((feature) => {
+                    const isFocus = this.hasFocus(feature.id)
+                    const outOfFocusBracket = !!this.focusBracket && !isFocus
+                    const stroke = isFocus ? this.focusStrokeColor : "#aaa"
+                    const fillOpacity = outOfFocusBracket
+                        ? this.blurFillOpacity
+                        : 1
+                    const strokeOpacity = outOfFocusBracket
+                        ? this.blurStrokeOpacity
+                        : 1
+                    const strokeWidth =
+                        (isFocus
+                            ? this.focusStrokeWidth
+                            : this.defaultStrokeWidth) / this.viewportScale
+                    return (
+                        <path
+                            key={feature.id}
+                            id={makeIdForHumanConsumption(feature.id)}
+                            d={feature.path}
+                            strokeWidth={strokeWidth}
+                            stroke={stroke}
+                            strokeOpacity={strokeOpacity}
+                            cursor="pointer"
+                            fill={`url(#${Patterns.noDataPatternForMapChart}-${this.manager.projection})`}
+                            fillOpacity={fillOpacity}
+                            onClick={(ev: SVGMouseEvent): void =>
+                                this.manager.onClick(feature.geo, ev)
+                            }
+                            onMouseEnter={(): void =>
+                                this.onMouseEnter(feature)
+                            }
+                            onMouseLeave={this.onMouseLeave}
+                        />
+                    )
+                })}
+            </g>
+        )
+    }
+
+    renderFeaturesWithData(): React.ReactElement | void {
+        if (this.featuresWithData.length === 0) return
+
+        return (
+            <g id={makeIdForHumanConsumption("countries-with-data")}>
+                {sortBy(
+                    this.featuresWithData.map((feature) => {
+                        const isFocus = this.hasFocus(feature.id)
+                        const showSelectedStyle =
+                            this.showSelectedStyle &&
+                            this.isSelected(feature.id)
+                        const outOfFocusBracket =
+                            !!this.focusBracket && !isFocus
+                        const series = this.choroplethData.get(
+                            feature.id as string
+                        )
+                        const stroke =
+                            isFocus || showSelectedStyle
+                                ? this.focusStrokeColor
+                                : DEFAULT_STROKE_COLOR
+                        const fill = series ? series.color : this.defaultFill
+                        const fillOpacity = outOfFocusBracket
+                            ? this.blurFillOpacity
+                            : 1
+                        const strokeOpacity = outOfFocusBracket
+                            ? this.blurStrokeOpacity
+                            : 1
+                        const strokeWidth =
+                            (isFocus
+                                ? this.focusStrokeWidth
+                                : showSelectedStyle
+                                  ? this.selectedStrokeWidth
+                                  : this.defaultStrokeWidth) /
+                            this.viewportScale
+
+                        return (
+                            <path
+                                key={feature.id}
+                                id={makeIdForHumanConsumption(feature.id)}
+                                d={feature.path}
+                                strokeWidth={strokeWidth}
+                                stroke={stroke}
+                                strokeOpacity={strokeOpacity}
+                                cursor="pointer"
+                                fill={fill}
+                                fillOpacity={fillOpacity}
+                                onClick={(ev: SVGMouseEvent): void =>
+                                    this.manager.onClick(feature.geo, ev)
+                                }
+                                onMouseEnter={(): void =>
+                                    this.onMouseEnter(feature)
+                                }
+                                onMouseLeave={this.onMouseLeave}
+                            />
+                        )
+                    }),
+                    (p) => p.props["strokeWidth"]
+                )}
+            </g>
+        )
+    }
+
+    renderStatic(): React.ReactElement {
+        return (
+            <g
+                id={makeIdForHumanConsumption("map")}
+                transform={this.matrixTransform}
+            >
+                {this.renderFeaturesOutsideProjection()}
+                {this.renderFeaturesWithoutData()}
+                {this.renderFeaturesWithData()}
+            </g>
+        )
+    }
+
+    renderInteractive(): React.ReactElement {
+        const { bounds, matrixTransform } = this
 
         // this needs to be referenced here or it will be recomputed on every mousemove
         const _cachedCentroids = this.quadtree
 
+        // SVG layering is based on order of appearance in the element tree (later elements rendered on top)
+        // The ordering here is quite careful
         return (
             <g
                 ref={this.base}
                 className={CHOROPLETH_MAP_CLASSNAME}
-                clipPath={clipPath.id}
                 onMouseDown={
                     (ev: SVGMouseEvent): void =>
                         ev.preventDefault() /* Without this, title may get selected while shift clicking */
@@ -876,149 +1066,18 @@ class ChoroplethMap extends React.Component<{
                     fill="rgba(255,255,255,0)"
                     opacity={0}
                 />
-                {clipPath.element}
                 <g className="subunits" transform={matrixTransform}>
-                    {featuresOutsideProjection.length > 0 && (
-                        <g className="nonProjectionFeatures">
-                            {featuresOutsideProjection.map((feature) => {
-                                return (
-                                    <path
-                                        key={feature.id}
-                                        d={feature.path}
-                                        strokeWidth={
-                                            defaultStrokeWidth / viewportScale
-                                        }
-                                        stroke={"#aaa"}
-                                        fill={"#fff"}
-                                    />
-                                )
-                            })}
-                        </g>
-                    )}
-
-                    {featuresWithNoData.length > 0 && (
-                        <g className="noDataFeatures">
-                            <defs>
-                                <pattern
-                                    // Ids should be unique per document (!) not just a grapher instance -
-                                    // we disregard this for other patterns that are defined the same everywhere
-                                    // because id collisions there are benign but here the pattern will be different
-                                    // depending on the projection so we include this in the id
-                                    id={`${Patterns.noDataPatternForMapChart}-${this.manager.projection}`}
-                                    key={Patterns.noDataPatternForMapChart}
-                                    patternUnits="userSpaceOnUse"
-                                    width="4"
-                                    height="4"
-                                    patternTransform={`rotate(-45 2 2) scale(${
-                                        1 / this.viewportScale
-                                    })`} // <-- This scale here is crucial and map specific
-                                >
-                                    <path
-                                        d="M -1,2 l 6,0"
-                                        stroke="#ccc"
-                                        strokeWidth={patternStrokeWidth}
-                                    />
-                                </pattern>
-                            </defs>
-
-                            {featuresWithNoData.map((feature) => {
-                                const isFocus = this.hasFocus(feature.id)
-                                const outOfFocusBracket =
-                                    !!this.focusBracket && !isFocus
-                                const stroke = isFocus
-                                    ? focusStrokeColor
-                                    : "#aaa"
-                                const fillOpacity = outOfFocusBracket
-                                    ? blurFillOpacity
-                                    : 1
-                                const strokeOpacity = outOfFocusBracket
-                                    ? blurStrokeOpacity
-                                    : 1
-                                return (
-                                    <path
-                                        key={feature.id}
-                                        d={feature.path}
-                                        strokeWidth={
-                                            (isFocus
-                                                ? focusStrokeWidth
-                                                : defaultStrokeWidth) /
-                                            viewportScale
-                                        }
-                                        stroke={stroke}
-                                        strokeOpacity={strokeOpacity}
-                                        cursor="pointer"
-                                        fill={`url(#${Patterns.noDataPatternForMapChart}-${this.manager.projection})`}
-                                        fillOpacity={fillOpacity}
-                                        onClick={(ev: SVGMouseEvent): void =>
-                                            this.manager.onClick(
-                                                feature.geo,
-                                                ev
-                                            )
-                                        }
-                                        onMouseEnter={(): void =>
-                                            this.onMouseEnter(feature)
-                                        }
-                                        onMouseLeave={this.onMouseLeave}
-                                    />
-                                )
-                            })}
-                        </g>
-                    )}
-
-                    {sortBy(
-                        featuresWithData.map((feature) => {
-                            const isFocus = this.hasFocus(feature.id)
-                            const showSelectedStyle =
-                                this.showSelectedStyle &&
-                                this.isSelected(feature.id)
-                            const outOfFocusBracket =
-                                !!this.focusBracket && !isFocus
-                            const series = choroplethData.get(
-                                feature.id as string
-                            )
-                            const stroke =
-                                isFocus || showSelectedStyle
-                                    ? focusStrokeColor
-                                    : DEFAULT_STROKE_COLOR
-                            const fill = series ? series.color : defaultFill
-                            const fillOpacity = outOfFocusBracket
-                                ? blurFillOpacity
-                                : 1
-                            const strokeOpacity = outOfFocusBracket
-                                ? blurStrokeOpacity
-                                : 1
-
-                            return (
-                                <path
-                                    key={feature.id}
-                                    d={feature.path}
-                                    strokeWidth={
-                                        (isFocus
-                                            ? focusStrokeWidth
-                                            : showSelectedStyle
-                                              ? selectedStrokeWidth
-                                              : defaultStrokeWidth) /
-                                        viewportScale
-                                    }
-                                    stroke={stroke}
-                                    strokeOpacity={strokeOpacity}
-                                    cursor="pointer"
-                                    fill={fill}
-                                    fillOpacity={fillOpacity}
-                                    onClick={(ev: SVGMouseEvent): void =>
-                                        this.manager.onClick(feature.geo, ev)
-                                    }
-                                    onMouseEnter={(): void =>
-                                        this.onMouseEnter(feature)
-                                    }
-                                    onMouseLeave={this.onMouseLeave}
-                                />
-                            )
-                        }),
-                        (p) => p.props["strokeWidth"]
-                    )}
+                    {this.renderFeaturesOutsideProjection()}
+                    {this.renderFeaturesWithoutData()}
+                    {this.renderFeaturesWithData()}
                 </g>
             </g>
         )
+    }
+
+    render(): React.ReactElement {
+        return this.manager.isStatic
+            ? this.renderStatic()
+            : this.renderInteractive()
     }
 }

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapChartConstants.ts
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapChartConstants.ts
@@ -42,6 +42,7 @@ export interface ChoroplethMapManager {
     onClick: (d: GeoFeature, ev: React.MouseEvent<SVGElement>) => void
     onMapMouseOver: (d: GeoFeature) => void
     onMapMouseLeave: () => void
+    isStatic?: boolean
 }
 
 export interface RenderFeature {


### PR DESCRIPTION
Optimise maps for Figma, similar to how that has been done for other chart types.

| Before  | After  |
| ------- | ------ |
| <img width="320" alt="Screenshot 2024-10-24 at 16 48 48" src="https://github.com/user-attachments/assets/f7fb3bc7-908d-4b3f-8d13-4d4740265c0b">  | <img width="320" alt="Screenshot 2024-10-24 at 16 49 05" src="https://github.com/user-attachments/assets/a4424249-9ee8-4b4b-896d-a0ad0223bef3"> |