### PR TITLE
Add images to archived articles

### DIFF
--- a/baker/ExplorerBaker.tsx
+++ b/baker/ExplorerBaker.tsx
@@ -11,7 +11,7 @@ import * as db from "../db/db.js"
 import { stringify } from "safe-stable-stringify"
 import { ExplorerArchivalManifest } from "../serverUtils/archivalUtils.js"
 import { ArchiveMetaInformation } from "@ourworldindata/types"
-import { getLatestExplorerArchivedVersionsIfEnabled } from "../db/model/archival/archivalDb.js"
+import { getLatestArchivedExplorerPageVersionsIfEnabled } from "../db/model/ArchivedExplorerVersion.js"
 
 export const bakeAllPublishedExplorers = async (
     outputFolder: string,
@@ -32,7 +32,7 @@ const bakeExplorersToDir = async (
     knex: db.KnexReadonlyTransaction
 ) => {
     const latestArchivedBySlug =
-        await getLatestExplorerArchivedVersionsIfEnabled(
+        await getLatestArchivedExplorerPageVersionsIfEnabled(
             knex,
             explorers.map((e) => e.slug)
         )

--- a/baker/GrapherBaker.tsx
+++ b/baker/GrapherBaker.tsx
@@ -59,7 +59,7 @@ import { getAllMultiDimDataPageSlugs } from "../db/model/MultiDimDataPage.js"
 import pMap from "p-map"
 import { stringify } from "safe-stable-stringify"
 import { GrapherArchivalManifest } from "../serverUtils/archivalUtils.js"
-import { getLatestChartArchivedVersionsIfEnabled } from "../db/model/archival/archivalDb.js"
+import { getLatestArchivedChartPageVersionsIfEnabled } from "../db/model/ArchivedChartVersion.js"
 import { GdocDataInsight } from "../db/model/Gdoc/GdocDataInsight.js"
 
 const renderDatapageIfApplicable = async (
@@ -319,7 +319,7 @@ export const renderPreviewDataPageOrGrapherPage = async (
     knex: db.KnexReadonlyTransaction
 ) => {
     const archiveContextDictionary =
-        await getLatestChartArchivedVersionsIfEnabled(knex)
+        await getLatestArchivedChartPageVersionsIfEnabled(knex)
     const datapage = await renderDatapageIfApplicable(grapher, true, knex, {
         archiveContextDictionary,
     })
@@ -481,7 +481,7 @@ export const bakeAllChangedGrapherPagesAndDeleteRemovedGraphers = async (
         _.keyBy(images, "filename")
     )
     const archiveContextDictionary =
-        await getLatestChartArchivedVersionsIfEnabled(knex)
+        await getLatestArchivedChartPageVersionsIfEnabled(knex)
 
     const jobs: BakeSingleGrapherChartArguments[] = chartsToBake.map((row) => ({
         id: row.id,

--- a/baker/MultiDimBaker.tsx
+++ b/baker/MultiDimBaker.tsx
@@ -40,7 +40,7 @@ import {
     getMultiDimDataPageBySlug,
 } from "../db/model/MultiDimDataPage.js"
 import { MultiDimArchivalManifest } from "../serverUtils/archivalUtils.js"
-import { getLatestMultiDimArchivedVersions } from "../db/model/archival/archivalDb.js"
+import { getLatestArchivedMultiDimPageVersions } from "../db/model/ArchivedMultiDimVersion.js"
 
 const getLatestMultiDimArchivedVersionsIfEnabled = async (
     knex: db.KnexReadonlyTransaction,
@@ -48,7 +48,7 @@ const getLatestMultiDimArchivedVersionsIfEnabled = async (
 ): Promise<Record<number, ArchivedPageVersion>> => {
     if (!ARCHIVE_BASE_URL) return {}
 
-    return await getLatestMultiDimArchivedVersions(knex, multiDimIds)
+    return await getLatestArchivedMultiDimPageVersions(knex, multiDimIds)
 }
 
 export function getRelevantVariableIds(

--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -93,10 +93,8 @@ import { getNarrativeChartsInfo } from "../db/model/NarrativeChart.js"
 import { getGrapherRedirectsMap } from "./redirectsFromDb.js"
 import * as R from "remeda"
 import { getDods, getParsedDodsDictionary } from "../db/model/Dod.js"
-import {
-    getLatestChartArchivedVersionsIfEnabled,
-    getLatestMultiDimArchivedVersionsIfEnabled,
-} from "../db/model/archival/archivalDb.js"
+import { getLatestArchivedChartPageVersionsIfEnabled } from "../db/model/ArchivedChartVersion.js"
+import { getLatestArchivedMultiDimPageVersionsIfEnabled } from "../db/model/ArchivedMultiDimVersion.js"
 import { SEARCH_BASE_PATH } from "../site/search/searchUtils.js"
 import {
     getLatestPageItems,
@@ -331,8 +329,8 @@ export class SiteBaker {
             console.log("Prefetching archived versions")
             const [archivedChartVersions, archivedMultiDimVersions] =
                 await Promise.all([
-                    getLatestChartArchivedVersionsIfEnabled(knex),
-                    getLatestMultiDimArchivedVersionsIfEnabled(knex),
+                    getLatestArchivedChartPageVersionsIfEnabled(knex),
+                    getLatestArchivedMultiDimPageVersionsIfEnabled(knex),
                 ])
 
             const archivedVersions = {

--- a/baker/siteRenderers.tsx
+++ b/baker/siteRenderers.tsx
@@ -105,7 +105,7 @@ import {
     AttachmentsContext,
 } from "../site/gdocs/AttachmentsContext.js"
 import AtomArticleBlocks from "../site/gdocs/components/AtomArticleBlocks.js"
-import { getLatestExplorerArchivedVersionsIfEnabled } from "../db/model/archival/archivalDb.js"
+import { getLatestArchivedExplorerPageVersionsIfEnabled } from "../db/model/ArchivedExplorerVersion.js"
 import { GdocDataInsight } from "../db/model/Gdoc/GdocDataInsight.js"
 import { getImagesByFilenames } from "../db/model/Image.js"
 import { getCanonicalUrl } from "@ourworldindata/components"
@@ -827,10 +827,10 @@ export const renderExplorerPage = async (
 
     let archiveContext = opts?.archiveContext
     if (!archiveContext && !opts?.skipArchiveContext) {
-        const latestBySlug = await getLatestExplorerArchivedVersionsIfEnabled(
-            knex,
-            [program.slug]
-        )
+        const latestBySlug =
+            await getLatestArchivedExplorerPageVersionsIfEnabled(knex, [
+                program.slug,
+            ])
         archiveContext = latestBySlug[program.slug]
     }
 

--- a/db/model/ArchivedChartVersion.ts
+++ b/db/model/ArchivedChartVersion.ts
@@ -1,0 +1,116 @@
+import {
+    ArchivedChartVersionsTableName,
+    ArchivedPageVersion,
+    DbInsertArchivedChartVersion,
+    DbPlainArchivedChartVersion,
+    GrapherChecksumsObjectWithHash,
+} from "@ourworldindata/types"
+import {
+    ArchivalTimestamp,
+    convertToArchivalDateStringIfNecessary,
+} from "@ourworldindata/utils"
+import { stringify } from "safe-stable-stringify"
+import {
+    assembleGrapherArchivalUrl,
+    GrapherArchivalManifest,
+} from "../../serverUtils/archivalUtils.js"
+import { ARCHIVE_BASE_URL } from "../../settings/serverSettings.js"
+import * as db from "../db.js"
+
+export async function getLatestArchivedChartVersions(
+    knex: db.KnexReadonlyTransaction,
+    chartIds?: number[]
+): Promise<
+    Pick<
+        DbPlainArchivedChartVersion,
+        "grapherId" | "grapherSlug" | "archivalTimestamp"
+    >[]
+> {
+    const queryBuilder = knex<DbPlainArchivedChartVersion>(
+        ArchivedChartVersionsTableName
+    )
+        .select("grapherId", "grapherSlug", "archivalTimestamp")
+        .whereRaw(
+            `(grapherId, archivalTimestamp) IN (SELECT grapherId, MAX(archivalTimestamp) FROM archived_chart_versions a2 GROUP BY grapherId)`
+        )
+    if (chartIds) {
+        queryBuilder.whereIn("grapherId", chartIds)
+    }
+    return await queryBuilder
+}
+
+export async function getLatestArchivedChartPageVersions(
+    knex: db.KnexReadonlyTransaction,
+    chartIds?: number[]
+): Promise<Record<number, ArchivedPageVersion>> {
+    const rows = await getLatestArchivedChartVersions(knex, chartIds)
+    return Object.fromEntries(
+        rows.map((r) => [
+            r.grapherId,
+            {
+                archivalDate: convertToArchivalDateStringIfNecessary(
+                    r.archivalTimestamp
+                ),
+                archiveUrl: assembleGrapherArchivalUrl(
+                    r.archivalTimestamp,
+                    r.grapherSlug,
+                    {
+                        relative: false,
+                    }
+                ),
+                type: "archived-page-version",
+            },
+        ])
+    )
+}
+
+export async function getLatestArchivedChartPageVersionsIfEnabled(
+    knex: db.KnexReadonlyTransaction,
+    chartIds?: number[]
+): Promise<Record<number, ArchivedPageVersion>> {
+    if (!ARCHIVE_BASE_URL) return {}
+    return await getLatestArchivedChartPageVersions(knex, chartIds)
+}
+
+export async function getExistingArchivedChartVersionHashes(
+    knex: db.KnexReadonlyTransaction,
+    hashes: string[]
+): Promise<Set<string>> {
+    const rows = await knex<DbPlainArchivedChartVersion>(
+        ArchivedChartVersionsTableName
+    )
+        .select("hashOfInputs")
+        .whereIn("hashOfInputs", hashes)
+        .pluck("hashOfInputs")
+    return new Set(rows)
+}
+
+export async function insertArchivedChartVersions(
+    knex: db.KnexReadWriteTransaction,
+    versions: GrapherChecksumsObjectWithHash[],
+    date: ArchivalTimestamp,
+    manifests: Record<number, GrapherArchivalManifest>
+): Promise<void> {
+    const rows: DbInsertArchivedChartVersion[] = versions.map((v) => ({
+        grapherId: v.chartId,
+        grapherSlug: v.chartSlug,
+        archivalTimestamp: date.date,
+        hashOfInputs: v.checksumsHashed,
+        manifest: stringify(manifests[v.chartId], undefined, 2),
+    }))
+    await knex.batchInsert(ArchivedChartVersionsTableName, rows)
+}
+
+export async function getArchivedChartVersionsByChartId(
+    knex: db.KnexReadonlyTransaction,
+    chartId: number
+): Promise<
+    Pick<DbPlainArchivedChartVersion, "archivalTimestamp" | "grapherSlug">[]
+> {
+    return await knex<DbPlainArchivedChartVersion>(
+        ArchivedChartVersionsTableName
+    )
+        .select("archivalTimestamp", "grapherSlug")
+        .where("grapherId", chartId)
+        .orderBy("archivalTimestamp", "asc")
+}

--- a/db/model/ArchivedExplorerVersion.ts
+++ b/db/model/ArchivedExplorerVersion.ts
@@ -1,0 +1,110 @@
+import {
+    ArchivedExplorerVersionsTableName,
+    ArchivedPageVersion,
+    DbInsertArchivedExplorerVersion,
+    DbPlainArchivedExplorerVersion,
+    ExplorerChecksumsObjectWithHash,
+} from "@ourworldindata/types"
+import {
+    ArchivalTimestamp,
+    convertToArchivalDateStringIfNecessary,
+} from "@ourworldindata/utils"
+import { stringify } from "safe-stable-stringify"
+import {
+    assembleExplorerArchivalUrl,
+    ExplorerArchivalManifest,
+} from "../../serverUtils/archivalUtils.js"
+import { ARCHIVE_BASE_URL } from "../../settings/serverSettings.js"
+import * as db from "../db.js"
+
+export async function getLatestArchivedExplorerVersions(
+    knex: db.KnexReadonlyTransaction,
+    slugs?: string[]
+): Promise<
+    Pick<DbPlainArchivedExplorerVersion, "explorerSlug" | "archivalTimestamp">[]
+> {
+    const queryBuilder = knex<DbPlainArchivedExplorerVersion>(
+        ArchivedExplorerVersionsTableName
+    )
+        .select("explorerSlug", "archivalTimestamp")
+        .whereRaw(
+            `(explorerSlug, archivalTimestamp) IN (SELECT explorerSlug, MAX(archivalTimestamp) FROM archived_explorer_versions a2 GROUP BY explorerSlug)`
+        )
+    if (slugs) {
+        queryBuilder.whereIn("explorerSlug", slugs)
+    }
+    return await queryBuilder
+}
+
+export async function getLatestArchivedExplorerPageVersions(
+    knex: db.KnexReadonlyTransaction,
+    slugs?: string[]
+): Promise<Record<string, ArchivedPageVersion>> {
+    const rows = await getLatestArchivedExplorerVersions(knex, slugs)
+    return Object.fromEntries(
+        rows.map((r) => [
+            r.explorerSlug,
+            {
+                archivalDate: convertToArchivalDateStringIfNecessary(
+                    r.archivalTimestamp
+                ),
+                archiveUrl: assembleExplorerArchivalUrl(
+                    r.archivalTimestamp,
+                    r.explorerSlug,
+                    { relative: false }
+                ),
+                type: "archived-page-version",
+            },
+        ])
+    )
+}
+
+export async function getLatestArchivedExplorerPageVersionsIfEnabled(
+    knex: db.KnexReadonlyTransaction,
+    slugs?: string[]
+): Promise<Record<string, ArchivedPageVersion>> {
+    if (!ARCHIVE_BASE_URL) return {}
+    return await getLatestArchivedExplorerPageVersions(knex, slugs)
+}
+
+export async function getExistingArchivedExplorerVersionHashes(
+    knex: db.KnexReadonlyTransaction,
+    hashes: string[]
+): Promise<Set<string>> {
+    const rows = await knex<DbPlainArchivedExplorerVersion>(
+        ArchivedExplorerVersionsTableName
+    )
+        .select("hashOfInputs")
+        .whereIn("hashOfInputs", hashes)
+        .pluck("hashOfInputs")
+    return new Set(rows)
+}
+
+export async function insertArchivedExplorerVersions(
+    knex: db.KnexReadWriteTransaction,
+    versions: ExplorerChecksumsObjectWithHash[],
+    date: ArchivalTimestamp,
+    manifests: Record<string, ExplorerArchivalManifest>
+): Promise<void> {
+    const rows: DbInsertArchivedExplorerVersion[] = versions.map((v) => ({
+        explorerSlug: v.explorerSlug,
+        archivalTimestamp: date.date,
+        hashOfInputs: v.checksumsHashed,
+        manifest: stringify(manifests[v.explorerSlug], undefined, 2),
+    }))
+    await knex.batchInsert(ArchivedExplorerVersionsTableName, rows)
+}
+
+export async function getArchivedExplorerVersionsByExplorerSlug(
+    knex: db.KnexReadonlyTransaction,
+    explorerSlug: string
+): Promise<
+    Pick<DbPlainArchivedExplorerVersion, "archivalTimestamp" | "explorerSlug">[]
+> {
+    return await knex<DbPlainArchivedExplorerVersion>(
+        ArchivedExplorerVersionsTableName
+    )
+        .select("archivalTimestamp", "explorerSlug")
+        .where("explorerSlug", explorerSlug)
+        .orderBy("archivalTimestamp", "asc")
+}

--- a/db/model/ArchivedMultiDimVersion.ts
+++ b/db/model/ArchivedMultiDimVersion.ts
@@ -1,0 +1,116 @@
+import {
+    ArchivedMultiDimVersionsTableName,
+    ArchivedPageVersion,
+    DbInsertArchivedMultiDimVersion,
+    DbPlainArchivedMultiDimVersion,
+    MultiDimChecksumsObjectWithHash,
+} from "@ourworldindata/types"
+import {
+    ArchivalTimestamp,
+    convertToArchivalDateStringIfNecessary,
+} from "@ourworldindata/utils"
+import { stringify } from "safe-stable-stringify"
+import {
+    assembleMultiDimArchivalUrl,
+    MultiDimArchivalManifest,
+} from "../../serverUtils/archivalUtils.js"
+import { ARCHIVE_BASE_URL } from "../../settings/serverSettings.js"
+import * as db from "../db.js"
+
+export async function getLatestArchivedMultiDimVersions(
+    knex: db.KnexReadonlyTransaction,
+    multiDimIds?: number[]
+): Promise<
+    Pick<
+        DbPlainArchivedMultiDimVersion,
+        "multiDimId" | "multiDimSlug" | "archivalTimestamp"
+    >[]
+> {
+    const queryBuilder = knex<DbPlainArchivedMultiDimVersion>(
+        ArchivedMultiDimVersionsTableName
+    )
+        .select("multiDimId", "multiDimSlug", "archivalTimestamp")
+        .whereRaw(
+            `(multiDimId, archivalTimestamp) IN (SELECT multiDimId, MAX(archivalTimestamp) FROM archived_multi_dim_versions a2 GROUP BY multiDimId)`
+        )
+    if (multiDimIds) {
+        queryBuilder.whereIn("multiDimId", multiDimIds)
+    }
+    return await queryBuilder
+}
+
+export async function getLatestArchivedMultiDimPageVersions(
+    knex: db.KnexReadonlyTransaction,
+    multiDimIds?: number[]
+): Promise<Record<number, ArchivedPageVersion>> {
+    const rows = await getLatestArchivedMultiDimVersions(knex, multiDimIds)
+    return Object.fromEntries(
+        rows.map((r) => [
+            r.multiDimId,
+            {
+                archivalDate: convertToArchivalDateStringIfNecessary(
+                    r.archivalTimestamp
+                ),
+                archiveUrl: assembleMultiDimArchivalUrl(
+                    r.archivalTimestamp,
+                    r.multiDimSlug,
+                    {
+                        relative: false,
+                    }
+                ),
+                type: "archived-page-version",
+            },
+        ])
+    )
+}
+
+export async function getLatestArchivedMultiDimPageVersionsIfEnabled(
+    knex: db.KnexReadonlyTransaction,
+    multiDimIds?: number[]
+): Promise<Record<number, ArchivedPageVersion>> {
+    if (!ARCHIVE_BASE_URL) return {}
+    return await getLatestArchivedMultiDimPageVersions(knex, multiDimIds)
+}
+
+export async function getExistingArchivedMultiDimVersionHashes(
+    knex: db.KnexReadonlyTransaction,
+    hashes: string[]
+): Promise<Set<string>> {
+    const rows = await knex<DbPlainArchivedMultiDimVersion>(
+        ArchivedMultiDimVersionsTableName
+    )
+        .select("hashOfInputs")
+        .whereIn("hashOfInputs", hashes)
+        .pluck("hashOfInputs")
+    return new Set(rows)
+}
+
+export async function insertArchivedMultiDimVersions(
+    knex: db.KnexReadWriteTransaction,
+    versions: MultiDimChecksumsObjectWithHash[],
+    date: ArchivalTimestamp,
+    manifests: Record<number, MultiDimArchivalManifest>
+): Promise<void> {
+    const rows: DbInsertArchivedMultiDimVersion[] = versions.map((v) => ({
+        multiDimId: v.multiDimId,
+        multiDimSlug: v.multiDimSlug,
+        archivalTimestamp: date.date,
+        hashOfInputs: v.checksumsHashed,
+        manifest: stringify(manifests[v.multiDimId], undefined, 2),
+    }))
+    await knex.batchInsert(ArchivedMultiDimVersionsTableName, rows)
+}
+
+export async function getArchivedMultiDimVersionsByMultiDimId(
+    knex: db.KnexReadonlyTransaction,
+    multiDimId: number
+): Promise<
+    Pick<DbPlainArchivedMultiDimVersion, "archivalTimestamp" | "multiDimSlug">[]
+> {
+    return await knex<DbPlainArchivedMultiDimVersion>(
+        ArchivedMultiDimVersionsTableName
+    )
+        .select("archivalTimestamp", "multiDimSlug")
+        .where("multiDimId", multiDimId)
+        .orderBy("archivalTimestamp", "asc")
+}

--- a/db/model/ArchivedPostVersion.ts
+++ b/db/model/ArchivedPostVersion.ts
@@ -1,0 +1,116 @@
+import {
+    ArchivedPageVersion,
+    ArchivedPostVersionsTableName,
+    DbInsertArchivedPostVersion,
+    DbPlainArchivedPostVersion,
+    PostChecksumsObjectWithHash,
+} from "@ourworldindata/types"
+import {
+    ArchivalTimestamp,
+    convertToArchivalDateStringIfNecessary,
+} from "@ourworldindata/utils"
+import { stringify } from "safe-stable-stringify"
+import {
+    assemblePostArchivalUrl,
+    PostArchivalManifest,
+} from "../../serverUtils/archivalUtils.js"
+import { ARCHIVE_BASE_URL } from "../../settings/serverSettings.js"
+import * as db from "../db.js"
+
+export async function getLatestArchivedPostVersions(
+    knex: db.KnexReadonlyTransaction,
+    postIds?: string[]
+): Promise<
+    Pick<
+        DbPlainArchivedPostVersion,
+        "postId" | "postSlug" | "archivalTimestamp"
+    >[]
+> {
+    const queryBuilder = knex<DbPlainArchivedPostVersion>(
+        ArchivedPostVersionsTableName
+    )
+        .select("postId", "postSlug", "archivalTimestamp")
+        .whereRaw(
+            `(postId, archivalTimestamp) IN (SELECT postId, MAX(archivalTimestamp) FROM archived_post_versions a2 GROUP BY postId)`
+        )
+
+    if (postIds) {
+        queryBuilder.whereIn("postId", postIds)
+    }
+
+    return await queryBuilder
+}
+
+export async function getLatestArchivedPostPageVersions(
+    knex: db.KnexReadonlyTransaction,
+    postIds?: string[]
+): Promise<Record<string, ArchivedPageVersion>> {
+    const rows = await getLatestArchivedPostVersions(knex, postIds)
+    return Object.fromEntries(
+        rows.map((r) => [
+            r.postId,
+            {
+                archivalDate: convertToArchivalDateStringIfNecessary(
+                    r.archivalTimestamp
+                ),
+                archiveUrl: assemblePostArchivalUrl(
+                    r.archivalTimestamp,
+                    r.postSlug,
+                    {
+                        relative: false,
+                    }
+                ),
+                type: "archived-page-version",
+            },
+        ])
+    )
+}
+
+export async function getLatestArchivedPostPageVersionsIfEnabled(
+    knex: db.KnexReadonlyTransaction,
+    postIds?: string[]
+): Promise<Record<string, ArchivedPageVersion>> {
+    if (!ARCHIVE_BASE_URL) return {}
+    return await getLatestArchivedPostPageVersions(knex, postIds)
+}
+
+export async function getExistingArchivedPostVersionHashes(
+    knex: db.KnexReadonlyTransaction,
+    hashes: string[]
+): Promise<Set<string>> {
+    const rows = await knex<DbPlainArchivedPostVersion>(
+        ArchivedPostVersionsTableName
+    )
+        .select("hashOfInputs")
+        .whereIn("hashOfInputs", hashes)
+        .pluck("hashOfInputs")
+    return new Set(rows)
+}
+
+export async function insertArchivedPostVersions(
+    knex: db.KnexReadWriteTransaction,
+    versions: PostChecksumsObjectWithHash[],
+    date: ArchivalTimestamp,
+    manifests: Record<string, PostArchivalManifest>
+): Promise<void> {
+    const rows: DbInsertArchivedPostVersion[] = versions.map((v) => ({
+        postId: v.postId,
+        postSlug: v.postSlug,
+        archivalTimestamp: date.date,
+        hashOfInputs: v.checksumsHashed,
+        manifest: stringify(manifests[v.postSlug], undefined, 2),
+    }))
+    await knex.batchInsert(ArchivedPostVersionsTableName, rows)
+}
+
+export async function getArchivedPostVersionsByPostId(
+    knex: db.KnexReadonlyTransaction,
+    postId: string
+): Promise<
+    Pick<DbPlainArchivedPostVersion, "archivalTimestamp" | "postSlug">[]
+> {
+    return await knex<DbPlainArchivedPostVersion>(ArchivedPostVersionsTableName)
+        .select("archivalTimestamp", "postSlug")
+        .where("postId", postId)
+        .orderBy("archivalTimestamp", "asc")
+}

--- a/db/model/Gdoc/GdocBase.ts
+++ b/db/model/Gdoc/GdocBase.ts
@@ -77,11 +77,9 @@ import {
 } from "../NarrativeChart.js"
 import * as R from "remeda"
 import { getDods } from "../Dod.js"
-import {
-    getLatestChartArchivedVersionsIfEnabled,
-    getLatestMultiDimArchivedVersionsIfEnabled,
-    getLatestExplorerArchivedVersionsIfEnabled,
-} from "../archival/archivalDb.js"
+import { getLatestArchivedExplorerPageVersionsIfEnabled } from "../ArchivedExplorerVersion.js"
+import { getLatestArchivedMultiDimPageVersionsIfEnabled } from "../ArchivedMultiDimVersion.js"
+import { getLatestArchivedChartPageVersionsIfEnabled } from "../ArchivedChartVersion.js"
 
 export async function getLinkedIndicatorsForCharts(
     knex: db.KnexReadonlyTransaction,
@@ -133,12 +131,12 @@ export async function loadLinkedChartsForSlugs(
         archivedMultiDimVersions,
         archivedExplorerVersions,
     ] = await Promise.all([
-        getLatestChartArchivedVersionsIfEnabled(
+        getLatestArchivedChartPageVersionsIfEnabled(
             knex,
             excludeUndefined(grapherSlugs.map((slug) => slugToIdMap[slug]))
         ),
-        getLatestMultiDimArchivedVersionsIfEnabled(knex),
-        getLatestExplorerArchivedVersionsIfEnabled(knex, explorerSlugs),
+        getLatestArchivedMultiDimPageVersionsIfEnabled(knex),
+        getLatestArchivedExplorerPageVersionsIfEnabled(knex, explorerSlugs),
     ])
 
     // TODO: rewrite this as a single query instead of N queries

--- a/db/model/Gdoc/GdocPost.ts
+++ b/db/model/Gdoc/GdocPost.ts
@@ -26,7 +26,7 @@ import { parseFaqs } from "./rawToEnriched.js"
 import { htmlToEnrichedTextBlock } from "./htmlToEnriched.js"
 import { GdocBase, getMinimalAuthorsByNames } from "./GdocBase.js"
 import { KnexReadonlyTransaction, knexRaw } from "../../db.js"
-import { getLatestChartArchivedVersionsIfEnabled } from "../archival/archivalDb.js"
+import { getLatestArchivedChartPageVersionsIfEnabled } from "../ArchivedChartVersion.js"
 import * as db from "../../db.js"
 import { BLOG_POSTS_PER_PAGE } from "../../../settings/serverSettings.js"
 import { GdocAnnouncement } from "./GdocAnnouncement.js"
@@ -187,7 +187,7 @@ export class GdocPost extends GdocBase implements OwidGdocPostInterface {
             `,
             [this.tags.map((tag) => tag.id)]
         )
-        archivedVersions ??= await getLatestChartArchivedVersionsIfEnabled(
+        archivedVersions ??= await getLatestArchivedChartPageVersionsIfEnabled(
             knex,
             relatedCharts.map((c) => c.chartId)
         )

--- a/packages/@ourworldindata/types/src/domainTypes/Archive.ts
+++ b/packages/@ourworldindata/types/src/domainTypes/Archive.ts
@@ -115,6 +115,9 @@ export interface PostChecksums {
             }
         }
     }
+    images: {
+        [imageId: string]: { filename: string; hash: string }
+    }
 }
 
 export interface PostChecksumsObjectWithHash {

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -271,6 +271,7 @@ export {
     THUMBNAIL_WIDTH,
     LARGE_THUMBNAIL_WIDTH,
     LARGEST_IMAGE_WIDTH,
+    appendImageSizeSuffix,
     getSizes,
     generateSrcSet,
     getFilenameWithoutExtension,

--- a/serverUtils/archivalFileUtils.ts
+++ b/serverUtils/archivalFileUtils.ts
@@ -3,11 +3,14 @@ import path from "path"
 import { hashBase36, hashBase36FromStream } from "./hash.js"
 
 const hashFile = async (file: string) => {
-    const stream = await fs.createReadStream(file)
+    const stream = fs.createReadStream(file)
     return await hashBase36FromStream(stream)
 }
 
-export const hashAndWriteFile = async (targetPath: string, content: string) => {
+export const hashAndWriteFile = async (
+    targetPath: string,
+    content: string | Buffer
+) => {
     const hash = hashBase36(content)
     const targetPathWithHash = targetPath.replace(
         /^(.*\/)?([^.]+\.)/,

--- a/settings/serverSettings.ts
+++ b/settings/serverSettings.ts
@@ -29,6 +29,8 @@ export const BAKED_BASE_URL: string = clientSettings.BAKED_BASE_URL
 export const ARCHIVE_BASE_URL: string | null =
     serverSettings.ARCHIVE_BASE_URL || null
 
+export const CLOUDFLARE_IMAGES_URL = clientSettings.CLOUDFLARE_IMAGES_URL
+
 export const VITE_PREVIEW: boolean = serverSettings.VITE_PREVIEW === "true"
 
 export const ADMIN_BASE_URL: string = clientSettings.ADMIN_BASE_URL

--- a/site/gdocs/OwidGdocPage.tsx
+++ b/site/gdocs/OwidGdocPage.tsx
@@ -20,6 +20,7 @@ import {
     spansToUnformattedPlainText,
     extractGdocPageData,
     OwidGdocPageData,
+    readFromAssetMap,
 } from "@ourworldindata/utils"
 import { getCanonicalUrl, getPageTitle } from "@ourworldindata/components"
 import { DebugProvider } from "./DebugProvider.js"
@@ -261,7 +262,11 @@ export default function OwidGdocPage({
         ])
         if (cloudflareId) {
             // "public" is a hard-coded variant that doesn't need to know the image's width
-            imageUrl = `${CLOUDFLARE_IMAGES_URL}/${cloudflareId}/public`
+            const fallbackUrl = `${CLOUDFLARE_IMAGES_URL}/${cloudflareId}/public`
+            imageUrl = readFromAssetMap(assetMaps?.runtime, {
+                path: featuredImageFilename,
+                fallback: fallbackUrl,
+            })
         }
     }
 

--- a/site/gdocs/components/LinkedA.tsx
+++ b/site/gdocs/components/LinkedA.tsx
@@ -1,3 +1,4 @@
+import { useContext } from "react"
 import { getLinkType } from "@ourworldindata/components"
 import { SpanLink } from "@ourworldindata/types"
 import { useLinkedDocument, useLinkedChart } from "../utils.js"
@@ -8,11 +9,14 @@ import { ChartPreview } from "./ChartPreview.js"
 import { SiteAnalytics } from "../../SiteAnalytics.js"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faChartLine } from "@fortawesome/free-solid-svg-icons"
+import { DocumentContext } from "../DocumentContext.js"
 
 const analytics = new SiteAnalytics()
 
 export default function LinkedA({ span }: { span: SpanLink }) {
     const linkType = getLinkType(span.url)
+    const { archiveContext } = useContext(DocumentContext)
+    const isOnArchivalPage = archiveContext?.type === "archive-page"
     const { linkedDocument } = useLinkedDocument(span.url)
     const { linkedChart } = useLinkedChart(span.url)
 
@@ -27,6 +31,23 @@ export default function LinkedA({ span }: { span: SpanLink }) {
         const url = Url.fromURL(linkedChart.resolvedUrl)
         const chartSlug = url.slug || ""
         const queryString = url.queryStr
+
+        const chartLink = (
+            <a
+                href={linkedChart.resolvedUrl}
+                className="span-link span-linked-chart"
+            >
+                <SpanElements spans={span.children} />
+                <FontAwesomeIcon
+                    className="span-linked-chart-icon"
+                    icon={faChartLine}
+                />
+            </a>
+        )
+
+        if (isOnArchivalPage) {
+            return chartLink
+        }
 
         return (
             <Tippy
@@ -47,16 +68,7 @@ export default function LinkedA({ span }: { span: SpanLink }) {
                 arrow={false}
                 touch={false}
             >
-                <a
-                    href={linkedChart.resolvedUrl}
-                    className="span-link span-linked-chart"
-                >
-                    <SpanElements spans={span.children} />
-                    <FontAwesomeIcon
-                        className="span-linked-chart-icon"
-                        icon={faChartLine}
-                    />
-                </a>
+                {chartLink}
             </Tippy>
         )
     }

--- a/site/gdocs/components/Thumbnail.tsx
+++ b/site/gdocs/components/Thumbnail.tsx
@@ -21,7 +21,8 @@ export const Thumbnail = ({
             />
         )
     if (
-        thumbnail.startsWith(GRAPHER_DYNAMIC_THUMBNAIL_URL) ||
+        (GRAPHER_DYNAMIC_THUMBNAIL_URL &&
+            thumbnail.startsWith(GRAPHER_DYNAMIC_THUMBNAIL_URL)) ||
         thumbnail.endsWith(ARCHIVED_THUMBNAIL_FILENAME) ||
         thumbnail.endsWith(DEFAULT_THUMBNAIL_FILENAME)
     ) {


### PR DESCRIPTION
## Context

I had to refactor the archival DB functions to avoid circular imports, so I decided to split (and rename) them according to the models (DB tables) to hopefully improve the navigation and comprehension.

Getting the checksums of posts with images is a bit slow, but should be fast enough.

## Testing guidance

Please double-check that the logic around archiving of posts based on changes to images and arching of the images themselves works correctly.
