### PR TITLE
✨ (facets) improve svg structure for figma

### DIFF
--- a/packages/@ourworldindata/grapher/src/facetChart/FacetChart.tsx
+++ b/packages/@ourworldindata/grapher/src/facetChart/FacetChart.tsx
@@ -18,6 +18,7 @@ import {
     HorizontalAlign,
     Color,
     uniq,
+    makeIdForHumanConsumption,
 } from "@ourworldindata/utils"
 import { shortenForTargetWidth } from "@ourworldindata/components"
 import { action, computed, observable } from "mobx"
@@ -141,6 +142,10 @@ export class FacetChart
 
     @computed private get chartTypeName(): GrapherChartType {
         return this.props.chartTypeName ?? GRAPHER_CHART_TYPES.LineChart
+    }
+
+    @computed get isStatic(): boolean {
+        return !!this.manager.isStatic
     }
 
     @computed get failMessage(): string {
@@ -267,6 +272,7 @@ export class FacetChart
             missingDataStrategy,
             backgroundColor,
             focusArray,
+            isStatic,
         } = manager
 
         // Use compact labels, e.g. 50k instead of 50,000.
@@ -324,6 +330,7 @@ export class FacetChart
                 backgroundColor,
                 hideNoDataSection,
                 focusArray,
+                isStatic,
                 ...series.manager,
                 xAxisConfig: {
                     ...globalXAxisConfig,
@@ -896,10 +903,12 @@ export class FacetChart
                                 {shortenedLabel}
                                 <title>{seriesName}</title>
                             </text>
-                            <ChartClass
-                                bounds={bounds}
-                                manager={facetChart.manager}
-                            />
+                            <g id={makeIdForHumanConsumption(seriesName)}>
+                                <ChartClass
+                                    bounds={bounds}
+                                    manager={facetChart.manager}
+                                />
+                            </g>
                         </React.Fragment>
                     )
                 })}


### PR DESCRIPTION
Passing `isStatic` to the chart instances makes it so that they render their static version when exported to a SVG.

<!-- GitButler Footer Boundary Top -->
---
This is **part 7 of 7 in a stack** made with GitButler:
- <kbd>&nbsp;7&nbsp;</kbd> #4539 👈 
- <kbd>&nbsp;6&nbsp;</kbd> #4538 
- <kbd>&nbsp;5&nbsp;</kbd> #4537 
- <kbd>&nbsp;4&nbsp;</kbd> #4531 
- <kbd>&nbsp;3&nbsp;</kbd> #4529 
- <kbd>&nbsp;2&nbsp;</kbd> #4522 
- <kbd>&nbsp;1&nbsp;</kbd> #4427 
<!-- GitButler Footer Boundary Bottom -->

