### PR TITLE
Fix copy for data insights

### DIFF
--- a/baker/siteRenderers.tsx
+++ b/baker/siteRenderers.tsx
@@ -391,7 +391,7 @@ export async function makeAtomFeedFromDataInsights({
 }) {
     return `<?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
-<title>Our World in Data - Daily Data Insights</title>
+<title>Our World in Data - Data Insights</title>
 <subtitle>Bite-sized insights on how the world is changing, written by our team</subtitle>
 <id>${htmlUrl}/</id>
 <link type="text/html" rel="alternate" href="${htmlUrl}"/>

--- a/site/DataInsightsIndexPage.tsx
+++ b/site/DataInsightsIndexPage.tsx
@@ -28,9 +28,9 @@ export const DataInsightsIndexPage = (props: DataInsightsIndexPageProps) => {
         <Html>
             <Head
                 canonicalUrl={`${baseUrl}/data-insights`}
-                pageTitle="Daily Data Insights"
+                pageTitle="Data Insights"
                 baseUrl={baseUrl}
-                pageDesc="Bite-sized insights on how the world is changing, published every weekday"
+                pageDesc="Bite-sized insights on how the world is changing, published every few days"
                 imageUrl={`${baseUrl}/data-insights-thumbnail.png`}
                 atom={DATA_INSIGHT_ATOM_FEED_PROPS}
             ></Head>

--- a/site/DataInsightsIndexPageContent.tsx
+++ b/site/DataInsightsIndexPageContent.tsx
@@ -119,11 +119,11 @@ export const DataInsightsIndexPageContent = (
             >
                 <header className="data-insights-index-page__header grid grid-cols-12-full-width span-cols-14">
                     <h2 className="span-cols-6 col-start-5 col-md-start-4 span-md-cols-10 col-sm-start-2 span-sm-cols-12 display-2-semibold ">
-                        Daily Data Insights
+                        Data Insights
                     </h2>
                     <p className="span-cols-6 col-start-5 col-md-start-4 span-md-cols-8 col-sm-start-2 span-sm-cols-12 body-1-regular">
                         Bite-sized insights on how the world is changing,
-                        published every weekday.
+                        published every few days.
                     </p>
                 </header>
                 {dataInsights.map((dataInsight, index) => {

--- a/site/NewsletterSubscription.tsx
+++ b/site/NewsletterSubscription.tsx
@@ -111,10 +111,10 @@ export const NewsletterSubscriptionForm = ({
                     onChange={updateFrequencies}
                 />
                 <label htmlFor={idDataInsights}>
-                    <div className="label-title">Daily Data Insights</div>
+                    <div className="label-title">Data Insights</div>
                     <div className="label-text">
                         Receive our bite-sized insights on how the world is
-                        changing, every weekday.
+                        changing, every few days.
                     </div>
                 </label>
             </div>

--- a/site/SiteConstants.ts
+++ b/site/SiteConstants.ts
@@ -33,7 +33,7 @@ export const TOUCH_DEVICE_MEDIA_QUERY =
 export const DATA_INSIGHTS_ATOM_FEED_NAME = "atom-data-insights.xml"
 
 export const DATA_INSIGHT_ATOM_FEED_PROPS = {
-    title: "Atom feed for Daily Data Insights",
+    title: "Atom feed for Data Insights",
     href: `https://ourworldindata.org/${DATA_INSIGHTS_ATOM_FEED_NAME}`,
 }
 
@@ -88,7 +88,7 @@ export const RSS_FEEDS = [
         icon: faRss,
     },
     {
-        title: "Daily Data Insights",
+        title: "Data Insights",
         url: `/${DATA_INSIGHTS_ATOM_FEED_NAME}`,
         icon: faRss,
     },

