### PR TITLE
✨ don't sort columns used in the About this data modal and the entity selector

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -62,7 +62,6 @@ import {
     isEmpty,
     compact,
     getOriginAttributionFragments,
-    sortBy,
     extractDetailsFromSyntax,
     omit,
     isTouchDevice,
@@ -1922,14 +1921,8 @@ export class Grapher
         const { yColumnSlugs, xColumnSlug, sizeColumnSlug, colorColumnSlug } =
             this
 
-        // sort y columns by their display name
-        const sortedYColumnSlugs = sortBy(
-            yColumnSlugs,
-            (slug) => this.inputTable.get(slug).titlePublicOrDisplayName.title
-        )
-
         return excludeUndefined([
-            ...sortedYColumnSlugs,
+            ...yColumnSlugs,
             xColumnSlug,
             sizeColumnSlug,
             colorColumnSlug,
@@ -1940,14 +1933,8 @@ export class Grapher
         const { yColumnSlugs, xColumnSlug, sizeColumnSlug, colorColumnSlug } =
             this
 
-        // sort y-columns by their display name
-        const sortedYColumnSlugs = sortBy(
-            yColumnSlugs,
-            (slug) => this.inputTable.get(slug).titlePublicOrDisplayName.title
-        )
-
         const columnSlugs = excludeUndefined([
-            ...sortedYColumnSlugs,
+            ...yColumnSlugs,
             xColumnSlug,
             sizeColumnSlug,
             colorColumnSlug,


### PR DESCRIPTION
Resolves https://github.com/owid/owid-grapher/issues/4612

The 'About this data' tabs used to be sorted alphabetically, but we prefer the author-specified sort order. The same is true for the columns used for sorting in the entity selector.

<details><summary>Screenshots</summary>
<p>

<img width="1081" alt="Screenshot 2025-03-07 at 17 01 57" src="https://github.com/user-attachments/assets/871a9ccc-5834-4232-885b-4ffd1b061ab7" />
<img width="1081" alt="Screenshot 2025-03-07 at 17 01 50" src="https://github.com/user-attachments/assets/ab58fa95-fe2d-4068-a0e9-566a350f8cc9" />


</p>
</details> 