### PR TITLE
🔨 drop staticFormat

### DIFF
--- a/adminSiteClient/ChartEditorView.tsx
+++ b/adminSiteClient/ChartEditorView.tsx
@@ -16,12 +16,13 @@ import {
     extractDetailsFromSyntax,
     getIndexableKeys,
 } from "@ourworldindata/utils"
+import { GrapherInterface, DimensionProperty } from "@ourworldindata/types"
 import {
-    GrapherInterface,
-    GrapherStaticFormat,
-    DimensionProperty,
-} from "@ourworldindata/types"
-import { Grapher, GrapherState } from "@ourworldindata/grapher"
+    DEFAULT_GRAPHER_BOUNDS,
+    DEFAULT_GRAPHER_BOUNDS_SQUARE,
+    Grapher,
+    GrapherState,
+} from "@ourworldindata/grapher"
 import { Admin } from "./Admin.js"
 import { getFullReferencesCount, isChartEditorInstance } from "./ChartEditor.js"
 import { EditorBasicTab } from "./EditorBasicTab.js"
@@ -189,11 +190,10 @@ export class ChartEditorView<
             ? new Bounds(0, 0, 380, 525)
             : this.grapherState.defaultBounds
     }
-
-    @computed private get staticFormat(): GrapherStaticFormat {
+    @computed private get staticBounds(): Bounds {
         return this.isMobilePreview
-            ? GrapherStaticFormat.square
-            : GrapherStaticFormat.landscape
+            ? DEFAULT_GRAPHER_BOUNDS_SQUARE
+            : DEFAULT_GRAPHER_BOUNDS
     }
 
     // unvalidated terms extracted from the subtitle and note fields
@@ -320,7 +320,7 @@ export class ChartEditorView<
             reaction(
                 () => this.editor && this.editor.previewMode,
                 () => {
-                    this.grapherState.staticFormat = this.staticFormat
+                    this.grapherState.staticBounds = this.staticBounds
                     this.grapherState.externalBounds = this.bounds
                 }
             )

--- a/adminSiteClient/EditorExportTab.tsx
+++ b/adminSiteClient/EditorExportTab.tsx
@@ -3,12 +3,13 @@ import { observer } from "mobx-react"
 import { Component } from "react"
 import { Section, Toggle } from "./Forms.js"
 import {
+    DEFAULT_GRAPHER_BOUNDS,
+    DEFAULT_GRAPHER_BOUNDS_SQUARE,
     GrapherState,
     loadVariableDataAndMetadata,
 } from "@ourworldindata/grapher"
 import {
     triggerDownloadFromBlob,
-    GrapherStaticFormat,
     OwidVariableDataMetadataDimensions,
     OwidVariableId,
 } from "@ourworldindata/utils"
@@ -203,31 +204,31 @@ export class EditorExportTab<
 
     @action.bound private onDownloadDesktopSVG() {
         void this.download(`${this.baseFilename}-desktop.svg`, {
-            format: GrapherStaticFormat.landscape,
+            format: "landscape",
         })
     }
 
     @action.bound private onDownloadDesktopPNG() {
         void this.download(`${this.baseFilename}-desktop.png`, {
-            format: GrapherStaticFormat.landscape,
+            format: "landscape",
         })
     }
 
     @action.bound private onDownloadMobileSVG() {
         void this.download(`${this.baseFilename}-mobile.svg`, {
-            format: GrapherStaticFormat.square,
+            format: "square",
         })
     }
 
     @action.bound private onDownloadMobilePNG() {
         void this.download(`${this.baseFilename}-mobile.png`, {
-            format: GrapherStaticFormat.square,
+            format: "square",
         })
     }
 
     @action.bound private onDownloadMobileSVGForSocialMedia() {
         void this.download(`${this.baseFilename}-instagram.svg`, {
-            format: GrapherStaticFormat.square,
+            format: "square",
             isSocialMediaExport: true,
         })
     }
@@ -238,19 +239,24 @@ export class EditorExportTab<
             format,
             isSocialMediaExport = false,
         }: {
-            format: GrapherStaticFormat
+            format: "landscape" | "square"
             isSocialMediaExport?: boolean
         }
     ) {
+        const requestedBounds =
+            format === "landscape"
+                ? DEFAULT_GRAPHER_BOUNDS
+                : DEFAULT_GRAPHER_BOUNDS_SQUARE
+
         try {
             let grapherState = this.grapherState
             if (
-                this.grapherState.staticFormat !== format ||
+                !this.grapherState.staticBounds.equals(requestedBounds) ||
                 this.grapherState.isSocialMediaExport !== isSocialMediaExport
             ) {
                 grapherState = new GrapherState({
                     ...this.grapherState.toObject(),
-                    staticFormat: format,
+                    staticBounds: requestedBounds,
                     selectedEntityNames: [
                         ...this.grapherState.selection.selectedEntityNames,
                     ],

--- a/functions/_common/imageOptions.ts
+++ b/functions/_common/imageOptions.ts
@@ -1,6 +1,8 @@
+import * as _ from "lodash-es"
 import {
     GrapherProgrammaticInterface,
     GRAPHER_SQUARE_SIZE,
+    DEFAULT_GRAPHER_BOUNDS_SQUARE,
 } from "@ourworldindata/grapher"
 import {
     DEFAULT_ASPECT_RATIO,
@@ -11,7 +13,6 @@ import {
     DEFAULT_WIDTH,
     DEFAULT_HEIGHT,
 } from "./grapherRenderer.js"
-import { GrapherStaticFormat } from "@ourworldindata/types"
 
 export interface ImageOptions {
     pngWidth: number
@@ -49,7 +50,7 @@ const SQUARE_OPTIONS: Readonly<ImageOptions> = {
     fontSize: undefined,
     grapherProps: {
         isSocialMediaExport: false,
-        staticFormat: GrapherStaticFormat.square,
+        staticBounds: DEFAULT_GRAPHER_BOUNDS_SQUARE,
     },
 }
 
@@ -59,7 +60,7 @@ export const extractOptions = (params: URLSearchParams): ImageOptions => {
     if (imType === "twitter") return TWITTER_OPTIONS
     else if (imType === "og") return OPEN_GRAPH_OPTIONS
     else if (imType === "square" || imType === "social-media-square") {
-        const squareOptions = structuredClone(SQUARE_OPTIONS) as ImageOptions
+        const squareOptions = _.cloneDeep(SQUARE_OPTIONS) as ImageOptions
         if (imType === "social-media-square") {
             squareOptions.grapherProps.isSocialMediaExport = true
         }

--- a/packages/@ourworldindata/explorer/src/Explorer.tsx
+++ b/packages/@ourworldindata/explorer/src/Explorer.tsx
@@ -36,7 +36,6 @@ import {
 import {
     Bounds,
     ColumnSlug,
-    DEFAULT_BOUNDS,
     DimensionProperty,
     excludeUndefined,
     exposeInstanceOnWindow,
@@ -950,7 +949,6 @@ export class Explorer
     private grapherContainerRef: React.RefObject<HTMLDivElement> =
         React.createRef()
 
-    @observable.ref private grapherBounds = DEFAULT_BOUNDS
     @observable.ref
     private grapherRef: React.RefObject<Grapher> = React.createRef()
 

--- a/packages/@ourworldindata/grapher/src/axis/Axis.ts
+++ b/packages/@ourworldindata/grapher/src/axis/Axis.ts
@@ -5,7 +5,6 @@ import {
     rollingMap,
     numberMagnitude,
     Bounds,
-    DEFAULT_BOUNDS,
     AxisAlign,
     HorizontalAlign,
     Position,
@@ -21,6 +20,7 @@ import { AxisConfig, AxisManager } from "./AxisConfig"
 import { MarkdownTextWrap } from "@ourworldindata/components"
 import { ColumnTypeMap, CoreColumn } from "@ourworldindata/core-table"
 import {
+    DEFAULT_GRAPHER_BOUNDS,
     GRAPHER_FONT_SCALE_10_5,
     GRAPHER_FONT_SCALE_12,
 } from "../core/GrapherConstants.js"
@@ -860,7 +860,7 @@ export class DualAxis {
     }
 
     @computed get bounds(): Bounds {
-        return this.props.bounds ?? DEFAULT_BOUNDS
+        return this.props.bounds ?? DEFAULT_GRAPHER_BOUNDS
     }
 
     @computed get comparisonLines(): ComparisonLineConfig[] {

--- a/packages/@ourworldindata/grapher/src/axis/AxisViews.tsx
+++ b/packages/@ourworldindata/grapher/src/axis/AxisViews.tsx
@@ -3,7 +3,6 @@ import { computed } from "mobx"
 import { observer } from "mobx-react"
 import {
     Bounds,
-    DEFAULT_BOUNDS,
     HorizontalAlign,
     Position,
     VerticalAlign,
@@ -16,6 +15,7 @@ import classNames from "classnames"
 import { GRAPHER_DARK_TEXT } from "../color/ColorConstants"
 import { ScaleType, DetailsMarker, AxisAlign } from "@ourworldindata/types"
 import { ComparisonLine } from "../comparisonLine/ComparisonLine"
+import { DEFAULT_GRAPHER_BOUNDS } from "../core/GrapherConstants"
 
 const TICK_COLOR = "#ddd"
 const FAINT_TICK_COLOR = "#eee"
@@ -79,7 +79,7 @@ interface HorizontalAxisGridLinesProps {
 @observer
 export class HorizontalAxisGridLines extends React.Component<HorizontalAxisGridLinesProps> {
     @computed get bounds(): Bounds {
-        return this.props.bounds ?? DEFAULT_BOUNDS
+        return this.props.bounds ?? DEFAULT_GRAPHER_BOUNDS
     }
 
     render(): React.ReactElement {

--- a/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChart.tsx
@@ -4,7 +4,6 @@ import { select } from "d3-selection"
 import {
     exposeInstanceOnWindow,
     Bounds,
-    DEFAULT_BOUNDS,
     Time,
     SortOrder,
     SortBy,
@@ -28,6 +27,7 @@ import {
 } from "@ourworldindata/types"
 import {
     BASE_FONT_SIZE,
+    DEFAULT_GRAPHER_BOUNDS,
     GRAPHER_AREA_OPACITY_DEFAULT,
     GRAPHER_FONT_SCALE_12,
 } from "../core/GrapherConstants"
@@ -156,7 +156,7 @@ export class DiscreteBarChart
     }
 
     @computed private get bounds(): Bounds {
-        return (this.props.bounds ?? DEFAULT_BOUNDS).padRight(10)
+        return (this.props.bounds ?? DEFAULT_GRAPHER_BOUNDS).padRight(10)
     }
 
     @computed private get boundsWithoutColorLegend(): Bounds {

--- a/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
@@ -4,7 +4,6 @@ import { computed } from "mobx"
 import { observer } from "mobx-react"
 import {
     Bounds,
-    DEFAULT_BOUNDS,
     exposeInstanceOnWindow,
     makeIdForHumanConsumption,
 } from "@ourworldindata/utils"
@@ -23,6 +22,7 @@ import {
     GRAPHER_FRAME_PADDING_HORIZONTAL,
     GRAPHER_CHART_AREA_CLASS,
     SVG_STYLE_PROPS,
+    DEFAULT_GRAPHER_BOUNDS,
 } from "../core/GrapherConstants"
 import { MapChartManager } from "../mapCharts/MapChartConstants"
 import { ChartManager } from "../chart/ChartManager"
@@ -175,7 +175,7 @@ abstract class AbstractCaptionedChart extends React.Component<CaptionedChartProp
         const bounds =
             this.props.bounds ??
             this.manager.captionedChartBounds ??
-            DEFAULT_BOUNDS
+            DEFAULT_GRAPHER_BOUNDS
         // the padding ensures grapher's frame is not cut off
         return bounds.padRight(2).padBottom(2)
     }
@@ -485,7 +485,11 @@ export class StaticCaptionedChart extends AbstractCaptionedChart {
     }
 
     @computed protected get bounds(): Bounds {
-        return this.props.bounds ?? this.manager.staticBounds ?? DEFAULT_BOUNDS
+        return (
+            this.props.bounds ??
+            this.manager.staticBounds ??
+            DEFAULT_GRAPHER_BOUNDS
+        )
     }
 
     @computed protected get staticFooter(): Footer {

--- a/packages/@ourworldindata/grapher/src/controls/ActionButtons.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/ActionButtons.tsx
@@ -18,8 +18,9 @@ import {
     shareUsingShareApi,
     shouldShareUsingShareApi,
 } from "./ShareMenu.js"
-import { DEFAULT_BOUNDS, Bounds } from "@ourworldindata/utils"
+import { Bounds } from "@ourworldindata/utils"
 import classNames from "classnames"
+import { DEFAULT_GRAPHER_BOUNDS } from "../core/GrapherConstants.js"
 
 export interface ActionButtonsManager extends ShareMenuManager {
     isShareMenuActive?: boolean
@@ -52,7 +53,7 @@ export class ActionButtons extends React.Component<ActionButtonsProps> {
     }
 
     @computed protected get maxWidth(): number {
-        return this.props.maxWidth ?? DEFAULT_BOUNDS.width
+        return this.props.maxWidth ?? DEFAULT_GRAPHER_BOUNDS.width
     }
 
     @computed get height(): number {

--- a/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
@@ -1,4 +1,5 @@
 import { EntityName, GRAPHER_CHART_TYPES } from "@ourworldindata/types"
+import { Bounds } from "@ourworldindata/utils"
 import { defaultGrapherConfig } from "../schema/defaultGrapherConfig.js"
 import type { GrapherProgrammaticInterface } from "./Grapher"
 
@@ -30,6 +31,20 @@ export const DEFAULT_GRAPHER_WIDTH = 850
 export const DEFAULT_GRAPHER_HEIGHT = 600
 
 export const GRAPHER_SQUARE_SIZE = 540
+
+export const DEFAULT_GRAPHER_BOUNDS = new Bounds(
+    0,
+    0,
+    DEFAULT_GRAPHER_WIDTH,
+    DEFAULT_GRAPHER_HEIGHT
+)
+
+export const DEFAULT_GRAPHER_BOUNDS_SQUARE = new Bounds(
+    0,
+    0,
+    GRAPHER_SQUARE_SIZE,
+    GRAPHER_SQUARE_SIZE
+)
 
 export const GRAPHER_FRAME_PADDING_VERTICAL = 16
 export const GRAPHER_FRAME_PADDING_HORIZONTAL = 16

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
@@ -27,7 +27,6 @@ import {
     exposeInstanceOnWindow,
     DataValue,
     Bounds,
-    DEFAULT_BOUNDS,
     TickFormattingOptions,
     Tippy,
     excludeUndefined,
@@ -36,6 +35,7 @@ import {
 } from "@ourworldindata/utils"
 import { SelectionArray } from "../selection/SelectionArray"
 import {
+    DEFAULT_GRAPHER_BOUNDS,
     DEFAULT_GRAPHER_ENTITY_TYPE,
     SVG_STYLE_PROPS,
 } from "../core/GrapherConstants"
@@ -602,7 +602,7 @@ export class DataTable extends React.Component<DataTableProps> {
     }
 
     @computed get bounds(): Bounds {
-        return this.props.bounds ?? DEFAULT_BOUNDS
+        return this.props.bounds ?? DEFAULT_GRAPHER_BOUNDS
     }
 
     @computed private get tableCaption(): React.ReactElement | null {

--- a/packages/@ourworldindata/grapher/src/facetChart/FacetChart.tsx
+++ b/packages/@ourworldindata/grapher/src/facetChart/FacetChart.tsx
@@ -4,7 +4,6 @@ import * as R from "remeda"
 import { observer } from "mobx-react"
 import {
     Bounds,
-    DEFAULT_BOUNDS,
     excludeUndefined,
     getIdealGridParams,
     IDEAL_PLOT_ASPECT_RATIO,
@@ -17,7 +16,10 @@ import {
 } from "@ourworldindata/utils"
 import { shortenForTargetWidth } from "@ourworldindata/components"
 import { action, computed, observable } from "mobx"
-import { BASE_FONT_SIZE } from "../core/GrapherConstants"
+import {
+    BASE_FONT_SIZE,
+    DEFAULT_GRAPHER_BOUNDS,
+} from "../core/GrapherConstants"
 import {
     GRAPHER_CHART_TYPES,
     GrapherChartType,
@@ -148,7 +150,7 @@ export class FacetChart
     }
 
     @computed private get bounds(): Bounds {
-        return this.props.bounds ?? DEFAULT_BOUNDS
+        return this.props.bounds ?? DEFAULT_GRAPHER_BOUNDS
     }
 
     @computed private get legendPadding(): number {

--- a/packages/@ourworldindata/grapher/src/footer/Footer.tsx
+++ b/packages/@ourworldindata/grapher/src/footer/Footer.tsx
@@ -4,7 +4,6 @@ import { observer } from "mobx-react"
 import parseUrl from "url-parse"
 import {
     Bounds,
-    DEFAULT_BOUNDS,
     getRelativeMouse,
     makeIdForHumanConsumption,
 } from "@ourworldindata/utils"
@@ -18,6 +17,7 @@ import { FooterManager } from "./FooterManager"
 import { ActionButtons } from "../controls/ActionButtons"
 import {
     BASE_FONT_SIZE,
+    DEFAULT_GRAPHER_BOUNDS,
     GRAPHER_FOOTER_CLASS,
     GRAPHER_FRAME_PADDING_HORIZONTAL,
 } from "../core/GrapherConstants"
@@ -79,7 +79,7 @@ abstract class AbstractFooter<
     }
 
     @computed protected get maxWidth(): number {
-        return this.props.maxWidth ?? DEFAULT_BOUNDS.width
+        return this.props.maxWidth ?? DEFAULT_GRAPHER_BOUNDS.width
     }
 
     @computed protected get useBaseFontSize(): boolean {

--- a/packages/@ourworldindata/grapher/src/header/Header.tsx
+++ b/packages/@ourworldindata/grapher/src/header/Header.tsx
@@ -1,7 +1,6 @@
 import * as _ from "lodash-es"
 import * as React from "react"
 import {
-    DEFAULT_BOUNDS,
     LogoOption,
     makeIdForHumanConsumption,
     Bounds,
@@ -14,6 +13,7 @@ import { Logo } from "../captionedChart/Logos"
 import { HeaderManager } from "./HeaderManager"
 import {
     BASE_FONT_SIZE,
+    DEFAULT_GRAPHER_BOUNDS,
     GRAPHER_FRAME_PADDING_HORIZONTAL,
     GRAPHER_FRAME_PADDING_VERTICAL,
     GRAPHER_HEADER_CLASS,
@@ -35,7 +35,7 @@ abstract class AbstractHeader<
     }
 
     @computed protected get maxWidth(): number {
-        return this.props.maxWidth ?? DEFAULT_BOUNDS.width
+        return this.props.maxWidth ?? DEFAULT_GRAPHER_BOUNDS.width
     }
 
     @computed protected get useBaseFontSize(): boolean {

--- a/packages/@ourworldindata/grapher/src/index.ts
+++ b/packages/@ourworldindata/grapher/src/index.ts
@@ -35,6 +35,8 @@ export {
     CONTINENTS_INDICATOR_ID,
     POPULATION_INDICATOR_ID_USED_IN_ADMIN,
     latestGrapherConfigSchema,
+    DEFAULT_GRAPHER_BOUNDS,
+    DEFAULT_GRAPHER_BOUNDS_SQUARE,
 } from "./core/GrapherConstants"
 export {
     getVariableDataRoute,

--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
@@ -10,7 +10,6 @@ import {
     excludeUndefined,
     isMobile,
     Bounds,
-    DEFAULT_BOUNDS,
     PointVector,
     AxisAlign,
     Color,
@@ -47,7 +46,11 @@ import {
     VerticalAlign,
     InteractionState,
 } from "@ourworldindata/types"
-import { BASE_FONT_SIZE, GRAPHER_OPACITY_MUTE } from "../core/GrapherConstants"
+import {
+    BASE_FONT_SIZE,
+    DEFAULT_GRAPHER_BOUNDS,
+    GRAPHER_OPACITY_MUTE,
+} from "../core/GrapherConstants"
 import { ColorSchemes } from "../color/ColorSchemes"
 import { AxisConfig, AxisManager } from "../axis/AxisConfig"
 import { ChartInterface } from "../chart/ChartInterface"
@@ -516,7 +519,7 @@ export class LineChart
     }
 
     @computed get bounds(): Bounds {
-        return this.props.bounds ?? DEFAULT_BOUNDS
+        return this.props.bounds ?? DEFAULT_GRAPHER_BOUNDS
     }
 
     @computed private get boundsWithoutColorLegend(): Bounds {

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
@@ -1,7 +1,6 @@
 import * as R from "remeda"
 import {
     Bounds,
-    DEFAULT_BOUNDS,
     getRelativeMouse,
     guid,
     exposeInstanceOnWindow,
@@ -49,6 +48,7 @@ import {
 } from "../color/ColorScale"
 import {
     BASE_FONT_SIZE,
+    DEFAULT_GRAPHER_BOUNDS,
     GRAPHER_FRAME_PADDING_HORIZONTAL,
     GRAPHER_MAX_TOOLTIP_WIDTH,
     Patterns,
@@ -330,7 +330,7 @@ export class MapChart
     }
 
     @computed get bounds(): Bounds {
-        return this.props.bounds ?? DEFAULT_BOUNDS
+        return this.props.bounds ?? DEFAULT_GRAPHER_BOUNDS
     }
 
     @computed get choroplethData(): ChoroplethSeriesByName {

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
@@ -5,7 +5,6 @@ import { observable, computed, action } from "mobx"
 import { observer } from "mobx-react"
 import {
     Bounds,
-    DEFAULT_BOUNDS,
     getOriginAttributionFragments,
     getPhraseForProcessingLevel,
     triggerDownloadFromBlob,
@@ -24,12 +23,7 @@ import {
     faDownload,
     faInfoCircle,
 } from "@fortawesome/free-solid-svg-icons"
-import {
-    OwidColumnDef,
-    GrapherStaticFormat,
-    OwidOrigin,
-    QueryParams,
-} from "@ourworldindata/types"
+import { OwidColumnDef, OwidOrigin, QueryParams } from "@ourworldindata/types"
 import {
     BlankOwidTable,
     OwidTable,
@@ -45,13 +39,16 @@ import {
 import { match } from "ts-pattern"
 import * as R from "remeda"
 import { GrapherImageDownloadEvent } from "../core/GrapherAnalytics"
+import {
+    DEFAULT_GRAPHER_BOUNDS,
+    DEFAULT_GRAPHER_BOUNDS_SQUARE,
+} from "../core/GrapherConstants"
 
 export interface DownloadModalManager {
     displaySlug: string
     rasterize: (bounds?: Bounds) => Promise<GrapherExport>
     staticBounds?: Bounds
     staticBoundsWithDetails?: Bounds
-    staticFormat?: GrapherStaticFormat
     baseUrl?: string
     queryStr?: string
     externalQueryParams?: QueryParams
@@ -85,7 +82,7 @@ interface DownloadModalProps {
 export const DownloadModal = (
     props: DownloadModalProps
 ): React.ReactElement => {
-    const frameBounds = props.manager.frameBounds ?? DEFAULT_BOUNDS
+    const frameBounds = props.manager.frameBounds ?? DEFAULT_GRAPHER_BOUNDS
 
     const modalBounds = useMemo(() => {
         const maxWidth = 640
@@ -168,15 +165,18 @@ export const DownloadModal = (
 @observer
 export class DownloadModalVisTab extends React.Component<DownloadModalProps> {
     @computed private get staticBounds(): Bounds {
-        return this.manager.staticBounds ?? DEFAULT_BOUNDS
+        return this.manager.staticBounds ?? DEFAULT_GRAPHER_BOUNDS
     }
 
     @computed private get captionedChartBounds(): Bounds {
-        return this.manager.captionedChartBounds ?? DEFAULT_BOUNDS
+        return this.manager.captionedChartBounds ?? DEFAULT_GRAPHER_BOUNDS
     }
 
     @computed private get isExportingSquare(): boolean {
-        return this.manager.staticFormat === GrapherStaticFormat.square
+        return (
+            this.manager.staticBounds?.width ===
+            this.manager.staticBounds?.height
+        )
     }
 
     @computed private get isSocialMediaExport(): boolean {
@@ -266,9 +266,9 @@ export class DownloadModalVisTab extends React.Component<DownloadModalProps> {
     }
 
     @action.bound private toggleExportFormat(): void {
-        this.manager.staticFormat = this.isExportingSquare
-            ? GrapherStaticFormat.landscape
-            : GrapherStaticFormat.square
+        this.manager.staticBounds = this.isExportingSquare
+            ? DEFAULT_GRAPHER_BOUNDS
+            : DEFAULT_GRAPHER_BOUNDS_SQUARE
     }
 
     @action.bound private toggleExportForUseInSocialMedia(): void {
@@ -435,8 +435,8 @@ export class DownloadModalVisTab extends React.Component<DownloadModalProps> {
 
                                             // set reasonable defaults for social media exports
                                             if (this.isSocialMediaExport) {
-                                                this.manager.staticFormat =
-                                                    GrapherStaticFormat.square
+                                                this.manager.staticBounds =
+                                                    DEFAULT_GRAPHER_BOUNDS_SQUARE
                                                 this.manager.shouldIncludeDetailsInStaticExport = false
                                             }
 

--- a/packages/@ourworldindata/grapher/src/modal/EmbedModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/EmbedModal.tsx
@@ -1,13 +1,14 @@
 import { observer } from "mobx-react"
 import * as React from "react"
 import { computed, action } from "mobx"
-import { Bounds, DEFAULT_BOUNDS, Url } from "@ourworldindata/utils"
+import { Bounds, Url } from "@ourworldindata/utils"
 import { Modal } from "./Modal"
 import {
     Checkbox,
     CodeSnippet,
     OverlayHeader,
 } from "@ourworldindata/components"
+import { DEFAULT_GRAPHER_BOUNDS } from "../core/GrapherConstants"
 
 export interface EmbedModalManager {
     embedUrl?: string
@@ -36,7 +37,7 @@ export class EmbedModal extends React.Component<EmbedModalProps> {
     }
 
     @computed private get frameBounds(): Bounds {
-        return this.manager.frameBounds ?? DEFAULT_BOUNDS
+        return this.manager.frameBounds ?? DEFAULT_GRAPHER_BOUNDS
     }
 
     @computed private get modalBounds(): Bounds {

--- a/packages/@ourworldindata/grapher/src/modal/EntitySelectorModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/EntitySelectorModal.tsx
@@ -1,12 +1,13 @@
 import * as React from "react"
 import { observer } from "mobx-react"
 import { computed, action } from "mobx"
-import { Bounds, DEFAULT_BOUNDS } from "@ourworldindata/utils"
+import { Bounds } from "@ourworldindata/utils"
 import { Modal } from "./Modal"
 import {
     EntitySelector,
     EntitySelectorManager,
 } from "../entitySelector/EntitySelector"
+import { DEFAULT_GRAPHER_BOUNDS } from "../core/GrapherConstants"
 
 export interface EntitySelectorModalManager extends EntitySelectorManager {
     isEntitySelectorModalOrDrawerOpen?: boolean
@@ -22,7 +23,7 @@ export class EntitySelectorModal extends React.Component<{
     }
 
     @computed private get frameBounds(): Bounds {
-        return this.manager.frameBounds ?? DEFAULT_BOUNDS
+        return this.manager.frameBounds ?? DEFAULT_GRAPHER_BOUNDS
     }
 
     @computed private get modalBounds(): Bounds {

--- a/packages/@ourworldindata/grapher/src/modal/SourcesModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/SourcesModal.tsx
@@ -1,7 +1,6 @@
 import * as _ from "lodash-es"
 import {
     Bounds,
-    DEFAULT_BOUNDS,
     getAttributionFragmentsFromVariable,
     getLastUpdatedFromVariable,
     getNextUpdateFromVariable,
@@ -37,7 +36,10 @@ import { SourcesDescriptions } from "./SourcesDescriptions"
 import { TabLabel, Tabs } from "../tabs/Tabs"
 import { ExpandableTabs } from "../tabs/ExpandableTabs"
 import { LoadingIndicator } from "../loadingIndicator/LoadingIndicator"
-import { isContinentsVariableId } from "../core/GrapherConstants"
+import {
+    DEFAULT_GRAPHER_BOUNDS,
+    isContinentsVariableId,
+} from "../core/GrapherConstants"
 import * as R from "remeda"
 
 // keep in sync with variables in SourcesModal.scss
@@ -84,7 +86,7 @@ export class SourcesModal extends React.Component<
     }
 
     @computed private get frameBounds(): Bounds {
-        return this.manager.frameBounds ?? DEFAULT_BOUNDS
+        return this.manager.frameBounds ?? DEFAULT_GRAPHER_BOUNDS
     }
 
     @computed private get modalBounds(): Bounds {

--- a/packages/@ourworldindata/grapher/src/noDataModal/NoDataModal.tsx
+++ b/packages/@ourworldindata/grapher/src/noDataModal/NoDataModal.tsx
@@ -2,14 +2,10 @@ import * as React from "react"
 import { computed } from "mobx"
 import { observer } from "mobx-react"
 import a from "indefinite"
-import {
-    Bounds,
-    DEFAULT_BOUNDS,
-    VerticalAlign,
-    dyFromAlign,
-} from "@ourworldindata/utils"
+import { Bounds, VerticalAlign, dyFromAlign } from "@ourworldindata/utils"
 import {
     BASE_FONT_SIZE,
+    DEFAULT_GRAPHER_BOUNDS,
     DEFAULT_GRAPHER_ENTITY_TYPE,
     DEFAULT_GRAPHER_ENTITY_TYPE_PLURAL,
     GRAPHER_TEXT_OUTLINE_FACTOR,
@@ -37,7 +33,7 @@ interface NoDataModalProps {
 @observer
 export class NoDataModal extends React.Component<NoDataModalProps> {
     @computed private get bounds(): Bounds {
-        return this.props.bounds ?? DEFAULT_BOUNDS
+        return this.props.bounds ?? DEFAULT_GRAPHER_BOUNDS
     }
 
     @computed private get manager(): NoDataModalManager {

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
@@ -28,13 +28,15 @@ import {
     exposeInstanceOnWindow,
     PointVector,
     Bounds,
-    DEFAULT_BOUNDS,
     isTouchDevice,
     makeIdForHumanConsumption,
 } from "@ourworldindata/utils"
 import { observer } from "mobx-react"
 import { NoDataModal } from "../noDataModal/NoDataModal"
-import { BASE_FONT_SIZE } from "../core/GrapherConstants"
+import {
+    BASE_FONT_SIZE,
+    DEFAULT_GRAPHER_BOUNDS,
+} from "../core/GrapherConstants"
 import {
     OwidTable,
     defaultIfErrorValue,
@@ -284,7 +286,7 @@ export class ScatterPlotChart
     }
 
     @computed.struct private get bounds(): Bounds {
-        return this.props.bounds ?? DEFAULT_BOUNDS
+        return this.props.bounds ?? DEFAULT_GRAPHER_BOUNDS
     }
 
     @computed private get innerBounds(): Bounds {

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
@@ -2,7 +2,6 @@ import * as _ from "lodash-es"
 import React from "react"
 import {
     Bounds,
-    DEFAULT_BOUNDS,
     domainExtent,
     exposeInstanceOnWindow,
     PointVector,
@@ -18,6 +17,7 @@ import { observer } from "mobx-react"
 import { NoDataModal } from "../noDataModal/NoDataModal"
 import {
     BASE_FONT_SIZE,
+    DEFAULT_GRAPHER_BOUNDS,
     GRAPHER_FONT_SCALE_12,
     GRAPHER_OPACITY_MUTE,
     GRAPHER_TEXT_OUTLINE_FACTOR,
@@ -203,7 +203,7 @@ export class SlopeChart
     }
 
     @computed private get bounds(): Bounds {
-        return this.props.bounds ?? DEFAULT_BOUNDS
+        return this.props.bounds ?? DEFAULT_GRAPHER_BOUNDS
     }
 
     @computed private get innerBounds(): Bounds {

--- a/packages/@ourworldindata/grapher/src/stackedCharts/AbstractStackedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/AbstractStackedChart.tsx
@@ -9,11 +9,14 @@ import {
     MissingDataStrategy,
     SeriesStrategy,
 } from "@ourworldindata/types"
-import { BASE_FONT_SIZE, WORLD_ENTITY_NAME } from "../core/GrapherConstants"
+import {
+    BASE_FONT_SIZE,
+    DEFAULT_GRAPHER_BOUNDS,
+    WORLD_ENTITY_NAME,
+} from "../core/GrapherConstants"
 import {
     Bounds,
     checkHasMembers,
-    DEFAULT_BOUNDS,
     excludeUndefined,
     exposeInstanceOnWindow,
     getCountryNamesForRegion,
@@ -144,7 +147,7 @@ export abstract class AbstractStackedChart
     }
 
     @computed get bounds(): Bounds {
-        return this.props.bounds ?? DEFAULT_BOUNDS
+        return this.props.bounds ?? DEFAULT_GRAPHER_BOUNDS
     }
 
     @computed get isStatic(): boolean {

--- a/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChart.tsx
@@ -3,7 +3,6 @@ import React from "react"
 import * as R from "remeda"
 import {
     Bounds,
-    DEFAULT_BOUNDS,
     excludeUndefined,
     HorizontalAlign,
     Position,
@@ -20,6 +19,7 @@ import { action, computed, observable } from "mobx"
 import { observer } from "mobx-react"
 import {
     BASE_FONT_SIZE,
+    DEFAULT_GRAPHER_BOUNDS,
     GRAPHER_FONT_SCALE_12,
     Patterns,
 } from "../core/GrapherConstants"
@@ -487,7 +487,7 @@ export class MarimekkoChart
     }
 
     @computed private get bounds(): Bounds {
-        return (this.props.bounds ?? DEFAULT_BOUNDS).padRight(10)
+        return (this.props.bounds ?? DEFAULT_GRAPHER_BOUNDS).padRight(10)
     }
 
     @computed private get innerBounds(): Bounds {

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBarChart.tsx
@@ -3,7 +3,6 @@ import React from "react"
 import * as R from "remeda"
 import {
     Bounds,
-    DEFAULT_BOUNDS,
     excludeUndefined,
     numberMagnitude,
     Color,
@@ -30,6 +29,7 @@ import {
 } from "@ourworldindata/types"
 import {
     BASE_FONT_SIZE,
+    DEFAULT_GRAPHER_BOUNDS,
     GRAPHER_AREA_OPACITY_DEFAULT,
     GRAPHER_FONT_SCALE_12,
 } from "../core/GrapherConstants"
@@ -213,7 +213,9 @@ export class StackedDiscreteBarChart
 
     @computed private get bounds(): Bounds {
         // bottom padding avoids axis labels to be cut off at some resolutions
-        return (this.props.bounds ?? DEFAULT_BOUNDS).padRight(10).padBottom(2)
+        return (this.props.bounds ?? DEFAULT_GRAPHER_BOUNDS)
+            .padRight(10)
+            .padBottom(2)
     }
 
     @computed private get baseFontSize(): number {

--- a/packages/@ourworldindata/grapher/src/timeline/TimelineComponent.tsx
+++ b/packages/@ourworldindata/grapher/src/timeline/TimelineComponent.tsx
@@ -2,12 +2,7 @@ import * as _ from "lodash-es"
 import * as React from "react"
 import { select } from "d3-selection"
 import cx from "classnames"
-import {
-    getRelativeMouse,
-    isMobile,
-    Bounds,
-    DEFAULT_BOUNDS,
-} from "@ourworldindata/utils"
+import { getRelativeMouse, isMobile, Bounds } from "@ourworldindata/utils"
 import { observable, computed, action } from "mobx"
 import { observer } from "mobx-react"
 import { faPlay, faPause } from "@fortawesome/free-solid-svg-icons"
@@ -18,6 +13,7 @@ import {
 } from "./TimelineController"
 import { ActionButton } from "../controls/ActionButtons"
 import {
+    DEFAULT_GRAPHER_BOUNDS,
     GRAPHER_FRAME_PADDING_HORIZONTAL,
     GRAPHER_TIMELINE_CLASS,
 } from "../core/GrapherConstants.js"
@@ -36,7 +32,7 @@ export class TimelineComponent extends React.Component<TimelineComponentProps> {
     base: React.RefObject<HTMLDivElement> = React.createRef()
 
     @computed protected get maxWidth(): number {
-        return this.props.maxWidth ?? DEFAULT_BOUNDS.width
+        return this.props.maxWidth ?? DEFAULT_GRAPHER_BOUNDS.width
     }
 
     @computed private get dragTarget(): TimelineDragTarget | undefined {

--- a/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
+++ b/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
@@ -773,11 +773,6 @@ export const grapherKeysToSerialize = [
     "bakedGrapherURL",
 ]
 
-export enum GrapherStaticFormat {
-    landscape = "landscape",
-    square = "square",
-}
-
 export interface ChartRedirect {
     id: number
     slug: string

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -127,7 +127,6 @@ export {
     type SeriesName,
     type LegacyGrapherQueryParams,
     GRAPHER_QUERY_PARAM_KEYS,
-    GrapherStaticFormat,
     type ChartRedirect,
     type DetailsMarker,
     GrapherWindowType,

--- a/packages/@ourworldindata/utils/src/Bounds.ts
+++ b/packages/@ourworldindata/utils/src/Bounds.ts
@@ -437,7 +437,3 @@ interface SplitBoundsPadding {
     rowPadding?: number
     outerPadding?: number
 }
-
-// Since nearly all our components need a bounds, but most tests don't care about bounds, have a default bounds
-// to use so we don't have to create a bounds for every test.
-export const DEFAULT_BOUNDS = new Bounds(0, 0, 640, 480)

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -220,12 +220,7 @@ export {
 
 export { getStylesForTargetHeight } from "./react-select.js"
 
-export {
-    type GridBounds,
-    FontFamily,
-    Bounds,
-    DEFAULT_BOUNDS,
-} from "./Bounds.js"
+export { type GridBounds, FontFamily, Bounds } from "./Bounds.js"
 
 export {
     type Persistable,

--- a/site/hooks.ts
+++ b/site/hooks.ts
@@ -2,11 +2,8 @@ import * as _ from "lodash-es"
 import { useEffect, RefObject, useState, useCallback, useMemo } from "react"
 import { useSyncExternalStore } from "use-sync-external-store/shim"
 import { MultiEmbedderSingleton } from "./multiembedder/MultiEmbedder.js"
-import {
-    Bounds,
-    DEFAULT_BOUNDS,
-    getWindowQueryStr,
-} from "@ourworldindata/utils"
+import { Bounds, getWindowQueryStr } from "@ourworldindata/utils"
+import { DEFAULT_GRAPHER_BOUNDS } from "@ourworldindata/grapher"
 import { useResizeObserver } from "usehooks-ts"
 import { reaction } from "mobx"
 
@@ -97,7 +94,7 @@ export const useTriggerOnEscape = (trigger: VoidFunction) => {
 // Optionally throttles the bounds updates
 export const useElementBounds = (
     ref: RefObject<HTMLElement>,
-    initialValue: Bounds = DEFAULT_BOUNDS,
+    initialValue: Bounds = DEFAULT_GRAPHER_BOUNDS,
     throttleTime: number | undefined = 100
 ) => {
     const [bounds, setBounds] = useState<Bounds>(initialValue)


### PR DESCRIPTION
Drops `staticFormat` (which could be either ‘landscape’ or ‘square’) in favour of using `staticBounds` directly. Felt like unnecessary complexity and I likely need a bit more flexibility for thumbnails.

Most of the diff comes from moving `DEFAULT_BOUNDS` to the Grapher package and renaming it to `GRAPHER_DEFAULT_BOUNDS`

The default bounds used to be 640px wide and 480px tall (this was defined in the Bounds file as testing utility). Now, the default width is 850px and the default height is 600px (as defined in Grapher). I think that should be ok.