### PR TITLE
✨ Filter for only active columsn in grapher data download

### DIFF
--- a/packages/@ourworldindata/core-table/src/OwidTable.ts
+++ b/packages/@ourworldindata/core-table/src/OwidTable.ts
@@ -607,30 +607,25 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
 
     // Give our users a clean CSV of each Grapher. Assumes an Owid Table with entityName.
     toPrettyCsv(
-        //
         useShortNames: boolean = false,
         activeColumnSlugs: string[] | undefined = undefined
     ): string {
-        const activeColumnsDiff: Set<string> = activeColumnSlugs
-            ? differenceOfSets([
-                  new Set(this.columnSlugs),
-                  new Set(activeColumnSlugs),
-              ])
-            : new Set()
-        const columnSlugsToRemove = differenceOfSets([
-            activeColumnsDiff,
-            new Set([
+        let table
+        if (activeColumnSlugs?.length) {
+            table = this.select([
                 OwidTableSlugs.year,
                 OwidTableSlugs.day,
                 this.entityNameSlug,
-            ]),
-        ])
-        return this.dropColumns([
-            OwidTableSlugs.entityId,
-            OwidTableSlugs.time,
-            OwidTableSlugs.entityColor,
-            ...columnSlugsToRemove,
-        ])
+                ...activeColumnSlugs,
+            ])
+        } else {
+            table = this.dropColumns([
+                OwidTableSlugs.entityId,
+                OwidTableSlugs.time,
+                OwidTableSlugs.entityColor,
+            ])
+        }
+        return table
             .sortBy([this.entityNameSlug])
             .toCsvWithColumnNames(useShortNames)
     }

--- a/packages/@ourworldindata/core-table/src/OwidTable.ts
+++ b/packages/@ourworldindata/core-table/src/OwidTable.ts
@@ -606,11 +606,30 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
     }
 
     // Give our users a clean CSV of each Grapher. Assumes an Owid Table with entityName.
-    toPrettyCsv(useShortNames: boolean = false): string {
+    toPrettyCsv(
+        //
+        useShortNames: boolean = false,
+        activeColumnSlugs: string[] | undefined = undefined
+    ): string {
+        const activeColumnsDiff: Set<string> = activeColumnSlugs
+            ? differenceOfSets([
+                  new Set(this.columnSlugs),
+                  new Set(activeColumnSlugs),
+              ])
+            : new Set()
+        const columnSlugsToRemove = differenceOfSets([
+            activeColumnsDiff,
+            new Set([
+                OwidTableSlugs.year,
+                OwidTableSlugs.day,
+                this.entityNameSlug,
+            ]),
+        ])
         return this.dropColumns([
             OwidTableSlugs.entityId,
             OwidTableSlugs.time,
             OwidTableSlugs.entityColor,
+            ...columnSlugsToRemove,
         ])
             .sortBy([this.entityNameSlug])
             .toCsvWithColumnNames(useShortNames)

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
@@ -65,6 +65,7 @@ export interface DownloadModalManager {
     showAdminControls?: boolean
     isSocialMediaExport?: boolean
     isPublished?: boolean
+    activeColumnSlugs?: string[]
 }
 
 interface DownloadModalProps {
@@ -432,13 +433,17 @@ interface DataDownloadContextClientSide extends DataDownloadContextBase {
     // Only needed for local CSV generation
     table: OwidTable
     transformedTable: OwidTable
+    activeColumnSlugs: string[] | undefined
 }
 
 const createCsvBlobLocally = async (ctx: DataDownloadContextClientSide) => {
     const csv =
         ctx.csvDownloadType === CsvDownloadType.Full
-            ? ctx.table.toPrettyCsv(ctx.shortColNames)
-            : ctx.transformedTable.toPrettyCsv(ctx.shortColNames)
+            ? ctx.table.toPrettyCsv(ctx.shortColNames, ctx.activeColumnSlugs)
+            : ctx.transformedTable.toPrettyCsv(
+                  ctx.shortColNames,
+                  ctx.activeColumnSlugs
+              )
 
     return new Blob([csv], { type: "text/csv;charset=utf-8" })
 }
@@ -765,6 +770,7 @@ export const DownloadModalDataTab = (props: DownloadModalProps) => {
             table: props.manager.table ?? BlankOwidTable(),
             transformedTable:
                 props.manager.transformedTable ?? BlankOwidTable(),
+            activeColumnSlugs: props.manager.activeColumnSlugs,
         }),
         [
             props.manager.baseUrl,
@@ -772,6 +778,7 @@ export const DownloadModalDataTab = (props: DownloadModalProps) => {
             props.manager.queryStr,
             props.manager.table,
             props.manager.transformedTable,
+            props.manager.activeColumnSlugs,
         ]
     )
 


### PR DESCRIPTION
Filter data downloads in grapher to only the actively used columns. Not doing this was a problem for csv based explorers that can have a huge number of columns.