### PR TITLE
🔨 Allow chart overrides again

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/FetchingGrapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/FetchingGrapher.tsx
@@ -84,12 +84,13 @@ export function FetchingGrapher(
                 const fetchedConfig = await fetch(props.configUrl).then((res) =>
                     res.json()
                 )
-                setdownloadedConfig(fetchedConfig)
-                grapherState.current.updateFromObject(fetchedConfig)
+                const mergedConfig = { ...fetchedConfig, ...props.config }
+                setdownloadedConfig(mergedConfig)
+                grapherState.current.updateFromObject(mergedConfig)
             }
         }
         void fetchConfigAndLoadData()
-    }, [props.configUrl])
+    }, [props.config, props.configUrl])
 
     React.useEffect(() => {
         async function fetchData(): Promise<void> {

--- a/site/GrapherWithFallback.tsx
+++ b/site/GrapherWithFallback.tsx
@@ -63,7 +63,7 @@ export function GrapherWithFallback(
                 imageFallback
             ) : inView ? (
                 <GrapherFigureView
-                    slug={fetchConfig ? slug : undefined}
+                    slug={slug}
                     config={config}
                     queryStr={queryStr}
                 />

--- a/site/gdocs/components/Chart.tsx
+++ b/site/gdocs/components/Chart.tsx
@@ -151,7 +151,6 @@ export default function Chart({
                     )}
                 </figure>
             ) : (
-                // TODO: 2025-01-05 Daniel - this is a crude first version, this entire control has to be touched again
                 <GrapherWithFallback slug={slug} config={chartConfig} />
             )}
             {d.caption ? (


### PR DESCRIPTION
Our Chart Gdoc component can override properties like the title - this was the old style of doing narrative charts. This PR re-enables this functionality after the grapher state refactor.