### PR TITLE
🐛 disable nice ticks for map sparklines

### DIFF
--- a/packages/@ourworldindata/grapher/src/mapCharts/MapSparkline.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapSparkline.tsx
@@ -139,6 +139,7 @@ export class MapSparkline extends React.Component<{
                     { value: -Infinity, priority: 2 },
                     { value: 0, priority: 1 },
                 ],
+                nice: false,
             },
             xAxisConfig: {
                 hideAxis: false,


### PR DESCRIPTION
For map sparklines, the top grid line should always be the max value, not a 'nice' tick value