### PR TITLE
🎉 reupload DI images automatically / TAS-831

### DIFF
--- a/adminShared/AdminTypes.ts
+++ b/adminShared/AdminTypes.ts
@@ -1,3 +1,5 @@
+import { DbRawImage } from "@ourworldindata/types"
+
 export interface ApiChartViewOverview {
     id: number
     name: string
@@ -9,4 +11,17 @@ export interface ApiChartViewOverview {
     lastEditedByUser: string | null
     chartConfigId: string
     title: string
+}
+
+export interface DataInsight {
+    gdocId: string
+    title: string
+    published: boolean
+    figmaUrl?: string
+    image?: {
+        id: NonNullable<DbRawImage["id"]>
+        filename: NonNullable<DbRawImage["filename"]>
+        cloudflareId: NonNullable<DbRawImage["cloudflareId"]>
+        originalWidth: NonNullable<DbRawImage["originalWidth"]>
+    }
 }

--- a/adminSiteClient/AbstractChartEditor.ts
+++ b/adminSiteClient/AbstractChartEditor.ts
@@ -14,6 +14,7 @@ import { Admin } from "./Admin.js"
 import { defaultGrapherConfig, Grapher } from "@ourworldindata/grapher"
 import { ChartViewMinimalInformation } from "./ChartEditor.js"
 import { IndicatorChartInfo } from "./IndicatorChartEditor.js"
+import { DataInsight } from "../adminShared/AdminTypes.js"
 
 export type EditorTab =
     | "basic"
@@ -41,6 +42,7 @@ export interface References {
     explorers?: string[]
     chartViews?: ChartViewMinimalInformation[]
     childCharts?: IndicatorChartInfo[]
+    dataInsights?: DataInsight[]
 }
 
 export abstract class AbstractChartEditor<

--- a/adminSiteClient/ChartViewEditor.ts
+++ b/adminSiteClient/ChartViewEditor.ts
@@ -21,6 +21,7 @@ export interface Chart {
 
 export interface ChartViewEditorManager extends AbstractChartEditorManager {
     chartViewId: number
+    idsAndName: { id: number; name: string; configId: string } | undefined
     parentChartId: number
     references: References | undefined
 }

--- a/adminSiteClient/ChartViewEditorPage.tsx
+++ b/adminSiteClient/ChartViewEditorPage.tsx
@@ -18,7 +18,8 @@ export class ChartViewEditorPage
     static contextType = AdminAppContext
     context!: AdminAppContextType
 
-    idAndName: { id: number; name: string } | undefined = undefined
+    idsAndName: { id: number; name: string; configId: string } | undefined =
+        undefined
 
     patchConfig: GrapherInterface = {}
     fullConfig: GrapherInterface = {}
@@ -34,7 +35,11 @@ export class ChartViewEditorPage
             `/api/chartViews/${this.chartViewId}.config.json`
         )
 
-        this.idAndName = { id: data.id, name: data.name }
+        this.idsAndName = {
+            id: data.id,
+            name: data.name,
+            configId: data.chartConfigId,
+        }
         this.fullConfig = data.configFull
         this.patchConfig = data.configPatch
         this.parentChartId = data.parentChartId

--- a/adminSiteClient/DataInsightIndexPage.tsx
+++ b/adminSiteClient/DataInsightIndexPage.tsx
@@ -707,19 +707,19 @@ function UploadFigmaImageModal({
 function hasNarrativeChart(
     dataInsight: OwidGdocDataInsightIndexItem
 ): dataInsight is RequiredBy<OwidGdocDataInsightIndexItem, "narrativeChart"> {
-    return dataInsight.narrativeChart !== undefined
+    return !!dataInsight.narrativeChart
 }
 
 function hasImage(
     dataInsight: OwidGdocDataInsightIndexItem
 ): dataInsight is RequiredBy<OwidGdocDataInsightIndexItem, "image"> {
-    return dataInsight.image !== undefined
+    return !!dataInsight.image
 }
 
 function hasFigmaUrl(
     dataInsight: OwidGdocDataInsightIndexItem
 ): dataInsight is RequiredBy<OwidGdocDataInsightIndexItem, "figmaUrl"> {
-    return dataInsight.figmaUrl !== undefined
+    return !!dataInsight.figmaUrl
 }
 
 function canReuploadNarrativeChartImage(

--- a/adminSiteClient/DataInsightIndexPage.tsx
+++ b/adminSiteClient/DataInsightIndexPage.tsx
@@ -30,6 +30,7 @@ import {
     filterFunctionForSearchWords,
     highlightFunctionForSearchWords,
 } from "../adminShared/search.js"
+import { Admin } from "./Admin.js"
 import {
     ALL_GRAPHER_CHART_TYPES,
     DbEnrichedImageWithUserId,

--- a/adminSiteClient/DataInsightIndexPage.tsx
+++ b/adminSiteClient/DataInsightIndexPage.tsx
@@ -10,10 +10,12 @@ import {
     Select,
     Space,
     Table,
+    Tooltip,
 } from "antd"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import {
     faCopy,
+    faPanorama,
     faPen,
     faUpload,
     faUpRightFromSquare,
@@ -80,6 +82,7 @@ const linkIcon = <FontAwesomeIcon icon={faUpRightFromSquare} size="sm" />
 const uploadIcon = <FontAwesomeIcon icon={faUpload} size="sm" />
 const figmaIcon = <FontAwesomeIcon icon={faFigma} size="sm" />
 const copyIcon = <FontAwesomeIcon icon={faCopy} size="sm" />
+const panoramaIcon = <FontAwesomeIcon icon={faPanorama} size="sm" />
 
 const NotificationContext = React.createContext(null)
 
@@ -209,6 +212,15 @@ function createColumns(ctx: {
                     >
                         Preview
                     </Button>
+                    {hasNarrativeChart(dataInsight) && (
+                        <Button
+                            href={makeNarrativeChartEditLink(dataInsight)}
+                            target="_blank"
+                            icon={panoramaIcon}
+                        >
+                            Narrative chart
+                        </Button>
+                    )}
                     {dataInsight.grapherUrl && (
                         <Button
                             href={dataInsight.grapherUrl}
@@ -252,25 +264,17 @@ function createColumns(ctx: {
                     >
                         Edit GDoc
                     </Button>
-                    {hasNarrativeChart(dataInsight) && (
-                        <Button
-                            type="primary"
-                            href={makeNarrativeChartEditLink(dataInsight)}
-                            target="_blank"
-                            icon={editIcon}
-                        >
-                            Edit narrative chart
-                        </Button>
-                    )}
                     {canReuploadImage(dataInsight) && (
-                        <Button
-                            icon={uploadIcon}
-                            onClick={() =>
-                                ctx.triggerImageUploadFlow(dataInsight)
-                            }
-                        >
-                            Reupload image
-                        </Button>
+                        <Tooltip title={makeUploadImageHelpText(dataInsight)}>
+                            <Button
+                                icon={uploadIcon}
+                                onClick={() =>
+                                    ctx.triggerImageUploadFlow(dataInsight)
+                                }
+                            >
+                                Reupload image
+                            </Button>
+                        </Tooltip>
                     )}
                 </Space>
             ),
@@ -641,6 +645,7 @@ function UploadNarrativeChartImageModal({
 
     return (
         <ReuploadImageForDataInsightModal
+            description={makeUploadImageHelpText(dataInsight)}
             dataInsight={dataInsight}
             existingImage={dataInsight.image}
             sourceUrl={sourceUrl}
@@ -687,6 +692,7 @@ function UploadFigmaImageModal({
 
     return (
         <ReuploadImageForDataInsightModal
+            description={makeUploadImageHelpText(dataInsight)}
             dataInsight={dataInsight}
             existingImage={dataInsight.image}
             sourceUrl={figmaImageUrl}
@@ -735,6 +741,16 @@ function canReuploadImage(
         canReuploadNarrativeChartImage(dataInsight) ||
         canReuploadFigmaImage(dataInsight)
     )
+}
+
+function makeUploadImageHelpText(
+    dataInsight: DataInsightIndexItemThatCanBeUploaded
+): string {
+    if (canReuploadFigmaImage(dataInsight))
+        return "Fetch a PNG from Figma and upload it as the image for this data insight"
+    else if (canReuploadNarrativeChartImage(dataInsight))
+        return "Fetch a PNG of the narrative chart and upload it as the image for this data insight"
+    else return ""
 }
 
 async function fetchFigmaProvidedImageUrl(

--- a/adminSiteClient/DataInsightIndexPage.tsx
+++ b/adminSiteClient/DataInsightIndexPage.tsx
@@ -17,7 +17,7 @@ import {
     faCopy,
     faPanorama,
     faPen,
-    faUpload,
+    faRotate,
     faUpRightFromSquare,
 } from "@fortawesome/free-solid-svg-icons"
 import { faFigma } from "@fortawesome/free-brands-svg-icons"
@@ -79,7 +79,7 @@ const DEFAULT_LAYOUT: Layout = "list"
 
 const editIcon = <FontAwesomeIcon icon={faPen} size="sm" />
 const linkIcon = <FontAwesomeIcon icon={faUpRightFromSquare} size="sm" />
-const uploadIcon = <FontAwesomeIcon icon={faUpload} size="sm" />
+const rotateIcon = <FontAwesomeIcon icon={faRotate} size="sm" />
 const figmaIcon = <FontAwesomeIcon icon={faFigma} size="sm" />
 const copyIcon = <FontAwesomeIcon icon={faCopy} size="sm" />
 const panoramaIcon = <FontAwesomeIcon icon={faPanorama} size="sm" />
@@ -267,12 +267,12 @@ function createColumns(ctx: {
                     {canReuploadImage(dataInsight) && (
                         <Tooltip title={makeUploadImageHelpText(dataInsight)}>
                             <Button
-                                icon={uploadIcon}
+                                icon={rotateIcon}
                                 onClick={() =>
                                     ctx.triggerImageUploadFlow(dataInsight)
                                 }
                             >
-                                Reupload image
+                                Update image
                             </Button>
                         </Tooltip>
                     )}

--- a/adminSiteClient/DataInsightIndexPage.tsx
+++ b/adminSiteClient/DataInsightIndexPage.tsx
@@ -489,6 +489,9 @@ export function DataInsightIndexPage() {
                                 type="dashed"
                                 onClick={() => {
                                     setSearchValue("")
+                                    setChartTypeFilter(
+                                        DEFAULT_CHART_TYPE_FILTER
+                                    )
                                     setPublicationFilter(
                                         DEFAULT_PUBLICATION_FILTER
                                     )

--- a/adminSiteClient/EditorReferencesTab.tsx
+++ b/adminSiteClient/EditorReferencesTab.tsx
@@ -540,6 +540,7 @@ const ReferencesDataInsights = (props: {
                 </ul>
                 {dataInsightForUpload?.image && (
                     <ReuploadImageForDataInsightModal
+                        description="Upload a static export of the chart as the image for this data insight"
                         dataInsight={{
                             id: dataInsightForUpload.gdocId,
                             title: dataInsightForUpload.title,

--- a/adminSiteClient/EditorReferencesTab.tsx
+++ b/adminSiteClient/EditorReferencesTab.tsx
@@ -509,7 +509,8 @@ const ReferencesDataInsights = (props: {
                 <p>Data insights based on this narrative chart</p>
                 <ul className="list-group">
                     {props.references.dataInsights.map((dataInsight) => {
-                        const canReuploadImage = dataInsight.image
+                        const canReuploadImage =
+                            dataInsight.image && !dataInsight.figmaUrl
                         return (
                             <Fragment key={dataInsight.gdocId}>
                                 <li>

--- a/adminSiteClient/EditorReferencesTab.tsx
+++ b/adminSiteClient/EditorReferencesTab.tsx
@@ -1,4 +1,6 @@
-import { Component, Fragment } from "react"
+/* eslint-disable react-refresh/only-export-components */
+
+import { Component, createContext, Fragment, useState } from "react"
 import { observer } from "mobx-react"
 import {
     ChartEditor,
@@ -6,7 +8,10 @@ import {
     isChartEditorInstance,
 } from "./ChartEditor.js"
 import { computed, action, observable, runInAction } from "mobx"
-import { BAKED_GRAPHER_URL } from "../settings/clientSettings.js"
+import {
+    BAKED_GRAPHER_URL,
+    GRAPHER_DYNAMIC_THUMBNAIL_URL,
+} from "../settings/clientSettings.js"
 import { AdminAppContext, AdminAppContextType } from "./AdminAppContext.js"
 import {
     stringifyUnknownError,
@@ -26,6 +31,10 @@ import {
     ChartViewEditor,
     isChartViewEditorInstance,
 } from "./ChartViewEditor.js"
+import { ReuploadImageForDataInsightModal } from "./ReuploadImageForDataInsightModal.js"
+import { ImageUploadResponse } from "./imagesHelpers.js"
+import { DataInsight } from "../adminShared/AdminTypes.js"
+import { notification } from "antd"
 
 const BASE_URL = BAKED_GRAPHER_URL.replace(/^https?:\/\//, "")
 
@@ -45,127 +54,6 @@ export class EditorReferencesTab<
             return <EditorReferencesTabForChartView editor={editor} />
         else return null
     }
-}
-
-export const ReferencesSection = (props: {
-    references: References | undefined
-}) => {
-    const wpPosts = props.references?.postsWordpress?.length ? (
-        <>
-            {" "}
-            <p>Public wordpress pages that embed or reference this chart:</p>
-            <ul className="list-group">
-                {props.references.postsWordpress.map((post) => (
-                    <li key={post.id} className="list-group-item">
-                        <a href={post.url} target="_blank" rel="noopener">
-                            <strong>{post.title}</strong>
-                        </a>{" "}
-                        (
-                        <a
-                            href={`https://owid.cloud/wp/wp-admin/post.php?post=${post.id}&action=edit`}
-                            target="_blank"
-                            rel="noopener"
-                        >
-                            Edit
-                        </a>
-                        )
-                    </li>
-                ))}
-            </ul>
-        </>
-    ) : (
-        <></>
-    )
-    const gdocsPosts = props.references?.postsGdocs?.length ? (
-        <>
-            <p>Public gdocs pages that embed or reference this chart:</p>
-            <ul className="list-group">
-                {props.references.postsGdocs.map((post) => (
-                    <li key={post.id} className="list-group-item">
-                        <a href={post.url} target="_blank" rel="noopener">
-                            <strong>{post.title}</strong>
-                        </a>{" "}
-                        (
-                        <a
-                            href={`/admin/gdocs/${post.id}/preview`}
-                            target="_blank"
-                            rel="noopener"
-                        >
-                            Edit
-                        </a>
-                        )
-                    </li>
-                ))}
-            </ul>
-        </>
-    ) : (
-        <></>
-    )
-    const explorers = props.references?.explorers?.length ? (
-        <>
-            <p>Explorers that reference this chart:</p>
-            <ul className="list-group">
-                {props.references.explorers.map((explorer) => (
-                    <li key={explorer} className="list-group-item">
-                        <a
-                            href={`https://ourworldindata.org/explorers/${explorer}`}
-                            target="_blank"
-                            rel="noopener"
-                        >
-                            <strong>{explorer}</strong>
-                        </a>{" "}
-                        (
-                        <a
-                            href={`/admin/explorers/${explorer}`}
-                            target="_blank"
-                            rel="noopener"
-                        >
-                            Edit
-                        </a>
-                        )
-                    </li>
-                ))}
-            </ul>
-        </>
-    ) : (
-        <></>
-    )
-
-    const chartViews = !!props.references?.chartViews?.length && (
-        <>
-            <p>Narrative charts based on this chart</p>
-            <ul className="list-group">
-                {props.references.chartViews.map((chartView) => (
-                    <li key={chartView.id} className="list-group-item">
-                        <a
-                            href={`/admin/chartViews/${chartView.id}/edit`}
-                            target="_blank"
-                            rel="noopener"
-                        >
-                            <strong>{chartView.title}</strong>
-                        </a>
-                    </li>
-                ))}
-            </ul>
-        </>
-    )
-
-    return (
-        <>
-            <h5>References</h5>
-            {props.references &&
-            getFullReferencesCount(props.references) > 0 ? (
-                <>
-                    {wpPosts}
-                    {gdocsPosts}
-                    {explorers}
-                    {chartViews}
-                </>
-            ) : (
-                <p>No references found</p>
-            )}
-        </>
-    )
 }
 
 @observer
@@ -199,7 +87,7 @@ export class EditorReferencesTabForChart extends Component<{
 
     render() {
         return (
-            <div>
+            <div className="EditorReferencesTab">
                 <section>
                     <h5>Pageviews</h5>
                     <div>
@@ -233,7 +121,22 @@ export class EditorReferencesTabForChart extends Component<{
                     </small>
                 </section>
                 <section>
-                    <ReferencesSection references={this.references} />
+                    <h5>References</h5>
+                    {this.references &&
+                    getFullReferencesCount(this.references) > 0 ? (
+                        <>
+                            <ReferencesWordpressPosts
+                                references={this.references}
+                            />
+                            <ReferencesGdocPosts references={this.references} />
+                            <ReferencesExplorers references={this.references} />
+                            <ReferencesChartViews
+                                references={this.references}
+                            />
+                        </>
+                    ) : (
+                        <p>No references found</p>
+                    )}
                 </section>
                 <section>
                     <h5>Alternative URLs for this chart</h5>
@@ -281,11 +184,30 @@ export class EditorReferencesTabForChartView extends Component<{
         return this.props.editor.references
     }
 
+    @computed get chartViewConfigId() {
+        return this.props.editor.manager.idsAndName?.configId ?? ""
+    }
+
     render() {
         return (
-            <div>
+            <div className="EditorReferencesTab">
                 <section>
-                    <ReferencesSection references={this.references} />
+                    <h5>References</h5>
+                    {this.references &&
+                    getFullReferencesCount(this.references) > 0 ? (
+                        <>
+                            <ReferencesWordpressPosts
+                                references={this.references}
+                            />
+                            <ReferencesGdocPosts references={this.references} />
+                            <ReferencesDataInsights
+                                references={this.references}
+                                chartViewConfigId={this.chartViewConfigId}
+                            />
+                        </>
+                    ) : (
+                        <p>No references found</p>
+                    )}
                 </section>
             </div>
         )
@@ -410,24 +332,225 @@ export class EditorReferencesTabForIndicator extends Component<{
         )
 
         return (
-            <Section name="Inheriting charts">
-                <p>
-                    Published charts that inherit from this indicator:{" "}
-                    {chartsInheritanceEnabled.length === 0 && <i>None</i>}
-                </p>
+            <div className="EditorReferencesTab">
+                <Section name="Inheriting charts">
+                    <p>
+                        Published charts that inherit from this indicator:{" "}
+                        {chartsInheritanceEnabled.length === 0 && <i>None</i>}
+                    </p>
 
-                {chartsInheritanceEnabled.length > 0 &&
-                    renderChartList(chartsInheritanceEnabled)}
+                    {chartsInheritanceEnabled.length > 0 &&
+                        renderChartList(chartsInheritanceEnabled)}
 
-                <p>
-                    Published charts that may inherit from this indicator, but
-                    inheritance is currently disabled:{" "}
-                    {chartsInheritanceDisabled.length === 0 && <i>None</i>}
-                </p>
+                    <p>
+                        Published charts that may inherit from this indicator,
+                        but inheritance is currently disabled:{" "}
+                        {chartsInheritanceDisabled.length === 0 && <i>None</i>}
+                    </p>
 
-                {chartsInheritanceDisabled.length > 0 &&
-                    renderChartList(chartsInheritanceDisabled)}
-            </Section>
+                    {chartsInheritanceDisabled.length > 0 &&
+                        renderChartList(chartsInheritanceDisabled)}
+                </Section>
+            </div>
         )
     }
+}
+
+const ReferencesWordpressPosts = (props: {
+    references: Pick<References, "postsWordpress">
+}) => {
+    if (!props.references.postsWordpress?.length) return null
+    return (
+        <>
+            <p>Public wordpress pages that embed or reference this chart:</p>
+            <ul className="list-group">
+                {props.references.postsWordpress.map((post) => (
+                    <li key={post.id} className="list-group-item">
+                        <a href={post.url} target="_blank" rel="noopener">
+                            <strong>{post.title}</strong>
+                        </a>{" "}
+                        (
+                        <a
+                            href={`https://owid.cloud/wp/wp-admin/post.php?post=${post.id}&action=edit`}
+                            target="_blank"
+                            rel="noopener"
+                        >
+                            Edit
+                        </a>
+                        )
+                    </li>
+                ))}
+            </ul>
+        </>
+    )
+}
+
+const ReferencesGdocPosts = (props: {
+    references: Pick<References, "postsGdocs">
+}) => {
+    if (!props.references.postsGdocs?.length) return null
+    return (
+        <>
+            <p>Public gdocs pages that embed or reference this chart:</p>
+            <ul className="list-group">
+                {props.references.postsGdocs.map((post) => (
+                    <li key={post.id} className="list-group-item">
+                        <a href={post.url} target="_blank" rel="noopener">
+                            <strong>{post.title}</strong>
+                        </a>{" "}
+                        (
+                        <a
+                            href={`/admin/gdocs/${post.id}/preview`}
+                            target="_blank"
+                            rel="noopener"
+                        >
+                            Edit
+                        </a>
+                        )
+                    </li>
+                ))}
+            </ul>
+        </>
+    )
+}
+
+const ReferencesExplorers = (props: {
+    references: Pick<References, "explorers">
+}) => {
+    if (!props.references.explorers?.length) return null
+    return (
+        <>
+            <p>Explorers that reference this chart:</p>
+            <ul className="list-group">
+                {props.references.explorers.map((explorer) => (
+                    <li key={explorer} className="list-group-item">
+                        <a
+                            href={`https://ourworldindata.org/explorers/${explorer}`}
+                            target="_blank"
+                            rel="noopener"
+                        >
+                            <strong>{explorer}</strong>
+                        </a>{" "}
+                        (
+                        <a
+                            href={`/admin/explorers/${explorer}`}
+                            target="_blank"
+                            rel="noopener"
+                        >
+                            Edit
+                        </a>
+                        )
+                    </li>
+                ))}
+            </ul>
+        </>
+    )
+}
+
+const ReferencesChartViews = (props: {
+    references: Pick<References, "chartViews">
+}) => {
+    if (!props.references.chartViews?.length) return null
+    return (
+        <>
+            <p>Narrative charts based on this chart</p>
+            <ul className="list-group">
+                {props.references.chartViews.map((chartView) => (
+                    <li key={chartView.id} className="list-group-item">
+                        <a
+                            href={`/admin/chartViews/${chartView.id}/edit`}
+                            target="_blank"
+                            rel="noopener"
+                        >
+                            <strong>{chartView.title}</strong>
+                        </a>
+                    </li>
+                ))}
+            </ul>
+        </>
+    )
+}
+
+const NotificationContext = createContext(null)
+
+const ReferencesDataInsights = (props: {
+    references: Pick<References, "dataInsights">
+    chartViewConfigId: string
+}) => {
+    const [dataInsightForUpload, setDataInsightForUpload] =
+        useState<DataInsight>()
+
+    const [notificationApi, notificationContextHolder] =
+        notification.useNotification()
+
+    if (!props.references.dataInsights?.length) return null
+
+    const onImageUploadComplete = async (response: ImageUploadResponse) => {
+        if (response.success) {
+            notificationApi.info({
+                message: "Image replaced!",
+                description:
+                    "Make sure you update the alt text if your revision has substantive changes",
+                placement: "bottomRight",
+            })
+        } else {
+            notificationApi.warning({
+                message: "Image upload failed",
+                description: response?.errorMessage,
+                placement: "bottomRight",
+            })
+        }
+    }
+
+    return (
+        <div className="ReferencesDataInsights">
+            <NotificationContext.Provider value={null}>
+                {notificationContextHolder}
+                <p>Data insights based on this narrative chart</p>
+                <ul className="list-group">
+                    {props.references.dataInsights.map((dataInsight) => {
+                        const canReuploadImage = dataInsight.image
+                        return (
+                            <Fragment key={dataInsight.gdocId}>
+                                <li>
+                                    <a
+                                        className="list-group-item"
+                                        href={`/admin/gdocs/${dataInsight.gdocId}/preview`}
+                                        target="_blank"
+                                        rel="noopener"
+                                    >
+                                        <strong>{dataInsight.title}</strong>
+                                    </a>
+                                    {canReuploadImage && (
+                                        <button
+                                            className="btn btn-secondary"
+                                            onClick={() =>
+                                                setDataInsightForUpload(
+                                                    dataInsight
+                                                )
+                                            }
+                                        >
+                                            Upload static export as DI image
+                                        </button>
+                                    )}
+                                </li>
+                            </Fragment>
+                        )
+                    })}
+                </ul>
+                {dataInsightForUpload?.image && (
+                    <ReuploadImageForDataInsightModal
+                        dataInsight={{
+                            id: dataInsightForUpload.gdocId,
+                            title: dataInsightForUpload.title,
+                        }}
+                        existingImage={dataInsightForUpload.image}
+                        sourceUrl={`${GRAPHER_DYNAMIC_THUMBNAIL_URL}/by-uuid/${props.chartViewConfigId}.png?imType=square&nocache`}
+                        closeModal={() => setDataInsightForUpload(undefined)}
+                        onUploadComplete={onImageUploadComplete}
+                    />
+                )}
+            </NotificationContext.Provider>
+        </div>
+    )
 }

--- a/adminSiteClient/ImagesIndexPage.tsx
+++ b/adminSiteClient/ImagesIndexPage.tsx
@@ -31,7 +31,7 @@ import {
     faSave,
     faUpload,
 } from "@fortawesome/free-solid-svg-icons"
-import { RcFile } from "antd/es/upload/interface.js"
+import { type File, fileToBase64 } from "./imagesHelpers.js"
 import { CLOUDFLARE_IMAGES_URL } from "../settings/clientSettings.js"
 import { Dictionary, keyBy } from "lodash"
 import cx from "classnames"
@@ -463,34 +463,6 @@ function createColumns({
             },
         },
     ]
-}
-
-type File = string | Blob | RcFile
-
-type FileToBase64Result = {
-    filename: string
-    content: string
-    type: string
-}
-
-/**
- * Uploading as base64, because otherwise we'd need multipart/form-data parsing middleware in the server.
- * This seems easier as a one-off.
- **/
-function fileToBase64(file: File): Promise<FileToBase64Result | null> {
-    if (typeof file === "string") return Promise.resolve(null)
-
-    return new Promise((resolve) => {
-        const reader = new FileReader()
-        reader.onload = () => {
-            resolve({
-                filename: file.name,
-                content: reader.result?.toString() ?? "",
-                type: file.type,
-            })
-        }
-        reader.readAsDataURL(file)
-    })
 }
 
 function PostImageButton({

--- a/adminSiteClient/ReuploadImageForDataInsightModal.tsx
+++ b/adminSiteClient/ReuploadImageForDataInsightModal.tsx
@@ -1,0 +1,156 @@
+import { faCheck, faSpinner } from "@fortawesome/free-solid-svg-icons"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import { Modal, Space } from "antd"
+import { useContext, useState } from "react"
+import {
+    ImageUploadResponse,
+    makeImageSrc,
+    reuploadImageFromSourceUrl,
+} from "./imagesHelpers"
+import { AdminAppContext } from "./AdminAppContext"
+
+const spinnerIcon = <FontAwesomeIcon icon={faSpinner} spin />
+const checkIcon = <FontAwesomeIcon icon={faCheck} />
+
+export function ReuploadImageForDataInsightModal({
+    dataInsight,
+    existingImage,
+
+    // the source URL to upload the image from
+    sourceUrl,
+
+    // loading state
+    isLoadingSourceUrl,
+    loadingSourceUrlError,
+
+    // modal-related actions
+    closeModal,
+    onUploadComplete,
+}: {
+    dataInsight: { id: string; title: string }
+    existingImage: {
+        id: number
+        filename: string
+        cloudflareId: string
+        originalWidth: number
+    }
+    sourceUrl?: string
+    isLoadingSourceUrl?: boolean
+    loadingSourceUrlError?: string
+    closeModal: () => void
+    onUploadComplete?: (
+        response: ImageUploadResponse,
+        dataInsight: { id: string; title: string }
+    ) => void
+}) {
+    const { admin } = useContext(AdminAppContext)
+
+    const currentImageUrl = makeImageSrc(
+        existingImage.cloudflareId,
+        existingImage.originalWidth
+    )
+
+    const [isImageUploadInProgress, setIsImageUploadInProgress] =
+        useState(false)
+
+    const handleImageUpload = async () => {
+        setIsImageUploadInProgress(true)
+        const response = sourceUrl
+            ? await reuploadImageFromSourceUrl({
+                  admin,
+                  image: existingImage,
+                  sourceUrl,
+              })
+            : ({
+                  success: false,
+                  errorMessage: "Source URL missing",
+              } as ImageUploadResponse)
+        onUploadComplete?.(response, dataInsight)
+        setIsImageUploadInProgress(false)
+        closeModal()
+    }
+
+    return (
+        <Modal
+            title="Upload image for data insight"
+            open={true}
+            width={765}
+            okText="Upload"
+            okButtonProps={{
+                icon: isImageUploadInProgress ? spinnerIcon : checkIcon,
+                disabled:
+                    isImageUploadInProgress ||
+                    isLoadingSourceUrl ||
+                    (!sourceUrl && !isLoadingSourceUrl),
+            }}
+            onOk={() => handleImageUpload()}
+            onCancel={() => closeModal()}
+        >
+            <div className="di-modal-content">
+                <div>
+                    <b>Data insight</b>
+                    <br />
+                    {dataInsight.title}
+                </div>
+
+                <div>
+                    <b>Filename</b>
+                    <br />
+                    {existingImage.filename}
+                </div>
+
+                <ImagePreview
+                    imageBefore={currentImageUrl}
+                    imageAfter={sourceUrl}
+                    isLoading={isLoadingSourceUrl}
+                    loadingError={loadingSourceUrlError}
+                />
+            </div>
+        </Modal>
+    )
+}
+
+function ImagePreview({
+    imageBefore,
+    imageAfter,
+    size = 350,
+    isLoading = false,
+    loadingError = "",
+}: {
+    imageBefore: string
+    imageAfter?: string
+    size?: number
+    isLoading?: boolean
+    loadingError?: string
+}) {
+    return (
+        <div>
+            <b>Preview (before/after)</b>
+            <div className="image-preview">
+                <Space size="middle">
+                    <img
+                        className="border"
+                        src={imageBefore}
+                        width={size}
+                        height={size}
+                    />
+                    {isLoading ? (
+                        <div className="placeholder">{spinnerIcon}</div>
+                    ) : imageAfter ? (
+                        <img
+                            className="border"
+                            src={imageAfter}
+                            width={size}
+                            height={size}
+                        />
+                    ) : (
+                        <div className="error">
+                            <b>Loading preview failed</b>
+                            <p>{loadingError}</p>
+                        </div>
+                    )}
+                </Space>
+            </div>
+        </div>
+    )
+}

--- a/adminSiteClient/ReuploadImageForDataInsightModal.tsx
+++ b/adminSiteClient/ReuploadImageForDataInsightModal.tsx
@@ -23,6 +23,10 @@ export function ReuploadImageForDataInsightModal({
     isLoadingSourceUrl,
     loadingSourceUrlError,
 
+    // modal presentation
+    title = "Upload image for data insight",
+    description,
+
     // modal-related actions
     closeModal,
     onUploadComplete,
@@ -37,6 +41,8 @@ export function ReuploadImageForDataInsightModal({
     sourceUrl?: string
     isLoadingSourceUrl?: boolean
     loadingSourceUrlError?: string
+    title?: string
+    description?: string
     closeModal: () => void
     onUploadComplete?: (
         response: ImageUploadResponse,
@@ -72,7 +78,7 @@ export function ReuploadImageForDataInsightModal({
 
     return (
         <Modal
-            title="Upload image for data insight"
+            title={title}
             open={true}
             width={765}
             okText="Upload"
@@ -87,17 +93,23 @@ export function ReuploadImageForDataInsightModal({
             onCancel={() => closeModal()}
         >
             <div className="di-modal-content">
-                <div>
+                {description && (
+                    <p>
+                        <i>{description}</i>
+                    </p>
+                )}
+
+                <p>
                     <b>Data insight</b>
                     <br />
                     {dataInsight.title}
-                </div>
+                </p>
 
-                <div>
+                <p>
                     <b>Filename</b>
                     <br />
                     {existingImage.filename}
-                </div>
+                </p>
 
                 <ImagePreview
                     imageBefore={currentImageUrl}

--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -1314,9 +1314,30 @@ main:not(.ChartEditorPage):not(.GdocsEditPage) {
 
     > div {
         margin-bottom: 12px;
+    }
 
-        .preview {
-            margin-top: 6px;
-        }
+    .image-preview {
+        margin-top: 6px;
+    }
+
+    .image-preview .placeholder,
+    .image-preview .error {
+        width: 350px;
+        height: 350px;
+        border: 1px solid #f0f0f0;
+    }
+
+    .image-preview .placeholder {
+        padding: 8px;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        font-size: 16px;
+    }
+
+    .image-preview .error {
+        font-size: 14px;
+        display: block;
+        padding: 12px;
     }
 }

--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -1309,6 +1309,21 @@ main:not(.ChartEditorPage):not(.GdocsEditPage) {
     }
 }
 
+.EditorReferencesTab .ReferencesDataInsights {
+    li {
+        display: flex;
+        gap: 1em;
+
+        a {
+            flex-grow: 1;
+        }
+
+        button {
+            min-width: 144px;
+        }
+    }
+}
+
 .di-modal-content {
     margin: 16px 0 24px 0;
 

--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -1308,3 +1308,15 @@ main:not(.ChartEditorPage):not(.GdocsEditPage) {
         border: 1px solid rgb(240, 240, 240) !important;
     }
 }
+
+.di-modal-content {
+    margin: 16px 0 24px 0;
+
+    > div {
+        margin-bottom: 12px;
+
+        .preview {
+            margin-top: 6px;
+        }
+    }
+}

--- a/adminSiteClient/imagesHelpers.ts
+++ b/adminSiteClient/imagesHelpers.ts
@@ -1,0 +1,29 @@
+import { RcFile } from "antd/es/upload/interface.js"
+
+export type File = string | Blob | RcFile
+
+type FileToBase64Result = {
+    filename: string
+    content: string
+    type: string
+}
+
+/**
+ * Uploading as base64, because otherwise we'd need multipart/form-data parsing middleware in the server.
+ * This seems easier as a one-off.
+ **/
+export function fileToBase64(file: File): Promise<FileToBase64Result | null> {
+    if (typeof file === "string") return Promise.resolve(null)
+
+    return new Promise((resolve) => {
+        const reader = new FileReader()
+        reader.onload = () => {
+            resolve({
+                filename: file.name,
+                content: reader.result?.toString() ?? "",
+                type: file.type,
+            })
+        }
+        reader.readAsDataURL(file)
+    })
+}

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -126,6 +126,7 @@ import {
     getChartTagsJson,
 } from "./apiRoutes/charts.js"
 import { getAllDataInsightIndexItems } from "./apiRoutes/dataInsights.js"
+import { getFigmaImageUrl } from "./apiRoutes/figma.js"
 
 const apiRouter = new FunctionalRouter()
 
@@ -446,6 +447,9 @@ getRouteWithROTransaction(
     "/variables/:variableId/charts.json",
     getVariablesVariableIdChartsJson
 )
+
+// Figma routes
+getRouteWithROTransaction(apiRouter, "/figma/image", getFigmaImageUrl)
 
 // Deploy helpers
 apiRouter.get("/deploys.json", async () => ({

--- a/adminSiteServer/apiRoutes/dataInsights.ts
+++ b/adminSiteServer/apiRoutes/dataInsights.ts
@@ -151,14 +151,17 @@ function extractDataInsightIndexItem(
     })
 
     // collect the image data if it exists
-    const image = dataInsight.imageId
-        ? {
-              id: dataInsight.imageId,
-              filename: dataInsight.filename,
-              cloudflareId: dataInsight.cloudflareId,
-              originalWidth: dataInsight.originalWidth,
-          }
-        : undefined
+    const image =
+        dataInsight.imageId &&
+        dataInsight.cloudflareId &&
+        dataInsight.originalWidth
+            ? {
+                  id: dataInsight.imageId,
+                  filename: dataInsight.filename,
+                  cloudflareId: dataInsight.cloudflareId,
+                  originalWidth: dataInsight.originalWidth,
+              }
+            : undefined
 
     return {
         id: dataInsight.gdocId,

--- a/adminSiteServer/apiRoutes/figma.ts
+++ b/adminSiteServer/apiRoutes/figma.ts
@@ -1,0 +1,33 @@
+import { JsonError } from "@ourworldindata/types"
+import { Request } from "express"
+import * as e from "express"
+import * as db from "../../db/db.js"
+import * as Figma from "figma-api"
+import { FIGMA_API_KEY } from "../../settings/serverSettings.js"
+
+const figmaApi = new Figma.Api({ personalAccessToken: FIGMA_API_KEY })
+
+export async function getFigmaImageUrl(
+    req: Request,
+    _res: e.Response<any, Record<string, any>>,
+    _trx: db.KnexReadonlyTransaction
+) {
+    const { fileId, nodeId } = req.query
+
+    if (!fileId || !nodeId) throw new JsonError("fileId or nodeId missing")
+
+    // Request the image URL from Figma
+    const imageMap = await figmaApi.getImages(
+        { file_key: fileId },
+        { ids: [nodeId], scale: 3 }
+    )
+    if (!imageMap || imageMap.err !== null)
+        throw new JsonError("Failed to fetch image map from Figma")
+
+    // Grab the image URL from the image map
+    const imageUrl = imageMap.images[nodeId]
+    if (!imageUrl)
+        throw new JsonError("Figma's image map does not contain the image")
+
+    return { success: true, imageUrl }
+}

--- a/adminSiteServer/apiRoutes/images.ts
+++ b/adminSiteServer/apiRoutes/images.ts
@@ -117,7 +117,7 @@ export async function putImageHandler(
     if (collision) {
         return {
             success: false,
-            error: `An exact copy of this image already exists (filename: ${collision.filename})`,
+            errorMessage: `An exact copy of this image already exists (filename: ${collision.filename})`,
         }
     }
 

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
         "express": "^4.21.2",
         "express-async-errors": "^3.1.1",
         "express-rate-limit": "^5.1.3",
+        "figma-api": "^2.0.1-beta",
         "filenamify": "^4.1.0",
         "fs-extra": "^11.1.1",
         "fuzzysort": "^1.1.4",

--- a/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
@@ -178,10 +178,12 @@ export type OwidGdocDataInsightIndexItem = Pick<
         narrativeChart?: Pick<DbPlainChartView, "id" | "name" | "chartConfigId">
         chartType?: GrapherChartOrMapType
         figmaUrl?: OwidGdocDataInsightContent["figma-url"]
-        image?: Pick<
-            DbRawImage,
-            "id" | "cloudflareId" | "filename" | "originalWidth"
-        >
+        image?: {
+            id: NonNullable<DbRawImage["id"]>
+            filename: NonNullable<DbRawImage["filename"]>
+            cloudflareId: NonNullable<DbRawImage["cloudflareId"]>
+            originalWidth: NonNullable<DbRawImage["originalWidth"]>
+        }
     }
 
 export const DATA_INSIGHTS_INDEX_PAGE_SIZE = 20

--- a/settings/serverSettings.ts
+++ b/settings/serverSettings.ts
@@ -195,3 +195,5 @@ export const SEARCH_EVAL_URL: string =
 export const ENV_IS_STAGING: boolean = ADMIN_BASE_URL.includes(
     "http://staging-site"
 )
+
+export const FIGMA_API_KEY: string = process.env.FIGMA_API_KEY ?? ""

--- a/yarn.lock
+++ b/yarn.lock
@@ -7405,6 +7405,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"axios@npm:^0.27.2":
+  version: 0.27.2
+  resolution: "axios@npm:0.27.2"
+  dependencies:
+    follow-redirects: "npm:^1.14.9"
+    form-data: "npm:^4.0.0"
+  checksum: 10/2efaf18dd0805f7bc772882bc86f004abd92d51007b54c5081f74db0d08ce3593e2c010261896d25a14318eeaa2e966fd825e34f810e8a3339dc64b9d177cf70
+  languageName: node
+  linkType: hard
+
 "axios@npm:^0.28.0":
   version: 0.28.1
   resolution: "axios@npm:0.28.1"
@@ -10924,6 +10934,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"figma-api@npm:^2.0.1-beta":
+  version: 2.0.1-beta
+  resolution: "figma-api@npm:2.0.1-beta"
+  dependencies:
+    "@types/node": "npm:^22.8.7"
+    axios: "npm:^0.27.2"
+  checksum: 10/332a792a53b6efa5dc4b8d7a0b5130711a467a75be63a0fdb6d183f751548943c9f46c49c4189f1b1a2be5469936f0603af417598861da497b161ca1eb1dc270
+  languageName: node
+  linkType: hard
+
 "figures@npm:3.2.0, figures@npm:^3.0.0, figures@npm:^3.2.0":
   version: 3.2.0
   resolution: "figures@npm:3.2.0"
@@ -11069,6 +11089,16 @@ __metadata:
     debug:
       optional: true
   checksum: 10/70c7612c4cab18e546e36b991bbf8009a1a41cf85354afe04b113d1117569abf760269409cb3eb842d9f7b03d62826687086b081c566ea7b1e6613cf29030bf7
+  languageName: node
+  linkType: hard
+
+"follow-redirects@npm:^1.14.9":
+  version: 1.15.9
+  resolution: "follow-redirects@npm:1.15.9"
+  peerDependenciesMeta:
+    debug:
+      optional: true
+  checksum: 10/e3ab42d1097e90d28b913903841e6779eb969b62a64706a3eb983e894a5db000fbd89296f45f08885a0e54cd558ef62e81be1165da9be25a6c44920da10f424c
   languageName: node
   linkType: hard
 
@@ -11858,6 +11888,7 @@ __metadata:
     express: "npm:^4.21.2"
     express-async-errors: "npm:^3.1.1"
     express-rate-limit: "npm:^5.1.3"
+    figma-api: "npm:^2.0.1-beta"
     filenamify: "npm:^4.1.0"
     flag-icons: "npm:^7.3.1"
     fs-extra: "npm:^11.1.1"


### PR DESCRIPTION
Adds affordances for automatically re-uploading data insight images for DIs linked to a narrative chart or to a Figma chart.

### Summary

- Adds a 'Reupload image' button on the data insight index page
    - If a `figma-url` is given, a PNG version of the chart is fetched from Figma and then uploaded
    - If a `narrative-chart` name is given, the PNG version of that narrative chart is uploaded as a DI image
- Adds a new section to the Reference tab in the chart editor for narrative charts
    - Lists the DIs that use this narrative chart (there should usually only be one)
    - Adds an affordance to upload the PNG export of the narrative chart as the Di image

### Examples

- The [DI index page on staging](http://staging-site-di-automatic-image-upload/admin/dataInsights) lists two test DIs, one with a narrative chart URL and one with a Figma URL
- [This narrative chart on staging](http://staging-site-di-automatic-image-upload/admin/chartViews/8/edit) is linked to two DIs (this is a bit atypical; I expect a narrative chart to be linked to a single DI usually)

### Notes

- It's not possible to upload a new image for a DI; only replacing existing images is supported (I didn't want to reimplement an images admin within the DI page)
    - If a 'Create DI' workflow is added, then that could take care of the initial upload
- The Figma URL should point to a valid Figma node (see screenshot for an example)
- `FIGMA_API_KEY` is added as env var to prod and staging; it's in 1password if you want to set it locally

### Screenshots

<details><summary>Data insights index page (with Reupload image buttons)</summary>
<p>

<img width="1512" alt="Screenshot 2025-02-04 at 16 18 26" src="https://github.com/user-attachments/assets/b24d3e9a-c8c5-4abf-b45a-275fe71b5a04" />

</p>
</details> 

<details><summary>Narrative chart editor: Ref tab</summary>
<p>

<img width="1512" alt="Screenshot 2025-02-04 at 16 19 04" src="https://github.com/user-attachments/assets/8147452b-ae6c-4981-b9d9-74795af24d33" />

</p>
</details> 

<details><summary>Figma URL</summary>
<p>

<img width="1512" alt="Screenshot 2025-02-04 at 16 29 19" src="https://github.com/user-attachments/assets/1743fc02-853f-455d-b13a-023e5d5117c0" />

</p>
</details>

<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 9 in a stack** made with GitButler:
- <kbd>&nbsp;9&nbsp;</kbd> #4571 
- <kbd>&nbsp;8&nbsp;</kbd> #4570 
- <kbd>&nbsp;7&nbsp;</kbd> #4558 
- <kbd>&nbsp;6&nbsp;</kbd> #4557 
- <kbd>&nbsp;5&nbsp;</kbd> #4556 
- <kbd>&nbsp;4&nbsp;</kbd> #4547 
- <kbd>&nbsp;3&nbsp;</kbd> #4500 👈 
- <kbd>&nbsp;2&nbsp;</kbd> #4490 
- <kbd>&nbsp;1&nbsp;</kbd> #4489 
<!-- GitButler Footer Boundary Bottom -->

