### PR TITLE
feat(archive): disable sentry & cookie-based tracking

### DIFF
--- a/settings/clientSettings.ts
+++ b/settings/clientSettings.ts
@@ -124,3 +124,10 @@ export const FEATURE_FLAGS: Set<Feature> = new Set(
 
 export const SLACK_DI_PITCHES_CHANNEL_ID: string =
     process.env.SLACK_DI_PITCHES_CHANNEL_ID ?? ""
+
+export const IS_RUNNING_INSIDE_VITEST: boolean = !!process.env.VITEST
+
+/// Generated properties only, these cannot be overridden directly
+// Whether to only enable cookie-less tracking & never show the cookie notice
+export const REDUCED_TRACKING = ARCHIVE
+export const LOAD_SENTRY = !REDUCED_TRACKING && !IS_RUNNING_INSIDE_VITEST

--- a/settings/clientSettings.ts
+++ b/settings/clientSettings.ts
@@ -16,7 +16,8 @@ const parseIntOrUndefined = (value: string | undefined): number | undefined => {
 type Environment = "development" | "staging" | "production"
 export const ENV: Environment =
     (process.env.ENV as Environment) || "development"
-export const ARCHIVE: boolean = process.env.ARCHIVE === "true"
+export const ARCHIVE: boolean =
+    process.env.ARCHIVE === "true" || process.env.ARCHIVE === true
 export const COMMIT_SHA = process.env.COMMIT_SHA
 
 export const SENTRY_DSN: string | undefined = process.env.SENTRY_DSN
@@ -69,7 +70,8 @@ export const GOOGLE_TAG_MANAGER_ID: string =
     process.env.GOOGLE_TAG_MANAGER_ID ?? ""
 
 export const TOPICS_CONTENT_GRAPH: boolean =
-    process.env.TOPICS_CONTENT_GRAPH === "true"
+    process.env.TOPICS_CONTENT_GRAPH === "true" ||
+    process.env.TOPICS_CONTENT_GRAPH === true
 
 export const GDOCS_CLIENT_EMAIL: string = process.env.GDOCS_CLIENT_EMAIL ?? ""
 export const GDOCS_ARTICLE_DUPLICATION_TEMPLATE_ID: string =

--- a/settings/clientSettings.ts
+++ b/settings/clientSettings.ts
@@ -16,8 +16,7 @@ const parseIntOrUndefined = (value: string | undefined): number | undefined => {
 type Environment = "development" | "staging" | "production"
 export const ENV: Environment =
     (process.env.ENV as Environment) || "development"
-export const ARCHIVE: boolean =
-    process.env.ARCHIVE === "true" || process.env.ARCHIVE === true
+export const ARCHIVE: boolean = process.env.ARCHIVE === "true"
 export const COMMIT_SHA = process.env.COMMIT_SHA
 
 export const SENTRY_DSN: string | undefined = process.env.SENTRY_DSN
@@ -70,8 +69,7 @@ export const GOOGLE_TAG_MANAGER_ID: string =
     process.env.GOOGLE_TAG_MANAGER_ID ?? ""
 
 export const TOPICS_CONTENT_GRAPH: boolean =
-    process.env.TOPICS_CONTENT_GRAPH === "true" ||
-    process.env.TOPICS_CONTENT_GRAPH === true
+    process.env.TOPICS_CONTENT_GRAPH === "true"
 
 export const GDOCS_CLIENT_EMAIL: string = process.env.GDOCS_CLIENT_EMAIL ?? ""
 export const GDOCS_ARTICLE_DUPLICATION_TEMPLATE_ID: string =

--- a/site/cookiePreferences.ts
+++ b/site/cookiePreferences.ts
@@ -110,6 +110,7 @@ export const getPreferenceValue = (
     type: PreferenceType,
     preferences: Preference[] = getInitialState().preferences
 ) => {
+    // The REDUCED_TRACKING env setting can be used to disable analytics tracking entirely, regardless of user preferences or cookies
     if (type === PreferenceType.Analytics && REDUCED_TRACKING) return false
 
     return (

--- a/site/cookiePreferences.ts
+++ b/site/cookiePreferences.ts
@@ -1,5 +1,6 @@
 import { dayjs } from "@ourworldindata/utils"
 import Cookies from "js-cookie"
+import { REDUCED_TRACKING } from "../settings/clientSettings.js"
 
 export enum PreferenceType {
     Analytics = "a",
@@ -109,6 +110,8 @@ export const getPreferenceValue = (
     type: PreferenceType,
     preferences: Preference[] = getInitialState().preferences
 ) => {
+    if (type === PreferenceType.Analytics && REDUCED_TRACKING) return false
+
     return (
         preferences.find((preference) => {
             return preference.type === type

--- a/site/instrument.ts
+++ b/site/instrument.ts
@@ -1,9 +1,14 @@
 import * as Sentry from "@sentry/react"
 import { isInIFrame } from "@ourworldindata/utils"
-import { COMMIT_SHA, ENV, SENTRY_DSN } from "../settings/clientSettings.js"
+import {
+    COMMIT_SHA,
+    ENV,
+    LOAD_SENTRY,
+    SENTRY_DSN,
+} from "../settings/clientSettings.js"
 import { getPreferenceValue, PreferenceType } from "./cookiePreferences.js"
 
-if (!process.env.VITEST) {
+if (LOAD_SENTRY) {
     const analyticsConsent = getPreferenceValue(PreferenceType.Analytics)
 
     let sentryOpts: Sentry.BrowserOptions = {}

--- a/site/runSiteFooterScripts.tsx
+++ b/site/runSiteFooterScripts.tsx
@@ -43,6 +43,7 @@ import {
     MultiDimDataPageContentProps,
 } from "./multiDim/MultiDimDataPageContent.js"
 import { BrowserRouter } from "react-router-dom-v5-compat"
+import { REDUCED_TRACKING } from "../settings/clientSettings.js"
 
 function hydrateDataCatalogPage() {
     const root = document.getElementById("data-catalog-page-root")
@@ -100,6 +101,8 @@ function hydrateExplorerIndex() {
 }
 
 function runCookiePreferencesManager() {
+    if (REDUCED_TRACKING) return
+
     const div = document.createElement("div")
     document.body.appendChild(div)
 

--- a/vite.config-common.mts
+++ b/vite.config-common.mts
@@ -42,7 +42,7 @@ export const defineViteConfigForEntrypoint = (entrypoint: ViteEntryPoint) => {
             ...Object.fromEntries(
                 Object.entries(clientSettings).map(([key, value]) => [
                     `process.env.${key}`,
-                    JSON.stringify(value),
+                    JSON.stringify(value?.toString()), // We need to stringify e.g. `true` to `"true"`, so that it's correctly parsed _again_
                 ])
             ),
         },


### PR DESCRIPTION
When the `ARCHIVE` env var is set, we disable initializing Sentry, and will likewise disable cookie-based GA4 and the cookie notice.

The Sentry code (or, at the very least, part of it) is completely stripped from the bundled JS.