### PR TITLE
fix(admin-api): fix authenticated SQL injection & remove unnecessary WP codepath

### DIFF
--- a/adminSiteServer/apiRoutes/misc.ts
+++ b/adminSiteServer/apiRoutes/misc.ts
@@ -31,10 +31,11 @@ export async function fetchAllWork(
         `-- sql
             SELECT id, publishedAt
             FROM posts_gdocs
-            WHERE JSON_CONTAINS(content->'$.authors', '"${author}"')
+            WHERE JSON_CONTAINS(content->'$.authors', ?)
             AND type NOT IN ("data-insight", "fragment")
             AND published = 1
-    `
+    `,
+        [`"${author}"`]
     )
 
     // type: page
@@ -51,14 +52,15 @@ export async function fetchAllWork(
             wpApiSnapshot->>"$.date" as publishedAt
         FROM posts p
         WHERE wpApiSnapshot->>"$.content" LIKE '%topic-page%'
-        AND JSON_CONTAINS(wpApiSnapshot->'$.authors_name', '"${author}"')
+        AND JSON_CONTAINS(wpApiSnapshot->'$.authors_name', ?)
         AND wpApiSnapshot->>"$.status" = 'publish'
         AND NOT EXISTS (
             SELECT 1 FROM posts_gdocs pg
             WHERE pg.slug = p.slug
             AND pg.content->>'$.type' LIKE '%topic-page'
         )
-        `
+        `,
+        [`"${author}"`]
     )
 
     const isWordpressPage = (


### PR DESCRIPTION
Fixes https://github.com/owid/owid-grapher/security/advisories/GHSA-28j4-g4cq-9r32 - an SQL injection that can only be used when authenticated in the admin.
This is thus not super important to fix, but it's also super easy to fix, so let's just do it.


While working on this, I noticed that the whole WP codepath of this handler is not required any more - there are no published WP topic pages at this point. So I got rid of it and simplified the function quite a bit.