### PR TITLE
🐛 fix topic page heading size

### DIFF
--- a/site/gdocs/components/OwidGdocHeader.tsx
+++ b/site/gdocs/components/OwidGdocHeader.tsx
@@ -125,7 +125,7 @@ function OwidArticleHeader({
 function OwidTopicPageHeader({ content }: { content: OwidGdocPostContent }) {
     return (
         <header className="topic-page-header grid span-cols-14 grid-cols-12-full-width">
-            <h1 className="display-2-semibold col-start-2 span-cols-8 col-sm-start-2 span-sm-cols-12">
+            <h1 className="display-1-semibold col-start-2 span-cols-8 col-sm-start-2 span-sm-cols-12">
                 {content.title}
             </h1>
             <p className="topic-page-header__subtitle body-1-regular col-start-2 span-cols-8 col-sm-start-2 span-sm-cols-12">
@@ -157,7 +157,7 @@ function OwidLinearTopicPageHeader({
 }) {
     return (
         <header className="topic-page-header grid span-cols-14 grid-cols-12-full-width">
-            <h1 className="display-2-semibold col-start-5 span-cols-6 col-md-start-3 span-md-cols-10 span-sm-cols-12 col-sm-start-2">
+            <h1 className="display-1-semibold col-start-5 span-cols-6 col-md-start-3 span-md-cols-10 span-sm-cols-12 col-sm-start-2">
                 {content.title}
             </h1>
             <p className="topic-page-header__subtitle body-1-regular col-start-5 span-cols-6 col-md-start-3 span-md-cols-10 span-sm-cols-12 col-sm-start-2">


### PR DESCRIPTION
A small oversight from the LTP restyle.

[Figma reference](https://www.figma.com/design/HcwsPwvmm3azqy2a7RL5QK/Topic-Page?node-id=116-882&p=f&t=EOgpWTISF6KihKIH-0)