### PR TITLE
feat(archive): allow navigating to next version

### DIFF
--- a/baker/archival/ArchivalBaker.ts
+++ b/baker/archival/ArchivalBaker.ts
@@ -6,6 +6,7 @@ import {
     DbPlainArchivedChartVersion,
     GrapherInterface,
     UrlAndMaybeDate,
+    ArchiveVersions,
 } from "@ourworldindata/types"
 import fs from "fs-extra"
 import { keyBy } from "lodash-es"
@@ -414,6 +415,7 @@ async function bakeGrapherPageForArchival(
     const archiveNavigation: ArchiveSiteNavigationInfo = {
         liveUrl: `${PROD_URL}/grapher/${config.slug}`,
         previousVersion,
+        versionsFileUrl: `/versions/charts/${chartInfo.chartId}.json`,
     }
     const fullUrl = assembleGrapherArchivalUrl(
         date.formattedDate,
@@ -498,7 +500,10 @@ export async function generateChartVersionsFiles(
                 }))
             )
 
-            const fileContent = { chartId: chartId, versions: chartVersions }
+            const fileContent = {
+                chartId: chartId,
+                versions: chartVersions,
+            } satisfies ArchiveVersions
             await fs.writeFile(
                 path.join(targetPath, `${chartId}.json`),
                 JSON.stringify(fileContent, undefined, 2),

--- a/baker/archival/archivalChecksum.ts
+++ b/baker/archival/archivalChecksum.ts
@@ -187,3 +187,16 @@ export const insertChartVersions = async (
     if (rows.length)
         await knex.batchInsert(ArchivedChartVersionsTableName, rows)
 }
+
+export const getAllChartVersionsForChartId = async (
+    knex: db.KnexReadonlyTransaction,
+    chartId: number
+) => {
+    const rows = await knex<DbPlainArchivedChartVersion>(
+        ArchivedChartVersionsTableName
+    )
+        .select("archivalTimestamp", "grapherSlug")
+        .where("grapherId", chartId)
+        .orderBy("archivalTimestamp", "asc")
+    return rows
+}

--- a/baker/archival/archiveChangedGrapherPages.ts
+++ b/baker/archival/archiveChangedGrapherPages.ts
@@ -12,7 +12,10 @@ import {
     GrapherChecksumsObjectWithHash,
     insertChartVersions,
 } from "./archivalChecksum.js"
-import { bakeArchivalGrapherPagesToFolder } from "./ArchivalBaker.js"
+import {
+    bakeArchivalGrapherPagesToFolder,
+    generateChartVersionsFiles,
+} from "./ArchivalBaker.js"
 
 interface Options {
     dir: string
@@ -65,6 +68,12 @@ const findChangedPagesAndArchive = async (opts: Options) => {
         )
 
         await insertChartVersions(trx, needToBeArchived, date, manifests)
+
+        await generateChartVersionsFiles(
+            trx,
+            opts.dir,
+            needToBeArchived.map((c) => c.chartId)
+        )
     })
 
     process.exit(0)

--- a/packages/@ourworldindata/types/src/domainTypes/Archive.ts
+++ b/packages/@ourworldindata/types/src/domainTypes/Archive.ts
@@ -12,6 +12,7 @@ export interface ArchiveSiteNavigationInfo {
     liveUrl?: string
     previousVersion?: UrlAndMaybeDate
     nextVersion?: UrlAndMaybeDate
+    versionsFileUrl?: string
 }
 
 // Information about an archived chart version that is available, i.e. we can point to from the live site
@@ -35,3 +36,12 @@ export interface ArchiveMetaInformation
 export type ArchivedChartOrArchivePageMeta =
     | ChartArchivedVersion
     | ArchiveMetaInformation
+
+export interface ArchiveVersions {
+    chartId: number
+    versions: Array<{
+        archivalDate: ArchivalDateString
+        slug: string
+        url: string
+    }>
+}

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -765,4 +765,5 @@ export {
     type ArchiveSiteNavigationInfo,
     type ArchiveMetaInformation,
     type ChartArchivedVersion,
+    type ArchiveVersions,
 } from "./domainTypes/Archive.js"

--- a/site/SiteHeader.tsx
+++ b/site/SiteHeader.tsx
@@ -14,20 +14,23 @@ interface SiteHeaderProps {
     archiveInfo?: ArchiveMetaInformation
 }
 
+export const SiteHeaderNavigation = (props: SiteHeaderProps) =>
+    props.archiveInfo?.archiveNavigation ? (
+        <ArchiveSiteNavigation
+            archivalDate={props.archiveInfo.archivalDate}
+            {...props.archiveInfo.archiveNavigation}
+        />
+    ) : (
+        <SiteNavigation
+            hideDonationFlag={props.hideDonationFlag}
+            isOnHomepage={props.isOnHomepage}
+        />
+    )
+
 export const SiteHeader = (props: SiteHeaderProps) => (
     <header className="site-header">
-        {props.archiveInfo ? (
-            <ArchiveSiteNavigation
-                archivalDate={props.archiveInfo.archivalDate}
-                {...props.archiveInfo.archiveNavigation}
-            />
-        ) : (
-            <div className="site-navigation-root">
-                <SiteNavigation
-                    hideDonationFlag={props.hideDonationFlag}
-                    isOnHomepage={props.isOnHomepage}
-                />
-            </div>
-        )}
+        <div className="site-navigation-root">
+            <SiteHeaderNavigation {...props} />
+        </div>
     </header>
 )