--- a/site/gdocs/components/DataInsightsNewsletter.tsx
+++ b/site/gdocs/components/DataInsightsNewsletter.tsx
@@ -44,8 +44,8 @@ export default function DataInsightsNewsletter({
                             Get Data Insights delivered to your inbox
                         </h3>
                         <p className="data-insights-newsletter__description body-3-medium">
-                            Receive an email from us when we publish a
-                            Data Insight (every few days).
+                            Receive an email from us when we publish a Data
+                            Insight (every few days).
                         </p>
                     </div>
                 </div>

--- a/site/gdocs/components/DataInsightsNewsletter.tsx
+++ b/site/gdocs/components/DataInsightsNewsletter.tsx
@@ -41,11 +41,11 @@ export default function DataInsightsNewsletter({
                     <Icon className="data-insights-newsletter__icon" />
                     <div className="data-insights-newsletter__left__text">
                         <h3 className="data-insights-newsletter__heading h3-bold">
-                            Get Daily Data Insights delivered to your inbox
+                            Get Data Insights delivered to your inbox
                         </h3>
                         <p className="data-insights-newsletter__description body-3-medium">
-                            Receive an email from us when we publish a Daily
-                            Data Insight (every weekday).
+                            Receive an email from us when we publish a
+                            Data Insight (every few days).
                         </p>
                     </div>
                 </div>
@@ -72,7 +72,7 @@ export default function DataInsightsNewsletter({
                         />
                         <input type="hidden" name="group[85302][16]" value="" />
                         <Button
-                            ariaLabel="Subscribe to the Daily Data Insights newsletter"
+                            ariaLabel="Subscribe to the Data Insights newsletter"
                             theme="solid-vermillion"
                             text="Subscribe"
                             type="submit"

--- a/site/gdocs/components/LatestDataInsights.tsx
+++ b/site/gdocs/components/LatestDataInsights.tsx
@@ -97,7 +97,7 @@ export default function LatestDataInsights({
                         <Button
                             className="latest-data-insights__card latest-data-insights__card__see-all body-3-medium"
                             href="/data-insights"
-                            text="See all our Daily Data Insights"
+                            text="See all our Data Insights"
                             theme="outline-vermillion"
                         />
                     )}

--- a/site/gdocs/components/LatestDataInsightsBlock.tsx
+++ b/site/gdocs/components/LatestDataInsightsBlock.tsx
@@ -18,16 +18,16 @@ export default function LatestDataInsightsBlock({
     return (
         <section className={cx(className, "latest-data-insights-block")}>
             <header className="latest-data-insights-block__header span-cols-8 col-start-2 span-sm-cols-12 col-sm-start-2">
-                <h2 className="h2-bold">Daily Data Insights</h2>
+                <h2 className="h2-bold">Data Insights</h2>
                 <p className="body-2-regular">
                     Bite-sized insights on how the world is changing, published
-                    every weekday.
+                    every few days.
                 </p>
             </header>
             <Button
                 href="/data-insights"
                 className="latest-data-insights-block__see-all-data-insights-button body-3-medium span-cols-4 col-start-10 span-sm-cols-12 col-sm-start-2"
-                text="See all Daily Data Insights"
+                text="See all Data Insights"
                 theme="outline-vermillion"
             />
             <LatestDataInsights

--- a/site/gdocs/pages/DataInsight.tsx
+++ b/site/gdocs/pages/DataInsight.tsx
@@ -31,9 +31,9 @@ export const LatestDataInsightCards = (props: {
 
     return (
         <div className={cx(className, "data-insight-cards-container")}>
-            <h2 className="h2-bold ">Our latest Daily Data Insights</h2>
+            <h2 className="h2-bold ">Our latest Data Insights</h2>
             <a href="/data-insights" className="see-all-button">
-                See all Daily Data Insights{" "}
+                See all Data Insights{" "}
                 <FontAwesomeIcon icon={faArrowRight} />
             </a>
             <LatestDataInsights
@@ -179,7 +179,7 @@ export const DataInsightPage = (
     return (
         <div className="grid grid-cols-12-full-width data-insight-page">
             <div className="span-cols-6 col-start-5 span-md-cols-8 col-md-start-4 col-sm-start-2 span-sm-cols-12 data-insight-breadcrumbs">
-                <a href="/data-insights">Daily Data Insights</a>
+                <a href="/data-insights">Data Insights</a>
                 <FontAwesomeIcon icon={faChevronRight} />
                 <span>{props.content.title}</span>
             </div>

--- a/site/gdocs/pages/DataInsight.tsx
+++ b/site/gdocs/pages/DataInsight.tsx
@@ -33,8 +33,7 @@ export const LatestDataInsightCards = (props: {
         <div className={cx(className, "data-insight-cards-container")}>
             <h2 className="h2-bold ">Our latest Data Insights</h2>
             <a href="/data-insights" className="see-all-button">
-                See all Data Insights{" "}
-                <FontAwesomeIcon icon={faArrowRight} />
+                See all Data Insights <FontAwesomeIcon icon={faArrowRight} />
             </a>
             <LatestDataInsights
                 className="data-insights-carousel"


### PR DESCRIPTION
## Context

Starting next week, we'll send our data insights three times per week. I've adapted the copy throughout the site to remove the word "daily" and replace "every weekday" with "every few days".

## Testing guidance

I _think_ I've identified all instances, but it's probably worth double-checking whether I've missed some or maybe other relevant words/sentences.