### PR TITLE
Fix tooltip sparkline axis default min handling

### DIFF
--- a/packages/@ourworldindata/grapher/src/mapCharts/MapSparkline.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapSparkline.tsx
@@ -134,13 +134,17 @@ export class MapSparkline extends React.Component<MapSparklineProps> {
                     unit: yAxisUnit,
                     numberAbbreviation: "short",
                 },
-                // Copy min/max from top-level Grapher config if Y column == Map column
-                min: this.manager.mapAndYColumnAreTheSame
-                    ? this.manager.yAxisConfig?.min
-                    : undefined,
-                max: this.manager.mapAndYColumnAreTheSame
-                    ? this.manager.yAxisConfig?.max
-                    : undefined,
+                // Copy min/max from top-level Grapher config if Y column == Map column.
+                // Important: do not set min/max to undefined, otherwise we override
+                // LineChart's default of min: 0 with an explicit undefined.
+                ...(this.manager.mapAndYColumnAreTheSame &&
+                this.manager.yAxisConfig?.min !== undefined
+                    ? { min: this.manager.yAxisConfig.min }
+                    : {}),
+                ...(this.manager.mapAndYColumnAreTheSame &&
+                this.manager.yAxisConfig?.max !== undefined
+                    ? { max: this.manager.yAxisConfig.max }
+                    : {}),
                 ticks: [
                     // Show minimum and zero (maximum is added by hand in render so it's never omitted)
                     { value: -Infinity, priority: 2 },


### PR DESCRIPTION
Problem: The map tooltip sparkline overrode the LineChart default yAxis.min = 0 by passing min: undefined, causing the domain to start at the data min rather than zero.

Fix: Only include min/max in the sparkline yAxisConfig when explicitly defined on the parent and when the map and Y columns are the same; otherwise omit them so LineChart applies its default min: 0.

Fixes #5284