### PR TITLE
✨ add option to exclude sub-areas from parentTagArrays

### DIFF
--- a/adminSiteServer/app.test.ts
+++ b/adminSiteServer/app.test.ts
@@ -959,6 +959,7 @@ describe("OwidAdminApp: tag graph", { timeout: 10000 }, () => {
     const dummyTags: DbInsertTag[] = [
         { name: TagGraphRootName, id: 1  },
         { name: "Energy and Environment", id: 2  },
+        { name: "Climate & Air", id: 6 },
         { name: "Energy", slug: "energy", id: 3 },
         { name: "Nuclear Energy", slug: "nuclear-energy", id: 4 },
         { name: "CO2 & Greenhouse Gas Emissions", slug: "co2-and-greenhouse-gas-emissions", id: 5 },
@@ -966,8 +967,9 @@ describe("OwidAdminApp: tag graph", { timeout: 10000 }, () => {
 
     const dummyTagGraph: DbInsertTagGraphNode[] = [
         { parentId: 1, childId: 2 },
+        { parentId: 2, childId: 6 },
         { parentId: 2, childId: 3, weight: 110 },
-        { parentId: 2, childId: 5 },
+        { parentId: 6, childId: 5 },
         { parentId: 3, childId: 4 },
         { parentId: 5, childId: 4 },
     ]
@@ -1008,6 +1010,12 @@ describe("OwidAdminApp: tag graph", { timeout: 10000 }, () => {
         expect(tags).toEqual({
             tags: [
                 {
+                    id: 6,
+                    isTopic: 0,
+                    name: "Climate & Air",
+                    slug: null,
+                },
+                {
                     id: 5,
                     isTopic: 1,
                     name: "CO2 & Greenhouse Gas Emissions",
@@ -1040,6 +1048,63 @@ describe("OwidAdminApp: tag graph", { timeout: 10000 }, () => {
             ],
         })
     })
+    it("should be able to generate parent tag arrays with sub-areas", async () => {
+        await knexReadonlyTransaction(async (trx) => {
+            const parentTagArraysByChildName =
+                await getParentTagArraysByChildName(trx)
+
+            expect(
+                parentTagArraysByChildName["CO2 & Greenhouse Gas Emissions"]
+            ).toEqual([
+                [
+                    {
+                        id: 2,
+                        name: "Energy and Environment",
+                        slug: null,
+                    },
+                    {
+                        id: 6,
+                        name: "Climate & Air",
+                        slug: null,
+                    },
+                    {
+                        id: 5,
+                        name: "CO2 & Greenhouse Gas Emissions",
+                        slug: "co2-and-greenhouse-gas-emissions",
+                    },
+                ],
+            ])
+        })
+    })
+
+    it("should be able to generate parent tag arrays without sub-areas", async () => {
+        await knexReadonlyTransaction(async (trx) => {
+            const parentTagArraysByChildName =
+                await getParentTagArraysByChildName(trx, true)
+
+            console.log(
+                "parentTagArraysByChildName without sub-areas",
+                parentTagArraysByChildName
+            )
+
+            expect(
+                parentTagArraysByChildName["CO2 & Greenhouse Gas Emissions"]
+            ).toEqual([
+                [
+                    {
+                        id: 2,
+                        name: "Energy and Environment",
+                        slug: null,
+                    },
+                    {
+                        id: 5,
+                        name: "CO2 & Greenhouse Gas Emissions",
+                        slug: "co2-and-greenhouse-gas-emissions",
+                    },
+                ],
+            ])
+        })
+    })
 
     it("should be able to generate a tag graph", async () => {
         const json = await fetchJsonFromAdminApi("/flatTagGraph.json")
@@ -1064,10 +1129,10 @@ describe("OwidAdminApp: tag graph", { timeout: 10000 }, () => {
                     weight: 110,
                 },
                 {
-                    childId: 5,
-                    isTopic: 1,
-                    name: "CO2 & Greenhouse Gas Emissions",
-                    slug: "co2-and-greenhouse-gas-emissions",
+                    childId: 6,
+                    isTopic: 0,
+                    name: "Climate & Air",
+                    slug: null,
                     parentId: 2,
                     weight: 100,
                 },
@@ -1089,6 +1154,16 @@ describe("OwidAdminApp: tag graph", { timeout: 10000 }, () => {
                     name: "Nuclear Energy",
                     slug: "nuclear-energy",
                     parentId: 5,
+                    weight: 100,
+                },
+            ],
+            "6": [
+                {
+                    childId: 5,
+                    isTopic: 1,
+                    name: "CO2 & Greenhouse Gas Emissions",
+                    parentId: 6,
+                    slug: "co2-and-greenhouse-gas-emissions",
                     weight: 100,
                 },
             ],
@@ -1179,25 +1254,25 @@ describe("OwidAdminApp: tag graph", { timeout: 10000 }, () => {
                 // 2. Human Rights > Women's Rights > Women's Employment
                 // prettier-ignore
                 await testKnexInstance!(TagsTableName).insert([
-                    { name: "Human Rights", id: 6 },
-                    { name: "Women's Rights", slug: "womens-rights", id: 7 },
-                    { name: "Women's Employment", slug: "womens-employment", id: 8 },
-                    { name: "Poverty and Economic Development", id: 9 },
+                    { name: "Human Rights", id: 7 },
+                    { name: "Women's Rights", slug: "womens-rights", id: 8 },
+                    { name: "Women's Employment", slug: "womens-employment", id: 9 },
+                    { name: "Poverty and Economic Development", id: 10 },
                 ])
                 await testKnexInstance!(TagGraphTableName).insert([
-                    { parentId: 1, childId: 6 },
-                    { parentId: 6, childId: 7 },
+                    { parentId: 1, childId: 7 },
                     { parentId: 7, childId: 8 },
-                    { parentId: 1, childId: 9 },
-                    { parentId: 9, childId: 8 },
+                    { parentId: 8, childId: 9 },
+                    { parentId: 1, childId: 10 },
+                    { parentId: 10, childId: 9 },
                 ])
                 await testKnexInstance!(PostsGdocsTableName).insert([
                     makeDummyTopicPage("womens-rights"),
                     makeDummyTopicPage("womens-employment"),
                 ])
                 await testKnexInstance!(PostsGdocsXTagsTableName).insert([
-                    { gdocId: "womens-rights", tagId: 7 },
-                    { gdocId: "womens-employment", tagId: 8 },
+                    { gdocId: "womens-rights", tagId: 8 },
+                    { gdocId: "womens-employment", tagId: 9 },
                 ])
 
                 const parentTagArraysByChildName =
@@ -1205,7 +1280,7 @@ describe("OwidAdminApp: tag graph", { timeout: 10000 }, () => {
                 const breadcrumbs = getBestBreadcrumbs(
                     [
                         {
-                            id: 8,
+                            id: 9,
                             name: "Women's Employment",
                             slug: "womens-employment",
                         },

--- a/baker/algolia/utils/charts.ts
+++ b/baker/algolia/utils/charts.ts
@@ -102,8 +102,10 @@ export const getChartsRecords = async (
 
     const pageviews = await getAnalyticsPageviewsByUrlObj(knex)
 
-    const parentTagArraysByChildName =
-        await db.getParentTagArraysByChildName(knex)
+    const parentTagArraysByChildName = await db.getParentTagArraysByChildName(
+        knex,
+        true
+    )
 
     const records: ChartRecord[] = []
     for (const c of parsedRows) {

--- a/baker/algolia/utils/explorerViews.ts
+++ b/baker/algolia/utils/explorerViews.ts
@@ -761,7 +761,7 @@ async function getExplorersWithInheritedTags(trx: db.KnexReadonlyTransaction) {
     // The DB query gets the tags for the explorer, but we need to add the parent tags as well.
     // This isn't done in the query because it would require a recursive CTE.
     // It's easier to write that query once, separately, and reuse it.
-    const parentTagArrays = await db.getParentTagArraysByChildName(trx)
+    const parentTagArrays = await db.getParentTagArraysByChildName(trx, true)
     const publishedExplorersWithTags = []
 
     for (const explorer of Object.values(explorersBySlug)) {

--- a/baker/algolia/utils/mdimViews.ts
+++ b/baker/algolia/utils/mdimViews.ts
@@ -123,7 +123,7 @@ async function getMultiDimDataPagesWithInheritedTags(
     trx: db.KnexReadonlyTransaction
 ) {
     const multiDims = await getAllPublishedMultiDimDataPages(trx)
-    const parentTagArrays = await db.getParentTagArraysByChildName(trx)
+    const parentTagArrays = await db.getParentTagArraysByChildName(trx, true)
 
     const result = []
     for (const multiDim of multiDims) {


### PR DESCRIPTION
We don't want to index sub-areas to algolia, because they pollute the data catalog

<img width="1305" alt="image" src="https://github.com/user-attachments/assets/4e926c14-7825-4f28-b9dd-4d0f1af219e5" />


This PR changes the indexing scripts so that only areas and topics are included in each record's tags array.