--- a/site/archive/ArchiveSiteNavigation.tsx
+++ b/site/archive/ArchiveSiteNavigation.tsx
@@ -71,10 +71,22 @@ const ArchiveNavigationBar = (props: ArchiveSiteNavigationProps) => {
     const nextVersion = useMemo(() => {
         if (!versions) return props.nextVersion
 
+        // Find the index of the current version in the sorted list
         const currentVersionIdx = R.sortedIndexWith(
             versions.versions,
             (item) => item.archivalDate < pageArchivalDate
         )
+        if (
+            versions.versions[currentVersionIdx]?.archivalDate !==
+            pageArchivalDate
+        ) {
+            console.error(
+                `Current version not found in the list of versions. Current version: ${pageArchivalDate}, Versions: `,
+                versions.versions
+            )
+            return undefined
+        }
+
         return versions.versions.at(currentVersionIdx + 1)
     }, [versions, props.nextVersion, pageArchivalDate])
 

--- a/site/archive/ArchiveSiteNavigation.tsx
+++ b/site/archive/ArchiveSiteNavigation.tsx
@@ -5,7 +5,6 @@ import { formatAsArchivalDate, parseArchivalDate } from "@ourworldindata/utils"
 import {
     ArchiveSiteNavigationInfo,
     ArchiveVersions,
-    UrlAndMaybeDate,
 } from "@ourworldindata/types"
 import { PROD_URL } from "../SiteConstants.js"
 import { useEffect, useMemo, useState } from "react"
@@ -69,18 +68,15 @@ const ArchiveNavigationBar = (props: ArchiveSiteNavigationProps) => {
         }
     }, [props.versionsFileUrl])
 
-    const [nextVersion, setNextVersion] = useState<UrlAndMaybeDate | undefined>(
-        props.nextVersion
-    )
-    useEffect(() => {
-        if (!versions) return
+    const nextVersion = useMemo(() => {
+        if (!versions) return props.nextVersion
 
         const currentVersionIdx = R.sortedIndexWith(
             versions.versions,
             (item) => item.archivalDate < pageArchivalDate
         )
-        setNextVersion(versions.versions.at(currentVersionIdx + 1))
-    }, [pageArchivalDate, versions])
+        return versions.versions.at(currentVersionIdx + 1)
+    }, [versions, props.nextVersion, pageArchivalDate])
 
     return (
         <nav className="archive-navigation-bar">

--- a/site/runSiteFooterScripts.tsx
+++ b/site/runSiteFooterScripts.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from "react"
 import { hydrate, render } from "react-dom"
 import {
+    ArchiveMetaInformation,
     DataPageV2ContentFields,
     deserializeOwidGdocPageData,
     isNil,
@@ -18,7 +19,6 @@ import { Footnote } from "./Footnote.js"
 import { OwidGdoc } from "./gdocs/OwidGdoc.js"
 import { runLightbox } from "./lightboxUtils.js"
 import { MultiEmbedderSingleton } from "./multiembedder/MultiEmbedder.js"
-import { SiteNavigation } from "./SiteNavigation.js"
 import SiteTools, { SITE_TOOLS_CLASS } from "./SiteTools.js"
 import { runDetailsOnDemand } from "./detailsOnDemand.js"
 import { hydrateCodeSnippets } from "@ourworldindata/components"
@@ -44,6 +44,7 @@ import {
 } from "./multiDim/MultiDimDataPageContent.js"
 import { BrowserRouter } from "react-router-dom-v5-compat"
 import { REDUCED_TRACKING } from "../settings/clientSettings.js"
+import { SiteHeaderNavigation } from "./SiteHeader.js"
 
 function hydrateDataCatalogPage() {
     const root = document.getElementById("data-catalog-page-root")
@@ -154,10 +155,20 @@ function runSiteNavigation(hideDonationFlag?: boolean) {
             isOnHomepage = props?.content?.type === OwidGdocType.Homepage
         }
 
+        let archiveInfo: ArchiveMetaInformation | undefined
+        if (window._OWID_ARCHIVE_INFO) {
+            archiveInfo = window._OWID_ARCHIVE_INFO
+        }
+
         render(
-            <SiteNavigation
+            <SiteHeaderNavigation
                 hideDonationFlag={hideDonationFlag}
                 isOnHomepage={isOnHomepage}
+                archiveInfo={
+                    archiveInfo?.type === "archive-page"
+                        ? archiveInfo
+                        : undefined
+                }
             />,
             siteNavigationElem
         )
@@ -226,13 +237,13 @@ export const runSiteFooterScriptsForArchive = (args: SiteFooterScriptsArgs) => {
             hydrateDataPageV2Content({ isPreviewing })
             // runAllGraphersLoadedListener()
             runLightbox()
-            // runSiteNavigation(hideDonationFlag)
+            runSiteNavigation()
             // runSiteTools()
             // runCookiePreferencesManager()
             void runDetailsOnDemand()
             break
         case SiteFooterContext.grapherPage:
-            // runSiteNavigation(hideDonationFlag)
+            runSiteNavigation()
             // runAllGraphersLoadedListener()
             // runSiteTools()
             // runCookiePreferencesManager()


### PR DESCRIPTION
Enables going forward in time with the "Go to next version" button.
It is powered by a client-side fetch of the `/versions/charts/[chartId].json` file.