### PR TITLE
enhance: use Structured Outputs for OpenAI topic suggestions

### DIFF
--- a/db/model/Chart.ts
+++ b/db/model/Chart.ts
@@ -478,8 +478,10 @@ export async function getGptTopicSuggestions(
         throw new JsonError("No response from GPT", 500)
 
     // We only want to return topics that are in the list of possible topics
-    const confirmedTopics = parsedResponse.topics.filter((topic) =>
-        topics.some((t) => t.id === topic.id)
+    const confirmedTopics = topics.filter((topic) =>
+        parsedResponse.topics.some(
+            (t) => t.id === topic.id && t.name === topic.name
+        )
     )
 
     return confirmedTopics

--- a/db/model/Chart.ts
+++ b/db/model/Chart.ts
@@ -444,9 +444,11 @@ export async function getGptTopicSuggestions(
                 <listed-on>${enrichedChartConfig.originUrl}</listed-on>
             </chart>
             <topics>
-                ${topics.map(
-                    (topic) => `<topic id=${topic.id}>${topic.name}</topic>\n`
-                )}
+                ${topics
+                    .map(
+                        (topic) => `<topic id=${topic.id}>${topic.name}</topic>`
+                    )
+                    .join("\n")}
             </topics>
 
             Respond with the two categories you think best describe the chart.
@@ -462,7 +464,7 @@ export async function getGptTopicSuggestions(
     })
     const completion = await openai.chat.completions.create({
         messages: [{ role: "user", content: prompt }],
-        model: "gpt-4-1106-preview",
+        model: "gpt-4o",
     })
 
     const json = completion.choices[0]?.message?.content

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
         "mysql2": "^3.10.1",
         "nodejs-polars": "^0.7.2",
         "normalize.css": "^8.0.1",
-        "openai": "^4.47.1",
+        "openai": "^4.85.4",
         "p-map": "^4.0.0",
         "papaparse": "^5.4.1",
         "progress": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -173,7 +173,8 @@
         "webfontloader": "^1.6.28",
         "workerpool": "^6.2.0",
         "yaml": "^2.4.2",
-        "yargs": "^17.7.2"
+        "yargs": "^17.7.2",
+        "zod": "^3.24.2"
     },
     "devDependencies": {
         "@eslint/js": "^9.21.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11452,7 +11452,7 @@ __metadata:
     mysql2: "npm:^3.10.1"
     nodejs-polars: "npm:^0.7.2"
     normalize.css: "npm:^8.0.1"
-    openai: "npm:^4.47.1"
+    openai: "npm:^4.85.4"
     p-map: "npm:^4.0.0"
     papaparse: "npm:^5.4.1"
     prettier: "npm:^3.5.0"
@@ -15141,9 +15141,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"openai@npm:^4.47.1":
-  version: 4.47.1
-  resolution: "openai@npm:4.47.1"
+"openai@npm:^4.85.4":
+  version: 4.85.4
+  resolution: "openai@npm:4.85.4"
   dependencies:
     "@types/node": "npm:^18.11.18"
     "@types/node-fetch": "npm:^2.6.4"
@@ -15152,10 +15152,17 @@ __metadata:
     form-data-encoder: "npm:1.7.2"
     formdata-node: "npm:^4.3.2"
     node-fetch: "npm:^2.6.7"
-    web-streams-polyfill: "npm:^3.2.1"
+  peerDependencies:
+    ws: ^8.18.0
+    zod: ^3.23.8
+  peerDependenciesMeta:
+    ws:
+      optional: true
+    zod:
+      optional: true
   bin:
     openai: bin/cli
-  checksum: 10/9f33766c4c8042a17f4527eb3bb9cc72d5d7ad595da7f71d0cb7425bae59847242af6e0de55520708893c1a6fd35b24364b0ecc662f3cc3855e1dfef197c8845
+  checksum: 10/5eda2a305bacd126513e6743b0f77842560a1273a850fc281439aed16d3ca264bc6673dd4f720ded378e0a22ac109863b1c319c6a23ff2e77b9acf672ac73d8b
   languageName: node
   linkType: hard
 
@@ -20383,13 +20390,6 @@ __metadata:
   version: 4.0.0-beta.3
   resolution: "web-streams-polyfill@npm:4.0.0-beta.3"
   checksum: 10/dcdef67de57d83008f9dc330662b65ba4497315555dd0e4e7bcacb132ffdf8a830eaab8f74ad40a4a44f542461f51223f406e2a446ece1cc29927859b1405853
-  languageName: node
-  linkType: hard
-
-"web-streams-polyfill@npm:^3.2.1":
-  version: 3.3.3
-  resolution: "web-streams-polyfill@npm:3.3.3"
-  checksum: 10/8e7e13501b3834094a50abe7c0b6456155a55d7571312b89570012ef47ec2a46d766934768c50aabad10a9c30dd764a407623e8bfcc74fcb58495c29130edea9
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11517,6 +11517,7 @@ __metadata:
     wrangler: "npm:^3.111.0"
     yaml: "npm:^2.4.2"
     yargs: "npm:^17.7.2"
+    zod: "npm:^3.24.2"
   languageName: unknown
   linkType: soft
 
@@ -20892,5 +20893,12 @@ __metadata:
   version: 3.22.3
   resolution: "zod@npm:3.22.3"
   checksum: 10/3aad6e6b61ddceaeb887dccc5f747903e619b09dfd208f6dc30eef15edf3942b8e6cd97a08e080c9c8723575446941edb823a8881c512e00e8dd3085f20659cc
+  languageName: node
+  linkType: hard
+
+"zod@npm:^3.24.2":
+  version: 3.24.2
+  resolution: "zod@npm:3.24.2"
+  checksum: 10/604c62a8cf8e330d78b106a557f4b44f5d14845d20b1360a423ccc09b58cb8525ccf7e4b40cf1bd4852d22393d2c67774b5817ec5a2fedab25f543b36ed15943
   languageName: node
   linkType: hard


### PR DESCRIPTION
OpenAI allows us to provide a Zod schema, to which it will adhere in its response ([Structured Outputs](https://platform.openai.com/docs/guides/structured-outputs)).

This allows us to get rid of quite some parsing and validation logic :)

I also updated the model used to `gpt-4o`, which is both [quite a bit cheaper](https://platform.openai.com/docs/pricing) and more capable (not that it really matters).