### PR TITLE
Add explorers to archivalDb

### DIFF
--- a/db/docs/archived_chart_versions.yml
+++ b/db/docs/archived_chart_versions.yml
@@ -13,4 +13,4 @@ fields:
     hashOfInputs:
         description: Hash of the inputs used to generate this chart version, used for deduplication and change detection
     manifest:
-        description: JSON manifest containing the full chart configuration and metadata at the time of archival
+        description: JSON manifest containing metadata needed for reproducible archive

--- a/db/docs/archived_explorer_versions.yml
+++ b/db/docs/archived_explorer_versions.yml
@@ -1,0 +1,14 @@
+metadata:
+    description: |
+        Table for keeping track of archived versions of our data explorers at https://archive.ourworldindata.org. On every content publish we create a new archival version of all published explorers (as given in the explorers table) that were updated since the last content publish.
+fields:
+    id:
+        description: Unique identifier for the archived explorer version
+    archivalTimestamp:
+        description: Timestamp when this explorer version was archived
+    explorerSlug:
+        description: Slug of the explorer at the time of archival (not a foreign key as archives are kept even after deletion)
+    hashOfInputs:
+        description: Hash of the inputs used to generate this explorer version, used for deduplication and change detection
+    manifest:
+        description: JSON manifest containing metadata needed for reproducible archive

--- a/db/docs/archived_multi_dim_versions.yml
+++ b/db/docs/archived_multi_dim_versions.yml
@@ -13,4 +13,4 @@ fields:
     hashOfInputs:
         description: Hash of the inputs used to generate this page version, used for deduplication and change detection
     manifest:
-        description: JSON manifest containing the full page configuration and metadata at the time of archival
+        description: JSON manifest containing metadata needed for reproducible archive

--- a/db/docs/explorers.yml
+++ b/db/docs/explorers.yml
@@ -13,6 +13,8 @@ fields:
         description: URL-friendly identifier for the explorer used in URLs like /explorers/[slug]
     config:
         description: Explorer configuration JSON parsed from the TSV configuration
+    configMd5:
+        description: Generated MD5 hash (base64) of the explorer config, used for change detection and archival deduplication
     createdAt:
         description: Timestamp when the explorer was created
     updatedAt:

--- a/db/migration/1756991563977-CreateArchivedExplorerVersions.ts
+++ b/db/migration/1756991563977-CreateArchivedExplorerVersions.ts
@@ -1,0 +1,30 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class CreateArchivedExplorerVersions1756991563977
+    implements MigrationInterface
+{
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`-- sql
+            CREATE TABLE archived_explorer_versions (
+                id INT AUTO_INCREMENT PRIMARY KEY NOT NULL,
+                archivalTimestamp TIMESTAMP NOT NULL,
+                -- Not a FK because we want to keep explorers archived
+                -- even after they're deleted.
+                explorerSlug VARCHAR(150) NOT NULL,
+                hashOfInputs VARCHAR(255) NOT NULL,
+                manifest JSON,
+
+                -- Useful for querying the latest version of an explorer.
+                UNIQUE INDEX idx_explorerSlug_archivalTimestamp (explorerSlug, archivalTimestamp),
+                INDEX idx_timestamp (archivalTimestamp),
+                INDEX idx_hashOfInputs (hashOfInputs)
+            )
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`-- sql
+            DROP TABLE archived_explorer_versions
+        `)
+    }
+}

--- a/db/migration/1756993313186-AddExplorerConfigMd5.ts
+++ b/db/migration/1756993313186-AddExplorerConfigMd5.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class AddExplorerConfigMd51756993313186 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`-- sql
+            ALTER TABLE explorers 
+            ADD COLUMN configMd5 CHAR(24) GENERATED ALWAYS AS (to_base64(unhex(md5(config)))) STORED NOT NULL AFTER config
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`-- sql
+            ALTER TABLE explorers 
+            DROP COLUMN configMd5
+        `)
+    }
+}

--- a/packages/@ourworldindata/types/src/dbTypes/ArchivedExplorerVersion.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/ArchivedExplorerVersion.ts
@@ -1,0 +1,20 @@
+import { JsonString } from "../domainTypes/Various.js"
+
+export const ArchivedExplorerVersionsTableName = "archived_explorer_versions"
+
+export interface DbInsertArchivedExplorerVersion {
+    archivalTimestamp: Date
+    explorerSlug: string
+    hashOfInputs: string
+    manifest: JsonString
+}
+
+export interface DbPlainArchivedExplorerVersion
+    extends Required<DbInsertArchivedExplorerVersion> {
+    id: number
+}
+
+export interface DbEnrichedArchivedExplorerVersion
+    extends Omit<DbPlainArchivedExplorerVersion, "manifest"> {
+    manifest: Record<string, any> // TODO: Turn into more specific type
+}

