### PR TITLE
Fix links in archived articles

### DIFF
--- a/db/model/Gdoc/GdocBase.ts
+++ b/db/model/Gdoc/GdocBase.ts
@@ -24,7 +24,6 @@ import {
     excludeUndefined,
     Url,
 } from "@ourworldindata/utils"
-import { BAKED_GRAPHER_URL } from "../../../settings/serverSettings.js"
 import { docs as googleDocs, type docs_v1 } from "@googleapis/docs"
 import { gdocToArchie } from "./gdocToArchie.js"
 import { archieToEnriched } from "./archieToEnriched.js"
@@ -32,7 +31,9 @@ import { getChartConfigById, mapSlugsToIds } from "../Chart.js"
 import {
     BAKED_BASE_URL,
     GRAPHER_DYNAMIC_THUMBNAIL_URL,
+    IS_ARCHIVE,
 } from "../../../settings/clientSettings.js"
+import { PROD_URL } from "../../../site/SiteConstants.js"
 import { EXPLORERS_ROUTE_FOLDER } from "@ourworldindata/explorer"
 import { match, P } from "ts-pattern"
 import {
@@ -80,6 +81,8 @@ import { getDods } from "../Dod.js"
 import { getLatestArchivedExplorerPageVersionsIfEnabled } from "../ArchivedExplorerVersion.js"
 import { getLatestArchivedMultiDimPageVersionsIfEnabled } from "../ArchivedMultiDimVersion.js"
 import { getLatestArchivedChartPageVersionsIfEnabled } from "../ArchivedChartVersion.js"
+
+const BASE_URL = IS_ARCHIVE ? PROD_URL : BAKED_BASE_URL
 
 export async function getLinkedIndicatorsForCharts(
     knex: db.KnexReadonlyTransaction,
@@ -1246,7 +1249,7 @@ export async function makeGrapherLinkedChart(
         text: config.subtitle || "",
         fontSize: 12,
     }).plaintext
-    const resolvedUrl = `${BAKED_GRAPHER_URL}/${resolvedSlug}`
+    const resolvedUrl = `${BASE_URL}/grapher/${resolvedSlug}`
     const tab = config.tab ?? GRAPHER_TAB_CONFIG_OPTIONS.chart
     const indicatorId = await getDatapageIndicatorId(knex, config)
     return {
@@ -1282,7 +1285,7 @@ export function makeExplorerLinkedChart(
         originalSlug,
         title: explorer.title ?? "",
         subtitle: explorer.subtitle ?? "",
-        resolvedUrl: `${BAKED_BASE_URL}/${EXPLORERS_ROUTE_FOLDER}/${originalSlug}`,
+        resolvedUrl: `${BASE_URL}/${EXPLORERS_ROUTE_FOLDER}/${originalSlug}`,
         thumbnail:
             explorer.thumbnail ||
             `${BAKED_BASE_URL}/${DEFAULT_THUMBNAIL_FILENAME}`,
@@ -1306,7 +1309,7 @@ export function makeMultiDimLinkedChart(
         originalSlug: slug,
         title,
         dimensionSlugs: config.dimensions.map((d) => d.slug),
-        resolvedUrl: `${BAKED_GRAPHER_URL}/${slug}`,
+        resolvedUrl: `${BASE_URL}/grapher/${slug}`,
         tags: [],
         archivedPageVersion,
     }

--- a/site/gdocs/components/LinkedAuthor.tsx
+++ b/site/gdocs/components/LinkedAuthor.tsx
@@ -2,6 +2,10 @@ import { getCanonicalUrl } from "@ourworldindata/components"
 import { OwidGdocType } from "@ourworldindata/types"
 import { useLinkedAuthor } from "../utils.js"
 import Image from "./Image.js"
+import { IS_ARCHIVE } from "../../../settings/clientSettings.js"
+import { PROD_URL } from "../../SiteConstants.js"
+
+const BASE_URL = IS_ARCHIVE ? PROD_URL : ""
 
 export default function LinkedAuthor({
     className,
@@ -24,7 +28,7 @@ export default function LinkedAuthor({
             />
         ) : undefined
 
-    const path = getCanonicalUrl("", {
+    const path = getCanonicalUrl(BASE_URL, {
         // If there's no author slug, this will link to /team/
         slug: author.slug || "",
         content: { type: OwidGdocType.Author },

--- a/site/gdocs/pages/GdocPost.tsx
+++ b/site/gdocs/pages/GdocPost.tsx
@@ -16,12 +16,15 @@ import {
     getPhraseForArchivalDate,
 } from "@ourworldindata/utils"
 import { CodeSnippet } from "@ourworldindata/components"
-import { BAKED_BASE_URL } from "../../../settings/clientSettings.js"
+import { BAKED_BASE_URL, IS_ARCHIVE } from "../../../settings/clientSettings.js"
 import { OwidGdocHeader } from "../components/OwidGdocHeader.js"
 import StickyNav from "../../blocks/StickyNav.js"
 import { getShortPageCitation } from "../utils.js"
 import { TableOfContents } from "../../TableOfContents.js"
 import { DocumentContext } from "../DocumentContext.js"
+import { PROD_URL } from "../../SiteConstants.js"
+
+const BASE_URL = IS_ARCHIVE ? PROD_URL : ""
 
 const citationDescriptionsByArticleType: Record<
     | OwidGdocType.Article
@@ -220,7 +223,9 @@ export function GdocPost({
                     {!isDeprecated && (
                         <p>
                             All of{" "}
-                            <a href="/faqs#how-can-i-embed-one-of-your-interactive-charts-in-my-website">
+                            <a
+                                href={`${BASE_URL}/faqs#how-can-i-embed-one-of-your-interactive-charts-in-my-website`}
+                            >
                                 our charts can be embedded
                             </a>{" "}
                             in any site.

--- a/site/gdocs/utils.ts
+++ b/site/gdocs/utils.ts
@@ -24,8 +24,8 @@ import {
     Url,
 } from "@ourworldindata/utils"
 import { AttachmentsContext } from "./AttachmentsContext.js"
-import { SubnavItem, subnavs } from "../SiteConstants.js"
-import { BAKED_BASE_URL } from "../../settings/clientSettings.js"
+import { PROD_URL, SubnavItem, subnavs } from "../SiteConstants.js"
+import { BAKED_BASE_URL, IS_ARCHIVE } from "../../settings/clientSettings.js"
 
 const getOrigin = (url: string, base?: string): string | undefined => {
     try {
@@ -92,6 +92,9 @@ export const getLinkedDocumentUrl = (
     originalUrl: string,
     baseUrl: string = BAKED_BASE_URL
 ): string => {
+    if (IS_ARCHIVE) {
+        baseUrl = PROD_URL
+    }
     const canonicalUrl = getCanonicalUrl(baseUrl, {
         slug: linkedDocument.slug,
         content: { type: linkedDocument.type },


### PR DESCRIPTION
Links to other pages on OWID should point to the live site. This fixes:

- Link to the author in the article header
- Links to charts
  - Some links were correct, depending on how the author links to the chart in the gdoc
- Link to the FAQs in the "reuse this work" section