### PR TITLE
🐛 fix overflowing sparklines in data tables

### DIFF
--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
@@ -128,6 +128,12 @@ export class DataTable extends React.Component<{
     @computed get table(): OwidTable {
         let table = this.manager.tableForDisplay
 
+        // make sure the given table doesn't contain any rows outside of the time range
+        table = table.filterByTimeRange(
+            this.manager.closestTimelineMinTime ?? -Infinity,
+            this.manager.closestTimelineMaxTime ?? Infinity
+        )
+
         // apply the region type filter if given
         const keepEntityNames = this.filteredEntityNames
         if (keepEntityNames && keepEntityNames.length > 0)


### PR DESCRIPTION
It's currently possible for some columns to have years outside of the given timeline range, e.g. a Population column used as size dimension in a scatter plot.

I think this happens when timelineMinTime and timelineMaxTime are not set. In that case, `tableAfterAuthorTimelineAndEntityFilter` doesn't actually get filtered and auxiliary columns (like the color or size dimensions) end up with data for years outside of the x/y range.

<img width="929" alt="Screenshot 2025-06-21 at 15 12 05" src="https://github.com/user-attachments/assets/f1d0c691-f6bd-4c09-b629-c42e9889cd64" />
