### PR TITLE
feat: add zod validation for url params

### DIFF
--- a/site/search/searchHooks.ts
+++ b/site/search/searchHooks.ts
@@ -289,6 +289,7 @@ export function useSearchParamsState(
     const [searchParams, setSearchParams] = useSearchParams()
 
     // Derive state from URL
+    // Countries and topics are validated against their respective sets
     const state = useMemo(
         () => searchParamsToState(searchParams, validCountries, validTopics),
         [searchParams, validCountries, validTopics]

--- a/site/search/searchUtils.tsx
+++ b/site/search/searchUtils.tsx
@@ -423,7 +423,7 @@ export function serializeSet(set: Set<string>) {
     return set.size ? [...set].join("~") : undefined
 }
 
-export function deserializeSet(str: string | null): Set<string> {
+export function deserializeSet(str?: string): Set<string> {
     return str ? new Set(str.split("~")) : new Set()
 }
 


### PR DESCRIPTION
## Improved Search URL Parameter Handling with Zod Validation

This PR enhances the search functionality by implementing robust URL parameter validation using Zod. The changes improve how search parameters are processed, validated, and serialized.

Key improvements:

- Added Zod schema validation for search URL parameters
- Implemented validation of countries and topics against their respective valid sets
- Created a single source of truth for default search state
- Improved parameter serialization to only include non-default values in the URL
- Fixed type handling for the `deserializeSet` function to accept undefined instead of null

## Testing guidance

1. Navigate to the search page
2. Test various search parameters in the URL:
    - Try valid and invalid country codes
    - Try valid and invalid topic names
    - Test with and without query parameters
    - Test with different result types
3. Verify that:
    - Invalid parameters are properly filtered out
    - Default values are not included in the URL
    - The search state correctly reflects the validated parameters