### PR TITLE
🔨 (perf) avoid retrying failed requests

### DIFF
--- a/site/search/SearchChartHitRichData.tsx
+++ b/site/search/SearchChartHitRichData.tsx
@@ -412,6 +412,11 @@ function useQuerySearchResultDataForChartHit({
             if (!url) return null
             return fetchJson<GrapherSearchResultJson>(url)
         },
+        // If a query fails, it's likely because the worker
+        // exceeded resource limits (which is expected for some
+        // of our charts). Rather than retrying, we fail immediately
+        // and fall back to a simpler display.
+        retry: false,
         enabled,
     })
 


### PR DESCRIPTION
Some chart results take forever to load and eventually show the fallback display without the table: https://ourworldindata.org/search?topics=Artificial+Intelligence&resultType=all

If a query fails, it‘s likely because the worker ran out of space. Instead of retrying, we should fail immediately so the fallback without the data table is shown right away.

It‘s not clear to me why, for this specific chart, the thumbnails render but the `.search-result.json` endpoint runs out of space. That‘s a separate issue to look into.