### PR TITLE
🔨 add chart view map to public admin router

### DIFF
--- a/adminSiteServer/functionalRouterHelpers.ts
+++ b/adminSiteServer/functionalRouterHelpers.ts
@@ -1,6 +1,7 @@
 import { FunctionalRouter } from "./FunctionalRouter.js"
 import { Request, Response } from "express"
 import * as db from "../db/db.js"
+
 export function getRouteWithROTransaction<T>(
     router: FunctionalRouter,
     targetPath: string,

--- a/adminSiteServer/publicApiRouter.ts
+++ b/adminSiteServer/publicApiRouter.ts
@@ -1,6 +1,9 @@
+import e from "express"
 import { FunctionalRouter } from "./FunctionalRouter.js"
 import { Request, Response } from "./authentication.js"
 import * as db from "../db/db.js"
+import { getChartViewNameConfigMap } from "../db/model/ChartView.js"
+import { getRouteWithROTransaction } from "./functionalRouterHelpers.js"
 
 export const publicApiRouter = new FunctionalRouter()
 
@@ -22,3 +25,16 @@ publicApiRouter.router.get("/health", async (req: Request, res: Response) => {
         console.error("Error at health endpoint", e)
     }
 })
+
+getRouteWithROTransaction(
+    publicApiRouter,
+    "/chartViewMap",
+    async (
+        _req: Request,
+        _res: e.Response<any, Record<string, any>>,
+        trx: db.KnexReadonlyTransaction
+    ) => {
+        const chartViewMap = await getChartViewNameConfigMap(trx)
+        return chartViewMap
+    }
+)

--- a/db/model/ChartView.ts
+++ b/db/model/ChartView.ts
@@ -1,4 +1,8 @@
-import { ChartViewInfo, JsonString } from "@ourworldindata/types"
+import {
+    ChartViewInfo,
+    DbPlainChartView,
+    JsonString,
+} from "@ourworldindata/types"
 import * as db from "../db.js"
 
 export const getChartViewsInfo = async (
@@ -31,4 +35,15 @@ JOIN chart_configs pcc on pc.configId = pcc.id
         ...row,
         queryParamsForParentChart: JSON.parse(row.queryParamsForParentChart),
     }))
+}
+
+export const getChartViewNameConfigMap = async (
+    knex: db.KnexReadonlyTransaction
+): Promise<
+    Record<DbPlainChartView["name"], DbPlainChartView["chartConfigId"]>
+> => {
+    const rows = await db.knexRaw<
+        Pick<DbPlainChartView, "name" | "chartConfigId">
+    >(knex, `SELECT name, chartConfigId FROM chart_views`)
+    return Object.fromEntries(rows.map((row) => [row.name, row.chartConfigId]))
 }


### PR DESCRIPTION
Adding a new `/chartViewMap` route to the public admin router, as disucssed.

I can access it locally (http://localhost:3030/api/chartViewMap) but not on staging.