### PR TITLE
🐛 fix unpublished chart delete

### DIFF
--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -1066,12 +1066,14 @@ deleteRouteWithRWTransaction(
     "/charts/:chartId",
     async (req, res, trx) => {
         const chart = await expectChartById(trx, req.params.chartId)
-        const links = await getPublishedLinksTo(trx, [chart.slug!])
-        if (links.length) {
-            const sources = links.map((link) => link.sourceSlug).join(", ")
-            throw new Error(
-                `Cannot delete chart in-use in the following published documents: ${sources}`
-            )
+        if (chart.slug) {
+            const links = await getPublishedLinksTo(trx, [chart.slug])
+            if (links.length) {
+                const sources = links.map((link) => link.sourceSlug).join(", ")
+                throw new Error(
+                    `Cannot delete chart in-use in the following published documents: ${sources}`
+                )
+            }
         }
 
         await db.knexRaw(trx, `DELETE FROM chart_dimensions WHERE chartId=?`, [


### PR DESCRIPTION
This was an incorrect assumption that is now throwing a few errors in the admin as we clean out some old charts