### PR TITLE
feat(search): sanitize url

### DIFF
--- a/site/search/Search.tsx
+++ b/site/search/Search.tsx
@@ -34,6 +34,7 @@ import { SearchDetectedFilters } from "./SearchDetectedFilters.js"
 import { buildSynonymMap } from "./synonymUtils.js"
 import { SiteAnalytics } from "../SiteAnalytics.js"
 import { PoweredBy } from "react-instantsearch"
+import { listedRegionsNames } from "@ourworldindata/utils"
 
 export const Search = ({
     topicTagGraph,
@@ -42,11 +43,17 @@ export const Search = ({
     topicTagGraph: TagGraphRoot
     liteSearchClient: LiteClient
 }) => {
-    // State derived from URL - single source of truth
-    const { state, actions } = useSearchParamsState()
-
     // Extract topic and area data from the graph
     const { allAreas, allTopics } = useTagGraphTopics(topicTagGraph)
+
+    const validRegions = useMemo(() => new Set(listedRegionsNames()), [])
+    const validTopics = useMemo(
+        () => new Set([...allAreas, ...allTopics]),
+        [allAreas, allTopics]
+    )
+
+    // State derived from URL - single source of truth
+    const { state, actions } = useSearchParamsState(validRegions, validTopics)
 
     const synonymMap = useMemo(() => buildSynonymMap(), [])
 

--- a/site/search/searchHooks.ts
+++ b/site/search/searchHooks.ts
@@ -19,6 +19,7 @@ import {
     searchParamsToState,
     stateToSearchParams,
     DEFAULT_SEARCH_STATE,
+    urlNeedsSanitization,
 } from "./searchState.js"
 import { useSearchContext } from "./SearchContext.js"
 import { flattenNonTopicNodes } from "@ourworldindata/utils"
@@ -261,7 +262,10 @@ export const useTopicTagGraph = () => {
  * Key design principle: URL is the source of truth. State is derived
  * synchronously from URL params.
  */
-export function useSearchParamsState(): {
+export function useSearchParamsState(
+    validRegions: Set<string>,
+    validTopics: Set<string>
+): {
     state: SearchState
     actions: SearchActions
 } {
@@ -269,20 +273,32 @@ export function useSearchParamsState(): {
 
     // Derive state from URL
     const state = useMemo(
-        () => searchParamsToState(searchParams),
-        [searchParams]
+        () => searchParamsToState(searchParams, validRegions, validTopics),
+        [searchParams, validRegions, validTopics]
     )
+
+    // Sanitize URL if it contains invalid values (e.g., unknown countries/topics)
+    // Uses replace: true to avoid creating browser history entries
+    useEffect(() => {
+        if (urlNeedsSanitization(searchParams, state)) {
+            setSearchParams(stateToSearchParams(state), { replace: true })
+        }
+    }, [searchParams, state, setSearchParams])
 
     // Helper to update params atomically
     const updateParams = useCallback(
         (updater: (current: SearchState) => SearchState) => {
             setSearchParams((prev) => {
-                const currentState = searchParamsToState(prev)
+                const currentState = searchParamsToState(
+                    prev,
+                    validRegions,
+                    validTopics
+                )
                 const newState = updater(currentState)
                 return stateToSearchParams(newState)
             })
         },
-        [setSearchParams]
+        [setSearchParams, validRegions, validTopics]
     )
 
     const actions = useMemo<SearchActions>(

--- a/site/search/searchUtils.tsx
+++ b/site/search/searchUtils.tsx
@@ -421,7 +421,7 @@ export function serializeSet(set: Set<string>) {
     return set.size ? [...set].join("~") : undefined
 }
 
-export function deserializeSet(str?: string): Set<string> {
+export function deserializeSet(str: string | null): Set<string> {
     return str ? new Set(str.split("~")) : new Set()
 }
 


### PR DESCRIPTION
## Context

This PR adds validation for search parameters in the URL, ensuring that only valid countries and topics are included in the search state (other params already handled). It also rewrites the URL accordingly for all params.

## Testing guidance

1. Navigate to the search page with valid search parameters
2. Verify that the search works as expected
3. Try adding invalid countries or topics to the URL
4. Try adding invalid parameters to the URL
5. Verify that the URL is automatically sanitized and invalid parameters are removed
6. Check that the browser history isn't polluted with invalid URLs (the sanitization should replace the current history entry)

👉 In #5801, I clarified sanitization around automatic filters, refactored and better documented some of this PR's scope so it might be best to review sanitization there for all three scenarios:
- wrong param
- wrong param value
- automatic filters

See relevant examples in the comments.

- [ ] Does the staging experience have sign-off from product stakeholders?

## Alternatives

- zod #5775 but not convinced by the somewhat poor DX for no obvious gains