### PR TITLE
fix(grapher refactor): fix time param handling

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/Grapher.jsdom.test.ts
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.jsdom.test.ts
@@ -760,6 +760,7 @@ describe("time parameter", () => {
                 minTime: 0,
                 maxTime: 75,
             })
+            expect(grapher.hasUserChangedTimeHandles).toBe(false)
             expect(grapher.changedParams.time).toEqual(undefined)
         })
 
@@ -768,6 +769,7 @@ describe("time parameter", () => {
                 minTime: undefined,
                 maxTime: 75,
             })
+            expect(grapher.hasUserChangedTimeHandles).toBe(false)
             expect(grapher.changedParams.time).toEqual(undefined)
         })
     })

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -2697,7 +2697,7 @@ export class GrapherState {
     }
 
     @computed get hasUserChangedTimeHandles(): boolean {
-        const authorsVersion = this.legacyConfigAsAuthored
+        const authorsVersion = this.authorsVersion
         return (
             this.minTime !== authorsVersion.minTime ||
             this.maxTime !== authorsVersion.maxTime

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -2696,7 +2696,7 @@ export class GrapherState {
         return this.manager?.embedDialogAdditionalElements
     }
 
-    @computed private get hasUserChangedTimeHandles(): boolean {
+    @computed get hasUserChangedTimeHandles(): boolean {
         const authorsVersion = this.legacyConfigAsAuthored
         return (
             this.minTime !== authorsVersion.minTime ||


### PR DESCRIPTION
This should fix the SVG diffs present in #4419, hopefully.

Reason being that `legacyConfigAsAuthored.minTime == undefined`, whereas `authorsVersion.minTime == -Infinity` (since it's explicitly set in the `GrapherState#constructor -> updateFromObject` call).

You _explicitly_ changed this in the PR - maybe to circumvent some sort of circular dependency that occurred at some point? Anyhow, it seems this is now safe to do.

Decided to add a test for it, too, for which I had to make the getter public.