### PR TITLE
cleanup: don't query WP for related research posts

### DIFF
--- a/db/model/Post.ts
+++ b/db/model/Post.ts
@@ -485,14 +485,10 @@ export const getPostTags = async (
 }
 
 export interface RelatedResearchQueryResult {
-    linkTargetSlug: string
-    chartSlug: string
     title: string
     postSlug: string
-    chartId: number
     authors: string
     thumbnail: string
-    pageviews: number
     tags: string
 }
 
@@ -504,14 +500,10 @@ export const getRelatedResearchAndWritingForVariables = async (
         knex,
         `-- sql
         SELECT DISTINCT
-            pl.target AS linkTargetSlug,
-            COALESCE(csr.slug, cc.slug) AS chartSlug,
             p.content ->> '$.title' AS title,
             p.slug AS postSlug,
-            COALESCE(csr.chart_id, c.id) AS chartId,
-            authors,
+            p.authors,
             p.content ->> '$."featured-image"' AS thumbnail,
-            COALESCE(pv.views_365d, 0) AS pageviews,
             (
                 SELECT
                     COALESCE(JSON_ARRAYAGG(t.name), JSON_ARRAY())
@@ -532,12 +524,12 @@ export const getRelatedResearchAndWritingForVariables = async (
             LEFT JOIN posts_gdocs_x_tags pt ON pt.gdocId = p.id
         WHERE
             pl.linkType = 'grapher'
-            AND componentType = 'chart' -- this filters out links in tags and keeps only embedded charts
+            AND pl.componentType = 'chart' -- this filters out links in tags and keeps only embedded charts
             AND cd.variableId IN (?)
             AND cd.property IN ('x', 'y') -- ignore cases where the indicator is size, color etc
             AND p.published = 1
             AND p.type != 'fragment'
-        ORDER BY pageviews DESC`,
+        ORDER BY pv.pageviews DESC`,
         [variableIds]
     )
 

--- a/db/model/Post.ts
+++ b/db/model/Post.ts
@@ -27,7 +27,6 @@ import {
 } from "@ourworldindata/types"
 import {
     uniqBy,
-    sortBy,
     memoize,
     orderBy,
     keyBy,
@@ -487,7 +486,6 @@ export const getPostTags = async (
 
 export interface RelatedResearchQueryResult {
     linkTargetSlug: string
-    componentType: string
     chartSlug: string
     title: string
     postSlug: string
@@ -495,7 +493,6 @@ export interface RelatedResearchQueryResult {
     authors: string
     thumbnail: string
     pageviews: number
-    post_source: string
     tags: string
 }
 
@@ -503,73 +500,11 @@ export const getRelatedResearchAndWritingForVariables = async (
     knex: db.KnexReadonlyTransaction,
     variableIds: Iterable<number>
 ): Promise<DataPageRelatedResearch[]> => {
-    const wp_posts: RelatedResearchQueryResult[] = await db.knexRaw(
-        knex,
-        `-- sql
-            -- What we want here is to get from the variable to the charts
-            -- to the posts and collect different pieces of information along the way
-            -- One important complication is that the slugs that are used in posts to
-            -- embed charts can either be the current slugs or old slugs that are redirected
-            -- now.
-            SELECT DISTINCT
-                pl.target AS linkTargetSlug,
-                pl.componentType AS componentType,
-                COALESCE(csr.slug, cc.slug) AS chartSlug,
-                p.title AS title,
-                p.slug AS postSlug,
-                COALESCE(csr.chart_id, c.id) AS chartId,
-                p.authors AS authors,
-                p.featured_image AS thumbnail,
-                COALESCE(pv.views_365d, 0) AS pageviews,
-                'wordpress' AS post_source,
-                (
-                    SELECT
-                        COALESCE(JSON_ARRAYAGG(t.name), JSON_ARRAY())
-                    FROM
-                        post_tags pt
-                        JOIN tags t ON pt.tag_id = t.id
-                    WHERE
-                        pt.post_id = p.id
-                ) AS tags
-            FROM
-                posts_links pl
-                JOIN posts p ON pl.sourceId = p.id
-                LEFT JOIN chart_configs cc on pl.target = cc.slug
-                LEFT JOIN charts c ON cc.id = c.configId
-                LEFT JOIN chart_slug_redirects csr ON pl.target = csr.slug
-                LEFT JOIN chart_dimensions cd ON cd.chartId = COALESCE(csr.chart_id, c.id)
-                LEFT JOIN analytics_pageviews pv ON pv.url = CONCAT('https://ourworldindata.org/', p.slug)
-                LEFT JOIN posts_gdocs pg ON pg.id = p.gdocSuccessorId
-                LEFT JOIN posts_gdocs pgs ON pgs.slug = p.slug
-                LEFT JOIN post_tags pt ON pt.post_id = p.id
-            WHERE
-                -- we want only urls that point to grapher charts
-                pl.linkType = 'grapher'
-                -- componentType src is for those links that matched the anySrcregex (not anyHrefRegex or prominentLinkRegex)
-                -- this means that only the links that are of the iframe kind will be kept - normal a href style links will
-                -- be disregarded
-                AND componentType = 'src'
-                AND cd.variableId IN (?)
-                AND cd.property IN ('x', 'y') -- ignore cases where the indicator is size, color etc
-                AND p.status = 'publish' -- only use published wp posts
-                AND p.type != 'wp_block'
-                AND COALESCE(pg.published, 0) = 0 -- ignore posts if the wp post has a published gdoc successor. The
-                -- coalesce makes sure that if there is no gdoc successor then
-                -- the filter keeps the post
-                AND COALESCE(pgs.published, 0) = 0 -- ignore posts if there is a gdoc post with the same slug that is published
-                -- this case happens for example for topic pages that are newly created (successorId is null)
-                -- but that replace an old wordpress page
-
-            `,
-        [variableIds]
-    )
-
-    const gdocs_posts: RelatedResearchQueryResult[] = await db.knexRaw(
+    const gdocsPosts: RelatedResearchQueryResult[] = await db.knexRaw(
         knex,
         `-- sql
         SELECT DISTINCT
             pl.target AS linkTargetSlug,
-            pl.componentType AS componentType,
             COALESCE(csr.slug, cc.slug) AS chartSlug,
             p.content ->> '$.title' AS title,
             p.slug AS postSlug,
@@ -577,7 +512,6 @@ export const getRelatedResearchAndWritingForVariables = async (
             authors,
             p.content ->> '$."featured-image"' AS thumbnail,
             COALESCE(pv.views_365d, 0) AS pageviews,
-            'gdocs' AS post_source,
             (
                 SELECT
                     COALESCE(JSON_ARRAYAGG(t.name), JSON_ARRAY())
@@ -602,17 +536,12 @@ export const getRelatedResearchAndWritingForVariables = async (
             AND cd.variableId IN (?)
             AND cd.property IN ('x', 'y') -- ignore cases where the indicator is size, color etc
             AND p.published = 1
-            AND p.type != 'fragment'`,
+            AND p.type != 'fragment'
+        ORDER BY pageviews DESC`,
         [variableIds]
     )
 
-    const combined = [...wp_posts, ...gdocs_posts]
-
-    // we could do the sorting in the SQL query if we'd union the two queries
-    // but it seemed easier to understand if we do the sort here
-    const sorted = sortBy(combined, (post) => -post.pageviews)
-
-    const allSortedRelatedResearch = sorted.map((post) => {
+    const allSortedRelatedResearch = gdocsPosts.map((post) => {
         const parsedAuthors = JSON.parse(post.authors)
         const parsedTags = post.tags !== "" ? JSON.parse(post.tags) : []
 

--- a/site/dataPage.ts
+++ b/site/dataPage.ts
@@ -10,19 +10,7 @@ export function processRelatedResearch(
             const shared = intersection(research.tags, topicTags)
             return shared.length > 0
         })
-    } else {
-        relatedResearch = [...candidates]
-    }
-    for (const item of relatedResearch) {
-        // TODO: these are workarounds to not link to the (not really existing) template pages for energy or co2
-        // country profiles but instead to the topic page at the country selector.
-        if (item.url === "/co2-country-profile")
-            item.url =
-                "/co2-and-greenhouse-gas-emissions#co2-and-greenhouse-gas-emissions-country-profiles"
-        else if (item.url === "/energy-country-profile")
-            item.url = "/energy#country-profiles"
-        else if (item.url === "/coronavirus-country-profile")
-            item.url = "/coronavirus#coronavirus-country-profiles"
-    }
+    } else relatedResearch = [...candidates]
+
     return relatedResearch
 }


### PR DESCRIPTION
I noticed that we have this very complex query hanging around, which isn't really delivering any insightful results at this point.

You can find all the results this can ever find [over here, in this slightly adapted query](http://analytics/private?sql=--+What+we+want+here+is+to+get+from+the+variable+to+the+charts%0D%0A++++++++++++--+to+the+posts+and+collect+different+pieces+of+information+along+the+way%0D%0A++++++++++++--+One+important+complication+is+that+the+slugs+that+are+used+in+posts+to%0D%0A++++++++++++--+embed+charts+can+either+be+the+current+slugs+or+old+slugs+that+are+redirected%0D%0A++++++++++++--+now.%0D%0A++++++++++++SELECT+DISTINCT%0D%0A++++++++++++++++pl.target+AS+linkTargetSlug%2C%0D%0A++++++++++++++++COALESCE%28csr.slug%2C+cc.slug%29+AS+chartSlug%2C%0D%0A++++++++++++++++p.title+AS+title%2C%0D%0A++++++++++++++++p.slug+AS+postSlug%2C%0D%0A++++++++++++++++COALESCE%28csr.chart_id%2C+c.id%29+AS+chartId%2C%0D%0A++++++++++++++++p.authors+AS+authors%2C%0D%0A++++++++++++++++p.featured_image+AS+thumbnail%2C%0D%0A++++++++++++++++COALESCE%28pv.views_365d%2C+0%29+AS+pageviews%2C%0D%0A++++++++++++++++%27wordpress%27+AS+post_source%0D%0A++++++++++++++++--%28%0D%0A++++++++++++++++--++++SELECT%0D%0A++++++++++++++++--++++++++COALESCE%28JSON_ARRAYAGG%28t.name%29%2C+JSON_ARRAY%28%29%29%0D%0A++++++++++++++++--++++FROM%0D%0A++++++++++++++++--++++++++post_tags+pt%0D%0A++++++++++++++++--++++++++JOIN+tags+t+ON+pt.tag_id+%3D+t.id%0D%0A++++++++++++++++--++++WHERE%0D%0A++++++++++++++++--++++++++pt.post_id+%3D+p.id%0D%0A++++++++++++++++--%29+AS+tags%0D%0A++++++++++++FROM%0D%0A++++++++++++++++posts_links+pl%0D%0A++++++++++++++++JOIN+posts+p+ON+pl.sourceId+%3D+p.id%0D%0A++++++++++++++++LEFT+JOIN+chart_configs+cc+on+pl.target+%3D+cc.slug%0D%0A++++++++++++++++LEFT+JOIN+charts+c+ON+cc.id+%3D+c.configId%0D%0A++++++++++++++++LEFT+JOIN+chart_slug_redirects+csr+ON+pl.target+%3D+csr.slug%0D%0A++++++++++++++++LEFT+JOIN+chart_dimensions+cd+ON+cd.chartId+%3D+COALESCE%28csr.chart_id%2C+c.id%29%0D%0A++++++++++++++++LEFT+JOIN+analytics_pageviews+pv+ON+pv.url+%3D+CONCAT%28%27https%3A%2F%2Fourworldindata.org%2F%27%2C+p.slug%29%0D%0A++++++++++++++++LEFT+JOIN+posts_gdocs+pg+ON+pg.id+%3D+p.gdocSuccessorId%0D%0A++++++++++++++++LEFT+JOIN+posts_gdocs+pgs+ON+pgs.slug+%3D+p.slug%0D%0A++++++++++++++++LEFT+JOIN+post_tags+pt+ON+pt.post_id+%3D+p.id%0D%0A++++++++++++WHERE%0D%0A++++++++++++++++--+we+want+only+urls+that+point+to+grapher+charts%0D%0A++++++++++++++++pl.linkType+%3D+%27grapher%27%0D%0A++++++++++++++++--+componentType+src+is+for+those+links+that+matched+the+anySrcregex+%28not+anyHrefRegex+or+prominentLinkRegex%29%0D%0A++++++++++++++++--+this+means+that+only+the+links+that+are+of+the+iframe+kind+will+be+kept+-+normal+a+href+style+links+will%0D%0A++++++++++++++++--+be+disregarded%0D%0A++++++++++++++++AND+componentType+%3D+%27src%27%0D%0A++++++++++++++++AND+cd.property+IN+%28%27x%27%2C+%27y%27%29+--+ignore+cases+where+the+indicator+is+size%2C+color+etc%0D%0A++++++++++++++++AND+p.status+%3D+%27publish%27+--+only+use+published+wp+posts%0D%0A++++++++++++++++AND+p.type+%21%3D+%27wp_block%27%0D%0A++++++++++++++++AND+COALESCE%28pg.published%2C+0%29+%3D+0+--+ignore+posts+if+the+wp+post+has+a+published+gdoc+successor.+The%0D%0A++++++++++++++++--+coalesce+makes+sure+that+if+there+is+no+gdoc+successor+then%0D%0A++++++++++++++++--+the+filter+keeps+the+post%0D%0A++++++++++++++++AND+COALESCE%28pgs.published%2C+0%29+%3D+0+--+ignore+posts+if+there+is+a+gdoc+post+with+the+same+slug+that+is+published%0D%0A++++++++++++++++--+this+case+happens+for+example+for+topic+pages+that+are+newly+created+%28successorId+is+null%29%0D%0A++++++++++++++++--+but+that+replace+an+old+wordpress+page%0D%0A+++++++++++++ORDER+BY+postSlug). Take a special look at `postSlug` - all of these are not really pages we want to link to, at this point.

For an example of a page that links out to the Energy country profile currently, see https://ourworldindata.org/grapher/change-energy-consumption vs http://staging-site-related-research-drop-wp/grapher/change-energy-consumption.