### PR TITLE
Integrate article archive with tombstone pages

### DIFF
--- a/adminSiteClient/GdocsMoreMenu.tsx
+++ b/adminSiteClient/GdocsMoreMenu.tsx
@@ -252,9 +252,9 @@ function DeleteModal({
                         <Form.Item
                             name="includeArchiveLink"
                             valuePropName="checked"
-                            extra="Adds a paragraphs with automatically generated link to the Internet Archive's Wayback Machine."
+                            extra="Adds a paragraph with a link to the latest archived version of the article with a fallback to the Internet Archive's Wayback Machine."
                         >
-                            <Checkbox>Include Wayback Machine link</Checkbox>
+                            <Checkbox>Include archive link</Checkbox>
                         </Form.Item>
                         <fieldset>
                             <legend>Related prominent link</legend>

--- a/db/model/GdocTombstone.ts
+++ b/db/model/GdocTombstone.ts
@@ -6,6 +6,7 @@ export async function getTombstones(
 ): Promise<
     Pick<
         DbPlainPostGdocTombstone,
+        | "gdocId"
         | "id"
         | "slug"
         | "reason"
@@ -21,6 +22,7 @@ export async function getTombstones(
         `-- sql
         SELECT
             id,
+            gdocId,
             slug,
             reason,
             includeArchiveLink,
@@ -38,6 +40,7 @@ export async function getTombstoneBySlug(
 ): Promise<
     | Pick<
           DbPlainPostGdocTombstone,
+          | "gdocId"
           | "slug"
           | "reason"
           | "includeArchiveLink"
@@ -52,6 +55,7 @@ export async function getTombstoneBySlug(
         knex,
         `-- sql
         SELECT
+            gdocId,
             slug,
             reason,
             includeArchiveLink,

--- a/packages/@ourworldindata/types/src/domainTypes/Tombstone.ts
+++ b/packages/@ourworldindata/types/src/domainTypes/Tombstone.ts
@@ -15,4 +15,5 @@ export type TombstonePageData = {
     relatedLinkTitle: string
     relatedLinkDescription: string
     relatedLinkThumbnail: string
+    archiveUrl?: string
 }

--- a/site/TombstonePage.tsx
+++ b/site/TombstonePage.tsx
@@ -21,6 +21,7 @@ export default function TombstonePage({
         relatedLinkDescription,
         relatedLinkThumbnail,
         slug,
+        archiveUrl,
     },
 }: {
     baseUrl: string
@@ -28,6 +29,7 @@ export default function TombstonePage({
 }) {
     const canonicalUrl = urljoin(baseUrl, "deleted", slug)
     const oldUrl = urljoin(baseUrl, slug)
+    const waybackUrl = `https://web.archive.org/web/*/${oldUrl}`
     return (
         <Html>
             <Head
@@ -53,13 +55,20 @@ export default function TombstonePage({
                         {includeArchiveLink && (
                             <p className="body-3-medium">
                                 If you’d still like to view this page, you can
-                                check its archived copy via the{" "}
-                                <a
-                                    href={`https://web.archive.org/web/*/${oldUrl}`}
-                                >
-                                    Internet Archive's Wayback Machine
-                                </a>
-                                .
+                                check its archived copy{" "}
+                                {archiveUrl ? (
+                                    <>
+                                        in <a href={archiveUrl}>our archive</a>.
+                                    </>
+                                ) : (
+                                    <>
+                                        via the{" "}
+                                        <a href={waybackUrl}>
+                                            Internet Archive's Wayback Machine
+                                        </a>
+                                        .
+                                    </>
+                                )}
                             </p>
                         )}
                     </div>


### PR DESCRIPTION
## Context

Part of #5366

## Screenshots / Videos / Diagrams

![image.png](https://app.graphite.com/user-attachments/assets/e065634c-58f0-4252-995e-3b4c7316c401.png)

![image.png](https://app.graphite.com/user-attachments/assets/97c5a7cc-689c-445b-bd97-57c077e3da06.png)

## Testing guidance

You can try to delete an article, which has an archived version, and should see it being used in the tombstone page. You need to create a tombstone page explicitly and with the "Include archive link" checkbox checked and test it with `http://localhost:3030/deleted/<postSlug>`.