### PR TITLE
Bump remeda to 2.23.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
         "react-tag-autocomplete": "^7.5.0",
         "react-zoom-pan-pinch": "^2.1.3",
         "reflect-metadata": "^0.2.2",
-        "remeda": "^2.21.2",
+        "remeda": "^2.23.3",
         "rxjs": "^7.8.2",
         "s-expression": "^3.1.1",
         "safe-stable-stringify": "^2.4.1",

--- a/packages/@ourworldindata/components/package.json
+++ b/packages/@ourworldindata/components/package.json
@@ -29,7 +29,7 @@
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-markdown": "^8.0.7",
-        "remeda": "^2.21.2",
+        "remeda": "^2.23.3",
         "ts-pattern": "^5.0.5",
         "unist-util-visit": "^4.1.2",
         "url-slug": "^3.0.2"

--- a/packages/@ourworldindata/core-table/package.json
+++ b/packages/@ourworldindata/core-table/package.json
@@ -19,14 +19,14 @@
     "@ourworldindata/utils": "workspace:^",
     "d3": "^6.1.1",
     "dayjs": "^1.11.11",
-    "papaparse": "^5.4.1"
+    "papaparse": "^5.4.1",
+    "remeda": "^2.23.3"
   },
   "devDependencies": {
     "@types/d3": "^6",
     "@types/lodash-es": "^4",
     "@types/papaparse": "^5.3.15",
     "eslint": "^9.23.0",
-    "remeda": "^2.21.2",
     "typescript": "~5.8.2",
     "vitest": "^3.2.4"
   },

--- a/packages/@ourworldindata/explorer/package.json
+++ b/packages/@ourworldindata/explorer/package.json
@@ -38,7 +38,7 @@
     "react-flip-toolkit": "^7.0.9",
     "react-move": "^6.5.0",
     "react-select": "^5.8.0",
-    "remeda": "^2.21.2",
+    "remeda": "^2.23.3",
     "simple-statistics": "^7.3.2",
     "topojson-client": "^3.1.0",
     "ts-pattern": "^5.0.5",

--- a/packages/@ourworldindata/grapher/package.json
+++ b/packages/@ourworldindata/grapher/package.json
@@ -43,6 +43,7 @@
     "react-flip-toolkit": "^7.0.9",
     "react-move": "^6.5.0",
     "react-select": "^5.8.0",
+    "remeda": "^2.23.3",
     "simple-statistics": "^7.3.2",
     "topojson-client": "^3.1.0",
     "ts-pattern": "^5.0.5",
@@ -67,7 +68,6 @@
     "@wojtekmaj/enzyme-adapter-react-17": "^0.8.0",
     "eslint": "^9.23.0",
     "eslint-plugin-react-hooks": "^5.2.0",
-    "remeda": "^2.21.2",
     "typescript": "~5.8.2",
     "vitest": "^3.2.4"
   },

--- a/packages/@ourworldindata/utils/package.json
+++ b/packages/@ourworldindata/utils/package.json
@@ -26,6 +26,7 @@
     "mobx-react": "5",
     "react": "^17.0.2",
     "react-select": "^5.8.0",
+    "remeda": "^2.23.3",
     "string-pixel-width": "^1.10.0",
     "striptags": "^3.2.0",
     "timezone-mock": "^1.0.18",
@@ -42,7 +43,6 @@
     "@types/url-parse": "^1.4.8",
     "eslint": "^9.23.0",
     "eslint-plugin-react-hooks": "^5.2.0",
-    "remeda": "^2.21.2",
     "typescript": "~5.8.2",
     "vitest": "^3.2.4"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2817,7 +2817,7 @@ __metadata:
     react: "npm:^17.0.2"
     react-dom: "npm:^17.0.2"
     react-markdown: "npm:^8.0.7"
-    remeda: "npm:^2.21.2"
+    remeda: "npm:^2.23.3"
     ts-pattern: "npm:^5.0.5"
     typescript: "npm:~5.8.2"
     unist-util-visit: "npm:^4.1.2"
