### PR TITLE
🎉 Link from admin indicator search to ETL semantic search

### DIFF
--- a/adminSiteClient/VariablesIndexPage.tsx
+++ b/adminSiteClient/VariablesIndexPage.tsx
@@ -84,7 +84,12 @@ export class VariablesIndexPage extends Component {
                         <code>after:</code>, <code>is:public</code>,{" "}
                         <code>is:private</code>
                     </p>
-                    <p>Also try: <a href={urljoin(ETL_WIZARD_URL, "indicator_search")}>semantic indicator search</a></p>
+                    <p>
+                        Also try:{" "}
+                        <a href={urljoin(ETL_WIZARD_URL, "indicator_search")}>
+                            semantic indicator search
+                        </a>
+                    </p>
                     <VariableList
                         variables={variablesToShow}
                         fields={[

--- a/adminSiteClient/VariablesIndexPage.tsx
+++ b/adminSiteClient/VariablesIndexPage.tsx
@@ -14,6 +14,8 @@ import { AdminLayout } from "./AdminLayout.js"
 import { SearchField, FieldsRow } from "./Forms.js"
 import { VariableList, VariableListItem } from "./VariableList.js"
 import { AdminAppContext, AdminAppContextType } from "./AdminAppContext.js"
+import { ETL_WIZARD_URL } from "../settings/clientSettings.js"
+import urljoin from "url-join"
 
 @observer
 export class VariablesIndexPage extends Component {
@@ -82,6 +84,7 @@ export class VariablesIndexPage extends Component {
                         <code>after:</code>, <code>is:public</code>,{" "}
                         <code>is:private</code>
                     </p>
+                    <p>Also try: <a href={urljoin(ETL_WIZARD_URL, "indicator_search")}>semantic indicator search</a></p>
                     <VariableList
                         variables={variablesToShow}
                         fields={[


### PR DESCRIPTION
We have a great semantic search over indicators in the ETL, but people may not be aware of it or have used it.

This change adds a link from the existing indicator search, making it easy to discover.