### PR TITLE
fix: adhere to `tooltipUseCustomLabels` for map sparkline min/max formatting

### DIFF
--- a/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
@@ -56,6 +56,7 @@ import {
     InteractionState,
     MapRegionName,
     SeriesName,
+    TickFormattingOptions,
 } from "@ourworldindata/types"
 import { ClipPath, makeClipPath } from "../chart/ChartUtils"
 import { NoDataModal } from "../noDataModal/NoDataModal"
@@ -71,6 +72,14 @@ import { MapChartState } from "./MapChartState"
 import { ChartComponentProps } from "../chart/ChartTypeMap.js"
 
 export type MapChartProps = ChartComponentProps<MapChartState>
+
+export type MapFormatValueForTooltip = (
+    d: PrimitiveType,
+    options?: TickFormattingOptions
+) => {
+    formattedValue: string
+    isRounded: boolean
+}
 
 @observer
 export class MapChart
@@ -214,13 +223,10 @@ export class MapChart
         this.mapConfig.region = value
     }
 
-    @computed private get formatValueForTooltip(): (d: PrimitiveType) => {
-        formattedValue: string
-        isRounded: boolean
-    } {
+    @computed private get formatValueForTooltip(): MapFormatValueForTooltip {
         const { mapConfig, colorScale } = this
 
-        return (d: PrimitiveType) => {
+        return (d: PrimitiveType, options?: TickFormattingOptions) => {
             if (mapConfig.tooltipUseCustomLabels) {
                 // Find the bin (and its label) that this value belongs to
                 const bin = colorScale.getBinForValue(d)
@@ -231,7 +237,7 @@ export class MapChart
 
             if (typeof d === "number")
                 return {
-                    formattedValue: this.mapColumn.formatValueShort(d),
+                    formattedValue: this.mapColumn.formatValueShort(d, options),
                     isRounded: true,
                 }
             else return { formattedValue: anyToString(d), isRounded: false }

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapSparkline.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapSparkline.tsx
@@ -6,8 +6,8 @@ import {
     AxisConfigInterface,
     ColumnSlug,
     EntityName,
+    OwidVariableRoundingMode,
     OwidVariableRow,
-    PrimitiveType,
     Time,
 } from "@ourworldindata/types"
 import { OwidTable } from "@ourworldindata/core-table"
@@ -18,6 +18,7 @@ import { LineChartManager } from "../lineCharts/LineChartConstants"
 import { ColorScale } from "../color/ColorScale.js"
 import * as R from "remeda"
 import { MapColumnInfo } from "./MapChartConstants"
+import type { MapFormatValueForTooltip } from "./MapChart.js"
 
 const DEFAULT_SPARKLINE_WIDTH = 250
 const DEFAULT_SPARKLINE_HEIGHT = 87
@@ -35,10 +36,7 @@ export interface MapSparklineManager {
     datum?: OwidVariableRow<number | string>
     mapAndYColumnAreTheSame?: boolean
     yAxisConfig?: AxisConfigInterface
-    formatValueForTooltip: (d: PrimitiveType) => {
-        formattedValue: string
-        isRounded: boolean
-    }
+    formatValueForTooltip: MapFormatValueForTooltip
 }
 
 interface MapSparklineProps {
@@ -206,8 +204,12 @@ export class MapSparkline extends React.Component<MapSparklineProps> {
             yColumn = this.sparklineTable.get(mapColumnSlug),
             minVal = _.min([yColumn.minValue, yAxisConfig?.min]) ?? 0,
             maxVal = _.max([yColumn.maxValue, yAxisConfig?.max]) ?? 0,
-            minLabel = formatValueForTooltip(minVal).formattedValue,
-            maxLabel = formatValueForTooltip(maxVal).formattedValue
+            minLabel = formatValueForTooltip(minVal, {
+                roundingMode: OwidVariableRoundingMode.decimalPlaces,
+            }).formattedValue,
+            maxLabel = formatValueForTooltip(maxVal, {
+                roundingMode: OwidVariableRoundingMode.decimalPlaces,
+            }).formattedValue
         const { innerBounds: axisBounds } = this.sparklineChart.dualAxis
 
         const labelX = axisBounds.right - SPARKLINE_NUDGE

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapTooltip.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapTooltip.tsx
@@ -19,14 +19,11 @@ import {
     ColumnSlug,
 } from "@ourworldindata/types"
 import { CoreColumn, OwidTable } from "@ourworldindata/core-table"
-import {
-    PrimitiveType,
-    excludeUndefined,
-    PointVector,
-} from "@ourworldindata/utils"
+import { excludeUndefined, PointVector } from "@ourworldindata/utils"
 import { darkenColorForHighContrastText } from "../color/ColorUtils"
 import { MapSparkline, MapSparklineManager } from "./MapSparkline.js"
 import { match } from "ts-pattern"
+import type { MapFormatValueForTooltip } from "./MapChart.js"
 
 interface MapTooltipProps {
     entityName: EntityName
@@ -35,10 +32,7 @@ interface MapTooltipProps {
     mapColumnInfo: MapColumnInfo
     position?: PointVector
     lineColorScale: ColorScale
-    formatValueForTooltip: (d: PrimitiveType) => {
-        formattedValue: string
-        isRounded: boolean
-    }
+    formatValueForTooltip: MapFormatValueForTooltip
     timeSeriesTable: OwidTable
     targetTime?: Time
     sparklineWidth?: number
@@ -117,10 +111,7 @@ export class MapTooltip
         return this.props.lineColorScale
     }
 
-    @computed get formatValueForTooltip(): (d: PrimitiveType) => {
-        formattedValue: string
-        isRounded: boolean
-    } {
+    @computed get formatValueForTooltip(): MapFormatValueForTooltip {
         return this.props.formatValueForTooltip
     }
 


### PR DESCRIPTION
Fixes #4762.


<img width="884" height="563" alt="CleanShot 2025-10-14 at 10 36 17" src="https://github.com/user-attachments/assets/09df4e87-e686-4f55-8b6e-d44b0338bfbd" />
