### PR TITLE
🔨  Reduce session replay sampling rate

### DIFF
--- a/packages/@ourworldindata/types/src/siteTypes/SiteConstants.ts
+++ b/packages/@ourworldindata/types/src/siteTypes/SiteConstants.ts
@@ -7,6 +7,6 @@ export const HIDE_IF_JS_DISABLED_CLASSNAME = "js--hide-if-js-disabled"
 export const GRAPHER_PREVIEW_CLASS = "grapherPreview"
 
 // Sentry constants
-export const SENTRY_DEFAULT_REPLAYS_SESSION_SAMPLE_RATE = 0.1
+export const SENTRY_DEFAULT_REPLAYS_SESSION_SAMPLE_RATE = 0.08
 export const SENTRY_SESSION_STORAGE_KEY = "sentryReplaySession"
 export const SENTRY_SAMPLED_RATE_KEY = "sentrySampledRate"

--- a/site/SentryUtils.ts
+++ b/site/SentryUtils.ts
@@ -151,7 +151,9 @@ function parseExperimentsSampleRate(): number | undefined {
     const expSentrySampleRates: number[] = []
 
     for (const [cookieName, cookieValue] of Object.entries(allCookies)) {
-        const exp = experiments.find((e) => e.id === cookieName)
+        const exp = experiments
+            .filter((e) => !e.isExpired())
+            .find((e) => e.id === cookieName)
         if (!exp || !cookieValue) continue
 
         const pathname = window.location.pathname


### PR DESCRIPTION
## Context

Reduces Sentry session replay sampling from 0.1 -> 0.08 to (hopefully) keep us below our monthly budget.

Also adds a filter in `parseExperimentsSampleRate` to filter out expired experiments. This *shouldn't* change anything b/c `allCookies` should already not contain any cookies for expired experiments. But doesn't hurt to have an extra guard here in case there's a reason some browsers are sending expired cookies in the request.