### PR TITLE
🎉 support entity exclusion for all chart types

### DIFF
--- a/adminSiteClient/AbstractChartEditor.ts
+++ b/adminSiteClient/AbstractChartEditor.ts
@@ -181,8 +181,23 @@ export abstract class AbstractChartEditor<
         return difference(focusedSeriesNames, availableSeriesNames)
     }
 
+    @computed get invalidSelectedEntityNames(): SeriesName[] {
+        const { grapher } = this
+
+        // find invalid selected entities
+        const availableEntityNames = grapher.availableEntities.map(
+            (e) => e.entityName
+        )
+        const selectedEntityNames = grapher.selection.selectedEntityNames
+        return difference(selectedEntityNames, availableEntityNames)
+    }
+
     @action.bound removeInvalidFocusedSeriesNames(): void {
         this.grapher.focusArray.remove(...this.invalidFocusedSeriesNames)
+    }
+
+    @action.bound removeInvalidSelectedEntityNames(): void {
+        this.grapher.selection.deselectEntities(this.invalidSelectedEntityNames)
     }
 
     abstract get isNewGrapher(): boolean

--- a/adminSiteClient/EditorMarimekkoTab.tsx
+++ b/adminSiteClient/EditorMarimekkoTab.tsx
@@ -1,12 +1,9 @@
-import { faMinus, faTrash } from "@fortawesome/free-solid-svg-icons"
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
-import { EntityName } from "@ourworldindata/types"
 import { Grapher } from "@ourworldindata/grapher"
 import lodash from "lodash"
-import { action, computed, IReactionDisposer, observable, reaction } from "mobx"
+import { action, IReactionDisposer, observable, reaction } from "mobx"
 import { observer } from "mobx-react"
 import { Component } from "react"
