### PR TITLE
🔨 refactor tooltip contents for use without owid table columns

### DIFF
--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
@@ -26,6 +26,7 @@ import {
     TooltipState,
     TooltipTable,
     makeTooltipRoundingNotice,
+    toTooltipTableColumns,
 } from "../tooltip/Tooltip"
 import { NoDataModal } from "../noDataModal/NoDataModal"
 import { extent } from "d3-array"
@@ -388,7 +389,7 @@ export class LineChart
                 dismiss={this.dismissTooltip}
             >
                 <TooltipTable
-                    columns={columns}
+                    columns={toTooltipTableColumns(columns)}
                     rows={sortedData.map((series) => {
                         const {
                             seriesName,

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapTooltip.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapTooltip.tsx
@@ -13,6 +13,7 @@ import {
     makeTooltipToleranceNotice,
     makeTooltipRoundingNotice,
     TooltipValueRange,
+    formatTooltipRangeValues,
 } from "../tooltip/Tooltip"
 import { MapChartManager, MapColumnInfo } from "./MapChartConstants"
 import { ColorScale } from "../color/ColorScale"
@@ -25,7 +26,11 @@ import {
     PrimitiveType,
 } from "@ourworldindata/types"
 import { CoreColumn, OwidTable } from "@ourworldindata/core-table"
-import { excludeUndefined, PointVector } from "@ourworldindata/utils"
+import {
+    calculateTrendDirection,
+    excludeUndefined,
+    PointVector,
+} from "@ourworldindata/utils"
 import { darkenColorForHighContrastText } from "../color/ColorUtils"
 import { MapSparkline, MapSparklineManager } from "./MapSparkline.js"
 import { match } from "ts-pattern"
@@ -345,10 +350,12 @@ function MapTooltipValue({
 
     return (
         <TooltipValue
-            column={mapColumn}
+            label={mapColumn.displayName}
+            unit={mapColumn.displayUnit}
             value={formattedValue}
             color={color}
             isProjection={isProjection}
+            isRoundedToSignificantFigures={mapColumn.roundsToSignificantFigures}
             labelVariant="unit-only"
         />
     )
@@ -383,9 +390,12 @@ function MapTooltipRangeValues({
 
     return (
         <TooltipValueRange
-            column={mapColumn}
-            values={values}
+            label={mapColumn.displayName}
+            unit={mapColumn.displayUnit}
+            values={formatTooltipRangeValues(values, mapColumn)}
             colors={colors}
+            trend={calculateTrendDirection(...values) ?? "right"}
+            isRoundedToSignificantFigures={mapColumn.roundsToSignificantFigures}
             labelVariant="unit-only"
         />
     )

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
@@ -12,6 +12,7 @@ import {
     dyFromAlign,
     isTouchDevice,
     domainExtent,
+    calculateTrendDirection,
 } from "@ourworldindata/utils"
 import { observable, computed, action, makeObservable } from "mobx"
 import { observer } from "mobx-react"
@@ -49,6 +50,7 @@ import { NoDataSection } from "../scatterCharts/NoDataSection"
 
 import { LineLegend, LineLegendProps } from "../lineLegend/LineLegend"
 import {
+    formatTooltipRangeValues,
     makeTooltipRoundingNotice,
     makeTooltipToleranceNotice,
     Tooltip,
@@ -807,8 +809,13 @@ export class SlopeChart
                 dismiss={() => (this.tooltipState.target = null)}
             >
                 <TooltipValueRange
-                    column={series.column}
-                    values={values}
+                    label={series.column.displayName}
+                    unit={series.column.displayUnit}
+                    values={formatTooltipRangeValues(values, series.column)}
+                    trend={calculateTrendDirection(...values)}
+                    isRoundedToSignificantFigures={
+                        series.column.roundsToSignificantFigures
+                    }
                     labelVariant="unit-only"
                 />
             </Tooltip>

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
@@ -26,6 +26,7 @@ import {
     TooltipState,
     TooltipTable,
     makeTooltipRoundingNotice,
+    toTooltipTableColumns,
 } from "../tooltip/Tooltip"
 import { StackedAreaChartState } from "./StackedAreaChartState.js"
 import { AREA_OPACITY, StackedSeries } from "./StackedConstants"
@@ -472,7 +473,7 @@ export class StackedAreaChart
                 dismiss={this.dismissTooltip}
             >
                 <TooltipTable
-                    columns={[formatColumn]}
+                    columns={toTooltipTableColumns(formatColumn)}
                     totals={[totalValue]}
                     rows={series.toReversed().map((series) => {
                         const { seriesName: name, color, points } = series

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChart.tsx
@@ -24,6 +24,7 @@ import {
     TooltipState,
     TooltipTable,
     makeTooltipRoundingNotice,
+    toTooltipTableColumns,
 } from "../tooltip/Tooltip"
 import {
     BASE_FONT_SIZE,
@@ -400,7 +401,7 @@ export class StackedBarChart
                 dismiss={() => (this.tooltipState.target = null)}
             >
                 <TooltipTable
-                    columns={[formatColumn]}
+                    columns={toTooltipTableColumns(formatColumn)}
                     totals={[totalValue]}
                     rows={sortedHoverPoints.map(
                         ({ point, seriesName: name, seriesColor }) => {

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBars.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBars.tsx
@@ -38,6 +38,7 @@ import {
     TooltipTable,
     makeTooltipRoundingNotice,
     makeTooltipToleranceNotice,
+    toTooltipTableColumns,
 } from "../tooltip/Tooltip"
 import {
     Bar,
@@ -608,7 +609,7 @@ export class StackedDiscreteBars
                     dismiss={() => (this.tooltipState.target = null)}
                 >
                     <TooltipTable
-                        columns={[this.formatColumn]}
+                        columns={toTooltipTableColumns(this.formatColumn)}
                         totals={[item.totalValue]}
                         rows={item.bars.map((bar) => {
                             const {
@@ -623,7 +624,7 @@ export class StackedDiscreteBars
                                 blurred,
                                 focused: name === target.seriesName,
                                 values: [!blurred ? value : undefined],
-                                notice:
+                                originalTime:
                                     !blurred && time !== targetTime
                                         ? timeColumn.formatValue(time)
                                         : undefined,

--- a/packages/@ourworldindata/grapher/src/tooltip/Tooltip.tsx
+++ b/packages/@ourworldindata/grapher/src/tooltip/Tooltip.tsx
@@ -17,7 +17,7 @@ import {
     TooltipContext,
     TooltipFooterIcon,
 } from "./TooltipProps"
-import { IconCircledS } from "./TooltipContents.js"
+import { SignificanceIcon } from "./TooltipContents.js"
 
 export * from "./TooltipContents.js"
 export { TooltipState } from "./TooltipState.js"
@@ -286,7 +286,7 @@ function TooltipIcon({
         ))
         .with(TooltipFooterIcon.Significance, () => (
             <div className="icon">
-                <IconCircledS />
+                <SignificanceIcon />
             </div>
         ))
         .with(TooltipFooterIcon.None, () => null)

--- a/packages/@ourworldindata/grapher/src/tooltip/TooltipProps.ts
+++ b/packages/@ourworldindata/grapher/src/tooltip/TooltipProps.ts
@@ -1,8 +1,7 @@
 import * as React from "react"
-import { CoreColumn } from "@ourworldindata/core-table"
 import {
     GrapherTooltipAnchor,
-    TickFormattingOptions,
+    GrapherTrendArrowDirection,
 } from "@ourworldindata/utils"
 import { IObservableValue } from "mobx"
 
@@ -51,32 +50,41 @@ export interface TooltipProps {
 }
 
 export interface TooltipValueProps {
-    column: CoreColumn
-    value?: number | string
+    label?: string
+    unit?: string
+    value?: string
     color?: string
     isProjection?: boolean
-    notice?: number | string // actual year data was drawn from (when ≠ target year)
+    originalTime?: string // actual year data was drawn from (when ≠ target year)
+    isRoundedToSignificantFigures?: boolean
     showSignificanceSuperscript?: boolean // show significance-s superscript if applicable
-    labelVariant?: "name+unit" | "unit-only"
+    labelVariant?: "label+unit" | "unit-only"
 }
 
 export interface TooltipValueRangeProps {
-    column: CoreColumn
-    values: (number | string | undefined)[]
+    label?: string
+    unit?: string
+    values: [string | undefined, string | undefined]
+    trend?: GrapherTrendArrowDirection
     colors?: string[] // value colors, matched by indices
-    notice?: (number | string | undefined)[] // actual year data was drawn from (when ≠ target year)
+    originalTimes?: (string | undefined)[] // actual year data was drawn from (when ≠ target year)
+    isRoundedToSignificantFigures?: boolean
     showSignificanceSuperscript?: boolean // show significance-s superscript if applicable
-    labelVariant?: "name+unit" | "unit-only"
+    labelVariant?: "label+unit" | "unit-only"
 }
 
 export interface TooltipTableProps {
-    columns: CoreColumn[]
+    columns: TooltipTableColumn[]
     rows: TooltipTableRow[]
     totals?: (number | undefined)[]
-    format?: TickFormattingOptions
 }
 
-export interface TooltipTableRow {
+interface TooltipTableColumn {
+    label: string
+    formatValue: (value: unknown) => string
+}
+
+interface TooltipTableRow {
     name: string
     annotation?: string
     swatch?: {
@@ -86,8 +94,18 @@ export interface TooltipTableRow {
     focused?: boolean // highlighted (based on hovered series in chart)
     blurred?: boolean // greyed out (typically due to missing data)
     striped?: boolean // use textured swatch (to show data is extrapolated)
-    notice?: string | number // actual year data was drawn (when ≠ target year)
+    originalTime?: string // actual year data was drawn (when ≠ target year)
     values: (string | number | undefined)[]
+}
+
+export interface TooltipVariableProps {
+    label?: string
+    unit?: string
+    color?: string
+    isProjection?: boolean
+    originalTimes?: (string | undefined)[]
+    labelVariant?: "label+unit" | "unit-only"
+    children?: React.ReactNode
 }
 
 export interface TooltipTableData {


### PR DESCRIPTION
Refactor the tooltip content component such that they can be used without OWID's data structures. This is useful if Grapher's tooltips are used outside of Grapher.