### PR TITLE
Fix misaligned action buttons

### DIFF
--- a/packages/@ourworldindata/grapher/src/controls/ActionButtons.scss
+++ b/packages/@ourworldindata/grapher/src/controls/ActionButtons.scss
@@ -10,6 +10,7 @@ $paddingX: 12px; // keep in sync with PADDING_X
     white-space: nowrap;
 
     ul {
+        display: flex;
         list-style: none;
         height: $actionButtonHeight;
         padding: 0;


### PR DESCRIPTION
This happens at least in Firefox on macOS.

| Before | After |
|--------|--------|
| <img width="312" alt="Screenshot 2025-04-11 at 13 52 39" src="https://github.com/user-attachments/assets/d30e919f-6f60-4176-bb9d-413d00fb17d0" /> | <img width="315" alt="Screenshot 2025-04-11 at 13 53 11" src="https://github.com/user-attachments/assets/ed4ecd94-45c6-4508-96d1-5e834b9845c4" /> | 