### PR TITLE
🔨 ignore invalid chart types in a valid combination

### DIFF
--- a/packages/@ourworldindata/grapher/src/chart/ChartUtils.test.ts
+++ b/packages/@ourworldindata/grapher/src/chart/ChartUtils.test.ts
@@ -1,0 +1,41 @@
+import { expect, it, describe } from "vitest"
+import { findValidChartTypeCombination } from "./ChartUtils"
+import { GRAPHER_CHART_TYPES } from "@ourworldindata/types"
+
+const { LineChart, SlopeChart, ScatterPlot, StackedArea } = GRAPHER_CHART_TYPES
+
+describe(findValidChartTypeCombination, () => {
+    it("works for valid chart type combinations", () => {
+        const chartTypes = [LineChart, SlopeChart]
+        expect(findValidChartTypeCombination(chartTypes)).toEqual([
+            LineChart,
+            SlopeChart,
+        ])
+    })
+
+    it("orders chart types correctly", () => {
+        const chartTypes = [SlopeChart, LineChart]
+        expect(findValidChartTypeCombination(chartTypes)).toEqual([
+            LineChart,
+            SlopeChart,
+        ])
+    })
+
+    it("ignores invalid chart types in a combination", () => {
+        const chartTypes = [LineChart, ScatterPlot, SlopeChart]
+        expect(findValidChartTypeCombination(chartTypes)).toEqual([
+            LineChart,
+            SlopeChart,
+        ])
+    })
+
+    it("allows subsets of valid combinations", () => {
+        const chartTypes = [SlopeChart]
+        expect(findValidChartTypeCombination(chartTypes)).toEqual([SlopeChart])
+    })
+
+    it("returns undefined if no valid chart type combination is found", () => {
+        const chartTypes = [StackedArea, ScatterPlot]
+        expect(findValidChartTypeCombination(chartTypes)).toBeUndefined()
+    })
+})

--- a/packages/@ourworldindata/grapher/src/chart/ChartUtils.tsx
+++ b/packages/@ourworldindata/grapher/src/chart/ChartUtils.tsx
@@ -1,6 +1,5 @@
 import * as React from "react"
 import {
-    areSetsEqual,
     Box,
     getCountryByName,
     getTimeDomainFromQueryString,
@@ -240,16 +239,26 @@ export function mapChartTypeNameToTabOption(
     }
 }
 
+function findPotentialChartTypeSiblings(
+    chartTypes: GrapherChartType[]
+): GrapherChartType[] | undefined {
+    for (const validCombination of validChartTypeCombinations) {
+        const validSet: Set<GrapherChartType> = new Set(validCombination)
+        const hasIntersection = chartTypes.some((chartType) =>
+            validSet.has(chartType)
+        )
+        if (hasIntersection) return validCombination
+    }
+    return undefined
+}
+
 export function findValidChartTypeCombination(
     chartTypes: GrapherChartType[]
 ): GrapherChartType[] | undefined {
-    const chartTypeSet = new Set(chartTypes)
-    for (const validCombination of validChartTypeCombinations) {
-        const validCombinationSet = new Set(validCombination)
-        if (areSetsEqual(chartTypeSet, validCombinationSet))
-            return validCombination
-    }
-    return undefined
+    const validCombination = findPotentialChartTypeSiblings(chartTypes)
+    return validCombination?.filter((chartType) =>
+        chartTypes.includes(chartType)
+    )
 }
 
 export function getHoverStateForSeries(


### PR DESCRIPTION
It's convenient for the valid-chart-type-combination-picker to be a bit more robust before merging https://github.com/owid/owid-grapher/pull/4854.

In particular, if the only valid combination is [LineChart, SlopeChart] (as it is right now), and one more chart type is given, like [LineChart, SlopeChart, DiscreteBar], then DiscreteBar should just be ignored.