### PR TITLE
✨ (slope) improve svg structure for figma / TAS-878

### DIFF
--- a/packages/@ourworldindata/components/src/Halo/Halo.tsx
+++ b/packages/@ourworldindata/components/src/Halo/Halo.tsx
@@ -1,6 +1,14 @@
 import * as React from "react"
 import { Color } from "@ourworldindata/types"
 
+interface HaloProps {
+    id: string
+    children: React.ReactElement
+    show?: boolean
+    outlineColor?: Color
+    style?: React.CSSProperties
+}
+
 const defaultHaloStyle: React.CSSProperties = {
     fill: "#fff",
     stroke: "#fff",
@@ -10,13 +18,7 @@ const defaultHaloStyle: React.CSSProperties = {
     userSelect: "none",
 }
 
-export function Halo(props: {
-    id: React.Key
-    children: React.ReactElement
-    show?: boolean
-    outlineColor?: Color
-    style?: React.CSSProperties
-}): React.ReactElement {
+export function Halo(props: HaloProps): React.ReactElement {
     const show = props.show ?? true
     if (!show) return props.children
 
@@ -26,6 +28,7 @@ export function Halo(props: {
         stroke: props.outlineColor ?? defaultHaloStyle.stroke,
     }
     const halo = React.cloneElement(props.children, {
+        id: props.id,
         style: {
             ...defaultStyle,
             ...props.style,

--- a/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.tsx
+++ b/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.tsx
@@ -135,7 +135,10 @@ class LineLabels extends React.Component<{
 
                     return (
                         <Halo
-                            id={series.seriesName}
+                            id={makeIdForHumanConsumption(
+                                "outline",
+                                series.seriesName
+                            )}
                             key={getSeriesKey(series, index)}
                             show={this.showTextOutline}
                             outlineColor={this.textOutlineColor}
@@ -143,7 +146,13 @@ class LineLabels extends React.Component<{
                             {series.textWrapForRendering.renderSVG(
                                 labelText.x,
                                 labelText.y,
-                                { textProps }
+                                {
+                                    textProps,
+                                    id: makeIdForHumanConsumption(
+                                        "label",
+                                        series.seriesName
+                                    ),
+                                }
                             )}
                         </Halo>
                     )

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
@@ -1329,7 +1329,7 @@ interface SlopeProps {
 
 function Slope({
     series,
-    dotRadius = 2.5,
+    dotRadius = 3.5,
     strokeWidth = 2,
     outlineWidth = 0.5,
     outlineStroke = "#fff",
@@ -1347,17 +1347,19 @@ function Slope({
         hover.background || focus.background ? 0.66 * strokeWidth : strokeWidth
 
     return (
-        <g id={makeIdForHumanConsumption(seriesName)} className="slope">
+        <>
             {showOutline && (
                 <LineWithDots
+                    id={makeIdForHumanConsumption("outline", seriesName)}
                     startPoint={startPoint}
                     endPoint={endPoint}
-                    radius={dotRadius}
+                    radius={dotRadius + 2 * outlineWidth}
                     color={outlineStroke}
                     lineWidth={lineWidth + 2 * outlineWidth}
                 />
             )}
             <LineWithDots
+                id={makeIdForHumanConsumption("slope", seriesName)}
                 startPoint={startPoint}
                 endPoint={endPoint}
                 radius={dotRadius}
@@ -1365,14 +1367,12 @@ function Slope({
                 lineWidth={lineWidth}
                 opacity={opacity}
             />
-        </g>
+        </>
     )
 }
 
-/**
- * Line with two dots at the ends, drawn as a single path element.
- */
 function LineWithDots({
+    id,
     startPoint,
     endPoint,
     radius,
@@ -1380,6 +1380,7 @@ function LineWithDots({
     lineWidth = 2,
     opacity = 1,
 }: {
+    id?: string
     startPoint: PointVector
     endPoint: PointVector
     radius: number
@@ -1387,24 +1388,32 @@ function LineWithDots({
     lineWidth?: number
     opacity?: number
 }): React.ReactElement {
-    const startDotPath = makeCirclePath(startPoint.x, startPoint.y, radius)
-    const endDotPath = makeCirclePath(endPoint.x, endPoint.y, radius)
-
-    const linePath = makeLinePath(
-        startPoint.x,
-        startPoint.y,
-        endPoint.x,
-        endPoint.y
-    )
-
     return (
-        <path
-            d={`${startDotPath} ${endDotPath} ${linePath}`}
-            fill={color}
-            stroke={color}
-            strokeWidth={lineWidth.toFixed(1)}
-            opacity={opacity}
-        />
+        <g id={id} opacity={opacity} className="slope">
+            <circle
+                id={makeIdForHumanConsumption("start-point")}
+                cx={startPoint.x}
+                cy={startPoint.y}
+                r={radius}
+                fill={color}
+            />
+            <circle
+                id={makeIdForHumanConsumption("end-point")}
+                cx={endPoint.x}
+                cy={endPoint.y}
+                r={radius}
+                fill={color}
+            />
+            <line
+                id={makeIdForHumanConsumption("line")}
+                x1={startPoint.x}
+                y1={startPoint.y}
+                x2={endPoint.x}
+                y2={endPoint.y}
+                stroke={color}
+                strokeWidth={lineWidth.toFixed(1)}
+            />
+        </g>
     )
 }
 
@@ -1472,14 +1481,4 @@ function MarkX({
             </text>
         </>
     )
-}
-
-const makeCirclePath = (centerX: number, centerY: number, radius: number) => {
-    const topX = centerX
-    const topY = centerY - radius
-    return `M ${topX},${topY} A ${radius},${radius} 0 1,1 ${topX - 0.0001},${topY}`
-}
-
-const makeLinePath = (x1: number, y1: number, x2: number, y2: number) => {
-    return `M ${x1},${y1} L ${x2},${y2}`
 }


### PR DESCRIPTION
Improves the SVG structure of slope charts for use in Figma.

The line labels are messed up when imported into Figma because Figma doesn't display `<tspan />` elements correctly and `MarkdownTextWrap` relies on them for rendering. I filed a bug report with Figma and hope this gets fixed on their site.

Changes:
- Figma users prefer the slope to be made up individual elements (two dots and a line) because it's then easier to make changes to those elements, like resizing the dots or increasing the line thickness
- I also added more specific element names

<!-- GitButler Footer Boundary Top -->
---
This is **part 4 of 7 in a stack** made with GitButler:
- <kbd>&nbsp;7&nbsp;</kbd> #4539 
- <kbd>&nbsp;6&nbsp;</kbd> #4538 
- <kbd>&nbsp;5&nbsp;</kbd> #4537 
- <kbd>&nbsp;4&nbsp;</kbd> #4531 👈 
- <kbd>&nbsp;3&nbsp;</kbd> #4529 
- <kbd>&nbsp;2&nbsp;</kbd> #4522 
- <kbd>&nbsp;1&nbsp;</kbd> #4427 
<!-- GitButler Footer Boundary Bottom -->

