### PR TITLE
Remove unused suggested_chart_revisions table

### DIFF
--- a/db/migration/1748446282000-DropSuggestedChartRevisionsTable.ts
+++ b/db/migration/1748446282000-DropSuggestedChartRevisionsTable.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class DropSuggestedChartRevisionsTable1748446282000
+    implements MigrationInterface
+{
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            "DROP TABLE IF EXISTS `suggested_chart_revisions`"
+        )
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        // No rollback - table removal is permanent
+    }
+}

--- a/db/migration/1748446282000-DropSuggestedChartRevisionsTable.ts
+++ b/db/migration/1748446282000-DropSuggestedChartRevisionsTable.ts
@@ -9,7 +9,7 @@ export class DropSuggestedChartRevisionsTable1748446282000
         )
     }
 
-    public async down(queryRunner: QueryRunner): Promise<void> {
+    public async down(_queryRunner: QueryRunner): Promise<void> {
         // No rollback - table removal is permanent
     }
 }


### PR DESCRIPTION
## Summary
• Removes the `suggested_chart_revisions` table which appears to be unused in the application code
• Analysis shows this table is only referenced in database migrations, with no TypeScript/JavaScript usage

## Test plan
- [x] Verify migration runs successfully
- [x] Confirm no application functionality is affected
- [x] Check that all existing migrations still work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)