### PR TITLE
Rename archive variables to better match types

### DIFF
--- a/baker/ExplorerBaker.tsx
+++ b/baker/ExplorerBaker.tsx
@@ -41,7 +41,7 @@ const bakeExplorersToDir = async (
         await write(
             `${directory}/${explorer.slug}.html`,
             await renderExplorerPage(explorer, knex, {
-                archivedChartInfo: latestArchivedBySlug[explorer.slug],
+                archiveContext: latestArchivedBySlug[explorer.slug],
             })
         )
     }
@@ -104,7 +104,7 @@ export const bakeSingleExplorerPageForArchival = async (
     await fs.writeFile(
         outPathHtml,
         await renderExplorerPage(program, knex, {
-            archivedChartInfo: archiveInfo,
+            archiveContext: archiveInfo,
         })
     )
     const outPathManifest = `${bakedSiteDir}/explorers/${program.slug}.manifest.json`

--- a/baker/MultiDimBaker.tsx
+++ b/baker/MultiDimBaker.tsx
@@ -118,14 +118,14 @@ export async function renderMultiDimDataPageFromConfig({
     config,
     imageMetadataDictionary,
     isPreviewing = false,
-    archiveInfo,
+    archiveContext,
 }: {
     knex: db.KnexReadonlyTransaction
     slug: string | null
     config: MultiDimDataPageConfigEnriched
     imageMetadataDictionary?: Record<string, ImageMetadata>
     isPreviewing?: boolean
-    archiveInfo?: ArchiveContext
+    archiveContext?: ArchiveContext
 }) {
     const pageConfig = MultiDimDataPageConfig.fromObject(config)
     const variableIds = getRelevantVariableIds(config)
@@ -144,7 +144,7 @@ export async function renderMultiDimDataPageFromConfig({
 
     // If we're baking to an archival page, then we want to skip a bunch of sections
     // where the links would break
-    if (archiveInfo?.type !== "archive-page") {
+    if (archiveContext?.type !== "archive-page") {
         // TAGS
         const fullTagToSlugMap = await getTagToSlugMap(knex)
         // Only embed the tags that are actually used by the datapage, instead of the complete JSON object with ~240 properties
@@ -177,8 +177,8 @@ export async function renderMultiDimDataPageFromConfig({
     }
 
     let canonicalUrl: string
-    if (archiveInfo?.type === "archive-page") {
-        canonicalUrl = archiveInfo.archiveUrl
+    if (archiveContext?.type === "archive-page") {
+        canonicalUrl = archiveContext.archiveUrl
     } else {
         canonicalUrl = slug ? `${BAKED_GRAPHER_URL}/${slug}` : ""
     }
@@ -194,7 +194,7 @@ export async function renderMultiDimDataPageFromConfig({
         relatedResearchCandidates,
         imageMetadata,
         isPreviewing,
-        archivedChartInfo: archiveInfo,
+        archiveContext,
     }
 
     return renderMultiDimDataPageFromProps(props)
@@ -217,7 +217,7 @@ export const renderMultiDimDataPageBySlug = async (
         knex,
         slug,
         config: dbRow.config,
-        archiveInfo: archivedVersion[dbRow.id],
+        archiveContext: archivedVersion[dbRow.id],
     })
 }
 
@@ -240,7 +240,7 @@ export async function renderMultiDimDataPageByCatalogPath(
         knex,
         slug: dbRow.slug,
         config: dbRow.config,
-        archiveInfo: archivedVersion[dbRow.id],
+        archiveContext: archivedVersion[dbRow.id],
     })
 }
 
@@ -263,7 +263,7 @@ export const bakeMultiDimDataPage = async (
         slug,
         config,
         imageMetadataDictionary: imageMetadata,
-        archiveInfo: archivedVersion,
+        archiveContext: archivedVersion,
     })
     const outPath = path.join(bakedSiteDir, `grapher/${slug}.html`)
     await fs.writeFile(outPath, renderedHtml)
@@ -336,7 +336,7 @@ export const bakeSingleMultiDimDataPageForArchival = async (
             config,
             imageMetadataDictionary,
             isPreviewing: false,
-            archiveInfo,
+            archiveContext: archiveInfo,
         })
     )
     const outPathManifest = `${bakedSiteDir}/grapher/${slug}.manifest.json`

--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -368,7 +368,7 @@ export class SiteBaker {
                                 chart.config,
                                 chart.slug,
                                 {
-                                    archivedChartInfo:
+                                    archivedPageVersion:
                                         archivedVersions.charts[chart.id] ||
                                         undefined,
                                 }
@@ -382,7 +382,7 @@ export class SiteBaker {
             for (const { id, slug, config } of multiDims) {
                 publishedCharts.push(
                     makeMultiDimLinkedChart(config, slug, {
-                        archivedChartInfo:
+                        archivedPageVersion:
                             archivedVersions.multiDims[id] || undefined,
                     })
                 )

--- a/baker/siteRenderers.tsx
+++ b/baker/siteRenderers.tsx
@@ -658,7 +658,7 @@ export const renderExplorerIndexPage = async (
 interface ExplorerRenderOpts {
     urlMigrationSpec?: ExplorerPageUrlMigrationSpec
     isPreviewing?: boolean
-    archivedChartInfo?: ArchiveContext
+    archiveContext?: ArchiveContext
 }
 
 export const renderExplorerPage = async (
@@ -779,7 +779,7 @@ export const renderExplorerPage = async (
           )
         : undefined
 
-    let archiveContext = opts?.archivedChartInfo
+    let archiveContext = opts?.archiveContext
     if (!archiveContext) {
         const latestBySlug = await getLatestExplorerArchivedVersionsIfEnabled(
             knex,
@@ -799,7 +799,7 @@ export const renderExplorerPage = async (
                 baseUrl={BAKED_BASE_URL}
                 urlMigrationSpec={opts?.urlMigrationSpec}
                 isPreviewing={opts?.isPreviewing}
-                archivedChartInfo={archiveContext}
+                archiveContext={archiveContext}
             />
         )
     )

--- a/db/model/Gdoc/GdocBase.ts
+++ b/db/model/Gdoc/GdocBase.ts
@@ -770,7 +770,7 @@ export class GdocBase implements OwidGdocBaseInterface {
                         chart.config,
                         originalSlug,
                         {
-                            archivedChartInfo:
+                            archivedPageVersion:
                                 archivedChartVersions[chartId] || undefined,
                         }
                     )
@@ -786,7 +786,7 @@ export class GdocBase implements OwidGdocBaseInterface {
                         multiDim.config,
                         originalSlug,
                         {
-                            archivedChartInfo:
+                            archivedPageVersion:
                                 archivedMultiDimVersions[multiDim.id] ||
                                 undefined,
                         }
@@ -1202,7 +1202,7 @@ export async function makeGrapherLinkedChart(
     knex: db.KnexReadonlyTransaction,
     config: GrapherInterface,
     originalSlug: string,
-    { archivedChartInfo }: { archivedChartInfo?: ArchivedPageVersion } = {}
+    { archivedPageVersion }: { archivedPageVersion?: ArchivedPageVersion } = {}
 ): Promise<LinkedChart> {
     const resolvedSlug = config.slug ?? ""
     const resolvedTitle = config.title ?? ""
@@ -1223,7 +1223,7 @@ export async function makeGrapherLinkedChart(
         thumbnail: `${GRAPHER_DYNAMIC_THUMBNAIL_URL}/${resolvedSlug}.png`,
         tags: [],
         indicatorId,
-        archivedChartInfo,
+        archivedPageVersion,
     }
 }
 
@@ -1254,7 +1254,7 @@ export function makeExplorerLinkedChart(
 export function makeMultiDimLinkedChart(
     config: MultiDimDataPageConfigEnriched,
     slug: string,
-    { archivedChartInfo }: { archivedChartInfo?: ArchivedPageVersion } = {}
+    { archivedPageVersion }: { archivedPageVersion?: ArchivedPageVersion } = {}
 ): LinkedChart {
     let title = config.title.title
     const titleVariant = config.title.titleVariant
@@ -1268,6 +1268,6 @@ export function makeMultiDimLinkedChart(
         dimensionSlugs: config.dimensions.map((d) => d.slug),
         resolvedUrl: `${BAKED_GRAPHER_URL}/${slug}`,
         tags: [],
-        archivedChartInfo,
+        archivedPageVersion,
     }
 }

--- a/db/model/Gdoc/GdocPost.ts
+++ b/db/model/Gdoc/GdocPost.ts
@@ -181,7 +181,7 @@ export class GdocPost extends GdocBase implements OwidGdocPostInterface {
 
         this.relatedCharts = relatedCharts.map((chart) => ({
             ...chart,
-            archivedChartInfo: archivedVersions[chart.chartId] || undefined,
+            archiveContext: archivedVersions[chart.chartId] || undefined,
         }))
     }
 }

--- a/packages/@ourworldindata/explorer/src/Explorer.tsx
+++ b/packages/@ourworldindata/explorer/src/Explorer.tsx
@@ -94,7 +94,7 @@ export interface ExplorerProps extends SerializedGridProgram {
     loadMetadataOnly?: boolean
     throwOnMissingGrapher?: boolean
     setupGrapher?: boolean
-    archivedChartInfo?: ArchiveContext
+    archiveContext?: ArchiveContext
 }
 
 const LivePreviewComponent = (props: ExplorerProps) => {
@@ -226,11 +226,9 @@ export class Explorer
         this.explorerProgram = ExplorerProgram.fromJson(
             props
         ).initDecisionMatrix(this.initialQueryParams)
-        const { archivedChartInfo } = props
-        const isOnArchivalPage = archivedChartInfo?.type === "archive-page"
-        const assetMaps = isOnArchivalPage
-            ? archivedChartInfo?.assets
-            : undefined
+        const { archiveContext } = props
+        const isOnArchivalPage = archiveContext?.type === "archive-page"
+        const assetMaps = isOnArchivalPage ? archiveContext?.assets : undefined
         this.isOnArchivalPage = isOnArchivalPage
         this.grapherState = new GrapherState({
             staticBounds: props.staticBounds,
@@ -240,7 +238,7 @@ export class Explorer
             isEmbeddedInAnOwidPage: this.props.isEmbeddedInAnOwidPage,
             adminBaseUrl: this.adminBaseUrl,
             canHideExternalControlsInEmbed: true,
-            archivedChartInfo: props.archivedChartInfo,
+            archiveContext: props.archiveContext,
             additionalDataLoaderFn: (
                 varId: number,
                 loadMetadataOnly?: boolean
@@ -262,7 +260,7 @@ export class Explorer
         partialGrapherConfigs: GrapherInterface[],
         explorerConstants: Record<string, string>,
         urlMigrationSpec?: ExplorerPageUrlMigrationSpec,
-        archivedChartInfo?: ArchiveContext
+        archiveContext?: ArchiveContext
     ) {
         const props: ExplorerProps = {
             ...program,
@@ -271,7 +269,7 @@ export class Explorer
             partialGrapherConfigs,
             isEmbeddedInAnOwidPage: false,
             isInStandalonePage: true,
-            archivedChartInfo,
+            archiveContext,
         }
 
         if (window.location.href.includes(EXPLORERS_PREVIEW_ROUTE)) {
@@ -652,7 +650,7 @@ export class Explorer
                 config.dimensions ?? [],
                 config.selectedEntityColors,
                 this.props.dataApiUrl,
-                this.props.archivedChartInfo,
+                this.props.archiveContext,
                 this.props.isPreview,
                 this.props.loadMetadataOnly
             ).then((owidTable) => (owidTable ? owidTable : BlankOwidTable()))
@@ -840,7 +838,7 @@ export class Explorer
                 config.dimensions,
                 config.selectedEntityColors,
                 this.props.dataApiUrl,
-                this.props.archivedChartInfo,
+                this.props.archiveContext,
                 this.props.isPreview,
                 this.props.loadMetadataOnly
             ).then((owidTable) => (owidTable ? owidTable : BlankOwidTable()))
@@ -1144,7 +1142,7 @@ export class Explorer
     @computed get baseUrl() {
         let archiveUrl = undefined
         if (this.isOnArchivalPage) {
-            archiveUrl = this.props.archivedChartInfo?.archiveUrl
+            archiveUrl = this.props.archiveContext?.archiveUrl
         }
         return (
             archiveUrl ??

--- a/packages/@ourworldindata/grapher/src/core/FetchingGrapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/FetchingGrapher.tsx
@@ -18,7 +18,7 @@ export interface FetchingGrapherProps {
     config?: GrapherProgrammaticInterface
     configUrl?: string
     dataApiUrl: string
-    archivedChartInfo: ArchiveContext | undefined
+    archiveContext: ArchiveContext | undefined
     queryStr?: string
     externalBounds?: Bounds
     noCache?: boolean
@@ -122,7 +122,7 @@ export function FetchingGrapher(
                 downloadedConfig?.selectedEntityColors ??
                     props.config?.selectedEntityColors,
                 props.dataApiUrl,
-                props.archivedChartInfo,
+                props.archiveContext,
                 props.noCache
             )
 
@@ -141,7 +141,7 @@ export function FetchingGrapher(
         downloadedConfig?.dimensions,
         downloadedConfig?.selectedEntityColors,
         props.config?.selectedEntityColors,
-        props.archivedChartInfo,
+        props.archiveContext,
         props.noCache,
         grapherState,
     ])

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -286,7 +286,7 @@ export interface GrapherProgrammaticInterface extends GrapherInterface {
     canHideExternalControlsInEmbed?: boolean
 
     narrativeChartInfo?: MinimalNarrativeChartInfo
-    archivedChartInfo?: ArchiveContext
+    archiveContext?: ArchiveContext
 
     manager?: GrapherManager
     additionalDataLoaderFn?: AdditionalGrapherDataFetchFn
@@ -462,7 +462,7 @@ export class GrapherState {
         this.canHideExternalControlsInEmbed
 
     narrativeChartInfo?: MinimalNarrativeChartInfo = undefined
-    archivedChartInfo?: ArchiveContext
+    archiveContext?: ArchiveContext
 
     selection: SelectionArray = new SelectionArray()
     focusArray = new FocusArray()
@@ -636,7 +636,7 @@ export class GrapherState {
         this.staticBounds = options.staticBounds ?? DEFAULT_GRAPHER_BOUNDS
 
         this.narrativeChartInfo = options.narrativeChartInfo
-        this.archivedChartInfo = options.archivedChartInfo
+        this.archiveContext = options.archiveContext
 
         this.populateFromQueryParams(
             legacyToCurrentGrapherQueryParams(
@@ -1001,16 +1001,16 @@ export class GrapherState {
     }
 
     @computed get isOnArchivalPage(): boolean {
-        return this.archivedChartInfo?.type === "archive-page"
+        return this.archiveContext?.type === "archive-page"
     }
 
     @computed get hasArchivedPage(): boolean {
-        return this.archivedChartInfo?.type === "archived-page-version"
+        return this.archiveContext?.type === "archived-page-version"
     }
 
     @computed private get runtimeAssetMap(): AssetMap | undefined {
-        return this.archivedChartInfo?.type === "archive-page"
-            ? this.archivedChartInfo.assets.runtime
+        return this.archiveContext?.type === "archive-page"
+            ? this.archiveContext.assets.runtime
             : undefined
     }
 
@@ -3230,7 +3230,7 @@ export class GrapherState {
         })
     }
     @computed get baseUrl(): string | undefined {
-        if (this.isOnArchivalPage) return this.archivedChartInfo?.archiveUrl
+        if (this.isOnArchivalPage) return this.archiveContext?.archiveUrl
 
         return this.isPublished
             ? `${this.bakedGrapherURL ?? "/grapher"}/${this.displaySlug}`
@@ -3292,8 +3292,8 @@ export class GrapherState {
     }
 
     @computed get embedArchivedUrl(): string | undefined {
-        if (!this.archivedChartInfo) return undefined
-        const baseUrl = this.archivedChartInfo.archiveUrl + this.queryStr
+        if (!this.archiveContext) return undefined
+        const baseUrl = this.archiveContext.archiveUrl + this.queryStr
         return this.makeEmbedUrl(baseUrl)
     }
 

--- a/packages/@ourworldindata/grapher/src/core/GrapherUseHelpers.tsx
+++ b/packages/@ourworldindata/grapher/src/core/GrapherUseHelpers.tsx
@@ -16,9 +16,9 @@ export function renderGrapherIntoContainer(
     containerNode: Element,
     dataApiUrl: string,
     {
-        archivedChartInfo,
+        archiveContext,
         noCache,
-    }: { archivedChartInfo?: ArchiveContext; noCache?: boolean } = {}
+    }: { archiveContext?: ArchiveContext; noCache?: boolean } = {}
 ): void {
     const reactRoot = createRoot(containerNode)
 
@@ -48,7 +48,7 @@ export function renderGrapherIntoContainer(
                 <FetchingGrapher
                     config={grapherConfigWithBounds}
                     dataApiUrl={dataApiUrl}
-                    archivedChartInfo={archivedChartInfo}
+                    archiveContext={archiveContext}
                     externalBounds={Bounds.fromRect(entry.contentRect)}
                     queryStr={grapherConfigWithBounds.queryStr}
                     noCache={noCache}
@@ -81,9 +81,9 @@ export function renderSingleGrapherOnGrapherPage(
     jsonConfig: GrapherProgrammaticInterface,
     dataApiUrl: string,
     {
-        archivedChartInfo,
+        archiveContext,
         noCache,
-    }: { archivedChartInfo?: ArchiveContext; noCache?: boolean } = {}
+    }: { archiveContext?: ArchiveContext; noCache?: boolean } = {}
 ): void {
     const container = document.getElementsByTagName("figure")[0]
     try {
@@ -93,11 +93,11 @@ export function renderSingleGrapherOnGrapherPage(
                 bindUrlToWindow: true,
                 enableKeyboardShortcuts: true,
                 queryStr: window.location.search,
-                archivedChartInfo,
+                archiveContext,
             },
             container,
             dataApiUrl,
-            { archivedChartInfo, noCache }
+            { archiveContext, noCache }
         )
     } catch (err) {
         container.innerHTML = `<p>Unable to load interactive visualization</p>`

--- a/packages/@ourworldindata/grapher/src/core/loadGrapherTableHelpers.ts
+++ b/packages/@ourworldindata/grapher/src/core/loadGrapherTableHelpers.ts
@@ -18,7 +18,7 @@ export async function fetchInputTableForConfig(
         | { [entityName: string]: string | undefined }
         | undefined,
     dataApiUrl: string,
-    archivedChartInfo: ArchiveContext | undefined,
+    archiveContext: ArchiveContext | undefined,
     noCache?: boolean,
     loadMetadataOnly?: boolean
 ): Promise<OwidTable | undefined> {
@@ -27,7 +27,7 @@ export async function fetchInputTableForConfig(
     const variablesDataMap = await loadVariablesDataSite(
         variables,
         dataApiUrl,
-        archivedChartInfo,
+        archiveContext,
         noCache,
         loadMetadataOnly
     )
@@ -42,7 +42,7 @@ export async function fetchInputTableForConfig(
 
 export function getCachingInputTableFetcher(
     dataApiUrl: string,
-    archivedChartInfo: ArchiveContext | undefined,
+    archiveContext: ArchiveContext | undefined,
     noCache?: boolean,
     loadMetadataOnly?: boolean
 ): (
@@ -88,8 +88,8 @@ export function getCachingInputTableFetcher(
                 variablesToFetch.map((variableId) =>
                     loadVariableDataAndMetadata(variableId, dataApiUrl, {
                         assetMap:
-                            archivedChartInfo?.type === "archive-page"
-                                ? archivedChartInfo.assets.runtime
+                            archiveContext?.type === "archive-page"
+                                ? archiveContext.assets.runtime
                                 : undefined,
                         noCache,
                         loadMetadataOnly,

--- a/packages/@ourworldindata/grapher/src/core/loadVariable.ts
+++ b/packages/@ourworldindata/grapher/src/core/loadVariable.ts
@@ -81,15 +81,15 @@ export async function loadVariableDataAndMetadata(
 export async function loadVariablesDataSite(
     variableIds: number[],
     dataApiUrl: string,
-    archivedChartInfo: ArchiveContext | undefined,
+    archiveContext: ArchiveContext | undefined,
     noCache?: boolean,
     loadMetadataOnly?: boolean
 ): Promise<MultipleOwidVariableDataDimensionsMap> {
     const loadVariableDataPromises = variableIds.map((variableId) =>
         loadVariableDataAndMetadata(variableId, dataApiUrl, {
             assetMap:
-                archivedChartInfo?.type === "archive-page"
-                    ? archivedChartInfo.assets.runtime
+                archiveContext?.type === "archive-page"
+                    ? archiveContext.assets.runtime
                     : undefined,
             noCache,
             loadMetadataOnly,

--- a/packages/@ourworldindata/types/src/gdocTypes/Datapage.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/Datapage.ts
@@ -137,7 +137,7 @@ export interface DataPageV2ContentFields {
     canonicalUrl: string
     tagToSlugMap: Record<string, string>
     imageMetadata: Record<string, ImageMetadata>
-    archivedChartInfo?: ArchiveContext
+    archiveContext?: ArchiveContext
 }
 
 export interface DisplaySource {

--- a/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
@@ -59,7 +59,7 @@ export interface LinkedChart {
     tags: string[]
     tab?: GrapherTabConfigOption
     indicatorId?: number // in case of a datapage
-    archivedChartInfo?: ArchivedPageVersion | undefined
+    archivedPageVersion?: ArchivedPageVersion | undefined
     dimensionSlugs?: string[] // for validating mdim links, to make sure the query params are correct
 }
 

--- a/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
+++ b/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
@@ -97,7 +97,7 @@ export interface BasicChartInformation {
 export interface RelatedChart extends BasicChartInformation {
     chartId: number
     keyChartLevel?: KeyChartLevel
-    archivedChartInfo?: ArchiveContext | undefined
+    archiveContext?: ArchiveContext | undefined
 }
 export enum DimensionProperty {
     y = "y",

--- a/packages/@ourworldindata/types/src/siteTypes/MultiDimDataPage.ts
+++ b/packages/@ourworldindata/types/src/siteTypes/MultiDimDataPage.ts
@@ -120,5 +120,5 @@ export interface MultiDimDataPageProps {
     relatedResearchCandidates: DataPageRelatedResearch[]
     imageMetadata: Record<string, ImageMetadata>
     isPreviewing?: boolean
-    archivedChartInfo?: ArchiveContext
+    archiveContext?: ArchiveContext
 }

--- a/site/DataPageV2.tsx
+++ b/site/DataPageV2.tsx
@@ -43,7 +43,7 @@ export const DataPageV2 = (props: {
     faqEntries?: FaqEntryData
     imageMetadata: Record<string, ImageMetadata>
     tagToSlugMap: Record<string | number, string>
-    archivedChartInfo?: ArchiveContext
+    archiveContext?: ArchiveContext
     dataApiUrl?: string
 }) => {
     const {
@@ -55,7 +55,7 @@ export const DataPageV2 = (props: {
         faqEntries,
         tagToSlugMap,
         imageMetadata,
-        archivedChartInfo,
+        archiveContext,
     } = props
     const pageTitle = grapher?.title ?? datapageData.title.title
     const dataApiOrigin = Url.fromURL(DATA_API_URL).origin
@@ -101,13 +101,12 @@ export const DataPageV2 = (props: {
         datapageData.topicTagsLinks || []
     )
 
-    const isOnArchivalPage = archivedChartInfo?.type === "archive-page"
-    const assetMaps = isOnArchivalPage ? archivedChartInfo.assets : undefined
+    const isOnArchivalPage = archiveContext?.type === "archive-page"
+    const assetMaps = isOnArchivalPage ? archiveContext.assets : undefined
 
-    const liveUrlIfIsArchive =
-        archivedChartInfo?.type === "archive-page"
-            ? archivedChartInfo.archiveNavigation.liveUrl
-            : undefined
+    const liveUrlIfIsArchive = isOnArchivalPage
+        ? archiveContext.archiveNavigation.liveUrl
+        : undefined
     const canonicalUrlForHead = liveUrlIfIsArchive ?? canonicalUrl
 
     return (
@@ -119,7 +118,7 @@ export const DataPageV2 = (props: {
                 imageUrl={imageUrl}
                 baseUrl={baseUrl}
                 staticAssetMap={assetMaps?.static}
-                archivedChartInfo={archivedChartInfo}
+                archiveContext={archiveContext}
             >
                 <meta property="og:image:width" content={imageWidth} />
                 <meta property="og:image:height" content={imageHeight} />
@@ -153,9 +152,7 @@ export const DataPageV2 = (props: {
             </Head>
             <body className="DataPage">
                 <SiteHeader
-                    archiveInfo={
-                        isOnArchivalPage ? archivedChartInfo : undefined
-                    }
+                    archiveInfo={isOnArchivalPage ? archiveContext : undefined}
                 />
                 <main>
                     <script
@@ -165,7 +162,7 @@ export const DataPageV2 = (props: {
                                     datapageData,
                                     faqEntries,
                                     canonicalUrl,
-                                    archivedChartInfo,
+                                    archiveContext,
                                     tagToSlugMap: minimalTagToSlugMap,
                                     imageMetadata,
                                 }
@@ -182,7 +179,7 @@ export const DataPageV2 = (props: {
                                 faqEntries={faqEntries}
                                 canonicalUrl={canonicalUrl}
                                 tagToSlugMap={tagToSlugMap}
-                                archivedChartInfo={archivedChartInfo}
+                                archiveContext={archiveContext}
                             />
                         </DebugProvider>
                     </div>
@@ -190,9 +187,7 @@ export const DataPageV2 = (props: {
                 <SiteFooter
                     context={SiteFooterContext.dataPageV2}
                     isPreviewing={isPreviewing}
-                    archiveInfo={
-                        isOnArchivalPage ? archivedChartInfo : undefined
-                    }
+                    archiveInfo={isOnArchivalPage ? archiveContext : undefined}
                 />
                 <script
                     dangerouslySetInnerHTML={{

--- a/site/DataPageV2Content.tsx
+++ b/site/DataPageV2Content.tsx
@@ -54,7 +54,7 @@ export const DataPageV2Content = ({
     canonicalUrl = "{URL}", // when we bake pages to their proper url this will be set correctly but on preview pages we leave this undefined
     tagToSlugMap,
     imageMetadata,
-    archivedChartInfo,
+    archiveContext,
 }: DataPageV2ContentFields & {
     grapherConfig: GrapherInterface
     imageMetadata: Record<string, ImageMetadata>
@@ -72,9 +72,9 @@ export const DataPageV2Content = ({
             adminBaseUrl: ADMIN_BASE_URL,
             bakedGrapherURL: BAKED_GRAPHER_URL,
             enableKeyboardShortcuts: typeof window !== "undefined",
-            archivedChartInfo,
+            archiveContext,
         }),
-        [grapherConfig, archivedChartInfo]
+        [grapherConfig, archiveContext]
     )
     const stickyNavLinks = excludeNull([
         {
@@ -304,7 +304,7 @@ export const DataPageV2Content = ({
                         source={datapageData.source}
                         title={datapageData.title}
                         titleVariant={datapageData.titleVariant}
-                        archivedChartInfo={archivedChartInfo}
+                        archiveContext={archiveContext}
                     />
                 </div>
             </DocumentContext.Provider>

--- a/site/ExplorerPage.tsx
+++ b/site/ExplorerPage.tsx
@@ -37,7 +37,7 @@ interface ExplorerPageSettings {
     baseUrl: string
     urlMigrationSpec?: ExplorerPageUrlMigrationSpec
     isPreviewing?: boolean
-    archivedChartInfo?: ArchiveContext
+    archiveContext?: ArchiveContext
 }
 
 const ExplorerContent = ({ content }: { content: string }) => {
@@ -69,7 +69,7 @@ export const ExplorerPage = (props: ExplorerPageSettings) => {
         partialGrapherConfigs,
         baseUrl,
         urlMigrationSpec,
-        archivedChartInfo,
+        archiveContext,
     } = props
     const {
         subNavId,
@@ -81,8 +81,8 @@ export const ExplorerPage = (props: ExplorerPageSettings) => {
         hideAlertBanner,
     } = program
 
-    const isOnArchivalPage = archivedChartInfo?.type === "archive-page"
-    const assetMaps = isOnArchivalPage ? archivedChartInfo.assets : undefined
+    const isOnArchivalPage = archiveContext?.type === "archive-page"
+    const assetMaps = isOnArchivalPage ? archiveContext.assets : undefined
 
     const subNav = subNavId ? (
         <SiteSubnavigation
@@ -115,14 +115,14 @@ const explorerConstants = ${serializeJSONForHTML(
         },
         EXPLORER_CONSTANTS_DELIMITER
     )}
-const archivedChartInfo = ${JSON.stringify(archivedChartInfo)};
+const archiveContext = ${JSON.stringify(archiveContext)};
 window.Explorer.renderSingleExplorerOnExplorerPage(
     explorerProgram,
     grapherConfigs,
     partialGrapherConfigs,
     explorerConstants,
     urlMigrationSpec,
-    archivedChartInfo
+    archiveContext
 );`
 
     return (
@@ -134,16 +134,14 @@ window.Explorer.renderSingleExplorerOnExplorerPage(
                 imageUrl={thumbnail}
                 baseUrl={baseUrl}
                 staticAssetMap={assetMaps?.static}
-                archivedChartInfo={archivedChartInfo}
+                archiveContext={archiveContext}
             >
                 <IFrameDetector />
             </Head>
             <body className={GRAPHER_PAGE_BODY_CLASS}>
                 <SiteHeader
                     hideAlertBanner={hideAlertBanner || false}
-                    archiveInfo={
-                        isOnArchivalPage ? archivedChartInfo : undefined
-                    }
+                    archiveInfo={isOnArchivalPage ? archiveContext : undefined}
                 />
                 {subNav}
                 <main id={ExplorerContainerId}>
@@ -154,9 +152,7 @@ window.Explorer.renderSingleExplorerOnExplorerPage(
                 <SiteFooter
                     context={SiteFooterContext.explorerPage}
                     isPreviewing={props.isPreviewing}
-                    archiveInfo={
-                        isOnArchivalPage ? archivedChartInfo : undefined
-                    }
+                    archiveInfo={isOnArchivalPage ? archiveContext : undefined}
                 />
                 <script
                     type="module"

--- a/site/GrapherFigureView.tsx
+++ b/site/GrapherFigureView.tsx
@@ -72,7 +72,7 @@ export function GrapherFigureView(
                     config={config}
                     configUrl={configUrl}
                     dataApiUrl={DATA_API_URL}
-                    archivedChartInfo={config.archivedChartInfo}
+                    archiveContext={config.archiveContext}
                     queryStr={props.queryStr}
                     externalBounds={bounds}
                     noCache={props.isPreviewing}

--- a/site/GrapherPage.tsx
+++ b/site/GrapherPage.tsx
@@ -40,7 +40,7 @@ export const GrapherPage = (props: {
     relatedArticles?: PostReference[]
     baseUrl: string
     baseGrapherUrl: string
-    archivedChartInfo?: ArchiveContext
+    archiveContext?: ArchiveContext
     isPreviewing?: boolean
 }) => {
     const {
@@ -49,15 +49,17 @@ export const GrapherPage = (props: {
         relatedArticles,
         baseGrapherUrl,
         baseUrl,
-        archivedChartInfo,
+        archiveContext,
         isPreviewing,
     } = props
     const pageTitle = grapher.title
 
-    const liveUrlIfIsArchive =
-        archivedChartInfo?.type === "archive-page"
-            ? archivedChartInfo.archiveNavigation.liveUrl
-            : undefined
+    const isOnArchivalPage = archiveContext?.type === "archive-page"
+    const assetMaps = isOnArchivalPage ? archiveContext.assets : undefined
+
+    const liveUrlIfIsArchive = isOnArchivalPage
+        ? archiveContext.archiveNavigation.liveUrl
+        : undefined
 
     const canonicalUrl =
         liveUrlIfIsArchive ?? urljoin(baseGrapherUrl, grapher.slug as string)
@@ -92,14 +94,11 @@ export const GrapherPage = (props: {
         adminBaseUrl: ADMIN_BASE_URL,
         bakedGrapherURL: BAKED_GRAPHER_URL,
     })}
-const archivedChartInfo = ${JSON.stringify(archivedChartInfo || undefined)}
+const archiveContext = ${JSON.stringify(archiveContext || undefined)}
 const isPreviewing = ${isPreviewing}
-window.renderSingleGrapherOnGrapherPage(jsonConfig, "${DATA_API_URL}", { archivedChartInfo, isPreviewing })`
+window.renderSingleGrapherOnGrapherPage(jsonConfig, "${DATA_API_URL}", { archiveContext, isPreviewing })`
 
     const variableIds = _.uniq(grapher.dimensions!.map((d) => d.variableId))
-
-    const isOnArchivalPage = archivedChartInfo?.type === "archive-page"
-    const assetMaps = isOnArchivalPage ? archivedChartInfo.assets : undefined
 
     return (
         <Html>
@@ -110,7 +109,7 @@ window.renderSingleGrapherOnGrapherPage(jsonConfig, "${DATA_API_URL}", { archive
                 imageUrl={imageUrl}
                 baseUrl={baseUrl}
                 staticAssetMap={assetMaps?.static}
-                archivedChartInfo={archivedChartInfo}
+                archiveContext={archiveContext}
             >
                 <meta property="og:image:width" content={imageWidth} />
                 <meta property="og:image:height" content={imageHeight} />
@@ -146,9 +145,7 @@ window.renderSingleGrapherOnGrapherPage(jsonConfig, "${DATA_API_URL}", { archive
             </Head>
             <body className={GRAPHER_PAGE_BODY_CLASS}>
                 <SiteHeader
-                    archiveInfo={
-                        isOnArchivalPage ? archivedChartInfo : undefined
-                    }
+                    archiveInfo={isOnArchivalPage ? archiveContext : undefined}
                 />
                 <main>
                     <figure
@@ -202,9 +199,7 @@ window.renderSingleGrapherOnGrapherPage(jsonConfig, "${DATA_API_URL}", { archive
                 </main>
                 <SiteFooter
                     context={SiteFooterContext.grapherPage}
-                    archiveInfo={
-                        isOnArchivalPage ? archivedChartInfo : undefined
-                    }
+                    archiveInfo={isOnArchivalPage ? archiveContext : undefined}
                     isPreviewing={isPreviewing}
                 />
                 <script

--- a/site/Head.tsx
+++ b/site/Head.tsx
@@ -47,7 +47,7 @@ export const Head = (props: {
         href: string
     }
     staticAssetMap?: AssetMap
-    archivedChartInfo?: ArchiveContext
+    archiveContext?: ArchiveContext
 }) => {
     const { canonicalUrl, baseUrl } = props
     const pageTitle = props.pageTitle || `Our World in Data`
@@ -69,10 +69,8 @@ export const Head = (props: {
     }).forHeader
 
     let archivalDateStr = undefined
-    if (props.archivedChartInfo?.archivalDate) {
-        archivalDateStr = parseArchivalDate(
-            props.archivedChartInfo?.archivalDate
-        )
+    if (props.archiveContext?.archivalDate) {
+        archivalDateStr = parseArchivalDate(props.archiveContext?.archivalDate)
             .utc()
             .format("YYYY-MM-DD")
     }
@@ -92,12 +90,12 @@ export const Head = (props: {
                 href={atom.href}
                 title={atom.title}
             />
-            {props.archivedChartInfo && (
+            {props.archiveContext && (
                 <link
                     rel="archives"
-                    href={props.archivedChartInfo.archiveUrl}
+                    href={props.archiveContext.archiveUrl}
                     title={`Archived version of this chart as of ${archivalDateStr}`}
-                    data-archival-date={props.archivedChartInfo.archivalDate}
+                    data-archival-date={props.archiveContext.archivalDate}
                 />
             )}
             <link

--- a/site/MetadataSection.tsx
+++ b/site/MetadataSection.tsx
@@ -38,7 +38,7 @@ export default function MetadataSection({
     source,
     title,
     titleVariant,
-    archivedChartInfo,
+    archiveContext,
 }: {
     attributionShort?: string
     attributions: string[]
@@ -51,10 +51,10 @@ export default function MetadataSection({
     source?: OwidSource
     title: IndicatorTitleWithFragments
     titleVariant?: string
-    archivedChartInfo?: ArchiveContext
+    archiveContext?: ArchiveContext
 }) {
     const sourcesForDisplay = prepareSourcesForDisplay({ origins, source })
-    const citationUrl = archivedChartInfo?.archiveUrl ?? canonicalUrl
+    const citationUrl = archiveContext?.archiveUrl ?? canonicalUrl
     const citationShort = getCitationShort(
         origins,
         attributions,
@@ -69,7 +69,7 @@ export default function MetadataSection({
         titleVariant,
         owidProcessingLevel,
         citationUrl,
-        archivedChartInfo?.archivalDate
+        archiveContext?.archivalDate
     )
     const currentYear = dayjs().year()
     const producers = _.uniq(origins.map((o) => `${o.producer}`))
@@ -82,7 +82,7 @@ export default function MetadataSection({
     // For the citation of the data page add a period it doesn't have that or a question mark
     const primaryTopicCitation = maybeAddPeriod(primaryTopic?.citation ?? "")
     const archivalString = getPhraseForArchivalDate(
-        archivedChartInfo?.archivalDate
+        archiveContext?.archivalDate
     )
     const citationDatapage = excludeUndefined([
         primaryTopic

--- a/site/blocks/RelatedCharts.tsx
+++ b/site/blocks/RelatedCharts.tsx
@@ -53,7 +53,7 @@ export const RelatedCharts = ({
             enablePopulatingUrlParams={true}
             isEmbeddedInAnOwidPage={true}
             isEmbeddedInADataPage={false}
-            config={{ archivedChartInfo: activeChart.archivedChartInfo }}
+            config={{ archiveContext: activeChart.archiveContext }}
             isPreviewing={isPreviewing}
         />
     )

--- a/site/gdocs/components/Chart.tsx
+++ b/site/gdocs/components/Chart.tsx
@@ -113,10 +113,10 @@ export default function Chart({
 
     const chartConfig = useMemo(
         () => ({
-            archivedChartInfo: linkedChart?.archivedChartInfo,
+            archiveContext: linkedChart?.archivedPageVersion,
             ...customizedChartConfig,
         }),
-        [linkedChart?.archivedChartInfo, customizedChartConfig]
+        [linkedChart?.archivedPageVersion, customizedChartConfig]
     )
 
     if (!linkedChart) return null

--- a/site/multiDim/MultiDim.tsx
+++ b/site/multiDim/MultiDim.tsx
@@ -34,19 +34,19 @@ export default function MultiDim({
     localGrapherConfig,
     slug,
     queryStr,
-    archivedChartInfo,
+    archiveContext,
     isPreviewing,
 }: {
     config: MultiDimDataPageConfig
     localGrapherConfig?: GrapherProgrammaticInterface
     slug: string | null
     queryStr: string
-    archivedChartInfo?: ArchiveContext
+    archiveContext?: ArchiveContext
     isPreviewing?: boolean
 }) {
     const assetMap =
-        archivedChartInfo?.type === "archive-page"
-            ? archivedChartInfo.assets.runtime
+        archiveContext?.type === "archive-page"
+            ? archiveContext.assets.runtime
             : undefined
     const manager = useRef(localGrapherConfig?.manager ?? {})
     const grapherRef = useMaybeGlobalGrapherStateRef({
@@ -57,22 +57,18 @@ export default function MultiDim({
                 assetMap,
                 noCache: isPreviewing,
             }),
-        archivedChartInfo,
+        archiveContext,
         isConfigReady: false,
     })
 
     const grapherDataLoader = useRef(
-        getCachingInputTableFetcher(
-            DATA_API_URL,
-            archivedChartInfo,
-            isPreviewing
-        )
+        getCachingInputTableFetcher(DATA_API_URL, archiveContext, isPreviewing)
     )
     const grapherContainerRef = useRef<HTMLDivElement>(null)
     const bounds = useElementBounds(grapherContainerRef)
     const additionalConfig = useMemo(
-        () => ({ archivedChartInfo, isEmbeddedInAnOwidPage: true }),
-        [archivedChartInfo]
+        () => ({ archiveContext, isEmbeddedInAnOwidPage: true }),
+        [archiveContext]
     )
     const baseGrapherConfig = useBaseGrapherConfig(additionalConfig)
     const searchParams = useMemo(

--- a/site/multiDim/MultiDimDataPage.tsx
+++ b/site/multiDim/MultiDimDataPage.tsx
@@ -20,7 +20,7 @@ export function MultiDimDataPage({
     relatedResearchCandidates,
     imageMetadata,
     isPreviewing,
-    archivedChartInfo,
+    archiveContext,
     canonicalUrl,
 }: MultiDimDataPageProps) {
     if (!slug && !isPreviewing) {
@@ -41,7 +41,7 @@ export function MultiDimDataPage({
         imageMetadata,
         tagToSlugMap,
         isPreviewing,
-        archivedChartInfo,
+        archiveContext,
     }
     const imageUrl: string = urljoin(
         baseUrl || "/",
@@ -50,13 +50,12 @@ export function MultiDimDataPage({
     const imageWidth = "1200"
     const imageHeight = "628"
 
-    const isOnArchivalPage = archivedChartInfo?.type === "archive-page"
-    const assetMaps = isOnArchivalPage ? archivedChartInfo.assets : undefined
+    const isOnArchivalPage = archiveContext?.type === "archive-page"
+    const assetMaps = isOnArchivalPage ? archiveContext.assets : undefined
 
-    const liveUrlIfIsArchive =
-        archivedChartInfo?.type === "archive-page"
-            ? archivedChartInfo.archiveNavigation.liveUrl
-            : undefined
+    const liveUrlIfIsArchive = isOnArchivalPage
+        ? archiveContext.archiveNavigation.liveUrl
+        : undefined
     const canonicalUrlForHead = liveUrlIfIsArchive ?? canonicalUrl
 
     return (
@@ -68,7 +67,7 @@ export function MultiDimDataPage({
                 imageUrl={imageUrl}
                 baseUrl={baseUrl}
                 staticAssetMap={assetMaps?.static}
-                archivedChartInfo={archivedChartInfo}
+                archiveContext={archiveContext}
             >
                 <meta property="og:image:width" content={imageWidth} />
                 <meta property="og:image:height" content={imageHeight} />
@@ -88,9 +87,7 @@ export function MultiDimDataPage({
             </Head>
             <body className="DataPage MultiDimDataPage">
                 <SiteHeader
-                    archiveInfo={
-                        isOnArchivalPage ? archivedChartInfo : undefined
-                    }
+                    archiveInfo={isOnArchivalPage ? archiveContext : undefined}
                 />
                 <main>
                     <script
@@ -117,9 +114,7 @@ export function MultiDimDataPage({
                 <SiteFooter
                     context={SiteFooterContext.multiDimDataPage}
                     isPreviewing={isPreviewing}
-                    archiveInfo={
-                        isOnArchivalPage ? archivedChartInfo : undefined
-                    }
+                    archiveInfo={isOnArchivalPage ? archiveContext : undefined}
                 />
             </body>
         </Html>

--- a/site/multiDim/MultiDimDataPageContent.tsx
+++ b/site/multiDim/MultiDimDataPageContent.tsx
@@ -70,7 +70,7 @@ export type MultiDimDataPageContentProps = {
     relatedResearchCandidates: DataPageRelatedResearch[]
     imageMetadata: Record<string, ImageMetadata>
     isPreviewing?: boolean
-    archivedChartInfo?: ArchiveContext
+    archiveContext?: ArchiveContext
 }
 
 export type MultiDimDataPageData = Omit<
@@ -100,11 +100,11 @@ export function DataPageContent({
     relatedResearchCandidates,
     tagToSlugMap,
     imageMetadata,
-    archivedChartInfo,
+    archiveContext,
 }: MultiDimDataPageContentProps) {
     const assetMap =
-        archivedChartInfo?.type === "archive-page"
-            ? archivedChartInfo.assets.runtime
+        archiveContext?.type === "archive-page"
+            ? archiveContext.assets.runtime
             : undefined
     // A non-empty manager is used in the size calculations
     // within grapher, so we have to initialize it early with
@@ -118,7 +118,7 @@ export function DataPageContent({
                     noCache: isPreviewing,
                 }),
             manager: managerRef.current,
-            archivedChartInfo,
+            archiveContext,
             isConfigReady: false,
         })
     )
@@ -130,16 +130,16 @@ export function DataPageContent({
         () =>
             getCachingInputTableFetcher(
                 DATA_API_URL,
-                archivedChartInfo,
+                archiveContext,
                 isPreviewing
             ),
-        [archivedChartInfo, isPreviewing]
+        [archiveContext, isPreviewing]
     )
 
     const titleFragments = useTitleFragments(config)
     const additionalConfig = useMemo(
-        () => ({ archivedChartInfo }),
-        [archivedChartInfo]
+        () => ({ archiveContext }),
+        [archiveContext]
     )
     const baseGrapherConfig = useBaseGrapherConfig(additionalConfig)
 
@@ -466,7 +466,7 @@ export function DataPageContent({
                         source={varDatapageData.source}
                         title={varDatapageData.title}
                         titleVariant={varDatapageData.titleVariant}
-                        archivedChartInfo={archivedChartInfo}
+                        archiveContext={archiveContext}
                     />
                 )}
             </div>
@@ -484,14 +484,14 @@ export function MultiDimDataPageContent({
     relatedResearchCandidates,
     tagToSlugMap,
     imageMetadata,
-    archivedChartInfo,
+    archiveContext,
 }: MultiDimDataPageContentProps) {
     return isIframe ? (
         <MultiDim
             config={config}
             slug={slug}
             queryStr={location.search}
-            archivedChartInfo={archivedChartInfo}
+            archiveContext={archiveContext}
             isPreviewing={isPreviewing}
         />
     ) : (
@@ -505,7 +505,7 @@ export function MultiDimDataPageContent({
             relatedResearchCandidates={relatedResearchCandidates}
             tagToSlugMap={tagToSlugMap}
             imageMetadata={imageMetadata}
-            archivedChartInfo={archivedChartInfo}
+            archiveContext={archiveContext}
         />
     )
 }


### PR DESCRIPTION
## Context

In the past, the type(s) got renamed without renaming all of their variables. Since we are going to start archiving articles, which will also use `ArchiveContext`, it makes even more sense now to stop using "chart" as part of variable names for `ArchiveContext` and clean up the naming.

This also fixes a few other instances that I found confusing.

This change should not affect the behavior in any way.

## Testing guidance

Check that everything still works as expected.


