### PR TITLE
Switch to ErrorBoundary from Sentry

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,6 @@
         "react-color": "^2.18.1",
         "react-diff-viewer-continued": "^3.4.0",
         "react-dom": "^17.0.2",
-        "react-error-boundary": "^4.0.10",
         "react-flip-toolkit": "^7.0.9",
         "react-hook-form": "^7.51.3",
         "react-horizontal-scrolling-menu": "^4.0.3",

--- a/site/gdocs/components/ArticleBlock.tsx
+++ b/site/gdocs/components/ArticleBlock.tsx
@@ -47,7 +47,7 @@ import Person from "./Person.js"
 import NarrativeChart from "./NarrativeChart.js"
 import { Container, getLayout } from "./layout.js"
 
-export default function ArticleBlock({
+function ArticleBlockInternal({
     b: block,
     containerType = "default",
     toc,
@@ -70,7 +70,7 @@ export default function ArticleBlock({
             />
         )
     }
-    const content: any | null = match(block)
+    return match(block)
         .with({ type: "aside" }, ({ caption, position = "right" }) => (
             <figure
                 className={cx(
@@ -225,9 +225,7 @@ export default function ArticleBlock({
                 />
             )
         })
-        .with({ type: "simple-text" }, (block) => {
-            return block.value
-        })
+        .with({ type: "simple-text" }, (block) => <>{block.value.text}</>)
         .with({ type: "heading", level: 1 }, (block) => (
             <h1
                 className={cx(
@@ -684,10 +682,27 @@ export default function ArticleBlock({
             />
         ))
         .exhaustive()
+}
 
+export default function ArticleBlock({
+    b: block,
+    containerType = "default",
+    toc,
+    shouldRenderLinks = true,
+}: {
+    b: OwidEnrichedGdocBlock
+    containerType?: Container
+    toc?: TocHeadingWithTitleSupertitle[]
+    shouldRenderLinks?: boolean
+}) {
     return (
         <BlockErrorBoundary className={getLayout("default", containerType)}>
-            {content}
+            <ArticleBlockInternal
+                b={block}
+                containerType={containerType}
+                toc={toc}
+                shouldRenderLinks={shouldRenderLinks}
+            />
         </BlockErrorBoundary>
     )
 }

--- a/site/gdocs/components/BlockErrorBoundary.tsx
+++ b/site/gdocs/components/BlockErrorBoundary.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
 import * as Sentry from "@sentry/react"
+import { Button } from "@ourworldindata/components"
 import { useDebug } from "../DebugContext.js"
 
 export const BlockErrorBoundary = ({
@@ -43,30 +44,31 @@ export const BlockErrorFallback = ({
         <div
             className={className}
             style={{
-                textAlign: "center",
-                backgroundColor: "rgba(255,0,0,0.1)",
+                display: "flex",
+                flexDirection: "column",
+                gap: "8px",
+                alignItems: "center",
+                backgroundColor: "#ffe5e5",
                 padding: "20px",
                 marginTop: "20px",
                 marginBottom: "20px",
             }}
         >
             <h3 style={{ margin: 0 }}>{error.name}</h3>
-            {debug ? (
+            {debug && (
                 <>
                     <div>{error.message}</div>
-                    {resetError ? (
-                        <div>
-                            <button
-                                aria-label="Reload content"
-                                style={{ margin: "10px" }}
-                                onClick={resetError}
-                            >
-                                Try again
-                            </button>
-                        </div>
-                    ) : null}
+                    {resetError && (
+                        <Button
+                            theme="solid-vermillion"
+                            text="Try again"
+                            ariaLabel="Reload content"
+                            onClick={resetError}
+                            icon={null}
+                        />
+                    )}
                 </>
-            ) : null}
+            )}
         </div>
     )
 }

--- a/site/gdocs/components/BlockErrorBoundary.tsx
+++ b/site/gdocs/components/BlockErrorBoundary.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { ErrorBoundary } from "react-error-boundary"
+import * as Sentry from "@sentry/react"
 import { useDebug } from "../DebugContext.js"
 
 export const BlockErrorBoundary = ({
@@ -10,23 +10,32 @@ export const BlockErrorBoundary = ({
     className: string
 }) => {
     return (
-        <ErrorBoundary
-            FallbackComponent={(props) => (
-                <BlockErrorFallback {...props} className={className} />
-            )}
+        <Sentry.ErrorBoundary
+            fallback={({ error, resetError }) => {
+                if (!(error instanceof Error)) {
+                    error = new Error(String(error))
+                }
+                return (
+                    <BlockErrorFallback
+                        className={className}
+                        error={error as Error}
+                        resetError={resetError}
+                    />
+                )
+            }}
         >
             {children}
-        </ErrorBoundary>
+        </Sentry.ErrorBoundary>
     )
 }
 
 export const BlockErrorFallback = ({
     error,
-    resetErrorBoundary,
+    resetError,
     className = "",
 }: {
     error: Error
-    resetErrorBoundary?: VoidFunction
+    resetError?: VoidFunction
     className?: string
 }): React.ReactElement => {
     const debug = useDebug()
@@ -45,12 +54,12 @@ export const BlockErrorFallback = ({
             {debug ? (
                 <>
                     <div>{error.message}</div>
-                    {resetErrorBoundary ? (
+                    {resetError ? (
                         <div>
                             <button
                                 aria-label="Reload content"
                                 style={{ margin: "10px" }}
-                                onClick={resetErrorBoundary}
+                                onClick={resetError}
                             >
                                 Try again
                             </button>

--- a/yarn.lock
+++ b/yarn.lock
@@ -11447,7 +11447,6 @@ __metadata:
     react-color: "npm:^2.18.1"
     react-diff-viewer-continued: "npm:^3.4.0"
     react-dom: "npm:^17.0.2"
-    react-error-boundary: "npm:^4.0.10"
     react-flip-toolkit: "npm:^7.0.9"
     react-hook-form: "npm:^7.51.3"
     react-horizontal-scrolling-menu: "npm:^4.0.3"
@@ -16836,17 +16835,6 @@ __metadata:
   peerDependencies:
     react: 17.0.2
   checksum: 10/0b3836131a64da8b1c2c852cc28b09c21a738c33c7a8d6021ac20d5619d753c8ee5fff8f97c95f2fc33053e44c2cbce9657453e21c55900164e6e0c3e955e826
-  languageName: node
-  linkType: hard
-
-"react-error-boundary@npm:^4.0.10":
-  version: 4.0.10
-  resolution: "react-error-boundary@npm:4.0.10"
-  dependencies:
-    "@babel/runtime": "npm:^7.12.5"
-  peerDependencies:
-    react: ">=16.13.1"
-  checksum: 10/521612cd8cec4d2b5507ac6191ac45117f2f83d9c5c0616790f2b0e8cce3b0c2254b5a494c24c16f01b3f30b4106f7044a572f650d2157076bd5686c2438cecb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This way we get also the React component stack attached to the error in Sentry.