### PR TITLE
🐛 fix default gdoc thumbnails not rendering in gdocs

### DIFF
--- a/baker/algolia/utils/pages.ts
+++ b/baker/algolia/utils/pages.ts
@@ -162,7 +162,7 @@ function getGdocThumbnailUrl(gdoc: OwidGdocPostInterface): string {
     if (gdoc.content["featured-image"]) {
         return getThumbnailPath(gdoc.content["featured-image"])
     }
-    return `/${DEFAULT_GDOC_FEATURED_IMAGE}`
+    return `/images/published/${DEFAULT_GDOC_FEATURED_IMAGE}`
 }
 
 function generateGdocRecords(

--- a/site/search/SearchPanel.tsx
+++ b/site/search/SearchPanel.tsx
@@ -11,6 +11,7 @@ import {
     groupBy,
     uniqBy,
     Region,
+    DEFAULT_GDOC_FEATURED_IMAGE,
 } from "@ourworldindata/utils"
 import {
     InstantSearch,
@@ -65,6 +66,12 @@ import { ChartHit } from "./ChartHit.js"
 const siteAnalytics = new SiteAnalytics()
 
 function PagesHit({ hit }: { hit: IPageHit }) {
+    // a temporary fix for articles that have been indexed without the directory
+    const src =
+        hit.thumbnailUrl === `/${DEFAULT_GDOC_FEATURED_IMAGE}`
+            ? `/images/published/${DEFAULT_GDOC_FEATURED_IMAGE}`
+            : hit.thumbnailUrl
+
     return (
         <a
             href={`${BAKED_BASE_URL}/${hit.slug}`}
@@ -76,7 +83,7 @@ function PagesHit({ hit }: { hit: IPageHit }) {
             {hit.thumbnailUrl && (
                 <div className="search-results__page-hit-img-container">
                     <img
-                        src={hit.thumbnailUrl}
+                        src={src}
                         role="presentation"
                         className="search-results__page-hit-img"
                     />


### PR DESCRIPTION
Fixes the following whoopsie

![image](https://github.com/user-attachments/assets/c583cc35-2dc9-4f3a-9eef-b6b123c373c3)

![image](https://github.com/user-attachments/assets/b875bff7-8ad9-47f6-a319-3cbecc7a1c11)
