### PR TITLE
perf(table): core table performance improvements

### DIFF
--- a/packages/@ourworldindata/core-table/src/CoreTable.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTable.ts
@@ -552,12 +552,11 @@ export class CoreTable<
     rowIndex(columnSlugs: ColumnSlug[]): Map<string, number[]> {
         const index = new Map<string, number[]>()
         const keyFn = makeKeyFn(this.columnStore, columnSlugs)
-        this.indices.forEach((rowIndex) => {
-            // todo: be smarter for string keys
-            const key = keyFn(rowIndex)
-            if (!index.has(key)) index.set(key, [])
-            index.get(key)!.push(rowIndex)
-        })
+        for (let i = 0; i < this.numRows; i++) {
+            const key = keyFn(i)
+            if (index.has(key)) index.get(key)!.push(i)
+            else index.set(key, [i])
+        }
         return index
     }
 

--- a/packages/@ourworldindata/core-table/src/CoreTable.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTable.ts
@@ -352,6 +352,15 @@ export class CoreTable<
         } as AdvancedOptions)
     }
 
+    protected noopTransform(tableDescription: string): this {
+        return this.transform(
+            this.columnStore,
+            this.defs,
+            tableDescription,
+            TransformType.Noop
+        )
+    }
+
     // Time between when the parent table finished loading and this table started constructing.
     // A large time may just be due to a transform only happening after a user action, or it
     // could be do to other sync code executing between transforms.
@@ -589,12 +598,17 @@ export class CoreTable<
     }
 
     sortBy(slugs: ColumnSlug[]): this {
-        return this.transform(
-            sortColumnStore(this.columnStore, slugs),
-            this.defs,
-            `Sort by ${slugs.join(",")}`,
-            TransformType.SortRows
-        )
+        const description = `Sort by ${slugs.join(",")}`
+        const sorted = sortColumnStore(this.columnStore, slugs)
+
+        if (sorted === this.columnStore) return this.noopTransform(description)
+        else
+            return this.transform(
+                sorted,
+                this.defs,
+                description,
+                TransformType.SortRows
+            )
     }
 
     // Assumes table is sorted by columnSlug. Returns an array representing the starting index of each new group.

--- a/packages/@ourworldindata/core-table/src/CoreTable.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTable.ts
@@ -182,6 +182,9 @@ export class CoreTable<
         return originalInput as CoreColumnStore
     }
 
