### PR TITLE
🐝  analytics: increase Sentry session replay sampling to 10%

### DIFF
--- a/site/owid.entry.ts
+++ b/site/owid.entry.ts
@@ -102,7 +102,7 @@ if (SENTRY_DSN) {
                         mask: [".sentry-mask"],
                     }),
                 ],
-                replaysSessionSampleRate: ENV === "development" ? 1 : 0.01,
+                replaysSessionSampleRate: ENV === "development" ? 1 : 0.1,
                 replaysOnErrorSampleRate: 0,
             }
         } else {


### PR DESCRIPTION
Increases Sentry session replay sampling from 1% of cookie-consenting sessions to 10% of cookie-consenting sessions. 

We are now on a "sponsored" Sentry plan (https://sentry.io/for/good/), which increases our budget of session replays to 100k per month (for free).