### PR TITLE
🐛 remove images with no cloudflare IDs

### DIFF
--- a/db/migration/1755030611375-RemoveImagesWithNoCloudflareId.ts
+++ b/db/migration/1755030611375-RemoveImagesWithNoCloudflareId.ts
@@ -1,0 +1,16 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class RemoveImagesWithNoCloudflareId1755030611375
+    implements MigrationInterface
+{
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`-- sql
+            DELETE FROM images 
+            WHERE cloudflareId IS NULL
+        `)
+    }
+
+    public async down(_: QueryRunner): Promise<void> {
+        // n/a, would have to restore from backup
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/owid/owid-grapher/issues/5265

> _We have some legacy images from the gdrive days that are "squatting" on filenames that prevent users from uploading images with the same filename (it throws a silent error)_ 
>
> _We should remove these images from the images table._

I cross referenced all images with no cloudflareIds against `posts_gdocs_x_images` and there were no conflicts.

I also wrote a node script to scan each published post's JSON for each filename to confirm the same thing.