### PR TITLE
🐛 (explorer) merge configs correctly

### DIFF
--- a/baker/siteRenderers.tsx
+++ b/baker/siteRenderers.tsx
@@ -826,12 +826,12 @@ const getExplorerTitleByUrl = async (
     if (url.queryStr) {
         explorer.initDecisionMatrix(url.queryParams as ExplorerFullQueryParams)
         return (
-            explorer.grapherConfig.title ??
-            (explorer.grapherConfig.grapherId
+            explorer.explorerGrapherConfig.title ??
+            (explorer.explorerGrapherConfig.grapherId
                 ? (
                       await getEnrichedChartById(
                           knex,
-                          explorer.grapherConfig.grapherId
+                          explorer.explorerGrapherConfig.grapherId
                       )
                   )?.config?.title
                 : undefined)

--- a/explorer/ExplorerProgram.test.ts
+++ b/explorer/ExplorerProgram.test.ts
@@ -108,8 +108,8 @@ columns\ttable1\ttable2\ttable3
     describe("grapherconfig", () => {
         it("can return a grapher config", () => {
             expect(
-                new ExplorerProgram("test", `yScaleToggle\ttrue`).grapherConfig
-                    .yScaleToggle
+                new ExplorerProgram("test", `yScaleToggle\ttrue`)
+                    .explorerGrapherConfig.yScaleToggle
             ).toEqual(true)
             const program = new ExplorerProgram(
                 "test",
@@ -118,7 +118,7 @@ columns\ttable1\ttable2\ttable3
 \ttrue\tLine`
             )
             expect(program.currentlySelectedGrapherRow).toEqual(2)
-            expect(program.grapherConfig.yScaleToggle).toEqual(true)
+            expect(program.explorerGrapherConfig.yScaleToggle).toEqual(true)
         })
 
         it("can convert \\n to a newline", () => {
@@ -128,7 +128,7 @@ columns\ttable1\ttable2\ttable3
 \tsubtitle\tLine Checkbox
 \tThis is a\\ntwo-line subtitle\tLine`
             )
-            expect(program.grapherConfig.subtitle).toEqual(
+            expect(program.explorerGrapherConfig.subtitle).toEqual(
                 "This is a\ntwo-line subtitle"
             )
         })
@@ -142,9 +142,24 @@ graphers
 \tyScaleToggle\tLine Checkbox
 \ttrue\tLine`
             )
-            expect(program.grapherConfig.hasMapTab).toEqual(true)
+            expect(program.explorerGrapherConfig.hasMapTab).toEqual(true)
             // Only parse white listed grapher props
-            expect((program.grapherConfig as any).table).toEqual(undefined)
+            expect((program.explorerGrapherConfig as any).table).toEqual(
+                undefined
+            )
+        })
+
+        it("can translate explorer-specific settings to valid config fields", () => {
+            const program = new ExplorerProgram(
+                "test",
+                `hasMapTab\ttrue
+table\tfoo
+graphers
+\tyAxisMin\tLine Checkbox
+\t1\tLine`
+            )
+            expect(program.explorerGrapherConfig.yAxisMin).toEqual(1)
+            expect(program.grapherConfig.yAxis?.min).toEqual(1)
         })
     })
 

--- a/explorer/GrapherGrammar.ts
+++ b/explorer/GrapherGrammar.ts
@@ -22,6 +22,7 @@ import {
     UrlCellDef,
     IndicatorIdsOrEtlPathsCellDef,
     IndicatorIdOrEtlPathCellDef,
+    GrapherCellDef,
 } from "../gridLang/GridLangConstants.js"
 
 const toTerminalOptions = (keywords: string[]): CellDef[] => {
@@ -32,103 +33,121 @@ const toTerminalOptions = (keywords: string[]): CellDef[] => {
     }))
 }
 
-export const GrapherGrammar: Grammar = {
+export const GrapherGrammar: Grammar<GrapherCellDef> = {
     title: {
         ...StringCellDef,
         keyword: "title",
         description: "Chart title",
         valuePlaceholder: "Life Expectancy around the world.",
+        toGrapherObject: (value) => ({ title: value }),
     },
     subtitle: {
         ...StringCellDef,
         keyword: "subtitle",
         description: "Chart subtitle",
         valuePlaceholder: "Life Expectancy has risen over time.",
+        toGrapherObject: (value) => ({ subtitle: value }),
     },
     ySlugs: {
         ...SlugsDeclarationCellDef,
         description: "ColumnSlug(s) for the yAxis",
         keyword: "ySlugs",
+        toGrapherObject: (value) => ({ ySlugs: value }),
     },
     yVariableIds: {
         ...IndicatorIdsOrEtlPathsCellDef,
         keyword: "yVariableIds",
         description: "Variable ID(s) or ETL path(s) for the yAxis",
+        toGrapherObject: () => ({}), // explorer-specific, not used in grapher config
     },
     type: {
         ...StringCellDef,
         keyword: "type",
         description: `The type of chart to show such as LineChart or ScatterPlot.`,
         terminalOptions: toTerminalOptions(Object.values(ChartTypeName)),
+        toGrapherObject: (value) => ({ type: value }),
     },
     grapherId: {
         ...IntegerCellDef,
         description: "ID of a legacy Grapher to load",
         keyword: "grapherId",
+        toGrapherObject: (value) => ({ id: value }),
     },
     tableSlug: {
         ...SlugDeclarationCellDef,
         description:
             "Slug of the explorer table (i.e. csv file) to use for this row. All variables used in this row must be present in the table/file.",
         keyword: "tableSlug",
+        toGrapherObject: () => ({}), // explorer-specific, not used in grapher config
     },
     hasMapTab: {
         ...BooleanCellDef,
         keyword: "hasMapTab",
         description: "Show the map tab?",
+        toGrapherObject: (value) => ({ hasMapTab: value }),
     },
     tab: {
         ...EnumCellDef,
         keyword: "tab",
         description: "Which tab to show by default",
         terminalOptions: toTerminalOptions(Object.values(GrapherTabOption)),
+        toGrapherObject: (value) => ({ tab: value }),
     },
     hasChartTab: {
         ...BooleanCellDef,
         keyword: "hasChartTab",
         description: "Show the chart tab?",
+        toGrapherObject: (value) => ({ hasChartTab: value }),
     },
     xSlug: {
         ...SlugDeclarationCellDef,
         description: "ColumnSlug for the xAxis",
         keyword: "xSlug",
+        toGrapherObject: (value) => ({ xSlug: value }),
     },
     xVariableId: {
         ...IndicatorIdOrEtlPathCellDef,
         keyword: "xVariableId",
         description: "Variable ID or ETL path for the xAxis",
+        toGrapherObject: () => ({}), // explorer-specific, not used in grapher config
     },
     colorSlug: {
         ...SlugDeclarationCellDef,
         description: "ColumnSlug for the color",
         keyword: "colorSlug",
+        toGrapherObject: (value) => ({ colorSlug: value }),
     },
     colorVariableId: {
         ...IndicatorIdOrEtlPathCellDef,
         keyword: "colorVariableId",
         description: "Variable ID or ETL path for the color",
+        toGrapherObject: () => ({}), // explorer-specific, not used in grapher config
     },
     sizeSlug: {
         ...SlugDeclarationCellDef,
         description: "ColumnSlug for the size of points on scatters",
         keyword: "sizeSlug",
+        toGrapherObject: (value) => ({ sizeSlug: value }),
     },
     sizeVariableId: {
         ...IndicatorIdOrEtlPathCellDef,
         keyword: "sizeVariableId",
         description:
             "Variable ID or ETL path for the size of points on scatters",
+        toGrapherObject: () => ({}), // explorer-specific, not used in grapher config
     },
     tableSlugs: {
         ...SlugsDeclarationCellDef,
         description:
             "Columns to show in the Table tab of the chart. If not specified all active slugs will be used.",
         keyword: "tableSlugs",
+        toGrapherObject: (value) => ({ tableSlugs: value }),
     },
     sourceDesc: {
         ...StringCellDef,
         keyword: "sourceDesc",
         description: "Short comma-separated list of source names",
+        toGrapherObject: (value) => ({ sourceDesc: value }),
     },
     hideAnnotationFieldsInTitle: {
         ...BooleanCellDef,
@@ -142,16 +161,25 @@ export const GrapherGrammar: Grammar = {
                 changeInPrefix: parsedValue,
             }
         },
+        toGrapherObject: (value) => ({
+            hideAnnotationFieldsInTitle: {
+                entity: value,
+                time: value,
+                changeInPrefix: value,
+            },
+        }),
     },
     yScaleToggle: {
         ...BooleanCellDef,
         keyword: "yScaleToggle",
         description: "Set to 'true' if the user can change the yAxis",
+        toGrapherObject: (value) => ({ yAxis: { canChangeScaleType: value } }),
     },
     yAxisMin: {
         ...NumericOrAutoCellDef,
         keyword: "yAxisMin",
         description: "Set the minimum value for the yAxis",
+        toGrapherObject: (value) => ({ yAxis: { min: value } }),
     },
     facetYDomain: {
         ...EnumCellDef,
@@ -159,18 +187,21 @@ export const GrapherGrammar: Grammar = {
         description:
             "Whether facets axes default to shared or independent domain",
         terminalOptions: toTerminalOptions(Object.values(FacetAxisDomain)),
+        toGrapherObject: (value) => ({ yAxis: { facetDomain: value } }),
     },
     selectedFacetStrategy: {
         ...EnumCellDef,
         keyword: "selectedFacetStrategy",
         description: "Whether the chart should be faceted or not",
         terminalOptions: toTerminalOptions(Object.values(FacetStrategy)),
+        toGrapherObject: (value) => ({ selectedFacetStrategy: value }),
     },
     entityType: {
         ...StringCellDef,
         keyword: "entityType",
         description:
             "Default is 'country', but you can specify a different one such as 'state' or 'region'.",
+        toGrapherObject: (value) => ({ entityType: value }),
     },
     baseColorScheme: {
         ...EnumCellDef,
@@ -178,29 +209,34 @@ export const GrapherGrammar: Grammar = {
         description:
             "The default color scheme if no color overrides are specified",
         terminalOptions: toTerminalOptions(Object.keys(ColorSchemeName)),
+        toGrapherObject: (value) => ({ baseColorScheme: value }),
     },
     note: {
         ...StringCellDef,
         keyword: "note",
         description: "Chart footnote",
+        toGrapherObject: (value) => ({ note: value }),
     },
     sortBy: {
         ...EnumCellDef,
         keyword: "sortBy",
         description: "Specify what to sort the entities by",
         terminalOptions: toTerminalOptions(Object.values(SortBy)),
+        toGrapherObject: (value) => ({ sortBy: value }),
     },
     sortOrder: {
         ...EnumCellDef,
         keyword: "sortOrder",
         description: "Whether to sort entities ascending or descending",
         terminalOptions: toTerminalOptions(Object.values(SortOrder)),
+        toGrapherObject: (value) => ({ sortOrder: value }),
     },
     sortColumnSlug: {
         ...SlugDeclarationCellDef,
         keyword: "sortColumnSlug",
         description:
             "This setting is only respected when `sortBy` is set to `column`",
+        toGrapherObject: (value) => ({ sortColumnSlug: value }),
     },
     stackMode: {
         ...EnumCellDef,
@@ -208,51 +244,60 @@ export const GrapherGrammar: Grammar = {
         description:
             "Show chart in absolute (default) or relative mode. Only works for some chart types.",
         terminalOptions: toTerminalOptions(Object.values(StackMode)),
+        toGrapherObject: (value) => ({ stackMode: value }),
     },
     hideTotalValueLabel: {
         ...BooleanCellDef,
         keyword: "hideTotalValueLabel",
         description:
             "Hide the total value that is normally displayed to the right of the bars in a stacked bar chart.",
+        toGrapherObject: (value) => ({ hideTotalValueLabel: value }),
     },
     hideRelativeToggle: {
         ...BooleanCellDef,
         keyword: "hideRelativeToggle",
         description: "Whether to hide the relative mode UI toggle",
+        toGrapherObject: (value) => ({ hideRelativeToggle: value }),
     },
     timelineMinTime: {
         ...IntegerCellDef,
         keyword: "timelineMinTime",
         description:
             "Set the minimum time for the timeline. For days, use days since 21 Jan 2020, e.g. 24 Jan 2020 is '3'.",
+        toGrapherObject: (value) => ({ timelineMinTime: value }),
     },
     timelineMaxTime: {
         ...IntegerCellDef,
         keyword: "timelineMaxTime",
         description:
             "Set the maximum time for the timeline. For days, use days since 21 Jan 2020, e.g. 24 Jan 2020 is '3'.",
+        toGrapherObject: (value) => ({ timelineMaxTime: value }),
     },
     defaultView: {
         ...BooleanCellDef,
         keyword: "defaultView",
         description: "Whether this view is used as the default view.",
+        toGrapherObject: () => ({}), // explorer-specific, not used in grapher config
     },
     relatedQuestionText: {
         ...StringCellDef,
         keyword: "relatedQuestionText",
         description:
             "The text used for the related question (at the very bottom of the chart)",
+        toGrapherObject: () => ({}), // handled in code (can be done properly once the relatedQuestion field is refactored)
     },
     relatedQuestionUrl: {
         ...UrlCellDef,
         keyword: "relatedQuestionUrl",
         description: "The link of the related question text",
+        toGrapherObject: () => ({}), // handled in code (can be done properly once the relatedQuestion field is refactored)
     },
     mapTargetTime: {
         ...IntegerCellDef,
         keyword: "mapTargetTime",
         description:
             "Set the 'target time' for the map chart. This is the year that will be shown by default in the map chart.",
+        toGrapherObject: (value) => ({ map: { time: value } }),
     },
     missingDataStrategy: {
         ...EnumCellDef,
@@ -260,15 +305,18 @@ export const GrapherGrammar: Grammar = {
         description:
             "Hide or show entities for which one or more variables are missing",
         terminalOptions: toTerminalOptions(Object.values(MissingDataStrategy)),
+        toGrapherObject: (value) => ({ missingDataStrategy: value }),
     },
     minTime: {
         ...IntegerCellDef,
         keyword: "minTime",
         description: "Start point of the initially selected time span",
+        toGrapherObject: (value) => ({ minTime: value }),
     },
     maxTime: {
         ...IntegerCellDef,
         keyword: "maxTime",
         description: "End point of the initially selected time span",
+        toGrapherObject: (value) => ({ maxTime: value }),
     },
 } as const

--- a/gridLang/GridLangConstants.ts
+++ b/gridLang/GridLangConstants.ts
@@ -1,3 +1,5 @@
+import { GrapherInterface } from "@ourworldindata/types"
+
 export const CellHasErrorsClass = "CellHasErrorsClass"
 
 export enum GridBoolean {
@@ -11,7 +13,9 @@ export const GRID_EDGE_DELIMITER = "\t"
 
 export type CellCoordinate = number // An integer >= 0
 
-export type Grammar = { [keywordSlug: string]: CellDef }
+export type Grammar<TCellDef extends CellDef = CellDef> = {
+    [keywordSlug: string]: TCellDef
+}
 
 // A CellDef is a tuple: part keyword and the other half is the contents. The contents can be 1 cell, a list of cells, and/or a subtable.
 export interface CellDef {
@@ -28,6 +32,10 @@ export interface CellDef {
     positionalCellDefs?: readonly CellDef[] // Additional cell types as positional arguments.
     isHorizontalList?: boolean // a list type, such as "colors\tred\torange\tgreen"
     parse?: (value: any) => any
+}
+
+export interface GrapherCellDef extends CellDef {
+    toGrapherObject: (value: any) => GrapherInterface // map to a partial config that is a valid GrapherInterface
 }
 
 export interface ParsedCell {

--- a/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
+++ b/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
@@ -592,6 +592,7 @@ export interface GrapherInterface extends SortConfig {
     xSlug?: ColumnSlug
     sizeSlug?: ColumnSlug
     colorSlug?: ColumnSlug
+    tableSlugs?: ColumnSlugs
 }
 
 export interface LegacyGrapherInterface extends GrapherInterface {


### PR DESCRIPTION
## Problem

Explorers incorrectly merge (partial) Grapher configs with explorer-level Grapher settings.

We naively merge configs like this

```js
{
   ...partialGrapherConfig,
   ...explorerProgram.grapherConfigOnlyGrapherProps
}
```

where `partialGrapherConfig` is the indicator config (of type `GrapherInterface`), but `explorerProgram.grapherConfigOnlyGrapherProps` is of type `ExplorerGrapherInterface` that includes explorer-flavoured flat config fields, like `yAxisMin`. Overwriting the y-axis min of the partial Grapher config, which is given as `yAxis.min`, thus won't work.

## Bug

I don't know of an example in the wild where this currently leads to a problem, but you can fabricate a bug locally by following these steps:

Set `yAxis.min` of an indicator that is used in the conflict explorer by running

```sql
update chart_configs cc
join variables v on cc.id = v.grapherConfigIdETL
set
  cc.patch = JSON_MERGE_PATCH(cc.patch, '{"yAxis":{"min": 1}}'),
  cc.full = JSON_MERGE_PATCH(cc.full, '{"yAxis":{"min": 1}}')
where v.id = 985431
```
against your local database.

Navigate to [this view](http://localhost:3030/explorers/conflict-data?Conflict+type=Intrastate+conflicts&Measure=Conflict+deaths&Conflict+sub-type=All+sub-types&Data+source=Uppsala+Conflict+Data+Program&Sub-measure=Regional+data&country=~OWID_WRL) of the conflict explorer. Note that
```js
// the partial grapher config sets y-axis min to 1
explorer.partialGrapherConfigsByVariableId.get(985431).yAxis.min // = 1

// the explorer overwrites this by setting yAxis.min to 0
explorer.explorerProgram.grapherConfig.yAxisMin // = 0

// the y-axis min being used in Grapher is 1, but should be 0
// i.e. the explorer settings didn't successfully overwrite the indicator settings
grapher.yAxis.min // = 1, but should be 0
```

I ran the same query against the database on staging. You'll see that on staging Grapher's y-axis min is correctly set to 0 ([staging](http://staging-site-fix-explorer-config-merge/explorers/conflict-data?Conflict+type=Intrastate+conflicts&Measure=Conflict+deaths&Conflict+sub-type=All+sub-types&Data+source=Uppsala+Conflict+Data+Program&Sub-measure=Regional+data&country=~OWID_WRL)).

## Solution

Before the explorer's Grapher config gets merged with the partial config, we translate explorer-specific fields to valid GrapherInterface fields, e.g. `yAxisMin` is translated to `{ yAxis: { min: ... } }`. This is defined by the `toGrapherObject` function of an explorer cell definition.

The `toGrapherObject` function is conceptually similar to the `parse` function. Alternatively, I could have reworked the `parse` function so that the given key/value pair is always parsed as a valid GrapherInterface object. Maybe that would have been the cleaner solution? I'm not sure. In the end, I went with the `toGrapherObject` function because I thought it would be useful to keep both Grapher row representations around:
- `explorerGrapherConfig`: explorer-flavoured settings that directly map to a Grapher row
- `grapherConfig`: corresponding chart config that is guaranteed to be a valid GrapherInterface

## Testing

Since I don't know of any bugs in the wild (doesn't mean they don't exist though), these changes should not result in any visual changes.