### PR TITLE
fix(search): pagination with dynamic page size

### DIFF
--- a/site/search/SearchTopicPageHit.tsx
+++ b/site/search/SearchTopicPageHit.tsx
@@ -5,7 +5,7 @@ import { getCanonicalPath } from "@ourworldindata/components"
 import { TopicPageHit } from "./searchTypes.js"
 
 function truncate(paragraphs: string[]) {
-    const maxWords = 95
+    const maxWords = 35
     let totalWords = 0
     const result = []
 

--- a/site/search/SearchWritingResults.tsx
+++ b/site/search/SearchWritingResults.tsx
@@ -132,7 +132,7 @@ export const SearchWritingResults = ({
         queryFn: (searchClient, state, offset, length) => {
             return queryArticles(searchClient, state, offset, length)
         },
-        firstPageSize: 3,
+        firstPageSize: 2,
         laterPageSize: 6,
     })
 

--- a/site/search/queries.ts
+++ b/site/search/queries.ts
@@ -194,8 +194,8 @@ export async function queryDataInsights(
 export async function queryArticles(
     searchClient: SearchClient,
     state: SearchState,
-    page: number = 0,
-    hitsPerPage: number
+    offset: number = 0,
+    length: number
 ): Promise<SearchFlatArticleResponse> {
     const selectedCountryNames = getFilterNamesOfType(
         state.filters,
@@ -238,8 +238,8 @@ export async function queryArticles(
             ],
             highlightPreTag: "<mark>",
             highlightPostTag: "</mark>",
-            hitsPerPage,
-            page,
+            offset,
+            length,
         },
     ]
 
@@ -251,8 +251,8 @@ export async function queryArticles(
 export async function queryTopicPages(
     searchClient: SearchClient,
     state: SearchState,
-    page: number = 0,
-    hitsPerPage: number
+    offset: number = 0,
+    length: number
 ): Promise<SearchTopicPageResponse> {
     const selectedTopics = getFilterNamesOfType(state.filters, FilterType.TOPIC)
 
@@ -269,10 +269,10 @@ export async function queryTopicPages(
                 "excerpt",
                 "excerptLong",
             ],
-            hitsPerPage,
             highlightPreTag: "<mark>",
             highlightPostTag: "</mark>",
-            page,
+            offset,
+            length,
         },
     ]
 

--- a/site/search/searchHooks.ts
+++ b/site/search/searchHooks.ts
@@ -156,7 +156,7 @@ type QueryKeyState = Pick<
 
 /**
  * Compute Algolia `offset` and `length` so the UI can show a smaller
- * first page (e.g. 3) and larger subsequent pages (e.g. 6) without
+ * first page (e.g. 2) and larger subsequent pages (e.g. 6) without
  * skipping results.
  *
  * Rationale:
@@ -167,10 +167,10 @@ type QueryKeyState = Pick<
  * - To avoid skipped results we request explicit `offset` and `length`:
  *   "start at result N and give me M results".
  *
- * Example (articles: first=3 later=6):
- * - UI page 0 -> offset=0, length=3 -> results 0..2
- * - UI page 1 -> offset=3, length=6 -> results 3..8
- * - UI page 2 -> offset=9, length=6 -> results 9..14
+ * Example (articles: first=2 later=6):
+ * - UI page 0 -> offset=0, length=2 -> results 0..1
+ * - UI page 1 -> offset=2, length=6 -> results 2..7
+ * - UI page 2 -> offset=8, length=6 -> results 8..13
  */
 
 export function useInfiniteSearchOffset<T extends SearchResponse<U>, U>({

--- a/site/search/searchUtils.test.ts
+++ b/site/search/searchUtils.test.ts
@@ -4,6 +4,8 @@ import {
     findMatches,
     getAutocompleteSuggestionsWithUnmatchedQuery,
     createCountryFilter,
+    getPaginationOffsetAndLength,
+    getNbPaginatedItemsRequested,
 } from "./searchUtils"
 
 import { FilterType, SynonymMap } from "./searchTypes.js"
@@ -456,5 +458,28 @@ describe("Fuzzy search in search autocomplete", () => {
         )
 
         expect(result.suggestions.some((s) => s.name === "Germany")).toBe(true)
+    })
+})
+
+describe("offset pagination for useInfiniteSearchOffset hook", () => {
+    it("computes offsets and lengths for first and later pages", () => {
+        expect(getPaginationOffsetAndLength(0, 3, 6)).toEqual({
+            offset: 0,
+            length: 3,
+        })
+        expect(getPaginationOffsetAndLength(1, 3, 6)).toEqual({
+            offset: 3,
+            length: 6,
+        })
+        expect(getPaginationOffsetAndLength(2, 3, 6)).toEqual({
+            offset: 9,
+            length: 6,
+        })
+    })
+
+    it("computes number of requested items correctly", () => {
+        expect(getNbPaginatedItemsRequested(0, 3, 6, 3)).toBe(3)
+        expect(getNbPaginatedItemsRequested(1, 3, 6, 6)).toBe(9)
+        expect(getNbPaginatedItemsRequested(2, 3, 6, 2)).toBe(11)
     })
 })

--- a/site/search/searchUtils.tsx
+++ b/site/search/searchUtils.tsx
@@ -1094,3 +1094,25 @@ export function getPageTypeNameAndIcon(pageType: OwidGdocType): {
         .exhaustive()
 }
 export const SEARCH_BASE_PATH = "/search"
+
+export const getPaginationOffsetAndLength = (
+    pageParam: number,
+    firstPageSize: number,
+    laterPageSize: number
+) => {
+    const offset =
+        pageParam === 0 ? 0 : firstPageSize + (pageParam - 1) * laterPageSize
+    const length = pageParam === 0 ? firstPageSize : laterPageSize
+    return { offset, length }
+}
+
+export const getNbPaginatedItemsRequested = (
+    currentPageIndex: number,
+    firstPageSize: number,
+    laterPageSize: number,
+    lastPageHits: number
+) => {
+    return currentPageIndex === 0
+        ? firstPageSize
+        : firstPageSize + (currentPageIndex - 1) * laterPageSize + lastPageHits
+}


### PR DESCRIPTION
## Context

This PR improves the search results pagination by implementing offset-based pagination to fix issues with result skipping when using different page sizes. Previously, when using Algolia's page parameter with different `hitsPerPage` values, some results would be skipped. The new approach uses explicit `offset` and `length` parameters to ensure continuous results (see [algolia docs](https://www.algolia.com/doc/guides/building-search-ui/ui-and-ux-patterns/pagination/js/#retrieving-a-subset-of-records-with-offset-and-length)).

## Changes

- Added `useInfiniteSearchOffset` hook that properly handles pagination with different page sizes
- Added utility functions `getPaginationOffsetAndLength` and `getNbPaginatedItemsRequested` to calculate correct pagination values
- Updated article and topic page queries to use offset/length instead of page/hitsPerPage
- Reduced the maximum words in topic page hit truncation from 95 to 35 for more concise previews ([figma](https://www.figma.com/design/lAIoPy94qgSocFKYO6HBTh/Search-2.0?node-id=302-24427&m=dev))
- Adjusted the first page size for articles from 3 to 2 ([figma](https://www.figma.com/design/lAIoPy94qgSocFKYO6HBTh/Search-2.0?node-id=302-24427&m=dev))

## Testing guidance

1. Navigate to the search page
2. Pick a topic
3. Click “show more”
4. Check that the second page of results matches Algolia, and that no results are skipped

| Before | After |
| --- | --- |
| ![Screenshot 2025-09-04 at 18.59.48.png](https://app.graphite.dev/user-attachments/assets/24c53803-b87f-4098-b265-90b5414d0c6d.png)<br> | ![Screenshot 2025-09-04 at 18.59.19.png](https://app.graphite.dev/user-attachments/assets/bfa9466d-ed77-4355-b7b3-650120f08301.png) |

## ![Screenshot 2025-09-04 at 19.02.21.png](https://app.graphite.dev/user-attachments/assets/551690e4-ef96-4e01-b6cf-d3f9cc368374.png)