### PR TITLE
🔨 (grapher) turn related questions into an object / TAS-676

### DIFF
--- a/adminSiteClient/AbstractChartEditor.ts
+++ b/adminSiteClient/AbstractChartEditor.ts
@@ -80,9 +80,19 @@ export abstract class AbstractChartEditor<
         return mergeGrapherConfigs(parentConfig ?? {}, patchConfig)
     }
 
-    /** live-updating full config */
+    /** live-updating config */
+    @computed get liveConfig(): GrapherInterface {
+        return this.grapher.object
+    }
+
+    @computed get liveConfigWithDefaults(): GrapherInterface {
+        return mergeGrapherConfigs(defaultGrapherConfig, this.liveConfig)
+    }
+
+    /** patch config merged with parent config */
     @computed get fullConfig(): GrapherInterface {
-        return mergeGrapherConfigs(defaultGrapherConfig, this.grapher.object)
+        if (!this.activeParentConfig) return this.liveConfig
+        return mergeGrapherConfigs(this.activeParentConfig, this.liveConfig)
     }
 
     /** parent config currently applied to grapher */
@@ -103,7 +113,7 @@ export abstract class AbstractChartEditor<
     /** patch config of the chart that is written to the db on save */
     @computed get patchConfig(): GrapherInterface {
         return diffGrapherConfigs(
-            this.fullConfig,
+            this.liveConfigWithDefaults,
             this.activeParentConfigWithDefaults ?? defaultGrapherConfig
         )
     }

--- a/adminSiteClient/ChartEditor.ts
+++ b/adminSiteClient/ChartEditor.ts
@@ -75,7 +75,7 @@ export class ChartEditor extends AbstractChartEditor<ChartEditorManager> {
 
     /** parent variable id, derived from the config */
     @computed get parentVariableId(): number | undefined {
-        return getParentVariableIdFromChartConfig(this.fullConfig)
+        return getParentVariableIdFromChartConfig(this.liveConfig)
     }
 
     @computed get availableTabs(): EditorTab[] {

--- a/adminSiteClient/EditorTextTab.tsx
+++ b/adminSiteClient/EditorTextTab.tsx
@@ -1,6 +1,6 @@
-import { faMinus, faPlus } from "@fortawesome/free-solid-svg-icons"
+import { faMinus } from "@fortawesome/free-solid-svg-icons"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
-import { LogoOption, RelatedQuestionsConfig } from "@ourworldindata/types"
+import { LogoOption } from "@ourworldindata/types"
 import { getErrorMessageRelatedQuestionUrl } from "@ourworldindata/grapher"
 import { slugify } from "@ourworldindata/utils"
 import { action, computed } from "mobx"
@@ -37,21 +37,6 @@ export class EditorTextTab<
         }
     }
 
