### PR TITLE
🎉 remove "**" from gpt-generated alt text

### DIFF
--- a/adminSiteServer/imagesHelpers.ts
+++ b/adminSiteServer/imagesHelpers.ts
@@ -119,6 +119,7 @@ export async function fetchGptGeneratedAltText(url: string) {
                 content: `Generate alt text for this image, describing it for a vision impaired person using a screen reader.
 Do not say "alt text:".
 Do not say "The image...".
+Do not use markdown in the text.
 If the image is a data visualization and there are data sources in the footer, describe them exhaustively.`,
             },
             {
@@ -136,5 +137,10 @@ If the image is a data visualization and there are data sources in the footer, d
         model: "gpt-4o-mini",
     })
 
-    return completion.choices[0].message.content
+    const content = completion.choices[0].message.content
+    if (content) {
+        // Sometimes the model still uses markdown bold even when told not to.
+        return content.replaceAll("**", "")
+    }
+    return null
 }

--- a/db/migration/1745941683275-NoMarkdownInAltText.ts
+++ b/db/migration/1745941683275-NoMarkdownInAltText.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class NoMarkdownInAltText1745941683275 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`-- sql
+            UPDATE images
+            SET defaultAlt = REPLACE(defaultAlt, '**', '')
+            WHERE defaultAlt LIKE '%**%'
+        `)
+    }
+
+    public async down(_: QueryRunner): Promise<void> {
+        // no-op
+    }
+}


### PR DESCRIPTION
GPT-4 was adding bold formatting to the alt text it was generating for us. This should fix it.

<img width="661" alt="image" src="https://github.com/user-attachments/assets/92ed92c7-25ed-4d37-ac5a-318e8f9f9c53" />
