### PR TITLE
Revert "enhance(gdocs): allow `?tab=` param coming from gdocs"

### DIFF
--- a/packages/@ourworldindata/types/src/gdocTypes/GdocConstants.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/GdocConstants.ts
@@ -22,7 +22,7 @@ export const IMAGES_DIRECTORY = "/images/published/"
  * https://docs.google.com/spreadsheets/d/abcd1234
  */
 export const gdocUrlRegex =
-    /https:\/\/docs\.google\.com\/document(?:\/u\/\d)?\/d\/([\-\w]+)\/?(edit)?(\?tab=[\w\.]+)#?/
+    /https:\/\/docs\.google\.com\/document(?:\/u\/\d)?\/d\/([\-\w]+)\/?(edit)?#?/
 
 export const GDOCS_BASE_URL = "https://docs.google.com"
 export const GDOCS_URL_PLACEHOLDER = `${GDOCS_BASE_URL}/document/d/****/edit`


### PR DESCRIPTION
This reverts commit 53dd6f0b32180364402aafa485a58db19b8848f5.