### PR TITLE
✨  Add 'View all published charts' button to the dataset admin

### DIFF
--- a/adminSiteClient/DatasetEditPage.tsx
+++ b/adminSiteClient/DatasetEditPage.tsx
@@ -200,15 +200,20 @@ class DatasetEditor extends Component<DatasetEditorProps> {
 
     @computed get collectionUrl(): string | null {
         const { dataset } = this.props
-        const publishedChartSlugs = dataset.charts
-            .filter((chart) => chart.isPublished)
-            .map((chart) => chart.slug)
+        const publishedCharts = dataset.charts.filter(
+            (chart) => chart.isPublished
+        )
 
-        if (publishedChartSlugs.length === 0) {
+        if (publishedCharts.length === 0) {
             return null
         }
 
-        const chartsParam = publishedChartSlugs.join("+")
+        // Sort by pageviews descending (most views first)
+        const sortedSlugs = publishedCharts
+            .sort((a, b) => b.pageviewsPerDay - a.pageviewsPerDay)
+            .map((chart) => chart.slug)
+
+        const chartsParam = sortedSlugs.join("+")
         return `https://ourworldindata.org/collection/custom?charts=${chartsParam}`
     }
 


### PR DESCRIPTION
Just a quick experiment to see if it's possible to add a button to dataset admin that allows us to view a collection of all the published charts in a dataset, ordered by views. 

This would be useful for collating information on dataset updates for funders and also sharing dataset updates with the public.

http://staging-site-collection-button/admin/datasets/6549