### PR TITLE
Fix logo position in them main nav on a small screen

### DIFF
--- a/site/SiteLogos.scss
+++ b/site/SiteLogos.scss
@@ -2,8 +2,15 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    @include column-gap(24px);
     flex-shrink: 0;
+
+    .logo-owid {
+        margin-right: 24px;
+
+        @include sm-only {
+            margin-right: 0;
+        }
+    }
 
     .logo-owid a {
         @include md-up {


### PR DESCRIPTION
The logo currently isn't centered on small screens.

The `column-gap` polyfill doesn't work correctly when the last child is `display: hidden` which became the case at some point.

Went with this fix to be on the safe side, instead of switching to the `column-gap` property, which wouldn't work correctly for all widths by itself anyway.

| Before | After |
|--------|--------|
| <img width="411" alt="image" src="https://github.com/user-attachments/assets/167fd432-cd75-4d80-9e5a-7f0e674fe853" /> | <img width="411" alt="image" src="https://github.com/user-attachments/assets/6a6e831f-103d-453e-9ac9-807362b0a041" /> |
