### PR TITLE
✨ (scatter) rotate y-axis label / TAS-801

### DIFF
--- a/packages/@ourworldindata/grapher/src/axis/AxisConfig.ts
+++ b/packages/@ourworldindata/grapher/src/axis/AxisConfig.ts
@@ -7,6 +7,7 @@ import {
     AxisAlign,
     Position,
     TickFormattingOptions,
+    Bounds,
 } from "@ourworldindata/utils"
 import { observable, computed } from "mobx"
 import { HorizontalAxis, VerticalAxis } from "./Axis"
@@ -20,6 +21,7 @@ import {
 
 export interface AxisManager {
     fontSize: number
+    axisBounds?: Bounds
     detailsOrderedByReference?: string[]
 }
 
@@ -33,7 +35,9 @@ class AxisConfigDefaults implements AxisConfigInterface {
     @observable.ref hideAxis?: boolean = undefined
     @observable.ref hideGridlines?: boolean = undefined
     @observable.ref hideTickLabels?: boolean = undefined
+    @observable.ref labelPosition?: AxisAlign = AxisAlign.middle
     @observable.ref labelPadding?: number = undefined
+    @observable.ref tickPadding?: number = undefined
     @observable.ref nice?: boolean = undefined
     @observable.ref maxTicks?: number = undefined
     @observable.ref tickFormattingOptions?: TickFormattingOptions = undefined

--- a/packages/@ourworldindata/grapher/src/axis/AxisViews.tsx
+++ b/packages/@ourworldindata/grapher/src/axis/AxisViews.tsx
@@ -14,7 +14,7 @@ import {
 import { VerticalAxis, HorizontalAxis, DualAxis } from "./Axis"
 import classNames from "classnames"
 import { GRAPHER_DARK_TEXT } from "../color/ColorConstants"
-import { ScaleType, DetailsMarker } from "@ourworldindata/types"
+import { ScaleType, DetailsMarker, AxisAlign } from "@ourworldindata/types"
 
 const dasharrayFromFontSize = (fontSize: number): string => {
     const dashLength = Math.round((fontSize / 16) * 3)
@@ -265,27 +265,27 @@ export class VerticalAxisComponent extends React.Component<{
         } = this.props
         const { tickLabels, labelTextWrap, config } = verticalAxis
 
+        const isLabelCentered = verticalAxis.labelPosition === AxisAlign.middle
+        const labelX = isLabelCentered ? -verticalAxis.rangeCenter : bounds.left
+        const labelY = isLabelCentered ? bounds.left : bounds.top
+
         return (
             <g
                 id={makeIdForHumanConsumption("vertical-axis")}
                 className="VerticalAxis"
             >
                 {labelTextWrap &&
-                    labelTextWrap.renderSVG(
-                        -verticalAxis.rangeCenter,
-                        bounds.left,
-                        {
-                            id: makeIdForHumanConsumption(
-                                "vertical-axis-label"
-                            ),
-                            textProps: {
-                                transform: "rotate(-90)",
-                                fill: labelColor || GRAPHER_DARK_TEXT,
-                                textAnchor: "middle",
-                            },
-                            detailsMarker,
-                        }
-                    )}
+                    labelTextWrap.renderSVG(labelX, labelY, {
+                        id: makeIdForHumanConsumption("vertical-axis-label"),
+                        textProps: {
+                            transform: isLabelCentered
+                                ? "rotate(-90)"
+                                : undefined,
+                            fill: labelColor || GRAPHER_DARK_TEXT,
+                            textAnchor: isLabelCentered ? "middle" : "start",
+                        },
+                        detailsMarker,
+                    })}
                 {showTickMarks && (
                     <g id={makeIdForHumanConsumption("tick-marks")}>
                         {tickLabels.map((label, i) => (
@@ -315,7 +315,7 @@ export class VerticalAxisComponent extends React.Component<{
                                     x={(
                                         bounds.left +
                                         verticalAxis.width -
-                                        verticalAxis.labelPadding
+                                        verticalAxis.tickPadding
                                     ).toFixed(2)}
                                     y={y}
                                     dy={dyFromAlign(
@@ -392,17 +392,20 @@ export class HorizontalAxisComponent extends React.Component<{
 
         const showTickLabels = !axis.config.hideTickLabels
 
+        const isLabelCentered = axis.labelPosition === AxisAlign.middle
+        const labelX = isLabelCentered ? axis.rangeCenter : bounds.right
+
         return (
             <g
                 id={makeIdForHumanConsumption("horizontal-axis")}
                 className="HorizontalAxis"
             >
                 {label &&
-                    label.renderSVG(axis.rangeCenter, labelYPosition, {
+                    label.renderSVG(labelX, labelYPosition, {
                         id: makeIdForHumanConsumption("horizontal-axis-label"),
                         textProps: {
                             fill: labelColor || GRAPHER_DARK_TEXT,
-                            textAnchor: "middle",
+                            textAnchor: isLabelCentered ? "middle" : "end",
                         },
                         detailsMarker,
                     })}

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
@@ -11,6 +11,7 @@ import {
     ColorSchemeName,
     ValueRange,
     ColumnSlug,
+    AxisAlign,
 } from "@ourworldindata/types"
 import { ComparisonLine } from "../scatterCharts/ComparisonLine"
 import { observable, computed, action } from "mobx"
@@ -339,10 +340,14 @@ export class ScatterPlotChart
             this.bounds
                 .padRight(this.sidebarWidth + 20)
                 // top padding leaves room for tick labels
-                .padTop(6)
+                .padTop(this.currentVerticalAxisLabel ? 0 : 6)
                 // bottom padding makes sure the x-axis label doesn't overflow
                 .padBottom(2)
         )
+    }
+
+    @computed get axisBounds(): Bounds {
+        return this.innerBounds
     }
 
     @computed private get canAddCountry(): boolean {
@@ -538,7 +543,7 @@ export class ScatterPlotChart
     @computed get dualAxis(): DualAxis {
         const { horizontalAxisPart, verticalAxisPart } = this
         return new DualAxis({
-            bounds: this.innerBounds,
+            bounds: this.axisBounds,
             horizontalAxis: horizontalAxisPart,
             verticalAxis: verticalAxisPart,
         })
@@ -774,7 +779,7 @@ export class ScatterPlotChart
 
         const legendPadding = 16
         const ySizeLegend =
-            bounds.top +
+            this.legendY +
             verticalLegendHeight +
             (verticalLegendHeight > 0 ? legendPadding : 0)
         const yArrowLegend =
@@ -989,7 +994,7 @@ export class ScatterPlotChart
     }
 
     @computed get legendY(): number {
-        return this.bounds.top
+        return this.bounds.top + this.yAxis.labelHeight
     }
 
     @computed get legendX(): number {
@@ -1029,15 +1034,20 @@ export class ScatterPlotChart
 
     @computed private get yAxisConfig(): AxisConfig {
         const { yAxisConfig = {} } = this.manager
-        const labelPadding = this.manager.isNarrow ? 2 : undefined
-        const config = { ...yAxisConfig, labelPadding }
+        const config = {
+            ...yAxisConfig,
+            labelPosition: AxisAlign.end,
+            labelPadding: this.manager.isNarrow ? 10 : 14,
+        }
         return new AxisConfig(config, this)
     }
 
     @computed private get xAxisConfig(): AxisConfig {
         const { xAxisConfig = {} } = this.manager
-        const labelPadding = this.manager.isNarrow ? 2 : undefined
-        const config = { ...xAxisConfig, labelPadding }
+        const config = {
+            ...xAxisConfig,
+            labelPadding: this.manager.isNarrow ? 6 : undefined,
+        }
         return new AxisConfig(config, this)
     }
 

--- a/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
+++ b/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
@@ -263,11 +263,21 @@ export interface AxisConfigInterface {
     minSize?: number
 
     /**
-     * The padding between:
-     * - an axis tick and an axis gridline
-     * - an axis label and an axis tick
+     * Position of the axis label.
+     * For vertical axes, 'middle' rotates the label and places it to the left of the axis,
+     * 'end' places the label above the axis.
+     */
+    labelPosition?: AxisAlign
+
+    /**
+     * The padding between an axis label and an axis tick
      */
     labelPadding?: number
+
+    /**
+     * The padding between an axis tick and an axis gridline
+     */
+    tickPadding?: number
 
     /**
      * Extend scale to start & end on "nicer" round values.


### PR DESCRIPTION
Resolves https://github.com/owid/owid-grapher/issues/3567

Rotates the y-axis labels for scatter plots to make them horizontal and easier to read.

It would be nice if we also rotated the y-axis label for Marimekko charts, but for Marimekko charts with an x-dimension, the x-axis labels are plotted above the chart area (see screenshot). It would be confusing if we showed both labels on the same line.

I also tried right-aligning x-axis labels, but it often looked unbalanced.

<details><summary>Example of a Marimekko chart with a x-dimension</summary>
<p>

<img width="1288" alt="Screenshot 2025-01-02 at 15 33 03" src="https://github.com/user-attachments/assets/ca7d19b3-19d9-4b6c-a475-518a8e044ef7" />


</p>
</details>

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #4403 
- <kbd>&nbsp;2&nbsp;</kbd> #4402 
- <kbd>&nbsp;1&nbsp;</kbd> #4331 👈 
<!-- GitButler Footer Boundary Bottom -->

