### PR TITLE
🐛 fix explorer featured metric indexing

### DIFF
--- a/baker/algolia/utils/shared.ts
+++ b/baker/algolia/utils/shared.ts
@@ -25,6 +25,8 @@ import { groupBy } from "remeda"
 import { BAKED_BASE_URL } from "../../../settings/clientSettings.js"
 import { incomeGroupMap, REAL_FM_INCOME_GROUPS } from "./types.js"
 import { ExpandedFeaturedMetric } from "@ourworldindata/types/dist/dbTypes/FeaturedMetrics.js"
+import { EXPLORERS_ROUTE_FOLDER } from "@ourworldindata/explorer"
+import { GRAPHER_ROUTE_FOLDER } from "@ourworldindata/grapher"
 
 const countriesWithVariantNames = new Set(
     countries
@@ -89,8 +91,8 @@ function createRecordUrl(record: ChartRecord) {
         urljoin(
             BAKED_BASE_URL,
             record.type === ChartRecordType.ExplorerView
-                ? "explorer"
-                : "grapher",
+                ? EXPLORERS_ROUTE_FOLDER
+                : GRAPHER_ROUTE_FOLDER,
             record.slug,
             record.queryParams ?? ""
         )

--- a/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
@@ -8,6 +8,8 @@ export const GRAPHER_EMBEDDED_FIGURE_CONFIG_ATTR = "data-grapher-config"
 export const GRAPHER_CHART_VIEW_EMBEDDED_FIGURE_CONFIG_ATTR =
     "data-grapher-chart-view-config"
 
+export const GRAPHER_ROUTE_FOLDER = "grapher"
+
 export const GRAPHER_PAGE_BODY_CLASS = "StandaloneGrapherOrExplorerPage"
 export const GRAPHER_IS_IN_IFRAME_CLASS = "IsInIframe"
 export const GRAPHER_TIMELINE_CLASS = "timeline-component"

--- a/packages/@ourworldindata/grapher/src/index.ts
+++ b/packages/@ourworldindata/grapher/src/index.ts
@@ -8,6 +8,7 @@ export {
 } from "./color/ColorScaleBin"
 export { ChartDimension } from "./chart/ChartDimension"
 export {
+    GRAPHER_ROUTE_FOLDER,
     GRAPHER_EMBEDDED_FIGURE_ATTR,
     GRAPHER_EMBEDDED_FIGURE_CONFIG_ATTR,
     GRAPHER_CHART_VIEW_EMBEDDED_FIGURE_CONFIG_ATTR,


### PR DESCRIPTION
`findMatchingRecordByPathnameAndQueryParams` was broken because I used the string `"explorer"` instead of the correct `"explorers"`

This PR fixes that by using the correct constant and creating one for Grapher as well, for consistency's sake. 

I'm holding off on using it everywhere because it competes with `BAKED_GRAPHER_URL`. I've added a point to next week's meeting's agenda to discuss.