### PR TITLE
🔨🤖 add viewId column to the explorer_views table

### DIFF
--- a/adminSiteServer/multiDim.ts
+++ b/adminSiteServer/multiDim.ts
@@ -27,7 +27,7 @@ import {
 import {
     mergeGrapherConfigs,
     MultiDimDataPageConfig,
-    multiDimDimensionsToViewId,
+    dimensionsToViewId,
 } from "@ourworldindata/utils"
 import * as db from "../db/db.js"
 import { upsertMultiDimDataPage } from "../db/model/MultiDimDataPage.js"
@@ -292,7 +292,7 @@ export async function upsertMultiDim(
                 patchGrapherConfig
             )
             const existingChartConfigId = existingViewIdsToChartConfigIds.get(
-                multiDimDimensionsToViewId(view.dimensions)
+                dimensionsToViewId(view.dimensions)
             )
             let chartConfigId
             if (existingChartConfigId) {
@@ -333,7 +333,7 @@ export async function upsertMultiDim(
     for (const view of enrichedConfig.views) {
         await upsertMultiDimXChartConfigs(knex, {
             multiDimId,
-            viewId: multiDimDimensionsToViewId(view.dimensions),
+            viewId: dimensionsToViewId(view.dimensions),
             variableId: view.indicators.y[0].id,
             chartConfigId: view.fullConfigId,
         })

--- a/baker/algolia/utils/mdimViews.ts
+++ b/baker/algolia/utils/mdimViews.ts
@@ -6,7 +6,7 @@ import {
     DbRawChartConfig,
     getUniqueNamesFromTagHierarchies,
     merge,
-    multiDimDimensionsToViewId,
+    dimensionsToViewId,
     MultiDimXChartConfigsTableName,
     parseChartConfig,
     queryParamsToStr,
@@ -62,7 +62,7 @@ async function getRecords(
     const relevantVariableMetadata =
         await getRelevantVariableMetadata(relevantVariableIds)
     return multiDim.config.views.map((view) => {
-        const viewId = multiDimDimensionsToViewId(view.dimensions)
+        const viewId = dimensionsToViewId(view.dimensions)
         const id = multiDimXChartConfigIdMap.get(`${multiDim.id}-${viewId}`)
         if (!id) {
             throw new Error(

--- a/db/docs/explorer_views.yml
+++ b/db/docs/explorer_views.yml
@@ -10,6 +10,9 @@ fields:
         description: Unique identifier for the explorer view
     explorerSlug:
         description: The slug of the explorer this view belongs to. References explorers.slug
+    viewId:
+        description: |
+            Human-readable identifier for this specific view within the explorer.
     dimensions:
         description: |
             JSON object containing the specific parameter choices for this view (e.g., {"energySource": "solar", "metric": "absolute energy"}).

--- a/db/migration/1764317847438-AddViewIdToExplorerViews.ts
+++ b/db/migration/1764317847438-AddViewIdToExplorerViews.ts
@@ -1,0 +1,125 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+// Inline the slugify logic to avoid external dependencies in migrations
+function slugify(str: string): string {
+    // Convert subscript and superscript numbers to regular numbers
+    const normalizedStr = str.replace(/[₀₁₂₃₄₅₆₇₈₉⁰¹²³⁴⁵⁶⁷⁸⁹]/g, (match) => {
+        const subscriptMap: { [key: string]: string } = {
+            "₀": "0",
+            "₁": "1",
+            "₂": "2",
+            "₃": "3",
+            "₄": "4",
+            "₅": "5",
+            "₆": "6",
+            "₇": "7",
+            "₈": "8",
+            "₉": "9",
+        }
+        const superscriptMap: { [key: string]: string } = {
+            "⁰": "0",
+            "¹": "1",
+            "²": "2",
+            "³": "3",
+            "⁴": "4",
+            "⁵": "5",
+            "⁶": "6",
+            "⁷": "7",
+            "⁸": "8",
+            "⁹": "9",
+        }
+        return subscriptMap[match] || superscriptMap[match] || match
+    })
+
+    return normalizedStr
+        .toLowerCase()
+        .trim()
+        .replace(/\s*\*.+\*/, "")
+        .replace(/[^\w\- /]+/g, "")
+        .replace(/ +/g, "-")
+        .replace(/\//g, "")
+}
+
+// Inline the dimensionsToViewId logic
+function dimensionsToViewId(
+    dimensions: Record<string, string> // Keys: dimension slugs, values: choice slugs
+): string {
+    return Object.entries(dimensions)
+        .sort(([keyA], [keyB]) => keyA.localeCompare(keyB))
+        .map(([_, value]) => slugify(value))
+        .join("__")
+        .toLowerCase()
+}
+
+export class AddViewIdToExplorerViews1764317847438
+    implements MigrationInterface
+{
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        // Add viewId column as nullable
+        await queryRunner.query(`-- sql
+            ALTER TABLE explorer_views
+            ADD COLUMN viewId VARCHAR(255) NULL
+        `)
+
+        // Fetch all existing rows
+        const rows = await queryRunner.query(`-- sql
+            SELECT id, dimensions FROM explorer_views
+        `)
+
+        // Update the explorer_views table in batches
+        if (rows.length > 0) {
+            // Create temporary table
+            await queryRunner.query(`-- sql
+                CREATE TEMPORARY TABLE temp_explorer_view_ids (
+                    id INT PRIMARY KEY,
+                    viewId VARCHAR(255) NOT NULL
+                )
+            `)
+
+            // Compute viewIds and insert in batches
+            const CHUNK_SIZE = 200
+            for (let i = 0; i < rows.length; i += CHUNK_SIZE) {
+                const chunk = rows.slice(i, i + CHUNK_SIZE)
+
+                // Build VALUES clause for batch insert
+                const values = chunk
+                    .map((row: any) => {
+                        const dimensions = JSON.parse(row.dimensions)
+                        const viewId = dimensionsToViewId(dimensions)
+                        return `(${row.id}, '${viewId}')`
+                    })
+                    .join(", ")
+
+                await queryRunner.query(`-- sql
+                    INSERT INTO temp_explorer_view_ids (id, viewId)
+                    VALUES ${values}
+                `)
+            }
+
+            // Update explorer_views from temporary table with single query
+            await queryRunner.query(`-- sql
+                UPDATE explorer_views ev
+                JOIN temp_explorer_view_ids tmp ON ev.id = tmp.id
+                SET ev.viewId = tmp.viewId
+            `)
+
+            // Drop temporary table
+            await queryRunner.query(`-- sql
+                DROP TEMPORARY TABLE temp_explorer_view_ids
+            `)
+        }
+
+        // Make column NOT NULL
+        await queryRunner.query(`-- sql
+            ALTER TABLE explorer_views
+            MODIFY COLUMN viewId VARCHAR(255) NOT NULL
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`-- sql
+            ALTER TABLE explorer_views
+            DROP COLUMN viewId
+        `)
+    }
+}

--- a/packages/@ourworldindata/types/src/dbTypes/ExplorerViews.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/ExplorerViews.ts
@@ -4,6 +4,7 @@ export const ExplorerViewsTableName = "explorer_views"
 export interface DbInsertExplorerView {
     id?: number
     explorerSlug: string
+    viewId: string
     dimensions: JsonString
     chartConfigId?: string // char(36) in database - UUID, nullable when error occurs
     error?: string // error message when configuration extraction fails

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -2272,3 +2272,13 @@ export function getDisplayUnit(
 
     return strippedUnit
 }
+
+export function dimensionsToViewId(
+    dimensions: Record<string, string> // Keys: dimension slugs, values: choice slugs
+): string {
+    return Object.entries(dimensions)
+        .sort(([keyA], [keyB]) => keyA.localeCompare(keyB))
+        .map(([_, value]) => slugify(value))
+        .join("__")
+        .toLowerCase()
+}

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -142,6 +142,7 @@ export {
     calculateTrendDirection,
     getDisplayUnit,
     stripOuterParentheses,
+    dimensionsToViewId,
 } from "./Util.js"
 
 export {
@@ -162,7 +163,7 @@ export {
     getPhraseForArchivalDate,
 } from "./metadataHelpers.js"
 
-export { multiDimDimensionsToViewId, getAllVariableIds } from "./multiDim.js"
+export { getAllVariableIds } from "./multiDim.js"
 
 export { isPresent } from "./isPresent.js"
 

--- a/packages/@ourworldindata/utils/src/multiDim.ts
+++ b/packages/@ourworldindata/utils/src/multiDim.ts
@@ -1,19 +1,4 @@
-import {
-    IndicatorsAfterPreProcessing,
-    MultiDimDimensionChoices,
-    View,
-} from "@ourworldindata/types"
-import { slugify } from "./Util.js"
-
-export function multiDimDimensionsToViewId(
-    dimensions: MultiDimDimensionChoices
-): string {
-    return Object.entries(dimensions)
-        .sort(([keyA], [keyB]) => keyA.localeCompare(keyB))
-        .map(([_, value]) => slugify(value))
-        .join("__")
-        .toLowerCase()
-}
+import { IndicatorsAfterPreProcessing, View } from "@ourworldindata/types"
 
 export function getAllVariableIds(
     views: View<IndicatorsAfterPreProcessing>[]


### PR DESCRIPTION
Adds a viewId column to the explorer_views table, similar to the mdim view ids we already have.

<!-- GitButler Footer Boundary Top -->
---
This is **part 4 of 5 in a stack** made with GitButler:
- <kbd>&nbsp;5&nbsp;</kbd> #5734 
- <kbd>&nbsp;4&nbsp;</kbd> #5732 👈 
- <kbd>&nbsp;3&nbsp;</kbd> #5725 
- <kbd>&nbsp;2&nbsp;</kbd> #5717 
- <kbd>&nbsp;1&nbsp;</kbd> #5713 
<!-- GitButler Footer Boundary Bottom -->

