### PR TITLE
✨ improve logging information for datapage topic tag resolution errors

### DIFF
--- a/baker/DatapageHelpers.ts
+++ b/baker/DatapageHelpers.ts
@@ -189,8 +189,9 @@ export const resolveFaqsForVariable = (
 
 export const getPrimaryTopic = async (
     knex: KnexReadonlyTransaction,
-    firstTopicTag: string | undefined
+    datapageData: DataPageDataV2
 ) => {
+    const firstTopicTag = datapageData.topicTagsLinks?.[0]
     if (!firstTopicTag) return undefined
 
     let topicSlug: string
@@ -199,7 +200,7 @@ export const getPrimaryTopic = async (
     } catch {
         await logErrorAndMaybeCaptureInSentry(
             new Error(
-                `Data page is using "${firstTopicTag}" as its primary tag, which we are unable to resolve to a tag in the grapher DB`
+                `Data page with slug "${datapageData.chartConfig.slug}" is using "${firstTopicTag}" as its primary tag, which we are unable to resolve to a tag in the grapher DB`
             )
         )
         return undefined

--- a/baker/GrapherBaker.tsx
+++ b/baker/GrapherBaker.tsx
@@ -204,8 +204,7 @@ export async function renderDataPageV2(
         grapher ?? {}
     )
 
-    const firstTopicTag = datapageData.topicTagsLinks?.[0]
-    datapageData.primaryTopic = await getPrimaryTopic(knex, firstTopicTag)
+    datapageData.primaryTopic = await getPrimaryTopic(knex, datapageData)
 
     // Get the charts this variable is being used in (aka "related charts")
     // and exclude the current chart to avoid duplicates


### PR DESCRIPTION
This will make it easier to work out which charts are causing issues during baking.
