### PR TITLE
🐛 fix overlapping discrete bar chart labels

### DIFF
--- a/packages/@ourworldindata/components/src/TextWrap/TextWrap.tsx
+++ b/packages/@ourworldindata/components/src/TextWrap/TextWrap.tsx
@@ -46,6 +46,10 @@ function startsWithNewline(text: string): boolean {
     return /^\n/.test(text)
 }
 
+/**
+ * Shortens text to fit within a target width using binary search.
+ * Returns the longest substring that fits within the target width.
+ */
 export const shortenForTargetWidth = (
     text: string,
     targetWidth: number,
@@ -55,7 +59,7 @@ export const shortenForTargetWidth = (
         fontFamily?: FontFamily
     } = {}
 ): string => {
-    // use binary search to find the largest substring that fits within the target width
+    // Use binary search to find the largest substring that fits within the target width
     let low = 0
     let high = text.length
     while (low <= high) {
@@ -68,6 +72,26 @@ export const shortenForTargetWidth = (
         }
     }
     return text.slice(0, low - 1)
+}
+
+/** Shortens text to fit within the target width and appends an ellipsis (…) */
+export const shortenWithEllipsis = (
+    text: string,
+    targetWidth: number,
+    fontSettings: {
+        fontSize?: number
+        fontWeight?: number
+        fontFamily?: FontFamily
+    } = {}
+): string => {
+    const ellipsis = "…"
+    const ellipsisWidth = Bounds.forText(ellipsis, fontSettings).width
+    const truncatedText = shortenForTargetWidth(
+        text,
+        targetWidth - ellipsisWidth,
+        fontSettings
+    )
+    return `${truncatedText}${ellipsis}`
 }
 
 export class TextWrap {

--- a/packages/@ourworldindata/components/src/index.ts
+++ b/packages/@ourworldindata/components/src/index.ts
@@ -1,4 +1,4 @@
-export { TextWrap, shortenForTargetWidth } from "./TextWrap/TextWrap.js"
+export { TextWrap, shortenWithEllipsis } from "./TextWrap/TextWrap.js"
 
 export {
     MarkdownTextWrap,

--- a/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChart.tsx
@@ -40,8 +40,8 @@ import {
 import { DiscreteBarChartState } from "./DiscreteBarChartState"
 import { ChartComponentProps } from "../chart/ChartTypeMap.js"
 import {
-    wrapLabelForHeight,
     makeProjectedDataPatternId,
+    enrichSeriesWithLabels,
 } from "./DiscreteBarChartHelpers"
 import { OwidTable } from "@ourworldindata/core-table"
 import { HorizontalAxis } from "../axis/Axis"
@@ -125,17 +125,12 @@ export class DiscreteBarChart
     }
 
     @computed get sizedSeries(): DiscreteBarSeries[] {
-        return this.series.map((series) => {
-            const label = series.shortEntityName ?? series.entityName
-            const labelWrap = wrapLabelForHeight({
-                label,
-                availableHeight: this.bounds.height / this.barCount,
-                minWidth: 0.3 * this.bounds.width,
-                maxWidth: 0.66 * this.bounds.width,
-                fontSettings: this.entityLabelStyle,
-            })
-
-            return { ...series, label: labelWrap }
+        return enrichSeriesWithLabels({
+            series: this.series,
+            availableHeightPerSeries: this.bounds.height / this.barCount,
+            minLabelWidth: 0.3 * this.bounds.width,
+            maxLabelWidth: 0.66 * this.bounds.width,
+            fontSettings: this.entityLabelStyle,
         })
     }
 

--- a/packages/@ourworldindata/grapher/src/facet/FacetChart.tsx
+++ b/packages/@ourworldindata/grapher/src/facet/FacetChart.tsx
@@ -16,7 +16,7 @@ import {
     exposeInstanceOnWindow,
     SplitBoundsPadding,
 } from "@ourworldindata/utils"
-import { shortenForTargetWidth } from "@ourworldindata/components"
+import { shortenWithEllipsis } from "@ourworldindata/components"
 import { action, computed, makeObservable, observable } from "mobx"
 import {
     BASE_FONT_SIZE,
@@ -876,16 +876,9 @@ export class FacetChart
         )
 
         if (fontSize > idealFontSize) {
-            const ellipsisWidth = Bounds.forText("…", {
-                fontSize,
-            }).width
-
-            label = `${shortenForTargetWidth(
-                label,
-                availableWidth - ellipsisWidth,
-                { fontSize }
-            )}…`
+            label = shortenWithEllipsis(label, availableWidth, { fontSize })
         }
+
         return { fontSize, shortenedLabel: label }
     }
 

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBars.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBars.tsx
@@ -51,7 +51,7 @@ import { HorizontalAxis } from "../axis/Axis"
 import { HashMap, NodeGroup } from "react-move"
 import { easeQuadOut } from "d3-ease"
 import { StackedDiscreteBarChartState } from "./StackedDiscreteBarChartState"
-import { wrapLabelForHeight } from "../barCharts/DiscreteBarChartHelpers.js"
+import { enrichSeriesWithLabels } from "../barCharts/DiscreteBarChartHelpers.js"
 
 const BAR_SPACING_FACTOR = 0.35
 
@@ -241,17 +241,12 @@ export class StackedDiscreteBars
     }
 
     @computed private get sizedItems(): readonly SizedItem[] {
-        return this.chartState.sortedItems.map((item) => {
-            const label = item.shortEntityName ?? item.entityName
-            const labelWrap = wrapLabelForHeight({
-                label,
-                availableHeight: this.bounds.height / this.barCount,
-                minWidth: 0.3 * this.bounds.width,
-                maxWidth: 0.66 * this.bounds.width,
-                fontSettings: this.labelStyle,
-            })
-
-            return { ...item, label: labelWrap }
+        return enrichSeriesWithLabels({
+            series: this.chartState.sortedItems,
+            availableHeightPerSeries: this.bounds.height / this.barCount,
+            minLabelWidth: 0.3 * this.bounds.width,
+            maxLabelWidth: 0.66 * this.bounds.width,
+            fontSettings: this.labelStyle,
         })
     }
 


### PR DESCRIPTION
Fixes #5461

Improves the labelling algorithm for discrete bar charts in cases with limited space (see screenshots).

It works in three steps: First, we find the minimum width that produces at most the available number of lines. If that doesn't work (i.e., we're at maximum width, but the text wraps into more lines than available), we reduce the font size until the text fits. If the font size becomes too small to read, we truncate the label as a last resort.

I'm not convinced that truncating lines is the right approach because it hides content, but using a comically small font size, which is difficult to read, also hides content in a way. So I went with the ellipsis solution hoping that we will only need this in very few cases.

The new strategy introduces line breaks a bit more frequently than the previous one. In some cases, that's ok, in other cases it would be better to avoid line breaks or, ideally, to implement them in a balanced manner, ensuring that all lines have approximately the same length. Idk, but for now, I think this is a net positive.

Examples:
- http://staging-site-fix-overlapping-labels/grapher/rate-of-violent-deaths-non-state-societies
- http://staging-site-fix-overlapping-labels/grapher/grocery-bag-environmental-impact

| Before | After |
|--------|--------|
| <img width="378" height="600" alt="Screenshot 2025-11-07 at 17 15 04" src="https://github.com/user-attachments/assets/16e9f332-e347-448e-b93d-cbe3e9405a9e" /> | <img width="378" height="600" alt="Screenshot 2025-11-10 at 11 23 11" src="https://github.com/user-attachments/assets/9f116b71-2ed0-43e9-b40f-90ebf452e3bc" /> | 
| <img width="378" height="600" alt="Screenshot 2025-11-07 at 17 14 28" src="https://github.com/user-attachments/assets/ccc528d6-af53-48fd-b5f1-904002b2859d" /> | <img width="378" height="600" alt="Screenshot 2025-11-10 at 11 23 25" src="https://github.com/user-attachments/assets/5bd4bd1f-b50e-4475-bfaa-21ea3036b695" /> | 

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #5641 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #5637 
<!-- GitButler Footer Boundary Bottom -->

