### PR TITLE
✨ retry data download client side

### DIFF
--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -507,7 +507,8 @@ export async function fetchJson<TResult>(
 // Adapted from https://github.com/sindresorhus/ky/blob/main/source/utils/timeout.ts
 export async function fetchWithTimeout(
     url: string,
-    timeoutMs: number
+    timeoutMs: number,
+    options?: RequestInit
 ): Promise<Response> {
     const abortController = new AbortController()
 
@@ -517,7 +518,7 @@ export async function fetchWithTimeout(
             reject(new Error(`Request timed out: ${url}`))
         }, timeoutMs)
 
-        void fetch(url, { signal: abortController.signal })
+        void fetch(url, { ...options, signal: abortController.signal })
             .then(resolve)
             .catch(reject)
             .finally(() => clearTimeout(timeoutId))

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -40,6 +40,7 @@ export {
     trimObject,
     fetchText,
     fetchJson,
+    fetchWithTimeout,
     getUserCountryInformation,
     stripHTML,
     getRandomNumberGenerator,


### PR DESCRIPTION
Adds a client-side fallback when the data download request fails

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 5 in a stack** made with GitButler:
- <kbd>&nbsp;5&nbsp;</kbd> #5734 
- <kbd>&nbsp;4&nbsp;</kbd> #5732 
- <kbd>&nbsp;3&nbsp;</kbd> #5725 
- <kbd>&nbsp;2&nbsp;</kbd> #5717 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #5713 
<!-- GitButler Footer Boundary Bottom -->

