### PR TITLE
✨ switch to the new owid regions data and tweak colors for regions

### DIFF
--- a/packages/@ourworldindata/grapher/src/color/CustomSchemes.ts
+++ b/packages/@ourworldindata/grapher/src/color/CustomSchemes.ts
@@ -314,14 +314,14 @@ CustomColorSchemes.push({
 
 export const ContinentColors = {
     Africa: OwidDistinctColors.Mauve,
-    Antarctica: OwidDistinctColors.Turquoise,
+    Antarctica: OwidDistinctColors.DarkCopper,
     Asia: OwidDistinctColors.Teal,
     Europe: OwidDistinctColors.Denim,
     NorthAmerica: OwidDistinctColors.Peach,
     ["North America"]: OwidDistinctColors.Peach,
     SouthAmerica: OwidDistinctColors.Maroon,
     ["South America"]: OwidDistinctColors.Maroon,
-    Oceania: OwidDistinctColors.DarkCopper,
+    Oceania: OwidDistinctColors.Turquoise,
     World: OwidDistinctColors.DarkOliveGreen,
     SubSaharanAfrica: OwidDistinctColors.DarkMauve,
     MiddleEastNorthAfrica: OwidDistinctColors.Purple,
@@ -340,7 +340,6 @@ const ContinentColorsNames = lazy(() => invert(ContinentColors))
 
 const ContinentColorPalette = [
     ContinentColors.Africa,
-    ContinentColors.Antarctica,
     ContinentColors.Asia,
     ContinentColors.Europe,
     ContinentColors.NorthAmerica,
@@ -357,6 +356,7 @@ const ContinentColorPalette = [
     ContinentColors.EasternEurope,
     ContinentColors.WesternEurope,
     ContinentColors.AustralasiaAndOceania,
+    ContinentColors.Antarctica,
 ]
 
 export const ContinentColorsColorScheme = {

--- a/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
@@ -53,7 +53,7 @@ export const ThereWasAProblemLoadingThisChart = `There was a problem loading thi
 
 export const WorldEntityName = "World"
 
-export const CONTINENTS_INDICATOR_ID = 123 // "Countries Continent"
+export const CONTINENTS_INDICATOR_ID = 900801 // "Countries Continent"
 export const POPULATION_INDICATOR_ID_USED_IN_ADMIN = 953899 // "Population (various sources, 2024-07-15)"
 export const POPULATION_INDICATOR_ID_USED_IN_ENTITY_SELECTOR = 953903 // "Population (historical) (various sources, 2024-07-15)"
 export const GDP_PER_CAPITA_INDICATOR_ID_USED_IN_ENTITY_SELECTOR = 905490 // "World Development Indicators - World Bank (2024-05-20)"

--- a/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.ts
+++ b/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.ts
@@ -618,9 +618,8 @@ const columnDefFromOwidVariable = (
         shortName,
     } = variable
 
-    // Without this the much used var 123 appears as "Countries Continent". We could rename in Grapher but not sure the effects of that.
     const isContinent = isContinentsVariableId(variable.id)
-    const name = isContinent ? "Continent" : variable.name
+    const name = variable.name
 
     // The column's type
     const type = isContinent

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.test.ts
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.test.ts
@@ -463,7 +463,6 @@ describe("colors & legend", () => {
             [2, "Canada", "", 2000, 1, 1, "North America", null],
             [3, "China", "", 2000, 1, null, "Asia", null],
             [4, "Australia", "", 2000, 1, 1, "Oceania", null],
-            [5, "Antarctica", "", 2000, null, null, "Antarctica", null],
             [6, "Chile", "", 2000, 1, 1, "South America", null],
             [7, "Nigeria", "", 2000, 1, 1, "Africa", null],
         ],
@@ -507,7 +506,6 @@ describe("colors & legend", () => {
                 Canada: "North America",
                 China: "Asia",
                 Australia: "Oceania",
-                Antarctica: "Antarctica",
                 Chile: "South America",
                 Nigeria: "Africa",
             }
@@ -531,7 +529,6 @@ describe("colors & legend", () => {
     it("legend contains every continent for which there is data (before timeline filter)", () => {
         expect(chart.legendItems.map((item) => item.label).sort()).toEqual([
             "Africa",
-            "Antarctica",
             "Europe",
             "North America",
             "Oceania",


### PR DESCRIPTION
This PR tackles the easy parts of #4176 - it uses the new indicator id instead of the old one for the OWID regions.

This PR also tweaks the colors a bit. The new regions datasets does not map any item to Antarctica so the order changed a bit. I used this opportunity to also change the mapping of continent colors (see [this slack thread](https://owid.slack.com/archives/C5BDCB2R3/p1731934875618319))