### PR TITLE
Add catalogPath to mdims

### DIFF
--- a/adminSiteServer/adminRouter.tsx
+++ b/adminSiteServer/adminRouter.tsx
@@ -44,7 +44,10 @@ import { getChartConfigBySlug } from "../db/model/Chart.js"
 import { getVariableMetadata } from "../db/model/Variable.js"
 import { DbPlainDatasetFile, DbPlainDataset } from "@ourworldindata/types"
 import { getPlainRouteWithROTransaction } from "./plainRouterHelpers.js"
-import { getMultiDimDataPageBySlug } from "../db/model/MultiDimDataPage.js"
+import {
+    getMultiDimDataPageByCatalogPath,
+    getMultiDimDataPageBySlug,
+} from "../db/model/MultiDimDataPage.js"
 import { renderMultiDimDataPageFromConfig } from "../baker/MultiDimBaker.js"
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -356,13 +359,14 @@ getPlainRouteWithROTransaction(
             return
         }
 
-        const mdd = await getMultiDimDataPageBySlug(trx, slug, {
-            onlyPublished: false,
-        })
+        const mdd =
+            (await getMultiDimDataPageBySlug(trx, slug, {
+                onlyPublished: false,
+            })) ?? (await getMultiDimDataPageByCatalogPath(trx, slug))
         if (mdd) {
             const renderedPage = await renderMultiDimDataPageFromConfig({
                 knex: trx,
-                slug,
+                slug: mdd.slug,
                 config: mdd.config,
                 isPreviewing: true,
             })

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -291,7 +291,11 @@ getRouteWithROTransaction(apiRouter, "/images/usage", getImageUsageHandler)
 
 // Mdim routes
 getRouteWithROTransaction(apiRouter, "/multi-dims.json", handleGetMultiDims)
-putRouteWithRWTransaction(apiRouter, "/multi-dim/:slug", handlePutMultiDim)
+putRouteWithRWTransaction(
+    apiRouter,
+    "/multi-dims/:catalogPath",
+    handlePutMultiDim
+)
 patchRouteWithRWTransaction(apiRouter, "/multi-dims/:id", handlePatchMultiDim)
 
 // Misc routes

--- a/adminSiteServer/app.test.ts
+++ b/adminSiteServer/app.test.ts
@@ -492,11 +492,12 @@ describe("OwidAdminApp: indicator-level chart configs", () => {
         // create mdim config that uses both of the variables
         await makeRequestAgainstAdminApi({
             method: "PUT",
-            path: "/multi-dim/energy",
-            body: JSON.stringify(testMultiDimConfig),
+            path: "/multi-dims/test%2Fcatalog%23path",
+            body: JSON.stringify({ config: testMultiDimConfig }),
         })
         const mdim = await testKnexInstance!(MultiDimDataPagesTableName).first()
-        expect(mdim.slug).toBe("energy")
+        expect(mdim.catalogPath).toBe("test/catalog#path")
+        expect(mdim.slug).toBe(null)
         const savedMdimConfig = JSON.parse(mdim.config)
         // variableId should be normalized to an array
         expect(savedMdimConfig.views[0].indicators.y).toBeInstanceOf(Array)
@@ -516,7 +517,6 @@ describe("OwidAdminApp: indicator-level chart configs", () => {
             ...mergedGrapherConfig,
             title: "Total energy use",
             selectedEntityNames: [], // mdims define their own default entities
-            slug: "energy",
         }
         const fullViewConfig1 = await testKnexInstance!(ChartConfigsTableName)
             .where("id", mdxcc1.chartConfigId)

--- a/adminSiteServer/validation.ts
+++ b/adminSiteServer/validation.ts
@@ -7,6 +7,8 @@ import * as db from "../db/db.js"
 import { multiDimDataPageExists } from "../db/model/MultiDimDataPage.js"
 import { isValidSlug } from "../serverUtils/serverUtil.js"
 
+const CATALOG_PATH_PATTERN = /^[\w\d_/-]+#[\w\d_/-]+$/
+
 async function isSlugUsedInRedirect(
     knex: db.KnexReadonlyTransaction,
     slug: string,
@@ -77,7 +79,7 @@ export async function validateNewGrapherSlug(
  */
 export async function validateMultiDimSlug(
     knex: db.KnexReadonlyTransaction,
-    slug: string,
+    slug: string | null,
     existingConfigId?: number
 ) {
     if (!isValidSlug(slug)) {
@@ -94,4 +96,8 @@ export async function validateMultiDimSlug(
         )
     }
     return slug
+}
+
+export function isValidCatalogPath(catalogPath: string) {
+    return CATALOG_PATH_PATTERN.test(catalogPath)
 }

--- a/db/migration/1738919205864-AddCatalogPathToMultiDim.ts
+++ b/db/migration/1738919205864-AddCatalogPathToMultiDim.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class AddCatalogPathToMultiDim1738919205864
+    implements MigrationInterface
+{
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `-- sql
+            ALTER TABLE multi_dim_data_pages
+            MODIFY COLUMN slug VARCHAR(255) NULL,
+            ADD COLUMN catalogPath VARCHAR(767) NULL AFTER id,
+            ADD UNIQUE INDEX idx_multi_dim_data_pages_catalog_path (catalogPath)`
+        )
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `-- sql
+            ALTER TABLE multi_dim_data_pages
+            MODIFY COLUMN slug VARCHAR(255) NOT NULL,
+            DROP COLUMN catalogPath`
+        )
+    }
+}

--- a/packages/@ourworldindata/types/src/dbTypes/MultiDimDataPages.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/MultiDimDataPages.ts
@@ -3,7 +3,8 @@ import { MultiDimDataPageConfigEnriched } from "../siteTypes/MultiDimDataPage.js
 
 export const MultiDimDataPagesTableName = "multi_dim_data_pages"
 export interface DbInsertMultiDimDataPage {
-    slug: string
+    catalogPath?: string
+    slug?: string | null
     config: JsonString
     published?: boolean
     createdAt?: Date

--- a/packages/@ourworldindata/types/src/siteTypes/MultiDimDataPage.ts
+++ b/packages/@ourworldindata/types/src/siteTypes/MultiDimDataPage.ts
@@ -111,7 +111,7 @@ export type FaqEntryKeyedByGdocIdAndFragmentId = {
 export interface MultiDimDataPageProps {
     baseUrl: string
     baseGrapherUrl: string
-    slug: string
+    slug: string | null
     configObj: MultiDimDataPageConfigEnriched
     tagToSlugMap?: Record<string, string>
     faqEntries?: FaqEntryKeyedByGdocIdAndFragmentId

--- a/site/multiDim/MultiDimDataPage.tsx
+++ b/site/multiDim/MultiDimDataPage.tsx
@@ -21,7 +21,10 @@ export function MultiDimDataPage({
     imageMetadata,
     isPreviewing,
 }: MultiDimDataPageProps) {
-    const canonicalUrl = `${baseGrapherUrl}/${slug}`
+    if (!slug && !isPreviewing) {
+        throw new Error("Missing slug for multidimensional data page")
+    }
+    const canonicalUrl = slug ? `${baseGrapherUrl}/${slug}` : ""
     const contentProps: MultiDimDataPageContentProps = {
         canonicalUrl,
         slug,

--- a/site/multiDim/MultiDimDataPageContent.tsx
+++ b/site/multiDim/MultiDimDataPageContent.tsx
@@ -211,7 +211,7 @@ const analytics = new GrapherAnalytics()
 
 export type MultiDimDataPageContentProps = {
     canonicalUrl: string
-    slug: string
+    slug: string | null
     configObj: MultiDimDataPageConfigEnriched
     tagToSlugMap?: Record<string, string>
     faqEntries?: FaqEntryKeyedByGdocIdAndFragmentId


### PR DESCRIPTION
* Catalog path will now be the main ID used by ETL
* It's temporarily allowed to be null; we'll disallow that once existing
  data is migrated
* Slug is now allowed to be null, since it will be only set in admin at
  some point
* For that reason we'll use the catalog path as a slug for previews of
  mdims in the admin, i.e. `/admin/grapher/{catalogPath}`