### PR TITLE
✨ update time selection when switching between explorer and mdim views

### DIFF
--- a/packages/@ourworldindata/explorer/src/Explorer.tsx
+++ b/packages/@ourworldindata/explorer/src/Explorer.tsx
@@ -472,6 +472,17 @@ export class Explorer
 
         this.grapherState.populateFromQueryParams(newGrapherParams)
 
+        // When switching between explorer views, we usually preserve the tab.
+        // However, if the new chart doesn't support the previously selected tab,
+        // Grapher automatically switches to a supported one. In such cases,
+        // we call onChartSwitching to make adjustments that ensure the new view
+        // is sensible (e.g. updating the time selection when switching from a
+        // single-time chart like a discrete bar chart to a multi-time chart like
+        // a line chart).
+        const currentTab = this.grapherState.activeTab
+        if (previousTab !== currentTab)
+            this.grapherState.onChartSwitching(previousTab, currentTab)
+
         this.analytics.logExplorerView(
             this.explorerProgram.slug,
             this.explorerProgram.decisionMatrix.currentParams

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -1482,7 +1482,7 @@ export class GrapherState {
         ].includes(tabName)
     }
 
-    @action.bound private onChartSwitching(
+    @action.bound onChartSwitching(
         _oldTab: GrapherTabName,
         newTab: GrapherTabName
     ): void {

--- a/site/multiDim/MultiDim.tsx
+++ b/site/multiDim/MultiDim.tsx
@@ -134,6 +134,8 @@ export default function MultiDim({
                 ? archivedChartInfo.assets.runtime
                 : undefined
 
+        const previousTab = grapher.activeTab
+
         cachedGetGrapherConfigByUuid(
             newView.fullConfigId,
             Boolean(isPreviewing),
@@ -164,6 +166,17 @@ export default function MultiDim({
                         }
                     })
                 grapher.populateFromQueryParams(newGrapherParams)
+
+                // When switching between mdim views, we usually preserve the tab.
+                // However, if the new chart doesn't support the previously selected tab,
+                // Grapher automatically switches to a supported one. In such cases,
+                // we call onChartSwitching to make adjustments that ensure the new view
+                // is sensible (e.g. updating the time selection when switching from a
+                // single-time chart like a discrete bar chart to a multi-time chart like
+                // a line chart).
+                const currentTab = grapher.activeTab
+                if (previousTab !== currentTab)
+                    grapher.onChartSwitching(previousTab, currentTab)
             })
             .catch(Sentry.captureException)
         return () => {

--- a/site/multiDim/MultiDimDataPageContent.tsx
+++ b/site/multiDim/MultiDimDataPageContent.tsx
@@ -232,6 +232,8 @@ export function DataPageContent({
                         // multiple times while flashing.
                         // https://stackoverflow.com/a/48610973/9846837
 
+                        const previousTab = grapherState.activeTab
+
                         // TODO we may not need to this anymore in React 18.
                         unstable_batchedUpdates(() => {
                             grapherState.setAuthoredVersion(config)
@@ -242,6 +244,20 @@ export function DataPageContent({
                             grapherState.populateFromQueryParams(
                                 grapherQueryParams
                             )
+
+                            // When switching between mdim views, we usually preserve the tab.
+                            // However, if the new chart doesn't support the previously selected tab,
+                            // Grapher automatically switches to a supported one. In such cases,
+                            // we call onChartSwitching to make adjustments that ensure the new view
+                            // is sensible (e.g. updating the time selection when switching from a
+                            // single-time chart like a discrete bar chart to a multi-time chart like
+                            // a line chart).
+                            const currentTab = grapherState.activeTab
+                            if (previousTab !== currentTab)
+                                grapherState.onChartSwitching(
+                                    previousTab,
+                                    currentTab
+                                )
                         })
                     }
                 })


### PR DESCRIPTION
When switching between explorer/mdim views, we try to persist the tab. But if the new chart doesn't support the previously selected tab, then that's not possible and Grapher switches to another tab. If we happen to switch from a single-time chart to a multi-time chart (e.g. switching from a discrete bar chart to a line chart), then the line chart doesn't show any data because only a single time is selected. This wasn't a problem before before all line charts came with a bar chart, but that isn't the case anymore.

For testing, see Pablo's videos in [Slack](https://owid.slack.com/archives/C46U9LXRR/p1753346302019379). Here are the links the the example explorer and midm:
- https://ourworldindata.org/explorers/poverty-explorer
- https://admin.owid.io/admin/grapher/wb%2Flatest%2Fworld_bank_pip%23poverty