### PR TITLE
fix: recursively fetch all tags in topic area

### DIFF
--- a/site/DataCatalog/DataCatalogUtils.ts
+++ b/site/DataCatalog/DataCatalogUtils.ts
@@ -5,7 +5,7 @@ import {
 } from "instantsearch.js"
 import { getIndexName } from "../search/searchClient.js"
 import { ChartRecordType, SearchIndexName } from "../search/searchTypes.js"
-import { TagGraphRoot } from "@ourworldindata/types"
+import { TagGraphNode, TagGraphRoot } from "@ourworldindata/types"
 import { DataCatalogState } from "./DataCatalogState.js"
 import { countriesByName, Region } from "@ourworldindata/utils"
 import { SearchClient } from "algoliasearch"
@@ -109,6 +109,17 @@ export function setToFacetFilters(
     return Array.from(facetSet).map((facet) => `${attribute}:${facet}`)
 }
 
+function getAllTagsInArea(area: TagGraphNode): string[] {
+    const topics = area.children.reduce((tags, child) => {
+        tags.push(child.name)
+        if (child.children.length > 0) {
+            tags.push(...getAllTagsInArea(child))
+        }
+        return tags
+    }, [] as string[])
+    return Array.from(new Set(topics))
+}
+
 export function getTopicsForRibbons(
     topics: Set<string>,
     tagGraph: TagGraphRoot
@@ -116,7 +127,7 @@ export function getTopicsForRibbons(
     if (topics.size === 0) return tagGraph.children.map((child) => child.name)
     if (topics.size === 1) {
         const area = tagGraph.children.find((child) => topics.has(child.name))
-        if (area) return area.children.map((child) => child.name)
+        if (area) return getAllTagsInArea(area)
     }
     return []
 }


### PR DESCRIPTION
![Screenshot 2025-01-24 at 12.12.42.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/0SFFiIjKuUK6UPYHVe6u/4228d5b0-a16d-4ff9-a938-4f01383ef8a0.png)

The data catalog area filters are not handling sub-areas, they only go one level deep.

We recently added sub-areas to the graph, so the real topics were "hidden" on level below.

This doesn't address:
- type error in getTopicsForRibbons
- other places areas might be considered a one-level deep tree structure

Note that ribbons continue to show all children (and now grandchildren tags), not just the topic tags (that is tags with a matching topic page)