### PR TITLE
🐛 fix gdoc page subdirectories not prepended to Autocomplete results

### DIFF
--- a/site/search/Autocomplete.tsx
+++ b/site/search/Autocomplete.tsx
@@ -88,6 +88,7 @@ const prependSubdirectoryToAlgoliaItemUrl = (item: BaseItem): string => {
     return match(indexName)
         .with(SearchIndexName.ExplorerViews, () => {
             return urljoin(
+                BAKED_BASE_URL,
                 EXPLORERS_ROUTE_FOLDER,
                 item.explorerSlug as string,
                 item.viewQueryParams as string
@@ -101,7 +102,7 @@ const prependSubdirectoryToAlgoliaItemUrl = (item: BaseItem): string => {
                 item.type === WordpressPageType.Country ||
                 item.type === WordpressPageType.Other
             ) {
-                return `/${item.slug}`
+                return urljoin(BAKED_BASE_URL, item.slug as string)
             }
             return getCanonicalUrl(BAKED_BASE_URL, {
                 slug: item.slug as string,
@@ -114,6 +115,7 @@ const prependSubdirectoryToAlgoliaItemUrl = (item: BaseItem): string => {
             return match(item.type as ChartRecordType)
                 .with(ChartRecordType.ExplorerView, () => {
                     return urljoin(
+                        BAKED_BASE_URL,
                         EXPLORERS_ROUTE_FOLDER,
                         item.explorerSlug as string,
                         item.viewQueryParams as string

--- a/site/search/Autocomplete.tsx
+++ b/site/search/Autocomplete.tsx
@@ -12,6 +12,7 @@ import {
 import algoliasearch from "algoliasearch"
 import { createLocalStorageRecentSearchesPlugin } from "@algolia/autocomplete-plugin-recent-searches"
 import {
+    ChartRecordType,
     PageType,
     SearchIndexName,
     WordpressPageType,
@@ -109,10 +110,27 @@ const prependSubdirectoryToAlgoliaItemUrl = (item: BaseItem): string => {
                 },
             })
         })
-        .with(
-            SearchIndexName.ExplorerViewsMdimViewsAndCharts,
-            () => `${BAKED_GRAPHER_URL}/${item.slug}`
-        )
+        .with(SearchIndexName.ExplorerViewsMdimViewsAndCharts, () => {
+            return match(item.type as ChartRecordType)
+                .with(ChartRecordType.ExplorerView, () => {
+                    return urljoin(
+                        EXPLORERS_ROUTE_FOLDER,
+                        item.explorerSlug as string,
+                        item.viewQueryParams as string
+                    )
+                })
+                .with(ChartRecordType.Chart, () => {
+                    return urljoin(BAKED_GRAPHER_URL, item.slug as string)
+                })
+                .with(ChartRecordType.MultiDimView, () => {
+                    return urljoin(
+                        BAKED_GRAPHER_URL,
+                        item.slug as string,
+                        item.queryParams as string
+                    )
+                })
+                .exhaustive()
+        })
         .exhaustive()
 }
 

--- a/site/search/searchTypes.ts
+++ b/site/search/searchTypes.ts
@@ -112,11 +112,3 @@ export const searchCategoryFilters: [string, SearchCategoryFilter][] = [
     ["Charts", SearchIndexName.Charts],
     ["Data Explorers", SearchIndexName.ExplorerViews],
 ]
-
-export const indexNameToSubdirectoryMap: Record<SearchIndexName, string> = {
-    [SearchIndexName.Pages]: "",
-    [SearchIndexName.Charts]: "/grapher",
-    [SearchIndexName.ExplorerViews]: "/explorers",
-    // n/a - charts and explorers have different subdirectories, so this needs to be resolved elsewhere
-    [SearchIndexName.ExplorerViewsMdimViewsAndCharts]: "",
-}


### PR DESCRIPTION
Fixes a path that I overlooked in https://github.com/owid/owid-grapher/pull/4541

## To test:
1. Check this code out locally, or on staging
2. Attempt the following searches on the homepage
    1. `blueberries` - data insight
    2. `sustainable` - SDG
    3. `optimism` - article
    4. `life expectancy` - chart
    5. `mpox` - explorer view
    6. `privacy` - WordPress "other" page
    7. `vatican` - Country profile page

All results should load correctly (team pages don't need to be verified as they aren't indexed)
