### PR TITLE
🔨 Fix explorer edit button

### DIFF
--- a/packages/@ourworldindata/explorer/src/Explorer.tsx
+++ b/packages/@ourworldindata/explorer/src/Explorer.tsx
@@ -554,6 +554,7 @@ export class Explorer
             ),
             bakedGrapherURL: this.bakedBaseUrl,
             dataApiUrl: this.dataApiUrl,
+            adminBaseUrl: ADMIN_BASE_URL,
             hideEntityControls: this.showExplorerControls,
             manuallyProvideData: false,
         }
@@ -599,6 +600,7 @@ export class Explorer
             ),
             bakedGrapherURL: this.bakedBaseUrl,
             dataApiUrl: this.dataApiUrl,
+            adminBaseUrl: ADMIN_BASE_URL,
             hideEntityControls: this.showExplorerControls,
             manuallyProvideData: false,
         }
@@ -749,6 +751,7 @@ export class Explorer
             ...this.explorerProgram.grapherConfig,
             bakedGrapherURL: this.bakedBaseUrl,
             dataApiUrl: this.dataApiUrl,
+            adminBaseUrl: ADMIN_BASE_URL,
             hideEntityControls: this.showExplorerControls,
             manuallyProvideData: true,
         }


### PR DESCRIPTION
This PR fixes the bug reported in #4033 where the edit button in the share menu of grapher does not point to the right location for explorers