### PR TITLE
🐛 migrate configs fetched from R2 to latest version on the fly

### DIFF
--- a/packages/@ourworldindata/explorer/src/Explorer.sample.tsx
+++ b/packages/@ourworldindata/explorer/src/Explorer.sample.tsx
@@ -1,7 +1,10 @@
 import React from "react"
 import { DimensionProperty } from "@ourworldindata/utils"
 import { GRAPHER_TAB_OPTIONS } from "@ourworldindata/types"
-import { GrapherProgrammaticInterface } from "@ourworldindata/grapher"
+import {
+    GrapherProgrammaticInterface,
+    latestGrapherConfigSchema,
+} from "@ourworldindata/grapher"
 import { Explorer, ExplorerProps } from "./Explorer.js"
 
 const SampleExplorerOfGraphersProgram = `explorerTitle	CO₂
@@ -46,6 +49,7 @@ graphers
 export const SampleExplorerOfGraphers = (props?: Partial<ExplorerProps>) => {
     const title = "AlphaBeta"
     const first: GrapherProgrammaticInterface = {
+        $schema: latestGrapherConfigSchema,
         id: 488,
         title,
         dimensions: [

--- a/site/multiembedder/MultiEmbedder.tsx
+++ b/site/multiembedder/MultiEmbedder.tsx
@@ -9,6 +9,7 @@ import {
     hydrateGlobalEntitySelectorIfAny,
     migrateSelectedEntityNamesParam,
     SelectionArray,
+    migrateGrapherConfigToLatestVersion,
 } from "@ourworldindata/grapher"
 import {
     fetchText,
@@ -199,8 +200,11 @@ class MultiEmbedder {
             } else {
                 configUrl = `${GRAPHER_DYNAMIC_CONFIG_URL}/${slug}.config.json`
             }
-            const grapherPageConfig = await fetch(configUrl).then((res) =>
-                res.json()
+            const fetchedGrapherPageConfig = await fetch(configUrl).then(
+                (res) => res.json()
+            )
+            const grapherPageConfig = migrateGrapherConfigToLatestVersion(
+                fetchedGrapherPageConfig
             )
 
             const figureConfigAttr = figure.getAttribute(


### PR DESCRIPTION
Configs in R2 might be out of date. This can happen after a config migration with a breaking change.

But Grapher expects configs to be of the latest version. We also merge configs in various places and can only do so if the configs are of the same version (or we get errors like [this one](https://owid.slack.com/archives/C028P3FM8CD/p1732679638441589)).

Whenever we fetch configs from R2, we need to make sure they adhere to the latest version and if not, migrate them on the fly. I updated the Multiembedder and explorers. Is there some place else where we should also do this?


