### PR TITLE
✨ add option to exclude sub-areas from parentTagArrays

### DIFF
--- a/baker/algolia/utils/charts.ts
+++ b/baker/algolia/utils/charts.ts
@@ -102,8 +102,10 @@ export const getChartsRecords = async (
 
     const pageviews = await getAnalyticsPageviewsByUrlObj(knex)
 
-    const parentTagArraysByChildName =
-        await db.getParentTagArraysByChildName(knex)
+    const parentTagArraysByChildName = await db.getParentTagArraysByChildName(
+        knex,
+        true
+    )
 
     const records: ChartRecord[] = []
     for (const c of parsedRows) {

--- a/baker/algolia/utils/explorerViews.ts
+++ b/baker/algolia/utils/explorerViews.ts
@@ -761,7 +761,7 @@ async function getExplorersWithInheritedTags(trx: db.KnexReadonlyTransaction) {
     // The DB query gets the tags for the explorer, but we need to add the parent tags as well.
     // This isn't done in the query because it would require a recursive CTE.
     // It's easier to write that query once, separately, and reuse it.
-    const parentTagArrays = await db.getParentTagArraysByChildName(trx)
+    const parentTagArrays = await db.getParentTagArraysByChildName(trx, true)
     const publishedExplorersWithTags = []
 
     for (const explorer of Object.values(explorersBySlug)) {

--- a/baker/algolia/utils/mdimViews.ts
+++ b/baker/algolia/utils/mdimViews.ts
@@ -123,7 +123,7 @@ async function getMultiDimDataPagesWithInheritedTags(
     trx: db.KnexReadonlyTransaction
 ) {
     const multiDims = await getAllPublishedMultiDimDataPages(trx)
-    const parentTagArrays = await db.getParentTagArraysByChildName(trx)
+    const parentTagArrays = await db.getParentTagArraysByChildName(trx, true)
 
     const result = []
     for (const multiDim of multiDims) {


### PR DESCRIPTION
Resolves https://github.com/owid/owid-grapher/issues/4675

Allows us to filter out non-topic, non-area tags from the tag graph and does so for mdim, chart, and explorer indexing.