### PR TITLE
Allow overriding display settings of indicators in mdims

### DIFF
--- a/baker/MultiDimBaker.tsx
+++ b/baker/MultiDimBaker.tsx
@@ -37,7 +37,7 @@ import {
 const getRelevantVariableIds = (config: MultiDimDataPageConfigPreProcessed) => {
     // A "relevant" variable id is the first y indicator of each view
     const allIndicatorIds = config.views
-        .map((view) => view.indicators.y?.[0])
+        .map((view) => view.indicators.y?.[0]?.id)
         .filter((id) => id !== undefined)
 
     return new Set(allIndicatorIds)

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -728,6 +728,7 @@ export {
 } from "./domainTypes/Author.js"
 
 export type {
+    IndicatorConfig,
     IndicatorEntryBeforePreProcessing,
     IndicatorsAfterPreProcessing,
     MultiDimDataPageConfigEnriched,
@@ -742,3 +743,5 @@ export type {
     View,
     ViewEnriched,
 } from "./siteTypes/MultiDimDataPage.js"
+
+export { isIndicatorConfig } from "./siteTypes/MultiDimDataPage.js"

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -731,6 +731,7 @@ export type {
     IndicatorConfig,
     IndicatorEntryBeforePreProcessing,
     IndicatorsAfterPreProcessing,
+    IndicatorsBeforePreProcessing,
     MultiDimDataPageConfigEnriched,
     MultiDimDataPageConfigPreProcessed,
     MultiDimDataPageConfigRaw,
@@ -743,5 +744,3 @@ export type {
     View,
     ViewEnriched,
 } from "./siteTypes/MultiDimDataPage.js"
-
-export { isIndicatorConfig } from "./siteTypes/MultiDimDataPage.js"

--- a/packages/@ourworldindata/types/src/siteTypes/MultiDimDataPage.ts
+++ b/packages/@ourworldindata/types/src/siteTypes/MultiDimDataPage.ts
@@ -7,11 +7,13 @@ import {
 } from "../OwidVariable.js"
 
 export type IndicatorConfig = Pick<OwidVariableWithSource, "id" | "display">
-
-type IndicatorConfigBeforePreProcessing = Omit<IndicatorConfig, "id"> & {
-    // Indicator ID or catalog path
-    id: number | string
+type IndicatorConfigByPath = Pick<IndicatorConfig, "display"> & {
+    catalogPath: string
 }
+
+type IndicatorConfigBeforePreProcessing =
+    | IndicatorConfig
+    | IndicatorConfigByPath
 
 // Indicator ID, catalog path or a an object
 export type IndicatorEntryBeforePreProcessing =
@@ -21,12 +23,6 @@ export type IndicatorEntryBeforePreProcessing =
 
 // Catalog paths have been resolved to indicator IDs
 export type IndicatorEntryAfterPreProcessing = IndicatorConfig
-
-export function isIndicatorConfig(
-    indicator: IndicatorEntryBeforePreProcessing | IndicatorConfig
-): indicator is IndicatorConfig {
-    return typeof indicator === "object" && typeof indicator.id === "number"
-}
 
 type Metadata = Omit<OwidVariableWithSource, "id">
 

--- a/packages/@ourworldindata/types/src/siteTypes/MultiDimDataPage.ts
+++ b/packages/@ourworldindata/types/src/siteTypes/MultiDimDataPage.ts
@@ -6,9 +6,27 @@ import {
     OwidVariableWithSource,
 } from "../OwidVariable.js"
 
-// Indicator ID, catalog path, or maybe an array of those
-export type IndicatorEntryBeforePreProcessing = string | number
-export type IndicatorEntryAfterPreProcessing = number // catalog paths have been resolved to indicator IDs
+export type IndicatorConfig = Pick<OwidVariableWithSource, "id" | "display">
+
+type IndicatorConfigBeforePreProcessing = Omit<IndicatorConfig, "id"> & {
+    // Indicator ID or catalog path
+    id: number | string
+}
+
+// Indicator ID, catalog path or a an object
+export type IndicatorEntryBeforePreProcessing =
+    | string
+    | number
+    | IndicatorConfigBeforePreProcessing
+
+// Catalog paths have been resolved to indicator IDs
+export type IndicatorEntryAfterPreProcessing = IndicatorConfig
+
+export function isIndicatorConfig(
+    indicator: IndicatorEntryBeforePreProcessing | IndicatorConfig
+): indicator is IndicatorConfig {
+    return typeof indicator === "object" && typeof indicator.id === "number"
+}
 
 type Metadata = Omit<OwidVariableWithSource, "id">
 

--- a/packages/@ourworldindata/utils/src/MultiDimDataPageConfig.test.ts
+++ b/packages/@ourworldindata/utils/src/MultiDimDataPageConfig.test.ts
@@ -51,7 +51,7 @@ const CONFIG: MultiDimDataPageConfigEnriched = {
                 interval: "yearly",
             },
             indicators: {
-                y: [111, 222],
+                y: [{ id: 111 }, { id: 222 }],
             },
             fullConfigId: uuidv7(),
         },
@@ -61,7 +61,7 @@ const CONFIG: MultiDimDataPageConfigEnriched = {
                 interval: "yearly",
             },
             indicators: {
-                y: [819727],
+                y: [{ id: 819727 }],
             },
             fullConfigId: uuidv7(),
         },

--- a/packages/@ourworldindata/utils/src/MultiDimDataPageConfig.ts
+++ b/packages/@ourworldindata/utils/src/MultiDimDataPageConfig.ts
@@ -156,27 +156,41 @@ export class MultiDimDataPageConfig {
     }
 
     static viewToDimensionsConfig(
-        view: View<IndicatorsAfterPreProcessing> | undefined
+        view?: View<IndicatorsAfterPreProcessing>
     ): OwidChartDimensionInterface[] {
-        if (!view?.indicators) return []
-
-        return Object.entries(view.indicators)
-            .flatMap(([property, variableIdOrIds]) => {
-                if (Array.isArray(variableIdOrIds)) {
-                    return variableIdOrIds.map((variableId) => ({
-                        property: property as DimensionProperty,
-                        variableId,
-                    }))
-                } else {
-                    return [
-                        {
-                            property: property as DimensionProperty,
-                            variableId: variableIdOrIds,
-                        },
-                    ]
-                }
+        const dimensions: OwidChartDimensionInterface[] = []
+        if (!view?.indicators) return dimensions
+        if (view.indicators.y) {
+            dimensions.push(
+                ...view.indicators.y.map(({ id, display }) => ({
+                    property: DimensionProperty.y,
+                    variableId: id,
+                    display,
+                }))
+            )
+        }
+        if (view.indicators.x) {
+            dimensions.push({
+                property: DimensionProperty.x,
+                variableId: view.indicators.x.id,
+                display: view.indicators.x.display,
             })
-            .filter((dim) => dim.variableId !== undefined)
+        }
+        if (view.indicators.size) {
+            dimensions.push({
+                property: DimensionProperty.size,
+                variableId: view.indicators.size.id,
+                display: view.indicators.size.display,
+            })
+        }
+        if (view.indicators.color) {
+            dimensions.push({
+                property: DimensionProperty.color,
+                variableId: view.indicators.color.id,
+                display: view.indicators.color.display,
+            })
+        }
+        return dimensions
     }
 }
 

--- a/site/multiDim/MultiDimDataPageContent.tsx
+++ b/site/multiDim/MultiDimDataPageContent.tsx
@@ -150,10 +150,7 @@ const useVarDatapageData = (
         setGrapherConfigIsReady(false)
         setGrapherConfig(null)
         setVarDatapageData(null)
-        const yIndicatorOrIndicators = currentView?.indicators?.["y"]
-        const variableId = Array.isArray(yIndicatorOrIndicators)
-            ? yIndicatorOrIndicators[0]
-            : yIndicatorOrIndicators
+        const variableId = currentView?.indicators?.["y"]?.[0]?.id
         if (!variableId) return
 
         const datapageDataPromise = cachedGetVariableMetadata(variableId).then(
@@ -297,7 +294,7 @@ export const MultiDimDataPageContent = ({
         const variables = currentView?.indicators?.["y"]
         const editUrl =
             variables?.length === 1
-                ? `variables/${variables[0]}/config`
+                ? `variables/${variables[0].id}/config`
                 : undefined
         return {
             ...varGrapherConfig,


### PR DESCRIPTION
We now normalize the indicators to a list of objects, which can have an optional `display` property. See `IndicatorConfig`.

Resolves #4040