### PR TITLE
✨ add unit to axis labels / TAS-784

### DIFF
--- a/packages/@ourworldindata/components/src/MarkdownTextWrap/MarkdownTextWrap.tsx
+++ b/packages/@ourworldindata/components/src/MarkdownTextWrap/MarkdownTextWrap.tsx
@@ -566,7 +566,11 @@ export class MarkdownTextWrap extends React.Component<MarkdownTextWrapProps> {
         const secondaryTextWrap = new MarkdownTextWrap({
             text: secondaryMarkdownText,
             ...textWrapProps,
-            maxWidth: mainTextWrap.maxWidth - mainTextWrap.lastLineWidth,
+            maxWidth:
+                mainTextWrap.maxWidth -
+                mainTextWrap.lastLineWidth -
+                Bounds.forText(" ", textWrapProps).width -
+                10, // arbitrary wiggle room
         })
 
         const secondaryTextFitsOnSameLine =

--- a/packages/@ourworldindata/components/src/MarkdownTextWrap/MarkdownTextWrap.tsx
+++ b/packages/@ourworldindata/components/src/MarkdownTextWrap/MarkdownTextWrap.tsx
@@ -978,11 +978,9 @@ function convertMarkdownNodeToIRTokens(
                 type: "paragraph",
             },
             (item) => {
-                return [
-                    ...item.children.flatMap((child) =>
-                        convertMarkdownNodeToIRTokens(child, fontParams)
-                    ),
-                ]
+                return item.children.flatMap((child) =>
+                    convertMarkdownNodeToIRTokens(child, fontParams)
+                )
             }
         )
         .with(

--- a/packages/@ourworldindata/core-table/src/CoreTableColumns.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTableColumns.ts
@@ -269,6 +269,12 @@ export abstract class AbstractCoreColumn<JS_TYPE extends PrimitiveType> {
         return undefined
     }
 
+    @imemo get displayUnit(): string | undefined {
+        return this.unit && this.unit !== this.shortUnit
+            ? this.unit.replace(/^\((.*)\)$/, "$1")
+            : undefined
+    }
+
     // Returns a map where the key is a series slug such as "name" and the value is a set
     // of all the unique values that this column has for that particular series.
     getUniqueValuesGroupedBy(

--- a/packages/@ourworldindata/grapher/src/axis/Axis.ts
+++ b/packages/@ourworldindata/grapher/src/axis/Axis.ts
@@ -493,17 +493,31 @@ abstract class AbstractAxis {
     }
 
     @computed get labelTextWrap(): MarkdownTextWrap | undefined {
-        const text = this.label
-        return text
-            ? new MarkdownTextWrap({
-                  maxWidth: this.labelMaxWidth,
-                  fontSize: this.labelFontSize,
-                  text,
-                  lineHeight: 1,
-                  detailsOrderedByReference:
-                      this.axisManager?.detailsOrderedByReference,
-              })
-            : undefined
+        if (!this.label) return
+
+        const textWrapProps = {
+            maxWidth: this.labelMaxWidth,
+            fontSize: this.labelFontSize,
+            lineHeight: 1,
+            detailsOrderedByReference:
+                this.axisManager?.detailsOrderedByReference,
+        }
+
+        const displayUnit = this.formatColumn?.displayUnit
+        if (displayUnit) {
+            return MarkdownTextWrap.fromFragments({
+                main: { text: this.label, bold: true },
+                secondary: { text: `(${displayUnit})` },
+                newLine: "avoid-wrap",
+                textWrapProps,
+            })
+        } else {
+            return new MarkdownTextWrap({
+                text: this.label,
+                fontWeight: 700,
+                ...textWrapProps,
+            })
+        }
     }
 
     @computed get labelHeight(): number {

--- a/packages/@ourworldindata/grapher/src/tooltip/TooltipContents.tsx
+++ b/packages/@ourworldindata/grapher/src/tooltip/TooltipContents.tsx
@@ -132,11 +132,7 @@ class Variable extends React.Component<{
 
         if (column.isMissing || column.name === "time") return null
 
-        const { unit, shortUnit, displayName } = column,
-            displayUnit =
-                unit && unit !== shortUnit
-                    ? unit.replace(/^\((.*)\)$/, "$1")
-                    : undefined,
+        const { displayUnit, displayName } = column,
             displayNotice =
                 uniq((notice ?? []).filter((t) => t !== undefined))
                     .map((time) =>


### PR DESCRIPTION
Resolves #4362 

Appends the unit to axis labels in parens, like "**label** (unit)".

The next PR makes it so that for axis labels that have parens, like `Human Development Index (male)`, only the first part (Human Development Index) is made bold. It looks nicer.

<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 4 in a stack** made with GitButler:
- <kbd>&nbsp;4&nbsp;</kbd> #4443 
- <kbd>&nbsp;3&nbsp;</kbd> #4403 👈 
- <kbd>&nbsp;2&nbsp;</kbd> #4402 
- <kbd>&nbsp;1&nbsp;</kbd> #4331 
<!-- GitButler Footer Boundary Bottom -->

