### PR TITLE
🐛 prevent unsaved-changes warning when creating a new chart

### DIFF
--- a/adminSiteClient/ChartEditorView.tsx
+++ b/adminSiteClient/ChartEditorView.tsx
@@ -403,7 +403,7 @@ export class ChartEditorView<
             <>
                 {!editor.isNewGrapher && (
                     <Prompt
-                        when={editor.isModified}
+                        when={editor.isModified && !chartEditor?.newChartId}
                         message="Are you sure you want to leave? Unsaved changes will be lost."
                     />
                 )}


### PR DESCRIPTION
Resolves #5764

Avoid showing the unsaved-changes navigation Prompt for editors that have created a new chart during the editing session (newChartId set). Previously the prompt appeared whenever editor.isModified was true, which could block navigation for newly-created charts; this change only shows the Prompt when there are unsaved modifications and no newChartId is present.