### PR TITLE
🔨 add available tabs to Algolia indices

### DIFF
--- a/baker/algolia/utils/charts.ts
+++ b/baker/algolia/utils/charts.ts
@@ -1,6 +1,10 @@
 import * as _ from "lodash-es"
 import { MarkdownTextWrap } from "@ourworldindata/components"
-import { KeyChartLevel, ContentGraphLinkType } from "@ourworldindata/types"
+import {
+    KeyChartLevel,
+    ContentGraphLinkType,
+    parseChartConfig,
+} from "@ourworldindata/types"
 import * as db from "../../../db/db.js"
 import {
     ChartRecord,
@@ -16,6 +20,7 @@ import {
     getUniqueNamesFromTopicHierarchies,
 } from "@ourworldindata/utils"
 import { processAvailableEntities } from "./shared.js"
+import { GrapherState } from "@ourworldindata/grapher"
 
 const computeChartScore = (record: Omit<ChartRecord, "score">): number => {
     const { numRelatedArticles, views_7d } = record
@@ -46,8 +51,11 @@ const parseAndProcessChartRecords = (
         rawRecord.keyChartForTags as string
     ).filter((t: string | null) => t)
 
+    const config = parseChartConfig(rawRecord.config)
+
     return {
         ...rawRecord,
+        config,
         entityNames,
         tags,
         keyChartForTags,
@@ -64,9 +72,7 @@ export const getChartsRecords = async (
         WITH indexable_charts_with_entity_names AS (
             SELECT c.id,
                    cc.slug,
-                   cc.full ->> "$.title"                   AS title,
-                   cc.full ->> "$.variantName"             AS variantName,
-                   cc.full ->> "$.subtitle"                AS subtitle,
+                   cc.full                                 AS config,
                    JSON_LENGTH(cc.full ->> "$.dimensions") AS numDimensions,
                    c.publishedAt,
                    c.updatedAt,
@@ -81,9 +87,7 @@ export const getChartsRecords = async (
         )
         SELECT c.id,
                c.slug,
-               c.title,
-               c.variantName,
-               c.subtitle,
+               c.config,
                c.numDimensions,
                c.publishedAt,
                c.updatedAt,
@@ -107,6 +111,8 @@ export const getChartsRecords = async (
 
     const records: ChartRecord[] = []
     for (const c of parsedRows) {
+        const grapherState = new GrapherState(c.config)
+
         // Our search currently cannot render explorers, so don't index them because
         // otherwise they will fail when rendered in the search results
         if (isPathRedirectedToExplorer(`/grapher/${c.slug}`)) continue
@@ -118,10 +124,10 @@ export const getChartsRecords = async (
             ContentGraphLinkType.Grapher
         )
 
-        const plaintextSubtitle = _.isNil(c.subtitle)
+        const plaintextSubtitle = _.isNil(c.config.subtitle)
             ? undefined
             : new MarkdownTextWrap({
-                  text: c.subtitle,
+                  text: c.config.subtitle,
                   fontSize: 10, // doesn't matter, but is a mandatory field
               }).plaintext
 
@@ -136,16 +142,17 @@ export const getChartsRecords = async (
             type: ChartRecordType.Chart,
             chartId: c.id,
             slug: c.slug,
-            title: c.title,
-            variantName: c.variantName,
+            title: c.config.title,
+            variantName: c.config.variantName,
             subtitle: plaintextSubtitle,
             availableEntities: c.entityNames,
             numDimensions: parseInt(c.numDimensions),
+            availableTabs: grapherState.availableTabs,
             publishedAt: c.publishedAt,
             updatedAt: c.updatedAt,
             tags: topicTags,
             keyChartForTags: c.keyChartForTags as string[],
-            titleLength: c.title.length,
+            titleLength: c.config.title?.length ?? 0,
             // Number of references to this chart in all our posts and pages
             numRelatedArticles: relatedArticles.length + linksFromGdocs.length,
             views_7d: pageviews[`/grapher/${c.slug}`]?.views_7d ?? 0,

--- a/baker/algolia/utils/mdimViews.ts
+++ b/baker/algolia/utils/mdimViews.ts
@@ -22,6 +22,7 @@ import {
     getRelevantVariableIds,
     getRelevantVariableMetadata,
 } from "../../MultiDimBaker.js"
+import { GrapherState } from "@ourworldindata/grapher"
 
 async function getChartConfigsByIds(
     knex: db.KnexReadonlyTransaction,
@@ -75,6 +76,7 @@ async function getRecords(
                     `viewId=${viewId} chartConfigId=${view.fullConfigId}`
             )
         }
+        const grapherState = new GrapherState(chartConfig)
         const queryStr = queryParamsToStr(view.dimensions)
         const variableId = view.indicators.y[0].id
         const metadata = _.merge(
@@ -104,6 +106,7 @@ async function getRecords(
             title,
             subtitle,
             variantName: chartConfig.variantName,
+            availableTabs: grapherState.availableTabs,
             keyChartForTags: [],
             tags,
             availableEntities,

--- a/baker/algolia/utils/types.ts
+++ b/baker/algolia/utils/types.ts
@@ -1,6 +1,8 @@
 import {
     DbEnrichedVariable,
     FeaturedMetricIncomeGroup,
+    GrapherInterface,
+    GrapherTabName,
 } from "@ourworldindata/types"
 import { ChartRecord } from "../../../site/search/searchTypes.js"
 import { OwidIncomeGroupName } from "@ourworldindata/utils"
@@ -9,9 +11,7 @@ import { OwidIncomeGroupName } from "@ourworldindata/utils"
 export interface RawChartRecordRow {
     id: number
     slug: string
-    title: string
-    variantName: string
-    subtitle: string
+    config: string
     numDimensions: string
     publishedAt: string
     updatedAt: string
@@ -23,9 +23,7 @@ export interface RawChartRecordRow {
 export interface ParsedChartRecordRow {
     id: number
     slug: string
-    title: string
-    variantName: string
-    subtitle: string
+    config: GrapherInterface
     numDimensions: string
     publishedAt: string
     updatedAt: string
@@ -74,6 +72,7 @@ export interface ExplorerViewBaseRecord {
     viewSettings: Array<string | null>
     viewSubtitle?: string
     viewTitle?: string
+    viewAvailableTabs?: GrapherTabName[]
     ySlugs: Array<string>
     yVariableIds: Array<number | string>
     explorerSlug: string

--- a/site/search/searchTypes.ts
+++ b/site/search/searchTypes.ts
@@ -1,4 +1,4 @@
-import { OwidGdocType } from "@ourworldindata/types"
+import { GrapherTabName, OwidGdocType } from "@ourworldindata/types"
 import { SearchResponse } from "instantsearch.js"
 import {
     BaseHit,
@@ -73,6 +73,7 @@ export interface ChartRecord {
     title: string
     subtitle: string | undefined
     variantName: string
+    availableTabs: GrapherTabName[]
     keyChartForTags: string[]
     tags: string[]
     availableEntities: string[]

--- a/site/search/searchUtils.tsx
+++ b/site/search/searchUtils.tsx
@@ -162,6 +162,7 @@ export const DATA_CATALOG_ATTRIBUTES = [
     "variantName",
     "type",
     "queryParams",
+    "availableTabs",
 ]
 
 export function setToFacetFilters(


### PR DESCRIPTION
Adds available tabs to Algolia’s indices. These usually look like `["Table", "WorldMap", "LineChart", "SlopeChart"]`. They’re based on the hasMapTab and chartTypes config fields, but Grapher runs a validation step to make sure the tab combination is actually valid. That’s why it’s safer to use `grapherState.availableTabs` instead of building it manually from the config.