### PR TITLE
Spotlight

### DIFF
--- a/ANNOUNCEMENT_SPOTLIGHTS.md
+++ b/ANNOUNCEMENT_SPOTLIGHTS.md
@@ -48,7 +48,7 @@ SEO and sitemap rules
 
 TODO
 
-- [ ] Add types for spotlight fields (`homepage-title`, `spotlight`, `source-document`)
+- [x] Add types for spotlight fields (`homepage-title`, `spotlight`, `source-document`)
 - [ ] Implement validation in `gdocsValidation.ts` (requirements, CTA exclusion, URL checks)
 - [ ] Update homepage latestAnnouncements behaviour for spotlights
 - [ ] Update announcement page rendering for spotlights

--- a/ANNOUNCEMENT_SPOTLIGHTS.md
+++ b/ANNOUNCEMENT_SPOTLIGHTS.md
@@ -50,6 +50,6 @@ TODO
 
 - [x] Add types for spotlight fields (`homepage-title`, `spotlight`, `source-document`)
 - [x] Implement validation in `gdocsValidation.ts` (requirements, CTA exclusion, URL checks)
-- [ ] Update homepage latestAnnouncements behaviour for spotlights
+- [x] Update homepage latestAnnouncements behaviour for spotlights
 - [ ] Update announcement page rendering for spotlights
 - [ ] Update announcement feed rendering for spotlights

--- a/ANNOUNCEMENT_SPOTLIGHTS.md
+++ b/ANNOUNCEMENT_SPOTLIGHTS.md
@@ -52,4 +52,4 @@ TODO
 - [x] Implement validation in `gdocsValidation.ts` (requirements, CTA exclusion, URL checks)
 - [x] Update homepage latestAnnouncements behaviour for spotlights
 - [ ] Update announcement page rendering for spotlights
-- [ ] Update announcement feed rendering for spotlights
+- [x] Update announcement feed rendering for spotlights

--- a/ANNOUNCEMENT_SPOTLIGHTS.md
+++ b/ANNOUNCEMENT_SPOTLIGHTS.md
@@ -1,0 +1,55 @@
+## Context
+
+We recently added a new “announcement” content type which powers the “Updates and Announcements” section on the homepage and also appears as a new kind of post on the new `/latest` feed.
+
+There are 2 kinds of announcement, currently:
+
+1. Regular - a standalone post that can contain whatever.
+    1. Clicking on it from the homepage takes you to the feed
+    2. Often has a short body and then a CTA at the bottom
+2. CTA - a short announcement that exists to link to a second resource.
+    1. Clicking on it from the homepage takes you straight to the resource
+    2. Unused so far
+
+Our authors are updating linear topic pages with new sections, and we want a way to announce them.
+
+Regular announcements don’t quite work because:
+
+1. These sections might be very long, longer than we want to put in the feed
+2. We want them to have a different title on the homepage vs. on the feed
+3. We want the homepage link to take you directly to announcement’s standalone page
+
+## Implementation plan
+
+Add new parameters to the announcement front-matter:
+
+1. `spotlight: true`
+2. `homepage-title: New writing on trade`
+3. `source-document: https://docs.google.com/document/d/some-id/edit`
+
+When spotlight = true:
+
+1. Homepage link takes you to the page
+2. Feed link takes you to the page
+3. Feed post is truncated in the data we render for the feed and the item is also height-limited via CSS (max-height 300px + overflow: hidden)
+4. Add `<meta name="robots" content="noindex, follow" />` to the head of the announcement and set `<link rel="canonical">` to the `source-document`
+5. Open Graph/Twitter meta should still reference the announcement URL for sharing previews, even if the canonical points to the source topic page
+
+Validation
+
+1.  homepage-title is required, if spotlight = true - will need to update gdocsValidation.ts
+2.  spotlight cannot be true if it's a cta-style announcement
+3.  source-document must exist, be published, and be a full URL without anchors/fragments
+
+SEO and sitemap rules
+
+1. Announcements are already excluded from sitemaps; keep spotlights excluded as well.
+2. Dedicated announcement pages (spotlight and non-spotlight) should include `<meta name="robots" content="noindex, follow" />`; spotlights also set canonical to `source-document`, while non-spotlights can canonical to themselves.
+
+TODO
+
+- [ ] Add types for spotlight fields (`homepage-title`, `spotlight`, `source-document`)
+- [ ] Implement validation in `gdocsValidation.ts` (requirements, CTA exclusion, URL checks)
+- [ ] Update homepage latestAnnouncements behaviour for spotlights
+- [ ] Update announcement page rendering for spotlights
+- [ ] Update announcement feed rendering for spotlights

--- a/ANNOUNCEMENT_SPOTLIGHTS.md
+++ b/ANNOUNCEMENT_SPOTLIGHTS.md
@@ -31,7 +31,7 @@ When spotlight = true:
 
 1. Homepage link takes you to the page
 2. Feed link takes you to the page
