### PR TITLE
refactor(grapher): better handling of query params

### DIFF
--- a/devTools/svgTester/chart-configurations.ts
+++ b/devTools/svgTester/chart-configurations.ts
@@ -7,9 +7,9 @@ import {
     GrapherQueryParams,
     GrapherChartType,
 } from "@ourworldindata/types"
-import { cartesian } from "@ourworldindata/utils"
+import { cartesian, PartialRecord } from "@ourworldindata/utils"
 
-export type ViewMatrix = Record<keyof GrapherQueryParams, string[]>
+export type ViewMatrix = PartialRecord<keyof GrapherQueryParams, string[]>
 
 enum TimePoint {
     earliest = "earliest",
@@ -96,7 +96,7 @@ const VIEW_MATRIX_BY_CHART_TYPE: Record<GrapherChartType, ViewMatrix> = {
 // for example, if a chart is not faceted, the uniformYAxis param doesn't apply
 const EXCLUDE_VIEWS_BY_CHART_TYPE: Record<
     GrapherChartType,
-    Record<keyof GrapherQueryParams, string>[]
+    PartialRecord<keyof GrapherQueryParams, string>[]
 > = {
     [GRAPHER_CHART_TYPES.LineChart]: [
         // sharing an axis only makes sense if a chart is faceted

--- a/packages/@ourworldindata/grapher/src/core/EntityUrlBuilder.ts
+++ b/packages/@ourworldindata/grapher/src/core/EntityUrlBuilder.ts
@@ -153,6 +153,10 @@ export const getSelectedEntityNamesParam = (
         : undefined
 }
 
+export const generateSelectedEntityNamesParam = (
+    entityNames: EntityName[]
+): string => entityNamesToV2Param(entityNames.map(entityNameToCode))
+
 export const setSelectedEntityNamesParam = (
     url: Url,
     entityNames: EntityName[] | undefined
@@ -160,7 +164,7 @@ export const setSelectedEntityNamesParam = (
     // Expects an already-migrated URL as input
     return url.updateQueryParams({
         country: entityNames
-            ? entityNamesToV2Param(entityNames.map(entityNameToCode))
+            ? generateSelectedEntityNamesParam(entityNames)
             : undefined,
     })
 }

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -150,10 +150,7 @@ import {
 import { TooltipManager } from "../tooltip/TooltipProps"
 
 import { DimensionSlot } from "../chart/DimensionSlot"
-import {
-    generateSelectedEntityNamesParam,
-    getSelectedEntityNamesParam,
-} from "./EntityUrlBuilder"
+import { getSelectedEntityNamesParam } from "./EntityUrlBuilder"
 import { AxisConfig, AxisManager } from "../axis/AxisConfig"
 import { ColorScaleConfig } from "../color/ColorScaleConfig"
 import { MapConfig } from "../mapCharts/MapConfig"
@@ -223,6 +220,7 @@ import {
 } from "../entitySelector/EntitySelector"
 import { SlideInDrawer } from "../slideInDrawer/SlideInDrawer"
 import { BodyDiv } from "../bodyDiv/BodyDiv"
+import { grapherObjectToQueryParams } from "./GrapherUrl.js"
 
 declare global {
     interface Window {
@@ -3318,31 +3316,10 @@ export class Grapher
     }
 
     @computed.struct get allParams(): GrapherQueryParams {
-        const params: GrapherQueryParams = {}
-        params.tab = this.mapGrapherTabToQueryParam(this.activeTab)
-        params.xScale = this.xAxis.scaleType
-        params.yScale = this.yAxis.scaleType
-        params.stackMode = this.stackMode
-        params.zoomToSelection = this.zoomToSelection ? "true" : undefined
-        params.endpointsOnly = this.compareEndPointsOnly ? "1" : "0"
-        params.time = this.timeParam
-        params.region = this.map.projection
-        params.facet = this.selectedFacetStrategy
-        params.uniformYAxis =
-            this.yAxis.facetDomain === FacetAxisDomain.independent ? "0" : "1"
-        params.showSelectionOnlyInTable = this.showSelectionOnlyInDataTable
-            ? "1"
-            : "0"
-        params.showNoDataArea = this.showNoDataArea ? "1" : "0"
-        params.country = this.selectedEntitiesIfDifferentThanAuthors
-            ? generateSelectedEntityNamesParam(
-                  this.selectedEntitiesIfDifferentThanAuthors
-              )
-            : undefined
-        return params
+        return grapherObjectToQueryParams(this)
     }
 
-    @computed private get selectedEntitiesIfDifferentThanAuthors():
+    @computed get selectedEntitiesIfDifferentThanAuthors():
         | EntityName[]
         | undefined {
         const authoredConfig = this.legacyConfigAsAuthored

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -151,8 +151,8 @@ import { TooltipManager } from "../tooltip/TooltipProps"
 
 import { DimensionSlot } from "../chart/DimensionSlot"
 import {
+    generateSelectedEntityNamesParam,
     getSelectedEntityNamesParam,
-    setSelectedEntityNamesParam,
 } from "./EntityUrlBuilder"
 import { AxisConfig, AxisManager } from "../axis/AxisConfig"
 import { ColorScaleConfig } from "../color/ColorScaleConfig"
@@ -3334,10 +3334,12 @@ export class Grapher
             ? "1"
             : "0"
         params.showNoDataArea = this.showNoDataArea ? "1" : "0"
-        return setSelectedEntityNamesParam(
-            Url.fromQueryParams(params),
-            this.selectedEntitiesIfDifferentThanAuthors
-        ).queryParams
+        params.country = this.selectedEntitiesIfDifferentThanAuthors
+            ? generateSelectedEntityNamesParam(
+                  this.selectedEntitiesIfDifferentThanAuthors
+              )
+            : undefined
+        return params
     }
 
     @computed private get selectedEntitiesIfDifferentThanAuthors():

--- a/packages/@ourworldindata/grapher/src/core/GrapherUrl.test.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherUrl.test.ts
@@ -1,0 +1,79 @@
+import { StackMode, TimeBoundValueStr } from "@ourworldindata/types"
+import { grapherConfigToQueryParams } from "./GrapherUrl.js"
+
+describe(grapherConfigToQueryParams, () => {
+    it("should convert an empty grapher config to an empty object", () => {
+        expect(grapherConfigToQueryParams({})).toEqual({})
+    })
+
+    it("time", () => {
+        expect(
+            grapherConfigToQueryParams({
+                minTime: 2000,
+            })
+        ).toEqual({ time: "2000..latest" })
+
+        expect(
+            grapherConfigToQueryParams({
+                maxTime: 2000,
+            })
+        ).toEqual({ time: "earliest..2000" })
+
+        expect(
+            grapherConfigToQueryParams({
+                minTime: 2000,
+                maxTime: 2000,
+            })
+        ).toEqual({ time: "2000" })
+
+        expect(
+            grapherConfigToQueryParams({
+                minTime: TimeBoundValueStr.unboundedLeft,
+                maxTime: TimeBoundValueStr.unboundedLeft,
+            })
+        ).toEqual({ time: "earliest" })
+
+        expect(
+            grapherConfigToQueryParams({
+                minTime: 2000,
+                maxTime: 2020,
+            })
+        ).toEqual({ time: "2000..2020" })
+    })
+
+    it("selectedEntityNames", () => {
+        expect(
+            grapherConfigToQueryParams({
+                selectedEntityNames: ["United States"],
+            })
+        ).toEqual({ country: "~USA" })
+
+        expect(
+            grapherConfigToQueryParams({
+                selectedEntityNames: ["United States", "France"],
+            })
+        ).toEqual({ country: "USA~FRA" })
+    })
+
+    it("stackMode", () => {
+        expect(
+            grapherConfigToQueryParams({
+                stackMode: StackMode.relative,
+            })
+        ).toEqual({ stackMode: "relative" })
+    })
+
+    it("combines multiple settings", () => {
+        expect(
+            grapherConfigToQueryParams({
+                minTime: 2000,
+                selectedEntityNames: ["United States", "France"],
+                stackMode: StackMode.relative,
+            })
+        ).toEqual({
+            time: "2000..latest",
+            country: "USA~FRA",
+            stackMode: "relative",
+        })
+    })
+})

--- a/packages/@ourworldindata/grapher/src/core/GrapherUrl.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherUrl.ts
@@ -6,6 +6,7 @@ import {
 } from "@ourworldindata/types"
 import { generateSelectedEntityNamesParam } from "./EntityUrlBuilder.js"
 import { match } from "ts-pattern"
+import { Grapher } from "./Grapher.js"
 
 // This function converts a (potentially partial) GrapherInterface to the query params this translates to.
 // This is helpful for when we have a patch config to a parent chart, and we want to know which query params we need to get the parent chart as close as possible to the patched child chart.
@@ -64,5 +65,35 @@ const grapherConfigToQueryParams = (
         },
         {} as GrapherQueryParams
     )
+    return params
+}
+
+export const grapherObjectToQueryParams = (
+    grapher: Grapher
+): GrapherQueryParams => {
+    const params: GrapherQueryParams = {
+        tab: grapher.mapGrapherTabToQueryParam(grapher.activeTab),
+        xScale: grapher.xAxis.scaleType,
+        yScale: grapher.yAxis.scaleType,
+        stackMode: grapher.stackMode,
+        zoomToSelection: grapher.zoomToSelection ? "true" : undefined,
+        endpointsOnly: grapher.compareEndPointsOnly ? "1" : "0",
+        time: grapher.timeParam,
+        region: grapher.map.projection,
+        facet: grapher.selectedFacetStrategy,
+        uniformYAxis:
+            grapher.yAxis.facetDomain === FacetAxisDomain.independent
+                ? "0"
+                : "1",
+        showSelectionOnlyInTable: grapher.showSelectionOnlyInDataTable
+            ? "1"
+            : "0",
+        showNoDataArea: grapher.showNoDataArea ? "1" : "0",
+        country: grapher.selectedEntitiesIfDifferentThanAuthors
+            ? generateSelectedEntityNamesParam(
+                  grapher.selectedEntitiesIfDifferentThanAuthors
+              )
+            : undefined,
+    }
     return params
 }

--- a/packages/@ourworldindata/grapher/src/core/GrapherUrl.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherUrl.ts
@@ -11,11 +11,14 @@ import { Grapher } from "./Grapher.js"
 // This function converts a (potentially partial) GrapherInterface to the query params this translates to.
 // This is helpful for when we have a patch config to a parent chart, and we want to know which query params we need to get the parent chart as close as possible to the patched child chart.
 // Note that some settings cannot be set in the config, so they are always set to undefined.
-const grapherConfigToQueryParams = (
+export const grapherConfigToQueryParams = (
     config: GrapherInterface
 ): GrapherQueryParams => {
-    const { minTime, maxTime } = config // can be a year, yyyy-mm-dd date, or "earliest" or "latest"
+    const { minTime, maxTime } = config // can be a number, or "earliest" or "latest"
 
+    // Note that this code will never format dates in yyyy-mm-dd format.
+    // For us to know that we're working with daily data, we need to have a DayColumn instance, which we only have when we have a grapher instance.
+    // Instead, we just serialize a date as a number - which also works fine for query params.
     const timeParam =
         minTime === maxTime
             ? minTime // This case also covers the case where both are undefined, in which case the result is also undefined

--- a/packages/@ourworldindata/grapher/src/core/GrapherUrl.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherUrl.ts
@@ -1,0 +1,68 @@
+import {
+    FacetAxisDomain,
+    GrapherInterface,
+    GrapherQueryParams,
+    TimeBoundValueStr,
+} from "@ourworldindata/types"
+import { generateSelectedEntityNamesParam } from "./EntityUrlBuilder.js"
+import { match } from "ts-pattern"
+
+// This function converts a (potentially partial) GrapherInterface to the query params this translates to.
+// This is helpful for when we have a patch config to a parent chart, and we want to know which query params we need to get the parent chart as close as possible to the patched child chart.
+// Note that some settings cannot be set in the config, so they are always set to undefined.
+const grapherConfigToQueryParams = (
+    config: GrapherInterface
+): GrapherQueryParams => {
+    const { minTime, maxTime } = config // can be a year, yyyy-mm-dd date, or "earliest" or "latest"
+
+    const timeParam =
+        minTime === maxTime
+            ? minTime // This case also covers the case where both are undefined, in which case the result is also undefined
+            : `${minTime ?? TimeBoundValueStr.unboundedLeft}..${maxTime ?? TimeBoundValueStr.unboundedRight}`
+
+    const paramsRaw: Record<
+        keyof GrapherQueryParams,
+        string | number | boolean | undefined
+    > = {
+        // TODO this can currently only be "chart", "map", or "table", but we should also allow for "slope" or "line" some way
+        tab: config.tab,
+        xScale: config.xAxis?.scaleType,
+        yScale: config.yAxis?.scaleType,
+        stackMode: config.stackMode,
+        zoomToSelection: config.zoomToSelection,
+        endpointsOnly: config.compareEndPointsOnly,
+        time: timeParam,
+        region: config.map?.projection,
+        facet: config.selectedFacetStrategy,
+        uniformYAxis: match(config.yAxis?.facetDomain)
+            .with(FacetAxisDomain.shared, () => 0)
+            .with(FacetAxisDomain.independent, () => 1)
+            .with(undefined, () => undefined)
+            .exhaustive(),
+        showNoDataArea: match(config.showNoDataArea)
+            .when(
+                (s) => typeof s === "boolean",
+                (s) => Number(s) // 1 or 0
+            )
+            .with(undefined, () => undefined)
+            .exhaustive(),
+        country: config.selectedEntityNames
+            ? generateSelectedEntityNamesParam(config.selectedEntityNames)
+            : undefined,
+
+        // These cannot be specified in config, so we always set them to undefined
+        showSelectionOnlyInTable: undefined,
+        overlay: undefined,
+    }
+
+    // Drop undefined values and convert all to string
+    const params = Object.entries(paramsRaw).reduce(
+        (acc, [currKey, currVal]) => {
+            if (currVal !== undefined)
+                acc[currKey as keyof GrapherQueryParams] = currVal.toString()
+            return acc
+        },
+        {} as GrapherQueryParams
+    )
+    return params
+}

--- a/packages/@ourworldindata/grapher/src/index.ts
+++ b/packages/@ourworldindata/grapher/src/index.ts
@@ -76,6 +76,7 @@ export {
     setSelectedEntityNamesParam,
     migrateSelectedEntityNamesParam,
     getSelectedEntityNamesParam,
+    generateSelectedEntityNamesParam,
 } from "./core/EntityUrlBuilder"
 export {
     type SlideShowManager,

--- a/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
+++ b/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
@@ -603,6 +603,7 @@ export interface LegacyGrapherInterface extends GrapherInterface {
 }
 
 export interface GrapherQueryParams extends QueryParams {
+    country?: string
     tab?: string
     overlay?: string
     stackMode?: string
@@ -611,9 +612,7 @@ export interface GrapherQueryParams extends QueryParams {
     yScale?: string
     time?: string
     region?: string
-    shown?: string
     endpointsOnly?: string
-    selection?: string
     facet?: string
     uniformYAxis?: string
     showSelectionOnlyInTable?: string
@@ -622,7 +621,6 @@ export interface GrapherQueryParams extends QueryParams {
 
 export interface LegacyGrapherQueryParams extends GrapherQueryParams {
     year?: string
-    country?: string // deprecated
 }
 
 // NOTE: This should list all keys of the LegacyGrapherQueryParams type. ATM
@@ -636,9 +634,7 @@ export const GRAPHER_QUERY_PARAM_KEYS: (keyof LegacyGrapherQueryParams)[] = [
     "yScale",
     "time",
     "region",
-    "shown",
     "endpointsOnly",
-    "selection",
     "facet",
     "uniformYAxis",
     "showSelectionOnlyInTable",

--- a/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
+++ b/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
@@ -625,25 +625,28 @@ export type LegacyGrapherQueryParams = GrapherQueryParams & {
     year?: string
 }
 
-// NOTE: This should list all keys of the LegacyGrapherQueryParams type. ATM
-// that can't be enforced with types.
-export const GRAPHER_QUERY_PARAM_KEYS: (keyof LegacyGrapherQueryParams)[] = [
-    "tab",
-    "overlay",
-    "stackMode",
-    "zoomToSelection",
-    "xScale",
-    "yScale",
-    "time",
-    "region",
-    "endpointsOnly",
-    "facet",
-    "uniformYAxis",
-    "showSelectionOnlyInTable",
-    "showNoDataArea",
-    "year",
-    "country",
-]
+// We don't use this anywhere, but this is a way to ensure that we have an object with all keys present
+// ... so GRAPHER_QUERY_PARAM_KEYS below is guaranteed to have all keys of LegacyGrapherQueryParams
+const GRAPHER_ALL_QUERY_PARAMS: Required<LegacyGrapherQueryParams> = {
+    country: "",
+    tab: "",
+    overlay: "",
+    stackMode: "",
+    zoomToSelection: "",
+    xScale: "",
+    yScale: "",
+    time: "",
+    region: "",
+    endpointsOnly: "",
+    facet: "",
+    uniformYAxis: "",
+    showSelectionOnlyInTable: "",
+    showNoDataArea: "",
+    year: "",
+}
+export const GRAPHER_QUERY_PARAM_KEYS = Object.keys(
+    GRAPHER_ALL_QUERY_PARAMS
+) as (keyof LegacyGrapherQueryParams)[]
 
 // Another approach we may want to try is this: https://github.com/mobxjs/serializr
 export const grapherKeysToSerialize = [

--- a/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
+++ b/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
@@ -4,7 +4,7 @@ import {
 } from "../OwidVariableDisplayConfigInterface.js"
 import { ColumnSlugs, EntityName } from "../domainTypes/CoreTableTypes.js"
 import { AxisAlign, Position } from "../domainTypes/Layout.js"
-import { Integer, QueryParams } from "../domainTypes/Various.js"
+import { Integer } from "../domainTypes/Various.js"
 import { DetailDictionary } from "../gdocTypes/Gdoc.js"
 import { observable } from "mobx"
 import {
@@ -602,7 +602,9 @@ export interface LegacyGrapherInterface extends GrapherInterface {
     data: any
 }
 
-export interface GrapherQueryParams extends QueryParams {
+// This is intentionally a `type` and not an `interface`, because the TS semantics make it so that this here can be assigned to a `Record<string, string>`.
+// See https://stackoverflow.com/q/64970414
+export type GrapherQueryParams = {
     country?: string
     tab?: string
     overlay?: string
@@ -619,7 +621,7 @@ export interface GrapherQueryParams extends QueryParams {
     showNoDataArea?: string
 }
 
-export interface LegacyGrapherQueryParams extends GrapherQueryParams {
+export type LegacyGrapherQueryParams = GrapherQueryParams & {
     year?: string
 }
 

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -230,6 +230,10 @@ export type AllKeysRequired<T> = AllowUndefinedValues<
 
 export type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>
 
+// doesn't do anything fancy, but makes it a bit more readable by skipping one layer of angle brackets:
+// PartialRecord<A, B> = Partial<Record<A, B>>
+export type PartialRecord<K extends keyof any, V> = Partial<Record<K, V>>
+
 // d3 v6 changed the default minus sign used in d3-format to "−" (Unicode minus sign), which looks
 // nicer but can cause issues when copy-pasting values into a spreadsheet or script.
 // For that reason we change that back to a plain old hyphen.

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -3,6 +3,7 @@ export {
     type NoUndefinedValues,
     type AllKeysRequired,
     type PartialBy,
+    type PartialRecord,
     createFormatter,
     getRelativeMouse,
     exposeInstanceOnWindow,

--- a/site/search/SearchUtils.tsx
+++ b/site/search/SearchUtils.tsx
@@ -1,5 +1,5 @@
 import { HitAttributeHighlightResult } from "instantsearch.js"
-import { EntityName } from "@ourworldindata/types"
+import { EntityName, GrapherQueryParams } from "@ourworldindata/types"
 import {
     Region,
     getRegionByNameOrVariantName,
@@ -9,7 +9,7 @@ import {
     lazy,
     Url,
 } from "@ourworldindata/utils"
-import { setSelectedEntityNamesParam } from "@ourworldindata/grapher"
+import { generateSelectedEntityNamesParam } from "@ourworldindata/grapher"
 
 /**
  * The below code is used to search for entities we can highlight in charts and explorer results.
@@ -121,12 +121,10 @@ export const getEntityQueryStr = (
 ) => {
     if (!entities?.length) return existingQueryStr
     else {
-        return setSelectedEntityNamesParam(
+        return Url.fromQueryStr(existingQueryStr).updateQueryParams({
             // If we have any entities pre-selected, we want to show the chart tab
-            Url.fromQueryStr(existingQueryStr).updateQueryParams({
-                tab: "chart",
-            }),
-            entities
-        ).queryStr
+            tab: "chart",
+            country: generateSelectedEntityNamesParam(entities),
+        } satisfies GrapherQueryParams).queryStr
     }
 }


### PR DESCRIPTION
The way we were handling grapher query params was subpar at best - including that some of the types were not an accurate reflection of the properties that can actually be set, and so on.

https://github.com/owid/owid-grapher/commit/d2da674f1599db3ee1a9016c6ae3df2a74d02006 's commit message explains the changes made to the `GrapherQueryParams` type, for example.
There were also some corners where we had less type-safety than we can have.

`grapherConfigToQueryParams` is not used yet, but I'll need it down the road for narrative views. It takes a (partial) chart config and converts it into the query params fitting to achieve this grapher state.