### PR TITLE
Avoid a redirect when detecting user's country

### DIFF
--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -590,7 +590,7 @@ export const fetchText = async (url: string): Promise<string> => {
 const _getUserCountryInformation = async (): Promise<
     UserCountryInformation | undefined
 > =>
-    await fetchWithRetry("/detect-country")
+    await fetchWithRetry("https://detect-country.owid.io")
         .then((res) => res.json())
         .then((res) => res.country)
         .catch(() => undefined)


### PR DESCRIPTION
This way we avoid one redirect request, which was slowing down the loading of the donate form, where we recently started using country detection.
