### PR TITLE
🎉 Featured metric indexing

### DIFF
--- a/adminSiteClient/FeaturedMetricsPage.tsx
+++ b/adminSiteClient/FeaturedMetricsPage.tsx
@@ -146,10 +146,6 @@ function filterUrlQueryParams(url: string): string {
         url
     )
 
-    if (url.endsWith("?")) {
-        url = url.slice(0, -1)
-    }
-
     return url
 }
 
@@ -197,18 +193,6 @@ function FeaturedMetricSection({
             setIsValid({
                 isValid: false,
                 reason: "Explorer URLs must have the view's query string",
-            })
-        } else if (
-            GRAPHER_QUERY_PARAM_KEYS.some((param) => url.queryParams[param])
-        ) {
-            const invalidParams = GRAPHER_QUERY_PARAM_KEYS.filter(
-                (param) => url.queryParams[param]
-            )
-            setIsValid({
-                isValid: false,
-                reason: `URL must not contain grapher query parameters: ${invalidParams.join(
-                    ", "
-                )}`,
             })
         } else {
             setIsValid({ isValid: true, reason: "" })
@@ -273,6 +257,16 @@ function FeaturedMetricSection({
                             return
                         }
                         handleAddFeaturedMetric()
+                    }}
+                    onBlur={() => {
+                        if (
+                            newFeaturedMetricInputValue.endsWith("?") ||
+                            newFeaturedMetricInputValue.endsWith("/")
+                        ) {
+                            handleInputChange(
+                                newFeaturedMetricInputValue.slice(0, -1)
+                            )
+                        }
                     }}
                     onChange={(e) => handleInputChange(e.target.value)}
                 />

--- a/adminSiteClient/FeaturedMetricsPage.tsx
+++ b/adminSiteClient/FeaturedMetricsPage.tsx
@@ -149,14 +149,36 @@ function FeaturedMetricSection({
 
     const [newFeaturedMetricInputValue, setNewFeaturedMetricInputValue] =
         useState("")
-    const [isValid, setIsValid] = useState(false)
+    const [{ isValid, reason }, setIsValid] = useState({
+        isValid: false,
+        reason: "",
+    })
 
     useEffect(() => {
         const url = Url.fromURL(newFeaturedMetricInputValue)
-        const isValid =
-            (url.isExplorer || url.isGrapher) &&
-            url.queryParams.country === undefined
-        setIsValid(!!isValid)
+        if (!url.isExplorer && !url.isGrapher) {
+            setIsValid({
+                isValid: false,
+                reason: "URL must be an OWID grapher/explorer URL",
+            })
+        } else if (url.isExplorer && !url.queryStr) {
+            setIsValid({
+                isValid: false,
+                reason: "Explorer URLs must have the view's query string (without countries or tab)",
+            })
+        } else if (url.queryParams.country) {
+            setIsValid({
+                isValid: false,
+                reason: "URL must not have a country query parameter",
+            })
+        } else if (url.queryParams.tab) {
+            setIsValid({
+                isValid: false,
+                reason: "URL must not have a tab query parameter",
+            })
+        } else {
+            setIsValid({ isValid: true, reason: "" })
+        }
     }, [newFeaturedMetricInputValue])
 
     const [newFeaturedMetricIncomeGroup, setNewFeaturedMetricIncomeGroup] =
@@ -247,8 +269,7 @@ function FeaturedMetricSection({
                 </Button>
                 {newFeaturedMetricInputValue && !isValid && (
                     <p className="featured-metrics-page-section__error-notice">
-                        URL must be an OWID grapher/explorer URL and not have a{" "}
-                        <span>country</span> query parameter.
+                        {reason}
                     </p>
                 )}
             </Flex>
@@ -301,10 +322,33 @@ function FeaturedMetricsExplainer() {
                         </>
                     ),
                 },
+                {
+                    key: "explorers",
+                    label: "How do I set an Explorer Featured Metric?",
+                    children: (
+                        <>
+                            <p>
+                                Explorer Featured Metrics require the whole
+                                explorer's query string, minus its countries and
+                                tab parameters.
+                            </p>
+                            <p>e.g.</p>
+                            <p>
+                                <span>
+                                    https://ourworldindata.org/explorers/monkeypox?Metric=Confirmed+cases&Frequency=7-day+average&Relative+to+population=false
+                                </span>
+                            </p>
+                            <p>
+                                If the default view of the explorer is the one
+                                you want, you can get its full query string
+                                representation by clicking another view, and
+                                then navigating back to the default.
+                            </p>
+                        </>
+                    ),
+                },
             ]}
-        >
-            What are Featured Metrics?
-        </Collapse>
+        />
     )
 }
 

