### PR TITLE
🐛 hide full-screen button on small screens only

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -2550,6 +2550,7 @@ export class Grapher
 
     @computed get hideFullScreenButton(): boolean {
         if (this.isInFullScreenMode) return false
+        if (!this.isSmall) return false
         // hide the full screen button if the full screen height
         // is barely larger than the current chart height
         const fullScreenHeight = this.windowInnerHeight!


### PR DESCRIPTION
the full screen button is sometimes hidden when going into full-screen doesn't make a big difference or even makes the experience worse

but we should only hide the full screen button on smaller screens. it's weird if it's missing on desktop