### PR TITLE
🔨 add line chart to grapher configs explicitly

### DIFF
--- a/db/migration/1746531337078-AddLineChartToGrapherConfigs.ts
+++ b/db/migration/1746531337078-AddLineChartToGrapherConfigs.ts
@@ -1,0 +1,36 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+const tables = [
+    { table: "chart_configs", column: "patch" },
+    { table: "chart_configs", column: "full" },
+    { table: "chart_revisions", column: "config" },
+    { table: "suggested_chart_revisions", column: "suggestedConfig" },
+]
+
+export class AddLineChartToGrapherConfigs1746531337078
+    implements MigrationInterface
+{
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        for (const { table, column } of tables) {
+            await queryRunner.query(`-- sql
+                UPDATE ${table}
+                SET ${column} = JSON_SET(
+                    ${column},
+                    '$.chartTypes',
+                    JSON_ARRAY('LineChart')
+                )
+                WHERE ${column} ->> '$.chartTypes' IS NULL
+            `)
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        for (const { table, column } of tables) {
+            await queryRunner.query(`-- sql
+                UPDATE ${table}
+                SET ${column} = JSON_REMOVE(${column}, '$.chartTypes')
+                WHERE ${column} ->> '$.chartTypes' = '["LineChart"]'
+            `)
+        }
+    }
+}


### PR DESCRIPTION


<!-- GitButler Footer Boundary Top -->
---
This is **part 5 of 7 in a stack** made with GitButler:
- <kbd>&nbsp;7&nbsp;</kbd> #4843 
- <kbd>&nbsp;6&nbsp;</kbd> #4842 
- <kbd>&nbsp;5&nbsp;</kbd> #4841 👈 
- <kbd>&nbsp;4&nbsp;</kbd> #4839 
- <kbd>&nbsp;3&nbsp;</kbd> #4838 
- <kbd>&nbsp;2&nbsp;</kbd> #4833 
- <kbd>&nbsp;1&nbsp;</kbd> #4832 
<!-- GitButler Footer Boundary Bottom -->

