### PR TITLE
✨ (discrete bar) hide horizontal axis

### DIFF
--- a/db/migration/1735896576517-RemoveRelativeModeFromDiscreteBarCharts.ts
+++ b/db/migration/1735896576517-RemoveRelativeModeFromDiscreteBarCharts.ts
@@ -1,0 +1,20 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class RemoveRelativeModeFromDiscreteBarCharts1735896576517 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            -- sql
+            update chart_configs
+            set
+                patch = json_remove(patch, '$.stackMode'),
+                full = json_remove(full, '$.stackMode')
+            where
+                chartType = 'DiscreteBar'
+                and full ->> '$.stackMode' = 'relative';
+        `)
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    public async down(): Promise<void> {}
+}

--- a/db/migration/1735896576517-RemoveRelativeModeFromDiscreteBarCharts.ts
+++ b/db/migration/1735896576517-RemoveRelativeModeFromDiscreteBarCharts.ts
@@ -1,7 +1,8 @@
-import { MigrationInterface, QueryRunner } from "typeorm";
+import { MigrationInterface, QueryRunner } from "typeorm"
 
-export class RemoveRelativeModeFromDiscreteBarCharts1735896576517 implements MigrationInterface {
-
+export class RemoveRelativeModeFromDiscreteBarCharts1735896576517
+    implements MigrationInterface
+{
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`
             -- sql

--- a/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChart.tsx
@@ -37,11 +37,7 @@ import {
     GRAPHER_AREA_OPACITY_DEFAULT,
     GRAPHER_FONT_SCALE_12,
 } from "../core/GrapherConstants"
-import {
-    HorizontalAxisComponent,
-    HorizontalAxisGridLines,
-    HorizontalAxisZeroLine,
-} from "../axis/AxisViews"
+import { HorizontalAxisZeroLine } from "../axis/AxisViews"
 import { NoDataModal } from "../noDataModal/NoDataModal"
 import { AxisConfig, AxisManager } from "../axis/AxisConfig"
 import { ColorSchemes } from "../color/ColorSchemes"
@@ -305,7 +301,6 @@ export class DiscreteBarChart
     @computed private get innerBounds(): Bounds {
         return this.boundsWithoutColorLegend
             .padLeft(Math.max(this.seriesLegendWidth, this.leftValueLabelWidth))
-            .padBottom(this.showHorizontalAxis ? this.yAxis.height : 0)
             .padRight(this.rightValueLabelWidth)
     }
 
@@ -348,10 +343,6 @@ export class DiscreteBarChart
 
     @computed private get barWidths(): number[] {
         return this.barPlacements.map((b) => b.width)
-    }
-
-    @computed private get showHorizontalAxis(): boolean | undefined {
-        return this.manager.isRelativeMode
     }
 
     private d3Bars(): Selection<
@@ -504,7 +495,7 @@ export class DiscreteBarChart
     }
 
     renderChartArea(): React.ReactElement {
-        const { manager, boundsWithoutColorLegend, yAxis, innerBounds } = this
+        const { manager, yAxis, innerBounds } = this
 
         const axisLineWidth = manager.isStaticAndSmall
             ? GRAPHER_AXIS_LINE_WIDTH_THICK
@@ -515,22 +506,6 @@ export class DiscreteBarChart
                 {this.renderDefs()}
                 {this.showColorLegend && (
                     <HorizontalNumericColorLegend manager={this} />
-                )}
-                {this.showHorizontalAxis && (
-                    <>
-                        <HorizontalAxisComponent
-                            bounds={boundsWithoutColorLegend}
-                            axis={yAxis}
-                            preferredAxisPosition={innerBounds.bottom}
-                            labelColor={manager.secondaryColorInStaticCharts}
-                            tickMarkWidth={axisLineWidth}
-                        />
-                        <HorizontalAxisGridLines
-                            horizontalAxis={yAxis}
-                            bounds={innerBounds}
-                            strokeWidth={axisLineWidth}
-                        />
-                    </>
                 )}
                 {!this.isLogScale && (
                     <HorizontalAxisZeroLine


### PR DESCRIPTION
Drops axis grid lines and labels for all discrete bar charts. The axis is currently only shown for discrete bar charts in relative mode, but relative mode is not supported for discrete bar charts. 

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #4372 
- <kbd>&nbsp;1&nbsp;</kbd> #4371 👈 
<!-- GitButler Footer Boundary Bottom -->

