### PR TITLE
🐛 fix active/checked state of checkboxes and radio buttons on mobile

### DIFF
--- a/packages/@ourworldindata/components/src/Checkbox.scss
+++ b/packages/@ourworldindata/components/src/Checkbox.scss
@@ -40,6 +40,7 @@
         svg {
             font-size: 10px;
             padding-left: 0.75px;
+            display: none;
         }
     }
 
@@ -47,17 +48,13 @@
         outline: 2px solid $controls-color;
     }
 
-    input:active + .custom {
-        background: $active-fill;
-    }
-
     input:checked + .custom {
         background: $active-fill;
         border-color: $active-fill;
-    }
 
-    input:checked:active + .custom {
-        background: white;
+        svg {
+            display: block;
+        }
     }
 
     .label {

--- a/packages/@ourworldindata/components/src/Checkbox.tsx
+++ b/packages/@ourworldindata/components/src/Checkbox.tsx
@@ -19,7 +19,7 @@ export class Checkbox extends React.Component<{
                         onChange={onChange}
                     />
                     <div className="custom">
-                        {checked && <FontAwesomeIcon icon={faCheck} />}
+                        <FontAwesomeIcon icon={faCheck} />
                     </div>
                     <div className="label">{label}</div>
                 </label>

--- a/packages/@ourworldindata/components/src/RadioButton.scss
+++ b/packages/@ourworldindata/components/src/RadioButton.scss
@@ -41,11 +41,17 @@
             height: math.div($radio-size, 2);
             background-color: $active-fill;
             border-radius: 50%;
+            display: none;
         }
     }
 
     input:focus-visible + .outer {
         outline: 2px solid $controls-color;
+    }
+
+    input:active + .outer .inner,
+    input:checked + .outer .inner {
+        display: block;
     }
 
     .label {

--- a/packages/@ourworldindata/components/src/RadioButton.tsx
+++ b/packages/@ourworldindata/components/src/RadioButton.tsx
@@ -19,7 +19,7 @@ export class RadioButton extends React.Component<{
                         onChange={onChange}
                     />
                     <div className="outer">
-                        {checked && <div className="inner" />}
+                        <div className="inner" />
                     </div>
                     <div className="label">{label}</div>
                 </label>


### PR DESCRIPTION
If you click an entity on mobile, then the checkbox gets a blue background colour on touch down, but show the tick only after the interaction is over.

https://github.com/user-attachments/assets/d1a2caa8-d399-41ab-89c8-98d8d84344ef

To do: Now there is a flicker...