### PR TITLE
Speed up gdoc preview page

### DIFF
--- a/adminSiteClient/GdocsPreviewPage.tsx
+++ b/adminSiteClient/GdocsPreviewPage.tsx
@@ -109,10 +109,10 @@ export const GdocsPreviewPage = ({ match, history }: GdocsMatchProps) => {
     useEffect(() => {
         async function fetchGdocs() {
             try {
-                // Fetching in sequence instead of with Promise.all to prevent race conditions
-                // if images need to be uploaded from the original
-                const original = await fetchGdoc(GdocsContentSource.Internal)
-                const current = await fetchGdoc(GdocsContentSource.Gdocs)
+                const [original, current] = await Promise.all([
+                    fetchGdoc(GdocsContentSource.Internal),
+                    fetchGdoc(GdocsContentSource.Gdocs),
+                ])
                 if (!current.slug && current.content.title) {
                     current.slug = slugify(current.content.title)
                 }

--- a/db/model/Chart.ts
+++ b/db/model/Chart.ts
@@ -37,19 +37,21 @@ export const PUBLIC_TAG_PARENT_IDS = [
 export async function mapSlugsToIds(
     knex: db.KnexReadonlyTransaction
 ): Promise<{ [slug: string]: number }> {
-    const redirects = await db.knexRaw<{ chart_id: number; slug: string }>(
-        knex,
-        `SELECT chart_id, slug FROM chart_slug_redirects`
-    )
-    const rows = await db.knexRaw<{ id: number; slug: string }>(
-        knex,
-        `-- sql
-            SELECT c.id, cc.slug
-            FROM charts c
-            JOIN chart_configs cc ON cc.id = c.configId
-            WHERE cc.full ->> "$.isPublished" = "true"
-        `
-    )
+    const [redirects, rows] = await Promise.all([
+        db.knexRaw<{ chart_id: number; slug: string }>(
+            knex,
+            `SELECT chart_id, slug FROM chart_slug_redirects`
+        ),
+        db.knexRaw<{ id: number; slug: string }>(
+            knex,
+            `-- sql
+                SELECT c.id, cc.slug
+                FROM charts c
+                JOIN chart_configs cc ON cc.id = c.configId
+                WHERE cc.full ->> "$.isPublished" = "true"
+            `
+        ),
+    ])
 
     const slugToId: { [slug: string]: number } = {}
     for (const row of redirects) {

--- a/db/model/ChartView.ts
+++ b/db/model/ChartView.ts
@@ -1,5 +1,6 @@
 import {
     ChartViewInfo,
+    ChartViewsTableName,
     DbPlainChartView,
     JsonString,
 } from "@ourworldindata/types"
@@ -46,4 +47,12 @@ export const getChartViewNameConfigMap = async (
         Pick<DbPlainChartView, "name" | "chartConfigId">
     >(knex, `SELECT name, chartConfigId FROM chart_views`)
     return Object.fromEntries(rows.map((row) => [row.name, row.chartConfigId]))
+}
+
+export const getAllChartViewNames = async (
+    knex: db.KnexReadonlyTransaction
+): Promise<Set<string>> => {
+    const rows =
+        await knex<DbPlainChartView>(ChartViewsTableName).select("name")
+    return new Set(rows.map((row) => row.name))
 }

--- a/db/model/Gdoc/GdocBase.ts
+++ b/db/model/Gdoc/GdocBase.ts
@@ -67,7 +67,7 @@ import {
     OwidGdocLinkType,
     OwidGdocType,
 } from "@ourworldindata/types"
-import { getChartViewsInfo } from "../ChartView.js"
+import { getAllChartViewNames, getChartViewsInfo } from "../ChartView.js"
 
 export class GdocBase implements OwidGdocBaseInterface {
     id!: string
@@ -801,12 +801,12 @@ export class GdocBase implements OwidGdocBaseInterface {
             []
         )
 
-        const chartIdsBySlug = await mapSlugsToIds(knex)
-        const publishedExplorersBySlug =
-            await db.getPublishedExplorersBySlug(knex)
-        const chartViewNames = await getChartViewsInfo(knex)
-            .then((cv) => cv.map((c) => c.name))
-            .then((chartViewNames) => new Set(chartViewNames))
+        const [chartIdsBySlug, publishedExplorersBySlug, chartViewNames] =
+            await Promise.all([
+                mapSlugsToIds(knex),
+                db.getPublishedExplorersBySlug(knex),
+                getAllChartViewNames(knex),
+            ])
 
         const linkErrors: OwidGdocErrorMessage[] = []
         for (const link of this.links) {


### PR DESCRIPTION
Loading times for the preview page and related API calls seem to be highly variable, but my rudimentary comparison between the staging and prod admin shows around ~1 s improvement:

* https://admin.owid.io/admin/gdocs/19AlSstYCtGglhNNt9mbKGAEf_oZcQTKNjYJ-5BlXSts/preview
* http://staging-site-speed-up-gdoc-preview/admin/gdocs/19AlSstYCtGglhNNt9mbKGAEf_oZcQTKNjYJ-5BlXSts/preview