### PR TITLE
✨ (explorer) allow to pass "auto" as yAxisMin

### DIFF
--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -9,6 +9,7 @@ import {
     GrapherInterface,
     GrapherQueryParams,
     GrapherTabOption,
+    AxisMinMaxValueStr,
 } from "@ourworldindata/types"
 import {
     OwidTable,
@@ -459,7 +460,8 @@ export class Explorer
         } = this.explorerProgram.grapherConfig
 
         grapher.yAxis.canChangeScaleType = yScaleToggle
-        grapher.yAxis.min = yAxisMin
+        grapher.yAxis.min =
+            yAxisMin === AxisMinMaxValueStr.auto ? Infinity : yAxisMin
         if (facetYDomain) {
             grapher.yAxis.facetDomain = facetYDomain
         }

--- a/explorer/ExplorerProgram.ts
+++ b/explorer/ExplorerProgram.ts
@@ -7,6 +7,7 @@ import {
     SubNavId,
     FacetAxisDomain,
     GrapherInterface,
+    AxisMinMaxValueStr,
 } from "@ourworldindata/types"
 import {
     CoreTable,
@@ -56,7 +57,7 @@ interface ExplorerGrapherInterface extends GrapherInterface {
     colorVariableId?: string
     sizeVariableId?: string
     yScaleToggle?: boolean
-    yAxisMin?: number
+    yAxisMin?: number | AxisMinMaxValueStr.auto
     facetYDomain?: FacetAxisDomain
     relatedQuestionText?: string
     relatedQuestionUrl?: string

--- a/explorer/GrapherGrammar.ts
+++ b/explorer/GrapherGrammar.ts
@@ -15,7 +15,7 @@ import {
     EnumCellDef,
     Grammar,
     IntegerCellDef,
-    NumericCellDef,
+    NumericOrAutoCellDef,
     SlugDeclarationCellDef,
     SlugsDeclarationCellDef,
     StringCellDef,
@@ -149,7 +149,7 @@ export const GrapherGrammar: Grammar = {
         description: "Set to 'true' if the user can change the yAxis",
     },
     yAxisMin: {
-        ...NumericCellDef,
+        ...NumericOrAutoCellDef,
         keyword: "yAxisMin",
         description: "Set the minimum value for the yAxis",
     },

--- a/gridLang/GridLangConstants.ts
+++ b/gridLang/GridLangConstants.ts
@@ -96,6 +96,19 @@ export const NumericCellDef: CellDef = {
     parse: (value: any) => parseFloat(value),
 }
 
+export const NumericOrAutoCellDef: CellDef = {
+    keyword: "",
+    cssClass: "NumericCellDef",
+    description: "",
+    regex: /^(-?\d+\.?\d*|auto)$/,
+    requirementsDescription: `Must be a number or "auto"`,
+    valuePlaceholder: "98.6",
+    parse: (value: any) => {
+        if (value === "auto") return "auto"
+        return parseFloat(value)
+    },
+}
+
 export const IntegerCellDef: CellDef = {
     keyword: "",
     cssClass: "IntegerCellDef",


### PR DESCRIPTION
Allow explorer configs to pass `auto` to `yAxisMin`.

This hasn't been necessary because the default behaviour used to be `auto`, but we'll soon be switching line charts to use 0 as the default value, and then we'll need a way to overwrite that in explorers.