### PR TITLE
Fix gdoc component extraction

### DIFF
--- a/db/model/Gdoc/extractGdocComponentInfo.ts
+++ b/db/model/Gdoc/extractGdocComponentInfo.ts
@@ -68,7 +68,7 @@ function iterateArrayProp<T extends OwidEnrichedGdocBlock>(
     parentPath: string,
     prop: keyof T
 ): ChildIterationInfo[] {
-    if (prop in parent)
+    if (parent[prop])
         return (parent[prop] as OwidEnrichedGdocBlock[]).map(
             (child, index) => ({
                 child: child,

--- a/db/model/Gdoc/extractGdocComponentInfo.ts
+++ b/db/model/Gdoc/extractGdocComponentInfo.ts
@@ -68,11 +68,15 @@ function iterateArrayProp<T extends OwidEnrichedGdocBlock>(
     parentPath: string,
     prop: keyof T
 ): ChildIterationInfo[] {
-    return (parent[prop] as OwidEnrichedGdocBlock[]).map((child, index) => ({
-        child: child,
-        parentPath: `${parentPath}`,
-        path: `${parentPath}.${String(prop)}[${index}]`,
-    }))
+    if (prop in parent)
+        return (parent[prop] as OwidEnrichedGdocBlock[]).map(
+            (child, index) => ({
+                child: child,
+                parentPath: `${parentPath}`,
+                path: `${parentPath}.${String(prop)}[${index}]`,
+            })
+        )
+    else return []
 }
 
 /** Convert the spans in a gdoc component to plain text.


### PR DESCRIPTION
This fixes a bug when gdoc components have optional properties that are enumerated by the gdoc component extraction code