### PR TITLE
housekeeper: this pr fixes all previous migrations

### DIFF
--- a/db/migration/1736177572560-HousekeepingSuggestedReviews.ts
+++ b/db/migration/1736177572560-HousekeepingSuggestedReviews.ts
@@ -5,7 +5,7 @@ export class HousekeepingSuggestedReviews1736177572560
 {
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`-- sql
-            CREATE TABLE housekeeping_suggested_reviews (
+            CREATE TABLE IF NOT EXISTS housekeeping_suggested_reviews (
                 id INTEGER NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT "Identifier of the review",
                 suggestedAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP COMMENT "Date where the review was suggested",
                 objectType VARCHAR(255) NOT NULL UNIQUE COMMENT "Type of the object to review (e.g. 'chart', 'dataset', etc.)",

--- a/db/migration/1736209759039-RemoveHousekeepingSuggestedReviews.ts
+++ b/db/migration/1736209759039-RemoveHousekeepingSuggestedReviews.ts
@@ -1,7 +1,8 @@
-import { MigrationInterface, QueryRunner } from "typeorm";
+import { MigrationInterface, QueryRunner } from "typeorm"
 
-export class RemoveHousekeepingSuggestedReviews1736209759039 implements MigrationInterface {
-
+export class RemoveHousekeepingSuggestedReviews1736209759039
+    implements MigrationInterface
+{
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(
             `DROP TABLE IF EXISTS housekeeping_suggested_reviews`
@@ -12,5 +13,4 @@ export class RemoveHousekeepingSuggestedReviews1736209759039 implements Migratio
     public async down(_queryRunner: QueryRunner): Promise<void> {
         return
     }
-
 }

--- a/db/migration/1736209759039-RemoveHousekeepingSuggestedReviews.ts
+++ b/db/migration/1736209759039-RemoveHousekeepingSuggestedReviews.ts
@@ -1,0 +1,16 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class RemoveHousekeepingSuggestedReviews1736209759039 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `DROP TABLE IF EXISTS housekeeping_suggested_reviews`
+        )
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    public async down(_queryRunner: QueryRunner): Promise<void> {
+        return
+    }
+
+}

--- a/db/migration/1736209905900-CreateHousekeeper.ts
+++ b/db/migration/1736209905900-CreateHousekeeper.ts
@@ -1,0 +1,20 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class CreateHousekeeper1736209905900 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`-- sql
+            CREATE TABLE housekeeper_reviews (
+                id INTEGER NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT "Identifier of the review",
+                suggestedAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP COMMENT "Date where the review was suggested",
+                objectType VARCHAR(255) NOT NULL COMMENT "Type of the object to review (e.g. 'chart', 'dataset', etc.)",
+                objectId INTEGER NOT NULL COMMENT "ID of the object to review"
+            )
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP TABLE housekeeper_reviews`)
+    }
+
+}

--- a/db/migration/1736209905900-CreateHousekeeper.ts
+++ b/db/migration/1736209905900-CreateHousekeeper.ts
@@ -1,7 +1,6 @@
-import { MigrationInterface, QueryRunner } from "typeorm";
+import { MigrationInterface, QueryRunner } from "typeorm"
 
 export class CreateHousekeeper1736209905900 implements MigrationInterface {
-
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`-- sql
             CREATE TABLE housekeeper_reviews (
@@ -16,5 +15,4 @@ export class CreateHousekeeper1736209905900 implements MigrationInterface {
     public async down(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`DROP TABLE housekeeper_reviews`)
     }
-
 }


### PR DESCRIPTION
I got a bit confused and ended up fixing various migrations due to two typos in the schema definition.

- initial commit (with typos): https://github.com/owid/owid-grapher/pull/4387
- First fix: https://github.com/owid/owid-grapher/pull/4388
- Second fix: https://github.com/owid/owid-grapher/pull/4389

Since it is not working, I think it's just better to drop the table (it was empty) and create the new one with the correct schema from scratch.