### PR TITLE
:bug: Make deploy queue polling sync

### DIFF
--- a/baker/DeployUtils.ts
+++ b/baker/DeployUtils.ts
@@ -160,9 +160,6 @@ const getSlackMentionByEmail = _.memoize(
     }
 )
 
-/** Whether a deploy is currently running */
-let deploying = false
-
 /**
  * Initiate deploy if no other deploy is currently pending, and there are changes
  * in the queue.
@@ -173,9 +170,6 @@ let deploying = false
 export const deployIfQueueIsNotEmpty = async (
     knex: KnexReadonlyTransaction
 ) => {
-    if (deploying) return
-    deploying = true
-
     if (!(await deployQueueServer.queueIsEmpty())) {
         const deployContent =
             await deployQueueServer.readQueuedAndPendingFiles()
@@ -209,7 +203,6 @@ export const deployIfQueueIsNotEmpty = async (
         )
         await deployQueueServer.deletePendingFile()
     }
-    deploying = false
 }
 
 const isLightningChange = (item: DeployChange) => item.slug

--- a/baker/startDeployQueueServer.ts
+++ b/baker/startDeployQueueServer.ts
@@ -26,25 +26,15 @@ const main = async () => {
         process.exit(1)
     }
 
-    console.log(`Watching for changes to: ${DEPLOY_QUEUE_FILE_PATH}`)
-
-    // Watch for file changes and run deploy function when file is modified
-    fs.watchFile(DEPLOY_QUEUE_FILE_PATH, async () => {
+    // Poll for changes every 5 seconds
+    while (true) {
         try {
-            console.log(
-                "Deploy queue file changed, checking for deployments..."
-            )
             await runDeployIfQueueIsNotEmpty()
         } catch (error) {
             await logErrorAndMaybeCaptureInSentry(error)
+            throw error
         }
-    })
-
-    // Run once at startup
-    try {
-        await runDeployIfQueueIsNotEmpty()
-    } catch (error) {
-        await logErrorAndMaybeCaptureInSentry(error)
+        await new Promise((resolve) => setTimeout(resolve, 5 * 1000))
     }
 }
 


### PR DESCRIPTION
Run `runDeployIfQueueIsNotEmpty` every 5 seconds instead of watching `.queue` file. This simplifies it a bit and avoids situations with empty `.queue` file, but non-empty `.pending` file.