### PR TITLE
🎉 (admin) add reset button for map settings

### DIFF
--- a/adminSiteClient/AbstractChartEditor.ts
+++ b/adminSiteClient/AbstractChartEditor.ts
@@ -162,7 +162,7 @@ export abstract class AbstractChartEditor<
     }
 
     // only works for top-level properties
-    couldPropertyBeInherited(property: keyof GrapherInterface): boolean {
+    canPropertyBeInherited(property: keyof GrapherInterface): boolean {
         if (!this.isInheritanceEnabled || !this.activeParentConfig) return false
         return Object.hasOwn(this.activeParentConfig, property)
     }

--- a/adminSiteClient/EditorCustomizeTab.tsx
+++ b/adminSiteClient/EditorCustomizeTab.tsx
@@ -410,7 +410,7 @@ class TimelineSection<
                                 editor.activeParentConfig?.minTime
                             )}
                             isInherited={editor.isPropertyInherited("minTime")}
-                            allowLinking={editor.couldPropertyBeInherited(
+                            allowLinking={editor.canPropertyBeInherited(
                                 "minTime"
                             )}
                         />
@@ -428,9 +428,7 @@ class TimelineSection<
                             editor.activeParentConfig?.maxTime
                         )}
                         isInherited={editor.isPropertyInherited("maxTime")}
