### PR TITLE
🐛 (explorer) fix hideAnnotationFieldsInTitle field

### DIFF
--- a/packages/@ourworldindata/explorer/src/GrapherGrammar.ts
+++ b/packages/@ourworldindata/explorer/src/GrapherGrammar.ts
@@ -40,20 +40,20 @@ export const GrapherGrammar: Grammar<GrapherCellDef> = {
         keyword: "title",
         description: "Chart title",
         valuePlaceholder: "Life Expectancy around the world.",
-        toGrapherObject: (value) => ({ title: value }),
+        toGrapherObject: (parsedValue) => ({ title: parsedValue }),
     },
     subtitle: {
         ...StringCellDef,
         keyword: "subtitle",
         description: "Chart subtitle",
         valuePlaceholder: "Life Expectancy has risen over time.",
-        toGrapherObject: (value) => ({ subtitle: value }),
+        toGrapherObject: (parsedValue) => ({ subtitle: parsedValue }),
     },
     ySlugs: {
         ...SlugsDeclarationCellDef,
         description: "ColumnSlug(s) for the yAxis",
         keyword: "ySlugs",
-        toGrapherObject: (value) => ({ ySlugs: value }),
+        toGrapherObject: (parsedValue) => ({ ySlugs: parsedValue }),
     },
     yVariableIds: {
         ...IndicatorIdsOrEtlPathsCellDef,
@@ -70,15 +70,15 @@ export const GrapherGrammar: Grammar<GrapherCellDef> = {
             `${GRAPHER_CHART_TYPES.LineChart} ${GRAPHER_CHART_TYPES.SlopeChart}`,
             "None",
         ]),
