### PR TITLE
🐛 Fix markdown regeneration for Gdocs

### DIFF
--- a/adminSiteServer/test-files/gdoc-markdown-api-test.json
+++ b/adminSiteServer/test-files/gdoc-markdown-api-test.json
@@ -1,0 +1,637 @@
+{
+    "size": 0,
+    "data": {
+        "title": "Minimal test",
+        "body": {
+            "content": [
+                {
+                    "endIndex": 1,
+                    "sectionBreak": {
+                        "sectionStyle": {
+                            "columnSeparatorStyle": "NONE",
+                            "contentDirection": "LEFT_TO_RIGHT",
+                            "sectionType": "CONTINUOUS"
+                        }
+                    }
+                },
+                {
+                    "startIndex": 1,
+                    "endIndex": 22,
+                    "paragraph": {
+                        "elements": [
+                            {
+                                "startIndex": 1,
+                                "endIndex": 22,
+                                "textRun": {
+                                    "content": "Title: Basic article\n",
+                                    "textStyle": {}
+                                }
+                            }
+                        ],
+                        "paragraphStyle": {
+                            "namedStyleType": "NORMAL_TEXT",
+                            "direction": "LEFT_TO_RIGHT"
+                        }
+                    }
+                },
+                {
+                    "startIndex": 22,
+                    "endIndex": 69,
+                    "paragraph": {
+                        "elements": [
+                            {
+                                "startIndex": 22,
+                                "endIndex": 69,
+                                "textRun": {
+                                    "content": "Subtitle: This will be shown beneath the title\n",
+                                    "textStyle": {}
+                                }
+                            }
+                        ],
+                        "paragraphStyle": {
+                            "namedStyleType": "NORMAL_TEXT",
+                            "direction": "LEFT_TO_RIGHT"
+                        }
+                    }
+                },
+                {
+                    "startIndex": 69,
+                    "endIndex": 122,
+                    "paragraph": {
+                        "elements": [
+                            {
+                                "startIndex": 69,
+                                "endIndex": 122,
+                                "textRun": {
+                                    "content": "Excerpt: This will be shown on social media previews\n",
+                                    "textStyle": {}
+                                }
+                            }
+                        ],
+                        "paragraphStyle": {
+                            "namedStyleType": "NORMAL_TEXT",
+                            "direction": "LEFT_TO_RIGHT"
+                        }
+                    }
+                },
+                {
+                    "startIndex": 122,
+                    "endIndex": 149,
+                    "paragraph": {
+                        "elements": [
+                            {
+                                "startIndex": 122,
+                                "endIndex": 149,
+                                "textRun": {
+                                    "content": "authors: Our World In Data\n",
+                                    "textStyle": {}
+                                }
+                            }
+                        ],
+                        "paragraphStyle": {
+                            "namedStyleType": "NORMAL_TEXT",
+                            "direction": "LEFT_TO_RIGHT"
+                        }
+                    }
+                },
+                {
+                    "startIndex": 149,
+                    "endIndex": 175,
+                    "paragraph": {
+                        "elements": [
+                            {
+                                "startIndex": 149,
+                                "endIndex": 175,
+                                "textRun": {
+                                    "content": "dateline: January 1, 2023\n",
+                                    "textStyle": {}
+                                }
+                            }
+                        ],
+                        "paragraphStyle": {
+                            "namedStyleType": "NORMAL_TEXT",
+                            "direction": "LEFT_TO_RIGHT"
+                        }
+                    }
+                },
+                {
+                    "startIndex": 175,
+                    "endIndex": 190,
+                    "paragraph": {
+                        "elements": [
+                            {
+                                "startIndex": 175,
+                                "endIndex": 190,
+                                "textRun": {
+                                    "content": "type: article \n",
+                                    "textStyle": {}
+                                }
+                            }
+                        ],
+                        "paragraphStyle": {
+                            "namedStyleType": "NORMAL_TEXT",
+                            "direction": "LEFT_TO_RIGHT"
+                        }
+                    }
+                },
+                {
+                    "startIndex": 190,
+                    "endIndex": 191,
+                    "paragraph": {
+                        "elements": [
+                            {
+                                "startIndex": 190,
+                                "endIndex": 191,
+                                "textRun": {
+                                    "content": "\n",
+                                    "textStyle": {}
+                                }
+                            }
+                        ],
+                        "paragraphStyle": {
+                            "namedStyleType": "NORMAL_TEXT",
+                            "direction": "LEFT_TO_RIGHT"
+                        }
+                    }
+                },
+                {
+                    "startIndex": 191,
+                    "endIndex": 199,
+                    "paragraph": {
+                        "elements": [
+                            {
+                                "startIndex": 191,
+                                "endIndex": 199,
+                                "textRun": {
+                                    "content": "[+body]\n",
+                                    "textStyle": {}
+                                }
+                            }
+                        ],
+                        "paragraphStyle": {
+                            "namedStyleType": "NORMAL_TEXT",
+                            "direction": "LEFT_TO_RIGHT"
+                        }
+                    }
+                },
+                {
+                    "startIndex": 199,
+                    "endIndex": 222,
+                    "paragraph": {
+                        "elements": [
+                            {
+                                "startIndex": 199,
+                                "endIndex": 222,
+                                "textRun": {
+                                    "content": "This is a minimal test\n",
+                                    "textStyle": {}
+                                }
+                            }
+                        ],
+                        "paragraphStyle": {
+                            "namedStyleType": "NORMAL_TEXT",
+                            "direction": "LEFT_TO_RIGHT"
+                        }
+                    }
+                },
+                {
+                    "startIndex": 222,
+                    "endIndex": 225,
+                    "paragraph": {
+                        "elements": [
+                            {
+                                "startIndex": 222,
+                                "endIndex": 225,
+                                "textRun": {
+                                    "content": "[]\n",
+                                    "textStyle": {}
+                                }
+                            }
+                        ],
+                        "paragraphStyle": {
+                            "namedStyleType": "NORMAL_TEXT",
+                            "direction": "LEFT_TO_RIGHT"
+                        }
+                    }
+                }
+            ]
+        },
+        "documentStyle": {
+            "background": {
+                "color": {}
+            },
+            "pageNumberStart": 1,
+            "marginTop": {
+                "magnitude": 72,
+                "unit": "PT"
+            },
+            "marginBottom": {
+                "magnitude": 72,
+                "unit": "PT"
+            },
+            "marginRight": {
+                "magnitude": 72,
+                "unit": "PT"
+            },
+            "marginLeft": {
+                "magnitude": 72,
+                "unit": "PT"
+            },
+            "pageSize": {
+                "height": {
+                    "magnitude": 792,
+                    "unit": "PT"
+                },
+                "width": {
+                    "magnitude": 612,
+                    "unit": "PT"
+                }
+            },
+            "marginHeader": {
+                "magnitude": 36,
+                "unit": "PT"
+            },
+            "marginFooter": {
+                "magnitude": 36,
+                "unit": "PT"
+            },
+            "useCustomHeaderFooterMargins": true,
+            "documentFormat": {
+                "documentMode": "PAGELESS"
+            }
+        },
+        "namedStyles": {
+            "styles": [
+                {
+                    "namedStyleType": "NORMAL_TEXT",
+                    "textStyle": {
+                        "bold": false,
+                        "italic": false,
+                        "underline": false,
+                        "strikethrough": false,
+                        "smallCaps": false,
+                        "backgroundColor": {},
+                        "foregroundColor": {
+                            "color": {
+                                "rgbColor": {}
+                            }
+                        },
+                        "fontSize": {
+                            "magnitude": 11,
+                            "unit": "PT"
+                        },
+                        "weightedFontFamily": {
+                            "fontFamily": "Arial",
+                            "weight": 400
+                        },
+                        "baselineOffset": "NONE"
+                    },
+                    "paragraphStyle": {
+                        "namedStyleType": "NORMAL_TEXT",
+                        "alignment": "START",
+                        "lineSpacing": 115,
+                        "direction": "LEFT_TO_RIGHT",
+                        "spacingMode": "COLLAPSE_LISTS",
+                        "spaceAbove": {
+                            "unit": "PT"
+                        },
+                        "spaceBelow": {
+                            "unit": "PT"
+                        },
+                        "borderBetween": {
+                            "color": {},
+                            "width": {
+                                "unit": "PT"
+                            },
+                            "padding": {
+                                "unit": "PT"
+                            },
+                            "dashStyle": "SOLID"
+                        },
+                        "borderTop": {
+                            "color": {},
+                            "width": {
+                                "unit": "PT"
+                            },
+                            "padding": {
+                                "unit": "PT"
+                            },
+                            "dashStyle": "SOLID"
+                        },
+                        "borderBottom": {
+                            "color": {},
+                            "width": {
+                                "unit": "PT"
+                            },
+                            "padding": {
+                                "unit": "PT"
+                            },
+                            "dashStyle": "SOLID"
+                        },
+                        "borderLeft": {
+                            "color": {},
+                            "width": {
+                                "unit": "PT"
+                            },
+                            "padding": {
+                                "unit": "PT"
+                            },
+                            "dashStyle": "SOLID"
+                        },
+                        "borderRight": {
+                            "color": {},
+                            "width": {
+                                "unit": "PT"
+                            },
+                            "padding": {
+                                "unit": "PT"
+                            },
+                            "dashStyle": "SOLID"
+                        },
+                        "indentFirstLine": {
+                            "unit": "PT"
+                        },
+                        "indentStart": {
+                            "unit": "PT"
+                        },
+                        "indentEnd": {
+                            "unit": "PT"
+                        },
+                        "keepLinesTogether": false,
+                        "keepWithNext": false,
+                        "avoidWidowAndOrphan": true,
+                        "shading": {
+                            "backgroundColor": {}
+                        },
+                        "pageBreakBefore": false
+                    }
+                },
+                {
+                    "namedStyleType": "HEADING_1",
+                    "textStyle": {
+                        "fontSize": {
+                            "magnitude": 20,
+                            "unit": "PT"
+                        }
+                    },
+                    "paragraphStyle": {
+                        "namedStyleType": "NORMAL_TEXT",
+                        "direction": "LEFT_TO_RIGHT",
+                        "spaceAbove": {
+                            "magnitude": 20,
+                            "unit": "PT"
+                        },
+                        "spaceBelow": {
+                            "magnitude": 6,
+                            "unit": "PT"
+                        },
+                        "keepLinesTogether": true,
+                        "keepWithNext": true,
+                        "pageBreakBefore": false
+                    }
+                },
+                {
+                    "namedStyleType": "HEADING_2",
+                    "textStyle": {
+                        "bold": false,
+                        "fontSize": {
+                            "magnitude": 16,
+                            "unit": "PT"
+                        }
+                    },
+                    "paragraphStyle": {
+                        "namedStyleType": "NORMAL_TEXT",
+                        "direction": "LEFT_TO_RIGHT",
+                        "spaceAbove": {
+                            "magnitude": 18,
+                            "unit": "PT"
+                        },
+                        "spaceBelow": {
+                            "magnitude": 6,
+                            "unit": "PT"
+                        },
+                        "keepLinesTogether": true,
+                        "keepWithNext": true,
+                        "pageBreakBefore": false
+                    }
+                },
+                {
+                    "namedStyleType": "HEADING_3",
+                    "textStyle": {
+                        "bold": false,
+                        "foregroundColor": {
+                            "color": {
+                                "rgbColor": {
+                                    "red": 0.2627451,
+                                    "green": 0.2627451,
+                                    "blue": 0.2627451
+                                }
+                            }
+                        },
+                        "fontSize": {
+                            "magnitude": 14,
+                            "unit": "PT"
+                        }
+                    },
+                    "paragraphStyle": {
+                        "namedStyleType": "NORMAL_TEXT",
+                        "direction": "LEFT_TO_RIGHT",
+                        "spaceAbove": {
+                            "magnitude": 16,
+                            "unit": "PT"
+                        },
+                        "spaceBelow": {
+                            "magnitude": 4,
+                            "unit": "PT"
+                        },
+                        "keepLinesTogether": true,
+                        "keepWithNext": true,
+                        "pageBreakBefore": false
+                    }
+                },
+                {
+                    "namedStyleType": "HEADING_4",
+                    "textStyle": {
+                        "foregroundColor": {
+                            "color": {
+                                "rgbColor": {
+                                    "red": 0.4,
+                                    "green": 0.4,
+                                    "blue": 0.4
+                                }
+                            }
+                        },
+                        "fontSize": {
+                            "magnitude": 12,
+                            "unit": "PT"
+                        }
+                    },
+                    "paragraphStyle": {
+                        "namedStyleType": "NORMAL_TEXT",
+                        "direction": "LEFT_TO_RIGHT",
+                        "spaceAbove": {
+                            "magnitude": 14,
+                            "unit": "PT"
+                        },
+                        "spaceBelow": {
+                            "magnitude": 4,
+                            "unit": "PT"
+                        },
+                        "keepLinesTogether": true,
+                        "keepWithNext": true,
+                        "pageBreakBefore": false
+                    }
+                },
+                {
+                    "namedStyleType": "HEADING_5",
+                    "textStyle": {
+                        "foregroundColor": {
+                            "color": {
+                                "rgbColor": {
+                                    "red": 0.4,
+                                    "green": 0.4,
+                                    "blue": 0.4
+                                }
+                            }
+                        },
+                        "fontSize": {
+                            "magnitude": 11,
+                            "unit": "PT"
+                        }
+                    },
+                    "paragraphStyle": {
+                        "namedStyleType": "NORMAL_TEXT",
+                        "direction": "LEFT_TO_RIGHT",
+                        "spaceAbove": {
+                            "magnitude": 12,
+                            "unit": "PT"
+                        },
+                        "spaceBelow": {
+                            "magnitude": 4,
+                            "unit": "PT"
+                        },
+                        "keepLinesTogether": true,
+                        "keepWithNext": true,
+                        "pageBreakBefore": false
+                    }
+                },
+                {
+                    "namedStyleType": "HEADING_6",
+                    "textStyle": {
+                        "italic": true,
+                        "foregroundColor": {
+                            "color": {
+                                "rgbColor": {
+                                    "red": 0.4,
+                                    "green": 0.4,
+                                    "blue": 0.4
+                                }
+                            }
+                        },
+                        "fontSize": {
+                            "magnitude": 11,
+                            "unit": "PT"
+                        }
+                    },
+                    "paragraphStyle": {
+                        "namedStyleType": "NORMAL_TEXT",
+                        "direction": "LEFT_TO_RIGHT",
+                        "spaceAbove": {
+                            "magnitude": 12,
+                            "unit": "PT"
+                        },
+                        "spaceBelow": {
+                            "magnitude": 4,
+                            "unit": "PT"
+                        },
+                        "keepLinesTogether": true,
+                        "keepWithNext": true,
+                        "pageBreakBefore": false
+                    }
+                },
+                {
+                    "namedStyleType": "TITLE",
+                    "textStyle": {
+                        "fontSize": {
+                            "magnitude": 26,
+                            "unit": "PT"
+                        }
+                    },
+                    "paragraphStyle": {
+                        "namedStyleType": "NORMAL_TEXT",
+                        "direction": "LEFT_TO_RIGHT",
+                        "spaceAbove": {
+                            "unit": "PT"
+                        },
+                        "spaceBelow": {
+                            "magnitude": 3,
+                            "unit": "PT"
+                        },
+                        "keepLinesTogether": true,
+                        "keepWithNext": true,
+                        "pageBreakBefore": false
+                    }
+                },
+                {
+                    "namedStyleType": "SUBTITLE",
+                    "textStyle": {
+                        "italic": false,
+                        "foregroundColor": {
+                            "color": {
+                                "rgbColor": {
+                                    "red": 0.4,
+                                    "green": 0.4,
+                                    "blue": 0.4
+                                }
+                            }
+                        },
+                        "fontSize": {
+                            "magnitude": 15,
+                            "unit": "PT"
+                        },
+                        "weightedFontFamily": {
+                            "fontFamily": "Arial",
+                            "weight": 400
+                        }
+                    },
+                    "paragraphStyle": {
+                        "namedStyleType": "NORMAL_TEXT",
+                        "direction": "LEFT_TO_RIGHT",
+                        "spaceAbove": {
+                            "unit": "PT"
+                        },
+                        "spaceBelow": {
+                            "magnitude": 16,
+                            "unit": "PT"
+                        },
+                        "keepLinesTogether": true,
+                        "keepWithNext": true,
+                        "pageBreakBefore": false
+                    }
+                }
+            ]
+        },
+        "revisionId": "AOuX7-ZytodW5OO_f2JcOr5nchw0nB72WANBFEL7vaKdubCX8pe57Fxjh6cJTgwaucWcNli-V3GfWmlKGWNK3w",
+        "suggestionsViewMode": "PREVIEW_WITHOUT_SUGGESTIONS",
+        "documentId": "1TZOYb5VeZXdK65yQE5u9XHPtQJ9kxudmTnEAY3vcup0"
+    },
+    "config": {
+        "url": "https://docs.googleapis.com/v1/documents/1TZOYb5VeZXdK65yQE5u9XHPtQJ9kxudmTnEAY3vcup0?suggestionsViewMode=PREVIEW_WITHOUT_SUGGESTIONS",
+        "method": "GET",
+        "apiVersion": "",
+        "userAgentDirectives": [
+            {
+                "product": "google-api-nodejs-client",
+                "version": "8.0.2-rc.0",
+                "comment": "gzip"
+            }
+        ],
+        "headers": {},
+        "params": {
+            "suggestionsViewMode": "PREVIEW_WITHOUT_SUGGESTIONS"
+        },
+        "retry": true,
+        "responseType": "unknown"
+    },
+    "headers": {}
+}

