### PR TITLE
🔨 initialize markdown at gdoc creation

### DIFF
--- a/db/model/Gdoc/GdocFactory.ts
+++ b/db/model/Gdoc/GdocFactory.ts
@@ -113,6 +113,8 @@ export async function createGdocAndInsertIntoDb(
         GdocsContentSource.Gdocs
     )
 
+    base.updateMarkdown()
+
     // Save the enriched Gdoc to the database (including subclass-specific
     // enrichments, cf. _enrichSubclassContent()). Otherwise subclass
     // enrichments are not present on the Gdoc subclass when loading from the DB


### PR DESCRIPTION
Lucas noticed that some unpublished data insights don't have content in the markdown column - this PR should make sure that going forward the markdown column is filled. 

It would be good to also add a migration for the ones that are missing markdown but I don't have time for that rn