### PR TITLE
chore: use zod for type validation, remove typebox

### DIFF
--- a/db/model/Chart.ts
+++ b/db/model/Chart.ts
@@ -24,8 +24,8 @@ import {
 } from "@ourworldindata/types"
 import { OpenAI } from "openai"
 import { OPENAI_API_KEY } from "../../settings/serverSettings.js"
-import zod from "zod"
-import { zodResponseFormat } from "openai/helpers/zod"
+import { z } from "zod"
+import { zodResponseFormat } from "../../serverUtils/openAiUtils.js"
 
 // XXX hardcoded filtering to public parent tags
 export const PUBLIC_TAG_PARENT_IDS = [
@@ -469,12 +469,12 @@ export async function getGptTopicSuggestions(
     if (!topics.length) throw new JsonError("No topics found", 404)
 
     // Define Zod schema for the response
-    const TopicSchema = zod.object({
-        id: zod.number(),
-        name: zod.string(),
+    const TopicSchema = z.object({
+        id: z.number(),
+        name: z.string(),
     })
-    const TopicsResponseSchema = zod.object({
-        topics: zod.array(TopicSchema),
+    const TopicsResponseSchema = z.object({
+        topics: z.array(TopicSchema),
     })
 
     const prompt = `

--- a/functions/donation/donate.ts
+++ b/functions/donation/donate.ts
@@ -10,7 +10,7 @@ import {
 import { Env } from "../_common/env.js"
 import { DEFAULT_HEADERS, CORS_HEADERS } from "./_utils/constants.js"
 import { logError } from "./_utils/error.js"
-import { z } from "zod/mini"
+import { z } from "zod"
 
 const filePath = "donation/donate.ts"
 
@@ -43,10 +43,6 @@ export const onRequestPost: PagesFunction<Env> = async ({
             )
         // Parse the body of the request as JSON
         const donation = await request.json()
-
-        // Load Zod locale so we can use it for error messages.
-        // See https://zod.dev/packages/mini?id=no-default-locale
-        z.config(z.locales.en())
 
         // Check that the received donation object has the right type. Given that we
         // use the same types in the client and the server, this should never fail

--- a/functions/donation/donate.ts
+++ b/functions/donation/donate.ts
@@ -44,6 +44,10 @@ export const onRequestPost: PagesFunction<Env> = async ({
         // Parse the body of the request as JSON
         const donation = await request.json()
 
+        // Load Zod locale so we can use it for error messages.
+        // See https://zod.dev/packages/mini?id=no-default-locale
+        z.config(z.locales.en())
+
         // Check that the received donation object has the right type. Given that we
         // use the same types in the client and the server, this should never fail
         // when the request is coming from the client. However, it could happen if a

--- a/functions/donation/donate.ts
+++ b/functions/donation/donate.ts
@@ -7,10 +7,10 @@ import {
     PLEASE_TRY_AGAIN,
     stringifyUnknownError,
 } from "@ourworldindata/utils"
-import { Value } from "@sinclair/typebox/value"
 import { Env } from "../_common/env.js"
 import { DEFAULT_HEADERS, CORS_HEADERS } from "./_utils/constants.js"
 import { logError } from "./_utils/error.js"
+import { z } from "zod/mini"
 
 const filePath = "donation/donate.ts"
 
@@ -49,28 +49,20 @@ export const onRequestPost: PagesFunction<Env> = async ({
         // when the request is coming from the client. However, it could happen if a
         // request is manually crafted. In this case, we select the first error and
         // send TypeBox's default error message.
-        if (!Value.Check(DonationRequestTypeObject, donation)) {
-            const { message, path } = Value.Errors(
-                DonationRequestTypeObject,
-                donation
-            ).First()
-            throw new JsonError(`${message} (${path})`)
+        const { data, error } = DonationRequestTypeObject.safeParse(donation)
+        if (!data) {
+            const message = z.prettifyError(error)
+            throw new JsonError(`Invalid donation request: ${message}`, 400)
         }
 
         if (
-            !(await isCaptchaValid(
-                donation.captchaToken,
-                env.RECAPTCHA_SECRET_KEY
-            ))
+            !(await isCaptchaValid(data.captchaToken, env.RECAPTCHA_SECRET_KEY))
         )
             throw new JsonError(
                 `The CAPTCHA challenge failed. ${PLEASE_TRY_AGAIN}`
             )
 
-        const session = await createCheckoutSession(
-            donation,
-            env.STRIPE_API_KEY
-        )
+        const session = await createCheckoutSession(data, env.STRIPE_API_KEY)
         const sessionResponse: DonateSessionResponse = { url: session.url }
 
         return new Response(JSON.stringify(sessionResponse), {

--- a/functions/package.json
+++ b/functions/package.json
@@ -7,12 +7,12 @@
         "@ourworldindata/types": "workspace:^",
         "@ourworldindata/utils": "workspace:^",
         "@sentry/cloudflare": "^9.40.0",
-        "@sinclair/typebox": "^0.28.5",
         "itty-router": "^5.0.17",
         "littlezipper": "^0.1.4",
         "stripe": "^14.20.0",
         "svg2png-wasm": "^1.4.1",
-        "uuidv7": "^1.0.1"
+        "uuidv7": "^1.0.1",
+        "zod": "^4.0.5"
     },
     "devDependencies": {
         "@cloudflare/workers-types": "^4.20250510.0",

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -1,10 +1,12 @@
 {
     "compilerOptions": {
-        "target": "esnext",
-        "module": "NodeNext",
-        "moduleResolution": "NodeNext",
+        "target": "es2023",
+        "module": "commonjs",
+        // "moduleResolution": "node16",
         "lib": ["esnext"],
         "types": ["@cloudflare/workers-types"],
-        "esModuleInterop": true
+        "esModuleInterop": true,
+
+        "outDir": "./dist"
     }
 }

--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
         "@sentry/profiling-node": "^9.40.0",
         "@sentry/react": "^9.40.0",
         "@sentry/vite-plugin": "^4.0.0",
-        "@sinclair/typebox": "^0.28.5",
         "@slack/web-api": "^7.9.1",
         "@tanstack/react-query": "4",
         "@tippyjs/react": "^4.2.6",
@@ -181,7 +180,7 @@
         "workerpool": "^9.2.0",
         "yaml": "^2.8.0",
         "yargs": "^17.7.2",
-        "zod": "^3.24.2"
+        "zod": "^4.0.5"
     },
     "devDependencies": {
         "@eslint/js": "^9.21.0",

--- a/packages/@ourworldindata/types/package.json
+++ b/packages/@ourworldindata/types/package.json
@@ -21,7 +21,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@sinclair/typebox": "^0.28.5",
-    "mobx": "^6.13.7"
+    "mobx": "^6.13.7",
+    "zod": "^4.0.5"
   }
 }

--- a/packages/@ourworldindata/types/src/DonationTypes.ts
+++ b/packages/@ourworldindata/types/src/DonationTypes.ts
@@ -14,7 +14,7 @@ export const DonationRequestTypeObject = z.object({
     name: z.optional(z.string()),
     showOnList: z.boolean(),
     subscribeToDonorNewsletter: z.boolean(),
-    currency: z.union([z.literal("GBP"), z.literal("EUR"), z.literal("USD")]),
+    currency: z.enum(["GBP", "EUR", "USD"]),
     amount: z.optional(
         z.number({
             // We don't want to enforce a minimum or maximum donation amount at the
@@ -23,11 +23,7 @@ export const DonationRequestTypeObject = z.object({
             // by getErrorMessageDonation().
         })
     ),
-    interval: z.union([
-        z.literal("once"),
-        z.literal("monthly"),
-        z.literal("annual"),
-    ]),
+    interval: z.enum(["once", "monthly", "annual"]),
     successUrl: z.string(),
     cancelUrl: z.string(),
     captchaToken: z.string(),

--- a/packages/@ourworldindata/types/src/DonationTypes.ts
+++ b/packages/@ourworldindata/types/src/DonationTypes.ts
@@ -1,4 +1,4 @@
-import { Static, Type } from "@sinclair/typebox"
+import { z } from "zod/mini"
 export type DonationInterval = "once" | "monthly" | "annual"
 
 export type DonationCurrencyCode = "USD" | "GBP" | "EUR"
@@ -10,31 +10,27 @@ export interface DonateSessionResponse {
 
 // This is used to validate the type of the request body in the donate session
 // when received by the server (see functions/donation/checkout).
-export const DonationRequestTypeObject = Type.Object({
-    name: Type.Optional(Type.String()),
-    showOnList: Type.Boolean(),
-    subscribeToDonorNewsletter: Type.Boolean(),
-    currency: Type.Union([
-        Type.Literal("GBP"),
-        Type.Literal("EUR"),
-        Type.Literal("USD"),
-    ]),
-    amount: Type.Optional(
-        Type.Number({
+export const DonationRequestTypeObject = z.object({
+    name: z.optional(z.string()),
+    showOnList: z.boolean(),
+    subscribeToDonorNewsletter: z.boolean(),
+    currency: z.union([z.literal("GBP"), z.literal("EUR"), z.literal("USD")]),
+    amount: z.optional(
+        z.number({
             // We don't want to enforce a minimum or maximum donation amount at the
             // type level so that we can return friendlier error messages than
-            // Typebox's default ones. These friendlier error messages are returned
+            // zod's default ones. These friendlier error messages are returned
             // by getErrorMessageDonation().
         })
     ),
-    interval: Type.Union([
-        Type.Literal("once"),
-        Type.Literal("monthly"),
-        Type.Literal("annual"),
+    interval: z.union([
+        z.literal("once"),
+        z.literal("monthly"),
+        z.literal("annual"),
     ]),
-    successUrl: Type.String(),
-    cancelUrl: Type.String(),
-    captchaToken: Type.String(),
+    successUrl: z.string(),
+    cancelUrl: z.string(),
+    captchaToken: z.string(),
 })
 
-export type DonationRequest = Static<typeof DonationRequestTypeObject>
+export type DonationRequest = z.infer<typeof DonationRequestTypeObject>

--- a/packages/@ourworldindata/types/src/gdocTypes/Datapage.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/Datapage.ts
@@ -64,7 +64,7 @@ export interface DataPageRelatedResearch {
 // and we don't want to risk exposing unwanted draft or internal content.
 export const DataPageJsonTypeObject = z.strictObject({
     showDataPageOnChartIds: z.array(z.number()),
-    status: z.union([z.literal("published"), z.literal("draft")]),
+    status: z.enum(["published", "draft"]),
     title: z.string(),
     googleDocEditLink: z.optional(z.string().check(z.regex(gdocUrlRegex))),
     topicTagsLinks: z.array(

--- a/serverUtils/openAiUtils.ts
+++ b/serverUtils/openAiUtils.ts
@@ -1,0 +1,29 @@
+import { z } from "zod"
+import { makeParseableResponseFormat } from "openai/lib/parser"
+
+import type { AutoParseableResponseFormat } from "openai/lib/parser"
+import type { ResponseFormatJSONSchema } from "openai/resources"
+
+// Workaround: OpenAI doesn't currently support Zod v4, so we need to use a custom zodResponseFormat function
+// see https://github.com/openai/openai-node/issues/1576#issuecomment-3056734414
+export function zodResponseFormat<ZodInput extends z.ZodType>(
+    zodObject: ZodInput,
+    name: string,
+    props?: Omit<
+        ResponseFormatJSONSchema.JSONSchema,
+        "schema" | "strict" | "name"
+    >
+): AutoParseableResponseFormat<z.infer<ZodInput>> {
+    return makeParseableResponseFormat(
+        {
+            type: "json_schema",
+            json_schema: {
+                ...props,
+                name,
+                strict: true,
+                schema: z.toJSONSchema(zodObject, { target: "draft-7" }),
+            },
+        },
+        (content) => zodObject.parse(JSON.parse(content))
+    )
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3470,11 +3470,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@ourworldindata/types@workspace:packages/@ourworldindata/types"
   dependencies:
-    "@sinclair/typebox": "npm:^0.28.5"
     eslint: "npm:^9.23.0"
     eslint-plugin-react-hooks: "npm:^5.2.0"
     mobx: "npm:^6.13.7"
     typescript: "npm:~5.8.2"
+    zod: "npm:^4.0.5"
   languageName: unknown
   linkType: soft
 
@@ -6138,13 +6138,6 @@ __metadata:
   version: 0.27.8
   resolution: "@sinclair/typebox@npm:0.27.8"
   checksum: 10/297f95ff77c82c54de8c9907f186076e715ff2621c5222ba50b8d40a170661c0c5242c763cba2a4791f0f91cb1d8ffa53ea1d7294570cf8cd4694c0e383e484d
-  languageName: node
-  linkType: hard
-
-"@sinclair/typebox@npm:^0.28.5":
-  version: 0.28.5
-  resolution: "@sinclair/typebox@npm:0.28.5"
-  checksum: 10/fe06bb2fdaf1b53f0711d73cd2f9046b7df37780e6da0bc6e7af27c8a57a1d064cfbcb77cb62491e2a83c2dc860b0eeb500760b45968ced23f8997256558e342
   languageName: node
   linkType: hard
 
@@ -12998,7 +12991,6 @@ __metadata:
     "@sentry/profiling-node": "npm:^9.40.0"
     "@sentry/react": "npm:^9.40.0"
     "@sentry/vite-plugin": "npm:^4.0.0"
-    "@sinclair/typebox": "npm:^0.28.5"
     "@slack/web-api": "npm:^7.9.1"
     "@tanstack/react-query": "npm:4"
     "@testing-library/dom": "npm:^10.4.0"
@@ -13171,7 +13163,7 @@ __metadata:
     wrangler: "npm:^4.25.0"
     yaml: "npm:^2.8.0"
     yargs: "npm:^17.7.2"
-    zod: "npm:^3.24.2"
+    zod: "npm:^4.0.5"
   languageName: unknown
   linkType: soft
 
@@ -16999,13 +16991,13 @@ __metadata:
     "@ourworldindata/types": "workspace:^"
     "@ourworldindata/utils": "workspace:^"
     "@sentry/cloudflare": "npm:^9.40.0"
-    "@sinclair/typebox": "npm:^0.28.5"
     "@types/lodash-es": "npm:^4"
     itty-router: "npm:^5.0.17"
     littlezipper: "npm:^0.1.4"
     stripe: "npm:^14.20.0"
     svg2png-wasm: "npm:^1.4.1"
     uuidv7: "npm:^1.0.1"
+    zod: "npm:^4.0.5"
   languageName: unknown
   linkType: soft
 
@@ -22514,10 +22506,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod@npm:^3.24.2":
-  version: 3.24.2
-  resolution: "zod@npm:3.24.2"
-  checksum: 10/604c62a8cf8e330d78b106a557f4b44f5d14845d20b1360a423ccc09b58cb8525ccf7e4b40cf1bd4852d22393d2c67774b5817ec5a2fedab25f543b36ed15943
+"zod@npm:^4.0.5":
+  version: 4.0.5
+  resolution: "zod@npm:4.0.5"
+  checksum: 10/f057f46e685e91ea280039ecda026c91facabdcbf869b3bae482ed13d34dce2efe9ee1f513fb1c8c0fde3b32e5904391f5ca015ec50b0924abf83a2b6f9dba65
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
We were using both `zod` and `@sinclair/typebox` for type validation.

Let's make it just one again, and Zod seems like the better one at this point because it has a bunch more features, and supports [Standard Schema](https://standardschema.dev/).

Also, when using `zod/mini`, we end up with a slightly smaller bundle.