### PR TITLE
feat: show fewer controls during loading

### DIFF
--- a/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
@@ -421,29 +421,39 @@ export class CaptionedChart extends React.Component<CaptionedChartProps> {
                 <Header manager={this.manager} maxWidth={this.maxWidth} />
                 <VerticalSpace height={this.verticalPadding} />
 
-                {/* #2 [Controls] */}
-                {this.showControlsRow && this.renderControlsRow()}
-                {this.showControlsRow && (
-                    <VerticalSpace height={this.verticalPaddingSmall} />
+                {this.manager.isReady ? (
+                    <>
+                        {/* #2 [Controls] */}
+                        {this.showControlsRow && this.renderControlsRow()}
+                        {this.showControlsRow && (
+                            <VerticalSpace height={this.verticalPaddingSmall} />
+                        )}
+
+                        {/* #3 Chart/Map/Table */}
+                        {this.manager.isOnTableTab
+                            ? this.renderDataTable()
+                            : this.renderChartOrMap()}
+
+                        {/* #4 [Timeline] */}
+                        {this.manager.hasTimeline && (
+                            <VerticalSpace height={this.verticalPaddingSmall} />
+                        )}
+                        {this.manager.hasTimeline && this.renderTimeline()}
+
+                        {/* #5 Footer */}
+                        <VerticalSpace height={this.verticalPadding} />
+                        <Footer
+                            manager={this.manager}
+                            maxWidth={this.maxWidth}
+                        />
+
+                        {/* #6 [Related question] */}
+                        {this.showRelatedQuestion &&
+                            this.renderRelatedQuestion()}
+                    </>
+                ) : (
+                    this.renderLoadingIndicator()
                 )}
-
-                {/* #3 Chart/Map/Table */}
-                {this.manager.isOnTableTab
-                    ? this.renderDataTable()
-                    : this.renderChartOrMap()}
-
-                {/* #4 [Timeline] */}
-                {this.manager.hasTimeline && (
-                    <VerticalSpace height={this.verticalPaddingSmall} />
-                )}
-                {this.manager.hasTimeline && this.renderTimeline()}
-
-                {/* #5 Footer */}
-                <VerticalSpace height={this.verticalPadding} />
-                <Footer manager={this.manager} maxWidth={this.maxWidth} />
-
-                {/* #6 [Related question] */}
-                {this.showRelatedQuestion && this.renderRelatedQuestion()}
             </div>
         )
     }


### PR DESCRIPTION
This is an optional addendum to #5080.

During loading, we currently show a bunch of controls - things like the tab bar, data source, settings menu, download button, etc.

While a few of these may make sense, many of these just don't make any sense and can just be removed.

What do you think?


Here are some before/after videos with the loading artificially slowed down:

## Before (current master)

https://github.com/user-attachments/assets/e9c12b07-99c6-4e04-a8a3-79e60041aa93

## Before (with #5080)

https://github.com/user-attachments/assets/15fb7e58-82cc-4854-921a-38397b2ed5af


## After

https://github.com/user-attachments/assets/52f9c3bc-5a5e-471c-9096-2515f28a1a4b


<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #5081 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #5080 
<!-- GitButler Footer Boundary Bottom -->

