### PR TITLE
🐛 fix cloudflare image UI issues

### DIFF
--- a/site/Lightbox.tsx
+++ b/site/Lightbox.tsx
@@ -37,18 +37,6 @@ function getActiveSourceImgUrl(img: HTMLImageElement): string | undefined {
     return undefined
 }
 
-// Cloudflare Images URLs end in w=1000, so we need to extract the filename from the URL
-// e.g. https://imagedelivery.net/owid-id/the-filename.png/w=1000 -> the-filename.png
-function getFilenameFromCloudflareUrl(url: string | undefined) {
-    if (!url) return undefined
-    const regex = /\/([^\/]+)\/w=/
-    const match = url.match(regex)
-    if (match) {
-        return match[1]
-    }
-    return undefined
-}
-
 const Lightbox = ({
     children,
     containerNode,
@@ -217,7 +205,8 @@ export const runLightbox = () => {
             const highResSrc = img.getAttribute("data-high-res-src")
             // If the image is a Gdoc Image with a smallFilename, get the source that is currently active
             const activeSourceImgUrl = getActiveSourceImgUrl(img)
-            const imgFilename = getFilenameFromCloudflareUrl(activeSourceImgUrl)
+            const imgFilename =
+                img.getAttribute("data-filename") || "owid-image"
 
             const imgSrc = highResSrc
                 ? // getAttribute doesn't automatically URI encode values, img.src does

--- a/site/gdocs/components/KeyInsights.tsx
+++ b/site/gdocs/components/KeyInsights.tsx
@@ -363,7 +363,7 @@ export const KeyInsights = ({
                                                     />
                                                 </div>
                                             </div>
-                                            <div className="span-cols-7 span-md-cols-12">
+                                            <div className="key-insight__asset-container span-cols-7 span-md-cols-12">
                                                 {renderAssetForInsight({
                                                     filename,
                                                     url,

--- a/site/gdocs/components/centered-article.scss
+++ b/site/gdocs/components/centered-article.scss
@@ -331,7 +331,8 @@ h3.article-block__heading {
     }
 }
 
-.article-block__image {
+.article-block__image,
+.key-insight__asset-container {
     width: 100%;
     margin: 32px 0;
 


### PR DESCRIPTION
2 small issues that were overlooked in the CF images work

- Lightbox download filenames weren't updated after the decision to stick with CF's guid's
- Key insights images weren't styling their download button correctly