### PR TITLE
enhance(mysql): add better indexes for `posts_gdocs` table

### DIFF
--- a/adminSiteServer/apiRoutes/misc.ts
+++ b/adminSiteServer/apiRoutes/misc.ts
@@ -19,19 +19,18 @@ export async function fetchAllWork(
     type GdocRecord = Pick<DbRawPostGdoc, "id" | "publishedAt">
 
     const author = req.query.author
-    const gdocs = await db
-        .knexRaw<GdocRecord>(
-            trx,
-            `-- sql
-            SELECT id, publishedAt
+    const gdocs = await db.knexRaw<GdocRecord>(
+        trx,
+        `-- sql
+            SELECT id
             FROM posts_gdocs
-            WHERE JSON_CONTAINS(content->'$.authors', ?)
+            WHERE JSON_CONTAINS(authors, ?)
             AND type NOT IN ("data-insight", "fragment")
             AND published = 1
+            ORDER BY publishedAt DESC
     `,
-            [`"${author}"`]
-        )
-        .then((rows) => lodash.orderBy(rows, (row) => row.publishedAt, "desc"))
+        [`"${author}"`]
+    )
 
     const archieLines = gdocs.map(
         (post) => `url: https://docs.google.com/document/d/${post.id}/edit`

--- a/db/db.ts
+++ b/db/db.ts
@@ -270,7 +270,7 @@ export const getPublishedDataInsights = (
         `-- sql
         SELECT
             content->>'$.title' AS title,
-            content->>'$.authors' AS authors,
+            authors,
             publishedAt,
             updatedAt,
             slug,

--- a/db/db.ts
+++ b/db/db.ts
@@ -426,7 +426,8 @@ export const getPublishedGdocPosts = async (
         g.publishedAt,
         g.revisionId,
         g.slug,
-        g.updatedAt
+        g.updatedAt,
+        g.authors
     FROM
         posts_gdocs g
     WHERE

--- a/db/migration/1739788202649-PostsGdocsIndexes.ts
+++ b/db/migration/1739788202649-PostsGdocsIndexes.ts
@@ -29,9 +29,18 @@ export class PostsGdocsIndexes1739788202649 implements MigrationInterface {
             ALTER TABLE posts_gdocs
             ADD COLUMN authors JSON GENERATED ALWAYS AS (JSON_EXTRACT(content, '$.authors')) STORED AFTER content
         `)
+
+        // Add a composite index on `posts_gdocs_links` for `linkType` and `componentType` - we especially use queries for `linkType = 'grapher'`
+        await queryRunner.query(`-- sql
+            CREATE INDEX idx_linkType_componentType ON posts_gdocs_links (linkType, componentType)
+        `)
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`-- sql
+            DROP INDEX idx_linkType_componentType ON posts_gdocs_links
+        `)
+
         await queryRunner.query(`-- sql
             ALTER TABLE posts_gdocs
             DROP COLUMN authors

--- a/db/migration/1739788202649-PostsGdocsIndexes.ts
+++ b/db/migration/1739788202649-PostsGdocsIndexes.ts
@@ -10,14 +10,15 @@ export class PostsGdocsIndexes1739788202649 implements MigrationInterface {
             ADD COLUMN type VARCHAR(255) GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(content, '$.type'))) STORED AFTER slug
         `)
 
-        // Add a combined index on `type` and `published`
+        // Add a combined index on `type`, `published` and `publishedAt`
         // It can get used for just `type` queries, and often times we also filter by `published` in the same query
+        // and potentially by `publishedAt` as well
         await queryRunner.query(`-- sql
             ALTER TABLE posts_gdocs
-            ADD INDEX idx_posts_gdocs_type_published (type, published)
+            ADD INDEX idx_posts_gdocs_type_published_publishedAt (type, published, publishedAt)
         `)
 
-        // Another common type of query is to filter by `published` and `publishedAt`
+        // Another common type of query is to filter/sort by `published` and `publishedAt`
         await queryRunner.query(`-- sql
             ALTER TABLE posts_gdocs
             ADD INDEX idx_posts_gdocs_published_publishedAt (published, publishedAt)
@@ -41,7 +42,7 @@ export class PostsGdocsIndexes1739788202649 implements MigrationInterface {
         `)
 
         await queryRunner.query(`-- sql
-            DROP INDEX idx_posts_gdocs_type_published ON posts_gdocs
+            DROP INDEX idx_posts_gdocs_type_published_publishedAt ON posts_gdocs
         `)
 
         await queryRunner.query(`-- sql

--- a/db/migration/1739788202649-PostsGdocsIndexes.ts
+++ b/db/migration/1739788202649-PostsGdocsIndexes.ts
@@ -10,15 +10,27 @@ export class PostsGdocsIndexes1739788202649 implements MigrationInterface {
             ADD COLUMN type VARCHAR(255) GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(content, '$.type'))) STORED AFTER slug
         `)
 
+        // Add a combined index on `type` and `published`
+        // It can get used for just `type` queries, and often times we also filter by `published` in the same query
         await queryRunner.query(`-- sql
             ALTER TABLE posts_gdocs
-            ADD INDEX idx_posts_gdocs_published (published)
+            ADD INDEX idx_posts_gdocs_type_published (type, published)
+        `)
+
+        // Another common type of query is to filter by `published` and `publishedAt`
+        await queryRunner.query(`-- sql
+            ALTER TABLE posts_gdocs
+            ADD INDEX idx_posts_gdocs_published_publishedAt (published, publishedAt)
         `)
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`-- sql
-            DROP INDEX idx_posts_gdocs_published ON posts_gdocs
+            DROP INDEX idx_posts_gdocs_published_publishedAt ON posts_gdocs
+        `)
+
+        await queryRunner.query(`-- sql
+            DROP INDEX idx_posts_gdocs_type_published ON posts_gdocs
         `)
 
         await queryRunner.query(`-- sql

--- a/db/migration/1739788202649-PostsGdocsIndexes.ts
+++ b/db/migration/1739788202649-PostsGdocsIndexes.ts
@@ -22,9 +22,20 @@ export class PostsGdocsIndexes1739788202649 implements MigrationInterface {
             ALTER TABLE posts_gdocs
             ADD INDEX idx_posts_gdocs_published_publishedAt (published, publishedAt)
         `)
