### PR TITLE
feat(gdocs): support rich links

### DIFF
--- a/db/gdocTests.test.ts
+++ b/db/gdocTests.test.ts
@@ -488,6 +488,34 @@ level: 2
         expect(matches.length).toBe(1)
     })
 
+    it("handles rich links the same way as regular links", async () => {
+        const url = "https://docs.google.com/document/d/1234567890"
+        const title = "My Google Doc"
+        const doc: docs_v1.Schema$Document = {
+            body: {
+                content: [
+                    {
+                        paragraph: {
+                            elements: [
+                                {
+                                    richLink: {
+                                        richLinkProperties: {
+                                            uri: url,
+                                            title: title,
+                                        },
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                ],
+            },
+        }
+
+        const { text } = await gdocToArchie(doc)
+        expect(text).toContain(`<a href="${url}">${title}</a>`)
+    })
+
     it.each(Object.values(enrichedBlockExamples))(
         "Parse <-> Serialize roundtrip should be equal - example type $type",
         (example) => {

--- a/db/model/Gdoc/gdocToArchie.ts
+++ b/db/model/Gdoc/gdocToArchie.ts
@@ -318,6 +318,21 @@ function parseParagraph(
         return span
     } else if (element.horizontalRule) {
         return { type: "horizontal-rule" }
+    } else if (element.richLink && element.richLink.richLinkProperties) {
+        // Rich links are special "pills" that Google Docs creates for links to other Google Docs or Google Drive files
+        const richLinkProperties = element.richLink.richLinkProperties
+        if (!richLinkProperties.uri) return null
+
+        return {
+            spanType: "span-link",
+            url: richLinkProperties.uri,
+            children: [
+                {
+                    spanType: "span-simple-text",
+                    text: richLinkProperties.title ?? richLinkProperties.uri,
+                },
+            ],
+        }
     } else {
         return null
     }


### PR DESCRIPTION
In gdocs, rich links are "pills" that reference another gdoc document, by name and URL.
They are auto-suggested when you copy a gdocs URL into a gdoc.

https://github.com/user-attachments/assets/4548f917-2755-4ac1-b827-bb270f15a654


The JSON representation of them looks like this:
```json
{
  "startIndex": 694,
  "endIndex": 695,
  "richLink": {
    "richLinkId": "kix.bkbxva228lzc",
    "textStyle": {},
    "richLinkProperties": {
      "title": "World map region definitions",
      "uri": "https://docs.google.com/document/d/1Suo5l3uf0TwqNVcEIBcm_MgwaazcUo_VHKMD3w4AqIg/edit?tab=t.0",
      "mimeType": "application/vnd.google-apps.kix"
    }
  }
},
```