### PR TITLE
🐛 fix grapher 3D zoom trap

### DIFF
--- a/packages/@ourworldindata/grapher/src/mapCharts/ChoroplethMap.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/ChoroplethMap.tsx
@@ -329,8 +329,9 @@ export class ChoroplethMap extends React.Component<{
         if (isMapSelectionEnabled) {
             // select/deselect the country if allowed
             selection.toggleSelection(feature.id)
-        } else {
-            // rotate to the selected country on the globe on mobile
+        } else if (window?.visualViewport?.scale === 1) {
+            // rotate to the selected country on the globe
+            // but not if the user is zoomed in, otherwise they can get stuck in 3D mode
             globeController?.focusOnCountry(feature.id)
         }
     }


### PR DESCRIPTION
## Context

A "dumb" fix for https://github.com/owid/owid-grapher/issues/4957

## Video

https://github.com/user-attachments/assets/7d9a9982-120c-4cc9-b52f-0f2e418860b0

## Testing guidance

You can use either the MacOS simulator app, or your browser's phone simulator and zoom in via the track pad.