### PR TITLE
🚧 (wip) grapher configs of explorer views

### DIFF
--- a/db/migration/1746446180336-AddExplorerViewsTable.ts
+++ b/db/migration/1746446180336-AddExplorerViewsTable.ts
@@ -1,0 +1,20 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class AddExplorerViewsTable1746446180336 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`-- sql
+            CREATE TABLE explorer_views (
+                id INT AUTO_INCREMENT PRIMARY KEY,
+                explorerSlug varchar(255) NOT NULL,
+                explorerView json NOT NULL,
+                grapherConfig json NOT NULL
+            )
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`-- sql
+            DROP TABLE explorer_views
+        `)
+    }
+}

--- a/db/refreshExplorerViews.ts
+++ b/db/refreshExplorerViews.ts
@@ -1,0 +1,315 @@
+import {
+    ExplorerChartCreationMode,
+    ExplorerProgram,
+    ExplorerGrapherInterface,
+} from "@ourworldindata/explorer"
+import * as db from "./db.js"
+import {
+    CoreRow,
+    DbPlainExplorer,
+    DimensionProperty,
+    GrapherInterface,
+    OwidChartDimensionInterface,
+    OwidColumnDef,
+    DbInsertExplorerView,
+    serializeChartConfig,
+} from "@ourworldindata/types"
+import {
+    excludeUndefined,
+    mergeGrapherConfigs,
+    omitUndefinedValues,
+    parseIntOrUndefined,
+    PartialBy,
+    RequiredBy,
+} from "@ourworldindata/utils"
+import { defaultGrapherConfig } from "@ourworldindata/grapher"
+import { transformExplorerProgramToResolveCatalogPaths } from "../baker/ExplorerBaker.js"
+import { getChartConfigById } from "./model/Chart.js"
+import { getMergedGrapherConfigForVariable } from "./model/Variable.js"
+import * as R from "remeda"
+
+// This scrips constructs Grapher configs for every view in an explorer.
+// The constructed Grapher configs are an approximation of the actual Grapher
+// configs; they are not guaranteed to be complete or correct. In particular,
+// - column transforms, including the `duplicate` transform, are not taken into account
+// - the dimension's `display` field doesn't necessarily doesn't adhere to the schema;
+// (e.g. it simply contains all specified fields in the columns section)
+
+function columnDefToDimensionObject(
+    colDef?: OwidColumnDef
+): Partial<OwidChartDimensionInterface> {
+    if (!colDef) return {}
+    return omitUndefinedValues({
+        variableId: colDef.owidVariableId,
+        slug: colDef.slug,
+        // pipe all fields of the explorer's column grammar into the display field
+        // this is not necessarilly correct; we need to add a translation step here
+        display: R.omit(colDef, ["slug", "owidVariableId", "catalogPath"]),
+    })
+}
+
+function getPrimaryYVariableId(
+    explorerRow: ExplorerGrapherInterface
+): number | undefined {
+    const yVariableIdsList: number[] = explorerRow.yVariableIds
+        ? excludeUndefined(
+              explorerRow.yVariableIds.split(" ").map(parseIntOrUndefined)
+          )
+        : []
+    return yVariableIdsList[0]
+}
+
+async function getGrapherConfigByIdForExplorerRow(
+    knex: db.KnexReadonlyTransaction,
+    explorerRow: ExplorerGrapherInterface
+): Promise<GrapherInterface | undefined> {
+    const { grapherId } = explorerRow
+    if (!grapherId) return
+    return (await getChartConfigById(knex, grapherId))?.config
+}
+
+async function getVariableGrapherConfigForExplorerRow(
+    knex: db.KnexReadonlyTransaction,
+    explorerRow: ExplorerGrapherInterface
+): Promise<GrapherInterface | undefined> {
+    const yVariableId = getPrimaryYVariableId(explorerRow)
+    if (!yVariableId) return
+    return getMergedGrapherConfigForVariable(knex, yVariableId)
+}
+
+async function fetchBaseGrapherConfigForMode(
+    knex: db.KnexReadonlyTransaction,
+    mode: ExplorerChartCreationMode,
+    explorerRow: ExplorerGrapherInterface
+): Promise<GrapherInterface | undefined> {
+    switch (mode) {
+        case ExplorerChartCreationMode.FromGrapherId:
+            return getGrapherConfigByIdForExplorerRow(knex, explorerRow)
+        case ExplorerChartCreationMode.FromVariableIds:
+            return getVariableGrapherConfigForExplorerRow(knex, explorerRow)
+        case ExplorerChartCreationMode.FromExplorerTableColumnSlugs:
+            // csv-based explorers only rely on the explorer config
+            return
+    }
+}
+
+function constructDimensionsForVariableIds(
+    explorerProgram: ExplorerProgram,
+    grapherRow: CoreRow
+): OwidChartDimensionInterface[] | undefined {
+    const colDefs = explorerProgram.columnDefsWithoutTableSlug
+    const colDefByVariableId = new Map(
+        colDefs.map((colDef) => [colDef.owidVariableId, colDef])
+    )
+
+    const yVariableIds: string[] = grapherRow.yVariableIds?.split(" ") ?? []
+    const variableIds: OwidChartDimensionInterface[] = [
+        ...yVariableIds.map((id) => ({
+            property: DimensionProperty.y,
+            variableId: parseIntOrUndefined(id),
+        })),
+        {
+            property: DimensionProperty.x,
+            variableId: parseIntOrUndefined(grapherRow.xVariableId),
+        },
+        {
+            property: DimensionProperty.color,
+            variableId: parseIntOrUndefined(grapherRow.colorVariableId),
+        },
+        {
+            property: DimensionProperty.size,
+            variableId: parseIntOrUndefined(grapherRow.sizeVariableId),
+        },
+    ].filter((obj): obj is OwidChartDimensionInterface => !!obj.variableId)
+
+    const dimensions = variableIds.map(({ property, variableId }) => ({
+        variableId,
+        property,
+        ...columnDefToDimensionObject(colDefByVariableId.get(variableId)),
+    }))
+
+    return dimensions
+}
+
+function constructDimensionsForTableColumnSlugs(
+    explorerProgram: ExplorerProgram,
+    grapherRow: CoreRow
+): PartialBy<OwidChartDimensionInterface, "variableId">[] | undefined {
+    const colDefsForTableSlug = explorerProgram.columnDefsByTableSlug.get(
+        grapherRow.tableSlug
+    )
+    const colDefBySlug = new Map(
+        colDefsForTableSlug?.map((colDef) => [colDef.slug, colDef]) ?? []
+    )
+
+    const ySlugs: string[] = grapherRow.ySlugs?.split(" ") ?? []
+    const slugs: RequiredBy<
+        PartialBy<OwidChartDimensionInterface, "variableId">,
+        "slug"
+    >[] = [
+        ...ySlugs.map((slug) => ({ property: DimensionProperty.y, slug })),
+        { property: DimensionProperty.x, slug: grapherRow.xSlug },
+        { property: DimensionProperty.color, slug: grapherRow.colorSlug },
+        { property: DimensionProperty.size, slug: grapherRow.sizeSlug },
+    ].filter((dim) => dim.slug)
+
+    const dimensions = slugs.map(({ property, slug }) => ({
+        slug,
+        property,
+        ...columnDefToDimensionObject(colDefBySlug.get(slug)),
+    }))
+
+    return dimensions
+}
+
+function constructDimensionsForMode(
+    mode: ExplorerChartCreationMode,
+    explorerProgram: ExplorerProgram,
+    grapherRow: CoreRow
+): PartialBy<OwidChartDimensionInterface, "variableId">[] | undefined {
+    switch (mode) {
+        case ExplorerChartCreationMode.FromGrapherId:
+            // grapher id based explorers don't support metadata overwrites
+            return
+
+        case ExplorerChartCreationMode.FromVariableIds:
+            return constructDimensionsForVariableIds(
+                explorerProgram,
+                grapherRow
+            )
+
+        case ExplorerChartCreationMode.FromExplorerTableColumnSlugs:
+            return constructDimensionsForTableColumnSlugs(
+                explorerProgram,
+                grapherRow
+            )
+    }
+}
+
+async function constructGrapherConfig(
+    knex: db.KnexReadonlyTransaction,
+    explorerProgram: ExplorerProgram,
+    grapherRow: CoreRow
+): Promise<GrapherInterface> {
+    // corresponds to a grapher row in the explorer config, i.e. contains
+    // choice params as well as explorer-flavoured grapher config
+    const parsedGrapherRow =
+        explorerProgram.constructExplorerGrapherConfig(grapherRow)
+
+    // translate explorer-flavoured grapher config to a valid grapher interface
+    const grapherConfigOverwrites =
+        explorerProgram.constructGrapherConfig(parsedGrapherRow)
+
+    // available modes: csv-based, indicator-based or grapher id-based
+    const mode =
+        explorerProgram.getChartCreationModeForExplorerGrapherConfig(
+            parsedGrapherRow
+        )
+
+    // fetch the underlying grapher config or variable config if necessary
+    const baseGrapherConfig = await fetchBaseGrapherConfigForMode(
+        knex,
+        mode,
+        parsedGrapherRow
+    )
+
+    // construct the config's dimensions array from the explorer's columns section
+    const dimensions = constructDimensionsForMode(
+        mode,
+        explorerProgram,
+        grapherRow
+    )
+
+    return mergeGrapherConfigs(
+        // variable-level config or config of the specified grapher id
+        baseGrapherConfig ?? {},
+        // grapher config specified in the explorer config
+        grapherConfigOverwrites ?? {},
+        // selection specified as global setting in the explorer config
+        {
+            $schema: defaultGrapherConfig.$schema,
+            selectedEntityNames: explorerProgram.selection,
+        },
+        // chart dimensions
+        // @ts-expect-error csv-based explorers don't use variable ids
+        { $schema: defaultGrapherConfig.$schema, dimensions }
+    )
+}
+
+async function fetchPublishedExplorers(
+    knex: db.KnexReadonlyTransaction
+): Promise<Pick<DbPlainExplorer, "slug" | "tsv">[]> {
+    return db.knexRaw(
+        knex,
+        `-- sql
+            SELECT slug, tsv
+            FROM explorers
+            WHERE isPublished IS TRUE
+        `
+    )
+}
+
+async function prepareGrapherConfigsForExplorerViews(
+    knex: db.KnexReadWriteTransaction
+): Promise<void> {
+    await db.knexRaw(knex, "TRUNCATE TABLE explorer_views")
+
+    const explorers = await fetchPublishedExplorers(knex)
+
+    for (const explorer of explorers) {
+        console.info("Processing... " + explorer.slug)
+
+        const explorerViews: DbInsertExplorerView[] = []
+
+        // init explorer program
+        const rawExplorerProgram = new ExplorerProgram(
+            explorer.slug,
+            explorer.tsv
+        )
+
+        // map catalog paths to indicator ids if necessary
+        const explorerProgram = (
+            await transformExplorerProgramToResolveCatalogPaths(
+                rawExplorerProgram,
+                knex
+            )
+        ).program
+
+        // iterate over all grapher rows in the explorer and construct a
+        // grapher config for every row
+        const grapherRows = explorerProgram.decisionMatrix.table.rows
+        for (const grapherRow of grapherRows) {
+            const view =
+                explorerProgram.decisionMatrix.getChoiceParamsForRow(grapherRow)
+
+            const config = await constructGrapherConfig(
+                knex,
+                explorerProgram,
+                grapherRow
+            )
+
+            explorerViews.push({
+                explorerSlug: explorer.slug,
+                explorerView: JSON.stringify(view),
+                grapherConfig: serializeChartConfig(config),
+            })
+        }
+
+        await knex.transaction(async (trx) => {
+            await trx.batchInsert("explorer_views", explorerViews)
+        })
+    }
+}
+
+const main = async (): Promise<void> => {
+    try {
+        await db.knexReadWriteTransaction(
+            (trx) => prepareGrapherConfigsForExplorerViews(trx),
+            db.TransactionCloseMode.Close
+        )
+    } catch (e) {
+        console.error(e)
+    }
+}
+
+void main()

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
         "runRegionsUpdater": "tsx --tsconfig tsconfig.tsx.json devTools/regionsUpdater/update.ts",
         "runDbMigrations": "tsx --tsconfig tsconfig.tsx.json node_modules/typeorm/cli.js migration:run -d db/dataSource.ts",
         "refreshPageviews": "tsx --tsconfig tsconfig.tsx.json db/refreshPageviewsFromDatasette.ts",
+        "refreshExplorerViews": "tsx --tsconfig tsconfig.tsx.json db/refreshExplorerViews.ts",
         "revertLastDbMigration": "tsx --tsconfig tsconfig.tsx.json node_modules/typeorm/cli.js migration:revert -d db/dataSource.ts",
         "startAdminServer": "node --enable-source-maps ./itsJustJavascript/adminSiteServer/app.js",
         "startAdminDevServer": "tsx watch --ignore '**.mjs' --tsconfig tsconfig.tsx.json adminSiteServer/app.ts",

--- a/packages/@ourworldindata/explorer/src/ExplorerDecisionMatrix.ts
+++ b/packages/@ourworldindata/explorer/src/ExplorerDecisionMatrix.ts
@@ -7,7 +7,7 @@ import {
     uniq,
     parseIntOrUndefined,
 } from "@ourworldindata/utils"
-import { ColumnTypeNames } from "@ourworldindata/types"
+import { ColumnTypeNames, CoreRow } from "@ourworldindata/types"
 import {
     CoreTable,
     detectDelimiter,
@@ -308,6 +308,14 @@ export class DecisionMatrix {
             result[choiceName] = this.allChoiceOptions[choiceName].filter(
                 (option) => this.isOptionAvailable(choiceName, option)
             )
+        })
+        return result
+    }
+
+    getChoiceParamsForRow(row: CoreRow): ExplorerChoiceParams {
+        const result: ExplorerChoiceParams = {}
+        this.choiceNames.forEach((choiceName) => {
+            result[choiceName] = row[choiceName]
         })
         return result
     }

--- a/packages/@ourworldindata/explorer/src/index.ts
+++ b/packages/@ourworldindata/explorer/src/index.ts
@@ -36,6 +36,7 @@ export {
     ExplorerProgram,
     EXPLORER_FILE_SUFFIX,
     makeFullPath,
+    type ExplorerGrapherInterface,
 } from "./ExplorerProgram.js"
 
 export { type ExplorerPageUrlMigrationSpec } from "./urlMigrations/ExplorerPageUrlMigrationSpec.js"

--- a/packages/@ourworldindata/types/src/dbTypes/ExplorerViews.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/ExplorerViews.ts
@@ -1,0 +1,41 @@
+import { JsonString } from "../domainTypes/Various"
+import { GrapherInterface } from "../grapherTypes/GrapherTypes"
+import { parseChartConfig, serializeChartConfig } from "./ChartConfigs"
+
+export const ExplorerViewsTableName = "explorer_views"
+export interface DbInsertExplorerView {
+    id?: number
+    explorerSlug: string
+    explorerView: JsonString
+    grapherConfig: JsonString
+}
+
+export type DbRawExplorerView = Required<DbInsertExplorerView>
+
+export type DbEnrichedExplorerView = Omit<
+    DbRawExplorerView,
+    "explorerView" | "grapherConfig"
+> & {
+    explorerView: Record<string, string>
+    grapherConfig: GrapherInterface
+}
+
+export function parseExplorerViewRow(
+    row: Pick<DbRawExplorerView, "explorerView" | "grapherConfig">
+): Pick<DbEnrichedExplorerView, "explorerView" | "grapherConfig"> {
+    return {
+        ...row,
+        explorerView: JSON.parse(row.explorerView),
+        grapherConfig: parseChartConfig(row.grapherConfig),
+    }
+}
+
+export function serializeChartsRow(
+    row: DbEnrichedExplorerView
+): DbRawExplorerView {
+    return {
+        ...row,
+        explorerView: JSON.stringify(row.explorerView),
+        grapherConfig: serializeChartConfig(row.grapherConfig),
+    }
+}

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -734,6 +734,12 @@ export {
 
 export { RedirectCode, type DbPlainRedirect } from "./dbTypes/Redirects.js"
 
+export {
+    type DbInsertExplorerView,
+    type DbRawExplorerView,
+    type DbEnrichedExplorerView,
+} from "./dbTypes/ExplorerViews.js"
+
 export { type Nominal, wrap, unwrap } from "./NominalType.js"
 
 export {


### PR DESCRIPTION
Stitches Grapher configs together for every view in an explorer and stores it in a table. It's work in progress (I stopped mid implemention)

Parked since Martin will work on one-table-for-all-chart-views this cycle and this fits into his work.

A better approach is to wait for the Grapher state refactor to land, then instantiate an Explorer, go through every view and extract the grapher config used (similar to how it's done for explorer thumbnails, but without downloading data for every view.)

If that doesn't work for some reason and we do need to stitch Grapher configs together, then there are at least two more things that need to be done here:
- Add support for the `duplicate` transform column
- Translate column defs specified in the columns section to valid grapher config fields

There is probably more to do to make this right (I stopped mid-implementation so haven't tested this extensively)