### PR TITLE
:hammer: increase /data-insights newsletter banner timeout

### DIFF
--- a/site/DataInsightsNewsletterBanner.tsx
+++ b/site/DataInsightsNewsletterBanner.tsx
@@ -19,7 +19,7 @@ export default function DataInsightsNewsletterBanner() {
         if (keepHidden) return
         const timeoutId = setTimeout(() => {
             setIsVisible(true)
-        }, 3000)
+        }, 20000)
         return () => clearTimeout(timeoutId)
     }, [])
 


### PR DESCRIPTION
## Context

Increases delay for newsletter signup popup on `/data-insights/*` pages from 3s to 15s.