### PR TITLE
:bug: Fix stuck deploy queue on staging servers

### DIFF
--- a/adminSiteServer/appClass.tsx
+++ b/adminSiteServer/appClass.tsx
@@ -4,7 +4,7 @@ import * as Sentry from "@sentry/node"
 require("express-async-errors") // todo: why the require?
 import cookieParser from "cookie-parser"
 import http from "http"
-import { BAKED_BASE_URL, ENV_IS_STAGING } from "../settings/serverSettings.js"
+import { BAKED_BASE_URL, ENV } from "../settings/serverSettings.js"
 import * as db from "../db/db.js"
 import { IndexPage } from "./IndexPage.js"
 import {
@@ -57,7 +57,7 @@ export class OwidAdminApp {
 
         app.use(express.urlencoded({ extended: true, limit: "50mb" }))
 
-        if (ENV_IS_STAGING) {
+        if (ENV == "staging") {
             // Try to log in with tailscale if we're in staging
             app.use(tailscaleAuthMiddleware)
         } else {

--- a/adminSiteServer/appClass.tsx
+++ b/adminSiteServer/appClass.tsx
@@ -57,7 +57,7 @@ export class OwidAdminApp {
 
         app.use(express.urlencoded({ extended: true, limit: "50mb" }))
 
-        if (ENV == "staging") {
+        if (ENV === "staging") {
             // Try to log in with tailscale if we're in staging
             app.use(tailscaleAuthMiddleware)
         } else {

--- a/baker/DeployUtils.ts
+++ b/baker/DeployUtils.ts
@@ -6,6 +6,7 @@ import {
     BAKED_BASE_URL,
     BUILDKITE_API_ACCESS_TOKEN,
     SLACK_BOT_OAUTH_TOKEN,
+    ENV,
 } from "../settings/serverSettings.js"
 import { SiteBaker } from "../baker/SiteBaker.js"
 import { WebClient } from "@slack/web-api"
@@ -93,8 +94,7 @@ const getChangesSlackMentions = async (
 const getEmailSlackMentionsMap = async (
     queueItems: DeployChange[]
 ): Promise<Map<string, string>> => {
-    // SLACK_BOT_OAUTH_TOKEN is not available on staging environments
-    if (!SLACK_BOT_OAUTH_TOKEN) return new Map()
+    if (ENV === "staging" || !SLACK_BOT_OAUTH_TOKEN) return new Map()
 
     const slackClient = new WebClient(SLACK_BOT_OAUTH_TOKEN)
 

--- a/settings/serverSettings.ts
+++ b/settings/serverSettings.ts
@@ -183,10 +183,4 @@ export const LEGACY_WORDPRESS_IMAGE_URL: string =
 export const SEARCH_EVAL_URL: string =
     "https://pub-ec761fe0df554b02bc605610f3296000.r2.dev"
 
-// We currently use ENV=production on staging servers, it'd be better to have ENV=staging
-// but that would require changing a lot of code
-export const ENV_IS_STAGING: boolean = ADMIN_BASE_URL.includes(
-    "http://staging-site"
-)
-
 export const FIGMA_API_KEY: string = process.env.FIGMA_API_KEY ?? ""


### PR DESCRIPTION
A lot of staging servers were failing in `getEmailSlackMentionsMap`, causing their deploy queues to run indefinitely. This happened because we used `SLACK_BOT_OAUTH_TOKEN` to detect staging servers—but we recently added that token to staging servers as well.

Fortunately, our staging servers now finally use `ENV=staging`, so we can clean up these hacks for good. 🎉

(I’ve deleted all `.pending` files on staging servers to unstuck the queues.)  