### PR TITLE
feat(archive): force local data download

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -2949,6 +2949,22 @@ export class Grapher
         )
     }
 
+    // Whether a server-side download is available for the download modal
+    @computed get isServerSideDownloadAvailable(): boolean {
+        return (
+            // Chart is published (this is false for charts inside explorers, for example)
+            !!this.isPublished &&
+            // We're not on an archival grapher page
+            !this.runtimeAssetMap &&
+            // We're not inside the admin
+            window.admin === undefined &&
+            // We're not on a Mdim
+            !!this.slug &&
+            // We're not in a chart view / narrative chart
+            !this.chartViewInfo
+        )
+    }
+
     private renderError(): React.ReactElement {
         return (
             <div

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
@@ -69,6 +69,7 @@ export interface DownloadModalManager {
     isSocialMediaExport?: boolean
     isPublished?: boolean
     activeColumnSlugs?: string[]
+    isServerSideDownloadAvailable?: boolean
 }
 
 interface DownloadModalProps {
@@ -753,12 +754,9 @@ export const DownloadModalDataTab = (props: DownloadModalProps) => {
     const { cols: nonRedistributableCols, sourceLinks } =
         getNonRedistributableInfo(props.manager.inputTable)
 
-    // Server-side download is not necessarily available for:
-    // - Explorers
-    // - Mdims
-    // - Charts authored/changed in the admin (incl. unpublished charts)
+    // Server-side download is not necessarily available for all types of charts
     const serverSideDownloadAvailable =
-        !!props.manager.isPublished && window.admin === undefined
+        props.manager.isServerSideDownloadAvailable
 
     const downloadCtx: Omit<
         DataDownloadContextClientSide,


### PR DESCRIPTION
Forces a local data download for archived pages, rather than a server-based one.

Also, it does the same for Mdims for now: until #4656 is fixed.