### PR TITLE
✨ (slope) redesign / TAS-722

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ dist/
 .dev.vars
 **/tsup.config.bundled*.mjs
 cfstorage/
+vite.*.mjs

--- a/packages/@ourworldindata/components/src/Halo/Halo.tsx
+++ b/packages/@ourworldindata/components/src/Halo/Halo.tsx
@@ -14,7 +14,7 @@ export function Halo(props: {
     id: React.Key
     children: React.ReactElement
     show?: boolean
-    background?: Color
+    outlineColor?: Color
     style?: React.CSSProperties
 }): React.ReactElement {
     const show = props.show ?? true
@@ -22,8 +22,8 @@ export function Halo(props: {
 
     const defaultStyle = {
         ...defaultHaloStyle,
-        fill: props.background ?? defaultHaloStyle.fill,
-        stroke: props.background ?? defaultHaloStyle.stroke,
+        fill: props.outlineColor ?? defaultHaloStyle.fill,
+        stroke: props.outlineColor ?? defaultHaloStyle.stroke,
     }
     const halo = React.cloneElement(props.children, {
         style: {

--- a/packages/@ourworldindata/components/src/TextWrap/TextWrap.test.ts
+++ b/packages/@ourworldindata/components/src/TextWrap/TextWrap.test.ts
@@ -145,3 +145,60 @@ describe("lines()", () => {
         ])
     })
 })
+
+describe("firstLineOffset", () => {
+    it("should offset the first line if requested", () => {
+        const text = "an example line"
+        const props = { text, maxWidth: 100, fontSize: FONT_SIZE }
+
+        const wrapWithoutOffset = new TextWrap(props)
+        const wrapWithOffset = new TextWrap({
+            ...props,
+            firstLineOffset: 50,
+        })
+
+        expect(wrapWithoutOffset.lines.map((l) => l.text)).toEqual([
+            "an example",
+            "line",
+        ])
+        expect(wrapWithOffset.lines.map((l) => l.text)).toEqual([
+            "an",
+            "example line",
+        ])
+    })
+
+    it("should break into a new line even if the first line would end up being empty", () => {
+        const text = "a-very-long-word"
+        const props = { text, maxWidth: 100, fontSize: FONT_SIZE }
+
+        const wrapWithoutOffset = new TextWrap(props)
+        const wrapWithOffset = new TextWrap({
+            ...props,
+            firstLineOffset: 50,
+        })
+
+        expect(wrapWithoutOffset.lines.map((l) => l.text)).toEqual([
+            "a-very-long-word",
+        ])
+        expect(wrapWithOffset.lines.map((l) => l.text)).toEqual([
+            "",
+            "a-very-long-word",
+        ])
+    })
+
+    it("should break into a new line if firstLineOffset > maxWidth", () => {
+        const text = "an example line"
+        const wrap = new TextWrap({
+            text,
+            maxWidth: 100,
+            fontSize: FONT_SIZE,
+            firstLineOffset: 150,
+        })
+
+        expect(wrap.lines.map((l) => l.text)).toEqual([
+            "",
+            "an example",
+            "line",
+        ])
+    })
+})

--- a/packages/@ourworldindata/components/src/TextWrap/TextWrap.tsx
+++ b/packages/@ourworldindata/components/src/TextWrap/TextWrap.tsx
@@ -266,10 +266,10 @@ export class TextWrap {
             textProps,
             id,
         }: { textProps?: React.SVGProps<SVGTextElement>; id?: string } = {}
-    ): React.ReactElement | null {
+    ): React.ReactElement {
         const { props, lines, fontSize, fontWeight, lineHeight } = this
 
-        if (lines.length === 0) return null
+        if (lines.length === 0) return <></>
 
         const [correctedX, correctedY] = this.getPositionForSvgRendering(x, y)
 

--- a/packages/@ourworldindata/components/src/TextWrap/TextWrapGroup.test.ts
+++ b/packages/@ourworldindata/components/src/TextWrap/TextWrapGroup.test.ts
@@ -43,7 +43,7 @@ it("should place the second segment in a new line if preferred", () => {
     const textWrapGroup = new TextWrapGroup({
         fragments: [
             { text: TEXT },
-            { text: "30 million", preferLineBreakOverWrapping: true },
+            { text: "30 million", newLine: "avoid-wrap" },
         ],
         maxWidth,
         fontSize: FONT_SIZE,
@@ -65,7 +65,7 @@ it("should place the second segment in the same line if possible", () => {
     const textWrapGroup = new TextWrapGroup({
         fragments: [
             { text: TEXT },
-            { text: "30 million", preferLineBreakOverWrapping: true },
+            { text: "30 million", newLine: "avoid-wrap" },
         ],
         maxWidth,
         fontSize: FONT_SIZE,
@@ -74,6 +74,25 @@ it("should place the second segment in the same line if possible", () => {
     // since the max width is large, "30 million" fits into the same line
     // as the text of the first fragmemt
     expect(textWrapGroup.height).toEqual(
+        new TextWrap({
+            text: TEXT,
+            maxWidth,
+            fontSize: FONT_SIZE,
+        }).height
+    )
+})
+
+it("should place the second segment in the same line if specified", () => {
+    const maxWidth = 1000
+    const textWrapGroup = new TextWrapGroup({
+        fragments: [{ text: TEXT }, { text: "30 million", newLine: "always" }],
+        maxWidth,
+        fontSize: FONT_SIZE,
+    })
+
+    // since the max width is large, "30 million" fits into the same line
+    // as the text of the first fragmemt
+    expect(textWrapGroup.height).toBeGreaterThan(
         new TextWrap({
             text: TEXT,
             maxWidth,

--- a/packages/@ourworldindata/components/src/TextWrap/TextWrapGroup.test.ts
+++ b/packages/@ourworldindata/components/src/TextWrap/TextWrapGroup.test.ts
@@ -90,8 +90,7 @@ it("should place the second segment in the same line if specified", () => {
         fontSize: FONT_SIZE,
     })
 
-    // since the max width is large, "30 million" fits into the same line
-    // as the text of the first fragmemt
+    // "30 million" should be placed in a new line since newLine is set to 'always'
     expect(textWrapGroup.height).toBeGreaterThan(
         new TextWrap({
             text: TEXT,
@@ -118,4 +117,24 @@ it("should use all available space when one fragment exceeds the given max width
     })
     expect(textWrap.width).toBeGreaterThan(maxWidth)
     expect(textWrapGroup.maxWidth).toEqual(textWrap.width)
+})
+
+it("should place very long words in a separate line", () => {
+    const maxWidth = 150
+    const textWrapGroup = new TextWrapGroup({
+        fragments: [
+            { text: "30 million" },
+            { text: "Long-word-that-can't-be-broken-up" },
+        ],
+        maxWidth,
+        fontSize: FONT_SIZE,
+    })
+    expect(textWrapGroup.lines.length).toEqual(2)
+
+    const placedTextWrapOffsets = textWrapGroup.placedTextWraps.map(
+        ({ yOffset }) => yOffset
+    )
+    const lineOffsets = textWrapGroup.lines.map(({ yOffset }) => yOffset)
+    expect(placedTextWrapOffsets).toEqual([0, 0])
+    expect(lineOffsets).toEqual([0, textWrapGroup.lineHeight * FONT_SIZE])
 })

--- a/packages/@ourworldindata/components/src/TextWrap/TextWrapGroup.test.ts
+++ b/packages/@ourworldindata/components/src/TextWrap/TextWrapGroup.test.ts
@@ -1,0 +1,102 @@
+#! /usr/bin/env jest
+
+import { TextWrap } from "./TextWrap"
+import { TextWrapGroup } from "./TextWrapGroup"
+
+const FONT_SIZE = 14
+const TEXT = "Lower middle-income countries"
+const MAX_WIDTH = 150
+
+const textWrap = new TextWrap({
+    text: TEXT,
+    maxWidth: MAX_WIDTH,
+    fontSize: FONT_SIZE,
+})
+
+it("should work like TextWrap for a single fragment", () => {
+    const textWrapGroup = new TextWrapGroup({
+        fragments: [{ text: TEXT }],
+        maxWidth: MAX_WIDTH,
+        fontSize: FONT_SIZE,
+    })
+
+    const firstTextWrap = textWrapGroup.textWraps[0]
+    expect(firstTextWrap.text).toEqual(textWrap.text)
+    expect(firstTextWrap.width).toEqual(textWrap.width)
+    expect(firstTextWrap.height).toEqual(textWrap.height)
+    expect(firstTextWrap.lines).toEqual(textWrap.lines)
+})
+
+it("should place fragments in-line if there is space", () => {
+    const textWrapGroup = new TextWrapGroup({
+        fragments: [{ text: TEXT }, { text: "30 million" }],
+        maxWidth: MAX_WIDTH,
+        fontSize: FONT_SIZE,
+    })
+
+    expect(textWrapGroup.text).toEqual([TEXT, "30 million"].join(" "))
+    expect(textWrapGroup.height).toEqual(textWrap.height)
+})
+
+it("should place the second segment in a new line if preferred", () => {
+    const maxWidth = 250
+    const textWrapGroup = new TextWrapGroup({
+        fragments: [
+            { text: TEXT },
+            { text: "30 million", preferLineBreakOverWrapping: true },
+        ],
+        maxWidth,
+        fontSize: FONT_SIZE,
+    })
+
+    // 30 million should be placed in a new line, thus the group's height
+    // should be greater than the textWrap's height
+    expect(textWrapGroup.height).toBeGreaterThan(
+        new TextWrap({
+            text: TEXT,
+            maxWidth,
+            fontSize: FONT_SIZE,
+        }).height
+    )
+})
+
+it("should place the second segment in the same line if possible", () => {
+    const maxWidth = 1000
+    const textWrapGroup = new TextWrapGroup({
+        fragments: [
+            { text: TEXT },
+            { text: "30 million", preferLineBreakOverWrapping: true },
+        ],
+        maxWidth,
+        fontSize: FONT_SIZE,
+    })
+
+    // since the max width is large, "30 million" fits into the same line
+    // as the text of the first fragmemt
+    expect(textWrapGroup.height).toEqual(
+        new TextWrap({
+            text: TEXT,
+            maxWidth,
+            fontSize: FONT_SIZE,
+        }).height
+    )
+})
+
+it("should use all available space when one fragment exceeds the given max width", () => {
+    const maxWidth = 150
+    const textWrap = new TextWrap({
+        text: "Long-word-that-can't-be-broken-up more words",
+        maxWidth,
+        fontSize: FONT_SIZE,
+    })
+    const textWrapGroup = new TextWrapGroup({
+        fragments: [
+            { text: "Long-word-that-can't-be-broken-up more words" },
+            { text: "30 million" },
+        ],
+        maxWidth,
+        fontSize: FONT_SIZE,
+    })
+    expect(textWrap.width).toBeGreaterThan(maxWidth)
+    expect(textWrapGroup.maxWidth).toEqual(textWrap.width)
+})

--- a/packages/@ourworldindata/components/src/TextWrap/TextWrapGroup.tsx
+++ b/packages/@ourworldindata/components/src/TextWrap/TextWrapGroup.tsx
@@ -147,6 +147,9 @@ export class TextWrapGroup {
         return max(this.textWraps.map((textWrap) => textWrap.width)) ?? 0
     }
 
+    // split concatenated fragments into lines for rendering. a line may have
+    // multiple fragments since each fragment comes with its own style and
+    // is therefore rendered into a separate tspan.
     @computed get lines(): {
         fragments: Omit<TextWrapFragment, "newLine">[]
         textWrap: TextWrap
@@ -189,10 +192,7 @@ export class TextWrapGroup {
     render(
         x: number,
         y: number,
-        {
-            textProps,
-            id,
-        }: { textProps?: React.SVGProps<SVGTextElement>; id?: string } = {}
+        { textProps }: { textProps?: React.SVGProps<SVGTextElement> } = {}
     ): React.ReactElement {
         // Alternatively, we could render each TextWrap one by one. That would
         // give us a good but not pixel-perfect result since the text
@@ -200,7 +200,7 @@ export class TextWrapGroup {
         // between text wraps, we split the text into lines and render
         // the different styles as tspans within the same text element.
         return (
-            <g id={id}>
+            <>
                 {this.lines.map((line) => {
                     const [textX, textY] =
                         line.textWrap.getPositionForSvgRendering(x, y)
@@ -224,7 +224,7 @@ export class TextWrapGroup {
                         </text>
                     )
                 })}
-            </g>
+            </>
         )
     }
 }

--- a/packages/@ourworldindata/components/src/TextWrap/TextWrapGroup.tsx
+++ b/packages/@ourworldindata/components/src/TextWrap/TextWrapGroup.tsx
@@ -1,0 +1,156 @@
+import React from "react"
+import { computed } from "mobx"
+import { TextWrap } from "./TextWrap"
+import { splitIntoFragments } from "./TextWrapUtils"
+import { Bounds, last, max } from "@ourworldindata/utils"
+
+interface TextWrapFragment {
+    text: string
+    fontWeight?: number
+    preferLineBreakOverWrapping?: boolean
+}
+
+interface PlacedTextWrap {
+    textWrap: TextWrap
+    yOffset: number
+}
+
+interface TextWrapGroupProps {
+    fragments: TextWrapFragment[]
+    maxWidth: number
+    lineHeight?: number
+    fontSize: number
+    fontWeight?: number
+}
+
+export class TextWrapGroup {
+    props: TextWrapGroupProps
+    constructor(props: TextWrapGroupProps) {
+        this.props = props
+    }
+
+    @computed get lineHeight(): number {
+        return this.props.lineHeight ?? 1.1
+    }
+
+    @computed get fontSize(): number {
+        return this.props.fontSize
+    }
+
+    @computed get fontWeight(): number | undefined {
+        return this.props.fontWeight
+    }
+
+    @computed get text(): string {
+        return this.props.fragments.map((fragment) => fragment.text).join(" ")
+    }
+
+    @computed get maxWidth(): number {
+        const wordWidths = this.props.fragments.flatMap((fragment) =>
+            splitIntoFragments(fragment.text).map(
+                ({ text }) =>
+                    Bounds.forText(text, {
+                        fontSize: this.fontSize,
+                        fontWeight: fragment.fontWeight ?? this.fontWeight,
+                    }).width
+            )
+        )
+        return max([...wordWidths, this.props.maxWidth]) ?? Infinity
+    }
+
+    private makeTextWrapForFragment(
+        fragment: TextWrapFragment,
+        offset = 0
+    ): TextWrap {
+        return new TextWrap({
+            text: fragment.text,
+            maxWidth: this.maxWidth,
+            lineHeight: this.lineHeight,
+            fontSize: this.fontSize,
+            fontWeight: fragment.fontWeight ?? this.fontWeight,
+            firstLineOffset: offset,
+        })
+    }
+
+    @computed get placedTextWraps(): PlacedTextWrap[] {
+        const { fragments } = this.props
+        if (fragments.length === 0) return []
+
+        const whitespaceWidth = Bounds.forText(" ", {
+            fontSize: this.fontSize,
+        }).width
+
+        const textWraps: PlacedTextWrap[] = [
+            {
+                textWrap: this.makeTextWrapForFragment(fragments[0]),
+                yOffset: 0,
+            },
+        ]
+
+        for (let i = 1; i < fragments.length; i++) {
+            const fragment = fragments[i]
+            const { textWrap: lastTextWrap, yOffset: lastYOffset } =
+                textWraps[i - 1]
+
+            let textWrap = this.makeTextWrapForFragment(
+                fragment,
+                lastTextWrap.lastLineWidth + whitespaceWidth
+            )
+
+            let yOffset = lastYOffset
+            if (textWrap.firstLineOffset === 0) {
+                yOffset += lastTextWrap.height
+            } else {
+                yOffset +=
+                    (lastTextWrap.lineCount - 1) * lastTextWrap.singleLineHeight
+            }
+
+            // some fragments are preferred to break into a new line
+            // instead of being wrapped
+            if (
+                fragment.preferLineBreakOverWrapping &&
+                textWrap.lineCount > 1
+            ) {
+                textWrap = this.makeTextWrapForFragment(fragment)
+                yOffset += lastTextWrap.singleLineHeight
+            }
+
+            textWraps.push({ textWrap, yOffset })
+        }
+
+        return textWraps
+    }
+
+    @computed get textWraps(): TextWrap[] {
+        return this.placedTextWraps.map(({ textWrap }) => textWrap)
+    }
+
+    @computed get height(): number {
+        if (this.placedTextWraps.length === 0) return 0
+        const { textWrap, yOffset } = last(this.placedTextWraps)!
+        return yOffset + textWrap.height
+    }
+
+    @computed get width(): number {
+        return max(this.textWraps.map((textWrap) => textWrap.width)) ?? 0
+    }
+
+    render(
+        x: number,
+        y: number,
+        {
+            textProps,
+            id,
+        }: { textProps?: React.SVGProps<SVGTextElement>; id?: string } = {}
+    ): React.ReactElement {
+        return (
+            <g>
+                {this.placedTextWraps.map(({ textWrap, yOffset }, index) => (
+                    <React.Fragment key={index}>
+                        {textWrap.render(x, y + yOffset, { textProps, id })}
+                    </React.Fragment>
+                ))}
+            </g>
+        )
+    }
+}

--- a/packages/@ourworldindata/components/src/TextWrap/TextWrapGroup.tsx
+++ b/packages/@ourworldindata/components/src/TextWrap/TextWrapGroup.tsx
@@ -3,6 +3,7 @@ import { computed } from "mobx"
 import { TextWrap } from "./TextWrap"
 import { splitIntoFragments } from "./TextWrapUtils"
 import { Bounds, last, max } from "@ourworldindata/utils"
+import { Halo } from "../Halo/Halo"
 
 interface TextWrapFragment {
     text: string
@@ -249,7 +250,15 @@ export class TextWrapGroup {
     render(
         x: number,
         y: number,
-        { textProps }: { textProps?: React.SVGProps<SVGTextElement> } = {}
+        {
+            showTextOutline,
+            textOutlineColor,
+            textProps,
+        }: {
+            showTextOutline?: boolean
+            textOutlineColor?: string
+            textProps?: React.SVGProps<SVGTextElement>
+        } = {}
     ): React.ReactElement {
         // Alternatively, we could render each TextWrap one by one. That would
         // give us a good but not pixel-perfect result since the text
@@ -259,29 +268,38 @@ export class TextWrapGroup {
         return (
             <>
                 {this.lines.map((line) => {
+                    const key = line.yOffset.toString()
                     const [textX, textY] =
                         line.fragments[0].textWrap.getPositionForSvgRendering(
                             x,
                             y
                         )
                     return (
-                        <text
-                            key={line.yOffset.toString()}
-                            x={textX}
-                            y={textY + line.yOffset}
-                            fontSize={this.fontSize.toFixed(2)}
-                            {...textProps}
+                        <Halo
+                            id={key}
+                            key={key}
+                            show={showTextOutline}
+                            outlineColor={textOutlineColor}
                         >
-                            {line.fragments.map((fragment, index) => (
-                                <tspan
-                                    key={index}
-                                    fontWeight={fragment.textWrap.fontWeight}
-                                >
-                                    {index === 0 ? "" : " "}
-                                    {fragment.text}
-                                </tspan>
-                            ))}
-                        </text>
+                            <text
+                                x={textX}
+                                y={textY + line.yOffset}
+                                fontSize={this.fontSize.toFixed(2)}
+                                {...textProps}
+                            >
+                                {line.fragments.map((fragment, index) => (
+                                    <tspan
+                                        key={index}
+                                        fontWeight={
+                                            fragment.textWrap.fontWeight
+                                        }
+                                    >
+                                        {index === 0 ? "" : " "}
+                                        {fragment.text}
+                                    </tspan>
+                                ))}
+                            </text>
+                        </Halo>
                     )
                 })}
             </>

--- a/packages/@ourworldindata/components/src/TextWrap/TextWrapGroup.tsx
+++ b/packages/@ourworldindata/components/src/TextWrap/TextWrapGroup.tsx
@@ -131,6 +131,11 @@ export class TextWrapGroup {
         return yOffset + textWrap.height
     }
 
+    @computed get singleLineHeight(): number {
+        if (this.textWraps.length === 0) return 0
+        return this.textWraps[0].singleLineHeight
+    }
+
     @computed get width(): number {
         return max(this.textWraps.map((textWrap) => textWrap.width)) ?? 0
     }

--- a/packages/@ourworldindata/components/src/index.ts
+++ b/packages/@ourworldindata/components/src/index.ts
@@ -1,4 +1,5 @@
 export { TextWrap, shortenForTargetWidth } from "./TextWrap/TextWrap.js"
+export { TextWrapGroup } from "./TextWrap/TextWrapGroup.js"
 
 export {
     MarkdownTextWrap,

--- a/packages/@ourworldindata/components/src/index.ts
+++ b/packages/@ourworldindata/components/src/index.ts
@@ -60,3 +60,5 @@ export {
 } from "./SharedDataPageConstants.js"
 
 export { Button } from "./Button/Button.js"
+
+export { Halo } from "./Halo/Halo.js"

--- a/packages/@ourworldindata/grapher/src/chart/ChartUtils.tsx
+++ b/packages/@ourworldindata/grapher/src/chart/ChartUtils.tsx
@@ -26,11 +26,11 @@ export const autoDetectYColumnSlugs = (manager: ChartManager): string[] => {
 }
 
 export const getDefaultFailMessage = (manager: ChartManager): string => {
-    if (manager.table.rootTable.isBlank) return `No table loaded yet.`
+    if (manager.table.rootTable.isBlank) return `No table loaded yet`
     if (manager.table.rootTable.entityNameColumn.isMissing)
-        return `Table is missing an EntityName column.`
+        return `Table is missing an EntityName column`
     if (manager.table.rootTable.timeColumn.isMissing)
-        return `Table is missing a Time column.`
+        return `Table is missing a Time column`
     const yColumnSlugs = autoDetectYColumnSlugs(manager)
     if (!yColumnSlugs.length) return "Missing Y axis column"
     const selection = makeSelectionArray(manager.selection)

--- a/packages/@ourworldindata/grapher/src/controls/ChartIcons.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/ChartIcons.tsx
@@ -104,7 +104,10 @@ export const chartIcons: Record<GrapherChartType, React.ReactElement> = {
                 strokeLinejoin="round"
                 strokeWidth="1.6"
             >
-                <path d="M1 1v11.267h12M3.6 7.933 12.267 3.6" />
+                <path d="M1 1.3V12.5667" />
+                <path d="M13 1.3V12.5667" />
+                <path d="M1 3.3L13 11.3" />
+                <path d="M13 3.3L1 11.3" />
             </g>
         </svg>
     ),

--- a/packages/@ourworldindata/grapher/src/controls/ChartIcons.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/ChartIcons.tsx
@@ -93,21 +93,22 @@ export const chartIcons: Record<GrapherChartType, React.ReactElement> = {
     [GRAPHER_CHART_TYPES.SlopeChart]: (
         <svg
             className="custom-icon slope"
-            width="14"
-            height="14"
-            viewBox="0 0 14 14"
+            width="16"
+            height="16"
+            viewBox="0 0 16 16"
             fill="none"
         >
             <g
                 stroke="currentColor"
+                strokeWidth="1.6"
                 strokeLinecap="round"
                 strokeLinejoin="round"
-                strokeWidth="1.6"
             >
-                <path d="M1 1.3V12.5667" />
-                <path d="M13 1.3V12.5667" />
-                <path d="M1 3.3L13 11.3" />
-                <path d="M13 3.3L1 11.3" />
+                <path d="M2 2.30005V13.5667" />
+                <path d="M14 2.30005V13.5667" />
+                <path d="M2 3.30005L14 12.3" />
+                <path d="M2 11L14 12" />
+                <path d="M14 4.30005L2 9.30005" />
             </g>
         </svg>
     ),

--- a/packages/@ourworldindata/grapher/src/controls/ContentSwitchers.scss
+++ b/packages/@ourworldindata/grapher/src/controls/ContentSwitchers.scss
@@ -22,7 +22,8 @@
                 vertical-align: -1.625px;
 
                 &.scatter,
-                &.marimekko {
+                &.marimekko,
+                &.slope {
                     --size: 14px;
                 }
             }

--- a/packages/@ourworldindata/grapher/src/core/grapher.scss
+++ b/packages/@ourworldindata/grapher/src/core/grapher.scss
@@ -78,6 +78,7 @@ $zindex-controls-drawer: 150;
     @import "../slideInDrawer/SlideInDrawer.scss";
     @import "../sidePanel/SidePanel.scss";
     @import "../controls/Dropdown.scss";
+    @import "../scatterCharts/NoDataSection.scss";
 }
 
 // These rules are currently used elsewhere in the site. e.g. Explorers

--- a/packages/@ourworldindata/grapher/src/halo/Halo.tsx
+++ b/packages/@ourworldindata/grapher/src/halo/Halo.tsx
@@ -13,9 +13,13 @@ const defaultHaloStyle: React.CSSProperties = {
 export function Halo(props: {
     id: React.Key
     children: React.ReactElement
+    show?: boolean
     background?: Color
     style?: React.CSSProperties
 }): React.ReactElement {
+    const show = props.show ?? true
+    if (!show) return props.children
+
     const defaultStyle = {
         ...defaultHaloStyle,
         fill: props.background ?? defaultHaloStyle.fill,

--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
@@ -958,6 +958,7 @@ export class LineChart
                         verticalAlign={VerticalAlign.top}
                         fontSize={this.fontSize}
                         fontWeight={this.fontWeight}
+                        outlineColor={this.manager.backgroundColor}
                         isStatic={this.isStatic}
                         focusedSeriesNames={this.focusedSeriesNames}
                         onMouseOver={this.onLineLegendMouseOver}

--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
@@ -52,6 +52,7 @@ import {
     MissingDataStrategy,
     ColorScaleConfigInterface,
     ColorSchemeName,
+    VerticalAlign,
 } from "@ourworldindata/types"
 import {
     GRAPHER_AXIS_LINE_WIDTH_THICK,
@@ -885,6 +886,7 @@ export class LineChart
             maxWidth: this.maxLineLegendWidth,
             fontSize: this.fontSize,
             fontWeight: this.fontWeight,
+            verticalAlign: VerticalAlign.top,
         })
     }
 
@@ -953,6 +955,7 @@ export class LineChart
                         x={this.lineLegendX}
                         yRange={this.lineLegendY}
                         maxWidth={this.maxLineLegendWidth}
+                        verticalAlign={VerticalAlign.top}
                         fontSize={this.fontSize}
                         fontWeight={this.fontWeight}
                         isStatic={this.isStatic}

--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
@@ -880,7 +880,7 @@ export class LineChart
 
         // only pass props that are required to calculate
         // the width to avoid circular dependencies
-        return LineLegend.width({
+        return LineLegend.incorrectWidth({
             labelSeries: this.lineLegendSeries,
             maxWidth: this.maxLineLegendWidth,
             fontSize: this.fontSize,

--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
@@ -881,7 +881,7 @@ export class LineChart
 
         // only pass props that are required to calculate
         // the width to avoid circular dependencies
-        return LineLegend.width({
+        return LineLegend.stableWidth({
             labelSeries: this.lineLegendSeries,
             maxWidth: this.maxLineLegendWidth,
             fontSize: this.fontSize,

--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
@@ -881,7 +881,7 @@ export class LineChart
 
         // only pass props that are required to calculate
         // the width to avoid circular dependencies
-        return LineLegend.incorrectWidth({
+        return LineLegend.width({
             labelSeries: this.lineLegendSeries,
             maxWidth: this.maxLineLegendWidth,
             fontSize: this.fontSize,

--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
@@ -958,7 +958,6 @@ export class LineChart
                         verticalAlign={VerticalAlign.top}
                         fontSize={this.fontSize}
                         fontWeight={this.fontWeight}
-                        outlineColor={this.manager.backgroundColor}
                         isStatic={this.isStatic}
                         focusedSeriesNames={this.focusedSeriesNames}
                         onMouseOver={this.onLineLegendMouseOver}

--- a/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.test.tsx
+++ b/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.test.tsx
@@ -1,9 +1,9 @@
 #! /usr/bin/env jest
 
 import { AxisConfig } from "../axis/AxisConfig"
-import { LineLegend, LineLegendManager } from "./LineLegend"
+import { LineLegend, LineLegendProps } from "./LineLegend"
 
-const manager: LineLegendManager = {
+const props: LineLegendProps = {
     labelSeries: [
         {
             seriesName: "Canada",
@@ -20,13 +20,13 @@ const manager: LineLegendManager = {
             annotation: "Below Canada",
         },
     ],
-    lineLegendX: 200,
+    x: 200,
     focusedSeriesNames: [],
     yAxis: new AxisConfig({ min: 0, max: 100 }).toVerticalAxis(),
 }
 
 it("can create a new legend", () => {
-    const legend = new LineLegend({ manager })
+    const legend = new LineLegend(props)
 
     expect(legend.sizedLabels.length).toEqual(2)
 })

--- a/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.tsx
+++ b/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.tsx
@@ -335,13 +335,13 @@ export interface LineLegendProps {
     textOutlineColor?: Color
 
     // used to determine which series should be labelled when there is limited space
-    seriesSortedByImportance?: EntityName[]
+    seriesSortedByImportance?: SeriesName[]
 
     // interactions
     isStatic?: boolean // don't add interactions if true
-    focusedSeriesNames?: EntityName[] // currently in focus
-    onClick?: (key: EntityName) => void
-    onMouseOver?: (key: EntityName) => void
+    focusedSeriesNames?: SeriesName[] // currently in focus
+    onClick?: (key: SeriesName) => void
+    onMouseOver?: (key: SeriesName) => void
     onMouseLeave?: () => void
 }
 
@@ -788,7 +788,8 @@ export class LineLegend extends React.Component<LineLegendProps> {
                 uniqueKey="background"
                 series={this.backgroundSeries}
                 needsConnectorLines={this.needsLines}
-                outlineColor={this.props.outlineColor}
+                showTextOutline={this.props.showTextOutlines}
+                textOutlineColor={this.props.textOutlineColor}
                 isFocus={false}
                 anchor={this.props.xAnchor}
                 isStatic={this.props.isStatic}
@@ -807,7 +808,8 @@ export class LineLegend extends React.Component<LineLegendProps> {
                 uniqueKey="focus"
                 series={this.focusedSeries}
                 needsConnectorLines={this.needsLines}
-                outlineColor={this.props.outlineColor}
+                showTextOutline={this.props.showTextOutlines}
+                textOutlineColor={this.props.textOutlineColor}
                 isFocus={true}
                 anchor={this.props.xAnchor}
                 isStatic={this.props.isStatic}

--- a/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.tsx
+++ b/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.tsx
@@ -373,7 +373,10 @@ export class LineLegend extends React.Component<LineLegendProps> {
             const labelFragments = excludeUndefined([
                 { text: label.label, fontWeight },
                 label.formattedValue
-                    ? { text: label.formattedValue }
+                    ? {
+                          text: label.formattedValue,
+                          preferLineBreakOverWrapping: true,
+                      }
                     : undefined,
             ])
             const textWrap = new TextWrapGroup({

--- a/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.tsx
+++ b/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.tsx
@@ -344,11 +344,6 @@ export class LineLegend extends React.Component<LineLegendProps> {
         return test.maxLabelWidth + test.connectorLineWidth + MARKER_MARGIN
     }
 
-    static needsConnectorLines(props: LineLegendProps): boolean {
-        const test = new LineLegend(props)
-        return test.needsLines
-    }
-
     static fontSize(props: Partial<LineLegendProps>): number {
         const test = new LineLegend(props as LineLegendProps)
         return test.fontSize

--- a/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.tsx
+++ b/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.tsx
@@ -95,7 +95,6 @@ class LineLabels extends React.Component<{
     needsConnectorLines: boolean
     connectorLineWidth?: number
     anchor?: "start" | "end"
-    showValueLabelsInline?: boolean
     isFocus?: boolean
     isStatic?: boolean
     onClick?: (series: PlacedSeries) => void
@@ -112,10 +111,6 @@ class LineLabels extends React.Component<{
 
     @computed private get connectorLineWidth(): number {
         return this.props.connectorLineWidth ?? DEFAULT_CONNECTOR_LINE_WIDTH
-    }
-
-    @computed private get showValueLabelsInline(): boolean {
-        return this.props.showValueLabelsInline ?? true
     }
 
     @computed private get markers(): {
@@ -311,7 +306,6 @@ export interface LineLegendProps {
     connectorLineWidth?: number
     fontSize?: number
     fontWeight?: number
-    showValueLabelsInline?: boolean
 
     // used to determine which series should be labelled when there is limited space
     seriesSortedByImportance?: EntityName[]
@@ -365,20 +359,6 @@ export class LineLegend extends React.Component<LineLegendProps> {
         return this.props.connectorLineWidth ?? DEFAULT_CONNECTOR_LINE_WIDTH
     }
 
-    @computed private get showValueLabelsInline(): boolean {
-        return this.props.showValueLabelsInline ?? true
-    }
-
-    @computed private get hasValueLabels(): boolean {
-        return this.props.labelSeries.some(
-            (series) => series.formattedValue !== undefined
-        )
-    }
-
-    @computed private get hideAnnotations(): boolean {
-        return this.hasValueLabels && !this.showValueLabelsInline
-    }
-
     @computed.struct get sizedLabels(): SizedSeries[] {
         const { fontSize, fontWeight, maxWidth } = this
         const maxTextWidth = maxWidth - this.connectorLineWidth
@@ -397,15 +377,14 @@ export class LineLegend extends React.Component<LineLegendProps> {
                 fontSize,
                 lineHeight: 1,
             })
-            const annotationTextWrap =
-                !this.hideAnnotations && label.annotation
-                    ? new TextWrap({
-                          text: label.annotation,
-                          maxWidth: maxAnnotationWidth,
-                          fontSize: fontSize * 0.9,
-                          lineHeight: 1,
-                      })
-                    : undefined
+            const annotationTextWrap = label.annotation
+                ? new TextWrap({
+                      text: label.annotation,
+                      maxWidth: maxAnnotationWidth,
+                      fontSize: fontSize * 0.9,
+                      lineHeight: 1,
+                  })
+                : undefined
 
             const annotationWidth = annotationTextWrap
                 ? annotationTextWrap.width
@@ -757,7 +736,6 @@ export class LineLegend extends React.Component<LineLegendProps> {
                 series={this.backgroundSeries}
                 needsConnectorLines={this.needsLines}
                 connectorLineWidth={this.connectorLineWidth}
-                showValueLabelsInline={this.showValueLabelsInline}
                 isFocus={false}
                 anchor={this.props.lineLegendAnchorX}
                 isStatic={this.props.isStatic}
@@ -777,7 +755,6 @@ export class LineLegend extends React.Component<LineLegendProps> {
                 series={this.focusedSeries}
                 needsConnectorLines={this.needsLines}
                 connectorLineWidth={this.connectorLineWidth}
-                showValueLabelsInline={this.showValueLabelsInline}
                 isFocus={true}
                 anchor={this.props.lineLegendAnchorX}
                 isStatic={this.props.isStatic}

--- a/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.tsx
+++ b/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.tsx
@@ -332,6 +332,11 @@ export class LineLegend extends React.Component<LineLegendProps> {
         return test.needsLines
     }
 
+    static fontSize(props: Partial<LineLegendProps>): number {
+        const test = new LineLegend(props as LineLegendProps)
+        return test.fontSize
+    }
+
     /**
      * Always adds the width of connector lines, which leads to an incorrect
      * result if no connector lines are rendered. We sometimes can't use the

--- a/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.tsx
+++ b/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.tsx
@@ -381,17 +381,16 @@ export class LineLegend extends React.Component<LineLegendProps> {
         const maxAnnotationWidth = Math.min(maxTextWidth, 150)
 
         return this.props.labelSeries.map((label) => {
-            const labelFragments = excludeUndefined([
-                { text: label.label, fontWeight },
-                label.formattedValue
-                    ? {
-                          text: label.formattedValue,
-                          newLine: label.placeFormattedValueInNewLine
-                              ? "always"
-                              : "avoid-wrap",
-                      }
-                    : undefined,
-            ])
+            const mainLabel = { text: label.label, fontWeight }
+            const valueLabel = label.formattedValue
+                ? {
+                      text: label.formattedValue,
+                      newLine: (label.placeFormattedValueInNewLine
+                          ? "always"
+                          : "avoid-wrap") as "always" | "avoid-wrap",
+                  }
+                : undefined
+            const labelFragments = excludeUndefined([mainLabel, valueLabel])
             const textWrap = new TextWrapGroup({
                 fragments: labelFragments,
                 maxWidth: maxTextWidth,

--- a/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.tsx
+++ b/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.tsx
@@ -381,7 +381,10 @@ export class LineLegend extends React.Component<LineLegendProps> {
     }
 
     @computed private get fontSize(): number {
-        return GRAPHER_FONT_SCALE_12 * (this.props.fontSize ?? BASE_FONT_SIZE)
+        return Math.max(
+            GRAPHER_FONT_SCALE_12 * (this.props.fontSize ?? BASE_FONT_SIZE),
+            11.5
+        )
     }
 
     @computed private get fontWeight(): number {

--- a/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.tsx
+++ b/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.tsx
@@ -14,7 +14,7 @@ import {
     last,
     maxBy,
 } from "@ourworldindata/utils"
-import { TextWrap, TextWrapGroup } from "@ourworldindata/components"
+import { TextWrap, TextWrapGroup, Halo } from "@ourworldindata/components"
 import { computed } from "mobx"
 import { observer } from "mobx-react"
 import { VerticalAxis } from "../axis/Axis"
@@ -32,7 +32,6 @@ import {
 import { ChartSeries } from "../chart/ChartInterface"
 import { darkenColorForText } from "../color/ColorUtils"
 import { AxisConfig } from "../axis/AxisConfig.js"
-import { Halo } from "@ourworldindata/components"
 
 // Minimum vertical space between two legend items
 const LEGEND_ITEM_MIN_SPACING = 4

--- a/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.tsx
+++ b/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.tsx
@@ -354,9 +354,9 @@ export class LineLegend extends React.Component<LineLegendProps> {
      * This is partly due to a circular dependency (in line and stacked area
      * charts), partly to avoid jumpy layout changes (slope charts).
      */
-    static width(props: LineLegendProps): number {
+    static stableWidth(props: LineLegendProps): number {
         const test = new LineLegend(props)
-        return test.maxLabelWidth + DEFAULT_CONNECTOR_LINE_WIDTH + MARKER_MARGIN
+        return test.stableWidth
     }
 
     static fontSize(props: Partial<LineLegendProps>): number {
@@ -371,7 +371,7 @@ export class LineLegend extends React.Component<LineLegendProps> {
 
     static visibleSeriesNames(props: LineLegendProps): SeriesName[] {
         const test = new LineLegend(props as LineLegendProps)
-        return test.partialInitialSeries.map((series) => series.seriesName)
+        return test.visibleSeriesNames
     }
 
     @computed private get fontSize(): number {
@@ -420,6 +420,7 @@ export class LineLegend extends React.Component<LineLegendProps> {
                       text: label.annotation,
                       maxWidth: maxAnnotationWidth,
                       fontSize: fontSize * 0.9,
+                      lineHeight: 1,
                   })
                 : undefined
 
@@ -443,6 +444,10 @@ export class LineLegend extends React.Component<LineLegendProps> {
     @computed private get maxLabelWidth(): number {
         const { sizedLabels = [] } = this
         return max(sizedLabels.map((d) => d.width)) ?? 0
+    }
+
+    @computed get stableWidth(): number {
+        return this.maxLabelWidth + DEFAULT_CONNECTOR_LINE_WIDTH + MARKER_MARGIN
     }
 
     @computed get onMouseOver(): any {
@@ -753,6 +758,10 @@ export class LineLegend extends React.Component<LineLegendProps> {
 
             return sortedKeepSeries
         }
+    }
+
+    @computed get visibleSeriesNames(): SeriesName[] {
+        return this.partialInitialSeries.map((series) => series.seriesName)
     }
 
     @computed private get backgroundSeries(): PlacedSeries[] {

--- a/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.tsx
+++ b/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.tsx
@@ -30,7 +30,7 @@ const LEGEND_ITEM_MIN_SPACING = 4
 // Horizontal distance from the end of the chart to the start of the marker
 const MARKER_MARGIN = 4
 // Space between the label and the annotation
-const ANNOTATION_PADDING = 2
+const ANNOTATION_PADDING = 1
 
 const DEFAULT_CONNECTOR_LINE_WIDTH = 35
 const DEFAULT_FONT_WEIGHT = 400

--- a/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.tsx
+++ b/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.tsx
@@ -322,10 +322,16 @@ export interface LineLegendProps {
 
 @observer
 export class LineLegend extends React.Component<LineLegendProps> {
+    /**
+     * Larger than the actual width since the width of the connector lines
+     * is always added, even if they're not rendered.
+     *
+     * This is partly due to a circular dependency (in line and stacked area
+     * charts), partly to avoid jumpy layout changes (slope charts).
+     */
     static width(props: LineLegendProps): number {
         const test = new LineLegend(props)
-        const connectorLineWidth = test.needsLines ? test.connectorLineWidth : 0
-        return test.maxLabelWidth + connectorLineWidth + MARKER_MARGIN
+        return test.maxLabelWidth + test.connectorLineWidth + MARKER_MARGIN
     }
 
     static needsConnectorLines(props: LineLegendProps): boolean {
@@ -336,16 +342,6 @@ export class LineLegend extends React.Component<LineLegendProps> {
     static fontSize(props: Partial<LineLegendProps>): number {
         const test = new LineLegend(props as LineLegendProps)
         return test.fontSize
-    }
-
-    /**
-     * Always adds the width of connector lines, which leads to an incorrect
-     * result if no connector lines are rendered. We sometimes can't use the
-     * correct width above due to circular dependencies.
-     */
-    static incorrectWidth(props: LineLegendProps): number {
-        const test = new LineLegend(props)
-        return test.maxLabelWidth + test.connectorLineWidth + MARKER_MARGIN
     }
 
     @computed private get fontSize(): number {

--- a/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.tsx
+++ b/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.tsx
@@ -40,6 +40,7 @@ export interface LineLabelSeries extends ChartSeries {
     yValue: number
     annotation?: string
     formattedValue?: string
+    placeFormattedValueInNewLine?: boolean
     yRange?: [number, number]
 }
 
@@ -385,7 +386,9 @@ export class LineLegend extends React.Component<LineLegendProps> {
                 label.formattedValue
                     ? {
                           text: label.formattedValue,
-                          preferLineBreakOverWrapping: true,
+                          newLine: label.placeFormattedValueInNewLine
+                              ? "always"
+                              : "avoid-wrap",
                       }
                     : undefined,
             ])

--- a/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.tsx
+++ b/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.tsx
@@ -395,11 +395,15 @@ export class LineLegend extends React.Component<LineLegendProps> {
     }
 
     @computed.struct get sizedLabels(): SizedSeries[] {
-        const { fontSize, fontWeight, maxWidth } = this
+        const { fontSize, maxWidth } = this
         const maxTextWidth = maxWidth - DEFAULT_CONNECTOR_LINE_WIDTH
         const maxAnnotationWidth = Math.min(maxTextWidth, 150)
 
         return this.props.labelSeries.map((label) => {
+            // if a formatted value is given, make the main label bold by default
+            const fontWeight =
+                this.fontWeight ?? (label.formattedValue ? 700 : undefined)
+
             const mainLabel = { text: label.label, fontWeight }
             const valueLabel = label.formattedValue
                 ? {

--- a/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.tsx
+++ b/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.tsx
@@ -18,8 +18,12 @@ import { TextWrap, TextWrapGroup } from "@ourworldindata/components"
 import { computed } from "mobx"
 import { observer } from "mobx-react"
 import { VerticalAxis } from "../axis/Axis"
-import { EntityName, VerticalAlign } from "@ourworldindata/types"
-import { BASE_FONT_SIZE, GRAPHER_FONT_SCALE_12 } from "../core/GrapherConstants"
+import { Color, EntityName, VerticalAlign } from "@ourworldindata/types"
+import {
+    BASE_FONT_SIZE,
+    GRAPHER_BACKGROUND_DEFAULT,
+    GRAPHER_FONT_SCALE_12,
+} from "../core/GrapherConstants"
 import { ChartSeries } from "../chart/ChartInterface"
 import { darkenColorForText } from "../color/ColorUtils"
 import { AxisConfig } from "../axis/AxisConfig.js"
@@ -95,6 +99,7 @@ class LineLabels extends React.Component<{
     uniqueKey: string
     needsConnectorLines: boolean
     connectorLineWidth?: number
+    outlineColor?: Color
     anchor?: "start" | "end"
     isFocus?: boolean
     isStatic?: boolean
@@ -112,6 +117,10 @@ class LineLabels extends React.Component<{
 
     @computed private get connectorLineWidth(): number {
         return this.props.connectorLineWidth ?? DEFAULT_CONNECTOR_LINE_WIDTH
+    }
+
+    @computed private get outlineColor(): Color {
+        return this.props.outlineColor ?? GRAPHER_BACKGROUND_DEFAULT
     }
 
     @computed private get markers(): {
@@ -154,7 +163,7 @@ class LineLabels extends React.Component<{
                     )
                     const textColor = darkenColorForText(series.color)
                     return (
-                        <Halo id={key} key={key}>
+                        <Halo id={key} key={key} background={this.outlineColor}>
                             {series.textWrap.render(labelText.x, labelText.y, {
                                 textProps: {
                                     fill: textColor,
@@ -184,7 +193,7 @@ class LineLabels extends React.Component<{
                     )
                     if (!series.annotationTextWrap) return
                     return (
-                        <Halo id={key} key={key}>
+                        <Halo id={key} key={key} background={this.outlineColor}>
                             {series.annotationTextWrap.render(
                                 labelText.x,
                                 labelText.y +
@@ -308,6 +317,7 @@ export interface LineLegendProps {
     connectorLineWidth?: number
     fontSize?: number
     fontWeight?: number
+    outlineColor?: Color // used for halos
 
     // used to determine which series should be labelled when there is limited space
     seriesSortedByImportance?: EntityName[]
@@ -762,6 +772,7 @@ export class LineLegend extends React.Component<LineLegendProps> {
                 series={this.backgroundSeries}
                 needsConnectorLines={this.needsLines}
                 connectorLineWidth={this.connectorLineWidth}
+                outlineColor={this.props.outlineColor}
                 isFocus={false}
                 anchor={this.props.xAnchor}
                 isStatic={this.props.isStatic}
@@ -781,6 +792,7 @@ export class LineLegend extends React.Component<LineLegendProps> {
                 series={this.focusedSeries}
                 needsConnectorLines={this.needsLines}
                 connectorLineWidth={this.connectorLineWidth}
+                outlineColor={this.props.outlineColor}
                 isFocus={true}
                 anchor={this.props.xAnchor}
                 isStatic={this.props.isStatic}

--- a/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.tsx
+++ b/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.tsx
@@ -41,7 +41,7 @@ const MARKER_MARGIN = 4
 // Space between the label and the annotation
 const ANNOTATION_PADDING = 1
 
-const DEFAULT_CONNECTOR_LINE_WIDTH = 35
+const DEFAULT_CONNECTOR_LINE_WIDTH = 25
 const DEFAULT_FONT_WEIGHT = 400
 
 export interface LineLabelSeries extends ChartSeries {
@@ -103,8 +103,8 @@ class LineLabels extends React.Component<{
     series: PlacedSeries[]
     uniqueKey: string
     needsConnectorLines: boolean
-    connectorLineWidth?: number
-    outlineColor?: Color
+    showTextOutline?: boolean
+    textOutlineColor?: Color
     anchor?: "start" | "end"
     isFocus?: boolean
     isStatic?: boolean
@@ -120,12 +120,12 @@ class LineLabels extends React.Component<{
         return this.props.anchor ?? "start"
     }
 
-    @computed private get connectorLineWidth(): number {
-        return this.props.connectorLineWidth ?? DEFAULT_CONNECTOR_LINE_WIDTH
+    @computed private get showTextOutline(): boolean {
+        return this.props.showTextOutline ?? false
     }
 
-    @computed private get outlineColor(): Color {
-        return this.props.outlineColor ?? GRAPHER_BACKGROUND_DEFAULT
+    @computed private get textOutlineColor(): Color {
+        return this.props.textOutlineColor ?? GRAPHER_BACKGROUND_DEFAULT
     }
 
     @computed private get markers(): {
@@ -136,7 +136,7 @@ class LineLabels extends React.Component<{
         return this.props.series.map((series) => {
             const direction = this.anchor === "start" ? 1 : -1
             const markerMargin = direction * MARKER_MARGIN
-            const connectorLineWidth = direction * this.connectorLineWidth
+            const connectorLineWidth = direction * DEFAULT_CONNECTOR_LINE_WIDTH
 
             const { x } = series.origBounds
             const connectorLine = {
@@ -168,7 +168,12 @@ class LineLabels extends React.Component<{
                     )
                     const textColor = darkenColorForText(series.color)
                     return (
-                        <Halo id={key} key={key} background={this.outlineColor}>
+                        <Halo
+                            id={key}
+                            key={key}
+                            show={this.showTextOutline}
+                            background={this.textOutlineColor}
+                        >
                             {series.textWrap.render(labelText.x, labelText.y, {
                                 textProps: {
                                     fill: textColor,
@@ -198,7 +203,12 @@ class LineLabels extends React.Component<{
                     )
                     if (!series.annotationTextWrap) return
                     return (
-                        <Halo id={key} key={key} background={this.outlineColor}>
+                        <Halo
+                            id={key}
+                            key={key}
+                            show={this.showTextOutline}
+                            background={this.textOutlineColor}
+                        >
                             {series.annotationTextWrap.render(
                                 labelText.x,
                                 labelText.y +
@@ -319,10 +329,10 @@ export interface LineLegendProps {
     verticalAlign?: VerticalAlign
 
     // presentation
-    connectorLineWidth?: number
     fontSize?: number
     fontWeight?: number
-    outlineColor?: Color // used for halos
+    showTextOutlines?: boolean
+    textOutlineColor?: Color
 
     // used to determine which series should be labelled when there is limited space
     seriesSortedByImportance?: EntityName[]
@@ -346,7 +356,7 @@ export class LineLegend extends React.Component<LineLegendProps> {
      */
     static width(props: LineLegendProps): number {
         const test = new LineLegend(props)
-        return test.maxLabelWidth + test.connectorLineWidth + MARKER_MARGIN
+        return test.maxLabelWidth + DEFAULT_CONNECTOR_LINE_WIDTH + MARKER_MARGIN
     }
 
     static fontSize(props: Partial<LineLegendProps>): number {
@@ -365,10 +375,7 @@ export class LineLegend extends React.Component<LineLegendProps> {
     }
 
     @computed private get fontSize(): number {
-        return Math.max(
-            GRAPHER_FONT_SCALE_12 * (this.props.fontSize ?? BASE_FONT_SIZE),
-            11.5
-        )
+        return GRAPHER_FONT_SCALE_12 * (this.props.fontSize ?? BASE_FONT_SIZE)
     }
 
     @computed private get fontWeight(): number {
@@ -383,17 +390,13 @@ export class LineLegend extends React.Component<LineLegendProps> {
         return this.props.yAxis ?? new VerticalAxis(new AxisConfig())
     }
 
-    @computed private get connectorLineWidth(): number {
-        return this.props.connectorLineWidth ?? DEFAULT_CONNECTOR_LINE_WIDTH
-    }
-
     @computed private get verticalAlign(): VerticalAlign {
         return this.props.verticalAlign ?? VerticalAlign.middle
     }
 
     @computed.struct get sizedLabels(): SizedSeries[] {
         const { fontSize, fontWeight, maxWidth } = this
-        const maxTextWidth = maxWidth - this.connectorLineWidth
+        const maxTextWidth = maxWidth - DEFAULT_CONNECTOR_LINE_WIDTH
         const maxAnnotationWidth = Math.min(maxTextWidth, 150)
 
         return this.props.labelSeries.map((label) => {
@@ -492,7 +495,7 @@ export class LineLegend extends React.Component<LineLegendProps> {
 
         return this.sizedLabels.map((label) => {
             const labelHeight = label.height
-            const labelWidth = label.width + this.connectorLineWidth
+            const labelWidth = label.width + DEFAULT_CONNECTOR_LINE_WIDTH
 
             const midY = yAxis.place(label.yValue)
             const origBounds = new Bounds(
@@ -785,7 +788,6 @@ export class LineLegend extends React.Component<LineLegendProps> {
                 uniqueKey="background"
                 series={this.backgroundSeries}
                 needsConnectorLines={this.needsLines}
-                connectorLineWidth={this.connectorLineWidth}
                 outlineColor={this.props.outlineColor}
                 isFocus={false}
                 anchor={this.props.xAnchor}
@@ -805,7 +807,6 @@ export class LineLegend extends React.Component<LineLegendProps> {
                 uniqueKey="focus"
                 series={this.focusedSeries}
                 needsConnectorLines={this.needsLines}
-                connectorLineWidth={this.connectorLineWidth}
                 outlineColor={this.props.outlineColor}
                 isFocus={true}
                 anchor={this.props.xAnchor}

--- a/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.tsx
+++ b/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.tsx
@@ -354,6 +354,11 @@ export class LineLegend extends React.Component<LineLegendProps> {
         return test.fontSize
     }
 
+    static maxLevel(props: Partial<LineLegendProps>): number {
+        const test = new LineLegend(props as LineLegendProps)
+        return test.maxLevel
+    }
+
     static visibleSeriesNames(props: LineLegendProps): SeriesName[] {
         const test = new LineLegend(props as LineLegendProps)
         return test.partialInitialSeries.map((series) => series.seriesName)
@@ -768,6 +773,10 @@ export class LineLegend extends React.Component<LineLegendProps> {
     // Does this placement need line markers or is the position of the labels already clear?
     @computed private get needsLines(): boolean {
         return this.placedSeries.some((series) => series.totalLevels > 1)
+    }
+
+    @computed private get maxLevel(): number {
+        return max(this.placedSeries.map((series) => series.totalLevels)) ?? 0
     }
 
     private renderBackground(): React.ReactElement {

--- a/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.tsx
+++ b/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.tsx
@@ -218,8 +218,9 @@ class LineLabels extends React.Component<{
             <g id={makeIdForHumanConsumption("text-values")}>
                 {markersWithTextValues.map(({ series, labelText }, index) => {
                     const textColor = darkenColorForText(series.color)
+                    const direction = this.anchor === "start" ? 1 : -1
                     const x = this.showValueLabelsInline
-                        ? labelText.x + series.textWrap.width + 4
+                        ? labelText.x + direction * (series.textWrap.width + 4)
                         : labelText.x
                     const y = this.showValueLabelsInline
                         ? labelText.y

--- a/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.tsx
+++ b/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.tsx
@@ -380,14 +380,12 @@ export class LineLegend extends React.Component<LineLegendProps> {
                 fragments: labelFragments,
                 maxWidth: maxTextWidth,
                 fontSize,
-                lineHeight: 1,
             })
             const annotationTextWrap = label.annotation
                 ? new TextWrap({
                       text: label.annotation,
                       maxWidth: maxAnnotationWidth,
                       fontSize: fontSize * 0.9,
-                      lineHeight: 1,
                   })
                 : undefined
 

--- a/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.tsx
+++ b/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.tsx
@@ -327,6 +327,11 @@ export class LineLegend extends React.Component<LineLegendProps> {
         return test.maxLabelWidth + connectorLineWidth + MARKER_MARGIN
     }
 
+    static needsConnectorLines(props: LineLegendProps): boolean {
+        const test = new LineLegend(props)
+        return test.needsLines
+    }
+
     /**
      * Always adds the width of connector lines, which leads to an incorrect
      * result if no connector lines are rendered. We sometimes can't use the

--- a/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.tsx
+++ b/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.tsx
@@ -32,7 +32,7 @@ import {
 import { ChartSeries } from "../chart/ChartInterface"
 import { darkenColorForText } from "../color/ColorUtils"
 import { AxisConfig } from "../axis/AxisConfig.js"
-import { Halo } from "../halo/Halo"
+import { Halo } from "@ourworldindata/components"
 
 // Minimum vertical space between two legend items
 const LEGEND_ITEM_MIN_SPACING = 4
@@ -168,20 +168,17 @@ class LineLabels extends React.Component<{
                     )
                     const textColor = darkenColorForText(series.color)
                     return (
-                        <Halo
-                            id={key}
-                            key={key}
-                            show={this.showTextOutline}
-                            background={this.textOutlineColor}
-                        >
+                        <React.Fragment key={key}>
                             {series.textWrap.render(labelText.x, labelText.y, {
+                                showTextOutline: this.showTextOutline,
+                                textOutlineColor: this.textOutlineColor,
                                 textProps: {
                                     fill: textColor,
                                     opacity: this.textOpacity,
                                     textAnchor: this.anchor,
                                 },
                             })}
-                        </Halo>
+                        </React.Fragment>
                     )
                 })}
             </g>
@@ -207,7 +204,7 @@ class LineLabels extends React.Component<{
                             id={key}
                             key={key}
                             show={this.showTextOutline}
-                            background={this.textOutlineColor}
+                            outlineColor={this.textOutlineColor}
                         >
                             {series.annotationTextWrap.render(
                                 labelText.x,

--- a/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.tsx
+++ b/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.tsx
@@ -396,9 +396,8 @@ export class LineLegend extends React.Component<LineLegendProps> {
         const maxAnnotationWidth = Math.min(maxTextWidth, 150)
 
         return this.props.labelSeries.map((label) => {
-            // if a formatted value is given, make the main label bold by default
-            const fontWeight =
-                this.fontWeight ?? (label.formattedValue ? 700 : undefined)
+            // if a formatted value is given, make the main label bold
+            const fontWeight = label.formattedValue ? 700 : this.fontWeight
 
             const mainLabel = { text: label.label, fontWeight }
             const valueLabel = label.formattedValue

--- a/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.tsx
+++ b/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.tsx
@@ -23,9 +23,10 @@ import { BASE_FONT_SIZE, GRAPHER_FONT_SCALE_12 } from "../core/GrapherConstants"
 import { ChartSeries } from "../chart/ChartInterface"
 import { darkenColorForText } from "../color/ColorUtils"
 import { AxisConfig } from "../axis/AxisConfig.js"
+import { Halo } from "../halo/Halo"
 
 // Minimum vertical space between two legend items
-const LEGEND_ITEM_MIN_SPACING = 2
+const LEGEND_ITEM_MIN_SPACING = 4
 // Horizontal distance from the end of the chart to the start of the marker
 const MARKER_MARGIN = 4
 // Space between the label and the annotation
@@ -151,15 +152,14 @@ class LineLabels extends React.Component<{
         return (
             <g id={makeIdForHumanConsumption("text-labels")}>
                 {this.markers.map(({ series, labelText }, index) => {
+                    const key = getSeriesKey(
+                        series,
+                        index,
+                        this.props.uniqueKey
+                    )
                     const textColor = darkenColorForText(series.color)
                     return (
-                        <React.Fragment
-                            key={getSeriesKey(
-                                series,
-                                index,
-                                this.props.uniqueKey
-                            )}
-                        >
+                        <Halo id={key} key={key}>
                             {series.textWrap.render(labelText.x, labelText.y, {
                                 textProps: {
                                     fill: textColor,
@@ -167,7 +167,7 @@ class LineLabels extends React.Component<{
                                     textAnchor: this.anchor,
                                 },
                             })}
-                        </React.Fragment>
+                        </Halo>
                     )
                 })}
             </g>
@@ -182,17 +182,19 @@ class LineLabels extends React.Component<{
         return (
             <g id={makeIdForHumanConsumption("text-annotations")}>
                 {markersWithAnnotations.map(({ series, labelText }, index) => {
+                    const key = getSeriesKey(
+                        series,
+                        index,
+                        this.props.uniqueKey
+                    )
+                    if (!series.annotationTextWrap) return
                     return (
-                        <React.Fragment
-                            key={getSeriesKey(
-                                series,
-                                index,
-                                this.props.uniqueKey
-                            )}
-                        >
-                            {series.annotationTextWrap?.render(
+                        <Halo id={key} key={key}>
+                            {series.annotationTextWrap.render(
                                 labelText.x,
-                                labelText.y + series.textWrap.height,
+                                labelText.y +
+                                    series.textWrap.height +
+                                    ANNOTATION_PADDING,
                                 {
                                     textProps: {
                                         fill: "#333",
@@ -202,7 +204,7 @@ class LineLabels extends React.Component<{
                                     },
                                 }
                             )}
-                        </React.Fragment>
+                        </Halo>
                     )
                 })}
             </g>
@@ -217,6 +219,12 @@ class LineLabels extends React.Component<{
         return (
             <g id={makeIdForHumanConsumption("text-values")}>
                 {markersWithTextValues.map(({ series, labelText }, index) => {
+                    if (!series.valueTextWrap) return
+                    const key = getSeriesKey(
+                        series,
+                        index,
+                        this.props.uniqueKey
+                    )
                     const textColor = darkenColorForText(series.color)
                     const direction = this.anchor === "start" ? 1 : -1
                     const x = this.showValueLabelsInline
@@ -224,23 +232,19 @@ class LineLabels extends React.Component<{
                         : labelText.x
                     const y = this.showValueLabelsInline
                         ? labelText.y
-                        : labelText.y + series.textWrap.height
+                        : labelText.y +
+                          series.textWrap.height +
+                          ANNOTATION_PADDING
                     return (
-                        <React.Fragment
-                            key={getSeriesKey(
-                                series,
-                                index,
-                                this.props.uniqueKey
-                            )}
-                        >
-                            {series.valueTextWrap?.render(x, y, {
+                        <Halo id={key} key={key}>
+                            {series.valueTextWrap.render(x, y, {
                                 textProps: {
                                     fill: textColor,
                                     opacity: this.textOpacity,
                                     textAnchor: this.anchor,
                                 },
                             })}
-                        </React.Fragment>
+                        </Halo>
                     )
                 })}
             </g>

--- a/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.tsx
+++ b/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.tsx
@@ -18,7 +18,12 @@ import { TextWrap, TextWrapGroup } from "@ourworldindata/components"
 import { computed } from "mobx"
 import { observer } from "mobx-react"
 import { VerticalAxis } from "../axis/Axis"
-import { Color, EntityName, VerticalAlign } from "@ourworldindata/types"
+import {
+    Color,
+    EntityName,
+    SeriesName,
+    VerticalAlign,
+} from "@ourworldindata/types"
 import {
     BASE_FONT_SIZE,
     GRAPHER_BACKGROUND_DEFAULT,
@@ -347,6 +352,11 @@ export class LineLegend extends React.Component<LineLegendProps> {
     static fontSize(props: Partial<LineLegendProps>): number {
         const test = new LineLegend(props as LineLegendProps)
         return test.fontSize
+    }
+
+    static visibleSeriesNames(props: LineLegendProps): SeriesName[] {
+        const test = new LineLegend(props as LineLegendProps)
+        return test.partialInitialSeries.map((series) => series.seriesName)
     }
 
     @computed private get fontSize(): number {

--- a/packages/@ourworldindata/grapher/src/noDataModal/NoDataModal.tsx
+++ b/packages/@ourworldindata/grapher/src/noDataModal/NoDataModal.tsx
@@ -15,7 +15,7 @@ import {
     GRAPHER_DARK_TEXT,
     GRAPHER_LIGHT_TEXT,
 } from "../core/GrapherConstants"
-import { Halo } from "../halo/Halo"
+import { Halo } from "@ourworldindata/components"
 
 export interface NoDataModalManager {
     canChangeEntity?: boolean

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ComparisonLine.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ComparisonLine.tsx
@@ -10,7 +10,7 @@ import { computed } from "mobx"
 import { observer } from "mobx-react"
 import { DualAxis } from "../axis/Axis"
 import { generateComparisonLinePoints } from "./ComparisonLineGenerator"
-import { Halo } from "../halo/Halo"
+import { Halo } from "@ourworldindata/components"
 import { Color, ComparisonLineConfig } from "@ourworldindata/types"
 import { GRAPHER_FONT_SCALE_10_5 } from "../core/GrapherConstants"
 
@@ -125,7 +125,7 @@ export class ComparisonLine extends React.Component<{
                     >
                         <Halo
                             id={`path-${renderUid}`}
-                            background={this.props.backgroundColor}
+                            outlineColor={this.props.backgroundColor}
                         >
                             <textPath
                                 baselineShift="-0.2rem"

--- a/packages/@ourworldindata/grapher/src/scatterCharts/NoDataSection.scss
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/NoDataSection.scss
@@ -1,0 +1,14 @@
+.NoDataSection {
+    .heading {
+        @include grapher_h5-black-caps;
+        margin-bottom: 0.25em;
+    }
+
+    .body {
+        @include grapher_label-2-regular;
+
+        li {
+            margin-bottom: 0.15em;
+        }
+    }
+}

--- a/packages/@ourworldindata/grapher/src/scatterCharts/NoDataSection.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/NoDataSection.tsx
@@ -1,8 +1,9 @@
 import React from "react"
 import { Bounds } from "@ourworldindata/utils"
 import {
-    GRAPHER_DARK_TEXT,
-    GRAPHER_FONT_SCALE_11_2,
+    GRAPHER_FONT_SCALE_11,
+    GRAPHER_FONT_SCALE_12,
+    GRAPHER_LIGHT_TEXT,
 } from "../core/GrapherConstants"
 
 export function NoDataSection({
@@ -21,41 +22,31 @@ export function NoDataSection({
             seriesNames.length - displayedNames.length
         )
 
+        const headingFontsize = GRAPHER_FONT_SCALE_11 * baseFontSize
+        const bodyFontsize = GRAPHER_FONT_SCALE_12 * baseFontSize
+
         return (
             <foreignObject
+                className="NoDataSection"
                 {...bounds.toProps()}
                 style={{
-                    color: GRAPHER_DARK_TEXT,
-                    fontSize: GRAPHER_FONT_SCALE_11_2 * baseFontSize,
+                    textAlign: "right",
+                    color: GRAPHER_LIGHT_TEXT,
                 }}
             >
-                <div
-                    style={{
-                        textTransform: "uppercase",
-                        fontWeight: 700,
-                        marginBottom: 2,
-                        lineHeight: 1.15,
-                    }}
-                >
+                <div className="heading" style={{ fontSize: headingFontsize }}>
                     No data
                 </div>
-                <ul>
-                    {displayedNames.map((entityName) => (
-                        <li
-                            key={entityName}
-                            style={{
-                                fontStyle: "italic",
-                                lineHeight: 1.15,
-                                marginBottom: 2,
-                            }}
-                        >
-                            {entityName}
-                        </li>
-                    ))}
-                </ul>
-                {remaining > 0 && (
-                    <div>& {remaining === 1 ? "one" : remaining} more</div>
-                )}
+                <div className="body" style={{ fontSize: bodyFontsize }}>
+                    <ul>
+                        {displayedNames.map((entityName) => (
+                            <li key={entityName}>{entityName}</li>
+                        ))}
+                    </ul>
+                    {remaining > 0 && (
+                        <div>& {remaining === 1 ? "one" : remaining} more</div>
+                    )}
+                </div>
             </foreignObject>
         )
     }

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPointsWithLabels.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPointsWithLabels.tsx
@@ -18,7 +18,7 @@ import {
 import { computed, action, observable } from "mobx"
 import { observer } from "mobx-react"
 import React from "react"
-import { Halo } from "../halo/Halo"
+import { Halo } from "@ourworldindata/components"
 import { MultiColorPolyline } from "./MultiColorPolyline"
 import {
     ScatterPointsWithLabelsProps,
@@ -425,7 +425,7 @@ export class ScatterPointsWithLabels extends React.Component<ScatterPointsWithLa
                             <Halo
                                 key={series.displayKey + "-endLabel"}
                                 id={series.displayKey + "-endLabel"}
-                                background={this.props.backgroundColor}
+                                outlineColor={this.props.backgroundColor}
                             >
                                 <text
                                     id={makeIdForHumanConsumption(
@@ -561,7 +561,7 @@ export class ScatterPointsWithLabels extends React.Component<ScatterPointsWithLa
                     <Halo
                         key={`${series.displayKey}-label-${index}`}
                         id={`${series.displayKey}-label-${index}`}
-                        background={this.props.backgroundColor}
+                        outlineColor={this.props.backgroundColor}
                     >
                         <text
                             id={makeIdForHumanConsumption(

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterSizeLegend.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterSizeLegend.tsx
@@ -18,7 +18,7 @@ import {
     GRAPHER_LIGHT_TEXT,
 } from "../core/GrapherConstants"
 import { CoreColumn } from "@ourworldindata/core-table"
-import { Halo } from "../halo/Halo"
+import { Halo } from "@ourworldindata/components"
 import {
     ScatterSeries,
     SCATTER_POINT_MAX_RADIUS,
@@ -310,7 +310,7 @@ const LegendItem = ({
             />
             <Halo
                 id={label}
-                background={backgroundColor}
+                outlineColor={backgroundColor}
                 style={{ ...style, strokeWidth: 3.5 }}
             >
                 <text

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterSizeLegend.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterSizeLegend.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { computed } from "mobx"
 import { scaleLinear, ScaleLinear } from "d3-scale"
-import { TextWrap } from "@ourworldindata/components"
+import { TextWrap, Halo } from "@ourworldindata/components"
 import {
     Color,
     first,
@@ -18,7 +18,6 @@ import {
     GRAPHER_LIGHT_TEXT,
 } from "../core/GrapherConstants"
 import { CoreColumn } from "@ourworldindata/core-table"
-import { Halo } from "@ourworldindata/components"
 import {
     ScatterSeries,
     SCATTER_POINT_MAX_RADIUS,

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
@@ -13,6 +13,7 @@ import {
     getRelativeMouse,
     minBy,
     dyFromAlign,
+    uniq,
 } from "@ourworldindata/utils"
 import { observable, computed, action } from "mobx"
 import { observer } from "mobx-react"
@@ -986,8 +987,18 @@ export class SlopeChart
     }
 
     private renderLineLegendLeft(): React.ReactElement {
-        // in relative mode, all slopes start from 0%
-        if (this.manager.isRelativeMode)
+        const uniqYValues = uniq(
+            this.lineLegendSeriesLeft.map((series) => series.yValue)
+        )
+        const allSlopesStartFromZero =
+            uniqYValues.length === 1 && uniqYValues[0] === 0
+
+        // if all values have a start value of 0, show the 0-label only once
+        if (
+            // in relative mode, all slopes start from 0%
+            this.manager.isRelativeMode ||
+            allSlopesStartFromZero
+        )
             return (
                 <text
                     x={this.startX}

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
@@ -549,10 +549,7 @@ export class SlopeChart
     }
 
     @computed private get lineLegendPropsRight(): Partial<LineLegendProps> {
-        return {
-            xAnchor: "start",
-            fontWeight: 700,
-        }
+        return { xAnchor: "start" }
     }
 
     @computed private get lineLegendPropsLeft(): Partial<LineLegendProps> {

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
@@ -22,7 +22,6 @@ import {
     BASE_FONT_SIZE,
     GRAPHER_BACKGROUND_DEFAULT,
     GRAPHER_DARK_TEXT,
-    GRAPHER_FONT_SCALE_12,
 } from "../core/GrapherConstants"
 import {
     ScaleType,
@@ -501,6 +500,23 @@ export class SlopeChart
 
     @computed get maxLineLegendWidth(): number {
         return this.innerBounds.width / 4
+    }
+
+    @computed get lineLegendFontSize(): number {
+        return LineLegend.fontSize({ fontSize: this.fontSize })
+    }
+
+    @computed get lineLegendYRange(): [number, number] {
+        const top = this.bounds.top
+
+        const bottom =
+            this.bounds.bottom -
+            // leave space for the x-axis labels
+            BOTTOM_PADDING +
+            // but allow for a little extra space
+            this.lineLegendFontSize / 2
+
+        return [top, bottom]
     }
 
     @computed private get lineLegendLeftHasConnectorLines(): boolean {
@@ -1009,7 +1025,7 @@ export class SlopeChart
                 labelSeries={this.lineLegendSeriesRight}
                 yAxis={this.yAxis}
                 x={this.xRange[1] + LINE_LEGEND_PADDING}
-                yRange={[this.bounds.top, this.bounds.bottom - BOTTOM_PADDING]}
+                yRange={this.lineLegendYRange}
                 maxWidth={this.maxLineLegendWidth}
                 xAnchor="start"
                 verticalAlign={VerticalAlign.top}
@@ -1044,7 +1060,7 @@ export class SlopeChart
                     textAnchor="end"
                     dx={-LINE_LEGEND_PADDING - 4}
                     dy={dyFromAlign(VerticalAlign.middle)}
-                    fontSize={GRAPHER_FONT_SCALE_12 * this.fontSize}
+                    fontSize={this.lineLegendFontSize}
                 >
                     {this.formatColumn.formatValueShort(0)}
                 </text>
@@ -1055,7 +1071,7 @@ export class SlopeChart
                 labelSeries={this.lineLegendSeriesLeft}
                 yAxis={this.yAxis}
                 x={this.xRange[0] - LINE_LEGEND_PADDING}
-                yRange={[this.bounds.top, this.bounds.bottom - BOTTOM_PADDING]}
+                yRange={this.lineLegendYRange}
                 maxWidth={this.maxLineLegendWidth}
                 xAnchor="end"
                 verticalAlign={VerticalAlign.top}
@@ -1269,7 +1285,6 @@ function MarkX({
                 textAnchor="middle"
                 fill={GRAPHER_DARK_TEXT}
                 fontSize={fontSize}
-                fontWeight={600}
             >
                 {label}
             </text>

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
@@ -525,31 +525,6 @@ export class SlopeChart
         return [top, bottom]
     }
 
-    @computed private get lineLegendLeftHasConnectorLines(): boolean {
-        // can't use this.lineLegendSeriesLeft due to a circular dependency
-        const lineLegendSeries = this.series.map((series) => {
-            const { seriesName, color, start } = series
-            const formattedValue = this.formatColumn.formatValueShort(
-                start.value
-            )
-            return {
-                color,
-                seriesName,
-                label: formattedValue,
-                yValue: start.value,
-            }
-        })
-
-        return LineLegend.needsConnectorLines({
-            labelSeries: lineLegendSeries,
-            yAxis: this.yAxis,
-            maxWidth: this.maxLineLegendWidth,
-            connectorLineWidth: this.lineLegendConnectorLinesWidth,
-            fontSize: this.fontSize,
-            isStatic: this.manager.isStatic,
-        })
-    }
-
     @computed get lineLegendWidthLeft(): number {
         if (!this.manager.showLegend) return 0
         return LineLegend.width({
@@ -636,26 +611,16 @@ export class SlopeChart
         return this.hoveredSeriesName ? [this.hoveredSeriesName] : []
     }
 
-    /**
-     * If the line legend uses connector lines, then we do show the series
-     * name to make it clear which slope the value belongs to
-     */
-    @computed private get showSeriesNamesInLineLegendLeft(): boolean {
-        return this.lineLegendLeftHasConnectorLines
-    }
-
     @computed get lineLegendSeriesLeft(): LineLabelSeries[] {
-        const { showSeriesNamesInLineLegendLeft: showSeriesName } = this
         return this.series.map((series) => {
             const { seriesName, color, start } = series
-            const value = this.formatColumn.formatValueShort(start.value)
-            const label = showSeriesName ? seriesName : value
-            const formattedValue = showSeriesName ? value : undefined
+            const formattedValue = this.formatColumn.formatValueShort(
+                start.value
+            )
             return {
                 color,
                 seriesName,
-                label,
-                formattedValue,
+                label: formattedValue,
                 valueInNewLine: this.useCompactLineLegend,
                 yValue: start.value,
             }

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
@@ -565,9 +565,12 @@ export class SlopeChart
         return LineLegend.width({
             labelSeries: this.lineLegendSeriesRight,
             yAxis: this.yAxis,
+            yRange: this.lineLegendYRange,
+            verticalAlign: VerticalAlign.top,
             maxWidth: this.maxLineLegendWidth,
             connectorLineWidth: this.lineLegendConnectorLinesWidth,
             fontSize: this.fontSize,
+            fontWeight: 700,
             isStatic: this.manager.isStatic,
         })
     }

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
@@ -928,7 +928,7 @@ export class SlopeChart
                 <GridLines
                     bounds={this.bounds}
                     yAxis={this.yAxis}
-                    endX={this.innerBounds.right}
+                    endX={this.endX}
                 />
                 <VerticalAxisComponent
                     bounds={bounds}

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
@@ -802,9 +802,7 @@ export class SlopeChart
         const formatTime = (time: Time) => formatColumn.formatTime(time)
 
         const title = series.seriesName
-        const titleAnnotation = this.useCompactLineLegend
-            ? series.annotation
-            : undefined
+        const titleAnnotation = series.annotation
 
         const actualStartTime = series.start.originalTime
         const actualEndTime = series.end.originalTime

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
@@ -558,7 +558,6 @@ export class SlopeChart
     @computed private get lineLegendPropsLeft(): Partial<LineLegendProps> {
         return {
             xAnchor: "end",
-            fontWeight: this.showSeriesNamesInLineLegendLeft ? 700 : undefined,
             seriesSortedByImportance:
                 this.seriesSortedByImportanceForLineLegendLeft,
         }
@@ -618,7 +617,7 @@ export class SlopeChart
     @computed get seriesSortedByImportanceForLineLegendLeft(): SeriesName[] {
         return this.series
             .map((s) => s.seriesName)
-            .toSorted((s1: SeriesName, s2: SeriesName): number => {
+            .sort((s1: SeriesName, s2: SeriesName): number => {
                 const PREFER_S1 = -1
                 const PREFER_S2 = 1
 

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
@@ -776,17 +776,13 @@ export class SlopeChart
     @computed get failMessage(): string {
         const message = getDefaultFailMessage(this.manager)
         if (message) return message
-        else if (this.startTime === this.endTime)
-            return "No data to display for the selected time period"
+        else if (this.startTime === this.endTime) return "Single date selected"
         return ""
     }
 
     @computed get helpMessage(): string | undefined {
-        if (
-            this.failMessage ===
-            "No data to display for the selected time period"
-        )
-            return "Try dragging the time slider to display data."
+        if (this.failMessage === "Single date selected")
+            return "Please select two dates to display data."
         return undefined
     }
 
@@ -1200,7 +1196,7 @@ function LineWithDots({
 }: {
     startPoint: PointVector
     endPoint: PointVector
-    radius?: number
+    radius: number
     color: string
     lineWidth?: number
     opacity?: number

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
@@ -49,6 +49,7 @@ import {
     autoDetectSeriesStrategy,
     autoDetectYColumnSlugs,
     getDefaultFailMessage,
+    getShortNameForEntity,
     makeSelectionArray,
 } from "../chart/ChartUtils"
 import { AxisConfig } from "../axis/AxisConfig"
@@ -281,9 +282,11 @@ export class SlopeChart
         const { canSelectMultipleEntities = false } = this.manager
 
         const { availableEntityNames } = this.transformedTable
+        const displayEntityName =
+            getShortNameForEntity(entityName) ?? entityName
         const columnName = column.nonEmptyDisplayName
         const seriesName = getSeriesName({
-            entityName,
+            entityName: displayEntityName,
             columnName,
             seriesStrategy,
             availableEntityNames,

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
@@ -186,7 +186,7 @@ export class SlopeChart
 
     private sidebarMargin = 10
     @computed private get innerBounds(): Bounds {
-        return this.bounds.padRight(this.sidebarWidth + 8)
+        return this.bounds.padRight(this.sidebarWidth + this.sidebarMargin)
     }
 
     @computed get fontSize() {
@@ -480,7 +480,7 @@ export class SlopeChart
     }
 
     @computed private get yAxisWidth(): number {
-        return this.yAxis.width + 5 // 5px account for the tick marks
+        return this.yAxis.width
     }
 
     @computed private get xScale(): ScaleLinear<number, number> {
@@ -972,14 +972,13 @@ export class SlopeChart
         return (
             <g>
                 <GridLines
-                    bounds={this.bounds}
+                    bounds={bounds}
                     yAxis={this.yAxis}
                     endX={this.endX}
                 />
                 <VerticalAxisComponent
                     bounds={bounds}
                     verticalAxis={this.yAxis}
-                    showTickMarks={true}
                     labelColor={this.manager.secondaryColorInStaticCharts}
                 />
                 <MarkX
@@ -1247,7 +1246,7 @@ function GridLines({ bounds, yAxis, endX }: GridLinesProps) {
                         key={tick.formattedValue}
                     >
                         <line
-                            x1={bounds.left + yAxis.width + 8}
+                            x1={bounds.left + yAxis.width}
                             y1={y}
                             x2={endX}
                             y2={y}

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
@@ -10,7 +10,6 @@ import {
     guid,
     excludeUndefined,
     partition,
-    max,
     getRelativeMouse,
     minBy,
     dyFromAlign,
@@ -973,7 +972,8 @@ export class SlopeChart
                 x={this.xRange[1] + LINE_LEGEND_PADDING}
                 yRange={[this.bounds.top, this.bounds.bottom]}
                 maxWidth={this.maxLineLegendWidth}
-                lineLegendAnchorX="start"
+                xAnchor="start"
+                verticalAlign={VerticalAlign.top}
                 connectorLineWidth={this.lineLegendConnectorLinesWidth}
                 fontSize={this.fontSize}
                 fontWeight={700}
@@ -1008,7 +1008,8 @@ export class SlopeChart
                 x={this.xRange[0] - LINE_LEGEND_PADDING}
                 yRange={[this.bounds.top, this.bounds.bottom]}
                 maxWidth={this.maxLineLegendWidth}
-                lineLegendAnchorX="end"
+                xAnchor="end"
+                verticalAlign={VerticalAlign.top}
                 connectorLineWidth={this.lineLegendConnectorLinesWidth}
                 fontSize={this.fontSize}
                 isStatic={this.manager.isStatic}

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
@@ -504,6 +504,7 @@ export class SlopeChart
             yAxis: this.yAxis,
             maxWidth: this.maxLineLegendWidth,
             connectorLineWidth: this.lineLegendConnectorLinesWidth,
+            showValueLabelsInline: false,
             fontSize: this.fontSize,
             isStatic: this.manager.isStatic,
         })
@@ -516,6 +517,7 @@ export class SlopeChart
             yAxis: this.yAxis,
             maxWidth: this.maxLineLegendWidth,
             connectorLineWidth: this.lineLegendConnectorLinesWidth,
+            showValueLabelsInline: false,
             fontSize: this.fontSize,
             isStatic: this.manager.isStatic,
         })
@@ -596,11 +598,13 @@ export class SlopeChart
     @computed get lineLegendSeriesRight(): LineLabelSeries[] {
         return this.series.map((series) => {
             const { seriesName, color, end, annotation } = series
+            const formattedValue = this.formatColumn.formatValueLong(end.value)
             return {
                 color,
                 seriesName,
                 label: seriesName,
                 annotation,
+                formattedValue,
                 yValue: end.value,
             }
         })
@@ -962,8 +966,10 @@ export class SlopeChart
                     x={this.xRange[1] + LINE_LEGEND_PADDING}
                     maxWidth={this.maxLineLegendWidth}
                     lineLegendAnchorX="start"
+                    showValueLabelsInline={false}
                     connectorLineWidth={this.lineLegendConnectorLinesWidth}
                     fontSize={this.fontSize}
+                    fontWeight={700}
                     isStatic={this.manager.isStatic}
                     focusedSeriesNames={this.focusedSeriesNames}
                     onMouseLeave={this.onLineLegendMouseLeave}
@@ -975,6 +981,7 @@ export class SlopeChart
                     x={this.xRange[0] - LINE_LEGEND_PADDING}
                     maxWidth={this.maxLineLegendWidth}
                     lineLegendAnchorX="end"
+                    showValueLabelsInline={false}
                     connectorLineWidth={this.lineLegendConnectorLinesWidth}
                     fontSize={this.fontSize}
                     isStatic={this.manager.isStatic}

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
@@ -427,6 +427,9 @@ export class SlopeChart
         // nothing to show if there are no series with missing data
         if (this.noDataSeries.length === 0) return false
 
+        // the No Data section is HTML and won't show up in the SVG export
+        if (this.manager.isStatic) return false
+
         // we usually don't show the no data section if columns are plotted
         // (since columns don't appear in the entity selector there is no need
         // to explain that a column is missing – it just adds noise). but if

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
@@ -550,7 +550,7 @@ export class SlopeChart
     }
 
     // used in LineLegend
-    @computed get labelSeries(): LineLabelSeries[] {
+    @computed get lineLegendSeries(): LineLabelSeries[] {
         return this.series.map((series) => {
             const { seriesName, color, end, annotation } = series
             return {
@@ -917,7 +917,19 @@ export class SlopeChart
         return (
             <g>
                 {this.renderChartArea()}
-                {this.manager.showLegend && <LineLegend manager={this} />}
+                {this.manager.showLegend && (
+                    <LineLegend
+                        labelSeries={this.lineLegendSeries}
+                        yAxis={this.yAxis}
+                        x={this.lineLegendX}
+                        maxWidth={this.maxLineLegendWidth}
+                        fontSize={this.fontSize}
+                        isStatic={this.manager.isStatic}
+                        focusedSeriesNames={this.focusedSeriesNames}
+                        onMouseLeave={this.onLineLegendMouseLeave}
+                        onMouseOver={this.onLineLegendMouseOver}
+                    />
+                )}
                 {this.showNoDataSection && this.renderNoDataSection()}
                 {this.tooltip}
             </g>

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
@@ -1037,6 +1037,7 @@ export class SlopeChart
                 connectorLineWidth={this.lineLegendConnectorLinesWidth}
                 fontSize={this.fontSize}
                 fontWeight={700}
+                outlineColor={this.backgroundColor}
                 isStatic={this.manager.isStatic}
                 focusedSeriesNames={this.focusedSeriesNames}
                 onMouseLeave={this.onLineLegendMouseLeave}
@@ -1085,6 +1086,7 @@ export class SlopeChart
                 fontWeight={
                     this.showSeriesNamesInLineLegendLeft ? 700 : undefined
                 }
+                outlineColor={this.backgroundColor}
                 isStatic={this.manager.isStatic}
                 focusedSeriesNames={this.focusedSeriesNames}
                 onMouseLeave={this.onLineLegendMouseLeave}

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
@@ -80,7 +80,7 @@ import {
     getSeriesName,
 } from "../lineCharts/LineChartHelpers"
 import { SelectionArray } from "../selection/SelectionArray"
-import { Halo } from "../halo/Halo"
+import { Halo } from "@ourworldindata/components"
 
 type SVGMouseOrTouchEvent =
     | React.MouseEvent<SVGGElement>
@@ -1108,7 +1108,10 @@ export class SlopeChart
             allSlopesStartFromZero
         )
             return (
-                <Halo id="x-axis-zero-label" background={this.backgroundColor}>
+                <Halo
+                    id="x-axis-zero-label"
+                    outlineColor={this.backgroundColor}
+                >
                     <text
                         x={this.startX}
                         y={this.yAxis.place(0)}

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
@@ -509,7 +509,9 @@ export class SlopeChart
     }
 
     @computed get maxLineLegendWidth(): number {
-        return 0.25 * this.innerBounds.width
+        return this.useCompactLayout
+            ? 0.15 * this.innerBounds.width
+            : 0.25 * this.innerBounds.width
     }
 
     @computed get lineLegendFontSize(): number {
@@ -650,7 +652,7 @@ export class SlopeChart
         return this.xRange[1] + LINE_LEGEND_PADDING
     }
 
-    @computed get useCompactLineLegend(): boolean {
+    @computed get useCompactLayout(): boolean {
         return !!this.manager.isSemiNarrow
     }
 
@@ -675,7 +677,7 @@ export class SlopeChart
                     seriesName,
                     label,
                     formattedValue,
-                    valueInNewLine: this.useCompactLineLegend,
+                    valueInNewLine: this.useCompactLayout,
                     yValue: start.value,
                 }
             })
@@ -690,16 +692,16 @@ export class SlopeChart
                 color,
                 seriesName,
                 label: seriesName,
-                annotation: this.useCompactLineLegend ? undefined : annotation,
+                annotation: this.useCompactLayout ? undefined : annotation,
                 formattedValue,
-                valueInNewLine: this.useCompactLineLegend,
+                valueInNewLine: this.useCompactLayout,
                 yValue: end.value,
             }
         })
     }
 
     @computed private get lineLegendConnectorLinesWidth(): number {
-        return this.useCompactLineLegend ? 15 : 25
+        return this.useCompactLayout ? 15 : 25
     }
 
     private playIntroAnimation() {

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
@@ -581,6 +581,10 @@ export class SlopeChart
         return !!this.manager.isSemiNarrow
     }
 
+    @computed private get showValueLabelsInline(): boolean {
+        return this.useCompactLineLegend
+    }
+
     // used by LineLegend
     @computed get focusedSeriesNames(): SeriesName[] {
         return this.hoveredSeriesName ? [this.hoveredSeriesName] : []
@@ -588,7 +592,7 @@ export class SlopeChart
 
     @computed get lineLegendSeriesLeft(): LineLabelSeries[] {
         return this.series.map((series) => {
-            const { seriesName, color, start, annotation } = series
+            const { seriesName, color, start } = series
             const formattedValue = this.formatColumn.formatValueShort(
                 start.value
             )
@@ -596,7 +600,6 @@ export class SlopeChart
                 color,
                 seriesName,
                 label: formattedValue,
-                annotation,
                 yValue: start.value,
             }
         })
@@ -750,6 +753,11 @@ export class SlopeChart
 
         const formatTime = (time: Time) => formatColumn.formatTime(time)
 
+        const title = series.seriesName
+        const titleAnnotation = !this.showValueLabelsInline
+            ? series.annotation
+            : undefined
+
         const actualStartTime = series.start.originalTime
         const actualEndTime = series.end.originalTime
         const timeRange = `${formatTime(actualStartTime)} to ${formatTime(actualEndTime)}`
@@ -803,7 +811,8 @@ export class SlopeChart
                 offsetX={20}
                 offsetY={-16}
                 style={{ maxWidth: "250px" }}
-                title={series.seriesName}
+                title={title}
+                titleAnnotation={titleAnnotation}
                 subtitle={timeLabel}
                 subtitleFormat={targetYear ? "notice" : undefined}
                 dissolve={fading}
@@ -971,7 +980,7 @@ export class SlopeChart
                 yRange={[this.bounds.top, this.bounds.bottom]}
                 maxWidth={this.maxLineLegendWidth}
                 lineLegendAnchorX="start"
-                showValueLabelsInline={!this.useCompactLineLegend}
+                showValueLabelsInline={this.showValueLabelsInline}
                 connectorLineWidth={this.lineLegendConnectorLinesWidth}
                 fontSize={this.fontSize}
                 fontWeight={700}
@@ -1007,7 +1016,6 @@ export class SlopeChart
                 yRange={[this.bounds.top, this.bounds.bottom]}
                 maxWidth={this.maxLineLegendWidth}
                 lineLegendAnchorX="end"
-                showValueLabelsInline={!this.useCompactLineLegend}
                 connectorLineWidth={this.lineLegendConnectorLinesWidth}
                 fontSize={this.fontSize}
                 isStatic={this.manager.isStatic}

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
@@ -777,13 +777,14 @@ export class SlopeChart
     @computed get failMessage(): string {
         const message = getDefaultFailMessage(this.manager)
         if (message) return message
-        else if (this.startTime === this.endTime) return "Single date selected"
+        else if (this.startTime === this.endTime)
+            return "Two time points needed for comparison"
         return ""
     }
 
     @computed get helpMessage(): string | undefined {
-        if (this.failMessage === "Single date selected")
-            return "Please select two dates to display data."
+        if (this.failMessage === "Two time points needed for compariso")
+            return "Click or drag the timeline to select two different points in time"
         return undefined
     }
 

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
@@ -500,7 +500,7 @@ export class SlopeChart
     }
 
     @computed get maxLineLegendWidth(): number {
-        return this.bounds.width / 6
+        return this.innerBounds.width / 4
     }
 
     @computed get lineLegendWidthLeft(): number {
@@ -510,7 +510,6 @@ export class SlopeChart
             yAxis: this.yAxis,
             maxWidth: this.maxLineLegendWidth,
             connectorLineWidth: this.lineLegendConnectorLinesWidth,
-            showValueLabelsInline: false,
             fontSize: this.fontSize,
             isStatic: this.manager.isStatic,
         })
@@ -523,7 +522,6 @@ export class SlopeChart
             yAxis: this.yAxis,
             maxWidth: this.maxLineLegendWidth,
             connectorLineWidth: this.lineLegendConnectorLinesWidth,
-            showValueLabelsInline: false,
             fontSize: this.fontSize,
             isStatic: this.manager.isStatic,
         })
@@ -581,10 +579,6 @@ export class SlopeChart
         return !!this.manager.isSemiNarrow
     }
 
-    @computed private get showValueLabelsInline(): boolean {
-        return this.useCompactLineLegend
-    }
-
     // used by LineLegend
     @computed get focusedSeriesNames(): SeriesName[] {
         return this.hoveredSeriesName ? [this.hoveredSeriesName] : []
@@ -613,7 +607,7 @@ export class SlopeChart
                 color,
                 seriesName,
                 label: seriesName,
-                annotation,
+                annotation: this.useCompactLineLegend ? undefined : annotation,
                 formattedValue,
                 yValue: end.value,
             }
@@ -754,7 +748,7 @@ export class SlopeChart
         const formatTime = (time: Time) => formatColumn.formatTime(time)
 
         const title = series.seriesName
-        const titleAnnotation = !this.showValueLabelsInline
+        const titleAnnotation = this.useCompactLineLegend
             ? series.annotation
             : undefined
 
@@ -980,7 +974,6 @@ export class SlopeChart
                 yRange={[this.bounds.top, this.bounds.bottom]}
                 maxWidth={this.maxLineLegendWidth}
                 lineLegendAnchorX="start"
-                showValueLabelsInline={this.showValueLabelsInline}
                 connectorLineWidth={this.lineLegendConnectorLinesWidth}
                 fontSize={this.fontSize}
                 fontWeight={700}

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
@@ -1,4 +1,4 @@
-import React, { SVGProps } from "react"
+import React from "react"
 import {
     Bounds,
     DEFAULT_BOUNDS,

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
@@ -686,6 +686,7 @@ export class SlopeChart
             .attr("stroke-dasharray", "100%")
             .attr("stroke-dashoffset", "100%")
             .transition()
+            .duration(600)
             .attr("stroke-dashoffset", "0%")
     }
 

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
@@ -966,7 +966,7 @@ export class SlopeChart
                     x={this.xRange[1] + LINE_LEGEND_PADDING}
                     maxWidth={this.maxLineLegendWidth}
                     lineLegendAnchorX="start"
-                    showValueLabelsInline={false}
+                    showValueLabelsInline={!this.useCompactLineLegend}
                     connectorLineWidth={this.lineLegendConnectorLinesWidth}
                     fontSize={this.fontSize}
                     fontWeight={700}
@@ -981,7 +981,7 @@ export class SlopeChart
                     x={this.xRange[0] - LINE_LEGEND_PADDING}
                     maxWidth={this.maxLineLegendWidth}
                     lineLegendAnchorX="end"
-                    showValueLabelsInline={false}
+                    showValueLabelsInline={!this.useCompactLineLegend}
                     connectorLineWidth={this.lineLegendConnectorLinesWidth}
                     fontSize={this.fontSize}
                     isStatic={this.manager.isStatic}

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
@@ -411,10 +411,6 @@ export class SlopeChart
         )
     }
 
-    @computed get seriesByName(): Map<SeriesName, SlopeChartSeries> {
-        return new Map(this.series.map((series) => [series.seriesName, series]))
-    }
-
     @computed private get placedSeries(): PlacedSlopeChartSeries[] {
         const { yAxis, startX, endX } = this
 
@@ -595,31 +591,28 @@ export class SlopeChart
 
     @computed get lineLegendWidthLeft(): number {
         if (!this.manager.showLegend) return 0
-        return LineLegend.width({
+        return LineLegend.stableWidth({
             labelSeries: this.lineLegendSeriesLeft,
             ...this.lineLegendPropsCommon,
             ...this.lineLegendPropsLeft,
         })
     }
 
-    @computed get lineLegendWidthRight(): number {
-        if (!this.manager.showLegend) return 0
-        return LineLegend.width({
+    @computed get lineLegendRight(): LineLegend | undefined {
+        if (!this.manager.showLegend) return undefined
+        return new LineLegend({
             labelSeries: this.lineLegendSeriesRight,
             ...this.lineLegendPropsCommon,
             ...this.lineLegendPropsRight,
         })
     }
 
+    @computed get lineLegendWidthRight(): number {
+        return this.lineLegendRight?.stableWidth ?? 0
+    }
+
     @computed get visibleLineLegendLabelsRight(): Set<SeriesName> {
-        if (!this.manager.showLegend) return new Set()
-        return new Set(
-            LineLegend.visibleSeriesNames({
-                labelSeries: this.lineLegendSeriesRight,
-                ...this.lineLegendPropsCommon,
-                ...this.lineLegendPropsRight,
-            })
-        )
+        return new Set(this.lineLegendRight?.visibleSeriesNames ?? [])
     }
 
     @computed get seriesSortedByImportanceForLineLegendLeft(): SeriesName[] {

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
@@ -970,7 +970,7 @@ export class SlopeChart
                 labelSeries={this.lineLegendSeriesRight}
                 yAxis={this.yAxis}
                 x={this.xRange[1] + LINE_LEGEND_PADDING}
-                yRange={[this.bounds.top, this.bounds.bottom]}
+                yRange={[this.bounds.top, this.bounds.bottom - BOTTOM_PADDING]}
                 maxWidth={this.maxLineLegendWidth}
                 xAnchor="start"
                 verticalAlign={VerticalAlign.top}
@@ -1006,7 +1006,7 @@ export class SlopeChart
                 labelSeries={this.lineLegendSeriesLeft}
                 yAxis={this.yAxis}
                 x={this.xRange[0] - LINE_LEGEND_PADDING}
-                yRange={[this.bounds.top, this.bounds.bottom]}
+                yRange={[this.bounds.top, this.bounds.bottom - BOTTOM_PADDING]}
                 maxWidth={this.maxLineLegendWidth}
                 xAnchor="end"
                 verticalAlign={VerticalAlign.top}

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
@@ -663,7 +663,6 @@ export class StackedAreaChart extends AbstractStackedChart {
                 yRange={this.lineLegendY}
                 maxWidth={this.maxLineLegendWidth}
                 fontSize={this.fontSize}
-                outlineColor={this.manager.backgroundColor}
                 seriesSortedByImportance={this.seriesSortedByImportance}
                 isStatic={this.isStatic}
                 focusedSeriesNames={this.focusedSeriesNames}

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
@@ -294,7 +294,7 @@ export class StackedAreaChart extends AbstractStackedChart {
         })
     }
 
-    @computed get labelSeries(): LineLabelSeries[] {
+    @computed get lineLegendSeries(): LineLabelSeries[] {
         const { midpoints } = this
         return this.series
             .map((series, index) => ({
@@ -318,7 +318,7 @@ export class StackedAreaChart extends AbstractStackedChart {
         // only pass props that are required to calculate
         // the width to avoid circular dependencies
         return LineLegend.incorrectWidth({
-            labelSeries: this.labelSeries,
+            labelSeries: this.lineLegendSeries,
             maxWidth: this.maxLineLegendWidth,
             fontSize: this.fontSize,
         })
@@ -657,7 +657,7 @@ export class StackedAreaChart extends AbstractStackedChart {
         if (!this.manager.showLegend) return
         return (
             <LineLegend
-                labelSeries={this.labelSeries}
+                labelSeries={this.lineLegendSeries}
                 yAxis={this.yAxis}
                 x={this.lineLegendX}
                 yRange={this.lineLegendY}

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
@@ -317,7 +317,7 @@ export class StackedAreaChart extends AbstractStackedChart {
 
         // only pass props that are required to calculate
         // the width to avoid circular dependencies
-        return LineLegend.width({
+        return LineLegend.stableWidth({
             labelSeries: this.lineLegendSeries,
             maxWidth: this.maxLineLegendWidth,
             fontSize: this.fontSize,

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
@@ -317,7 +317,7 @@ export class StackedAreaChart extends AbstractStackedChart {
 
         // only pass props that are required to calculate
         // the width to avoid circular dependencies
-        return LineLegend.incorrectWidth({
+        return LineLegend.width({
             labelSeries: this.lineLegendSeries,
             maxWidth: this.maxLineLegendWidth,
             fontSize: this.fontSize,

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
@@ -663,6 +663,7 @@ export class StackedAreaChart extends AbstractStackedChart {
                 yRange={this.lineLegendY}
                 maxWidth={this.maxLineLegendWidth}
                 fontSize={this.fontSize}
+                outlineColor={this.manager.backgroundColor}
                 seriesSortedByImportance={this.seriesSortedByImportance}
                 isStatic={this.isStatic}
                 focusedSeriesNames={this.focusedSeriesNames}

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
@@ -317,7 +317,7 @@ export class StackedAreaChart extends AbstractStackedChart {
 
         // only pass props that are required to calculate
         // the width to avoid circular dependencies
-        return LineLegend.width({
+        return LineLegend.incorrectWidth({
             labelSeries: this.labelSeries,
             maxWidth: this.maxLineLegendWidth,
             fontSize: this.fontSize,

--- a/packages/@ourworldindata/grapher/src/tooltip/Tooltip.scss
+++ b/packages/@ourworldindata/grapher/src/tooltip/Tooltip.scss
@@ -67,6 +67,13 @@
                     font-size: 14px;
                     font-weight: $bold;
                     letter-spacing: 0;
+
+                    .annotation {
+                        margin-left: 4px;
+                        font-weight: normal;
+                        color: $grey;
+                        font-size: 0.9em;
+                    }
                 }
                 .subtitle {
                     margin: 4px 0 2px 0;

--- a/packages/@ourworldindata/grapher/src/tooltip/Tooltip.scss
+++ b/packages/@ourworldindata/grapher/src/tooltip/Tooltip.scss
@@ -67,9 +67,10 @@
                     font-size: 14px;
                     font-weight: $bold;
                     letter-spacing: 0;
+                    margin-right: 4px;
 
                     .annotation {
-                        margin-left: 4px;
+                        display: inline-block;
                         font-weight: normal;
                         color: $grey;
                         font-size: 0.9em;

--- a/packages/@ourworldindata/grapher/src/tooltip/Tooltip.tsx
+++ b/packages/@ourworldindata/grapher/src/tooltip/Tooltip.tsx
@@ -103,6 +103,7 @@ class TooltipCard extends React.Component<
         let {
             id,
             title,
+            titleAnnotation,
             subtitle,
             subtitleFormat,
             footer,
@@ -189,7 +190,14 @@ class TooltipCard extends React.Component<
             >
                 {hasHeader && (
                     <div className="frontmatter">
-                        {title && <div className="title">{title}</div>}
+                        {title && (
+                            <div className="title">
+                                {title}{" "}
+                                <span className="annotation">
+                                    {titleAnnotation}
+                                </span>
+                            </div>
+                        )}
                         {subtitle && (
                             <div className="subtitle">
                                 {timeNotice && TOOLTIP_ICON.notice}

--- a/packages/@ourworldindata/grapher/src/tooltip/TooltipProps.ts
+++ b/packages/@ourworldindata/grapher/src/tooltip/TooltipProps.ts
@@ -28,6 +28,7 @@ export interface TooltipProps {
     offsetXDirection?: "left" | "right"
     offsetYDirection?: "upward" | "downward"
     title?: string | number // header text
+    titleAnnotation?: string // rendered next to the title, but muted
     subtitle?: string | number // header deck
     subtitleFormat?: "notice" | "unit" // optional postprocessing for subtitle
     footer?: { icon: TooltipFooterIcon; text: string }[]


### PR DESCRIPTION
### Summary

- Entity names are usually only shown only on the right side
- If it would be otherwise difficult to match a label on the left to the corresponding slope, then the entity name is repeated
    - The heuristic here uses the number of levels used by the line legend, the actual threshold (4) is arbitrary of course
- We prefer to add labels on the left if they're also labelled on the right (this is only important if labels are dropped due to space constraints)
- Entity annotations are hidden on smaller screens
- Entity annotations are also shown in the tooltip (line charts show entity annotations in the tooltip as well) 

### Future improvements

- Show hidden line legend labels on hover
- Toggling the No Data section is quite disruptive. Once we make changes to the entity selector that account for the No data problem, we should remove the section

### Testing

The Multiembedder problem is hot-fixed on [this staging site](http://staging-site-slope-charts) for testing.