### PR TITLE
🐛 parse table search param from url

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -854,6 +854,11 @@ export class Grapher
                 ? params.tableFilter
                 : "all"
         }
+
+        // data table search
+        if (params.tableSearch) {
+            this.dataTableConfig.search = params.tableSearch
+        }
     }
 
     @action.bound private setTimeFromTimeQueryParam(time: string): void {


### PR DESCRIPTION
Respect the `tableSearch` param (I forgot to parse it from the url when adding this feature)