### PR TITLE
🔨 (perf) make dropping rows more efficient

### DIFF
--- a/packages/@ourworldindata/utils/src/Util.test.ts
+++ b/packages/@ourworldindata/utils/src/Util.test.ts
@@ -17,6 +17,7 @@ import {
     getRandomNumberGenerator,
     findClosestTimeIndex,
     intersection,
+    union,
     getClosestTimePairs,
     differenceObj,
     numberMagnitude,
@@ -259,6 +260,18 @@ describe("intersection", () => {
             )
         ).toEqual([])
         expect(intersectionOfSets([]).size).toEqual(new Set().size)
+    })
+})
+
+describe("union", () => {
+    it("can compute unions", () => {
+        expect(union([1, 2], [2, 3])).toEqual([1, 2, 3])
+        expect(union([1, 2], [3, 4])).toEqual([1, 2, 3, 4])
+        expect(union([], [])).toEqual([])
+        expect(union([1, 2, 3])).toEqual([1, 2, 3])
+        expect(union()).toEqual([])
+        expect(union([1, 1, 2], [2, 3, 3])).toEqual([1, 2, 3])
+        expect(union(["a"], ["b"], ["c"])).toEqual(["a", "b", "c"])
     })
 })
 

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -893,6 +893,18 @@ export const intersection = <T>(...arrs: T[][]): T[] => {
     return intersection(arrs[0], intersection(...arrs.slice(1)))
 }
 
+export const union = <T>(...arrs: T[][]): T[] => {
+    if (arrs.length === 0) return []
+    if (arrs.length === 1) return arrs[0]
+    const set = new Set<T>()
+    for (const arr of arrs) {
+        for (const value of arr) {
+            set.add(value)
+        }
+    }
+    return Array.from(set)
+}
+
 export function sortByUndefinedLast<T>(
     array: T[],
     accessor: (t: T) => string | number | undefined,

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -64,6 +64,7 @@ export {
     areSetsEqual,
     isSubsetOf,
     intersection,
+    union,
     sortByUndefinedLast,
     mapNullToUndefined,
     lowerCaseFirstLetterUnlessAbbreviation,


### PR DESCRIPTION
Using column operations is more efficient then using row operations

<!-- GitButler Footer Boundary Top -->
---
This is **part 4 of 4 in a stack** made with GitButler:
- <kbd>&nbsp;4&nbsp;</kbd> #5672 👈 
- <kbd>&nbsp;3&nbsp;</kbd> #5671 
- <kbd>&nbsp;2&nbsp;</kbd> #5675 
- <kbd>&nbsp;1&nbsp;</kbd> #5649 
<!-- GitButler Footer Boundary Bottom -->

