### PR TITLE
refactor: remove createdAt and updatedAt from insertable properties

### DIFF
--- a/adminSiteServer/app.test.ts
+++ b/adminSiteServer/app.test.ts
@@ -961,7 +961,6 @@ describe("OwidAdminApp: tag graph", () => {
             }),
             id: slug,
             published: 1,
-            createdAt: new Date(),
             publishedAt: new Date(),
             markdown: "",
         }

--- a/db/migration/1740690097502-CreatedAtNotNull.ts
+++ b/db/migration/1740690097502-CreatedAtNotNull.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class CreatedAtNotNull1740690097502 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `ALTER TABLE posts_gdocs MODIFY createdAt DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP;`
+        )
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `ALTER TABLE posts_gdocs MODIFY createdAt DATETIME NULL DEFAULT CURRENT_TIMESTAMP;`
+        )
+    }
+}

--- a/db/model/Gdoc/GdocFactory.ts
+++ b/db/model/Gdoc/GdocFactory.ts
@@ -616,8 +616,7 @@ export async function upsertGdoc(
     let sql = undefined
     try {
         const enrichedGdoc = getDbEnrichedGdocFromOwidGdoc(gdoc)
-        const { updatedAt: _, ...rawPost } =
-            serializePostsGdocsRow(enrichedGdoc)
+        const rawPost = serializePostsGdocsRow(enrichedGdoc)
         const query = knex
             .table(PostsGdocsTableName)
             .insert(rawPost)

--- a/packages/@ourworldindata/types/src/dbTypes/PostsGdocs.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/PostsGdocs.ts
@@ -11,7 +11,6 @@ export const PostsGdocsTableName = "posts_gdocs"
 export interface DbInsertPostGdoc {
     manualBreadcrumbs?: JsonString | null
     content: JsonString
-    createdAt: Date
     id: string
     markdown?: string | null
     publicationContext?: OwidGdocPublicationContext
@@ -19,11 +18,12 @@ export interface DbInsertPostGdoc {
     publishedAt?: Date | null
     revisionId?: string | null
     slug: string
-    updatedAt?: Date | null
 }
 export type DbRawPostGdoc = Required<DbInsertPostGdoc> & {
     type?: OwidGdocType
     authors?: JsonString
+    createdAt: Date
+    updatedAt: Date | null
 }
 export type DbEnrichedPostGdoc = Omit<
     DbRawPostGdoc,
@@ -93,7 +93,13 @@ export function serializePostsGdocsRow(
 ): DbInsertPostGdoc {
     // Kind of awkward, but some props may be set on the row but we don't want to insert them.
     // So we remove them here.
-    const KEYS_TO_REMOVE = ["breadcrumbs", "type", "authors"]
+    const KEYS_TO_REMOVE = [
+        "breadcrumbs",
+        "type",
+        "authors",
+        "updatedAt", // updated by the DB on update
+        "createdAt", // set by the DB to the current time on creation. We should never set this manually.
+    ]
 
     KEYS_TO_REMOVE.forEach((key) => {
         if (key in row) {


### PR DESCRIPTION
_inspired by https://github.com/owid/owid-grapher/pull/4567_

Removed the possibility to manually update `createdAt` and `updatedAt` dates in `serializePostsGdocsRow()`. These dates should only be handled by the DB and not at the application level.

- `createdAt` is set on row creation (and never needs to be updated)
- `updatedAt` is updated on row update by the DB

Also removed nullability for `createdAt` in the DB, to properly reflect this assumption in the application code.

### How to test?

1. Create a new Gdoc and verify that `createdAt` is automatically set by the database
2. Update an existing Gdoc and confirm that `updatedAt` is automatically updated

(nothing has changed on that front, that was already the case)

