### PR TITLE
:hammer: Sentry: remove `minReplayDuration`

### DIFF
--- a/site/instrument.ts
+++ b/site/instrument.ts
@@ -41,7 +41,6 @@ if (LOAD_SENTRY) {
                 maskAllText: false,
                 maskAllInputs: false,
                 blockAllMedia: false,
-                minReplayDuration: 1000,
                 mask: [".sentry-mask"],
             }),
         ],


### PR DESCRIPTION
## Context

Recorded Sentry session replays are higher than expected (#5546), which might be driven by the introduction of `minReplayDuration` in #5344. Contrary to what I had hoped, `minReplayDuration` hasn't qualitatively improved Sentry session replays from what I've seen. So it's merely using up our session replay budget without adding tangible value.

It might not be the *main* driver of #5546, but it's definitely contributing (b/c we are for sure getting lots of session replays <5s in length that we wouldn't otherwise).