### PR TITLE
🐛 update data insight image ID in place after uploading a new version

### DIFF
--- a/adminSiteClient/DataInsightIndexPage.tsx
+++ b/adminSiteClient/DataInsightIndexPage.tsx
@@ -431,6 +431,7 @@ export function DataInsightIndexPage() {
                           image: dataInsight.image
                               ? {
                                     ...dataInsight.image,
+                                    id: uploadedImage.id,
                                     filename: uploadedImage.filename!,
                                     cloudflareId: uploadedImage.cloudflareId!,
                                     originalWidth: uploadedImage.originalWidth!,


### PR DESCRIPTION
Fixes an [issue Saloni's been encountering](https://our-world-in-data.sentry.io/issues/34514650/?alert_rule_id=119552&alert_type=issue&environment=production&notification_uuid=4baf4420-b103-4fdf-9725-68756196d1d7&project=4508607592464464&referrer=slack) where a second attempt to update an image would fail, due to a DB collision.

**The broken flow:**
1. Image with ID 1 exists in the DB
2. Update image from Figma via a PUT to `/api/images/1`
3. DB adds new image data as image with ID 2
4. Client doesn't update the ID
5. Update image from Figma again, via a PUT to `/api/images/1`
6. DB throws error

**Fix**
Update the ID of the image in the client as well, so that the second update will PUT to `/api/images/2`