### PR TITLE
✨ prevent site-tools from obscuring content of page

### DIFF
--- a/site/SiteFooter.tsx
+++ b/site/SiteFooter.tsx
@@ -5,6 +5,7 @@ import { viteAssetsForSite } from "./viteUtils.js"
 import { ScriptLoadErrorDetector } from "./NoJSDetector.js"
 import { ABOUT_LINKS, RSS_FEEDS, SOCIALS } from "./SiteConstants.js"
 import { Button } from "@ourworldindata/components"
+import { SITE_TOOLS_CLASS } from "./SiteTools.js"
 
 interface SiteFooterProps {
     hideDonate?: boolean
@@ -181,7 +182,7 @@ export const SiteFooter = (props: SiteFooterProps) => (
                 </div>
             </div>
 
-            <div className="site-tools" />
+            <div className={SITE_TOOLS_CLASS} />
             {viteAssetsForSite().forFooter}
             <ScriptLoadErrorDetector />
             <script

--- a/site/css/site-tools.scss
+++ b/site/css/site-tools.scss
@@ -1,6 +1,16 @@
 .site-tools {
     display: none;
 }
+
+@keyframes get-out-da-way {
+    0% {
+        transform: translateY(0);
+    }
+    100% {
+        transform: translateY(48px);
+    }
+}
+
 @include md-up {
     .site-tools {
         position: fixed;
@@ -9,6 +19,9 @@
         right: $vertical-spacing;
         bottom: $vertical-spacing;
         border: none;
+        &:has(.hide) {
+            animation: get-out-da-way 0.3s forwards;
+        }
 
         .hide-wrapper {
             display: flex;


### PR DESCRIPTION
Fixes the issue where the `site-tools` container was obscuring content even when its contents was hidden.

If we're not okay with 94% browser support, I'll rewrite this with JS but it's slightly annoying as I'll have to use a ref and layout effect to apply the transformation to `SiteTools` parent (the div container)


https://github.com/user-attachments/assets/a8fb3079-3419-43a9-b020-51c9c5722e83

