### PR TITLE
✨ improve wide tables

### DIFF
--- a/db/model/Gdoc/GdocBase.ts
+++ b/db/model/Gdoc/GdocBase.ts
@@ -722,6 +722,17 @@ export class GdocBase implements OwidGdocBaseInterface {
                     })
                 )
             })
+            .with({ type: "table" }, (block) => {
+                const links: DbInsertPostGdocLink[] = []
+                if (!block.caption) return links
+                for (const span of block.caption) {
+                    traverseEnrichedSpan(span, (span) => {
+                        const link = this.extractLinkFromSpan(span)
+                        if (link) links.push(link)
+                    })
+                }
+                return links
+            })
             .with(
                 {
                     // no urls directly on any of these blocks
@@ -757,7 +768,6 @@ export class GdocBase implements OwidGdocBaseInterface {
                         "simple-text",
                         "sticky-left",
                         "sticky-right",
-                        "table",
                         "text",
                         "homepage-search",
                         "latest-data-insights",

--- a/db/model/Gdoc/enrichedToMarkdown.ts
+++ b/db/model/Gdoc/enrichedToMarkdown.ts
@@ -402,7 +402,11 @@ ${links}`
                 )
                 return `|${cells.join("|")}|`
             })
-            return "\n" + rows.join("\n") // markdown tables need a leading empty line
+            const table = "\n" + rows.join("\n") // markdown tables need a leading empty line
+            const caption = b.caption
+                ? `\n\n*${spansToMarkdown(b.caption)}*`
+                : ""
+            return table + caption
         })
         .with({ type: "explorer-tiles" }, () => undefined) // Note: dropped
         .with({ type: "blockquote" }, (b): string | undefined => {

--- a/db/model/Gdoc/enrichedToRaw.ts
+++ b/db/model/Gdoc/enrichedToRaw.ts
@@ -584,6 +584,7 @@ export function enrichedBlockToRawBlock(
                 type: b.type,
                 value: {
                     template: b.template,
+                    size: b.size,
                     rows: b.rows.map((row) => ({
                         type: row.type,
                         value: {
@@ -595,6 +596,7 @@ export function enrichedBlockToRawBlock(
                             })),
                         },
                     })),
+                    caption: b.caption ? spansToHtmlText(b.caption) : undefined,
                 },
             }
         })

--- a/db/model/Gdoc/exampleEnrichedBlocks.ts
+++ b/db/model/Gdoc/exampleEnrichedBlocks.ts
@@ -667,6 +667,12 @@ export const enrichedBlockExamples: Record<
         type: "table",
         template: "header-row",
         size: "narrow",
+        caption: [
+            {
+                spanType: "span-simple-text",
+                text: "Table 1: Example cities and their continents",
+            },
+        ],
         rows: [
             {
                 type: "table-row",

--- a/db/model/Gdoc/rawToArchie.ts
+++ b/db/model/Gdoc/rawToArchie.ts
@@ -840,6 +840,7 @@ function* rawBlockTableToArchieMLString(
     yield "{.table}"
     yield* propertyToArchieMLString("template", block.value)
     yield* propertyToArchieMLString("size", block.value)
+    yield* propertyToArchieMLString("caption", block.value)
     const rows = block?.value?.rows
     if (rows) {
         yield "[.+rows]"

--- a/db/model/Gdoc/rawToEnriched.ts
+++ b/db/model/Gdoc/rawToEnriched.ts
@@ -1386,11 +1386,16 @@ export const parseTable = (raw: RawBlockTable): EnrichedBlockTable => {
         }
     }
 
+    const caption = raw.value?.caption
+        ? htmlToSpans(raw.value.caption)
+        : undefined
+
     return {
         type: "table",
         rows: enrichedRows,
         template,
         size,
+        caption,
         parseErrors,
     }
 }

--- a/packages/@ourworldindata/types/src/gdocTypes/ArchieMlComponents.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/ArchieMlComponents.ts
@@ -885,6 +885,7 @@ export type RawBlockTable = {
         template?: TableTemplate
         size?: TableSize
         rows?: RawBlockTableRow[]
+        caption?: string
     }
 }
 
@@ -906,6 +907,7 @@ export type EnrichedBlockTable = {
     template: TableTemplate
     size: TableSize
     rows: EnrichedBlockTableRow[]
+    caption?: Span[]
 } & EnrichedBlockWithParseErrors
 
 export interface EnrichedBlockTableRow {

--- a/site/gdocs/components/Table.tsx
+++ b/site/gdocs/components/Table.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 import { EnrichedBlockTable } from "@ourworldindata/utils"
 import { ArticleBlocks } from "./ArticleBlocks.js"
+import SpanElements from "./SpanElements.js"
 
 function TableCell(props: {
     tag: "td" | "th"
@@ -79,6 +80,11 @@ export function Table(props: TableProps) {
                             )
                         })}
                 </tbody>
+                {props.caption && (
+                    <caption>
+                        <SpanElements spans={props.caption} />
+                    </caption>
+                )}
             </table>
         </div>
     )

--- a/site/gdocs/components/centered-article.scss
+++ b/site/gdocs/components/centered-article.scss
@@ -937,6 +937,15 @@ p.article-block__text + #article-licence {
                 font-size: 0.75rem;
             }
         }
+        caption {
+            margin-top: 6px;
+            caption-side: bottom;
+            color: $blue-60;
+            @include body-3-medium-italic;
+            a {
+                @include owid-link-90;
+            }
+        }
     }
 }
 


### PR DESCRIPTION
| Before | After |
|--------|--------|
| <img width="1322" height="670" alt="image" src="https://github.com/user-attachments/assets/322174c0-8b3f-4a90-9451-f6bd831d2b85" /> | <img width="822" height="651" alt="image" src="https://github.com/user-attachments/assets/1ab741f0-6933-4f41-834b-681586a3dae5" /> | 

Tables to QA:
```
https://ourworldindata.org/global-decline-fertility-rate
https://ourworldindata.org/the-our-world-in-data-dataset-of-famines
https://ourworldindata.org/faq-on-plastics
https://ourworldindata.org/how-urban-is-the-world
https://ourworldindata.org/eradication-of-diseases
https://ourworldindata.org/the-worlds-deadliest-earthquakes
https://ourworldindata.org/gender-ratio
https://ourworldindata.org/childhood-diarrheal-diseases
https://ourworldindata.org/rotavirus-vaccine
https://ourworldindata.org/food-transport-by-mode
https://ourworldindata.org/covid-excess-mortality
https://ourworldindata.org/soil-lifespans
https://ourworldindata.org/human-height
https://ourworldindata.org/covid-deaths-by-vaccination
https://ourworldindata.org/polio
https://ourworldindata.org/living-planet-index-decline
https://ourworldindata.org/faq-living-planet-index
https://ourworldindata.org/quaternary-megafauna-extinction
https://ourworldindata.org/mass-extinctions
https://ourworldindata.org/gcp-faqs
https://ourworldindata.org/how-do-statistical-organizations-define-age-periods-in-children
https://ourworldindata.org/urbanization
https://ourworldindata.org/elephant-populations
https://ourworldindata.org/future-updates-data-covid
https://ourworldindata.org/air-pollution-sources
https://ourworldindata.org/demographic-health-surveys-risk
```