-import { NumberField, Section, SelectField, Toggle } from "./Forms.js"
+import { NumberField, Section, Toggle } from "./Forms.js"
 
 @observer
 export class EditorMarimekkoTab extends Component<{ grapher: Grapher }> {
@@ -16,79 +13,11 @@ export class EditorMarimekkoTab extends Component<{ grapher: Grapher }> {
         this.xOverrideTimeInputField = props.grapher.xOverrideTime
     }
 
-    @computed private get includedEntityNames(): EntityName[] {
-        return this.props.grapher.includedEntityNames ?? []
-    }
-
-    @computed private get excludedEntityNames(): EntityName[] {
-        return this.props.grapher.excludedEntityNames ?? []
-    }
-
-    @computed private get includedEntityChoices() {
-        const { inputTable, includedEntityNames = [] } = this.props.grapher
-        return inputTable.availableEntityNames
-            .filter((entityName) => !includedEntityNames.includes(entityName))
-            .sort()
-    }
-
-    @computed private get excludedEntityChoices() {
-        const { inputTable, excludedEntityNames = [] } = this.props.grapher
-        return inputTable.availableEntityNames
-            .filter((entityName) => !excludedEntityNames.includes(entityName))
-            .sort()
-    }
-
-    @action.bound onExcludeEntity(entityName: string) {
-        const { grapher } = this.props
-        if (grapher.excludedEntityNames === undefined) {
-            grapher.excludedEntityNames = []
-        }
-
-        if (!grapher.excludedEntityNames.includes(entityName))
-            grapher.excludedEntityNames.push(entityName)
-    }
-
-    @action.bound onUnexcludeEntity(entityName: string) {
-        const { grapher } = this.props
-        if (!grapher.excludedEntityNames) return
-        grapher.excludedEntityNames = grapher.excludedEntityNames.filter(
-            (e) => e !== entityName
-        )
-    }
-
-    @action.bound onIncludeEntity(entityName: string) {
-        const { grapher } = this.props
-        if (grapher.includedEntityNames === undefined) {
-            grapher.includedEntityNames = []
-        }
-
-        if (!grapher.includedEntityNames.includes(entityName))
-            grapher.includedEntityNames.push(entityName)
-    }
-
-    @action.bound onUnincludeEntity(entityName: string) {
-        const { grapher } = this.props
-        if (!grapher.includedEntityNames) return
-        grapher.includedEntityNames = grapher.includedEntityNames.filter(
-            (e) => e !== entityName
-        )
-    }
-
-    @action.bound onClearExcludedEntities() {
-        const { grapher } = this.props
-        grapher.excludedEntityNames = []
-    }
-
-    @action.bound onClearIncludedEntities() {
-        const { grapher } = this.props
-        grapher.includedEntityNames = []
-    }
-
     @action.bound onXOverrideYear(value: number | undefined) {
         this.xOverrideTimeInputField = value
     }
+
     render() {
-        const { excludedEntityChoices, includedEntityChoices } = this
         const { grapher } = this.props
 
         return (
@@ -110,80 +39,6 @@ export class EditorMarimekkoTab extends Component<{ grapher: Grapher }> {
                                     value || undefined)
                         )}
                     />
-                </Section>
-                <Section name="Manual entity selection">
-                    <SelectField
-                        label={
-                            "Explicit start selection (leave empty to show all entities)"
-                        }
-                        placeholder={"Select an entity to include"}
-                        value={undefined}
-                        onValue={(v) => v && this.onIncludeEntity(v)}
-                        options={includedEntityChoices.map((entry) => ({
-                            value: entry,
-                        }))}
-                    />
-                    {this.includedEntityNames && (
-                        <ul className="includedEntities">
-                            {this.includedEntityNames.map((entity) => (
-                                <li key={entity}>
-                                    <div
-                                        className="clickable"
-                                        onClick={() =>
-                                            this.onUnincludeEntity(entity)
-                                        }
-                                    >
-                                        <FontAwesomeIcon icon={faMinus} />
-                                    </div>
-                                    {entity}
-                                </li>
-                            ))}
-                        </ul>
-                    )}
-                    {this.includedEntityNames && (
-                        <button
-                            className="btn btn-light btn-clear-selection"
-                            onClick={this.onClearIncludedEntities}
-                        >
-                            <FontAwesomeIcon icon={faTrash} /> Clear start
-                            selection
-                        </button>
-                    )}
-                    <SelectField
-                        label={"Exclude individual entities"}
-                        placeholder={"Select an entity to exclude"}
-                        value={undefined}
-                        onValue={(v) => v && this.onExcludeEntity(v)}
-                        options={excludedEntityChoices.map((entry) => ({
-                            value: entry,
-                        }))}
-                    />
-                    {this.excludedEntityNames && (
-                        <ul className="excludedEntities">
-                            {this.excludedEntityNames.map((entity) => (
-                                <li key={entity}>
-                                    <div
-                                        className="clickable"
-                                        onClick={() =>
-                                            this.onUnexcludeEntity(entity)
-                                        }
-                                    >
-                                        <FontAwesomeIcon icon={faMinus} />
-                                    </div>
-                                    {entity}
-                                </li>
-                            ))}
-                        </ul>
-                    )}
-                    {this.excludedEntityNames && (
-                        <button
-                            className="btn btn-light btn-clear-selection"
-                            onClick={this.onClearExcludedEntities}
-                        >
-                            <FontAwesomeIcon icon={faTrash} /> Clear exclude
-                            list
-                        </button>
-                    )}
                 </Section>
             </div>
         )

--- a/adminSiteClient/EditorScatterTab.tsx
+++ b/adminSiteClient/EditorScatterTab.tsx
@@ -1,13 +1,10 @@
-import { faMinus, faTrash } from "@fortawesome/free-solid-svg-icons"
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
 import {
-    EntityName,
     ComparisonLineConfig,
     ScatterPointLabelStrategy,
 } from "@ourworldindata/types"
 import { Grapher } from "@ourworldindata/grapher"
 import { debounce } from "@ourworldindata/utils"
-import { action, computed, observable } from "mobx"
+import { action, observable } from "mobx"
 import { observer } from "mobx-react"
 import { Component } from "react"
 import { NumberField, Section, SelectField, Toggle } from "./Forms.js"
@@ -32,74 +29,6 @@ export class EditorScatterTab extends Component<{ grapher: Grapher }> {
         this.props.grapher.xOverrideTime = value
     }
 
