### PR TITLE
refactor: allow loading multiple .env files

### DIFF
--- a/.env.archive
+++ b/.env.archive
@@ -1,0 +1,3 @@
+ARCHIVE=true
+ENVIRONMENT=production
+BAKED_BASE_URL=

--- a/serverUtils/instrument.ts
+++ b/serverUtils/instrument.ts
@@ -1,18 +1,11 @@
-import dotenv from "dotenv"
+import { SENTRY_ADMIN_DSN } from "../settings/clientSettings.js"
 import * as Sentry from "@sentry/node"
 import { nodeProfilingIntegration } from "@sentry/profiling-node"
-import findBaseDir from "../settings/findBaseDir.js"
 
 if (!process.env.VITEST) {
-    const baseDir = findBaseDir(__dirname)
-    if (baseDir === undefined)
-        throw new Error("could not locate base package.json")
-
-    dotenv.config({ path: `${baseDir}/.env` })
-
     // Ensure to call this before importing any other modules!
     Sentry.init({
-        dsn: process.env.SENTRY_ADMIN_DSN,
+        dsn: SENTRY_ADMIN_DSN,
         integrations: [nodeProfilingIntegration()],
         tracesSampleRate: 0.1,
         profilesSampleRate: 1.0, // This is relative to tracesSampleRate

--- a/settings/clientSettings.ts
+++ b/settings/clientSettings.ts
@@ -16,6 +16,7 @@ const parseIntOrUndefined = (value: string | undefined): number | undefined => {
 type Environment = "development" | "staging" | "production"
 export const ENV: Environment =
     (process.env.ENV as Environment) || "development"
+export const ARCHIVE: boolean = process.env.ARCHIVE === "true"
 export const COMMIT_SHA = process.env.COMMIT_SHA
 
 export const SENTRY_DSN: string | undefined = process.env.SENTRY_DSN

--- a/settings/clientSettings.ts
+++ b/settings/clientSettings.ts
@@ -3,15 +3,7 @@
 // Settings in here will be made available to the client-side code that is
 // bundled and shipped out to our users.
 
-import dotenv from "dotenv"
-import findBaseDir from "./findBaseDir.js"
-
-if (typeof __dirname !== "undefined") {
-    // only run this code in node, not in the browser.
-    // in the browser, process.env is already populated by vite.
-    const baseDir = findBaseDir(__dirname)
-    if (baseDir) dotenv.config({ path: `${baseDir}/.env` })
-}
+import "./loadDotenv.js"
 
 const parseIntOrUndefined = (value: string | undefined): number | undefined => {
     try {

--- a/settings/loadDotenv.ts
+++ b/settings/loadDotenv.ts
@@ -7,11 +7,14 @@ if (typeof __dirname !== "undefined") {
     const baseDir = findBaseDir(__dirname)
     if (!baseDir) throw new Error("could not locate base package.json")
 
-    // If a ENV_FILE is specified, load its variables first, and then load the default .env file
-    const additionalEnvFile = process.env.ENV_FILE || undefined
+    // If a PRIMARY_ENV_FILE is specified, load its variables first, and then load the default .env file
+    const additionalEnvFile = process.env.PRIMARY_ENV_FILE || undefined
     let dotenvPath: string[]
     if (additionalEnvFile) {
         dotenvPath = [`${baseDir}/${additionalEnvFile}`, `${baseDir}/.env`]
+        console.log(
+            `Loading environment variables from ${dotenvPath.join(", ")}`
+        )
     } else {
         dotenvPath = [`${baseDir}/.env`]
     }

--- a/settings/loadDotenv.ts
+++ b/settings/loadDotenv.ts
@@ -1,0 +1,9 @@
+import dotenv from "dotenv"
+import findBaseDir from "./findBaseDir.js"
+
+if (typeof __dirname !== "undefined") {
+    // only run this code in node, not in the browser.
+    // in the browser, process.env is already populated by vite.
+    const baseDir = findBaseDir(__dirname)
+    if (baseDir) dotenv.config({ path: `${baseDir}/.env` })
+}

--- a/settings/loadDotenv.ts
+++ b/settings/loadDotenv.ts
@@ -5,5 +5,15 @@ if (typeof __dirname !== "undefined") {
     // only run this code in node, not in the browser.
     // in the browser, process.env is already populated by vite.
     const baseDir = findBaseDir(__dirname)
-    if (baseDir) dotenv.config({ path: `${baseDir}/.env` })
+    if (!baseDir) throw new Error("could not locate base package.json")
+
+    // If a ENV_FILE is specified, load its variables first, and then load the default .env file
+    const additionalEnvFile = process.env.ENV_FILE || undefined
+    let dotenvPath: string[]
+    if (additionalEnvFile) {
+        dotenvPath = [`${baseDir}/${additionalEnvFile}`, `${baseDir}/.env`]
+    } else {
+        dotenvPath = [`${baseDir}/.env`]
+    }
+    dotenv.config({ path: dotenvPath })
 }

--- a/settings/serverSettings.ts
+++ b/settings/serverSettings.ts
@@ -1,8 +1,9 @@
 // This is where server-side only, potentially sensitive settings enter from the environment
 // DO NOT store sensitive strings in this file itself, as it is checked in to git!
 
+import "./loadDotenv.js"
+
 import path from "path"
-import dotenv from "dotenv"
 import findBaseDir from "./findBaseDir.js"
 import fs from "fs"
 import ini from "ini"
@@ -10,8 +11,6 @@ import os from "os"
 
 const baseDir = findBaseDir(__dirname)
 if (baseDir === undefined) throw new Error("could not locate base package.json")
-
-dotenv.config({ path: `${baseDir}/.env` })
 
 import * as clientSettings from "./clientSettings.js"
 import { parseIntOrUndefined } from "@ourworldindata/utils"

--- a/site/viteUtils.tsx
+++ b/site/viteUtils.tsx
@@ -12,6 +12,7 @@ import { readFromAssetMap, sortBy } from "@ourworldindata/utils"
 import urljoin from "url-join"
 import { AssetMap } from "@ourworldindata/types"
 import { VITE_ENTRYPOINT_INFO, ViteEntryPoint } from "./viteConstants.js"
+import { ARCHIVE } from "../settings/clientSettings.js"
 
 const VITE_DEV_URL = process.env.VITE_DEV_URL ?? "http://localhost:8090"
 
@@ -185,7 +186,7 @@ const prodAssets = (
     }
 }
 
-const useProductionAssets = ENV !== "development" || VITE_PREVIEW
+const useProductionAssets = ENV !== "development" || VITE_PREVIEW || ARCHIVE
 
 const viteAssets = (
     entrypoint: ViteEntryPoint,


### PR DESCRIPTION
This PR allows specifying, e.g., `PRIMARY_ENV_FILE=.env.archive yarn tsx ./baker/archival/archiveChangedGrapherPages.ts`.

`PRIMARY_ENV_FILE` loads the specified env file as the _primary_ file, but still always loads `.env` and uses it for anything that's not explicitly overridden in `PRIMARY_ENV_FILE`.