### PR TITLE
Add archived videos to archived articles

### DIFF
--- a/site/gdocs/components/Video.tsx
+++ b/site/gdocs/components/Video.tsx
@@ -1,8 +1,14 @@
+import { useContext } from "react"
 import cx from "classnames"
-import { LARGEST_IMAGE_WIDTH, Span } from "@ourworldindata/utils"
+import {
+    LARGEST_IMAGE_WIDTH,
+    Span,
+    readFromAssetMap,
+} from "@ourworldindata/utils"
 import { useImage } from "../utils.js"
 import SpanElements from "./SpanElements.js"
 import { CLOUDFLARE_IMAGES_URL } from "../../../settings/clientSettings.js"
+import { DocumentContext } from "../DocumentContext.js"
 
 interface VideoProps {
     url: string
@@ -16,10 +22,25 @@ interface VideoProps {
 export default function Video(props: VideoProps) {
     const { url, caption, className, shouldLoop, shouldAutoplay, filename } =
         props
+    const { archiveContext } = useContext(DocumentContext)
+    const isOnArchivalPage = archiveContext?.type === "archive-page"
+    const assetMap = isOnArchivalPage
+        ? archiveContext?.assets?.runtime
+        : undefined
+
     const poster = useImage(filename)
     const posterSrc = poster?.cloudflareId
-        ? `${CLOUDFLARE_IMAGES_URL}/${poster.cloudflareId}/w=${LARGEST_IMAGE_WIDTH}`
+        ? readFromAssetMap(assetMap, {
+              path: poster.filename,
+              fallback: `${CLOUDFLARE_IMAGES_URL}/${poster.cloudflareId}/w=${LARGEST_IMAGE_WIDTH}`,
+          })
         : undefined
+
+    const videoSrc = readFromAssetMap(assetMap, {
+        path: url,
+        fallback: url,
+    })
+
     return (
         <figure className={cx(className)}>
             <video
@@ -30,7 +51,7 @@ export default function Video(props: VideoProps) {
                 loop={shouldLoop}
                 poster={posterSrc}
             >
-                <source src={url} type="video/mp4" />
+                <source src={videoSrc} type="video/mp4" />
             </video>
             {caption ? (
                 <figcaption>


### PR DESCRIPTION
## Context

Part of #5366

## Testing guidance

Check that the videos are properly archived and used in archived articles. Example article with a video:

https://ourworldindata.org/new-feature-embed-archived-charts

You can archive it with:

```
yarn buildArchive --latestDir --type posts --postSlugs new-feature-embed-archived-charts
```
