### PR TITLE
🎉 add query param for download overlay tab

### DIFF
--- a/packages/@ourworldindata/grapher/src/controls/ActionButtons.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/ActionButtons.tsx
@@ -20,7 +20,10 @@ import {
 } from "./ShareMenu.js"
 import { Bounds } from "@ourworldindata/utils"
 import classNames from "classnames"
-import { DEFAULT_GRAPHER_BOUNDS } from "../core/GrapherConstants.js"
+import {
+    DEFAULT_GRAPHER_BOUNDS,
+    GrapherModal,
+} from "../core/GrapherConstants.js"
 
 export interface ActionButtonsManager extends ShareMenuManager {
     isAdmin?: boolean
@@ -30,7 +33,7 @@ export interface ActionButtonsManager extends ShareMenuManager {
     isInIFrame?: boolean
     canonicalUrl?: string
     isInFullScreenMode?: boolean
-    isDownloadModalOpen?: boolean
+    activeModal?: GrapherModal
     hideFullScreenButton?: boolean
 }
 
@@ -297,7 +300,8 @@ export class ActionButtons extends React.Component<ActionButtonsProps> {
                                 showLabel={this.showButtonLabels}
                                 icon={faDownload}
                                 onClick={(e): void => {
-                                    this.manager.isDownloadModalOpen = true
+                                    this.manager.activeModal =
+                                        GrapherModal.Download
                                     e.stopPropagation()
                                 }}
                             />

--- a/packages/@ourworldindata/grapher/src/controls/ShareMenu.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/ShareMenu.tsx
@@ -10,6 +10,7 @@ import {
     faPanorama,
 } from "@fortawesome/free-solid-svg-icons"
 import { canWriteToClipboard, isAndroid, isIOS } from "@ourworldindata/utils"
+import { GrapherModal } from "../core/GrapherConstants"
 
 export interface ShareMenuManager {
     slug?: string
@@ -17,7 +18,7 @@ export interface ShareMenuManager {
     canonicalUrl?: string
     editUrl?: string
     createNarrativeChartUrl?: string
-    isEmbedModalOpen?: boolean
+    activeModal?: GrapherModal
 }
 
 interface ShareMenuProps {
@@ -138,7 +139,7 @@ export class ShareMenu extends React.Component<ShareMenuProps, ShareMenuState> {
     @action.bound onEmbed(e: React.MouseEvent): void {
         const { canonicalUrl, manager } = this
         if (!canonicalUrl) return
-        manager.isEmbedModalOpen = true
+        manager.activeModal = GrapherModal.Embed
         this.dismiss()
         e.stopPropagation()
     }

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -4045,15 +4045,18 @@ export class Grapher extends React.Component<GrapherProps> {
                 </div>
 
                 {/* Modals */}
-                {this.grapherState.activeModal === GrapherModal.Sources && (
-                    <SourcesModal manager={this.grapherState} />
-                )}
-                {this.grapherState.activeModal === GrapherModal.Download && (
-                    <DownloadModal manager={this.grapherState} />
-                )}
-                {this.grapherState.activeModal === GrapherModal.Embed && (
-                    <EmbedModal manager={this.grapherState} />
-                )}
+                {this.grapherState.activeModal === GrapherModal.Sources &&
+                    this.grapherState.isReady && (
+                        <SourcesModal manager={this.grapherState} />
+                    )}
+                {this.grapherState.activeModal === GrapherModal.Download &&
+                    this.grapherState.isReady && (
+                        <DownloadModal manager={this.grapherState} />
+                    )}
+                {this.grapherState.activeModal === GrapherModal.Embed &&
+                    this.grapherState.isReady && (
+                        <EmbedModal manager={this.grapherState} />
+                    )}
                 {this.grapherState.isEntitySelectorModalOpen && (
                     <EntitySelectorModal manager={this.grapherState} />
                 )}

--- a/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
@@ -180,3 +180,9 @@ export const SVG_STYLE_PROPS: React.CSSProperties = {
 
 export const CHART_TYPES_THAT_SWITCH_TO_DISCRETE_BAR_WHEN_SINGLE_TIME: GrapherChartType[] =
     [GRAPHER_CHART_TYPES.LineChart, GRAPHER_CHART_TYPES.SlopeChart]
+
+export enum GrapherModal {
+    Sources = "sources",
+    Download = "download",
+    Embed = "embed",
+}

--- a/packages/@ourworldindata/grapher/src/core/GrapherUrl.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherUrl.ts
@@ -75,6 +75,7 @@ export const grapherConfigToQueryParams = (
         // These cannot be specified in config, so we always set them to undefined
         showSelectionOnlyInTable: undefined,
         overlay: undefined,
+        downloadOverlayTab: undefined,
         tableFilter: undefined,
         tableSearch: undefined,
     }
@@ -133,6 +134,8 @@ export const grapherObjectToQueryParams = (
                 : undefined,
         tableFilter: grapher.dataTableConfig.filter,
         tableSearch: grapher.dataTableConfig.search,
+        overlay: grapher.overlayParam,
+        downloadOverlayTab: grapher.downloadOverlayTabParam,
     }
     return params
 }

--- a/packages/@ourworldindata/grapher/src/footer/Footer.tsx
+++ b/packages/@ourworldindata/grapher/src/footer/Footer.tsx
@@ -20,6 +20,7 @@ import {
     DEFAULT_GRAPHER_BOUNDS,
     GRAPHER_FOOTER_CLASS,
     GRAPHER_FRAME_PADDING_HORIZONTAL,
+    GrapherModal,
 } from "../core/GrapherConstants"
 import { GRAPHER_LIGHT_TEXT } from "../color/ColorConstants"
 
@@ -448,7 +449,7 @@ abstract class AbstractFooter<
                             this.manager.isEmbeddedInAnOwidPage ||
                             this.manager.isInIFrame
                         ) {
-                            this.manager.isSourcesModalOpen = true
+                            this.manager.activeModal = GrapherModal.Sources
                             return
                         }
 
@@ -468,7 +469,7 @@ abstract class AbstractFooter<
                             this.manager.isInFullScreenMode = false
                         } else {
                             // on grapher pages, open the sources modal
-                            this.manager.isSourcesModalOpen = true
+                            this.manager.activeModal = GrapherModal.Sources
                         }
                     })}
                 >

--- a/packages/@ourworldindata/grapher/src/footer/FooterManager.ts
+++ b/packages/@ourworldindata/grapher/src/footer/FooterManager.ts
@@ -1,6 +1,7 @@
 import { TooltipManager } from "../tooltip/TooltipProps"
 import { DetailsMarker } from "@ourworldindata/types"
 import { ActionButtonsManager } from "../controls/ActionButtons"
+import { GrapherModal } from "../core/GrapherConstants"
 
 export interface FooterManager extends TooltipManager, ActionButtonsManager {
     sourcesLine?: string
@@ -9,7 +10,7 @@ export interface FooterManager extends TooltipManager, ActionButtonsManager {
     originUrlWithProtocol?: string
     detailsOrderedByReference?: string[]
     shouldIncludeDetailsInStaticExport?: boolean
-    isSourcesModalOpen?: boolean
+    activeModal?: GrapherModal
     isSmall?: boolean
     isMedium?: boolean
     useBaseFontSize?: boolean

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
@@ -42,6 +42,7 @@ import { GrapherImageDownloadEvent } from "../core/GrapherAnalytics"
 import {
     DEFAULT_GRAPHER_BOUNDS,
     DEFAULT_GRAPHER_BOUNDS_SQUARE,
+    GrapherModal,
 } from "../core/GrapherConstants"
 
 export interface DownloadModalManager {
@@ -58,8 +59,7 @@ export interface DownloadModalManager {
     yColumnsFromDimensionsOrSlugsOrAuto?: CoreColumn[]
     shouldIncludeDetailsInStaticExport?: boolean
     detailsOrderedByReference?: string[]
-    isDownloadModalOpen?: boolean
-    isEmbedModalOpen?: boolean
+    activeModal?: GrapherModal
     frameBounds?: Bounds
     captionedChartBounds?: Bounds
     isOnChartOrMapTab?: boolean
@@ -138,7 +138,7 @@ export class DownloadModal extends React.Component<DownloadModalProps> {
     }
 
     @action.bound private onDismiss() {
-        this.props.manager.isDownloadModalOpen = false
+        this.props.manager.activeModal = undefined
     }
 
     override render(): React.ReactElement {
@@ -357,8 +357,7 @@ export class DownloadModalVisTab extends React.Component<DownloadModalProps> {
     }
 
     @action.bound openEmbedDialog(): void {
-        this.manager.isDownloadModalOpen = false
-        this.manager.isEmbedModalOpen = true
+        this.manager.activeModal = GrapherModal.Embed
     }
 
     override componentDidMount(): void {

--- a/packages/@ourworldindata/grapher/src/modal/EmbedModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/EmbedModal.tsx
@@ -8,12 +8,12 @@ import {
     CodeSnippet,
     OverlayHeader,
 } from "@ourworldindata/components"
-import { DEFAULT_GRAPHER_BOUNDS } from "../core/GrapherConstants"
+import { DEFAULT_GRAPHER_BOUNDS, GrapherModal } from "../core/GrapherConstants"
 
 export interface EmbedModalManager {
     embedUrl?: string
     embedArchivedUrl?: string
-    isEmbedModalOpen?: boolean
+    activeModal?: GrapherModal
     canHideExternalControlsInEmbed: boolean
     hideExternalControlsInEmbedUrl: boolean
     setHideExternalControlsInEmbedUrl: (value: boolean) => void
@@ -99,7 +99,7 @@ export class EmbedModal extends React.Component<EmbedModalProps> {
     }
 
     @action.bound private onDismiss(): void {
-        this.manager.isEmbedModalOpen = false
+        this.manager.activeModal = undefined
     }
 
     override render() {

--- a/packages/@ourworldindata/grapher/src/modal/SourcesModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/SourcesModal.tsx
@@ -38,6 +38,7 @@ import { TabItem, Tabs } from "../tabs/Tabs"
 import { ExpandableTabs } from "../tabs/ExpandableTabs"
 import {
     DEFAULT_GRAPHER_BOUNDS,
+    GrapherModal,
     isContinentsVariableId,
 } from "../core/GrapherConstants"
 import * as R from "remeda"
@@ -54,7 +55,7 @@ export interface SourcesModalManager {
     adminBaseUrl?: string
     columnsWithSourcesExtensive: CoreColumn[]
     showAdminControls?: boolean
-    isSourcesModalOpen?: boolean
+    activeModal?: GrapherModal
     frameBounds?: Bounds
     isEmbeddedInADataPage?: boolean
     isNarrow?: boolean
@@ -310,7 +311,7 @@ export class SourcesModal extends React.Component<
     }
 
     @action.bound private onDismiss(): void {
-        this.manager.isSourcesModalOpen = false
+        this.manager.activeModal = undefined
     }
 
     override render(): React.ReactElement {

--- a/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
+++ b/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
@@ -672,6 +672,7 @@ export type GrapherQueryParams = {
     focus?: string
     tab?: string
     overlay?: string
+    downloadOverlayTab?: string
     stackMode?: string
     zoomToSelection?: string
     xScale?: string
@@ -720,6 +721,7 @@ const GRAPHER_ALL_QUERY_PARAMS: Required<LegacyGrapherQueryParams> = {
     mapSelect: "",
     tableFilter: "",
     tableSearch: "",
+    downloadOverlayTab: "",
 }
 export const GRAPHER_QUERY_PARAM_KEYS = Object.keys(
     GRAPHER_ALL_QUERY_PARAMS


### PR DESCRIPTION
Persists the open modal to the URL and adds a new query param for the active tab in the download modal. For search, I need to link to the 'Data' tab of the download modal, which currently isn't possible.

I also did a small refactor that combines three booleans (`is{Sources,Embed,Download}ModalOpen`) into one variable (`activeModal`).

The entity selector modal is a bit special, so it's left untouched in this PR.

These links should work now:
- Download modal / Viz tab: http://staging-site-overlay-query-param/grapher/life-expectancy-at-different-ages?overlay=download&downloadOverlayTab=vis
- Download modal / Data tab: http://staging-site-overlay-query-param/grapher/life-expectancy-at-different-ages?overlay=download&downloadOverlayTab=data
- Sources modal: http://staging-site-overlay-query-param/grapher/life-expectancy-at-different-ages?overlay=sources
- Embed modal: http://staging-site-overlay-query-param/grapher/life-expectancy-at-different-ages?overlay=embed
