### PR TITLE
✨ show average daily pageviews in charts list and references tab

### DIFF
--- a/1733503871571-AddPageviewsUrlIndex.ts
+++ b/1733503871571-AddPageviewsUrlIndex.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class AddPageviewsUrlIndex1733503871571 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        // add an index on url of the analtyics_pageviews table
+        // we already have one on (day, url) but we never join that way
+        await queryRunner.query(
+            `CREATE INDEX analytics_pageviews_url_index ON analytics_pageviews (url)`
+        )
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP INDEX analytics_pageviews_url_index`)
+    }
+}

--- a/adminSiteClient/ChartIndexPage.tsx
+++ b/adminSiteClient/ChartIndexPage.tsx
@@ -12,6 +12,7 @@ import {
     highlightFunctionForSearchWords,
     SearchWord,
 } from "../adminShared/search.js"
+import { sortNumeric, SortOrder } from "@ourworldindata/utils"
 
 @observer
 export class ChartIndexPage extends React.Component {
@@ -56,13 +57,11 @@ export class ChartIndexPage extends React.Component {
 
         // Apply sorting if needed
         if (sortConfig?.field === "pageviewsPerDay") {
-            return [...filtered].sort((a, b) => {
-                const aValue = a.pageviewsPerDay || 0
-                const bValue = b.pageviewsPerDay || 0
-                return sortConfig.direction === "desc"
-                    ? bValue - aValue
-                    : aValue - bValue
-            })
+            return sortNumeric(
+                [...filtered],
+                (chart) => chart.pageviewsPerDay,
+                sortConfig.direction === "asc" ? SortOrder.asc : SortOrder.desc
+            )
         }
 
         return filtered

--- a/adminSiteClient/ChartList.tsx
+++ b/adminSiteClient/ChartList.tsx
@@ -38,13 +38,21 @@ export interface ChartListItem {
     isInheritanceEnabled?: boolean
 
     tags: DbChartTagJoin[]
+    pageviewsPerDay: number
 }
+
+export type SortConfig = {
+    field: "pageviewsPerDay"
+    direction: "asc" | "desc"
+} | null
 
 @observer
 export class ChartList extends React.Component<{
     charts: ChartListItem[]
     searchHighlight?: (text: string) => string | React.ReactElement
     onDelete?: (chart: ChartListItem) => void
+    onSort?: (sort: SortConfig) => void
+    sortConfig?: SortConfig
 }> {
     static contextType = AdminAppContext
     context!: AdminAppContextType
@@ -109,8 +117,23 @@ export class ChartList extends React.Component<{
     }
 
     render() {
-        const { charts, searchHighlight } = this.props
+        const { charts, searchHighlight, sortConfig, onSort } = this.props
         const { availableTags } = this
+
+        const getSortIndicator = () => {
+            if (!sortConfig || sortConfig.field !== "pageviewsPerDay") return ""
+            return sortConfig.direction === "desc" ? " ↓" : " ↑"
+        }
+
+        const handleSortClick = () => {
+            if (!sortConfig || sortConfig.field !== "pageviewsPerDay") {
+                onSort?.({ field: "pageviewsPerDay", direction: "desc" })
+            } else if (sortConfig.direction === "desc") {
+                onSort?.({ field: "pageviewsPerDay", direction: "asc" })
+            } else {
+                onSort?.(null)
+            }
+        }
 
         // if the first chart has inheritance information, we assume all charts have it
         const showInheritanceColumn =
@@ -128,6 +151,12 @@ export class ChartList extends React.Component<{
                         <th>Tags</th>
                         <th>Published</th>
                         <th>Last Updated</th>
+                        <th
+                            style={{ cursor: "pointer" }}
+                            onClick={handleSortClick}
+                        >
+                            views/day{getSortIndicator()}
+                        </th>
                         <th></th>
                         <th></th>
                     </tr>

--- a/adminSiteClient/ChartRow.tsx
+++ b/adminSiteClient/ChartRow.tsx
@@ -105,6 +105,7 @@ export class ChartRow extends React.Component<{
                         by={highlight(chart.lastEditedBy)}
                     />
                 </td>
+                <td>{chart.pageviewsPerDay?.toLocaleString() ?? "0"}</td>
                 <td>
                     <Link
                         to={`/charts/${chart.id}/edit`}

--- a/adminSiteClient/EditorReferencesTab.tsx
+++ b/adminSiteClient/EditorReferencesTab.tsx
@@ -13,6 +13,7 @@ import {
     formatValue,
     ChartRedirect,
     partition,
+    round,
 } from "@ourworldindata/utils"
 import { AbstractChartEditor, References } from "./AbstractChartEditor.js"
 import {
@@ -214,9 +215,7 @@ export class EditorReferencesTabForChart extends React.Component<{
                             </strong>{" "}
                             {this.renderPageview(
                                 this.pageviews?.views_365d
-                                    ? Math.round(
-                                          this.pageviews?.views_365d / 36.5
-                                      ) / 10
+                                    ? round(this.pageviews?.views_365d / 365, 1)
                                     : undefined
                             )}
                         </div>

--- a/adminSiteClient/EditorReferencesTab.tsx
+++ b/adminSiteClient/EditorReferencesTab.tsx
@@ -208,6 +208,18 @@ export class EditorReferencesTabForChart extends React.Component<{
                             <strong>Last 365 days:</strong>{" "}
                             {this.renderPageview(this.pageviews?.views_365d)}
                         </div>
+                        <div>
+                            <strong>
+                                Average pageviews per day over the last year:
+                            </strong>{" "}
+                            {this.renderPageview(
+                                this.pageviews?.views_365d
+                                    ? Math.round(
+                                          this.pageviews?.views_365d / 36.5
+                                      ) / 10
+                                    : undefined
+                            )}
+                        </div>
                     </div>
                     <small className="form-text text-muted">
                         Pageview numbers are inaccurate when the chart has been

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -715,6 +715,7 @@ getRouteWithROTransaction(apiRouter, "/charts.json", async (req, res, trx) => {
             SELECT ${oldChartFieldList} FROM charts
             JOIN chart_configs ON chart_configs.id = charts.configId
             JOIN users lastEditedByUser ON lastEditedByUser.id = charts.lastEditedByUserId
+            LEFT JOIN analytics_pageviews on analytics_pageviews.url = CONCAT("https://ourworldindata.org/grapher/", chart_configs.slug)
             LEFT JOIN users publishedByUser ON publishedByUser.id = charts.publishedByUserId
             ORDER BY charts.lastEditedAt DESC LIMIT ?
         `,
