### PR TITLE
✨ disable focus on touch devices

### DIFF
--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
@@ -24,6 +24,7 @@ import {
     Color,
     HorizontalAlign,
     makeIdForHumanConsumption,
+    isTouchDevice,
 } from "@ourworldindata/utils"
 import { computed, action, observable } from "mobx"
 import { observer } from "mobx-react"
@@ -815,6 +816,10 @@ export class LineChart
         return !this.focusArray.isEmpty
     }
 
+    @computed get canToggleFocusMode(): boolean {
+        return !isTouchDevice() && this.series.length > 1
+    }
+
     @computed private get hasEntityYearHighlight(): boolean {
         return this.props.manager.entityYearHighlight !== undefined
     }
@@ -988,7 +993,7 @@ export class LineChart
                         onMouseOver={this.onLineLegendMouseOver}
                         onMouseLeave={this.onLineLegendMouseLeave}
                         onClick={
-                            this.series.length > 1
+                            this.canToggleFocusMode
                                 ? this.onLineLegendClick
                                 : undefined
                         }

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
@@ -14,6 +14,7 @@ import {
     dyFromAlign,
     uniq,
     sortBy,
+    isTouchDevice,
 } from "@ourworldindata/utils"
 import { observable, computed, action } from "mobx"
 import { observer } from "mobx-react"
@@ -256,6 +257,10 @@ export class SlopeChart
 
     @computed get isFocusModeActive(): boolean {
         return !this.focusArray.isEmpty
+    }
+
+    @computed get canToggleFocusMode(): boolean {
+        return !isTouchDevice() && this.series.length > 1
     }
 
     @computed private get yColumns(): CoreColumn[] {
@@ -644,8 +649,9 @@ export class SlopeChart
             textOutlineColor: this.backgroundColor,
             onMouseOver: this.onLineLegendMouseOver,
             onMouseLeave: this.onLineLegendMouseLeave,
-            onClick:
-                this.series.length > 1 ? this.onLineLegendClick : undefined,
+            onClick: this.canToggleFocusMode
+                ? this.onLineLegendClick
+                : undefined,
         }
     }
 

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -552,7 +552,8 @@ export const isMobile = (): boolean =>
         ? false
         : !!window?.navigator?.userAgent.toLowerCase().includes("mobi")
 
-export const isTouchDevice = (): boolean => !!("ontouchstart" in window)
+export const isTouchDevice = (): boolean =>
+    typeof window === "undefined" ? false : !!("ontouchstart" in window)
 
 // General type representing arbitrary json data; basically a non-nullable 'any'
 export interface Json {


### PR DESCRIPTION
Disables focus mode on touch devices since users can easily accidentally end up in a focus state not being able to reset since they don't know how (I've seen this happen in session replays)