### PR TITLE
feat(admin): bring feature parity to all uses of `ChartList` component

### DIFF
--- a/adminSiteClient/ChartIndexPage.tsx
+++ b/adminSiteClient/ChartIndexPage.tsx
@@ -1,126 +1,30 @@
 import { Component } from "react"
 import { observer } from "mobx-react"
-import { observable, computed, action, runInAction } from "mobx"
+import { observable, action, runInAction } from "mobx"
 
-import { TextField } from "./Forms.js"
 import { AdminLayout } from "./AdminLayout.js"
-import { ChartList, ChartListItem, SortConfig } from "./ChartList.js"
+import { ChartList, ChartListItem } from "./ChartList.js"
 import { AdminAppContext, AdminAppContextType } from "./AdminAppContext.js"
-import {
-    buildSearchWordsFromSearchString,
-    filterFunctionForSearchWords,
-    highlightFunctionForSearchWords,
-    SearchWord,
-} from "../adminShared/search.js"
-import { sortNumeric, SortOrder } from "@ourworldindata/utils"
 
 @observer
 export class ChartIndexPage extends Component {
     static contextType = AdminAppContext
     context!: AdminAppContextType
 
-    @observable searchInput?: string
-    @observable maxVisibleCharts = 50
     @observable charts: ChartListItem[] = []
-    @observable sortBy: "pageviewsPerDay" | null = null
-    @observable sortConfig: SortConfig = null
-
-    @computed get searchWords(): SearchWord[] {
-        const { searchInput } = this
-        return buildSearchWordsFromSearchString(searchInput)
-    }
-    @computed get numTotalCharts() {
-        return this.charts.length
-    }
-
-    @computed get allChartsToShow(): ChartListItem[] {
-        const { searchWords, charts, sortConfig } = this
-        let filtered = charts
-        if (searchWords.length > 0) {
-            const filterFn = filterFunctionForSearchWords(
-                searchWords,
-                (chart: ChartListItem) => [
-                    chart.title,
-                    chart.variantName,
-                    chart.internalNotes,
-                    chart.publishedBy,
-                    chart.lastEditedBy,
-                    `${chart.id}`,
-                    chart.slug,
-                    chart.hasChartTab !== false ? chart.type : undefined,
-                    chart.hasMapTab ? "Map" : undefined,
-                    ...chart.tags.map((tag) => tag.name),
-                ]
-            )
-            filtered = charts.filter(filterFn)
-        }
-
-        // Apply sorting if needed
-        if (sortConfig?.field === "pageviewsPerDay") {
-            return sortNumeric(
-                [...filtered],
-                (chart) => chart.pageviewsPerDay,
-                sortConfig.direction === "asc" ? SortOrder.asc : SortOrder.desc
-            )
-        }
-
-        return filtered
-    }
-
-    @computed get chartsToShow(): ChartListItem[] {
-        return this.allChartsToShow.slice(0, this.maxVisibleCharts)
-    }
-
-    @action.bound onSearchInput(input: string) {
-        this.searchInput = input
-        this.setSearchInputInUrl(input)
-    }
-
-    @action.bound onShowMore() {
-        this.maxVisibleCharts += 100
-    }
-
-    @action.bound onSort(sortConfig: SortConfig) {
-        this.sortConfig = sortConfig
-    }
 
     render() {
-        const { chartsToShow, searchInput, numTotalCharts, sortConfig } = this
-
-        const highlight = highlightFunctionForSearchWords(this.searchWords)
+        const { charts } = this
 
         return (
             <AdminLayout title="Charts">
                 <main className="ChartIndexPage">
-                    <div className="topRow">
-                        <span>
-                            Showing {chartsToShow.length} of {numTotalCharts}{" "}
-                            charts
-                        </span>
-                        <TextField
-                            placeholder="Search all charts..."
-                            value={searchInput}
-                            onValue={this.onSearchInput}
-                            autofocus
-                        />
-                    </div>
                     <ChartList
-                        charts={chartsToShow}
-                        searchHighlight={highlight}
+                        charts={charts}
                         onDelete={action((c: ChartListItem) =>
                             this.charts.splice(this.charts.indexOf(c), 1)
                         )}
-                        onSort={this.onSort}
-                        sortConfig={sortConfig}
                     />
-                    {!searchInput && (
-                        <button
-                            className="btn btn-secondary"
-                            onClick={this.onShowMore}
-                        >
-                            Show more charts...
-                        </button>
-                    )}
                 </main>
             </AdminLayout>
         )
@@ -135,23 +39,6 @@ export class ChartIndexPage extends Component {
     }
 
     componentDidMount() {
-        this.searchInput = this.getSearchInputFromUrl()
         void this.getData()
-    }
-
-    getSearchInputFromUrl(): string {
-        const params = new URLSearchParams(window.location.search)
-        return params.get("search") || ""
-    }
-
-    setSearchInputInUrl(searchInput: string) {
-        const params = new URLSearchParams(window.location.search)
-        if (searchInput) {
-            params.set("search", searchInput)
-        } else {
-            params.delete("search")
-        }
-        const newUrl = `${window.location.pathname}?${params.toString()}`
-        window.history.replaceState({}, "", newUrl)
     }
 }

--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -763,8 +763,7 @@ main:not(.ChartEditorPage):not(.GdocsEditPage) {
     margin-top: 6px;
 }
 
-.ChartIndexPage,
-.UsersIndexPage {
+.ChartList {
     .topRow {
         display: flex;
         align-items: center;

--- a/adminSiteServer/apiRoutes/charts.ts
+++ b/adminSiteServer/apiRoutes/charts.ts
@@ -511,7 +511,7 @@ export async function getChartsJson(
             FROM charts
             JOIN chart_configs ON chart_configs.id = charts.configId
             JOIN users lastEditedByUser ON lastEditedByUser.id = charts.lastEditedByUserId
-            LEFT JOIN analytics_pageviews on (analytics_pageviews.url = CONCAT("https://ourworldindata.org/grapher/", chart_configs.slug)  AND chart_configs.full ->> '$.isPublished' = "true" )
+            LEFT JOIN analytics_pageviews on (analytics_pageviews.url = CONCAT("https://ourworldindata.org/grapher/", chart_configs.slug) AND chart_configs.full ->> '$.isPublished' = "true" )
             LEFT JOIN users publishedByUser ON publishedByUser.id = charts.publishedByUserId
             ORDER BY charts.lastEditedAt DESC LIMIT ?
         `,

--- a/adminSiteServer/apiRoutes/variables.ts
+++ b/adminSiteServer/apiRoutes/variables.ts
@@ -243,14 +243,16 @@ export async function getVariablesVariableIdJson(
     >(
         trx,
         `-- sql
-                SELECT ${oldChartFieldList}, charts.isInheritanceEnabled, chart_configs.full AS config
+                SELECT ${oldChartFieldList}, charts.isInheritanceEnabled, chart_configs.full AS config,
+                    round(views_365d / 365, 1) as pageviewsPerDay
                 FROM charts
                 JOIN chart_configs ON chart_configs.id = charts.configId
                 JOIN users lastEditedByUser ON lastEditedByUser.id = charts.lastEditedByUserId
                 LEFT JOIN users publishedByUser ON publishedByUser.id = charts.publishedByUserId
+                LEFT JOIN analytics_pageviews on (analytics_pageviews.url = CONCAT("https://ourworldindata.org/grapher/", chart_configs.slug) AND chart_configs.full ->> '$.isPublished' = "true" )
                 JOIN chart_dimensions cd ON cd.chartId = charts.id
                 WHERE cd.variableId = ?
-                GROUP BY charts.id
+                GROUP BY charts.id, views_365d
             `,
         [variableId]
     )


### PR DESCRIPTION
Fixes #4521 by including `pageviewsPerDay` in the 3 relevant queries for dataset, variable, and tag pages.

Also improves the 3 uses of `ChartList` (in dataset, variable, and tag pages) insofar that one can now also search these lists.

The split between `ChartIndexPage` and `ChartList` is now as follows: ChartIndexPage only needs to take care of data loading, and then passes a complete, unfiltered list of charts to `<ChartList>`.
It then takes care of sorting, filtering, basic pagination (via "Show more charts"), and handling the `?chartSearch=` query param.