### PR TITLE
🔨 axis should make space for tick labels

### DIFF
--- a/packages/@ourworldindata/grapher/src/axis/Axis.ts
+++ b/packages/@ourworldindata/grapher/src/axis/Axis.ts
@@ -852,10 +852,18 @@ export class DualAxis {
                     [this.props.horizontalAxis.orient]: this.horizontalAxisSize,
                     [this.props.verticalAxis.orient]: this.verticalAxisSize,
                 })
-                // make space for the y-axis label if plotted above the axis
-                .padTop(this.props.verticalAxis.labelOffsetTop)
+                .padTop(
+                    Math.max(
+                        // make space for tick labels (they might overflow since they're center-aligned)
+                        0.5 * this.props.verticalAxis.tickFontSize,
+                        // make space for the y-axis label if plotted above the axis
+                        this.props.verticalAxis.labelOffsetTop
+                    )
+                )
                 // make space for vertical comparison line labels if any
                 .padTop(this.comparisonLineLabelOffset)
+                // avoid axis labels being cut off at some resolutions
+                .padBottom(2)
         )
     }
 

--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
@@ -1460,18 +1460,17 @@ export class LineChart
         return axis
     }
 
+    @computed private get innerBounds(): Bounds {
+        return this.boundsWithoutColorLegend.padRight(
+            this.manager.showLegend
+                ? this.lineLegendWidth
+                : this.defaultRightPadding
+        )
+    }
+
     @computed get dualAxis(): DualAxis {
         return new DualAxis({
-            bounds: this.boundsWithoutColorLegend
-                .padRight(
-                    this.manager.showLegend
-                        ? this.lineLegendWidth
-                        : this.defaultRightPadding
-                )
-                // top padding leaves room for tick labels
-                .padTop(6)
-                // bottom padding avoids axis labels to be cut off at some resolutions
-                .padBottom(2),
+            bounds: this.innerBounds,
             verticalAxis: this.verticalAxisPart,
             horizontalAxis: this.horizontalAxisPart,
             comparisonLines: this.manager.comparisonLines,

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
@@ -286,14 +286,7 @@ export class ScatterPlotChart
     }
 
     @computed private get innerBounds(): Bounds {
-        return (
-            this.bounds
-                .padRight(this.sidebarWidth + 20)
-                // top padding leaves room for tick labels
-                .padTop(this.currentVerticalAxisLabel ? 0 : 6)
-                // bottom padding makes sure the x-axis label doesn't overflow
-                .padBottom(2)
-        )
+        return this.bounds.padRight(this.sidebarWidth + 20)
     }
 
     @computed get axisBounds(): Bounds {

--- a/packages/@ourworldindata/grapher/src/stackedCharts/AbstractStackedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/AbstractStackedChart.tsx
@@ -215,15 +215,9 @@ export class AbstractStackedChart
     }
 
     @computed get innerBounds(): Bounds {
-        return (
-            this.bounds
-                .padTop(this.paddingForLegendTop)
-                .padRight(this.paddingForLegendRight)
-                // top padding leaves room for tick labels
-                .padTop(6)
-                // bottom padding avoids axis labels to be cut off at some resolutions
-                .padBottom(2)
-        )
+        return this.bounds
+            .padTop(this.paddingForLegendTop)
+            .padRight(this.paddingForLegendRight)
     }
 
     @computed protected get dualAxis(): DualAxis {


### PR DESCRIPTION
The top and bottom of the chart area needs to be padded to prevent tick labels from overflowing. This used to implemented on the chart level, but it makes more sense on the axis level.

<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #5044 👈 
- <kbd>&nbsp;2&nbsp;</kbd> #5027 
- <kbd>&nbsp;1&nbsp;</kbd> #5026 
<!-- GitButler Footer Boundary Bottom -->

