### PR TITLE
🐝 automatically add 'staging-viz' label to my PRs

### DIFF
--- a/.github/workflows/project-automations.yml
+++ b/.github/workflows/project-automations.yml
@@ -38,3 +38,12 @@ jobs:
               with:
                   add-labels: "needs triage"
                   repo-token: ${{ secrets.GITHUB_TOKEN }}
+    staging_viz:
+        name: Add "staging-viz" label to Sophia's PRs
+        runs-on: ubuntu-latest
+        if: github.event_name == 'pull_request' && github.event.action == 'opened' && github.actor == 'sophiamersmann'
+        steps:
+            - uses: andymckay/labeler@e6c4322d0397f3240f0e7e30a33b5c5df2d39e90
+              with:
+                  add-labels: "staging-viz"
+                  repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I know it's unconventional to have an action target my PRs only, but manually adding the 'staging-viz' label to all of my PRs is soo annoying.

The 'staging-viz' label makes it so that the SVG tester doesn't fail when there are differences. That's the better default for me since SVG changes are expected for most of my PRs.


<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #4429 
- <kbd>&nbsp;1&nbsp;</kbd> #4428 👈 
<!-- GitButler Footer Boundary Bottom -->

