### PR TITLE
🔨 remove availableEntities from SelectionArray

### DIFF
--- a/adminSiteClient/EditorBasicTab.tsx
+++ b/adminSiteClient/EditorBasicTab.tsx
@@ -124,7 +124,9 @@ class DimensionSlotView<
     @action.bound private updateDefaultSelection() {
         const { grapher } = this.props.editor
         const { selection } = grapher
-        const { availableEntityNames, availableEntityNameSet } = selection
+
+        const availableEntityNames = grapher.availableEntityNames
+        const availableEntityNameSet = new Set(grapher.availableEntityNames)
 
         if (grapher.isScatter || grapher.isMarimekko) {
             // chart types that display all entities by default shouldn't select any by default

--- a/adminSiteClient/EditorDataTab.tsx
+++ b/adminSiteClient/EditorDataTab.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
 import {
+    difference,
     differenceOfSets,
     moveArrayItemToIndex,
     omit,
@@ -179,7 +180,12 @@ export class EntitySelectionSection extends React.Component<{
         const { editor } = this
         const { grapher } = editor
         const { selection } = grapher
-        const { unselectedEntityNames, selectedEntityNames } = selection
+        const { selectedEntityNames } = selection
+
+        const unselectedEntityNames = difference(
+            grapher.availableEntityNames,
+            selectedEntityNames
+        )
 
         const isEntitySelectionInherited = editor.isPropertyInherited(
             "selectedEntityNames"
@@ -450,7 +456,6 @@ class EntityFilterSection<
     @action.bound validateSelectionAndFocus() {
         this.editor.removeInvalidSelectedEntityNames()
         this.editor.removeInvalidFocusedSeriesNames()
-        this.editor.grapher.updateAvailableEntitiesOfSelection()
     }
 
     @action.bound onExcludeEntity(entityName: string) {

--- a/packages/@ourworldindata/explorer/src/Explorer.tsx
+++ b/packages/@ourworldindata/explorer/src/Explorer.tsx
@@ -8,6 +8,7 @@ import {
     TableSlug,
     GrapherInterface,
     GrapherQueryParams,
+    EntityName,
 } from "@ourworldindata/types"
 import {
     OwidTable,
@@ -461,8 +462,11 @@ export class Explorer
     @action.bound private setGrapherTable(table: OwidTable) {
         if (this.grapher) {
             this.grapher.inputTable = table
-            this.grapher.updateAvailableEntitiesOfSelection()
         }
+    }
+
+    @computed get availableEntityNames(): EntityName[] {
+        return this.grapher?.availableEntityNames ?? []
     }
 
     private futureGrapherTable = new PromiseSwitcher<OwidTable>({

--- a/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChart.test.ts
+++ b/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChart.test.ts
@@ -16,7 +16,7 @@ import { OwidDistinctColorScheme } from "../color/CustomSchemes"
 
 it("can create a new bar chart", () => {
     const table = SynthesizeGDPTable({ timeRange: [2000, 2001] })
-    const selection = new SelectionArray([], table.availableEntities)
+    const selection = new SelectionArray()
     const manager: DiscreteBarChartManager = {
         table,
         selection,
@@ -26,7 +26,7 @@ it("can create a new bar chart", () => {
     const chart = new DiscreteBarChart({ manager })
 
     expect(chart.failMessage).toBeTruthy()
-    selection.selectAll()
+    selection.setSelectedEntities(table.availableEntityNames)
     expect(chart.failMessage).toEqual("")
 
     const series = chart.series

--- a/packages/@ourworldindata/grapher/src/controls/entityPicker/EntityPicker.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/entityPicker/EntityPicker.tsx
@@ -177,7 +177,8 @@ export class EntityPicker extends React.Component<{
     }
 
     @computed private get availableEntitiesForCurrentView(): Set<string> {
-        if (!this.grapherTable) return this.selection.availableEntityNameSet
+        if (!this.grapherTable)
+            return new Set(this.manager.availableEntityNames)
         if (!this.manager.requiredColumnSlugs?.length)
             return this.grapherTable.availableEntityNameSet
         return this.grapherTable.entitiesWith(this.manager.requiredColumnSlugs)
@@ -209,9 +210,10 @@ export class EntityPicker extends React.Component<{
 
     @computed
     private get entitiesWithMetricValue(): EntityOptionWithMetricValue[] {
-        const { metricTable, selection, localEntityNames } = this
+        const { metricTable, localEntityNames } = this
         const col = this.activePickerMetricColumn
-        const entityNames = selection.availableEntityNames.slice().sort()
+        const entityNames =
+            this.manager.availableEntityNames?.slice().sort() ?? []
         return entityNames.map((entityName) => {
             const plotValue =
                 col && metricTable?.has(col.slug)

--- a/packages/@ourworldindata/grapher/src/controls/entityPicker/EntityPickerConstants.ts
+++ b/packages/@ourworldindata/grapher/src/controls/entityPicker/EntityPickerConstants.ts
@@ -1,7 +1,7 @@
 import { ColumnSlug } from "@ourworldindata/utils"
 import { GrapherAnalytics } from "../../core/GrapherAnalytics"
 import { OwidTable } from "@ourworldindata/core-table"
-import { CoreColumnDef, SortOrder } from "@ourworldindata/types"
+import { CoreColumnDef, EntityName, SortOrder } from "@ourworldindata/types"
 import { SelectionArray } from "../../selection/SelectionArray"
 import { FocusArray } from "../../focus/FocusArray"
 
@@ -21,4 +21,5 @@ export interface EntityPickerManager {
     entityType?: string
     analytics?: GrapherAnalytics
     focusArray?: FocusArray
+    availableEntityNames?: EntityName[]
 }

--- a/packages/@ourworldindata/grapher/src/core/Grapher.jsdom.test.ts
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.jsdom.test.ts
@@ -184,7 +184,7 @@ it("can generate a url with country selection even if there is no entity code", 
     }
     const grapher = new Grapher(config)
     expect(grapher.queryStr).toBe("")
-    grapher.selection.selectAll()
+    grapher.selection.setSelectedEntities(grapher.availableEntityNames)
     expect(grapher.queryStr).toContain("AFG")
 
     const config2 = {
@@ -196,7 +196,7 @@ it("can generate a url with country selection even if there is no entity code", 
     )!.code = undefined as any
     const grapher2 = new Grapher(config2)
     expect(grapher2.queryStr).toBe("")
-    grapher2.selection.selectAll()
+    grapher2.selection.setSelectedEntities(grapher.availableEntityNames)
     expect(grapher2.queryStr).toContain("AFG")
 })
 

--- a/packages/@ourworldindata/grapher/src/selection/SelectionArray.test.ts
+++ b/packages/@ourworldindata/grapher/src/selection/SelectionArray.test.ts
@@ -3,13 +3,10 @@
 import { SelectionArray } from "./SelectionArray"
 
 it("can create a selection", () => {
-    const selection = new SelectionArray(
-        [],
-        [{ entityName: "USA" }, { entityName: "Canada" }]
-    )
+    const selection = new SelectionArray()
     expect(selection.hasSelection).toEqual(false)
 
-    selection.selectAll()
+    selection.setSelectedEntities(["USA", "Canada"])
     expect(selection.hasSelection).toEqual(true)
     expect(selection.selectedEntityNames).toEqual(["USA", "Canada"])
 })

--- a/packages/@ourworldindata/grapher/src/selection/SelectionArray.ts
+++ b/packages/@ourworldindata/grapher/src/selection/SelectionArray.ts
@@ -1,39 +1,15 @@
-import { EntityCode, EntityId, EntityName } from "@ourworldindata/types"
-import { difference } from "@ourworldindata/utils"
+import { EntityName } from "@ourworldindata/types"
 import { action, computed, observable } from "mobx"
 
-export interface Entity {
-    entityName: EntityName
-    entityId?: EntityId
-    entityCode?: EntityCode
-}
-
 export class SelectionArray {
-    constructor(
-        selectedEntityNames: EntityName[] = [],
-        availableEntities: Entity[] = []
-    ) {
+    constructor(selectedEntityNames: EntityName[] = []) {
         this.selectedEntityNames = selectedEntityNames.slice()
-        this.availableEntities = availableEntities.slice()
     }
 
     @observable selectedEntityNames: EntityName[]
-    @observable private availableEntities: Entity[]
-
-    @computed get availableEntityNames(): string[] {
-        return this.availableEntities.map((entity) => entity.entityName)
-    }
-
-    @computed get availableEntityNameSet(): Set<string> {
-        return new Set(this.availableEntityNames)
-    }
 
     @computed get hasSelection(): boolean {
         return this.selectedEntityNames.length > 0
-    }
-
-    @computed get unselectedEntityNames(): string[] {
-        return difference(this.availableEntityNames, this.selectedEntityNames)
     }
 
     @computed get numSelectedEntities(): number {
@@ -55,20 +31,6 @@ export class SelectionArray {
         return this
     }
 
-    @action.bound addAvailableEntityNames(entities: Entity[]): this {
-        this.availableEntities.push(...entities)
-        return this
-    }
-
-    @action.bound setAvailableEntities(entities: Entity[]): this {
-        this.availableEntities = entities
-        return this
-    }
-
-    @action.bound selectAll(): this {
-        return this.addToSelection(this.unselectedEntityNames)
-    }
-
     @action.bound clearSelection(): void {
         this.selectedEntityNames = []
     }
@@ -77,10 +39,6 @@ export class SelectionArray {
         return this.selectedSet.has(entityName)
             ? this.deselectEntity(entityName)
             : this.selectEntity(entityName)
-    }
-
-    @computed get numAvailableEntityNames(): number {
-        return this.availableEntityNames.length
     }
 
     @action.bound selectEntity(entityName: EntityName): this {
@@ -106,12 +64,5 @@ export class SelectionArray {
             (name) => !entityNames.includes(name)
         )
         return this
-    }
-
-    // Mainly for testing
-    @action.bound selectSample(howMany = 1): this {
-        return this.setSelectedEntities(
-            this.availableEntityNames.slice(0, howMany)
-        )
     }
 }

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.test.ts
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.test.ts
@@ -110,10 +110,7 @@ describe("series naming in multi-column mode", () => {
     })
 
     it("combines entity and column name if multiple entities are selected and multi entity selection is disabled", () => {
-        const selection = new SelectionArray(
-            table.availableEntityNames,
-            table.availableEntities
-        )
+        const selection = new SelectionArray(table.availableEntityNames)
         const manager = {
             table,
             canSelectMultipleEntities: false,
@@ -242,10 +239,7 @@ describe("colors", () => {
             ]
         )
 
-        const selection = new SelectionArray(
-            ["usa", "canada"],
-            [{ entityName: "usa" }, { entityName: "canada" }]
-        )
+        const selection = new SelectionArray(["usa", "canada"])
         const manager: SlopeChartManager = {
             yColumnSlugs: ["gdp", "pop"],
             table: table,

--- a/packages/@ourworldindata/types/src/domainTypes/CoreTableTypes.ts
+++ b/packages/@ourworldindata/types/src/domainTypes/CoreTableTypes.ts
@@ -144,6 +144,12 @@ export type EntityName = string
 export type EntityCode = string
 export type EntityId = number
 
+export interface Entity {
+    entityName: EntityName
+    entityId?: EntityId
+    entityCode?: EntityCode
+}
+
 export enum ColumnTypeNames {
     NumberOrString = "NumberOrString",
     Numeric = "Numeric",

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -440,6 +440,7 @@ export {
     type EntityName,
     type EntityCode,
     type EntityId,
+    type Entity,
     type OwidColumnDef,
     OwidEntityNameColumnDef,
     OwidEntityIdColumnDef,


### PR DESCRIPTION
I tripped over the `availableEntities` of Grapher's selection in the last PR and wondered if it makes sense for the SelectionArray to manage both, the selected and the available entities.

I don't have a strong opinion but I am in slight favour of removing the available entities from the SelectionArray. I don't see a compelling reason for them to be part of the SelectionArray interface, and the fact that the available entities need to be kept up-to-date is a potential foot gun.

I also wonder if we could unify SelectionArray and FocusArray now that both essentially do the same thing (manage a selection).

Feel free to stop me – again, no strong opinion from my side.