### PR TITLE
Add SSG for multi-dim data pages

### DIFF
--- a/site/multiDim/MultiDimDataPage.tsx
+++ b/site/multiDim/MultiDimDataPage.tsx
@@ -1,13 +1,23 @@
 import urljoin from "url-join"
+import { StaticRouter } from "react-router-dom-v5-compat"
+
 import { Head } from "../Head.js"
 import { IFrameDetector } from "../IframeDetector.js"
 import { SiteHeader } from "../SiteHeader.js"
 import { OWID_DATAPAGE_CONTENT_ROOT_ID } from "../DataPageV2Content.js"
 import { SiteFooter } from "../SiteFooter.js"
-import { SiteFooterContext, serializeJSONForHTML } from "@ourworldindata/utils"
+import {
+    MultiDimDataPageConfig,
+    SiteFooterContext,
+    serializeJSONForHTML,
+} from "@ourworldindata/utils"
 import { MultiDimDataPageProps } from "@ourworldindata/types"
+import { DebugProvider } from "../gdocs/DebugProvider.js"
 import { Html } from "../Html.js"
-import { MultiDimDataPageData } from "./MultiDimDataPageContent.js"
+import {
+    MultiDimDataPageContent,
+    MultiDimDataPageData,
+} from "./MultiDimDataPageContent.js"
 import { DEFAULT_PAGE_DESCRIPTION } from "../dataPage.js"
 
 export function MultiDimDataPage({
@@ -98,17 +108,27 @@ export function MultiDimDataPage({
                         }}
                     />
                     <div id={OWID_DATAPAGE_CONTENT_ROOT_ID}>
-                        {/* <DebugProvider debug={isPreviewing}>
-                            <DataPageV2Content
-                                datapageData={datapageData}
-                                grapherConfig={grapherConfig}
-                                imageMetadata={imageMetadata}
-                                isPreviewing={isPreviewing}
-                                faqEntries={faqEntries}
-                                canonicalUrl={canonicalUrl}
-                                tagToSlugMap={tagToSlugMap}
-                            />
-                        </DebugProvider> */}
+                        <DebugProvider debug={isPreviewing}>
+                            {/* Location is mandatory, but we don't really need it. */}
+                            <StaticRouter location="/">
+                                <MultiDimDataPageContent
+                                    slug={slug}
+                                    canonicalUrl={canonicalUrl}
+                                    config={MultiDimDataPageConfig.fromObject(
+                                        configObj
+                                    )}
+                                    isPreviewing={isPreviewing}
+                                    faqEntries={faqEntries}
+                                    primaryTopic={primaryTopic}
+                                    relatedResearchCandidates={
+                                        relatedResearchCandidates
+                                    }
+                                    tagToSlugMap={tagToSlugMap}
+                                    imageMetadata={imageMetadata}
+                                    archiveContext={archiveContext}
+                                />
+                            </StaticRouter>
+                        </DebugProvider>
                     </div>
                 </main>
                 <SiteFooter

--- a/site/multiDim/MultiDimDataPageContent.tsx
+++ b/site/multiDim/MultiDimDataPageContent.tsx
@@ -434,6 +434,7 @@ export function DataPageContent({
                                 />
                             </figure>
                         </div>
+                        <div className="js--show-warning-block-if-js-disabled" />
                         {varDatapageData && (
                             <AboutThisData
                                 datapageData={varDatapageData}


### PR DESCRIPTION
| Before | After |
|--------|--------|
| <img width="1618" height="2334" alt="image" src="https://github.com/user-attachments/assets/2eae7a8b-5216-4ef0-9e2b-99a730b2919a" /> | <img width="1618" height="3080" alt="image" src="https://github.com/user-attachments/assets/b2a85216-b6e1-4748-b233-8762f60a754b" /> |

A clear improvement, but we unfortunately still miss the metadata. We could add that in the future, but that will be much more work.