### PR TITLE
:sparkles: Update lastEditedAt if tags are updated

### DIFF
--- a/adminSiteServer/apiRoutes/charts.ts
+++ b/adminSiteServer/apiRoutes/charts.ts
@@ -733,7 +733,7 @@ export async function setChartTagsHandler(
 ) {
     const chartId = expectInt(req.params.chartId)
 
-    await setChartTags(trx, chartId, req.body.tags)
+    await setChartTags(trx, chartId, req.body.tags, res.locals.user.id)
 
     return { success: true }
 }

--- a/db/model/Chart.ts
+++ b/db/model/Chart.ts
@@ -389,8 +389,9 @@ export async function setChartTags(
     const isIndexable = tags.some((t) => t.name === "Unlisted")
         ? false
         : parentIds.some((t) => PUBLIC_TAG_PARENT_IDS.includes(t.parentId))
-    await db.knexRaw(knex, "update charts set isIndexable = ? where id = ?", [
+    await db.knexRaw(knex, "update charts set isIndexable = ?, lastEditedAt = ? where id = ?", [
         isIndexable,
+        new Date(),
         chartId,
     ])
 }

--- a/db/model/Chart.ts
+++ b/db/model/Chart.ts
@@ -392,12 +392,12 @@ export async function setChartTags(
         : parentIds.some((t) => PUBLIC_TAG_PARENT_IDS.includes(t.parentId))
     const updateFields = ["isIndexable = ?", "lastEditedAt = ?"]
     const updateValues: (boolean | Date | number)[] = [isIndexable, new Date()]
-    
+
     if (userId) {
         updateFields.push("lastEditedByUserId = ?")
         updateValues.push(userId)
     }
-    
+
     await db.knexRaw(
         knex,
         `update charts set ${updateFields.join(", ")} where id = ?`,

--- a/db/model/Chart.ts
+++ b/db/model/Chart.ts
@@ -389,11 +389,11 @@ export async function setChartTags(
     const isIndexable = tags.some((t) => t.name === "Unlisted")
         ? false
         : parentIds.some((t) => PUBLIC_TAG_PARENT_IDS.includes(t.parentId))
-    await db.knexRaw(knex, "update charts set isIndexable = ?, lastEditedAt = ? where id = ?", [
-        isIndexable,
-        new Date(),
-        chartId,
-    ])
+    await db.knexRaw(
+        knex,
+        "update charts set isIndexable = ?, lastEditedAt = ? where id = ?",
+        [isIndexable, new Date(), chartId]
+    )
 }
 
 export async function assignTagsForCharts(


### PR DESCRIPTION
We want to start syncing charts with just tags changes in ETL's chart-diff. For that, it'd be very useful to know the time of an update. Can we bump `lastEditedAt` when we make edits to tags? It'd show up at the top of charts view in Admin. Are there any risks from doing this?