### PR TITLE
:hammer: Alter indexes for variables table

### DIFF
--- a/db/migration/1738574434234-AlterVariablesIndexes.ts
+++ b/db/migration/1738574434234-AlterVariablesIndexes.ts
@@ -2,7 +2,7 @@ import { MigrationInterface, QueryRunner } from "typeorm"
 
 export class AlterVariablesIndexes1738574434234 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
-        // Drop the unique index on shortName (and datasetId)
+        // Drop the unique index on (shortName ,datasetId)
         await queryRunner.query(`
             ALTER TABLE variables
             DROP INDEX unique_short_name_per_dataset;

--- a/db/migration/1738574434234-AlterVariablesIndexes.ts
+++ b/db/migration/1738574434234-AlterVariablesIndexes.ts
@@ -1,0 +1,43 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class AlterVariablesIndexes1738574434234 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        // Drop the unique index on shortName (and datasetId)
+        await queryRunner.query(`
+            ALTER TABLE variables
+            DROP INDEX unique_short_name_per_dataset;
+        `)
+
+        // Drop the unique index on (name, datasetId)
+        await queryRunner.query(`
+            ALTER TABLE variables
+            DROP INDEX variables_name_fk_dst_id_f7453c33_uniq;
+        `)
+
+        // Recreate a non-unique index on (name, datasetId)
+        await queryRunner.query(`
+            ALTER TABLE variables
+            ADD INDEX idx_name_dataset (name, datasetId);
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        // Drop the non-unique index on (name, datasetId)
+        await queryRunner.query(`
+            ALTER TABLE variables
+            DROP INDEX idx_name_dataset;
+        `)
+
+        // Recreate the unique index on (name, datasetId)
+        await queryRunner.query(`
+            ALTER TABLE variables
+            ADD UNIQUE INDEX variables_name_fk_dst_id_f7453c33_uniq (name, datasetId);
+        `)
+
+        // Recreate the unique index on (shortName, datasetId)
+        await queryRunner.query(`
+            ALTER TABLE variables
+            ADD UNIQUE INDEX unique_short_name_per_dataset (shortName, datasetId);
+        `)
+    }
+}


### PR DESCRIPTION
The `variables` table uses two indexes that make our ETL process more difficult. One is a unique index on `short_name`, and the other is a unique index on `title`. Both are now redundant since all variables can be addressed by `catalogPath`.  

These indexes become problematic when a dataset contains two tables with the same title (rare but harmless). Additionally, we recently encountered a [consistency issue](https://github.com/owid/etl/pull/3918) caused by hacky workarounds related to these indexes.  

Can these indexes be safely removed, or do we rely on them somewhere in owid-grapher?