### PR TITLE
Serialize archive context only once

### DIFF
--- a/baker/archival/README.md
+++ b/baker/archival/README.md
@@ -118,11 +118,11 @@ This works as follows:
 
 When `ARCHIVE_BASE_URL` is set, we provide information about the latest archived version (if any) to the data page / grapher page.
 
-This information is of the type `ArchivedChartOrArchivePageMeta`, which can be one of two things:
+This information is of the type `ArchiveContext`, which can be one of two things:
 
 - When in a normal (_live_) bake, this is going to be basic information about the last archived version, like its URL and date. The object has `{ type: "archived-page-version" }`.
 - When in an archival bake, there is extended information relevant for rendering the archived page, like the previous archived version (for backwards navigation), and also the runtime and static asset maps. The object has `{ type: "archive-page" }`.
-    - In this case, you can also conveniently access this information through the `window._OWID_ARCHIVE_INFO` variable.
+- You can also conveniently access this information through the `window._OWID_ARCHIVE_CONTEXT` variable.
 
 This information is then used to compute the citation text, and in the latter case also for other considerations like the archive navigation bar.
 

--- a/site/DataPageV2.tsx
+++ b/site/DataPageV2.tsx
@@ -162,7 +162,6 @@ export const DataPageV2 = (props: {
                                     datapageData,
                                     faqEntries,
                                     canonicalUrl,
-                                    archiveContext,
                                     tagToSlugMap: minimalTagToSlugMap,
                                     imageMetadata,
                                 }
@@ -187,7 +186,7 @@ export const DataPageV2 = (props: {
                 <SiteFooter
                     context={SiteFooterContext.dataPageV2}
                     isPreviewing={isPreviewing}
-                    archiveInfo={isOnArchivalPage ? archiveContext : undefined}
+                    archiveContext={archiveContext}
                 />
                 <script
                     dangerouslySetInnerHTML={{

--- a/site/ExplorerPage.tsx
+++ b/site/ExplorerPage.tsx
@@ -115,7 +115,7 @@ const explorerConstants = ${serializeJSONForHTML(
         },
         EXPLORER_CONSTANTS_DELIMITER
     )}
-const archiveContext = ${JSON.stringify(archiveContext)};
+const archiveContext = window._OWID_ARCHIVE_CONTEXT
 window.Explorer.renderSingleExplorerOnExplorerPage(
     explorerProgram,
     grapherConfigs,
@@ -152,7 +152,7 @@ window.Explorer.renderSingleExplorerOnExplorerPage(
                 <SiteFooter
                     context={SiteFooterContext.explorerPage}
                     isPreviewing={props.isPreviewing}
-                    archiveInfo={isOnArchivalPage ? archiveContext : undefined}
+                    archiveContext={archiveContext}
                 />
                 <script
                     type="module"

--- a/site/GrapherPage.tsx
+++ b/site/GrapherPage.tsx
@@ -94,7 +94,7 @@ export const GrapherPage = (props: {
         adminBaseUrl: ADMIN_BASE_URL,
         bakedGrapherURL: BAKED_GRAPHER_URL,
     })}
-const archiveContext = ${JSON.stringify(archiveContext || undefined)}
+const archiveContext = window._OWID_ARCHIVE_CONTEXT
 const isPreviewing = ${isPreviewing}
 window.renderSingleGrapherOnGrapherPage(jsonConfig, "${DATA_API_URL}", { archiveContext, isPreviewing })`
 
@@ -199,7 +199,7 @@ window.renderSingleGrapherOnGrapherPage(jsonConfig, "${DATA_API_URL}", { archive
                 </main>
                 <SiteFooter
                     context={SiteFooterContext.grapherPage}
-                    archiveInfo={isOnArchivalPage ? archiveContext : undefined}
+                    archiveContext={archiveContext}
                     isPreviewing={isPreviewing}
                 />
                 <script

--- a/site/SiteFooter.tsx
+++ b/site/SiteFooter.tsx
@@ -1,9 +1,6 @@
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faRss } from "@fortawesome/free-solid-svg-icons"
-import {
-    ArchiveMetaInformation,
-    SiteFooterContext,
-} from "@ourworldindata/utils"
+import { ArchiveContext, SiteFooterContext } from "@ourworldindata/types"
 import { viteAssetsForSite } from "./viteUtils.js"
 import { ScriptLoadErrorDetector } from "./NoJSDetector.js"
 import { ABOUT_LINKS, PROD_URL, RSS_FEEDS, SOCIALS } from "./SiteConstants.js"
@@ -19,7 +16,7 @@ interface SiteFooterProps {
     context?: SiteFooterContext
     debug?: boolean
     isPreviewing?: boolean
-    archiveInfo?: ArchiveMetaInformation
+    archiveContext?: ArchiveContext
 }
 
 const linkBaseUrl = IS_ARCHIVE ? PROD_URL : ""
@@ -109,10 +106,15 @@ const FooterLinkColumnsArchive = () => (
 )
 
 export const SiteFooter = (props: SiteFooterProps) => {
+    const archiveContext = props.archiveContext
+    const isOnArchivalPage = archiveContext?.type === "archive-page"
+    const staticAssetMap = isOnArchivalPage
+        ? archiveContext?.assets?.static
+        : undefined
     const scripts: string[] = []
-    if (props.archiveInfo)
+    if (archiveContext)
         scripts.push(
-            `window._OWID_ARCHIVE_INFO = ${JSON.stringify(props.archiveInfo)};`
+            `window._OWID_ARCHIVE_CONTEXT = ${JSON.stringify(archiveContext)};`
         )
 
     scripts.push(
@@ -186,7 +188,7 @@ export const SiteFooter = (props: SiteFooterProps) => {
                         </a>
                     </div>
                 </div>
-                {props.archiveInfo ? (
+                {isOnArchivalPage ? (
                     <FooterLinkColumnsArchive />
                 ) : (
                     <FooterLinkColumnsProd />
@@ -210,11 +212,7 @@ export const SiteFooter = (props: SiteFooterProps) => {
                 </div>
 
                 <div className={SITE_TOOLS_CLASS} />
-                {
-                    viteAssetsForSite({
-                        staticAssetMap: props.archiveInfo?.assets?.static,
-                    }).forFooter
-                }
+                {viteAssetsForSite({ staticAssetMap }).forFooter}
                 <ScriptLoadErrorDetector />
                 <script
                     type="module"

--- a/site/detailsOnDemand.tsx
+++ b/site/detailsOnDemand.tsx
@@ -21,7 +21,7 @@ type Tippyfied<E> = E & {
 declare global {
     interface Window {
         details?: DetailDictionary
-        _OWID_ARCHIVE_INFO?: ArchiveMetaInformation
+        _OWID_ARCHIVE_CONTEXT?: ArchiveMetaInformation
     }
 }
 
@@ -37,7 +37,7 @@ export async function runDetailsOnDemand(
 
     const runtimeAssetMap =
         (typeof window !== "undefined" &&
-            window._OWID_ARCHIVE_INFO?.assets?.runtime) ||
+            window._OWID_ARCHIVE_CONTEXT?.assets?.runtime) ||
         undefined
 
     const dodFetchUrl = shouldFetchFromAdminApi

--- a/site/gdocs/OwidGdocPage.tsx
+++ b/site/gdocs/OwidGdocPage.tsx
@@ -337,7 +337,7 @@ export default function OwidGdocPage({
                     context={SiteFooterContext.gdocsDocument}
                     debug={debug}
                     isPreviewing={isPreviewing}
-                    archiveInfo={isOnArchivalPage ? archiveContext : undefined}
+                    archiveContext={archiveContext}
                 />
             </body>
         </Html>

--- a/site/multiDim/MultiDimDataPage.tsx
+++ b/site/multiDim/MultiDimDataPage.tsx
@@ -51,7 +51,6 @@ export function MultiDimDataPage({
         imageMetadata,
         tagToSlugMap,
         isPreviewing,
-        archiveContext,
     }
     const imageUrl: string = urljoin(
         baseUrl || "/",
@@ -134,7 +133,7 @@ export function MultiDimDataPage({
                 <SiteFooter
                     context={SiteFooterContext.multiDimDataPage}
                     isPreviewing={isPreviewing}
-                    archiveInfo={isOnArchivalPage ? archiveContext : undefined}
+                    archiveContext={archiveContext}
                 />
             </body>
         </Html>

--- a/site/runSiteFooterScripts.tsx
+++ b/site/runSiteFooterScripts.tsx
@@ -137,6 +137,7 @@ function hydrateDataPageV2Content({
                 {...props}
                 grapherConfig={grapherConfig}
                 isPreviewing={isPreviewing}
+                archiveContext={window._OWID_ARCHIVE_CONTEXT}
             />
         </DebugProvider>
     )
@@ -209,8 +210,8 @@ function runSiteNavigation(hideDonationFlag?: boolean) {
         }
 
         let archiveInfo: ArchiveMetaInformation | undefined
-        if (window._OWID_ARCHIVE_INFO) {
-            archiveInfo = window._OWID_ARCHIVE_INFO
+        if (window._OWID_ARCHIVE_CONTEXT) {
+            archiveInfo = window._OWID_ARCHIVE_CONTEXT
         }
 
         const root = createRoot(siteNavigationElem)
@@ -247,7 +248,7 @@ const hydrateOwidGdoc = (debug?: boolean, isPreviewing?: boolean) => {
                 <OwidGdoc
                     {...props}
                     isPreviewing={isPreviewing}
-                    archiveContext={window._OWID_ARCHIVE_INFO}
+                    archiveContext={window._OWID_ARCHIVE_CONTEXT}
                 />
             </DebugProvider>
             <AriaAnnouncer />
@@ -269,6 +270,7 @@ const hydrateMultiDimDataPageContent = (isPreviewing?: boolean) => {
                     config={MultiDimDataPageConfig.fromObject(configObj)}
                     {...props}
                     isPreviewing={isPreviewing}
+                    archiveContext={window._OWID_ARCHIVE_CONTEXT}
                 />
             </BrowserRouter>
         </DebugProvider>


### PR DESCRIPTION
In SiteFooter we were serializing the archive context only on archived
pages, i.e. only when it was ArchiveMetaInformation. AFAICT this was
originally done for DoDs, which are handled outside of the normal
component tree and which don't need the archive context on live pages.

For live pages we also need the archive context to use an archive link
in citations and embeds. In this case the archive context is
ArchivedPageVersion. We were serializing it separately for different
kinds of pages, both for archived and live versions, which meant that
the same archive context was serialized twice for archived pages: once
in the footer and once in props of the specific page, which was
unnecessary.

Since we need to put it in a separate global prop on window for DoDs, we
can rely on that prop also for the other use cases and remove the
additional serialization.