### PR TITLE
Remove MultiDimDataPage feature flag

### DIFF
--- a/adminSiteServer/apiRoutes/mdims.ts
+++ b/adminSiteServer/apiRoutes/mdims.ts
@@ -9,10 +9,6 @@ import {
 } from "../../db/model/MultiDimDataPage.js"
 import { expectInt, isValidSlug } from "../../serverUtils/serverUtil.js"
 import {
-    FEATURE_FLAGS,
-    FeatureFlagFeature,
-} from "../../settings/clientSettings.js"
-import {
     upsertMultiDimConfig,
     setMultiDimPublished,
     setMultiDimSlug,
@@ -71,10 +67,7 @@ export async function handlePutMultiDim(
     const rawConfig = req.body as MultiDimDataPageConfigRaw
     const id = await upsertMultiDimConfig(trx, slug, rawConfig)
 
-    if (
-        FEATURE_FLAGS.has(FeatureFlagFeature.MultiDimDataPage) &&
-        (await multiDimDataPageExists(trx, { slug, published: true }))
-    ) {
+    if (await multiDimDataPageExists(trx, { slug, published: true })) {
         await triggerStaticBuild(
             res.locals.user,
             `Publishing multidimensional chart ${slug}`

--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -12,7 +12,6 @@ import {
     BLOG_POSTS_PER_PAGE,
     BASE_DIR,
     GDOCS_DETAILS_ON_DEMAND_ID,
-    FEATURE_FLAGS,
 } from "../settings/serverSettings.js"
 
 import {
@@ -83,7 +82,6 @@ import { getAllImages } from "../db/model/Image.js"
 import { generateEmbedSnippet } from "../site/viteUtils.js"
 import { logErrorAndMaybeCaptureInSentry } from "../serverUtils/errorLog.js"
 import { mapSlugsToConfigs } from "../db/model/Chart.js"
-import { FeatureFlagFeature } from "../settings/clientSettings.js"
 import pMap from "p-map"
 import { GdocDataInsight } from "../db/model/Gdoc/GdocDataInsight.js"
 import { calculateDataInsightIndexPageCount } from "../db/model/Gdoc/gdocUtils.js"
@@ -811,12 +809,6 @@ export class SiteBaker {
 
     private async bakeMultiDimPages(knex: db.KnexReadonlyTransaction) {
         if (!this.bakeSteps.has("multiDimPages")) return
-        if (!FEATURE_FLAGS.has(FeatureFlagFeature.MultiDimDataPage)) {
-            console.log(
-                "Skipping baking multi-dim pages because feature flag is not set"
-            )
-            return
-        }
         const { imageMetadata } = await this.getPrefetchedGdocAttachments(knex)
         await bakeAllMultiDimDataPages(knex, this.bakedSiteDir, imageMetadata)
 

--- a/settings/clientSettings.ts
+++ b/settings/clientSettings.ts
@@ -104,18 +104,23 @@ export const GDOCS_DETAILS_ON_DEMAND_ID: string =
 
 export const PUBLISHED_AT_FORMAT = "ddd, MMM D, YYYY HH:mm"
 
-// Feature flags: FEATURE_FLAGS is a comma-separated list of flags, and they need to be part of this enum to be considered
-export enum FeatureFlagFeature {
-    MultiDimDataPage = "MultiDimDataPage",
-}
+/** A map of possible features which can be enabled or disabled. */
+const Features = {
+    ExampleFeature: "ExampleFeature",
+} as const
+
+type Feature = (typeof Features)[keyof typeof Features]
+
+// process.env.FEATURE_FLAGS is a comma-separated list of flags, and they need
+// to be a valid value in the Features object to be considered.
 const featureFlagsRaw =
     (typeof process.env.FEATURE_FLAGS === "string" &&
         process.env.FEATURE_FLAGS.trim()?.split(",")) ||
     []
-export const FEATURE_FLAGS: Set<FeatureFlagFeature> = new Set(
-    Object.keys(FeatureFlagFeature).filter((key) =>
-        featureFlagsRaw.includes(key)
-    ) as FeatureFlagFeature[]
+export const FEATURE_FLAGS: Set<Feature> = new Set(
+    Object.values(Features).filter((feature) =>
+        featureFlagsRaw.includes(feature)
+    )
 )
 
 export const SLACK_DI_PITCHES_CHANNEL_ID: string =

--- a/settings/clientSettings.ts
+++ b/settings/clientSettings.ts
@@ -105,7 +105,7 @@ export const GDOCS_DETAILS_ON_DEMAND_ID: string =
 export const PUBLISHED_AT_FORMAT = "ddd, MMM D, YYYY HH:mm"
 
 /** A map of possible features which can be enabled or disabled. */
-const Features = {
+export const Features = {
     ExampleFeature: "ExampleFeature",
 } as const
 


### PR DESCRIPTION
It should be safe to remove the feature flag when this stack is merged. I want to make it easier for data managers to play with the feature on their staging servers.

In the next PR of the stack I'll introduce the `catalogPath` and a new API for ETL.