### PR TITLE
🐛 (admin) color scale controls are unresponsive

### DIFF
--- a/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChart.tsx
@@ -40,7 +40,6 @@ import {
     EntityName,
     OwidVariableRow,
     OwidTableSlugs,
-    colorScaleConfigDefaults,
     VerticalAlign,
 } from "@ourworldindata/types"
 import { OwidTable, CoreColumn } from "@ourworldindata/core-table"
@@ -504,10 +503,8 @@ export class MarimekkoChart
 
     @computed get colorScaleConfig(): ColorScaleConfigDefaults | undefined {
         return (
-            ColorScaleConfig.fromDSL(this.colorColumn.def) ?? {
-                ...colorScaleConfigDefaults,
-                ...this.manager.colorScale,
-            }
+            ColorScaleConfig.fromDSL(this.colorColumn.def) ??
+            this.manager.colorScale
         )
     }
 

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChart.tsx
@@ -8,7 +8,6 @@ import {
     makeSafeForCSS,
     sum,
     getRelativeMouse,
-    colorScaleConfigDefaults,
     excludeUndefined,
     min,
     max,
@@ -627,10 +626,7 @@ export class StackedBarChart
     }
 
     @computed get colorScaleConfig(): ColorScaleConfigDefaults | undefined {
-        return {
-            ...colorScaleConfigDefaults,
-            ...this.manager.colorScale,
-        }
+        return this.manager.colorScale
     }
 
     defaultBaseColorScheme = ColorSchemeName.stackedAreaDefault

--- a/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
+++ b/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
@@ -410,16 +410,16 @@ export type ColorScaleConfigInterface = ColorScaleConfigDefaults
 //     legendDescription?: string
 // }
 
-export const colorScaleConfigDefaults = {
-    binningStrategy: BinningStrategy.ckmeans,
-    customNumericValues: [],
-    customNumericLabels: [],
-    customNumericColors: [],
-    equalSizeBins: true,
-    customCategoryColors: {},
-    customCategoryLabels: {},
-    customHiddenCategories: {},
-} satisfies ColorScaleConfigInterface
+// export const colorScaleConfigDefaults = {
+//     binningStrategy: BinningStrategy.ckmeans,
+//     customNumericValues: [],
+//     customNumericLabels: [],
+//     customNumericColors: [],
+//     equalSizeBins: true,
+//     customCategoryColors: {},
+//     customCategoryLabels: {},
+//     customHiddenCategories: {},
+// } satisfies ColorScaleConfigInterface
 
 export interface ColorSchemeInterface {
     name: string

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -73,7 +73,6 @@ export {
     BinningStrategy,
     type ColorScaleConfigInterface,
     ColorSchemeName,
-    colorScaleConfigDefaults,
     ChartTypeName,
     GrapherTabOption,
     StackMode,


### PR DESCRIPTION
Reverts changes that broke the color scale controls for Marimekko charts in the admin.