### PR TITLE
🐛 don't capitalize unit in tooltip

### DIFF
--- a/packages/@ourworldindata/grapher/src/tooltip/Tooltip.scss
+++ b/packages/@ourworldindata/grapher/src/tooltip/Tooltip.scss
@@ -462,8 +462,6 @@
                     }
 
                     .unit {
-                        text-transform: capitalize;
-
                         &::after,
                         &::before {
                             content: none;


### PR DESCRIPTION
It should be controllable from outside whether the unit is capitalized or not