### PR TITLE
fix: use diacritics in country names

### DIFF
--- a/packages/@ourworldindata/utils/src/regions.json
+++ b/packages/@ourworldindata/utils/src/regions.json
@@ -362,7 +362,7 @@
     {
         "code": "CIV",
         "shortCode": "CI",
-        "name": "Cote d'Ivoire",
+        "name": "Côte d'Ivoire",
         "slug": "cote-divoire",
         "regionType": "country",
         "isMappable": true
@@ -443,7 +443,7 @@
     {
         "code": "CUW",
         "shortCode": "CW",
-        "name": "Curacao",
+        "name": "Curaçao",
         "slug": "curacao",
         "regionType": "country",
         "isUnlisted": true
@@ -2426,7 +2426,7 @@
     {
         "code": "REU",
         "shortCode": "RE",
-        "name": "Reunion",
+        "name": "Réunion",
         "slug": "reunion",
         "regionType": "country"
     },
@@ -2576,7 +2576,7 @@
     {
         "code": "STP",
         "shortCode": "ST",
-        "name": "Sao Tome and Principe",
+        "name": "São Tomé and Príncipe",
         "slug": "sao-tome-and-principe",
         "regionType": "country",
         "isMappable": true


### PR DESCRIPTION
⚠️ not tested, more of a discussion prompt

## Context

This PR updates the spelling of several country names in our regions.json file to include proper diacritical marks:

- "Cote d'Ivoire" → "Côte d'Ivoire"
- "Curacao" → "Curaçao"
- "Reunion" → "Réunion"
- "Sao Tome and Principe" → "São Tomé and Príncipe"

These changes ensure our country names follow official spellings with correct accents.
