### PR TITLE
🐛 (scatter/marimekko) apply color/size tolerance early

### DIFF
--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
@@ -171,28 +171,8 @@ export class ScatterPlotChart
         if (this.yScaleType === ScaleType.log && this.yColumnSlug)
             table = table.replaceNonPositiveCellsForLogScale([this.yColumnSlug])
 
-        if (this.sizeColumnSlug) {
-            const tolerance =
-                table.get(this.sizeColumnSlug)?.display?.tolerance ?? Infinity
-            table = table.interpolateColumnWithTolerance(
-                this.sizeColumnSlug,
-                tolerance
-            )
-        }
-
-        if (this.colorColumnSlug) {
-            const tolerance =
-                table.get(this.colorColumnSlug)?.display?.tolerance ?? Infinity
-            table = table.interpolateColumnWithTolerance(
-                this.colorColumnSlug,
-                tolerance
-            )
-            if (this.manager.matchingEntitiesOnly) {
-                table = table.dropRowsWithErrorValuesForColumn(
-                    this.colorColumnSlug
-                )
-            }
-        }
+        if (this.colorColumnSlug && this.manager.matchingEntitiesOnly)
+            table = table.dropRowsWithErrorValuesForColumn(this.colorColumnSlug)
 
         // We want to "chop off" any rows outside the time domain for X and Y to avoid creating
         // leading and trailing timeline times that don't really exist in the dataset.

--- a/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChart.tsx
@@ -318,17 +318,9 @@ export class MarimekkoChart
         if (xColumnSlug)
             table = table.interpolateColumnWithTolerance(xColumnSlug)
 
-        if (colorColumnSlug) {
-            const tolerance =
-                table.get(colorColumnSlug)?.display?.tolerance ?? Infinity
-            table = table.interpolateColumnWithTolerance(
-                colorColumnSlug,
-                tolerance
-            )
-            if (manager.matchingEntitiesOnly) {
-                table = table.dropRowsWithErrorValuesForColumn(colorColumnSlug)
-            }
-        }
+        if (colorColumnSlug && manager.matchingEntitiesOnly)
+            table = table.dropRowsWithErrorValuesForColumn(colorColumnSlug)
+
         if (!manager.showNoDataArea)
             table = table.dropRowsWithErrorValuesForAllColumns(yColumnSlugs)
 


### PR DESCRIPTION
Fixes #4284 by applying color tolerance before the author's timeline filter is applied to the input table.

This is how the bug for gray scatter plots like [this one](https://ourworldindata.org/grapher/affected-by-disasters-vs-gdp) happened:
- The World regions dataset only has data for 2023
- The chart's `timelineMax` is set to 2021
- Grapher first filters the input table by `[timelineMin, timelineMax]`, thereby dropping years 2022 and 2023 including all color values
- Later, in the scatter plot's `transformTable` function, Grapher applies infinite tolerance to the color dimension, but since all colour values have been removed, the colour column remains empty

Fixed by running colour (and size) tolerance for scatter and marimekkos earlier. 
