### PR TITLE
🔨 refactor fetchInputTableForConfig signature

### DIFF
--- a/adminSiteClient/GrapherConfigGridEditor.tsx
+++ b/adminSiteClient/GrapherConfigGridEditor.tsx
@@ -318,13 +318,14 @@ export class GrapherConfigGridEditor extends React.Component<GrapherConfigGridEd
             // the same country selection as you zap through the variables
             this.grapherState.clearSelection()
         this.grapherState.updateFromObject(newConfig)
-        const inputTable = await fetchInputTableForConfig(
-            newConfig.dimensions ?? [],
-            newConfig.selectedEntityColors,
-            this.context.admin.settings.DATA_API_FOR_ADMIN_UI || DATA_API_URL,
-            undefined,
-            true
-        )
+        const inputTable = await fetchInputTableForConfig({
+            dimensions: newConfig.dimensions,
+            selectedEntityColors: newConfig.selectedEntityColors,
+            dataApiUrl:
+                this.context.admin.settings.DATA_API_FOR_ADMIN_UI ||
+                DATA_API_URL,
+            noCache: true,
+        })
         if (inputTable) this.grapherState.inputTable = inputTable
     }
 

--- a/adminSiteClient/VariableEditPage.tsx
+++ b/adminSiteClient/VariableEditPage.tsx
@@ -731,13 +731,12 @@ class VariableEditor extends Component<{
                     noCache: true,
                 }),
         })
