### PR TITLE
📜 improve documentation for gdocs for agents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,3 +45,11 @@ Some key directories, going roughly along the dependency chain from the most sta
 Our main datastore is a mysql 8 database. The documentation for this lives in db/docs - there is README.md file which is a good overview and starting point, then one TABLE-NAME.yml file per table describing the table in more detail. ALWAYS list the directory db/docs/ to understand which tables are available and read the relevant table description files before constructing a query or writing a migration.
 
 You can run (read only) queries against the database with `yarn query "QUERY TEXT"` - e.g. if you need to understand the contents of a table of the cardinality of various tables.
+
+# Additional documentation
+
+More details of our gdocs pipeline are described in these files:
+
+- ./docs/agent-guidelines/gdocs-cms-pipeline.md - detailed overview of our archieml pipeline from gdocs to our database. Read this before you work on gdocs related things.
+- ./docs/agent-guidelines/gdocs-class-hierarchy.md - overview of the different types of gdocs and how they differ and how to create new types.
+- ./docs/agent-guidelines/gdocs-attachments.md - outlines the attachments mechanism and how we use it to give the react components that ultimately render our site the necessary context

--- a/docs/agent-guidelines/gdocs-attachments.md
+++ b/docs/agent-guidelines/gdocs-attachments.md
@@ -1,0 +1,92 @@
+# Google Docs Attachments
+
+Attachments are the extra bits of data that accompany a rendered Google Doc: linked authors, referenced charts, image metadata, donor lists, etc. They are loaded on the server alongside the document content and exposed to React pages through the `AttachmentsContext`. This document describes how attachments are prepared, how pages consume them, and the current constraints of the system.
+
+## Where Attachments Are Loaded
+
+All Google Doc subclasses inherit the attachment workflow from `GdocBase` (`db/model/Gdoc/GdocBase.ts`):
+
+1. `loadState(knex)` orchestrates attachment loading **after** the document has been parsed into enriched blocks.
+2. Each helper method populates a different slice of state on the instance:
+    - `loadLinkedAuthors` → `linkedAuthors`: batched lookup of published author pages via `getMinimalAuthorsByNames`.
+    - `loadLinkedDocuments` → `linkedDocuments`: single query (`getMinimalGdocPostsByIds`) for referenced Google Docs.
+    - `loadImageMetadataFromDB` → `imageMetadata`: batch query (`getImageMetadataByFilenames`) driven by filenames extracted from blocks, linked docs, and referenced authors.
+    - `loadLinkedCharts` → `linkedCharts`: fetches Grapher, Explorer, or MultiDim configs for all linked slugs. (Currently an `O(n)` set of queries; see limitations below.)
+    - `loadLinkedIndicators` → `linkedIndicators`: derives indicator metadata for datapage-linked charts.
+    - `loadNarrativeChartsInfo` → `linkedNarrativeCharts`: fetches metadata for referenced narrative charts.
+    - Subclass overrides `_loadSubclassAttachments` to append type-specific data (e.g., donor names, homepage metrics, latest insights, author “latest work” tiles).
+3. `validate` runs after attachments are loaded so that missing metadata (images, authors, links, etc.) can trigger contextual errors.
+
+Because attachments are populated directly onto the `GdocBase` instance, they are automatically included in `extractGdocPageData` (`packages/@ourworldindata/utils/src/Util.ts:1314`), which shapes the payload handed to React pages.
+
+## How Pages Receive Attachments
+
+### Single-document pages
+
+`OwidGdoc` (`site/gdocs/OwidGdoc.tsx:70`) wraps the rendered page with `AttachmentsContext.Provider`, passing through the attachment fields exposed on `OwidGdocPageProps`. Individual blocks and components consume the context via helper hooks in `site/gdocs/utils.ts`:
+
+- `useLinkedAuthor`, `useLinkedDocument`, `useLinkedChart`, `useLinkedIndicator`
+- `useImage`, `useDonors`, `useLinkedNarrativeChart`
+
+Examples:
+
+- The “All Charts” block pulls `relatedCharts` and `tags` from the context to render the key-charts grid (`site/gdocs/components/AllCharts.tsx`).
+- The research-and-writing block reads `latestWorkLinks` to show author content (`site/gdocs/components/ResearchAndWriting.tsx`).
+- Homepage components depend on `homepageMetadata` and `latestDataInsights` to render counts and cards.
+
+### Multi-document contexts
+
+Some pages aggregate attachments from multiple sources before providing them:
+
+- `DataInsightsIndexPageContent` merges image metadata, authors, charts, and linked documents from every data insight on the page before creating a single provider (`site/DataInsightsIndexPageContent.tsx:103`).
+- MultiDim datapage views use the same context to expose chart image metadata to components that reuse shared rendering code (`site/multiDim/MultiDimDataPageContent.tsx:380`).
+- Static rendering (`baker/siteRenderers.tsx`) injects attachments when baking HTML, including tombstone pages.
+
+Pages that do not rely on Google Docs (e.g., WordPress articles) bypass this system entirely.
+
+## Subclass-specific Attachments
+
+- **`GdocPost`** uses `_loadSubclassAttachments` to fetch `relatedCharts` when the document contains an “all charts” block and has tags (`db/model/Gdoc/GdocPost.ts:140`). It also exposes parsed FAQ content through `_getSubclassEnrichedBlocks`.
+- **`GdocDataInsight`** fetches `latestDataInsights` plus their image metadata so that we can surface related insights or previews (`db/model/Gdoc/GdocDataInsight.ts:55`).
+- **`GdocHomepage`** collects site metrics (`homepageMetadata`) and recent insights each time the homepage is loaded (`db/model/Gdoc/GdocHomepage.ts:61`).
+- **`GdocAbout`** loads donor names when the document references a donors block (`db/model/Gdoc/GdocAbout.ts:20`).
+- **`GdocAuthor`** retrieves “latest work” cards and associated images (`db/model/Gdoc/GdocAuthor.ts:76`).
+- **`GdocAnnouncement`** currently only inherits the base attachments.
+
+## Limitations and Trade-offs
+
+- **Multiple round-trips for charts**: `loadLinkedCharts` still performs one query per grapher slug (`db/model/Gdoc/GdocBase.ts:744`). The inline TODO notes we should batch this into a single query; today, heavily linked posts can trigger dozens of round-trips.
+- **Sequential loading**: `loadState` awaits each attachment loader in order. Dependencies (e.g., indicators rely on charts) require this sequencing, but it means high-latency queries delay the entire load. There is no concurrency between independent loaders.
+- **No cross-document caching**: Attachments are recomputed per request. Rendering the homepage and the data insights index in the same bake run will fetch the latest insights twice.
+- **Published-only lookups**: author attachments only consider published author pages with matching titles; unpublished authors cause validation warnings but no attachment data.
+- **Attachment payload growth**: every attachment is serialized into the page payload. Documents that link to many charts, images, or related posts can substantially increase the JSON footprint.
+- **Index aggregation is shallow**: pages like the data insights index simply merge attachment maps (`_.merge`) and deduplicate authors by name. Conflicts are resolved by last-write wins, which is acceptable for current use cases but can mask discrepancies if two insights embed different metadata for the same slug.
+- **Subclass fetches are eager**: homepage and data insight pages always trigger their extra queries (latest insights, site metrics) even if the blocks are hidden or unused in a given template.
+
+## Batch vs. Single-item Fetches
+
+| Attachment type           | Loader                            | Query strategy                         |
+| ------------------------- | --------------------------------- | -------------------------------------- |
+| Authors                   | `loadLinkedAuthors`               | Single `IN` clause on author titles    |
+| Linked documents          | `loadLinkedDocuments`             | Single `IN` clause on document IDs     |
+| Images                    | `loadImageMetadataFromDB`         | Single `IN` clause on filenames        |
+| Grapher / Explorer charts | `loadLinkedCharts`                | **Per-slug lookup** (`Promise.all`)    |
+| Indicators                | `loadLinkedIndicators`            | Batched query using indicator IDs      |
+| Narrative charts          | `loadNarrativeChartsInfo`         | Single batched query                   |
+| Related charts            | `GdocPost.loadRelatedCharts`      | Batched query filtered by tags         |
+| Latest insights           | `getLatestDataInsights`           | Single query + batched image lookup    |
+| Author latest work        | `GdocAuthor.loadLatestWorkImages` | Single query for work + batched images |
+
+Understanding these hotspots helps when optimising for new features. For example, when adding another attachment type, prefer the existing “batch with `IN` clause” pattern to avoid the N+1 behaviour that currently exists for charts.
+
+## Extending Attachments
+
+When a new block or document type needs auxiliary data:
+
+1. Add fields to the relevant `OwidGdoc…` interface in `packages/@ourworldindata/types`.
+2. Populate those fields during `_loadSubclassAttachments` (or a new helper called in `loadState`).
+3. Expose the data through `extractGdocPageData`.
+4. Consume it via `AttachmentsContext` on the front-end.
+5. If necessary, update `DataInsightsIndexPageContent`, `baker/siteRenderers`, or other aggregate providers so multi-document pages pass through the new data.
+
+Keep an eye on batching (avoid per-item lookups), payload size, and validation requirements as you extend the attachment system.

