### PR TITLE
✨ autofocus SearchBox on search page

### DIFF
--- a/site/search/Search.scss
+++ b/site/search/Search.scss
@@ -417,11 +417,10 @@ $reset-button-margin: 16px;
 
 section.search-page__no-results {
     display: none;
-    height: 60vh;
+    height: 70vh;
     text-align: center;
     flex-direction: column;
     justify-content: center;
-    background-color: $gray-10;
 
     h2 {
         margin-bottom: 0;

--- a/site/search/SearchPanel.tsx
+++ b/site/search/SearchPanel.tsx
@@ -766,6 +766,7 @@ export class InstantSearchContainer extends React.Component {
             >
                 <div className="search-panel">
                     <SearchBox
+                        autoFocus
                         placeholder={DEFAULT_SEARCH_PLACEHOLDER}
                         className="searchbox"
                         classNames={{


### PR DESCRIPTION
Changes:
- Autofocus SearchBox on the search page
- Removes the gray background for the no results screen
- Approximately places the algolia logo in a slightly better spot on the no results screen for most resolutions