### PR TITLE
chore(ci): split up & speed up CI tasks

### DIFF
--- a/.github/actions/build-tsc/action.yml
+++ b/.github/actions/build-tsc/action.yml
@@ -1,8 +1,0 @@
-name: Build TypeScript
-description: Compiles our TypeScript code
-runs:
-    using: composite
-    steps:
-        - name: Run tsc
-          run: yarn buildTsc
-          shell: bash

--- a/.github/actions/setup-node-yarn-deps/action.yml
+++ b/.github/actions/setup-node-yarn-deps/action.yml
@@ -27,5 +27,7 @@ runs:
           shell: bash
 
         - name: Install dependencies
+          env:
+              YARN_ENABLE_HARDENED_MODE: ${{ github.event.pull_request.head.repo.full_name != 'owid/owid-grapher' }}
           run: yarn --immutable ${{ inputs.runPostinstallScripts != 'true' && '--mode=skip-build' || '' }}
           shell: bash

--- a/.github/actions/setup-node-yarn-deps/action.yml
+++ b/.github/actions/setup-node-yarn-deps/action.yml
@@ -1,5 +1,10 @@
 name: Set up node and dependencies
 description: Runs all the setup steps required to have the proper Node version and all dependencies installed
+inputs:
+    runPostinstallScripts:
+        description: "Whether to run postinstall scripts during dependency installation. Usually only needed for native packages, like esbuild, sharp or wranglerd."
+        required: false
+        default: "true"
 runs:
     using: composite
     steps:
@@ -22,5 +27,5 @@ runs:
           shell: bash
 
         - name: Install dependencies
-          run: yarn --immutable
+          run: yarn --immutable ${{ inputs.runPostinstallScripts != 'true' && '--mode=skip-build' || '' }}
           shell: bash

--- a/.github/actions/setup-node-yarn-deps/action.yml
+++ b/.github/actions/setup-node-yarn-deps/action.yml
@@ -24,7 +24,3 @@ runs:
         - name: Install dependencies
           run: yarn --immutable
           shell: bash
-
-        - name: Build packages
-          run: yarn buildLerna
-          shell: bash

--- a/.github/workflows/check-default-grapher-config.yml
+++ b/.github/workflows/check-default-grapher-config.yml
@@ -17,9 +17,6 @@ jobs:
               with:
                   ref: ${{ github.head_ref }}
 
-            - uses: ./.github/actions/setup-node-yarn-deps
-            - uses: ./.github/actions/build-tsc
-
             - uses: hustcer/setup-nu@v3
               with:
                   version: "0.101" # Don't use 0.101 here, as it was a float number and will be convert to 0.101, you can use v0.101/0.101.0 or '0.101'
@@ -42,7 +39,7 @@ jobs:
               run: |
                   (ls packages/@ourworldindata/grapher/src/schema/grapher-schema.*.json
                   | each {|json|
-                      node itsJustJavascript/devTools/schema/generate-default-object-from-schema.js $json.name --save-ts packages/@ourworldindata/grapher/src/schema/defaultGrapherConfig.ts })
+                      yarn tsx --tsconfig tsconfig.tsx.json devTools/schema/generate-default-object-from-schema.ts $json.name --save-ts packages/@ourworldindata/grapher/src/schema/defaultGrapherConfig.ts })
               shell: nu {0}
 
             - name: Run prettier

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,8 @@ jobs:
               uses: actions/checkout@v4
 
             - uses: ./.github/actions/setup-node-yarn-deps
+              with:
+                  runPostinstallScripts: false
 
             - name: Run lerna build
               run: yarn buildLerna
@@ -55,6 +57,8 @@ jobs:
               uses: actions/checkout@v4
 
             - uses: ./.github/actions/setup-node-yarn-deps
+              with:
+                  runPostinstallScripts: false
 
             - name: Run prettier
               run: yarn testPrettierAll
@@ -67,6 +71,8 @@ jobs:
               uses: actions/checkout@v4
 
             - uses: ./.github/actions/setup-node-yarn-deps
+              with:
+                  runPostinstallScripts: false
 
             - name: Run eslint
               # the --max-warnings makes eslint exit with non-zero exit code even for warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,9 @@
-name: Continuous Integration
+name: CI
 on: [push, pull_request]
 
 jobs:
     # Checks for prettify errors, TypeScript errors and runs vitest tests.
