### PR TITLE
✨ add 'square' option to grapher thumbnails

### DIFF
--- a/functions/_common/imageOptions.ts
+++ b/functions/_common/imageOptions.ts
@@ -22,7 +22,7 @@ export interface ImageOptions {
     fontSize: number | undefined
     grapherProps?: Partial<GrapherProgrammaticInterface>
 }
-export const TWITTER_OPTIONS: ImageOptions = {
+export const TWITTER_OPTIONS: Readonly<ImageOptions> = {
     // Twitter cards are 1.91:1 in aspect ratio, and 800x418 is the recommended size
     pngWidth: 800,
     pngHeight: 418,
@@ -31,7 +31,7 @@ export const TWITTER_OPTIONS: ImageOptions = {
     details: false,
     fontSize: 21,
 }
-const OPEN_GRAPH_OPTIONS: ImageOptions = {
+const OPEN_GRAPH_OPTIONS: Readonly<ImageOptions> = {
     // Open Graph is used by "everything but Twitter": Facebook, LinkedIn, WhatsApp, Signal, etc.
     pngWidth: 1200,
     pngHeight: 628,
@@ -40,7 +40,7 @@ const OPEN_GRAPH_OPTIONS: ImageOptions = {
     details: false,
     fontSize: 21,
 }
-const SQUARE_OPTIONS: ImageOptions = {
+const SQUARE_OPTIONS: Readonly<ImageOptions> = {
     pngWidth: 4 * GRAPHER_SQUARE_SIZE,
     pngHeight: 4 * GRAPHER_SQUARE_SIZE,
     svgWidth: GRAPHER_SQUARE_SIZE,
@@ -61,7 +61,7 @@ export const extractOptions = (params: URLSearchParams): ImageOptions => {
         params.get("imType") === "square" ||
         params.get("imType") === "social-media-square"
     ) {
-        const squareOptions = SQUARE_OPTIONS
+        const squareOptions = structuredClone(SQUARE_OPTIONS) as ImageOptions
         if (params.get("imType") === "social-media-square") {
             squareOptions.grapherProps.isSocialMediaExport = true
         }

--- a/functions/_common/imageOptions.ts
+++ b/functions/_common/imageOptions.ts
@@ -40,7 +40,7 @@ const OPEN_GRAPH_OPTIONS: ImageOptions = {
     details: false,
     fontSize: 21,
 }
-const SOCIAL_MEDIA_SQUARE_OPTIONS: ImageOptions = {
+const SQUARE_OPTIONS: ImageOptions = {
     pngWidth: 4 * GRAPHER_SQUARE_SIZE,
     pngHeight: 4 * GRAPHER_SQUARE_SIZE,
     svgWidth: GRAPHER_SQUARE_SIZE,
@@ -48,7 +48,7 @@ const SOCIAL_MEDIA_SQUARE_OPTIONS: ImageOptions = {
     details: false,
     fontSize: undefined,
     grapherProps: {
-        isSocialMediaExport: true,
+        isSocialMediaExport: false,
         staticFormat: GrapherStaticFormat.square,
     },
 }
@@ -57,8 +57,14 @@ export const extractOptions = (params: URLSearchParams): ImageOptions => {
     // We have two special images types specified via the `imType` query param:
     if (params.get("imType") === "twitter") return TWITTER_OPTIONS
     else if (params.get("imType") === "og") return OPEN_GRAPH_OPTIONS
-    else if (params.get("imType") === "social-media-square") {
-        const squareOptions = SOCIAL_MEDIA_SQUARE_OPTIONS
+    else if (
+        params.get("imType") === "square" ||
+        params.get("imType") === "social-media-square"
+    ) {
+        const squareOptions = SQUARE_OPTIONS
+        if (params.get("imType") === "social-media-square") {
+            squareOptions.grapherProps.isSocialMediaExport = true
+        }
         if (params.has("imSquareSize")) {
             const size = parseInt(params.get("imSquareSize")!)
             squareOptions.pngWidth = size

--- a/functions/_common/imageOptions.ts
+++ b/functions/_common/imageOptions.ts
@@ -54,15 +54,13 @@ const SQUARE_OPTIONS: Readonly<ImageOptions> = {
 }
 
 export const extractOptions = (params: URLSearchParams): ImageOptions => {
-    // We have two special images types specified via the `imType` query param:
-    if (params.get("imType") === "twitter") return TWITTER_OPTIONS
-    else if (params.get("imType") === "og") return OPEN_GRAPH_OPTIONS
-    else if (
-        params.get("imType") === "square" ||
-        params.get("imType") === "social-media-square"
-    ) {
+    const imType = params.get("imType")
+    // We have some special images types specified via the `imType` query param:
+    if (imType === "twitter") return TWITTER_OPTIONS
+    else if (imType === "og") return OPEN_GRAPH_OPTIONS
+    else if (imType === "square" || imType === "social-media-square") {
         const squareOptions = structuredClone(SQUARE_OPTIONS) as ImageOptions
-        if (params.get("imType") === "social-media-square") {
+        if (imType === "social-media-square") {
             squareOptions.grapherProps.isSocialMediaExport = true
         }
         if (params.has("imSquareSize")) {


### PR DESCRIPTION
Adds an `imType=square` option to Grapher SVGs that returns a square version of the SVG with a white background (`imType=social-media-square` downloads a square version with beige background).

I need this for the Figma Plugin I'm working on.

I can verify that these changes work locally, but on staging `imType=square` returns the square image with beige background. Not sure why.