### PR TITLE
✨ (map) left-align multi-line categorical legends

### DIFF
--- a/packages/@ourworldindata/grapher/src/horizontalColorLegend/HorizontalColorLegends.tsx
+++ b/packages/@ourworldindata/grapher/src/horizontalColorLegend/HorizontalColorLegends.tsx
@@ -808,6 +808,10 @@ export class HorizontalCategoricalColorLegend extends HorizontalColorLegend {
         return max(this.marks.map((mark) => mark.y + mark.rectSize)) ?? 0
     }
 
+    @computed get numLines(): number {
+        return this.markLines.length
+    }
+
     renderLabels(): React.ReactElement {
         const { manager, marks } = this
         const { focusColors, hoverColors = [] } = manager

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
@@ -514,13 +514,11 @@ export class MapChart
     }
 
     @computed get legendMaxWidth(): number {
-        // it seems nice to have just a little bit of
-        // extra padding left and right
-        return this.bounds.width * 0.95
+        return this.bounds.width
     }
 
     @computed get legendX(): number {
-        return this.bounds.x + (this.bounds.width - this.legendMaxWidth) / 2
+        return this.bounds.x
     }
 
     @computed get legendHeight(): number {
@@ -557,7 +555,9 @@ export class MapChart
     }
 
     @computed get legendAlign(): HorizontalAlign {
-        return HorizontalAlign.center
+        if (this.numericLegend) return HorizontalAlign.center
+        const { numLines = 0 } = this.categoryLegend ?? {}
+        return numLines > 1 ? HorizontalAlign.left : HorizontalAlign.center
     }
 
     @computed get numericLegendY(): number {


### PR DESCRIPTION
Resolves https://github.com/owid/owid-grapher/issues/3988 by left-aligning categorical map legends when they have more than one line.

Introduces a bit of a regression, where the left/right padding around legend is removed (see second screenshot below). The padding has to be zero when the legend is left-aligned, but I can't add a condition to the code to that effect since that would introduce a cyclic dependency (to know whether to left-align the legend, I need to know the number of lines, and to know the number of lines, I need to know the `maxLegendWidth`).

| Before | After |
|--------|--------|
| <img width="552" alt="Screenshot 2024-12-17 at 12 55 11" src="https://github.com/user-attachments/assets/9ad656d6-f5ca-4742-984f-f99d5f411548" /> | <img width="552" alt="Screenshot 2024-12-17 at 12 55 02" src="https://github.com/user-attachments/assets/53867960-d257-4253-9ce3-fd916a6b7c36" /> |

<img width="1243" alt="Screenshot 2024-12-17 at 12 57 13" src="https://github.com/user-attachments/assets/98ed5925-fcce-4ad5-b2a7-41ab274c3759" />
