### PR TITLE
🐛 fix tolerance notice for relative scatter tooltips

### DIFF
--- a/packages/@ourworldindata/core-table/src/CoreTableColumns.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTableColumns.ts
@@ -35,6 +35,7 @@ import {
 } from "@ourworldindata/types"
 import { ErrorValueTypes, isNotErrorValue } from "./ErrorValues.js"
 import {
+    getOriginalStartTimeColumnSlug,
     getOriginalTimeColumnSlug,
     getOriginalValueColumnSlug,
 } from "./OwidTableUtil.js"
@@ -350,6 +351,14 @@ export abstract class AbstractCoreColumn<JS_TYPE extends PrimitiveType> {
 
     @imemo get originalTimeColumn(): CoreColumn {
         return this.table.get(this.originalTimeColumnSlug)
+    }
+
+    @imemo get originalStartTimeColumnSlug(): string {
+        return getOriginalStartTimeColumnSlug(this.table, this.slug)
+    }
+
+    @imemo get originalStartTimeColumn(): CoreColumn {
+        return this.table.get(this.originalStartTimeColumnSlug)
     }
 
     @imemo get originalTimes(): number[] {

--- a/packages/@ourworldindata/core-table/src/OwidTableUtil.ts
+++ b/packages/@ourworldindata/core-table/src/OwidTableUtil.ts
@@ -17,6 +17,12 @@ export function makeOriginalTimeSlugFromColumnSlug(slug: ColumnSlug): string {
     return `${slug}-originalTime`
 }
 
+export function makeOriginalStartTimeSlugFromColumnSlug(
+    slug: ColumnSlug
+): string {
+    return `${slug}-originalStartTime`
+}
+
 export function makeOriginalValueSlugFromColumnSlug(slug: ColumnSlug): string {
     return `${slug}-originalValue`
 }
@@ -27,6 +33,15 @@ export function getOriginalTimeColumnSlug(
 ): ColumnSlug {
     const originalTimeSlug = makeOriginalTimeSlugFromColumnSlug(slug)
     if (table.has(originalTimeSlug)) return originalTimeSlug
+    return table.timeColumn.slug
+}
+
+export function getOriginalStartTimeColumnSlug(
+    table: CoreTable,
+    slug: ColumnSlug
+): ColumnSlug {
+    const originalStartTimeSlug = makeOriginalStartTimeSlugFromColumnSlug(slug)
+    if (table.has(originalStartTimeSlug)) return originalStartTimeSlug
     return table.timeColumn.slug
 }
 

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.test.ts
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.test.ts
@@ -729,6 +729,11 @@ describe("average annual change", () => {
         )
         expect(chart.dualAxis.verticalAxis.scaleType).toEqual(ScaleType.linear)
     })
+
+    it("sets time.span correctly in relative mode", () => {
+        const point = chartState.series[0].points[0]
+        expect(point.time.span).toEqual([2000, 2002])
+    })
 })
 
 describe("scatter plot with xOverrideTime", () => {

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChartConstants.ts
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChartConstants.ts
@@ -58,6 +58,10 @@ export interface SeriesPoint {
     time: {
         x: number
         y: number
+        // Time span in relative mode for both axes
+        // Technically, to be more correct, we should support distinct
+        // start and end times for each axis, but for simplicity we use
+        // a single span (see getAverageAnnualChangeIndicesByEntity)
         span?: [number, number]
     }
 }

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChartState.ts
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChartState.ts
@@ -386,6 +386,21 @@ export class ScatterPlotChartState implements ChartState, ColorScaleManager {
                             .valuesIncludingErrorValues[rowIndex] as number,
                         y: yColumn.originalTimeColumn
                             .valuesIncludingErrorValues[rowIndex] as number,
+                        // Technically, to be more correct, we should support distinct
+                        // start and end times for each axis, but for simplicity we use
+                        // a single span (see getAverageAnnualChangeIndicesByEntity)
+                        span: this.manager.isRelativeMode
+                            ? [
+                                  yColumn.originalStartTimeColumn
+                                      .valuesIncludingErrorValues[
+                                      rowIndex
+                                  ] as number,
+                                  yColumn.originalTimeColumn
+                                      .valuesIncludingErrorValues[
+                                      rowIndex
+                                  ] as number,
+                              ]
+                            : undefined,
                     },
                 }
             })


### PR DESCRIPTION
Scatter plots didn't correctly show tolerance in relative mode.

| Before | After |
|--------|--------|
| <img width="1068" height="752" alt="Screenshot 2025-11-25 at 10 35 39" src="https://github.com/user-attachments/assets/79d319f5-bc25-4b03-8969-42e1884885f6" /> | <img width="1068" height="752" alt="Screenshot 2025-11-25 at 10 35 59" src="https://github.com/user-attachments/assets/a8ef9e7b-6c77-42a0-9be2-911977396f27" /> | 
| <img width="1068" height="752" alt="Screenshot 2025-11-25 at 10 35 45" src="https://github.com/user-attachments/assets/867a598f-0b77-4332-bfee-09240d04b89f" /> | <img width="1068" height="752" alt="Screenshot 2025-11-25 at 10 36 03" src="https://github.com/user-attachments/assets/853e8e1a-9818-4016-a464-070d92d89060" /> | 

Example: [prod](https://ourworldindata.org/grapher/growth-of-income-and-trade?country=ALB~ISL~ARG) / [staging](http://staging-site-fix-relative-scatter-tooltip/grapher/growth-of-income-and-trade?country=ALB~ISL~ARG)