### PR TITLE
refactor: use react router for url state sync

### DIFF
--- a/packages/@ourworldindata/types/src/domainTypes/Search.ts
+++ b/packages/@ourworldindata/types/src/domainTypes/Search.ts
@@ -259,67 +259,24 @@ export type SearchState = Readonly<{
     resultType: SearchResultType
 }>
 
-type AddFilterAction = {
-    type: "addFilter"
-    filter: Filter
+export interface SearchActions {
+    setQuery: (query: string) => void
+    addCountry: (country: string) => void
+    addCountryAndSetQuery: (country: string, query: string) => void
+    removeCountry: (country: string) => void
+    setTopic: (topic: string) => void
+    setTopicAndClearQuery: (topic: string) => void
+    removeTopic: (topic: string) => void
+    addFilter: (filter: Filter) => void
+    removeFilter: (filter: Filter) => void
+    toggleRequireAllCountries: () => void
+    setResultType: (resultType: SearchResultType) => void
+    replaceQueryWithFilters: (
+        filters: Filter[],
+        matchedPositions: number[]
+    ) => void
+    reset: () => void
 }
-type RemoveFilterAction = {
-    type: "removeFilter"
-    filter: Filter
-}
-type SetTopicAction = {
-    type: "setTopic"
-    topic: string
-}
-type RemoveTopicAction = {
-    type: "removeTopic"
-    topic: string
-}
-type SetQueryAction = {
-    type: "setQuery"
-    query: string
-}
-type AddCountryAction = {
-    type: "addCountry"
-    country: string
-}
-type RemoveCountryAction = {
-    type: "removeCountry"
-    country: string
-}
-type ToggleRequireAllCountriesAction = {
-    type: "toggleRequireAllCountries"
-}
-type SetStateAction = {
-    type: "setState"
-    state: SearchState
-}
-type ResetAction = {
-    type: "reset"
-}
-type SetResultTypeAction = {
-    type: "setResultType"
-    resultType: SearchResultType
-}
-type ReplaceQueryWithFiltersAction = {
-    type: "replaceQueryWithFilters"
-    filters: Filter[]
-    matchedPositions: number[]
-}
-
-export type SearchAction =
-    | AddFilterAction
-    | RemoveFilterAction
-    | AddCountryAction
-    | SetTopicAction
-    | RemoveCountryAction
-    | RemoveTopicAction
-    | SetQueryAction
-    | SetStateAction
-    | ToggleRequireAllCountriesAction
-    | ResetAction
-    | SetResultTypeAction
-    | ReplaceQueryWithFiltersAction
 
 export enum SearchTopicType {
     Topic = "topic",

--- a/site/FeaturedMetrics.tsx
+++ b/site/FeaturedMetrics.tsx
@@ -7,12 +7,11 @@ import {
 } from "@ourworldindata/types"
 import { SearchChartHitComponent } from "./search/SearchChartHitComponent.js"
 import { createTopicFilter, SEARCH_BASE_PATH } from "./search/searchUtils.js"
+import { stateToSearchParams } from "./search/searchState.js"
 import { queryCharts, searchQueryKeys } from "./search/queries.js"
 import { getLiteSearchClient } from "./search/searchClients.js"
 import { SearchDataResultsSkeleton } from "./search/SearchDataResultsSkeleton.js"
 import { Button } from "@ourworldindata/components"
-import { searchStateToUrl } from "./search/searchState.js"
-import { Url } from "@ourworldindata/utils"
 import { faMagnifyingGlass } from "@fortawesome/free-solid-svg-icons"
 import cx from "classnames"
 
@@ -54,8 +53,8 @@ export const FeaturedMetrics = ({
 
     if (!isLoading && hits.length === 0) return null
 
-    const url = Url.fromURL(searchStateToUrl(searchState))
-    const searchHref = `${SEARCH_BASE_PATH}${url.queryStr}`
+    const params = stateToSearchParams(searchState)
+    const searchHref = `${SEARCH_BASE_PATH}?${params.toString()}`
 
     return (
         <section

--- a/site/gdocs/components/LTPTableOfContents.tsx
+++ b/site/gdocs/components/LTPTableOfContents.tsx
@@ -5,13 +5,13 @@ import {
     faBook,
     faChartSimple,
 } from "@fortawesome/free-solid-svg-icons"
-import { TocHeadingWithTitleSupertitle, Url } from "@ourworldindata/utils"
+import { TocHeadingWithTitleSupertitle } from "@ourworldindata/utils"
 import { SearchResultType, SearchState } from "@ourworldindata/types"
 import {
     createTopicFilter,
     SEARCH_BASE_PATH,
 } from "../../search/searchUtils.js"
-import { searchStateToUrl } from "../../search/searchState.js"
+import { stateToSearchParams } from "../../search/searchState.js"
 import cx from "classnames"
 
 const DEFAULT_TITLE = "Sections"
@@ -133,6 +133,6 @@ const buildSearchHrefForCard = (
         requireAllCountries: false,
         resultType,
     }
-    const url = Url.fromURL(searchStateToUrl(searchState))
-    return `${SEARCH_BASE_PATH}${url.queryStr}`
+    const params = stateToSearchParams(searchState)
+    return `${SEARCH_BASE_PATH}?${params.toString()}`
 }

--- a/site/gdocs/components/ResearchAndWriting.tsx
+++ b/site/gdocs/components/ResearchAndWriting.tsx
@@ -7,7 +7,6 @@ import {
     formatAuthors,
     formatDate,
     slugify,
-    Url,
 } from "@ourworldindata/utils"
 import { useLinkedDocument } from "../utils.js"
 import Image, { ImageParentContainer } from "./Image.js"
@@ -27,7 +26,7 @@ import {
     createTopicFilter,
     SEARCH_BASE_PATH,
 } from "../../search/searchUtils.js"
-import { searchStateToUrl } from "../../search/searchState.js"
+import { stateToSearchParams } from "../../search/searchState.js"
 import { faMagnifyingGlass } from "@fortawesome/free-solid-svg-icons"
 
 function Thumbnail({
@@ -209,8 +208,8 @@ export function ResearchAndWriting(props: ResearchAndWritingProps) {
             requireAllCountries: false,
             resultType: SearchResultType.WRITING,
         }
-        const url = Url.fromURL(searchStateToUrl(searchState))
-        seeAllResearchHref = `${SEARCH_BASE_PATH}${url.queryStr}`
+        const params = stateToSearchParams(searchState)
+        seeAllResearchHref = `${SEARCH_BASE_PATH}?${params.toString()}`
     }
     // There might be latestWorkLinks available but we only want to show them if
     // a {.latest} block has been added

--- a/site/runSiteFooterScripts.tsx
+++ b/site/runSiteFooterScripts.tsx
@@ -50,11 +50,15 @@ import { NewsletterSubscriptionForm } from "./NewsletterSubscription.js"
 import { NewsletterSubscriptionContext } from "./newsletter.js"
 import { SUBSCRIBE_PAGE_FORM_CONTAINER_ID } from "@ourworldindata/types"
 
-function hydrateSearchPage() {
+function runSearchPage() {
     const root = document.getElementById("search-page-root")
     const topicTagGraph = window._OWID_TOPIC_TAG_GRAPH as TagGraphRoot
     if (root) {
-        hydrateRoot(root, <SearchWrapper topicTagGraph={topicTagGraph} />)
+        createRoot(root).render(
+            <BrowserRouter>
+                <SearchWrapper topicTagGraph={topicTagGraph} />
+            </BrowserRouter>
+        )
     }
 }
 
@@ -387,7 +391,7 @@ export const runSiteFooterScripts = async (
             await hydrateDataInsightsIndexPage()
         // falls through
         case SiteFooterContext.searchPage:
-            hydrateSearchPage()
+            runSearchPage()
         // falls through
         case SiteFooterContext.subscribePage:
             hydrateSubscribePage()

--- a/site/search/SearchAutocomplete.tsx
+++ b/site/search/SearchAutocomplete.tsx
@@ -39,7 +39,7 @@ export const SearchAutocomplete = ({
 }) => {
     const {
         state: { filters },
-        actions: { addCountry, setTopic },
+        actions: { addCountryAndSetQuery, setTopicAndClearQuery },
         synonymMap,
         analytics,
     } = useSearchContext()
@@ -111,10 +111,10 @@ export const SearchAutocomplete = ({
                 // For instance, when searching for "co2 france", we detect:
                 // - "france" as a country filter
                 //     - and show "france" as a filter pill (SearchFilterPill in 1)
-                //     - and add "france" to the active filters (addCountry in 2)
+                //     - and add "france" to the active filters (addCountryAndSetQuery in 2)
                 // - "co2" as the unmatchedQuery
                 //    - and show "co2" as the unmatched query (unmatchedQuery in 1)
-                //    - and set the queries to "co2" (setQueries in 2)
+                //    - and set the queries to "co2" (addCountryAndSetQuery in 2)
                 //
                 // This symmetry between display and handling logic needs to be
                 // manually maintained. If you change the handling logic, make
@@ -122,13 +122,16 @@ export const SearchAutocomplete = ({
                 // versa).
                 .with(FilterType.COUNTRY, () => {
                     logSearchAutocompleteClick()
-                    addCountry(filter.name)
-                    setQueries(unmatchedQueryNoStopWords)
+                    setLocalQuery(unmatchedQueryNoStopWords)
+                    addCountryAndSetQuery(
+                        filter.name,
+                        unmatchedQueryNoStopWords
+                    )
                 })
                 .with(FilterType.TOPIC, () => {
                     logSearchAutocompleteClick()
-                    setTopic(filter.name)
-                    setQueries("")
+                    setLocalQuery("")
+                    setTopicAndClearQuery(filter.name)
                 })
                 .with(FilterType.QUERY, () => {
                     logSearchAutocompleteClick()
@@ -138,8 +141,9 @@ export const SearchAutocomplete = ({
             setShowSuggestions(false)
         },
         [
-            addCountry,
-            setTopic,
+            addCountryAndSetQuery,
+            setTopicAndClearQuery,
+            setLocalQuery,
             setShowSuggestions,
             setQueries,
             unmatchedQuery,

--- a/site/search/SearchContext.tsx
+++ b/site/search/SearchContext.tsx
@@ -4,12 +4,10 @@ import {
     SynonymMap,
     TemplateConfig,
     TagGraphRoot,
+    SearchActions,
 } from "@ourworldindata/types"
-import { createActions } from "./searchState.js"
 import { LiteClient } from "algoliasearch/lite"
 import { SiteAnalytics } from "../SiteAnalytics.js"
-
-type SearchActions = ReturnType<typeof createActions>
 
 interface SearchContextType {
     state: SearchState

--- a/site/search/SearchPage.tsx
+++ b/site/search/SearchPage.tsx
@@ -2,7 +2,6 @@ import { Head } from "../Head.js"
 import { SiteHeader } from "../SiteHeader.js"
 import { SiteFooter } from "../SiteFooter.js"
 import { SiteFooterContext, TagGraphRoot } from "@ourworldindata/utils"
-import { SearchWrapper } from "./SearchWrapper.js"
 import { Html } from "../Html.js"
 import { SEARCH_BASE_PATH } from "./searchUtils.js"
 
@@ -41,7 +40,7 @@ export const SearchPage = (props: {
                     id="search-page-root"
                     className="grid grid-cols-12-full-width"
                 >
-                    <SearchWrapper topicTagGraph={topicTagGraph} />
+                    {/* Search UI is rendered client-side only */}
                 </main>
                 <SiteFooter context={SiteFooterContext.searchPage} />
             </body>

--- a/site/search/SearchWrapper.tsx
+++ b/site/search/SearchWrapper.tsx
@@ -1,7 +1,6 @@
 import { TagGraphRoot } from "@ourworldindata/types"
 import { QueryClientProvider } from "@tanstack/react-query"
 import { Search } from "./Search.js"
-import { getInitialSearchState } from "./searchState.js"
 import { getLiteSearchClient, getSearchQueryClient } from "./searchClients.js"
 
 export const SearchWrapper = ({
@@ -11,12 +10,10 @@ export const SearchWrapper = ({
 }) => {
     const queryClient = getSearchQueryClient()
     const liteSearchClient = getLiteSearchClient()
-    const initialState = getInitialSearchState()
 
     return (
         <QueryClientProvider client={queryClient}>
             <Search
-                initialState={initialState}
                 topicTagGraph={topicTagGraph}
                 liteSearchClient={liteSearchClient}
             />

--- a/site/search/searchState.ts
+++ b/site/search/searchState.ts
@@ -1,206 +1,89 @@
-import { Url } from "@ourworldindata/utils"
-import { match } from "ts-pattern"
-import * as R from "remeda"
 import {
     SearchState,
-    SearchAction,
     Filter,
-    FilterType,
     SearchResultType,
     SearchUrlParam,
+    FilterType,
 } from "@ourworldindata/types"
 import {
-    createCountryFilter,
-    createTopicFilter,
     deserializeSet,
-    getFilterNamesOfType,
+    createTopicFilter,
+    createCountryFilter,
     isValidResultType,
     serializeSet,
-    removeMatchedWordsWithStopWords,
-    splitIntoWords,
+    getFilterNamesOfType,
 } from "./searchUtils.js"
 
-function handleAddFilter(state: SearchState, filter: Filter): SearchState {
-    const filterExists = state.filters.some(
-        (f) => f.type === filter.type && f.name === filter.name
-    )
-    const newFilters = filterExists ? state.filters : [...state.filters, filter]
-    return {
-        ...state,
-        filters: newFilters,
-    }
+export const DEFAULT_SEARCH_STATE: SearchState = {
+    query: "",
+    filters: [],
+    requireAllCountries: false,
+    resultType: SearchResultType.DATA,
 }
 
-function handleRemoveFilter(state: SearchState, filter: Filter): SearchState {
-    const newFilters = state.filters.filter(
-        (f) => !(f.type === filter.type && f.name === filter.name)
-    )
-    // Check if we're removing the last country filter
-    const hasCountryFilters = newFilters.some(
-        (filter) => filter.type === FilterType.COUNTRY
-    )
-
-    return {
-        ...state,
-        requireAllCountries: hasCountryFilters
-            ? state.requireAllCountries
-            : false,
-        filters: newFilters,
-    }
-}
-
-export function searchReducer(
-    state: SearchState,
-    action: SearchAction
+/**
+ * Derives SearchState from URLSearchParams. If parameters are missing, defaults
+ * are used.
+ */
+export function searchParamsToState(
+    searchParams: URLSearchParams
 ): SearchState {
-    return match(action)
-        .with({ type: "setQuery" }, ({ query }) => ({
-            ...state,
-            query: query.trim(),
-        }))
-        .with({ type: "addFilter" }, ({ filter }) =>
-            handleAddFilter(state, filter)
-        )
-        .with({ type: "removeFilter" }, ({ filter }) =>
-            handleRemoveFilter(state, filter)
-        )
-        .with({ type: "addCountry" }, ({ country }) =>
-            handleAddFilter(state, createCountryFilter(country))
-        )
-        .with({ type: "removeCountry" }, ({ country }) =>
-            handleRemoveFilter(state, createCountryFilter(country))
-        )
-        .with({ type: "removeTopic" }, ({ topic }) =>
-            handleRemoveFilter(state, createTopicFilter(topic))
-        )
-        .with({ type: "setTopic" }, ({ topic }) => {
-            // Remove all existing topic filters and add the new one
-            const newFilters = state.filters.filter(
-                (f) => f.type !== FilterType.TOPIC
-            )
-            return {
-                ...state,
-                filters: [...newFilters, createTopicFilter(topic)],
-            }
-        })
-        .with({ type: "toggleRequireAllCountries" }, () => ({
-            ...state,
-            requireAllCountries: !state.requireAllCountries,
-        }))
-        .with({ type: "setState" }, ({ state }) => state)
-        .with({ type: "reset" }, () => ({
-            ...state,
-            ...getInitialSearchState(),
-        }))
-        .with({ type: "setResultType" }, ({ resultType }) => ({
-            ...state,
-            resultType,
-        }))
-        .with(
-            // Apply multiple filters and update query in one atomic operation
-            { type: "replaceQueryWithFilters" },
-            ({ filters, matchedPositions }) => {
-                const queryWords = splitIntoWords(state.query)
-                const newQuery = removeMatchedWordsWithStopWords(
-                    queryWords,
-                    matchedPositions
-                )
-
-                // Deduplicate filters by type and name
-                const allFilters = [...state.filters, ...filters]
-                const uniqueFilters = R.uniqueBy(
-                    allFilters,
-                    (filter) => `${filter.type}:${filter.name}`
-                )
-                return {
-                    ...state,
-                    query: newQuery.trim(),
-                    filters: uniqueFilters,
-                }
-            }
-        )
-        .exhaustive()
-}
-
-export function createActions(dispatch: (action: SearchAction) => void) {
-    // prettier-ignore
-    return {
-        addCountry: (country: string) => dispatch({ type: "addCountry", country }),
-        setTopic: (topic: string) => dispatch({ type: "setTopic", topic }),
-        removeCountry: (country: string) => dispatch({ type: "removeCountry", country }),
-        removeTopic: (topic: string) => dispatch({ type: "removeTopic", topic }),
-        addFilter: (filter: Filter) => dispatch({ type: "addFilter", filter }),
-        removeFilter: (filter: Filter) => dispatch({ type: "removeFilter", filter }),
-        setQuery: (query: string) => dispatch({ type: "setQuery", query }),
-        setState: (state: SearchState) => dispatch({ type: "setState", state }),
-        toggleRequireAllCountries: () => dispatch({ type: "toggleRequireAllCountries" }),
-        setResultType: (resultType: SearchResultType) => dispatch({ type: "setResultType", resultType }),
-        replaceQueryWithFilters: (filters: Filter[], matchedPositions: number[]) => dispatch({ type: "replaceQueryWithFilters", filters, matchedPositions }),
-        reset: () => dispatch({ type: "reset" }),
-    }
-}
-
-export function getInitialSearchState(): SearchState {
-    // Always return the default state to prevent hydration mismatches. The
-    // actual URL state will be applied client-side after hydration using the
-    // useSyncUrlToState hook.
-    return {
-        query: "",
-        filters: [],
-        requireAllCountries: false,
-        resultType: SearchResultType.DATA,
-    }
-}
-
-export function urlToSearchState(url: Url): SearchState {
-    const topicsSet = deserializeSet(url.queryParams.topics)
-    const countriesSet = deserializeSet(url.queryParams.countries)
+    const topicsSet = deserializeSet(searchParams.get("topics") ?? undefined)
+    const countriesSet = deserializeSet(
+        searchParams.get("countries") ?? undefined
+    )
 
     const filters: Filter[] = [
         [...topicsSet].map((topic) => createTopicFilter(topic)),
         [...countriesSet].map((country) => createCountryFilter(country)),
     ].flat()
 
-    const queryParams = url.queryParams as Record<
-        SearchUrlParam,
-        string | undefined
-    >
+    const resultTypeParam = searchParams.get("resultType") ?? undefined
 
     return {
-        query: queryParams.q || "",
+        query: searchParams.get("q") ?? DEFAULT_SEARCH_STATE.query,
         filters,
-        requireAllCountries: url.queryParams.requireAllCountries === "true",
-        resultType: isValidResultType(url.queryParams.resultType)
-            ? url.queryParams.resultType
-            : SearchResultType.DATA,
+        requireAllCountries:
+            searchParams.get("requireAllCountries") === "true" ||
+            DEFAULT_SEARCH_STATE.requireAllCountries,
+        resultType: isValidResultType(resultTypeParam)
+            ? resultTypeParam
+            : DEFAULT_SEARCH_STATE.resultType,
     }
 }
 
-export function searchStateToUrl(state: SearchState) {
-    let url = Url.fromURL(
-        typeof window === "undefined" ? "" : window.location.href
-    )
+/**
+ * Converts SearchState to URLSearchParams, only including non-default values.
+ */
+export function stateToSearchParams(state: SearchState): URLSearchParams {
+    const params = new URLSearchParams()
 
-    const params: Record<SearchUrlParam, string | undefined> = {
-        [SearchUrlParam.QUERY]: state.query || undefined,
-        [SearchUrlParam.TOPIC]: serializeSet(
-            getFilterNamesOfType(state.filters, FilterType.TOPIC)
-        ),
-        [SearchUrlParam.COUNTRY]: serializeSet(
-            getFilterNamesOfType(state.filters, FilterType.COUNTRY)
-        ),
-        [SearchUrlParam.REQUIRE_ALL_COUNTRIES]: state.requireAllCountries
-            ? "true"
-            : undefined,
-        [SearchUrlParam.RESULT_TYPE]:
-            state.resultType !== SearchResultType.DATA
-                ? state.resultType
-                : undefined,
+    if (state.query) {
+        params.set(SearchUrlParam.QUERY, state.query)
     }
 
-    Object.entries(params).forEach(([key, value]) => {
-        url = url.updateQueryParams({ [key]: value })
-    })
+    const topics = serializeSet(
+        getFilterNamesOfType(state.filters, FilterType.TOPIC)
+    )
+    if (topics) {
+        params.set(SearchUrlParam.TOPIC, topics)
+    }
 
-    return url.fullUrl
+    const countries = serializeSet(
+        getFilterNamesOfType(state.filters, FilterType.COUNTRY)
+    )
+    if (countries) {
+        params.set(SearchUrlParam.COUNTRY, countries)
+    }
+
+    if (state.requireAllCountries) {
+        params.set(SearchUrlParam.REQUIRE_ALL_COUNTRIES, "true")
+    }
+
+    // Only include resultType if not the default
+    if (state.resultType !== DEFAULT_SEARCH_STATE.resultType) {
+        params.set(SearchUrlParam.RESULT_TYPE, state.resultType)
+    }
+
+    return params
 }


### PR DESCRIPTION
addresses #5627

## Context

This PR refactors the search functionality to use React Router's URL search parameters as the single source of truth for search state, replacing the previous approach that used a reducer with custom URL synchronization.

## Changes

- Replaced `searchState.ts` with `useSearchParamsState.ts` hook that derives state directly from URL parameters
- Removed bidirectional URL sync logic in favor of React Router's `useSearchParams`
- Updated search components to work with the new state management approach
- Fixed client-side rendering of search page with proper BrowserRouter setup

## Testing guidance

1. Navigate to the search page
2. Test all search functionality:
    - Enter search queries
    - Add/remove topic filters
    - Add/remove country filters
    - Toggle "require all countries" option
    - Switch between result types (data, articles, etc.)
    - Use the autocomplete suggestions
3. Verify that the URL updates correctly with each state change
4. Verify that browser navigation (back/forward) correctly restores the search state (updated for automatic filters in #5801  )

- [ ] Does the staging experience have sign-off from product stakeholders?