### PR TITLE
🐛 fix whitespace in gdocs

### DIFF
--- a/db/migration/1755709232592-RemoveTabsFromGdocContent.ts
+++ b/db/migration/1755709232592-RemoveTabsFromGdocContent.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class RemoveTabsFromGdocContent1755709232592
+    implements MigrationInterface
+{
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`-- sql
+            UPDATE posts_gdocs
+            SET content = REPLACE(content, '\\\\u000b', ' ')
+            WHERE content LIKE '%\\\\u000b%'
+        `)
+    }
+
+    public async down(_: QueryRunner): Promise<void> {
+        // no-op
+    }
+}


### PR DESCRIPTION
## Context
Resolves https://github.com/owid/owid-grapher/issues/5082

## Screenshots / Videos / Diagrams

Fixes an issue with line tabulation characters making it into our JSON and rendering on mobile and prevents such characters from getting published again

<img width="265" height="159" alt="image" src="https://github.com/user-attachments/assets/9532a253-f845-4b78-8bda-62dafbe86701" />

## Testing guidance

[You can use this gdoc](https://docs.google.com/document/d/19Qkw0KWlNFziB4t-ePazy-7If1PQaCfbiA-aUtakHJo/edit)

Confirm a vertical tab is present via `View` > `Show non-printing characters`

<img width="269" height="43" alt="image" src="https://github.com/user-attachments/assets/d7a9bc17-b1b3-4e46-a7fe-f79230e84c82" />

Preview the article and confirm there's an error:
<img width="689" height="73" alt="image" src="https://github.com/user-attachments/assets/705fe548-9383-486c-8c72-1c1dc63afd6c" />

Confirm that the suggested RegEx will catch the offending character:
<img width="523" height="278" alt="image" src="https://github.com/user-attachments/assets/fdf4c422-0d57-4785-adee-46d14676ed1a" />

Replace it and confirm that there's no error

Check other articles and make sure they can be (re)published as expected.