### PR TITLE
Migrate to external ETL regions dataset

### DIFF
--- a/devTools/regionsUpdater/update.ts
+++ b/devTools/regionsUpdater/update.ts
@@ -13,7 +13,7 @@ import _ from "lodash"
 
 const ETL_REGIONS_URL =
         process.env.ETL_REGIONS_URL ||
-        "https://catalog.ourworldindata.org/grapher/regions/latest/regions/regions.csv",
+        "https://catalog.ourworldindata.org/external/owid_grapher/latest/regions/regions.csv",
     GEO_JSON_URL =
         "https://raw.githubusercontent.com/alexabruck/worldmap-sensitive/master/dist/world.geo.json",
     GRAPHER_ROOT = __dirname.replace(/\/(itsJustJavascript\/)?devTools.*/, ""),


### PR DESCRIPTION
We want to stop generating `grapher/regions/latest/regions` dataset, which is meant for our Grapher database and generates this dataset in Admin which no one uses: [Regions data (OWID, 2023)](https://admin.owid.io/admin/datasets/6334).

Instead, we should rely on step `data://external/owid_grapher/latest/regions`, which should just be equivalent for use-cases like this one in `owid-grapher`.

Would the change in this PR suffice? Are there other instances where we rely on this dataset?