### PR TITLE
🎉 chart previews on mouseover

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/GrapherAnalytics.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherAnalytics.ts
@@ -33,6 +33,7 @@ export enum EventCategory {
     DataCatalogSearch = "owid.data_catalog_search",
     DataCatalogResultClick = "owid.data_catalog_result_click",
     SiteGuidedChartLinkClick = "owid.site_guided_chart_link_click",
+    SiteChartPreviewMouseover = "owid.site_chart_preview_mouseover",
 }
 
 enum EventAction {

--- a/site/SiteAnalytics.ts
+++ b/site/SiteAnalytics.ts
@@ -170,4 +170,12 @@ export class SiteAnalytics extends GrapherAnalytics {
             eventTarget: url,
         })
     }
+
+    logChartPreviewMouseover(chartUrl: string) {
+        this.logToGA({
+            event: EventCategory.SiteChartPreviewMouseover,
+            eventAction: "mouseover",
+            eventTarget: chartUrl,
+        })
+    }
 }

--- a/site/gdocs/components/ChartPreview.scss
+++ b/site/gdocs/components/ChartPreview.scss
@@ -1,0 +1,18 @@
+.chart-preview {
+    padding: 8px;
+}
+
+.chart-preview-error,
+.chart-preview-loading {
+    @include body-2-regular;
+    width: 350px;
+    aspect-ratio: 16 / 9;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #666;
+    font-size: 14px;
+    svg {
+        margin-right: 8px;
+    }
+}

--- a/site/gdocs/components/ChartPreview.tsx
+++ b/site/gdocs/components/ChartPreview.tsx
@@ -1,0 +1,54 @@
+import { useState } from "react"
+import {
+    EXPLORER_DYNAMIC_THUMBNAIL_URL,
+    GRAPHER_DYNAMIC_THUMBNAIL_URL,
+} from "../../../settings/clientSettings.js"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import { faHeartBroken } from "@fortawesome/free-solid-svg-icons"
+
+interface ChartPreviewProps {
+    chartSlug: string
+    queryString?: string
+    chartType?: "chart" | "explorer"
+}
+
+export function ChartPreview({
+    chartSlug,
+    queryString = "",
+    chartType,
+}: ChartPreviewProps) {
+    const [imgLoaded, setImgLoaded] = useState(false)
+    const [imgError, setImgError] = useState(false)
+    const baseUrl =
+        chartType === "explorer"
+            ? EXPLORER_DYNAMIC_THUMBNAIL_URL
+            : GRAPHER_DYNAMIC_THUMBNAIL_URL
+
+    const thumbnailUrl = `${baseUrl}/${chartSlug}.png${queryString}`
+
+    return (
+        <div className="chart-preview">
+            {imgError ? (
+                <div className="chart-preview-error">
+                    <FontAwesomeIcon icon={faHeartBroken} />
+                    Preview unavailable
+                </div>
+            ) : (
+                <img
+                    src={thumbnailUrl}
+                    alt="Chart preview"
+                    style={{
+                        display: imgLoaded ? "block" : "none",
+                    }}
+                    onLoad={() => setImgLoaded(true)}
+                    onError={() => setImgError(true)}
+                />
+            )}
+            {!imgLoaded && !imgError && (
+                <div className="chart-preview-loading">
+                    Loading preview&hellip;
+                </div>
+            )}
+        </div>
+    )
+}

--- a/site/gdocs/components/LinkedA.tsx
+++ b/site/gdocs/components/LinkedA.tsx
@@ -1,7 +1,15 @@
 import { getLinkType } from "@ourworldindata/components"
 import { SpanLink } from "@ourworldindata/types"
 import { useLinkedDocument, useLinkedChart } from "../utils.js"
+import { Url } from "@ourworldindata/utils"
+import Tippy from "@tippyjs/react"
 import SpanElements from "./SpanElements.js"
+import { ChartPreview } from "./ChartPreview.js"
+import { SiteAnalytics } from "../../SiteAnalytics.js"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import { faChartLine } from "@fortawesome/free-solid-svg-icons"
+
+const analytics = new SiteAnalytics()
 
 export default function LinkedA({ span }: { span: SpanLink }) {
     const linkType = getLinkType(span.url)
@@ -20,10 +28,37 @@ export default function LinkedA({ span }: { span: SpanLink }) {
         )
     }
     if (linkedChart) {
+        const url = Url.fromURL(linkedChart.resolvedUrl)
+        const chartSlug = url.slug || ""
+        const queryString = url.queryStr
+
         return (
-            <a href={linkedChart.resolvedUrl} className="span-link">
-                <SpanElements spans={span.children} />
-            </a>
+            <Tippy
+                content={
+                    <ChartPreview
+                        chartType={url.isExplorer ? "explorer" : "chart"}
+                        chartSlug={chartSlug}
+                        queryString={queryString}
+                    />
+                }
+                onShow={() =>
+                    analytics.logChartPreviewMouseover(linkedChart.resolvedUrl)
+                }
+                delay={[300, 0]}
+                placement="top"
+                maxWidth={512}
+                theme="light"
+                arrow={false}
+                touch={false}
+            >
+                <a
+                    href={linkedChart.resolvedUrl}
+                    className="span-link span-linked-chart"
+                >
+                    <SpanElements spans={span.children} />
+                    <FontAwesomeIcon icon={faChartLine} />
+                </a>
+            </Tippy>
         )
     }
     if (linkedDocument && linkedDocument.published && linkedDocument.url) {

--- a/site/gdocs/components/centered-article.scss
+++ b/site/gdocs/components/centered-article.scss
@@ -808,6 +808,20 @@ p.article-block__text + #article-licence {
         color: inherit;
     }
 
+    .span-linked-chart {
+        svg {
+            position: relative;
+            top: -1px;
+            width: 12px;
+            height: 12px;
+            margin-left: 3px;
+            color: $blue-30;
+            @media (hover: none) {
+                display: none;
+            }
+        }
+    }
+
     @include md-down {
         @include body-2-regular;
     }

--- a/site/owid.scss
+++ b/site/owid.scss
@@ -94,6 +94,7 @@
 @import "./gdocs/components/centered-article.scss";
 @import "./gdocs/components/topic-page.scss";
 @import "./gdocs/components/Callout.scss";
+@import "./gdocs/components/ChartPreview.scss";
 @import "./gdocs/components/DataInsightDateline.scss";
 @import "./gdocs/components/DataInsightsNewsletter.scss";
 @import "./gdocs/components/Donors.scss";


### PR DESCRIPTION
## Context

Adds mouseover previews to inline chart links.

## Screenshots / Videos / Diagrams

https://github.com/user-attachments/assets/351ebcf4-cb11-4726-b998-2899563f2ba6

## Testing guidance

Check out some articles on the staging site and see how it feels :)

- [x] Does the staging experience have sign-off from product stakeholders?

**Reminder to annotate the PR diff with design notes, alternatives you considered, and any other helpful context.**

## Checklist

(delete all that do not apply)

### Before merging

- [x] Google Analytics events were adapted to fit the changes in this PR
- [x] Changes to CSS/HTML were checked on Desktop and Mobile Safari at all three breakpoints
- [x] Changes to HTML were checked for accessibility concerns
  -  keyboard navigation works, but there's no alt text or announcement for the preview.
