### PR TITLE
refactor: introduce explicit props interfaces for many react components

### DIFF
--- a/adminSiteClient/AdminLayout.tsx
+++ b/adminSiteClient/AdminLayout.tsx
@@ -14,13 +14,15 @@ import {
 } from "@ourworldindata/explorer"
 import classNames from "classnames"
 
-@observer
-export class AdminLayout extends React.Component<{
+interface AdminLayoutProps {
     noSidebar?: boolean
     hasFixedNav?: boolean
     title?: string
     children: React.ReactNode
-}> {
+}
+
+@observer
+export class AdminLayout extends React.Component<AdminLayoutProps> {
     static contextType = AdminAppContext
     context!: AdminAppContextType
     static defaultProps = { fixedNav: true }

--- a/adminSiteClient/ChartEditorPage.tsx
+++ b/adminSiteClient/ChartEditorPage.tsx
@@ -22,12 +22,14 @@ import { AdminAppContext, AdminAppContextType } from "./AdminAppContext.js"
 import { ChartEditorView, ChartEditorViewManager } from "./ChartEditorView.js"
 import { References } from "./AbstractChartEditor.js"
 
+interface ChartEditorPageProps {
+    grapherId?: number
+    grapherConfig?: GrapherInterface
+}
+
 @observer
 export class ChartEditorPage
-    extends React.Component<{
-        grapherId?: number
-        grapherConfig?: GrapherInterface
-    }>
+    extends React.Component<ChartEditorPageProps>
     implements ChartEditorManager, ChartEditorViewManager<ChartEditor>
 {
     static contextType = AdminAppContext

--- a/adminSiteClient/ChartEditorView.tsx
+++ b/adminSiteClient/ChartEditorView.tsx
@@ -98,12 +98,14 @@ export interface ChartEditorViewManager<Editor> {
     editor: Editor
 }
 
+interface ChartEditorViewProps<Editor> {
+    manager: ChartEditorViewManager<Editor>
+}
+
 @observer
 export class ChartEditorView<
     Editor extends AbstractChartEditor,
-> extends React.Component<{
-    manager: ChartEditorViewManager<Editor>
-}> {
+> extends React.Component<ChartEditorViewProps<Editor>> {
     @observable.ref database = new EditorDatabase({})
     @observable details: DetailDictionary = {}
     @computed get grapherState(): GrapherState {

--- a/adminSiteClient/ChartList.tsx
+++ b/adminSiteClient/ChartList.tsx
@@ -60,12 +60,14 @@ export type SortConfig = {
     direction: "asc" | "desc"
 } | null
 
-@observer
-export class ChartList extends React.Component<{
+interface ChartListProps {
     charts: ChartListItem[]
     autofocusSearchInput?: boolean
     onDelete?: (chart: ChartListItem) => void
-}> {
+}
+
+@observer
+export class ChartList extends React.Component<ChartListProps> {
     static contextType = AdminAppContext
     context!: AdminAppContextType
 

--- a/adminSiteClient/ChartRow.tsx
+++ b/adminSiteClient/ChartRow.tsx
@@ -20,14 +20,16 @@ import {
 } from "@ourworldindata/utils"
 import { Dropdown } from "antd"
 
-@observer
-export class ChartRow extends React.Component<{
+interface ChartRowProps {
     chart: ChartListItem
     searchHighlight?: (text: string) => string | React.ReactElement
     availableTags: DbChartTagJoin[]
     onDelete: (chart: ChartListItem) => void
     showInheritanceColumn?: boolean
-}> {
+}
+
+@observer
+export class ChartRow extends React.Component<ChartRowProps> {
     static contextType = AdminAppContext
     context!: AdminAppContextType
 

--- a/adminSiteClient/DatasetEditPage.tsx
+++ b/adminSiteClient/DatasetEditPage.tsx
@@ -79,11 +79,17 @@ class DatasetEditable {
     }
 }
 
-@observer
-class DatasetTagEditor extends Component<{
+interface DatasetTagEditorProps {
     newDataset: DatasetEditable
-    availableTags: { id: number; name: string; parentName: string }[]
-}> {
+    availableTags: {
+        id: number
+        name: string
+        parentName: string
+    }[]
+}
+
+@observer
+class DatasetTagEditor extends Component<DatasetTagEditorProps> {
     @action.bound onSaveTags(tags: DbChartTagJoin[]) {
         this.props.newDataset.tags = tags
     }
@@ -104,8 +110,12 @@ class DatasetTagEditor extends Component<{
     }
 }
 
+interface DatasetEditorProps {
+    dataset: DatasetPageData
+}
+
 @observer
-class DatasetEditor extends Component<{ dataset: DatasetPageData }> {
+class DatasetEditor extends Component<DatasetEditorProps> {
     static contextType = AdminAppContext
     context!: AdminAppContextType
     @observable newDataset!: DatasetEditable
@@ -396,8 +406,12 @@ class DatasetEditor extends Component<{ dataset: DatasetPageData }> {
     }
 }
 
+interface DatasetEditPageProps {
+    datasetId: number
+}
+
 @observer
-export class DatasetEditPage extends Component<{ datasetId: number }> {
+export class DatasetEditPage extends Component<DatasetEditPageProps> {
     static contextType = AdminAppContext
     context!: AdminAppContextType
     @observable dataset?: DatasetPageData

--- a/adminSiteClient/DatasetList.tsx
+++ b/adminSiteClient/DatasetList.tsx
@@ -27,12 +27,14 @@ export interface DatasetListItem {
     numCharts: number
 }
 
-@observer
-class DatasetRow extends React.Component<{
+interface DatasetRowProps {
     dataset: DatasetListItem
     availableTags: DbChartTagJoin[]
     searchHighlight?: (text: string) => string | React.ReactElement
-}> {
+}
+
+@observer
+class DatasetRow extends React.Component<DatasetRowProps> {
     static contextType = AdminAppContext
     context!: AdminAppContextType
 
@@ -97,11 +99,13 @@ class DatasetRow extends React.Component<{
     }
 }
 
-@observer
-export class DatasetList extends React.Component<{
+interface DatasetListProps {
     datasets: DatasetListItem[]
     searchHighlight?: (text: string) => string | React.ReactElement
-}> {
+}
+
+@observer
+export class DatasetList extends React.Component<DatasetListProps> {
     static contextType = AdminAppContext
     context!: AdminAppContextType
 

--- a/adminSiteClient/DimensionCard.tsx
+++ b/adminSiteClient/DimensionCard.tsx
@@ -24,10 +24,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
 import { OwidTable } from "@ourworldindata/core-table"
 import { AbstractChartEditor } from "./AbstractChartEditor.js"
 
-@observer
-export class DimensionCard<
-    Editor extends AbstractChartEditor,
-> extends Component<{
+interface DimensionCardProps<Editor> {
     dimension: ChartDimension
     editor: Editor
     isDndEnabled?: boolean
@@ -35,7 +32,12 @@ export class DimensionCard<
     onEdit?: () => void
     onRemove?: () => void
     errorMessage?: string
-}> {
+}
+
+@observer
+export class DimensionCard<
+    Editor extends AbstractChartEditor,
+> extends Component<DimensionCardProps<Editor>> {
     @observable.ref isExpanded: boolean = false
 
     @computed get table(): OwidTable {

--- a/adminSiteClient/EditTags.tsx
+++ b/adminSiteClient/EditTags.tsx
@@ -8,14 +8,16 @@ import {
     Tag as TagAutocomplete,
 } from "react-tag-autocomplete"
 
-@observer
-export class EditTags extends Component<{
+interface EditTagsProps {
     tags: DbChartTagJoin[]
     suggestions: DbChartTagJoin[]
     onDelete: (index: number) => void
     onAdd: (tag: DbChartTagJoin) => void
     onSave: () => void
-}> {
+}
+
+@observer
+export class EditTags extends Component<EditTagsProps> {
     dismissable: boolean = true
     reactTagsApi = createRef<ReactTagsAPI>()
 

--- a/adminSiteClient/EditableTags.tsx
+++ b/adminSiteClient/EditableTags.tsx
@@ -18,8 +18,7 @@ interface TaggableItem {
     type: TaggableType
 }
 
-@observer
-export class EditableTags extends React.Component<{
+interface EditableTagsProps {
     tags: DbChartTagJoin[]
     suggestions: DbChartTagJoin[]
     onSave: (tags: DbChartTagJoin[]) => void
@@ -27,7 +26,10 @@ export class EditableTags extends React.Component<{
     hasKeyChartSupport?: boolean
     hasSuggestionsSupport?: boolean
     taggable?: TaggableItem
-}> {
+}
+
+@observer
+export class EditableTags extends React.Component<EditableTagsProps> {
     static contextType = AdminAppContext
     context!: AdminAppContextType
 

--- a/adminSiteClient/EditorBasicTab.tsx
+++ b/adminSiteClient/EditorBasicTab.tsx
@@ -59,15 +59,17 @@ import { faCopy } from "@fortawesome/free-solid-svg-icons"
 import { Button } from "antd"
 import * as R from "remeda"
 
-@observer
-class DimensionSlotView<
-    Editor extends AbstractChartEditor,
-> extends React.Component<{
+interface DimensionSlotViewProps<Editor> {
     slot: DimensionSlot
     editor: Editor
     database: EditorDatabase
     errorMessagesForDimensions: ErrorMessagesForDimensions
-}> {
+}
+
+@observer
+class DimensionSlotView<
+    Editor extends AbstractChartEditor,
+> extends React.Component<DimensionSlotViewProps<Editor>> {
     disposers: IReactionDisposer[] = []
 
     @observable.ref isSelectingVariables: boolean = false
@@ -350,14 +352,16 @@ class DimensionSlotView<
     }
 }
 
-@observer
-class VariablesSection<
-    Editor extends AbstractChartEditor,
-> extends React.Component<{
+interface VariablesSectionProps<Editor> {
     editor: Editor
     database: EditorDatabase
     errorMessagesForDimensions: ErrorMessagesForDimensions
-}> {
+}
+
+@observer
+class VariablesSection<
+    Editor extends AbstractChartEditor,
+> extends React.Component<VariablesSectionProps<Editor>> {
     base: React.RefObject<HTMLDivElement> = React.createRef()
     @observable.ref isAddingVariable: boolean = false
 
@@ -424,14 +428,16 @@ const TagsSection = (props: {
     )
 }
 
-@observer
-export class EditorBasicTab<
-    Editor extends AbstractChartEditor,
-> extends React.Component<{
+interface EditorBasicTabProps<Editor> {
     editor: Editor
     database: EditorDatabase
     errorMessagesForDimensions: ErrorMessagesForDimensions
-}> {
+}
+
+@observer
+export class EditorBasicTab<
+    Editor extends AbstractChartEditor,
+> extends React.Component<EditorBasicTabProps<Editor>> {
     static contextType = AdminAppContext
     context!: AdminAppContextType
 

--- a/adminSiteClient/EditorColorScaleSection.tsx
+++ b/adminSiteClient/EditorColorScaleSection.tsx
@@ -40,14 +40,16 @@ interface EditorColorScaleSectionFeatures {
     legendDescription: boolean
 }
 
-@observer
-export class EditorColorScaleSection extends Component<{
+interface EditorColorScaleSectionProps {
     scale: ColorScale
     chartType: GrapherChartOrMapType
     features: EditorColorScaleSectionFeatures
     showLineChartColors: boolean
     onChange?: () => void
-}> {
+}
+
+@observer
+export class EditorColorScaleSection extends Component<EditorColorScaleSectionProps> {
     render() {
         return (
             <Fragment>
@@ -67,12 +69,14 @@ export class EditorColorScaleSection extends Component<{
     }
 }
 
-@observer
-class ColorLegendSection extends Component<{
+interface ColorLegendSectionProps {
     scale: ColorScale
     features: EditorColorScaleSectionFeatures
     onChange?: () => void
-}> {
+}
+
+@observer
+class ColorLegendSection extends Component<ColorLegendSectionProps> {
     @action.bound onManualBins() {
         populateManualBinValuesIfAutomatic(this.props.scale)
         this.props.onChange?.()
@@ -115,13 +119,15 @@ class ColorLegendSection extends Component<{
     }
 }
 
-@observer
-class ColorsSection extends Component<{
+interface ColorsSectionProps {
     scale: ColorScale
     chartType: GrapherChartOrMapType
     showLineChartColors: boolean
     onChange?: () => void
-}> {
+}
+
+@observer
+class ColorsSection extends Component<ColorsSectionProps> {
     @action.bound onColorScheme(selected: ColorSchemeOption) {
         const { config } = this
 
@@ -254,12 +260,14 @@ class ColorsSection extends Component<{
     }
 }
 
-@observer
-class ColorSchemeEditor extends Component<{
+interface ColorSchemeEditorProps {
     scale: ColorScale
     showLineChartColors: boolean
     onChange?: () => void
-}> {
+}
+
+@observer
+class ColorSchemeEditor extends Component<ColorSchemeEditorProps> {
     render() {
         const { scale } = this.props
         return (
@@ -298,13 +306,15 @@ class ColorSchemeEditor extends Component<{
     }
 }
 
-@observer
-class BinLabelView extends Component<{
+interface BinLabelViewProps {
     scale: ColorScale
     bin: ColorScaleBin
     index: number
     onChange?: () => void
-}> {
+}
+
+@observer
+class BinLabelView extends Component<BinLabelViewProps> {
     @action.bound onLabel(value: string) {
         if (this.props.bin instanceof NumericBin) {
             const { scale, index } = this.props
@@ -356,14 +366,16 @@ function populateManualBinValuesIfAutomatic(scale: ColorScale) {
     })
 }
 
-@observer
-class NumericBinView extends Component<{
+interface NumericBinViewProps {
     scale: ColorScale
     bin: NumericBin
     index: number
     showLineChartColors: boolean
     onChange?: () => void
-}> {
+}
+
+@observer
+class NumericBinView extends Component<NumericBinViewProps> {
     @action.bound onColor(color: Color | undefined) {
         const { scale, index } = this.props
 
@@ -483,13 +495,15 @@ class NumericBinView extends Component<{
     }
 }
 
-@observer
-class CategoricalBinView extends Component<{
+interface CategoricalBinViewProps {
     scale: ColorScale
     bin: CategoricalBin
     showLineChartColors: boolean
     onChange?: () => void
-}> {
+}
+
+@observer
+class CategoricalBinView extends Component<CategoricalBinViewProps> {
     @action.bound onColor(color: Color | undefined) {
         const { scale, bin } = this.props
         if (!scale.customNumericColorsActive) {

--- a/adminSiteClient/EditorCustomizeTab.tsx
+++ b/adminSiteClient/EditorCustomizeTab.tsx
@@ -116,11 +116,13 @@ class TimeField<
     }
 }
 
-@observer
-export class ColorSchemeSelector extends React.Component<{
+interface ColorSchemeSelectorProps {
     grapherState: GrapherState
     defaultValue?: ColorSchemeName
-}> {
+}
+
+@observer
+export class ColorSchemeSelector extends React.Component<ColorSchemeSelectorProps> {
     @action.bound onChange(selected: ColorSchemeOption) {
         // The onChange method can return an array of values (when multiple
         // items can be selected) or a single value. Since we are certain that
@@ -631,13 +633,15 @@ class ComparisonLineSection<
     }
 }
 
+interface EditorCustomizeTabProps<Editor> {
+    editor: Editor
+    errorMessages: ErrorMessages
+}
+
 @observer
 export class EditorCustomizeTab<
     Editor extends AbstractChartEditor,
-> extends React.Component<{
-    editor: Editor
-    errorMessages: ErrorMessages
-}> {
+> extends React.Component<EditorCustomizeTabProps<Editor>> {
     @computed get errorMessages() {
         return this.props.errorMessages
     }

--- a/adminSiteClient/EditorHistoryTab.tsx
+++ b/adminSiteClient/EditorHistoryTab.tsx
@@ -52,11 +52,13 @@ function LogCompareModal({
     )
 }
 
-@observer
-class LogRenderer extends Component<{
+interface LogRendererProps {
     log: Log
     previousLog: Log | undefined
-}> {
+}
+
+@observer
+class LogRenderer extends Component<LogRendererProps> {
     @observable isCompareModalOpen = false
 
     @computed get title() {

--- a/adminSiteClient/EditorMapTab.tsx
+++ b/adminSiteClient/EditorMapTab.tsx
@@ -20,12 +20,14 @@ import { AbstractChartEditor } from "./AbstractChartEditor.js"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faLink } from "@fortawesome/free-solid-svg-icons"
 
-@observer
-class VariableSection extends Component<{
+interface VariableSectionProps {
     mapConfig: MapConfig
     filledDimensions: ChartDimension[]
     parentConfig?: GrapherInterface
-}> {
+}
+
+@observer
+class VariableSection extends Component<VariableSectionProps> {
     @action.bound onColumnSlug(columnSlug: ColumnSlug) {
         this.props.mapConfig.columnSlug = columnSlug
     }

--- a/adminSiteClient/EditorReferencesTab.tsx
+++ b/adminSiteClient/EditorReferencesTab.tsx
@@ -224,11 +224,15 @@ export class EditorReferencesTabForNarrativeChart extends Component<{
     }
 }
 
-@observer
-class AddRedirectForm<Editor extends AbstractChartEditor> extends Component<{
+interface AddRedirectFormProps<Editor> {
     editor: Editor
     onSuccess: (redirect: ChartRedirect) => void
-}> {
+}
+
+@observer
+class AddRedirectForm<Editor extends AbstractChartEditor> extends Component<
+    AddRedirectFormProps<Editor>
+> {
     static contextType = AdminAppContext
     context!: AdminAppContextType
 

--- a/adminSiteClient/EditorTextTab.tsx
+++ b/adminSiteClient/EditorTextTab.tsx
@@ -26,10 +26,15 @@ import {
     ADMIN_BASE_URL,
 } from "../settings/clientSettings.js"
 
+interface EditorTextTabProps<Editor> {
+    editor: Editor
+    errorMessages: ErrorMessages
+}
+
 @observer
 export class EditorTextTab<
     Editor extends AbstractChartEditor,
-> extends Component<{ editor: Editor; errorMessages: ErrorMessages }> {
+> extends Component<EditorTextTabProps<Editor>> {
     @action.bound onSlug(slug: string) {
         this.props.editor.grapherState.slug = slugify(slug)
     }

--- a/adminSiteClient/ExplorerCreatePage.tsx
+++ b/adminSiteClient/ExplorerCreatePage.tsx
@@ -35,11 +35,13 @@ const RESERVED_NAMES = [DefaultNewExplorerSlug, "index", "new", "create"] // don
 // Register all Handsontable modules
 registerAllModules()
 
-@observer
-export class ExplorerCreatePage extends Component<{
+interface ExplorerCreatePageProps {
     slug: string
     manager?: AdminManager
-}> {
+}
+
+@observer
+export class ExplorerCreatePage extends Component<ExplorerCreatePageProps> {
     static contextType = AdminAppContext
     context!: AdminAppContextType
     disposers: Array<() => void> = []

--- a/adminSiteClient/ExplorersListPage.tsx
+++ b/adminSiteClient/ExplorersListPage.tsx
@@ -24,12 +24,14 @@ import { BAKED_BASE_URL } from "../settings/clientSettings.js"
 import { AdminManager } from "./AdminManager.js"
 import { AdminAppContext, AdminAppContextType } from "./AdminAppContext.js"
 
-@observer
-class ExplorerRow extends Component<{
+interface ExplorerRowProps {
     explorer: ExplorerProgram
     indexPage: ExplorersIndexPage
     searchHighlight?: (text: string) => any
-}> {
+}
+
+@observer
+class ExplorerRow extends Component<ExplorerRowProps> {
     render() {
         const { explorer, searchHighlight, indexPage } = this.props
         const {
@@ -124,12 +126,14 @@ class ExplorerRow extends Component<{
     }
 }
 
-@observer
-class ExplorerList extends Component<{
+interface ExplorerListProps {
     explorers: ExplorerProgram[]
     searchHighlight?: (text: string) => any
     indexPage: ExplorersIndexPage
-}> {
+}
+
+@observer
+class ExplorerList extends Component<ExplorerListProps> {
     render() {
         const { props } = this
         return (

--- a/adminSiteClient/Forms.tsx
+++ b/adminSiteClient/Forms.tsx
@@ -642,12 +642,14 @@ export class EditableListItem extends React.Component<EditableListItemProps> {
     }
 }
 
-@observer
-export class ColorBox extends React.Component<{
+interface ColorBoxProps {
     color: string | undefined
     onColor: (color: string | undefined) => void
     showLineChartColors: boolean
-}> {
+}
+
+@observer
+export class ColorBox extends React.Component<ColorBoxProps> {
     render() {
         const { color } = this.props
 
@@ -716,11 +718,13 @@ const ErrorMessage = ({ message }: { message: string }) => (
     <div style={{ color: "red" }}>{message}</div>
 )
 
-@observer
-class SoftCharacterLimit extends React.Component<{
+interface SoftCharacterLimitProps {
     text: string
     limit: number
-}> {
+}
+
+@observer
+class SoftCharacterLimit extends React.Component<SoftCharacterLimitProps> {
     render() {
         const { text, limit } = this.props
         return (
@@ -777,8 +781,7 @@ export class AutoTextField extends React.Component<AutoTextFieldProps> {
     }
 }
 
-@observer
-export class BindString extends React.Component<{
+interface BindStringProps {
     field: string
     store: Record<string, any>
     label?: React.ReactNode
@@ -793,7 +796,10 @@ export class BindString extends React.Component<{
     buttonContent?: React.ReactChild
     onButtonClick?: () => void
     onBlur?: () => void
-}> {
+}
+
+@observer
+export class BindString extends React.Component<BindStringProps> {
     @action.bound onValue(value: string = "") {
         this.props.store[this.props.field] = value
     }
@@ -832,8 +838,7 @@ export class BindString extends React.Component<{
     }
 }
 
-@observer
-export class BindStringArray extends React.Component<{
+interface BindStringArrayProps {
     field: string
     store: Record<string, any>
     label?: React.ReactNode
@@ -846,7 +851,10 @@ export class BindStringArray extends React.Component<{
     errorMessage?: string
     buttonContent?: React.ReactChild
     onButtonClick?: () => void
-}> {
+}
+
+@observer
+export class BindStringArray extends React.Component<BindStringArrayProps> {
     @action.bound onValue(value: string = "") {
         this.props.store[this.props.field] = parseBulletList(value)
     }
@@ -866,14 +874,19 @@ export class BindStringArray extends React.Component<{
     }
 }
 
-@observer
-export class BindDropdown extends React.Component<{
+interface BindDropdownProps {
     field: string
     store: Record<string, any>
     label?: React.ReactNode
-    options: Array<{ value: string; label: string }>
+    options: Array<{
+        value: string
+        label: string
+    }>
     disabled?: boolean
-}> {
+}
+
+@observer
+export class BindDropdown extends React.Component<BindDropdownProps> {
     @action.bound onChange(event: React.ChangeEvent<HTMLSelectElement>) {
         const value = event.target.value
         this.props.store[this.props.field] = value
@@ -902,11 +915,7 @@ export class BindDropdown extends React.Component<{
     }
 }
 
-@observer
-export class BindAutoString<
-    T extends { [field: string]: any },
-    K extends Extract<keyof T, string>,
-> extends React.Component<{
+interface BindAutoStringProps<K, T> {
     field: K
     store: T
     auto: string
@@ -917,7 +926,13 @@ export class BindAutoString<
     onBlur?: () => void
     placeholder?: string
     textarea?: boolean
-}> {
+}
+
+@observer
+export class BindAutoString<
+    T extends { [field: string]: any },
+    K extends Extract<keyof T, string>,
+> extends React.Component<BindAutoStringProps<K, T>> {
     @action.bound onValue(value: string) {
         this.props.store[this.props.field] = value as any
     }
@@ -976,20 +991,18 @@ export class BindAutoString<
     />
     ```
  */
+
+type BindAutoStringExtProps<T> = {
+    readFn: (x: T) => string
+    writeFn: (x: T, value: string | undefined) => void
+    store: T
+    auto?: string
+} & Omit<AutoTextFieldProps, "onValue" | "onToggleAuto" | "value" | "isBlur">
+
 @observer
 export class BindAutoStringExt<
     T extends Record<string, any>,
-> extends React.Component<
-    {
-        readFn: (x: T) => string
-        writeFn: (x: T, value: string | undefined) => void
-        store: T
-        auto?: string
-    } & Omit<
-        AutoTextFieldProps,
-        "onValue" | "onToggleAuto" | "value" | "isBlur"
-    >
-> {
+> extends React.Component<BindAutoStringExtProps<T>> {
     @action.bound onValue(value: string | undefined = "") {
         this.props.writeFn(this.props.store, value)
     }
@@ -1199,11 +1212,14 @@ export class BindAutoFloatExt<
     }
 }
 
-@observer
-export class Modal extends React.Component<{
+interface ModalProps {
+    children: React.ReactNode
     className?: string
     onClose: () => void
-}> {
+}
+
+@observer
+export class Modal extends React.Component<ModalProps> {
     base: React.RefObject<HTMLDivElement> = React.createRef()
     dismissable: boolean = true
 
@@ -1322,11 +1338,13 @@ export function LoadingBlocker() {
     )
 }
 
-@observer
-export class Timeago extends React.Component<{
+interface TimeagoProps {
     time: dayjs.ConfigType
     by?: string | React.ReactElement | null | undefined
-}> {
+}
+
+@observer
+export class Timeago extends React.Component<TimeagoProps> {
     render() {
         return (
             <>
@@ -1337,11 +1355,13 @@ export class Timeago extends React.Component<{
     }
 }
 
-@observer
-export class Button extends React.Component<{
-    children: any
+interface ButtonProps {
+    children: React.ReactNode
     onClick: () => void
-}> {
+}
+
+@observer
+export class Button extends React.Component<ButtonProps> {
     render() {
         return (
             <button className="btn btn-link" onClick={this.props.onClick}>

--- a/adminSiteClient/GdocsIndexPage.tsx
+++ b/adminSiteClient/GdocsIndexPage.tsx
@@ -53,11 +53,15 @@ enum GdocPublishStatus {
     Unpublished = "unpublished",
 }
 
-@observer
-class GdocsIndexPageSearch extends React.Component<{
+interface GdocsIndexPageSearchProps {
     filters: GdocsSearchFilters
-    search: { value: string }
-}> {
+    search: {
+        value: string
+    }
+}
+
+@observer
+class GdocsIndexPageSearch extends React.Component<GdocsIndexPageSearchProps> {
     toggleGdocTypeFilter = (type: OwidGdocType) => {
         this.props.filters[type] = !this.props.filters[type]
     }

--- a/adminSiteClient/NarrativeChartEditorPage.tsx
+++ b/adminSiteClient/NarrativeChartEditorPage.tsx
@@ -12,12 +12,14 @@ import {
 } from "./NarrativeChartEditor.js"
 import { References } from "./AbstractChartEditor.js"
 
+interface NarrativeChartEditorPageProps {
+    narrativeChartId: number
+    history: History
+}
+
 @observer
 export class NarrativeChartEditorPage
-    extends React.Component<{
-        narrativeChartId: number
-        history: History
-    }>
+    extends React.Component<NarrativeChartEditorPageProps>
     implements
         NarrativeChartEditorManager,
         ChartEditorViewManager<NarrativeChartEditor>

--- a/adminSiteClient/RedirectsIndexPage.tsx
+++ b/adminSiteClient/RedirectsIndexPage.tsx
@@ -13,11 +13,13 @@ interface RedirectListItem {
     chartSlug: string
 }
 
-@observer
-class RedirectRow extends Component<{
+interface RedirectRowProps {
     redirect: RedirectListItem
     onDelete: (redirect: RedirectListItem) => void
-}> {
+}
+
+@observer
+class RedirectRow extends Component<RedirectRowProps> {
     static contextType = AdminAppContext
     context!: AdminAppContextType
 

--- a/adminSiteClient/SaveButtons.tsx
+++ b/adminSiteClient/SaveButtons.tsx
@@ -20,12 +20,16 @@ import {
 import { NarrativeChartNameModal } from "./NarrativeChartNameModal.js"
 import { CreateDataInsightModal } from "./CreateDataInsightModal.js"
 
-@observer
-export class SaveButtons<Editor extends AbstractChartEditor> extends Component<{
+interface SaveButtonsProps<Editor extends AbstractChartEditor> {
     editor: Editor
     errorMessages: ErrorMessages
     errorMessagesForDimensions: ErrorMessagesForDimensions
-}> {
+}
+
+@observer
+export class SaveButtons<Editor extends AbstractChartEditor> extends Component<
+    SaveButtonsProps<Editor>
+> {
     render() {
         const { editor } = this.props
         const passthroughProps = _.omit(this.props, "editor")
@@ -50,11 +54,7 @@ export class SaveButtons<Editor extends AbstractChartEditor> extends Component<{
 }
 
 @observer
-class SaveButtonsForChart extends Component<{
-    editor: ChartEditor
-    errorMessages: ErrorMessages
-    errorMessagesForDimensions: ErrorMessagesForDimensions
-}> {
+class SaveButtonsForChart extends Component<SaveButtonsProps<ChartEditor>> {
     @action.bound onSaveChart() {
         void this.props.editor.saveGrapher()
     }
@@ -173,11 +173,9 @@ class SaveButtonsForChart extends Component<{
 }
 
 @observer
-class SaveButtonsForIndicatorChart extends Component<{
-    editor: IndicatorChartEditor
-    errorMessages: ErrorMessages
-    errorMessagesForDimensions: ErrorMessagesForDimensions
-}> {
+class SaveButtonsForIndicatorChart extends Component<
+    SaveButtonsProps<IndicatorChartEditor>
+> {
     @action.bound onSaveChart() {
         void this.props.editor.saveGrapher()
     }
@@ -223,11 +221,9 @@ class SaveButtonsForIndicatorChart extends Component<{
 }
 
 @observer
-class SaveButtonsForNarrativeChart extends Component<{
-    editor: NarrativeChartEditor
-    errorMessages: ErrorMessages
-    errorMessagesForDimensions: ErrorMessagesForDimensions
-}> {
+class SaveButtonsForNarrativeChart extends Component<
+    SaveButtonsProps<NarrativeChartEditor>
+> {
     @observable isCreateDataInsightModalOpen = false
 
     @action.bound onSaveChart() {

--- a/adminSiteClient/TagBadge.tsx
+++ b/adminSiteClient/TagBadge.tsx
@@ -9,13 +9,15 @@ import cx from "classnames"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
 import { faClock } from "@fortawesome/free-solid-svg-icons"
 
-@observer
-export class TagBadge extends React.Component<{
+interface TagBadgeProps {
     tag: DbChartTagJoin
     onToggleKey?: () => void
     onApprove?: () => void
     searchHighlight?: (text: string) => string | React.ReactElement
-}> {
+}
+
+@observer
+export class TagBadge extends React.Component<TagBadgeProps> {
     levelToDesc(level?: KeyChartLevel) {
         switch (level) {
             case KeyChartLevel.Bottom:

--- a/adminSiteClient/TagGraphPage.tsx
+++ b/adminSiteClient/TagGraphPage.tsx
@@ -83,13 +83,15 @@ function DraggableDroppable(props: {
     )
 }
 
-@observer
-class AddChildForm extends React.Component<{
+interface AddChildFormProps {
     tags: MinimalTagWithIsTopic[]
     label: string
     setChild: (parentId: number, childId: number) => void
     parentId: number
-}> {
+}
+
+@observer
+class AddChildForm extends React.Component<AddChildFormProps> {
     @observable isAddingTag: boolean = false
     @observable autocompleteValue: string = ""
 
@@ -149,8 +151,7 @@ class AddChildForm extends React.Component<{
     }
 }
 
-@observer
-class TagGraphNodeContainer extends React.Component<{
+interface TagGraphNodeContainerProps {
     node: TagGraphNode
     parentId: number
     setWeight: (parentId: number, childId: number, weight: number) => void
@@ -159,7 +160,10 @@ class TagGraphNodeContainer extends React.Component<{
     tags: MinimalTagWithIsTopic[]
     parentsById: Record<string, MinimalTagWithIsTopic[]>
     disableDroppable?: boolean
-}> {
+}
+
+@observer
+class TagGraphNodeContainer extends React.Component<TagGraphNodeContainerProps> {
     constructor(props: any) {
         super(props)
         this.handleUpdateWeight = this.handleUpdateWeight.bind(this)

--- a/adminSiteClient/VariableList.tsx
+++ b/adminSiteClient/VariableList.tsx
@@ -19,12 +19,14 @@ export interface VariableListItem {
     nonRedistributable?: boolean
 }
 
-@observer
-class VariableRow extends React.Component<{
+interface VariableRowProps {
     variable: VariableListItem
     fields: string[]
     searchHighlight?: (text: string) => string | React.ReactElement
-}> {
+}
+
+@observer
+class VariableRow extends React.Component<VariableRowProps> {
     static contextType = AdminAppContext
     context!: AdminAppContextType
 
@@ -86,12 +88,14 @@ class VariableRow extends React.Component<{
     }
 }
 
-@observer
-export class VariableList extends React.Component<{
+interface VariableListProps {
     variables: VariableListItem[]
     fields: string[]
     searchHighlight?: (text: string) => string | React.ReactElement
-}> {
+}
+
+@observer
+export class VariableList extends React.Component<VariableListProps> {
     static contextType = AdminAppContext
     context!: AdminAppContextType
 

--- a/packages/@ourworldindata/grapher/src/axis/AxisViews.tsx
+++ b/packages/@ourworldindata/grapher/src/axis/AxisViews.tsx
@@ -21,13 +21,15 @@ const TICK_COLOR = "#ddd"
 const FAINT_TICK_COLOR = "#eee"
 const SOLID_TICK_COLOR = "#999"
 
-@observer
-export class VerticalAxisGridLines extends React.Component<{
+interface VerticalAxisGridLinesProps {
     verticalAxis: VerticalAxis
     bounds: Bounds
     strokeWidth?: number
     dashPattern?: string
-}> {
+}
+
+@observer
+export class VerticalAxisGridLines extends React.Component<VerticalAxisGridLinesProps> {
     render(): React.ReactElement {
         const { bounds, verticalAxis, strokeWidth } = this.props
         const axis = verticalAxis.clone()
@@ -67,13 +69,15 @@ export class VerticalAxisGridLines extends React.Component<{
     }
 }
 
-@observer
-export class HorizontalAxisGridLines extends React.Component<{
+interface HorizontalAxisGridLinesProps {
     horizontalAxis: HorizontalAxis
     bounds?: Bounds
     strokeWidth?: number
     dashPattern?: string
-}> {
+}
+
+@observer
+export class HorizontalAxisGridLines extends React.Component<HorizontalAxisGridLinesProps> {
     @computed get bounds(): Bounds {
         return this.props.bounds ?? DEFAULT_BOUNDS
     }
@@ -118,13 +122,15 @@ export class HorizontalAxisGridLines extends React.Component<{
     }
 }
 
-@observer
-export class HorizontalAxisZeroLine extends React.Component<{
+interface HorizontalAxisZeroLineProps {
     horizontalAxis: HorizontalAxis
     bounds: Bounds
     strokeWidth?: number
     align?: HorizontalAlign
-}> {
+}
+
+@observer
+export class HorizontalAxisZeroLine extends React.Component<HorizontalAxisZeroLineProps> {
     render(): React.ReactElement {
         const {
             bounds,
@@ -248,15 +254,17 @@ export class DualAxisComponent extends React.Component<DualAxisViewProps> {
     }
 }
 
-@observer
-export class VerticalAxisComponent extends React.Component<{
+interface VerticalAxisComponentProps {
     bounds: Bounds
     verticalAxis: VerticalAxis
     showTickMarks?: boolean
     labelColor?: string
     tickColor?: string
     detailsMarker?: DetailsMarker
-}> {
+}
+
+@observer
+export class VerticalAxisComponent extends React.Component<VerticalAxisComponentProps> {
     render(): React.ReactElement {
         const {
             bounds,

--- a/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChart.tsx
@@ -97,12 +97,14 @@ interface DiscreteBarItem {
     color?: Color
 }
 
+interface DiscreteBarChartProps {
+    bounds?: Bounds
+    manager: DiscreteBarChartManager
+}
+
 @observer
 export class DiscreteBarChart
-    extends React.Component<{
-        bounds?: Bounds
-        manager: DiscreteBarChartManager
-    }>
+    extends React.Component<DiscreteBarChartProps>
     implements ChartInterface, AxisManager, ColorScaleManager
 {
     base: React.RefObject<SVGGElement> = React.createRef()

--- a/packages/@ourworldindata/grapher/src/controls/ActionButtons.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/ActionButtons.tsx
@@ -40,11 +40,13 @@ const PADDING_X = 12
 
 const BUTTON_WIDTH_ICON_ONLY = BUTTON_HEIGHT
 
-@observer
-export class ActionButtons extends React.Component<{
+interface ActionButtonsProps {
     manager: ActionButtonsManager
     maxWidth?: number
-}> {
+}
+
+@observer
+export class ActionButtons extends React.Component<ActionButtonsProps> {
     @computed private get manager(): ActionButtonsManager {
         return this.props.manager
     }

--- a/packages/@ourworldindata/grapher/src/controls/CommandPalette.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/CommandPalette.tsx
@@ -14,11 +14,13 @@ export interface Command {
 
 const CommandPaletteClassName = "CommandPalette"
 
-@observer
-export class CommandPalette extends React.Component<{
+interface CommandPaletteProps {
     commands: Command[]
     display: "none" | "block"
-}> {
+}
+
+@observer
+export class CommandPalette extends React.Component<CommandPaletteProps> {
     static togglePalette(): void {
         const element = document.getElementsByClassName(
             CommandPaletteClassName

--- a/packages/@ourworldindata/grapher/src/controls/SettingsMenu.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/SettingsMenu.tsx
@@ -83,13 +83,15 @@ export interface SettingsMenuManager
     compareEndPointsOnly?: boolean
 }
 
-@observer
-export class SettingsMenu extends React.Component<{
+interface SettingsMenuProps {
     manager: SettingsMenuManager
     top: number
     bottom: number
     right: number
-}> {
+}
+
+@observer
+export class SettingsMenu extends React.Component<SettingsMenuProps> {
     @observable.ref active: boolean = false
     contentRef: React.RefObject<HTMLDivElement> = React.createRef() // the menu contents & backdrop
 
@@ -422,13 +424,15 @@ export class SettingsMenu extends React.Component<{
     }
 }
 
-@observer
-class SettingsGroup extends React.Component<{
+interface SettingsGroupProps {
     title: string
     subtitle?: string
     active?: boolean
     children?: React.ReactNode
-}> {
+}
+
+@observer
+class SettingsGroup extends React.Component<SettingsGroupProps> {
     render(): React.ReactElement | null {
         const { active, title, subtitle, children } = this.props
         if (!active) return null

--- a/packages/@ourworldindata/grapher/src/controls/controlsRow/ControlsRow.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/controlsRow/ControlsRow.tsx
@@ -45,12 +45,14 @@ export interface ControlsRowManager
     isSmall?: boolean
 }
 
-@observer
-export class ControlsRow extends Component<{
+interface ControlsRowProps {
     manager: ControlsRowManager
     maxWidth?: number
     settingsMenuTop?: number
-}> {
+}
+
+@observer
+export class ControlsRow extends Component<ControlsRowProps> {
     private framePaddingHorizontal = GRAPHER_FRAME_PADDING_HORIZONTAL
     private framePaddingVertical = GRAPHER_FRAME_PADDING_VERTICAL
 

--- a/packages/@ourworldindata/grapher/src/controls/entityPicker/EntityPicker.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/entityPicker/EntityPicker.tsx
@@ -53,15 +53,17 @@ interface EntityOptionWithMetricValue {
 /** Modulo that wraps negative numbers too */
 const mod = (n: number, m: number): number => ((n % m) + m) % m
 
-@observer
-export class EntityPicker extends React.Component<{
+interface EntityPickerProps {
     manager: EntityPickerManager
     selection: SelectionArray
     isDropdownMenu?: boolean
     onSelectEntity?: (entityName: EntityName) => void
     onDeselectEntity?: (entityName: EntityName) => void
     onClearEntities?: () => void
-}> {
+}
+
+@observer
+export class EntityPicker extends React.Component<EntityPickerProps> {
     @observable private searchInput?: string
     @observable
     private searchInputRef: React.RefObject<HTMLInputElement> =

--- a/packages/@ourworldindata/grapher/src/controls/globalEntitySelector/GlobalEntitySelector.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/globalEntitySelector/GlobalEntitySelector.tsx
@@ -144,12 +144,14 @@ function SelectedItems(props: {
     )
 }
 
-@observer
-export class GlobalEntitySelector extends React.Component<{
+interface GlobalEntitySelectorProps {
     selection: SelectionArray
     graphersAndExplorersToUpdate?: Set<SelectionArray>
     environment?: string
-}> {
+}
+
+@observer
+export class GlobalEntitySelector extends React.Component<GlobalEntitySelectorProps> {
     refContainer: React.RefObject<HTMLDivElement> = React.createRef()
     disposers: IReactionDisposer[] = []
 

--- a/packages/@ourworldindata/grapher/src/controls/settings/AxisScaleToggle.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/settings/AxisScaleToggle.tsx
@@ -5,12 +5,14 @@ import { ScaleType } from "@ourworldindata/types"
 import { AxisConfig } from "../../axis/AxisConfig"
 import classnames from "classnames"
 
-@observer
-export class AxisScaleToggle extends React.Component<{
+interface AxisScaleToggleProps {
     axis: AxisConfig
     subtitle?: string
     prefix?: string
-}> {
+}
+
+@observer
+export class AxisScaleToggle extends React.Component<AxisScaleToggleProps> {
     @action.bound private setAxisScale(scale: ScaleType): void {
         this.props.axis.scaleType = scale
     }

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
@@ -90,11 +90,13 @@ const columnNameByType: Record<DataTableColumnKey, string> = {
 const inverseSortOrder = (order: SortOrder): SortOrder =>
     order === SortOrder.asc ? SortOrder.desc : SortOrder.asc
 
-@observer
-export class DataTable extends React.Component<{
+interface DataTableProps {
     manager: DataTableManager
     bounds?: Bounds
-}> {
+}
+
+@observer
+export class DataTable extends React.Component<DataTableProps> {
     @observable private storedState: DataTableState = {
         sort: DEFAULT_SORT_STATE,
     }

--- a/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
+++ b/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
@@ -215,13 +215,15 @@ type ExternalSortIndicatorKey = ExternalSortIndicatorDefinition["key"]
 
 const regionNamesSet = new Set(regions.map((region) => region.name))
 
-@observer
-export class EntitySelector extends React.Component<{
+interface EntitySelectorProps {
     manager: EntitySelectorManager
     selection?: SelectionArray
     autoFocus?: boolean
     onDismiss?: () => void
-}> {
+}
+
+@observer
+export class EntitySelector extends React.Component<EntitySelectorProps> {
     static contextType = DrawerContext
 
     scrollableContainer: React.RefObject<HTMLDivElement> = React.createRef()

--- a/packages/@ourworldindata/grapher/src/fullScreen/FullScreen.tsx
+++ b/packages/@ourworldindata/grapher/src/fullScreen/FullScreen.tsx
@@ -4,12 +4,14 @@ import { observer } from "mobx-react"
 import { BodyDiv } from "../bodyDiv/BodyDiv"
 import { isTargetOutsideElement } from "../chart/ChartUtils"
 
-@observer
-export class FullScreen extends React.Component<{
+interface FullScreenProps {
     children: React.ReactNode
     onDismiss: () => void
     overlayColor?: string
-}> {
+}
+
+@observer
+export class FullScreen extends React.Component<FullScreenProps> {
     content: React.RefObject<HTMLDivElement> = React.createRef()
 
     @action.bound onDocumentClick(e: React.MouseEvent): void {

--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
@@ -359,12 +359,14 @@ function LinePath(props: LinePathProps): React.ReactElement {
     )
 }
 
+interface LineChartProps {
+    bounds?: Bounds
+    manager: LineChartManager
+}
+
 @observer
 export class LineChart
-    extends React.Component<{
-        bounds?: Bounds
-        manager: LineChartManager
-    }>
+    extends React.Component<LineChartProps>
     implements
         ChartInterface,
         AxisManager,

--- a/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.tsx
+++ b/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.tsx
@@ -60,8 +60,7 @@ function stackGroupVertically(
     return group
 }
 
-@observer
-class LineLabels extends React.Component<{
+interface LineLabelsProps {
     series: PlacedSeries[]
     needsConnectorLines: boolean
     showTextOutline?: boolean
@@ -72,7 +71,10 @@ class LineLabels extends React.Component<{
     onClick?: (series: PlacedSeries) => void
     onMouseOver?: (series: PlacedSeries) => void
     onMouseLeave?: (series: PlacedSeries) => void
-}> {
+}
+
+@observer
+class LineLabels extends React.Component<LineLabelsProps> {
     @computed private get anchor(): "start" | "end" {
         return this.props.anchor ?? "start"
     }

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapSparkline.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapSparkline.tsx
@@ -36,12 +36,14 @@ export interface MapSparklineManager {
     yAxisConfig?: AxisConfigInterface
 }
 
-@observer
-export class MapSparkline extends React.Component<{
+interface MapSparklineProps {
     manager: MapSparklineManager
     sparklineWidth?: number
     sparklineHeight?: number
-}> {
+}
+
+@observer
+export class MapSparkline extends React.Component<MapSparklineProps> {
     static shouldShow(manager: MapSparklineManager): boolean {
         const test = new MapSparkline({ manager })
         return test.showSparkline

--- a/packages/@ourworldindata/grapher/src/modal/SourcesModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/SourcesModal.tsx
@@ -341,12 +341,14 @@ export class SourcesModal extends React.Component<
     }
 }
 
-@observer
-export class Source extends React.Component<{
+interface SourceProps {
     column: CoreColumn
     editBaseUrl?: string
     isEmbeddedInADataPage?: boolean
-}> {
+}
+
+@observer
+export class Source extends React.Component<SourceProps> {
     @computed get column(): CoreColumn {
         return this.props.column
     }

--- a/packages/@ourworldindata/grapher/src/noDataModal/NoDataModal.tsx
+++ b/packages/@ourworldindata/grapher/src/noDataModal/NoDataModal.tsx
@@ -26,14 +26,16 @@ export interface NoDataModalManager {
     isStatic?: boolean
 }
 
-@observer
-export class NoDataModal extends React.Component<{
+interface NoDataModalProps {
     bounds?: Bounds
     message?: string
     helpText?: string
     hideTextOutline?: boolean
     manager: NoDataModalManager
-}> {
+}
+
+@observer
+export class NoDataModal extends React.Component<NoDataModalProps> {
     @computed private get bounds(): Bounds {
         return this.props.bounds ?? DEFAULT_BOUNDS
     }

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
@@ -102,12 +102,14 @@ function computeSizeDomain(table: OwidTable, slug: ColumnSlug): ValueRange {
     return [0, _.max(sizeValues) ?? 1]
 }
 
+interface ScatterPlotChartProps {
+    bounds?: Bounds
+    manager: ScatterPlotManager
+}
+
 @observer
 export class ScatterPlotChart
-    extends React.Component<{
-        bounds?: Bounds
-        manager: ScatterPlotManager
-    }>
+    extends React.Component<ScatterPlotChartProps>
     implements
         ConnectedScatterLegendManager,
         ScatterSizeLegendManager,

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPoints.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPoints.tsx
@@ -10,14 +10,16 @@ import {
 } from "./ScatterPlotChartConstants"
 import { Triangle } from "./Triangle"
 
-// When there's only a single point in a series (e.g. single year mode)
-@observer
-export class ScatterPoint extends React.Component<{
+interface ScatterPointProps {
     series: ScatterRenderSeries
     isLayerMode?: boolean
     onMouseEnter?: (seriesName: string) => void
     onMouseLeave?: () => void
-}> {
+}
+
+// When there's only a single point in a series (e.g. single year mode)
+@observer
+export class ScatterPoint extends React.Component<ScatterPointProps> {
     render(): React.ReactElement | null {
         const { series, isLayerMode, onMouseEnter, onMouseLeave } = this.props
         const value = R.first(series.points)
@@ -67,13 +69,15 @@ export class ScatterPoint extends React.Component<{
     }
 }
 
-@observer
-export class ScatterLine extends React.Component<{
+interface ScatterLineProps {
     series: ScatterRenderSeries
     isLayerMode: boolean
     onMouseEnter?: (seriesName: string) => void
     onMouseLeave?: () => void
-}> {
+}
+
+@observer
+export class ScatterLine extends React.Component<ScatterLineProps> {
     render(): React.ReactElement | null {
         const { series, isLayerMode, onMouseEnter, onMouseLeave } = this.props
 

--- a/packages/@ourworldindata/grapher/src/slideInDrawer/SlideInDrawer.tsx
+++ b/packages/@ourworldindata/grapher/src/slideInDrawer/SlideInDrawer.tsx
@@ -8,13 +8,15 @@ export const DrawerContext = React.createContext<{
     toggleDrawerVisibility?: () => void
 }>({})
 
-@observer
-export class SlideInDrawer extends React.Component<{
+interface SlideInDrawerProps {
     active: boolean
     toggle: () => void
     children: React.ReactNode
     grapherRef?: React.RefObject<HTMLDivElement>
-}> {
+}
+
+@observer
+export class SlideInDrawer extends React.Component<SlideInDrawerProps> {
     @observable.ref visible: boolean = this.props.active // true while the drawer is active and during enter/exit transitions
     drawerRef: React.RefObject<HTMLDivElement> = React.createRef()
 

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
@@ -107,12 +107,14 @@ const NON_FOCUSED_LINE_COLOR = OWID_NON_FOCUSED_GRAY
 const TOP_PADDING = 6 // leave room for overflowing dots
 const LINE_LEGEND_PADDING = 4
 
+interface SlopeChartProps {
+    bounds?: Bounds
+    manager: SlopeChartManager
+}
+
 @observer
 export class SlopeChart
-    extends React.Component<{
-        bounds?: Bounds
-        manager: SlopeChartManager
-    }>
+    extends React.Component<SlopeChartProps>
     implements ChartInterface
 {
     private slopeAreaRef: React.RefObject<SVGGElement> = React.createRef()

--- a/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChart.tsx
@@ -245,13 +245,15 @@ function MarimekkoBarsForOneEntity(
     )
 }
 
+interface MarimekkoChartProps {
+    bounds?: Bounds
+    manager: MarimekkoChartManager
+    containerElement?: HTMLDivElement
+}
+
 @observer
 export class MarimekkoChart
-    extends React.Component<{
-        bounds?: Bounds
-        manager: MarimekkoChartManager
-        containerElement?: HTMLDivElement
-    }>
+    extends React.Component<MarimekkoChartProps>
     implements ChartInterface, HorizontalColorLegendManager, ColorScaleManager
 {
     base: React.RefObject<SVGGElement> = React.createRef()

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBarChart.tsx
@@ -122,13 +122,15 @@ interface StackedBarChartContext {
     baseFontSize: number
 }
 
+interface StackedDiscreteBarChartProps {
+    bounds?: Bounds
+    manager: StackedDiscreteBarChartManager
+    containerElement?: HTMLDivElement
+}
+
 @observer
 export class StackedDiscreteBarChart
-    extends React.Component<{
-        bounds?: Bounds
-        manager: StackedDiscreteBarChartManager
-        containerElement?: HTMLDivElement
-    }>
+    extends React.Component<StackedDiscreteBarChartProps>
     implements ChartInterface, HorizontalColorLegendManager
 {
     base: React.RefObject<SVGGElement> = React.createRef()

--- a/packages/@ourworldindata/grapher/src/timeline/TimelineComponent.tsx
+++ b/packages/@ourworldindata/grapher/src/timeline/TimelineComponent.tsx
@@ -26,11 +26,13 @@ export const TIMELINE_HEIGHT = 32 // keep in sync with $timelineHeight in Timeli
 
 const HANDLE_TOOLTIP_FADE_TIME_MS = 2000
 
-@observer
-export class TimelineComponent extends React.Component<{
+interface TimelineComponentProps {
     timelineController: TimelineController
     maxWidth?: number
-}> {
+}
+
+@observer
+export class TimelineComponent extends React.Component<TimelineComponentProps> {
     base: React.RefObject<HTMLDivElement> = React.createRef()
 
     @computed protected get maxWidth(): number {

--- a/packages/@ourworldindata/grapher/src/tooltip/Tooltip.tsx
+++ b/packages/@ourworldindata/grapher/src/tooltip/Tooltip.tsx
@@ -239,14 +239,16 @@ class TooltipCard extends React.Component<
     }
 }
 
-@observer
-export class TooltipContainer extends React.Component<{
+interface TooltipContainerProps {
     tooltipProvider: TooltipManager
     anchor?: GrapherTooltipAnchor
     // if container dimensions are given, the tooltip will be positioned within its bounds
     containerWidth?: number
     containerHeight?: number
-}> {
+}
+
+@observer
+export class TooltipContainer extends React.Component<TooltipContainerProps> {
     @computed private get tooltip(): TooltipProps | undefined {
         const { tooltip } = this.props.tooltipProvider
         return tooltip?.get()

--- a/site/Feedback.tsx
+++ b/site/Feedback.tsx
@@ -116,11 +116,13 @@ const topicNotices = new Map<SpecialFeedbackTopic, React.ReactElement>([
     [SpecialFeedbackTopic.Translation, translateNotice],
 ])
 
-@observer
-export class FeedbackForm extends React.Component<{
+interface FeedbackFormProps {
     onClose?: () => void
     autofocus?: boolean
-}> {
+}
+
+@observer
+export class FeedbackForm extends React.Component<FeedbackFormProps> {
     feedback: Feedback = new Feedback()
     @observable loading: boolean = false
     @observable done: boolean = false

--- a/site/blocks/ProminentLink.tsx
+++ b/site/blocks/ProminentLink.tsx
@@ -23,15 +23,17 @@ export enum ProminentLinkStyles {
 
 export const WITH_IMAGE = "with-image"
 
-@observer
-export class ProminentLink extends Component<{
+interface ProminentLinkProps {
     href: string
     style: string | null
     title: string | null
     content?: string | null
     image?: string | null
     globalEntitySelection?: SelectionArray
-}> {
+}
+
+@observer
+export class ProminentLink extends Component<ProminentLinkProps> {
     @computed get originalUrl(): Url {
         return migrateSelectedEntityNamesParam(Url.fromURL(this.props.href))
     }


### PR DESCRIPTION
Introduces an explicit interface for props for all `@observer` React components that had them inline (e.g. `extends Component<{ manager: A, bounds: Bounds }>`), and has more than one prop.

No behavioral change whatsoever.


Regex used: `@observer([^{]*\n[^{]*){0,5}Component<\{`