### PR TITLE
🐛 fix the square and social media exports on the export tab

### DIFF
--- a/adminSiteClient/EditorExportTab.tsx
+++ b/adminSiteClient/EditorExportTab.tsx
@@ -213,14 +213,22 @@ export class EditorExportTab<
                 this.grapherState.staticFormat !== format ||
                 this.grapherState.isSocialMediaExport !== isSocialMediaExport
             ) {
+                // Without this explicit conversion to object there was a mobx error deep
+                // down in the call stack of rasterize below, when the authorsVersion
+                // was computed
+                const grapherStateAsObject = this.grapherState.toObject()
                 grapherState = new GrapherState({
-                    ...this.grapherState,
+                    ...grapherStateAsObject,
                     staticFormat: format,
-                    selectedEntityNames:
-                        this.grapherState.selection.selectedEntityNames,
-                    focusedSeriesNames: this.grapherState.focusedSeriesNames,
+                    selectedEntityNames: [
+                        ...this.grapherState.selection.selectedEntityNames,
+                    ],
+                    focusedSeriesNames: [
+                        ...this.grapherState.focusedSeriesNames,
+                    ],
                     isSocialMediaExport,
                 })
+                grapherState.inputTable = this.grapherState.inputTable
             }
             const { blob: pngBlob, svgBlob } = await grapherState.rasterize()
             if (filename.endsWith("svg") && svgBlob) {

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -480,15 +480,14 @@ export class GrapherState {
             this.ensureValidConfigWhenEditing()
         }
     }
-
     toObject(): GrapherInterface {
         const obj: GrapherInterface = objectWithPersistablesToObject(
             this,
             grapherKeysToSerialize
         )
 
-        obj.selectedEntityNames = this.selection.selectedEntityNames
-        obj.focusedSeriesNames = this.focusArray.seriesNames
+        obj.selectedEntityNames = [...this.selection.selectedEntityNames]
+        obj.focusedSeriesNames = [...this.focusArray.seriesNames]
 
         deleteRuntimeAndUnchangedProps(obj, defaultObject)
 


### PR DESCRIPTION
## Context

Links to issues, Figma, Slack, and a technical introduction to the work.

## Screenshots / Videos / Diagrams

Add if relevant, i.e. might not be necessary when there are no UI changes.

## Testing guidance

Step-by-step instructions on how to test this change

- [ ] Does the staging experience have sign-off from product stakeholders?

**Reminder to annotate the PR diff with design notes, alternatives you considered, and any other helpful context.**

## Checklist

(delete all that do not apply)

### Before merging

- [ ] Google Analytics events were adapted to fit the changes in this PR
- [ ] Changes to CSS/HTML were checked on Desktop and Mobile Safari at all three breakpoints
- [ ] Changes to HTML were checked for accessibility concerns

If DB migrations exists:

- [ ] If columns have been added/deleted, all necessary views were recreated
- [ ] The DB type definitions have been updated
- [ ] The DB types in the ETL have been updated
- [ ] If tables/views were added/removed, the Datasette export has been updated to take this into account

### After merging

- [ ] If a table was touched that is synced to R2, the sync script to update R2 has been run
