### PR TITLE
🎉 scatter plot chart table

### DIFF
--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.test.ts
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.test.ts
@@ -955,7 +955,7 @@ describe("correct bubble sizes", () => {
 
         const scatterPoints = new ScatterPointsWithLabels({
             noDataModalManager: manager,
-            isConnected: chart["isConnected"],
+            isConnected: chartState["isConnected"],
             hideConnectedScatterLines: chart["hideConnectedScatterLines"],
             seriesArray: chart["series"],
             dualAxis: chart["dualAxis"],
@@ -1020,7 +1020,7 @@ describe("correct bubble sizes", () => {
 
         const scatterPoints = new ScatterPointsWithLabels({
             noDataModalManager: manager,
-            isConnected: chart["isConnected"],
+            isConnected: chartState["isConnected"],
             hideConnectedScatterLines: chart["hideConnectedScatterLines"],
             seriesArray: chart["series"],
             dualAxis: chart["dualAxis"],

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
@@ -505,7 +505,7 @@ export class ScatterPlotChart
         return (
             <ScatterPointsWithLabels
                 noDataModalManager={this.manager}
-                isConnected={this.isConnected}
+                isConnected={this.chartState.isConnected}
                 hideConnectedScatterLines={this.hideConnectedScatterLines}
                 seriesArray={this.series}
                 dualAxis={this.dualAxis}
@@ -574,13 +574,9 @@ export class ScatterPlotChart
             )
     }
 
-    /** Whether series are shown as lines (instead of single points) */
-    @computed private get isConnected(): boolean {
-        return this.series.some((s) => s.points.length > 1)
-    }
-
     @computed private get sizeLegend(): ScatterSizeLegend | undefined {
-        if (this.isConnected || this.sizeColumn.isMissing) return undefined
+        if (this.chartState.isConnected || this.sizeColumn.isMissing)
+            return undefined
         return new ScatterSizeLegend(this)
     }
 
@@ -990,7 +986,7 @@ export class ScatterPlotChart
     @computed private get sizeRange(): [number, number] {
         if (this.sizeColumn.isMissing) {
             // if the size column is missing, we want all points/lines to have the same width
-            return this.isConnected
+            return this.chartState.isConnected
                 ? [SCATTER_LINE_DEFAULT_WIDTH, SCATTER_LINE_DEFAULT_WIDTH]
                 : [SCATTER_POINT_DEFAULT_RADIUS, SCATTER_POINT_DEFAULT_RADIUS]
         }
@@ -1005,7 +1001,7 @@ export class ScatterPlotChart
             )
         )
 
-        return this.isConnected
+        return this.chartState.isConnected
             ? // Note that the scale starts at 0.
               // When using the scale to plot marks, we need to make sure the minimums
               // (e.g. `SCATTER_POINT_MIN_RADIUS`) are respected.

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChartState.ts
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChartState.ts
@@ -364,6 +364,11 @@ export class ScatterPlotChartState implements ChartState, ColorScaleManager {
         })
     }
 
+    /** Whether series are shown as lines (instead of single points) */
+    @computed get isConnected(): boolean {
+        return this.series.some((s) => s.points.length > 1)
+    }
+
     @computed get allPoints(): SeriesPoint[] {
         return this.series.flatMap((series) => series.points)
     }

--- a/site/owid.scss
+++ b/site/owid.scss
@@ -59,6 +59,7 @@
 @import "./search/SearchChartHitSmall.scss";
 @import "./search/SearchChartHitDataDisplay.scss";
 @import "./search/SearchChartHitDataTable.scss";
+@import "./search/SearchChartHitDataPoints.scss";
 @import "./search/SearchActiveFilters.scss";
 @import "./search/SearchFilterPill.scss";
 @import "./search/SearchAutocompleteItemContents.scss";

--- a/site/search/SearchChartHitDataPoints.scss
+++ b/site/search/SearchChartHitDataPoints.scss
@@ -1,0 +1,43 @@
+.search-chart-hit-data-points {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-evenly;
+    height: 100%;
+    gap: 6px;
+
+    &.search-chart-hit-data-points--align-top {
+        justify-content: flex-start;
+    }
+
+    .search-chart-hit-data-points__separator {
+        border-bottom: 1px solid $gray-50;
+    }
+}
+
+.search-chart-hit-data-point {
+    .search-chart-hit-data-point__label {
+        @include note-1-regular;
+        color: $gray-70;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        margin-bottom: 2px;
+    }
+
+    .search-chart-hit-data-point__title {
+        font-weight: 700;
+    }
+
+    .search-chart-hit-data-point__value {
+        @include subtitle-1;
+        margin: 0;
+        font-weight: 700;
+        color: $gray-100;
+    }
+
+    .search-chart-hit-data-point__arrow {
+        height: 0.8em;
+        padding-right: 0.25em;
+        padding-left: 0.15em;
+    }
+}

--- a/site/search/SearchChartHitDataPoints.tsx
+++ b/site/search/SearchChartHitDataPoints.tsx
@@ -1,0 +1,73 @@
+import React from "react"
+import cx from "classnames"
+import {
+    GrapherTrendArrow,
+    GrapherTrendArrowDirection,
+} from "@ourworldindata/components"
+
+interface DataPoint {
+    columnName: string
+    unit?: string
+    time: string
+    entityName: string
+    value: string
+    startValue?: string
+    trend?: GrapherTrendArrowDirection // only relevant if startValue is given
+}
+
+export interface SearchChartHitDataPointsProps {
+    type: "data-points" // discriminant property, not used for rendering
+    dataPoints: DataPoint[]
+}
+
+export function SearchChartHitDataPoints({
+    dataPoints,
+}: SearchChartHitDataPointsProps): React.ReactElement {
+    return (
+        <div
+            className={cx("search-chart-hit-data-points", {
+                "search-chart-hit-data-points--align-top":
+                    dataPoints.length < 2,
+            })}
+        >
+            {dataPoints.map((point, index) => (
+                <React.Fragment key={index}>
+                    {index > 0 && (
+                        <div className="search-chart-hit-data-points__separator" />
+                    )}
+                    <DataPoint dataPoint={point} />
+                </React.Fragment>
+            ))}
+        </div>
+    )
+}
+
+function DataPoint({
+    dataPoint,
+}: {
+    dataPoint: DataPoint
+}): React.ReactElement {
+    return (
+        <div className="search-chart-hit-data-point">
+            <div className="search-chart-hit-data-point__label">
+                <span className="search-chart-hit-data-point__title">
+                    {dataPoint.columnName}
+                </span>
+                {dataPoint.unit && ` (${dataPoint.unit})`}, {dataPoint.time},{" "}
+                {dataPoint.entityName}
+            </div>
+            <div className="search-chart-hit-data-point__value">
+                {dataPoint.startValue && (
+                    <>
+                        {dataPoint.startValue}
+                        <GrapherTrendArrow
+                            className="search-chart-hit-data-point__arrow"
+                            direction={dataPoint.trend ?? "right"}
+                        />
+                    </>
+                )}
+                {dataPoint.value}
+            </div>
+        </div>
+    )
+}

--- a/site/search/SearchChartHitDataPoints.tsx
+++ b/site/search/SearchChartHitDataPoints.tsx
@@ -16,7 +16,6 @@ interface DataPoint {
 }
 
 export interface SearchChartHitDataPointsProps {
-    type: "data-points" // discriminant property, not used for rendering
     dataPoints: DataPoint[]
 }
 

--- a/site/search/SearchChartHitDataTable.scss
+++ b/site/search/SearchChartHitDataTable.scss
@@ -1,4 +1,4 @@
-.search-chart-hit-table-content {
+.search-chart-hit-table {
     @include note-1-regular;
     color: $gray-100;
     height: 100%;

--- a/site/search/SearchChartHitDataTable.tsx
+++ b/site/search/SearchChartHitDataTable.tsx
@@ -19,6 +19,7 @@ interface TableRow {
 }
 
 export interface SearchChartHitDataTableProps {
+    type: "data-table" // discriminant property, not used for rendering
     rows: TableRow[]
     title: string
 }
@@ -43,20 +44,18 @@ export function SearchChartHitDataTable({
 
     return (
         <div className="search-chart-hit-table">
-            <div className="search-chart-hit-table-content">
-                <Header
-                    title={title}
-                    time={shouldShowTimeInTitle ? time : undefined}
+            <Header
+                title={title}
+                time={shouldShowTimeInTitle ? time : undefined}
+            />
+            {displayRows.map((row) => (
+                <Row
+                    key={row.name}
+                    row={row}
+                    shouldShowSwatch={shouldShowSwatch}
+                    shouldSpanBothColumns={displayRows.length <= 4}
                 />
-                {displayRows.map((row) => (
-                    <Row
-                        key={row.name}
-                        row={row}
-                        shouldShowSwatch={shouldShowSwatch}
-                        shouldSpanBothColumns={rows.length <= 4}
-                    />
-                ))}
-            </div>
+            ))}
         </div>
     )
 }

--- a/site/search/SearchChartHitDataTable.tsx
+++ b/site/search/SearchChartHitDataTable.tsx
@@ -19,7 +19,6 @@ interface TableRow {
 }
 
 export interface SearchChartHitDataTableProps {
-    type: "data-table" // discriminant property, not used for rendering
     rows: TableRow[]
     title: string
 }

--- a/site/search/SearchChartHitDataTableHelpers.test.ts
+++ b/site/search/SearchChartHitDataTableHelpers.test.ts
@@ -17,6 +17,7 @@ import {
     SynthesizeFruitTable,
 } from "@ourworldindata/core-table"
 import { buildChartHitDataTableProps } from "./SearchChartHitDataTableHelpers"
+import { SearchChartHitDataTableProps } from "./SearchChartHitDataTable"
 
 function createSingleIndicatorGrapherState(
     overrides: GrapherProgrammaticInterface = {}
@@ -104,33 +105,39 @@ describe("buildChartHitDataTableProps for LineChart", () => {
     it("lists entities when entities are plotted", () => {
         const grapherState = createSingleIndicatorGrapherState()
 
-        const dataTable = buildChartHitDataTableProps({ grapherState })
+        const result = buildChartHitDataTableProps({ grapherState })
 
-        expect(dataTable?.title).toBe("GDP")
-        expect(dataTable?.rows).toMatchObject([
+        expect(result?.type).toBe("data-table")
+        const dataTable = result as SearchChartHitDataTableProps
+
+        expect(dataTable.title).toBe("GDP")
+        expect(dataTable.rows).toMatchObject([
             { name: "Philippines", time: "2009", value: "$682.03 billion" },
             { name: "Benin", time: "2009", value: "$233.42 billion" },
             { name: "Eritrea", time: "2009", value: "$63.2 billion" },
         ])
 
         // Check that the colors are unique
-        const colors = dataTable?.rows.map((row) => row.color)
+        const colors = dataTable.rows.map((row) => row.color)
         expect(new Set(colors)).toHaveLength(colors!.length)
     })
 
     it("lists columns when columns are plotted", () => {
         const grapherState = createFruityMultipleIndicatorsGrapherState()
 
-        const dataTable = buildChartHitDataTableProps({ grapherState })
+        const result = buildChartHitDataTableProps({ grapherState })
 
-        expect(dataTable?.title).toBe("Benin")
-        expect(dataTable?.rows).toMatchObject([
+        expect(result?.type).toBe("data-table")
+        const dataTable = result as SearchChartHitDataTableProps
+
+        expect(dataTable.title).toBe("Benin")
+        expect(dataTable.rows).toMatchObject([
             { name: "Fruit", time: "2009", value: "573" },
             { name: "Vegetables", time: "2009", value: "542" },
         ])
 
         // Check that the colors are unique
-        const colors = dataTable?.rows.map((row) => row.color)
+        const colors = dataTable.rows.map((row) => row.color)
         expect(new Set(colors)).toHaveLength(colors!.length)
     })
 
@@ -141,9 +148,12 @@ describe("buildChartHitDataTableProps for LineChart", () => {
             focusedSeriesNames: [selectedEntityNames[1]],
         })
 
-        const dataTable = buildChartHitDataTableProps({ grapherState })
+        const result = buildChartHitDataTableProps({ grapherState })
 
-        expect(dataTable?.rows).toMatchObject([
+        expect(result?.type).toBe("data-table")
+        const dataTable = result as SearchChartHitDataTableProps
+
+        expect(dataTable.rows).toMatchObject([
             { name: "Philippines", muted: true },
             { name: "Benin", muted: false },
             { name: "Eritrea", muted: true },
@@ -155,10 +165,13 @@ describe("buildChartHitDataTableProps for LineChart", () => {
             selectedFacetStrategy: FacetStrategy.entity,
         })
 
-        const dataTable = buildChartHitDataTableProps({ grapherState })
+        const result = buildChartHitDataTableProps({ grapherState })
 
-        expect(dataTable?.title).toBe("GDP")
-        expect(dataTable?.rows).toMatchObject([
+        expect(result?.type).toBe("data-table")
+        const dataTable = result as SearchChartHitDataTableProps
+
+        expect(dataTable.title).toBe("GDP")
+        expect(dataTable.rows).toMatchObject([
             { name: "Philippines", time: "2009", value: "$682.03 billion" },
             { name: "Benin", time: "2009", value: "$233.42 billion" },
             { name: "Eritrea", time: "2009", value: "$63.2 billion" },
@@ -170,17 +183,20 @@ describe("buildChartHitDataTableProps for LineChart", () => {
             selectedFacetStrategy: FacetStrategy.metric,
         })
 
-        const dataTable = buildChartHitDataTableProps({ grapherState })
+        const result = buildChartHitDataTableProps({ grapherState })
 
-        expect(dataTable?.title).toBe("GDP")
-        expect(dataTable?.rows).toMatchObject([
+        expect(result?.type).toBe("data-table")
+        const dataTable = result as SearchChartHitDataTableProps
+
+        expect(dataTable.title).toBe("GDP")
+        expect(dataTable.rows).toMatchObject([
             { name: "Philippines", time: "2009", value: "$682.03 billion" },
             { name: "Benin", time: "2009", value: "$233.42 billion" },
             { name: "Eritrea", time: "2009", value: "$63.2 billion" },
         ])
 
         // Check that the colors are unique
-        const colors = dataTable?.rows.map((row) => row.color)
+        const colors = dataTable.rows.map((row) => row.color)
         expect(new Set(colors)).toHaveLength(colors!.length)
     })
 })
@@ -191,10 +207,13 @@ describe("buildChartHitDataTableProps for SlopeChart", () => {
             chartTypes: [GRAPHER_CHART_TYPES.SlopeChart],
         })
 
-        const dataTable = buildChartHitDataTableProps({ grapherState })
+        const result = buildChartHitDataTableProps({ grapherState })
 
-        expect(dataTable?.title).toBe("GDP")
-        expect(dataTable?.rows).toMatchObject([
+        expect(result?.type).toBe("data-table")
+        const dataTable = result as SearchChartHitDataTableProps
+
+        expect(dataTable.title).toBe("GDP")
+        expect(dataTable.rows).toMatchObject([
             {
                 name: "Philippines",
                 time: "2000–2009",
@@ -219,7 +238,7 @@ describe("buildChartHitDataTableProps for SlopeChart", () => {
         ])
 
         // Check that the colors are unique
-        const colors = dataTable?.rows.map((row) => row.color)
+        const colors = dataTable.rows.map((row) => row.color)
         expect(new Set(colors)).toHaveLength(colors!.length)
     })
 
@@ -228,10 +247,13 @@ describe("buildChartHitDataTableProps for SlopeChart", () => {
             chartTypes: [GRAPHER_CHART_TYPES.SlopeChart],
         })
 
-        const dataTable = buildChartHitDataTableProps({ grapherState })
+        const result = buildChartHitDataTableProps({ grapherState })
 
-        expect(dataTable?.title).toBe("Benin")
-        expect(dataTable?.rows).toMatchObject([
+        expect(result?.type).toBe("data-table")
+        const dataTable = result as SearchChartHitDataTableProps
+
+        expect(dataTable.title).toBe("Benin")
+        expect(dataTable.rows).toMatchObject([
             {
                 name: "Fruit",
                 time: "2000–2009",
@@ -249,7 +271,7 @@ describe("buildChartHitDataTableProps for SlopeChart", () => {
         ])
 
         // Check that the colors are unique
-        const colors = dataTable?.rows.map((row) => row.color)
+        const colors = dataTable.rows.map((row) => row.color)
         expect(new Set(colors)).toHaveLength(colors!.length)
     })
 
@@ -264,10 +286,13 @@ describe("buildChartHitDataTableProps for SlopeChart", () => {
             focusedSeriesNames: [selectedEntityNames[0]],
         })
 
-        const dataTable = buildChartHitDataTableProps({ grapherState })
+        const result = buildChartHitDataTableProps({ grapherState })
 
-        expect(dataTable?.title).toBe("GDP")
-        expect(dataTable?.rows).toMatchObject([
+        expect(result?.type).toBe("data-table")
+        const dataTable = result as SearchChartHitDataTableProps
+
+        expect(dataTable.title).toBe("GDP")
+        expect(dataTable.rows).toMatchObject([
             { name: "Philippines", muted: true },
             { name: "Benin", muted: false },
             { name: "Eritrea", muted: true },
@@ -280,10 +305,13 @@ describe("buildChartHitDataTableProps for SlopeChart", () => {
             selectedFacetStrategy: FacetStrategy.entity,
         })
 
-        const dataTable = buildChartHitDataTableProps({ grapherState })
+        const result = buildChartHitDataTableProps({ grapherState })
 
-        expect(dataTable?.title).toBe("GDP")
-        expect(dataTable?.rows).toMatchObject([
+        expect(result?.type).toBe("data-table")
+        const dataTable = result as SearchChartHitDataTableProps
+
+        expect(dataTable.title).toBe("GDP")
+        expect(dataTable.rows).toMatchObject([
             {
                 name: "Philippines",
                 startValue: "$663.99 billion",
@@ -314,10 +342,13 @@ describe("buildChartHitDataTableProps for SlopeChart", () => {
             selectedFacetStrategy: FacetStrategy.metric,
         })
 
-        const dataTable = buildChartHitDataTableProps({ grapherState })
+        const result = buildChartHitDataTableProps({ grapherState })
 
-        expect(dataTable?.title).toBe("GDP")
-        expect(dataTable?.rows).toMatchObject([
+        expect(result?.type).toBe("data-table")
+        const dataTable = result as SearchChartHitDataTableProps
+
+        expect(dataTable.title).toBe("GDP")
+        expect(dataTable.rows).toMatchObject([
             {
                 name: "Philippines",
                 startValue: "$663.99 billion",
@@ -342,7 +373,7 @@ describe("buildChartHitDataTableProps for SlopeChart", () => {
         ])
 
         // Check that the colors are unique
-        const colors = dataTable?.rows.map((row) => row.color)
+        const colors = dataTable.rows.map((row) => row.color)
         expect(new Set(colors)).toHaveLength(colors!.length)
     })
 })
@@ -353,17 +384,20 @@ describe("buildChartHitDataTableProps for StackedAreaChart", () => {
             chartTypes: [GRAPHER_CHART_TYPES.StackedArea],
         })
 
-        const dataTable = buildChartHitDataTableProps({ grapherState })
+        const result = buildChartHitDataTableProps({ grapherState })
 
-        expect(dataTable?.title).toBe("GDP")
-        expect(dataTable?.rows).toMatchObject([
+        expect(result?.type).toBe("data-table")
+        const dataTable = result as SearchChartHitDataTableProps
+
+        expect(dataTable.title).toBe("GDP")
+        expect(dataTable.rows).toMatchObject([
             { name: "Benin", time: "2009", value: "$233.42 billion" },
             { name: "Philippines", time: "2009", value: "$682.03 billion" },
             { name: "Eritrea", time: "2009", value: "$63.2 billion" },
         ])
 
         // Check that the colors are unique
-        const colors = dataTable?.rows.map((row) => row.color)
+        const colors = dataTable.rows.map((row) => row.color)
         expect(new Set(colors)).toHaveLength(colors!.length)
     })
 
@@ -372,16 +406,19 @@ describe("buildChartHitDataTableProps for StackedAreaChart", () => {
             chartTypes: [GRAPHER_CHART_TYPES.StackedArea],
         })
 
-        const dataTable = buildChartHitDataTableProps({ grapherState })
+        const result = buildChartHitDataTableProps({ grapherState })
 
-        expect(dataTable?.title).toBe("Benin")
-        expect(dataTable?.rows).toMatchObject([
+        expect(result?.type).toBe("data-table")
+        const dataTable = result as SearchChartHitDataTableProps
+
+        expect(dataTable.title).toBe("Benin")
+        expect(dataTable.rows).toMatchObject([
             { name: "Fruit", time: "2009", value: "573" },
             { name: "Vegetables", time: "2009", value: "542" },
         ])
 
         // Check that the colors are unique
-        const colors = dataTable?.rows.map((row) => row.color)
+        const colors = dataTable.rows.map((row) => row.color)
         expect(new Set(colors)).toHaveLength(colors!.length)
     })
 
@@ -393,9 +430,12 @@ describe("buildChartHitDataTableProps for StackedAreaChart", () => {
             focusedSeriesNames: [selectedEntityNames[1]],
         })
 
-        const dataTable = buildChartHitDataTableProps({ grapherState })
+        const result = buildChartHitDataTableProps({ grapherState })
 
-        expect(dataTable?.rows).toMatchObject([
+        expect(result?.type).toBe("data-table")
+        const dataTable = result as SearchChartHitDataTableProps
+
+        expect(dataTable.rows).toMatchObject([
             { name: "Philippines", muted: true },
             { name: "Benin", muted: false },
             { name: "Eritrea", muted: true },
@@ -408,10 +448,13 @@ describe("buildChartHitDataTableProps for StackedAreaChart", () => {
             selectedFacetStrategy: FacetStrategy.entity,
         })
 
-        const dataTable = buildChartHitDataTableProps({ grapherState })
+        const result = buildChartHitDataTableProps({ grapherState })
 
-        expect(dataTable?.title).toBe("GDP")
-        expect(dataTable?.rows).toMatchObject([
+        expect(result?.type).toBe("data-table")
+        const dataTable = result as SearchChartHitDataTableProps
+
+        expect(dataTable.title).toBe("GDP")
+        expect(dataTable.rows).toMatchObject([
             { name: "Benin", time: "2009", value: "$233.42 billion" },
             { name: "Philippines", time: "2009", value: "$682.03 billion" },
             { name: "Eritrea", time: "2009", value: "$63.2 billion" },
@@ -424,17 +467,20 @@ describe("buildChartHitDataTableProps for StackedAreaChart", () => {
             selectedFacetStrategy: FacetStrategy.metric,
         })
 
-        const dataTable = buildChartHitDataTableProps({ grapherState })
+        const result = buildChartHitDataTableProps({ grapherState })
 
-        expect(dataTable?.title).toBe("GDP")
-        expect(dataTable?.rows).toMatchObject([
+        expect(result?.type).toBe("data-table")
+        const dataTable = result as SearchChartHitDataTableProps
+
+        expect(dataTable.title).toBe("GDP")
+        expect(dataTable.rows).toMatchObject([
             { name: "Benin", time: "2009", value: "$233.42 billion" },
             { name: "Philippines", time: "2009", value: "$682.03 billion" },
             { name: "Eritrea", time: "2009", value: "$63.2 billion" },
         ])
 
         // Check that the colors are unique
-        const colors = dataTable?.rows.map((row) => row.color)
+        const colors = dataTable.rows.map((row) => row.color)
         expect(new Set(colors)).toHaveLength(colors!.length)
     })
 })
@@ -445,10 +491,13 @@ describe("buildChartHitDataTableProps for DiscreteBar", () => {
             chartTypes: [GRAPHER_CHART_TYPES.DiscreteBar],
         })
 
-        const dataTable = buildChartHitDataTableProps({ grapherState })
+        const result = buildChartHitDataTableProps({ grapherState })
 
-        expect(dataTable?.title).toBe("GDP")
-        expect(dataTable?.rows).toMatchObject([
+        expect(result?.type).toBe("data-table")
+        const dataTable = result as SearchChartHitDataTableProps
+
+        expect(dataTable.title).toBe("GDP")
+        expect(dataTable.rows).toMatchObject([
             { name: "Philippines", time: "2009", value: "$682.03 billion" },
             { name: "Benin", time: "2009", value: "$233.42 billion" },
             { name: "Eritrea", time: "2009", value: "$63.2 billion" },
@@ -460,10 +509,13 @@ describe("buildChartHitDataTableProps for DiscreteBar", () => {
             chartTypes: [GRAPHER_CHART_TYPES.DiscreteBar],
         })
 
-        const dataTable = buildChartHitDataTableProps({ grapherState })
+        const result = buildChartHitDataTableProps({ grapherState })
 
-        expect(dataTable?.title).toBe("Benin")
-        expect(dataTable?.rows).toMatchObject([
+        expect(result?.type).toBe("data-table")
+        const dataTable = result as SearchChartHitDataTableProps
+
+        expect(dataTable.title).toBe("Benin")
+        expect(dataTable.rows).toMatchObject([
             { name: "Fruit", time: "2009", value: "573" },
             { name: "Vegetables", time: "2009", value: "542" },
         ])
@@ -477,9 +529,12 @@ describe("buildChartHitDataTableProps for DiscreteBar", () => {
             focusedSeriesNames: [selectedEntityNames[1]],
         })
 
-        const dataTable = buildChartHitDataTableProps({ grapherState })
+        const result = buildChartHitDataTableProps({ grapherState })
 
-        expect(dataTable?.rows).toMatchObject([
+        expect(result?.type).toBe("data-table")
+        const dataTable = result as SearchChartHitDataTableProps
+
+        expect(dataTable.rows).toMatchObject([
             { name: "Philippines", muted: true },
             { name: "Benin", muted: false },
             { name: "Eritrea", muted: true },
@@ -492,10 +547,13 @@ describe("buildChartHitDataTableProps for DiscreteBar", () => {
             selectedFacetStrategy: FacetStrategy.entity,
         })
 
-        const dataTable = buildChartHitDataTableProps({ grapherState })
+        const result = buildChartHitDataTableProps({ grapherState })
 
-        expect(dataTable?.title).toBe("GDP")
-        expect(dataTable?.rows).toMatchObject([
+        expect(result?.type).toBe("data-table")
+        const dataTable = result as SearchChartHitDataTableProps
+
+        expect(dataTable.title).toBe("GDP")
+        expect(dataTable.rows).toMatchObject([
             { name: "Philippines", time: "2009", value: "$682.03 billion" },
             { name: "Benin", time: "2009", value: "$233.42 billion" },
             { name: "Eritrea", time: "2009", value: "$63.2 billion" },
@@ -508,10 +566,13 @@ describe("buildChartHitDataTableProps for DiscreteBar", () => {
             selectedFacetStrategy: FacetStrategy.metric,
         })
 
-        const dataTable = buildChartHitDataTableProps({ grapherState })
+        const result = buildChartHitDataTableProps({ grapherState })
 
-        expect(dataTable?.title).toBe("GDP")
-        expect(dataTable?.rows).toMatchObject([
+        expect(result?.type).toBe("data-table")
+        const dataTable = result as SearchChartHitDataTableProps
+
+        expect(dataTable.title).toBe("GDP")
+        expect(dataTable.rows).toMatchObject([
             { name: "Philippines", time: "2009", value: "$682.03 billion" },
             { name: "Benin", time: "2009", value: "$233.42 billion" },
             { name: "Eritrea", time: "2009", value: "$63.2 billion" },
@@ -536,10 +597,13 @@ describe("buildChartHitDataTableProps for WorldMap", () => {
             },
         })
 
-        const dataTable = buildChartHitDataTableProps({ grapherState })
+        const result = buildChartHitDataTableProps({ grapherState })
 
-        expect(dataTable?.title).toBe("GDP")
-        expect(dataTable?.rows).toMatchObject([
+        expect(result?.type).toBe("data-table")
+        const dataTable = result as SearchChartHitDataTableProps
+
+        expect(dataTable.title).toBe("GDP")
+        expect(dataTable.rows).toMatchObject([
             {
                 color: "#eff3ff",
                 name: "$1 billion-$3 billion",

--- a/site/search/SearchChartHitDataTableHelpers.test.ts
+++ b/site/search/SearchChartHitDataTableHelpers.test.ts
@@ -16,7 +16,7 @@ import {
     SampleColumnSlugs,
     SynthesizeFruitTable,
 } from "@ourworldindata/core-table"
-import { buildChartHitDataTableProps } from "./SearchChartHitDataTableHelpers"
+import { buildChartHitDataTableContent } from "./SearchChartHitDataTableHelpers"
 import { SearchChartHitDataTableProps } from "./SearchChartHitDataTable"
 
 function createSingleIndicatorGrapherState(
@@ -101,14 +101,14 @@ function createFruityMultipleIndicatorsGrapherState(
     })
 }
 
-describe("buildChartHitDataTableProps for LineChart", () => {
+describe("buildChartHitDataTableContent for LineChart", () => {
     it("lists entities when entities are plotted", () => {
         const grapherState = createSingleIndicatorGrapherState()
 
-        const result = buildChartHitDataTableProps({ grapherState })
+        const result = buildChartHitDataTableContent({ grapherState })
 
         expect(result?.type).toBe("data-table")
-        const dataTable = result as SearchChartHitDataTableProps
+        const dataTable = result?.props as SearchChartHitDataTableProps
 
         expect(dataTable.title).toBe("GDP")
         expect(dataTable.rows).toMatchObject([
@@ -125,10 +125,10 @@ describe("buildChartHitDataTableProps for LineChart", () => {
     it("lists columns when columns are plotted", () => {
         const grapherState = createFruityMultipleIndicatorsGrapherState()
 
-        const result = buildChartHitDataTableProps({ grapherState })
+        const result = buildChartHitDataTableContent({ grapherState })
 
         expect(result?.type).toBe("data-table")
-        const dataTable = result as SearchChartHitDataTableProps
+        const dataTable = result?.props as SearchChartHitDataTableProps
 
         expect(dataTable.title).toBe("Benin")
         expect(dataTable.rows).toMatchObject([
@@ -148,10 +148,10 @@ describe("buildChartHitDataTableProps for LineChart", () => {
             focusedSeriesNames: [selectedEntityNames[1]],
         })
 
-        const result = buildChartHitDataTableProps({ grapherState })
+        const result = buildChartHitDataTableContent({ grapherState })
 
         expect(result?.type).toBe("data-table")
-        const dataTable = result as SearchChartHitDataTableProps
+        const dataTable = result?.props as SearchChartHitDataTableProps
 
         expect(dataTable.rows).toMatchObject([
             { name: "Philippines", muted: true },
@@ -165,10 +165,10 @@ describe("buildChartHitDataTableProps for LineChart", () => {
             selectedFacetStrategy: FacetStrategy.entity,
         })
 
-        const result = buildChartHitDataTableProps({ grapherState })
+        const result = buildChartHitDataTableContent({ grapherState })
 
         expect(result?.type).toBe("data-table")
-        const dataTable = result as SearchChartHitDataTableProps
+        const dataTable = result?.props as SearchChartHitDataTableProps
 
         expect(dataTable.title).toBe("GDP")
         expect(dataTable.rows).toMatchObject([
@@ -183,10 +183,10 @@ describe("buildChartHitDataTableProps for LineChart", () => {
             selectedFacetStrategy: FacetStrategy.metric,
         })
 
-        const result = buildChartHitDataTableProps({ grapherState })
+        const result = buildChartHitDataTableContent({ grapherState })
 
         expect(result?.type).toBe("data-table")
-        const dataTable = result as SearchChartHitDataTableProps
+        const dataTable = result?.props as SearchChartHitDataTableProps
 
         expect(dataTable.title).toBe("GDP")
         expect(dataTable.rows).toMatchObject([
@@ -201,16 +201,16 @@ describe("buildChartHitDataTableProps for LineChart", () => {
     })
 })
 
-describe("buildChartHitDataTableProps for SlopeChart", () => {
+describe("buildChartHitDataTableContent for SlopeChart", () => {
     it("lists entities when entities are plotted", () => {
         const grapherState = createSingleIndicatorGrapherState({
             chartTypes: [GRAPHER_CHART_TYPES.SlopeChart],
         })
 
-        const result = buildChartHitDataTableProps({ grapherState })
+        const result = buildChartHitDataTableContent({ grapherState })
 
         expect(result?.type).toBe("data-table")
-        const dataTable = result as SearchChartHitDataTableProps
+        const dataTable = result?.props as SearchChartHitDataTableProps
 
         expect(dataTable.title).toBe("GDP")
         expect(dataTable.rows).toMatchObject([
@@ -247,10 +247,10 @@ describe("buildChartHitDataTableProps for SlopeChart", () => {
             chartTypes: [GRAPHER_CHART_TYPES.SlopeChart],
         })
 
-        const result = buildChartHitDataTableProps({ grapherState })
+        const result = buildChartHitDataTableContent({ grapherState })
 
         expect(result?.type).toBe("data-table")
-        const dataTable = result as SearchChartHitDataTableProps
+        const dataTable = result?.props as SearchChartHitDataTableProps
 
         expect(dataTable.title).toBe("Benin")
         expect(dataTable.rows).toMatchObject([
@@ -286,10 +286,10 @@ describe("buildChartHitDataTableProps for SlopeChart", () => {
             focusedSeriesNames: [selectedEntityNames[0]],
         })
 
-        const result = buildChartHitDataTableProps({ grapherState })
+        const result = buildChartHitDataTableContent({ grapherState })
 
         expect(result?.type).toBe("data-table")
-        const dataTable = result as SearchChartHitDataTableProps
+        const dataTable = result?.props as SearchChartHitDataTableProps
 
         expect(dataTable.title).toBe("GDP")
         expect(dataTable.rows).toMatchObject([
@@ -305,10 +305,10 @@ describe("buildChartHitDataTableProps for SlopeChart", () => {
             selectedFacetStrategy: FacetStrategy.entity,
         })
 
-        const result = buildChartHitDataTableProps({ grapherState })
+        const result = buildChartHitDataTableContent({ grapherState })
 
         expect(result?.type).toBe("data-table")
-        const dataTable = result as SearchChartHitDataTableProps
+        const dataTable = result?.props as SearchChartHitDataTableProps
 
         expect(dataTable.title).toBe("GDP")
         expect(dataTable.rows).toMatchObject([
@@ -342,10 +342,10 @@ describe("buildChartHitDataTableProps for SlopeChart", () => {
             selectedFacetStrategy: FacetStrategy.metric,
         })
 
-        const result = buildChartHitDataTableProps({ grapherState })
+        const result = buildChartHitDataTableContent({ grapherState })
 
         expect(result?.type).toBe("data-table")
-        const dataTable = result as SearchChartHitDataTableProps
+        const dataTable = result?.props as SearchChartHitDataTableProps
 
         expect(dataTable.title).toBe("GDP")
         expect(dataTable.rows).toMatchObject([
@@ -378,16 +378,16 @@ describe("buildChartHitDataTableProps for SlopeChart", () => {
     })
 })
 
-describe("buildChartHitDataTableProps for StackedAreaChart", () => {
+describe("buildChartHitDataTableContent for StackedAreaChart", () => {
     it("lists entities when entities are plotted", () => {
         const grapherState = createSingleIndicatorGrapherState({
             chartTypes: [GRAPHER_CHART_TYPES.StackedArea],
         })
 
-        const result = buildChartHitDataTableProps({ grapherState })
+        const result = buildChartHitDataTableContent({ grapherState })
 
         expect(result?.type).toBe("data-table")
-        const dataTable = result as SearchChartHitDataTableProps
+        const dataTable = result?.props as SearchChartHitDataTableProps
 
         expect(dataTable.title).toBe("GDP")
         expect(dataTable.rows).toMatchObject([
@@ -406,10 +406,10 @@ describe("buildChartHitDataTableProps for StackedAreaChart", () => {
             chartTypes: [GRAPHER_CHART_TYPES.StackedArea],
         })
 
-        const result = buildChartHitDataTableProps({ grapherState })
+        const result = buildChartHitDataTableContent({ grapherState })
 
         expect(result?.type).toBe("data-table")
-        const dataTable = result as SearchChartHitDataTableProps
+        const dataTable = result?.props as SearchChartHitDataTableProps
 
         expect(dataTable.title).toBe("Benin")
         expect(dataTable.rows).toMatchObject([
@@ -430,10 +430,10 @@ describe("buildChartHitDataTableProps for StackedAreaChart", () => {
             focusedSeriesNames: [selectedEntityNames[1]],
         })
 
-        const result = buildChartHitDataTableProps({ grapherState })
+        const result = buildChartHitDataTableContent({ grapherState })
 
         expect(result?.type).toBe("data-table")
-        const dataTable = result as SearchChartHitDataTableProps
+        const dataTable = result?.props as SearchChartHitDataTableProps
 
         expect(dataTable.rows).toMatchObject([
             { name: "Philippines", muted: true },
@@ -448,10 +448,10 @@ describe("buildChartHitDataTableProps for StackedAreaChart", () => {
             selectedFacetStrategy: FacetStrategy.entity,
         })
 
-        const result = buildChartHitDataTableProps({ grapherState })
+        const result = buildChartHitDataTableContent({ grapherState })
 
         expect(result?.type).toBe("data-table")
-        const dataTable = result as SearchChartHitDataTableProps
+        const dataTable = result?.props as SearchChartHitDataTableProps
 
         expect(dataTable.title).toBe("GDP")
         expect(dataTable.rows).toMatchObject([
@@ -467,10 +467,10 @@ describe("buildChartHitDataTableProps for StackedAreaChart", () => {
             selectedFacetStrategy: FacetStrategy.metric,
         })
 
-        const result = buildChartHitDataTableProps({ grapherState })
+        const result = buildChartHitDataTableContent({ grapherState })
 
         expect(result?.type).toBe("data-table")
-        const dataTable = result as SearchChartHitDataTableProps
+        const dataTable = result?.props as SearchChartHitDataTableProps
 
         expect(dataTable.title).toBe("GDP")
         expect(dataTable.rows).toMatchObject([
@@ -485,16 +485,16 @@ describe("buildChartHitDataTableProps for StackedAreaChart", () => {
     })
 })
 
-describe("buildChartHitDataTableProps for DiscreteBar", () => {
+describe("buildChartHitDataTableContent for DiscreteBar", () => {
     it("lists entities when entities are plotted", () => {
         const grapherState = createSingleIndicatorGrapherState({
             chartTypes: [GRAPHER_CHART_TYPES.DiscreteBar],
         })
 
-        const result = buildChartHitDataTableProps({ grapherState })
+        const result = buildChartHitDataTableContent({ grapherState })
 
         expect(result?.type).toBe("data-table")
-        const dataTable = result as SearchChartHitDataTableProps
+        const dataTable = result?.props as SearchChartHitDataTableProps
 
         expect(dataTable.title).toBe("GDP")
         expect(dataTable.rows).toMatchObject([
@@ -509,10 +509,10 @@ describe("buildChartHitDataTableProps for DiscreteBar", () => {
             chartTypes: [GRAPHER_CHART_TYPES.DiscreteBar],
         })
 
-        const result = buildChartHitDataTableProps({ grapherState })
+        const result = buildChartHitDataTableContent({ grapherState })
 
         expect(result?.type).toBe("data-table")
-        const dataTable = result as SearchChartHitDataTableProps
+        const dataTable = result?.props as SearchChartHitDataTableProps
 
         expect(dataTable.title).toBe("Benin")
         expect(dataTable.rows).toMatchObject([
@@ -529,10 +529,10 @@ describe("buildChartHitDataTableProps for DiscreteBar", () => {
             focusedSeriesNames: [selectedEntityNames[1]],
         })
 
-        const result = buildChartHitDataTableProps({ grapherState })
+        const result = buildChartHitDataTableContent({ grapherState })
 
         expect(result?.type).toBe("data-table")
-        const dataTable = result as SearchChartHitDataTableProps
+        const dataTable = result?.props as SearchChartHitDataTableProps
 
         expect(dataTable.rows).toMatchObject([
             { name: "Philippines", muted: true },
@@ -547,10 +547,10 @@ describe("buildChartHitDataTableProps for DiscreteBar", () => {
             selectedFacetStrategy: FacetStrategy.entity,
         })
 
-        const result = buildChartHitDataTableProps({ grapherState })
+        const result = buildChartHitDataTableContent({ grapherState })
 
         expect(result?.type).toBe("data-table")
-        const dataTable = result as SearchChartHitDataTableProps
+        const dataTable = result?.props as SearchChartHitDataTableProps
 
         expect(dataTable.title).toBe("GDP")
         expect(dataTable.rows).toMatchObject([
@@ -566,10 +566,10 @@ describe("buildChartHitDataTableProps for DiscreteBar", () => {
             selectedFacetStrategy: FacetStrategy.metric,
         })
 
-        const result = buildChartHitDataTableProps({ grapherState })
+        const result = buildChartHitDataTableContent({ grapherState })
 
         expect(result?.type).toBe("data-table")
-        const dataTable = result as SearchChartHitDataTableProps
+        const dataTable = result?.props as SearchChartHitDataTableProps
 
         expect(dataTable.title).toBe("GDP")
         expect(dataTable.rows).toMatchObject([
@@ -580,7 +580,7 @@ describe("buildChartHitDataTableProps for DiscreteBar", () => {
     })
 })
 
-describe("buildChartHitDataTableProps for WorldMap", () => {
+describe("buildChartHitDataTableContent for WorldMap", () => {
     it("shows the map legend", () => {
         const grapherState = createSingleIndicatorGrapherState({
             chartTypes: [],
@@ -597,10 +597,10 @@ describe("buildChartHitDataTableProps for WorldMap", () => {
             },
         })
 
-        const result = buildChartHitDataTableProps({ grapherState })
+        const result = buildChartHitDataTableContent({ grapherState })
 
         expect(result?.type).toBe("data-table")
-        const dataTable = result as SearchChartHitDataTableProps
+        const dataTable = result?.props as SearchChartHitDataTableProps
 
         expect(dataTable.title).toBe("GDP")
         expect(dataTable.rows).toMatchObject([

--- a/site/search/SearchChartHitDataTableHelpers.tsx
+++ b/site/search/SearchChartHitDataTableHelpers.tsx
@@ -45,9 +45,19 @@ interface Args<State extends ChartState = ChartState> extends BaseArgs {
     chartState: State
 }
 
-export function buildChartHitDataTableProps(
+export type SearchChartHitDataTableContent =
+    | {
+          type: "data-table"
+          props: SearchChartHitDataTableProps
+      }
+    | {
+          type: "data-points"
+          props: SearchChartHitDataPointsProps
+      }
+
+export function buildChartHitDataTableContent(
     props: BaseArgs
-): SearchChartHitDataTableProps | SearchChartHitDataPointsProps | undefined {
+): SearchChartHitDataTableContent | undefined {
     if (!props.grapherState.isReady) return undefined
 
     // If the chart is faceted and displays multiple series per facet
@@ -62,70 +72,70 @@ export function buildChartHitDataTableProps(
 
     return match(props.grapherState.activeTab)
         .with(GRAPHER_TAB_NAMES.LineChart, () =>
-            buildDataTablePropsForLineChart({
+            buildDataTableContentForLineChart({
                 ...props,
                 chartState: chartState as LineChartState,
             })
         )
         .with(GRAPHER_TAB_NAMES.DiscreteBar, () =>
-            buildDataTablePropsForDiscreteBarChart({
+            buildDataTableContentForDiscreteBarChart({
                 ...props,
                 chartState: chartState as DiscreteBarChartState,
             })
         )
         .with(GRAPHER_TAB_NAMES.ScatterPlot, () =>
-            buildDataTablePropsForScatterPlot({
+            buildDataTableContentForScatterPlot({
                 ...props,
                 chartState: chartState as ScatterPlotChartState,
             })
         )
         .with(GRAPHER_TAB_NAMES.StackedArea, () =>
-            buildDataTablePropsForStackedAreaAndBarChart({
+            buildDataTableContentForStackedAreaAndBarChart({
                 ...props,
                 chartState: chartState as StackedAreaChartState,
             })
         )
         .with(GRAPHER_TAB_NAMES.StackedDiscreteBar, () =>
-            buildDataTablePropsForStackedDiscreteBarChart({
+            buildDataTableContentForStackedDiscreteBarChart({
                 ...props,
                 chartState: chartState as StackedDiscreteBarChartState,
             })
         )
         .with(GRAPHER_TAB_NAMES.SlopeChart, () =>
-            buildDataTablePropsForSlopeChart({
+            buildDataTableContentForSlopeChart({
                 ...props,
                 chartState: chartState as SlopeChartState,
             })
         )
         .with(GRAPHER_TAB_NAMES.StackedBar, () =>
-            buildDataTablePropsForStackedAreaAndBarChart({
+            buildDataTableContentForStackedAreaAndBarChart({
                 ...props,
                 chartState: chartState as StackedBarChartState,
             })
         )
         .with(GRAPHER_TAB_NAMES.Marimekko, () =>
-            buildDataTablePropsForMarimekkoChart({
+            buildDataTableContentForMarimekkoChart({
                 ...props,
                 chartState: chartState as MarimekkoChartState,
             })
         )
         .with(GRAPHER_TAB_NAMES.WorldMap, () =>
-            buildDataTablePropsForWorldMap({
+            buildDataTableContentForWorldMap({
                 ...props,
                 chartState: chartState as MapChartState,
             })
         )
         .with(GRAPHER_TAB_NAMES.Table, () =>
-            buildDataTablePropsForTableTab(props)
+            buildDataTableContentForTableTab(props)
         )
         .exhaustive()
 }
 
-function buildDataTablePropsForLineChart({
+function buildDataTableContentForLineChart({
     grapherState,
     chartState,
     maxRows,
-}: Args<LineChartState>): SearchChartHitDataTableProps {
+}: Args<LineChartState>): SearchChartHitDataTableContent {
     const formatColumn = grapherState.inputTable.get(grapherState.yColumnSlug)
 
     // Create a map chart state to access custom label formatting.
@@ -197,14 +207,14 @@ function buildDataTablePropsForLineChart({
 
     const title = makeTableTitle(grapherState, chartState)
 
-    return { type: "data-table", rows: displayRows, title }
+    return { type: "data-table", props: { rows: displayRows, title } }
 }
 
-function buildDataTablePropsForDiscreteBarChart({
+function buildDataTableContentForDiscreteBarChart({
     grapherState,
     chartState,
     maxRows,
-}: Args<DiscreteBarChartState>): SearchChartHitDataTableProps {
+}: Args<DiscreteBarChartState>): SearchChartHitDataTableContent {
     const formatColumn = grapherState.inputTable.get(grapherState.yColumnSlug)
 
     let rows = chartState.series.map((series) => ({
@@ -221,14 +231,14 @@ function buildDataTablePropsForDiscreteBarChart({
 
     const title = makeTableTitle(grapherState, chartState)
 
-    return { type: "data-table", rows, title }
+    return { type: "data-table", props: { rows, title } }
 }
 
-function buildDataTablePropsForSlopeChart({
+function buildDataTableContentForSlopeChart({
     grapherState,
     chartState,
     maxRows,
-}: Args<SlopeChartState>): SearchChartHitDataTableProps {
+}: Args<SlopeChartState>): SearchChartHitDataTableContent {
     const formatColumn = chartState.formatColumn
 
     let rows = chartState.series.map((series) => {
@@ -264,14 +274,14 @@ function buildDataTablePropsForSlopeChart({
 
     const title = makeTableTitle(grapherState, chartState)
 
-    return { type: "data-table", rows, title }
+    return { type: "data-table", props: { rows, title } }
 }
 
-function buildDataTablePropsForStackedDiscreteBarChart({
+function buildDataTableContentForStackedDiscreteBarChart({
     grapherState,
     chartState,
     maxRows,
-}: Args<StackedDiscreteBarChartState>): SearchChartHitDataTableProps {
+}: Args<StackedDiscreteBarChartState>): SearchChartHitDataTableContent {
     const formatColumn = grapherState.inputTable.get(grapherState.yColumnSlug)
 
     const mode =
@@ -339,16 +349,16 @@ function buildDataTablePropsForStackedDiscreteBarChart({
 
     if (maxRows !== undefined) rows = rows.slice(0, maxRows)
 
-    return { type: "data-table", rows, title }
+    return { type: "data-table", props: { rows, title } }
 }
 
-function buildDataTablePropsForStackedAreaAndBarChart({
+function buildDataTableContentForStackedAreaAndBarChart({
     grapherState,
     chartState,
     maxRows,
 }: Args<
     StackedAreaChartState | StackedBarChartState
->): SearchChartHitDataTableProps {
+>): SearchChartHitDataTableContent {
     const formatColumn = grapherState.inputTable.get(grapherState.yColumnSlug)
 
     const hasSingleSeriesPerFacet =
@@ -390,29 +400,27 @@ function buildDataTablePropsForStackedAreaAndBarChart({
 
     const title = makeTableTitle(grapherState, chartState)
 
-    return { type: "data-table", rows, title }
+    return { type: "data-table", props: { rows, title } }
 }
 
-function buildDataTablePropsForMarimekkoChart({
+function buildDataTableContentForMarimekkoChart({
     grapherState: _grapherState,
     chartState: _chartState,
     maxRows: _maxRows,
-}: Args<MarimekkoChartState>): SearchChartHitDataTableProps {
-    return { type: "data-table", rows: [], title: "" }
+}: Args<MarimekkoChartState>): SearchChartHitDataTableContent {
+    return { type: "data-table", props: { rows: [], title: "" } }
 }
 
-function buildDataTablePropsForScatterPlot({
+function buildDataTableContentForScatterPlot({
     grapherState,
     chartState,
     maxRows,
-}: Args<ScatterPlotChartState>):
-    | SearchChartHitDataTableProps
-    | SearchChartHitDataPointsProps {
+}: Args<ScatterPlotChartState>): SearchChartHitDataTableContent {
     // If entities are selected, then we display the x and y values for the
     // first entity. The remaining entities are ignored
     if (grapherState.selection.hasSelection) {
         const selectedEntity = grapherState.selection.selectedEntityNames[0]
-        return buildDataPointsPropsForScatterPlot({
+        return buildDataPointsContentForScatterPlot({
             grapherState,
             chartState,
             entityName: selectedEntity,
@@ -422,7 +430,7 @@ function buildDataTablePropsForScatterPlot({
     // If the selection is empty and the scatter plot has a legend (which is the
     // case if it has a color dimension), then we display the legend
     if (!grapherState.selection.hasSelection && grapherState.colorColumnSlug) {
-        return buildLegendTablePropsForScatterPlot({
+        return buildLegendTableContentForScatterPlot({
             grapherState,
             chartState,
             maxRows,
@@ -441,7 +449,7 @@ function buildDataTablePropsForScatterPlot({
     //   of one of the entities.
     if (chartState.series.length === 1 || chartState.isConnected) {
         const firstEntity = chartState.series[0].seriesName
-        return buildDataPointsPropsForScatterPlot({
+        return buildDataPointsContentForScatterPlot({
             grapherState,
             chartState,
             entityName: firstEntity,
@@ -450,7 +458,7 @@ function buildDataTablePropsForScatterPlot({
 
     // Display a table where each row corresponds to an entity and lists x and
     // y-values in this format: '<x-value> vs. <y-value>'.
-    return buildValueTablePropsForScatterPlot({
+    return buildValueTableContentForScatterPlot({
         grapherState,
         chartState,
         maxRows,
@@ -458,7 +466,7 @@ function buildDataTablePropsForScatterPlot({
 }
 
 /** Creates a table where each row represents a legend bin from the color scale */
-function buildLegendTablePropsForScatterPlot({
+function buildLegendTableContentForScatterPlot({
     grapherState,
     chartState,
     maxRows,
@@ -466,7 +474,7 @@ function buildLegendTablePropsForScatterPlot({
     grapherState: GrapherState
     chartState: ScatterPlotChartState
     maxRows?: number
-}): SearchChartHitDataTableProps {
+}): SearchChartHitDataTableContent {
     const bins = chartState.colorScale.legendBins
 
     let rows = bins
@@ -480,14 +488,14 @@ function buildLegendTablePropsForScatterPlot({
 
     const title = grapherState.colorScale.legendDescription || "Legend"
 
-    return { type: "data-table", rows, title }
+    return { type: "data-table", props: { rows, title } }
 }
 
 /**
  * Creates a table where each row represents an entity in a scatter plot,
  * displaying both x and y values in a "y vs x" format for each entity.
  */
-function buildValueTablePropsForScatterPlot({
+function buildValueTableContentForScatterPlot({
     grapherState,
     chartState,
     maxRows,
@@ -495,7 +503,7 @@ function buildValueTablePropsForScatterPlot({
     grapherState: GrapherState
     chartState: ScatterPlotChartState
     maxRows?: number
-}): SearchChartHitDataTableProps {
+}): SearchChartHitDataTableContent {
     const { xColumn, yColumn } = chartState
 
     const yLabel = grapherState.yAxis.label || getColumnNameForDisplay(yColumn)
@@ -520,7 +528,7 @@ function buildValueTablePropsForScatterPlot({
 
     const title = `${yLabel} vs. ${xLabel}`
 
-    return { type: "data-table", rows, title }
+    return { type: "data-table", props: { rows, title } }
 }
 
 /**
@@ -528,7 +536,7 @@ function buildValueTablePropsForScatterPlot({
  * for a specific entity. For connected scatter plots, includes both start and
  * end values.
  */
-function buildDataPointsPropsForScatterPlot({
+function buildDataPointsContentForScatterPlot({
     grapherState,
     chartState,
     entityName,
@@ -536,7 +544,7 @@ function buildDataPointsPropsForScatterPlot({
     grapherState: GrapherState
     chartState: ScatterPlotChartState
     entityName: string
-}): SearchChartHitDataPointsProps {
+}): SearchChartHitDataTableContent {
     const { xColumn, yColumn } = chartState
 
     const yLabel = grapherState.yAxis.label || getColumnNameForDisplay(yColumn)
@@ -592,14 +600,14 @@ function buildDataPointsPropsForScatterPlot({
 
     const dataPoints = excludeUndefined([yDataPoint, xDataPoint])
 
-    return { type: "data-points", dataPoints }
+    return { type: "data-points", props: { dataPoints } }
 }
 
-function buildDataTablePropsForWorldMap({
+function buildDataTableContentForWorldMap({
     grapherState,
     chartState,
     maxRows,
-}: Args<MapChartState>): SearchChartHitDataTableProps {
+}: Args<MapChartState>): SearchChartHitDataTableContent {
     const bins = chartState.colorScale.legendBins
 
     const makeLabelForNumericBin = (bin: NumericBin): string => {
@@ -651,14 +659,14 @@ function buildDataTablePropsForWorldMap({
 
     const title = makeTableTitle(grapherState, chartState)
 
-    return { type: "data-table", rows, title }
+    return { type: "data-table", props: { rows, title } }
 }
 
-function buildDataTablePropsForTableTab({
+function buildDataTableContentForTableTab({
     grapherState: _grapherState,
     maxRows: _maxRows,
-}: BaseArgs): SearchChartHitDataTableProps {
-    return { type: "data-table", rows: [], title: "" }
+}: BaseArgs): SearchChartHitDataTableContent {
+    return { type: "data-table", props: { rows: [], title: "" } }
 }
 
 function makeTableTitle(

--- a/site/search/SearchChartHitMedium.scss
+++ b/site/search/SearchChartHitMedium.scss
@@ -49,7 +49,7 @@
         text-underline-offset: 3px;
     }
 
-    .search-chart-hit-table {
+    .search-chart-hit-table-wrapper {
         height: 100%;
         width: 100%;
         background: #fff;
@@ -65,6 +65,10 @@
             aspect-ratio: calc(
                 2 * $grapher-thumbnail-width / $grapher-thumbnail-height
             );
+        }
+
+        .search-chart-hit-data-points--align-top {
+            padding-top: 12px;
         }
     }
 
@@ -95,7 +99,7 @@
         grid-column: span 2;
         grid-row: span 2;
 
-        .search-chart-hit-table-content {
+        .search-chart-hit-table {
             grid-template-columns: repeat(1, 1fr);
         }
     }
@@ -104,7 +108,7 @@
         grid-column: span 4;
         grid-row: span 2;
 
-        .search-chart-hit-table-content {
+        .search-chart-hit-table {
             grid-template-columns: repeat(2, 1fr);
         }
     }
@@ -113,7 +117,7 @@
         grid-column: span 6;
         grid-row: span 2;
 
-        .search-chart-hit-table-content {
+        .search-chart-hit-table {
             grid-template-columns: repeat(3, 1fr);
         }
     }
@@ -122,7 +126,7 @@
         grid-column: span 8;
         grid-row: span 2;
 
-        .search-chart-hit-table-content {
+        .search-chart-hit-table {
             grid-template-columns: repeat(4, 1fr);
         }
     }

--- a/site/search/searchUtils.test.ts
+++ b/site/search/searchUtils.test.ts
@@ -105,6 +105,7 @@ describe("placeGrapherTabsInGridLayout", () => {
         it("distributes tabs across 4 available grid slots", () => {
             const tabs = [LineChart, Table, WorldMap, DiscreteBar]
             const result = placeGrapherTabsInGridLayout(tabs, {
+                tableType: "data-table",
                 hasDataDisplay: false,
                 numDataTableRows: 4,
             })
@@ -120,6 +121,7 @@ describe("placeGrapherTabsInGridLayout", () => {
         it("limits tabs to available grid slots when there are too many", () => {
             const tabs = [LineChart, Table, WorldMap, Marimekko, DiscreteBar]
             const result = placeGrapherTabsInGridLayout(tabs, {
+                tableType: "data-table",
                 hasDataDisplay: false,
                 numDataTableRows: 2,
             })
@@ -135,6 +137,7 @@ describe("placeGrapherTabsInGridLayout", () => {
         it("allocates larger slot to Table when it has many rows", () => {
             const tabs = [LineChart, Table, WorldMap]
             const result = placeGrapherTabsInGridLayout(tabs, {
+                tableType: "data-table",
                 hasDataDisplay: false,
                 numDataTableRows: 12,
             })
@@ -149,6 +152,7 @@ describe("placeGrapherTabsInGridLayout", () => {
         it("uses single slot for Table when it has few rows", () => {
             const tabs = [LineChart, Table, WorldMap]
             const result = placeGrapherTabsInGridLayout(tabs, {
+                tableType: "data-table",
                 hasDataDisplay: false,
                 numDataTableRows: 2,
             })
@@ -163,6 +167,7 @@ describe("placeGrapherTabsInGridLayout", () => {
         it("allocates triple slot to Table when it needs more space", () => {
             const tabs = [LineChart, Table]
             const result = placeGrapherTabsInGridLayout(tabs, {
+                tableType: "data-table",
                 hasDataDisplay: false,
                 numDataTableRows: 20,
             })
@@ -173,9 +178,24 @@ describe("placeGrapherTabsInGridLayout", () => {
             ])
         })
 
+        it("should respect the given number of max slots for the table", () => {
+            const tabs = [LineChart, Table]
+            const result = placeGrapherTabsInGridLayout(tabs, {
+                tableType: "data-points",
+                hasDataDisplay: false,
+                numMaxSlotsForTable: 2,
+            })
+
+            expect(result).toEqual([
+                { tab: LineChart, slot: GridSlot.SingleSlot },
+                { tab: Table, slot: GridSlot.DoubleSlot },
+            ])
+        })
+
         it("should handle single tab case", () => {
             const tabs = [Table]
             const result = placeGrapherTabsInGridLayout(tabs, {
+                tableType: "data-table",
                 hasDataDisplay: false,
                 numDataTableRows: 6,
             })
@@ -186,6 +206,7 @@ describe("placeGrapherTabsInGridLayout", () => {
         it("should give Table the maximum available space when needed", () => {
             const tabs = [Table]
             const result = placeGrapherTabsInGridLayout(tabs, {
+                tableType: "data-table",
                 hasDataDisplay: false,
                 numDataTableRows: 18,
             })
@@ -198,6 +219,7 @@ describe("placeGrapherTabsInGridLayout", () => {
         it("places first 3 tabs in main slots and remaining tabs in small slots", () => {
             const tabs = [LineChart, Table, Marimekko, WorldMap, DiscreteBar]
             const result = placeGrapherTabsInGridLayout(tabs, {
+                tableType: "data-table",
                 hasDataDisplay: true,
                 numDataTableRows: 12,
             })
@@ -214,6 +236,7 @@ describe("placeGrapherTabsInGridLayout", () => {
         it("uses only main slots when 3 or fewer tabs are provided", () => {
             const tabs = [LineChart, Table, WorldMap]
             const result = placeGrapherTabsInGridLayout(tabs, {
+                tableType: "data-table",
                 hasDataDisplay: true,
                 numDataTableRows: 16,
             })
@@ -228,6 +251,7 @@ describe("placeGrapherTabsInGridLayout", () => {
         it("should allocate two slots to Table if possible", () => {
             const tabs = [LineChart, Table]
             const result = placeGrapherTabsInGridLayout(tabs, {
+                tableType: "data-table",
                 hasDataDisplay: true,
                 numDataTableRows: 16,
             })
@@ -235,6 +259,20 @@ describe("placeGrapherTabsInGridLayout", () => {
             expect(result).toEqual([
                 { tab: LineChart, slot: GridSlot.SingleSlot },
                 { tab: Table, slot: GridSlot.DoubleSlot },
+            ])
+        })
+
+        it("should respect the given number of max slots for the table", () => {
+            const tabs = [LineChart, Table]
+            const result = placeGrapherTabsInGridLayout(tabs, {
+                tableType: "data-points",
+                hasDataDisplay: true,
+                numMaxSlotsForTable: 1,
+            })
+
+            expect(result).toEqual([
+                { tab: LineChart, slot: GridSlot.SingleSlot },
+                { tab: Table, slot: GridSlot.SingleSlot },
             ])
         })
     })

--- a/site/search/searchUtils.tsx
+++ b/site/search/searchUtils.tsx
@@ -31,7 +31,6 @@ import {
     timeBoundToTimeBoundString,
     queryParamsToStr,
 } from "@ourworldindata/utils"
-import { partition, uniqueBy } from "remeda"
 import { type GrapherTrendArrowDirection } from "@ourworldindata/components"
 import {
     generateSelectedEntityNamesParam,
@@ -579,7 +578,7 @@ export function searchWithWords(
         // the limit given that we are running the search twice and combining
         // result sets, effectively doubling the number of results.
         const deduplicateResults = (results: ScoredSearchResult[]) =>
-            uniqueBy(
+            R.uniqueBy(
                 results.sort((a, b) => b.score - a.score),
                 (result) => result.name
             ).slice(0, sortOptions.limit)

--- a/site/search/searchUtils.tsx
+++ b/site/search/searchUtils.tsx
@@ -1068,10 +1068,15 @@ type PlacingOptions =
           numMaxSlotsForTable: number
       }
 
+export interface PlacedTab {
+    tab: GrapherTabName
+    slot: GridSlot
+}
+
 export function placeGrapherTabsInGridLayout(
     tabs: GrapherTabName[],
     options: { hasDataDisplay: boolean } & PlacingOptions
-): { tab: GrapherTabName; slot: GridSlot }[] {
+): PlacedTab[] {
     // If there is a data display, then three equally-sized slots are available,
     // plus two smaller slots below the data display. If there is no data display,
     // then four equally-sized slots are available.


### PR DESCRIPTION
Implements the data table for scatter plots.

Scatter plots either display a data table, a legend or a specific data point.

Examples:
- Legend: http://staging-site-rich-data-revisions/data?q=People+asked+for+a+bribe+vs.+political+corruption+index
- Table: http://staging-site-rich-data-revisions/data?q=Global+biomass+vs.+abundance+of+taxa
- Data point:
    - Not connected: http://staging-site-rich-data-revisions/data?q=People+asked+for+a+bribe+vs.+political+corruption+index&countries=Germany 
    - Connected: http://staging-site-rich-data-revisions/data?q=England%27s+economy+over+the+long+run

More examples: https://www.notion.so/owid/24074b71f92e804591e8dd8534b2d25d?v=24074b71f92e8006a870000c4c3c4be7&source=copy_link
