### PR TITLE
Fix spacing of logos in archive on small screen

### DIFF
--- a/site/SiteLogos.scss
+++ b/site/SiteLogos.scss
@@ -4,14 +4,6 @@
     justify-content: space-between;
     flex-shrink: 0;
 
-    .logo-owid {
-        margin-right: 24px;
-
-        @include sm-only {
-            margin-right: 0;
-        }
-    }
-
     .logo-owid a {
         @include md-up {
             font-size: 20px;
@@ -30,6 +22,7 @@
         @include column-gap(6px);
         align-items: flex-start;
         margin-top: 5px;
+        margin-left: 24px;
 
         a {
             color: white;

--- a/site/SiteNavigation.scss
+++ b/site/SiteNavigation.scss
@@ -30,9 +30,6 @@
     @include sm-up {
         @include column-gap(24px);
     }
-    @include md-only {
-        @include column-gap(0px);
-    }
 
     .SiteNavigationToggle--mobile-menu {
         flex: 1; // center owid logo


### PR DESCRIPTION
There was a missing margin between the OWID logo and the affiliate logos on archive site on a small screen introduced in 0324820c2.

We can simplify the code, but the change introduces smaller margin between the OWID logo and the affiliate logos on live site on a single size, which probably wasn't even intentional, since the margin is smaller on both smaller and larger screen sizes.

| Before | After |
|--------|--------|
| <img width="375" src="https://github.com/user-attachments/assets/6dfe540a-d7a7-40ec-b7da-3ba9c25fbe30" /> | <img width="376" alt="SCR-20250617-lefo" src="https://github.com/user-attachments/assets/85bba03e-bc79-42ba-95a7-a1b35dba31ed" /> |
| <img width="358" alt="SCR-20250617-leip" src="https://github.com/user-attachments/assets/85d72603-9fff-40d4-bb08-ca25a9f97854" /> | <img width="334" alt="SCR-20250617-lelp" src="https://github.com/user-attachments/assets/0f4e67bc-7e2f-4376-b426-2d2f9ad0f12f" /> |