### PR TITLE
fix: db-load-data error when restarting

### DIFF
--- a/devTools/docker/mysql-init-docker/Dockerfile
+++ b/devTools/docker/mysql-init-docker/Dockerfile
@@ -7,4 +7,5 @@ RUN rpm --import https://repo.mysql.com/RPM-GPG-KEY-mysql-2023 \
     curl \
     rsync \
     unzip \
-    gzip
+    gzip \
+ && microdnf clean all


### PR DESCRIPTION
Building db-load-data through docker compose (and/or as part of `make up.full`) fails with the following error:
``` 
Error response from daemon: invalid argument
```

The dockerd logs return the same generic error

```
Jan 08 13:38:52 matthieu-pr dockerd[16067]: time="2025-01-08T13:38:52.522058822Z" level=error msg="Handler for POST /v1.47/containers/create returned error: invalid argument" spanID=fe7aeda7b6d9d9b0 traceID=1c9ac07f8dd5be064aa53533cf0aa86e

```

## Solution
Clearing the microdnf cache: `microdnf clean all`

## Failed attempts 
Considered along the way:

- ❌ checking the container logs: empty
- ❌ create a container on a base mysql image then drop into it, and run the commands manually: goes through
- ❌ using a different package manager: apt, yum not present on base mysql image