### PR TITLE
🔨 remove default layer from chart configs / TAS-675

### DIFF
--- a/adminSiteClient/AbstractChartEditor.ts
+++ b/adminSiteClient/AbstractChartEditor.ts
@@ -80,9 +80,19 @@ export abstract class AbstractChartEditor<
         return mergeGrapherConfigs(parentConfig ?? {}, patchConfig)
     }
 
-    /** live-updating full config */
+    /** live-updating config */
+    @computed get liveConfig(): GrapherInterface {
+        return this.grapher.object
+    }
+
+    @computed get liveConfigWithDefaults(): GrapherInterface {
+        return mergeGrapherConfigs(defaultGrapherConfig, this.liveConfig)
+    }
+
+    /** patch config merged with parent config */
     @computed get fullConfig(): GrapherInterface {
-        return mergeGrapherConfigs(defaultGrapherConfig, this.grapher.object)
+        if (!this.activeParentConfig) return this.liveConfig
+        return mergeGrapherConfigs(this.activeParentConfig, this.liveConfig)
     }
 
     /** parent config currently applied to grapher */
@@ -103,7 +113,7 @@ export abstract class AbstractChartEditor<
     /** patch config of the chart that is written to the db on save */
     @computed get patchConfig(): GrapherInterface {
         return diffGrapherConfigs(
-            this.fullConfig,
+            this.liveConfigWithDefaults,
             this.activeParentConfigWithDefaults ?? defaultGrapherConfig
         )
     }

