### PR TITLE
enhance(search): auto-focus the search input when landing on /search

### DIFF
--- a/site/search/SearchInput.tsx
+++ b/site/search/SearchInput.tsx
@@ -125,6 +125,7 @@ export const SearchInput = forwardRef(
                         enterKeyHint="search"
                         value={value}
                         role="combobox"
+                        autoFocus
                         aria-expanded={showSuggestions}
                         aria-controls={autocompleteId}
                         aria-activedescendant={activeOptionId}


### PR DESCRIPTION
This makes it so that, when landing on /search, the search bar is auto-focused immediately.

This is mostly a net-positive, but it also means that it's a bit harder to make the autocomplete box show up, as you can see in the video:
https://github.com/user-attachments/assets/0cdffa8c-c891-48df-be14-fff0360d4f64

That's a bit annoying, but I still feel like this is a net-positive change. Up to you to decide.