### PR TITLE
🐛 fix query string not being updated on chart changes

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -535,6 +535,8 @@ export class GrapherState {
 
         updatePersistables(this, obj)
 
+        this.bindUrlToWindow = obj.bindUrlToWindow
+
         // Regression fix: some legacies have this set to Null. Todo: clean DB.
         if (obj.originUrl === null) this.originUrl = ""
 

--- a/site/DataPageV2Content.tsx
+++ b/site/DataPageV2Content.tsx
@@ -57,9 +57,11 @@ export const DataPageV2Content = ({
         () => ({
             ...grapherConfig,
             isEmbeddedInADataPage: true,
-            bindUrlToWindow: true,
+            bindUrlToWindow: typeof window !== "undefined",
             adminBaseUrl: ADMIN_BASE_URL,
             bakedGrapherURL: BAKED_GRAPHER_URL,
+            enableKeyboardShortcuts: typeof window !== "undefined",
+
             archivedChartInfo,
         }),
         [grapherConfig, archivedChartInfo]


### PR DESCRIPTION
Fix Query string not being updated when the chart changes on grapher pages or data pages.