### PR TITLE
🐛 fix all-charts weirdness

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/FetchingGrapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/FetchingGrapher.tsx
@@ -72,10 +72,10 @@ export function FetchingGrapher(
                         signal: abortController.signal,
                     }).then((res) => res.json())
 
+                    if (abortController.signal.aborted) return
+
                     const migratedConfig =
                         migrateGrapherConfigToLatestVersion(fetchedConfig)
-
-                    if (abortController.signal.aborted) return
 
                     const mergedConfig = {
                         ...defaultGrapherConfig,
@@ -88,6 +88,7 @@ export function FetchingGrapher(
                     // multiple times while flashing.
                     // https://stackoverflow.com/a/48610973/9846837
                     unstable_batchedUpdates(() => {
+                        grapherState.current.reset()
                         grapherState.current.updateFromObject(mergedConfig)
                         grapherState.current.legacyConfigAsAuthored =
                             mergedConfig


### PR DESCRIPTION
## Context

When clicking around in the all charts block, charts could get into pretty weird states as they didn't reset cleanly.

This PR adds a call to GrapherState.reset() that should fix this

## Screenshots / Videos / Diagrams

See https://owid.slack.com/archives/C46U9LXRR/p1750333064504219
