### PR TITLE
🐛 fix style of the settings popup close button

### DIFF
--- a/packages/@ourworldindata/grapher/src/controls/Controls.scss
+++ b/packages/@ourworldindata/grapher/src/controls/Controls.scss
@@ -22,7 +22,7 @@ nav.controlsRow .controls {
     justify-content: flex-end;
     gap: 8px;
 
-    button {
+    button.menu-toggle {
         font: $medium 13px/16px $lato;
         letter-spacing: 0.01em;
         display: flex;

--- a/packages/@ourworldindata/grapher/src/controls/MapResetButton.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/MapResetButton.tsx
@@ -105,6 +105,7 @@ export class MapResetButton extends React.Component<{
                 type="button"
                 data-track-note={this.trackNote}
                 onClick={this.onClick}
+                className="menu-toggle"
             >
                 <FontAwesomeIcon icon={faRotateLeft} />
                 {this.label}

--- a/packages/@ourworldindata/grapher/src/controls/MapZoomToSelectionButton.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/MapZoomToSelectionButton.tsx
@@ -58,6 +58,7 @@ export class MapZoomToSelectionButton extends React.Component<MapZoomToSelection
                 onClick={this.onClick}
                 type="button"
                 data-track-note="map_zoom_to_selection"
+                className="menu-toggle"
             >
                 <GlobeIcon size={16} />
                 Zoom to selection


### PR DESCRIPTION
I introduced a regression in #5544, causing the close button in the settings popup to be styled incorrectly (see screenshot).

<img width="480" height="279" alt="image" src="https://github.com/user-attachments/assets/8e8c374f-becd-4f07-b4fa-655f10269274" />
