### PR TITLE
fix: restore correct ellipsis word wrap for sources modal

### DIFF
--- a/packages/@ourworldindata/grapher/src/modal/SourcesModal.scss
+++ b/packages/@ourworldindata/grapher/src/modal/SourcesModal.scss
@@ -68,7 +68,6 @@
 
         .attribution {
             color: $gray-60;
-            display: inline-block;
             margin-left: $tab-title-spacing;
         }
 


### PR DESCRIPTION
Fixes #4180 by restoring the `span` to the default `display: inline`.
