### PR TITLE
:broom: Remove dataset_files table

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,11 @@ migrate: node_modules
 	yarn buildLerna && yarn runDbMigrations
 
 refresh:
+	@if grep -q "ENV=production" .env; then \
+		echo "ERROR: Cannot run refresh in production environment."; \
+		exit 1; \
+	fi
+
 	@echo '==> Downloading chart data'
 	./devTools/docker/download-grapher-metadata-mysql.sh
 

--- a/adminSiteClient/DatasetEditPage.tsx
+++ b/adminSiteClient/DatasetEditPage.tsx
@@ -48,7 +48,6 @@ interface DatasetPageData {
     variables: VariableListItem[]
     charts: ChartListItem[]
     variableSources: OwidSource[]
-    zipFile?: { filename: string }
 
     origins: OwidOrigin[]
 }

--- a/adminSiteClient/DatasetEditPage.tsx
+++ b/adminSiteClient/DatasetEditPage.tsx
@@ -282,17 +282,6 @@ class DatasetEditor extends Component<{ dataset: DatasetPageData }> {
                             <FontAwesomeIcon icon={faGithub} /> View on GitHub
                         </a>
                     )}
-                    {/* Download additional content (old) */}
-                    {dataset.zipFile && (
-                        <Link
-                            native
-                            to={`/datasets/${dataset.id}/downloadZip`}
-                            className="btn btn-secondary"
-                        >
-                            <FontAwesomeIcon icon={faDownload} />{" "}
-                            additional-material.zip
-                        </Link>
-                    )}
                 </section>
 
                 {/* DATASET METADATA */}

--- a/adminSiteServer/adminRouter.tsx
+++ b/adminSiteServer/adminRouter.tsx
@@ -38,7 +38,7 @@ import {
 } from "../baker/GrapherBaker.js"
 import { getChartConfigById, getChartConfigBySlug } from "../db/model/Chart.js"
 import { getVariableMetadata } from "../db/model/Variable.js"
-import { DbPlainDatasetFile, DbPlainDataset } from "@ourworldindata/types"
+import { DbPlainDataset } from "@ourworldindata/types"
 import { getPlainRouteWithROTransaction } from "./plainRouterHelpers.js"
 import {
     getMultiDimDataPageByCatalogPath,
@@ -163,23 +163,6 @@ getPlainRouteWithROTransaction(
         })
         await writeDatasetCSV(trx, datasetId, writeStream)
         res.end()
-    }
-)
-
-getPlainRouteWithROTransaction(
-    adminRouter,
-    "/datasets/:datasetId/downloadZip",
-    async (req, res, trx) => {
-        const datasetId = expectInt(req.params.datasetId)
-
-        res.attachment("additional-material.zip")
-
-        const file = await db.knexRawFirst<
-            Pick<DbPlainDatasetFile, "filename" | "file">
-        >(trx, `SELECT filename, file FROM dataset_files WHERE datasetId=?`, [
-            datasetId,
-        ])
-        res.send(file?.file)
     }
 )
 

--- a/adminSiteServer/apiRoutes/datasets.ts
+++ b/adminSiteServer/apiRoutes/datasets.ts
@@ -121,13 +121,6 @@ export async function getDataset(
 
     if (!dataset) throw new JsonError(`No dataset by id '${datasetId}'`, 404)
 
-    const zipFile = await db.knexRawFirst<{ filename: string }>(
-        trx,
-        `SELECT filename FROM dataset_files WHERE datasetId=?`,
-        [datasetId]
-    )
-    if (zipFile) dataset.zipFile = zipFile
-
     const variables = await db.knexRaw<
         Pick<
             DbRawVariable,
@@ -350,9 +343,6 @@ export async function deleteDataset(
         `DELETE d FROM country_latest_data AS d JOIN variables AS v ON d.variable_id=v.id WHERE v.datasetId=?`,
         [datasetId]
     )
-    await db.knexRaw(trx, `DELETE FROM dataset_files WHERE datasetId=?`, [
-        datasetId,
-    ])
     await db.knexRaw(trx, `DELETE FROM variables WHERE datasetId=?`, [
         datasetId,
     ])

--- a/db/exportMetadata.ts
+++ b/db/exportMetadata.ts
@@ -22,12 +22,7 @@ const filePath =
         ? "/tmp/owid_metadata.sql"
         : "/tmp/owid_metadata_with_passwords.sql")
 
-const excludeTables = [
-    "analytics_pageviews",
-    "dataset_files",
-    "donors",
-    "sessions",
-]
+const excludeTables = ["analytics_pageviews", "donors", "sessions"]
 
 async function dataExport(): Promise<void> {
     console.log(`Exporting database structure and metadata to ${filePath}...`)

--- a/db/migration/1743576697066-RemoveDatasetFilesTable.ts
+++ b/db/migration/1743576697066-RemoveDatasetFilesTable.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
 import { MigrationInterface, QueryRunner } from "typeorm"
 
 export class RemoveDatasetFilesTable1743576697066
@@ -7,5 +8,5 @@ export class RemoveDatasetFilesTable1743576697066
         await queryRunner.query(`DROP TABLE IF EXISTS dataset_files`)
     }
 
-    public async down(_queryRunner: QueryRunner): Promise<void> {}
+    public async down(): Promise<void> {}
 }

--- a/db/migration/1743576697066-RemoveDatasetFilesTable.ts
+++ b/db/migration/1743576697066-RemoveDatasetFilesTable.ts
@@ -1,0 +1,11 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class RemoveDatasetFilesTable1743576697066
+    implements MigrationInterface
+{
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP TABLE IF EXISTS dataset_files`)
+    }
+
+    public async down(_queryRunner: QueryRunner): Promise<void> {}
+}

--- a/packages/@ourworldindata/types/src/dbTypes/DatasetFiles.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/DatasetFiles.ts
@@ -1,9 +1,0 @@
-export const DatasetFilesTableName = "dataset_files"
-export interface DbInsertDatasetFile {
-    createdAt?: Date
-    datasetId: number
-    file: any
-    filename: string
-    updatedAt?: Date | null
-}
-export type DbPlainDatasetFile = Required<DbInsertDatasetFile>

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -524,11 +524,6 @@ export {
     CountryLatestDataTableName,
 } from "./dbTypes/CountryLatestData.js"
 export {
-    type DbPlainDatasetFile,
-    type DbInsertDatasetFile,
-    DatasetFilesTableName,
-} from "./dbTypes/DatasetFiles.js"
-export {
     type DbPlainDataset,
     type DbInsertDataset,
     DatasetsTableName,


### PR DESCRIPTION
Table `dataset_files` was historically used for downloading a zipped version of a dataset. It hasn't been used for years and the table is empty in production.

I also smuggled in a safeguard to prevent `make refresh` from running when `ENV=production`.