--- a/docs/agent-guidelines/gdocs-class-hierarchy.md
+++ b/docs/agent-guidelines/gdocs-class-hierarchy.md
@@ -1,0 +1,91 @@
+# Gdocs Class Hierarchy
+
+This note complements the Google Docs CMS pipeline overview by mapping the server-side class structure that models Google Docs content. All classes live in `db/model/Gdoc/` and ultimately persist to the `posts_gdocs` table.
+
+## Base Class: `GdocBase`
+
+`GdocBase` (`db/model/Gdoc/GdocBase.ts`) implements the shared life cycle for every Google Doc type:
+
+- Fetches the document from the Google Docs API (`fetchAndEnrichGdoc`), records the `revisionId`, and converts the document to enriched JSON (`gdocToArchie` → `archieToEnriched`).
+- Provides shared state: `content`, `linkedCharts`, `linkedIndicators`, `linkedDocuments`, `imageMetadata`, `latestDataInsights`, `errors`, etc.
+- Coordinates attachment loading (`loadLinkedCharts`, `loadLinkedIndicators`, `loadLinkedDocuments`, `loadImageMetadataFromDB`, `loadNarrativeChartsInfo`).
+- Enforces cross-cutting validation (`validate`) including whitespace checks, linked author verification, image metadata completeness, and link integrity.
+- Offers hook methods that subclasses override:
+    - `_getSubclassEnrichedBlocks` to expose extra content for markdown/export.
+    - `_enrichSubclassContent` for post-parse transformations.
+    - `_validateSubclass` for type-specific validation.
+    - `_loadSubclassAttachments` for bespoke data fetches.
+    - `typeSpecificFilenames` / `typeSpecificUrls` to augment dependency discovery.
+- Supplies computed helpers such as `enrichedBlockSources`, `linkedImageFilenames`, and `links` that downstream code uses for rendering and dependency tracking.
+
+`GdocBase` does not assume a concrete `OwidGdocType`; subclasses are responsible for shaping their `content` and validation rules.
+
+## Subclasses
+
+### `GdocPost` (`db/model/Gdoc/GdocPost.ts`)
+
+- Represents the majority of articles (article, topic page, linear topic page, fragment).
+- Generates derived structures: table of contents (`generateToc`), sticky nav (`generateStickyNav`), citations (`formatCitation`), FAQ parsing (`parseFaqs`), and summary text blocks.
+- Exposes FAQ, reference, and deprecation notice blocks via `_getSubclassEnrichedBlocks` for markdown conversion.
+- Validates required tags for certain components and ensures linked charts/indicators are present.
+
+### `GdocDataInsight` (`db/model/Gdoc/GdocDataInsight.ts`)
+
+- Focused on short-form insights highlighting a single chart or dataset.
+- Enforces presence of `approved-by` metadata and tracks optional URLs (`grapher-url`, `narrative-chart`, `figma-url`).
+- Loads latest data insight metadata and companion image information for preview panels.
+
+### `GdocHomepage` (`db/model/Gdoc/GdocHomepage.ts`)
+
+- Models the public homepage.
+- Validates that only one homepage is published at a time.
+- Loads aggregate site metrics (chart count, topic count, tag graph) plus latest data insights for homepage modules.
+
+### `GdocAbout` (`db/model/Gdoc/GdocAbout.ts`)
+
+- Used for about-style pages that may embed donor acknowledgements.
+- Crawls the enriched block tree to detect donor blocks and, if present, loads donor names via `getPublicDonorNames`.
+
+### `GdocAuthor` (`db/model/Gdoc/GdocAuthor.ts`)
+
+- Represents author profile pages.
+- Normalises HTML summary fields (bio) into enriched text, parses socials (`parseSocials`), and exposes these blocks to the markdown/export pipeline.
+- Loads the author’s latest work (with fallback featured image) and associated image metadata.
+- Warns when bio or social information is missing.
+
+### `GdocAnnouncement` (`db/model/Gdoc/GdocAnnouncement.ts`)
+
+- Lightweight wrapper for announcements; currently only inherits shared behaviour and reuses latest data insight metadata.
+
+## Factory and Registration
+
+- `GdocFactory.gdocFromJSON` maps database rows to subclass instances based on `content.type`. When a document is first ingested, `createGdocAndInsertIntoDb` instantiates `GdocBase`, fetches Google Docs content, then rehydrates the correct subclass via `loadGdocFromGdocBase`.
+- `GdocFactory` also exposes helpers to list published instances of specific types (authors, data insights, homepages).
+
+## Adding a New Gdoc Type
+
+When introducing another document type:
+
+1. **Define the type**
+    - Add a new enum entry to `OwidGdocType` (`packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts`) and extend any related type definitions (content interface, minimal interface, etc.).
+
+2. **Implement a subclass**
+    - Create `db/model/Gdoc/GdocYourType.ts` extending `GdocBase`.
+    - Specify `content` with the correct TypeScript interface and override hooks for enrichment, validation, attachment loading, and dependency discovery as needed.
+
+3. **Register the subclass**
+    - Update `GdocFactory.gdocFromJSON` and `GdocFactory.loadGdocFromGdocBase` to route the new `OwidGdocType` to your class.
+    - Wire any listing helpers (similar to `getPublishedDataInsights`) if the type needs querying endpoints.
+
+4. **Update parsing expectations**
+    - Ensure the ArchieML schema used by authors is supported by `rawToEnriched.ts` and `htmlToEnriched.ts`. Add or adjust block parsers if the new type introduces bespoke components.
+
+5. **Extend validation & admin UI**
+    - Provide subclass-specific validation messages by overriding `_validateSubclass`.
+    - Adjust the admin interface if new front-matter fields or components need bespoke handling.
+
+6. **Add tests and documentation**
+    - Extend `db/gdocTests.test.ts` (or add new tests) to cover parsing and round-tripping.
+    - Document authoring expectations in internal guides or ArchieML reference docs.
+
+By following this pattern, new document types get the full lifecycle support—fetching, parsing, validation, enrichment, and persistence—while keeping behaviour encapsulated in targeted subclasses.

