### PR TITLE
✨ pick better comparison entities

### DIFF
--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -221,6 +221,8 @@ export {
     getCountryNamesForRegion,
     checkHasMembers,
     getRegionByName,
+    getParentRegions,
+    getSiblingRegions,
 } from "./regions.js"
 
 export { getStylesForTargetHeight } from "./react-select.js"


### PR DESCRIPTION
We used to show the user selected entity alongside the default entities. That wasn't nice in many cases because the combination often seemed quite random.

We now pick comparison entities for a selected entity like this:
- If it's a country, we pick its continent, income group and World (if available). For example, Spain might be shown alongside 'Europe' and 'World'
- If it's a continent, we pick other continents
- If the entity is not geographical or we can't find any good comparison entities, then we still rely on the default entities

The failing test is unrelated.