### PR TITLE
fix: show loading indicator while config is being fetched

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/FetchingGrapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/FetchingGrapher.tsx
@@ -50,6 +50,7 @@ export function FetchingGrapher(
                 }),
             queryStr: props.queryStr,
             bounds: props.externalBounds,
+            isConfigReady: !props.configUrl,
         })
     )
 
@@ -95,6 +96,7 @@ export function FetchingGrapher(
                         grapherState.current.updateFromObject(mergedConfig)
                         grapherState.current.legacyConfigAsAuthored =
                             mergedConfig
+                        grapherState.current.isConfigReady = true
                         // Special logic to handle the tab option
                         if (mergedConfig.tab) {
                             match(mergedConfig.tab)

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -452,7 +452,8 @@ export class GrapherState {
     isEmbeddedInAnOwidPage?: boolean = false
     isEmbeddedInADataPage?: boolean = false
 
-    // This one's explicitly set to `false` if FetchingGrapher is fetching the config
+    // This one's explicitly set to `false` if FetchingGrapher or some other
+    // external code is fetching the config
     @observable isConfigReady?: boolean = true
     /** Whether external grapher controls can be hidden in embeds. */
     @observable.ref canHideExternalControlsInEmbed: boolean = false

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -283,6 +283,7 @@ export interface GrapherProgrammaticInterface extends GrapherInterface {
     bindUrlToWindow?: boolean
     isEmbeddedInAnOwidPage?: boolean
     isEmbeddedInADataPage?: boolean
+    isConfigReady?: boolean
     canHideExternalControlsInEmbed?: boolean
 
     narrativeChartInfo?: Pick<
@@ -450,6 +451,9 @@ export class GrapherState {
     }
     isEmbeddedInAnOwidPage?: boolean = false
     isEmbeddedInADataPage?: boolean = false
+
+    // This one's explicitly set to `false` if FetchingGrapher is fetching the config
+    @observable isConfigReady?: boolean = true
     /** Whether external grapher controls can be hidden in embeds. */
     @observable.ref canHideExternalControlsInEmbed: boolean = false
 
@@ -1204,6 +1208,7 @@ export class GrapherState {
     }
     // Ready to go iff we have retrieved data for every variable associated with the chart
     @computed get isReady(): boolean {
+        if (!this.isConfigReady) return false
         return this.whatAreWeWaitingFor === ""
     }
 

--- a/site/multiDim/MultiDim.tsx
+++ b/site/multiDim/MultiDim.tsx
@@ -48,6 +48,7 @@ export default function MultiDim({
                 loadVariableDataAndMetadata(varId, DATA_API_URL, {
                     noCache: isPreviewing,
                 }),
+            isConfigReady: false,
         })
     )
     const grapherDataLoader = useRef(
@@ -151,6 +152,7 @@ export default function MultiDim({
                 grapher.setAuthoredVersion(grapherConfig)
                 grapher.reset()
                 grapher.updateFromObject(grapherConfig)
+                grapher.isConfigReady = true
                 void grapherDataLoader
                     .current(
                         grapherConfig.dimensions ?? [],

--- a/site/multiDim/MultiDimDataPageContent.tsx
+++ b/site/multiDim/MultiDimDataPageContent.tsx
@@ -121,6 +121,7 @@ export function DataPageContent({
                     noCache: isPreviewing,
                 }),
             manager: managerRef.current,
+            isConfigReady: false,
         })
     )
     const grapherFigureRef = useRef<HTMLDivElement>(null)
@@ -236,6 +237,7 @@ export function DataPageContent({
                             grapherState.setAuthoredVersion(config)
                             grapherState.reset()
                             grapherState.updateFromObject(config)
+                            grapherState.isConfigReady = true
 
                             grapherState.populateFromQueryParams(
                                 grapherQueryParams


### PR DESCRIPTION
Fixes #5062.

The refactor made it so the config is fetched inside `FetchingGrapher`, but Grapher is unaware of that.

On the other hand, it is somewhat important that a dimensionless Grapher continues to show the "No table loaded yet" warning in other places, for example in the admin.

For this reason, I opted to introduce the new `isConfigReady` state, which goes into grapher's `isReady`.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #5081 
- <kbd>&nbsp;1&nbsp;</kbd> #5080 👈 
<!-- GitButler Footer Boundary Bottom -->

