### PR TITLE
✨ (line) deduplicate line labels

### DIFF
--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
@@ -1363,13 +1363,21 @@ export class LineChart
     // Order of the legend items on a line chart should visually correspond
     // to the order of the lines as the approach the legend
     @computed get lineLegendSeries(): LineLabelSeries[] {
-        // If there are any projections, ignore non-projection legends
-        // Bit of a hack
-        let seriesToShow = this.series
-        if (seriesToShow.some((series) => !!series.isProjection))
-            seriesToShow = seriesToShow.filter((series) => series.isProjection)
+        // If there are any projections, ignore non-projection legends (bit of a hack)
+        let series = this.series
+        if (series.some((series) => !!series.isProjection))
+            series = series.filter((series) => series.isProjection)
 
-        return seriesToShow.map((series) => {
+        // Deduplicate series by seriesName to avoid showing the same label multiple times
+        const deduplicatedSeries: LineChartSeries[] = []
+        const seriesGroupedByName = groupBy(series, "seriesName")
+        for (const duplicates of Object.values(seriesGroupedByName)) {
+            // keep only the label for the series with the most recent data
+            // (series are sorted by time, so we can just take the last one)
+            deduplicatedSeries.push(last(duplicates)!)
+        }
+
+        return deduplicatedSeries.map((series) => {
             const { seriesName, color } = series
             const lastValue = last(series.points)!.y
             return {


### PR DESCRIPTION
In rare cases, authors hack line charts to show breaks between line segments. They do so by using the same indicator multiple times. One side effect is that Grapher then shows a line legend label for each of these lines.

This PR makes this a bit better by de-duplicating line legend labels. I can't think of a use case where we'd want to show identical line labels.

| Before | After |
|--------|--------|
| <img width="1219" alt="Screenshot 2025-01-09 at 13 04 44" src="https://github.com/user-attachments/assets/dabb6f27-8973-4981-81e3-14f070532198" /> | <img width="1219" alt="Screenshot 2025-01-09 at 13 04 59" src="https://github.com/user-attachments/assets/f6e57b3c-76e1-4941-8675-20430a039460" /> |

Link: https://ourworldindata.org/explorers/poverty-explorer?facet=none&country=BOL~DEU~ALB&Indicator=Share+in+poverty&Poverty+line=%242.15+per+day%3A+International+Poverty+Line&Household+survey+data+type=Show+data+from+both+income+and+consumption+surveys&Show+breaks+between+less+comparable+surveys=true

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #4421 
- <kbd>&nbsp;1&nbsp;</kbd> #4420 👈 
<!-- GitButler Footer Boundary Bottom -->