-    @action.bound onAddRelatedQuestion() {
-        const { grapher } = this.props.editor
-        if (!grapher.relatedQuestions) grapher.relatedQuestions = []
-        grapher.relatedQuestions.push({
-            text: "",
-            url: "",
-        })
-    }
-
-    @action.bound onRemoveRelatedQuestion(idx: number) {
-        const { grapher } = this.props.editor
-        if (!grapher.relatedQuestions) grapher.relatedQuestions = []
-        grapher.relatedQuestions.splice(idx, 1)
-    }
-
     @action.bound onToggleTitleAnnotationEntity(value: boolean) {
         const { grapher } = this.props.editor
         grapher.hideAnnotationFieldsInTitle ??= {}
@@ -86,7 +71,6 @@ export class EditorTextTab<
     render() {
         const { editor } = this.props
         const { grapher, features } = editor
-        const { relatedQuestions = [] } = grapher
 
         return (
             <div className="EditorTextTab">
@@ -250,50 +234,49 @@ export class EditorTextTab<
                 </Section>
 
                 <Section name="Related">
-                    {relatedQuestions.map(
-                        (question: RelatedQuestionsConfig, idx: number) => (
-                            <div key={idx}>
-                                <TextField
-                                    label="Related question"
-                                    value={question.text}
-                                    onValue={action((value: string) => {
-                                        question.text = value
-                                    })}
-                                    placeholder="e.g. How did countries respond to the pandemic?"
-                                    helpText="Short question promoting exploration of related content"
-                                    softCharacterLimit={50}
-                                />
-                                {question.text && (
-                                    <TextField
-                                        label="URL"
-                                        value={question.url}
-                                        onValue={action((value: string) => {
-                                            question.url = value
-                                        })}
-                                        placeholder="e.g. https://ourworldindata.org/coronavirus"
-                                        helpText="Page or section of a page where the answer to the previous question can be found."
-                                        errorMessage={getErrorMessageRelatedQuestionUrl(
-                                            question
-                                        )}
-                                    />
-                                )}
-                                <Button
-                                    onClick={() =>
-                                        this.onRemoveRelatedQuestion(idx)
+                    <div>
+                        <TextField
+                            label="Related question"
+                            value={grapher.relatedQuestion?.text}
+                            onValue={action((value: string) => {
+                                if (grapher.relatedQuestion) {
+                                    grapher.relatedQuestion.text = value
+                                } else {
+                                    grapher.relatedQuestion = {
+                                        text: value,
+                                        url: "",
                                     }
-                                >
-                                    <FontAwesomeIcon icon={faMinus} /> Remove
-                                    related question
-                                </Button>
-                            </div>
-                        )
-                    )}
-                    {!relatedQuestions.length && (
-                        <Button onClick={this.onAddRelatedQuestion}>
-                            <FontAwesomeIcon icon={faPlus} /> Add related
-                            question
-                        </Button>
-                    )}
+                                }
+                            })}
+                            placeholder="e.g. How did countries respond to the pandemic?"
+                            helpText="Short question promoting exploration of related content"
+                            softCharacterLimit={50}
+                        />
+                        {grapher.relatedQuestion?.text && (
+                            <TextField
+                                label="URL"
+                                value={grapher.relatedQuestion.url}
+                                onValue={action((value: string) => {
+                                    grapher.relatedQuestion!.url = value
+                                })}
+                                placeholder="e.g. https://ourworldindata.org/coronavirus"
+                                helpText="Page or section of a page where the answer to the previous question can be found."
+                                errorMessage={getErrorMessageRelatedQuestionUrl(
+                                    grapher.relatedQuestion
+                                )}
+                            />
+                        )}
+                        {grapher.relatedQuestion?.text && (
+                            <Button
+                                onClick={() =>
+                                    (grapher.relatedQuestion = undefined)
+                                }
+                            >
+                                <FontAwesomeIcon icon={faMinus} /> Remove
+                                related question
+                            </Button>
+                        )}
+                    </div>
                 </Section>
                 <Section name="Misc">
                     <BindString

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -109,7 +109,6 @@ import {
 } from "@ourworldindata/types"
 import { uuidv7 } from "uuidv7"
 import {
-    defaultGrapherConfig,
     migrateGrapherConfigToLatestVersion,
     getVariableDataRoute,
     getVariableMetadataRoute,
@@ -328,14 +327,10 @@ const saveNewChart = async (
     const parent = shouldInherit
         ? await getParentByChartConfig(knex, config)
         : undefined
-    const fullParentConfig = mergeGrapherConfigs(
-        defaultGrapherConfig,
-        parent?.config ?? {}
-    )
 
     // compute patch and full configs
-    const patchConfig = diffGrapherConfigs(config, fullParentConfig)
-    const fullConfig = mergeGrapherConfigs(fullParentConfig, patchConfig)
+    const patchConfig = diffGrapherConfigs(config, parent?.config ?? {})
+    const fullConfig = mergeGrapherConfigs(parent?.config ?? {}, patchConfig)
     const fullConfigStringified = serializeChartConfig(fullConfig)
 
     // insert patch & full configs into the chart_configs table
@@ -424,14 +419,10 @@ const updateExistingChart = async (
     const parent = shouldInherit
         ? await getParentByChartConfig(knex, config)
         : undefined
-    const fullParentConfig = mergeGrapherConfigs(
-        defaultGrapherConfig,
-        parent?.config ?? {}
-    )
 
     // compute patch and full configs
-    const patchConfig = diffGrapherConfigs(config, fullParentConfig)
-    const fullConfig = mergeGrapherConfigs(fullParentConfig, patchConfig)
+    const patchConfig = diffGrapherConfigs(config, parent?.config ?? {})
+    const fullConfig = mergeGrapherConfigs(parent?.config ?? {}, patchConfig)
     const fullConfigStringified = serializeChartConfig(fullConfig)
 
     const chartConfigId = await db.knexRawFirst<Pick<DbPlainChart, "configId">>(

--- a/adminSiteServer/app.test.tsx
+++ b/adminSiteServer/app.test.tsx
@@ -58,11 +58,14 @@ import {
 import path from "path"
 import fs from "fs"
 import { omitUndefinedValues } from "@ourworldindata/utils"
+import { defaultGrapherConfig } from "@ourworldindata/grapher"
 
 const ADMIN_SERVER_HOST = "localhost"
 const ADMIN_SERVER_PORT = 8765
 
 const ADMIN_URL = `http://${ADMIN_SERVER_HOST}:${ADMIN_SERVER_PORT}/admin/api`
+
+const currentSchema = defaultGrapherConfig.$schema
 
 jest.setTimeout(10000) // wait for up to 10s for the app server to start
 let testKnexInstance: Knex<any, unknown[]> | undefined = undefined
@@ -192,8 +195,7 @@ async function makeRequestAgainstAdminApi(
 
 describe("OwidAdminApp", () => {
     const testChartConfig = {
-        $schema:
-            "https://files.ourworldindata.org/schemas/grapher-schema.005.json",
+        $schema: currentSchema,
         slug: "test-chart",
         title: "Test chart",
         type: "LineChart",
@@ -311,16 +313,14 @@ describe("OwidAdminApp: indicator-level chart configs", () => {
         display: '{ "unit": "kg", "shortUnit": "kg" }',
     }
     const testVariableConfigETL = {
-        $schema:
-            "https://files.ourworldindata.org/schemas/grapher-schema.005.json",
+        $schema: currentSchema,
         hasMapTab: true,
         note: "Indicator note",
         selectedEntityNames: ["France", "Italy", "Spain"],
         hideRelativeToggle: false,
     }
     const testVariableConfigAdmin = {
-        $schema:
-            "https://files.ourworldindata.org/schemas/grapher-schema.005.json",
+        $schema: currentSchema,
         title: "Admin title",
         subtitle: "Admin subtitle",
     }
@@ -331,14 +331,12 @@ describe("OwidAdminApp: indicator-level chart configs", () => {
         id: otherVariableId,
     }
     const otherTestVariableConfig = {
-        $schema:
-            "https://files.ourworldindata.org/schemas/grapher-schema.005.json",
+        $schema: currentSchema,
         note: "Other indicator note",
     }
 
     const testChartConfig = {
-        $schema:
-            "https://files.ourworldindata.org/schemas/grapher-schema.005.json",
+        $schema: currentSchema,
         slug: "test-chart",
         title: "Test chart",
         type: "Marimekko",
@@ -352,8 +350,7 @@ describe("OwidAdminApp: indicator-level chart configs", () => {
         ],
     }
     const testMultiDimConfig = {
-        grapherConfigSchema:
-            "https://files.ourworldindata.org/schemas/grapher-schema.005.json",
+        grapherConfigSchema: currentSchema,
         title: {
             title: "Energy use",
             titleVariant: "by energy source",
@@ -613,8 +610,7 @@ describe("OwidAdminApp: indicator-level chart configs", () => {
         )
 
         expect(fullConfig).toEqual({
-            $schema:
-                "https://files.ourworldindata.org/schemas/grapher-schema.005.json",
+            $schema: currentSchema,
             id: chartId,
             isPublished: false,
             version: 1,
@@ -634,8 +630,7 @@ describe("OwidAdminApp: indicator-level chart configs", () => {
             `/charts/${chartId}.patchConfig.json`
         )
         expect(patchConfig).toEqual({
-            $schema:
-                "https://files.ourworldindata.org/schemas/grapher-schema.005.json",
+            $schema: currentSchema,
             id: chartId,
             version: 1,
             isPublished: false,
@@ -671,8 +666,7 @@ describe("OwidAdminApp: indicator-level chart configs", () => {
             `/charts/${chartId}.config.json`
         )
         expect(fullConfigAfterDelete).toEqual({
-            $schema:
-                "https://files.ourworldindata.org/schemas/grapher-schema.005.json",
+            $schema: currentSchema,
             id: chartId,
             version: 1,
             isPublished: false,
@@ -688,8 +682,7 @@ describe("OwidAdminApp: indicator-level chart configs", () => {
             `/charts/${chartId}.patchConfig.json`
         )
         expect(patchConfigAfterDelete).toEqual({
-            $schema:
-                "https://files.ourworldindata.org/schemas/grapher-schema.005.json",
+            $schema: currentSchema,
             id: chartId,
             version: 1,
             isPublished: false,

--- a/adminSiteServer/multiDim.ts
+++ b/adminSiteServer/multiDim.ts
@@ -1,7 +1,10 @@
 import { uniq } from "lodash"
 import { uuidv7 } from "uuidv7"
 
-import { migrateGrapherConfigToLatestVersion } from "@ourworldindata/grapher"
+import {
+    defaultGrapherConfig,
+    migrateGrapherConfigToLatestVersion,
+} from "@ourworldindata/grapher"
 import {
     Base64String,
     ChartConfigsTableName,
@@ -290,8 +293,7 @@ export async function createMultiDimConfig(
             const variableId = view.indicators.y[0]
             // Main config for each view.
             const mainGrapherConfig: GrapherInterface = {
-                $schema:
-                    "https://files.ourworldindata.org/schemas/grapher-schema.005.json",
+                $schema: defaultGrapherConfig.$schema,
                 dimensions: MultiDimDataPageConfig.viewToDimensionsConfig(view),
                 selectedEntityNames: config.defaultSelection ?? [],
                 slug,

--- a/db/migration/1730455806132-RemoveDefaultConfigLayer.ts
+++ b/db/migration/1730455806132-RemoveDefaultConfigLayer.ts
@@ -1,0 +1,113 @@
+import { defaultGrapherConfig } from "@ourworldindata/grapher"
+import { mergeGrapherConfigs } from "@ourworldindata/utils"
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class RemoveDefaultConfigLayer1730455806132
+    implements MigrationInterface
+{
+    private async recomputeFullChartConfigs(
+        queryRunner: QueryRunner,
+        { useDefaultLayer }: { useDefaultLayer: boolean }
+    ): Promise<void> {
+        const charts = await queryRunner.query(`
+             -- sql
+             SELECT
+                 cc.id AS configId,
+                 cc.patch AS patchConfig,
+                 cc_etl.patch AS etlConfig,
+                 cc_admin.patch AS adminConfig,
+                 c.isInheritanceEnabled
+             FROM charts c
+             JOIN chart_configs cc ON cc.id = c.configId
+             LEFT JOIN charts_x_parents cxp ON cxp.chartId = c.id
+             LEFT JOIN variables v ON v.id = cxp.variableId
+             LEFT JOIN chart_configs cc_etl ON cc_etl.id = v.grapherConfigIdETL
+             LEFT JOIN chart_configs cc_admin ON cc_admin.id = v.grapherConfigIdAdmin
+         `)
+        for (const chart of charts) {
+            const patchConfig = JSON.parse(chart.patchConfig)
+
+            const etlConfig = chart.etlConfig ? JSON.parse(chart.etlConfig) : {}
+            const adminConfig = chart.adminConfig
+                ? JSON.parse(chart.adminConfig)
+                : {}
+
+            const fullConfig = mergeGrapherConfigs(
+                useDefaultLayer ? defaultGrapherConfig : {},
+                chart.isInheritanceEnabled ? etlConfig : {},
+                chart.isInheritanceEnabled ? adminConfig : {},
+                patchConfig
+            )
+
+            await queryRunner.query(
+                `
+                    -- sql
+                    UPDATE chart_configs cc
+                    SET cc.full = ?
+                    WHERE cc.id = ?
+                `,
+                [JSON.stringify(fullConfig), chart.configId]
+            )
+        }
+    }
+
+    private async updateChartsXParentsView(
+        queryRunner: QueryRunner
+    ): Promise<void> {
+        // identical to the current view definition,
+        // but uses `COALESCE(cc.full ->> '$.type', 'LineChart')`
+        // instead of `cc.full ->> '$.type'` since the full config
+        // might not have a type
+        await queryRunner.query(`-- sql
+          ALTER VIEW charts_x_parents AS (
+            WITH y_dimensions AS (
+              SELECT
+                *
+              FROM
+                chart_dimensions
+              WHERE
+                property = 'y'
+            ),
+            single_y_indicator_charts AS (
+              SELECT
+                c.id as chartId,
+                cc.patch as patchConfig,
+                -- should only be one
+                max(yd.variableId) as variableId
+              FROM
+                charts c
+                JOIN chart_configs cc ON cc.id = c.configId
+                JOIN y_dimensions yd ON c.id = yd.chartId
+              WHERE
+                -- scatter plots can't inherit settings
+                COALESCE(cc.full ->> '$.type', 'LineChart') != 'ScatterPlot'
+              GROUP BY
+                c.id
+              HAVING
+                -- restrict to single y-variable charts
+                COUNT(distinct yd.variableId) = 1
+            )
+            SELECT
+              variableId,
+              chartId
+            FROM
+              single_y_indicator_charts
+            ORDER BY
+              variableId
+          )
+        `)
+    }
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await this.recomputeFullChartConfigs(queryRunner, {
+            useDefaultLayer: false,
+        })
+        await this.updateChartsXParentsView(queryRunner)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await this.recomputeFullChartConfigs(queryRunner, {
+            useDefaultLayer: true,
+        })
+    }
+}

--- a/db/migration/1730722779919-TurnRelatedQuestionIntoObject.ts
+++ b/db/migration/1730722779919-TurnRelatedQuestionIntoObject.ts
@@ -1,0 +1,91 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class TurnRelatedQuestionIntoObject1730722779919
+    implements MigrationInterface
+{
+    private async updateSchema(
+        queryRunner: QueryRunner,
+        newSchema: string
+    ): Promise<void> {
+        await queryRunner.query(
+            `
+            -- sql
+            UPDATE chart_configs cc
+            SET cc.patch = JSON_SET(cc.patch, '$.$schema', ?),
+                cc.full = JSON_SET(cc.full, '$.$schema', ?)
+        `,
+            [newSchema, newSchema]
+        )
+    }
+
+    private async turnRelatedQuestionIntoObject(
+        queryRunner: QueryRunner,
+        config: "patch" | "full"
+    ): Promise<void> {
+        await queryRunner.query(
+            `
+            -- sql
+            UPDATE chart_configs
+            SET
+                ?? = JSON_REMOVE(
+                    JSON_SET(
+                        ??,
+                        '$.relatedQuestion',
+                        ??->'$.relatedQuestions[0]'
+                    ),
+                    '$.relatedQuestions'
+                )
+            WHERE ?? ->> '$.relatedQuestions' is not null
+            `,
+            [config, config, config, config]
+        )
+    }
+
+    private async turnRelatedQuestionIntoArray(
+        queryRunner: QueryRunner,
+        config: "patch" | "full"
+    ): Promise<void> {
+        await queryRunner.query(
+            `
+            -- sql
+            UPDATE chart_configs
+            SET
+                ?? = JSON_REMOVE(
+                    JSON_SET(
+                        ??,
+                        '$.relatedQuestions',
+                        JSON_ARRAY(
+                            JSON_OBJECT(
+                                'url', ?? ->> '$.relatedQuestion.url',
+                                'text', ?? ->> '$.relatedQuestion.text'
+                            )
+                        )
+                    ),
+                    '$.relatedQuestion'
+                )
+            WHERE ?? ->> '$.relatedQuestion' IS NOT NULL
+            `,
+            [config, config, config, config, config]
+        )
+    }
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await this.turnRelatedQuestionIntoObject(queryRunner, "patch")
+        await this.turnRelatedQuestionIntoObject(queryRunner, "full")
+
+        await this.updateSchema(
+            queryRunner,
+            "https://files.ourworldindata.org/schemas/grapher-schema.006.json"
+        )
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await this.turnRelatedQuestionIntoArray(queryRunner, "patch")
+        await this.turnRelatedQuestionIntoArray(queryRunner, "full")
+
+        await this.updateSchema(
+            queryRunner,
+            "https://files.ourworldindata.org/schemas/grapher-schema.005.json"
+        )
+    }
+}

--- a/db/model/Chart.ts
+++ b/db/model/Chart.ts
@@ -567,7 +567,7 @@ export const getMostViewedGrapherIdsByChartType = async (
             JOIN chart_configs cc ON slug = SUBSTRING_INDEX(a.url, '/', -1)
             JOIN charts c ON c.configId = cc.id
             WHERE a.url LIKE "https://ourworldindata.org/grapher/%"
-                AND cc.full ->> "$.type" = ?
+                AND COALESCE(cc.full ->> "$.type", 'LineChart') = ?
                 AND cc.full ->> "$.isPublished" = "true"
                 and (cc.full ->> "$.hasChartTab" = "true" or cc.full ->> "$.hasChartTab" is null)
             ORDER BY a.views_365d DESC

--- a/db/model/Variable.ts
+++ b/db/model/Variable.ts
@@ -11,7 +11,6 @@ import {
 import {
     getVariableDataRoute,
     getVariableMetadataRoute,
-    defaultGrapherConfig,
 } from "@ourworldindata/grapher"
 import pl from "nodejs-polars"
 import { uuidv7 } from "uuidv7"
@@ -271,7 +270,6 @@ export async function updateAllChartsThatInheritFromIndicator(
 
     for (const chart of inheritingCharts) {
         const fullConfig = mergeGrapherConfigs(
-            defaultGrapherConfig,
             patchConfigETL ?? {},
             patchConfigAdmin ?? {},
             chart.patchConfig

--- a/devTools/schemaProcessor/columns.json
+++ b/devTools/schemaProcessor/columns.json
@@ -617,12 +617,12 @@
     },
     {
         "type": "string",
-        "pointer": "/relatedQuestions/0/url",
+        "pointer": "/relatedQuestion/url",
         "editor": "textfield"
     },
     {
         "type": "string",
-        "pointer": "/relatedQuestions/0/text",
+        "pointer": "/relatedQuestion/text",
         "editor": "textfield"
     },
     {

--- a/devTools/svgTester/dump-data.ts
+++ b/devTools/svgTester/dump-data.ts
@@ -1,8 +1,6 @@
 #! /usr/bin/env node
 
 import { getPublishedGraphersBySlug } from "../../baker/GrapherImageBaker.js"
-import { defaultGrapherConfig } from "@ourworldindata/grapher"
-import { diffGrapherConfigs } from "@ourworldindata/utils"
 
 import { TransactionCloseMode, knexReadonlyTransaction } from "../../db/db.js"
 
@@ -26,11 +24,7 @@ async function main(parsedArgs: parseArgs.ParsedArgs) {
         const allGraphers = [...graphersBySlug.values()]
         const saveJobs: utils.SaveGrapherSchemaAndDataJob[] = allGraphers.map(
             (grapher) => {
-                // since we're not baking defaults, we also exclude them here
-                return {
-                    config: diffGrapherConfigs(grapher, defaultGrapherConfig),
-                    outDir,
-                }
+                return { config: grapher, outDir }
             }
         )
 

--- a/packages/@ourworldindata/explorer/src/ExplorerProgram.ts
+++ b/packages/@ourworldindata/explorer/src/ExplorerProgram.ts
@@ -401,15 +401,6 @@ export class ExplorerProgram extends GridProgram {
         // assume config is valid against the latest schema
         mergedConfig.$schema = defaultGrapherConfig.$schema
 
-        // TODO: can be removed once relatedQuestions is refactored
-        const { relatedQuestionUrl, relatedQuestionText } =
-            this.explorerGrapherConfig
-        if (relatedQuestionUrl && relatedQuestionText) {
-            mergedConfig.relatedQuestions = [
-                { url: relatedQuestionUrl, text: relatedQuestionText },
-            ]
-        }
-
         return mergedConfig
     }
 

--- a/packages/@ourworldindata/explorer/src/GrapherGrammar.ts
+++ b/packages/@ourworldindata/explorer/src/GrapherGrammar.ts
@@ -284,13 +284,13 @@ export const GrapherGrammar: Grammar<GrapherCellDef> = {
         keyword: "relatedQuestionText",
         description:
             "The text used for the related question (at the very bottom of the chart)",
-        toGrapherObject: () => ({}), // handled in code (can be done properly once the relatedQuestion field is refactored)
+        toGrapherObject: (value) => ({ relatedQuestion: { text: value } }),
     },
     relatedQuestionUrl: {
         ...UrlCellDef,
         keyword: "relatedQuestionUrl",
         description: "The link of the related question text",
-        toGrapherObject: () => ({}), // handled in code (can be done properly once the relatedQuestion field is refactored)
+        toGrapherObject: (value) => ({ relatedQuestion: { url: value } }),
     },
     mapTargetTime: {
         ...IntegerCellDef,

--- a/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
@@ -94,7 +94,7 @@ export interface CaptionedChartManager
     detailRenderers: MarkdownTextWrap[]
 
     // related question
-    relatedQuestions?: RelatedQuestionsConfig[]
+    relatedQuestion?: RelatedQuestionsConfig
     showRelatedQuestion?: boolean
 }
 
@@ -271,7 +271,7 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
     }
 
     private renderRelatedQuestion(): React.ReactElement {
-        const { relatedQuestions } = this.manager
+        const { relatedQuestion } = this.manager
         return (
             <div
                 className="relatedQuestion"
@@ -283,12 +283,12 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
             >
                 Related:&nbsp;
                 <a
-                    href={relatedQuestions![0].url}
+                    href={relatedQuestion!.url}
                     target="_blank"
                     rel="noopener"
                     data-track-note="chart_click_related"
                 >
-                    {relatedQuestions![0].text}
+                    {relatedQuestion!.text}
                 </a>
                 <FontAwesomeIcon icon={faExternalLinkAlt} />
             </div>

--- a/packages/@ourworldindata/grapher/src/schema/README.md
+++ b/packages/@ourworldindata/grapher/src/schema/README.md
@@ -18,7 +18,6 @@ Checklist for breaking changes:
 -   Rename the authorative url inside the schema file to point to the new version number json
 -   Write the migrations from the last to the current version of the schema, including the migration of pointing to the URL of the new schema version
 -   Regenerate the default object from the schema and save it to `defaultGrapherConfig.ts` (see below)
--   Write a migration to update the `chart_configs.full` column in the database for all stand-alone charts
 -   Write a migration to update configs in code (see `migrations/migrations.ts`)
 -   Update the hardcoded default schema version in ETL
 

--- a/packages/@ourworldindata/grapher/src/schema/README.md
+++ b/packages/@ourworldindata/grapher/src/schema/README.md
@@ -6,7 +6,7 @@ The schema is versioned. There is one yaml file with a version number. For nonbr
 edit the yaml file as is. A github action will then generate a .latest.yaml and two json files (one .latest.json and one with the version number.json)
 and upload them to S3 so they can be accessed publicly.
 
-If you update the default value of an existing property or you add a new property with a default value, make sure to regenerate the default object from the schema and save it to `defaultGrapherConfig.ts` (see below). You should also write a migration to update the `chart_configs.full` column in the database for all stand-alone charts.
+If you update the default value of an existing property or you add a new property with a default value, make sure to regenerate the default object from the schema and save it to `defaultGrapherConfig.ts` (see below).
 
 Breaking changes should be done by renaming the schema file to an increased version number. Make sure to also rename the authorative url
 inside the schema file (the "$id" field at the top level) to point to the new version number json. Then write the migrations from the last to

--- a/packages/@ourworldindata/grapher/src/schema/defaultGrapherConfig.ts
+++ b/packages/@ourworldindata/grapher/src/schema/defaultGrapherConfig.ts
@@ -4,11 +4,17 @@
 
 import { GrapherInterface } from "@ourworldindata/types"
 
-export const latestSchemaVersion = "005" as const
-export const outdatedSchemaVersions = ["001", "002", "003", "004"] as const
+export const latestSchemaVersion = "006" as const
+export const outdatedSchemaVersions = [
+    "001",
+    "002",
+    "003",
+    "004",
+    "005",
+] as const
 
 export const defaultGrapherConfig = {
-    $schema: "https://files.ourworldindata.org/schemas/grapher-schema.005.json",
+    $schema: "https://files.ourworldindata.org/schemas/grapher-schema.006.json",
     map: {
         projection: "World",
         hideTimeline: false,

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.006.yaml
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.006.yaml
@@ -1,7 +1,7 @@
 $schema: "http://json-schema.org/draft-07/schema#"
 # if you update the required keys, make sure that the mergeGrapherConfigs and
 # diffGrapherConfigs functions both reflect this change
-$id: "https://files.ourworldindata.org/schemas/grapher-schema.005.json"
+$id: "https://files.ourworldindata.org/schemas/grapher-schema.006.json"
 required:
     - $schema
     - dimensions
@@ -14,13 +14,13 @@ properties:
         type: string
         description: Url of the concrete schema version to use to validate this document
         format: uri
-        default: "https://files.ourworldindata.org/schemas/grapher-schema.005.json"
+        default: "https://files.ourworldindata.org/schemas/grapher-schema.006.json"
         # for now, we only validate configs in our database using this schema.
         # since we expect all configs in our database to be valid against the latest schema,
         # we restrict the $schema field to a single value, the latest schema version.
         # if we ever need to validate configs against multiple schema versions,
         # we can remove this constraint.
-        const: "https://files.ourworldindata.org/schemas/grapher-schema.005.json"
+        const: "https://files.ourworldindata.org/schemas/grapher-schema.006.json"
     id:
         type: integer
         description: Internal DB id. Useful internally for OWID but not required if just using grapher directly.
@@ -354,17 +354,18 @@ properties:
         patternProperties:
             ".*":
                 type: string
-    relatedQuestions:
-        type: array
-        description: Links to related questions
-        items:
-            type: object
-            properties:
-                url:
-                    type: string
-                text:
-                    type: string
-            additionalProperties: false
+    relatedQuestion:
+        type: object
+        description: Links to a related question. Displayed in the footer of the chart.
+        properties:
+            text:
+                type: string
+            url:
+                type: string
+        required:
+            - text
+            - url
+        additionalProperties: false
     title:
         type: string
         description: Big title text of the chart
@@ -419,6 +420,7 @@ properties:
                 type: boolean
                 description: Whether to hide "Change in" in relative line charts
                 default: false
+        additionalProperties: false
     excludedEntities:
         type: array
         description: Entities that should be excluded from the chart

--- a/packages/@ourworldindata/grapher/src/schema/migrations/migrations.ts
+++ b/packages/@ourworldindata/grapher/src/schema/migrations/migrations.ts
@@ -60,6 +60,18 @@ const migrateFrom004To005 = (
     return config
 }
 
+const migrateFrom005To006 = (
+    config: AnyConfigWithValidSchema
+): AnyConfigWithValidSchema => {
+    if (config.relatedQuestions && config.relatedQuestions.length > 0) {
+        const { text, url } = config.relatedQuestions[0]
+        if (text && url) config.relatedQuestion = config.relatedQuestions[0]
+    }
+    delete config.relatedQuestions
+    config.$schema = createSchemaForVersion("006")
+    return config
+}
+
 export const runMigration = (
     config: AnyConfigWithValidSchema
 ): AnyConfigWithValidSchema => {
@@ -70,5 +82,6 @@ export const runMigration = (
         .with("002", () => migrateFrom002To003(config))
         .with("003", () => migrateFrom003To004(config))
         .with("004", () => migrateFrom004To005(config))
+        .with("005", () => migrateFrom005To006(config))
         .exhaustive()
 }

--- a/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
+++ b/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
@@ -179,8 +179,8 @@ export enum GrapherTabOption {
 }
 
 export interface RelatedQuestionsConfig {
-    text: string
-    url: string
+    text?: string
+    url?: string
 }
 
 export enum MissingDataStrategy {
@@ -559,7 +559,7 @@ export interface GrapherInterface extends SortConfig {
     hasChartTab?: boolean
     hasMapTab?: boolean
     tab?: GrapherTabOption
-    relatedQuestions?: RelatedQuestionsConfig[]
+    relatedQuestion?: RelatedQuestionsConfig
     details?: DetailDictionary
     internalNotes?: string
     variantName?: string
@@ -703,7 +703,7 @@ export const grapherKeysToSerialize = [
     "selectedFacetStrategy",
     "hideFacetControl",
     "comparisonLines",
-    "relatedQuestions",
+    "relatedQuestion",
     "missingDataStrategy",
 
     // internals

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -1964,7 +1964,7 @@ export function traverseObjects<T extends Record<string, any>>(
 }
 
 export function getParentVariableIdFromChartConfig(
-    config: GrapherInterface // could be a patch config
+    config: GrapherInterface
 ): number | undefined {
     const { type = ChartTypeName.LineChart, dimensions } = config
 

--- a/site/DataPageV2.tsx
+++ b/site/DataPageV2.tsx
@@ -1,5 +1,4 @@
 import {
-    defaultGrapherConfig,
     getVariableDataRoute,
     getVariableMetadataRoute,
     GrapherProgrammaticInterface,
@@ -16,7 +15,6 @@ import {
     GrapherInterface,
     ImageMetadata,
     Url,
-    diffGrapherConfigs,
 } from "@ourworldindata/utils"
 import { MarkdownTextWrap } from "@ourworldindata/components"
 import React from "react"
@@ -105,12 +103,6 @@ export const DataPageV2 = (props: {
         dataApiUrl: DATA_API_URL,
     }
 
-    // We bake the Grapher config without defaults
-    const grapherConfigToBake = diffGrapherConfigs(
-        grapherConfig,
-        defaultGrapherConfig
-    )
-
     // Only embed the tags that are actually used by the datapage, instead of the complete JSON object with ~240 properties
     const minimalTagToSlugMap = pick(
         tagToSlugMap,
@@ -190,7 +182,7 @@ export const DataPageV2 = (props: {
                 <script
                     dangerouslySetInnerHTML={{
                         __html: `window._OWID_GRAPHER_CONFIG = ${serializeJSONForHTML(
-                            grapherConfigToBake
+                            grapherConfig
                         )}`,
                     }}
                 />

--- a/site/ExplorerPage.tsx
+++ b/site/ExplorerPage.tsx
@@ -1,5 +1,4 @@
 import {
-    defaultGrapherConfig,
     GRAPHER_PAGE_BODY_CLASS,
     LoadingIndicator,
 } from "@ourworldindata/grapher"
@@ -7,7 +6,6 @@ import {
     serializeJSONForHTML,
     SiteFooterContext,
     GrapherInterface,
-    diffGrapherConfigs,
 } from "@ourworldindata/utils"
 import React from "react"
 import {
@@ -89,24 +87,16 @@ export const ExplorerPage = (props: ExplorerPageSettings) => {
         />
     ) : undefined
 
-    // We bake the given Grapher configs without defaults
-    const grapherConfigsToBake = grapherConfigs.map((config) =>
-        diffGrapherConfigs(config, defaultGrapherConfig)
-    )
-    const partialGrapherConfigsToBake = partialGrapherConfigs.map((config) =>
-        diffGrapherConfigs(config, defaultGrapherConfig)
-    )
-
     const inlineJs = `const explorerProgram = ${serializeJSONForHTML(
         program.toJson(),
         EMBEDDED_EXPLORER_DELIMITER
     )};
 const grapherConfigs = ${serializeJSONForHTML(
-        grapherConfigsToBake,
+        grapherConfigs,
         EMBEDDED_EXPLORER_GRAPHER_CONFIGS
     )};
 const partialGrapherConfigs = ${serializeJSONForHTML(
-        partialGrapherConfigsToBake,
+        partialGrapherConfigs,
         EMBEDDED_EXPLORER_PARTIAL_GRAPHER_CONFIGS
     )};
 const urlMigrationSpec = ${

--- a/site/GrapherPage.tsx
+++ b/site/GrapherPage.tsx
@@ -3,7 +3,6 @@ import {
     getVariableMetadataRoute,
     GRAPHER_PAGE_BODY_CLASS,
     LoadingIndicator,
-    defaultGrapherConfig,
 } from "@ourworldindata/grapher"
 import {
     PostReference,
@@ -13,7 +12,6 @@ import {
     uniq,
     SiteFooterContext,
     Url,
-    diffGrapherConfigs,
 } from "@ourworldindata/utils"
 import { MarkdownTextWrap } from "@ourworldindata/components"
 import React from "react"
@@ -66,11 +64,8 @@ export const GrapherPage = (props: {
     const imageWidth = "1200"
     const imageHeight = "628"
 
-    // We bake the Grapher config without defaults
-    const grapherToBake = diffGrapherConfigs(grapher, defaultGrapherConfig)
-
     const script = `const jsonConfig = ${serializeJSONForHTML({
-        ...grapherToBake,
+        ...grapher,
         adminBaseUrl: ADMIN_BASE_URL,
         bakedGrapherURL: BAKED_GRAPHER_URL,
         dataApiUrl: DATA_API_URL,


### PR DESCRIPTION
> [!IMPORTANT]  
> Merge https://github.com/owid/etl/pull/3491 when merging this PR

Applies a breaking change to the Grapher config schema by migrating the `relatedQuestions` array to a `relatedQuestion` object. We only show the first related question and we don't want to add support for multiple related question in the future.

The SVG tester differences are due to a parent PR.