### PR TITLE
🎉 show projected data in the entity selector

### DIFF
--- a/packages/@ourworldindata/core-table/src/CoreTableColumns.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTableColumns.ts
@@ -488,6 +488,22 @@ export abstract class AbstractCoreColumn<JS_TYPE extends PrimitiveType> {
     }
 
     // todo: remove? Should not be on CoreTable
+    @imemo get valueByTimeAndEntityName(): Map<Time, Map<EntityName, JS_TYPE>> {
+        const valueByTimeAndEntityName = new Map<
+            Time,
+            Map<EntityName, JS_TYPE>
+        >()
+        this.owidRows.forEach((row) => {
+            if (!valueByTimeAndEntityName.has(row.time))
+                valueByTimeAndEntityName.set(row.time, new Map())
+            valueByTimeAndEntityName
+                .get(row.time)!
+                .set(row.entityName, row.value)
+        })
+        return valueByTimeAndEntityName
+    }
+
+    // todo: remove? Should not be on CoreTable
     // NOTE: this uses the original times, so any tolerance is effectively unapplied.
     @imemo get valueByEntityNameAndOriginalTime(): Map<
         EntityName,


### PR DESCRIPTION
> [!IMPORTANT]
> Check SVG tester after all parent PRs have been merged.  

Adds projection columns to the entity selector.

### Summary

Similar to how it works for maps, projection columns and their historical counterparts are combined into one sort column. If we can’t find a historical counterpart for a projection column, we just add it as-is to the dropdown options.

The dropdown label automatically updates when you drag the timeline handle (should the historical and project columns have different names)

### Debatable

Usually, projection columns have a clear cut-off year, but we do sometimes have combined columns with historical and projected data for the same year ([example](http://staging-site-entity-selector-projections/admin/charts/7406/edit)). In such cases, we drop the projected data and only show the historical data values in the entity selector. That's potentially confusing because the chart/map might show data values where the entity selector doesn't, but it's a rare case, so this seemed more practical than adding a note or tooltip or such to projected data values. (From a technical point of view, it would be easier to just show a tooltip, but I don't think we want to overload the entity selector with an additional tooltip or something similar)

<!-- GitButler Footer Boundary Top -->
---
This is **part 15 of 16 in a stack** made with GitButler:
- <kbd>&nbsp;16&nbsp;</kbd> #4914 
- <kbd>&nbsp;15&nbsp;</kbd> #4911 👈 
- <kbd>&nbsp;14&nbsp;</kbd> #4907 
- <kbd>&nbsp;13&nbsp;</kbd> #4883 
- <kbd>&nbsp;12&nbsp;</kbd> #4877 
- <kbd>&nbsp;11&nbsp;</kbd> #4876 
- <kbd>&nbsp;10&nbsp;</kbd> #4875 
- <kbd>&nbsp;9&nbsp;</kbd> #4864 
- <kbd>&nbsp;8&nbsp;</kbd> #4809 
- <kbd>&nbsp;7&nbsp;</kbd> #4808 
- <kbd>&nbsp;6&nbsp;</kbd> #4770 
- <kbd>&nbsp;5&nbsp;</kbd> #4745 
- <kbd>&nbsp;4&nbsp;</kbd> #4744 
- <kbd>&nbsp;3&nbsp;</kbd> #4743 
- <kbd>&nbsp;2&nbsp;</kbd> #4719 
- <kbd>&nbsp;1&nbsp;</kbd> #4708 
<!-- GitButler Footer Boundary Bottom -->

