### PR TITLE
Add prototype for embedding multi-dim with controls

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -488,7 +488,7 @@ export class Grapher
     dataApiUrl =
         this.props.dataApiUrl ?? "https://api.ourworldindata.org/v1/indicators/"
 
-    @observable.ref externalQueryParams: QueryParams
+    @observable.ref externalQueryParams: QueryParams = {}
 
     private framePaddingHorizontal = GRAPHER_FRAME_PADDING_HORIZONTAL
     private framePaddingVertical = GRAPHER_FRAME_PADDING_VERTICAL
@@ -571,10 +571,6 @@ export class Grapher
         this.populateFromQueryParams(
             legacyToCurrentGrapherQueryParams(props.queryStr ?? "")
         )
-        this.externalQueryParams = omit(
-            Url.fromQueryStr(props.queryStr ?? "").queryParams,
-            GRAPHER_QUERY_PARAM_KEYS
-        )
 
         if (this.isEditor) {
             this.ensureValidConfigWhenEditing()
@@ -654,6 +650,8 @@ export class Grapher
     }
 
     @action.bound populateFromQueryParams(params: GrapherQueryParams): void {
+        this.externalQueryParams = omit(params, GRAPHER_QUERY_PARAM_KEYS)
+
         // Set tab if specified
         if (params.tab) {
             const tab = this.mapQueryParamToGrapherTab(params.tab)

--- a/site/gdocs/components/Chart.tsx
+++ b/site/gdocs/components/Chart.tsx
@@ -46,6 +46,7 @@ export default function Chart({
     const isMultiDim = linkedChart.configType === ChartConfigType.MultiDim
     const hasControls = url.queryParams.hideControls !== "true"
     const isExplorerWithControls = isExplorer && hasControls
+    const isMultiDimWithControls = isMultiDim && hasControls
 
     // config passed to grapher charts
     let customizedChartConfig: GrapherProgrammaticInterface = {}
@@ -100,7 +101,9 @@ export default function Chart({
         <div
             className={cx(d.position, className, {
                 "full-width-on-mobile":
-                    !isExplorerWithControls && fullWidthOnMobile,
+                    !isExplorerWithControls &&
+                    !isMultiDimWithControls &&
+                    fullWidthOnMobile,
             })}
             style={{ gridRow: d.row, gridColumn: d.column }}
             ref={refChartContainer}
@@ -108,10 +111,12 @@ export default function Chart({
             <figure
                 // Use unique `key` to force React to re-render tree
                 key={resolvedUrl}
-                className={cx(
-                    { [GRAPHER_PREVIEW_CLASS]: !isExplorer },
-                    isExplorerWithControls ? "explorer" : "chart"
-                )}
+                className={cx({
+                    [GRAPHER_PREVIEW_CLASS]: !isExplorer,
+                    chart: !isExplorerWithControls && !isMultiDimWithControls,
+                    explorer: isExplorerWithControls,
+                    "multi-dim": isMultiDimWithControls,
+                })}
                 data-is-multi-dim={isMultiDim || undefined}
                 data-grapher-src={isExplorer ? undefined : resolvedUrl}
                 data-grapher-config={

--- a/site/multiDim/MultiDim.scss
+++ b/site/multiDim/MultiDim.scss
@@ -1,0 +1,7 @@
+.multi-dim-settings {
+    margin-bottom: 16px;
+}
+
+.multi-dim-grapher-container {
+    height: $grapher-height;
+}

--- a/site/multiDim/MultiDim.tsx
+++ b/site/multiDim/MultiDim.tsx
@@ -1,0 +1,128 @@
+import { useCallback, useEffect, useRef, useState } from "react"
+import * as Sentry from "@sentry/react"
+import { Grapher, GrapherProgrammaticInterface } from "@ourworldindata/grapher"
+import {
+    extractMultiDimChoicesFromSearchParams,
+    GrapherQueryParams,
+    MultiDimDataPageConfig,
+    MultiDimDimensionChoices,
+} from "@ourworldindata/utils"
+import {
+    ADMIN_BASE_URL,
+    BAKED_GRAPHER_URL,
+    DATA_API_URL,
+} from "../../settings/clientSettings.js"
+import { useElementBounds } from "../hooks.js"
+import { cachedGetGrapherConfigByUuid } from "./api.js"
+import { MultiDimSettingsPanel } from "./MultiDimDataPageSettingsPanel.js"
+
+const baseGrapherConfig: GrapherProgrammaticInterface = {
+    bakedGrapherURL: BAKED_GRAPHER_URL,
+    adminBaseUrl: ADMIN_BASE_URL,
+    dataApiUrl: DATA_API_URL,
+    isEmbeddedInAnOwidPage: true,
+}
+
+export default function MultiDim({
+    config,
+    localGrapherConfig,
+    queryStr,
+}: {
+    config: MultiDimDataPageConfig
+    localGrapherConfig: GrapherProgrammaticInterface
+    queryStr: string
+}) {
+    const grapherRef = useRef<Grapher>(null)
+    const grapherContainerRef = useRef<HTMLDivElement>(null)
+    const bounds = useElementBounds(grapherContainerRef)
+    const [manager, setManager] = useState({
+        ...localGrapherConfig.manager,
+    })
+    const [settings, setSettings] = useState(() => {
+        const choices = extractMultiDimChoicesFromSearchParams(
+            new URLSearchParams(queryStr),
+            config
+        )
+        return config.filterToAvailableChoices(choices).selectedChoices
+    })
+
+    const handleSettingsChange = useCallback(
+        (settings: MultiDimDimensionChoices) => {
+            setSettings(
+                config.filterToAvailableChoices(settings).selectedChoices
+            )
+        },
+        [config]
+    )
+
+    useEffect(() => {
+        // Prevent a race condition from setting incorrect data.
+        // https://react.dev/learn/synchronizing-with-effects#fetching-data
+        let ignoreFetchedData = false
+
+        const grapher = grapherRef.current
+        if (!grapher) return
+
+        const newView = config.findViewByDimensions(settings)
+        if (!newView) {
+            throw new Error(
+                `No view found for dimensions: ${JSON.stringify(settings)}`
+            )
+        }
+
+        const variables = newView.indicators?.["y"]
+        const editUrl =
+            variables?.length === 1
+                ? `variables/${variables[0].id}/config`
+                : undefined
+        setManager((prev) => ({ ...prev, editUrl }))
+
+        const newGrapherParams: GrapherQueryParams = {
+            ...grapher.changedParams,
+            tab: grapher.mapGrapherTabToQueryParam(grapher.activeTab),
+            ...settings,
+        }
+
+        cachedGetGrapherConfigByUuid(newView.fullConfigId, false)
+            .then((viewGrapherConfig) => {
+                if (ignoreFetchedData) return
+                const grapherConfig = {
+                    ...viewGrapherConfig,
+                    ...localGrapherConfig,
+                    ...baseGrapherConfig,
+                }
+                grapher.setAuthoredVersion(grapherConfig)
+                grapher.reset()
+                grapher.updateFromObject(grapherConfig)
+                grapher.downloadData()
+                grapher.populateFromQueryParams(newGrapherParams)
+            })
+            .catch(Sentry.captureException)
+        return () => {
+            ignoreFetchedData = true
+        }
+    }, [config, localGrapherConfig, settings])
+
+    return (
+        <>
+            <MultiDimSettingsPanel
+                className="multi-dim-settings"
+                config={config}
+                settings={settings}
+                onChange={handleSettingsChange}
+            />
+            <div
+                className="multi-dim-grapher-container"
+                ref={grapherContainerRef}
+            >
+                <Grapher
+                    ref={grapherRef}
+                    {...baseGrapherConfig}
+                    bounds={bounds}
+                    manager={manager}
+                    queryStr={queryStr}
+                />
+            </div>
+        </>
+    )
+}

--- a/site/multiDim/MultiDimDataPageContent.scss
+++ b/site/multiDim/MultiDimDataPageContent.scss
@@ -26,8 +26,6 @@ $zindex-controls-backdrop: 130;
 $zindex-controls-popup: 140;
 
 .MultiDimDataPageContent {
-    @import "./MultiDimDataPageSettingsPanel.scss";
-
     .header {
         margin-bottom: 24px;
     }

--- a/site/multiDim/MultiDimDataPageContent.tsx
+++ b/site/multiDim/MultiDimDataPageContent.tsx
@@ -5,7 +5,6 @@ import {
     Grapher,
     GrapherAnalytics,
     GrapherProgrammaticInterface,
-    getVariableMetadataRoute,
 } from "@ourworldindata/grapher"
 import {
     DataPageDataV2,
@@ -16,13 +15,10 @@ import {
     getNextUpdateFromVariable,
     omitUndefinedValues,
     getAttributionFragmentsFromVariable,
-    OwidVariableWithSourceAndDimension,
-    memoize,
     compact,
     MultiDimDataPageConfig,
     extractMultiDimChoicesFromSearchParams,
     merge,
-    fetchWithRetry,
 } from "@ourworldindata/utils"
 import {
     ADMIN_BASE_URL,
@@ -46,6 +42,10 @@ import { MultiDimSettingsPanel } from "./MultiDimDataPageSettingsPanel.js"
 import { processRelatedResearch } from "../dataPage.js"
 import DataPageResearchAndWriting from "../DataPageResearchAndWriting.js"
 import { AttachmentsContext } from "../gdocs/AttachmentsContext.js"
+import {
+    cachedGetGrapherConfigByUuid,
+    cachedGetVariableMetadata,
+} from "./api.js"
 
 declare global {
     interface Window {
@@ -109,24 +109,6 @@ const getDatapageDataV2 = async (
         return datapageJson
     }
 }
-
-const cachedGetVariableMetadata = memoize(
-    (variableId: number): Promise<OwidVariableWithSourceAndDimension> =>
-        fetchWithRetry(getVariableMetadataRoute(DATA_API_URL, variableId)).then(
-            (resp) => resp.json()
-        )
-)
-
-const cachedGetGrapherConfigByUuid = memoize(
-    (
-        grapherConfigUuid: string,
-        isPreviewing: boolean
-    ): Promise<GrapherInterface> => {
-        return fetchWithRetry(
-            `/grapher/by-uuid/${grapherConfigUuid}.config.json${isPreviewing ? "?nocache" : ""}`
-        ).then((resp) => resp.json())
-    }
-)
 
 const useTitleFragments = (config: MultiDimDataPageConfig) => {
     const title = config.config.title

--- a/site/multiDim/MultiDimDataPageSettingsPanel.tsx
+++ b/site/multiDim/MultiDimDataPageSettingsPanel.tsx
@@ -116,13 +116,17 @@ const DimensionDropdown = (props: {
     )
 }
 
-export const MultiDimSettingsPanel = (props: {
+export const MultiDimSettingsPanel = ({
+    className,
+    config,
+    settings,
+    onChange,
+}: {
+    className?: string
     config: MultiDimDataPageConfig
     settings: MultiDimDimensionChoices
     onChange: (settings: MultiDimDimensionChoices) => void
 }) => {
-    const { config, settings, onChange } = props
-
     const { dimensions } = config
 
     // Non-partial version of `settings` with all dimensions filled in
@@ -142,7 +146,7 @@ export const MultiDimSettingsPanel = (props: {
     }, [resolvedSettings, config])
 
     return (
-        <div className="md-settings-row">
+        <div className={cx("md-settings-row", className)}>
             <div className="h5-black-caps md-settings__configure-data">
                 Configure the data
             </div>

--- a/site/multiDim/api.ts
+++ b/site/multiDim/api.ts
@@ -1,0 +1,28 @@
+import { getVariableMetadataRoute } from "@ourworldindata/grapher"
+import {
+    GrapherInterface,
+    OwidVariableWithSourceAndDimension,
+} from "@ourworldindata/types"
+import { fetchWithRetry } from "@ourworldindata/utils"
+import { DATA_API_URL } from "../../settings/clientSettings.js"
+import { memoize } from "lodash"
+
+export const cachedGetVariableMetadata = memoize(
+    async (variableId: number): Promise<OwidVariableWithSourceAndDimension> => {
+        const response = await fetchWithRetry(
+            getVariableMetadataRoute(DATA_API_URL, variableId)
+        )
+        return await response.json()
+    }
+)
+export const cachedGetGrapherConfigByUuid = memoize(
+    async (
+        grapherConfigUuid: string,
+        isPreviewing: boolean
+    ): Promise<GrapherInterface> => {
+        const response = await fetchWithRetry(
+            `/grapher/by-uuid/${grapherConfigUuid}.config.json${isPreviewing ? "?nocache" : ""}`
+        )
+        return await response.json()
+    }
+)

--- a/site/owid.scss
+++ b/site/owid.scss
@@ -115,7 +115,9 @@
 @import "./DataInsightsNewsletterBanner.scss";
 @import "./DataPage.scss";
 @import "./DataPageContent.scss";
+@import "./multiDim/MultiDim.scss";
 @import "./multiDim/MultiDimDataPageContent.scss";
+@import "./multiDim/MultiDimDataPageSettingsPanel.scss";
 @import "./GrapherImage.scss";
 @import "./KeyDataTable.scss";
 @import "./MetadataSection.scss";


### PR DESCRIPTION
## Description

We now embed a multi-dim chart with controls by default and hide the controls if the URL contains `hideControls=true` (same as for explorer).

This is a prototype to inform the design of the component. We currently don't have finalized designs to follow, so the implementation is minimal.

## Context

Resolves #4741

## Screenshots / Videos / Diagrams

<img width="1308" alt="image" src="https://github.com/user-attachments/assets/09d2d18d-acc0-4807-b379-f21d0bf8223e" />

## Testing guidance

You can try the component in various ArchieML contexts (see [my testing doc](https://docs.google.com/document/d/1XFA35qElj_sV42sEk6s3fL9QfD23ZMsV2oYIrwPb_lE/edit?tab=t.0)), but since this is a prototype, thorough QA is not necessary.