### PR TITLE
chore: add support for caddy for https/http2 in remote dev setup

### DIFF
--- a/.env.example-full
+++ b/.env.example-full
@@ -62,3 +62,6 @@ DATA_API_URL= # optional
 
 SLACK_BOT_OAUTH_TOKEN= # optional
 SLACK_DI_PITCHES_CHANNEL_ID= # optional; #data-insight-pitches channel id
+
+VITE_DEV_URL= #optional
+VITE_ALLOWED_HOSTS= #optional (used for remote dev through caddy)

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ dist/
 cfstorage/
 vite.*.mjs
 archive/*
+Caddyfile
 
 # Sentry Config File
 .env.sentry-build-plugin

--- a/Caddyfile.example
+++ b/Caddyfile.example
@@ -1,0 +1,28 @@
+# Example Caddyfile for remote development setup with vite dev assets served through HTTP/2.
+#
+# Scenario:
+# - Admin server (Express) listens on 127.0.0.1:3030
+# - Vite dev server listens on 127.0.0.1:8090
+# - Caddy terminates TLS (using an internal CA) and reverse proxies both. The local CA cert issued by caddy
+# will require to bypass the security warning in the browser but still gives the performance benefits of HTTP/2.
+#
+# How-to use:
+# 1. Copy to "Caddyfile" to enable the automatic tmux caddy window (Makefile checks for that file)
+# 2. Replace "YOURMACHINE.TAILXXX.ts.net" accordingly (you can find this in Tailscale admin console)
+# 3. Update .env
+#  - ADMIN_BASE_URL=https://YOURMACHINE.TAILXXX.ts.net
+#  - VITE_DEV_URL=https://YOURMACHINE.TAILXXX.ts.net
+#  - VITE_ALLOWED_HOSTS=YOURMACHINE.TAILXXX.ts.net
+# 4. Reload after edits: `make up` (if using tmux) or `caddy reload`
+
+# This makes the admin accessible on https://YOURMACHINE.TAILXXXX.ts.net (without a port, for convenience)
+YOURMACHINE.TAILXXXX.ts.net {
+    reverse_proxy 127.0.0.1:3030
+    tls internal
+}
+
+YOURMACHINE.TAILXXXX.ts.net:8091 {
+    reverse_proxy 127.0.0.1:8090
+    tls internal
+}
+

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,7 @@ up: require create-if-missing.env tmp-downloads/owid_metadata.sql.gz node_module
 			set remain-on-exit on \; \
 		new-window -n vite 'yarn run startSiteFront' \; \
 			set remain-on-exit on \; \
+		$(if $(wildcard Caddyfile),new-window -n caddy 'sudo caddy run' \; ) \
 		new-window -n welcome 'devTools/docker/banner.sh; exec $(LOGIN_SHELL)' \; \
 		bind R respawn-pane -k \; \
 		bind X kill-pane \; \
@@ -104,6 +105,7 @@ up.full: require create-if-missing.env.full tmp-downloads/owid_metadata.sql.gz n
 		-n docker 'docker compose -f docker-compose.grapher.yml up' \; \
 			set remain-on-exit on \; \
 		set-option -g default-shell $(SCRIPT_SHELL) \; \
+		$(if $(wildcard Caddyfile),new-window -n caddy 'sudo -E caddy run' \; ) \
 		new-window -n admin \
 			'devTools/docker/wait-for-mysql.sh && yarn startAdminDevServer' \; \
 			set remain-on-exit on \; \

--- a/vite.config-common.mts
+++ b/vite.config-common.mts
@@ -78,6 +78,10 @@ export const defineViteConfigForEntrypoint = (entrypoint: ViteEntryPoint) => {
         server: {
             port: 8090,
             warmup: { clientFiles: [VITE_ASSET_SITE_ENTRY] },
+            // See Caddyfile.example for context about these settings
+            ...(process.env.VITE_ALLOWED_HOSTS
+                ? { allowedHosts: [process.env.VITE_ALLOWED_HOSTS], cors: true }
+                : {}),
         },
         preview: {
             port: 8090,


### PR DESCRIPTION
## Context

This PR adds support for remote development using Caddy as a reverse proxy. It enables developers to access the admin server and Vite dev server through HTTPS with HTTP/2 performance benefits, particularly useful for those working with Tailscale. It also removes the need for flaky port forwarding.

## Testing guidance

1. Copy `Caddyfile.example` to `Caddyfile` in your project root
2. Replace "[YOURMACHINE.TAILXXX.ts.net](http://YOURMACHINE.TAILXXX.ts.net)" with your Tailscale machine name
3. Update your `.env` file with the following:
4. Run `make up` to start the development environment with Caddy
5. Access your application via HTTPS at your Tailscale domain