### PR TITLE
✨ use the display title as filename for zip downloads

### DIFF
--- a/functions/_common/explorerHandlers.ts
+++ b/functions/_common/explorerHandlers.ts
@@ -9,7 +9,7 @@ import {
 import { renderSvgToPng } from "./grapherRenderer.js"
 import { error, png } from "itty-router"
 import { createZip, File } from "littlezipper"
-import { Bounds, Url } from "@ourworldindata/utils"
+import { Bounds, slugify, Url } from "@ourworldindata/utils"
 import {
     getEntityNamesParam,
     getSelectedEntityNamesParam,
@@ -227,15 +227,14 @@ export async function fetchZipForExplorerView(
         const csv = assembleCsv(grapherState, searchParams)
         console.log("Fetched the parts, creating zip file")
 
-        // Extract explorer slug
-        const explorerSlug = explorerEnv.url.pathname.split("/").pop()
+        const filename = slugify(grapherState.displayTitle)
 
         const zipContent: File[] = [
             {
-                path: `${explorerSlug}.metadata.json`,
+                path: `${filename}.metadata.json`,
                 data: JSON.stringify(metadata, undefined, 2),
             },
-            { path: `${explorerSlug}.csv`, data: csv },
+            { path: `${filename}.csv`, data: csv },
             { path: "readme.md", data: readme },
         ]
         const content = await createZip(zipContent)
@@ -244,7 +243,7 @@ export async function fetchZipForExplorerView(
         return new Response(content, {
             headers: {
                 "Content-Type": "application/zip",
-                "Content-Disposition": `attachment; filename="${explorerSlug}.zip"`,
+                "Content-Disposition": `attachment; filename="${filename}.zip"`,
             },
         })
     } catch (e) {

--- a/functions/_common/grapherTools.ts
+++ b/functions/_common/grapherTools.ts
@@ -223,7 +223,10 @@ export async function initGrapher(
 ): Promise<{
     grapher: Grapher
     multiDimAvailableDimensions?: string[]
+    identifierType: GrapherIdentifier["type"]
 }> {
+    let effectiveType = identifier.type
+
     let grapherConfigResponse: FetchGrapherConfigResult
     try {
         grapherConfigResponse = await fetchGrapherConfig({
@@ -249,6 +252,7 @@ export async function initGrapher(
                 env,
                 searchParams,
             })
+            effectiveType = "multi-dim-slug"
         } else {
             throw e
         }
@@ -282,6 +286,7 @@ export async function initGrapher(
 
     return {
         grapher,
+        identifierType: effectiveType,
         multiDimAvailableDimensions:
             grapherConfigResponse.multiDimAvailableDimensions,
     }


### PR DESCRIPTION
I figured that the nicest filename for our zip downloads is probably the slugified display title for explorers and mdims. It's of course not _guaranteed_ to be unique but it's nice and readable and much shorter than the serialised dimension value kets.

<!-- GitButler Footer Boundary Top -->
---
This is **part 5 of 5 in a stack** made with GitButler:
- <kbd>&nbsp;5&nbsp;</kbd> #5734 👈 
- <kbd>&nbsp;4&nbsp;</kbd> #5732 
- <kbd>&nbsp;3&nbsp;</kbd> #5725 
- <kbd>&nbsp;2&nbsp;</kbd> #5717 
- <kbd>&nbsp;1&nbsp;</kbd> #5713 
<!-- GitButler Footer Boundary Bottom -->

