### PR TITLE
🐛 remove unlisted charts from datapages

### DIFF
--- a/baker/GrapherBaker.tsx
+++ b/baker/GrapherBaker.tsx
@@ -227,7 +227,8 @@ export async function renderDataPageV2(
         const allCharts = await getRelatedChartsForVariable(
             knex,
             variableId,
-            grapher && "id" in grapher ? [grapher.id as number] : []
+            grapher && "id" in grapher ? [grapher.id as number] : [],
+            true
         )
         datapageData.allCharts = allCharts.map((chart) => ({
             ...chart,


### PR DESCRIPTION
Charts with the `Unlisted` tag appear in the Related charts section of datapages. 

[Example](https://ourworldindata.org/grapher/total-population-living-in-extreme-poverty-by-world-region), where a [article-specific chart](https://ourworldindata.org/grapher/number-extreme-poverty-version-comparison) is shown.

This PR filters out Unlisted charts from this selection.