### PR TITLE
Stalebot: 4 months stale, 1 month to close

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,11 +20,12 @@ jobs:
             - uses: actions/stale@v9
               with:
                   repo-token: ${{ secrets.GITHUB_TOKEN }}
-                  stale-issue-message: "This issue has had no activity within 6 months. It is considered stale and will be closed in 7 days unless it is worked on or tagged as pinned."
+                  stale-issue-message: "This issue has had no activity within 4 months. It is considered stale and will be closed in 30 days unless it is worked on or tagged as pinned."
                   stale-pr-message: "This PR has had no activity within the last two weeks. It is considered stale and will be closed in 3 days if no further activity is detected."
                   stale-issue-label: "stale"
                   stale-pr-label: "stale"
-                  days-before-stale: 182
+                  days-before-stale: 120
+                  days-before-close: 30
                   days-before-pr-stale: 14
                   days-before-pr-close: 3
                   exempt-issue-labels: "pinned,security,correctness,external-contributor"


### PR DESCRIPTION
Change stalebot to mark issues stale after 4 instead of 6 months and auto-close 30 days later (instead of 7)