### PR TITLE
🔨 (grapher) replace some enum types / TAS-709

### DIFF
--- a/adminSiteClient/ChartList.tsx
+++ b/adminSiteClient/ChartList.tsx
@@ -4,9 +4,10 @@ import { runInAction, observable } from "mobx"
 import { bind } from "decko"
 import { AdminAppContext, AdminAppContextType } from "./AdminAppContext.js"
 import {
-    ChartTypeName,
+    GrapherChartType,
     GrapherInterface,
-    GrapherTabOption,
+    GRAPHER_CHART_TYPES,
+    GRAPHER_TAB_OPTIONS,
 } from "@ourworldindata/types"
 import { startCase, DbChartTagJoin } from "@ourworldindata/utils"
 import { References, getFullReferencesCount } from "./ChartEditor.js"
@@ -24,7 +25,7 @@ export interface ChartListItem {
     tab: GrapherInterface["tab"]
     hasMapTab: GrapherInterface["hasMapTab"]
 
-    type?: ChartTypeName
+    type?: GrapherChartType
     hasChartTab: boolean
 
     lastEditedAt: string
@@ -152,11 +153,11 @@ export function showChartType(chart: ChartListItem): string {
 
     if (!chartType) return "Map"
 
-    const displayType = ChartTypeName[chartType]
-        ? startCase(ChartTypeName[chartType])
+    const displayType = GRAPHER_CHART_TYPES[chartType]
+        ? startCase(GRAPHER_CHART_TYPES[chartType])
         : "Unknown"
 
-    if (chart.tab === GrapherTabOption.map) {
+    if (chart.tab === GRAPHER_TAB_OPTIONS.map) {
         if (chart.hasChartTab) return `Map + ${displayType}`
         else return "Map"
     } else {

--- a/adminSiteClient/ColorSchemeDropdown.tsx
+++ b/adminSiteClient/ColorSchemeDropdown.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { computed, action } from "mobx"
 import Select from "react-select"
-import { ChartTypeName } from "@ourworldindata/types"
+import { GrapherChartOrMapType } from "@ourworldindata/types"
 import {
     ColorScheme,
     getColorSchemeForChartType,
@@ -21,7 +21,7 @@ interface ColorSchemeDropdownProps {
     value?: string
     gradientColorCount: number
     invertedColorScheme: boolean
-    chartType: ChartTypeName
+    chartType: GrapherChartOrMapType
     onChange: (selected: ColorSchemeOption) => void
     onBlur?: () => void
 }

--- a/adminSiteClient/EditorBasicTab.tsx
+++ b/adminSiteClient/EditorBasicTab.tsx
@@ -9,9 +9,10 @@ import {
 } from "mobx"
 import { observer } from "mobx-react"
 import {
-    ChartTypeName,
     EntitySelectionMode,
     StackMode,
+    ALL_GRAPHER_CHART_TYPES,
+    GrapherChartType,
 } from "@ourworldindata/types"
 import {
     DimensionSlot,
@@ -362,7 +363,9 @@ export class EditorBasicTab<
         const { grapher } = this.props.editor
 
         grapher.chartTypes =
-            value === this.chartTypeOptionNone ? [] : [value as ChartTypeName]
+            value === this.chartTypeOptionNone
+                ? []
+                : [value as GrapherChartType]
 
         if (grapher.isMarimekko) {
             grapher.hideRelativeToggle = false
@@ -403,7 +406,7 @@ export class EditorBasicTab<
         value: string
         label: string
     }[] {
-        const chartTypeOptions = Object.keys(ChartTypeName).map((key) => ({
+        const chartTypeOptions = ALL_GRAPHER_CHART_TYPES.map((key) => ({
             value: key,
             label: startCase(key),
         }))

--- a/adminSiteClient/EditorBasicTab.tsx
+++ b/adminSiteClient/EditorBasicTab.tsx
@@ -403,11 +403,7 @@ export class EditorBasicTab<
         value: string
         label: string
     }[] {
-        const allChartTypes = Object.keys(ChartTypeName).filter(
-            (chartType) => chartType !== ChartTypeName.WorldMap
-        )
-
-        const chartTypeOptions = allChartTypes.map((key) => ({
+        const chartTypeOptions = Object.keys(ChartTypeName).map((key) => ({
             value: key,
             label: startCase(key),
         }))

--- a/adminSiteClient/EditorColorScaleSection.tsx
+++ b/adminSiteClient/EditorColorScaleSection.tsx
@@ -7,7 +7,7 @@ import { faPlus, faMinus } from "@fortawesome/free-solid-svg-icons"
 import {
     ColorSchemeName,
     BinningStrategy,
-    ChartTypeName,
+    GrapherChartOrMapType,
     Color,
 } from "@ourworldindata/types"
 import {
@@ -43,7 +43,7 @@ interface EditorColorScaleSectionFeatures {
 @observer
 export class EditorColorScaleSection extends React.Component<{
     scale: ColorScale
-    chartType: ChartTypeName
+    chartType: GrapherChartOrMapType
     features: EditorColorScaleSectionFeatures
     showLineChartColors: boolean
     onChange?: () => void
@@ -132,7 +132,7 @@ class ColorLegendSection extends React.Component<{
 @observer
 class ColorsSection extends React.Component<{
     scale: ColorScale
-    chartType: ChartTypeName
+    chartType: GrapherChartOrMapType
     showLineChartColors: boolean
     onChange?: () => void
 }> {

--- a/adminSiteClient/EditorCustomizeTab.tsx
+++ b/adminSiteClient/EditorCustomizeTab.tsx
@@ -6,7 +6,7 @@ import {
     ColorSchemeName,
     FacetAxisDomain,
     FacetStrategy,
-    ChartTypeName,
+    GRAPHER_CHART_TYPES,
 } from "@ourworldindata/types"
 import { Grapher } from "@ourworldindata/grapher"
 import {
@@ -161,7 +161,7 @@ export class ColorSchemeSelector extends React.Component<{
                             onBlur={this.onBlur}
                             chartType={
                                 this.props.grapher.chartType ??
-                                ChartTypeName.LineChart
+                                GRAPHER_CHART_TYPES.LineChart
                             }
                             invertedColorScheme={!!grapher.invertColorScheme}
                             additionalOptions={[
@@ -755,7 +755,9 @@ export class EditorCustomizeTab<
                 {grapher.chartInstanceExceptMap.colorScale && (
                     <EditorColorScaleSection
                         scale={grapher.chartInstanceExceptMap.colorScale}
-                        chartType={grapher.chartType ?? ChartTypeName.LineChart}
+                        chartType={
+                            grapher.chartType ?? GRAPHER_CHART_TYPES.LineChart
+                        }
                         showLineChartColors={grapher.isLineChart}
                         features={{
                             visualScaling: true,

--- a/adminSiteClient/EditorMapTab.tsx
+++ b/adminSiteClient/EditorMapTab.tsx
@@ -1,7 +1,7 @@
 import {
-    ChartTypeName,
     GrapherInterface,
     MapProjectionName,
+    GRAPHER_MAP_TYPE,
 } from "@ourworldindata/types"
 import {
     ChartDimension,
@@ -202,7 +202,7 @@ export class EditorMapTab<
                         <TimelineSection mapConfig={mapConfig} />
                         <EditorColorScaleSection
                             scale={colorScale}
-                            chartType={ChartTypeName.WorldMap}
+                            chartType={GRAPHER_MAP_TYPE}
                             showLineChartColors={false}
                             features={{
                                 visualScaling: true,

--- a/adminSiteClient/GrapherConfigGridEditor.tsx
+++ b/adminSiteClient/GrapherConfigGridEditor.tsx
@@ -44,7 +44,7 @@ import { BaseEditorComponent, HotColumn, HotTable } from "@handsontable/react"
 import { AdminAppContext, AdminAppContextType } from "./AdminAppContext.js"
 
 import Handsontable from "handsontable"
-import { ChartTypeName, GRAPHER_MAP_TYPE } from "@ourworldindata/types"
+import { GRAPHER_CHART_TYPES, GRAPHER_MAP_TYPE } from "@ourworldindata/types"
 import {
     Grapher,
     GrapherProgrammaticInterface,
@@ -513,7 +513,8 @@ export class GrapherConfigGridEditor extends React.Component<GrapherConfigGridEd
                             <EditorColorScaleSection
                                 scale={colorScale}
                                 chartType={
-                                    grapher.chartType ?? ChartTypeName.LineChart
+                                    grapher.chartType ??
+                                    GRAPHER_CHART_TYPES.LineChart
                                 }
                                 features={{
                                     visualScaling: true,

--- a/adminSiteClient/GrapherConfigGridEditor.tsx
+++ b/adminSiteClient/GrapherConfigGridEditor.tsx
@@ -44,7 +44,7 @@ import { BaseEditorComponent, HotColumn, HotTable } from "@handsontable/react"
 import { AdminAppContext, AdminAppContextType } from "./AdminAppContext.js"
 
 import Handsontable from "handsontable"
-import { ChartTypeName } from "@ourworldindata/types"
+import { ChartTypeName, GRAPHER_MAP_TYPE } from "@ourworldindata/types"
 import {
     Grapher,
     GrapherProgrammaticInterface,
@@ -488,7 +488,7 @@ export class GrapherConfigGridEditor extends React.Component<GrapherConfigGridEd
                     return colorScale ? (
                         <EditorColorScaleSection
                             scale={colorScale}
-                            chartType={ChartTypeName.WorldMap}
+                            chartType={GRAPHER_MAP_TYPE}
                             features={{
                                 visualScaling: true,
                                 legendDescription: false,

--- a/adminSiteClient/VariableEditPage.tsx
+++ b/adminSiteClient/VariableEditPage.tsx
@@ -43,7 +43,7 @@ import { SourceList } from "./SourceList.js"
 import { AdminAppContext, AdminAppContextType } from "./AdminAppContext.js"
 import { Base64 } from "js-base64"
 import {
-    GrapherTabOption,
+    GRAPHER_TAB_OPTIONS,
     GrapherInterface,
     OwidVariableRoundingMode,
 } from "@ourworldindata/types"
@@ -691,13 +691,13 @@ class VariableEditor extends React.Component<{
             return {
                 ...grapherConfig,
                 hasMapTab: true,
-                tab: GrapherTabOption.map,
+                tab: GRAPHER_TAB_OPTIONS.map,
             }
         else
             return {
                 yAxis: { min: 0 },
                 map: { columnSlug: this.props.variable.id.toString() },
-                tab: GrapherTabOption.map,
+                tab: GRAPHER_TAB_OPTIONS.map,
                 hasMapTab: true,
                 dimensions: [
                     {

--- a/adminSiteServer/testPageRouter.tsx
+++ b/adminSiteServer/testPageRouter.tsx
@@ -31,6 +31,7 @@ import {
     GrapherTabOption,
     StackMode,
     parseChartConfig,
+    GRAPHER_MAP_TYPE,
 } from "@ourworldindata/types"
 import { ExplorerAdminServer } from "../explorerAdminServer/ExplorerAdminServer.js"
 import { GIT_CMS_DIR } from "../gitCms/GitCmsConstants.js"
@@ -148,7 +149,7 @@ async function propsFromQueryParams(
     let tab = params.tab
 
     if (params.type) {
-        if (params.type === ChartTypeName.WorldMap) {
+        if (params.type === GRAPHER_MAP_TYPE) {
             query = query.andWhereRaw(`cc.full->>"$.hasMapTab" = "true"`)
             tab = tab || GrapherTabOption.map
         } else {

--- a/adminSiteServer/testPageRouter.tsx
+++ b/adminSiteServer/testPageRouter.tsx
@@ -23,15 +23,16 @@ import {
 } from "@ourworldindata/utils"
 import { grapherToSVG } from "../baker/GrapherImageBaker.js"
 import {
-    ChartTypeName,
     ColorSchemeName,
     DbRawChartConfig,
     DbPlainChart,
     EntitySelectionMode,
-    GrapherTabOption,
+    GRAPHER_TAB_OPTIONS,
     StackMode,
     parseChartConfig,
     GRAPHER_MAP_TYPE,
+    GrapherTabOption,
+    GrapherChartOrMapType,
 } from "@ourworldindata/types"
 import { ExplorerAdminServer } from "../explorerAdminServer/ExplorerAdminServer.js"
 import { GIT_CMS_DIR } from "../gitCms/GitCmsConstants.js"
@@ -102,7 +103,7 @@ interface EmbedTestPageQueryParams {
     readonly page?: string
     readonly random?: string
     readonly tab?: GrapherTabOption
-    readonly type?: ChartTypeName
+    readonly type?: GrapherChartOrMapType
     readonly logLinear?: string
     readonly comparisonLines?: string
     readonly stackMode?: StackMode
@@ -151,12 +152,12 @@ async function propsFromQueryParams(
     if (params.type) {
         if (params.type === GRAPHER_MAP_TYPE) {
             query = query.andWhereRaw(`cc.full->>"$.hasMapTab" = "true"`)
-            tab = tab || GrapherTabOption.map
+            tab = tab || GRAPHER_TAB_OPTIONS.map
         } else {
             query = query.andWhereRaw(`cc.chartType = :type`, {
                 type: params.type,
             })
-            tab = tab || GrapherTabOption.chart
+            tab = tab || GRAPHER_TAB_OPTIONS.chart
         }
     }
 
@@ -164,26 +165,26 @@ async function propsFromQueryParams(
         query = query.andWhereRaw(
             `cc.full->>'$.yAxis.canChangeScaleType' = "true" OR cc.full->>'$.xAxis.canChangeScaleType'  = "true"`
         )
-        tab = GrapherTabOption.chart
+        tab = GRAPHER_TAB_OPTIONS.chart
     }
 
     if (params.comparisonLines) {
         query = query.andWhereRaw(
             `cc.full->'$.comparisonLines[0].yEquals' != ''`
         )
-        tab = GrapherTabOption.chart
+        tab = GRAPHER_TAB_OPTIONS.chart
     }
 
     if (params.stackMode) {
         query = query.andWhereRaw(`cc.full->'$.stackMode' = :stackMode`, {
             stackMode: params.stackMode,
         })
-        tab = GrapherTabOption.chart
+        tab = GRAPHER_TAB_OPTIONS.chart
     }
 
     if (params.relativeToggle) {
         query = query.andWhereRaw(`cc.full->>'$.hideRelativeToggle' = "false"`)
-        tab = GrapherTabOption.chart
+        tab = GRAPHER_TAB_OPTIONS.chart
     }
 
     if (params.categoricalLegend) {
@@ -193,7 +194,7 @@ async function propsFromQueryParams(
         query = query.andWhereRaw(
             `json_length(cc.full->'$.map.colorScale.customCategoryColors') > 1`
         )
-        tab = GrapherTabOption.map
+        tab = GRAPHER_TAB_OPTIONS.map
     }
 
     if (params.mixedTimeTypes) {
@@ -233,9 +234,9 @@ async function propsFromQueryParams(
         query = query.andWhereRaw(`charts.id IN (${params.ids})`)
     }
 
-    if (tab === GrapherTabOption.map) {
+    if (tab === GRAPHER_TAB_OPTIONS.map) {
         query = query.andWhereRaw(`cc.full->>"$.hasMapTab" = "true"`)
-    } else if (tab === GrapherTabOption.chart) {
+    } else if (tab === GRAPHER_TAB_OPTIONS.chart) {
         query = query.andWhereRaw(`cc.chartType IS NOT NULL`)
     }
 

--- a/baker/updateChartEntities.ts
+++ b/baker/updateChartEntities.ts
@@ -9,7 +9,7 @@ import {
     ChartsXEntitiesTableName,
     DbPlainChart,
     GrapherInterface,
-    GrapherTabOption,
+    GRAPHER_TAB_OPTIONS,
     MultipleOwidVariableDataDimensionsMap,
     OwidVariableDataMetadataDimensions,
     DbRawChartConfig,
@@ -97,7 +97,7 @@ const obtainAvailableEntitiesForGrapherConfig = async (
 
     // If the grapher has a chart tab, then the available entities there are the "most interesting" ones to us
     if (grapher.hasChartTab) {
-        grapher.tab = GrapherTabOption.chart
+        grapher.tab = GRAPHER_TAB_OPTIONS.chart
 
         // If the grapher allows for changing or multi-selecting entities, then let's index all entities the
         // user can choose from. Otherwise, we'll just use the default-selected entities.
@@ -112,7 +112,7 @@ const obtainAvailableEntitiesForGrapherConfig = async (
             return grapher.tableForSelection.availableEntityNames as string[]
         else return grapher.selectedEntityNames ?? []
     } else if (grapher.hasMapTab) {
-        grapher.tab = GrapherTabOption.map
+        grapher.tab = GRAPHER_TAB_OPTIONS.map
         // On a map tab, tableAfterAuthorTimelineAndActiveChartTransform contains all
         // mappable entities for which data is available
         return grapher.tableAfterAuthorTimelineAndActiveChartTransform

--- a/db/migration/1661264304751-MigrateSelectedData.ts
+++ b/db/migration/1661264304751-MigrateSelectedData.ts
@@ -3,7 +3,7 @@ import { MigrationInterface, QueryRunner } from "typeorm"
 
 import { entityNameById } from "./data/entityNameById.js"
 
-import { ChartTypeName } from "@ourworldindata/types"
+import { GRAPHER_CHART_TYPES, GrapherChartType } from "@ourworldindata/types"
 
 type GrapherInterface = Record<string, any>
 
@@ -85,11 +85,11 @@ export class MigrateSelectedData1661264304751 implements MigrationInterface {
                 }
             })
 
-        const migrateDimensionsTypes: ChartTypeName[] = [
-            ChartTypeName.Marimekko,
-            ChartTypeName.StackedArea,
-            ChartTypeName.StackedBar,
-            ChartTypeName.StackedDiscreteBar,
+        const migrateDimensionsTypes: GrapherChartType[] = [
+            GRAPHER_CHART_TYPES.Marimekko,
+            GRAPHER_CHART_TYPES.StackedArea,
+            GRAPHER_CHART_TYPES.StackedBar,
+            GRAPHER_CHART_TYPES.StackedDiscreteBar,
         ]
 
         // Migrate order of dimensions.

--- a/db/model/Chart.ts
+++ b/db/model/Chart.ts
@@ -13,7 +13,6 @@ import {
 } from "@ourworldindata/utils"
 import {
     GrapherInterface,
-    ChartTypeName,
     RelatedChart,
     DbPlainPostLink,
     DbPlainChart,
@@ -22,6 +21,7 @@ import {
     DbPlainTag,
     DbRawChartConfig,
     DbEnrichedChartConfig,
+    GrapherChartType,
 } from "@ourworldindata/types"
 import { OpenAI } from "openai"
 import {
@@ -556,7 +556,7 @@ export async function getChartVariableData(
 
 export const getMostViewedGrapherIdsByChartType = async (
     knex: db.KnexReadonlyTransaction,
-    chartType: ChartTypeName,
+    chartType: GrapherChartType,
     count = 10
 ): Promise<number[]> => {
     const ids = await db.knexRaw<{ id: number }>(

--- a/db/model/Gdoc/GdocBase.ts
+++ b/db/model/Gdoc/GdocBase.ts
@@ -19,7 +19,7 @@ import {
     OwidGdocMinimalPostInterface,
     urlToSlug,
     grabMetadataForGdocLinkedIndicator,
-    GrapherTabOption,
+    GRAPHER_TAB_OPTIONS,
     DbInsertPostGdocLink,
     DbPlainTag,
     formatDate,
@@ -934,7 +934,7 @@ export async function makeGrapherLinkedChart(
     const resolvedSlug = config.slug ?? ""
     const resolvedTitle = config.title ?? ""
     const resolvedUrl = `${BAKED_GRAPHER_URL}/${resolvedSlug}`
-    const tab = config.tab ?? GrapherTabOption.chart
+    const tab = config.tab ?? GRAPHER_TAB_OPTIONS.chart
     const datapageIndicator = await getVariableOfDatapageIfApplicable(config)
     return {
         configType: ChartConfigType.Grapher,

--- a/db/model/Variable.ts
+++ b/db/model/Variable.ts
@@ -22,7 +22,7 @@ import {
     OwidVariableMixedData,
     OwidVariableWithSourceAndDimension,
     OwidVariableId,
-    ChartTypeName,
+    GRAPHER_CHART_TYPES,
     DimensionProperty,
     GrapherInterface,
     DbRawVariable,
@@ -878,7 +878,7 @@ export async function getVariableOfDatapageIfApplicable(
     // showing a data page.
     if (
         yVariableIds.length === 1 &&
-        (grapher.chartTypes?.[0] !== ChartTypeName.ScatterPlot ||
+        (grapher.chartTypes?.[0] !== GRAPHER_CHART_TYPES.ScatterPlot ||
             xVariableIds.length === 0)
     ) {
         const variableId = yVariableIds[0]

--- a/devTools/graphersToGit/tasks.ts
+++ b/devTools/graphersToGit/tasks.ts
@@ -2,7 +2,7 @@
 
 import { CoreTable } from "@ourworldindata/core-table"
 import {
-    ChartTypeName,
+    GRAPHER_CHART_TYPES,
     ColorScaleConfig,
     Grapher,
     GrapherProgrammaticInterface,
@@ -173,7 +173,7 @@ const dumpComplexSelections = async () => {
                 : 0
         return {
             grapherId: config.id,
-            type: config.type ?? ChartTypeName.LineChart,
+            type: config.type ?? GRAPHER_CHART_TYPES.LineChart,
             url: `https://ourworldindata.org/grapher/${config.slug}`,
             dimensionVariableCount,
             selectionVariableCount,

--- a/devTools/svgTester/chart-configurations.ts
+++ b/devTools/svgTester/chart-configurations.ts
@@ -88,7 +88,6 @@ const VIEW_MATRIX_BY_CHART_TYPE: Record<ChartTypeName, ViewMatrix> = {
         facet: facetOptions,
         uniformYAxis: booleanOptions,
     },
-    [ChartTypeName.WorldMap]: {},
 }
 
 // the above view matrix is used to generate all possible combinations of query params
@@ -129,7 +128,6 @@ const EXCLUDE_VIEWS_BY_CHART_TYPE: Record<
         // sharing an axis only makes sense if a chart is faceted
         { facet: FacetStrategy.none, uniformYAxis: Boolean.true },
     ],
-    [ChartTypeName.WorldMap]: [],
 }
 
 export const queryStringsByChartType = Object.fromEntries(

--- a/devTools/svgTester/chart-configurations.ts
+++ b/devTools/svgTester/chart-configurations.ts
@@ -1,10 +1,11 @@
 import _ from "lodash"
 import {
-    ChartTypeName,
+    GRAPHER_CHART_TYPES,
     StackMode,
     ScaleType,
     FacetStrategy,
     GrapherQueryParams,
+    GrapherChartType,
 } from "@ourworldindata/types"
 import { cartesian } from "@ourworldindata/utils"
 
@@ -32,8 +33,8 @@ const scaleTypeOptions = Object.values(ScaleType)
 const facetOptions = Object.values(FacetStrategy)
 const booleanOptions = Object.values(Boolean)
 
-const VIEW_MATRIX_BY_CHART_TYPE: Record<ChartTypeName, ViewMatrix> = {
-    [ChartTypeName.LineChart]: {
+const VIEW_MATRIX_BY_CHART_TYPE: Record<GrapherChartType, ViewMatrix> = {
+    [GRAPHER_CHART_TYPES.LineChart]: {
         tab: ["chart"],
         time: timeOptionsAll,
         stackMode: stackModeOptions,
@@ -41,7 +42,7 @@ const VIEW_MATRIX_BY_CHART_TYPE: Record<ChartTypeName, ViewMatrix> = {
         facet: facetOptions,
         uniformYAxis: booleanOptions,
     },
-    [ChartTypeName.ScatterPlot]: {
+    [GRAPHER_CHART_TYPES.ScatterPlot]: {
         tab: ["chart"],
         time: timeOptionsAll,
         stackMode: stackModeOptions,
@@ -50,38 +51,38 @@ const VIEW_MATRIX_BY_CHART_TYPE: Record<ChartTypeName, ViewMatrix> = {
         endpointsOnly: booleanOptions,
         // zoomToSelection ignored for now
     },
-    [ChartTypeName.DiscreteBar]: {
+    [GRAPHER_CHART_TYPES.DiscreteBar]: {
         tab: ["chart"],
         time: timePoints,
         facet: facetOptions,
         // uniformYAxis doesn't apply
     },
-    [ChartTypeName.StackedDiscreteBar]: {
+    [GRAPHER_CHART_TYPES.StackedDiscreteBar]: {
         tab: ["chart"],
         time: timePoints,
         stackMode: stackModeOptions,
         facet: facetOptions,
         // uniformYAxis doesn't apply
     },
-    [ChartTypeName.Marimekko]: {
+    [GRAPHER_CHART_TYPES.Marimekko]: {
         tab: ["chart"],
         time: timePoints,
         stackMode: stackModeOptions,
         showNoDataArea: booleanOptions,
     },
-    [ChartTypeName.SlopeChart]: {
+    [GRAPHER_CHART_TYPES.SlopeChart]: {
         tab: ["chart"],
         time: timeSpan,
         yScale: scaleTypeOptions,
     },
-    [ChartTypeName.StackedArea]: {
+    [GRAPHER_CHART_TYPES.StackedArea]: {
         tab: ["chart"],
         time: timeSpan,
         stackMode: stackModeOptions,
         facet: facetOptions,
         uniformYAxis: booleanOptions,
     },
-    [ChartTypeName.StackedBar]: {
+    [GRAPHER_CHART_TYPES.StackedBar]: {
         tab: ["chart"],
         time: timeSpan,
         stackMode: stackModeOptions,
@@ -94,16 +95,16 @@ const VIEW_MATRIX_BY_CHART_TYPE: Record<ChartTypeName, ViewMatrix> = {
 // but some combinations don't make sense. this matrix is used to exclude those combinations.
 // for example, if a chart is not faceted, the uniformYAxis param doesn't apply
 const EXCLUDE_VIEWS_BY_CHART_TYPE: Record<
-    ChartTypeName,
+    GrapherChartType,
     Record<keyof GrapherQueryParams, string>[]
 > = {
-    [ChartTypeName.LineChart]: [
+    [GRAPHER_CHART_TYPES.LineChart]: [
         // sharing an axis only makes sense if a chart is faceted
         { facet: FacetStrategy.none, uniformYAxis: Boolean.true },
         // log scale for percentage values doesn't make sense
         { stackMode: StackMode.relative, yScale: ScaleType.log },
     ],
-    [ChartTypeName.ScatterPlot]: [
+    [GRAPHER_CHART_TYPES.ScatterPlot]: [
         // relative mode only makes sense if a time span is selected
         { time: TimePoint.earliest, stackMode: StackMode.relative },
         { time: TimePoint.latest, stackMode: StackMode.relative },
@@ -116,15 +117,15 @@ const EXCLUDE_VIEWS_BY_CHART_TYPE: Record<
         { stackMode: StackMode.relative, yScale: ScaleType.log },
         { stackMode: StackMode.relative, xScale: ScaleType.log },
     ],
-    [ChartTypeName.DiscreteBar]: [],
-    [ChartTypeName.StackedDiscreteBar]: [],
-    [ChartTypeName.Marimekko]: [],
-    [ChartTypeName.SlopeChart]: [],
-    [ChartTypeName.StackedArea]: [
+    [GRAPHER_CHART_TYPES.DiscreteBar]: [],
+    [GRAPHER_CHART_TYPES.StackedDiscreteBar]: [],
+    [GRAPHER_CHART_TYPES.Marimekko]: [],
+    [GRAPHER_CHART_TYPES.SlopeChart]: [],
+    [GRAPHER_CHART_TYPES.StackedArea]: [
         // sharing an axis only makes sense if a chart is faceted
         { facet: FacetStrategy.none, uniformYAxis: Boolean.true },
     ],
-    [ChartTypeName.StackedBar]: [
+    [GRAPHER_CHART_TYPES.StackedBar]: [
         // sharing an axis only makes sense if a chart is faceted
         { facet: FacetStrategy.none, uniformYAxis: Boolean.true },
     ],
@@ -135,7 +136,7 @@ export const queryStringsByChartType = Object.fromEntries(
         const combinations = explode(viewMatrix)
 
         const viewsToExclude =
-            EXCLUDE_VIEWS_BY_CHART_TYPE[chartType as ChartTypeName]
+            EXCLUDE_VIEWS_BY_CHART_TYPE[chartType as GrapherChartType]
         const validCombinations = combinations.filter((view) =>
             viewsToExclude.every(
                 (viewToExclude) => !_.isMatch(view, viewToExclude)
@@ -145,7 +146,7 @@ export const queryStringsByChartType = Object.fromEntries(
         const queryStrings = validCombinations.map(toQueryStr)
         return [chartType, queryStrings]
     })
-) as Record<ChartTypeName, string[]>
+) as Record<GrapherChartType, string[]>
 
 function toQueryStr(params: Record<string, string>): string {
     return new URLSearchParams(params).toString()

--- a/devTools/svgTester/dump-chart-ids.ts
+++ b/devTools/svgTester/dump-chart-ids.ts
@@ -5,7 +5,7 @@ import parseArgs from "minimist"
 
 import { TransactionCloseMode, knexReadonlyTransaction } from "../../db/db.js"
 import { getMostViewedGrapherIdsByChartType } from "../../db/model/Chart.js"
-import { CHART_TYPES } from "./utils.js"
+import { allChartTypes } from "./utils.js"
 
 const DEFAULT_OUT_FILE = "../owid-grapher-svgs/most-viewed-charts.txt"
 const CHART_COUNT_PER_TYPE = 25
@@ -15,7 +15,7 @@ async function main(parsedArgs: parseArgs.ParsedArgs) {
         const outFile = parsedArgs["o"] ?? DEFAULT_OUT_FILE
 
         const chartIds = await knexReadonlyTransaction(async (trx) => {
-            const promises = CHART_TYPES.flatMap((chartType) =>
+            const promises = allChartTypes.flatMap((chartType) =>
                 getMostViewedGrapherIdsByChartType(
                     trx,
                     chartType,

--- a/devTools/svgTester/dump-chart-ids.ts
+++ b/devTools/svgTester/dump-chart-ids.ts
@@ -5,7 +5,7 @@ import parseArgs from "minimist"
 
 import { TransactionCloseMode, knexReadonlyTransaction } from "../../db/db.js"
 import { getMostViewedGrapherIdsByChartType } from "../../db/model/Chart.js"
-import { allChartTypes } from "./utils.js"
+import { ALL_GRAPHER_CHART_TYPES } from "@ourworldindata/types"
 
 const DEFAULT_OUT_FILE = "../owid-grapher-svgs/most-viewed-charts.txt"
 const CHART_COUNT_PER_TYPE = 25
@@ -15,7 +15,7 @@ async function main(parsedArgs: parseArgs.ParsedArgs) {
         const outFile = parsedArgs["o"] ?? DEFAULT_OUT_FILE
 
         const chartIds = await knexReadonlyTransaction(async (trx) => {
-            const promises = allChartTypes.flatMap((chartType) =>
+            const promises = ALL_GRAPHER_CHART_TYPES.flatMap((chartType) =>
                 getMostViewedGrapherIdsByChartType(
                     trx,
                     chartType,

--- a/devTools/svgTester/utils.ts
+++ b/devTools/svgTester/utils.ts
@@ -1,7 +1,8 @@
 import {
-    ChartTypeName,
+    GRAPHER_CHART_TYPES,
+    GrapherChartType,
     GrapherTabName,
-    GrapherTabOption,
+    ALL_GRAPHER_CHART_TYPES,
 } from "@ourworldindata/types"
 import {
     MultipleOwidVariableDataDimensionsMap,
@@ -26,8 +27,6 @@ import { getHeapStatistics } from "v8"
 import { queryStringsByChartType } from "./chart-configurations.js"
 import * as d3 from "d3"
 
-export const allChartTypes = Object.values(ChartTypeName)
-
 // the owid-grapher-svgs repo is usually cloned as a sibling to the owid-grapher repo
 export const DEFAULT_CONFIGS_DIR = "../owid-grapher-svgs/configs"
 export const DEFAULT_REFERENCE_DIR = "../owid-grapher-svgs/svg"
@@ -41,7 +40,7 @@ export const finished = util.promisify(stream.finished) // (A)
 export interface ChartWithQueryStr {
     id: number
     slug: string
-    type: ChartTypeName
+    type: GrapherChartType
     queryStr?: string
 }
 
@@ -179,7 +178,7 @@ export async function selectChartIdsToProcess(
     options: {
         chartIdsFile?: string
         grapherIds?: number[]
-        chartTypes?: ChartTypeName[]
+        chartTypes?: GrapherChartType[]
         randomCount?: number
     }
 ): Promise<number[]> {
@@ -207,7 +206,7 @@ export async function findChartViewsToGenerate(
 
         const slug = grapherConfig.slug ?? chartId.toString()
         const chartType =
-            grapherConfig.chartTypes?.[0] ?? ChartTypeName.LineChart
+            grapherConfig.chartTypes?.[0] ?? GRAPHER_CHART_TYPES.LineChart
 
         const queryStrings = options.shouldTestAllViews
             ? queryStringsByChartType[chartType]
@@ -237,7 +236,7 @@ export async function findValidChartIds(
     }: {
         chartIdsFile?: string
         grapherIds?: number[]
-        chartTypes?: ChartTypeName[]
+        chartTypes?: GrapherChartType[]
     }
 ): Promise<number[]> {
     const validChartIds: number[] = []
@@ -286,7 +285,8 @@ export async function findValidChartIds(
                     inDir,
                 })
                 const chartType =
-                    grapherConfig.chartTypes?.[0] ?? ChartTypeName.LineChart
+                    grapherConfig.chartTypes?.[0] ??
+                    GRAPHER_CHART_TYPES.LineChart
                 if (chartTypes.includes(chartType)) {
                     validChartIds.push(grapherId)
                 }
@@ -297,17 +297,17 @@ export async function findValidChartIds(
     return validChartIds
 }
 
-export function validateChartTypes(chartTypes: string[]): ChartTypeName[] {
+export function validateChartTypes(chartTypes: string[]): GrapherChartType[] {
     const validChartTypes = chartTypes.filter(
-        (chartType): chartType is ChartTypeName =>
-            allChartTypes.includes(chartType as any)
+        (chartType): chartType is GrapherChartType =>
+            ALL_GRAPHER_CHART_TYPES.includes(chartType as any)
     )
     const invalidChartTypes = chartTypes.filter(
-        (chartType) => !allChartTypes.includes(chartType as any)
+        (chartType) => !ALL_GRAPHER_CHART_TYPES.includes(chartType as any)
     )
     if (invalidChartTypes.length) {
         console.warn(
-            `Invalid chart types given: ${invalidChartTypes}. Valid chart types are: ${allChartTypes}`
+            `Invalid chart types given: ${invalidChartTypes}. Valid chart types are: ${ALL_GRAPHER_CHART_TYPES}`
         )
     }
     return _.uniq(validChartTypes)

--- a/devTools/svgTester/utils.ts
+++ b/devTools/svgTester/utils.ts
@@ -26,10 +26,7 @@ import { getHeapStatistics } from "v8"
 import { queryStringsByChartType } from "./chart-configurations.js"
 import * as d3 from "d3"
 
-// ignore WorldMaps
-export const CHART_TYPES = Object.values(ChartTypeName).filter(
-    (chartType) => chartType !== ChartTypeName.WorldMap
-)
+export const allChartTypes = Object.values(ChartTypeName)
 
 // the owid-grapher-svgs repo is usually cloned as a sibling to the owid-grapher repo
 export const DEFAULT_CONFIGS_DIR = "../owid-grapher-svgs/configs"
@@ -303,14 +300,14 @@ export async function findValidChartIds(
 export function validateChartTypes(chartTypes: string[]): ChartTypeName[] {
     const validChartTypes = chartTypes.filter(
         (chartType): chartType is ChartTypeName =>
-            CHART_TYPES.includes(chartType as any)
+            allChartTypes.includes(chartType as any)
     )
     const invalidChartTypes = chartTypes.filter(
-        (chartType) => !CHART_TYPES.includes(chartType as any)
+        (chartType) => !allChartTypes.includes(chartType as any)
     )
     if (invalidChartTypes.length) {
         console.warn(
-            `Invalid chart types given: ${invalidChartTypes}. Valid chart types are: ${CHART_TYPES}`
+            `Invalid chart types given: ${invalidChartTypes}. Valid chart types are: ${allChartTypes}`
         )
     }
     return _.uniq(validChartTypes)

--- a/packages/@ourworldindata/explorer/src/Explorer.jsdom.test.tsx
+++ b/packages/@ourworldindata/explorer/src/Explorer.jsdom.test.tsx
@@ -8,7 +8,7 @@ import {
 
 import Enzyme from "enzyme"
 import Adapter from "@wojtekmaj/enzyme-adapter-react-17"
-import { GrapherTabOption } from "@ourworldindata/types"
+import { GRAPHER_TAB_OPTIONS } from "@ourworldindata/types"
 
 Enzyme.configure({ adapter: new Adapter() })
 
@@ -30,20 +30,20 @@ describe(Explorer, () => {
 
         explorer.onChangeChoice("Gas")("All GHGs (CO₂eq)")
 
-        if (explorer.grapher) explorer.grapher.tab = GrapherTabOption.table
+        if (explorer.grapher) explorer.grapher.tab = GRAPHER_TAB_OPTIONS.table
         else throw Error("where's the grapher?")
         expect(explorer.queryParams.tab).toEqual("table")
 
         explorer.onChangeChoice("Gas")("CO₂")
         expect(explorer.queryParams.tab).toEqual("table")
 
-        explorer.grapher.tab = GrapherTabOption.chart
+        explorer.grapher.tab = GRAPHER_TAB_OPTIONS.chart
     })
 
     it("switches to first tab if current tab does not exist in new view", () => {
         const explorer = element.instance() as Explorer
         expect(explorer.queryParams.tab).toBeUndefined()
-        if (explorer.grapher) explorer.grapher.tab = GrapherTabOption.map
+        if (explorer.grapher) explorer.grapher.tab = GRAPHER_TAB_OPTIONS.map
         else throw Error("where's the grapher?")
         expect(explorer.queryParams.tab).toEqual("map")
 

--- a/packages/@ourworldindata/explorer/src/Explorer.sample.tsx
+++ b/packages/@ourworldindata/explorer/src/Explorer.sample.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { DimensionProperty } from "@ourworldindata/utils"
-import { GrapherTabOption } from "@ourworldindata/types"
+import { GRAPHER_TAB_OPTIONS } from "@ourworldindata/types"
 import { GrapherProgrammaticInterface } from "@ourworldindata/grapher"
 import { Explorer, ExplorerProps } from "./Explorer.js"
 
@@ -54,7 +54,7 @@ export const SampleExplorerOfGraphers = (props?: Partial<ExplorerProps>) => {
                 property: DimensionProperty.y,
             },
         ],
-        tab: GrapherTabOption.chart,
+        tab: GRAPHER_TAB_OPTIONS.chart,
         owidDataset: new Map([
             [
                 142609,

--- a/packages/@ourworldindata/explorer/src/Explorer.tsx
+++ b/packages/@ourworldindata/explorer/src/Explorer.tsx
@@ -8,8 +8,7 @@ import {
     TableSlug,
     GrapherInterface,
     GrapherQueryParams,
-    GrapherTabQueryParam,
-    GrapherTabName,
+    GRAPHER_TAB_QUERY_PARAMS,
 } from "@ourworldindata/types"
 import {
     OwidTable,
@@ -455,14 +454,14 @@ export class Explorer
         } else if (this.grapher.validChartTypes.length > 0) {
             // otherwise, switch to the first chart tab
             newGrapherParams.tab = this.grapher.mapGrapherTabToQueryParam(
-                this.grapher.validChartTypes[0] as unknown as GrapherTabName
+                this.grapher.validChartTypes[0]
             )
         } else if (this.grapher.hasMapTab) {
             // or switch to the map, if there is one
-            newGrapherParams.tab = GrapherTabQueryParam.WorldMap
+            newGrapherParams.tab = GRAPHER_TAB_QUERY_PARAMS.map
         } else {
             // if everything fails, switch to the table tab that is always available
-            newGrapherParams.tab = GrapherTabQueryParam.Table
+            newGrapherParams.tab = GRAPHER_TAB_QUERY_PARAMS.table
         }
 
         this.grapher.populateFromQueryParams(newGrapherParams)

--- a/packages/@ourworldindata/explorer/src/ExplorerProgram.ts
+++ b/packages/@ourworldindata/explorer/src/ExplorerProgram.ts
@@ -8,7 +8,7 @@ import {
     FacetAxisDomain,
     GrapherInterface,
     AxisMinMaxValueStr,
-    ChartTypeName,
+    GrapherChartType,
 } from "@ourworldindata/types"
 import {
     CoreTable,
@@ -65,7 +65,7 @@ interface ExplorerGrapherInterface extends GrapherInterface {
     relatedQuestionText?: string
     relatedQuestionUrl?: string
     mapTargetTime?: number
-    type?: ChartTypeName | "None"
+    type?: GrapherChartType | "None"
 }
 
 const ExplorerRootDef: CellDef = {

--- a/packages/@ourworldindata/explorer/src/GrapherGrammar.ts
+++ b/packages/@ourworldindata/explorer/src/GrapherGrammar.ts
@@ -1,9 +1,9 @@
 import {
-    ChartTypeName,
+    ALL_GRAPHER_CHART_TYPES,
     ColorSchemeName,
     FacetAxisDomain,
     FacetStrategy,
-    GrapherTabOption,
+    GRAPHER_TAB_OPTIONS,
     MissingDataStrategy,
     StackMode,
 } from "@ourworldindata/types"
@@ -65,7 +65,7 @@ export const GrapherGrammar: Grammar<GrapherCellDef> = {
         keyword: "type",
         description: `The type of chart to show such as LineChart or ScatterPlot. If set to None, then the chart tab is hidden.`,
         terminalOptions: toTerminalOptions([
-            ...Object.values(ChartTypeName),
+            ...ALL_GRAPHER_CHART_TYPES,
             "None",
         ]),
         toGrapherObject: (value) => ({
@@ -95,7 +95,7 @@ export const GrapherGrammar: Grammar<GrapherCellDef> = {
         ...EnumCellDef,
         keyword: "tab",
         description: "Which tab to show by default",
-        terminalOptions: toTerminalOptions(Object.values(GrapherTabOption)),
+        terminalOptions: toTerminalOptions(Object.values(GRAPHER_TAB_OPTIONS)),
         toGrapherObject: (value) => ({ tab: value }),
     },
     xSlug: {

--- a/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.stories.tsx
+++ b/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.stories.tsx
@@ -1,8 +1,8 @@
 import { SynthesizeGDPTable } from "@ourworldindata/core-table"
 import {
-    ChartTypeName,
+    GRAPHER_CHART_TYPES,
     FacetStrategy,
-    GrapherTabOption,
+    GRAPHER_TAB_OPTIONS,
     SeriesStrategy,
 } from "@ourworldindata/types"
 import { DEFAULT_BOUNDS } from "@ourworldindata/utils"
@@ -48,13 +48,13 @@ export const StaticLineChartForExport = (): React.ReactElement => {
 }
 
 export const MapChart = (): React.ReactElement => (
-    <CaptionedChart manager={{ ...manager, tab: GrapherTabOption.map }} />
+    <CaptionedChart manager={{ ...manager, tab: GRAPHER_TAB_OPTIONS.map }} />
 )
 export const StackedArea = (): React.ReactElement => (
     <CaptionedChart
         manager={{
             ...manager,
-            type: ChartTypeName.StackedArea,
+            type: GRAPHER_CHART_TYPES.StackedArea,
             seriesStrategy: SeriesStrategy.entity,
         }}
     />
@@ -63,7 +63,7 @@ export const Scatter = (): React.ReactElement => (
     <CaptionedChart
         manager={{
             ...manager,
-            type: ChartTypeName.ScatterPlot,
+            type: GRAPHER_CHART_TYPES.ScatterPlot,
             table: table.filterByTargetTimes([1999], 0),
         }}
     />

--- a/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
@@ -39,6 +39,8 @@ import {
     RelatedQuestionsConfig,
     Color,
     GrapherTabName,
+    GRAPHER_MAP_TYPE,
+    GrapherChartOrMapType,
 } from "@ourworldindata/types"
 import { DataTable, DataTableManager } from "../dataTable/DataTable"
 import {
@@ -189,10 +191,10 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
         return !this.manager.isOnMapTab && hasStrategy
     }
 
-    @computed get activeChartType(): ChartTypeName | undefined {
+    @computed get activeChartOrMapType(): GrapherChartOrMapType | undefined {
         const { manager } = this
         if (manager.isOnTableTab) return undefined
-        if (manager.isOnMapTab) return ChartTypeName.WorldMap
+        if (manager.isOnMapTab) return GRAPHER_MAP_TYPE
         if (manager.isOnChartTab) {
             return manager.isLineChartThatTurnedIntoDiscreteBar
                 ? ChartTypeName.DiscreteBar
@@ -202,20 +204,21 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
     }
 
     renderChart(): React.ReactElement | void {
-        const { manager, activeChartType, containerElement } = this
+        const { manager, activeChartOrMapType, containerElement } = this
 
-        if (!activeChartType) return
+        if (!activeChartOrMapType) return
 
         const bounds = this.boundsForChartArea
         const ChartClass =
-            ChartComponentClassMap.get(activeChartType) ?? DefaultChartClass
+            ChartComponentClassMap.get(activeChartOrMapType) ??
+            DefaultChartClass
 
         // Todo: make FacetChart a chart type name?
-        if (this.isFaceted)
+        if (this.isFaceted && activeChartOrMapType !== GRAPHER_MAP_TYPE)
             return (
                 <FacetChart
                     bounds={bounds}
-                    chartTypeName={activeChartType}
+                    chartTypeName={activeChartOrMapType}
                     manager={manager}
                 />
             )

--- a/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
@@ -34,13 +34,14 @@ import { HeaderManager } from "../header/HeaderManager"
 import { SelectionArray } from "../selection/SelectionArray"
 import {
     EntityName,
-    ChartTypeName,
+    GRAPHER_CHART_TYPES,
     FacetStrategy,
     RelatedQuestionsConfig,
     Color,
     GrapherTabName,
     GRAPHER_MAP_TYPE,
     GrapherChartOrMapType,
+    GrapherChartType,
 } from "@ourworldindata/types"
 import { DataTable, DataTableManager } from "../dataTable/DataTable"
 import {
@@ -81,7 +82,7 @@ export interface CaptionedChartManager
     activeTab?: GrapherTabName
     isOnMapTab?: boolean
     isOnTableTab?: boolean
-    activeChartType?: ChartTypeName
+    activeChartType?: GrapherChartType
     isLineChartThatTurnedIntoDiscreteBar?: boolean
     showEntitySelectionToggle?: boolean
     isExportingForSocialMedia?: boolean
@@ -197,31 +198,39 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
         if (manager.isOnMapTab) return GRAPHER_MAP_TYPE
         if (manager.isOnChartTab) {
             return manager.isLineChartThatTurnedIntoDiscreteBar
-                ? ChartTypeName.DiscreteBar
+                ? GRAPHER_CHART_TYPES.DiscreteBar
                 : manager.activeChartType
         }
         return undefined
     }
 
     renderChart(): React.ReactElement | void {
-        const { manager, activeChartOrMapType, containerElement } = this
+        const {
+            manager,
+            boundsForChartArea: bounds,
+            activeChartOrMapType,
+            containerElement,
+        } = this
 
         if (!activeChartOrMapType) return
 
-        const bounds = this.boundsForChartArea
-        const ChartClass =
-            ChartComponentClassMap.get(activeChartOrMapType) ??
-            DefaultChartClass
-
         // Todo: make FacetChart a chart type name?
-        if (this.isFaceted && activeChartOrMapType !== GRAPHER_MAP_TYPE)
+        const activeChartType =
+            activeChartOrMapType !== GRAPHER_MAP_TYPE
+                ? activeChartOrMapType
+                : undefined
+        if (this.isFaceted && activeChartType)
             return (
                 <FacetChart
                     bounds={bounds}
-                    chartTypeName={activeChartOrMapType}
+                    chartTypeName={activeChartType}
                     manager={manager}
                 />
             )
+
+        const ChartClass =
+            ChartComponentClassMap.get(activeChartOrMapType) ??
+            DefaultChartClass
 
         return (
             <ChartClass

--- a/packages/@ourworldindata/grapher/src/chart/ChartTypeMap.tsx
+++ b/packages/@ourworldindata/grapher/src/chart/ChartTypeMap.tsx
@@ -4,7 +4,11 @@ import { LineChart } from "../lineCharts/LineChart"
 import { StackedAreaChart } from "../stackedCharts/StackedAreaChart"
 import { DiscreteBarChart } from "../barCharts/DiscreteBarChart"
 import { StackedBarChart } from "../stackedCharts/StackedBarChart"
-import { ChartTypeName } from "@ourworldindata/types"
+import {
+    ChartTypeName,
+    GrapherChartOrMapType,
+    GRAPHER_MAP_TYPE,
+} from "@ourworldindata/types"
 import { MapChart } from "../mapCharts/MapChart"
 import { ChartInterface } from "./ChartInterface"
 import { ChartManager } from "./ChartManager"
@@ -24,7 +28,7 @@ interface ChartComponentClass extends ComponentClass<ChartComponentProps> {
 }
 
 export const ChartComponentClassMap = new Map<
-    ChartTypeName,
+    GrapherChartOrMapType,
     ChartComponentClass
 >([
     [ChartTypeName.DiscreteBar, DiscreteBarChart],
@@ -35,7 +39,7 @@ export const ChartComponentClassMap = new Map<
     [ChartTypeName.StackedDiscreteBar, StackedDiscreteBarChart],
     [ChartTypeName.ScatterPlot, ScatterPlotChart],
     [ChartTypeName.Marimekko, MarimekkoChart],
-    [ChartTypeName.WorldMap, MapChart],
+    [GRAPHER_MAP_TYPE, MapChart],
 ])
 
 export const DefaultChartClass = LineChart as ChartComponentClass

--- a/packages/@ourworldindata/grapher/src/chart/ChartTypeMap.tsx
+++ b/packages/@ourworldindata/grapher/src/chart/ChartTypeMap.tsx
@@ -5,7 +5,7 @@ import { StackedAreaChart } from "../stackedCharts/StackedAreaChart"
 import { DiscreteBarChart } from "../barCharts/DiscreteBarChart"
 import { StackedBarChart } from "../stackedCharts/StackedBarChart"
 import {
-    ChartTypeName,
+    GRAPHER_CHART_TYPES,
     GrapherChartOrMapType,
     GRAPHER_MAP_TYPE,
 } from "@ourworldindata/types"
@@ -31,15 +31,16 @@ export const ChartComponentClassMap = new Map<
     GrapherChartOrMapType,
     ChartComponentClass
 >([
-    [ChartTypeName.DiscreteBar, DiscreteBarChart],
-    [ChartTypeName.LineChart, LineChart],
-    [ChartTypeName.SlopeChart, SlopeChart],
-    [ChartTypeName.StackedArea, StackedAreaChart],
-    [ChartTypeName.StackedBar, StackedBarChart],
-    [ChartTypeName.StackedDiscreteBar, StackedDiscreteBarChart],
-    [ChartTypeName.ScatterPlot, ScatterPlotChart],
-    [ChartTypeName.Marimekko, MarimekkoChart],
+    [GRAPHER_CHART_TYPES.DiscreteBar, DiscreteBarChart],
+    [GRAPHER_CHART_TYPES.LineChart, LineChart],
+    [GRAPHER_CHART_TYPES.SlopeChart, SlopeChart],
+    [GRAPHER_CHART_TYPES.StackedArea, StackedAreaChart],
+    [GRAPHER_CHART_TYPES.StackedBar, StackedBarChart],
+    [GRAPHER_CHART_TYPES.StackedDiscreteBar, StackedDiscreteBarChart],
+    [GRAPHER_CHART_TYPES.ScatterPlot, ScatterPlotChart],
+    [GRAPHER_CHART_TYPES.Marimekko, MarimekkoChart],
     [GRAPHER_MAP_TYPE, MapChart],
 ])
 
 export const DefaultChartClass = LineChart as ChartComponentClass
+export const defaultChartType = GRAPHER_CHART_TYPES.LineChart

--- a/packages/@ourworldindata/grapher/src/chart/ChartTypeSwitcher.tsx
+++ b/packages/@ourworldindata/grapher/src/chart/ChartTypeSwitcher.tsx
@@ -1,9 +1,12 @@
 import React from "react"
-import { ChartTypeName } from "@ourworldindata/types"
+import {
+    ALL_GRAPHER_CHART_TYPES,
+    GrapherChartType,
+} from "@ourworldindata/types"
 
 // Just a utility for testing
 export class ChartTypeSwitcher extends React.Component<{
-    onChange: (chartType: ChartTypeName) => void
+    onChange: (chartType: GrapherChartType) => void
 }> {
     render(): React.ReactElement {
         return (
@@ -12,7 +15,7 @@ export class ChartTypeSwitcher extends React.Component<{
                     this.props.onChange(event.target.value as any)
                 }
             >
-                {Object.values(ChartTypeName).map((value) => (
+                {ALL_GRAPHER_CHART_TYPES.map((value) => (
                     <option key={value} value={value}>
                         {value}
                     </option>

--- a/packages/@ourworldindata/grapher/src/chart/ChartUtils.tsx
+++ b/packages/@ourworldindata/grapher/src/chart/ChartUtils.tsx
@@ -4,7 +4,9 @@ import {
     SeriesStrategy,
     EntityName,
     GrapherTabQueryParam,
-    ChartTypeName,
+    GrapherChartType,
+    GRAPHER_CHART_TYPES,
+    GRAPHER_TAB_QUERY_PARAMS,
 } from "@ourworldindata/types"
 import { LineChartSeries } from "../lineCharts/LineChartConstants"
 import { SelectionArray } from "../selection/SelectionArray"
@@ -128,51 +130,48 @@ export function isTargetOutsideElement(
 
 export function mapQueryParamToChartTypeName(
     chartTab: string
-): ChartTypeName | undefined {
+): GrapherChartType | undefined {
     switch (chartTab) {
-        case GrapherTabQueryParam.LineChart:
-            return ChartTypeName.LineChart
-        case GrapherTabQueryParam.SlopeChart:
-            return ChartTypeName.SlopeChart
-        case GrapherTabQueryParam.ScatterPlot:
-            return ChartTypeName.ScatterPlot
-        case GrapherTabQueryParam.StackedArea:
-            return ChartTypeName.StackedArea
-        case GrapherTabQueryParam.StackedBar:
-            return ChartTypeName.StackedBar
-        case GrapherTabQueryParam.DiscreteBar:
-            return ChartTypeName.DiscreteBar
-        case GrapherTabQueryParam.StackedDiscreteBar:
-            return ChartTypeName.StackedDiscreteBar
-        case GrapherTabQueryParam.Marimekko:
-            return ChartTypeName.Marimekko
+        case GRAPHER_TAB_QUERY_PARAMS.line:
+            return GRAPHER_CHART_TYPES.LineChart
+        case GRAPHER_TAB_QUERY_PARAMS.slope:
+            return GRAPHER_CHART_TYPES.SlopeChart
+        case GRAPHER_TAB_QUERY_PARAMS.scatter:
+            return GRAPHER_CHART_TYPES.ScatterPlot
+        case GRAPHER_TAB_QUERY_PARAMS["stacked-area"]:
+            return GRAPHER_CHART_TYPES.StackedArea
+        case GRAPHER_TAB_QUERY_PARAMS["stacked-bar"]:
+            return GRAPHER_CHART_TYPES.StackedBar
+        case GRAPHER_TAB_QUERY_PARAMS["discrete-bar"]:
+            return GRAPHER_CHART_TYPES.DiscreteBar
+        case GRAPHER_TAB_QUERY_PARAMS["stacked-discrete-bar"]:
+            return GRAPHER_CHART_TYPES.StackedDiscreteBar
+        case GRAPHER_TAB_QUERY_PARAMS.marimekko:
+            return GRAPHER_CHART_TYPES.Marimekko
         default:
             return undefined
     }
 }
 
 export function mapChartTypeNameToQueryParam(
-    chartType: ChartTypeName
+    chartType: GrapherChartType
 ): GrapherTabQueryParam {
     switch (chartType) {
-        case ChartTypeName.LineChart:
-            return GrapherTabQueryParam.LineChart
-        case ChartTypeName.SlopeChart:
-            return GrapherTabQueryParam.SlopeChart
-        case ChartTypeName.ScatterPlot:
-            return GrapherTabQueryParam.ScatterPlot
-        case ChartTypeName.StackedArea:
-            return GrapherTabQueryParam.StackedArea
-        case ChartTypeName.StackedBar:
-            return GrapherTabQueryParam.StackedBar
-        case ChartTypeName.DiscreteBar:
-            return GrapherTabQueryParam.DiscreteBar
-        case ChartTypeName.StackedDiscreteBar:
-            return GrapherTabQueryParam.StackedDiscreteBar
-        case ChartTypeName.Marimekko:
-            return GrapherTabQueryParam.Marimekko
-        // TODO: remove once stricter typed
-        default:
-            return GrapherTabQueryParam.LineChart
+        case GRAPHER_CHART_TYPES.LineChart:
+            return GRAPHER_TAB_QUERY_PARAMS.line
+        case GRAPHER_CHART_TYPES.SlopeChart:
+            return GRAPHER_TAB_QUERY_PARAMS.slope
+        case GRAPHER_CHART_TYPES.ScatterPlot:
+            return GRAPHER_TAB_QUERY_PARAMS.scatter
+        case GRAPHER_CHART_TYPES.StackedArea:
+            return GRAPHER_TAB_QUERY_PARAMS["stacked-area"]
+        case GRAPHER_CHART_TYPES.StackedBar:
+            return GRAPHER_TAB_QUERY_PARAMS["stacked-bar"]
+        case GRAPHER_CHART_TYPES.DiscreteBar:
+            return GRAPHER_TAB_QUERY_PARAMS["discrete-bar"]
+        case GRAPHER_CHART_TYPES.StackedDiscreteBar:
+            return GRAPHER_TAB_QUERY_PARAMS["stacked-discrete-bar"]
+        case GRAPHER_CHART_TYPES.Marimekko:
+            return GRAPHER_TAB_QUERY_PARAMS.marimekko
     }
 }

--- a/packages/@ourworldindata/grapher/src/color/ColorSchemes.ts
+++ b/packages/@ourworldindata/grapher/src/color/ColorSchemes.ts
@@ -3,7 +3,7 @@ import { ColorScheme } from "./ColorScheme"
 import { match } from "ts-pattern"
 import { partition } from "@ourworldindata/utils"
 import {
-    ChartTypeName,
+    GRAPHER_CHART_TYPES,
     ColorSchemeInterface,
     ColorSchemeName,
     GRAPHER_MAP_TYPE,
@@ -14,21 +14,21 @@ import { getColorBrewerScheme } from "./ColorBrewerSchemes.js"
 function getPreferredSchemesByType(
     type: GrapherChartOrMapType
 ): ColorSchemeName[] {
-    // This function could also be a Map<ChartTypeName, ColorName[]> but
+    // This function could also be a Map<GrapherChartOrMapType, ColorName[]> but
     // by doing it as a function usign ts-pattern.match we get compile
-    // time safety that all enum cases in ChartTypeName are always handled here
+    // time safety that all enum cases in GrapherChartOrMapType are always handled here
     return match(type)
-        .with(ChartTypeName.DiscreteBar, () => [
+        .with(GRAPHER_CHART_TYPES.DiscreteBar, () => [
             ColorSchemeName.SingleColorDenim,
             ColorSchemeName.SingleColorDustyCoral,
             ColorSchemeName.SingleColorPurple,
             ColorSchemeName.SingleColorTeal,
             ColorSchemeName.SingleColorDarkCopper,
         ])
-        .with(ChartTypeName.LineChart, () => [
+        .with(GRAPHER_CHART_TYPES.LineChart, () => [
             ColorSchemeName.OwidDistinctLines,
         ])
-        .with(ChartTypeName.Marimekko, () => [
+        .with(GRAPHER_CHART_TYPES.Marimekko, () => [
             ColorSchemeName.continents,
             ColorSchemeName.SingleColorDenim,
             ColorSchemeName.SingleColorDustyCoral,
@@ -41,15 +41,15 @@ function getPreferredSchemesByType(
             ColorSchemeName.OwidCategoricalD,
             ColorSchemeName.OwidCategoricalE,
         ])
-        .with(ChartTypeName.ScatterPlot, () => [
+        .with(GRAPHER_CHART_TYPES.ScatterPlot, () => [
             ColorSchemeName.continents,
             ColorSchemeName.OwidDistinctLines,
         ])
-        .with(ChartTypeName.SlopeChart, () => [
+        .with(GRAPHER_CHART_TYPES.SlopeChart, () => [
             ColorSchemeName.continents,
             ColorSchemeName.OwidDistinctLines,
         ])
-        .with(ChartTypeName.StackedArea, () => [
+        .with(GRAPHER_CHART_TYPES.StackedArea, () => [
             ColorSchemeName["owid-distinct"],
             ColorSchemeName.OwidCategoricalA,
             ColorSchemeName.OwidCategoricalB,
@@ -62,7 +62,7 @@ function getPreferredSchemesByType(
             ColorSchemeName.SingleColorGradientDustyCoral,
             ColorSchemeName.SingleColorGradientDarkCopper,
         ])
-        .with(ChartTypeName.StackedBar, () => [
+        .with(GRAPHER_CHART_TYPES.StackedBar, () => [
             ColorSchemeName["owid-distinct"],
             ColorSchemeName.OwidCategoricalA,
             ColorSchemeName.OwidCategoricalB,
@@ -75,7 +75,7 @@ function getPreferredSchemesByType(
             ColorSchemeName.SingleColorGradientDustyCoral,
             ColorSchemeName.SingleColorGradientDarkCopper,
         ])
-        .with(ChartTypeName.StackedDiscreteBar, () => [
+        .with(GRAPHER_CHART_TYPES.StackedDiscreteBar, () => [
             ColorSchemeName["owid-distinct"],
             ColorSchemeName.OwidCategoricalA,
             ColorSchemeName.OwidCategoricalB,
@@ -133,7 +133,7 @@ const getAllColorSchemes = (): Map<ColorSchemeName, ColorScheme> => {
     )
 }
 
-export function getColorSchemeForChartType(type: ChartTypeName): {
+export function getColorSchemeForChartType(type: GrapherChartOrMapType): {
     [key in ColorSchemeName]: ColorScheme
 } {
     const preferred = new Set(getPreferredSchemesByType(type))

--- a/packages/@ourworldindata/grapher/src/color/ColorSchemes.ts
+++ b/packages/@ourworldindata/grapher/src/color/ColorSchemes.ts
@@ -6,10 +6,14 @@ import {
     ChartTypeName,
     ColorSchemeInterface,
     ColorSchemeName,
+    GRAPHER_MAP_TYPE,
+    GrapherChartOrMapType,
 } from "@ourworldindata/types"
 import { getColorBrewerScheme } from "./ColorBrewerSchemes.js"
 
-function getPreferredSchemesByType(type: ChartTypeName): ColorSchemeName[] {
+function getPreferredSchemesByType(
+    type: GrapherChartOrMapType
+): ColorSchemeName[] {
     // This function could also be a Map<ChartTypeName, ColorName[]> but
     // by doing it as a function usign ts-pattern.match we get compile
     // time safety that all enum cases in ChartTypeName are always handled here
@@ -84,7 +88,7 @@ function getPreferredSchemesByType(type: ChartTypeName): ColorSchemeName[] {
             ColorSchemeName.SingleColorGradientDustyCoral,
             ColorSchemeName.SingleColorGradientDarkCopper,
         ])
-        .with(ChartTypeName.WorldMap, () => [
+        .with(GRAPHER_MAP_TYPE, () => [
             ColorSchemeName.BinaryMapPaletteA,
             ColorSchemeName.BinaryMapPaletteB,
             ColorSchemeName.BinaryMapPaletteC,

--- a/packages/@ourworldindata/grapher/src/controls/ChartIcons.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/ChartIcons.tsx
@@ -107,7 +107,4 @@ export const chartIcons: Record<ChartTypeName, React.ReactElement> = {
             </g>
         </svg>
     ),
-
-    // world map (will never be invoked but included for completeness)
-    [ChartTypeName.WorldMap]: <FontAwesomeIcon icon={faEarthAmericas} />,
 }

--- a/packages/@ourworldindata/grapher/src/controls/ChartIcons.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/ChartIcons.tsx
@@ -4,21 +4,22 @@ import {
     faChartBar,
     faChartLine,
     faChartColumn,
-    faEarthAmericas,
 } from "@fortawesome/free-solid-svg-icons"
-import { ChartTypeName } from "@ourworldindata/types"
+import { GRAPHER_CHART_TYPES, GrapherChartType } from "@ourworldindata/types"
 
-export const chartIcons: Record<ChartTypeName, React.ReactElement> = {
+export const chartIcons: Record<GrapherChartType, React.ReactElement> = {
     // line chart
-    [ChartTypeName.LineChart]: <FontAwesomeIcon icon={faChartLine} />,
+    [GRAPHER_CHART_TYPES.LineChart]: <FontAwesomeIcon icon={faChartLine} />,
 
     // bar charts
-    [ChartTypeName.DiscreteBar]: <FontAwesomeIcon icon={faChartColumn} />,
-    [ChartTypeName.StackedBar]: <FontAwesomeIcon icon={faChartColumn} />,
-    [ChartTypeName.StackedDiscreteBar]: <FontAwesomeIcon icon={faChartBar} />,
+    [GRAPHER_CHART_TYPES.DiscreteBar]: <FontAwesomeIcon icon={faChartColumn} />,
+    [GRAPHER_CHART_TYPES.StackedBar]: <FontAwesomeIcon icon={faChartColumn} />,
+    [GRAPHER_CHART_TYPES.StackedDiscreteBar]: (
+        <FontAwesomeIcon icon={faChartBar} />
+    ),
 
     // scatter
-    [ChartTypeName.ScatterPlot]: (
+    [GRAPHER_CHART_TYPES.ScatterPlot]: (
         <svg
             className="custom-icon scatter"
             width="16"
@@ -43,7 +44,7 @@ export const chartIcons: Record<ChartTypeName, React.ReactElement> = {
     ),
 
     // marimekko
-    [ChartTypeName.Marimekko]: (
+    [GRAPHER_CHART_TYPES.Marimekko]: (
         <svg
             className="custom-icon marimekko"
             width="16"
@@ -68,7 +69,7 @@ export const chartIcons: Record<ChartTypeName, React.ReactElement> = {
     ),
 
     // stacked area
-    [ChartTypeName.StackedArea]: (
+    [GRAPHER_CHART_TYPES.StackedArea]: (
         <svg
             className="custom-icon stacked-area"
             width="14"
@@ -89,7 +90,7 @@ export const chartIcons: Record<ChartTypeName, React.ReactElement> = {
     ),
 
     // slope chart
-    [ChartTypeName.SlopeChart]: (
+    [GRAPHER_CHART_TYPES.SlopeChart]: (
         <svg
             className="custom-icon slope"
             width="14"

--- a/packages/@ourworldindata/grapher/src/controls/ContentSwitchers.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/ContentSwitchers.tsx
@@ -4,7 +4,11 @@ import { observer } from "mobx-react"
 import classnames from "classnames"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
 import { faTable, faEarthAmericas } from "@fortawesome/free-solid-svg-icons"
-import { ChartTypeName, GrapherTabName } from "@ourworldindata/types"
+import {
+    GRAPHER_CHART_TYPES,
+    GrapherTabName,
+    GRAPHER_TAB_NAMES,
+} from "@ourworldindata/types"
 import { chartIcons } from "./ChartIcons"
 import { Bounds } from "@ourworldindata/utils"
 import { TabLabel, Tabs } from "../tabs/Tabs.js"
@@ -166,14 +170,14 @@ function TabIcon({
     isLineChartThatTurnedIntoDiscreteBar?: boolean
 }): React.ReactElement {
     switch (tab) {
-        case GrapherTabName.Table:
+        case GRAPHER_TAB_NAMES.Table:
             return <FontAwesomeIcon icon={faTable} />
-        case GrapherTabName.WorldMap:
+        case GRAPHER_TAB_NAMES.WorldMap:
             return <FontAwesomeIcon icon={faEarthAmericas} />
         default:
             const chartIcon = isLineChartThatTurnedIntoDiscreteBar
-                ? chartIcons[ChartTypeName.DiscreteBar]
-                : chartIcons[tab as unknown as ChartTypeName]
+                ? chartIcons[GRAPHER_CHART_TYPES.DiscreteBar]
+                : chartIcons[tab]
             return chartIcon
     }
 }
@@ -185,28 +189,28 @@ function makeTabLabelText(
         hasMultipleChartTypes?: boolean
     }
 ): string {
-    if (tab === GrapherTabName.Table) return "Table"
-    if (tab === GrapherTabName.WorldMap) return "Map"
+    if (tab === GRAPHER_TAB_NAMES.Table) return "Table"
+    if (tab === GRAPHER_TAB_NAMES.WorldMap) return "Map"
     if (!options.hasMultipleChartTypes) return "Chart"
 
     switch (tab) {
-        case GrapherTabName.LineChart:
+        case GRAPHER_TAB_NAMES.LineChart:
             return options.isLineChartThatTurnedIntoDiscreteBar ? "Bar" : "Line"
-        case GrapherTabName.SlopeChart:
+        case GRAPHER_TAB_NAMES.SlopeChart:
             return "Slope"
 
         // chart type labels are preliminary
-        case GrapherTabName.ScatterPlot:
+        case GRAPHER_TAB_NAMES.ScatterPlot:
             return "Scatter"
-        case GrapherTabName.StackedArea:
+        case GRAPHER_TAB_NAMES.StackedArea:
             return "Stacked area"
-        case GrapherTabName.StackedBar:
+        case GRAPHER_TAB_NAMES.StackedBar:
             return "Stacked bar"
-        case GrapherTabName.DiscreteBar:
+        case GRAPHER_TAB_NAMES.DiscreteBar:
             return "Bar"
-        case GrapherTabName.StackedDiscreteBar:
+        case GRAPHER_TAB_NAMES.StackedDiscreteBar:
             return "Stacked bar"
-        case GrapherTabName.Marimekko:
+        case GRAPHER_TAB_NAMES.Marimekko:
             return "Marimekko"
         default:
             return "Chart"

--- a/packages/@ourworldindata/grapher/src/controls/SettingsMenu.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/SettingsMenu.tsx
@@ -4,7 +4,12 @@ import { observer } from "mobx-react"
 import classnames from "classnames"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
 import { faGear } from "@fortawesome/free-solid-svg-icons"
-import { EntityName, ChartTypeName, FacetStrategy } from "@ourworldindata/types"
+import {
+    EntityName,
+    GRAPHER_CHART_TYPES,
+    FacetStrategy,
+    GrapherChartType,
+} from "@ourworldindata/types"
 import { DEFAULT_BOUNDS } from "@ourworldindata/utils"
 import { SelectionArray } from "../selection/SelectionArray"
 import { ChartDimension } from "../chart/ChartDimension"
@@ -46,7 +51,7 @@ const {
     StackedDiscreteBar,
     StackedBar,
     Marimekko,
-} = ChartTypeName
+} = GRAPHER_CHART_TYPES
 
 export interface SettingsMenuManager
     extends AbsRelToggleManager,
@@ -67,7 +72,7 @@ export interface SettingsMenuManager
     hideTableFilterToggle?: boolean
 
     // chart state
-    activeChartType?: ChartTypeName
+    activeChartType?: GrapherChartType
     isRelativeMode?: boolean
     selection?: SelectionArray | EntityName[]
     canChangeAddOrHighlightEntities?: boolean
@@ -104,8 +109,8 @@ export class SettingsMenu extends React.Component<{
         return test.showSettingsMenuToggle
     }
 
-    @computed get chartType(): ChartTypeName {
-        return this.manager.activeChartType ?? ChartTypeName.LineChart
+    @computed get chartType(): GrapherChartType {
+        return this.manager.activeChartType ?? GRAPHER_CHART_TYPES.LineChart
     }
 
     @computed get maxWidth(): number {
@@ -115,7 +120,8 @@ export class SettingsMenu extends React.Component<{
     @computed get showYScaleToggle(): boolean | undefined {
         if (this.manager.hideYScaleToggle) return false
         if (this.manager.isRelativeMode) return false
-        if ([StackedArea, StackedBar].includes(this.chartType)) return false // We currently do not have these charts with log scale
+        if ([StackedArea, StackedBar].includes(this.chartType as any))
+            return false // We currently do not have these charts with log scale
         return this.manager.yAxis.canChangeScaleType
     }
 
@@ -164,7 +170,7 @@ export class SettingsMenu extends React.Component<{
             ScatterPlot,
             LineChart,
             Marimekko,
-        ].includes(this.chartType)
+        ].includes(this.chartType as any)
     }
 
     @computed get showFacetControl(): boolean {
@@ -187,7 +193,7 @@ export class SettingsMenu extends React.Component<{
             StackedBar,
             StackedDiscreteBar,
             LineChart,
-        ].includes(this.chartType)
+        ].includes(this.chartType as any)
 
         const hasProjection = filledDimensions.some(
             (dim) => dim.display.isProjection

--- a/packages/@ourworldindata/grapher/src/controls/settings/AbsRelToggle.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/settings/AbsRelToggle.tsx
@@ -1,15 +1,19 @@
 import React from "react"
 import { computed, action } from "mobx"
 import { observer } from "mobx-react"
-import { ChartTypeName, StackMode } from "@ourworldindata/types"
+import {
+    GRAPHER_CHART_TYPES,
+    GrapherChartType,
+    StackMode,
+} from "@ourworldindata/types"
 import { LabeledSwitch } from "@ourworldindata/components"
 
-const { LineChart, ScatterPlot } = ChartTypeName
+const { LineChart, ScatterPlot } = GRAPHER_CHART_TYPES
 
 export interface AbsRelToggleManager {
     stackMode?: StackMode
     relativeToggleLabel?: string
-    activeChartType?: ChartTypeName
+    activeChartType?: GrapherChartType
 }
 
 @observer

--- a/packages/@ourworldindata/grapher/src/core/Grapher.jsdom.test.ts
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.jsdom.test.ts
@@ -1,15 +1,15 @@
 #! /usr/bin/env jest
 import { Grapher, GrapherProgrammaticInterface } from "../core/Grapher"
 import {
-    ChartTypeName,
+    GRAPHER_CHART_TYPES,
     EntitySelectionMode,
-    GrapherTabOption,
+    GRAPHER_TAB_OPTIONS,
     ScaleType,
     GrapherInterface,
     GrapherQueryParams,
     LegacyGrapherInterface,
     LegacyGrapherQueryParams,
-    GrapherTabName,
+    GRAPHER_TAB_NAMES,
 } from "@ourworldindata/types"
 import {
     TimeBoundValue,
@@ -72,7 +72,7 @@ it("can get dimension slots", () => {
     const grapher = new Grapher()
     expect(grapher.dimensionSlots.length).toBe(2)
 
-    grapher.chartTypes = [ChartTypeName.ScatterPlot]
+    grapher.chartTypes = [GRAPHER_CHART_TYPES.ScatterPlot]
     expect(grapher.dimensionSlots.length).toBe(4)
 })
 
@@ -99,7 +99,7 @@ it("a bad chart type does not crash grapher", () => {
 })
 
 it("does not preserve defaults in the object (except for the schema)", () => {
-    expect(new Grapher({ tab: GrapherTabOption.chart }).toObject()).toEqual({
+    expect(new Grapher({ tab: GRAPHER_TAB_OPTIONS.chart }).toObject()).toEqual({
         $schema: latestGrapherConfigSchema,
 
         // TODO: ideally, selectedEntityNames is not serialised for an empty object
@@ -212,24 +212,24 @@ it("can generate a url with country selection even if there is no entity code", 
 describe("hasTimeline", () => {
     it("charts with timeline", () => {
         const grapher = new Grapher(legacyConfig)
-        grapher.chartTypes = [ChartTypeName.LineChart]
+        grapher.chartTypes = [GRAPHER_CHART_TYPES.LineChart]
         expect(grapher.hasTimeline).toBeTruthy()
-        grapher.chartTypes = [ChartTypeName.SlopeChart]
+        grapher.chartTypes = [GRAPHER_CHART_TYPES.SlopeChart]
         expect(grapher.hasTimeline).toBeTruthy()
-        grapher.chartTypes = [ChartTypeName.StackedArea]
+        grapher.chartTypes = [GRAPHER_CHART_TYPES.StackedArea]
         expect(grapher.hasTimeline).toBeTruthy()
-        grapher.chartTypes = [ChartTypeName.StackedBar]
+        grapher.chartTypes = [GRAPHER_CHART_TYPES.StackedBar]
         expect(grapher.hasTimeline).toBeTruthy()
-        grapher.chartTypes = [ChartTypeName.DiscreteBar]
+        grapher.chartTypes = [GRAPHER_CHART_TYPES.DiscreteBar]
         expect(grapher.hasTimeline).toBeTruthy()
     })
 
     it("map tab has timeline even if chart doesn't", () => {
         const grapher = new Grapher(legacyConfig)
         grapher.hideTimeline = true
-        grapher.chartTypes = [ChartTypeName.LineChart]
+        grapher.chartTypes = [GRAPHER_CHART_TYPES.LineChart]
         expect(grapher.hasTimeline).toBeFalsy()
-        grapher.tab = GrapherTabOption.map
+        grapher.tab = GRAPHER_TAB_OPTIONS.map
         expect(grapher.hasTimeline).toBeTruthy()
         grapher.map.hideTimeline = true
         expect(grapher.hasTimeline).toBeFalsy()
@@ -380,7 +380,7 @@ describe("authors can use maxTime", () => {
         const table = SynthesizeGDPTable({ timeRange: [2000, 2010] })
         const grapher = new Grapher({
             table,
-            chartTypes: [ChartTypeName.DiscreteBar],
+            chartTypes: [GRAPHER_CHART_TYPES.DiscreteBar],
             selectedEntityNames: table.availableEntityNames,
             maxTime: 2005,
             ySlugs: "GDP",
@@ -396,7 +396,7 @@ describe("line chart to bar chart and bar chart race", () => {
     it("can create a new line chart with different start and end times", () => {
         expect(
             grapher.typeExceptWhenLineChartAndSingleTimeThenWillBeBarChart
-        ).toEqual(ChartTypeName.LineChart)
+        ).toEqual(GRAPHER_CHART_TYPES.LineChart)
         expect(grapher.endHandleTimeBound).toBeGreaterThan(
             grapher.startHandleTimeBound
         )
@@ -408,13 +408,13 @@ describe("line chart to bar chart and bar chart race", () => {
 
         expect(
             grapher.typeExceptWhenLineChartAndSingleTimeThenWillBeBarChart
-        ).toEqual(ChartTypeName.LineChart)
+        ).toEqual(GRAPHER_CHART_TYPES.LineChart)
 
         grapher.startHandleTimeBound = 2000
         grapher.endHandleTimeBound = 2000
         expect(
             grapher.typeExceptWhenLineChartAndSingleTimeThenWillBeBarChart
-        ).toEqual(ChartTypeName.DiscreteBar)
+        ).toEqual(GRAPHER_CHART_TYPES.DiscreteBar)
 
         it("still has a timeline even though its now a bar chart", () => {
             expect(grapher.hasTimeline).toBe(true)
@@ -450,7 +450,7 @@ describe("line chart to bar chart and bar chart race", () => {
         )
         expect(
             grapher.typeExceptWhenLineChartAndSingleTimeThenWillBeBarChart
-        ).toEqual(ChartTypeName.LineChart)
+        ).toEqual(GRAPHER_CHART_TYPES.LineChart)
     })
 
     it("turns into a bar chart when constrained start & end handles are equal", () => {
@@ -458,7 +458,7 @@ describe("line chart to bar chart and bar chart race", () => {
         grapher.endHandleTimeBound = Infinity
         expect(
             grapher.typeExceptWhenLineChartAndSingleTimeThenWillBeBarChart
-        ).toEqual(ChartTypeName.DiscreteBar)
+        ).toEqual(GRAPHER_CHART_TYPES.DiscreteBar)
     })
 })
 
@@ -483,7 +483,7 @@ describe("urls", () => {
             isPublished: true,
             slug: "foo",
             bakedGrapherURL: "/grapher",
-            tab: GrapherTabOption.map,
+            tab: GRAPHER_TAB_OPTIONS.map,
         })
         expect(grapher.embedUrl).toEqual("/grapher/foo?tab=map")
     })
@@ -514,67 +514,78 @@ describe("urls", () => {
     it("parses tab=table correctly", () => {
         const grapher = new Grapher()
         grapher.populateFromQueryParams({ tab: "table" })
-        expect(grapher.activeTab).toEqual(GrapherTabName.Table)
+        expect(grapher.activeTab).toEqual(GRAPHER_TAB_NAMES.Table)
     })
 
     it("parses tab=map correctly", () => {
         const grapher = new Grapher()
         grapher.populateFromQueryParams({ tab: "map" })
-        expect(grapher.activeTab).toEqual(GrapherTabName.WorldMap)
+        expect(grapher.activeTab).toEqual(GRAPHER_TAB_NAMES.WorldMap)
     })
 
     it("parses tab=chart correctly", () => {
-        const grapher = new Grapher({ chartTypes: [ChartTypeName.ScatterPlot] })
+        const grapher = new Grapher({
+            chartTypes: [GRAPHER_CHART_TYPES.ScatterPlot],
+        })
         grapher.populateFromQueryParams({ tab: "chart" })
-        expect(grapher.activeTab).toEqual(GrapherTabName.ScatterPlot)
+        expect(grapher.activeTab).toEqual(GRAPHER_TAB_NAMES.ScatterPlot)
     })
 
     it("parses tab=line and tab=slope correctly", () => {
         const grapher = new Grapher({
-            chartTypes: [ChartTypeName.LineChart, ChartTypeName.SlopeChart],
+            chartTypes: [
+                GRAPHER_CHART_TYPES.LineChart,
+                GRAPHER_CHART_TYPES.SlopeChart,
+            ],
         })
         grapher.populateFromQueryParams({ tab: "line" })
-        expect(grapher.activeTab).toEqual(GrapherTabName.LineChart)
+        expect(grapher.activeTab).toEqual(GRAPHER_TAB_NAMES.LineChart)
         grapher.populateFromQueryParams({ tab: "slope" })
-        expect(grapher.activeTab).toEqual(GrapherTabName.SlopeChart)
+        expect(grapher.activeTab).toEqual(GRAPHER_TAB_NAMES.SlopeChart)
     })
 
     it("switches to the first chart tab if the given chart isn't available", () => {
         const grapher = new Grapher({
-            chartTypes: [ChartTypeName.LineChart, ChartTypeName.SlopeChart],
+            chartTypes: [
+                GRAPHER_CHART_TYPES.LineChart,
+                GRAPHER_CHART_TYPES.SlopeChart,
+            ],
         })
         grapher.populateFromQueryParams({ tab: "bar" })
-        expect(grapher.activeTab).toEqual(GrapherTabName.LineChart)
+        expect(grapher.activeTab).toEqual(GRAPHER_TAB_NAMES.LineChart)
     })
 
     it("switches to the map tab if no chart is available", () => {
         const grapher = new Grapher({ chartTypes: [], hasMapTab: true })
         grapher.populateFromQueryParams({ tab: "line" })
-        expect(grapher.activeTab).toEqual(GrapherTabName.WorldMap)
+        expect(grapher.activeTab).toEqual(GRAPHER_TAB_NAMES.WorldMap)
     })
 
     it("switches to the table tab if it's the only tab available", () => {
         const grapher = new Grapher({ chartTypes: [] })
         grapher.populateFromQueryParams({ tab: "line" })
-        expect(grapher.activeTab).toEqual(GrapherTabName.Table)
+        expect(grapher.activeTab).toEqual(GRAPHER_TAB_NAMES.Table)
     })
 
     it("adds tab=chart to the URL if there is a single chart tab", () => {
         const grapher = new Grapher({
             hasMapTab: true,
-            tab: GrapherTabOption.map,
+            tab: GRAPHER_TAB_OPTIONS.map,
         })
-        grapher.setTab(GrapherTabName.LineChart)
+        grapher.setTab(GRAPHER_TAB_NAMES.LineChart)
         expect(grapher.changedParams.tab).toEqual("chart")
     })
 
     it("adds the chart type name as tab query param if there are multiple chart tabs", () => {
         const grapher = new Grapher({
-            chartTypes: [ChartTypeName.LineChart, ChartTypeName.SlopeChart],
+            chartTypes: [
+                GRAPHER_CHART_TYPES.LineChart,
+                GRAPHER_CHART_TYPES.SlopeChart,
+            ],
             hasMapTab: true,
-            tab: GrapherTabOption.map,
+            tab: GRAPHER_TAB_OPTIONS.map,
         })
-        grapher.setTab(GrapherTabName.LineChart)
+        grapher.setTab(GRAPHER_TAB_NAMES.LineChart)
         expect(grapher.changedParams.tab).toEqual("line")
     })
 })
@@ -902,7 +913,7 @@ describe("year parameter (applies to map only)", () => {
             })
             it(`encode ${test.name}`, () => {
                 const params = toQueryParams({
-                    tab: GrapherTabOption.map,
+                    tab: GRAPHER_TAB_OPTIONS.map,
                     map: { time: test.param },
                 })
                 expect(params.time).toEqual(test.query)
@@ -968,7 +979,7 @@ describe("year parameter (applies to map only)", () => {
                 it(`encode ${test.name}`, () => {
                     const grapher = getGrapher()
                     grapher.updateFromObject({
-                        tab: GrapherTabOption.map,
+                        tab: GRAPHER_TAB_OPTIONS.map,
                         map: { time: test.param },
                     })
                     const params = grapher.changedParams
@@ -986,7 +997,7 @@ it("correctly identifies activeColumnSlugs", () => {
     `)
     const grapher = new Grapher({
         table,
-        chartTypes: [ChartTypeName.ScatterPlot],
+        chartTypes: [GRAPHER_CHART_TYPES.ScatterPlot],
         xSlug: "gdp",
         ySlugs: "child_mortality",
         colorSlug: "continent",
@@ -1024,7 +1035,7 @@ it("considers map tolerance before using column tolerance", () => {
     const grapher = new Grapher({
         table,
         ySlugs: "gdp",
-        tab: GrapherTabOption.map,
+        tab: GRAPHER_TAB_OPTIONS.map,
         hasMapTab: true,
         map: new MapConfig({ timeTolerance: 1, columnSlug: "gdp", time: 2002 }),
     })
@@ -1084,7 +1095,7 @@ describe("tableForSelection", () => {
 
         const grapher = new Grapher({
             table,
-            chartTypes: [ChartTypeName.ScatterPlot],
+            chartTypes: [GRAPHER_CHART_TYPES.ScatterPlot],
             excludedEntities: [3],
             xSlug: "x",
             ySlugs: "y",
@@ -1120,7 +1131,7 @@ it("handles tolerance when there are gaps in ScatterPlot data", () => {
 
     const grapher = new Grapher({
         table,
-        chartTypes: [ChartTypeName.ScatterPlot],
+        chartTypes: [GRAPHER_CHART_TYPES.ScatterPlot],
         xSlug: "x",
         ySlugs: "y",
         minTime: 1999,

--- a/packages/@ourworldindata/grapher/src/core/Grapher.stories.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.stories.tsx
@@ -6,9 +6,9 @@ import {
     BlankOwidTable,
 } from "@ourworldindata/core-table"
 import {
-    ChartTypeName,
+    GRAPHER_CHART_TYPES,
     FacetStrategy,
-    GrapherTabOption,
+    GRAPHER_TAB_OPTIONS,
 } from "@ourworldindata/types"
 import { action, observable } from "mobx"
 import { observer } from "mobx-react"
@@ -49,7 +49,7 @@ export const Line = (): React.ReactElement => <Grapher {...basics} />
 
 export const SlopeChart = (): React.ReactElement => {
     const model = {
-        chartTypes: [ChartTypeName.SlopeChart],
+        chartTypes: [GRAPHER_CHART_TYPES.SlopeChart],
         ...basics,
     }
     return <Grapher {...model} />
@@ -57,7 +57,7 @@ export const SlopeChart = (): React.ReactElement => {
 
 export const ScatterPlot = (): React.ReactElement => {
     const model = {
-        chartTypes: [ChartTypeName.ScatterPlot],
+        chartTypes: [GRAPHER_CHART_TYPES.ScatterPlot],
         ...basics,
     }
     return <Grapher {...model} />
@@ -65,7 +65,7 @@ export const ScatterPlot = (): React.ReactElement => {
 
 export const DiscreteBar = (): React.ReactElement => {
     const model = {
-        chartTypes: [ChartTypeName.DiscreteBar],
+        chartTypes: [GRAPHER_CHART_TYPES.DiscreteBar],
         ...basics,
     }
     return <Grapher {...model} />
@@ -73,7 +73,7 @@ export const DiscreteBar = (): React.ReactElement => {
 
 export const StackedBar = (): React.ReactElement => {
     const model = {
-        chartTypes: [ChartTypeName.StackedBar],
+        chartTypes: [GRAPHER_CHART_TYPES.StackedBar],
         ...basics,
     }
     return <Grapher {...model} />
@@ -81,7 +81,7 @@ export const StackedBar = (): React.ReactElement => {
 
 export const StackedArea = (): React.ReactElement => {
     const model = {
-        chartTypes: [ChartTypeName.StackedArea],
+        chartTypes: [GRAPHER_CHART_TYPES.StackedArea],
         ...basics,
     }
     return <Grapher {...model} />
@@ -90,14 +90,14 @@ export const StackedArea = (): React.ReactElement => {
 export const MapFirst = (): React.ReactElement => {
     const model = {
         ...basics,
-        tab: GrapherTabOption.map,
+        tab: GRAPHER_TAB_OPTIONS.map,
     }
     return <Grapher {...model} />
 }
 
 export const BlankGrapher = (): React.ReactElement => {
     const model = {
-        tab: GrapherTabOption.map,
+        tab: GRAPHER_TAB_OPTIONS.map,
         table: BlankOwidTable(),
         hasMapTab: true,
     }
@@ -114,7 +114,7 @@ export const NoMap = (): React.ReactElement => {
 
 export const Faceting = (): React.ReactElement => {
     const model = {
-        chartTypes: [ChartTypeName.StackedArea],
+        chartTypes: [GRAPHER_CHART_TYPES.StackedArea],
         facet: FacetStrategy.entity,
         ...basics,
     }
@@ -141,11 +141,11 @@ class PerfGrapher extends React.Component {
 
     @observable.ref table = basics.table!
 
-    @action.bound private changeChartType(type: ChartTypeName): void {
+    @action.bound private changeChartType(type: GRAPHER_CHART_TYPES): void {
         this.chartTypeName = type
     }
 
-    @observable chartTypeName = ChartTypeName.LineChart
+    @observable chartTypeName = GRAPHER_CHART_TYPES.LineChart
 
     render(): React.ReactElement {
         const key = Math.random() // I do this hack to force a rerender until can re-add the grapher model/grapher view that we used to have. @breck 10/29/2020

--- a/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
@@ -1,5 +1,5 @@
+import { GRAPHER_CHART_TYPES } from "@ourworldindata/types"
 import { defaultGrapherConfig } from "../schema/defaultGrapherConfig.js"
-import { ChartTypeName } from "@ourworldindata/types"
 import type { GrapherProgrammaticInterface } from "./Grapher"
 
 export const GRAPHER_EMBEDDED_FIGURE_ATTR = "data-grapher-src"
@@ -113,5 +113,5 @@ export const grapherInterfaceWithHiddenTabs: GrapherProgrammaticInterface = {
  * This also determines the order of chart types in the UI.
  */
 export const validChartTypeCombinations = [
-    [ChartTypeName.LineChart, ChartTypeName.SlopeChart],
+    [GRAPHER_CHART_TYPES.LineChart, GRAPHER_CHART_TYPES.SlopeChart],
 ]

--- a/packages/@ourworldindata/grapher/src/core/GrapherWithChartTypes.jsdom.test.tsx
+++ b/packages/@ourworldindata/grapher/src/core/GrapherWithChartTypes.jsdom.test.tsx
@@ -8,7 +8,7 @@ import {
 import { Grapher, GrapherProgrammaticInterface } from "../core/Grapher"
 import { MapChart } from "../mapCharts/MapChart"
 import { legacyMapGrapher } from "../mapCharts/MapChart.sample"
-import { ChartTypeName } from "@ourworldindata/types"
+import { GRAPHER_CHART_TYPES } from "@ourworldindata/types"
 
 describe("grapher and map charts", () => {
     describe("map time tolerance plus query string works with a map chart", () => {
@@ -50,7 +50,7 @@ const basicGrapherConfig: GrapherProgrammaticInterface = {
 
 describe("grapher and discrete bar charts", () => {
     const grapher = new Grapher({
-        chartTypes: [ChartTypeName.DiscreteBar],
+        chartTypes: [GRAPHER_CHART_TYPES.DiscreteBar],
         ...basicGrapherConfig,
     })
     expect(grapher.chartInstance.series.length).toBeGreaterThan(0)

--- a/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.test.ts
+++ b/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.test.ts
@@ -1,7 +1,7 @@
 #! /usr/bin/env jest
 
 import {
-    ChartTypeName,
+    GRAPHER_CHART_TYPES,
     OwidColumnDef,
     OwidTableSlugs,
     StandardOwidColumnDefs,
@@ -466,7 +466,7 @@ describe(legacyToOwidTableAndDimensions, () => {
             it("joins targetTime", () => {
                 const scatterLegacyGrapherConfig = {
                     ...legacyGrapherConfig,
-                    chartTypes: [ChartTypeName.ScatterPlot],
+                    chartTypes: [GRAPHER_CHART_TYPES.ScatterPlot],
                 }
 
                 const { table } = legacyToOwidTableAndDimensions(

--- a/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.ts
+++ b/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.ts
@@ -1,7 +1,7 @@
 // todo: Remove this file when we've migrated OWID data and OWID charts to next version
 
 import {
-    ChartTypeName,
+    GRAPHER_CHART_TYPES,
     ColumnTypeNames,
     CoreColumnDef,
     StandardOwidColumnDefs,
@@ -200,8 +200,8 @@ export const legacyToOwidTableAndDimensions = (
         const targetTime = dimension?.targetYear
         const chartType = grapherConfig.chartTypes?.[0]
         if (
-            (chartType === ChartTypeName.ScatterPlot ||
-                chartType === ChartTypeName.Marimekko) &&
+            (chartType === GRAPHER_CHART_TYPES.ScatterPlot ||
+                chartType === GRAPHER_CHART_TYPES.Marimekko) &&
             isNumber(targetTime)
         ) {
             variableTable = variableTable

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.jsdom.test.tsx
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.jsdom.test.tsx
@@ -3,7 +3,7 @@
 import React from "react"
 
 import { DataTable } from "./DataTable"
-import { ChartTypeName, GrapherTabOption } from "@ourworldindata/types"
+import { GRAPHER_CHART_TYPES, GRAPHER_TAB_OPTIONS } from "@ourworldindata/types"
 import {
     childMortalityGrapher,
     GrapherWithIncompleteData,
@@ -70,8 +70,8 @@ describe("when you select a range of years", () => {
     let view: ReactWrapper
     beforeAll(() => {
         const grapher = childMortalityGrapher({
-            chartTypes: [ChartTypeName.LineChart],
-            tab: GrapherTabOption.table,
+            chartTypes: [GRAPHER_CHART_TYPES.LineChart],
+            tab: GRAPHER_TAB_OPTIONS.table,
         })
         grapher.timelineHandleTimeBounds = [1950, 2019]
 

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.sample.ts
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.sample.ts
@@ -1,6 +1,6 @@
 import { DimensionProperty } from "@ourworldindata/utils"
 import { Grapher } from "../core/Grapher"
-import { GrapherTabOption, GrapherInterface } from "@ourworldindata/types"
+import { GRAPHER_TAB_OPTIONS, GrapherInterface } from "@ourworldindata/types"
 import {
     TestMetadata,
     createOwidTestDataset,
@@ -38,7 +38,7 @@ export const childMortalityGrapher = (
     ]
     return new Grapher({
         hasMapTab: true,
-        tab: GrapherTabOption.map,
+        tab: GRAPHER_TAB_OPTIONS.map,
         dimensions,
         ...props,
         owidDataset: createOwidTestDataset([
@@ -85,7 +85,7 @@ export const GrapherWithIncompleteData = (
         },
     ]
     return new Grapher({
-        tab: GrapherTabOption.table,
+        tab: GRAPHER_TAB_OPTIONS.table,
         dimensions,
         ...props,
         owidDataset: createOwidTestDataset([{ metadata, data }]),
@@ -125,7 +125,7 @@ export const GrapherWithAggregates = (
         },
     ]
     return new Grapher({
-        tab: GrapherTabOption.table,
+        tab: GRAPHER_TAB_OPTIONS.table,
         dimensions,
         ...props,
         owidDataset: createOwidTestDataset([
@@ -169,7 +169,7 @@ export const GrapherWithMultipleVariablesAndMultipleYears = (
     }
 
     return new Grapher({
-        tab: GrapherTabOption.table,
+        tab: GRAPHER_TAB_OPTIONS.table,
         dimensions,
         ...props,
         owidDataset: createOwidTestDataset([

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.stories.tsx
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.stories.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { DataTable, DataTableManager } from "./DataTable"
 import { SynthesizeGDPTable } from "@ourworldindata/core-table"
-import { ChartTypeName, GrapherTabOption } from "@ourworldindata/types"
+import { GRAPHER_CHART_TYPES, GRAPHER_TAB_OPTIONS } from "@ourworldindata/types"
 import {
     childMortalityGrapher,
     GrapherWithIncompleteData,
@@ -88,8 +88,8 @@ export const FromLegacy = (): React.ReactElement => {
 
 export const FromLegacyWithTimeRange = (): React.ReactElement => {
     const grapher = childMortalityGrapher({
-        type: ChartTypeName.LineChart,
-        tab: GrapherTabOption.chart,
+        chartTypes: [GRAPHER_CHART_TYPES.LineChart],
+        tab: GRAPHER_TAB_OPTIONS.chart,
     })
     grapher.startHandleTimeBound = 1950
     grapher.endHandleTimeBound = 2019

--- a/packages/@ourworldindata/grapher/src/facetChart/FacetChart.stories.tsx
+++ b/packages/@ourworldindata/grapher/src/facetChart/FacetChart.stories.tsx
@@ -6,7 +6,7 @@ import {
     SynthesizeGDPTable,
 } from "@ourworldindata/core-table"
 import { Bounds } from "@ourworldindata/utils"
-import { ChartTypeName, FacetStrategy } from "../core/GrapherConstants"
+import { FacetStrategy, GRAPHER_CHART_TYPES } from "@ourworldindata/types"
 import { ChartManager } from "../chart/ChartManager"
 
 // See https://storybook.js.org/docs/react/essentials/controls for Control Types
@@ -34,7 +34,7 @@ export const OneMetricOneCountryPerChart = (): React.ReactElement => {
         <svg width={bounds.width} height={bounds.height}>
             <FacetChart
                 bounds={bounds}
-                chartTypeName={ChartTypeName.LineChart}
+                chartTypeName={GRAPHER_CHART_TYPES.LineChart}
                 manager={manager}
             />
         </svg>
@@ -49,7 +49,7 @@ export const MultipleMetricsOneCountryPerChart = (): React.ReactElement => {
         <svg width={bounds.width} height={bounds.height}>
             <FacetChart
                 bounds={bounds}
-                chartTypeName={ChartTypeName.LineChart}
+                chartTypeName={GRAPHER_CHART_TYPES.LineChart}
                 manager={{
                     selection: table.availableEntityNames,
                     table,
@@ -67,7 +67,7 @@ export const OneChartPerMetric = (): React.ReactElement => {
         <svg width={bounds.width} height={bounds.height}>
             <FacetChart
                 bounds={bounds}
-                chartTypeName={ChartTypeName.LineChart}
+                chartTypeName={GRAPHER_CHART_TYPES.LineChart}
                 manager={{
                     facetStrategy: FacetStrategy.metric,
                     yColumnSlugs: table.numericColumnSlugs,

--- a/packages/@ourworldindata/grapher/src/facetChart/FacetChart.test.ts
+++ b/packages/@ourworldindata/grapher/src/facetChart/FacetChart.test.ts
@@ -4,7 +4,7 @@ import { FacetChart } from "./FacetChart"
 import { SynthesizeGDPTable, OwidTable } from "@ourworldindata/core-table"
 import { ChartManager } from "../chart/ChartManager"
 import {
-    ChartTypeName,
+    GRAPHER_CHART_TYPES,
     FacetAxisDomain,
     FacetStrategy,
     ColumnTypeNames,
@@ -65,7 +65,7 @@ describe("uniform axes", () => {
     }
     const chart = new FacetChart({
         manager,
-        chartTypeName: ChartTypeName.LineChart,
+        chartTypeName: GRAPHER_CHART_TYPES.LineChart,
     })
     const yAxisConfigs = chart.placedSeries.map(
         (series) => series.manager.yAxisConfig
@@ -165,7 +165,7 @@ describe("config overrides", () => {
     }
     const chart = new FacetChart({
         manager,
-        chartTypeName: ChartTypeName.LineChart,
+        chartTypeName: GRAPHER_CHART_TYPES.LineChart,
     })
 
     it("preserves config passed from manager", () => {
@@ -187,7 +187,7 @@ describe("config overrides", () => {
         }
         const chart = new FacetChart({
             manager: newManager,
-            chartTypeName: ChartTypeName.LineChart,
+            chartTypeName: GRAPHER_CHART_TYPES.LineChart,
         })
         expect(chart.placedSeries[0].manager.yAxisConfig?.nice).toEqual(true)
     })
@@ -231,7 +231,7 @@ describe("global legend", () => {
         }
         const chart = new FacetChart({
             manager,
-            chartTypeName: ChartTypeName.LineChart,
+            chartTypeName: GRAPHER_CHART_TYPES.LineChart,
         })
 
         const legend = chart.categoricalLegendData

--- a/packages/@ourworldindata/grapher/src/facetChart/FacetChart.tsx
+++ b/packages/@ourworldindata/grapher/src/facetChart/FacetChart.tsx
@@ -23,7 +23,8 @@ import { shortenForTargetWidth } from "@ourworldindata/components"
 import { action, computed, observable } from "mobx"
 import { BASE_FONT_SIZE, GRAPHER_DARK_TEXT } from "../core/GrapherConstants"
 import {
-    ChartTypeName,
+    GRAPHER_CHART_TYPES,
+    GrapherChartType,
     FacetAxisDomain,
     FacetStrategy,
     SeriesColorMap,
@@ -137,8 +138,8 @@ export class FacetChart
         return this.props.manager
     }
 
-    @computed private get chartTypeName(): ChartTypeName {
-        return this.props.chartTypeName ?? ChartTypeName.LineChart
+    @computed private get chartTypeName(): GrapherChartType {
+        return this.props.chartTypeName ?? GRAPHER_CHART_TYPES.LineChart
     }
 
     @computed get failMessage(): string {
@@ -357,9 +358,9 @@ export class FacetChart
         return (
             this.uniformYAxis &&
             ![
-                ChartTypeName.StackedDiscreteBar,
-                ChartTypeName.DiscreteBar,
-            ].includes(this.chartTypeName)
+                GRAPHER_CHART_TYPES.StackedDiscreteBar,
+                GRAPHER_CHART_TYPES.DiscreteBar,
+            ].includes(this.chartTypeName as any)
         )
     }
 
@@ -367,7 +368,7 @@ export class FacetChart
         return (
             this.uniformXAxis &&
             // TODO: do this for stacked area charts and line charts as well?
-            this.chartTypeName === ChartTypeName.StackedBar &&
+            this.chartTypeName === GRAPHER_CHART_TYPES.StackedBar &&
             this.facetCount >= SHARED_X_AXIS_MIN_FACET_COUNT
         )
     }
@@ -612,7 +613,8 @@ export class FacetChart
         if (!hasBins) return false
         if (isNumericLegend) return true
         if (
-            this.props.chartTypeName === ChartTypeName.StackedDiscreteBar &&
+            this.props.chartTypeName ===
+                GRAPHER_CHART_TYPES.StackedDiscreteBar &&
             this.facetStrategy === FacetStrategy.metric
         ) {
             return false

--- a/packages/@ourworldindata/grapher/src/facetChart/FacetChartConstants.ts
+++ b/packages/@ourworldindata/grapher/src/facetChart/FacetChartConstants.ts
@@ -1,6 +1,6 @@
 import { ChartSeries } from "../chart/ChartInterface"
 import { ChartManager } from "../chart/ChartManager"
-import { ChartTypeName } from "@ourworldindata/types"
+import { GrapherChartType } from "@ourworldindata/types"
 import { Bounds } from "@ourworldindata/utils"
 
 export interface FacetChartManager extends ChartManager {
@@ -9,7 +9,7 @@ export interface FacetChartManager extends ChartManager {
 
 export interface FacetChartProps {
     bounds?: Bounds
-    chartTypeName?: ChartTypeName
+    chartTypeName?: GrapherChartType
     manager: FacetChartManager
 }
 

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapChart.sample.ts
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapChart.sample.ts
@@ -1,10 +1,10 @@
 import { DimensionProperty } from "@ourworldindata/utils"
 import { GrapherProgrammaticInterface } from "../core/Grapher"
-import { GrapherTabOption } from "@ourworldindata/types"
+import { GRAPHER_TAB_OPTIONS } from "@ourworldindata/types"
 
 export const legacyMapGrapher: GrapherProgrammaticInterface = {
     hasMapTab: true,
-    tab: GrapherTabOption.map,
+    tab: GRAPHER_TAB_OPTIONS.map,
     map: {
         timeTolerance: 5,
     },

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
@@ -59,7 +59,7 @@ import { getCountriesByProjection } from "./WorldRegionsToProjection"
 import {
     ColorSchemeName,
     MapProjectionName,
-    GrapherTabOption,
+    GRAPHER_TAB_OPTIONS,
     SeriesName,
     EntityName,
 } from "@ourworldindata/types"
@@ -293,7 +293,7 @@ export class MapChart
 
         if (!ev.shiftKey) {
             this.selectionArray.setSelectedEntities([entityName])
-            this.manager.tab = GrapherTabOption.chart
+            this.manager.tab = GRAPHER_TAB_OPTIONS.chart
             if (
                 this.manager.isLineChartThatTurnedIntoDiscreteBar &&
                 this.manager.hasTimeline

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapChartConstants.ts
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapChartConstants.ts
@@ -4,7 +4,7 @@ import {
     MapProjectionName,
     Color,
     Time,
-    ChartTypeName,
+    GrapherChartType,
     GrapherTabOption,
     SeriesName,
 } from "@ourworldindata/types"
@@ -57,7 +57,7 @@ export interface MapChartManager extends ChartManager {
     mapColumnSlug?: ColumnSlug
     mapIsClickable?: boolean
     tab?: GrapherTabOption // Used to switch to chart tab on map click
-    type?: ChartTypeName // Used to determine the "Click to select" text in MapTooltip
+    type?: GrapherChartType // Used to determine the "Click to select" text in MapTooltip
     isLineChartThatTurnedIntoDiscreteBar?: boolean // Used to determine whether to reset the timeline on map click
     hasTimeline?: boolean // Used to determine whether to reset the timeline on map click
     resetHandleTimeBounds?: () => void // Used to reset the timeline on map click

--- a/packages/@ourworldindata/grapher/src/schema/migrations/migrations.ts
+++ b/packages/@ourworldindata/grapher/src/schema/migrations/migrations.ts
@@ -15,7 +15,7 @@ import {
     getSchemaVersion,
     isLatestVersion,
 } from "./helpers"
-import { ChartTypeName } from "@ourworldindata/types"
+import { GRAPHER_CHART_TYPES } from "@ourworldindata/types"
 
 // see https://github.com/owid/owid-grapher/commit/26f2a0d1790c71bdda7e12f284ca552945d2f6ef
 const migrateFrom001To002 = (
@@ -64,11 +64,11 @@ const migrateFrom004To005 = (
 const migrateFrom005To006 = (
     config: AnyConfigWithValidSchema
 ): AnyConfigWithValidSchema => {
-    const { type = ChartTypeName.LineChart, hasChartTab = true } = config
+    const { type = GRAPHER_CHART_TYPES.LineChart, hasChartTab = true } = config
 
     // add types field
     if (!hasChartTab) config.chartTypes = []
-    else if (type !== ChartTypeName.LineChart) config.chartTypes = [type]
+    else if (type !== GRAPHER_CHART_TYPES.LineChart) config.chartTypes = [type]
 
     // remove deprecated fields
     delete config.type

--- a/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChart.jsdom.test.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChart.jsdom.test.tsx
@@ -4,7 +4,7 @@ import { Bounds, ColumnTypeNames } from "@ourworldindata/utils"
 import { OwidTable } from "@ourworldindata/core-table"
 import { DefaultColorScheme } from "../color/CustomSchemes"
 import { Grapher } from "../core/Grapher"
-import { ChartTypeName } from "@ourworldindata/types"
+import { GRAPHER_CHART_TYPES } from "@ourworldindata/types"
 import { MarimekkoChart } from "./MarimekkoChart"
 import { BarShape, PlacedItem } from "./MarimekkoChartConstants"
 it("can filter years correctly", () => {
@@ -23,7 +23,7 @@ it("can filter years correctly", () => {
 
     // TODO: why is it ySlugs and xSlug here instead of yColumnSlugs and xColumnSlug? Unify when we have config migrations?
     const manager = {
-        chartTypes: [ChartTypeName.Marimekko],
+        chartTypes: [GRAPHER_CHART_TYPES.Marimekko],
         table,
         selection: table.availableEntityNames,
         ySlugs: "percentBelow2USD",
@@ -133,7 +133,7 @@ it("shows no data points at the end", () => {
 
     // TODO: why is it ySlugs and xSlug here instead of yColumnSlugs and xColumnSlug? Unify when we have config migrations?
     const manager = {
-        chartTypes: [ChartTypeName.Marimekko],
+        chartTypes: [GRAPHER_CHART_TYPES.Marimekko],
         table,
         selection: table.availableEntityNames,
         ySlugs: "percentBelow2USD",
@@ -233,7 +233,7 @@ test("interpolation works as expected", () => {
 
     // TODO: why is it ySlugs and xSlug here instead of yColumnSlugs and xColumnSlug? Unify when we have config migrations?
     const manager = {
-        chartTypes: [ChartTypeName.Marimekko],
+        chartTypes: [GRAPHER_CHART_TYPES.Marimekko],
         table,
         selection: table.availableEntityNames,
         ySlugs: "percentBelow2USD",
@@ -344,7 +344,7 @@ it("can deal with y columns with missing values", () => {
 
     // TODO: why is it ySlugs and xSlug here instead of yColumnSlugs and xColumnSlug? Unify when we have config migrations?
     const manager = {
-        chartTypes: [ChartTypeName.Marimekko],
+        chartTypes: [GRAPHER_CHART_TYPES.Marimekko],
         table,
         selection: table.availableEntityNames,
         ySlugs: "percentBelow2USD percentBelow10USD",

--- a/packages/@ourworldindata/types/src/dbTypes/ChartConfigs.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/ChartConfigs.ts
@@ -11,7 +11,7 @@ export interface DbInsertChartConfig {
     full: JsonString
     fullMd5?: Base64String
     slug?: string | null
-    chartType?: ChartTypeName | null // TODO: exclude WorldMap
+    chartType?: ChartTypeName | null
     createdAt?: Date
     updatedAt?: Date | null
 }

--- a/packages/@ourworldindata/types/src/dbTypes/ChartConfigs.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/ChartConfigs.ts
@@ -1,6 +1,6 @@
 import { Base64String, JsonString } from "../domainTypes/Various.js"
 import {
-    ChartTypeName,
+    GrapherChartType,
     GrapherInterface,
 } from "../grapherTypes/GrapherTypes.js"
 
@@ -11,7 +11,7 @@ export interface DbInsertChartConfig {
     full: JsonString
     fullMd5?: Base64String
     slug?: string | null
-    chartType?: ChartTypeName | null
+    chartType?: GrapherChartType | null
     createdAt?: Date
     updatedAt?: Date | null
 }

--- a/packages/@ourworldindata/types/src/grapherTypes/GrapherConstants.ts
+++ b/packages/@ourworldindata/types/src/grapherTypes/GrapherConstants.ts
@@ -3,3 +3,67 @@ export const EPOCH_DATE = "2020-01-21"
 
 /** The "plot" is a chart without any header, footer or controls */
 export const IDEAL_PLOT_ASPECT_RATIO = 1.8
+
+export const GRAPHER_MAP_TYPE = "WorldMap"
+
+export const GRAPHER_CHART_TYPES = {
+    LineChart: "LineChart",
+    ScatterPlot: "ScatterPlot",
+    StackedArea: "StackedArea",
+    DiscreteBar: "DiscreteBar",
+    StackedDiscreteBar: "StackedDiscreteBar",
+    SlopeChart: "SlopeChart",
+    StackedBar: "StackedBar",
+    Marimekko: "Marimekko",
+} as const
+
+export const ALL_GRAPHER_CHART_TYPES = Object.values(GRAPHER_CHART_TYPES)
+
+/**
+ * Grapher tab specified in the config that determines the default tab to show.
+ * If `chart` is selected and Grapher has more than one chart tab, then the
+ * first chart tab will be active.
+ */
+export const GRAPHER_TAB_OPTIONS = {
+    table: "table",
+    map: "map",
+    chart: "chart",
+} as const
+
+/**
+ * Internal tab names used in Grapher.
+ */
+export const GRAPHER_TAB_NAMES = {
+    Table: "Table",
+    WorldMap: "WorldMap",
+
+    // chart types
+    LineChart: "LineChart",
+    ScatterPlot: "ScatterPlot",
+    StackedArea: "StackedArea",
+    DiscreteBar: "DiscreteBar",
+    StackedDiscreteBar: "StackedDiscreteBar",
+    SlopeChart: "SlopeChart",
+    StackedBar: "StackedBar",
+    Marimekko: "Marimekko",
+} as const
+
+/**
+ * Valid values for the `tab` query parameter in Grapher.
+ */
+export const GRAPHER_TAB_QUERY_PARAMS = {
+    // generic params
+    table: "table",
+    map: "map",
+    chart: "chart",
+
+    // chart types
+    line: "line",
+    scatter: "scatter",
+    "stacked-area": "stacked-area",
+    "discrete-bar": "discrete-bar",
+    "stacked-discrete-bar": "stacked-discrete-bar",
+    slope: "slope",
+    "stacked-bar": "stacked-bar",
+    marimekko: "marimekko",
+} as const

--- a/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
+++ b/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
@@ -119,6 +119,10 @@ export enum ToleranceStrategy {
     backwards = "backwards",
     forwards = "forwards",
 }
+
+export const GRAPHER_MAP_TYPE = "WorldMap"
+type GrapherMapType = typeof GRAPHER_MAP_TYPE
+
 export enum ChartTypeName {
     LineChart = "LineChart",
     ScatterPlot = "ScatterPlot",
@@ -128,9 +132,9 @@ export enum ChartTypeName {
     SlopeChart = "SlopeChart",
     StackedBar = "StackedBar",
     Marimekko = "Marimekko",
-    // special map type that can't be selected by authors
-    WorldMap = "WorldMap",
 }
+
+export type GrapherChartOrMapType = ChartTypeName | GrapherMapType
 
 export enum AxisMinMaxValueStr {
     auto = "auto",

--- a/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
+++ b/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
@@ -7,6 +7,13 @@ import { AxisAlign, Position } from "../domainTypes/Layout.js"
 import { Integer, QueryParams } from "../domainTypes/Various.js"
 import { DetailDictionary } from "../gdocTypes/Gdoc.js"
 import { observable } from "mobx"
+import {
+    GRAPHER_CHART_TYPES,
+    GRAPHER_MAP_TYPE,
+    GRAPHER_TAB_NAMES,
+    GRAPHER_TAB_OPTIONS,
+    GRAPHER_TAB_QUERY_PARAMS,
+} from "./GrapherConstants.js"
 
 export interface Box {
     x: number
@@ -120,22 +127,6 @@ export enum ToleranceStrategy {
     forwards = "forwards",
 }
 
-export const GRAPHER_MAP_TYPE = "WorldMap"
-type GrapherMapType = typeof GRAPHER_MAP_TYPE
-
-export enum ChartTypeName {
-    LineChart = "LineChart",
-    ScatterPlot = "ScatterPlot",
-    StackedArea = "StackedArea",
-    DiscreteBar = "DiscreteBar",
-    StackedDiscreteBar = "StackedDiscreteBar",
-    SlopeChart = "SlopeChart",
-    StackedBar = "StackedBar",
-    Marimekko = "Marimekko",
-}
-
-export type GrapherChartOrMapType = ChartTypeName | GrapherMapType
-
 export enum AxisMinMaxValueStr {
     auto = "auto",
 }
@@ -176,53 +167,13 @@ export type SeriesName = string
 
 export type SeriesColorMap = Map<SeriesName, Color>
 
-/**
- * Grapher tab specified in the config that determines the default tab to show.
- * If `chart` is selected and Grapher has more than one chart tab, then the
- * first chart tab will be active.
- */
-export enum GrapherTabOption {
-    chart = "chart",
-    map = "map",
-    table = "table",
-}
+export type GrapherMapType = typeof GRAPHER_MAP_TYPE
+export type GrapherChartType = keyof typeof GRAPHER_CHART_TYPES
+export type GrapherChartOrMapType = GrapherChartType | GrapherMapType
 
-/**
- * Internal tab names used in Grapher.
- */
-export enum GrapherTabName {
-    Table = "Table",
-    WorldMap = "WorldMap",
-
-    // chart types
-    LineChart = "LineChart",
-    ScatterPlot = "ScatterPlot",
-    StackedArea = "StackedArea",
-    DiscreteBar = "DiscreteBar",
-    StackedDiscreteBar = "StackedDiscreteBar",
-    SlopeChart = "SlopeChart",
-    StackedBar = "StackedBar",
-    Marimekko = "Marimekko",
-}
-
-/**
- * Valid values for the `tab` query parameter in Grapher.
- */
-export enum GrapherTabQueryParam {
-    Chart = "chart",
-    Table = "table",
-    WorldMap = "map",
-
-    // chart types
-    LineChart = "line",
-    ScatterPlot = "scatter",
-    StackedArea = "stacked-area",
-    DiscreteBar = "discrete-bar",
-    StackedDiscreteBar = "stacked-discrete-bar",
-    SlopeChart = "slope",
-    StackedBar = "stacked-bar",
-    Marimekko = "marimekko",
-}
+export type GrapherTabOption = keyof typeof GRAPHER_TAB_OPTIONS
+export type GrapherTabQueryParam = keyof typeof GRAPHER_TAB_QUERY_PARAMS
+export type GrapherTabName = keyof typeof GRAPHER_TAB_NAMES
 
 export interface RelatedQuestionsConfig {
     text: string
@@ -581,7 +532,7 @@ export interface MapConfigInterface {
 // under the same rendering conditions it ought to remain visually identical
 export interface GrapherInterface extends SortConfig {
     $schema?: string
-    chartTypes?: ChartTypeName[]
+    chartTypes?: GrapherChartType[]
     id?: number
     version?: number
     slug?: string

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -74,6 +74,8 @@ export {
     type ColorScaleConfigInterface,
     ColorSchemeName,
     ChartTypeName,
+    type GrapherChartOrMapType,
+    GRAPHER_MAP_TYPE,
     GrapherTabOption,
     GrapherTabName,
     GrapherTabQueryParam,

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -44,6 +44,12 @@ export {
 export {
     IDEAL_PLOT_ASPECT_RATIO,
     EPOCH_DATE,
+    GRAPHER_MAP_TYPE,
+    GRAPHER_CHART_TYPES,
+    GRAPHER_TAB_NAMES,
+    GRAPHER_TAB_OPTIONS,
+    GRAPHER_TAB_QUERY_PARAMS,
+    ALL_GRAPHER_CHART_TYPES,
 } from "./grapherTypes/GrapherConstants.js"
 
 export {
@@ -73,12 +79,11 @@ export {
     BinningStrategy,
     type ColorScaleConfigInterface,
     ColorSchemeName,
-    ChartTypeName,
     type GrapherChartOrMapType,
-    GRAPHER_MAP_TYPE,
-    GrapherTabOption,
-    GrapherTabName,
-    GrapherTabQueryParam,
+    type GrapherTabOption,
+    type GrapherTabName,
+    type GrapherTabQueryParam,
+    type GrapherChartType,
     StackMode,
     EntitySelectionMode,
     ScatterPointLabelStrategy,

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -175,8 +175,8 @@ import {
     TagGraphRootName,
     TagGraphNode,
     GrapherInterface,
-    ChartTypeName,
     DimensionProperty,
+    GRAPHER_CHART_TYPES,
 } from "@ourworldindata/types"
 import { PointVector } from "./PointVector.js"
 import React from "react"
@@ -1971,8 +1971,8 @@ export function getParentVariableIdFromChartConfig(
 ): number | undefined {
     const { chartTypes, dimensions } = config
 
-    const chartType = chartTypes?.[0] ?? ChartTypeName.LineChart
-    if (chartType === ChartTypeName.ScatterPlot) return undefined
+    const chartType = chartTypes?.[0] ?? GRAPHER_CHART_TYPES.LineChart
+    if (chartType === GRAPHER_CHART_TYPES.ScatterPlot) return undefined
     if (!dimensions) return undefined
 
     const yVariableIds = dimensions

--- a/packages/@ourworldindata/utils/src/grapherConfigUtils.test.ts
+++ b/packages/@ourworldindata/utils/src/grapherConfigUtils.test.ts
@@ -3,8 +3,8 @@
 import {
     DimensionProperty,
     GrapherInterface,
-    GrapherTabOption,
     MapProjectionName,
+    GRAPHER_TAB_OPTIONS,
 } from "@ourworldindata/types"
 import {
     mergeGrapherConfigs,
@@ -243,14 +243,14 @@ describe(diffGrapherConfigs, () => {
     it("drops redundant entries", () => {
         expect(
             diffGrapherConfigs(
-                { tab: GrapherTabOption.map },
-                { tab: GrapherTabOption.map }
+                { tab: GRAPHER_TAB_OPTIONS.map },
+                { tab: GRAPHER_TAB_OPTIONS.map }
             )
         ).toEqual({})
         expect(
             diffGrapherConfigs(
-                { tab: GrapherTabOption.chart, title: "Chart" },
-                { tab: GrapherTabOption.chart, title: "Reference chart" }
+                { tab: GRAPHER_TAB_OPTIONS.chart, title: "Chart" },
+                { tab: GRAPHER_TAB_OPTIONS.chart, title: "Reference chart" }
             )
         ).toEqual({ title: "Chart" })
     })
@@ -260,7 +260,7 @@ describe(diffGrapherConfigs, () => {
             diffGrapherConfigs(
                 {
                     title: "Chart",
-                    tab: GrapherTabOption.chart,
+                    tab: GRAPHER_TAB_OPTIONS.chart,
                     map: {
                         projection: MapProjectionName.World,
                         hideTimeline: true,
@@ -268,7 +268,7 @@ describe(diffGrapherConfigs, () => {
                 },
                 {
                     title: "Reference chart",
-                    tab: GrapherTabOption.chart,
+                    tab: GRAPHER_TAB_OPTIONS.chart,
                     map: {
                         projection: MapProjectionName.World,
                         hideTimeline: false,
@@ -279,14 +279,14 @@ describe(diffGrapherConfigs, () => {
         expect(
             diffGrapherConfigs(
                 {
-                    tab: GrapherTabOption.chart,
+                    tab: GRAPHER_TAB_OPTIONS.chart,
                     map: {
                         projection: MapProjectionName.World,
                         hideTimeline: true,
                     },
                 },
                 {
-                    tab: GrapherTabOption.chart,
+                    tab: GRAPHER_TAB_OPTIONS.chart,
                     map: {
                         projection: MapProjectionName.World,
                         hideTimeline: true,
@@ -300,11 +300,11 @@ describe(diffGrapherConfigs, () => {
         expect(
             diffGrapherConfigs(
                 {
-                    tab: GrapherTabOption.chart,
+                    tab: GRAPHER_TAB_OPTIONS.chart,
                     title: "Chart",
                     subtitle: undefined,
                 },
-                { tab: GrapherTabOption.chart, title: "Reference chart" }
+                { tab: GRAPHER_TAB_OPTIONS.chart, title: "Reference chart" }
             )
         ).toEqual({ title: "Chart" })
     })
@@ -361,12 +361,12 @@ describe(diffGrapherConfigs, () => {
 
     it("is idempotent", () => {
         const config: GrapherInterface = {
-            tab: GrapherTabOption.chart,
+            tab: GRAPHER_TAB_OPTIONS.chart,
             title: "Chart",
             subtitle: undefined,
         }
         const reference: GrapherInterface = {
-            tab: GrapherTabOption.chart,
+            tab: GRAPHER_TAB_OPTIONS.chart,
             title: "Reference chart",
         }
         const diffedOnce = diffGrapherConfigs(config, reference)
@@ -378,12 +378,12 @@ describe(diffGrapherConfigs, () => {
 describe("diff+merge", () => {
     it("are consistent", () => {
         const config: GrapherInterface = {
-            tab: GrapherTabOption.chart,
+            tab: GRAPHER_TAB_OPTIONS.chart,
             title: "Chart",
             subtitle: "Chart subtitle",
         }
         const reference: GrapherInterface = {
-            tab: GrapherTabOption.chart,
+            tab: GRAPHER_TAB_OPTIONS.chart,
             title: "Reference chart",
         }
         const diffedAndMerged = mergeGrapherConfigs(

--- a/site/gdocs/components/KeyIndicatorCollection.tsx
+++ b/site/gdocs/components/KeyIndicatorCollection.tsx
@@ -13,6 +13,7 @@ import {
 import {
     EnrichedBlockKeyIndicatorCollection,
     EnrichedBlockKeyIndicator,
+    GRAPHER_TAB_OPTIONS,
     GrapherTabOption,
 } from "@ourworldindata/types"
 import { Url, urlToSlug, commafyNumber } from "@ourworldindata/utils"
@@ -26,9 +27,9 @@ import { Button } from "@ourworldindata/components"
 const HEIGHT_ANIMATION_DURATION_IN_SECONDS = 0.4
 
 const tabIconMap: Record<GrapherTabOption, IconDefinition> = {
-    [GrapherTabOption.chart]: faChartLine,
-    [GrapherTabOption.map]: faEarthAmericas,
-    [GrapherTabOption.table]: faTable,
+    [GRAPHER_TAB_OPTIONS.chart]: faChartLine,
+    [GRAPHER_TAB_OPTIONS.map]: faEarthAmericas,
+    [GRAPHER_TAB_OPTIONS.table]: faTable,
 }
 
 export default function KeyIndicatorCollection({
@@ -247,7 +248,7 @@ function KeyIndicatorHeader({
             ? queryParams.tab
             : undefined
     const activeTab =
-        tabFromQueryParams || linkedChart.tab || GrapherTabOption.chart
+        tabFromQueryParams || linkedChart.tab || GRAPHER_TAB_OPTIONS.chart
 
     const source = block.source || linkedIndicator.attributionShort
 
@@ -357,5 +358,5 @@ function isElementAtTopOfViewport(element: HTMLElement): boolean {
 }
 
 function isValidGrapherTab(tab: string): tab is GrapherTabOption {
-    return Object.values(GrapherTabOption).includes(tab as GrapherTabOption)
+    return Object.values(GRAPHER_TAB_OPTIONS).includes(tab as GrapherTabOption)
 }

--- a/site/multiembedder/MultiEmbedder.tsx
+++ b/site/multiembedder/MultiEmbedder.tsx
@@ -15,7 +15,7 @@ import {
     getWindowUrl,
     isPresent,
     Url,
-    GrapherTabOption,
+    GRAPHER_TAB_OPTIONS,
     merge,
     MultiDimDataPageConfig,
     extractMultiDimChoicesFromQueryStr,
@@ -213,11 +213,11 @@ class MultiEmbedder {
             // make sure the tab of the active pane is visible
             if (figureConfigAttr && !isEmpty(localConfig)) {
                 const activeTab = queryParams.tab || grapherPageConfig.tab
-                if (activeTab === GrapherTabOption.chart)
+                if (activeTab === GRAPHER_TAB_OPTIONS.chart)
                     localConfig.hideChartTabs = false
-                if (activeTab === GrapherTabOption.map)
+                if (activeTab === GRAPHER_TAB_OPTIONS.map)
                     localConfig.hasMapTab = true
-                if (activeTab === GrapherTabOption.table)
+                if (activeTab === GRAPHER_TAB_OPTIONS.table)
                     localConfig.hasTableTab = true
             }
 


### PR DESCRIPTION
Refactors Grapher types by replacing enums with compile-time-only types.

I introduced `GrapherTabName` in the previous PR, which is either a `ChartTypeName` or `"WorldMap"` or `"Table"`. But enums currently [can't be extended or merged](https://github.com/microsoft/TypeScript/issues/17592), which means that I had to copy-paste all chart type names into `GrapherTabName`. As a result, TypeScript doesn't do a good job of type narrowing, forcing me to write (unnecessary) type assertions in many places.

This PR refactors `ChartTypeName` and other tab-related types so they don't use enums. However, I still wanted the convenience of a single object to access chart types, for example. To get that, the types are inferred from const objects:

```ts
const GRAPHER_CHART_TYPES = {
    LineChart: "LineChart",
    ScatterPlot: "ScatterPlot"
} as const

type GrapherChartType = keyof typeof GRAPHER_CHART_TYPES
```

I first did it the other way around (first defining the types, then using them for the objects), but it turns out the way it's done now leads to better type narrowing. 

**Newly introduced types:**
- `GrapherMapType`: only "WorldMap"
- `GrapherChartType`: "LineChart", "ScatterPlot", etc. (without "WorldMap")
- `GrapherChartOrMapType`: `GrapherChartType` or `GrapherMapType`
- `GrapherTabName`: Internal tab names used in Grapher (a chart type name or "WorldMap" or "Table")
- `GrapherTabOption`: Grapher tab specified in the config that determines the default tab to show ("chart", "map" or "tab")
- `GrapherTabQueryParam`: Valid values for the `tab` query parameter in Grapher ("chart", "map", "line", "slope", etc.)