### PR TITLE
fix: close DB connections on deploy queue server errors to prevent hang

### DIFF
--- a/baker/startDeployQueueServer.ts
+++ b/baker/startDeployQueueServer.ts
@@ -32,6 +32,8 @@ const main = async () => {
             await runDeployIfQueueIsNotEmpty()
         } catch (error) {
             await logErrorAndMaybeCaptureInSentry(error)
+            // Close DB connections to allow process to exit cleanly
+            await db.closeTypeOrmAndKnexConnections()
             throw error
         }
         await new Promise((resolve) => setTimeout(resolve, 5 * 1000))


### PR DESCRIPTION
## Summary
- Close database connection pool when errors occur in the deploy queue server
- Prevents process from hanging when database errors occur (deadlocks, connection pool exhaustion, connection loss)

## Test plan
- [x] Verified that the process now exits cleanly with code 1 on errors instead of hanging
- PM2 should now be able to detect the exit and restart the process

🤖 Generated with [Claude Code](https://claude.com/claude-code)