### PR TITLE
✨ (line+slope) add log axis notice

### DIFF
--- a/packages/@ourworldindata/grapher/src/axis/AxisViews.tsx
+++ b/packages/@ourworldindata/grapher/src/axis/AxisViews.tsx
@@ -325,7 +325,8 @@ export class VerticalAxisComponent extends React.Component<VerticalAxisComponent
             showTickMarks,
             showEndpointsOnly,
         } = this.props
-        const { tickLabels, labelTextWrap, config } = verticalAxis
+        const { tickLabels, labelTextWrap, logNoticeTextWrap, config } =
+            verticalAxis
 
         let visibleTickLabels = tickLabels
         if (showEndpointsOnly) {
@@ -334,11 +335,36 @@ export class VerticalAxisComponent extends React.Component<VerticalAxisComponent
             )
         }
 
+        const shouldShowLogNotice =
+            verticalAxis.shouldShowLogNotice &&
+            // Only show the notice if it fits in the margin
+            verticalAxis.logNoticeWidth <= verticalAxis.width
+
+        const tickX =
+            bounds.left + verticalAxis.width - verticalAxis.tickPadding
+
         return (
             <g
                 id={makeIdForHumanConsumption("vertical-axis")}
                 className="VerticalAxis"
             >
+                {shouldShowLogNotice && logNoticeTextWrap && (
+                    <React.Fragment key={logNoticeTextWrap.text}>
+                        {logNoticeTextWrap.renderSVG(tickX, bounds.top, {
+                            id: makeIdForHumanConsumption(
+                                "vertical-axis-log-notice"
+                            ),
+                            textProps: {
+                                fill: tickColor || GRAPHER_DARK_TEXT,
+                                textAnchor: textAnchorFromAlign(
+                                    HorizontalAlign.right
+                                ),
+                                fontStyle: "italic",
+                            },
+                            detailsMarker,
+                        })}
+                    </React.Fragment>
+                )}
                 {labelTextWrap && (
                     <React.Fragment key={labelTextWrap.text}>
                         {labelTextWrap.renderSVG(bounds.left, bounds.top, {
@@ -378,11 +404,7 @@ export class VerticalAxisComponent extends React.Component<VerticalAxisComponent
                             return (
                                 <text
                                     key={i}
-                                    x={(
-                                        bounds.left +
-                                        verticalAxis.width -
-                                        verticalAxis.tickPadding
-                                    ).toFixed(2)}
+                                    x={tickX.toFixed(2)}
                                     y={y}
                                     dy={dyFromAlign(
                                         yAlign ?? VerticalAlign.middle

--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
@@ -894,9 +894,11 @@ export class LineChart
                         ? this.lineLegendWidth
                         : this.defaultRightPadding
                 )
-                // top padding leaves room for tick labels
-                .padTop(6)
-                // bottom padding avoids axis labels to be cut off at some resolutions
+                // The top padding leaves room for tick labels.
+                // No padding is needed when plotted on a log axis because the
+                // log scale notice leaves enough space for tick labels.
+                .padTop(this.chartState.isLogScale ? 0 : 6)
+                // The bottom padding avoids axis labels to be cut off at some resolutions
                 .padBottom(2)
         )
     }

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChartState.ts
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChartState.ts
@@ -66,8 +66,8 @@ export class SlopeChartState implements ChartState {
         let table = this.transformedTableFromGrapher
         // The % growth transform cannot be applied in transformTable() because it will filter out
         // any rows before startTime and change the timeline bounds.
-        const { isRelativeMode, startTime } = this.manager
-        if (isRelativeMode && startTime !== undefined) {
+        const { startTime } = this.manager
+        if (this.isRelativeMode && startTime !== undefined) {
             table = table.toTotalGrowthForEachColumnComparedToStartTime(
                 startTime,
                 this.yColumnSlugs ?? []
@@ -144,6 +144,10 @@ export class SlopeChartState implements ChartState {
 
     @computed get formatColumn(): CoreColumn {
         return this.yColumns[0]
+    }
+
+    @computed get isRelativeMode(): boolean {
+        return !!this.manager.isRelativeMode
     }
 
     @computed get isLogScale(): boolean {


### PR DESCRIPTION
Resolves #4737

Examples:
- Scatter plot: http://staging-site-log-notice-axis/grapher/consumption-co2-emissions-vs-population
- Scatter plot (with name+unit label): http://staging-site-log-notice-axis/grapher/consumption-co2-per-capita-vs-gdppc
- Scatter plot (without y-axis label): http://staging-site-log-notice-line-slope/grapher/cereal-yield-vs-gdp-per-capita
- Slope chart: http://staging-site-log-notice-line-slope/grapher/military-spending-per-military-personnel?tab=slope&yScale=log&country=~USA
- Facetted slope chart: http://staging-site-log-notice-line-slope/grapher/military-spending-per-military-personnel?tab=slope&yScale=log&country=RUS~DEU~USA~GBR
- Facetted line chart: http://staging-site-log-notice-line-slope/grapher/military-spending-per-military-personnel?yScale=log
- Line charts:
    - http://staging-site-log-notice-line-slope/grapher/air-passengers-per-fatality
    - http://staging-site-log-notice-line-slope/grapher/cost-of-sequencing-a-full-human-genome
    - http://staging-site-log-notice-line-slope/grapher/cost-per-gigabase-dna-sequencing
    - http://staging-site-log-notice-line-slope/grapher/efficiency-lighting-uk-sources