### PR TITLE
✨ (line+slope) render thumbnails as facets

### DIFF
--- a/packages/@ourworldindata/grapher/src/axis/AxisViews.tsx
+++ b/packages/@ourworldindata/grapher/src/axis/AxisViews.tsx
@@ -210,6 +210,34 @@ export class VerticalAxisZeroLine extends React.Component<VerticalAxisZeroLinePr
     }
 }
 
+interface VerticalAxisDomainLineProps {
+    verticalAxis: VerticalAxis
+    bounds: Bounds
+    strokeWidth?: number
+}
+
+@observer
+export class VerticalAxisDomainLine extends React.Component<VerticalAxisDomainLineProps> {
+    override render(): React.ReactElement {
+        const { bounds, verticalAxis, strokeWidth = 1 } = this.props
+
+        const axis = verticalAxis.clone()
+        axis.range = bounds.yRange()
+
+        return (
+            <line
+                id={makeIdForHumanConsumption("horizontal-domain-line")}
+                x1={bounds.left.toFixed(2)}
+                y1={bounds.bottom.toFixed(2)}
+                x2={bounds.right.toFixed(2)}
+                y2={bounds.bottom.toFixed(2)}
+                stroke={SOLID_TICK_COLOR}
+                strokeWidth={strokeWidth}
+            />
+        )
+    }
+}
+
 interface DualAxisViewProps {
     dualAxis: DualAxis
     highlightValue?: { x: number; y: number }

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChartThumbnail.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChartThumbnail.tsx
@@ -33,6 +33,8 @@ import {
 import { VerticalLabels } from "../verticalLabels/VerticalLabels"
 import { MarkX } from "./MarkX"
 import { NoDataModal } from "../noDataModal/NoDataModal"
+import { HorizontalColorLegendManager } from "../horizontalColorLegend/HorizontalColorLegends.js"
+import { CategoricalBin } from "../color/ColorScaleBin.js"
 
 const DOT_RADIUS = 3.5
 const SPACE_BETWEEN_DOT_AND_LABEL = 4
@@ -212,8 +214,6 @@ export class SlopeChartThumbnail
     }
 
     @computed private get endLabelsState(): VerticalLabelsState | undefined {
-        if (!this.manager.showLegend) return undefined
-
         const series = this.labelCandidateSeries.map((series) => {
             const { seriesName, color } = series
 
@@ -242,8 +242,6 @@ export class SlopeChartThumbnail
     }
 
     @computed private get startLabelsState(): VerticalLabelsState | undefined {
-        if (!this.manager.showLegend) return undefined
-
         const showEntityNames = !this.manager.isMinimalThumbnail
 
         const series = this.labelCandidateSeries.map((series) => {
@@ -303,6 +301,20 @@ export class SlopeChartThumbnail
         return this.startLabelsWidth > 0
             ? this.startLabelsWidth + LABEL_PADDING
             : 0
+    }
+
+    // TODO: reconcile with SlopeChart.externalLegend
+    @computed get externalLegend(): HorizontalColorLegendManager {
+        const categoricalLegendData = this.chartState.series.map(
+            (series, index) =>
+                new CategoricalBin({
+                    index,
+                    value: series.seriesName,
+                    label: series.displayName,
+                    color: series.color,
+                })
+        )
+        return { categoricalLegendData }
     }
 
     override render(): React.ReactElement {


### PR DESCRIPTION
Examples:
- https://ourworldindata.org/grapher/peak-birth-month?tab=line
- http://localhost:3030/grapher/cost-drugs-extensive-resistant-tb?tab=line
- http://localhost:3030/grapher/uk-number-vehicles-miles-road-deaths
- http://localhost:3030/grapher/death-rate-from-cardiovascular-diseases-age-group-who-mdb
- http://localhost:3030/grapher/key-features-of-democracy
- http://localhost:3030/grapher/mean-income-or-consumption-per-day-2011-vs-2017-prices?country=VNM~DEU~OWID_WRL~ALB~AGO~DZA~Argentina+%28urban%29~ARM~AUS~AUT~AZE~BGD~BLR~BEL~BEN~BLZ~BTN~BOL~Bolivia+%28urban%29~BIH
- https://ourworldindata.org/grapher/co2-emissions-and-gdp-per-capita?uniformYAxis=0&country=GBR~FRA~DEU~SWE~USA~FIN~OWID_EU27~OWID_WRL~ALB~BLR~BOL~BGR~BHR~AUT~ARM~ARG

To do:
- [ ] Add numeric legend to line thumbnails
- [ ] Add interactivity

Follow up / stretch goals:
- [ ] For both line and slope thumbnails, harmonise the spacing (ensure start and end slope positions are the same for all facets)
- [ ] Move line chart labels into the chart area