### PR TITLE
🐛 fix off-by-one errors

### DIFF
--- a/packages/@ourworldindata/core-table/src/OwidTable.ts
+++ b/packages/@ourworldindata/core-table/src/OwidTable.ts
@@ -279,8 +279,7 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
         // Iterate over all entities, and remove them as we go if they have no data in some column
         const entityNamesToKeep = new Set(indexesByEntityName.keys())
 
-        for (let i = 0; i <= columnSlugs.length; i++) {
-            const slug = columnSlugs[i]
+        for (const slug of columnSlugs) {
             const col = this.get(slug)
 
             // Optimization, if there are no error values in this column, we can skip this column
@@ -358,8 +357,7 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
 
         // Optimization: if there is a column that has a valid data entry for
         // every entity and every time, we are done
-        for (let i = 0; i <= columnSlugs.length; i++) {
-            const slug = columnSlugs[i]
+        for (const slug of columnSlugs) {
             const col = this.get(slug)
 
             if (
@@ -377,8 +375,7 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
             }
         }
 
-        for (let i = 0; i <= columnSlugs.length; i++) {
-            const slug = columnSlugs[i]
+        for (const slug of columnSlugs) {
             const col = this.get(slug)
 
             for (const entityName of entityNamesToIterateOver) {


### PR DESCRIPTION
While working on something else I noticed these loops that are off by one.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #4892 
- <kbd>&nbsp;1&nbsp;</kbd> #4889 👈 
<!-- GitButler Footer Boundary Bottom -->

