### PR TITLE
feat(search): small topic card when more than one

### DIFF
--- a/site/search/SearchTemplatesAll.tsx
+++ b/site/search/SearchTemplatesAll.tsx
@@ -20,7 +20,7 @@ export const SearchTemplatesAll = () => {
                 <>
                     <SearchDataInsightsResults />
                     <SearchDataResults isFirstChartLarge={true} />
-                    <SearchWritingResults topicType={SearchTopicType.Topic} />
+                    <SearchWritingResults />
                 </>
             ))
             // All + Topic + Country + No Query
@@ -28,13 +28,13 @@ export const SearchTemplatesAll = () => {
                 <>
                     <SearchDataInsightsResults />
                     <SearchDataResults isFirstChartLarge={false} />
-                    <SearchWritingResults topicType={SearchTopicType.Topic} />
+                    <SearchWritingResults />
                 </>
             ))
             // All + Topic + No Country + Query
             .with([SearchTopicType.Topic, false, true], () => (
                 <>
-                    <SearchWritingResults topicType={SearchTopicType.Topic} />
+                    <SearchWritingResults />
                     <SearchDataResults isFirstChartLarge={true} />
                     <SearchDataInsightsResults />
                 </>
@@ -42,7 +42,7 @@ export const SearchTemplatesAll = () => {
             // All + Topic + No Country + No Query
             .with([SearchTopicType.Topic, false, false], () => (
                 <>
-                    <SearchWritingResults topicType={SearchTopicType.Topic} />
+                    <SearchWritingResults />
                     <SearchDataResults isFirstChartLarge={false} />
                     <SearchDataInsightsResults />
                 </>
@@ -52,7 +52,7 @@ export const SearchTemplatesAll = () => {
                 <>
                     <SearchDataInsightsResults />
                     <SearchDataResults isFirstChartLarge={true} />
-                    <SearchWritingResults topicType={SearchTopicType.Area} />
+                    <SearchWritingResults />
                 </>
             ))
             // All + Area + Country + No Query
@@ -60,13 +60,13 @@ export const SearchTemplatesAll = () => {
                 <>
                     <SearchDataInsightsResults />
                     <SearchDataTopicsResults />
-                    <SearchWritingResults topicType={SearchTopicType.Area} />
+                    <SearchWritingResults />
                 </>
             ))
             // All + Area + No Country + Query
             .with([SearchTopicType.Area, false, true], () => (
                 <>
-                    <SearchWritingResults topicType={SearchTopicType.Area} />
+                    <SearchWritingResults />
                     <SearchDataResults isFirstChartLarge={true} />
                     <SearchDataInsightsResults />
                 </>
@@ -74,7 +74,7 @@ export const SearchTemplatesAll = () => {
             // All + Area + No Country + No Query
             .with([SearchTopicType.Area, false, false], () => (
                 <>
-                    <SearchWritingResults topicType={SearchTopicType.Area} />
+                    <SearchWritingResults />
                     <SearchDataTopicsResults />
                     <SearchDataInsightsResults />
                 </>

--- a/site/search/SearchTemplatesWriting.tsx
+++ b/site/search/SearchTemplatesWriting.tsx
@@ -17,7 +17,7 @@ export const SearchTemplatesWriting = () => {
             // Writing + Topic + Country + Query
             .with([SearchTopicType.Topic, true, true], () => (
                 <>
-                    <SearchWritingResults topicType={SearchTopicType.Topic} />
+                    <SearchWritingResults />
                     <SearchDataInsightsResults />
                 </>
             ))
@@ -25,27 +25,27 @@ export const SearchTemplatesWriting = () => {
             .with([SearchTopicType.Topic, true, false], () => (
                 <>
                     <SearchDataInsightsResults />
-                    <SearchWritingResults topicType={SearchTopicType.Topic} />
+                    <SearchWritingResults />
                 </>
             ))
             // Writing + Topic + No Country + Query
             .with([SearchTopicType.Topic, false, true], () => (
                 <>
-                    <SearchWritingResults topicType={SearchTopicType.Topic} />
+                    <SearchWritingResults />
                     <SearchDataInsightsResults />
                 </>
             ))
             // Writing + Topic + No Country + No Query
             .with([SearchTopicType.Topic, false, false], () => (
                 <>
-                    <SearchWritingResults topicType={SearchTopicType.Topic} />
+                    <SearchWritingResults />
                     <SearchDataInsightsResults />
                 </>
             ))
             // Writing + Area + Country + Query
             .with([SearchTopicType.Area, true, true], () => (
                 <>
-                    <SearchWritingResults topicType={SearchTopicType.Area} />
+                    <SearchWritingResults />
                     <SearchDataInsightsResults />
                 </>
             ))
@@ -53,20 +53,20 @@ export const SearchTemplatesWriting = () => {
             .with([SearchTopicType.Area, true, false], () => (
                 <>
                     <SearchDataInsightsResults />
-                    <SearchWritingResults topicType={SearchTopicType.Area} />
+                    <SearchWritingResults />
                 </>
             ))
             // Writing + Area + No Country + Query
             .with([SearchTopicType.Area, false, true], () => (
                 <>
-                    <SearchWritingResults topicType={SearchTopicType.Area} />
+                    <SearchWritingResults />
                     <SearchDataInsightsResults />
                 </>
             ))
             // Writing + Area + No Country + No Query
             .with([SearchTopicType.Area, false, false], () => (
                 <>
-                    <SearchWritingResults topicType={SearchTopicType.Area} />
+                    <SearchWritingResults />
                     <SearchDataInsightsResults />
                 </>
             ))

--- a/site/search/SearchWritingResults.tsx
+++ b/site/search/SearchWritingResults.tsx
@@ -7,7 +7,6 @@ import {
     SearchFlatArticleResponse,
     SearchTopicPageResponse,
     TopicPageHit,
-    SearchTopicType,
 } from "@ourworldindata/types"
 import { SMALL_BREAKPOINT_MEDIA_QUERY } from "../SiteConstants.js"
 import { searchQueryKeys, queryArticles, queryTopicPages } from "./queries.js"
@@ -149,13 +148,10 @@ function MultiColumnResults({
 
 export const SearchWritingResults = ({
     hasTopicPages = true,
-    topicType,
 }: {
     hasTopicPages?: boolean
-    topicType?: SearchTopicType
 }) => {
     const isSmallScreen = useMediaQuery(SMALL_BREAKPOINT_MEDIA_QUERY)
-    const hasLargeTopic = topicType === SearchTopicType.Topic
     const articlesQuery = useInfiniteSearchOffset<
         SearchFlatArticleResponse,
         FlatArticleHit
@@ -183,6 +179,7 @@ export const SearchWritingResults = ({
         enabled: hasTopicPages && !articlesQuery.isLoading,
     })
 
+    const hasLargeTopic = topicsQuery.totalResults === 1
     const totalCount = articlesQuery.totalResults + topicsQuery.totalResults
     const hasNextPage = articlesQuery.hasNextPage || topicsQuery.hasNextPage
     const isFetchingNextPage =


### PR DESCRIPTION
## Context

This PR simplifies the `SearchWritingResults` component by removing the explicit `topicType` prop and instead determining whether to display a large topic dynamically based on the number of topic pages returned.

We had initially designed for:

1. area tag selected -> multiple small topic results
2. topic tag selected -> 1 large topic result

- 2\. works when there is a 1:1 mapping of topic tag to topic pages.
- 2 doesn't work when that assumption is broken:
    - overassigned tags ([issue being fixed at the content level by Fiona](https://github.com/owid/owid-issues/issues/2200))
    - sub-topics

We don't have a good story for subtopics, so I went ahead and simplified the rule:

- 1 topic returned -> large
- 2+ topics returned (areas, overassigned or subtopics) -> small

## Testing guidance

1. Navigate to the search page
2. Test various search queries:
    1. multiple topic pages for one topic tag ([related content issue](https://github.com/owid/owid-issues/issues/2200)): http://staging-site-search-topic-size/search?resultType=writing&topics=Global+Education
    2. area tag: http://staging-site-search-topic-size/search?resultType=writing&topics=Health
    3. topic page with sub-topics: http://staging-site-search-topic-size/search?topics=Energy&resultType=writing
3. Confirm that large topics are only displayed when there is exactly one topic result (otherwise smaller variants are being shown when more than one topic pages results is present)

## Checklist

- [x] product/design review ([slack](https://owid.slack.com/archives/C06UA61V85U/p1764063256004059?thread_ts=1763987475.581519&cid=C06UA61V85U))