### PR TITLE
Fix KeyIndicator not showing grapher with a redirect

### DIFF
--- a/site/gdocs/components/KeyIndicator.tsx
+++ b/site/gdocs/components/KeyIndicator.tsx
@@ -53,7 +53,7 @@ export default function KeyIndicator({
             <Chart
                 className="key-indicator-chart col-start-5 span-cols-8 span-sm-cols-12 margin-0"
                 d={{
-                    url: linkedChart.resolvedUrl,
+                    url: d.datapageUrl, // The URL is resolved in the component.
                     type: "chart",
                     parseErrors: [],
                 }}


### PR DESCRIPTION
We need to pass the unresolved URL to Chart, where we resolve it with useLinkedChart again. If we pass the already resolved URL for a chart that was redirected, it won't be found in the attachments.

See [Slack discussion](https://owid.slack.com/archives/C46U9LXRR/p1738749662622129).