### PR TITLE
Switch SiteRedirectsIndexPage to antd components

### DIFF
--- a/adminSiteClient/SiteRedirectsIndexPage.tsx
+++ b/adminSiteClient/SiteRedirectsIndexPage.tsx
@@ -1,11 +1,23 @@
-import cx from "classnames"
-import { useContext, useEffect, useState } from "react"
-import { useForm } from "react-hook-form"
-
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { useContext, useEffect, useMemo, useState } from "react"
+import {
+    Alert,
+    Button,
+    Flex,
+    Form,
+    Input,
+    Popconfirm,
+    Space,
+    Table,
+    TableColumnsType,
+    Typography,
+    notification,
+} from "antd"
 import { BAKED_BASE_URL } from "../settings/clientSettings.js"
 import { AdminAppContext } from "./AdminAppContext.js"
 import { AdminLayout } from "./AdminLayout.js"
 import { Link } from "./Link.js"
+import { Admin } from "./Admin.js"
 
 const SOURCE_PATTERN = /^\/$|^\/.*[^/]+$/
 const INVALID_SOURCE_MESSAGE =
@@ -20,213 +32,344 @@ type Redirect = {
     target: string
 }
 
-function RedirectRow({
-    redirect,
-    onDelete,
-}: {
-    redirect: Redirect
-    onDelete: (redirect: Redirect) => void
-}) {
-    const targetUrl = new URL(redirect.target, BAKED_BASE_URL)
-    return (
-        <tr>
-            <td className="text-break">{redirect.source}</td>
-            <td className="text-break">
-                <a href={targetUrl.href} target="_blank" rel="noopener">
-                    {redirect.target}
-                </a>
-            </td>
-            <td>
-                <button
-                    className="btn btn-danger"
-                    onClick={() => onDelete(redirect)}
-                >
-                    Delete
-                </button>
-            </td>
-        </tr>
-    )
-}
-
 type FormData = {
     source: string
     target: string
 }
 
