### PR TITLE
Allow fetching grapher configs from all origins

### DIFF
--- a/functions/grapher/by-uuid/[uuid].ts
+++ b/functions/grapher/by-uuid/[uuid].ts
@@ -1,9 +1,17 @@
 import { Env, extensions } from "../../_common/env.js"
 import { fetchGrapherConfig } from "../../_common/grapherTools.js"
-import { IRequestStrict, Router, error, StatusError } from "itty-router"
+import { IRequestStrict, Router, error, StatusError, cors } from "itty-router"
 import { handleThumbnailRequest } from "../../_common/reusableHandlers.js"
 
-const router = Router<IRequestStrict, [URL, Env, string]>()
+const { preflight, corsify } = cors({
+    allowMethods: ["GET", "OPTIONS", "HEAD"],
+})
+
+const router = Router<IRequestStrict, [URL, Env, string]>({
+    before: [preflight],
+    finally: [corsify],
+})
+
 router
     .get(
         `/grapher/by-uuid/:uuid${extensions.configJson}`,


### PR DESCRIPTION
Fixes an error when we try to load grapher configs for multi-dim preview in admin in prod, which runs on a different domain (admin.owid.io) than the Cloudflare Pages function (ourworldindata.org).