### PR TITLE
fix: caching of country profile landing

### DIFF
--- a/baker/siteRenderers.tsx
+++ b/baker/siteRenderers.tsx
@@ -468,7 +468,7 @@ const getCountryProfilePost = memoize(
 
 // todo: we used to flush cache of this thing.
 const getCountryProfileLandingPost = memoize(
-    async (knex: KnexReadonlyTransaction, profileSpec: CountryProfileSpec) => {
+    async (profileSpec: CountryProfileSpec, knex: KnexReadonlyTransaction) => {
         return getFullPostBySlugFromSnapshot(knex, profileSpec.landingPageSlug)
     }
 )
@@ -485,7 +485,7 @@ export const renderCountryProfile = async (
 
     const formattedCountryProfile = formatCountryProfile(formatted, country)
 
-    const landing = await getCountryProfileLandingPost(knex, profileSpec)
+    const landing = await getCountryProfileLandingPost(profileSpec, knex)
 
     const overrides: PageOverrides = {
         pageTitle: `${country.name}: ${profileSpec.pageTitle} Country Profile`,


### PR DESCRIPTION
<img width="1440" alt="Screenshot 2025-02-10 at 20 18 10" src="https://github.com/user-attachments/assets/6e72eaa0-bf6e-49f2-badc-0eee09156a6b" />

Citation uses the same landing page for all three country profiles (meaning 2 are wrong):
- https://ourworldindata.org/coronavirus/country/united-states#citation
- https://ourworldindata.org/co2/country/united-states#citation
- https://ourworldindata.org/energy/country/united-states#citation

> By default, the first argument provided to the memoized function is coerced to a string and used as the cache key.

Passing the same `knex` connection as the first argument meant that the function would only be called once, and would return the same landing for all country profiles.