### PR TITLE
✨ use 'nice' axis ticks for linear scales / TAS-795

### DIFF
--- a/packages/@ourworldindata/grapher/src/axis/Axis.test.ts
+++ b/packages/@ourworldindata/grapher/src/axis/Axis.test.ts
@@ -7,7 +7,7 @@ import {
     SynthesizeGDPTable,
 } from "@ourworldindata/core-table"
 import { AxisConfig } from "./AxisConfig"
-import { AxisAlign } from "@ourworldindata/utils"
+import { AxisAlign, last } from "@ourworldindata/utils"
 
 it("can create an axis", () => {
     const axisConfig = new AxisConfig({
@@ -88,7 +88,21 @@ it("respects nice parameter", () => {
     axis.range = [0, 300]
     const tickValues = axis.getTickValues()
     expect(tickValues[0].value).toEqual(0)
-    expect(tickValues[tickValues.length - 1].value).toEqual(100)
+    expect(last(tickValues)?.value).toEqual(100)
+})
+
+it("doesn't add 'nice' ticks to eagerly", () => {
+    const config: AxisConfigInterface = {
+        min: 0.0001,
+        max: 90.0001,
+        maxTicks: 10,
+        nice: true,
+    }
+    const axis = new AxisConfig(config).toVerticalAxis()
+    axis.range = [0, 300]
+    const tickValues = axis.getTickValues()
+    expect(tickValues[0].value).toEqual(0)
+    expect(last(tickValues)?.value).toEqual(90)
 })
 
 it("creates compact labels", () => {

--- a/packages/@ourworldindata/grapher/src/facetChart/FacetChart.tsx
+++ b/packages/@ourworldindata/grapher/src/facetChart/FacetChart.tsx
@@ -280,8 +280,7 @@ export class FacetChart
 
         // We infer that the user cares about the trend if the axis is not uniform
         // and the metrics on all facets are the same
-        const careAboutTrend =
-            !this.uniformYAxis && this.facetStrategy === FacetStrategy.entity
+        const careAboutTrend = !this.uniformYAxis
         if (careAboutTrend) {
             // Force disable nice axes if we care about the trend,
             // because nice axes misrepresent trends.

--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
@@ -1462,9 +1462,9 @@ export class LineChart
     }
 
     @computed private get yAxisConfig(): AxisConfig {
-        // TODO: enable nice axis ticks for linear scales
         return new AxisConfig(
             {
+                nice: this.manager.yAxisConfig?.scaleType !== ScaleType.log,
                 // if we only have a single y value (probably 0), we want the
                 // horizontal axis to be at the bottom of the chart.
                 // see https://github.com/owid/owid-grapher/pull/975#issuecomment-890798547

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
@@ -520,7 +520,13 @@ export class SlopeChart
     }
 
     @computed private get yAxisConfig(): AxisConfig {
-        return new AxisConfig(this.manager.yAxisConfig, this)
+        return new AxisConfig(
+            {
+                nice: this.manager.yAxisConfig?.scaleType !== ScaleType.log,
+                ...this.manager.yAxisConfig,
+            },
+            this
+        )
     }
 
     @computed get allYValues(): number[] {

--- a/packages/@ourworldindata/grapher/src/stackedCharts/AbstractStackedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/AbstractStackedChart.tsx
@@ -253,8 +253,13 @@ export class AbstractStackedChart
     }
 
     @computed private get yAxisConfig(): AxisConfig {
-        // TODO: enable nice axis ticks for linear scales
-        return new AxisConfig(this.manager.yAxisConfig, this)
+        return new AxisConfig(
+            {
+                nice: true,
+                ...this.manager.yAxisConfig,
+            },
+            this
+        )
     }
 
     // implemented in subclasses


### PR DESCRIPTION
Resolves https://github.com/owid/owid-grapher/issues/3978

See https://github.com/owid/owid-grapher/commit/3790bad420d85b8915dfb9ce3df41712f5daf768 😅

Relying on d3's nice implementation sometimes leads to suboptimal results because d3 adds grid lines too eagerly (some examples below). That's why I ended up writing a custom 'nice' function for Grapher. It only adds an additional grid line if any data value exceeds the highest grid line by more than 25%. 

<details><summary>Examples of d3.nice where grid lines are placed to eagerly</summary>
<p>

If any data value is _just above_ a grid line, then showing an additional grid line 'squishes' the rest of the chart.

<img width="1344" alt="Screenshot 2025-01-09 at 11 55 45" src="https://github.com/user-attachments/assets/7a3af2a8-07df-4e1b-b1be-cc82ecb03946" />
<img width="1344" alt="Screenshot 2025-01-09 at 11 56 29" src="https://github.com/user-attachments/assets/b1f529bb-baf4-4c1a-89b7-abe0a2ae62b7" />

</p>
</details> 
