### PR TITLE
🐛 Fix chart references tab to include chart redirects

### DIFF
--- a/adminSiteServer/apiRoutes/charts.ts
+++ b/adminSiteServer/apiRoutes/charts.ts
@@ -102,22 +102,23 @@ export const getReferencesByChartId = async (
             FROM charts c
             JOIN chart_configs cc ON c.configId = cc.id
             WHERE c.id = ?
-            
+
             UNION ALL
-            
+
             SELECT cr.slug as main_slug, c.id as chart_id
             FROM charts c
             JOIN chart_slug_redirects cr ON cr.chart_id = c.id
             WHERE c.id = ?
         ),
         gdoc_grapher_slugs AS (
-            SELECT 
+            SELECT
                 pg.id,
                 pg.content ->> '$.title' AS title,
                 pg.published,
                 pg.content ->> '$."narrative-chart"' AS narrativeChart,
                 pg.content ->> '$."figma-url"' AS figmaUrl,
                 SUBSTRING_INDEX(SUBSTRING_INDEX(pg.content ->> '$."grapher-url"', '/grapher/', -1), '\\?', 1) AS extracted_slug,
+                -- prepare for a join on the images table by filename (only works for data insights where the image block comes first)
                 COALESCE(pg.content ->> '$.body[0].smallFilename', pg.content ->> '$.body[0].filename') AS image_filename
             FROM posts_gdocs pg
             WHERE pg.type = 'data-insight'


### PR DESCRIPTION
## Summary

I recently added a references and narrative charts column to our charts table in the admin. Bertha then asked why some charts (like [this one](https://admin.owid.io/admin/charts/166/edit)) show with a ref count of 1 in the table but 0 in the side panel. It turns out that the page for [Child Labor](https://admin.owid.io/admin/gdocs/1049NVx1QWUKDro4Ztuu3L8hGMw7GyHtv5EZFpPp2uzg/preview) references this chart but with the british spelling which only exists as a chart slug redirect. The query for the table takes this into account correctly, but the code for the individual chart didn't. This PR fixes this.

- Fixed discrepancy between admin table and references tab chart reference counts
- References tab now properly includes references via chart slug redirects  
- Refactored reference queries for better performance and readability

🤖 Generated with [Claude Code](https://claude.ai/code)