### PR TITLE
🔨 thumbnail rendering

### DIFF
--- a/functions/_common/imageOptions.ts
+++ b/functions/_common/imageOptions.ts
@@ -4,6 +4,8 @@ import {
     GRAPHER_SQUARE_SIZE,
     DEFAULT_GRAPHER_BOUNDS_SQUARE,
 } from "@ourworldindata/grapher"
+import { Bounds } from "@ourworldindata/utils"
+import { GrapherRenderMode } from "@ourworldindata/types"
 import {
     DEFAULT_ASPECT_RATIO,
     MIN_ASPECT_RATIO,
@@ -53,12 +55,26 @@ const SQUARE_OPTIONS: Readonly<ImageOptions> = {
         staticBounds: DEFAULT_GRAPHER_BOUNDS_SQUARE,
     },
 }
+const THUMBNAIL_OPTIONS: Readonly<ImageOptions> = {
+    pngWidth: 900,
+    pngHeight: 480,
+    svgWidth: 900,
+    svgHeight: 480,
+    details: false,
+    fontSize: undefined,
+    grapherProps: {
+        isSocialMediaExport: false,
+        staticBounds: new Bounds(0, 0, 900, 480),
+        renderMode: GrapherRenderMode.Thumbnail,
+    },
+}
 
 export const extractOptions = (params: URLSearchParams): ImageOptions => {
     const imType = params.get("imType")
     // We have some special images types specified via the `imType` query param:
     if (imType === "twitter") return TWITTER_OPTIONS
     else if (imType === "og") return OPEN_GRAPH_OPTIONS
+    else if (imType === "thumbnail") return THUMBNAIL_OPTIONS
     else if (imType === "square" || imType === "social-media-square") {
         const squareOptions = _.cloneDeep(SQUARE_OPTIONS) as ImageOptions
         if (imType === "social-media-square") {

--- a/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
@@ -53,7 +53,6 @@ export interface CaptionedChartManager
         HeaderManager,
         DataTableManager,
         ControlsRowManager {
-    containerElement?: HTMLDivElement
     bakedGrapherURL?: string
     isReady?: boolean
     whatAreWeWaitingFor?: string

--- a/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
@@ -11,23 +11,14 @@ import { MarkdownTextWrap } from "@ourworldindata/components"
 import { Header, StaticHeader } from "../header/Header"
 import { Footer, StaticFooter } from "../footer/Footer"
 import {
-    ChartComponentClassMap,
-    DefaultChartClass,
-} from "../chart/ChartTypeMap"
-import {
-    BASE_FONT_SIZE,
-    Patterns,
     STATIC_EXPORT_DETAIL_SPACING,
     GRAPHER_FRAME_PADDING_VERTICAL,
     GRAPHER_FRAME_PADDING_HORIZONTAL,
-    GRAPHER_CHART_AREA_CLASS,
-    SVG_STYLE_PROPS,
     DEFAULT_GRAPHER_BOUNDS,
 } from "../core/GrapherConstants"
 import { MapChartManager } from "../mapCharts/MapChartConstants"
 import { ChartManager } from "../chart/ChartManager"
 import { LoadingIndicator } from "../loadingIndicator/LoadingIndicator"
-import { FacetChart } from "../facetChart/FacetChart"
 import { faExternalLinkAlt } from "@fortawesome/free-solid-svg-icons"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
 import { FooterManager } from "../footer/FooterManager"
@@ -35,15 +26,11 @@ import { HeaderManager } from "../header/HeaderManager"
 import { SelectionArray } from "../selection/SelectionArray"
 import {
     EntityName,
-    GRAPHER_CHART_TYPES,
     RelatedQuestionsConfig,
     Color,
     GrapherTabName,
-    GRAPHER_MAP_TYPE,
-    GrapherChartOrMapType,
     GrapherChartType,
 } from "@ourworldindata/types"
-import { DataTable } from "../dataTable/DataTable"
 import { DataTableManager } from "../dataTable/DataTableConstants"
 import {
     TimelineComponent,
@@ -54,7 +41,10 @@ import {
     ControlsRow,
     ControlsRowManager,
 } from "../controls/controlsRow/ControlsRow"
-import { GRAPHER_BACKGROUND_DEFAULT } from "../color/ColorConstants"
+import { GRAPHER_BACKGROUND_DEFAULT } from "../color/ColorConstants.js"
+import { ChartAreaContent } from "../chart/ChartAreaContent"
+import { getChartSvgProps } from "../chart/ChartUtils"
+import { StaticChartWrapper } from "../chart/StaticChartWrapper"
 
 export interface CaptionedChartManager
     extends ChartManager,
@@ -120,10 +110,6 @@ abstract class AbstractCaptionedChart extends React.Component<CaptionedChartProp
         return this.props.manager
     }
 
-    @computed private get containerElement(): HTMLDivElement | undefined {
-        return this.manager?.containerElement
-    }
-
     @computed protected get maxWidth(): number {
         return (
             this.props.maxWidth ??
@@ -154,23 +140,6 @@ abstract class AbstractCaptionedChart extends React.Component<CaptionedChartProp
         })
     }
 
-    protected get patterns(): React.ReactElement {
-        return (
-            <defs>
-                <pattern
-                    id={Patterns.noDataPattern}
-                    key={Patterns.noDataPattern}
-                    patternUnits="userSpaceOnUse"
-                    width="4"
-                    height="4"
-                    patternTransform="rotate(-45 2 2)"
-                >
-                    <path d="M -1,2 l 6,0" stroke="#ccc" strokeWidth="0.7" />
-                </pattern>
-            </defs>
-        )
-    }
-
     @computed protected get bounds(): Bounds {
         const bounds =
             this.props.bounds ??
@@ -182,59 +151,7 @@ abstract class AbstractCaptionedChart extends React.Component<CaptionedChartProp
 
     @computed protected get boundsForChartArea(): Bounds {
         const { bounds, chartHeight } = this
-        return new Bounds(0, 0, bounds.width, chartHeight).padWidth(
-            this.framePaddingHorizontal
-        )
-    }
-
-    @computed get activeChartOrMapType(): GrapherChartOrMapType | undefined {
-        const { manager } = this
-        if (manager.isOnTableTab) return undefined
-        if (manager.isOnMapTab) return GRAPHER_MAP_TYPE
-        if (manager.isOnChartTab) {
-            return manager.isLineChartThatTurnedIntoDiscreteBarActive
-                ? GRAPHER_CHART_TYPES.DiscreteBar
-                : manager.activeChartType
-        }
-        return undefined
-    }
-
-    renderChart(): React.ReactElement | void {
-        const {
-            manager,
-            boundsForChartArea: bounds,
-            activeChartOrMapType,
-            containerElement,
-        } = this
-        const { isFaceted } = manager
-
-        if (!activeChartOrMapType) return
-
-        // Todo: make FacetChart a chart type name?
-        const activeChartType =
-            activeChartOrMapType !== GRAPHER_MAP_TYPE
-                ? activeChartOrMapType
-                : undefined
-        if (isFaceted && activeChartType)
-            return (
-                <FacetChart
-                    bounds={bounds}
-                    chartTypeName={activeChartType}
-                    manager={manager}
-                />
-            )
-
-        const ChartClass =
-            ChartComponentClassMap.get(activeChartOrMapType) ??
-            DefaultChartClass
-
-        return (
-            <ChartClass
-                bounds={bounds}
-                manager={manager}
-                containerElement={containerElement}
-            />
-        )
+        return new Bounds(0, 0, bounds.width, chartHeight)
     }
 
     componentDidMount(): void {
@@ -299,60 +216,11 @@ abstract class AbstractCaptionedChart extends React.Component<CaptionedChartProp
         )
     }
 
-    private renderLoadingIndicator(): React.ReactElement {
+    private renderLoadingIndicatorIntoSvg(): React.ReactElement {
         return (
             <foreignObject {...this.boundsForChartArea.toProps()}>
                 <LoadingIndicator title={this.manager.whatAreWeWaitingFor} />
             </foreignObject>
-        )
-    }
-
-    private renderDataTable(): React.ReactElement {
-        const { boundsForChartArea } = this
-        const containerStyle: React.CSSProperties = {
-            position: "relative",
-            ...this.boundsForChartArea.toCSS(),
-        }
-        return (
-            <div className="DataTableContainer" style={containerStyle}>
-                {this.manager.isReady ? (
-                    <DataTable
-                        bounds={boundsForChartArea}
-                        manager={this.manager}
-                    />
-                ) : (
-                    <LoadingIndicator
-                        title={this.manager.whatAreWeWaitingFor}
-                    />
-                )}
-            </div>
-        )
-    }
-
-    private renderChartOrMap(): React.ReactElement {
-        const { bounds, chartHeight } = this
-        const { width } = bounds
-
-        const containerStyle: React.CSSProperties = {
-            position: "relative",
-            clear: "both",
-            height: chartHeight,
-        }
-
-        return (
-            <div style={containerStyle}>
-                <svg
-                    {...this.svgProps}
-                    width={width}
-                    height={chartHeight}
-                    viewBox={`0 0 ${width} ${chartHeight}`}
-                >
-                    {this.patterns}
-                    {this.manager.isReady
-                        ? this.renderChart()
-                        : this.renderLoadingIndicator()}
-                </svg>
-            </div>
         )
     }
 
@@ -429,9 +297,11 @@ abstract class AbstractCaptionedChart extends React.Component<CaptionedChartProp
                         )}
 
                         {/* #3 Chart/Map/Table */}
-                        {this.manager.isOnTableTab
-                            ? this.renderDataTable()
-                            : this.renderChartOrMap()}
+                        <ChartAreaContent
+                            manager={this.manager}
+                            bounds={this.boundsForChartArea}
+                            padWidth={GRAPHER_FRAME_PADDING_HORIZONTAL}
+                        />
 
                         {/* #4 [Timeline] */}
                         {this.manager.hasTimeline && (
@@ -451,7 +321,7 @@ abstract class AbstractCaptionedChart extends React.Component<CaptionedChartProp
                             this.renderRelatedQuestion()}
                     </>
                 ) : (
-                    this.renderLoadingIndicator()
+                    this.renderLoadingIndicatorIntoSvg()
                 )}
             </div>
         )
