### PR TITLE
Fix country selector input zoom in iOS

### DIFF
--- a/site/search/SearchCountrySelector.scss
+++ b/site/search/SearchCountrySelector.scss
@@ -116,7 +116,6 @@
 
     &:placeholder-shown,
     &::placeholder {
-        @include label-2-regular;
         color: $gray-60;
     }
 


### PR DESCRIPTION
We already set the font size to 16px in the parent, and we don't really need to override the font. This way the placeholder will inherit the font size.

Fixes #5470
