### PR TITLE
✨ disable switching from line to bar chart via the timeline

### DIFF
--- a/db/migration/1764661863496-DisableLineBarChartSwitching.ts
+++ b/db/migration/1764661863496-DisableLineBarChartSwitching.ts
@@ -1,0 +1,34 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class DisableLineBarChartSwitching1764661863496
+    implements MigrationInterface
+{
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`-- sql
+            UPDATE chart_configs cc
+            SET
+                full = JSON_SET(full, '$.tab', 'discrete-bar'),
+                patch = JSON_SET(patch, '$.tab', 'discrete-bar')
+            WHERE
+                -- Only update charts that have both LineChart and DiscreteBar chart types
+                (
+                    cc.full ->> '$.chartTypes' is null
+                    OR (
+                        JSON_SEARCH(cc.full -> '$.chartTypes', 'one', 'LineChart') IS NOT NULL
+                        AND JSON_SEARCH(cc.full -> '$.chartTypes', 'one', 'DiscreteBar') IS NOT NULL
+                    )
+                )
+                -- Only update charts with identical minTime and maxTime (i.e. the bar chart is initially shown)
+                AND COALESCE(cc.full ->> '$.minTime', 'earliest') = COALESCE(cc.full ->> '$.maxTime', 'latest')
+                -- Only update charts without explicit tab setting or with tab set to 'line'
+                AND (
+                    cc.full ->> '$.tab' IS NULL
+                    OR cc.full ->> '$.tab' = 'line'
+                );
+     `)
+    }
+
+    public async down(): Promise<void> {
+        // The migration is irreversible
+    }
+}

--- a/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
@@ -167,9 +167,6 @@ export enum GrapherModal {
     Embed = "embed",
 }
 