-3. Feed post is truncated in the data we render for the feed and the item is also height-limited via CSS (max-height 300px + overflow: hidden)
+3. Feed post is truncated in the data we render for the feed and the item is also height-limited via CSS
 4. Add `<meta name="robots" content="noindex, follow" />` to the head of the announcement and set `<link rel="canonical">` to the `source-document`
 5. Open Graph/Twitter meta should still reference the announcement URL for sharing previews, even if the canonical points to the source topic page
 
@@ -51,5 +51,5 @@ TODO
 - [x] Add types for spotlight fields (`homepage-title`, `spotlight`, `source-document`)
 - [x] Implement validation in `gdocsValidation.ts` (requirements, CTA exclusion, URL checks)
 - [x] Update homepage latestAnnouncements behaviour for spotlights
-- [ ] Update announcement page rendering for spotlights
-- [x] Update announcement feed rendering for spotlights
+- [x] Update announcement page rendering for spotlights
+- [x] Update announcement feed rendering for spotlights (truncate data + CSS height limit)

--- a/ANNOUNCEMENT_SPOTLIGHTS.md
+++ b/ANNOUNCEMENT_SPOTLIGHTS.md
@@ -49,7 +49,7 @@ SEO and sitemap rules
 TODO
 
 - [x] Add types for spotlight fields (`homepage-title`, `spotlight`, `source-document`)
-- [ ] Implement validation in `gdocsValidation.ts` (requirements, CTA exclusion, URL checks)
+- [x] Implement validation in `gdocsValidation.ts` (requirements, CTA exclusion, URL checks)
 - [ ] Update homepage latestAnnouncements behaviour for spotlights
 - [ ] Update announcement page rendering for spotlights
 - [ ] Update announcement feed rendering for spotlights

--- a/adminSiteClient/gdocsDeploy.ts
+++ b/adminSiteClient/gdocsDeploy.ts
@@ -133,6 +133,9 @@ export const checkIsLightningUpdate = (
         excerpt: false,
         "featured-image": false,
         cta: false,
+        "homepage-title": false,
+        spotlight: false,
+        "source-document": false,
     }
     const authorLightningPropContentConfigMap: Record<
         keyof OwidGdocAuthorContent,

--- a/adminSiteClient/gdocsValidation.ts
+++ b/adminSiteClient/gdocsValidation.ts
@@ -8,6 +8,7 @@ import {
     traverseEnrichedBlock,
     OwidGdocErrorMessageProperty,
     OwidGdoc,
+    OwidGdocAnnouncementInterface,
     checkIsGdocPost,
     checkIsDataInsight,
     OwidGdocDataInsightInterface,
@@ -288,6 +289,53 @@ function validateSocials(
     )
 }
 
+function validateAnnouncement(
+    gdoc: OwidGdocAnnouncementInterface,
+    errors: OwidGdocErrorMessage[]
+) {
+    const spotlight = gdoc.content.spotlight
+    const homepageTitle = gdoc.content["homepage-title"]
+    const sourceDocument = gdoc.content["source-document"]
+    const { cta, kicker } = gdoc.content
+
+    if (!kicker) {
+        errors.push({
+            property: "kicker",
+            type: OwidGdocErrorMessageType.Error,
+            message: "Announcement must have a kicker.",
+        })
+    }
+
+    if (spotlight) {
+        if (!homepageTitle) {
+            errors.push({
+                property: "homepage-title",
+                type: OwidGdocErrorMessageType.Error,
+                message:
+                    "Spotlight announcements require a homepage-title for the homepage listing.",
+            })
+        }
+
+        if (!sourceDocument) {
+            errors.push({
+                property: "source-document",
+                type: OwidGdocErrorMessageType.Error,
+                message:
+                    "Spotlight announcements must specify a source-document URL for the canonical target.",
+            })
+        }
+
+        if (cta) {
+            errors.push({
+                property: "spotlight",
+                type: OwidGdocErrorMessageType.Error,
+                message:
+                    "Spotlight announcements cannot include a CTA. Remove spotlight or remove the CTA.",
+            })
+        }
+    }
+}
+
 export const getErrors = (gdoc: OwidGdoc): OwidGdocErrorMessage[] => {
     const errors: OwidGdocErrorMessage[] = []
 
@@ -312,6 +360,8 @@ export const getErrors = (gdoc: OwidGdoc): OwidGdocErrorMessage[] => {
         validateDataInsightImage(gdoc, errors)
     } else if (checkIsAuthor(gdoc)) {
         validateSocials(gdoc, errors)
+    } else if (gdoc.content.type === OwidGdocType.Announcement) {
+        validateAnnouncement(gdoc as OwidGdocAnnouncementInterface, errors)
     }
 
     return errors

--- a/db/model/Gdoc/GdocAnnouncement.ts
+++ b/db/model/Gdoc/GdocAnnouncement.ts
@@ -5,9 +5,11 @@ import {
     excludeNullish,
     OwidGdocErrorMessage,
     OwidGdocErrorMessageType,
+    Url,
 } from "@ourworldindata/utils"
 import { GdocBase } from "./GdocBase.js"
 import { extractUrl } from "./gdocUtils.js"
+import { getUrlTarget } from "@ourworldindata/components"
 
 export class GdocAnnouncement
     extends GdocBase
@@ -20,7 +22,10 @@ export class GdocAnnouncement
     }
 
     protected override typeSpecificUrls(): string[] {
-        return excludeNullish([this.content.cta?.url])
+        return excludeNullish([
+            this.content.cta?.url,
+            this.content["source-document"],
+        ])
     }
 
     override _validateSubclass = async (): Promise<OwidGdocErrorMessage[]> => {
@@ -35,12 +40,70 @@ export class GdocAnnouncement
             }
         }
 
