### PR TITLE
🔨 remove background from grapher exports / TAS-875

### DIFF
--- a/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
@@ -580,14 +580,6 @@ export class StaticCaptionedChart extends CaptionedChart {
             >
                 {this.fonts}
                 {this.patterns}
-                {!this.manager.isExportingForSocialMedia && (
-                    <rect
-                        className="background-fill"
-                        fill={this.backgroundColor}
-                        width={width}
-                        height={height}
-                    />
-                )}
                 <StaticHeader
                     manager={manager}
                     maxWidth={maxWidth}


### PR DESCRIPTION
Removes the background rect from grapher exports.

Notes from the [Slack conversation](https://owid.slack.com/archives/CQQUA2C2U/p1738779580648569) where Marcel shared his thoughts:
- The rect was introduced to aid Wikipedians, because Wikipedia back then didn't respect any other background properties we had and instead put the chart on a transparent background. see https://github.com/owid/owid-grapher/issues/1993 
- Not a blocker because our SVGs can currently not be uploaded to Wikimedia Commons because the <style> block for loading fonts is considered unsafe