### PR TITLE
refactor: merge ColorScale's `customNumericMinValue` and `customNumericValues` into one

### DIFF
--- a/adminSiteClient/GrapherConfigGridEditor.tsx
+++ b/adminSiteClient/GrapherConfigGridEditor.tsx
@@ -1107,7 +1107,7 @@ export class GrapherConfigGridEditor extends React.Component<GrapherConfigGridEd
 
     async getFieldDefinitions() {
         const json = await fetch(
-            "https://files.ourworldindata.org/schemas/grapher-schema.007.json"
+            "https://files.ourworldindata.org/schemas/grapher-schema.008.json"
         ).then((response) => response.json())
         const fieldDescriptions = extractFieldDescriptionsFromSchema(json)
         runInAction(() => {

--- a/db/migration/1750251210487-RemoveColorScaleMinValue.ts
+++ b/db/migration/1750251210487-RemoveColorScaleMinValue.ts
@@ -1,0 +1,111 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+const tables = [
+    { table: "chart_configs", column: "patch" },
+    { table: "chart_configs", column: "full" },
+    { table: "chart_revisions", column: "config" },
+]
+
+export class RemoveColorScaleMinValue1750251210487
+    implements MigrationInterface
+{
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        for (const { table, column } of tables) {
+            await queryRunner.query(
+                `-- sql
+                    UPDATE ${table}
+                    SET ${column} = JSON_REMOVE(
+                        JSON_SET(${column}, "$.map.colorScale.customNumericValues", JSON_MERGE_PRESERVE(
+                            JSON_ARRAY(COALESCE(${column} -> "$.map.colorScale.customNumericMinValue", CAST(0 AS JSON))),
+                            COALESCE(${column} -> "$.map.colorScale.customNumericValues", JSON_ARRAY())
+                        )),
+                        "$.map.colorScale.customNumericMinValue"
+                    )
+                    WHERE ${column} ->> "$.map.colorScale.customNumericMinValue" IS NOT NULL
+                    OR ${column} ->> "$.map.colorScale.customNumericValues" IS NOT NULL
+                `
+            )
+            await queryRunner.query(
+                `-- sql
+                    UPDATE ${table}
+                    SET ${column} = JSON_REMOVE(
+                        JSON_SET(${column}, "$.colorScale.customNumericValues", JSON_MERGE_PRESERVE(
+                            JSON_ARRAY(COALESCE(${column} -> "$.colorScale.customNumericMinValue", CAST(0 AS JSON))),
+                            COALESCE(${column} -> "$.colorScale.customNumericValues", JSON_ARRAY())
+                        )),
+                        "$.colorScale.customNumericMinValue"
+                    )
+                    WHERE ${column} ->> "$.colorScale.customNumericMinValue" IS NOT NULL
+                    OR ${column} ->> "$.colorScale.customNumericValues" IS NOT NULL
+                `
+            )
+
+            await queryRunner.query(
+                `-- sql
+                    update ${table} set ${column} = JSON_SET(${column}, "$.$schema", "https://files.ourworldindata.org/schemas/grapher-schema.008.json")`
+            )
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        for (const { table, column } of tables) {
+            // Restore customNumericMinValue from first element of customNumericValues for map.colorScale
+            await queryRunner.query(
+                `-- sql
+                    UPDATE ${table}
+                    SET ${column} = JSON_SET(
+                        ${column},
+                        "$.map.colorScale.customNumericMinValue",
+                        ${column} -> "$.map.colorScale.customNumericValues[0]"
+                    )
+                    WHERE JSON_LENGTH(${column} -> "$.map.colorScale.customNumericValues") > 0
+                `
+            )
+
+            // Remove first element from customNumericValues array for map.colorScale
+            await queryRunner.query(
+                `-- sql
+                    UPDATE ${table}
+                    SET ${column} = JSON_SET(
+                        ${column},
+                        "$.map.colorScale.customNumericValues",
+                        JSON_REMOVE(${column} -> "$.map.colorScale.customNumericValues", "$[0]")
+                    )
+                    WHERE JSON_LENGTH(${column} -> "$.map.colorScale.customNumericValues") > 1
+                `
+            )
+
+            // Restore customNumericMinValue from first element of customNumericValues for colorScale
+            await queryRunner.query(
+                `-- sql
+                    UPDATE ${table}
+                    SET ${column} = JSON_SET(
+                        ${column},
+                        "$.colorScale.customNumericMinValue",
+                        ${column} -> "$.colorScale.customNumericValues[0]"
+                    )
+                    WHERE JSON_LENGTH(${column} -> "$.colorScale.customNumericValues") > 0
+                `
+            )
+
+            // Remove first element from customNumericValues array for colorScale
+            await queryRunner.query(
+                `-- sql
+                    UPDATE ${table}
+                    SET ${column} = JSON_SET(
+                        ${column},
+                        "$.colorScale.customNumericValues",
+                        JSON_REMOVE(${column} -> "$.colorScale.customNumericValues", "$[0]")
+                    )
+                    WHERE JSON_LENGTH(${column} -> "$.colorScale.customNumericValues") > 1
+                `
+            )
+
+            await queryRunner.query(
+                `-- sql
+                    UPDATE ${table} SET ${column} = JSON_SET(${column}, "$.$schema", "https://files.ourworldindata.org/schemas/grapher-schema.007.json")
+                `
+            )
+        }
+    }
+}

--- a/devTools/schemaProcessor/columns.json
+++ b/devTools/schemaProcessor/columns.json
@@ -141,11 +141,6 @@
         "editor": "numeric"
     },
     {
-        "type": "number",
-        "pointer": "/map/colorScale/customNumericMinValue",
-        "editor": "numeric"
-    },
-    {
         "type": "integer",
         "pointer": "/map/timeTolerance",
         "editor": "numeric"
@@ -381,11 +376,6 @@
         "type": "integer",
         "pointer": "/colorScale/binningStrategyBinCount",
         "default": 5,
-        "editor": "numeric"
-    },
-    {
-        "type": "number",
-        "pointer": "/colorScale/customNumericMinValue",
         "editor": "numeric"
     },
     {

--- a/packages/@ourworldindata/grapher/src/color/ColorScale.test.ts
+++ b/packages/@ourworldindata/grapher/src/color/ColorScale.test.ts
@@ -27,7 +27,7 @@ describe(ColorScale, () => {
     describe("numerical color scale", () => {
         const colorScaleConfig: ColorScaleConfigInterface = {
             binningStrategy: BinningStrategy.manual,
-            customNumericValues: [1, 2, 3],
+            customNumericValues: [-10, 1, 2, 3],
             customNumericLabels: [],
             customNumericColorsActive: true,
             customNumericColors: ["#182f4d", "#3b4c61", "#5875a6"],
@@ -63,7 +63,7 @@ describe(ColorScale, () => {
                 colorScaleConfig
             )
             const bins = scale.legendBins
-            expect(scale.getBinForValue(-100)).toBeUndefined() // doesn't belong in any bin
+            expect(scale.getBinForValue(-100)).toEqual(undefined) // doesn't belong in any bin
             expect(scale.getBinForValue(-10)).toEqual(bins[0])
             expect(scale.getBinForValue(0)).toEqual(bins[0])
             expect(scale.getBinForValue(0.9)).toEqual(bins[0])
@@ -132,7 +132,7 @@ describe(ColorScale, () => {
     it("transforms all colors", () => {
         const colorScaleConfig: ColorScaleConfigInterface = {
             binningStrategy: BinningStrategy.manual,
-            customNumericValues: [1, 2, 3],
+            customNumericValues: [0, 1, 2, 3],
             customNumericLabels: [],
             customNumericColorsActive: true,
             customNumericColors: ["#111", "#222", "#333"],

--- a/packages/@ourworldindata/grapher/src/color/ColorScaleConfig.test.ts
+++ b/packages/@ourworldindata/grapher/src/color/ColorScaleConfig.test.ts
@@ -23,7 +23,6 @@ describe("fromDSL", () => {
     it("handles comprehensive test case", () => {
         expect(colorScale.baseColorScheme).toEqual(ColorSchemeName.Magma)
         expect(colorScale.colorSchemeInvert).toBeTruthy()
-        expect(colorScale.customNumericMinValue).toEqual(0.5)
         expect(colorScale.customCategoryLabels).toEqual({
             one: "uno",
             two: "dos",
@@ -52,7 +51,7 @@ describe("fromDSL", () => {
             colorScaleNumericBins: "1;2;3",
         })!
         expect(numericScale.binningStrategy).toEqual(BinningStrategy.manual)
-        expect(numericScale.customNumericValues).toEqual([1, 2, 3])
+        expect(numericScale.customNumericValues).toEqual([0, 1, 2, 3])
         expect(numericScale.customNumericColorsActive).toBeTruthy()
     })
 
@@ -72,7 +71,7 @@ describe("fromDSL", () => {
         const colorScale = ColorScaleConfig.fromDSL({
             colorScaleNumericBins: "1;2;3",
         })!
-        expect(colorScale.customNumericValues).toEqual([1, 2, 3])
+        expect(colorScale.customNumericValues).toEqual([0, 1, 2, 3])
         expect(colorScale.customNumericLabels).toEqual([
             undefined,
             undefined,
@@ -86,7 +85,7 @@ describe("fromDSL", () => {
         const colorScale2 = ColorScaleConfig.fromDSL({
             colorScaleNumericBins: "1,#ddd;2,#eee;3,#fff",
         })!
-        expect(colorScale2.customNumericValues).toEqual([1, 2, 3])
+        expect(colorScale2.customNumericValues).toEqual([0, 1, 2, 3])
         expect(colorScale2.customNumericColors).toEqual([
             "#ddd",
             "#eee",
@@ -100,7 +99,7 @@ describe("fromDSL", () => {
         const colorScale3 = ColorScaleConfig.fromDSL({
             colorScaleNumericBins: "1,,One;2,,Two;3,,Three",
         })!
-        expect(colorScale3.customNumericValues).toEqual([1, 2, 3])
+        expect(colorScale3.customNumericValues).toEqual([0, 1, 2, 3])
         expect(colorScale3.customNumericColors).toEqual([
             undefined,
             undefined,

--- a/packages/@ourworldindata/grapher/src/color/ColorScaleConfig.ts
+++ b/packages/@ourworldindata/grapher/src/color/ColorScaleConfig.ts
@@ -125,9 +125,6 @@ export class ColorScaleConfig
                 })
         }
 
-        // TODO: once Grammar#parse() is called for all values, we can remove parseFloat() here
-        // See issue: https://www.notion.so/owid/ColumnGrammar-parse-function-does-not-get-applied-67b578b8af7642c5859a1db79c8d5712
-
         const customNumericColorsActive =
             customNumericColors.length > 0 ? true : undefined
 

--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChart.test.ts
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChart.test.ts
@@ -350,11 +350,10 @@ describe("color scale", () => {
                 customCategoryColors: {},
                 customCategoryLabels: {},
                 customHiddenCategories: {},
-                customNumericMinValue: 0,
                 customNumericColors: ["#111111", "#222222"],
                 customNumericColorsActive: true,
                 customNumericLabels: [],
-                customNumericValues: [1.5, 2.5],
+                customNumericValues: [0, 1.5, 2.5],
             },
         }
         const chart = new LineChart({ manager })

--- a/packages/@ourworldindata/grapher/src/schema/defaultGrapherConfig.ts
+++ b/packages/@ourworldindata/grapher/src/schema/defaultGrapherConfig.ts
@@ -4,7 +4,7 @@
 
 import { GrapherInterface } from "@ourworldindata/types"
 
-export const latestSchemaVersion = "007" as const
+export const latestSchemaVersion = "008" as const
 export const outdatedSchemaVersions = [
     "001",
     "002",
@@ -12,10 +12,11 @@ export const outdatedSchemaVersions = [
     "004",
     "005",
     "006",
+    "007",
 ] as const
 
 export const defaultGrapherConfig = {
-    $schema: "https://files.ourworldindata.org/schemas/grapher-schema.007.json",
+    $schema: "https://files.ourworldindata.org/schemas/grapher-schema.008.json",
     map: {
         region: "World",
         hideTimeline: false,

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.008.yaml
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.008.yaml
@@ -1,7 +1,7 @@
 $schema: "http://json-schema.org/draft-07/schema#"
 # if you update the required keys, make sure that the mergeGrapherConfigs and
 # diffGrapherConfigs functions both reflect this change
-$id: "https://files.ourworldindata.org/schemas/grapher-schema.007.json"
+$id: "https://files.ourworldindata.org/schemas/grapher-schema.008.json"
 required:
     - $schema
     - dimensions
@@ -14,12 +14,12 @@ properties:
         type: string
         description: Url of the concrete schema version to use to validate this document
         format: uri
-        default: "https://files.ourworldindata.org/schemas/grapher-schema.007.json"
+        default: "https://files.ourworldindata.org/schemas/grapher-schema.008.json"
         # We restrict the $schema field to a single value since we expect all
         # configs in our database to be valid against the latest schema.
         # If we ever need to validate configs against multiple schema versions,
         # we can remove this constraint.
-        const: "https://files.ourworldindata.org/schemas/grapher-schema.007.json"
+        const: "https://files.ourworldindata.org/schemas/grapher-schema.008.json"
     id:
         type: integer
         description: Internal DB id. Useful internally for OWID but not required if just using grapher directly.
@@ -734,7 +734,4 @@ $defs:
                 default: 5
                 description: The *suggested* number of bins for the automatic binning algorithm
                 minimum: 0
-            customNumericMinValue:
-                type: number
-                description: The minimum bracket of the first bin. Inferred from data if not provided.
         additionalProperties: false

--- a/packages/@ourworldindata/grapher/src/schema/migrations/migrate.test.ts
+++ b/packages/@ourworldindata/grapher/src/schema/migrations/migrate.test.ts
@@ -2,7 +2,7 @@ import { expect, it } from "vitest"
 
 import { defaultGrapherConfig } from "../defaultGrapherConfig"
 import { migrateGrapherConfigToLatestVersion } from "./migrate"
-import { migrateFrom006To007 } from "./migrations"
+import { migrateFrom006To007, migrateFrom007To008 } from "./migrations"
 import { AnyConfigWithValidSchema } from "./helpers"
 
 it("returns a valid config as is", () => {
@@ -97,4 +97,32 @@ it("migrates version 006 to 007 correctly", () => {
 
     // check that the map.region field is added
     expect(migrateFrom006To007(config)).toHaveProperty("map.region", "Europe")
+})
+
+it("migrates version 007 to 008 correctly", () => {
+    const config: AnyConfigWithValidSchema = {
+        $schema:
+            "https://files.ourworldindata.org/schemas/grapher-schema.007.json",
+        hasMapTab: true,
+        map: {
+            colorScale: {
+                customNumericMinValue: 0,
+                customNumericValues: [1, 2, 3],
+            },
+        },
+    }
+
+    const migrated = migrateFrom007To008(config)
+
+    // check that the $schema field is updated
+    expect(migrated).toHaveProperty(
+        "$schema",
+        "https://files.ourworldindata.org/schemas/grapher-schema.008.json"
+    )
+
+    expect(migrated).not.toHaveProperty("map.colorScale.customNumericMinValue")
+    expect(migrated).toHaveProperty(
+        "map.colorScale.customNumericValues",
+        [0, 1, 2, 3]
+    )
 })

--- a/packages/@ourworldindata/grapher/src/schema/migrations/migrations.ts
+++ b/packages/@ourworldindata/grapher/src/schema/migrations/migrations.ts
@@ -91,6 +91,34 @@ export const migrateFrom006To007 = (
     return config
 }
 
+export const migrateFrom007To008 = (
+    config: AnyConfigWithValidSchema
+): AnyConfigWithValidSchema => {
+    // remove colorScale.customNumericMinValue, merge it into colorScale.customNumericValues
+    if (config.map?.colorScale?.customNumericValues) {
+        config.map.colorScale.customNumericValues = [
+            config.map.colorScale.customNumericMinValue ?? 0,
+            ...config.map.colorScale.customNumericValues,
+        ]
+    }
+    if (config.map?.colorScale?.customNumericMinValue !== undefined) {
+        delete config.map.colorScale.customNumericMinValue
+    }
+
+    if (config.colorScale?.customNumericValues) {
+        config.colorScale.customNumericValues = [
+            config.colorScale.customNumericMinValue ?? 0,
+            ...config.colorScale.customNumericValues,
+        ]
+    }
+    if (config.colorScale?.customNumericMinValue !== undefined) {
+        delete config.colorScale.customNumericMinValue
+    }
+
+    config.$schema = createSchemaForVersion("008")
+    return config
+}
+
 export const runMigration = (
     config: AnyConfigWithValidSchema
 ): AnyConfigWithValidSchema => {
@@ -103,5 +131,6 @@ export const runMigration = (
         .with("004", () => migrateFrom004To005(config))
         .with("005", () => migrateFrom005To006(config))
         .with("006", () => migrateFrom006To007(config))
+        .with("007", () => migrateFrom007To008(config))
         .exhaustive()
 }

--- a/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
+++ b/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
@@ -360,8 +360,6 @@ export class ColorScaleConfigDefaults {
     /** The *suggested* number of bins for the automatic binning algorithm */
     @observable binningStrategyBinCount?: number
 
-    /** The minimum bracket of the first bin */
-    @observable customNumericMinValue?: number
     /** Custom maximum brackets for each numeric bin. Only applied when strategy is `manual`. */
     @observable customNumericValues: number[] = []
     /**
@@ -417,7 +415,6 @@ export type ColorScaleConfigInterface = ColorScaleConfigDefaults
 //     colorSchemeInvert?: boolean
 //     binningStrategy?: BinningStrategy
 //     binningStrategyBinCount?: number
-//     customNumericMinValue?: number
 //     customNumericValues: number[]
 //     customNumericLabels: (string | undefined | null)[]
 //     customNumericColorsActive?: boolean


### PR DESCRIPTION
This makes it so we go from
```ts
{
  customNumericMinValue: 0,
  customNumericValues: [1, 2, 3],
  customNumericLabels: ["one", "two", "three"]
}
```

to
```ts
{
  customNumericValues: [0, 1, 2, 3],
  customNumericLabels: ["one", "two", "three"]
}
```

Both of these will result in the bins:
- 0-1, labelled one
- 1-2, labelled two
- 2-3, labelled three

That is, the two properties are merged into one.

For a color scale with `n` bins, we'll now have `customNumericValues.length === n + 1` and `customNumericLabels?.length === n` and `customNumericColors?.length === n`.

## Why?

This makes it easier to support automatic brackets, because the map bracket thresholds don't have this weird split into two properties any more.

## Explorers

Explorers have a very high number of them using `colorScaleNumericMinValue` and we can't easily migrate them, so they stay the same in terms of config and just convert it to `[colorScaleNumericMinValue, ...colorScaleNumericBins]` on the fly.

## Admin changes

The admin has also changed to accomodate this:

![CleanShot 2025-06-19 at 12 31 54](https://github.com/user-attachments/assets/e2cbd49f-9045-43ae-914f-640f6e03ec45)