@@ -2839,7 +2839,7 @@ __metadata:
     dayjs: "npm:^1.11.11"
     eslint: "npm:^9.23.0"
     papaparse: "npm:^5.4.1"
-    remeda: "npm:^2.21.2"
+    remeda: "npm:^2.23.3"
     typescript: "npm:~5.8.2"
     vitest: "npm:^3.2.4"
   languageName: unknown
@@ -2886,7 +2886,7 @@ __metadata:
     react-flip-toolkit: "npm:^7.0.9"
     react-move: "npm:^6.5.0"
     react-select: "npm:^5.8.0"
-    remeda: "npm:^2.21.2"
+    remeda: "npm:^2.23.3"
     simple-statistics: "npm:^7.3.2"
     topojson-client: "npm:^3.1.0"
     ts-pattern: "npm:^5.0.5"
@@ -2944,7 +2944,7 @@ __metadata:
     react-flip-toolkit: "npm:^7.0.9"
     react-move: "npm:^6.5.0"
     react-select: "npm:^5.8.0"
-    remeda: "npm:^2.21.2"
+    remeda: "npm:^2.23.3"
     simple-statistics: "npm:^7.3.2"
     topojson-client: "npm:^3.1.0"
     ts-pattern: "npm:^5.0.5"
@@ -2991,7 +2991,7 @@ __metadata:
     mobx-react: "npm:5"
     react: "npm:^17.0.2"
     react-select: "npm:^5.8.0"
-    remeda: "npm:^2.21.2"
+    remeda: "npm:^2.23.3"
     string-pixel-width: "npm:^1.10.0"
     striptags: "npm:^3.2.0"
     timezone-mock: "npm:^1.0.18"
@@ -11525,7 +11525,7 @@ __metadata:
     react-tag-autocomplete: "npm:^7.5.0"
     react-zoom-pan-pinch: "npm:^2.1.3"
     reflect-metadata: "npm:^0.2.2"
-    remeda: "npm:^2.21.2"
+    remeda: "npm:^2.23.3"
     rxjs: "npm:^7.8.2"
     s-expression: "npm:^3.1.1"
     safe-stable-stringify: "npm:^2.4.1"
@@ -16212,12 +16212,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"remeda@npm:^2.21.2":
-  version: 2.21.2
-  resolution: "remeda@npm:2.21.2"
+"remeda@npm:^2.23.3":
+  version: 2.23.3
+  resolution: "remeda@npm:2.23.3"
   dependencies:
-    type-fest: "npm:^4.37.0"
-  checksum: 10/70461b9f380eb16bff37acb2f63c5c45f80f74e0079deda4ad471897a108fc4e0b8ef55707eb17ff6c0e59ca5a35a20dea9da42e07b324a39677cd14045b5889
+    type-fest: "npm:^4.41.0"
+  checksum: 10/82797d18369a42d3259c4756e7cfda8a53b4dd9fbaab04d48e7b1589dc24b353887d42fd9a23d37a52d44a8ca1aab965521a9c30469853714b5369b781ce39b0
   languageName: node
   linkType: hard
 
@@ -17806,10 +17806,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"type-fest@npm:^4.37.0":
-  version: 4.39.1
-  resolution: "type-fest@npm:4.39.1"
-  checksum: 10/8f3fc947cb072effd9ba240425397b4d3c08901b344409bc12a0aabf43fd309f87fa214d7ee0b600f6e2335b435f40992cd22c0ce4bc7ab8dc5a987200f83bcc
+"type-fest@npm:^4.41.0":
+  version: 4.41.0
+  resolution: "type-fest@npm:4.41.0"
+  checksum: 10/617ace794ac0893c2986912d28b3065ad1afb484cad59297835a0807dc63286c39e8675d65f7de08fafa339afcb8fe06a36e9a188b9857756ae1e92ee8bda212
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Fixes https://github.com/remeda/remeda/issues/1128
- Fix type errors after the bump
- Add remeda as explicit dependency to packages which already use it
