### PR TITLE
migrate: mark `images` columns as non-null

### DIFF
--- a/adminSiteClient/DataInsightIndexPage.tsx
+++ b/adminSiteClient/DataInsightIndexPage.tsx
@@ -429,7 +429,7 @@ export function DataInsightIndexPage() {
                                     ...dataInsight.image,
                                     id: uploadedImage.id,
                                     filename: uploadedImage.filename,
-                                    cloudflareId: uploadedImage.cloudflareId!,
+                                    cloudflareId: uploadedImage.cloudflareId,
                                     originalWidth: uploadedImage.originalWidth,
                                 }
                               : undefined,

--- a/adminSiteClient/ImagesIndexPage.tsx
+++ b/adminSiteClient/ImagesIndexPage.tsx
@@ -33,6 +33,7 @@ import {
     faUpload,
 } from "@fortawesome/free-solid-svg-icons"
 import {
+    ACCEPTED_IMG_TYPES,
     type File,
     fileToBase64,
     type ImageUploadResponse,
@@ -462,7 +463,7 @@ function PostImageButton({
     }
     return (
         <Upload
-            accept="image/*"
+            accept={ACCEPTED_IMG_TYPES.join(",")}
             showUploadList={false}
             customRequest={uploadImage}
         >

--- a/adminSiteClient/ImagesIndexPage.tsx
+++ b/adminSiteClient/ImagesIndexPage.tsx
@@ -248,26 +248,24 @@ function Filename({
     originalWidth,
 }: {
     filename: string
-    cloudflareId: string | null
-    originalWidth: number | null
+    cloudflareId: string
+    originalWidth: number
 }) {
     return (
         <>
             {filename}
-            {cloudflareId && originalWidth && (
-                <Button
-                    type="link"
-                    size="small"
-                    icon={<FontAwesomeIcon icon={faDownload} />}
-                    aria-label="Download"
-                    onClick={() => {
-                        void downloadImage(
-                            makeImageSrc(cloudflareId, originalWidth),
-                            filename
-                        )
-                    }}
-                />
-            )}
+            <Button
+                type="link"
+                size="small"
+                icon={<FontAwesomeIcon icon={faDownload} />}
+                aria-label="Download"
+                onClick={() => {
+                    void downloadImage(
+                        makeImageSrc(cloudflareId, originalWidth),
+                        filename
+                    )
+                }}
+            />
         </>
     )
 }

--- a/adminSiteClient/imagesHelpers.ts
+++ b/adminSiteClient/imagesHelpers.ts
@@ -19,6 +19,14 @@ export type ImageUploadResponse =
     | { success: true; image: DbEnrichedImageWithUserId }
     | { success: false; errorMessage: string }
 
+export const ACCEPTED_IMG_TYPES = [
+    "image/jpeg",
+    "image/png",
+    "image/webp",
+    "image/avif",
+    "image/gif",
+]
+
 /**
  * Uploading as base64, because otherwise we'd need multipart/form-data parsing middleware in the server.
  * This seems easier as a one-off.

--- a/adminSiteServer/imagesHelpers.ts
+++ b/adminSiteServer/imagesHelpers.ts
@@ -7,6 +7,7 @@ import {
     OPENAI_API_KEY,
 } from "../settings/serverSettings.js"
 import { OpenAI } from "openai"
+import { ACCEPTED_IMG_TYPES } from "../adminSiteClient/imagesHelpers.js"
 
 export function validateImagePayload(body: any): {
     filename: string
@@ -23,6 +24,9 @@ export function validateImagePayload(body: any): {
         typeof content !== "string"
     ) {
         throw new JsonError("Invalid field types", 400)
+    }
+    if (!ACCEPTED_IMG_TYPES.includes(type)) {
+        throw new JsonError(`Unsupported image type: ${type}`, 400)
     }
     return { filename, type, content }
 }

--- a/db/migration/1758638800569-ImagesSetNonNull.ts
+++ b/db/migration/1758638800569-ImagesSetNonNull.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class ImagesSetNonNull1758638800569 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+                ALTER TABLE images
+                    MODIFY COLUMN originalWidth INT NOT NULL,
+                    MODIFY COLUMN originalHeight INT NOT NULL,
+                    MODIFY COLUMN cloudflareId CHAR(36) NOT NULL,
+                    MODIFY COLUMN hash VARCHAR(255) NOT NULL;
+            `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+                ALTER TABLE images
+                    MODIFY COLUMN originalWidth INT NULL,
+                    MODIFY COLUMN originalHeight INT NULL,
+                    MODIFY COLUMN cloudflareId CHAR(36) NULL,
+                    MODIFY COLUMN hash VARCHAR(255) NULL;
+            `)
+    }
+}

--- a/packages/@ourworldindata/types/src/dbTypes/Images.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/Images.ts
@@ -9,8 +9,8 @@ export interface DbInsertImage {
     originalWidth: number
     originalHeight: number
     updatedAt?: string | null // MySQL Date objects round to the nearest second, whereas Google includes milliseconds so we store as an epoch of type bigint to avoid any conversion issues
-    cloudflareId?: string | null
-    hash?: string | null
+    cloudflareId: string
+    hash: string
     userId?: number | null
     replacedBy?: number | null
     /**


### PR DESCRIPTION
Updating these 4 columns to make them non-nullable.

Marking `originalWidth` as non-null also means that, for now, we don't support uploading SVGs. Not sure if there's any codepaths we should remove also.