### PR TITLE
In the tooltip, show interpolated values with striped pattern.

### DIFF
--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
@@ -578,7 +578,20 @@ export class StackedAreaChart extends AbstractStackedChart {
                   ]),
               }
             : undefined
-        const footer = excludeUndefined([roundingNotice])
+
+        const hasInterpolatedValues = series.some((s) => {
+            const point = s.points[hoveredPointIndex]
+            return point?.interpolated && point?.value !== undefined
+        })
+
+        const interpolationNotice = hasInterpolatedValues
+            ? {
+                  icon: TooltipFooterIcon.stripes,
+                  text: "Striped values are interpolated",
+              }
+            : undefined
+
+        const footer = excludeUndefined([roundingNotice, interpolationNotice])
 
         return (
             <Tooltip
@@ -605,7 +618,12 @@ export class StackedAreaChart extends AbstractStackedChart {
                         const { seriesName: name, color, points } = series
                         const point = points[hoveredPointIndex]
                         const focused = name === target.series
-                        const values = [point?.fake ? undefined : point?.value]
+                        const isInterpolated = point?.interpolated ?? false
+                        const values = [
+                            point?.fake && !point?.interpolated
+                                ? undefined
+                                : point?.value,
+                        ]
                         const opacity = focused
                             ? AREA_OPACITY.focus
                             : AREA_OPACITY.default
@@ -616,6 +634,7 @@ export class StackedAreaChart extends AbstractStackedChart {
                             swatch,
                             focused,
                             values,
+                            striped: isInterpolated,
                         }
                     })}
                 />


### PR DESCRIPTION
## Context

This PR tries to improve the visual cues for interpolated values in stacked area charts (#5120). E.g. in chart [2007](http://staging-site-interpolated-stacked-striped/admin/charts/2007/edit) (Causes of death in the US) the values for accidents are shown as interpolated now in the early years.