### PR TITLE
🎉 support slope as default for line+slope charts

### DIFF
--- a/packages/@ourworldindata/grapher/src/chart/ChartUtils.tsx
+++ b/packages/@ourworldindata/grapher/src/chart/ChartUtils.tsx
@@ -13,6 +13,8 @@ import {
     GrapherChartType,
     GRAPHER_CHART_TYPES,
     GRAPHER_TAB_QUERY_PARAMS,
+    GrapherTabOption,
+    GRAPHER_TAB_OPTIONS,
     InteractionState,
     SeriesName,
     GrapherInterface,
@@ -188,6 +190,32 @@ export function mapChartTypeNameToQueryParam(
             return GRAPHER_TAB_QUERY_PARAMS["stacked-discrete-bar"]
         case GRAPHER_CHART_TYPES.Marimekko:
             return GRAPHER_TAB_QUERY_PARAMS.marimekko
+    }
+}
+
+export function mapTabOptionToChartTypeName(
+    chartTab: GrapherTabOption
+): GrapherChartType | undefined {
+    switch (chartTab) {
+        case GRAPHER_TAB_OPTIONS.line:
+            return GRAPHER_CHART_TYPES.LineChart
+        case GRAPHER_TAB_OPTIONS.slope:
+            return GRAPHER_CHART_TYPES.SlopeChart
+        default:
+            return undefined
+    }
+}
+
+export function mapChartTypeNameToTabOption(
+    chartType: GrapherChartType
+): GrapherTabOption {
+    switch (chartType) {
+        case GRAPHER_CHART_TYPES.LineChart:
+            return GRAPHER_TAB_OPTIONS.line
+        case GRAPHER_CHART_TYPES.SlopeChart:
+            return GRAPHER_TAB_OPTIONS.slope
+        default:
+            return GRAPHER_TAB_OPTIONS.chart
     }
 }
 

--- a/packages/@ourworldindata/grapher/src/core/Grapher.test.ts
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.test.ts
@@ -76,25 +76,39 @@ it("can get dimension slots", () => {
     expect(grapher.dimensionSlots.length).toBe(4)
 })
 
