### PR TITLE
Fix padding of headings with multiple children

### DIFF
--- a/site/owid.scss
+++ b/site/owid.scss
@@ -238,7 +238,9 @@ h6 {
     // doesn't work and programmatically wrapping the last word and the
     // deep-link in a span with text-wrap: nowrap would be an even bigger hack.
     &:has(.deep-link) {
-        > *:first-child {
+        // Pick the second-to-last child, since the heading can have multiple
+        // elements as children and the last child is the deep-link.
+        > *:nth-last-child(2) {
             padding-right: 2rem;
 
             // On touch devices, the deep-link is hidden, so we don't need the


### PR DESCRIPTION
This is the case when e.g. part of the heading is italicized.