### PR TITLE
enhance: reuse ColorScale for map tooltip

### DIFF
--- a/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
@@ -41,7 +41,7 @@ import {
     MAP_CHART_CLASSNAME,
 } from "./MapChartConstants"
 import { MapConfig } from "./MapConfig"
-import { ColorScale, ColorScaleManager } from "../color/ColorScale"
+import { ColorScale } from "../color/ColorScale"
 import {
     BASE_FONT_SIZE,
     GRAPHER_FRAME_PADDING_HORIZONTAL,
@@ -82,7 +82,6 @@ export class MapChart
     implements
         ChartInterface,
         HorizontalColorLegendManager,
-        ColorScaleManager,
         ChoroplethMapManager
 {
     /** The id of the currently hovered feature/country */
@@ -394,7 +393,7 @@ export class MapChart
         document.addEventListener("keydown", this.onDocumentKeyDown)
     }
 
-    @computed get legendData(): ColorScaleBin[] {
+    @computed private get legendData(): ColorScaleBin[] {
         return this.colorScale.legendBins
     }
 
@@ -697,7 +696,7 @@ export class MapChart
                         timeSeriesTable={this.inputTable}
                         formatValueIfCustom={this.formatTooltipValueIfCustom}
                         manager={this.manager}
-                        colorScaleManager={this}
+                        lineColorScale={this.colorScale}
                         targetTime={this.targetTime}
                         sparklineWidth={sparklineWidth}
                         dismissTooltip={() => {

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapTooltip.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapTooltip.tsx
@@ -9,7 +9,7 @@ import {
     makeTooltipRoundingNotice,
 } from "../tooltip/Tooltip"
 import { MapChartManager } from "./MapChartConstants"
-import { ColorScale, ColorScaleManager } from "../color/ColorScale"
+import { ColorScale } from "../color/ColorScale"
 import {
     Time,
     EntityName,
@@ -19,7 +19,6 @@ import {
 import { CoreColumn, OwidTable } from "@ourworldindata/core-table"
 import {
     isNumber,
-    AllKeysRequired,
     PrimitiveType,
     excludeUndefined,
     anyToString,
@@ -32,7 +31,7 @@ interface MapTooltipProps {
     entityName: EntityName
     manager: MapChartManager
     position?: PointVector
-    colorScaleManager: ColorScaleManager
+    lineColorScale: ColorScale
     formatValueIfCustom: (d: PrimitiveType) => string | undefined
     timeSeriesTable: OwidTable
     targetTime?: Time
@@ -86,18 +85,7 @@ export class MapTooltip
     }
 
     @computed get lineColorScale(): ColorScale {
-        const oldManager = this.props.colorScaleManager
-        // Make sure all ColorScaleManager props are included.
-        // We can't ...rest here because I think mobx computeds aren't
-        // enumerable or something.
-        const newManager: AllKeysRequired<ColorScaleManager> = {
-            colorScaleConfig: oldManager.colorScaleConfig,
-            hasNoDataBin: oldManager.hasNoDataBin,
-            defaultNoDataColor: oldManager.defaultNoDataColor,
-            defaultBaseColorScheme: oldManager.defaultBaseColorScheme,
-            colorScaleColumn: oldManager.colorScaleColumn,
-        }
-        return new ColorScale(newManager)
+        return this.props.lineColorScale
     }
 
     @computed private get showSparkline(): boolean {


### PR DESCRIPTION
Just something I noticed, which sometimes also makes map tooltips quite sluggish because `sortedNumericValues` needs to be re-computed again and again and again.