### PR TITLE
feat(search): do not send analytics for default search

### DIFF
--- a/site/search/searchHooks.ts
+++ b/site/search/searchHooks.ts
@@ -15,7 +15,11 @@ import {
     removeMatchedWordsWithStopWords,
     splitIntoWords,
 } from "./searchUtils.js"
-import { searchParamsToState, stateToSearchParams } from "./searchState.js"
+import {
+    searchParamsToState,
+    stateToSearchParams,
+    DEFAULT_SEARCH_STATE,
+} from "./searchState.js"
 import { useSearchContext } from "./SearchContext.js"
 import { flattenNonTopicNodes } from "@ourworldindata/utils"
 import { useInfiniteQuery } from "@tanstack/react-query"
@@ -91,9 +95,16 @@ export function useSearchAnalytics(
         [state]
     )
 
+    const defaultStateKey = useMemo(
+        () => stateToSearchParams(DEFAULT_SEARCH_STATE).toString(),
+        []
+    )
+
     useEffect(() => {
+        // Skip analytics for default/empty search state
+        if (stateKey === defaultStateKey) return
         analytics.logSearch(state)
-    }, [stateKey, analytics, state])
+    }, [stateKey, defaultStateKey, analytics, state])
 }
 
 type QueryKeyState = Pick<


### PR DESCRIPTION
fixes #5614

## Context

This PR modifies the `useSearchAnalytics` hook to avoid tracking analytics for default/empty search states by comparing the current search state against the default search state.

This means the following actions will not send events:

- navigation from "Data" in the nav bar
- clearing the input

## Testing guidance

1. Navigate to the search page
2. Verify that no analytics events are triggered when the search state matches the default state
3. Perform a search and confirm that analytics events are properly logged for non-default search states

- [ ] Does the staging experience have sign-off from product stakeholders?

## Checklist

### Before merging

- [x] Google Analytics events were adapted to fit the changes in this PR