### PR TITLE
✨ (entity selector) sort by current values / TAS-932

### DIFF
--- a/adminSiteClient/EditorBasicTab.tsx
+++ b/adminSiteClient/EditorBasicTab.tsx
@@ -19,7 +19,7 @@ import {
 } from "@ourworldindata/types"
 import {
     DimensionSlot,
-    WorldEntityName,
+    WORLD_ENTITY_NAME,
     CONTINENTS_INDICATOR_ID,
     POPULATION_INDICATOR_ID_USED_IN_ADMIN,
 } from "@ourworldindata/grapher"
@@ -140,8 +140,8 @@ class DimensionSlotView<
             // non-stacked charts with multiple y-dimensions should select a single entity by default.
             // if possible, the currently selected entity is persisted, otherwise "World" is preferred
             if (selection.numSelectedEntities !== 1) {
-                const entity = availableEntityNameSet.has(WorldEntityName)
-                    ? WorldEntityName
+                const entity = availableEntityNameSet.has(WORLD_ENTITY_NAME)
+                    ? WORLD_ENTITY_NAME
                     : sample(availableEntityNames)
                 if (entity) selection.setSelectedEntities([entity])
             }

--- a/packages/@ourworldindata/core-table/src/CoreTableColumns.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTableColumns.ts
@@ -583,6 +583,16 @@ export abstract class AbstractCoreColumn<JS_TYPE extends PrimitiveType> {
     }
 
     // todo: remove? Should not be on CoreTable
+    @imemo get valuesByTime(): Map<Time, JS_TYPE[]> {
+        const map = new Map<Time, JS_TYPE[]>()
+        this.owidRows.forEach((row) => {
+            if (!map.has(row.time)) map.set(row.time, [])
+            map.get(row.time)!.push(row.value)
+        })
+        return map
+    }
+
+    // todo: remove? Should not be on CoreTable
     // NOTE: this uses the original times, so any tolerance is effectively unapplied.
     @imemo get valueByEntityNameAndOriginalTime(): Map<
         EntityName,

--- a/packages/@ourworldindata/grapher/src/controls/Dropdown.scss
+++ b/packages/@ourworldindata/grapher/src/controls/Dropdown.scss
@@ -20,6 +20,8 @@
     display: grid;
     grid-template-columns: minmax(0, 1fr);
 
