### PR TITLE
:sparkles: Log in Tailscale users automatically on staging servers

### DIFF
--- a/adminSiteServer/appClass.tsx
+++ b/adminSiteServer/appClass.tsx
@@ -96,7 +96,7 @@ export class OwidAdminApp {
 
         if (ENV_IS_STAGING) {
             // Try to log in with tailscale if we're in staging
-            app.use("/admin/login", tailscaleAuthMiddleware)
+            app.use(tailscaleAuthMiddleware)
         } else {
             // In production use Cloudflare
             app.use("/admin/login", authCloudflareSSOMiddleware)

--- a/adminSiteServer/authentication.tsx
+++ b/adminSiteServer/authentication.tsx
@@ -272,14 +272,12 @@ interface TailscaleStatus {
     }
 }
 
-// Middleware for Tailscale authentication
 export async function tailscaleAuthMiddleware(
     req: express.Request,
     res: express.Response,
     next: express.NextFunction
 ) {
     // If there's a sessionid in cookies, proceed to `authMiddleware` middleware
-    // TODO: we should also check if this sessionid is valid (not expired)
     if (req.cookies["sessionid"]) {
         return next()
     }
@@ -293,7 +291,7 @@ export async function tailscaleAuthMiddleware(
     // Get the Tailscale display name / github username associated with the client's IP address
     const githubUserName = ipToUserMap[clientIp]
 
-    // Next if user is not found
+    // Next if user is not found, user can still log in as admin
     if (!githubUserName) {
         return next()
     }
@@ -335,7 +333,6 @@ function getClientIp(req: express.Request): string {
     return ip
 }
 
-// Function to get Tailscale IP-to-User mapping
 async function getTailscaleIpToUserMap(): Promise<Record<string, string>> {
     return new Promise((resolve) => {
         exec("tailscale status --json", (error, stdout) => {

--- a/adminSiteServer/authentication.tsx
+++ b/adminSiteServer/authentication.tsx
@@ -289,7 +289,9 @@ export async function tailscaleAuthMiddleware(
     const ipToUserMap = await getTailscaleIpToUserMap()
 
     // Get the Tailscale display name / github username associated with the client's IP address
-    const githubUserName = ipToUserMap[clientIp]
+    // const githubUserName = ipToUserMap[clientIp]
+    let githubUserName = ipToUserMap[clientIp]
+    githubUserName = "unknown"
 
     // Next if user is not found, user can still log in as admin
     if (!githubUserName) {
@@ -334,11 +336,11 @@ function getClientIp(req: express.Request): string {
 }
 
 async function getTailscaleIpToUserMap(): Promise<Record<string, string>> {
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
         exec("tailscale status --json", (error, stdout) => {
             if (error) {
                 console.error(`Error getting Tailscale status: ${error}`)
-                return resolve({})
+                return reject(error)
             }
             const tailscaleStatus: TailscaleStatus = JSON.parse(stdout)
             const ipToUser: Record<string, string> = {}

--- a/adminSiteServer/authentication.tsx
+++ b/adminSiteServer/authentication.tsx
@@ -289,9 +289,7 @@ export async function tailscaleAuthMiddleware(
     const ipToUserMap = await getTailscaleIpToUserMap()
 
     // Get the Tailscale display name / github username associated with the client's IP address
-    // const githubUserName = ipToUserMap[clientIp]
-    let githubUserName = ipToUserMap[clientIp]
-    githubUserName = "unknown"
+    const githubUserName = ipToUserMap[clientIp]
 
     // Next if user is not found, user can still log in as admin
     if (!githubUserName) {

--- a/settings/serverSettings.ts
+++ b/settings/serverSettings.ts
@@ -200,3 +200,9 @@ export const LEGACY_WORDPRESS_IMAGE_URL: string =
 // search evaluation
 export const SEARCH_EVAL_URL: string =
     "https://pub-ec761fe0df554b02bc605610f3296000.r2.dev"
+
+// We currently use ENV=production on staging servers, it'd be better to have ENV=staging
+// but that would require changing a lot of code
+export const ENV_IS_STAGING: boolean = ADMIN_BASE_URL.includes(
+    "http://staging-site"
+)


### PR DESCRIPTION
## Motivation

We log in as admin user on staging servers. This is a bit annoying because for [data managers](https://github.com/owid/etl/issues/2578) because:
- Each time we land on a new staging server, we have to log in with admin (only once per staging server) and then we see a warning about "compromised passwords" on Chrome
- Chart edits on staging server are all made by "ETL" user (this is problematic since a lot of chart edits come from staging servers via chart-sync)

## Implementation

Add middleware that compares user IP to IPs from `tailscale status --json`. If we find a match, we'll look up Tailscale display name (which is actually a **Github name**) and use it to look up that user in MySQL. This assumes that Github names match MySQL full names (which is true for most people, and exceptions can change it).

Once we identify user, we call `logInAsUser` and set `sessionid` in cookies. `authMiddleware` then uses the sessionid and logs us automatically.

## How to test

1. Open admin at http://staging-site-real-users/admin in **incognito mode**
2. You should be automatically logged in

## How to develop

1. Go to `ssh owid@staging-site-real-users` in terminal or VSCode
3. `pm2 stop admin`, then `cd owid-grapher && yarn startAdminDevServer`
4. Open admin at http://staging-site-real-users/admin in anonymous mode
5. You should be logged automatically and shouldn't see a login page

## Github names not matching `users.fullName`

Tuna -> Tuna Acisu
bastianherre -> Bastian Herre
JoeHasell -> Joe Hasell
mrwbkrm -> Marwa Boukarim
veronikasamborska1994 -> Veronika Samborska