### PR TITLE
✨ use correct link colour in datapage key info

### DIFF
--- a/site/AboutThisData.scss
+++ b/site/AboutThisData.scss
@@ -16,6 +16,10 @@
         margin: 0;
     }
 
+    a {
+        @include owid-link-90;
+    }
+
     ul,
     ol {
         padding-left: 1em;


### PR DESCRIPTION
Currently the markdown on datapages has default styles applied to links:
https://ourworldindata.org/grapher/total-population-in-extreme-poverty?tab=chart&time=2010..latest&focus=&country=~OWID_WRL

![image](https://github.com/user-attachments/assets/66d03813-7bf1-4385-9989-79a49bb0075f)
