### PR TITLE
enhance(markdown): detect more types of links

### DIFF
--- a/packages/@ourworldindata/components/src/markdown/remarkPlainLinks.test.ts
+++ b/packages/@ourworldindata/components/src/markdown/remarkPlainLinks.test.ts
@@ -7,7 +7,7 @@ describe("urlRegex", () => {
         "http://example.com/",
         "http://example.com/path/to/resource",
         "http://example.com/path/to/resource?query=string",
-        "http://example.com/path/to/resource#fragment",
+        "http://example.com/path/to/resource.svg#fragment",
         "http://example.com/path/to/resource?query=string#fragment",
         "http://example.com/path/to/resource#fragment?query=string",
         "http://example.com/path/to/resource?query=string&another=query#fragment",
@@ -46,6 +46,20 @@ describe("urlRegex", () => {
             "This is a test string without a URL, but it contains http:// and example.com"
         const match = input.match(urlRegex)
         expect(match).toBeFalsy()
+    })
+
+    it("should exclude trailing period", () => {
+        const input = `This is an http://example.com.`
+        const match = input.match(urlRegex)
+        expect(match).toBeTruthy()
+        expect(match![0]).toBe("http://example.com")
+    })
+
+    it("should exclude trailing question mark", () => {
+        const input = `Is this an http://example.com?`
+        const match = input.match(urlRegex)
+        expect(match).toBeTruthy()
+        expect(match![0]).toBe("http://example.com")
     })
 
     it("should match urls without TLD", () => {

--- a/packages/@ourworldindata/components/src/markdown/remarkPlainLinks.test.ts
+++ b/packages/@ourworldindata/components/src/markdown/remarkPlainLinks.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest"
+import { urlRegex } from "./remarkPlainLinks.js"
+
+describe("urlRegex", () => {
+    const urls = [
+        "https://example.com",
+        "http://example.com/",
+        "http://example.com/path/to/resource",
+        "http://example.com/path/to/resource?query=string",
+        "http://example.com/path/to/resource#fragment",
+        "http://example.com/path/to/resource?query=string#fragment",
+        "http://example.com/path/to/resource#fragment?query=string",
+        "http://example.com/path/to/resource?query=string&another=query#fragment",
+        "https://sub1.sub2.example.com/path/to/resource#fragment&another=query?query=string",
+        "https://sub1.sub2.example.com/path/to/你好",
+    ]
+
+    it.each(urls)("should match URL: %s", (url) => {
+        const input = `This is a test string with a URL: ${url}`
+        const match = input.match(urlRegex)
+        expect(match).toBeTruthy()
+        expect(match![0]).toBe(url)
+    })
+
+    it("should match multiple URLs in string", () => {
+        const input = `This is a test string with a URL: ${urls[0]} and another URL: ${urls[1]}`
+        const matches = input.match(urlRegex)
+        expect(matches).toBeTruthy()
+        expect(matches).toHaveLength(2)
+        expect(matches![0]).toBe(urls[0])
+        expect(matches![1]).toBe(urls[1])
+    })
+
+    it("should match all URLs", () => {
+        const input = `This is a test string with all URLs: ${urls.join(" ")}`
+        const matches = input.match(urlRegex)
+        expect(matches).toBeTruthy()
+        expect(matches).toHaveLength(urls.length)
+        urls.forEach((url, index) => {
+            expect(matches![index]).toBe(url)
+        })
+    })
+
+    it("should not match non-URL", () => {
+        const input =
+            "This is a test string without a URL, but it contains http:// and example.com"
+        const match = input.match(urlRegex)
+        expect(match).toBeFalsy()
+    })
+
+    it("should match urls without TLD", () => {
+        const input = `This is a test string with a URL: http://staging-site-example`
+        const match = input.match(urlRegex)
+        expect(match).toBeTruthy()
+        expect(match![0]).toBe("http://staging-site-example")
+    })
+
+    it("should match localhost URLs with port", () => {
+        const input = `This is a test string with a URL: http://localhost:3000/path/to/resource`
+        const match = input.match(urlRegex)
+        expect(match).toBeTruthy()
+        expect(match![0]).toBe("http://localhost:3000/path/to/resource")
+    })
+})

--- a/packages/@ourworldindata/components/src/markdown/remarkPlainLinks.ts
+++ b/packages/@ourworldindata/components/src/markdown/remarkPlainLinks.ts
@@ -4,8 +4,9 @@ import findAndReplace from "mdast-util-find-and-replace"
 //   "http"
 //   an optional "s"
 //   two / characters
-//   The subdomains and hostname: Any word or numeric character or "_" or "-" one or more times followed by a period
-//   The TLD: Any word or numeric character or "_" or "-" one or more times
+//   The subdomains and hostname: Any word or numeric character or "-" one or more times followed by a period
+//   The TLD: Any word or numeric character or "-" one or more times (the TLD is optional, and URLs like localhost are also valid)
+//   The port: A colon followed by one or more digits (optional)
 //   The path, query string and fragment: A forward slash followed by any word or numeric character (unicode classes so umlauts like ö match
 //       as well as any of the following: .+?:%&=~#) zero or more times. Note that we exclude space even though that is valid in a URL but it tends
 //       to make the match too greedy.
@@ -14,7 +15,7 @@ import findAndReplace from "mdast-util-find-and-replace"
 //       period should not be part of the URL)
 //       Finally, the very last part is a lone forward slash which would not be matched by the previous subgroup.
 export const urlRegex =
-    /https?:\/\/([\w-]+\.)+[\w-]+((\/[\p{L}\p{N}_\-.+/?:%&=~#]*[\p{L}\p{N}_\-+/%&=~#])|\/)?/gu
+    /https?:\/\/([\w-]+\.)*[\w-]+(:\d+)?((\/[\p{L}\p{N}_\-.+/?:%&=~#]*[\p{L}\p{N}_\-+/%&=~#])|\/)?/gu
 
 export function remarkPlainLinks() {
     const turnIntoLink = (value: any, _match: string) => {


### PR DESCRIPTION
Makes the URL regex a bit less restrictive, so it also allows detecting the following two types of URLs (e.g. in the citations section on a data page):
- http://staging-site-url-regex
- http://localhost:3030

I've also added a bunch of tests for the regex!