### PR TITLE
✨ add tooltips for tab icons and download button

### DIFF
--- a/site/search/SearchChartHitSmall.scss
+++ b/site/search/SearchChartHitSmall.scss
@@ -26,6 +26,10 @@
         a {
             color: $blue-60;
             line-height: 0;
+
+            &:hover {
+                color: $blue-90;
+            }
         }
 
         svg {
@@ -34,9 +38,11 @@
         }
     }
 
-    .search-chart-hit-small__download-button {
+    .search-chart-hit-small__download-button-wrapper {
         align-self: center;
+    }
 
+    .search-chart-hit-small__download-button {
         &:hover {
             background-color: #bed2e7;
         }
@@ -50,5 +56,16 @@
         .search-chart-hit-data-display {
             display: none;
         }
+    }
+}
+
+.search-chart-hit-small__tippy {
+    $background: $gray-90;
+
+    @include note-1-regular;
+    background-color: $background;
+
+    .tippy-arrow {
+        color: $background;
     }
 }

--- a/site/search/SearchChartHitSmall.tsx
+++ b/site/search/SearchChartHitSmall.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react"
-import { Region } from "@ourworldindata/utils"
+import { Region, Tippy } from "@ourworldindata/utils"
 import {
     GRAPHER_TAB_NAMES,
     GrapherChartType,
@@ -116,17 +116,28 @@ export function SearchChartHitSmall({
                             ...timeParam,
                         })
 
+                        const href = constructChartUrl({ hit, grapherParams })
+                        const label = makeLabelForGrapherTab(tab, {
+                            format: "long",
+                        })
+
                         return (
-                            <a
+                            <Tippy
                                 key={tab}
-                                href={constructChartUrl({ hit, grapherParams })}
-                                onClick={onClick}
-                                aria-label={makeLabelForGrapherTab(tab, {
-                                    format: "long",
-                                })}
+                                appendTo={() => document.body}
+                                className="search-chart-hit-small__tippy"
+                                content={label}
+                                placement="bottom"
+                                theme="dark"
                             >
-                                <GrapherTabIcon tab={tab} />
-                            </a>
+                                <a
+                                    href={href}
+                                    onClick={onClick}
+                                    aria-label={label}
+                                >
+                                    <GrapherTabIcon tab={tab} />
+                                </a>
+                            </Tippy>
                         )
                     })}
                 </div>
@@ -134,13 +145,24 @@ export function SearchChartHitSmall({
             {dataDisplayProps && (
                 <SearchChartHitDataDisplay {...dataDisplayProps} />
             )}
-            <Button
-                className="search-chart-hit-small__download-button"
-                theme="solid-light-blue"
-                href={constructDownloadUrl({ hit })}
-                icon={faDownload}
-                ariaLabel="Download options"
-            />
+            <Tippy
+                appendTo={() => document.body}
+                className="search-chart-hit-small__tippy"
+                content="Download options"
+                placement="bottom"
+                theme="dark"
+            >
+                {/* Without this wrapper element, the tippy isn't positioned correctly */}
+                <div className="search-chart-hit-small__download-button-wrapper">
+                    <Button
+                        className="search-chart-hit-small__download-button"
+                        theme="solid-light-blue"
+                        href={constructDownloadUrl({ hit })}
+                        icon={faDownload}
+                        ariaLabel="Download options"
+                    />
+                </div>
+            </Tippy>
         </article>
     )
 }


### PR DESCRIPTION
Adds tooltips to the tab icons and download button of the small chart hit compoment.

<img width="1291" height="139" alt="Screenshot 2025-08-12 at 13 06 29" src="https://github.com/user-attachments/assets/39768a41-2133-440e-a51c-6e85e1aa29e6" />
