### PR TITLE
Fix archival multi-dims

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -3268,28 +3268,33 @@ export class GrapherState {
         )
     }
 
-    @computed get embedUrl(): string | undefined {
-        const url = this.canonicalUrl
-        if (!url) return
-
+    private makeEmbedUrl(baseUrl: string): string {
+        let url = Url.fromURL(baseUrl)
         // We want to preserve the tab in the embed URL so that if we change the
         // default view of the chart, it won't change existing embeds.
         // See https://github.com/owid/owid-grapher/issues/2805
-        let urlObj = Url.fromURL(url)
-        if (!urlObj.queryParams.tab) {
-            urlObj = urlObj.updateQueryParams({ tab: this.allParams.tab })
+        const { tab } = this.allParams
+        if (tab && !url.queryParams.tab) {
+            url = url.updateQueryParams({ tab })
         }
         if (this.canHideExternalControlsInEmbed) {
-            urlObj = urlObj.updateQueryParams({
+            url = url.updateQueryParams({
                 hideControls: this.hideExternalControlsInEmbedUrl.toString(),
             })
         }
-        return urlObj.fullUrl
+        return url.fullUrl
+    }
+
+    @computed get embedUrl(): string | undefined {
+        const baseUrl = this.canonicalUrl
+        if (!baseUrl) return undefined
+        return this.makeEmbedUrl(baseUrl)
     }
 
     @computed get embedArchivedUrl(): string | undefined {
         if (!this.archivedChartInfo) return undefined
-        return this.archivedChartInfo.archiveUrl + this.queryStr
+        const baseUrl = this.archivedChartInfo.archiveUrl + this.queryStr
+        return this.makeEmbedUrl(baseUrl)
     }
 
     @computed get hasUserChangedTimeHandles(): boolean {

--- a/packages/@ourworldindata/grapher/src/modal/EmbedModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/EmbedModal.tsx
@@ -56,16 +56,16 @@ export class EmbedModal extends React.Component<EmbedModalProps> {
 
         const opts: EmbedOptions[] = []
 
-        // Check that the embedUrl and embedArchivedUrl are the same, disregarding query params
-        const areEmbedUrlAndArchivedUrlSame =
-            Url.fromURL(this.manager.embedUrl ?? "").update({
-                queryStr: undefined,
-            }).fullUrl ===
-            Url.fromURL(this.manager.embedArchivedUrl ?? "").update({
-                queryStr: undefined,
-            }).fullUrl
+        // We only check origins (domain + port) because:
+        // - Query params are not relevant
+        // - We use the /latest/ path prefix as an alias for the latest version
+        //   of the chart, which is not the same as the canonical URL
+        // - Archive and live versions live on a different domain
+        const areEmbedAndArchivedOriginsSame =
+            Url.fromURL(this.manager.embedUrl ?? "").origin ===
+            Url.fromURL(this.manager.embedArchivedUrl ?? "").origin
 
-        if (embedUrl && !areEmbedUrlAndArchivedUrlSame) {
+        if (embedUrl && !areEmbedAndArchivedOriginsSame) {
             opts.push({
                 title: "Chart with data updates",
                 description: (

--- a/site/multiDim/MultiDim.scss
+++ b/site/multiDim/MultiDim.scss
@@ -14,7 +14,12 @@ html.IsInIframe {
     }
 
     .multi-dim-grapher-container {
-        min-height: auto !important;
+        // Martin: min-height must be zero to allow the grapher to grow to the
+        // height of the container, but not higher. Not even sure if this answer
+        // applies to height the same as to width, but it's what helped me
+        // figure it out:
+        // https://stackoverflow.com/a/66689926/9846837
+        min-height: 0;
         max-height: none;
     }
 }

--- a/site/multiDim/MultiDim.tsx
+++ b/site/multiDim/MultiDim.tsx
@@ -44,19 +44,29 @@ export default function MultiDim({
     archivedChartInfo?: ArchiveContext
     isPreviewing?: boolean
 }) {
+    const assetMap =
+        archivedChartInfo?.type === "archive-page"
+            ? archivedChartInfo.assets.runtime
+            : undefined
     const manager = useRef(localGrapherConfig?.manager ?? {})
     const grapherRef = useMaybeGlobalGrapherStateRef({
         manager: manager.current,
         queryStr,
         additionalDataLoaderFn: (varId: number) =>
             loadVariableDataAndMetadata(varId, DATA_API_URL, {
+                assetMap,
                 noCache: isPreviewing,
             }),
+        archivedChartInfo,
         isConfigReady: false,
     })
 
     const grapherDataLoader = useRef(
-        getCachingInputTableFetcher(DATA_API_URL, undefined, isPreviewing)
+        getCachingInputTableFetcher(
+            DATA_API_URL,
+            archivedChartInfo,
+            isPreviewing
+        )
     )
     const grapherContainerRef = useRef<HTMLDivElement>(null)
     const bounds = useElementBounds(grapherContainerRef)
@@ -148,11 +158,6 @@ export default function MultiDim({
             newGrapherParams.mapSelect = ""
         }
 
-        const assetMap =
-            archivedChartInfo?.type === "archive-page"
-                ? archivedChartInfo.assets.runtime
-                : undefined
-
         const previousTab = grapher.activeTab
 
         cachedGetGrapherConfigByUuid(
@@ -202,13 +207,13 @@ export default function MultiDim({
             ignoreFetchedData = true
         }
     }, [
+        assetMap,
         config,
         isPreviewing,
         localGrapherConfig,
         searchParams,
         settings,
         slug,
-        archivedChartInfo,
         baseGrapherConfig,
         manager,
         grapherRef,


### PR DESCRIPTION
- Fix ArchiveContext not being passed down in some cases
- Fix iframe height
- Fix query params behaving differently for live and archival embeds

This was cherry-picked from my article archive stack (so you reviewed this once already) to get the fixes into prod earlier, since we are publishing more mdims and I don't want their archive to be broken.