### PR TITLE
Refactor input table

### DIFF
--- a/packages/@ourworldindata/grapher/src/chart/ChartDimension.ts
+++ b/packages/@ourworldindata/grapher/src/chart/ChartDimension.ts
@@ -13,6 +13,7 @@ import {
     OwidVariableDisplayConfig,
     OwidChartDimensionInterface,
     Time,
+    OwidChartDimensionInterfaceWithMandatorySlug,
 } from "@ourworldindata/utils"
 import { OwidTable, CoreColumn } from "@ourworldindata/core-table"
 
@@ -35,9 +36,17 @@ export interface LegacyDimensionsManager {
     table: OwidTable
 }
 
+export function getDimensionColumnSlug(
+    variableId: OwidVariableId,
+    targetYear: Time | undefined
+): ColumnSlug {
+    if (targetYear) return `${variableId}-${targetYear}`
+    return variableId.toString()
+}
+
 export class ChartDimension
     extends ChartDimensionDefaults
-    implements Persistable
+    implements Persistable, OwidChartDimensionInterfaceWithMandatorySlug
 {
     private manager: LegacyDimensionsManager
 
@@ -78,7 +87,16 @@ export class ChartDimension
     }
 
     // Do not persist yet, until we migrate off VariableIds
-    @observable slug?: ColumnSlug
+    @observable _slug?: ColumnSlug | undefined
+
+    @computed get slug(): ColumnSlug {
+        if (this._slug) return this._slug
+        return getDimensionColumnSlug(this.variableId, this.targetYear)
+    }
+
+    set slug(value: ColumnSlug | undefined) {
+        this._slug = value
+    }
 
     @computed get column(): CoreColumn {
         return this.table.get(this.columnSlug)

--- a/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.ts
+++ b/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.ts
@@ -8,9 +8,9 @@ import {
     OwidColumnDef,
     OwidVariableDimensions,
     OwidVariableDataMetadataDimensions,
-    EntityId,
     ErrorValue,
     OwidChartDimensionInterfaceWithMandatorySlug,
+    EntityName,
 } from "@ourworldindata/types"
 import {
     OwidTable,
@@ -332,20 +332,19 @@ export const legacyToOwidTableAndDimensions = (
         const entityColorColumnSlug = OwidTableSlugs.entityColor
 
         const valueFn = (
-            entityId: EntityId | undefined
+            entityName: EntityName | undefined
         ): string | ErrorValue => {
-            if (!entityId) return ErrorValueTypes.UndefinedButShouldBeString
-            const entityName =
-                joinedVariablesTable.entityIdToNameMap.get(entityId)
+            if (!entityName) return ErrorValueTypes.UndefinedButShouldBeString
             return entityName && selectedEntityColors
                 ? (selectedEntityColors[entityName] ??
                       ErrorValueTypes.UndefinedButShouldBeString)
                 : ErrorValueTypes.UndefinedButShouldBeString
         }
 
-        const values = joinedVariablesTable.rows.map((row) =>
-            valueFn(row.entityId)
-        )
+        const values =
+            joinedVariablesTable.entityNameColumn.valuesIncludingErrorValues.map(
+                (entityName) => valueFn(entityName as EntityName)
+            )
 
         joinedVariablesTable = joinedVariablesTable.appendColumns([
             {

--- a/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.ts
+++ b/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.ts
@@ -1,15 +1,14 @@
 // todo: Remove this file when we've migrated OWID data and OWID charts to next version
 
 import {
-    GRAPHER_CHART_TYPES,
     ColumnTypeNames,
     CoreColumnDef,
     StandardOwidColumnDefs,
     OwidTableSlugs,
     OwidColumnDef,
-    LegacyGrapherInterface,
     OwidVariableDimensions,
     OwidVariableDataMetadataDimensions,
+    EntityId,
 } from "@ourworldindata/types"
 import {
     OwidTable,
@@ -42,8 +41,8 @@ import { isContinentsVariableId } from "./GrapherConstants"
 
 export const legacyToOwidTableAndDimensions = (
     json: MultipleOwidVariableDataDimensionsMap,
-    grapherConfig: Partial<LegacyGrapherInterface>
-): { dimensions: OwidChartDimensionInterface[]; table: OwidTable } => {
+    dimensions: OwidChartDimensionInterface[]
+): OwidTable => {
     // Entity meta map
 
     const entityMeta = [...json.values()].flatMap(
@@ -53,8 +52,6 @@ export const legacyToOwidTableAndDimensions = (
         entityMeta.map((entity) => [entity.id.toString(), entity])
     )
 
-    const dimensions = grapherConfig.dimensions || []
-
     // Base column defs, shared by all variable tables
 
     const baseColumnDefs: Map<ColumnSlug, CoreColumnDef> = new Map()
@@ -62,25 +59,9 @@ export const legacyToOwidTableAndDimensions = (
         baseColumnDefs.set(def.slug, def)
     })
 
-    const entityColorColumnSlug = grapherConfig.selectedEntityColors
-        ? OwidTableSlugs.entityColor
-        : undefined
-    if (entityColorColumnSlug) {
-        baseColumnDefs.set(entityColorColumnSlug, {
-            slug: entityColorColumnSlug,
-            type: ColumnTypeNames.Color,
-            name: entityColorColumnSlug,
-        })
-    }
-
     // We need to create a column for each unique [variable, targetTime] pair. So there can be
     // multiple columns for a single variable.
-    const newDimensions = dimensions.map((dimension) => ({
-        ...dimension,
-        slug: dimension.targetYear
-            ? `${dimension.variableId}-${dimension.targetYear}`
-            : `${dimension.variableId}`,
-    }))
+    const newDimensions = computeActualDimensions(dimensions)
     const dimensionColumns = uniqBy(newDimensions, (dim) => dim.slug)
 
     const variableTablesToJoinByYear: OwidTable[] = []
@@ -174,18 +155,6 @@ export const legacyToOwidTableAndDimensions = (
             )
             columnDefs.set(annotationColumnDef.slug, annotationColumnDef)
         }
-
-        if (entityColorColumnSlug) {
-            columnStore[entityColorColumnSlug] = entityIds.map((entityId) => {
-                // see comment above about entityMetaById[id]
-                const entityName = entityMetaById[entityId]?.name
-                const selectedEntityColors = grapherConfig.selectedEntityColors
-                return entityName && selectedEntityColors
-                    ? selectedEntityColors[entityName]
-                    : undefined
-            })
-        }
-
         // Build the tables
 
         let variableTable = new OwidTable(
@@ -198,12 +167,7 @@ export const legacyToOwidTableAndDimensions = (
         // We do this by dropping the column. We interpolate before which adds an originalTime
         // column which can be used to recover the time.
         const targetTime = dimension?.targetYear
-        const chartType = grapherConfig.chartTypes?.[0]
-        if (
-            (chartType === GRAPHER_CHART_TYPES.ScatterPlot ||
-                chartType === GRAPHER_CHART_TYPES.Marimekko) &&
-            isNumber(targetTime)
-        ) {
+        if (isNumber(targetTime)) {
             variableTable = variableTable
                 // interpolateColumnWithTolerance() won't handle injecting times beyond the current
                 // allTimes. So if targetYear is 2018, and we have data up to 2017, the
@@ -359,7 +323,34 @@ export const legacyToOwidTableAndDimensions = (
         }
     }
 
-    return { dimensions: newDimensions, table: joinedVariablesTable }
+    return joinedVariablesTable
+}
+
+export const addSelectedEntityColorsToTable = (
+    table: OwidTable,
+    selectedEntityColors: { [entityName: string]: string | undefined }
+): OwidTable => {
+    const entityColorColumnSlug = OwidTableSlugs.entityColor
+
+    const valueFn = (entityId: EntityId | undefined) => {
+        if (!entityId) return ErrorValueTypes.UndefinedButShouldBeString
+        const entityName = table.entityIdToNameMap.get(entityId)
+        return entityName && selectedEntityColors
+            ? (selectedEntityColors[entityName] ??
+                  ErrorValueTypes.UndefinedButShouldBeString)
+            : ErrorValueTypes.UndefinedButShouldBeString
+    }
+
+    const values = table.rows.map((row) => valueFn(row.entityId))
+
+    return table.appendColumns([
+        {
+            slug: entityColorColumnSlug,
+            name: entityColorColumnSlug,
+            type: ColumnTypeNames.Color,
+            values: values,
+        },
+    ])
 }
 
 const fullJoinTables = (
@@ -745,6 +736,17 @@ const annotationsToMap = (annotations: string): Map<string, string> => {
         entityAnnotationsMap.set(key.trim(), words.join(delimiter).trim())
     })
     return entityAnnotationsMap
+}
+
+export function computeActualDimensions(
+    dimensions: OwidChartDimensionInterface[]
+): OwidChartDimensionInterface[] {
+    return dimensions.map((dimension) => ({
+        ...dimension,
+        slug: dimension.targetYear
+            ? `${dimension.variableId}-${dimension.targetYear}`
+            : `${dimension.variableId}`,
+    }))
 }
 
 /**

--- a/packages/@ourworldindata/types/src/OwidVariableDisplayConfigInterface.ts
+++ b/packages/@ourworldindata/types/src/OwidVariableDisplayConfigInterface.ts
@@ -42,3 +42,8 @@ export interface OwidChartDimensionInterface {
     variableId: OwidVariableId
     slug?: ColumnSlug
 }
+
+export interface OwidChartDimensionInterfaceWithMandatorySlug
+    extends OwidChartDimensionInterface {
+    slug: ColumnSlug
+}

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -412,6 +412,7 @@ export {
     type OwidVariableDataTableConfigInterface,
     OwidVariableRoundingMode,
     type OwidChartDimensionInterface,
+    type OwidChartDimensionInterfaceWithMandatorySlug,
 } from "./OwidVariableDisplayConfigInterface.js"
 
 export {


### PR DESCRIPTION
Refactor the creation of inputtable in anticipation of extracting the loading functionality. This PR does the following things:
- legacyToOwidTable is changed to no longer require a full grapher config but only a dimensions array and the selected entity colors
- dimensions is no longer returned from legacyToOwidTableAndDimensions - instead the slug adjustements are made as a getter in ChartDimension