-        toGrapherObject: (value) => ({
-            chartTypes: value === "None" ? [] : value.split(" "),
+        toGrapherObject: (parsedValue) => ({
+            chartTypes: parsedValue === "None" ? [] : parsedValue.split(" "),
         }),
     },
     grapherId: {
         ...IntegerCellDef,
         description: "ID of a legacy Grapher to load",
         keyword: "grapherId",
-        toGrapherObject: (value) => ({ id: value }),
+        toGrapherObject: (parsedValue) => ({ id: parsedValue }),
     },
     tableSlug: {
         ...SlugDeclarationCellDef,
@@ -91,20 +91,20 @@ export const GrapherGrammar: Grammar<GrapherCellDef> = {
         ...BooleanCellDef,
         keyword: "hasMapTab",
         description: "Show the map tab?",
-        toGrapherObject: (value) => ({ hasMapTab: value }),
+        toGrapherObject: (parsedValue) => ({ hasMapTab: parsedValue }),
     },
     tab: {
         ...EnumCellDef,
         keyword: "tab",
         description: "Which tab to show by default",
         terminalOptions: toTerminalOptions(Object.values(GRAPHER_TAB_OPTIONS)),
-        toGrapherObject: (value) => ({ tab: value }),
+        toGrapherObject: (parsedValue) => ({ tab: parsedValue }),
     },
     xSlug: {
         ...SlugDeclarationCellDef,
         description: "ColumnSlug for the xAxis",
         keyword: "xSlug",
-        toGrapherObject: (value) => ({ xSlug: value }),
+        toGrapherObject: (parsedValue) => ({ xSlug: parsedValue }),
     },
     xVariableId: {
         ...IndicatorIdOrEtlPathCellDef,
@@ -116,7 +116,7 @@ export const GrapherGrammar: Grammar<GrapherCellDef> = {
         ...SlugDeclarationCellDef,
         description: "ColumnSlug for the color",
         keyword: "colorSlug",
-        toGrapherObject: (value) => ({ colorSlug: value }),
+        toGrapherObject: (parsedValue) => ({ colorSlug: parsedValue }),
     },
     colorVariableId: {
         ...IndicatorIdOrEtlPathCellDef,
@@ -128,7 +128,7 @@ export const GrapherGrammar: Grammar<GrapherCellDef> = {
         ...SlugDeclarationCellDef,
         description: "ColumnSlug for the size of points on scatters",
         keyword: "sizeSlug",
-        toGrapherObject: (value) => ({ sizeSlug: value }),
+        toGrapherObject: (parsedValue) => ({ sizeSlug: parsedValue }),
     },
     sizeVariableId: {
         ...IndicatorIdOrEtlPathCellDef,
@@ -142,13 +142,13 @@ export const GrapherGrammar: Grammar<GrapherCellDef> = {
         description:
             "Columns to show in the Table tab of the chart. If not specified all active slugs will be used.",
         keyword: "tableSlugs",
-        toGrapherObject: (value) => ({ tableSlugs: value }),
+        toGrapherObject: (parsedValue) => ({ tableSlugs: parsedValue }),
     },
     sourceDesc: {
         ...StringCellDef,
         keyword: "sourceDesc",
         description: "Short comma-separated list of source names",
-        toGrapherObject: (value) => ({ sourceDesc: value }),
+        toGrapherObject: (parsedValue) => ({ sourceDesc: parsedValue }),
     },
     hideAnnotationFieldsInTitle: {
         ...BooleanCellDef,
@@ -162,25 +162,23 @@ export const GrapherGrammar: Grammar<GrapherCellDef> = {
                 changeInPrefix: parsedValue,
             }
         },
-        toGrapherObject: (value) => ({
-            hideAnnotationFieldsInTitle: {
-                entity: value,
-                time: value,
-                changeInPrefix: value,
-            },
+        toGrapherObject: (parsedValue) => ({
+            hideAnnotationFieldsInTitle: parsedValue,
         }),
     },
     yScaleToggle: {
         ...BooleanCellDef,
         keyword: "yScaleToggle",
         description: "Set to 'true' if the user can change the yAxis",
-        toGrapherObject: (value) => ({ yAxis: { canChangeScaleType: value } }),
+        toGrapherObject: (parsedValue) => ({
+            yAxis: { canChangeScaleType: parsedValue },
+        }),
     },
     yAxisMin: {
         ...NumericOrAutoCellDef,
         keyword: "yAxisMin",
         description: "Set the minimum value for the yAxis",
-        toGrapherObject: (value) => ({ yAxis: { min: value } }),
+        toGrapherObject: (parsedValue) => ({ yAxis: { min: parsedValue } }),
     },
     facetYDomain: {
         ...EnumCellDef,
@@ -188,21 +186,25 @@ export const GrapherGrammar: Grammar<GrapherCellDef> = {
         description:
             "Whether facets axes default to shared or independent domain",
         terminalOptions: toTerminalOptions(Object.values(FacetAxisDomain)),
-        toGrapherObject: (value) => ({ yAxis: { facetDomain: value } }),
+        toGrapherObject: (parsedValue) => ({
+            yAxis: { facetDomain: parsedValue },
+        }),
     },
     selectedFacetStrategy: {
         ...EnumCellDef,
         keyword: "selectedFacetStrategy",
         description: "Whether the chart should be faceted or not",
         terminalOptions: toTerminalOptions(Object.values(FacetStrategy)),
-        toGrapherObject: (value) => ({ selectedFacetStrategy: value }),
+        toGrapherObject: (parsedValue) => ({
+            selectedFacetStrategy: parsedValue,
+        }),
     },
     entityType: {
         ...StringCellDef,
         keyword: "entityType",
         description:
             "Default is 'country', but you can specify a different one such as 'state' or 'region'.",
-        toGrapherObject: (value) => ({ entityType: value }),
+        toGrapherObject: (parsedValue) => ({ entityType: parsedValue }),
     },
     baseColorScheme: {
         ...EnumCellDef,
@@ -210,34 +212,34 @@ export const GrapherGrammar: Grammar<GrapherCellDef> = {
         description:
             "The default color scheme if no color overrides are specified",
         terminalOptions: toTerminalOptions(Object.keys(ColorSchemeName)),
-        toGrapherObject: (value) => ({ baseColorScheme: value }),
+        toGrapherObject: (parsedValue) => ({ baseColorScheme: parsedValue }),
     },
     note: {
         ...StringCellDef,
         keyword: "note",
         description: "Chart footnote",
-        toGrapherObject: (value) => ({ note: value }),
+        toGrapherObject: (parsedValue) => ({ note: parsedValue }),
     },
     sortBy: {
         ...EnumCellDef,
         keyword: "sortBy",
         description: "Specify what to sort the entities by",
         terminalOptions: toTerminalOptions(Object.values(SortBy)),
-        toGrapherObject: (value) => ({ sortBy: value }),
+        toGrapherObject: (parsedValue) => ({ sortBy: parsedValue }),
     },
     sortOrder: {
         ...EnumCellDef,
         keyword: "sortOrder",
         description: "Whether to sort entities ascending or descending",
         terminalOptions: toTerminalOptions(Object.values(SortOrder)),
-        toGrapherObject: (value) => ({ sortOrder: value }),
+        toGrapherObject: (parsedValue) => ({ sortOrder: parsedValue }),
     },
     sortColumnSlug: {
         ...SlugDeclarationCellDef,
         keyword: "sortColumnSlug",
         description:
             "This setting is only respected when `sortBy` is set to `column`",
-        toGrapherObject: (value) => ({ sortColumnSlug: value }),
+        toGrapherObject: (parsedValue) => ({ sortColumnSlug: parsedValue }),
     },
     stackMode: {
         ...EnumCellDef,
@@ -245,34 +247,36 @@ export const GrapherGrammar: Grammar<GrapherCellDef> = {
         description:
             "Show chart in absolute (default) or relative mode. Only works for some chart types.",
         terminalOptions: toTerminalOptions(Object.values(StackMode)),
-        toGrapherObject: (value) => ({ stackMode: value }),
+        toGrapherObject: (parsedValue) => ({ stackMode: parsedValue }),
     },
     hideTotalValueLabel: {
         ...BooleanCellDef,
         keyword: "hideTotalValueLabel",
         description:
             "Hide the total value that is normally displayed to the right of the bars in a stacked bar chart.",
-        toGrapherObject: (value) => ({ hideTotalValueLabel: value }),
+        toGrapherObject: (parsedValue) => ({
+            hideTotalValueLabel: parsedValue,
+        }),
     },
     hideRelativeToggle: {
         ...BooleanCellDef,
         keyword: "hideRelativeToggle",
         description: "Whether to hide the relative mode UI toggle",
-        toGrapherObject: (value) => ({ hideRelativeToggle: value }),
+        toGrapherObject: (parsedValue) => ({ hideRelativeToggle: parsedValue }),
     },
     timelineMinTime: {
         ...IntegerCellDef,
         keyword: "timelineMinTime",
         description:
             "Set the minimum time for the timeline. For days, use days since 21 Jan 2020, e.g. 24 Jan 2020 is '3'.",
-        toGrapherObject: (value) => ({ timelineMinTime: value }),
+        toGrapherObject: (parsedValue) => ({ timelineMinTime: parsedValue }),
     },
     timelineMaxTime: {
         ...IntegerCellDef,
         keyword: "timelineMaxTime",
         description:
             "Set the maximum time for the timeline. For days, use days since 21 Jan 2020, e.g. 24 Jan 2020 is '3'.",
-        toGrapherObject: (value) => ({ timelineMaxTime: value }),
+        toGrapherObject: (parsedValue) => ({ timelineMaxTime: parsedValue }),
     },
     defaultView: {
         ...BooleanCellDef,
@@ -298,7 +302,7 @@ export const GrapherGrammar: Grammar<GrapherCellDef> = {
         keyword: "mapTargetTime",
         description:
             "Set the 'target time' for the map chart. This is the year that will be shown by default in the map chart.",
-        toGrapherObject: (value) => ({ map: { time: value } }),
+        toGrapherObject: (parsedValue) => ({ map: { time: parsedValue } }),
     },
     missingDataStrategy: {
         ...EnumCellDef,
@@ -306,18 +310,20 @@ export const GrapherGrammar: Grammar<GrapherCellDef> = {
         description:
             "Hide or show entities for which one or more variables are missing",
         terminalOptions: toTerminalOptions(Object.values(MissingDataStrategy)),
-        toGrapherObject: (value) => ({ missingDataStrategy: value }),
+        toGrapherObject: (parsedValue) => ({
+            missingDataStrategy: parsedValue,
+        }),
     },
     minTime: {
         ...IntegerCellDef,
         keyword: "minTime",
         description: "Start point of the initially selected time span",
-        toGrapherObject: (value) => ({ minTime: value }),
+        toGrapherObject: (parsedValue) => ({ minTime: parsedValue }),
     },
     maxTime: {
         ...IntegerCellDef,
         keyword: "maxTime",
         description: "End point of the initially selected time span",
-        toGrapherObject: (value) => ({ maxTime: value }),
+        toGrapherObject: (parsedValue) => ({ maxTime: parsedValue }),
     },
 } as const


### PR DESCRIPTION
Drive-by change for an issue I noticed.

`hideAnnotationFieldsInTitle` is currently parsed into

```javascript
{
  hideAnnotationFieldsInTitle: {
    entity: { entity: false, time: false, … },
    time: { entity: false, time: false, … },
    changeInPrefix: { … }
  }
}
```