### PR TITLE
🎉 (line) allow to disconnect lines / TAS-775

### DIFF
--- a/adminSiteClient/DimensionCard.tsx
+++ b/adminSiteClient/DimensionCard.tsx
@@ -51,8 +51,8 @@ export class DimensionCard<
         this.onChange()
     }
 
-    @action.bound onIsConnected(value: boolean) {
-        this.props.dimension.display.isConnected = value
+    @action.bound onPlotMarkersOnly(value: boolean) {
+        this.props.dimension.display.plotMarkersOnlyInLineChart = value
         this.onChange()
     }
 
@@ -259,9 +259,12 @@ export class DimensionCard<
                         )}
                         {grapher.isLineChart && (
                             <Toggle
-                                label="Is connected"
-                                value={column.display?.isConnected ?? true}
-                                onValue={this.onIsConnected}
+                                label="Plot markers only"
+                                value={
+                                    column.display
+                                        ?.plotMarkersOnlyInLineChart ?? false
+                                }
+                                onValue={this.onPlotMarkersOnly}
                             />
                         )}
                         <hr className="ui divider" />

--- a/adminSiteClient/DimensionCard.tsx
+++ b/adminSiteClient/DimensionCard.tsx
@@ -51,6 +51,11 @@ export class DimensionCard<
         this.onChange()
     }
 
+    @action.bound onIsConnected(value: boolean) {
+        this.props.dimension.display.isConnected = value
+        this.onChange()
+    }
+
     @action.bound onColor(color: string | undefined) {
         this.props.dimension.display.color = color
         this.onChange()
@@ -250,6 +255,13 @@ export class DimensionCard<
                                 label="Is projection"
                                 value={column.isProjection}
                                 onValue={this.onIsProjection}
+                            />
+                        )}
+                        {grapher.isLineChart && (
+                            <Toggle
+                                label="Is connected"
+                                value={column.display?.isConnected ?? true}
+                                onValue={this.onIsConnected}
                             />
                         )}
                         <hr className="ui divider" />

--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
@@ -127,6 +127,7 @@ const VARIABLE_COLOR_STROKE_WIDTH = 2.5
 // marker radius
 const DEFAULT_MARKER_RADIUS = 1.8
 const VARIABLE_COLOR_MARKER_RADIUS = 2.2
+const DISCONNECTED_DOTS_MARKER_RADIUS = 2.6
 // line outline
 const DEFAULT_LINE_OUTLINE_WIDTH = 0.5
 const VARIABLE_COLOR_LINE_OUTLINE_WIDTH = 1.0
@@ -151,8 +152,12 @@ class Lines extends React.Component<LinesProps> {
         return this.props.lineStrokeWidth ?? DEFAULT_STROKE_WIDTH
     }
 
