### PR TITLE
fix: relax constraint one topic shown when topic tag

### DIFF
--- a/site/search/SearchWritingResults.tsx
+++ b/site/search/SearchWritingResults.tsx
@@ -110,69 +110,37 @@ function MultiColumnResults({
             )}
             {interleavedTopics.length > 0 && (
                 <div className="search-writing-results__topics">
-                    {hasLargeTopic ? (
+                    {interleavedTopics.map((hit, index) => (
                         <SearchTopicPageHit
-                            hit={interleavedTopics[0]}
-                            variant="large"
+                            key={hit.objectID}
+                            hit={hit}
+                            variant={hasLargeTopic ? "large" : undefined}
                             onClick={() => {
-                                analytics.logSiteSearchResultClick(
-                                    interleavedTopics[0],
-                                    {
-                                        position: 1,
-                                        source: "search",
-                                    }
-                                )
+                                analytics.logSiteSearchResultClick(hit, {
+                                    position: index + 1,
+                                    source: "search",
+                                })
                             }}
                         />
-                    ) : (
-                        interleavedTopics.map((hit, index) => (
-                            <SearchTopicPageHit
-                                key={hit.objectID}
-                                hit={hit}
-                                onClick={() => {
-                                    analytics.logSiteSearchResultClick(hit, {
-                                        position: index + 1,
-                                        source: "search",
-                                    })
-                                }}
-                            />
-                        ))
-                    )}
+                    ))}
                 </div>
             )}
             {remainingTopics.length > 0 && (
                 <div className="search-writing-results__overflow">
-                    {hasLargeTopic ? (
+                    {remainingTopics.map((hit, index) => (
                         <SearchTopicPageHit
-                            hit={remainingTopics[0]}
-                            variant="large"
+                            key={hit.objectID}
+                            hit={hit}
+                            variant={hasLargeTopic ? "large" : undefined}
                             onClick={() => {
-                                analytics.logSiteSearchResultClick(
-                                    remainingTopics[0],
-                                    {
-                                        position: interleavedTopics.length + 1,
-                                        source: "search",
-                                    }
-                                )
+                                analytics.logSiteSearchResultClick(hit, {
+                                    position:
+                                        interleavedTopics.length + index + 1,
+                                    source: "search",
+                                })
                             }}
                         />
-                    ) : (
-                        remainingTopics.map((hit, index) => (
-                            <SearchTopicPageHit
-                                key={hit.objectID}
-                                hit={hit}
-                                onClick={() => {
-                                    analytics.logSiteSearchResultClick(hit, {
-                                        position:
-                                            interleavedTopics.length +
-                                            index +
-                                            1,
-                                        source: "search",
-                                    })
-                                }}
-                            />
-                        ))
-                    )}
+                    ))}
                 </div>
             )}
         </div>


### PR DESCRIPTION
## Context

Topic tags should be associated with only one topic page.

This relaxes that assumption in the search layout until https://github.com/owid/owid-issues/issues/2200 is addressed.


Without it, some topic pages are hidden from search results.

| Before | After |
|--------|--------|
| <img width="1440" height="816" alt="Screenshot 2025-11-14 at 16 29 51" src="https://github.com/user-attachments/assets/8039ccea-3ce2-4e59-b185-fcf77fba4110" /> | <img width="1440" height="816" alt="Screenshot 2025-11-14 at 16 30 05" src="https://github.com/user-attachments/assets/5210d996-ba28-4472-a5ba-7717181e1ab5" /> | 

See [slack](https://owid.slack.com/archives/C06UA61V85U/p1762943000706749)