### PR TITLE
✨ show loading state for data downloads

### DIFF
--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.scss
@@ -71,12 +71,11 @@
         text-align: left;
         cursor: pointer;
 
-        &:hover {
-            background-color: $hover-fill;
-        }
-
-        &:active {
-            background-color: $active-fill;
+        &:not(.download-modal__download-button--loading) {
+            &:hover,
+            &:active {
+                background-color: $hover-fill;
+            }
         }
 
         + .download-modal__download-button {
@@ -103,8 +102,27 @@
             flex: 1;
         }
 
-        .download-modal__download-button-description {
+        .download-modal__download-button-description-wrapper {
+            position: relative;
+        }
+
+        .download-modal__download-button-description,
+        .download-modal__download-button-loading-label {
             color: $bluish-grey-text-color;
+        }
+
+        // Hide the description and use an overlay for the 'Downloading...' label
+        // to keep the button height fixed and avoid a layout shift
+        &.download-modal__download-button--loading
+            .download-modal__download-button-description {
+            visibility: hidden;
+        }
+
+        .download-modal__download-button-loading-label {
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
         }
 
         .download-modal__download-icon {
@@ -122,6 +140,11 @@
             gap: 4px;
             font-size: 11px;
             width: auto;
+        }
+
+        &.download-modal__download-button--loading {
+            cursor: not-allowed;
+            opacity: 0.8;
         }
     }
 


### PR DESCRIPTION
Adds a loading state to the download buttons in Grapher's download modal

<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 5 in a stack** made with GitButler:
- <kbd>&nbsp;5&nbsp;</kbd> #5734 
- <kbd>&nbsp;4&nbsp;</kbd> #5732 
- <kbd>&nbsp;3&nbsp;</kbd> #5725 👈 
- <kbd>&nbsp;2&nbsp;</kbd> #5717 
- <kbd>&nbsp;1&nbsp;</kbd> #5713 
<!-- GitButler Footer Boundary Bottom -->

