### PR TITLE
🐛 fix prominent links CSS in column layouts

### DIFF
--- a/site/gdocs/components/layout.ts
+++ b/site/gdocs/components/layout.ts
@@ -99,18 +99,22 @@ const layouts: { [key in Container]: Layouts} = {
     },
     ["sticky-right-left-column"]: {
         ["default"]: "span-cols-5 span-md-cols-10 span-sm-cols-12",
+        ["prominent-link"]: "grid grid-cols-5 span-cols-5 span-md-cols-10 grid-md-cols-10 span-sm-cols-12 grid-sm-cols-12",
     },
     ["sticky-right-left-heading-column"]: {
         ["default"]: "span-cols-5 span-md-cols-10 col-md-start-2 span-sm-cols-12 col-sm-start-1"
     },
     ["sticky-right-right-column"]: {
         ["default"]: "span-cols-7 span-md-cols-10 span-sm-cols-12",
+         ["prominent-link"]: "grid grid-cols-6 span-cols-6 span-md-cols-12 grid-md-cols-12",
     },
     ["sticky-left-left-column"]: {
         ["default"]: "span-cols-7 span-md-cols-10 span-sm-cols-12",
+        ["prominent-link"]: "grid grid-cols-6 span-cols-6 span-md-cols-12 grid-md-cols-12",
     },
     ["sticky-left-right-column"]: {
         ["default"]: "span-cols-5 span-md-cols-10 span-sm-cols-12",
+        ["prominent-link"]: "grid grid-cols-6 span-cols-6 span-md-cols-12 grid-md-cols-12",
     },
     ["side-by-side"]: {
         ["default"]: "span-cols-6 span-sm-cols-12",


### PR DESCRIPTION
Fixes a regression from https://github.com/owid/owid-grapher/pull/5183

| Before | After |
|--------|--------|
| <img width="563" height="526" alt="image" src="https://github.com/user-attachments/assets/1fd15a50-6699-43af-bad9-8aca1d941cb3" /> |<img width="577" height="236" alt="image" src="https://github.com/user-attachments/assets/3ad5d3af-ad64-45e4-a428-1ccec8101363" /> | 