### PR TITLE
feat(entitySelector): allow searching for entities in multiple languages

### DIFF
--- a/devTools/regionsUpdater/update.ts
+++ b/devTools/regionsUpdater/update.ts
@@ -40,12 +40,57 @@ const ETL_REGIONS_URL =
     // note that these currently only work in Firefox and Safari, not Chrome: see https://issues.chromium.org/issues/40801814
     TRANSLATION_CODES = {
         OWID_WRL: "001",
+
+        // Continents & aggregates according to OWID
         OWID_AFR: "002",
-        OWID_NAM: "003",
-        OWID_SAM: "005",
-        OWID_OCE: "009",
         OWID_ASI: "142",
         OWID_EUR: "150",
+        OWID_MNS: "054",
+        OWID_NAM: "003",
+        OWID_OCE: "009",
+        OWID_PYA: "061",
+        OWID_SAM: "005",
+
+        // Regions according to UNSD
+        UNSD_AUS: "053",
+        UNSD_CAM: "013",
+        UNSD_CAR: "029",
+        UNSD_CAS: "143",
+        UNSD_EAF: "014",
+        UNSD_EAS: "030",
+        UNSD_EEU: "151",
+        UNSD_MAF: "017",
+        UNSD_MEL: "054",
+        UNSD_MIC: "057",
+        UNSD_NAF: "015",
+        UNSD_NAM: "003",
+        UNSD_NEU: "154",
+        UNSD_POL: "061",
+        UNSD_SAF: "018",
+        UNSD_SAM: "005",
+        UNSD_SAS: "034",
+        UNSD_SEA: "035",
+        UNSD_SEU: "039",
+        UNSD_WAF: "011",
+        UNSD_WAS: "145",
+        UNSD_WEU: "155",
+
+        // Regions according to World Bank
+        WB_EAP: ["030", "009"], // East Asia; Pacific ≈ Oceania
+        WB_ECA: ["143", "150"],
+        WB_LAC: ["419", "029"],
+        WB_MENA: ["145", "015"], // Middle East ≈ Western Asia; Northern Africa
+        WB_NA: "003",
+        WB_SA: "034",
+        WB_SSA: "202",
+
+        // Regions according to WHO
+        WHO_AFR: "002",
+        WHO_AMR: "019",
+        WHO_EMR: "145",
+        WHO_EUR: "150",
+        WHO_SEAR: "035",
+        WHO_WPAC: ["030", "035", "009"], // Western Pacific ≈ East Asia + Southeast Asia + Oceania
     }
 
 interface Entity {
@@ -59,7 +104,7 @@ interface Entity {
     is_historical?: boolean
     is_unlisted?: boolean
     variant_names?: string[]
-    translation_code?: string
+    translation_codes?: string[]
     members?: string[]
 }
 
@@ -251,7 +296,13 @@ async function main() {
 
         // merge in alternate search names and translation codes
         entity.variant_names = _.get(SEARCH_ALIASES, entity.code)
-        entity.translation_code = _.get(TRANSLATION_CODES, entity.code)
+        entity.translation_codes = _.get(TRANSLATION_CODES, entity.code)
+
+        if (
+            entity.translation_codes &&
+            !Array.isArray(entity.translation_codes)
+        )
+            entity.translation_codes = [entity.translation_codes]
 
         return _.chain(entity)
             .mapKeys((_val, key) =>
@@ -274,7 +325,7 @@ async function main() {
                 "isHistorical",
                 "isUnlisted",
                 "variantNames",
-                "translationCode",
+                "translationCodes",
                 "members"
             )
             .value()

--- a/devTools/regionsUpdater/update.ts
+++ b/devTools/regionsUpdater/update.ts
@@ -34,7 +34,19 @@ const ETL_REGIONS_URL =
     },
     // we want to exclude income groups for now, until we can properly display the user's
     // income group in the UI
-    REGIONS_TO_EXCLUDE = ["OWID_HIC", "OWID_UMC", "OWID_LMC", "OWID_LIC"]
+    REGIONS_TO_EXCLUDE = ["OWID_HIC", "OWID_UMC", "OWID_LMC", "OWID_LIC"],
+    // used for Intl.DisplayNames mapping
+    // see https://github.com/unicode-org/cldr/blob/480029bab5301d79e762b872b463e9101ba91a40/common/main/en.xml#L927-L957 for these codes
+    // note that these currently only work in Firefox and Safari, not Chrome: see https://issues.chromium.org/issues/40801814
+    TRANSLATION_CODES = {
+        OWID_WRL: "001",
+        OWID_AFR: "002",
+        OWID_NAM: "003",
+        OWID_SAM: "005",
+        OWID_OCE: "009",
+        OWID_ASI: "142",
+        OWID_EUR: "150",
+    }
 
 interface Entity {
     code: string
@@ -47,6 +59,7 @@ interface Entity {
     is_historical?: boolean
     is_unlisted?: boolean
     variant_names?: string[]
+    translation_code?: string
     members?: string[]
 }
 
@@ -236,8 +249,9 @@ async function main() {
             ]
         }
 
-        // merge in alternate search terms
+        // merge in alternate search names and translation codes
         entity.variant_names = _.get(SEARCH_ALIASES, entity.code)
+        entity.translation_code = _.get(TRANSLATION_CODES, entity.code)
 
         return _.chain(entity)
             .mapKeys((_val, key) =>
@@ -260,6 +274,7 @@ async function main() {
                 "isHistorical",
                 "isUnlisted",
                 "variantNames",
+                "translationCode",
                 "members"
             )
             .value()

--- a/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
+++ b/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
@@ -21,7 +21,6 @@ import {
     intersection,
     FuzzySearch,
     getUserNavigatorLanguagesNonEnglish,
-    uniqBy,
     getRegionAlternativeNames,
 } from "@ourworldindata/utils"
 import {
@@ -557,13 +556,14 @@ export class EntitySelector extends React.Component<{
     @computed get fuzzy(): FuzzySearch<SearchableEntity> {
         return FuzzySearch.withKeyArray(
             this.sortedAvailableEntities,
-            (entity) => [entity.name, ...(entity.alternativeNames ?? [])]
+            (entity) => [entity.name, ...(entity.alternativeNames ?? [])],
+            (entity) => entity.name
         )
     }
 
     @computed get searchResults(): SearchableEntity[] | undefined {
         if (!this.searchInput) return undefined
-        return uniqBy(this.fuzzy.search(this.searchInput), "name")
+        return this.fuzzy.search(this.searchInput)
     }
 
     @computed get partitionedSearchResults(): PartitionedEntities | undefined {

--- a/packages/@ourworldindata/utils/src/FuzzySearch.test.ts
+++ b/packages/@ourworldindata/utils/src/FuzzySearch.test.ts
@@ -65,6 +65,84 @@ describe(FuzzySearch, () => {
         })
     })
 
+    const countriesWithAliases = [
+        {
+            name: "Netherlands",
+            aliases: ["Netherlands", "Nederland", "Holland"],
+        },
+        { name: "Spain", aliases: ["Spain", "España"] },
+        { name: "Germany", aliases: ["Germany", "Deutschland"] },
+    ]
+
+    describe("withKeyArray", () => {
+        it("creates a fuzzy search instance with multiple keys per object", () => {
+            const search = FuzzySearch.withKeyArray(
+                countriesWithAliases,
+                (country) => country.aliases
+            )
+            expect(search).toBeInstanceOf(FuzzySearch)
+        })
+
+        it("finds results based on any of the keys", () => {
+            const search = FuzzySearch.withKeyArray(
+                countriesWithAliases,
+                (country) => country.aliases
+            )
+
+            const hollandResults = search.search("holland")
+            expect(hollandResults).toHaveLength(1)
+            expect(hollandResults[0].name).toBe("Netherlands")
+
+            const espanaResults = search.search("españa")
+            expect(espanaResults).toHaveLength(1)
+            expect(espanaResults[0].name).toBe("Spain")
+        })
+
+        it("may return duplicate objects if multiple keys match", () => {
+            const duplicateKeyData = [
+                { id: 1, keys: ["apple", "fruit", "red"] },
+                { id: 2, keys: ["banana", "fruit", "yellow"] },
+            ]
+
+            const search = FuzzySearch.withKeyArray(
+                duplicateKeyData,
+                (item) => item.keys
+            )
+            const results = search.search("fruit")
+            expect(results).toHaveLength(2)
+        })
+
+        it("can make use of a 'unique by' function", () => {
+            const search = FuzzySearch.withKeyArray(
+                countriesWithAliases,
+                (item) => item.aliases,
+                (item) => item.name
+            )
+            const results = search.search("land")
+            expect(results).toHaveLength(2)
+        })
+
+        it("handles case sensitivity in searches", () => {
+            const search = FuzzySearch.withKeyArray(
+                countriesWithAliases,
+                (item) => item.aliases
+            )
+            const results = search.search("NETHERLANDS")
+            expect(results).toHaveLength(1)
+            expect(results[0].name).toBe("Netherlands")
+        })
+
+        it("handles accented characters in searches", () => {
+            const search = FuzzySearch.withKeyArray(
+                countriesWithAliases,
+                (item) => item.aliases
+            )
+            const results = search.search("espana")
+            expect(results).toHaveLength(1)
+            expect(results[0].name).toBe("Spain")
+        })
+    })
+
     describe("searchResults", () => {
         it("returns raw fuzzysort results", () => {
             const search = FuzzySearch.withKey(

--- a/packages/@ourworldindata/utils/src/FuzzySearch.ts
+++ b/packages/@ourworldindata/utils/src/FuzzySearch.ts
@@ -25,6 +25,28 @@ export class FuzzySearch<T> {
         return new FuzzySearch(datamap, opts)
     }
 
+    // Allows for multiple keys per object, e.g. aliases:
+    // [
+    //     { name: "Netherlands", "keys": ["Netherlands", "Nederland"] },
+    //     { name: "Spain", "keys": ["Spain", "España"] },
+    // ]
+    // Note that the calling site will need to take care of uniqueness of results,
+    // if that's desired, e.g. using uniqBy(results, "name")
+    static withKeyArray<T>(
+        data: T[],
+        keys: (obj: T) => string[],
+        opts?: Fuzzysort.Options
+    ): FuzzySearch<T> {
+        const datamap: Record<string, T[]> = {}
+        data.forEach((d) => {
+            keys(d).forEach((key) => {
+                if (!datamap[key]) datamap[key] = [d]
+                else datamap[key].push(d)
+            })
+        })
+        return new FuzzySearch(datamap, opts)
+    }
+
     search(input: string): T[] {
         return fuzzysort
             .go(input, this.strings, this.opts)

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -2154,3 +2154,11 @@ export function readFromAssetMap(
         throw new Error(`Entry for asset not found in asset map: ${path}`)
     return assetValue
 }
+
+export const getUserNavigatorLanguages = (): readonly string[] => {
+    return navigator.languages ?? [navigator.language]
+}
+
+export const getUserNavigatorLanguagesNonEnglish = (): readonly string[] => {
+    return getUserNavigatorLanguages().filter((lang) => !lang.startsWith("en"))
+}

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -133,6 +133,8 @@ export {
     isArrayDifferentFromReference,
     readFromAssetMap,
     downloadImage,
+    getUserNavigatorLanguages,
+    getUserNavigatorLanguagesNonEnglish,
 } from "./Util.js"
 
 export {
@@ -264,6 +266,7 @@ export {
     type Aggregate,
     getOthers,
     countriesByName,
+    getRegionAlternativeNames,
 } from "./regions.js"
 
 export { getStylesForTargetHeight } from "./react-select.js"

--- a/packages/@ourworldindata/utils/src/regions.json
+++ b/packages/@ourworldindata/utils/src/regions.json
@@ -1382,6 +1382,7 @@
         "name": "Africa",
         "slug": "africa",
         "regionType": "continent",
+        "translationCode": "002",
         "members": [
             "AGO",
             "BDI",
@@ -1458,6 +1459,7 @@
         "name": "Asia",
         "slug": "asia",
         "regionType": "continent",
+        "translationCode": "142",
         "members": [
             "AFG",
             "ARE",
@@ -1628,6 +1630,7 @@
         "name": "Europe",
         "slug": "europe",
         "regionType": "continent",
+        "translationCode": "150",
         "members": [
             "ALA",
             "ALB",
@@ -1770,6 +1773,7 @@
         "name": "North America",
         "slug": "north-america",
         "regionType": "continent",
+        "translationCode": "003",
         "members": [
             "ABW",
             "AIA",
@@ -1821,6 +1825,7 @@
         "name": "Oceania",
         "slug": "oceania",
         "regionType": "continent",
+        "translationCode": "009",
         "members": [
             "ASM",
             "AUS",
@@ -1903,6 +1908,7 @@
         "name": "South America",
         "slug": "south-america",
         "regionType": "continent",
+        "translationCode": "005",
         "members": [
             "ARG",
             "BOL",
@@ -1993,6 +1999,7 @@
         "name": "World",
         "slug": "world",
         "regionType": "aggregate",
+        "translationCode": "001",
         "members": [
             "OWID_AFR",
             "OWID_ASI",

--- a/packages/@ourworldindata/utils/src/regions.json
+++ b/packages/@ourworldindata/utils/src/regions.json
@@ -1382,7 +1382,7 @@
         "name": "Africa",
         "slug": "africa",
         "regionType": "continent",
-        "translationCode": "002",
+        "translationCodes": ["002"],
         "members": [
             "AGO",
             "BDI",
@@ -1459,7 +1459,7 @@
         "name": "Asia",
         "slug": "asia",
         "regionType": "continent",
-        "translationCode": "142",
+        "translationCodes": ["142"],
         "members": [
             "AFG",
             "ARE",
@@ -1630,7 +1630,7 @@
         "name": "Europe",
         "slug": "europe",
         "regionType": "continent",
-        "translationCode": "150",
+        "translationCodes": ["150"],
         "members": [
             "ALA",
             "ALB",
@@ -1753,6 +1753,7 @@
         "name": "Melanesia",
         "slug": "melanesia",
         "regionType": "aggregate",
+        "translationCodes": ["054"],
         "members": ["FJI", "PNG", "SLB", "VUT"]
     },
     {
@@ -1773,7 +1774,7 @@
         "name": "North America",
         "slug": "north-america",
         "regionType": "continent",
-        "translationCode": "003",
+        "translationCodes": ["003"],
         "members": [
             "ABW",
             "AIA",
@@ -1825,7 +1826,7 @@
         "name": "Oceania",
         "slug": "oceania",
         "regionType": "continent",
-        "translationCode": "009",
+        "translationCodes": ["009"],
         "members": [
             "ASM",
             "AUS",
@@ -1874,6 +1875,7 @@
         "name": "Polynesia",
         "slug": "polynesia",
         "regionType": "aggregate",
+        "translationCodes": ["061"],
         "members": [
             "ASM",
             "COK",
@@ -1908,7 +1910,7 @@
         "name": "South America",
         "slug": "south-america",
         "regionType": "continent",
-        "translationCode": "005",
+        "translationCodes": ["005"],
         "members": [
             "ARG",
             "BOL",
@@ -1999,7 +2001,7 @@
         "name": "World",
         "slug": "world",
         "regionType": "aggregate",
-        "translationCode": "001",
+        "translationCodes": ["001"],
         "members": [
             "OWID_AFR",
             "OWID_ASI",
@@ -2540,6 +2542,7 @@
         "name": "Australia and New Zealand (UNSD)",
         "slug": "australia-and-new-zealand-unsd",
         "regionType": "aggregate",
+        "translationCodes": ["053"],
         "members": ["AUS", "CXR", "CCK", "HMD", "NZL", "NFK"]
     },
     {
@@ -2547,6 +2550,7 @@
         "name": "Central America (UNSD)",
         "slug": "central-america-unsd",
         "regionType": "aggregate",
+        "translationCodes": ["013"],
         "members": ["BLZ", "CRI", "SLV", "GTM", "HND", "MEX", "NIC", "PAN"]
     },
     {
@@ -2554,6 +2558,7 @@
         "name": "Caribbean (UNSD)",
         "slug": "caribbean-unsd",
         "regionType": "aggregate",
+        "translationCodes": ["029"],
         "members": [
             "AIA",
             "ATG",
@@ -2590,6 +2595,7 @@
         "name": "Central Asia (UNSD)",
         "slug": "central-asia-unsd",
         "regionType": "aggregate",
+        "translationCodes": ["143"],
         "members": ["KAZ", "KGZ", "TJK", "TKM", "UZB"]
     },
     {
@@ -2597,6 +2603,7 @@
         "name": "Eastern Africa (UNSD)",
         "slug": "eastern-africa-unsd",
         "regionType": "aggregate",
+        "translationCodes": ["014"],
         "members": [
             "IOT",
             "BDI",
@@ -2627,6 +2634,7 @@
         "name": "Eastern Asia (UNSD)",
         "slug": "eastern-asia-unsd",
         "regionType": "aggregate",
+        "translationCodes": ["030"],
         "members": ["CHN", "HKG", "JPN", "MAC", "MNG", "PRK", "KOR"]
     },
     {
@@ -2634,6 +2642,7 @@
         "name": "Eastern Europe (UNSD)",
         "slug": "eastern-europe-unsd",
         "regionType": "aggregate",
+        "translationCodes": ["151"],
         "members": [
             "BLR",
             "BGR",
@@ -2652,6 +2661,7 @@
         "name": "Middle Africa (UNSD)",
         "slug": "middle-africa-unsd",
         "regionType": "aggregate",
+        "translationCodes": ["017"],
         "members": [
             "AGO",
             "CMR",
@@ -2669,6 +2679,7 @@
         "name": "Melanesia (UNSD)",
         "slug": "melanesia-unsd",
         "regionType": "aggregate",
+        "translationCodes": ["054"],
         "members": ["FJI", "NCL", "PNG", "SLB", "VUT"]
     },
     {
@@ -2676,6 +2687,7 @@
         "name": "Micronesia (UNSD)",
         "slug": "micronesia-unsd",
         "regionType": "aggregate",
+        "translationCodes": ["057"],
         "members": ["GUM", "KIR", "MHL", "FSM", "NRU", "MNP", "PLW", "UMI"]
     },
     {
@@ -2683,6 +2695,7 @@
         "name": "Northern Africa (UNSD)",
         "slug": "northern-africa-unsd",
         "regionType": "aggregate",
+        "translationCodes": ["015"],
         "members": ["DZA", "EGY", "LBY", "MAR", "SDN", "TUN", "ESH"]
     },
     {
@@ -2690,6 +2703,7 @@
         "name": "Northern America (UNSD)",
         "slug": "northern-america-unsd",
         "regionType": "aggregate",
+        "translationCodes": ["003"],
         "members": ["BMU", "CAN", "GRL", "SPM", "USA"]
     },
     {
@@ -2697,6 +2711,7 @@
         "name": "Northern Europe (UNSD)",
         "slug": "northern-europe-unsd",
         "regionType": "aggregate",
+        "translationCodes": ["154"],
         "members": [
             "ALA",
             "DNK",
@@ -2721,6 +2736,7 @@
         "name": "Polynesia (UNSD)",
         "slug": "polynesia-unsd",
         "regionType": "aggregate",
+        "translationCodes": ["061"],
         "members": [
             "ASM",
             "COK",
@@ -2739,6 +2755,7 @@
         "name": "Southern Africa (UNSD)",
         "slug": "southern-africa-unsd",
         "regionType": "aggregate",
+        "translationCodes": ["018"],
         "members": ["BWA", "LSO", "NAM", "ZAF", "SWZ"]
     },
     {
@@ -2746,6 +2763,7 @@
         "name": "South America (UNSD)",
         "slug": "south-america-unsd",
         "regionType": "aggregate",
+        "translationCodes": ["005"],
         "members": [
             "ARG",
             "BOL",
@@ -2770,6 +2788,7 @@
         "name": "Southern Asia (UNSD)",
         "slug": "southern-asia-unsd",
         "regionType": "aggregate",
+        "translationCodes": ["034"],
         "members": [
             "AFG",
             "BGD",
@@ -2787,6 +2806,7 @@
         "name": "South-eastern Asia (UNSD)",
         "slug": "south-eastern-asia-unsd",
         "regionType": "aggregate",
+        "translationCodes": ["035"],
         "members": [
             "BRN",
             "KHM",
@@ -2806,6 +2826,7 @@
         "name": "Southern Europe (UNSD)",
         "slug": "southern-europe-unsd",
         "regionType": "aggregate",
+        "translationCodes": ["039"],
         "members": [
             "ALB",
             "AND",
@@ -2830,6 +2851,7 @@
         "name": "Western Africa (UNSD)",
         "slug": "western-africa-unsd",
         "regionType": "aggregate",
+        "translationCodes": ["011"],
         "members": [
             "BEN",
             "BFA",
@@ -2855,6 +2877,7 @@
         "name": "Western Asia (UNSD)",
         "slug": "western-asia-unsd",
         "regionType": "aggregate",
+        "translationCodes": ["145"],
         "members": [
             "ARM",
             "AZE",
@@ -2880,6 +2903,7 @@
         "name": "Western Europe (UNSD)",
         "slug": "western-europe-unsd",
         "regionType": "aggregate",
+        "translationCodes": ["155"],
         "members": [
             "AUT",
             "BEL",
@@ -2975,6 +2999,7 @@
         "name": "East Asia and Pacific (WB)",
         "slug": "east-asia-and-pacific-wb",
         "regionType": "aggregate",
+        "translationCodes": ["030", "009"],
         "members": [
             "ASM",
             "AUS",
@@ -3033,6 +3058,7 @@
         "name": "Europe and Central Asia (WB)",
         "slug": "europe-and-central-asia-wb",
         "regionType": "aggregate",
+        "translationCodes": ["143", "150"],
         "members": [
             "AIA",
             "ALA",
@@ -3131,6 +3157,7 @@
         "name": "Latin America and Caribbean (WB)",
         "slug": "latin-america-and-caribbean-wb",
         "regionType": "aggregate",
+        "translationCodes": ["419", "029"],
         "members": [
             "ABW",
             "ARG",
@@ -3185,6 +3212,7 @@
         "name": "Middle East and North Africa (WB)",
         "slug": "middle-east-and-north-africa-wb",
         "regionType": "aggregate",
+        "translationCodes": ["145", "015"],
         "members": [
             "ARE",
             "BHR",
@@ -3217,6 +3245,7 @@
         "name": "North America (WB)",
         "slug": "north-america-wb",
         "regionType": "aggregate",
+        "translationCodes": ["003"],
         "members": ["BMU", "CAN", "SPM", "USA"]
     },
     {
@@ -3224,6 +3253,7 @@
         "name": "South Asia (WB)",
         "slug": "south-asia-wb",
         "regionType": "aggregate",
+        "translationCodes": ["034"],
         "members": [
             "AFG",
             "BGD",
@@ -3242,6 +3272,7 @@
         "name": "Sub-Saharan Africa (WB)",
         "slug": "sub-saharan-africa-wb",
         "regionType": "aggregate",
+        "translationCodes": ["202"],
         "members": [
             "AGO",
             "BDI",
@@ -3300,6 +3331,7 @@
         "name": "Africa (WHO)",
         "slug": "africa-who",
         "regionType": "aggregate",
+        "translationCodes": ["002"],
         "members": [
             "DZA",
             "AGO",
@@ -3355,6 +3387,7 @@
         "name": "Americas (WHO)",
         "slug": "americas-who",
         "regionType": "aggregate",
+        "translationCodes": ["019"],
         "members": [
             "AIA",
             "ATG",
@@ -3402,6 +3435,7 @@
         "name": "Eastern Mediterranean (WHO)",
         "slug": "eastern-mediterranean-who",
         "regionType": "aggregate",
+        "translationCodes": ["145"],
         "members": [
             "AFG",
             "BHR",
@@ -3431,6 +3465,7 @@
         "name": "Europe (WHO)",
         "slug": "europe-who",
         "regionType": "aggregate",
+        "translationCodes": ["150"],
         "members": [
             "ALB",
             "AND",
@@ -3492,6 +3527,7 @@
         "name": "South-East Asia (WHO)",
         "slug": "south-east-asia-who",
         "regionType": "aggregate",
+        "translationCodes": ["035"],
         "members": [
             "BGD",
             "BTN",
@@ -3511,6 +3547,7 @@
         "name": "Western Pacific (WHO)",
         "slug": "western-pacific-who",
         "regionType": "aggregate",
+        "translationCodes": ["030", "035", "009"],
         "members": [
             "AUS",
             "ASM",

--- a/packages/@ourworldindata/utils/src/regions.ts
+++ b/packages/@ourworldindata/utils/src/regions.ts
@@ -25,7 +25,7 @@ export interface Aggregate {
     name: string
     regionType: "aggregate"
     code: string
-    translationCode?: string
+    translationCodes?: string[]
     members: string[]
 }
 
@@ -39,7 +39,7 @@ export interface Continent {
         | "South America"
     regionType: "continent"
     code: string
-    translationCode?: string
+    translationCodes?: string[]
     members: string[]
 }
 
@@ -154,14 +154,22 @@ export const getRegionAlternativeNames = (
                 }
             }
 
-            const codeForTranslation =
-                ("translationCode" in region && region.translationCode) ||
+            const codesForTranslation =
+                ("translationCodes" in region && region.translationCodes) ||
                 ("shortCode" in region && region.shortCode)
-            if (codeForTranslation) {
+            if (codesForTranslation) {
                 const translations = languages
-                    .map((lang) =>
-                        getRegionTranslation(codeForTranslation, lang)
-                    )
+                    .flatMap((lang) => {
+                        if (Array.isArray(codesForTranslation))
+                            return codesForTranslation.map((code) =>
+                                getRegionTranslation(code, lang)
+                            )
+                        else
+                            return getRegionTranslation(
+                                codesForTranslation,
+                                lang
+                            )
+                    })
                     .filter((name) => name !== undefined)
 
                 translations.forEach((translation) => names.add(translation))

--- a/packages/@ourworldindata/utils/src/regions.ts
+++ b/packages/@ourworldindata/utils/src/regions.ts
@@ -25,6 +25,7 @@ export interface Aggregate {
     name: string
     regionType: "aggregate"
     code: string
+    translationCode?: string
     members: string[]
 }
 
@@ -38,6 +39,7 @@ export interface Continent {
         | "South America"
     regionType: "continent"
     code: string
+    translationCode?: string
     members: string[]
 }
 
@@ -152,7 +154,9 @@ export const getRegionAlternativeNames = (
                 }
             }
 
-            const codeForTranslation = "shortCode" in region && region.shortCode
+            const codeForTranslation =
+                ("translationCode" in region && region.translationCode) ||
+                ("shortCode" in region && region.shortCode)
             if (codeForTranslation) {
                 const translations = languages
                     .map((lang) =>


### PR DESCRIPTION
Resolves #4256, supersedes #4352.

Note: review #4621 first.

This PR makes use of the [Intl.DisplayNames](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DisplayNames) (caniuse: 95% support, all major modern browsers), which can have the browser provide translations to country names into all languages.

How this works:
- Using `navigator.languages`, we find out all *non-English* language codes that the user's browser is set to
	- Example: for me, `navigator.languages` is `['en', 'de', 'de-DE', 'en-GB', 'en-US']`, and so the non-English ones are `de, de-DE`.
- We then use `Intl.DisplayNames` to generate alternative names for each entity, at least if it matches a region in `regions.json` and has a `shortCode` attached to it.
	- These alternative names also include a region's variant names, e.g. `Swaziland <-> Eswatini`.
- We feed all of these alternative names into `FuzzySearch`, so that it can find an entity using any of these names.
- This also works for non-countries like "World" and "Europe" - sort of. Their special translation codes are supported in Firefox and Safari, but not Chrome.


https://github.com/user-attachments/assets/32091888-5036-47cf-ae25-69fbcbea1af7

