### PR TITLE
Fix margin of Button without icon

### DIFF
--- a/packages/@ourworldindata/components/src/Button/Button.scss
+++ b/packages/@ourworldindata/components/src/Button/Button.scss
@@ -12,12 +12,12 @@
     }
 }
 
-.owid-btn--icon-right span {
-    margin-right: 0.5rem;
+.owid-btn--icon-right {
+    margin-left: 0.5rem;
 }
 
-.owid-btn--icon-left span {
-    margin-left: 0.5rem;
+.owid-btn--icon-left {
+    margin-right: 0.5rem;
 }
 
 .owid-btn--solid-vermillion {

--- a/packages/@ourworldindata/components/src/Button/Button.tsx
+++ b/packages/@ourworldindata/components/src/Button/Button.tsx
@@ -42,17 +42,16 @@ export const Button = ({
     iconPosition = "right",
     dataTrackNote,
 }: ButtonProps) => {
-    const classes = cx(
-        "owid-btn",
-        `owid-btn--${theme}`,
-        `owid-btn--icon-${iconPosition}`,
-        className
-    )
+    const classes = cx("owid-btn", `owid-btn--${theme}`, className)
     const content = (
         <>
-            {iconPosition === "left" && icon && <FontAwesomeIcon icon={icon} />}
+            {iconPosition === "left" && icon && (
+                <FontAwesomeIcon className="owid-btn--icon-left" icon={icon} />
+            )}
             {text && <span>{text}</span>}
-            {iconPosition !== "left" && icon && <FontAwesomeIcon icon={icon} />}
+            {iconPosition !== "left" && icon && (
+                <FontAwesomeIcon className="owid-btn--icon-right" icon={icon} />
+            )}
         </>
     )
 


### PR DESCRIPTION
## Context

When we recently changed how icons in `Button` work, we introduced this additional margin when there is no icon.

## Screenshots / Videos / Diagrams

<img width="131" alt="image" src="https://github.com/user-attachments/assets/6a5813fc-4c4f-4649-bdae-586ea399f24e" />