### PR TITLE
🐛 ensure marimekkos use a linear scale

### DIFF
--- a/adminSiteClient/EditorFeatures.tsx
+++ b/adminSiteClient/EditorFeatures.tsx
@@ -42,8 +42,11 @@ export class EditorFeatures {
 
     @computed get canEnableLogLinearToggle() {
         return (
+            !this.grapherState.isStackedArea &&
+            !this.grapherState.isStackedBar &&
             !this.grapherState.isDiscreteBar &&
-            !this.grapherState.isStackedDiscreteBar
+            !this.grapherState.isStackedDiscreteBar &&
+            !this.grapherState.isMarimekko
         )
     }
 

--- a/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChartState.ts
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChartState.ts
@@ -28,6 +28,7 @@ import {
     SortConfig,
     SortBy,
     SortOrder,
+    ScaleType,
 } from "@ourworldindata/types"
 import { OWID_NO_DATA_GRAY } from "../color/ColorConstants"
 import { StackedPoint, StackedSeries } from "./StackedConstants"
@@ -444,6 +445,7 @@ export class MarimekkoChartState implements ChartState, ColorScaleManager {
         const axis = config.toVerticalAxis()
         axis.updateDomainPreservingUserSettings(this.yDomainDefault)
 
+        axis.scaleType = ScaleType.linear
         axis.formatColumn = this.formatColumn
         axis.label = ""
 


### PR DESCRIPTION
Marimekkos where the y-axis is in log mode are currently broken: https://ourworldindata.org/grapher/military-spending-per-military-personnel?tab=marimekko&yScale=log&time=2016&facet=none

Marimekkos don‘t support log axes and shouldn‘t ever be in this state. However, this can happen when switching from a line chart in log mode to a Marimekko.