### PR TITLE
✨ all-charts block updates

### DIFF
--- a/adminSiteServer/mockSiteRouter.ts
+++ b/adminSiteServer/mockSiteRouter.ts
@@ -527,6 +527,7 @@ async function getTombstoneAttachments(
         linkedDocuments,
         linkedIndicators: {},
         relatedCharts: [],
+        tags: [],
     }
 }
 

--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -254,6 +254,7 @@ export class SiteBaker {
             ...attachments,
             linkedCharts: {},
             relatedCharts: [],
+            tags: [],
         })
         const outPath = path.join(
             this.bakedSiteDir,

--- a/baker/siteRenderers.tsx
+++ b/baker/siteRenderers.tsx
@@ -414,6 +414,7 @@ ${dataInsights
                     homepageMetadata: get(post, "homepageMetadata", {}),
                     latestWorkLinks: get(post, "latestWorkLinks", []),
                     linkedChartViews: get(post, "linkedChartViews", {}),
+                    tags: get(post, "tags", []) ?? [],
                 }}
             >
                 <AtomArticleBlocks blocks={post.content.body} />

--- a/baker/siteRenderers.tsx
+++ b/baker/siteRenderers.tsx
@@ -414,7 +414,8 @@ ${dataInsights
                     homepageMetadata: get(post, "homepageMetadata", {}),
                     latestWorkLinks: get(post, "latestWorkLinks", []),
                     linkedChartViews: get(post, "linkedChartViews", {}),
-                    tags: get(post, "tags", []) ?? [],
+                    // lodash doesn't use fallback when value is null
+                    tags: post.tags ?? [],
                 }}
             >
                 <AtomArticleBlocks blocks={post.content.body} />

--- a/site/DataInsightsIndexPageContent.tsx
+++ b/site/DataInsightsIndexPageContent.tsx
@@ -114,6 +114,7 @@ export const DataInsightsIndexPageContent = (
                     linkedIndicators: {}, // not needed for data insights
                     relatedCharts: [], // not needed for the index page
                     latestDataInsights: [], // not needed for the index page
+                    tags: [], // not needed for the index page
                 }}
             >
                 <header className="data-insights-index-page__header grid grid-cols-12-full-width span-cols-14">

--- a/site/DataPageV2Content.tsx
+++ b/site/DataPageV2Content.tsx
@@ -93,6 +93,7 @@ export const DataPageV2Content = ({
                 linkedCharts: {},
                 linkedIndicators: {},
                 relatedCharts: [],
+                tags: [],
             }}
         >
             <DocumentContext.Provider value={{ isPreviewing }}>

