### PR TITLE
:sparkles: Improve 'make refresh'

### DIFF
--- a/db/exportMetadata.ts
+++ b/db/exportMetadata.ts
@@ -33,7 +33,7 @@ async function dataExport(): Promise<void> {
 
     // Dump all tables including schema
     await execWrapper(
-        `mysqldump --default-character-set=utf8mb4 --no-tablespaces -u '${GRAPHER_DB_USER}' -h '${GRAPHER_DB_HOST}' -P ${GRAPHER_DB_PORT} ${GRAPHER_DB_NAME} ${excludeTables
+        `mysqldump --default-character-set=utf8mb4 --no-tablespaces --column-statistics -u '${GRAPHER_DB_USER}' -h '${GRAPHER_DB_HOST}' -P ${GRAPHER_DB_PORT} ${GRAPHER_DB_NAME} ${excludeTables
             .map(
                 (tableName) => `--ignore-table=${GRAPHER_DB_NAME}.${tableName}`
             )

--- a/devTools/docker/refresh-grapher-data.sh
+++ b/devTools/docker/refresh-grapher-data.sh
@@ -28,13 +28,45 @@ import_db() {
 
 fillGrapherDb() {
     echo "==> Refreshing grapher database"
-    _mysql --database="" -e "DROP DATABASE IF EXISTS $GRAPHER_DB_NAME;CREATE DATABASE $GRAPHER_DB_NAME;ALTER DATABASE $GRAPHER_DB_NAME CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_as_cs;"
 
+    # Create a backup database name with timestamp
+    BACKUP_DB_NAME="${GRAPHER_DB_NAME}_bak_$(date +%s)"
+
+    # Check if the original database exists
+    DB_EXISTS=$(_mysql --database="" -e "SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME='$GRAPHER_DB_NAME'" 2>/dev/null | grep -c "$GRAPHER_DB_NAME" || true)
+
+    # If it exists, rename it instead of dropping it
+    if [ "$DB_EXISTS" -gt 0 ]; then
+        echo "Renaming existing database to $BACKUP_DB_NAME"
+        _mysql --database="" -e "CREATE DATABASE IF NOT EXISTS $BACKUP_DB_NAME;
+                                 RENAME TABLES
+                                 $GRAPHER_DB_NAME.* TO $BACKUP_DB_NAME.*;"
+    fi
+
+    # Create a new database
+    _mysql --database="" -e "DROP DATABASE IF EXISTS $GRAPHER_DB_NAME;
+                             CREATE DATABASE $GRAPHER_DB_NAME;
+                             ALTER DATABASE $GRAPHER_DB_NAME CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_as_cs;"
+
+    # Import data
     if [ -f "${DATA_FOLDER}/owid_metadata.sql.gz" ]; then
         echo "Importing live Grapher metadata database (owid_metadata)"
         import_db $DATA_FOLDER/owid_metadata.sql.gz
+
+        # If we got here, the import was successful, so drop the backup
+        if [ "$DB_EXISTS" -gt 0 ]; then
+            echo "Dropping backup database $BACKUP_DB_NAME"
+            _mysql --database="" -e "DROP DATABASE IF EXISTS $BACKUP_DB_NAME;"
+        fi
     else
-        echo "owid_metata.sql.gz missing in ${DATA_FOLDER}. Refresh aborted."
+        echo "owid_metadata.sql.gz missing in ${DATA_FOLDER}. Refresh aborted."
+
+        # If import fails and we had an original database, restore the original by renaming it back
+        if [ "$DB_EXISTS" -gt 0 ]; then
+            echo "Restoring original database from $BACKUP_DB_NAME"
+            _mysql --database="" -e "DROP DATABASE IF EXISTS $GRAPHER_DB_NAME;
+                                     RENAME DATABASE $BACKUP_DB_NAME TO $GRAPHER_DB_NAME;"
+        fi
         return 1
     fi
 


### PR DESCRIPTION
- Use `--column-statistics` to include statistics about indexes in the dump
- Instead of dropping MySQL and recreating it, rename it first and drop it only if the refresh is successful