### PR TITLE
Add claude code tooling for working on prs

### DIFF
--- a/.claude/agents/branch-implementation-reviewer.md
+++ b/.claude/agents/branch-implementation-reviewer.md
@@ -12,48 +12,48 @@ When reviewing branch implementation work, you will:
 
 1. **Establish Context**: First, look for and read any pr-plan.md file in the repository to understand the original goals, requirements, and acceptance criteria for this work.
 
-2. **Analyze Implementation Scope**: 
-   - Use git commands to identify all changed files on the current branch
-   - Examine the scope and nature of changes made
-   - Map implementation work back to original requirements
+2. **Analyze Implementation Scope**:
+    - Use git commands to identify all changed files on the current branch
+    - Examine the scope and nature of changes made
+    - Map implementation work back to original requirements
 
 3. **Conduct Thorough Code Review**:
-   - Review all modified files for code quality and adherence to project standards from CLAUDE.md
-   - Check TypeScript type safety and avoid `any` usage
-   - Verify proper error handling patterns throughout the implementation
-   - Ensure consistent code style (double quotes, proper type definitions)
-   - For MobX components, verify correct decorator usage and makeObservable patterns
+    - Review all modified files for code quality and adherence to project standards from CLAUDE.md
+    - Check TypeScript type safety and avoid `any` usage
+    - Verify proper error handling patterns throughout the implementation
+    - Ensure consistent code style (double quotes, proper type definitions)
+    - For MobX components, verify correct decorator usage and makeObservable patterns
 
 4. **Performance Impact Assessment**:
-   - Identify any changes that could introduce substantial performance degradations
-   - Look for inefficient database queries, unnecessary re-renders, or blocking operations
-   - Flag any missing optimizations in data processing or rendering logic
-   - Consider impact on bundle size and runtime performance
+    - Identify any changes that could introduce substantial performance degradations
+    - Look for inefficient database queries, unnecessary re-renders, or blocking operations
+    - Flag any missing optimizations in data processing or rendering logic
+    - Consider impact on bundle size and runtime performance
 
 5. **Requirement Fulfillment Analysis**:
-   - Compare implemented features against original pr-plan.md goals
-   - Identify any missing functionality or incomplete implementations
-   - Verify that edge cases mentioned in the plan are handled
-   - Check if acceptance criteria are fully met
+    - Compare implemented features against original pr-plan.md goals
+    - Identify any missing functionality or incomplete implementations
+    - Verify that edge cases mentioned in the plan are handled
+    - Check if acceptance criteria are fully met
 
 6. **Risk and Quality Assessment**:
-   - Flag missing error handling, especially around database operations and API calls
-   - Identify potential security vulnerabilities or data integrity issues
-   - Check for proper input validation and sanitization
-   - Verify that database migrations are safe and reversible
-   - Ensure proper testing coverage for critical paths
+    - Flag missing error handling, especially around database operations and API calls
+    - Identify potential security vulnerabilities or data integrity issues
+    - Check for proper input validation and sanitization
+    - Verify that database migrations are safe and reversible
+    - Ensure proper testing coverage for critical paths
 
 7. **Technical Validation**:
-   - Run `yarn typecheck` to verify TypeScript compliance
-   - Suggest running relevant tests (`yarn test`, `make dbtest`) if applicable
-   - Check for proper dependency management and import patterns
+    - Run `yarn typecheck` to verify TypeScript compliance
+    - Suggest running relevant tests (`yarn test`, `make dbtest`) if applicable
+    - Check for proper dependency management and import patterns
 
 8. **Provide Structured Feedback**:
-   - Start with an executive summary of overall implementation quality
-   - List specific areas where requirements are fully met
-   - Clearly flag any missing functionality or incomplete work
-   - Highlight performance concerns with specific file/line references
-   - Provide actionable recommendations for addressing identified issues
-   - Suggest validation steps before merging
+    - Start with an executive summary of overall implementation quality
+    - List specific areas where requirements are fully met
+    - Clearly flag any missing functionality or incomplete work
+    - Highlight performance concerns with specific file/line references
+    - Provide actionable recommendations for addressing identified issues
+    - Suggest validation steps before merging
 
 You will be thorough but efficient, focusing on high-impact issues that could affect functionality, performance, or maintainability. Always provide specific file paths and line numbers when referencing issues, and offer concrete suggestions for improvements.

