### PR TITLE
Update base TSConfig to options supported by Node 22

### DIFF
--- a/devTools/tsconfigs/tsconfig.base.json
+++ b/devTools/tsconfigs/tsconfig.base.json
@@ -1,23 +1,15 @@
 {
-    "$schema": "https://json.schemastore.org/tsconfig",
+    "extends": "@tsconfig/node22/tsconfig.json",
     "compilerOptions": {
         "module": "commonjs",
-        "strict": true,
-        "esModuleInterop": true,
         "resolveJsonModule": true,
         "forceConsistentCasingInFileNames": true,
-        "skipLibCheck": true,
         "composite": true,
 
         "declaration": true,
         "declarationMap": true,
 
-        // We start with https://github.com/tsconfig/bases/blob/master/bases/node14.json then drop:
-        //   "lib": ["es2020"],
-        //   "target": "es2020",
-
         "lib": ["dom", "dom.iterable", "es2020", "es2021", "es2022", "es2023"],
-        "target": "es2019",
 
         "alwaysStrict": true,
         "noImplicitReturns": true,

--- a/package.json
+++ b/package.json
@@ -179,6 +179,7 @@
         "@rmp135/sql-ts": "^2.1.0",
         "@testing-library/jest-dom": "^6.1.3",
         "@testing-library/react": "^12.1.5",
+        "@tsconfig/node22": "^22.0.0",
         "@types/bcrypt": "^5.0.0",
         "@types/chunk-text": "^1.0.0",
         "@types/codemirror": "^5.60.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5431,6 +5431,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tsconfig/node22@npm:^22.0.0":
+  version: 22.0.0
+  resolution: "@tsconfig/node22@npm:22.0.0"
+  checksum: 10/9fc45789304640e1e37e1f1e04c02dca593c290d4f1cb55af7e9cab799fb2c6356e1cc15ee9f140185591a81f491a4c7f2d6c08c1e5a3d758658ba69f1afee6d
+  languageName: node
+  linkType: hard
+
 "@tufjs/canonical-json@npm:2.0.0":
   version: 2.0.0
   resolution: "@tufjs/canonical-json@npm:2.0.0"
@@ -11762,6 +11769,7 @@ __metadata:
     "@testing-library/jest-dom": "npm:^6.1.3"
     "@testing-library/react": "npm:^12.1.5"
     "@tippyjs/react": "npm:^4.2.6"
+    "@tsconfig/node22": "npm:^22.0.0"
     "@types/bcrypt": "npm:^5.0.0"
     "@types/chunk-text": "npm:^1.0.0"
     "@types/codemirror": "npm:^5.60.5"


### PR DESCRIPTION
https://www.npmjs.com/package/@tsconfig/node22

We still have to override `module` and `moduleResolution` because `node16` causes issues with imports of external packages like `instantsearch.js`.