### PR TITLE
Fix entity selector drawer closing on dropdown click

### DIFF
--- a/packages/@ourworldindata/grapher/src/controls/Dropdown.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/Dropdown.tsx
@@ -46,6 +46,7 @@ export interface DropdownProps<DropdownOption extends BasicDropdownOption> {
         option: DropdownOption | null
     ) => React.ReactNode | undefined
     renderMenuOption?: (option: DropdownOption) => React.ReactNode
+    portalContainer?: HTMLElement
     "data-track-note"?: string
     "aria-label"?: string
 }
@@ -79,6 +80,7 @@ export function Dropdown<DropdownOption extends BasicDropdownOption>({
     isLoading,
     renderTriggerValue,
     renderMenuOption,
+    portalContainer,
     ...otherProps
 }: DropdownProps<DropdownOption>): React.ReactElement {
     const flatOptions = useMemo(() => flattenOptions(options), [options])
@@ -140,6 +142,7 @@ export function Dropdown<DropdownOption extends BasicDropdownOption>({
             <Popover
                 className={cx("grapher-dropdown-menu", menuClassName)}
                 offset={4}
+                UNSTABLE_portalContainer={portalContainer}
             >
                 <ListBox>
                     {options.map((item, index) =>

--- a/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
+++ b/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
@@ -1378,6 +1378,9 @@ export class EntitySelector extends React.Component<EntitySelectorProps> {
                     renderTriggerValue={renderFilterTriggerValue}
                     renderMenuOption={renderFilterMenuOption}
                     aria-label="Filter by type"
+                    portalContainer={
+                        this.scrollableContainer.current ?? undefined
+                    }
                 />
             </div>
         )
@@ -1414,6 +1417,9 @@ export class EntitySelector extends React.Component<EntitySelectorProps> {
                         renderTriggerValue={renderSortTriggerValue}
                         renderMenuOption={renderSortMenuOption}
                         aria-label="Sort by"
+                        portalContainer={
+                            this.scrollableContainer.current ?? undefined
+                        }
                     />
                     <button
                         type="button"


### PR DESCRIPTION
React Aria has an escape hatch for providing a portal container for cases like this one. The nicer way of solving this would be by using a React Aria component for the slide in drawer, which should then make the dropdown behave correctly.

However, we have an indiosyncratic UI drawer that doesn't follow established patterns (is not a modal) and it's not clear if it could be implemented with something like RA Popover while preserving the current behavior.