### PR TITLE
Fix slugify function to handle subscript/superscript numbers

### DIFF
--- a/packages/@ourworldindata/utils/src/Util.test.ts
+++ b/packages/@ourworldindata/utils/src/Util.test.ts
@@ -23,6 +23,7 @@ import {
     urlToSlug,
     toRectangularMatrix,
     slugifySameCase,
+    slugify,
     greatestCommonDivisor,
     findGreatestCommonDivisorOfArray,
     traverseEnrichedBlock,
@@ -488,6 +489,35 @@ describe(toRectangularMatrix, () => {
             [1, 2, 3, 4],
         ]
         expect(toRectangularMatrix(arr, undefined)).toEqual(expected)
+    })
+})
+
+describe("slugify", () => {
+    it("handles subscript numbers correctly", () => {
+        expect(slugify("Per capita CO₂ emissions")).toBe("per-capita-co2-emissions")
+        expect(slugify("SO₂ concentrations")).toBe("so2-concentrations") 
+        expect(slugify("H₂O molecules")).toBe("h2o-molecules")
+        expect(slugify("CO₂ and CH₄ emissions")).toBe("co2-and-ch4-emissions")
+        expect(slugify("X₁₂₃ test case")).toBe("x123-test-case")
+    })
+
+    it("handles superscript numbers correctly", () => {
+        expect(slugify("X² + Y² = Z²")).toBe("x2-y2-z2")
+        expect(slugify("10³ cubic meters")).toBe("103-cubic-meters")
+        expect(slugify("E = mc²")).toBe("e-mc2")
+    })
+
+    it("handles mixed subscript and superscript numbers", () => {
+        expect(slugify("H₂SO₄²⁻ ion")).toBe("h2so42-ion")
+    })
+
+    it("handles text without subscripts/superscripts normally", () => {
+        expect(slugify("Regular text without subscripts")).toBe("regular-text-without-subscripts")
+        expect(slugify("Normal Numbers 123")).toBe("normal-numbers-123")
+    })
+
+    it("can allow slashes with subscripts", () => {
+        expect(slugify("CO₂/GDP ratios", true)).toBe("co2/gdp-ratios")
     })
 })
 