+
+        // Add a computed stored column for `authors`
+        await queryRunner.query(`-- sql
+            ALTER TABLE posts_gdocs
+            ADD COLUMN authors JSON GENERATED ALWAYS AS (JSON_EXTRACT(content, '$.authors')) STORED AFTER content
+        `)
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`-- sql
+            ALTER TABLE posts_gdocs
+            DROP COLUMN authors
+        `)
+
         await queryRunner.query(`-- sql
             DROP INDEX idx_posts_gdocs_published_publishedAt ON posts_gdocs
         `)

--- a/db/migration/1739788202649-PostsGdocsIndexes.ts
+++ b/db/migration/1739788202649-PostsGdocsIndexes.ts
@@ -1,0 +1,31 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class PostsGdocsIndexes1739788202649 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        // Change `type` col def from `VIRTUAL` to `STORED`
+        await queryRunner.query(`-- sql
+            ALTER TABLE posts_gdocs
+            DROP INDEX idx_posts_gdocs_type,
+            DROP COLUMN type,
+            ADD COLUMN type VARCHAR(255) GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(content, '$.type'))) STORED AFTER slug
+        `)
+
+        await queryRunner.query(`-- sql
+            ALTER TABLE posts_gdocs
+            ADD INDEX idx_posts_gdocs_published (published)
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`-- sql
+            DROP INDEX idx_posts_gdocs_published ON posts_gdocs
+        `)
+
+        await queryRunner.query(`-- sql
+            ALTER TABLE posts_gdocs
+            DROP COLUMN type,
+            ADD COLUMN type VARCHAR(255) GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(content, '$.type'))) VIRTUAL AFTER slug,
+            ADD INDEX idx_posts_gdocs_type (type)
+        `)
+    }
+}

--- a/db/model/Gdoc/GdocBase.ts
+++ b/db/model/Gdoc/GdocBase.ts
@@ -946,7 +946,7 @@ export async function getMinimalGdocPostsByIds(
                 id,
                 content ->> '$.title' as title,
                 slug,
-                content ->> '$.authors' as authors,
+                authors,
                 publishedAt,
                 published,
                 content ->> '$.subtitle' as subtitle,

--- a/db/model/Gdoc/GdocFactory.ts
+++ b/db/model/Gdoc/GdocFactory.ts
@@ -241,7 +241,7 @@ export async function getAllMinimalGdocBaseObjects(
                 id,
                 content ->> '$.title' as title,
                 slug,
-                content ->> '$.authors' as authors,
+                authors,
                 publishedAt,
                 published,
                 content ->> '$.subtitle' as subtitle,

--- a/db/model/Post.ts
+++ b/db/model/Post.ts
@@ -588,7 +588,7 @@ export const getRelatedResearchAndWritingForVariables = async (
             p.content ->> '$.title' AS title,
             p.slug AS postSlug,
             COALESCE(csr.chart_id, c.id) AS chartId,
-            p.content ->> '$.authors' AS authors,
+            authors,
             p.content ->> '$."featured-image"' AS thumbnail,
             COALESCE(pv.views_365d, 0) AS pageviews,
             'gdocs' AS post_source,
@@ -657,7 +657,7 @@ export const getLatestWorkByAuthor = async (
             pg.slug,
             pg.content->>'$.title' AS title,
             pg.content->>'$.subtitle' AS subtitle,
-            pg.content->>'$.authors' AS authors,
+            authors,
             pg.publishedAt,
             CASE
                 WHEN content ->> '$."deprecation-notice"' IS NOT NULL THEN '${ARCHVED_THUMBNAIL_FILENAME}'
@@ -666,19 +666,13 @@ export const getLatestWorkByAuthor = async (
         FROM
             posts_gdocs pg
         WHERE
-            pg.content ->> '$.authors' LIKE ?
+            JSON_CONTAINS(authors, ?)
             AND pg.published = TRUE
             AND pg.type = "${OwidGdocType.Article}"
+        ORDER BY publishedAt DESC
         `,
