### PR TITLE
🐛 fix line labels not wrapping into a new line

### DIFF
--- a/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.tsx
+++ b/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.tsx
@@ -147,11 +147,11 @@ class LineLabels extends React.Component<{
                             show={this.showTextOutline}
                             outlineWidth={
                                 GRAPHER_TEXT_OUTLINE_FACTOR *
-                                series.textWrapForRendering.fontSize
+                                series.textWrap.fontSize
                             }
                             outlineColor={this.textOutlineColor}
                         >
-                            {series.textWrapForRendering.renderSVG(
+                            {series.textWrap.renderSVG(
                                 labelText.x,
                                 labelText.y,
                                 {
@@ -441,17 +441,8 @@ export class LineLegend extends React.Component<LineLegendProps> {
             const fontWeight =
                 activeFontWeight ?? seriesFontWeight ?? globalFontWeight
 
-            // line labels might be focused/unfocused, which affects their font weight.
-            // if we used the actual font weight for measuring the text width,
-            // the layout would be jumpy when focusing/unfocusing a series.
-            const fontWeightsForMeasuring = { label: 700, value: 700 }
-            const fontWeightsForRendering = { label: fontWeight, value: 400 }
-            const textWrap = this.makeLabelTextWrap(series, {
-                fontWeights: fontWeightsForMeasuring,
-            })
-            const textWrapForRendering = this.makeLabelTextWrap(series, {
-                fontWeights: fontWeightsForRendering,
-            })
+            const fontWeights = { label: fontWeight, value: 400 }
+            const textWrap = this.makeLabelTextWrap(series, { fontWeights })
 
             const annotationTextWrap = this.makeAnnotationTextWrap(series)
             const annotationWidth = annotationTextWrap?.width ?? 0
@@ -462,7 +453,6 @@ export class LineLegend extends React.Component<LineLegendProps> {
             return {
                 ...series,
                 textWrap,
-                textWrapForRendering,
                 annotationTextWrap,
                 width: Math.max(textWrap.width, annotationWidth),
                 height: textWrap.height + annotationHeight,

--- a/packages/@ourworldindata/grapher/src/lineLegend/LineLegendTypes.ts
+++ b/packages/@ourworldindata/grapher/src/lineLegend/LineLegendTypes.ts
@@ -15,7 +15,6 @@ export interface LineLabelSeries extends ChartSeries {
 
 export interface SizedSeries extends LineLabelSeries {
     textWrap: TextWrap | MarkdownTextWrap
-    textWrapForRendering: TextWrap | MarkdownTextWrap
     annotationTextWrap?: TextWrap
     width: number
     height: number


### PR DESCRIPTION
Fixes #4941

We used a special logic to make sure the label doesn't jump on click when it's bolded. This lead to the issue described in #4941. This PR gets rid of the extra logic since it's more important to wrap labels correctly than preventing jumpy behaviour for a feature that barely anyone uses.