--- a/adminSiteClient/ChartEditor.ts
+++ b/adminSiteClient/ChartEditor.ts
@@ -75,7 +75,7 @@ export class ChartEditor extends AbstractChartEditor<ChartEditorManager> {
 
     /** parent variable id, derived from the config */
     @computed get parentVariableId(): number | undefined {
-        return getParentVariableIdFromChartConfig(this.fullConfig)
+        return getParentVariableIdFromChartConfig(this.liveConfig)
     }
 
     @computed get availableTabs(): EditorTab[] {

--- a/adminSiteClient/IndicatorChartEditorPage.tsx
+++ b/adminSiteClient/IndicatorChartEditorPage.tsx
@@ -11,7 +11,7 @@ import {
     IndicatorChartEditorManager,
     type Chart,
 } from "./IndicatorChartEditor.js"
-import { defaultGrapherConfig } from "@ourworldindata/grapher"
+import { latestGrapherConfigSchema } from "@ourworldindata/grapher"
 
 @observer
 export class IndicatorChartEditorPage
@@ -40,7 +40,7 @@ export class IndicatorChartEditorPage
         )
         if (isEmpty(config)) {
             this.patchConfig = {
-                $schema: defaultGrapherConfig.$schema,
+                $schema: latestGrapherConfigSchema,
                 dimensions: [{ variableId, property: DimensionProperty.y }],
             }
             this.isNewGrapher = true

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -109,7 +109,6 @@ import {
 } from "@ourworldindata/types"
 import { uuidv7 } from "uuidv7"
 import {
-    defaultGrapherConfig,
     migrateGrapherConfigToLatestVersion,
     getVariableDataRoute,
     getVariableMetadataRoute,
@@ -328,14 +327,10 @@ const saveNewChart = async (
     const parent = shouldInherit
         ? await getParentByChartConfig(knex, config)
         : undefined
-    const fullParentConfig = mergeGrapherConfigs(
-        defaultGrapherConfig,
-        parent?.config ?? {}
-    )
 
     // compute patch and full configs
-    const patchConfig = diffGrapherConfigs(config, fullParentConfig)
-    const fullConfig = mergeGrapherConfigs(fullParentConfig, patchConfig)
+    const patchConfig = diffGrapherConfigs(config, parent?.config ?? {})
+    const fullConfig = mergeGrapherConfigs(parent?.config ?? {}, patchConfig)
     const fullConfigStringified = serializeChartConfig(fullConfig)
 
     // insert patch & full configs into the chart_configs table
@@ -424,14 +419,10 @@ const updateExistingChart = async (
     const parent = shouldInherit
         ? await getParentByChartConfig(knex, config)
         : undefined
-    const fullParentConfig = mergeGrapherConfigs(
-        defaultGrapherConfig,
-        parent?.config ?? {}
-    )
 
     // compute patch and full configs
-    const patchConfig = diffGrapherConfigs(config, fullParentConfig)
-    const fullConfig = mergeGrapherConfigs(fullParentConfig, patchConfig)
+    const patchConfig = diffGrapherConfigs(config, parent?.config ?? {})
+    const fullConfig = mergeGrapherConfigs(parent?.config ?? {}, patchConfig)
     const fullConfigStringified = serializeChartConfig(fullConfig)
 
     const chartConfigId = await db.knexRawFirst<Pick<DbPlainChart, "configId">>(

--- a/db/migration/1730455806132-RemoveDefaultConfigLayer.ts
+++ b/db/migration/1730455806132-RemoveDefaultConfigLayer.ts
@@ -1,0 +1,113 @@
+import { defaultGrapherConfig } from "@ourworldindata/grapher"
+import { mergeGrapherConfigs } from "@ourworldindata/utils"
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class RemoveDefaultConfigLayer1730455806132
+    implements MigrationInterface
+{
+    private async recomputeFullChartConfigs(
+        queryRunner: QueryRunner,
+        { useDefaultLayer }: { useDefaultLayer: boolean }
+    ): Promise<void> {
+        const charts = await queryRunner.query(`
+             -- sql
+             SELECT
+                 cc.id AS configId,
+                 cc.patch AS patchConfig,
+                 cc_etl.patch AS etlConfig,
+                 cc_admin.patch AS adminConfig,
+                 c.isInheritanceEnabled
+             FROM charts c
+             JOIN chart_configs cc ON cc.id = c.configId
+             LEFT JOIN charts_x_parents cxp ON cxp.chartId = c.id
+             LEFT JOIN variables v ON v.id = cxp.variableId
+             LEFT JOIN chart_configs cc_etl ON cc_etl.id = v.grapherConfigIdETL
+             LEFT JOIN chart_configs cc_admin ON cc_admin.id = v.grapherConfigIdAdmin
+         `)
+        for (const chart of charts) {
+            const patchConfig = JSON.parse(chart.patchConfig)
+
+            const etlConfig = chart.etlConfig ? JSON.parse(chart.etlConfig) : {}
+            const adminConfig = chart.adminConfig
+                ? JSON.parse(chart.adminConfig)
+                : {}
+
+            const fullConfig = mergeGrapherConfigs(
+                useDefaultLayer ? defaultGrapherConfig : {},
+                chart.isInheritanceEnabled ? etlConfig : {},
+                chart.isInheritanceEnabled ? adminConfig : {},
+                patchConfig
+            )
+
+            await queryRunner.query(
+                `
+                    -- sql
+                    UPDATE chart_configs cc
+                    SET cc.full = ?
+                    WHERE cc.id = ?
+                `,
+                [JSON.stringify(fullConfig), chart.configId]
+            )
+        }
+    }
+
+    private async updateChartsXParentsView(
+        queryRunner: QueryRunner
+    ): Promise<void> {
+        // identical to the current view definition,
+        // but uses `COALESCE(cc.full ->> '$.type', 'LineChart')`
+        // instead of `cc.full ->> '$.type'` since the full config
+        // might not have a type
+        await queryRunner.query(`-- sql
+          ALTER VIEW charts_x_parents AS (
+            WITH y_dimensions AS (
+              SELECT
+                *
+              FROM
+                chart_dimensions
+              WHERE
+                property = 'y'
+            ),
+            single_y_indicator_charts AS (
+              SELECT
+                c.id as chartId,
+                cc.patch as patchConfig,
+                -- should only be one
+                max(yd.variableId) as variableId
+              FROM
+                charts c
+                JOIN chart_configs cc ON cc.id = c.configId
+                JOIN y_dimensions yd ON c.id = yd.chartId
+              WHERE
+                -- scatter plots can't inherit settings
+                COALESCE(cc.full ->> '$.type', 'LineChart') != 'ScatterPlot'
+              GROUP BY
+                c.id
+              HAVING
+                -- restrict to single y-variable charts
+                COUNT(distinct yd.variableId) = 1
+            )
+            SELECT
+              variableId,
+              chartId
+            FROM
+              single_y_indicator_charts
+            ORDER BY
+              variableId
+          )
+        `)
+    }
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await this.recomputeFullChartConfigs(queryRunner, {
+            useDefaultLayer: false,
+        })
+        await this.updateChartsXParentsView(queryRunner)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await this.recomputeFullChartConfigs(queryRunner, {
+            useDefaultLayer: true,
+        })
+    }
+}

--- a/db/model/Chart.ts
+++ b/db/model/Chart.ts
@@ -567,7 +567,7 @@ export const getMostViewedGrapherIdsByChartType = async (
             JOIN chart_configs cc ON slug = SUBSTRING_INDEX(a.url, '/', -1)
             JOIN charts c ON c.configId = cc.id
             WHERE a.url LIKE "https://ourworldindata.org/grapher/%"
-                AND cc.full ->> "$.type" = ?
+                AND COALESCE(cc.full ->> "$.type", 'LineChart') = ?
                 AND cc.full ->> "$.isPublished" = "true"
                 and (cc.full ->> "$.hasChartTab" = "true" or cc.full ->> "$.hasChartTab" is null)
             ORDER BY a.views_365d DESC

--- a/db/model/Variable.ts
+++ b/db/model/Variable.ts
@@ -11,7 +11,6 @@ import {
 import {
     getVariableDataRoute,
     getVariableMetadataRoute,
-    defaultGrapherConfig,
 } from "@ourworldindata/grapher"
 import pl from "nodejs-polars"
 import { uuidv7 } from "uuidv7"
@@ -271,7 +270,6 @@ export async function updateAllChartsThatInheritFromIndicator(
 
     for (const chart of inheritingCharts) {
         const fullConfig = mergeGrapherConfigs(
-            defaultGrapherConfig,
             patchConfigETL ?? {},
             patchConfigAdmin ?? {},
             chart.patchConfig

--- a/devTools/svgTester/dump-data.ts
+++ b/devTools/svgTester/dump-data.ts
@@ -1,8 +1,6 @@
 #! /usr/bin/env node
 
 import { getPublishedGraphersBySlug } from "../../baker/GrapherImageBaker.js"
-import { defaultGrapherConfig } from "@ourworldindata/grapher"
-import { diffGrapherConfigs } from "@ourworldindata/utils"
 
 import { TransactionCloseMode, knexReadonlyTransaction } from "../../db/db.js"
 
@@ -26,11 +24,7 @@ async function main(parsedArgs: parseArgs.ParsedArgs) {
         const allGraphers = [...graphersBySlug.values()]
         const saveJobs: utils.SaveGrapherSchemaAndDataJob[] = allGraphers.map(
             (grapher) => {
-                // since we're not baking defaults, we also exclude them here
-                return {
-                    config: diffGrapherConfigs(grapher, defaultGrapherConfig),
-                    outDir,
-                }
+                return { config: grapher, outDir }
             }
         )
 

--- a/packages/@ourworldindata/explorer/src/ExplorerProgram.ts
+++ b/packages/@ourworldindata/explorer/src/ExplorerProgram.ts
@@ -40,7 +40,7 @@ import {
 import { DecisionMatrix } from "./ExplorerDecisionMatrix.js"
 import { ExplorerGrammar } from "./ExplorerGrammar.js"
 import { GrapherGrammar } from "./GrapherGrammar.js"
-import { defaultGrapherConfig } from "@ourworldindata/grapher"
+import { latestGrapherConfigSchema } from "@ourworldindata/grapher"
 
 export const EXPLORER_FILE_SUFFIX = ".explorer.tsv"
 
@@ -399,7 +399,7 @@ export class ExplorerProgram extends GridProgram {
         const mergedConfig = merge({}, ...partialConfigs)
 
         // assume config is valid against the latest schema
-        mergedConfig.$schema = defaultGrapherConfig.$schema
+        mergedConfig.$schema = latestGrapherConfigSchema
 
         // TODO: can be removed once relatedQuestions is refactored
         const { relatedQuestionUrl, relatedQuestionText } =

--- a/packages/@ourworldindata/grapher/src/core/Grapher.jsdom.test.ts
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.jsdom.test.ts
@@ -1,6 +1,5 @@
 #! /usr/bin/env jest
 import { Grapher, GrapherProgrammaticInterface } from "../core/Grapher"
-import { defaultGrapherConfig } from "../schema/defaultGrapherConfig"
 import {
     ChartTypeName,
     EntitySelectionMode,
@@ -35,6 +34,7 @@ import {
     OwidDistinctColorScheme,
     OwidDistinctLinesColorScheme,
 } from "../color/CustomSchemes"
+import { latestGrapherConfigSchema } from "./GrapherConstants.js"
 
 const TestGrapherConfig = (): {
     table: OwidTable
@@ -77,7 +77,7 @@ it("can get dimension slots", () => {
 
 it("an empty Grapher serializes to an object that includes only the schema", () => {
     expect(new Grapher().toObject()).toEqual({
-        $schema: defaultGrapherConfig.$schema,
+        $schema: latestGrapherConfigSchema,
 
         // TODO: ideally, selectedEntityNames is not serialised for an empty object
         selectedEntityNames: [],
@@ -90,7 +90,7 @@ it("a bad chart type does not crash grapher", () => {
     }
     expect(new Grapher(input).toObject()).toEqual({
         ...input,
-        $schema: defaultGrapherConfig.$schema,
+        $schema: latestGrapherConfigSchema,
 
         // TODO: ideally, selectedEntityNames is not serialised for an empty object
         selectedEntityNames: [],
@@ -99,7 +99,7 @@ it("a bad chart type does not crash grapher", () => {
 
 it("does not preserve defaults in the object (except for the schema)", () => {
     expect(new Grapher({ tab: GrapherTabOption.chart }).toObject()).toEqual({
-        $schema: defaultGrapherConfig.$schema,
+        $schema: latestGrapherConfigSchema,
 
         // TODO: ideally, selectedEntityNames is not serialised for an empty object
         selectedEntityNames: [],

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -132,8 +132,8 @@ import {
     GRAPHER_BACKGROUND_DEFAULT,
     GRAPHER_FRAME_PADDING_HORIZONTAL,
     GRAPHER_FRAME_PADDING_VERTICAL,
+    latestGrapherConfigSchema,
 } from "../core/GrapherConstants"
-import { defaultGrapherConfig } from "../schema/defaultGrapherConfig"
 import { loadVariableDataAndMetadata } from "./loadVariable"
 import Cookies from "js-cookie"
 import {
@@ -353,7 +353,7 @@ export class Grapher
         MapChartManager,
         SlopeChartManager
 {
-    @observable.ref $schema = defaultGrapherConfig.$schema
+    @observable.ref $schema = latestGrapherConfigSchema
     @observable.ref type = ChartTypeName.LineChart
     @observable.ref id?: number = undefined
     @observable.ref version = 1
@@ -558,7 +558,7 @@ export class Grapher
         deleteRuntimeAndUnchangedProps(obj, defaultObject)
 
         // always include the schema, even if it's the default
-        obj.$schema = this.$schema || defaultGrapherConfig.$schema
+        obj.$schema = this.$schema || latestGrapherConfigSchema
 
         // JSON doesn't support Infinity, so we use strings instead.
         if (obj.minTime) obj.minTime = minTimeToJSON(this.minTime) as any

--- a/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
@@ -1,3 +1,4 @@
+import { defaultGrapherConfig } from "../schema/defaultGrapherConfig.js"
 import type { GrapherProgrammaticInterface } from "./Grapher"
 
 export const GRAPHER_EMBEDDED_FIGURE_ATTR = "data-grapher-src"
@@ -44,6 +45,8 @@ export const GRAPHER_FONT_SCALE_12 = 12 / BASE_FONT_SIZE
 export const GRAPHER_FONT_SCALE_12_8 = 12.8 / BASE_FONT_SIZE
 export const GRAPHER_FONT_SCALE_13 = 13 / BASE_FONT_SIZE
 export const GRAPHER_FONT_SCALE_14 = 14 / BASE_FONT_SIZE
+
+export const latestGrapherConfigSchema = defaultGrapherConfig.$schema
 
 export enum CookieKey {
     isAdmin = "isAdmin",

--- a/packages/@ourworldindata/grapher/src/index.ts
+++ b/packages/@ourworldindata/grapher/src/index.ts
@@ -26,6 +26,7 @@ export {
     grapherInterfaceWithHiddenTabsOnly,
     CONTINENTS_INDICATOR_ID,
     POPULATION_INDICATOR_ID_USED_IN_ADMIN,
+    latestGrapherConfigSchema,
 } from "./core/GrapherConstants"
 export {
     getVariableDataRoute,

--- a/packages/@ourworldindata/grapher/src/schema/README.md
+++ b/packages/@ourworldindata/grapher/src/schema/README.md
@@ -6,7 +6,7 @@ The schema is versioned. There is one yaml file with a version number. For nonbr
 edit the yaml file as is. A github action will then generate a .latest.yaml and two json files (one .latest.json and one with the version number.json)
 and upload them to S3 so they can be accessed publicly.
 
-If you update the default value of an existing property or you add a new property with a default value, make sure to regenerate the default object from the schema and save it to `defaultGrapherConfig.ts` (see below). You should also write a migration to update the `chart_configs.full` column in the database for all stand-alone charts.
+If you update the default value of an existing property or you add a new property with a default value, make sure to regenerate the default object from the schema and save it to `defaultGrapherConfig.ts` (see below).
 
 Breaking changes should be done by renaming the schema file to an increased version number. Make sure to also rename the authorative url
 inside the schema file (the "$id" field at the top level) to point to the new version number json. Then write the migrations from the last to

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -1964,7 +1964,7 @@ export function traverseObjects<T extends Record<string, any>>(
 }
 
 export function getParentVariableIdFromChartConfig(
-    config: GrapherInterface // could be a patch config
+    config: GrapherInterface
 ): number | undefined {
     const { type = ChartTypeName.LineChart, dimensions } = config
 

--- a/site/DataPageV2.tsx
+++ b/site/DataPageV2.tsx
@@ -1,5 +1,4 @@
 import {
-    defaultGrapherConfig,
     getVariableDataRoute,
     getVariableMetadataRoute,
     GrapherProgrammaticInterface,
@@ -16,7 +15,6 @@ import {
     GrapherInterface,
     ImageMetadata,
     Url,
-    diffGrapherConfigs,
 } from "@ourworldindata/utils"
 import { MarkdownTextWrap } from "@ourworldindata/components"
 import React from "react"
@@ -105,12 +103,6 @@ export const DataPageV2 = (props: {
         dataApiUrl: DATA_API_URL,
     }
 
-    // We bake the Grapher config without defaults
-    const grapherConfigToBake = diffGrapherConfigs(
-        grapherConfig,
-        defaultGrapherConfig
-    )
-
     // Only embed the tags that are actually used by the datapage, instead of the complete JSON object with ~240 properties
     const minimalTagToSlugMap = pick(
         tagToSlugMap,
@@ -190,7 +182,7 @@ export const DataPageV2 = (props: {
                 <script
                     dangerouslySetInnerHTML={{
                         __html: `window._OWID_GRAPHER_CONFIG = ${serializeJSONForHTML(
-                            grapherConfigToBake
+                            grapherConfig
                         )}`,
                     }}
                 />

--- a/site/ExplorerPage.tsx
+++ b/site/ExplorerPage.tsx
@@ -1,5 +1,4 @@
 import {
-    defaultGrapherConfig,
     GRAPHER_PAGE_BODY_CLASS,
     LoadingIndicator,
 } from "@ourworldindata/grapher"
@@ -7,7 +6,6 @@ import {
     serializeJSONForHTML,
     SiteFooterContext,
     GrapherInterface,
-    diffGrapherConfigs,
 } from "@ourworldindata/utils"
 import React from "react"
 import {
@@ -89,24 +87,16 @@ export const ExplorerPage = (props: ExplorerPageSettings) => {
         />
     ) : undefined
 
-    // We bake the given Grapher configs without defaults
-    const grapherConfigsToBake = grapherConfigs.map((config) =>
-        diffGrapherConfigs(config, defaultGrapherConfig)
-    )
-    const partialGrapherConfigsToBake = partialGrapherConfigs.map((config) =>
-        diffGrapherConfigs(config, defaultGrapherConfig)
-    )
-
     const inlineJs = `const explorerProgram = ${serializeJSONForHTML(
         program.toJson(),
         EMBEDDED_EXPLORER_DELIMITER
     )};
 const grapherConfigs = ${serializeJSONForHTML(
-        grapherConfigsToBake,
+        grapherConfigs,
         EMBEDDED_EXPLORER_GRAPHER_CONFIGS
     )};
 const partialGrapherConfigs = ${serializeJSONForHTML(
-        partialGrapherConfigsToBake,
+        partialGrapherConfigs,
         EMBEDDED_EXPLORER_PARTIAL_GRAPHER_CONFIGS
     )};
 const urlMigrationSpec = ${

--- a/site/GrapherPage.tsx
+++ b/site/GrapherPage.tsx
@@ -3,7 +3,6 @@ import {
     getVariableMetadataRoute,
     GRAPHER_PAGE_BODY_CLASS,
     LoadingIndicator,
-    defaultGrapherConfig,
 } from "@ourworldindata/grapher"
 import {
     PostReference,
@@ -13,7 +12,6 @@ import {
     uniq,
     SiteFooterContext,
     Url,
-    diffGrapherConfigs,
 } from "@ourworldindata/utils"
 import { MarkdownTextWrap } from "@ourworldindata/components"
 import React from "react"
@@ -66,11 +64,8 @@ export const GrapherPage = (props: {
     const imageWidth = "1200"
     const imageHeight = "628"
 
-    // We bake the Grapher config without defaults
-    const grapherToBake = diffGrapherConfigs(grapher, defaultGrapherConfig)
-
     const script = `const jsonConfig = ${serializeJSONForHTML({
-        ...grapherToBake,
+        ...grapher,
         adminBaseUrl: ADMIN_BASE_URL,
         bakedGrapherURL: BAKED_GRAPHER_URL,
         dataApiUrl: DATA_API_URL,


### PR DESCRIPTION
Removes the default layer from the full config of charts.

This is the smaller version that removes the default layer from the full configs of all charts but keeps using it in the admin. If I find the time this week, I also want to remove the admin's dependence on the default config, but even if I don't find the time, I think this PR is okay to be merged as is since keeping the default config up-to-date is zero effort (we have a GitHub action that infers the default config from the schema and automatically commits it).

I tested this by comparing the previously baked Grapher configs with the now-baked Grapher configs. The diff was empty for most configs. There were a few that used to have `map.colorScale` set to an empty object (not sure why) that is missing now, but that makes no difference to Grapher.

The SVG tester differences are due to a parent PR.