### PR TITLE
🔨 bake chart view map / TAS-829

### DIFF
--- a/_routes.json
+++ b/_routes.json
@@ -1,5 +1,5 @@
 {
     "version": 1,
     "include": ["/grapher/*", "/deleted/*", "/donation/*", "/explorers/*"],
-    "exclude": ["/grapher/_grapherRedirects.json"]
+    "exclude": ["/grapher/_grapherRedirects.json", "/grapher/_chartViews.json"]
 }

--- a/db/model/ChartView.ts
+++ b/db/model/ChartView.ts
@@ -1,4 +1,8 @@
-import { ChartViewInfo, JsonString } from "@ourworldindata/types"
+import {
+    ChartViewInfo,
+    DbPlainChartView,
+    JsonString,
+} from "@ourworldindata/types"
 import * as db from "../db.js"
 
 export const getChartViewsInfo = async (
@@ -31,4 +35,15 @@ JOIN chart_configs pcc on pc.configId = pcc.id
         ...row,
         queryParamsForParentChart: JSON.parse(row.queryParamsForParentChart),
     }))
+}
+
+export const getChartViewNameConfigMap = async (
+    knex: db.KnexReadonlyTransaction
+): Promise<
+    Record<DbPlainChartView["name"], DbPlainChartView["chartConfigId"]>
+> => {
+    const rows = await db.knexRaw<
+        Pick<DbPlainChartView, "name" | "chartConfigId">
+    >(knex, `SELECT name, chartConfigId FROM chart_views`)
+    return Object.fromEntries(rows.map((row) => [row.name, row.chartConfigId]))
 }


### PR DESCRIPTION
Bakes http://staging-site-bake-chart-views/grapher/_chartViews.json that maps chart view names to chart config IDs.

The Figma plugin uses this information for autocompletion and to fetch a chart view via UUID.

Ideally, we don't trigger a full rebuild when a chart view is created or deleted. I imagine authors creating a chart view going directly to Figma to try to import it, so there shouldn't be a too-long lag.

We wouldn't need to bake if we exposed the map on the Admin API instead, but Mojmir said auth is tricky. I wonder if we could add another auth method to our admin that would make that easier? But I don't think it's a good use of my time to think about admin auth at the beginning of the cycle, so I want to go with this for now. It would be easy to revert these changes if I reconsider during the cycle.

The map is baked to `/grapher/_chartViews.json`. I named it similarly to `/grapher/_grapherRedirects.json`, but I'm happy to rename it if the name I chose is awkward.