### PR TITLE
✨ support fragments in linked gdoc urls

### DIFF
--- a/site/gdocs/utils.test.ts
+++ b/site/gdocs/utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
-import { ContentGraphLinkType } from "@ourworldindata/types"
-import { isExternalUrl } from "./utils.js"
+import { getLinkedDocumentUrl, isExternalUrl } from "./utils.js"
+import { ContentGraphLinkType, OwidGdocType } from "@ourworldindata/types"
 import { BAKED_BASE_URL } from "../../settings/clientSettings.js"
 
 describe(isExternalUrl, () => {
@@ -30,5 +30,25 @@ describe(isExternalUrl, () => {
         expect(isExternalUrl(ContentGraphLinkType.Url, "not-a-valid-url")).toBe(
             false
         )
+    })
+})
+
+describe(getLinkedDocumentUrl, () => {
+    it("appends the fragment from the original gdoc URL to the canonical URL", () => {
+        const url = getLinkedDocumentUrl(
+            { slug: "a-slug", type: OwidGdocType.Article },
+            "https://docs.google.com/document/d/abcd/edit#my-heading",
+            "https://ourworldindata.org"
+        )
+        expect(url).toBe("https://ourworldindata.org/a-slug#my-heading")
+    })
+
+    it("returns the canonical URL when no fragment is provided", () => {
+        const url = getLinkedDocumentUrl(
+            { slug: "a-slug", type: OwidGdocType.Article },
+            "https://docs.google.com/document/d/abcd/edit",
+            "https://ourworldindata.org"
+        )
+        expect(url).toBe("https://ourworldindata.org/a-slug")
     })
 })

--- a/site/gdocs/utils.ts
+++ b/site/gdocs/utils.ts
@@ -87,6 +87,19 @@ export const useLinkedAuthor = (
 
 type LinkedDocument = OwidGdocMinimalPostInterface & { url: string }
 
+export const getLinkedDocumentUrl = (
+    linkedDocument: Pick<OwidGdocMinimalPostInterface, "slug" | "type">,
+    originalUrl: string,
+    baseUrl: string = BAKED_BASE_URL
+): string => {
+    const canonicalUrl = getCanonicalUrl(baseUrl, {
+        slug: linkedDocument.slug,
+        content: { type: linkedDocument.type },
+    })
+    const hash = Url.fromURL(originalUrl).hash
+    return `${canonicalUrl}${hash}`
+}
+
 export const useLinkedDocument = (
     url: string
 ): { linkedDocument?: LinkedDocument; errorMessage?: string } => {
@@ -113,10 +126,7 @@ export const useLinkedDocument = (
     return {
         linkedDocument: {
             ...linkedDocument,
-            url: getCanonicalUrl(BAKED_BASE_URL, {
-                slug: linkedDocument.slug,
-                content: { type: linkedDocument.type },
-            }),
+            url: getLinkedDocumentUrl(linkedDocument, url),
         },
         errorMessage,
     }


### PR DESCRIPTION
Allows us to use the gdoc linking system with fragments

e.g.

`[this](https://docs.google.com/document/d/some-id/edit#some-heading)`

will resolve to 

`[this](https://ourworldindata.org/some-slug#some-heading)`