--- a/adminSiteClient/FeaturedMetricsPage.tsx
+++ b/adminSiteClient/FeaturedMetricsPage.tsx
@@ -362,8 +362,8 @@ function FeaturedMetricsExplainer() {
                             <p>
                                 Explorer Featured Metrics require the whole
                                 explorer's query string, minus any query
-                                paramters that customize the grapher chart (e.g.
-                                tab, country, etc.)
+                                parameters that customize the grapher chart
+                                (country, tab, etc...)
                             </p>
                             <p>e.g.</p>
                             <p>

--- a/adminSiteClient/FeaturedMetricsPage.tsx
+++ b/adminSiteClient/FeaturedMetricsPage.tsx
@@ -125,6 +125,24 @@ function FeaturedMetricList({
     )
 }
 
+function filterUrlQueryParams(url: string): string {
+    if (!url) return ""
+    if (!url.includes("?")) return url
+
+    url = url.replace(/([?&])country=[^&]*(&|$)/g, (match, prefix, suffix) => {
+        // If the suffix is & (meaning there are more params), keep the prefix
+        // If the suffix is empty (end of string), keep nothing unless prefix is ? and it's the only param
+        return suffix === "&" ? prefix : prefix === "?" ? "?" : ""
+    })
+
+    // Remove tab parameter using the same approach
+    url = url.replace(/([?&])tab=[^&]*(&|$)/g, (match, prefix, suffix) => {
+        return suffix === "&" ? prefix : prefix === "?" ? "?" : ""
+    })
+
+    return url
+}
+
 function FeaturedMetricSection({
     parentTagName,
     featuredMetrics,
@@ -149,6 +167,10 @@ function FeaturedMetricSection({
 
     const [newFeaturedMetricInputValue, setNewFeaturedMetricInputValue] =
         useState("")
+    const handleInputChange = (inputValue: string) => {
+        setNewFeaturedMetricInputValue(filterUrlQueryParams(inputValue))
+    }
+
     const [{ isValid, reason }, setIsValid] = useState({
         isValid: false,
         reason: "",
@@ -194,7 +216,7 @@ function FeaturedMetricSection({
             ranking,
             parentTagName,
         })
-        setNewFeaturedMetricInputValue("")
+        handleInputChange("")
     }
 
     return (
@@ -240,9 +262,7 @@ function FeaturedMetricSection({
                         }
                         handleAddFeaturedMetric()
                     }}
-                    onChange={(e) =>
-                        setNewFeaturedMetricInputValue(e.target.value)
-                    }
+                    onChange={(e) => handleInputChange(e.target.value)}
                 />
                 <Dropdown
                     menu={{

--- a/baker/algolia/configureAlgolia.ts
+++ b/baker/algolia/configureAlgolia.ts
@@ -138,6 +138,7 @@ export const configureAlgolia = async () => {
             "unordered(subtitle)",
             "unordered(tags)",
             "unordered(availableEntities)",
+            "unordered(originalAvailableEntities)",
         ],
         ranking: ["typo", "words", "exact", "attribute", "custom", "proximity"],
         customRanking: [

--- a/baker/algolia/indexExplorerViewsMdimViewsAndChartsToAlgolia.ts
+++ b/baker/algolia/indexExplorerViewsMdimViewsAndChartsToAlgolia.ts
@@ -10,15 +10,15 @@ import {
     getExplorerViewRecords,
     scaleExplorerRecordScores,
 } from "./utils/explorerViews.js"
-import { scaleRecordScores } from "./utils/shared.js"
+import {
+    createFeaturedMetricRecords,
+    scaleRecordScores,
+} from "./utils/shared.js"
 import { getChartsRecords } from "./utils/charts.js"
 import { getIndexName } from "../../site/search/searchClient.js"
 import { SearchIndexName } from "../../site/search/searchTypes.js"
 import { getMdimViewRecords } from "./utils/mdimViews.js"
 
-// We get 200k operations with Algolia's Open Source plan. We've hit 140k in the past so this might push us over.
-// If we standardize the record shape, we could have this be the only index and have a `type` field
-// to use in /search.
 const indexExplorerViewsMdimViewsAndChartsToAlgolia = async () => {
     if (!ALGOLIA_INDEXING) return
     const indexName = getIndexName(
@@ -54,8 +54,12 @@ const indexExplorerViewsMdimViewsAndChartsToAlgolia = async () => {
             ...scaledExplorerViews,
             ...scaledMdimViews,
         ]
+        const featuredMetricRecords = await createFeaturedMetricRecords(
+            trx,
+            records
+        )
 
-        return records
+        return [...records, ...featuredMetricRecords]
     }, db.TransactionCloseMode.Close)
 
     const index = client.initIndex(indexName)

--- a/baker/algolia/indexExplorerViewsMdimViewsAndChartsToAlgolia.ts
+++ b/baker/algolia/indexExplorerViewsMdimViewsAndChartsToAlgolia.ts
@@ -12,6 +12,7 @@ import {
 } from "./utils/explorerViews.js"
 import {
     createFeaturedMetricRecords,
+    MAX_NON_FM_RECORD_SCORE,
     scaleRecordScores,
 } from "./utils/shared.js"
 import { getChartsRecords } from "./utils/charts.js"
@@ -42,12 +43,15 @@ const indexExplorerViewsMdimViewsAndChartsToAlgolia = async () => {
         // Scale the remaining explorer views between 0 and 1000.
         // This is because Graphers are generally higher quality than Explorers and we don't want
         // the data catalog to smother Grapher results with hundreds of low-quality Explorer results.
-        const scaledGrapherViews = scaleRecordScores(
-            grapherViews,
-            [1000, 10000]
-        )
+        const scaledGrapherViews = scaleRecordScores(grapherViews, [
+            1000,
+            MAX_NON_FM_RECORD_SCORE,
+        ])
         const scaledExplorerViews = scaleExplorerRecordScores(explorerViews)
-        const scaledMdimViews = scaleRecordScores(mdimViews, [1000, 10000])
+        const scaledMdimViews = scaleRecordScores(mdimViews, [
+            1000,
+            MAX_NON_FM_RECORD_SCORE,
+        ])
 
         const records = [
             ...scaledGrapherViews,

--- a/baker/algolia/utils/charts.ts
+++ b/baker/algolia/utils/charts.ts
@@ -134,6 +134,7 @@ export const getChartsRecords = async (
 
         const record = {
             objectID: c.id.toString(),
+            id: `grapher/${c.slug}`,
             type: ChartRecordType.Chart,
             chartId: c.id,
             slug: c.slug,

--- a/baker/algolia/utils/explorerViews.ts
+++ b/baker/algolia/utils/explorerViews.ts
@@ -631,6 +631,7 @@ async function finalizeRecords(
                 queryParams: record.viewQueryParams,
                 tags: explorerInfo.tags,
                 objectID: `${explorerInfo.slug}-${i}`,
+                id: `explorer/${explorerInfo.slug}${record.viewQueryParams}`,
                 score: computeExplorerViewScore(record),
                 views_7d: record.views_7d,
                 availableEntities: record.availableEntities,

--- a/baker/algolia/utils/explorerViews.ts
+++ b/baker/algolia/utils/explorerViews.ts
@@ -49,6 +49,7 @@ import {
     FinalizedExplorerRecord,
 } from "./types.js"
 import {
+    MAX_NON_FM_RECORD_SCORE,
     processAvailableEntities as processRecordAvailableEntities,
     scaleRecordScores,
 } from "./shared.js"
@@ -123,7 +124,7 @@ export function scaleExplorerRecordScores(
         (view) => view.isFirstExplorerView
     )
     return [
-        ...scaleRecordScores(firstViews, [1000, 10000]),
+        ...scaleRecordScores(firstViews, [1000, MAX_NON_FM_RECORD_SCORE]),
         ...scaleRecordScores(rest, [0, 1000]),
     ]
 }

--- a/baker/algolia/utils/mdimViews.ts
+++ b/baker/algolia/utils/mdimViews.ts
@@ -97,6 +97,7 @@ async function getRecords(
         return {
             type: ChartRecordType.MultiDimView,
             objectID: `mdim-view-${id}`,
+            id: `mdim/${slug}${queryStr}`,
             chartId: -1,
             slug,
             queryParams: queryStr,

--- a/baker/algolia/utils/shared.ts
+++ b/baker/algolia/utils/shared.ts
@@ -233,6 +233,7 @@ export async function createFeaturedMetricRecords(
             tags: [featuredMetric.parentTagName],
             objectID,
             availableEntities,
+            originalAvailableEntities: correspondingRecord.availableEntities,
             score,
         }
 

--- a/baker/algolia/utils/shared.ts
+++ b/baker/algolia/utils/shared.ts
@@ -96,17 +96,19 @@ function createRecordUrl(record: ChartRecord) {
     )
 }
 
-function findMatchingRecordBySlugAndQueryParams(
+function findMatchingRecordByPathnameAndQueryParams(
     records: ChartRecord[],
     featuredMetric: DbPlainFeaturedMetricWithParentTagName
 ) {
     const fmUrl = Url.fromURL(featuredMetric.url)
     return records.find((record) => {
-        if (record.slug !== fmUrl.slug) return false
         const recordUrl = createRecordUrl(record)
+        if (fmUrl.pathname !== recordUrl.pathname) return false
         return fmUrl.areQueryParamsEqual(recordUrl)
     })
 }
+
+export const MAX_NON_FM_RECORD_SCORE = 10000
 
 /**
  * All featured metrics start at a score of 11000, which places them above all other records
@@ -119,7 +121,7 @@ function calculateFeaturedMetricScore(
     featuredMetric: DbPlainFeaturedMetricWithParentTagName,
     group: DbPlainFeaturedMetricWithParentTagName[]
 ): number {
-    let score = 11000
+    let score = MAX_NON_FM_RECORD_SCORE + 1000
     // If there are 3 FMs in the group, rank 1 gets 3 points, rank 2 gets 2 points, rank 3 gets 1 point.
     // This means we can sort by desc(score) in Algolia and they'll show up according to their rank.
     score += group.length - featuredMetric.ranking
@@ -204,7 +206,7 @@ export async function createFeaturedMetricRecords(
     const featuredMetricRecords: ChartRecord[] = []
 
     for (const featuredMetric of featuredMetricsWithParentTagName) {
-        const correspondingRecord = findMatchingRecordBySlugAndQueryParams(
+        const correspondingRecord = findMatchingRecordByPathnameAndQueryParams(
             records,
             featuredMetric
         )

--- a/baker/algolia/utils/shared.ts
+++ b/baker/algolia/utils/shared.ts
@@ -1,8 +1,29 @@
 import {
     countries,
+    DbPlainFeaturedMetricWithParentTagName,
+    FeaturedMetricIncomeGroup,
+    groupBy,
     orderBy,
     removeTrailingParenthetical,
+    slugify,
+    Url,
 } from "@ourworldindata/utils"
+import * as Sentry from "@sentry/node"
+import {
+    getFeaturedMetricsWithParentTagName,
+    KnexReadonlyTransaction,
+} from "../../../db/db.js"
+import {
+    ChartRecord,
+    ChartRecordType,
+} from "../../../site/search/searchTypes.js"
+import {
+    countriesByName,
+    incomeGroupsByName,
+} from "@ourworldindata/utils/dist/regions.js"
+import urljoin from "url-join"
+import { BAKED_BASE_URL } from "../../../settings/clientSettings.js"
+import { incomeGroupMap } from "./types.js"
 
 const countriesWithVariantNames = new Set(
     countries
@@ -60,4 +81,144 @@ export function scaleRecordScores<T extends { score: number }>(
             score: scaled,
         }
     })
+}
+
+function createRecordUrl(record: ChartRecord) {
+    return Url.fromURL(
+        urljoin(
+            BAKED_BASE_URL,
+            record.type === ChartRecordType.ExplorerView
+                ? "explorer"
+                : "grapher",
+            record.slug,
+            record.queryParams ?? ""
+        )
+    )
+}
+
+function findMatchingRecordBySlugAndQueryParams(
+    records: ChartRecord[],
+    featuredMetric: DbPlainFeaturedMetricWithParentTagName
+) {
+    const fmUrl = Url.fromURL(featuredMetric.url)
+    return records.find((record) => {
+        if (record.slug !== fmUrl.slug) return false
+        const recordUrl = createRecordUrl(record)
+        return fmUrl.areQueryParamsEqual(recordUrl)
+    })
+}
+
+function calculateFeaturedMetricScore(
+    featuredMetric: DbPlainFeaturedMetricWithParentTagName,
+    group: DbPlainFeaturedMetricWithParentTagName[]
+): number {
+    let score = 11000
+    score += group.length - featuredMetric.ranking
+    if (featuredMetric.incomeGroup === FeaturedMetricIncomeGroup.All) {
+        score += 100
+    }
+    return score
+}
+
+function getCorrespondingIncomeGroup(
+    incomeGroupName: FeaturedMetricIncomeGroup
+) {
+    const owidIncomeGroupName =
+        incomeGroupMap[
+            incomeGroupName as Exclude<
+                FeaturedMetricIncomeGroup,
+                FeaturedMetricIncomeGroup.All
+            >
+        ]
+
+    const countriesByIncomeGroup = incomeGroupsByName()
+    return countriesByIncomeGroup[owidIncomeGroupName]
+}
+
+function filterAvailableEntities(
+    featuredMetric: DbPlainFeaturedMetricWithParentTagName,
+    availableEntities: string[]
+): string[] {
+    const shouldFilterAvailableEntities =
+        featuredMetric.incomeGroup !== FeaturedMetricIncomeGroup.All
+    if (!shouldFilterAvailableEntities) return availableEntities
+
+    const owidIncomeGroup = getCorrespondingIncomeGroup(
+        featuredMetric.incomeGroup
+    )
+
+    const filteredEntities = availableEntities.filter((entity) => {
+        const country = countriesByName()[entity]
+        if (!country) return false
+        return owidIncomeGroup.members.includes(country.code)
+    })
+    return filteredEntities
+}
+
+function generateObjectID(
+    featuredMetric: DbPlainFeaturedMetricWithParentTagName,
+    correspondingRecord: ChartRecord
+): string {
+    return `${correspondingRecord.objectID}-fm-${featuredMetric.incomeGroup}-${slugify(featuredMetric.parentTagName)}`
+}
+
+function getGroupKey(
+    featuredMetric: DbPlainFeaturedMetricWithParentTagName
+): string {
+    return `${featuredMetric.parentTagName}-${featuredMetric.incomeGroup}`
+}
+
+export async function createFeaturedMetricRecords(
+    trx: KnexReadonlyTransaction,
+    records: ChartRecord[]
+): Promise<ChartRecord[]> {
+    const featuredMetricsWithParentTagName =
+        await getFeaturedMetricsWithParentTagName(trx)
+
+    const featuredMetricsGroupedByTagAndIncomeGroup = groupBy(
+        featuredMetricsWithParentTagName,
+        getGroupKey
+    )
+
+    const featuredMetricRecords: ChartRecord[] = []
+
+    for (const featuredMetric of featuredMetricsWithParentTagName) {
+        const correspondingRecord = findMatchingRecordBySlugAndQueryParams(
+            records,
+            featuredMetric
+        )
+
+        if (!correspondingRecord) {
+            const error = `Featured metric "${featuredMetric.url}" not found in records`
+            console.error(error)
+            Sentry.captureException(error)
+            continue
+        }
+
+        const score = calculateFeaturedMetricScore(
+            featuredMetric,
+            featuredMetricsGroupedByTagAndIncomeGroup[
+                getGroupKey(featuredMetric)
+            ]
+        )
+
+        const availableEntities = filterAvailableEntities(
+            featuredMetric,
+            correspondingRecord.availableEntities
+        )
+
+        const objectID = generateObjectID(featuredMetric, correspondingRecord)
+
+        const featuredMetricRecord: ChartRecord = {
+            ...correspondingRecord,
+            tags: [featuredMetric.parentTagName],
+            objectID,
+            availableEntities,
+            score,
+        }
+
+        featuredMetricRecords.push(featuredMetricRecord)
+    }
+
+    return featuredMetricRecords
 }

--- a/baker/algolia/utils/shared.ts
+++ b/baker/algolia/utils/shared.ts
@@ -108,18 +108,32 @@ function findMatchingRecordBySlugAndQueryParams(
     })
 }
 
+/**
+ * All featured metrics start at a score of 11000, which places them above all other records
+ * in the `explorer-views-and-charts` index.
+ * The score is then adjusted based on the ranking of the featured metric within its group.
+ * Featured Metrics for the "all" income group are also given a boost to make sure they
+ * show before the other income groups.
+ */
 function calculateFeaturedMetricScore(
     featuredMetric: DbPlainFeaturedMetricWithParentTagName,
     group: DbPlainFeaturedMetricWithParentTagName[]
 ): number {
     let score = 11000
+    // If there are 3 FMs in the group, rank 1 gets 3 points, rank 2 gets 2 points, rank 3 gets 1 point.
+    // This means we can sort by desc(score) in Algolia and they'll show up according to their rank.
     score += group.length - featuredMetric.ranking
+
     if (featuredMetric.incomeGroup === FeaturedMetricIncomeGroup.All) {
         score += 100
     }
+
     return score
 }
 
+/**
+ * FeaturedMetricIncomeGroup.Low -> { name: 'OWID_LIC', members: ["AFG", "BFA", "BDI", etc..] }
+ */
 function getCorrespondingIncomeGroup(
     incomeGroupName: FeaturedMetricIncomeGroup
 ) {
@@ -135,6 +149,10 @@ function getCorrespondingIncomeGroup(
     return countriesByIncomeGroup[owidIncomeGroupName]
 }
 
+/**
+ * If an FM is assigned to the "low" income group, we filter the record's available entities
+ * to only include countries in that income group.
+ */
 function filterAvailableEntities(
     featuredMetric: DbPlainFeaturedMetricWithParentTagName,
     availableEntities: string[]
@@ -152,6 +170,7 @@ function filterAvailableEntities(
         if (!country) return false
         return owidIncomeGroup.members.includes(country.code)
     })
+
     return filteredEntities
 }
 

--- a/baker/algolia/utils/shared.ts
+++ b/baker/algolia/utils/shared.ts
@@ -10,7 +10,7 @@ import {
 } from "@ourworldindata/utils"
 import * as Sentry from "@sentry/node"
 import {
-    getFeaturedMetricsWithParentTagName,
+    getFeaturedMetricsByParentTagName,
     KnexReadonlyTransaction,
 } from "../../../db/db.js"
 import {
@@ -192,7 +192,9 @@ export async function createFeaturedMetricRecords(
     records: ChartRecord[]
 ): Promise<ChartRecord[]> {
     const featuredMetricsWithParentTagName =
-        await getFeaturedMetricsWithParentTagName(trx)
+        await getFeaturedMetricsByParentTagName(trx).then((fms) =>
+            Object.values(fms).flat()
+        )
 
     const featuredMetricsGroupedByTagAndIncomeGroup = groupBy(
         featuredMetricsWithParentTagName,

--- a/baker/algolia/utils/types.ts
+++ b/baker/algolia/utils/types.ts
@@ -1,5 +1,9 @@
-import { DbEnrichedVariable } from "@ourworldindata/types"
+import {
+    DbEnrichedVariable,
+    FeaturedMetricIncomeGroup,
+} from "@ourworldindata/types"
 import { ChartRecord } from "../../../site/search/searchTypes.js"
+import { OwidIncomeGroupName } from "@ourworldindata/utils"
 
 /** Charts */
 export interface RawChartRecordRow {
@@ -126,4 +130,17 @@ export type EnrichedExplorerRecord =
 export type FinalizedExplorerRecord = ChartRecord & {
     viewTitleIndexWithinExplorer: number
     isFirstExplorerView: boolean
+}
+
+/**
+ * Maps OWID income groups to Featured Metric income groups.
+ */
+export const incomeGroupMap: Record<
+    Exclude<FeaturedMetricIncomeGroup, FeaturedMetricIncomeGroup.All>,
+    OwidIncomeGroupName
+> = {
+    [FeaturedMetricIncomeGroup.Low]: "OWID_LIC",
+    [FeaturedMetricIncomeGroup.LowerMiddle]: "OWID_LMC",
+    [FeaturedMetricIncomeGroup.UpperMiddle]: "OWID_UMC",
+    [FeaturedMetricIncomeGroup.High]: "OWID_HIC",
 }

--- a/db/db.ts
+++ b/db/db.ts
@@ -40,6 +40,7 @@ import {
     TagsTableName,
     TagGraphTableName,
     ExplorersTableName,
+    DbPlainFeaturedMetricWithParentTagName,
 } from "@ourworldindata/types"
 import { groupBy } from "lodash-es"
 import { gdocFromJSON } from "./model/Gdoc/GdocFactory.js"
@@ -952,6 +953,19 @@ export const getFeaturedMetricsByParentTagName = async (
         ...blankFeaturedMetricsByParentTagName,
         ...featuredMetricsByParentTagName,
     }
+}
+
+export async function getFeaturedMetricsWithParentTagName(
+    trx: KnexReadonlyTransaction
+): Promise<DbPlainFeaturedMetricWithParentTagName[]> {
+    return getFeaturedMetricsByParentTagName(trx).then((dictionary) =>
+        Object.entries(dictionary).flatMap(([parentTagName, metrics]) =>
+            metrics.map((metric) => ({
+                ...metric,
+                parentTagName,
+            }))
+        )
+    )
 }
 
 /**

--- a/db/db.ts
+++ b/db/db.ts
@@ -955,19 +955,6 @@ export const getFeaturedMetricsByParentTagName = async (
     }
 }
 
-export async function getFeaturedMetricsWithParentTagName(
-    trx: KnexReadonlyTransaction
-): Promise<DbPlainFeaturedMetricWithParentTagName[]> {
-    return getFeaturedMetricsByParentTagName(trx).then((dictionary) =>
-        Object.entries(dictionary).flatMap(([parentTagName, metrics]) =>
-            metrics.map((metric) => ({
-                ...metric,
-                parentTagName,
-            }))
-        )
-    )
-}
-
 /**
  * Takes a URL and checks if it points to a valid grapher, explorer, or MDIM view.
  * Doesn't validate query params as this would be quite complicated / overkill for our needs

--- a/packages/@ourworldindata/utils/src/regions.ts
+++ b/packages/@ourworldindata/utils/src/regions.ts
@@ -6,6 +6,7 @@ export enum RegionType {
     Other = "other",
     Aggregate = "aggregate",
     Continent = "continent",
+    IncomeGroup = "income_group",
 }
 
 export interface Country {
@@ -43,15 +44,23 @@ export interface Continent {
     members: string[]
 }
 
-export type Region = Country | Aggregate | Continent
-
-export const regions: Region[] = entities as Region[]
+export type IncomeGroup = {
+    code: OwidIncomeGroupName
+    name: string
+    slug: string
+    regionType: RegionType.IncomeGroup
+    members: string[]
+}
 
 export type OwidIncomeGroupName =
     | "OWID_LIC"
     | "OWID_LMC"
     | "OWID_UMC"
     | "OWID_HIC"
+
+export type Region = Country | Aggregate | Continent | IncomeGroup
+
+export const regions: Region[] = entities as Region[]
 
 export function checkIsOwidIncomeGroupName(
     name: string
@@ -100,7 +109,7 @@ export const incomeGroupsByName = lazy(
             regions
                 .filter((region) => checkIsOwidIncomeGroupName(region.code))
                 .map((region) => [region.code, region])
-        ) as Record<OwidIncomeGroupName, Aggregate>
+        ) as Record<OwidIncomeGroupName, IncomeGroup>
 )
 
 const countriesBySlug = lazy(() =>

--- a/packages/@ourworldindata/utils/src/regions.ts
+++ b/packages/@ourworldindata/utils/src/regions.ts
@@ -94,6 +94,15 @@ export const countriesByName = lazy(() =>
     Object.fromEntries(countries.map((country) => [country.name, country]))
 )
 
+export const incomeGroupsByName = lazy(
+    () =>
+        Object.fromEntries(
+            regions
+                .filter((region) => checkIsOwidIncomeGroupName(region.code))
+                .map((region) => [region.code, region])
+        ) as Record<OwidIncomeGroupName, Aggregate>
+)
+
 const countriesBySlug = lazy(() =>
     Object.fromEntries(countries.map((country) => [country.slug, country]))
 )

--- a/packages/@ourworldindata/utils/src/urls/Url.test.ts
+++ b/packages/@ourworldindata/utils/src/urls/Url.test.ts
@@ -131,4 +131,36 @@ describe(Url, () => {
         const url = Url.fromURL("/")
         expect(url.fullUrlNoTrailingSlash).toEqual("/")
     })
+
+    describe("areQueryParamsEqual", () => {
+        it("returns true for identical query params", () => {
+            const url1 = Url.fromURL("https://example.com/?a=1&b=2")
+            const url2 = Url.fromURL("https://example.com/?a=1&b=2")
+            expect(url1.areQueryParamsEqual(url2)).toBe(true)
+        })
+
+        it("returns true when order is different", () => {
+            const url1 = Url.fromURL("https://example.com/?a=1&b=2")
+            const url2 = Url.fromURL("https://example.com/?b=2&a=1")
+            expect(url1.areQueryParamsEqual(url2)).toBe(true)
+        })
+
+        it("returns false when there are different number of params", () => {
+            const url1 = Url.fromURL("https://example.com/?a=1&b=2")
+            const url2 = Url.fromURL("https://example.com/?a=1&b=2&c=3")
+            expect(url1.areQueryParamsEqual(url2)).toBe(false)
+        })
+
+        it("returns false when param values differ", () => {
+            const url1 = Url.fromURL("https://example.com/?a=1&b=2")
+            const url2 = Url.fromURL("https://example.com/?a=1&b=3")
+            expect(url1.areQueryParamsEqual(url2)).toBe(false)
+        })
+
+        it("returns false when param keys differ", () => {
+            const url1 = Url.fromURL("https://example.com/?a=1&b=2")
+            const url2 = Url.fromURL("https://example.com/?a=1&c=2")
+            expect(url1.areQueryParamsEqual(url2)).toBe(false)
+        })
+    })
 })

--- a/packages/@ourworldindata/utils/src/urls/Url.test.ts
+++ b/packages/@ourworldindata/utils/src/urls/Url.test.ts
@@ -162,5 +162,11 @@ describe(Url, () => {
             const url2 = Url.fromURL("https://example.com/?a=1&c=2")
             expect(url1.areQueryParamsEqual(url2)).toBe(false)
         })
+
+        it("returns true even when domain is different", () => {
+            const url1 = Url.fromURL("https://example.com/?a=1&b=2")
+            const url2 = Url.fromURL("https://other-thing.com/?a=1&b=2")
+            expect(url1.areQueryParamsEqual(url2)).toBe(true)
+        })
     })
 })

--- a/packages/@ourworldindata/utils/src/urls/Url.ts
+++ b/packages/@ourworldindata/utils/src/urls/Url.ts
@@ -167,6 +167,34 @@ export class Url {
             ),
         })
     }
+
+    areQueryParamsEqual(otherUrl: Url): boolean {
+        const thisParams = this.queryParams
+        const otherParams = otherUrl.queryParams
+
+        // First check if they have the same number of keys
+        const thisKeys = Object.keys(thisParams)
+        const otherKeys = Object.keys(otherParams)
+        if (thisKeys.length !== otherKeys.length) {
+            return false
+        }
+
+        // Check if all keys exist in both objects and have the same values
+        for (const key of thisKeys) {
+            if (!(key in otherParams)) {
+                return false
+            }
+
+            const thisValue = thisParams[key]
+            const otherValue = otherParams[key]
+
+            if (thisValue !== otherValue) {
+                return false
+            }
+        }
+
+        return true
+    }
 }
 
 export const setWindowUrl = (url: Url): void => {

--- a/packages/@ourworldindata/utils/src/urls/Url.ts
+++ b/packages/@ourworldindata/utils/src/urls/Url.ts
@@ -4,6 +4,7 @@ import { gdocUrlRegex, QueryParams } from "@ourworldindata/types"
 import { excludeUndefined, omitUndefinedValues } from "../Util.js"
 
 import { queryParamsToStr, strToQueryParams } from "./UrlUtils.js"
+import { isDeepEqual, isShallowEqual } from "remeda"
 
 const parseUrl = (url: string): urlParseLib<string> => {
     const parsed = urlParseLib(url, {})
@@ -172,28 +173,7 @@ export class Url {
         const thisParams = this.queryParams
         const otherParams = otherUrl.queryParams
 
-        // First check if they have the same number of keys
-        const thisKeys = Object.keys(thisParams)
-        const otherKeys = Object.keys(otherParams)
-        if (thisKeys.length !== otherKeys.length) {
-            return false
-        }
-
-        // Check if all keys exist in both objects and have the same values
-        for (const key of thisKeys) {
-            if (!(key in otherParams)) {
-                return false
-            }
-
-            const thisValue = thisParams[key]
-            const otherValue = otherParams[key]
-
-            if (thisValue !== otherValue) {
-                return false
-            }
-        }
-
-        return true
+        return isShallowEqual(thisParams, otherParams)
     }
 }
 

--- a/site/DataCatalog/DataCatalogUtils.ts
+++ b/site/DataCatalog/DataCatalogUtils.ts
@@ -21,6 +21,7 @@ const DATA_CATALOG_ATTRIBUTES = [
     "title",
     "slug",
     "availableEntities",
+    "originalAvailableEntities",
     "variantName",
     "type",
     "queryParams",
@@ -46,6 +47,7 @@ export type IDataCatalogHit = {
     title: string
     slug: string
     availableEntities: string[]
+    originalAvailableEntities?: string[]
     objectID: string
     variantName: string | null
     type: ChartRecordType

--- a/site/search/ChartHit.tsx
+++ b/site/search/ChartHit.tsx
@@ -40,21 +40,25 @@ export function ChartHit({
     const isExplorerView = hit.type === ChartRecordType.ExplorerView
     const isMultiDimView = hit.type === ChartRecordType.MultiDimView
 
-    const entities = useMemo(
-        () =>
-            pickEntitiesForChartHit(
-                hit._highlightResult?.availableEntities as
-                    | HitAttributeHighlightResult[]
-                    | undefined,
-                hit.availableEntities,
-                searchQueryRegionsMatches
-            ),
-        [
-            hit._highlightResult?.availableEntities,
-            hit.availableEntities,
-            searchQueryRegionsMatches,
-        ]
-    )
+    const entities = useMemo(() => {
+        const highlighted = (hit._highlightResult?.originalAvailableEntities ||
+            hit._highlightResult?.availableEntities) as
+            | HitAttributeHighlightResult[]
+            | undefined
+        const available = hit.originalAvailableEntities ?? hit.availableEntities
+
+        return pickEntitiesForChartHit(
+            highlighted,
+            available,
+            searchQueryRegionsMatches
+        )
+    }, [
+        hit._highlightResult?.availableEntities,
+        hit._highlightResult?.originalAvailableEntities,
+        hit.availableEntities,
+        hit.originalAvailableEntities,
+        searchQueryRegionsMatches,
+    ])
     const entityQueryStr = useMemo(
         () => getEntityQueryStr(entities),
         [entities]

--- a/site/search/searchTypes.ts
+++ b/site/search/searchTypes.ts
@@ -70,6 +70,13 @@ export interface ChartRecord {
     keyChartForTags: string[]
     tags: string[]
     availableEntities: string[]
+    /**
+     * Only present for income group-specific FMs: availableEntities before it gets filtered down.
+     * Without this, searching for charts with data for "Uganda" OR "United States" would return
+     * the FM version of the chart that only has Uganda in its available entities, and thus we
+     * wouldn't plot the data for the US, even though the chart has data for the US.
+     */
+    originalAvailableEntities?: string[]
     publishedAt: string
     updatedAt: string
     numDimensions: number

--- a/site/search/searchTypes.ts
+++ b/site/search/searchTypes.ts
@@ -77,6 +77,9 @@ export interface ChartRecord {
     numRelatedArticles: number
     views_7d: number
     score: number
+    // we set attributeForDistinct on this, so we can use it to deduplicate
+    // when we have multiple records for the same chart (e.g. with featured metrics)
+    id: string
 }
 
 export type IChartHit = Hit<BaseHit> & ChartRecord


### PR DESCRIPTION
Resolves https://github.com/owid/owid-grapher/issues/4677

## Changes
- Improves validation and error messages in the Featured Metrics admin to ensure URLs with grapher-specific query strings aren't added
- Adds a `areQueryParamsEqual` method to the `Url` class to allow for smart comparisons of URLs
  - e.g. `blah.com?a=a&b=b === blah.com?b=b&a=a // true`
- Adds an `id` property to all of the records that we index to `explorer-views-and-charts`
  - This property is used in `attributeForDistinct`, so that only one record per `id` can be returned
- Adds an optional `originalAvailableEntities` property to these records
- Adds a `createFeaturedMetricRecords` function
  - Takes the records about to be indexed
  - For each featured metric, it finds the corresponding record
  - Duplicates it
  - Increases its score, filters its `availableEntities`, adds `originalAvailableEntities`, and sets its `tags` to only be for the tag it was specified as an FM for

## To test
1. Go to http://staging-site-fm-indexing/admin/featured-metrics
2. Note the FMs set for `Poverty and Economic Development` and `Poverty`
3. Go to http://staging-site-fm-indexing/data
4. See all 4 FMs in the results for the `Poverty and Economic Development`
5. Apply `Uganda` as a country filter
6. See the `all` and `low` FMs, and one natural result
7. Apply `Uganda` and `United States` as a country filter
8. See the `all` and `low` FMs, and one natural result
9. Apply `Uganda` and `India`
10. See the `all`, `low`, and `lower-middle` FMs
11. Apply `United States` as a country filter
12. See only the `all` FMs, and then regular results
13. Click on the `Poverty and Economic Development` ribbon
14. See the `Poverty` ribbon's FM
