### PR TITLE
chore: remove "external csv" functionality

### DIFF
--- a/explorer/Explorer.tsx
+++ b/explorer/Explorer.tsx
@@ -778,9 +778,6 @@ export class Explorer
             BlankOwidTable(tableSlug, `Loading table '${tableSlug}'`)
         )
         void this.futureGrapherTable.set(this.tableLoader.get(tableSlug))
-
-        if (this.downloadDataLink)
-            grapher.externalCsvLink = this.downloadDataLink
     }
 
     @action.bound setSlide(choiceParams: ExplorerFullQueryParams) {

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -1239,8 +1239,6 @@ export class Grapher
         return uniq(this.dimensions.map((d) => d.variableId))
     }
 
-    externalCsvLink = ""
-
     @computed get hasOWIDLogo(): boolean {
         return (
             !this.hideLogo && (this.logo === undefined || this.logo === "owid")

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
@@ -56,7 +56,6 @@ export interface DownloadModalManager {
     table?: OwidTable
     transformedTable?: OwidTable
     yColumnsFromDimensionsOrSlugsOrAuto?: CoreColumn[]
-    externalCsvLink?: string // TODO: do we want to drop this feature?
     shouldIncludeDetailsInStaticExport?: boolean
     detailsOrderedByReference?: string[]
     isDownloadModalOpen?: boolean


### PR DESCRIPTION
When `downloadDataLink` was provided in an explorer, we used to download that file in the download modal rather than the normal, client-generated csv file.

This feature didn't work for some time now already, so let's just get rid of it.