### PR TITLE
🎉 (entity selector) filter entities by type / TAS-923

### DIFF
--- a/devTools/regionsUpdater/update.ts
+++ b/devTools/regionsUpdater/update.ts
@@ -97,6 +97,7 @@ interface Entity {
     short_name?: string
     slug?: string
     region_type?: string
+    defined_by?: string
     is_mappable?: boolean
     is_historical?: boolean
     is_unlisted?: boolean
@@ -268,6 +269,7 @@ async function main() {
         // drop redundant attrs
         if (entity.short_name === entity.name) delete entity.short_name
         if (entity.region_type !== "country") delete entity.is_mappable
+        if (entity.defined_by === "owid") delete entity.defined_by
 
         // update geojson with canonical names & validate mappability flag
         const outline = owidGeoJson.features.find(
@@ -318,6 +320,7 @@ async function main() {
                 "shortName",
                 "slug",
                 "regionType",
+                "definedBy",
                 "isMappable",
                 "isHistorical",
                 "isUnlisted",

--- a/packages/@ourworldindata/grapher/src/controls/globalEntitySelector/GlobalEntitySelector.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/globalEntitySelector/GlobalEntitySelector.tsx
@@ -21,6 +21,7 @@ import {
     getWindowUrl,
     setWindowUrl,
     lazy,
+    RegionType,
 } from "@ourworldindata/utils"
 import { GrapherAnalytics } from "../../core/GrapherAnalytics"
 import { WORLD_ENTITY_NAME } from "../../core/GrapherConstants"
@@ -53,7 +54,7 @@ const getAllEntitiesSortedWithWorld = lazy(() =>
                 name: WORLD_ENTITY_NAME,
                 code: "OWID_WRL",
                 slug: "world",
-                regionType: "other",
+                regionType: RegionType.Other,
             },
         ])
 )

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -1529,7 +1529,7 @@ export class Grapher
         }
     }
 
-    @computed private get entitySelector(): EntitySelector {
+    @computed get entitySelector(): EntitySelector {
         const entitySelectorArray = this.isOnMapTab
             ? this.mapConfig.selection
             : this.selection

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -1614,7 +1614,8 @@ export class Grapher
     ): void {
         if (isMapTab(newTab) || isChartTab(newTab)) {
             const { mapColumnSlug, entitySelector } = this
-            const { interpolatedSortColumnsBySlug } = this.entitySelectorState
+            const { interpolatedSortColumnsBySlug, entityFilter } =
+                this.entitySelectorState
             const sortSlug = entitySelector.sortConfig.slug
 
             // the map and chart tab might have a different set of sort columns;
@@ -1622,6 +1623,14 @@ export class Grapher
             if (!entitySelector.isSortSlugValid(sortSlug)) {
                 this.entitySelectorState.sortConfig =
                     entitySelector.getDefaultSortConfig()
+            }
+
+            // the map and chart tab might have a different set of entity filters;
+            // if the currently selected entity filter is invalid, reset it
+            if (entityFilter) {
+                if (!this.entitySelector.isEntityFilterValid(entityFilter)) {
+                    this.entitySelectorState.entityFilter = undefined
+                }
             }
 
             // the map column slug might be interpolated with different

--- a/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.scss
+++ b/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.scss
@@ -121,6 +121,11 @@
         .label {
             flex-shrink: 0;
             margin-bottom: 6px;
+
+            svg {
+                margin-right: 6px;
+                transform: rotate(-90deg);
+            }
         }
 
         button.sort {
@@ -170,6 +175,10 @@
 
         .label {
             margin-bottom: 6px;
+
+            svg {
+                margin-right: 6px;
+            }
         }
     }
 

--- a/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.scss
+++ b/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.scss
@@ -112,8 +112,9 @@
         .entity-selector__dropdown {
             flex-grow: 1;
 
-            .time {
-                color: $gray-60;
+            // make the options menu wider to cover the sort button
+            .menu {
+                width: calc(100% + $sort-button-margin + $sort-button-size);
             }
         }
 
@@ -160,6 +161,15 @@
                 background: $gray-10;
                 color: $gray-60;
             }
+        }
+    }
+
+    .entity-selector__filter-bar {
+        margin-top: 16px;
+        margin-bottom: 8px;
+
+        .label {
+            margin-bottom: 6px;
         }
     }
 
@@ -291,20 +301,35 @@
             list-style-type: none;
         }
 
+        // add borders in between elements
         li + li .selectable-entity {
             border-top: $row-border;
         }
 
+        // add a top border to the first element
         li:first-of-type .selectable-entity {
             border-top: $row-border;
         }
 
+        // add a bottom border to the last element
         li:last-of-type .selectable-entity {
             border-bottom: $row-border;
         }
+
+        // make an exception for the top border if requested
+        .hide-top-border li:first-of-type .selectable-entity {
+            border-top: none;
+        }
     }
 
-    .grapher-dropdown .menu {
-        width: calc(100% + $sort-button-margin + $sort-button-size);
+    .grapher-dropdown {
+        .control .detail,
+        .option .detail {
+            color: $gray-60;
+        }
+
+        .option.active .detail {
+            color: $blue-50;
+        }
     }
 }

--- a/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.scss
+++ b/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.scss
@@ -65,18 +65,8 @@
                 padding-right: $svg-margin + $svg-size + 4px;
                 border-radius: 4px;
                 background: #fff;
