### PR TITLE
:sparkles: Move explorer TSV parsing from automation to API

### DIFF
--- a/db/explorerParser.test.ts
+++ b/db/explorerParser.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest"
+import { parseExplorer } from "./explorerParser.js"
+
+describe("parseExplorer", () => {
+    it("parses table blocks correctly", () => {
+        const tsv = `table
+\tmyDataVar\tanotherVar
+\t1\t2
+\t3\t4`
+        const result = parseExplorer("test-table", tsv)
+
+        expect(result).toEqual({
+            _version: 1,
+            blocks: [
+                {
+                    type: "table",
+                    args: [],
+                    block: [
+                        { myDataVar: "1", anotherVar: "2" },
+                        { myDataVar: "3", anotherVar: "4" },
+                    ],
+                },
+            ],
+            isPublished: "false",
+        })
+    })
+
+    it("parses basic TSV structure", () => {
+        const tsv = `explorerTitle\tMy Explorer
+isPublished\tfalse
+explorerSubtitle\tThis is a test explorer
+graphers
+\tgrapherId\tTest Radio\ttype\tySlugs
+\t488\tA\tLineChart\tgdp
+\t4331\tB\tScatterPlot\tlife_expectancy
+columns
+\tslug\ttype\tname
+\tgdp\tNumeric\tGDP
+\tlife_expectancy\tNumeric\tLife Expectancy`
+
+        const result = parseExplorer("test-explorer", tsv)
+
+        expect(result).toEqual({
+            _version: 1,
+            explorerTitle: "My Explorer",
+            isPublished: "false",
+            explorerSubtitle: "This is a test explorer",
+            blocks: [
+                {
+                    type: "graphers",
+                    args: [],
+                    block: [
+                        {
+                            grapherId: "488",
+                            "Test Radio": "A",
+                            type: "LineChart",
+                            ySlugs: "gdp",
+                        },
+                        {
+                            grapherId: "4331",
+                            "Test Radio": "B",
+                            type: "ScatterPlot",
+                            ySlugs: "life_expectancy",
+                        },
+                    ],
+                },
+                {
+                    type: "columns",
+                    args: [],
+                    block: [
+                        { slug: "gdp", type: "Numeric", name: "GDP" },
+                        {
+                            slug: "life_expectancy",
+                            type: "Numeric",
+                            name: "Life Expectancy",
+                        },
+                    ],
+                },
+            ],
+        })
+    })
+})

