### PR TITLE
feat(archive): archive banner & navigation links

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ help:
 	@echo '  make dbtest                 run db test suite that needs a running mysql db'
 	@echo '  make svgtest                compare current rendering against reference SVGs'
 	@echo '  make local-bake             do a full local site bake'
+	@echo '  make archive                create an archived version of our charts'
 	@echo
 	@echo '  GRAPHER + CLOUDFLARE (staff-only)'
 	@echo '  make up.full                start dev environment via docker-compose and tmux'
@@ -309,6 +310,11 @@ local-bake: itsJustJavascript
 	@echo '==> Baking site'
 	yarn buildVite
 	yarn buildLocalBake
+
+archive: itsJustJavascript
+	@echo '==> Creating an archived version of our charts'
+	PRIMARY_ENV_FILE=.env.archive yarn buildViteArchive
+	PRIMARY_ENV_FILE=.env.archive yarn tsx --tsconfig tsconfig.tsx.json ./baker/archival/archiveChangedGrapherPages.ts --latestDir
 
 clean:
 	rm -rf node_modules itsJustJavascript

--- a/baker/archival/ArchivalBaker.ts
+++ b/baker/archival/ArchivalBaker.ts
@@ -15,6 +15,7 @@ import {
 } from "./archivalUtils.js"
 import pMap from "p-map"
 import { GrapherChecksumsObjectWithHash } from "./archivalChecksum.js"
+import type { ArchiveMetaInformation } from "../../site/archive/archiveTypes.js"
 
 export const projBaseDir = findProjectBaseDir(__dirname)
 if (!projBaseDir) throw new Error("Could not find project base directory")
@@ -270,11 +271,16 @@ export const bakeGrapherPagesToFolder = async (
                 archivalDate: date.formattedDate,
                 chartConfigId,
             })
+            const archiveInformation: ArchiveMetaInformation = {
+                archiveDate: date.date,
+                liveUrl: `https://ourworldindata.org/grapher/${config.slug}`,
+            }
             await bakeSingleGrapherPageForArchival(dir, config, trx, {
                 imageMetadataDictionary,
                 staticAssetMap,
                 runtimeAssetMap: runtimeFiles,
                 manifest,
+                archiveInformation,
             })
             manifests[chartId] = manifest
 

