### PR TITLE
✨ Data Insight Safari CSS fix and linked titles on Data Insight Index Page

### DIFF
--- a/site/DataInsightsIndexPageContent.tsx
+++ b/site/DataInsightsIndexPageContent.tsx
@@ -134,6 +134,7 @@ export const DataInsightsIndexPageContent = (
                         <DataInsightBody
                             key={dataInsight.id}
                             anchor={id}
+                            shouldLinkTitle
                             {...dataInsight}
                         />
                     )

--- a/site/gdocs/components/LatestDataInsights.scss
+++ b/site/gdocs/components/LatestDataInsights.scss
@@ -83,11 +83,14 @@ html:not(.js-enabled) .latest-data-insights__card,
     padding: 257px 0;
 }
 
+// Sizing flex child picture elements is finnicky on Safari.
+// Make sure you test all 3 browsers if you're making changes here.
 .latest-data-insights__card-left {
     display: flex;
+    height: 100%;
 
     picture {
-        display: flex; // Fix extra padding at the bottom.
+        height: 100%;
     }
 
     img {

--- a/site/gdocs/pages/DataInsight.scss
+++ b/site/gdocs/pages/DataInsight.scss
@@ -43,6 +43,13 @@
     padding: 24px;
     margin-bottom: 30px;
 
+    .data-insight-heading-link {
+        color: $blue-90;
+        &:hover {
+            text-decoration: underline;
+        }
+    }
+
     h1 {
         margin-top: 0;
         margin-bottom: 8px;
@@ -86,6 +93,9 @@
     display: flex;
     align-items: center;
     gap: 8px;
+    &:hover {
+        text-decoration: underline;
+    }
 }
 
 .data-insight-blocks {

--- a/site/gdocs/pages/DataInsight.tsx
+++ b/site/gdocs/pages/DataInsight.tsx
@@ -101,8 +101,10 @@ export const DataInsightBody = (
     props: OwidGdocDataInsightInterface & {
         anchor?: string
         publishedAt: Date | string | null
+        shouldLinkTitle?: boolean
     }
 ) => {
+    const shouldLinkTitle = props.shouldLinkTitle
     const publishedAt = props.publishedAt ? new Date(props.publishedAt) : null
     return (
         <div className="grid grid-cols-12-full-width span-cols-14">
@@ -124,7 +126,20 @@ export const DataInsightBody = (
                         day: "2-digit",
                     }}
                 />
-                <h1 className="display-3-semibold">{props.content.title}</h1>
+                {shouldLinkTitle ? (
+                    <a
+                        href={`${BAKED_BASE_URL}/data-insights/${props.slug}`}
+                        className="data-insight-heading-link"
+                    >
+                        <h1 className="display-3-semibold">
+                            {props.content.title}
+                        </h1>
+                    </a>
+                ) : (
+                    <h1 className="display-3-semibold">
+                        {props.content.title}
+                    </h1>
+                )}
                 <div className="data-insight-authors body-3-medium">
                     {props.content.authors.map((author, index) => (
                         <LinkedAuthor


### PR DESCRIPTION
### Safari
![di safari](https://github.com/user-attachments/assets/5b747541-448d-4fd8-a57c-ebc78e89eddc)
![di safari mobile](https://github.com/user-attachments/assets/c6cdbf3c-d684-48a1-8937-f69d02dcffb5)


### Firefox
![di firefox](https://github.com/user-attachments/assets/dc6be77d-a29f-48e6-b8cc-9fdebecdd151)
![di firefox mobile](https://github.com/user-attachments/assets/2fb44bdd-de10-48ee-86bb-e6a031bee00a)

### Chrome
![di chrome](https://github.com/user-attachments/assets/9d074dd4-942a-4325-9093-2642a97214da)
![di chrome mobile](https://github.com/user-attachments/assets/b4906d22-a1c6-4be8-b40e-179e1317a59a)


### Linking behaviour

https://github.com/user-attachments/assets/a54e5b8e-7a84-4a4b-816f-6500049a8f99

