### PR TITLE
fix(admin): fix chart type failures when y dimension is missing

### DIFF
--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
@@ -577,6 +577,8 @@ export class DataTable extends React.Component<{
 
     @computed private get tableCaption(): React.ReactElement | null {
         if (this.hasDimensionHeaders) return null
+        if (this.displayDimensions.length === 0) return null
+
         const singleDimension = this.displayDimensions[0]
         const titleFragments = (singleDimension.display.columnName
             .attributionShort ||

--- a/packages/@ourworldindata/grapher/src/stackedCharts/AbstractStackedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/AbstractStackedChart.tsx
@@ -286,6 +286,8 @@ export class AbstractStackedChart
 
     @computed
     private get entitiesAsSeries(): readonly StackedRawSeries<number>[] {
+        if (!this.yColumns.length) return []
+
         const { isProjection, owidRowsByEntityName } = this.yColumns[0]
         return this.selectionArray.selectedEntityNames
             .map((seriesName) => {


### PR DESCRIPTION
I noticed that, in the admin, several chart types failed when creating a new chart and switching chart types before selecting a y variable: StackedArea and DataTable would just fail, with no way to recover from it.

![image](https://github.com/user-attachments/assets/9cca26f8-d0db-485d-ac6f-8a841f65d521)

![image](https://github.com/user-attachments/assets/77962cc9-4477-4999-acc7-54322caf323c)

