### PR TITLE
Add button to archive dataset if it contains no charts

### DIFF
--- a/adminSiteClient/DatasetEditPage.tsx
+++ b/adminSiteClient/DatasetEditPage.tsx
@@ -374,14 +374,21 @@ class DatasetEditor extends React.Component<{ dataset: DatasetPageData }> {
                         </p>
                     ) : (
                         <p>
-                            <strong>
-                                Before archiving, ensure that the corresponding
-                                ETL grapher step has been archived:{" "}
-                                <code>
-                                    grapher/{dataset.namespace}/
-                                    {dataset.version}/{dataset.shortName}
-                                </code>
-                            </strong>
+                            <strong>Before archiving, ensure that:</strong>
+                            <ul>
+                                <li>
+                                    The corresponding ETL grapher step has been
+                                    archived:{" "}
+                                    <code>
+                                        grapher/{dataset.namespace}/
+                                        {dataset.version}/{dataset.shortName}
+                                    </code>
+                                </li>
+                                <li>
+                                    The dataset is not used in any
+                                    indicator-based explorers.
+                                </li>
+                            </ul>
                         </p>
                     )}
                     <button


### PR DESCRIPTION
Add a button to archive grapher datasets, if it contains no charts.
Also, remove the "Delete dataset" button, which we probably don't need.

For more context, see https://github.com/owid/owid-grapher/issues/3308
