### PR TITLE
Fix missing FAQs in multi-dim data page

### DIFF
--- a/packages/@ourworldindata/types/src/gdocTypes/Datapage.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/Datapage.ts
@@ -32,7 +32,6 @@ export interface DataPageDataV2 {
     description?: string
     descriptionShort?: string
     descriptionFromProducer?: string
-    faqs: FaqLink[] // Todo: resolve these at this level to the point where we can preview them
     descriptionKey: string[]
     descriptionProcessing?: string
     owidProcessingLevel?: OwidProcessingLevel

--- a/site/dataPage.ts
+++ b/site/dataPage.ts
@@ -56,7 +56,6 @@ export function getDatapageDataV2(
         titleVariant: variableMetadata.presentation?.titleVariant,
         topicTagsLinks: variableMetadata.presentation?.topicTagsLinks ?? [],
         attributions: getAttributionFragmentsFromVariable(variableMetadata),
-        faqs: [],
         descriptionKey: variableMetadata.descriptionKey ?? [],
         descriptionProcessing: variableMetadata.descriptionProcessing,
         owidProcessingLevel: variableMetadata.processingLevel,

--- a/site/multiDim/MultiDimDataPageContent.tsx
+++ b/site/multiDim/MultiDimDataPageContent.tsx
@@ -24,6 +24,7 @@ import {
 import {
     DataPageRelatedResearch,
     FaqEntryKeyedByGdocIdAndFragmentId,
+    FaqLink,
     GrapherQueryParams,
     ImageMetadata,
     MultiDimDataPageConfigEnriched,
@@ -89,6 +90,10 @@ declare global {
     }
 }
 
+interface VariableDataPageData extends DataPageDataV2 {
+    faqs: FaqLink[]
+}
+
 export function DataPageContent({
     slug,
     canonicalUrl,
@@ -105,7 +110,7 @@ export function DataPageContent({
     const [searchParams, setSearchParams] = useSearchParams()
     const [manager, setManager] = useState({})
     const [varDatapageData, setVarDatapageData] =
-        useState<DataPageDataV2 | null>(null)
+        useState<VariableDataPageData | null>(null)
     const titleFragments = useTitleFragments(config)
 
     const settings = useMemo(() => {
@@ -130,12 +135,17 @@ export function DataPageContent({
 
             const datapageDataPromise = cachedGetVariableMetadata(
                 variableId
-            ).then((json) =>
-                getDatapageDataV2(
-                    merge(json, config.config?.metadata, newView.metadata),
-                    newView.config ?? {}
+            ).then((json) => {
+                const mergedMetadata = merge(
+                    json,
+                    config.config?.metadata,
+                    newView.metadata
                 )
-            )
+                return {
+                    ...getDatapageDataV2(mergedMetadata, newView.config ?? {}),
+                    faqs: mergedMetadata.presentation?.faqs ?? [],
+                }
+            })
             const grapherConfigUuid = newView.fullConfigId
             const grapherConfigPromise = cachedGetGrapherConfigByUuid(
                 grapherConfigUuid,


### PR DESCRIPTION
Regression introduced in 60127dc81. We construct the FAQs for mdims differently than for the classic data page, which was one difference between the duplicated `getDatapageDataV2` function, that I missed.