### PR TITLE
🔨 add map.startTime and map.endTime

### DIFF
--- a/adminSiteClient/EditorMapTab.tsx
+++ b/adminSiteClient/EditorMapTab.tsx
@@ -96,7 +96,8 @@ class TimelineSection extends Component<{ mapConfig: MapConfig }> {
     }
 
     @action.bound setMapTime(time: number | undefined) {
-        this.props.mapConfig.time = time
+        this.props.mapConfig.startTime = time
+        this.props.mapConfig.endTime = time
     }
 
     @action.bound onTolerance(tolerance: number | undefined) {
@@ -134,7 +135,11 @@ class TimelineSection extends Component<{ mapConfig: MapConfig }> {
             <Section name="Timeline">
                 <NumberField
                     label="Target year"
-                    value={mapConfig.time}
+                    value={
+                        mapConfig.startTime === mapConfig.endTime
+                            ? mapConfig.endTime
+                            : undefined
+                    }
                     onValue={this.setMapTime}
                     allowNegative
                 />

--- a/adminSiteClient/GrapherConfigGridEditor.tsx
+++ b/adminSiteClient/GrapherConfigGridEditor.tsx
@@ -1113,7 +1113,7 @@ export class GrapherConfigGridEditor extends React.Component<GrapherConfigGridEd
 
     async getFieldDefinitions() {
         const json = await fetch(
-            "https://files.ourworldindata.org/schemas/grapher-schema.009.json"
+            "https://files.ourworldindata.org/schemas/grapher-schema.010.json"
         ).then((response) => response.json())
         const fieldDescriptions = extractFieldDescriptionsFromSchema(json)
         runInAction(() => {

--- a/db/migration/1760952848159-AddStartTimeToMapConfig.ts
+++ b/db/migration/1760952848159-AddStartTimeToMapConfig.ts
@@ -1,0 +1,61 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+const tables = [
+    { table: "chart_configs", column: "patch" },
+    { table: "chart_configs", column: "full" },
+    { table: "chart_revisions", column: "config" },
+]
+
+export class AddStartTimeToMapConfig1760952848159
+    implements MigrationInterface
+{
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        for (const { table, column } of tables) {
+            // Replace map.time with map.endTime
+            await queryRunner.query(
+                `-- sql
+                    UPDATE chart_configs
+                    SET full = JSON_SET(
+                        JSON_REMOVE(full, '$.map.time'),
+                        '$.map.endTime',
+                        full -> '$.map.time'
+                    )
+                    WHERE full -> '$.map.time' IS NOT NULL;
+                `
+            )
+
+            // Update schema version
+            await queryRunner.query(
+                `-- sql
+                    UPDATE ${table}
+                    SET ${column} = JSON_SET(${column}, "$.$schema", "https://files.ourworldindata.org/schemas/grapher-schema.010.json")
+                `
+            )
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        for (const { table, column } of tables) {
+            // Replace map.endTime with map.time
+            await queryRunner.query(
+                `-- sql
+                    UPDATE chart_configs
+                    SET full = JSON_SET(
+                        JSON_REMOVE(full, '$.map.endTime'),
+                        '$.map.time',
+                        full -> '$.map.endTime'
+                    )
+                    WHERE full -> '$.map.endTime' IS NOT NULL;
+                `
+            )
+
+            // Update schema version
+            await queryRunner.query(
+                `-- sql
+                    UPDATE ${table}
+                    SET ${column} = JSON_SET(${column}, "$.$schema", "https://files.ourworldindata.org/schemas/grapher-schema.009.json")
+                `
+            )
+        }
+    }
+}

--- a/packages/@ourworldindata/explorer/src/GrapherGrammar.ts
+++ b/packages/@ourworldindata/explorer/src/GrapherGrammar.ts
@@ -340,7 +340,10 @@ export const GrapherGrammar: Grammar<GrapherCellDef> = {
             "Set the 'target time' for the map chart. This is the year that will be shown by default in the map chart.",
         toGrapherObject: (parsedValue) =>
             omitEmptyObjectValues({
-                map: omitEmptyStringValues({ time: parsedValue }),
+                map: omitEmptyStringValues({
+                    startTime: parsedValue,
+                    endTime: parsedValue,
+                }),
             }),
     },
     missingDataStrategy: {

--- a/packages/@ourworldindata/grapher/src/core/Grapher.test.ts
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.test.ts
@@ -11,6 +11,7 @@ import {
     LegacyGrapherQueryParams,
     GRAPHER_TAB_NAMES,
     OwidChartDimensionInterface,
+    GRAPHER_TAB_QUERY_PARAMS,
 } from "@ourworldindata/types"
 import {
     TimeBoundValue,
@@ -371,7 +372,7 @@ function toQueryParams(
         minTime: -5000,
         maxTime: 5000,
         hasMapTab: true,
-        map: { time: 5000 },
+        map: { startTime: 5000, endTime: 5000 },
     })
     if (props) grapher.updateFromObject(props)
     return grapher.changedParams
@@ -767,6 +768,31 @@ describe("time parameter", () => {
             }
         }
 
+        for (const test of tests) {
+            it(`parse ${test.name} (map tab)`, () => {
+                const grapher = fromQueryParams({
+                    tab: GRAPHER_TAB_QUERY_PARAMS.map,
+                    time: test.query,
+                })
+                const [start, end] = grapher.timelineHandleTimeBounds
+                expect(start).toEqual(test.param[0])
+                expect(end).toEqual(test.param[1])
+            })
+            if (!test.irreversible) {
+                it(`encode ${test.name}`, () => {
+                    const params = toQueryParams({
+                        hasMapTab: true,
+                        tab: GRAPHER_TAB_CONFIG_OPTIONS.map,
+                        map: {
+                            startTime: test.param[0],
+                            endTime: test.param[1],
+                        },
+                    })
+                    expect(params.time).toEqual(test.query)
+                })
+            }
+        }
+
         it("empty string doesn't change time", () => {
             const grapher = fromQueryParams(
                 { time: "" },
@@ -969,7 +995,7 @@ describe("year parameter (applies to map only)", () => {
             it(`encode ${test.name}`, () => {
                 const params = toQueryParams({
                     tab: GRAPHER_TAB_CONFIG_OPTIONS.map,
-                    map: { time: test.param },
+                    map: { startTime: test.param, endTime: test.param },
                 })
                 expect(params.time).toEqual(test.query)
             })
@@ -1035,7 +1061,7 @@ describe("year parameter (applies to map only)", () => {
                     const grapher = getGrapher()
                     grapher.updateFromObject({
                         tab: GRAPHER_TAB_CONFIG_OPTIONS.map,
-                        map: { time: test.param },
+                        map: { startTime: test.param, endTime: test.param },
                     })
                     const params = grapher.changedParams
                     expect(params.time).toEqual(test.query)
@@ -1092,7 +1118,12 @@ it("considers map tolerance before using column tolerance", () => {
         ySlugs: "gdp",
         tab: GRAPHER_TAB_CONFIG_OPTIONS.map,
         hasMapTab: true,
-        map: new MapConfig({ timeTolerance: 1, columnSlug: "gdp", time: 2002 }),
+        map: new MapConfig({
+            timeTolerance: 1,
+            columnSlug: "gdp",
+            startTime: 2002,
+            endTime: 2002,
+        }),
     })
 
     expect(grapher.timelineHandleTimeBounds[1]).toEqual(2002)
@@ -1101,13 +1132,15 @@ it("considers map tolerance before using column tolerance", () => {
             .values
     ).toEqual([])
 
-    grapher.map.time = 2001
+    grapher.map.startTime = 2001
+    grapher.map.endTime = 2001
     expect(
         grapher.transformedTable.filterByEntityNames(["Germany"]).get("gdp")
             .values
     ).toEqual([2])
 
-    grapher.map.time = 2002
+    grapher.map.startTime = 2002
+    grapher.map.endTime = 2002
     grapher.map.timeTolerance = undefined
     expect(
         grapher.transformedTable.filterByEntityNames(["Germany"]).get("gdp")

--- a/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
@@ -1665,8 +1665,10 @@ export class GrapherState {
     }
     @computed get timelineHandleTimeBounds(): TimeBounds {
         if (this.isOnMapTab) {
-            const time = maxTimeBoundFromJSONOrPositiveInfinity(this.map.time)
-            return [time, time]
+            return [
+                minTimeBoundFromJSONOrNegativeInfinity(this.map.startTime),
+                maxTimeBoundFromJSONOrPositiveInfinity(this.map.endTime),
+            ]
         }
 
         // If the timeline is hidden on the chart tab but displayed on the table tab
@@ -1690,7 +1692,8 @@ export class GrapherState {
 
     set timelineHandleTimeBounds(value: TimeBounds) {
         if (this.isOnMapTab) {
-            this.map.time = value[1]
+            this.map.startTime = value[0]
+            this.map.endTime = value[1]
         } else {
             this.minTime = value[0]
             this.maxTime = value[1]
@@ -3075,7 +3078,8 @@ export class GrapherState {
         this.compareEndPointsOnly = authorsVersion.compareEndPointsOnly
         this.minTime = authorsVersion.minTime
         this.maxTime = authorsVersion.maxTime
-        this.map.time = authorsVersion.map.time
+        this.map.startTime = authorsVersion.map.startTime
+        this.map.endTime = authorsVersion.map.endTime
         this.map.region = authorsVersion.map.region
         this.showNoDataArea = authorsVersion.showNoDataArea
         this.dataTableConfig.filter = authorsVersion.dataTableConfig.filter
@@ -3250,22 +3254,38 @@ export class GrapherState {
             this.maxTime !== authorsVersion.maxTime
         )
     }
+
     @computed private get hasUserChangedMapTimeHandle(): boolean {
-        return this.map.time !== this.authorsVersion.map.time
+        const authorsVersion = this.authorsVersion
+        return (
+            this.map.startTime !== authorsVersion.map.startTime ||
+            this.map.endTime !== authorsVersion.map.endTime
+        )
     }
+
     @computed get timeParam(): string | undefined {
         const { timeColumn } = this.table
-        const formatTime = (t: Time): string =>
+        const formatTime = (time: Time): string =>
             timeBoundToTimeBoundString(
-                t,
+                time,
                 timeColumn instanceof ColumnTypeMap.Day
             )
 
         if (this.isOnMapTab) {
-            return this.map.time !== undefined &&
-                this.hasUserChangedMapTimeHandle
-                ? formatTime(this.map.time)
-                : undefined
+            if (!this.hasUserChangedMapTimeHandle) return undefined
+
+            if (
+                this.map.startTime === undefined ||
+                this.map.endTime === undefined
+            )
+                return undefined
+
+            const startTime = formatTime(this.map.startTime)
+            const endTime = formatTime(this.map.endTime)
+
+            return startTime === endTime
+                ? startTime
+                : `${startTime}..${endTime}`
         }
 
         if (!this.hasUserChangedTimeHandles) return undefined

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapConfig.ts
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapConfig.ts
@@ -3,6 +3,7 @@ import {
     GlobeConfig,
     MapRegionName,
     MapConfigInterface,
+    TimeBound,
 } from "@ourworldindata/types"
 import { ColorScaleConfig } from "../color/ColorScaleConfig"
 import {
@@ -13,9 +14,11 @@ import {
     deleteRuntimeAndUnchangedProps,
     maxTimeBoundFromJSONOrPositiveInfinity,
     maxTimeToJSON,
+    minTimeToJSON,
     trimObject,
     NoUndefinedValues,
     ToleranceStrategy,
+    minTimeBoundFromJSONOrNegativeInfinity,
 } from "@ourworldindata/utils"
 import { MapSelectionArray } from "../selection/MapSelectionArray"
 import { DEFAULT_GLOBE_ROTATION, DEFAULT_GLOBE_ZOOM } from "./MapChartConstants"
@@ -26,7 +29,8 @@ import * as R from "remeda"
 // TODO: migrate database config & only pass legend props
 class MapConfigDefaults {
     columnSlug: ColumnSlug | undefined = undefined
-    time: number | undefined = undefined
+    startTime: TimeBound | undefined = undefined
+    endTime: TimeBound | undefined = undefined
     timeTolerance: number | undefined = undefined
     toleranceStrategy: ToleranceStrategy | undefined = undefined
     hideTimeline: boolean | undefined = undefined
@@ -47,7 +51,8 @@ class MapConfigDefaults {
     constructor() {
         makeObservable(this, {
             columnSlug: observable,
-            time: observable,
+            startTime: observable,
+            endTime: observable,
             timeTolerance: observable,
             toleranceStrategy: observable,
             hideTimeline: observable,
@@ -64,8 +69,15 @@ export class MapConfig extends MapConfigDefaults implements Persistable {
     updateFromObject(obj: Partial<MapConfigInterface>): void {
         updatePersistables(this, obj)
 
-        if (obj.time)
-            this.time = maxTimeBoundFromJSONOrPositiveInfinity(obj.time)
+        if (obj.startTime) {
+            this.startTime = minTimeBoundFromJSONOrNegativeInfinity(
+                obj.startTime
+            )
+        }
+
+        if (obj.endTime) {
+            this.endTime = maxTimeBoundFromJSONOrPositiveInfinity(obj.endTime)
+        }
 
         // If the region is set, automatically switch to the globe
         if (obj.region && obj.region !== MapRegionName.World) {
@@ -90,7 +102,11 @@ export class MapConfig extends MapConfigDefaults implements Persistable {
         const obj = objectWithPersistablesToObject(this) as MapConfigInterface
         deleteRuntimeAndUnchangedProps(obj, new MapConfigDefaults())
 
-        if (obj.time) obj.time = maxTimeToJSON(this.time) as any
+        if (obj.startTime) obj.startTime = minTimeToJSON(this.startTime) as any
+        if (obj.endTime) obj.endTime = maxTimeToJSON(this.endTime) as any
+
+        // No need to store the startTime if it's the same as the endTime
+        if (obj.startTime === obj.endTime) delete obj.startTime
 
         // persist selection
         obj.selectedEntityNames = this.selection.selectedEntityNames

--- a/packages/@ourworldindata/grapher/src/schema/defaultGrapherConfig.ts
+++ b/packages/@ourworldindata/grapher/src/schema/defaultGrapherConfig.ts
@@ -4,7 +4,7 @@
 
 import { GrapherInterface } from "@ourworldindata/types"
 
-export const latestSchemaVersion = "009" as const
+export const latestSchemaVersion = "010" as const
 export const outdatedSchemaVersions = [
     "001",
     "002",
@@ -14,10 +14,11 @@ export const outdatedSchemaVersions = [
     "006",
     "007",
     "008",
+    "009",
 ] as const
 
 export const defaultGrapherConfig = {
-    $schema: "https://files.ourworldindata.org/schemas/grapher-schema.009.json",
+    $schema: "https://files.ourworldindata.org/schemas/grapher-schema.010.json",
     map: {
         region: "World",
         hideTimeline: false,
@@ -30,7 +31,8 @@ export const defaultGrapherConfig = {
         },
         toleranceStrategy: "closest",
         tooltipUseCustomLabels: false,
-        time: "latest",
+        startTime: "latest",
+        endTime: "latest",
         selectedEntityNames: [],
     },
     maxTime: "latest",

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.010.yaml
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.010.yaml
@@ -1,7 +1,7 @@
 $schema: "http://json-schema.org/draft-07/schema#"
 # if you update the required keys, make sure that the mergeGrapherConfigs and
 # diffGrapherConfigs functions both reflect this change
-$id: "https://files.ourworldindata.org/schemas/grapher-schema.009.json"
+$id: "https://files.ourworldindata.org/schemas/grapher-schema.010.json"
 required:
     - $schema
     - dimensions
@@ -14,12 +14,12 @@ properties:
         type: string
         description: Url of the concrete schema version to use to validate this document
         format: uri
-        default: "https://files.ourworldindata.org/schemas/grapher-schema.009.json"
+        default: "https://files.ourworldindata.org/schemas/grapher-schema.010.json"
         # We restrict the $schema field to a single value since we expect all
         # configs in our database to be valid against the latest schema.
         # If we ever need to validate configs against multiple schema versions,
         # we can remove this constraint.
-        const: "https://files.ourworldindata.org/schemas/grapher-schema.009.json"
+        const: "https://files.ourworldindata.org/schemas/grapher-schema.010.json"
     id:
         type: integer
         description: Internal DB id. Useful internally for OWID but not required if just using grapher directly.
@@ -69,8 +69,21 @@ properties:
                 type: boolean
                 default: false
                 description: Show the label from colorSchemeLabels in the tooltip instead of the numeric value
-            time:
-                description: Select a specific time to be displayed.
+            startTime:
+                description: |
+                    Select a specific start time to be displayed. If startTime equals endTime,
+                    then the map will show the data for that specific time point.
+                default: "latest"
+                oneOf:
+                    - type: number
+                    - type: string
+                      enum:
+                          - latest
+                          - earliest
+            endTime:
+                description: |
+                    Select a specific end time to be displayed. If endTime equals startTime,
+                    then the map will show the data for that specific time point.
                 default: "latest"
                 oneOf:
                     - type: number

--- a/packages/@ourworldindata/grapher/src/schema/migrations/migrations.ts
+++ b/packages/@ourworldindata/grapher/src/schema/migrations/migrations.ts
@@ -140,6 +140,16 @@ export const migrateFrom008To009 = (config: AnyConfigWithValidSchema) => {
     return config
 }
 
+export const migrateFrom009To010 = (config: AnyConfigWithValidSchema) => {
+    if (config.map?.time !== undefined) {
+        config.map.endTime = config.map.time
+        delete config.map.time
+    }
+
+    config.$schema = createSchemaForVersion("010")
+    return config
+}
+
 export const runMigration = (
     config: AnyConfigWithValidSchema
 ): AnyConfigWithValidSchema => {
@@ -154,5 +164,6 @@ export const runMigration = (
         .with("006", () => migrateFrom006To007(config))
         .with("007", () => migrateFrom007To008(config))
         .with("008", () => migrateFrom008To009(config))
+        .with("009", () => migrateFrom009To010(config))
         .exhaustive()
 }

--- a/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
+++ b/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
@@ -485,7 +485,8 @@ export interface GlobeConfig {
 
 export interface MapConfigInterface {
     columnSlug?: ColumnSlug
-    time?: Time | TimeBoundValueStr
+    startTime?: TimeBound | TimeBoundValueStr
+    endTime?: TimeBound | TimeBoundValueStr
     timeTolerance?: number
     toleranceStrategy?: ToleranceStrategy
     hideTimeline?: boolean

--- a/packages/@ourworldindata/utils/src/grapherConfigUtils.test.ts
+++ b/packages/@ourworldindata/utils/src/grapherConfigUtils.test.ts
@@ -95,7 +95,7 @@ describe(mergeGrapherConfigs, () => {
                 {
                     map: {
                         region: MapRegionName.World,
-                        time: 2000,
+                        endTime: 2000,
                     },
                 },
                 {
@@ -108,7 +108,7 @@ describe(mergeGrapherConfigs, () => {
         ).toEqual({
             map: {
                 region: MapRegionName.Africa,
-                time: 2000,
+                endTime: 2000,
                 hideTimeline: true,
             },
         })


### PR DESCRIPTION
Drops `map.time` in favour of `map.startTime` and `map.endTime`, in preparation for adding small multiple maps.

This is a breaking change.

This PR shouldn't have any visible effect.