### PR TITLE
🔨 stop exposing grapher for charts embedded on a data page

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -3120,7 +3120,7 @@ export class Grapher
         this.setBaseFontSize()
         this.setUpIntersectionObserver()
         this.setUpWindowResizeEventHandler()
-        exposeInstanceOnWindow(this, "grapher")
+        if (!this.isEmbeddedInADataPage) exposeInstanceOnWindow(this, "grapher")
         // Emit a custom event when the grapher is ready
         // We can use this in global scripts that depend on the grapher e.g. the site-screenshots tool
         this.disposers.push(


### PR DESCRIPTION
It's a bit annoying that I can't rely on `window.grapher` referring to the "main" Grapher on the data page if there is a Related Charts section