### PR TITLE
:bug: Don't block explorers table in processExplorerViewsJob

### DIFF
--- a/jobQueue/explorerJobProcessor.ts
+++ b/jobQueue/explorerJobProcessor.ts
@@ -6,10 +6,7 @@ import {
     updateExplorerRefreshStatus,
     isJobStillRunning,
 } from "../db/model/Jobs.js"
-import {
-    refreshExplorerViewsForSlug,
-    ExplorerViewsRefreshResult,
-} from "../db/model/ExplorerViews.js"
+import { refreshExplorerViewsForSlug } from "../db/model/ExplorerViews.js"
 import { knexReadWriteTransaction, knexReadonlyTransaction } from "../db/db.js"
 import {
     saveGrapherConfigToR2ByUUID,


### PR DESCRIPTION
## Summary

We were getting deadlocks on `explorers` table when running two jobs in a short order. Fix it by moving `refreshExplorerViewsForSlug` that acquires `explorers` to a different transaction. Also send errors to Sentry.



## How to replicate

Create a staging server and run from `etl/` folder
```
etlr export://explorers/covid/latest/covid --export --private --force --only
```
then run it again, the second run will fail with 500 and deadlock error