### PR TITLE
🔨 rely on Grapher's defaults in FetchingGrapher

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/FetchingGrapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/FetchingGrapher.tsx
@@ -16,7 +16,6 @@ import { legacyToCurrentGrapherQueryParams } from "./GrapherUrlMigrations.js"
 import { unstable_batchedUpdates } from "react-dom"
 import { Bounds } from "@ourworldindata/utils"
 import { migrateGrapherConfigToLatestVersion } from "../schema/migrations/migrate.js"
-import { defaultGrapherConfig } from "../schema/defaultGrapherConfig.js"
 
 export interface FetchingGrapherProps {
     config?: GrapherProgrammaticInterface
@@ -80,7 +79,6 @@ export function FetchingGrapher(
                         migrateGrapherConfigToLatestVersion(fetchedConfig)
 
                     const mergedConfig = {
-                        ...defaultGrapherConfig,
                         ...migratedConfig,
                         ...props.config,
                     }


### PR DESCRIPTION
I don’t think we should merge the default settings here, unless I’m missing something?

The Grapher component should be the source of truth for defaults. `defaultGrapherConfig` _should_ be in sync, but it’s safer not to depend on that.