### PR TITLE
✨ add narrative-chart and figma-url to DI frontmatter / TAS-850

### DIFF
--- a/adminSiteClient/GdocsSettingsForms.tsx
+++ b/adminSiteClient/GdocsSettingsForms.tsx
@@ -180,7 +180,12 @@ export const GdocInsightSettings = ({
         <form className="GdocsSettingsForm">
             <GdocCommonErrors
                 errors={errors}
-                errorsToFilter={["approved-by", "grapher-url"]}
+                errorsToFilter={[
+                    "approved-by",
+                    "grapher-url",
+                    "narrative-chart",
+                    "figma-url",
+                ]}
             />
             <GdocCommonSettings
                 gdoc={gdoc}
@@ -195,7 +200,17 @@ export const GdocInsightSettings = ({
                     errors={errors}
                 />
                 <GdocsSettingsContentField
+                    property="narrative-chart"
+                    gdoc={gdoc}
+                    errors={errors}
+                />
+                <GdocsSettingsContentField
                     property="grapher-url"
+                    gdoc={gdoc}
+                    errors={errors}
+                />
+                <GdocsSettingsContentField
+                    property="figma-url"
                     gdoc={gdoc}
                     errors={errors}
                 />

--- a/adminSiteClient/gdocsDeploy.ts
+++ b/adminSiteClient/gdocsDeploy.ts
@@ -102,6 +102,8 @@ export const checkIsLightningUpdate = (
     > = {
         ["grapher-url"]: true,
         ["approved-by"]: true,
+        ["narrative-chart"]: true,
+        ["figma-url"]: true,
         title: false, // requires rebaking the feed
         authors: false, // requires rebaking the feed
         body: false, // requires rebaking the feed

--- a/adminSiteClient/gdocsValidation.ts
+++ b/adminSiteClient/gdocsValidation.ts
@@ -186,45 +186,6 @@ function validateApprovedBy(
     }
 }
 
-function validateGrapherUrl(
-    gdoc: OwidGdocDataInsightInterface,
-    errors: OwidGdocErrorMessage[]
-) {
-    if (!gdoc.content["narrative-chart"] && !gdoc.content["grapher-url"]) {
-        errors.push({
-            property: "grapher-url",
-            type: OwidGdocErrorMessageType.Warning,
-            message: `Missing "grapher-url". This isn't required, but if you're referencing a grapher, it's a good idea to add it so that we can link it to this data insight in the future. Include country selections, if applicable.`,
-        })
-    }
-}
-
-function validateNarrativeChart(
-    gdoc: OwidGdocDataInsightInterface,
-    errors: OwidGdocErrorMessage[]
-) {
-    if (!gdoc.content["narrative-chart"] && !gdoc.content["grapher-url"]) {
-        errors.push({
-            property: "narrative-chart",
-            type: OwidGdocErrorMessageType.Warning,
-            message: `Missing "narrative-chart". This isn't required, but if you're referencing a narrative chart, it's a good idea to add it so that we can link it to this data insight.`,
-        })
-    }
-}
-
-function validateFigmaUrl(
-    gdoc: OwidGdocDataInsightInterface,
-    errors: OwidGdocErrorMessage[]
-) {
-    if (!gdoc.content["figma-url"]) {
-        errors.push({
-            property: "figma-url",
-            type: OwidGdocErrorMessageType.Warning,
-            message: `Missing "figma-url". This isn't required, but if you edited the chart in Figma, it's a good idea to share the URL so that we can link it to this data insight.`,
-        })
-    }
-}
-
 function validateDataInsightImage(
     gdoc: OwidGdocDataInsightInterface,
     errors: OwidGdocErrorMessage[]
@@ -322,9 +283,6 @@ export const getErrors = (gdoc: OwidGdoc): OwidGdocErrorMessage[] => {
         validateAtomFields(gdoc, errors)
     } else if (checkIsDataInsight(gdoc)) {
         validateApprovedBy(gdoc, errors)
-        validateNarrativeChart(gdoc, errors)
-        validateGrapherUrl(gdoc, errors)
-        validateFigmaUrl(gdoc, errors)
         validateDataInsightImage(gdoc, errors)
     } else if (checkIsAuthor(gdoc)) {
         validateSocials(gdoc, errors)

--- a/adminSiteClient/gdocsValidation.ts
+++ b/adminSiteClient/gdocsValidation.ts
@@ -190,11 +190,37 @@ function validateGrapherUrl(
     gdoc: OwidGdocDataInsightInterface,
     errors: OwidGdocErrorMessage[]
 ) {
-    if (!gdoc.content["grapher-url"]) {
+    if (!gdoc.content["narrative-chart"] && !gdoc.content["grapher-url"]) {
         errors.push({
             property: "grapher-url",
             type: OwidGdocErrorMessageType.Warning,
             message: `Missing "grapher-url". This isn't required, but if you're referencing a grapher, it's a good idea to add it so that we can link it to this data insight in the future. Include country selections, if applicable.`,
+        })
+    }
+}
+
+function validateNarrativeChart(
+    gdoc: OwidGdocDataInsightInterface,
+    errors: OwidGdocErrorMessage[]
+) {
+    if (!gdoc.content["narrative-chart"] && !gdoc.content["grapher-url"]) {
+        errors.push({
+            property: "narrative-chart",
+            type: OwidGdocErrorMessageType.Warning,
+            message: `Missing "narrative-chart". This isn't required, but if you're referencing a narrative chart, it's a good idea to add it so that we can link it to this data insight.`,
+        })
+    }
+}
+
+function validateFigmaUrl(
+    gdoc: OwidGdocDataInsightInterface,
+    errors: OwidGdocErrorMessage[]
+) {
+    if (!gdoc.content["figma-url"]) {
+        errors.push({
+            property: "figma-url",
+            type: OwidGdocErrorMessageType.Warning,
+            message: `Missing "figma-url". This isn't required, but if you edited the chart in Figma, it's a good idea to share the URL so that we can link it to this data insight.`,
         })
     }
 }
@@ -296,7 +322,9 @@ export const getErrors = (gdoc: OwidGdoc): OwidGdocErrorMessage[] => {
         validateAtomFields(gdoc, errors)
     } else if (checkIsDataInsight(gdoc)) {
         validateApprovedBy(gdoc, errors)
+        validateNarrativeChart(gdoc, errors)
         validateGrapherUrl(gdoc, errors)
+        validateFigmaUrl(gdoc, errors)
         validateDataInsightImage(gdoc, errors)
     } else if (checkIsAuthor(gdoc)) {
         validateSocials(gdoc, errors)

--- a/db/model/Gdoc/GdocDataInsight.ts
+++ b/db/model/Gdoc/GdocDataInsight.ts
@@ -20,6 +20,7 @@ export class GdocDataInsight
     implements OwidGdocDataInsightInterface
 {
     content!: OwidGdocDataInsightContent
+    _omittableFields = ["grapher-url", "narrative-chart", "figma-url"]
 
     constructor(id?: string) {
         super(id)

--- a/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
@@ -153,7 +153,9 @@ export function extractGdocIndexItem(
 export interface OwidGdocDataInsightContent {
     title: string
     authors: string[]
+    ["narrative-chart"]?: string
     ["grapher-url"]?: string
+    ["figma-url"]?: string
     ["approved-by"]: string // can't publish an insight unless this is set
     body: OwidEnrichedGdocBlock[]
     type: OwidGdocType.DataInsight


### PR DESCRIPTION
Adds two new properties to the front matter of DIs.

- `narrative-chart` is the name of a narrative chart. It's useful to know which narrative chart a DI is based on, similar to how we track the `grapher-url` a DI is based on.
- `figma-url` is a link to a Figma page. Authors are encouraged to share a Figma link if they customised the chart, but currently paste the link into the comment section of the GDoc. We double-down on Figma as an important piece of infrastructure this cycle, so I think it's justified to track it properly. 

Both properties will be surfaced in a new Data Insights index page we have in mind.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 9 in a stack** made with GitButler:
- <kbd>&nbsp;9&nbsp;</kbd> #4571 
- <kbd>&nbsp;8&nbsp;</kbd> #4570 
- <kbd>&nbsp;7&nbsp;</kbd> #4558 
- <kbd>&nbsp;6&nbsp;</kbd> #4557 
- <kbd>&nbsp;5&nbsp;</kbd> #4556 
- <kbd>&nbsp;4&nbsp;</kbd> #4547 
- <kbd>&nbsp;3&nbsp;</kbd> #4500 
- <kbd>&nbsp;2&nbsp;</kbd> #4490 
- <kbd>&nbsp;1&nbsp;</kbd> #4489 👈 
<!-- GitButler Footer Boundary Bottom -->

