### PR TITLE
🐛 hide variable name in slope tooltips

### DIFF
--- a/packages/@ourworldindata/grapher/src/mapCharts/MapTooltip.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapTooltip.tsx
@@ -208,6 +208,7 @@ export class MapTooltip
                     value={valueLabel}
                     color={valueColor}
                     isProjection={isProjection}
+                    labelVariant="unit-only"
                     showSignificanceSuperscript={
                         !!roundingNotice &&
                         roundingNotice.icon !== TooltipFooterIcon.none

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
@@ -818,7 +818,11 @@ export class SlopeChart
                 footer={footer}
                 dismiss={() => (this.tooltipState.target = null)}
             >
-                <TooltipValueRange column={this.formatColumn} values={values} />
+                <TooltipValueRange
+                    column={series.column}
+                    values={values}
+                    labelVariant="unit-only"
+                />
             </Tooltip>
         )
     }

--- a/packages/@ourworldindata/grapher/src/tooltip/Tooltip.scss
+++ b/packages/@ourworldindata/grapher/src/tooltip/Tooltip.scss
@@ -185,6 +185,36 @@
                             color: $grey;
                         }
                     }
+
+                    // Hide the variable name and use just the unit (if present) as a label
+                    &.variable--no-name .definition {
+                        .name {
+                            display: none;
+                        }
+
+                        // Remove parentheses around unit
+                        .unit {
+                            &::after,
+                            &::before {
+                                content: none;
+                            }
+                        }
+
+                        &:not(:has(.unit)) .projection {
+                            display: inline-block; // Required for ::first-letter pseudo-element to work
+
+                            // Capitalize only the first letter of the projection text
+                            &::first-letter {
+                                text-transform: uppercase;
+                            }
+
+                            // Remove parentheses around unit
+                            &::after,
+                            &::before {
+                                content: none;
+                            }
+                        }
+                    }
                 }
 
                 .variable + .variable {
@@ -447,42 +477,6 @@
                 transition: opacity $fade-time $fade-delay;
                 &.immediate {
                     transition: opacity $fade-time;
-                }
-            }
-
-            //
-            // ‘TEMPORARY’ FIX:
-            // Until the map variable displayNames can be copy-edited, hide the variable name entirely
-            // and use just the unit (if present) as a label
-            //
-            &#mapTooltip {
-                .variable .definition {
-                    .name {
-                        display: none;
-                    }
-
-                    .unit {
-                        &::after,
-                        &::before {
-                            content: none;
-                        }
-                    }
-
-                    &:not(:has(.unit)) .projection {
-                        display: inline-block; // to make ::first-letter work
-
-                        // 'text:transform: capitalize' capitalizes the first
-                        // letter of each word. that's why we're only uppercasing
-                        // the first letter instead
-                        &::first-letter {
-                            text-transform: uppercase;
-                        }
-
-                        &::after,
-                        &::before {
-                            content: none;
-                        }
-                    }
                 }
             }
         }

--- a/packages/@ourworldindata/grapher/src/tooltip/TooltipContents.tsx
+++ b/packages/@ourworldindata/grapher/src/tooltip/TooltipContents.tsx
@@ -23,6 +23,7 @@ export function TooltipValue({
     color,
     notice,
     isProjection,
+    labelVariant = "name+unit",
     showSignificanceSuperscript,
 }: TooltipValueProps): React.ReactElement | null {
     const displayValue = _.isNumber(value)
@@ -41,6 +42,7 @@ export function TooltipValue({
             color={displayColor}
             isProjection={isProjection}
             notice={notice ? [notice] : undefined}
+            labelVariant={labelVariant}
         >
             <span>
                 {displayValue}
@@ -73,6 +75,7 @@ export function TooltipValueRange({
     values,
     color,
     notice,
+    labelVariant = "name+unit",
     showSignificanceSuperscript,
 }: TooltipValueRangeProps): React.ReactElement | null {
     const [firstValue, lastValue] = values.map((v) =>
@@ -99,7 +102,12 @@ export function TooltipValueRange({
     const superscript = showSuperscript ? <IconCircledS asSup={true} /> : null
 
     return values.length ? (
-        <Variable column={column} color={color} notice={notice}>
+        <Variable
+            column={column}
+            color={color}
+            notice={notice}
+            labelVariant={labelVariant}
+        >
             <span className="range">
                 <span className="term">
                     {firstTerm}
@@ -123,16 +131,18 @@ function Variable({
     color,
     notice,
     isProjection,
+    labelVariant = "name+unit",
 }: {
     column: CoreColumn
     color?: string
     isProjection?: boolean
     notice?: (number | string | undefined)[]
+    labelVariant?: "name+unit" | "unit-only"
     children?: React.ReactNode
 }): React.ReactElement | null {
     if (column.isMissing || column.name === "time") return null
 
-    const { mainLabel: label, unit } = makeAxisLabel({
+    const { mainLabel: columnName, unit } = makeAxisLabel({
         label: column.displayName,
         unit: column.unit,
         shortUnit: column.shortUnit,
@@ -146,9 +156,13 @@ function Variable({
             .join("\u2013") || null
 
     return (
-        <div className="variable">
+        <div
+            className={classnames("variable", {
+                "variable--no-name": labelVariant === "unit-only",
+            })}
+        >
             <div className="definition">
-                {label && <span className="name">{label}</span>}
+                {columnName && <span className="name">{columnName}</span>}
                 {unit && unit.length > 1 && (
                     <span className="unit">{unit}</span>
                 )}

--- a/packages/@ourworldindata/grapher/src/tooltip/TooltipProps.ts
+++ b/packages/@ourworldindata/grapher/src/tooltip/TooltipProps.ts
@@ -46,6 +46,7 @@ export interface TooltipValueProps {
     isProjection?: boolean
     notice?: number | string // actual year data was drawn from (when ≠ target year)
     showSignificanceSuperscript?: boolean // show significance-s superscript if applicable
+    labelVariant?: "name+unit" | "unit-only"
 }
 
 export interface TooltipValueRangeProps {
@@ -54,6 +55,7 @@ export interface TooltipValueRangeProps {
     color?: string
     notice?: (number | string | undefined)[] // actual year data was drawn from (when ≠ target year)
     showSignificanceSuperscript?: boolean // show significance-s superscript if applicable
+    labelVariant?: "name+unit" | "unit-only"
 }
 
 export interface TooltipTableProps {


### PR DESCRIPTION
Hides the display name in slope tooltips.