### PR TITLE
🐛 fix explorer view configs

### DIFF
--- a/db/model/ExplorerViews.ts
+++ b/db/model/ExplorerViews.ts
@@ -195,7 +195,7 @@ async function iterateExplorerViews(
             await explorer.updateGrapherFromExplorer()
 
             // Extract the generated config from the explorer's grapher state
-            const config = explorer.grapherState.toObject(false)
+            const config = explorer.grapherState.toObject()
 
             // Grapher uses an internal fallback chain for some important properties.
             // For explorer views we want to have a config that materializes as much

--- a/packages/@ourworldindata/core-table/src/CoreTable.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTable.ts
@@ -53,7 +53,7 @@ import {
     isNotErrorValue,
     DroppedForTesting,
 } from "./ErrorValues.js"
-import { applyTransforms, extractTransformNameAndParams } from "./Transforms.js"
+import { applyTransforms, parseTransformString } from "./Transforms.js"
 
 interface AdvancedOptions {
     tableDescription?: string
@@ -99,10 +99,10 @@ export class CoreTable<
         // Column definitions with a "duplicate" transform are merged with the column definition of the specified source column
         this.inputColumnDefs = this.inputColumnDefs.map((def) => {
             if (!def.transform) return def
-            const transform = extractTransformNameAndParams(def.transform)
+            const transform = parseTransformString(def.transform)
             if (transform?.transformName !== "duplicate") return def
 
-            const sourceSlug = transform.params[0]
+            const sourceSlug = transform.params[0].value
             const sourceDef = this.inputColumnDefs.find(
                 (def) => def.slug === sourceSlug
             )

--- a/packages/@ourworldindata/core-table/src/index.ts
+++ b/packages/@ourworldindata/core-table/src/index.ts
@@ -76,7 +76,7 @@ export {
 export {
     insertMissingValuePlaceholders,
     computeRollingAverage,
-    AvailableTransforms,
+    availableTransformNames,
     applyTransforms,
-    extractPotentialDataSlugsFromTransform,
+    parseTransformString,
 } from "./Transforms.js"

--- a/packages/@ourworldindata/explorer/src/ColumnGrammar.ts
+++ b/packages/@ourworldindata/explorer/src/ColumnGrammar.ts
@@ -1,4 +1,4 @@
-import { AvailableTransforms } from "@ourworldindata/core-table"
+import { availableTransformNames } from "@ourworldindata/core-table"
 import {
     automaticBinningStrategies,
     ColorSchemeName,
@@ -38,6 +38,7 @@ export const ColumnGrammar: Grammar<ColumnCellDef> = {
         keyword: "name",
         description:
             "This is the name that may appear on the y or x axis of a chart",
+        isDisplayProperty: true,
     },
     type: {
         ...StringCellDef,
@@ -52,7 +53,7 @@ export const ColumnGrammar: Grammar<ColumnCellDef> = {
     transform: {
         ...StringCellDef,
         keyword: "transform",
-        description: `An advanced option. Available transforms are: ${AvailableTransforms.join(
+        description: `An advanced option. Available transforms are: ${availableTransformNames.join(
             ", "
         )}`,
     },
@@ -61,6 +62,7 @@ export const ColumnGrammar: Grammar<ColumnCellDef> = {
         keyword: "tolerance",
         description:
             "Set this to interpolate missing values as long as they are within this range of an actual value.",
+        isDisplayProperty: true,
     },
     toleranceStrategy: {
         ...EnumCellDef,
@@ -76,16 +78,19 @@ export const ColumnGrammar: Grammar<ColumnCellDef> = {
         ...StringCellDef,
         keyword: "description",
         description: "Describe the column",
+        isDisplayProperty: true,
     },
     unit: {
         ...StringCellDef,
         keyword: "unit",
         description: "Unit of measurement",
+        isDisplayProperty: true,
     },
     shortUnit: {
         ...StringCellDef,
         keyword: "shortUnit",
         description: "Short (axis) unit",
+        isDisplayProperty: true,
     },
     notes: {
         ...StringCellDef,
@@ -142,6 +147,7 @@ export const ColumnGrammar: Grammar<ColumnCellDef> = {
         ...StringCellDef,
         keyword: "color",
         description: "Default color for column",
+        isDisplayProperty: true,
     },
     colorScaleScheme: {
         ...EnumCellDef,
@@ -206,12 +212,12 @@ export const ColumnGrammar: Grammar<ColumnCellDef> = {
         ...BooleanCellDef,
         keyword: "isProjection",
         description: "Is the time series a forward projection?",
-        display: true,
+        isDisplayProperty: true,
     },
     plotMarkersOnlyInLineChart: {
         ...BooleanCellDef,
         keyword: "plotMarkersOnlyInLineChart",
         description: "Should data points be connected by a line?",
-        display: true,
+        isDisplayProperty: true,
     },
 } as const

--- a/packages/@ourworldindata/explorer/src/Explorer.sample.ts
+++ b/packages/@ourworldindata/explorer/src/Explorer.sample.ts
@@ -160,3 +160,30 @@ export const SampleInlineDataExplorer = (props?: Partial<ExplorerProps>) => {
         ...props,
     })
 }
+
+export const SampleIndicatorBasedExplorerProgram = `explorerTitle	Sample Explorer
+selection	World
+
+graphers
+	Test Radio	yVariableIds	ySlugs
+	Indicator id based	952182
+	Slug based		duplicated
+
+columns
+	slug	variableId	transform	unit	shortUnit	name
+		952182			tons	Variable name
+	duplicated		duplicate 952182	people		Overwritten name`
+
+export const SampleIndicatorBasedExplorer = (
+    props?: Partial<ExplorerProps>
+) => {
+    return new Explorer({
+        slug: "test-slug-indicator-based",
+        program: SampleIndicatorBasedExplorerProgram,
+        adminBaseUrl: "",
+        bakedBaseUrl: "",
+        bakedGrapherUrl: "",
+        dataApiUrl: "",
+        ...props,
+    })
+}

--- a/packages/@ourworldindata/explorer/src/Explorer.test.ts
+++ b/packages/@ourworldindata/explorer/src/Explorer.test.ts
@@ -3,6 +3,7 @@ import { expect, it, describe } from "vitest"
 import { Explorer } from "./Explorer.js"
 import {
     SampleExplorerOfGraphers,
+    SampleIndicatorBasedExplorer,
     SampleInlineDataExplorer,
 } from "./Explorer.sample.js"
 
@@ -72,5 +73,33 @@ describe("inline data explorer", () => {
         expect(explorer.grapherState?.ySlugs).toEqual("y")
         expect(explorer.grapherState?.colorSlug).toEqual(undefined)
         expect(explorer.grapherState?.sizeSlug).toEqual(undefined)
+    })
+})
+
+describe("indicator-based explorer", () => {
+    it("adds variable ids to the dimensions array", async () => {
+        const explorer = SampleIndicatorBasedExplorer()
+        await explorer.onChangeChoice("Test")("Indicator id based")
+        expect(explorer.grapherState.yColumnSlugs).toEqual(["952182"])
+        expect(explorer.grapherState.object.dimensions).toEqual([
+            {
+                property: "y",
+                variableId: 952182,
+                display: { name: "Variable name", shortUnit: "tons" },
+            },
+        ])
+    })
+
+    it("adds variable ids to the dimensions array for transformed columns", async () => {
+        const explorer = SampleIndicatorBasedExplorer()
+        await explorer.onChangeChoice("Test")("Slug based")
+        expect(explorer.grapherState.yColumnSlugs).toEqual(["duplicated"])
+        expect(explorer.grapherState.object.dimensions).toEqual([
+            {
+                property: "y",
+                variableId: 952182,
+                display: { name: "Overwritten name", unit: "people" },
+            },
+        ])
     })
 })

--- a/packages/@ourworldindata/explorer/src/ExplorerProgram.test.ts
+++ b/packages/@ourworldindata/explorer/src/ExplorerProgram.test.ts
@@ -9,6 +9,7 @@ import {
 import { ExplorerGrammar } from "./ExplorerGrammar.js"
 import { GrapherGrammar } from "./GrapherGrammar.js"
 import { DecisionMatrix } from "./ExplorerDecisionMatrix.js"
+import { SampleIndicatorBasedExplorerProgram } from "./Explorer.sample.js"
 
 const grapherIdKeyword = GrapherGrammar.grapherId.keyword
 const tableSlugKeyword = GrapherGrammar.tableSlug.keyword
@@ -75,8 +76,8 @@ columns\ttable1\ttable2\ttable3
             "table3",
         ])
 
-        const columnDef1 = [{ slug: "gdp", name: "GDP" }]
-        const columnDef2 = [{ slug: "banana", name: "Bananas" }]
+        const columnDef1 = [{ slug: "gdp", display: { name: "GDP" } }]
+        const columnDef2 = [{ slug: "banana", display: { name: "Bananas" } }]
 
         expect(program.columnDefsByTableSlug.get(undefined)).toEqual(columnDef1)
         expect(program.columnDefsByTableSlug.get("table1")).toEqual(columnDef2)
@@ -161,6 +162,34 @@ graphers
             expect(program.explorerGrapherConfig.yAxisMin).toEqual(1)
             expect(program.grapherConfig.yAxis?.min).toEqual(1)
         })
+    })
+
+    it("gets dimensions of the selected row", () => {
+        const program = new ExplorerProgram(
+            "test",
+            SampleIndicatorBasedExplorerProgram
+        )
+
+        expect(program.dimensionsOfSelectedRow).toStrictEqual([
+            {
+                display: { name: "Variable name", shortUnit: "tons" },
+                property: "y",
+                type: "variableId",
+                variableId: 952182,
+            },
+        ])
+
+        // Change to a different row
+        program.decisionMatrix.setValueCommand("Test", "Slug based")
+
+        expect(program.dimensionsOfSelectedRow).toStrictEqual([
+            {
+                display: { name: "Overwritten name", unit: "people" },
+                property: "y",
+                slug: "duplicated",
+                type: "slug",
+            },
+        ])
     })
 
     it("can power a grapher", () => {

--- a/packages/@ourworldindata/explorer/src/gridLang/GridLangConstants.ts
+++ b/packages/@ourworldindata/explorer/src/gridLang/GridLangConstants.ts
@@ -39,7 +39,7 @@ export interface GrapherCellDef extends CellDef {
 }
 
 export interface ColumnCellDef extends CellDef {
-    display?: boolean
+    isDisplayProperty?: boolean
 }
 
 export interface ParsedCell {

--- a/packages/@ourworldindata/grapher/src/chart/ChartDimension.ts
+++ b/packages/@ourworldindata/grapher/src/chart/ChartDimension.ts
@@ -14,6 +14,7 @@ import {
     OwidChartDimensionInterface,
     Time,
     OwidChartDimensionInterfaceWithMandatorySlug,
+    objectWithPersistablesToObject,
 } from "@ourworldindata/utils"
 import { OwidTable, CoreColumn } from "@ourworldindata/core-table"
 
@@ -86,17 +87,20 @@ export class ChartDimension
     }
 
     toObject(): OwidChartDimensionInterface {
-        return trimObject(
-            deleteRuntimeAndUnchangedProps(
-                {
-                    property: this.property,
-                    variableId: this.variableId,
-                    display: this.display,
-                    targetYear: this.targetYear,
-                },
-                new ChartDimensionDefaults()
-            )
+        const keysToSerialize = [
+            "variableId",
+            "property",
+            "display",
+            "targetYear",
+        ]
+        const obj: OwidChartDimensionInterface = objectWithPersistablesToObject(
+            this,
+            keysToSerialize
         )
+
+        deleteRuntimeAndUnchangedProps(obj, new ChartDimensionDefaults())
+
+        return trimObject(obj)
     }
 
     // Do not persist yet, until we migrate off VariableIds


### PR DESCRIPTION
Daniel recently added a table for explorer view configs, and for search I added a new endpoint that returns the grapher config for a specific explorer view ([example](http://staging-site-search-tpl/explorers/conflict-data.config.json?Conflict+type=Intrastate+conflicts&Measure=Conflict+deaths&Conflict+sub-type=All+sub-types&Data+source=Uppsala+Conflict+Data+Program&Sub-measure=Country+and+regional+data)). Both spin up an Explorer, pick a specific view, then serialise the grapher state with `grapherState.toObject()`.

The tricky part is that explorers only partially rely on that config. So when those exported configs are used to render a chart, there are visible differences compared to the explorer itself. Here’s what I noticed:
- Columns defined by a duplicate transform are added to the dimensions array as a `table` property, which means they’re not used as chart dimensions
- Color scale properties aren’t serialised because they’re set directly on the column def
- Display properties also aren’t serialised for the same reason

This PR kind of snowballed into a refactor of the code handling of indicator-based explorers. I dropped support for two explorer features to make the code a bit simpler:
- Multi-step transforms for indicator-based explorers (not used anywhere)
- The `where` transform (dropped for convenience, see my code comments below)

I would have wanted to do a bit more testing before I open this up for review and there are still a few things I'd want to improve and/or double-check, but I still think it's useful to hand this over to you before my holiday. 

One thing that I might want to rewrite is how the display properties are handled. I think it might be nicer to drop the special handling via `isDisplayProperty` and just serialise whatever is set on the column defs, similar to how it’s done for the color scales. 

The easiest way to test is to go into the console and look at `grapherState.object`.

To do:
- [x] Broken: http://staging-site-fix-explorer-dimension-prope/explorers/conflict-data-source?Data+source=Uppsala+Conflict+Data+Program&Conflict+type=Extrastate+conflicts&Measure=Conflict+deaths&Conflict+sub-type=&Sub-measure=Country+and+region+data