-    testdbcheck:
+    "test-db":
         runs-on: ubuntu-latest
 
         steps:
@@ -20,7 +20,34 @@ jobs:
               run: make dbtest
               timeout-minutes: 6
 
-    testcheck:
+    test:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Clone repository
+              uses: actions/checkout@v4
+
+            - uses: ./.github/actions/setup-node-yarn-deps
+
+            - name: Run vitest
+              run: yarn test --pool=forks
+
+    typecheck:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Clone repository
+              uses: actions/checkout@v4
+
+            - uses: ./.github/actions/setup-node-yarn-deps
+
+            - name: Run lerna build
+              run: yarn buildLerna
+
+            - name: Run tsc build
+              run: yarn buildTsc
+
+    prettier:
         runs-on: ubuntu-latest
 
         steps:
@@ -31,12 +58,6 @@ jobs:
 
             - name: Run prettier
               run: yarn testPrettierAll
-
-            - name: Run tsc build
-              run: yarn buildTsc
-
-            - name: Run vitest
-              run: yarn test --pool=forks
 
     eslint:
         runs-on: ubuntu-latest
@@ -60,7 +81,6 @@ jobs:
               uses: actions/checkout@v4
 
             - uses: ./.github/actions/setup-node-yarn-deps
-            - uses: ./.github/actions/build-tsc
 
             - name: Run bundlewatch
               run: yarn testBundlewatch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ jobs:
 
             - uses: ./.github/actions/setup-node-yarn-deps
 
+            - name: Build lerna
+              run: yarn buildLerna
+
             - name: Install dependencies
               run: cp .env.example-grapher .env
               shell: bash

--- a/.github/workflows/prettify.yml
+++ b/.github/workflows/prettify.yml
@@ -19,6 +19,8 @@ jobs:
                   ref: ${{ github.head_ref }}
 
             - uses: ./.github/actions/setup-node-yarn-deps
+              with:
+                  runPostinstallScripts: false
 
             - name: Run prettier
               run: yarn fixPrettierAll

--- a/.github/workflows/sync-grapher-schema-to-digital-ocean.yml
+++ b/.github/workflows/sync-grapher-schema-to-digital-ocean.yml
@@ -15,7 +15,6 @@ jobs:
               uses: actions/checkout@master
 
             - uses: ./.github/actions/setup-node-yarn-deps
-            - uses: ./.github/actions/build-tsc
 
             - uses: hustcer/setup-nu@v3
               with:
