### PR TITLE
🐛 hide entity name when a single entity is selected in multi-indicator line and slope charts

### DIFF
--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChart.test.ts
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChart.test.ts
@@ -103,14 +103,14 @@ describe("series naming in multi-column mode", () => {
         expect(chart.series[0].seriesName).not.toContain(" – ")
     })
 
-    it("combines entity and column name if only one entity is selected and multi entity selection is enabled", () => {
+    it("only displays column name if only one entity is selected even if multi entity selection is enabled", () => {
         const manager = {
             table,
             canSelectMultipleEntities: true,
             selection: [table.availableEntityNames[0]],
         }
         const chart = new LineChart({ manager })
-        expect(chart.series[0].seriesName).toContain(" – ")
+        expect(chart.series[0].seriesName).not.toContain(" – ")
     })
 
     it("combines entity and column name if multiple entities are selected and multi entity selection is disabled", () => {
@@ -208,7 +208,6 @@ describe("colors", () => {
             selection: ["usa"],
             seriesStrategy: SeriesStrategy.column,
             facetStrategy: FacetStrategy.entity,
-            canSelectMultipleEntities: true,
         }
         const chart = new LineChart({ manager })
         const series = chart.series
@@ -241,7 +240,6 @@ describe("colors", () => {
             table: table,
             selection: ["usa", "canada"],
             seriesStrategy: SeriesStrategy.column,
-            canSelectMultipleEntities: true,
         }
         const chart = new LineChart({ manager })
         const series = chart.series

--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
@@ -106,7 +106,6 @@ import {
     AnnotationsMap,
     getAnnotationsForSeries,
     getAnnotationsMap,
-    getColorKey,
     getSeriesName,
 } from "./LineChartHelpers"
 import { FocusArray } from "../focus/FocusArray.js"
@@ -1246,8 +1245,7 @@ export class LineChart
         column: CoreColumn
     ): LineChartSeries {
         const {
-            manager: { canSelectMultipleEntities = false },
-            transformedTable: { availableEntityNames },
+            transformedTable: { availableEntityNames: selectedEntityNames },
             seriesStrategy,
             hasColorScale,
             colorColumn,
@@ -1285,8 +1283,7 @@ export class LineChart
             entityName,
             columnName,
             seriesStrategy,
-            availableEntityNames,
-            canSelectMultipleEntities,
+            selectedEntityNames,
         })
 
         let seriesColor: Color
@@ -1294,14 +1291,7 @@ export class LineChart
             const colorValue = last(points)?.colorValue
             seriesColor = this.getColorScaleColor(colorValue)
         } else {
-            seriesColor = this.categoricalColorAssigner.assign(
-                getColorKey({
-                    entityName,
-                    columnName,
-                    seriesStrategy,
-                    availableEntityNames,
-                })
-            )
+            seriesColor = this.categoricalColorAssigner.assign(seriesName)
         }
 
         return {

--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChartConstants.ts
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChartConstants.ts
@@ -51,5 +51,4 @@ export interface LinesProps {
 export interface LineChartManager extends ChartManager {
     entityYearHighlight?: EntityYearHighlight
     lineStrokeWidth?: number
-    canSelectMultipleEntities?: boolean // used to pick an appropriate series name
 }

--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChartHelpers.ts
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChartHelpers.ts
@@ -17,44 +17,20 @@ export function getSeriesName({
     entityName,
     columnName,
     seriesStrategy,
-    availableEntityNames,
-    canSelectMultipleEntities,
+    selectedEntityNames,
 }: {
     entityName: EntityName
     columnName: string
     seriesStrategy: SeriesStrategy
-    availableEntityNames: EntityName[]
-    canSelectMultipleEntities: boolean
+    selectedEntityNames: EntityName[]
 }): SeriesName {
     // if entities are plotted, use the entity name
     if (seriesStrategy === SeriesStrategy.entity) return entityName
 
     // if columns are plotted, use the column name
-    // and prepend the entity name if multiple entities can be selected
-    return availableEntityNames.length > 1 || canSelectMultipleEntities
+    // and prepend the entity name if multiple entities are selected
+    return selectedEntityNames.length > 1
         ? `${entityName} – ${columnName}`
-        : columnName
-}
-
-export function getColorKey({
-    entityName,
-    columnName,
-    seriesStrategy,
-    availableEntityNames,
-}: {
-    entityName: EntityName
-    columnName: string
-    seriesStrategy: SeriesStrategy
-    availableEntityNames: EntityName[]
-}): SeriesName {
-    // if entities are plotted, use the entity name
-    if (seriesStrategy === SeriesStrategy.entity) return entityName
-
-    // If only one entity is plotted, we want to use the column colors.
-    // Unlike in `getSeriesName`, we don't care whether the user can select
-    // multiple entities, only whether more than one is plotted.
-    return availableEntityNames.length > 1
-        ? `${entityName} - ${columnName}`
         : columnName
 }
 

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.test.ts
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.test.ts
@@ -99,14 +99,14 @@ describe("series naming in multi-column mode", () => {
         expect(chart.series[0].seriesName).not.toContain(" – ")
     })
 
-    it("combines entity and column name if only one entity is selected and multi entity selection is enabled", () => {
+    it("only displays column name if only one entity is selected even if multi entity selection is enabled", () => {
         const manager = {
             table,
             canSelectMultipleEntities: true,
             selection: [table.availableEntityNames[0]],
         }
         const chart = new SlopeChart({ manager })
-        expect(chart.series[0].seriesName).toContain(" – ")
+        expect(chart.series[0].seriesName).not.toContain(" – ")
     })
 
     it("combines entity and column name if multiple entities are selected and multi entity selection is disabled", () => {
@@ -208,7 +208,6 @@ describe("colors", () => {
             selection: ["usa"],
             seriesStrategy: SeriesStrategy.column,
             facetStrategy: FacetStrategy.entity,
-            canSelectMultipleEntities: true,
         }
         const chart = new SlopeChart({ manager })
         const series = chart.series
@@ -251,7 +250,6 @@ describe("colors", () => {
             table: table,
             selection,
             seriesStrategy: SeriesStrategy.column,
-            canSelectMultipleEntities: true,
         }
         const chart = new SlopeChart({ manager })
         const series = chart.series

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
@@ -78,7 +78,6 @@ import {
     AnnotationsMap,
     getAnnotationsForSeries,
     getAnnotationsMap,
-    getColorKey,
     getSeriesName,
 } from "../lineCharts/LineChartHelpers"
 import { SelectionArray } from "../selection/SelectionArray"
@@ -98,7 +97,6 @@ type SVGMouseOrTouchEvent =
     | React.TouchEvent<SVGGElement>
 
 export interface SlopeChartManager extends ChartManager {
-    canSelectMultipleEntities?: boolean // used to pick an appropriate series name
     hasTimeline?: boolean // used to filter the table for the entity selector
     hideNoDataSection?: boolean
 }
@@ -326,16 +324,15 @@ export class SlopeChart
         column: CoreColumn
     ): RawSlopeChartSeries {
         const { startTime, endTime, seriesStrategy } = this
-        const { canSelectMultipleEntities = false } = this.manager
 
-        const { availableEntityNames } = this.transformedTable
+        const { availableEntityNames: selectedEntityNames } =
+            this.transformedTable
         const columnName = column.nonEmptyDisplayName
         const props = {
             entityName,
             columnName,
             seriesStrategy,
-            availableEntityNames,
-            canSelectMultipleEntities,
+            selectedEntityNames,
         }
         const seriesName = getSeriesName(props)
         const displayName = getSeriesName({
@@ -347,8 +344,7 @@ export class SlopeChart
         const start = owidRowByTime?.get(startTime)
         const end = owidRowByTime?.get(endTime)
 
-        const colorKey = getColorKey(props)
-        const color = this.categoricalColorAssigner.assign(colorKey)
+        const color = this.categoricalColorAssigner.assign(seriesName)
 
         const annotation = getAnnotationsForSeries(
             this.annotationsMap,


### PR DESCRIPTION
Fixes #4600

I agree with Pablo R that not showing the entity name is the better default if a single entity is selected (regardless of the entity selection setting).

I can see in the code that showing the entity name in such cases was a deliberate choice, but ~I can't think of a good reason.~

We persist the series name in the URL, so ideally the series name of a line shouldn't change throughout a session. Working on a solution...