### PR TITLE
🐝 fix schema update nuschell script (-r flag needed now)

### DIFF
--- a/.github/workflows/sync-grapher-schema-to-digital-ocean.yml
+++ b/.github/workflows/sync-grapher-schema-to-digital-ocean.yml
@@ -48,7 +48,7 @@ jobs:
                   ( ls packages/@ourworldindata/grapher/src/schema/*
                      | where name =~ '\d+.(json|yaml)$'
                      | get name
-                     | each { |it| cp $it ($it | str replace '\d+.(json|yaml)$' 'latest.$1') })
+                     | each { |it| cp $it ($it | str replace -r '\d+.(json|yaml)$' 'latest.$1') })
               shell: nu {0}
             - run: ls packages/@ourworldindata/grapher/src/schema
               shell: nu {0}


### PR DESCRIPTION
Our schema update script stopped working after upgrading nushell in the github runner from 0.80 to 0.101. The reason was that `str replace` changed the default from regex mode to normal string replace and now you have to pass `-r` to do a regex replace.