### PR TITLE
:bug: fix error with ExplorerCreatePage.scss

### DIFF
--- a/adminSiteClient/admin.entry.ts
+++ b/adminSiteClient/admin.entry.ts
@@ -4,7 +4,7 @@ import "./instrument.js"
 
 import "./admin.scss"
 import "@ourworldindata/grapher/src/core/grapher.scss"
-import "../explorerAdminClient/ExplorerCreatePage.scss"
+import "../adminSiteClient/ExplorerCreatePage.scss"
 import "handsontable/dist/handsontable.full.css"
 import updateLocale from "dayjs/plugin/updateLocale"
 import { dayjs } from "@ourworldindata/utils"

--- a/adminSiteClient/admin.entry.ts
+++ b/adminSiteClient/admin.entry.ts
@@ -4,7 +4,7 @@ import "./instrument.js"
 
 import "./admin.scss"
 import "@ourworldindata/grapher/src/core/grapher.scss"
-import "../adminSiteClient/ExplorerCreatePage.scss"
+import "./ExplorerCreatePage.scss"
 import "handsontable/dist/handsontable.full.css"
 import updateLocale from "dayjs/plugin/updateLocale"
 import { dayjs } from "@ourworldindata/utils"

--- a/devTools/project-dependencies.md
+++ b/devTools/project-dependencies.md
@@ -9,7 +9,6 @@ graph TD;
     coreTable;
     db;
     explorer;
-    explorerAdminClient;
     explorerAdminServer;
     gitCms;
     grapher;
@@ -20,7 +19,6 @@ graph TD;
 
     adminSiteClient --> clientUtils;
     adminSiteClient --> explorer;
-    adminSiteClient --> explorerAdminClient;
     adminSiteClient --> grapher;
     adminSiteClient --> settings;
     adminSiteClient --> site;
@@ -54,13 +52,6 @@ graph TD;
     explorer --> coreTable;
     explorer --> grapher;
     explorer --> gridLang;
-
-    explorerAdminClient --> clientUtils;
-    explorerAdminClient --> coreTable;
-    explorerAdminClient --> explorer;
-    explorerAdminClient --> gitCms;
-    explorerAdminClient --> grapher;
-    explorerAdminClient --> gridLang;
 
     explorerAdminServer --> clientUtils;
     explorerAdminServer --> coreTable;

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -23,7 +23,6 @@ export default tseslint.config(
             // TODO: Apply to all React files when we move off class components,
             // since they are not supported.
             "adminSiteClient/**/*.tsx",
-            "explorerAdminClient/**/*.tsx",
             "packages/@ourworldindata/components/src/**/*.tsx",
             "site/**/*.tsx",
         ],
@@ -131,7 +130,6 @@ export default tseslint.config(
             "db/**/*",
             "devTools/**/*",
             "functions/**/*",
-            "explorerAdminClient/**/*",
             "explorerAdminServer/**/*",
             "settings/**/*",
         ],


### PR DESCRIPTION
I forgot `explorerAdminClient/ExplorerCreatePage.scss` in there which caused build error
```
error during build:
--
  | Could not resolve "../explorerAdminClient/ExplorerCreatePage.scss" from "adminSiteClient/admin.entry.ts"
  | file: /home/owid/owid-grapher/adminSiteClient/admin.entry.ts
  | at getRollupError (file:///home/owid/owid-grapher/node_modules/rollup/dist/es/shared/parseAst.js:397:41)
  | at error (file:///home/owid/owid-grapher/node_modules/rollup/dist/es/shared/parseAst.js:393:42)
  | at ModuleLoader.handleInvalidResolvedId (file:///home/owid/owid-grapher/node_modules/rollup/dist/es/shared/node-entry.js:21111:24)
  | at file:///home/owid/owid-grapher/node_modules/rollup/dist/es/shared/node-entry.js:21071:26
  | 🚨 Error: The command exited with status 1
```