### PR TITLE
fix: duplicate search queries and renders

### DIFF
--- a/site/search/Search.tsx
+++ b/site/search/Search.tsx
@@ -69,19 +69,20 @@ export const Search = ({
 
     const isFetching = useIsFetching()
 
-    // Derived state for template configuration
-    const topicType = getSelectedTopicType(deferredState.filters, allAreas)
+    // Derived state for template configuration Use immediate state to avoid
+    // firing duplicate queries (one for the current (deferred) template, one for the
+    // target template after deferred value catches up)
+    const topicType = getSelectedTopicType(state.filters, allAreas)
     const templateConfig: TemplateConfig = {
         resultType: getEffectiveResultType(
-            deferredState.filters,
-            deferredState.query,
-            deferredState.resultType
+            state.filters,
+            state.query,
+            state.resultType
         ),
         topicType,
         hasCountry:
-            getFilterNamesOfType(deferredState.filters, FilterType.COUNTRY)
-                .size > 0,
-        hasQuery: deferredState.query.length > 0,
+            getFilterNamesOfType(state.filters, FilterType.COUNTRY).size > 0,
+        hasQuery: state.query.length > 0,
     }
 
     return (

--- a/site/search/SearchDataResults.tsx
+++ b/site/search/SearchDataResults.tsx
@@ -17,7 +17,7 @@ export const SearchDataResults = ({
     isFirstChartLarge: boolean
 }) => {
     const { analytics } = useSearchContext()
-    const selectedRegionNames = useSelectedRegionNames(true)
+    const selectedRegionNames = useSelectedRegionNames()
 
     const query = useInfiniteSearch<SearchChartsResponse, SearchChartHit>({
         queryKey: (state) => searchQueryKeys.charts(state),

--- a/site/search/SearchDataTopic.tsx
+++ b/site/search/SearchDataTopic.tsx
@@ -17,7 +17,7 @@ export const SearchDataTopic = ({
         analytics,
     } = useSearchContext()
 
-    const selectedRegionNames = useSelectedRegionNames(true)
+    const selectedRegionNames = useSelectedRegionNames()
 
     if (charts.nbHits === 0) return null
     const titleLabel = title.replaceAll(" and ", " & ")

--- a/site/search/searchHooks.ts
+++ b/site/search/searchHooks.ts
@@ -248,7 +248,7 @@ export function useInfiniteSearch<T extends SearchResponse<U>, U>({
     ) => Promise<T>
     enabled?: boolean
 }) {
-    const { deferredState: state, liteSearchClient } = useSearchContext()
+    const { state, liteSearchClient } = useSearchContext()
 
     const query = useInfiniteQuery<T, Error>({
         // All paginated subqueries share the same query key


### PR DESCRIPTION
fixes #5626

## Context

This PR fixes an issue where the search component was using deferred state for template configuration, which was causing duplicate queries to be fired. The issue occurs because the template configuration was using deferred state values, while the actual queries should be based on the immediate state.

## Changes

- Modified `Search.tsx` to use immediate state (`state`) instead of deferred state (`deferredState`) for template configuration
- Updated `useSelectedRegionNames()` calls in `SearchDataResults.tsx` and `SearchDataTopic.tsx` to use immediate state instead of deferred state
- Updated `useInfiniteSearch` in `searchHooks.ts` to use immediate state instead of deferred state

## Testing guidance

1. Open the search page and search "gdp"
2. Verify that only a single query is being fired in the network tab (filter by "queries"), even though a the template has changed from the default search page.
3. Confirm that search results are displayed correctly

- [ ] Does the staging experience have sign-off from product stakeholders?
