### PR TITLE
Fix bad algolia excerpts

### DIFF
--- a/baker/algolia/utils/pages.ts
+++ b/baker/algolia/utils/pages.ts
@@ -49,7 +49,10 @@ import {
 } from "../../../settings/clientSettings.js"
 import { logErrorAndMaybeCaptureInSentry } from "../../../serverUtils/errorLog.js"
 import { getFirstBlockOfType } from "../../../site/gdocs/utils.js"
-import { getPrefixedGdocPath } from "@ourworldindata/components"
+import {
+    getPrefixedGdocPath,
+    MarkdownTextWrap,
+} from "@ourworldindata/components"
 
 const computePageScore = (record: Omit<PageRecord, "score">): number => {
     const { importance, views_7d } = record
@@ -251,8 +254,9 @@ function generateGdocRecords(
             createElement(
                 "div",
                 null,
-                createElement(ArticleBlocks, {
-                    blocks: gdoc.content.body,
+                createElement(MarkdownTextWrap, {
+                    text: gdoc.markdown || "",
+                    fontSize: 12,
                 })
             )
         )

--- a/baker/algolia/utils/pages.ts
+++ b/baker/algolia/utils/pages.ts
@@ -18,7 +18,6 @@ import {
     DbEnrichedImage,
     OwidGdocDataInsightInterface,
     OwidGdocAboutInterface,
-    gdocUrlRegex,
 } from "@ourworldindata/utils"
 import { formatPost } from "../../formatWordpressPost.js"
 import { getAlgoliaClient } from "../configureAlgolia.js"
@@ -217,21 +216,8 @@ function getExcerptFromGdoc(
 
 function formatGdocMarkdown(content: string): string {
     const simplifiedMarkdown = stripCustomMarkdownComponents(content)
-
-    const withoutGdocLinks = simplifiedMarkdown.replaceAll(
-        new RegExp(gdocUrlRegex, "g"),
-        ""
-    )
-
-    // There's a bug somewhere in enrichedToMarkdown that leaves "undefined" in the text
-    const withoutUndefinedString = withoutGdocLinks.replaceAll(
-        new RegExp("undefined", "g"),
-        ""
-    )
-
     // This is used in many data insights but shouldn't be shown in search results
-    const withoutArrow = withoutUndefinedString.replaceAll("→", "")
-
+    const withoutArrow = simplifiedMarkdown.replaceAll("→", "")
     return withoutArrow
 }
 
@@ -275,7 +261,7 @@ function generateGdocRecords(
             fontSize: 12,
         }).plaintext
 
-        const chunks = generateChunksFromHtmlText(plaintextContent)
+        const chunks = chunkParagraphs(plaintextContent, 1000)
         let i = 0
 
         const thumbnailUrl = getThumbnailUrl(gdoc, cloudflareImagesByFilename)

--- a/db/migration/1747337107717-FixMalformedGdocMarkdown.ts
+++ b/db/migration/1747337107717-FixMalformedGdocMarkdown.ts
@@ -1,0 +1,50 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+import { enrichedBlocksToMarkdown } from "../model/Gdoc/enrichedToMarkdown.js"
+import { gdocFromJSON } from "../model/Gdoc/GdocFactory.js"
+
+export class FixMalformedGdocMarkdown1747337107717
+    implements MigrationInterface
+{
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const malformedGdocQuery = `-- sql
+            SELECT
+                id,
+                content
+            FROM
+                posts_gdocs pg
+            WHERE
+                (
+                    pg.markdown IS NULL
+                    OR pg.markdown LIKE "%undefined%"
+                    OR pg.markdown LIKE "%docs.google.com/document%"
+                )
+                AND pg.published = TRUE
+                AND pg.type != "fragment"`
+        const publishedGdocsWithMalformedMarkdown = await queryRunner
+            .query(malformedGdocQuery)
+            .then((rows: { id: string; content: string }[]) =>
+                rows.map((row) => gdocFromJSON(row))
+            )
+
+        for (const gdoc of publishedGdocsWithMalformedMarkdown) {
+            const markdown = enrichedBlocksToMarkdown(gdoc.content.body, true)
+            await queryRunner.query(
+                `-- sql
+                UPDATE posts_gdocs
+                SET markdown = ?
+                WHERE id = ?
+            `,
+                [markdown, gdoc.id]
+            )
+        }
+
+        const stillMalformed = await queryRunner.query(malformedGdocQuery)
+        console.warn(
+            `${stillMalformed.length} malformed gdoc(s) remaining after migration`
+        )
+    }
+
+    public async down(): Promise<void> {
+        // no-op
+    }
+}

--- a/db/model/Gdoc/enrichedToMarkdown.ts
+++ b/db/model/Gdoc/enrichedToMarkdown.ts
@@ -87,7 +87,7 @@ function markdownComponent(
 export function stripCustomMarkdownComponents(content: string): string {
     let strippedContent = content
     for (const componentName of Object.values(CUSTOM_MARKDOWN_COMPONENTS)) {
-        const regex = new RegExp(`<${componentName}.*?/>`, "g")
+        const regex = new RegExp(`<${componentName}[^\n]*?/>`, "g")
         strippedContent = strippedContent.replace(regex, "")
     }
     return strippedContent

--- a/db/model/Gdoc/enrichedToMarkdown.ts
+++ b/db/model/Gdoc/enrichedToMarkdown.ts
@@ -92,13 +92,7 @@ export function enrichedBlockToMarkdown(
             return spansToMarkdown(b.value)
         })
         .with({ type: "simple-text" }, (b): string | undefined => b.value.text)
-        .with({ type: "all-charts" }, (b): string | undefined =>
-            markdownComponent(
-                "AllCharts",
-                { heading: b.heading }, // Note: truncated
-                exportComponents
-            )
-        )
+        .with({ type: "all-charts" }, (b): string | undefined => "")
         .with({ type: "additional-charts" }, (b): string | undefined => {
             if (!exportComponents) return undefined
             else {


### PR DESCRIPTION
## Context

Resolves https://github.com/owid/owid-grapher/issues/4820

We were extracting plaintext from a rendered article to fill the `content` field in our algolia records. This included some useless content such as text from an unhydrated key charts block which was showing up in search results.

This PR fixes this issue by using each gdoc's markdown representation instead, which is already filtered down to only show semantically significant content. Some additional work was needed to format this in a way that's appropriate for Algolia search excerpts (i.e. removing our custom components from `enrichedToMarkdown` like `<Video />`)

I also added a migration that fixes ~150 documents with errors in them due to a few small oversights in the `enrichedToMarkdown` functions.

## Screenshots / Videos / Diagrams

**Before**
![image](https://github.com/user-attachments/assets/c86b9c1d-60d6-4edf-9690-718a9e1cd8a9)

**After**
![image](https://github.com/user-attachments/assets/02072e50-1754-4557-b714-5038dcd956e2)


## Testing guidance
Check out the `ike-dev-pages` index on our Algolia  staging application and inspect all the content for bad content.
