### PR TITLE
🐛 (marimekko) don't show entities without data in the entity selector

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -899,9 +899,10 @@ export class Grapher
         // Depending on the chart type, the criteria for being able to select an entity are
         // different; e.g. for scatterplots, the entity needs to (1) not be excluded and
         // (2) needs to have data for the x and y dimension.
-        let table = this.isScatter
-            ? this.tableAfterAuthorTimelineAndActiveChartTransform
-            : this.table
+        let table =
+            this.isScatter || this.isMarimekko
+                ? this.tableAfterAuthorTimelineAndActiveChartTransform
+                : this.table
 
         if (!this.isReady) return table
 


### PR DESCRIPTION
Relates to https://github.com/owid/owid-grapher/issues/3492 but more work is needed to resolve the issue.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #4895 
- <kbd>&nbsp;1&nbsp;</kbd> #4892 👈 
<!-- GitButler Footer Boundary Bottom -->

