### PR TITLE
🔨 (admin) remove hiding element in export

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -256,11 +256,6 @@ export interface GrapherProgrammaticInterface extends GrapherInterface {
     baseFontSize?: number
     staticBounds?: Bounds
 
-    hideTitle?: boolean
-    hideSubtitle?: boolean
-    hideNote?: boolean
-    hideOriginUrl?: boolean
-
     hideEntityControls?: boolean
     hideZoomToggle?: boolean
     hideNoDataAreaToggle?: boolean
@@ -1619,12 +1614,8 @@ export class GrapherState {
         if (typeof window === "undefined") return []
 
         // extract details from supporting text
-        const subtitleDetails = !this.hideSubtitle
-            ? extractDetailsFromSyntax(this.currentSubtitle)
-            : []
-        const noteDetails = !this.hideNote
-            ? extractDetailsFromSyntax(this.note ?? "")
-            : []
+        const subtitleDetails = extractDetailsFromSyntax(this.currentSubtitle)
+        const noteDetails = extractDetailsFromSyntax(this.note ?? "")
 
         // extract details from axis labels
         const yAxisDetails = extractDetailsFromSyntax(
@@ -3380,11 +3371,6 @@ export class GrapherState {
     @computed private get numSelectableEntityNames(): number {
         return this.availableEntityNames.length
     }
-
-    @observable hideTitle = false
-    @observable hideSubtitle = false
-    @observable hideNote = false
-    @observable hideOriginUrl = false
 
     // For now I am only exposing this programmatically for the dashboard builder. Setting this to true
     // allows you to still use add country "modes" without showing the buttons in order to prioritize

--- a/packages/@ourworldindata/grapher/src/footer/Footer.tsx
+++ b/packages/@ourworldindata/grapher/src/footer/Footer.tsx
@@ -91,10 +91,6 @@ export class Footer<
         return this.manager.fontSize ?? BASE_FONT_SIZE
     }
 
-    @computed protected get hideOriginUrl(): boolean {
-        return !!this.manager.hideOriginUrl
-    }
-
     @computed protected get sourcesLine(): string {
         return this.manager.sourcesLine?.replace(/\r\n|\n|\r/g, "") ?? ""
     }
@@ -162,8 +158,6 @@ export class Footer<
             actionButtons,
         } = this
 
-        if (this.hideOriginUrl) return undefined
-
         if (!correctedUrlText) return undefined
 
         const licenseAndOriginUrlText = Footer.constructLicenseAndOriginUrlText(
@@ -212,7 +206,7 @@ export class Footer<
     }
 
     @computed protected get showNote(): boolean {
-        return !this.manager.hideNote && !!this.noteText
+        return !!this.noteText
     }
 
     @computed private get actionButtonsWidthWithIconsOnly(): number {
@@ -645,7 +639,7 @@ export class StaticFooter extends Footer<StaticFooterProps> {
     componentWillUnmount(): void {}
 
     @computed protected get hideOriginUrl(): boolean {
-        return !!this.manager.hideOriginUrl || !!this.manager.isStaticAndSmall
+        return !!this.manager.isStaticAndSmall
     }
 
     @computed private get textColor(): string {

--- a/packages/@ourworldindata/grapher/src/footer/FooterManager.ts
+++ b/packages/@ourworldindata/grapher/src/footer/FooterManager.ts
@@ -17,8 +17,6 @@ export interface FooterManager extends TooltipManager, ActionButtonsManager {
     isInFullScreenMode?: boolean
     isEmbeddedInAnOwidPage?: boolean
     isEmbeddedInADataPage?: boolean
-    hideNote?: boolean
-    hideOriginUrl?: boolean
     isStaticAndSmall?: boolean
     isSocialMediaExport?: boolean
     detailsMarkerInSvg?: DetailsMarker

--- a/packages/@ourworldindata/grapher/src/header/Header.tsx
+++ b/packages/@ourworldindata/grapher/src/header/Header.tsx
@@ -48,11 +48,11 @@ export class Header<
     }
 
     @computed protected get showTitle(): boolean {
-        return !this.manager.hideTitle && !!this.titleText
+        return !!this.titleText
     }
 
     @computed protected get showSubtitle(): boolean {
-        return !this.manager.hideSubtitle && !!this.subtitleText
+        return !!this.subtitleText
     }
 
     @computed protected get titleText(): string {

--- a/packages/@ourworldindata/grapher/src/header/HeaderManager.ts
+++ b/packages/@ourworldindata/grapher/src/header/HeaderManager.ts
@@ -20,8 +20,6 @@ export interface HeaderManager {
     isInIFrame?: boolean
     useBaseFontSize?: boolean
     fontSize?: number
-    hideTitle?: boolean
-    hideSubtitle?: boolean
     isStaticAndSmall?: boolean
     isSocialMediaExport?: boolean
     detailsMarkerInSvg?: DetailsMarker


### PR DESCRIPTION
The show/hide directives don't seem to be used by anyone, so I'm dropping them.

Only the 'Details on demand' option is kept because otherwise there wouldn't be a way on the export tab to hide them.

<img width="1682" height="858" alt="Screenshot 2025-07-14 at 11 32 20" src="https://github.com/user-attachments/assets/fb7ef85b-0cbf-460e-a3fa-2934a9fae7d1" />