### PR TITLE
Add sentry user, experiment tags, referrer tag

### DIFF
--- a/packages/@ourworldindata/utils/src/experiments/config.ts
+++ b/packages/@ourworldindata/utils/src/experiments/config.ts
@@ -13,7 +13,7 @@ export const experiments: Experiment[] = [
          * Treatment arm treat0: show placebo button ("Data sources and measurement") beneath grapher
          * Treatment arm treat1: show "view insights about this data" button beneath grapher
          */
-        id: "data-page-insight-buttons-basic",
+        id: "data-page-insight-btns-basic",
         expires: "2025-09-04T00:00:00.000Z",
         arms: [
             // control arm

--- a/site/CookiePreferencesManager.tsx
+++ b/site/CookiePreferencesManager.tsx
@@ -15,7 +15,11 @@ import {
     updatePreference,
 } from "./cookiePreferences.js"
 import { SiteAnalytics } from "./SiteAnalytics.js"
-import { maybeSampleSession, getSessionSampleRate } from "./SentryUtils.js"
+import {
+    maybeSampleSession,
+    getSessionSampleRate,
+    updateSentryUser,
+} from "./SentryUtils.js"
 
 const analytics = new SiteAnalytics()
 
@@ -55,6 +59,7 @@ export const CookiePreferencesManager = ({
             analytics_storage: analyticsConsent,
         })
 
+        updateSentryUser()
         const sampleRate = getSessionSampleRate()
         maybeSampleSession(sampleRate)
     }, [analyticsConsent])

--- a/site/CookiePreferencesManager.tsx
+++ b/site/CookiePreferencesManager.tsx
@@ -18,6 +18,7 @@ import { SiteAnalytics } from "./SiteAnalytics.js"
 import {
     maybeSampleSession,
     getSessionSampleRate,
+    updateSentryTags,
     updateSentryUser,
 } from "./SentryUtils.js"
 
@@ -59,6 +60,7 @@ export const CookiePreferencesManager = ({
             analytics_storage: analyticsConsent,
         })
 
+        updateSentryTags()
         updateSentryUser()
         const sampleRate = getSessionSampleRate()
         maybeSampleSession(sampleRate)

--- a/site/DataPageContent.scss
+++ b/site/DataPageContent.scss
@@ -229,14 +229,14 @@ By default when a user is NOT assigned to {armId}, blocks with "{experimentId}--
 are hidden, while blocks with "{experimentId}--{armId}--hide" are shown.
 */
 $experiments: (
-    exp-data-page-insight-buttons-basic: (
+    exp-data-page-insight-btns-basic: (
         control1,
         treat0,
         treat1,
     ),
 );
 
-$experimentId: exp-data-page-insight-buttons-basic;
+$experimentId: exp-data-page-insight-btns-basic;
 $armIds: control1, treat0, treat1;
 
 @each $exp, $arms in $experiments {
@@ -269,9 +269,9 @@ $armIds: control1, treat0, treat1;
     }
 }
 