--- a/baker/archival/ArchivalBaker.ts
+++ b/baker/archival/ArchivalBaker.ts
@@ -120,7 +120,7 @@ const bakeOwidMjsFile = async (
 const ASSET_FILES = ["owid.mjs.map", "owid.mjs", "owid.css"]
 const IGNORED_FILES = [".vite"]
 export const bakeAssets = async (archiveDir: string) => {
-    const srcDir = path.join(projBaseDir, "dist/assets")
+    const srcDir = path.join(projBaseDir, "dist/assets-archive")
     const targetDir = path.join(archiveDir, "assets")
 
     await fs.mkdirp(targetDir)

--- a/baker/archival/archivalChecksum.ts
+++ b/baker/archival/archivalChecksum.ts
@@ -86,10 +86,10 @@ export const getLatestArchivedVersionsFromDb = async (
         WHERE (grapherId, archivalTimestamp) IN (SELECT grapherId, MAX(archivalTimestamp) FROM archived_chart_versions a2 GROUP BY grapherId)
             AND (
                  grapherId IN (:chartIds)
-                 OR :chartIds IS NULL
+                 OR (:chartIdsIsNull)
             )
         `,
-        { chartIds: chartIds ?? null }
+        { chartIds: chartIds ?? null, chartIdsIsNull: !chartIds }
     )
 }
 

--- a/baker/archival/archivalChecksum.ts
+++ b/baker/archival/archivalChecksum.ts
@@ -69,18 +69,27 @@ const getGrapherChecksumsFromDb = async (knex: db.KnexReadonlyTransaction) => {
     return rows
 }
 
-// Not currently used, but this method/query will be useful for debugging and for future work
-const _getLatestArchivedVersionsFromDb = async (
-    knex: db.KnexReadonlyTransaction
-) => {
+export const getLatestArchivedVersionsFromDb = async (
+    knex: db.KnexReadonlyTransaction,
+    chartIds?: number[]
+): Promise<
+    Pick<
+        DbPlainArchivedChartVersion,
+        "grapherId" | "grapherSlug" | "archivalTimestamp" | "hashOfInputs"
+    >[]
+> => {
     return db.knexRaw(
         knex,
         `-- sql
-        SELECT grapherId, archivalTimestamp, hashOfInputs
+        SELECT grapherId, grapherSlug, archivalTimestamp, hashOfInputs
         FROM archived_chart_versions a1
         WHERE (grapherId, archivalTimestamp) IN (SELECT grapherId, MAX(archivalTimestamp) FROM archived_chart_versions a2 GROUP BY grapherId)
-        GROUP BY id
-        `
+            AND (
+                 grapherId IN (:chartIds)
+                 OR :chartIds IS NULL
+            )
+        `,
+        { chartIds: chartIds ?? null }
     )
 }
 

--- a/baker/archival/archivalUtils.ts
+++ b/baker/archival/archivalUtils.ts
@@ -28,8 +28,13 @@ export interface ArchivalManifest {
 
 const DATE_TIME_FORMAT = "YYYYMMDD-HHmmss"
 
-export const getDateForArchival = (): ArchivalTimestamp => {
-    const date = dayjs().utc()
+export const getDateForArchival = (dateInput?: Date): ArchivalTimestamp => {
+    const date = dayjs(dateInput)
+        .utc()
+        // it's important here that we explicitly set the milliseconds to 0 -
+        // otherwise we run the risk of MySQL rounding up to the next second,
+        // which would break the archival URL
+        .millisecond(0)
     const formattedDate = date.format(DATE_TIME_FORMAT)
 
     return { date: date.toDate(), formattedDate }
@@ -42,6 +47,20 @@ const getOwidGrapherCommitSha = lazy(async () => {
         return undefined
     }
 })
+
+export const assembleGrapherArchivalUrl = (
+    archivalDate: string | Date,
+    chartSlug: string
+) => {
+    let formattedDate: string
+    if (typeof archivalDate === "string") {
+        formattedDate = archivalDate
+    } else {
+        formattedDate = getDateForArchival(archivalDate).formattedDate
+    }
+
+    return `/${formattedDate}/grapher/${chartSlug}`
+}
 
 export const assembleManifest = async (manifestInfo: {
     staticAssetMap: AssetMap

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
         "buildTsc": "tsc -b -verbose",
         "buildLerna": "lerna run build",
         "buildViteAdmin": "vite build --config vite.config-admin.mts",
+        "buildViteArchive": "vite build --config vite.config-archive.mts",
         "buildViteSite": "vite build --config vite.config-site.mts",
         "buildVite": "yarn buildViteSite && yarn buildViteAdmin",
         "bakeGdocPosts": "tsx --tsconfig tsconfig.tsx.json baker/bakeGdocPosts.ts",

--- a/packages/@ourworldindata/components/src/Button/Button.scss
+++ b/packages/@ourworldindata/components/src/Button/Button.scss
@@ -47,3 +47,22 @@
         background-color: $blue-90;
     }
 }
+
+.owid-btn--solid-dark-blue {
+    background-color: $blue-95;
+    color: #fff;
+
+    &:hover {
+        background-color: #164377;
+    }
+}
+
+.owid-btn--outline-white {
+    border-color: $white;
+    color: $white;
+
+    &:hover {
+        background-color: $white;
+        color: $blue-90;
+    }
+}

--- a/packages/@ourworldindata/components/src/Button/Button.tsx
+++ b/packages/@ourworldindata/components/src/Button/Button.tsx
@@ -5,7 +5,12 @@ import { IconDefinition, faArrowRight } from "@fortawesome/free-solid-svg-icons"
 type ButtonCommonProps = {
     text: string
     className?: string
-    theme: "solid-vermillion" | "outline-vermillion" | "solid-blue"
+    theme:
+        | "solid-vermillion"
+        | "outline-vermillion"
+        | "solid-blue"
+        | "solid-dark-blue"
+        | "outline-white"
     /** Set to null to hide the icon */
     icon?: IconDefinition | null
     iconPosition?: "left" | "right"

--- a/site/DataPageV2.tsx
+++ b/site/DataPageV2.tsx
@@ -34,6 +34,7 @@ import { SiteHeader } from "./SiteHeader.js"
 import { IFrameDetector } from "./IframeDetector.js"
 import { DebugProvider } from "./gdocs/DebugProvider.js"
 import { Html } from "./Html.js"
+import type { ArchiveMetaInformation } from "../site/archive/archiveTypes.js"
 
 export const DataPageV2 = (props: {
     grapher: GrapherInterface | undefined
@@ -47,6 +48,7 @@ export const DataPageV2 = (props: {
     staticAssetMap?: AssetMap
     runtimeAssetMap?: AssetMap
     dataApiUrl?: string
+    archiveInformation?: ArchiveMetaInformation
 }) => {
     const {
         grapher,
@@ -150,7 +152,7 @@ export const DataPageV2 = (props: {
                 />
             </Head>
             <body className="DataPage">
-                <SiteHeader />
+                <SiteHeader archiveInformation={props.archiveInformation} />
                 <main>
                     <script
                         dangerouslySetInnerHTML={{

--- a/site/GrapherPage.tsx
+++ b/site/GrapherPage.tsx
@@ -33,6 +33,7 @@ import { SiteFooter } from "./SiteFooter.js"
 import { SiteHeader } from "./SiteHeader.js"
 import GrapherImage from "./GrapherImage.js"
 import { Html } from "./Html.js"
+import { ArchiveMetaInformation } from "./archive/archiveTypes.js"
 
 export const GrapherPage = (props: {
     grapher: GrapherInterface
@@ -42,6 +43,7 @@ export const GrapherPage = (props: {
     baseGrapherUrl: string
     staticAssetMap?: AssetMap
     runtimeAssetMap?: AssetMap
+    archiveInformation?: ArchiveMetaInformation
 }) => {
     const { grapher, relatedCharts, relatedArticles, baseGrapherUrl, baseUrl } =
         props
@@ -126,7 +128,7 @@ window.Grapher.renderSingleGrapherOnGrapherPage(jsonConfig, { runtimeAssetMap: r
                 />
             </Head>
             <body className={GRAPHER_PAGE_BODY_CLASS}>
-                <SiteHeader />
+                <SiteHeader archiveInformation={props.archiveInformation} />
                 <main>
                     <figure
                         className={HIDE_IF_JS_DISABLED_CLASSNAME}

--- a/site/SiteHeader.tsx
+++ b/site/SiteHeader.tsx
@@ -1,3 +1,5 @@
+import { ArchiveSiteNavigation } from "./archive/ArchiveSiteNavigation.js"
+import { ArchiveMetaInformation } from "./archive/archiveTypes.js"
 import { SiteNavigation } from "./SiteNavigation.js"
 
 interface SiteHeaderProps {
@@ -7,15 +9,22 @@ interface SiteHeaderProps {
      * Stops the search bar from being rendered, as we show it in the page content on the homepage
      */
     isOnHomepage?: boolean
+
+    // If this is an archived page, we need to render a different version of the site header
+    archiveInformation?: ArchiveMetaInformation
 }
 
 export const SiteHeader = (props: SiteHeaderProps) => (
     <header className="site-header">
-        <div className="site-navigation-root">
-            <SiteNavigation
-                hideDonationFlag={props.hideDonationFlag}
-                isOnHomepage={props.isOnHomepage}
-            />
-        </div>
+        {props.archiveInformation ? (
+            <ArchiveSiteNavigation {...props.archiveInformation} />
+        ) : (
+            <div className="site-navigation-root">
+                <SiteNavigation
+                    hideDonationFlag={props.hideDonationFlag}
+                    isOnHomepage={props.isOnHomepage}
+                />
+            </div>
+        )}
     </header>
 )

--- a/site/SiteLogos.tsx
+++ b/site/SiteLogos.tsx
@@ -30,11 +30,11 @@ export const OxfordAndGcdlLogos = () => (
     </>
 )
 
-export const SiteLogos = () => {
+export const SiteLogos = ({ homeUrl = "/" }: { homeUrl?: string }) => {
     return (
         <div className="site-logos">
             <div className="logo-owid">
-                <a href="/">
+                <a href={homeUrl}>
                     Our World
                     <br /> in Data
                 </a>

--- a/site/archive/ArchiveSiteNavigation.scss
+++ b/site/archive/ArchiveSiteNavigation.scss
@@ -24,41 +24,44 @@
         padding-top: 18px;
         padding-bottom: 24px;
 
-        display: flex;
-        flex-direction: column;
+        .archive-navigation-bar__wrapper {
+            @include wrapper-x-spacing;
+            max-width: $wrapper-max-width;
 
-        .wrapper {
-            width: 100%;
-        }
-
-        .archive-navigation-bar__date {
             display: flex;
             flex-direction: column;
             align-items: center;
-            gap: 4px;
-            @include subtitle-1;
+        }
 
-            &::before {
-                content: "Archive";
-                text-transform: uppercase;
-                @include h5-black-caps;
-            }
+        .archive-navigation-bar__archive_text {
+            text-transform: uppercase;
+            @include h5-black-caps;
+            margin-bottom: 4px;
+        }
+
+        .archive-navigation-bar__date {
+            text-align: center;
+            @include subtitle-1;
         }
 
         .archive-navigation-bar__buttons {
             margin-top: 16px;
+            row-gap: 8px;
+            width: 100%;
 
-            .archive-navigation-bar__button-left {
-                grid-column: 1;
-                justify-self: left;
-            }
-            .archive-navigation-bar__button-center {
-                grid-column: 2;
-                justify-self: center;
-            }
-            .archive-navigation-bar__button-right {
-                grid-column: 3;
-                justify-self: right;
+            @include sm-up {
+                .archive-navigation-bar__button-left {
+                    grid-column: 1;
+                    justify-self: left;
+                }
+                .archive-navigation-bar__button-center {
+                    grid-column: 2;
+                    justify-self: center;
+                }
+                .archive-navigation-bar__button-right {
+                    grid-column: 3;
+                    justify-self: right;
+                }
             }
         }
     }

--- a/site/archive/ArchiveSiteNavigation.scss
+++ b/site/archive/ArchiveSiteNavigation.scss
@@ -1,21 +1,19 @@
-.archive-site-navigation {
-    .archive-header-logo-bar {
-        position: relative;
-        z-index: $zindex-lightbox;
-        border-bottom: $header-border-height solid $vermillion;
-        background-color: $oxford-blue;
+.archive-header-logo-bar {
+    position: relative;
+    z-index: $zindex-lightbox;
+    border-bottom: $header-border-height solid $vermillion;
+    background-color: $oxford-blue;
 
-        .site-logos {
-            justify-content: start;
+    .site-logos {
+        justify-content: start;
 
-            .logos-wrapper {
-                display: flex;
-            }
+        .logos-wrapper {
+            display: flex;
         }
-
-        padding-top: 12px;
-        padding-bottom: 12px;
     }
+
+    padding-top: 12px;
+    padding-bottom: 12px;
 }
 
 .archive-navigation-bar {

--- a/site/archive/ArchiveSiteNavigation.scss
+++ b/site/archive/ArchiveSiteNavigation.scss
@@ -45,24 +45,45 @@
 
     .archive-navigation-bar__buttons {
         margin-top: 16px;
-        row-gap: 8px;
+        gap: 15px;
         width: 100%;
 
-        // On small screens, stack the buttons vertically and make them full width
-        // On big screens, display them in a row, and make sure the previous/latest/next buttons are always
-        // aligned to the left, center, and right respectively - no matter if one of the others is missing
-        @include sm-up {
-            .archive-navigation-bar__button-left {
-                grid-column: 1;
-                justify-self: left;
+        --archive-mobile-button-width: 40px;
+
+        .archive-navigation-bar__button-left {
+            grid-column: 1;
+            justify-self: left;
+        }
+        .archive-navigation-bar__button-center {
+            grid-column: 2;
+            justify-self: center;
+        }
+        .archive-navigation-bar__button-right {
+            grid-column: 3;
+            justify-self: right;
+        }
+
+        // On small screens, make the prev/next buttons icon-only and narrow, with the center one taking the rest of the space
+        @include sm-only {
+            grid-template-columns:
+                var(--archive-mobile-button-width)
+                1fr var(--archive-mobile-button-width);
+
+            .archive-navigation-bar__button {
+                width: 100%;
             }
-            .archive-navigation-bar__button-center {
-                grid-column: 2;
-                justify-self: center;
-            }
+
+            .archive-navigation-bar__button-left,
             .archive-navigation-bar__button-right {
-                grid-column: 3;
-                justify-self: right;
+                padding-left: 0;
+                padding-right: 0;
+
+                > span {
+                    display: none;
+                }
+                > svg {
+                    margin: 0;
+                }
             }
         }
     }

--- a/site/archive/ArchiveSiteNavigation.scss
+++ b/site/archive/ArchiveSiteNavigation.scss
@@ -16,52 +16,55 @@
         padding-top: 12px;
         padding-bottom: 12px;
     }
+}
 
-    .archive-navigation-bar {
-        background-color: $blue-50;
-        color: $white;
+.archive-navigation-bar {
+    background-color: $blue-50;
+    color: $white;
 
-        padding-top: 18px;
-        padding-bottom: 24px;
+    padding-top: 18px;
+    padding-bottom: 24px;
 
-        .archive-navigation-bar__wrapper {
-            @include wrapper-x-spacing;
-            max-width: $wrapper-max-width;
+    .archive-navigation-bar__wrapper {
+        @include wrapper-x-spacing;
+        max-width: $wrapper-max-width;
 
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-        }
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+    }
 
-        .archive-navigation-bar__archive_text {
-            text-transform: uppercase;
-            @include h5-black-caps;
-            margin-bottom: 4px;
-        }
+    .archive-navigation-bar__archive_text {
+        text-transform: uppercase;
+        @include h5-black-caps;
+        margin-bottom: 4px;
+    }
 
-        .archive-navigation-bar__date {
-            text-align: center;
-            @include subtitle-1;
-        }
+    .archive-navigation-bar__date {
+        text-align: center;
+        @include subtitle-1;
+    }
 
-        .archive-navigation-bar__buttons {
-            margin-top: 16px;
-            row-gap: 8px;
-            width: 100%;
+    .archive-navigation-bar__buttons {
+        margin-top: 16px;
+        row-gap: 8px;
+        width: 100%;
 
-            @include sm-up {
-                .archive-navigation-bar__button-left {
-                    grid-column: 1;
-                    justify-self: left;
-                }
-                .archive-navigation-bar__button-center {
-                    grid-column: 2;
-                    justify-self: center;
-                }
-                .archive-navigation-bar__button-right {
-                    grid-column: 3;
-                    justify-self: right;
-                }
+        // On small screens, stack the buttons vertically and make them full width
+        // On big screens, display them in a row, and make sure the previous/latest/next buttons are always
+        // aligned to the left, center, and right respectively - no matter if one of the others is missing
+        @include sm-up {
+            .archive-navigation-bar__button-left {
+                grid-column: 1;
+                justify-self: left;
+            }
+            .archive-navigation-bar__button-center {
+                grid-column: 2;
+                justify-self: center;
+            }
+            .archive-navigation-bar__button-right {
+                grid-column: 3;
+                justify-self: right;
             }
         }
     }

--- a/site/archive/ArchiveSiteNavigation.scss
+++ b/site/archive/ArchiveSiteNavigation.scss
@@ -1,0 +1,65 @@
+.archive-site-navigation {
+    .archive-header-logo-bar {
+        position: relative;
+        z-index: $zindex-lightbox;
+        border-bottom: $header-border-height solid $vermillion;
+        background-color: $oxford-blue;
+
+        .site-logos {
+            justify-content: start;
+
+            .logos-wrapper {
+                display: flex;
+            }
+        }
+
+        padding-top: 12px;
+        padding-bottom: 12px;
+    }
+
+    .archive-navigation-bar {
+        background-color: $blue-50;
+        color: $white;
+
+        padding-top: 18px;
+        padding-bottom: 24px;
+
+        display: flex;
+        flex-direction: column;
+
+        .wrapper {
+            width: 100%;
+        }
+
+        .archive-navigation-bar__date {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 4px;
+            @include subtitle-1;
+
+            &::before {
+                content: "Archive";
+                text-transform: uppercase;
+                @include h5-black-caps;
+            }
+        }
+
+        .archive-navigation-bar__buttons {
+            margin-top: 16px;
+
+            .archive-navigation-bar__button-left {
+                grid-column: 1;
+                justify-self: left;
+            }
+            .archive-navigation-bar__button-center {
+                grid-column: 2;
+                justify-self: center;
+            }
+            .archive-navigation-bar__button-right {
+                grid-column: 3;
+                justify-self: right;
+            }
+        }
+    }
+}

--- a/site/archive/ArchiveSiteNavigation.tsx
+++ b/site/archive/ArchiveSiteNavigation.tsx
@@ -41,10 +41,10 @@ const ArchiveNavigationBar = (props: ArchiveSiteNavigationProps) => {
                     </span>
                 </div>
                 {hasButtons && (
-                    <div className="archive-navigation-bar__buttons grid grid-cols-3 grid-sm-cols-1">
+                    <div className="archive-navigation-bar__buttons grid grid-cols-3">
                         {props.previousVersion && (
                             <Button
-                                className="archive-navigation-bar__button-left"
+                                className="archive-navigation-bar__button archive-navigation-bar__button-left"
                                 href={props.previousVersion.url}
                                 theme="outline-white"
                                 icon={faArrowLeft}
@@ -55,7 +55,7 @@ const ArchiveNavigationBar = (props: ArchiveSiteNavigationProps) => {
                         )}
                         {props.liveUrl && (
                             <Button
-                                className="archive-navigation-bar__button-center"
+                                className="archive-navigation-bar__button archive-navigation-bar__button-center"
                                 href={props.liveUrl}
                                 theme="solid-dark-blue"
                                 icon={null}
@@ -65,7 +65,7 @@ const ArchiveNavigationBar = (props: ArchiveSiteNavigationProps) => {
                         )}
                         {props.nextVersion && (
                             <Button
-                                className="archive-navigation-bar__button-right"
+                                className="archive-navigation-bar__button archive-navigation-bar__button-right"
                                 href={props.nextVersion.url}
                                 theme="outline-white"
                                 icon={faArrowRight}

--- a/site/archive/ArchiveSiteNavigation.tsx
+++ b/site/archive/ArchiveSiteNavigation.tsx
@@ -31,14 +31,17 @@ const ArchiveNavigationBar = (props: ArchiveSiteNavigationProps) => {
 
     return (
         <nav className="archive-navigation-bar">
-            <div className="wrapper">
+            <div className="archive-navigation-bar__wrapper">
+                <div className="archive-navigation-bar__archive_text">
+                    Archive
+                </div>
                 <div className="archive-navigation-bar__date">
                     <span className="archive-navigation-bar__date-value">
                         {dayjs.utc(props.archiveDate).format(DATE_FORMAT)}
                     </span>
                 </div>
                 {hasButtons && (
-                    <div className="archive-navigation-bar__buttons grid grid-cols-3">
+                    <div className="archive-navigation-bar__buttons grid grid-cols-3 grid-sm-cols-1">
                         {props.previousVersion && (
                             <Button
                                 className="archive-navigation-bar__button-left"

--- a/site/archive/ArchiveSiteNavigation.tsx
+++ b/site/archive/ArchiveSiteNavigation.tsx
@@ -1,0 +1,87 @@
+import { Button } from "@ourworldindata/components"
+import { SiteLogos } from "../SiteLogos.js"
+import { faArrowLeft, faArrowRight } from "@fortawesome/free-solid-svg-icons"
+import { dayjs } from "@ourworldindata/utils"
+
+export interface UrlAndMaybeDate {
+    url: string
+    date?: Date
+}
+export interface ArchiveSiteNavigationProps {
+    archiveDate: Date
+    liveUrl?: string
+    previousVersion?: UrlAndMaybeDate
+    nextVersion?: UrlAndMaybeDate
+}
+
+export const ArchiveSiteNavigation = (props: ArchiveSiteNavigationProps) => {
+    return (
+        <div className="archive-site-navigation">
+            <ArchiveHeaderLogoBar />
+            <ArchiveNavigationBar {...props} />
+        </div>
+    )
+}
+
+const ArchiveHeaderLogoBar = () => (
+    <div className="archive-header-logo-bar">
+        <div className="wrapper">
+            <SiteLogos homeUrl="https://ourworldindata.org" />
+        </div>
+    </div>
+)
+
+const DATE_FORMAT = "MMMM D, YYYY"
+const ArchiveNavigationBar = (props: ArchiveSiteNavigationProps) => {
+    const hasButtons = !!(
+        props.liveUrl ||
+        props.previousVersion ||
+        props.nextVersion
+    )
+
+    return (
+        <nav className="archive-navigation-bar">
+            <div className="wrapper">
+                <div className="archive-navigation-bar__date">
+                    <span className="archive-navigation-bar__date-value">
+                        {dayjs.utc(props.archiveDate).format(DATE_FORMAT)}
+                    </span>
+                </div>
+                {hasButtons && (
+                    <div className="archive-navigation-bar__buttons grid grid-cols-3">
+                        {props.previousVersion && (
+                            <Button
+                                className="archive-navigation-bar__button-left"
+                                href={props.previousVersion.url}
+                                theme="outline-white"
+                                text="Go to the previous version"
+                                icon={faArrowLeft}
+                                iconPosition="left"
+                            />
+                        )}
+                        {props.liveUrl && (
+                            <Button
+                                className="archive-navigation-bar__button-center"
+                                href={props.liveUrl}
+                                theme="solid-dark-blue"
+                                icon={null}
+                                text="Go to the latest version"
+                                dataTrackNote="archive-header-back-to-homepage"
+                            />
+                        )}
+                        {props.nextVersion && (
+                            <Button
+                                className="archive-navigation-bar__button-right"
+                                href={props.nextVersion.url}
+                                theme="outline-white"
+                                text="Go to the next version"
+                                icon={faArrowRight}
+                                iconPosition="right"
+                            />
+                        )}
+                    </div>
+                )}
+            </div>
+        </nav>
+    )
+}

--- a/site/archive/ArchiveSiteNavigation.tsx
+++ b/site/archive/ArchiveSiteNavigation.tsx
@@ -2,17 +2,7 @@ import { Button } from "@ourworldindata/components"
 import { SiteLogos } from "../SiteLogos.js"
 import { faArrowLeft, faArrowRight } from "@fortawesome/free-solid-svg-icons"
 import { dayjs } from "@ourworldindata/utils"
-
-export interface UrlAndMaybeDate {
-    url: string
-    date?: Date
-}
-export interface ArchiveSiteNavigationProps {
-    archiveDate: Date
-    liveUrl?: string
-    previousVersion?: UrlAndMaybeDate
-    nextVersion?: UrlAndMaybeDate
-}
+import { ArchiveSiteNavigationProps } from "./archiveTypes.js"
 
 export const ArchiveSiteNavigation = (props: ArchiveSiteNavigationProps) => {
     return (

--- a/site/archive/ArchiveSiteNavigation.tsx
+++ b/site/archive/ArchiveSiteNavigation.tsx
@@ -47,9 +47,10 @@ const ArchiveNavigationBar = (props: ArchiveSiteNavigationProps) => {
                                 className="archive-navigation-bar__button-left"
                                 href={props.previousVersion.url}
                                 theme="outline-white"
-                                text="Go to the previous version"
                                 icon={faArrowLeft}
                                 iconPosition="left"
+                                text="Go to the previous version"
+                                dataTrackNote="archive-header-go-to-previous"
                             />
                         )}
                         {props.liveUrl && (
@@ -58,8 +59,8 @@ const ArchiveNavigationBar = (props: ArchiveSiteNavigationProps) => {
                                 href={props.liveUrl}
                                 theme="solid-dark-blue"
                                 icon={null}
-                                text="Go to the latest version"
-                                dataTrackNote="archive-header-back-to-homepage"
+                                text="Go to the live version"
+                                dataTrackNote="archive-header-go-to-live"
                             />
                         )}
                         {props.nextVersion && (
@@ -67,9 +68,10 @@ const ArchiveNavigationBar = (props: ArchiveSiteNavigationProps) => {
                                 className="archive-navigation-bar__button-right"
                                 href={props.nextVersion.url}
                                 theme="outline-white"
-                                text="Go to the next version"
                                 icon={faArrowRight}
                                 iconPosition="right"
+                                text="Go to the next version"
+                                dataTrackNote="archive-header-go-to-next"
                             />
                         )}
                     </div>

--- a/site/archive/archiveTypes.ts
+++ b/site/archive/archiveTypes.ts
@@ -1,0 +1,12 @@
+export interface UrlAndMaybeDate {
+    url: string
+    date?: Date
+}
+export interface ArchiveSiteNavigationProps {
+    archiveDate: Date
+    liveUrl?: string
+    previousVersion?: UrlAndMaybeDate
+    nextVersion?: UrlAndMaybeDate
+}
+
+export type ArchiveMetaInformation = ArchiveSiteNavigationProps

--- a/site/owid.scss
+++ b/site/owid.scss
@@ -60,6 +60,8 @@
 @import "css/page.scss";
 @import "css/sidebar.scss";
 
+@import "./archive/ArchiveSiteNavigation.scss";
+
 @import "css/faq.scss";
 @import "css/covid.scss";
 @import "css/chart.scss";

--- a/site/viteConstants.ts
+++ b/site/viteConstants.ts
@@ -3,6 +3,7 @@ export const VITE_ASSET_ADMIN_ENTRY = "adminSiteClient/admin.entry.ts"
 
 export enum ViteEntryPoint {
     Site = "site",
+    Archive = "archive",
     Admin = "admin",
 }
 
@@ -10,6 +11,11 @@ export const VITE_ENTRYPOINT_INFO = {
     [ViteEntryPoint.Site]: {
         entryPointFile: VITE_ASSET_SITE_ENTRY,
         outDir: "assets",
+        outName: "owid",
+    },
+    [ViteEntryPoint.Archive]: {
+        entryPointFile: VITE_ASSET_SITE_ENTRY,
+        outDir: "assets-archive",
         outName: "owid",
     },
     [ViteEntryPoint.Admin]: {

--- a/vite.config-archive.mts
+++ b/vite.config-archive.mts
@@ -1,0 +1,4 @@
+import { ViteEntryPoint } from "./site/viteConstants.ts"
+import { defineViteConfigForEntrypoint } from "./vite.config-common.mts"
+
+export default defineViteConfigForEntrypoint(ViteEntryPoint.Archive)


### PR DESCRIPTION
## Context

This introduces a banner & navigation bar to archived pages.

[Figma](https://www.figma.com/design/0bSkR5nTebL69w8O6upNWd/Archival-Embeds?node-id=1-35&t=scrct9M2QpRichKL-1)

## Screenshots / Videos / Diagrams

![CleanShot 2025-04-04 at 08 29 57](https://github.com/user-attachments/assets/50b7c788-b19f-4af0-86f2-9e4b41353c98)

## Testing guidance

See a live demo over at http://staging-site-archive-navigation-banner:3000/latest/grapher/life-expectancy.

You can also run an archive step locally by running `make archive`.

## Checklist

- [ ] Does the staging experience have sign-off from product stakeholders?

### Before merging

- [ ] Changes to CSS/HTML were checked on Desktop and Mobile Safari at all three breakpoints
- [ ] Changes to HTML were checked for accessibility concerns

