### PR TITLE
🎉 (admin) data insight index page / TAS-845

### DIFF
--- a/adminSiteClient/AdminApp.tsx
+++ b/adminSiteClient/AdminApp.tsx
@@ -45,6 +45,7 @@ import { IndicatorChartEditorPage } from "./IndicatorChartEditorPage.js"
 import { ChartViewEditorPage } from "./ChartViewEditorPage.js"
 import { ChartViewIndexPage } from "./ChartViewIndexPage.js"
 import { ImageIndexPage } from "./ImagesIndexPage.js"
+import { DataInsightIndexPage } from "./DataInsightIndexPage.js"
 
 @observer
 class AdminErrorMessage extends React.Component<{ admin: Admin }> {
@@ -336,6 +337,10 @@ export class AdminApp extends React.Component<{
                                         <GdocsIndexPage {...props} />
                                     </GdocsStoreProvider>
                                 )}
+                            />
+                            <Route
+                                path="/data-insights"
+                                component={DataInsightIndexPage}
                             />
                             <Route
                                 exact

--- a/adminSiteClient/AdminSidebar.tsx
+++ b/adminSiteClient/AdminSidebar.tsx
@@ -20,6 +20,7 @@ import {
     faSitemap,
     faPanorama,
     faImage,
+    faLightbulb,
 } from "@fortawesome/free-solid-svg-icons"
 
 import { ETL_WIZARD_URL } from "../settings/clientSettings.js"
