### PR TITLE
Fix cut off text in DimensionDropdown

### DIFF
--- a/site/multiDim/DimensionDropdown.scss
+++ b/site/multiDim/DimensionDropdown.scss
@@ -5,13 +5,14 @@ $toggle-full-width-breakpoint: 520px;
 
 .md-settings__dropdown-toggle {
     display: flex;
+    align-items: center;
     color: $secondary-text;
     background: white;
     border: 1px solid $light-stroke;
     font: $medium 13px/16px $lato;
     letter-spacing: 0.01em;
     border-radius: 4px;
-    padding: 8px 10px 8px 12px;
+    padding: 4px 10px 4px 12px;
     height: $toggle-height;
     cursor: pointer;
 


### PR DESCRIPTION
This didn't happen in Firefox, so I missed it at first.

See [Slack](https://owid.slack.com/archives/C071F90MD0X/p1749809143559879).