### PR TITLE
🎉 stacked bar chart thumbnail

### DIFF
--- a/packages/@ourworldindata/grapher/src/stackedCharts/AbstractStackedChartState.ts
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/AbstractStackedChartState.ts
@@ -1,4 +1,5 @@
 import * as _ from "lodash-es"
+import * as R from "remeda"
 import { ChartState } from "../chart/ChartInterface.js"
 import { ChartManager } from "../chart/ChartManager.js"
 import {
@@ -47,6 +48,7 @@ export abstract class AbstractStackedChartState implements ChartState {
     abstract shouldRunLinearInterpolation: boolean
 
     abstract get series(): readonly StackedSeries<number>[]
+    abstract get yDomain(): [number, number]
     abstract get useValueBasedColorScheme(): boolean
 
     constructor({ manager }: { manager: ChartManager }) {
@@ -130,6 +132,11 @@ export abstract class AbstractStackedChartState implements ChartState {
 
     @computed get yColumnSlugs(): string[] {
         return this.manager.yColumnSlugs ?? autoDetectYColumnSlugs(this.manager)
+    }
+
+    @computed get formatColumn(): CoreColumn {
+        // we can just use the first column for formatting, b/c we assume all columns have same type
+        return this.yColumns[0]
     }
 
     @computed get seriesStrategy(): SeriesStrategy {
@@ -309,11 +316,17 @@ export abstract class AbstractStackedChartState implements ChartState {
             })
     }
 
-    @computed get yDomain(): [number, number] {
-        const yValues = this.allStackedPoints.map(
-            (point) => point.value + point.valueOffset
-        )
-        return [0, _.max(yValues) ?? 0]
+    @computed get midpoints(): number[] {
+        let prevY = 0
+        return this.series.map((series) => {
+            const lastValue = R.last(series.points)
+            if (!lastValue) return 0
+
+            const y = lastValue.value + lastValue.valueOffset
+            const middleY = prevY + (y - prevY) / 2
+            prevY = y
+            return middleY
+        })
     }
 
     toHorizontalAxis(config: AxisConfig): HorizontalAxis {

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
@@ -413,7 +413,7 @@ export class StackedAreaChart
         const bottomSeriesPoint = series[0].points[hoveredPointIndex]
         if (!bottomSeriesPoint) return undefined
 
-        const formatColumn = this.chartState.yColumns[0], // Assumes same type for all columns.
+        const formatColumn = this.chartState.formatColumn,
             formattedTime = formatColumn.formatTime(bottomSeriesPoint.position),
             { unit, shortUnit } = formatColumn
 

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChartState.ts
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChartState.ts
@@ -1,4 +1,4 @@
-import * as R from "remeda"
+import * as _ from "lodash-es"
 import { computed, makeObservable } from "mobx"
 import { AbstractStackedChartState } from "./AbstractStackedChartState.js"
 import { ChartState } from "../chart/ChartInterface.js"
@@ -25,16 +25,10 @@ export class StackedAreaChartState
         return stackSeries(withMissingValuesAsZeroes(this.unstackedSeries))
     }
 
-    @computed get midpoints(): number[] {
-        let prevY = 0
-        return this.series.map((series) => {
-            const lastValue = R.last(series.points)
-            if (!lastValue) return 0
-
-            const y = lastValue.value + lastValue.valueOffset
-            const middleY = prevY + (y - prevY) / 2
-            prevY = y
-            return middleY
-        })
+    @computed get yDomain(): [number, number] {
+        const yValues = this.allStackedPoints.map(
+            (point) => point.value + point.valueOffset
+        )
+        return [0, _.max(yValues) ?? 0]
     }
 }

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChartState.ts
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChartState.ts
@@ -1,3 +1,4 @@
+import * as _ from "lodash-es"
 import { computed, makeObservable } from "mobx"
 import { AbstractStackedChartState } from "./AbstractStackedChartState.js"
 import { ChartState } from "../chart/ChartInterface.js"
@@ -45,6 +46,14 @@ export class StackedBarChartState
         )
     }
 
+    @computed get xValues(): number[] {
+        return _.uniq(
+            this.unstackedSeriesWithMissingValuesAsZeroes.flatMap((s) =>
+                s.points.map((p) => p.position)
+            )
+        )
+    }
+
     /** Colour positive and negative values differently in stacked bar charts */
     @computed get useValueBasedColorScheme(): boolean {
         // Switched on externally, e.g. in a faceted chart
@@ -60,5 +69,12 @@ export class StackedBarChartState
 
     @computed get colorScaleConfig(): ColorScaleConfigInterface | undefined {
         return this.manager.colorScale
+    }
+
+    @computed get yDomain(): [number, number] {
+        const yValues = this.allStackedPoints.map(
+            (point) => point.value + point.valueOffset
+        )
+        return [_.min([0, ...yValues]) ?? 0, _.max([0, ...yValues]) ?? 0]
     }
 }

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChartThumbnail.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChartThumbnail.tsx
@@ -11,7 +11,7 @@ import {
     DEFAULT_GRAPHER_BOUNDS,
     GRAPHER_FONT_SCALE_12,
 } from "../core/GrapherConstants"
-import { Bounds, GrapherVariant } from "@ourworldindata/utils"
+import { Bounds, excludeUndefined, GrapherVariant } from "@ourworldindata/utils"
 import { AxisConfig, AxisManager } from "../axis/AxisConfig"
 import { DualAxis, HorizontalAxis, VerticalAxis } from "../axis/Axis"
 import {
@@ -119,21 +119,21 @@ export class StackedBarChartThumbnail
         | undefined {
         if (!this.manager.showLegend || this.isMinimal) return undefined
 
-        // If any series is focused, only show the labels for those
-        const candidateSeries = this.chartState.isFocusModeActive
-            ? this.chartState.series.filter((series) => series.focus?.active)
-            : this.chartState.series
+        const series = excludeUndefined(
+            this.chartState.series.map((series, seriesIndex) => {
+                const { seriesName, color, focus } = series
 
-        const series = candidateSeries.map((series, seriesIndex) => {
-            const { seriesName, color } = series
+                // Don't label background series
+                if (focus?.background) return undefined
 
-            const value = this.chartState.midpoints[seriesIndex]
+                const value = this.chartState.midpoints[seriesIndex]
 
-            const yPosition = this.outerBoundsVerticalAxis.place(value)
-            const label = seriesName
+                const yPosition = this.outerBoundsVerticalAxis.place(value)
+                const label = seriesName
 
-            return { series, seriesName, value, label, yPosition, color }
-        })
+                return { series, seriesName, value, label, yPosition, color }
+            })
+        )
 
         return new VerticalLabelsState(series, {
             fontSize: this.labelFontSize,

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChartThumbnail.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChartThumbnail.tsx
@@ -1,17 +1,40 @@
+import * as _ from "lodash-es"
 import React from "react"
 import { computed, makeObservable } from "mobx"
 import { observer } from "mobx-react"
 import { ChartInterface } from "../chart/ChartInterface"
 import { StackedBarChartState } from "./StackedBarChartState.js"
+import { type StackedBarChartProps } from "./StackedBarChart.js"
+import { ChartManager } from "../chart/ChartManager"
 import {
-    StackedBarChart,
-    type StackedBarChartProps,
-} from "./StackedBarChart.js"
+    BASE_FONT_SIZE,
+    DEFAULT_GRAPHER_BOUNDS,
+    GRAPHER_FONT_SCALE_12,
+} from "../core/GrapherConstants"
+import { Bounds, GrapherVariant } from "@ourworldindata/utils"
+import { AxisConfig, AxisManager } from "../axis/AxisConfig"
+import { DualAxis, HorizontalAxis, VerticalAxis } from "../axis/Axis"
+import {
+    getXAxisConfigDefaultsForStackedBar,
+    resolveCollision,
+} from "./StackedUtils"
+import {
+    HorizontalAxisComponent,
+    VerticalAxisZeroLine,
+} from "../axis/AxisViews"
+import { StackedBars } from "./StackedBars"
+import {
+    InitialVerticalLabelsSeries,
+    VerticalLabelsState,
+} from "../verticalLabels/VerticalLabelsState"
+import { VerticalLabels } from "../verticalLabels/VerticalLabels"
+
+const LEGEND_PADDING = 4
 
 @observer
 export class StackedBarChartThumbnail
     extends React.Component<StackedBarChartProps>
-    implements ChartInterface
+    implements ChartInterface, AxisManager
 {
     constructor(props: StackedBarChartProps) {
         super(props)
@@ -22,7 +45,152 @@ export class StackedBarChartThumbnail
         return this.props.chartState
     }
 
-    override render(): React.ReactElement {
-        return <StackedBarChart {...this.props} />
+    @computed get manager(): ChartManager {
+        return this.chartState.manager
+    }
+
+    @computed private get isMinimal(): boolean {
+        return this.manager.variant === GrapherVariant.MinimalThumbnail
+    }
+
+    @computed get fontSize(): number {
+        return this.manager.fontSize ?? BASE_FONT_SIZE
+    }
+
+    @computed private get bounds(): Bounds {
+        return this.props.bounds ?? DEFAULT_GRAPHER_BOUNDS
+    }
+
+    @computed private get innerBounds(): Bounds {
+        return this.bounds.padRight(this.paddedLabelsWidth)
+    }
+
+    @computed private get xAxisConfig(): AxisConfig {
+        const { xAxisConfig } = this.manager
+        const defaults = getXAxisConfigDefaultsForStackedBar(this.chartState)
+        const custom = { labelPadding: 0 }
+        return new AxisConfig({ ...custom, ...defaults, ...xAxisConfig }, this)
+    }
+
+    @computed private get yAxisConfig(): AxisConfig {
+        const { yAxisConfig } = this.manager
+        const custom = { nice: true, hideAxis: true }
+        return new AxisConfig({ ...custom, ...yAxisConfig }, this)
+    }
+
+    @computed private get horizontalAxisPart(): HorizontalAxis {
+        return this.chartState.toHorizontalAxis(this.xAxisConfig)
+    }
+
+    @computed private get verticalAxisPart(): VerticalAxis {
+        return this.chartState.toVerticalAxis(this.yAxisConfig)
+    }
+
+    @computed private get dualAxis(): DualAxis {
+        const { horizontalAxisPart, verticalAxisPart } = this
+        return new DualAxis({
+            bounds: this.innerBounds,
+            horizontalAxis: horizontalAxisPart,
+            verticalAxis: verticalAxisPart,
+        })
+    }
+
+    @computed get xAxis(): HorizontalAxis {
+        return this.dualAxis.horizontalAxis
+    }
+
+    @computed get yAxis(): VerticalAxis {
+        return this.dualAxis.verticalAxis
+    }
+
+    @computed private get labelFontSize(): number {
+        return Math.floor(GRAPHER_FONT_SCALE_12 * this.fontSize)
+    }
+
+    // Same as dualAxis.verticalAxis, but doesn't depend on innerBounds
+    @computed get outerBoundsVerticalAxis(): VerticalAxis {
+        const yAxis = this.verticalAxisPart.clone()
+        yAxis.range = this.bounds.yRange()
+        return yAxis
+    }
+
+    @computed private get verticalLabelsState():
+        | VerticalLabelsState
+        | undefined {
+        if (!this.manager.showLegend || this.isMinimal) return undefined
+
+        // If any series is focused, only show the labels for those
+        const candidateSeries = this.chartState.isFocusModeActive
+            ? this.chartState.series.filter((series) => series.focus?.active)
+            : this.chartState.series
+
+        const series = candidateSeries.map((series, seriesIndex) => {
+            const { seriesName, color } = series
+
+            const value = this.chartState.midpoints[seriesIndex]
+
+            const yPosition = this.outerBoundsVerticalAxis.place(value)
+            const label = seriesName
+
+            return { series, seriesName, value, label, yPosition, color }
+        })
+
+        return new VerticalLabelsState(series, {
+            fontSize: this.labelFontSize,
+            maxWidth: 0.25 * this.bounds.width,
+            resolveCollision: (
+                s1: InitialVerticalLabelsSeries,
+                s2: InitialVerticalLabelsSeries
+            ): InitialVerticalLabelsSeries => {
+                const series1 = this.chartState.seriesByName.get(s1.seriesName)
+                const series2 = this.chartState.seriesByName.get(s2.seriesName)
+
+                if (!series1 || !series2) return s1 // no preference
+
+                const picked = resolveCollision(series1, series2)
+                if (picked?.seriesName === s1.seriesName) return s1
+                if (picked?.seriesName === s2.seriesName) return s2
+
+                return s1 // no preference
+            },
+        })
+    }
+
+    @computed private get labelsWidth(): number {
+        return this.verticalLabelsState?.width ?? 0
+    }
+
+    @computed private get paddedLabelsWidth(): number {
+        return this.labelsWidth ? this.labelsWidth + LEGEND_PADDING : 0
+    }
+
+    override render(): React.ReactElement | null {
+        if (this.chartState.errorInfo.reason) return null
+
+        return (
+            <>
+                <VerticalAxisZeroLine
+                    verticalAxis={this.dualAxis.verticalAxis}
+                    bounds={this.dualAxis.innerBounds}
+                />
+                <HorizontalAxisComponent
+                    axis={this.dualAxis.horizontalAxis}
+                    bounds={this.dualAxis.bounds}
+                    showEndpointsOnly
+                />
+                <StackedBars
+                    dualAxis={this.dualAxis}
+                    series={this.chartState.series}
+                    formatColumn={this.chartState.formatColumn}
+                />
+                {this.verticalLabelsState && (
+                    <VerticalLabels
+                        state={this.verticalLabelsState}
+                        yAxis={this.dualAxis.verticalAxis}
+                        x={this.innerBounds.right + LEGEND_PADDING}
+                    />
+                )}
+            </>
+        )
     }
 }

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarSegment.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarSegment.tsx
@@ -15,11 +15,11 @@ interface StackedBarSegmentProps extends React.SVGAttributes<SVGGElement> {
     yAxis: VerticalAxis
     xOffset: number
     barWidth: number
-    onBarMouseOver: (
+    onBarMouseOver?: (
         bar: StackedPoint<Time>,
         series: StackedSeries<Time>
     ) => void
-    onBarMouseLeave: () => void
+    onBarMouseLeave?: () => void
 }
 
 @observer
@@ -57,12 +57,12 @@ export class StackedBarSegment extends React.Component<StackedBarSegmentProps> {
 
     @action.bound onBarMouseOver(): void {
         this.mouseOver = true
-        this.props.onBarMouseOver(this.props.bar, this.props.series)
+        this.props.onBarMouseOver?.(this.props.bar, this.props.series)
     }
 
     @action.bound onBarMouseLeave(): void {
         this.mouseOver = false
-        this.props.onBarMouseLeave()
+        this.props.onBarMouseLeave?.()
     }
 
     override render(): React.ReactElement {

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedBars.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedBars.tsx
@@ -1,0 +1,101 @@
+import * as React from "react"
+import { makeObservable } from "mobx"
+import { observer } from "mobx-react"
+import { SeriesName, Time } from "@ourworldindata/types"
+import { DualAxis } from "../axis/Axis"
+import { BAR_OPACITY, StackedPoint, StackedSeries } from "./StackedConstants"
+import {
+    makeIdForHumanConsumption,
+    makeSafeForCSS,
+} from "@ourworldindata/utils"
+import { StackedBarSegment } from "./StackedBarSegment"
+import { CoreColumn } from "@ourworldindata/core-table"
+
+interface StackedBarsProps {
+    dualAxis: DualAxis
+    series: readonly StackedSeries<Time>[]
+    formatColumn: CoreColumn
+    hoveredSeriesNames?: SeriesName[]
+    hoveredBar?: StackedPoint<Time>
+    onBarMouseOver?: (
+        bar: StackedPoint<Time>,
+        series: StackedSeries<Time>
+    ) => void
+    onBarMouseLeave?: () => void
+}
+
+@observer
+export class StackedBars extends React.Component<StackedBarsProps> {
+    constructor(props: StackedBarsProps) {
+        super(props)
+        makeObservable(this)
+    }
+
+    override render(): React.ReactElement {
+        const {
+            dualAxis,
+            series,
+            formatColumn,
+            hoveredSeriesNames = [],
+            hoveredBar,
+            onBarMouseOver,
+            onBarMouseLeave,
+        } = this.props
+
+        const { verticalAxis, horizontalAxis } = dualAxis
+
+        const barWidth = (horizontalAxis.bandWidth ?? 0) * 0.8
+
+        return (
+            <>
+                {series.map((series, index) => {
+                    const isLegendHovered = hoveredSeriesNames.includes(
+                        series.seriesName
+                    )
+                    const opacity =
+                        isLegendHovered || hoveredSeriesNames.length === 0
+                            ? BAR_OPACITY.DEFAULT
+                            : BAR_OPACITY.MUTE
+
+                    return (
+                        <g
+                            key={index}
+                            id={makeIdForHumanConsumption(series.seriesName)}
+                            className={
+                                makeSafeForCSS(series.seriesName) + "-segments"
+                            }
+                        >
+                            {series.points.map((bar, index) => {
+                                const xPos =
+                                    horizontalAxis.place(bar.position) -
+                                    barWidth / 2
+                                const barOpacity =
+                                    bar === hoveredBar
+                                        ? BAR_OPACITY.FOCUS
+                                        : opacity
+
+                                return (
+                                    <StackedBarSegment
+                                        key={index}
+                                        id={makeIdForHumanConsumption(
+                                            formatColumn.formatTime(bar.time)
+                                        )}
+                                        bar={bar}
+                                        color={bar.color ?? series.color}
+                                        xOffset={xPos}
+                                        opacity={barOpacity}
+                                        yAxis={verticalAxis}
+                                        series={series}
+                                        onBarMouseOver={onBarMouseOver}
+                                        onBarMouseLeave={onBarMouseLeave}
+                                        barWidth={barWidth}
+                                    />
+                                )
+                            })}
+                        </g>
+                    )
+                })}
+            </>
+        )
+    }
+}

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedBars.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedBars.tsx
@@ -53,7 +53,8 @@ export class StackedBars extends React.Component<StackedBarsProps> {
                         series.seriesName
                     )
                     const opacity =
-                        isLegendHovered || hoveredSeriesNames.length === 0
+                        (isLegendHovered || hoveredSeriesNames.length === 0) &&
+                        !series.focus?.background
                             ? BAR_OPACITY.DEFAULT
                             : BAR_OPACITY.MUTE
 
@@ -70,7 +71,7 @@ export class StackedBars extends React.Component<StackedBarsProps> {
                                     horizontalAxis.place(bar.position) -
                                     barWidth / 2
                                 const barOpacity =
-                                    bar === hoveredBar
+                                    bar === hoveredBar || series.focus?.active
                                         ? BAR_OPACITY.FOCUS
                                         : opacity
 

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedUtils.ts
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedUtils.ts
@@ -12,9 +12,11 @@ import {
     EntityName,
     excludeUndefined,
     getRegionByName,
+    AxisConfigInterface,
 } from "@ourworldindata/utils"
 import { StackedPointPositionType, StackedSeries } from "./StackedConstants"
 import { WORLD_ENTITY_NAME } from "../core/GrapherConstants.js"
+import { StackedBarChartState } from "./StackedBarChartState.js"
 
 // This method shift up the Y Values of a Series with Points in place.
 export const stackSeries = <PositionType extends StackedPointPositionType>(
@@ -187,4 +189,14 @@ export function resolveCollision(
     if (area2 > area1) return s2
 
     return undefined // no preference
+}
+
+export function getXAxisConfigDefaultsForStackedBar(
+    chartState: StackedBarChartState
+): AxisConfigInterface {
+    return {
+        hideGridlines: true,
+        domainValues: chartState.xValues,
+        ticks: chartState.xValues.map((value) => ({ value, priority: 2 })),
+    }
 }


### PR DESCRIPTION
Implements stacked bar chart thumbnails.

- Minimal version: Renders only the bars, no annotations.
- Normal version: Renders entity names as labels, same way it's done for stacked area charts. Note that this is different from the non-thumbnail version where a separate legend is used instead of the labels.