### PR TITLE
🐛 prevent applying tolerance twice

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
@@ -1147,24 +1147,15 @@ export class GrapherState {
             const targetTimes = this.isFaceted
                 ? [startTime, endTime]
                 : [endTime]
-            const tolerance =
-                this.map.timeTolerance ??
-                table.get(this.mapColumnSlug).tolerance
 
-            return table.filterByTargetTimes(targetTimes, tolerance)
+            return table.filterByTargetTimes(targetTimes)
         }
 
         if (this.isOnDiscreteBarTab || this.isOnMarimekkoTab)
-            return table.filterByTargetTimes(
-                [endTime],
-                table.get(this.yColumnSlugs[0]).tolerance
-            )
+            return table.filterByTargetTimes([endTime])
 
         if (this.isOnSlopeChartTab)
-            return table.filterByTargetTimes(
-                [startTime, endTime],
-                table.get(this.yColumnSlugs[0]).tolerance
-            )
+            return table.filterByTargetTimes([startTime, endTime])
 
         return table.filterByTimeRange(startTime, endTime)
     }


### PR DESCRIPTION
Resolves #4891

Example: https://ourworldindata.org/grapher/share-of-children-reaching-sufficient-reading-comprehension-by-the-end-of-lower-secondary-age?time=2012&country=~BLR

If a column has tolerance=3, and an entity (e.g. Belarus) has data at year 2018, that data should be visible for years 2015-2021 (exactly ±3 years from 2018). However, the bug caused the data to appear at years 2012-2024 (±6 years), effectively
applying the tolerance twice.

The data transformation pipeline has two stages where tolerance is applied:
1.	Interpolation (in transformTable):
	- Creates a complete table with all entity-year combinations
	- Fills missing years using tolerance (e.g., 2015-2021 get value from 2018)
	- Years outside tolerance (e.g., 2014) remain empty
2.	Filtering (in filterByTargetTimes):
	- For a target year (e.g., 2014), finds the closest available year
	- Originally used tolerance AGAIN to search (looking ±3 years from 2014)
	- This could find 2015, which is within tolerance of 2014
	- Result: 2018 data shown at 2014 (via 2015), which is 4 years away—outside the intended tolerance

Normally this bug is hidden because after interpolation (step 1), every year has a row. The bug only manifests when some rows are removed between interpolation and filtering, such as when showNoDataArea=false in Marimekko charts.

Fixed by dropping tolerance from `filterByTargetTimes`.

### SVG tester

This happens because the y-axis has quasi infinite tolerance (9999), but the x-axis doesn't have tolerance set, which is why then most rows are dropped. This can be fixed by assigning an appropriate tolerance value for the x-axis (which I did on prod and [staging](http://staging-site-fix-marimekko-tolerance/admin/charts/5349/edit))

<img width="1245" height="448" alt="Screenshot 2025-11-25 at 10 12 05" src="https://github.com/user-attachments/assets/e91c8cf3-696e-44de-a207-a13286b7d750" />
