### PR TITLE
Switch internal non-leaf packages to just-in-time

### DIFF
--- a/packages/@ourworldindata/components/package.json
+++ b/packages/@ourworldindata/components/package.json
@@ -2,14 +2,10 @@
     "name": "@ourworldindata/components",
     "version": "0.0.0",
     "description": "This package contains shared UI components and styles for the Our World in Data site and the Grapher tool.",
-    "main": "dist/index.js",
+    "main": "src/index.ts",
+    "types": "src/index.ts",
     "directories": {
         "lib": "src"
-    },
-    "types": "dist",
-    "scripts": {
-        "build": "rm -rf ./dist && tsc --build",
-        "watch": "tsc --watch"
     },
     "keywords": [],
     "author": "",

--- a/packages/@ourworldindata/core-table/package.json
+++ b/packages/@ourworldindata/core-table/package.json
@@ -1,30 +1,26 @@
 {
-  "name": "@ourworldindata/core-table",
-  "version": "0.0.0",
-  "description": "This is our core tabular data structure class which parses JSON or delimited data and makes it available for charts. This class performs core transformations like filtering, grouping, etc. This is roughly our \"Pandas for TypeScript\".",
-  "main": "dist/index.js",
-  "directories": {
-    "lib": "src"
-  },
-  "types": "dist",
-  "scripts": {
-    "build": "rm -rf ./dist && tsc --build",
-    "watch": "tsc --watch"
-  },
-  "keywords": [],
-  "author": "",
-  "dependencies": {
-    "@ourworldindata/types": "workspace:^",
-    "@ourworldindata/utils": "workspace:^",
-    "d3": "^6.1.1",
-    "dayjs": "^1.11.11",
-    "papaparse": "^5.4.1"
-  },
-  "devDependencies": {
-    "@types/d3": "^6",
-    "@types/papaparse": "^5.3.15",
-    "eslint": "^9.21.0",
-    "typescript": "~5.8.2"
-  },
-  "license": "MIT"
+    "name": "@ourworldindata/core-table",
+    "version": "0.0.0",
+    "description": "This is our core tabular data structure class which parses JSON or delimited data and makes it available for charts. This class performs core transformations like filtering, grouping, etc. This is roughly our \"Pandas for TypeScript\".",
+    "main": "src/index.ts",
+    "types": "src/index.ts",
+    "directories": {
+        "lib": "src"
+    },
+    "keywords": [],
+    "author": "",
+    "dependencies": {
+        "@ourworldindata/types": "workspace:^",
+        "@ourworldindata/utils": "workspace:^",
+        "d3": "^6.1.1",
+        "dayjs": "^1.11.11",
+        "papaparse": "^5.4.1"
+    },
+    "devDependencies": {
+        "@types/d3": "^6",
+        "@types/papaparse": "^5.3.15",
+        "eslint": "^9.21.0",
+        "typescript": "~5.8.2"
+    },
+    "license": "MIT"
 }

--- a/packages/@ourworldindata/types/package.json
+++ b/packages/@ourworldindata/types/package.json
@@ -1,26 +1,22 @@
 {
-  "name": "@ourworldindata/types",
-  "version": "0.0.0",
-  "description": "",
-  "main": "dist/index.js",
-  "directories": {
-    "lib": "src"
-  },
-  "types": "dist",
-  "scripts": {
-    "build": "rm -rf ./dist && tsc --build",
-    "watch": "tsc --watch"
-  },
-  "keywords": [],
-  "author": "",
-  "devDependencies": {
-    "eslint": "^9.21.0",
-    "eslint-plugin-react-hooks": "^5.2.0",
-    "typescript": "~5.8.2"
-  },
-  "license": "MIT",
-  "dependencies": {
-    "@sinclair/typebox": "^0.28.5",
-    "mobx": "^5.15.7"
-  }
+    "name": "@ourworldindata/types",
+    "version": "0.0.0",
+    "description": "",
+    "main": "src/index.ts",
+    "types": "src/index.ts",
+    "directories": {
+        "lib": "src"
+    },
+    "keywords": [],
+    "author": "",
+    "devDependencies": {
+        "eslint": "^9.21.0",
+        "eslint-plugin-react-hooks": "^5.2.0",
+        "typescript": "~5.8.2"
+    },
+    "license": "MIT",
+    "dependencies": {
+        "@sinclair/typebox": "^0.28.5",
+        "mobx": "^5.15.7"
+    }
 }