--- a/db/explorerParser.ts
+++ b/db/explorerParser.ts
@@ -1,0 +1,143 @@
+// This code was adapted from https://github.com/owid/automation/blob/main/automation/mirror_explorers.py
+
+interface Statement {
+    verb: string
+    args: string[]
+    block?: Record<string, any>[]
+}
+
+const JSON_VERSION = 1
+
+// Added FLAGS constant from mirror_explorers.py
+const FLAGS: Set<string> = new Set([
+    "backgroundSeriesLimit",
+    "downloadDataLink",
+    "entityType",
+    "explorerSubtitle",
+    "explorerTitle",
+    "facet",
+    "googleSheet",
+    "hasMapTab",
+    "hideAlertBanner",
+    "hideControls",
+    "hideTitleAnnotation",
+    "indexViewsSeparately",
+    "isPublished",
+    "sourceDesc",
+    "subNavCurrentId",
+    "subNavId",
+    "subtitle",
+    "tab",
+    "thumbnail",
+    "title",
+    "type",
+    "wpBlockId",
+    "yAxisMin",
+    "ySlugs",
+])
+
+function isBlock(verb: string, args: string[]): boolean {
+    if (verb === "graphers" || verb === "columns") return true
+    return verb === "table" && !args.length
+}
+
+function readBlock(
+    lines: string[],
+    slug: string,
+    start: number
+): [Record<string, any>[], number] {
+    const block: string[] = []
+    let i = start
+    while (i < lines.length && lines[i].startsWith("\t")) {
+        block.push(lines[i].slice(1).replace(/\r?$/, ""))
+        i++
+    }
+    const records = tsvToRecords(block, slug, start)
+    pruneNulls(records)
+    return [records, i - start]
+}
+
+function pruneNulls(records: Record<string, any>[]): void {
+    for (const r of records) {
+        for (const k of Object.keys(r)) {
+            if (!r[k]) delete r[k]
+        }
+    }
+}
+
+function tsvToRecords(
+    block: string[],
+    slug: string,
+    start: number
+): Record<string, any>[] {
+    if (block[0].endsWith("\t")) {
+        console.warn("loose tab on block header", {
+            name: slug,
+            line_no: start,
+        })
+    }
+    // Modified: Check for empty column names with logging
+    let header = block[0].replace(/\t+$/, "").split("\t")
+    if (!header.every((col) => col)) {
+        console.error("empty column name", { name: slug, line_no: start })
+        header = header.map((col, idx) => col || `_column${idx}`)
+    }
+    const records: Record<string, any>[] = []
+    for (const line of block.slice(1)) {
+        const rowData = line.split("\t")
+        const record: Record<string, any> = {}
+        header.forEach((col, idx) => {
+            record[col] = rowData[idx]
+        })
+        records.push(record)
+    }
+    return records
+}
+
+function parseLineByLine(lines: string[], slug: string): Statement[] {
+    const filtered = lines.filter((l) => l.trim() || l.startsWith("##"))
+    const data: Statement[] = []
+    let i = 0
+    while (i < filtered.length) {
+        const parts = filtered[i].replace(/\r?$/, "").split("\t")
+        const verb = parts[0]
+        const args = parts.slice(1)
+        i++
+        if (!isBlock(verb, args)) {
+            data.push({ verb, args })
+            continue
+        }
+        const [records, offset] = readBlock(filtered, slug, i)
+        i += offset
+        data.push({ verb, args, block: records })
+    }
+    return data
+}
+
+export function parseExplorer(
+    slug: string,
+    tsvContent: string
+): Record<string, any> {
+    console.log(`Parsing explorer for slug: ${slug}`)
+    const lines = tsvContent.split(/\r?\n/)
+    const statements = parseLineByLine(lines, slug)
+    const result: Record<string, any> = { _version: JSON_VERSION }
+
+    for (const s of statements) {
+        if (FLAGS.has(s.verb)) {
+            result[s.verb] = s.args[0] ?? null
+        } else if (!["table", "graphers", "columns"].includes(s.verb)) {
+            result[s.verb] = s.args
+        } else {
+            const blocks = result.blocks ?? []
+            blocks.push({ type: s.verb, args: s.args, block: s.block })
+            result.blocks = blocks
+        }
+    }
+
+    if (result.isPublished === undefined) {
+        result.isPublished = "false"
+    }
+
+    return result
+}

--- a/db/model/Explorer.ts
+++ b/db/model/Explorer.ts
@@ -4,6 +4,7 @@ import {
     DbPlainExplorer,
     ExplorersTableName,
 } from "@ourworldindata/types"
