### PR TITLE
fix: re-enable extended tooltip hover area

### DIFF
--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
@@ -941,7 +941,7 @@ export class LineChart
                 {/* The tiny bit of extra space in the clippath is to ensure circles
                     centered on the very edge are still fully visible */}
                 {this.clipPath.element}
-                <rect {...this.bounds.toProps()} fill="none">
+                <rect {...this.bounds.toProps()} fillOpacity="0">
                     {/* This <rect> ensures that the parent <g> is big enough such that
                         we get mouse hover events for the whole charting area, including
                         the axis, the entity labels, and the whitespace next to them.

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
@@ -634,7 +634,7 @@ export class StackedAreaChart
                 onTouchMove={this.onCursorMove}
             >
                 {clipPath.element}
-                <rect {...this.bounds.toProps()} fill="none">
+                <rect {...this.bounds.toProps()} fillOpacity="0">
                     {/* This <rect> ensures that the parent <g> is big enough such that we get mouse hover events for the
                     whole charting area, including the axis, the entity labels, and the whitespace next to them.
                     We need these to be able to show the tooltip for the first/last year even if the mouse is outside the charting area. */}


### PR DESCRIPTION
Fixes #4117.

Also, fixes that currently, a StackedArea tooltip is only visible when hovering over the actual areas.

This regression was introduced in https://github.com/owid/owid-grapher/pull/2610/commits/d830a0133e4f1007d9318c98130bac049cd0b833.