@@ -1558,6 +1559,7 @@ getRouteWithROTransaction(
                 JOIN chart_configs ON chart_configs.id = charts.configId
                 JOIN users lastEditedByUser ON lastEditedByUser.id = charts.lastEditedByUserId
                 LEFT JOIN users publishedByUser ON publishedByUser.id = charts.publishedByUserId
+                LEFT JOIN analytics_pageviews on analytics_pageviews.url = CONCAT("https://ourworldindata.org/grapher/", chart_configs.slug)
                 JOIN chart_dimensions cd ON cd.chartId = charts.id
                 WHERE cd.variableId = ?
                 GROUP BY charts.id
@@ -2044,6 +2046,7 @@ getRouteWithROTransaction(
                 JOIN variables AS v ON cd.variableId = v.id
                 JOIN users lastEditedByUser ON lastEditedByUser.id = charts.lastEditedByUserId
                 LEFT JOIN users publishedByUser ON publishedByUser.id = charts.publishedByUserId
+                LEFT JOIN analytics_pageviews on analytics_pageviews.url = CONCAT("https://ourworldindata.org/grapher/", chart_configs.slug)
                 WHERE v.datasetId = ?
                 GROUP BY charts.id
             `,
@@ -2441,6 +2444,7 @@ getRouteWithROTransaction(
                 LEFT JOIN chart_tags ct ON ct.chartId=charts.id
                 JOIN users lastEditedByUser ON lastEditedByUser.id = charts.lastEditedByUserId
                 LEFT JOIN users publishedByUser ON publishedByUser.id = charts.publishedByUserId
+                LEFT JOIN analytics_pageviews on analytics_pageviews.url = CONCAT("https://ourworldindata.org/grapher/", chart_configs.slug)
                 WHERE ct.tagId ${tagId === UNCATEGORIZED_TAG_ID ? "IS NULL" : "= ?"}
                 GROUP BY charts.id
                 ORDER BY charts.updatedAt DESC

--- a/db/model/Chart.ts
+++ b/db/model/Chart.ts
@@ -538,7 +538,8 @@ export const oldChartFieldList = `
         lastEditedByUser.fullName AS lastEditedBy,
         charts.publishedAt,
         charts.publishedByUserId,
-        publishedByUser.fullName AS publishedBy
+        publishedByUser.fullName AS publishedBy,
+        round(views_365d / 365, 1) as pageviewsPerDay
     `
 // TODO: replace this with getBySlug and pick
 


### PR DESCRIPTION
This was a small request by authors - surfacing pageviews more prominently is useful prioritizing work on charts.

This PR shows the average daily pageviews in the chart index page and allows users to sort by these pageviews.

An index on analytics_pageviews is added so that joins can be more performant