### PR TITLE
fix(search): do not send synthetic event in lieu of vizType in chart hit header

### DIFF
--- a/site/SiteAnalytics.ts
+++ b/site/SiteAnalytics.ts
@@ -80,13 +80,14 @@ export class SiteAnalytics extends GrapherAnalytics {
             position: number
             source: "ribbon" | "search" // "ribbons" are the per-area overview components present on the unparameterized browse pages for writing and data.
             ribbonTag?: string
-            vizType?: string
+            vizType?: string | null
         }
     ) {
         const eventContext = {
             ...context,
             type: hit.type,
         }
+
         this.logToGA({
             event: EventCategory.SiteSearchResultClick,
             eventAction: "click",

--- a/site/search/SearchChartHitHeader.tsx
+++ b/site/search/SearchChartHitHeader.tsx
@@ -10,7 +10,7 @@ interface SearchChartHitHeaderProps {
     url: string
     source?: string
     isLarge?: boolean
-    onClick?: () => void
+    onClick: (vizType: null) => void
 }
 
 export function SearchChartHitHeader({
@@ -28,7 +28,7 @@ export function SearchChartHitHeader({
                 "search-chart-hit-header--large": isLarge,
             })}
             href={url}
-            onClick={onClick}
+            onClick={() => onClick(null)}
             data-algolia-index={getIndexName(
                 SearchIndexName.ExplorerViewsMdimViewsAndCharts
             )}

--- a/site/search/SearchChartHitRichDataFallback.tsx
+++ b/site/search/SearchChartHitRichDataFallback.tsx
@@ -97,7 +97,7 @@ export function SearchChartHitRichDataFallback({
                     hit={hit}
                     url={chartUrl}
                     source={chartInfo?.source}
-                    onClick={() => onClick(chartType)}
+                    onClick={onClick}
                 />
                 <div className="search-chart-hit-rich-data__header-actions">
                     <Button

--- a/site/search/SearchChartHitSmall.tsx
+++ b/site/search/SearchChartHitSmall.tsx
@@ -80,7 +80,7 @@ export function SearchChartHitSmall({
                     hit={hit}
                     url={chartUrl}
                     source={chartInfo?.source}
-                    onClick={() => onClick(chartType)}
+                    onClick={onClick}
                 />
                 <div className="search-chart-hit-small__tabs-container">
                     {hit.availableTabs.map((tab) => {

--- a/site/search/SearchDataResults.tsx
+++ b/site/search/SearchDataResults.tsx
@@ -51,7 +51,7 @@ export const SearchDataResults = ({
                                           ? "medium"
                                           : "small"
 
-                                const onClick = (vizType?: string) => {
+                                const onClick = (vizType: string | null) => {
                                     analytics.logSiteSearchResultClick(hit, {
                                         position: hitIndex + 1,
                                         source: "search",

--- a/site/search/SearchDataTopic.tsx
+++ b/site/search/SearchDataTopic.tsx
@@ -56,7 +56,7 @@ export const SearchDataTopic = ({
                             <SearchChartHitComponent
                                 hit={hit}
                                 variant={hitIndex === 0 ? "medium" : "small"}
-                                onClick={(vizType?: string) => {
+                                onClick={(vizType?: string | null) => {
                                     analytics.logSiteSearchResultClick(hit, {
                                         position: hitIndex + 1,
                                         source: "ribbon",

--- a/site/search/searchTypes.ts
+++ b/site/search/searchTypes.ts
@@ -138,7 +138,7 @@ export interface SearchChartHitComponentProps {
     selectedRegionNames?: string[] | undefined
     // Search uses a global onClick handler to track analytics
     // But the data catalog passes a function to this component explicitly
-    onClick: (vizType?: string) => void
+    onClick: (vizType: string | null) => void
 }
 
 export type SearchChartHitComponentVariant = "large" | "medium" | "small"


### PR DESCRIPTION
## Context

This PR fixes the `SearchChartHitHeader` component to pass an `onClick` event with a `null` vizType, instead of a react synthetic event, which then breaks the JSON serialization in `logSiteSearchResultClick`.

See [sentry](https://our-world-in-data.sentry.io/issues/69929524/?alert_rule_id=126714&alert_type=issue&notification_uuid=260121ff-284a-444a-ad0f-3d7351fb220d&project=4508220269199440&referrer=slack)

## Testing guidance

1. Navigate to the search functionality on the site
2. Click on the header of a chart search result
3. Check in the tag assistant that vizType is null
4. Check in the console that no circular dependency error is present

## Checklist

### Before merging

- [x] Google Analytics events were adapted to fit the changes in this PR