### PR TITLE
✨ re-enable map tab tickbox for scatters

### DIFF
--- a/adminSiteClient/EditorBasicTab.tsx
+++ b/adminSiteClient/EditorBasicTab.tsx
@@ -542,15 +542,13 @@ export class EditorBasicTab<
                         options={this.chartTypeOptions}
                     />
                     <FieldsRow>
-                        {editor.features.canToggleMapTab && (
-                            <Toggle
-                                label="Map tab"
-                                value={grapher.hasMapTab}
-                                onValue={(shouldHaveMapTab) =>
-                                    (grapher.hasMapTab = shouldHaveMapTab)
-                                }
-                            />
-                        )}
+                        <Toggle
+                            label="Map tab"
+                            value={grapher.hasMapTab}
+                            onValue={(shouldHaveMapTab) =>
+                                (grapher.hasMapTab = shouldHaveMapTab)
+                            }
+                        />
                         {grapher.isLineChart && (
                             <Toggle
                                 label="Slope chart"

--- a/adminSiteClient/EditorFeatures.tsx
+++ b/adminSiteClient/EditorFeatures.tsx
@@ -167,8 +167,4 @@ export class EditorFeatures {
             this.grapher.isOnChartTab
         )
     }
-
-    @computed get canToggleMapTab() {
-        return !this.grapher.isScatter
-    }
 }


### PR DESCRIPTION
Re-enabling to make it possible to remove a map tab when it's enabled for a scatter plot.