### PR TITLE
🐛 fix invalid html in latest data insights block causing unstable pageheight on homepage

### DIFF
--- a/site/gdocs/components/SpanElement.tsx
+++ b/site/gdocs/components/SpanElement.tsx
@@ -30,18 +30,27 @@ export default function SpanElement({
                 <LinkedA span={span} />
             ) : (
                 <span>
-                    <SpanElements spans={span.children} />
+                    <SpanElements
+                        spans={span.children}
+                        shouldRenderLinks={shouldRenderLinks}
+                    />
                 </span>
             )
         )
         .with({ spanType: "span-ref" }, (span) =>
             shouldRenderLinks ? (
                 <a href={span.url} className="ref">
-                    <SpanElements spans={span.children} />
+                    <SpanElements
+                        spans={span.children}
+                        shouldRenderLinks={shouldRenderLinks}
+                    />
                 </a>
             ) : (
                 <span className="ref">
-                    <SpanElements spans={span.children} />
+                    <SpanElements
+                        spans={span.children}
+                        shouldRenderLinks={shouldRenderLinks}
+                    />
                 </span>
             )
         )
@@ -49,7 +58,10 @@ export default function SpanElement({
             if (!shouldRenderLinks) {
                 return (
                     <span className="guided-chart-link">
-                        <SpanElements spans={span.children} />
+                        <SpanElements
+                            spans={span.children}
+                            shouldRenderLinks={shouldRenderLinks}
+                        />
                     </span>
                 )
             }
@@ -73,49 +85,76 @@ export default function SpanElement({
                     onClick={handleClick}
                 >
                     <FontAwesomeIcon icon={faEye} />
-                    <SpanElements spans={span.children} />
+                    <SpanElements
+                        spans={span.children}
+                        shouldRenderLinks={shouldRenderLinks}
+                    />
                 </a>
             )
         })
         .with({ spanType: "span-dod" }, (span) => (
             <span className="dod-span" data-id={`${span.id}`} tabIndex={0}>
-                <SpanElements spans={span.children} />
+                <SpanElements
+                    spans={span.children}
+                    shouldRenderLinks={shouldRenderLinks}
+                />
             </span>
         ))
         .with({ spanType: "span-newline" }, () => <br />)
         .with({ spanType: "span-italic" }, (span) => (
             <em>
-                <SpanElements spans={span.children} />
+                <SpanElements
+                    spans={span.children}
+                    shouldRenderLinks={shouldRenderLinks}
+                />
             </em>
         ))
         .with({ spanType: "span-bold" }, (span) => (
             <strong>
-                <SpanElements spans={span.children} />
+                <SpanElements
+                    spans={span.children}
+                    shouldRenderLinks={shouldRenderLinks}
+                />
             </strong>
         ))
         .with({ spanType: "span-underline" }, (span) => (
             <u>
-                <SpanElements spans={span.children} />
+                <SpanElements
+                    spans={span.children}
+                    shouldRenderLinks={shouldRenderLinks}
+                />
             </u>
         ))
         .with({ spanType: "span-subscript" }, (span) => (
             <sub>
-                <SpanElements spans={span.children} />
+                <SpanElements
+                    spans={span.children}
+                    shouldRenderLinks={shouldRenderLinks}
+                />
             </sub>
         ))
         .with({ spanType: "span-superscript" }, (span) => (
             <sup>
-                <SpanElements spans={span.children} />
+                <SpanElements
+                    spans={span.children}
+                    shouldRenderLinks={shouldRenderLinks}
+                />
             </sup>
         ))
         .with({ spanType: "span-quote" }, (span) => (
             <q>
-                <SpanElements spans={span.children} />
+                <SpanElements
+                    spans={span.children}
+                    shouldRenderLinks={shouldRenderLinks}
+                />
             </q>
         ))
         .with({ spanType: "span-fallback" }, (span) => (
             <span>
-                <SpanElements spans={span.children} />
+                <SpanElements
+                    spans={span.children}
+                    shouldRenderLinks={shouldRenderLinks}
+                />
             </span>
         ))
         .exhaustive()


### PR DESCRIPTION
## Context

https://ourworldindata.org#subscribe doesn't render at the correct y position currently.

This is happening because browsers are rewriting our served HTML (because it's invalid) and then hydration re-rewrites it (back to the invalid state), causing a jump in page height.

This PR fixes the issue by making the HTML valid (removing nested anchor links)

We'd already made [a fix similar to this](https://github.com/owid/owid-grapher/commit/dbbf452021f51ca2a774afab2773a0dbb9d39833) before, but due to [another bug in our parsing](https://github.com/owid/owid-grapher/issues/2842) a link with subscript in it caused it to happen again.

## Screenshots / Videos / Diagrams

| Before | After |
|--------|--------|
| <img width="770" height="521" alt="image" src="https://github.com/user-attachments/assets/1d4254ba-4822-4c03-abcf-369d65970cf6" /> | <img width="959" height="541" alt="image" src="https://github.com/user-attachments/assets/49831e09-402b-4900-926c-fdb913209411" /> | 

Note the errant "div" child in Before that is absent in After.

## Testing guidance

Load the homepage on staging with JS disabled and ensure the children of `.latest-data-insights__card-container` are formatted correctly.
