### PR TITLE
Fix detail on demand underline offset

### DIFF
--- a/packages/@ourworldindata/components/src/styles/mixins.scss
+++ b/packages/@ourworldindata/components/src/styles/mixins.scss
@@ -69,6 +69,7 @@
 @mixin dod-span {
     text-decoration: underline;
     text-decoration-style: dotted;
+    text-underline-offset: 2px;
     cursor: help;
 
     span {


### PR DESCRIPTION
Reported being too cramped by Marcel with Chrome on macOS with non-retina external display.

## Context

[Slack discussion](https://owid.slack.com/archives/C03NV9Z3YSV/p1744373674034099).