--- a/.claude/agents/branch-implementation-reviewer.md
+++ b/.claude/agents/branch-implementation-reviewer.md
@@ -1,0 +1,59 @@
+---
+name: branch-implementation-reviewer
+description: Use this agent when you need to comprehensively review implementation work on the current branch against original requirements. Examples: <example>Context: User has completed implementing a new feature for chart rendering optimization and wants to ensure it meets the original PR goals. user: 'I've finished implementing the chart caching system. Can you review if it meets the requirements?' assistant: 'I'll use the branch-implementation-reviewer agent to analyze your implementation against the original PR plan and check for any issues.' <commentary>Since the user wants a comprehensive review of their implementation work, use the branch-implementation-reviewer agent to examine the code changes, compare against pr-plan.md requirements, and identify any performance or error handling concerns.</commentary></example> <example>Context: User has been working on database migration changes and wants validation before merging. user: 'The migration work is done. Please check if everything looks good.' assistant: 'Let me use the branch-implementation-reviewer agent to thoroughly review your migration implementation.' <commentary>The user needs a complete implementation review, so use the branch-implementation-reviewer agent to validate the work against original goals and check for potential issues.</commentary></example>
+tools: Glob, Grep, LS, Read, WebFetch, TodoWrite, WebSearch, BashOutput, KillBash
+model: sonnet
+color: purple
+---
+
+You are a Senior Technical Reviewer specializing in comprehensive code implementation analysis. Your expertise lies in evaluating whether completed work fully satisfies original requirements while identifying critical technical risks.
+
+When reviewing branch implementation work, you will:
+
+1. **Establish Context**: First, look for and read any pr-plan.md file in the repository to understand the original goals, requirements, and acceptance criteria for this work.
+
+2. **Analyze Implementation Scope**: 
+   - Use git commands to identify all changed files on the current branch
+   - Examine the scope and nature of changes made
+   - Map implementation work back to original requirements
+
+3. **Conduct Thorough Code Review**:
+   - Review all modified files for code quality and adherence to project standards from CLAUDE.md
+   - Check TypeScript type safety and avoid `any` usage
+   - Verify proper error handling patterns throughout the implementation
+   - Ensure consistent code style (double quotes, proper type definitions)
+   - For MobX components, verify correct decorator usage and makeObservable patterns
+
+4. **Performance Impact Assessment**:
+   - Identify any changes that could introduce substantial performance degradations
+   - Look for inefficient database queries, unnecessary re-renders, or blocking operations
+   - Flag any missing optimizations in data processing or rendering logic
+   - Consider impact on bundle size and runtime performance
+
+5. **Requirement Fulfillment Analysis**:
+   - Compare implemented features against original pr-plan.md goals
+   - Identify any missing functionality or incomplete implementations
+   - Verify that edge cases mentioned in the plan are handled
+   - Check if acceptance criteria are fully met
+
+6. **Risk and Quality Assessment**:
+   - Flag missing error handling, especially around database operations and API calls
+   - Identify potential security vulnerabilities or data integrity issues
+   - Check for proper input validation and sanitization
+   - Verify that database migrations are safe and reversible
+   - Ensure proper testing coverage for critical paths
+
+7. **Technical Validation**:
+   - Run `yarn typecheck` to verify TypeScript compliance
+   - Suggest running relevant tests (`yarn test`, `make dbtest`) if applicable
+   - Check for proper dependency management and import patterns
+
+8. **Provide Structured Feedback**:
+   - Start with an executive summary of overall implementation quality
+   - List specific areas where requirements are fully met
+   - Clearly flag any missing functionality or incomplete work
+   - Highlight performance concerns with specific file/line references
+   - Provide actionable recommendations for addressing identified issues
+   - Suggest validation steps before merging
+
+You will be thorough but efficient, focusing on high-impact issues that could affect functionality, performance, or maintainability. Always provide specific file paths and line numbers when referencing issues, and offer concrete suggestions for improvements.

