### PR TITLE
fix: hide indicator name again in map tooltips

### DIFF
--- a/packages/@ourworldindata/grapher/src/mapCharts/MapTooltip.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapTooltip.tsx
@@ -349,6 +349,7 @@ function MapTooltipValue({
             value={formattedValue}
             color={color}
             isProjection={isProjection}
+            labelVariant="unit-only"
         />
     )
 }
@@ -381,7 +382,12 @@ function MapTooltipRangeValues({
         : [startDatum?.value, endDatum?.value]
 
     return (
-        <TooltipValueRange column={mapColumn} values={values} colors={colors} />
+        <TooltipValueRange
+            column={mapColumn}
+            values={values}
+            colors={colors}
+            labelVariant="unit-only"
+        />
     )
 }
 


### PR DESCRIPTION
This fixes a regression introduced in #5544 https://github.com/owid/owid-grapher/commit/64fb6392deed9f27fca7663d73ccd4b542ae3f82#diff-204e2ed01cf58c18cf16cfcb19fb363d1f434e19581a3dc38309c90156ba120a.

| Before | After |
|--------|--------|
| <img width="877" height="734" alt="CleanShot 2025-11-10 at 10 42 04" src="https://github.com/user-attachments/assets/9ee138df-0f53-46a0-9531-7a47e2d571df" /> | <img width="877" height="734" alt="CleanShot 2025-11-10 at 10 41 23" src="https://github.com/user-attachments/assets/e32df8c9-3637-41b7-8dc7-3c7f5309cd63" /> |


[Slack context](https://owid.slack.com/archives/C03NV9Z3YSV/p1762762569136889)