### PR TITLE
🐛🤖 Ensure explorer views refresh when dependencies change

### DIFF
--- a/adminSiteServer/apiRoutes/charts.ts
+++ b/adminSiteServer/apiRoutes/charts.ts
@@ -40,6 +40,8 @@ import {
     getWordpressPostReferencesByChartId,
     getGdocsPostReferencesByChartId,
 } from "../../db/model/Post.js"
+import { UpdatedChartInheritanceRecord } from "../../db/model/Variable.js"
+import { enqueueExplorerRefreshJobsForDependencies } from "../../db/model/Explorer.js"
 import { expectInt } from "../../serverUtils/serverUtil.js"
 import {
     BAKED_BASE_URL,
@@ -468,6 +470,10 @@ export const saveGrapher = async (
     } else if (fullConfig.isPublished)
         await triggerStaticBuild(user, `Updating chart ${fullConfig.slug}`)
 
+    await enqueueExplorerRefreshJobsForDependencies(knex, {
+        chartIds: [chartId],
+    })
+
     return {
         chartId,
         savedPatch: patchConfig,
@@ -476,7 +482,7 @@ export const saveGrapher = async (
 
 export async function updateGrapherConfigsInR2(
     knex: db.KnexReadonlyTransaction,
-    updatedCharts: { chartConfigId: string; isPublished: boolean }[],
+    updatedCharts: UpdatedChartInheritanceRecord[],
     updatedMultiDimViews: { chartConfigId: string; isPublished: boolean }[]
 ) {
     const idsToUpdate = [

--- a/adminSiteServer/apiRoutes/variables.ts
+++ b/adminSiteServer/apiRoutes/variables.ts
@@ -26,6 +26,7 @@ import {
     updateGrapherConfigAdminOfVariable,
     updateGrapherConfigETLOfVariable,
 } from "../../db/model/Variable.js"
+import { enqueueExplorerRefreshJobsForDependencies } from "../../db/model/Explorer.js"
 import { DATA_API_URL } from "../../settings/clientSettings.js"
 import * as db from "../../db/db.js"
 import {
@@ -341,6 +342,17 @@ export async function putVariablesVariableIdGrapherConfigETL(
         await updateGrapherConfigETLOfVariable(trx, variable, validConfig)
 
     await updateGrapherConfigsInR2(trx, updatedCharts, updatedMultiDimViews)
+    const chartIdsForRefresh = Array.from(
+        new Set(
+            updatedCharts
+                .map((chart) => chart.chartId)
+                .filter((id): id is number => typeof id === "number")
+        )
+    )
+    await enqueueExplorerRefreshJobsForDependencies(trx, {
+        chartIds: chartIdsForRefresh,
+        variableIds: [variableId],
+    })
     const allUpdatedConfigs = [...updatedCharts, ...updatedMultiDimViews]
 
     if (allUpdatedConfigs.some(({ isPublished }) => isPublished)) {
@@ -416,6 +428,17 @@ export async function deleteVariablesVariableIdGrapherConfigETL(
             updates
         )
     await updateGrapherConfigsInR2(trx, updatedCharts, updatedMultiDimViews)
+    const chartIdsForRefresh = Array.from(
+        new Set(
+            updatedCharts
+                .map((chart) => chart.chartId)
+                .filter((id): id is number => typeof id === "number")
+        )
+    )
+    await enqueueExplorerRefreshJobsForDependencies(trx, {
+        chartIds: chartIdsForRefresh,
+        variableIds: [variableId],
+    })
     const allUpdatedConfigs = [...updatedCharts, ...updatedMultiDimViews]
 
     if (allUpdatedConfigs.some(({ isPublished }) => isPublished)) {
@@ -456,6 +479,17 @@ export async function putVariablesVariableIdGrapherConfigAdmin(
         await updateGrapherConfigAdminOfVariable(trx, variable, validConfig)
 
     await updateGrapherConfigsInR2(trx, updatedCharts, updatedMultiDimViews)
+    const chartIdsForRefresh = Array.from(
+        new Set(
+            updatedCharts
+                .map((chart) => chart.chartId)
+                .filter((id): id is number => typeof id === "number")
+        )
+    )
+    await enqueueExplorerRefreshJobsForDependencies(trx, {
+        chartIds: chartIdsForRefresh,
+        variableIds: [variableId],
+    })
     const allUpdatedConfigs = [...updatedCharts, ...updatedMultiDimViews]
 
     if (allUpdatedConfigs.some(({ isPublished }) => isPublished)) {
@@ -522,6 +556,17 @@ export async function deleteVariablesVariableIdGrapherConfigAdmin(
             updates
         )
     await updateGrapherConfigsInR2(trx, updatedCharts, updatedMultiDimViews)
+    const chartIdsForRefresh = Array.from(
+        new Set(
+            updatedCharts
+                .map((chart) => chart.chartId)
+                .filter((id): id is number => typeof id === "number")
+        )
+    )
+    await enqueueExplorerRefreshJobsForDependencies(trx, {
+        chartIds: chartIdsForRefresh,
+        variableIds: [variableId],
+    })
     const allUpdatedConfigs = [...updatedCharts, ...updatedMultiDimViews]
 
     if (allUpdatedConfigs.some(({ isPublished }) => isPublished)) {

--- a/db/tests/testHelpers.ts
+++ b/db/tests/testHelpers.ts
@@ -8,6 +8,7 @@ import {
     ExplorerVariablesTableName,
     ExplorerViewsTableName,
     ExplorersTableName,
+    JobsTableName,
     MultiDimDataPagesTableName,
     MultiDimXChartConfigsTableName,
     PostsGdocsTableName,
@@ -28,6 +29,7 @@ export const TABLES_IN_USE = [
     ExplorerChartsTableName, // Must come before ChartsTableName due to foreign key
     ExplorerVariablesTableName,
     ExplorersTableName,
+    JobsTableName,
     ChartsTableName,
     VariablesTableName,
     ChartConfigsTableName,

--- a/docker-compose.dbtests.yml
+++ b/docker-compose.dbtests.yml
@@ -3,7 +3,7 @@
 services:
     # Stock mysql database. Root password is hardcoded for now
     db:
-        image: mysql:8
+        image: mysql:8.4.5
         command: --log-bin-trust-function-creators=ON
         restart: always
         volumes:
@@ -17,7 +17,7 @@ services:
 
     # mysql:8 container for running the DB creation scripts
     db-load-data:
-        image: mysql:8
+        image: mysql:8.4.5
         command: "/app/create-test-db.sh"
         volumes:
             - ./devTools/docker:/app


### PR DESCRIPTION
Fixes #5396

- add helper to enqueue refresh jobs from chart and variable updates
- wire helper into admin routes so dependent explorers get queued
- extend queue suite and db test harness to cover refresh triggers without flakes
- pin dbtest mysql image to 8.4.5 to avoid upstream hang

