### PR TITLE
✨ hide origin url for square exports / TAS-876

### DIFF
--- a/adminSiteClient/EditorExportTab.tsx
+++ b/adminSiteClient/EditorExportTab.tsx
@@ -302,15 +302,16 @@ export class EditorExportTab<
                             }
                         />
                     )}
-                    {this.originalGrapher.originUrl && (
-                        <Toggle
-                            label="Origin URL"
-                            value={!this.settings.hideOriginUrl}
-                            onValue={(value) =>
-                                (this.settings.hideOriginUrl = !value)
-                            }
-                        />
-                    )}
+                    {this.originalGrapher.originUrl &&
+                        !this.grapher.isStaticAndSmall && (
+                            <Toggle
+                                label="Origin URL"
+                                value={!this.settings.hideOriginUrl}
+                                onValue={(value) =>
+                                    (this.settings.hideOriginUrl = !value)
+                                }
+                            />
+                        )}
                     {this.originalGrapher.detailsOrderedByReference.length >
                         0 && (
                         <Toggle

--- a/packages/@ourworldindata/grapher/src/footer/Footer.tsx
+++ b/packages/@ourworldindata/grapher/src/footer/Footer.tsx
@@ -91,6 +91,10 @@ export class Footer<
         return this.manager.fontSize ?? BASE_FONT_SIZE
     }
 
+    @computed protected get hideOriginUrl(): boolean {
+        return !!this.manager.hideOriginUrl
+    }
+
     @computed protected get sourcesLine(): string {
         return this.manager.sourcesLine?.replace(/\r\n|\n|\r/g, "") ?? ""
     }
@@ -158,7 +162,7 @@ export class Footer<
             actionButtons,
         } = this
 
-        if (this.manager.hideOriginUrl) return undefined
+        if (this.hideOriginUrl) return undefined
 
         if (!correctedUrlText) return undefined
 
@@ -640,6 +644,10 @@ export class StaticFooter extends Footer<StaticFooterProps> {
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     componentWillUnmount(): void {}
 
+    @computed protected get hideOriginUrl(): boolean {
+        return !!this.manager.hideOriginUrl || !!this.manager.isStaticAndSmall
+    }
+
     @computed private get textColor(): string {
         return GRAPHER_LIGHT_TEXT
     }
@@ -654,7 +662,7 @@ export class StaticFooter extends Footer<StaticFooterProps> {
     @computed protected get finalUrlText(): string | undefined {
         const { correctedUrlText, licenseText, fontSize, maxWidth } = this
 
-        if (this.manager.hideOriginUrl) return undefined
+        if (this.hideOriginUrl) return undefined
 
         if (!correctedUrlText) return undefined
 


### PR DESCRIPTION
Hide origin URL for square format exports. 


<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #4529 👈 
- <kbd>&nbsp;2&nbsp;</kbd> #4522 
- <kbd>&nbsp;1&nbsp;</kbd> #4427 
<!-- GitButler Footer Boundary Bottom -->

