### PR TITLE
:bug: Add MySQL lock when updating `country_latest_data` to avoid deadlocks

### DIFF
--- a/baker/countryProfiles.tsx
+++ b/baker/countryProfiles.tsx
@@ -141,7 +141,7 @@ export const denormalizeLatestCountryData = async (
         const records = df.toRecords()
         await trx.raw(
             `
-            REPLACE INTO country_latest_data (country_code, variable_id, year, value) 
+            REPLACE INTO country_latest_data (country_code, variable_id, year, value)
             VALUES ${records.map(() => "(?, ?, ?, ?)").join(", ")}
         `,
             records.flatMap((r) => [

--- a/baker/countryProfiles.tsx
+++ b/baker/countryProfiles.tsx
@@ -139,11 +139,19 @@ export const denormalizeLatestCountryData = async (
     // Upsert new values to avoid deadlock issues
     if (df.height > 0) {
         const records = df.toRecords()
-        await trx.raw(`
+        await trx.raw(
+            `
             INSERT INTO country_latest_data (country_code, variable_id, year, value) 
             VALUES ${records.map(() => "(?, ?, ?, ?)").join(", ")} 
             ON DUPLICATE KEY UPDATE year = VALUES(year), value = VALUES(value)
-        `, records.flatMap(r => [r.country_code, r.variable_id, r.year, r.value]))
+        `,
+            records.flatMap((r) => [
+                r.country_code,
+                r.variable_id,
+                r.year,
+                r.value,
+            ])
+        )
     } else {
         // Still need to delete if no new data
         await trx

--- a/baker/countryProfiles.tsx
+++ b/baker/countryProfiles.tsx
@@ -164,7 +164,12 @@ export const denormalizeLatestCountryData = async (
         } catch (error: any) {
             if (error.code === "ER_LOCK_DEADLOCK" && attempt < maxRetries - 1) {
                 // Wait with exponential backoff
-                await new Promise(resolve => setTimeout(resolve, 100 * Math.pow(2, attempt) + Math.random() * 50))
+                await new Promise((resolve) =>
+                    setTimeout(
+                        resolve,
+                        100 * Math.pow(2, attempt) + Math.random() * 50
+                    )
+                )
             } else {
                 throw error
             }

--- a/baker/countryProfiles.tsx
+++ b/baker/countryProfiles.tsx
@@ -136,15 +136,20 @@ export const denormalizeLatestCountryData = async (
         .select("variableId", "entityCode", "year", "value")
         .rename({ variableId: "variable_id", entityCode: "country_code" })
 
-    // Remove existing values
-    await trx
-        .table("country_latest_data")
-        .whereIn("variable_id", variableIds as number[])
-        .delete()
-
-    // Insert new ones
+    // Upsert new values to avoid deadlock issues
     if (df.height > 0) {
-        await trx.table("country_latest_data").insert(df.toRecords())
+        const records = df.toRecords()
+        await trx.raw(`
+            INSERT INTO country_latest_data (country_code, variable_id, year, value) 
+            VALUES ${records.map(() => "(?, ?, ?, ?)").join(", ")} 
+            ON DUPLICATE KEY UPDATE year = VALUES(year), value = VALUES(value)
+        `, records.flatMap(r => [r.country_code, r.variable_id, r.year, r.value]))
+    } else {
+        // Still need to delete if no new data
+        await trx
+            .table("country_latest_data")
+            .whereIn("variable_id", variableIds as number[])
+            .delete()
     }
 }
 


### PR DESCRIPTION
Concurrent calls to update charts using Admin API endpoint `/charts/[chart_id]` sometimes fail with deadlock. Adding a MySQL lock prevents them.

(Note that `country_latest_data` is scheduled for deprecation anyway, so this should be low risk)