### PR TITLE
🐛 include all entities when splitting by type

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -2813,7 +2813,7 @@ export class GrapherState {
         return this.tableForSelection.availableEntityNames
     }
     @computed get entityRegionTypeGroups(): EntityRegionTypeGroup[] {
-        return groupEntityNamesByRegionType(this.table.availableEntityNames)
+        return groupEntityNamesByRegionType(this.availableEntityNames)
     }
 
     @computed get entityNamesByRegionType(): EntityNamesByRegionType {


### PR DESCRIPTION
The `tableForSelection` might have more entities than the given table since the entity selector on the map tab includes _all_ countries, even if they have no data for any of the years