### PR TITLE
fix(csv): provide cells even if they're missing in csv

### DIFF
--- a/packages/@ourworldindata/core-table/src/CoreTableUtils.test.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTableUtils.test.ts
@@ -299,6 +299,14 @@ describe("matrix methods", () => {
 123 345 usa`)
     })
 
+    it("handles missing data for some cells", () => {
+        const rows = parseDelimited(`gdp,pop
+1
+1,2`)
+        expect(Object.keys(rows[0])).toEqual(["gdp", "pop"])
+        expect(rows[0].pop).toEqual("")
+    })
+
     it("can trim an array", () => {
         expect(trimArray([1, "2", "", null, undefined])).toEqual([1, "2"])
         const test = [1, "2", "", null, undefined, 1]

--- a/packages/@ourworldindata/core-table/src/CoreTableUtils.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTableUtils.ts
@@ -573,6 +573,15 @@ export const parseDelimited = (
     }: Papa.ParseResult<any>): DSVParsedArray<Record<string, any>> => {
         const dsvParsed = data as DSVParsedArray<Record<string, any>>
         dsvParsed.columns = meta.fields || []
+
+        // Some downstream methods expect all rows to have fields for all columns,
+        // even if they are missing in that row. This loop ensures that.
+        for (const row of dsvParsed) {
+            for (const col of dsvParsed.columns) {
+                if (!(col in row)) row[col] = ""
+            }
+        }
+
         return dsvParsed
     }
 


### PR DESCRIPTION
CSV parsing behavior is slightly different between Papaparse and d3:
If there are missing cells at the end of a row, then d3 would still include them in the object, whereas d3 wouldn't. Consider:
```csv
gdp,pop
1
1,2
```

Here, `row[0]` would be `{gdp: "1", pop: ""}` in d3, but just `{gdp: "1"}` with Papaparse.

Turns out, we are relying on `Object.keys(row[0])` [here](https://github.com/owid/owid-grapher/blob/1fc853cb6cdb452aa5dcd642715fd3df3ad8a0e2/packages/%40ourworldindata/core-table/src/CoreTableUtils.ts#L392-L395).

... [which caused this explorer issue reported on Slack.](https://owid.slack.com/archives/C46U9LXRR/p1731944717195399)

This was broken in https://github.com/owid/owid-grapher/commit/4a15b85933de11089c60266d8b1133d3a88d6d20.