### PR TITLE
🐛 fix indexing scheduled gdoc posts

### DIFF
--- a/baker/algolia/utils/pages.ts
+++ b/baker/algolia/utils/pages.ts
@@ -375,6 +375,17 @@ export async function indexIndividualGdocPost(
     indexedSlug: string
 ) {
     if (!ALGOLIA_INDEXING) return
+    const isScheduled = gdoc.publishedAt
+        ? gdoc.publishedAt.getTime() > Date.now()
+        : false
+
+    if (isScheduled) {
+        console.log(
+            `Not indexing Gdoc post ${gdoc.id} because it's scheduled for publishing`
+        )
+        return
+    }
+
     if (typeof gdoc.slug === "undefined") {
         console.error(`Failed indexing gdoc post ${gdoc.id} (No slug)`)
         return


### PR DESCRIPTION
Fixes `indexIndividualGdocPost` indexing posts that were scheduled for the future, which was causing not-live posts to show up in search