### PR TITLE
Hide data page tags on a small screen

### DIFF
--- a/site/DataPageContent.scss
+++ b/site/DataPageContent.scss
@@ -58,17 +58,13 @@
     }
 
     .header__right {
-        @include sm-only {
-            padding-top: 16px;
-            padding-bottom: 16px;
-            border-top: 1px solid $blue-20;
-        }
+        margin-bottom: 16px;
+        padding-left: 24px;
+        border-left: 1px solid $blue-20;
+        align-self: start;
 
-        @include sm-up {
-            margin-bottom: 16px;
-            padding-left: 24px;
-            border-left: 1px solid $blue-20;
-            align-self: start;
+        @include sm-only {
+            display: none;
         }
     }
 


### PR DESCRIPTION
Resolves #4992

I confirmed with Joe and Marwa that we only want to hide the tags on a small screen for now.
