### PR TITLE
Switch Grapher to React Aria select

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
         "progress": "^2.0.3",
         "react": "^19.1.0",
         "react-animate-height": "^3.2.3",
-        "react-aria-components": "^1.9.0",
+        "react-aria-components": "^1.13.0",
         "react-color": "^2.18.1",
         "react-diff-viewer-continued": "^3.4.0",
         "react-dom": "^19.1.0",

--- a/packages/@ourworldindata/explorer/package.json
+++ b/packages/@ourworldindata/explorer/package.json
@@ -36,7 +36,6 @@
     "react-dom": "^19.1.0",
     "react-flip-toolkit": "^7.2.4",
     "react-move": "^6.5.0",
-    "react-select": "^5.10.2",
     "remeda": "^2.32.0",
     "simple-statistics": "^7.3.2",
     "topojson-client": "^3.1.0",

--- a/packages/@ourworldindata/explorer/src/ExplorerControls.tsx
+++ b/packages/@ourworldindata/explorer/src/ExplorerControls.tsx
@@ -1,6 +1,6 @@
 import { Component } from "react"
-import { bind, getStylesForTargetHeight } from "@ourworldindata/utils"
-import Select, { components, SingleValueProps } from "react-select"
+import { Dropdown, SearchDropdown } from "@ourworldindata/grapher"
+import { bind } from "@ourworldindata/utils"
 import {
     ExplorerControlType,
     ExplorerChoiceOption,
@@ -57,20 +57,6 @@ interface ExplorerDropdownOption {
     value: string
 }
 
-const ExplorerSingleValue = (
-    props: SingleValueProps<ExplorerDropdownOption>
-) => {
-    if (props.selectProps.isSearchable && props.selectProps.menuIsOpen)
-        return (
-            <components.SingleValue {...props}>
-                <span style={{ fontStyle: "italic", opacity: 0.75 }}>
-                    Type to search&hellip;
-                </span>
-            </components.SingleValue>
-        )
-    else return <components.SingleValue {...props} />
-}
-
 const ExplorerDropdown = (props: {
     options: ExplorerDropdownOption[]
     value: ExplorerDropdownOption
@@ -78,28 +64,40 @@ const ExplorerDropdown = (props: {
     onChange: (option: string) => void
 }) => {
     const { options, value, isMobile, onChange } = props
-    const styles = getStylesForTargetHeight(30)
+    const isSearchable = !isMobile && options.length > 10
+    const dropdownOptions = options.map((option) => ({
+        label: option.label,
+        value: option.value,
+    }))
+    const selectedOption =
+        dropdownOptions.find((option) => option.value === value?.value) ?? null
+    const isDisabled = options.length < 2
+
+    if (isSearchable) {
+        return (
+            <SearchDropdown
+                className={EXPLORER_DROPDOWN_CLASS}
+                options={dropdownOptions}
+                value={selectedOption}
+                onChange={(option) => {
+                    if (option) onChange(option.value)
+                }}
+                placeholder="Type to search..."
+                isDisabled={isDisabled}
+            />
+        )
+    }
 
     return (
-        <Select<ExplorerDropdownOption>
+        <Dropdown
             className={EXPLORER_DROPDOWN_CLASS}
-            classNamePrefix={EXPLORER_DROPDOWN_CLASS}
-            isDisabled={options.length < 2}
-            // menuPlacement="auto" doesn't work perfectly well on mobile, with fixed position
-            menuPlacement={isMobile ? "top" : "auto"}
-            menuPosition="absolute"
-            options={options}
-            value={value}
-            onChange={(option: ExplorerDropdownOption | null) => {
+            options={dropdownOptions}
+            value={selectedOption}
+            onChange={(option) => {
                 if (option) onChange(option.value)
             }}
-            components={{
-                IndicatorSeparator: null,
-                SingleValue: ExplorerSingleValue,
-            }}
-            styles={styles}
-            isSearchable={!isMobile && options.length > 10}
-            maxMenuHeight={350}
+            isDisabled={isDisabled}
+            placeholder="-"
         />
     )
 }

--- a/packages/@ourworldindata/grapher/package.json
+++ b/packages/@ourworldindata/grapher/package.json
@@ -38,6 +38,7 @@
     "mobx-react": "^7.6.0",
     "mousetrap": "^1.6.5",
     "react": "^19.1.0",
+    "react-aria-components": "^1.13.0",
     "react-dom": "^19.1.0",
     "react-flip-toolkit": "^7.2.4",
     "react-move": "^6.5.0",

--- a/packages/@ourworldindata/grapher/src/controls/DataTableFilterDropdown.scss
+++ b/packages/@ourworldindata/grapher/src/controls/DataTableFilterDropdown.scss
@@ -1,8 +1,7 @@
 .data-table-filter-dropdown {
     width: 194px;
+}
 
-    .menu {
-        min-width: 170px;
-        right: 0;
-    }
+.data-table-filter-dropdown-menu {
+    min-width: 170px;
 }

--- a/packages/@ourworldindata/grapher/src/controls/DataTableFilterDropdown.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/DataTableFilterDropdown.tsx
@@ -135,20 +135,33 @@ export class DataTableFilterDropdown extends React.Component<{
         return (
             <Dropdown<DropdownOption>
                 className="data-table-filter-dropdown"
+                menuClassName="data-table-filter-dropdown-menu"
                 options={this.options}
                 onChange={this.onChange}
                 value={this.value}
-                formatOptionLabel={formatOptionLabel}
+                renderTriggerValue={renderFilterTriggerValue}
+                renderMenuOption={renderFilterMenuOption}
                 aria-label="Filter by"
             />
         )
     }
 }
 
-function formatOptionLabel(option: DropdownOption): React.ReactElement {
+function renderFilterTriggerValue(
+    option: DropdownOption | null
+): React.ReactNode | undefined {
+    if (!option) return undefined
     return (
         <>
             <span className="label">Filter by: </span>
+            {option.label} <span className="detail">({option.count})</span>
+        </>
+    )
+}
+
+function renderFilterMenuOption(option: DropdownOption): React.ReactNode {
+    return (
+        <>
             {option.label} <span className="detail">({option.count})</span>
         </>
     )

--- a/packages/@ourworldindata/grapher/src/controls/Dropdown.scss
+++ b/packages/@ourworldindata/grapher/src/controls/Dropdown.scss
@@ -1,30 +1,20 @@
-@use "sass:math";
+$grapher-dropdown-hover-fill: $gray-10;
+$grapher-dropdown-active-fill: $blue-20;
+$grapher-dropdown-selected-fill: #c7ced7;
 
 .grapher-dropdown {
-    $option-checkmark: "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTIiIGhlaWdodD0iOSIgdmlld0JveD0iMCAwIDEyIDkiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxwYXRoIGQ9Ik0xMS4wMTU2IDAuOTg0Mzc1QzExLjMyMDMgMS4yNjU2MiAxMS4zMjAzIDEuNzU3ODEgMTEuMDE1NiAyLjAzOTA2TDUuMDE1NjIgOC4wMzkwNkM0LjczNDM4IDguMzQzNzUgNC4yNDIxOSA4LjM0Mzc1IDMuOTYwOTQgOC4wMzkwNkwwLjk2MDkzOCA1LjAzOTA2QzAuNjU2MjUgNC43NTc4MSAwLjY1NjI1IDQuMjY1NjIgMC45NjA5MzggMy45ODQzOEMxLjI0MjE5IDMuNjc5NjkgMS43MzQzOCAzLjY3OTY5IDIuMDE1NjIgMy45ODQzOEw0LjQ3NjU2IDYuNDQ1MzFMOS45NjA5NCAwLjk4NDM3NUMxMC4yNDIyIDAuNjc5Njg4IDEwLjczNDQgMC42Nzk2ODggMTEuMDE1NiAwLjk4NDM3NVoiIGZpbGw9IiMxRDNENjMiLz4KPC9zdmc+";
     $menu-caret-up: "data:image/svg+xml;base64, PHN2ZyB3aWR0aD0iOCIgaGVpZ2h0PSI1IiB2aWV3Qm94PSIwIDAgOCA1IiBmaWxsPSJub25lIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgo8cGF0aCBkPSJNMC40NjA5MzggMy43MzQzOEwzLjQzNzUgMC43MzQzNzVDMy42MDE1NiAwLjU5Mzc1IDMuNzg5MDYgMC41IDQgMC41QzQuMTg3NSAwLjUgNC4zNzUgMC41OTM3NSA0LjUxNTYyIDAuNzM0Mzc1TDcuNDkyMTkgMy43MzQzOEM3LjcwMzEyIDMuOTQ1MzEgNy43NzM0NCA0LjI3MzQ0IDcuNjU2MjUgNC41NTQ2OUM3LjUzOTA2IDQuODM1OTQgNy4yODEyNSA1IDYuOTc2NTYgNUgxQzAuNjk1MzEyIDUgMC40MTQwNjIgNC44MzU5NCAwLjI5Njg3NSA0LjU1NDY5QzAuMTc5Njg4IDQuMjczNDQgMC4yNSAzLjk0NTMxIDAuNDYwOTM4IDMuNzM0MzhaIiBmaWxsPSIjNUI1QjVCIi8+Cjwvc3ZnPg==";
     $menu-caret-down: "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iOCIgaGVpZ2h0PSI1IiB2aWV3Qm94PSIwIDAgOCA1IiBmaWxsPSJub25lIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgo8cGF0aCBkPSJNNy41MTU2MiAxLjI4OTA2TDQuNTM5MDYgNC4yODkwNkM0LjM3NSA0LjQyOTY5IDQuMTg3NSA0LjUgNCA0LjVDMy43ODkwNiA0LjUgMy42MDE1NiA0LjQyOTY5IDMuNDYwOTQgNC4yODkwNkwwLjQ4NDM3NSAxLjI4OTA2QzAuMjUgMS4wNzgxMiAwLjE3OTY4OCAwLjc1IDAuMjk2ODc1IDAuNDY4NzVDMC40MTQwNjIgMC4xODc1IDAuNjk1MzEyIDAgMSAwSDYuOTc2NTZDNy4yODEyNSAwIDcuNTM5MDYgMC4xODc1IDcuNjU2MjUgMC40Njg3NUM3Ljc3MzQ0IDAuNzUgNy43MjY1NiAxLjA3ODEyIDcuNTE1NjIgMS4yODkwNloiIGZpbGw9IiM1QjVCNUIiLz4KPC9zdmc+Cg==";
     $clear: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA1MTIgNTEyIj4KICA8cGF0aAogICAgZD0iTTI1NiA1MTJBMjU2IDI1NiAwIDEgMCAyNTYgMGEyNTYgMjU2IDAgMSAwIDAgNTEyek0xNzUgMTc1YzkuNC05LjQgMjQuNi05LjQgMzMuOSAwbDQ3IDQ3IDQ3LTQ3YzkuNC05LjQgMjQuNi05LjQgMzMuOSAwczkuNCAyNC42IDAgMzMuOWwtNDcgNDcgNDcgNDdjOS40IDkuNCA5LjQgMjQuNiAwIDMzLjlzLTI0LjYgOS40LTMzLjkgMGwtNDctNDctNDcgNDdjLTkuNCA5LjQtMjQuNiA5LjQtMzMuOSAwcy05LjQtMjQuNiAwLTMzLjlsNDctNDctNDctNDdjLTkuNC05LjQtOS40LTI0LjYgMC0zMy45eiIKICAgIGZpbGw9IiM4NTg1ODUiCiAgLz4KPC9zdmc+Cg==";
     $clear-hover: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA1MTIgNTEyIj4KICA8cGF0aAogICAgZD0iTTI1NiA1MTJBMjU2IDI1NiAwIDEgMCAyNTYgMGEyNTYgMjU2IDAgMSAwIDAgNTEyek0xNzUgMTc1YzkuNC05LjQgMjQuNi05LjQgMzMuOSAwbDQ3IDQ3IDQ3LTQ3YzkuNC05LjQgMjQuNi05LjQgMzMuOSAwczkuNCAyNC42IDAgMzMuOWwtNDcgNDcgNDcgNDdjOS40IDkuNCA5LjQgMjQuNiAwIDMzLjlzLTI0LjYgOS40LTMzLjkgMGwtNDctNDctNDcgNDdjLTkuNCA5LjQtMjQuNiA5LjQtMzMuOSAwcy05LjQtMjQuNiAwLTMzLjlsNDctNDctNDctNDdjLTkuNC05LjQtOS40LTI0LjYgMC0zMy45eiIKICAgIGZpbGw9IiM1YjViNWIiCiAgLz4KPC9zdmc+Cg==";
 
-    $medium: 400;
-    $lato: $sans-serif-font-stack;
-
-    $light-stroke: $gray-20;
-    $active-stroke: $blue-30;
-
-    $active-fill: $blue-20;
-    $hover-fill: $gray-10;
-    $selected-fill: #c7ced7;
-
-    font: $medium 13px/16px $lato;
+    position: relative;
+    font: 400 13px/16px $sans-serif-font-stack;
 
     // fixes a bug in Firefox where long labels would cause the dropdown to resize,
     // see https://github.com/JedWatson/react-select/issues/5170
     display: grid;
     grid-template-columns: minmax(0, 1fr);
-
-    $option-checkmark-width: 12px;
 
     .placeholder {
         color: $gray-60;
@@ -32,50 +22,61 @@
     }
 
     .clear-indicator {
-        margin-right: 5px;
         padding-right: 10px;
-
-        // this is a trick to make the vertical border a bit longer
-        $scaleY: 1.25;
-        transform: scaleY($scaleY);
+        position: absolute;
+        right: 29px; // Leave space for the dropdown caret
+        top: 50%;
+        transform: translateY(-50%);
+        cursor: pointer;
         border-right: 1px solid #dadada;
+        background: none;
+        display: flex;
+        align-items: center;
+        z-index: 1;
+        height: calc(100% - 12px);
 
         &::after {
             content: " ";
             background: url($clear) no-repeat center;
             width: 12px;
             height: 12px;
-            transform: scaleY(math.div(1, $scaleY)); // invert scaling of parent
         }
 
         &:hover::after {
             background-image: url($clear-hover);
         }
-
-        svg {
-            display: none;
-        }
     }
 
     .control {
         min-height: auto;
-        font: $medium 13px/16px $lato;
+        font: 400 13px/16px $sans-serif-font-stack;
         letter-spacing: 0.01em;
+        text-align: left;
         display: flex;
         align-items: center;
-        border: 1px solid $light-stroke;
+        border: 1px solid $gray-20;
         border-radius: 4px;
         padding: 7px;
         color: $dark-text;
+        background: white;
+        cursor: pointer;
+        position: relative;
+        width: 100%;
 
-        &.focus {
-            outline: 1px solid $blue-30 !important;
+        &:focus-visible {
+            // Override global focus-visible style.
+            outline: 1px solid $blue-30;
             outline-offset: -1px;
         }
 
         &:hover {
-            background: $hover-fill;
-            cursor: pointer;
+            background: $grapher-dropdown-hover-fill;
+        }
+
+        &[data-disabled] {
+            opacity: 0.75;
+            cursor: default;
+            background: $gray-10;
         }
 
         &:after {
@@ -83,90 +84,112 @@
             background: url($menu-caret-down) no-repeat center;
             width: 16px;
             height: 16px;
+            margin-left: auto;
         }
 
-        &.active {
-            border-color: $active-stroke;
+        &.loading:after {
+            opacity: 0.5;
+        }
+
+        &[data-pressed] {
+            border-color: $blue-30;
             &:after {
                 background: url($menu-caret-up) no-repeat center;
             }
         }
-    }
 
-    .menu {
-        margin-top: 3px;
-        border-radius: 4px;
-        background: white;
-        box-shadow: 0px 4px 40px 0px rgba(0, 0, 0, 0.15);
-        z-index: $zindex-controls-popup;
-        color: $dark-text;
+        .label {
+            color: $gray-60;
 
-        .group-heading {
-            @include grapher_h5-black-caps;
-
-            font-size: 11px;
-            color: $light-text;
-
-            margin: 12px 8px 2px 8px;
-            font-weight: 700;
-        }
-
-        .group + .group .group-heading {
-            margin-top: 8px;
-            padding: 12px 0 2px 0;
-            border-top: 1px solid #f2f2f2;
-        }
-
-        .option {
-            padding: 8px calc(16px + $option-checkmark-width + 2px) 8px 16px;
-            &:hover,
-            &.focus {
-                cursor: pointer;
-                background: $hover-fill;
-            }
-            &:active,
-            &.active {
-                color: $active-text;
-                background: $active-fill;
-            }
-            &.active {
-                position: relative;
-                &:hover {
-                    background: $selected-fill;
-                }
-                &:after {
-                    content: " ";
-                    background: url($option-checkmark) no-repeat;
-                    width: $option-checkmark-width;
-                    height: 9px;
-                    position: absolute;
-                    right: 18px;
-                    bottom: 50%;
-                    transform: translateY(50%);
-                }
+            svg {
+                margin-left: 1px;
+                margin-right: 5px;
             }
         }
     }
 
-    // only show the label in the control; don't show it for each option
-    .option .label {
-        display: none;
+    .select-value {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        width: 100%;
+    }
+}
+
+.grapher-dropdown-menu {
+    $option-checkmark: "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTIiIGhlaWdodD0iOSIgdmlld0JveD0iMCAwIDEyIDkiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxwYXRoIGQ9Ik0xMS4wMTU2IDAuOTg0Mzc1QzExLjMyMDMgMS4yNjU2MiAxMS4zMjAzIDEuNzU3ODEgMTEuMDE1NiAyLjAzOTA2TDUuMDE1NjIgOC4wMzkwNkM0LjczNDM4IDguMzQzNzUgNC4yNDIxOSA4LjM0Mzc1IDMuOTYwOTQgOC4wMzkwNkwwLjk2MDkzOCA1LjAzOTA2QzAuNjU2MjUgNC43NTc4MSAwLjY1NjI1IDQuMjY1NjIgMC45NjA5MzggMy45ODQzOEMxLjI0MjE5IDMuNjc5NjkgMS43MzQzOCAzLjY3OTY5IDIuMDE1NjIgMy45ODQzOEw0LjQ3NjU2IDYuNDQ1MzFMOS45NjA5NCAwLjk4NDM3NUMxMC4yNDIyIDAuNjc5Njg4IDEwLjczNDQgMC42Nzk2ODggMTEuMDE1NiAwLjk4NDM3NVoiIGZpbGw9IiMxRDNENjMiLz4KPC9zdmc+";
+    $option-checkmark-width: 12px;
+    font: 400 13px/16px $sans-serif-font-stack;
+
+    margin-top: 3px;
+    border-radius: 4px;
+    background: white;
+    box-shadow: 0px 4px 40px 0px rgba(0, 0, 0, 0.15);
+    z-index: $zindex-controls-popup;
+    color: $dark-text;
+    width: var(--trigger-width);
+    overflow-y: auto;
+
+    .group-heading {
+        @include grapher_h5-black-caps;
+        font-size: 11px;
+        color: $light-text;
+        margin: 12px 8px 2px 8px;
+        font-weight: 700;
     }
 
-    .control .label {
-        color: $gray-60;
+    .group + .group .group-heading {
+        margin-top: 8px;
+        padding: 12px 0 2px 0;
+        border-top: 1px solid #f2f2f2;
+    }
 
-        svg {
-            margin-left: 1px;
-            margin-right: 5px;
+    .option {
+        padding: 8px calc(16px + $option-checkmark-width + 2px) 8px 16px;
+        cursor: pointer;
+
+        &[data-hovered],
+        &[data-focused] {
+            background: $grapher-dropdown-hover-fill;
         }
-    }
 
-    .option .detail {
-        color: $gray-60;
-    }
+        &:focus-visible {
+            // Override global focus-visible style.
+            outline: none !important;
+        }
 
-    .option.active .detail {
-        color: $blue-50;
+        &[data-pressed] {
+            color: $active-text;
+            background: $grapher-dropdown-active-fill;
+        }
+
+        &[data-selected] {
+            position: relative;
+            color: $active-text;
+            background: $grapher-dropdown-active-fill;
+
+            &:hover {
+                background: $grapher-dropdown-selected-fill;
+            }
+
+            &:after {
+                content: " ";
+                background: url($option-checkmark) no-repeat;
+                width: $option-checkmark-width;
+                height: 9px;
+                position: absolute;
+                right: 18px;
+                top: 50%;
+                transform: translateY(-50%);
+            }
+        }
+
+        .detail {
+            color: $gray-60;
+        }
+
+        &[data-selected] .detail {
+            color: $blue-50;
+        }
     }
 }

--- a/packages/@ourworldindata/grapher/src/controls/Dropdown.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/Dropdown.tsx
@@ -1,58 +1,195 @@
-import * as React from "react"
-import Select, { OptionProps, Props } from "react-select"
 import cx from "classnames"
+import * as React from "react"
+import { useMemo } from "react"
+import {
+    Button,
+    ListBox,
+    ListBoxItem,
+    ListBoxSection,
+    Popover,
+    Header,
+    Select,
+    SelectValue,
+    Key,
+} from "react-aria-components"
 
 export interface BasicDropdownOption {
     trackNote?: string
+    value: string
+    label: React.ReactNode
 }
 
-export function Dropdown<DropdownOption extends BasicDropdownOption>(
-    props: Props<DropdownOption, false>
-): React.ReactElement {
-    // Bringing our own Option component is necessary to add the data-track-note
-    // attribute that is used for tracking clicks in Grapher
-    const TrackedOption = (
-        optionProps: OptionProps<DropdownOption, false>
-    ): React.ReactElement => {
-        return (
-            <div
-                ref={optionProps.innerRef}
-                {...optionProps.innerProps}
-                className={cx("option", {
-                    focus: optionProps.isFocused,
-                    active: optionProps.isSelected,
-                })}
-                data-track-note={optionProps.data.trackNote}
-            >
-                {optionProps.children}
-            </div>
-        )
+export interface DropdownOptionGroup<
+    DropdownOption extends BasicDropdownOption,
+> {
+    label: React.ReactNode
+    options: DropdownOption[]
+}
+
+export type DropdownCollectionItem<DropdownOption extends BasicDropdownOption> =
+    DropdownOption | DropdownOptionGroup<DropdownOption>
+
+export type DropdownCollection<DropdownOption extends BasicDropdownOption> =
+    DropdownCollectionItem<DropdownOption>[]
+
+export interface DropdownProps<DropdownOption extends BasicDropdownOption> {
+    className?: string
+    menuClassName?: string
+    options: DropdownCollection<DropdownOption>
+    value?: DropdownOption | null
+    onChange?: (option: DropdownOption | null) => void
+    placeholder?: string
+    isDisabled?: boolean
+    isClearable?: boolean
+    isLoading?: boolean
+    renderTriggerValue?: (
+        option: DropdownOption | null
+    ) => React.ReactNode | undefined
+    renderMenuOption?: (option: DropdownOption) => React.ReactNode
+    "data-track-note"?: string
+    "aria-label"?: string
+}
+
+function isOptionGroup<DropdownOption extends BasicDropdownOption>(
+    item: DropdownCollectionItem<DropdownOption>
+): item is DropdownOptionGroup<DropdownOption> {
+    return (item as DropdownOptionGroup<DropdownOption>).options !== undefined
+}
+
+function flattenOptions<DropdownOption extends BasicDropdownOption>(
+    options: DropdownCollection<DropdownOption>
+): DropdownOption[] {
+    return options.flatMap((item) =>
+        isOptionGroup(item) ? item.options : [item]
+    )
+}
+
+export function Dropdown<DropdownOption extends BasicDropdownOption>({
+    className,
+    // We use a separate prop for the menu's className because the Popover
+    // (menu) doesn't render as a child of the select, so it's not trivial to
+    // style it using the main className.
+    menuClassName,
+    options,
+    value,
+    onChange,
+    placeholder,
+    isDisabled,
+    isClearable,
+    isLoading,
+    renderTriggerValue,
+    renderMenuOption,
+    ...otherProps
+}: DropdownProps<DropdownOption>): React.ReactElement {
+    const flatOptions = useMemo(() => flattenOptions(options), [options])
+    const selectedValue = value ?? null
+
+    function handleSelectionChange(key: Key | null): void {
+        if (key === null) {
+            onChange?.(null)
+            return
+        }
+
+        if (typeof key === "number") return
+        const selected = flatOptions.find((option) => option.value === key)
+        if (selected) {
+            onChange?.(selected)
+        }
     }
+
     return (
-        <Select<DropdownOption, false>
-            menuPlacement="bottom"
-            components={{
-                IndicatorSeparator: null,
-                DropdownIndicator: null,
-                Option: TrackedOption,
-            }}
-            isSearchable={false}
-            unstyled={true}
-            isMulti={false}
-            classNames={{
-                control: (state) =>
-                    cx("control", {
-                        focus: state.isFocused,
-                        active: state.menuIsOpen,
-                    }),
-                menu: () => "menu",
-                placeholder: () => "placeholder",
-                clearIndicator: () => "clear-indicator",
-                group: () => "group",
-                groupHeading: () => "group-heading",
-            }}
-            {...props}
-            className={cx("grapher-dropdown", props.className)}
-        />
+        <Select
+            className={cx("grapher-dropdown", className)}
+            // null means no selection, undefined means the component is
+            // uncontrolled, so we need to set it explicitly.
+            selectedKey={value?.value ?? null}
+            onSelectionChange={handleSelectionChange}
+            isDisabled={isDisabled}
+            {...otherProps}
+        >
+            <Button
+                className={cx("control", {
+                    loading: isLoading,
+                })}
+            >
+                <SelectValue className="select-value">
+                    {() => {
+                        const rendered = renderTriggerValue?.(selectedValue)
+                        if (rendered !== undefined) return rendered
+                        if (selectedValue)
+                            return selectedValue.label as React.ReactNode
+                        if (placeholder)
+                            return (
+                                <span className="placeholder">
+                                    {placeholder}
+                                </span>
+                            )
+                        return null
+                    }}
+                </SelectValue>
+            </Button>
+            {isClearable && value && (
+                <Button
+                    className="clear-indicator"
+                    slot={null}
+                    type="button"
+                    onPress={() => onChange?.(null)}
+                    aria-label="Clear selection"
+                />
+            )}
+            <Popover
+                className={cx("grapher-dropdown-menu", menuClassName)}
+                offset={4}
+            >
+                <ListBox>
+                    {options.map((item, index) =>
+                        isOptionGroup(item) ? (
+                            <ListBoxSection
+                                key={`section-${index}`}
+                                id={`section-${index}`}
+                                className="group"
+                            >
+                                <Header className="group-heading">
+                                    {item.label}
+                                </Header>
+                                {item.options.map((option) => (
+                                    <ListBoxItem
+                                        className="option"
+                                        key={option.value}
+                                        id={option.value}
+                                        textValue={
+                                            typeof option.label === "string"
+                                                ? option.label
+                                                : String(option.value)
+                                        }
+                                        data-track-note={option.trackNote}
+                                    >
+                                        {renderMenuOption
+                                            ? renderMenuOption(option)
+                                            : option.label}
+                                    </ListBoxItem>
+                                ))}
+                            </ListBoxSection>
+                        ) : (
+                            <ListBoxItem
+                                className="option"
+                                key={item.value}
+                                id={item.value}
+                                textValue={
+                                    typeof item.label === "string"
+                                        ? item.label
+                                        : String(item.value)
+                                }
+                                data-track-note={item.trackNote}
+                            >
+                                {renderMenuOption
+                                    ? renderMenuOption(item)
+                                    : item.label}
+                            </ListBoxItem>
+                        )
+                    )}
+                </ListBox>
+            </Popover>
+        </Select>
     )
 }

--- a/packages/@ourworldindata/grapher/src/controls/MapCountryDropdown.scss
+++ b/packages/@ourworldindata/grapher/src/controls/MapCountryDropdown.scss
@@ -1,9 +1,9 @@
 .map-country-dropdown {
     flex: 0 1 202px;
+}
 
-    .local-icon {
-        margin-left: 6px;
-        font-size: 0.9em;
-        color: #a1a1a1;
-    }
+.map-country-dropdown-local-icon {
+    margin-left: 6px;
+    font-size: 0.9em;
+    color: #a1a1a1;
 }

--- a/packages/@ourworldindata/grapher/src/controls/MapRegionDropdown.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/MapRegionDropdown.tsx
@@ -53,18 +53,13 @@ export class MapRegionDropdown extends React.Component<{
         return !!(!hideMapRegionDropdown && isOnMapTab && isMapSelectionEnabled)
     }
 
-    @action.bound onChange(
-        selected: MapRegionDropdownOption | null,
-        mode: { action: unknown }
-    ): void {
-        if (mode.action === "clear") {
+    @action.bound onChange(selected: MapRegionDropdownOption | null): void {
+        if (!selected) {
             this.manager.mapRegionDropdownValue = undefined
             this.mapConfig.region = MapRegionName.World
             this.manager.globeController?.hideGlobe()
             return
         }
-
-        if (!selected) return
 
         // update active option
         const { value } = selected

--- a/packages/@ourworldindata/grapher/src/controls/SearchDropdown.scss
+++ b/packages/@ourworldindata/grapher/src/controls/SearchDropdown.scss
@@ -1,28 +1,42 @@
 .grapher-search-dropdown {
     $magnifying-glass: "data:image/svg+xml;base64,PHN2ZwogICAgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIgogICAgdmlld0JveD0iMCAwIDUxMiA1MTIiCj4KICA8cGF0aAogICAgZD0iTTQxNiAyMDhjMCA0NS45LTE0LjkgODguMy00MCAxMjIuN0w1MDIuNiA0NTcuNGMxMi41IDEyLjUgMTIuNSAzMi44IDAgNDUuM3MtMzIuOCAxMi41LTQ1LjMgMEwzMzAuNyAzNzZjLTM0LjQgMjUuMi03Ni44IDQwLTEyMi43IDQwQzkzLjEgNDE2IDAgMzIyLjkgMCAyMDhTOTMuMSAwIDIwOCAwUzQxNiA5My4xIDQxNiAyMDh6TTIwOCAzNTJhMTQ0IDE0NCAwIDEgMCAwLTI4OCAxNDQgMTQ0IDAgMSAwIDAgMjg4eiIKICAgIGZpbGw9IiM4NTg1ODUiCiAgLz4KPC9zdmc+Cg==";
 
+    .control-wrapper {
+        position: relative;
+    }
+
+    .control-icon {
+        position: absolute;
+        left: 8px;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 12px;
+        height: 12px;
+        background: url($magnifying-glass) no-repeat center;
+    }
+
     .control {
-        &:before {
-            content: " ";
-            background: url($magnifying-glass) no-repeat center;
-            width: 12px;
-            height: 12px;
-            margin-right: 6px;
+        padding-left: 25px;
+        width: 100%;
+        height: 32px;
+
+        &::placeholder {
+            color: $gray-60;
+            font-size: 13px;
+            line-height: 16px;
         }
 
-        // overwrite hover of the Dropdown component
+        &[data-focused] {
+            outline: 1px solid $blue-30;
+            outline-offset: -1px;
+        }
+
         &:hover {
-            background: #fff;
-            cursor: default;
-        }
-
-        // hide caret
-        &:after {
-            display: none;
+            background: white;
         }
     }
 
-    input[type="text"] {
-        height: 16px;
+    &:hover .control {
+        background: white;
     }
 }

--- a/packages/@ourworldindata/grapher/src/controls/SearchDropdown.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/SearchDropdown.tsx
@@ -1,24 +1,159 @@
+import cx from "classnames"
 import * as React from "react"
-import { Props } from "react-select"
-import { BasicDropdownOption, Dropdown } from "./Dropdown.js"
+import { useMemo } from "react"
+import {
+    ComboBox,
+    Input,
+    Key,
+    ListBox,
+    ListBoxItem,
+    ListBoxSection,
+    Popover,
+    Header,
+} from "react-aria-components"
 import { isTouchDevice } from "@ourworldindata/utils"
+import {
+    BasicDropdownOption,
+    DropdownCollection,
+    DropdownCollectionItem,
+    DropdownOptionGroup,
+    DropdownProps,
+} from "./Dropdown.js"
 
-export function SearchDropdown<DropdownOption extends BasicDropdownOption>(
-    props: Props<DropdownOption, false>
-): React.ReactElement {
+interface SearchDropdownProps<DropdownOption extends BasicDropdownOption>
+    extends Omit<DropdownProps<DropdownOption>, "isClearable"> {
+    options: DropdownCollection<DropdownOption>
+    onFocus?: () => void
+    onInputChange?: (value: string) => void
+    inputValue?: string
+}
+
+function isOptionGroup<DropdownOption extends BasicDropdownOption>(
+    item: DropdownCollectionItem<DropdownOption>
+): item is DropdownOptionGroup<DropdownOption> {
+    return (item as DropdownOptionGroup<DropdownOption>).options !== undefined
+}
+
+function flattenOptions<DropdownOption extends BasicDropdownOption>(
+    options: DropdownCollection<DropdownOption>
+): DropdownOption[] {
+    return options.flatMap((item) =>
+        isOptionGroup(item) ? item.options : [item]
+    )
+}
+
+export function SearchDropdown<DropdownOption extends BasicDropdownOption>({
+    className,
+    options,
+    value,
+    onChange,
+    onFocus,
+    onInputChange,
+    placeholder,
+    isDisabled,
+    inputValue,
+    renderMenuOption,
+    ...otherProps
+}: SearchDropdownProps<DropdownOption>): React.ReactElement {
+    const flatOptions = useMemo(() => flattenOptions(options), [options])
+
+    function handleSelectionChange(key: Key | null): void {
+        if (key === null) {
+            onChange?.(null)
+            onInputChange?.("")
+            return
+        }
+        if (typeof key === "number") return
+        const selected = flatOptions.find((option) => option.value === key)
+        if (selected) {
+            onChange?.(selected)
+            onInputChange?.("")
+        }
+    }
+
+    function handleInputChange(value: string): void {
+        onInputChange?.(value)
+    }
+
     return (
-        <Dropdown
-            className="grapher-search-dropdown"
-            isSearchable={true}
-            noOptionsMessage={() => null}
-            // prevent auto-zoom on ios
-            styles={{
-                input: (provided) => ({
-                    ...provided,
-                    fontSize: isTouchDevice() ? 16 : provided.fontSize,
-                }),
-            }}
-            {...props}
-        />
+        <ComboBox
+            className={cx(
+                "grapher-dropdown grapher-search-dropdown",
+                className
+            )}
+            selectedKey={value?.value}
+            onSelectionChange={handleSelectionChange}
+            menuTrigger="focus"
+            isDisabled={isDisabled}
+            inputValue={inputValue}
+            onInputChange={handleInputChange}
+            {...otherProps}
+        >
+            <div className="control-wrapper">
+                <Input
+                    className="control"
+                    placeholder={placeholder}
+                    onFocus={onFocus}
+                    style={{
+                        fontSize: isTouchDevice() ? 16 : undefined,
+                    }}
+                />
+                <span className="control-icon"></span>
+            </div>
+            <Popover
+                className="grapher-dropdown-menu"
+                maxHeight={400}
+                offset={4}
+            >
+                <ListBox>
+                    {options.map((item, index) =>
+                        isOptionGroup(item) ? (
+                            <ListBoxSection
+                                key={`section-${index}`}
+                                id={`section-${index}`}
+                                className="group"
+                            >
+                                <Header className="group-heading">
+                                    {item.label}
+                                </Header>
+                                {item.options.map((option) => (
+                                    <ListBoxItem
+                                        className="option"
+                                        key={option.value}
+                                        id={option.value}
+                                        textValue={
+                                            typeof option.label === "string"
+                                                ? option.label
+                                                : String(option.value)
+                                        }
+                                        data-track-note={option.trackNote}
+                                    >
+                                        {renderMenuOption
+                                            ? renderMenuOption(option)
+                                            : option.label}
+                                    </ListBoxItem>
+                                ))}
+                            </ListBoxSection>
+                        ) : (
+                            <ListBoxItem
+                                className="option"
+                                key={item.value}
+                                id={item.value}
+                                textValue={
+                                    typeof item.label === "string"
+                                        ? item.label
+                                        : String(item.value)
+                                }
+                                data-track-note={item.trackNote}
+                            >
+                                {renderMenuOption
+                                    ? renderMenuOption(item)
+                                    : item.label}
+                            </ListBoxItem>
+                        )
+                    )}
+                </ListBox>
+            </Popover>
+        </ComboBox>
     )
 }

--- a/packages/@ourworldindata/grapher/src/controls/entityPicker/EntityPicker.scss
+++ b/packages/@ourworldindata/grapher/src/controls/entityPicker/EntityPicker.scss
@@ -63,9 +63,6 @@ $zindex-dropdown: 100;
 
     .metricDropdown {
         flex: 1;
-        font-size: 14px;
-        font-weight: 700;
-        color: $blue-100;
     }
 
     .sort {

--- a/packages/@ourworldindata/grapher/src/core/grapher.scss
+++ b/packages/@ourworldindata/grapher/src/core/grapher.scss
@@ -58,7 +58,6 @@ $zindex-controls-drawer: 150;
     @import "../popover/Popover.scss";
     @import "../controls/SettingsMenu.scss";
     @import "../controls/MapRegionDropdown.scss";
-    @import "../controls/MapCountryDropdown.scss";
     @import "../captionedChart/CaptionedChart.scss";
     @import "../timeline/TimelineComponent.scss";
     @import "../controls/ContentSwitchers.scss";
@@ -80,13 +79,10 @@ $zindex-controls-drawer: 150;
     @import "../tabs/ExpandableTabs.scss";
     @import "../slideInDrawer/SlideInDrawer.scss";
     @import "../sidePanel/SidePanel.scss";
-    @import "../controls/Dropdown.scss";
-    @import "../controls/SearchDropdown.scss";
     @import "../scatterCharts/NoDataSection.scss";
     @import "../controls/CloseGlobeViewButton.scss";
     @import "../controls/GlobeSwitcher.scss";
     @import "../mapCharts/MapChart.scss";
-    @import "../controls/DataTableFilterDropdown.scss";
     @import "../controls/SearchField.scss";
     @import "../controls/DataTableSearchField.scss";
 }
@@ -102,6 +98,11 @@ $zindex-controls-drawer: 150;
 
 @import "../../../components/src/closeButton/CloseButton.scss";
 @import "../../../components/src/OverlayHeader.scss";
+
+@import "../controls/Dropdown.scss";
+@import "../controls/DataTableFilterDropdown.scss";
+@import "../controls/SearchDropdown.scss";
+@import "../controls/MapCountryDropdown.scss";
 
 .grapher_dark {
     color: $dark-text;

--- a/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
+++ b/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
@@ -1375,7 +1375,8 @@ export class EntitySelector extends React.Component<EntitySelectorProps> {
                     options={this.filterOptions}
                     onChange={this.onChangeEntityFilter}
                     value={this.filterValue}
-                    formatOptionLabel={formatFilterOptionLabel}
+                    renderTriggerValue={renderFilterTriggerValue}
+                    renderMenuOption={renderFilterMenuOption}
                     aria-label="Filter by type"
                 />
             </div>
@@ -1410,7 +1411,8 @@ export class EntitySelector extends React.Component<EntitySelectorProps> {
                         onChange={this.onChangeSortSlug}
                         value={this.sortValue}
                         isLoading={this.isLoadingExternalSortColumn}
-                        formatOptionLabel={formatSortOptionLabel}
+                        renderTriggerValue={renderSortTriggerValue}
+                        renderMenuOption={renderSortMenuOption}
                         aria-label="Sort by"
                     />
                     <button
@@ -1765,7 +1767,10 @@ function FlippedListItem({
     )
 }
 
-function formatSortOptionLabel(option: SortDropdownOption): React.ReactElement {
+function renderSortTriggerValue(
+    option: SortDropdownOption | null
+): React.ReactNode | undefined {
+    if (!option) return undefined
     return (
         <>
             <span className="label">
@@ -1780,15 +1785,35 @@ function formatSortOptionLabel(option: SortDropdownOption): React.ReactElement {
     )
 }
 
-function formatFilterOptionLabel(
-    option: FilterDropdownOption
-): React.ReactElement {
+function renderSortMenuOption(option: SortDropdownOption): React.ReactNode {
+    return (
+        <>
+            {option.label}
+            {option.formattedTime && (
+                <span className="detail">, {option.formattedTime}</span>
+            )}
+        </>
+    )
+}
+
+function renderFilterTriggerValue(
+    option: FilterDropdownOption | null
+): React.ReactNode | undefined {
+    if (!option) return undefined
     return (
         <>
             <span className="label">
                 <FontAwesomeIcon icon={faFilter} size="sm" />
                 {"Filter by type: "}
             </span>
+            {option.label} <span className="detail">({option.count})</span>
+        </>
+    )
+}
+
+function renderFilterMenuOption(option: FilterDropdownOption): React.ReactNode {
+    return (
+        <>
             {option.label} <span className="detail">({option.count})</span>
         </>
     )

--- a/packages/@ourworldindata/grapher/src/index.ts
+++ b/packages/@ourworldindata/grapher/src/index.ts
@@ -131,6 +131,8 @@ export {
 export { GeoFeatures } from "./mapCharts/GeoFeatures"
 export { isValidVerticalComparisonLineConfig } from "./comparisonLine/ComparisonLineHelpers"
 export { hasValidConfigForBinningStrategy } from "./color/BinningStrategies"
+export { Dropdown } from "./controls/Dropdown"
+export { SearchDropdown } from "./controls/SearchDropdown"
 
 export { makeChartState } from "./chart/ChartTypeMap"
 export type { ChartState } from "./chart/ChartInterface"

--- a/site/multiDim/DimensionDropdown.scss
+++ b/site/multiDim/DimensionDropdown.scss
@@ -24,6 +24,11 @@ $toggle-full-width-breakpoint: 520px;
         visibility: hidden;
     }
 
+    &:focus-visible {
+        // Override global focus-visible style.
+        outline: none !important;
+    }
+
     &:hover:not([data-disabled]),
     &:focus:not([data-disabled]) {
         border-color: $blue-30;
@@ -175,6 +180,10 @@ $toggle-full-width-breakpoint: 520px;
         padding: 16px 0;
         border-bottom: 1px solid $gray-20;
         cursor: pointer;
+
+        &:focus-visible {
+            outline: none !important;
+        }
 
         &:first-of-type {
             padding-top: 0;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2328,40 +2328,40 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@internationalized/date@npm:^3.8.1":
-  version: 3.8.1
-  resolution: "@internationalized/date@npm:3.8.1"
+"@internationalized/date@npm:^3.10.0":
+  version: 3.10.0
+  resolution: "@internationalized/date@npm:3.10.0"
   dependencies:
     "@swc/helpers": "npm:^0.5.0"
-  checksum: 10/caf718fd973386e6785852776f3b728f5adc855276b843ad57d7f72633397ac3daa6d91a68d4f6694dc15d19190e23de9977f55a996f3315cb36a8d3cc9719d8
+  checksum: 10/5940667ea2b0be54b798088ef995f787508bf4305d3741babc8b1f48de008c872555a5440ae61fa7399461a7339d3257fb8e86cc2111e72e185fc37d99e06392
   languageName: node
   linkType: hard
 
-"@internationalized/message@npm:^3.1.7":
-  version: 3.1.7
-  resolution: "@internationalized/message@npm:3.1.7"
+"@internationalized/message@npm:^3.1.8":
+  version: 3.1.8
+  resolution: "@internationalized/message@npm:3.1.8"
   dependencies:
     "@swc/helpers": "npm:^0.5.0"
     intl-messageformat: "npm:^10.1.0"
-  checksum: 10/57d0a7277e7c90b478f4981707f3222f3de2603aad1ac6bf42deb8bbc6eb5695496906e2e852385cfc3fe860d928e994bd01fe1dde144e415a41231c52348f27
+  checksum: 10/8f27a31f5d1eef7084447ed141e896e12cc19d786a1346ba60137de5b8bcc58a9da978d79954e2a74302aa673f942fb772130ebd6195565e33db30bd7eb4ef47
   languageName: node
   linkType: hard
 
-"@internationalized/number@npm:^3.6.2":
-  version: 3.6.2
-  resolution: "@internationalized/number@npm:3.6.2"
+"@internationalized/number@npm:^3.6.5":
+  version: 3.6.5
+  resolution: "@internationalized/number@npm:3.6.5"
   dependencies:
     "@swc/helpers": "npm:^0.5.0"
-  checksum: 10/a8faaa3101754acdd0b13f9dad51aae88dc9bdacca0d5ae96127324b2076ed7444e6ba5c1e1b5799fdae09e63c55170e546139344a83fd9aef6e01d73cc54c43
+  checksum: 10/f80618842b9b8ea04e235277911eeb8e2ee129f1b266b94704a9f773df7536486c25db41ae708f6c2f4845cdb0a25e7d1856332370daba6c530528ac0ee997e3
   languageName: node
   linkType: hard
 
-"@internationalized/string@npm:^3.2.6":
-  version: 3.2.6
-  resolution: "@internationalized/string@npm:3.2.6"
+"@internationalized/string@npm:^3.2.7":
+  version: 3.2.7
+  resolution: "@internationalized/string@npm:3.2.7"
   dependencies:
     "@swc/helpers": "npm:^0.5.0"
-  checksum: 10/d9fa35814be43e9b6770f3f9280581d7bbd8022861ab2223c9366cadee186c9be236a9a48af1dadf0aad1591ffc11cf104dd587a367a65c453bbc487a6bcce3d
+  checksum: 10/38b54817cf125ba88d1136a6bca4fb57c46672d26d21490f838efe928049546800df6d9c8048411696455fc8caacb8ac23c2de2a1b61f2258b1302c1c97cc128
   languageName: node
   linkType: hard
 
@@ -3063,7 +3063,6 @@ __metadata:
     react-dom: "npm:^19.1.0"
     react-flip-toolkit: "npm:^7.2.4"
     react-move: "npm:^6.5.0"
-    react-select: "npm:^5.10.2"
     remeda: "npm:^2.32.0"
     simple-statistics: "npm:^7.3.2"
     topojson-client: "npm:^3.1.0"
@@ -3115,6 +3114,7 @@ __metadata:
     mobx-react: "npm:^7.6.0"
     mousetrap: "npm:^1.6.5"
     react: "npm:^19.1.0"
+    react-aria-components: "npm:^1.13.0"
     react-dom: "npm:^19.1.0"
     react-flip-toolkit: "npm:^7.2.4"
     react-move: "npm:^6.5.0"
@@ -3495,928 +3495,928 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-aria/autocomplete@npm:3.0.0-beta.3":
-  version: 3.0.0-beta.3
-  resolution: "@react-aria/autocomplete@npm:3.0.0-beta.3"
+"@react-aria/autocomplete@npm:3.0.0-rc.3":
+  version: 3.0.0-rc.3
+  resolution: "@react-aria/autocomplete@npm:3.0.0-rc.3"
   dependencies:
-    "@react-aria/combobox": "npm:^3.12.3"
-    "@react-aria/focus": "npm:^3.20.3"
-    "@react-aria/i18n": "npm:^3.12.9"
-    "@react-aria/interactions": "npm:^3.25.1"
-    "@react-aria/listbox": "npm:^3.14.4"
-    "@react-aria/searchfield": "npm:^3.8.4"
-    "@react-aria/textfield": "npm:^3.17.3"
-    "@react-aria/utils": "npm:^3.29.0"
-    "@react-stately/autocomplete": "npm:3.0.0-beta.1"
-    "@react-stately/combobox": "npm:^3.10.5"
-    "@react-types/autocomplete": "npm:3.0.0-alpha.31"
-    "@react-types/button": "npm:^3.12.1"
-    "@react-types/shared": "npm:^3.29.1"
+    "@react-aria/combobox": "npm:^3.14.0"
+    "@react-aria/focus": "npm:^3.21.2"
+    "@react-aria/i18n": "npm:^3.12.13"
+    "@react-aria/interactions": "npm:^3.25.6"
+    "@react-aria/listbox": "npm:^3.15.0"
+    "@react-aria/searchfield": "npm:^3.8.9"
+    "@react-aria/textfield": "npm:^3.18.2"
+    "@react-aria/utils": "npm:^3.31.0"
+    "@react-stately/autocomplete": "npm:3.0.0-beta.3"
+    "@react-stately/combobox": "npm:^3.12.0"
+    "@react-types/autocomplete": "npm:3.0.0-alpha.35"
+    "@react-types/button": "npm:^3.14.1"
+    "@react-types/shared": "npm:^3.32.1"
     "@swc/helpers": "npm:^0.5.0"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
     react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/154328025c44e6e1d5df0ec996e343a62ecbfe55faa2805f957dbad9307da4c9b0912e80eea6c65c63e3789afae7d58a5802522744c1e7e44f0897e9740f6933
+  checksum: 10/7acddd01b0f07bdbd2cf09d01a8b0fb9551d27656a92adf995411620a1599f8ff6421a72de1fcd56611d5eced49073cae48aee8127f3620fc1ca38d4ce3dcb62
   languageName: node
   linkType: hard
 
-"@react-aria/breadcrumbs@npm:^3.5.24":
-  version: 3.5.24
-  resolution: "@react-aria/breadcrumbs@npm:3.5.24"
+"@react-aria/breadcrumbs@npm:^3.5.29":
+  version: 3.5.29
+  resolution: "@react-aria/breadcrumbs@npm:3.5.29"
   dependencies:
-    "@react-aria/i18n": "npm:^3.12.9"
-    "@react-aria/link": "npm:^3.8.1"
-    "@react-aria/utils": "npm:^3.29.0"
-    "@react-types/breadcrumbs": "npm:^3.7.13"
-    "@react-types/shared": "npm:^3.29.1"
+    "@react-aria/i18n": "npm:^3.12.13"
+    "@react-aria/link": "npm:^3.8.6"
+    "@react-aria/utils": "npm:^3.31.0"
+    "@react-types/breadcrumbs": "npm:^3.7.17"
+    "@react-types/shared": "npm:^3.32.1"
     "@swc/helpers": "npm:^0.5.0"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
     react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/91d9950d0e3fdef7900b16eb2c01f0a79139cecf92f4dafd7cbd7aa0d4f08ea6c179522f3446b7d73e9b37ea858c66e904adfcb152878466b49e27fc659b43c7
+  checksum: 10/875c2280539362e33200a9869dc52e5cec8a7407e068faa70cc190eaf266135448410acf9dd37b59bd86e53f330ac32e7598ceec468a2339cc04f18f826c4cbc
   languageName: node
   linkType: hard
 
-"@react-aria/button@npm:^3.13.1":
-  version: 3.13.1
-  resolution: "@react-aria/button@npm:3.13.1"
+"@react-aria/button@npm:^3.14.2":
+  version: 3.14.2
+  resolution: "@react-aria/button@npm:3.14.2"
   dependencies:
-    "@react-aria/interactions": "npm:^3.25.1"
-    "@react-aria/toolbar": "npm:3.0.0-beta.16"
-    "@react-aria/utils": "npm:^3.29.0"
-    "@react-stately/toggle": "npm:^3.8.4"
-    "@react-types/button": "npm:^3.12.1"
-    "@react-types/shared": "npm:^3.29.1"
+    "@react-aria/interactions": "npm:^3.25.6"
+    "@react-aria/toolbar": "npm:3.0.0-beta.21"
+    "@react-aria/utils": "npm:^3.31.0"
+    "@react-stately/toggle": "npm:^3.9.2"
+    "@react-types/button": "npm:^3.14.1"
+    "@react-types/shared": "npm:^3.32.1"
     "@swc/helpers": "npm:^0.5.0"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
     react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/1b4fc1ec142509767759a7270ca22520cfc6f70315f147aab3dc64537fb7f55b915318927d430e41375d810957849bdd2a7f35e0459c9c407f48bb312a0db750
+  checksum: 10/d6891ab39a81b349a80ac2c381a5663e33caf209d29aa536b0a8ca2963898b011913593c71f4bceb3f48a54a95cd5bc842b0ffbb33498d38a120d1a6d28f932b
   languageName: node
   linkType: hard
 
-"@react-aria/calendar@npm:^3.8.1":
-  version: 3.8.1
-  resolution: "@react-aria/calendar@npm:3.8.1"
+"@react-aria/calendar@npm:^3.9.2":
+  version: 3.9.2
+  resolution: "@react-aria/calendar@npm:3.9.2"
   dependencies:
-    "@internationalized/date": "npm:^3.8.1"
-    "@react-aria/i18n": "npm:^3.12.9"
-    "@react-aria/interactions": "npm:^3.25.1"
-    "@react-aria/live-announcer": "npm:^3.4.2"
-    "@react-aria/utils": "npm:^3.29.0"
-    "@react-stately/calendar": "npm:^3.8.1"
-    "@react-types/button": "npm:^3.12.1"
-    "@react-types/calendar": "npm:^3.7.1"
-    "@react-types/shared": "npm:^3.29.1"
+    "@internationalized/date": "npm:^3.10.0"
+    "@react-aria/i18n": "npm:^3.12.13"
+    "@react-aria/interactions": "npm:^3.25.6"
+    "@react-aria/live-announcer": "npm:^3.4.4"
+    "@react-aria/utils": "npm:^3.31.0"
+    "@react-stately/calendar": "npm:^3.9.0"
+    "@react-types/button": "npm:^3.14.1"
+    "@react-types/calendar": "npm:^3.8.0"
+    "@react-types/shared": "npm:^3.32.1"
     "@swc/helpers": "npm:^0.5.0"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
     react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/52b8712ea084a8e61f469cbce2c4f34546dd0dd4e1f4c3de32c9e9e5160b13cfbeebe0b4043baadcb0d03cff3a45a078ad13cfec682b37e94061f38ccb0ded89
+  checksum: 10/3697b14765895c864db1a9393b86e0370cda01fab44464e9c1966150d7c793bcc9fd1e7a50d34022b0730fcaf9fd1995d431ccb1b5518eb086ccfb4b35e47ff2
   languageName: node
   linkType: hard
 
-"@react-aria/checkbox@npm:^3.15.5":
-  version: 3.15.5
-  resolution: "@react-aria/checkbox@npm:3.15.5"
+"@react-aria/checkbox@npm:^3.16.2":
+  version: 3.16.2
+  resolution: "@react-aria/checkbox@npm:3.16.2"
   dependencies:
-    "@react-aria/form": "npm:^3.0.16"
-    "@react-aria/interactions": "npm:^3.25.1"
-    "@react-aria/label": "npm:^3.7.18"
-    "@react-aria/toggle": "npm:^3.11.3"
-    "@react-aria/utils": "npm:^3.29.0"
-    "@react-stately/checkbox": "npm:^3.6.14"
-    "@react-stately/form": "npm:^3.1.4"
-    "@react-stately/toggle": "npm:^3.8.4"
-    "@react-types/checkbox": "npm:^3.9.4"
-    "@react-types/shared": "npm:^3.29.1"
+    "@react-aria/form": "npm:^3.1.2"
+    "@react-aria/interactions": "npm:^3.25.6"
+    "@react-aria/label": "npm:^3.7.22"
+    "@react-aria/toggle": "npm:^3.12.2"
+    "@react-aria/utils": "npm:^3.31.0"
+    "@react-stately/checkbox": "npm:^3.7.2"
+    "@react-stately/form": "npm:^3.2.2"
+    "@react-stately/toggle": "npm:^3.9.2"
+    "@react-types/checkbox": "npm:^3.10.2"
+    "@react-types/shared": "npm:^3.32.1"
     "@swc/helpers": "npm:^0.5.0"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
     react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/7cc59b1f1f348f1a1033a2cda7271de6cc8932d1e61906e38e1cf5368c3f1aa061c11a7a895c38b669fdeafd3ded90ee314e7fb92094280fab2dee46a06e7aae
+  checksum: 10/77058d41d78b8feea4801022ba56f225b69f9b6577edc42a747dea21e4b38ea8d343f3a38455e9ae47a95a41b77e37fa0929a7136507f7b446111919f5e34478
   languageName: node
   linkType: hard
 
-"@react-aria/collections@npm:3.0.0-rc.1":
-  version: 3.0.0-rc.1
-  resolution: "@react-aria/collections@npm:3.0.0-rc.1"
+"@react-aria/collections@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@react-aria/collections@npm:3.0.0"
   dependencies:
-    "@react-aria/interactions": "npm:^3.25.1"
-    "@react-aria/ssr": "npm:^3.9.8"
-    "@react-aria/utils": "npm:^3.29.0"
-    "@react-types/shared": "npm:^3.29.1"
+    "@react-aria/interactions": "npm:^3.25.6"
+    "@react-aria/ssr": "npm:^3.9.10"
+    "@react-aria/utils": "npm:^3.31.0"
+    "@react-types/shared": "npm:^3.32.1"
     "@swc/helpers": "npm:^0.5.0"
     use-sync-external-store: "npm:^1.4.0"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
     react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/17ef711eef72aac74c105ac91af2f360a2742eb26fa4ac5e542a2df1a5ec87b522eddfbd712d01ebd3d9611c6c6b8d0c22b0900cc534ff7c41641e24641248c6
+  checksum: 10/2704d35e0cc67e8e2f7fa61f593160768a633e2ff3ced45f01806928dc15738dcd005c49ff7130c0c92fbaabf0b0624833e54b7d24a10181c7910a469a9da52b
   languageName: node
   linkType: hard
 
-"@react-aria/color@npm:^3.0.7":
-  version: 3.0.7
-  resolution: "@react-aria/color@npm:3.0.7"
+"@react-aria/color@npm:^3.1.2":
+  version: 3.1.2
+  resolution: "@react-aria/color@npm:3.1.2"
   dependencies:
-    "@react-aria/i18n": "npm:^3.12.9"
-    "@react-aria/interactions": "npm:^3.25.1"
-    "@react-aria/numberfield": "npm:^3.11.14"
-    "@react-aria/slider": "npm:^3.7.19"
-    "@react-aria/spinbutton": "npm:^3.6.15"
-    "@react-aria/textfield": "npm:^3.17.3"
-    "@react-aria/utils": "npm:^3.29.0"
-    "@react-aria/visually-hidden": "npm:^3.8.23"
-    "@react-stately/color": "npm:^3.8.5"
-    "@react-stately/form": "npm:^3.1.4"
-    "@react-types/color": "npm:^3.0.5"
-    "@react-types/shared": "npm:^3.29.1"
+    "@react-aria/i18n": "npm:^3.12.13"
+    "@react-aria/interactions": "npm:^3.25.6"
+    "@react-aria/numberfield": "npm:^3.12.2"
+    "@react-aria/slider": "npm:^3.8.2"
+    "@react-aria/spinbutton": "npm:^3.6.19"
+    "@react-aria/textfield": "npm:^3.18.2"
+    "@react-aria/utils": "npm:^3.31.0"
+    "@react-aria/visually-hidden": "npm:^3.8.28"
+    "@react-stately/color": "npm:^3.9.2"
+    "@react-stately/form": "npm:^3.2.2"
+    "@react-types/color": "npm:^3.1.2"
+    "@react-types/shared": "npm:^3.32.1"
     "@swc/helpers": "npm:^0.5.0"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
     react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/6ed9fb284fb12a9eea07ec629a23f1095be2abf3b7d2d50335f426524a96780bc69b8d0a95088f6cbb5a293363f465cd498515cd6ea390504e20d681d2203da9
+  checksum: 10/8b2c29097e86e2fa30bb5a53777dd09a7b2b24f6fb44ac1847275345aa895bb663735dcdc94bac90ba6fee074f11fe571f7effc5ba4ac4adb0bc87f67705479c
   languageName: node
   linkType: hard
 
-"@react-aria/combobox@npm:^3.12.3":
-  version: 3.12.3
-  resolution: "@react-aria/combobox@npm:3.12.3"
-  dependencies:
-    "@react-aria/focus": "npm:^3.20.3"
-    "@react-aria/i18n": "npm:^3.12.9"
-    "@react-aria/listbox": "npm:^3.14.4"
-    "@react-aria/live-announcer": "npm:^3.4.2"
-    "@react-aria/menu": "npm:^3.18.3"
-    "@react-aria/overlays": "npm:^3.27.1"
-    "@react-aria/selection": "npm:^3.24.1"
-    "@react-aria/textfield": "npm:^3.17.3"
-    "@react-aria/utils": "npm:^3.29.0"
-    "@react-stately/collections": "npm:^3.12.4"
-    "@react-stately/combobox": "npm:^3.10.5"
-    "@react-stately/form": "npm:^3.1.4"
-    "@react-types/button": "npm:^3.12.1"
-    "@react-types/combobox": "npm:^3.13.5"
-    "@react-types/shared": "npm:^3.29.1"
-    "@swc/helpers": "npm:^0.5.0"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/d626a2e91e4afadda214dad3834f60678fea70b9e4e48f59744a532baad80e5e927a784cea4396d63c2ebdc2c19a5c65e07aaad0c248b1a17b26a86911e703ae
-  languageName: node
-  linkType: hard
-
-"@react-aria/datepicker@npm:^3.14.3":
-  version: 3.14.3
-  resolution: "@react-aria/datepicker@npm:3.14.3"
-  dependencies:
-    "@internationalized/date": "npm:^3.8.1"
-    "@internationalized/number": "npm:^3.6.2"
-    "@internationalized/string": "npm:^3.2.6"
-    "@react-aria/focus": "npm:^3.20.3"
-    "@react-aria/form": "npm:^3.0.16"
-    "@react-aria/i18n": "npm:^3.12.9"
-    "@react-aria/interactions": "npm:^3.25.1"
-    "@react-aria/label": "npm:^3.7.18"
-    "@react-aria/spinbutton": "npm:^3.6.15"
-    "@react-aria/utils": "npm:^3.29.0"
-    "@react-stately/datepicker": "npm:^3.14.1"
-    "@react-stately/form": "npm:^3.1.4"
-    "@react-types/button": "npm:^3.12.1"
-    "@react-types/calendar": "npm:^3.7.1"
-    "@react-types/datepicker": "npm:^3.12.1"
-    "@react-types/dialog": "npm:^3.5.18"
-    "@react-types/shared": "npm:^3.29.1"
-    "@swc/helpers": "npm:^0.5.0"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/90d3753b67b4ee61b959fbdf042fc9bef6bf397a47b8e3a78f7c05d87f8b21cbe24c8d3c55edbfedfc343ba6f9c858ac19c5f87faa3b01f90a76ad3a5b82ccc0
-  languageName: node
-  linkType: hard
-
-"@react-aria/dialog@npm:^3.5.25":
-  version: 3.5.25
-  resolution: "@react-aria/dialog@npm:3.5.25"
-  dependencies:
-    "@react-aria/interactions": "npm:^3.25.1"
-    "@react-aria/overlays": "npm:^3.27.1"
-    "@react-aria/utils": "npm:^3.29.0"
-    "@react-types/dialog": "npm:^3.5.18"
-    "@react-types/shared": "npm:^3.29.1"
-    "@swc/helpers": "npm:^0.5.0"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/33dedc1914e1268d8a6061bc01dfc74d3acf2d9c4092fb62dfa377a718573ae4020609c28271377fdd67137e5ca61fb9ded0d8134ebea86e9b031eb35d9b39aa
-  languageName: node
-  linkType: hard
-
-"@react-aria/disclosure@npm:^3.0.5":
-  version: 3.0.5
-  resolution: "@react-aria/disclosure@npm:3.0.5"
-  dependencies:
-    "@react-aria/ssr": "npm:^3.9.8"
-    "@react-aria/utils": "npm:^3.29.0"
-    "@react-stately/disclosure": "npm:^3.0.4"
-    "@react-types/button": "npm:^3.12.1"
-    "@swc/helpers": "npm:^0.5.0"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/1e8cbc3b83d41aef174e8b6eceeca223c5d537f49351ad0a90f30805b150f3bd450870a4ff2990f29c5ec19f0b2f202dd7676c0c1db4110b3dcc8326a0e1d433
-  languageName: node
-  linkType: hard
-
-"@react-aria/dnd@npm:^3.9.3":
-  version: 3.9.3
-  resolution: "@react-aria/dnd@npm:3.9.3"
-  dependencies:
-    "@internationalized/string": "npm:^3.2.6"
-    "@react-aria/i18n": "npm:^3.12.9"
-    "@react-aria/interactions": "npm:^3.25.1"
-    "@react-aria/live-announcer": "npm:^3.4.2"
-    "@react-aria/overlays": "npm:^3.27.1"
-    "@react-aria/utils": "npm:^3.29.0"
-    "@react-stately/dnd": "npm:^3.5.4"
-    "@react-types/button": "npm:^3.12.1"
-    "@react-types/shared": "npm:^3.29.1"
-    "@swc/helpers": "npm:^0.5.0"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/b85e6d8129080f08edb756d68eecda003f415ea2ff9b5d1efaf362eb778b20cc620a0a1d1f194f46bf74cfad08b5d97dd6ea25d597f02092e3c744a4174a2380
-  languageName: node
-  linkType: hard
-
-"@react-aria/focus@npm:^3.20.3":
-  version: 3.20.3
-  resolution: "@react-aria/focus@npm:3.20.3"
-  dependencies:
-    "@react-aria/interactions": "npm:^3.25.1"
-    "@react-aria/utils": "npm:^3.29.0"
-    "@react-types/shared": "npm:^3.29.1"
-    "@swc/helpers": "npm:^0.5.0"
-    clsx: "npm:^2.0.0"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/c0159499d5be26e74d0aebd92a229db676ad6a68320b84358a7a12a2cca2695a5c02c1bf14decbb766669535cb7095abdaa990668321b3cf4feaab2a1ba8b076
-  languageName: node
-  linkType: hard
-
-"@react-aria/form@npm:^3.0.16":
-  version: 3.0.16
-  resolution: "@react-aria/form@npm:3.0.16"
-  dependencies:
-    "@react-aria/interactions": "npm:^3.25.1"
-    "@react-aria/utils": "npm:^3.29.0"
-    "@react-stately/form": "npm:^3.1.4"
-    "@react-types/shared": "npm:^3.29.1"
-    "@swc/helpers": "npm:^0.5.0"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/6b16100c103f4349c2c486f4d8f14ec2827bf9ac83d5053b709dbabea73b8ddf093faf6dc041889308e39bb211672bd72c4c92fcc0ea2f9670c97b8c86559342
-  languageName: node
-  linkType: hard
-
-"@react-aria/grid@npm:^3.14.0":
+"@react-aria/combobox@npm:^3.14.0":
   version: 3.14.0
-  resolution: "@react-aria/grid@npm:3.14.0"
+  resolution: "@react-aria/combobox@npm:3.14.0"
   dependencies:
-    "@react-aria/focus": "npm:^3.20.3"
-    "@react-aria/i18n": "npm:^3.12.9"
-    "@react-aria/interactions": "npm:^3.25.1"
-    "@react-aria/live-announcer": "npm:^3.4.2"
-    "@react-aria/selection": "npm:^3.24.1"
-    "@react-aria/utils": "npm:^3.29.0"
-    "@react-stately/collections": "npm:^3.12.4"
-    "@react-stately/grid": "npm:^3.11.2"
-    "@react-stately/selection": "npm:^3.20.2"
-    "@react-types/checkbox": "npm:^3.9.4"
-    "@react-types/grid": "npm:^3.3.2"
-    "@react-types/shared": "npm:^3.29.1"
+    "@react-aria/focus": "npm:^3.21.2"
+    "@react-aria/i18n": "npm:^3.12.13"
+    "@react-aria/listbox": "npm:^3.15.0"
+    "@react-aria/live-announcer": "npm:^3.4.4"
+    "@react-aria/menu": "npm:^3.19.3"
+    "@react-aria/overlays": "npm:^3.30.0"
+    "@react-aria/selection": "npm:^3.26.0"
+    "@react-aria/textfield": "npm:^3.18.2"
+    "@react-aria/utils": "npm:^3.31.0"
+    "@react-stately/collections": "npm:^3.12.8"
+    "@react-stately/combobox": "npm:^3.12.0"
+    "@react-stately/form": "npm:^3.2.2"
+    "@react-types/button": "npm:^3.14.1"
+    "@react-types/combobox": "npm:^3.13.9"
+    "@react-types/shared": "npm:^3.32.1"
     "@swc/helpers": "npm:^0.5.0"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
     react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/bef0d85d605c51d43d23f069cfc7f15a41e2be42e8f7bae683596c252f2ca74e9c1bb8b8d41b6ca745b43769834ddd3c56c0b19fa947988f2a2a2b4aa18845c7
+  checksum: 10/e583a99133b884e49b5848271a18d3dcbc6fdb4fb9aa9477d2164790b7386ada3316f6a4c19af3e8d989ed9c6207af12e2377c2f1644e8114afd916697a26c33
   languageName: node
   linkType: hard
 
-"@react-aria/gridlist@npm:^3.13.0":
-  version: 3.13.0
-  resolution: "@react-aria/gridlist@npm:3.13.0"
+"@react-aria/datepicker@npm:^3.15.2":
+  version: 3.15.2
+  resolution: "@react-aria/datepicker@npm:3.15.2"
   dependencies:
-    "@react-aria/focus": "npm:^3.20.3"
-    "@react-aria/grid": "npm:^3.14.0"
-    "@react-aria/i18n": "npm:^3.12.9"
-    "@react-aria/interactions": "npm:^3.25.1"
-    "@react-aria/selection": "npm:^3.24.1"
-    "@react-aria/utils": "npm:^3.29.0"
-    "@react-stately/collections": "npm:^3.12.4"
-    "@react-stately/list": "npm:^3.12.2"
-    "@react-stately/tree": "npm:^3.8.10"
-    "@react-types/shared": "npm:^3.29.1"
+    "@internationalized/date": "npm:^3.10.0"
+    "@internationalized/number": "npm:^3.6.5"
+    "@internationalized/string": "npm:^3.2.7"
+    "@react-aria/focus": "npm:^3.21.2"
+    "@react-aria/form": "npm:^3.1.2"
+    "@react-aria/i18n": "npm:^3.12.13"
+    "@react-aria/interactions": "npm:^3.25.6"
+    "@react-aria/label": "npm:^3.7.22"
+    "@react-aria/spinbutton": "npm:^3.6.19"
+    "@react-aria/utils": "npm:^3.31.0"
+    "@react-stately/datepicker": "npm:^3.15.2"
+    "@react-stately/form": "npm:^3.2.2"
+    "@react-types/button": "npm:^3.14.1"
+    "@react-types/calendar": "npm:^3.8.0"
+    "@react-types/datepicker": "npm:^3.13.2"
+    "@react-types/dialog": "npm:^3.5.22"
+    "@react-types/shared": "npm:^3.32.1"
     "@swc/helpers": "npm:^0.5.0"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
     react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/f0aa0686b78adcf4bd49f751f135663550690739271ed304f35c29e7534dc5ae0d3feffeb54c14fb25308cdad456382f073dc8101b4a0f02390994b4cdc5bf82
+  checksum: 10/05f9b7bda5e5aa304ea4eebfded8040ea040b12284f2aa67f6b2a9e5458526a1e8dfbe077a53989a8633debb8184123e0907186f5b511c5a4c85a48f4c755f4b
   languageName: node
   linkType: hard
 
-"@react-aria/i18n@npm:^3.12.9":
-  version: 3.12.9
-  resolution: "@react-aria/i18n@npm:3.12.9"
+"@react-aria/dialog@npm:^3.5.31":
+  version: 3.5.31
+  resolution: "@react-aria/dialog@npm:3.5.31"
   dependencies:
-    "@internationalized/date": "npm:^3.8.1"
-    "@internationalized/message": "npm:^3.1.7"
-    "@internationalized/number": "npm:^3.6.2"
-    "@internationalized/string": "npm:^3.2.6"
-    "@react-aria/ssr": "npm:^3.9.8"
-    "@react-aria/utils": "npm:^3.29.0"
-    "@react-types/shared": "npm:^3.29.1"
+    "@react-aria/interactions": "npm:^3.25.6"
+    "@react-aria/overlays": "npm:^3.30.0"
+    "@react-aria/utils": "npm:^3.31.0"
+    "@react-types/dialog": "npm:^3.5.22"
+    "@react-types/shared": "npm:^3.32.1"
     "@swc/helpers": "npm:^0.5.0"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
     react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/a7fad699d9f58f4fa0c74d27f1a3aec03c4ee10b0b48897ede0b5a6d11d052ea6fa26031390edbc09026800dfd3bd84deea7ba51a7fd6aa69f67cec06bca20aa
+  checksum: 10/ea5d197b13d1441b45b5288382f9f25cf4ecec07ea6c8e989ce62b5f0ce2eaa7e6afe7e40fc808451b040eda2c41aa64f8e510d5205b26a5a07324b86468e53d
   languageName: node
   linkType: hard
 
-"@react-aria/interactions@npm:^3.25.1":
-  version: 3.25.1
-  resolution: "@react-aria/interactions@npm:3.25.1"
+"@react-aria/disclosure@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "@react-aria/disclosure@npm:3.1.0"
   dependencies:
-    "@react-aria/ssr": "npm:^3.9.8"
-    "@react-aria/utils": "npm:^3.29.0"
-    "@react-stately/flags": "npm:^3.1.1"
-    "@react-types/shared": "npm:^3.29.1"
+    "@react-aria/ssr": "npm:^3.9.10"
+    "@react-aria/utils": "npm:^3.31.0"
+    "@react-stately/disclosure": "npm:^3.0.8"
+    "@react-types/button": "npm:^3.14.1"
     "@swc/helpers": "npm:^0.5.0"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
     react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/162364ca0341c27e1a5dd51c0e4b70217380785f45362952a4854f6eecbfd4640cbe4abb8fd020c829153588ec6655177b9f5d26c819f385fdaa4ec13dc3a750
+  checksum: 10/34f5a0b5c7130fc686025f8015cefe219b84ed153dbca93ee4b47b2f598ca833ed161426dc76d2f09ee480b88741df046fcbb600516eb77b919afcb80b1b61a3
   languageName: node
   linkType: hard
 
-"@react-aria/label@npm:^3.7.18":
-  version: 3.7.18
-  resolution: "@react-aria/label@npm:3.7.18"
-  dependencies:
-    "@react-aria/utils": "npm:^3.29.0"
-    "@react-types/shared": "npm:^3.29.1"
-    "@swc/helpers": "npm:^0.5.0"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/92fc4fe306aad1c07a332f4da36e3c0fe9c2dc3f77deeee4524bb4897b0665f2cdd6f383646fe0a8d2a69fe9524e49769b9f91ed2794d4f49b9351ed3e7fad2b
-  languageName: node
-  linkType: hard
-
-"@react-aria/landmark@npm:^3.0.3":
-  version: 3.0.3
-  resolution: "@react-aria/landmark@npm:3.0.3"
-  dependencies:
-    "@react-aria/utils": "npm:^3.29.0"
-    "@react-types/shared": "npm:^3.29.1"
-    "@swc/helpers": "npm:^0.5.0"
-    use-sync-external-store: "npm:^1.4.0"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/91cb5c06a712a62120606f8e80f6913038421f3f1f6cc674cce4f7bd98ecd7e388c06cd2f1882fcc895ed7feae703f1fa1493617398f7dbb660bc0f61c86a0c9
-  languageName: node
-  linkType: hard
-
-"@react-aria/link@npm:^3.8.1":
-  version: 3.8.1
-  resolution: "@react-aria/link@npm:3.8.1"
-  dependencies:
-    "@react-aria/interactions": "npm:^3.25.1"
-    "@react-aria/utils": "npm:^3.29.0"
-    "@react-types/link": "npm:^3.6.1"
-    "@react-types/shared": "npm:^3.29.1"
-    "@swc/helpers": "npm:^0.5.0"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/3814067b17e7198467a5f11fbc33ac65037809113daf7d6e0b1d1eb0738c7b50e011da73e523f5fe2dec6d22de80386e6ceb390784a5d05d3ebdf645297bd05f
-  languageName: node
-  linkType: hard
-
-"@react-aria/listbox@npm:^3.14.4":
-  version: 3.14.4
-  resolution: "@react-aria/listbox@npm:3.14.4"
-  dependencies:
-    "@react-aria/interactions": "npm:^3.25.1"
-    "@react-aria/label": "npm:^3.7.18"
-    "@react-aria/selection": "npm:^3.24.1"
-    "@react-aria/utils": "npm:^3.29.0"
-    "@react-stately/collections": "npm:^3.12.4"
-    "@react-stately/list": "npm:^3.12.2"
-    "@react-types/listbox": "npm:^3.7.0"
-    "@react-types/shared": "npm:^3.29.1"
-    "@swc/helpers": "npm:^0.5.0"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/86bbea492aa70079e540e43e6ff872d72f8fbe21838581a12929883a58cb7c79b3b2d056753f755ed6d547fc4272cad59994b7c56e0e8c6cdbcb054a62d42a38
-  languageName: node
-  linkType: hard
-
-"@react-aria/live-announcer@npm:^3.4.2":
-  version: 3.4.2
-  resolution: "@react-aria/live-announcer@npm:3.4.2"
-  dependencies:
-    "@swc/helpers": "npm:^0.5.0"
-  checksum: 10/e1379ea819fb2b2921126114da141328514e9cd054a89dec1f226ecfebf884319dcb02a04c360261b1cf17a8e0a74822b5fbd3f110025fdf85372db9c4a2fff5
-  languageName: node
-  linkType: hard
-
-"@react-aria/menu@npm:^3.18.3":
-  version: 3.18.3
-  resolution: "@react-aria/menu@npm:3.18.3"
-  dependencies:
-    "@react-aria/focus": "npm:^3.20.3"
-    "@react-aria/i18n": "npm:^3.12.9"
-    "@react-aria/interactions": "npm:^3.25.1"
-    "@react-aria/overlays": "npm:^3.27.1"
-    "@react-aria/selection": "npm:^3.24.1"
-    "@react-aria/utils": "npm:^3.29.0"
-    "@react-stately/collections": "npm:^3.12.4"
-    "@react-stately/menu": "npm:^3.9.4"
-    "@react-stately/selection": "npm:^3.20.2"
-    "@react-stately/tree": "npm:^3.8.10"
-    "@react-types/button": "npm:^3.12.1"
-    "@react-types/menu": "npm:^3.10.1"
-    "@react-types/shared": "npm:^3.29.1"
-    "@swc/helpers": "npm:^0.5.0"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/815b6d0bb4f4a259c3c7e2176d87f9470bb00e13de664261ee596efdc4024ce0c7a7c213ad3b60f69e3b993f89faeca755eaf527ce9c3a18376abf56c35ddff0
-  languageName: node
-  linkType: hard
-
-"@react-aria/meter@npm:^3.4.23":
-  version: 3.4.23
-  resolution: "@react-aria/meter@npm:3.4.23"
-  dependencies:
-    "@react-aria/progress": "npm:^3.4.23"
-    "@react-types/meter": "npm:^3.4.9"
-    "@react-types/shared": "npm:^3.29.1"
-    "@swc/helpers": "npm:^0.5.0"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/a9ea11d34a36766fbdb8a7f696020ff5fec99ad54675e568ceb6a4f2138d4100b8f2f5b4eb45e90711090aad0d4a354315cb35470cb19a5b677e3da4a77517fd
-  languageName: node
-  linkType: hard
-
-"@react-aria/numberfield@npm:^3.11.14":
-  version: 3.11.14
-  resolution: "@react-aria/numberfield@npm:3.11.14"
-  dependencies:
-    "@react-aria/i18n": "npm:^3.12.9"
-    "@react-aria/interactions": "npm:^3.25.1"
-    "@react-aria/spinbutton": "npm:^3.6.15"
-    "@react-aria/textfield": "npm:^3.17.3"
-    "@react-aria/utils": "npm:^3.29.0"
-    "@react-stately/form": "npm:^3.1.4"
-    "@react-stately/numberfield": "npm:^3.9.12"
-    "@react-types/button": "npm:^3.12.1"
-    "@react-types/numberfield": "npm:^3.8.11"
-    "@react-types/shared": "npm:^3.29.1"
-    "@swc/helpers": "npm:^0.5.0"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/b4f8a05ac4c6e0bec872319ce0ec76d8b6733410f802175b7a7467e1d5d81cdab240352c13f8e9c5e1e4b7642faa33a30be40bf59b67b0b68c72860971edaab9
-  languageName: node
-  linkType: hard
-
-"@react-aria/overlays@npm:^3.27.1":
-  version: 3.27.1
-  resolution: "@react-aria/overlays@npm:3.27.1"
-  dependencies:
-    "@react-aria/focus": "npm:^3.20.3"
-    "@react-aria/i18n": "npm:^3.12.9"
-    "@react-aria/interactions": "npm:^3.25.1"
-    "@react-aria/ssr": "npm:^3.9.8"
-    "@react-aria/utils": "npm:^3.29.0"
-    "@react-aria/visually-hidden": "npm:^3.8.23"
-    "@react-stately/overlays": "npm:^3.6.16"
-    "@react-types/button": "npm:^3.12.1"
-    "@react-types/overlays": "npm:^3.8.15"
-    "@react-types/shared": "npm:^3.29.1"
-    "@swc/helpers": "npm:^0.5.0"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/254fd9c531a89a70908fa7003a9214044238d324ec2b22ca38d19a2fdf0bbfb58ba0d6af11b2bda8079f43fc49f43c0570162312ae6007177ad04dd4d853a844
-  languageName: node
-  linkType: hard
-
-"@react-aria/progress@npm:^3.4.23":
-  version: 3.4.23
-  resolution: "@react-aria/progress@npm:3.4.23"
-  dependencies:
-    "@react-aria/i18n": "npm:^3.12.9"
-    "@react-aria/label": "npm:^3.7.18"
-    "@react-aria/utils": "npm:^3.29.0"
-    "@react-types/progress": "npm:^3.5.12"
-    "@react-types/shared": "npm:^3.29.1"
-    "@swc/helpers": "npm:^0.5.0"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/f96a2d8c17e69db699b1acc142bc7000384bf96a0990096fbd1571ffe6b510552ca673a69d557ed2bed659af4b629d986129e6228c64d265da8ab58efd4595a5
-  languageName: node
-  linkType: hard
-
-"@react-aria/radio@npm:^3.11.3":
+"@react-aria/dnd@npm:^3.11.3":
   version: 3.11.3
-  resolution: "@react-aria/radio@npm:3.11.3"
+  resolution: "@react-aria/dnd@npm:3.11.3"
   dependencies:
-    "@react-aria/focus": "npm:^3.20.3"
-    "@react-aria/form": "npm:^3.0.16"
-    "@react-aria/i18n": "npm:^3.12.9"
-    "@react-aria/interactions": "npm:^3.25.1"
-    "@react-aria/label": "npm:^3.7.18"
-    "@react-aria/utils": "npm:^3.29.0"
-    "@react-stately/radio": "npm:^3.10.13"
-    "@react-types/radio": "npm:^3.8.9"
-    "@react-types/shared": "npm:^3.29.1"
+    "@internationalized/string": "npm:^3.2.7"
+    "@react-aria/i18n": "npm:^3.12.13"
+    "@react-aria/interactions": "npm:^3.25.6"
+    "@react-aria/live-announcer": "npm:^3.4.4"
+    "@react-aria/overlays": "npm:^3.30.0"
+    "@react-aria/utils": "npm:^3.31.0"
+    "@react-stately/collections": "npm:^3.12.8"
+    "@react-stately/dnd": "npm:^3.7.1"
+    "@react-types/button": "npm:^3.14.1"
+    "@react-types/shared": "npm:^3.32.1"
     "@swc/helpers": "npm:^0.5.0"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
     react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/32a69ea8b9725da925a793a9a49954ad2a4649c570a10cfe7bdf4aed2196f7b255d4b501b365e2b7626641617ec16fb3341c9381243e5338e8781d174844bc71
+  checksum: 10/48c58ab1fdb0e4dfce2e5933b580df3e46c0407535a28d2434fc6921d049bde45d0b3b94b7f3f4775e683e77c4a5b17ccfd9894c345230b7f49c7c0742663dce
   languageName: node
   linkType: hard
 
-"@react-aria/searchfield@npm:^3.8.4":
-  version: 3.8.4
-  resolution: "@react-aria/searchfield@npm:3.8.4"
+"@react-aria/focus@npm:^3.21.2":
+  version: 3.21.2
+  resolution: "@react-aria/focus@npm:3.21.2"
   dependencies:
-    "@react-aria/i18n": "npm:^3.12.9"
-    "@react-aria/textfield": "npm:^3.17.3"
-    "@react-aria/utils": "npm:^3.29.0"
-    "@react-stately/searchfield": "npm:^3.5.12"
-    "@react-types/button": "npm:^3.12.1"
-    "@react-types/searchfield": "npm:^3.6.2"
-    "@react-types/shared": "npm:^3.29.1"
-    "@swc/helpers": "npm:^0.5.0"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/9e26f495631d936cfac2e9d6ce5a452fd4dd2fcdadb38fd7e772c51eedde9559b92de38c6958ee4d6dcecef19668f15ae9a623c969c73bba14c855616619b7ce
-  languageName: node
-  linkType: hard
-
-"@react-aria/select@npm:^3.15.5":
-  version: 3.15.5
-  resolution: "@react-aria/select@npm:3.15.5"
-  dependencies:
-    "@react-aria/form": "npm:^3.0.16"
-    "@react-aria/i18n": "npm:^3.12.9"
-    "@react-aria/interactions": "npm:^3.25.1"
-    "@react-aria/label": "npm:^3.7.18"
-    "@react-aria/listbox": "npm:^3.14.4"
-    "@react-aria/menu": "npm:^3.18.3"
-    "@react-aria/selection": "npm:^3.24.1"
-    "@react-aria/utils": "npm:^3.29.0"
-    "@react-aria/visually-hidden": "npm:^3.8.23"
-    "@react-stately/select": "npm:^3.6.13"
-    "@react-types/button": "npm:^3.12.1"
-    "@react-types/select": "npm:^3.9.12"
-    "@react-types/shared": "npm:^3.29.1"
-    "@swc/helpers": "npm:^0.5.0"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/e3e381bbf1c209fd26bb48b2aad0f7e0d180c097400377c3aea3334c4302f31e1d9f9ff1a50332cd3660c5a532f823d131cce681f5ceade94ef4b9f28e50c7d3
-  languageName: node
-  linkType: hard
-
-"@react-aria/selection@npm:^3.24.1":
-  version: 3.24.1
-  resolution: "@react-aria/selection@npm:3.24.1"
-  dependencies:
-    "@react-aria/focus": "npm:^3.20.3"
-    "@react-aria/i18n": "npm:^3.12.9"
-    "@react-aria/interactions": "npm:^3.25.1"
-    "@react-aria/utils": "npm:^3.29.0"
-    "@react-stately/selection": "npm:^3.20.2"
-    "@react-types/shared": "npm:^3.29.1"
-    "@swc/helpers": "npm:^0.5.0"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/af7c6fb4fbe26812908163f21ed5a74fc3b4c1b1cc2c5fbe26a4da71a667a9a685f935e41499194c79dc5deed738f3c7318dc9c8ab325a6715f8f8bc2f595749
-  languageName: node
-  linkType: hard
-
-"@react-aria/separator@npm:^3.4.9":
-  version: 3.4.9
-  resolution: "@react-aria/separator@npm:3.4.9"
-  dependencies:
-    "@react-aria/utils": "npm:^3.29.0"
-    "@react-types/shared": "npm:^3.29.1"
-    "@swc/helpers": "npm:^0.5.0"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/293af57a96a166f34a71e45a089ca65f5f78b0b7fb6057d62ea209608792eac91166db8b1dec55e04ec640c6e06e1347c0de90fe0144e58719af31a6dc43f72c
-  languageName: node
-  linkType: hard
-
-"@react-aria/slider@npm:^3.7.19":
-  version: 3.7.19
-  resolution: "@react-aria/slider@npm:3.7.19"
-  dependencies:
-    "@react-aria/i18n": "npm:^3.12.9"
-    "@react-aria/interactions": "npm:^3.25.1"
-    "@react-aria/label": "npm:^3.7.18"
-    "@react-aria/utils": "npm:^3.29.0"
-    "@react-stately/slider": "npm:^3.6.4"
-    "@react-types/shared": "npm:^3.29.1"
-    "@react-types/slider": "npm:^3.7.11"
-    "@swc/helpers": "npm:^0.5.0"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/80c30ec4e32e1c0827dd364a5700969824ad4001d75b2d51836539969f1d0bbeea0aac8ada8533f2c18b23cbdd31c593bdf12de6af589730951dbcfa1967d5b5
-  languageName: node
-  linkType: hard
-
-"@react-aria/spinbutton@npm:^3.6.15":
-  version: 3.6.15
-  resolution: "@react-aria/spinbutton@npm:3.6.15"
-  dependencies:
-    "@react-aria/i18n": "npm:^3.12.9"
-    "@react-aria/live-announcer": "npm:^3.4.2"
-    "@react-aria/utils": "npm:^3.29.0"
-    "@react-types/button": "npm:^3.12.1"
-    "@react-types/shared": "npm:^3.29.1"
-    "@swc/helpers": "npm:^0.5.0"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/96446ab36147da9f29988330e0642a1b01bba76e436b13a6088d079af227c5c8b1d0fe5668f66f58648d10614a84c551554d04829e20ea75c39e5f1711b2008f
-  languageName: node
-  linkType: hard
-
-"@react-aria/ssr@npm:^3.9.8":
-  version: 3.9.8
-  resolution: "@react-aria/ssr@npm:3.9.8"
-  dependencies:
-    "@swc/helpers": "npm:^0.5.0"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/01b40c57146406cb4d8e1aa628ffbcf1ea50521dfd81bbcdad777b87eef865abe01168f0c959e140cabae1f323b522243b77228d9e533d1b1b34de71c886623a
-  languageName: node
-  linkType: hard
-
-"@react-aria/switch@npm:^3.7.3":
-  version: 3.7.3
-  resolution: "@react-aria/switch@npm:3.7.3"
-  dependencies:
-    "@react-aria/toggle": "npm:^3.11.3"
-    "@react-stately/toggle": "npm:^3.8.4"
-    "@react-types/shared": "npm:^3.29.1"
-    "@react-types/switch": "npm:^3.5.11"
-    "@swc/helpers": "npm:^0.5.0"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/f722355586eeb70ab50a8aeefbb148551e0ef1d2302db861c94e9f09d1c470db0729e4e1f91f0c8baf078c18724222fc15633dc7c5a0ef4a4568b47efdf73e29
-  languageName: node
-  linkType: hard
-
-"@react-aria/table@npm:^3.17.3":
-  version: 3.17.3
-  resolution: "@react-aria/table@npm:3.17.3"
-  dependencies:
-    "@react-aria/focus": "npm:^3.20.3"
-    "@react-aria/grid": "npm:^3.14.0"
-    "@react-aria/i18n": "npm:^3.12.9"
-    "@react-aria/interactions": "npm:^3.25.1"
-    "@react-aria/live-announcer": "npm:^3.4.2"
-    "@react-aria/utils": "npm:^3.29.0"
-    "@react-aria/visually-hidden": "npm:^3.8.23"
-    "@react-stately/collections": "npm:^3.12.4"
-    "@react-stately/flags": "npm:^3.1.1"
-    "@react-stately/table": "npm:^3.14.2"
-    "@react-types/checkbox": "npm:^3.9.4"
-    "@react-types/grid": "npm:^3.3.2"
-    "@react-types/shared": "npm:^3.29.1"
-    "@react-types/table": "npm:^3.13.0"
-    "@swc/helpers": "npm:^0.5.0"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/53f8416c954a2c47fbe633c465fe68cbbb8ab86c2edd46b23bea64b49d2fedb7207f9750c811c64436485eccb379a34fc6028b26071b583b8cb8619fa7130053
-  languageName: node
-  linkType: hard
-
-"@react-aria/tabs@npm:^3.10.3":
-  version: 3.10.3
-  resolution: "@react-aria/tabs@npm:3.10.3"
-  dependencies:
-    "@react-aria/focus": "npm:^3.20.3"
-    "@react-aria/i18n": "npm:^3.12.9"
-    "@react-aria/selection": "npm:^3.24.1"
-    "@react-aria/utils": "npm:^3.29.0"
-    "@react-stately/tabs": "npm:^3.8.2"
-    "@react-types/shared": "npm:^3.29.1"
-    "@react-types/tabs": "npm:^3.3.15"
-    "@swc/helpers": "npm:^0.5.0"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/935566950cc331ef702b896d7b9e745f175a0c46e81c0a44b0b5c044109fde39d8d8a63ceef0c065393fef1149dacb000cf1590ccf5070307967c2fc35bbc579
-  languageName: node
-  linkType: hard
-
-"@react-aria/tag@npm:^3.6.0":
-  version: 3.6.0
-  resolution: "@react-aria/tag@npm:3.6.0"
-  dependencies:
-    "@react-aria/gridlist": "npm:^3.13.0"
-    "@react-aria/i18n": "npm:^3.12.9"
-    "@react-aria/interactions": "npm:^3.25.1"
-    "@react-aria/label": "npm:^3.7.18"
-    "@react-aria/selection": "npm:^3.24.1"
-    "@react-aria/utils": "npm:^3.29.0"
-    "@react-stately/list": "npm:^3.12.2"
-    "@react-types/button": "npm:^3.12.1"
-    "@react-types/shared": "npm:^3.29.1"
-    "@swc/helpers": "npm:^0.5.0"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/b4d2556929437adb2d0e5d02a3f4777ca6ee234c2a96e387a52ff3204d485b5bca0f3bf46065c292c0586c70e5c98540c5b31d2f062671c2ba820f6a5526bf7a
-  languageName: node
-  linkType: hard
-
-"@react-aria/textfield@npm:^3.17.3":
-  version: 3.17.3
-  resolution: "@react-aria/textfield@npm:3.17.3"
-  dependencies:
-    "@react-aria/form": "npm:^3.0.16"
-    "@react-aria/interactions": "npm:^3.25.1"
-    "@react-aria/label": "npm:^3.7.18"
-    "@react-aria/utils": "npm:^3.29.0"
-    "@react-stately/form": "npm:^3.1.4"
-    "@react-stately/utils": "npm:^3.10.6"
-    "@react-types/shared": "npm:^3.29.1"
-    "@react-types/textfield": "npm:^3.12.2"
-    "@swc/helpers": "npm:^0.5.0"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/2f29021f3b77af16af6e439c4c724ee21d00bff4754437a820e9a407eea1303710368ad45ea416fc72e9795f457497619e89b1b155368425e19ffde2edae3ce0
-  languageName: node
-  linkType: hard
-
-"@react-aria/toast@npm:^3.0.3":
-  version: 3.0.3
-  resolution: "@react-aria/toast@npm:3.0.3"
-  dependencies:
-    "@react-aria/i18n": "npm:^3.12.9"
-    "@react-aria/interactions": "npm:^3.25.1"
-    "@react-aria/landmark": "npm:^3.0.3"
-    "@react-aria/utils": "npm:^3.29.0"
-    "@react-stately/toast": "npm:^3.1.0"
-    "@react-types/button": "npm:^3.12.1"
-    "@react-types/shared": "npm:^3.29.1"
-    "@swc/helpers": "npm:^0.5.0"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/2494bd866ccd8603adcd0cee2e4b393b068632d5eb145a52f52e1fb43abce8422e653028c3bc04537f7e5e657369e50f87218f8be0e96688c116b2514fb17a33
-  languageName: node
-  linkType: hard
-
-"@react-aria/toggle@npm:^3.11.3":
-  version: 3.11.3
-  resolution: "@react-aria/toggle@npm:3.11.3"
-  dependencies:
-    "@react-aria/interactions": "npm:^3.25.1"
-    "@react-aria/utils": "npm:^3.29.0"
-    "@react-stately/toggle": "npm:^3.8.4"
-    "@react-types/checkbox": "npm:^3.9.4"
-    "@react-types/shared": "npm:^3.29.1"
-    "@swc/helpers": "npm:^0.5.0"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/24e49318c7eb01c2c5ce62a606ccf8c876eac7eae8fba6ad5e0717cad44f49fe3cce27e0706f01c2ae8942bb2afdc7a73dfbc114b243107b8e4d9e44daf19dbb
-  languageName: node
-  linkType: hard
-
-"@react-aria/toolbar@npm:3.0.0-beta.16":
-  version: 3.0.0-beta.16
-  resolution: "@react-aria/toolbar@npm:3.0.0-beta.16"
-  dependencies:
-    "@react-aria/focus": "npm:^3.20.3"
-    "@react-aria/i18n": "npm:^3.12.9"
-    "@react-aria/utils": "npm:^3.29.0"
-    "@react-types/shared": "npm:^3.29.1"
-    "@swc/helpers": "npm:^0.5.0"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/95ffd07674d3f56c49d1b27e3b3bcb9c6a2f1dea0f1819e4c6e69800f347710ff23ee4bc2c8fae005778c4f91dfb580e15abe296ac38bc746120829dca51cac6
-  languageName: node
-  linkType: hard
-
-"@react-aria/tooltip@npm:^3.8.3":
-  version: 3.8.3
-  resolution: "@react-aria/tooltip@npm:3.8.3"
-  dependencies:
-    "@react-aria/interactions": "npm:^3.25.1"
-    "@react-aria/utils": "npm:^3.29.0"
-    "@react-stately/tooltip": "npm:^3.5.4"
-    "@react-types/shared": "npm:^3.29.1"
-    "@react-types/tooltip": "npm:^3.4.17"
-    "@swc/helpers": "npm:^0.5.0"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/c693ea47ab410541459ed6fabc252052a876632f93007ee9771d345678df3baa5dba244cd0012043f2f7befd789927c35af8886f927732cbe070abeb392375e1
-  languageName: node
-  linkType: hard
-
-"@react-aria/tree@npm:^3.0.3":
-  version: 3.0.3
-  resolution: "@react-aria/tree@npm:3.0.3"
-  dependencies:
-    "@react-aria/gridlist": "npm:^3.13.0"
-    "@react-aria/i18n": "npm:^3.12.9"
-    "@react-aria/selection": "npm:^3.24.1"
-    "@react-aria/utils": "npm:^3.29.0"
-    "@react-stately/tree": "npm:^3.8.10"
-    "@react-types/button": "npm:^3.12.1"
-    "@react-types/shared": "npm:^3.29.1"
-    "@swc/helpers": "npm:^0.5.0"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/3d04d17be6900021d0e2a387ccc4f22b649610a8f5d78590a0362a94b4cfd972573092b33f126dc65d1a13c6abb2b2b79adf4d74d74d539d9f69a6de2b524c5e
-  languageName: node
-  linkType: hard
-
-"@react-aria/utils@npm:^3.29.0":
-  version: 3.29.0
-  resolution: "@react-aria/utils@npm:3.29.0"
-  dependencies:
-    "@react-aria/ssr": "npm:^3.9.8"
-    "@react-stately/flags": "npm:^3.1.1"
-    "@react-stately/utils": "npm:^3.10.6"
-    "@react-types/shared": "npm:^3.29.1"
+    "@react-aria/interactions": "npm:^3.25.6"
+    "@react-aria/utils": "npm:^3.31.0"
+    "@react-types/shared": "npm:^3.32.1"
     "@swc/helpers": "npm:^0.5.0"
     clsx: "npm:^2.0.0"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
     react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/7dcf6e332d654a8d070d63f3b9a9cf142dcba2ba81163554f47d55e185b37ddc370c6b5aa30be3aa38089d3ccef5d2d9bbd6f466f80f3f17c89c6178f33f4daf
+  checksum: 10/4bce20d956c24ab08b707e84896afafd66b3496971efb6dd611dae1c4c1f47a5c99c786a96b2fd0eb083a7c9ba5368ac04ce3a937cc48fdcc8bb85f81e7a3098
   languageName: node
   linkType: hard
 
-"@react-aria/virtualizer@npm:^4.1.5":
-  version: 4.1.5
-  resolution: "@react-aria/virtualizer@npm:4.1.5"
+"@react-aria/form@npm:^3.1.2":
+  version: 3.1.2
+  resolution: "@react-aria/form@npm:3.1.2"
   dependencies:
-    "@react-aria/i18n": "npm:^3.12.9"
-    "@react-aria/interactions": "npm:^3.25.1"
-    "@react-aria/utils": "npm:^3.29.0"
-    "@react-stately/virtualizer": "npm:^4.4.0"
-    "@react-types/shared": "npm:^3.29.1"
+    "@react-aria/interactions": "npm:^3.25.6"
+    "@react-aria/utils": "npm:^3.31.0"
+    "@react-stately/form": "npm:^3.2.2"
+    "@react-types/shared": "npm:^3.32.1"
     "@swc/helpers": "npm:^0.5.0"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
     react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/aad8a4c9f33d36f5df7fae56a9524ee7f9258c4c188cfeed2d06d9641bdc9ef012406b8a81e1e5861c516fa8b36ad0cec59a957eb5d104195d934211560acfd2
+  checksum: 10/140d8cb830fab6fc4d885e79fbdfc92f06af43134b6ab68ec93b58fec25220b823b58698bd9bbd574bc21d1c0d443813df89b44f5ea33b5bcd314128560bd4fd
   languageName: node
   linkType: hard
 
-"@react-aria/visually-hidden@npm:^3.8.23":
-  version: 3.8.23
-  resolution: "@react-aria/visually-hidden@npm:3.8.23"
+"@react-aria/grid@npm:^3.14.5":
+  version: 3.14.5
+  resolution: "@react-aria/grid@npm:3.14.5"
   dependencies:
-    "@react-aria/interactions": "npm:^3.25.1"
-    "@react-aria/utils": "npm:^3.29.0"
-    "@react-types/shared": "npm:^3.29.1"
+    "@react-aria/focus": "npm:^3.21.2"
+    "@react-aria/i18n": "npm:^3.12.13"
+    "@react-aria/interactions": "npm:^3.25.6"
+    "@react-aria/live-announcer": "npm:^3.4.4"
+    "@react-aria/selection": "npm:^3.26.0"
+    "@react-aria/utils": "npm:^3.31.0"
+    "@react-stately/collections": "npm:^3.12.8"
+    "@react-stately/grid": "npm:^3.11.6"
+    "@react-stately/selection": "npm:^3.20.6"
+    "@react-types/checkbox": "npm:^3.10.2"
+    "@react-types/grid": "npm:^3.3.6"
+    "@react-types/shared": "npm:^3.32.1"
     "@swc/helpers": "npm:^0.5.0"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
     react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/dfa35599c52b60fb4d6ca14ee69c796452cae7855fa863a97b5d2a06438ca479957ca97ba0769d7614d32da0cc3c8e431ff6e5e26849116a5b7eb101dfd2886a
+  checksum: 10/7e8731b55366b05f619259fbeb149b63d7c17158e25a2ebaacbe3368f50e71f054e4cef3a943ca6076d3ebf0242cfcb155ff276ab984a7495dc46f6b5b13f1d2
+  languageName: node
+  linkType: hard
+
+"@react-aria/gridlist@npm:^3.14.1":
+  version: 3.14.1
+  resolution: "@react-aria/gridlist@npm:3.14.1"
+  dependencies:
+    "@react-aria/focus": "npm:^3.21.2"
+    "@react-aria/grid": "npm:^3.14.5"
+    "@react-aria/i18n": "npm:^3.12.13"
+    "@react-aria/interactions": "npm:^3.25.6"
+    "@react-aria/selection": "npm:^3.26.0"
+    "@react-aria/utils": "npm:^3.31.0"
+    "@react-stately/list": "npm:^3.13.1"
+    "@react-stately/tree": "npm:^3.9.3"
+    "@react-types/shared": "npm:^3.32.1"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/1d7ff55a869a3157edd266b5d14a9e1380561bcb8d949fdd43e983e64932ec251aa7221e6156e93ea977b8942c5b9b8f9aae5f04ebc2ed27eef9be2b7e00b5ab
+  languageName: node
+  linkType: hard
+
+"@react-aria/i18n@npm:^3.12.13":
+  version: 3.12.13
+  resolution: "@react-aria/i18n@npm:3.12.13"
+  dependencies:
+    "@internationalized/date": "npm:^3.10.0"
+    "@internationalized/message": "npm:^3.1.8"
+    "@internationalized/number": "npm:^3.6.5"
+    "@internationalized/string": "npm:^3.2.7"
+    "@react-aria/ssr": "npm:^3.9.10"
+    "@react-aria/utils": "npm:^3.31.0"
+    "@react-types/shared": "npm:^3.32.1"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/a5464213e626c60d63e0dbab84907ab452c53022a27a5c482c8f86f23c96b53522e52005c5cfc829f388c807eaf246cded69d5bee24b9e0fc08f34f9b0359e82
+  languageName: node
+  linkType: hard
+
+"@react-aria/interactions@npm:^3.25.6":
+  version: 3.25.6
+  resolution: "@react-aria/interactions@npm:3.25.6"
+  dependencies:
+    "@react-aria/ssr": "npm:^3.9.10"
+    "@react-aria/utils": "npm:^3.31.0"
+    "@react-stately/flags": "npm:^3.1.2"
+    "@react-types/shared": "npm:^3.32.1"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/fd30e14107d919be25909ca8f69fb99d88aa1f1ead523717a390a40be6d774e40de47dd7f9fcc7e6d66e0f4abc12238001a10d2128cbd7af9b141641cacf6da4
+  languageName: node
+  linkType: hard
+
+"@react-aria/label@npm:^3.7.22":
+  version: 3.7.22
+  resolution: "@react-aria/label@npm:3.7.22"
+  dependencies:
+    "@react-aria/utils": "npm:^3.31.0"
+    "@react-types/shared": "npm:^3.32.1"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/2bbfca230465057230597fd23f47ebe591bb5307ff7e37a082a4922e132f1310b69a06dcb4905c356b674b159bd09c2ca690e0526d9f303bed8f66eeb8a61b13
+  languageName: node
+  linkType: hard
+
+"@react-aria/landmark@npm:^3.0.7":
+  version: 3.0.7
+  resolution: "@react-aria/landmark@npm:3.0.7"
+  dependencies:
+    "@react-aria/utils": "npm:^3.31.0"
+    "@react-types/shared": "npm:^3.32.1"
+    "@swc/helpers": "npm:^0.5.0"
+    use-sync-external-store: "npm:^1.4.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/b86cbd8356fa08e01318644082b9ef948cb3d61695c3dfdb5bdc67a59ce3e3f774c91bf62795280c7ac620b87f9d7e66635c7e02a2c2eb2663b3e2b6a77a448a
+  languageName: node
+  linkType: hard
+
+"@react-aria/link@npm:^3.8.6":
+  version: 3.8.6
+  resolution: "@react-aria/link@npm:3.8.6"
+  dependencies:
+    "@react-aria/interactions": "npm:^3.25.6"
+    "@react-aria/utils": "npm:^3.31.0"
+    "@react-types/link": "npm:^3.6.5"
+    "@react-types/shared": "npm:^3.32.1"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/7f0fd02e7eb5c69ba5e280c57b0e7ec6568fbca231159f591201f9d753bd2f985613d0f75a54465f292a617684a55d8f5f10585538ce1fbc3f9f29fb3d339529
+  languageName: node
+  linkType: hard
+
+"@react-aria/listbox@npm:^3.15.0":
+  version: 3.15.0
+  resolution: "@react-aria/listbox@npm:3.15.0"
+  dependencies:
+    "@react-aria/interactions": "npm:^3.25.6"
+    "@react-aria/label": "npm:^3.7.22"
+    "@react-aria/selection": "npm:^3.26.0"
+    "@react-aria/utils": "npm:^3.31.0"
+    "@react-stately/collections": "npm:^3.12.8"
+    "@react-stately/list": "npm:^3.13.1"
+    "@react-types/listbox": "npm:^3.7.4"
+    "@react-types/shared": "npm:^3.32.1"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/e361b11ab4ae521a3e4d41ea811f15e2863b97aa9e65c19eef06c38b9f378191c34dfedf545d1ea4667aa0b89aa157712ed6f78950d71cfc712643666cc59d7a
+  languageName: node
+  linkType: hard
+
+"@react-aria/live-announcer@npm:^3.4.4":
+  version: 3.4.4
+  resolution: "@react-aria/live-announcer@npm:3.4.4"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+  checksum: 10/058859f7c0895bccd902f038586333016d7a33d38508e5edaf0f4c809a00217c19db3aa00604e78f3a788e399c3701a8d7fe95e2eb29c8ae754ff4bb62da1f7a
+  languageName: node
+  linkType: hard
+
+"@react-aria/menu@npm:^3.19.3":
+  version: 3.19.3
+  resolution: "@react-aria/menu@npm:3.19.3"
+  dependencies:
+    "@react-aria/focus": "npm:^3.21.2"
+    "@react-aria/i18n": "npm:^3.12.13"
+    "@react-aria/interactions": "npm:^3.25.6"
+    "@react-aria/overlays": "npm:^3.30.0"
+    "@react-aria/selection": "npm:^3.26.0"
+    "@react-aria/utils": "npm:^3.31.0"
+    "@react-stately/collections": "npm:^3.12.8"
+    "@react-stately/menu": "npm:^3.9.8"
+    "@react-stately/selection": "npm:^3.20.6"
+    "@react-stately/tree": "npm:^3.9.3"
+    "@react-types/button": "npm:^3.14.1"
+    "@react-types/menu": "npm:^3.10.5"
+    "@react-types/shared": "npm:^3.32.1"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/04987d1fae12979335a755093b74e0a9c61d2bf1f207111bca2a8513ea43962b282315976d33e5f06d3e2e1fc1927e2f9030365c4e4a26024e156ebcb88a8d9c
+  languageName: node
+  linkType: hard
+
+"@react-aria/meter@npm:^3.4.27":
+  version: 3.4.27
+  resolution: "@react-aria/meter@npm:3.4.27"
+  dependencies:
+    "@react-aria/progress": "npm:^3.4.27"
+    "@react-types/meter": "npm:^3.4.13"
+    "@react-types/shared": "npm:^3.32.1"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/b79bc0f2a96b53ec427a25315cdec4a50dd1bc1cb1fbff9f84847c0bb2597851a514ecbbf4b0fbb18b165bc007142ad45bd432641301b8db990e09f281563d39
+  languageName: node
+  linkType: hard
+
+"@react-aria/numberfield@npm:^3.12.2":
+  version: 3.12.2
+  resolution: "@react-aria/numberfield@npm:3.12.2"
+  dependencies:
+    "@react-aria/i18n": "npm:^3.12.13"
+    "@react-aria/interactions": "npm:^3.25.6"
+    "@react-aria/spinbutton": "npm:^3.6.19"
+    "@react-aria/textfield": "npm:^3.18.2"
+    "@react-aria/utils": "npm:^3.31.0"
+    "@react-stately/form": "npm:^3.2.2"
+    "@react-stately/numberfield": "npm:^3.10.2"
+    "@react-types/button": "npm:^3.14.1"
+    "@react-types/numberfield": "npm:^3.8.15"
+    "@react-types/shared": "npm:^3.32.1"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/7ec498b0d3bf6a55e891e61d1693a6395a3e7b89a04d81af433a0cb3dd673603ce5dd7f861d39658a5fe6c0cd48356c8120c39b9a4495563d9b13af0f8c0b3ca
+  languageName: node
+  linkType: hard
+
+"@react-aria/overlays@npm:^3.30.0":
+  version: 3.30.0
+  resolution: "@react-aria/overlays@npm:3.30.0"
+  dependencies:
+    "@react-aria/focus": "npm:^3.21.2"
+    "@react-aria/i18n": "npm:^3.12.13"
+    "@react-aria/interactions": "npm:^3.25.6"
+    "@react-aria/ssr": "npm:^3.9.10"
+    "@react-aria/utils": "npm:^3.31.0"
+    "@react-aria/visually-hidden": "npm:^3.8.28"
+    "@react-stately/overlays": "npm:^3.6.20"
+    "@react-types/button": "npm:^3.14.1"
+    "@react-types/overlays": "npm:^3.9.2"
+    "@react-types/shared": "npm:^3.32.1"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/32c25162b55078cf18ca6f514065d97982a9447b1ec9d75fda4db69fa909cd5dcc3d5b4c8917edecce7d8dd5b20bc51c3862945110c0badef021c86878e8fb4d
+  languageName: node
+  linkType: hard
+
+"@react-aria/progress@npm:^3.4.27":
+  version: 3.4.27
+  resolution: "@react-aria/progress@npm:3.4.27"
+  dependencies:
+    "@react-aria/i18n": "npm:^3.12.13"
+    "@react-aria/label": "npm:^3.7.22"
+    "@react-aria/utils": "npm:^3.31.0"
+    "@react-types/progress": "npm:^3.5.16"
+    "@react-types/shared": "npm:^3.32.1"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/7b0ac3c2da6205096e94b4d72a2b2b0250f864cace05b562e49b86986dbebbab633e62fcc39ffa915974318de37d5f6256b1f584d8e33ebca70e564d32b3aca2
+  languageName: node
+  linkType: hard
+
+"@react-aria/radio@npm:^3.12.2":
+  version: 3.12.2
+  resolution: "@react-aria/radio@npm:3.12.2"
+  dependencies:
+    "@react-aria/focus": "npm:^3.21.2"
+    "@react-aria/form": "npm:^3.1.2"
+    "@react-aria/i18n": "npm:^3.12.13"
+    "@react-aria/interactions": "npm:^3.25.6"
+    "@react-aria/label": "npm:^3.7.22"
+    "@react-aria/utils": "npm:^3.31.0"
+    "@react-stately/radio": "npm:^3.11.2"
+    "@react-types/radio": "npm:^3.9.2"
+    "@react-types/shared": "npm:^3.32.1"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/709bdd0515e797f2bf37dc17f55e46103aa918a4549880c15ecca7c03adc0716e5650376b1cc877437b12e5df4e3050138699707e4ec9fa611614a1e38b98eb0
+  languageName: node
+  linkType: hard
+
+"@react-aria/searchfield@npm:^3.8.9":
+  version: 3.8.9
+  resolution: "@react-aria/searchfield@npm:3.8.9"
+  dependencies:
+    "@react-aria/i18n": "npm:^3.12.13"
+    "@react-aria/textfield": "npm:^3.18.2"
+    "@react-aria/utils": "npm:^3.31.0"
+    "@react-stately/searchfield": "npm:^3.5.16"
+    "@react-types/button": "npm:^3.14.1"
+    "@react-types/searchfield": "npm:^3.6.6"
+    "@react-types/shared": "npm:^3.32.1"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/a088f7b1c434aea1d4603acb34e591c8f11a1532a41407b68336933a73e1e5f55b07bb6323642af5ebeebe39756e1e60943487d77d69882409c491fd816e86f4
+  languageName: node
+  linkType: hard
+
+"@react-aria/select@npm:^3.17.0":
+  version: 3.17.0
+  resolution: "@react-aria/select@npm:3.17.0"
+  dependencies:
+    "@react-aria/form": "npm:^3.1.2"
+    "@react-aria/i18n": "npm:^3.12.13"
+    "@react-aria/interactions": "npm:^3.25.6"
+    "@react-aria/label": "npm:^3.7.22"
+    "@react-aria/listbox": "npm:^3.15.0"
+    "@react-aria/menu": "npm:^3.19.3"
+    "@react-aria/selection": "npm:^3.26.0"
+    "@react-aria/utils": "npm:^3.31.0"
+    "@react-aria/visually-hidden": "npm:^3.8.28"
+    "@react-stately/select": "npm:^3.8.0"
+    "@react-types/button": "npm:^3.14.1"
+    "@react-types/select": "npm:^3.11.0"
+    "@react-types/shared": "npm:^3.32.1"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/e986470eb5d8c675fbd5753e0051827c94dad00c5472015d4744e4e9233e7a4ff97f4634e94c5686ef9f65f2b6ffa894b24f3a07bde0437de6fe5802901969cd
+  languageName: node
+  linkType: hard
+
+"@react-aria/selection@npm:^3.26.0":
+  version: 3.26.0
+  resolution: "@react-aria/selection@npm:3.26.0"
+  dependencies:
+    "@react-aria/focus": "npm:^3.21.2"
+    "@react-aria/i18n": "npm:^3.12.13"
+    "@react-aria/interactions": "npm:^3.25.6"
+    "@react-aria/utils": "npm:^3.31.0"
+    "@react-stately/selection": "npm:^3.20.6"
+    "@react-types/shared": "npm:^3.32.1"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/6c3c59993c719cfdfd42ef9c753212e7bddf30c348117726e8abfe977876f583e0d0b6fa4ce73e46f1fa53e79e42f0866a333e257cef400c4a24bd5d1c81c379
+  languageName: node
+  linkType: hard
+
+"@react-aria/separator@npm:^3.4.13":
+  version: 3.4.13
+  resolution: "@react-aria/separator@npm:3.4.13"
+  dependencies:
+    "@react-aria/utils": "npm:^3.31.0"
+    "@react-types/shared": "npm:^3.32.1"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/4326c36d002f3931c8c717b7aacbe30943d42ca190fe400a151d8f480dd65359a0bc9192da33213d4e8215bbfd47436de07fedfe957e83be4101a926d116862e
+  languageName: node
+  linkType: hard
+
+"@react-aria/slider@npm:^3.8.2":
+  version: 3.8.2
+  resolution: "@react-aria/slider@npm:3.8.2"
+  dependencies:
+    "@react-aria/i18n": "npm:^3.12.13"
+    "@react-aria/interactions": "npm:^3.25.6"
+    "@react-aria/label": "npm:^3.7.22"
+    "@react-aria/utils": "npm:^3.31.0"
+    "@react-stately/slider": "npm:^3.7.2"
+    "@react-types/shared": "npm:^3.32.1"
+    "@react-types/slider": "npm:^3.8.2"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/3b9115eaf61f722929dcb739cd910b9e84f04644fdce8add21bc0f9305a3e7d0948c2e417afe424783b22738d52060505a32187aba1e7aca19dd572ebb6d10ed
+  languageName: node
+  linkType: hard
+
+"@react-aria/spinbutton@npm:^3.6.19":
+  version: 3.6.19
+  resolution: "@react-aria/spinbutton@npm:3.6.19"
+  dependencies:
+    "@react-aria/i18n": "npm:^3.12.13"
+    "@react-aria/live-announcer": "npm:^3.4.4"
+    "@react-aria/utils": "npm:^3.31.0"
+    "@react-types/button": "npm:^3.14.1"
+    "@react-types/shared": "npm:^3.32.1"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/9b87a1c87a09ddde141bb23e8e3ce1b1137cb1931df848d6fd3bbcd0773b3579045413b725686629da02c22733ad5b5dfc57e06c5fefaf07f8cfb8c4e2334997
+  languageName: node
+  linkType: hard
+
+"@react-aria/ssr@npm:^3.9.10":
+  version: 3.9.10
+  resolution: "@react-aria/ssr@npm:3.9.10"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/3b414b5b174769e874014604749d9beaf2556f360f61d3df3223bca6150c16dd37fbf16800e669a2b0045bd221df70212756991a426a7a472c56aac6c0dabd1b
+  languageName: node
+  linkType: hard
+
+"@react-aria/switch@npm:^3.7.8":
+  version: 3.7.8
+  resolution: "@react-aria/switch@npm:3.7.8"
+  dependencies:
+    "@react-aria/toggle": "npm:^3.12.2"
+    "@react-stately/toggle": "npm:^3.9.2"
+    "@react-types/shared": "npm:^3.32.1"
+    "@react-types/switch": "npm:^3.5.15"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/2a9cc90fb6f9593c8b41517d83e4a2e05f77ba544ee41d5beeb865329863ca70afa5beec94230512d3eab44d62f0c0c25110323ba89745ba64e05bee0f34c4ec
+  languageName: node
+  linkType: hard
+
+"@react-aria/table@npm:^3.17.8":
+  version: 3.17.8
+  resolution: "@react-aria/table@npm:3.17.8"
+  dependencies:
+    "@react-aria/focus": "npm:^3.21.2"
+    "@react-aria/grid": "npm:^3.14.5"
+    "@react-aria/i18n": "npm:^3.12.13"
+    "@react-aria/interactions": "npm:^3.25.6"
+    "@react-aria/live-announcer": "npm:^3.4.4"
+    "@react-aria/utils": "npm:^3.31.0"
+    "@react-aria/visually-hidden": "npm:^3.8.28"
+    "@react-stately/collections": "npm:^3.12.8"
+    "@react-stately/flags": "npm:^3.1.2"
+    "@react-stately/table": "npm:^3.15.1"
+    "@react-types/checkbox": "npm:^3.10.2"
+    "@react-types/grid": "npm:^3.3.6"
+    "@react-types/shared": "npm:^3.32.1"
+    "@react-types/table": "npm:^3.13.4"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/39281b279c2efea9342877e4e2cb1af38f776a7349bcbe6e6daabf281e01445c28b8c7cd38c4f3cfeaea42a126552fd332fc242abd1e5e009c9252e3f1b88512
+  languageName: node
+  linkType: hard
+
+"@react-aria/tabs@npm:^3.10.8":
+  version: 3.10.8
+  resolution: "@react-aria/tabs@npm:3.10.8"
+  dependencies:
+    "@react-aria/focus": "npm:^3.21.2"
+    "@react-aria/i18n": "npm:^3.12.13"
+    "@react-aria/selection": "npm:^3.26.0"
+    "@react-aria/utils": "npm:^3.31.0"
+    "@react-stately/tabs": "npm:^3.8.6"
+    "@react-types/shared": "npm:^3.32.1"
+    "@react-types/tabs": "npm:^3.3.19"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/eae72fb6636ae1352ceec509605d35018d96f66aacab896748697da9f6b1e166c7bff88a0ffcfdee2869f653464df401d857906f44bdce5d5b9887b75f533287
+  languageName: node
+  linkType: hard
+
+"@react-aria/tag@npm:^3.7.2":
+  version: 3.7.2
+  resolution: "@react-aria/tag@npm:3.7.2"
+  dependencies:
+    "@react-aria/gridlist": "npm:^3.14.1"
+    "@react-aria/i18n": "npm:^3.12.13"
+    "@react-aria/interactions": "npm:^3.25.6"
+    "@react-aria/label": "npm:^3.7.22"
+    "@react-aria/selection": "npm:^3.26.0"
+    "@react-aria/utils": "npm:^3.31.0"
+    "@react-stately/list": "npm:^3.13.1"
+    "@react-types/button": "npm:^3.14.1"
+    "@react-types/shared": "npm:^3.32.1"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/757daed07380eee13a05b1ba0b72e062db689526dd67087cd34726a6003b4791cb450c9765be3ea32208ce1a430903db3885d07700cb8775cd8bcd97b8124cb4
+  languageName: node
+  linkType: hard
+
+"@react-aria/textfield@npm:^3.18.2":
+  version: 3.18.2
+  resolution: "@react-aria/textfield@npm:3.18.2"
+  dependencies:
+    "@react-aria/form": "npm:^3.1.2"
+    "@react-aria/interactions": "npm:^3.25.6"
+    "@react-aria/label": "npm:^3.7.22"
+    "@react-aria/utils": "npm:^3.31.0"
+    "@react-stately/form": "npm:^3.2.2"
+    "@react-stately/utils": "npm:^3.10.8"
+    "@react-types/shared": "npm:^3.32.1"
+    "@react-types/textfield": "npm:^3.12.6"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/2713e3c42f502ecd1d8a505b01c404a6531d1450d8c422a12ac477d1d45dd5e11e9da48807e75c4915948f579969b4b894f1dda14d87ce3790ab67659b20a396
+  languageName: node
+  linkType: hard
+
+"@react-aria/toast@npm:^3.0.8":
+  version: 3.0.8
+  resolution: "@react-aria/toast@npm:3.0.8"
+  dependencies:
+    "@react-aria/i18n": "npm:^3.12.13"
+    "@react-aria/interactions": "npm:^3.25.6"
+    "@react-aria/landmark": "npm:^3.0.7"
+    "@react-aria/utils": "npm:^3.31.0"
+    "@react-stately/toast": "npm:^3.1.2"
+    "@react-types/button": "npm:^3.14.1"
+    "@react-types/shared": "npm:^3.32.1"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/b8b21566723e9038f15517934c45c3e6406f28d476a682421aee270f01852e8a46f0170af13c3a5c8e80926169ebd7802d5def0115876e395dedad4fc9409f49
+  languageName: node
+  linkType: hard
+
+"@react-aria/toggle@npm:^3.12.2":
+  version: 3.12.2
+  resolution: "@react-aria/toggle@npm:3.12.2"
+  dependencies:
+    "@react-aria/interactions": "npm:^3.25.6"
+    "@react-aria/utils": "npm:^3.31.0"
+    "@react-stately/toggle": "npm:^3.9.2"
+    "@react-types/checkbox": "npm:^3.10.2"
+    "@react-types/shared": "npm:^3.32.1"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/f6b9ce00d7a6bb0e7b6123826761cb7f40b9c7736ce8edc14b39f1865cd9165c086da8a3f6e27ddae8c8557f54f421bb0b4761c455dae81ed037a765b84b5cb7
+  languageName: node
+  linkType: hard
+
+"@react-aria/toolbar@npm:3.0.0-beta.21":
+  version: 3.0.0-beta.21
+  resolution: "@react-aria/toolbar@npm:3.0.0-beta.21"
+  dependencies:
+    "@react-aria/focus": "npm:^3.21.2"
+    "@react-aria/i18n": "npm:^3.12.13"
+    "@react-aria/utils": "npm:^3.31.0"
+    "@react-types/shared": "npm:^3.32.1"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/ada5f50c4409997d46e4af0b739f1fada6d3c6ac0bdd3a7eef7ad2a440a53eaeebbd0685d19deb4b7c21832882dbe27a5a8162bf89135d2c930fbaf4bb5e0365
+  languageName: node
+  linkType: hard
+
+"@react-aria/tooltip@npm:^3.8.8":
+  version: 3.8.8
+  resolution: "@react-aria/tooltip@npm:3.8.8"
+  dependencies:
+    "@react-aria/interactions": "npm:^3.25.6"
+    "@react-aria/utils": "npm:^3.31.0"
+    "@react-stately/tooltip": "npm:^3.5.8"
+    "@react-types/shared": "npm:^3.32.1"
+    "@react-types/tooltip": "npm:^3.4.21"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/eddb4736b3813b26fdb21ce07cef170215a900a233d859605ad17a2c72c66ca8cc2fe105d3920f9b24fce0eb18e050551268dc25a9c5d4b987b7eca1e60b24e9
+  languageName: node
+  linkType: hard
+
+"@react-aria/tree@npm:^3.1.4":
+  version: 3.1.4
+  resolution: "@react-aria/tree@npm:3.1.4"
+  dependencies:
+    "@react-aria/gridlist": "npm:^3.14.1"
+    "@react-aria/i18n": "npm:^3.12.13"
+    "@react-aria/selection": "npm:^3.26.0"
+    "@react-aria/utils": "npm:^3.31.0"
+    "@react-stately/tree": "npm:^3.9.3"
+    "@react-types/button": "npm:^3.14.1"
+    "@react-types/shared": "npm:^3.32.1"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/ed3e48d011b846026b4c3bf78a96fbe91ff892d995a94e94ff6f5218dcbd6736660507dee1e06aac9ce48f9f66fdc8898cf8486192cecad428242b5b4930fde8
+  languageName: node
+  linkType: hard
+
+"@react-aria/utils@npm:^3.31.0":
+  version: 3.31.0
+  resolution: "@react-aria/utils@npm:3.31.0"
+  dependencies:
+    "@react-aria/ssr": "npm:^3.9.10"
+    "@react-stately/flags": "npm:^3.1.2"
+    "@react-stately/utils": "npm:^3.10.8"
+    "@react-types/shared": "npm:^3.32.1"
+    "@swc/helpers": "npm:^0.5.0"
+    clsx: "npm:^2.0.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/b021d2c3704ce934ec41cfc4d87fa6904fb3e007030e31b824cd8287053e866076cb7c7f072d6ed2fee82ca68f2e3f4677f3d58d7938e4b3315831f1fdea4d90
+  languageName: node
+  linkType: hard
+
+"@react-aria/virtualizer@npm:^4.1.10":
+  version: 4.1.10
+  resolution: "@react-aria/virtualizer@npm:4.1.10"
+  dependencies:
+    "@react-aria/i18n": "npm:^3.12.13"
+    "@react-aria/interactions": "npm:^3.25.6"
+    "@react-aria/utils": "npm:^3.31.0"
+    "@react-stately/virtualizer": "npm:^4.4.4"
+    "@react-types/shared": "npm:^3.32.1"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/a9d1083ee2e424a33cbe5520fc86fd5194a77555b3be21792f648a723770998320220bc32e49ae1551ce5e00b024520ad0bca6ca0d7fdee86bc6216eb1cf78dc
+  languageName: node
+  linkType: hard
+
+"@react-aria/visually-hidden@npm:^3.8.28":
+  version: 3.8.28
+  resolution: "@react-aria/visually-hidden@npm:3.8.28"
+  dependencies:
+    "@react-aria/interactions": "npm:^3.25.6"
+    "@react-aria/utils": "npm:^3.31.0"
+    "@react-types/shared": "npm:^3.32.1"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/07e61b18d385127353014c2bd2bb9bba5035ac064988fa1bfc2f13d8050ccc9488891d4d3fbe6c79a808bfed7f06f1867b89ec1c975818712a36266040d76597
   languageName: node
   linkType: hard
 
@@ -4473,765 +4473,764 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-stately/autocomplete@npm:3.0.0-beta.1":
-  version: 3.0.0-beta.1
-  resolution: "@react-stately/autocomplete@npm:3.0.0-beta.1"
+"@react-stately/autocomplete@npm:3.0.0-beta.3":
+  version: 3.0.0-beta.3
+  resolution: "@react-stately/autocomplete@npm:3.0.0-beta.3"
   dependencies:
-    "@react-stately/utils": "npm:^3.10.6"
+    "@react-stately/utils": "npm:^3.10.8"
     "@swc/helpers": "npm:^0.5.0"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/d6d43339d64ac846ed5bd19b2f5fbc904990916e24d8ff8ea3e9b748d2770ac62080d219035d47678b1d29765df2fe6ab9688e6619540fc10cff5e18621fbd9d
+  checksum: 10/3920ce479e577730870bc6845ee888a44a9a1f90188cf68efb60c74a8264b5886c9059b0cedc07b82fcb26afd770bff5fc971bef0d93ff6ba7d07024a3e628cd
   languageName: node
   linkType: hard
 
-"@react-stately/calendar@npm:^3.8.1":
-  version: 3.8.1
-  resolution: "@react-stately/calendar@npm:3.8.1"
+"@react-stately/calendar@npm:^3.9.0":
+  version: 3.9.0
+  resolution: "@react-stately/calendar@npm:3.9.0"
   dependencies:
-    "@internationalized/date": "npm:^3.8.1"
-    "@react-stately/utils": "npm:^3.10.6"
-    "@react-types/calendar": "npm:^3.7.1"
-    "@react-types/shared": "npm:^3.29.1"
+    "@internationalized/date": "npm:^3.10.0"
+    "@react-stately/utils": "npm:^3.10.8"
+    "@react-types/calendar": "npm:^3.8.0"
+    "@react-types/shared": "npm:^3.32.1"
     "@swc/helpers": "npm:^0.5.0"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/94835fb6ef34af81812b6447a28cc996c2583e2e0112e2b9c7ad6ce555f54bef9c9d9fc26766deb5c204282f9fc72c6c2d64dd862006c8c6bb9c60cbc4e72c96
+  checksum: 10/6021927974cfaee9b48e07c4a4744105d1076fbad841aafdbd8633deb105c56f724a2a2f51285b426755873c3c2c8ae677649c9c38431433e7cf9e8dea7b334c
   languageName: node
   linkType: hard
 
-"@react-stately/checkbox@npm:^3.6.14":
-  version: 3.6.14
-  resolution: "@react-stately/checkbox@npm:3.6.14"
+"@react-stately/checkbox@npm:^3.7.2":
+  version: 3.7.2
+  resolution: "@react-stately/checkbox@npm:3.7.2"
   dependencies:
-    "@react-stately/form": "npm:^3.1.4"
-    "@react-stately/utils": "npm:^3.10.6"
-    "@react-types/checkbox": "npm:^3.9.4"
-    "@react-types/shared": "npm:^3.29.1"
+    "@react-stately/form": "npm:^3.2.2"
+    "@react-stately/utils": "npm:^3.10.8"
+    "@react-types/checkbox": "npm:^3.10.2"
+    "@react-types/shared": "npm:^3.32.1"
     "@swc/helpers": "npm:^0.5.0"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/7b6bd7726db316b725f3e4d3718793fe077911abb5bd711f6bb09b67f6361c3b0954f2a0eeebd311f7310ddc546d4d1f67f0ce513b4e12f6d716c48ea9025c01
+  checksum: 10/e0dda0c536ee43b2b925b9bf2932fdf5d27370b55d069633bb1e4d6a9dfb0db783ed0119ab0893ec192aa4099da0341f39fd2065bfd2e6c89ca3997e92e83ca1
   languageName: node
   linkType: hard
 
-"@react-stately/collections@npm:^3.12.4":
-  version: 3.12.4
-  resolution: "@react-stately/collections@npm:3.12.4"
+"@react-stately/collections@npm:^3.12.8":
+  version: 3.12.8
+  resolution: "@react-stately/collections@npm:3.12.8"
   dependencies:
-    "@react-types/shared": "npm:^3.29.1"
+    "@react-types/shared": "npm:^3.32.1"
     "@swc/helpers": "npm:^0.5.0"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/9985f27fa2ff9aa5262ad0501dabb5117ece3fba2f0975dc4a3d138d2aa2fb7d379ac5ed6ec0cf0af7a9b994b85e2adbf147ef33de0135f71d0a3b5aa0d817dd
+  checksum: 10/da17c50d9323002f8dc05870265d54afa162575ceba83bc42d8ccd5d0ccf3bc0634d3896086e7975e1e7f1d7497de6f09ca0e5b82a697ad04349d5b59eca5a8f
   languageName: node
   linkType: hard
 
-"@react-stately/color@npm:^3.8.5":
-  version: 3.8.5
-  resolution: "@react-stately/color@npm:3.8.5"
+"@react-stately/color@npm:^3.9.2":
+  version: 3.9.2
+  resolution: "@react-stately/color@npm:3.9.2"
   dependencies:
-    "@internationalized/number": "npm:^3.6.2"
-    "@internationalized/string": "npm:^3.2.6"
-    "@react-stately/form": "npm:^3.1.4"
-    "@react-stately/numberfield": "npm:^3.9.12"
-    "@react-stately/slider": "npm:^3.6.4"
-    "@react-stately/utils": "npm:^3.10.6"
-    "@react-types/color": "npm:^3.0.5"
-    "@react-types/shared": "npm:^3.29.1"
+    "@internationalized/number": "npm:^3.6.5"
+    "@internationalized/string": "npm:^3.2.7"
+    "@react-stately/form": "npm:^3.2.2"
+    "@react-stately/numberfield": "npm:^3.10.2"
+    "@react-stately/slider": "npm:^3.7.2"
+    "@react-stately/utils": "npm:^3.10.8"
+    "@react-types/color": "npm:^3.1.2"
+    "@react-types/shared": "npm:^3.32.1"
     "@swc/helpers": "npm:^0.5.0"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/fca0facb5e8f35bd55fad6f7b80affefb45834bddeff2d8aeeffa71fd4cc8a2425645e77e1b12271565a79636a5f9f2c3ac58e9bec7085a9ecf7a3ece7086f71
+  checksum: 10/1aaea8dc241911b634ef072352076a8b3eec25300bb6c88ff2ce6147f05d2504688465a0342272b74a8484cdf272d10d2d9abc6cbbb64a111228046369f92ce5
   languageName: node
   linkType: hard
 
-"@react-stately/combobox@npm:^3.10.5":
-  version: 3.10.5
-  resolution: "@react-stately/combobox@npm:3.10.5"
+"@react-stately/combobox@npm:^3.12.0":
+  version: 3.12.0
+  resolution: "@react-stately/combobox@npm:3.12.0"
   dependencies:
-    "@react-stately/collections": "npm:^3.12.4"
-    "@react-stately/form": "npm:^3.1.4"
-    "@react-stately/list": "npm:^3.12.2"
-    "@react-stately/overlays": "npm:^3.6.16"
-    "@react-stately/select": "npm:^3.6.13"
-    "@react-stately/utils": "npm:^3.10.6"
-    "@react-types/combobox": "npm:^3.13.5"
-    "@react-types/shared": "npm:^3.29.1"
+    "@react-stately/collections": "npm:^3.12.8"
+    "@react-stately/form": "npm:^3.2.2"
+    "@react-stately/list": "npm:^3.13.1"
+    "@react-stately/overlays": "npm:^3.6.20"
+    "@react-stately/utils": "npm:^3.10.8"
+    "@react-types/combobox": "npm:^3.13.9"
+    "@react-types/shared": "npm:^3.32.1"
     "@swc/helpers": "npm:^0.5.0"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/0b1d4397074cb8a530efa2da19bb0da07a17befabc36eac31e6571d61b23c630d46ab1b566b483242597f1c2cdfdd023897bc4562389204f26f6a1792980c0a5
+  checksum: 10/3471a9c2f60e215784f63085b4ebcb2445ec804b3f0f50261933261afd7c9f7ed6d0675f00b5581aa43763c37561bcf6c6967a0ab485f403b1f8cf33a6b65d40
   languageName: node
   linkType: hard
 
-"@react-stately/data@npm:^3.13.0":
-  version: 3.13.0
-  resolution: "@react-stately/data@npm:3.13.0"
-  dependencies:
-    "@react-types/shared": "npm:^3.29.1"
-    "@swc/helpers": "npm:^0.5.0"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/7db08b90d7d38067dcfbc149b0b0538b9badcdd27e2fd72ffb24855b3afb54aa6dffa9770d74d24cdf0f464c182dc7473f308497d549693159402e4c9975b4b4
-  languageName: node
-  linkType: hard
-
-"@react-stately/datepicker@npm:^3.14.1":
+"@react-stately/data@npm:^3.14.1":
   version: 3.14.1
-  resolution: "@react-stately/datepicker@npm:3.14.1"
+  resolution: "@react-stately/data@npm:3.14.1"
   dependencies:
-    "@internationalized/date": "npm:^3.8.1"
-    "@internationalized/string": "npm:^3.2.6"
-    "@react-stately/form": "npm:^3.1.4"
-    "@react-stately/overlays": "npm:^3.6.16"
-    "@react-stately/utils": "npm:^3.10.6"
-    "@react-types/datepicker": "npm:^3.12.1"
-    "@react-types/shared": "npm:^3.29.1"
+    "@react-types/shared": "npm:^3.32.1"
     "@swc/helpers": "npm:^0.5.0"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/e2ae1e2b2e73ffa6c9f17ed332d79703237887d2e505985bd1ace821b697515f754e605de8a76506389135ba0cf41d1ceaace42e9cbe8f8481c4602130880080
+  checksum: 10/ac069e41036fd534a8ec4e77847234abc35aa02c1901b0abc3af3d5cede0baadb5ce0d5f648fed5d6b2e37f673669f2b21fbf74cfb760f0e99734f1d9e841d33
   languageName: node
   linkType: hard
 
-"@react-stately/disclosure@npm:^3.0.4":
-  version: 3.0.4
-  resolution: "@react-stately/disclosure@npm:3.0.4"
+"@react-stately/datepicker@npm:^3.15.2":
+  version: 3.15.2
+  resolution: "@react-stately/datepicker@npm:3.15.2"
   dependencies:
-    "@react-stately/utils": "npm:^3.10.6"
-    "@react-types/shared": "npm:^3.29.1"
+    "@internationalized/date": "npm:^3.10.0"
+    "@internationalized/string": "npm:^3.2.7"
+    "@react-stately/form": "npm:^3.2.2"
+    "@react-stately/overlays": "npm:^3.6.20"
+    "@react-stately/utils": "npm:^3.10.8"
+    "@react-types/datepicker": "npm:^3.13.2"
+    "@react-types/shared": "npm:^3.32.1"
     "@swc/helpers": "npm:^0.5.0"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/f4e6e39c7468a484693f4884266fb6a6e0c58ba3d6cc74ddcb83faffcd360493911629ee71eff6fb11601bd9babfdc1115e13540bd3e885bd42769d2b3f446a2
+  checksum: 10/59ef011e4d56a3a40923d0a2ce02f6150ca4e5c7b9dac638d4f2b512af9a213ea6cda2d8d85b114758f2db2b06a8840a93c5b9c8c30859366249d58d960ed149
   languageName: node
   linkType: hard
 
-"@react-stately/dnd@npm:^3.5.4":
-  version: 3.5.4
-  resolution: "@react-stately/dnd@npm:3.5.4"
+"@react-stately/disclosure@npm:^3.0.8":
+  version: 3.0.8
+  resolution: "@react-stately/disclosure@npm:3.0.8"
   dependencies:
-    "@react-stately/selection": "npm:^3.20.2"
-    "@react-types/shared": "npm:^3.29.1"
+    "@react-stately/utils": "npm:^3.10.8"
+    "@react-types/shared": "npm:^3.32.1"
     "@swc/helpers": "npm:^0.5.0"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/11c3bbc6d5c5599fddaf524c0bc21e5009d97d9debcc2753f12a69af26988ed47b1ace3d9266820bf3c0313b38eeba2d52d33b78ce214aedf2b63f0630c8c7c1
+  checksum: 10/8a36946589a199a788c07ef6ab04d0a30868db0484c660e5066ba38dd8bb8cef6e00fca324e7645b561fc7f3b3ffa152add555f2971c6be532d9cd3b67237b31
   languageName: node
   linkType: hard
 
-"@react-stately/flags@npm:^3.1.1":
-  version: 3.1.1
-  resolution: "@react-stately/flags@npm:3.1.1"
+"@react-stately/dnd@npm:^3.7.1":
+  version: 3.7.1
+  resolution: "@react-stately/dnd@npm:3.7.1"
   dependencies:
-    "@swc/helpers": "npm:^0.5.0"
-  checksum: 10/1a0b8cd09d1c8ab6a9a1245338b093b4c3a5a5e854a096a41a33054dc0162accd91c6fa323cb215444f2d8949cdebba03e2ad590ea500f7234cf63c8c7c34e01
-  languageName: node
-  linkType: hard
-
-"@react-stately/form@npm:^3.1.4":
-  version: 3.1.4
-  resolution: "@react-stately/form@npm:3.1.4"
-  dependencies:
-    "@react-types/shared": "npm:^3.29.1"
+    "@react-stately/selection": "npm:^3.20.6"
+    "@react-types/shared": "npm:^3.32.1"
     "@swc/helpers": "npm:^0.5.0"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/484b9af403d7e4c8731331384e9a0a5e655f262f7a1302f8004e76ae2a5ef5fe0a2332c6d28ad1f9316c6956a69f4d0788554e91617c73925b38f0c0e7be7409
+  checksum: 10/d5500055a5398914556eeb767b141e4192be446990dfecb385b0348a35dc0baf0b0a72567dde806369995e09f5dc27a13fe4261739da7bc8ba483875bd88e694
   languageName: node
   linkType: hard
 
-"@react-stately/grid@npm:^3.11.2":
-  version: 3.11.2
-  resolution: "@react-stately/grid@npm:3.11.2"
+"@react-stately/flags@npm:^3.1.2":
+  version: 3.1.2
+  resolution: "@react-stately/flags@npm:3.1.2"
   dependencies:
-    "@react-stately/collections": "npm:^3.12.4"
-    "@react-stately/selection": "npm:^3.20.2"
-    "@react-types/grid": "npm:^3.3.2"
-    "@react-types/shared": "npm:^3.29.1"
+    "@swc/helpers": "npm:^0.5.0"
+  checksum: 10/a020c3680c36d9624f765c5916ce95d69959f64887928e8f380f11b5362bb0499a901a5842e4e12eb8e5a776af59212b1ee0c4c6a6681ce75f61dace8b2f9c40
+  languageName: node
+  linkType: hard
+
+"@react-stately/form@npm:^3.2.2":
+  version: 3.2.2
+  resolution: "@react-stately/form@npm:3.2.2"
+  dependencies:
+    "@react-types/shared": "npm:^3.32.1"
     "@swc/helpers": "npm:^0.5.0"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/3f05858e6ee8b283f229c3ede9e1e230d876cb343858353511cb6706674f745b09429e8332d32e7eab0c420eb984e67f59cadfe03fd16791e12d7c6f8417a9f0
+  checksum: 10/e466309999cb2f28e892b11cdfc7cee2b7d08eefced41d9e346e2c4353dd5fc1864de145a6b332735cdc94b278ff8e6b599489d2aa6945ec5389171f89a633d1
   languageName: node
   linkType: hard
 
-"@react-stately/layout@npm:^4.3.0":
-  version: 4.3.0
-  resolution: "@react-stately/layout@npm:4.3.0"
+"@react-stately/grid@npm:^3.11.6":
+  version: 3.11.6
+  resolution: "@react-stately/grid@npm:3.11.6"
   dependencies:
-    "@react-stately/collections": "npm:^3.12.4"
-    "@react-stately/table": "npm:^3.14.2"
-    "@react-stately/virtualizer": "npm:^4.4.0"
-    "@react-types/grid": "npm:^3.3.2"
-    "@react-types/shared": "npm:^3.29.1"
-    "@react-types/table": "npm:^3.13.0"
+    "@react-stately/collections": "npm:^3.12.8"
+    "@react-stately/selection": "npm:^3.20.6"
+    "@react-types/grid": "npm:^3.3.6"
+    "@react-types/shared": "npm:^3.32.1"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/b6bc2a24ff37bdf375caa0f73dd6812ec4368f314f7754472f8b5de47ed296c4d3aadab787768c50d17d5606732291f05448891d5b08c0facaf8a1c9f7a70d31
+  languageName: node
+  linkType: hard
+
+"@react-stately/layout@npm:^4.5.1":
+  version: 4.5.1
+  resolution: "@react-stately/layout@npm:4.5.1"
+  dependencies:
+    "@react-stately/collections": "npm:^3.12.8"
+    "@react-stately/table": "npm:^3.15.1"
+    "@react-stately/virtualizer": "npm:^4.4.4"
+    "@react-types/grid": "npm:^3.3.6"
+    "@react-types/shared": "npm:^3.32.1"
+    "@react-types/table": "npm:^3.13.4"
     "@swc/helpers": "npm:^0.5.0"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
     react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/53e58c2403a15c4c9817740250c712ca1c678e3bec29cefbf1a1c3d44498bc5550ec5d96b8c2210fecf512eb549d5752bfbb63be2f92b36c48e2bb94b3570742
+  checksum: 10/a4413d766efdea8decf4549cd773f5a94ce086690195223e605b78ccb9e1c0dd25011bd37a011b805c72a7a9f3a27dc1dd6c8684d9cc2a0b6efaa084fbd337a4
   languageName: node
   linkType: hard
 
-"@react-stately/list@npm:^3.12.2":
-  version: 3.12.2
-  resolution: "@react-stately/list@npm:3.12.2"
+"@react-stately/list@npm:^3.13.1":
+  version: 3.13.1
+  resolution: "@react-stately/list@npm:3.13.1"
   dependencies:
-    "@react-stately/collections": "npm:^3.12.4"
-    "@react-stately/selection": "npm:^3.20.2"
-    "@react-stately/utils": "npm:^3.10.6"
-    "@react-types/shared": "npm:^3.29.1"
+    "@react-stately/collections": "npm:^3.12.8"
+    "@react-stately/selection": "npm:^3.20.6"
+    "@react-stately/utils": "npm:^3.10.8"
+    "@react-types/shared": "npm:^3.32.1"
     "@swc/helpers": "npm:^0.5.0"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/56d97f6778b9586832859160338cc0e8ce7a1da4c8fa39fbbc87fff38d967d00e5d4f0c1f70b668d44a0a3abef9a09f5717da2908d8a16f963dd544d3bf3b0cd
+  checksum: 10/3da2ca14eaee5f0915c1c79df66268bf1e7cc5d60ce68170515180993941c4c8679033589a8bc38e08138b882a62a8ad69ca727a500c882bd0f4214ce9a69384
   languageName: node
   linkType: hard
 
-"@react-stately/menu@npm:^3.9.4":
-  version: 3.9.4
-  resolution: "@react-stately/menu@npm:3.9.4"
+"@react-stately/menu@npm:^3.9.8":
+  version: 3.9.8
+  resolution: "@react-stately/menu@npm:3.9.8"
   dependencies:
-    "@react-stately/overlays": "npm:^3.6.16"
-    "@react-types/menu": "npm:^3.10.1"
-    "@react-types/shared": "npm:^3.29.1"
+    "@react-stately/overlays": "npm:^3.6.20"
+    "@react-types/menu": "npm:^3.10.5"
+    "@react-types/shared": "npm:^3.32.1"
     "@swc/helpers": "npm:^0.5.0"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/51cba945a56bf5d8b92c3fc78c9a43a116c95cc6bcc55160b16df8a19134b37aaf22e780ba0b636c61051b32ffcdbf4728acdf491e895ec0c480c9e013eba879
+  checksum: 10/7798aa91f0af2743d4d441be1a0bac54489413c187d0e926a336cf13482ad4d54c7215426cd6ea288b8bcf621406db6ebaca5209095be5bfb4dfe4464ece7875
   languageName: node
   linkType: hard
 
-"@react-stately/numberfield@npm:^3.9.12":
-  version: 3.9.12
-  resolution: "@react-stately/numberfield@npm:3.9.12"
+"@react-stately/numberfield@npm:^3.10.2":
+  version: 3.10.2
+  resolution: "@react-stately/numberfield@npm:3.10.2"
   dependencies:
-    "@internationalized/number": "npm:^3.6.2"
-    "@react-stately/form": "npm:^3.1.4"
-    "@react-stately/utils": "npm:^3.10.6"
-    "@react-types/numberfield": "npm:^3.8.11"
+    "@internationalized/number": "npm:^3.6.5"
+    "@react-stately/form": "npm:^3.2.2"
+    "@react-stately/utils": "npm:^3.10.8"
+    "@react-types/numberfield": "npm:^3.8.15"
     "@swc/helpers": "npm:^0.5.0"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/f2dd768323d9e206a3564ffdb8f739d17c0241126674a97557c304c419768745f33d40e928b73a54c111cfcc60293936e70ff7b112b6f2bd08043671a9be1662
+  checksum: 10/5fd1d4cc1b90a7b03b98a82e47162044a78534291b9baa77847eddd4fb8040bddb91329dfcc7aa2a7cc38ace23817b6c9d52dd7b0f9bd7ce249f763006580797
   languageName: node
   linkType: hard
 
-"@react-stately/overlays@npm:^3.6.16":
-  version: 3.6.16
-  resolution: "@react-stately/overlays@npm:3.6.16"
+"@react-stately/overlays@npm:^3.6.20":
+  version: 3.6.20
+  resolution: "@react-stately/overlays@npm:3.6.20"
   dependencies:
-    "@react-stately/utils": "npm:^3.10.6"
-    "@react-types/overlays": "npm:^3.8.15"
+    "@react-stately/utils": "npm:^3.10.8"
+    "@react-types/overlays": "npm:^3.9.2"
     "@swc/helpers": "npm:^0.5.0"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/3a5f1e6910d81e116fa9f1bde716347b1a42296ba2c038a91bc48c0334cccd720140b70fca5ce37ab3cdd84525d6a416043268eebf80d435d835f5578b5227f4
+  checksum: 10/e9a3023b3fc3d9383d36dbd0a1e6a0d3d84350dee4f5ce6578464d613e063ca32dd6685c4fdfaa774ded24497c9e5c56363b9650c551d5d1a4dbb6d7d1d04382
   languageName: node
   linkType: hard
 
-"@react-stately/radio@npm:^3.10.13":
-  version: 3.10.13
-  resolution: "@react-stately/radio@npm:3.10.13"
+"@react-stately/radio@npm:^3.11.2":
+  version: 3.11.2
+  resolution: "@react-stately/radio@npm:3.11.2"
   dependencies:
-    "@react-stately/form": "npm:^3.1.4"
-    "@react-stately/utils": "npm:^3.10.6"
-    "@react-types/radio": "npm:^3.8.9"
-    "@react-types/shared": "npm:^3.29.1"
+    "@react-stately/form": "npm:^3.2.2"
+    "@react-stately/utils": "npm:^3.10.8"
+    "@react-types/radio": "npm:^3.9.2"
+    "@react-types/shared": "npm:^3.32.1"
     "@swc/helpers": "npm:^0.5.0"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/626949c60ded2f140c9474ed5dbd385bd1ff21b3536666c55621091ac5aaaa09478f4cbf8bb2d97ad641c81c385197b76eade3825531f84cb75bff155b2cb437
+  checksum: 10/182946fb5e963fed62df59d8893ca92443e587bcf3d644b54b991b3acb2124b777af11884e6e31c953becc2dad2226a13238a219747fb596a7e08f0e31e97a22
   languageName: node
   linkType: hard
 
-"@react-stately/searchfield@npm:^3.5.12":
-  version: 3.5.12
-  resolution: "@react-stately/searchfield@npm:3.5.12"
+"@react-stately/searchfield@npm:^3.5.16":
+  version: 3.5.16
+  resolution: "@react-stately/searchfield@npm:3.5.16"
   dependencies:
-    "@react-stately/utils": "npm:^3.10.6"
-    "@react-types/searchfield": "npm:^3.6.2"
+    "@react-stately/utils": "npm:^3.10.8"
+    "@react-types/searchfield": "npm:^3.6.6"
     "@swc/helpers": "npm:^0.5.0"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/a4b6e69c0daa5be3d5c7b06386f8a986caa1a73251e33ab3064c7299095da96ac5ecdfcee632dcf541f4175eac99fc68df2555a45f8704174b792df4f82c692a
+  checksum: 10/879e736c6888e36e227efffa665420c7e4fd2b319c2fb11661d6689fbbdad549129adc1c218e531f79f5e52be5b4c075c3c8120363ca3238fec24195c1976527
   languageName: node
   linkType: hard
 
-"@react-stately/select@npm:^3.6.13":
-  version: 3.6.13
-  resolution: "@react-stately/select@npm:3.6.13"
+"@react-stately/select@npm:^3.8.0":
+  version: 3.8.0
+  resolution: "@react-stately/select@npm:3.8.0"
   dependencies:
-    "@react-stately/form": "npm:^3.1.4"
-    "@react-stately/list": "npm:^3.12.2"
-    "@react-stately/overlays": "npm:^3.6.16"
-    "@react-types/select": "npm:^3.9.12"
-    "@react-types/shared": "npm:^3.29.1"
+    "@react-stately/form": "npm:^3.2.2"
+    "@react-stately/list": "npm:^3.13.1"
+    "@react-stately/overlays": "npm:^3.6.20"
+    "@react-stately/utils": "npm:^3.10.8"
+    "@react-types/select": "npm:^3.11.0"
+    "@react-types/shared": "npm:^3.32.1"
     "@swc/helpers": "npm:^0.5.0"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/20e25c0040748c3150fba23b6dff6a3f4ef772c2cc6f495fd51dbbd52de253c907e5ea4f7fa130ba14309c003579b2f9668b110d5b2ad2a1217e64dd6f4b20c3
+  checksum: 10/d611bbd9d6b55a2dfb31455227efe54c9fc2684f37abd9ba5633b2d1b838bc8fc182e92e64e94ef17c8bbaf351a72daf6089c9d54ce8acad76d3f1be3bdb05aa
   languageName: node
   linkType: hard
 
-"@react-stately/selection@npm:^3.20.2":
-  version: 3.20.2
-  resolution: "@react-stately/selection@npm:3.20.2"
+"@react-stately/selection@npm:^3.20.6":
+  version: 3.20.6
+  resolution: "@react-stately/selection@npm:3.20.6"
   dependencies:
-    "@react-stately/collections": "npm:^3.12.4"
-    "@react-stately/utils": "npm:^3.10.6"
-    "@react-types/shared": "npm:^3.29.1"
+    "@react-stately/collections": "npm:^3.12.8"
+    "@react-stately/utils": "npm:^3.10.8"
+    "@react-types/shared": "npm:^3.32.1"
     "@swc/helpers": "npm:^0.5.0"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/1aebbd5edf7f5a0593862a174d63049cae610c87c5c5f3dfffe2d944ffb64398d58174d31a99783b5f68f6a986e0f81c721f56aad059efb89ae7521e148afd02
+  checksum: 10/b72941f9d23d285b826aa0a5be55e299d934b335d8ebe50c6b061f72b59f860a37549ac4fc0f41a7357eab0d40edb404207cca201fc78915b001b5532e45a9db
   languageName: node
   linkType: hard
 
-"@react-stately/slider@npm:^3.6.4":
-  version: 3.6.4
-  resolution: "@react-stately/slider@npm:3.6.4"
+"@react-stately/slider@npm:^3.7.2":
+  version: 3.7.2
+  resolution: "@react-stately/slider@npm:3.7.2"
   dependencies:
-    "@react-stately/utils": "npm:^3.10.6"
-    "@react-types/shared": "npm:^3.29.1"
-    "@react-types/slider": "npm:^3.7.11"
+    "@react-stately/utils": "npm:^3.10.8"
+    "@react-types/shared": "npm:^3.32.1"
+    "@react-types/slider": "npm:^3.8.2"
     "@swc/helpers": "npm:^0.5.0"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/ecba9014731a92b778ae7d16ff8bc552a8a658d31fb11d81b32e83790f4cc46e84948f9c3969592344f631f1fc1c656486d033e9cba45fe550a32c35a62d4082
+  checksum: 10/c11a5374904434bfad5e87767900ed40e12d4341abf74d835b59ab26efb69ad669c86016926f83eae5fb3b3e39c175f775c4457b77eec64d73785c92369a79da
   languageName: node
   linkType: hard
 
-"@react-stately/table@npm:^3.14.2":
-  version: 3.14.2
-  resolution: "@react-stately/table@npm:3.14.2"
+"@react-stately/table@npm:^3.15.1":
+  version: 3.15.1
+  resolution: "@react-stately/table@npm:3.15.1"
   dependencies:
-    "@react-stately/collections": "npm:^3.12.4"
-    "@react-stately/flags": "npm:^3.1.1"
-    "@react-stately/grid": "npm:^3.11.2"
-    "@react-stately/selection": "npm:^3.20.2"
-    "@react-stately/utils": "npm:^3.10.6"
-    "@react-types/grid": "npm:^3.3.2"
-    "@react-types/shared": "npm:^3.29.1"
-    "@react-types/table": "npm:^3.13.0"
+    "@react-stately/collections": "npm:^3.12.8"
+    "@react-stately/flags": "npm:^3.1.2"
+    "@react-stately/grid": "npm:^3.11.6"
+    "@react-stately/selection": "npm:^3.20.6"
+    "@react-stately/utils": "npm:^3.10.8"
+    "@react-types/grid": "npm:^3.3.6"
+    "@react-types/shared": "npm:^3.32.1"
+    "@react-types/table": "npm:^3.13.4"
     "@swc/helpers": "npm:^0.5.0"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/fcd3848dbb850fe40666e4d6ea4f4347b4f82f78f6bf7145999a3d37ae730ebd555613ebb4e692e662f4b4d66e05eca1c097f9f1cfc79c67b34606d657cecdb6
+  checksum: 10/005292a0803de55179a9d27aa7bb68f44865fff64921141fac7aab0fbd5d2adff27a9a70db904f9a57bd6bc8db84036e8ad58b7a1ea57c990829500eb3f3ee6d
   languageName: node
   linkType: hard
 
-"@react-stately/tabs@npm:^3.8.2":
-  version: 3.8.2
-  resolution: "@react-stately/tabs@npm:3.8.2"
+"@react-stately/tabs@npm:^3.8.6":
+  version: 3.8.6
+  resolution: "@react-stately/tabs@npm:3.8.6"
   dependencies:
-    "@react-stately/list": "npm:^3.12.2"
-    "@react-types/shared": "npm:^3.29.1"
-    "@react-types/tabs": "npm:^3.3.15"
+    "@react-stately/list": "npm:^3.13.1"
+    "@react-types/shared": "npm:^3.32.1"
+    "@react-types/tabs": "npm:^3.3.19"
     "@swc/helpers": "npm:^0.5.0"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/4d73d19c24eede90d17e4eab3a30f2895e5b395a0f97c0c20f583545c23666a68871488c70c96ce49f7659c20a7afaee96242f4b8aa0096984b04b02aa2934a3
+  checksum: 10/ed71a8351b6b9db7c191cbb60acf72121751864b20c1d9a552438a1f4f6c96fdd41469396a17a86ef52287463ef3c8f217167f9498bc5f36e77a621415fac388
   languageName: node
   linkType: hard
 
-"@react-stately/toast@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "@react-stately/toast@npm:3.1.0"
+"@react-stately/toast@npm:^3.1.2":
+  version: 3.1.2
+  resolution: "@react-stately/toast@npm:3.1.2"
   dependencies:
     "@swc/helpers": "npm:^0.5.0"
     use-sync-external-store: "npm:^1.4.0"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/54e222e068433791549ff5f5238690384e2246041f41fdcae2d0e9d629569c3073d2aa92751601c0f1526a3cd0ca2cd2918c7031a753b8c897df99ce7280ab95
+  checksum: 10/771eade3a6f84d7aac3f5766e9cc47826cdb179d58165d12650a843548c13cbf4b4bd3b804a1f367e884e0e28d1d51693cb6f5e7c8391ebdb233cb1dddc015c5
   languageName: node
   linkType: hard
 
-"@react-stately/toggle@npm:^3.8.4":
-  version: 3.8.4
-  resolution: "@react-stately/toggle@npm:3.8.4"
+"@react-stately/toggle@npm:^3.9.2":
+  version: 3.9.2
+  resolution: "@react-stately/toggle@npm:3.9.2"
   dependencies:
-    "@react-stately/utils": "npm:^3.10.6"
-    "@react-types/checkbox": "npm:^3.9.4"
-    "@react-types/shared": "npm:^3.29.1"
+    "@react-stately/utils": "npm:^3.10.8"
+    "@react-types/checkbox": "npm:^3.10.2"
+    "@react-types/shared": "npm:^3.32.1"
     "@swc/helpers": "npm:^0.5.0"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/4f28b2c37609f0489112a439606b52f8ab77a6fde73ded21547a5c310d68c75bff42985d20d66dbfb2c8b1db7879e18cd1a20ef1ac6eca0bfe559405d56f798e
+  checksum: 10/06f0e11cbbda0b479113df6c82e650db9ac772162566fd749da19a3ca274d25831849dc6c67383f4a440be82f61b5dff80e97513763f66bf3994a55febed5827
   languageName: node
   linkType: hard
 
-"@react-stately/tooltip@npm:^3.5.4":
-  version: 3.5.4
-  resolution: "@react-stately/tooltip@npm:3.5.4"
+"@react-stately/tooltip@npm:^3.5.8":
+  version: 3.5.8
+  resolution: "@react-stately/tooltip@npm:3.5.8"
   dependencies:
-    "@react-stately/overlays": "npm:^3.6.16"
-    "@react-types/tooltip": "npm:^3.4.17"
+    "@react-stately/overlays": "npm:^3.6.20"
+    "@react-types/tooltip": "npm:^3.4.21"
     "@swc/helpers": "npm:^0.5.0"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/6b340436c876f82a0f9dc85ac76e5d8c0fd31c1f8c911bf6c4f40b429a268dbb75778632b29547849fe0579fd30cfb115f650d948f21250ce3bed5b45e684c59
+  checksum: 10/fbddb1f0efc6a6275f8f558bf80b984aea0c49f6c0d17fc42fc27e48a02a3c36bc9ca3eed6de9347a3b12289d21e22dc3de159b8b4b8ab21fe18218ab8a0e4ec
   languageName: node
   linkType: hard
 
-"@react-stately/tree@npm:^3.8.10":
-  version: 3.8.10
-  resolution: "@react-stately/tree@npm:3.8.10"
+"@react-stately/tree@npm:^3.9.3":
+  version: 3.9.3
+  resolution: "@react-stately/tree@npm:3.9.3"
   dependencies:
-    "@react-stately/collections": "npm:^3.12.4"
-    "@react-stately/selection": "npm:^3.20.2"
-    "@react-stately/utils": "npm:^3.10.6"
-    "@react-types/shared": "npm:^3.29.1"
+    "@react-stately/collections": "npm:^3.12.8"
+    "@react-stately/selection": "npm:^3.20.6"
+    "@react-stately/utils": "npm:^3.10.8"
+    "@react-types/shared": "npm:^3.32.1"
     "@swc/helpers": "npm:^0.5.0"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/4485fe47a949e7fc75611c9e32e2e8b496c9c32b46602adf82e0e681b77b12c4e9dcc28500a7bf4de569c12ae0d35934634b8447692c2e90ae66cd026f9bc3e6
+  checksum: 10/294cc70ffa08280a187a85f72c2402547d71295ddb95b2752fcfa395016947e7fe27116e970df597bab87319e18b3bf1f6b837124fb4bbda8686f7f0018b46ab
   languageName: node
   linkType: hard
 
-"@react-stately/utils@npm:^3.10.6":
-  version: 3.10.6
-  resolution: "@react-stately/utils@npm:3.10.6"
+"@react-stately/utils@npm:^3.10.8":
+  version: 3.10.8
+  resolution: "@react-stately/utils@npm:3.10.8"
   dependencies:
     "@swc/helpers": "npm:^0.5.0"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/84a2374b2dbc343af0c88283b331ddd5a8916edc0a5413189f572da77f37860d0a971cf7dc0b401fcc0be8c972af85099c11c704ea59bcbb8e57347832deee27
+  checksum: 10/7878ec47b132075566708bae630cb86d8237dde976eb3793bba43695abbb29fcaea9d00ea3f4f7244fcda253368f5b2b85263c37665c24e390500cdcc978c6fe
   languageName: node
   linkType: hard
 
-"@react-stately/virtualizer@npm:^4.4.0":
-  version: 4.4.0
-  resolution: "@react-stately/virtualizer@npm:4.4.0"
+"@react-stately/virtualizer@npm:^4.4.4":
+  version: 4.4.4
+  resolution: "@react-stately/virtualizer@npm:4.4.4"
   dependencies:
-    "@react-aria/utils": "npm:^3.29.0"
-    "@react-types/shared": "npm:^3.29.1"
+    "@react-types/shared": "npm:^3.32.1"
     "@swc/helpers": "npm:^0.5.0"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
     react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/124fccba87bc2108ba5801fbcd9d84e1b7710fdae3983b6b93acc84e83e14ec5bf6c5e11280eb70f4203d71badb106037142ecf547f53479fbacc37fa2c0aa87
+  checksum: 10/c9d8d4b34250b8c0e91811bc618c654bac3e8eabe7a8ec119abc8f5dbbfa19faa4b31575eb0775773fda0f533fc2835e9a233b4ed0e4ae1835ddb5f0521a18aa
   languageName: node
   linkType: hard
 
-"@react-types/autocomplete@npm:3.0.0-alpha.31":
-  version: 3.0.0-alpha.31
-  resolution: "@react-types/autocomplete@npm:3.0.0-alpha.31"
+"@react-types/autocomplete@npm:3.0.0-alpha.35":
+  version: 3.0.0-alpha.35
+  resolution: "@react-types/autocomplete@npm:3.0.0-alpha.35"
   dependencies:
-    "@react-types/combobox": "npm:^3.13.5"
-    "@react-types/searchfield": "npm:^3.6.2"
-    "@react-types/shared": "npm:^3.29.1"
+    "@react-types/combobox": "npm:^3.13.9"
+    "@react-types/searchfield": "npm:^3.6.6"
+    "@react-types/shared": "npm:^3.32.1"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/ae7e13f11f3eacc2d6a190c87380dbae7e23924451e3fdd7b8066ec45ec46a702b5c5a48faf3d70fdd20b2868400fcc48c646987c59409d68ddcad200d93939c
+  checksum: 10/2a51111a94f5df1ce0b1b137a69ca783fa2fa399b4c305ebc7f137b0aa6a420cfe2a3925d40fda9a7d0d3b832d390823015959eee41b6c6b31f7a6b30739a596
   languageName: node
   linkType: hard
 
-"@react-types/breadcrumbs@npm:^3.7.13":
-  version: 3.7.13
-  resolution: "@react-types/breadcrumbs@npm:3.7.13"
+"@react-types/breadcrumbs@npm:^3.7.17":
+  version: 3.7.17
+  resolution: "@react-types/breadcrumbs@npm:3.7.17"
   dependencies:
-    "@react-types/link": "npm:^3.6.1"
-    "@react-types/shared": "npm:^3.29.1"
+    "@react-types/link": "npm:^3.6.5"
+    "@react-types/shared": "npm:^3.32.1"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/495c71b646b09b657a323f3a2fe6acf80b93ad90338b370ec712a42b3c8badefbd2b6a04547dd2d8f0c9fdf60d30e546a49ec12ea2410f69ee91f133eaac942a
+  checksum: 10/e9754d1b8010f3cdfdfcd8abf03cdb5b37dc1038496fcc103569b9f349269b39680979c2293cdc04c376cd1ea7b97b00571d46677b9d4939a60dd01b55f765a6
   languageName: node
   linkType: hard
 
-"@react-types/button@npm:^3.12.1":
-  version: 3.12.1
-  resolution: "@react-types/button@npm:3.12.1"
+"@react-types/button@npm:^3.14.1":
+  version: 3.14.1
+  resolution: "@react-types/button@npm:3.14.1"
   dependencies:
-    "@react-types/shared": "npm:^3.29.1"
+    "@react-types/shared": "npm:^3.32.1"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/2badf58832bdafdab5b131dc6fd52c8a05019a093418acbe19e9078cc03daedd219de688ac6f581a3a59e0a2999fc0c8978bb9bf17c810af71c0b1231bc0e082
+  checksum: 10/bbbf2e5db83f6b925af154199aaad438d950187862c4ca6f82122c0209632c0c358201ec9b0b503f9b96c8b5b765066af41c6472440ca7ea75b75031d7d9eacf
   languageName: node
   linkType: hard
 
-"@react-types/calendar@npm:^3.7.1":
-  version: 3.7.1
-  resolution: "@react-types/calendar@npm:3.7.1"
+"@react-types/calendar@npm:^3.8.0":
+  version: 3.8.0
+  resolution: "@react-types/calendar@npm:3.8.0"
   dependencies:
-    "@internationalized/date": "npm:^3.8.1"
-    "@react-types/shared": "npm:^3.29.1"
+    "@internationalized/date": "npm:^3.10.0"
+    "@react-types/shared": "npm:^3.32.1"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/12edfd2c2dc8515c0969be0069245bebdad23c6354524d05f33962fe9d296de33c4fe0f7e3c6dd127f4da4b8fed1ce7acfb5b57c3d66f62dfeb9ab4c948f3361
+  checksum: 10/06fe32c8e5d78eedcb511fa3d18f66582b5664ab85c572538e24b953e8204a7c5f98407df0d028625a1dfdd94223153e8e04d9d7feefd96f7533b90fb82be907
   languageName: node
   linkType: hard
 
-"@react-types/checkbox@npm:^3.9.4":
-  version: 3.9.4
-  resolution: "@react-types/checkbox@npm:3.9.4"
+"@react-types/checkbox@npm:^3.10.2":
+  version: 3.10.2
+  resolution: "@react-types/checkbox@npm:3.10.2"
   dependencies:
-    "@react-types/shared": "npm:^3.29.1"
+    "@react-types/shared": "npm:^3.32.1"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/cee69cd4612312bb81f919dc0d317d93b93a43e878d9418e61675dfd398b2eac01cee904d8e593301267aeff037490463cadfee84c53f979b04b98f69771aefd
+  checksum: 10/3d2f8468ce3326825bc820c958dc52b68f11a18ff15a68de2663115b168fecb165a2381cfecf2d7a254bfba66760590d8d76dabae5f48626a15eddf309206516
   languageName: node
   linkType: hard
 
-"@react-types/color@npm:^3.0.5":
-  version: 3.0.5
-  resolution: "@react-types/color@npm:3.0.5"
+"@react-types/color@npm:^3.1.2":
+  version: 3.1.2
+  resolution: "@react-types/color@npm:3.1.2"
   dependencies:
-    "@react-types/shared": "npm:^3.29.1"
-    "@react-types/slider": "npm:^3.7.11"
+    "@react-types/shared": "npm:^3.32.1"
+    "@react-types/slider": "npm:^3.8.2"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/9e0334ff46ed212b659c1ffeb342d6e4b27c9255197a9666d9718c595b1ab1c4dc8c178764be54854504baa575ad3ed68fcf25784a7f8ff455a9806b56828dcd
+  checksum: 10/a41e786bd17b1815d5b7414f2dcbc79e655c3a4b8fe2dfa68c200c553f922bab5468a2ea272c76cdf6611d7d3f20518ca31b442729ef7b68141d91839e580410
   languageName: node
   linkType: hard
 
-"@react-types/combobox@npm:^3.13.5":
-  version: 3.13.5
-  resolution: "@react-types/combobox@npm:3.13.5"
+"@react-types/combobox@npm:^3.13.9":
+  version: 3.13.9
+  resolution: "@react-types/combobox@npm:3.13.9"
   dependencies:
-    "@react-types/shared": "npm:^3.29.1"
+    "@react-types/shared": "npm:^3.32.1"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/5c37fe03c78e705c5ba82b464bf697097e8c27c74857307eba77abe562c0564403eb5718fdae470d7e94afd92a288c695ba4649a91502fe60cb2e7c9add8c5d8
+  checksum: 10/0583d24f38b965e5c2cd2b436a7ad374635e183dc7c12145ce9ed0a166d7b6e46ed4685a68c9fb24aed065d1fca644ca3b0606cb360ae5fac3a9881e88ee2f2b
   languageName: node
   linkType: hard
 
-"@react-types/datepicker@npm:^3.12.1":
-  version: 3.12.1
-  resolution: "@react-types/datepicker@npm:3.12.1"
+"@react-types/datepicker@npm:^3.13.2":
+  version: 3.13.2
+  resolution: "@react-types/datepicker@npm:3.13.2"
   dependencies:
-    "@internationalized/date": "npm:^3.8.1"
-    "@react-types/calendar": "npm:^3.7.1"
-    "@react-types/overlays": "npm:^3.8.15"
-    "@react-types/shared": "npm:^3.29.1"
+    "@internationalized/date": "npm:^3.10.0"
+    "@react-types/calendar": "npm:^3.8.0"
+    "@react-types/overlays": "npm:^3.9.2"
+    "@react-types/shared": "npm:^3.32.1"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/c8b7a13ea437643df376dd478a7fc19233827772d240f6d0d1a94f354ec7ae5be6095c12bc28430054931367683b55a0bcb5af269f1318927c5fb1d6c5d67445
+  checksum: 10/1f1686360f64051f5eff5e170ab78e890b20e07680b6031c96c77e47085ca022c55997018911095cd61076bdf63470f61c99ac25ef9b493420f69cde6e4763bd
   languageName: node
   linkType: hard
 
-"@react-types/dialog@npm:^3.5.18":
-  version: 3.5.18
-  resolution: "@react-types/dialog@npm:3.5.18"
+"@react-types/dialog@npm:^3.5.22":
+  version: 3.5.22
+  resolution: "@react-types/dialog@npm:3.5.22"
   dependencies:
-    "@react-types/overlays": "npm:^3.8.15"
-    "@react-types/shared": "npm:^3.29.1"
+    "@react-types/overlays": "npm:^3.9.2"
+    "@react-types/shared": "npm:^3.32.1"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/2aa33a5f63e74defd6f374d46e7f25d1c81b8ff890d6444de78b1f5aae7f6b32e910d951c9f38b12cbffda000555b75e2e7217ce3dc52ade875da77b0b22dff2
+  checksum: 10/dedac6cf8a85568344242eb6e7f9c6f9dd9fff31711d23586374a1cfc4f3b7b7bed43fdff633d54135792dcdd9941a8a15a34bbbec1a9d4caff7b869b35dd71e
   languageName: node
   linkType: hard
 
-"@react-types/form@npm:^3.7.12":
-  version: 3.7.12
-  resolution: "@react-types/form@npm:3.7.12"
+"@react-types/form@npm:^3.7.16":
+  version: 3.7.16
+  resolution: "@react-types/form@npm:3.7.16"
   dependencies:
-    "@react-types/shared": "npm:^3.29.1"
+    "@react-types/shared": "npm:^3.32.1"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/bc31e5d0641047d256a2a9b70ff7952f8b9b143862bc0280103df77149a528c94b19db136e544408d3716edf842d13f484c18a3a756b933c78b9a17c30298cbe
+  checksum: 10/3e8f156318746d31ef7470d366dcc1004f3a59b1a3a3f9e54331921a4b251ff51c6bf76a32be229f6d8c524b5b1292f3c1135597de6b0f52bae2d8c32a542a74
   languageName: node
   linkType: hard
 
-"@react-types/grid@npm:^3.3.2":
-  version: 3.3.2
-  resolution: "@react-types/grid@npm:3.3.2"
+"@react-types/grid@npm:^3.3.6":
+  version: 3.3.6
+  resolution: "@react-types/grid@npm:3.3.6"
   dependencies:
-    "@react-types/shared": "npm:^3.29.1"
+    "@react-types/shared": "npm:^3.32.1"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/50133fb103cf82cf16cdc2d061bbca0d600968ff8bfa84c91353f93d924676887c4b6bb449f6e413bf89a4c96c1e174fb12823010bee58c3f3e55f2e549db356
+  checksum: 10/2b4be0fd8f6d07d3feca68039b89e0c13e1e566d27334a6ca7b6368f073ee55cf026833c5af664c78ccd137716aefd4f46b88f1b97709cd8080d7380c79454df
   languageName: node
   linkType: hard
 
-"@react-types/link@npm:^3.6.1":
-  version: 3.6.1
-  resolution: "@react-types/link@npm:3.6.1"
+"@react-types/link@npm:^3.6.5":
+  version: 3.6.5
+  resolution: "@react-types/link@npm:3.6.5"
   dependencies:
-    "@react-types/shared": "npm:^3.29.1"
+    "@react-types/shared": "npm:^3.32.1"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/a197b31a7e73248177ebaf7ee423cb0a9286c0e4aa343ed350a8df2f9d357b2ccd0b6efe5d2fd7c4eff75ba1f1875057f844e47918d97f165cbc29ce1dcdfde6
+  checksum: 10/59fb6011b146cffcdaae94e8fdd9241cb70697f7e518d39e3aacd14f244db6eea7ba3984d8b13d3ce601e6f160da36fd1bfa56827b2e1df728505e426a8db353
   languageName: node
   linkType: hard
 
-"@react-types/listbox@npm:^3.7.0":
-  version: 3.7.0
-  resolution: "@react-types/listbox@npm:3.7.0"
+"@react-types/listbox@npm:^3.7.4":
+  version: 3.7.4
+  resolution: "@react-types/listbox@npm:3.7.4"
   dependencies:
-    "@react-types/shared": "npm:^3.29.1"
+    "@react-types/shared": "npm:^3.32.1"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/ca687be1708d6617469a26be9fd2dfbc35e4b84e4fc3b89a524697eadd622df90936d27d00f1960d7f2b44e6217ce9d528df3b46e826522985dcf2ca7c343a82
+  checksum: 10/79dd3f6a7284b74f5156cc2265b384d2074ddfb7b38e608be855ec4ad1234aa0e7cdbfc0d7ef899e34113781381a6ee18b820dbe3dbee67364c72ac240144522
   languageName: node
   linkType: hard
 
-"@react-types/menu@npm:^3.10.1":
-  version: 3.10.1
-  resolution: "@react-types/menu@npm:3.10.1"
+"@react-types/menu@npm:^3.10.5":
+  version: 3.10.5
+  resolution: "@react-types/menu@npm:3.10.5"
   dependencies:
-    "@react-types/overlays": "npm:^3.8.15"
-    "@react-types/shared": "npm:^3.29.1"
+    "@react-types/overlays": "npm:^3.9.2"
+    "@react-types/shared": "npm:^3.32.1"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/34e41ba3d6a2cc817ae31eac707bb9c18917876eb859a6d49be7c3667ce4f8b56e37de7fe4f38fb68fc4d20f2f7e5636c8e17bc29660a46d55f36d7e8bc5f731
+  checksum: 10/0466f5b7602ccfc8cb8fec3cd2482d587acbfd1701d427c7d79a121eb3f2b137feca70e62fd401aea95022fd616460575c4d5dd541cf3d69d8644ca54a2446c8
   languageName: node
   linkType: hard
 
-"@react-types/meter@npm:^3.4.9":
-  version: 3.4.9
-  resolution: "@react-types/meter@npm:3.4.9"
+"@react-types/meter@npm:^3.4.13":
+  version: 3.4.13
+  resolution: "@react-types/meter@npm:3.4.13"
   dependencies:
-    "@react-types/progress": "npm:^3.5.12"
+    "@react-types/progress": "npm:^3.5.16"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/b4524e7fb8c34443b9b5651887dda0840c33e0c4f6c953753008530f2824380633da5e8432d1e504fc2d18a3bd388391eedcdf18468ba144600ec8965728e790
+  checksum: 10/28b519a4640c72732719c056903fcf4037582984d235c388095319b5005eb9d5d2698306d9f79d1ad61d594b8ceda115acae27c22e95cb771d0e07da30305708
   languageName: node
   linkType: hard
 
-"@react-types/numberfield@npm:^3.8.11":
-  version: 3.8.11
-  resolution: "@react-types/numberfield@npm:3.8.11"
-  dependencies:
-    "@react-types/shared": "npm:^3.29.1"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/4790614ce5465ab065e4378616a742f2274d45d55002e3c08b489ccbc93af120d7b33d37f0190e6f41cf6f078fd8c3f7fdb20d4808d7b3f478501b84f97410a3
-  languageName: node
-  linkType: hard
-
-"@react-types/overlays@npm:^3.8.15":
+"@react-types/numberfield@npm:^3.8.15":
   version: 3.8.15
-  resolution: "@react-types/overlays@npm:3.8.15"
+  resolution: "@react-types/numberfield@npm:3.8.15"
   dependencies:
-    "@react-types/shared": "npm:^3.29.1"
+    "@react-types/shared": "npm:^3.32.1"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/256d2f0bb599ec31d66d640699a19b3362d65215cbf1b687058278d0947b8236cfa5e81d1849c189a2e059452af00ab01d753229897497e3eb3e95887ec49cb6
+  checksum: 10/242584ab3ece90a5e26ebee9788c25fd44b85d6be405c5f31e08bda9d58ad8d7fcf199744a2fcd816275da13ae546ca0239175403e68788a43563f2a070c0574
   languageName: node
   linkType: hard
 
-"@react-types/progress@npm:^3.5.12":
-  version: 3.5.12
-  resolution: "@react-types/progress@npm:3.5.12"
+"@react-types/overlays@npm:^3.9.2":
+  version: 3.9.2
+  resolution: "@react-types/overlays@npm:3.9.2"
   dependencies:
-    "@react-types/shared": "npm:^3.29.1"
+    "@react-types/shared": "npm:^3.32.1"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/31665d5b11a9bac2843986520a23f870257f695aa342e67f895755868c0a3a9ddacda7f156b1c945d182241039a212e1447dd19623ccc2614d4fd58337a05b2a
+  checksum: 10/6cab7f2cbb813f710696095db1169f902cfe7e4a9aeef496848343ff5116be3782bfea68dffbeaf3f984a0475c2fb6c4a26ad9fb563172c4ec3e47110ca1e672
   languageName: node
   linkType: hard
 
-"@react-types/radio@npm:^3.8.9":
-  version: 3.8.9
-  resolution: "@react-types/radio@npm:3.8.9"
+"@react-types/progress@npm:^3.5.16":
+  version: 3.5.16
+  resolution: "@react-types/progress@npm:3.5.16"
   dependencies:
-    "@react-types/shared": "npm:^3.29.1"
+    "@react-types/shared": "npm:^3.32.1"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/e6f997f119c559b047fa5709c45fb27ed5d76125b5afeb1d7f2e75e0c7f5f36121ca1e6a46c22e8854ea5fc8d9c09bb3652bbe7abb700f4733cefe65dac5036a
+  checksum: 10/315b34314dc135a6c9319f4ffd83570fac8c0da377b00d56f17c6eb3d416904682738b522b05d6d8cbb89d3ef92c5118bf8e58eca10fac121da6dcaa40563b8d
   languageName: node
   linkType: hard
 
-"@react-types/searchfield@npm:^3.6.2":
-  version: 3.6.2
-  resolution: "@react-types/searchfield@npm:3.6.2"
+"@react-types/radio@npm:^3.9.2":
+  version: 3.9.2
+  resolution: "@react-types/radio@npm:3.9.2"
   dependencies:
-    "@react-types/shared": "npm:^3.29.1"
-    "@react-types/textfield": "npm:^3.12.2"
+    "@react-types/shared": "npm:^3.32.1"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/cbada042a28a1cb4f1cf4160b56321810bb39beaba8661cb1b4c1ee75f8ff2d75dbca50f9068f6252a53f2b9ca5fc6a21ea9409f9fdf58b84270af27c4518e2f
+  checksum: 10/3375d13bbeed28a1b959077e727b43324f4282cf43ec985edbaaa5b3e50b46199c083550882e2a9e4788c74555bfd25f5cc2b0351bf48a768f81a4ba6bf73222
   languageName: node
   linkType: hard
 
-"@react-types/select@npm:^3.9.12":
-  version: 3.9.12
-  resolution: "@react-types/select@npm:3.9.12"
+"@react-types/searchfield@npm:^3.6.6":
+  version: 3.6.6
+  resolution: "@react-types/searchfield@npm:3.6.6"
   dependencies:
-    "@react-types/shared": "npm:^3.29.1"
+    "@react-types/shared": "npm:^3.32.1"
+    "@react-types/textfield": "npm:^3.12.6"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/110f7c67bffe46c969658503ac21ceadcc7bbf7dac7942c1e1b6e859e824a311821b6a848ff1743187e6ab0fb88b9cfe30d3618c4caf060204f4b8c2f7831e72
+  checksum: 10/942cb80234be5d61cae410c144873d75a243dec0bbf8bb0c696f13d66fd729dabb188bb6214d4bfadeb0d54e14eed3bb7e86c6721206bcb395658b613f22b53f
   languageName: node
   linkType: hard
 
-"@react-types/shared@npm:^3.29.1":
-  version: 3.29.1
-  resolution: "@react-types/shared@npm:3.29.1"
+"@react-types/select@npm:^3.11.0":
+  version: 3.11.0
+  resolution: "@react-types/select@npm:3.11.0"
+  dependencies:
+    "@react-types/shared": "npm:^3.32.1"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/496f281007a67b54f2eba31431d7a53f125633fbe747a0b722aa2a5d34e6aa7c14f0d44c42051a9a99325453d30251b78f766e40525e0a5721aafc84cb38a3fa
+  checksum: 10/6c431daa847a034ce06625fe75f220f301e8bdb50961c74e915f36919641f7907aa0d16d15127b9889853d197d66d964fd3726bd6c446b8aecf0e756e30e3925
   languageName: node
   linkType: hard
 
-"@react-types/slider@npm:^3.7.11":
-  version: 3.7.11
-  resolution: "@react-types/slider@npm:3.7.11"
-  dependencies:
-    "@react-types/shared": "npm:^3.29.1"
+"@react-types/shared@npm:^3.32.1":
+  version: 3.32.1
+  resolution: "@react-types/shared@npm:3.32.1"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/9855486e5959138e55cc48c532500bd5876e60f0287efa9d602b3f1b4f6fb5965bcdfd194753b8390e04e7805b92921c5e607113be26ed8868e2d548d9580751
+  checksum: 10/33c39d1e23fd73a18519679742ba548c128097831710af4803bec244ae96800271f88dcc4eab958734fc501bb65c17e590028596733761610fb0103c5dea6e36
   languageName: node
   linkType: hard
 
-"@react-types/switch@npm:^3.5.11":
-  version: 3.5.11
-  resolution: "@react-types/switch@npm:3.5.11"
+"@react-types/slider@npm:^3.8.2":
+  version: 3.8.2
+  resolution: "@react-types/slider@npm:3.8.2"
   dependencies:
-    "@react-types/shared": "npm:^3.29.1"
+    "@react-types/shared": "npm:^3.32.1"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/1376d5d11244e4765b24609fecf9a7de7f94affcd7905f04a8037f1b4a898ff31e6920ac443c54e186ed2a8b2f2eb3a8e3f06fe6679a676f61145b44575f3422
+  checksum: 10/cb9600a1842ace218be1a8bdb7b6785113c7165fde0cc76682b82cf7809927d2f45f95facb2570e7abb683f28f0a2ed0590c8ec8e948ed8dadffadb8905918d9
   languageName: node
   linkType: hard
 
-"@react-types/table@npm:^3.13.0":
-  version: 3.13.0
-  resolution: "@react-types/table@npm:3.13.0"
+"@react-types/switch@npm:^3.5.15":
+  version: 3.5.15
+  resolution: "@react-types/switch@npm:3.5.15"
   dependencies:
-    "@react-types/grid": "npm:^3.3.2"
-    "@react-types/shared": "npm:^3.29.1"
+    "@react-types/shared": "npm:^3.32.1"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/f0e4cb5a0e48273def964b751b07ede8c9a710623b2903d58830e39e347c17dc30f30782dc125b2bce203879302889caa39a6b4da807804fc21996bbc64b7974
+  checksum: 10/f35c075188b93aa07b6ab367a6d5bcc4316bcd5481d47e1b0319944411e3a12b15455c443079159280b6d168da36271f3df8bc55808a7d8249b239f5886f0253
   languageName: node
   linkType: hard
 
-"@react-types/tabs@npm:^3.3.15":
-  version: 3.3.15
-  resolution: "@react-types/tabs@npm:3.3.15"
+"@react-types/table@npm:^3.13.4":
+  version: 3.13.4
+  resolution: "@react-types/table@npm:3.13.4"
   dependencies:
-    "@react-types/shared": "npm:^3.29.1"
+    "@react-types/grid": "npm:^3.3.6"
+    "@react-types/shared": "npm:^3.32.1"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/658fd03a315331b2e3f08bc37c88c2b2625da7b50863ef76decda6a029a4ae86661b56cc7ee1e56d96da353db945993ce5214e58a11694e7c8e6c33a42ebf0b1
+  checksum: 10/2f8c1878c8b9a6515a62c7592a335e9688c95a07e0445a891dd6069cbe26921573db6f7d6d2e0c22a8818ec5ef3f48f242ae24d955a1b18e7868f306fadfe7f5
   languageName: node
   linkType: hard
 
-"@react-types/textfield@npm:^3.12.2":
-  version: 3.12.2
-  resolution: "@react-types/textfield@npm:3.12.2"
+"@react-types/tabs@npm:^3.3.19":
+  version: 3.3.19
+  resolution: "@react-types/tabs@npm:3.3.19"
   dependencies:
-    "@react-types/shared": "npm:^3.29.1"
+    "@react-types/shared": "npm:^3.32.1"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/28b1e300029ef1467cf8000e5f2a11e041fcaf8714ddd4b4f83c0a1f2fa885a1666751abe6f7138611090c20806c594bf5ae87e47389f046d07277ae8bb1b209
+  checksum: 10/cdc3217251502c6f89621ab366a4d23e32a334dc3ca2f5366cd980fb828bb413be1262a76f4c4794a0908bfd02c3237a3608e283b02ef472707fb7c22b80b44b
   languageName: node
   linkType: hard
 
-"@react-types/tooltip@npm:^3.4.17":
-  version: 3.4.17
-  resolution: "@react-types/tooltip@npm:3.4.17"
+"@react-types/textfield@npm:^3.12.6":
+  version: 3.12.6
+  resolution: "@react-types/textfield@npm:3.12.6"
   dependencies:
-    "@react-types/overlays": "npm:^3.8.15"
-    "@react-types/shared": "npm:^3.29.1"
+    "@react-types/shared": "npm:^3.32.1"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/bead1b0bc5cc64dbfd9a025643562b510aa2a6d8ceff8d7dfc72ee8db142f650164c894213d5462f492f9929001856cbd292d9f5d10def5abc579fcf507ddacc
+  checksum: 10/e223531d29bbaad566f142b44a0f2e42b4ce08eab5661962ad3451391311a604077c49181f89a407aecf8697d59d887f5524f6eff8e9fe7416afda6b1f3ac7b3
+  languageName: node
+  linkType: hard
+
+"@react-types/tooltip@npm:^3.4.21":
+  version: 3.4.21
+  resolution: "@react-types/tooltip@npm:3.4.21"
+  dependencies:
+    "@react-types/overlays": "npm:^3.9.2"
+    "@react-types/shared": "npm:^3.32.1"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/50d1beea407a7e58ef8e3638c2517d8c90f6b15777d396b4adf7cffbd80d38dfb7d68d6a38127ed130bfe7b0c3116c5d499de3f7b6353f54d022a22739e0141d
   languageName: node
   linkType: hard
 
@@ -11493,7 +11492,7 @@ __metadata:
     progress: "npm:^2.0.3"
     react: "npm:^19.1.0"
     react-animate-height: "npm:^3.2.3"
-    react-aria-components: "npm:^1.9.0"
+    react-aria-components: "npm:^1.13.0"
     react-color: "npm:^2.18.1"
     react-diff-viewer-continued: "npm:^3.4.0"
     react-dom: "npm:^19.1.0"
@@ -15352,95 +15351,96 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-aria-components@npm:^1.9.0":
-  version: 1.9.0
-  resolution: "react-aria-components@npm:1.9.0"
+"react-aria-components@npm:^1.13.0":
+  version: 1.13.0
+  resolution: "react-aria-components@npm:1.13.0"
   dependencies:
-    "@internationalized/date": "npm:^3.8.1"
-    "@internationalized/string": "npm:^3.2.6"
-    "@react-aria/autocomplete": "npm:3.0.0-beta.3"
-    "@react-aria/collections": "npm:3.0.0-rc.1"
-    "@react-aria/dnd": "npm:^3.9.3"
-    "@react-aria/focus": "npm:^3.20.3"
-    "@react-aria/interactions": "npm:^3.25.1"
-    "@react-aria/live-announcer": "npm:^3.4.2"
-    "@react-aria/overlays": "npm:^3.27.1"
-    "@react-aria/ssr": "npm:^3.9.8"
-    "@react-aria/toolbar": "npm:3.0.0-beta.16"
-    "@react-aria/utils": "npm:^3.29.0"
-    "@react-aria/virtualizer": "npm:^4.1.5"
-    "@react-stately/autocomplete": "npm:3.0.0-beta.1"
-    "@react-stately/layout": "npm:^4.3.0"
-    "@react-stately/selection": "npm:^3.20.2"
-    "@react-stately/table": "npm:^3.14.2"
-    "@react-stately/utils": "npm:^3.10.6"
-    "@react-stately/virtualizer": "npm:^4.4.0"
-    "@react-types/form": "npm:^3.7.12"
-    "@react-types/grid": "npm:^3.3.2"
-    "@react-types/shared": "npm:^3.29.1"
-    "@react-types/table": "npm:^3.13.0"
+    "@internationalized/date": "npm:^3.10.0"
+    "@internationalized/string": "npm:^3.2.7"
+    "@react-aria/autocomplete": "npm:3.0.0-rc.3"
+    "@react-aria/collections": "npm:^3.0.0"
+    "@react-aria/dnd": "npm:^3.11.3"
+    "@react-aria/focus": "npm:^3.21.2"
+    "@react-aria/interactions": "npm:^3.25.6"
+    "@react-aria/live-announcer": "npm:^3.4.4"
+    "@react-aria/overlays": "npm:^3.30.0"
+    "@react-aria/ssr": "npm:^3.9.10"
+    "@react-aria/textfield": "npm:^3.18.2"
+    "@react-aria/toolbar": "npm:3.0.0-beta.21"
+    "@react-aria/utils": "npm:^3.31.0"
+    "@react-aria/virtualizer": "npm:^4.1.10"
+    "@react-stately/autocomplete": "npm:3.0.0-beta.3"
+    "@react-stately/layout": "npm:^4.5.1"
+    "@react-stately/selection": "npm:^3.20.6"
+    "@react-stately/table": "npm:^3.15.1"
+    "@react-stately/utils": "npm:^3.10.8"
+    "@react-stately/virtualizer": "npm:^4.4.4"
+    "@react-types/form": "npm:^3.7.16"
+    "@react-types/grid": "npm:^3.3.6"
+    "@react-types/shared": "npm:^3.32.1"
+    "@react-types/table": "npm:^3.13.4"
     "@swc/helpers": "npm:^0.5.0"
     client-only: "npm:^0.0.1"
-    react-aria: "npm:^3.40.0"
-    react-stately: "npm:^3.38.0"
+    react-aria: "npm:^3.44.0"
+    react-stately: "npm:^3.42.0"
     use-sync-external-store: "npm:^1.4.0"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
     react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/cef1a2285635cb9a54a272113b9ab3ca369c33954ca3d1b5e9e15e362870b45b2d902d213452d7d3a19d3ecc8412f5244af8a30030753bc2cdf3b6c5dac3f2ad
+  checksum: 10/8bff1890ef342b0c32d6a50329ce4657bce2fcc91f2a2f903351f375354b186b47f265e7718caaff0ed9a5f630037f17649d85d00bc20a4928a6417204d75ff2
   languageName: node
   linkType: hard
 
-"react-aria@npm:^3.40.0":
-  version: 3.40.0
-  resolution: "react-aria@npm:3.40.0"
+"react-aria@npm:^3.44.0":
+  version: 3.44.0
+  resolution: "react-aria@npm:3.44.0"
   dependencies:
-    "@internationalized/string": "npm:^3.2.6"
-    "@react-aria/breadcrumbs": "npm:^3.5.24"
-    "@react-aria/button": "npm:^3.13.1"
-    "@react-aria/calendar": "npm:^3.8.1"
-    "@react-aria/checkbox": "npm:^3.15.5"
-    "@react-aria/color": "npm:^3.0.7"
-    "@react-aria/combobox": "npm:^3.12.3"
-    "@react-aria/datepicker": "npm:^3.14.3"
-    "@react-aria/dialog": "npm:^3.5.25"
-    "@react-aria/disclosure": "npm:^3.0.5"
-    "@react-aria/dnd": "npm:^3.9.3"
-    "@react-aria/focus": "npm:^3.20.3"
-    "@react-aria/gridlist": "npm:^3.13.0"
-    "@react-aria/i18n": "npm:^3.12.9"
-    "@react-aria/interactions": "npm:^3.25.1"
-    "@react-aria/label": "npm:^3.7.18"
-    "@react-aria/landmark": "npm:^3.0.3"
-    "@react-aria/link": "npm:^3.8.1"
-    "@react-aria/listbox": "npm:^3.14.4"
-    "@react-aria/menu": "npm:^3.18.3"
-    "@react-aria/meter": "npm:^3.4.23"
-    "@react-aria/numberfield": "npm:^3.11.14"
-    "@react-aria/overlays": "npm:^3.27.1"
-    "@react-aria/progress": "npm:^3.4.23"
-    "@react-aria/radio": "npm:^3.11.3"
-    "@react-aria/searchfield": "npm:^3.8.4"
-    "@react-aria/select": "npm:^3.15.5"
-    "@react-aria/selection": "npm:^3.24.1"
-    "@react-aria/separator": "npm:^3.4.9"
-    "@react-aria/slider": "npm:^3.7.19"
-    "@react-aria/ssr": "npm:^3.9.8"
-    "@react-aria/switch": "npm:^3.7.3"
-    "@react-aria/table": "npm:^3.17.3"
-    "@react-aria/tabs": "npm:^3.10.3"
-    "@react-aria/tag": "npm:^3.6.0"
-    "@react-aria/textfield": "npm:^3.17.3"
-    "@react-aria/toast": "npm:^3.0.3"
-    "@react-aria/tooltip": "npm:^3.8.3"
-    "@react-aria/tree": "npm:^3.0.3"
-    "@react-aria/utils": "npm:^3.29.0"
-    "@react-aria/visually-hidden": "npm:^3.8.23"
-    "@react-types/shared": "npm:^3.29.1"
+    "@internationalized/string": "npm:^3.2.7"
+    "@react-aria/breadcrumbs": "npm:^3.5.29"
+    "@react-aria/button": "npm:^3.14.2"
+    "@react-aria/calendar": "npm:^3.9.2"
+    "@react-aria/checkbox": "npm:^3.16.2"
+    "@react-aria/color": "npm:^3.1.2"
+    "@react-aria/combobox": "npm:^3.14.0"
+    "@react-aria/datepicker": "npm:^3.15.2"
+    "@react-aria/dialog": "npm:^3.5.31"
+    "@react-aria/disclosure": "npm:^3.1.0"
+    "@react-aria/dnd": "npm:^3.11.3"
+    "@react-aria/focus": "npm:^3.21.2"
+    "@react-aria/gridlist": "npm:^3.14.1"
+    "@react-aria/i18n": "npm:^3.12.13"
+    "@react-aria/interactions": "npm:^3.25.6"
+    "@react-aria/label": "npm:^3.7.22"
+    "@react-aria/landmark": "npm:^3.0.7"
+    "@react-aria/link": "npm:^3.8.6"
+    "@react-aria/listbox": "npm:^3.15.0"
+    "@react-aria/menu": "npm:^3.19.3"
+    "@react-aria/meter": "npm:^3.4.27"
+    "@react-aria/numberfield": "npm:^3.12.2"
+    "@react-aria/overlays": "npm:^3.30.0"
+    "@react-aria/progress": "npm:^3.4.27"
+    "@react-aria/radio": "npm:^3.12.2"
+    "@react-aria/searchfield": "npm:^3.8.9"
+    "@react-aria/select": "npm:^3.17.0"
+    "@react-aria/selection": "npm:^3.26.0"
+    "@react-aria/separator": "npm:^3.4.13"
+    "@react-aria/slider": "npm:^3.8.2"
+    "@react-aria/ssr": "npm:^3.9.10"
+    "@react-aria/switch": "npm:^3.7.8"
+    "@react-aria/table": "npm:^3.17.8"
+    "@react-aria/tabs": "npm:^3.10.8"
+    "@react-aria/tag": "npm:^3.7.2"
+    "@react-aria/textfield": "npm:^3.18.2"
+    "@react-aria/toast": "npm:^3.0.8"
+    "@react-aria/tooltip": "npm:^3.8.8"
+    "@react-aria/tree": "npm:^3.1.4"
+    "@react-aria/utils": "npm:^3.31.0"
+    "@react-aria/visually-hidden": "npm:^3.8.28"
+    "@react-types/shared": "npm:^3.32.1"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
     react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/94912a055332f39609f1543fec24baf9160dfb5e823dd2ede0bc440e2e6a883c5a7009a40df0b38081b14fe254df0a8bc182e22be14b10688488029cd4614042
+  checksum: 10/46b428af3f68703c03d7836a79f288dae1e945cb34164220a61f57d77df0a5adfc6c4a4c993282f9dbf57f159c9d249e1d644b57b61caca3dec8af1285404ec1
   languageName: node
   linkType: hard
 
@@ -15734,39 +15734,39 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-stately@npm:^3.38.0":
-  version: 3.38.0
-  resolution: "react-stately@npm:3.38.0"
+"react-stately@npm:^3.42.0":
+  version: 3.42.0
+  resolution: "react-stately@npm:3.42.0"
   dependencies:
-    "@react-stately/calendar": "npm:^3.8.1"
-    "@react-stately/checkbox": "npm:^3.6.14"
-    "@react-stately/collections": "npm:^3.12.4"
-    "@react-stately/color": "npm:^3.8.5"
-    "@react-stately/combobox": "npm:^3.10.5"
-    "@react-stately/data": "npm:^3.13.0"
-    "@react-stately/datepicker": "npm:^3.14.1"
-    "@react-stately/disclosure": "npm:^3.0.4"
-    "@react-stately/dnd": "npm:^3.5.4"
-    "@react-stately/form": "npm:^3.1.4"
-    "@react-stately/list": "npm:^3.12.2"
-    "@react-stately/menu": "npm:^3.9.4"
-    "@react-stately/numberfield": "npm:^3.9.12"
-    "@react-stately/overlays": "npm:^3.6.16"
-    "@react-stately/radio": "npm:^3.10.13"
-    "@react-stately/searchfield": "npm:^3.5.12"
-    "@react-stately/select": "npm:^3.6.13"
-    "@react-stately/selection": "npm:^3.20.2"
-    "@react-stately/slider": "npm:^3.6.4"
-    "@react-stately/table": "npm:^3.14.2"
-    "@react-stately/tabs": "npm:^3.8.2"
-    "@react-stately/toast": "npm:^3.1.0"
-    "@react-stately/toggle": "npm:^3.8.4"
-    "@react-stately/tooltip": "npm:^3.5.4"
-    "@react-stately/tree": "npm:^3.8.10"
-    "@react-types/shared": "npm:^3.29.1"
+    "@react-stately/calendar": "npm:^3.9.0"
+    "@react-stately/checkbox": "npm:^3.7.2"
+    "@react-stately/collections": "npm:^3.12.8"
+    "@react-stately/color": "npm:^3.9.2"
+    "@react-stately/combobox": "npm:^3.12.0"
+    "@react-stately/data": "npm:^3.14.1"
+    "@react-stately/datepicker": "npm:^3.15.2"
+    "@react-stately/disclosure": "npm:^3.0.8"
+    "@react-stately/dnd": "npm:^3.7.1"
+    "@react-stately/form": "npm:^3.2.2"
+    "@react-stately/list": "npm:^3.13.1"
+    "@react-stately/menu": "npm:^3.9.8"
+    "@react-stately/numberfield": "npm:^3.10.2"
+    "@react-stately/overlays": "npm:^3.6.20"
+    "@react-stately/radio": "npm:^3.11.2"
+    "@react-stately/searchfield": "npm:^3.5.16"
+    "@react-stately/select": "npm:^3.8.0"
+    "@react-stately/selection": "npm:^3.20.6"
+    "@react-stately/slider": "npm:^3.7.2"
+    "@react-stately/table": "npm:^3.15.1"
+    "@react-stately/tabs": "npm:^3.8.6"
+    "@react-stately/toast": "npm:^3.1.2"
+    "@react-stately/toggle": "npm:^3.9.2"
+    "@react-stately/tooltip": "npm:^3.5.8"
+    "@react-stately/tree": "npm:^3.9.3"
+    "@react-types/shared": "npm:^3.32.1"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/7c41bae17027ca949c430c64eb7550bd6b5e645b9e9b30fa821a2d8d175dbd6041897169e0e89f0cb0c7ff0fa6646c60b57ffb19cd8fe505a58c74a5b9a38261
+  checksum: 10/4913f8ae9beb909d07669b97c0960dadad72c3c9e572051158a64acac3eadc73ff495b3c145b3673c15494751506e5b8a666a59f65364900fa66917412971d32
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Context

We don't want to ship two different packages for our select components to reduce bundle size.

Unfortunately, I didn't go all the way — we still use `react-select` in `GlobalEntitySelector`, which is hard to switch and only used in country pages, which should be soon removed/reworked. So the hope is we'll get rid of `react-select` completely at that point in `site`.

It's still used in admin, but bundle size there doesn't really matter. We'll probably switch it to antd components there eventually.

## Testing guidance

Please check that we get equivalent functionality in grapher and explorer with after the change.

## Checklist

### Before merging

- [x] Changes to CSS/HTML were checked on Desktop and Mobile Safari at all three breakpoints
- [x] Changes to HTML were checked for accessibility concerns