-    @computed private get includedEntityNames(): EntityName[] {
-        return this.props.grapher.includedEntityNames ?? []
-    }
-
-    @computed private get excludedEntityNames(): EntityName[] {
-        return this.props.grapher.excludedEntityNames ?? []
-    }
-
-    @computed private get includedEntityChoices() {
-        const { inputTable, includedEntityNames = [] } = this.props.grapher
-        return inputTable.availableEntityNames
-            .filter((entityName) => !includedEntityNames.includes(entityName))
-            .sort()
-    }
-
-    @computed private get excludedEntityChoices() {
-        const { inputTable, excludedEntityNames = [] } = this.props.grapher
-        return inputTable.availableEntityNames
-            .filter((entityName) => !excludedEntityNames.includes(entityName))
-            .sort()
-    }
-
-    @action.bound onExcludeEntity(entityName: string) {
-        const { grapher } = this.props
-        if (grapher.excludedEntityNames === undefined) {
-            grapher.excludedEntityNames = []
-        }
-
-        if (!grapher.excludedEntityNames.includes(entityName))
-            grapher.excludedEntityNames.push(entityName)
-    }
-
-    @action.bound onUnexcludeEntity(entityName: string) {
-        const { grapher } = this.props
-        if (!grapher.excludedEntityNames) return
-        grapher.excludedEntityNames = grapher.excludedEntityNames.filter(
-            (e) => e !== entityName
-        )
-    }
-
-    @action.bound onIncludeEntity(entityName: string) {
-        const { grapher } = this.props
-        if (grapher.includedEntityNames === undefined) {
-            grapher.includedEntityNames = []
-        }
-
-        if (!grapher.includedEntityNames.includes(entityName))
-            grapher.includedEntityNames.push(entityName)
-    }
-
-    @action.bound onUnincludeEntity(entityName: string) {
-        const { grapher } = this.props
-        if (!grapher.includedEntityNames) return
-        grapher.includedEntityNames = grapher.includedEntityNames.filter(
-            (e) => e !== entityName
-        )
-    }
-
-    @action.bound onClearExcludedEntities() {
-        const { grapher } = this.props
-        grapher.excludedEntityNames = []
-    }
-
-    @action.bound onClearIncludedEntities() {
-        const { grapher } = this.props
-        grapher.includedEntityNames = []
-    }
-
     @action.bound onToggleConnection(value: boolean) {
         const { grapher } = this.props
         grapher.hideConnectedScatterLines = value
@@ -111,7 +40,6 @@ export class EditorScatterTab extends Component<{ grapher: Grapher }> {
     }
 
     render() {
-        const { includedEntityChoices, excludedEntityChoices } = this
         const { grapher } = this.props
 
         return (
@@ -158,80 +86,6 @@ export class EditorScatterTab extends Component<{ grapher: Grapher }> {
                                     value || undefined)
                         )}
                     />
-                </Section>
-                <Section name="Manual entity selection">
-                    <SelectField
-                        label={
-                            "Explicit start selection (leave empty to show all entities)"
-                        }
-                        placeholder={"Select an entity to include"}
-                        value={undefined}
-                        onValue={(v) => v && this.onIncludeEntity(v)}
-                        options={includedEntityChoices.map((entry) => ({
-                            value: entry,
-                        }))}
-                    />
-                    {this.includedEntityNames && (
-                        <ul className="includedEntities">
-                            {this.includedEntityNames.map((entity) => (
-                                <li key={entity}>
-                                    <div
-                                        className="clickable"
-                                        onClick={() =>
-                                            this.onUnincludeEntity(entity)
-                                        }
-                                    >
-                                        <FontAwesomeIcon icon={faMinus} />
-                                    </div>
-                                    {entity}
-                                </li>
-                            ))}
-                        </ul>
-                    )}
-                    {this.includedEntityNames && (
-                        <button
-                            className="btn btn-light btn-clear-selection"
-                            onClick={this.onClearIncludedEntities}
-                        >
-                            <FontAwesomeIcon icon={faTrash} /> Clear start
-                            selection
-                        </button>
-                    )}
-                    <SelectField
-                        label="Exclude individual entities"
-                        placeholder="Select an entity to exclude"
-                        value={undefined}
-                        onValue={(v) => v && this.onExcludeEntity(v)}
-                        options={excludedEntityChoices.map((entry) => ({
-                            value: entry,
-                        }))}
-                    />
-                    {this.excludedEntityNames && (
-                        <ul className="excludedEntities">
-                            {this.excludedEntityNames.map((entity) => (
-                                <li key={entity}>
-                                    <div
-                                        className="clickable"
-                                        onClick={() =>
-                                            this.onUnexcludeEntity(entity)
-                                        }
-                                    >
-                                        <FontAwesomeIcon icon={faMinus} />
-                                    </div>
-                                    {entity}
-                                </li>
-                            ))}
-                        </ul>
-                    )}
-                    {this.excludedEntityNames && (
-                        <button
-                            className="btn btn-light btn-clear-selection"
-                            onClick={this.onClearExcludedEntities}
-                        >
-                            <FontAwesomeIcon icon={faTrash} /> Clear exclude
-                            list
-                        </button>
-                    )}
                 </Section>
             </div>
         )

