### PR TITLE
✨ hide blocks on mobile/desktop

### DIFF
--- a/db/model/Gdoc/enrichedToRaw.ts
+++ b/db/model/Gdoc/enrichedToRaw.ts
@@ -133,6 +133,7 @@ export function enrichedBlockToRawBlock(
                     height: b.height,
                     size: b.size,
                     caption: b.caption ? spansToHtmlText(b.caption) : undefined,
+                    visibility: b.visibility ? b.visibility : undefined,
                 },
             })
         )
@@ -208,6 +209,7 @@ export function enrichedBlockToRawBlock(
                     caption: b.caption && spansToHtmlText(b.caption),
                     size: b.size,
                     hasOutline: String(b.hasOutline),
+                    visibility: b.visibility ? b.visibility : undefined,
                 },
             })
         )
@@ -231,6 +233,7 @@ export function enrichedBlockToRawBlock(
                     filename: b.filename,
                     caption: b.caption ? spansToHtmlText(b.caption) : undefined,
                     shouldLoop: String(b.shouldLoop),
+                    visibility: b.visibility ? b.visibility : undefined,
                 },
             })
         )

--- a/db/model/Gdoc/exampleEnrichedBlocks.ts
+++ b/db/model/Gdoc/exampleEnrichedBlocks.ts
@@ -218,6 +218,7 @@ export const enrichedBlockExamples: Record<
         alt: "",
         caption: [spanSimpleText],
         size: BlockSize.Wide,
+        visibility: "desktop",
         parseErrors: [],
     },
     video: {
@@ -227,6 +228,7 @@ export const enrichedBlockExamples: Record<
         caption: boldLinkExampleText,
         shouldLoop: true,
         shouldAutoplay: false,
+        visibility: "mobile",
         parseErrors: [],
     },
     "static-viz": {

--- a/db/model/Gdoc/rawToArchie.ts
+++ b/db/model/Gdoc/rawToArchie.ts
@@ -132,6 +132,7 @@ function* rawBlockChartToArchieMLString(
         yield* propertyToArchieMLString("height", block.value)
         yield* propertyToArchieMLString("size", block.value)
         yield* propertyToArchieMLString("caption", block.value)
+        yield* propertyToArchieMLString("visibility", block.value)
     }
     yield "{}"
 }
@@ -212,6 +213,7 @@ function* rawBlockImageToArchieMLString(
         yield* propertyToArchieMLString("size", block.value)
         yield* propertyToArchieMLString("hasOutline", block.value)
         yield* propertyToArchieMLString("alt", block.value)
+        yield* propertyToArchieMLString("visibility", block.value)
     }
     yield "{}"
 }
@@ -224,6 +226,7 @@ function* rawBlockVideoToArchieMLString(
     yield* propertyToArchieMLString("filename", block.value)
     yield* propertyToArchieMLString("shouldLoop", block.value)
     yield* propertyToArchieMLString("caption", block.value)
+    yield* propertyToArchieMLString("visibility", block.value)
     yield "{}"
 }
 

--- a/packages/@ourworldindata/components/src/styles/util.scss
+++ b/packages/@ourworldindata/components/src/styles/util.scss
@@ -40,6 +40,12 @@
     }
 }
 
