### PR TITLE
✨ prefer a horizontal layout for world maps

### DIFF
--- a/packages/@ourworldindata/grapher/src/facet/FacetMap.tsx
+++ b/packages/@ourworldindata/grapher/src/facet/FacetMap.tsx
@@ -198,7 +198,12 @@ export class FacetMap
         const verticalDiff = Math.abs(
             Math.log2(mapAspectRatio / verticalLayoutAspectRatio)
         )
-        return horizontalDiff <= verticalDiff
+
+        // World maps tend to look better side-by-side, so we give the
+        // horizontal layout an advantage when the region is World
+        const bias = this.mapConfig.region === MapRegionName.World ? 0.5 : 0
+
+        return horizontalDiff - bias <= verticalDiff
             ? horizontalLayout
             : verticalLayout
     }


### PR DESCRIPTION
Static exports (with the default dimensions) currently display world maps stacked vertically. It would be better if they were arranged side by side.