### PR TITLE
Allow previewing unpublished mdims in gdocs

### DIFF
--- a/adminSiteClient/GdocsSettingsForms.tsx
+++ b/adminSiteClient/GdocsSettingsForms.tsx
@@ -32,12 +32,12 @@ const GdocCommonErrors = ({
     )
     return (
         <>
-            {errorsToShowInDrawer.map((error) => (
+            {errorsToShowInDrawer.map((error, index) => (
                 <Alert
+                    key={index}
+                    className="GdocsSettingsForm__alert"
                     message={error.message}
                     type={error.type}
-                    key={error.message}
-                    className="GdocsSettingsForm__alert"
                     showIcon
                 />
             ))}

--- a/adminSiteServer/mockSiteRouter.ts
+++ b/adminSiteServer/mockSiteRouter.ts
@@ -243,7 +243,9 @@ getPlainRouteWithROTransaction(
     mockSiteRouter,
     "/multi-dim/:slug.json",
     async (req, res, trx) => {
-        const multiDim = await getMultiDimDataPageBySlug(trx, req.params.slug)
+        const multiDim = await getMultiDimDataPageBySlug(trx, req.params.slug, {
+            onlyPublished: false,
+        })
         if (!multiDim) throw new JsonError("No such multi-dim", 404)
         res.json(multiDim.config)
     }

--- a/db/model/Gdoc/GdocBase.ts
+++ b/db/model/Gdoc/GdocBase.ts
@@ -677,7 +677,8 @@ export class GdocBase implements OwidGdocBaseInterface {
                 } else {
                     const multiDim = await getMultiDimDataPageBySlug(
                         knex,
-                        originalSlug
+                        originalSlug,
+                        { onlyPublished: false }
                     )
                     if (!multiDim) return
                     return makeMultiDimLinkedChart(


### PR DESCRIPTION
## Description

We identify both normal charts and mdims by slug in the Archie component, but we can preview only unpublisehd mdims in the gdoc because slug is not unique for unpublished charts.

We still show a validation error in the admin and prevent publishing a gdoc with unpublished mdim.

## Context

Requested by Joe. Required for our work on new topic pages (and/or articles) with mdims.

## Screenshots / Videos / Diagrams

<img width="733" alt="image" src="https://github.com/user-attachments/assets/68d034cd-ded5-4b6c-9601-3de83a338017" />

## Testing guidance

Check that it's possible to preview unpublished mdim in a gdoc, but it's not possible to publish such gdoc.