### PR TITLE
🐛 show error message in the admin

### DIFF
--- a/adminSiteServer/apiRoutes/charts.ts
+++ b/adminSiteServer/apiRoutes/charts.ts
@@ -717,7 +717,7 @@ export async function createChart(
 
         return { success: true, chartId: chartId }
     } catch (err) {
-        return { success: false, error: String(err) }
+        return { success: false, error: { message: String(err), status: 500 } }
     }
 }
 
@@ -763,7 +763,7 @@ export async function updateChart(
     } catch (err) {
         return {
             success: false,
-            error: String(err),
+            error: { message: String(err), status: 500 },
         }
     }
 }


### PR DESCRIPTION
I'm literally so confused by our error handling in the admin api router. `admin.requestJSON` expects `error` to have a `message` and `status`, so I added those for the charts endpoints. Not sure if we need to do this elsewhere as well?

Try updating [this chart on staging](http://staging-site-show-errors-in-admin/admin/charts/349/edit) (unless Bastian has fixed the problem by now)