### PR TITLE
🎉🤖 Add toggle to preview GDocs with suggested edits accepted

### DIFF
--- a/adminSiteServer/appClass.tsx
+++ b/adminSiteServer/appClass.tsx
@@ -91,11 +91,13 @@ export class OwidAdminApp {
         // Public preview of a Gdoc document
         app.get("/gdocs/:id/preview", async (req, res) => {
             try {
+                const acceptSuggestions = req.query.acceptSuggestions === "true"
                 await db.knexReadonlyTransaction(async (knex) => {
                     const gdoc = await getAndLoadGdocById(
                         knex,
                         req.params.id,
-                        GdocsContentSource.Gdocs
+                        GdocsContentSource.Gdocs,
+                        acceptSuggestions
                     )
 
                     res.set("X-Robots-Tag", "noindex")

--- a/db/model/Gdoc/GdocBase.ts
+++ b/db/model/Gdoc/GdocBase.ts
@@ -872,7 +872,9 @@ export class GdocBase implements OwidGdocBaseInterface {
         this.linkedNarrativeCharts = _.keyBy(result, "name")
     }
 
-    async fetchAndEnrichGdoc(): Promise<void> {
+    async fetchAndEnrichGdoc(
+        acceptSuggestions: boolean = false
+    ): Promise<void> {
         const docsClient = googleDocs({
             version: "v1",
             auth: OwidGoogleAuth.getGoogleReadonlyAuth(),
@@ -881,7 +883,9 @@ export class GdocBase implements OwidGdocBaseInterface {
         // Retrieve raw data from Google
         const { data } = await docsClient.documents.get({
             documentId: this.id,
-            suggestionsViewMode: "PREVIEW_WITHOUT_SUGGESTIONS",
+            suggestionsViewMode: acceptSuggestions
+                ? "PREVIEW_SUGGESTIONS_ACCEPTED"
+                : "PREVIEW_WITHOUT_SUGGESTIONS",
         })
 
         this.revisionId = data.revisionId ?? null

--- a/db/model/Gdoc/GdocFactory.ts
+++ b/db/model/Gdoc/GdocFactory.ts
@@ -357,7 +357,8 @@ export async function getAndLoadGdocBySlug(
 export async function getAndLoadGdocById(
     knex: KnexReadonlyTransaction,
     id: string,
-    contentSource?: GdocsContentSource
+    contentSource?: GdocsContentSource,
+    acceptSuggestions: boolean = false
 ): Promise<
     | GdocPost
     | GdocDataInsight
@@ -369,7 +370,7 @@ export async function getAndLoadGdocById(
     const base = await getGdocBaseObjectById(knex, id, true)
     if (!base)
         throw new Error(`No Google Doc with id "${id}" found in the database`)
-    return loadGdocFromGdocBase(knex, base, contentSource)
+    return loadGdocFromGdocBase(knex, base, contentSource, acceptSuggestions)
 }
 
 export async function createOrLoadGdocById(
@@ -390,7 +391,8 @@ export async function createOrLoadGdocById(
 export async function loadGdocFromGdocBase(
     knex: KnexReadonlyTransaction,
     base: OwidGdocBaseInterface,
-    contentSource?: GdocsContentSource
+    contentSource?: GdocsContentSource,
+    acceptSuggestions: boolean = false
 ): Promise<
     | GdocPost
     | GdocDataInsight
@@ -429,7 +431,7 @@ export async function loadGdocFromGdocBase(
 
     if (contentSource === GdocsContentSource.Gdocs) {
         // TODO: if we get here via fromJSON then we have already done this - optimize that?
-        await gdoc.fetchAndEnrichGdoc()
+        await gdoc.fetchAndEnrichGdoc(acceptSuggestions)
     }
 
     await gdoc.loadState(knex)


### PR DESCRIPTION
Implements #5485. Adds an "Accept suggestions" toggle button in the GDocs
preview page that allows previewing content as if all suggested edits were
accepted, without persisting those changes to the database.

Changes:
- Add acceptSuggestions parameter to fetchAndEnrichGdoc() that controls
  Google Docs API suggestionsViewMode
- Thread parameter through loadGdocFromGdocBase() and getAndLoadGdocById()
- Update preview routes (API and iframe) to accept acceptSuggestions param
- Add UI toggle button in GdocsPreviewPage with tooltip
- Add critical safeguard to prevent DB writes when suggestions are accepted

The feature only affects preview display - publishing and database saves
always use the default mode without suggestions accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
