### PR TITLE
🎉 slope chart table

### DIFF
--- a/packages/@ourworldindata/components/src/GrapherTrendArrow.tsx
+++ b/packages/@ourworldindata/components/src/GrapherTrendArrow.tsx
@@ -1,5 +1,7 @@
 import cx from "classnames"
 
+export type GrapherTrendArrowDirection = "up" | "right" | "down"
+
 const ARROW_PATHS = {
     up: "m14,0H5c-.552,0-1,.448-1,1s.448,1,1,1h6.586L.29303,13.29297l1.41394,1.414L13,3.41394v6.58606c0,.552.448,1,1,1s1-.448,1-1V1c0-.552-.448-1-1-1Z",
     down: "m14,4c-.552,0-1,.448-1,1v6.586L1.56049.14648.14655,1.56042l11.43958,11.43958h-6.58612c-.552,0-1,.448-1,1s.448,1,1,1h9c.552,0,1-.448,1-1V5c0-.552-.448-1-1-1Z",
@@ -8,12 +10,14 @@ const ARROW_PATHS = {
 
 export function GrapherTrendArrow({
     direction,
+    className,
 }: {
-    direction: "up" | "right" | "down"
+    direction: GrapherTrendArrowDirection
+    className?: string
 }): React.ReactElement {
     return (
         <svg
-            className={cx("GrapherTrendArrow", direction)}
+            className={cx("GrapherTrendArrow", direction, className)}
             xmlns="http://www.w3.org/2000/svg"
             viewBox={`0 0 ${direction === "right" ? 20 : 15} 15`}
         >

--- a/packages/@ourworldindata/components/src/index.ts
+++ b/packages/@ourworldindata/components/src/index.ts
@@ -68,4 +68,7 @@ export { LoadingIndicator } from "./loadingIndicator/LoadingIndicator.js"
 export { reactRenderToStringClientOnly } from "./reactUtil.js"
 
 export { GrapherTabIcon } from "./GrapherTabIcon.js"
-export { GrapherTrendArrow } from "./GrapherTrendArrow.js"
+export {
+    GrapherTrendArrow,
+    type GrapherTrendArrowDirection,
+} from "./GrapherTrendArrow.js"

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
@@ -216,18 +216,10 @@ export class SlopeChart
         })
     }
 
-    private focusStateForSeries(series: SlopeChartSeries): InteractionState {
-        return this.focusArray.state(series.seriesName)
-    }
-
     @computed private get renderSeries(): RenderSlopeChartSeries[] {
         const series: RenderSlopeChartSeries[] = this.placedSeries.map(
             (series) => {
-                return {
-                    ...series,
-                    hover: this.hoverStateForSeries(series),
-                    focus: this.focusStateForSeries(series),
-                }
+                return { ...series, hover: this.hoverStateForSeries(series) }
             }
         )
 
@@ -592,8 +584,8 @@ export class SlopeChart
             formattedValue: showSeriesName ? formattedValue : undefined,
             placeFormattedValueInNewLine: this.useCompactLayout,
             yValue: value,
+            focus: series.focus,
             hover: this.hoverStateForSeries(series),
-            focus: this.focusStateForSeries(series),
         }
     }
 

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChartConstants.ts
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChartConstants.ts
@@ -21,6 +21,7 @@ export interface SlopeChartSeries extends ChartSeries {
     start: Pick<OwidVariableRow<number>, "value" | "originalTime">
     end: Pick<OwidVariableRow<number>, "value" | "originalTime">
     annotation?: string
+    focus: InteractionState
 }
 
 export type RawSlopeChartSeries = PartialBy<SlopeChartSeries, "start" | "end">

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChartState.ts
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChartState.ts
@@ -227,6 +227,8 @@ export class SlopeChartState implements ChartState {
             seriesName
         )
 
+        const focus = this.focusArray.state(seriesName)
+
         return {
             column,
             seriesName,
@@ -236,6 +238,7 @@ export class SlopeChartState implements ChartState {
             start,
             end,
             annotation,
+            focus,
         }
     }
 

