### PR TITLE
🐛 hide full screen button when not useful

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -2419,9 +2419,10 @@ export class Grapher
     }
 
     @computed get hideFullScreenButton(): boolean {
-        const { windowInnerHeight } = this
-        if (!windowInnerHeight) return true
-        return this.windowInnerHeight! < this.frameBounds.height
+        // hide the full screen button if the full screen height
+        // is barely larger than the current chart height
+        const fullScreenHeight = this.windowInnerHeight!
+        return fullScreenHeight < this.frameBounds.height + 80
     }
 
     @computed private get availableWidth(): number {


### PR DESCRIPTION
This fixes a problem on mobile where showing/hiding the browser chrome (which happens on scroll) toggled the full screen button visibility, which lead to a jumpy layout.