### PR TITLE
🔨 drop map tab for scatter plots / TAS-916

### DIFF
--- a/adminSiteClient/EditorBasicTab.tsx
+++ b/adminSiteClient/EditorBasicTab.tsx
@@ -540,13 +540,15 @@ export class EditorBasicTab<
                         options={this.chartTypeOptions}
                     />
                     <FieldsRow>
-                        <Toggle
-                            label="Map tab"
-                            value={grapher.hasMapTab}
-                            onValue={(shouldHaveMapTab) =>
-                                (grapher.hasMapTab = shouldHaveMapTab)
-                            }
-                        />
+                        {editor.features.canToggleMapTab && (
+                            <Toggle
+                                label="Map tab"
+                                value={grapher.hasMapTab}
+                                onValue={(shouldHaveMapTab) =>
+                                    (grapher.hasMapTab = shouldHaveMapTab)
+                                }
+                            />
+                        )}
                         {grapher.isLineChart && (
                             <Toggle
                                 label="Slope chart"

--- a/adminSiteClient/EditorFeatures.tsx
+++ b/adminSiteClient/EditorFeatures.tsx
@@ -167,4 +167,8 @@ export class EditorFeatures {
             this.grapher.isOnChartTab
         )
     }
+
+    @computed get canToggleMapTab() {
+        return !this.grapher.isScatter
+    }
 }

--- a/db/migration/1741164615077-DropMapTabForScatterPlots.ts
+++ b/db/migration/1741164615077-DropMapTabForScatterPlots.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class DropMapTabForScatterPlots1741164615077
+    implements MigrationInterface
+{
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        // Drop the map tab for all scatter plots (hasMapTab is false by default)
+        await queryRunner.query(`-- sql
+            update chart_configs
+            join charts on chart_configs.id = charts.configId
+            set
+                full = json_remove(full, '$.hasMapTab'),
+                patch = json_remove(patch, '$.hasMapTab')
+            where chartType = 'ScatterPlot' and full ->> '$.hasMapTab' = 'true';
+        `)
+    }
+
+    public async down(): Promise<void> {
+        // intentionally empty
+    }
+}


### PR DESCRIPTION
We have very few scatter plots that come with a map tab, but there is no indication of whether the x or y variable is plotted ([example](https://ourworldindata.org/grapher/energy-use-per-capita-vs-co2-emissions-per-capita?tab=map)). Fiona suggested to remove the map tab for all those scatters.

Below is the list of scatters that currently come with a map tab. I checked for references manually in the chart editor. The first four charts had references at all and for those I scrolled through all articles to make sure the map view is not embedded anywhere.

There are four more chart configs with this issue that seem to be used in mdims, so I left them as is for now and only dropped the map tab for stand-alone grapher charts.

### Scatter plots with a map tab

[https://admin.owid.io/admin/charts/1699/edit](https://admin.owid.io/admin/charts/1699/edit)
[https://admin.owid.io/admin/charts/3615/edit](https://admin.owid.io/admin/charts/3615/edit)
[https://admin.owid.io/admin/charts/7613/edit](https://admin.owid.io/admin/charts/7613/edit)
[https://admin.owid.io/admin/charts/7683/edit](https://admin.owid.io/admin/charts/7683/edit)

[https://admin.owid.io/admin/charts/1700/edit](https://admin.owid.io/admin/charts/1700/edit)
[https://admin.owid.io/admin/charts/3042/edit](https://admin.owid.io/admin/charts/3042/edit)
[https://admin.owid.io/admin/charts/3070/edit](https://admin.owid.io/admin/charts/3070/edit)
[https://admin.owid.io/admin/charts/3078/edit](https://admin.owid.io/admin/charts/3078/edit)
[https://admin.owid.io/admin/charts/3115/edit](https://admin.owid.io/admin/charts/3115/edit)
[https://admin.owid.io/admin/charts/3254/edit](https://admin.owid.io/admin/charts/3254/edit)
[https://admin.owid.io/admin/charts/3272/edit](https://admin.owid.io/admin/charts/3272/edit)
[https://admin.owid.io/admin/charts/3287/edit](https://admin.owid.io/admin/charts/3287/edit)
[https://admin.owid.io/admin/charts/3288/edit](https://admin.owid.io/admin/charts/3288/edit)
[https://admin.owid.io/admin/charts/3289/edit](https://admin.owid.io/admin/charts/3289/edit)
[https://admin.owid.io/admin/charts/3302/edit](https://admin.owid.io/admin/charts/3302/edit)
[https://admin.owid.io/admin/charts/3303/edit](https://admin.owid.io/admin/charts/3303/edit)
[https://admin.owid.io/admin/charts/3306/edit](https://admin.owid.io/admin/charts/3306/edit)
[https://admin.owid.io/admin/charts/3307/edit](https://admin.owid.io/admin/charts/3307/edit)
[https://admin.owid.io/admin/charts/3524/edit](https://admin.owid.io/admin/charts/3524/edit)
[https://admin.owid.io/admin/charts/3540/edit](https://admin.owid.io/admin/charts/3540/edit)
[https://admin.owid.io/admin/charts/4133/edit](https://admin.owid.io/admin/charts/4133/edit)
[https://admin.owid.io/admin/charts/4135/edit](https://admin.owid.io/admin/charts/4135/edit)
[https://admin.owid.io/admin/charts/4136/edit](https://admin.owid.io/admin/charts/4136/edit)
[https://admin.owid.io/admin/charts/4310/edit](https://admin.owid.io/admin/charts/4310/edit)
[https://admin.owid.io/admin/charts/4362/edit](https://admin.owid.io/admin/charts/4362/edit)
[https://admin.owid.io/admin/charts/4366/edit](https://admin.owid.io/admin/charts/4366/edit)
[https://admin.owid.io/admin/charts/7294/edit](https://admin.owid.io/admin/charts/7294/edit)