### PR TITLE
Capture error instead of object in explorerViews

### DIFF
--- a/baker/algolia/utils/explorerViews.ts
+++ b/baker/algolia/utils/explorerViews.ts
@@ -486,10 +486,12 @@ async function enrichRecordWithIndicatorData(
 
     const indicatorInfo = indicatorMetadataDictionary[firstYIndicator]
     if (!indicatorInfo) {
-        await logErrorAndMaybeCaptureInSentry({
-            name: "ExplorerViewIndicatorMissing",
-            message: `Explorer with slug "${record.explorerSlug}" has a view with missing indicator metadata: ${record.viewQueryParams}.`,
-        })
+        await logErrorAndMaybeCaptureInSentry(
+            new Error(
+                `Explorer with slug "${record.explorerSlug}" has a view ` +
+                    `with missing indicator metadata: ${record.viewQueryParams}.`
+            )
+        )
         return
     }
 


### PR DESCRIPTION
Otherwise Sentry won't group the event correctly.

Follow up to #4511.