### PR TITLE
Add support for external multi-dim embeds

### DIFF
--- a/packages/@ourworldindata/components/src/Checkbox.tsx
+++ b/packages/@ourworldindata/components/src/Checkbox.tsx
@@ -4,6 +4,7 @@ import { faCheck } from "@fortawesome/free-solid-svg-icons"
 import cx from "classnames"
 
 export class Checkbox extends React.Component<{
+    className?: string
     checked: boolean
     onChange: React.ChangeEventHandler<HTMLInputElement>
     label: React.ReactNode
@@ -12,11 +13,17 @@ export class Checkbox extends React.Component<{
     "data-test"?: string
 }> {
     render(): React.ReactElement {
-        const { checked, onChange, label, disabled, id } = this.props
+        const { className, checked, onChange, label, disabled, id } = this.props
         const testHook = this.props["data-test"]
 
         return (
-            <div className={cx("checkbox", { "checkbox--disabled": disabled })}>
+            <div
+                className={cx(
+                    "checkbox",
+                    { "checkbox--disabled": disabled },
+                    className
+                )}
+            >
                 <label>
                     <input
                         id={id}

--- a/packages/@ourworldindata/components/src/RadioButton.tsx
+++ b/packages/@ourworldindata/components/src/RadioButton.tsx
@@ -1,6 +1,8 @@
 import * as React from "react"
+import cx from "classnames"
 
 export class RadioButton extends React.Component<{
+    className?: string
     checked: boolean
     onChange: React.ChangeEventHandler<HTMLInputElement>
     label: React.ReactNode
@@ -10,11 +12,12 @@ export class RadioButton extends React.Component<{
     "data-test"?: string
 }> {
     render(): React.ReactElement {
-        const { checked, onChange, label, group, disabled, id } = this.props
+        const { className, checked, onChange, label, group, disabled, id } =
+            this.props
         const testHook = this.props["data-test"]
 
         return (
-            <div className="radio">
+            <div className={cx("radio", className)}>
                 <label>
                     <input
                         type="radio"

--- a/packages/@ourworldindata/explorer/src/Explorer.tsx
+++ b/packages/@ourworldindata/explorer/src/Explorer.tsx
@@ -53,7 +53,7 @@ import {
     uniqBy,
     Url,
 } from "@ourworldindata/utils"
-import { MarkdownTextWrap, Checkbox } from "@ourworldindata/components"
+import { MarkdownTextWrap } from "@ourworldindata/components"
 import classNames from "classnames"
 import { action, computed, observable, reaction } from "mobx"
 import { observer } from "mobx-react"
@@ -264,9 +264,6 @@ export class Explorer
     explorerProgram = ExplorerProgram.fromJson(this.props).initDecisionMatrix(
         this.initialQueryParams
     )
-
-    // only used for the checkbox at the bottom of the embed dialog
-    @observable embedDialogHideControls = true
 
     bakedBaseUrl = this.props.bakedBaseUrl
     dataApiUrl = this.props.dataApiUrl
@@ -998,6 +995,7 @@ export class Explorer
                     <Grapher
                         adminBaseUrl={this.adminBaseUrl}
                         bounds={this.grapherBounds}
+                        canHideExternalControlsInEmbed={true}
                         enableKeyboardShortcuts={true}
                         manager={this}
                         ref={this.grapherRef}
@@ -1020,28 +1018,6 @@ export class Explorer
 
     @computed get canonicalUrl() {
         return this.props.canonicalUrl ?? this.currentUrl.fullUrl
-    }
-
-    @computed get embedDialogUrl() {
-        return this.currentUrl.updateQueryParams({
-            hideControls: this.embedDialogHideControls.toString(),
-        }).fullUrl
-    }
-
-    @action.bound embedDialogToggleHideControls() {
-        this.embedDialogHideControls = !this.embedDialogHideControls
-    }
-
-    @computed get embedDialogAdditionalElements() {
-        return (
-            <div className="embed-additional-elements">
-                <Checkbox
-                    label="Hide controls"
-                    checked={this.embedDialogHideControls}
-                    onChange={this.embedDialogToggleHideControls}
-                />
-            </div>
-        )
     }
 
     @computed get grapherTable() {

--- a/packages/@ourworldindata/grapher/src/core/relatedQuestion.ts
+++ b/packages/@ourworldindata/grapher/src/core/relatedQuestion.ts
@@ -1,0 +1,12 @@
+import { RelatedQuestionsConfig } from "@ourworldindata/types"
+
+export const getErrorMessageRelatedQuestionUrl = (
+    question: RelatedQuestionsConfig
+): string | undefined => {
+    return question.text
+        ? (!question.url && "Missing URL") ||
+              (!question.url.match(/^https?:\/\//) &&
+                  "URL should start with http(s)://") ||
+              undefined
+        : undefined
+}

--- a/packages/@ourworldindata/grapher/src/index.ts
+++ b/packages/@ourworldindata/grapher/src/index.ts
@@ -55,12 +55,12 @@ export {
     Grapher,
     type GrapherProgrammaticInterface,
     type GrapherManager,
-    getErrorMessageRelatedQuestionUrl,
 } from "./core/Grapher"
 export { GrapherAnalytics, EventCategory } from "./core/GrapherAnalytics"
 export { hydrateGlobalEntitySelectorIfAny } from "./controls/globalEntitySelector/GlobalEntitySelector"
 export { legacyToCurrentGrapherUrl } from "./core/GrapherUrlMigrations"
 export { legacyToOwidTableAndDimensions } from "./core/LegacyToOwidTable"
+export { getErrorMessageRelatedQuestionUrl } from "./core/relatedQuestion"
 export { LoadingIndicator } from "./loadingIndicator/LoadingIndicator"
 export { MapChart } from "./mapCharts/MapChart"
 export { MapConfig } from "./mapCharts/MapConfig"

--- a/packages/@ourworldindata/grapher/src/modal/EmbedModal.scss
+++ b/packages/@ourworldindata/grapher/src/modal/EmbedModal.scss
@@ -20,10 +20,6 @@
         margin-bottom: 16px;
     }
 
-    .embed-additional-elements {
-        margin-top: 16px;
-    }
-
     .embed-modal--options {
         display: flex;
         gap: 32px;
@@ -37,4 +33,8 @@
     .embed-modal--option-description {
         color: $gray-70;
     }
+}
+
+.embed-modal-hide-controls {
+    margin-top: 16px;
 }

--- a/packages/@ourworldindata/grapher/src/modal/EmbedModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/EmbedModal.tsx
@@ -3,13 +3,19 @@ import * as React from "react"
 import { computed, action } from "mobx"
 import { Bounds, DEFAULT_BOUNDS, Url } from "@ourworldindata/utils"
 import { Modal } from "./Modal"
-import { CodeSnippet, OverlayHeader } from "@ourworldindata/components"
+import {
+    Checkbox,
+    CodeSnippet,
+    OverlayHeader,
+} from "@ourworldindata/components"
 
 export interface EmbedModalManager {
     embedUrl?: string
     embedArchivedUrl?: string
-    embedDialogAdditionalElements?: React.ReactElement
     isEmbedModalOpen?: boolean
+    canHideExternalControlsInEmbed: boolean
+    hideExternalControlsInEmbedUrl: boolean
+    setHideExternalControlsInEmbedUrl: (value: boolean) => void
     frameBounds?: Bounds
 }
 
@@ -126,7 +132,20 @@ export class EmbedModal extends React.Component<EmbedModalProps> {
                                 </div>
                             ))}
                         </div>
-                        {this.manager.embedDialogAdditionalElements}
+                        {this.manager.canHideExternalControlsInEmbed && (
+                            <Checkbox
+                                className="embed-modal-hide-controls"
+                                label="Hide controls"
+                                checked={
+                                    this.manager.hideExternalControlsInEmbedUrl
+                                }
+                                onChange={(event) =>
+                                    this.manager.setHideExternalControlsInEmbedUrl(
+                                        event.target.checked
+                                    )
+                                }
+                            />
+                        )}
                     </div>
                 </div>
             </Modal>

--- a/site/multiDim/MultiDim.scss
+++ b/site/multiDim/MultiDim.scss
@@ -1,7 +1,24 @@
+.multi-dim-container {
+    display: flex;
+    flex-direction: column;
+}
+
 .multi-dim-settings {
     margin-bottom: 16px;
 }
 
 .multi-dim-grapher-container {
-    height: $grapher-height;
+    flex-grow: 1;
+    min-height: $grapher-height;
+}
+
+html.IsInIframe {
+    .multi-dim-container {
+        height: 100vh;
+    }
+
+    .multi-dim-grapher-container {
+        min-height: auto !important;
+        max-height: none;
+    }
 }

--- a/site/multiDim/MultiDimDataPage.tsx
+++ b/site/multiDim/MultiDimDataPage.tsx
@@ -7,7 +7,7 @@ import { SiteFooter } from "../SiteFooter.js"
 import { SiteFooterContext, serializeJSONForHTML } from "@ourworldindata/utils"
 import { MultiDimDataPageProps } from "@ourworldindata/types"
 import { Html } from "../Html.js"
-import { MultiDimDataPageContentProps } from "./MultiDimDataPageContent.js"
+import { MultiDimDataPageData } from "./MultiDimDataPageContent.js"
 
 export function MultiDimDataPage({
     baseUrl,
@@ -25,7 +25,7 @@ export function MultiDimDataPage({
         throw new Error("Missing slug for multidimensional data page")
     }
     const canonicalUrl = slug ? `${baseGrapherUrl}/${slug}` : ""
-    const contentProps: MultiDimDataPageContentProps = {
+    const contentProps: MultiDimDataPageData = {
         canonicalUrl,
         slug,
         configObj,

--- a/site/multiembedder/MultiEmbedder.tsx
+++ b/site/multiembedder/MultiEmbedder.tsx
@@ -239,6 +239,7 @@ class MultiEmbedder {
     async _renderMultiDimWithControlsIntoFigure(
         figure: Element,
         multiDimConfig: MultiDimDataPageConfigEnriched,
+        slug: string,
         queryStr: string
     ) {
         figure.classList.remove(GRAPHER_PREVIEW_CLASS)
@@ -258,6 +259,7 @@ class MultiEmbedder {
         }
         ReactDOM.render(
             <MultiDim
+                slug={slug}
                 config={MultiDimDataPageConfig.fromObject(multiDimConfig)}
                 localGrapherConfig={localGrapherConfig}
                 queryStr={queryStr}
@@ -272,6 +274,7 @@ class MultiEmbedder {
         const embedUrl = Url.fromURL(embedUrlRaw)
 
         const { queryStr, slug } = embedUrl
+        if (!slug) return
 
         const mdimConfigUrl = `${MULTI_DIM_DYNAMIC_CONFIG_URL}/${slug}.json`
         const multiDimConfig = await fetchWithRetry(mdimConfigUrl).then((res) =>
@@ -292,6 +295,7 @@ class MultiEmbedder {
             await this._renderMultiDimWithControlsIntoFigure(
                 figure,
                 multiDimConfig,
+                slug,
                 queryStr
             )
         }

--- a/site/runSiteFooterScripts.tsx
+++ b/site/runSiteFooterScripts.tsx
@@ -5,6 +5,7 @@ import {
     DataPageV2ContentFields,
     deserializeOwidGdocPageData,
     isNil,
+    MultiDimDataPageConfig,
     OwidGdocType,
     parseIntOrUndefined,
     SiteFooterContext,
@@ -40,7 +41,7 @@ import { NewsletterSubscriptionForm } from "./NewsletterSubscription.js"
 import { NewsletterSubscriptionContext } from "./newsletter.js"
 import {
     MultiDimDataPageContent,
-    MultiDimDataPageContentProps,
+    MultiDimDataPageData,
 } from "./multiDim/MultiDimDataPageContent.js"
 import { BrowserRouter } from "react-router-dom-v5-compat"
 import { REDUCED_TRACKING } from "../settings/clientSettings.js"
@@ -206,12 +207,14 @@ const hydrateOwidGdoc = (debug?: boolean, isPreviewing?: boolean) => {
 
 const hydrateMultiDimDataPageContent = (isPreviewing?: boolean) => {
     const wrapper = document.querySelector(`#${OWID_DATAPAGE_CONTENT_ROOT_ID}`)
-    const props: MultiDimDataPageContentProps = window._OWID_MULTI_DIM_PROPS!
+    const { configObj, ...props }: MultiDimDataPageData =
+        window._OWID_MULTI_DIM_PROPS!
 
     hydrate(
         <DebugProvider debug={isPreviewing}>
             <BrowserRouter>
                 <MultiDimDataPageContent
+                    config={MultiDimDataPageConfig.fromObject(configObj)}
                     {...props}
                     isPreviewing={isPreviewing}
                 />


### PR DESCRIPTION
## Context

This is a prototype of an external mdim embed. The final design might be different.

Resolves #4775.

## Screenshots / Videos / Diagrams

`<iframe>` of the same mdim in a blank HTML page, with and without controls:

![image](https://github.com/user-attachments/assets/6eafbc51-de15-4bcb-8bc1-f1ea15400479)

## Testing guidance

Test that the iframe behaves correctly. And since I also changed the mdim data page implementation, testing that would be appreciated too.

## Checklist

### Before merging

- [X] Google Analytics events were adapted to fit the changes in this PR
- [X] Changes to CSS/HTML were checked on Desktop and Mobile Safari at all three breakpoints
- [X] Changes to HTML were checked for accessibility concerns