### PR TITLE
✨ (line chart) deduplicate tooltip columns

### DIFF
--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
@@ -347,7 +347,8 @@ export class LineChart
         const titleAnnotation = this.xAxis.label ? `(${this.xAxis.label})` : ""
 
         const columns = [formatColumn]
-        if (hasColorScale) columns.push(colorColumn)
+        if (hasColorScale && colorColumn.slug !== formatColumn.slug)
+            columns.push(colorColumn)
 
         const subtitle =
             isRelativeMode && startTime


### PR DESCRIPTION
We sometimes use the same variable for the color dimension and the y-axis. In such cases, the tooltip should display this variable only once.