### PR TITLE
🐛 remove invalid buildkite step

### DIFF
--- a/adminSiteServer/mockSiteRouter.tsx
+++ b/adminSiteServer/mockSiteRouter.tsx
@@ -419,13 +419,6 @@ getPlainRouteWithROTransaction(
 )
 
 mockSiteRouter.use(
-    "/images/published",
-    express.static(path.join(DEFAULT_LOCAL_BAKE_DIR, "images/published"), {
-        fallthrough: false,
-    })
-)
-
-mockSiteRouter.use(
     // Not all /app/uploads paths are going through formatting
     // and being rewritten as /uploads. E.g. blog index images paths
     // on front page.

--- a/ops/buildkite/deploy-content
+++ b/ops/buildkite/deploy-content
@@ -108,9 +108,6 @@ create_dist() {
 
     "${RSYNC_COMMAND[@]}" live-data/bakedSite/ dist/
 
-    # remove .etag of gdoc images from dist
-    rm dist/images/published/*.etag
-
     # copy over Pages Functions as-is
     rsync -havzq --delete owid-grapher/functions dist/
     rsync -havzq owid-grapher/wrangler.toml dist/

--- a/packages/@ourworldindata/types/src/gdocTypes/GdocConstants.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/GdocConstants.ts
@@ -9,8 +9,6 @@ export const RESEARCH_AND_WRITING_ID = "research-writing"
 
 export const RESEARCH_AND_WRITING_DEFAULT_HEADING = "Research & Writing"
 
-export const IMAGES_DIRECTORY = "/images/published/"
-
 /** Works for:
  * https://docs.google.com/document/d/abcd1234
  * https://docs.google.com/document/d/abcd1234/

--- a/site/search/searchTypes.ts
+++ b/site/search/searchTypes.ts
@@ -31,9 +31,9 @@ export interface PageRecord {
     date?: string
     modifiedDate?: string
     tags?: string[]
-    // Either a URL (for WP posts) or a filepath (for GDocs)
     // WP example: https://ourworldindata.org/wp-content/uploads/2021/03/Biodiversity-thumbnail.png
-    // GDoc example: /images/published/artificial-intelligence-featured-image_100.png
+    // GDoc example: https://imagedelivery.net/our-id/image-uuid/w=512
+    // Fallback example: https://ourworldindta.org/default-thumbnail.png
     thumbnailUrl: string
     documentType?: "wordpress" | "gdoc" | "country-page"
 }


### PR DESCRIPTION
`rm dist/images/published/*.etag` no longer works as the directory no longer exists, causing builds to fail