### PR TITLE
🎉 (admin) add mobile preview to gdocs preview / TAS-837

### DIFF
--- a/adminSiteClient/GdocsMoreMenu.tsx
+++ b/adminSiteClient/GdocsMoreMenu.tsx
@@ -5,6 +5,8 @@ import {
     faTrash,
     faXmark,
     faBug,
+    faMobileScreen,
+    faDesktop,
 } from "@fortawesome/free-solid-svg-icons"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
 import {
@@ -23,6 +25,7 @@ enum GdocsMoreMenuAction {
     Debug = "debug",
     Unpublish = "unpublish",
     Delete = "delete",
+    Mobile = "mobile",
 }
 
 export const GdocsMoreMenu = ({
@@ -30,11 +33,15 @@ export const GdocsMoreMenu = ({
     onDebug,
     onUnpublish,
     onDelete,
+    isMobilePreviewActive,
+    toggleMobilePreview,
 }: {
     gdoc: OwidGdoc
     onDebug: VoidFunction
     onUnpublish: VoidFunction
     onDelete: (tombstone?: CreateTombstoneData) => Promise<void>
+    isMobilePreviewActive: boolean
+    toggleMobilePreview: () => void
 }) => {
     const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
 
@@ -68,6 +75,8 @@ export const GdocsMoreMenu = ({
                             case GdocsMoreMenuAction.Delete:
                                 setIsDeleteModalOpen(true)
                                 break
+                            case GdocsMoreMenuAction.Mobile:
+                                toggleMobilePreview()
                         }
                     },
                     items: [
@@ -75,6 +84,21 @@ export const GdocsMoreMenu = ({
                             key: GdocsMoreMenuAction.Debug,
                             label: "Debug",
                             icon: <FontAwesomeIcon icon={faBug} />,
+                        },
+                        {
+                            key: GdocsMoreMenuAction.Mobile,
+                            label: isMobilePreviewActive
+                                ? "Desktop preview"
+                                : "Mobile preview",
+                            icon: (
+                                <FontAwesomeIcon
+                                    icon={
+                                        isMobilePreviewActive
+                                            ? faDesktop
+                                            : faMobileScreen
+                                    }
+                                />
+                            ),
                         },
                         {
                             key: GdocsMoreMenuAction.Unpublish,

--- a/adminSiteClient/GdocsPreviewPage.tsx
+++ b/adminSiteClient/GdocsPreviewPage.tsx
@@ -74,6 +74,8 @@ export const GdocsPreviewPage = ({ match, history }: GdocsMatchProps) => {
     const { admin } = useContext(AdminAppContext)
     const store = useGdocsStore()
 
+    const [isMobilePreviewActive, setIsMobilePreviewActive] = useState(false)
+
     const iframeRef = useRef<HTMLIFrameElement>(null)
 
     const fetchGdoc = useCallback(
@@ -172,6 +174,11 @@ export const GdocsPreviewPage = ({ match, history }: GdocsMatchProps) => {
         await store.delete(currentGdoc, tombstone)
         history.push("/gdocs")
     }
+
+    const toggleMobilePreview = () =>
+        setIsMobilePreviewActive(
+            (isMobilePreviewActive) => !isMobilePreviewActive
+        )
 
     const onSettingsClose = () => {
         setSettingsOpen(false)
@@ -303,6 +310,8 @@ export const GdocsPreviewPage = ({ match, history }: GdocsMatchProps) => {
                                 onDebug={() => setDiffOpen(true)}
                                 onUnpublish={doUnpublish}
                                 onDelete={onDelete}
+                                isMobilePreviewActive={isMobilePreviewActive}
+                                toggleMobilePreview={toggleMobilePreview}
                             />
                         </Space>
                     </Col>
@@ -408,19 +417,25 @@ export const GdocsPreviewPage = ({ match, history }: GdocsMatchProps) => {
                     />
                 </Drawer>
 
-                {/*
-                    This uses the full SSR rendering pipeline. It is more accurate but comes
-                    with an additional requests to the Google API and has a less polished
-                    authoring experience at the moment (content flashes and scrolling position
-                    resets on every change)
-                */}
-                <iframe
-                    ref={iframeRef}
-                    src={`/gdocs/${currentGdoc.id}/preview#owid-document-root`}
-                    style={{ width: "100%", border: "none" }}
-                    // use `updatedAt` as a proxy for when database-level settings such as breadcrumbs have changed
-                    key={`${currentGdoc.revisionId}-${originalGdoc?.updatedAt}`}
-                />
+                <div className="iframe-container">
+                    {/*
+                        This uses the full SSR rendering pipeline. It is more accurate but comes
+                        with an additional requests to the Google API and has a less polished
+                        authoring experience at the moment (content flashes and scrolling position
+                        resets on every change)
+                    */}
+                    <iframe
+                        ref={iframeRef}
+                        src={`/gdocs/${currentGdoc.id}/preview#owid-document-root`}
+                        style={{
+                            width: "100%",
+                            border: "none",
+                            maxWidth: isMobilePreviewActive ? 375 : undefined,
+                        }}
+                        // use `updatedAt` as a proxy for when database-level settings such as breadcrumbs have changed
+                        key={`${currentGdoc.revisionId}-${originalGdoc?.updatedAt}`}
+                    />
+                </div>
 
                 {currentGdoc.published && (
                     <div

--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -1156,8 +1156,11 @@ main:not(.ChartEditorPage):not(.GdocsEditPage) {
         }
     }
 
-    iframe {
+    .iframe-container {
         height: calc(100% - 65px);
+        display: flex;
+        justify-content: center;
+        background: #f2f2f2;
     }
 
     .GdocsEditPage__error-container {


### PR DESCRIPTION
Adds a mobile preview for GDocs.

I didn't want to clutter the interface, so I added it to the 'More' menu. I'm happy to move it elsewhere if you prefer.

The mobile preview width is 375px. The smallest size I usually check is 325 but that seems a little harsh – 375 is closer to the reality of today's phones, I think. 

<details><summary>Screenshot</summary>
<p>

<img width="1512" alt="Screenshot 2025-02-17 at 12 49 06" src="https://github.com/user-attachments/assets/2a4f33de-a392-42fe-b8d3-71bc8e4bca83" />

</p>
</details> 