@@ -35,7 +34,7 @@ jobs:
             - run: |
                   (ls packages/@ourworldindata/grapher/src/schema/grapher-schema.*.json
                   | each {|json|
-                      node itsJustJavascript/devTools/schema/generate-default-object-from-schema.js $json.name
+                      yarn tsx --tsconfig tsconfig.tsx.json devTools/schema/generate-default-object-from-schema.ts $json.name
                       | save -f ($json.name
                           | path parse
                           | upsert stem ($json.name

--- a/settings/clientSettings.ts
+++ b/settings/clientSettings.ts
@@ -13,7 +13,7 @@ if (typeof __dirname !== "undefined") {
     if (baseDir) dotenv.config({ path: `${baseDir}/.env` })
 }
 
-const parseIntOrUndefined = (value: string | undefined) => {
+const parseIntOrUndefined = (value: string | undefined): number | undefined => {
     try {
         return value ? parseInt(value) : undefined
     } catch {

--- a/settings/clientSettings.ts
+++ b/settings/clientSettings.ts
@@ -13,7 +13,13 @@ if (typeof __dirname !== "undefined") {
     if (baseDir) dotenv.config({ path: `${baseDir}/.env` })
 }
 
-import { parseIntOrUndefined } from "@ourworldindata/utils"
+const parseIntOrUndefined = (value: string | undefined) => {
+    try {
+        return value ? parseInt(value) : undefined
+    } catch {
+        return undefined
+    }
+}
 
 type Environment = "development" | "staging" | "production"
 export const ENV: Environment =

--- a/site/viteConstants.ts
+++ b/site/viteConstants.ts
@@ -1,0 +1,20 @@
+export const VITE_ASSET_SITE_ENTRY = "site/owid.entry.ts"
+export const VITE_ASSET_ADMIN_ENTRY = "adminSiteClient/admin.entry.ts"
+
+export enum ViteEntryPoint {
+    Site = "site",
+    Admin = "admin",
+}
+
+export const VITE_ENTRYPOINT_INFO = {
+    [ViteEntryPoint.Site]: {
+        entryPointFile: VITE_ASSET_SITE_ENTRY,
+        outDir: "assets",
+        outName: "owid",
+    },
+    [ViteEntryPoint.Admin]: {
+        entryPointFile: VITE_ASSET_ADMIN_ENTRY,
+        outDir: "assets-admin",
+        outName: "admin",
+    },
+}

--- a/site/viteUtils.tsx
+++ b/site/viteUtils.tsx
@@ -11,29 +11,9 @@ import type { Manifest, ManifestChunk } from "vite"
 import { readFromAssetMap, sortBy } from "@ourworldindata/utils"
 import urljoin from "url-join"
 import { AssetMap } from "@ourworldindata/types"
+import { VITE_ENTRYPOINT_INFO, ViteEntryPoint } from "./viteConstants.js"
 
 const VITE_DEV_URL = process.env.VITE_DEV_URL ?? "http://localhost:8090"
-
-export const VITE_ASSET_SITE_ENTRY = "site/owid.entry.ts"
-export const VITE_ASSET_ADMIN_ENTRY = "adminSiteClient/admin.entry.ts"
-
-export enum ViteEntryPoint {
-    Site = "site",
-    Admin = "admin",
-}
-
-export const VITE_ENTRYPOINT_INFO = {
-    [ViteEntryPoint.Site]: {
-        entryPointFile: VITE_ASSET_SITE_ENTRY,
-        outDir: "assets",
-        outName: "owid",
-    },
-    [ViteEntryPoint.Admin]: {
-        entryPointFile: VITE_ASSET_ADMIN_ENTRY,
-        outDir: "assets-admin",
-        outName: "admin",
-    },
-}
 
 // We ALWAYS load polyfills.
 

--- a/vite.config-admin.mts
+++ b/vite.config-admin.mts
@@ -1,4 +1,4 @@
-import { ViteEntryPoint } from "./site/viteUtils.tsx"
+import { ViteEntryPoint } from "./site/viteConstants.ts"
 import { defineViteConfigForEntrypoint } from "./vite.config-common.mts"
 
 export default defineViteConfigForEntrypoint(ViteEntryPoint.Admin)

--- a/vite.config-common.mts
+++ b/vite.config-common.mts
@@ -7,7 +7,7 @@ import {
     VITE_ASSET_SITE_ENTRY,
     VITE_ENTRYPOINT_INFO,
     ViteEntryPoint,
-} from "./site/viteUtils.js"
+} from "./site/viteConstants.js"
 
 // https://vitejs.dev/config/
 export const defineViteConfigForEntrypoint = (entrypoint: ViteEntryPoint) => {

--- a/vite.config-common.mts
+++ b/vite.config-common.mts
@@ -9,6 +9,8 @@ import {
     ViteEntryPoint,
 } from "./site/viteConstants.js"
 
+const runTypeCheckerPlugin = !(process.env.VITEST || process.env.CI)
+
 // https://vitejs.dev/config/
 export const defineViteConfigForEntrypoint = (entrypoint: ViteEntryPoint) => {
     const entrypointInfo = VITE_ENTRYPOINT_INFO[entrypoint]
@@ -71,7 +73,7 @@ export const defineViteConfigForEntrypoint = (entrypoint: ViteEntryPoint) => {
                     },
                 },
             }),
-            !process.env.VITEST &&
+            runTypeCheckerPlugin &&
                 pluginChecker({
                     typescript: {
                         buildMode: true,

--- a/vite.config-site.mts
+++ b/vite.config-site.mts
@@ -1,4 +1,4 @@
-import { ViteEntryPoint } from "./site/viteUtils.tsx"
+import { ViteEntryPoint } from "./site/viteConstants.ts"
 import { defineViteConfigForEntrypoint } from "./vite.config-common.mts"
 
 export default defineViteConfigForEntrypoint(ViteEntryPoint.Site)


### PR DESCRIPTION
Improves CI speed & accuracy by:
- Only running things like `buildLerna` and `buildTsc` when they're actually needed!
- splitting out typecheck, prettier, and test into three separate, parallel tasks