### PR TITLE
chore: update minimum browser versions we support

### DIFF
--- a/docs/browser-support.md
+++ b/docs/browser-support.md
@@ -1,21 +1,20 @@
 ## Supported browsers
 
-As of **2024-03-20**, we support the following browsers:
+As of **2024-11-26**, we support the following browsers:
 
-- Safari 12+ [September 2018] (earlier versions are missing support for [the CSS `gap` property](https://caniuse.com/mdn-css_properties_gap_grid_context))
-- iOS Safari 12+ [September 2018] (earlier versions are missing support for [the CSS `gap` property](https://caniuse.com/mdn-css_properties_gap_grid_context))
-- Chrome/Edge 66+ [April 2018] (earlier versions are missing support for [Optional catch binding](https://caniuse.com/mdn-javascript_statements_try_catch_optional_catch_binding))
-- Opera 53+ [May 2018] (since Opera 53 is based on Chromium 66)
+- Safari 13.1+ [March 2020] (earlier versions are missing support for [the nullish coalescing operator (`??`)](https://caniuse.com/mdn-javascript_operators_nullish_coalescing))
+- iOS Safari 13.4+ [March 2020] (earlier versions are missing support for [the nullish coalescing operator (`??`)](https://caniuse.com/mdn-javascript_operators_nullish_coalescing))
+- Chrome/Edge 80+ [February 2020] (earlier versions are missing support for [the nullish coalescing operator (`??`)](https://caniuse.com/mdn-javascript_operators_nullish_coalescing))
+- Opera 67+ [February 2020] (since Opera 67 is based on Chromium 80)
 - Firefox 78+ [June 2020] (earlier versions are missing support for [Unicode character class escapes in regular expressions](https://caniuse.com/mdn-javascript_regular_expressions_unicode_character_class_escape))
 
-**Overall, [this caniuse link shows which browsers are supported](https://caniuse.com/mdn-css_properties_gap_grid_context,es6-module,mdn-javascript_statements_try_catch_optional_catch_binding,mdn-javascript_regular_expressions_unicode_character_class_escape)** (scroll down to "Feature summary").
+**Overall, [this caniuse link shows which browsers are supported](https://caniuse.com/mdn-javascript_operators_nullish_coalescing,template-literals,mdn-css_properties_gap_grid_context,es6-module,mdn-javascript_regular_expressions_unicode_character_class_escape)** (scroll down to "Feature summary").
 
 ### "Most breaking" features
 
 "Most breaking" features we use are:
 
-- [Optional catch binding](https://caniuse.com/mdn-javascript_statements_try_catch_optional_catch_binding), which allows for `catch {}` instead of `catch (e) {}`.
-  We don't _have_ to use it, but Chrome < 66 is so uncommon now that's it not a worry.
+- [Nullish coalescing operator (`??`)](https://caniuse.com/mdn-javascript_operators_nullish_coalescing), allowing for expressions like `const foo = null ?? 'default string'`.
 - [ES6 modules](https://caniuse.com/es6-module), where we use `<script type="module">` (in HTML) and `import ... from "..."` (in JS)
 - [The CSS `gap` property](https://caniuse.com/mdn-css_properties_gap_grid_context), together with `row-gap` and `column-gap`, which was previously prefixed by `grid-` in most browsers. Without support for these properties Google Docs-based pages are borderline unusable; however our interactive charts themselves work pretty much fine on their standalone pages.
 - [Unicode character class escapes in regular expressions](https://caniuse.com/mdn-javascript_regular_expressions_unicode_character_class_escape), which lets you do something like `\p{Letter}` to match any unicode letters in a RegExp.

--- a/vite.config-common.mts
+++ b/vite.config-common.mts
@@ -48,7 +48,7 @@ export const defineViteConfigForEntrypoint = (entrypoint: ViteEntryPoint) => {
             emptyOutDir: true,
             outDir: `dist/${entrypointInfo.outDir}`,
             sourcemap: true,
-            target: ["chrome66", "firefox78", "safari12"], // see docs/browser-support.md
+            target: ["chrome80", "firefox78", "safari13.1"], // see docs/browser-support.md
             rollupOptions: {
                 input: {
                     [entrypointInfo.outName]: entrypointInfo.entryPointFile,


### PR DESCRIPTION
I think it's time :)

This is dropping support for Safari 12 in particular, and beginning our browser support at Safari 13.1.
This makes us support browsers going back to early 2020, roughly 4.5 years.

I've hand-checked the features that Vite enables with this change, and it's mainly:
- No longer transpiling [ES6 template literals](https://caniuse.com/template-literals) but keeping them in their ES6 syntax
- Including the [nullish coalescing operator (`??`)](https://caniuse.com/mdn-javascript_operators_nullish_coalescing) as-is in the output JS and not transpiling it
- In CSS, it's dropping some vendor prefixes, e.g. `-webkit-sticky, -webkit-text-decoration-color`.

I've tested this in Safari 12 and Chrome 78, both of which are properly falling back to our no-JS solution (because of syntax errors related to `??`). Safari 13.1 is working fine.