+    $option-checkmark-width: 12px;
+
     .control {
         min-height: auto;
         font: $medium 13px/16px $lato;
@@ -65,7 +67,7 @@
         color: $dark-text;
 
         .option {
-            padding: 8px 28px 8px 18px;
+            padding: 8px calc(16px + $option-checkmark-width + 2px) 8px 16px;
             &:hover,
             &.focus {
                 cursor: pointer;
@@ -84,7 +86,7 @@
                 &:after {
                     content: " ";
                     background: url($option-checkmark) no-repeat;
-                    width: 12px;
+                    width: $option-checkmark-width;
                     height: 9px;
                     position: absolute;
                     right: 18px;

--- a/packages/@ourworldindata/grapher/src/controls/Dropdown.scss
+++ b/packages/@ourworldindata/grapher/src/controls/Dropdown.scss
@@ -65,7 +65,7 @@
         color: $dark-text;
 
         .option {
-            padding: 8px 18px;
+            padding: 8px 28px 8px 18px;
             &:hover,
             &.focus {
                 cursor: pointer;
@@ -88,7 +88,8 @@
                     height: 9px;
                     position: absolute;
                     right: 18px;
-                    bottom: 11px;
+                    bottom: 50%;
+                    transform: translateY(50%);
                 }
             }
         }

--- a/packages/@ourworldindata/grapher/src/controls/Dropdown.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/Dropdown.tsx
@@ -2,10 +2,11 @@ import * as React from "react"
 import Select, { Props } from "react-select"
 import cx from "classnames"
 
-export function Dropdown(props: Props): React.ReactElement {
+export function Dropdown<DropdownOption>(
+    props: Props<DropdownOption, false>
+): React.ReactElement {
     return (
-        <Select
-            className="grapher-dropdown"
+        <Select<DropdownOption, false>
             menuPlacement="bottom"
             components={{
                 IndicatorSeparator: null,
@@ -30,6 +31,7 @@ export function Dropdown(props: Props): React.ReactElement {
                 menu: () => "menu",
             }}
             {...props}
+            className={cx("grapher-dropdown", props.className)}
         />
     )
 }

--- a/packages/@ourworldindata/grapher/src/controls/MapProjectionMenu.scss
+++ b/packages/@ourworldindata/grapher/src/controls/MapProjectionMenu.scss
@@ -11,6 +11,6 @@
         content: "Zoom to selection";
         font: 700 12px/16px $lato;
         color: $light-text;
-        padding: 8px 18px;
+        padding: 8px 16px;
     }
 }

--- a/packages/@ourworldindata/grapher/src/controls/globalEntitySelector/GlobalEntitySelector.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/globalEntitySelector/GlobalEntitySelector.tsx
@@ -23,7 +23,7 @@ import {
     lazy,
 } from "@ourworldindata/utils"
 import { GrapherAnalytics } from "../../core/GrapherAnalytics"
-import { WorldEntityName } from "../../core/GrapherConstants"
+import { WORLD_ENTITY_NAME } from "../../core/GrapherConstants"
 import { GLOBAL_ENTITY_SELECTOR_ELEMENT } from "./GlobalEntitySelectorConstants"
 import { SelectionArray } from "../../selection/SelectionArray"
 import { EntityName } from "@ourworldindata/types"
@@ -50,7 +50,7 @@ const getAllEntitiesSortedWithWorld = lazy(() =>
         // Add 'World'
         .concat([
             {
-                name: WorldEntityName,
+                name: WORLD_ENTITY_NAME,
                 code: "OWID_WRL",
                 slug: "world",
                 regionType: "other",

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -126,7 +126,6 @@ import {
 import {
     BASE_FONT_SIZE,
     CookieKey,
-    ThereWasAProblemLoadingThisChart,
     DEFAULT_GRAPHER_WIDTH,
     DEFAULT_GRAPHER_HEIGHT,
     DEFAULT_GRAPHER_ENTITY_TYPE,
@@ -2983,7 +2982,7 @@ export class Grapher
             >
                 <p style={{ color: "#cc0000", fontWeight: 700 }}>
                     <FontAwesomeIcon icon={faExclamationTriangle} />
-                    {ThereWasAProblemLoadingThisChart}
+                    There was a problem loading this chart
                 </p>
                 <p>
                     We have been notified of this error, please check back later

--- a/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
@@ -68,7 +68,7 @@ export const isWorldEntityName = (entityName: EntityName): boolean =>
 export const CONTINENTS_INDICATOR_ID = 900801 // "Countries Continent"
 export const POPULATION_INDICATOR_ID_USED_IN_ADMIN = 953899 // "Population (various sources, 2024-07-15)"
 export const POPULATION_INDICATOR_ID_USED_IN_ENTITY_SELECTOR = 953903 // "Population (historical) (various sources, 2024-07-15)"
-export const GDP_PER_CAPITA_INDICATOR_ID_USED_IN_ENTITY_SELECTOR = 905490 // "World Development Indicators - World Bank (2024-05-20)"
+export const GDP_PER_CAPITA_INDICATOR_ID_USED_IN_ENTITY_SELECTOR = 900793 // "GDP per capita - Maddison Project Database (2024-04-26)"
 
 export const isContinentsVariableId = (id: string | number): boolean =>
     id.toString() === CONTINENTS_INDICATOR_ID.toString()

--- a/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
@@ -1,4 +1,4 @@
-import { GRAPHER_CHART_TYPES } from "@ourworldindata/types"
+import { EntityName, GRAPHER_CHART_TYPES } from "@ourworldindata/types"
 import { defaultGrapherConfig } from "../schema/defaultGrapherConfig.js"
 import type { GrapherProgrammaticInterface } from "./Grapher"
 
@@ -62,7 +62,10 @@ export enum CookieKey {
 
 export const ThereWasAProblemLoadingThisChart = `There was a problem loading this chart`
 
-export const WorldEntityName = "World"
+export const WORLD_ENTITY_NAME = "World"
+
+export const isWorldEntityName = (entityName: EntityName): boolean =>
+    entityName === WORLD_ENTITY_NAME
 
 export const CONTINENTS_INDICATOR_ID = 900801 // "Countries Continent"
 export const POPULATION_INDICATOR_ID_USED_IN_ADMIN = 953899 // "Population (various sources, 2024-07-15)"

--- a/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
@@ -60,8 +60,6 @@ export enum CookieKey {
     isAdmin = "isAdmin",
 }
 
-export const ThereWasAProblemLoadingThisChart = `There was a problem loading this chart`
-
 export const WORLD_ENTITY_NAME = "World"
 
 export const isWorldEntityName = (entityName: EntityName): boolean =>

--- a/packages/@ourworldindata/grapher/src/core/grapher.scss
+++ b/packages/@ourworldindata/grapher/src/core/grapher.scss
@@ -93,11 +93,11 @@ $zindex-controls-drawer: 150;
 @import "../../../components/src/OverlayHeader.scss";
 
 .grapher_dark {
-    color: $gray-80;
+    color: $dark-text;
 }
 
 .grapher_light {
-    color: $gray-70;
+    color: $light-text;
 }
 
 .GrapherComponent,

--- a/packages/@ourworldindata/grapher/src/core/typography.scss
+++ b/packages/@ourworldindata/grapher/src/core/typography.scss
@@ -129,6 +129,15 @@
     @include grapher_body-3-regular;
 }
 
+@mixin grapher_body-3-regular-italic {
+    @include grapher_body-3-regular;
+    font-style: italic;
+}
+
+.grapher_body-3-regular-italic {
+    @include grapher_body-3-regular-italic;
+}
+
 @mixin grapher_body-3-medium-italic {
     @include grapher_body-3-medium;
     font-style: italic;

--- a/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.scss
+++ b/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.scss
@@ -2,7 +2,7 @@
     --padding: var(--modal-padding, 16px);
 
     $sort-button-size: 32px;
-    $sort-button-margin: 16px;
+    $sort-button-margin: 8px;
 
     color: $dark-text;
 
@@ -101,10 +101,13 @@
 
     .entity-selector__sort-bar {
         padding: 0 var(--padding);
-        display: flex;
-        align-items: center;
         margin-top: 8px;
         margin-bottom: 16px;
+
+        .entity-selector__sort-dropdown-and-button {
+            display: flex;
+            align-items: center;
+        }
 
         .grapher-dropdown {
             flex-grow: 1;
@@ -112,7 +115,7 @@
 
         .label {
             flex-shrink: 0;
-            margin-right: 8px;
+            margin-bottom: 6px;
         }
 
         button.sort {

--- a/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.scss
+++ b/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.scss
@@ -109,8 +109,12 @@
             align-items: center;
         }
 
-        .grapher-dropdown {
+        .entity-selector__dropdown {
             flex-grow: 1;
+
+            .time {
+                color: $gray-60;
+            }
         }
 
         .label {

--- a/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
+++ b/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
@@ -836,25 +836,31 @@ export class EntitySelector extends React.Component<{
     private renderSortBar(): React.ReactElement {
         return (
             <div className="entity-selector__sort-bar">
-                <span className="label grapher_label-2-regular grapher_light">
-                    Sort by
-                </span>
-                <Dropdown
-                    options={this.sortOptions}
-                    onChange={this.onChangeSortSlug}
-                    value={this.sortValue}
-                    isLoading={this.isLoadingExternalSortColumn}
-                />
-                <button
-                    type="button"
-                    className="sort"
-                    onClick={this.onChangeSortOrder}
+                <div
+                    id="entity-selector__sort-dropdown-label"
+                    className="label grapher_label-2-regular grapher_light"
                 >
-                    <SortIcon
-                        type={this.isSortedByName ? "text" : "numeric"}
-                        order={this.sortConfig.order}
+                    Sort by
+                </div>
+                <div className="entity-selector__sort-dropdown-and-button">
+                    <Dropdown
+                        options={this.sortOptions}
+                        onChange={this.onChangeSortSlug}
+                        value={this.sortValue}
+                        isLoading={this.isLoadingExternalSortColumn}
+                        aria-labelledby="entity-selector__sort-dropdown-label"
                     />
-                </button>
+                    <button
+                        type="button"
+                        className="sort"
+                        onClick={this.onChangeSortOrder}
+                    >
+                        <SortIcon
+                            type={this.isSortedByName ? "text" : "numeric"}
+                            order={this.sortConfig.order}
+                        />
+                    </button>
+                </div>
             </div>
         )
     }

--- a/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
+++ b/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
@@ -43,6 +43,7 @@ import {
     POPULATION_INDICATOR_ID_USED_IN_ENTITY_SELECTOR,
     GDP_PER_CAPITA_INDICATOR_ID_USED_IN_ENTITY_SELECTOR,
     isPopulationVariableETLPath,
+    isWorldEntityName,
 } from "../core/GrapherConstants"
 import { CoreColumn, OwidTable } from "@ourworldindata/core-table"
 import { SortIcon } from "../controls/SortIcon"
@@ -84,8 +85,7 @@ interface SortConfig {
 type SearchableEntity = {
     name: string
     sortColumnValues: Record<ColumnSlug, CoreValueType | undefined>
-    local?: boolean
-    isWorld?: boolean
+    isLocal?: boolean
     alternativeNames?: string[]
 }
 
@@ -451,13 +451,12 @@ export class EntitySelector extends React.Component<{
         return this.availableEntityNames.map((entityName) => {
             const searchableEntity: SearchableEntity = {
                 name: entityName,
-                isWorld: entityName === "World",
                 sortColumnValues: {},
                 alternativeNames: getRegionAlternativeNames(entityName, langs),
             }
 
             if (this.localEntityNames) {
-                searchableEntity.local =
+                searchableEntity.isLocal =
                     this.localEntityNames.includes(entityName)
             }
 
@@ -497,12 +496,12 @@ export class EntitySelector extends React.Component<{
         if (shouldBeSortedByName && options.sortLocalsAndWorldToTop) {
             const [[worldEntity], entitiesWithoutWorld] = partition(
                 entities,
-                (entity) => entity.isWorld
+                (entity) => isWorldEntityName(entity.name)
             )
 
             const [localEntities, otherEntities] = partition(
                 entitiesWithoutWorld,
-                (entity: SearchableEntity) => entity.local
+                (entity: SearchableEntity) => entity.isLocal
             )
 
             const sortedLocalEntities = sortBy(
@@ -814,7 +813,7 @@ export class EntitySelector extends React.Component<{
                             checked={this.isEntitySelected(entity)}
                             bar={this.getBarConfigForEntity(entity)}
                             onChange={() => this.onChange(entity.name)}
-                            local={entity.local}
+                            isLocal={entity.isLocal}
                         />
                     </li>
                 ))}
@@ -835,7 +834,7 @@ export class EntitySelector extends React.Component<{
                             checked={this.isEntitySelected(entity)}
                             bar={this.getBarConfigForEntity(entity)}
                             onChange={() => this.onChange(entity.name)}
-                            local={entity.local}
+                            isLocal={entity.isLocal}
                         />
                     </li>
                 ))}
@@ -929,7 +928,7 @@ export class EntitySelector extends React.Component<{
                                     checked={true}
                                     bar={this.getBarConfigForEntity(entity)}
                                     onChange={() => this.onChange(entity.name)}
-                                    local={entity.local}
+                                    isLocal={entity.isLocal}
                                 />
                             </FlippedListItem>
                         ))}
@@ -964,7 +963,7 @@ export class EntitySelector extends React.Component<{
                                             onChange={() =>
                                                 this.onChange(entity.name)
                                             }
-                                            local={entity.local}
+                                            isLocal={entity.isLocal}
                                         />
                                     </FlippedListItem>
                                 )
@@ -1016,14 +1015,14 @@ function SelectableEntity({
     type,
     bar,
     onChange,
-    local,
+    isLocal,
 }: {
     name: string
     checked: boolean
     type: "checkbox" | "radio"
     bar?: BarConfig
     onChange: () => void
-    local?: boolean
+    isLocal?: boolean
 }) {
     const Input = {
         checkbox: Checkbox,
@@ -1031,7 +1030,7 @@ function SelectableEntity({
     }[type]
 
     const nameWords = name.split(" ")
-    const label = local ? (
+    const label = isLocal ? (
         <span className="label-with-location-icon">
             {nameWords.slice(0, -1).join(" ")}{" "}
             <span className="label-with-location-icon label-with-location-icon--no-line-break">

--- a/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
+++ b/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
@@ -830,7 +830,7 @@ export class EntitySelector extends React.Component<{
     private renderSortBar(): React.ReactElement {
         return (
             <div className="entity-selector__sort-bar">
-                <span className="label grapher_label-2-medium grapher_light">
+                <span className="label grapher_label-2-regular grapher_light">
                     Sort by
                 </span>
                 <Dropdown
@@ -959,7 +959,7 @@ export class EntitySelector extends React.Component<{
                     {selected.length > 0 && (
                         <Flipped flipId="__selection" translate opacity>
                             <div className="entity-section__header">
-                                <div className="entity-section__title grapher_body-3-medium-italic grapher_light">
+                                <div className="entity-section__title grapher_body-3-regular-italic grapher_light">
                                     Selection{" "}
                                     {numSelectedEntities > 0 &&
                                         `(${numSelectedEntities})`}
@@ -999,7 +999,7 @@ export class EntitySelector extends React.Component<{
                 {!hideAvailableEntities && (
                     <div className="entity-section">
                         <Flipped flipId="__available" translate opacity>
-                            <div className="entity-section__title grapher_body-3-medium-italic grapher_light">
+                            <div className="entity-section__title grapher_body-3-regular-italic grapher_light">
                                 All {this.entityTypePlural}
                             </div>
                         </Flipped>
@@ -1120,7 +1120,7 @@ function SelectableEntity({
             )}
             <Input label={label} checked={checked} onChange={onChange} />
             {bar && (
-                <span className="value grapher_label-1-medium">
+                <span className="value grapher_label-1-regular">
                     {bar.formattedValue}
                 </span>
             )}

--- a/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
+++ b/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
@@ -358,6 +358,10 @@ export class EntitySelector extends React.Component<{
 
     @computed private get entitiesAreCountriesOrRegions(): boolean {
         for (const entityName of this.availableEntityNames) {
+            // Ignore the World entity since we have charts that only have the
+            // World entity but no other countries or regions (e.g. 'World',
+            // 'Northern Hemisphere' and 'Southern hemisphere')
+            if (isWorldEntityName(entityName)) continue
             if (regionNamesSet.has(entityName)) return true
         }
         return false

--- a/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
+++ b/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
@@ -111,10 +111,18 @@ const EXTERNAL_SORT_INDICATOR_DEFINITIONS = [
             POPULATION_INDICATOR_ID_USED_IN_ENTITY_SELECTOR
         ),
         // checks if a column has population data
-        isMatch: (column: CoreColumn): boolean =>
-            isPopulationVariableETLPath(
+        isMatch: (column: CoreColumn): boolean => {
+            // check the slug first
+            const externalSlug = indicatorIdToSlug(
+                POPULATION_INDICATOR_ID_USED_IN_ENTITY_SELECTOR
+            )
+            if (column.slug === externalSlug) return true
+
+            // then check the catalog path
+            return isPopulationVariableETLPath(
                 (column.def as OwidColumnDef)?.catalogPath ?? ""
-            ),
+            )
+        },
     },
     {
         key: "gdpPerCapita",
@@ -125,8 +133,14 @@ const EXTERNAL_SORT_INDICATOR_DEFINITIONS = [
         ),
         // checks if a column has GDP per capita data
         isMatch: (column: CoreColumn): boolean => {
-            const label = makeLabelForSortColumn(column)
+            // check the slug first
+            const externalSlug = indicatorIdToSlug(
+                GDP_PER_CAPITA_INDICATOR_ID_USED_IN_ENTITY_SELECTOR
+            )
+            if (column.slug === externalSlug) return true
 
+            // then check the label
+            const label = makeLabelForSortColumn(column)
             // matches "gdp per capita" and content within parentheses
             const potentialMatches =
                 label.match(/\(.*?\)|(\bgdp per capita\b)/gi) ?? []

--- a/packages/@ourworldindata/grapher/src/index.ts
+++ b/packages/@ourworldindata/grapher/src/index.ts
@@ -22,7 +22,7 @@ export {
     CookieKey,
     BASE_FONT_SIZE,
     ThereWasAProblemLoadingThisChart,
-    WorldEntityName,
+    WORLD_ENTITY_NAME,
     Patterns,
     grapherInterfaceWithHiddenControls,
     grapherInterfaceWithHiddenTabs,

--- a/packages/@ourworldindata/grapher/src/index.ts
+++ b/packages/@ourworldindata/grapher/src/index.ts
@@ -21,7 +21,6 @@ export {
     GRAPHER_LOADED_EVENT_NAME,
     CookieKey,
     BASE_FONT_SIZE,
-    ThereWasAProblemLoadingThisChart,
     WORLD_ENTITY_NAME,
     Patterns,
     grapherInterfaceWithHiddenControls,

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -324,15 +324,19 @@ export function makeIdForHumanConsumption(...unsafeKeys: string[]): string {
     return makeSafeForFigma(unsafeKeys.join("__"))
 }
 
+export function toDate(dayAsYear: number): dayjs.Dayjs {
+    // Use dayjs' UTC mode
+    // This will force dayjs to format in UTC time instead of local time,
+    // making dates consistent no matter what timezone the user is in.
+    return dayjs.utc(EPOCH_DATE).add(dayAsYear, "days")
+}
+
 export function formatDay(
     dayAsYear: number,
     options?: { format?: string }
 ): string {
     const format = options?.format ?? "MMM D, YYYY"
-    // Use dayjs' UTC mode
-    // This will force dayjs to format in UTC time instead of local time,
-    // making dates consistent no matter what timezone the user is in.
-    return dayjs.utc(EPOCH_DATE).add(dayAsYear, "days").format(format)
+    return toDate(dayAsYear).format(format)
 }
 
 export const formatYear = (year: number): string => {

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -324,7 +324,7 @@ export function makeIdForHumanConsumption(...unsafeKeys: string[]): string {
     return makeSafeForFigma(unsafeKeys.join("__"))
 }
 
-export function toDate(dayAsYear: number): dayjs.Dayjs {
+export function convertDaysSinceEpochToDate(dayAsYear: number): dayjs.Dayjs {
     // Use dayjs' UTC mode
     // This will force dayjs to format in UTC time instead of local time,
     // making dates consistent no matter what timezone the user is in.
@@ -336,7 +336,7 @@ export function formatDay(
     options?: { format?: string }
 ): string {
     const format = options?.format ?? "MMM D, YYYY"
-    return toDate(dayAsYear).format(format)
+    return convertDaysSinceEpochToDate(dayAsYear).format(format)
 }
 
 export const formatYear = (year: number): string => {

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -136,7 +136,7 @@ export {
     getUniqueNamesFromParentTagArrays,
     getUserNavigatorLanguages,
     getUserNavigatorLanguagesNonEnglish,
-    toDate,
+    convertDaysSinceEpochToDate,
 } from "./Util.js"
 
 export {

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -136,6 +136,7 @@ export {
     getUniqueNamesFromParentTagArrays,
     getUserNavigatorLanguages,
     getUserNavigatorLanguagesNonEnglish,
+    toDate,
 } from "./Util.js"
 
 export {


### PR DESCRIPTION
Sort entities in Grapher's entity selector by the values of the currently selected year, rather than by the latest data point available for an entity

I also refactored some bits around externally loaded sort columns.

### Summary

- We need to interpolate with tolerance so that the chart data and the entity selector data is consistent
  - We do so on demand, i.e. only when a column is selected. Alternatively, we could apply tolerance to all columns of the `tableForSelection` but that's potentially expensive since we would apply tolerance to all columns of an unfiltered table with all available entities. That's not really worth it since most users don't use the Sort by option in the entity selector
  - Infinite tolerance is applied to the externally loaded indicators (population, GDP per capita) 
- Externally loaded indicators (population, GDP per capita) have yearly data but might be loaded into charts with daily data. In that case, we need to convert the `endTime` (in days) to years
  - Alternatively, we could join the externally loaded column into the table, but joining daily+yearly data is error-prone, so I opted for this approach instead
- For external indicators, we only know which year to use after the data has been loaded. If an external indicator hasn't been loaded yet, we don't mention any time in the option label and add it only after the data has been loaded.
  - Alternatively, we could load the external indicators up front, but that doesn't seem worth it. We could also hard-code the available time range for external indicators, but I don't think it's worth the maintenance burden. We could also only load the metadata and derive the available time range from it, but that also feels like an overkill to me

### Examples

- http://staging-site-sort-entities-by-current-val/grapher/life-expectancy
- http://staging-site-sort-entities-by-current-val/grapher/maternal-mortality-ratio-vs-mean-daily-income
- http://staging-site-sort-entities-by-current-val/grapher/share-of-students-achieving-minimum-proficiency-in-reading-and-math-by-education-level
- http://staging-site-sort-entities-by-current-val/grapher/excess-mortality-raw-death-count-single-series
- http://staging-site-sort-entities-by-current-val/grapher/excess-deaths-cumulative-economist-single-entity

The last example is a case where the data is sparse (and no appropriate tolerance is set), which means that value-sorting becomes kind of useless in the entity selector. I thought about applying infinite tolerance for daily data by default but then there would be a mismatch between chart and selector and I want to avoid that for now

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;1&nbsp;</kbd> #4692 👈 
<!-- GitButler Footer Boundary Bottom -->


<!-- GitButler Review Footer Boundary Top -->
---
⧓ Review in [Butler Review `#8It5EBMsL`](https://gitbutler.com/sophiamersmann/owid-grapher/reviews/8It5EBMsL)

**✨ (entity selector) sort by current values**


16 commit series (version 7)

| Series | Commit Title | Status | Reviewers | 
| --- | --- | --- | --- |
| 16/16 | [🔨 minor refactoring](https://gitbutler.com/sophiamersmann/owid-grapher/reviews/8It5EBMsL/commit/c123ed8b-70f4-4982-91b8-459f4f0fe4e4) | ⏳ |  |
| 15/16 | [🔨 only convert time for external indicators](https://gitbutler.com/sophiamersmann/owid-grapher/reviews/8It5EBMsL/commit/cd6456b1-49a2-4617-afff-5c61da28ab9f) | ⏳ |  |
| 14/16 | [🔨 check the slug when looking for column matches](https://gitbutler.com/sophiamersmann/owid-grapher/reviews/8It5EBMsL/commit/b2fe8db8-a4f8-4c7e-94dc-c0afe389085e) | ⏳ |  |
| 13/16 | [🐛 ignore World when checking for countries and regions](https://gitbutler.com/sophiamersmann/owid-grapher/reviews/8It5EBMsL/commit/aa55202b-7fab-4a3f-899d-c35570aacb6d) | ⏳ |  |
| 12/16 | [💄 make the year of sort option labels more subtle](https://gitbutler.com/sophiamersmann/owid-grapher/reviews/8It5EBMsL/commit/d3bcbc78-0c1f-43aa-8e49-ada26f047454) | ⏳ |  |
| 11/16 | [💄 use the full width for the sort-by dropdown](https://gitbutler.com/sophiamersmann/owid-grapher/reviews/8It5EBMsL/commit/354f7dd0-fc82-417d-80f9-e7f6e3188082) | ⏳ |  |
| 10/16 | [✨ scale bars by the max value for the currently selected year](https://gitbutler.com/sophiamersmann/owid-grapher/reviews/8It5EBMsL/commit/449705d9-1431-4c84-b2ab-98f3a43fa42c) | ⏳ |  |
| 9/16 | [✨ update gdp per capita indicator for sorting](https://gitbutler.com/sophiamersmann/owid-grapher/reviews/8It5EBMsL/commit/9e92962b-bb4d-43ed-be47-e677dfde4659) | ⏳ |  |
| 8/16 | [♻️ use light/dark text css variables](https://gitbutler.com/sophiamersmann/owid-grapher/reviews/8It5EBMsL/commit/0b02c30b-ce68-45f5-baca-c19337fb3f18) | ⏳ |  |
| 7/16 | [💄 change font weights to regular](https://gitbutler.com/sophiamersmann/owid-grapher/reviews/8It5EBMsL/commit/67c61115-1acc-4edf-9a01-0862c0bc2c41) | ⏳ |  |
| 6/16 | [✨ add time to sort dropdown labels](https://gitbutler.com/sophiamersmann/owid-grapher/reviews/8It5EBMsL/commit/94e96f97-cc95-4c70-9065-9ca5ff7ea91d) | ⏳ |  |
| 5/16 | [✨ sort by values of the currently selected year](https://gitbutler.com/sophiamersmann/owid-grapher/reviews/8It5EBMsL/commit/9eba5bba-6ef7-4a66-a560-1a65569b1340) | ⏳ |  |
| 4/16 | [♻️ simplify implementation of external sort indicators](https://gitbutler.com/sophiamersmann/owid-grapher/reviews/8It5EBMsL/commit/1f1995f3-73b7-40d4-a608-ffe4a778ecc6) | ⏳ |  |
| 3/16 | [♻️ remove unnecessary constant variable](https://gitbutler.com/sophiamersmann/owid-grapher/reviews/8It5EBMsL/commit/92ab3d5b-2b4e-4df5-8a91-9e88d1d609ab) | ⏳ |  |
| 2/16 | [♻️ improve/simplify variable names](https://gitbutler.com/sophiamersmann/owid-grapher/reviews/8It5EBMsL/commit/60e8371c-5023-44ea-b1d6-23892b01f9ca) | ⏳ |  |
| 1/16 | [🐛 prevent text and check icon from overlapping](https://gitbutler.com/sophiamersmann/owid-grapher/reviews/8It5EBMsL/commit/6ee4f99c-6198-432a-a367-c1b381881111) | ⏳ |  |

_Please leave review feedback in the [Butler Review](https://gitbutler.com/sophiamersmann/owid-grapher/reviews/8It5EBMsL)_
<!-- GitButler Review Footer Boundary Bottom -->