+        if (this.content.spotlight) {
+            if (!this.content["homepage-title"]) {
+                errors.push({
+                    property: "homepage-title",
+                    message:
+                        "Spotlight announcements require a homepage-title for the homepage listing.",
+                    type: OwidGdocErrorMessageType.Error,
+                })
+            }
+            if (!this.content["source-document"]) {
+                errors.push({
+                    property: "source-document",
+                    message:
+                        "Spotlight announcements must specify a source-document URL for the canonical target.",
+                    type: OwidGdocErrorMessageType.Error,
+                })
+            }
+            if (this.content.cta) {
+                errors.push({
+                    property: "spotlight",
+                    message:
+                        "Spotlight announcements cannot include a CTA. Remove spotlight or remove the CTA.",
+                    type: OwidGdocErrorMessageType.Error,
+                })
+            }
+
+            if (this.content["source-document"]) {
+                const parsed = Url.fromURL(this.content["source-document"])
+                if (parsed.hash) {
+                    errors.push({
+                        property: "source-document",
+                        message:
+                            "source-document must not include anchors or fragments.",
+                        type: OwidGdocErrorMessageType.Error,
+                    })
+                }
+
+                const target = getUrlTarget(this.content["source-document"])
+                const linkedDoc = this.linkedDocuments?.[target]
+                if (!linkedDoc) {
+                    errors.push({
+                        property: "source-document",
+                        message: `source-document must link to a published gdoc, but no linked document was found for target "${target}".`,
+                        type: OwidGdocErrorMessageType.Error,
+                    })
+                } else if (!linkedDoc.published) {
+                    errors.push({
+                        property: "source-document",
+                        message: `source-document must link to a published gdoc, but "${linkedDoc.slug}" is not published.`,
+                        type: OwidGdocErrorMessageType.Error,
+                    })
+                }
+            }
+        }
+
         return errors
     }
 
     override _enrichSubclassContent = (content: Record<string, any>): void => {
         if (content.cta?.url) {
             content.cta.url = extractUrl(content.cta.url)
+        }
+        if (content["source-document"]) {
+            content["source-document"] = extractUrl(content["source-document"])
         }
     }
 

--- a/db/model/Gdoc/GdocBase.ts
+++ b/db/model/Gdoc/GdocBase.ts
@@ -1231,6 +1231,9 @@ export function rawGdocToMinimalPost(
         "featured-image": featuredImage,
         kicker: content.kicker,
         cta: content.cta,
+        "homepage-title": content["homepage-title"],
+        spotlight: content.spotlight,
+        "source-document": content["source-document"],
     }
 }
 

--- a/db/model/Gdoc/GdocPost.ts
+++ b/db/model/Gdoc/GdocPost.ts
@@ -15,6 +15,7 @@ import {
     DbEnrichedImage,
     LinkedAuthor,
     LinkedChart,
+    OwidGdocAnnouncementInterface,
 } from "@ourworldindata/types"
 import { excludeNullish, formatDate } from "@ourworldindata/utils"
 import {
@@ -233,9 +234,20 @@ function gdocToLatestItem(
             },
         }
     } else {
+        const announcementJson = gdoc.toJSON() as OwidGdocAnnouncementInterface
+        const isSpotlight = announcementJson.content.spotlight
+        const body = isSpotlight
+            ? announcementJson.content.body.slice(0, 4)
+            : announcementJson.content.body
         return {
             type: OwidGdocType.Announcement,
-            data: gdoc,
+            data: {
+                ...announcementJson,
+                content: {
+                    ...announcementJson.content,
+                    body,
+                },
+            },
         }
     }
 }

