### PR TITLE
🐛 Fix algolia indexing and error capturing

### DIFF
--- a/baker/algolia/indexChartsToAlgolia.ts
+++ b/baker/algolia/indexChartsToAlgolia.ts
@@ -2,6 +2,7 @@
 // set up before any errors are thrown.
 import "../../serverUtils/instrument.js"
 
+import * as Sentry from "@sentry/node"
 import * as db from "../../db/db.js"
 import { ALGOLIA_INDEXING } from "../../settings/serverSettings.js"
 import { getAlgoliaClient } from "./configureAlgolia.js"
@@ -27,9 +28,9 @@ const indexChartsToAlgolia = async () => {
     await index.replaceAllObjects(records)
 }
 
-process.on("unhandledRejection", (e) => {
-    console.error(e)
+indexChartsToAlgolia().catch(async (e) => {
+    console.error("Error in indexChartsToAlgolia:", e)
+    Sentry.captureException(e)
+    await Sentry.close()
     process.exit(1)
 })
-
-void indexChartsToAlgolia()

--- a/baker/algolia/indexExplorerViewsAndChartsToAlgolia.ts
+++ b/baker/algolia/indexExplorerViewsAndChartsToAlgolia.ts
@@ -2,6 +2,7 @@
 // set up before any errors are thrown.
 import "../../serverUtils/instrument.js"
 
+import * as Sentry from "@sentry/node"
 import * as db from "../../db/db.js"
 import { ALGOLIA_INDEXING } from "../../settings/serverSettings.js"
 import { getAlgoliaClient } from "./configureAlgolia.js"
@@ -55,9 +56,9 @@ const indexExplorerViewsAndChartsToAlgolia = async () => {
     console.log(`Indexing complete`)
 }
 
-process.on("unhandledRejection", (e) => {
-    console.error(e)
+indexExplorerViewsAndChartsToAlgolia().catch(async (e) => {
+    console.error("Error in indexExplorerViewsAndChartsToAlgolia:", e)
+    Sentry.captureException(e)
+    await Sentry.close()
     process.exit(1)
 })
-
-void indexExplorerViewsAndChartsToAlgolia()

--- a/baker/algolia/indexExplorerViewsToAlgolia.ts
+++ b/baker/algolia/indexExplorerViewsToAlgolia.ts
@@ -2,6 +2,7 @@
 // set up before any errors are thrown.
 import "../../serverUtils/instrument.js"
 
+import * as Sentry from "@sentry/node"
 import * as db from "../../db/db.js"
 import { ALGOLIA_INDEXING } from "../../settings/serverSettings.js"
 import { getAlgoliaClient } from "./configureAlgolia.js"
@@ -30,9 +31,9 @@ const indexExplorerViewsToAlgolia = async () => {
     console.log(`Indexing complete`)
 }
 
-process.on("unhandledRejection", (e) => {
-    console.error(e)
+indexExplorerViewsToAlgolia().catch(async (e) => {
+    console.error("Error in indexExplorerViewsToAlgolia:", e)
+    Sentry.captureException(e)
+    await Sentry.close()
     process.exit(1)
 })
-
-void indexExplorerViewsToAlgolia()

--- a/baker/algolia/indexPagesToAlgolia.tsx
+++ b/baker/algolia/indexPagesToAlgolia.tsx
@@ -1,3 +1,8 @@
+// This should be imported as early as possible so the global error handler is
+// set up before any errors are thrown.
+import "../../serverUtils/instrument.js"
+
+import * as Sentry from "@sentry/node"
 import * as db from "../../db/db.js"
 import { ALGOLIA_INDEXING } from "../../settings/serverSettings.js"
 import { getAlgoliaClient } from "./configureAlgolia.js"
@@ -25,9 +30,9 @@ const indexPagesToAlgolia = async () => {
     process.exit(0)
 }
 
-process.on("unhandledRejection", (e) => {
-    console.error(e)
+indexPagesToAlgolia().catch(async (e) => {
+    console.error("Error in indexPagesToAlgolia:", e)
+    Sentry.captureException(e)
+    await Sentry.close()
     process.exit(1)
 })
-
-void indexPagesToAlgolia()


### PR DESCRIPTION
There's been an issue for a while with `indexExplorerViewsAndCharts` due to some missing metadata in the covid explorer that was crashing the indexing script, that wasn't getting caught due to the process terminating before the Sentry request could finish.

This PR fixes both issues.