### PR TITLE
🔨 (line legend) refactor label dropping algorithm

### DIFF
--- a/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.test.tsx
+++ b/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.test.tsx
@@ -176,10 +176,10 @@ describe("dropping labels", () => {
         })
 
         // the two outermost labels don't fit both into the available space.
-        // so 'Mexico' is picked instead of 'Democratic Republic of Congo'
+        // so 'Canada' is picked instead of 'United States of America'
         expect(lineLegend.visibleSeriesNames).toEqual([
-            "United States of America",
-            "Mexico",
+            "Canada",
+            "Democratic Republic of Congo",
         ])
     })
 

--- a/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.test.tsx
+++ b/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.test.tsx
@@ -2,11 +2,8 @@
 
 import { PartialBy } from "@ourworldindata/utils"
 import { AxisConfig } from "../axis/AxisConfig"
-import {
-    LEGEND_ITEM_MIN_SPACING,
-    LineLabelSeries,
-    LineLegend,
-} from "./LineLegend"
+import { LineLabelSeries, LineLegend } from "./LineLegend"
+import { LEGEND_ITEM_MIN_SPACING } from "./LineLegendConstants"
 
 const makeAxis = ({
     min = 0,
@@ -94,8 +91,8 @@ describe("dropping labels", () => {
 
         // 'Democratic Republic of Congo' is skipped since it doesn't fit
         expect(lineLegend.visibleSeriesNames).toEqual([
-            "Mexico",
             "Canada",
+            "Mexico",
             "Spain",
         ])
     })
@@ -162,6 +159,28 @@ describe("dropping labels", () => {
         })
 
         expect(lineLegend.visibleSeriesNames).toEqual(["Canada", "France"])
+    })
+
+    it("picks labels from the edges, skipping long labels", () => {
+        const series = makeSeries([
+            { seriesName: "United States of America", yValue: 5 },
+            { seriesName: "Canada", yValue: 10 },
+            { seriesName: "Mexico", yValue: 50 },
+            { seriesName: "Democratic Republic of Congo", yValue: 90 },
+        ])
+
+        const lineLegend = new LineLegend({
+            series,
+            maxWidth: 100,
+            yAxis: makeAxis({ yRange: [0, 60] }),
+        })
+
+        // the two outermost labels don't fit both into the available space.
+        // so 'Mexico' is picked instead of 'Democratic Republic of Congo'
+        expect(lineLegend.visibleSeriesNames).toEqual([
+            "United States of America",
+            "Mexico",
+        ])
     })
 
     it("picks labels in a balanced way", () => {

--- a/packages/@ourworldindata/grapher/src/lineLegend/LineLegendConstants.ts
+++ b/packages/@ourworldindata/grapher/src/lineLegend/LineLegendConstants.ts
@@ -1,0 +1,13 @@
+import { GRAY_70 } from "../color/ColorConstants.js"
+
+// text color for labels of background series
+export const NON_FOCUSED_TEXT_COLOR = GRAY_70
+// Minimum vertical space between two legend items
+export const LEGEND_ITEM_MIN_SPACING = 4
+// Horizontal distance from the end of the chart to the start of the marker
+export const MARKER_MARGIN = 4
+// Space between the label and the annotation
+export const ANNOTATION_PADDING = 1
+
+export const DEFAULT_CONNECTOR_LINE_WIDTH = 25
+export const DEFAULT_FONT_WEIGHT = 400

--- a/packages/@ourworldindata/grapher/src/lineLegend/LineLegendFilterAlgorithms.ts
+++ b/packages/@ourworldindata/grapher/src/lineLegend/LineLegendFilterAlgorithms.ts
@@ -1,0 +1,140 @@
+import { maxBy, partition } from "@ourworldindata/utils"
+import {
+    computeCandidateScores,
+    LineLegendFilterAlgorithmContext,
+    pickAsManyAsPossibleWithRetry,
+    pickCandidateWithMaxDistanceToReferenceCandidate,
+    pickCandidateWithRetry,
+    pickOutermostCanidate,
+} from "./LineLegendHelpers"
+import { PlacedSeries } from "./LineLegendTypes"
+
+/**
+ * Keep a subset of series that fit within the available height, prioritizing by
+ * importance. Focused series have priority, even if they're less important.
+ *
+ * Note that more important (but longer) series names might be skipped if they don't fit.
+ */
+export function findImportantSeriesThatFitIntoTheAvailableSpace(
+    seriesSortedByImportance: PlacedSeries[],
+    availableHeight: number
+) {
+    let context: LineLegendFilterAlgorithmContext = {
+        candidates: new Set(seriesSortedByImportance),
+        availableHeight,
+        sortedKeepSeries: [],
+        keepSeriesHeight: 0,
+    }
+
+    const [focusedCandidates, nonFocusedCandidates] = partition(
+        seriesSortedByImportance,
+        (series) => series.focus?.active
+    )
+
+    const importanceScore = new Map(
+        seriesSortedByImportance.map((series, index) => [
+            series.seriesName,
+            -index, // higher index means lower importance
+        ])
+    )
+
+    const pop = (candidates: PlacedSeries[]) =>
+        maxBy(candidates, (c) => importanceScore.get(c.seriesName))
+
+    // focused series have priority
+    context = pickAsManyAsPossibleWithRetry({
+        context,
+        candidateSubset: focusedCandidates,
+        popCandidateFromSubset: pop,
+    })
+
+    context = pickAsManyAsPossibleWithRetry({
+        context,
+        candidateSubset: nonFocusedCandidates,
+        popCandidateFromSubset: pop,
+    })
+
+    return context.sortedKeepSeries
+}
+
+/**
+ * Pick a subset of series that fit within the available height.
+ *
+ * The algorithm tries to pick labels in a 'balanced' way such that they're
+ * spread out as much as possible. Focused series have priority.
+ *
+ * The algorithm works as follows: Given a set of placed labels and a set of
+ * candidates, for each candidate, we find the two closest already placed labels,
+ * one to each side, and calculate a score based on the available space between
+ * the two placed labels (the bigger, the better) and the candidate's distance to
+ * the midpoint (the smaller, the better). We then pick the candidate with the best
+ * score that fits into the available space.
+ */
+export function findSeriesThatFitIntoTheAvailableSpace(
+    series: PlacedSeries[],
+    availableHeight: number
+): PlacedSeries[] {
+    let context: LineLegendFilterAlgorithmContext = {
+        candidates: new Set(series),
+        availableHeight,
+        sortedKeepSeries: [],
+        keepSeriesHeight: 0,
+    }
+
+    const [focusedCandidates, nonFocusedCandidates] = partition(
+        series,
+        (series) => series.focus?.active
+    )
+
+    // focused series have priority
+    context = pickAsManyAsPossibleWithRetry({
+        context,
+        candidateSubset: focusedCandidates,
+    })
+
+    // we initially need to pick at least two candidates
+    const numPickedCandidates = context.sortedKeepSeries.length
+    if (numPickedCandidates === 0) {
+        // pick two candidates with maximal distance to each other
+        context = pickOutermostCanidate({
+            context,
+            candidateSubset: nonFocusedCandidates,
+        })
+        context = pickCandidateWithMaxDistanceToReferenceCandidate({
+            context,
+            candidateSubset: nonFocusedCandidates,
+            referenceCandidate: context.sortedKeepSeries[0],
+        })
+    } else if (numPickedCandidates === 1) {
+        // pick the candidate that is furthest away from the focused label
+        context = pickCandidateWithMaxDistanceToReferenceCandidate({
+            context,
+            candidateSubset: nonFocusedCandidates,
+            referenceCandidate: context.sortedKeepSeries[0],
+        })
+    }
+
+    // pick candidates based on a scoring system
+    while (
+        context.candidates.size > 0 &&
+        context.keepSeriesHeight <= availableHeight
+    ) {
+        const candidates = Array.from(context.candidates)
+        const scoreMap = computeCandidateScores(
+            candidates,
+            context.sortedKeepSeries
+        )
+
+        // pick the candidate with the highest score
+        const pop = (candidates: PlacedSeries[]) =>
+            maxBy(candidates, (c) => scoreMap.get(c.seriesName))
+
+        context = pickCandidateWithRetry({
+            context,
+            candidateSubset: candidates,
+            popCandidateFromSubset: pop,
+        })
+    }
+
+    return context.sortedKeepSeries
+}

--- a/packages/@ourworldindata/grapher/src/lineLegend/LineLegendHelpers.ts
+++ b/packages/@ourworldindata/grapher/src/lineLegend/LineLegendHelpers.ts
@@ -1,0 +1,286 @@
+import {
+    last,
+    maxBy,
+    minBy,
+    SeriesName,
+    sortedIndexBy,
+} from "@ourworldindata/utils"
+import { PlacedSeries } from "./LineLegendTypes"
+import { LEGEND_ITEM_MIN_SPACING } from "./LineLegendConstants"
+
+type Bracket = [number, number]
+
+export interface LineLegendFilterAlgorithmContext {
+    candidates: Set<PlacedSeries> // remaining candidates to be considered for placement
+    availableHeight: number
+    sortedKeepSeries: PlacedSeries[] // series that have been picked to be labelled, sorted by their y position
+    keepSeriesHeight: number // total height of the picked series
+}
+
+interface PickFromCandidateSubsetParams {
+    context: LineLegendFilterAlgorithmContext
+    candidateSubset: PlacedSeries[]
+    popCandidateFromSubset?: (
+        candidateSubset: PlacedSeries[]
+    ) => PlacedSeries | undefined
+}
+
+const dist = (c1: PlacedSeries, c2: PlacedSeries) => Math.abs(c1.midY - c2.midY)
+
+function getNewHeight(currentHeight: number, candidate: PlacedSeries): number {
+    // if the candidate is the first one, don't add padding
+    const padding = currentHeight === 0 ? 0 : LEGEND_ITEM_MIN_SPACING
+    return currentHeight + candidate.bounds.height + padding
+}
+
+/**
+ * Given a sorted list of brackets, like [[0, 10], [10, 20], [20, 30]],
+ * find the bracket that contains the given number n.
+ */
+function findBracket(
+    sortedBrackets: Bracket[],
+    n: number
+): [number | undefined, number | undefined] {
+    if (sortedBrackets.length === 0) return [undefined, undefined]
+
+    const firstBracketValue = sortedBrackets[0][0]
+    const lastBracketValue = last(sortedBrackets)![1]
+
+    if (n < firstBracketValue) return [undefined, firstBracketValue]
+    if (n >= lastBracketValue) return [lastBracketValue, undefined]
+
+    for (const bracket of sortedBrackets) {
+        if (n >= bracket[0] && n < bracket[1]) return bracket
+    }
+
+    return [undefined, undefined]
+}
+
+/**
+ * Add a candidate to the list of picked series and update the context accordingly.
+ */
+function pickCandidate(
+    context: LineLegendFilterAlgorithmContext,
+    candidate: PlacedSeries
+): LineLegendFilterAlgorithmContext {
+    let { candidates, sortedKeepSeries, keepSeriesHeight } = context
+
+    // insert into sortedKeepSeries at the right position
+    const insertIndex = sortedIndexBy(
+        context.sortedKeepSeries,
+        candidate,
+        (s) => s.midY
+    )
+    sortedKeepSeries.splice(insertIndex, 0, candidate)
+
+    // update keepSeriesHeight
+    keepSeriesHeight = getNewHeight(keepSeriesHeight, candidate)
+
+    // delete from candidates
+    candidates.delete(candidate)
+
+    return { ...context, candidates, sortedKeepSeries, keepSeriesHeight }
+}
+
+/**
+ * Remove a candidate from the list of candidates to be considered for placement.
+ */
+function dismissCandidate(
+    context: LineLegendFilterAlgorithmContext,
+    candidate: PlacedSeries
+) {
+    const { candidates } = context
+    candidates.delete(candidate)
+    return { ...context, candidates }
+}
+
+/**
+ * Pick from a subset of candidates until one of the following conditions is met:
+ * - no candidates are left or the maximum number of candidates to pick is reached
+ * - no more candidates fit into the available space
+ *
+ * The order of candidates to consider for placement is determined by the
+ * `popCandidateFromSubset` function. The function should return the next candidate
+ * to consider. If the function returns `undefined`, the algorithm stops.
+ *
+ * If no custom function is provided, the algorithm picks candidates starting from
+ * the end (!) of the given list.
+ */
+function pickFromCandidateSubsetWithRetry(
+    params: PickFromCandidateSubsetParams & { maxCandidatesToPick?: number }
+): LineLegendFilterAlgorithmContext {
+    let {
+        context,
+        candidateSubset,
+        popCandidateFromSubset,
+        maxCandidatesToPick,
+    } = params
+
+    if (candidateSubset.length === 0 || maxCandidatesToPick === 0)
+        return context
+
+    const remainingCandidates = [...candidateSubset]
+    let numPicked = 0
+
+    // if a custom function to pop candidates is provided, use it
+    // otherwise, pop the last candidate
+    const popCandidate = (): PlacedSeries | undefined => {
+        if (popCandidateFromSubset) {
+            const candidate = popCandidateFromSubset(remainingCandidates)
+            if (candidate) {
+                const index = remainingCandidates.indexOf(candidate)
+                remainingCandidates.splice(index, 1)
+            }
+            return candidate
+        }
+
+        return remainingCandidates.pop()
+    }
+
+    while (remainingCandidates.length > 0) {
+        const candidate = popCandidate()
+        if (!candidate) break
+
+        // sanity check if this is a valid candidate
+        if (!context.candidates.has(candidate)) continue
+
+        // either pick or dismiss the candidate
+        const newHeight = getNewHeight(context.keepSeriesHeight, candidate)
+        if (newHeight <= context.availableHeight) {
+            context = pickCandidate(context, candidate)
+            numPicked++
+        } else {
+            context = dismissCandidate(context, candidate)
+        }
+
+        // stop if we picked enough candidates
+        if (numPicked === maxCandidatesToPick) break
+    }
+
+    return context
+}
+
+/**
+ * Pick as many candidates as possible from a given subset.
+ *
+ * The order of candidates to consider for placement is determined by the
+ * `popCandidateFromSubset` function. The function should return the next candidate
+ * to consider. If the function returns `undefined`, the algorithm stops.
+ *
+ * If no custom function is provided, the algorithm picks candidates starting from
+ * the end (!) of the given list.
+ */
+export function pickAsManyAsPossibleWithRetry(
+    params: PickFromCandidateSubsetParams
+): LineLegendFilterAlgorithmContext {
+    return pickFromCandidateSubsetWithRetry(params)
+}
+
+/**
+ * Pick a fixed number of candidates from a give subset.
+ *
+ * The order of candidates to consider for placement is determined by the
+ * `popCandidateFromSubset` function. The function should return the next candidate
+ * to consider. If the function returns `undefined`, the algorithm stops.
+ *
+ * If no custom function is provided, the algorithm picks candidates starting from
+ * the end (!) of the given list.
+ */
+export function pickCandidateWithRetry(
+    params: PickFromCandidateSubsetParams
+): LineLegendFilterAlgorithmContext {
+    return pickFromCandidateSubsetWithRetry({
+        ...params,
+        maxCandidatesToPick: 1,
+    })
+}
+
+export function pickCandidateWithMaxDistanceToReferenceCandidate(params: {
+    context: LineLegendFilterAlgorithmContext
+    candidateSubset: PlacedSeries[]
+    referenceCandidate: PlacedSeries
+}): LineLegendFilterAlgorithmContext {
+    const { context, candidateSubset, referenceCandidate } = params
+    const distanceMap = new Map(
+        candidateSubset.map((c) => [c.seriesName, dist(c, referenceCandidate)])
+    )
+    const pop = (candidates: PlacedSeries[]) =>
+        maxBy(candidates, (c) => distanceMap.get(c.seriesName))
+
+    return pickCandidateWithRetry({
+        context,
+        candidateSubset,
+        popCandidateFromSubset: pop,
+    })
+}
+
+export function pickOutermostCanidate(params: {
+    context: LineLegendFilterAlgorithmContext
+    candidateSubset: PlacedSeries[]
+}): LineLegendFilterAlgorithmContext {
+    const { context, candidateSubset } = params
+
+    if (candidateSubset.length === 0) return context
+
+    if (candidateSubset.length === 1) {
+        return pickCandidate(context, candidateSubset[1])
+    }
+
+    const minCandidate = minBy(candidateSubset, (c) => c.midY)!
+    const maxCanidate = maxBy(candidateSubset, (c) => c.midY)!
+    const distanceMap = new Map(
+        candidateSubset.map((c) => [
+            c.seriesName,
+            Math.min(dist(minCandidate, c), dist(maxCanidate, c)),
+        ])
+    )
+
+    const pop = (candidates: PlacedSeries[]) =>
+        minBy(candidates, (c) => distanceMap.get(c.seriesName))
+
+    return pickCandidateWithRetry({
+        context,
+        candidateSubset,
+        popCandidateFromSubset: pop,
+    })
+}
+
+/**
+ * Compute a score for each candidate based on how large the space between the
+ * neighboring labels is and how far it is from the mid point of the neighboring
+ * labels.
+ */
+export function computeCandidateScores(
+    candidates: PlacedSeries[],
+    sortedKeepSeries: PlacedSeries[]
+): Map<SeriesName, number> {
+    const scoreMap = new Map<SeriesName, number>()
+
+    const sortedBrackets = sortedKeepSeries
+        .slice(0, -1)
+        .map((s, i) => [s.midY, sortedKeepSeries[i + 1].midY])
+        .filter((bracket) => bracket[0] !== bracket[1]) as Bracket[]
+
+    // score each candidate based on how well it fits into the available space
+    for (const candidate of candidates) {
+        // find the bracket that the candidate is contained in
+        const [start, end] = findBracket(sortedBrackets, candidate.midY)
+
+        // if no bracket is found, return the worst possible score
+        if (end === undefined || start === undefined) {
+            scoreMap.set(candidate.seriesName, 0)
+            continue
+        }
+
+        // score the candidate based on how far it is from the
+        // middle of the bracket and how large the bracket is
+        const length = end - start
+        const midPoint = start + length / 2
+        const distanceFromMidPoint = Math.abs(candidate.midY - midPoint)
+        const score = length - distanceFromMidPoint
+
+        scoreMap.set(candidate.seriesName, score)
+    }
+
+    return scoreMap
+}

--- a/packages/@ourworldindata/grapher/src/lineLegend/LineLegendTypes.ts
+++ b/packages/@ourworldindata/grapher/src/lineLegend/LineLegendTypes.ts
@@ -1,0 +1,31 @@
+import { TextWrap, TextWrapGroup } from "@ourworldindata/components"
+import { Bounds, InteractionState } from "@ourworldindata/utils"
+import { ChartSeries } from "../chart/ChartInterface"
+
+export interface LineLabelSeries extends ChartSeries {
+    label: string
+    yValue: number
+    annotation?: string
+    formattedValue?: string
+    placeFormattedValueInNewLine?: boolean
+    yRange?: [number, number]
+    hover?: InteractionState
+    focus?: InteractionState
+}
+
+export interface SizedSeries extends LineLabelSeries {
+    textWrap: TextWrap | TextWrapGroup
+    annotationTextWrap?: TextWrap
+    width: number
+    height: number
+    fontWeight?: number
+}
+
+export interface PlacedSeries extends SizedSeries {
+    origBounds: Bounds
+    bounds: Bounds
+    repositions: number
+    level: number
+    totalLevels: number
+    midY: number
+}

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
@@ -732,13 +732,6 @@ export class SlopeChart
                 const PREFER_S1 = -1
                 const PREFER_S2 = 1
 
-                const s1_isFocused = this.focusArray.has(s1)
-                const s2_isFocused = this.focusArray.has(s2)
-
-                // prefer to label focused series
-                if (s1_isFocused && !s2_isFocused) return PREFER_S1
-                if (s2_isFocused && !s1_isFocused) return PREFER_S2
-
                 const s1_isLabelled = this.visibleLineLegendLabelsRight.has(s1)
                 const s2_isLabelled = this.visibleLineLegendLabelsRight.has(s2)
 


### PR DESCRIPTION
Refactors the code that is responsible for dropping labels if there is not enough space.

The SVG tester comes back with one additional difference. It's a slope charts where the 'Tanzania' and 'Mali' labels are swapped. Tanzania should be on top (its value is 1339) and 'Mali' should be below (its value is 1337), so the updated chart is correct. 