### PR TITLE
🐛 (data page) avoid horizontal page overflow

### DIFF
--- a/packages/@ourworldindata/components/src/IndicatorProcessing/IndicatorProcessing.scss
+++ b/packages/@ourworldindata/components/src/IndicatorProcessing/IndicatorProcessing.scss
@@ -40,7 +40,7 @@ div.indicator-processing {
         display: flex;
         flex-direction: column;
         background-color: var(--background);
-        margin: 32px -24px 0;
+        margin: 32px calc(-1 * var(--grid-gap)) 0;
         padding: 24px;
 
         .indicator-processing-callout__title {


### PR DESCRIPTION
Fixes an issue where horizontally dragging moves the whole page.

This happened because one of the elements had overflow.

https://github.com/user-attachments/assets/7835e9db-a546-429c-a0ec-c9dfdfee32ac

