### PR TITLE
:hammer: track data insight "copy link" clicks

### DIFF
--- a/site/gdocs/pages/DataInsight.tsx
+++ b/site/gdocs/pages/DataInsight.tsx
@@ -88,6 +88,7 @@ function CopyLinkButton(props: { slug: string }) {
     return (
         <button
             aria-label="Copy link to clipboard"
+            data-track-note="data_insight_copy_link"
             id="copy-link-button"
             className="data-insight-copy-link-button body-3-medium"
             onClick={() => {


### PR DESCRIPTION
Track "copy link" clicks on data insights. Closes owid/analytics#206

<img width="561" alt="Screenshot 2024-11-07 at 1 30 44 PM" src="https://github.com/user-attachments/assets/90e75d3f-0323-4fe2-a48b-90a6fa7f03f5">
