### PR TITLE
new table for chart (and possibly other objects) revisions

### DIFF
--- a/db/migration/1736177572560-HousekeepingSuggestedReviews.ts
+++ b/db/migration/1736177572560-HousekeepingSuggestedReviews.ts
@@ -1,7 +1,8 @@
-import { MigrationInterface, QueryRunner } from "typeorm";
+import { MigrationInterface, QueryRunner } from "typeorm"
 
-export class HousekeepingSuggestedReviews1736177572560 implements MigrationInterface {
-
+export class HousekeepingSuggestedReviews1736177572560
+    implements MigrationInterface
+{
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`-- sql
             CREATE TABLE housekeeping_suggested_reviews (
@@ -14,7 +15,6 @@ export class HousekeepingSuggestedReviews1736177572560 implements MigrationInter
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`DROP TABLE housekeeping_suggested_reviews`);
+        await queryRunner.query(`DROP TABLE housekeeping_suggested_reviews`)
     }
-
 }

--- a/db/migration/1736177572560-HousekeepingSuggestedReviews.ts
+++ b/db/migration/1736177572560-HousekeepingSuggestedReviews.ts
@@ -1,0 +1,20 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class HousekeepingSuggestedReviews1736177572560 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`-- sql
+            CREATE TABLE housekeeping_suggested_reviews (
+                id INTEGER NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT "Identifier of the review",
+                suggestedAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP COMMENT "Date where the review was suggested",
+                objectType VARCHAR(255) NOT NULL UNIQUE COMMENT "Type of the object to review (e.g. 'chart', 'dataset', etc.)",
+                objectId CHAR(36) NOT NULL COMMENT "ID of the object to review"
+            )
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP TABLE housekeeping_suggested_reviews`);
+    }
+
+}


### PR DESCRIPTION
[Tracking issue](https://github.com/owid/owid-issues/issues/1777)

In https://github.com/owid/etl/pull/3792 I'm working on a bot that will suggest a chart for revision daily. It'll be a public chart, that has few visits.

We want to avoid suggesting the same chart multiple times, so we need to track what has already been suggested. This PR adds a new table for that.

I had thought of a table named `suggested_reviews`, with columns `id`, `type`, `date`. Where `type` can be 'chart', 'dataset', etc.