--- a/packages/@ourworldindata/types/src/dbTypes/Explorers.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/Explorers.ts
@@ -25,6 +25,9 @@ export type DbPlainExplorer = Required<DbInsertExplorer> & {
     // config is a parsed version of the TSV
     // it is used in getNonGrapherExplorerViewCount or in getPublishedExplorersBySlug
     config: JsonString
+    // Automatically generated MD5 of the config by the DB. Used to detect
+    // changes in the config.
+    configMd5: string
     // Views refresh status for async job processing
     viewsRefreshStatus: ExplorerViewsRefreshStatus
     lastViewsRefreshAt: Date | null

--- a/packages/@ourworldindata/types/src/dbTypes/Variables.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/Variables.ts
@@ -39,6 +39,8 @@ export interface DbInsertVariable {
     updatedAt?: Date | null
     type?: OwidVariableType | null
     sort?: JsonString | null
+    dataChecksum?: string | null
+    metadataChecksum?: string | null
 }
 
 export type DbRawVariable = Required<DbInsertVariable>

--- a/packages/@ourworldindata/types/src/domainTypes/Archive.ts
+++ b/packages/@ourworldindata/types/src/domainTypes/Archive.ts
@@ -3,6 +3,10 @@ export const ARCHIVE_DATE_TIME_FORMAT = "YYYYMMDD-HHmmss" // e.g. 20250414-07433
 
 export type AssetMap = Record<string, string>
 
+export type IndicatorChecksums = {
+    [id: string]: { metadataChecksum: string; dataChecksum: string }
+}
+
 export interface UrlAndMaybeDate {
     url: string
     date?: Date | ArchivalDateString
@@ -46,9 +50,7 @@ export interface ArchiveVersions {
 
 export interface GrapherChecksums {
     chartConfigMd5: string
-    indicators: {
-        [id: string]: { metadataChecksum: string; dataChecksum: string }
-    }
+    indicators: IndicatorChecksums
 }
 
 export interface GrapherChecksumsObjectWithHash {
@@ -63,14 +65,26 @@ export interface MultiDimChecksums {
     chartConfigs: {
         [id: string]: string // chartConfigId -> MD5
     }
-    indicators: {
-        [id: string]: { metadataChecksum: string; dataChecksum: string }
-    }
+    indicators: IndicatorChecksums
 }
 
 export interface MultiDimChecksumsObjectWithHash {
     multiDimId: number
     multiDimSlug: string
     checksums: MultiDimChecksums
+    checksumsHashed: string
+}
+
+export interface ExplorerChecksums {
+    explorerConfigMd5: string
+    chartConfigs: {
+        [id: string]: string // chartId -> chart_configs.fullMd5 of explorer view configs
+    }
+    indicators: IndicatorChecksums
+}
+
+export interface ExplorerChecksumsObjectWithHash {
+    explorerSlug: string
+    checksums: ExplorerChecksums
     checksumsHashed: string
 }

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -510,6 +510,12 @@ export {
     ArchivedMultiDimVersionsTableName,
 } from "./dbTypes/ArchivedMultiDimVersion.js"
 export {
+    type DbInsertArchivedExplorerVersion,
+    type DbPlainArchivedExplorerVersion,
+    type DbEnrichedArchivedExplorerVersion,
+    ArchivedExplorerVersionsTableName,
+} from "./dbTypes/ArchivedExplorerVersion.js"
+export {
     type DbInsertChartConfig,
     type DbRawChartConfig,
     type DbEnrichedChartConfig,
@@ -849,6 +855,8 @@ export {
     type GrapherChecksumsObjectWithHash,
     type MultiDimChecksums,
     type MultiDimChecksumsObjectWithHash,
+    type ExplorerChecksums,
+    type ExplorerChecksumsObjectWithHash,
 } from "./domainTypes/Archive.js"
 export { type AdditionalGrapherDataFetchFn } from "./grapherTypes/GrapherTypes.js"
 

--- a/packages/@ourworldindata/utils/src/archival/archivalDate.ts
+++ b/packages/@ourworldindata/utils/src/archival/archivalDate.ts
@@ -9,7 +9,7 @@ export interface ArchivalTimestamp {
     formattedDate: ArchivalDateString
 }
 
-type DateInput = Date | ArchivalDateString | string | dayjs.Dayjs
+export type DateInput = Date | ArchivalDateString | string | dayjs.Dayjs
 
 export const parseArchivalDate = (dateInput: DateInput): dayjs.Dayjs => {
     if (typeof dateInput === "string") {

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -311,6 +311,7 @@ export { FuzzySearch, type FuzzySearchResult } from "./FuzzySearch.js"
 
 export {
     type ArchivalTimestamp,
+    type DateInput,
     convertToArchivalDateStringIfNecessary,
     formatAsArchivalDate,
     getDateForArchival,


### PR DESCRIPTION
Adds DB helpers for archiving explorers. The rest of the feature comes in the next PR.

## Context

Part of #5366

## Testing guidance

- Migrate DB with `yarn runDbMigrations`

## Checklist

### Before merging

If DB migrations exists:

- [x] The DB type definitions have been updated
- [x] The DB types in the ETL have been updated
- [x] Update the documentation in db/docs
