### PR TITLE
cleanup(table): get rid of unnecessary `availableEntities`

### DIFF
--- a/adminSiteClient/AbstractChartEditor.ts
+++ b/adminSiteClient/AbstractChartEditor.ts
@@ -185,9 +185,7 @@ export abstract class AbstractChartEditor<
         const { grapher } = this
 
         // find invalid selected entities
-        const availableEntityNames = grapher.availableEntities.map(
-            (e) => e.entityName
-        )
+        const { availableEntityNames } = grapher
         const selectedEntityNames = grapher.selection.selectedEntityNames
         return difference(selectedEntityNames, availableEntityNames)
     }

--- a/adminSiteClient/EditorDataTab.tsx
+++ b/adminSiteClient/EditorDataTab.tsx
@@ -447,7 +447,7 @@ class EntityFilterSection<
         const availableEntityNames =
             this.includedEntityNames.length > 0
                 ? this.includedEntityNames
-                : this.grapher.availableEntities.map((e) => e.entityName)
+                : this.grapher.availableEntityNames
         return availableEntityNames
             .filter((entityName) => !excludedEntityNames.includes(entityName))
             .sort()

--- a/packages/@ourworldindata/core-table/src/OwidTable.ts
+++ b/packages/@ourworldindata/core-table/src/OwidTable.ts
@@ -67,34 +67,6 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
         return this.entityNameColumn.uniqValuesAsSet
     }
 
-    @imemo get entityNameToIdMap(): Map<string, number> {
-        return this.valueIndex(
-            this.entityNameColumn.slug,
-            this.entityIdColumn.slug
-        ) as Map<string, number>
-    }
-
-    @imemo get entityNameToCodeMap(): Map<string, string> {
-        return this.valueIndex(
-            this.entityNameColumn.slug,
-            this.entityCodeColumn.slug
-        ) as Map<string, string>
-    }
-
-    @imemo get entityIdColumn(): CoreColumn {
-        return (
-            this.getFirstColumnWithType(ColumnTypeNames.EntityId) ??
-            this.get(OwidTableSlugs.entityId)
-        )
-    }
-
-    @imemo get entityCodeColumn(): CoreColumn {
-        return (
-            this.getFirstColumnWithType(ColumnTypeNames.EntityCode) ??
-            this.get(OwidTableSlugs.entityCode)
-        )
-    }
-
     @imemo get entityNameColumn(): CoreColumn {
         return (
             this.getFirstColumnWithType(ColumnTypeNames.EntityName) ??
@@ -1148,21 +1120,6 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
                 return rowIndex ? rowIndices[rowIndex] : null
             })
             .filter(isPresent)
-    }
-
-    @imemo get availableEntities(): {
-        entityName: string
-        entityId?: number
-        entityCode?: string
-    }[] {
-        const { entityNameToCodeMap, entityNameToIdMap } = this
-        return this.availableEntityNames.map((entityName) => {
-            return {
-                entityName,
-                entityId: entityNameToIdMap.get(entityName),
-                entityCode: entityNameToCodeMap.get(entityName),
-            }
-        })
     }
 
     sampleEntityName(howMany = 1): any[] {

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -115,7 +115,6 @@ import {
     ChartViewInfo,
     OwidChartDimensionInterfaceWithMandatorySlug,
     AssetMap,
-    Entity,
 } from "@ourworldindata/types"
 import {
     BlankOwidTable,
@@ -2645,10 +2644,6 @@ export class Grapher
         void this.timelineController.togglePlay()
     }
 
-    @computed get availableEntities(): Entity[] {
-        return this.tableForSelection.availableEntities
-    }
-
     @computed get availableEntityNames(): EntityName[] {
         return this.tableForSelection.availableEntityNames
     }
@@ -3822,7 +3817,7 @@ export class Grapher
     // we may still want to show those entities as available in a picker. We also do not want to do things like
     // hide the Add Entity button as the user drags the timeline.
     @computed private get numSelectableEntityNames(): number {
-        return this.availableEntities.length
+        return this.availableEntityNames.length
     }
 
     @computed get entitiesAreCountryLike(): boolean {

--- a/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.test.ts
+++ b/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.test.ts
@@ -82,9 +82,6 @@ describe(legacyToOwidTableAndDimensions, () => {
         expect(table.entityNameColumn.valuesIncludingErrorValues).toEqual([
             "World",
         ])
-        expect(table.entityCodeColumn.valuesIncludingErrorValues).toEqual([
-            "OWID_WRL",
-        ])
     })
 
     describe("conversionFactor", () => {

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.test.tsx
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.test.tsx
@@ -164,7 +164,7 @@ describe("when the table has no filter toggle", () => {
         })
         const view = Enzyme.mount(<DataTable manager={grapher} />)
         const rows = view.find("tbody tr:not(.title)")
-        expect(rows).toHaveLength(grapher.availableEntities.length)
+        expect(rows).toHaveLength(grapher.availableEntityNames.length)
     })
 
     it("does not filter by default if the selection is empty", () => {
@@ -175,6 +175,6 @@ describe("when the table has no filter toggle", () => {
         })
         const view = Enzyme.mount(<DataTable manager={grapher} />)
         const rows = view.find("tbody tr:not(.title)")
-        expect(rows).toHaveLength(grapher.availableEntities.length)
+        expect(rows).toHaveLength(grapher.availableEntityNames.length)
     })
 })


### PR DESCRIPTION
To my surprise, I found out that computing `OwidTable.availableEntities` takes 80ms on my machine for https://ourworldindata.org/grapher/covid-daily-vs-total-cases-per-million - when in reality we only ever need the entity name.

A next step would be to remove `entityCode` and possibly `entityId` entirely from OwidTable, since there's not much of a use to it at this point. `entityCode` could be useful in data downloads, though.