--- a/adminSiteServer/tests/gdocs-markdown.test.ts
+++ b/adminSiteServer/tests/gdocs-markdown.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest"
+import { getAdminTestEnv } from "./testEnv.js"
+import {
+    OwidGdocType,
+    PostsGdocsTableName,
+    type DbRawPostGdoc,
+} from "@ourworldindata/types"
+
+const env = getAdminTestEnv()
+
+const makeTextBlock = (text: string) => ({
+    type: "text",
+    value: [
+        {
+            spanType: "span-simple-text",
+            text,
+        },
+    ],
+    parseErrors: [],
+})
+
+describe("Gdoc markdown regeneration via API", { timeout: 20000 }, () => {
+    it("recomputes markdown when saving a published document", async () => {
+        const gdocId = "gdoc-markdown-api-test"
+
+        // Create an empty draft so we have a row in posts_gdocs
+        await env.request({
+            method: "PUT",
+            path: `/gdocs/${gdocId}`,
+        })
+
+        const base = await env.fetchJson(`/gdocs/${gdocId}`)
+
+        const draftPayload = {
+            ...base,
+            slug: "markdown-api-test",
+            revisionId: "rev-draft",
+            published: false,
+            publishedAt: null,
+            markdown: "outdated draft markdown",
+            content: {
+                ...base.content,
+                type: OwidGdocType.Article,
+                title: "Markdown API test",
+                body: [makeTextBlock("First published text")],
+                authors: base.content.authors?.length
+                    ? base.content.authors
+                    : ["Our World in Data"],
+            },
+        }
+
+        await env.request({
+            method: "PUT",
+            path: `/gdocs/${gdocId}`,
+            body: JSON.stringify(draftPayload),
+        })
+
+        const firstSave = (await env
+            .testKnex(PostsGdocsTableName)
+            .where({ id: gdocId })
+            .first()) as DbRawPostGdoc
+        expect(firstSave.markdown).toContain("First published text")
+
+        const updatePayload = {
+            ...draftPayload,
+            revisionId: "rev-update",
+            published: true,
+            publishedAt: new Date("2024-01-01T00:00:00.000Z").toISOString(),
+            markdown: "still stale markdown",
+            content: {
+                ...draftPayload.content,
+                body: [makeTextBlock("Second version of the text")],
+            },
+        }
+
+        await env.request({
+            method: "PUT",
+            path: `/gdocs/${gdocId}`,
+            body: JSON.stringify(updatePayload),
+        })
+
+        const updated = (await env
+            .testKnex(PostsGdocsTableName)
+            .where({ id: gdocId })
+            .first()) as DbRawPostGdoc
+
+        expect(updated.markdown).toContain("Second version of the text")
+        expect(updated.markdown).not.toContain("First published text")
+    })
+})

