### PR TITLE
feat: open up "copy chart png" to all users

### DIFF
--- a/packages/@ourworldindata/grapher/src/controls/ShareMenu.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/ShareMenu.tsx
@@ -226,7 +226,7 @@ export class ShareMenu extends React.Component<ShareMenuProps, ShareMenuState> {
                         onClick={this.onEmbed}
                     >
                         <FontAwesomeIcon className="icon" icon={faCode} />
-                        Embed
+                        Embed this chart
                     </a>
                 )}
                 {canUseShareApi && (
@@ -239,18 +239,6 @@ export class ShareMenu extends React.Component<ShareMenuProps, ShareMenuState> {
                         Share via&hellip;
                     </a>
                 )}
-                {this.state.canWriteToClipboard && this.canonicalUrl && (
-                    <a
-                        title="Copy a link to this chart to the clipboard"
-                        data-track-note="chart_share_copylink"
-                        onClick={this.onCopyUrl}
-                    >
-                        <FontAwesomeIcon className="icon" icon={faLink} />
-                        {this.state.copiedLink
-                            ? "Link copied!"
-                            : "Copy link to chart"}
-                    </a>
-                )}
                 {showCopyPngButton && (
                     <a
                         title="Copy an image of this chart to the clipboard"
@@ -261,6 +249,18 @@ export class ShareMenu extends React.Component<ShareMenuProps, ShareMenuState> {
                         {this.state.copiedPng
                             ? "Chart copied!"
                             : "Copy chart as image"}
+                    </a>
+                )}
+                {this.state.canWriteToClipboard && this.canonicalUrl && (
+                    <a
+                        title="Copy a link to this chart to the clipboard"
+                        data-track-note="chart_share_copylink"
+                        onClick={this.onCopyUrl}
+                    >
+                        <FontAwesomeIcon className="icon" icon={faLink} />
+                        {this.state.copiedLink
+                            ? "Link copied!"
+                            : "Copy link to chart"}
                     </a>
                 )}
                 {editUrl && (


### PR DESCRIPTION
Resolves #1441.

Makes the Share menu entry "Copy chart as image" available to every OWID user, not just OWID staff.

<img width="452" height="614" alt="CleanShot 2025-10-16 at 15 42 44@2x" src="https://github.com/user-attachments/assets/a8b1a015-4630-46e7-9d81-01eb12942342" />

