### PR TITLE
feat: default suggestions, recent searches and raw submit go to resultType ALL

### DIFF
--- a/site/search/Autocomplete.tsx
+++ b/site/search/Autocomplete.tsx
@@ -17,6 +17,7 @@ import {
     Filter,
     FilterType,
     SynonymMap,
+    SearchResultType,
 } from "./searchTypes.js"
 import { getCanonicalUrl } from "@ourworldindata/components"
 import {
@@ -62,7 +63,7 @@ const recentSearchesPlugin = createLocalStorageRecentSearchesPlugin({
             ...source,
             onSelect({ item, navigator }) {
                 navigator.navigate({
-                    itemUrl: `${SEARCH_BASE_PATH}${queryParamsToStr({ q: item.id })}`,
+                    itemUrl: `${SEARCH_BASE_PATH}${queryParamsToStr({ q: item.id, resultType: SearchResultType.ALL })}`,
                 } as any)
             },
         }
@@ -138,7 +139,7 @@ const FeaturedSearchesSource: AutocompleteSource<BaseItem> = {
         return ["CO2", "Energy", "Education", "Poverty", "Democracy"].map(
             (term) => ({
                 title: term,
-                slug: `${SEARCH_BASE_PATH}${queryParamsToStr({ q: term })}`,
+                slug: `${SEARCH_BASE_PATH}${queryParamsToStr({ q: term, resultType: SearchResultType.ALL })}`,
             })
         )
     },
@@ -381,7 +382,7 @@ export function Autocomplete({
             onSubmit({ state, navigator }) {
                 if (!state.query) return
                 navigator.navigate({
-                    itemUrl: `${SEARCH_BASE_PATH}${queryParamsToStr({ q: state.query })}`,
+                    itemUrl: `${SEARCH_BASE_PATH}${queryParamsToStr({ q: state.query, resultType: SearchResultType.ALL })}`,
                     // this method is incorrectly typed - `item` and `state` are optional
                 } as any)
             },


### PR DESCRIPTION
## Context

This PR updates the search functionality to ensure that recent searches, featured searches in autocomplete as well as direct query submissions results include the `resultType=all` parameter.

## Testing guidance

1. Test the autocomplete search functionality by:
   - Clicking on a recent search
   - Clicking on a featured search term
   - Typing a search query and submitting it
2. Verify that all resulting URLs include the `resultType=all` parameter
3. Confirm that search results display correctly with this parameter

- [ ] Does the staging experience have sign-off from product stakeholders?