### PR TITLE
🐛 take table filter toggle into account for data download / TAS-796

### DIFF
--- a/functions/_common/downloadFunctions.ts
+++ b/functions/_common/downloadFunctions.ts
@@ -68,10 +68,12 @@ export async function fetchZipForGrapher(
 }
 function assembleCsv(grapher: Grapher, searchParams: URLSearchParams): string {
     const useShortNames = searchParams.get("useColumnShortNames") === "true"
+    const fullTable = grapher.inputTable
+    const filteredTable = grapher.isOnTableTab
+        ? grapher.tableForDisplay
+        : grapher.transformedTable
     const table =
-        searchParams.get("csvType") === "filtered"
-            ? grapher.transformedTable
-            : grapher.inputTable
+        searchParams.get("csvType") === "filtered" ? filteredTable : fullTable
     return table.toPrettyCsv(useShortNames)
 }
 

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.sample.ts
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.sample.ts
@@ -86,6 +86,7 @@ export const GrapherWithIncompleteData = (
     ]
     return new Grapher({
         tab: GRAPHER_TAB_OPTIONS.table,
+        selectedEntityNames: ["Iceland", "France", "Afghanistan"],
         dimensions,
         ...props,
         owidDataset: createOwidTestDataset([{ metadata, data }]),
@@ -127,6 +128,7 @@ export const GrapherWithAggregates = (
     return new Grapher({
         tab: GRAPHER_TAB_OPTIONS.table,
         dimensions,
+        selectedEntityNames: ["Afghanistan", "Iceland", "World"],
         ...props,
         owidDataset: createOwidTestDataset([
             { metadata: childMortalityMetadata, data: childMortalityData },

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
@@ -44,7 +44,6 @@ import {
     IndicatorTitleWithFragments,
     joinTitleFragments,
 } from "@ourworldindata/utils"
-import { makeSelectionArray } from "../chart/ChartUtils"
 import { SelectionArray } from "../selection/SelectionArray"
 import { DEFAULT_GRAPHER_ENTITY_TYPE } from "../core/GrapherConstants"
 
@@ -86,7 +85,6 @@ export interface DataTableManager {
     endTime?: Time
     startTime?: Time
     dataTableSlugs?: ColumnSlug[]
-    showSelectionOnlyInDataTable?: boolean
     entitiesAreCountryLike?: boolean
     isSmall?: boolean
     isMedium?: boolean
@@ -138,36 +136,8 @@ export class DataTable extends React.Component<{
         }
     }
 
-    @computed get showSelectionOnlyInDataTable(): boolean {
-        const {
-            showSelectionOnlyInDataTable,
-            canChangeAddOrHighlightEntities,
-            hasChartTab,
-            hasMapTab,
-        } = this.manager
-        const { selectionArray } = this
-
-        // filter the table if the "Show selection only" toggle is hidden
-        if (
-            !canChangeAddOrHighlightEntities &&
-            selectionArray.hasSelection &&
-            hasChartTab &&
-            // if we have a map tab, we want to show all entities
-            !hasMapTab
-        )
-            return true
-
-        return !!showSelectionOnlyInDataTable
-    }
-
     @computed get table(): OwidTable {
-        let table = this.manager.tableForDisplay
-        if (this.showSelectionOnlyInDataTable) {
-            table = table.filterByEntityNames(
-                this.selectionArray.selectedEntityNames
-            )
-        }
-        return table
+        return this.manager.tableForDisplay
     }
 
     @computed get manager(): DataTableManager {
@@ -691,10 +661,6 @@ export class DataTable extends React.Component<{
                 //  dim.property !== "color" &&
                 (column.display?.includeInTable ?? true)
         )
-    }
-
-    @computed private get selectionArray(): SelectionArray {
-        return makeSelectionArray(this.manager.selection)
     }
 
     @computed private get entityNames(): string[] {


### PR DESCRIPTION
Fixes #4432

If 'Show selection only' on the table tab is toggled, then 'Download displayed data' only downloads data for those entities that are displayed in the table.

If 'Show selection only' isn't toggled, then 'Download displayed data' downloads all data (since all data is displayed). Don't know if this could be confusing. I find it okay.

This PR makes non-trivial changes to the Grapher component. Let me know if you prefer to wait for your refactor before merging this PR.

👇🏻 See my comment about `grapher.inputTable` vs `grapher.table` below

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #4447 
- <kbd>&nbsp;1&nbsp;</kbd> #4433 👈 
<!-- GitButler Footer Boundary Bottom -->

