### PR TITLE
🐛 fix form state on image alt text

### DIFF
--- a/adminSiteClient/EditableTextarea.tsx
+++ b/adminSiteClient/EditableTextarea.tsx
@@ -15,6 +15,7 @@ interface EditableTextareaProps {
     placeholder?: string
     disabled?: boolean
     valid?: boolean
+    isDirtyOverride?: boolean
 }
 
 export function EditableTextarea({
@@ -27,8 +28,10 @@ export function EditableTextarea({
     placeholder,
     disabled = false,
     valid = true,
+    isDirtyOverride,
 }: EditableTextareaProps) {
-    const [isDirty, setIsDirty] = useState(false)
+    const [internalIsDirty, setInternalIsDirty] = useState(false)
+    const isDirty = isDirtyOverride ?? internalIsDirty
 
     const handleChange = useCallback(
         (e: React.ChangeEvent<HTMLTextAreaElement>) => {
@@ -40,7 +43,7 @@ export function EditableTextarea({
     const handleSave = useCallback(() => {
         const trimmed = value.trim()
         onSave(trimmed)
-        setIsDirty(false)
+        setInternalIsDirty(false)
     }, [onSave, value])
 
     return (
@@ -50,7 +53,7 @@ export function EditableTextarea({
                 value={value}
                 onChange={(e) => {
                     handleChange(e)
-                    setIsDirty(true)
+                    setInternalIsDirty(true)
                 }}
                 placeholder={placeholder}
                 disabled={disabled}

--- a/adminSiteClient/ImagesIndexPage.tsx
+++ b/adminSiteClient/ImagesIndexPage.tsx
@@ -94,11 +94,18 @@ function AltTextEditor({
     getAltText: ImageEditorApi["getAltText"]
 }) {
     const [value, setValue] = useState(text)
+    const [savedValue, setSavedValue] = useState(text)
+
+    useEffect(() => {
+        setValue(text)
+        setSavedValue(text)
+    }, [text])
 
     const saveAltText = useCallback(
         (newValue: string) => {
             patchImage(image, { defaultAlt: newValue })
             setValue(newValue)
+            setSavedValue(newValue)
         },
         [image, patchImage]
     )
@@ -122,6 +129,7 @@ function AltTextEditor({
             className="ImageIndexPage__alt-text-editor"
             extraActions={altTextButton}
             autoResize
+            isDirtyOverride={value !== savedValue}
         />
     )
 }


### PR DESCRIPTION
Currently, on the images index page, if you click the `getAltText` button, the form doesn't allow you to save unless you manually dirty the input yourself.

This fixes that by allowing a pattern where a caller of `EditableTextarea` can track dirty state itself and pass it down if necessary.

To test:

1. Go to `/admin/images` 
2. Generate some alt text
3. Note the "Unsaved" span that appears, and that you can save the image immediately