### PR TITLE
cleanup: remove `equalSizeBins` from ColorScale

### DIFF
--- a/adminSiteClient/EditorColorScaleSection.tsx
+++ b/adminSiteClient/EditorColorScaleSection.tsx
@@ -37,7 +37,6 @@ import {
 } from "./ColorSchemeDropdown.js"
 
 interface EditorColorScaleSectionFeatures {
-    visualScaling: boolean
     legendDescription: boolean
 }
 
@@ -74,11 +73,6 @@ class ColorLegendSection extends Component<{
     features: EditorColorScaleSectionFeatures
     onChange?: () => void
 }> {
-    @action.bound onEqualSizeBins(isEqual: boolean) {
-        this.props.scale.config.equalSizeBins = isEqual
-        this.props.onChange?.()
-    }
-
     @action.bound onManualBins() {
         populateManualBinValuesIfAutomatic(this.props.scale)
         this.props.onChange?.()
@@ -88,15 +82,6 @@ class ColorLegendSection extends Component<{
         const { scale, features } = this.props
         return (
             <Section name="Color legend">
-                {features.visualScaling && (
-                    <FieldsRow>
-                        <Toggle
-                            label="Disable visual scaling of legend bins"
-                            value={!!scale.config.equalSizeBins}
-                            onValue={this.onEqualSizeBins}
-                        />
-                    </FieldsRow>
-                )}
                 {features.legendDescription && (
                     <FieldsRow>
                         <BindString

--- a/adminSiteClient/EditorCustomizeTab.tsx
+++ b/adminSiteClient/EditorCustomizeTab.tsx
@@ -759,7 +759,6 @@ export class EditorCustomizeTab<
                         }
                         showLineChartColors={grapher.isLineChart}
                         features={{
-                            visualScaling: true,
                             legendDescription: true,
                         }}
                     />

--- a/adminSiteClient/EditorMapTab.tsx
+++ b/adminSiteClient/EditorMapTab.tsx
@@ -255,7 +255,6 @@ export class EditorMapTab<
                             chartType={GRAPHER_MAP_TYPE}
                             showLineChartColors={false}
                             features={{
-                                visualScaling: true,
                                 legendDescription: false,
                             }}
                         />

--- a/adminSiteClient/GrapherConfigGridEditor.tsx
+++ b/adminSiteClient/GrapherConfigGridEditor.tsx
@@ -486,7 +486,6 @@ export class GrapherConfigGridEditor extends React.Component<GrapherConfigGridEd
                             scale={colorScale}
                             chartType={GRAPHER_MAP_TYPE}
                             features={{
-                                visualScaling: true,
                                 legendDescription: false,
                             }}
                             showLineChartColors={false}
@@ -513,7 +512,6 @@ export class GrapherConfigGridEditor extends React.Component<GrapherConfigGridEd
                                     GRAPHER_CHART_TYPES.LineChart
                                 }
                                 features={{
-                                    visualScaling: true,
                                     legendDescription: false,
                                 }}
                                 showLineChartColors={grapher.isLineChart}

--- a/db/migration/1748436369499-RemoveEqualSizeBins.ts
+++ b/db/migration/1748436369499-RemoveEqualSizeBins.ts
@@ -1,0 +1,64 @@
+import { Json } from "@ourworldindata/utils"
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+const tables = [
+    { table: "chart_configs", column: "patch" },
+    { table: "chart_configs", column: "full" },
+    { table: "chart_revisions", column: "config" },
+    { table: "suggested_chart_revisions", column: "suggestedConfig" },
+]
+
+export class RemoveEqualSizeBins1748436369499 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        // Remove equalSizeBins from colorScale and map.colorScale for all charts
+        for (const { table, column } of tables) {
+            await queryRunner.query(
+                `-- sql
+                    UPDATE ${table}
+                    SET ${column} = JSON_REMOVE(
+                        ${column},
+                        "$.colorScale.equalSizeBins",
+                        "$.map.colorScale.equalSizeBins"
+                    )
+                    WHERE ${column} ->> "$.colorScale.equalSizeBins" IS NOT NULL
+                       OR ${column} ->> "$.map.colorScale.equalSizeBins" IS NOT NULL
+                `
+            )
+        }
+
+        // Remove colorScaleEqualSizeBins from explorers. This cannot easily be done with JSON_REMOVE, so we need to
+        // do it in JS instead.
+        const deleteEqualSizeBinsFromExplorer = (config: Json): Json => {
+            for (const block of config.blocks ?? []) {
+                for (const props of block.block ?? []) {
+                    delete props.colorScaleEqualSizeBins
+                }
+            }
+            return config
+        }
+
+        const affectedExplorers = await queryRunner.query(
+            `-- sql
+                SELECT slug, config
+                FROM explorers
+                WHERE config LIKE "%colorScaleEqualSizeBins%"
+            `
+        )
+        for (const { slug, config } of affectedExplorers) {
+            const parsedConfig = JSON.parse(config)
+            const updatedConfig = deleteEqualSizeBinsFromExplorer(parsedConfig)
+            await queryRunner.query(
+                `-- sql
+                    UPDATE explorers
+                    SET config = ?
+                    WHERE slug = ?
+                `,
+                [JSON.stringify(updatedConfig), slug]
+            )
+        }
+    }
+
+    public async down(_queryRunner: QueryRunner): Promise<void> {
+        // intentionally left empty
+    }
+}

--- a/devTools/schemaProcessor/columns.json
+++ b/devTools/schemaProcessor/columns.json
@@ -91,12 +91,6 @@
         ]
     },
     {
-        "type": "boolean",
-        "pointer": "/map/colorScale/equalSizeBins",
-        "default": false,
-        "editor": "checkbox"
-    },
-    {
         "type": "object",
         "pointer": "/map/colorScale/customHiddenCategories",
         "editor": "mappingEditor"
@@ -338,12 +332,6 @@
             "stackedAreaDefault",
             "owid-distinct"
         ]