--- a/db/tests/run-db-tests.sh
+++ b/db/tests/run-db-tests.sh
@@ -11,6 +11,10 @@ if [ -e .env ]; then
     source .env
 fi
 
+# Some developers enable Algolia indexing in their local .env, but it interferes
+# with the db test suite. Since indexing is never needed here, force-disable it.
+export ALGOLIA_INDEXING=false
+
 : "${GRAPHER_TEST_DB_USER:?Need to set GRAPHER_TEST_DB_USER non-empty}"
 : "${GRAPHER_TEST_DB_PASS:?Need to set GRAPHER_TEST_DB_PASS non-empty}"
 : "${GRAPHER_TEST_DB_NAME:?Need to set GRAPHER_TEST_DB_NAME non-empty}"

--- a/devTools/regenerateGdocMarkdown.ts
+++ b/devTools/regenerateGdocMarkdown.ts
@@ -1,0 +1,147 @@
+import * as db from "../db/db.js"
+import parseArgs from "minimist"
+import {
+    PostsGdocsTableName,
+    parsePostsGdocsRow,
+    type DbRawPostGdoc,
+} from "@ourworldindata/types"
+import { gdocFromJSON } from "../db/model/Gdoc/GdocFactory.js"
+
+const DEFAULT_BATCH_SIZE = 50
+
+type CliOptions = {
+    batchSize: number
+    id?: string
+}
+
+function printHelp(): void {
+    console.log(`Regenerate posts_gdocs.markdown from enriched content.
+
+Usage:
+    yarn tsx devTools/regenerateGdocMarkdown.ts [options]
+
+Options:
+    --batch-size <n>    Number of rows to process per query (default: ${DEFAULT_BATCH_SIZE}).
+    --id <gdocId>       Restrict regeneration to a single Google Doc by id.
+    -h, --help          Show this message.
+`)
+}
+
+async function regenerateMarkdown({
+    batchSize,
+    id,
+}: CliOptions): Promise<void> {
+    const knex = db.knexInstance()
+    try {
+        const totalQuery = knex(PostsGdocsTableName)
+        if (id) totalQuery.where({ id })
+        const totalResult = await totalQuery.count<{ total: number | string }>({
+            total: "*",
+        })
+        const total = Number(totalResult?.[0]?.total ?? 0)
+
+        if (total === 0) {
+            console.log(id ? `No gdoc found with id ${id}` : "No gdocs found.")
+            return
+        }
+
+        let offset = 0
+        let processed = 0
+        let updated = 0
+        const failures: { id: string; error: unknown }[] = []
+
+        while (true) {
+            const pageQuery = knex
+                .table<DbRawPostGdoc>(PostsGdocsTableName)
+                .orderBy("id")
+                .limit(batchSize)
+            if (id) {
+                pageQuery.where({ id })
+            } else {
+                pageQuery.offset(offset)
+            }
+
+            const rows = await pageQuery
+            if (!rows.length) break
+
+            for (const row of rows) {
+                processed += 1
+                try {
+                    const enrichedRow = parsePostsGdocsRow(row)
+                    const gdoc = gdocFromJSON(enrichedRow as any)
+                    gdoc.updateMarkdown()
+                    const nextMarkdown = gdoc.markdown ?? null
+                    if (nextMarkdown !== row.markdown) {
+                        await knex
+                            .table(PostsGdocsTableName)
+                            .where({ id: row.id })
+                            .update({
+                                markdown: nextMarkdown,
+                                updatedAt: row.updatedAt,
+                            })
+                        updated += 1
+                    }
+                } catch (error) {
+                    failures.push({ id: row.id, error })
+                    console.error(
+                        `Failed to regenerate markdown for gdoc ${row.id}`,
+                        error
+                    )
+                }
+            }
+
+            if (id) break
+            offset += rows.length
+            console.log(
+                `Processed ${processed}/${total} documents (${updated} updated so far)`
+            )
+        }
+
+        console.log(
+            `Finished regenerating markdown. Updated ${updated} of ${processed} documents. ${processed - updated - failures.length} unchanged.`
+        )
+        if (failures.length) {
+            console.log(
+                `Encountered ${failures.length} errors:\n${failures
+                    .map(
+                        ({ id: gdocId, error }) =>
+                            ` - ${gdocId}: ${(error as Error)?.message ?? error}`
+                    )
+                    .join("\n")}`
+            )
+        }
+    } finally {
+        await db.closeTypeOrmAndKnexConnections()
+    }
+}
+
+function parseCli(): CliOptions | null {
+    const parsed = parseArgs(process.argv.slice(2))
+    if (parsed.h || parsed.help) {
+        printHelp()
+        return null
+    }
+
+    const batchSizeArg = parsed["batch-size"] ?? parsed.batchSize
+    const batchSize = Number(batchSizeArg ?? DEFAULT_BATCH_SIZE)
+    if (!Number.isFinite(batchSize) || batchSize <= 0) {
+        throw new Error("--batch-size must be a positive number")
+    }
+
+    const id = parsed.id ?? parsed._?.[0]
+
+    return { batchSize, id }
+}
+
+async function main(): Promise<void> {
+    try {
+        const options = parseCli()
+        if (!options) return
+        await regenerateMarkdown(options)
+    } catch (error) {
+        console.error(error)
+        process.exitCode = 1
+    }
+}
+
+void main()

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
         "syncCloudflareImages": "tsx --tsconfig tsconfig.tsx.json devTools/cloudflareImagesSync/cloudflareImagesSync.ts",
         "reconstructPostsGdocsComponents": "tsx --tsconfig tsconfig.tsx.json devTools/reconstructPostsGdocsComponents/reconstructPostsGdocsComponents.ts",
         "query": "tsx --tsconfig tsconfig.tsx.json devTools/db-ai-helpers/query.ts",
+        "regenerateGdocMarkdown": "tsx --tsconfig tsconfig.tsx.json devTools/regenerateGdocMarkdown.ts",
         "addIncomingForeignKeys": "tsx --tsconfig tsconfig.tsx.json devTools/db-ai-helpers/addIncomingForeignKeys.ts"
     },
     "dependencies": {


### PR DESCRIPTION
Fixes #5436. Markdown generation was initially an experimental feature, but more and more pieces of our codebase rely on this field being up-to-date. At one point, a refactor must have broken markdown regeneration on post updates. This PR fixes this issue.
