### PR TITLE
🐛 fix admin API error messages not showing in client

### DIFF
--- a/adminSiteServer/apiRoutes/charts.ts
+++ b/adminSiteServer/apiRoutes/charts.ts
@@ -725,7 +725,7 @@ export async function createChart(
 
         return { success: true, chartId: chartId }
     } catch (err) {
-        return { success: false, error: String(err) }
+        throw new JsonError(String(err))
     }
 }
 
@@ -769,10 +769,7 @@ export async function updateChart(
             newLog: logs[0],
         }
     } catch (err) {
-        return {
-            success: false,
-            error: String(err),
-        }
+        throw new JsonError(String(err))
     }
 }
 

--- a/adminSiteServer/apiRoutes/images.ts
+++ b/adminSiteServer/apiRoutes/images.ts
@@ -49,10 +49,9 @@ export async function postImageHandler(
         .first()
 
     if (collision) {
-        return {
-            success: false,
-            error: `An image with this content already exists (filename: ${collision.filename})`,
-        }
+        throw new JsonError(
+            `An exact copy of this image already exists (filename: ${collision.filename})`
+        )
     }
 
     const preexisting = await trx<DbEnrichedImage>("images")
@@ -60,19 +59,15 @@ export async function postImageHandler(
         .first()
 
     if (preexisting) {
-        return {
-            success: false,
-            error: "An image with this filename already exists",
-        }
+        throw new JsonError(
+            `An image with this filename already exists (id: ${preexisting.id})`
+        )
     }
 
     const cloudflareId = await uploadToCloudflare(filename, asBlob)
 
     if (!cloudflareId) {
-        return {
-            success: false,
-            error: "Failed to upload image",
-        }
+        throw new JsonError("Failed to upload image", 500)
     }
 
     await trx<DbEnrichedImage>("images").insert({
@@ -115,10 +110,10 @@ export async function putImageHandler(
         .first()
 
     if (collision) {
-        return {
-            success: false,
-            error: `An exact copy of this image already exists (filename: ${collision.filename})`,
-        }
+        throw new JsonError(
+            `An exact copy of this image already exists (filename: ${collision.filename})`,
+            400
+        )
     }
 
     const { id } = req.params

--- a/adminSiteServer/apiRoutes/variables.ts
+++ b/adminSiteServer/apiRoutes/variables.ts
@@ -320,10 +320,7 @@ export async function putVariablesVariableIdGrapherConfigETL(
     try {
         validConfig = migrateGrapherConfigToLatestVersion(req.body)
     } catch (err) {
-        return {
-            success: false,
-            error: String(err),
-        }
+        throw new JsonError(String(err))
     }
 
     const variable = await getGrapherConfigsForVariable(trx, variableId)
@@ -433,10 +430,7 @@ export async function putVariablesVariableIdGrapherConfigAdmin(
     try {
         validConfig = migrateGrapherConfigToLatestVersion(req.body)
     } catch (err) {
-        return {
-            success: false,
-            error: String(err),
-        }
+        throw new JsonError(String(err))
     }
 
     const variable = await getGrapherConfigsForVariable(trx, variableId)

--- a/adminSiteServer/app.test.ts
+++ b/adminSiteServer/app.test.ts
@@ -193,11 +193,10 @@ async function makeRequestAgainstAdminApi(
         body,
     })
 
-    expect(response.status).toBe(200)
-
     const json = await response.json()
 
     if (verifySuccess) {
+        expect(response.status).toBe(200)
         expect(json.success).toBe(true)
     }
 
@@ -914,7 +913,7 @@ describe("OwidAdminApp: indicator-level chart configs", () => {
             },
             { verifySuccess: false }
         )
-        expect(json.success).toBe(false)
+        expect(json.error.status).toBe(400)
     })
 
     it("should return an error if the schema is invalid", async () => {
@@ -930,7 +929,7 @@ describe("OwidAdminApp: indicator-level chart configs", () => {
             },
             { verifySuccess: false }
         )
-        expect(json.success).toBe(false)
+        expect(json.error.status).toBe(400)
     })
 })
 


### PR DESCRIPTION
## Problem

`return { success: false, error: "Oh no!" }` was being used in a few places in our API, but the admin client didn't understand what to do with that response. 

![image](https://github.com/user-attachments/assets/df7b5527-e7f5-4d33-9a63-e8e2043f13f3)

## Fix
I grep'd `return {` in the API folder, and updated any instance of the non-working pattern with `throw new JsonError(` instead.

## To test
Check this branch out, go to `http://localhost:3030/admin/charts/create` and click "Create Draft"
The error that throws (due to missing data) will render correctly in the client.