### PR TITLE
🔨 refactor legacyToOwidTableAndDimensions

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -1149,6 +1149,12 @@ export class Grapher
             json,
             legacyConfig.dimensions ?? []
         )
+        const tableWithColors = legacyConfig.selectedEntityColors
+            ? addSelectedEntityColorsToTable(
+                  table,
+                  legacyConfig.selectedEntityColors
+              )
+            : table
         const dimensions = legacyConfig.dimensions ?? []
         this.createPerformanceMeasurement(
             "legacyToOwidTableAndDimensions",
@@ -1156,8 +1162,8 @@ export class Grapher
         )
 
         if (inputTableTransformer)
-            this.inputTable = inputTableTransformer(table)
-        else this.inputTable = table
+            this.inputTable = inputTableTransformer(tableWithColors)
+        else this.inputTable = tableWithColors
 
         // We need to reset the dimensions because some of them may have changed slugs in the legacy
         // transformation (can happen when columns use targetTime)

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -1145,10 +1145,11 @@ export class Grapher
         // TODO grapher model: switch this to downloading multiple data and metadata files
 
         const startMark = performance.now()
-        const { dimensions, table } = legacyToOwidTableAndDimensions(
+        const table = legacyToOwidTableAndDimensions(
             json,
-            legacyConfig
+            legacyConfig.dimensions ?? []
         )
+        const dimensions = legacyConfig.dimensions ?? []
         this.createPerformanceMeasurement(
             "legacyToOwidTableAndDimensions",
             startMark


### PR DESCRIPTION
This PR refactors legacyToOwidTableAndDimensions. The old code used the full config to assemble the input table but for extracting the loading code it's much nicer if only the dimensions influence the input table.

This meant geting rid of chart type specific code (luckily that was superfluous because it was only relevant when targetTime is set and that only happens for scatter and marimekko charts anyhow); and extracting the code that fills in the selected entity colors from the config into the table.