### PR TITLE
🐛 drop entities without plottable data

### DIFF
--- a/packages/@ourworldindata/core-table/src/OwidTable.test.ts
+++ b/packages/@ourworldindata/core-table/src/OwidTable.test.ts
@@ -677,3 +677,55 @@ gdp	annotation`
         (table.get("gdp").def as OwidColumnDef).annotationsColumnSlug
     ).toEqual("annotation")
 })
+
+describe("dropEntitiesThatHaveNoDataInAllColumns", () => {
+    it("drops only entities missing data in every specified column", () => {
+        const csv = `year,entityName,gdp,population,lifeExpectancy
+2020,USA,1000,330,78
+2020,China,2000,1400,76
+2020,OnlyGDP,500,,
+2020,OnlyPopulation,,100,
+2020,OnlyLifeExpectancy,,,80
+2020,NoDataAtAll,,,`
+        const table = new OwidTable(csv, [
+            { slug: "gdp", type: ColumnTypeNames.Numeric },
+            { slug: "population", type: ColumnTypeNames.Numeric },
+            { slug: "lifeExpectancy", type: ColumnTypeNames.Numeric },
+            { slug: "year", type: ColumnTypeNames.Year },
+        ])
+
+        const result = table.dropEntitiesThatHaveNoDataInAllColumns([
+            "gdp",
+            "population",
+            "lifeExpectancy",
+        ])
+
+        // Should keep all entities except NoDataAtAll
+        expect(result.availableEntityNames).toEqual([
+            "USA",
+            "China",
+            "OnlyGDP",
+            "OnlyPopulation",
+            "OnlyLifeExpectancy",
+        ])
+    })
+
+    it("filters correctly when checking a subset of columns", () => {
+        const csv = `year,entityName,gdp,population,continent
+2020,USA,1000,330,North America
+2020,China,,1400,Asia
+2020,India,,500,Asia`
+        const table = new OwidTable(csv, [
+            { slug: "gdp", type: ColumnTypeNames.Numeric },
+            { slug: "population", type: ColumnTypeNames.Numeric },
+            { slug: "year", type: ColumnTypeNames.Year },
+            { slug: "continent", type: ColumnTypeNames.Continent },
+        ])
+
+        const result = table.dropEntitiesThatHaveNoDataInAllColumns(["gdp"])
+
+        // Only USA should remain when checking just GDP
+        expect(result.availableEntityNames).toEqual(["USA"])
+        expect(result.numRows).toEqual(1)
+    })
+})

--- a/packages/@ourworldindata/grapher/src/core/GrapherState.test.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.test.ts
@@ -1830,3 +1830,32 @@ describe("tolerance is not applied twice (issue #4891)", () => {
         expect(testColumnValues2015).toEqual([100])
     })
 })
+
+describe("tableAfterAuthorTimelineAndEntityFilter", () => {
+    it("drops entities that have no data in any x or y column", () => {
+        const table = new OwidTable([
+            ["entityName", "year", "x", "y", "color"],
+            ["USA", 2000, 1, 2, "red"],
+            ["Canada", 2000, null, null, "blue"], // No x or y data
+            ["Mexico", 2000, 3, null, "green"], // Has x but no y
+        ])
+
+        const grapher = new GrapherState({
+            table,
+            chartTypes: [GRAPHER_CHART_TYPES.Marimekko],
+            xSlug: "x",
+            ySlugs: "y",
+            colorSlug: "color",
+        })
+
+        const result = grapher.tableAfterAuthorTimelineAndEntityFilter
+        const entityNames = result.availableEntityNames
+
+        // USA should be included (has both x and y data)
+        expect(entityNames).toContain("USA")
+        // Mexico should be included (has x data)
+        expect(entityNames).toContain("Mexico")
+        // Canada should be excluded (has no x or y data, only color)
+        expect(entityNames).not.toContain("Canada")
+    })
+})

--- a/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
@@ -905,14 +905,22 @@ export class GrapherState
 
         // Filter times
         if (
-            this.timelineMinTime === undefined &&
-            this.timelineMaxTime === undefined
+            this.timelineMinTime !== undefined ||
+            this.timelineMaxTime !== undefined
         )
-            return table
-        return table.filterByTimeRange(
-            this.timelineMinTime ?? -Infinity,
-            this.timelineMaxTime ?? Infinity
-        )
+            table = table.filterByTimeRange(
+                this.timelineMinTime ?? -Infinity,
+                this.timelineMaxTime ?? Infinity
+            )
+
+        // Drop entities that have no data in any of the x or y columns
+        // (This can happen if an entity has data only for the color or size column)
+        const slugs = excludeUndefined([...this.yColumnSlugs, this.xColumnSlug])
+        if (slugs.length > 0) {
+            table = table.dropEntitiesThatHaveNoDataInAllColumns(slugs)
+        }
+
+        return table
     }
 
     /** The base data table after author-configured filters have been applied */


### PR DESCRIPTION
Fixes #3492

Some entities only have data for the colour dimension, so they technically exist in the data (which is why they appear in the entity selector), but they're not plotted because they don't have any actual (plottable) data.

The SVG tester reports color differences because after dropping entities, we might miss some color categories and colors are applied in order. For the continents, it would be nice if we ensured that semantic colors are consistent across all charts (e.g. Europe is always denim, etc). This is fixed in the follow up PR

Example: Search for 'Monaco' in https://ourworldindata.org/grapher/gdp-per-capita-worldbank?tab=line&time=1990..2024&country=IND~CHN~MCO~LUX

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 4 in a stack** made with GitButler:
- <kbd>&nbsp;4&nbsp;</kbd> #5672 
- <kbd>&nbsp;3&nbsp;</kbd> #5671 
- <kbd>&nbsp;2&nbsp;</kbd> #5675 
- <kbd>&nbsp;1&nbsp;</kbd> #5649 👈 
<!-- GitButler Footer Boundary Bottom -->

