### PR TITLE
✨ Extract grapher state from the react component [3/4]

### DIFF
--- a/adminSiteServer/testPageRouter.tsx
+++ b/adminSiteServer/testPageRouter.tsx
@@ -131,8 +131,8 @@ async function propsFromQueryParams(
     const page = params.page
         ? expectInt(params.page)
         : params.random
-          ? Math.floor(1 + Math.random() * 180) // Sample one of 180 pages. Some charts won't ever get picked but good enough.
-          : 1
+        ? Math.floor(1 + Math.random() * 180) // Sample one of 180 pages. Some charts won't ever get picked but good enough.
+        : 1
     const perPage = parseIntOrUndefined(params.perPage) ?? 20
     const ids = parseIntArrayOrUndefined(params.ids)
     const datasetIds = parseIntArrayOrUndefined(params.datasetIds)
@@ -807,7 +807,6 @@ getPlainRouteWithROTransaction(
         res.send(svg)
     }
 )
-
 testPageRouter.get("/explorers", async (req, res) => {
     let explorers = await explorerAdminServer.getAllPublishedExplorers()
     const viewProps = getViewPropsFromQueryParams(req.query)

--- a/packages/@ourworldindata/explorer/src/Explorer.jsdom.test.tsx
+++ b/packages/@ourworldindata/explorer/src/Explorer.jsdom.test.tsx
@@ -30,26 +30,28 @@ describe(Explorer, () => {
 
         explorer.onChangeChoice("Gas")("All GHGs (CO₂eq)")
 
-        if (explorer.grapher) explorer.grapher.tab = GRAPHER_TAB_OPTIONS.table
+        if (explorer.grapher?.grapherState)
+            explorer.grapher.grapherState.tab = GRAPHER_TAB_OPTIONS.table
         else throw Error("where's the grapher?")
         expect(explorer.queryParams.tab).toEqual("table")
 
         explorer.onChangeChoice("Gas")("CO₂")
         expect(explorer.queryParams.tab).toEqual("table")
 
-        explorer.grapher.tab = GRAPHER_TAB_OPTIONS.chart
+        explorer.grapher.grapherState.tab = GRAPHER_TAB_OPTIONS.chart
     })
 
     it("switches to first tab if current tab does not exist in new view", () => {
         const explorer = element.instance() as Explorer
         expect(explorer.queryParams.tab).toBeUndefined()
-        if (explorer.grapher) explorer.grapher.tab = GRAPHER_TAB_OPTIONS.map
+        if (explorer.grapher?.grapherState)
+            explorer.grapher.grapherState.tab = GRAPHER_TAB_OPTIONS.map
         else throw Error("where's the grapher?")
         expect(explorer.queryParams.tab).toEqual("map")
 
         explorer.onChangeChoice("Gas")("All GHGs (CO₂eq)")
 
-        expect(explorer.grapher.tab).toEqual("chart")
+        expect(explorer.grapher?.grapherState.tab).toEqual("chart")
         expect(explorer.queryParams.tab).toEqual(undefined)
     })
 
@@ -85,10 +87,10 @@ describe("inline data explorer", () => {
         expect(explorer.queryParams).toMatchObject({
             Test: "Scatter",
         })
-        expect(explorer.grapher?.xSlug).toEqual("x")
-        expect(explorer.grapher?.ySlugs).toEqual("y")
-        expect(explorer.grapher?.colorSlug).toEqual("color")
-        expect(explorer.grapher?.sizeSlug).toEqual("size")
+        expect(explorer.grapher?.grapherState?.xSlug).toEqual("x")
+        expect(explorer.grapher?.grapherState?.ySlugs).toEqual("y")
+        expect(explorer.grapher?.grapherState?.colorSlug).toEqual("color")
+        expect(explorer.grapher?.grapherState?.sizeSlug).toEqual("size")
     })
 
     it("clears column slugs that don't exist in current row", () => {
@@ -96,9 +98,9 @@ describe("inline data explorer", () => {
         expect(explorer.queryParams).toMatchObject({
             Test: "Line",
         })
-        expect(explorer.grapher?.xSlug).toEqual(undefined)
-        expect(explorer.grapher?.ySlugs).toEqual("y")
-        expect(explorer.grapher?.colorSlug).toEqual(undefined)
-        expect(explorer.grapher?.sizeSlug).toEqual(undefined)
+        expect(explorer.grapher?.grapherState?.xSlug).toEqual(undefined)
+        expect(explorer.grapher?.grapherState?.ySlugs).toEqual("y")
+        expect(explorer.grapher?.grapherState?.colorSlug).toEqual(undefined)
+        expect(explorer.grapher?.grapherState?.sizeSlug).toEqual(undefined)
     })
 })

--- a/packages/@ourworldindata/grapher/src/chart/DimensionSlot.ts
+++ b/packages/@ourworldindata/grapher/src/chart/DimensionSlot.ts
@@ -1,21 +1,21 @@
 // todo: remove
 
-import { Grapher } from "../core/Grapher"
+import { Grapher, GrapherState } from "../core/Grapher"
 import { computed } from "mobx"
 import { ChartDimension } from "./ChartDimension"
 import { DimensionProperty } from "@ourworldindata/utils"
 
 export class DimensionSlot {
-    private grapher: Grapher
+    private grapherState: GrapherState
     property: DimensionProperty
-    constructor(grapher: Grapher, property: DimensionProperty) {
-        this.grapher = grapher
+    constructor(grapher: GrapherState, property: DimensionProperty) {
+        this.grapherState = grapher
         this.property = property
     }
 
     @computed get name(): string {
         const names = {
-            y: this.grapher.isDiscreteBar ? "X axis" : "Y axis",
+            y: this.grapherState.isDiscreteBar ? "X axis" : "Y axis",
             x: "X axis",
             size: "Size",
             color: "Color",
@@ -28,7 +28,7 @@ export class DimensionSlot {
     @computed get allowMultiple(): boolean {
         return (
             this.property === DimensionProperty.y &&
-            this.grapher.supportsMultipleYColumns
+            this.grapherState.supportsMultipleYColumns
         )
     }
 
@@ -37,7 +37,7 @@ export class DimensionSlot {
     }
 
     @computed get dimensions(): ChartDimension[] {
-        return this.grapher.dimensions.filter(
+        return this.grapherState.dimensions.filter(
             (d) => d.property === this.property
         )
     }

--- a/packages/@ourworldindata/grapher/src/core/FetchingGrapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/FetchingGrapher.tsx
@@ -4,7 +4,7 @@ import {
     OwidVariableDataMetadataDimensions,
 } from "@ourworldindata/types"
 import React from "react"
-import { Grapher } from "./Grapher.js"
+import { Grapher, GrapherState } from "./Grapher.js"
 import { loadVariableDataAndMetadata } from "./loadVariable.js"
 import { legacyToOwidTableAndDimensionsWithMandatorySlug } from "./LegacyToOwidTable.js"
 import { OwidTable } from "@ourworldindata/core-table"
@@ -22,12 +22,18 @@ export function FetchingGrapher(
 ): JSX.Element | null {
     // if config is not provided, fetch it from configUrl
 
-    const [config, setConfig] = React.useState<GrapherInterface | undefined>(
-        props.config
+    const [config, setConfig] = React.useState<GrapherInterface>(
+        props.config ?? {}
     )
 
-    const [inputTable, setInputTable] = React.useState<OwidTable | undefined>(
-        undefined
+    const [grapherState, setGrapherState] = React.useState<GrapherState>(
+        new GrapherState({
+            ...config,
+            queryStr: props.queryString,
+            dataApiUrl: props.dataApiUrl,
+            adminBaseUrl: props.adminBaseUrl,
+            bakedGrapherURL: props.bakedGrapherURL,
+        })
     )
 
     React.useEffect(() => {
@@ -39,34 +45,41 @@ export function FetchingGrapher(
                 setConfig(fetchedConfig)
             }
             if (!config) return
-            const dimensions = config.dimensions || []
-            if (dimensions.length === 0) return
-            const variables = dimensions.map((d) => d.variableId)
-            const variablesDataMap = await loadVariablesDataSite(
-                variables,
+            const inputTable = await fetchInputTableForConfig(
+                config,
                 props.dataApiUrl
             )
-            const inputTable = legacyToOwidTableAndDimensionsWithMandatorySlug(
-                variablesDataMap,
-                dimensions,
-                config.selectedEntityColors
-            )
-            setInputTable(inputTable)
+            if (inputTable) grapherState.inputTable = inputTable
         }
         void fetchConfigAndLoadData()
-    }, [props.configUrl, config, props.dataApiUrl])
+    }, [
+        props.configUrl,
+        config,
+        props.dataApiUrl,
+        props.queryString,
+        props.adminBaseUrl,
+        props.bakedGrapherURL,
+        grapherState,
+    ])
 
-    if (!config) return null
-    if (!inputTable) return null
-    return (
-        <Grapher
-            table={inputTable}
-            queryStr={props.queryString}
-            dataApiUrl={props.dataApiUrl}
-            adminBaseUrl={props.adminBaseUrl}
-            bakedGrapherURL={props.bakedGrapherURL}
-        />
+    return <Grapher grapherState={grapherState} />
+}
+
+export async function fetchInputTableForConfig(
+    config: GrapherInterface,
+    dataApiUrl: string
+): Promise<OwidTable | undefined> {
+    const dimensions = config.dimensions || []
+    if (dimensions.length === 0) return undefined
+    const variables = dimensions.map((d) => d.variableId)
+    const variablesDataMap = await loadVariablesDataSite(variables, dataApiUrl)
+    const inputTable = legacyToOwidTableAndDimensionsWithMandatorySlug(
+        variablesDataMap,
+        dimensions,
+        config.selectedEntityColors
     )
+
+    return inputTable
 }
 
 // async function loadVariablesDataAdmin(

--- a/packages/@ourworldindata/grapher/src/core/Grapher.jsdom.test.ts
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.jsdom.test.ts
@@ -1,5 +1,9 @@
 #! /usr/bin/env jest
-import { Grapher, GrapherProgrammaticInterface } from "../core/Grapher"
+import {
+    Grapher,
+    GrapherProgrammaticInterface,
+    GrapherState,
+} from "../core/Grapher"
 import {
     GRAPHER_CHART_TYPES,
     EntitySelectionMode,
@@ -61,7 +65,7 @@ const TestGrapherConfig = (): {
 }
 
 it("regression fix: container options are not serialized", () => {
-    const grapher = new Grapher({ xAxis: { min: 1 } })
+    const grapher = new GrapherState({ xAxis: { min: 1 } })
     const obj = grapher.toObject().xAxis!
     expect(obj.min).toBe(1)
     expect(obj.scaleType).toBe(undefined)
@@ -69,7 +73,7 @@ it("regression fix: container options are not serialized", () => {
 })
 
 it("can get dimension slots", () => {
-    const grapher = new Grapher()
+    const grapher = new GrapherState({})
     expect(grapher.dimensionSlots.length).toBe(2)
 
     grapher.chartTypes = [GRAPHER_CHART_TYPES.ScatterPlot]
@@ -77,7 +81,7 @@ it("can get dimension slots", () => {
 })
 
 it("an empty Grapher serializes to an object that includes only the schema", () => {
-    expect(new Grapher().toObject()).toEqual({
+    expect(new GrapherState({}).toObject()).toEqual({
         $schema: latestGrapherConfigSchema,
     })
 })
@@ -86,14 +90,16 @@ it("a bad chart type does not crash grapher", () => {
     const input = {
         chartTypes: ["fff" as any],
     }
-    expect(new Grapher(input).toObject()).toEqual({
+    expect(new GrapherState(input).toObject()).toEqual({
         ...input,
         $schema: latestGrapherConfigSchema,
     })
 })
 
 it("does not preserve defaults in the object (except for the schema)", () => {
-    expect(new Grapher({ tab: GRAPHER_TAB_OPTIONS.chart }).toObject()).toEqual({
+    expect(
+        new GrapherState({ tab: GRAPHER_TAB_OPTIONS.chart }).toObject()
+    ).toEqual({
         $schema: latestGrapherConfigSchema,
     })
 })
@@ -146,7 +152,7 @@ const legacyConfig: Omit<LegacyGrapherInterface, "data"> &
 }
 
 it("can apply legacy chart dimension settings", () => {
-    const grapher = new Grapher(legacyConfig)
+    const grapher = new GrapherState(legacyConfig)
     const col = grapher.yColumnsFromDimensions[0]!
     expect(col.unit).toEqual(unit)
     expect(col.displayName).toEqual(name)
@@ -154,7 +160,7 @@ it("can apply legacy chart dimension settings", () => {
 
 it("correctly identifies changes to passed-in selection", () => {
     const selection = new SelectionArray()
-    const grapher = new Grapher({
+    const grapher = new GrapherState({
         ...legacyConfig,
         manager: { selection },
     })
@@ -173,7 +179,7 @@ it("can fallback to a ycolumn if a map variableId does not exist", () => {
         hasMapTab: true,
         map: { variableId: 444 },
     } as GrapherInterface
-    const grapher = new Grapher(config)
+    const grapher = new GrapherState(config)
     expect(grapher.mapColumnSlug).toEqual("3512")
 })
 
@@ -182,7 +188,7 @@ it("can generate a url with country selection even if there is no entity code", 
         ...legacyConfig,
         selectedEntityNames: [],
     }
-    const grapher = new Grapher(config)
+    const grapher = new GrapherState(config)
     expect(grapher.queryStr).toBe("")
     grapher.selection.selectAll()
     expect(grapher.queryStr).toContain("AFG")
@@ -194,7 +200,7 @@ it("can generate a url with country selection even if there is no entity code", 
     metadata.dimensions.entities.values.find(
         (entity) => entity.id === 15
     )!.code = undefined as any
-    const grapher2 = new Grapher(config2)
+    const grapher2 = new GrapherState(config2)
     expect(grapher2.queryStr).toBe("")
     grapher2.selection.selectAll()
     expect(grapher2.queryStr).toContain("AFG")
@@ -202,7 +208,7 @@ it("can generate a url with country selection even if there is no entity code", 
 
 describe("hasTimeline", () => {
     it("charts with timeline", () => {
-        const grapher = new Grapher(legacyConfig)
+        const grapher = new GrapherState(legacyConfig)
         grapher.chartTypes = [GRAPHER_CHART_TYPES.LineChart]
         expect(grapher.hasTimeline).toBeTruthy()
         grapher.chartTypes = [GRAPHER_CHART_TYPES.SlopeChart]
@@ -216,7 +222,7 @@ describe("hasTimeline", () => {
     })
 
     it("map tab has timeline even if chart doesn't", () => {
-        const grapher = new Grapher(legacyConfig)
+        const grapher = new GrapherState(legacyConfig)
         grapher.hideTimeline = true
         grapher.chartTypes = [GRAPHER_CHART_TYPES.LineChart]
         expect(grapher.hasTimeline).toBeFalsy()
@@ -227,8 +233,8 @@ describe("hasTimeline", () => {
     })
 })
 
-const getGrapher = (): Grapher =>
-    new Grapher({
+const getGrapher = (): GrapherState =>
+    new GrapherState({
         dimensions: [
             {
                 variableId: 142609,
@@ -286,8 +292,8 @@ const getGrapher = (): Grapher =>
 function fromQueryParams(
     params: LegacyGrapherQueryParams,
     props?: Partial<GrapherInterface>
-): Grapher {
-    const grapher = new Grapher(props)
+): GrapherState {
+    const grapher = new GrapherState(props ?? {})
     grapher.populateFromQueryParams(
         legacyToCurrentGrapherQueryParams(queryParamsToStr(params))
     )
@@ -297,7 +303,7 @@ function fromQueryParams(
 function toQueryParams(
     props?: Partial<GrapherInterface>
 ): Partial<GrapherQueryParams> {
-    const grapher = new Grapher({
+    const grapher = new GrapherState({
         minTime: -5000,
         maxTime: 5000,
         map: { time: 5000 },
@@ -307,8 +313,8 @@ function toQueryParams(
 }
 
 it("can serialize scaleType if it changes", () => {
-    expect(new Grapher().changedParams.xScale).toEqual(undefined)
-    const grapher = new Grapher({
+    expect(new GrapherState({}).changedParams.xScale).toEqual(undefined)
+    const grapher = new GrapherState({
         xAxis: { scaleType: ScaleType.linear },
     })
     expect(grapher.changedParams.xScale).toEqual(undefined)
@@ -322,7 +328,7 @@ describe("currentTitle", () => {
             { entityCount: 2, timeRange: [2000, 2010] },
             1
         )
-        const grapher = new Grapher({
+        const grapher = new GrapherState({
             table,
             selectedEntityNames: table.availableEntityNames,
             dimensions: [
@@ -357,7 +363,7 @@ describe("currentTitle", () => {
             { entityCount: 2, timeRange: [2000, 2010] },
             1
         )
-        const grapher = new Grapher({
+        const grapher = new GrapherState({
             table,
             ySlugs: "GDP",
         })
@@ -369,7 +375,7 @@ describe("currentTitle", () => {
 describe("authors can use maxTime", () => {
     it("can can create a discretebar chart with correct maxtime", () => {
         const table = SynthesizeGDPTable({ timeRange: [2000, 2010] })
-        const grapher = new Grapher({
+        const grapher = new GrapherState({
             table,
             chartTypes: [GRAPHER_CHART_TYPES.DiscreteBar],
             selectedEntityNames: table.availableEntityNames,
@@ -382,7 +388,7 @@ describe("authors can use maxTime", () => {
 })
 
 describe("line chart to bar chart and bar chart race", () => {
-    const grapher = new Grapher(TestGrapherConfig())
+    const grapher = new GrapherState(TestGrapherConfig())
 
     it("can create a new line chart with different start and end times", () => {
         expect(
@@ -394,7 +400,7 @@ describe("line chart to bar chart and bar chart race", () => {
     })
 
     describe("switches from a line chart to a bar chart when there is only 1 year selected", () => {
-        const grapher = new Grapher(TestGrapherConfig())
+        const grapher = new GrapherState(TestGrapherConfig())
         const lineSeries = grapher.chartInstance.series
 
         expect(
@@ -455,7 +461,7 @@ describe("line chart to bar chart and bar chart race", () => {
 
 describe("urls", () => {
     it("can change base url", () => {
-        const url = new Grapher({
+        const url = new GrapherState({
             isPublished: true,
             slug: "foo",
             bakedGrapherURL: "/grapher",
@@ -464,13 +470,13 @@ describe("urls", () => {
     })
 
     it("does not include country param in url if unchanged", () => {
-        const grapher = new Grapher(legacyConfig)
+        const grapher = new GrapherState(legacyConfig)
         grapher.isPublished = true
         expect(grapher.canonicalUrl?.includes("country")).toBeFalsy()
     })
 
     it("includes the tab param in embed url even if it's the default value", () => {
-        const grapher = new Grapher({
+        const grapher = new GrapherState({
             isPublished: true,
             slug: "foo",
             bakedGrapherURL: "/grapher",
@@ -491,7 +497,7 @@ describe("urls", () => {
     })
 
     it("doesn't apply selection if addCountryMode is 'disabled'", () => {
-        const grapher = new Grapher({
+        const grapher = new GrapherState({
             selectedEntityNames: ["usa", "canada"],
             addCountryMode: EntitySelectionMode.Disabled,
         })
@@ -503,19 +509,19 @@ describe("urls", () => {
     })
 
     it("parses tab=table correctly", () => {
-        const grapher = new Grapher()
+        const grapher = new GrapherState({})
         grapher.populateFromQueryParams({ tab: "table" })
         expect(grapher.activeTab).toEqual(GRAPHER_TAB_NAMES.Table)
     })
 
     it("parses tab=map correctly", () => {
-        const grapher = new Grapher()
+        const grapher = new GrapherState({})
         grapher.populateFromQueryParams({ tab: "map" })
         expect(grapher.activeTab).toEqual(GRAPHER_TAB_NAMES.WorldMap)
     })
 
     it("parses tab=chart correctly", () => {
-        const grapher = new Grapher({
+        const grapher = new GrapherState({
             chartTypes: [GRAPHER_CHART_TYPES.ScatterPlot],
         })
         grapher.populateFromQueryParams({ tab: "chart" })
@@ -523,7 +529,7 @@ describe("urls", () => {
     })
 
     it("parses tab=line and tab=slope correctly", () => {
-        const grapher = new Grapher({
+        const grapher = new GrapherState({
             chartTypes: [
                 GRAPHER_CHART_TYPES.LineChart,
                 GRAPHER_CHART_TYPES.SlopeChart,
@@ -536,7 +542,7 @@ describe("urls", () => {
     })
 
     it("switches to the first chart tab if the given chart isn't available", () => {
-        const grapher = new Grapher({
+        const grapher = new GrapherState({
             chartTypes: [
                 GRAPHER_CHART_TYPES.LineChart,
                 GRAPHER_CHART_TYPES.SlopeChart,
@@ -547,19 +553,19 @@ describe("urls", () => {
     })
 
     it("switches to the map tab if no chart is available", () => {
-        const grapher = new Grapher({ chartTypes: [], hasMapTab: true })
+        const grapher = new GrapherState({ chartTypes: [], hasMapTab: true })
         grapher.populateFromQueryParams({ tab: "line" })
         expect(grapher.activeTab).toEqual(GRAPHER_TAB_NAMES.WorldMap)
     })
 
     it("switches to the table tab if it's the only tab available", () => {
-        const grapher = new Grapher({ chartTypes: [] })
+        const grapher = new GrapherState({ chartTypes: [] })
         grapher.populateFromQueryParams({ tab: "line" })
         expect(grapher.activeTab).toEqual(GRAPHER_TAB_NAMES.Table)
     })
 
     it("adds tab=chart to the URL if there is a single chart tab", () => {
-        const grapher = new Grapher({
+        const grapher = new GrapherState({
             hasMapTab: true,
             tab: GRAPHER_TAB_OPTIONS.map,
         })
@@ -568,7 +574,7 @@ describe("urls", () => {
     })
 
     it("adds the chart type name as tab query param if there are multiple chart tabs", () => {
-        const grapher = new Grapher({
+        const grapher = new GrapherState({
             chartTypes: [
                 GRAPHER_CHART_TYPES.LineChart,
                 GRAPHER_CHART_TYPES.SlopeChart,
@@ -587,7 +593,7 @@ describe("time domain tests", () => {
         { entityCount: 2, timeRange: [2000, 2010] },
         seed
     ).replaceRandomCells(17, [SampleColumnSlugs.GDP], seed)
-    const grapher = new Grapher({
+    const grapher = new GrapherState({
         table,
         selectedEntityNames: table.availableEntityNames,
         dimensions: [
@@ -716,7 +722,7 @@ describe("time parameter", () => {
         })
 
         it("doesn't include URL param if it's identical to original config", () => {
-            const grapher = new Grapher({
+            const grapher = new GrapherState({
                 minTime: 0,
                 maxTime: 75,
             })
@@ -724,7 +730,7 @@ describe("time parameter", () => {
         })
 
         it("doesn't include URL param if unbounded is encoded as `undefined`", () => {
-            const grapher = new Grapher({
+            const grapher = new GrapherState({
                 minTime: undefined,
                 maxTime: 75,
             })
@@ -863,7 +869,7 @@ describe("time parameter", () => {
 
 it("canChangeEntity reflects all available entities before transforms", () => {
     const table = SynthesizeGDPTable()
-    const grapher = new Grapher({
+    const grapher = new GrapherState({
         addCountryMode: EntitySelectionMode.SingleEntity,
         table,
         selectedEntityNames: table.sampleEntityName(1),
@@ -986,7 +992,7 @@ it("correctly identifies activeColumnSlugs", () => {
         new OwidTable(`entityName,entityId,entityColor,year,gdp,gdp-annotations,child_mortality,population,continent,happiness
     Belgium,BEL,#f6f,2010,80000,pretty damn high,1.5,9000000,Europe,81.2
     `)
-    const grapher = new Grapher({
+    const grapher = new GrapherState({
         table,
         chartTypes: [GRAPHER_CHART_TYPES.ScatterPlot],
         xSlug: "gdp",
@@ -1023,7 +1029,7 @@ it("considers map tolerance before using column tolerance", () => {
         ]
     )
 
-    const grapher = new Grapher({
+    const grapher = new GrapherState({
         table,
         ySlugs: "gdp",
         tab: GRAPHER_TAB_OPTIONS.map,
@@ -1055,7 +1061,7 @@ describe("tableForSelection", () => {
     it("should include all available entities (LineChart)", () => {
         const table = SynthesizeGDPTable({ entityNames: ["A", "B"] })
 
-        const grapher = new Grapher({ table })
+        const grapher = new GrapherState({ table })
 
         expect(grapher.tableForSelection.availableEntityNames).toEqual([
             "A",
@@ -1084,7 +1090,7 @@ describe("tableForSelection", () => {
             [4, "France", "", 2000, 0, null, null, null], // y value missing
         ])
 
-        const grapher = new Grapher({
+        const grapher = new GrapherState({
             table,
             chartTypes: [GRAPHER_CHART_TYPES.ScatterPlot],
             excludedEntities: [3],
@@ -1120,7 +1126,7 @@ it("handles tolerance when there are gaps in ScatterPlot data", () => {
         ]
     )
 
-    const grapher = new Grapher({
+    const grapher = new GrapherState({
         table,
         chartTypes: [GRAPHER_CHART_TYPES.ScatterPlot],
         xSlug: "x",

--- a/packages/@ourworldindata/grapher/src/core/GrapherUrl.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherUrl.ts
@@ -9,7 +9,11 @@ import {
     generateSelectedEntityNamesParam,
 } from "./EntityUrlBuilder.js"
 import { match } from "ts-pattern"
-import { Grapher } from "./Grapher.js"
+import {
+    Grapher,
+    GrapherProgrammaticInterface,
+    GrapherState,
+} from "./Grapher.js"
 
 // This function converts a (potentially partial) GrapherInterface to the query params this translates to.
 // This is helpful for when we have a patch config to a parent chart, and we want to know which query params we need to get the parent chart as close as possible to the patched child chart.
@@ -78,12 +82,12 @@ export const grapherConfigToQueryParams = (
 }
 
 export const grapherObjectToQueryParams = (
-    grapher: Grapher
+    grapher: GrapherState
 ): GrapherQueryParams => {
     const params: GrapherQueryParams = {
         tab: grapher.mapGrapherTabToQueryParam(grapher.activeTab),
-        xScale: grapher.xAxis.scaleType,
-        yScale: grapher.yAxis.scaleType,
+        xScale: grapher.xAxis?.scaleType,
+        yScale: grapher.yAxis?.scaleType,
         stackMode: grapher.stackMode,
         zoomToSelection: grapher.zoomToSelection ? "true" : undefined,
         endpointsOnly: grapher.compareEndPointsOnly ? "1" : "0",

--- a/packages/@ourworldindata/grapher/src/core/GrapherWithChartTypes.jsdom.test.tsx
+++ b/packages/@ourworldindata/grapher/src/core/GrapherWithChartTypes.jsdom.test.tsx
@@ -5,14 +5,18 @@ import {
     SynthesizeGDPTable,
     SampleColumnSlugs,
 } from "@ourworldindata/core-table"
-import { Grapher, GrapherProgrammaticInterface } from "../core/Grapher"
+import {
+    Grapher,
+    GrapherProgrammaticInterface,
+    GrapherState,
+} from "../core/Grapher"
 import { MapChart } from "../mapCharts/MapChart"
 import { legacyMapGrapher } from "../mapCharts/MapChart.sample"
 import { GRAPHER_CHART_TYPES } from "@ourworldindata/types"
 
 describe("grapher and map charts", () => {
     describe("map time tolerance plus query string works with a map chart", () => {
-        const grapher = new Grapher(legacyMapGrapher)
+        const grapher = new GrapherState(legacyMapGrapher)
         expect(grapher.mapColumnSlug).toBe("3512")
         expect(grapher.inputTable.minTime).toBe(2000)
         expect(grapher.inputTable.maxTime).toBe(2010)
@@ -26,7 +30,7 @@ describe("grapher and map charts", () => {
     })
 
     it("can change time and see more points", () => {
-        const manager = new Grapher(legacyMapGrapher)
+        const manager = new GrapherState(legacyMapGrapher)
         const chart = new MapChart({ manager })
 
         expect(Object.keys(chart.series).length).toEqual(1)
@@ -49,7 +53,7 @@ const basicGrapherConfig: GrapherProgrammaticInterface = {
 }
 
 describe("grapher and discrete bar charts", () => {
-    const grapher = new Grapher({
+    const grapher = new GrapherState({
         chartTypes: [GRAPHER_CHART_TYPES.DiscreteBar],
         ...basicGrapherConfig,
     })

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.sample.ts
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.sample.ts
@@ -1,5 +1,5 @@
 import { DimensionProperty } from "@ourworldindata/utils"
-import { Grapher } from "../core/Grapher"
+import { Grapher, GrapherState } from "../core/Grapher"
 import { GRAPHER_TAB_OPTIONS, GrapherInterface } from "@ourworldindata/types"
 import {
     TestMetadata,
@@ -9,7 +9,7 @@ import {
 
 export const childMortalityGrapher = (
     props: Partial<GrapherInterface> = {}
-): Grapher => {
+): GrapherState => {
     const childMortalityId = 104402
     const childMortalityMetadata: TestMetadata = {
         id: childMortalityId,
@@ -36,7 +36,7 @@ export const childMortalityGrapher = (
             property: DimensionProperty.y,
         },
     ]
-    return new Grapher({
+    return new GrapherState({
         hasMapTab: true,
         tab: GRAPHER_TAB_OPTIONS.map,
         dimensions,
@@ -52,7 +52,7 @@ export const childMortalityGrapher = (
 
 export const GrapherWithIncompleteData = (
     props: Partial<GrapherInterface> = {}
-): Grapher => {
+): GrapherState => {
     const indicatorId = 3512
     const metadata = { id: indicatorId, shortUnit: "%" }
     const data = [
@@ -84,7 +84,7 @@ export const GrapherWithIncompleteData = (
             },
         },
     ]
-    return new Grapher({
+    return new GrapherState({
         tab: GRAPHER_TAB_OPTIONS.table,
         selectedEntityNames: ["Iceland", "France", "Afghanistan"],
         dimensions,
@@ -95,7 +95,7 @@ export const GrapherWithIncompleteData = (
 
 export const GrapherWithAggregates = (
     props: Partial<GrapherInterface> = {}
-): Grapher => {
+): GrapherState => {
     const childMortalityId = 104402
     const childMortalityMetadata: TestMetadata = {
         id: childMortalityId,
@@ -125,7 +125,7 @@ export const GrapherWithAggregates = (
             property: DimensionProperty.y,
         },
     ]
-    return new Grapher({
+    return new GrapherState({
         tab: GRAPHER_TAB_OPTIONS.table,
         dimensions,
         selectedEntityNames: ["Afghanistan", "Iceland", "World"],
@@ -138,7 +138,7 @@ export const GrapherWithAggregates = (
 
 export const GrapherWithMultipleVariablesAndMultipleYears = (
     props: Partial<GrapherInterface> = {}
-): Grapher => {
+): GrapherState => {
     const abovePovertyLineId = 514050
     const belowPovertyLineId = 472265
 
@@ -170,7 +170,7 @@ export const GrapherWithMultipleVariablesAndMultipleYears = (
         ],
     }
 
-    return new Grapher({
+    return new GrapherState({
         tab: GRAPHER_TAB_OPTIONS.table,
         dimensions,
         ...props,

--- a/packages/@ourworldindata/grapher/src/index.ts
+++ b/packages/@ourworldindata/grapher/src/index.ts
@@ -7,7 +7,10 @@ export {
     type ColorScaleBin,
 } from "./color/ColorScaleBin"
 export { ChartDimension } from "./chart/ChartDimension"
-export { FetchingGrapher } from "./core/FetchingGrapher"
+export {
+    FetchingGrapher,
+    fetchInputTableForConfig,
+} from "./core/FetchingGrapher"
 export {
     GRAPHER_EMBEDDED_FIGURE_ATTR,
     GRAPHER_EMBEDDED_FIGURE_CONFIG_ATTR,
@@ -55,6 +58,7 @@ export {
 export { GlobalEntitySelector } from "./controls/globalEntitySelector/GlobalEntitySelector"
 export {
     Grapher,
+    GrapherState,
     type GrapherProgrammaticInterface,
     type GrapherManager,
     getErrorMessageRelatedQuestionUrl,

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
@@ -244,6 +244,7 @@ export class MapChart
             id: feature.id,
             series: series || { value: "No data" },
         }
+        console.log("Changing focusEntity")
 
         if (feature.id !== undefined) {
             const featureId = feature.id as string,

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapTooltip.jsdom.test.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapTooltip.jsdom.test.tsx
@@ -1,12 +1,14 @@
 #! /usr/bin/env jest
-import { Grapher } from "../core/Grapher.js"
+import { Grapher, GrapherState } from "../core/Grapher.js"
 import { legacyMapGrapher } from "./MapChart.sample.js"
 
 import Enzyme from "enzyme"
 import Adapter from "@wojtekmaj/enzyme-adapter-react-17"
 Enzyme.configure({ adapter: new Adapter() })
 
-const grapherWrapper = Enzyme.mount(<Grapher {...legacyMapGrapher} />)
+const grapherWrapper = Enzyme.mount(
+    <Grapher grapherState={new GrapherState({ ...legacyMapGrapher })} />
+)
 
 test("map tooltip renders iff mouseenter", () => {
     expect(grapherWrapper.find(".Tooltip")).toHaveLength(0)

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.test.ts
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.test.ts
@@ -27,7 +27,7 @@ import {
 import { ContinentColors } from "../color/CustomSchemes"
 import { sortBy, uniq, uniqBy } from "@ourworldindata/utils"
 import { ScatterPointsWithLabels } from "./ScatterPointsWithLabels"
-import { Grapher } from "../core/Grapher"
+import { Grapher, GrapherState } from "../core/Grapher"
 
 it("can create a new chart", () => {
     const manager: ScatterPlotManager = {
@@ -142,7 +142,7 @@ describe("interpolation defaults", () => {
         ]
     )
 
-    const grapher = new Grapher({
+    const grapher = new GrapherState({
         table,
         chartTypes: [GRAPHER_CHART_TYPES.ScatterPlot],
         xSlug: "x",
@@ -199,7 +199,7 @@ describe("basic scatterplot", () => {
         ]
     )
 
-    const grapher = new Grapher({
+    const grapher = new GrapherState({
         chartTypes: [GRAPHER_CHART_TYPES.ScatterPlot],
         xSlug: "x",
         ySlugs: "y",
@@ -429,7 +429,7 @@ describe("entity exclusion", () => {
         ]
     )
 
-    const grapher = new Grapher({
+    const grapher = new GrapherState({
         chartTypes: [GRAPHER_CHART_TYPES.ScatterPlot],
         xSlug: "x",
         ySlugs: "y",
@@ -819,7 +819,7 @@ describe("x/y tolerance", () => {
         ]
     )
 
-    const grapher = new Grapher({
+    const grapher = new GrapherState({
         chartTypes: [GRAPHER_CHART_TYPES.ScatterPlot],
         xSlug: "x",
         ySlugs: "y",
@@ -1064,7 +1064,7 @@ it("applies color tolerance before applying the author timeline filter", () => {
         ]
     )
 
-    const grapher = new Grapher({
+    const grapher = new GrapherState({
         table,
         chartTypes: [GRAPHER_CHART_TYPES.ScatterPlot],
         xSlug: "x",

--- a/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChart.jsdom.test.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChart.jsdom.test.tsx
@@ -3,7 +3,7 @@
 import { Bounds, ColumnTypeNames, omit } from "@ourworldindata/utils"
 import { OwidTable } from "@ourworldindata/core-table"
 import { DefaultColorScheme } from "../color/CustomSchemes"
-import { Grapher } from "../core/Grapher"
+import { Grapher, GrapherState } from "../core/Grapher"
 import { GRAPHER_CHART_TYPES } from "@ourworldindata/types"
 import { MarimekkoChart } from "./MarimekkoChart"
 import { BarShape, PlacedItem } from "./MarimekkoChartConstants"
@@ -30,7 +30,7 @@ it("can filter years correctly", () => {
         xSlug: "population",
         endTime: 2001,
     }
-    const grapher = new Grapher(manager)
+    const grapher = new GrapherState(manager)
     const chart = new MarimekkoChart({
         manager: grapher,
         bounds: new Bounds(0, 0, 1000, 1000),
@@ -140,7 +140,7 @@ it("shows no data points at the end", () => {
         xSlug: "population",
         endTime: 2001,
     }
-    const grapher = new Grapher(manager)
+    const grapher = new GrapherState(manager)
     const chart = new MarimekkoChart({
         manager: grapher,
         bounds: new Bounds(0, 0, 1001, 1000),
@@ -240,7 +240,7 @@ test("interpolation works as expected", () => {
         xSlug: "population",
         endTime: 2001,
     }
-    const grapher = new Grapher(manager)
+    const grapher = new GrapherState(manager)
     const chart = new MarimekkoChart({
         manager: grapher,
         bounds: new Bounds(0, 0, 1000, 1000),
@@ -351,7 +351,7 @@ it("can deal with y columns with missing values", () => {
         xSlug: "population",
         endTime: 2001,
     }
-    const grapher = new Grapher(manager)
+    const grapher = new GrapherState(manager)
     const chart = new MarimekkoChart({
         manager: grapher,
         bounds: new Bounds(0, 0, 1000, 1000),

--- a/packages/@ourworldindata/grapher/src/testData/OwidTestData.sample.ts
+++ b/packages/@ourworldindata/grapher/src/testData/OwidTestData.sample.ts
@@ -1,5 +1,9 @@
 import { DimensionProperty } from "@ourworldindata/utils"
-import { Grapher, GrapherProgrammaticInterface } from "../core/Grapher"
+import {
+    Grapher,
+    GrapherProgrammaticInterface,
+    GrapherState,
+} from "../core/Grapher"
 import {
     TestMetadata,
     createOwidTestDataset,
@@ -13,7 +17,7 @@ Grapher properties:
  */
 export const LifeExpectancyGrapher = (
     props: Partial<GrapherProgrammaticInterface> = {}
-): Grapher => {
+): GrapherState => {
     const lifeExpectancyId = 815383
     const lifeExpectancyMetadata: TestMetadata = {
         id: lifeExpectancyId,
@@ -55,7 +59,7 @@ export const LifeExpectancyGrapher = (
             property: DimensionProperty.y,
         },
     ]
-    return new Grapher({
+    return new GrapherState({
         ...props,
         dimensions,
         owidDataset: createOwidTestDataset([

--- a/site/DataPageV2Content.tsx
+++ b/site/DataPageV2Content.tsx
@@ -1,12 +1,17 @@
 import { useMemo } from "react"
 import {
     FetchingGrapher,
+    fetchInputTableForConfig,
+    Grapher,
     GrapherProgrammaticInterface,
+    GrapherState,
+    MapChart,
 } from "@ourworldindata/grapher"
 import {
     REUSE_THIS_WORK_SECTION_ID,
     DATAPAGE_SOURCES_AND_PROCESSING_SECTION_ID,
 } from "@ourworldindata/components"
+import ReactDOM from "react-dom"
 import { RelatedCharts } from "./blocks/RelatedCharts.js"
 import {
     DataPageV2ContentFields,
@@ -14,9 +19,9 @@ import {
     joinTitleFragments,
     ImageMetadata,
 } from "@ourworldindata/utils"
-import { DocumentContext } from "./gdocs/DocumentContext.js"
-import { AttachmentsContext } from "./gdocs/AttachmentsContext.js"
+import { AttachmentsContext, DocumentContext } from "./gdocs/OwidGdoc.js"
 import StickyNav from "./blocks/StickyNav.js"
+import { DebugProvider } from "./gdocs/DebugContext.js"
 import {
     ADMIN_BASE_URL,
     BAKED_GRAPHER_URL,
@@ -134,12 +139,8 @@ export const DataPageV2Content = ({
                     </nav>
                     <div className="span-cols-14 grid grid-cols-12-full-width full-width--border">
                         <div className="chart-key-info col-start-2 span-cols-12">
-                            <FetchingGrapher
-                                config={mergedGrapherConfig}
-                                dataApiUrl={DATA_API_URL}
-                                adminBaseUrl={ADMIN_BASE_URL}
-                                bakedGrapherURL={BAKED_GRAPHER_URL}
-                            />
+                            <Grapher grapherState={grapher1State} />
+                            <Grapher grapherState={grapher2State} />
                             <AboutThisData
                                 datapageData={datapageData}
                                 hasFaq={!!faqEntries?.faqs.length}
@@ -187,5 +188,22 @@ export const DataPageV2Content = ({
                 </div>
             </DocumentContext.Provider>
         </AttachmentsContext.Provider>
+    )
+}
+
+export const hydrateDataPageV2Content = (isPreviewing?: boolean) => {
+    const wrapper = document.querySelector(`#${OWID_DATAPAGE_CONTENT_ROOT_ID}`)
+    const props: DataPageV2ContentFields = window._OWID_DATAPAGEV2_PROPS
+    const grapherConfig = window._OWID_GRAPHER_CONFIG
+
+    ReactDOM.hydrate(
+        <DebugProvider debug={isPreviewing}>
+            <DataPageV2Content
+                {...props}
+                grapherConfig={grapherConfig}
+                isPreviewing={isPreviewing}
+            />
+        </DebugProvider>,
+        wrapper
     )
 }

--- a/site/GrapherFigureView.tsx
+++ b/site/GrapherFigureView.tsx
@@ -1,6 +1,10 @@
 import { useRef } from "react"
 
-import { Grapher, GrapherProgrammaticInterface } from "@ourworldindata/grapher"
+import {
+    Grapher,
+    GrapherProgrammaticInterface,
+    GrapherState,
+} from "@ourworldindata/grapher"
 import {
     ADMIN_BASE_URL,
     BAKED_GRAPHER_URL,
@@ -19,28 +23,25 @@ export const GrapherFigureView = ({
     const base = useRef<HTMLDivElement>(null)
     const bounds = useElementBounds(base)
 
-    const grapherProps: GrapherProgrammaticInterface = {
-        ...grapher.toObject(),
-        isEmbeddedInADataPage: grapher.isEmbeddedInADataPage,
-        bindUrlToWindow: grapher.props.bindUrlToWindow,
-        queryStr: grapher.props.bindUrlToWindow
+    const grapherState: GrapherState = new GrapherState({
+        ...grapher.grapherState.toObject(),
+        isEmbeddedInADataPage: grapher.grapherState.isEmbeddedInADataPage,
+        bindUrlToWindow: grapher.grapherState.initialOptions.bindUrlToWindow,
+        queryStr: grapher.grapherState.initialOptions.bindUrlToWindow
             ? window.location.search
-            : undefined,
+            : "", // TODO: 2025-01-03 changed this from undefined to empty string - is this a problem?
         bounds,
         dataApiUrl: DATA_API_URL,
         enableKeyboardShortcuts: true,
+        adminBaseUrl: ADMIN_BASE_URL,
+        bakedGrapherURL: BAKED_GRAPHER_URL,
         ...extraProps,
-    }
+    })
     return (
         // They key= in here makes it so that the chart is re-loaded when the slug changes.
         <figure data-grapher-src ref={base}>
             {bounds && (
-                <Grapher
-                    key={grapherProps.slug}
-                    {...grapherProps}
-                    adminBaseUrl={ADMIN_BASE_URL}
-                    bakedGrapherURL={BAKED_GRAPHER_URL}
-                />
+                <Grapher key={grapherState.slug} grapherState={grapherState} />
             )}
         </figure>
     )


### PR DESCRIPTION
This PR is a part of a stack and not intended to be merged on it's own or maybe even reviewed on it's own. The tests fail on this and Grapher does not in most places load it's data anymore.

This is the first of two big PRs - this one moves almost all Grapher observables and computed props into the new `GrapherState` class. It doesn't fix the usage sites yet so while the lerna packages compile, the rest of the typescript projects (admin, site, ...) don't.

I'm not sure if this PR can be reasonably reviewed on it's own or if the entire stack should be looked at in one go.