### PR TITLE
remove unnecessary quotation marks

### DIFF
--- a/db/docs/chart_configs.yml
+++ b/db/docs/chart_configs.yml
@@ -29,24 +29,24 @@ fields:
         description: Unique identifier for the chart configuration
     patch:
         description: |
-            "Incremental configuration JSON that contains only the changes from the inherited or base configuration. Stored as a JSON column, so can be queried with the ->> operator.
+            Incremental configuration JSON that contains only the changes from the inherited or base configuration. Stored as a JSON column, so can be queried with the ->> operator.
 
             The full schema is available at 'https://files.ourworldindata.org/schemas/grapher-schema.latest.json'. For querying chart contents, the most important fields are:
                 - title
                 - subtitle
                 - chartTypes: array of string enums with valid values: ScatterPlot, StackedArea, DiscreteBar, StackedDiscreteBar, SlopeChart, StackedBar, Marimekko. Indicates which of these chart tabs are enabled for the chart.
                 - hasMapTab: Whether the map tab is enabled
-                - isPublished: whether the chart is published, if it is a standalone chart (i.e. a chart referenced from the charts table)"
+                - isPublished: whether the chart is published, if it is a standalone chart (i.e. a chart referenced from the charts table)
     full:
         description: |
-            "Complete merged configuration JSON that combines inherited configuration with local patches. This is the final configuration used for rendering. Stored as a JSON column, so can be queried with the ->> operator.
+            Complete merged configuration JSON that combines inherited configuration with local patches. This is the final configuration used for rendering. Stored as a JSON column, so can be queried with the ->> operator.
 
             The full schema is available at 'https://files.ourworldindata.org/schemas/grapher-schema.latest.json'. For querying chart contents, the most important fields are:
                 - title
                 - subtitle
                 - chartTypes: array of string enums with valid values: ScatterPlot, StackedArea, DiscreteBar, StackedDiscreteBar, SlopeChart, StackedBar, Marimekko. Indicates which of these chart tabs are enabled for the chart.
                 - hasMapTab: Whether the map tab is enabled
-                - isPublished: whether the chart is published, if it is a standalone chart (i.e. a chart referenced from the charts table)"
+                - isPublished: whether the chart is published, if it is a standalone chart (i.e. a chart referenced from the charts table)
     slug:
         description: URL-friendly identifier for the chart, used in URLs like /grapher/[slug]
     chartType:

--- a/db/docs/chart_revisions.yml
+++ b/db/docs/chart_revisions.yml
@@ -14,14 +14,14 @@ fields:
         description: Foreign key to users table. The user who created this revision.
     config:
         description: |
-            "JSON configuration of the chart at the time of this revision
+            JSON configuration of the chart at the time of this revision
 
             The full schema is available at 'https://files.ourworldindata.org/schemas/grapher-schema.latest.json'. For querying chart contents, the most important fields are:
                 - title
                 - subtitle
                 - chartTypes: array of string enums with valid values: ScatterPlot, StackedArea, DiscreteBar, StackedDiscreteBar, SlopeChart, StackedBar, Marimekko. Indicates which of these chart tabs are enabled for the chart.
                 - hasMapTab: Whether the map tab is enabled
-                - isPublished: whether the chart is published, if it is a standalone chart (i.e. a chart referenced from the charts table)"
+                - isPublished: whether the chart is published, if it is a standalone chart (i.e. a chart referenced from the charts table)
     createdAt:
         description: Timestamp when the revision was created
     updatedAt:

--- a/db/docs/posts_gdocs.yml
+++ b/db/docs/posts_gdocs.yml
@@ -25,13 +25,13 @@ fields:
         description: "Post type. One of: about-page, article, author, data-insight, fragment, homepage, linear-topic-page, topic-page"
     content:
         description: |
-            "Structured JSON content parsed from Google Docs. This is the JSON representation of text written in the ArchieML in the Google Doc. There exists no JSON schema ATM for this - the best guide to understand this is to follow the type OwidGdocContent defined in /packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts or to query the DB and look at example rows.
+            Structured JSON content parsed from Google Docs. This is the JSON representation of text written in the ArchieML in the Google Doc. There exists no JSON schema ATM for this - the best guide to understand this is to follow the type OwidGdocContent defined in /packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts or to query the DB and look at example rows.
 
             The content is always a JSON object containing a body field that contains the main document text object tree, and various properties like the title and other front matter. Common (though not mandatory), important top level frontmatter fields are:
             - title
             - excerpt
             - subtitle
-            - dateline"
+            - dateline
     authors:
         description: JSON array of post authors
     published:


### PR DESCRIPTION
## Context

Some fields in the new DB documentation were using quotation marks, but these are not really needed.

## Screenshots / Videos / Diagrams
This leads to quotation marks showing up in places like Metabase.
<img width="617" height="458" alt="image" src="https://github.com/user-attachments/assets/d64494c5-6f95-42a3-8d79-3c8879d9bb97" />