--- a/site/search/SearchChartHitDataTable.scss
+++ b/site/search/SearchChartHitDataTable.scss
@@ -82,4 +82,10 @@
         color: $gray-70;
         font-weight: 400;
     }
+
+    .search-chart-hit-table-row__arrow {
+        height: 0.8em;
+        padding-right: 0.25em;
+        padding-left: 0.15em;
+    }
 }

--- a/site/search/SearchChartHitDataTable.tsx
+++ b/site/search/SearchChartHitDataTable.tsx
@@ -1,14 +1,20 @@
 import cx from "classnames"
 import * as R from "remeda"
+import {
+    GrapherTrendArrow,
+    GrapherTrendArrowDirection,
+} from "@ourworldindata/components"
 
 interface TableRow {
     color: string
     name: string
     value: string
+    startValue?: string
     time?: string
     timePreposition?: string // defaults to 'in'
     muted?: boolean
     striped?: boolean
+    trend?: GrapherTrendArrowDirection // only relevant if startValue is given
 }
 
 export interface SearchChartHitDataTableProps {
@@ -89,6 +95,15 @@ function Row({
             <span className="search-chart-hit-table-row__name">{row.name}</span>
             <span className="search-chart-hit-table-row__spacer" />
             <span className="search-chart-hit-table-row__value">
+                {row.startValue && (
+                    <>
+                        {row.startValue}
+                        <GrapherTrendArrow
+                            className="search-chart-hit-table-row__arrow"
+                            direction={row.trend ?? "right"}
+                        />
+                    </>
+                )}
                 {row.value}
                 {row.time && (
                     <span className="search-chart-hit-table-row__time">

--- a/site/search/searchUtils.tsx
+++ b/site/search/searchUtils.tsx
@@ -12,6 +12,7 @@ import {
     GrapherValuesJson,
     GrapherValuesJsonDataPoint,
     OwidGdocType,
+    PrimitiveType,
     TagGraphRoot,
     TimeBounds,
 } from "@ourworldindata/types"
@@ -30,6 +31,7 @@ import {
     queryParamsToStr,
 } from "@ourworldindata/utils"
 import { partition, uniqueBy } from "remeda"
+import { type GrapherTrendArrowDirection } from "@ourworldindata/components"
 import {
     generateSelectedEntityNamesParam,
     GrapherState,
@@ -971,14 +973,10 @@ export function buildChartHitDataDisplayProps({
     const time = startDatapoint?.formattedTime
         ? `${startDatapoint?.formattedTime}–${endDatapoint.formattedTime}`
         : endDatapoint.formattedTime
-    const trend =
-        startDatapoint?.value !== undefined && endDatapoint?.value !== undefined
-            ? endDatapoint.value > startDatapoint.value
-                ? "up"
-                : endDatapoint.value < startDatapoint.value
-                  ? "down"
-                  : "right"
-            : undefined
+    const trend = calculateTrendDirection(
+        startDatapoint?.value,
+        endDatapoint?.value
+    )
     const showLocationIcon = isEntityPickedByUser
 
     return {
@@ -990,6 +988,19 @@ export function buildChartHitDataDisplayProps({
         trend,
         showLocationIcon,
     }
+}
+
+export function calculateTrendDirection(
+    startValue?: PrimitiveType,
+    endValue?: PrimitiveType
+): GrapherTrendArrowDirection | undefined {
+    if (typeof startValue !== "number" || typeof endValue !== "number")
+        return undefined
+    return endValue > startValue
+        ? "up"
+        : endValue < startValue
+          ? "down"
+          : "right"
 }
 
 function findDatapoint(


### PR DESCRIPTION
Implements slope chart tables in search results. The table shows start and end values with a trend indicator.

Example: http://staging-site-rich-data-revisions/data?q=Proportion+of+women+participating+in+the+labor+force

More examples: https://www.notion.so/owid/24074b71f92e804591e8dd8534b2d25d?v=24274b71f92e8071810b000c1d05ac90&source=copy_link