### PR TITLE
🎉 add info section to the narrative chart editor

### DIFF
--- a/adminSiteClient/EditorBasicTab.tsx
+++ b/adminSiteClient/EditorBasicTab.tsx
@@ -31,6 +31,7 @@ import {
     sampleSize,
     startCase,
     OwidChartDimensionInterface,
+    copyToClipboard,
 } from "@ourworldindata/utils"
 import { FieldsRow, Section, SelectField, Toggle } from "./Forms.js"
 import { VariableSelector } from "./VariableSelector.js"
@@ -51,6 +52,13 @@ import {
 } from "./IndicatorChartEditor.js"
 import { EditableTags } from "./EditableTags.js"
 import { AdminAppContext, AdminAppContextType } from "./AdminAppContext.js"
+import {
+    ChartViewEditor,
+    isChartViewEditorInstance,
+} from "./ChartViewEditor.js"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import { faCopy } from "@fortawesome/free-solid-svg-icons"
+import { Button } from "antd"
 
 @observer
 class DimensionSlotView<
@@ -515,10 +523,12 @@ export class EditorBasicTab<
         const { editor } = this.props
         const { grapher } = editor
         const isIndicatorChart = isIndicatorChartEditorInstance(editor)
+        const isChartView = isChartViewEditorInstance(editor)
 
         return (
             <div className="EditorBasicTab">
                 {isIndicatorChart && <IndicatorChartInfo editor={editor} />}
+                {isChartView && <ChartViewInfo editor={editor} />}
 
                 <Section name="Tabs">
                     <SelectField
@@ -585,7 +595,31 @@ function IndicatorChartInfo(props: { editor: IndicatorChartEditor }) {
 
     return (
         <Section name="Indicator chart">
-            <p>This is the Grapher config for indicator {variableLink}.</p>
+            <p>Your are editing the config of the {variableLink} indicator.</p>
+        </Section>
+    )
+}
+
+// The rule doesn't support class components in the same file.
+// eslint-disable-next-line react-refresh/only-export-components
+function ChartViewInfo(props: { editor: ChartViewEditor }) {
+    const { name = "" } = props.editor.manager.idsAndName ?? {}
+
+    return (
+        <Section name="Narrative chart">
+            <p>
+                Your are editing the config of a narrative chart named{" "}
+                <i>{name}</i>.
+            </p>
+            <Button
+                size="small"
+                color="default"
+                variant="filled"
+                icon={<FontAwesomeIcon icon={faCopy} size="sm" />}
+                onClick={() => copyToClipboard(name)}
+            >
+                Copy name
+            </Button>
         </Section>
     )
 }


### PR DESCRIPTION
Adds an info box for narrative chart editors, including a copy button for the name of a narrative chart.

The copy action is useful for the Figma plugin that expects a narrative chart name as input.

<img width="549" alt="Screenshot 2025-02-13 at 16 36 54" src="https://github.com/user-attachments/assets/7acfbd91-24ed-4137-9437-cb4b02a6098a" />

<!-- GitButler Footer Boundary Top -->
---
This is **part 6 of 9 in a stack** made with GitButler:
- <kbd>&nbsp;9&nbsp;</kbd> #4571 
- <kbd>&nbsp;8&nbsp;</kbd> #4570 
- <kbd>&nbsp;7&nbsp;</kbd> #4558 
- <kbd>&nbsp;6&nbsp;</kbd> #4557 👈 
- <kbd>&nbsp;5&nbsp;</kbd> #4556 
- <kbd>&nbsp;4&nbsp;</kbd> #4547 
- <kbd>&nbsp;3&nbsp;</kbd> #4500 
- <kbd>&nbsp;2&nbsp;</kbd> #4490 
- <kbd>&nbsp;1&nbsp;</kbd> #4489 
<!-- GitButler Footer Boundary Bottom -->

