### PR TITLE
Add baking of explorer archive

### DIFF
--- a/baker/siteRenderers.tsx
+++ b/baker/siteRenderers.tsx
@@ -43,6 +43,7 @@ import {
 } from "@ourworldindata/utils"
 import { extractFormattingOptions } from "../serverUtils/wordpressUtils.js"
 import {
+    ArchiveContext,
     DEFAULT_THUMBNAIL_FILENAME,
     DbPlainChart,
     DbRawChartConfig,
@@ -98,6 +99,7 @@ import {
     AttachmentsContext,
 } from "../site/gdocs/AttachmentsContext.js"
 import AtomArticleBlocks from "../site/gdocs/components/AtomArticleBlocks.js"
+import { getLatestExplorerArchivedVersionsIfEnabled } from "../db/model/archival/archivalDb.js"
 import { GdocDataInsight } from "../db/model/Gdoc/GdocDataInsight.js"
 
 export const renderToHtmlPage = (element: any) =>
@@ -656,6 +658,7 @@ export const renderExplorerIndexPage = async (
 interface ExplorerRenderOpts {
     urlMigrationSpec?: ExplorerPageUrlMigrationSpec
     isPreviewing?: boolean
+    archivedChartInfo?: ArchiveContext
 }
 
 export const renderExplorerPage = async (
@@ -776,6 +779,15 @@ export const renderExplorerPage = async (
           )
         : undefined
 
+    let archiveContext = opts?.archivedChartInfo
+    if (!archiveContext) {
+        const latestBySlug = await getLatestExplorerArchivedVersionsIfEnabled(
+            knex,
+            [program.slug]
+        )
+        archiveContext = latestBySlug[program.slug]
+    }
+
     return (
         `<!doctype html>` +
         ReactDOMServer.renderToString(
@@ -787,6 +799,7 @@ export const renderExplorerPage = async (
                 baseUrl={BAKED_BASE_URL}
                 urlMigrationSpec={opts?.urlMigrationSpec}
                 isPreviewing={opts?.isPreviewing}
+                archivedChartInfo={archiveContext}
             />
         )
     )

--- a/site/ExplorerPage.tsx
+++ b/site/ExplorerPage.tsx
@@ -5,6 +5,7 @@ import {
     SiteFooterContext,
     GrapherInterface,
 } from "@ourworldindata/utils"
+import { ArchiveContext } from "@ourworldindata/types"
 import {
     EMBEDDED_EXPLORER_DELIMITER,
     EMBEDDED_EXPLORER_GRAPHER_CONFIGS,
@@ -36,6 +37,7 @@ interface ExplorerPageSettings {
     baseUrl: string
     urlMigrationSpec?: ExplorerPageUrlMigrationSpec
     isPreviewing?: boolean
+    archivedChartInfo?: ArchiveContext
 }
 
 const ExplorerContent = ({ content }: { content: string }) => {
@@ -67,6 +69,7 @@ export const ExplorerPage = (props: ExplorerPageSettings) => {
         partialGrapherConfigs,
         baseUrl,
         urlMigrationSpec,
+        archivedChartInfo,
     } = props
     const {
         subNavId,
@@ -77,6 +80,10 @@ export const ExplorerPage = (props: ExplorerPageSettings) => {
         thumbnail,
         hideAlertBanner,
     } = program
+
+    const isOnArchivalPage = archivedChartInfo?.type === "archive-page"
+    const assetMaps = isOnArchivalPage ? archivedChartInfo.assets : undefined
+
     const subNav = subNavId ? (
         <SiteSubnavigation
             subnavId={subNavId}
@@ -108,7 +115,15 @@ const explorerConstants = ${serializeJSONForHTML(
         },
         EXPLORER_CONSTANTS_DELIMITER
     )}
-window.Explorer.renderSingleExplorerOnExplorerPage(explorerProgram, grapherConfigs, partialGrapherConfigs, explorerConstants, urlMigrationSpec);`
+const archivedChartInfo = ${JSON.stringify(archivedChartInfo)};
+window.Explorer.renderSingleExplorerOnExplorerPage(
+    explorerProgram,
+    grapherConfigs,
+    partialGrapherConfigs,
+    explorerConstants,
+    urlMigrationSpec,
+    archivedChartInfo
+);`
 
     return (
         <Html>
@@ -118,11 +133,18 @@ window.Explorer.renderSingleExplorerOnExplorerPage(explorerProgram, grapherConfi
                 pageDesc={explorerSubtitle}
                 imageUrl={thumbnail}
                 baseUrl={baseUrl}
+                staticAssetMap={assetMaps?.static}
+                archivedChartInfo={archivedChartInfo}
             >
                 <IFrameDetector />
             </Head>
             <body className={GRAPHER_PAGE_BODY_CLASS}>
-                <SiteHeader hideAlertBanner={hideAlertBanner || false} />
+                <SiteHeader
+                    hideAlertBanner={hideAlertBanner || false}
+                    archiveInfo={
+                        isOnArchivalPage ? archivedChartInfo : undefined
+                    }
+                />
                 {subNav}
                 <main id={ExplorerContainerId}>
                     <div className="js--show-warning-block-if-js-disabled" />
@@ -132,6 +154,9 @@ window.Explorer.renderSingleExplorerOnExplorerPage(explorerProgram, grapherConfi
                 <SiteFooter
                     context={SiteFooterContext.explorerPage}
                     isPreviewing={props.isPreviewing}
+                    archiveInfo={
+                        isOnArchivalPage ? archivedChartInfo : undefined
+                    }
                 />
                 <script
                     type="module"

--- a/site/owid-archive.entry.ts
+++ b/site/owid-archive.entry.ts
@@ -10,12 +10,14 @@ import {
     Grapher,
     renderSingleGrapherOnGrapherPage,
 } from "@ourworldindata/grapher"
+import { Explorer } from "@ourworldindata/explorer"
 import { SiteAnalytics } from "./SiteAnalytics.js"
 import { runMonkeyPatchForGoogleTranslate } from "./hacks.js"
 import { runSiteFooterScriptsForArchive } from "./runSiteFooterScripts.js"
 
 declare let window: any
 window.Grapher = Grapher
+window.Explorer = Explorer
 window.renderSingleGrapherOnGrapherPage = renderSingleGrapherOnGrapherPage
 
 // Note: do a text search of the project for "runSiteFooterScripts" to find the usage. todo: clean that up.

--- a/site/runSiteFooterScripts.tsx
+++ b/site/runSiteFooterScripts.tsx
@@ -296,6 +296,7 @@ export const runSiteFooterScriptsForArchive = (args: SiteFooterScriptsArgs) => {
             void runDetailsOnDemand()
             break
         case SiteFooterContext.grapherPage:
+        case SiteFooterContext.explorerPage:
             runSiteNavigation()
             // runAllGraphersLoadedListener()
             // runSiteTools()


### PR DESCRIPTION
## Context

Part of #5366

## Screenshots / Videos / Diagrams

![image.png](https://app.graphite.dev/user-attachments/assets/d9d9ce0b-23e6-4431-b0ba-6b0b8ebc04b5.png)

Missing images is a known issue. This might be solved at the same time as when we implement archiving of images for articles.

## Testing guidance

- Migrate DB with `yarn runDbMigrations`
- Create archive for one grapher-based and one indicator-based explorer
  
  ```
  yarn buildArchive --type explorers --explorerSlugs co2 air-pollution --latestDir
  ```

- [x] Does the staging experience have sign-off from product stakeholders?

## Checklist

### Before merging

- [x] Changes to CSS/HTML were checked on Desktop and Mobile Safari at all three breakpoints
- [x] Changes to HTML were checked for accessibility concerns
