### PR TITLE
✨ don't show icon for rounded values in the map tooltip

### DIFF
--- a/packages/@ourworldindata/grapher/src/mapCharts/MapTooltip.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapTooltip.tsx
@@ -186,9 +186,7 @@ export class MapTooltip
         if (!isRounded) return undefined
 
         return {
-            icon: this.showSparkline
-                ? TooltipFooterIcon.significance
-                : TooltipFooterIcon.none,
+            icon: TooltipFooterIcon.none,
             text: makeTooltipRoundingNotice([mapColumn.numSignificantFigures], {
                 plural: false,
             }),
@@ -232,10 +230,6 @@ export class MapTooltip
                     color={valueColor}
                     isProjection={isProjection}
                     labelVariant="unit-only"
-                    showSignificanceSuperscript={
-                        !!this.roundingNotice &&
-                        this.roundingNotice.icon !== TooltipFooterIcon.none
-                    }
                 />
                 <MapSparkline
                     manager={this}


### PR DESCRIPTION
Drop the 'S' icon for rounded values in the tooltip.

| Before | After |
|--------|--------|
| <img width="255" height="237" alt="Screenshot 2025-10-20 at 10 32 39" src="https://github.com/user-attachments/assets/d3bd19ed-d624-411d-8971-5fb074fd1724" /> | <img width="255" height="228" alt="Screenshot 2025-10-20 at 10 32 10" src="https://github.com/user-attachments/assets/18acea56-5c73-44f3-addf-cc892b236544" /> | 


