### PR TITLE
Add archived guided charts to archived articles

### DIFF
--- a/packages/@ourworldindata/grapher/src/chart/guidedChartUtils.test.ts
+++ b/packages/@ourworldindata/grapher/src/chart/guidedChartUtils.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest"
+import { Url } from "@ourworldindata/utils"
+import {
+    buildArchiveGuidedChartSrc,
+    type ArchiveGuidedChartRegistration,
+} from "./guidedChartUtils.js"
+import { createRef } from "react"
+import { ChartConfigType } from "@ourworldindata/types"
+
+const makeRegistration = (
+    baseUrl: string,
+    defaultQueryParams: Record<string, string | undefined> = {}
+): ArchiveGuidedChartRegistration => ({
+    iframeRef: createRef<HTMLIFrameElement>(),
+    baseUrl,
+    defaultQueryParams,
+    chartConfigType: ChartConfigType.Grapher,
+})
+
+describe(buildArchiveGuidedChartSrc, () => {
+    it("merges guided query params over defaults", () => {
+        const registration = makeRegistration(
+            "https://archive.ourworldindata.org/grapher/test?tab=chart&stackMode=relative",
+            { tab: "chart", stackMode: "relative" }
+        )
+        const guidedUrl = Url.fromURL(
+            "https://ourworldindata.org/grapher/test?tab=map&stackMode=absolute"
+        )
+
+        const result = buildArchiveGuidedChartSrc(registration, guidedUrl)
+
+        expect(result).toBe(
+            "https://archive.ourworldindata.org/grapher/test?tab=map&stackMode=absolute"
+        )
+    })
+
+    it("preserves default params when guided link omits them", () => {
+        const registration = makeRegistration(
+            "https://archive.ourworldindata.org/grapher/test?tab=chart&stackMode=relative",
+            { tab: "chart", stackMode: "relative" }
+        )
+        const guidedUrl = Url.fromURL(
+            "https://ourworldindata.org/grapher/test?tab=map"
+        )
+
+        const result = buildArchiveGuidedChartSrc(registration, guidedUrl)
+
+        expect(result).toBe(
+            "https://archive.ourworldindata.org/grapher/test?tab=map&stackMode=relative"
+        )
+    })
+
+    it("includes hash fragments from guided link when present", () => {
+        const registration = makeRegistration(
+            "https://archive.ourworldindata.org/grapher/test?tab=chart",
+            { tab: "chart" }
+        )
+        const guidedUrl = Url.fromURL(
+            "https://ourworldindata.org/grapher/test?tab=map#scatterplot"
+        )
+
+        const result = buildArchiveGuidedChartSrc(registration, guidedUrl)
+
+        expect(result).toBe(
+            "https://archive.ourworldindata.org/grapher/test?tab=map#scatterplot"
+        )
+    })
+
+    it("falls back to base hash when guided link omits one", () => {
+        const registration = makeRegistration(
+            "https://archive.ourworldindata.org/grapher/test?tab=chart#chart",
+            { tab: "chart" }
+        )
+        const guidedUrl = Url.fromURL(
+            "https://ourworldindata.org/grapher/test?stackMode=relative"
+        )
+
+        const result = buildArchiveGuidedChartSrc(registration, guidedUrl)
+
+        expect(result).toBe(
+            "https://archive.ourworldindata.org/grapher/test?tab=chart&stackMode=relative#chart"
+        )
+    })
+})

--- a/packages/@ourworldindata/grapher/src/chart/guidedChartUtils.ts
+++ b/packages/@ourworldindata/grapher/src/chart/guidedChartUtils.ts
@@ -1,13 +1,26 @@
 import * as React from "react"
 import { GrapherProgrammaticInterface } from "../core/Grapher.js"
 import { GrapherState } from "../core/GrapherState.js"
-import { MultiDimDataPageConfig } from "@ourworldindata/utils"
-import { MultiDimDimensionChoices } from "@ourworldindata/types"
+import { MultiDimDataPageConfig, Url } from "@ourworldindata/utils"
+import {
+    MultiDimDimensionChoices,
+    ChartConfigType,
+} from "@ourworldindata/types"
+
+export interface ArchiveGuidedChartRegistration {
+    iframeRef: React.RefObject<HTMLIFrameElement | null>
+    baseUrl: string
+    defaultQueryParams: Record<string, string | undefined>
+    chartConfigType: ChartConfigType
+}
 
 export interface GuidedChartContextValue {
     grapherStateRef: React.RefObject<GrapherState>
     chartRef?: React.RefObject<HTMLDivElement>
     onGuidedChartLinkClick?: (href: string) => void
+    registerArchiveChart?: (
+        registration: ArchiveGuidedChartRegistration
+    ) => () => void
     registerMultiDim?: (registrationData: {
         config: MultiDimDataPageConfig
         onSettingsChange: (newSettings: MultiDimDimensionChoices) => void
@@ -47,4 +60,19 @@ export function useGuidedChartLinkHandler():
     | undefined {
     const context = React.useContext(GuidedChartContext)
     return context?.onGuidedChartLinkClick
+}
+
+export const buildArchiveGuidedChartSrc = (
+    registration: ArchiveGuidedChartRegistration,
+    guidedUrl: Url
+): string => {
+    const baseUrl = Url.fromURL(registration.baseUrl)
+    const mergedQuery = {
+        ...registration.defaultQueryParams,
+        ...guidedUrl.queryParams,
+    }
+    const updatedUrl = baseUrl.setQueryParams(mergedQuery)
+
+    const hash = guidedUrl.hash || baseUrl.hash
+    return hash ? updatedUrl.update({ hash }).fullUrl : updatedUrl.fullUrl
 }

--- a/packages/@ourworldindata/grapher/src/core/FetchingGrapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/FetchingGrapher.tsx
@@ -12,7 +12,7 @@ import { legacyToCurrentGrapherQueryParams } from "./GrapherUrlMigrations.js"
 import { unstable_batchedUpdates } from "react-dom"
 import { Bounds } from "@ourworldindata/utils"
 import { migrateGrapherConfigToLatestVersion } from "../schema/migrations/migrate.js"
-import { useMaybeGlobalGrapherStateRef } from "../chart/GuidedChartUtils.js"
+import { useMaybeGlobalGrapherStateRef } from "../chart/guidedChartUtils.js"
 
 export interface FetchingGrapherProps {
     config?: GrapherProgrammaticInterface

--- a/packages/@ourworldindata/grapher/src/index.ts
+++ b/packages/@ourworldindata/grapher/src/index.ts
@@ -114,7 +114,9 @@ export {
     useGuidedChartLinkHandler,
     GuidedChartContext,
     type GuidedChartContextValue,
-} from "./chart/GuidedChartUtils"
+    type ArchiveGuidedChartRegistration,
+    buildArchiveGuidedChartSrc,
+} from "./chart/guidedChartUtils"
 export {
     isChartTypeName,
     isValidTabQueryParam,


### PR DESCRIPTION
## Context

Part of #5366

## Testing guidance

1. Publish example [guided charts gdoc](http://localhost:3030/admin/gdocs/16bKYpPJdB_BP1Y3-qpoSmbQiRTdhWjTAt59xtvyWSNU/preview) locally
2. Archive its dependencies (if they are not archived locally yet):

    ```
    yarn buildArchive --latestDir --type charts --chartIds 64
    yarn buildArchive --latestDir --type multiDims --multiDimIds 2390
    ```

3. Archive the article:

    ```
    yarn buildArchive --latestDir --type posts --postSlugs guided-chart
    ```
4. Test that the guided charts behave correctly both in the live and archival versions