### PR TITLE
✨ (data page) restrict Grapher to reasonable min height

### DIFF
--- a/site/DataPageContent.scss
+++ b/site/DataPageContent.scss
@@ -104,7 +104,6 @@
             // doesn't cover the full viewport height
             @include sm-up {
                 height: #{math.div(1, $ideal-ratio) * 100}vw;
-                min-height: $orientation-height;
                 max-height: calc(100vh - $header-height-sm - 110px);
             }
 


### PR DESCRIPTION
I think this very small min-height was set so that content below the fold is more often visible, but we went to far. The above given min-height (540px) is reasonable and should apply in all cases.

| Before | After |
|--------|--------|
| <img width="513" alt="Screenshot 2024-12-13 at 16 40 05" src="https://github.com/user-attachments/assets/7400fc3e-cdde-4aae-8b56-f4b624f47c9b" /> | <img width="513" alt="Screenshot 2024-12-13 at 16 40 18" src="https://github.com/user-attachments/assets/1c58b18f-bd60-425c-85e4-40e59be2df30" /> |