### PR TITLE
🔨 unify legend events

### DIFF
--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.test.ts
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.test.ts
@@ -541,7 +541,9 @@ describe("colors & legend", () => {
     })
 
     it("legend contains every continent for which there is data (before timeline filter)", () => {
-        expect(chart.legendItems.map((item) => item.label).sort()).toEqual([
+        expect(
+            chart.categoricalLegendData.map((item) => item.label).sort()
+        ).toEqual([
             "Africa",
             "Europe",
             "North America",

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
@@ -171,9 +171,9 @@ export class ScatterPlotChart
         return this.manager.fontSize ?? BASE_FONT_SIZE
     }
 
-    @action.bound onLegendMouseOver(color: string): void {
+    @action.bound onLegendMouseOver(bin: ColorScaleBin): void {
         if (isTouchDevice()) return
-        this.hoverColor = color
+        this.hoverColor = bin.color
     }
 
     @action.bound onLegendMouseLeave(): void {
@@ -182,9 +182,11 @@ export class ScatterPlotChart
     }
 
     // When the color legend is clicked, toggle selection fo all associated keys
-    @action.bound onLegendClick(color: string): void {
+    @action.bound onLegendClick(bin: ColorScaleBin): void {
         const { selectionArray } = this.chartState
         if (!this.canAddCountry) return
+
+        const color = bin.color
 
         const keysToToggle = this.series
             .filter((g) => g.color === color)
@@ -299,7 +301,7 @@ export class ScatterPlotChart
         | VerticalColorLegend
         | undefined {
         if (
-            this.legendItems.length === 0 ||
+            this.categoricalLegendData.length === 0 ||
             this.manager.isDisplayedAlongsideComplementaryTable
         )
             return undefined
@@ -480,7 +482,7 @@ export class ScatterPlotChart
         return this.chartState.colorColumn
     }
 
-    @computed get legendItems(): ColorScaleBin[] {
+    @computed get categoricalLegendData(): ColorScaleBin[] {
         return this.colorScale.legendBins.filter(
             (bin) =>
                 this.colorsInUse.includes(bin.color) &&

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChart.tsx
@@ -16,7 +16,6 @@ import { NoDataModal } from "../noDataModal/NoDataModal"
 import {
     VerticalColorLegend,
     VerticalColorLegendManager,
-    LegendItem,
 } from "../verticalColorLegend/VerticalColorLegend"
 import { TooltipFooterIcon } from "../tooltip/TooltipProps.js"
 import {
@@ -233,30 +232,18 @@ export class StackedBarChart
         )
     }
 
-    // used by <VerticalColorLegend />
-    @computed get legendItems(): (LegendItem &
-        Required<Pick<LegendItem, "label">>)[] {
-        return this.stackedSeries
-            .map((series) => {
-                return {
-                    label: series.seriesName,
-                    color: series.color,
-                }
-            })
-            .toReversed() // Vertical legend orders things in the opposite direction we want
-    }
-
-    // used by <HorizontalCategoricalColorLegend />
     @computed get categoricalLegendData(): CategoricalBin[] {
-        return this.legendItems.map(
-            (legendItem, index) =>
-                new CategoricalBin({
-                    index,
-                    value: legendItem.label,
-                    label: legendItem.label,
-                    color: legendItem.color,
-                })
-        )
+        return this.stackedSeries
+            .map(
+                (series, index) =>
+                    new CategoricalBin({
+                        index,
+                        value: series.seriesName,
+                        label: series.seriesName,
+                        color: series.color,
+                    })
+            )
+            .toReversed() // Vertical legend orders things in the opposite direction we want
     }
 
     @computed get legendWidth(): number {
@@ -425,12 +412,8 @@ export class StackedBarChart
         )
     }
 
-    // Both legend managers accept a `onLegendMouseOver` property, but define different signatures.
-    // The <HorizontalCategoricalColorLegend /> component expects a string,
-    // the <VerticalColorLegend /> component expects a ColorScaleBin.
-    @action.bound onLegendMouseOver(binOrColor: string | ColorScaleBin): void {
-        this.hoverColor =
-            typeof binOrColor === "string" ? binOrColor : binOrColor.color
+    @action.bound onLegendMouseOver(bin: ColorScaleBin): void {
+        this.hoverColor = bin.color
     }
 
     @action.bound onLegendMouseLeave(): void {


### PR DESCRIPTION
This pull request refactors how categorical color legend data is handled and passed between chart components, standardizing on the `ColorScaleBin` type and the `categoricalLegendData` property instead of the previously used `legendItems` and custom types.

