### PR TITLE
🐛 (facet) show swatch colour on hovering

### DIFF
--- a/packages/@ourworldindata/grapher/src/horizontalColorLegend/HorizontalColorLegends.tsx
+++ b/packages/@ourworldindata/grapher/src/horizontalColorLegend/HorizontalColorLegends.tsx
@@ -854,6 +854,7 @@ export class HorizontalCategoricalColorLegend extends HorizontalColorLegend {
             <g id={makeIdForHumanConsumption("swatches")}>
                 {marks.map((mark, index) => {
                     const isActive = activeColors?.includes(mark.bin.color)
+                    const isHovered = hoverColors.includes(mark.bin.color)
                     const isNotHovered =
                         hoverColors.length > 0 &&
                         !hoverColors.includes(mark.bin.color)
@@ -863,7 +864,7 @@ export class HorizontalCategoricalColorLegend extends HorizontalColorLegend {
                         : mark.bin.color
 
                     const fill =
-                        isActive || activeColors === undefined
+                        isHovered || isActive || activeColors === undefined
                             ? color
                             : OWID_NON_FOCUSED_GRAY
 


### PR DESCRIPTION
If a non-focused series is hovered in the facet legend, then its colour should be used (not the un-focused gray)