### PR TITLE
fix(search): dedup analytics events when auto filters applied

### DIFF
--- a/site/search/Search.tsx
+++ b/site/search/Search.tsx
@@ -64,8 +64,7 @@ export const Search = ({
 
     const deferredState = useDeferredValue(state)
 
-    // Handle analytics tracking (skips initial page load)
-    useSearchAnalytics(deferredState, analytics)
+    useSearchAnalytics(deferredState, analytics, allTopics, synonymMap)
 
     const isFetching = useIsFetching()
 

--- a/site/search/SearchDetectedFilters.tsx
+++ b/site/search/SearchDetectedFilters.tsx
@@ -1,6 +1,10 @@
 import { useCallback, useMemo, useEffect } from "react"
 import { useSearchContext } from "./SearchContext.js"
-import { getFilterIcon, extractFiltersFromQuery } from "./searchUtils.js"
+import {
+    getFilterIcon,
+    extractFiltersFromQuery,
+    getAutoFilters,
+} from "./searchUtils.js"
 import { FilterType, ScoredFilterPositioned } from "@ourworldindata/types"
 import { SearchFilterPill } from "./SearchFilterPill.js"
 import { listedRegionsNames } from "@ourworldindata/utils"
@@ -23,19 +27,17 @@ export const SearchDetectedFilters = ({
 
     const allRegionNames = listedRegionsNames()
 
-    const automaticFilters = useMemo(() => {
-        const matches = extractFiltersFromQuery(
-            query,
-            allRegionNames,
-            allTopics,
-            filters,
-            { threshold: 1, limit: 1 },
-            synonymMap
-        )
-
-        // Only auto-apply exact country matches
-        return matches.filter((match) => match.type === FilterType.COUNTRY)
-    }, [query, allRegionNames, allTopics, filters, synonymMap])
+    const automaticFilters = useMemo(
+        () =>
+            getAutoFilters(
+                query,
+                allRegionNames,
+                allTopics,
+                filters,
+                synonymMap
+            ),
+        [query, allRegionNames, allTopics, filters, synonymMap]
+    )
 
     // Manual filter suggestions are parsed independently to give shorter exact
     // matches priority. Otherwise, a query like "north korea south korea" would


### PR DESCRIPTION
related to #5614, #5777 and #5765

superseded by #5801 

This PR enhances our search analytics by preventing duplicate tracking events when automatic filters are applied. Previously, we would log both the initial query state and the state after auto-filters were applied, creating noise in our analytics data.

The changes:

- Add a check to skip analytics tracking for search states that have pending automatic filters

## Testing guidance

1. Perform a search that triggers automatic filter detection (e.g., "co2 france" -> "France" detected and applied) from the homepage search bar.
2. Open the tag assistant (or check GTM): there should only be a single `owid.site_search` event
3. Repeat the test in the following scenarios:
    1. Submitting "co2 france" from the search page bar directly
    2. Visiting http://staging-site-dedup-analytics-auto-filters/search?q=co2+france&resultType=all

- [ ] Does the staging experience have sign-off from product stakeholders?

## Alternatives

- debouncing analytics events but this solution was not complex enough to justify losing deterministic logging

## Checklist

### Before merging

- [x] Google Analytics events were adapted to fit the changes in this PR