### PR TITLE
🐛 fix double-logging data catalog searches

### DIFF
--- a/site/DataCatalog/DataCatalog.tsx
+++ b/site/DataCatalog/DataCatalog.tsx
@@ -855,18 +855,25 @@ export const DataCatalog = ({
     const currentResults = cache[cacheKey].get(stateAsUrl)
 
     useEffect(() => {
+        // Reconstructing state from the `stateAsUrl` serialization to avoid a `state` dependency in this effect,
+        // which would cause it to run on every state change (even no-ops)
+        const url = Url.fromURL(stateAsUrl)
+        const state = urlToDataCatalogState(url)
+        analytics.logDataCatalogSearch(state)
+    }, [stateAsUrl])
+
+    useEffect(() => {
         async function fetchData() {
             const results = shouldShowRibbons
                 ? await queryRibbons(searchClient, state, tagGraph)
                 : await querySearch(searchClient, state)
-            setCache((cache) => ({
-                ...cache,
-                [cacheKey]: cache[cacheKey].set(stateAsUrl, results as any),
+            setCache((prevCache) => ({
+                ...prevCache,
+                [cacheKey]: prevCache[cacheKey].set(stateAsUrl, results as any),
             }))
         }
 
         syncDataCatalogURL(stateAsUrl)
-        analytics.logDataCatalogSearch(state)
         if (cache[cacheKey].has(stateAsUrl)) return
 
         setIsLoading(true)


### PR DESCRIPTION
Fixes https://github.com/owid/owid-grapher/issues/4316

## Context
The data catalog was logging searches to google analytics twice. You can see this on prod by going to https://ourworldindata.org/data, entering a query, and then opening the dev console and typing `dataLayer.at(-1)` and `dataLayer.at(-2)`

## Problem
The data catalog ran all of its business logic through a single `useEffect`, which meant it called anytime any of its dependencies changed. Analytics was one of the last things I added and I didn't stop to think that this callback would fire anytime any of the dependencies updated, including updates to the cache or even no-op calls to update the state.

## The fix
Extracts the analytics logic into an independent effect, which only runs when `stateAsUrl` changes (which always corresponds to a search running, even when the results are restored from the cache)

## How to test
Add a `console.log` to [`logDataCatalogSearch`](https://github.com/owid/owid-grapher/blob/65c42cbfc1f11893afbbae5f2416ccdd5be18c36/site/SiteAnalytics.ts#L96) and run some searches locally, noting that a log call only happens when a new query is run.
```ts
logDataCatalogSearch(state: DataCatalogState) {
        console.log("logging search", state);
        this.logToGA({
            event: EventCategory.DataCatalogSearch,
            eventAction: "search",
            eventContext: JSON.stringify({
                ...state,
                topics: Array.from(state.topics),
                selectedCountryNames: Array.from(state.selectedCountryNames),
            }),
        })
    }
```