### PR TITLE
Fix external icon in ProminentLink

### DIFF
--- a/site/gdocs/components/ProminentLink.tsx
+++ b/site/gdocs/components/ProminentLink.tsx
@@ -4,7 +4,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faArrowUpRightFromSquare } from "@fortawesome/free-solid-svg-icons"
 import { getLinkType } from "@ourworldindata/components"
 
-import { useLinkedChart, useLinkedDocument } from "../utils.js"
+import { isExternalUrl, useLinkedChart, useLinkedDocument } from "../utils.js"
 import { DocumentContext } from "../DocumentContext.js"
 import { BlockErrorFallback } from "./BlockErrorBoundary.js"
 import { ContentGraphLinkType } from "@ourworldindata/types"
@@ -69,6 +69,7 @@ export const ProminentLink = (props: {
         : "col-start-1 col-end-limit"
 
     const shouldVerticallyCenter = !description
+    const isExternal = isExternalUrl(linkType, href)
 
     return (
         <a className={cx(props.className, "prominent-link")} href={href}>
@@ -92,7 +93,7 @@ export const ProminentLink = (props: {
             >
                 <div className="prominent-link__heading-wrapper">
                     <h3 className="h3-bold">{title}</h3>
-                    {linkType === "url" && (
+                    {isExternal && (
                         <FontAwesomeIcon
                             className="prominent-link__icon-external"
                             icon={faArrowUpRightFromSquare}

--- a/site/gdocs/utils.test.ts
+++ b/site/gdocs/utils.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest"
+import { ContentGraphLinkType } from "@ourworldindata/types"
+import { isExternalUrl } from "./utils.js"
+import { BAKED_BASE_URL } from "../../settings/clientSettings.js"
+
+describe(isExternalUrl, () => {
+    it("returns false when the link type is not a URL", () => {
+        expect(
+            isExternalUrl(ContentGraphLinkType.Gdoc, "https://example.com")
+        ).toBe(false)
+    })
+
+    it("returns false for URLs on the baked origin", () => {
+        expect(
+            isExternalUrl(ContentGraphLinkType.Url, `${BAKED_BASE_URL}/data`)
+        ).toBe(false)
+    })
+
+    it("returns false for relative URLs", () => {
+        expect(isExternalUrl(ContentGraphLinkType.Url, "/data")).toBe(false)
+    })
+
+    it("returns true for external URLs", () => {
+        expect(
+            isExternalUrl(ContentGraphLinkType.Url, "https://example.com/data")
+        ).toBe(true)
+    })
+
+    it("returns false when link origin cannot be determined", () => {
+        expect(isExternalUrl(ContentGraphLinkType.Url, "not-a-valid-url")).toBe(
+            false
+        )
+    })
+})

--- a/site/gdocs/utils.ts
+++ b/site/gdocs/utils.ts
@@ -27,6 +27,26 @@ import { AttachmentsContext } from "./AttachmentsContext.js"
 import { SubnavItem, subnavs } from "../SiteConstants.js"
 import { BAKED_BASE_URL } from "../../settings/clientSettings.js"
 
+const getOrigin = (url: string, base?: string): string | undefined => {
+    try {
+        return new URL(url, base).origin
+    } catch {
+        return undefined
+    }
+}
+
+export function isExternalUrl(
+    linkType: ContentGraphLinkType,
+    url: string
+): boolean {
+    if (linkType !== ContentGraphLinkType.Url) return false
+    const bakedOrigin = getOrigin(BAKED_BASE_URL)
+    if (!bakedOrigin) return false
+    const linkOrigin = getOrigin(url, bakedOrigin)
+    if (!linkOrigin) return false
+    return linkOrigin !== bakedOrigin
+}
+
 export const breadcrumbColorForCoverColor = (
     coverColor: OwidGdocPostContent["cover-color"]
 ): "white" | "blue" => {


### PR DESCRIPTION
Don't show the external icon when the URL is absolute and links to our site, e.g. https://ourworldindata.org/search

## Screenshots / Videos / Diagrams

| Before | After |
|--------|--------|
| <img width="642" height="257" alt="SCR-20251111-kutf" src="https://github.com/user-attachments/assets/d2daea05-5791-42fe-8b60-dd151288cbc6" /> | <img width="639" height="249" alt="image" src="https://github.com/user-attachments/assets/a05a9697-0fba-49e2-91ab-1ece7ab032ee" /> |

## Testing guidance

The gdocs that use internal/external prominent links I tested with: 
- Icon was used incorrectly: https://ourworldindata.org/large-mammals-extinction
- Icon was used correctly: https://ourworldindata.org/about

You have to set production `BAKED_BASE_URL` in `.env` to test it locally:

```
BAKED_BASE_URL=https://ourworldindata.org
```