+    // This can, in theory, be used to detect whether we can reuse the input column store, which can save us time parsing.
+    // However, I'm not entirely sure whether the conditions included here are complete, so we don't currently use it.
+    // We do use `advancedOptions.forceReuseColumnStore`, however.
     @imemo get canReuseInputColumnStore(): boolean {
         const { inputColumnDefs, valuesFromColumnDefs, columnSlugs } = this
 
@@ -204,10 +207,7 @@ export class CoreTable<
     @imemo get columnStore(): CoreColumnStore {
         const { inputColumnStore, advancedOptions } = this
 
-        if (
-            advancedOptions.forceReuseColumnStore ||
-            this.canReuseInputColumnStore
-        ) {
+        if (advancedOptions.forceReuseColumnStore) {
             if (advancedOptions.filterMask)
                 return advancedOptions.filterMask.apply(inputColumnStore)
             else return inputColumnStore

--- a/packages/@ourworldindata/core-table/src/CoreTableUtils.test.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTableUtils.test.ts
@@ -397,6 +397,27 @@ describe(sortColumnStore, () => {
         expect(result).not.toBe(columnStore)
     })
 
+    it("can sort", () => {
+        const columnStore = {
+            pops: [1, 2, 3, 1.5],
+        }
+        const result = sortColumnStore(columnStore, ["pops"])
+        expect(result["pops"]).toEqual([1, 1.5, 2, 3])
+        expect(result).not.toBe(columnStore)
+    })
+
+    it("can sort by multiple columns", () => {
+        const columnStore = {
+            countries: ["usa", "usa", "can", "mex"],
+            pops: [123, 11, 21, 99],
+            gdp: [1, 2, 3, 4],
+        }
+        const result = sortColumnStore(columnStore, ["countries", "pops"])
+        expect(result["countries"]).toEqual(["can", "mex", "usa", "usa"])
+        expect(result["pops"]).toEqual([21, 99, 11, 123])
+        expect(result["gdp"]).toEqual([3, 4, 2, 1])
+    })
+
     it("can detect a sorted array and leave it untouched", () => {
         const columnStore = {
             countries: ["usa", "can", "mex"],

--- a/packages/@ourworldindata/core-table/src/CoreTableUtils.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTableUtils.ts
@@ -347,8 +347,7 @@ export const makeKeyFn = (
             ? ""
             : typeof val === "string"
               ? val
-              : // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
-                val + ""
+              : (val as any) + ""
 
     // perf: this function is performance-critical, and so for the common cases of 1, 2, or 3 columns, we can provide a
     // faster implementation.

--- a/packages/@ourworldindata/core-table/src/OwidTable.ts
+++ b/packages/@ourworldindata/core-table/src/OwidTable.ts
@@ -190,17 +190,18 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
 
         // perf: if the time range is greater than the table's time range, we can skip the filter
         if (adjustedStart <= this.minTime && adjustedEnd >= this.maxTime!)
-            return this.sortedByTime.noopTransform(description)
+            return this.noopTransform(description).sortedByTime
 
-        // Sorting by time, because incidentally some parts of the code depended on this method
-        // returning sorted rows.
-        return this.sortedByTime.columnFilter(
+        return this.columnFilter(
             timeColumnSlug,
             (time) =>
                 (time as number) >= adjustedStart &&
                 (time as number) <= adjustedEnd,
             description
-        )
+
+            // Sorting by time, because incidentally some parts of the code depended on this method
+            // returning sorted rows.
+        ).sortedByTime
     }
 
     filterByTargetTimes(targetTimes: Time[], tolerance = 0): this {

--- a/packages/@ourworldindata/core-table/src/OwidTable.ts
+++ b/packages/@ourworldindata/core-table/src/OwidTable.ts
@@ -314,10 +314,16 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
                 ? [...entityNamesToDrop].join(", ")
                 : "(None)"
 
+        if (entityNamesToDrop.size === 0) {
+            return this.noopTransform(
+                `Drop entities that have no data in some column`
+            )
+        }
+
         return this.columnFilter(
             this.entityNameSlug,
             (rowEntityName) => entityNamesToKeep.has(rowEntityName as string),
-            `Drop entities that have no data in some column: ${columnSlugs.join(", ")}.\nDropped entities: ${droppedEntitiesStr}`
+            `Drop ${entityNamesToDrop.size} entities that have no data in some column: ${columnSlugs.join(", ")}.\nDropped entities: ${droppedEntitiesStr}`
         )
     }
 

--- a/packages/@ourworldindata/grapher/src/color/ColorScale.ts
+++ b/packages/@ourworldindata/grapher/src/color/ColorScale.ts
@@ -7,6 +7,7 @@ import {
     last,
     roundSigFig,
     mapNullToUndefined,
+    sortNumeric,
 } from "@ourworldindata/utils"
 import { ColorSchemes } from "../color/ColorSchemes"
 import { ColorScheme } from "../color/ColorScheme"
@@ -22,6 +23,7 @@ import {
     OwidVariableRoundingMode,
 } from "@ourworldindata/types"
 import { CoreColumn } from "@ourworldindata/core-table"
+import * as R from "remeda"
 
 export const NO_DATA_LABEL = "No data"
 
@@ -117,23 +119,21 @@ export class ColorScale {
         return this.manager.hasNoDataBin || false
     }
 
-    @computed get sortedNumericValues(): any[] {
-        return (
-            this.colorScaleColumn?.valuesAscending?.filter(
-                (x) => typeof x === "number"
-            ) ?? []
+    @computed get sortedNumericValues(): number[] {
+        return sortNumeric(
+            this.colorScaleColumn?.values.filter(R.isNumber) ?? []
         )
     }
 
-    @computed private get minPossibleValue(): any {
+    @computed private get minPossibleValue(): number | undefined {
         return first(this.sortedNumericValues)
     }
 
-    @computed private get maxPossibleValue(): any {
+    @computed private get maxPossibleValue(): number | undefined {
         return last(this.sortedNumericValues)
     }
 
-    @computed private get categoricalValues(): any[] {
+    @computed private get categoricalValues(): string[] {
         return this.colorScaleColumn?.sortedUniqNonEmptyStringVals ?? []
     }
 

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
@@ -135,6 +135,14 @@ export class ScatterPlotChart
     }>()
 
     transformTable(table: OwidTable): OwidTable {
+        // Drop all entities that have no data in either the X or Y column.
+        // For some charts, this can drop more than 50% of rows, so we do it first.
+        // If there's no data at all for an entity, then tolerance can also not "recover" any data, so this is safe to do.
+        table = table.dropEntitiesThatHaveNoDataInSomeColumn([
+            this.xColumnSlug,
+            this.yColumnSlug,
+        ])
+
         if (this.xScaleType === ScaleType.log && this.xColumnSlug)
             table = table.replaceNonPositiveCellsForLogScale([this.xColumnSlug])
 

--- a/packages/@ourworldindata/types/src/domainTypes/CoreTableTypes.ts
+++ b/packages/@ourworldindata/types/src/domainTypes/CoreTableTypes.ts
@@ -50,6 +50,7 @@ export enum TransformType {
     LoadFromColumnStore = "LoadFromColumnStore",
     LoadFromMatrix = "LoadFromMatrix",
     Concat = "Concat",
+    Noop = "Noop", // for when we notice that we can skip a transform
 
     // Row ops
     FilterRows = "FilterRows",

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -1040,7 +1040,7 @@ export function getClosestTimePairs(
 
     const seenTimes = new Set(decidedPairs.flat())
 
-    sortBy(undecidedPairs, (pair) => Math.abs(pair[0] - pair[1])).forEach(
+    sortNumeric(undecidedPairs, (pair) => Math.abs(pair[0] - pair[1])).forEach(
         (pair) => {
             if (!seenTimes.has(pair[0]) && !seenTimes.has(pair[1])) {
                 decidedPairs.push(pair)


### PR DESCRIPTION
I found a good bunch of optimizations that we can apply to make core table methods more performant, especially for the our worst offender charts.

| Method                               | URL                                                                                   | Before: longest single call | Before: overall time | After: longest single call | After: overall time |
|--------------------------------------|---------------------------------------------------------------------------------------|-----------------------------|----------------------|----------------------------|---------------------|
| rowIndex                             | [covid-19-cumulative-confirmed-cases-vs-confirmed-deaths](http://localhost:3030/grapher/covid-19-cumulative-confirmed-cases-vs-confirmed-deaths) | 214ms                       | 501ms                | 131ms                      | 355ms               |
| sortBy                               | [covid-19-cumulative-confirmed-cases-vs-confirmed-deaths](http://localhost:3030/grapher/covid-19-cumulative-confirmed-cases-vs-confirmed-deaths) | 124ms                       | 296ms                | 100ms                      | 224ms               |
| interpolateColumnsByClosestTimeMatch | [covid-19-cumulative-confirmed-cases-vs-confirmed-deaths](http://localhost:3030/grapher/covid-19-cumulative-confirmed-cases-vs-confirmed-deaths) |                             | 763ms                |                            | 338ms               |
|                                      | [covid-19-daily-tests-vs-daily-new-confirmed-cases](http://localhost:3030/grapher/covid-19-daily-tests-vs-daily-new-confirmed-cases)       |                             | 350ms                |                            | 190ms               |
|                                      | [growth-of-income-and-trade](http://localhost:3030/grapher/growth-of-income-and-trade)                              |                             | 136ms                |                            | 80ms                |


The SVG tester duration also goes down (measured with `--isolate`):
- For the top-50 heaviest charts (many of them are scatters), down from 150s to 130s (-15%)
- overall runtime goes down from 988s to 941s (-5%)