-// styles specific to experiment exp-data-page-insight-buttons-basic
-.exp-data-page-insight-buttons-basic {
-    $arms: map-get($experiments, exp-data-page-insight-buttons-basic);
+// styles specific to experiment exp-data-page-insight-btns-basic
+.exp-data-page-insight-btns-basic {
+    $arms: map-get($experiments, exp-data-page-insight-btns-basic);
     @each $a in $arms {
         &--#{$a} .DataPageContent {
             .chart-key-info {

--- a/site/DataPageV2Content.tsx
+++ b/site/DataPageV2Content.tsx
@@ -199,7 +199,7 @@ export const DataPageV2Content = ({
                                 />
                             )}
 
-                            {/* A/B experiment: data-page-insight-buttons-basic */}
+                            {/* A/B experiment: data-page-insight-btns-basic */}
                             {insightsHref && (
                                 <InsightLinksInsightButtonsBasic
                                     insightsHref={insightsHref}
@@ -210,9 +210,9 @@ export const DataPageV2Content = ({
                                 datapageData={datapageData}
                                 hasFaq={!!faqEntries?.faqs.length}
                                 className={cx(
-                                    "exp-data-page-insight-buttons-basic--control1--hide",
-                                    "exp-data-page-insight-buttons-basic--treat0--hide",
-                                    "exp-data-page-insight-buttons-basic--treat1--hide"
+                                    "exp-data-page-insight-btns-basic--control1--hide",
+                                    "exp-data-page-insight-btns-basic--treat0--hide",
+                                    "exp-data-page-insight-btns-basic--treat1--hide"
                                 )}
                                 id={
                                     // if visitor is assigned to an arm other than
@@ -221,7 +221,7 @@ export const DataPageV2Content = ({
                                     assignedExperiments &&
                                     ["control1", "treat0", "treat1"].includes(
                                         assignedExperiments[
-                                            "exp-data-page-insight-buttons-basic"
+                                            "exp-data-page-insight-btns-basic"
                                         ]
                                     )
                                         ? ""
@@ -258,9 +258,9 @@ export const DataPageV2Content = ({
                             datapageData={datapageData}
                             hasFaq={!!faqEntries?.faqs.length}
                             className={cx(
-                                "exp-data-page-insight-buttons-basic--control1--show",
-                                "exp-data-page-insight-buttons-basic--treat0--show",
-                                "exp-data-page-insight-buttons-basic--treat1--show"
+                                "exp-data-page-insight-btns-basic--control1--show",
+                                "exp-data-page-insight-btns-basic--treat0--show",
+                                "exp-data-page-insight-btns-basic--treat1--show"
                             )}
                             id={
                                 // if visitor is assigned to an arm other than
@@ -269,7 +269,7 @@ export const DataPageV2Content = ({
                                 assignedExperiments &&
                                 ["control1", "treat0", "treat1"].includes(
                                     assignedExperiments[
-                                        "exp-data-page-insight-buttons-basic"
+                                        "exp-data-page-insight-btns-basic"
                                     ]
                                 )
                                     ? DATAPAGE_ABOUT_THIS_DATA_SECTION_ID
@@ -300,17 +300,17 @@ export const DataPageV2Content = ({
 }
 
 /**
- * A/B experiment: data-page-insight-buttons-basic
+ * A/B experiment: data-page-insight-btns-basic
  *
  * Renders the insight buttons for each experimental arm in the
- * data-page-insight-buttons-basic experiment.
+ * data-page-insight-btns-basic experiment.
  */
 const InsightLinksInsightButtonsBasic = ({
     insightsHref,
 }: {
     insightsHref: string
 }) => {
-    const experimentId = "data-page-insight-buttons-basic"
+    const experimentId = "data-page-insight-btns-basic"
 
     return (
         <>

--- a/site/SentryUtils.ts
+++ b/site/SentryUtils.ts
@@ -253,6 +253,11 @@ function isSentryInitialized(): boolean {
     return !!Sentry.getClient()
 }
 
+export function updateSentryTags() {
+    updateSentryReferrerTag()
+    updateSentryExperimentTags()
+}
+
 /**
  * Updates the Sentry experiment tags from the current experiment state.
  */
@@ -293,4 +298,11 @@ function extractGaClientIdFromCookie(): string | undefined {
         return clientId
     }
     return
+}
+
+function updateSentryReferrerTag() {
+    if (document.referrer) {
+        const ref = new URL(document.referrer).hostname
+        Sentry.setTag("referrer", ref)
+    }
 }

--- a/site/SentryUtils.ts
+++ b/site/SentryUtils.ts
@@ -248,3 +248,35 @@ async function stopSessionRecording(): Promise<void> {
 function isSentryInitialized(): boolean {
     return !!Sentry.getClient()
 }
+
+/**
+ * Updates the Sentry user ID from Google Analytics client ID.
+ *
+ * If analytics consent is given, the user ID is set to the Google Analytics 4
+ * client ID. If not, the Sentry user is cleared.
+ */
+export function updateSentryUser(): void {
+    let user: Sentry.User | null = null // by default, clear Sentry user
+    if (allowRecording()) {
+        const clientId = extractGaClientIdFromCookie()
+        if (clientId) {
+            user = { id: clientId }
+        }
+    }
+    Sentry.setUser(user)
+}
+
+function extractGaClientIdFromCookie(): string | undefined {
+    const gaCookie = Cookies.get("_ga")
+    if (!gaCookie) {
+        return
+    }
+
+    // Extract client ID from GA cookie (format: GA1.1.clientId.timestamp)
+    const parts = gaCookie.split(".")
+    if (parts.length >= 4) {
+        const clientId = `${parts[2]}.${parts[3]}`
+        return clientId
+    }
+    return
+}

--- a/site/SentryUtils.ts
+++ b/site/SentryUtils.ts
@@ -1,7 +1,11 @@
 import * as Sentry from "@sentry/react"
 import Cookies from "js-cookie"
 import { getPreferenceValue, PreferenceType } from "./cookiePreferences.js"
-import { experiments, isInIFrame } from "@ourworldindata/utils"
+import {
+    experiments,
+    isInIFrame,
+    getExperimentState,
+} from "@ourworldindata/utils"
 import {
     SENTRY_DEFAULT_REPLAYS_SESSION_SAMPLE_RATE,
     SENTRY_SESSION_STORAGE_KEY,
@@ -250,12 +254,22 @@ function isSentryInitialized(): boolean {
 }
 
 /**
+ * Updates the Sentry experiment tags from the current experiment state.
+ */
+export function updateSentryExperimentTags() {
+    const { assignedExperiments } = getExperimentState()
+    if (isSentryInitialized() && Object.keys(assignedExperiments).length > 0) {
+        Sentry.setTags(assignedExperiments)
+    }
+}
+
+/**
  * Updates the Sentry user ID from Google Analytics client ID.
  *
  * If analytics consent is given, the user ID is set to the Google Analytics 4
  * client ID. If not, the Sentry user is cleared.
  */
-export function updateSentryUser(): void {
+export function updateSentryUser() {
     let user: Sentry.User | null = null // by default, clear Sentry user
     if (allowRecording()) {
         const clientId = extractGaClientIdFromCookie()

--- a/site/instrument.ts
+++ b/site/instrument.ts
@@ -52,6 +52,11 @@ if (LOAD_SENTRY) {
 }
 
 function updateSentryTags() {
+    updateSentryReferrerTag()
     updateSentryExperimentTags()
 }
 
+function updateSentryReferrerTag() {
+    const ref = document.referrer ? new URL(document.referrer).hostname : "none"
+    Sentry.setTag("referrer", ref)
+}

--- a/site/instrument.ts
+++ b/site/instrument.ts
@@ -17,7 +17,7 @@ import {
     hasSessionBeenSampled,
     maybeSampleSession,
     updateSentryUser,
-    updateSentryExperimentTags,
+    updateSentryTags,
 } from "./SentryUtils.js"
 
 if (LOAD_SENTRY) {
@@ -49,16 +49,4 @@ if (LOAD_SENTRY) {
     })
     updateSentryTags()
     updateSentryUser()
-}
-
-function updateSentryTags() {
-    updateSentryReferrerTag()
-    updateSentryExperimentTags()
-}
-
-function updateSentryReferrerTag() {
-    if (document.referrer) {
-        const ref = new URL(document.referrer).hostname
-        Sentry.setTag("referrer", ref)
-    }
 }

--- a/site/instrument.ts
+++ b/site/instrument.ts
@@ -16,6 +16,7 @@ import {
     getSessionSampleRate,
     hasSessionBeenSampled,
     maybeSampleSession,
+    updateSentryUser,
 } from "./SentryUtils.js"
 
 if (LOAD_SENTRY) {
@@ -45,4 +46,5 @@ if (LOAD_SENTRY) {
         replaysSessionSampleRate: sampleRate,
         replaysOnErrorSampleRate: 0,
     })
+    updateSentryUser()
 }

--- a/site/instrument.ts
+++ b/site/instrument.ts
@@ -57,6 +57,8 @@ function updateSentryTags() {
 }
 
 function updateSentryReferrerTag() {
-    const ref = document.referrer ? new URL(document.referrer).hostname : "none"
-    Sentry.setTag("referrer", ref)
+    if (document.referrer) {
+        const ref = new URL(document.referrer).hostname
+        Sentry.setTag("referrer", ref)
+    }
 }

--- a/site/instrument.ts
+++ b/site/instrument.ts
@@ -17,6 +17,7 @@ import {
     hasSessionBeenSampled,
     maybeSampleSession,
     updateSentryUser,
+    updateSentryExperimentTags,
 } from "./SentryUtils.js"
 
 if (LOAD_SENTRY) {
@@ -46,5 +47,11 @@ if (LOAD_SENTRY) {
         replaysSessionSampleRate: sampleRate,
         replaysOnErrorSampleRate: 0,
     })
+    updateSentryTags()
     updateSentryUser()
 }
+
+function updateSentryTags() {
+    updateSentryExperimentTags()
+}
+


### PR DESCRIPTION
## Context

Enhances Sentry tracking in three ways:

(1) Sets the user to the GA4 client ID (when analytics consent provided), which allows us to filter by user id in the Sentry UI and also connect Sentry session replays to GA4 sessions. Duplicates #5274. Closes #5231.

(2) Sets tag(s) for all assigned experiments, which allows us to filter Sentry session replays by experiment name and arm assignment. Sentry tag keys have a max length of 32 characters and values have a max length of 200 characters, so this PR adds type checking to experiment ids and arm ids accordingly.

(3) Sets tag for `document.referrer` hostname, which allows us to filter Sentry session replays by referrer (e.g. "google.com", "ourworldindata.org"). Only stores the hostname to keep cardinality low. Closes #5221.

### Before merging

⚠️  NOTE: do NOT merge this before Sept 4 2025, b/c this PR shortens the id of an ongoing experiment. Best to just let the experiment expire on Sept 4 and then merge on Sept 5 or later.
- Q: but... wouldn't it be good to merge enhancement (2) while the experiment is going? A: Sure, but it's not essential. It's not that hard to filter in Sentry to the 6 data pages the experiment is running on, and you can visually see what arm the user is assigned to. But future experiments might run on many more pages and have less obvious treatment vs control content, so having these tags in the future would be nice.

## FYIs and questions for reviewer

1. ❓ QUESTION: #5221 was closed as not planned b/c it seemed cumbersome to track referrer in Sentry. But it's pretty trivial to just send `document.referrer` as a tag. Am I missing some reason why we wouldn't want to do this? Not exactly sure what the shortcomings of `document.referrer` are, but it is also what gtag uses for tracking `referrer`, so I'd expect it to be good enough for our purposes.

2. ℹ️ FYI: This PR only sets `document.referrer` hostname as the Sentry `referrer` tag in order to keep cardinality relatively low, which is what Sentry [seems to recommend doing](https://github.com/getsentry/sentry/issues/54444#issuecomment-1875670210). This is fine for external referrers like Google etc, but for internal referrers we *might* find ourselves also wanting to know the full URL pathname (e.g. `/search`). My thinking is that let's just keep the cardinality low for now until we have clear use cases for wanting to know the full path name for internal referrals. 

3. ℹ️ FYI: This PR doesn't check the referrer tag value length to make sure it's less than the limit of 200 characters b/c Sentry will truncate automatically. But for the experiment tag value, we do want to do our own type-checking to make sure the arm id is < 200 characters b/c if it gets truncated then it might not be uniquely identifiable in Sentry.

4. ℹ️ FYI: I've checked that things seem to be appearing correctly in the Sentry UI for all 3 enhancements (user id, experiment tag, referrer tag), but have not thought through and checked edge cases. If you can flag edge cases worth checking, that might be helpful.
