### PR TITLE
Remove country profiles from indexing and autocomplete

### DIFF
--- a/baker/algolia/configureAlgolia.ts
+++ b/baker/algolia/configureAlgolia.ts
@@ -115,7 +115,6 @@ export const configureAlgolia = async () => {
             "afterDistinct(type)",
             "afterDistinct(searchable(tags))",
             "afterDistinct(searchable(authors))",
-            "afterDistinct(documentType)",
         ],
 
         // These lines below essentially demote matches in the `content` (i.e. fulltext) field:

--- a/baker/algolia/utils/pages.ts
+++ b/baker/algolia/utils/pages.ts
@@ -3,14 +3,11 @@ import * as db from "../../../db/db.js"
 import { ALGOLIA_INDEXING } from "../../../settings/serverSettings.js"
 import { chunkParagraphs } from "../../chunk.js"
 import {
-    countries,
-    Country,
     OwidGdocType,
     type RawPageview,
     OwidGdocPostInterface,
     ARCHVED_THUMBNAIL_FILENAME,
     DEFAULT_GDOC_FEATURED_IMAGE,
-    DEFAULT_THUMBNAIL_FILENAME,
     DbEnrichedImage,
     OwidGdocDataInsightInterface,
     OwidGdocAboutInterface,
@@ -23,7 +20,6 @@ import { getAlgoliaClient } from "../configureAlgolia.js"
 import {
     PageRecord,
     SearchIndexName,
-    WordpressPageType,
 } from "../../../site/search/searchTypes.js"
 import { getAnalyticsPageviewsByUrlObj } from "../../../db/model/Pageview.js"
 import { getIndexName } from "../../../site/search/searchClient.js"
@@ -47,27 +43,6 @@ import { toPlaintext } from "./shared.js"
 const computePageScore = (record: Omit<PageRecord, "score">): number => {
     const { importance, views_7d } = record
     return importance * 1000 + views_7d
-}
-
-function generateCountryRecords(
-    countries: Country[],
-    pageviews: Record<string, RawPageview>
-): PageRecord[] {
-    return countries.map((country) => {
-        const record = {
-            objectID: country.slug,
-            type: WordpressPageType.Country,
-            importance: -1,
-            slug: `country/${country.slug}`,
-            title: country.name,
-            content: `All available indicators for ${country.name}.`,
-            views_7d: pageviews[`/country/${country.slug}`]?.views_7d ?? 0,
-            documentType: "country-page" as const,
-            thumbnailUrl: `/${DEFAULT_THUMBNAIL_FILENAME}`,
-        }
-        const score = computePageScore(record)
-        return { ...record, score }
-    })
 }
 
 const getThumbnailUrl = (
@@ -292,7 +267,6 @@ async function generateGdocRecords(
                     gdoc.updatedAt ?? gdoc.publishedAt!
                 ).toISOString(),
                 tags: [...topicTags],
-                documentType: "gdoc" as const,
                 authors: gdoc.content.authors,
                 thumbnailUrl,
             }
@@ -304,7 +278,6 @@ async function generateGdocRecords(
     return records
 }
 
-// Generate records for countries, WP posts (not including posts that have been succeeded by Gdocs equivalents), and Gdocs
 export const getPagesRecords = async (knex: db.KnexReadonlyTransaction) => {
     const pageviews = await getAnalyticsPageviewsByUrlObj(knex)
     const gdocs = (await db
@@ -320,7 +293,6 @@ export const getPagesRecords = async (knex: db.KnexReadonlyTransaction) => {
         | OwidGdocDataInsightInterface
     )[]
 
-    const countryRecords = generateCountryRecords(countries, pageviews)
     const cloudflareImagesByFilename = await db
         .getCloudflareImages(knex)
         .then((images) => _.keyBy(images, "filename"))
@@ -332,7 +304,7 @@ export const getPagesRecords = async (knex: db.KnexReadonlyTransaction) => {
         knex
     )
 
-    return [...countryRecords, ...gdocsRecords]
+    return gdocsRecords
 }
 
 async function getExistingRecordsForSlug(

--- a/site/search/Autocomplete.tsx
+++ b/site/search/Autocomplete.tsx
@@ -13,9 +13,7 @@ import algoliasearch from "algoliasearch"
 import { createLocalStorageRecentSearchesPlugin } from "@algolia/autocomplete-plugin-recent-searches"
 import {
     ChartRecordType,
-    PageType,
     SearchIndexName,
-    WordpressPageType,
     Filter,
     FilterType,
     SynonymMap,
@@ -90,12 +88,6 @@ const prependSubdirectoryToAlgoliaItemUrl = (item: BaseItem): string => {
             return urljoin(BAKED_GRAPHER_URL, item.slug as string)
         })
         .with(SearchIndexName.Pages, () => {
-            if (
-                item.type === WordpressPageType.Country ||
-                item.type === WordpressPageType.Other
-            ) {
-                return urljoin(BAKED_BASE_URL, item.slug as string)
-            }
             return getCanonicalUrl(BAKED_BASE_URL, {
                 slug: item.slug as string,
                 content: {
@@ -209,12 +201,12 @@ const AlgoliaSource: AutocompleteSource<BaseItem> = {
                     ? item.type === ChartRecordType.ExplorerView
                         ? "Explorer"
                         : "Chart"
-                    : getPageTypeNameAndIcon(item.type as PageType).name
+                    : getPageTypeNameAndIcon(item.type as OwidGdocType).name
 
             const indexIcon =
                 index === SearchIndexName.ExplorerViewsMdimViewsAndCharts
                     ? faLineChart
-                    : getPageTypeNameAndIcon(item.type as PageType).icon
+                    : getPageTypeNameAndIcon(item.type as OwidGdocType).icon
 
             return (
                 <span

--- a/site/search/searchTypes.ts
+++ b/site/search/searchTypes.ts
@@ -7,24 +7,9 @@ import {
     HitHighlightResult,
 } from "instantsearch.js/es/types/results.js"
 
-export enum WordpressPageType {
-    Other = "other",
-    Country = "country",
-}
-
-export function checkIsWordpressPageType(
-    type: string
-): type is WordpressPageType {
-    return (
-        type === WordpressPageType.Country || type === WordpressPageType.Other
-    )
-}
-
-export type PageType = OwidGdocType | WordpressPageType
-
 export interface PageRecord {
     objectID: string
-    type: PageType
+    type: OwidGdocType
     importance: number
     slug: string
     title: string
@@ -41,7 +26,6 @@ export interface PageRecord {
     // GDoc example: https://imagedelivery.net/our-id/image-uuid/w=512
     // Fallback example: https://ourworldindta.org/default-thumbnail.png
     thumbnailUrl: string
-    documentType?: "wordpress" | "gdoc" | "country-page"
 }
 
 export type IPageHit = PageRecord & Hit<BaseHit>

--- a/site/search/searchUtils.tsx
+++ b/site/search/searchUtils.tsx
@@ -51,15 +51,12 @@ import {
     SearchChartHit,
     IChartHit,
     SearchUrlParam,
-    PageType,
-    WordpressPageType,
     SynonymMap,
 } from "./searchTypes.js"
 import {
     faBook,
     faBookmark,
     faFileLines,
-    faGlobe,
     faLightbulb,
     faTag,
     IconDefinition,
@@ -1057,7 +1054,7 @@ export const getItemUrlForFilter = (filter: Filter): string => {
     return `${BAKED_BASE_URL}${SEARCH_BASE_PATH}${queryParamsToStr(queryParams)}`
 }
 
-export function getPageTypeNameAndIcon(pageType: PageType): {
+export function getPageTypeNameAndIcon(pageType: OwidGdocType): {
     name: string
     icon: IconDefinition
 } {
@@ -1075,12 +1072,7 @@ export function getPageTypeNameAndIcon(pageType: PageType): {
             name: "Topic page",
             icon: faBookmark,
         }))
-        .with(WordpressPageType.Country, () => ({
-            name: "Country",
-            icon: faGlobe,
-        }))
         .with(
-            WordpressPageType.Other,
             OwidGdocType.Author, // Should never be indexed
             OwidGdocType.Fragment, // Should never be indexed
             OwidGdocType.Homepage, // Should never be indexed


### PR DESCRIPTION
## Context

This PR eliminates country page records from the homepage/navbar autocomplete and the search index. 
It also removes the `documentType` field from Algolia search records (which would otherwise contain a single value, "gdoc")

![Screenshot 2025-08-29 at 17.36.36.png](https://app.graphite.dev/user-attachments/assets/1cd5326c-2d90-4e1b-b568-c50008c13b75.png)

## Testing guidance

1. Open the homepage
2. Search for "Ghana"
3. Only the country filter should appear

Also:

1. Go to Algolia's dashboard
2. Search for "ghana" in the pages index (staging app - indexing rerun locally with this PR's code)
3. Check that no record of type "country" is shown
4. Check that the documentType facet is not listed

👇 This should not show up

![Screenshot 2025-08-29 at 17.39.07.png](https://app.graphite.dev/user-attachments/assets/fe8170d8-8c00-4bd5-9453-85f8486a8013.png)

- [ ] Does the staging experience have sign-off from product stakeholders?