-        void fetchInputTableForConfig(
-            this.grapherConfig.dimensions ?? [],
-            this.grapherConfig.selectedEntityColors,
-            DATA_API_URL,
-            undefined,
-            true
-        ).then((inputTable) => {
+        void fetchInputTableForConfig({
+            dimensions: this.grapherConfig.dimensions,
+            selectedEntityColors: this.grapherConfig.selectedEntityColors,
+            dataApiUrl: DATA_API_URL,
+            noCache: true,
+        }).then((inputTable) => {
             if (inputTable) this.grapherState!.inputTable = inputTable
         })
 

--- a/baker/GrapherImageBaker.tsx
+++ b/baker/GrapherImageBaker.tsx
@@ -127,13 +127,12 @@ export async function grapherToSVG(
     grapher.grapherState.isExportingToSvgOrPng = true
     grapher.grapherState.shouldIncludeDetailsInStaticExport = false
     // grapher.receiveOwidData(vardata)
-    const inputTable = await fetchInputTableForConfig(
-        jsonConfig.dimensions ?? [],
-        jsonConfig.selectedEntityColors,
-        DATA_API_URL,
-        undefined,
-        false
-    )
+    const inputTable = await fetchInputTableForConfig({
+        dimensions: jsonConfig.dimensions ?? [],
+        selectedEntityColors: jsonConfig.selectedEntityColors,
+        dataApiUrl: DATA_API_URL,
+        noCache: false,
+    })
     if (inputTable) grapher.grapherState.inputTable = inputTable
     return grapher.grapherState.generateStaticSvg(
         ReactDOMServer.renderToStaticMarkup

--- a/functions/_common/downloadFunctions.ts
+++ b/functions/_common/downloadFunctions.ts
@@ -42,12 +42,11 @@ export async function fetchMetadataForGrapher(
         env
     )
 
-    const inputTable = await fetchInputTableForConfig(
-        grapher.grapherState.dimensions,
-        grapher.grapherState.selectedEntityColors,
-        getDataApiUrl(env),
-        undefined
-    )
+    const inputTable = await fetchInputTableForConfig({
+        dimensions: grapher.grapherState.dimensions,
+        selectedEntityColors: grapher.grapherState.selectedEntityColors,
+        dataApiUrl: getDataApiUrl(env),
+    })
     grapher.grapherState.inputTable = inputTable
 
     const fullMetadata = assembleMetadata(
@@ -71,12 +70,11 @@ export async function fetchZipForGrapher(
         searchParams ?? new URLSearchParams(""),
         env
     )
-    const inputTable = await fetchInputTableForConfig(
-        grapher.grapherState.dimensions,
-        grapher.grapherState.selectedEntityColors,
-        getDataApiUrl(env),
-        undefined
-    )
+    const inputTable = await fetchInputTableForConfig({
+        dimensions: grapher.grapherState.dimensions,
+        selectedEntityColors: grapher.grapherState.selectedEntityColors,
+        dataApiUrl: getDataApiUrl(env),
+    })
     grapher.grapherState.inputTable = inputTable
     ensureDownloadOfDataAllowed(grapher.grapherState)
     const metadata = assembleMetadata(grapher.grapherState, searchParams)
@@ -125,12 +123,11 @@ export async function fetchCsvForGrapher(
         searchParams ?? new URLSearchParams(""),
         env
     )
-    const inputTable = await fetchInputTableForConfig(
-        grapher.grapherState.dimensions,
-        grapher.grapherState.selectedEntityColors,
-        getDataApiUrl(env),
-        undefined
-    )
+    const inputTable = await fetchInputTableForConfig({
+        dimensions: grapher.grapherState.dimensions,
+        selectedEntityColors: grapher.grapherState.selectedEntityColors,
+        dataApiUrl: getDataApiUrl(env),
+    })
     grapher.grapherState.inputTable = inputTable
     console.log("checking if download is allowed")
     ensureDownloadOfDataAllowed(grapher.grapherState)
@@ -172,12 +169,11 @@ export async function fetchReadmeForGrapher(
         env
     )
 
-    const inputTable = await fetchInputTableForConfig(
-        grapher.grapherState.dimensions,
-        grapher.grapherState.selectedEntityColors,
-        getDataApiUrl(env),
-        undefined
-    )
+    const inputTable = await fetchInputTableForConfig({
+        dimensions: grapher.grapherState.dimensions,
+        selectedEntityColors: grapher.grapherState.selectedEntityColors,
+        dataApiUrl: getDataApiUrl(env),
+    })
     grapher.grapherState.inputTable = inputTable
 
     const readme = assembleReadme(
@@ -235,12 +231,11 @@ export async function fetchDataValuesForGrapher(
         searchParams,
         env
     )
-    const inputTable = await fetchInputTableForConfig(
-        grapher.grapherState.dimensions,
-        grapher.grapherState.selectedEntityColors,
-        getDataApiUrl(env),
-        undefined
-    )
+    const inputTable = await fetchInputTableForConfig({
+        dimensions: grapher.grapherState.dimensions,
+        selectedEntityColors: grapher.grapherState.selectedEntityColors,
+        dataApiUrl: getDataApiUrl(env),
+    })
     grapher.grapherState.inputTable = inputTable
 
     const { grapherState } = grapher

--- a/functions/_common/grapherRenderer.ts
+++ b/functions/_common/grapherRenderer.ts
@@ -77,12 +77,11 @@ async function fetchAndRenderGrapherToSvg(
     grapherLogger.log("initGrapher")
     const promises = []
     promises.push(
-        fetchInputTableForConfig(
-            grapher.grapherState.dimensions,
-            grapher.grapherState.selectedEntityColors,
-            getDataApiUrl(env),
-            undefined
-        )
+        fetchInputTableForConfig({
+            dimensions: grapher.grapherState.dimensions,
+            selectedEntityColors: grapher.grapherState.selectedEntityColors,
+            dataApiUrl: getDataApiUrl(env),
+        })
     )
     if (
         options.details &&

--- a/packages/@ourworldindata/explorer/src/Explorer.tsx
+++ b/packages/@ourworldindata/explorer/src/Explorer.tsx
@@ -600,13 +600,12 @@ export class Explorer
         grapherState.inputTable = BlankOwidTable()
         grapherState.updateFromObject(config)
         if (!config.table) {
-            const inputTable = await fetchInputTableForConfig(
-                config.dimensions ?? [],
-                config.selectedEntityColors,
-                this.props.dataApiUrl,
-                undefined,
-                this.props.isPreview
-            )
+            const inputTable = await fetchInputTableForConfig({
+                dimensions: config.dimensions,
+                selectedEntityColors: config.selectedEntityColors,
+                dataApiUrl: this.props.dataApiUrl,
+                noCache: this.props.isPreview,
+            })
             if (inputTable)
                 grapherState.inputTable = this.inputTableTransformer(inputTable)
         } else {
@@ -785,13 +784,12 @@ export class Explorer
             // so we don't end up confusingly showing stale data from a previous chart
             grapherState.inputTable = BlankOwidTable()
         } else {
-            const inputTable = await fetchInputTableForConfig(
-                config.dimensions,
-                config.selectedEntityColors,
-                this.props.dataApiUrl,
-                undefined,
-                this.props.isPreview
-            )
+            const inputTable = await fetchInputTableForConfig({
+                dimensions: config.dimensions,
+                selectedEntityColors: config.selectedEntityColors,
+                dataApiUrl: this.props.dataApiUrl,
+                noCache: this.props.isPreview,
+            })
             if (inputTable)
                 grapherState.inputTable = this.inputTableTransformer(inputTable)
         }

--- a/packages/@ourworldindata/grapher/src/core/FetchingGrapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/FetchingGrapher.tsx
@@ -122,14 +122,16 @@ export function FetchingGrapher(
         let isCancelled = false
 
         async function fetchData(): Promise<void> {
-            const inputTable = await fetchInputTableForConfig(
-                downloadedConfig?.dimensions ?? props.config?.dimensions ?? [],
-                downloadedConfig?.selectedEntityColors ??
+            const inputTable = await fetchInputTableForConfig({
+                dimensions:
+                    downloadedConfig?.dimensions ?? props.config?.dimensions,
+                selectedEntityColors:
+                    downloadedConfig?.selectedEntityColors ??
                     props.config?.selectedEntityColors,
-                props.dataApiUrl,
-                props.archivedChartInfo,
-                props.noCache
-            )
+                dataApiUrl: props.dataApiUrl,
+                archivedChartInfo: props.archivedChartInfo,
+                noCache: props.noCache,
+            })
 
             if (isCancelled) return
 

--- a/packages/@ourworldindata/grapher/src/core/loadGrapherTableHelpers.ts
+++ b/packages/@ourworldindata/grapher/src/core/loadGrapherTableHelpers.ts
@@ -12,27 +12,25 @@ import {
 } from "./loadVariable.js"
 import { toJS } from "mobx"
 
-export async function fetchInputTableForConfig(
-    dimensions: OwidChartDimensionInterface[],
-    selectedEntityColors:
-        | { [entityName: string]: string | undefined }
-        | undefined,
-    dataApiUrl: string,
-    archivedChartInfo: ArchiveContext | undefined,
+export async function fetchInputTableForConfig(args: {
+    dimensions?: OwidChartDimensionInterface[]
+    selectedEntityColors?: { [entityName: string]: string | undefined }
+    dataApiUrl: string
+    archivedChartInfo?: ArchiveContext
     noCache?: boolean
-): Promise<OwidTable | undefined> {
-    if (dimensions.length === 0) return undefined
-    const variables = dimensions.map((d) => d.variableId)
+}): Promise<OwidTable | undefined> {
+    if (!args.dimensions || args.dimensions.length === 0) return undefined
+    const variables = args.dimensions.map((d) => d.variableId)
     const variablesDataMap = await loadVariablesDataSite(
         variables,
-        dataApiUrl,
-        archivedChartInfo,
-        noCache
+        args.dataApiUrl,
+        args.archivedChartInfo,
+        args.noCache
     )
     const inputTable = legacyToOwidTableAndDimensionsWithMandatorySlug(
         variablesDataMap,
-        dimensions,
-        selectedEntityColors
+        args.dimensions,
+        args.selectedEntityColors
     )
 
     return inputTable


### PR DESCRIPTION
Minor refactor to make the `fetchInputTableForConfig` function easier to read