### PR TITLE
Remove issue type labels from templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,7 @@ name: Bug report
 about: Create a report to help us improve
 title: ""
 type: bug
-labels: bug, needs triage
+labels: needs triage
 assignees: ""
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,7 +3,7 @@ name: Feature request
 about: Suggest an idea for this project
 title: ""
 type: enhancement
-labels: feature, needs triage
+labels: needs triage
 assignees: ""
 ---
 


### PR DESCRIPTION
We've been using both labels (old) and issue types (new) to specify the type of issue in issue templates. This was a transitory period to get used to the new property and we can now remove the duplication.