--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -588,11 +588,14 @@ $nav-height: 45px;
 }
 
 .EditorScatterTab,
-.EditorMarimekkoTab {
+.EditorMarimekkoTab,
+.EditorDataTab {
     .form-group > label {
         margin-bottom: 0.3rem;
     }
+}
 
+.EditorDataTab {
     ul.excludedEntities,
     ul.includedEntities {
         padding: 0;

--- a/packages/@ourworldindata/core-table/src/OwidTable.ts
+++ b/packages/@ourworldindata/core-table/src/OwidTable.ts
@@ -167,6 +167,39 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
         )
     }
 
+    filterByEntityNamesUsingIncludeExcludePattern({
+        excluded,
+        included,
+    }: {
+        excluded?: EntityName[]
+        included?: EntityName[]
+    }): this {
+        if (!included && !excluded) return this
+
+        const excludedSet = new Set(excluded)
+        const includedSet = new Set(included)
+
+        const excludeFilter = (entityName: EntityName): boolean =>
+            !excludedSet.has(entityName)
+        const includeFilter =
+            includedSet.size > 0
+                ? (entityName: EntityName): boolean =>
+                      includedSet.has(entityName)
+                : (): boolean => true
+
+        const filterFn = (entityName: any): boolean =>
+            excludeFilter(entityName) && includeFilter(entityName)
+
+        const excludedList = excluded ? excluded.join(", ") : ""
+        const includedList = included ? included.join(", ") : ""
+
+        return this.columnFilter(
+            this.entityNameSlug,
+            filterFn,
+            `Excluded entities specified by author: ${excludedList} - Included entities specified by author: ${includedList}`
+        )
+    }
+
     // Does a stable sort by time. You can refer to this table for fast time filtering.
     @imemo private get sortedByTime(): this {
         if (this.timeColumn.isMissing) return this

--- a/packages/@ourworldindata/explorer/src/Explorer.tsx
+++ b/packages/@ourworldindata/explorer/src/Explorer.tsx
@@ -476,7 +476,7 @@ export class Explorer
     @action.bound private setGrapherTable(table: OwidTable) {
         if (this.grapher) {
             this.grapher.inputTable = table
-            this.grapher.appendNewEntitySelectionOptions()
+            this.grapher.updateAvailableEntitiesOfSelection()
         }
     }
 
@@ -1077,7 +1077,7 @@ export class Explorer
     }
 
     @computed get grapherTable() {
-        return this.grapher?.tableAfterAuthorTimelineFilter
+        return this.grapher?.tableAfterAuthorTimelineAndEntityFilter
     }
 
     @observable entityPickerMetric? = this.initialQueryParams.pickerMetric

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
@@ -7,7 +7,6 @@ import {
     SeriesName,
     Color,
     EntityName,
-    OwidTableSlugs,
     ColorSchemeName,
     ValueRange,
     ColumnSlug,
@@ -135,39 +134,7 @@ export class ScatterPlotChart
         series: ScatterSeries
     }>()
 
-    private filterManuallySelectedEntities(table: OwidTable): OwidTable {
-        const { includedEntityNames, excludedEntityNames } = this.manager
-
-        if (!includedEntityNames && !excludedEntityNames) return table
-
-        const excludedSet = new Set(excludedEntityNames)
-        const includedSet = new Set(includedEntityNames)
-
-        const excludeFilter = (entityName: EntityName): boolean =>
-            !excludedSet.has(entityName)
-        const includeFilter = (entityName: EntityName): boolean =>
-            includedSet.size > 0 ? includedSet.has(entityName) : true
-
-        const filterFn = (entityName: any): boolean =>
-            excludeFilter(entityName) && includeFilter(entityName)
-
-        const excludedList = excludedEntityNames
-            ? excludedEntityNames.join(", ")
-            : ""
-        const includedList = includedEntityNames
-            ? includedEntityNames.join(", ")
-            : ""
-
-        return table.columnFilter(
-            OwidTableSlugs.entityName,
-            filterFn,
-            `Excluded entities specified by author: ${excludedList} - Included entities specified by author: ${includedList}`
-        )
-    }
-
     transformTable(table: OwidTable): OwidTable {
-        table = this.filterManuallySelectedEntities(table)
-
         if (this.xScaleType === ScaleType.log && this.xColumnSlug)
             table = table.replaceNonPositiveCellsForLogScale([this.xColumnSlug])
 
@@ -228,8 +195,6 @@ export class ScatterPlotChart
     }
 
     transformTableForDisplay(table: OwidTable): OwidTable {
-        table = this.filterManuallySelectedEntities(table)
-
         // Drop any rows which have non-number values for X or Y.
         table = table
             .columnFilter(
@@ -287,8 +252,6 @@ export class ScatterPlotChart
             animationStartTime,
             animationEndTime
         )
-
-        table = this.filterManuallySelectedEntities(table)
 
         if (this.manager.matchingEntitiesOnly && !this.colorColumn.isMissing) {
             table = table.filterByEntityNames(

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChartConstants.ts
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChartConstants.ts
@@ -29,8 +29,6 @@ export interface ScatterPlotManager extends ChartManager {
     addCountryMode?: EntitySelectionMode
     xOverrideTime?: Time | undefined
     tableAfterAuthorTimelineAndActiveChartTransform?: OwidTable
-    includedEntityNames?: EntityName[]
-    excludedEntityNames?: EntityName[]
     startTime?: Time
     endTime?: Time
     hasTimeline?: boolean

--- a/packages/@ourworldindata/grapher/src/selection/SelectionArray.ts
+++ b/packages/@ourworldindata/grapher/src/selection/SelectionArray.ts
@@ -60,6 +60,11 @@ export class SelectionArray {
         return this
     }
 
+    @action.bound setAvailableEntities(entities: Entity[]): this {
+        this.availableEntities = entities
+        return this
+    }
+
     @action.bound selectAll(): this {
         return this.addToSelection(this.unselectedEntityNames)
     }

--- a/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChart.tsx
@@ -37,7 +37,6 @@ import { ChartInterface } from "../chart/ChartInterface"
 import {
     EntityName,
     OwidVariableRow,
-    OwidTableSlugs,
     VerticalAlign,
 } from "@ourworldindata/types"
 import { OwidTable, CoreColumn } from "@ourworldindata/core-table"
@@ -276,41 +275,9 @@ export class MarimekkoChart
         entityName: string
     }>()
 
-    private filterManuallySelectedEntities(table: OwidTable): OwidTable {
-        const { includedEntityNames, excludedEntityNames } = this.manager
-
-        if (!includedEntityNames && !excludedEntityNames) return table
-
-        const excludedSet = new Set(excludedEntityNames)
-        const includedSet = new Set(includedEntityNames)
-
-        const excludeFilter = (entityName: EntityName): boolean =>
-            !excludedSet.has(entityName)
-        const includeFilter = (entityName: EntityName): boolean =>
-            includedSet.size > 0 ? includedSet.has(entityName) : true
-
-        const filterFn = (entityName: any): boolean =>
-            excludeFilter(entityName) && includeFilter(entityName)
-
-        const excludedList = excludedEntityNames
-            ? excludedEntityNames.join(", ")
-            : ""
-        const includedList = includedEntityNames
-            ? includedEntityNames.join(", ")
-            : ""
-
-        return table.columnFilter(
-            OwidTableSlugs.entityName,
-            filterFn,
-            `Excluded entities specified by author: ${excludedList} - Included entities specified by author: ${includedList}`
-        )
-    }
-
     transformTable(table: OwidTable): OwidTable {
         const { yColumnSlugs, manager, colorColumnSlug, xColumnSlug } = this
         if (!this.yColumnSlugs.length) return table
-
-        table = this.filterManuallySelectedEntities(table)
 
         // TODO: remove this filter once we don't have mixed type columns in datasets
         table = table.replaceNonNumericCellsWithErrorValues(yColumnSlugs)
@@ -346,10 +313,6 @@ export class MarimekkoChart
         }
 
         return table
-    }
-
-    transformTableForDisplay(table: OwidTable): OwidTable {
-        return this.filterManuallySelectedEntities(table)
     }
 
     @computed get inputTable(): OwidTable {

--- a/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChartConstants.ts
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChartConstants.ts
@@ -17,8 +17,6 @@ export interface MarimekkoChartManager extends ChartManager {
     tableAfterAuthorTimelineAndActiveChartTransform?: OwidTable
     sortConfig?: SortConfig
     hideNoDataArea?: boolean
-    excludedEntityNames?: EntityName[]
-    includedEntityNames?: EntityName[]
 }
 
 export interface EntityColorData {


### PR DESCRIPTION
Allows to exclude entities for all chart types (used to be supported for Scatter and Marimekko only).

Entity exclusion is similar to the author's timeline filter in the sense that it should seem like the excluded entities simply don't exist, so the entity exclusion runs as early as the author timeline filter.