--- a/site/gdocs/AttachmentsContext.tsx
+++ b/site/gdocs/AttachmentsContext.tsx
@@ -10,6 +10,7 @@ import {
     OwidGdocHomepageMetadata,
     DbEnrichedLatestWork,
     ChartViewInfo,
+    MinimalTag,
 } from "@ourworldindata/types"
 
 export type Attachments = {
@@ -24,6 +25,7 @@ export type Attachments = {
     homepageMetadata?: OwidGdocHomepageMetadata
     latestWorkLinks?: DbEnrichedLatestWork[]
     linkedChartViews?: Record<string, ChartViewInfo>
+    tags: MinimalTag[]
 }
 
 export const AttachmentsContext = createContext<Attachments>({
@@ -37,4 +39,5 @@ export const AttachmentsContext = createContext<Attachments>({
     homepageMetadata: {},
     latestWorkLinks: [],
     linkedChartViews: {},
+    tags: [],
 })

--- a/site/gdocs/OwidGdoc.tsx
+++ b/site/gdocs/OwidGdoc.tsx
@@ -94,6 +94,7 @@ export function OwidGdoc({
                 homepageMetadata: get(props, "homepageMetadata", {}),
                 latestWorkLinks: get(props, "latestWorkLinks", []),
                 linkedChartViews: get(props, "linkedChartViews", {}),
+                tags: get(props, "tags", []) ?? [],
             }}
         >
             <DocumentContext.Provider value={{ isPreviewing }}>

--- a/site/gdocs/OwidGdoc.tsx
+++ b/site/gdocs/OwidGdoc.tsx
@@ -94,7 +94,8 @@ export function OwidGdoc({
                 homepageMetadata: get(props, "homepageMetadata", {}),
                 latestWorkLinks: get(props, "latestWorkLinks", []),
                 linkedChartViews: get(props, "linkedChartViews", {}),
-                tags: get(props, "tags", []) ?? [],
+                // lodash doesn't use fallback when value is null
+                tags: props.tags ?? [],
             }}
         >
             <DocumentContext.Provider value={{ isPreviewing }}>

--- a/site/gdocs/components/AllCharts.scss
+++ b/site/gdocs/components/AllCharts.scss
@@ -1,6 +1,43 @@
 .article-block__all-charts {
     h1.h1-semibold {
-        margin-bottom: 40px;
+        margin: 0;
+        flex: 1 1 0%;
+        .deep-link {
+            // Any value smaller than -16 causes the h1 to wrap in Firefox
+            margin-left: -16px;
+        }
+    }
+
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 40px;
+
+    .owid-button {
+        line-height: 40px;
+        text-align: center;
+        padding: 0 24px;
+        height: 40px;
+        flex-shrink: 0;
+        align-self: start;
+        background-color: $vermillion;
+        svg {
+            margin-left: 8px;
+        }
+        &:hover {
+            background-color: $accent-vermillion;
+        }
+        @include sm-only {
+            order: 3;
+            margin-top: 24px;
+            width: 100%;
+        }
+    }
+
+    .related-charts {
+        flex-basis: 100%;
+        margin-top: 40px;
     }
 
     figure[data-grapher-src]:not(.grapherPreview) {

--- a/site/gdocs/components/AllCharts.scss
+++ b/site/gdocs/components/AllCharts.scss
@@ -2,10 +2,6 @@
     h1.h1-semibold {
         margin: 0;
         flex: 1 1 0%;
-        .deep-link {
-            // Any value smaller than -16 causes the h1 to wrap in Firefox
-            margin-left: -16px;
-        }
     }
 
     display: flex;
@@ -14,20 +10,8 @@
     align-items: center;
     margin-bottom: 40px;
 
-    .owid-button {
-        line-height: 40px;
-        text-align: center;
-        padding: 0 24px;
-        height: 40px;
-        flex-shrink: 0;
+    .owid-btn {
         align-self: start;
-        background-color: $vermillion;
-        svg {
-            margin-left: 8px;
-        }
-        &:hover {
-            background-color: $accent-vermillion;
-        }
         @include sm-only {
             order: 3;
             margin-top: 24px;

--- a/site/gdocs/components/AllCharts.tsx
+++ b/site/gdocs/components/AllCharts.tsx
@@ -1,4 +1,5 @@
 import { useContext } from "react"
+import urljoin from "url-join"
 import cx from "classnames"
 import {
     EnrichedBlockAllCharts,
@@ -9,6 +10,9 @@ import {
 } from "@ourworldindata/utils"
 import { AttachmentsContext } from "../AttachmentsContext.js"
 import { RelatedCharts } from "../../blocks/RelatedCharts.js"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import { faArrowRight } from "@fortawesome/free-solid-svg-icons"
+import { BAKED_BASE_URL } from "../../../settings/clientSettings.js"
 
 type AllChartsProps = EnrichedBlockAllCharts & {
     className?: string
@@ -42,8 +46,13 @@ function sortRelatedCharts(
 
 export function AllCharts(props: AllChartsProps) {
     const { heading, top, className } = props
-    const { relatedCharts } = useContext(AttachmentsContext)
+    const { relatedCharts, tags } = useContext(AttachmentsContext)
     const topSlugs = top.map((item) => Url.fromURL(item.url).slug as string)
+
+    const firstTag = tags[0]
+    const firstTagDataCatalogQueryString = firstTag
+        ? `?topics=${firstTag.name}`
+        : ""
 
     const sortedRelatedCharts = sortRelatedCharts(relatedCharts, topSlugs)
     return (
@@ -52,13 +61,24 @@ export function AllCharts(props: AllChartsProps) {
                 className="article-block__heading h1-semibold"
                 id={ALL_CHARTS_ID}
             >
-                <span>{heading}</span>
+                <span>
+                    {firstTag ? `Key Charts on ${firstTag.name}` : heading}
+                </span>
                 <a
                     className="deep-link"
                     aria-labelledby={ALL_CHARTS_ID}
                     href={`#${ALL_CHARTS_ID}`}
                 />
             </h1>
+            <a
+                className="owid-button"
+                href={`${urljoin(BAKED_BASE_URL, `/data`, firstTagDataCatalogQueryString)}`}
+            >
+                <span className="body-3-medium">
+                    See all charts on this topic
+                    <FontAwesomeIcon icon={faArrowRight} />
+                </span>
+            </a>
             <RelatedCharts
                 showKeyChartsOnly={true}
                 charts={sortedRelatedCharts}

--- a/site/gdocs/components/AllCharts.tsx
+++ b/site/gdocs/components/AllCharts.tsx
@@ -10,9 +10,8 @@ import {
 } from "@ourworldindata/utils"
 import { AttachmentsContext } from "../AttachmentsContext.js"
 import { RelatedCharts } from "../../blocks/RelatedCharts.js"
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
-import { faArrowRight } from "@fortawesome/free-solid-svg-icons"
 import { BAKED_BASE_URL } from "../../../settings/clientSettings.js"
+import { Button } from "@ourworldindata/components"
 
 type AllChartsProps = EnrichedBlockAllCharts & {
     className?: string
@@ -70,15 +69,11 @@ export function AllCharts(props: AllChartsProps) {
                     href={`#${ALL_CHARTS_ID}`}
                 />
             </h1>
-            <a
-                className="owid-button"
+            <Button
+                theme="solid-vermillion"
+                text="See all charts on this topic"
                 href={`${urljoin(BAKED_BASE_URL, `/data`, firstTagDataCatalogQueryString)}`}
-            >
-                <span className="body-3-medium">
-                    See all charts on this topic
-                    <FontAwesomeIcon icon={faArrowRight} />
-                </span>
-            </a>
+            />
             <RelatedCharts
                 showKeyChartsOnly={true}
                 charts={sortedRelatedCharts}

--- a/site/multiDim/MultiDimDataPageContent.tsx
+++ b/site/multiDim/MultiDimDataPageContent.tsx
@@ -354,6 +354,7 @@ export const MultiDimDataPageContent = ({
                 linkedCharts: {},
                 linkedIndicators: {},
                 relatedCharts: [],
+                tags: [],
             }}
         >
             <div className="DataPageContent MultiDimDataPageContent">


### PR DESCRIPTION
Resolves https://github.com/owid/owid-grapher/issues/4426

# Changes
- Adds a button to the data catalog on the all charts block
- Adds `tags` to the gdoc AttachmentsContext
- Uses a gdoc's first tag to automatically generate the heading of the all charts block


https://github.com/user-attachments/assets/a8d9e59e-8076-4c37-8bf0-13d40981a8df

