### PR TITLE
🐛 consistent mapping for semantic colors

### DIFF
--- a/packages/@ourworldindata/grapher/src/color/CategoricalColorAssigner.ts
+++ b/packages/@ourworldindata/grapher/src/color/CategoricalColorAssigner.ts
@@ -88,6 +88,8 @@ export class CategoricalColorAssigner {
     assign(id: CategoryId): Color {
         let color = this.colorMap.get(id)
         if (color === undefined) color = this.autoColorMapCache.get(id)
+        if (color === undefined && this.colorScheme.colorMap)
+            color = this.colorScheme.colorMap[id]
         if (color === undefined) color = this.leastUsedColor
         this.autoColorMapCache.set(id, color)
         return color

--- a/packages/@ourworldindata/grapher/src/color/ColorScale.ts
+++ b/packages/@ourworldindata/grapher/src/color/ColorScale.ts
@@ -276,6 +276,7 @@ export class ColorScale {
             customCategoryColors,
             customCategoryLabels,
             customHiddenCategories,
+            colorScheme,
         } = this
 
         let allCategoricalValues = categoricalValues
@@ -301,7 +302,15 @@ export class ColorScale {
             const boundingOffset = _.isEmpty(bucketThresholds)
                 ? 0
                 : bucketThresholds.length - 1
-            const baseColor = baseColors[index + boundingOffset]
+
+            // Use colorMap if available and the value exists in it
+            let baseColor: Color | undefined
+            if (colorScheme.colorMap && value in colorScheme.colorMap) {
+                baseColor = colorScheme.colorMap[value]
+            } else {
+                baseColor = baseColors[index + boundingOffset]
+            }
+
             const color = customCategoryColors[value] ?? baseColor
             const label = customCategoryLabels[value] ?? value
 

--- a/packages/@ourworldindata/grapher/src/color/ColorScheme.ts
+++ b/packages/@ourworldindata/grapher/src/color/ColorScheme.ts
@@ -10,17 +10,20 @@ export class ColorScheme implements ColorSchemeInterface {
     colorSets: Color[][]
     singleColorScale: boolean
     isDistinct: boolean
+    colorMap?: Record<string, Color>
 
     constructor(
         name: string,
         colorSets: Color[][],
         singleColorScale?: boolean,
-        isDistinct?: boolean
+        isDistinct?: boolean,
+        colorMap?: Record<string, Color>
     ) {
         this.name = name
         this.colorSets = []
         this.singleColorScale = !!singleColorScale
         this.isDistinct = !!isDistinct
+        this.colorMap = colorMap
         colorSets.forEach((set) => (this.colorSets[set.length] = set))
     }
 

--- a/packages/@ourworldindata/grapher/src/color/ColorSchemes.ts
+++ b/packages/@ourworldindata/grapher/src/color/ColorSchemes.ts
@@ -103,7 +103,8 @@ const initColorScheme = (scheme: ColorSchemeInterface): ColorScheme =>
         scheme.displayName ?? scheme.name,
         scheme.colorSets,
         scheme.singleColorScale,
-        scheme.isDistinct
+        scheme.isDistinct,
+        scheme.colorMap
     )
 
 const _colorSchemes = new Map<ColorSchemeName, ColorScheme>()

--- a/packages/@ourworldindata/grapher/src/color/CustomSchemes.ts
+++ b/packages/@ourworldindata/grapher/src/color/CustomSchemes.ts
@@ -279,6 +279,7 @@ export const OwidEnergy = {
     singleColorScale: false,
     isDistinct: true,
     colorSets: [EnergyColorPalette],
+    colorMap: EnergyColors,
 }
 CustomColorSchemes.push(OwidEnergy)
 
@@ -369,6 +370,7 @@ export const ContinentColorsColorScheme = {
     singleColorScale: false,
     isDistinct: true,
     colorSets: [ContinentColorPalette],
+    colorMap: ContinentColors,
 }
 
 CustomColorSchemes.push(ContinentColorsColorScheme)
@@ -383,9 +385,19 @@ function getModifiedLinesColorScheme(
             : color
     )
 
+    // If the scheme has a colorMap, we need to create a modified version with darker colors
+    const modifiedColorMap = colorScheme.colorMap
+        ? _.mapValues(colorScheme.colorMap, (color) =>
+              color in darkerColorReplacementsHexToReplacementColorName
+                  ? darkerColorReplacementsHexToReplacementColorName[color]
+                  : color
+          )
+        : undefined
+
     return {
         ...colorScheme,
         colorSets: [modifiedColors],
+        colorMap: modifiedColorMap,
         name: colorScheme.name + "Lines",
         displayName: (colorScheme.displayName ?? "") + " (Lines)",
     }

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.test.ts
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.test.ts
@@ -246,7 +246,7 @@ describe("basic scatterplot", () => {
     it("plots correct series", () => {
         expect(chartState.series).toEqual([
             {
-                color: ContinentColors.Africa, // First "continents" color
+                color: ContinentColors.Europe,
                 isScaleColor: true,
                 label: "UK",
                 points: [
@@ -1103,4 +1103,40 @@ it("applies color tolerance before applying the author timeline filter", () => {
             chartState.transformedTable.get("color").valuesIncludingErrorValues
         )
     ).toEqual(["Europe"])
+})
+
+describe("continent colors remain consistent regardless of data", () => {
+    it("assigns correct colors even when some continents are missing", () => {
+        // Test with only Asia and Europe (missing Africa, which is first in palette)
+        const table1 = new OwidTable(
+            [
+                ["entityId", "entityName", "year", "x", "y", "color"],
+                [1, "China", 2000, 1, 1, "Asia"],
+                [2, "Germany", 2000, 2, 2, "Europe"],
+            ],
+            [
+                { slug: "x", type: ColumnTypeNames.Numeric },
+                { slug: "y", type: ColumnTypeNames.Numeric },
+                { slug: "color", type: ColumnTypeNames.String },
+            ]
+        )
+
+        const manager: ScatterPlotManager = {
+            xColumnSlug: "x",
+            yColumnSlug: "y",
+            categoricalColorColumnSlug: "color",
+            table: table1,
+        }
+
+        const chartState1 = new ScatterPlotChartState({ manager })
+
+        // Asia should get its designated color (Teal), not the first color (Africa's Mauve)
+        expect(chartState1.colorScale.getColor("Asia")).toEqual(
+            ContinentColors.Asia
+        )
+        // Europe should get its designated color (Denim), not the second color (Asia's Teal)
+        expect(chartState1.colorScale.getColor("Europe")).toEqual(
+            ContinentColors.Europe
+        )
+    })
 })

--- a/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
+++ b/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
@@ -383,6 +383,7 @@ export interface ColorSchemeInterface {
     singleColorScale?: boolean
     isDistinct?: boolean
     displayName?: string
+    colorMap?: Record<string, Color> // Optional mapping from categorical values to specific colors
 }
 
 // Note: TypeScript does not currently support extending or merging enums. Ideally we would have 2 enums here (one for custom and one for brewer) and then just merge them.


### PR DESCRIPTION
Resolves #2297

Add support for explicit mappings of categorical values to specific colors via a new `colorMap` property. This ensures consistent color assignments for categories (like continents or energy), regardless of their order or presence in the data.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #5675 
- <kbd>&nbsp;1&nbsp;</kbd> #5674 👈 
<!-- GitButler Footer Boundary Bottom -->