-    @computed private get lineOutlineWidth(): number {
+    @computed private get outlineWidth(): number {
         return this.props.lineOutlineWidth ?? DEFAULT_LINE_OUTLINE_WIDTH
+    }
+
+    @computed private get outlineColor(): string {
+        return this.props.backgroundColor ?? GRAPHER_BACKGROUND_DEFAULT
     }
 
     // Don't display point markers if there are very many of them for performance reasons
@@ -167,13 +172,28 @@ class Lines extends React.Component<LinesProps> {
         return totalPoints < 500
     }
 
+    @computed private get hasDisconnectedSeries(): boolean {
+        return this.props.series.some((series) => !series.isConnected)
+    }
+
     private seriesHasMarkers(series: RenderLineChartSeries): boolean {
-        if (series.hover.background || series.isProjection) return false
+        if (
+            series.hover.background ||
+            series.isProjection ||
+            // if the series is connected, but there is another one that isn't connected,
+            // don't show markers since the connected series is likely a smoothed version
+            (this.hasDisconnectedSeries && series.isConnected)
+        )
+            return false
         return !series.focus.background || series.hover.active
     }
 
-    private renderLine(series: RenderLineChartSeries): React.ReactElement {
+    private renderLine(
+        series: RenderLineChartSeries
+    ): React.ReactElement | void {
         const { hover, focus } = series
+
+        if (!series.isConnected) return
 
         const seriesColor = series.placedPoints[0]?.color ?? DEFAULT_LINE_COLOR
         const color =
@@ -190,9 +210,8 @@ class Lines extends React.Component<LinesProps> {
             hover.background && !focus.background ? GRAPHER_OPACITY_MUTE : 1
 
         const showOutline = !focus.background || hover.active
-        const outlineColor =
-            this.props.backgroundColor ?? GRAPHER_BACKGROUND_DEFAULT
-        const outlineWidth = strokeWidth + this.lineOutlineWidth * 2
+        const outlineColor = this.outlineColor
+        const outlineWidth = strokeWidth + this.outlineWidth * 2
 
         const outline = (
             <LinePath
@@ -238,9 +257,12 @@ class Lines extends React.Component<LinesProps> {
         const { horizontalAxis } = this.props.dualAxis
         const { hover, focus } = series
 
-        // If the series only contains one point, then we will always want to
-        // show a marker/circle because we can't draw a line.
-        const forceMarkers = series.placedPoints.length === 1
+        const forceMarkers =
+            // If the series only contains one point, then we will always want to
+            // show a marker/circle because we can't draw a line.
+            series.placedPoints.length === 1 ||
+            // If no line is plotted, we'll always want to show markers
+            !series.isConnected
 
         // check if we should hide markers on the chart and series level
         const hideMarkers = !this.hasMarkers || !this.seriesHasMarkers(series)
@@ -249,6 +271,9 @@ class Lines extends React.Component<LinesProps> {
 
         const opacity =
             hover.background && !focus.background ? GRAPHER_OPACITY_MUTE : 1
+
+        const outlineColor = !series.isConnected ? this.outlineColor : undefined
+        const outlineWidth = !series.isConnected ? this.outlineWidth : undefined
 
         return (
             <g id={makeIdForHumanConsumption("markers", series.seriesName)}>
@@ -268,6 +293,8 @@ class Lines extends React.Component<LinesProps> {
                             cy={value.y}
                             r={this.markerRadius}
                             fill={color}
+                            stroke={outlineColor}
+                            strokeWidth={outlineWidth}
                             opacity={opacity}
                         />
                     )
@@ -521,9 +548,9 @@ export class LineChart
     }
 
     @computed private get markerRadius(): number {
-        return this.hasColorScale
-            ? VARIABLE_COLOR_MARKER_RADIUS
-            : DEFAULT_MARKER_RADIUS
+        if (this.hasDisconnectedSeries) return DISCONNECTED_DOTS_MARKER_RADIUS
+        if (this.hasColorScale) return VARIABLE_COLOR_MARKER_RADIUS
+        return DEFAULT_MARKER_RADIUS
     }
 
     @computed get selectionArray(): SelectionArray {
@@ -845,6 +872,10 @@ export class LineChart
         return this.hasColorScale ? 700 : 400
     }
 
+    @computed get hidePoints(): boolean {
+        return !!this.manager.hidePoints || !!this.manager.isStaticAndSmall
+    }
+
     @computed get lineLegendX(): number {
         return this.bounds.right - this.lineLegendWidth
     }
@@ -975,7 +1006,7 @@ export class LineChart
                     dualAxis={this.dualAxis}
                     series={this.renderSeries}
                     multiColor={this.hasColorScale}
-                    hidePoints={manager.hidePoints || manager.isStaticAndSmall}
+                    hidePoints={this.hidePoints}
                     lineStrokeWidth={this.lineStrokeWidth}
                     lineOutlineWidth={this.lineOutlineWidth}
                     backgroundColor={this.manager.backgroundColor}
@@ -1285,6 +1316,7 @@ export class LineChart
             points,
             seriesName,
             isProjection: column.isProjection,
+            isConnected: column.display?.isConnected ?? true,
             color: seriesColor,
         }
     }
@@ -1296,6 +1328,10 @@ export class LineChart
                     this.constructSingleSeries(entityName, col)
             )
         )
+    }
+
+    @computed private get hasDisconnectedSeries(): boolean {
+        return this.series.some((series) => !series.isConnected)
     }
 
     // TODO: remove, seems unused
@@ -1341,7 +1377,7 @@ export class LineChart
     }
 
     @computed get renderSeries(): RenderLineChartSeries[] {
-        const series: RenderLineChartSeries[] = this.placedSeries.map(
+        let series: RenderLineChartSeries[] = this.placedSeries.map(
             (series) => {
                 return {
                     ...series,
@@ -1351,10 +1387,13 @@ export class LineChart
             }
         )
 
+        // draw connected series on top of disconnected ones
+        series = sortBy(series, (series) => series.isConnected)
+
         // sort by interaction state so that foreground series
         // are drawn on top of background series
         if (this.isHoverModeActive || this.isFocusModeActive) {
-            return sortBy(series, byHoverThenFocusState)
+            series = sortBy(series, byHoverThenFocusState)
         }
 
         return series

--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChartConstants.ts
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChartConstants.ts
@@ -23,7 +23,7 @@ export interface PlacedPoint {
 
 export interface LineChartSeries extends ChartSeries {
     isProjection?: boolean
-    isConnected?: boolean
+    plotMarkersOnly?: boolean
     points: LinePoint[]
 }
 

--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChartConstants.ts
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChartConstants.ts
@@ -23,6 +23,7 @@ export interface PlacedPoint {
 
 export interface LineChartSeries extends ChartSeries {
     isProjection?: boolean
+    isConnected?: boolean
     points: LinePoint[]
 }
 

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.006.yaml
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.006.yaml
@@ -266,11 +266,11 @@ properties:
                             description: |
                                 Indicates if this time series is a forward projection (if yes then this is rendered
                                 differently in e.g. line charts)
-                        isConnected:
+                        plotMarkersOnlyInLineChart:
                             type: boolean
                             default: false
                             description: |
-                                Indicates if this time series should be connected with a line. Only relevant for line charts.
+                                Indicates if data points should be connected with a line in a line chart
                         name:
                             type: string
                             description: The display string for this variable

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.006.yaml
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.006.yaml
@@ -266,6 +266,11 @@ properties:
                             description: |
                                 Indicates if this time series is a forward projection (if yes then this is rendered
                                 differently in e.g. line charts)
+                        isConnected:
+                            type: boolean
+                            default: false
+                            description: |
+                                Indicates if this time series should be connected with a line. Only relevant for line charts.
                         name:
                             type: string
                             description: The display string for this variable

--- a/packages/@ourworldindata/types/src/OwidVariableDisplayConfigInterface.ts
+++ b/packages/@ourworldindata/types/src/OwidVariableDisplayConfigInterface.ts
@@ -21,7 +21,7 @@ export interface OwidVariableDisplayConfigInterface {
     includeInTable?: boolean
     tableDisplay?: OwidVariableDataTableConfigInterface
     color?: string
-    isConnected?: boolean
+    plotMarkersOnlyInLineChart?: boolean
 }
 
 // todo: flatten onto the above

--- a/packages/@ourworldindata/types/src/OwidVariableDisplayConfigInterface.ts
+++ b/packages/@ourworldindata/types/src/OwidVariableDisplayConfigInterface.ts
@@ -21,6 +21,7 @@ export interface OwidVariableDisplayConfigInterface {
     includeInTable?: boolean
     tableDisplay?: OwidVariableDataTableConfigInterface
     color?: string
+    isConnected?: boolean
 }
 
 // todo: flatten onto the above

--- a/packages/@ourworldindata/utils/src/OwidVariable.ts
+++ b/packages/@ourworldindata/utils/src/OwidVariable.ts
@@ -29,6 +29,7 @@ class OwidVariableDisplayConfigDefaults {
     @observable includeInTable? = true
     @observable tableDisplay?: OwidVariableDataTableConfigInterface
     @observable color?: string = undefined
+    @observable isConnected?: boolean = undefined
 }
 
 export class OwidVariableDisplayConfig

--- a/packages/@ourworldindata/utils/src/OwidVariable.ts
+++ b/packages/@ourworldindata/utils/src/OwidVariable.ts
@@ -29,7 +29,7 @@ class OwidVariableDisplayConfigDefaults {
     @observable includeInTable? = true
     @observable tableDisplay?: OwidVariableDataTableConfigInterface
     @observable color?: string = undefined
-    @observable isConnected?: boolean = undefined
+    @observable plotMarkersOnlyInLineChart?: boolean = undefined
 }
 
 export class OwidVariableDisplayConfig


### PR DESCRIPTION
Resolves https://github.com/owid/owid-grapher/issues/2824

Allow line charts to plot indicators with markers only.

Example on staging: http://staging-site-disconnect-lines/admin/charts/8428/edit

### Summary

- Adds a new flag to the `display` object of an indicator, `plotMarkersOnlyInLineChart`
- If the flag is enabled for an indicator, then the line chart only draws markers (and doesn't connect data points by a line)
- Marker-only mode for projections is not supported

I struggled to come up with a good name and in the end went with something explicit, `plotMarkersOnlyInLineChart`. I'm happy to rename if we come up with a better name.

I don't know why the default config action is failing, but I don't think it's related to the changes in this PR.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #4406 
- <kbd>&nbsp;2&nbsp;</kbd> #4405 
- <kbd>&nbsp;1&nbsp;</kbd> #4382 👈 
<!-- GitButler Footer Boundary Bottom -->