-        [`%${author}%`]
+        [`"${author}"`]
     )
 
-    // We're sorting in JS because of the "Out of sort memory, consider
-    // increasing server sort buffer size" error when using ORDER BY. Adding an
-    // index on the publishedAt column doesn't help.
-    return sortBy(
-        rawLatestWorkLinks.map((work) => parseLatestWork(work)),
-        // Sort by most recent first
-        (work) => -work.publishedAt! // "!" because we're only selecting published posts, so publishedAt can't be NULL
-    )
+    return rawLatestWorkLinks.map(parseLatestWork)
 }


### PR DESCRIPTION
This PR does a few things to the `posts_gdocs` table:
- Add a composite index on `type, published, publishedAt`
	- These sorts of queries are very common, e.g. `WHERE type = "data-insight" AND published = 1 AND publishedAt <= NOW()`
	- Also, it can be used on queries that _just_ filter on `type`
- Add another composite index on `published, publishedAt`
	- Again, filtering on `published` is very common
- Convert the computed column `type` from `VIRTUAL` to `STORED`
- Add a computed stored column on `content ->> "$.authors`"
    - This allows us to filter on them [without running out of MySQL sort memory](https://github.com/owid/owid-grapher/pull/4545#discussion_r1955835992)
- Add a composite index on `posts_gdocs_links (linkType, componentType)`, to aid filtering for `linkType = 'grapher'`


I tested this a bunch and it works well overall, and the new indexes are used.
The only thing I'm not sure about is the addition of the `authors` column, which in theory could cause issues because we're not properly removing it someplace before inserting/updating into the DB. But if `serializePostsGdocsRow` is always used before sending things to the DB, then things will be fine on that end. (Also worth noting that we never had any issues with `type`, which has been a computed column for a long time now.)