+async function fetchRedirects(admin: Admin) {
+    const { redirects } = await admin.getJSON<{ redirects: Redirect[] }>(
+        "/api/site-redirects.json"
+    )
+    return redirects
+}
+
+async function createRedirect(
+    admin: Admin,
+    data: { source: string; target: string }
+) {
+    const sourceUrl = new URL(data.source, window.location.origin)
+    const sourcePath = sourceUrl.pathname
+    const json = await admin.requestJSON<{
+        success: boolean
+        redirect: Redirect
+    }>(
+        "/api/site-redirects/new",
+        { source: sourcePath, target: data.target },
+        "POST"
+    )
+    if (!json.success) {
+        throw new Error("Failed to create redirect")
+    }
+    return json.redirect
+}
+
+async function deleteRedirect(admin: Admin, id: number) {
+    const json = await admin.requestJSON<{ success: boolean }>(
+        `/api/site-redirects/${id}`,
+        {},
+        "DELETE"
+    )
+    if (!json.success) {
+        throw new Error("Failed to delete redirect")
+    }
+}
+
+function createColumns(
+    onDelete: (id: number) => void
+): TableColumnsType<Redirect> {
+    return [
+        {
+            title: "Source",
+            dataIndex: "source",
+            key: "source",
+            render: (source) => (
+                <Typography.Text style={{ wordBreak: "break-all" }}>
+                    {source}
+                </Typography.Text>
+            ),
+        },
+        {
+            title: "Target",
+            dataIndex: "target",
+            key: "target",
+            render: (target) => {
+                const targetUrl = new URL(target, BAKED_BASE_URL)
+                return (
+                    <a
+                        href={targetUrl.href}
+                        target="_blank"
+                        rel="noopener"
+                        style={{ wordBreak: "break-all" }}
+                    >
+                        {target}
+                    </a>
+                )
+            },
+        },
+        {
+            title: "",
+            key: "actions",
+            width: 100,
+            render: (_, record) => (
+                <Popconfirm
+                    title={`Delete the redirect from ${record.source}?`}
+                    onConfirm={() => onDelete(record.id)}
+                    okText="Yes"
+                    cancelText="No"
+                >
+                    <Button danger size="small">
+                        Delete
+                    </Button>
+                </Popconfirm>
+            ),
+        },
+    ]
+}
+
 export default function SiteRedirectsIndexPage() {
     const { admin } = useContext(AdminAppContext)
-    const [redirects, setRedirects] = useState<Redirect[]>([])
-    const [error, setError] = useState<string | null>(null)
-    const {
-        register,
-        formState: { errors, isSubmitting },
-        handleSubmit,
-        setValue,
-        watch,
-    } = useForm<FormData>()
-    const source = watch("source")
+    const [notificationApi, notificationContextHolder] =
+        notification.useNotification()
+    const queryClient = useQueryClient()
+    const [form] = Form.useForm<FormData>()
+    const [search, setSearch] = useState("")
 
     useEffect(() => {
-        admin
-            .getJSON("/api/site-redirects.json")
-            .then((json) => {
-                setRedirects(json.redirects)
-            })
-            .catch(() => {
-                setError("Error loading redirects.")
-            })
+        admin.loadingIndicatorSetting = "off"
+        return () => {
+            admin.loadingIndicatorSetting = "default"
+        }
     }, [admin])
 
-    function validateTarget(value: string) {
-        if (value === source) {
-            return "Source and target cannot be the same."
-        }
-        const sourceUrl = new URL(source, "https://ourworldindata.org")
-        if (sourceUrl.pathname === "/") {
-            return "Source cannot be the root."
-        }
-        return undefined
+    const { data: redirects } = useQuery({
+        queryKey: ["siteRedirects"],
+        queryFn: () => fetchRedirects(admin),
+    })
+
+    const createMutation = useMutation({
+        mutationFn: (data: FormData) => createRedirect(admin, data),
+        onSuccess: async () => {
+            notificationApi.success({
+                message: "Redirect created",
+                placement: "bottomRight",
+            })
+            form.resetFields()
+            return queryClient.invalidateQueries({
+                queryKey: ["siteRedirects"],
+            })
+        },
+        onError: () => {
+            notificationApi.error({
+                message: "Error creating redirect",
+                placement: "bottomRight",
+            })
+        },
+    })
+
+    const deleteMutation = useMutation({
+        mutationFn: (id: number) => deleteRedirect(admin, id),
+        onSuccess: async () => {
+            notificationApi.success({
+                message: "Redirect deleted",
+                placement: "bottomRight",
+            })
+            return queryClient.invalidateQueries({
+                queryKey: ["siteRedirects"],
+            })
+        },
+        onError: () => {
+            notificationApi.error({
+                message: "Error deleting redirect",
+                placement: "bottomRight",
+            })
+        },
+    })
+
+    function handleSubmit(values: FormData) {
+        createMutation.mutate(values)
     }
 
-    async function onSubmit({ source, target }: FormData) {
-        const sourceUrl = new URL(source, window.location.origin)
-        const sourcePath = sourceUrl.pathname
-        setValue("source", sourcePath)
-        setError(null)
-        const json = await admin.requestJSON(
-            "/api/site-redirects/new",
-            { source: sourcePath, target },
-            "POST"
+    const filteredRedirects = useMemo(() => {
+        const query = search.trim().toLowerCase()
+        return redirects?.filter((redirect) =>
+            [redirect.source, redirect.target].some((field) =>
+                field.toLowerCase().includes(query)
+            )
         )
-        if (json.success) {
-            setRedirects([json.redirect, ...redirects])
-        } else {
-            setError("Error creating a redirect.")
-        }
-    }
+    }, [redirects, search])
 
-    async function handleDelete(redirect: Redirect) {
-        if (!window.confirm(`Delete the redirect from ${redirect.source}?`)) {
-            return
-        }
-        setError(null)
-        const json = await admin.requestJSON(
-            `/api/site-redirects/${redirect.id}`,
-            {},
-            "DELETE"
-        )
-        if (json.success) {
-            setRedirects(redirects.filter((r) => r.id !== redirect.id))
-        } else {
-            setError("Error deleting the redirect.")
-        }
-    }
+    const columns = useMemo(
+        () => createColumns((id) => deleteMutation.mutate(id)),
+        [deleteMutation]
+    )
 
     return (
         <AdminLayout title="Site Redirects">
+            {notificationContextHolder}
             <main>
-                <div className="row">
-                    <div className="col-12 col-md-8">
-                        <p>
-                            This page is used to create and delete redirects for
-                            the site. Don't use this page to create redirects
-                            for charts, use the{" "}
-                            <Link to="/redirects">chart redirects page</Link>{" "}
-                            instead.
-                        </p>
-                        <p>
-                            The source has to start with a slash and any query
-                            parameters (/war-and-peace
-                            <span className="redirect-emphasis">
-                                ?insight=insightid
-                            </span>
-                            ) or fragments (/war-and-peace
-                            <span className="redirect-emphasis">
-                                #all-charts
-                            </span>
-                            ) will be stripped, if present.
-                        </p>
-                        <p>
-                            The target can point to a full URL at another domain
-                            or a relative URL starting with a slash and both
-                            query parameters and fragments are allowed.
-                        </p>
-                        <p>
-                            To redirect to our homepage use a single slash as
-                            the target.
-                        </p>
-                    </div>
-                </div>
-                <form onSubmit={handleSubmit(onSubmit)}>
-                    <div className="form-row">
-                        <div className="form-group col-12 col-md-4">
-                            <label>Source</label>
-                            <input
-                                className={cx("form-control", {
-                                    "is-invalid": errors.source,
-                                })}
-                                placeholder="/fertility-can-decline-extremely-fast"
-                                {...register("source", {
-                                    required: "Please provide a source.",
-                                    pattern: {
-                                        value: SOURCE_PATTERN,
-                                        message: INVALID_SOURCE_MESSAGE,
-                                    },
-                                })}
-                            />
-                            <div className="invalid-feedback">
-                                {errors.source?.message}
-                            </div>
-                        </div>
-                        <div className="form-group col-12 col-md-4">
-                            <label>Target</label>
-                            <input
-                                className={cx("form-control", {
-                                    "is-invalid": errors.target,
-                                })}
-                                placeholder="/fertility-rate"
-                                {...register("target", {
-                                    required: "Please provide a target.",
-                                    pattern: {
-                                        value: TARGET_PATTERN,
-                                        message: INVALID_TARGET_MESSAGE,
-                                    },
-                                    validate: validateTarget,
-                                })}
-                            />
-                            <div className="invalid-feedback">
-                                {errors.target?.message}
-                            </div>
-                        </div>
-                    </div>
-                    <button
-                        className="btn btn-primary mb-3"
-                        type="submit"
-                        disabled={isSubmitting}
+                <Space
+                    direction="vertical"
+                    size="large"
+                    style={{ width: "100%" }}
+                >
+                    <Alert
+                        message="About Site Redirects"
+                        description={
+                            <>
+                                <Typography.Paragraph>
+                                    This page is used to create and delete
+                                    redirects for the site. Don't use this page
+                                    to create redirects for charts, use the{" "}
+                                    <Link to="/redirects">
+                                        chart redirects page
+                                    </Link>{" "}
+                                    instead.
+                                </Typography.Paragraph>
+                                <Typography.Paragraph>
+                                    The source has to start with a slash. Any
+                                    query parameters (/war-and-peace
+                                    <Typography.Text underline>
+                                        ?insight=insightid
+                                    </Typography.Text>
+                                    ) or fragments (/war-and-peace
+                                    <Typography.Text underline>
+                                        #all-charts
+                                    </Typography.Text>
+                                    ) will be stripped, if present.
+                                </Typography.Paragraph>
+                                <Typography.Paragraph>
+                                    The target can point to a full URL at
+                                    another domain or a relative URL starting
+                                    with a slash and both query parameters and
+                                    fragments are allowed.
+                                </Typography.Paragraph>
+                                <Typography.Paragraph
+                                    style={{ marginBottom: 0 }}
+                                >
+                                    To redirect to our homepage use a single
+                                    slash as the target.
+                                </Typography.Paragraph>
+                            </>
+                        }
+                        type="info"
+                        showIcon
+                    />
+
+                    <Form
+                        form={form}
+                        layout="inline"
+                        onFinish={handleSubmit}
+                        style={{ gap: 16 }}
                     >
-                        Create
-                    </button>
-                    {error && <div className="text-danger mb-3">{error}</div>}
-                </form>
-                <p>Showing {redirects.length} redirects</p>
-                <table className="table table-bordered">
-                    <thead>
-                        <tr>
-                            <th>Source</th>
-                            <th>Target</th>
-                            <th></th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {redirects.map((redirect) => (
-                            <RedirectRow
-                                key={redirect.id}
-                                redirect={redirect}
-                                onDelete={handleDelete}
+                        <Form.Item
+                            name="source"
+                            label="Source"
+                            rules={[
+                                {
+                                    required: true,
+                                    message: "Please provide a source.",
+                                },
+                                {
+                                    pattern: SOURCE_PATTERN,
+                                    message: INVALID_SOURCE_MESSAGE,
+                                },
+                                ({ getFieldValue }) => ({
+                                    validator(_, value) {
+                                        const target = getFieldValue("target")
+                                        if (value && value === target) {
+                                            return Promise.reject(
+                                                new Error(
+                                                    "Source and target cannot be the same."
+                                                )
+                                            )
+                                        }
+                                        if (value) {
+                                            const sourceUrl = new URL(
+                                                value,
+                                                "https://ourworldindata.org"
+                                            )
+                                            if (sourceUrl.pathname === "/") {
+                                                return Promise.reject(
+                                                    new Error(
+                                                        "Source cannot be the root."
+                                                    )
+                                                )
+                                            }
+                                        }
+                                        return Promise.resolve()
+                                    },
+                                }),
+                            ]}
+                            style={{ minWidth: 400 }}
+                        >
+                            <Input placeholder="/fertility-can-decline-extremely-fast" />
+                        </Form.Item>
+                        <Form.Item
+                            name="target"
+                            label="Target"
+                            rules={[
+                                {
+                                    required: true,
+                                    message: "Please provide a target.",
+                                },
+                                {
+                                    pattern: TARGET_PATTERN,
+                                    message: INVALID_TARGET_MESSAGE,
+                                },
+                                ({ getFieldValue }) => ({
+                                    validator(_, value) {
+                                        const source = getFieldValue("source")
+                                        if (value && value === source) {
+                                            return Promise.reject(
+                                                new Error(
+                                                    "Source and target cannot be the same."
+                                                )
+                                            )
+                                        }
+                                        return Promise.resolve()
+                                    },
+                                }),
+                            ]}
+                            style={{ minWidth: 400 }}
+                        >
+                            <Input placeholder="/fertility-rate" />
+                        </Form.Item>
+                        <Form.Item>
+                            <Button
+                                type="primary"
+                                htmlType="submit"
+                                loading={createMutation.isLoading}
+                            >
+                                Create
+                            </Button>
+                        </Form.Item>
+                    </Form>
+
+                    <div>
+                        <Flex align="center" justify="space-between" gap={24}>
+                            <Input
+                                placeholder="Search by source or target"
+                                value={search}
+                                onChange={(e) => setSearch(e.target.value)}
+                                style={{ width: 400 }}
+                                autoFocus
                             />
-                        ))}
-                    </tbody>
-                </table>
+                            <Typography.Text>
+                                Showing {filteredRedirects?.length ?? 0} of{" "}
+                                {redirects?.length ?? 0} redirects
+                            </Typography.Text>
+                        </Flex>
+                        <Table
+                            columns={columns}
+                            dataSource={filteredRedirects}
+                            rowKey="id"
+                            loading={!redirects}
+                            pagination={{ pageSize: 20 }}
+                            style={{ marginTop: 16 }}
+                        />
+                    </div>
+                </Space>
             </main>
         </AdminLayout>
     )

--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -1012,11 +1012,6 @@ main:not(.ChartEditorPage):not(.GdocsEditPage) {
     text-decoration: none;
 }
 
-.redirect-emphasis {
-    text-decoration: underline;
-    text-decoration-color: #ccc;
-}
-
 .add-redirect-form {
     display: flex;
     flex-direction: row;

--- a/package.json
+++ b/package.json
@@ -139,7 +139,6 @@
         "react-diff-viewer-continued": "^3.4.0",
         "react-dom": "^19.1.0",
         "react-flip-toolkit": "^7.2.4",
-        "react-hook-form": "^7.60.0",
         "react-horizontal-scrolling-menu": "^8.2.0",
         "react-instantsearch": "^7.16.2",
         "react-markdown": "^10.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11504,7 +11504,6 @@ __metadata:
     react-diff-viewer-continued: "npm:^3.4.0"
     react-dom: "npm:^19.1.0"
     react-flip-toolkit: "npm:^7.2.4"
-    react-hook-form: "npm:^7.60.0"
     react-horizontal-scrolling-menu: "npm:^8.2.0"
     react-instantsearch: "npm:^7.16.2"
     react-markdown: "npm:^10.1.0"
@@ -15496,15 +15495,6 @@ __metadata:
     react: ">= 16.x"
     react-dom: ">= 16.x"
   checksum: 10/7e6833f2e1330c9be048d549f3e67438dc1625417645d938b00bb8e2fc2d3c81799a54591f21de1c55e82efd0320d943539be9e15bafacb89b03b848bdaa86b6
-  languageName: node
-  linkType: hard
-
-"react-hook-form@npm:^7.60.0":
-  version: 7.60.0
-  resolution: "react-hook-form@npm:7.60.0"
-  peerDependencies:
-    react: ^16.8.0 || ^17 || ^18 || ^19
-  checksum: 10/cc86ef4029f7b06f82dff919c8933156683b70669a6306d2471706443192b8916afaa07bc64452b590ecb18ea94f3d156f3fb38d59ada3462f5b108e89e186c9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Context

This page was among the first things I made after joining OWID and I didn't even realize I could have used Ant Design there.

I wanted to get rid of the `react-hook-form` (it's great, but not really necessary) and this kind of rewrite is cheap using AI.

## Screenshots / Videos / Diagrams

| Before | After |
|--------|--------|
| <img width="3840" height="1968" alt="image" src="https://github.com/user-attachments/assets/08e949e2-af0d-4a16-a9c3-7f34b7c6cb3e" /> | <img width="3840" height="1968" alt="image" src="https://github.com/user-attachments/assets/0153c627-7770-4ffa-8a8b-2035747522d0" /> |

## Testing guidance

You could double-check if everything still works (I already checked), if you want.