### PR TITLE
fix(mdim): properly pass archive information, such that it can be shown in an embedded mdim

### DIFF
--- a/site/multiDim/MultiDim.tsx
+++ b/site/multiDim/MultiDim.tsx
@@ -165,8 +165,8 @@ export default function MultiDim({
                 if (ignoreFetchedData) return
                 const grapherConfig = {
                     ...viewGrapherConfig,
-                    ...localGrapherConfig,
                     ...baseGrapherConfig,
+                    ...localGrapherConfig,
                 }
                 if (slug) {
                     grapherConfig.slug = slug // Needed for the URL used for sharing.


### PR DESCRIPTION
The before/after here is in https://ourworldindata.org/vaccination.

| Before | After |
|--------|--------|
| <img width="924" height="801" alt="CleanShot 2025-10-30 at 18 28 30" src="https://github.com/user-attachments/assets/e387ae82-9872-4bc4-8a87-8dfff1b57447" /> | <img width="891" height="713" alt="CleanShot 2025-10-30 at 18 28 57" src="https://github.com/user-attachments/assets/dd0ae4da-6fa8-4184-b4d9-09c33894e586" /> | 

## What's going on here:

This is the code that's rendering the `<MultiDimEmbed>`, it has `chartConfig = { archiveContext }`:
https://github.com/owid/owid-grapher/blob/8fa135a0e5b9c4bacf060e7bb05a21964575836d/site/gdocs/components/Chart.tsx#L160-L165

https://github.com/owid/owid-grapher/blob/8fa135a0e5b9c4bacf060e7bb05a21964575836d/site/gdocs/components/Chart.tsx#L114-L121

Then, `<MultiDimEmbed>` just passes these along to `<MultiDim>` as-is:
https://github.com/owid/owid-grapher/blob/8fa135a0e5b9c4bacf060e7bb05a21964575836d/site/MultiDimEmbed.tsx#L90-L97


`<MultiDim>` always sets `baseGrapherConfig.archiveContext`, even if `archiveContext` is undefined, thereby overriding whatever is in `localGrapherConfig`:
https://github.com/owid/owid-grapher/blob/8fa135a0e5b9c4bacf060e7bb05a21964575836d/site/multiDim/MultiDim.tsx#L69-L74

---

I'm not entirely sure whether there's other props in `baseGrapherConfig` that should always override what's in `localGrapherConfig`. It's your call, @rakyi, and there are also a bunch of other solution we can alternatively consider! (such as explicitly passing `archiveContext` to the `<MultiDim>` component in this case).