--- a/docs/agent-guidelines/gdocs-cms-pipeline.md
+++ b/docs/agent-guidelines/gdocs-cms-pipeline.md
@@ -1,0 +1,127 @@
+# Google Docs CMS Pipeline
+
+This document explains how content written in Google Docs travels through our ingestion pipeline before it is rendered on the site or written to MySQL. It focuses on implementation details, the layout of the relevant code, and quirks that have evolved as we keep the Google authoring experience in sync with our ArchieML tooling.
+
+## Source Code Map
+
+- `db/model/Gdoc/` — end-to-end pipeline code. Key files are:
+    - `GdocBase.ts` and the subtype classes (e.g. `GdocPost.ts`, `GdocDataInsight.ts`) for fetching documents, attaching related metadata, validation, and persistence hooks.
+    - `gdocToArchie.ts` for converting the Google Docs JSON AST into ArchieML-compatible text.
+    - `archieToEnriched.ts`, `rawToEnriched.ts`, and `htmlToEnriched.ts` for parsing ArchieML output into our enriched JSON block model.
+    - `rawToArchie.ts` and `enrichedToRaw.ts` for the inverse conversions used by tests and some editing tools.
+- `db/OwidGoogleAuth.ts` — Google service account configuration.
+- `db/gdocTests.test.ts` — Vitest coverage for the parsing steps.
+- `db/docs/posts_gdocs.yml` — database table documentation for the final stored format.
+
+Supporting type definitions live in `packages/@ourworldindata/types/src/gdocTypes/` and shared utilities for spans, links, etc. are in `packages/utils`.
+
+## Authentication and Entry Points
+
+Service account credentials from `settings/serverSettings.js` are wrapped by `OwidGoogleAuth` to produce cached, scope-limited `GoogleAuth` instances (`getGoogleReadonlyAuth` for ingestion, `getGoogleReadWriteAuth` when we need to write back to Docs).
+
+The two most common ingestion entry points are:
+
+1. `createGdocAndInsertIntoDb` in `GdocFactory.ts`, which fetches the latest version of a Google Doc and stores it in `posts_gdocs`.
+2. `loadGdocFromGdocBase`, which hydrates a `GdocBase` (or subtype) either from Google Docs (`contentSource === GdocsContentSource.Gdocs`) or from existing database rows.
+
+Both pathways call `GdocBase.fetchAndEnrichGdoc`, so the pipeline described below runs every time we ingest or refresh a document.
+
+## Pipeline Overview
+
+### 1. Fetch the Google Doc (`GdocBase.fetchAndEnrichGdoc`)
+
+We request the document via `docs.documents.get` with `suggestionsViewMode: "PREVIEW_WITHOUT_SUGGESTIONS"` to avoid inline suggestion noise. The method caches the returned `revisionId` for change detection and then hands the raw Google Docs `Schema$Document` object to the conversion layer.
+
+### 2. Convert the Google AST to ArchieML (`gdocToArchie.ts`)
+
+Google Docs returns a deeply nested AST that captures formatting, suggestions, and layout. We map it to ArchieML-oriented plain text while retaining rich inline semantics by serialising spans to HTML:
+
+- **Paragraphs and lists** — `paragraphToString` walks each `Schema$Paragraph`, checks bullet metadata, and wraps lists in `[.list] … []` groups the way ArchieML expects. `context.isInList` ensures we emit the closing `[]` whenever we leave a list.
+- **Headings** — Google’s named styles are turned into Archie `heading` blocks using `OwidRawGdocBlockToArchieMLString`.
+- **Inline formatting** — `parseParagraph` builds `Span` trees (links, italics, bold, underline, superscript, subscript, dod references, guided chart links) and serialises them to HTML with `spanToHtmlString`. HTML is the temporary carrier that survives the ArchieML parser even though Archie is block-only.
+- **Horizontal rules** — direct map to `{.horizontal-rule}` blocks.
+- **Tables** — Google tables are only consumed when authors precede them with a `{.table}` block. That sentinel flips `context.isInTable`, letting `tableToString` emit structured Archie table rows. Without it, we skip the table entirely (protecting incidental layout tables).
+- **Other quirks** — we strip excess Google formatting objects, collapse repeated newlines, and explicitly close lists when a paragraph did not do so.
+
+The result is an ArchieML document string with HTML inline fragments.
+
+### 3. Parse ArchieML to the “raw” block tree (`archieToEnriched.ts`)
+
+We pre-process the Archie text before loading it:
+
+- **Inline references** — `{ref}…{/ref}` syntax is expanded by `extractRefs`. Inline references are hashed to stable IDs, replaced with numbered `<a class="ref"><sup>…</sup></a>` tags, and their content is queued so it can be appended to `refs`.
+- **Whitespace inside links** — strip pure whitespace anchor tags and move leading whitespace outside of the `<a>` tag.
+- **Front matter normalisation** — `lowercaseObjectKeys` makes front matter case-insensitive (so `Title:` works), `"true"/"false"` are coerced to booleans, and any front matter value with HTML is run through `extractUrl` so the canonical href is used.
+
+`archieml.load` gives us arrays of `OwidRawGdocBlock` instances. We convert each via `parseRawBlocksToEnrichedBlocks`, producing `OwidEnrichedGdocBlock` nodes with validated props and `parseErrors` arrays.
+
+Finally, we merge ref definitions (`parseRefs`), normalise author lists (`parseAuthors`), and allow subtype-specific enrichment via the `additionalEnrichmentFunction` callback supplied by subclasses.
+
+### 4. HTML and span handling (`htmlToEnriched.ts`)
+
+Many raw blocks contain HTML fields. We parse them with Cheerio and map DOM nodes back to span nodes or block components:
+
+- **Inline spans** — anchors, bold, italic, underline, superscript, subscript, quotes, guided-chart links, and detail-on-demand references map to dedicated span types. Unknown tags fall back to `span-fallback` so formatting is preserved even if we do not explicitly support it yet.
+- **Paragraphs** — become `text` blocks merging their child spans.
+- **Lists** — `<ul>` and `<ol>` items are transformed into Archie `list` / `numbered-list` blocks; we surface errors when list items contain unsupported markup.
+- **Figures** — we expect an `<img>` plus optional `<figcaption>`. Captions are parsed as rich text; file names have size suffixes stripped (`-1280x840` etc.). Missing `<img>` or multiple `<figcaption>` tags add parse errors.
+- **Callout heuristics** — `<div>` elements with class names containing `pcrm` (legacy “warning boxes”) are converted into `callout` blocks, promoting the first heading to the callout title.
+- **Prominent links** — blockquotes that mention “related chart” and contain a Grapher link are rewritten as `prominent-link` components.
+- **Tables & embeds** — unsupported tables are wrapped as raw HTML blocks (`raw-html-table__container`), while `<iframe>` Grapher embeds, `<svg>`, `<video>`, etc. become HTML blocks or chart references depending on the URL.
+- **Whitespace trimming** — `withoutEmptyOrWhitespaceOnlyTextBlocks` removes empty spans so that incidental authoring whitespace does not create empty nodes.
+
+These utilities are reused across raw parsers so that every component (aside, callout, card grids, etc.) expresses its requirements in terms of spans and enriched blocks.
+
+### 5. Component-specific parsing and validation (`rawToEnriched.ts`)
+
+`parseRawBlocksToEnrichedBlocks` matches block types with exhaustive `ts-pattern` clauses. Each parser enforces structure and reports actionable parse errors:
+
+- **Charts (`.chart`, `.narrative-chart`, `.key-indicator`, `.guided-chart`)** ensure URLs resolve, optional heights are numbers, and query params look sane.
+- **Lists and text** reuse `htmlToSpans`, but `parseText` additionally warns when links still point to `owid.cloud`.
+- **Tables** validate templates and sizes against `tableTemplates` / `tableSizes`, then recurse into cell content.
+- **Headings** split title and supertitle using the legacy vertical tab separator, then parse span trees for each part.
+- **Research & writing, FAQs, topic page intros, data insights, etc.** perform bespoke validation (e.g., required authors for data insights, FAQ block constraints).
+
+Every enriched block carries a `parseErrors` array so downstream code and the admin UI can surface issues without failing ingestion.
+
+### 6. Subclass enrichment and metadata load
+
+`GdocBase` provides helpers that subclasses override:
+
+- `_enrichSubclassContent` can attach derived data (e.g., `GdocPost` generates a TOC, sticky nav, renders summary HTML into spans, and parses FAQs).
+- `_getSubclassEnrichedBlocks` allows subclasses to expose extra blocks (FAQ content, references) for markdown export and search indexing.
+- Validation hooks (e.g., ensuring topic pages have tags, linked charts exist) live in `_validateSubclass`.
+
+`GdocBase` also loads linked charts, indicators, documents, authors, and image metadata after the content is parsed so we have everything needed for rendering and previews.
+
+### 7. Persistence (`GdocFactory.ts`)
+
+After enrichment and validation, `upsertGdoc` serialises the enriched content to JSON, records the revision in `posts_gdocs`, and updates helper tables (`posts_gdocs_components`, `posts_gdocs_links`, `posts_gdocs_x_images`, etc.). Markdown fallback text is generated via `enrichedBlocksToMarkdown`.
+
+## Key Quirks and Edge Cases
+
+- **Inline styling retention** — all Google inline styles are mapped to HTML tags before running through ArchieML so that we keep precise spans (bold, italic, underline, superscript, subscript, quotes, detail-on-demand links, guided chart links). Subscripts and superscripts specifically map to `<sub>` / `<sup>` and later to `span-subscript` / `span-superscript` nodes (see `spanToHtmlString` and `htmlToEnriched.ts`).
+- **List delimiters** — Google lists auto-close; to keep Archie response deterministic we track `context.isInList` and emit `[]` when the next paragraph is not a list item.
+- **Tables require opt-in** — Only tables preceded by `{.table}` are parsed into structured blocks. Otherwise we assume they are layout tables and drop them to avoid surprising structure in the output.
+- **Heading supertitles** — We still rely on the vertical tab (`\u000b`) separator to distinguish supertitles, so authors must avoid using that character inside nested spans.
+- **Footnotes** — Inline `{ref}` blocks hash their content to a stable ID, letting multiple mentions reuse the same footnote number. Missing definitions or unused IDs surface explicit errors in the admin.
+- **Legacy callouts & prominent links** — Because authors historically used ad-hoc markup, we heuristically upgrade known patterns (e.g., `.pcrm` divs, “related chart” blockquotes).
+- **URL hygiene** — `parseText` warns on `owid.cloud` URLs so we catch staging leftovers early, and front matter links always resolve to their `<a href>` targets.
+- **Whitespace handling** — `GdocBase.validate` guards against vertical tabs, carriage returns, and tabs sneaking into serialized JSON to prevent rendering issues.
+
+## Testing and Debugging
+
+- Run `yarn test run db/gdocTests.test.ts --reporter dot` to execute ingestion-focused unit tests.
+- For ad-hoc experiments, `devTools/markdownTest/markdown.ts` can parse a database row into enriched blocks.
+- The database schema docs in `db/docs/posts_gdocs.yml` summarise the stored format and companion tables (`posts_gdocs_components`, `posts_gdocs_links`, etc.).
+
+## Extending the Pipeline
+
+1. Add or update type definitions in `packages/@ourworldindata/types/src/gdocTypes/ArchieMlComponents.ts` and `types/src/gdocTypes/Gdoc.ts`.
+2. Teach `gdocToArchie` how to serialise any new Google Docs constructs (if required) by producing appropriate `OwidRawGdocBlock` objects.
+3. Implement a parser in `rawToEnriched.ts` with strict validation and targeted `parseErrors`.
+4. Update `htmlToEnriched.ts` if the block carries inline HTML that needs bespoke handling.
+5. Cover the new behaviour with unit tests in `db/gdocTests.test.ts`.
+6. Consider whether subclasses need additional enrichment, validation, or derived metadata.
+
+By following these steps we keep the ingestion pipeline deterministic while preserving the rich authoring experience our authors expect inside Google Docs.


### PR DESCRIPTION
Adds 3 documentation files that outline various quirks about our gdocs pipeline to agents (but also humans :) ). One each explains the overall gdocs - html -archieml pipeline; the gdocs class hierarchy; and the gdocs attachments system.