### PR TITLE
🎉 updated aside component

### DIFF
--- a/site/gdocs/components/centered-article.scss
+++ b/site/gdocs/components/centered-article.scss
@@ -807,33 +807,42 @@ p.article-block__text + #article-licence {
     }
 }
 
-.article-block__aside-right figcaption {
-    border-left: 1px solid $blue-20;
-    padding-left: 24px;
-    a {
-        @include owid-link-90;
+figure[class*="article-block__aside"] {
+    position: relative;
+    margin: 0;
+
+    figcaption {
+        margin-bottom: 8px;
+        a {
+            @include owid-link-90;
+        }
+
+        @include md-up {
+            position: absolute;
+        }
+
+        @include md-down {
+            border-left: 1px solid $blue-20;
+            border-right: 1px solid $blue-20;
+            padding: 16px;
+            text-align: center;
+        }
     }
 
     @include md-down {
-        border: 1px solid $blue-20;
-        padding: 24px;
+        margin-bottom: 16px;
     }
+}
+
+.article-block__aside-right figcaption {
+    border-left: 1px solid $blue-20;
+    padding-left: 16px;
 }
 
 .article-block__aside-left figcaption {
     border-right: 1px solid $blue-20;
-    padding-right: 24px;
+    padding-right: 16px;
     text-align: right;
-    a {
-        @include owid-link-90;
-    }
-
-    // Same as aside-right when in a single-column mobile view
-    @include md-down {
-        border: 1px solid $blue-20;
-        padding: 24px;
-        text-align: left;
-    }
 }
 
 div.article-block__table--narrow,

--- a/site/gdocs/components/layout.ts
+++ b/site/gdocs/components/layout.ts
@@ -24,8 +24,8 @@ const layouts: { [key in Container]: Layouts} = {
     ["default"]: {
         ["align"]: "col-start-5 span-cols-6 col-md-start-3 span-md-cols-10 span-sm-cols-12 col-sm-start-2",
         ["all-charts"]: "col-start-2 span-cols-12",
-        ["aside-left"]: "col-start-2 span-cols-3 span-md-cols-10 col-md-start-3",
-        ["aside-right"]: "col-start-11 span-cols-3 span-md-cols-10 col-md-start-3",
+        ["aside-left"]: "col-start-2 span-cols-3 span-md-cols-10 col-md-start-3 span-sm-cols-12 col-sm-start-2",
+        ["aside-right"]: "col-start-11 span-cols-3 span-md-cols-10 col-md-start-3 span-sm-cols-12 col-sm-start-2",
         ["chart-story"]: "col-start-4 span-cols-8 col-md-start-3 span-md-cols-10 span-sm-cols-12 col-sm-start-2",
         ["chart"]: "col-start-4 span-cols-8 col-md-start-3 span-md-cols-10 span-sm-cols-12 col-sm-start-2",
         ["default"]: "col-start-5 span-cols-6 col-md-start-3 span-md-cols-10 span-sm-cols-12 col-sm-start-2",


### PR DESCRIPTION
## Context

Part of https://github.com/owid/owid-grapher/issues/4851

[Figma](https://www.figma.com/design/8XR11jiphFH5YwegxkhqxE/Archie-Components-Revamp?node-id=1-25&t=IfpuZFpxGIFO1YMO-0)

## Screenshots / Videos / Diagrams

https://github.com/user-attachments/assets/6f2a5925-b17a-4502-83e2-db08c611bbb2

## Testing guidance

You can use the following Archie:
```
{.aside}
caption: Nulla ut ex nec sem consequat ullamcorper. Sed neque risus, ultrices sit amet neque varius, posuere efficitur nibh. Donec viverra maximus euismod. Nunc tincidunt pharetra diam ut accumsan.
position: left
{}
```

`position: right` is also supported. Try it beside paragraphs that are very short. As long as it's not at the very end of the article or prior to a full-width component, it should be okay)

- [ ] Does the staging experience have sign-off from product stakeholders?
- [x] Changes to CSS/HTML were checked on Desktop and Mobile Safari at all three breakpoints
- [x] Changes to HTML were checked for accessibility concerns