### PR TITLE
🐛 fix embedded charts showing empty selection

### DIFF
--- a/site/multiembedder/MultiEmbedder.tsx
+++ b/site/multiembedder/MultiEmbedder.tsx
@@ -211,9 +211,9 @@ class MultiEmbedder {
             localConfig,
             {
                 manager: {
-                    selection: new SelectionArray(
-                        this.selection.selectedEntityNames
-                    ),
+                    selection: this.selection.hasSelection
+                        ? new SelectionArray(this.selection.selectedEntityNames)
+                        : undefined,
                 },
             }
         )


### PR DESCRIPTION
Fixes a regression introduced by #5150 

This [key insight](https://ourworldindata.org/poverty?insight=the-pandemic-pushed-tens-of-millions-into-extreme-poverty#key-insights) currently shows an empty selection although the narrative chart specifies a default entity. This happens because `manager.selection` overwrites the selected entity names in the Multiembedder.