### PR TITLE
✨ outline article images by default

### DIFF
--- a/db/model/Gdoc/rawToEnriched.ts
+++ b/db/model/Gdoc/rawToEnriched.ts
@@ -762,7 +762,9 @@ const parseImage = (image: RawBlockImage): EnrichedBlockImage => {
     if (!booleanValidation.isValid) {
         return createError(booleanValidation)
     }
-    const hasOutline = image.value.hasOutline === "true"
+    const hasOutline = image.value.hasOutline
+        ? image.value.hasOutline === "true"
+        : true // Default to true if not specified
 
     return {
         type: "image",


### PR DESCRIPTION
Part of https://github.com/owid/owid-grapher/issues/4851

It's much rarer that we _don't_ want outlines around our images, so Marwa has asked that we make this the new default.

Will check with her to see if we need to do an audit/update before merging.