### PR TITLE
🐛 (admin) prevent infinite loop when loading variables / TAS-859

### DIFF
--- a/adminSiteClient/EditorBasicTab.tsx
+++ b/adminSiteClient/EditorBasicTab.tsx
@@ -103,12 +103,12 @@ class DimensionSlotView<
 
         this.isSelectingVariables = false
 
-        this.updateDimensionsAndRebuildTable(dimensionConfigs)
+        void this.updateDimensionsAndRebuildTable(dimensionConfigs)
         this.updateParentConfig()
     }
 
     @action.bound private onRemoveDimension(variableId: OwidVariableId) {
-        this.updateDimensionsAndRebuildTable(
+        void this.updateDimensionsAndRebuildTable(
             this.props.slot.dimensions.filter(
                 (d) => d.variableId !== variableId
             )
@@ -117,7 +117,7 @@ class DimensionSlotView<
     }
 
     @action.bound private onChangeDimension() {
-        this.updateDimensionsAndRebuildTable()
+        void this.updateDimensionsAndRebuildTable()
         this.updateParentConfig()
     }
 
@@ -190,7 +190,7 @@ class DimensionSlotView<
         this.disposers.forEach((dispose) => dispose())
     }
 
-    @action.bound private updateDimensionsAndRebuildTable(
+    @action.bound private async updateDimensionsAndRebuildTable(
         updatedDimensions?: OwidChartDimensionInterface[]
     ) {
         const { grapher } = this.props.editor
@@ -206,7 +206,9 @@ class DimensionSlotView<
             dimensions: grapher.dimensions.map((dim) => dim.toObject()),
         })
         grapher.seriesColorMap?.clear()
-        this.grapher.rebuildInputOwidTable()
+
+        await grapher.downloadLegacyDataFromOwidVariableIds()
+        grapher.rebuildInputOwidTable()
     }
 
     @action.bound private updateParentConfig() {
@@ -226,7 +228,7 @@ class DimensionSlotView<
             destination.index
         )
 
-        this.updateDimensionsAndRebuildTable(dimensions)
+        void this.updateDimensionsAndRebuildTable(dimensions)
         this.updateParentConfig()
     }
 

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -1466,12 +1466,6 @@ export class Grapher
     // todo: can we remove this?
     // I believe these states can only occur during editing.
     @action.bound private ensureValidConfigWhenEditing(): void {
-        this.disposers.push(
-            reaction(
-                () => this.variableIds,
-                () => this.downloadLegacyDataFromOwidVariableIds()
-            )
-        )
         const disposers = [
             autorun(() => {
                 if (!this.availableTabs.includes(this.activeTab))


### PR DESCRIPTION
Invalid dimensions lead to an infinite loop where variables are loaded again and again in the admin

~This appears to be fixed in the Grapher state refactor, so I'm closing this one down.~ Might still makes sense to fix this now since the refactor only ships in 6 to 8 weeks?

Example: [live](https://admin.owid.io/admin/charts/1250/edit) / [staging](http://staging-site-fix-admin-infinite-loading/admin/charts/1250/edit)