### PR TITLE
🔨 simplify overlay query params

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -745,21 +745,18 @@ export class GrapherState {
         if (overlay) {
             if (overlay === "sources") {
                 this.activeModal = GrapherModal.Sources
+            } else if (overlay === "download-data") {
+                this.activeModal = GrapherModal.Download
+                this.activeDownloadModalTab = DownloadModalTabName.Data
+            } else if (overlay === "download-vis") {
+                this.activeModal = GrapherModal.Download
+                this.activeDownloadModalTab = DownloadModalTabName.Vis
             } else if (overlay === "download") {
                 this.activeModal = GrapherModal.Download
             } else if (overlay === "embed") {
                 this.activeModal = GrapherModal.Embed
             } else {
                 console.error("Unexpected overlay: " + overlay)
-            }
-        }
-
-        const downloadOverlayTab = params.downloadOverlayTab
-        if (downloadOverlayTab) {
-            if (downloadOverlayTab === "data") {
-                this.activeDownloadModalTab = DownloadModalTabName.Data
-            } else if (downloadOverlayTab === "vis") {
-                this.activeDownloadModalTab = DownloadModalTabName.Vis
             }
         }
 
@@ -3173,7 +3170,12 @@ export class GrapherState {
     @computed get overlayParam(): string | undefined {
         if (!this.activeModal) return undefined
         return match(this.activeModal)
-            .with(GrapherModal.Download, () => "download")
+            .with(GrapherModal.Download, () => {
+                return match(this.activeDownloadModalTab)
+                    .with(DownloadModalTabName.Data, () => "download-data")
+                    .with(DownloadModalTabName.Vis, () => "download-vis")
+                    .exhaustive()
+            })
             .with(GrapherModal.Embed, () => "embed")
             .with(GrapherModal.Sources, () => "sources")
             .exhaustive()

--- a/packages/@ourworldindata/grapher/src/core/GrapherUrl.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherUrl.ts
@@ -75,7 +75,6 @@ export const grapherConfigToQueryParams = (
         // These cannot be specified in config, so we always set them to undefined
         showSelectionOnlyInTable: undefined,
         overlay: undefined,
-        downloadOverlayTab: undefined,
         tableFilter: undefined,
         tableSearch: undefined,
     }
@@ -135,7 +134,6 @@ export const grapherObjectToQueryParams = (
         tableFilter: grapher.dataTableConfig.filter,
         tableSearch: grapher.dataTableConfig.search,
         overlay: grapher.overlayParam,
-        downloadOverlayTab: grapher.downloadOverlayTabParam,
     }
     return params
 }

--- a/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
+++ b/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
@@ -585,7 +585,6 @@ export type GrapherQueryParams = {
     focus?: string
     tab?: string
     overlay?: string
-    downloadOverlayTab?: string
     stackMode?: string
     zoomToSelection?: string
     xScale?: string
@@ -634,7 +633,6 @@ const GRAPHER_ALL_QUERY_PARAMS: Required<LegacyGrapherQueryParams> = {
     mapSelect: "",
     tableFilter: "",
     tableSearch: "",
-    downloadOverlayTab: "",
 }
 export const GRAPHER_QUERY_PARAM_KEYS = Object.keys(
     GRAPHER_ALL_QUERY_PARAMS

--- a/site/search/searchUtils.tsx
+++ b/site/search/searchUtils.tsx
@@ -346,8 +346,7 @@ export const constructDownloadUrl = ({
 }): string => {
     const viewQueryStr = generateQueryStrForChartHit({ hit })
     const grapherParams = new URLSearchParams({
-        overlay: "download",
-        downloadOverlayTab: "data",
+        overlay: "download-data",
     })
     const queryStr = viewQueryStr
         ? `${viewQueryStr}&${grapherParams}`


### PR DESCRIPTION
Drops `downloadOverlayTab` and adds 'data-download' and 'data-viz' options as overlay options.