### PR TITLE
Use middleware for grapher redirects

### DIFF
--- a/functions/explorers/[slug].ts
+++ b/functions/explorers/[slug].ts
@@ -1,7 +1,7 @@
 import { Env, Etag, extensions } from "../_common/env.js"
 import { extractOptions } from "../_common/imageOptions.js"
 import { buildExplorerProps, Explorer } from "@ourworldindata/explorer"
-import { handlePageNotFound } from "../_common/redirectTools.js"
+import { redirectMiddleware } from "../_common/redirectTools.js"
 import { renderSvgToPng } from "../_common/grapherRenderer.js"
 import { IRequestStrict, Router, error, cors, png } from "itty-router"
 import { Bounds, Url } from "@ourworldindata/utils"
@@ -24,6 +24,7 @@ const router = Router<
     finally: [corsify],
 })
 router
+    .get("*", redirectMiddleware)
     .get(
         `/explorers/:slug${extensions.svg}`,
         async (_, { searchParams }, env) => {
@@ -111,7 +112,7 @@ async function handleHtmlPageRequest(
     })
 
     if (explorerPage.status === 404) {
-        return handlePageNotFound(env, explorerPage)
+        return explorerPage
     }
 
     const openGraphThumbnailUrl = `/explorers/${slug}.png?imType=og${


### PR DESCRIPTION
This has been now reported in Slack multiple times. It confuses authors that they don't see the change after they create a chart redirect. It also means different users can see different charts when clicking on the same link, depending on whether the CDN datacenter that handles their request had the old page cached. I tested this case with Pablo A.

I naively measured how much it takes to fetch a redirect slug in Cloudflare preview deployment, and it's between 2–10 ms for the majority of requests, and the highest outlier I saw was 35 ms.

If there is no redirect, we pay this cost once, if there is one, we pay it twice — first the page gets redirected successfully, then we check the second time as we handle the now correct request.

**TODO**: It might be better to take the same approach as we did for deleted articles and add temporary redirects to the redirects table with a TTL that is cleaned up in a cron job.