### PR TITLE
Fix multi-dim embed URL query params on page load

### DIFF
--- a/site/multiDim/MultiDimDataPageContent.tsx
+++ b/site/multiDim/MultiDimDataPageContent.tsx
@@ -310,7 +310,13 @@ export function DataPageContent({
     useEffect(() => {
         const grapher = grapherStateRef.current
         if (!grapher) return
-        const queryParams = Object.fromEntries(searchParams.entries())
+        const queryParams = {
+            // On first page load, query params may be empty but settings are
+            // already correctly computed, so include them (e.g. for embed
+            // URLs).
+            ...Object.fromEntries(searchParams.entries()),
+            ...settings,
+        }
         // this is not taking into account what used to be passed as "manager"
         grapher.externalBounds = bounds
         grapher.bakedGrapherURL = BAKED_GRAPHER_URL


### PR DESCRIPTION
When the initial page load URL doesn't include multi-dim view query params (or they are incorrect), we compute them from config and display the default (closest correct) ones. In such case they were not correctly passed to Grapher and were missing from the embed URLs.