--- a/packages/@ourworldindata/utils/src/Util.test.ts
+++ b/packages/@ourworldindata/utils/src/Util.test.ts
@@ -494,8 +494,10 @@ describe(toRectangularMatrix, () => {
 
 describe("slugify", () => {
     it("handles subscript numbers correctly", () => {
-        expect(slugify("Per capita CO₂ emissions")).toBe("per-capita-co2-emissions")
-        expect(slugify("SO₂ concentrations")).toBe("so2-concentrations") 
+        expect(slugify("Per capita CO₂ emissions")).toBe(
+            "per-capita-co2-emissions"
+        )
+        expect(slugify("SO₂ concentrations")).toBe("so2-concentrations")
         expect(slugify("H₂O molecules")).toBe("h2o-molecules")
         expect(slugify("CO₂ and CH₄ emissions")).toBe("co2-and-ch4-emissions")
         expect(slugify("X₁₂₃ test case")).toBe("x123-test-case")
@@ -512,7 +514,9 @@ describe("slugify", () => {
     })
 
     it("handles text without subscripts/superscripts normally", () => {
-        expect(slugify("Regular text without subscripts")).toBe("regular-text-without-subscripts")
+        expect(slugify("Regular text without subscripts")).toBe(
+            "regular-text-without-subscripts"
+        )
         expect(slugify("Normal Numbers 123")).toBe("normal-numbers-123")
     })
 

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -321,13 +321,29 @@ export const slugify = (str: string, allowSlashes?: boolean): string => {
     const normalizedStr = str.replace(/[₀₁₂₃₄₅₆₇₈₉⁰¹²³⁴⁵⁶⁷⁸⁹]/g, (match) => {
         // Subscript characters (₀₁₂₃₄₅₆₇₈₉)
         const subscriptMap: { [key: string]: string } = {
-            '₀': '0', '₁': '1', '₂': '2', '₃': '3', '₄': '4',
-            '₅': '5', '₆': '6', '₇': '7', '₈': '8', '₉': '9'
+            "₀": "0",
+            "₁": "1",
+            "₂": "2",
+            "₃": "3",
+            "₄": "4",
+            "₅": "5",
+            "₆": "6",
+            "₇": "7",
+            "₈": "8",
+            "₉": "9",
         }
         // Superscript characters (⁰¹²³⁴⁵⁶⁷⁸⁹)
         const superscriptMap: { [key: string]: string } = {
-            '⁰': '0', '¹': '1', '²': '2', '³': '3', '⁴': '4',
-            '⁵': '5', '⁶': '6', '⁷': '7', '⁸': '8', '⁹': '9'
+            "⁰": "0",
+            "¹": "1",
+            "²": "2",
+            "³": "3",
+            "⁴": "4",
+            "⁵": "5",
+            "⁶": "6",
+            "⁷": "7",
+            "⁸": "8",
+            "⁹": "9",
         }
         return subscriptMap[match] || superscriptMap[match] || match
     })

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -316,8 +316,23 @@ export const makeAnnotationsSlug = (columnSlug: string): string =>
     `${columnSlug}-annotations`
 
 // Take an arbitrary string and turn it into a nice url slug
-export const slugify = (str: string, allowSlashes?: boolean): string =>
-    slugifySameCase(str.toLowerCase(), allowSlashes)
+export const slugify = (str: string, allowSlashes?: boolean): string => {
+    // Convert subscript and superscript numbers to regular numbers
+    const normalizedStr = str.replace(/[₀₁₂₃₄₅₆₇₈₉⁰¹²³⁴⁵⁶⁷⁸⁹]/g, (match) => {
+        // Subscript characters (₀₁₂₃₄₅₆₇₈₉)
+        const subscriptMap: { [key: string]: string } = {
+            '₀': '0', '₁': '1', '₂': '2', '₃': '3', '₄': '4',
+            '₅': '5', '₆': '6', '₇': '7', '₈': '8', '₉': '9'
+        }
+        // Superscript characters (⁰¹²³⁴⁵⁶⁷⁸⁹)
+        const superscriptMap: { [key: string]: string } = {
+            '⁰': '0', '¹': '1', '²': '2', '³': '3', '⁴': '4',
+            '⁵': '5', '⁶': '6', '⁷': '7', '⁸': '8', '⁹': '9'
+        }
+        return subscriptMap[match] || superscriptMap[match] || match
+    })
+    return slugifySameCase(normalizedStr.toLowerCase(), allowSlashes)
+}
 
 export const slugifySameCase = (
     str: string,


### PR DESCRIPTION
## Summary

Fixes the `slugify` function to properly handle Unicode subscript and superscript numbers by converting them to regular digits before slugification. This ensures that titles with chemical formulas like "Per capita CO₂ emissions" are correctly slugified as "per-capita-co2-emissions" instead of "per-capita-co-emissions".

## Issue

Fixes #5189

## Changes

- Modified the `slugify` function in `/packages/@ourworldindata/utils/src/Util.ts` to normalize Unicode subscript (₀₁₂₃₄₅₆₇₈₉) and superscript (⁰¹²³⁴⁵⁶⁷⁸⁹) characters to regular numbers before applying slugification
- Added comprehensive test cases in `/packages/@ourworldindata/utils/src/Util.test.ts` covering:
  - Subscript numbers in chemical formulas (CO₂, H₂O, etc.)
  - Superscript numbers in mathematical expressions (X², 10³, etc.)
  - Mixed subscript/superscript scenarios
  - Edge cases and backward compatibility
- All existing tests continue to pass, ensuring no breaking changes

## Design Decisions

- Used character mapping approach rather than Unicode normalization to maintain precise control over the conversion
- Applied the normalization before case conversion to ensure consistent behavior
- Maintained the existing function signature and behavior for backward compatibility
- Added the normalization step as a preprocessing stage before calling the existing `slugifySameCase` function

🤖 Generated with [Claude Code](https://claude.ai/code)