@@ -462,16 +332,7 @@ abstract class AbstractCaptionedChart extends React.Component<CaptionedChartProp
     }
 
     @computed protected get svgProps(): React.SVGProps<SVGSVGElement> {
-        return {
-            xmlns: "http://www.w3.org/2000/svg",
-            version: "1.1",
-            style: {
-                ...SVG_STYLE_PROPS,
-                fontSize: this.manager.fontSize ?? BASE_FONT_SIZE,
-                // needs to be set here or else pngs will have a black background
-                backgroundColor: this.backgroundColor,
-            },
-        }
+        return getChartSvgProps(this.manager)
     }
 }
 
@@ -484,6 +345,28 @@ export class StaticCaptionedChart extends AbstractCaptionedChart {
         super(props)
     }
 
+    // Bounds diagram
+    //
+    // +---------------------------+   |  |
+    // |  Padding                  |   |  |
+    // |  +--------------------+   |   |  |  |
+    // |  | Header             |   |   |  |  |
+    // |  |                    |   |   |  |  |
+    // |  | Chart area         |   |   |  |  |
+    // |  |                    |   |   |  |  |
+    // |  | Footer             |   |   |  |  | innerBounds
+    // |  +--------------------+   |   |  |
+    // |  Padding                  |   |  |
+    // +---------------------------+   |  | bounds
+    // | Details                   |   |
+    // +---------------------------+   | svgBounds
+
+    /** Bounds of the SVG element including details */
+    @computed private get svgBounds(): Bounds {
+        return this.manager.staticBoundsWithDetails ?? this.bounds
+    }
+
+    /** Bounds without details */
     @computed protected get bounds(): Bounds {
         return (
             this.props.bounds ??
@@ -492,37 +375,37 @@ export class StaticCaptionedChart extends AbstractCaptionedChart {
         )
     }
 
-    @computed protected get staticFooter(): Footer {
-        const { paddedBounds } = this
-        return new StaticFooter({
-            manager: this.manager,
-            maxWidth: this.maxWidth,
-            targetX: paddedBounds.x,
-            targetY: paddedBounds.bottom - this.footer.height,
-        })
-    }
-
-    @computed protected get staticHeader(): Header {
-        const { paddedBounds } = this
-        return new StaticHeader({
-            manager: this.manager,
-            maxWidth: this.maxWidth,
-            targetX: paddedBounds.x,
-            targetY: paddedBounds.y,
-        })
-    }
-
-    @computed private get paddedBounds(): Bounds {
+    /** Padded bounds of the actual chart area (without whitespace around it) */
+    @computed private get innerBounds(): Bounds {
         return this.bounds
             .padWidth(this.framePaddingHorizontal)
             .padHeight(this.framePaddingVertical)
     }
 
+    /** Bounds of the chart area (without header and footer) */
     @computed protected get boundsForChartArea(): Bounds {
-        return this.paddedBounds
+        return this.innerBounds
             .padTop(this.staticHeader.height)
             .padBottom(this.staticFooter.height + this.verticalPadding)
             .padTop(this.manager.isOnMapTab ? 0 : this.verticalPadding)
+    }
+
+    @computed protected get staticFooter(): Footer {
+        return new StaticFooter({
+            manager: this.manager,
+            maxWidth: this.maxWidth,
+            targetX: this.innerBounds.x,
+            targetY: this.innerBounds.bottom - this.footer.height,
+        })
+    }
+
+    @computed protected get staticHeader(): Header {
+        return new StaticHeader({
+            manager: this.manager,
+            maxWidth: this.maxWidth,
+            targetX: this.innerBounds.x,
+            targetY: this.innerBounds.y,
+        })
     }
 
     renderSVGDetails(): React.ReactElement {
@@ -562,77 +445,33 @@ export class StaticCaptionedChart extends AbstractCaptionedChart {
         )
     }
 
-    @computed private get fonts(): React.ReactElement {
-        let origin = ""
-        try {
-            if (this.manager.bakedGrapherURL)
-                origin = new URL(this.manager.bakedGrapherURL).origin
-        } catch {
-            // ignore
-        }
-        const css = `@import url(${origin}/fonts.css)`
-        return (
-            <defs>
-                <style>{css}</style>
-            </defs>
-        )
-    }
-
     render(): React.ReactElement {
-        const { paddedBounds, manager, maxWidth } = this
-
-        const bounds = this.manager.staticBoundsWithDetails ?? this.bounds
-        const width = bounds.width
-        const height = bounds.height
+        const { innerBounds, manager, maxWidth } = this
 
         const includeDetailsInStaticExport =
             manager.shouldIncludeDetailsInStaticExport &&
             !_.isEmpty(this.manager.detailRenderers)
 
-        const includeFontsStyle = !manager.isExportingForWikimedia
-        const includeBackgroundRect = !!manager.isExportingForWikimedia
-
         return (
-            <svg
-                {...this.svgProps}
-                width={width}
-                height={height}
-                viewBox={`0 0 ${width} ${height}`}
-            >
-                {includeFontsStyle && this.fonts}
-                {this.patterns}
-                {includeBackgroundRect && (
-                    <rect
-                        className="background-fill"
-                        fill={this.backgroundColor}
-                        width={width}
-                        height={height}
-                    />
-                )}
+            <StaticChartWrapper manager={this.manager} bounds={this.svgBounds}>
                 <StaticHeader
                     manager={manager}
                     maxWidth={maxWidth}
-                    targetX={paddedBounds.x}
-                    targetY={paddedBounds.y}
+                    targetX={innerBounds.x}
+                    targetY={innerBounds.y}
                 />
-                <g
-                    id={makeIdForHumanConsumption(GRAPHER_CHART_AREA_CLASS)}
-                    style={{ pointerEvents: "none" }}
-                >
-                    {/*
-                     We cannot render a table to svg, but would rather display nothing at all to avoid issues.
-                     See https://github.com/owid/owid-grapher/issues/3283
-                    */}
-                    {this.manager.isOnTableTab ? undefined : this.renderChart()}
-                </g>
+                <ChartAreaContent
+                    manager={this.manager}
+                    bounds={this.boundsForChartArea}
+                />
                 <StaticFooter
                     manager={manager}
                     maxWidth={maxWidth}
-                    targetX={paddedBounds.x}
-                    targetY={paddedBounds.bottom - this.staticFooter.height}
+                    targetX={innerBounds.x}
+                    targetY={innerBounds.bottom - this.staticFooter.height}
                 />
                 {includeDetailsInStaticExport && this.renderSVGDetails()}
-            </svg>
+            </StaticChartWrapper>
         )
     }
 }

--- a/packages/@ourworldindata/grapher/src/chart/CaptionedOrThumbnailChart.tsx
+++ b/packages/@ourworldindata/grapher/src/chart/CaptionedOrThumbnailChart.tsx
@@ -1,0 +1,64 @@
+import React from "react"
+import { computed } from "mobx"
+import { observer } from "mobx-react"
+import { match } from "ts-pattern"
+import { GrapherRenderMode } from "@ourworldindata/utils"
+import {
+    CaptionedChart,
+    StaticCaptionedChart,
+} from "../captionedChart/CaptionedChart.js"
+import { GrapherState } from "../core/Grapher.js"
+import { ChartAreaContent } from "./ChartAreaContent.js"
+import { StaticChartWrapper } from "./StaticChartWrapper.js"
+
+@observer
+export class CaptionedOrThumbnailChart extends React.Component<{
+    manager: GrapherState
+}> {
+    @computed private get manager(): GrapherState {
+        return this.props.manager
+    }
+
+    @computed private get renderMode(): GrapherRenderMode {
+        return this.props.manager.renderMode ?? GrapherRenderMode.Captioned
+    }
+
+    private renderInteractive(): React.ReactElement {
+        return match(this.renderMode)
+            .with(GrapherRenderMode.Captioned, () => (
+                <CaptionedChart manager={this.manager} />
+            ))
+            .with(GrapherRenderMode.Thumbnail, () => (
+                <ChartAreaContent
+                    manager={this.manager}
+                    bounds={this.manager.chartAreaBounds}
+                />
+            ))
+            .exhaustive()
+    }
+
+    private renderStatic(): React.ReactElement {
+        return match(this.renderMode)
+            .with(GrapherRenderMode.Captioned, () => (
+                <StaticCaptionedChart manager={this.manager} />
+            ))
+            .with(GrapherRenderMode.Thumbnail, () => (
+                <StaticChartWrapper
+                    manager={this.manager}
+                    bounds={this.manager.chartAreaBounds}
+                >
+                    <ChartAreaContent
+                        manager={this.manager}
+                        bounds={this.manager.chartAreaBounds}
+                    />
+                </StaticChartWrapper>
+            ))
+            .exhaustive()
+    }
+
+    render(): React.ReactElement {
+        return this.manager.isStatic
+            ? this.renderStatic()
+            : this.renderInteractive()
+    }
+}

--- a/packages/@ourworldindata/grapher/src/chart/ChartAreaContent.tsx
+++ b/packages/@ourworldindata/grapher/src/chart/ChartAreaContent.tsx
@@ -32,10 +32,6 @@ export class ChartAreaContent extends React.Component<ChartAreaContentProps> {
         return this.props.bounds.padWidth(this.props.padWidth ?? 0)
     }
 
-    @computed private get containerElement(): HTMLDivElement | undefined {
-        return this.manager?.containerElement
-    }
-
     @computed private get activeChartOrMapType():
         | GrapherChartOrMapType
         | undefined {
@@ -68,7 +64,7 @@ export class ChartAreaContent extends React.Component<ChartAreaContentProps> {
 
     private renderReadyChartOrMap(): React.ReactElement | null {
         const { bounds } = this
-        const { manager, activeChartOrMapType, containerElement } = this
+        const { manager, activeChartOrMapType } = this
         const { isFaceted } = manager
 
         if (!activeChartOrMapType) return null
@@ -91,13 +87,7 @@ export class ChartAreaContent extends React.Component<ChartAreaContentProps> {
             ChartComponentClassMap.get(activeChartOrMapType) ??
             DefaultChartClass
 
-        return (
-            <ChartClass
-                bounds={bounds}
-                manager={manager}
-                containerElement={containerElement}
-            />
-        )
+        return <ChartClass bounds={bounds} manager={manager} />
     }
 
     private renderChartOrMap(): React.ReactElement {

--- a/packages/@ourworldindata/grapher/src/chart/ChartManager.ts
+++ b/packages/@ourworldindata/grapher/src/chart/ChartManager.ts
@@ -12,6 +12,7 @@ import {
     EntityName,
     DetailsMarker,
     Color,
+    GrapherRenderMode,
 } from "@ourworldindata/types"
 import { TooltipManager } from "../tooltip/TooltipProps"
 import { OwidTable, CoreColumn } from "@ourworldindata/core-table"
@@ -30,6 +31,8 @@ export interface ChartManager {
 
     table: OwidTable
     transformedTable?: OwidTable
+
+    renderMode?: GrapherRenderMode
 
     isExportingToSvgOrPng?: boolean
     isRelativeMode?: boolean

--- a/packages/@ourworldindata/grapher/src/chart/ChartTypeMap.tsx
+++ b/packages/@ourworldindata/grapher/src/chart/ChartTypeMap.tsx
@@ -20,7 +20,6 @@ import { MarimekkoChart } from "../stackedCharts/MarimekkoChart"
 interface ChartComponentProps {
     manager: ChartManager
     bounds?: Bounds
-    containerElement?: HTMLDivElement
 }
 
 interface ChartComponentClass extends ComponentClass<ChartComponentProps> {

--- a/packages/@ourworldindata/grapher/src/chart/ChartUtils.tsx
+++ b/packages/@ourworldindata/grapher/src/chart/ChartUtils.tsx
@@ -2,6 +2,7 @@ import * as React from "react"
 import {
     areSetsEqual,
     Box,
+    excludeUndefined,
     getCountryByName,
     getTimeDomainFromQueryString,
     Url,
@@ -37,6 +38,9 @@ import {
     GRAPHER_TIMELINE_CLASS,
     GRAPHER_SETTINGS_CLASS,
     validChartTypeCombinations,
+    Patterns,
+    SVG_STYLE_PROPS,
+    BASE_FONT_SIZE,
 } from "../core/GrapherConstants"
 import { ChartSeries } from "./ChartInterface"
 import {
@@ -44,6 +48,7 @@ import {
     isNotErrorValueOrEmptyCell,
     OwidTable,
 } from "@ourworldindata/core-table"
+import { GRAPHER_BACKGROUND_DEFAULT } from "../color/ColorConstants.js"
 
 export const autoDetectYColumnSlugs = (manager: ChartManager): string[] => {
     if (manager.yColumnSlugs && manager.yColumnSlugs.length)
@@ -500,4 +505,47 @@ export function combineHistoricalAndProjectionColumns(
         )
 
     return table
+}
+
+export function NoDataPattern({
+    patternId = Patterns.noDataPattern,
+    scale = 1,
+}: {
+    patternId?: string
+    scale?: number
+}): React.ReactElement {
+    const patternTransforms = excludeUndefined([
+        `rotate(-45 2 2)`,
+        scale !== 1 ? `scale(${scale})` : undefined,
+    ])
+    return (
+        <pattern
+            id={patternId}
+            patternUnits="userSpaceOnUse"
+            width="4"
+            height="4"
+            patternTransform={patternTransforms.join(" ")}
+        >
+            <path d="M -1,2 l 6,0" stroke="#ccc" strokeWidth={0.7} />
+        </pattern>
+    )
+}
+
+export function getChartSvgProps({
+    fontSize,
+    backgroundColor,
+}: {
+    fontSize?: number
+    backgroundColor?: string
+}): React.SVGProps<SVGSVGElement> {
+    return {
+        xmlns: "http://www.w3.org/2000/svg",
+        version: "1.1",
+        style: {
+            ...SVG_STYLE_PROPS,
+            fontSize: fontSize ?? BASE_FONT_SIZE,
+            // Needs to be set here or else pngs will have a black background
+            backgroundColor: backgroundColor ?? GRAPHER_BACKGROUND_DEFAULT,
+        },
+    }
 }

--- a/packages/@ourworldindata/grapher/src/chart/StaticChartWrapper.tsx
+++ b/packages/@ourworldindata/grapher/src/chart/StaticChartWrapper.tsx
@@ -1,0 +1,86 @@
+import React from "react"
+import { computed } from "mobx"
+import { observer } from "mobx-react"
+import { Bounds } from "@ourworldindata/utils"
+import { DEFAULT_GRAPHER_BOUNDS } from "../core/GrapherConstants.js"
+import { CaptionedChartManager } from "../captionedChart/CaptionedChart.js"
+import { GRAPHER_BACKGROUND_DEFAULT } from "../color/ColorConstants.js"
+import { getChartSvgProps, NoDataPattern } from "./ChartUtils.js"
+
+@observer
+export class StaticChartWrapper extends React.Component<{
+    manager: CaptionedChartManager
+    bounds?: Bounds
+}> {
+    @computed private get manager(): CaptionedChartManager {
+        return this.props.manager
+    }
+
+    @computed protected get bounds(): Bounds {
+        return (
+            this.props.bounds ??
+            this.manager.staticBounds ??
+            DEFAULT_GRAPHER_BOUNDS
+        )
+    }
+
+    @computed private get fonts(): React.ReactElement {
+        let origin = ""
+        try {
+            if (this.manager.bakedGrapherURL)
+                origin = new URL(this.manager.bakedGrapherURL).origin
+        } catch {
+            // ignore
+        }
+        const css = `@import url(${origin}/fonts.css)`
+        return (
+            <defs>
+                <style>{css}</style>
+            </defs>
+        )
+    }
+
+    @computed private get backgroundColor(): string {
+        return this.manager.backgroundColor ?? GRAPHER_BACKGROUND_DEFAULT
+    }
+
+    @computed private get noDataPattern(): React.ReactElement {
+        return (
+            <defs>
+                <NoDataPattern />
+            </defs>
+        )
+    }
+
+    render(): React.ReactElement {
+        const { manager } = this
+
+        const bounds = this.manager.staticBoundsWithDetails ?? this.bounds
+        const width = bounds.width
+        const height = bounds.height
+
+        const includeFontsStyle = !manager.isExportingForWikimedia
+        const includeBackgroundRect = !!manager.isExportingForWikimedia
+
+        return (
+            <svg
+                {...getChartSvgProps(this.manager)}
+                width={width}
+                height={height}
+                viewBox={`0 0 ${width} ${height}`}
+            >
+                {includeFontsStyle && this.fonts}
+                {this.noDataPattern}
+                {includeBackgroundRect && (
+                    <rect
+                        className="background-fill"
+                        fill={this.backgroundColor}
+                        width={width}
+                        height={height}
+                    />
+                )}
+                {this.props.children}
+            </svg>
+        )
+    }
+}

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -112,6 +112,7 @@ import {
     OwidVariableRow,
     AdditionalGrapherDataFetchFn,
     ProjectionColumnInfo,
+    GrapherRenderMode,
 } from "@ourworldindata/types"
 import {
     BlankOwidTable,
@@ -255,6 +256,7 @@ export interface GrapherProgrammaticInterface extends GrapherInterface {
     entityYearHighlight?: EntityYearHighlight
     baseFontSize?: number
     staticBounds?: Bounds
+    renderMode?: GrapherRenderMode
 
     hideTitle?: boolean
     hideSubtitle?: boolean
@@ -1067,6 +1069,8 @@ export class GrapherState {
     @observable.ref isExportingToSvgOrPng = false
     @observable.ref isSocialMediaExport = false
     @observable.ref isWikimediaExport = false
+
+    @observable.ref renderMode = GrapherRenderMode.Captioned
 
     @observable staticBounds: Bounds = DEFAULT_GRAPHER_BOUNDS
 

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
@@ -88,7 +88,6 @@ import { makeProjectedDataPatternId } from "./MapComponents"
 interface MapChartProps {
     bounds?: Bounds
     manager: MapChartManager
-    containerElement?: HTMLDivElement
 }
 
 @observer

--- a/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChart.tsx
@@ -248,7 +248,6 @@ function MarimekkoBarsForOneEntity(
 interface MarimekkoChartProps {
     bounds?: Bounds
     manager: MarimekkoChartManager
-    containerElement?: HTMLDivElement
 }
 
 @observer

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBarChart.tsx
@@ -125,7 +125,6 @@ interface StackedBarChartContext {
 interface StackedDiscreteBarChartProps {
     bounds?: Bounds
     manager: StackedDiscreteBarChartManager
-    containerElement?: HTMLDivElement
 }
 
 @observer

--- a/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
+++ b/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
@@ -773,6 +773,11 @@ export const grapherKeysToSerialize = [
     "bakedGrapherURL",
 ]
 
+export enum GrapherRenderMode {
+    Captioned = "captioned", // Chart with header and footer
+    Thumbnail = "thumbnail", // Chart only, no header or footer
+}
+
 export interface ChartRedirect {
     id: number
     slug: string

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -136,6 +136,7 @@ export {
     type MapConfigInterface,
     type GlobeConfig,
     type ProjectionColumnInfo,
+    GrapherRenderMode,
 } from "./grapherTypes/GrapherTypes.js"
 
 export {


### PR DESCRIPTION
Grapher thumbnails in search render just the chart area, no header or footer.

This PR adds a `renderMode` to Grapher, which can be either 'captioned' (renders Grapher as usual with header and footer) or 'thumbnail' (renders only the chart area).

The chart area content has been extracted from `CaptionedChart` into its own component, `ChartAreaContent`. A new wrapper component, `CaptionedOrThumbnailChart`, chooses between rendering `CaptionedChart` or just `ChartAreaContent` based on the `renderMode`.

Also drops the `containerElement` prop from the chart component, since it didn’t appear to be used.

You can test by setting `imType=thumbnail` to static exports, e.g http://staging-site-grapher-thumbnail-setup/grapher/life-expectancy.svg?imType=thumbnail&nocache.