### PR TITLE
Add text-wrap: balance to short article elements

### DIFF
--- a/site/gdocs/components/centered-article.scss
+++ b/site/gdocs/components/centered-article.scss
@@ -328,6 +328,10 @@
     }
 }
 
+.article-block__heading {
+    text-wrap: balance;
+}
+
 h1.article-block__heading {
     a.deep-link {
         height: 16px;
@@ -487,6 +491,7 @@ h3.article-block__heading {
     @include body-3-medium-italic;
     color: $blue-60;
     text-align: center;
+    text-wrap: balance;
     margin-top: 16px;
 }
 
@@ -587,6 +592,7 @@ h3.article-block__heading.has-supertitle {
         margin-top: 0;
         margin-bottom: 24px;
         color: $blue-90;
+        text-wrap: balance;
 
         @include md-down {
             @include h2-bold;
@@ -600,6 +606,7 @@ h3.article-block__heading.has-supertitle {
     @include subtitle-1;
     margin-top: 0;
     color: $blue-50;
+    text-wrap: balance;
 
     @include md-down {
         @include body-2-regular;
@@ -881,6 +888,7 @@ div.raw-html-table__container {
     margin: 32px 0;
     padding: 32px 0;
     text-align: center;
+    text-wrap: balance;
 }
 
 .article-block__horizontal-rule {


### PR DESCRIPTION
## Description

Add the [`text-wrap: balance`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-wrap#balance) to:

* Headings
* Image captions
* Pull quotes

Not adding it to blockquote, since we often use it to cite longer paragraphs of text, and `balance` only works for text spanning a limited number of lines, so it can easily lead to paragraphs of different length looking inconsistent next to each other.

## Context

[Slack discussion](https://owid.slack.com/archives/C03SK89695E/p1747028552252099).

## Screenshots / Videos / Diagrams

Example of the difference it makes for headings:

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/9526add8-8d51-44d4-b268-555499324e82) | ![image](https://github.com/user-attachments/assets/200166ad-5c2d-443a-9c30-d19238fb1cc0) | 

## Testing guidance

I already tested all the components in existing articles that this modifies. You could double-check that. For that, the `posts_gdocs_components` table is useful.

- [x] Does the staging experience have sign-off from product stakeholders?