### PR TITLE
Fix Buildkite output groups

### DIFF
--- a/baker/countryProfiles.tsx
+++ b/baker/countryProfiles.tsx
@@ -222,6 +222,7 @@ export const bakeCountries = async (
     baker: SiteBaker,
     trx: db.KnexReadonlyTransaction
 ) => {
+    baker.progressBar.tick({ name: "Baking countries" })
     const html = await countriesIndexPage(baker.baseUrl)
     await baker.writeFile("/countries.html", html)
 
@@ -231,6 +232,4 @@ export const bakeCountries = async (
         const html = await countryProfilePage(trx, country.slug, baker.baseUrl)
         await baker.writeFile(path, html)
     }
-
-    baker.progressBar.tick({ name: "✅ baked countries" })
 }


### PR DESCRIPTION
## Context

Buildkite uses special syntax where --- marks a start of the group in the output of a build. We were using it to mark an end of the group, making the rendered HTML collapsible sections confusing in the Builkite UI.

## Testing guidance

See the output of the Buildkite build for this PR.