### PR TITLE
🐛 (scatter) hide separator above no-data section

### DIFF
--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
@@ -619,6 +619,9 @@ export class ScatterPlotChart
                 {this.hasNoDataSection && (
                     <>
                         {!this.manager.isStatic &&
+                            (verticalColorLegend ||
+                                sizeLegend ||
+                                arrowLegend) &&
                             separatorLine(noDataSectionBounds.top)}
                         <NoDataSection
                             seriesNames={this.selectedEntitiesWithoutData}


### PR DESCRIPTION
The separator should only appear if there are other legends (vertical color, size, or arrow) present

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #5679 
- <kbd>&nbsp;1&nbsp;</kbd> #5678 👈 
<!-- GitButler Footer Boundary Bottom -->

