### PR TITLE
✨ make second time slider handle more discoverable

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
@@ -1428,7 +1428,7 @@ export class GrapherState {
         return this.checkOnlySingleTimeSelectionPossible(this.activeTab)
     }
 
-    @computed private get isSingleTimeSelectionActive(): boolean {
+    @computed get isSingleTimeSelectionActive(): boolean {
         return (
             this.onlySingleTimeSelectionPossible ||
             this.isSingleTimeScatterAnimationActive

--- a/packages/@ourworldindata/grapher/src/timeline/TimelineComponent.scss
+++ b/packages/@ourworldindata/grapher/src/timeline/TimelineComponent.scss
@@ -1,12 +1,17 @@
 $timelineHeight: 32px;
 
 .timeline-component {
+    // diameter of the start and and handle
+    $handle-diameter: 20px; // keep in sync with HANDLE_DIAMETER in TimelineComponent.tsx
+
+    // start and end handles
+    $default-knob: $gray-60;
+    $active-knob: $blue-50;
+
     // timeline slider and interval
     $light-timeline: $gray-20;
     $active-timeline: $blue-30;
-
-    // end handle
-    $active-knob: $blue-50;
+    $hover-timeline: $default-knob;
 
     // start/end year label
     $light-fill: $gray-10;
@@ -50,7 +55,6 @@ $timelineHeight: 32px;
         }
     }
 
-    $handle-diameter: 20px;
     .slider {
         height: 2px;
         flex-grow: 1;
@@ -73,12 +77,20 @@ $timelineHeight: 32px;
         cursor: col-resize;
         padding: 10px $handleSidePadding;
 
+        &.hoverMarker {
+            cursor: pointer;
+
+            > .icon {
+                background: $default-knob;
+            }
+        }
+
         > .icon {
             height: $handle-diameter;
             width: $handle-diameter;
             border-radius: 100%;
 
-            background: $gray-60;
+            background: $default-knob;
             border: 2px solid #fff;
             z-index: 1;
             pointer-events: none;
@@ -126,6 +138,10 @@ $timelineHeight: 32px;
         &:active {
             cursor: grabbing;
         }
+
+        &.interval-hover {
+            background: $hover-timeline;
+        }
     }
 
     .handle,
@@ -137,8 +153,11 @@ $timelineHeight: 32px;
 
     &.hover {
         .handle > .icon {
-            background: $active-knob;
             transform: scale(1.3);
+        }
+
+        .handle:not(.hoverMarker) > .icon {
+            background: $active-knob;
         }
     }
 }

--- a/packages/@ourworldindata/grapher/src/timeline/TimelineComponent.tsx
+++ b/packages/@ourworldindata/grapher/src/timeline/TimelineComponent.tsx
@@ -2,7 +2,7 @@ import * as _ from "lodash-es"
 import * as React from "react"
 import { select } from "d3-selection"
 import cx from "classnames"
-import { getRelativeMouse, isMobile, Bounds } from "@ourworldindata/utils"
+import { getRelativeMouse, isMobile, Bounds, Time } from "@ourworldindata/utils"
 import { observable, computed, action, makeObservable } from "mobx"
 import { observer } from "mobx-react"
 import { faPlay, faPause } from "@fortawesome/free-solid-svg-icons"
@@ -18,9 +18,15 @@ import {
     GRAPHER_TIMELINE_CLASS,
 } from "../core/GrapherConstants.js"
 
-export const TIMELINE_HEIGHT = 32 // keep in sync with $timelineHeight in TimelineComponent.scss
+export const TIMELINE_HEIGHT = 32 // Keep in sync with $timelineHeight in TimelineComponent.scss
 
+const HANDLE_DIAMETER = 20 // Keep in sync with $handle-diameter in TimelineComponent.scss
 const HANDLE_TOOLTIP_FADE_TIME_MS = 2000
+
+enum MarkerType {
+    Start = "startMarker",
+    End = "endMarker",
+}
 
 interface TimelineComponentProps {
     timelineController: TimelineController
@@ -36,13 +42,20 @@ export class TimelineComponent extends React.Component<TimelineComponentProps> {
 
         makeObservable<
             TimelineComponent,
-            "startTooltipVisible" | "endTooltipVisible" | "lastUpdatedTooltip"
+            | "startTooltipVisible"
+            | "endTooltipVisible"
+            | "lastUpdatedTooltip"
+            | "hoverTime"
         >(this, {
             startTooltipVisible: observable,
             endTooltipVisible: observable,
             lastUpdatedTooltip: observable,
+            hoverTime: observable,
         })
     }
+
+    /** Currently hovered time */
+    private hoverTime?: Time
 
     @computed protected get maxWidth(): number {
         return this.props.maxWidth ?? DEFAULT_GRAPHER_BOUNDS.width
@@ -99,13 +112,14 @@ export class TimelineComponent extends React.Component<TimelineComponentProps> {
         this.startTooltipVisible = true
         this.endTooltipVisible = true
 
-        if (this.dragTarget === "start") this.lastUpdatedTooltip = "startMarker"
-        if (this.dragTarget === "end") this.lastUpdatedTooltip = "endMarker"
+        if (this.dragTarget === "start")
+            this.lastUpdatedTooltip = MarkerType.Start
+        if (this.dragTarget === "end") this.lastUpdatedTooltip = MarkerType.End
         if (this.manager.startHandleTimeBound > this.manager.endHandleTimeBound)
             this.lastUpdatedTooltip =
-                this.lastUpdatedTooltip === "startMarker"
-                    ? "endMarker"
-                    : "startMarker"
+                this.lastUpdatedTooltip === MarkerType.Start
+                    ? MarkerType.End
+                    : MarkerType.Start
     }
 
     private getDragTarget(
@@ -126,25 +140,28 @@ export class TimelineComponent extends React.Component<TimelineComponentProps> {
         return "both"
     }
 
-    @action.bound private onMouseDown(event: any): void {
+    @action.bound private onMouseDown(event: MouseEvent | TouchEvent): void {
         this.manager.onTimelineClick?.()
 
-        const logic = this.controller
-        const targetEl = select(event.target)
+        // Immediately hide the hover time handle
+        this.hoverTime = undefined
+
+        const targetEl = select(event.target as Element)
 
         const inputTime = this.getInputTimeFromMouse(event)
-
         if (!inputTime) return
 
         this.manager.timelineDragTarget = this.getDragTarget(
             inputTime,
-            targetEl.classed("startMarker"),
-            targetEl.classed("endMarker")
+            targetEl.classed(MarkerType.Start),
+            targetEl.classed(MarkerType.End)
         )
 
-        if (this.dragTarget === "both") logic.setDragOffsets(inputTime)
+        if (this.dragTarget === "both")
+            this.controller.setDragOffsets(inputTime)
 
         this.onDrag(inputTime)
+
         event.preventDefault()
     }
 
@@ -174,8 +191,49 @@ export class TimelineComponent extends React.Component<TimelineComponentProps> {
         }
     }
 
+    @computed private get areBothHandlesVisible(): boolean {
+        return this.controller.startTime !== this.controller.endTime
+    }
+
+    @computed private get shouldShowHoverTimeHandle(): boolean {
+        return (
+            !this.manager.isSingleTimeSelectionActive &&
+            !this.isDragging &&
+            !this.areBothHandlesVisible
+        )
+    }
+
+    private setHoverTime(event: MouseEvent | TouchEvent): void {
+        if (!this.shouldShowHoverTimeHandle) return
+
+        const inputTime = this.getInputTimeFromMouse(event)
+        if (!inputTime) return
+
+        if (!this.slider) return
+        const mouseX = getRelativeMouse(this.slider, event).x
+        const startX =
+            this.controller.startTimeProgress * this.slider.clientWidth
+
+        // Hide the hover handle when the mouse is positioned directly over
+        // the existing time handle
+        if (Math.abs(mouseX - startX) < HANDLE_DIAMETER) {
+            this.hoverTime = undefined
+            return
+        }
+
+        const timeBound = this.controller.getTimeBoundFromDrag(inputTime)
+        if (!Number.isFinite(timeBound)) return
+
+        this.hoverTime = timeBound
+    }
+
+    @computed private get hoverTimeProgress(): number | undefined {
+        if (this.hoverTime === undefined) return undefined
+        return this.controller.calculateProgress(this.hoverTime)
+    }
+
     private mouseHoveringOverTimeline: boolean = false
-    @action.bound private onMouseOver(): void {
+    @action.bound private onMouseOverSlider(event: MouseEvent): void {
         this.mouseHoveringOverTimeline = true
 
         this.hideStartTooltip.cancel()
@@ -183,14 +241,21 @@ export class TimelineComponent extends React.Component<TimelineComponentProps> {
 
         this.hideEndTooltip.cancel()
         this.endTooltipVisible = true
+
+        this.setHoverTime(event)
     }
 
-    @action.bound private onMouseLeave(): void {
+    @action.bound private onMouseMoveSlider(event: MouseEvent): void {
+        this.setHoverTime(event)
+    }
+
+    @action.bound private onMouseLeaveSlider(): void {
         if (!this.manager.isPlaying && !this.isDragging) {
             this.startTooltipVisible = false
             this.endTooltipVisible = false
         }
         this.mouseHoveringOverTimeline = false
+        this.hoverTime = undefined
     }
 
     private hideStartTooltip = _.debounce(() => {
@@ -200,10 +265,14 @@ export class TimelineComponent extends React.Component<TimelineComponentProps> {
         this.endTooltipVisible = false
     }, HANDLE_TOOLTIP_FADE_TIME_MS)
 
-    @action.bound onPlayTouchEnd(evt: Event): void {
+    @action.bound private onPlayTouchEnd(evt: Event): void {
         evt.preventDefault()
         evt.stopPropagation()
         void this.controller.togglePlay()
+    }
+
+    @action.bound private onSliderTouchStart(event: Event): void {
+        this.onMouseDown(event as TouchEvent)
     }
 
     @computed private get showPlayLabel(): boolean {
@@ -226,7 +295,7 @@ export class TimelineComponent extends React.Component<TimelineComponentProps> {
         document.documentElement.addEventListener("mousemove", this.onMouseMove)
         document.documentElement.addEventListener("touchend", this.onMouseUp)
         document.documentElement.addEventListener("touchmove", this.onMouseMove)
-        this.slider?.addEventListener("touchstart", this.onMouseDown, {
+        this.slider?.addEventListener("touchstart", this.onSliderTouchStart, {
             passive: false,
         })
         this.playButton?.addEventListener("touchend", this.onPlayTouchEnd, {
@@ -249,12 +318,8 @@ export class TimelineComponent extends React.Component<TimelineComponentProps> {
             "touchmove",
             this.onMouseMove
         )
-        this.slider?.removeEventListener("touchstart", this.onMouseDown, {
-            passive: false,
-        } as EventListenerOptions)
-        this.playButton?.removeEventListener("touchend", this.onPlayTouchEnd, {
-            passive: false,
-        } as EventListenerOptions)
+        this.slider?.removeEventListener("touchstart", this.onSliderTouchStart)
+        this.playButton?.removeEventListener("touchend", this.onPlayTouchEnd)
     }
 
     private formatTime(time: number): string {
@@ -278,6 +343,12 @@ export class TimelineComponent extends React.Component<TimelineComponentProps> {
                         ? controller.resetStartToMin()
                         : controller.resetEndToMax()
                 }
+                onMouseEnter={() => {
+                    if (this.shouldShowHoverTimeHandle) this.hoverTime = time
+                }}
+                onMouseLeave={() => {
+                    this.hoverTime = undefined
+                }}
             >
                 {this.formatTime(time)}
             </button>
@@ -286,8 +357,7 @@ export class TimelineComponent extends React.Component<TimelineComponentProps> {
 
     private startTooltipVisible: boolean = false
     private endTooltipVisible: boolean = false
-    private lastUpdatedTooltip: "startMarker" | "endMarker" | undefined =
-        undefined
+    private lastUpdatedTooltip?: MarkerType
 
     @action.bound private togglePlay(): void {
         void this.controller.togglePlay()
@@ -326,7 +396,7 @@ export class TimelineComponent extends React.Component<TimelineComponentProps> {
     }
 
     override render(): React.ReactElement {
-        const { manager, controller } = this
+        const { manager, controller, hoverTime } = this
         const {
             startTimeProgress,
             endTimeProgress,
@@ -340,6 +410,8 @@ export class TimelineComponent extends React.Component<TimelineComponentProps> {
         const formattedMaxTime = this.formatTime(maxTime)
         const formattedStartTime = this.formatTime(startTime)
         const formattedEndTime = this.formatTime(endTime)
+        const formattedHoverTime =
+            hoverTime !== undefined ? this.formatTime(hoverTime) : undefined
 
         return (
             <div
@@ -347,11 +419,14 @@ export class TimelineComponent extends React.Component<TimelineComponentProps> {
                 className={cx(GRAPHER_TIMELINE_CLASS, {
                     hover: this.mouseHoveringOverTimeline,
                 })}
-                style={{
-                    padding: `0 ${GRAPHER_FRAME_PADDING_HORIZONTAL}px`,
-                }}
-                onMouseOver={this.onMouseOver}
-                onMouseLeave={this.onMouseLeave}
+                style={{ padding: `0 ${GRAPHER_FRAME_PADDING_HORIZONTAL}px` }}
+                onMouseOver={(event) =>
+                    this.onMouseOverSlider(event.nativeEvent)
+                }
+                onMouseLeave={this.onMouseLeaveSlider}
+                onMouseMove={(event) =>
+                    this.onMouseMoveSlider(event.nativeEvent)
+                }
             >
                 {!this.manager.disablePlay && (
                     <ActionButton
@@ -375,18 +450,18 @@ export class TimelineComponent extends React.Component<TimelineComponentProps> {
                 {this.timelineEdgeMarker("start")}
                 <div
                     className="slider clickable"
-                    onMouseDown={this.onMouseDown}
+                    onMouseDown={(event) => this.onMouseDown(event.nativeEvent)}
                 >
                     <TimelineHandle
-                        type="startMarker"
-                        label="Start time"
+                        type={MarkerType.Start}
+                        ariaLabel="Start time"
                         offsetPercent={startTimeProgress * 100}
                         formattedMinTime={formattedMinTime}
                         formattedMaxTime={formattedMaxTime}
                         formattedCurrTime={formattedStartTime}
                         tooltipVisible={this.startTooltipVisible}
                         tooltipZIndex={
-                            this.lastUpdatedTooltip === "startMarker" ? 2 : 1
+                            this.lastUpdatedTooltip === MarkerType.Start ? 2 : 1
                         }
                         onKeyDown={action((e) => {
                             // prevent browser to scroll to the top or bottom of the page
@@ -403,23 +478,33 @@ export class TimelineComponent extends React.Component<TimelineComponentProps> {
                             this.endTooltipVisible = false
                         })}
                     />
-                    <div
-                        className="interval"
-                        style={{
-                            left: `${startTimeProgress * 100}%`,
-                            right: `${100 - endTimeProgress * 100}%`,
-                        }}
+                    <TimelineInterval
+                        startTimeProgress={startTimeProgress}
+                        endTimeProgress={endTimeProgress}
                     />
+                    {this.hoverTimeProgress !== undefined && (
+                        <TimelineInterval
+                            className="interval-hover"
+                            startTimeProgress={Math.min(
+                                startTimeProgress,
+                                this.hoverTimeProgress
+                            )}
+                            endTimeProgress={Math.max(
+                                startTimeProgress,
+                                this.hoverTimeProgress
+                            )}
+                        />
+                    )}
                     <TimelineHandle
-                        type="endMarker"
-                        label="End time"
+                        type={MarkerType.End}
+                        ariaLabel="End time"
                         offsetPercent={endTimeProgress * 100}
                         formattedMinTime={formattedMinTime}
                         formattedMaxTime={formattedMaxTime}
                         formattedCurrTime={formattedEndTime}
                         tooltipVisible={this.endTooltipVisible}
                         tooltipZIndex={
-                            this.lastUpdatedTooltip === "endMarker" ? 2 : 1
+                            this.lastUpdatedTooltip === MarkerType.End ? 2 : 1
                         }
                         onKeyDown={action((e) => {
                             // prevent browser to scroll to the top or bottom of the page
@@ -436,6 +521,18 @@ export class TimelineComponent extends React.Component<TimelineComponentProps> {
                             this.endTooltipVisible = false
                         })}
                     />
+                    {this.hoverTime !== undefined &&
+                        this.hoverTimeProgress !== undefined && (
+                            <TimelineHandle
+                                type="hoverMarker"
+                                offsetPercent={this.hoverTimeProgress * 100}
+                                formattedMinTime={formattedMinTime}
+                                formattedMaxTime={formattedMaxTime}
+                                formattedCurrTime={formattedHoverTime!}
+                                tooltipVisible={true}
+                                tooltipZIndex={3}
+                            />
+                        )}
                 </div>
                 {this.timelineEdgeMarker("end")}
             </div>
@@ -445,7 +542,7 @@ export class TimelineComponent extends React.Component<TimelineComponentProps> {
 
 const TimelineHandle = ({
     type,
-    label,
+    ariaLabel,
     offsetPercent,
     formattedMinTime,
     formattedMaxTime,
@@ -456,8 +553,8 @@ const TimelineHandle = ({
     onFocus,
     onBlur,
 }: {
-    type: "startMarker" | "endMarker"
-    label: string
+    type: MarkerType | "hoverMarker"
+    ariaLabel?: string
     offsetPercent: number
     formattedMinTime: string
     formattedMaxTime: string
@@ -473,15 +570,13 @@ const TimelineHandle = ({
         // the numeric representation of a date is meaningless, so we pass the formatted date string instead.
         <div
             className={cx("handle", type)}
-            style={{
-                left: `${offsetPercent}%`,
-            }}
+            style={{ left: `${offsetPercent}%` }}
             role="slider"
             tabIndex={0}
             aria-valuemin={castToNumberIfPossible(formattedMinTime)}
             aria-valuenow={castToNumberIfPossible(formattedCurrTime)}
             aria-valuemax={castToNumberIfPossible(formattedMaxTime)}
-            aria-label={label}
+            aria-label={ariaLabel}
             onFocus={onFocus}
             onBlur={onBlur}
             onKeyDown={onKeyDown}
@@ -502,6 +597,25 @@ const TimelineHandle = ({
                 </>
             )}
         </div>
+    )
+}
+
+const TimelineInterval = ({
+    startTimeProgress,
+    endTimeProgress,
+    className,
+}: {
+    startTimeProgress: number
+    endTimeProgress: number
+    className?: string
+}): React.ReactElement => {
+    const left = startTimeProgress * 100
+    const right = 100 - endTimeProgress * 100
+    return (
+        <div
+            className={cx("interval", className)}
+            style={{ left: `${left}%`, right: `${right}%` }}
+        />
     )
 }
 

--- a/packages/@ourworldindata/grapher/src/timeline/TimelineController.ts
+++ b/packages/@ourworldindata/grapher/src/timeline/TimelineController.ts
@@ -19,6 +19,7 @@ export interface TimelineManager {
     startHandleTimeBound: TimeBound
     endHandleTimeBound: TimeBound
     areHandlesOnSameTimeBeforeAnimation?: boolean
+    isSingleTimeSelectionActive?: boolean
     msPerTick?: number
     onPlay?: () => void
     onTimelineClick?: () => void
@@ -56,12 +57,16 @@ export class TimelineController {
         return R.last(this.timesAsc)!
     }
 
+    calculateProgress(time: Time): number {
+        return (time - this.minTime) / (this.maxTime - this.minTime)
+    }
+
     get startTimeProgress(): number {
-        return (this.startTime - this.minTime) / (this.maxTime - this.minTime)
+        return this.calculateProgress(this.startTime)
     }
 
     get endTimeProgress(): number {
-        return (this.endTime - this.minTime) / (this.maxTime - this.minTime)
+        return this.calculateProgress(this.endTime)
     }
 
     getNextTime(time: number): number {


### PR DESCRIPTION
Make adding a second time slider handle more discoverable. When a single time is selected and you hover the timeline, a second handle should appear.

Test on the Table tab, for example: http://staging-site-second-time-slider-handle/grapher/life-expectancy?tab=table&time=latest

I’m working on this now since it’s a nice to have for small multiple maps, which you can only access by adding a second time slider handle.