### PR TITLE
🎉 add rich data support for explorers

### DIFF
--- a/baker/algolia/utils/explorerViews.ts
+++ b/baker/algolia/utils/explorerViews.ts
@@ -40,7 +40,6 @@ import {
     IndicatorUnenrichedExplorerViewRecord,
     CsvEnrichedExplorerViewRecord,
     FinalizedExplorerRecord,
-    ExplorerType,
 } from "./types.js"
 import {
     MAX_NON_FM_RECORD_SCORE,
@@ -51,6 +50,7 @@ import {
 import {
     ChartRecord,
     ChartRecordType,
+    ExplorerType,
 } from "../../../site/search/searchTypes.js"
 
 /**

--- a/baker/algolia/utils/types.ts
+++ b/baker/algolia/utils/types.ts
@@ -4,7 +4,7 @@ import {
     GrapherInterface,
     GrapherTabName,
 } from "@ourworldindata/types"
-import { ChartRecord } from "../../../site/search/searchTypes.js"
+import { ChartRecord, ExplorerType } from "../../../site/search/searchTypes.js"
 import { OwidIncomeGroupName } from "@ourworldindata/utils"
 
 /** Charts */
@@ -60,12 +60,6 @@ export type ExplorerIndicatorMetadataDictionary = Record<
         entityNames?: string[]
     }
 >
-
-export enum ExplorerType {
-    Grapher = "grapher",
-    Indicator = "indicator",
-    Csv = "csv",
-}
 
 export interface ExplorerViewBaseRecord {
     explorerType: ExplorerType

--- a/baker/algolia/utils/types.ts
+++ b/baker/algolia/utils/types.ts
@@ -61,7 +61,14 @@ export type ExplorerIndicatorMetadataDictionary = Record<
     }
 >
 
+export enum ExplorerType {
+    Grapher = "grapher",
+    Indicator = "indicator",
+    Csv = "csv",
+}
+
 export interface ExplorerViewBaseRecord {
+    explorerType: ExplorerType
     availableEntities: string[]
     numNonDefaultSettings: number
     tableSlug?: string
@@ -82,22 +89,26 @@ export interface ExplorerViewBaseRecord {
 }
 
 export type GrapherUnenrichedExplorerViewRecord = ExplorerViewBaseRecord & {
+    explorerType: ExplorerType.Grapher
     viewGrapherId: number
 }
 
 export type GrapherEnrichedExplorerViewRecord = ExplorerViewBaseRecord & {
+    explorerType: ExplorerType.Grapher
     viewTitle: string
     viewSubtitle: string
     titleLength: number
 }
 
 export type IndicatorUnenrichedExplorerViewRecord = ExplorerViewBaseRecord & {
+    explorerType: ExplorerType.Indicator
     viewGrapherId: never
     ySlugs: []
     tableSlug: never
 }
 
 export type IndicatorEnrichedExplorerViewRecord = ExplorerViewBaseRecord & {
+    explorerType: ExplorerType.Indicator
     viewGrapherId: never
     ySlugs: string[]
     tableSlug: never
@@ -106,12 +117,14 @@ export type IndicatorEnrichedExplorerViewRecord = ExplorerViewBaseRecord & {
 }
 
 export type CsvUnenrichedExplorerViewRecord = ExplorerViewBaseRecord & {
+    explorerType: ExplorerType.Csv
     viewGrapherId: never
     ySlugs: string[]
     tableSlug: string
 }
 
 export type CsvEnrichedExplorerViewRecord = ExplorerViewBaseRecord & {
+    explorerType: ExplorerType.Csv
     viewGrapherId: never
     ySlugs: string[]
     tableSlug: string
@@ -127,6 +140,7 @@ export type EnrichedExplorerRecord =
 // These properties are only used in Algolia for ranking purposes.
 // This type shouldn't be necessary in any client-side code.
 export type FinalizedExplorerRecord = ChartRecord & {
+    explorerType: ExplorerType
     viewTitleIndexWithinExplorer: number
     isFirstExplorerView: boolean
 }

--- a/functions/_common/explorerHandlers.ts
+++ b/functions/_common/explorerHandlers.ts
@@ -56,11 +56,11 @@ async function initGrapherForExplorerView(
     await explorer.updateGrapherFromExplorer()
     explorer.grapherState.populateFromQueryParams(urlObj.queryParams)
 
-    explorer.grapherState.isExportingToSvgOrPng = true
-    explorer.grapherState.shouldIncludeDetailsInStaticExport = options.details
-    explorer.grapherState.isSocialMediaExport =
-        options.grapherProps.isSocialMediaExport
-    explorer.grapherState.renderMode = options.grapherProps.renderMode
+    if (options.grapherProps?.isSocialMediaExport)
+        explorer.grapherState.isSocialMediaExport =
+            options.grapherProps.isSocialMediaExport
+    if (options.grapherProps?.renderMode)
+        explorer.grapherState.renderMode = options.grapherProps.renderMode
     explorer.grapherState.initialOptions = { baseFontSize: options.fontSize }
 
     return {
@@ -100,6 +100,29 @@ export async function handleThumbnailRequestForExplorerView(
     }
 }
 
+export async function handleConfigRequestForExplorerView(
+    searchParams: URLSearchParams,
+    env: Env
+) {
+    const options = extractOptions(searchParams)
+
+    const url = env.url
+    url.href = url.href.replace(extensions.configJson, "")
+
+    try {
+        const { grapherState } = await initGrapherForExplorerView(env, options)
+
+        const config = grapherState.object
+        return new Response(JSON.stringify(config), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+        })
+    } catch (e) {
+        console.error(e)
+        return error(500, e)
+    }
+}
+
 export async function fetchCsvForExplorerView(
     searchParams: URLSearchParams,
     env: Env
@@ -121,9 +144,7 @@ export async function fetchCsvForExplorerView(
             searchParams ?? new URLSearchParams("")
         )
         return new Response(csv, {
-            headers: {
-                "Content-Type": "text/csv",
-            },
+            headers: { "Content-Type": "text/csv" },
         })
     } catch (e) {
         console.error(e)
@@ -163,9 +184,7 @@ export async function fetchReadmeForExplorerView(
         const { grapherState } = await initGrapherForExplorerView(env, options)
         const readme = assembleReadme(grapherState, searchParams)
         return new Response(readme, {
-            headers: {
-                "Content-Type": "text/markdown; charset=utf-8",
-            },
+            headers: { "Content-Type": "text/markdown; charset=utf-8" },
         })
     } catch (e) {
         console.error(e)

--- a/functions/explorers/[slug].ts
+++ b/functions/explorers/[slug].ts
@@ -8,6 +8,7 @@ import {
     fetchMetadataForExplorerView,
     fetchReadmeForExplorerView,
     fetchZipForExplorerView,
+    handleConfigRequestForExplorerView,
     handleThumbnailRequestForExplorerView,
 } from "../_common/explorerHandlers.js"
 
@@ -23,6 +24,13 @@ const router = Router<
     finally: [corsify],
 })
 router
+    .get(
+        `/explorers/:slug${extensions.configJson}`,
+        async (_, { searchParams }, env) => {
+            console.log("Handling explorer config request")
+            return handleConfigRequestForExplorerView(searchParams, env)
+        }
+    )
     .get(
         `/explorers/:slug${extensions.svg}`,
         async (_, { searchParams }, env) => {

--- a/settings/clientSettings.ts
+++ b/settings/clientSettings.ts
@@ -41,6 +41,9 @@ export const EXPLORER_DYNAMIC_THUMBNAIL_URL: string =
 export const GRAPHER_DYNAMIC_CONFIG_URL: string =
     process.env.GRAPHER_DYNAMIC_CONFIG_URL ?? `${BAKED_GRAPHER_URL}`
 
+export const EXPLORER_DYNAMIC_CONFIG_URL: string =
+    process.env.EXPLORER_DYNAMIC_CONFIG_URL ?? `${BAKED_BASE_URL}/explorers`
+
 export const MULTI_DIM_DYNAMIC_CONFIG_URL: string =
     process.env.MULTI_DIM_DYNAMIC_CONFIG_URL ?? `${BAKED_BASE_URL}/multi-dim`
 

--- a/site/search/searchTypes.ts
+++ b/site/search/searchTypes.ts
@@ -51,6 +51,12 @@ export enum ChartRecordType {
     MultiDimView = "multiDimView",
 }
 
+export enum ExplorerType {
+    Grapher = "grapher",
+    Indicator = "indicator",
+    Csv = "csv",
+}
+
 export interface ChartRecord {
     type: ChartRecordType
     objectID: string
@@ -104,26 +110,44 @@ export const searchCategoryFilters: [string, SearchCategoryFilter][] = [
     ["Charts", SearchIndexName.ExplorerViewsMdimViewsAndCharts],
 ]
 
-/**
- * This is the type for the hits that we get back from algolia when we search
- * response.results[0].hits is an array of these
- */
-export type SearchChartHit = {
+interface BaseSearchChartHit {
     title: string
     slug: string
     availableEntities: string[]
     originalAvailableEntities?: string[]
     objectID: string
-    variantName: string | null
-    type: ChartRecordType
-    queryParams: string
+    variantName?: string
     subtitle?: string
     availableTabs: GrapherTabName[]
-    chartConfigId?: string
     __position: number
     _highlightResult?: HitHighlightResult
     _snippetResult?: HitHighlightResult
 }
+
+type SearchChartViewHit = BaseSearchChartHit & {
+    type: ChartRecordType.Chart
+}
+
+type SearchExplorerViewHit = BaseSearchChartHit & {
+    type: ChartRecordType.ExplorerView
+    explorerType: ExplorerType
+    queryParams: string
+}
+
+type SearchMultiDimViewHit = BaseSearchChartHit & {
+    type: ChartRecordType.MultiDimView
+    queryParams: string
+    chartConfigId: string
+}
+
+/**
+ * This is the type for the hits that we get back from algolia when we search
+ * response.results[0].hits is an array of these
+ */
+export type SearchChartHit =
+    | SearchChartViewHit
+    | SearchExplorerViewHit
+    | SearchMultiDimViewHit
 
 // SearchResponse adds the extra fields from Algolia: page, nbHits, etc
 export type SearchChartsResponse = SearchResponse<SearchChartHit>

--- a/site/search/searchUtils.tsx
+++ b/site/search/searchUtils.tsx
@@ -70,6 +70,7 @@ import { ForwardedRef } from "react"
 import {
     BAKED_BASE_URL,
     BAKED_GRAPHER_URL,
+    EXPLORER_DYNAMIC_CONFIG_URL,
     EXPLORER_DYNAMIC_THUMBNAIL_URL,
     GRAPHER_DYNAMIC_CONFIG_URL,
     GRAPHER_DYNAMIC_THUMBNAIL_URL,
@@ -348,18 +349,21 @@ export const constructConfigUrl = ({
 }: {
     hit: SearchChartHit
 }): string | undefined => {
-    const isExplorerView = hit.type === ChartRecordType.ExplorerView
-    const isMultiDimView = hit.type === ChartRecordType.MultiDimView
-
-    if (isExplorerView) return undefined // Not yet supported
-
-    // Fetch Mdim config by its UUID
-    if (isMultiDimView)
-        return hit.chartConfigId
-            ? `${GRAPHER_DYNAMIC_CONFIG_URL}/by-uuid/${hit.chartConfigId}.config.json`
-            : undefined
-
-    return `${GRAPHER_DYNAMIC_CONFIG_URL}/${hit.slug}.config.json`
+    return match(hit)
+        .with(
+            { type: ChartRecordType.Chart },
+            (hit) => `${GRAPHER_DYNAMIC_CONFIG_URL}/${hit.slug}.config.json`
+        )
+        .with(
+            { type: ChartRecordType.MultiDimView },
+            (hit) =>
+                `${GRAPHER_DYNAMIC_CONFIG_URL}/by-uuid/${hit.chartConfigId}.config.json`
+        )
+        .with({ type: ChartRecordType.ExplorerView }, () => {
+            const queryStr = generateQueryStrForChartHit({ hit })
+            return `${EXPLORER_DYNAMIC_CONFIG_URL}/${hit.slug}.config.json${queryStr}`
+        })
+        .exhaustive()
 }
 
 export const constructMdimConfigUrl = ({
@@ -436,6 +440,7 @@ export const DATA_CATALOG_ATTRIBUTES = [
     "availableTabs",
     "subtitle",
     "chartConfigId",
+    "explorerType",
 ]
 
 export function setToFacetFilters(


### PR DESCRIPTION
Adds support for rich data display in search for explorers. CSV-based explorers aren’t supported.

I was planning to wait for Daniel’s PR, but since we’re late in the cycle I figured it’s better to start now. Once Daniel’s PR lands we might want to rewrite.

### Summary
- A new `/explorers/{slug}.config.json` endpoint returns the chart config for a given explorer view. It works for any explorer type, but csv-based configs don’t include the dimensions field
- The client fetches the config and everything works as usual
- I also added a new `explorerType` field to Algolia records so we know upfront if an explorer view uses csv data and doesn’t support rich data display