### PR TITLE
🐛 fix issue where configs with a map region specified weren't rotated to the region

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -614,6 +614,16 @@ export class GrapherState {
             }
         }
 
+        // if a region is specified, show it on the globe
+        if (
+            obj.map?.region !== undefined &&
+            isValidGlobeRegionName(obj.map.region)
+        ) {
+            this.mapRegionDropdownValue = obj.map.region
+            this.globeController.jumpToOwidContinent(obj.map.region)
+            this.globeController.showGlobe()
+        }
+
         // Todo: remove once we are more RAII.
         if (obj?.dimensions?.length)
             this.setDimensionsFromConfigs(obj.dimensions)


### PR DESCRIPTION
The bug was introduced by [this commit](https://github.com/owid/owid-grapher/commit/0845ee4b5d19292d9366f58ac5b70005c4780e08).