### PR TITLE
Disable MySQL logging

### DIFF
--- a/devTools/docker/my.cnf
+++ b/devTools/docker/my.cnf
@@ -9,8 +9,8 @@ user=mysql
 pid-file=/var/run/mysqld/mysqld.pid
 
 # owid-specific
-general_log = 1
-general_log_file = /var/log/mysql/queries.log
-slow_query_log = 1
-slow_query_log_file = /var/log/mysql/slow-queries.log
-long_query_time = 2
+# general_log = 1
+# general_log_file = /var/log/mysql/queries.log
+# slow_query_log = 1
+# slow_query_log_file = /var/log/mysql/slow-queries.log
+# long_query_time = 2


### PR DESCRIPTION
I noticed there are 20 GB of logs I never needed to look at on my machine. IMHO, we can enable logging when debugging something as needed instead of having it always on.