### PR TITLE
🚧 (wip) extract chart state from line charts

### DIFF
--- a/adminSiteClient/EditorCustomizeTab.tsx
+++ b/adminSiteClient/EditorCustomizeTab.tsx
@@ -827,9 +827,9 @@ export class EditorCustomizeTab<
                 {features.canSpecifySortOrder && (
                     <SortOrderSection editor={this.props.editor} />
                 )}
-                {grapherState.chartInstanceExceptMap.colorScale && (
+                {grapherState.chartStateExceptMap.colorScale && (
                     <EditorColorScaleSection
-                        scale={grapherState.chartInstanceExceptMap.colorScale}
+                        scale={grapherState.chartStateExceptMap.colorScale}
                         chartType={
                             grapherState.chartType ??
                             GRAPHER_CHART_TYPES.LineChart

--- a/adminSiteClient/GrapherConfigGridEditor.tsx
+++ b/adminSiteClient/GrapherConfigGridEditor.tsx
@@ -501,9 +501,9 @@ export class GrapherConfigGridEditor extends React.Component<GrapherConfigGridEd
                         />
                     ) : undefined
                 } else {
-                    if (grapherState.chartInstanceExceptMap.colorScale) {
+                    if (grapherState.chartStateExceptMap.colorScale) {
                         const colorScale =
-                            grapherState.chartInstanceExceptMap.colorScale
+                            grapherState.chartStateExceptMap.colorScale
                         // TODO: instead of using onChange below that has to be maintained when
                         // the color scale changes I tried to use a reaction here after Daniel G's suggestion
                         // but I couldn't get this to work. Worth trying again later.

--- a/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChart.tsx
@@ -35,7 +35,7 @@ import { HorizontalAxisZeroLine } from "../axis/AxisViews"
 import { NoDataModal } from "../noDataModal/NoDataModal"
 import { AxisConfig, AxisManager } from "../axis/AxisConfig"
 import { ColorSchemes } from "../color/ColorSchemes"
-import { ChartInterface } from "../chart/ChartInterface"
+import { ChartState } from "../chart/ChartInterface"
 import {
     BACKGROUND_COLOR,
     DiscreteBarChartManager,
@@ -103,7 +103,7 @@ export class DiscreteBarChart
         bounds?: Bounds
         manager: DiscreteBarChartManager
     }>
-    implements ChartInterface, AxisManager, ColorScaleManager
+    implements ChartState, AxisManager, ColorScaleManager
 {
     base: React.RefObject<SVGGElement> = React.createRef()
 

--- a/packages/@ourworldindata/grapher/src/chart/ChartInterface.ts
+++ b/packages/@ourworldindata/grapher/src/chart/ChartInterface.ts
@@ -8,6 +8,7 @@ import {
 import { ColorScale } from "../color/ColorScale"
 import { HorizontalAxis, VerticalAxis } from "../axis/Axis"
 import { HorizontalColorLegendManager } from "../horizontalColorLegend/HorizontalColorLegends"
+
 // The idea of this interface is to try and start reusing more code across our Chart classes and make it easier
 // for a dev to work on a chart type they haven't touched before if they've worked with another that implements
 // this interface.
@@ -19,22 +20,32 @@ export interface ChartSeries {
 
 export type ChartTableTransformer = (inputTable: OwidTable) => OwidTable
 
-export interface ChartInterface {
+/** Interface implemented by all chart state classes */
+export interface ChartState {
     failMessage: string // We require every chart have some fail message(s) to show to the user if something went wrong
 
     inputTable: OwidTable // Points to the OwidTable coming into the chart. All charts have an inputTable. Standardized as part of the interface as a development aid.
     transformedTable: OwidTable // Points to the OwidTable after the chart has transformed the input table. The chart may add a relative transform, for example. Standardized as part of the interface as a development aid.
 
-    colorScale?: ColorScale
-    shouldUseValueBasedColorScheme?: boolean // Opt-out of assigned colors and use a value-based color scheme instead
-
-    seriesStrategy?: SeriesStrategy
     series: readonly ChartSeries[] // This points to the marks that the chart will render. They don't have to be placed yet. Standardized as part of the interface as a development aid.
-    // Todo: should all charts additionally have a placedSeries: ChartPlacedSeries[] getter?
+    seriesStrategy?: SeriesStrategy
 
     transformTable: ChartTableTransformer
     transformTableForDisplay?: ChartTableTransformer
     transformTableForSelection?: ChartTableTransformer
+
+    colorScale?: ColorScale
+
+    /**
+     * Which facet strategies the chart type finds reasonable in its current setting, if any.
+     * Does not necessarily contain FacetStrategy.None -- there are situations where an unfaceted chart doesn't make sense.
+     */
+    availableFacetStrategies?: FacetStrategy[]
+}
+
+/** Interface implemented by all chart component classes */
+export interface ChartInterface {
+    chartState: ChartState
 
     yAxis?: HorizontalAxis | VerticalAxis
     xAxis?: HorizontalAxis | VerticalAxis
@@ -46,8 +57,8 @@ export interface ChartInterface {
     externalLegend?: HorizontalColorLegendManager
 
     /**
-     * Which facet strategies the chart type finds reasonable in its current setting, if any.
-     * Does not necessarily contain FacetStrategy.None -- there are situations where an unfaceted chart doesn't make sense.
+     * Opt-out of assigned colors and use a value-based color scheme instead.
+     * Only relevant for StackedBar charts.
      */
-    availableFacetStrategies?: FacetStrategy[]
+    shouldUseValueBasedColorScheme?: boolean
 }

--- a/packages/@ourworldindata/grapher/src/chart/ChartTypeMap.tsx
+++ b/packages/@ourworldindata/grapher/src/chart/ChartTypeMap.tsx
@@ -1,45 +1,128 @@
-import { ScatterPlotChart } from "../scatterCharts/ScatterPlotChart"
-import { SlopeChart } from "../slopeCharts/SlopeChart"
-import { LineChart } from "../lineCharts/LineChart"
-import { StackedAreaChart } from "../stackedCharts/StackedAreaChart"
-import { DiscreteBarChart } from "../barCharts/DiscreteBarChart"
-import { StackedBarChart } from "../stackedCharts/StackedBarChart"
+import { match } from "ts-pattern"
 import {
     GRAPHER_CHART_TYPES,
     GrapherChartOrMapType,
-    GRAPHER_MAP_TYPE,
+    GrapherRenderMode,
 } from "@ourworldindata/types"
-import { MapChart } from "../mapCharts/MapChart"
-import { ChartInterface } from "./ChartInterface"
+import { ChartInterface, ChartState } from "./ChartInterface"
 import { ChartManager } from "./ChartManager"
 import { ComponentClass, Component } from "react"
 import { Bounds } from "@ourworldindata/utils"
-import { StackedDiscreteBarChart } from "../stackedCharts/StackedDiscreteBarChart"
-import { MarimekkoChart } from "../stackedCharts/MarimekkoChart"
 
-interface ChartComponentProps {
-    manager: ChartManager
+import { LineChartState } from "../lineCharts/LineChartState.js"
+import { LineChart } from "../lineCharts/LineChart"
+import { LineChartThumbnail } from "../lineCharts/LineChartThumbnail"
+
+interface ChartComponentProps<TState extends ChartState = ChartState> {
+    chartState: TState
     bounds?: Bounds
 }
 
-interface ChartComponentClass extends ComponentClass<ChartComponentProps> {
-    new (props: ChartComponentProps): Component & ChartInterface
+interface ChartComponentClass<T extends ChartState = ChartState>
+    extends ComponentClass<ChartComponentProps<T>> {
+    new (props: ChartComponentProps<T>): Component & ChartInterface
 }
 
-export const ChartComponentClassMap = new Map<
+type ChartFactoryProps = {
+    manager: ChartManager
+    chartType: GrapherChartOrMapType
+    chartState?: ChartState
+    renderMode?: GrapherRenderMode
+} & Omit<ChartComponentProps, "chartState">
+
+const ChartComponentClassMap = new Map<
     GrapherChartOrMapType,
-    ChartComponentClass
+    ChartComponentClass<any>
 >([
-    [GRAPHER_CHART_TYPES.DiscreteBar, DiscreteBarChart],
     [GRAPHER_CHART_TYPES.LineChart, LineChart],
-    [GRAPHER_CHART_TYPES.SlopeChart, SlopeChart],
-    [GRAPHER_CHART_TYPES.StackedArea, StackedAreaChart],
-    [GRAPHER_CHART_TYPES.StackedBar, StackedBarChart],
-    [GRAPHER_CHART_TYPES.StackedDiscreteBar, StackedDiscreteBarChart],
-    [GRAPHER_CHART_TYPES.ScatterPlot, ScatterPlotChart],
-    [GRAPHER_CHART_TYPES.Marimekko, MarimekkoChart],
-    [GRAPHER_MAP_TYPE, MapChart],
+    // [GRAPHER_CHART_TYPES.DiscreteBar, DiscreteBarChart],
+    // [GRAPHER_CHART_TYPES.SlopeChart, SlopeChart],
+    // [GRAPHER_CHART_TYPES.StackedArea, StackedAreaChart],
+    // [GRAPHER_CHART_TYPES.StackedBar, StackedBarChart],
+    // [GRAPHER_CHART_TYPES.StackedDiscreteBar, StackedDiscreteBarChart],
+    // [GRAPHER_CHART_TYPES.ScatterPlot, ScatterPlotChart],
+    // [GRAPHER_CHART_TYPES.Marimekko, MarimekkoChart],
+    // [GRAPHER_MAP_TYPE, MapChart],
 ])
 
-export const DefaultChartClass = LineChart as ChartComponentClass
-export const defaultChartType = GRAPHER_CHART_TYPES.LineChart
+const ChartThumbnailClassMap = new Map<
+    GrapherChartOrMapType,
+    ChartComponentClass<any>
+>([
+    [GRAPHER_CHART_TYPES.LineChart, LineChartThumbnail],
+    // [GRAPHER_CHART_TYPES.DiscreteBar, DiscreteBarChart],
+    // [GRAPHER_CHART_TYPES.SlopeChart, SlopeChart],
+    // [GRAPHER_CHART_TYPES.StackedArea, StackedAreaChart],
+    // [GRAPHER_CHART_TYPES.StackedBar, StackedBarChart],
+    // [GRAPHER_CHART_TYPES.StackedDiscreteBar, StackedDiscreteBarChart],
+    // [GRAPHER_CHART_TYPES.ScatterPlot, ScatterPlotChart],
+    // [GRAPHER_CHART_TYPES.Marimekko, MarimekkoChart],
+    // [GRAPHER_MAP_TYPE, MapChart],
+])
+
+const ChartStateMap = new Map<
+    GrapherChartOrMapType,
+    new (args: { manager: ChartManager }) => ChartState
+>([
+    [GRAPHER_CHART_TYPES.LineChart, LineChartState],
+    // [GRAPHER_CHART_TYPES.DiscreteBar, DiscreteBarChart],
+    // [GRAPHER_CHART_TYPES.SlopeChart, SlopeChart],
+    // [GRAPHER_CHART_TYPES.StackedArea, StackedAreaChart],
+    // [GRAPHER_CHART_TYPES.StackedBar, StackedBarChart],
+    // [GRAPHER_CHART_TYPES.StackedDiscreteBar, StackedDiscreteBarChart],
+    // [GRAPHER_CHART_TYPES.ScatterPlot, ScatterPlotChart],
+    // [GRAPHER_CHART_TYPES.Marimekko, MarimekkoChart],
+    // [GRAPHER_MAP_TYPE, MapChart],
+])
+
+export function makeChartState(
+    chartType: GrapherChartOrMapType,
+    manager: ChartManager
+): ChartState {
+    const StateClass = ChartStateMap.get(chartType) ?? LineChartState
+    return new StateClass({ manager })
+}
+
+function getChartComponentClass(
+    chartType: GrapherChartOrMapType,
+    renderMode = GrapherRenderMode.Captioned
+): ChartComponentClass {
+    const { ClassMap, DefaultChartClass } = match(renderMode)
+        .with(GrapherRenderMode.Captioned, () => ({
+            ClassMap: ChartComponentClassMap,
+            DefaultChartClass: LineChart,
+        }))
+        .with(GrapherRenderMode.Thumbnail, () => ({
+            ClassMap: ChartThumbnailClassMap,
+            DefaultChartClass: LineChartThumbnail,
+        }))
+        .exhaustive()
+
+    const ChartClass = ClassMap.get(chartType) ?? DefaultChartClass
+
+    return ChartClass as ChartComponentClass
+}
+
+export const ChartComponent = ({
+    manager,
+    chartType,
+    chartState,
+    renderMode = GrapherRenderMode.Captioned,
+    ...componentProps
+}: ChartFactoryProps): React.ReactElement => {
+    const validChartState = chartState ?? makeChartState(chartType, manager)
+    const ChartClass = getChartComponentClass(chartType, renderMode)
+    return <ChartClass {...componentProps} chartState={validChartState} />
+}
+
+export const makeChartInstance = ({
+    manager,
+    chartType,
+    chartState,
+    renderMode = GrapherRenderMode.Captioned,
+    ...componentProps
+}: ChartFactoryProps): ChartInterface => {
+    const validChartState = chartState ?? makeChartState(chartType, manager)
+    const ChartClass = getChartComponentClass(chartType, renderMode)
+    return new ChartClass({ ...componentProps, chartState: validChartState })
+}

--- a/packages/@ourworldindata/grapher/src/core/Grapher.test.ts
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.test.ts
@@ -431,7 +431,7 @@ describe("authors can use maxTime", () => {
             maxTime: 2005,
             ySlugs: "GDP",
         })
-        const chart = grapher.chartInstance
+        const chart = grapher.chartState
         expect(chart.failMessage).toBeFalsy()
     })
 })
@@ -450,7 +450,7 @@ describe("line chart to bar chart and bar chart race", () => {
 
     describe("switches from a line chart to a bar chart when there is only 1 year selected", () => {
         const grapher = new GrapherState(TestGrapherConfig())
-        const lineSeries = grapher.chartInstance.series
+        const lineSeries = grapher.chartState.series
 
         expect(
             grapher.typeExceptWhenLineChartAndSingleTimeThenWillBeBarChart
@@ -467,7 +467,7 @@ describe("line chart to bar chart and bar chart race", () => {
         })
 
         it("color goes to monochrome when the chart switches from line chart to bar chart", () => {
-            const barSeries = grapher.chartInstance.series
+            const barSeries = grapher.chartState.series
             const barColors = _.orderBy(barSeries, "seriesName").map(
                 (series) => series.color
             )

--- a/packages/@ourworldindata/grapher/src/core/GrapherWithChartTypes.test.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherWithChartTypes.test.ts
@@ -71,5 +71,5 @@ test("grapher and discrete bar charts", () => {
         chartTypes: [GRAPHER_CHART_TYPES.DiscreteBar],
         ...basicGrapherConfig,
     })
-    expect(grapher.chartInstance.series.length).toBeGreaterThan(0)
+    expect(grapher.chartState.series.length).toBeGreaterThan(0)
 })

--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
@@ -5,16 +5,12 @@ import {
     guid,
     excludeNullish,
     getRelativeMouse,
-    pointsToPath,
     exposeInstanceOnWindow,
     excludeUndefined,
     isMobile,
     Bounds,
-    PointVector,
-    AxisAlign,
     Color,
     HorizontalAlign,
-    makeIdForHumanConsumption,
     isTouchDevice,
 } from "@ourworldindata/utils"
 import { computed, action, observable } from "mobx"
@@ -35,64 +31,47 @@ import { NoDataModal } from "../noDataModal/NoDataModal"
 import { extent } from "d3-array"
 import {
     SeriesName,
-    ScaleType,
-    EntityName,
-    SeriesStrategy,
-    FacetStrategy,
-    CoreValueType,
-    MissingDataStrategy,
-    ColorScaleConfigInterface,
-    ColorSchemeName,
     VerticalAlign,
     InteractionState,
+    AxisAlign,
+    ScaleType,
 } from "@ourworldindata/types"
 import {
     BASE_FONT_SIZE,
     DEFAULT_GRAPHER_BOUNDS,
-    GRAPHER_OPACITY_MUTE,
 } from "../core/GrapherConstants"
-import { ColorSchemes } from "../color/ColorSchemes"
-import { AxisConfig, AxisManager } from "../axis/AxisConfig"
 import { ChartInterface } from "../chart/ChartInterface"
 import {
-    LinesProps,
     LineChartSeries,
     LineChartManager,
     LinePoint,
     PlacedLineChartSeries,
     PlacedPoint,
     RenderLineChartSeries,
+    LEGEND_PADDING,
+    VARIABLE_COLOR_STROKE_WIDTH,
+    DEFAULT_STROKE_WIDTH,
+    VARIABLE_COLOR_LINE_OUTLINE_WIDTH,
+    DEFAULT_LINE_OUTLINE_WIDTH,
+    DISCONNECTED_DOTS_MARKER_RADIUS,
+    VARIABLE_COLOR_MARKER_RADIUS,
+    STATIC_SMALL_MARKER_RADIUS,
+    DEFAULT_MARKER_RADIUS,
+    NON_FOCUSED_LINE_COLOR,
+    LINE_CHART_CLASS_NAME,
 } from "./LineChartConstants"
+import { CoreColumn } from "@ourworldindata/core-table"
 import {
-    OwidTable,
-    CoreColumn,
-    isNotErrorValue,
-} from "@ourworldindata/core-table"
-import {
-    autoDetectSeriesStrategy,
-    autoDetectYColumnSlugs,
     byHoverThenFocusState,
     ClipPath,
-    getDefaultFailMessage,
     getHoverStateForSeries,
     getSeriesKey,
     isTargetOutsideElement,
     makeClipPath,
-    makeSelectionArray,
 } from "../chart/ChartUtils"
-import { ColorScheme } from "../color/ColorScheme"
-import { SelectionArray } from "../selection/SelectionArray"
 import { CategoricalBin, ColorScaleBin } from "../color/ColorScaleBin"
-import { ColorScale, ColorScaleManager } from "../color/ColorScale"
-import { ColorScaleConfig } from "../color/ColorScaleConfig"
-import {
-    GRAPHER_BACKGROUND_DEFAULT,
-    OWID_NO_DATA_GRAY,
-    GRAY_50,
-    OWID_NON_FOCUSED_GRAY,
-} from "../color/ColorConstants"
-import { MultiColorPolyline } from "../scatterCharts/MultiColorPolyline"
-import { CategoricalColorAssigner } from "../color/CategoricalColorAssigner"
+import { ColorScale } from "../color/ColorScale"
+import { GRAPHER_BACKGROUND_DEFAULT, GRAY_50 } from "../color/ColorConstants"
 import { darkenColorForLine } from "../color/ColorUtils"
 import {
     HorizontalColorLegendManager,
@@ -102,355 +81,40 @@ import {
     AnnotationsMap,
     getAnnotationsForSeries,
     getAnnotationsMap,
-    getColorKey,
-    getSeriesName,
 } from "./LineChartHelpers"
 import { FocusArray } from "../focus/FocusArray.js"
 import { LineLabelSeries } from "../lineLegend/LineLegendTypes"
-
-const LINE_CHART_CLASS_NAME = "LineChart"
-
-// line color
-const NON_FOCUSED_LINE_COLOR = OWID_NON_FOCUSED_GRAY
-const DEFAULT_LINE_COLOR = "#000"
-// stroke width
-const DEFAULT_STROKE_WIDTH = 1.5
-const VARIABLE_COLOR_STROKE_WIDTH = 2.5
-// marker radius
-const DEFAULT_MARKER_RADIUS = 1.8
-const VARIABLE_COLOR_MARKER_RADIUS = 2.2
-const DISCONNECTED_DOTS_MARKER_RADIUS = 2.6
-const STATIC_SMALL_MARKER_RADIUS = 3
-// line outline
-const DEFAULT_LINE_OUTLINE_WIDTH = 0.5
-const VARIABLE_COLOR_LINE_OUTLINE_WIDTH = 1.0
-// legend
-const LEGEND_PADDING = 25
-
-@observer
-class Lines extends React.Component<LinesProps> {
-    @computed get bounds(): Bounds {
-        const { horizontalAxis, verticalAxis } = this.props.dualAxis
-        return Bounds.fromCorners(
-            new PointVector(horizontalAxis.range[0], verticalAxis.range[0]),
-            new PointVector(horizontalAxis.range[1], verticalAxis.range[1])
-        )
-    }
-
-    @computed private get markerRadius(): number {
-        return this.props.markerRadius ?? DEFAULT_MARKER_RADIUS
-    }
-
-    @computed private get strokeWidth(): number {
-        return this.props.lineStrokeWidth ?? DEFAULT_STROKE_WIDTH
-    }
-
-    @computed private get outlineWidth(): number {
-        return this.props.lineOutlineWidth ?? DEFAULT_LINE_OUTLINE_WIDTH
-    }
-
-    @computed private get outlineColor(): string {
-        return this.props.backgroundColor ?? GRAPHER_BACKGROUND_DEFAULT
-    }
-
-    // Don't display point markers if there are very many of them for performance reasons
-    // Note that we're using circle elements instead of marker-mid because marker performance in Safari 10 is very poor for some reason
-    @computed private get hasMarkers(): boolean {
-        if (this.props.hidePoints) return false
-        const totalPoints = _.sum(
-            this.props.series
-                .filter((series) => this.seriesHasMarkers(series))
-                .map((series) => series.placedPoints.length)
-        )
-        return totalPoints < 500
-    }
-
-    @computed private get hasMarkersOnlySeries(): boolean {
-        return this.props.series.some((series) => series.plotMarkersOnly)
-    }
-
-    private seriesHasMarkers(series: RenderLineChartSeries): boolean {
-        if (
-            series.hover.background ||
-            series.isProjection ||
-            // if the series has a line, but there is another one that hasn't, then
-            // don't show markers since the plotted line is likely a smoothed version
-            (this.hasMarkersOnlySeries && !series.plotMarkersOnly)
-        )
-            return false
-        return !series.focus.background || series.hover.active
-    }
-
-    private renderLine(
-        series: RenderLineChartSeries
-    ): React.ReactElement | void {
-        const { hover, focus } = series
-
-        if (series.plotMarkersOnly) return
-
-        const seriesColor = series.placedPoints[0]?.color ?? DEFAULT_LINE_COLOR
-        const color =
-            !focus.background || hover.active
-                ? seriesColor
-                : NON_FOCUSED_LINE_COLOR
-
-        const strokeDasharray = series.isProjection ? "2,3" : undefined
-        const strokeWidth =
-            hover.background || focus.background
-                ? 0.66 * this.strokeWidth
-                : this.strokeWidth
-        const strokeOpacity =
-            hover.background && !focus.background ? GRAPHER_OPACITY_MUTE : 1
-
-        const showOutline = !focus.background || hover.active
-        const outlineColor = this.outlineColor
-        const outlineWidth = strokeWidth + this.outlineWidth * 2
-
-        const outline = (
-            <LinePath
-                id={makeIdForHumanConsumption("outline", series.seriesName)}
-                placedPoints={series.placedPoints}
-                stroke={outlineColor}
-                strokeWidth={outlineWidth.toFixed(1)}
-            />
-        )
-
-        const line =
-            this.props.multiColor && !focus.background ? (
-                <MultiColorPolyline
-                    id={makeIdForHumanConsumption("line", series.seriesName)}
-                    points={series.placedPoints}
-                    strokeLinejoin="round"
-                    strokeWidth={strokeWidth.toFixed(1)}
-                    strokeDasharray={strokeDasharray}
-                    strokeOpacity={strokeOpacity}
-                />
-            ) : (
-                <LinePath
-                    id={makeIdForHumanConsumption("line", series.seriesName)}
-                    placedPoints={series.placedPoints}
-                    stroke={color}
-                    strokeWidth={strokeWidth.toFixed(1)}
-                    strokeOpacity={strokeOpacity}
-                    strokeDasharray={strokeDasharray}
-                />
-            )
-
-        return (
-            <>
-                {showOutline && outline}
-                {line}
-            </>
-        )
-    }
-
-    private renderLineMarkers(
-        series: RenderLineChartSeries
-    ): React.ReactElement | void {
-        const { horizontalAxis } = this.props.dualAxis
-        const { hover, focus } = series
-
-        const forceMarkers =
-            // If the series only contains one point, then we will always want to
-            // show a marker/circle because we can't draw a line.
-            series.placedPoints.length === 1 ||
-            // If no line is plotted, we'll always want to show markers
-            series.plotMarkersOnly
-
-        // check if we should hide markers on the chart and series level
-        const hideMarkers = !this.hasMarkers || !this.seriesHasMarkers(series)
-
-        if (hideMarkers && !forceMarkers) return
-
-        const opacity =
-            hover.background && !focus.background ? GRAPHER_OPACITY_MUTE : 1
-
-        const outlineColor = series.plotMarkersOnly
-            ? this.outlineColor
-            : undefined
-        const outlineWidth = series.plotMarkersOnly
-            ? this.outlineWidth
-            : undefined
-
-        return (
-            <g id={makeIdForHumanConsumption("datapoints", series.seriesName)}>
-                {series.placedPoints.map((value, index) => {
-                    const valueColor = value.color
-                    const color =
-                        !focus.background || hover.active
-                            ? valueColor
-                            : NON_FOCUSED_LINE_COLOR
-                    return (
-                        <circle
-                            id={makeIdForHumanConsumption(
-                                horizontalAxis.formatTick(value.time)
-                            )}
-                            key={index}
-                            cx={value.x}
-                            cy={value.y}
-                            r={this.markerRadius}
-                            fill={color}
-                            stroke={outlineColor}
-                            strokeWidth={outlineWidth}
-                            opacity={opacity}
-                        />
-                    )
-                })}
-            </g>
-        )
-    }
-
-    private renderLines(): React.ReactElement {
-        return (
-            <>
-                {this.props.series.map((series, index) => (
-                    <React.Fragment key={getSeriesKey(series, index)}>
-                        {this.renderLine(series)}
-                        {this.renderLineMarkers(series)}
-                    </React.Fragment>
-                ))}
-            </>
-        )
-    }
-
-    private renderStatic(): React.ReactElement {
-        return (
-            <g id={makeIdForHumanConsumption("lines")}>{this.renderLines()}</g>
-        )
-    }
-
-    private renderInteractive(): React.ReactElement {
-        const { bounds } = this
-        return (
-            <g className="Lines">
-                <rect
-                    x={Math.round(bounds.x)}
-                    y={Math.round(bounds.y)}
-                    width={Math.round(bounds.width)}
-                    height={Math.round(bounds.height)}
-                    fill="rgba(255,255,255,0)"
-                    opacity={0}
-                />
-                {this.renderLines()}
-            </g>
-        )
-    }
-
-    render(): React.ReactElement {
-        return this.props.isStatic
-            ? this.renderStatic()
-            : this.renderInteractive()
-    }
-}
-
-interface LinePathProps extends React.SVGProps<SVGPathElement> {
-    placedPoints: PlacedLineChartSeries["placedPoints"]
-}
-
-function LinePath(props: LinePathProps): React.ReactElement {
-    const { placedPoints, ...pathProps } = props
-    const coords = placedPoints.map(({ x, y }) => [x, y] as [number, number])
-    return (
-        <path
-            fill="none"
-            strokeLinecap="butt"
-            strokeLinejoin="round"
-            stroke={DEFAULT_LINE_COLOR}
-            {...pathProps}
-            d={pointsToPath(coords)}
-        />
-    )
-}
+import { Lines } from "./Lines"
+import { LineChartState } from "./LineChartState.js"
+import { AxisConfig, AxisManager } from "../axis/AxisConfig"
 
 @observer
 export class LineChart
     extends React.Component<{
+        chartState: LineChartState
         bounds?: Bounds
-        manager: LineChartManager
     }>
-    implements
-        ChartInterface,
-        AxisManager,
-        ColorScaleManager,
-        HorizontalColorLegendManager
+    implements ChartInterface, HorizontalColorLegendManager, AxisManager
 {
-    base: React.RefObject<SVGGElement> = React.createRef()
+    private base: React.RefObject<SVGGElement> = React.createRef()
 
-    transformTable(table: OwidTable): OwidTable {
-        table = table.filterByEntityNames(
-            this.selectionArray.selectedEntityNames
-        )
-
-        // TODO: remove this filter once we don't have mixed type columns in datasets
-        // Currently we set skipParsing=true on these columns to be backwards-compatible
-        table = table.replaceNonNumericCellsWithErrorValues(this.yColumnSlugs)
-
-        if (this.isLogScale)
-            table = table.replaceNonPositiveCellsForLogScale(this.yColumnSlugs)
-
-        if (this.colorColumnSlug) {
-            table = table
-                // TODO: remove this filter once we don't have mixed type columns in datasets
-                // Currently we set skipParsing=true on these columns to be backwards-compatible
-                .replaceNonNumericCellsWithErrorValues([this.colorColumnSlug])
-                .interpolateColumnWithTolerance(this.colorColumnSlug)
-        }
-
-        // drop all data when the author chose to hide entities with missing data and
-        // at least one of the variables has no data for the current entity
-        if (
-            this.missingDataStrategy === MissingDataStrategy.hide &&
-            table.hasAnyColumnNoValidValue(this.yColumnSlugs)
-        ) {
-            table = table.dropAllRows()
-        }
-
-        return table
-    }
-
-    transformTableForSelection(table: OwidTable): OwidTable {
-        // if entities with partial data are not plotted,
-        // make sure they don't show up in the entity selector
-        if (this.missingDataStrategy === MissingDataStrategy.hide) {
-            table = table
-                .replaceNonNumericCellsWithErrorValues(this.yColumnSlugs)
-                .dropEntitiesThatHaveNoDataInSomeColumn(this.yColumnSlugs)
-        }
-
-        return table
-    }
-
-    @computed private get missingDataStrategy(): MissingDataStrategy {
-        return this.manager.missingDataStrategy || MissingDataStrategy.auto
-    }
-
-    @computed get inputTable(): OwidTable {
-        return this.manager.table
+    @computed get chartState(): LineChartState {
+        return this.props.chartState
     }
 
     @computed get isStatic(): boolean {
         return this.manager.isStatic ?? false
     }
 
-    @computed private get transformedTableFromGrapher(): OwidTable {
-        return (
-            this.manager.transformedTable ??
-            this.transformTable(this.inputTable)
-        )
+    @computed get detailsOrderedByReference(): string[] {
+        return this.manager.detailsOrderedByReference ?? []
     }
 
-    @computed get transformedTable(): OwidTable {
-        let table = this.transformedTableFromGrapher
-        // The % growth transform cannot be applied in transformTable() because it will filter out
-        // any rows before startHandleTimeBound and change the timeline bounds.
-        const { isRelativeMode, startTime } = this.manager
-        if (isRelativeMode && startTime !== undefined) {
-            table = table.toTotalGrowthForEachColumnComparedToStartTime(
-                startTime,
-                this.manager.yColumnSlugs ?? []
-            )
-        }
-        return table
+    @computed get annotationsMap(): AnnotationsMap | undefined {
+        return getAnnotationsMap(
+            this.chartState.inputTable,
+            this.yColumnSlugs[0]
+        )
     }
 
     @action.bound private dismissTooltip(): void {
@@ -468,7 +132,7 @@ export class LineChart
         return this.placedSeries.flatMap((series) => series.points)
     }
 
-    @observable tooltipState = new TooltipState<{
+    @observable private tooltipState = new TooltipState<{
         x: number
     }>({ fade: "immediate" })
 
@@ -513,10 +177,10 @@ export class LineChart
     }
 
     @computed private get manager(): LineChartManager {
-        return this.props.manager
+        return this.chartState.manager
     }
 
-    @computed get bounds(): Bounds {
+    @computed private get bounds(): Bounds {
         return this.props.bounds ?? DEFAULT_GRAPHER_BOUNDS
     }
 
@@ -526,7 +190,7 @@ export class LineChart
         )
     }
 
-    @computed get maxLineLegendWidth(): number {
+    @computed private get maxLineLegendWidth(): number {
         return this.bounds.width / 3
     }
 
@@ -551,22 +215,20 @@ export class LineChart
         return DEFAULT_MARKER_RADIUS
     }
 
-    @computed get selectionArray(): SelectionArray {
-        return makeSelectionArray(this.manager.selection)
-    }
-
-    @computed get focusArray(): FocusArray {
+    @computed private get focusArray(): FocusArray {
         return this.manager.focusArray ?? new FocusArray()
     }
 
-    @computed get activeX(): number | undefined {
+    @computed private get activeX(): number | undefined {
         return (
             this.tooltipState.target?.x ??
-            this.props.manager.entityYearHighlight?.year
+            this.manager.entityYearHighlight?.year
         )
     }
 
-    @computed get activeXVerticalLine(): React.ReactElement | undefined {
+    @computed private get activeXVerticalLine():
+        | React.ReactElement
+        | undefined {
         const { activeX, dualAxis } = this
         const { horizontalAxis, verticalAxis } = dualAxis
 
@@ -589,7 +251,9 @@ export class LineChart
 
                     const valueColor = this.hasColorScale
                         ? darkenColorForLine(
-                              this.getColorScaleColor(value.colorValue)
+                              this.chartState.getColorScaleColor(
+                                  value.colorValue
+                              )
                           )
                         : series.color
                     const color =
@@ -735,7 +399,9 @@ export class LineChart
                             ? NON_FOCUSED_LINE_COLOR
                             : this.hasColorScale
                               ? darkenColorForLine(
-                                    this.getColorScaleColor(point?.colorValue)
+                                    this.chartState.getColorScaleColor(
+                                        point?.colorValue
+                                    )
                                 )
                               : series.color
                         const swatch = { color }
@@ -759,17 +425,17 @@ export class LineChart
         )
     }
 
-    defaultRightPadding = 1
+    private defaultRightPadding = 1
 
-    @observable lineLegendHoveredSeriesName?: SeriesName
+    @observable private lineLegendHoveredSeriesName?: SeriesName
     @observable private hoverTimer?: NodeJS.Timeout
 
-    @action.bound onLineLegendMouseOver(seriesName: SeriesName): void {
+    @action.bound private onLineLegendMouseOver(seriesName: SeriesName): void {
         clearTimeout(this.hoverTimer)
         this.lineLegendHoveredSeriesName = seriesName
     }
 
-    @action.bound clearHighlightedSeries(): void {
+    @action.bound private clearHighlightedSeries(): void {
         clearTimeout(this.hoverTimer)
         this.hoverTimer = setTimeout(() => {
             // wait before clearing selection in case the mouse is moving quickly over neighboring labels
@@ -777,18 +443,18 @@ export class LineChart
         }, 200)
     }
 
-    @action.bound onLineLegendMouseLeave(): void {
+    @action.bound private onLineLegendMouseLeave(): void {
         this.clearHighlightedSeries()
     }
 
-    @action.bound onLineLegendClick(seriesName: SeriesName): void {
+    @action.bound private onLineLegendClick(seriesName: SeriesName): void {
         this.focusArray.toggle(seriesName)
     }
 
-    @computed get hoveredSeriesNames(): string[] {
+    @computed private get hoveredSeriesNames(): string[] {
         const { externalLegendHoverBin } = this.manager
         const hoveredSeriesNames = excludeUndefined([
-            this.props.manager.entityYearHighlight?.entityName,
+            this.manager.entityYearHighlight?.entityName,
             this.lineLegendHoveredSeriesName,
         ])
         if (externalLegendHoverBin) {
@@ -801,7 +467,7 @@ export class LineChart
         return hoveredSeriesNames
     }
 
-    @computed get isHoverModeActive(): boolean {
+    @computed private get isHoverModeActive(): boolean {
         return (
             this.hoveredSeriesNames.length > 0 ||
             // if the external legend is hovered, we want to mute
@@ -811,19 +477,19 @@ export class LineChart
         )
     }
 
-    @computed get isFocusModeActive(): boolean {
+    @computed private get isFocusModeActive(): boolean {
         return !this.focusArray.isEmpty
     }
 
-    @computed get canToggleFocusMode(): boolean {
+    @computed private get canToggleFocusMode(): boolean {
         return !isTouchDevice() && this.series.length > 1
     }
 
     @computed private get hasEntityYearHighlight(): boolean {
-        return this.props.manager.entityYearHighlight !== undefined
+        return this.manager.entityYearHighlight !== undefined
     }
 
-    @action.bound onDocumentClick(e: MouseEvent): void {
+    @action.bound private onDocumentClick(e: MouseEvent): void {
         // only dismiss the tooltip if the click is outside of the chart area
         // and outside of the chart areas of neighbouring facets
         const chartContainer = this.manager.base?.current
@@ -839,7 +505,7 @@ export class LineChart
         }
     }
 
-    animSelection?: d3.Selection<
+    private animSelection?: d3.Selection<
         d3.BaseType,
         unknown,
         SVGGElement | null,
@@ -862,45 +528,41 @@ export class LineChart
         })
     }
 
-    @computed get renderUid(): number {
+    @computed private get renderUid(): number {
         return guid()
-    }
-
-    @computed get detailsOrderedByReference(): string[] {
-        return this.manager.detailsOrderedByReference ?? []
     }
 
     @computed get fontSize(): number {
         return this.manager.fontSize ?? BASE_FONT_SIZE
     }
 
-    @computed get fontWeight(): number {
+    @computed private get fontWeight(): number {
         return this.hasColorScale ? 700 : 400
     }
 
-    @computed get hidePoints(): boolean {
+    @computed private get hidePoints(): boolean {
         return !!this.manager.hidePoints
     }
 
-    @computed get lineLegendX(): number {
+    @computed private get lineLegendX(): number {
         return this.bounds.right - this.lineLegendWidth
     }
 
-    @computed get lineLegendY(): [number, number] {
+    @computed private get lineLegendY(): [number, number] {
         return [
             this.boundsWithoutColorLegend.top,
             this.boundsWithoutColorLegend.bottom,
         ]
     }
 
-    @computed get clipPathBounds(): Bounds {
+    @computed private get clipPathBounds(): Bounds {
         const { dualAxis, boundsWithoutColorLegend } = this
         return boundsWithoutColorLegend
             .set({ x: dualAxis.innerBounds.x })
             .expand(10)
     }
 
-    @computed get clipPath(): ClipPath {
+    @computed private get clipPath(): ClipPath {
         return makeClipPath({
             renderUid: this.renderUid,
             box: this.clipPathBounds,
@@ -933,21 +595,7 @@ export class LineChart
         })
     }
 
-    @computed get availableFacetStrategies(): FacetStrategy[] {
-        const strategies: FacetStrategy[] = [FacetStrategy.none]
-
-        if (this.selectionArray.numSelectedEntities > 1)
-            strategies.push(FacetStrategy.entity)
-
-        const numNonProjectionColumns = this.yColumns.filter(
-            (c) => !c.display?.isProjection
-        ).length
-        if (numNonProjectionColumns > 1) strategies.push(FacetStrategy.metric)
-
-        return strategies
-    }
-
-    renderDualAxis(): React.ReactElement {
+    private renderDualAxis(): React.ReactElement {
         const { manager, dualAxis } = this
 
         return (
@@ -960,15 +608,15 @@ export class LineChart
         )
     }
 
-    renderColorLegend(): React.ReactElement | void {
-        if (this.hasColorLegend)
-            return <HorizontalNumericColorLegend manager={this} />
+    private renderColorLegend(): React.ReactElement | null {
+        if (!this.hasColorLegend) return null
+        return <HorizontalNumericColorLegend manager={this} />
     }
 
     /**
      * Render the lines themselves and their labels
      */
-    renderChartElements(): React.ReactElement {
+    private renderChartElements(): React.ReactElement {
         const { manager } = this
         return (
             <>
@@ -1007,7 +655,7 @@ export class LineChart
         )
     }
 
-    renderStatic(): React.ReactElement {
+    private renderStatic(): React.ReactElement {
         return (
             <>
                 {this.renderColorLegend()}
@@ -1017,7 +665,7 @@ export class LineChart
         )
     }
 
-    renderInteractive(): React.ReactElement {
+    private renderInteractive(): React.ReactElement {
         return (
             <g
                 ref={this.base}
@@ -1053,14 +701,14 @@ export class LineChart
     render(): React.ReactElement {
         const { manager, dualAxis } = this
 
-        if (this.failMessage)
+        if (this.chartState.failMessage)
             return (
                 <g>
                     {this.renderDualAxis()}
                     <NoDataModal
                         manager={manager}
                         bounds={dualAxis.innerBounds}
-                        message={this.failMessage}
+                        message={this.chartState.failMessage}
                     />
                 </g>
             )
@@ -1068,75 +716,21 @@ export class LineChart
         return manager.isStatic ? this.renderStatic() : this.renderInteractive()
     }
 
-    @computed get failMessage(): string {
-        const message = getDefaultFailMessage(this.manager)
-        if (message) return message
-        if (!this.series.length) return "No matching data"
-        return ""
-    }
-
-    @computed private get yColumns(): CoreColumn[] {
-        return this.yColumnSlugs.map((slug) => this.transformedTable.get(slug))
-    }
-
     @computed protected get yColumnSlugs(): string[] {
-        return autoDetectYColumnSlugs(this.manager)
-    }
-
-    @computed private get colorColumnSlug(): string | undefined {
-        return this.manager.colorColumnSlug
+        return this.chartState.yColumnSlugs
     }
 
     @computed private get colorColumn(): CoreColumn {
-        return this.transformedTable.get(this.colorColumnSlug)
+        return this.chartState.colorColumn
     }
 
     @computed private get formatColumn(): CoreColumn {
-        return this.yColumns[0]
+        return this.chartState.yColumns[0]
     }
 
     @computed private get hasColorScale(): boolean {
-        return !this.colorColumn.isMissing
+        return this.chartState.hasColorScale
     }
-
-    // Color scale props
-
-    @computed get colorScaleColumn(): CoreColumn {
-        return (
-            // For faceted charts, we have to get the values of inputTable before it's filtered by
-            // the faceting logic.
-            this.manager.colorScaleColumnOverride ?? // We need to use inputTable in order to get consistent coloring for a variable across
-            // charts, e.g. each continent being assigned to the same color.
-            // inputTable is unfiltered, so it contains every value that exists in the variable.
-            this.inputTable.get(this.colorColumnSlug)
-        )
-    }
-
-    @computed get colorScaleConfig(): ColorScaleConfigInterface | undefined {
-        return (
-            ColorScaleConfig.fromDSL(this.colorColumn.def) ??
-            this.manager.colorScale
-        )
-    }
-
-    @computed get hasNoDataBin(): boolean {
-        if (!this.hasColorScale) return false
-        return this.colorColumn.valuesIncludingErrorValues.some(
-            (value) => !isNotErrorValue(value)
-        )
-    }
-
-    defaultBaseColorScheme = ColorSchemeName.OwidDistinctLines
-    defaultNoDataColor = OWID_NO_DATA_GRAY
-    colorScale = this.props.manager.colorScaleOverride ?? new ColorScale(this)
-
-    private getColorScaleColor(value: CoreValueType | undefined): Color {
-        return this.colorScale.getColor(value) ?? DEFAULT_LINE_COLOR
-    }
-
-    // End of color scale props
-
-    // Color legend props
 
     @computed private get hasColorLegend(): boolean {
         return this.hasColorScale && !!this.manager.showLegend
@@ -1152,6 +746,10 @@ export class LineChart
 
     @computed get legendAlign(): HorizontalAlign {
         return HorizontalAlign.center
+    }
+
+    @computed private get colorScale(): ColorScale {
+        return this.chartState.colorScale
     }
 
     // TODO just pass colorScale to legend and let it figure it out?
@@ -1172,7 +770,9 @@ export class LineChart
         return this.manager.backgroundColor ?? GRAPHER_BACKGROUND_DEFAULT
     }
 
-    @computed get numericLegend(): HorizontalNumericColorLegend | undefined {
+    @computed private get numericLegend():
+        | HorizontalNumericColorLegend
+        | undefined {
         return this.hasColorScale && this.manager.showLegend
             ? new HorizontalNumericColorLegend({ manager: this })
             : undefined
@@ -1194,126 +794,12 @@ export class LineChart
 
     // End of color legend props
 
-    @computed private get annotationsMap(): AnnotationsMap | undefined {
-        return getAnnotationsMap(this.inputTable, this.yColumnSlugs[0])
-    }
-
-    @computed private get colorScheme(): ColorScheme {
-        return (
-            (this.manager.baseColorScheme
-                ? ColorSchemes.get(this.manager.baseColorScheme)
-                : null) ?? ColorSchemes.get(this.defaultBaseColorScheme)
-        )
-    }
-
-    @computed get seriesStrategy(): SeriesStrategy {
-        return autoDetectSeriesStrategy(this.manager, true)
-    }
-
-    @computed get isLogScale(): boolean {
-        return this.yAxisConfig.scaleType === ScaleType.log
-    }
-
-    @computed private get categoricalColorAssigner(): CategoricalColorAssigner {
-        return new CategoricalColorAssigner({
-            colorScheme: this.colorScheme,
-            invertColorScheme: this.manager.invertColorScheme,
-            colorMap:
-                this.seriesStrategy === SeriesStrategy.entity
-                    ? this.inputTable.entityNameColorIndex
-                    : this.inputTable.columnDisplayNameToColorMap,
-            autoColorMapCache: this.manager.seriesColorMap,
-        })
-    }
-
-    private constructSingleSeries(
-        entityName: EntityName,
-        column: CoreColumn
-    ): LineChartSeries {
-        const {
-            manager: { canSelectMultipleEntities = false },
-            transformedTable: { availableEntityNames },
-            seriesStrategy,
-            hasColorScale,
-            colorColumn,
-        } = this
-
-        // Construct the points
-        const timeValues = column.originalTimeColumn.valuesIncludingErrorValues
-        const values = column.valuesIncludingErrorValues
-        const colorValues = colorColumn.valuesIncludingErrorValues
-        // If Y and Color are the same column, we need to get rid of any duplicate rows.
-        // Duplicates occur because Y doesn't have tolerance applied, but Color does.
-        const rowIndexes = _.sortedUniqBy(
-            this.transformedTable.rowIndicesByEntityName
-                .get(entityName)!
-                .filter((index) => _.isNumber(values[index])),
-            (index) => timeValues[index]
-        )
-        const points = rowIndexes.map((index) => {
-            const point: LinePoint = {
-                x: timeValues[index] as number,
-                y: values[index] as number,
-            }
-            if (hasColorScale) {
-                const colorValue = colorValues[index]
-                point.colorValue = isNotErrorValue(colorValue)
-                    ? colorValue
-                    : undefined
-            }
-            return point
-        })
-
-        // Construct series properties
-        const columnName = column.nonEmptyDisplayName
-        const seriesName = getSeriesName({
-            entityName,
-            columnName,
-            seriesStrategy,
-            availableEntityNames,
-            canSelectMultipleEntities,
-        })
-
-        let seriesColor: Color
-        if (hasColorScale) {
-            const colorValue = R.last(points)?.colorValue
-            seriesColor = this.getColorScaleColor(colorValue)
-        } else {
-            seriesColor = this.categoricalColorAssigner.assign(
-                getColorKey({
-                    entityName,
-                    columnName,
-                    seriesStrategy,
-                    availableEntityNames,
-                })
-            )
-        }
-
-        return {
-            points,
-            seriesName,
-            isProjection: column.isProjection,
-            plotMarkersOnly: column.display?.plotMarkersOnlyInLineChart,
-            color: seriesColor,
-        }
-    }
-
     @computed get series(): readonly LineChartSeries[] {
-        return this.yColumns.flatMap((col) =>
-            col.uniqEntityNames.map(
-                (entityName): LineChartSeries =>
-                    this.constructSingleSeries(entityName, col)
-            )
-        )
+        return this.chartState.series
     }
 
     @computed private get hasMarkersOnlySeries(): boolean {
         return this.series.some((series) => series.plotMarkersOnly)
-    }
-
-    // TODO: remove, seems unused
-    @computed get allPoints(): LinePoint[] {
-        return this.series.flatMap((series) => series.points)
     }
 
     @computed get placedSeries(): PlacedLineChartSeries[] {
@@ -1330,7 +816,9 @@ export class LineChart
                         y: _.round(verticalAxis.place(point.y), 1),
                         color: this.hasColorScale
                             ? darkenColorForLine(
-                                  this.getColorScaleColor(point.colorValue)
+                                  this.chartState.getColorScaleColor(
+                                      point.colorValue
+                                  )
                               )
                             : series.color,
                     })
@@ -1350,7 +838,7 @@ export class LineChart
         return this.focusArray.state(series.seriesName)
     }
 
-    @computed get renderSeries(): RenderLineChartSeries[] {
+    @computed private get renderSeries(): RenderLineChartSeries[] {
         let series: RenderLineChartSeries[] = this.placedSeries.map(
             (series) => {
                 return {
@@ -1375,7 +863,7 @@ export class LineChart
 
     // Order of the legend items on a line chart should visually correspond
     // to the order of the lines as the approach the legend
-    @computed get lineLegendSeries(): LineLabelSeries[] {
+    @computed private get lineLegendSeries(): LineLabelSeries[] {
         // If there are any projections, ignore non-projection legends (bit of a hack)
         let series = this.series
         if (series.some((series) => !!series.isProjection))
@@ -1409,28 +897,7 @@ export class LineChart
         })
     }
 
-    @computed private get xAxisConfig(): AxisConfig {
-        return new AxisConfig(
-            {
-                hideGridlines: true,
-                ...this.manager.xAxisConfig,
-            },
-            this
-        )
-    }
-
-    @computed private get horizontalAxisPart(): HorizontalAxis {
-        const axis = this.xAxisConfig.toHorizontalAxis()
-        axis.updateDomainPreservingUserSettings(
-            this.transformedTable.timeDomainFor(this.yColumnSlugs)
-        )
-        axis.scaleType = ScaleType.linear
-        axis.formatColumn = this.inputTable.timeColumn
-        axis.hideFractionalTicks = true
-        return axis
-    }
-
-    @computed private get yAxisConfig(): AxisConfig {
+    @computed get yAxisConfig(): AxisConfig {
         return new AxisConfig(
             {
                 nice: this.manager.yAxisConfig?.scaleType !== ScaleType.log,
@@ -1446,16 +913,39 @@ export class LineChart
         )
     }
 
+    @computed private get xAxisConfig(): AxisConfig {
+        return new AxisConfig(
+            {
+                hideGridlines: true,
+                ...this.manager.xAxisConfig,
+            },
+            this
+        )
+    }
+
+    @computed private get horizontalAxisPart(): HorizontalAxis {
+        const axis = this.xAxisConfig.toHorizontalAxis()
+        axis.updateDomainPreservingUserSettings(
+            this.chartState.transformedTable.timeDomainFor(this.yColumnSlugs)
+        )
+        axis.scaleType = ScaleType.linear
+        axis.formatColumn = this.chartState.inputTable.timeColumn
+        axis.hideFractionalTicks = true
+        return axis
+    }
+
     @computed private get verticalAxisPart(): VerticalAxis {
         const axisConfig = this.yAxisConfig
-        const yDomain = this.transformedTable.domainFor(this.yColumnSlugs)
+        const yDomain = this.chartState.transformedTable.domainFor(
+            this.yColumnSlugs
+        )
         const domain = axisConfig.domain
         const axis = axisConfig.toVerticalAxis()
         axis.updateDomainPreservingUserSettings([
             Math.min(domain[0], yDomain[0]),
             Math.max(domain[1], yDomain[1]),
         ])
-        axis.hideFractionalTicks = this.yColumns.every(
+        axis.hideFractionalTicks = this.chartState.yColumns.every(
             (yColumn) => yColumn.isAllIntegers
         ) // all y axis points are integral, don't show fractional ticks in that case
         axis.label = ""

--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChartConstants.ts
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChartConstants.ts
@@ -7,6 +7,26 @@ import {
 } from "@ourworldindata/types"
 import { ChartSeries } from "../chart/ChartInterface"
 import { Color } from "@ourworldindata/utils"
+import { OWID_NON_FOCUSED_GRAY } from "../color/ColorConstants"
+
+export const LINE_CHART_CLASS_NAME = "LineChart"
+
+// line color
+export const NON_FOCUSED_LINE_COLOR = OWID_NON_FOCUSED_GRAY
+export const DEFAULT_LINE_COLOR = "#000"
+// stroke width
+export const DEFAULT_STROKE_WIDTH = 1.5
+export const VARIABLE_COLOR_STROKE_WIDTH = 2.5
+// marker radius
+export const DEFAULT_MARKER_RADIUS = 1.8
+export const VARIABLE_COLOR_MARKER_RADIUS = 2.2
+export const DISCONNECTED_DOTS_MARKER_RADIUS = 2.6
+export const STATIC_SMALL_MARKER_RADIUS = 3
+// line outline
+export const DEFAULT_LINE_OUTLINE_WIDTH = 0.5
+export const VARIABLE_COLOR_LINE_OUTLINE_WIDTH = 1.0
+// legend
+export const LEGEND_PADDING = 25
 
 export interface LinePoint {
     x: number

--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChartState.ts
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChartState.ts
@@ -1,0 +1,309 @@
+import * as _ from "lodash-es"
+import * as R from "remeda"
+import { Color } from "@ourworldindata/utils"
+import { computed } from "mobx"
+import {
+    ScaleType,
+    EntityName,
+    SeriesStrategy,
+    FacetStrategy,
+    CoreValueType,
+    MissingDataStrategy,
+    ColorScaleConfigInterface,
+    ColorSchemeName,
+} from "@ourworldindata/types"
+import { ColorSchemes } from "../color/ColorSchemes"
+import { ChartState } from "../chart/ChartInterface"
+import {
+    LineChartSeries,
+    LineChartManager,
+    LinePoint,
+    DEFAULT_LINE_COLOR,
+} from "./LineChartConstants"
+import {
+    OwidTable,
+    CoreColumn,
+    isNotErrorValue,
+} from "@ourworldindata/core-table"
+import {
+    autoDetectSeriesStrategy,
+    autoDetectYColumnSlugs,
+    getDefaultFailMessage,
+    makeSelectionArray,
+} from "../chart/ChartUtils"
+import { ColorScheme } from "../color/ColorScheme"
+import { SelectionArray } from "../selection/SelectionArray"
+import { ColorScale, ColorScaleManager } from "../color/ColorScale"
+import { ColorScaleConfig } from "../color/ColorScaleConfig"
+import { OWID_NO_DATA_GRAY } from "../color/ColorConstants"
+import { CategoricalColorAssigner } from "../color/CategoricalColorAssigner"
+import { getColorKey, getSeriesName } from "./LineChartHelpers"
+
+export class LineChartState implements ChartState, ColorScaleManager {
+    manager: LineChartManager
+
+    colorScale: ColorScale
+    defaultBaseColorScheme = ColorSchemeName.OwidDistinctLines
+    defaultNoDataColor = OWID_NO_DATA_GRAY
+
+    constructor({ manager }: { manager: LineChartManager }) {
+        this.manager = manager
+        this.colorScale = manager.colorScaleOverride ?? new ColorScale(this)
+    }
+
+    @computed get inputTable(): OwidTable {
+        return this.manager.table
+    }
+
+    @computed get transformedTableFromGrapher(): OwidTable {
+        return (
+            this.manager.transformedTable ??
+            this.transformTable(this.inputTable)
+        )
+    }
+
+    @computed get transformedTable(): OwidTable {
+        let table = this.transformedTableFromGrapher
+        // The % growth transform cannot be applied in transformTable() because it will filter out
+        // any rows before startHandleTimeBound and change the timeline bounds.
+        const { isRelativeMode, startTime } = this.manager
+        if (isRelativeMode && startTime !== undefined) {
+            table = table.toTotalGrowthForEachColumnComparedToStartTime(
+                startTime,
+                this.manager.yColumnSlugs ?? []
+            )
+        }
+        return table
+    }
+
+    transformTable(table: OwidTable): OwidTable {
+        table = table.filterByEntityNames(
+            this.selectionArray.selectedEntityNames
+        )
+
+        // TODO: remove this filter once we don't have mixed type columns in datasets
+        // Currently we set skipParsing=true on these columns to be backwards-compatible
+        table = table.replaceNonNumericCellsWithErrorValues(this.yColumnSlugs)
+
+        if (this.isLogScale)
+            table = table.replaceNonPositiveCellsForLogScale(this.yColumnSlugs)
+
+        if (this.colorColumnSlug) {
+            table = table
+                // TODO: remove this filter once we don't have mixed type columns in datasets
+                // Currently we set skipParsing=true on these columns to be backwards-compatible
+                .replaceNonNumericCellsWithErrorValues([this.colorColumnSlug])
+                .interpolateColumnWithTolerance(this.colorColumnSlug)
+        }
+
+        // drop all data when the author chose to hide entities with missing data and
+        // at least one of the variables has no data for the current entity
+        if (
+            this.missingDataStrategy === MissingDataStrategy.hide &&
+            table.hasAnyColumnNoValidValue(this.yColumnSlugs)
+        ) {
+            table = table.dropAllRows()
+        }
+
+        return table
+    }
+
+    transformTableForSelection(table: OwidTable): OwidTable {
+        // if entities with partial data are not plotted,
+        // make sure they don't show up in the entity selector
+        if (this.missingDataStrategy === MissingDataStrategy.hide) {
+            table = table
+                .replaceNonNumericCellsWithErrorValues(this.yColumnSlugs)
+                .dropEntitiesThatHaveNoDataInSomeColumn(this.yColumnSlugs)
+        }
+
+        return table
+    }
+
+    @computed get selectionArray(): SelectionArray {
+        return makeSelectionArray(this.manager.selection)
+    }
+
+    @computed get yColumnSlugs(): string[] {
+        return autoDetectYColumnSlugs(this.manager)
+    }
+
+    @computed get colorColumnSlug(): string | undefined {
+        return this.manager.colorColumnSlug
+    }
+
+    @computed get yColumns(): CoreColumn[] {
+        return this.yColumnSlugs.map((slug) => this.transformedTable.get(slug))
+    }
+
+    @computed get colorColumn(): CoreColumn {
+        return this.transformedTable.get(this.colorColumnSlug)
+    }
+
+    @computed get isLogScale(): boolean {
+        return this.manager.yAxisConfig?.scaleType === ScaleType.log
+    }
+
+    @computed get colorScheme(): ColorScheme {
+        return (
+            (this.manager.baseColorScheme
+                ? ColorSchemes.get(this.manager.baseColorScheme)
+                : null) ?? ColorSchemes.get(this.defaultBaseColorScheme)
+        )
+    }
+
+    @computed get colorScaleColumn(): CoreColumn {
+        return (
+            // For faceted charts, we have to get the values of inputTable before it's filtered by
+            // the faceting logic.
+            this.manager.colorScaleColumnOverride ?? // We need to use inputTable in order to get consistent coloring for a variable across
+            // charts, e.g. each continent being assigned to the same color.
+            // inputTable is unfiltered, so it contains every value that exists in the variable.
+            this.inputTable.get(this.colorColumnSlug)
+        )
+    }
+
+    @computed get colorScaleConfig(): ColorScaleConfigInterface | undefined {
+        return (
+            ColorScaleConfig.fromDSL(this.colorColumn.def) ??
+            this.manager.colorScale
+        )
+    }
+
+    @computed get categoricalColorAssigner(): CategoricalColorAssigner {
+        return new CategoricalColorAssigner({
+            colorScheme: this.colorScheme,
+            invertColorScheme: this.manager.invertColorScheme,
+            colorMap:
+                this.seriesStrategy === SeriesStrategy.entity
+                    ? this.inputTable.entityNameColorIndex
+                    : this.inputTable.columnDisplayNameToColorMap,
+            autoColorMapCache: this.manager.seriesColorMap,
+        })
+    }
+
+    @computed get hasColorScale(): boolean {
+        return !this.colorColumn.isMissing
+    }
+
+    getColorScaleColor(value: CoreValueType | undefined): Color {
+        return this.colorScale.getColor(value) ?? DEFAULT_LINE_COLOR
+    }
+
+    @computed get hasNoDataBin(): boolean {
+        if (!this.hasColorScale) return false
+        return this.colorColumn.valuesIncludingErrorValues.some(
+            (value) => !isNotErrorValue(value)
+        )
+    }
+
+    @computed get missingDataStrategy(): MissingDataStrategy {
+        return this.manager.missingDataStrategy || MissingDataStrategy.auto
+    }
+
+    @computed get seriesStrategy(): SeriesStrategy {
+        return autoDetectSeriesStrategy(this.manager, true)
+    }
+
+    @computed get series(): readonly LineChartSeries[] {
+        return this.yColumns.flatMap((col) =>
+            col.uniqEntityNames.map(
+                (entityName): LineChartSeries =>
+                    this.constructSingleSeries(entityName, col)
+            )
+        )
+    }
+
+    @computed get availableFacetStrategies(): FacetStrategy[] {
+        const strategies: FacetStrategy[] = [FacetStrategy.none]
+
+        if (this.selectionArray.numSelectedEntities > 1)
+            strategies.push(FacetStrategy.entity)
+
+        const numNonProjectionColumns = this.yColumns.filter(
+            (c) => !c.display?.isProjection
+        ).length
+        if (numNonProjectionColumns > 1) strategies.push(FacetStrategy.metric)
+
+        return strategies
+    }
+
+    private constructSingleSeries(
+        entityName: EntityName,
+        column: CoreColumn
+    ): LineChartSeries {
+        const {
+            manager: { canSelectMultipleEntities = false },
+            transformedTable: { availableEntityNames },
+            seriesStrategy,
+            hasColorScale,
+            colorColumn,
+        } = this
+
+        // Construct the points
+        const timeValues = column.originalTimeColumn.valuesIncludingErrorValues
+        const values = column.valuesIncludingErrorValues
+        const colorValues = colorColumn.valuesIncludingErrorValues
+        // If Y and Color are the same column, we need to get rid of any duplicate rows.
+        // Duplicates occur because Y doesn't have tolerance applied, but Color does.
+        const rowIndexes = _.sortedUniqBy(
+            this.transformedTable.rowIndicesByEntityName
+                .get(entityName)!
+                .filter((index) => _.isNumber(values[index])),
+            (index) => timeValues[index]
+        )
+        const points = rowIndexes.map((index) => {
+            const point: LinePoint = {
+                x: timeValues[index] as number,
+                y: values[index] as number,
+            }
+            if (hasColorScale) {
+                const colorValue = colorValues[index]
+                point.colorValue = isNotErrorValue(colorValue)
+                    ? colorValue
+                    : undefined
+            }
+            return point
+        })
+
+        // Construct series properties
+        const columnName = column.nonEmptyDisplayName
+        const seriesName = getSeriesName({
+            entityName,
+            columnName,
+            seriesStrategy,
+            availableEntityNames,
+            canSelectMultipleEntities,
+        })
+
+        let seriesColor: Color
+        if (hasColorScale) {
+            const colorValue = R.last(points)?.colorValue
+            seriesColor = this.getColorScaleColor(colorValue)
+        } else {
+            seriesColor = this.categoricalColorAssigner.assign(
+                getColorKey({
+                    entityName,
+                    columnName,
+                    seriesStrategy,
+                    availableEntityNames,
+                })
+            )
+        }
+
+        return {
+            points,
+            seriesName,
+            isProjection: column.isProjection,
+            plotMarkersOnly: column.display?.plotMarkersOnlyInLineChart,
+            color: seriesColor,
+        }
+    }
+
+    @computed get failMessage(): string {
+        const message = getDefaultFailMessage(this.manager)
+        if (message) return message
+        if (!this.series.length) return "No matching data"
+        return ""
+    }
+}

--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChartThumbnail.tsx
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChartThumbnail.tsx
@@ -1,0 +1,27 @@
+import React from "react"
+import { Bounds } from "@ourworldindata/utils"
+import { computed } from "mobx"
+import { observer } from "mobx-react"
+import { ChartInterface } from "../chart/ChartInterface"
+import { LineChartState } from "./LineChartState"
+
+@observer
+export class LineChartThumbnail
+    extends React.Component<{
+        bounds?: Bounds
+        chartState: LineChartState
+    }>
+    implements ChartInterface
+{
+    @computed get chartState(): LineChartState {
+        return this.props.chartState
+    }
+
+    render(): React.ReactElement {
+        return (
+            <text x={15} y={30}>
+                Line chart thumbnail
+            </text>
+        )
+    }
+}

--- a/packages/@ourworldindata/grapher/src/lineCharts/Lines.tsx
+++ b/packages/@ourworldindata/grapher/src/lineCharts/Lines.tsx
@@ -1,0 +1,259 @@
+import * as _ from "lodash-es"
+import React from "react"
+import {
+    Bounds,
+    PointVector,
+    makeIdForHumanConsumption,
+    pointsToPath,
+} from "@ourworldindata/utils"
+import { computed } from "mobx"
+import { observer } from "mobx-react"
+import { GRAPHER_OPACITY_MUTE } from "../core/GrapherConstants"
+import {
+    DEFAULT_LINE_COLOR,
+    DEFAULT_LINE_OUTLINE_WIDTH,
+    DEFAULT_MARKER_RADIUS,
+    DEFAULT_STROKE_WIDTH,
+    LinesProps,
+    NON_FOCUSED_LINE_COLOR,
+    PlacedLineChartSeries,
+    RenderLineChartSeries,
+} from "./LineChartConstants"
+import { getSeriesKey } from "../chart/ChartUtils"
+import { GRAPHER_BACKGROUND_DEFAULT } from "../color/ColorConstants"
+import { MultiColorPolyline } from "../scatterCharts/MultiColorPolyline"
+
+@observer
+export class Lines extends React.Component<LinesProps> {
+    @computed get bounds(): Bounds {
+        const { horizontalAxis, verticalAxis } = this.props.dualAxis
+        return Bounds.fromCorners(
+            new PointVector(horizontalAxis.range[0], verticalAxis.range[0]),
+            new PointVector(horizontalAxis.range[1], verticalAxis.range[1])
+        )
+    }
+
+    @computed private get markerRadius(): number {
+        return this.props.markerRadius ?? DEFAULT_MARKER_RADIUS
+    }
+
+    @computed private get strokeWidth(): number {
+        return this.props.lineStrokeWidth ?? DEFAULT_STROKE_WIDTH
+    }
+
+    @computed private get outlineWidth(): number {
+        return this.props.lineOutlineWidth ?? DEFAULT_LINE_OUTLINE_WIDTH
+    }
+
+    @computed private get outlineColor(): string {
+        return this.props.backgroundColor ?? GRAPHER_BACKGROUND_DEFAULT
+    }
+
+    // Don't display point markers if there are very many of them for performance reasons
+    // Note that we're using circle elements instead of marker-mid because marker performance in Safari 10 is very poor for some reason
+    @computed private get hasMarkers(): boolean {
+        if (this.props.hidePoints) return false
+        const totalPoints = _.sum(
+            this.props.series
+                .filter((series) => this.seriesHasMarkers(series))
+                .map((series) => series.placedPoints.length)
+        )
+        return totalPoints < 500
+    }
+
+    @computed private get hasMarkersOnlySeries(): boolean {
+        return this.props.series.some((series) => series.plotMarkersOnly)
+    }
+
+    private seriesHasMarkers(series: RenderLineChartSeries): boolean {
+        if (
+            series.hover.background ||
+            series.isProjection ||
+            // if the series has a line, but there is another one that hasn't, then
+            // don't show markers since the plotted line is likely a smoothed version
+            (this.hasMarkersOnlySeries && !series.plotMarkersOnly)
+        )
+            return false
+        return !series.focus.background || series.hover.active
+    }
+
+    private renderLine(
+        series: RenderLineChartSeries
+    ): React.ReactElement | void {
+        const { hover, focus } = series
+
+        if (series.plotMarkersOnly) return
+
+        const seriesColor = series.placedPoints[0]?.color ?? DEFAULT_LINE_COLOR
+        const color =
+            !focus.background || hover.active
+                ? seriesColor
+                : NON_FOCUSED_LINE_COLOR
+
+        const strokeDasharray = series.isProjection ? "2,3" : undefined
+        const strokeWidth =
+            hover.background || focus.background
+                ? 0.66 * this.strokeWidth
+                : this.strokeWidth
+        const strokeOpacity =
+            hover.background && !focus.background ? GRAPHER_OPACITY_MUTE : 1
+
+        const showOutline = !focus.background || hover.active
+        const outlineColor = this.outlineColor
+        const outlineWidth = strokeWidth + this.outlineWidth * 2
+
+        const outline = (
+            <LinePath
+                id={makeIdForHumanConsumption("outline", series.seriesName)}
+                placedPoints={series.placedPoints}
+                stroke={outlineColor}
+                strokeWidth={outlineWidth.toFixed(1)}
+            />
+        )
+
+        const line =
+            this.props.multiColor && !focus.background ? (
+                <MultiColorPolyline
+                    id={makeIdForHumanConsumption("line", series.seriesName)}
+                    points={series.placedPoints}
+                    strokeLinejoin="round"
+                    strokeWidth={strokeWidth.toFixed(1)}
+                    strokeDasharray={strokeDasharray}
+                    strokeOpacity={strokeOpacity}
+                />
+            ) : (
+                <LinePath
+                    id={makeIdForHumanConsumption("line", series.seriesName)}
+                    placedPoints={series.placedPoints}
+                    stroke={color}
+                    strokeWidth={strokeWidth.toFixed(1)}
+                    strokeOpacity={strokeOpacity}
+                    strokeDasharray={strokeDasharray}
+                />
+            )
+
+        return (
+            <>
+                {showOutline && outline}
+                {line}
+            </>
+        )
+    }
+
+    private renderLineMarkers(
+        series: RenderLineChartSeries
+    ): React.ReactElement | void {
+        const { horizontalAxis } = this.props.dualAxis
+        const { hover, focus } = series
+
+        const forceMarkers =
+            // If the series only contains one point, then we will always want to
+            // show a marker/circle because we can't draw a line.
+            series.placedPoints.length === 1 ||
+            // If no line is plotted, we'll always want to show markers
+            series.plotMarkersOnly
+
+        // check if we should hide markers on the chart and series level
+        const hideMarkers = !this.hasMarkers || !this.seriesHasMarkers(series)
+
+        if (hideMarkers && !forceMarkers) return
+
+        const opacity =
+            hover.background && !focus.background ? GRAPHER_OPACITY_MUTE : 1
+
+        const outlineColor = series.plotMarkersOnly
+            ? this.outlineColor
+            : undefined
+        const outlineWidth = series.plotMarkersOnly
+            ? this.outlineWidth
+            : undefined
+
+        return (
+            <g id={makeIdForHumanConsumption("datapoints", series.seriesName)}>
+                {series.placedPoints.map((value, index) => {
+                    const valueColor = value.color
+                    const color =
+                        !focus.background || hover.active
+                            ? valueColor
+                            : NON_FOCUSED_LINE_COLOR
+                    return (
+                        <circle
+                            id={makeIdForHumanConsumption(
+                                horizontalAxis.formatTick(value.time)
+                            )}
+                            key={index}
+                            cx={value.x}
+                            cy={value.y}
+                            r={this.markerRadius}
+                            fill={color}
+                            stroke={outlineColor}
+                            strokeWidth={outlineWidth}
+                            opacity={opacity}
+                        />
+                    )
+                })}
+            </g>
+        )
+    }
+
+    private renderLines(): React.ReactElement {
+        return (
+            <>
+                {this.props.series.map((series, index) => (
+                    <React.Fragment key={getSeriesKey(series, index)}>
+                        {this.renderLine(series)}
+                        {this.renderLineMarkers(series)}
+                    </React.Fragment>
+                ))}
+            </>
+        )
+    }
+
+    private renderStatic(): React.ReactElement {
+        return (
+            <g id={makeIdForHumanConsumption("lines")}>{this.renderLines()}</g>
+        )
+    }
+
+    private renderInteractive(): React.ReactElement {
+        const { bounds } = this
+        return (
+            <g className="Lines">
+                <rect
+                    x={Math.round(bounds.x)}
+                    y={Math.round(bounds.y)}
+                    width={Math.round(bounds.width)}
+                    height={Math.round(bounds.height)}
+                    fill="rgba(255,255,255,0)"
+                    opacity={0}
+                />
+                {this.renderLines()}
+            </g>
+        )
+    }
+
+    render(): React.ReactElement {
+        return this.props.isStatic
+            ? this.renderStatic()
+            : this.renderInteractive()
+    }
+}
+
+interface LinePathProps extends React.SVGProps<SVGPathElement> {
+    placedPoints: PlacedLineChartSeries["placedPoints"]
+}
+
+function LinePath(props: LinePathProps): React.ReactElement {
+    const { placedPoints, ...pathProps } = props
+    const coords = placedPoints.map(({ x, y }) => [x, y] as [number, number])
+    return (
+        <path
+            fill="none"
+            strokeLinecap="butt"
+            strokeLinejoin="round"
+            stroke={DEFAULT_LINE_COLOR}
+            {...pathProps}
+            d={pointsToPath(coords)}
+        />
+    )
+}

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
@@ -53,7 +53,7 @@ import {
     GRAPHER_MAX_TOOLTIP_WIDTH,
     Patterns,
 } from "../core/GrapherConstants"
-import { ChartInterface } from "../chart/ChartInterface"
+import { ChartState } from "../chart/ChartInterface"
 import {
     CategoricalBin,
     ColorScaleBin,
@@ -93,10 +93,7 @@ interface MapChartProps {
 @observer
 export class MapChart
     extends Component<MapChartProps>
-    implements
-        ChartInterface,
-        HorizontalColorLegendManager,
-        ChoroplethMapManager
+    implements ChartState, HorizontalColorLegendManager, ChoroplethMapManager
 {
     /** The id of the currently hovered feature/country */
     @observable hoverFeatureId?: string

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapSparkline.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapSparkline.tsx
@@ -12,6 +12,7 @@ import {
 } from "@ourworldindata/types"
 import { OwidTable } from "@ourworldindata/core-table"
 import { LineChart } from "../lineCharts/LineChart"
+import { LineChartState } from "../lineCharts/LineChartState"
 import { Bounds, checkIsVeryShortUnit } from "@ourworldindata/utils"
 import { LineChartManager } from "../lineCharts/LineChartConstants"
 import { ColorScale } from "../color/ColorScale.js"
@@ -174,10 +175,14 @@ export class MapSparkline extends React.Component<{
         })
     }
 
+    @computed private get sparklineChartState(): LineChartState {
+        return new LineChartState({ manager: this.sparklineManager })
+    }
+
     @computed private get sparklineChart(): LineChart {
         return new LineChart({
-            manager: this.sparklineManager,
             bounds: this.sparklineBounds,
+            chartState: this.sparklineChartState,
         })
     }
 
@@ -230,8 +235,8 @@ export class MapSparkline extends React.Component<{
                         y2={axisBounds.y}
                     />
                     <LineChart
-                        manager={this.sparklineManager}
                         bounds={this.sparklineBounds}
+                        chartState={this.sparklineChartState}
                     />
                     {maxLabel !== minLabel && (
                         <g className="max axis-label">

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.test.ts
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.test.ts
@@ -150,7 +150,7 @@ describe("interpolation defaults", () => {
         colorSlug: "color",
         sizeSlug: "size",
     })
-    const chart = grapher.chartInstance as ScatterPlotChart
+    const chart = grapher.chartState as ScatterPlotChart
 
     it("color defaults to infinity tolerance if none specified", () => {
         expect(
@@ -207,7 +207,7 @@ describe("basic scatterplot", () => {
         sizeSlug: "size",
         table,
     })
-    const chart = grapher.chartInstance as ScatterPlotChart
+    const chart = grapher.chartState as ScatterPlotChart
 
     it("removes error values from X and Y", () => {
         expect(chart.transformedTable.numRows).toEqual(2)
@@ -438,7 +438,7 @@ describe("entity exclusion", () => {
         matchingEntitiesOnly: true,
         table,
     })
-    const chart = grapher.chartInstance as ScatterPlotChart
+    const chart = grapher.chartState as ScatterPlotChart
 
     it("excludes entities without color when matchingEntitiesOnly is enabled", () => {
         expect(chart.allPoints.length).toEqual(1)
@@ -827,7 +827,7 @@ describe("x/y tolerance", () => {
         sizeSlug: "size",
         table,
     })
-    const chart = grapher.chartInstance as ScatterPlotChart
+    const chart = grapher.chartState as ScatterPlotChart
 
     const transformedTable = chart.transformedTable
 
@@ -1073,7 +1073,7 @@ it("applies color tolerance before applying the author timeline filter", () => {
         sizeSlug: "size",
         timelineMaxTime: 2020,
     })
-    const chart = grapher.chartInstance as ScatterPlotChart
+    const chart = grapher.chartState as ScatterPlotChart
 
     expect(
         _.uniq(chart.transformedTable.get("color").valuesIncludingErrorValues)

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
@@ -61,7 +61,7 @@ import {
     NO_DATA_LABEL,
 } from "../color/ColorScale"
 import { AxisConfig } from "../axis/AxisConfig"
-import { ChartInterface } from "../chart/ChartInterface"
+import { ChartState } from "../chart/ChartInterface"
 import {
     ScatterPlotManager,
     ScatterSeries,
@@ -113,7 +113,7 @@ export class ScatterPlotChart
     implements
         ConnectedScatterLegendManager,
         ScatterSizeLegendManager,
-        ChartInterface,
+        ChartState,
         VerticalColorLegendManager,
         ColorScaleManager
 {

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
@@ -36,7 +36,7 @@ import {
     InteractionState,
     HorizontalAlign,
 } from "@ourworldindata/types"
-import { ChartInterface } from "../chart/ChartInterface"
+import { ChartState } from "../chart/ChartInterface"
 import { ChartManager } from "../chart/ChartManager"
 import { scaleLinear, ScaleLinear } from "d3-scale"
 import { select } from "d3-selection"
@@ -113,7 +113,7 @@ export class SlopeChart
         bounds?: Bounds
         manager: SlopeChartManager
     }>
-    implements ChartInterface
+    implements ChartState
 {
     private slopeAreaRef: React.RefObject<SVGGElement> = React.createRef()
     private defaultBaseColorScheme = ColorSchemeName.OwidDistinctLines

--- a/packages/@ourworldindata/grapher/src/stackedCharts/AbstractStackedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/AbstractStackedChart.tsx
@@ -1,6 +1,6 @@
 import { DualAxis, HorizontalAxis, VerticalAxis } from "../axis/Axis"
 import { AxisConfig, AxisManager } from "../axis/AxisConfig"
-import { ChartInterface } from "../chart/ChartInterface"
+import { ChartState } from "../chart/ChartInterface"
 import { ChartManager } from "../chart/ChartManager"
 import {
     ColorSchemeName,
@@ -65,7 +65,7 @@ export interface AbstractStackedChartProps {
 
 export abstract class AbstractStackedChart
     extends React.Component<AbstractStackedChartProps>
-    implements ChartInterface, AxisManager
+    implements ChartState, AxisManager
 {
     transformTable(table: OwidTable): OwidTable {
         table = table.filterByEntityNames(

--- a/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChart.tsx
@@ -26,7 +26,7 @@ import {
 import { DualAxisComponent } from "../axis/AxisViews"
 import { NoDataModal } from "../noDataModal/NoDataModal"
 import { AxisConfig } from "../axis/AxisConfig"
-import { ChartInterface } from "../chart/ChartInterface"
+import { ChartState } from "../chart/ChartInterface"
 import {
     EntityName,
     OwidVariableRow,
@@ -251,7 +251,7 @@ export class MarimekkoChart
         bounds?: Bounds
         manager: MarimekkoChartManager
     }>
-    implements ChartInterface, HorizontalColorLegendManager, ColorScaleManager
+    implements ChartState, HorizontalColorLegendManager, ColorScaleManager
 {
     base: React.RefObject<SVGGElement> = React.createRef()
 

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBarChart.tsx
@@ -40,7 +40,7 @@ import {
 } from "../axis/AxisViews"
 import { NoDataModal } from "../noDataModal/NoDataModal"
 import { AxisConfig } from "../axis/AxisConfig"
-import { ChartInterface } from "../chart/ChartInterface"
+import { ChartState } from "../chart/ChartInterface"
 import { OwidTable, CoreColumn } from "@ourworldindata/core-table"
 import {
     autoDetectYColumnSlugs,
@@ -128,7 +128,7 @@ export class StackedDiscreteBarChart
         bounds?: Bounds
         manager: StackedDiscreteBarChartManager
     }>
-    implements ChartInterface, HorizontalColorLegendManager
+    implements ChartState, HorizontalColorLegendManager
 {
     base: React.RefObject<SVGGElement> = React.createRef()
 


### PR DESCRIPTION
Extract state from line charts

Also updates all pieces around it:
- Extracts `ChartState` from `ChartInterface`
    - `ChartState` contains the tables and (un-placed) series
    - `ChartInterface` contains presentational stuff, like the axes and external legend
- Grapher's `chartInstance` is now a `chartState`
- Facet charts have also been updated accordingly

On this branch, all charts render as line charts, so tests are expected to fail! The PRs stacked on top of this one add back chart types one by one.