### PR TITLE
✨ use short entity names for more chart types

### DIFF
--- a/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChartHelpers.ts
+++ b/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChartHelpers.ts
@@ -1,6 +1,54 @@
 // Pattern IDs should be unique per document (!), not just per grapher instance.
 // Including the color in the id guarantees that the pattern uses the correct color,
+
+import { TextWrap } from "@ourworldindata/components"
+
 // even if it gets resolved to a striped pattern of a different grapher instance.
 export function makeProjectedDataPatternId(color: string): string {
     return `DiscreteBarChart_stripes_${color}`
+}
+
+/**
+ * Creates a TextWrap for discrete bar chart labels with automatic width adjustment.
+ * The function tries to fit the label within the bar height by iteratively expanding
+ * the label width up to a maximum threshold.
+ */
+export function fitLabelToBarHeight({
+    label,
+    barHeight,
+    initialWidth,
+    maxWidth,
+    labelStyle,
+}: {
+    label: string
+    barHeight: number
+    initialWidth: number
+    maxWidth: number
+    labelStyle: { fontSize: number; fontWeight: number }
+}): TextWrap {
+    // Make sure we're dealing with a single-line text fragment
+    const cleanedLabel = label.replace(/\n/g, " ").trim()
+
+    const makeTextWrap = (maxWidth: number): TextWrap =>
+        new TextWrap({ text: cleanedLabel, maxWidth, ...labelStyle })
+
+    let labelWrap = makeTextWrap(initialWidth)
+
+    // Prevent labels from being taller than the bar
+    let step = 0
+    while (
+        labelWrap.height > barHeight &&
+        labelWrap.lines.length > 1 &&
+        step < 10 // safety net
+    ) {
+        const currMaxWidth = labelWrap.maxWidth + 20
+
+        // Labels shouldn't exceed this width
+        if (currMaxWidth > maxWidth) break
+
+        labelWrap = makeTextWrap(currMaxWidth)
+        step += 1
+    }
+
+    return labelWrap
 }

--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChartState.ts
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChartState.ts
@@ -30,6 +30,7 @@ import {
     autoDetectSeriesStrategy,
     autoDetectYColumnSlugs,
     getDefaultFailMessage,
+    getShortNameForEntity,
     makeSelectionArray,
 } from "../chart/ChartUtils"
 import { ColorScheme } from "../color/ColorScheme"
@@ -305,8 +306,9 @@ export class LineChartState implements ChartState, ColorScaleManager {
             hasMultipleEntitiesSelected,
             allowsMultiEntitySelection: canSelectMultipleEntities,
         })
