### PR TITLE
Fix grapher view analytics events in mdims

### DIFF
--- a/site/multiDim/MultiDim.tsx
+++ b/site/multiDim/MultiDim.tsx
@@ -63,16 +63,13 @@ export default function MultiDim({
 
     const handleSettingsChange = useCallback(
         (settings: MultiDimDimensionChoices) => {
-            setSettings(
-                config.filterToAvailableChoices(settings).selectedChoices
-            )
+            const { selectedChoices } =
+                config.filterToAvailableChoices(settings)
+            setSettings(selectedChoices)
+            if (slug) analytics.logGrapherView(slug, { view: selectedChoices })
         },
-        [config]
+        [config, slug]
     )
-
-    useEffect(() => {
-        if (slug) analytics.logGrapherView(slug, { view: settings })
-    }, [slug, settings])
 
     useEffect(() => {
         // Prevent a race condition from setting incorrect data.

--- a/site/multiDim/MultiDimDataPageContent.tsx
+++ b/site/multiDim/MultiDimDataPageContent.tsx
@@ -172,10 +172,6 @@ export function DataPageContent({
         return config.filterToAvailableChoices(choices).selectedChoices
     }, [searchParams, config])
 
-    useEffect(() => {
-        if (slug) analytics.logGrapherView(slug, { view: settings })
-    }, [slug, settings])
-
     const updateGrapher = useCallback(
         (
             grapher: Grapher,
@@ -262,9 +258,10 @@ export function DataPageContent({
             }
 
             setSearchParams(newSearchParams, { replace: true })
+            if (slug) analytics.logGrapherView(slug, { view: selectedChoices })
             updateGrapher(grapher, selectedChoices, newGrapherParams)
         },
-        [config, setSearchParams, updateGrapher]
+        [config, setSearchParams, slug, updateGrapher]
     )
 
     // Set state from query params on page load.


### PR DESCRIPTION
We were logging the event every time any search params changed in `MultiDimDataPageContent` because that created a new `searchParams` state that we depended on when calculating the `settings`.

It worked correctly in `MultiDim`, but making the analytics call in the event handler instead of `useEffect` is better in general.
