### PR TITLE
✨ add missig icons to fallback component

### DIFF
--- a/site/search/SearchChartHitCaptionedThumbnail.tsx
+++ b/site/search/SearchChartHitCaptionedThumbnail.tsx
@@ -8,7 +8,7 @@ export function CaptionedThumbnail({
     chartType,
     chartUrl,
     previewUrl,
-    isSmallSlot,
+    isSmallSlot = false,
     imageWidth,
     imageHeight,
     className,
@@ -17,7 +17,7 @@ export function CaptionedThumbnail({
     chartType: GrapherTabName
     chartUrl: string
     previewUrl: string
-    isSmallSlot: boolean
+    isSmallSlot?: boolean
     imageWidth?: number
     imageHeight?: number
     className?: string

--- a/site/search/SearchChartHitRichDataFallback.tsx
+++ b/site/search/SearchChartHitRichDataFallback.tsx
@@ -7,10 +7,7 @@ import {
     pickEntitiesForChartHit,
     toGrapherQueryParams,
 } from "./searchUtils.js"
-import {
-    makeLabelForGrapherTab,
-    WORLD_ENTITY_NAME,
-} from "@ourworldindata/grapher"
+import { WORLD_ENTITY_NAME } from "@ourworldindata/grapher"
 import {
     buildChartHitDataDisplayProps,
     GRAPHER_TAB_NAMES,
@@ -20,8 +17,7 @@ import {
 import { SearchChartHitHeader } from "./SearchChartHitHeader.js"
 import { Button } from "@ourworldindata/components"
 import { faDownload } from "@fortawesome/free-solid-svg-icons"
-import { CaptionedLink } from "./SearchChartHitCaptionedLink.js"
-import { SearchChartHitThumbnail } from "./SearchChartHitThumbnail.js"
+import { CaptionedThumbnail } from "./SearchChartHitCaptionedThumbnail.js"
 import { SearchChartHitDataDisplay } from "./SearchChartHitDataDisplay.js"
 import {
     getTotalColumnCount,
@@ -127,10 +123,6 @@ export function SearchChartHitRichDataFallback({
                 style={contentStyle}
             >
                 {placedTabs.map(({ grapherTab, slotKey }) => {
-                    const caption = makeLabelForGrapherTab(grapherTab, {
-                        format: "long",
-                    })
-
                     const { chartUrl, previewUrl } =
                         constructChartAndPreviewUrlsForTab({
                             hit,
@@ -143,18 +135,14 @@ export function SearchChartHitRichDataFallback({
                     const className = makeSlotClassNames("medium", slotKey)
 
                     return (
-                        <CaptionedLink
+                        <CaptionedThumbnail
                             key={grapherTab}
-                            caption={caption}
-                            url={chartUrl}
+                            chartType={grapherTab}
+                            chartUrl={chartUrl}
+                            previewUrl={previewUrl}
                             className={className}
                             onClick={() => onClick(grapherTab)}
-                        >
-                            <SearchChartHitThumbnail
-                                previewUrl={previewUrl}
-                                hoverOverlayText="Click to explore"
-                            />
-                        </CaptionedLink>
+                        />
                     )
                 })}
 


### PR DESCRIPTION
Chart icons are currently missing in the fallback component (see screenshot). This PR adds them by reusing the CaptionedThumbnail component from the rich data component. 

<img width="2116" height="1638" alt="image" src="https://github.com/user-attachments/assets/bf09b51e-56a8-4384-8e65-e5addad6c864" />