### PR TITLE
poc: sort all autocomplete items by fuzzy score

### DIFF
--- a/site/search/Autocomplete.scss
+++ b/site/search/Autocomplete.scss
@@ -231,13 +231,10 @@ section[data-autocomplete-source-id="recentSearchesPlugin"] {
     width: 100%; // for ellispses on the query to work
 }
 
-section[data-autocomplete-source-id="filters"] {
+section[data-autocomplete-source-id="unified"] {
     .search-filter-pill {
         flex-shrink: 0;
     }
-}
-
-section[data-autocomplete-source-id="autocomplete"] {
     .autocomplete-item-contents__contentType {
         margin-left: 8px;
         color: $blue-50;

--- a/site/search/searchTypes.ts
+++ b/site/search/searchTypes.ts
@@ -227,6 +227,14 @@ export enum SearchResultType {
 export type Filter = {
     type: FilterType
     name: string
+    score?: number
+}
+
+export enum AutocompleteSourceId {
+    FILTERS = "filters",
+    ALGOLIA = "algolia",
+    FEATURED_SEARCH = "suggestedSearch",
+    UNIFIED = "unified",
 }
 
 export enum SearchUrlParam {


### PR DESCRIPTION

## Context

See https://github.com/owid/owid-grapher/issues/5088#issuecomment-3214232606 for context about what was tried here, and why this is remaining at the stage of a PoC.

## Other limitations

- synonyms are not supported when running Algolia items through fuzzy search, so they will be systematically demoted)
- code is not production ready (Algolia types are only partially available)


## Screenshots / Videos / Diagrams

![Screenshot 2025-08-22 at 11.25.29.png](https://app.graphite.dev/user-attachments/assets/fd95ac5b-29bb-439d-8a11-023aac1ad704.png)

## Testing guidance

- [ ] Does the staging experience have sign-off from product stakeholders?


## Checklist

### Before merging

- [ ] Google Analytics events were adapted to fit the changes in this PR
- [ ] Changes to CSS/HTML were checked on Desktop and Mobile Safari at all three breakpoints
- [ ] Changes to HTML were checked for accessibility concerns
