### PR TITLE
feat: API handlers for narrative views

### DIFF
--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -3316,8 +3316,8 @@ postRouteWithRWTransaction(apiRouter, "/chartViews", async (req, res, trx) => {
     const { chartConfigId } = await saveNewChartConfigInDbAndR2(
         trx,
         undefined,
-        fullConfig,
-        patchConfig
+        patchConfig,
+        fullConfig
     )
 
     // insert into chart_views
@@ -3365,8 +3365,8 @@ putRouteWithRWTransaction(
         await updateChartConfigInDbAndR2(
             trx,
             chartConfigIdRow.chartConfigId as Base64String,
-            fullConfig,
-            patchConfig
+            patchConfig,
+            fullConfig
         )
 
         // update chart_views

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -3388,7 +3388,7 @@ postRouteWithRWTransaction(apiRouter, "/chartViews", async (req, res, trx) => {
     const result = await trx.table(ChartViewsTableName).insert(insertRow)
     const [resultId] = result
 
-    return { id: resultId, success: true }
+    return { chartViewId: resultId, success: true }
 })
 
 putRouteWithRWTransaction(

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -3385,9 +3385,10 @@ postRouteWithRWTransaction(apiRouter, "/chartViews", async (req, res, trx) => {
         lastEditedByUserId: res.locals.user.id,
         chartConfigId: chartConfigId,
     }
-    await trx.table(ChartViewsTableName).insert<DbInsertChartView>(insertRow)
+    const result = await trx.table(ChartViewsTableName).insert(insertRow)
+    const [resultId] = result
 
-    return { success: true }
+    return { id: resultId, success: true }
 })
 
 putRouteWithRWTransaction(

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -109,7 +109,6 @@ import {
     DbPlainChartView,
     ChartViewsTableName,
     DbInsertChartView,
-    DbInsertChartConfig,
 } from "@ourworldindata/types"
 import { uuidv7 } from "uuidv7"
 import {

--- a/db/migration/1731589634295-CreateChartViewsTable.ts
+++ b/db/migration/1731589634295-CreateChartViewsTable.ts
@@ -9,9 +9,11 @@ export class CreateChartViewsTable1731589634295 implements MigrationInterface {
                 chartConfigId CHAR(36) NOT NULL,
                 parentChartId INT NOT NULL,
                 createdAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                updatedAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                updatedAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                lastEditedByUserId INT NOT NULL,
                 FOREIGN KEY (chartConfigId) REFERENCES chart_configs(id) ON DELETE RESTRICT ON UPDATE RESTRICT,
-                FOREIGN KEY (parentChartId) REFERENCES charts(id) ON DELETE RESTRICT ON UPDATE RESTRICT
+                FOREIGN KEY (parentChartId) REFERENCES charts(id) ON DELETE RESTRICT ON UPDATE RESTRICT,
+                FOREIGN KEY (lastEditedByUserId) REFERENCES users(id) ON DELETE RESTRICT ON UPDATE RESTRICT
             );
         `)
     }

--- a/db/migration/1731589634295-CreateChartViewsTable.ts
+++ b/db/migration/1731589634295-CreateChartViewsTable.ts
@@ -5,7 +5,7 @@ export class CreateChartViewsTable1731589634295 implements MigrationInterface {
         await queryRunner.query(`-- sql
             CREATE TABLE chart_views (
                 id INT AUTO_INCREMENT PRIMARY KEY,
-                slug VARCHAR(255) NOT NULL,
+                slug VARCHAR(255) NOT NULL UNIQUE,
                 chartConfigId CHAR(36) NOT NULL,
                 parentChartId INT NOT NULL,
                 createdAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP,

--- a/db/migration/1731589634295-CreateChartViewsTable.ts
+++ b/db/migration/1731589634295-CreateChartViewsTable.ts
@@ -7,9 +7,11 @@ export class CreateChartViewsTable1731589634295 implements MigrationInterface {
                 id INT AUTO_INCREMENT PRIMARY KEY,
                 slug VARCHAR(255) NOT NULL,
                 chartConfigId CHAR(36) NOT NULL,
+                parentChartId INT NOT NULL,
                 createdAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                 updatedAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                FOREIGN KEY (chartConfigId) REFERENCES chart_configs(id)
+                FOREIGN KEY (chartConfigId) REFERENCES chart_configs(id) ON DELETE RESTRICT ON UPDATE RESTRICT,
+                FOREIGN KEY (parentChartId) REFERENCES charts(id) ON DELETE RESTRICT ON UPDATE RESTRICT
             );
         `)
     }

--- a/db/migration/1731589634295-CreateChartViewsTable.ts
+++ b/db/migration/1731589634295-CreateChartViewsTable.ts
@@ -1,0 +1,22 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class CreateChartViewsTable1731589634295 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`-- sql
+            CREATE TABLE chart_views (
+                id INT AUTO_INCREMENT PRIMARY KEY,
+                slug VARCHAR(255) NOT NULL,
+                chartConfigId CHAR(36) NOT NULL,
+                createdAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                updatedAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY (chartConfigId) REFERENCES chart_configs(id)
+            );
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            DROP TABLE chart_views;
+        `)
+    }
+}

--- a/db/model/ChartView.ts
+++ b/db/model/ChartView.ts
@@ -1,0 +1,19 @@
+// These props of the config object are _always_ explicitly persisted
+// in the chart view's config, and thus cannot be accidentally overridden by
+
+import { GrapherInterface } from "@ourworldindata/types"
+
+// an update to the parent chart's config.
+export const CHART_VIEW_PROPS_TO_PERSIST: (keyof GrapherInterface)[] = [
+    // Chart type
+    "type",
+    "tab",
+
+    // Entity selection
+    "selectedEntityNames",
+    "selectedEntityColors",
+
+    // Time selection
+    "minTime",
+    "maxTime",
+]

--- a/packages/@ourworldindata/types/src/dbTypes/ChartViews.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/ChartViews.ts
@@ -1,0 +1,11 @@
+export const ChartViewsTableName = "chart_views"
+export interface DbInsertChartView {
+    id?: number
+    slug: string
+    chartConfigId: string
+    parentChartId: number
+    createdAt?: Date | null
+    updatedAt?: Date | null
+    lastEditedByUserId: number
+}
+export type DbPlainChartView = Required<DbInsertChartView>

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -466,6 +466,11 @@ export {
     type DbChartTagJoin,
 } from "./dbTypes/ChartTags.js"
 export {
+    type DbPlainChartView,
+    type DbInsertChartView,
+    ChartViewsTableName,
+} from "./dbTypes/ChartViews.js"
+export {
     ChartsXEntitiesTableName,
     type DbInsertChartXEntity,
     type DbPlainChartXEntity,


### PR DESCRIPTION
Part of #4128.

This PR creates the DB table needed for narrative views, and sets up some CRUD methods for these that handle generating patch configs, explicitly persisting some properties of the patch, storing them in the DB and R2, and so on.