### PR TITLE
🐛 fix cloudflare image version management

### DIFF
--- a/adminSiteClient/ImagesIndexPage.tsx
+++ b/adminSiteClient/ImagesIndexPage.tsx
@@ -554,10 +554,14 @@ export function ImageIndexPage() {
                     image: DbEnrichedImageWithUserId
                 }>(`/api/images/${id}`, payload, "PUT")
                 if (response.success) {
-                    setImages((prevMap) => ({
-                        ...prevMap,
-                        [id]: response.image,
-                    }))
+                    setImages((prevMap) => {
+                        const nextMap = { ...prevMap }
+                        delete nextMap[id]
+                        return {
+                            ...nextMap,
+                            [response.image.id]: response.image,
+                        }
+                    })
                 }
             },
             postUserImage: async (user, image) => {

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -3225,7 +3225,7 @@ putRouteWithRWTransaction(apiRouter, "/images/:id", async (req, res, trx) => {
     if (collision) {
         return {
             success: false,
-            error: `An image with this content already exists (filename: ${collision.filename})`,
+            error: `An exact copy of this image already exists (filename: ${collision.filename})`,
         }
     }
 
@@ -3263,6 +3263,7 @@ putRouteWithRWTransaction(apiRouter, "/images/:id", async (req, res, trx) => {
         updatedAt: new Date().getTime(),
         userId: res.locals.user.id,
         hash,
+        version: image.version + 1,
     })
 
     await trx<DbEnrichedImage>("images").where("id", "=", id).update({

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -212,6 +212,7 @@ import {
     uploadToCloudflare,
     validateImagePayload,
 } from "./imagesHelpers.js"
+import pMap from "p-map"
 
 const apiRouter = new FunctionalRouter()
 
@@ -3152,7 +3153,10 @@ postRouteWithRWTransaction(apiRouter, "/images", async (req, res, trx) => {
     )
 
     const collision = await trx<DbEnrichedImage>("images")
-        .where("hash", "=", hash)
+        .where({
+            hash,
+            replacedBy: null,
+        })
         .first()
 
     if (collision) {
@@ -3201,9 +3205,9 @@ postRouteWithRWTransaction(apiRouter, "/images", async (req, res, trx) => {
 })
 
 /**
- * Similar to the POST route, but for updating an existing image. Deletes the image
- * from Cloudflare and re-uploads it with the new content. The filename will stay the same,
- * but the dimensions and cloudflareId will be updated.
+ * Similar to the POST route, but for updating an existing image.
+ * Creates a new image entry in the database and uploads the new image to Cloudflare.
+ * The old image is marked as replaced by the new image.
  */
 putRouteWithRWTransaction(apiRouter, "/images/:id", async (req, res, trx) => {
     const { type, content } = validateImagePayload(req.body)
@@ -3212,7 +3216,10 @@ putRouteWithRWTransaction(apiRouter, "/images/:id", async (req, res, trx) => {
         type
     )
     const collision = await trx<DbEnrichedImage>("images")
-        .where("hash", "=", hash)
+        .where({
+            hash,
+            replacedBy: null,
+        })
         .first()
 
     if (collision) {
@@ -3242,22 +3249,32 @@ putRouteWithRWTransaction(apiRouter, "/images/:id", async (req, res, trx) => {
         )
     }
 
-    await deleteFromCloudflare(originalCloudflareId)
     const newCloudflareId = await uploadToCloudflare(originalFilename, asBlob)
 
     if (!newCloudflareId) {
         throw new JsonError("Failed to upload image", 500)
     }
 
-    await trx<DbEnrichedImage>("images").where("id", "=", id).update({
+    const [newImageId] = await trx<DbEnrichedImage>("images").insert({
+        filename: originalFilename,
         originalWidth: dimensions.width,
         originalHeight: dimensions.height,
-        updatedAt: new Date().getTime(),
         cloudflareId: newCloudflareId,
+        updatedAt: new Date().getTime(),
+        userId: res.locals.user.id,
         hash,
     })
 
+    await trx<DbEnrichedImage>("images").where("id", "=", id).update({
+        replacedBy: newImageId,
+    })
+
     const updated = await db.getCloudflareImage(trx, originalFilename)
+
+    await triggerStaticBuild(
+        res.locals.user,
+        `Updating image "${originalFilename}"`
+    )
 
     return {
         success: true,
@@ -3296,32 +3313,39 @@ patchRouteWithRWTransaction(apiRouter, "/images/:id", async (req, res, trx) => {
     }
 })
 
-deleteRouteWithRWTransaction(
-    apiRouter,
-    "/images/:id",
-    async (req, res, trx) => {
-        const { id } = req.params
+deleteRouteWithRWTransaction(apiRouter, "/images/:id", async (req, _, trx) => {
+    const { id } = req.params
 
-        const image = await trx<DbEnrichedImage>("images")
-            .where("id", "=", id)
-            .first()
+    const image = await trx<DbEnrichedImage>("images")
+        .where("id", "=", id)
+        .first()
 
-        if (!image) {
-            throw new JsonError(`No image found for id ${id}`, 404)
-        }
-        if (!image.cloudflareId) {
-            throw new JsonError(`Image does not have a cloudflare ID`, 400)
-        }
-
-        await deleteFromCloudflare(image.cloudflareId)
-
-        await trx("images").where({ id }).delete()
-
-        return {
-            success: true,
-        }
+    if (!image) {
+        throw new JsonError(`No image found for id ${id}`, 404)
     }
-)
+    if (!image.cloudflareId) {
+        throw new JsonError(`Image does not have a cloudflare ID`, 400)
+    }
+
+    const replacementChain = await db.selectReplacementChainForImage(trx, id)
+
+    await pMap(
+        replacementChain,
+        async (image) => {
+            if (image.cloudflareId) {
+                await deleteFromCloudflare(image.cloudflareId)
+            }
+        },
+        { concurrency: 5 }
+    )
+
+    // There's an ON DELETE CASCADE which will delete the replacements
+    await trx("images").where({ id }).delete()
+
+    return {
+        success: true,
+    }
+})
 
 getRouteWithROTransaction(apiRouter, "/images/usage", async (_, __, trx) => {
     const usage = await db.getImageUsage(trx)

--- a/db/migration/1734369183234-CloudflareImagesReplacedBy.ts
+++ b/db/migration/1734369183234-CloudflareImagesReplacedBy.ts
@@ -4,51 +4,37 @@ export class CloudflareImagesReplacedBy1734369183234
     implements MigrationInterface
 {
     public async up(queryRunner: QueryRunner): Promise<void> {
-        // Drop the existing unique key on filename
         await queryRunner.query(`-- sql
             ALTER TABLE images
             DROP KEY filename
         `)
 
-        // Add the replacedBy column
         await queryRunner.query(`-- sql
             ALTER TABLE images 
             ADD COLUMN replacedBy INT NULL,
+            ADD COLUMN version INT NOT NULL DEFAULT 0,
             ADD CONSTRAINT fk_images_replaced_by 
                 FOREIGN KEY (replacedBy) 
                 REFERENCES images(id)
                 ON DELETE CASCADE
-                ON UPDATE CASCADE
-        `)
-
-        // Add unique constraint on replacedBy and filename
-        await queryRunner.query(`-- sql
-            ALTER TABLE images
-            ADD CONSTRAINT uk_images_replaced_by_filename 
-            UNIQUE (replacedBy, filename)
+                ON UPDATE CASCADE,
+            ADD CONSTRAINT uk_images_filename_version
+                UNIQUE (filename, version)
         `)
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
-        // First remove the foreign key constraint
         await queryRunner.query(`-- sql
             ALTER TABLE images
             DROP FOREIGN KEY fk_images_replaced_by
         `)
 
-        // Then remove the combined unique constraint
         await queryRunner.query(`-- sql
             ALTER TABLE images
-            DROP KEY uk_images_replaced_by_filename
+            DROP COLUMN replacedBy,
+            DROP COLUMN version
         `)
 
-        // Remove the column
-        await queryRunner.query(`-- sql
-            ALTER TABLE images
-            DROP COLUMN replacedBy
-        `)
-
-        // Restore the original unique key on filename
         await queryRunner.query(`-- sql
             ALTER TABLE images
             ADD UNIQUE KEY filename (filename)

--- a/db/migration/1734369183234-CloudflareImagesReplacedBy.ts
+++ b/db/migration/1734369183234-CloudflareImagesReplacedBy.ts
@@ -1,0 +1,52 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class CloudflareImagesReplacedBy1734369183234
+    implements MigrationInterface
+{
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        // Drop the existing unique key on filename
+        await queryRunner.query(`-- sql
+            ALTER TABLE images
+            DROP KEY filename
+        `)
+
+        // Add the replacedBy column
+        await queryRunner.query(`-- sql
+            ALTER TABLE images 
+            ADD COLUMN replacedBy INT NULL,
+            ADD CONSTRAINT fk_images_replaced_by 
+                FOREIGN KEY (replacedBy) 
+                REFERENCES images(id)
+                ON DELETE CASCADE
+                ON UPDATE CASCADE
+        `)
+
+        // Add unique constraint on replacedBy and filename
+        await queryRunner.query(`-- sql
+            ALTER TABLE images
+            ADD CONSTRAINT uk_images_replaced_by_filename 
+            UNIQUE (replacedBy, filename)
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        // Remove the combined unique constraint
+        await queryRunner.query(`-- sql
+            ALTER TABLE images
+            DROP KEY uk_images_replaced_by_filename
+        `)
+
+        // Remove the foreign key constraint and column
+        await queryRunner.query(`-- sql
+            ALTER TABLE images
+            DROP FOREIGN KEY fk_images_replaced_by,
+            DROP COLUMN replacedBy
+        `)
+
+        // Restore the original unique key on filename
+        await queryRunner.query(`-- sql
+            ALTER TABLE images
+            ADD UNIQUE KEY filename (filename)
+        `)
+    }
+}

--- a/db/migration/1734369183234-CloudflareImagesReplacedBy.ts
+++ b/db/migration/1734369183234-CloudflareImagesReplacedBy.ts
@@ -30,16 +30,21 @@ export class CloudflareImagesReplacedBy1734369183234
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
-        // Remove the combined unique constraint
+        // First remove the foreign key constraint
+        await queryRunner.query(`-- sql
+            ALTER TABLE images
+            DROP FOREIGN KEY fk_images_replaced_by
+        `)
+
+        // Then remove the combined unique constraint
         await queryRunner.query(`-- sql
             ALTER TABLE images
             DROP KEY uk_images_replaced_by_filename
         `)
 
-        // Remove the foreign key constraint and column
+        // Remove the column
         await queryRunner.query(`-- sql
             ALTER TABLE images
-            DROP FOREIGN KEY fk_images_replaced_by,
             DROP COLUMN replacedBy
         `)
 

--- a/db/migration/1734369183234-CloudflareImagesReplacedBy.ts
+++ b/db/migration/1734369183234-CloudflareImagesReplacedBy.ts
@@ -12,6 +12,13 @@ export class CloudflareImagesReplacedBy1734369183234
         await queryRunner.query(`-- sql
             ALTER TABLE images 
             ADD COLUMN replacedBy INT NULL,
+            -- Necessary to create a unique constraint with filename, so that we can have multiple versions of the same image,
+            -- but not multiple images with the same filename and version.
+            -- i.e.
+            -- You can upload test.png and *replace* it with test.png, but you can't upload a *new* image named test.png,
+            -- because that would have a version of 0 and conflict with the first test.png that was uploaded
+            -- This was done because MySQL 8 doesn't support partial unique indexes (e.g. "UNIQUE(filename) WHERE replacedBy IS NULL")
+            -- Nor a unique constraint when the column is nullable (e.g. "UNIQUE(filename, replacedBy)" would allow multiple rows with ["test.png", null])
             ADD COLUMN version INT NOT NULL DEFAULT 0,
             ADD CONSTRAINT fk_images_replaced_by 
                 FOREIGN KEY (replacedBy) 

--- a/db/model/Gdoc/GdocBase.ts
+++ b/db/model/Gdoc/GdocBase.ts
@@ -734,7 +734,7 @@ export class GdocBase implements OwidGdocBaseInterface {
                 if (!this.imageMetadata[filename]) {
                     errors.push({
                         property: "imageMetadata",
-                        message: `No image named ${filename} found in Drive`,
+                        message: `No image named ${filename} found in the admin`,
                         type: OwidGdocErrorMessageType.Error,
                     })
                 } else if (!this.imageMetadata[filename].defaultAlt) {

--- a/db/model/Gdoc/GdocFactory.ts
+++ b/db/model/Gdoc/GdocFactory.ts
@@ -648,8 +648,7 @@ export async function addImagesToContentGraph(
     await trx.table(PostsGdocsXImagesTableName).where({ gdocId: id }).delete()
     const filenames = gdoc.filenames
 
-    // Includes fragments so that images in data pages are
-    // synced to S3 and ultimately baked in bakeDriveImages().
+    // Includes fragments so that images in data pages are also tracked
     if (filenames.length && gdoc.published) {
         const images = await getImageMetadataByFilenames(trx, filenames)
         const gdocXImagesToInsert: DbInsertPostGdocXImage[] = []

--- a/db/model/Image.ts
+++ b/db/model/Image.ts
@@ -2,9 +2,15 @@ import { DbEnrichedImage, DbRawImage } from "@ourworldindata/types"
 import { parseImageRow } from "@ourworldindata/utils"
 import { KnexReadonlyTransaction } from "../db.js"
 
+/**
+ * Get all images that haven't been replaced
+ **/
 export async function getAllImages(
     knex: KnexReadonlyTransaction
 ): Promise<DbEnrichedImage[]> {
-    const images = await knex.table("images").select<DbRawImage[]>()
+    const images = await knex
+        .table("images")
+        .where("replacedBy", null)
+        .select<DbRawImage[]>()
     return images.map(parseImageRow)
 }

--- a/packages/@ourworldindata/types/src/dbTypes/Images.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/Images.ts
@@ -16,8 +16,11 @@ export interface DbInsertImage {
     /**
      * Necessary to create a unique constraint with filename, so that we can have multiple versions of the same image,
      * but not multiple images with the same filename and version.
-     * i.e. you can upload test.png and *replace* it with test.png, but you can't upload a *new* image named test.png,
+     * i.e.
+     * You can upload test.png and *replace* it with test.png, but you can't upload a *new* image named test.png,
      * because that would have a version of 0 and conflict with the first test.png that was uploaded
+     * This was done because MySQL 8 doesn't support partial unique indexes (e.g. "UNIQUE(filename) WHERE replacedBy IS NULL")
+     * Nor a unique constraint when the column is nullable (e.g. "UNIQUE(filename, replacedBy)" would allow multiple rows with ["test.png", null])
      */
     version?: number
 }

--- a/packages/@ourworldindata/types/src/dbTypes/Images.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/Images.ts
@@ -13,6 +13,13 @@ export interface DbInsertImage {
     hash?: string | null
     userId?: number | null
     replacedBy?: number | null
+    /**
+     * Necessary to create a unique constraint with filename, so that we can have multiple versions of the same image,
+     * but not multiple images with the same filename and version.
+     * i.e. you can upload test.png and *replace* it with test.png, but you can't upload a *new* image named test.png,
+     * because that would have a version of 0 and conflict with the first test.png that was uploaded
+     */
+    version?: number
 }
 export type DbRawImage = Required<DbInsertImage>
 

--- a/packages/@ourworldindata/types/src/dbTypes/Images.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/Images.ts
@@ -12,6 +12,7 @@ export interface DbInsertImage {
     cloudflareId?: string | null
     hash?: string | null
     userId?: number | null
+    replacedBy?: number | null
 }
 export type DbRawImage = Required<DbInsertImage>
 


### PR DESCRIPTION
Fixes https://github.com/owid/owid-grapher/issues/4313

# Changes
- Adds a `replacedBy` column to the `images` table
- Adds a `version` column to the `images` table
- Removes the unique `filename` constraint on the `images` column
- Adds a unique constraint on `filename, version`
- Updates all places that select "all images" to only select images where `replacedBy` is null
- Updates images API functions to reflect these changes
  - the PUT route now sets the `replacedBy` column, and triggers a build
  - the DELETE route uses a CTE to find every image in the chain and deletes them all
    - it's possible that a user unpublishes an article and immediately deletes its images before the rebake has occurred, thus temporarily breaking the article before it's removed, but that seems unlikely
 

# To test
## CRUD
1. Create three images
2. Upload the first one, replace it with the second, and the third
3. Confirm that all 3 images are still in the DB, and that `replacedBy` has been set correctly
4. Delete the third image and confirm that all 3 images get deleted in Cloudflare and the DB


## Baking
1. Create 2 images
2. Upload one of them, and publish it in an article
3. Confirm the image works
4. Update the image, and confirm that a bake is triggered
5. Confirm that the article still works in the meantime
6. Confirm that the updated image is used once the bake is finished