+.show-sm-only {
+    @include sm-up {
+        display: none !important;
+    }
+}
+
 .hide-sm-up {
     @include sm-up {
         display: none !important;

--- a/packages/@ourworldindata/types/src/gdocTypes/ArchieMlComponents.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/ArchieMlComponents.ts
@@ -37,6 +37,7 @@ export type RawBlockChartValue = {
     // TODO: position is used as a classname apparently? Should be renamed or split
     position?: string
     caption?: string
+    visibility?: string
 }
 
 export type RawBlockChart = {
@@ -50,6 +51,7 @@ export type EnrichedBlockChart = {
     height?: string
     size: BlockSize
     caption?: Span[]
+    visibility?: BlockVisibility
 } & EnrichedBlockWithParseErrors
 
 export type RawBlockNarrativeChartValue = {
@@ -189,6 +191,10 @@ export function checkIsBlockSize(size: unknown): size is BlockSize {
     return Object.values(BlockSize).includes(size as any)
 }
 
+export const blockVisibilitys = ["desktop", "mobile"] as const
+
+export type BlockVisibility = (typeof blockVisibilitys)[number]
+
 export type RawBlockImage = {
     type: "image"
     value: {
@@ -198,6 +204,7 @@ export type RawBlockImage = {
         caption?: string
         size?: BlockSize
         hasOutline?: string
+        visibility?: string
     }
 }
 
@@ -210,6 +217,7 @@ export type EnrichedBlockImage = {
     originalWidth?: number
     size: BlockSize
     hasOutline: boolean
+    visibility?: BlockVisibility
     // Not a real ArchieML prop - we set this to true for Data Insights, as a way to migrate
     // first generation data insights to only use their small image
     // See https://github.com/owid/owid-grapher/issues/4416
@@ -224,6 +232,7 @@ export type RawBlockVideo = {
         shouldLoop?: string
         shouldAutoplay?: string
         filename?: string
+        visibility?: string
     }
 }
 
@@ -234,6 +243,7 @@ export type EnrichedBlockVideo = {
     shouldAutoplay: boolean
     filename: string
     caption?: Span[]
+    visibility?: BlockVisibility
 } & EnrichedBlockWithParseErrors
 
 export type RawBlockStaticViz = {

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -179,6 +179,8 @@ export {
     type EnrichedBlockAlign,
     type RawBlockAlign,
     type ParseError,
+    type BlockVisibility,
+    blockVisibilitys,
     BlockSize,
     checkIsBlockSize,
     type RawBlockAllCharts,

--- a/site/gdocs/components/ArticleBlock.tsx
+++ b/site/gdocs/components/ArticleBlock.tsx
@@ -139,7 +139,11 @@ function ArticleBlockInternal({
                 <Chart
                     className={cx(
                         "article-block__chart",
-                        getLayout(layoutSubtype, containerType)
+                        getLayout(layoutSubtype, containerType),
+                        {
+                            "hide-sm-only": block.visibility === "desktop",
+                            "show-sm-only": block.visibility === "mobile",
+                        }
                     )}
                     d={block}
                     fullWidthOnMobile={true}
@@ -184,7 +188,11 @@ function ArticleBlockInternal({
             <figure
                 className={cx(
                     "article-block__image",
-                    getLayout(`image--${block.size}`, containerType)
+                    getLayout(`image--${block.size}`, containerType),
+                    {
+                        "hide-sm-only": block.visibility === "desktop",
+                        "show-sm-only": block.visibility === "mobile",
+                    }
                 )}
             >
                 <Image
@@ -210,7 +218,10 @@ function ArticleBlockInternal({
         ))
         .with({ type: "video" }, (block) => (
             <Video
-                className={getLayout("video", containerType)}
+                className={cx(getLayout("video", containerType), {
+                    "hide-sm-only": block.visibility === "desktop",
+                    "show-sm-only": block.visibility === "mobile",
+                })}
                 url={block.url}
                 shouldLoop={block.shouldLoop}
                 shouldAutoplay={block.shouldAutoplay}

--- a/site/gdocs/components/AtomArticleBlocks.tsx
+++ b/site/gdocs/components/AtomArticleBlocks.tsx
@@ -50,13 +50,17 @@ function AtomArticleBlock({
         )
     }
     return match(block)
-        .with({ type: "image" }, (block) => (
-            <Image
-                filename={block.filename}
-                smallFilename={block.smallFilename}
-                alt={block.alt}
-            />
-        ))
+        .with({ type: "image" }, (block) => {
+            // Skip mobile-only blocks in Atom feeds (assuming a desktop image will also be specified)
+            if (block.visibility === "mobile") return null
+            return (
+                <Image
+                    filename={block.filename}
+                    smallFilename={block.smallFilename}
+                    alt={block.alt}
+                />
+            )
+        })
         .otherwise(() => (
             <ArticleBlock b={block} containerType={containerType} />
         ))


### PR DESCRIPTION
## Context

Resolves https://github.com/owid/owid-grapher/issues/5285

Allows authors to specify whether an image/chart/video should only show on desktop/tablets, or mobile. 

This will allow us to handle the case where a two-column layout becomes hard to read on mobile because the image gets pushed to the very bottom of the column, while the text assumes that the reader can see the chart.

## Screenshots / Videos / Diagrams

<img width="1000" height="483" alt="desktopOnly mobileOnly" src="https://github.com/user-attachments/assets/5b2619e9-29ea-4881-bfbf-92b3414c0523" />

## Testing guidance

[You can use this gdoc](https://docs.google.com/document/d/1DjArt6cC9bwFRnTUKjc3GaWm6WggSSqdb9HclkYZ4k4/edit?tab=t.0)

I've tested that mobileOnly charts don't hydrate until they're shown.

- [x] Does the change work in the archive?
- [ ] Does the staging experience have sign-off from product stakeholders?

**Reminder to annotate the PR diff with design notes, alternatives you considered, and any other helpful context.**

## Checklist

### Before merging
- [x] Changes to CSS/HTML were checked on Desktop and Mobile Safari at all three breakpoints
- [x] Changes to HTML were checked for accessibility concerns

