### PR TITLE
Remove buildTsc script

### DIFF
--- a/.clinerules
+++ b/.clinerules
@@ -1,7 +1,6 @@
 # Bash commands
 
 - yarn buildLerna: Build the packages (types and utils, core table, the grapher data viz component and the data explorer)
-- yarn buildTsc: Build the typescript code for the rest of the codebase (the site, admin UI etc)
 - yarn typecheck: runs the typescript typechecker across all files (both frontend code in lerna managed packages and the rest of the site)
 - yarn testLint: run eslint
 - yarn test: run vitest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,8 +49,8 @@ jobs:
             - name: Run lerna build
               run: yarn buildLerna
 
-            - name: Run tsc build
-              run: yarn buildTsc
+            - name: Run typecheck
+              run: yarn typecheck
 
     prettier:
         runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,6 @@
 # Bash commands
 
 - yarn buildLerna: Build the packages (types and utils, core table, the grapher data viz component and the data explorer)
-- yarn buildTsc: Build the typescript code for the rest of the codebase (the site, admin UI etc)
 - yarn typecheck: runs the typescript typechecker across all files (both frontend code in lerna managed packages and the rest of the site)
 - yarn testLint: run eslint
 - yarn test: run vitest

--- a/devTools/svgTester/verify-against-master.sh
+++ b/devTools/svgTester/verify-against-master.sh
@@ -97,7 +97,6 @@ unstashChanges() {
 build() {
     echo "=> Build project"
     yarn buildLerna
-    yarn buildTsc
 }
 
 checkoutMaster() {

--- a/docs/devcontainer-setup.md
+++ b/docs/devcontainer-setup.md
@@ -49,19 +49,11 @@ If you want to access MySQL you have two options. ⚠ Note that depending on whi
 
 ## Running tests
 
-To run our test suite you first need to build the TypeScript files into JavaScript and then run vitest:
+Run vitest:
 
-1. Run buildTsc
-
-    ```sh
-    yarn buildTsc
-    ```
-
-2. Run vitest
-
-    ```sh
-    yarn test
-    ```
+```sh
+yarn test
+```
 
 ## Checking the docker compose logs
 

--- a/docs/local-typescript-setup.md
+++ b/docs/local-typescript-setup.md
@@ -64,12 +64,12 @@ Note: on Windows we strongly recommend using the [Windows Subsystem for Linux](h
 
 ## Running tests
 
-To run our test suite you first need to build the TypeScript files into JavaScript and then run vitest:
+To run our test suite you first need to build the internal packages and then run vitest:
 
-1. Build JavaScript
+1. Build packages
 
     ```sh
-    yarn lerna run build && yarn buildTsc
+    yarn lerna run build
     ```
 
 2. Run vitest

--- a/ops/buildkite/deploy-content
+++ b/ops/buildkite/deploy-content
@@ -112,7 +112,6 @@ bake_site() {
     (
         cd owid-grapher
         yarn install
-        yarn buildTsc
         mkdir -p /home/owid/live-data/bakedSite/grapher
         yarn buildLocalBake $BAKED_BASE_URL /home/owid/live-data/bakedSite
     )

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
         "batchTagWithGpt": "tsx --tsconfig tsconfig.tsx.json baker/batchTagWithGpt.ts",
         "buildArchive": "tsx --tsconfig tsconfig.tsx.json baker/archival/archiveChangedGrapherPages.ts",
         "buildLocalBake": "tsx --tsconfig tsconfig.tsx.json baker/buildLocalBake.ts",
-        "buildTsc": "tsc -b -verbose",
         "buildLerna": "lerna run build",
         "buildViteAdmin": "vite build --config vite.config-admin.mts",
         "buildViteArchive": "vite build --config vite.config-archive.mts",


### PR DESCRIPTION
Since we switched to `tsx` to execute TS files directly, we no longer need to compile TS to JS explicitly before running any commands.

We now have the `typecheck` script, which currently does almost the same as the old `buildTsc` (without the verbose flag), but it is used only for checking the types, and thus we don't need to run it in so many places.