-export const CHART_TYPES_THAT_SWITCH_TO_DISCRETE_BAR_WHEN_SINGLE_TIME: GrapherChartType[] =
-    [GRAPHER_CHART_TYPES.LineChart, GRAPHER_CHART_TYPES.SlopeChart]
-
 export const CHART_TYPES_THAT_SHOW_ALL_ENTITIES: GrapherChartType[] = [
     GRAPHER_CHART_TYPES.ScatterPlot,
     GRAPHER_CHART_TYPES.Marimekko,

--- a/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
@@ -200,7 +200,6 @@ import {
     GRAPHER_FRAME_PADDING_VERTICAL,
     DEFAULT_GRAPHER_BOUNDS,
     GrapherModal,
-    CHART_TYPES_THAT_SWITCH_TO_DISCRETE_BAR_WHEN_SINGLE_TIME,
     CookieKey,
     GRAPHER_PROD_URL,
     BASE_FONT_SIZE,
@@ -775,54 +774,10 @@ export class GrapherState {
         ) as TimeBounds
     }
 
-    @computed private get shouldShowDiscreteBarWhenSingleTime(): boolean {
-        let { minTime, maxTime } = this
-
-        if (!this.validChartTypeSet.has(GRAPHER_CHART_TYPES.DiscreteBar))
-            return false
-
-        // If we have a time dimension but the timeline is hidden,
-        // we always want to use the authored `minTime` and `maxTime`,
-        // irrespective of the time range the user might have selected
-        // on the table tab
-        if (this.hasTimeDimensionButTimelineIsHidden) {
-            minTime = this.authorsVersion.minTime
-            maxTime = this.authorsVersion.maxTime
-        }
-
-        // This is the easy case: minTime and maxTime are the same, no need to do
-        // more fancy checks
-        if (minTime === maxTime) return true
-
-        // We can have cases where minTime = Infinity and/or maxTime = -Infinity,
-        // but still only a single year is selected.
-        // To check for that we need to look at the times array.
-        const times = this.table.timeColumn.uniqValues
-        const closestMinTime = findClosestTime(times, minTime ?? -Infinity)
-        const closestMaxTime = findClosestTime(times, maxTime ?? Infinity)
-        return closestMinTime !== undefined && closestMinTime === closestMaxTime
-    }
-
     @computed get activeTab(): GrapherTabName {
-        const activeTab = this.mapTabConfigOptionToTabName(this.tab)
-
-        // Switch to the discrete bar chart tab if we're on the line or slope
-        // chart tab and a single time is selected
-        if (
-            CHART_TYPES_THAT_SWITCH_TO_DISCRETE_BAR_WHEN_SINGLE_TIME.includes(
-                activeTab as any
-            ) &&
-            this.shouldShowDiscreteBarWhenSingleTime &&
-            // Don't switch to a bar chart while the timeline animation is playing.
-            // This is necessary because the time handles are at the same time
-            // at the beginning of the timeline animation
-            !this.isTimelineAnimationActive
-        ) {
-            return GRAPHER_TAB_NAMES.DiscreteBar
-        }
-
-        return activeTab
+        return this.mapTabConfigOptionToTabName(this.tab)
     }
+
     @computed get activeChartType(): GrapherChartType | undefined {
         return isChartTypeName(this.activeTab) ? this.activeTab : undefined
     }
@@ -1447,6 +1402,10 @@ export class GrapherState {
         return this.checkOnlySingleTimeSelectionPossible(this.activeTab)
     }
 
+    @computed get onlyTimeRangeSelectionPossible(): boolean {
+        return this.checkOnlyTimeRangeSelectionPossible(this.activeTab)
+    }
+
     @computed get isSingleTimeSelectionActive(): boolean {
         return (
             this.onlySingleTimeSelectionPossible ||
@@ -1529,7 +1488,7 @@ export class GrapherState {
         ].includes(tabName as any)
     }
 
-    private checkStartAndEndTimeSelectionPreferred = (
+    private checkOnlyTimeRangeSelectionPossible = (
         tabName: GrapherTabName
     ): boolean => {
         return [
@@ -1545,7 +1504,7 @@ export class GrapherState {
     ): void {
         if (this.checkOnlySingleTimeSelectionPossible(tab)) {
             this.ensureHandlesAreOnSameTime()
-        } else if (this.checkStartAndEndTimeSelectionPreferred(tab)) {
+        } else if (this.checkOnlyTimeRangeSelectionPossible(tab)) {
             this.ensureHandlesAreOnDifferentTimes()
         }
     }

--- a/packages/@ourworldindata/grapher/src/index.ts
+++ b/packages/@ourworldindata/grapher/src/index.ts
@@ -35,7 +35,6 @@ export {
     latestGrapherConfigSchema,
     DEFAULT_GRAPHER_BOUNDS,
     DEFAULT_GRAPHER_BOUNDS_SQUARE,
-    CHART_TYPES_THAT_SWITCH_TO_DISCRETE_BAR_WHEN_SINGLE_TIME,
 } from "./core/GrapherConstants"
 export {
     getVariableDataRoute,

--- a/packages/@ourworldindata/grapher/src/timeline/TimelineController.test.ts
+++ b/packages/@ourworldindata/grapher/src/timeline/TimelineController.test.ts
@@ -112,3 +112,97 @@ it("pins time to unboundedLeft or unboundedRight when marker is dragged beyond e
     )
     expect(manager.endHandleTimeBound).toEqual(TimeBoundValue.positiveInfinity)
 })
+
+it("prevents handles from being on the same time when onlyTimeRangeSelectionPossible is true", () => {
+    const manager: TimelineManager = {
+        times: _.range(2000, 2010),
+        startHandleTimeBound: 2000,
+        endHandleTimeBound: 2005,
+        onlyTimeRangeSelectionPossible: true,
+    }
+
+    const controller = new TimelineController(manager)
+
+    // Test dragging start handle towards end handle
+    controller.dragHandleToTime("start", 2005)
+    expect(manager.startHandleTimeBound).toEqual(2004)
+    expect(manager.endHandleTimeBound).toEqual(2005)
+
+    // Test dragging end handle towards start handle
+    controller.dragHandleToTime("end", 2004)
+    expect(manager.startHandleTimeBound).toEqual(2004)
+    expect(manager.endHandleTimeBound).toEqual(2005)
+
+    // Handles can still cross each other - when start is dragged past end,
+    // it becomes the end handle and the handles swap positions
+    controller.dragHandleToTime("start", 2006)
+    expect(manager.startHandleTimeBound).toEqual(2005)
+    expect(manager.endHandleTimeBound).toEqual(2006)
+})
+
+it("allows handles on same time when onlyTimeRangeSelectionPossible is false", () => {
+    const manager: TimelineManager = {
+        times: _.range(2000, 2010),
+        startHandleTimeBound: 2000,
+        endHandleTimeBound: 2005,
+        onlyTimeRangeSelectionPossible: false,
+    }
+
+    const controller = new TimelineController(manager)
+
+    // Dragging start handle to same position as end handle should work
+    controller.dragHandleToTime("start", 2005)
+    expect(manager.startHandleTimeBound).toEqual(2005)
+    expect(manager.endHandleTimeBound).toEqual(2005)
+})
+
+it("prevents keyboard navigation from putting handles on same time when onlyTimeRangeSelectionPossible is true", () => {
+    const manager: TimelineManager = {
+        times: _.range(2000, 2010),
+        startHandleTimeBound: 2003,
+        endHandleTimeBound: 2004,
+        onlyTimeRangeSelectionPossible: true,
+    }
+
+    const controller = new TimelineController(manager)
+
+    // Test increaseStartTime - should not move to end time
+    controller.increaseStartTime()
+    expect(manager.startHandleTimeBound).toEqual(2003)
+    expect(manager.endHandleTimeBound).toEqual(2004)
+
+    // Test decreaseEndTime - should not move to start time
+    controller.decreaseEndTime()
+    expect(manager.startHandleTimeBound).toEqual(2003)
+    expect(manager.endHandleTimeBound).toEqual(2004)
+
+    // Moving away should work
+    controller.decreaseStartTime()
+    expect(manager.startHandleTimeBound).toEqual(2002)
+
+    controller.increaseEndTime()
+    expect(manager.endHandleTimeBound).toEqual(2005)
+})
+
+it("prevents large step keyboard navigation from putting handles on same time when onlyTimeRangeSelectionPossible is true", () => {
+    const manager: TimelineManager = {
+        times: _.range(2000, 2010),
+        startHandleTimeBound: 2003,
+        endHandleTimeBound: 2004,
+        onlyTimeRangeSelectionPossible: true,
+    }
+
+    const controller = new TimelineController(manager)
+
+    // Test increaseStartTimeByLargeStep - should fall back to increaseStartTime
+    const initialStart = manager.startHandleTimeBound
+    controller.increaseStartTimeByLargeStep()
+    // Should not move to 2004 or beyond
+    expect(manager.startHandleTimeBound).toEqual(initialStart)
+
+    // Test decreaseEndTimeByLargeStep - should fall back to decreaseEndTime
+    const initialEnd = manager.endHandleTimeBound
+    controller.decreaseEndTimeByLargeStep()
+    // Should not move to 2003 or before
+    expect(manager.endHandleTimeBound).toEqual(initialEnd)
+})

--- a/site/search/SearchChartHitRichDataFallback.tsx
+++ b/site/search/SearchChartHitRichDataFallback.tsx
@@ -127,7 +127,6 @@ export function SearchChartHitRichDataFallback({
                         constructChartAndPreviewUrlsForTab({
                             hit,
                             tab: grapherTab,
-                            chartInfo,
                             entities,
                             hasScatter,
                         })

--- a/site/search/SearchChartHitSmall.tsx
+++ b/site/search/SearchChartHitSmall.tsx
@@ -88,7 +88,7 @@ export function SearchChartHitSmall({
                 <div className="search-chart-hit-small__tabs-container">
                     {hit.availableTabs.map((tab) => {
                         const { chartUrl } = constructChartAndPreviewUrlsForTab(
-                            { hit, tab, chartInfo, entities }
+                            { hit, tab, entities }
                         )
 
                         const label = makeLabelForGrapherTab(tab, {

--- a/site/search/SearchChartHitSmallHelpers.ts
+++ b/site/search/SearchChartHitSmallHelpers.ts
@@ -7,12 +7,10 @@ import {
     SearchChartHit,
 } from "@ourworldindata/types"
 import { fetchJson } from "@ourworldindata/utils"
-import { CHART_TYPES_THAT_SWITCH_TO_DISCRETE_BAR_WHEN_SINGLE_TIME } from "@ourworldindata/grapher"
 import {
     constructChartInfoUrl,
     constructChartUrl,
     constructPreviewUrl,
-    getTimeBoundsForChartUrl,
     toGrapherQueryParams,
 } from "./searchUtils"
 import { chartHitQueryKeys } from "./queries"
@@ -61,33 +59,15 @@ export function useQueryChartInfo({
 export function constructChartAndPreviewUrlsForTab({
     hit,
     tab,
-    chartInfo,
     entities,
     hasScatter = false,
 }: {
     hit: SearchChartHit
     tab: GrapherTabName
-    chartInfo?: GrapherValuesJson
     entities?: EntityName[]
     hasScatter?: boolean
 }): { chartUrl: string; previewUrl: string } {
-    // Single-time line charts are rendered as bar charts
-    // by Grapher. Adjusting the time param makes sure
-    // Grapher actually shows a line chart. This is important
-    // since we offer separate links for going to the line
-    // chart view and the bar chart view. If we didn't do
-    // this, both links would end up going to the bar chart.
-    const timeParam =
-        CHART_TYPES_THAT_SWITCH_TO_DISCRETE_BAR_WHEN_SINGLE_TIME.includes(
-            tab as any
-        )
-            ? getTimeBoundsForChartUrl(chartInfo)
-            : undefined
-    const grapherParams = toGrapherQueryParams({
-        entities,
-        tab,
-        ...timeParam,
-    })
+    const grapherParams = toGrapherQueryParams({ entities, tab })
 
     const chartUrl = constructChartUrl({
         hit,

--- a/site/search/searchUtils.tsx
+++ b/site/search/searchUtils.tsx
@@ -6,7 +6,6 @@ import {
     GrapherQueryParams,
     GrapherTabName,
     GrapherTabQueryParam,
-    GrapherValuesJson,
     OwidGdocType,
     TagGraphRoot,
     TimeBounds,
@@ -352,35 +351,6 @@ export const constructConfigUrl = ({
             return `${EXPLORER_DYNAMIC_CONFIG_URL}/${hit.slug}.config.json${queryStr}`
         })
         .exhaustive()
-}
-
-// Generates time bounds to force line charts to display properly in previews.
-// When start and end times are the same (single time point), line charts
-// automatically switch to discrete bar charts. To prevent that, we set the start
-// time to -Infinity, which refers to the earliest available data.
-export function getTimeBoundsForChartUrl(
-    chartInfo?: GrapherValuesJson | null
-): { timeBounds: TimeBounds; timeMode: "year" | "day" } | undefined {
-    if (!chartInfo) return undefined
-
-    const { startTime, endTime } = chartInfo
-
-    // When a chart has different start and end times, we don't need to adjust
-    // the time parameter because the chart will naturally display as a line chart.
-    // Note: `chartInfo` is fetched for the _default_ view. If startTime equals
-    // endTime here, it doesn't necessarily mean that the line chart is actually
-    // single-time, since we're looking at the default tab rather than the specific
-    // line chart tab. However, false positives are generally harmless because most
-    // charts don't customize their start time.
-    if (startTime && startTime !== endTime) return undefined
-
-    const columnSlug = chartInfo.endValues?.y.at(0)?.columnSlug ?? ""
-    const columnInfo = chartInfo.columns?.[columnSlug]
-
-    return {
-        timeBounds: [-Infinity, endTime ?? Infinity],
-        timeMode: columnInfo?.yearIsDay ? "day" : "year",
-    }
 }
 
 export const CHARTS_INDEX = getIndexName(


### PR DESCRIPTION
Resolves #5223, resolves #5568

Disables switching from a line/slope to a bar chart via the timeline, as discussed. End of an era!

The migration should take care of all charts where the discrete bar chart is currently the default implicitly. If you check the charts reported by the SVG tester on staging, they should look unchanged.