### PR TITLE
✨ (scatter) add unit to axis labels

### DIFF
--- a/packages/@ourworldindata/core-table/src/CoreTableColumns.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTableColumns.ts
@@ -26,6 +26,7 @@ import {
     IndicatorTitleWithFragments,
     max,
     min,
+    capitalize,
 } from "@ourworldindata/utils"
 import { CoreTable } from "./CoreTable.js"
 import {
@@ -836,6 +837,10 @@ export abstract class TimeColumn extends AbstractCoreColumn<number> {
     jsType = JsTypes.number
 
     abstract preposition: string
+
+    @imemo get displayName(): string {
+        return capitalize(this.name)
+    }
 
     formatTime(time: number): string {
         return this.formatValue(time)

--- a/packages/@ourworldindata/core-table/src/CoreTableColumns.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTableColumns.ts
@@ -269,6 +269,12 @@ export abstract class AbstractCoreColumn<JS_TYPE extends PrimitiveType> {
         return undefined
     }
 
+    @imemo get displayUnit(): string | undefined {
+        return this.unit && this.unit !== this.shortUnit
+            ? this.unit.replace(/^\((.*)\)$/, "$1")
+            : undefined
+    }
+
     // Returns a map where the key is a series slug such as "name" and the value is a set
     // of all the unique values that this column has for that particular series.
     getUniqueValuesGroupedBy(

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
@@ -1248,7 +1248,10 @@ export class ScatterPlotChart
         const axis = axisConfig.toVerticalAxis()
         axis.formatColumn = this.yColumn
         axis.scaleType = this.yScaleType
-        axis.label = this.currentVerticalAxisLabel
+
+        let label = this.currentVerticalAxisLabel
+        if (this.yColumn.displayUnit) label += ` (${this.yColumn.displayUnit})`
+        axis.label = label
 
         if (
             this.manager.isSingleTimeScatterAnimationActive &&
@@ -1312,8 +1315,12 @@ export class ScatterPlotChart
         axis.formatColumn = this.xColumn
         axis.scaleType = this.xScaleType
 
-        if (this.currentHorizontalAxisLabel)
-            axis.label = this.currentHorizontalAxisLabel
+        if (this.currentHorizontalAxisLabel) {
+            let label = this.currentHorizontalAxisLabel
+            if (this.xColumn.displayUnit)
+                label += ` (${this.xColumn.displayUnit})`
+            axis.label = label
+        }
 
         if (
             this.manager.isSingleTimeScatterAnimationActive &&

--- a/packages/@ourworldindata/grapher/src/tooltip/TooltipContents.tsx
+++ b/packages/@ourworldindata/grapher/src/tooltip/TooltipContents.tsx
@@ -132,11 +132,7 @@ class Variable extends React.Component<{
 
         if (column.isMissing || column.name === "time") return null
 
-        const { unit, shortUnit, displayName } = column,
-            displayUnit =
-                unit && unit !== shortUnit
-                    ? unit.replace(/^\((.*)\)$/, "$1")
-                    : undefined,
+        const { displayUnit, displayName } = column,
             displayNotice =
                 uniq((notice ?? []).filter((t) => t !== undefined))
                     .map((time) =>


### PR DESCRIPTION
Should work, but I'd prefer to use the `TextWrapGroup`'s 'avoid-wrap' functionality to only add line breaks for the unit it necessary. To be able to use `TextWrapGroup` for axis labels, `TextWrapGroup` should support DoD's (since axis labels might contain DoDs)