### PR TITLE
feat: in download modal, show tip about interactive embeds

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -832,8 +832,12 @@ export class GrapherState {
         return this.isScatter || this.isMarimekko
     }
 
-    @computed private get isOnArchivalPage(): boolean {
+    @computed get isOnArchivalPage(): boolean {
         return this.archivedChartInfo?.type === "archive-page"
+    }
+
+    @computed get hasArchivedPage(): boolean {
+        return this.archivedChartInfo?.type === "archived-page-version"
     }
 
     @computed private get runtimeAssetMap(): AssetMap | undefined {

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
@@ -198,23 +198,22 @@
     }
 
     .download-modal__callout {
-        border: 1px solid $gray-20;
-        border-radius: 8px;
-        background: $gray-5;
+        background: $gray-10;
         padding: 16px;
 
         svg {
             margin-right: 8px;
-            color: $light-text;
         }
 
         .title {
             font-size: 16px;
+            color: $blue-90;
         }
 
         p {
+            color: $blue-60;
             margin: 8px 0 0;
-            font-size: 14px;
+            line-height: 1.3;
         }
 
         ul {

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
@@ -356,10 +356,21 @@ export class DownloadModalVisTab extends React.Component<DownloadModalProps> {
                                 >
                                     embed an interactive version
                                 </a>
-                                . You can choose between a live embed that
-                                always reflects our latest data updates, or a
-                                snapshot embed that stays fixed at the time you
-                                created it.
+                                .{" "}
+                                {this.manager.isOnArchivalPage ? (
+                                    <>
+                                        The interactive version will stay fixed
+                                        over time and will always show the same
+                                        chart and data you are seeing now.
+                                    </>
+                                ) : (
+                                    <>
+                                        You can choose between a live embed that
+                                        always reflects our latest data updates,
+                                        or a snapshot embed that stays fixed at
+                                        the time you created it.
+                                    </>
+                                )}
                             </Callout>
                         )}
                         <div>

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
@@ -64,6 +64,7 @@ export interface DownloadModalManager {
     shouldIncludeDetailsInStaticExport?: boolean
     detailsOrderedByReference?: string[]
     isDownloadModalOpen?: boolean
+    isEmbedModalOpen?: boolean
     frameBounds?: Bounds
     captionedChartBounds?: Bounds
     isOnChartOrMapTab?: boolean
@@ -288,6 +289,11 @@ export class DownloadModalVisTab extends React.Component<DownloadModalProps> {
         return !!(this.manager.isOnArchivalPage || this.manager.hasArchivedPage)
     }
 
+    @action.bound openEmbedDialog(): void {
+        this.manager.isDownloadModalOpen = false
+        this.manager.isEmbedModalOpen = true
+    }
+
     componentDidMount(): void {
         this.export()
     }
@@ -343,11 +349,17 @@ export class DownloadModalVisTab extends React.Component<DownloadModalProps> {
                                 icon={<FontAwesomeIcon icon={faInfoCircle} />}
                             >
                                 Instead of downloading a static image of this
-                                chart, you can also embed an interactive
-                                version. You can choose between a live embed
-                                that always reflects our latest data updates, or
-                                a snapshot embed that stays fixed at the time
-                                you created it.
+                                chart, you can also{" "}
+                                <a
+                                    onClick={this.openEmbedDialog}
+                                    data-track-note="chart_download_click_interactive_embed"
+                                >
+                                    embed an interactive version
+                                </a>
+                                . You can choose between a live embed that
+                                always reflects our latest data updates, or a
+                                snapshot embed that stays fixed at the time you
+                                created it.
                             </Callout>
                         )}
                         <div>

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
@@ -68,6 +68,8 @@ export interface DownloadModalManager {
     captionedChartBounds?: Bounds
     isOnChartOrMapTab?: boolean
     isOnTableTab?: boolean
+    isOnArchivalPage?: boolean
+    hasArchivedPage?: boolean
     showAdminControls?: boolean
     isSocialMediaExport?: boolean
     isPublished?: boolean
@@ -282,6 +284,10 @@ export class DownloadModalVisTab extends React.Component<DownloadModalProps> {
         return this.hasDetails || !!this.manager.showAdminControls
     }
 
+    @computed private get showInteractiveEmbedTip(): boolean {
+        return !!(this.manager.isOnArchivalPage || this.manager.hasArchivedPage)
+    }
+
     componentDidMount(): void {
         this.export()
     }
@@ -295,6 +301,7 @@ export class DownloadModalVisTab extends React.Component<DownloadModalProps> {
             captionedChartBounds,
             targetWidth,
             targetHeight,
+            showInteractiveEmbedTip,
         } = this
         const pngPreviewUrl = this.pngPreviewUrl || this.fallbackPngUrl
 
@@ -330,6 +337,19 @@ export class DownloadModalVisTab extends React.Component<DownloadModalProps> {
             <div>
                 {manager.isOnChartOrMapTab ? (
                     <div className="download-modal__vis-section">
+                        {showInteractiveEmbedTip && (
+                            <Callout
+                                title="Did you know?"
+                                icon={<FontAwesomeIcon icon={faInfoCircle} />}
+                            >
+                                Instead of downloading a static image of this
+                                chart, you can also embed an interactive
+                                version. You can choose between a live embed
+                                that always reflects our latest data updates, or
+                                a snapshot embed that stays fixed at the time
+                                you created it.
+                            </Callout>
+                        )}
                         <div>
                             <DownloadButton
                                 title="Image (PNG)"


### PR DESCRIPTION
![CleanShot 2025-06-24 at 10 57 30](https://github.com/user-attachments/assets/bb83610f-9591-4c8f-a6de-88da5b82340e)

As part of this, I also applied the new design to the other callouts we show in the download modal. I think it still fits:
![CleanShot 2025-06-24 at 10 58 06](https://github.com/user-attachments/assets/91b7da69-8b3c-4cdc-aae5-8c71ce3de426)
