### PR TITLE
🐛 (marimekko) hover state broken when selection is not empty

### DIFF
--- a/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoBars.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoBars.tsx
@@ -128,6 +128,7 @@ export function MarimekkoBars(props: MarimekkoBarsProps): React.ReactElement {
                 !focusColorBin.contains(entityColor?.colorDomainValue)) ||
             (focusColorBin === undefined && hasSelection && !isSelected) ||
             (!isHovered &&
+                !isSelected &&
                 tooltipState?.target !== undefined &&
                 !tooltipState.fading)
 


### PR DESCRIPTION
Example: [live](https://ourworldindata.org/grapher/share-of-population-in-extreme-poverty?tab=marimekko&time=latest&country=MWI~CAF~COD~MOZ~BDI~MDG) / [staging](http://staging-site-marimekko-legend-hover/grapher/share-of-population-in-extreme-poverty?tab=marimekko&time=latest&country=MWI~CAF~COD~MOZ~BDI~MDG)