### PR TITLE
feat(archive): deploy archive script

### DIFF
--- a/baker/archival/archiveChangedGrapherPages.ts
+++ b/baker/archival/archiveChangedGrapherPages.ts
@@ -10,7 +10,7 @@ import {
     findChangedGrapherPages,
     insertChartVersions,
 } from "./archivalChecksum.js"
-import { bakeGrapherPagesToFolder } from "./ArchivalBaker.js"
+import { bakeArchivalGrapherPagesToFolder } from "./ArchivalBaker.js"
 
 interface Options {
     dir: string
@@ -36,7 +36,8 @@ const findChangedPagesAndArchive = async (opts: Options) => {
             return
         }
 
-        const { date, manifests } = await bakeGrapherPagesToFolder(
+        const { date, manifests } = await bakeArchivalGrapherPagesToFolder(
+            trx,
             opts.dir,
             needToBeArchived,
             { shouldCopyToLatestDir: opts.latestDir }

--- a/db/model/Chart.ts
+++ b/db/model/Chart.ts
@@ -168,7 +168,7 @@ export async function getRawChartsByIds(
             SELECT c.*, cc.full AS config
             FROM charts c
             JOIN chart_configs cc ON c.configId = cc.id
-            WHERE id IN (?)
+            WHERE c.id IN (?)
         `,
         [ids]
     )

--- a/ops/buildkite/deploy-archive
+++ b/ops/buildkite/deploy-archive
@@ -9,7 +9,7 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-TARGET_DIR=/home/owid/live-data/bakedSite
+TARGET_DIR=/home/owid/live-data/archive
 
 # This is important, so `build_vite` and `bake_archive` load the correct env overrides
 export PRIMARY_ENV_FILE=.env.archive

--- a/ops/buildkite/deploy-archive
+++ b/ops/buildkite/deploy-archive
@@ -1,0 +1,53 @@
+#!/bin/bash
+#
+#  deploy-archive
+#
+#  Bake archive and copy to R2.
+#
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+TARGET_DIR=live-data/archive
+
+# This is important, so `build_vite` and `bake_archive` load the correct env overrides
+export PRIMARY_ENV_FILE=.env.archive
+
+build_vite() {
+    echo "--- Building Vite archive..."
+    yarn buildViteArchive
+}
+
+bake_archive() {
+    echo "--- Baking archive..."
+    yarn buildArchive --latestDir --dir "$TARGET_DIR"
+}
+
+copy_to_r2_rclone() {
+    echo "--- Syncing ${TARGET_DIR}..."
+    rclone copy "$TARGET_DIR" r2:owid-archive --checkers=64 --transfers=64
+}
+
+deploy_archive() {
+    echo "--- Deploying archive to Cloudflare"
+
+    if [[ "$BRANCH" != "master" ]]; then
+        echo "Error: You're not on the master branch. Exiting."
+        exit 1
+    fi
+
+    build_vite
+
+    # Create a new directory for the archive
+    mkdir -p "$TARGET_DIR"
+
+    bake_archive
+
+    # Copy to R2
+    copy_to_r2_rclone
+
+    echo "--- Archive baked and deployed to R2 ✅"
+}
+
+deploy_archive

--- a/ops/buildkite/deploy-archive
+++ b/ops/buildkite/deploy-archive
@@ -9,19 +9,25 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-TARGET_DIR=live-data/archive
+TARGET_DIR=/home/owid/live-data/bakedSite
 
 # This is important, so `build_vite` and `bake_archive` load the correct env overrides
 export PRIMARY_ENV_FILE=.env.archive
 
 build_vite() {
     echo "--- Building Vite archive..."
-    yarn buildViteArchive
+    (
+        cd owid-grapher
+        yarn buildViteArchive
+    )
 }
 
 bake_archive() {
     echo "--- Baking archive..."
-    yarn buildArchive --latestDir --dir "$TARGET_DIR"
+    (
+        cd owid-grapher
+        yarn buildArchive --latestDir --dir "$TARGET_DIR"
+    )
 }
 
 copy_to_r2_rclone() {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "packageManager": "yarn@4.6.0",
     "scripts": {
         "batchTagWithGpt": "tsx --tsconfig tsconfig.tsx.json baker/batchTagWithGpt.ts",
+        "buildArchive": "tsx --tsconfig tsconfig.tsx.json baker/archival/archiveChangedGrapherPages.ts",
         "buildLocalBake": "tsx --tsconfig tsconfig.tsx.json baker/buildLocalBake.ts",
         "buildTsc": "tsc -b -verbose",
         "buildLerna": "lerna run build",


### PR DESCRIPTION
This is the code to enable future archive deploys.

You can find the content that would be going up to the R2 bucket on http://staging-site-archive-deploy:3000, e.g. over at http://staging-site-archive-deploy:3000/latest/grapher/life-expectancy.

That archive dir over there was created using the `deploy-archive` script. I haven't tested the `rclone copy` command yet, because on the staging server the token doesn't have the right permissions. We can test it properly once we set up a Buildkite step on live for this, early next week.