### PR TITLE
🎉 (admin) add copy to markdown button / TAS-866

### DIFF
--- a/adminSiteClient/ChartRow.tsx
+++ b/adminSiteClient/ChartRow.tsx
@@ -7,11 +7,18 @@ import { Timeago } from "./Forms.js"
 import { EditableTags } from "./EditableTags.js"
 import { AdminAppContext, AdminAppContextType } from "./AdminAppContext.js"
 import {
+    ADMIN_BASE_URL,
     BAKED_GRAPHER_URL,
     GRAPHER_DYNAMIC_THUMBNAIL_URL,
 } from "../settings/clientSettings.js"
 import { ChartListItem, showChartType } from "./ChartList.js"
-import { TaggableType, DbChartTagJoin } from "@ourworldindata/utils"
+import {
+    TaggableType,
+    DbChartTagJoin,
+    copyToClipboard,
+    excludeUndefined,
+} from "@ourworldindata/utils"
+import { Dropdown } from "antd"
 
 @observer
 export class ChartRow extends React.Component<{
@@ -45,6 +52,26 @@ export class ChartRow extends React.Component<{
             this.props
 
         const highlight = searchHighlight || lodash.identity
+
+        type CopyToMarkdownOptionKey = "admin-url" | "grapher-url"
+        const copyToMarkdownOptions: {
+            key: CopyToMarkdownOptionKey
+            label: string
+        }[] = excludeUndefined([
+            { key: "admin-url", label: "Admin URL" },
+            chart.isPublished
+                ? { key: "grapher-url", label: "Grapher URL" }
+                : undefined,
+        ])
+
+        const makeMarkdownLink = (key: "admin-url" | "grapher-url") => {
+            switch (key) {
+                case "admin-url":
+                    return `[${chart.title}](${ADMIN_BASE_URL}/admin/charts/${chart.id}/edit)`
+                case "grapher-url":
+                    return `[${chart.title}](${BAKED_GRAPHER_URL}/${chart.slug})`
+            }
+        }
 
         return (
             <tr>
@@ -121,6 +148,23 @@ export class ChartRow extends React.Component<{
                     >
                         Edit
                     </Link>
+                    <Dropdown.Button
+                        className="mt-1"
+                        onClick={() =>
+                            copyToClipboard(makeMarkdownLink("admin-url"))
+                        }
+                        menu={{
+                            items: copyToMarkdownOptions,
+                            onClick: (e) =>
+                                copyToClipboard(
+                                    makeMarkdownLink(
+                                        e.key as CopyToMarkdownOptionKey
+                                    )
+                                ),
+                        }}
+                    >
+                        Copy
+                    </Dropdown.Button>
                 </td>
                 <td>
                     <button

--- a/adminSiteClient/EditorTextTab.tsx
+++ b/adminSiteClient/EditorTextTab.tsx
@@ -2,7 +2,7 @@ import { faMinus, faPlus } from "@fortawesome/free-solid-svg-icons"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
 import { LogoOption, RelatedQuestionsConfig } from "@ourworldindata/types"
 import { getErrorMessageRelatedQuestionUrl } from "@ourworldindata/grapher"
-import { slugify } from "@ourworldindata/utils"
+import { copyToClipboard, slugify } from "@ourworldindata/utils"
 import { action, computed } from "mobx"
 import { observer } from "mobx-react"
 import { Component } from "react"
@@ -20,6 +20,11 @@ import {
 import { AbstractChartEditor } from "./AbstractChartEditor.js"
 import { ErrorMessages } from "./ChartEditorTypes.js"
 import { isChartViewEditorInstance } from "./ChartViewEditor.js"
+import { Button as AntdButton, Space } from "antd"
+import {
+    BAKED_GRAPHER_URL,
+    ADMIN_BASE_URL,
+} from "../settings/clientSettings.js"
 
 @observer
 export class EditorTextTab<
@@ -86,6 +91,14 @@ export class EditorTextTab<
             features.showTimeAnnotationInTitleToggle ||
             features.showChangeInPrefixToggle
         )
+    }
+
+    @computed get hasCopyAdminURLButton() {
+        return !!this.props.editor.grapher.id
+    }
+
+    @computed get hasCopyGrapherURLButton() {
+        return !!this.props.editor.grapher.isPublished
     }
 
     render() {
@@ -319,6 +332,35 @@ export class EditorTextTab<
                         helpText="Optional variant name for distinguishing charts with the same title"
                     />
                 </Section>
+                {(this.hasCopyAdminURLButton ||
+                    this.hasCopyGrapherURLButton) && (
+                    <Section name="Copy as Markdown">
+                        <Space direction="vertical" size="small">
+                            {this.hasCopyAdminURLButton && (
+                                <AntdButton
+                                    onClick={() =>
+                                        copyToClipboard(
+                                            `[${grapher.title}](${ADMIN_BASE_URL}/admin/charts/${grapher.id}/edit)`
+                                        )
+                                    }
+                                >
+                                    Copy admin URL
+                                </AntdButton>
+                            )}
+                            {this.hasCopyGrapherURLButton && (
+                                <AntdButton
+                                    onClick={() =>
+                                        copyToClipboard(
+                                            `[${grapher.title}](${BAKED_GRAPHER_URL}/${grapher.slug})`
+                                        )
+                                    }
+                                >
+                                    Copy Grapher URL
+                                </AntdButton>
+                            )}
+                        </Space>
+                    </Section>
+                )}
             </div>
         )
     }


### PR DESCRIPTION
Adds copy to markdown buttons for a chart in two places:
- On the charts index page in the admin
- On the 'Text' tab in the chart editor

<img width="1512" alt="Screenshot 2025-02-04 at 09 45 43" src="https://github.com/user-attachments/assets/e3377afc-7313-4b3b-a76a-58ec4493c863" />
<img width="1512" alt="Screenshot 2025-02-04 at 09 45 56" src="https://github.com/user-attachments/assets/42e9d50a-d004-494f-8686-cda7e4962f11" />