--- a/db/model/Gdoc/GdocPost.ts
+++ b/db/model/Gdoc/GdocPost.ts
@@ -326,12 +326,19 @@ export const enrichLatestPageItems = async (
         (images) => images.map((image) => image.filename)
     )
 
+    // Gather author featured image filenames
+    const authorFeaturedImageFilenames = R.pipe(
+        linkedAuthors.map((author) => author.featuredImage),
+        excludeNullish
+    )
+
     // Fetch image metadata
     const imageMetadata = await getAllImages(knex).then((allImages) =>
         pick(keyBy(allImages, "filename"), [
             ...linkedDocumentFeaturedImageFilenames,
             ...articleFeaturedImageFilenames,
             ...announcementAndDataInsightImageFilenames,
+            ...authorFeaturedImageFilenames,
         ])
     )
 

--- a/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
@@ -152,6 +152,9 @@ export interface OwidGdocMinimalPostInterface {
     "featured-image"?: string // used in prominent links and research & writing block
     kicker?: string // used in homepage announcements
     cta?: { text: string; url: string } // used in homepage announcements
+    "homepage-title"?: string // alternate title for homepage spotlight announcements
+    spotlight?: boolean
+    "source-document"?: string
 }
 
 export type OwidGdocIndexItem = Pick<
@@ -242,6 +245,9 @@ export interface OwidGdocAnnouncementContent {
         text: string
         url: string
     }
