### PR TITLE
fix(make): don't read .env file as env variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,6 @@ SCRIPT_SHELL ?= $(or $(shell echo $$OWID_SCRIPT_SHELL),$(LOGIN_SHELL))
 # https://lithic.tech/blog/2020-05/makefile-dot-env/
 ifneq (,$(wildcard ./.env))
 	include .env
-	export
 endif
 
 .PHONY: help up up.full down refresh refresh.wp refresh.full migrate svgtest itsJustJavascript

--- a/Makefile
+++ b/Makefile
@@ -243,7 +243,7 @@ dbtest: node_modules
 	yarn buildTsc
 
 	@echo '==> Running db test script'
-	./db/tests/run-db-tests.sh
+	@. ./.env && ./db/tests/run-db-tests.sh
 
 lint: node_modules
 	@echo '==> Linting'

--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ refresh:
 	./devTools/docker/download-grapher-metadata-mysql.sh
 
 	@echo '==> Updating grapher database'
-	@. ./.env && DATA_FOLDER=tmp-downloads ./devTools/docker/refresh-grapher-data.sh
+	DATA_FOLDER=tmp-downloads ./devTools/docker/refresh-grapher-data.sh
 
 	@echo '!!! If you use ETL, wipe indicators from your R2 staging with `rclone delete r2:owid-api-staging/[yourname]/ ' \
 	'--fast-list --transfers 32 --checkers 32  --verbose`'
@@ -151,7 +151,7 @@ refresh.pageviews: node_modules
 
 sync-images: sync-images.preflight-check
 	@echo '==> Syncing images to R2'
-	@. ./.env && ./devTools/docker/sync-s3-images.sh
+	./devTools/docker/sync-s3-images.sh
 
 refresh.full: refresh refresh.pageviews sync-images
 	@echo '==> Full refresh completed'
@@ -243,7 +243,7 @@ dbtest: node_modules
 	yarn buildTsc
 
 	@echo '==> Running db test script'
-	@. ./.env && ./db/tests/run-db-tests.sh
+	./db/tests/run-db-tests.sh
 
 lint: node_modules
 	@echo '==> Linting'

--- a/db/tests/run-db-tests.sh
+++ b/db/tests/run-db-tests.sh
@@ -7,6 +7,10 @@ set -o nounset
 # you run this via "make dbtest" and it will then spin up the docker container for the
 # test database, initialize it and then run the tests
 
+if [ -e .env ]; then
+    source .env
+fi
+
 : "${GRAPHER_TEST_DB_USER:?Need to set GRAPHER_TEST_DB_USER non-empty}"
 : "${GRAPHER_TEST_DB_PASS:?Need to set GRAPHER_TEST_DB_PASS non-empty}"
 : "${GRAPHER_TEST_DB_NAME:?Need to set GRAPHER_TEST_DB_NAME non-empty}"

--- a/devTools/docker/refresh-grapher-data.sh
+++ b/devTools/docker/refresh-grapher-data.sh
@@ -2,7 +2,10 @@
 set -o errexit
 set -o pipefail
 set -o nounset
-set -x
+
+if [ -e .env ]; then
+    source .env
+fi
 
 : "${GRAPHER_DB_NAME:?Need to set GRAPHER_DB_NAME non-empty}"
 : "${GRAPHER_DB_USER:?Need to set GRAPHER_DB_USER non-empty}"

--- a/devTools/docker/sync-s3-images.sh
+++ b/devTools/docker/sync-s3-images.sh
@@ -3,6 +3,10 @@
 set -o errexit
 set -o pipefail
 
+if [ -e .env ]; then
+    source .env
+fi
+
 if [[ -z "$IMAGE_HOSTING_R2_BUCKET_PATH" ]]; then
   echo 'Please set IMAGE_HOSTING_R2_BUCKET_PATH in .env'
   exit 1


### PR DESCRIPTION
## The problem

I just noticed that we cannot run make targets (in this case, `make reindex`) on our prod servers - they'll fail with `Access denied for user 'live_grapher'@'[owid-admin-prod.tail6e23.ts.net](http://owid-admin-prod.tail6e23.ts.net/)' (using password: YES)` when accessing the DB.
I'm pretty sure I got some idea now of what is going on:
In prod, we have .env secrets like `GRAPHER_DB_PASS='abc'` - i.e. they are wrapped in single quotes.
When these are loaded in Node (via dotenv), it strips out the quote marks and just reads `abc`. On the other hand, when [this piece of code](https://github.com/owid/owid-grapher/blob/d8ba3a0b521df9091987df22205900c5f0b31f7f/Makefile#L14-L20) reads the same var in the makefile, it reads that same line as `'abc'`, i.e. including the quotation marks (the same happens for double quotes, too). This, [apparently](https://stackoverflow.com/a/23332194) and stupidly, is the only possible behavior of make.
From what I understand, this wrongly-parsed `GRAPHER_DB_PASS` is then passed as an env var to Node, "overpowering" the one that dotenv would read from the env file. Hence the above error.

## The solution

Note: I don't know what I'm doing!
But I think by removing the `export` call, these variables continue to be read (wrongly) into the make environment (enabling `validate.env`), _but_ are then not passed to the commands as env variables.