+        const shortEntityName = getShortNameForEntity(entityName)
         const displayName = getDisplayName({
-            entityName,
+            entityName: shortEntityName ?? entityName,
             columnName,
             seriesStrategy,
             hasMultipleEntitiesSelected,

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChartState.ts
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChartState.ts
@@ -15,7 +15,11 @@ import {
     SeriesPoint,
 } from "./ScatterPlotChartConstants"
 import { computed, makeObservable } from "mobx"
-import { autoDetectYColumnSlugs, makeSelectionArray } from "../chart/ChartUtils"
+import {
+    autoDetectYColumnSlugs,
+    getShortNameForEntity,
+    makeSelectionArray,
+} from "../chart/ChartUtils"
 import {
     ChartErrorInfo,
     ColorSchemeName,
@@ -388,9 +392,10 @@ export class ScatterPlotChartState implements ChartState, ColorScaleManager {
         return Object.entries(
             _.groupBy(this.allPointsBeforeEndpointsFilter, (p) => p.entityName)
         ).map(([entityName, points]) => {
+            const shortEntityName = getShortNameForEntity(entityName)
             const series: ScatterSeries = {
                 seriesName: entityName,
-                label: entityName,
+                label: shortEntityName ?? entityName,
                 color: SCATTER_POINT_DEFAULT_COLOR,
                 points,
                 focus: this.focusArray.state(entityName),

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChartState.ts
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChartState.ts
@@ -226,8 +226,9 @@ export class SlopeChartState implements ChartState {
             hasMultipleEntitiesSelected,
             allowsMultiEntitySelection: canSelectMultipleEntities,
         })
+        const shortEntityName = getShortNameForEntity(entityName)
         const displayName = getDisplayName({
-            entityName: getShortNameForEntity(entityName) ?? entityName,
+            entityName: shortEntityName ?? entityName,
             columnName,
             seriesStrategy,
             hasMultipleEntitiesSelected,

--- a/packages/@ourworldindata/grapher/src/stackedCharts/AbstractStackedChartState.ts
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/AbstractStackedChartState.ts
@@ -25,6 +25,7 @@ import {
     autoDetectSeriesStrategy,
     autoDetectYColumnSlugs,
     getDefaultFailMessage,
+    getShortNameForEntity,
     makeSelectionArray,
 } from "../chart/ChartUtils.js"
 import { ColorSchemes } from "../color/ColorSchemes.js"
@@ -168,6 +169,7 @@ export abstract class AbstractStackedChartState implements ChartState {
                 return {
                     isProjection,
                     seriesName: entityName,
+                    shortEntityName: getShortNameForEntity(entityName),
                     rows: owidRowsByEntityName.get(entityName) || [],
                     focus: this.focusArray.state(entityName),
                 }

--- a/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChart.tsx
@@ -67,9 +67,6 @@ const MARKER_MARGIN: number = 4
 const MARKER_AREA_HEIGHT: number = 25
 const MAX_LABEL_COUNT: number = 20
 
-// if an entity name exceeds this width, we use the short name instead (if available)
-const SOFT_MAX_LABEL_WIDTH = 60
-
 export type MarimekkoChartProps = ChartComponentProps<MarimekkoChartState>
 
 @observer
@@ -579,16 +576,9 @@ export class MarimekkoChart
         fontSize: number,
         isSelected: boolean
     ): LabelCandidate {
-        let label = item.entityName
-        let labelBounds = Bounds.forText(label, {
-            fontSize,
-        })
-        if (labelBounds.width > SOFT_MAX_LABEL_WIDTH && item.shortEntityName) {
-            label = item.shortEntityName
-            labelBounds = Bounds.forText(label, {
-                fontSize,
-            })
-        }
+        const label = item.shortEntityName ?? item.entityName
+        const labelBounds = Bounds.forText(label, { fontSize })
+
         return {
             item: item,
             label,

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
@@ -10,7 +10,7 @@ import {
     exposeInstanceOnWindow,
 } from "@ourworldindata/utils"
 import { computed, action, observable, makeObservable } from "mobx"
-import { SeriesName } from "@ourworldindata/types"
+import { SeriesName, SeriesStrategy } from "@ourworldindata/types"
 import {
     BASE_FONT_SIZE,
     DEFAULT_GRAPHER_BOUNDS,
@@ -153,11 +153,17 @@ export class StackedAreaChart
     }
 
     @computed private get lineLegendSeries(): LineLabelSeries[] {
+        const isEntityStrategy =
+            this.chartState.seriesStrategy === SeriesStrategy.entity
+
         return this.stackedSeries
             .map((series, index) => ({
                 color: series.color,
                 seriesName: series.seriesName,
-                label: series.seriesName,
+                label:
+                    isEntityStrategy && series.shortEntityName
+                        ? series.shortEntityName
+                        : series.seriesName,
                 yValue: this.chartState.midpoints[index],
                 isAllZeros: series.isAllZeros,
                 hover: this.hoverStateForSeries(series),

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedConstants.ts
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedConstants.ts
@@ -57,6 +57,7 @@ export interface StackedSeries<PositionType extends StackedPointPositionType>
     columnSlug?: string
     isProjection?: boolean
     isAllZeros?: boolean
+    shortEntityName?: string
     focus?: InteractionState
 }
 


### PR DESCRIPTION
Fixes #5596 

Uses short names for all chart types except for the following:

* Stacked bar charts (since entity names only appear in the legend)
* Map charts (since labels only appear in the tooltip)

We used to display the short version of an entity name only if the actual name was longer than a certain threshold. But I think we can assume that if a short name is available, we want to use it in the chart area. The longer version will still be used in the tooltip, entity selector, and data table.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #5641 
- <kbd>&nbsp;1&nbsp;</kbd> #5637 👈 
<!-- GitButler Footer Boundary Bottom -->