+    "homepage-title"?: string
+    spotlight?: boolean
+    "source-document"?: string
 }
 
 export interface OwidGdocAnnouncementInterface extends OwidGdocBaseInterface {

--- a/site/Head.tsx
+++ b/site/Head.tsx
@@ -37,6 +37,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
 export const Head = (props: {
     canonicalUrl: string
+    ogUrl?: string
     pageTitle?: string
     pageDesc?: string
     imageUrl?: string
@@ -48,8 +49,9 @@ export const Head = (props: {
     }
     staticAssetMap?: AssetMap
     archiveContext?: ArchiveContext
+    robots?: string
 }) => {
-    const { canonicalUrl, baseUrl } = props
+    const { canonicalUrl, baseUrl, ogUrl = canonicalUrl, robots } = props
     const pageTitle = props.pageTitle || `Our World in Data`
     const fullPageTitle = props.pageTitle
         ? `${props.pageTitle} - Our World in Data`
@@ -84,6 +86,7 @@ export const Head = (props: {
             <title>{fullPageTitle}</title>
             <meta name="description" content={pageDesc} />
             <link rel="canonical" href={canonicalUrl} />
+            {robots && <meta name="robots" content={robots} />}
             <link
                 rel="alternate"
                 type="application/atom+xml"
@@ -110,7 +113,7 @@ export const Head = (props: {
                 type="font/woff2"
                 crossOrigin="anonymous"
             />
-            <meta property="og:url" content={canonicalUrl} />
+            <meta property="og:url" content={ogUrl} />
             <meta property="og:title" content={pageTitle} />
             <meta property="og:description" content={pageDesc} />
             <meta property="og:image" content={encodeURI(imageUrl)} />

--- a/site/LatestPage.scss
+++ b/site/LatestPage.scss
@@ -204,11 +204,44 @@
 
 /* Announcement */
 .latest-page__announcement {
+    background-color: #fff;
     .announcement-page-content {
         margin: 0;
         @include sm-only {
             padding-left: 16px;
             padding-right: 16px;
         }
+    }
+}
+.latest-page__announcement--spotlight {
+    .announcement-page-content {
+        > [class*="article-block__"]:last-child {
+            position: relative;
+            &::before {
+                content: "";
+                position: absolute;
+                pointer-events: none;
+                bottom: 0;
+                width: 100%;
+                height: 100%;
+                z-index: 2;
+                background: linear-gradient(
+                    180deg,
+                    rgba(255, 255, 255, 0) 50%,
+                    #ffffff 100%
+                );
+            }
+        }
+    }
+}
+
+.latest-page__spotlight-cta {
+    margin-left: 24px;
+    // margin-top: -16px;
+    @include md-down {
+        @include body-2-regular;
+    }
+    @include sm-only {
+        margin-left: 16px;
     }
 }

--- a/site/LatestPage.tsx
+++ b/site/LatestPage.tsx
@@ -15,7 +15,10 @@ import {
 import { Html } from "./Html.js"
 import { AttachmentsContext } from "./gdocs/AttachmentsContext.js"
 import { AnnouncementPageContent } from "./gdocs/pages/Announcement.js"
-import { getPrefixedGdocPath } from "@ourworldindata/components"
+import {
+    getCanonicalUrl,
+    getPrefixedGdocPath,
+} from "@ourworldindata/components"
 import Image from "./gdocs/components/Image.js"
 import { ArticleBlocks } from "./gdocs/components/ArticleBlocks.js"
 import DataInsightDateline from "./gdocs/components/DataInsightDateline.js"
@@ -23,6 +26,8 @@ import cx from "classnames"
 import { Pagination } from "./Pagination.js"
 import { NewsletterSubscriptionContext } from "./newsletter.js"
 import { NewsletterSignupBlock } from "./NewsletterSignupBlock.js"
+import { Cta } from "./gdocs/components/Cta.js"
+import { BAKED_BASE_URL } from "../settings/clientSettings.js"
 
 const COMMON_CLASSES =
     "grid grid-cols-6 span-cols-6 col-start-5 span-md-cols-10 col-md-start-2 span-sm-cols-14 col-sm-start-1"
@@ -129,14 +134,29 @@ const LatestPageArticle = (props: { data: OwidGdocMinimalPostInterface }) => {
 const LatestPageAnnouncement = (props: {
     data: OwidGdocAnnouncementInterface
 }) => {
+    const isSpotlight = props.data.content.spotlight
     return (
         <article
             id={props.data.slug}
             className={cx(
-                "latest-page__announcement span-cols-6 col-start-5 span-md-cols-10 col-md-start-2 span-sm-cols-14 col-sm-start-1"
+                "latest-page__announcement span-cols-6 col-start-5 span-md-cols-10 col-md-start-2 span-sm-cols-14 col-sm-start-1",
+                {
+                    "latest-page__announcement--spotlight": isSpotlight,
+                }
             )}
         >
             <AnnouncementPageContent {...props.data} />
+            {isSpotlight && (
+                <Cta
+                    shouldRenderLinks
+                    className="latest-page__spotlight-cta"
+                    text="Continue reading"
+                    url={getCanonicalUrl(BAKED_BASE_URL, {
+                        slug: props.data.slug,
+                        content: { type: OwidGdocType.Announcement },
+                    })}
+                />
+            )}
         </article>
     )
 }

--- a/site/LatestPageContent.tsx
+++ b/site/LatestPageContent.tsx
@@ -3,6 +3,7 @@ import {
     LatestPageItem,
     LinkedAuthor,
     OwidGdocAnnouncementInterface,
+    OwidGdocMinimalPostInterface,
     OwidGdocType,
 } from "@ourworldindata/utils"
 import { AttachmentsContext } from "./gdocs/AttachmentsContext.js"
@@ -14,6 +15,7 @@ export interface LatestPageProps {
     posts: LatestPageItem[]
     imageMetadata: Record<string, ImageMetadata>
     linkedAuthors: LinkedAuthor[]
+    linkedDocuments?: Record<string, OwidGdocMinimalPostInterface>
 }
 
 const LatestPageAnnouncement = (props: {
@@ -27,7 +29,7 @@ const LatestPageAnnouncement = (props: {
 }
 
 export const LatestPageContent = (props: LatestPageProps) => {
-    const { posts, imageMetadata, linkedAuthors } = props
+    const { posts, imageMetadata, linkedAuthors, linkedDocuments = {} } = props
 
     // Filter only announcements that need hydration (have images with interactive elements)
     const announcements = posts.filter(
@@ -41,7 +43,7 @@ export const LatestPageContent = (props: LatestPageProps) => {
                 imageMetadata,
                 linkedAuthors,
                 linkedCharts: {},
-                linkedDocuments: {},
+                linkedDocuments,
                 linkedIndicators: {},
                 relatedCharts: [],
                 tags: [],

--- a/site/css/grid-margin-overrides.scss
+++ b/site/css/grid-margin-overrides.scss
@@ -12,7 +12,8 @@
 * e.g. .red-if-followed-by-h1:has(+ h1) { color: red }
 **/
 
-.centered-article-container {
+.centered-article-container,
+.announcement-page-content {
     [class*="article-block__"]:has(+ .article-block__side-by-side),
     [class*="article-block__"]:has(+ .article-block__sticky-left),
     [class*="article-block__"]:has(+ .article-block__sticky-right) {

--- a/site/gdocs/OwidGdocPage.tsx
+++ b/site/gdocs/OwidGdocPage.tsx
@@ -31,6 +31,7 @@ import {
     EnrichedBlockText,
     OwidGdocPostInterface,
     OwidGdocAuthorInterface,
+    OwidGdocAnnouncementContent,
 } from "@ourworldindata/types"
 import { DATA_INSIGHT_ATOM_FEED_PROPS } from "../SiteConstants.js"
 import { Html } from "../Html.js"
@@ -240,13 +241,29 @@ export default function OwidGdocPage({
 
     const pageDesc = getPageDesc(gdoc)
     const featuredImageFilename = getFeaturedImageFilename(gdoc)
-    const canonicalUrl = getCanonicalUrl(baseUrl, gdoc)
     const pageTitle = getPageTitle(gdoc)
     const isOnArchivalPage = archiveContext?.type === "archive-page"
     const assetMaps = isOnArchivalPage ? archiveContext.assets : undefined
     const isDataInsight = gdoc.content.type === OwidGdocType.DataInsight
+    const isAnnouncement = gdoc.content.type === OwidGdocType.Announcement
     const isAuthor = checkIsAuthor(gdoc)
     const isPost = isPostPredicate(gdoc)
+    const announcementPageUrl = getCanonicalUrl(baseUrl, gdoc)
+
+    let canonicalUrl = announcementPageUrl
+    let ogUrl = announcementPageUrl
+    let robots: string | undefined
+
+    if (isAnnouncement) {
+        robots = "noindex, follow"
+        const announcementContent =
+            gdoc.content as OwidGdocAnnouncementContent
+        const sourceDocument = announcementContent["source-document"]
+        if (announcementContent.spotlight && sourceDocument) {
+            canonicalUrl = sourceDocument
+            ogUrl = announcementPageUrl
+        }
+    }
 
     let imageUrl
     if (
@@ -280,11 +297,13 @@ export default function OwidGdocPage({
                 pageTitle={pageTitle}
                 pageDesc={pageDesc}
                 canonicalUrl={canonicalUrl}
+                ogUrl={ogUrl}
                 imageUrl={imageUrl} // uriEncoding is taken care of inside the Head component
                 atom={isDataInsight ? DATA_INSIGHT_ATOM_FEED_PROPS : undefined}
                 baseUrl={baseUrl}
                 staticAssetMap={assetMaps?.static}
                 archiveContext={archiveContext}
+                robots={robots}
             >
                 {!isAuthor && !isDataInsight && (
                     <CitationMeta

--- a/site/gdocs/OwidGdocPage.tsx
+++ b/site/gdocs/OwidGdocPage.tsx
@@ -256,8 +256,7 @@ export default function OwidGdocPage({
 
     if (isAnnouncement) {
         robots = "noindex, follow"
-        const announcementContent =
-            gdoc.content as OwidGdocAnnouncementContent
+        const announcementContent = gdoc.content as OwidGdocAnnouncementContent
         const sourceDocument = announcementContent["source-document"]
         if (announcementContent.spotlight && sourceDocument) {
             canonicalUrl = sourceDocument

--- a/site/gdocs/components/Callout.scss
+++ b/site/gdocs/components/Callout.scss
@@ -1,3 +1,30 @@
+.callout {
+    .article-block__text,
+    .article-block__list,
+    .article-block__html,
+    .article-block__numbered-list {
+        @include body-3-regular;
+        margin-bottom: 0;
+
+        &:not(:last-child) {
+            margin-bottom: 8px;
+        }
+    }
+
+    a {
+        @include owid-link-90;
+    }
+    color: $blue-60;
+    background: $gray-10;
+    padding: 16px 24px;
+    border-radius: 8px;
+    margin: 8px 0 32px;
+
+    + .article-block__horizontal-rule {
+        margin-top: 24px;
+    }
+}
+
 .callout-heading {
     @include h4-semibold;
     margin-top: 0;

--- a/site/gdocs/components/Callout.tsx
+++ b/site/gdocs/components/Callout.tsx
@@ -1,3 +1,4 @@
+import cx from "classnames"
 import { EnrichedBlockCallout } from "@ourworldindata/types"
 import { faInfoCircle } from "@fortawesome/free-solid-svg-icons"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
@@ -16,7 +17,7 @@ export default function Callout({
 }) {
     const icon = block.icon ? iconMap[block.icon] : null
     return (
-        <div className={className}>
+        <div className={cx("callout", className)}>
             {block.title ? (
                 <h4 className="callout-heading">
                     {icon && (

--- a/site/gdocs/components/HomepageIntro.tsx
+++ b/site/gdocs/components/HomepageIntro.tsx
@@ -139,8 +139,7 @@ function HomepageAnnouncement(props: {
 }) {
     const { announcement, index } = props
     const isSpotlight = announcement.spotlight
-    const homepageTitle =
-        announcement["homepage-title"] || announcement.title
+    const homepageTitle = announcement["homepage-title"] || announcement.title
     const announcementPageUrl = `/${announcement.slug}`
     const { linkedChart } = useLinkedChart(announcement.cta?.url || "")
     const { linkedDocument } = useLinkedDocument(announcement.cta?.url || "")

--- a/site/gdocs/components/HomepageIntro.tsx
+++ b/site/gdocs/components/HomepageIntro.tsx
@@ -138,6 +138,10 @@ function HomepageAnnouncement(props: {
     index: number
 }) {
     const { announcement, index } = props
+    const isSpotlight = announcement.spotlight
+    const homepageTitle =
+        announcement["homepage-title"] || announcement.title
+    const announcementPageUrl = `/${announcement.slug}`
     const { linkedChart } = useLinkedChart(announcement.cta?.url || "")
     const { linkedDocument } = useLinkedDocument(announcement.cta?.url || "")
     // If there's not enough space to show all of the third announcement, we link to the latest page, no matter what
@@ -149,12 +153,16 @@ function HomepageAnnouncement(props: {
         announcementRef as RefObject<HTMLElement>
     )
     const latestPageLink = `/latest#${announcement.slug}`
-    const href = isOverflowing
-        ? latestPageLink
-        : linkedChart?.resolvedUrl ||
-          linkedDocument?.url ||
-          announcement.cta?.url ||
-          latestPageLink
+    const ctaHref =
+        linkedChart?.resolvedUrl ||
+        linkedDocument?.url ||
+        announcement.cta?.url ||
+        null
+    const href = isSpotlight
+        ? announcementPageUrl
+        : isOverflowing
+          ? latestPageLink
+          : ctaHref || latestPageLink
 
     const publishedAtDayJs = dayjs(announcement.publishedAt!)
     const publishedAtFormatted = publishedAtDayJs.isToday()
@@ -185,7 +193,7 @@ function HomepageAnnouncement(props: {
                     id={`announcement-${announcement.id}`}
                     className="homepage-intro__announcement-title body-2-bold"
                 >
-                    {announcement.title}
+                    {homepageTitle}
                 </h3>
                 <p className="homepage-intro__excerpt body-3-medium">
                     {announcement.excerpt}

--- a/site/gdocs/components/centered-article.scss
+++ b/site/gdocs/components/centered-article.scss
@@ -1042,34 +1042,6 @@ div.raw-html-table__container {
     }
 }
 
-// A small grey block
-.article-block__callout {
-    .article-block__text,
-    .article-block__list,
-    .article-block__html,
-    .article-block__numbered-list {
-        @include body-3-regular;
-        margin-bottom: 0;
-
-        &:not(:last-child) {
-            margin-bottom: 8px;
-        }
-    }
-
-    a {
-        @include owid-link-90;
-    }
-    color: $blue-60;
-    background: $gray-10;
-    padding: 16px 24px;
-    border-radius: 8px;
-    margin: 8px 0 32px;
-
-    + .article-block__horizontal-rule {
-        margin-top: 24px;
-    }
-}
-
 @include column-block-override {
     margin: 48px 0;
 

--- a/site/gdocs/pages/Announcement.scss
+++ b/site/gdocs/pages/Announcement.scss
@@ -6,24 +6,20 @@
     background-color: #fff;
     padding: 24px;
     margin: 48px 0;
+    display: flex;
+    flex-direction: column;
 
     .data-insight-dateline {
         @include h6-black-caps;
+        margin: 0;
     }
 
     > [class*="article-block__"]:last-child {
         margin-bottom: 0;
     }
 
-    h2.article-block__heading {
-        @include subtitle-1-bold;
-        text-wrap: unset;
-        @include sm-only {
-            @include subtitle-2-bold;
-        }
-    }
     .article-block__chart {
-        margin: 32px 0;
+        margin: 16px 0;
     }
 }
 
@@ -38,8 +34,50 @@
 
 .announcement-page-heading {
     margin: 8px 0;
-    font-size: 30px;
+    font-size: 1.875rem;
+    line-height: 2.125rem;
+    font-weight: 600;
     @include sm-only {
-        font-size: 22px;
+        font-size: 1.375rem;
+        line-height: 1.75rem;
+    }
+}
+
+/* Spotlight specific styles */
+.announcement-page-content--spotlight {
+    .callout {
+        @include body-3-medium;
+        color: $blue-60;
+        background-color: transparent;
+        font-style: italic;
+        border-radius: 0;
+        padding: 0;
+        padding-bottom: 24px;
+        border-bottom: $blue-10 1px solid;
+
+        + h1.article-block__heading {
+            margin-top: 24px;
+            margin-bottom: 16px;
+            font-size: 1.5rem;
+            line-height: 2rem;
+
+            @include sm-only {
+                font-size: 1.25rem;
+                line-height: 1.75rem;
+            }
+
+            .deep-link {
+                display: none;
+            }
+        }
+    }
+
+    .article-block__chart + [class*="article-block__"] {
+        margin-top: 16px;
+    }
+
+    h2.article-block__heading,
+    h3.article-block__heading {
+        margin-bottom: 8px;
     }
 }

--- a/site/gdocs/pages/Announcement.scss
+++ b/site/gdocs/pages/Announcement.scss
@@ -14,6 +14,17 @@
     > [class*="article-block__"]:last-child {
         margin-bottom: 0;
     }
+
+    h2.article-block__heading {
+        @include subtitle-1-bold;
+        text-wrap: unset;
+        @include sm-only {
+            @include subtitle-2-bold;
+        }
+    }
+    .article-block__chart {
+        margin: 32px 0;
+    }
 }
 
 .announcement-page-header-meta {
@@ -27,4 +38,8 @@
 
 .announcement-page-heading {
     margin: 8px 0;
+    font-size: 30px;
+    @include sm-only {
+        font-size: 22px;
+    }
 }

--- a/site/gdocs/pages/Announcement.tsx
+++ b/site/gdocs/pages/Announcement.tsx
@@ -1,5 +1,6 @@
 import { OwidGdocAnnouncementInterface } from "@ourworldindata/utils"
 import * as React from "react"
+import cx from "classnames"
 import { ArticleBlocks } from "../components/ArticleBlocks.js"
 import DataInsightDateline from "../components/DataInsightDateline.js"
 import LinkedAuthor from "../components/LinkedAuthor.js"
@@ -14,9 +15,15 @@ type AnnouncementProps = {
 
 export const AnnouncementPageContent = (props: AnnouncementProps) => {
     const { publishedAt } = props
+    const isSpotlight = props.content.spotlight ?? false
     return (
-        <div className="announcement-page-content span-cols-6 col-start-5 span-md-cols-8 col-md-start-4 span-sm-cols-14 col-sm-start-1">
-            <header className="span-cols-6 col-start-5 span-md-cols-8 col-md-start-4 span-sm-cols-14 col-sm-start-1">
+        <div
+            className={cx(
+                "announcement-page-content span-cols-6 col-start-5 span-md-cols-8 col-md-start-4 span-sm-cols-14 col-sm-start-1",
+                { "announcement-page-content--spotlight": isSpotlight }
+            )}
+        >
+            <header className="announcement-page-header span-cols-6 col-start-5 span-md-cols-8 col-md-start-4 span-sm-cols-14 col-sm-start-1">
                 <div className="announcement-page-header-meta">
                     <DataInsightDateline
                         publishedAt={publishedAt}


### PR DESCRIPTION
## Context

[Figma](https://www.figma.com/board/NKQ2SoyeUxvYTTeJQVvTwB/Topic-spotlight?node-id=1-160&t=P9pPCZv9y9JtnYLz-0)

We recently added a new “announcement” content type which powers the “Updates and Announcements” section on the homepage and also appears as a new kind of post on the new `/latest` feed.

There are 2 kinds of announcement, currently:

1. Regular - a standalone post that can contain whatever.
    1. Clicking on it from the homepage takes you to the feed
    2. Often has a short body and then a CTA at the bottom
2. CTA - a short announcement that exists to link to a second resource.
    1. Clicking on it from the homepage takes you straight to the resource
    2. Unused so far

Our authors are updating linear topic pages with new sections, and we want a way to announce them.

Regular announcements don’t quite work because:

1. These sections might be very long, longer than we want to put in the feed
2. We want them to have a different title on the homepage vs. on the feed
3. We want the homepage link to take you directly to announcement’s standalone page

## Implementation plan

Add new parameters to the announcement front-matter:

1. `spotlight: true`
2. `homepage-title: New writing on trade`
3. `source-document: https://docs.google.com/document/d/some-id/edit`

When spotlight = true:

1. Homepage link takes you to the page
2. Feed link takes you to the page
3. Feed post is truncated in the data we render for the feed and the item is also height-limited via CSS
4. Add `<meta name="robots" content="noindex, follow" />` to the head of the announcement and set `<link rel="canonical">` to the `source-document`
5. Open Graph/Twitter meta should still reference the announcement URL for sharing previews, even if the canonical points to the source topic page

Validation

1.  homepage-title is required, if spotlight = true - will need to update gdocsValidation.ts
2.  spotlight cannot be true if it's a cta-style announcement
3.  source-document must exist, be published, and be a full URL without anchors/fragments

SEO and sitemap rules

1. Announcements are already excluded from sitemaps; keep spotlights excluded as well.
2. Dedicated announcement pages (spotlight and non-spotlight) should include `<meta name="robots" content="noindex, follow" />`; spotlights also set canonical to `source-document`, while non-spotlights can canonical to themselves.

We also want a new design for the callout at the top of the post, but that's TBD (to be designed)

## Screenshots / Videos / Diagrams

https://github.com/user-attachments/assets/ab3d5cc2-da8e-4474-976e-0d9adc64c176

## Testing guidance

[You can use this testing gdoc](https://docs.google.com/document/d/1IU0ErVX66nNI5L66rCgp_4ERzkY2KkGlhTVPLFhjkzc/edit?tab=t.0)

- [ ] Does the staging experience have sign-off from product stakeholders?

**Reminder to annotate the PR diff with design notes, alternatives you considered, and any other helpful context.**

## Checklist

- [x] Changes to CSS/HTML were checked on Desktop and Mobile Safari at all three breakpoints
- [x] Changes to HTML were checked for accessibility concerns