### PR TITLE
✨ default to the empty selection for Marimekkos and scatters

### DIFF
--- a/packages/@ourworldindata/grapher/src/chart/ChartTabs.ts
+++ b/packages/@ourworldindata/grapher/src/chart/ChartTabs.ts
@@ -169,8 +169,10 @@ export function isValidTabConfigOption(
     return Object.values(GRAPHER_TAB_CONFIG_OPTIONS).includes(candidate as any)
 }
 
-export const isChartTab = (tab: GrapherTabName): boolean =>
+export const isChartTab = (tab: GrapherTabName): tab is GrapherChartType =>
     tab !== GRAPHER_TAB_NAMES.Table && tab !== GRAPHER_TAB_NAMES.WorldMap
 
-export const isMapTab = (tab: GrapherTabName): boolean =>
+export const isMapTab = (
+    tab: GrapherTabName
+): tab is typeof GRAPHER_TAB_NAMES.WorldMap =>
     tab === GRAPHER_TAB_NAMES.WorldMap

--- a/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
@@ -165,3 +165,8 @@ export enum GrapherModal {
 
 export const CHART_TYPES_THAT_SWITCH_TO_DISCRETE_BAR_WHEN_SINGLE_TIME: GrapherChartType[] =
     [GRAPHER_CHART_TYPES.LineChart, GRAPHER_CHART_TYPES.SlopeChart]
+
+export const CHART_TYPES_THAT_SHOW_ALL_ENTITIES: GrapherChartType[] = [
+    GRAPHER_CHART_TYPES.ScatterPlot,
+    GRAPHER_CHART_TYPES.Marimekko,
+]

--- a/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
@@ -209,6 +209,7 @@ import {
     DEFAULT_GRAPHER_HEIGHT,
     STATIC_EXPORT_DETAIL_SPACING,
     DEFAULT_GRAPHER_BOUNDS_SQUARE,
+    CHART_TYPES_THAT_SHOW_ALL_ENTITIES,
 } from "./GrapherConstants.js"
 import { parseGlobeRotation, grapherObjectToQueryParams } from "./GrapherUrl.js"
 import { legacyToCurrentGrapherQueryParams } from "./GrapherUrlMigrations.js"
@@ -879,8 +880,16 @@ export class GrapherState {
         return !this.hideLegend
     }
 
+    private isChartTypeThatShowsAllEntities(
+        chartType: GrapherChartType
+    ): boolean {
+        return CHART_TYPES_THAT_SHOW_ALL_ENTITIES.includes(chartType)
+    }
+
     @computed private get hasChartThatShowsAllEntities(): boolean {
-        return this.hasScatter || this.hasMarimekko
+        return this.validChartTypes.some((chartType) =>
+            this.isChartTypeThatShowsAllEntities(chartType)
+        )
     }
 
     @computed get isOnArchivalPage(): boolean {
@@ -1509,6 +1518,33 @@ export class GrapherState {
         }
     }
 
+    @action.bound private ensureEntitySelectionIsSensibleForTab(
+        tab: GrapherTabName
+    ): void {
+        // No-op if the current tab is a map or table tab
+        if (!isChartTab(tab)) return
+
+        const isChartTypeThatShowsAllEntities =
+            this.isChartTypeThatShowsAllEntities(tab)
+
+        // If the chart show all entities (e.g. scatter plot or Marimekko chart),
+        // then we typically prefer no selection unless the user has explicitly
+        // made changes to the default selection
+        if (
+            isChartTypeThatShowsAllEntities &&
+            !this.areSelectedEntitiesDifferentThanAuthors
+        ) {
+            this.selection.clearSelection()
+        }
+
+        // If the chart type only shows a subset of entities at a time
+        // (e.g. line chart), then an empty selection is not useful, so we
+        // automatically apply the author's selection
+        if (!isChartTypeThatShowsAllEntities && !this.selection.hasSelection) {
+            this.applyOriginalSelectionAsAuthored()
+        }
+    }
+
     @action.bound onChartSwitching(
         _oldTab: GrapherTabName,
         newTab: GrapherTabName
@@ -1519,6 +1555,7 @@ export class GrapherState {
             )
 
         this.ensureTimeHandlesAreSensibleForTab(newTab)
+        this.ensureEntitySelectionIsSensibleForTab(newTab)
     }
 
     @action.bound syncEntitySelectionBetweenChartAndMap(


### PR DESCRIPTION
Fixes #5173

Currently, when you switch from the line chart (or another tab) to the Marimekko tab, the default selection is applied to the Marimekko chart, but we typically prefer an empty selection as the default view for Marimekko charts and scatter plots.

This PR introduces a validation step to ensure the entity selection is sensible for the tab that has been switched to:
-  If you switch to a Marimekko or Scatter tab, the selection is cleared if it hasn't been updated by the user.
-  If you switch to any other tab and the selection is empty, the default selection is re-applied. I did this to prevent situations where switching from a line chart to a Marimekko chart and back to the line chart results in no selected entities. But this is a bit of a drastic change that affects other use cases as well (e.g., if you deselect all entities on the slope and then go to the line chart, the default selection will be reapplied). I think I find this generally useful, but I have low confidence.

All of this only applies to switching between tabs in the UI. The behaviour of URLs remains unchanged. For example, if you [link to the Marimekko tab without a country parameter](http://staging-site-marimekko-selection/grapher/gdp-per-capita-worldbank?tab=marimekko), the default selection will still be applied.

I didn't implement this when I added Marimekkos as second tab because I'm always a bit hesitant to mess with user state. More often than not it creates more problems than it solves. So take this with a grain of salt and please let me know if you can think of a better solution.

Example: https://ourworldindata.org/grapher/gdp-per-capita-worldbank?tab=line