### PR TITLE
chore: add remote dev config for vite

### DIFF
--- a/.env.example-full
+++ b/.env.example-full
@@ -62,3 +62,9 @@ DATA_API_URL= # optional
 
 SLACK_BOT_OAUTH_TOKEN= # optional
 SLACK_DI_PITCHES_CHANNEL_ID= # optional; #data-insight-pitches channel id
+
+# for remote dev on tailscale without localhost + port forwarding
+ADMIN_SERVER_HOST= # optional; e.g: YOURMACHINE.TAILXXX.ts.net (find this in the tailscale admin panel)
+ADMIN_BASE_URL= # optional; e.g: http://YOURMACHINE.TAILXXX.ts.net
+VITE_HOST= # optional; e.g: YOURMACHINE.TAILXXX.ts.net
+VITE_DEV_URL= # optional; e.g: http://YOURMACHINE.TAILXXX.ts.net:8090

--- a/vite.config-common.mts
+++ b/vite.config-common.mts
@@ -78,6 +78,13 @@ export const defineViteConfigForEntrypoint = (entrypoint: ViteEntryPoint) => {
         server: {
             port: 8090,
             warmup: { clientFiles: [VITE_ASSET_SITE_ENTRY] },
+            // remote dev setup
+            ...(process.env.VITE_HOST
+                ? {
+                      host: process.env.VITE_HOST,
+                      cors: true,
+                  }
+                : {}),
         },
         preview: {
             port: 8090,


### PR DESCRIPTION
## Context

This PR adds environment variables to support remote development on Tailscale without requiring localhost and port forwarding.

A simpler version of #5381 (without https support)

## Testing guidance

1. Copy the new environment variables from `.env.example-full` to your `.env` file
2. Set the variables with your Tailscale information:
   - `ADMIN_SERVER_HOST`: Your machine name (e.g., `YOURMACHINE.TAILXXX.ts.net`)
   - `ADMIN_BASE_URL`: Full URL (e.g., `http://YOURMACHINE.TAILXXX.ts.net`)
   - `VITE_HOST`: Your machine name (e.g., `YOURMACHINE.TAILXXX.ts.net`)
   - `VITE_DEV_URL`: Full URL with port (e.g., `http://YOURMACHINE.TAILXXX.ts.net:8090`)
3. Start the development server and verify you can access it via your Tailscale URL