### PR TITLE
feat: provide `archivedChartInfo` for embedded charts

### DIFF
--- a/baker/GrapherBaker.tsx
+++ b/baker/GrapherBaker.tsx
@@ -9,7 +9,6 @@ import {
 } from "@ourworldindata/utils"
 import fs from "fs-extra"
 import {
-    ARCHIVE_BASE_URL,
     BAKED_BASE_URL,
     BAKED_GRAPHER_URL,
 } from "../settings/serverSettings.js"
@@ -32,7 +31,6 @@ import {
     DbRawChartConfig,
     DbEnrichedImage,
     ArchiveMetaInformation,
-    ArchivedPageVersion,
     ArchiveContext,
 } from "@ourworldindata/types"
 import ProgressBar from "progress"
@@ -55,17 +53,8 @@ import { getRelatedChartsForVariable } from "../db/model/Chart.js"
 import { getAllMultiDimDataPageSlugs } from "../db/model/MultiDimDataPage.js"
 import pMap from "p-map"
 import { stringify } from "safe-stable-stringify"
-import { GrapherArchivalManifest } from "./archival/archivalUtils.js"
-import { getLatestGrapherArchivedVersions } from "./archival/archivalChecksum.js"
-
-const getLatestChartArchivedVersionsIfEnabled = async (
-    knex: db.KnexReadonlyTransaction,
-    chartIds?: number[]
-): Promise<Record<number, ArchivedPageVersion>> => {
-    if (!ARCHIVE_BASE_URL) return {}
-
-    return await getLatestGrapherArchivedVersions(knex, chartIds)
-}
+import { GrapherArchivalManifest } from "../serverUtils/archivalUtils.js"
+import { getLatestChartArchivedVersionsIfEnabled } from "../db/model/archival/archivalDb.js"
 
 const renderDatapageIfApplicable = async (
     grapher: GrapherInterface,

--- a/baker/MultiDimBaker.tsx
+++ b/baker/MultiDimBaker.tsx
@@ -39,8 +39,8 @@ import {
     getMultiDimDataPageByCatalogPath,
     getMultiDimDataPageBySlug,
 } from "../db/model/MultiDimDataPage.js"
-import { MultiDimArchivalManifest } from "./archival/archivalUtils.js"
-import { getLatestMultiDimArchivedVersions } from "./archival/archivalChecksum.js"
+import { MultiDimArchivalManifest } from "../serverUtils/archivalUtils.js"
+import { getLatestMultiDimArchivedVersions } from "../db/model/archival/archivalDb.js"
 
 const getLatestMultiDimArchivedVersionsIfEnabled = async (
     knex: db.KnexReadonlyTransaction,

--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -90,6 +90,7 @@ import { getNarrativeChartsInfo } from "../db/model/NarrativeChart.js"
 import { getGrapherRedirectsMap } from "./redirectsFromDb.js"
 import * as R from "remeda"
 import { getDods, getParsedDodsDictionary } from "../db/model/Dod.js"
+import { getLatestChartArchivedVersionsIfEnabled } from "../db/model/archival/archivalDb.js"
 
 type PrefetchedAttachments = {
     donors: string[]
@@ -319,6 +320,9 @@ export class SiteBaker {
                 .then((rows) => rows.map((row) => row.target))
                 .then((targets) => new Set(targets))
 
+            const archivedChartVersions =
+                await getLatestChartArchivedVersionsIfEnabled(knex)
+
             // Includes redirects
             const publishedChartsRaw = await mapSlugsToConfigs(knex).then(
                 (configs) => {
@@ -339,7 +343,12 @@ export class SiteBaker {
                             await makeGrapherLinkedChart(
                                 knex,
                                 chart.config,
-                                chart.slug
+                                chart.slug,
+                                {
+                                    archivedChartInfo:
+                                        archivedChartVersions[chart.id] ||
+                                        undefined,
+                                }
                             )
                         )
                     })

--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -90,7 +90,10 @@ import { getNarrativeChartsInfo } from "../db/model/NarrativeChart.js"
 import { getGrapherRedirectsMap } from "./redirectsFromDb.js"
 import * as R from "remeda"
 import { getDods, getParsedDodsDictionary } from "../db/model/Dod.js"
-import { getLatestChartArchivedVersionsIfEnabled } from "../db/model/archival/archivalDb.js"
+import {
+    getLatestChartArchivedVersionsIfEnabled,
+    getLatestMultiDimArchivedVersionsIfEnabled,
+} from "../db/model/archival/archivalDb.js"
 
 type PrefetchedAttachments = {
     donors: string[]
@@ -356,8 +359,15 @@ export class SiteBaker {
             }
 
             const multiDims = await getAllLinkedPublishedMultiDimDataPages(knex)
-            for (const { slug, config } of multiDims) {
-                publishedCharts.push(makeMultiDimLinkedChart(config, slug))
+            const archivedMultiDimVersions =
+                await getLatestMultiDimArchivedVersionsIfEnabled(knex)
+            for (const { id, slug, config } of multiDims) {
+                publishedCharts.push(
+                    makeMultiDimLinkedChart(config, slug, {
+                        archivedChartInfo:
+                            archivedMultiDimVersions[id] || undefined,
+                    })
+                )
             }
 
             const publishedChartsBySlug = _.keyBy(

--- a/baker/archival/ArchivalBaker.ts
+++ b/baker/archival/ArchivalBaker.ts
@@ -12,6 +12,8 @@ import {
     GrapherInterface,
     MultiDimDataPageConfigEnriched,
     UrlAndMaybeDate,
+    GrapherChecksumsObjectWithHash,
+    MultiDimChecksumsObjectWithHash,
 } from "@ourworldindata/types"
 import fs from "fs-extra"
 import path from "path"
@@ -21,7 +23,10 @@ import { getVariableData } from "../../db/model/Variable.js"
 import findProjectBaseDir from "../../settings/findBaseDir.js"
 import { bakeSingleGrapherPageForArchival } from "../GrapherBaker.js"
 import { bakeSingleMultiDimDataPageForArchival } from "../MultiDimBaker.js"
-import { hashAndCopyFile, hashAndWriteFile } from "./archivalFileUtils.js"
+import {
+    hashAndCopyFile,
+    hashAndWriteFile,
+} from "../../serverUtils/archivalFileUtils.js"
 import {
     GrapherArchivalManifest,
     MultiDimArchivalManifest,
@@ -29,16 +34,14 @@ import {
     assembleGrapherManifest,
     assembleMultiDimArchivalUrl,
     assembleMultiDimManifest,
-} from "./archivalUtils.js"
+} from "../../serverUtils/archivalUtils.js"
 import pMap from "p-map"
 import {
     getAllChartVersionsForChartId,
     getAllMultiDimVersionsForId,
     getLatestGrapherArchivedVersionsFromDb,
     getLatestMultiDimArchivedVersionsFromDb,
-    GrapherChecksumsObjectWithHash,
-    MultiDimChecksumsObjectWithHash,
-} from "./archivalChecksum.js"
+} from "../../db/model/archival/archivalDb.js"
 import { ARCHIVE_BASE_URL } from "../../settings/serverSettings.js"
 import {
     ArchivalTimestamp,

--- a/baker/archival/archiveChangedPages.ts
+++ b/baker/archival/archiveChangedPages.ts
@@ -11,11 +11,13 @@ import {
     findChangedMultiDimPages,
     getGrapherChecksumsFromDb,
     getMultiDimChecksumsFromDb,
-    GrapherChecksumsObjectWithHash,
-    MultiDimChecksumsObjectWithHash,
     insertChartVersions,
     insertMultiDimVersions,
-} from "./archivalChecksum.js"
+} from "../../db/model/archival/archivalDb.js"
+import {
+    GrapherChecksumsObjectWithHash,
+    MultiDimChecksumsObjectWithHash,
+} from "@ourworldindata/types"
 import {
     getDateForArchival,
     getAllVariableIds,

--- a/db/model/Chart.ts
+++ b/db/model/Chart.ts
@@ -608,6 +608,7 @@ export const getRelatedChartsForVariable = async (
         knex,
         `-- sql
             SELECT
+                charts.id AS chartId,
                 chart_configs.slug,
                 chart_configs.full->>"$.title" AS title,
                 chart_configs.full->>"$.variantName" AS variantName,

--- a/db/model/Gdoc/GdocBase.ts
+++ b/db/model/Gdoc/GdocBase.ts
@@ -72,7 +72,10 @@ import {
 } from "../NarrativeChart.js"
 import { indexBy } from "remeda"
 import { getDods } from "../Dod.js"
-import { getLatestChartArchivedVersionsIfEnabled } from "../archival/archivalDb.js"
+import {
+    getLatestChartArchivedVersionsIfEnabled,
+    getLatestMultiDimArchivedVersionsIfEnabled,
+} from "../archival/archivalDb.js"
 
 export async function getLinkedIndicatorsForCharts(
     knex: db.KnexReadonlyTransaction,
@@ -725,9 +728,17 @@ export class GdocBase implements OwidGdocBaseInterface {
                         { onlyPublished: false }
                     )
                     if (!multiDim) return
+                    const archivedChartInfo =
+                        await getLatestMultiDimArchivedVersionsIfEnabled(knex, [
+                            multiDim.id,
+                        ])
                     return makeMultiDimLinkedChart(
                         multiDim.config,
-                        originalSlug
+                        originalSlug,
+                        {
+                            archivedChartInfo:
+                                archivedChartInfo[multiDim.id] || undefined,
+                        }
                     )
                 }
             })
@@ -1149,7 +1160,8 @@ export function makeExplorerLinkedChart(
 
 export function makeMultiDimLinkedChart(
     config: MultiDimDataPageConfigEnriched,
-    slug: string
+    slug: string,
+    { archivedChartInfo }: { archivedChartInfo?: ArchivedPageVersion } = {}
 ): LinkedChart {
     let title = config.title.title
     const titleVariant = config.title.titleVariant
@@ -1162,5 +1174,6 @@ export function makeMultiDimLinkedChart(
         title,
         resolvedUrl: `${BAKED_GRAPHER_URL}/${slug}`,
         tags: [],
+        archivedChartInfo,
     }
 }

--- a/db/model/Gdoc/GdocBase.ts
+++ b/db/model/Gdoc/GdocBase.ts
@@ -21,6 +21,7 @@ import {
     DbInsertPostGdocLink,
     DbPlainTag,
     formatDate,
+    excludeUndefined,
 } from "@ourworldindata/utils"
 import { BAKED_GRAPHER_URL } from "../../../settings/serverSettings.js"
 import { docs as googleDocs } from "@googleapis/docs"
@@ -706,7 +707,14 @@ export class GdocBase implements OwidGdocBaseInterface {
 
         const [archivedChartVersions, archivedMultiDimVersions] =
             await Promise.all([
-                getLatestChartArchivedVersionsIfEnabled(knex),
+                getLatestChartArchivedVersionsIfEnabled(
+                    knex,
+                    excludeUndefined(
+                        this.linkedChartSlugs.grapher.map(
+                            (slug) => slugToIdMap[slug]
+                        )
+                    )
+                ),
                 getLatestMultiDimArchivedVersionsIfEnabled(knex),
             ])
 

--- a/db/model/Gdoc/GdocPost.ts
+++ b/db/model/Gdoc/GdocPost.ts
@@ -148,7 +148,7 @@ export class GdocPost extends GdocBase implements OwidGdocPostInterface {
         if (!this.tags?.length || !this.hasAllChartsBlock) return
 
         const relatedCharts = await knexRaw<{
-            id: number
+            chartId: number
             slug: string
             title: string
             variantName: string
@@ -157,7 +157,7 @@ export class GdocPost extends GdocBase implements OwidGdocPostInterface {
             knex,
             `-- sql
                 SELECT DISTINCT
-                    charts.id AS id,
+                    charts.id AS chartId,
                     chart_configs.slug,
                     chart_configs.full->>"$.title" AS title,
                     chart_configs.full->>"$.variantName" AS variantName,
@@ -173,12 +173,12 @@ export class GdocPost extends GdocBase implements OwidGdocPostInterface {
         )
         archivedVersions ??= await getLatestChartArchivedVersionsIfEnabled(
             knex,
-            relatedCharts.map((c) => c.id)
+            relatedCharts.map((c) => c.chartId)
         )
 
         this.relatedCharts = relatedCharts.map((chart) => ({
             ...chart,
-            archivedChartInfo: archivedVersions[chart.id] || undefined,
+            archivedChartInfo: archivedVersions[chart.chartId] || undefined,
         }))
     }
 }

--- a/db/model/MultiDimDataPage.ts
+++ b/db/model/MultiDimDataPage.ts
@@ -71,13 +71,16 @@ export const getAllPublishedMultiDimDataPagesBySlug = async (
 
 export async function getAllLinkedPublishedMultiDimDataPages(
     knex: KnexReadonlyTransaction
-): Promise<{ slug: string; config: MultiDimDataPageConfigEnriched }[]> {
+): Promise<
+    { id: number; slug: string; config: MultiDimDataPageConfigEnriched }[]
+> {
     const rows = await knexRaw<
-        Pick<DbPlainMultiDimDataPage, "config"> & { slug: string }
+        Pick<DbPlainMultiDimDataPage, "config"> & { id: number; slug: string }
     >(
         knex,
         `-- sql
         SELECT
+            mddp.id as id,
             mddp.slug as slug,
             mddp.config as config
         FROM multi_dim_data_pages mddp

--- a/db/model/archival/archivalDb.ts
+++ b/db/model/archival/archivalDb.ts
@@ -11,52 +11,26 @@ import {
     JsonString,
     MultiDimDataPagesTableName,
     MultiDimDataPageConfigEnriched,
+    GrapherChecksumsObjectWithHash,
+    GrapherChecksums,
+    MultiDimChecksums,
+    MultiDimChecksumsObjectWithHash,
 } from "@ourworldindata/types"
-import * as db from "../../db/db.js"
+import * as db from "../../db.js"
 import { stringify } from "safe-stable-stringify"
-import { hashHex } from "../../serverUtils/hash.js"
-import {
-    GrapherArchivalManifest,
-    MultiDimArchivalManifest,
-    assembleGrapherArchivalUrl,
-    assembleMultiDimArchivalUrl,
-} from "./archivalUtils.js"
+import { hashHex } from "../../../serverUtils/hash.js"
 import {
     ArchivalTimestamp,
     convertToArchivalDateStringIfNecessary,
     getAllVariableIds,
 } from "@ourworldindata/utils"
-
-export interface GrapherChecksums {
-    chartConfigMd5: string
-    indicators: {
-        [id: string]: { metadataChecksum: string; dataChecksum: string }
-    }
-}
-
-export interface GrapherChecksumsObjectWithHash {
-    chartId: number
-    chartSlug: string
-    checksums: GrapherChecksums
-    checksumsHashed: string
-}
-
-export interface MultiDimChecksums {
-    multiDimConfigMd5: string
-    chartConfigs: {
-        [id: string]: string // chartConfigId -> MD5
-    }
-    indicators: {
-        [id: string]: { metadataChecksum: string; dataChecksum: string }
-    }
-}
-
-export interface MultiDimChecksumsObjectWithHash {
-    multiDimId: number
-    multiDimSlug: string
-    checksums: MultiDimChecksums
-    checksumsHashed: string
-}
+import {
+    assembleGrapherArchivalUrl,
+    assembleMultiDimArchivalUrl,
+    GrapherArchivalManifest,
+    MultiDimArchivalManifest,
+} from "../../../serverUtils/archivalUtils.js"
+import { ARCHIVE_BASE_URL } from "../../../settings/serverSettings.js"
 
 // Fetches checksum/hash information about all published charts from the database
 export const getGrapherChecksumsFromDb = async (
@@ -111,7 +85,12 @@ export const getGrapherChecksumsFromDb = async (
 export const getLatestGrapherArchivedVersionsFromDb = async (
     knex: db.KnexReadonlyTransaction,
     chartIds?: number[]
-) => {
+): Promise<
+    Pick<
+        DbPlainArchivedChartVersion,
+        "grapherId" | "grapherSlug" | "archivalTimestamp"
+    >[]
+> => {
     const queryBuilder = knex<DbPlainArchivedChartVersion>(
         ArchivedChartVersionsTableName
     )
@@ -130,7 +109,12 @@ export const getLatestGrapherArchivedVersionsFromDb = async (
 export const getLatestMultiDimArchivedVersionsFromDb = async (
     knex: db.KnexReadonlyTransaction,
     multiDimIds?: number[]
-) => {
+): Promise<
+    Pick<
+        DbPlainArchivedMultiDimVersion,
+        "multiDimId" | "multiDimSlug" | "archivalTimestamp"
+    >[]
+> => {
     const queryBuilder = knex<DbPlainArchivedMultiDimVersion>(
         ArchivedMultiDimVersionsTableName
     )
@@ -172,6 +156,15 @@ export const getLatestGrapherArchivedVersions = async (
     )
 }
 
+export const getLatestChartArchivedVersionsIfEnabled = async (
+    knex: db.KnexReadonlyTransaction,
+    chartIds?: number[]
+): Promise<Record<number, ArchivedPageVersion>> => {
+    if (!ARCHIVE_BASE_URL) return {}
+
+    return await getLatestGrapherArchivedVersions(knex, chartIds)
+}
+
 export const getLatestMultiDimArchivedVersions = async (
     knex: db.KnexReadonlyTransaction,
     multiDimIds?: number[]
@@ -201,7 +194,7 @@ export const getLatestMultiDimArchivedVersions = async (
     )
 }
 
-const hashGrapherChecksumsObj = (checksums: GrapherChecksums) => {
+const hashGrapherChecksumsObj = (checksums: GrapherChecksums): string => {
     const stringified = stringify(
         _.pick(checksums, "chartConfigMd5", "indicators")
     )
@@ -209,7 +202,7 @@ const hashGrapherChecksumsObj = (checksums: GrapherChecksums) => {
     return hashed
 }
 
-const hashMultiDimChecksumsObj = (checksums: MultiDimChecksums) => {
+const hashMultiDimChecksumsObj = (checksums: MultiDimChecksums): string => {
     const stringified = stringify(
         _.pick(checksums, "multiDimConfigMd5", "chartConfigs", "indicators")
     )
@@ -220,7 +213,7 @@ const hashMultiDimChecksumsObj = (checksums: MultiDimChecksums) => {
 const findGrapherHashesInDb = async (
     knex: db.KnexReadonlyTransaction,
     hashes: string[]
-) => {
+): Promise<Set<string>> => {
     const rows = await knex<DbPlainArchivedChartVersion>(
         ArchivedChartVersionsTableName
     )
@@ -232,7 +225,7 @@ const findGrapherHashesInDb = async (
 const findMultiDimHashesInDb = async (
     knex: db.KnexReadonlyTransaction,
     hashes: string[]
-) => {
+): Promise<Set<string>> => {
     const rows = await knex<DbPlainArchivedMultiDimVersion>(
         ArchivedMultiDimVersionsTableName
     )
@@ -243,7 +236,7 @@ const findMultiDimHashesInDb = async (
 
 export const findChangedGrapherPages = async (
     knex: db.KnexReadonlyTransaction
-) => {
+): Promise<GrapherChecksumsObjectWithHash[]> => {
     const allChartChecksums = await getGrapherChecksumsFromDb(knex)
 
     // We're gonna find the hashes of all the graphers that are already archived and up-to-date
@@ -265,7 +258,7 @@ export const findChangedGrapherPages = async (
 
 export const findChangedMultiDimPages = async (
     knex: db.KnexReadonlyTransaction
-) => {
+): Promise<MultiDimChecksumsObjectWithHash[]> => {
     const allMultiDimChecksums = await getMultiDimChecksumsFromDb(knex)
 
     // We're gonna find the hashes of all the multi-dim pages that are already archived and up-to-date
@@ -290,7 +283,7 @@ export const insertChartVersions = async (
     versions: GrapherChecksumsObjectWithHash[],
     date: ArchivalTimestamp,
     manifests: Record<number, GrapherArchivalManifest>
-) => {
+): Promise<void> => {
     const rows: DbInsertArchivedChartVersion[] = versions.map((v) => ({
         grapherId: v.chartId,
         grapherSlug: v.chartSlug,
@@ -308,7 +301,7 @@ export const insertMultiDimVersions = async (
     versions: MultiDimChecksumsObjectWithHash[],
     date: ArchivalTimestamp,
     manifests: Record<number, MultiDimArchivalManifest>
-) => {
+): Promise<void> => {
     const rows: DbInsertArchivedMultiDimVersion[] = versions.map((v) => ({
         multiDimId: v.multiDimId,
         multiDimSlug: v.multiDimSlug,
@@ -324,7 +317,9 @@ export const insertMultiDimVersions = async (
 export const getAllChartVersionsForChartId = async (
     knex: db.KnexReadonlyTransaction,
     chartId: number
-) => {
+): Promise<
+    Pick<DbPlainArchivedChartVersion, "archivalTimestamp" | "grapherSlug">[]
+> => {
     const rows = await knex<DbPlainArchivedChartVersion>(
         ArchivedChartVersionsTableName
     )
@@ -442,7 +437,9 @@ export const getMultiDimChecksumsFromDb = async (
 export const getAllMultiDimVersionsForId = async (
     knex: db.KnexReadonlyTransaction,
     multiDimId: number
-) => {
+): Promise<
+    Pick<DbPlainArchivedMultiDimVersion, "archivalTimestamp" | "multiDimSlug">[]
+> => {
     const rows = await knex<DbPlainArchivedMultiDimVersion>(
         ArchivedMultiDimVersionsTableName
     )

--- a/db/model/archival/archivalDb.ts
+++ b/db/model/archival/archivalDb.ts
@@ -194,6 +194,15 @@ export const getLatestMultiDimArchivedVersions = async (
     )
 }
 
+export const getLatestMultiDimArchivedVersionsIfEnabled = async (
+    knex: db.KnexReadonlyTransaction,
+    multiDimIds?: number[]
+): Promise<Record<number, ArchivedPageVersion>> => {
+    if (!ARCHIVE_BASE_URL) return {}
+
+    return await getLatestMultiDimArchivedVersions(knex, multiDimIds)
+}
+
 const hashGrapherChecksumsObj = (checksums: GrapherChecksums): string => {
     const stringified = stringify(
         _.pick(checksums, "chartConfigMd5", "indicators")

--- a/db/tsconfig.json
+++ b/db/tsconfig.json
@@ -4,5 +4,9 @@
         "outDir": "../itsJustJavascript/db",
         "rootDir": "."
     },
-    "references": [{ "path": "../settings" }, { "path": "../site" }]
+    "references": [
+        { "path": "../settings" },
+        { "path": "../serverUtils" },
+        { "path": "../site" }
+    ]
 }

--- a/packages/@ourworldindata/types/src/domainTypes/Archive.ts
+++ b/packages/@ourworldindata/types/src/domainTypes/Archive.ts
@@ -43,3 +43,34 @@ export interface ArchiveVersions {
         url: string
     }>
 }
+
+export interface GrapherChecksums {
+    chartConfigMd5: string
+    indicators: {
+        [id: string]: { metadataChecksum: string; dataChecksum: string }
+    }
+}
+
+export interface GrapherChecksumsObjectWithHash {
+    chartId: number
+    chartSlug: string
+    checksums: GrapherChecksums
+    checksumsHashed: string
+}
+
+export interface MultiDimChecksums {
+    multiDimConfigMd5: string
+    chartConfigs: {
+        [id: string]: string // chartConfigId -> MD5
+    }
+    indicators: {
+        [id: string]: { metadataChecksum: string; dataChecksum: string }
+    }
+}
+
+export interface MultiDimChecksumsObjectWithHash {
+    multiDimId: number
+    multiDimSlug: string
+    checksums: MultiDimChecksums
+    checksumsHashed: string
+}

--- a/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
@@ -20,6 +20,7 @@ import { QueryParams } from "../domainTypes/Various.js"
 import { TagGraphRoot } from "../domainTypes/ContentGraph.js"
 import { DbRawImage } from "../dbTypes/Images.js"
 import { DbPlainNarrativeChart } from "../dbTypes/NarrativeCharts.js"
+import { ArchivedPageVersion } from "../domainTypes/Archive.js"
 
 export enum OwidGdocPublicationContext {
     unlisted = "unlisted",
@@ -58,6 +59,7 @@ export interface LinkedChart {
     tags: string[]
     tab?: GrapherTabOption
     indicatorId?: number // in case of a datapage
+    archivedChartInfo?: ArchivedPageVersion | undefined
 }
 
 // An object containing metadata needed for embedded narrative charts

--- a/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
+++ b/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
@@ -88,6 +88,7 @@ export interface BasicChartInformation {
     variantName?: string | null
 }
 export interface RelatedChart extends BasicChartInformation {
+    chartId: number
     keyChartLevel?: KeyChartLevel
     archivedChartInfo?: ArchiveContext | undefined
 }

--- a/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
+++ b/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
@@ -16,6 +16,7 @@ import {
     GRAPHER_TAB_TYPES,
 } from "./GrapherConstants.js"
 import { OwidVariableDataMetadataDimensions } from "../OwidVariable.js"
+import { ArchiveContext } from "../domainTypes/Archive.js"
 
 export interface Box {
     x: number
@@ -88,6 +89,7 @@ export interface BasicChartInformation {
 }
 export interface RelatedChart extends BasicChartInformation {
     keyChartLevel?: KeyChartLevel
+    archivedChartInfo?: ArchiveContext | undefined
 }
 export enum DimensionProperty {
     y = "y",

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -806,5 +806,9 @@ export {
     type ArchivedPageVersion,
     type ArchiveVersions,
     type ArchiveContext,
+    type GrapherChecksums,
+    type GrapherChecksumsObjectWithHash,
+    type MultiDimChecksums,
+    type MultiDimChecksumsObjectWithHash,
 } from "./domainTypes/Archive.js"
 export { type AdditionalGrapherDataFetchFn } from "./grapherTypes/GrapherTypes.js"

--- a/serverUtils/archivalFileUtils.ts
+++ b/serverUtils/archivalFileUtils.ts
@@ -26,7 +26,7 @@ export const hashAndCopyFile = async (srcFile: string, targetDir: string) => {
     const targetFilename = path
         .basename(srcFile)
         .replace(/^(.*\/)?([^.]+\.)/, `$1$2${hash}.`)
-    const targetFile = path.resolve(targetDir, targetDir, targetFilename)
+    const targetFile = path.resolve(targetDir, targetFilename)
 
     // eslint-disable-next-line no-console
     console.log(`Copying ${srcFile} to ${targetFile}`)

--- a/serverUtils/archivalFileUtils.ts
+++ b/serverUtils/archivalFileUtils.ts
@@ -1,6 +1,6 @@
 import fs from "fs-extra"
 import path from "path"
-import { hashBase36, hashBase36FromStream } from "../../serverUtils/hash.js"
+import { hashBase36, hashBase36FromStream } from "./hash.js"
 
 const hashFile = async (file: string) => {
     const stream = await fs.createReadStream(file)
@@ -13,6 +13,8 @@ export const hashAndWriteFile = async (targetPath: string, content: string) => {
         /^(.*\/)?([^.]+\.)/,
         `$1$2${hash}.`
     )
+
+    // eslint-disable-next-line no-console
     console.log(`Writing ${targetPathWithHash}`)
     await fs.mkdirp(path.dirname(targetPathWithHash))
     await fs.writeFile(targetPathWithHash, content)
@@ -25,6 +27,8 @@ export const hashAndCopyFile = async (srcFile: string, targetDir: string) => {
         .basename(srcFile)
         .replace(/^(.*\/)?([^.]+\.)/, `$1$2${hash}.`)
     const targetFile = path.resolve(targetDir, targetDir, targetFilename)
+
+    // eslint-disable-next-line no-console
     console.log(`Copying ${srcFile} to ${targetFile}`)
     await fs.copyFile(srcFile, targetFile)
     return targetFile

--- a/serverUtils/archivalUtils.ts
+++ b/serverUtils/archivalUtils.ts
@@ -3,15 +3,15 @@ import {
     lazy,
     convertToArchivalDateStringIfNecessary,
 } from "@ourworldindata/utils"
-import { AssetMap } from "@ourworldindata/types"
 import {
+    AssetMap,
     GrapherChecksums,
     GrapherChecksumsObjectWithHash,
     MultiDimChecksums,
     MultiDimChecksumsObjectWithHash,
-} from "./archivalChecksum.js"
+} from "@ourworldindata/types"
 import { simpleGit } from "simple-git"
-import { ARCHIVE_BASE_URL } from "../../settings/serverSettings.js"
+import { ARCHIVE_BASE_URL } from "../settings/serverSettings.js"
 
 export interface GrapherArchivalManifest {
     assets: {

--- a/site/GrapherPage.test.tsx
+++ b/site/GrapherPage.test.tsx
@@ -36,11 +36,13 @@ beforeAll(() => {
             title: "Chart 1",
             slug: "chart-1",
             keyChartLevel: KeyChartLevel.Middle,
+            chartId: 1,
         },
         {
             title: "Chart 2",
             slug: "chart-2",
             keyChartLevel: KeyChartLevel.Top,
+            chartId: 2,
         },
     ]
 })

--- a/site/GrapherWithFallback.tsx
+++ b/site/GrapherWithFallback.tsx
@@ -1,13 +1,9 @@
-import {
-    ArchiveContext,
-    GRAPHER_PREVIEW_CLASS,
-    GrapherInterface,
-} from "@ourworldindata/types"
+import { GRAPHER_PREVIEW_CLASS } from "@ourworldindata/types"
 import { GrapherFigureView } from "./GrapherFigureView.js"
 import cx from "classnames"
 import GrapherImage from "./GrapherImage.js"
 import { useIntersectionObserver, useIsClient } from "usehooks-ts"
-import { useMemo } from "react"
+import { GrapherProgrammaticInterface } from "@ourworldindata/grapher"
 
 export interface GrapherWithFallbackProps {
     slug?: string
@@ -16,12 +12,11 @@ export interface GrapherWithFallbackProps {
     className?: string
     id?: string
     enablePopulatingUrlParams?: boolean
-    config: Partial<GrapherInterface>
+    config: Partial<GrapherProgrammaticInterface>
     queryStr?: string
     isEmbeddedInAnOwidPage: boolean
     isEmbeddedInADataPage: boolean
     isPreviewing?: boolean
-    archivedChartInfo?: ArchiveContext | undefined
 }
 
 export function GrapherWithFallback(
@@ -41,14 +36,6 @@ export function GrapherWithFallback(
         // Only trigger once
         freezeOnceVisible: true,
     })
-
-    const mergedConfig = useMemo(
-        () => ({
-            ...config,
-            archivedChartInfo: props.archivedChartInfo,
-        }),
-        [config, props.archivedChartInfo]
-    )
 
     // Render fallback png when javascript disabled or while
     // grapher is loading
@@ -90,7 +77,7 @@ export function GrapherWithFallback(
                 <GrapherFigureView
                     slug={slug}
                     configUrl={props.configUrl}
-                    config={mergedConfig}
+                    config={config}
                     useProvidedConfigOnly={props.useProvidedConfigOnly}
                     queryStr={queryStr}
                     isEmbeddedInAnOwidPage={props.isEmbeddedInAnOwidPage}

--- a/site/GrapherWithFallback.tsx
+++ b/site/GrapherWithFallback.tsx
@@ -1,8 +1,13 @@
-import { GRAPHER_PREVIEW_CLASS, GrapherInterface } from "@ourworldindata/types"
+import {
+    ArchiveContext,
+    GRAPHER_PREVIEW_CLASS,
+    GrapherInterface,
+} from "@ourworldindata/types"
 import { GrapherFigureView } from "./GrapherFigureView.js"
 import cx from "classnames"
 import GrapherImage from "./GrapherImage.js"
 import { useIntersectionObserver, useIsClient } from "usehooks-ts"
+import { useMemo } from "react"
 
 export interface GrapherWithFallbackProps {
     slug?: string
@@ -16,6 +21,7 @@ export interface GrapherWithFallbackProps {
     isEmbeddedInAnOwidPage: boolean
     isEmbeddedInADataPage: boolean
     isPreviewing?: boolean
+    archivedChartInfo?: ArchiveContext | undefined
 }
 
 export function GrapherWithFallback(
@@ -35,6 +41,14 @@ export function GrapherWithFallback(
         // Only trigger once
         freezeOnceVisible: true,
     })
+
+    const mergedConfig = useMemo(
+        () => ({
+            ...config,
+            archivedChartInfo: props.archivedChartInfo,
+        }),
+        [config, props.archivedChartInfo]
+    )
 
     // Render fallback png when javascript disabled or while
     // grapher is loading
@@ -76,7 +90,7 @@ export function GrapherWithFallback(
                 <GrapherFigureView
                     slug={slug}
                     configUrl={props.configUrl}
-                    config={config}
+                    config={mergedConfig}
                     useProvidedConfigOnly={props.useProvidedConfigOnly}
                     queryStr={queryStr}
                     isEmbeddedInAnOwidPage={props.isEmbeddedInAnOwidPage}

--- a/site/blocks/RelatedCharts.test.tsx
+++ b/site/blocks/RelatedCharts.test.tsx
@@ -16,11 +16,13 @@ const charts = [
         title: "Chart 1",
         slug: "chart-1",
         keyChartLevel: KeyChartLevel.Middle,
+        chartId: 1,
     },
     {
         title: "Chart 2",
         slug: "chart-2",
         keyChartLevel: KeyChartLevel.Top,
+        chartId: 2,
     },
 ]
 

--- a/site/blocks/RelatedCharts.tsx
+++ b/site/blocks/RelatedCharts.tsx
@@ -55,6 +55,7 @@ export const RelatedCharts = ({
             isEmbeddedInADataPage={false}
             config={{}}
             isPreviewing={isPreviewing}
+            archivedChartInfo={activeChart.archivedChartInfo}
         />
     )
 

--- a/site/blocks/RelatedCharts.tsx
+++ b/site/blocks/RelatedCharts.tsx
@@ -53,9 +53,8 @@ export const RelatedCharts = ({
             enablePopulatingUrlParams={true}
             isEmbeddedInAnOwidPage={true}
             isEmbeddedInADataPage={false}
-            config={{}}
+            config={{ archivedChartInfo: activeChart.archivedChartInfo }}
             isPreviewing={isPreviewing}
-            archivedChartInfo={activeChart.archivedChartInfo}
         />
     )
 

--- a/site/gdocs/components/Chart.tsx
+++ b/site/gdocs/components/Chart.tsx
@@ -102,7 +102,13 @@ export default function Chart({
         return config
     }, [d.title, d.subtitle, d.controls, d.tabs, isExplorer])
 
-    const chartConfig = customizedChartConfig
+    const chartConfig = useMemo(
+        () => ({
+            archivedChartInfo: linkedChart?.archivedChartInfo,
+            ...customizedChartConfig,
+        }),
+        [linkedChart?.archivedChartInfo, customizedChartConfig]
+    )
 
     if (!linkedChart) return null
     return (
@@ -155,7 +161,6 @@ export default function Chart({
                     isEmbeddedInAnOwidPage={true}
                     isEmbeddedInADataPage={false}
                     isPreviewing={isPreviewing}
-                    archivedChartInfo={linkedChart.archivedChartInfo}
                 />
             )}
             {d.caption ? (

--- a/site/gdocs/components/Chart.tsx
+++ b/site/gdocs/components/Chart.tsx
@@ -155,6 +155,7 @@ export default function Chart({
                     isEmbeddedInAnOwidPage={true}
                     isEmbeddedInADataPage={false}
                     isPreviewing={isPreviewing}
+                    archivedChartInfo={linkedChart.archivedChartInfo}
                 />
             )}
             {d.caption ? (


### PR DESCRIPTION
Resolves #5063.

Provides `archivedChartInfo` in the following blocks/places:
- For the `<Chart>` component, via `_OWID_GDOC_PROPS.linkedCharts`
- For the `<RelatedCharts>` component, via `OWID_GDOC_PROPS.relatedCharts`
- For the `<AllCharts>` component, via `_OWID_DATAPAGEV2_PROPS.datapageData.allCharts`

Putting it in the right places everywhere took a lot of work and moving code, frankly more than I expected, which isn't great. At the very least, the various commits are self-contained.

Also, while working on this, I noticed that gdocs' `prefetchedAttachments` don't quite work the way they should, and that each baked gdoc still runs all the various DB queries etc. no matter what. I didn't fix that, as it's out of scope for this issue.

## Testing advice

- _Note that the life expectancy chart is pretty much the only one that has archive info on staging servers_
- Go to http://staging-site-archive-info-in-gdocs/life-expectancy and observe that in both the key insights block and the related charts block, the original life expectancy block has the correct info inside the Embed dialog
- Go to http://staging-site-archive-info-in-gdocs/ and check that the same is true for the key indicator block on life expectancy there
- For completeness sake, check the same on http://staging-site-archive-info-in-gdocs/life-expectancy-how-is-it-calculated-and-how-should-it-be-interpreted