### PR TITLE
🐛 fix transparent background for explorer thumbnail previews

### DIFF
--- a/functions/explorers/[slug].ts
+++ b/functions/explorers/[slug].ts
@@ -91,7 +91,7 @@ async function handleThumbnailRequest(
                 },
             })
         } else {
-            return png(await renderSvgToPng(svg, options))
+            return png(await renderSvgToPng(svg, options, "#fff"))
         }
     } catch (e) {
         console.error(e)


### PR DESCRIPTION
## Problem
Explorer thumbnails (e.g. https://ourworldindata.org/explorers/co2.png) currently have a transparent background when they should be white.

## Context
This is due to https://github.com/owid/owid-grapher/pull/4527, which was done to make editing charts in Figma easier, and we didn't notice it quickly because Grapher thumbnails didn't have the issue.

I had added https://github.com/owid/owid-grapher/commit/10ff804fa7c538a1327625cfc4ad70954ff64f2f as a partial fix for this when I noticed it on the data catalog (and I see no harm in keeping 1 extra line of CSS just in case this breaks again, as unlikely as that seems)

## Fix
Adding a backgroundColor argument to the `svgToPng` call in the explorer rendering CF function.

## To test
Run `make up.full` and visit http://localhost:8788/explorers/migration.png

Download the image and confirm it has a background color