### PR TITLE
fix: accept newer schema versions without throwing

### DIFF
--- a/packages/@ourworldindata/grapher/src/schema/migrations/migrate.test.ts
+++ b/packages/@ourworldindata/grapher/src/schema/migrations/migrate.test.ts
@@ -1,9 +1,10 @@
-import { expect, it } from "vitest"
+import { expect, it, vi } from "vitest"
 
 import { defaultGrapherConfig } from "../defaultGrapherConfig"
 import { migrateGrapherConfigToLatestVersion } from "./migrate"
 import { migrateFrom006To007, migrateFrom007To008 } from "./migrations"
 import { AnyConfigWithValidSchema } from "./helpers"
+import * as _ from "lodash-es"
 
 it("returns a valid config as is", () => {
     const validConfig = {
@@ -19,12 +20,18 @@ it("throws if the schema field is missing", () => {
     expect(() => migrateGrapherConfigToLatestVersion({})).toThrow()
 })
 
-it("throws if the schema field is invalid", () => {
-    expect(() =>
-        migrateGrapherConfigToLatestVersion({
-            $schema: "invalid",
-        })
-    ).toThrow()
+it("warns if the schema field is invalid", () => {
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(_.noop)
+
+    const invalidConfig = {
+        $schema: "invalid",
+    }
+    expect(migrateGrapherConfigToLatestVersion(invalidConfig)).toEqual(
+        invalidConfig
+    )
+
+    expect(consoleWarnSpy).toHaveBeenCalled()
+    consoleWarnSpy.mockRestore()
 })
 
 it("runs multiple migrations if necessary", () => {

--- a/packages/@ourworldindata/utils/src/grapherConfigUtils.test.ts
+++ b/packages/@ourworldindata/utils/src/grapherConfigUtils.test.ts
@@ -1,5 +1,6 @@
-import { expect, it, describe } from "vitest"
+import { expect, it, describe, vi } from "vitest"
 
+import * as _ from "lodash-es"
 import {
     DimensionProperty,
     GrapherInterface,
@@ -132,13 +133,23 @@ describe(mergeGrapherConfigs, () => {
         })
     })
 
-    it("doesn't merge configs of different schema versions", () => {
-        expect(() =>
+    it("warns when merging configs of different schema versions", () => {
+        const consoleWarnSpy = vi
+            .spyOn(console, "warn")
+            .mockImplementation(_.noop)
+
+        expect(
             mergeGrapherConfigs(
                 { $schema: "1", title: "Title A" },
                 { $schema: "2", title: "Title B" }
             )
-        ).toThrowError()
+        ).toEqual({
+            $schema: "2",
+            title: "Title B",
+        })
+
+        expect(consoleWarnSpy).toHaveBeenCalled()
+        consoleWarnSpy.mockRestore()
     })
 
     it("excludes id, slug, version and isPublished from inheritance", () => {

--- a/packages/@ourworldindata/utils/src/grapherConfigUtils.ts
+++ b/packages/@ourworldindata/utils/src/grapherConfigUtils.ts
@@ -6,6 +6,7 @@ import {
     omitEmptyObjectsRecursive,
     traverseObjects,
 } from "./Util"
+import * as Sentry from "@sentry/browser"
 
 const REQUIRED_KEYS = ["$schema", "dimensions"]
 
@@ -63,11 +64,13 @@ export function mergeGrapherConfigs(
         excludeUndefined(configsToMerge.map((c) => c["$schema"]))
     )
     if (uniqueSchemas.length > 1) {
-        throw new Error(
-            `Can't merge Grapher configs with different schema versions: ${uniqueSchemas.join(
-                ", "
-            )}`
-        )
+        const message = `Merging Grapher configs with different schema versions. This may lead to unexpected behavior. Found: ${uniqueSchemas.join(
+            ", "
+        )}`
+        console.warn(message)
+        Sentry.captureMessage(message, {
+            level: "warning",
+        })
     }
 
     // keys that should not be inherited are removed from all but the last config


### PR DESCRIPTION
As discussed in the data viz meeting today, accepting the schema and hoping for the best is a better strategy than just outright rejecting it and throwing the towel.

I'm not sure what to do about `mergeGrapherConfigs`? https://github.com/owid/owid-grapher/blob/4ccb17228d8fa4e19417362130d096027fccdcf7/packages/%40ourworldindata/utils/src/grapherConfigUtils.ts#L41-L72

It is also throwing when it attempts to merge two different schema versions, but on the client it is only used for explorers.

Merging configs with different schema versions seems more tricky than just accepting them. What do you think, @sophiamersmann?