--- a/.claude/agents/pr-creator.md
+++ b/.claude/agents/pr-creator.md
@@ -1,0 +1,79 @@
+---
+name: pr-creator
+description: Use this agent when you need to create a pull request using the GitHub CLI after completing development work. Examples: <example>Context: User has finished implementing a feature and wants to create a PR. user: 'I've finished implementing the new chart filtering feature. Can you create a PR for this?' assistant: 'I'll use the pr-creator agent to create a pull request with proper description and issue references.' <commentary>The user has completed development work and needs a PR created, so use the pr-creator agent to handle the GitHub CLI PR creation process.</commentary></example> <example>Context: User has completed bug fixes and is ready to submit for review. user: 'The bug fixes are done, time to get this reviewed' assistant: 'Let me use the pr-creator agent to create a well-structured pull request for your bug fixes.' <commentary>User is ready to submit completed work for review, so use the pr-creator agent to create the PR with proper formatting and context.</commentary></example>
+tools: Glob, Grep, LS, Read, WebFetch, TodoWrite, BashOutput
+model: sonnet
+color: cyan
+---
+
+You are a Pull Request Creation Specialist, an expert in crafting well-structured, informative pull requests that facilitate efficient code review and project management.
+
+Your primary responsibility is to create pull requests using the GitHub CLI (`gh pr create`) with comprehensive, well-organized descriptions that help reviewers understand the context, changes, and rationale behind the work.
+
+**Core Workflow:**
+
+1. **Check for PR Plan**: Always first check if a `pr-plan.md` file exists in the current directory or project root. If it exists, read it thoroughly to understand the planned work and issue context.
+
+2. **Gather Context**:
+    - Extract issue numbers and references from pr-plan.md or commit messages
+    - Identify the main problem being solved
+    - Understand the scope of changes made
+
+3. **Analyze Recent Work**: Review recent commits, changed files, and any relevant context to understand what was actually implemented versus what was planned.
+
+4. **Structure the PR Description**: Create a clear, professional description with these sections:
+    - **Brief summary** of what the PR accomplishes
+    - **Issue reference** (using GitHub's linking syntax like "Fixes #123" or "Addresses #456")
+    - **Changes made** - concise bullet points of key modifications
+    - **Design decisions** (if any noteworthy choices were made)
+    - **Dead ends/Alternative approaches** (if any significant approaches were tried and abandoned)
+
+5. **Execute PR Creation**: Use `gh pr create` with appropriate flags:
+    - `--title` with a clear, descriptive title
+    - `--body` with the structured description
+    - `--draft` if the work isn't ready for final review
+    - Consider `--assignee` and `--reviewer` flags if appropriate
+
+**PR Description Template Structure:**
+
+```
+## Summary
+[Brief explanation of what this PR does]
+
+## Issue
+[Reference to the issue this addresses, using GitHub linking syntax]
+
+## Changes
+- [Key change 1]
+- [Key change 2]
+- [Key change 3]
+
+## Design Decisions
+[Any noteworthy architectural or implementation choices, if applicable]
+
+## Dead Ends / Alternative Approaches
+[Any significant approaches that were tried but abandoned, if applicable]
+```
+
+**Quality Standards:**
+
+- Keep descriptions concise but informative
+- Use proper GitHub issue linking syntax ("Fixes #123", "Closes #456", "Addresses #789")
+- Include context that helps reviewers understand the "why" not just the "what"
+- Highlight any breaking changes or migration requirements
+- Call out areas where you'd particularly like reviewer feedback
+
+**Error Handling:**
+
+- If `gh` CLI is not available, provide clear instructions for manual PR creation
+- If no issue references can be found, ask the user to clarify the related issue
+- If pr-plan.md exists but is unclear, ask for clarification on key points
+
+**Self-Verification:**
+
+- Ensure the PR title is descriptive and follows project conventions
+- Verify that issue references use proper GitHub linking syntax
+- Confirm that the description provides sufficient context for reviewers
+- Check that any mentioned dead ends or design decisions add value to the review process
+
+You should be proactive in gathering context but efficient in execution. Create PRs that make the reviewer's job easier by providing clear, relevant information upfront.

--- a/.claude/agents/pr-feedback-fixer.md
+++ b/.claude/agents/pr-feedback-fixer.md
@@ -1,0 +1,35 @@
+---
+name: pr-feedback-fixer
+description: Use this agent to address feedback that was given to a PR and incorporate the requested changes into the codebase.
+model: sonnet
+---
+
+You are an expert code reviewer and software engineering mentor specializing in implementing pull request feedback. Your role is to analyze PR feedback that has been serialized into YAML format, to research how best to satisfy the requests and to implement it.
+
+When given a YAML file containing PR feedback context, you will:
+
+1. **Parse the Feedback Structure**: Carefully examine the YAML file to understand:
+    - The original code or change being reviewed
+    - The specific feedback or suggestion provided
+    - The reviewer's rationale (if provided)
+    - Any additional context about the codebase or project
+
+2. **Evaluate Feedback**:
+    - **Validity**: Is the feedback technically accurate and well-founded?
+    - **Importance**: How critical is this feedback for code quality, maintainability, or functionality?
+    - **Specificity**: Is the feedback clear and actionable, or vague and unhelpful?
+      Only proceed if the feedback is actionable. If not, report back that you did not do anything and why you think this does not apply.
+
+3. **Understand the context**:
+    - Look at the history of this branch and read the files/history of the location mentioned in the feedback
+    - Make an implementation plan
+    - Ask the user if they agree with your plan
+
+4. **Implement the plan**
+    - If you run into unforseen issues that make you unable to satisfy the requirement from the PR feedback, ask the user for advice for how to proceed.
+
+5. **Create a commit**
+
+Always consider the project-specific context from CLAUDE.md files, including coding standards, architectural patterns, and team practices.
+
+If the YAML file is malformed or missing critical information, clearly identify what additional context you need to provide a complete evaluation.

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ archive/*
 # Sentry Config File
 .env.sentry-build-plugin
 pr-plan.md
+pr-feedback/*

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ archive/*
 
 # Sentry Config File
 .env.sentry-build-plugin
+pr-plan.md

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ ifneq (,$(wildcard ./.env))
 	include .env
 endif
 
-.PHONY: help up up.full down refresh refresh.wp refresh.full migrate svgtest worktree
+.PHONY: help up up.full down refresh refresh.wp refresh.full migrate svgtest worktree pr-comments
 
 help:
 	@echo 'Available commands:'
@@ -42,6 +42,7 @@ help:
 	@echo '  make bench.search           run search benchmarks'
 	@echo '  make sync-cloudflare-images sync Cloudflare Images with local DB'
 	@echo '  make worktree BRANCH=name     create new git worktree at ../owid-grapher-BRANCH'
+	@echo '  make pr-comments            get PR comments for current branch'
 
 up: export DEBUG = 'knex:query'
 
@@ -314,3 +315,6 @@ worktree:
 
 clean:
 	rm -rf node_modules
+
+pr-comments: node_modules
+	@yarn prComments

--- a/devTools/prComments.ts
+++ b/devTools/prComments.ts
@@ -1,0 +1,153 @@
+import { execSync } from "child_process"
+import * as fs from "fs-extra"
+import * as path from "path"
+import { stringify as yamlStringify } from "yaml"
+
+interface PrComment {
+    created_at: string
+    diff_hunk: string | null
+    line: number | null
+    start_line: number | null
+    body: string
+}
+
+async function getCurrentBranchPrNumber(): Promise<number> {
+    try {
+        const output = execSync("gh pr view --json number --jq '.number'", {
+            encoding: "utf8",
+            stdio: "pipe",
+        })
+        return parseInt(output.trim(), 10)
+    } catch {
+        throw new Error(
+            "No PR found for current branch. Make sure you're on a branch with an open PR."
+        )
+    }
+}
+
+async function fetchPrComments(prNumber: number): Promise<PrComment[]> {
+    try {
+        const output = execSync(
+            `gh api repos/:owner/:repo/pulls/${prNumber}/comments`,
+            {
+                encoding: "utf8",
+                stdio: "pipe",
+            }
+        )
+
+        const allComments = JSON.parse(output)
+
+        // Filter to only user comments and extract the required fields
+        const userComments: PrComment[] = allComments
+            .filter((comment: any) => comment.user.type === "User")
+            .map((comment: any) => ({
+                body: comment.body,
+                user: comment.user.login,
+                path: comment.path,
+                created_at: comment.created_at,
+                diff_hunk: comment.diff_hunk,
+                line: comment.line,
+                start_line: comment.start_line,
+            }))
+
+        return userComments
+    } catch (error) {
+        throw new Error(`Failed to fetch PR comments: ${error}`)
+    }
+}
+
+async function createPrFeedbackDirectory(): Promise<string> {
+    const feedbackDir = path.join(process.cwd(), "pr-feedback")
+
+    // Remove existing directory if it exists
+    if (await fs.pathExists(feedbackDir)) {
+        await fs.remove(feedbackDir)
+    }
+
+    // Create fresh directory
+    await fs.ensureDir(feedbackDir)
+
+    return feedbackDir
+}
+
+async function writeCommentFiles(
+    comments: PrComment[],
+    feedbackDir: string
+): Promise<string[]> {
+    const filenames: string[] = []
+
+    for (let i = 0; i < comments.length; i++) {
+        const filename = `comment-${i + 1}.yml`
+        const filepath = path.join(feedbackDir, filename)
+
+        // Create YAML with proper formatting similar to yq output
+        const yamlContent = yamlStringify(comments[i], {
+            defaultStringType: "PLAIN",
+            defaultKeyType: null,
+            blockQuote: "literal",
+            lineWidth: 0,
+        })
+
+        await fs.writeFile(filepath, yamlContent)
+        filenames.push(filename)
+    }
+
+    return filenames
+}
+
+async function createReadmeWithTaskList(
+    filenames: string[],
+    feedbackDir: string
+): Promise<void> {
+    const readmePath = path.join(feedbackDir, "README.md")
+
+    let content = "# PR Feedback Tasks\n\n"
+    content +=
+        "This directory contains individual PR comments that need to be addressed.\n\n"
+    content += "## Task List\n\n"
+
+    for (const filename of filenames) {
+        content += `- [ ] Review and address feedback in \`${filename}\`\n`
+    }
+
+    if (filenames.length === 0) {
+        content += "No PR comments found.\n"
+    }
+
+    await fs.writeFile(readmePath, content)
+}
+
+async function main(): Promise<void> {
+    try {
+        console.log("==> Getting PR comments for current branch")
+
+        const prNumber = await getCurrentBranchPrNumber()
+        console.log(`Found PR #${prNumber}`)
+
+        const comments = await fetchPrComments(prNumber)
+        console.log(`Found ${comments.length} user comments`)
+
+        const feedbackDir = await createPrFeedbackDirectory()
+        console.log(`Created feedback directory: ${feedbackDir}`)
+
+        const filenames = await writeCommentFiles(comments, feedbackDir)
+        console.log(`Created ${filenames.length} comment files`)
+
+        await createReadmeWithTaskList(filenames, feedbackDir)
+        console.log("Created README.md with task list")
+
+        console.log(
+            "\nPR feedback has been organized in the pr-feedback/ directory"
+        )
+    } catch (error) {
+        console.error(
+            "ERROR:",
+            error instanceof Error ? error.message : String(error)
+        )
+        process.exit(1)
+    }
+}
+
+if (require.main === module) {
+    await main()
+}

--- a/docs/agent-guidelines/pr-plan-template.md
+++ b/docs/agent-guidelines/pr-plan-template.md
@@ -1,0 +1,21 @@
+# PR project report
+
+This document is the central place to store all information on the PR that is currently being worked on. Use it to track tasks and store information about the project.
+
+## Goal of this PR
+
+TODO for the human user: tell the agent what to do here - feel free to ramble but try to make sure to add all the relevant context.
+
+Github issue url:
+
+## Tasks
+
+Prefer keeping tasks here in this section in this file as markdown tasks rather than keeping your own task list in memory. Tick tasks here once they are done but feel free to add new tasks as they arise.
+
+- [ ]
+
+## Development notes
+
+Update this section with bullet points whenever things happen that didn't go according to plan. This list will be used at the end when creating the PR description of the completed work to document approaches that were tried and failed. Note also alternative approaches that
+
+-

--- a/docs/agent-guidelines/pr-plan-template.md
+++ b/docs/agent-guidelines/pr-plan-template.md
@@ -1,21 +1,24 @@
 # PR project report
 
-This document is the central place to store all information on the PR that is currently being worked on. Use it to track tasks and store information about the project.
+This document is the central place to store all information on the PR that is currently being worked on. Use it to track project progress and store information about the project.
 
 ## Goal of this PR
 
 TODO for the human user: tell the agent what to do here - feel free to ramble but try to make sure to add all the relevant context.
 
-Github issue url:
+Github issue url: TODO for the human user.
 
-## Tasks
+## Project progress
 
-Prefer keeping tasks here in this section in this file as markdown tasks rather than keeping your own task list in memory. Tick tasks here once they are done but feel free to add new tasks as they arise.
+This project progress list is a high-level enumeration of the pieces of work that together form this project. If the project is trivial and consists of only a few changes to a single file, remove this section. If the project is bigger, edit this file regularly to keep track of your progress. As a rough guideline, it probably makes sense to create a commit after completing each high level step here. Use your own task list for keeping track of the smaller todo items as you work on one of this list at a time.
 
-- [ ]
+Below is an example list of high level phases for a project to add a feature to keep track of physical addresses for each user. Remove this section and replace it by a list that works for the project you are currently working on:
+
+- [ ] Research existing code base.
+- [ ] Create database migration to add new addresses table and add database access functions and type defintions
+- [ ] Add address section to user details view in admin
+- [ ] Add tests for database access functions to dbtest setup
 
 ## Development notes
 
-Update this section with bullet points whenever things happen that didn't go according to plan. This list will be used at the end when creating the PR description of the completed work to document approaches that were tried and failed. Note also alternative approaches that
-
--
+Update this section with bullet points whenever things happen that didn't go according to plan or when you encounter unexpected things in the codebase that create potential edge-cases for the feature you are working on. This list will be used at the end when creating the PR description of the completed work to document approaches that were tried and failed. Note also alternative approaches that were tried but didn't succeed.

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
         "syncCloudflareImages": "tsx --tsconfig tsconfig.tsx.json devTools/cloudflareImagesSync/cloudflareImagesSync.ts",
         "reconstructPostsGdocsComponents": "tsx --tsconfig tsconfig.tsx.json devTools/reconstructPostsGdocsComponents/reconstructPostsGdocsComponents.ts",
         "query": "tsx --tsconfig tsconfig.tsx.json devTools/db-ai-helpers/query.ts",
-        "addIncomingForeignKeys": "tsx --tsconfig tsconfig.tsx.json devTools/db-ai-helpers/addIncomingForeignKeys.ts"
+        "addIncomingForeignKeys": "tsx --tsconfig tsconfig.tsx.json devTools/db-ai-helpers/addIncomingForeignKeys.ts",
+        "prComments": "tsx --tsconfig tsconfig.tsx.json devTools/prComments.ts"
     },
     "dependencies": {
         "@algolia/autocomplete-js": "^1.19.2",


### PR DESCRIPTION
Adds two claude agents, one for reviewing all work on a PR and one to create a PR on github.

Also adds a `make worktree` command to create and initialize a an alternate git worktree working copy of the repo at a new branch