### PR TITLE
fix(archive): skip variable cache when archiving them

### DIFF
--- a/adminSiteServer/apiRoutes/variables.ts
+++ b/adminSiteServer/apiRoutes/variables.ts
@@ -128,7 +128,7 @@ export async function getVariableDataJson(
     const variableId = parseInt(variableStr)
     if (isNaN(variableId)) throw new JsonError("Invalid variable id")
     return await fetchS3DataValuesByPath(
-        getVariableDataRoute(DATA_API_URL, variableId) + "?nocache"
+        getVariableDataRoute(DATA_API_URL, variableId, { noCache: true })
     )
 }
 
@@ -146,7 +146,7 @@ export async function getVariableMetadataJson(
     const variableId = parseInt(variableStr)
     if (isNaN(variableId)) throw new JsonError("Invalid variable id")
     return await fetchS3MetadataByPath(
-        getVariableMetadataRoute(DATA_API_URL, variableId) + "?nocache"
+        getVariableMetadataRoute(DATA_API_URL, variableId, { noCache: true })
     )
 }
 
@@ -225,7 +225,7 @@ export async function getVariablesVariableIdJson(
     const variableId = expectInt(req.params.variableId)
 
     const variable = await fetchS3MetadataByPath(
-        getVariableMetadataRoute(DATA_API_URL, variableId) + "?nocache"
+        getVariableMetadataRoute(DATA_API_URL, variableId, { noCache: true })
     )
 
     // XXX: Patch shortName onto the end of catalogPath when it's missing,

--- a/baker/archival/ArchivalBaker.ts
+++ b/baker/archival/ArchivalBaker.ts
@@ -97,7 +97,9 @@ const bakeVariableDataFiles = async (
     variableId: number,
     archiveDir: string
 ) => {
-    const { data, metadata } = await getVariableData(variableId)
+    const { data, metadata } = await getVariableData(variableId, {
+        noCache: true,
+    })
     const dataStringified = JSON.stringify(data)
     const metadataStringified = JSON.stringify(metadata)
 

--- a/db/model/Variable.ts
+++ b/db/model/Variable.ts
@@ -580,10 +580,13 @@ export async function getVariableMetadata(
 }
 
 export async function getVariableData(
-    variableId: number
+    variableId: number,
+    { noCache }: { noCache?: boolean } = {}
 ): Promise<OwidVariableDataMetadataDimensions> {
-    const dataPath = getVariableDataRoute(DATA_API_URL, variableId)
-    const metadataPath = getVariableMetadataRoute(DATA_API_URL, variableId)
+    const dataPath = getVariableDataRoute(DATA_API_URL, variableId, { noCache })
+    const metadataPath = getVariableMetadataRoute(DATA_API_URL, variableId, {
+        noCache,
+    })
 
     const [data, metadata] = await Promise.all([
         fetchS3DataValuesByPath(dataPath),

--- a/packages/@ourworldindata/grapher/src/core/loadVariable.ts
+++ b/packages/@ourworldindata/grapher/src/core/loadVariable.ts
@@ -8,15 +8,16 @@ import urljoin from "url-join"
 export const getVariableDataRoute = (
     dataApiUrl: string,
     variableId: number,
-    assetMap?: AssetMap
+    { assetMap, noCache }: { assetMap?: AssetMap; noCache?: boolean } = {}
 ): string => {
     if (dataApiUrl.includes("v1/indicators")) {
         const filename = `${variableId}.data.json`
-        return readFromAssetMap(assetMap, {
+        const url = readFromAssetMap(assetMap, {
             path: filename,
             // fetching from Data API, e.g. https://api.ourworldindata.org/v1/indicators/123.data.json
             fallback: urljoin(dataApiUrl, filename),
         })
+        return noCache ? `${url}?nocache` : url
     } else {
         throw new Error(`dataApiUrl format not supported: ${dataApiUrl}`)
     }
@@ -25,15 +26,16 @@ export const getVariableDataRoute = (
 export const getVariableMetadataRoute = (
     dataApiUrl: string,
     variableId: number,
-    assetMap?: AssetMap
+    { assetMap, noCache }: { assetMap?: AssetMap; noCache?: boolean } = {}
 ): string => {
     if (dataApiUrl.includes("v1/indicators")) {
         const filename = `${variableId}.metadata.json`
-        return readFromAssetMap(assetMap, {
+        const url = readFromAssetMap(assetMap, {
             path: filename,
             // fetching from Data API, e.g. https://api.ourworldindata.org/v1/indicators/123.metadata.json
             fallback: urljoin(dataApiUrl, filename),
         })
+        return noCache ? `${url}?nocache` : url
     } else {
         throw new Error(`dataApiUrl format not supported: ${dataApiUrl}`)
     }
@@ -45,10 +47,10 @@ export async function loadVariableDataAndMetadata(
     assetMap?: AssetMap
 ): Promise<OwidVariableDataMetadataDimensions> {
     const dataPromise = fetchWithRetry(
-        getVariableDataRoute(dataApiUrl, variableId, assetMap)
+        getVariableDataRoute(dataApiUrl, variableId, { assetMap })
     )
     const metadataPromise = fetchWithRetry(
-        getVariableMetadataRoute(dataApiUrl, variableId, assetMap)
+        getVariableMetadataRoute(dataApiUrl, variableId, { assetMap })
     )
     const [dataResponse, metadataResponse] = await Promise.all([
         dataPromise,

--- a/site/DataPageV2.tsx
+++ b/site/DataPageV2.tsx
@@ -119,16 +119,12 @@ export const DataPageV2 = (props: {
                 <link rel="preconnect" href={dataApiOrigin} />
                 {variableIds.flatMap((variableId) =>
                     [
-                        getVariableDataRoute(
-                            DATA_API_URL,
-                            variableId,
-                            archiveInfo?.assets?.runtime
-                        ),
-                        getVariableMetadataRoute(
-                            DATA_API_URL,
-                            variableId,
-                            archiveInfo?.assets?.runtime
-                        ),
+                        getVariableDataRoute(DATA_API_URL, variableId, {
+                            assetMap: archiveInfo?.assets?.runtime,
+                        }),
+                        getVariableMetadataRoute(DATA_API_URL, variableId, {
+                            assetMap: archiveInfo?.assets?.runtime,
+                        }),
                     ].map((href) => (
                         <link
                             key={href}

--- a/site/GrapherPage.tsx
+++ b/site/GrapherPage.tsx
@@ -102,16 +102,12 @@ window.Grapher.renderSingleGrapherOnGrapherPage(jsonConfig, { archiveInfo })`
                 <link rel="preconnect" href={dataApiOrigin} />
                 {variableIds.flatMap((variableId) =>
                     [
-                        getVariableDataRoute(
-                            DATA_API_URL,
-                            variableId,
-                            archiveInfo?.assets?.runtime
-                        ),
-                        getVariableMetadataRoute(
-                            DATA_API_URL,
-                            variableId,
-                            archiveInfo?.assets?.runtime
-                        ),
+                        getVariableDataRoute(DATA_API_URL, variableId, {
+                            assetMap: archiveInfo?.assets?.runtime,
+                        }),
+                        getVariableMetadataRoute(DATA_API_URL, variableId, {
+                            assetMap: archiveInfo?.assets?.runtime,
+                        }),
                     ].map((href) => (
                         <link
                             key={href}


### PR DESCRIPTION
I ran into an issue where we'd freshly archive a variable, but end up with the previous version of the metadata file.

I hope this fixes it 🤞🏻 