### PR TITLE
🐛 fix all charts colors not resetting in all permutations

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -2958,6 +2958,7 @@ export class GrapherState {
             // @ts-expect-error grapherKeysToSerialize is not properly typed
             this[key] = grapherState[key]
         }
+        this.seriesColorMap = new Map()
 
         this.ySlugs = grapherState.ySlugs
         this.xSlug = grapherState.xSlug


### PR DESCRIPTION
Reset function was missing a reset of the seriesColorMap cache