-                        allowLinking={editor.couldPropertyBeInherited(
-                            "maxTime"
-                        )}
+                        allowLinking={editor.canPropertyBeInherited("maxTime")}
                     />
                 </FieldsRow>
                 {features.timelineRange && (
@@ -446,7 +444,7 @@ class TimelineSection<
                             isInherited={editor.isPropertyInherited(
                                 "timelineMinTime"
                             )}
-                            allowLinking={editor.couldPropertyBeInherited(
+                            allowLinking={editor.canPropertyBeInherited(
                                 "timelineMinTime"
                             )}
                         />
@@ -461,7 +459,7 @@ class TimelineSection<
                             isInherited={editor.isPropertyInherited(
                                 "timelineMaxTime"
                             )}
-                            allowLinking={editor.couldPropertyBeInherited(
+                            allowLinking={editor.canPropertyBeInherited(
                                 "timelineMaxTime"
                             )}
                         />

--- a/adminSiteClient/EditorDataTab.tsx
+++ b/adminSiteClient/EditorDataTab.tsx
@@ -207,7 +207,7 @@ export class EntitySelectionSection extends React.Component<{
                             .concat(unselectedEntityNames)
                             .map((key) => ({ value: key }))}
                     />
-                    {editor.couldPropertyBeInherited("selectedEntityNames") && (
+                    {editor.canPropertyBeInherited("selectedEntityNames") && (
                         <button
                             className="btn btn-outline-secondary"
                             type="button"
@@ -345,7 +345,7 @@ export class FocusSection extends React.Component<{
                             .concat(availableSeriesNames)
                             .map((key) => ({ value: key }))}
                     />
-                    {editor.couldPropertyBeInherited("focusedSeriesNames") && (
+                    {editor.canPropertyBeInherited("focusedSeriesNames") && (
                         <button
                             className="btn btn-outline-secondary"
                             type="button"

--- a/adminSiteClient/EditorMapTab.tsx
+++ b/adminSiteClient/EditorMapTab.tsx
@@ -190,7 +190,7 @@ class InheritanceSection<Editor extends AbstractChartEditor> extends Component<{
 
     render() {
         const canMapSettingsBeInherited =
-            this.editor.couldPropertyBeInherited("map")
+            this.editor.canPropertyBeInherited("map")
         const areMapSettingsInherited = this.editor.isPropertyInherited("map")
 
         if (!canMapSettingsBeInherited) return null

--- a/adminSiteClient/EditorMapTab.tsx
+++ b/adminSiteClient/EditorMapTab.tsx
@@ -16,6 +16,8 @@ import { Component, Fragment } from "react"
 import { EditorColorScaleSection } from "./EditorColorScaleSection.js"
 import { NumberField, Section, SelectField, Toggle } from "./Forms.js"
 import { AbstractChartEditor } from "./AbstractChartEditor.js"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import { faLink } from "@fortawesome/free-solid-svg-icons"
 
 @observer
 class VariableSection extends Component<{
@@ -171,6 +173,52 @@ class TooltipSection extends Component<{ mapConfig: MapConfig }> {
 }
 
 @observer
+class InheritanceSection<Editor extends AbstractChartEditor> extends Component<{
+    editor: Editor
+}> {
+    @computed private get editor() {
+        return this.props.editor
+    }
+
+    @action.bound resetToParent() {
+        const { grapher, activeParentConfig } = this.editor
+        if (!activeParentConfig || !activeParentConfig.map) return
+
+        grapher.map = new MapConfig()
+        grapher.map.updateFromObject(activeParentConfig.map)
+    }
+
+    render() {
+        const canMapSettingsBeInherited =
+            this.editor.couldPropertyBeInherited("map")
+        const areMapSettingsInherited = this.editor.isPropertyInherited("map")
+
+        if (!canMapSettingsBeInherited) return null
+
+        return (
+            <Section name="Inheritance">
+                {areMapSettingsInherited
+                    ? "All map settings are currently inherited."
+                    : "Some map settings overwrite the automatic defaults."}
+
+                {!areMapSettingsInherited && (
+                    <div className="mt-2">
+                        <button
+                            className="btn btn-outline-secondary"
+                            type="button"
+                            onClick={this.resetToParent}
+                        >
+                            <FontAwesomeIcon icon={faLink} className="mr-2" />
+                            Reset all map settings
+                        </button>
+                    </div>
+                )}
+            </Section>
+        )
+    }
+}
+
+@observer
 export class EditorMapTab<
     Editor extends AbstractChartEditor,
 > extends Component<{ editor: Editor }> {
@@ -209,6 +257,7 @@ export class EditorMapTab<
                         <TooltipSection mapConfig={mapConfig} />
                     </Fragment>
                 )}
+                <InheritanceSection editor={this.props.editor} />
             </div>
         )
     }

--- a/adminSiteClient/EditorTextTab.tsx
+++ b/adminSiteClient/EditorTextTab.tsx
@@ -114,7 +114,7 @@ export class EditorTextTab<
                         readFn={(grapher) => grapher.displayTitle}
                         writeFn={(grapher, newVal) => (grapher.title = newVal)}
                         auto={
-                            editor.couldPropertyBeInherited("title")
+                            editor.canPropertyBeInherited("title")
                                 ? editor.activeParentConfig!.title
                                 : undefined
                         }
@@ -179,7 +179,7 @@ export class EditorTextTab<
                             (grapher.subtitle = newVal)
                         }
                         auto={
-                            editor.couldPropertyBeInherited("subtitle")
+                            editor.canPropertyBeInherited("subtitle")
                                 ? editor.activeParentConfig!.subtitle
                                 : undefined
                         }
@@ -215,7 +215,7 @@ export class EditorTextTab<
                             (grapher.sourceDesc = newVal)
                         }
                         auto={
-                            editor.couldPropertyBeInherited("sourceDesc")
+                            editor.canPropertyBeInherited("sourceDesc")
                                 ? editor.activeParentConfig!.sourceDesc
                                 : undefined
                         }
@@ -257,7 +257,7 @@ export class EditorTextTab<
                         readFn={(grapher) => grapher.note ?? ""}
                         writeFn={(grapher, newVal) => (grapher.note = newVal)}
                         auto={
-                            editor.couldPropertyBeInherited("note")
+                            editor.canPropertyBeInherited("note")
                                 ? editor.activeParentConfig?.note
                                 : undefined
                         }

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapConfig.ts
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapConfig.ts
@@ -1,5 +1,5 @@
 import { observable } from "mobx"
-import { MapRegionName } from "@ourworldindata/types"
+import { MapConfigInterface, MapRegionName } from "@ourworldindata/types"
 import { ColorScaleConfig } from "../color/ColorScaleConfig"
 import {
     ColumnSlug,
@@ -29,8 +29,6 @@ class MapConfigDefaults {
     // Show the label from colorSchemeLabels in the tooltip instead of the numeric value
     @observable tooltipUseCustomLabels?: boolean = undefined
 }
-
-export type MapConfigInterface = MapConfigDefaults
 
 export class MapConfig extends MapConfigDefaults implements Persistable {
     updateFromObject(obj: Partial<MapConfigInterface>): void {

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -116,6 +116,7 @@ export {
     AxisMinMaxValueStr,
     GrapherTooltipAnchor,
     type InteractionState,
+    type MapConfigInterface,
 } from "./grapherTypes/GrapherTypes.js"
 
 export {


### PR DESCRIPTION
Adds a button to the chart editor that resets all map fields to their inherited defaults.

If you enable inheritance for an existing chart, then the chart's map settings overwrite the parent's map settings and there is currently no way in the admin to reset the map settings to their inherited defaults. This has been noticed by [Pablo A](https://owid.slack.com/archives/C0149NKLZAM/p1747399230591589).

This applies to all types of chart editors:
1. Chart editors for stand-alone charts
2. Chart editors for admin-authored indicator charts
3. Chart editors for narrative charts

To test each type:
- Go to this [GDP per capita chart](http://localhost:3030/admin/charts/4659/edit) that has a parent indicator with map settings
- Enable inheritance in the Debug tab
- Go to the Map tab and check that the Inheritance section on the bottom behaves correctly (editor type 1)
- Go to the Debug tab, click on 'Edit parent config in the admin' and check that the map's Inheritance section behaves correctly in the indicator chart editor (editor type 2)
- Check the map tab for any narrative chart (editor type 3)
