### PR TITLE
🐛 make Continent columns respect the sort order

### DIFF
--- a/packages/@ourworldindata/core-table/src/CoreTableColumns.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTableColumns.ts
@@ -576,20 +576,6 @@ class StringColumn extends AbstractCoreColumn<string> {
 
 class SeriesAnnotationColumn extends StringColumn {}
 class CategoricalColumn extends StringColumn {}
-class RegionColumn extends CategoricalColumn {}
-class ContinentColumn extends RegionColumn {}
-class ColorColumn extends CategoricalColumn {}
-class BooleanColumn extends AbstractCoreColumn<boolean> {
-    jsType = JsTypes.boolean
-
-    formatValue(value: unknown): "true" | "false" {
-        return value ? "true" : "false"
-    }
-
-    override parse(val: unknown): boolean {
-        return !!val
-    }
-}
 
 class OrdinalColumn extends CategoricalColumn {
     @imemo get allowedValuesSorted(): string[] | undefined {
@@ -600,6 +586,22 @@ class OrdinalColumn extends CategoricalColumn {
         return this.allowedValuesSorted
             ? this.allowedValuesSorted
             : super.sortedUniqNonEmptyStringVals
+    }
+}
+
+class RegionColumn extends OrdinalColumn {}
+class ContinentColumn extends RegionColumn {}
+class ColorColumn extends CategoricalColumn {}
+
+class BooleanColumn extends AbstractCoreColumn<boolean> {
+    jsType = JsTypes.boolean
+
+    formatValue(value: unknown): "true" | "false" {
+        return value ? "true" : "false"
+    }
+
+    override parse(val: unknown): boolean {
+        return !!val
     }
 }
 

--- a/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.ts
+++ b/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.ts
@@ -600,7 +600,7 @@ const getSortFromDimensions = (
 
     const sort = values
         .map((value) => value.name)
-        .filter((name): name is string => name !== undefined)
+        .filter((name) => name !== undefined)
 
     if (sort.length === 0) return
 
@@ -637,15 +637,18 @@ const columnDefFromOwidVariable = (
     const name = variable.name
 
     // The column's type
-    const type = isContinent
-        ? ColumnTypeNames.Continent
-        : variable.type
-          ? variableTypeToColumnType(variable.type)
-          : ColumnTypeNames.NumberOrString
+    const parsedType = variable.type
+        ? variableTypeToColumnType(variable.type)
+        : ColumnTypeNames.NumberOrString
 
-    // Sorted values for ordinal columns
+    // Override the column type for the special Continents variable
+    const type = isContinent ? ColumnTypeNames.Continent : parsedType
+
+    // Extract the sort order for ordinal variables from their dimension metadata.
+    // This preserves the author-specified ordering of categorical values
+    // (e.g., "Low", "Medium", "High").
     const sort =
-        type === ColumnTypeNames.Ordinal
+        parsedType === ColumnTypeNames.Ordinal
             ? getSortFromDimensions(variable.dimensions)
             : undefined
 


### PR DESCRIPTION
Makes `RegionColumn` inherit from the `OrdinalColumn`