-it("an empty Grapher serializes to an object that includes only the schema", () => {
-    expect(new Grapher().toObject()).toEqual({
-        $schema: latestGrapherConfigSchema,
+describe("toObject", () => {
+    it("an empty Grapher serializes to an object that includes only the schema", () => {
+        expect(new Grapher().toObject()).toEqual({
+            $schema: latestGrapherConfigSchema,
+        })
     })
-})
 
-it("a bad chart type does not crash grapher", () => {
-    const input = {
-        chartTypes: ["fff" as any],
-    }
-    expect(new Grapher(input).toObject()).toEqual({
-        ...input,
-        $schema: latestGrapherConfigSchema,
+    it("a bad chart type does not crash grapher", () => {
+        const input = {
+            chartTypes: ["fff" as any],
+        }
+        expect(new Grapher(input).toObject()).toEqual({
+            ...input,
+            $schema: latestGrapherConfigSchema,
+        })
     })
-})
 
-it("does not preserve defaults in the object (except for the schema)", () => {
-    expect(new Grapher({ tab: GRAPHER_TAB_OPTIONS.chart }).toObject()).toEqual({
-        $schema: latestGrapherConfigSchema,
+    it("does not preserve defaults in the object (except for the schema)", () => {
+        expect(
+            new Grapher({ tab: GRAPHER_TAB_OPTIONS.chart }).toObject()
+        ).toEqual({ $schema: latestGrapherConfigSchema })
+    })
+
+    it("serialises the currently active chart tab", () => {
+        const grapher = new Grapher({
+            chartTypes: ["LineChart", "SlopeChart"],
+            tab: "slope",
+        })
+        expect(grapher.toObject()).toEqual({
+            $schema: latestGrapherConfigSchema,
+            chartTypes: ["LineChart", "SlopeChart"],
+            tab: "slope",
+        })
     })
 })
 

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -110,12 +110,13 @@ import {
     GRAPHER_TAB_OPTIONS,
     GRAPHER_TAB_NAMES,
     GRAPHER_TAB_QUERY_PARAMS,
-    GrapherTabOption,
     SeriesName,
     ChartViewInfo,
     OwidChartDimensionInterfaceWithMandatorySlug,
     AssetMap,
     ArchivedChartOrArchivePageMeta,
+    GrapherTabType,
+    GRAPHER_TAB_TYPES,
 } from "@ourworldindata/types"
 import {
     BlankOwidTable,
@@ -203,7 +204,9 @@ import {
     findStartTimeForSlopeChart,
     findValidChartTypeCombination,
     mapChartTypeNameToQueryParam,
+    mapChartTypeNameToTabOption,
     mapQueryParamToChartTypeName,
+    mapTabOptionToChartTypeName,
 } from "../chart/ChartUtils"
 import classnames from "classnames"
 import { GrapherAnalytics } from "./GrapherAnalytics"
@@ -417,7 +420,7 @@ export class Grapher
     @observable.ref zoomToSelection?: boolean = undefined
     @observable.ref showYearLabels?: boolean = undefined // Always show year in labels for bar charts
     @observable.ref hasMapTab = false
-    @observable.ref tab: GrapherTabOption = GRAPHER_TAB_OPTIONS.chart
+    @observable.ref tab: GrapherTabType = GRAPHER_TAB_TYPES.chart
     @observable.ref chartTab?: GrapherChartType
     @observable.ref isPublished?: boolean = undefined
     @observable.ref baseColorScheme?: ColorSchemeName = undefined
@@ -615,6 +618,15 @@ export class Grapher
         if (obj.timelineMaxTime)
             obj.timelineMaxTime = maxTimeToJSON(this.timelineMaxTime) as any
 
+        // store the currently selected chart type if it's different from the primary chart type
+        if (
+            this.tab === GRAPHER_TAB_OPTIONS.chart &&
+            this.chartTab &&
+            this.chartTab !== this.chartType
+        ) {
+            obj.tab = mapChartTypeNameToTabOption(this.chartTab)
+        }
+
         // todo: remove dimensions concept
         // if (this.legacyConfigAsAuthored?.dimensions)
         //     obj.dimensions = this.legacyConfigAsAuthored.dimensions
@@ -656,6 +668,15 @@ export class Grapher
         this.timelineMaxTime = maxTimeBoundFromJSONOrPositiveInfinity(
             obj.timelineMaxTime
         )
+
+        // map the `tab` param to grapher state
+        if (obj.tab) {
+            const chartType = mapTabOptionToChartTypeName(obj.tab)
+            if (chartType) {
+                this.tab = GRAPHER_TAB_OPTIONS.chart
+                this.chartTab = chartType
+            }
+        }
 
         // Todo: remove once we are more RAII.
         if (obj?.dimensions?.length)

--- a/packages/@ourworldindata/grapher/src/core/GrapherUrl.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherUrl.ts
@@ -31,7 +31,6 @@ export const grapherConfigToQueryParams = (
         keyof GrapherQueryParams,
         string | number | boolean | undefined
     > = {
-        // TODO this can currently only be "chart", "map", or "table", but we should also allow for "slope" or "line" some way
         tab: config.tab,
         xScale: config.xAxis?.scaleType,
         yScale: config.yAxis?.scaleType,

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.007.yaml
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.007.yaml
@@ -128,6 +128,8 @@ properties:
             - chart
             - map
             - table
+            - line
+            - slope
     matchingEntitiesOnly:
         type: boolean
         default: false

--- a/packages/@ourworldindata/types/src/grapherTypes/GrapherConstants.ts
+++ b/packages/@ourworldindata/types/src/grapherTypes/GrapherConstants.ts
@@ -20,6 +20,15 @@ export const GRAPHER_CHART_TYPES = {
 export const ALL_GRAPHER_CHART_TYPES = Object.values(GRAPHER_CHART_TYPES)
 
 /**
+ * The different types of Grapher tabs
+ */
+export const GRAPHER_TAB_TYPES = {
+    table: "table",
+    map: "map",
+    chart: "chart",
+} as const
+
+/**
  * Grapher tab specified in the config that determines the default tab to show.
  * If `chart` is selected and Grapher has more than one chart tab, then the
  * first chart tab will be active.
@@ -28,6 +37,8 @@ export const GRAPHER_TAB_OPTIONS = {
     table: "table",
     map: "map",
     chart: "chart",
+    line: "line",
+    slope: "slope",
 } as const
 
 /**

--- a/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
+++ b/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
@@ -13,6 +13,7 @@ import {
     GRAPHER_TAB_NAMES,
     GRAPHER_TAB_OPTIONS,
     GRAPHER_TAB_QUERY_PARAMS,
+    GRAPHER_TAB_TYPES,
 } from "./GrapherConstants.js"
 
 export interface Box {
@@ -176,6 +177,7 @@ export type GrapherMapType = typeof GRAPHER_MAP_TYPE
 export type GrapherChartType = keyof typeof GRAPHER_CHART_TYPES
 export type GrapherChartOrMapType = GrapherChartType | GrapherMapType
 
+export type GrapherTabType = keyof typeof GRAPHER_TAB_TYPES
 export type GrapherTabOption = keyof typeof GRAPHER_TAB_OPTIONS
 export type GrapherTabQueryParam = keyof typeof GRAPHER_TAB_QUERY_PARAMS
 export type GrapherTabName = keyof typeof GRAPHER_TAB_NAMES

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -49,6 +49,7 @@ export {
     GRAPHER_TAB_NAMES,
     GRAPHER_TAB_OPTIONS,
     GRAPHER_TAB_QUERY_PARAMS,
+    GRAPHER_TAB_TYPES,
     ALL_GRAPHER_CHART_TYPES,
 } from "./grapherTypes/GrapherConstants.js"
 
@@ -83,6 +84,7 @@ export {
     type GrapherTabOption,
     type GrapherTabName,
     type GrapherTabQueryParam,
+    type GrapherTabType,
     type GrapherChartType,
     StackMode,
     EntitySelectionMode,

--- a/site/gdocs/components/KeyIndicatorCollection.tsx
+++ b/site/gdocs/components/KeyIndicatorCollection.tsx
@@ -30,6 +30,8 @@ const HEIGHT_ANIMATION_DURATION_IN_SECONDS = 0.4
 
 const tabIconMap: Record<GrapherTabOption, IconDefinition> = {
     [GRAPHER_TAB_OPTIONS.chart]: faChartLine,
+    [GRAPHER_TAB_OPTIONS.line]: faChartLine,
+    [GRAPHER_TAB_OPTIONS.slope]: faChartLine,
     [GRAPHER_TAB_OPTIONS.map]: faEarthAmericas,
     [GRAPHER_TAB_OPTIONS.table]: faTable,
 }


### PR DESCRIPTION
Resolves #4573

Adds support for slope charts being the default in line/slope chart combinations.

More concretely, adds support for 'line' and 'slope' options to the `tab` config field, in addition to the currently available options, 'table', 'map' and 'chart'. If `tab` is 'chart' and there are more than one chart type in Grapher, the first chart type is shown by default.

### Technical details

- Tabs are handled on two levels in Grapher:
    - `tab` is 'table', 'map' or 'chart' (these options map to the config's tab field)
    - if `tab` is 'chart', then `chartTab` determines the currently active chart type
- `toObject()` serialises Grapher into a config object
    - if the active tab is different from the first chart type, it's stored in the config
- `updateFromObject()` constructs Grapher from a config object
    - if `tab` refers to a chart type, then `tab` and `chartTab` are set accordingly 

### Testing

- Go to http://staging-site-slope-as-default/admin/charts/712/edit
- Select the slope chart
- Refresh
- Note that the slope chart tab is shown by default

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 7 in a stack** made with GitButler:
- <kbd>&nbsp;7&nbsp;</kbd> #4843 
- <kbd>&nbsp;6&nbsp;</kbd> #4842 
- <kbd>&nbsp;5&nbsp;</kbd> #4841 
- <kbd>&nbsp;4&nbsp;</kbd> #4839 
- <kbd>&nbsp;3&nbsp;</kbd> #4838 
- <kbd>&nbsp;2&nbsp;</kbd> #4833 
- <kbd>&nbsp;1&nbsp;</kbd> #4832 👈 
<!-- GitButler Footer Boundary Bottom -->

