### PR TITLE
🎉 add chart type menu to tab switcher

### DIFF
--- a/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
@@ -98,7 +98,7 @@ interface CaptionedChartProps {
 }
 
 // keep in sync with sass variables in CaptionedChart.scss
-const CONTROLS_ROW_HEIGHT = 32
+export const CONTROLS_ROW_HEIGHT = 32
 
 abstract class AbstractCaptionedChart extends React.Component<CaptionedChartProps> {
     protected framePaddingHorizontal = GRAPHER_FRAME_PADDING_HORIZONTAL

--- a/packages/@ourworldindata/grapher/src/controls/ContentSwitchers.scss
+++ b/packages/@ourworldindata/grapher/src/controls/ContentSwitchers.scss
@@ -1,10 +1,43 @@
-.Tabs.ContentSwitchers {
-    $icon-width: 13px;
-    $icon-padding: 6px;
+$active-icon: $blue-50;
 
-    $active-icon: $blue-50;
+@at-root {
+    .ContentSwitchers__OverflowMenu {
+        border-radius: 4px;
+        background-color: #fff;
+        box-shadow: 0px 4px 40px 0px rgba(0, 0, 0, 0.06);
+    }
 
-    .Tabs__Tab {
+    .ContentSwitchers__OverflowMenuItem {
+        @include grapher_label-2-medium;
+
+        margin: 4px 0;
+        padding: 0 16px;
+        height: $controlRowHeight;
+        display: flex;
+        align-items: center;
+        color: $light-text;
+        cursor: pointer;
+        width: 100%;
+
+        &:hover {
+            background-color: $gray-10;
+        }
+
+        &:focus-visible {
+            color: $active-text;
+            background-color: $active-fill;
+
+            svg {
+                color: $active-icon;
+            }
+        }
+    }
+
+    .Tabs.ContentSwitchers .Tabs__Tab,
+    .ContentSwitchers__OverflowMenuItem {
+        $icon-width: 13px;
+        $icon-padding: 6px;
+
         .label {
             margin-left: $icon-padding;
         }
@@ -32,6 +65,28 @@
             svg {
                 color: $active-icon;
             }
+        }
+    }
+}
+
+.Tabs.ContentSwitchers {
+    .Tabs__Tab.ContentSwitchers__OverflowMenuButton {
+        // Make the +X tab a bit narrower
+        padding: 0 8px;
+
+        // Don't show as 'active' when clicked
+        &[data-selected] {
+            background: #fff;
+            color: $light-text;
+        }
+    }
+
+    .Tabs__Tab.active {
+        color: $active-text;
+        background-color: $active-fill;
+
+        svg {
+            color: $active-icon;
         }
     }
 }

--- a/packages/@ourworldindata/grapher/src/controls/ContentSwitchers.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/ContentSwitchers.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
-import { action, computed, makeObservable } from "mobx"
+import { action, computed, observable, makeObservable } from "mobx"
+import cx from "classnames"
 import { observer } from "mobx-react"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faTable, faEarthAmericas } from "@fortawesome/free-solid-svg-icons"
@@ -7,6 +8,8 @@ import { GrapherTabName, GRAPHER_TAB_NAMES } from "@ourworldindata/types"
 import { chartIcons } from "./ChartIcons"
 import { TabItem, Tabs } from "../tabs/Tabs.js"
 import { CHART_TYPE_LABEL } from "../chart/ChartTabs"
+import { Popover } from "../popover/Popover"
+import { CONTROLS_ROW_HEIGHT } from "../captionedChart/CaptionedChart"
 
 export interface ContentSwitchersManager {
     availableTabs?: GrapherTabName[]
@@ -16,6 +19,13 @@ export interface ContentSwitchersManager {
     onTabChange: (oldTab: GrapherTabName, newTab: GrapherTabName) => void
     isMedium?: boolean
 }
+
+const OVERFLOW_MENU_KEY = "More"
+
+const MAX_VISIBLE_TABS = 4
+const MAX_VISIBLE_TABS_BEFORE_OVERFLOW = 3
+
+type TabKey = GrapherTabName | typeof OVERFLOW_MENU_KEY
 
 @observer
 export class ContentSwitchers extends React.Component<{
@@ -31,8 +41,14 @@ export class ContentSwitchers extends React.Component<{
         return test.shouldShow
     }
 
+    @observable private isOverflowMenuOpen = false
+
     @computed private get manager(): ContentSwitchersManager {
         return this.props.manager
+    }
+
+    @computed private get hasMultipleChartTypes(): boolean {
+        return !!this.manager.hasMultipleChartTypes
     }
 
     @computed private get availableTabs(): GrapherTabName[] {
@@ -43,33 +59,140 @@ export class ContentSwitchers extends React.Component<{
         return this.availableTabs.length > 1
     }
 
-    @computed private get tabItems(): TabItem<GrapherTabName>[] {
-        const { hasMultipleChartTypes } = this.manager
-        return this.availableTabs.map((tab) => ({
-            key: tab,
-            element: (
-                <ContentSwitcherTab
-                    key={tab}
-                    tab={tab}
-                    hasMultipleChartTypes={hasMultipleChartTypes}
-                />
-            ),
-            buttonProps: {
-                "data-track-note": "chart_click_" + tab,
-                "aria-label": makeTabLabelText(tab, { hasMultipleChartTypes }),
-            },
-        }))
+    @computed private get visibleTabs(): GrapherTabName[] {
+        const { activeTab, availableTabs } = this
+
+        // If there are four or fewer tabs, show all of them
+        if (availableTabs.length <= MAX_VISIBLE_TABS) {
+            return availableTabs
+        }
+
+        // Otherwise, only show the first 3 tabs
+        const visibleTabs = availableTabs.slice(
+            0,
+            MAX_VISIBLE_TABS_BEFORE_OVERFLOW
+        )
+
+        // If the active tab is not visible, replace the last visible tab with it
+        if (!visibleTabs.includes(activeTab)) {
+            visibleTabs[visibleTabs.length - 1] = activeTab
+        }
+
+        return visibleTabs
+    }
+
+    @computed private get hiddenTabs(): GrapherTabName[] {
+        return this.availableTabs.filter(
+            (tab) => !this.visibleTabs.includes(tab)
+        )
     }
 
     @computed private get activeTab(): GrapherTabName {
         return this.manager.activeTab ?? this.availableTabs[0]
     }
 
-    @action.bound setTab(selectedTab: GrapherTabName): void {
+    @computed private get selectedTabKey(): TabKey {
+        return this.isOverflowMenuOpen ? OVERFLOW_MENU_KEY : this.activeTab
+    }
+
+    @computed private get tabItems(): TabItem<TabKey>[] {
+        const { hasMultipleChartTypes } = this
+
+        const visibleTabItems: TabItem<TabKey>[] = this.visibleTabs.map(
+            (tab) => ({
+                key: tab,
+                element: (
+                    <TabContent
+                        key={tab}
+                        tab={tab}
+                        hasMultipleChartTypes={hasMultipleChartTypes}
+                    />
+                ),
+                buttonProps: {
+                    className: cx({ active: tab === this.activeTab }),
+                    "data-track-note": "chart_click_" + tab,
+                    "aria-label": getTabDisplayText(tab, {
+                        hasMultipleChartTypes,
+                    }),
+                },
+            })
+        )
+
+        // Add overflow menu button if there are hidden tabs
+        if (this.hiddenTabs.length > 0) {
+            visibleTabItems.push({
+                key: OVERFLOW_MENU_KEY,
+                element: <>+&#8202;{this.hiddenTabs.length}</>,
+                buttonProps: {
+                    className: "ContentSwitchers__OverflowMenuButton",
+                    "aria-label": "Show more chart types",
+                },
+            })
+        }
+
+        return visibleTabItems
+    }
+
+    @action.bound private setTab(selectedTab: GrapherTabName): void {
         const oldTab = this.manager.activeTab
         const newTab = selectedTab
         this.manager.setTab(newTab)
         this.manager.onTabChange?.(oldTab!, newTab)
+    }
+
+    @action.bound private showOverflowMenu(): void {
+        this.isOverflowMenuOpen = true
+    }
+
+    @action.bound private hideOverflowMenu(): void {
+        this.isOverflowMenuOpen = false
+    }
+
+    @action.bound private onTabChange(selectedKey: TabKey): void {
+        if (selectedKey === OVERFLOW_MENU_KEY) {
+            this.showOverflowMenu()
+        } else {
+            this.setTab(selectedKey as GrapherTabName)
+            this.hideOverflowMenu()
+        }
+    }
+
+    @action.bound private onOverflowMenuSelect(tab: GrapherTabName): void {
+        this.setTab(tab)
+        this.hideOverflowMenu()
+    }
+
+    private renderOverflowMenu(): React.ReactElement {
+        const { hasMultipleChartTypes } = this
+
+        const style = {
+            top: CONTROLS_ROW_HEIGHT + 4, // small margin between the tabs and popover
+            right: 14, // roughly the half width of the +X button
+            transform: `translateX(50%)`,
+        }
+
+        return (
+            <Popover
+                className="ContentSwitchers__OverflowMenu"
+                isOpen={this.isOverflowMenuOpen}
+                onClose={this.hideOverflowMenu}
+                style={style}
+            >
+                {this.hiddenTabs.map((tab) => (
+                    <button
+                        key={tab}
+                        type="button"
+                        className="ContentSwitchers__OverflowMenuItem"
+                        onClick={() => this.onOverflowMenuSelect(tab)}
+                    >
+                        <TabContent
+                            tab={tab}
+                            hasMultipleChartTypes={hasMultipleChartTypes}
+                        />
+                    </button>
+                ))}
+            </Popover>
+        )
     }
 
     render(): React.ReactElement | null {
@@ -80,14 +203,15 @@ export class ContentSwitchers extends React.Component<{
                 variant="slim"
                 className="ContentSwitchers"
                 items={this.tabItems}
-                selectedKey={this.activeTab}
-                onChange={this.setTab}
+                selectedKey={this.selectedTabKey}
+                onChange={this.onTabChange}
+                slot={this.renderOverflowMenu()}
             />
         )
     }
 }
 
-function ContentSwitcherTab({
+function TabContent({
     tab,
     hasMultipleChartTypes,
 }: {
@@ -95,12 +219,12 @@ function ContentSwitcherTab({
     hasMultipleChartTypes?: boolean
 }): React.ReactElement {
     return (
-        <span>
+        <>
             <TabIcon tab={tab} />
             <span className="label">
-                {makeTabLabelText(tab, { hasMultipleChartTypes })}
+                {getTabDisplayText(tab, { hasMultipleChartTypes })}
             </span>
-        </span>
+        </>
     )
 }
 
@@ -115,7 +239,7 @@ function TabIcon({ tab }: { tab: GrapherTabName }): React.ReactElement {
     }
 }
 
-function makeTabLabelText(
+function getTabDisplayText(
     tab: GrapherTabName,
     options: { hasMultipleChartTypes?: boolean }
 ): string {

--- a/packages/@ourworldindata/grapher/src/controls/Controls.scss
+++ b/packages/@ourworldindata/grapher/src/controls/Controls.scss
@@ -126,7 +126,7 @@ nav.controlsRow .controls {
 
 @container grapher (max-width:500px) {
     // hide labels on smaller screens
-    .ContentSwitchers .label {
+    .ContentSwitchers .Tabs__Tab .label {
         display: none;
     }
 }

--- a/packages/@ourworldindata/grapher/src/controls/SettingsMenu.scss
+++ b/packages/@ourworldindata/grapher/src/controls/SettingsMenu.scss
@@ -17,6 +17,10 @@ $indent: 15px;
 $control-row-height: 32px;
 
 .settings-menu-contents {
+    .GrapherPopover__wrapper {
+        width: 300px;
+    }
+
     .GrapherPopover__content {
         //
         // shared button coloring & behaviors

--- a/packages/@ourworldindata/grapher/src/controls/SettingsMenu.scss
+++ b/packages/@ourworldindata/grapher/src/controls/SettingsMenu.scss
@@ -16,43 +16,8 @@ $lato: $sans-serif-font-stack;
 $indent: 15px;
 $control-row-height: 32px;
 
-nav.controlsRow .controls .settings-menu {
-    // the pop-up version of the settings menu
-    .settings-menu-wrapper {
-        position: absolute;
-        width: 300px;
-        right: $indent;
-        background: white;
-        border-radius: 4px;
-        box-shadow: 0px 4px 23px 4px #0000000f;
-        z-index: $zindex-controls-popup;
-        overflow-y: scroll;
-    }
-
-    // transparent mouse-event catcher while popup is visible
-    .settings-menu-backdrop {
-        position: absolute;
-        left: 0;
-        top: 0;
-        width: 100%;
-        height: 100%;
-        z-index: $zindex-controls-backdrop;
-    }
-}
-
 .settings-menu-contents {
-    //
-    // chart-type label
-    //
-    .settings-menu-header {
-        background: white;
-        padding: 9px $indent 3px $indent;
-        position: sticky;
-        top: 0;
-        z-index: 1;
-    }
-
-    .settings-menu-controls {
+    .GrapherPopover__content {
         //
         // shared button coloring & behaviors
         //

--- a/packages/@ourworldindata/grapher/src/controls/SettingsMenu.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/SettingsMenu.tsx
@@ -81,9 +81,7 @@ export interface SettingsMenuManager
 
 interface SettingsMenuProps {
     manager: SettingsMenuManager
-    top: number
-    bottom: number
-    right: number
+    popoverStyle?: React.CSSProperties
 }
 
 @observer
@@ -96,7 +94,7 @@ export class SettingsMenu extends React.Component<SettingsMenuProps> {
     }
 
     static shouldShow(manager: SettingsMenuManager): boolean {
-        const test = new SettingsMenu({ manager, top: 0, bottom: 0, right: 0 })
+        const test = new SettingsMenu({ manager })
         return test.showSettingsMenuToggle
     }
 
@@ -322,7 +320,6 @@ export class SettingsMenu extends React.Component<SettingsMenuProps> {
     }
 
     private renderSettingsButtonAndPopup(): JSX.Element {
-        const { top, bottom, right } = this.props
         const { active } = this
 
         return (
@@ -343,7 +340,7 @@ export class SettingsMenu extends React.Component<SettingsMenuProps> {
                     isOpen={this.active}
                     onClose={this.toggleVisibility}
                     className={GRAPHER_SETTINGS_CLASS}
-                    position={{ top, bottom, right }}
+                    style={this.props.popoverStyle}
                 >
                     {this.menuContentsChart}
                 </Popover>

--- a/packages/@ourworldindata/grapher/src/controls/SettingsMenu.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/SettingsMenu.tsx
@@ -12,10 +12,7 @@ import {
 } from "@ourworldindata/types"
 import { SelectionArray } from "../selection/SelectionArray"
 import { ChartDimension } from "../chart/ChartDimension"
-import {
-    isTargetOutsideElement,
-    makeSelectionArray,
-} from "../chart/ChartUtils.js"
+import { makeSelectionArray } from "../chart/ChartUtils.js"
 import { AxisConfig } from "../axis/AxisConfig"
 
 import { AxisScaleToggle } from "./settings/AxisScaleToggle"
@@ -33,7 +30,7 @@ import {
     NoDataAreaToggle,
     NoDataAreaToggleManager,
 } from "./settings/NoDataAreaToggle"
-import { OverlayHeader } from "@ourworldindata/components"
+import { Popover } from "../popover/Popover"
 import { GRAPHER_SETTINGS_CLASS } from "../core/GrapherConstants"
 
 const {
@@ -92,7 +89,6 @@ interface SettingsMenuProps {
 @observer
 export class SettingsMenu extends React.Component<SettingsMenuProps> {
     @observable.ref active: boolean = false
-    contentRef: React.RefObject<HTMLDivElement> = React.createRef() // the menu contents & backdrop
 
     constructor(props: SettingsMenuProps) {
         super(props)
@@ -224,34 +220,6 @@ export class SettingsMenu extends React.Component<SettingsMenuProps> {
         // TODO: add a showCompareEndPointsOnlyToggle to complement compareEndPointsOnly
     }
 
-    componentDidMount(): void {
-        document.addEventListener("keydown", this.onDocumentKeyDown)
-        document.addEventListener("click", this.onDocumentClick, {
-            capture: true,
-        })
-    }
-
-    componentWillUnmount(): void {
-        document.removeEventListener("keydown", this.onDocumentKeyDown)
-        document.removeEventListener("click", this.onDocumentClick, {
-            capture: true,
-        })
-    }
-
-    @action.bound private onDocumentKeyDown(e: KeyboardEvent): void {
-        // dismiss menu on esc
-        if (this.active && e.key === "Escape") this.toggleVisibility()
-    }
-
-    @action.bound private onDocumentClick(e: MouseEvent): void {
-        if (
-            this.active &&
-            this.contentRef?.current &&
-            isTargetOutsideElement(e.target!, this.contentRef.current)
-        )
-            this.toggleVisibility()
-    }
-
     @action.bound private toggleVisibility(): void {
         this.active = !this.active
     }
@@ -266,18 +234,6 @@ export class SettingsMenu extends React.Component<SettingsMenuProps> {
 
     @computed private get selectionArray(): SelectionArray {
         return makeSelectionArray(this.manager.selection)
-    }
-
-    @computed private get layout(): {
-        maxHeight: string
-        maxWidth: string
-        top: number
-        right: number
-    } {
-        const { top, bottom, right } = this.props,
-            maxHeight = `calc(100% - ${top + bottom}px)`,
-            maxWidth = `calc(100% - ${2 * right}px)`
-        return { maxHeight, maxWidth, top, right }
     }
 
     @computed private get menuContentsChart(): React.ReactElement {
@@ -360,44 +316,15 @@ export class SettingsMenu extends React.Component<SettingsMenuProps> {
         )
     }
 
-    @computed private get menu(): JSX.Element | void {
-        if (this.active) {
-            return this.menuContents
-        }
-    }
-
-    @computed private get menuContents(): JSX.Element {
+    @computed private get menuTitle(): string {
         const { chartTypeLabel } = this
-
-        const menuTitle = `${chartTypeLabel} settings`
-
-        return (
-            <div className={GRAPHER_SETTINGS_CLASS} ref={this.contentRef}>
-                <div
-                    className="settings-menu-backdrop"
-                    onClick={this.toggleVisibility}
-                ></div>
-                <div
-                    className="settings-menu-wrapper"
-                    style={{
-                        ...this.layout,
-                    }}
-                >
-                    <OverlayHeader
-                        className="settings-menu-header"
-                        title={menuTitle}
-                        onDismiss={this.toggleVisibility}
-                    />
-                    <div className="settings-menu-controls">
-                        {this.menuContentsChart}
-                    </div>
-                </div>
-            </div>
-        )
+        return `${chartTypeLabel} settings`
     }
 
     private renderSettingsButtonAndPopup(): JSX.Element {
+        const { top, bottom, right } = this.props
         const { active } = this
+
         return (
             <div className="settings-menu">
                 <button
@@ -411,7 +338,15 @@ export class SettingsMenu extends React.Component<SettingsMenuProps> {
                     <FontAwesomeIcon icon={faGear} />
                     <span className="label"> Settings</span>
                 </button>
-                {this.menu}
+                <Popover
+                    title={this.menuTitle}
+                    isOpen={this.active}
+                    onClose={this.toggleVisibility}
+                    className={GRAPHER_SETTINGS_CLASS}
+                    position={{ top, bottom, right }}
+                >
+                    {this.menuContentsChart}
+                </Popover>
             </div>
         )
     }

--- a/packages/@ourworldindata/grapher/src/controls/controlsRow/ControlsRow.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/controlsRow/ControlsRow.tsx
@@ -87,15 +87,24 @@ export class ControlsRow extends Component<ControlsRowProps> {
         )
     }
 
+    @computed private get settingsMenuLayout(): React.CSSProperties {
+        const top = this.props.settingsMenuTop ?? 0
+        const bottom = this.framePaddingVertical
+        const right = this.sidePanelWidth + this.framePaddingHorizontal
+
+        const maxHeight = `calc(100% - ${top + bottom}px)`
+        const maxWidth = `calc(100% - ${2 * right}px)`
+
+        return { maxHeight, maxWidth, top, right }
+    }
+
     private renderChartControls(): React.ReactElement {
         return (
             <div className="controls chart-controls">
                 <EntitySelectionToggle manager={this.manager} />
                 <SettingsMenu
                     manager={this.manager}
-                    top={this.props.settingsMenuTop ?? 0}
-                    bottom={this.framePaddingVertical}
-                    right={this.sidePanelWidth + this.framePaddingHorizontal}
+                    popoverStyle={this.settingsMenuLayout}
                 />
             </div>
         )

--- a/packages/@ourworldindata/grapher/src/core/grapher.scss
+++ b/packages/@ourworldindata/grapher/src/core/grapher.scss
@@ -53,6 +53,7 @@ $zindex-controls-drawer: 150;
 .GrapherComponent {
     @import "../controls/CommandPalette.scss";
     @import "../controls/Controls.scss";
+    @import "../popover/Popover.scss";
     @import "../controls/SettingsMenu.scss";
     @import "../controls/MapRegionDropdown.scss";
     @import "../controls/MapCountryDropdown.scss";

--- a/packages/@ourworldindata/grapher/src/popover/Popover.scss
+++ b/packages/@ourworldindata/grapher/src/popover/Popover.scss
@@ -1,0 +1,31 @@
+.GrapherPopover {
+    // Backdrop - transparent mouse-event catcher while popup is visible
+    .GrapherPopover__backdrop {
+        position: absolute;
+        left: 0;
+        top: 0;
+        width: 100%;
+        height: 100%;
+        z-index: $zindex-controls-backdrop;
+    }
+
+    // Wrapper - the actual popover container
+    .GrapherPopover__wrapper {
+        position: absolute;
+        width: 300px;
+        background: white;
+        border-radius: 4px;
+        box-shadow: 0px 4px 23px 4px #0000000f;
+        z-index: $zindex-controls-popup;
+        overflow-y: auto;
+    }
+
+    // Header - sticky header with title and close button
+    .GrapherPopover__header {
+        background: white;
+        padding: 9px 15px 3px 15px;
+        position: sticky;
+        top: 0;
+        z-index: 1;
+    }
+}

--- a/packages/@ourworldindata/grapher/src/popover/Popover.scss
+++ b/packages/@ourworldindata/grapher/src/popover/Popover.scss
@@ -12,7 +12,6 @@
     // Wrapper - the actual popover container
     .GrapherPopover__wrapper {
         position: absolute;
-        width: 300px;
         background: white;
         border-radius: 4px;
         box-shadow: 0px 4px 23px 4px #0000000f;

--- a/packages/@ourworldindata/grapher/src/popover/Popover.tsx
+++ b/packages/@ourworldindata/grapher/src/popover/Popover.tsx
@@ -1,0 +1,110 @@
+import * as React from "react"
+import { computed, action, makeObservable } from "mobx"
+import { observer } from "mobx-react"
+import classnames from "classnames"
+import { isTargetOutsideElement } from "../chart/ChartUtils.js"
+import { OverlayHeader } from "@ourworldindata/components"
+
+export interface PopoverProps {
+    children: React.ReactNode
+    title?: string
+    isOpen: boolean
+    onClose: () => void
+    className?: string
+    position?: {
+        top: number
+        bottom: number
+        right: number
+    }
+}
+
+@observer
+export class Popover extends React.Component<PopoverProps> {
+    private contentRef: React.RefObject<HTMLDivElement> = React.createRef()
+
+    constructor(props: PopoverProps) {
+        super(props)
+        makeObservable(this)
+    }
+
+    @computed private get isOpen(): boolean {
+        return this.props.isOpen
+    }
+
+    @computed private get layout():
+        | {
+              maxHeight: string
+              maxWidth: string
+              top: number
+              right: number
+          }
+        | undefined {
+        const { position } = this.props
+        if (!position) return undefined
+
+        const { top, bottom, right } = position
+        const maxHeight = `calc(100% - ${top + bottom}px)`
+        const maxWidth = `calc(100% - ${2 * right}px)`
+
+        return { maxHeight, maxWidth, top, right }
+    }
+
+    componentDidMount(): void {
+        document.addEventListener("keydown", this.onDocumentKeyDown)
+        document.addEventListener("click", this.onDocumentClick, {
+            capture: true,
+        })
+    }
+
+    componentWillUnmount(): void {
+        document.removeEventListener("keydown", this.onDocumentKeyDown)
+        document.removeEventListener("click", this.onDocumentClick, {
+            capture: true,
+        })
+    }
+
+    @action.bound private onDocumentKeyDown(e: KeyboardEvent): void {
+        // dismiss popover on esc
+        if (this.isOpen && e.key === "Escape") {
+            this.props.onClose()
+        }
+    }
+
+    @action.bound private onDocumentClick(e: MouseEvent): void {
+        if (
+            this.isOpen &&
+            this.contentRef?.current &&
+            isTargetOutsideElement(e.target!, this.contentRef.current)
+        ) {
+            this.props.onClose()
+        }
+    }
+
+    render(): React.ReactElement | null {
+        if (!this.isOpen) return null
+
+        const { title, children, className } = this.props
+
+        return (
+            <div
+                className={classnames("GrapherPopover", className)}
+                ref={this.contentRef}
+            >
+                <div
+                    className="GrapherPopover__backdrop"
+                    onClick={this.props.onClose}
+                />
+                <div className="GrapherPopover__wrapper" style={this.layout}>
+                    {title && (
+                        <OverlayHeader
+                            className="GrapherPopover__header"
+                            title={title}
+                            onDismiss={this.props.onClose}
+                        />
+                    )}
+                    <div className="GrapherPopover__content">{children}</div>
+                </div>
+            </div>
+        )
+    }
+}

--- a/packages/@ourworldindata/grapher/src/popover/Popover.tsx
+++ b/packages/@ourworldindata/grapher/src/popover/Popover.tsx
@@ -11,11 +11,7 @@ export interface PopoverProps {
     isOpen: boolean
     onClose: () => void
     className?: string
-    position?: {
-        top: number
-        bottom: number
-        right: number
-    }
+    style?: React.CSSProperties
 }
 
 @observer
@@ -29,24 +25,6 @@ export class Popover extends React.Component<PopoverProps> {
 
     @computed private get isOpen(): boolean {
         return this.props.isOpen
-    }
-
-    @computed private get layout():
-        | {
-              maxHeight: string
-              maxWidth: string
-              top: number
-              right: number
-          }
-        | undefined {
-        const { position } = this.props
-        if (!position) return undefined
-
-        const { top, bottom, right } = position
-        const maxHeight = `calc(100% - ${top + bottom}px)`
-        const maxWidth = `calc(100% - ${2 * right}px)`
-
-        return { maxHeight, maxWidth, top, right }
     }
 
     componentDidMount(): void {
@@ -94,7 +72,10 @@ export class Popover extends React.Component<PopoverProps> {
                     className="GrapherPopover__backdrop"
                     onClick={this.props.onClose}
                 />
-                <div className="GrapherPopover__wrapper" style={this.layout}>
+                <div
+                    className="GrapherPopover__wrapper"
+                    style={this.props.style}
+                >
                     {title && (
                         <OverlayHeader
                             className="GrapherPopover__header"

--- a/packages/@ourworldindata/grapher/src/tabs/Tabs.scss
+++ b/packages/@ourworldindata/grapher/src/tabs/Tabs.scss
@@ -1,4 +1,6 @@
 .Tabs {
+    position: relative;
+
     &--horizontal-scroll {
         overflow-x: auto;
         white-space: nowrap;
@@ -25,9 +27,9 @@
             white-space: nowrap;
             text-overflow: ellipsis;
             overflow: hidden;
+            cursor: pointer;
 
             &:hover {
-                cursor: pointer;
                 background-color: $gray-10;
                 border-color: $gray-10;
             }
@@ -76,7 +78,7 @@
             line-height: $height;
             border-radius: $border-radius - $visual-gap;
             padding: 0 var(--tab-padding);
-            cursor: default;
+            cursor: pointer;
             letter-spacing: 0.01em;
             white-space: nowrap;
             user-select: none;
@@ -86,16 +88,11 @@
 
             &:hover {
                 background-color: $hover-fill;
-                cursor: pointer;
             }
 
             &[data-selected] {
                 color: $active-text;
                 background-color: $active-fill;
-
-                &:hover {
-                    cursor: default;
-                }
             }
         }
 

--- a/packages/@ourworldindata/grapher/src/tabs/Tabs.tsx
+++ b/packages/@ourworldindata/grapher/src/tabs/Tabs.tsx
@@ -81,7 +81,6 @@ export const Tabs = <TabKey extends string = string>({
                 return (
                     <button
                         key={item.key}
-                        className="Tabs__Tab"
                         style={{ maxWidth: maxTabWidth }}
                         type="button"
                         role="tab"
@@ -91,6 +90,7 @@ export const Tabs = <TabKey extends string = string>({
                         onClick={() => onChange(item.key)}
                         onKeyDown={handleKeyDown}
                         {...item.buttonProps}
+                        className={cx("Tabs__Tab", item.buttonProps?.className)}
                     >
                         {item.element}
                     </button>


### PR DESCRIPTION
> [!NOTE]
> Check SVG tester before merging 

Adds a '+X' tab that opens a popup with more chart types if there are more than four tabs. 

The first commit extracts a Popover component out of the Settings menu, and the second commit uses that component for the chart type menu.

<!-- GitButler Footer Boundary Top -->
---
This is **part 5 of 7 in a stack** made with GitButler:
- <kbd>&nbsp;7&nbsp;</kbd> #5021 
- <kbd>&nbsp;6&nbsp;</kbd> #5020 
- <kbd>&nbsp;5&nbsp;</kbd> #5037 👈 
- <kbd>&nbsp;4&nbsp;</kbd> #5036 
- <kbd>&nbsp;3&nbsp;</kbd> #4990 
- <kbd>&nbsp;2&nbsp;</kbd> #4855 
- <kbd>&nbsp;1&nbsp;</kbd> #4854 
<!-- GitButler Footer Boundary Bottom -->

