### PR TITLE
test error boundary

### DIFF
--- a/site/gdocs/components/ArticleBlock.tsx
+++ b/site/gdocs/components/ArticleBlock.tsx
@@ -47,7 +47,7 @@ import Person from "./Person.js"
 import NarrativeChart from "./NarrativeChart.js"
 import { Container, getLayout } from "./layout.js"
 
-function ArticleBlockInternal({
+export default function ArticleBlock({
     b: block,
     containerType = "default",
     toc,
@@ -70,7 +70,7 @@ function ArticleBlockInternal({
             />
         )
     }
-    return match(block)
+    const content = match(block)
         .with({ type: "aside" }, ({ caption, position = "right" }) => (
             <figure
                 className={cx(
@@ -682,27 +682,33 @@ function ArticleBlockInternal({
             />
         ))
         .exhaustive()
-}
 
-export default function ArticleBlock({
-    b: block,
-    containerType = "default",
-    toc,
-    shouldRenderLinks = true,
-}: {
-    b: OwidEnrichedGdocBlock
-    containerType?: Container
-    toc?: TocHeadingWithTitleSupertitle[]
-    shouldRenderLinks?: boolean
-}) {
     return (
         <BlockErrorBoundary className={getLayout("default", containerType)}>
-            <ArticleBlockInternal
-                b={block}
-                containerType={containerType}
-                toc={toc}
-                shouldRenderLinks={shouldRenderLinks}
-            />
+            {content}
         </BlockErrorBoundary>
     )
 }
+
+// export default function ArticleBlock({
+//     b: block,
+//     containerType = "default",
+//     toc,
+//     shouldRenderLinks = true,
+// }: {
+//     b: OwidEnrichedGdocBlock
+//     containerType?: Container
+//     toc?: TocHeadingWithTitleSupertitle[]
+//     shouldRenderLinks?: boolean
+// }) {
+//     return (
+//         <BlockErrorBoundary className={getLayout("default", containerType)}>
+//             <ArticleBlockInternal
+//                 b={block}
+//                 containerType={containerType}
+//                 toc={toc}
+//                 shouldRenderLinks={shouldRenderLinks}
+//             />
+//         </BlockErrorBoundary>
+//     )
+// }

--- a/site/gdocs/components/SpanElements.tsx
+++ b/site/gdocs/components/SpanElements.tsx
@@ -1,5 +1,6 @@
 import { Span } from "@ourworldindata/types"
 import SpanElement from "./SpanElement.js"
+import { useEffect, useState } from "react"
 
 export default function SpanElements({
     spans,
@@ -8,6 +9,16 @@ export default function SpanElements({
     spans: Span[]
     shouldRenderLinks?: boolean
 }) {
+    const [isClient, setIsClient] = useState(false)
+
+    useEffect(() => {
+        setIsClient(true)
+    }, [])
+
+    if (isClient) {
+        throw new Error("Test error boundary")
+    }
+
     return (
         <>
             {spans.map((span, index) => (


### PR DESCRIPTION
_⚠️ For testing purposes only, do not merge_

- Added error boundary testing code in `SpanElements` component that intentionally throws an error when rendered on the client side

Test by visiting any gdoc page.


![Screenshot 2025-03-12 at 10.51.10.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/0SFFiIjKuUK6UPYHVe6u/f1f8a564-4d58-4c04-beb2-7e9774d7c391.png)