@@ -36,6 +37,11 @@ export const AdminSidebar = (): React.ReactElement => (
             <li>
                 <Link to="/chartViews">
                     <FontAwesomeIcon icon={faPanorama} /> Narrative charts
+                </Link>
+            </li>
+            <li>
+                <Link to="/data-insights">
+                    <FontAwesomeIcon icon={faLightbulb} /> Data insights
                 </Link>
             </li>
             <li>

--- a/adminSiteClient/DataInsightIndexPage.tsx
+++ b/adminSiteClient/DataInsightIndexPage.tsx
@@ -1,0 +1,513 @@
+import { useContext, useEffect, useMemo, useState } from "react"
+import * as React from "react"
+import { Button, Card, Flex, Input, Radio, Select, Space, Table } from "antd"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import {
+    faCopy,
+    faPen,
+    faUpRightFromSquare,
+} from "@fortawesome/free-solid-svg-icons"
+import { faFigma } from "@fortawesome/free-brands-svg-icons"
+
+import { AdminLayout } from "./AdminLayout.js"
+import { Timeago } from "./Forms.js"
+import { ColumnsType } from "antd/es/table/InternalTable.js"
+import {
+    buildSearchWordsFromSearchString,
+    filterFunctionForSearchWords,
+    highlightFunctionForSearchWords,
+    SearchWord,
+} from "../adminShared/search.js"
+import {
+    ALL_GRAPHER_CHART_TYPES,
+    DbPlainTag,
+    GRAPHER_MAP_TYPE,
+    GrapherChartOrMapType,
+    OwidGdocDataInsightIndexItem,
+} from "@ourworldindata/types"
+import {
+    copyToClipboard,
+    dayjs,
+    RequiredBy,
+    startCase,
+} from "@ourworldindata/utils"
+import {
+    BAKED_BASE_URL,
+    CLOUDFLARE_IMAGES_URL,
+} from "../settings/clientSettings.js"
+import { AdminAppContext } from "./AdminAppContext.js"
+
+type ChartTypeFilter = GrapherChartOrMapType | "all"
+type PublicationFilter = "all" | "published" | "scheduled" | "draft"
+type Layout = "list" | "gallery"
+
+const DEFAULT_CHART_TYPE_FILTER: ChartTypeFilter = "all"
+const DEFAULT_PUBLICATION_FILTER: PublicationFilter = "all"
+const DEFAULT_LAYOUT: Layout = "list"
+
+const editIcon = <FontAwesomeIcon icon={faPen} size="sm" />
+const linkIcon = <FontAwesomeIcon icon={faUpRightFromSquare} size="sm" />
+const figmaIcon = <FontAwesomeIcon icon={faFigma} size="sm" />
+const copyIcon = <FontAwesomeIcon icon={faCopy} size="sm" />
+
+function createColumns(ctx: {
+    highlightFn: (
+        text: string | null | undefined
+    ) => React.ReactElement | string
+}): ColumnsType<OwidGdocDataInsightIndexItem> {
+    return [
+        {
+            title: "Preview",
+            key: "preview",
+            render: (_, dataInsight) =>
+                hasImage(dataInsight) ? (
+                    <>
+                        <img
+                            className="border"
+                            src={makePreviewImageSrc(dataInsight)}
+                            style={{ maxWidth: 200 }}
+                        />
+                        <Button
+                            type="text"
+                            size="small"
+                            icon={copyIcon}
+                            onClick={() =>
+                                copyToClipboard(dataInsight.image.filename)
+                            }
+                        >
+                            Copy filename
+                        </Button>
+                    </>
+                ) : undefined,
+        },
+        {
+            title: "Title",
+            dataIndex: "title",
+            key: "title",
+            width: 300,
+            render: (title, dataInsight) =>
+                dataInsight.published &&
+                dayjs(dataInsight.publishedAt).isBefore(dayjs()) &&
+                dataInsight.slug ? (
+                    <a
+                        href={makeDataInsightLink(dataInsight)}
+                        target="_blank"
+                        rel="noreferrer noopener"
+                    >
+                        {ctx.highlightFn(title)}
+                    </a>
+                ) : (
+                    ctx.highlightFn(title)
+                ),
+        },
+        {
+            title: "Authors",
+            dataIndex: "authors",
+            key: "authors",
+            width: 150,
+            render: (authors: string[], dataInsight) => (
+                <>
+                    {authors.map((author, index) => (
+                        <React.Fragment key={author}>
+                            {ctx.highlightFn(author)}
+                            {index < authors.length - 1 ? ", " : ""}
+                        </React.Fragment>
+                    ))}
+                    {dataInsight.approvedBy &&
+                        ` (approved by ${dataInsight.approvedBy})`}
+                </>
+            ),
+        },
+        {
+            title: "Topic tags",
+            dataIndex: "tags",
+            key: "tags",
+            render: (tags: DbPlainTag[]) =>
+                tags.map((tag) => (
+                    <a
+                        key={tag.name}
+                        href={`/admin/tags/${tag.id}`}
+                        target="_blank"
+                        rel="noreferrer noopener"
+                        style={{ display: "block" }}
+                    >
+                        {ctx.highlightFn(tag.name)}
+                    </a>
+                )),
+        },
+        {
+            title: "Published",
+            dataIndex: "publishedAt",
+            key: "publishedAt",
+            render: (publishedAt) => {
+                if (!publishedAt) return undefined
+                const publicationDate = dayjs(publishedAt)
+                const isScheduledForPublication =
+                    publicationDate.isAfter(dayjs())
+                if (isScheduledForPublication)
+                    return (
+                        <>
+                            Scheduled for publication{" "}
+                            <Timeago time={publishedAt} />
+                        </>
+                    )
+                return (
+                    <>
+                        Published <Timeago time={publishedAt} />
+                    </>
+                )
+            },
+        },
+        {
+            title: "Links",
+            key: "links",
+            render: (_, dataInsight) => (
+                <Space size="small" direction="vertical">
+                    <Button
+                        href={makePreviewLink(dataInsight)}
+                        target="_blank"
+                        icon={linkIcon}
+                    >
+                        Preview
+                    </Button>
+                    {dataInsight.grapherUrl && (
+                        <Button
+                            href={dataInsight.grapherUrl}
+                            target="_blank"
+                            icon={linkIcon}
+                        >
+                            Grapher page
+                        </Button>
+                    )}
+                    {dataInsight.explorerUrl && (
+                        <Button
+                            href={dataInsight.explorerUrl}
+                            target="_blank"
+                            icon={linkIcon}
+                        >
+                            Explorer view
+                        </Button>
+                    )}
+                    {dataInsight.figmaUrl && (
+                        <Button
+                            href={dataInsight.figmaUrl}
+                            target="_blank"
+                            icon={figmaIcon}
+                        >
+                            Figma
+                        </Button>
+                    )}
+                </Space>
+            ),
+        },
+        {
+            title: "Actions",
+            key: "actions",
+            render: (_, dataInsight) => (
+                <Space size="small" direction="vertical">
+                    <Button
+                        type="primary"
+                        target="_blank"
+                        href={makeGDocEditLink(dataInsight)}
+                        icon={editIcon}
+                    >
+                        Edit GDoc
+                    </Button>
+                    {hasNarrativeChart(dataInsight) && (
+                        <Button
+                            type="primary"
+                            href={makeNarrativeChartEditLink(dataInsight)}
+                            target="_blank"
+                            icon={editIcon}
+                        >
+                            Edit narrative chart
+                        </Button>
+                    )}
+                </Space>
+            ),
+        },
+    ]
+}
+
+export function DataInsightIndexPage() {
+    const { admin } = useContext(AdminAppContext)
+
+    const [dataInsights, setDataInsights] = useState<
+        OwidGdocDataInsightIndexItem[]
+    >([])
+    const [searchValue, setSearchValue] = useState("")
+    const [chartTypeFilter, setChartTypeFilter] = useState<
+        GrapherChartOrMapType | "all"
+    >(DEFAULT_CHART_TYPE_FILTER)
+    const [publicationFilter, setPublicationFilter] =
+        useState<PublicationFilter>(DEFAULT_PUBLICATION_FILTER)
+    const [layout, setLayout] = useState<Layout>(DEFAULT_LAYOUT)
+
+    const searchWords = useMemo(
+        () => buildSearchWordsFromSearchString(searchValue),
+        [searchValue]
+    )
+
+    const filteredDataInsights = useMemo(() => {
+        const chartTypeFilterFn = (
+            dataInsight: OwidGdocDataInsightIndexItem
+        ) => {
+            if (chartTypeFilter === "all") return true
+            return dataInsight.chartType === chartTypeFilter
+        }
+
+        const publicationFilterFn = (
+            dataInsight: OwidGdocDataInsightIndexItem
+        ) => {
+            switch (publicationFilter) {
+                case "draft":
+                    return !dataInsight.published
+                case "scheduled":
+                    return (
+                        dataInsight.published &&
+                        dayjs(dataInsight.publishedAt).isAfter(dayjs())
+                    )
+                case "published":
+                    return (
+                        dataInsight.published &&
+                        dayjs(dataInsight.publishedAt).isBefore(dayjs())
+                    )
+                case "all":
+                    return true
+            }
+        }
+
+        const searchFilterFn = filterFunctionForSearchWords(
+            searchWords,
+            (dataInsight: OwidGdocDataInsightIndexItem) => [
+                dataInsight.title,
+                dataInsight.slug,
+                startCase(dataInsight.chartType),
+                ...(dataInsight.tags ?? []).map((tag) => tag.name),
+                ...dataInsight.authors,
+                dataInsight.markdown ?? "",
+            ]
+        )
+
+        return dataInsights.filter(
+            (di) =>
+                chartTypeFilterFn(di) &&
+                publicationFilterFn(di) &&
+                searchFilterFn(di)
+        )
+    }, [dataInsights, chartTypeFilter, publicationFilter, searchWords])
+
+    useEffect(() => {
+        const fetchAllDataInsights = async () =>
+            (await admin.getJSON(
+                "/api/dataInsights"
+            )) as OwidGdocDataInsightIndexItem[]
+
+        void fetchAllDataInsights().then((dataInsights) =>
+            setDataInsights(dataInsights)
+        )
+    }, [admin])
+
+    return (
+        <AdminLayout title="Data insights">
+            <main className="DataInsightIndexPage">
+                <Flex justify="space-between">
+                    <Flex gap="small">
+                        <Input
+                            placeholder="Search"
+                            value={searchValue}
+                            onChange={(e) => setSearchValue(e.target.value)}
+                            onKeyDown={(e) => {
+                                if (e.key === "Escape") setSearchValue("")
+                            }}
+                            style={{ width: 500, marginBottom: 20 }}
+                        />
+                        <Select
+                            value={chartTypeFilter}
+                            options={[
+                                { value: "all", label: "All chart types" },
+                                ...ALL_GRAPHER_CHART_TYPES.map((type) => ({
+                                    value: type,
+                                    label: startCase(type),
+                                })),
+                                { value: GRAPHER_MAP_TYPE, label: "World map" },
+                            ]}
+                            onChange={(value: ChartTypeFilter) =>
+                                setChartTypeFilter(value)
+                            }
+                            popupMatchSelectWidth={false}
+                        />
+                        <Select
+                            value={publicationFilter}
+                            options={[
+                                {
+                                    value: "all",
+                                    label: "Any publication status",
+                                },
+                                { value: "draft", label: "Drafts" },
+                                { value: "published", label: "Published" },
+                                { value: "scheduled", label: "Scheduled" },
+                            ]}
+                            onChange={(value: PublicationFilter) =>
+                                setPublicationFilter(value)
+                            }
+                            popupMatchSelectWidth={false}
+                        />
+                        <Button
+                            type="dashed"
+                            onClick={() => {
+                                setSearchValue("")
+                                setPublicationFilter(DEFAULT_PUBLICATION_FILTER)
+                            }}
+                        >
+                            Reset
+                        </Button>
+                    </Flex>
+                    <Radio.Group
+                        defaultValue="list"
+                        onChange={(e) => setLayout(e.target.value)}
+                    >
+                        <Radio.Button value="list">List</Radio.Button>
+                        <Radio.Button value="gallery">Gallery</Radio.Button>
+                    </Radio.Group>
+                </Flex>
+                {layout === "list" && (
+                    <DataInsightList
+                        dataInsights={filteredDataInsights}
+                        searchWords={searchWords}
+                    />
+                )}
+                {layout === "gallery" && (
+                    <DataInsightGallery dataInsights={filteredDataInsights} />
+                )}
+            </main>
+        </AdminLayout>
+    )
+}
+
+function DataInsightList({
+    dataInsights,
+    searchWords,
+}: {
+    dataInsights: OwidGdocDataInsightIndexItem[]
+    searchWords: SearchWord[]
+}) {
+    const highlightFn = useMemo(
+        () => highlightFunctionForSearchWords(searchWords),
+        [searchWords]
+    )
+
+    const columns = useMemo(() => createColumns({ highlightFn }), [highlightFn])
+
+    return (
+        <Table
+            columns={columns}
+            dataSource={dataInsights}
+            rowKey={(dataInsight) => dataInsight.id}
+            size="small"
+        />
+    )
+}
+
+function DataInsightGallery({
+    dataInsights,
+}: {
+    dataInsights: OwidGdocDataInsightIndexItem[]
+}) {
+    const dataInsightsWithPreviewImage = dataInsights.filter((dataInsight) =>
+        hasImage(dataInsight)
+    )
+    return (
+        <Flex wrap gap="large">
+            {dataInsightsWithPreviewImage.map((dataInsight) => (
+                <DataInsightCard
+                    key={dataInsight.id}
+                    dataInsight={dataInsight}
+                />
+            ))}
+        </Flex>
+    )
+}
+
+function DataInsightCard({
+    dataInsight,
+}: {
+    dataInsight: RequiredBy<OwidGdocDataInsightIndexItem, "image">
+}) {
+    const preview = (
+        <img
+            className="border"
+            src={makePreviewImageSrc(dataInsight)}
+            style={{ width: 265, height: 265 }}
+        />
+    )
+
+    return (
+        <Card cover={preview}>
+            <a
+                href={makePreviewLink(dataInsight)}
+                target="_blank"
+                rel="noreferrer noopener"
+            >
+                Preview
+            </a>
+            {" / "}
+            <a
+                href={makeGDocEditLink(dataInsight)}
+                target="_blank"
+                rel="noreferrer noopener"
+            >
+                GDoc
+            </a>
+            {dataInsight.figmaUrl && (
+                <>
+                    {" / "}
+                    <a
+                        href={dataInsight.figmaUrl}
+                        target="_blank"
+                        rel="noreferrer noopener"
+                    >
+                        Figma
+                    </a>
+                </>
+            )}
+        </Card>
+    )
+}
+
+function hasNarrativeChart(
+    dataInsight: OwidGdocDataInsightIndexItem
+): dataInsight is RequiredBy<OwidGdocDataInsightIndexItem, "narrativeChart"> {
+    return dataInsight.narrativeChart !== undefined
+}
+
+function hasImage(
+    dataInsight: OwidGdocDataInsightIndexItem
+): dataInsight is RequiredBy<OwidGdocDataInsightIndexItem, "image"> {
+    return dataInsight.image !== undefined
+}
+
+function makePreviewLink(dataInsight: OwidGdocDataInsightIndexItem) {
+    return `/admin/gdocs/${dataInsight.id}/preview`
+}
+
+function makeGDocEditLink(dataInsight: OwidGdocDataInsightIndexItem) {
+    return `https://docs.google.com/document/d/${dataInsight.id}/edit`
+}
+
+function makeDataInsightLink(dataInsight: OwidGdocDataInsightIndexItem) {
+    return `${BAKED_BASE_URL}/data-insights/${dataInsight.slug}`
+}
+
+function makeNarrativeChartEditLink(
+    dataInsight: RequiredBy<OwidGdocDataInsightIndexItem, "narrativeChart">
+) {
+    return `/admin/chartViews/${dataInsight.narrativeChart.id}/edit`
+}
+
+function makePreviewImageSrc(
+    dataInsight: RequiredBy<OwidGdocDataInsightIndexItem, "image">
+) {
+    const { cloudflareId, originalWidth } = dataInsight.image
+    return `${CLOUDFLARE_IMAGES_URL}/${cloudflareId}/w=${originalWidth}`
+}

--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -1294,3 +1294,17 @@ main:not(.ChartEditorPage):not(.GdocsEditPage) {
     margin-top: -8px;
     margin-bottom: 0;
 }
+
+.DataInsightIndexPage {
+    .ant-card-body {
+        padding: 8px;
+
+        a {
+            color: rgba(0, 0, 0, 0.88);
+        }
+    }
+
+    img.border {
+        border: 1px solid rgb(240, 240, 240) !important;
+    }
+}

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -125,6 +125,7 @@ import {
     deleteChart,
     getChartTagsJson,
 } from "./apiRoutes/charts.js"
+import { getAllDataInsightIndexItems } from "./apiRoutes/dataInsights.js"
 
 const apiRouter = new FunctionalRouter()
 
@@ -249,6 +250,13 @@ getRouteNonIdempotentWithRWTransaction(
 putRouteWithRWTransaction(apiRouter, "/gdocs/:id", createOrUpdateGdoc)
 deleteRouteWithRWTransaction(apiRouter, "/gdocs/:id", deleteGdoc)
 postRouteWithRWTransaction(apiRouter, "/gdocs/:gdocId/setTags", setGdocTags)
+
+// Data insight routes
+getRouteWithROTransaction(
+    apiRouter,
+    "/dataInsights",
+    getAllDataInsightIndexItems
+)
 
 // Images routes
 getRouteNonIdempotentWithRWTransaction(

--- a/adminSiteServer/apiRoutes/dataInsights.ts
+++ b/adminSiteServer/apiRoutes/dataInsights.ts
@@ -1,0 +1,204 @@
+import e from "express"
+import { Request } from "../authentication.js"
+import {
+    DbPlainChartView,
+    DbRawChartConfig,
+    DbRawImage,
+    DbRawPostGdoc,
+    GrapherChartOrMapType,
+    GrapherInterface,
+    MinimalTag,
+    OwidGdocDataInsightContent,
+    OwidGdocDataInsightIndexItem,
+    parseChartConfig,
+    parsePostGdocContent,
+} from "@ourworldindata/types"
+import * as db from "../../db/db.js"
+import { getTagsGroupedByGdocId } from "../../db/model/Gdoc/GdocFactory.js"
+import {
+    getChartTypeFromConfig,
+    getChartTypeFromConfigAndQueryParams,
+} from "@ourworldindata/grapher"
+
+const GRAPHER_URL_PREFIX = "https://ourworldindata.org/grapher/"
+const EXPLORER_URL_PREFIX = "https://ourworldindata.org/explorers/"
+
+type DataInsightRow = Pick<
+    DbRawPostGdoc,
+    "slug" | "content" | "published" | "publishedAt" | "markdown"
+> &
+    Pick<DbRawImage, "cloudflareId" | "filename" | "originalWidth"> & {
+        gdocId: DbRawPostGdoc["id"]
+        narrativeChartId?: DbPlainChartView["id"]
+        narrativeChartConfigId?: DbPlainChartView["chartConfigId"]
+        chartConfig?: DbRawChartConfig["full"]
+        imageId?: DbRawImage["id"]
+        tags?: MinimalTag[]
+    }
+
+export async function getAllDataInsightIndexItems(
+    req: Request,
+    res: e.Response<any, Record<string, any>>,
+    trx: db.KnexReadonlyTransaction
+) {
+    return getAllDataInsightIndexItemsOrderedByUpdatedAt(trx)
+}
+
+async function getAllDataInsightIndexItemsOrderedByUpdatedAt(
+    knex: db.KnexReadonlyTransaction
+): Promise<OwidGdocDataInsightIndexItem[]> {
+    const rows = await db.knexRaw<DataInsightRow>(
+        knex,
+        `-- sql
+
+        -- only consider published stand-alone charts since we join by slug which is only unique for published charts
+        WITH published_charts AS (
+            SELECT cc.id, cc.slug, cc.full
+            FROM chart_configs cc
+            JOIN charts c ON c.configId = cc.id
+            WHERE cc.full ->> '$.isPublished' = 'true'
+        )
+
+        SELECT
+            -- gdoc fields
+            pg.id AS gdocId,
+            pg.slug,
+            pg.content,
+            pg.published,
+            pg.publishedAt,
+            pg.markdown,
+
+            -- narrative chart fields
+            cw.id AS narrativeChartId,
+            cw.chartConfigId AS narrativeChartConfigId,
+
+            -- chart config (prefer narrative charts over grapher URLs)
+            COALESCE(cc_chartView.full, cc_grapherUrl.full) AS chartConfig,
+
+            -- image fields
+            i.id AS imageId,
+            i.filename,
+            i.cloudflareId,
+            i.originalWidth
+        FROM posts_gdocs pg
+
+        -- extract the slug from the given Grapher URL and join by it
+        LEFT JOIN published_charts cc_grapherUrl
+            ON cc_grapherUrl.slug = SUBSTRING_INDEX(SUBSTRING_INDEX(content ->> '$."grapher-url"', '/grapher/', -1), '\\?', 1)
+
+        -- join the chart_views table to get the config of the narrative chart
+        LEFT JOIN chart_views cw
+            ON cw.name = content ->> '$."narrative-chart"'
+        LEFT JOIN chart_configs cc_chartView
+            ON cc_chartView.id = cw.chartConfigId
+
+        -- join the images table by filename (only works for data insights where the image block comes first)
+        LEFT JOIN images i
+            ON i.filename = COALESCE(pg.content ->> '$.body[0].smallFilename', pg.content ->> '$.body[0].filename')
+
+        WHERE
+            pg.type = 'data-insight'
+            AND i.replacedBy IS NULL
+
+        ORDER BY pg.updatedAt DESC`
+    )
+    const groupedTags = await getTagsGroupedByGdocId(
+        knex,
+        rows.map((row) => row.gdocId)
+    )
+    return rows.map((row) =>
+        extractDataInsightIndexItem({
+            ...row,
+            tags: groupedTags[row.gdocId] ? groupedTags[row.gdocId] : undefined,
+        })
+    )
+}
+
+function extractDataInsightIndexItem(
+    dataInsight: DataInsightRow
+): OwidGdocDataInsightIndexItem {
+    const content = parsePostGdocContent(
+        dataInsight.content
+    ) as OwidGdocDataInsightContent
+    const chartConfig = dataInsight.chartConfig
+        ? parseChartConfig(dataInsight.chartConfig)
+        : undefined
+
+    // check if the given grapher-url is a valid Grapher or Explorer URL
+    const grapherUrlField = content["grapher-url"]
+    const grapherUrl = grapherUrlField?.startsWith(GRAPHER_URL_PREFIX)
+        ? grapherUrlField
+        : undefined
+    const explorerUrl = grapherUrlField?.startsWith(EXPLORER_URL_PREFIX)
+        ? grapherUrlField
+        : undefined
+
+    // collect narrative chart data if it exists
+    const narrativeChart =
+        content["narrative-chart"] && dataInsight.narrativeChartId
+            ? {
+                  id: dataInsight.narrativeChartId,
+                  name: content["narrative-chart"],
+                  chartConfigId: dataInsight.narrativeChartConfigId!,
+              }
+            : undefined
+
+    // detect the chart type from the narrative chart or grapher URL
+    const chartType = detectChartType({
+        narrativeChart: narrativeChart?.name,
+        grapherUrl,
+        chartConfig,
+    })
+
+    // collect the image data if it exists
+    const image = dataInsight.imageId
+        ? {
+              id: dataInsight.imageId,
+              filename: dataInsight.filename,
+              cloudflareId: dataInsight.cloudflareId,
+              originalWidth: dataInsight.originalWidth,
+          }
+        : undefined
+
+    return {
+        id: dataInsight.gdocId,
+        slug: dataInsight.slug,
+        tags: dataInsight.tags ?? [],
+        published: !!dataInsight.published,
+        publishedAt: dataInsight.publishedAt,
+        markdown: dataInsight.markdown,
+        title: content.title ?? "",
+        authors: content.authors,
+        approvedBy: content["approved-by"],
+        narrativeChart,
+        grapherUrl,
+        explorerUrl,
+        figmaUrl: content["figma-url"],
+        chartType,
+        image,
+    }
+}
+
+function detectChartType({
+    narrativeChart,
+    grapherUrl,
+    chartConfig,
+}: {
+    narrativeChart?: string
+    grapherUrl?: string
+    chartConfig?: GrapherInterface
+}): GrapherChartOrMapType | undefined {
+    if (!chartConfig) return undefined
+
+    if (narrativeChart) return getChartTypeFromConfig(chartConfig)
+
+    if (grapherUrl) {
+        const url = new URL(grapherUrl)
+        return getChartTypeFromConfigAndQueryParams(
+            chartConfig,
+            url.searchParams
+        )
+    }
+
+    return undefined
+}

--- a/packages/@ourworldindata/grapher/src/chart/ChartUtils.tsx
+++ b/packages/@ourworldindata/grapher/src/chart/ChartUtils.tsx
@@ -1,5 +1,11 @@
 import * as React from "react"
-import { areSetsEqual, Box, getCountryByName, Url } from "@ourworldindata/utils"
+import {
+    areSetsEqual,
+    Box,
+    getCountryByName,
+    getTimeDomainFromQueryString,
+    Url,
+} from "@ourworldindata/utils"
 import {
     SeriesStrategy,
     EntityName,
@@ -9,6 +15,9 @@ import {
     GRAPHER_TAB_QUERY_PARAMS,
     InteractionState,
     SeriesName,
+    GrapherInterface,
+    GrapherChartOrMapType,
+    GRAPHER_MAP_TYPE,
 } from "@ourworldindata/types"
 import { LineChartSeries } from "../lineCharts/LineChartConstants"
 import { SelectionArray } from "../selection/SelectionArray"
@@ -280,4 +289,93 @@ export function generateGrapherImageSrcSet(defaultSrc: string): string {
         .join(", ")
 
     return srcSet
+}
+
+export function getChartTypeFromConfig(
+    chartConfig: GrapherInterface
+): GrapherChartOrMapType | undefined {
+    return getChartTypeFromConfigAndQueryParams(chartConfig)
+}
+
+// TODO: use GrapherState to detect chart type
+export function getChartTypeFromConfigAndQueryParams(
+    chartConfig: GrapherInterface,
+    queryParams?: URLSearchParams
+): GrapherChartOrMapType | undefined {
+    // If the tab query parameter is set, use it to determine the chart type
+    const tab = queryParams?.get("tab")
+    if (tab) {
+        // Handle cases where tab is set to 'line' or 'slope'
+        const chartType = mapQueryParamToChartTypeName(tab)
+        if (chartType)
+            return maybeLineChartThatTurnedIntoDiscreteBar(
+                chartType,
+                chartConfig,
+                queryParams
+            )
+
+        // Handle cases where tab is set to 'chart', 'map' or 'table'
+        if (tab === GRAPHER_TAB_QUERY_PARAMS.table) return undefined
+        if (tab === GRAPHER_TAB_QUERY_PARAMS.map) return GRAPHER_MAP_TYPE
+        if (tab === GRAPHER_TAB_QUERY_PARAMS.chart) {
+            const chartType = getChartTypeFromConfigField(
+                chartConfig.chartTypes
+            )
+            if (chartType)
+                return maybeLineChartThatTurnedIntoDiscreteBar(
+                    chartType,
+                    chartConfig,
+                    queryParams
+                )
+        }
+    }
+
+    // If the chart has a map tab and it's the default tab, use the map type
+    if (
+        chartConfig.hasMapTab &&
+        chartConfig.tab === GRAPHER_TAB_QUERY_PARAMS.map
+    )
+        return GRAPHER_MAP_TYPE
+
+    // Otherwise, rely on the config's chartTypes field
+    const chartType = getChartTypeFromConfigField(chartConfig.chartTypes)
+    if (chartType) {
+        return maybeLineChartThatTurnedIntoDiscreteBar(
+            chartType,
+            chartConfig,
+            queryParams
+        )
+    }
+
+    return undefined
+}
+
+function getChartTypeFromConfigField(
+    chartTypes?: GrapherChartType[]
+): GrapherChartType | undefined {
+    if (!chartTypes) return GRAPHER_CHART_TYPES.LineChart
+    if (chartTypes.length === 0) return undefined
+    return chartTypes[0]
+}
+
+function maybeLineChartThatTurnedIntoDiscreteBar(
+    chartType: GrapherChartType,
+    chartConfig: GrapherInterface,
+    queryParams?: URLSearchParams
+): GrapherChartType {
+    if (chartType !== GRAPHER_CHART_TYPES.LineChart) return chartType
+
+    const time = queryParams?.get("time")
+    if (time) {
+        const [minTime, maxTime] = getTimeDomainFromQueryString(time)
+        if (minTime === maxTime) return GRAPHER_CHART_TYPES.DiscreteBar
+    }
+
+    if (
+        chartConfig.minTime !== undefined &&
+        chartConfig.minTime === chartConfig.maxTime
+    )
+        return GRAPHER_CHART_TYPES.DiscreteBar
+
+    return chartType
 }

--- a/packages/@ourworldindata/grapher/src/index.ts
+++ b/packages/@ourworldindata/grapher/src/index.ts
@@ -87,4 +87,8 @@ export {
 } from "./slideshowController/SlideShowController"
 export { defaultGrapherConfig } from "./schema/defaultGrapherConfig"
 export { migrateGrapherConfigToLatestVersion } from "./schema/migrations/migrate"
-export { generateGrapherImageSrcSet } from "./chart/ChartUtils.js"
+export {
+    generateGrapherImageSrcSet,
+    getChartTypeFromConfig,
+    getChartTypeFromConfigAndQueryParams,
+} from "./chart/ChartUtils.js"

--- a/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
@@ -1,4 +1,8 @@
-import { GrapherTabOption, RelatedChart } from "../grapherTypes/GrapherTypes.js"
+import {
+    GrapherChartOrMapType,
+    GrapherTabOption,
+    RelatedChart,
+} from "../grapherTypes/GrapherTypes.js"
 import { BreadcrumbItem } from "../domainTypes/Site.js"
 import { TocHeadingWithTitleSupertitle } from "../domainTypes/Toc.js"
 import { ImageMetadata } from "./Image.js"
@@ -15,6 +19,8 @@ import { MinimalTag } from "../dbTypes/Tags.js"
 import { DbEnrichedLatestWork } from "../domainTypes/Author.js"
 import { QueryParams } from "../domainTypes/Various.js"
 import { TagGraphRoot } from "../domainTypes/ContentGraph.js"
+import { DbRawImage } from "../dbTypes/Images.js"
+import { DbPlainChartView } from "../dbTypes/ChartViews.js"
 
 export enum OwidGdocPublicationContext {
     unlisted = "unlisted",
@@ -160,6 +166,23 @@ export interface OwidGdocDataInsightContent {
     body: OwidEnrichedGdocBlock[]
     type: OwidGdocType.DataInsight
 }
+
+export type OwidGdocDataInsightIndexItem = Pick<
+    OwidGdocBaseInterface,
+    "id" | "slug" | "tags" | "published" | "publishedAt" | "markdown"
+> &
+    Pick<OwidGdocDataInsightContent, "title" | "authors"> & {
+        approvedBy?: OwidGdocDataInsightContent["approved-by"]
+        grapherUrl?: OwidGdocDataInsightContent["grapher-url"]
+        explorerUrl?: OwidGdocDataInsightContent["grapher-url"]
+        narrativeChart?: Pick<DbPlainChartView, "id" | "name" | "chartConfigId">
+        chartType?: GrapherChartOrMapType
+        figmaUrl?: OwidGdocDataInsightContent["figma-url"]
+        image?: Pick<
+            DbRawImage,
+            "id" | "cloudflareId" | "filename" | "originalWidth"
+        >
+    }
 
 export const DATA_INSIGHTS_INDEX_PAGE_SIZE = 20
 

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -338,6 +338,7 @@ export {
     type OwidGdocIndexItem,
     extractGdocIndexItem,
     type ChartViewInfo,
+    type OwidGdocDataInsightIndexItem,
 } from "./gdocTypes/Gdoc.js"
 
 export {

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -232,6 +232,8 @@ export type AllKeysRequired<T> = AllowUndefinedValues<
 
 export type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>
 
+export type RequiredBy<T, K extends keyof T> = Omit<T, K> & Required<Pick<T, K>>
+
 // doesn't do anything fancy, but makes it a bit more readable by skipping one layer of angle brackets:
 // PartialRecord<A, B> = Partial<Record<A, B>>
 export type PartialRecord<K extends keyof any, V> = Partial<Record<K, V>>

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -3,6 +3,7 @@ export {
     type NoUndefinedValues,
     type AllKeysRequired,
     type PartialBy,
+    type RequiredBy,
     type PartialRecord,
     createFormatter,
     getRelativeMouse,


### PR DESCRIPTION
Adds an index page for data insights in the admin.

### Summary

- The /dataInsights endpoint returns all data insights, enriched with information that is surfaced on the index page (e.g. image, topic tags, chart type)
- The index page has a list and gallery layout (top right) and allows to filter by publication status.

### Notes

- The data insights query assumes the image block comes first
- Because we're now surfacing the `grapher-url`, I added some validation for it. As far as I know, the `grapher-url` should be a valid grapher or explorer link, but maybe I'm forgetting something?
- Search includes the body text. I just grabbed the markdown column for that because it was easiest. What's a little weird about that is that the markdown contains image filenames (and maybe other stuff), which sometimes leads to weird search results. I don't think that's too bad but if it's straight-forward to concat all text elements instead, let me know and I'm happy to rewrite
- Data insight images that are not squared get squished in the gallery (see screenshot below)

<details><summary><b>Screenshots</b></summary>
<p>
<img width="1183" alt="Screenshot 2025-01-30 at 10 42 08" src="https://github.com/user-attachments/assets/63a73752-429a-460e-abe0-c5faa3c64652" />
</p>
</details>

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 9 in a stack** made with GitButler:
- <kbd>&nbsp;9&nbsp;</kbd> #4571 
- <kbd>&nbsp;8&nbsp;</kbd> #4570 
- <kbd>&nbsp;7&nbsp;</kbd> #4558 
- <kbd>&nbsp;6&nbsp;</kbd> #4557 
- <kbd>&nbsp;5&nbsp;</kbd> #4556 
- <kbd>&nbsp;4&nbsp;</kbd> #4547 
- <kbd>&nbsp;3&nbsp;</kbd> #4500 
- <kbd>&nbsp;2&nbsp;</kbd> #4490 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #4489 
<!-- GitButler Footer Boundary Bottom -->

