### PR TITLE
Fix ETL staging server MDim caching issues

### DIFF
--- a/adminSiteServer/adminRouter.tsx
+++ b/adminSiteServer/adminRouter.tsx
@@ -363,7 +363,8 @@ getPlainRouteWithROTransaction(
             const renderedPage = await renderMultiDimDataPageFromConfig(
                 trx,
                 slug,
-                mdd.config
+                mdd.config,
+                true
             )
             res.send(renderedPage)
             return

--- a/baker/MultiDimBaker.tsx
+++ b/baker/MultiDimBaker.tsx
@@ -119,7 +119,8 @@ const getFaqEntries = async (
 export const renderMultiDimDataPageFromConfig = async (
     knex: db.KnexReadonlyTransaction,
     slug: string,
-    config: MultiDimDataPageConfigEnriched
+    config: MultiDimDataPageConfigEnriched,
+    isPreviewing: boolean = false
 ) => {
     // TAGS
     const tagToSlugMap = await getTagToSlugMap(knex)
@@ -142,6 +143,7 @@ export const renderMultiDimDataPageFromConfig = async (
         tagToSlugMap: minimalTagToSlugMap,
         faqEntries,
         primaryTopic,
+        isPreviewing,
     }
 
     return renderMultiDimDataPageFromProps(props)

--- a/functions/grapher/[slug].ts
+++ b/functions/grapher/[slug].ts
@@ -186,7 +186,7 @@ async function handleConfigRequest(
     }
 
     const cacheControl = shouldCache
-        ? "s-maxage=3600, max-age=0, must-revalidate"
+        ? "s-maxage=300, max-age=0, must-revalidate"
         : "no-cache"
 
     //grapherPageResp.headers.set("Cache-Control", cacheControl)

--- a/functions/grapher/by-uuid/[uuid].ts
+++ b/functions/grapher/by-uuid/[uuid].ts
@@ -87,7 +87,7 @@ async function handleConfigRequest(
     console.log("Grapher page response", grapherPageResp.grapherConfig.title)
 
     const cacheControl = shouldCache
-        ? "s-maxage=3600, max-age=0, must-revalidate"
+        ? "s-maxage=300, max-age=0, must-revalidate"
         : "no-cache"
 
     return Response.json(grapherPageResp.grapherConfig, {

--- a/functions/multi-dim/[slug].json.ts
+++ b/functions/multi-dim/[slug].json.ts
@@ -28,7 +28,7 @@ export const onRequestGet: PagesFunction<Env> = async ({
     }
 
     const cacheControl = shouldCache
-        ? "s-maxage=3600, max-age=0, must-revalidate"
+        ? "s-maxage=300, max-age=0, must-revalidate"
         : "no-cache"
 
     return new Response(grapherPageResp.body, {

--- a/site/multiDim/MultiDimDataPage.tsx
+++ b/site/multiDim/MultiDimDataPage.tsx
@@ -18,6 +18,7 @@ export function MultiDimDataPage({
     faqEntries,
     primaryTopic,
     initialQueryStr,
+    isPreviewing,
 }: MultiDimDataPageProps) {
     const canonicalUrl = `${baseGrapherUrl}/${slug}`
     const contentProps: MultiDimDataPageContentProps = {
@@ -81,6 +82,7 @@ export function MultiDimDataPage({
                 <SiteFooter
                     baseUrl={baseUrl}
                     context={SiteFooterContext.multiDimDataPage}
+                    isPreviewing={isPreviewing}
                 />
             </body>
         </Html>


### PR DESCRIPTION
This PR fixes an issue in the MDim workflow when working in the ETL with staging servers. This is the setup that a lot of data managers use.

Lucas reported that when he makes changes in the ETL on his machine and runs the ETL update targeting a staging server, MDim views would not get updated. 

It turns out that the reason this happens (and is different from the local workflow) is that on staging servers, /grapher/by-uuid/UUID.config.json is not handled by the mock site router but instead by CF functions (atm wrangler if I understand correctly, soon probably the CF preview deploy).

These CF functions have s-MaxAge set and so cache the results for a good while.

This PR enables the IsPreviewing flag that we use in the runSiteFooterScripts script and if it is set then reqeusts to the above url append ?nocache which then leads to the CF function (either wrangler or preview deploy) to request the freshest version from R2.

While I was at it I also reduced the cache times. These small json objects don't have to be cached for a full hour, 5 min should be plenty for prod.