### PR TITLE
🐛 fix resource panel with many small paragraphs

### DIFF
--- a/site/css/grid.scss
+++ b/site/css/grid.scss
@@ -29,7 +29,7 @@ $grid-max-colums: 14;
 $grid-col-spans: (2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14);
 $grid-col-start: (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14);
 $grid-col-end: (2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14);
-$grid-row-spans: (1, 2, 3);
+$grid-row-spans: (1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
 
 // Remapping our breakpoint variables that we prefix with $ so that we can use them in class names
 // e.g. .grid-sm-cols-12
@@ -97,7 +97,7 @@ $grid-responsive: (lg, md, sm);
 // Spans Rows
 @each $span in $grid-row-spans {
     .span-rows-#{$span} {
-        grid-row: span #{$span} / span #{$span};
+        grid-row: span #{$span};
     }
 }
 

--- a/site/gdocs/components/layout.ts
+++ b/site/gdocs/components/layout.ts
@@ -55,7 +55,7 @@ const layouts: { [key in Container]: Layouts} = {
         ["pull-quote--left-center"]: "col-start-5 span-cols-6 col-md-start-3 span-md-cols-10 span-sm-cols-12 col-sm-start-2",
         ["pull-quote--right-center"]: "col-start-5 span-cols-6 col-md-start-3 span-md-cols-10 span-sm-cols-12 col-sm-start-2",
         ["pull-quote--right"]: "span-cols-14 grid grid-cols-12-full-width",
-        ["resource-panel"]: "col-start-11 span-cols-3 span-rows-3 col-md-start-3 span-md-cols-10 span-sm-cols-12 col-sm-start-2",
+        ["resource-panel"]: "col-start-11 span-cols-3 span-rows-10 col-md-start-3 span-md-cols-10 span-sm-cols-12 col-sm-start-2",
         ["recirc--left"]: "col-start-2 span-cols-3 span-rows-3 col-md-start-3 span-md-cols-10 span-sm-cols-12 col-sm-start-2",
         ["recirc--center"]: "col-start-5 span-cols-6 col-md-start-3 span-md-cols-10 span-sm-cols-12 col-sm-start-2",
         ["recirc--right"]: "col-start-11 span-cols-3 span-rows-3 col-md-start-3 span-md-cols-10 span-sm-cols-12 col-sm-start-2",


### PR DESCRIPTION
| Before | After |
|--------|--------|
| <img width="1047" height="707" alt="image" src="https://github.com/user-attachments/assets/a0566558-4ef2-42e2-8abc-43f28ad96362" /> | <img width="1047" height="707" alt="image" src="https://github.com/user-attachments/assets/103a862b-a0bd-4741-8b3b-5ca3dd81d1cc" /> | 