### PR TITLE
🐛 fix unpublished articles in author pages

### DIFF
--- a/db/model/Post.ts
+++ b/db/model/Post.ts
@@ -423,6 +423,7 @@ export const getLatestWorkByAuthor = async (
             JSON_CONTAINS(authors, ?)
             AND pg.published = TRUE
             AND pg.type = "${OwidGdocType.Article}"
+            AND publishedAt <= NOW()
         ORDER BY publishedAt DESC
         `,
         [`"${author}"`]


### PR DESCRIPTION
Fixes scheduled posts from showing up on author pages

e.g. on [Saloni's page](https://ourworldindata.org/team/saloni-dattani):

![oopsie](https://github.com/user-attachments/assets/dd43f500-4ef1-44d8-8745-5477a08c3181)

