### PR TITLE
🐛 Improve chart refs

### DIFF
--- a/adminSiteClient/ChartEditor.ts
+++ b/adminSiteClient/ChartEditor.ts
@@ -40,7 +40,11 @@ export interface NarrativeChartMinimalInformation {
 }
 
 export const getFullReferencesCount = (references: References): number => {
-    return Object.values(references).reduce((acc, ref) => acc + ref.length, 0)
+    // Get unique count, because a post can be referenced via the `grapher-url` Data Insight property,
+    // and also in its content directly. We want such cases to appear as one reference.
+    const allRefs = Object.values(references).flat()
+    const uniqueRefs = new Set(allRefs.map((ref) => `${ref.type}:${ref.slug}`))
+    return uniqueRefs.size
 }
 
 export interface ChartEditorManager extends AbstractChartEditorManager {

--- a/adminSiteClient/ChartList.tsx
+++ b/adminSiteClient/ChartList.tsx
@@ -27,6 +27,9 @@ import {
 } from "../adminShared/search.js"
 import { TextField } from "./Forms.js"
 import { ENV } from "../settings/clientSettings.js"
+import { Tooltip } from "antd"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import { faInfoCircle } from "@fortawesome/free-solid-svg-icons"
 
 // These properties are coming from OldChart.ts
 export interface ChartListItem {
@@ -344,6 +347,9 @@ export class ChartList extends React.Component<ChartListProps> {
                                 onClick={handleReferencesCountSortClick}
                             >
                                 references{getReferencesCountSortIndicator()}
+                                <Tooltip title="Only considers published content. This number might differ from the chart editor count, which includes unpublished data insights.">
+                                    <FontAwesomeIcon icon={faInfoCircle} />
+                                </Tooltip>
                             </th>
                             <th></th>
                             <th></th>

--- a/adminSiteClient/EditorReferencesTab.tsx
+++ b/adminSiteClient/EditorReferencesTab.tsx
@@ -10,6 +10,7 @@ import {
 } from "./ChartEditor.js"
 import { computed, action, observable, runInAction, makeObservable } from "mobx"
 import {
+    BAKED_BASE_URL,
     BAKED_GRAPHER_URL,
     GRAPHER_DYNAMIC_THUMBNAIL_URL,
 } from "../settings/clientSettings.js"
@@ -34,6 +35,7 @@ import { ReuploadImageForDataInsightModal } from "./ReuploadImageForDataInsightM
 import { ImageUploadResponse } from "./imagesHelpers.js"
 import { DataInsightMinimalInformation } from "../adminShared/AdminTypes.js"
 import { notification } from "antd"
+import { getCanonicalUrl } from "@ourworldindata/components"
 
 const BASE_URL = BAKED_GRAPHER_URL.replace(/^https?:\/\//, "")
 
@@ -421,16 +423,26 @@ const ReferencesWordpressPosts = (props: {
 }
 
 const ReferencesGdocPosts = (props: {
-    references: Pick<References, "postsGdocs">
+    references: Pick<References, "postsGdocs" | "dataInsights">
 }) => {
     if (!props.references.postsGdocs?.length) return null
+
     return (
         <>
-            <p>Public gdocs pages that embed or reference this chart:</p>
+            <p>Published content that references this chart</p>
             <ul className="list-group">
                 {props.references.postsGdocs.map((post) => (
                     <li key={post.id} className="list-group-item">
-                        <a href={post.url} target="_blank" rel="noopener">
+                        <a
+                            href={getCanonicalUrl(BAKED_BASE_URL, {
+                                slug: post.slug,
+                                content: {
+                                    type: post.type,
+                                },
+                            })}
+                            target="_blank"
+                            rel="noopener"
+                        >
                             <strong>{post.title}</strong>
                         </a>{" "}
                         (
@@ -542,7 +554,9 @@ const ReferencesDataInsights = (props: {
         <div className="ReferencesDataInsights">
             <NotificationContext.Provider value={null}>
                 {notificationContextHolder}
-                <p>Data insights based on this chart</p>
+                <p>
+                    Published and unpublished data insights based on this chart
+                </p>
                 <ul className="list-group">
                     {props.references.dataInsights.map((dataInsight) => (
                         <Fragment key={dataInsight.gdocId}>

--- a/adminSiteServer/apiRoutes/charts.ts
+++ b/adminSiteServer/apiRoutes/charts.ts
@@ -113,6 +113,8 @@ export const getReferencesByChartId = async (
         gdoc_grapher_slugs AS (
             SELECT
                 pg.id,
+                pg.slug,
+                pg.type,
                 pg.content ->> '$.title' AS title,
                 pg.published,
                 pg.content ->> '$."narrative-chart"' AS narrativeChart,
@@ -125,6 +127,8 @@ export const getReferencesByChartId = async (
         )
         SELECT
             ggs.id AS gdocId,
+            ggs.slug,
+            ggs.type,
             ggs.title,
             ggs.published,
             ggs.narrativeChart,

--- a/db/model/Post.ts
+++ b/db/model/Post.ts
@@ -270,7 +270,8 @@ export const getWordpressPostReferencesByChartId = async (
                 p.title,
                 p.slug,
                 p.id,
-                CONCAT("${BAKED_BASE_URL}","/",p.slug) as url
+                CONCAT("${BAKED_BASE_URL}","/",p.slug) as url,
+                'article' as type
             FROM
                 posts p
                 JOIN posts_links pl ON p.id = pl.sourceId
@@ -321,17 +322,14 @@ export const getGdocsPostReferencesByChartId = async (
                 pg.content ->> '$.title' AS title,
                 pg.slug AS slug,
                 pg.id AS id,
-                CONCAT("${BAKED_BASE_URL}","/",pg.slug) as url
+                CONCAT("${BAKED_BASE_URL}","/",pg.slug) as url,
+                pg.type AS type
             FROM
                 posts_gdocs pg
                 JOIN posts_gdocs_links pgl ON pg.id = pgl.sourceId
                 JOIN chart_slug_mapping csm ON pgl.target = csm.target_slug
             WHERE
-                pg.type NOT IN (
-                    '${OwidGdocType.Fragment}',
-                    '${OwidGdocType.AboutPage}',
-                    '${OwidGdocType.DataInsight}'
-                )
+                pg.type != '${OwidGdocType.Fragment}'
                 AND pg.published = 1
             ORDER BY
                 pg.content ->> '$.title' ASC

--- a/packages/@ourworldindata/types/src/domainTypes/ContentGraph.ts
+++ b/packages/@ourworldindata/types/src/domainTypes/ContentGraph.ts
@@ -1,4 +1,5 @@
 import { DbPlainTag } from "../dbTypes/Tags.js"
+import { OwidGdocType } from "../gdocTypes/Gdoc.js"
 
 export interface EntryMeta {
     slug: string
@@ -60,6 +61,7 @@ export interface PostReference {
     title: string
     slug: string
     url: string
+    type: OwidGdocType
 }
 
 export enum ContentGraphLinkType {

--- a/site/RelatedArticles/RelatedArticles.tsx
+++ b/site/RelatedArticles/RelatedArticles.tsx
@@ -1,4 +1,6 @@
+import { getCanonicalUrl } from "@ourworldindata/components"
 import { PostReference } from "@ourworldindata/utils"
+import { BAKED_BASE_URL } from "../../settings/clientSettings.js"
 
 export const RelatedArticles = ({
     articles,
@@ -9,7 +11,16 @@ export const RelatedArticles = ({
         <ul className="research">
             {articles.map((article) => (
                 <li key={article.slug}>
-                    <a href={article.url}>{article.title}</a>
+                    <a
+                        href={getCanonicalUrl(BAKED_BASE_URL, {
+                            slug: article.slug,
+                            content: {
+                                type: article.type,
+                            },
+                        })}
+                    >
+                        {article.title}
+                    </a>
                 </li>
             ))}
         </ul>


### PR DESCRIPTION
Somewhat resolves https://github.com/owid/owid-grapher/issues/5583

We had a bit of ambiguity in our refs tab / chart index page because both counts are derived in different ways.

The chart index page uses the `chart_references_view` view, which only considers published gdocs, whereas the chart editor page also looks at unpublished data insights.

I think this is useful behaviour: we want to know if a data insight has already been written about a chart, even if it hasn't yet been published.

So this PR adds some language to clarify that for our authors.

It also wasn't counting data insights that linked to charts that in ways other than the `grapher-url` front-matter property, so I fixed that by including data insights in the `getGdocsPostReferencesByChartId` function.

Consequently, data insights then showed up in the old grapher page Related Writing section, so I had to add `type` to a few SQL statements so that we can call `getCanonicalUrl` and add the `/data-insight/` sub-path where necessary.

### Example 1 (Data insight is published, shown twice)
<img width="518" height="409" alt="image" src="https://github.com/user-attachments/assets/739c9adc-2e21-40d9-8c79-6bef26bef461" />

### Example 2 (Data insight is unpublished, shown once)
<img width="516" height="340" alt="image" src="https://github.com/user-attachments/assets/dcf60b93-0946-43dc-91ee-18443c2f4cff" />

### Related Articles
https://github.com/user-attachments/assets/0d7d1e9b-b52b-4a1a-99e0-d30998b0d0af