--- a/packages/@ourworldindata/utils/package.json
+++ b/packages/@ourworldindata/utils/package.json
@@ -1,46 +1,42 @@
 {
-  "name": "@ourworldindata/utils",
-  "version": "0.0.0",
-  "description": "",
-  "main": "dist/index.js",
-  "directories": {
-    "lib": "src"
-  },
-  "types": "dist",
-  "scripts": {
-    "build": "rm -rf ./dist && tsc --build",
-    "watch": "tsc --watch"
-  },
-  "keywords": [],
-  "author": "",
-  "dependencies": {
-    "@ourworldindata/types": "workspace:^",
-    "@tippyjs/react": "^4.2.6",
-    "d3": "^6.1.1",
-    "dayjs": "^1.11.11",
-    "fuzzysort": "^3.1.0",
-    "lodash-es": "^4.17.21",
-    "mobx": "^5.15.7",
-    "mobx-react": "5",
-    "react": "^17.0.2",
-    "react-select": "^5.8.0",
-    "string-pixel-width": "^1.10.0",
-    "striptags": "^3.2.0",
-    "timezone-mock": "^1.0.18",
-    "ts-pattern": "^5.0.5",
-    "url-parse": "^1.5.10",
-    "uuidv7": "^1.0.1"
-  },
-  "devDependencies": {
-    "@types/d3": "^6",
-    "@types/d3-format": "^2",
-    "@types/lodash-es": "^4.17.12",
-    "@types/react": "^17.0.69",
-    "@types/string-pixel-width": "^1.7.2",
-    "@types/url-parse": "^1.4.8",
-    "eslint": "^9.21.0",
-    "eslint-plugin-react-hooks": "^5.2.0",
-    "typescript": "~5.8.2"
-  },
-  "license": "MIT"
+    "name": "@ourworldindata/utils",
+    "version": "0.0.0",
+    "description": "",
+    "main": "src/index.ts",
+    "types": "src/index.ts",
+    "directories": {
+        "lib": "src"
+    },
+    "keywords": [],
+    "author": "",
+    "dependencies": {
+        "@ourworldindata/types": "workspace:^",
+        "@tippyjs/react": "^4.2.6",
+        "d3": "^6.1.1",
+        "dayjs": "^1.11.11",
+        "fuzzysort": "^3.1.0",
+        "lodash-es": "^4.17.21",
+        "mobx": "^5.15.7",
+        "mobx-react": "5",
+        "react": "^17.0.2",
+        "react-select": "^5.8.0",
+        "string-pixel-width": "^1.10.0",
+        "striptags": "^3.2.0",
+        "timezone-mock": "^1.0.18",
+        "ts-pattern": "^5.0.5",
+        "url-parse": "^1.5.10",
+        "uuidv7": "^1.0.1"
+    },
+    "devDependencies": {
+        "@types/d3": "^6",
+        "@types/d3-format": "^2",
+        "@types/lodash-es": "^4.17.12",
+        "@types/react": "^17.0.69",
+        "@types/string-pixel-width": "^1.7.2",
+        "@types/url-parse": "^1.4.8",
+        "eslint": "^9.21.0",
+        "eslint-plugin-react-hooks": "^5.2.0",
+        "typescript": "~5.8.2"
+    },
+    "license": "MIT"
 }

--- a/vite.config-common.mts
+++ b/vite.config-common.mts
@@ -22,12 +22,8 @@ export const defineViteConfigForEntrypoint = (entrypoint: ViteEntryPoint) => {
                 // this means we get instant dev updates when we change one of them,
                 // and the prod build builds them all as esm modules, which helps with tree shaking
                 // Idea from https://github.com/LinusBorg/vue-lib-template/blob/3775e49b20a7c3349dd49321cad2ed7f9d575057/packages/playground/vite.config.ts
-                "@ourworldindata/components": "@ourworldindata/components/src/index.ts",
-                "@ourworldindata/core-table": "@ourworldindata/core-table/src/index.ts",
                 "@ourworldindata/explorer": "@ourworldindata/explorer/src/index.ts",
                 "@ourworldindata/grapher": "@ourworldindata/grapher/src/index.ts",
-                "@ourworldindata/types": "@ourworldindata/types/src/index.ts",
-                "@ourworldindata/utils": "@ourworldindata/utils/src/index.ts",
             },
         },
         css: {


### PR DESCRIPTION
## Description

Currently, all our internal packages in the `packages` dir are what Turborepo calls [compiled packages](https://turborepo.com/docs/core-concepts/internal-packages#compiled-packages). Here we switch packages other than `grapher` and `explorer` - which are bigger, and we intend to publish them separately - to [just-in-time packages](https://turborepo.com/docs/core-concepts/internal-packages#just-in-time-packages).

## Trade-offs

Compiling the packages separately means we don't have to compile the code again if something else changes. Switching to JIT packages means we'll lose that and running `tsc -b` will take longer. However, we avoid a chain of:

`utils` changes
-> `utils` re-compiles
-> `core-table` and `components` re-compile
-> `grapher` re-compiles
-> `explorer` re-compiles, 

and as the packages are changing, the `yarn startAdminDevServer` keeps restarting.

After the change, we shorten the chain to:

`utils` changes
-> `grapher` re-compiles
-> `explorer` re-compiles,

and the dev server restarts fewer times.

| Command | Before | After |
|--------|---: |---: |
| `yarn lerna run build --skip-nx-cache` | 28.19 s | 18.12 s |
| `yarn lerna run build` (using cache) after adding `console.log` to `comafyNumber` in `utils` | 26.46 s | 19.90 s |
| `yarn tsc -b -f` |  23.16 s | 40.52 s |
| `yarn buildVite` | 29.08 s | 31.36 s | 

We build Lerna packages much more often during development and run `tsc -b` rarely, therefore the trade-off is worth it.