### PR TITLE
Revert "🔨 stop exposing grapher for charts embedded on a data page"

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -3126,7 +3126,7 @@ export class Grapher
         this.setBaseFontSize()
         this.setUpIntersectionObserver()
         this.setUpWindowResizeEventHandler()
-        if (!this.isEmbeddedInADataPage) exposeInstanceOnWindow(this, "grapher")
+        exposeInstanceOnWindow(this, "grapher")
         // Emit a custom event when the grapher is ready
         // We can use this in global scripts that depend on the grapher e.g. the site-screenshots tool
         this.disposers.push(


### PR DESCRIPTION
Reverts owid/owid-grapher#4216

I thought `isEmbeddedInADataPage` is only set for charts in the Related charts block, for example, but not for the main chart. Apparently, I was wrong.