-    },
-    {
-        "type": "boolean",
-        "pointer": "/colorScale/equalSizeBins",
-        "default": true,
-        "editor": "checkbox"
     },
     {
         "type": "object",

--- a/packages/@ourworldindata/explorer/src/ColumnGrammar.ts
+++ b/packages/@ourworldindata/explorer/src/ColumnGrammar.ts
@@ -178,11 +178,6 @@ export const ColumnGrammar: Grammar<ColumnCellDef> = {
         keyword: "colorScaleLegendDescription",
         description: "Legend title",
     },
-    colorScaleEqualSizeBins: {
-        ...BooleanCellDef,
-        keyword: "colorScaleEqualSizeBins",
-        description: "Disable visual scaling of the bins based on values?",
-    },
     colorScaleNumericMinValue: {
         ...NumericCellDef,
         keyword: "colorScaleNumericMinValue",

--- a/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChart.tsx
@@ -828,11 +828,6 @@ export class DiscreteBarChart
         return undefined
     }
 
-    // TODO just pass colorScale to legend and let it figure it out?
-    @computed get equalSizeBins(): boolean | undefined {
-        return this.colorScale.config.equalSizeBins
-    }
-
     numericBinSize = 10
     numericBinStroke = BACKGROUND_COLOR
     numericBinStrokeWidth = 1

--- a/packages/@ourworldindata/grapher/src/color/ColorScale.test.ts
+++ b/packages/@ourworldindata/grapher/src/color/ColorScale.test.ts
@@ -34,7 +34,6 @@ describe(ColorScale, () => {
             customCategoryColors: {},
             customCategoryLabels: {},
             customHiddenCategories: {},
-            equalSizeBins: true,
         }
         it("returns correct color", () => {
             const colorValuePairs = [
@@ -140,7 +139,6 @@ describe(ColorScale, () => {
             customCategoryColors: { test: "#eee" },
             customCategoryLabels: {},
             customHiddenCategories: {},
-            equalSizeBins: true,
         }
         const table = new CoreTable(
             {

--- a/packages/@ourworldindata/grapher/src/color/ColorScaleConfig.test.ts
+++ b/packages/@ourworldindata/grapher/src/color/ColorScaleConfig.test.ts
@@ -13,7 +13,6 @@ describe("fromDSL", () => {
         colorScaleScheme: ColorSchemeName.Magma,
         colorScaleInvert: true,
         // colorScaleBinningStrategy: undefined,
-        colorScaleEqualSizeBins: true,
         colorScaleNumericMinValue: 0.5,
         colorScaleNumericBins: "1,#ddd,One;2,#eee,Two",
         colorScaleCategoricalBins: "one,#ddd,uno;two,#eee,dos",
@@ -24,7 +23,6 @@ describe("fromDSL", () => {
     it("handles comprehensive test case", () => {
         expect(colorScale.baseColorScheme).toEqual(ColorSchemeName.Magma)
         expect(colorScale.colorSchemeInvert).toBeTruthy()
-        expect(colorScale.equalSizeBins).toBeTruthy()
         expect(colorScale.customNumericMinValue).toEqual(0.5)
         expect(colorScale.customCategoryLabels).toEqual({
             one: "uno",

--- a/packages/@ourworldindata/grapher/src/color/ColorScaleConfig.ts
+++ b/packages/@ourworldindata/grapher/src/color/ColorScaleConfig.ts
@@ -58,7 +58,6 @@ export class ColorScaleConfigDefaults {
      */
     @observable customNumericColors: (Color | undefined | null)[] = []
 
-
     // Categorical bins
     // ================
 
@@ -160,7 +159,6 @@ export class ColorScaleConfig
             : scale.colorScaleNumericBins || scale.colorScaleCategoricalBins
               ? BinningStrategy.manual
               : undefined
-
 
         const legendDescription = scale.colorScaleLegendDescription
 

--- a/packages/@ourworldindata/grapher/src/color/ColorScaleConfig.ts
+++ b/packages/@ourworldindata/grapher/src/color/ColorScaleConfig.ts
@@ -58,8 +58,6 @@ export class ColorScaleConfigDefaults {
      */
     @observable customNumericColors: (Color | undefined | null)[] = []
 
-    /** Whether the visual scaling for the color legend is disabled. */
-    @observable equalSizeBins?: boolean = true
 
     // Categorical bins
     // ================
@@ -163,7 +161,6 @@ export class ColorScaleConfig
               ? BinningStrategy.manual
               : undefined
 
-        const equalSizeBins = scale.colorScaleEqualSizeBins
 
         const legendDescription = scale.colorScaleLegendDescription
 
@@ -178,7 +175,6 @@ export class ColorScaleConfig
             customNumericMinValue,
             customCategoryLabels,
             customCategoryColors,
-            equalSizeBins,
             legendDescription,
         })
 
@@ -196,7 +192,6 @@ export class ColorScaleConfig
             customNumericMinValue,
             customCategoryLabels,
             customCategoryColors,
-            equalSizeBins,
             legendDescription,
         } = this.toObject()
 
@@ -204,7 +199,6 @@ export class ColorScaleConfig
             colorScaleScheme: baseColorScheme,
             colorScaleInvert: colorSchemeInvert,
             colorScaleBinningStrategy: binningStrategy,
-            colorScaleEqualSizeBins: equalSizeBins,
             colorScaleLegendDescription: legendDescription,
             colorScaleNumericMinValue: customNumericMinValue,
             colorScaleNumericBins: (customNumericValues ?? [])

--- a/packages/@ourworldindata/grapher/src/facetChart/FacetChart.tsx
+++ b/packages/@ourworldindata/grapher/src/facetChart/FacetChart.tsx
@@ -729,10 +729,6 @@ export class FacetChart
         return this.getExternalLegendProp("numericBinStrokeWidth")
     }
 
-    @computed get equalSizeBins(): boolean | undefined {
-        return this.getExternalLegendProp("equalSizeBins")
-    }
-
     @computed get hoverColors(): Color[] | undefined {
         if (!this.legendHoverBin) return undefined
         return [this.legendHoverBin.color]

--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChart.test.ts
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChart.test.ts
@@ -355,7 +355,6 @@ describe("color scale", () => {
                 customNumericColorsActive: true,
                 customNumericLabels: [],
                 customNumericValues: [1.5, 2.5],
-                equalSizeBins: true,
             },
         }
         const chart = new LineChart({ manager })

--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
@@ -1174,11 +1174,6 @@ export class LineChart
         )
     }
 
-    // TODO just pass colorScale to legend and let it figure it out?
-    @computed get equalSizeBins(): boolean | undefined {
-        return this.colorScale.config.equalSizeBins
-    }
-
     numericBinSize = 6
     numericBinStrokeWidth = 1
     legendTextColor = "#555"
@@ -1524,7 +1519,6 @@ export class LineChart
                 legendTitle: this.legendTitle,
                 legendTextColor: this.legendTextColor,
                 legendTickSize: this.legendTickSize,
-                equalSizeBins: this.equalSizeBins,
                 numericBinSize: this.numericBinSize,
                 numericBinStroke: this.numericBinStroke,
                 numericBinStrokeWidth: this.numericBinStrokeWidth,

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
@@ -397,10 +397,6 @@ export class MapChart
         return this.colorScale.legendBins
     }
 
-    @computed get equalSizeBins(): boolean | undefined {
-        return this.colorScale.config.equalSizeBins
-    }
-
     /** The value of the currently hovered feature/country */
     @computed get hoverValue(): string | number | undefined {
         if (!this.hoverFeatureId) return undefined

--- a/packages/@ourworldindata/grapher/src/schema/defaultGrapherConfig.ts
+++ b/packages/@ourworldindata/grapher/src/schema/defaultGrapherConfig.ts
@@ -20,7 +20,6 @@ export const defaultGrapherConfig = {
         region: "World",
         hideTimeline: false,
         colorScale: {
-            equalSizeBins: true,
             binningStrategy: "ckmeans",
             customNumericColorsActive: false,
             colorSchemeInvert: false,
@@ -48,7 +47,6 @@ export const defaultGrapherConfig = {
     timelineMinTime: "earliest",
     hideTimeline: false,
     colorScale: {
-        equalSizeBins: true,
         binningStrategy: "ckmeans",
         customNumericColorsActive: false,
         colorSchemeInvert: false,

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.007.yaml
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.007.yaml
@@ -681,10 +681,6 @@ $defs:
                         type: string
             baseColorScheme:
                 $ref: "#/$defs/colorScheme"
-            equalSizeBins:
-                type: boolean
-                default: true
-                description: Whether the visual scaling for the color legend is disabled.
             customHiddenCategories:
                 type: object
                 description: Allow hiding categories from the legend

--- a/packages/@ourworldindata/types/src/domainTypes/CoreTableTypes.ts
+++ b/packages/@ourworldindata/types/src/domainTypes/CoreTableTypes.ts
@@ -180,7 +180,6 @@ export interface ColumnColorScale {
     colorScaleScheme?: string
     colorScaleInvert?: boolean
     colorScaleBinningStrategy?: string
-    colorScaleEqualSizeBins?: boolean
     colorScaleNumericMinValue?: number
     colorScaleNumericBins?: string
     colorScaleCategoricalBins?: string

--- a/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
+++ b/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
@@ -381,9 +381,6 @@ export class ColorScaleConfigDefaults {
      */
     @observable customNumericColors: (Color | undefined | null)[] = []
 
-    /** Whether the visual scaling for the color legend is disabled. */
-    @observable equalSizeBins?: boolean = true
-
     // Categorical bins
     // ================
 
@@ -424,7 +421,7 @@ export type ColorScaleConfigInterface = ColorScaleConfigDefaults
 //     customNumericLabels: (string | undefined | null)[]
 //     customNumericColorsActive?: boolean
 //     customNumericColors: (Color | undefined | null)[]
-//     equalSizeBins?: boolean
+
 //     customCategoryColors: Record<string, string | undefined>
 //     customCategoryLabels: Record<string, string | undefined>
 //     customHiddenCategories: Record<string, true | undefined>
@@ -436,7 +433,7 @@ export type ColorScaleConfigInterface = ColorScaleConfigDefaults
 //     customNumericValues: [],
 //     customNumericLabels: [],
 //     customNumericColors: [],
-//     equalSizeBins: true,
+
 //     customCategoryColors: {},
 //     customCategoryLabels: {},
 //     customHiddenCategories: {},


### PR DESCRIPTION
This option is enabled in pretty much every single chart (there was only one or two exceptions, and it most likely weren't intentional).

SVG diff is here: https://github.com/owid/owid-grapher-svgs/commit/79b3e96ddc5dd06c94e44c3f98a0bd3fedfdc090

For reference, this is what `equalSizeBins: false` would do:
![CleanShot 2025-05-28 at 15 46 32](https://github.com/user-attachments/assets/fc1011a3-7b9a-48a6-a2d3-8b6c44b5d40b)
Our [map bracket guide explicitly recommends](https://www.notion.so/owid/How-to-pick-map-brackets-fca269b396c3470e8d54dd762390ce2a?pvs=4#ee27365c7b6d480abdf2300fcf057f63) against enabling visual scaling.
