### PR TITLE
Migrate multi dimensional configs to new storage

### DIFF
--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -1145,14 +1145,19 @@ deleteRouteWithRWTransaction(
     }
 )
 
-postRouteWithRWTransaction(apiRouter, "/multi-dim", async (req, res, trx) => {
-    const { slug, config: rawConfig } = JSON.parse(req.body) as {
-        slug: string
-        config: MultiDimDataPageConfigRaw
+putRouteWithRWTransaction(
+    apiRouter,
+    "/multi-dim/:slug",
+    async (req, res, trx) => {
+        const { slug } = req.params
+        if (!isValidSlug(slug)) {
+            throw new JsonError(`Invalid multi-dim slug ${slug}`)
+        }
+        const rawConfig = req.body as MultiDimDataPageConfigRaw
+        const id = await createMultiDimConfig(trx, slug, rawConfig)
+        return { success: true, id }
     }
-    const id = await createMultiDimConfig(trx, slug, rawConfig)
-    return { success: true, id }
-})
+)
 
 getRouteWithROTransaction(apiRouter, "/users.json", async (req, res, trx) => ({
     users: await trx

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -9,11 +9,7 @@ import {
     ADMIN_BASE_URL,
     DATA_API_URL,
 } from "../settings/serverSettings.js"
-import {
-    Base64String,
-    expectInt,
-    isValidSlug,
-} from "../serverUtils/serverUtil.js"
+import { expectInt, isValidSlug } from "../serverUtils/serverUtil.js"
 import {
     OldChartFieldList,
     assignTagsForCharts,
@@ -79,6 +75,7 @@ import {
     VariableAnnotationsResponseRow,
 } from "../adminShared/AdminSessionTypes.js"
 import {
+    Base64String,
     DbPlainDatasetTag,
     GrapherInterface,
     OwidGdocType,
@@ -103,6 +100,7 @@ import {
     FlatTagGraph,
     DbRawChartConfig,
     parseChartConfig,
+    MultiDimDataPageConfigRaw,
     R2GrapherConfigDirectory,
 } from "@ourworldindata/types"
 import { uuidv7 } from "uuidv7"
@@ -183,6 +181,7 @@ import {
     saveGrapherConfigToR2ByUUID,
 } from "./chartConfigR2Helpers.js"
 import { fetchImagesFromDriveAndSyncToS3 } from "../db/model/Image.js"
+import { createMultiDimConfig } from "./multiDim.js"
 
 const apiRouter = new FunctionalRouter()
 
@@ -1145,6 +1144,15 @@ deleteRouteWithRWTransaction(
         return { success: true }
     }
 )
+
+postRouteWithRWTransaction(apiRouter, "/multi-dim", async (req, res, trx) => {
+    const { slug, config: rawConfig } = JSON.parse(req.body) as {
+        slug: string
+        config: MultiDimDataPageConfigRaw
+    }
+    const id = await createMultiDimConfig(trx, slug, rawConfig)
+    return { success: true, id }
+})
 
 getRouteWithROTransaction(apiRouter, "/users.json", async (req, res, trx) => ({
     users: await trx

--- a/adminSiteServer/migrateMultiDimConfigs.ts
+++ b/adminSiteServer/migrateMultiDimConfigs.ts
@@ -1,0 +1,29 @@
+import {
+    DbPlainMultiDimDataPage,
+    MultiDimDataPagesTableName,
+} from "@ourworldindata/types"
+import { knexReadWriteTransaction, TransactionCloseMode } from "../db/db.js"
+import { createMultiDimConfig } from "./multiDim.js"
+
+/**
+ * Migrates the old multi-dim config to a normalized format, creates related
+ * records in `chart_configs` and the `multi_dim_x_chart_configs` tables and
+ * uploads the full chart config of each view and the multi-dim config to R2.
+ *
+ * The old config must be valid, otherwise the migration will fail.
+ *
+ * This isn't an actual DB data migration because of circular dependencies
+ * between `adminSiteServer/multiDim` and `db`.
+ */
+async function main() {
+    await knexReadWriteTransaction(async (knex) => {
+        const results = await knex<DbPlainMultiDimDataPage>(
+            MultiDimDataPagesTableName
+        ).select("slug", "config")
+        for (const { slug, config } of results) {
+            await createMultiDimConfig(knex, slug, JSON.parse(config))
+        }
+    }, TransactionCloseMode.Close)
+}
+
+void main()

--- a/adminSiteServer/multiDim.ts
+++ b/adminSiteServer/multiDim.ts
@@ -122,7 +122,6 @@ async function getViewIdToChartConfigIdMap(
     knex: db.KnexReadonlyTransaction,
     slug: string
 ) {
-    const mapping = new Map<string, string>()
     const rows = await db.knexRaw<DbPlainMultiDimXChartConfig>(
         knex,
         `-- sql
@@ -132,10 +131,7 @@ async function getViewIdToChartConfigIdMap(
         WHERE mddp.slug = ?`,
         [slug]
     )
-    for (const { viewId, chartConfigId } of rows) {
-        mapping.set(viewId, chartConfigId)
-    }
-    return mapping
+    return new Map(rows.map((row) => [row.viewId, row.chartConfigId]))
 }
 
 async function saveNewMultiDimViewChartConfig(

--- a/adminSiteServer/multiDim.ts
+++ b/adminSiteServer/multiDim.ts
@@ -1,0 +1,205 @@
+import { uniq } from "lodash"
+import { uuidv7 } from "uuidv7"
+
+import {
+    Base64String,
+    DbPlainMultiDimDataPage,
+    DbRawChartConfig,
+    GrapherInterface,
+    IndicatorEntryBeforePreProcessing,
+    MultiDimDataPageConfigEnriched,
+    MultiDimDataPageConfigPreProcessed,
+    MultiDimDataPageConfigRaw,
+    MultiDimDataPagesTableName,
+    serializeChartConfig,
+} from "@ourworldindata/types"
+import { MultiDimDataPageConfig } from "@ourworldindata/utils"
+import * as db from "../db/db.js"
+import { upsertMultiDimDataPage } from "../db/model/MultiDimDataPage.js"
+import { upsertMultiDimXChartConfigs } from "../db/model/MultiDimXChartConfigs.js"
+import {
+    getMergedGrapherConfigsForVariables,
+    getVariableIdsByCatalogPath,
+} from "../db/model/Variable.js"
+import {
+    saveGrapherConfigToR2ByUUID,
+    saveMultiDimConfigToR2,
+} from "./chartConfigR2Helpers.js"
+
+async function resolveMultiDimDataPageCatalogPathsToIndicatorIds(
+    knex: db.KnexReadonlyTransaction,
+    rawConfig: MultiDimDataPageConfigRaw
+): Promise<MultiDimDataPageConfigPreProcessed> {
+    const allCatalogPaths = rawConfig.views
+        .flatMap((view) =>
+            Object.values(view.indicators).flatMap((indicatorOrIndicators) =>
+                Array.isArray(indicatorOrIndicators)
+                    ? indicatorOrIndicators
+                    : [indicatorOrIndicators]
+            )
+        )
+        .filter((indicator) => typeof indicator === "string")
+
+    const catalogPathToIndicatorIdMap = await getVariableIdsByCatalogPath(
+        allCatalogPaths,
+        knex
+    )
+
+    const missingCatalogPaths = new Set(
+        allCatalogPaths.filter(
+            (indicator) => !catalogPathToIndicatorIdMap.has(indicator)
+        )
+    )
+
+    if (missingCatalogPaths.size > 0) {
+        console.warn(
+            `Could not find the following catalog paths for MDD ${rawConfig.title} in the database: ${Array.from(
+                missingCatalogPaths
+            ).join(", ")}`
+        )
+    }
+
+    function resolveSingleField(indicator?: IndicatorEntryBeforePreProcessing) {
+        if (typeof indicator === "string") {
+            const indicatorId = catalogPathToIndicatorIdMap.get(indicator)
+            return indicatorId ?? undefined
+        }
+        return indicator
+    }
+
+    function resolveSingleOrArrayField(
+        indicator:
+            | IndicatorEntryBeforePreProcessing
+            | IndicatorEntryBeforePreProcessing[]
+    ) {
+        const indicatorIds = []
+        if (Array.isArray(indicator)) {
+            for (const item of indicator) {
+                const resolved = resolveSingleField(item)
+                if (resolved) indicatorIds.push(resolved)
+            }
+        } else {
+            const resolved = resolveSingleField(indicator)
+            if (resolved) indicatorIds.push(resolved)
+        }
+        return indicatorIds
+    }
+
+    return {
+        ...rawConfig,
+        views: rawConfig.views.map((view) => ({
+            ...view,
+            indicators: {
+                y: resolveSingleOrArrayField(view.indicators.y),
+                x: resolveSingleField(view.indicators.x),
+                size: resolveSingleField(view.indicators.size),
+                color: resolveSingleField(view.indicators.color),
+            },
+        })),
+    }
+}
+
+async function saveNewMultiDimViewChartConfig(
+    knex: db.KnexReadWriteTransaction,
+    patchConfig: GrapherInterface,
+    fullConfig: GrapherInterface
+): Promise<string> {
+    const chartConfigId = uuidv7()
+    await db.knexRaw(
+        knex,
+        `-- sql
+            INSERT INTO chart_configs (id, patch, full)
+            VALUES (?, ?, ?)
+        `,
+        [
+            chartConfigId,
+            serializeChartConfig(patchConfig),
+            serializeChartConfig(fullConfig),
+        ]
+    )
+
+    // We need to get the full config and the md5 hash from the database instead of
+    // computing our own md5 hash because MySQL normalizes JSON and our
+    // client computed md5 would be different from the ones computed by and stored in R2
+    const fullConfigMd5 = await db.knexRawFirst<
+        Pick<DbRawChartConfig, "full" | "fullMd5">
+    >(
+        knex,
+        `-- sql
+            select full, fullMd5 from chart_configs where id = ?`,
+        [chartConfigId]
+    )
+
+    await saveGrapherConfigToR2ByUUID(
+        chartConfigId,
+        fullConfigMd5!.full,
+        fullConfigMd5!.fullMd5 as Base64String
+    )
+
+    return chartConfigId
+}
+
+async function saveMultiDimConfig(
+    knex: db.KnexReadWriteTransaction,
+    slug: string,
+    config: MultiDimDataPageConfigEnriched
+) {
+    const id = await upsertMultiDimDataPage(knex, {
+        slug,
+        config: JSON.stringify(config),
+    })
+    // We need to get the full config and the md5 hash from the database instead of
+    // computing our own md5 hash because MySQL normalizes JSON and our
+    // client computed md5 would be different from the ones computed by and stored in R2
+    const result = await knex<DbPlainMultiDimDataPage>(
+        MultiDimDataPagesTableName
+    )
+        .select("config", "configMd5")
+        .where({ id })
+        .first()
+    const { config: normalizedConfig, configMd5 } = result!
+    await saveMultiDimConfigToR2(normalizedConfig, slug, configMd5)
+    return id
+}
+
+export async function createMultiDimConfig(
+    knex: db.KnexReadWriteTransaction,
+    slug: string,
+    rawConfig: MultiDimDataPageConfigRaw
+): Promise<number> {
+    const config = await resolveMultiDimDataPageCatalogPathsToIndicatorIds(
+        knex,
+        rawConfig
+    )
+    const variableConfigs = await getMergedGrapherConfigsForVariables(
+        knex,
+        uniq(config.views.map((view) => view.indicators.y[0]))
+    )
+    const enrichedViews = await Promise.all(
+        config.views.map(async (view) => {
+            const variableId = view.indicators.y[0]
+            const fullGrapherConfig = {
+                ...variableConfigs.get(variableId),
+                ...view.config,
+                dimensions: MultiDimDataPageConfig.viewToDimensionsConfig(view),
+                selectedEntityNames: config.defaultSelection ?? [],
+            }
+            const chartConfigId = await saveNewMultiDimViewChartConfig(
+                knex,
+                view.config || {},
+                fullGrapherConfig
+            )
+            return { ...view, fullConfigId: chartConfigId }
+        })
+    )
+    const enrichedConfig = { ...config, views: enrichedViews }
+    const multiDimId = await saveMultiDimConfig(knex, slug, enrichedConfig)
+    for (const view of enrichedConfig.views) {
+        await upsertMultiDimXChartConfigs(knex, {
+            multiDimId,
+            variableId: view.indicators.y[0],
+            chartConfigId: view.fullConfigId,
+        })
+    }
+    return multiDimId
+}

--- a/adminSiteServer/multiDim.ts
+++ b/adminSiteServer/multiDim.ts
@@ -3,7 +3,10 @@ import { uuidv7 } from "uuidv7"
 
 import {
     Base64String,
+    ChartConfigsTableName,
+    DbInsertChartConfig,
     DbPlainMultiDimDataPage,
+    DbPlainMultiDimXChartConfig,
     DbRawChartConfig,
     GrapherInterface,
     IndicatorEntryBeforePreProcessing,
@@ -11,9 +14,11 @@ import {
     MultiDimDataPageConfigPreProcessed,
     MultiDimDataPageConfigRaw,
     MultiDimDataPagesTableName,
+    MultiDimDimensionChoices,
+    MultiDimXChartConfigsTableName,
     serializeChartConfig,
 } from "@ourworldindata/types"
-import { MultiDimDataPageConfig } from "@ourworldindata/utils"
+import { MultiDimDataPageConfig, slugify } from "@ourworldindata/utils"
 import * as db from "../db/db.js"
 import { upsertMultiDimDataPage } from "../db/model/MultiDimDataPage.js"
 import { upsertMultiDimXChartConfigs } from "../db/model/MultiDimXChartConfigs.js"
@@ -22,9 +27,18 @@ import {
     getVariableIdsByCatalogPath,
 } from "../db/model/Variable.js"
 import {
+    deleteGrapherConfigFromR2ByUUID,
     saveGrapherConfigToR2ByUUID,
     saveMultiDimConfigToR2,
 } from "./chartConfigR2Helpers.js"
+
+function dimensionsToViewId(dimensions: MultiDimDimensionChoices) {
+    return Object.entries(dimensions)
+        .sort(([keyA], [keyB]) => keyA.localeCompare(keyB))
+        .map(([_, value]) => slugify(value))
+        .join("__")
+        .toLowerCase()
+}
 
 async function resolveMultiDimDataPageCatalogPathsToIndicatorIds(
     knex: db.KnexReadonlyTransaction,
@@ -99,6 +113,26 @@ async function resolveMultiDimDataPageCatalogPathsToIndicatorIds(
     }
 }
 
+async function getViewIdToChartConfigIdMap(
+    knex: db.KnexReadonlyTransaction,
+    slug: string
+) {
+    const mapping = new Map<string, string>()
+    const rows = await db.knexRaw<DbPlainMultiDimXChartConfig>(
+        knex,
+        `-- sql
+        SELECT viewId, chartConfigId
+        FROM multi_dim_x_chart_configs mdxcc
+        JOIN multi_dim_data_pages mddp ON mddp.id = mdxcc.multiDimId
+        WHERE mddp.slug = ?`,
+        [slug]
+    )
+    for (const { viewId, chartConfigId } of rows) {
+        mapping.set(viewId, chartConfigId)
+    }
+    return mapping
+}
+
 async function saveNewMultiDimViewChartConfig(
     knex: db.KnexReadWriteTransaction,
     patchConfig: GrapherInterface,
@@ -136,6 +170,42 @@ async function saveNewMultiDimViewChartConfig(
         fullConfigMd5!.fullMd5 as Base64String
     )
 
+    console.debug(`Chart config created id=${chartConfigId}`)
+    return chartConfigId
+}
+
+async function updateMultiDimViewChartConfig(
+    knex: db.KnexReadWriteTransaction,
+    chartConfigId: string,
+    patchConfig: GrapherInterface,
+    fullConfig: GrapherInterface
+): Promise<string> {
+    await knex<DbInsertChartConfig>(ChartConfigsTableName)
+        .update({
+            patch: serializeChartConfig(patchConfig),
+            full: serializeChartConfig(fullConfig),
+        })
+        .where({ id: chartConfigId })
+
+    // We need to get the full config and the md5 hash from the database instead of
+    // computing our own md5 hash because MySQL normalizes JSON and our
+    // client computed md5 would be different from the ones computed by and stored in R2
+    const fullConfigMd5 = await db.knexRawFirst<
+        Pick<DbRawChartConfig, "full" | "fullMd5">
+    >(
+        knex,
+        `-- sql
+            select full, fullMd5 from chart_configs where id = ?`,
+        [chartConfigId]
+    )
+
+    await saveGrapherConfigToR2ByUUID(
+        chartConfigId,
+        fullConfigMd5!.full,
+        fullConfigMd5!.fullMd5 as Base64String
+    )
+
+    console.debug(`Chart config updated id=${chartConfigId}`)
     return chartConfigId
 }
 
@@ -148,6 +218,17 @@ async function saveMultiDimConfig(
         slug,
         config: JSON.stringify(config),
     })
+    if (id === 0) {
+        // There are no updates to the config, return the existing id.
+        console.debug(`There are no changes to multi dim config slug=${slug}`)
+        const result = await knex<DbPlainMultiDimDataPage>(
+            MultiDimDataPagesTableName
+        )
+            .select("id")
+            .where({ slug })
+            .first()
+        return result!.id
+    }
     // We need to get the full config and the md5 hash from the database instead of
     // computing our own md5 hash because MySQL normalizes JSON and our
     // client computed md5 would be different from the ones computed by and stored in R2
@@ -160,6 +241,21 @@ async function saveMultiDimConfig(
     const { config: normalizedConfig, configMd5 } = result!
     await saveMultiDimConfigToR2(normalizedConfig, slug, configMd5)
     return id
+}
+
+async function cleanUpOrphanedChartConfigs(
+    knex: db.KnexReadWriteTransaction,
+    orphanedChartConfigIds: string[]
+) {
+    await knex<DbPlainMultiDimXChartConfig>(MultiDimXChartConfigsTableName)
+        .whereIn("chartConfigId", orphanedChartConfigIds)
+        .delete()
+    await knex<DbRawChartConfig>(ChartConfigsTableName)
+        .whereIn("id", orphanedChartConfigIds)
+        .delete()
+    for (const id of orphanedChartConfigIds) {
+        await deleteGrapherConfigFromR2ByUUID(id)
+    }
 }
 
 export async function createMultiDimConfig(
@@ -175,28 +271,57 @@ export async function createMultiDimConfig(
         knex,
         uniq(config.views.map((view) => view.indicators.y[0]))
     )
+    const existingViewIdsToChartConfigIds = await getViewIdToChartConfigIdMap(
+        knex,
+        slug
+    )
+    const reusedChartConfigIds = new Set<string>()
+
     const enrichedViews = await Promise.all(
         config.views.map(async (view) => {
             const variableId = view.indicators.y[0]
+            const patchGrapherConfig = view.config || {}
             const fullGrapherConfig = {
                 ...variableConfigs.get(variableId),
-                ...view.config,
+                ...patchGrapherConfig,
                 dimensions: MultiDimDataPageConfig.viewToDimensionsConfig(view),
                 selectedEntityNames: config.defaultSelection ?? [],
             }
-            const chartConfigId = await saveNewMultiDimViewChartConfig(
-                knex,
-                view.config || {},
-                fullGrapherConfig
+            const existingChartConfigId = existingViewIdsToChartConfigIds.get(
+                dimensionsToViewId(view.dimensions)
             )
+            let chartConfigId
+            if (existingChartConfigId) {
+                chartConfigId = existingChartConfigId
+                await updateMultiDimViewChartConfig(
+                    knex,
+                    chartConfigId,
+                    patchGrapherConfig,
+                    fullGrapherConfig
+                )
+                reusedChartConfigIds.add(chartConfigId)
+            } else {
+                chartConfigId = await saveNewMultiDimViewChartConfig(
+                    knex,
+                    patchGrapherConfig,
+                    fullGrapherConfig
+                )
+            }
             return { ...view, fullConfigId: chartConfigId }
         })
     )
+
+    const orphanedChartConfigIds = Array.from(
+        existingViewIdsToChartConfigIds.values()
+    ).filter((id) => !reusedChartConfigIds.has(id))
+    await cleanUpOrphanedChartConfigs(knex, orphanedChartConfigIds)
+
     const enrichedConfig = { ...config, views: enrichedViews }
     const multiDimId = await saveMultiDimConfig(knex, slug, enrichedConfig)
     for (const view of enrichedConfig.views) {
         await upsertMultiDimXChartConfigs(knex, {
             multiDimId,
+            viewId: dimensionsToViewId(view.dimensions),
             variableId: view.indicators.y[0],
             chartConfigId: view.fullConfigId,
         })

--- a/db/migration/1729600015045-AddMultiDimIdConfigMd5SlugIndex.ts
+++ b/db/migration/1729600015045-AddMultiDimIdConfigMd5SlugIndex.ts
@@ -1,0 +1,30 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class AddMultiDimIdConfigMd5SlugIndex1729600015045
+    implements MigrationInterface
+{
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`-- sql
+            ALTER TABLE multi_dim_data_pages
+            DROP PRIMARY KEY,
+            ADD COLUMN id SERIAL PRIMARY KEY FIRST,
+            ADD COLUMN configMd5 CHAR(24) GENERATED ALWAYS as (to_base64(unhex(md5(config)))) STORED NOT NULL AFTER config
+        `)
+        await queryRunner.query(`-- sql
+            CREATE UNIQUE INDEX idx_multi_dim_data_pages_slug
+            ON multi_dim_data_pages (slug)
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`-- sql
+            DROP INDEX idx_multi_dim_data_pages_slug ON multi_dim_data_pages
+        `)
+        await queryRunner.query(`-- sql
+            ALTER TABLE multi_dim_data_pages
+            DROP COLUMN id,
+            DROP COLUMN configMd5,
+            ADD PRIMARY KEY (slug)
+        `)
+    }
+}

--- a/db/migration/1729600015045-AddMultiDimIdConfigMd5SlugIndex.ts
+++ b/db/migration/1729600015045-AddMultiDimIdConfigMd5SlugIndex.ts
@@ -7,7 +7,7 @@ export class AddMultiDimIdConfigMd5SlugIndex1729600015045
         await queryRunner.query(`-- sql
             ALTER TABLE multi_dim_data_pages
             DROP PRIMARY KEY,
-            ADD COLUMN id SERIAL PRIMARY KEY FIRST,
+            ADD COLUMN id INT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY FIRST,
             ADD COLUMN configMd5 CHAR(24) GENERATED ALWAYS as (to_base64(unhex(md5(config)))) STORED NOT NULL AFTER config
         `)
         await queryRunner.query(`-- sql

--- a/db/migration/1729684787090-CreateMultiDimXChartConfigs.ts
+++ b/db/migration/1729684787090-CreateMultiDimXChartConfigs.ts
@@ -1,0 +1,28 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class CreateMultiDimXChartConfigs1729684787090
+    implements MigrationInterface
+{
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`-- sql
+            CREATE TABLE multi_dim_x_chart_configs (
+                id SERIAL PRIMARY KEY,
+                multiDimId BIGINT UNSIGNED NOT NULL,
+                variableId INT NOT NULL,
+                chartConfigId CHAR(36) NOT NULL UNIQUE,
+                createdAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                updatedAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                UNIQUE KEY (multiDimId, variableId),
+                CONSTRAINT fk_multi_dim_x_chart_configs_multi_dim_id FOREIGN KEY (multiDimId) REFERENCES multi_dim_data_pages(id),
+                CONSTRAINT fk_multi_dim_x_chart_configs_variable_id FOREIGN KEY (variableId) REFERENCES variables(id),
+                CONSTRAINT fk_multi_dim_x_chart_configs_chart_id FOREIGN KEY (chartConfigId) REFERENCES chart_configs(id)
+            )
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`-- sql
+            DROP TABLE multi_dim_x_chart_configs
+        `)
+    }
+}

--- a/db/migration/1729684787090-CreateMultiDimXChartConfigs.ts
+++ b/db/migration/1729684787090-CreateMultiDimXChartConfigs.ts
@@ -6,8 +6,8 @@ export class CreateMultiDimXChartConfigs1729684787090
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`-- sql
             CREATE TABLE multi_dim_x_chart_configs (
-                id SERIAL PRIMARY KEY,
-                multiDimId BIGINT UNSIGNED NOT NULL,
+                id INT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+                multiDimId INT UNSIGNED NOT NULL,
                 viewId VARCHAR(255) NOT NULL,
                 variableId INT NOT NULL,
                 chartConfigId CHAR(36) NOT NULL UNIQUE,

--- a/db/migration/1729684787090-CreateMultiDimXChartConfigs.ts
+++ b/db/migration/1729684787090-CreateMultiDimXChartConfigs.ts
@@ -8,14 +8,15 @@ export class CreateMultiDimXChartConfigs1729684787090
             CREATE TABLE multi_dim_x_chart_configs (
                 id SERIAL PRIMARY KEY,
                 multiDimId BIGINT UNSIGNED NOT NULL,
+                viewId VARCHAR(255) NOT NULL,
                 variableId INT NOT NULL,
                 chartConfigId CHAR(36) NOT NULL UNIQUE,
                 createdAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                 updatedAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-                UNIQUE KEY (multiDimId, variableId),
+                UNIQUE KEY (multiDimId, viewId),
                 CONSTRAINT fk_multi_dim_x_chart_configs_multi_dim_id FOREIGN KEY (multiDimId) REFERENCES multi_dim_data_pages(id),
                 CONSTRAINT fk_multi_dim_x_chart_configs_variable_id FOREIGN KEY (variableId) REFERENCES variables(id),
-                CONSTRAINT fk_multi_dim_x_chart_configs_chart_id FOREIGN KEY (chartConfigId) REFERENCES chart_configs(id)
+                CONSTRAINT fk_multi_dim_x_chart_configs_chart_config_id FOREIGN KEY (chartConfigId) REFERENCES chart_configs(id)
             )
         `)
     }

--- a/db/model/MultiDimDataPage.ts
+++ b/db/model/MultiDimDataPage.ts
@@ -1,9 +1,23 @@
-import { KnexReadonlyTransaction } from "../db.js"
+import { KnexReadonlyTransaction, KnexReadWriteTransaction } from "../db.js"
 import {
     MultiDimDataPagesTableName,
+    DbInsertMultiDimDataPage,
     DbPlainMultiDimDataPage,
     DbEnrichedMultiDimDataPage,
 } from "@ourworldindata/types"
+
+export async function upsertMultiDimDataPage(
+    knex: KnexReadWriteTransaction,
+    data: DbInsertMultiDimDataPage
+): Promise<number> {
+    const result = await knex<DbInsertMultiDimDataPage>(
+        MultiDimDataPagesTableName
+    )
+        .insert(data)
+        .onConflict()
+        .merge()
+    return result[0]
+}
 
 const createOnlyPublishedFilter = (
     onlyPublished: boolean

--- a/db/model/MultiDimDataPage.ts
+++ b/db/model/MultiDimDataPage.ts
@@ -6,7 +6,10 @@ import {
     DbEnrichedMultiDimDataPage,
 } from "@ourworldindata/types"
 
-/** Returns ID of the upserted row or zero, if there are no updates. */
+/**
+ * Returns zero if none of the inserted columns differs from the existing ones,
+ * ID of the upserted row otherwise.
+ */
 export async function upsertMultiDimDataPage(
     knex: KnexReadWriteTransaction,
     data: DbInsertMultiDimDataPage

--- a/db/model/MultiDimDataPage.ts
+++ b/db/model/MultiDimDataPage.ts
@@ -6,6 +6,7 @@ import {
     DbEnrichedMultiDimDataPage,
 } from "@ourworldindata/types"
 
+/** Returns ID of the upserted row or zero, if there are no updates. */
 export async function upsertMultiDimDataPage(
     knex: KnexReadWriteTransaction,
     data: DbInsertMultiDimDataPage

--- a/db/model/MultiDimXChartConfigs.ts
+++ b/db/model/MultiDimXChartConfigs.ts
@@ -1,0 +1,18 @@
+import {
+    DbInsertMultiDimXChartConfig,
+    MultiDimXChartConfigsTableName,
+} from "@ourworldindata/types"
+import { KnexReadWriteTransaction } from "../db.js"
+
+export async function upsertMultiDimXChartConfigs(
+    knex: KnexReadWriteTransaction,
+    data: DbInsertMultiDimXChartConfig
+): Promise<number> {
+    const result = await knex<DbInsertMultiDimXChartConfig>(
+        MultiDimXChartConfigsTableName
+    )
+        .insert(data)
+        .onConflict()
+        .merge()
+    return result[0]
+}

--- a/devTools/migrateMultiDimConfigs/migrateMultiDimConfigs.ts
+++ b/devTools/migrateMultiDimConfigs/migrateMultiDimConfigs.ts
@@ -2,8 +2,8 @@ import {
     DbPlainMultiDimDataPage,
     MultiDimDataPagesTableName,
 } from "@ourworldindata/types"
-import { knexReadWriteTransaction, TransactionCloseMode } from "../db/db.js"
-import { createMultiDimConfig } from "./multiDim.js"
+import { knexReadWriteTransaction, TransactionCloseMode } from "../../db/db.js"
+import { createMultiDimConfig } from "../../adminSiteServer/multiDim.js"
 
 /**
  * Migrates the old multi-dim config to a normalized format, creates related
@@ -11,9 +11,6 @@ import { createMultiDimConfig } from "./multiDim.js"
  * uploads the full chart config of each view and the multi-dim config to R2.
  *
  * The old config must be valid, otherwise the migration will fail.
- *
- * This isn't an actual DB data migration because of circular dependencies
- * between `adminSiteServer/multiDim` and `db`.
  */
 async function main() {
     await knexReadWriteTransaction(async (knex) => {

--- a/devTools/syncGraphersToR2/syncGraphersToR2.ts
+++ b/devTools/syncGraphersToR2/syncGraphersToR2.ts
@@ -25,12 +25,8 @@ import {
 import { DbRawChartConfig, excludeUndefined } from "@ourworldindata/utils"
 import { chunk } from "lodash"
 import ProgressBar from "progress"
-import {
-    bytesToBase64,
-    HexString,
-    hexToBytes,
-} from "../../serverUtils/serverUtil.js"
-import { R2GrapherConfigDirectory } from "@ourworldindata/types"
+import { bytesToBase64, hexToBytes } from "../../serverUtils/serverUtil.js"
+import { HexString, R2GrapherConfigDirectory } from "@ourworldindata/types"
 
 type HashAndId = Pick<DbRawChartConfig, "fullMd5" | "id">
 

--- a/packages/@ourworldindata/types/src/dbTypes/ChartConfigs.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/ChartConfigs.ts
@@ -1,4 +1,4 @@
-import { JsonString } from "../domainTypes/Various.js"
+import { Base64String, JsonString } from "../domainTypes/Various.js"
 import { GrapherInterface } from "../grapherTypes/GrapherTypes.js"
 
 export const ChartConfigsTableName = "chart_configs"
@@ -6,7 +6,7 @@ export interface DbInsertChartConfig {
     id: string
     patch: JsonString
     full: JsonString
-    fullMd5?: string
+    fullMd5?: Base64String
     slug?: string | null
     createdAt?: Date
     updatedAt?: Date | null

--- a/packages/@ourworldindata/types/src/dbTypes/MultiDimDataPages.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/MultiDimDataPages.ts
@@ -1,20 +1,23 @@
-import { JsonString } from "../domainTypes/Various.js"
-import { MultiDimDataPageConfigRaw } from "../siteTypes/MultiDimDataPage.js"
+import { Base64String, JsonString } from "../domainTypes/Various.js"
+import { MultiDimDataPageConfigEnriched } from "../siteTypes/MultiDimDataPage.js"
 
 export const MultiDimDataPagesTableName = "multi_dim_data_pages"
 export interface DbInsertMultiDimDataPage {
     slug: string
     config: JsonString
-    published: boolean
+    published?: boolean
     createdAt?: Date
     updatedAt?: Date
 }
 
-export type DbPlainMultiDimDataPage = Required<DbInsertMultiDimDataPage>
+export type DbPlainMultiDimDataPage = Required<DbInsertMultiDimDataPage> & {
+    id: number
+    configMd5: Base64String
+}
 
 export type DbEnrichedMultiDimDataPage = Omit<
     DbPlainMultiDimDataPage,
     "config"
 > & {
-    config: MultiDimDataPageConfigRaw
+    config: MultiDimDataPageConfigEnriched
 }

--- a/packages/@ourworldindata/types/src/dbTypes/MultiDimXChartConfigs.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/MultiDimXChartConfigs.ts
@@ -2,8 +2,14 @@ export const MultiDimXChartConfigsTableName = "multi_dim_x_chart_configs"
 
 export type DbInsertMultiDimXChartConfig = {
     multiDimId: number
+    viewId: string
     variableId: number
     chartConfigId: string
     createdAt?: Date
     updatedAt?: Date
 }
+
+export type DbPlainMultiDimXChartConfig =
+    Required<DbInsertMultiDimXChartConfig> & {
+        id: number
+    }

--- a/packages/@ourworldindata/types/src/dbTypes/MultiDimXChartConfigs.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/MultiDimXChartConfigs.ts
@@ -1,0 +1,9 @@
+export const MultiDimXChartConfigsTableName = "multi_dim_x_chart_configs"
+
+export type DbInsertMultiDimXChartConfig = {
+    multiDimId: number
+    variableId: number
+    chartConfigId: string
+    createdAt?: Date
+    updatedAt?: Date
+}

--- a/packages/@ourworldindata/types/src/domainTypes/Various.ts
+++ b/packages/@ourworldindata/types/src/domainTypes/Various.ts
@@ -1,8 +1,12 @@
+import { Nominal } from "../NominalType"
+
 export type Integer = number
 
 export type OwidVariableId = Integer // remove.
 
 export type JsonString = string
+export type Base64String = Nominal<string, "Base64">
+export type HexString = Nominal<string, "Hex">
 
 /**
  * Pageview information about a single URL

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -526,6 +526,7 @@ export {
 } from "./dbTypes/MultiDimDataPages.js"
 export {
     type DbInsertMultiDimXChartConfig,
+    type DbPlainMultiDimXChartConfig,
     MultiDimXChartConfigsTableName,
 } from "./dbTypes/MultiDimXChartConfigs.js"
 export {

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -7,9 +7,12 @@ export {
 } from "./DonationTypes.js"
 
 export {
+    type Base64String,
     type GitCommit,
+    type HexString,
     type Integer,
     JsonError,
+    type JsonString,
     type SerializedGridProgram,
     SiteFooterContext,
     TaggableType,
@@ -522,6 +525,10 @@ export {
     MultiDimDataPagesTableName,
 } from "./dbTypes/MultiDimDataPages.js"
 export {
+    type DbInsertMultiDimXChartConfig,
+    MultiDimXChartConfigsTableName,
+} from "./dbTypes/MultiDimXChartConfigs.js"
+export {
     type DbPlainNamespace,
     type DbInsertNamespace,
     NamespacesTableName,
@@ -671,6 +678,7 @@ export {
 export type {
     IndicatorEntryBeforePreProcessing,
     IndicatorsAfterPreProcessing,
+    MultiDimDataPageConfigEnriched,
     MultiDimDataPageConfigPreProcessed,
     MultiDimDataPageConfigRaw,
     MultiDimDataPageProps,
@@ -680,4 +688,5 @@ export type {
     DimensionEnriched,
     MultiDimDimensionChoices,
     View,
+    ViewEnriched,
 } from "./siteTypes/MultiDimDataPage.js"

--- a/packages/@ourworldindata/types/src/siteTypes/MultiDimDataPage.ts
+++ b/packages/@ourworldindata/types/src/siteTypes/MultiDimDataPage.ts
@@ -7,8 +7,8 @@ import {
 } from "../OwidVariable.js"
 
 // Indicator ID, catalog path, or maybe an array of those
-export type IndicatorEntryBeforePreProcessing = string | number | undefined
-export type IndicatorEntryAfterPreProcessing = number | undefined // catalog paths have been resolved to indicator IDs
+export type IndicatorEntryBeforePreProcessing = string | number
+export type IndicatorEntryAfterPreProcessing = number // catalog paths have been resolved to indicator IDs
 
 type Metadata = Omit<OwidVariableWithSource, "id">
 
@@ -29,6 +29,13 @@ export type MultiDimDataPageConfigRaw =
 
 export type MultiDimDataPageConfigPreProcessed =
     MultiDimDataPageConfigType<IndicatorsAfterPreProcessing>
+
+export type MultiDimDataPageConfigEnriched = Omit<
+    MultiDimDataPageConfigPreProcessed,
+    "views"
+> & {
+    views: ViewEnriched[]
+}
 
 export interface Dimension {
     slug: string
@@ -74,6 +81,11 @@ export interface View<IndicatorsType extends Record<string, any>> {
     config?: GrapherInterface
     metadata?: Metadata
 }
+
+export interface ViewEnriched extends View<IndicatorsAfterPreProcessing> {
+    fullConfigId: string
+}
+
 export type MultiDimDimensionChoices = Record<string, string> // Keys: dimension slugs, values: choice slugs
 
 export type FaqEntryKeyedByGdocIdAndFragmentId = {
@@ -81,11 +93,10 @@ export type FaqEntryKeyedByGdocIdAndFragmentId = {
 }
 
 export interface MultiDimDataPageProps {
-    configObj: MultiDimDataPageConfigPreProcessed
+    configObj: MultiDimDataPageConfigEnriched
     tagToSlugMap?: Record<string, string>
     faqEntries?: FaqEntryKeyedByGdocIdAndFragmentId
     primaryTopic?: PrimaryTopic | undefined
-    variableIdToGrapherConfigMap?: Record<number, string | null>
 
     initialQueryStr?: string
     canonicalUrl?: string

--- a/packages/@ourworldindata/types/src/siteTypes/MultiDimDataPage.ts
+++ b/packages/@ourworldindata/types/src/siteTypes/MultiDimDataPage.ts
@@ -15,6 +15,7 @@ type Metadata = Omit<OwidVariableWithSource, "id">
 interface MultiDimDataPageConfigType<
     IndicatorType extends Record<string, any>,
 > {
+    grapherConfigSchema?: string
     title: IndicatorTitleWithFragments
     defaultSelection?: string[]
     topicTags?: string[]

--- a/packages/@ourworldindata/utils/package.json
+++ b/packages/@ourworldindata/utils/package.json
@@ -28,7 +28,8 @@
     "striptags": "^3.2.0",
     "timezone-mock": "^1.0.18",
     "ts-pattern": "^5.0.5",
-    "url-parse": "^1.5.10"
+    "url-parse": "^1.5.10",
+    "uuidv7": "^1.0.1"
   },
   "devDependencies": {
     "@types/d3": "^6",

--- a/packages/@ourworldindata/utils/src/MultiDimDataPageConfig.test.ts
+++ b/packages/@ourworldindata/utils/src/MultiDimDataPageConfig.test.ts
@@ -1,6 +1,8 @@
 #! /usr/bin/env jest
 
-import { MultiDimDataPageConfigPreProcessed } from "@ourworldindata/types"
+import { uuidv7 } from "uuidv7"
+
+import { MultiDimDataPageConfigEnriched } from "@ourworldindata/types"
 import { MultiDimDataPageConfig } from "./MultiDimDataPageConfig.js"
 
 it("fromObject", () => {
@@ -8,7 +10,7 @@ it("fromObject", () => {
     expect(config.config.title).toBe("Test")
 })
 
-const CONFIG: MultiDimDataPageConfigPreProcessed = {
+const CONFIG: MultiDimDataPageConfigEnriched = {
     title: {
         title: "Anything goes",
     },
@@ -51,6 +53,7 @@ const CONFIG: MultiDimDataPageConfigPreProcessed = {
             indicators: {
                 y: [111, 222],
             },
+            fullConfigId: uuidv7(),
         },
         {
             dimensions: {
@@ -60,6 +63,7 @@ const CONFIG: MultiDimDataPageConfigPreProcessed = {
             indicators: {
                 y: [819727],
             },
+            fullConfigId: uuidv7(),
         },
     ],
 }

--- a/packages/@ourworldindata/utils/src/MultiDimDataPageConfig.ts
+++ b/packages/@ourworldindata/utils/src/MultiDimDataPageConfig.ts
@@ -3,12 +3,13 @@ import {
     ChoicesEnriched,
     DimensionEnriched,
     IndicatorsAfterPreProcessing,
-    MultiDimDataPageConfigPreProcessed,
     MultiDimDimensionChoices,
     View,
+    ViewEnriched,
     QueryParams,
     OwidChartDimensionInterface,
     DimensionProperty,
+    MultiDimDataPageConfigEnriched,
 } from "@ourworldindata/types"
 import { groupBy, keyBy, pick } from "./Util.js"
 import { Url } from "./urls/Url.js"
@@ -20,7 +21,7 @@ interface FilterToAvailableResult {
 
 export class MultiDimDataPageConfig {
     private constructor(
-        public readonly config: MultiDimDataPageConfigPreProcessed
+        public readonly config: MultiDimDataPageConfigEnriched
     ) {}
 
     static fromJson(jsonString: string): MultiDimDataPageConfig {
@@ -28,7 +29,7 @@ export class MultiDimDataPageConfig {
     }
 
     static fromObject(
-        obj: MultiDimDataPageConfigPreProcessed
+        obj: MultiDimDataPageConfigEnriched
     ): MultiDimDataPageConfig {
         return new MultiDimDataPageConfig(obj)
     }
@@ -55,7 +56,7 @@ export class MultiDimDataPageConfig {
 
     filterViewsByDimensions(
         dimensions: MultiDimDimensionChoices
-    ): View<IndicatorsAfterPreProcessing>[] {
+    ): ViewEnriched[] {
         return this.config.views.filter((view) => {
             for (const [dimensionSlug, choiceSlug] of Object.entries(
                 dimensions
@@ -70,7 +71,7 @@ export class MultiDimDataPageConfig {
     // if more than one matching views were found
     findViewByDimensions(
         dimensions: MultiDimDimensionChoices
-    ): View<IndicatorsAfterPreProcessing> | undefined {
+    ): ViewEnriched | undefined {
         const matchingViews = this.filterViewsByDimensions(dimensions)
         if (matchingViews.length === 0) return undefined
         if (matchingViews.length > 1) {

--- a/serverUtils/serverUtil.tsx
+++ b/serverUtils/serverUtil.tsx
@@ -1,6 +1,7 @@
 import ReactDOMServer from "react-dom/server.js"
 import * as lodash from "lodash"
-import { JsonError, Nominal } from "@ourworldindata/utils"
+import { JsonError } from "@ourworldindata/utils"
+import { Base64String, HexString } from "@ourworldindata/types"
 
 // Fail-fast integer conversion, for e.g. ids in url params
 export const expectInt = (value: any): number => {
@@ -17,9 +18,6 @@ export const renderToHtmlPage = (element: any) =>
 // Determine if input is suitable for use as a url slug
 export const isValidSlug = (slug: any) =>
     lodash.isString(slug) && slug.length > 1 && slug.match(/^[\w-]+$/)
-
-export type Base64String = Nominal<string, "Base64">
-export type HexString = Nominal<string, "Hex">
 
 export function base64ToBytes(base64: Base64String): Uint8Array {
     return Buffer.from(base64, "base64")

--- a/yarn.lock
+++ b/yarn.lock
@@ -3415,6 +3415,7 @@ __metadata:
     ts-pattern: "npm:^5.0.5"
     typescript: "npm:~5.6.2"
     url-parse: "npm:^1.5.10"
+    uuidv7: "npm:^1.0.1"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
* Add new HTTP API for upserting mdim configs
* Configs are normalized on creation
  * Indicator paths are resolved to variable IDs - this was previously done when baking
  * We create a full chart config for every view by merging config defined in the view with variable config already stored in the DB
  * We add the chart config UUID for each config to the `view` in the multidim config
  * For each view, we create a row in the newly added `multi_dim_x_chart_configs` table, to track the relationships between multidim views and chart configs  
* To migrate the existing configs, we have to run the `devTools/migrateMultiDimConfigs/migrateMultiDimConfigs.ts` script with:

  ```
  yarn tsx --tsconfig tsconfig.tsx.json devTools/migrateMultiDimConfigs/migrateMultiDimConfigs.ts
  ```

  The existing config must be valid for the migration to pass.
* Use the new chart configs in the multidim data page

In follow-up PRs, we'll:
* Update mdim config and related view chart configs when indicator configs are updated in admin/ETL
* Trigger baking of existing mdim page when its config or config it depends on gets updated
* Enable embedding of mdim views, making use of the new full chart configs and mdim configs stored in R2