### PR TITLE
:bug: Fix error message when fetching metadata

### DIFF
--- a/db/model/Variable.ts
+++ b/db/model/Variable.ts
@@ -826,9 +826,7 @@ export const fetchS3MetadataByPath = async (
         throw new Error(
             `Error parsing JSON from response for ${metadataPath}: ${
                 error.message
-            }\nStatus Code: ${resp.status} ${
-                resp.statusText
-            }\nResponse Body: ${await resp.text()}`
+            }\nStatus Code: ${resp.status} ${resp.statusText}`
         )
     }
 }


### PR DESCRIPTION
When fetching metadata fails, error message tries to re-read body with `await resp.text()` which fails. This PR removes the body from the error message, it's not that useful anyway.