### PR TITLE
🐛 fix entities incorrectly showing 'No data' in the entity selector

### DIFF
--- a/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
+++ b/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
@@ -104,6 +104,7 @@ export interface EntitySelectorState {
 
 export interface EntitySelectorManager {
     entitySelectorState: Partial<EntitySelectorState>
+    table: OwidTable
     tableForSelection: OwidTable
     selection: SelectionArray
     entityType?: string
@@ -451,7 +452,7 @@ export class EntitySelector extends React.Component<EntitySelectorProps> {
     }
 
     private interpolateSortColumn(slug: ColumnSlug): CoreColumn {
-        return this.table
+        return this.inputTable
             .interpolateColumnWithTolerance(
                 slug,
                 this.toleranceOverride.value,
@@ -673,6 +674,10 @@ export class EntitySelector extends React.Component<EntitySelectorProps> {
             this.manager.entitySelectorState.isLoadingExternalSortColumn ??
             false
         )
+    }
+
+    @computed private get inputTable(): OwidTable {
+        return this.manager.table
     }
 
     @computed private get table(): OwidTable {
@@ -1260,7 +1265,7 @@ export class EntitySelector extends React.Component<EntitySelectorProps> {
             const variable = await additionalDataLoaderFn(indicatorId)
             const variableTable = buildVariableTable(variable)
             const column = variableTable
-                .filterByEntityNames(this.availableEntityNames)
+                .filterByEntityNames(this.inputTable.availableEntityNames)
                 .interpolateColumnWithTolerance(slug, Infinity)
                 .get(slug)
             if (column) this.setInterpolatedSortColumn(column)


### PR DESCRIPTION
The `tableForSelection` doesn't necessarily contain all entities. Since interpolated columns are computed only once and then persisted, some entities incorrectly show 'No data', because they weren't contained in the table when the column was computed.