### PR TITLE
🐛 fix videos being uncentered

### DIFF
--- a/site/gdocs/components/centered-article.scss
+++ b/site/gdocs/components/centered-article.scss
@@ -466,6 +466,7 @@ h3.article-block__heading {
 
 .article-block__video {
     margin: 32px 0;
+    text-align: center;
     a {
         @include owid-link-90;
     }


### PR DESCRIPTION
https://github.com/owid/owid-grapher/pull/5149 removed a line of CSS that was doing work for when a video had a vertical aspect ratio. This fixes that.

| Before | After |
|--------|--------|
| <img width="1165" height="815" alt="image" src="https://github.com/user-attachments/assets/57d76d43-cb65-422d-95ab-5d4ec3d80901" /> | <img width="1058" height="924" alt="image" src="https://github.com/user-attachments/assets/668d7d09-3cc5-4d9b-808b-42fd8ea43b5f" /> |
