### PR TITLE
🐛 fix download modal in explorers

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -518,6 +518,9 @@ export class GrapherState {
         this.canHideExternalControlsInEmbed =
             options.canHideExternalControlsInEmbed ?? false
 
+        // make sure the static bounds are set
+        this.staticBounds = options.staticBounds ?? DEFAULT_GRAPHER_BOUNDS
+
         this.archivedChartInfo = options.archivedChartInfo
 
         this.populateFromQueryParams(


### PR DESCRIPTION
Explorers were passing in undefined `staticBounds`, which broke the download modal