### PR TITLE
Fix typecheck errors in components

### DIFF
--- a/adminSiteClient/Forms.tsx
+++ b/adminSiteClient/Forms.tsx
@@ -301,12 +301,11 @@ export class NumberField extends React.Component<
     NumberFieldProps,
     NumberFieldState
 > {
+    state: NumberFieldState = {
+        inputValue: undefined,
+    }
     constructor(props: NumberFieldProps) {
         super(props)
-
-        this.state = {
-            inputValue: undefined,
-        }
     }
 
     override render() {

--- a/site/blocks/StickyNav.tsx
+++ b/site/blocks/StickyNav.tsx
@@ -47,7 +47,7 @@ class StickyNav extends Component<
     ulRef = createRef<HTMLUListElement>()
     resizeObserver: ResizeObserver | null = null
 
-    override state = {
+    state = {
         currentHeadingIndex: undefined,
         headingPositions: [] as HeadingPosition[],
         links: this.props.links,


### PR DESCRIPTION
Resolve typecheck errors by adjusting state initialization in the NumberField and StickyNav components.