### PR TITLE
✨ Privacy Policy front-matter

### DIFF
--- a/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
@@ -219,6 +219,7 @@ export interface OwidGdocAboutContent {
     excerpt?: string
     "featured-image"?: string
     authors: string[]
+    "hide-nav"?: boolean
     body: OwidEnrichedGdocBlock[]
     refs?: { definitions: RefDictionary; errors: OwidGdocErrorMessage[] }
 }

--- a/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
@@ -220,6 +220,10 @@ export interface OwidGdocAboutContent {
     "featured-image"?: string
     authors: string[]
     "hide-nav"?: boolean
+    // By default, all about pages render with the title "About" even if they have a title set
+    // (which we use in the gdocs index page in the admin)
+    // This boolean makes it so that the title is used in *both* locations
+    "override-title"?: boolean
     body: OwidEnrichedGdocBlock[]
     refs?: { definitions: RefDictionary; errors: OwidGdocErrorMessage[] }
 }

--- a/site/gdocs/pages/AboutPage.tsx
+++ b/site/gdocs/pages/AboutPage.tsx
@@ -8,10 +8,11 @@ import { ArticleBlocks } from "../components/ArticleBlocks.js"
 import Footnotes from "../components/Footnotes.js"
 
 export default function AboutPage({ content, slug }: OwidGdocAboutInterface) {
+    const shouldOverrideTitle = content["override-title"]
     return (
         <main className="about-page centered-article-container grid grid-cols-12-full-width">
             <h1 className="about-header col-start-2 col-end-limit display-2-semibold">
-                {content.title || "About"}
+                {(shouldOverrideTitle && content.title) || "About"}
             </h1>
             <AboutNav slug={slug} hideNav={content["hide-nav"]} />
             <div className="about-body grid grid-cols-12-full-width col-start-1 col-end-limit">

--- a/site/gdocs/pages/AboutPage.tsx
+++ b/site/gdocs/pages/AboutPage.tsx
@@ -11,9 +11,9 @@ export default function AboutPage({ content, slug }: OwidGdocAboutInterface) {
     return (
         <main className="about-page centered-article-container grid grid-cols-12-full-width">
             <h1 className="about-header col-start-2 col-end-limit display-2-semibold">
-                About
+                {content.title || "About"}
             </h1>
-            <AboutNav slug={slug} />
+            <AboutNav slug={slug} hideNav={content["hide-nav"]} />
             <div className="about-body grid grid-cols-12-full-width col-start-1 col-end-limit">
                 <ArticleBlocks
                     containerType="about-page"
@@ -27,7 +27,7 @@ export default function AboutPage({ content, slug }: OwidGdocAboutInterface) {
     )
 }
 
-function AboutNav({ slug }: { slug: string }) {
+function AboutNav({ slug, hideNav }: { slug: string; hideNav?: boolean }) {
     const activeLinkRef = useRef<HTMLAnchorElement>(null)
 
     // Scroll the nav to the active link, since it might not be visible
@@ -46,6 +46,8 @@ function AboutNav({ slug }: { slug: string }) {
             }
         }
     }, [])
+
+    if (hideNav) return null
 
     return (
         <nav className="about-nav grid grid-cols-12-full-width col-start-1 col-end-limit">

--- a/site/gdocs/pages/AboutPage.tsx
+++ b/site/gdocs/pages/AboutPage.tsx
@@ -14,7 +14,7 @@ export default function AboutPage({ content, slug }: OwidGdocAboutInterface) {
             <h1 className="about-header col-start-2 col-end-limit display-2-semibold">
                 {(shouldOverrideTitle && content.title) || "About"}
             </h1>
-            <AboutNav slug={slug} hideNav={content["hide-nav"]} />
+            {!content["hide-nav"] && <AboutNav slug={slug} />}
             <div className="about-body grid grid-cols-12-full-width col-start-1 col-end-limit">
                 <ArticleBlocks
                     containerType="about-page"
@@ -28,7 +28,7 @@ export default function AboutPage({ content, slug }: OwidGdocAboutInterface) {
     )
 }
 
-function AboutNav({ slug, hideNav }: { slug: string; hideNav?: boolean }) {
+function AboutNav({ slug }: { slug: string }) {
     const activeLinkRef = useRef<HTMLAnchorElement>(null)
 
     // Scroll the nav to the active link, since it might not be visible
@@ -47,8 +47,6 @@ function AboutNav({ slug, hideNav }: { slug: string; hideNav?: boolean }) {
             }
         }
     }, [])
-
-    if (hideNav) return null
 
     return (
         <nav className="about-nav grid grid-cols-12-full-width col-start-1 col-end-limit">


### PR DESCRIPTION
Adds 2 new features to our about pages

1. `hide-nav` in the front-matter, to hide the about page nav
2. `override-title` in the front matter, to support existing About pages, and also the upcoming Privacy Policy page (which needs an actual title)

It's hard to imagine a scenario where we'd want one without the other, but given that they were both trivial to add and we won't be making many of them, I figured it was better to be explicit.


## To test
Create a gdoc with the following front-matter:
```
title: My custom about page title
type: about-page
hide-nav: true
override-title: true
```