### PR TITLE
🎉 add di section to the chart editor ref tab

### DIFF
--- a/adminShared/AdminTypes.ts
+++ b/adminShared/AdminTypes.ts
@@ -17,6 +17,7 @@ export interface DataInsight {
     gdocId: string
     title: string
     published: boolean
+    narrativeChart?: string
     figmaUrl?: string
     image?: {
         id: NonNullable<DbRawImage["id"]>

--- a/adminShared/AdminTypes.ts
+++ b/adminShared/AdminTypes.ts
@@ -13,7 +13,7 @@ export interface ApiChartViewOverview {
     title: string
 }
 
-export interface DataInsight {
+export interface DataInsightMinimalInformation {
     gdocId: string
     title: string
     published: boolean

--- a/adminSiteClient/AbstractChartEditor.ts
+++ b/adminSiteClient/AbstractChartEditor.ts
@@ -14,7 +14,7 @@ import { Admin } from "./Admin.js"
 import { defaultGrapherConfig, Grapher } from "@ourworldindata/grapher"
 import { ChartViewMinimalInformation } from "./ChartEditor.js"
 import { IndicatorChartInfo } from "./IndicatorChartEditor.js"
-import { DataInsight } from "../adminShared/AdminTypes.js"
+import { DataInsightMinimalInformation } from "../adminShared/AdminTypes.js"
 
 export type EditorTab =
     | "basic"
@@ -42,7 +42,7 @@ export interface References {
     explorers?: string[]
     chartViews?: ChartViewMinimalInformation[]
     childCharts?: IndicatorChartInfo[]
-    dataInsights?: DataInsight[]
+    dataInsights?: DataInsightMinimalInformation[]
 }
 
 export abstract class AbstractChartEditor<

--- a/adminSiteClient/EditorReferencesTab.tsx
+++ b/adminSiteClient/EditorReferencesTab.tsx
@@ -33,7 +33,7 @@ import {
 } from "./ChartViewEditor.js"
 import { ReuploadImageForDataInsightModal } from "./ReuploadImageForDataInsightModal.js"
 import { ImageUploadResponse } from "./imagesHelpers.js"
-import { DataInsight } from "../adminShared/AdminTypes.js"
+import { DataInsightMinimalInformation } from "../adminShared/AdminTypes.js"
 import { notification } from "antd"
 
 const BASE_URL = BAKED_GRAPHER_URL.replace(/^https?:\/\//, "")
@@ -483,11 +483,11 @@ const NotificationContext = createContext(null)
 
 const ReferencesDataInsights = (props: {
     references: Pick<References, "dataInsights">
-    canReuploadImage?: (dataInsight: DataInsight) => boolean
-    makeImageUrl?: (dataInsight: DataInsight) => string
+    canReuploadImage?: (dataInsight: DataInsightMinimalInformation) => boolean
+    makeImageUrl?: (dataInsight: DataInsightMinimalInformation) => string
 }) => {
     const [dataInsightForUpload, setDataInsightForUpload] =
-        useState<DataInsight>()
+        useState<DataInsightMinimalInformation>()
 
     const [notificationApi, notificationContextHolder] =
         notification.useNotification()

--- a/adminSiteServer/apiRoutes/chartViews.ts
+++ b/adminSiteServer/apiRoutes/chartViews.ts
@@ -27,7 +27,7 @@ import {
 import { omit, pick } from "lodash"
 import {
     ApiChartViewOverview,
-    DataInsight,
+    DataInsightMinimalInformation,
 } from "../../adminShared/AdminTypes.js"
 import { expectInt } from "../../serverUtils/serverUtil.js"
 import {
@@ -357,7 +357,7 @@ export async function getChartViewReferences(
 async function getDataInsightsForChartView(
     knex: Knex<any, any[]>,
     chartViewId: number
-): Promise<DataInsight[]> {
+): Promise<DataInsightMinimalInformation[]> {
     const rows = await db.knexRaw<
         Pick<DbRawPostGdoc, "id" | "published"> &
             Pick<OwidGdocDataInsightContent, "title"> & {

--- a/adminSiteServer/apiRoutes/charts.ts
+++ b/adminSiteServer/apiRoutes/charts.ts
@@ -62,7 +62,7 @@ import { getPublishedLinksTo } from "../../db/model/Link.js"
 
 import { Request } from "../authentication.js"
 import e from "express"
-import { DataInsight } from "../../adminShared/AdminTypes.js"
+import { DataInsightMinimalInformation } from "../../adminShared/AdminTypes.js"
 
 export const getReferencesByChartId = async (
     chartId: number,
@@ -92,7 +92,7 @@ export const getReferencesByChartId = async (
         WHERE cv.parentChartId = ?`,
         [chartId]
     )
-    const dataInsightsPromise = db.knexRaw<DataInsight>(
+    const dataInsightsPromise = db.knexRaw<DataInsightMinimalInformation>(
         knex,
         `-- sql
         SELECT


### PR DESCRIPTION
Adds a section to the Ref tab that lists all data insights that are based on the chart.

<img width="549" alt="Screenshot 2025-02-13 at 17 24 34" src="https://github.com/user-attachments/assets/f0299e6f-8fa0-4bca-945c-a405fecb1f2f" />

<!-- GitButler Footer Boundary Top -->
---
This is **part 7 of 9 in a stack** made with GitButler:
- <kbd>&nbsp;9&nbsp;</kbd> #4571 
- <kbd>&nbsp;8&nbsp;</kbd> #4570 
- <kbd>&nbsp;7&nbsp;</kbd> #4558 👈 
- <kbd>&nbsp;6&nbsp;</kbd> #4557 
- <kbd>&nbsp;5&nbsp;</kbd> #4556 
- <kbd>&nbsp;4&nbsp;</kbd> #4547 
- <kbd>&nbsp;3&nbsp;</kbd> #4500 
- <kbd>&nbsp;2&nbsp;</kbd> #4490 
- <kbd>&nbsp;1&nbsp;</kbd> #4489 
<!-- GitButler Footer Boundary Bottom -->