-
-                // style placeholder text in search input
-                &::placeholder {
-                    color: $placeholder;
-                    opacity: 1; /* Firefox */
-                }
-                &:-ms-input-placeholder {
-                    color: $placeholder;
-                }
-                &::-ms-input-placeholder {
-                    color: $placeholder;
-                }
+                color: $dark-text;
+                font-size: 16px; // prevent auto-zoom on ios
 
                 // style focus state
                 &:focus {
@@ -89,6 +79,16 @@
                 &:focus-visible {
                     border: $focus;
                 }
+            }
+
+            .search-placeholder {
+                @include grapher_label-2-regular;
+                color: $placeholder;
+                pointer-events: none;
+                position: absolute;
+                top: 50%;
+                left: $svg-size + $svg-margin + 6px;
+                transform: translateY(-50%);
             }
 
             &.search-input--empty {

--- a/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.test.ts
+++ b/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest"
+import { Grapher } from "../core/Grapher"
+import {
+    SynthesizeFruitTable,
+    SynthesizeGDPTable,
+} from "@ourworldindata/core-table"
+
+it("updates the selection based on the active tab", () => {
+    const grapher = new Grapher()
+
+    // updates the chart selection when shown next to the chart
+    grapher.entitySelector.onChange("Italy")
+    expect(grapher.selection.selectedEntityNames).toEqual(["Italy"])
+
+    // after switching to the map tab, the entity selector updates the map selection
+    grapher.tab = "map"
+    grapher.entitySelector.onChange("Spain")
+    expect(grapher.map.selection.selectedEntityNames).toEqual(["Spain"])
+})
+
+describe("filter by dropdown", () => {
+    it("doesn't show a dropdown for non-geographic data", () => {
+        const table = SynthesizeFruitTable()
+        const grapher = new Grapher({ table })
+        expect(grapher.entitySelector.shouldShowFilterBar).toBe(false)
+    })
+
+    it("doesn't show a dropdown if there is a single category", () => {
+        const table = SynthesizeGDPTable({ entityNames: ["Spain", "France"] })
+        const grapher = new Grapher({ table })
+        expect(grapher.entitySelector.shouldShowFilterBar).toBe(false)
+    })
+
+    it("shows a dropdown if there are at least two categories", () => {
+        const table = SynthesizeGDPTable({
+            entityNames: ["Spain", "France", "Europe"],
+        })
+        const grapher = new Grapher({ table })
+        expect(grapher.entitySelector.shouldShowFilterBar).toBe(true)
+        expect(
+            grapher.entitySelector.filterOptions.map((option) => option.value)
+        ).toEqual(["all", "countries", "continents"])
+    })
+
+    it("detects regions based on their suffix", () => {
+        const table = SynthesizeGDPTable({
+            entityNames: [
+                "Europe and Central Asia (WB)", // defined in regions.json
+                "Europe & Central Asia (WB)", // alternative name
+            ],
+        })
+        const grapher = new Grapher({ table })
+        expect(grapher.entitySelector.entitiesByRegionType.get("wb")).toEqual([
+            "Europe and Central Asia (WB)",
+            "Europe & Central Asia (WB)",
+        ])
+    })
+})

--- a/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
+++ b/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
@@ -472,6 +472,12 @@ export class EntitySelector extends React.Component<{
         return this.sortOptions.some((option) => option.value === slug)
     }
 
+    isEntityFilterValid(entityFilter: EntityRegionType): boolean {
+        return this.filterOptions.some(
+            (option) => option.value === entityFilter
+        )
+    }
+
     @computed private get entityFilter(): EntityRegionType {
         return (
             this.manager.entitySelectorState.entityFilter ??

--- a/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
+++ b/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
@@ -21,6 +21,10 @@ import {
     convertDaysSinceEpochToDate,
     max,
     checkIsOwidIncomeGroupName,
+    groupBy,
+    Aggregate,
+    AggregateSource,
+    getRegionByName,
 } from "@ourworldindata/utils"
 import {
     Checkbox,
@@ -64,9 +68,17 @@ import { MapConfig } from "../mapCharts/MapConfig"
 
 type CoreColumnBySlug = Record<ColumnSlug, CoreColumn>
 
+type EntityRegionType =
+    | "all"
+    | "countries"
+    | "continents" // owid continents
+    | "incomeGroups"
+    | AggregateSource // e.g. who or wb
+
 export interface EntitySelectorState {
     searchInput: string
     sortConfig: SortConfig
+    entityFilter: EntityRegionType
     localEntityNames?: string[]
     interpolatedSortColumnsBySlug?: CoreColumnBySlug
     isLoadingExternalSortColumn?: boolean
@@ -104,15 +116,28 @@ type SearchableEntity = {
     alternativeNames?: string[]
 }
 
-interface PartitionedEntities {
-    selected: SearchableEntity[]
-    unselected: SearchableEntity[]
-}
-
-interface DropdownOption {
+interface SortDropdownOption {
     value: string // slug
     label: string
     formattedTime?: string
+}
+
+const entityFilterLabels: Record<EntityRegionType, string> = {
+    all: "All",
+    countries: "Countries",
+    continents: "Continents", // OWID-defined continents
+    incomeGroups: "Income groups",
+
+    // Regions defined by an institution
+    who: "World Health Organization regions",
+    wb: "World Bank regions",
+    unsd: "UN Statistics Division regions",
+}
+
+interface FilterDropdownOption {
+    value: EntityRegionType
+    label: string
+    count: number
 }
 
 const EXTERNAL_SORT_INDICATOR_DEFINITIONS = [
@@ -321,6 +346,10 @@ export class EntitySelector extends React.Component<{
         this.set({ searchInput: "" })
     }
 
+    private resetEntityFilter(): void {
+        this.set({ entityFilter: undefined })
+    }
+
     private updateSortSlug(newSlug: ColumnSlug) {
         this.set({
             sortConfig: {
@@ -412,6 +441,14 @@ export class EntitySelector extends React.Component<{
 
     isSortSlugValid(slug: ColumnSlug): boolean {
         return this.sortOptions.some((option) => option.value === slug)
+    }
+
+    @computed private get entityFilter(): EntityRegionType {
+        return (
+            this.manager.entitySelectorState.entityFilter ??
+            this.filterOptions[0].value ??
+            "all"
+        )
     }
 
     @computed private get localEntityNames(): string[] | undefined {
@@ -506,8 +543,8 @@ export class EntitySelector extends React.Component<{
         )
     }
 
-    @computed get sortOptions(): DropdownOption[] {
-        const options: DropdownOption[] = []
+    @computed get sortOptions(): SortDropdownOption[] {
+        const options: SortDropdownOption[] = []
 
         // the first dropdown option is always the entity name
         options.push({
@@ -570,7 +607,7 @@ export class EntitySelector extends React.Component<{
         return options
     }
 
-    @computed get sortValue(): DropdownOption | null {
+    @computed get sortValue(): SortDropdownOption | null {
         return (
             this.sortOptions.find(
                 (option) => option.value === this.sortConfig.slug
@@ -639,6 +676,25 @@ export class EntitySelector extends React.Component<{
             }
 
             return searchableEntity
+        })
+    }
+
+    @computed private get filteredAvailableEntities(): SearchableEntity[] {
+        const { availableEntities, entityFilter } = this
+
+        if (entityFilter === "all") return this.sortEntities(availableEntities)
+
+        const entityNameSet = new Set(
+            this.entitiesByRegionType.get(entityFilter)
+        )
+        const filteredAvailableEntities = availableEntities.filter((entity) =>
+            entityNameSet.has(entity.name)
+        )
+
+        return this.sortEntities(filteredAvailableEntities, {
+            // non-country groups are usually small,
+            // so sorting local entities to the top isn't necessary
+            sortLocalsAndWorldToTop: entityFilter === "countries",
         })
     }
 
@@ -724,7 +780,7 @@ export class EntitySelector extends React.Component<{
 
     @computed get fuzzy(): FuzzySearch<SearchableEntity> {
         return FuzzySearch.withKeyArray(
-            this.sortedAvailableEntities,
+            this.filteredAvailableEntities,
             (entity) => [entity.name, ...(entity.alternativeNames ?? [])],
             (entity) => entity.name
         )
@@ -735,37 +791,18 @@ export class EntitySelector extends React.Component<{
         return this.fuzzy.search(this.searchInput)
     }
 
-    @computed get partitionedSearchResults(): PartitionedEntities | undefined {
-        const { searchResults } = this
-
-        if (!searchResults) return undefined
-
-        const [selected, unselected] = partition(
-            searchResults,
-            (entity: SearchableEntity) => this.isEntitySelected(entity)
+    @computed get selectedSearchResults(): SearchableEntity[] | undefined {
+        if (!this.searchResults) return undefined
+        return this.searchResults.filter((entity: SearchableEntity) =>
+            this.isEntitySelected(entity)
         )
-
-        return { selected, unselected }
     }
 
-    @computed get partitionedAvailableEntities(): PartitionedEntities {
-        const [selected, unselected] = partition(
-            this.sortedAvailableEntities,
-            (entity: SearchableEntity) => this.isEntitySelected(entity)
+    @computed get selectedEntities(): SearchableEntity[] {
+        const selected = this.availableEntities.filter((entity) =>
+            this.isEntitySelected(entity)
         )
-
-        return {
-            selected: this.sortEntities(selected, {
-                sortLocalsAndWorldToTop: false,
-            }),
-            unselected: this.sortEntities(unselected),
-        }
-    }
-
-    @computed get partitionedVisibleEntities(): PartitionedEntities {
-        return (
-            this.partitionedSearchResults ?? this.partitionedAvailableEntities
-        )
+        return this.sortEntities(selected, { sortLocalsAndWorldToTop: false })
     }
 
     @action.bound onTitleClick(): void {
@@ -817,9 +854,8 @@ export class EntitySelector extends React.Component<{
     }
 
     @action.bound onClear(): void {
-        const { partitionedSearchResults } = this
         if (this.searchInput) {
-            const { selected = [] } = partitionedSearchResults ?? {}
+            const selected = this.selectedSearchResults ?? []
             const dropEntityNames = selected.map((entity) => entity.name)
             this.selectionArray.deselectEntities(dropEntityNames)
             this.onDeselectEntities(dropEntityNames)
@@ -829,6 +865,8 @@ export class EntitySelector extends React.Component<{
             this.onDeselectEntities(dropEntityNames)
             this.manager.onClearEntities?.()
         }
+
+        this.resetEntityFilter()
     }
 
     @action.bound async loadAndSetExternalSortColumn(
@@ -861,7 +899,7 @@ export class EntitySelector extends React.Component<{
 
     @action.bound async onChangeSortSlug(selected: unknown): Promise<void> {
         if (selected) {
-            const { value: slug } = selected as DropdownOption
+            const { value: slug } = selected as SortDropdownOption
 
             // if an external indicator has been selected, load it
             const external = this.externalSortIndicatorDefinitions.find(
@@ -890,6 +928,138 @@ export class EntitySelector extends React.Component<{
         } else {
             this.manager.isEntitySelectorModalOrDrawerOpen = false
         }
+    }
+
+    @computed private get entitiesByRegionType(): Map<
+        EntityRegionType,
+        EntityName[]
+    > {
+        // the 'World' entity shouldn't show up in any of the groups
+        const availableEntityNames = this.availableEntityNames.filter(
+            (entityName) => !isWorldEntityName(entityName)
+        )
+
+        // map entities to their regions
+        const availableRegions = excludeUndefined(
+            availableEntityNames.map((entityName) =>
+                getRegionByName(entityName)
+            )
+        )
+
+        // group regions by type
+        const regionsGroupedByType = groupBy(
+            availableRegions,
+            (r) => r.regionType
+        )
+
+        const entitiesByType = new Map<EntityRegionType, EntityName[]>()
+
+        // add the 'countries' group
+        if (regionsGroupedByType.country) {
+            entitiesByType.set(
+                "countries",
+                regionsGroupedByType.country.map((region) => region.name)
+            )
+        }
+
+        // add the 'continents' group
+        if (regionsGroupedByType.continent) {
+            entitiesByType.set(
+                "continents",
+                regionsGroupedByType.continent.map((region) => region.name)
+            )
+        }
+
+        // add the 'incomeGroups' group
+        if (regionsGroupedByType.income_group) {
+            entitiesByType.set(
+                "incomeGroups",
+                regionsGroupedByType.income_group.map((region) => region.name)
+            )
+        }
+
+        // add groups for institution-defined regions
+        if (regionsGroupedByType.aggregate) {
+            const aggregates = regionsGroupedByType.aggregate as Aggregate[]
+            const aggregatesGroupedBySource = groupBy(
+                aggregates,
+                (region) => region.definedBy
+            )
+
+            for (const [source, members] of Object.entries(
+                aggregatesGroupedBySource
+            )) {
+                if (source) {
+                    entitiesByType.set(
+                        source as AggregateSource,
+                        members.map((region) => region.name)
+                    )
+                }
+            }
+        }
+
+        return entitiesByType
+    }
+
+    @computed private get filterOptions(): FilterDropdownOption[] {
+        const options = Array.from(this.entitiesByRegionType.entries()).map(
+            ([key, entities]) => ({
+                value: key,
+                label: entityFilterLabels[key],
+                count: entities.length,
+            })
+        )
+
+        return [
+            {
+                value: "all",
+                label: entityFilterLabels.all,
+                count: this.availableEntities.length,
+            },
+            ...options,
+        ]
+    }
+
+    @action.bound private onChangeEntityFilter(selected: unknown): void {
+        if (selected) {
+            this.set({
+                entityFilter: (selected as FilterDropdownOption).value,
+            })
+        }
+    }
+
+    @computed private get filterValue(): FilterDropdownOption {
+        return (
+            this.filterOptions.find(
+                (option) => option.value === this.entityFilter
+            ) ?? this.filterOptions[0]
+        )
+    }
+
+    private renderFilterBar(): React.ReactElement {
+        return (
+            <div className="entity-selector__filter-bar">
+                <span
+                    id="entity-selector__filter-dropdown-label"
+                    className="label grapher_label-2-regular grapher_light"
+                >
+                    Filter by type
+                </span>
+                <Dropdown<FilterDropdownOption>
+                    className="entity-selector__filter-dropdown"
+                    options={this.filterOptions}
+                    onChange={this.onChangeEntityFilter}
+                    value={this.filterValue}
+                    formatOptionLabel={(option) => (
+                        <>
+                            {option.label}{" "}
+                            <span className="detail">({option.count})</span>
+                        </>
+                    )}
+                    aria-labelledby="entity-selector__filter-dropdown-label"
+                />
+            </div>
+        )
     }
 
     private renderSearchBar(): React.ReactElement {
@@ -940,7 +1110,7 @@ export class EntitySelector extends React.Component<{
                     Sort by
                 </div>
                 <div className="entity-selector__sort-dropdown-and-button">
-                    <Dropdown<DropdownOption>
+                    <Dropdown<SortDropdownOption>
                         className="entity-selector__dropdown"
                         options={this.sortOptions}
                         onChange={this.onChangeSortSlug}
@@ -950,7 +1120,7 @@ export class EntitySelector extends React.Component<{
                             <>
                                 {option.label}
                                 {option.formattedTime && (
-                                    <span className="time">
+                                    <span className="detail">
                                         , {option.formattedTime}
                                     </span>
                                 )}
@@ -1071,17 +1241,18 @@ export class EntitySelector extends React.Component<{
     }
 
     private renderAllEntitiesInMultiMode(): React.ReactElement {
-        const {
-            sortedAvailableEntities,
-            partitionedVisibleEntities: visibleEntities,
-        } = this
-        const { selected } = this.partitionedAvailableEntities
+        const { filteredAvailableEntities, selectedEntities } = this
         const { numSelectedEntities, selectedEntityNames } = this.selectionArray
 
         // having a "Selection" and "Available entities" section both looks odd
         // when all entities are currently selected and there are only a few of them
-        const hasFewEntities = sortedAvailableEntities.length < 10
-        const hideAvailableEntities = hasFewEntities && this.allEntitiesSelected
+        const hasFewEntities = filteredAvailableEntities.length < 10
+        const shouldHideAvailableEntities =
+            hasFewEntities && this.allEntitiesSelected
+
+        const shouldShowFilterBar =
+            this.filterOptions.length > 1 &&
+            this.filterOptions[0].count !== this.filterOptions[1].count
 
         return (
             <Flipper
@@ -1089,7 +1260,7 @@ export class EntitySelector extends React.Component<{
                 flipKey={selectedEntityNames.join(",")}
             >
                 <div className="entity-section">
-                    {selected.length > 0 && (
+                    {selectedEntities.length > 0 && (
                         <Flipped flipId="__selection" translate opacity>
                             <div className="entity-section__header">
                                 <div className="entity-section__title grapher_body-3-regular-italic grapher_light">
@@ -1097,20 +1268,14 @@ export class EntitySelector extends React.Component<{
                                     {numSelectedEntities > 0 &&
                                         `(${numSelectedEntities})`}
                                 </div>
-                                <button
-                                    type="button"
-                                    onClick={this.onClear}
-                                    disabled={
-                                        visibleEntities.selected.length === 0
-                                    }
-                                >
+                                <button type="button" onClick={this.onClear}>
                                     Clear
                                 </button>
                             </div>
                         </Flipped>
                     )}
                     <ul>
-                        {selected.map((entity, entityIndex) => (
+                        {selectedEntities.map((entity, entityIndex) => (
                             <FlippedListItem
                                 index={entityIndex}
                                 key={entity.name}
@@ -1129,16 +1294,28 @@ export class EntitySelector extends React.Component<{
                     </ul>
                 </div>
 
-                {!hideAvailableEntities && (
-                    <div className="entity-section">
-                        <Flipped flipId="__available" translate opacity>
-                            <div className="entity-section__title grapher_body-3-regular-italic grapher_light">
-                                All {this.entityTypePlural}
-                            </div>
-                        </Flipped>
+                {shouldShowFilterBar && (
+                    <Flipped flipId="__filter-bar" translate opacity>
+                        {this.renderFilterBar()}
+                    </Flipped>
+                )}
+
+                {!shouldHideAvailableEntities && (
+                    <div
+                        className={cx("entity-section", {
+                            "hide-top-border": shouldShowFilterBar,
+                        })}
+                    >
+                        {!shouldShowFilterBar && (
+                            <Flipped flipId="__available" translate opacity>
+                                <div className="entity-section__title grapher_body-3-regular-italic grapher_light">
+                                    All {this.entityTypePlural}
+                                </div>
+                            </Flipped>
+                        )}
 
                         <ul>
-                            {sortedAvailableEntities.map(
+                            {filteredAvailableEntities.map(
                                 (entity, entityIndex) => (
                                     <FlippedListItem
                                         index={entityIndex}

--- a/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
+++ b/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
@@ -22,7 +22,7 @@ import {
     max,
     checkIsOwidIncomeGroupName,
     groupBy,
-    Aggregate,
+    aggregateSources,
     AggregateSource,
     getRegionByName,
 } from "@ourworldindata/utils"
@@ -978,24 +978,16 @@ export class EntitySelector extends React.Component<{
             )
         }
 
-        // add groups for institution-defined regions
-        if (regionsGroupedByType.aggregate) {
-            const aggregates = regionsGroupedByType.aggregate as Aggregate[]
-            const aggregatesGroupedBySource = groupBy(
-                aggregates,
-                (region) => region.definedBy
+        for (const source of aggregateSources) {
+            // The regions file includes a definedBy field for aggregates,
+            // which could be used here. However, non-OWID regions aren't
+            // standardized, meaning we might miss some entities.
+            // Instead, we rely on the convention that non-OWID regions
+            // are suffixed with (source) and check the entity name.
+            const entityNames = availableEntityNames.filter((entityName) =>
+                entityName.toLowerCase().trim().endsWith(`(${source})`)
             )
-
-            for (const [source, members] of Object.entries(
-                aggregatesGroupedBySource
-            )) {
-                if (source) {
-                    entitiesByType.set(
-                        source as AggregateSource,
-                        members.map((region) => region.name)
-                    )
-                }
-            }
+            if (entityNames.length > 0) entitiesByType.set(source, entityNames)
         }
 
         return entitiesByType

--- a/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
+++ b/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
@@ -121,6 +121,7 @@ export interface EntitySelectorManager {
     onSelectEntity?: (entityName: EntityName) => void
     onDeselectEntity?: (entityName: EntityName) => void
     onClearEntities?: () => void
+    yColumnSlugs?: ColumnSlug[]
 }
 
 interface SortConfig {
@@ -297,14 +298,20 @@ export class EntitySelector extends React.Component<{
     }
 
     getDefaultSortConfig(): SortConfig {
+        const { isOnMapTab } = this.manager
+
         // default to sorting by the first chart column on the map tab
-        if (this.manager.isOnMapTab && this.numericalChartColumns[0]) {
+        // or if there's only one y-axis dimension
+        const hasSingleYDimension = this.yColumnSlugs.length === 1
+        const shouldSortByValue = isOnMapTab || hasSingleYDimension
+
+        if (shouldSortByValue && this.numericalChartColumns[0]) {
             const { slug } = this.numericalChartColumns[0]
             this.setInterpolatedSortColumnBySlug(slug)
             return { slug, order: SortOrder.desc }
-        } else {
-            return this.sortConfigName
         }
+
+        return this.sortConfigName
     }
 
     @action.bound initSortConfig(): void {
@@ -448,6 +455,10 @@ export class EntitySelector extends React.Component<{
 
     @computed private get endTime(): Time {
         return this.manager.endTime ?? this.table.maxTime!
+    }
+
+    @computed private get yColumnSlugs(): ColumnSlug[] {
+        return this.manager.yColumnSlugs ?? []
     }
 
     @computed private get title(): string {

--- a/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
+++ b/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
@@ -1306,7 +1306,7 @@ export class EntitySelector extends React.Component<{
         // when all entities are currently selected and there are only a few of them
         const hasFewEntities = filteredAvailableEntities.length < 10
         const shouldHideAvailableEntities =
-            hasFewEntities && this.allEntitiesSelected
+            !shouldShowFilterBar && hasFewEntities && this.allEntitiesSelected
 
         return (
             <Flipper

--- a/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
+++ b/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
@@ -494,7 +494,7 @@ export class EntitySelector extends React.Component<{
     @computed private get entityFilter(): EntityRegionType {
         return (
             this.manager.entitySelectorState.entityFilter ??
-            this.filterOptions[0].value ??
+            this.filterOptions[0]?.value ??
             "all"
         )
     }

--- a/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
+++ b/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
@@ -35,6 +35,8 @@ import {
     faCircleXmark,
     faMagnifyingGlass,
     faLocationArrow,
+    faArrowRightArrowLeft,
+    faFilter,
 } from "@fortawesome/free-solid-svg-icons"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
 import { SelectionArray } from "../selection/SelectionArray"
@@ -1070,6 +1072,7 @@ export class EntitySelector extends React.Component<{
                     id="entity-selector__filter-dropdown-label"
                     className="label grapher_label-2-regular grapher_light"
                 >
+                    <FontAwesomeIcon icon={faFilter} size="sm" />
                     Filter by type
                 </span>
                 <Dropdown<FilterDropdownOption>
@@ -1134,6 +1137,7 @@ export class EntitySelector extends React.Component<{
                     id="entity-selector__sort-dropdown-label"
                     className="label grapher_label-2-regular grapher_light"
                 >
+                    <FontAwesomeIcon icon={faArrowRightArrowLeft} size="sm" />
                     Sort by
                 </div>
                 <div className="entity-selector__sort-dropdown-and-button">

--- a/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
+++ b/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
@@ -1065,6 +1065,13 @@ export class EntitySelector extends React.Component<{
         )
     }
 
+    @computed private get shouldShowFilterBar(): boolean {
+        return (
+            this.filterOptions.length > 1 &&
+            this.filterOptions[0].count !== this.filterOptions[1].count
+        )
+    }
+
     private renderFilterBar(): React.ReactElement {
         return (
             <div className="entity-selector__filter-bar">
@@ -1204,23 +1211,26 @@ export class EntitySelector extends React.Component<{
     }
 
     private renderAllEntitiesInSingleMode(): React.ReactElement {
-        const { sortedAvailableEntities } = this
+        const { filteredAvailableEntities, shouldShowFilterBar } = this
 
         return (
-            <ul>
-                {sortedAvailableEntities.map((entity) => (
-                    <li key={entity.name}>
-                        <SelectableEntity
-                            name={entity.name}
-                            type="radio"
-                            checked={this.isEntitySelected(entity)}
-                            bar={this.getBarConfigForEntity(entity)}
-                            onChange={this.onChange}
-                            isLocal={entity.isLocal}
-                        />
-                    </li>
-                ))}
-            </ul>
+            <>
+                {shouldShowFilterBar && this.renderFilterBar()}
+                <ul className={cx({ "hide-top-border": shouldShowFilterBar })}>
+                    {filteredAvailableEntities.map((entity) => (
+                        <li key={entity.name}>
+                            <SelectableEntity
+                                name={entity.name}
+                                type="radio"
+                                checked={this.isEntitySelected(entity)}
+                                bar={this.getBarConfigForEntity(entity)}
+                                onChange={this.onChange}
+                                isLocal={entity.isLocal}
+                            />
+                        </li>
+                    ))}
+                </ul>
+            </>
         )
     }
 
@@ -1272,7 +1282,11 @@ export class EntitySelector extends React.Component<{
     }
 
     private renderAllEntitiesInMultiMode(): React.ReactElement {
-        const { filteredAvailableEntities, selectedEntities } = this
+        const {
+            filteredAvailableEntities,
+            selectedEntities,
+            shouldShowFilterBar,
+        } = this
         const { numSelectedEntities, selectedEntityNames } = this.selectionArray
 
         // having a "Selection" and "Available entities" section both looks odd
@@ -1280,10 +1294,6 @@ export class EntitySelector extends React.Component<{
         const hasFewEntities = filteredAvailableEntities.length < 10
         const shouldHideAvailableEntities =
             hasFewEntities && this.allEntitiesSelected
-
-        const shouldShowFilterBar =
-            this.filterOptions.length > 1 &&
-            this.filterOptions[0].count !== this.filterOptions[1].count
 
         return (
             <Flipper

--- a/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
+++ b/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
@@ -818,10 +818,6 @@ export class EntitySelector extends React.Component<{
         return [...sortedEntitiesWithValues, ...sortedEntitiesWithoutValues]
     }
 
-    @computed private get sortedAvailableEntities(): SearchableEntity[] {
-        return this.sortEntities(this.availableEntities)
-    }
-
     @computed get isMultiMode(): boolean {
         return !this.manager.canChangeEntity
     }
@@ -978,10 +974,7 @@ export class EntitySelector extends React.Component<{
         }
     }
 
-    @computed private get entitiesByRegionType(): Map<
-        EntityRegionType,
-        EntityName[]
-    > {
+    @computed get entitiesByRegionType(): Map<EntityRegionType, EntityName[]> {
         // the 'World' entity shouldn't show up in any of the groups
         const availableEntityNames = this.availableEntityNames.filter(
             (entityName) => !isWorldEntityName(entityName)
@@ -1041,7 +1034,7 @@ export class EntitySelector extends React.Component<{
         return entitiesByType
     }
 
-    @computed private get filterOptions(): FilterDropdownOption[] {
+    @computed get filterOptions(): FilterDropdownOption[] {
         const options = Array.from(this.entitiesByRegionType.entries()).map(
             ([key, entities]) => ({
                 value: key,
@@ -1076,7 +1069,7 @@ export class EntitySelector extends React.Component<{
         )
     }
 
-    @computed private get shouldShowFilterBar(): boolean {
+    @computed get shouldShowFilterBar(): boolean {
         return (
             this.filterOptions.length > 1 &&
             this.filterOptions[0].count !== this.filterOptions[1].count

--- a/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
+++ b/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
@@ -1121,7 +1121,6 @@ export class EntitySelector extends React.Component<{
                     <input
                         ref={this.searchField}
                         type="search"
-                        placeholder={`Search for ${a(this.entityType)}`}
                         value={this.searchInput}
                         onChange={action((e): void => {
                             this.set({
@@ -1130,6 +1129,16 @@ export class EntitySelector extends React.Component<{
                         })}
                         onKeyDown={this.onSearchKeyDown}
                     />
+                    {/* We don't use the input's built-in placeholder because
+                        we want the input text and placeholder text to have different
+                        font sizes. This is not well-supported across browsers.
+                        The input text needs to be 16px to prevent auto-zoom on iOS,
+                        but the placeholder text should have a smaller font size. */}
+                    {!this.searchInput && (
+                        <span className="search-placeholder">
+                            Search for {a(this.entityType)}
+                        </span>
+                    )}
                     <FontAwesomeIcon
                         className="search-icon"
                         icon={faMagnifyingGlass}

--- a/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
+++ b/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
@@ -68,12 +68,29 @@ import { MapConfig } from "../mapCharts/MapConfig"
 
 type CoreColumnBySlug = Record<ColumnSlug, CoreColumn>
 
+const customAggregateSources = [
+    "un",
+    "fao",
+    "ei",
+    "pip",
+    "ember",
+    "gcp",
+    "niaid",
+    "unicef",
+    "unaids",
+    "undp",
+    "wid",
+    "oecd",
+] as const
+type CustomAggregateSource = (typeof customAggregateSources)[number]
+
 type EntityRegionType =
     | "all"
     | "countries"
     | "continents" // owid continents
     | "incomeGroups"
-    | AggregateSource // e.g. who or wb
+    | AggregateSource // defined in the regions file, e.g. who or wb
+    | CustomAggregateSource // hard-coded for now, see above
 
 export interface EntitySelectorState {
     searchInput: string
@@ -132,6 +149,18 @@ const entityFilterLabels: Record<EntityRegionType, string> = {
     who: "World Health Organization regions",
     wb: "World Bank regions",
     unsd: "UN Statistics Division regions",
+    un: "United Nations regions",
+    fao: "FAO regions", // UN's Food and Agriculture Organization
+    ei: "Education International regions",
+    pip: "PIP regions", // World Bank’s Poverty and Inequality Platform
+    ember: "Ember regions",
+    gcp: "Global Carbon Project regions",
+    niaid: "NIAID regions", // National Institute of Allergy and Infectious Diseases
+    unicef: "UNICEF regions",
+    unaids: "UNAIDS regions", // Joint United Nations Programme on HIV and AIDS
+    undp: "UN Development Programme regions",
+    wid: "World Inequality Database regions",
+    oecd: "OECD regions", // Organisation for Economic Co-operation and Development
 }
 
 interface FilterDropdownOption {
@@ -978,7 +1007,7 @@ export class EntitySelector extends React.Component<{
             )
         }
 
-        for (const source of aggregateSources) {
+        for (const source of [...aggregateSources, ...customAggregateSources]) {
             // The regions file includes a definedBy field for aggregates,
             // which could be used here. However, non-OWID regions aren't
             // standardized, meaning we might miss some entities.

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -252,11 +252,13 @@ export {
     type Continent,
     getAggregates,
     type Aggregate,
+    type AggregateSource,
     getOthers,
     countriesByName,
     incomeGroupsByName,
     getRegionAlternativeNames,
     mappableCountries,
+    getRegionByName,
 } from "./regions.js"
 
 export { getStylesForTargetHeight } from "./react-select.js"

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -253,6 +253,7 @@ export {
     getAggregates,
     type Aggregate,
     type AggregateSource,
+    aggregateSources,
     getOthers,
     countriesByName,
     incomeGroupsByName,

--- a/packages/@ourworldindata/utils/src/regions.json
+++ b/packages/@ourworldindata/utils/src/regions.json
@@ -2792,6 +2792,7 @@
         "name": "Australia and New Zealand (UNSD)",
         "slug": "australia-and-new-zealand-unsd",
         "regionType": "aggregate",
+        "definedBy": "unsd",
         "translationCodes": ["053"],
         "members": ["AUS", "CCK", "CXR", "HMD", "NFK", "NZL"]
     },
@@ -2800,6 +2801,7 @@
         "name": "Central America (UNSD)",
         "slug": "central-america-unsd",
         "regionType": "aggregate",
+        "definedBy": "unsd",
         "translationCodes": ["013"],
         "members": ["BLZ", "CRI", "GTM", "HND", "MEX", "NIC", "PAN", "SLV"]
     },
@@ -2808,6 +2810,7 @@
         "name": "Caribbean (UNSD)",
         "slug": "caribbean-unsd",
         "regionType": "aggregate",
+        "definedBy": "unsd",
         "translationCodes": ["029"],
         "members": [
             "ABW",
@@ -2845,6 +2848,7 @@
         "name": "Central Asia (UNSD)",
         "slug": "central-asia-unsd",
         "regionType": "aggregate",
+        "definedBy": "unsd",
         "translationCodes": ["143"],
         "members": ["KAZ", "KGZ", "TJK", "TKM", "UZB"]
     },
@@ -2853,6 +2857,7 @@
         "name": "Eastern Africa (UNSD)",
         "slug": "eastern-africa-unsd",
         "regionType": "aggregate",
+        "definedBy": "unsd",
         "translationCodes": ["014"],
         "members": [
             "ATF",
@@ -2884,6 +2889,7 @@
         "name": "Eastern Asia (UNSD)",
         "slug": "eastern-asia-unsd",
         "regionType": "aggregate",
+        "definedBy": "unsd",
         "translationCodes": ["030"],
         "members": ["CHN", "HKG", "JPN", "KOR", "MAC", "MNG", "PRK"]
     },
@@ -2892,6 +2898,7 @@
         "name": "Eastern Europe (UNSD)",
         "slug": "eastern-europe-unsd",
         "regionType": "aggregate",
+        "definedBy": "unsd",
         "translationCodes": ["151"],
         "members": [
             "BGR",
@@ -2911,6 +2918,7 @@
         "name": "Middle Africa (UNSD)",
         "slug": "middle-africa-unsd",
         "regionType": "aggregate",
+        "definedBy": "unsd",
         "translationCodes": ["017"],
         "members": [
             "AGO",
@@ -2929,6 +2937,7 @@
         "name": "Melanesia (UNSD)",
         "slug": "melanesia-unsd",
         "regionType": "aggregate",
+        "definedBy": "unsd",
         "translationCodes": ["054"],
         "members": ["FJI", "NCL", "PNG", "SLB", "VUT"]
     },
@@ -2937,6 +2946,7 @@
         "name": "Micronesia (UNSD)",
         "slug": "micronesia-unsd",
         "regionType": "aggregate",
+        "definedBy": "unsd",
         "translationCodes": ["057"],
         "members": ["FSM", "GUM", "KIR", "MHL", "MNP", "NRU", "PLW", "UMI"]
     },
@@ -2945,6 +2955,7 @@
         "name": "Northern Africa (UNSD)",
         "slug": "northern-africa-unsd",
         "regionType": "aggregate",
+        "definedBy": "unsd",
         "translationCodes": ["015"],
         "members": ["DZA", "EGY", "ESH", "LBY", "MAR", "SDN", "TUN"]
     },
@@ -2953,6 +2964,7 @@
         "name": "Northern America (UNSD)",
         "slug": "northern-america-unsd",
         "regionType": "aggregate",
+        "definedBy": "unsd",
         "translationCodes": ["003"],
         "members": ["BMU", "CAN", "GRL", "SPM", "USA"]
     },
@@ -2961,6 +2973,7 @@
         "name": "Northern Europe (UNSD)",
         "slug": "northern-europe-unsd",
         "regionType": "aggregate",
+        "definedBy": "unsd",
         "translationCodes": ["154"],
         "members": [
             "ALA",
@@ -2986,6 +2999,7 @@
         "name": "Polynesia (UNSD)",
         "slug": "polynesia-unsd",
         "regionType": "aggregate",
+        "definedBy": "unsd",
         "translationCodes": ["061"],
         "members": [
             "ASM",
@@ -3005,6 +3019,7 @@
         "name": "Southern Africa (UNSD)",
         "slug": "southern-africa-unsd",
         "regionType": "aggregate",
+        "definedBy": "unsd",
         "translationCodes": ["018"],
         "members": ["BWA", "LSO", "NAM", "SWZ", "ZAF"]
     },
@@ -3013,6 +3028,7 @@
         "name": "South America (UNSD)",
         "slug": "south-america-unsd",
         "regionType": "aggregate",
+        "definedBy": "unsd",
         "translationCodes": ["005"],
         "members": [
             "ARG",
@@ -3038,6 +3054,7 @@
         "name": "Southern Asia (UNSD)",
         "slug": "southern-asia-unsd",
         "regionType": "aggregate",
+        "definedBy": "unsd",
         "translationCodes": ["034"],
         "members": [
             "AFG",
@@ -3056,6 +3073,7 @@
         "name": "South-eastern Asia (UNSD)",
         "slug": "south-eastern-asia-unsd",
         "regionType": "aggregate",
+        "definedBy": "unsd",
         "translationCodes": ["035"],
         "members": [
             "BRN",
@@ -3076,6 +3094,7 @@
         "name": "Southern Europe (UNSD)",
         "slug": "southern-europe-unsd",
         "regionType": "aggregate",
+        "definedBy": "unsd",
         "translationCodes": ["039"],
         "members": [
             "ALB",
@@ -3101,6 +3120,7 @@
         "name": "Western Africa (UNSD)",
         "slug": "western-africa-unsd",
         "regionType": "aggregate",
+        "definedBy": "unsd",
         "translationCodes": ["011"],
         "members": [
             "BEN",
@@ -3127,6 +3147,7 @@
         "name": "Western Asia (UNSD)",
         "slug": "western-asia-unsd",
         "regionType": "aggregate",
+        "definedBy": "unsd",
         "translationCodes": ["145"],
         "members": [
             "ARE",
@@ -3153,6 +3174,7 @@
         "name": "Western Europe (UNSD)",
         "slug": "western-europe-unsd",
         "regionType": "aggregate",
+        "definedBy": "unsd",
         "translationCodes": ["155"],
         "members": [
             "AUT",
@@ -3249,6 +3271,7 @@
         "name": "East Asia and Pacific (WB)",
         "slug": "east-asia-and-pacific-wb",
         "regionType": "aggregate",
+        "definedBy": "wb",
         "translationCodes": ["030", "009"],
         "members": [
             "ASM",
@@ -3308,6 +3331,7 @@
         "name": "Europe and Central Asia (WB)",
         "slug": "europe-and-central-asia-wb",
         "regionType": "aggregate",
+        "definedBy": "wb",
         "translationCodes": ["143", "150"],
         "members": [
             "AIA",
@@ -3407,6 +3431,7 @@
         "name": "Latin America and Caribbean (WB)",
         "slug": "latin-america-and-caribbean-wb",
         "regionType": "aggregate",
+        "definedBy": "wb",
         "translationCodes": ["419", "029"],
         "members": [
             "ABW",
@@ -3462,6 +3487,7 @@
         "name": "Middle East and North Africa (WB)",
         "slug": "middle-east-and-north-africa-wb",
         "regionType": "aggregate",
+        "definedBy": "wb",
         "translationCodes": ["145", "015"],
         "members": [
             "ARE",
@@ -3495,6 +3521,7 @@
         "name": "North America (WB)",
         "slug": "north-america-wb",
         "regionType": "aggregate",
+        "definedBy": "wb",
         "translationCodes": ["003"],
         "members": ["BMU", "CAN", "SPM", "USA"]
     },
@@ -3503,6 +3530,7 @@
         "name": "South Asia (WB)",
         "slug": "south-asia-wb",
         "regionType": "aggregate",
+        "definedBy": "wb",
         "translationCodes": ["034"],
         "members": [
             "AFG",
@@ -3522,6 +3550,7 @@
         "name": "Sub-Saharan Africa (WB)",
         "slug": "sub-saharan-africa-wb",
         "regionType": "aggregate",
+        "definedBy": "wb",
         "translationCodes": ["202"],
         "members": [
             "AGO",
@@ -3581,6 +3610,7 @@
         "name": "Africa (WHO)",
         "slug": "africa-who",
         "regionType": "aggregate",
+        "definedBy": "who",
         "translationCodes": ["002"],
         "members": [
             "AGO",
@@ -3637,6 +3667,7 @@
         "name": "Americas (WHO)",
         "slug": "americas-who",
         "regionType": "aggregate",
+        "definedBy": "who",
         "translationCodes": ["019"],
         "members": [
             "AIA",
@@ -3685,6 +3716,7 @@
         "name": "Eastern Mediterranean (WHO)",
         "slug": "eastern-mediterranean-who",
         "regionType": "aggregate",
+        "definedBy": "who",
         "translationCodes": ["145"],
         "members": [
             "AFG",
@@ -3715,6 +3747,7 @@
         "name": "Europe (WHO)",
         "slug": "europe-who",
         "regionType": "aggregate",
+        "definedBy": "who",
         "translationCodes": ["150"],
         "members": [
             "ALB",
@@ -3777,6 +3810,7 @@
         "name": "South-East Asia (WHO)",
         "slug": "south-east-asia-who",
         "regionType": "aggregate",
+        "definedBy": "who",
         "translationCodes": ["035"],
         "members": [
             "BGD",
@@ -3797,6 +3831,7 @@
         "name": "Western Pacific (WHO)",
         "slug": "western-pacific-who",
         "regionType": "aggregate",
+        "definedBy": "who",
         "translationCodes": ["030", "035", "009"],
         "members": [
             "ASM",

--- a/packages/@ourworldindata/utils/src/regions.ts
+++ b/packages/@ourworldindata/utils/src/regions.ts
@@ -28,6 +28,7 @@ export interface Country extends BaseRegion {
 
 export interface Aggregate extends BaseRegion {
     regionType: RegionType.Aggregate
+    definedBy?: string
     translationCodes?: string[]
     members: string[]
 }

--- a/packages/@ourworldindata/utils/src/regions.ts
+++ b/packages/@ourworldindata/utils/src/regions.ts
@@ -64,7 +64,8 @@ export type OwidIncomeGroupName =
     | "OWID_UMC"
     | "OWID_HIC"
 
-export type AggregateSource = "who" | "unsd" | "wb"
+export const aggregateSources = ["who", "unsd", "wb"] as const
+export type AggregateSource = (typeof aggregateSources)[number]
 
 export function checkIsOwidIncomeGroupName(
     name: string

--- a/packages/@ourworldindata/utils/src/regions.ts
+++ b/packages/@ourworldindata/utils/src/regions.ts
@@ -9,58 +9,59 @@ export enum RegionType {
     IncomeGroup = "income_group",
 }
 
-export interface Country {
-    code: string
-    shortCode?: string
+export interface BaseRegion {
+    regionType: RegionType
     name: string
-    shortName?: string
+    code: string
     slug: string
-    regionType: "country" | "other"
+}
+
+export interface Country extends BaseRegion {
+    regionType: RegionType.Country | RegionType.Other
+    shortCode?: string
+    shortName?: string
     isMappable?: boolean
     isHistorical?: boolean
     isUnlisted?: boolean
     variantNames?: string[]
 }
 
-export interface Aggregate {
-    name: string
-    regionType: "aggregate"
-    code: string
+export interface Aggregate extends BaseRegion {
+    regionType: RegionType.Aggregate
     translationCodes?: string[]
     members: string[]
 }
 
-export interface Continent {
-    name:
-        | "Africa"
-        | "Asia"
-        | "Europe"
-        | "North America"
-        | "Oceania"
-        | "South America"
-    regionType: "continent"
-    code: string
+export interface Continent extends BaseRegion {
+    name: OwidContinentName
+    regionType: RegionType.Continent
     translationCodes?: string[]
     members: string[]
 }
 
-export type IncomeGroup = {
-    code: OwidIncomeGroupName
-    name: string
-    slug: string
+interface IncomeGroup extends BaseRegion {
+    name: OwidIncomeGroupName
     regionType: RegionType.IncomeGroup
     members: string[]
 }
+
+export type Region = Country | Aggregate | Continent | IncomeGroup
+
+export const regions: Region[] = entities as Region[]
+
+type OwidContinentName =
+    | "Africa"
+    | "Asia"
+    | "Europe"
+    | "North America"
+    | "Oceania"
+    | "South America"
 
 export type OwidIncomeGroupName =
     | "OWID_LIC"
     | "OWID_LMC"
     | "OWID_UMC"
     | "OWID_HIC"
-
-export type Region = Country | Aggregate | Continent | IncomeGroup
-
-export const regions: Region[] = entities as Region[]
 
 export function checkIsOwidIncomeGroupName(
     name: string
@@ -75,7 +76,7 @@ export function checkIsOwidIncomeGroupName(
 
 export const countries: Country[] = regions.filter(
     (entity) =>
-        entity.regionType === "country" &&
+        entity.regionType === RegionType.Country &&
         !entity.isUnlisted &&
         !entity.isHistorical
 ) as Country[]
@@ -87,20 +88,22 @@ export const mappableCountries: Country[] = regions.filter(
 
 export const getOthers = lazy(
     () =>
-        entities.filter((entity) => entity.regionType === "other") as Country[]
+        entities.filter(
+            (entity) => entity.regionType === RegionType.Other
+        ) as Country[]
 )
 
 export const getAggregates = lazy(
     () =>
         entities.filter(
-            (entity) => entity.regionType === "aggregate"
+            (entity) => entity.regionType === RegionType.Aggregate
         ) as Aggregate[]
 )
 
 export const getContinents = lazy(
     () =>
         entities.filter(
-            (entity) => entity.regionType === "continent"
+            (entity) => entity.regionType === RegionType.Continent
         ) as Continent[]
 )
 
@@ -140,7 +143,7 @@ const regionsByNameOrVariantNameLowercase = lazy(
 
 const currentAndHistoricalCountryNames = lazy(() =>
     regions
-        .filter(({ regionType }) => regionType === "country")
+        .filter(({ regionType }) => regionType === RegionType.Country)
         .map(({ name }) => name.toLowerCase())
 )
 

--- a/packages/@ourworldindata/utils/src/regions.ts
+++ b/packages/@ourworldindata/utils/src/regions.ts
@@ -28,7 +28,7 @@ export interface Country extends BaseRegion {
 
 export interface Aggregate extends BaseRegion {
     regionType: RegionType.Aggregate
-    definedBy?: string
+    definedBy?: AggregateSource
     translationCodes?: string[]
     members: string[]
 }
@@ -63,6 +63,8 @@ export type OwidIncomeGroupName =
     | "OWID_LMC"
     | "OWID_UMC"
     | "OWID_HIC"
+
+export type AggregateSource = "who" | "unsd" | "wb"
 
 export function checkIsOwidIncomeGroupName(
     name: string
@@ -106,6 +108,10 @@ export const getContinents = lazy(
         entities.filter(
             (entity) => entity.regionType === RegionType.Continent
         ) as Continent[]
+)
+
+const regionsByName = lazy(() =>
+    Object.fromEntries(regions.map((region) => [region.name, region]))
 )
 
 export const countriesByName = lazy(() =>
@@ -156,6 +162,9 @@ export const getCountryByName = (name: string): Country | undefined =>
 
 export const getCountryBySlug = (slug: string): Country | undefined =>
     countriesBySlug()[slug]
+
+export const getRegionByName = (name: string): Region | undefined =>
+    regionsByName()[name]
 
 export const getRegionByNameOrVariantName = (
     nameOrVariantName: string


### PR DESCRIPTION
Resolves #3599 

Adds a 'Filter by type' dropdown to the entity selector.

### Notes

- I initially thought I'd use the newly imported `definedBy` field of the regions file, but it turns out that non-owid regions aren't really standardised which is why I resorted to string matching '... (SOURCE)' instead
- In addition to `WB`, `UNSD` and `WHO` defined in the regions file, I also added support for more sources; those are hard-coded

<!-- GitButler Footer Boundary Top -->
---
This is **part 4 of 16 in a stack** made with GitButler:
- <kbd>&nbsp;16&nbsp;</kbd> #4914 
- <kbd>&nbsp;15&nbsp;</kbd> #4911 
- <kbd>&nbsp;14&nbsp;</kbd> #4907 
- <kbd>&nbsp;13&nbsp;</kbd> #4883 
- <kbd>&nbsp;12&nbsp;</kbd> #4877 
- <kbd>&nbsp;11&nbsp;</kbd> #4876 
- <kbd>&nbsp;10&nbsp;</kbd> #4875 
- <kbd>&nbsp;9&nbsp;</kbd> #4864 
- <kbd>&nbsp;8&nbsp;</kbd> #4809 
- <kbd>&nbsp;7&nbsp;</kbd> #4808 
- <kbd>&nbsp;6&nbsp;</kbd> #4770 
- <kbd>&nbsp;5&nbsp;</kbd> #4745 
- <kbd>&nbsp;4&nbsp;</kbd> #4744 👈 
- <kbd>&nbsp;3&nbsp;</kbd> #4743 
- <kbd>&nbsp;2&nbsp;</kbd> #4719 
- <kbd>&nbsp;1&nbsp;</kbd> #4708 
<!-- GitButler Footer Boundary Bottom -->


<!-- GitButler Review Footer Boundary Top -->
---
⧓ Review in [Butler Review `#1EhYge0Eu`](https://gitbutler.com/sophiamersmann/owid-grapher/reviews/1EhYge0Eu)

**entity-selector-filter-dropdown**


13 commit series (version 5)

| Series | Commit Title | Status | Reviewers | 
| --- | --- | --- | --- |
| 13/13 | [🔨 default to 'all' if no filter options are available](https://gitbutler.com/sophiamersmann/owid-grapher/reviews/1EhYge0Eu/commit/a05949fd-e626-4da2-8e82-4c2ac4301982) | ⏳ |  |
| 12/13 | [🐛 show available entities if filtering is active](https://gitbutler.com/sophiamersmann/owid-grapher/reviews/1EhYge0Eu/commit/d583f00b-7be5-46a9-8ada-cad108312670) | ⏳ |  |
| 11/13 | [🐛 add tests](https://gitbutler.com/sophiamersmann/owid-grapher/reviews/1EhYge0Eu/commit/131cc187-eed4-4acf-af93-2221cf785410) | ⏳ |  |
| 10/13 | [🐛 prevent auto-zoom on ios](https://gitbutler.com/sophiamersmann/owid-grapher/reviews/1EhYge0Eu/commit/98962912-92ab-47b3-8ec0-e27507b9566e) | ⏳ |  |
| 9/13 | [✨ default to sorting by value for single y-indicator charts](https://gitbutler.com/sophiamersmann/owid-grapher/reviews/1EhYge0Eu/commit/67bec362-e6c9-43d5-8a8a-bbfed0871cd5) | ⏳ |  |
| 8/13 | [🎉 add the entity type dropdown in single-entity selection mode](https://gitbutler.com/sophiamersmann/owid-grapher/reviews/1EhYge0Eu/commit/b6f887a2-0c14-40ba-966d-71f87e0e0b11) | ⏳ |  |
| 7/13 | [✨ add icons to dropdowns](https://gitbutler.com/sophiamersmann/owid-grapher/reviews/1EhYge0Eu/commit/e7e5926d-9efd-4dbd-9ddb-d1372fd89b11) | ⏳ |  |
| 6/13 | [🐛 validate the entity filter on tab change](https://gitbutler.com/sophiamersmann/owid-grapher/reviews/1EhYge0Eu/commit/82335e92-057a-4dee-93f0-28b295f13084) | ⏳ |  |
| 5/13 | [✨ detect more region definitions](https://gitbutler.com/sophiamersmann/owid-grapher/reviews/1EhYge0Eu/commit/ef932dd6-f9be-40dc-a686-19f09fd06a97) | ⏳ |  |
| 4/13 | [✨ make sure all non-owid regions are found](https://gitbutler.com/sophiamersmann/owid-grapher/reviews/1EhYge0Eu/commit/688008e9-fa0a-40f8-8d32-2c522f2d760e) | ⏳ |  |
| 3/13 | [🎉 add an entity type dropdown to the entity selector](https://gitbutler.com/sophiamersmann/owid-grapher/reviews/1EhYge0Eu/commit/804d75a4-be8a-41bb-8e12-ea3c62504b4d) | ⏳ |  |
| 2/13 | [🔨 add defined_by to the regions file](https://gitbutler.com/sophiamersmann/owid-grapher/reviews/1EhYge0Eu/commit/82218bc2-03c3-42d1-91dd-1bbf70bbcd02) | ⏳ |  |
| 1/13 | [🔨 add income_group to region types](https://gitbutler.com/sophiamersmann/owid-grapher/reviews/1EhYge0Eu/commit/2a2dda78-1a41-4a0d-9eca-10ac87e7a3a5) | ⏳ |  |

_Please leave review feedback in the [Butler Review](https://gitbutler.com/sophiamersmann/owid-grapher/reviews/1EhYge0Eu)_
<!-- GitButler Review Footer Boundary Bottom -->
