### PR TITLE
fix(search): dedup browser history entries when auto filters applied

### DIFF
--- a/site/search/searchHooks.ts
+++ b/site/search/searchHooks.ts
@@ -287,7 +287,10 @@ export function useSearchParamsState(
 
     // Helper to update params atomically
     const updateParams = useCallback(
-        (updater: (current: SearchState) => SearchState) => {
+        (
+            updater: (current: SearchState) => SearchState,
+            options?: { replace?: boolean }
+        ) => {
             setSearchParams((prev) => {
                 const currentState = searchParamsToState(
                     prev,
@@ -296,7 +299,7 @@ export function useSearchParamsState(
                 )
                 const newState = updater(currentState)
                 return stateToSearchParams(newState)
-            })
+            }, options)
         },
         [setSearchParams, validCountries, validTopics]
     )
@@ -440,25 +443,30 @@ export function useSearchParamsState(
                 filters: Filter[],
                 matchedPositions: number[]
             ) => {
-                updateParams((s) => {
-                    const queryWords = splitIntoWords(s.query)
-                    const newQuery = removeMatchedWordsWithStopWords(
-                        queryWords,
-                        matchedPositions
-                    )
+                updateParams(
+                    (s) => {
+                        const queryWords = splitIntoWords(s.query)
+                        const newQuery = removeMatchedWordsWithStopWords(
+                            queryWords,
+                            matchedPositions
+                        )
 
-                    const allFilters = [...s.filters, ...filters]
-                    const uniqueFilters = R.uniqueBy(
-                        allFilters,
-                        (f) => `${f.type}:${f.name}`
-                    )
+                        const allFilters = [...s.filters, ...filters]
+                        const uniqueFilters = R.uniqueBy(
+                            allFilters,
+                            (f) => `${f.type}:${f.name}`
+                        )
 
-                    return {
-                        ...s,
-                        query: newQuery.trim(),
-                        filters: uniqueFilters,
-                    }
-                })
+                        return {
+                            ...s,
+                            query: newQuery.trim(),
+                            filters: uniqueFilters,
+                        }
+                    },
+                    // Use replace: true to avoid creating a phantom history entry
+                    // when auto-applying detected filters after query submission
+                    { replace: true }
+                )
             },
 
             reset: () => {


### PR DESCRIPTION
fixes #5580

superseded by #5801 

## Context

This PR resolves an issue where automatically applying search filters created redundant browser history entries. It **corrects** the behavior to replace the current URL history state rather than pushing a new one, ensuring a cleaner navigation stack.

## Testing guidance

1. Perform a search that triggers automatic filter detection (e.g., "co2 france" -> "France" detected and applied) from the homepage search bar.
2. Hit the back browser button: you should be back to the homepage.
3. Repeat the test in the following scenarios:
    1. Submitting "co2 france" from the search page bar directly
    2. Visiting http://staging-site-repl-hist-auto-filters/search?q=co2+france&resultType=all

- [ ] Does the staging experience have sign-off from product stakeholders?