+import { parseExplorer } from "../explorerParser.js"
 
 type PlainExplorerWithLastCommit = Required<DbPlainExplorer> & {
     // lastCommit is a relic from our git-CMS days, it should be broken down
@@ -31,11 +32,212 @@ function createLastCommit(
     return JSON.stringify(lastCommit)
 }
 
+function detectChartIds(config: any): number[] {
+    const chartIds: number[] = []
+    if (config.blocks && Array.isArray(config.blocks)) {
+        for (const block of config.blocks) {
+            if (block.type === "graphers" && Array.isArray(block.block)) {
+                for (const row of block.block) {
+                    if (row.grapherId) {
+                        chartIds.push(Number(row.grapherId))
+                    }
+                }
+            }
+        }
+    }
+    return chartIds
+}
+
+function detectVariableIdsAndCatalogPaths(config: {
+    [key: string]: any
+}): Set<string> {
+    const variableIdsAndCatalogPaths = new Set<string>()
+    if (config.blocks && Array.isArray(config.blocks)) {
+        for (const block of config.blocks) {
+            if (block.type === "graphers" && Array.isArray(block.block)) {
+                for (const row of block.block) {
+                    if (row.yVariableIds) {
+                        row.yVariableIds
+                            .split(/\s+/)
+                            .forEach((id: string) =>
+                                variableIdsAndCatalogPaths.add(id)
+                            )
+                    }
+                    if (row.xVariableId) {
+                        variableIdsAndCatalogPaths.add(row.xVariableId)
+                    }
+                    if (row.colorVariableId) {
+                        variableIdsAndCatalogPaths.add(row.colorVariableId)
+                    }
+                    if (row.sizeVariableId) {
+                        variableIdsAndCatalogPaths.add(row.sizeVariableId)
+                    }
+                }
+            }
+        }
+    }
+    return variableIdsAndCatalogPaths
+}
+
+async function validateChartIds(
+    knex: KnexReadWriteTransaction,
+    proposed: number[]
+): Promise<number[]> {
+    if (!proposed.length) return []
+    const foundRows = await knex("charts").whereIn("id", proposed).select("id")
+    const found = foundRows.map((row: any) => row.id)
+    const missing = proposed.filter((id) => !found.includes(id))
+    if (missing.length > 0) {
+        console.warn("Missing charts in db:", missing)
+    }
+    return found
+}
+
+export async function upsertExplorerCharts(
+    knex: KnexReadWriteTransaction,
+    slug: string,
+    config: any
+): Promise<void> {
+    const detected = detectChartIds(config)
+    const validChartIds = new Set(await validateChartIds(knex, detected))
+    const existingRows = await knex("explorer_charts").where({
+        explorerSlug: slug,
+    })
+    const existing = new Set<number>(
+        existingRows.map((row: any) => row.chartId)
+    )
+
+    console.log(`Upserting chart links for explorer [${slug}]`)
+    if (
+        validChartIds.size !== existing.size ||
+        [...validChartIds].some((id) => !existing.has(id))
+    ) {
+        await knex("explorer_charts").where({ explorerSlug: slug }).delete()
+        for (const chartId of validChartIds) {
+            await knex("explorer_charts").insert({
+                explorerSlug: slug,
+                chartId,
+            })
+        }
+    }
+}
+
+function setEquals(a: Set<number>, b: Set<number>): boolean {
+    if (a.size !== b.size) return false
+    for (const v of a) {
+        if (!b.has(v)) return false
+    }
+    return true
+}
+
+async function validateVariableIds(
+    knex: KnexReadWriteTransaction,
+    proposed: number[],
+    isPublished: boolean
+): Promise<number[]> {
+    if (proposed.length === 0) return []
+    const foundRows = await knex("variables")
+        .whereIn("id", proposed)
+        .select("id")
+    const found = foundRows.map((row: any) => row.id)
+    const missing = proposed.filter((id) => !found.includes(id))
+    if (missing.length > 0) {
+        console.error("missing variables in db", {
+            missing_variables: missing,
+            isPublished,
+        })
+    }
+    return found
+}
+
+export async function upsertExplorerVariables(
+    knex: KnexReadWriteTransaction,
+    slug: string,
+    config: any
+): Promise<void> {
+    // Get all variable ids and catalog paths from the explorer config.
+    const proposed = detectVariableIdsAndCatalogPaths(config)
+    const proposedCatalogPaths = new Set(
+        Array.from(proposed).filter((x) => isNaN(Number(x)))
+    )
+    const proposedVariableIds = new Set(
+        Array.from(proposed)
+            .filter((x) => !isNaN(Number(x)))
+            .map((x) => Number(x))
+    )
+
+    // Verify that the total number of items in 'proposed' equals
+    // the sum of items in 'proposedCatalogPaths' and 'proposedVariableIds'
+    if (
+        proposed.size !==
+        proposedCatalogPaths.size + proposedVariableIds.size
+    ) {
+        throw new Error(
+            "Mismatch: proposed size does not equal the sum of proposedCatalogPaths and proposedVariableIds sizes"
+        )
+    }
+    const isPublished = config["isPublished"] === "true"
+
+    // Resolve catalog paths to variable ids via a knex query.
+    const resolvedRows = await knex("variables")
+        .whereIn("catalogPath", Array.from(proposedCatalogPaths))
+        .select("id", "catalogPath")
+    const foundCatalogPaths = new Set(
+        resolvedRows.map((row: any) => row.catalogPath)
+    )
+    const resolvedVariableIds = new Set<number>(
+        resolvedRows.map((row: any) => row.id)
+    )
+    const missing = Array.from(proposedCatalogPaths).filter(
+        (x) => !foundCatalogPaths.has(x)
+    )
+    if (missing.length > 0) {
+        console.error(
+            `Couldn't resolve ${missing.length} catalog paths:`,
+            missing,
+            isPublished
+        )
+    }
+    // Merge proposed variable ids and resolved variable ids.
+    const proposedUnion = new Set<number>([
+        ...proposedVariableIds,
+        ...resolvedVariableIds,
+    ])
+    const existingRows = await knex("explorer_variables").where({
+        explorerSlug: slug,
+    })
+    const existing = new Set<number>(
+        existingRows.map((row: any) => row.variableId)
+    )
+
+    if (!setEquals(proposedUnion, existing)) {
+        console.log("Linking explorer to variables", {
+            n_variables: proposedUnion.size,
+        })
+        const validIds = await validateVariableIds(
+            knex,
+            Array.from(proposedUnion),
+            isPublished
+        )
+        await knex("explorer_variables").where({ explorerSlug: slug }).delete()
+        for (const variableId of validIds) {
+            await knex("explorer_variables").insert({
+                explorerSlug: slug,
+                variableId,
+            })
+        }
+    }
+}
+
 export async function upsertExplorer(
     knex: KnexReadWriteTransaction,
     data: DbInsertExplorer
 ): Promise<string> {
     const { slug, tsv, lastEditedByUserId, commitMessage } = data
+
+    // Parse the TSV
+    const config = JSON.stringify(parseExplorer(slug, tsv))
+
     // Check if explorer with this catalog path already exists
     const existingExplorer = await knex<DbPlainExplorer>(ExplorersTableName)
         .where({ slug })
@@ -43,18 +245,17 @@ export async function upsertExplorer(
 
     // NOTE: We could do an actual upsert on the DB level here (see e.g. upsertMultiDimDataPage)
     if (existingExplorer) {
-        // Update existing explorer with new config
+        // Update existing explorer
         await knex<DbPlainExplorer>(ExplorersTableName)
             .where({ slug: existingExplorer.slug })
             .update({
                 tsv,
+                config,
                 commitMessage,
                 lastEditedByUserId,
                 lastEditedAt: new Date(),
                 updatedAt: new Date(),
             })
-
-        return existingExplorer.slug
     } else {
         // Create new explorer
         // isPublished is currently set in the
@@ -70,10 +271,14 @@ export async function upsertExplorer(
             lastEditedByUserId,
             lastEditedAt: new Date(),
             commitMessage,
-            config: "{}",
+            config,
         })
-        return slug
     }
+
+    upsertExplorerCharts(knex, slug, JSON.parse(config))
+    upsertExplorerVariables(knex, slug, JSON.parse(config))
+
+    return slug
 }
 
 export async function getExplorerBySlug(

--- a/packages/@ourworldindata/types/src/dbTypes/Explorers.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/Explorers.ts
@@ -14,8 +14,8 @@ export type DbPlainExplorer = Required<DbInsertExplorer> & {
     createdAt: Date
     // updatedAt is set automatically by MySQL
     updatedAt: Date
-    // these properties are populated from Buildkite's pipeline "Mirror explorers to MySQL"
-    // it's used in getNonGrapherExplorerViewCount or in getPublishedExplorersBySlug
+    // config is a parsed version of the TSV
+    // it is used in getNonGrapherExplorerViewCount or in getPublishedExplorersBySlug
     config: string
 }
 


### PR DESCRIPTION
We run a nightly script [mirror_explorers.py in automation](https://github.com/owid/automation/blob/main/automation/mirror_explorers.py) that parses TSV into structured format and adds links to tables `explorer_variables` and `explorer_charts`. Now that we have an API for explorers, it makes sense to move it there and do it as part of the request.

## TODO before merging
- [ ] Check parity of tables `explorers.config`, `explorer_variables` and `explorer_charts` between staging and production