### PR TITLE
✨ check there's no slug collision before publishing

### DIFF
--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -740,7 +740,8 @@ $nav-height: 45px;
 }
 
 .errorMessage {
-    z-index: 2000;
+    // 1 above .ant-modal-mask
+    z-index: 2001;
     .modal-dialog {
         max-width: 80%;
     }

--- a/db/model/Gdoc/GdocFactory.ts
+++ b/db/model/Gdoc/GdocFactory.ts
@@ -661,7 +661,7 @@ export async function getAllGdocIndexItemsOrderedByUpdatedAt(
     )
 }
 
-export async function addImagesToContentGraph(
+export async function setImagesInContentGraph(
     trx: KnexReadWriteTransaction,
     gdoc: GdocPost | GdocDataInsight | GdocHomepage | GdocAbout | GdocAuthor
 ): Promise<void> {


### PR DESCRIPTION
Resolves #4493

Compares via canonical URL in the event we want `/data-insights/some-slug` and `/some-slug`

Renamed `addImagesToContentGraph` to `setImagesToContentGraph` because I was confused when reading it to see that it also took care of deleting images from the content graph if unpublishing.


https://github.com/user-attachments/assets/496f66d0-b7a7-49d3-a2e2-8d24958d0ed4

