### PR TITLE
enhance(maps): scale country outline stroke in an area-preserving way

### DIFF
--- a/packages/@ourworldindata/grapher/src/mapCharts/ChoroplethMap.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/ChoroplethMap.tsx
@@ -110,6 +110,10 @@ export class ChoroplethMap extends React.Component<{
         )
     }
 
+    @computed private get viewportScaleSqrt(): number {
+        return Math.sqrt(this.viewportScale)
+    }
+
     @computed private get matrixTransform(): string {
         const { bounds, mapBounds, viewport, viewportScale } = this
 
@@ -219,7 +223,7 @@ export class ChoroplethMap extends React.Component<{
     renderFeaturesOutsideRegion(): React.ReactElement | void {
         if (this.featuresOutsideRegion.length === 0) return
 
-        const strokeWidth = this.defaultStrokeWidth / this.viewportScale
+        const strokeWidth = this.defaultStrokeWidth / this.viewportScaleSqrt
 
         return (
             <g
@@ -283,7 +287,7 @@ export class ChoroplethMap extends React.Component<{
                     const strokeWidth =
                         (isFocus
                             ? this.focusStrokeWidth
-                            : this.defaultStrokeWidth) / this.viewportScale
+                            : this.defaultStrokeWidth) / this.viewportScaleSqrt
                     return (
                         <path
                             key={feature.id}
@@ -342,7 +346,7 @@ export class ChoroplethMap extends React.Component<{
                                 : showSelectedStyle
                                   ? this.selectedStrokeWidth
                                   : this.defaultStrokeWidth) /
-                            this.viewportScale
+                            this.viewportScaleSqrt
 
                         return (
                             <path


### PR DESCRIPTION
Changes the way we calculate a country's stroke width depending on viewport scale.

## Technical/mathematical background

According to the [transform matrix docs](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/transform#matrix) (relevant in this formula: `a` and `d`), we're multiplying both x and y dimensions by `viewportScale`.
This, in turn, means that the right way to scale something in an area-preserving way is to use the square root of `viewportScale`.

## Screenshots

All screenshots taken in Firefox. You can see a stark difference at 300% and 400%.

| Zoom level | Live | This PR |
|--------|--------|--------|
| 50% | ![CleanShot 2025-04-02 at 17 41 12](https://github.com/user-attachments/assets/ecd10b42-d5f9-4de2-9ed7-8e8aeed075b5) | ![CleanShot 2025-04-02 at 17 41 41](https://github.com/user-attachments/assets/35fc7513-abec-45e5-a10a-d01398005484) |
| 100% | ![Screen Shot 2025-04-02 at 17 35 03](https://github.com/user-attachments/assets/50f33d89-09df-4a73-923b-3e94249a8653) | ![Screen Shot 2025-04-02 at 17 35 07](https://github.com/user-attachments/assets/34ea2dcd-e7e3-4aee-adb7-6398c0a5a7bd) |
| 200% | ![Screen Shot 2025-04-02 at 17 36 04](https://github.com/user-attachments/assets/d57b20d8-8c87-43b2-964f-5523753bf4a3) | ![Screen Shot 2025-04-02 at 17 36 11](https://github.com/user-attachments/assets/e7a3eae6-93f8-4d80-bef8-1a472144d1cd) |
| 300% | ![Screen Shot 2025-04-02 at 17 36 51](https://github.com/user-attachments/assets/565c4ad1-5667-4f79-b28a-37a2b7277877) | ![Screen Shot 2025-04-02 at 17 36 55](https://github.com/user-attachments/assets/d8a2b764-cee4-4df9-bdc9-5d516a378b87) |
| 400% | ![Screen Shot 2025-04-02 at 17 43 31](https://github.com/user-attachments/assets/93644bad-5523-4e58-8578-8f7517b9df59) | ![Screen Shot 2025-04-02 at 17 42 53](https://github.com/user-attachments/assets/31e0dde1-2d56-4a6e-af54-3dde8e95d47e) |

