### PR TITLE
Enable `strict: true` for TS in `functions/`

### DIFF
--- a/functions/_common/cookieTools.ts
+++ b/functions/_common/cookieTools.ts
@@ -42,7 +42,7 @@ export function extractClientIdFromGACookie(
     return cookieValue // fallback to using the whole value
 }
 
-export function getAnalyticsConsentValue(request) {
+export function getAnalyticsConsentValue(request: Request) {
     const parsedCookies = parseCookies(request)
     const preferencesRaw = parsedCookies["cookie_preferences"]
     let value = false

--- a/functions/_common/downloadFunctions.ts
+++ b/functions/_common/downloadFunctions.ts
@@ -55,7 +55,7 @@ export async function fetchMetadataForGrapher(
         selectedEntityColors: grapher.grapherState.selectedEntityColors,
         dataApiUrl: getDataApiUrl(env),
     })
-    grapher.grapherState.inputTable = inputTable
+    if (inputTable) grapher.grapherState.inputTable = inputTable
 
     const fullMetadata = assembleMetadata(
         grapher.grapherState,
@@ -84,11 +84,15 @@ export async function fetchZipForGrapher(
         selectedEntityColors: grapher.grapherState.selectedEntityColors,
         dataApiUrl: getDataApiUrl(env),
     })
-    grapher.grapherState.inputTable = inputTable
+    if (inputTable) grapher.grapherState.inputTable = inputTable
     ensureDownloadOfDataAllowed(grapher.grapherState)
-    const metadata = assembleMetadata(grapher.grapherState, searchParams)
-    const readme = assembleReadme(grapher.grapherState, searchParams)
-    const csv = assembleCsv(grapher.grapherState, searchParams)
+    const effectiveSearchParams = searchParams ?? new URLSearchParams("")
+    const metadata = assembleMetadata(
+        grapher.grapherState,
+        effectiveSearchParams
+    )
+    const readme = assembleReadme(grapher.grapherState, effectiveSearchParams)
+    const csv = assembleCsv(grapher.grapherState, effectiveSearchParams)
     console.log("Fetched the parts, creating zip file")
 
     // Use the slugified display title as filename for multi-dims
@@ -146,7 +150,7 @@ export async function fetchCsvForGrapher(
         selectedEntityColors: grapher.grapherState.selectedEntityColors,
         dataApiUrl: getDataApiUrl(env),
     })
-    grapher.grapherState.inputTable = inputTable
+    if (inputTable) grapher.grapherState.inputTable = inputTable
     console.log("checking if download is allowed")
     ensureDownloadOfDataAllowed(grapher.grapherState)
     console.log("data download is allowed")
@@ -192,11 +196,11 @@ export async function fetchReadmeForGrapher(
         selectedEntityColors: grapher.grapherState.selectedEntityColors,
         dataApiUrl: getDataApiUrl(env),
     })
-    grapher.grapherState.inputTable = inputTable
+    if (inputTable) grapher.grapherState.inputTable = inputTable
 
     const readme = assembleReadme(
         grapher.grapherState,
-        searchParams,
+        searchParams ?? new URLSearchParams(""),
         multiDimAvailableDimensions
     )
     return new Response(readme, {
@@ -251,14 +255,14 @@ export async function fetchDataValuesForGrapher(
         selectedEntityColors: grapher.grapherState.selectedEntityColors,
         dataApiUrl: getDataApiUrl(env),
     })
-    grapher.grapherState.inputTable = inputTable
+    if (inputTable) grapher.grapherState.inputTable = inputTable
 
     // Make sure the country query param is respected since Grapher ignores
     // the country param if entity selection is disabled
     const entityNames = getEntityNamesParam(
         searchParams.get("country") ?? undefined
     )
-    if (entityNames?.length > 0)
+    if (entityNames && entityNames.length > 0)
         grapher.grapherState.selection.setSelectedEntities(entityNames)
 
     const dataValues = assembleDataValues(grapher.grapherState, entityName)
@@ -301,7 +305,7 @@ export async function fetchSearchResultDataForGrapher(
     const supportedVersions = [1]
     const version = parseVersionParam(
         searchParams.get("version"),
-        supportedVersions.at(-1)
+        supportedVersions.at(-1)!
     )
 
     // Validate version
@@ -342,7 +346,7 @@ export async function fetchSearchResultDataForGrapher(
         selectedEntityColors: grapher.grapherState.selectedEntityColors,
         dataApiUrl,
     })
-    grapher.grapherState.inputTable = inputTable
+    if (inputTable) grapher.grapherState.inputTable = inputTable
 
     const searchResult = await assembleSearchResultData(grapher.grapherState, {
         variant,

--- a/functions/_common/experiments.ts
+++ b/functions/_common/experiments.ts
@@ -6,6 +6,7 @@ import {
 } from "@ourworldindata/utils"
 import * as cookie from "cookie"
 import { SerializeOptions } from "cookie"
+import { Env } from "./env.js"
 
 export interface ServerCookie {
     name: string
@@ -13,7 +14,9 @@ export interface ServerCookie {
     options?: SerializeOptions
 }
 
-export const experimentsMiddleware = (context) => {
+export const experimentsMiddleware = (
+    context: EventContext<Env, string, Record<string, unknown>>
+) => {
     if (shouldSkipExperiments(context.request.url)) {
         return context.next()
     }

--- a/functions/_common/explorerHandlers.ts
+++ b/functions/_common/explorerHandlers.ts
@@ -108,7 +108,7 @@ export async function handleThumbnailRequestForExplorerView(
         }
     } catch (e) {
         console.error(e)
-        return error(500, e)
+        return error(500, e instanceof Error ? e.message : String(e))
     }
 }
 
@@ -132,7 +132,7 @@ export async function handleConfigRequestForExplorerView(
         })
     } catch (e) {
         console.error(e)
-        return error(500, e)
+        return error(500, e instanceof Error ? e.message : String(e))
     }
 }
 
@@ -162,7 +162,7 @@ export async function fetchCsvForExplorerView(
         })
     } catch (e) {
         console.error(e)
-        return error(500, e)
+        return error(500, e instanceof Error ? e.message : String(e))
     }
 }
 
@@ -182,7 +182,7 @@ export async function fetchMetadataForExplorerView(
         return Response.json(metadata)
     } catch (e) {
         console.error(e)
-        return error(500, e)
+        return error(500, e instanceof Error ? e.message : String(e))
     }
 }
 
@@ -204,7 +204,7 @@ export async function fetchReadmeForExplorerView(
         })
     } catch (e) {
         console.error(e)
-        return error(500, e)
+        return error(500, e instanceof Error ? e.message : String(e))
     }
 }
 
@@ -248,7 +248,7 @@ export async function fetchZipForExplorerView(
         })
     } catch (e) {
         console.error(e)
-        return error(500, e)
+        return error(500, e instanceof Error ? e.message : String(e))
     }
 }
 
@@ -281,7 +281,7 @@ export async function fetchDataValuesForExplorerView(
         const entityNames = getEntityNamesParam(
             searchParams.get("country") ?? undefined
         )
-        if (entityNames?.length > 0)
+        if (entityNames && entityNames.length > 0)
             grapherState.selection.setSelectedEntities(entityNames)
 
         const dataValues = assembleDataValues(grapherState, entityName)
@@ -298,7 +298,7 @@ export async function fetchDataValuesForExplorerView(
         return response
     } catch (e) {
         console.error(e)
-        return error(500, e)
+        return error(500, e instanceof Error ? e.message : String(e))
     }
 }
 
@@ -315,7 +315,7 @@ export async function fetchSearchResultDataForExplorerView(
     const supportedVersions = [1]
     const version = parseVersionParam(
         searchParams.get("version"),
-        supportedVersions.at(-1)
+        supportedVersions.at(-1)!
     )
 
     // Validate version
@@ -376,7 +376,7 @@ export async function fetchSearchResultDataForExplorerView(
         return response
     } catch (e) {
         console.error(e)
-        return error(500, e)
+        return error(500, e instanceof Error ? e.message : String(e))
     }
 }
 

--- a/functions/_common/grapherValuesJson.ts
+++ b/functions/_common/grapherValuesJson.ts
@@ -72,7 +72,7 @@ export function constructGrapherValuesJson(
     })
 
     if (selectionWasModified) {
-        grapherState.selection.setSelectedEntities(originalSelection)
+        grapherState.selection.setSelectedEntities(originalSelection ?? [])
     }
 
     return result

--- a/functions/_common/imageOptions.ts
+++ b/functions/_common/imageOptions.ts
@@ -1,4 +1,3 @@
-import * as _ from "lodash-es"
 import {
     GrapherProgrammaticInterface,
     GRAPHER_SQUARE_SIZE,
@@ -45,7 +44,7 @@ const OPEN_GRAPH_OPTIONS: Readonly<ImageOptions> = {
     details: false,
     fontSize: 21,
 }
-const SQUARE_OPTIONS: Readonly<ImageOptions> = {
+const SQUARE_OPTIONS = {
     pngWidth: 4 * GRAPHER_SQUARE_SIZE,
     pngHeight: 4 * GRAPHER_SQUARE_SIZE,
     svgWidth: GRAPHER_SQUARE_SIZE,
@@ -55,9 +54,9 @@ const SQUARE_OPTIONS: Readonly<ImageOptions> = {
     grapherProps: {
         isSocialMediaExport: false,
         staticBounds: DEFAULT_GRAPHER_BOUNDS_SQUARE,
-    },
-}
-const THUMBNAIL_OPTIONS: Readonly<ImageOptions> = {
+    } as Partial<GrapherProgrammaticInterface>,
+} satisfies Readonly<ImageOptions>
+const THUMBNAIL_OPTIONS = {
     pngWidth: 4 * GRAPHER_THUMBNAIL_WIDTH,
     pngHeight: 4 * GRAPHER_THUMBNAIL_HEIGHT,
     svgWidth: GRAPHER_THUMBNAIL_WIDTH,
@@ -73,8 +72,8 @@ const THUMBNAIL_OPTIONS: Readonly<ImageOptions> = {
             GRAPHER_THUMBNAIL_HEIGHT
         ),
         variant: GrapherVariant.Thumbnail,
-    },
-}
+    } as Partial<GrapherProgrammaticInterface>,
+} satisfies Readonly<ImageOptions>
 
 export const extractOptions = (params: URLSearchParams): ImageOptions => {
     const options: Partial<ImageOptions> = {}
@@ -84,7 +83,7 @@ export const extractOptions = (params: URLSearchParams): ImageOptions => {
     if (imType === "twitter") return TWITTER_OPTIONS
     else if (imType === "og") return OPEN_GRAPH_OPTIONS
     else if (imType === "thumbnail") {
-        const thumbnailOptions = _.cloneDeep(THUMBNAIL_OPTIONS) as ImageOptions
+        const thumbnailOptions = structuredClone(THUMBNAIL_OPTIONS)
         if (params.has("imMinimal")) {
             thumbnailOptions.grapherProps.isDisplayedAlongsideComplementaryTable =
                 params.get("imMinimal")! === "1"
@@ -103,7 +102,7 @@ export const extractOptions = (params: URLSearchParams): ImageOptions => {
         )
         return thumbnailOptions
     } else if (imType === "square" || imType === "social-media-square") {
-        const squareOptions = _.cloneDeep(SQUARE_OPTIONS) as ImageOptions
+        const squareOptions = structuredClone(SQUARE_OPTIONS)
         if (imType === "social-media-square") {
             squareOptions.grapherProps.isSocialMediaExport = true
         }

--- a/functions/_common/metadataTools.ts
+++ b/functions/_common/metadataTools.ts
@@ -18,19 +18,19 @@ import { getGrapherTableWithRelevantColumns } from "./grapherTools.js"
 type MetadataColumn = {
     titleShort: string
     titleLong: string
-    descriptionShort: string
-    descriptionKey: string[]
-    descriptionProcessing: string
-    shortUnit: string
-    unit: string
-    timespan: string
-    tolerance: number
-    type: string
-    conversionFactor: number
-    owidVariableId: number
-    shortName: string
-    lastUpdated: string
-    nextUpdate: string
+    descriptionShort?: string
+    descriptionKey?: string[]
+    descriptionProcessing?: string
+    shortUnit?: string
+    unit?: string
+    timespan?: string
+    tolerance?: number
+    type?: string
+    conversionFactor?: number
+    owidVariableId?: number
+    shortName?: string
+    lastUpdated?: string
+    nextUpdate?: string
     citationShort: string
     citationLong: string
     fullMetadata: string
@@ -158,7 +158,7 @@ export function assembleMetadata(
         const titleLong = `${col.titlePublicOrDisplayName.title}${titleModifier}`
 
         return [
-            useShortNames ? shortName : col.name,
+            useShortNames && shortName ? shortName : col.name,
             {
                 titleShort,
                 titleLong,

--- a/functions/_common/readmeTools.ts
+++ b/functions/_common/readmeTools.ts
@@ -175,7 +175,7 @@ export function getAttribution(def: OwidColumnDef): string {
         getAttributionFragmentsFromVariable(def) ?? producers
     const attribution = attributionFragments.join(", ")
     if (attribution === "") {
-        return def.sourceName
+        return def.sourceName ?? ""
     } else return attribution
 }
 

--- a/functions/_common/redirectTools.ts
+++ b/functions/_common/redirectTools.ts
@@ -10,7 +10,7 @@ export function createRedirectResponse(
     })
 }
 
-export async function getRedirectForUrl(env: Env, url: URL): Promise<Response> {
+export async function getRedirectForUrl(env: Env, url: URL) {
     const fullslug = url.pathname.split("/").pop()
 
     const allExtensions = Object.values(extensions)
@@ -20,8 +20,8 @@ export async function getRedirectForUrl(env: Env, url: URL): Promise<Response> {
         `^(?<slug>.*?)(?<extension>${allExtensions})?$`
     )
 
-    const matchResult = fullslug.match(regexForKnownExtensions)
-    const slug = matchResult?.groups?.slug ?? fullslug
+    const matchResult = fullslug?.match(regexForKnownExtensions)
+    const slug = matchResult?.groups?.slug ?? fullslug ?? ""
     const extension = matchResult?.groups?.extension ?? ""
 
     if (slug.toLowerCase() !== slug)

--- a/functions/_common/search/constructSearchResultDataTableContent.test.ts
+++ b/functions/_common/search/constructSearchResultDataTableContent.test.ts
@@ -107,15 +107,15 @@ describe("constructSearchResultDataTableContent for LineChart", () => {
             grapherState,
         })
 
-        expect(dataTable.title).toBe("GDP")
-        expect(dataTable.rows).toMatchObject([
+        expect(dataTable!.title).toBe("GDP")
+        expect(dataTable!.rows).toMatchObject([
             { label: "Philippines", time: "2009", value: "$682.03 billion" },
             { label: "Benin", time: "2009", value: "$233.42 billion" },
             { label: "Eritrea", time: "2009", value: "$63.2 billion" },
         ])
 
         // Check that the colors are unique
-        const colors = dataTable.rows.map((row) => row.color)
+        const colors = dataTable!.rows.map((row) => row.color)
         expect(new Set(colors)).toHaveLength(colors!.length)
     })
 
@@ -126,14 +126,14 @@ describe("constructSearchResultDataTableContent for LineChart", () => {
             grapherState,
         })
 
-        expect(dataTable.title).toBe("Benin")
-        expect(dataTable.rows).toMatchObject([
+        expect(dataTable!.title).toBe("Benin")
+        expect(dataTable!.rows).toMatchObject([
             { label: "Fruit", time: "2009", value: "573" },
             { label: "Vegetables", time: "2009", value: "542" },
         ])
 
         // Check that the colors are unique
-        const colors = dataTable.rows.map((row) => row.color)
+        const colors = dataTable!.rows.map((row) => row.color)
         expect(new Set(colors)).toHaveLength(colors!.length)
     })
 
@@ -148,7 +148,7 @@ describe("constructSearchResultDataTableContent for LineChart", () => {
             grapherState,
         })
 
-        expect(dataTable.rows).toMatchObject([
+        expect(dataTable!.rows).toMatchObject([
             { label: "Philippines", muted: true },
             { label: "Benin", muted: false },
             { label: "Eritrea", muted: true },
@@ -164,8 +164,8 @@ describe("constructSearchResultDataTableContent for LineChart", () => {
             grapherState,
         })
 
-        expect(dataTable.title).toBe("GDP")
-        expect(dataTable.rows).toMatchObject([
+        expect(dataTable!.title).toBe("GDP")
+        expect(dataTable!.rows).toMatchObject([
             { label: "Philippines", time: "2009", value: "$682.03 billion" },
             { label: "Benin", time: "2009", value: "$233.42 billion" },
             { label: "Eritrea", time: "2009", value: "$63.2 billion" },
@@ -181,15 +181,15 @@ describe("constructSearchResultDataTableContent for LineChart", () => {
             grapherState,
         })
 
-        expect(dataTable.title).toBe("GDP")
-        expect(dataTable.rows).toMatchObject([
+        expect(dataTable!.title).toBe("GDP")
+        expect(dataTable!.rows).toMatchObject([
             { label: "Philippines", time: "2009", value: "$682.03 billion" },
             { label: "Benin", time: "2009", value: "$233.42 billion" },
             { label: "Eritrea", time: "2009", value: "$63.2 billion" },
         ])
 
         // Check that the colors are unique
-        const colors = dataTable.rows.map((row) => row.color)
+        const colors = dataTable!.rows.map((row) => row.color)
         expect(new Set(colors)).toHaveLength(colors!.length)
     })
 })
@@ -204,8 +204,8 @@ describe("constructSearchResultDataTableContent for SlopeChart", () => {
             grapherState,
         })
 
-        expect(dataTable.title).toBe("GDP")
-        expect(dataTable.rows).toMatchObject([
+        expect(dataTable!.title).toBe("GDP")
+        expect(dataTable!.rows).toMatchObject([
             {
                 label: "Philippines",
                 time: "2000–2009",
@@ -230,7 +230,7 @@ describe("constructSearchResultDataTableContent for SlopeChart", () => {
         ])
 
         // Check that the colors are unique
-        const colors = dataTable.rows.map((row) => row.color)
+        const colors = dataTable!.rows.map((row) => row.color)
         expect(new Set(colors)).toHaveLength(colors!.length)
     })
 
@@ -243,8 +243,8 @@ describe("constructSearchResultDataTableContent for SlopeChart", () => {
             grapherState,
         })
 
-        expect(dataTable.title).toBe("Benin")
-        expect(dataTable.rows).toMatchObject([
+        expect(dataTable!.title).toBe("Benin")
+        expect(dataTable!.rows).toMatchObject([
             {
                 label: "Fruit",
                 time: "2000–2009",
@@ -262,7 +262,7 @@ describe("constructSearchResultDataTableContent for SlopeChart", () => {
         ])
 
         // Check that the colors are unique
-        const colors = dataTable.rows.map((row) => row.color)
+        const colors = dataTable!.rows.map((row) => row.color)
         expect(new Set(colors)).toHaveLength(colors!.length)
     })
 
@@ -281,8 +281,8 @@ describe("constructSearchResultDataTableContent for SlopeChart", () => {
             grapherState,
         })
 
-        expect(dataTable.title).toBe("GDP")
-        expect(dataTable.rows).toMatchObject([
+        expect(dataTable!.title).toBe("GDP")
+        expect(dataTable!.rows).toMatchObject([
             { label: "Philippines", muted: true },
             { label: "Benin", muted: false },
             { label: "Eritrea", muted: true },
@@ -299,8 +299,8 @@ describe("constructSearchResultDataTableContent for SlopeChart", () => {
             grapherState,
         })
 
-        expect(dataTable.title).toBe("GDP")
-        expect(dataTable.rows).toMatchObject([
+        expect(dataTable!.title).toBe("GDP")
+        expect(dataTable!.rows).toMatchObject([
             {
                 label: "Philippines",
                 startValue: "$663.99 billion",
@@ -335,8 +335,8 @@ describe("constructSearchResultDataTableContent for SlopeChart", () => {
             grapherState,
         })
 
-        expect(dataTable.title).toBe("GDP")
-        expect(dataTable.rows).toMatchObject([
+        expect(dataTable!.title).toBe("GDP")
+        expect(dataTable!.rows).toMatchObject([
             {
                 label: "Philippines",
                 startValue: "$663.99 billion",
@@ -361,7 +361,7 @@ describe("constructSearchResultDataTableContent for SlopeChart", () => {
         ])
 
         // Check that the colors are unique
-        const colors = dataTable.rows.map((row) => row.color)
+        const colors = dataTable!.rows.map((row) => row.color)
         expect(new Set(colors)).toHaveLength(colors!.length)
     })
 })
@@ -376,15 +376,15 @@ describe("constructSearchResultDataTableContent for StackedAreaChart", () => {
             grapherState,
         })
 
-        expect(dataTable.title).toBe("GDP")
-        expect(dataTable.rows).toMatchObject([
+        expect(dataTable!.title).toBe("GDP")
+        expect(dataTable!.rows).toMatchObject([
             { label: "Benin", time: "2009", value: "$233.42 billion" },
             { label: "Philippines", time: "2009", value: "$682.03 billion" },
             { label: "Eritrea", time: "2009", value: "$63.2 billion" },
         ])
 
         // Check that the colors are unique
-        const colors = dataTable.rows.map((row) => row.color)
+        const colors = dataTable!.rows.map((row) => row.color)
         expect(new Set(colors)).toHaveLength(colors!.length)
     })
 
@@ -397,14 +397,14 @@ describe("constructSearchResultDataTableContent for StackedAreaChart", () => {
             grapherState,
         })
 
-        expect(dataTable.title).toBe("Benin")
-        expect(dataTable.rows).toMatchObject([
+        expect(dataTable!.title).toBe("Benin")
+        expect(dataTable!.rows).toMatchObject([
             { label: "Fruit", time: "2009", value: "573" },
             { label: "Vegetables", time: "2009", value: "542" },
         ])
 
         // Check that the colors are unique
-        const colors = dataTable.rows.map((row) => row.color)
+        const colors = dataTable!.rows.map((row) => row.color)
         expect(new Set(colors)).toHaveLength(colors!.length)
     })
 
@@ -420,7 +420,7 @@ describe("constructSearchResultDataTableContent for StackedAreaChart", () => {
             grapherState,
         })
 
-        expect(dataTable.rows).toMatchObject([
+        expect(dataTable!.rows).toMatchObject([
             { label: "Philippines", muted: true },
             { label: "Benin", muted: false },
             { label: "Eritrea", muted: true },
@@ -437,8 +437,8 @@ describe("constructSearchResultDataTableContent for StackedAreaChart", () => {
             grapherState,
         })
 
-        expect(dataTable.title).toBe("GDP")
-        expect(dataTable.rows).toMatchObject([
+        expect(dataTable!.title).toBe("GDP")
+        expect(dataTable!.rows).toMatchObject([
             { label: "Benin", time: "2009", value: "$233.42 billion" },
             { label: "Philippines", time: "2009", value: "$682.03 billion" },
             { label: "Eritrea", time: "2009", value: "$63.2 billion" },
@@ -455,15 +455,15 @@ describe("constructSearchResultDataTableContent for StackedAreaChart", () => {
             grapherState,
         })
 
-        expect(dataTable.title).toBe("GDP")
-        expect(dataTable.rows).toMatchObject([
+        expect(dataTable!.title).toBe("GDP")
+        expect(dataTable!.rows).toMatchObject([
             { label: "Benin", time: "2009", value: "$233.42 billion" },
             { label: "Philippines", time: "2009", value: "$682.03 billion" },
             { label: "Eritrea", time: "2009", value: "$63.2 billion" },
         ])
 
         // Check that the colors are unique
-        const colors = dataTable.rows.map((row) => row.color)
+        const colors = dataTable!.rows.map((row) => row.color)
         expect(new Set(colors)).toHaveLength(colors!.length)
     })
 })
@@ -478,8 +478,8 @@ describe("constructSearchResultDataTableContent for DiscreteBar", () => {
             grapherState,
         })
 
-        expect(dataTable.title).toBe("GDP")
-        expect(dataTable.rows).toMatchObject([
+        expect(dataTable!.title).toBe("GDP")
+        expect(dataTable!.rows).toMatchObject([
             { label: "Philippines", time: "2009", value: "$682.03 billion" },
             { label: "Benin", time: "2009", value: "$233.42 billion" },
             { label: "Eritrea", time: "2009", value: "$63.2 billion" },
@@ -495,8 +495,8 @@ describe("constructSearchResultDataTableContent for DiscreteBar", () => {
             grapherState,
         })
 
-        expect(dataTable.title).toBe("Benin")
-        expect(dataTable.rows).toMatchObject([
+        expect(dataTable!.title).toBe("Benin")
+        expect(dataTable!.rows).toMatchObject([
             { label: "Fruit", time: "2009", value: "573" },
             { label: "Vegetables", time: "2009", value: "542" },
         ])
@@ -514,7 +514,7 @@ describe("constructSearchResultDataTableContent for DiscreteBar", () => {
             grapherState,
         })
 
-        expect(dataTable.rows).toMatchObject([
+        expect(dataTable!.rows).toMatchObject([
             { label: "Philippines", muted: true },
             { label: "Benin", muted: false },
             { label: "Eritrea", muted: true },
@@ -531,8 +531,8 @@ describe("constructSearchResultDataTableContent for DiscreteBar", () => {
             grapherState,
         })
 
-        expect(dataTable.title).toBe("GDP")
-        expect(dataTable.rows).toMatchObject([
+        expect(dataTable!.title).toBe("GDP")
+        expect(dataTable!.rows).toMatchObject([
             { label: "Philippines", time: "2009", value: "$682.03 billion" },
             { label: "Benin", time: "2009", value: "$233.42 billion" },
             { label: "Eritrea", time: "2009", value: "$63.2 billion" },
@@ -549,8 +549,8 @@ describe("constructSearchResultDataTableContent for DiscreteBar", () => {
             grapherState,
         })
 
-        expect(dataTable.title).toBe("GDP")
-        expect(dataTable.rows).toMatchObject([
+        expect(dataTable!.title).toBe("GDP")
+        expect(dataTable!.rows).toMatchObject([
             { label: "Philippines", time: "2009", value: "$682.03 billion" },
             { label: "Benin", time: "2009", value: "$233.42 billion" },
             { label: "Eritrea", time: "2009", value: "$63.2 billion" },
@@ -579,8 +579,8 @@ describe("constructSearchResultDataTableContent for WorldMap", () => {
             grapherState,
         })
 
-        expect(dataTable.title).toBe("GDP")
-        expect(dataTable.rows).toMatchObject([
+        expect(dataTable!.title).toBe("GDP")
+        expect(dataTable!.rows).toMatchObject([
             {
                 color: "#eff3ff",
                 label: "$1 billion-$3 billion",

--- a/functions/_common/search/constructSearchResultDataTableContent.ts
+++ b/functions/_common/search/constructSearchResultDataTableContent.ts
@@ -1,4 +1,5 @@
 import * as _ from "lodash-es"
+import * as R from "remeda"
 import { match } from "ts-pattern"
 import {
     GrapherState,
@@ -135,7 +136,7 @@ function buildDataTableContentForLineChart({
 
     // Group series by name to handle cases where multiple series share the same name,
     // which can happen when projections are included alongside historical data
-    const groupedSeries = _.groupBy(
+    const groupedSeries = R.groupBy(
         chartState.series,
         (series) => series.seriesName
     )
@@ -143,13 +144,13 @@ function buildDataTableContentForLineChart({
     let rows = Object.values(groupedSeries)
         .map((seriesList) => {
             // Pick the series with the latest time
-            const series = _.maxBy(
-                seriesList,
-                (series) => _.last(series.points)?.x ?? 0
-            )
+            const series = R.firstBy(seriesList, [
+                (series) => R.last(series.points)?.x ?? 0,
+                "desc",
+            ])
 
             // Pick the data point with the latest time
-            const point = _.maxBy(series.points, (point) => point.x)
+            const point = R.firstBy(series.points, [(point) => point.x, "desc"])
             if (!point) return undefined
 
             const color =
@@ -197,7 +198,7 @@ function buildDataTableContentForLineChart({
     rows = _.orderBy(rows, [(row) => row.point.y], "desc")
 
     // Take the first X rows if maxRows is specified
-    if (maxRows > 0) rows = _.take(rows, maxRows)
+    if (maxRows && maxRows > 0) rows = _.take(rows, maxRows)
 
     return {
         rows: rows.map((row) => _.omit(row, ["series", "point"])),
@@ -224,7 +225,7 @@ function buildDataTableContentForDiscreteBarChart({
     }))
 
     // Take the first X rows if maxRows is specified
-    if (maxRows > 0) rows = _.take(rows, maxRows)
+    if (maxRows && maxRows > 0) rows = _.take(rows, maxRows)
 
     return {
         rows: rows.map((row) => _.omit(row, ["series"])),
@@ -270,7 +271,7 @@ function buildDataTableContentForSlopeChart({
     rows = _.orderBy(rows, [(row) => row.endValue], "desc")
 
     // Take the first X rows if maxRows is specified
-    if (maxRows > 0) rows = _.take(rows, maxRows)
+    if (maxRows && maxRows > 0) rows = _.take(rows, maxRows)
 
     const title = makeTableTitle(grapherState, chartState, formatColumn)
 
@@ -314,7 +315,7 @@ function buildDataTableContentForStackedDiscreteBarChart({
             rows = _.orderBy(rows, [(row) => row.point.value], ["desc"])
 
             // Take the first X rows if maxRows is specified
-            if (maxRows > 0) rows = _.take(rows, maxRows)
+            if (maxRows && maxRows > 0) rows = _.take(rows, maxRows)
 
             const columnName = getColumnNameForDisplay(formatColumn)
             const unit = getDisplayUnit(formatColumn)
@@ -393,7 +394,7 @@ function buildDataTableContentForStackedDiscreteBarChart({
             }
 
             // Take the first X rows if maxRows is specified
-            if (maxRows > 0) rows = _.take(rows, maxRows)
+            if (maxRows && maxRows > 0) rows = _.take(rows, maxRows)
 
             return {
                 rows: rows.map((row) =>
@@ -464,7 +465,7 @@ function buildDataTableContentForStackedAreaAndBarChart({
     rows = _.reverse(rows)
 
     // Take the first X rows if maxRows is specified
-    if (maxRows > 0) rows = _.take(rows, maxRows)
+    if (maxRows && maxRows > 0) rows = _.take(rows, maxRows)
 
     const title = makeTableTitle(grapherState, chartState, formatColumn)
 
@@ -511,7 +512,7 @@ function buildDataTableContentForMarimekkoChart({
     rows = _.orderBy(rows, [(row) => row.point.value], "desc")
 
     // Take the first X rows if maxRows is specified
-    if (maxRows > 0) rows = _.take(rows, maxRows)
+    if (maxRows && maxRows > 0) rows = _.take(rows, maxRows)
 
     return {
         rows: rows.map((row) => _.omit(row, ["point"])),
@@ -571,7 +572,7 @@ function buildDataTableContentForScatterPlot({
     rows = _.orderBy(rows, [(row) => row.yValue, "desc"])
 
     // Take the first X rows if maxRows is specified
-    if (maxRows > 0) rows = _.take(rows, maxRows)
+    if (maxRows && maxRows > 0) rows = _.take(rows, maxRows)
 
     const title = isTimeScatter ? yLabel : `${yLabel} vs. ${xLabel}`
 
@@ -626,7 +627,7 @@ function buildDataTableContentForWorldMap({
     }
 
     // Take the first X rows if maxRows is specified
-    if (maxRows > 0) rows = _.take(rows, maxRows)
+    if (maxRows && maxRows > 0) rows = _.take(rows, maxRows)
 
     return {
         rows: rows.map((row) =>
@@ -666,7 +667,7 @@ function buildDataTableContentForTableTab({
     }))
 
     // Take the first X rows if maxRows is specified
-    if (maxRows > 0) tableRows = _.take(tableRows, maxRows)
+    if (maxRows && maxRows > 0) tableRows = _.take(tableRows, maxRows)
 
     return { rows: tableRows, title }
 }

--- a/functions/_common/search/constructSearchResultJson.ts
+++ b/functions/_common/search/constructSearchResultJson.ts
@@ -152,6 +152,7 @@ export function constructSearchResultJson(
         maxRows,
     })
     if (!dataTableContent) return undefined
+    if (!layout) return undefined
 
     // Some charts and preview thumbnails need specific grapher query params
     const enrichedLayout = layout.map(({ slotKey, grapherTab }) => {
@@ -412,9 +413,12 @@ async function pickDisplayEntitiesForScatterPlot({
     const getY = (series: ScatterSeries) => series.points.at(0)?.y ?? 0
 
     // Color of the entity picked by the user
-    const pickedColor = grapherState.table
-        .get(colorColumnSlug)
-        .owidRowsByEntityName.get(entity)?.[0]?.value
+    const pickedColor =
+        colorColumnSlug && entity
+            ? grapherState.table
+                  .get(colorColumnSlug)
+                  .owidRowsByEntityName.get(entity)?.[0]?.value
+            : undefined
     const isDifferentFromPickedColor = (series: ScatterSeries) =>
         !pickedColor || getColor(series) !== pickedColor
 
@@ -428,7 +432,7 @@ async function pickDisplayEntitiesForScatterPlot({
 
     // When only the color dimension is available, select the entity with the
     // largest population from each color group
-    if (colorColumnSlug) {
+    if (colorColumnSlug && dataApiUrl) {
         const populationByEntityName = await fetchLatestPopulationData({
             dataApiUrl,
         })
@@ -487,9 +491,12 @@ async function pickDisplayEntitiesForMarimekko({
     const getY = (item: MarimekkoItem) => item.bars[0]?.yPoint?.value ?? 0
 
     // Color of the entity picked by the user
-    const pickedColor = grapherState.table
-        .get(colorColumnSlug)
-        .owidRowsByEntityName.get(entity)?.[0]?.value
+    const pickedColor =
+        colorColumnSlug && entity
+            ? grapherState.table
+                  .get(colorColumnSlug)
+                  .owidRowsByEntityName.get(entity)?.[0]?.value
+            : undefined
     const isDifferentFromPickedColor = (item: MarimekkoItem) =>
         !pickedColor || getColor(item) !== pickedColor
 
@@ -503,7 +510,7 @@ async function pickDisplayEntitiesForMarimekko({
 
     // When only the color dimension is available, select the entity with the
     // largest population from each color group
-    if (colorColumnSlug) {
+    if (colorColumnSlug && dataApiUrl) {
         const populationByEntityName = await fetchLatestPopulationData({
             dataApiUrl,
         })
@@ -629,6 +636,7 @@ async function fetchLatestPopulationData({
         ],
         dataApiUrl,
     })
+    if (!table) return undefined
 
     // Filter to the most recent year
     const maxTime = table.maxTime ?? 0
@@ -1035,6 +1043,7 @@ function getGrapherQueryParamsForMap(grapherState: GrapherState): {
 } {
     // The map.time setting is ignored on purpose for consistency between the different views
     const mapTime = grapherState.endTime
+    if (mapTime === undefined) return {}
     const params = { time: formatGrapherTimeParam(grapherState, mapTime) }
     return { chartParams: params, previewParams: params }
 }

--- a/functions/api/search/index.test.ts
+++ b/functions/api/search/index.test.ts
@@ -88,7 +88,7 @@ describe("Search API endpoint", () => {
 
             expect(response.status).toBe(400)
             const body = await response.json()
-            assert(typeof body === "object" && "error" in body)
+            assert(typeof body === "object" && body !== null && "error" in body)
             expect(body.error).toBe("Invalid type parameter")
         })
     })
@@ -159,7 +159,7 @@ describe("Search API endpoint", () => {
 
             expect(response.status).toBe(400)
             const body = await response.json()
-            assert(typeof body === "object" && "error" in body)
+            assert(typeof body === "object" && body !== null && "error" in body)
             expect(body.error).toBe("Invalid page parameter")
         })
 
@@ -174,7 +174,7 @@ describe("Search API endpoint", () => {
 
             expect(response.status).toBe(400)
             const body = await response.json()
-            assert(typeof body === "object" && "error" in body)
+            assert(typeof body === "object" && body !== null && "error" in body)
             expect(body.error).toBe("Invalid page parameter")
         })
 
@@ -189,7 +189,7 @@ describe("Search API endpoint", () => {
 
             expect(response.status).toBe(400)
             const body = await response.json()
-            assert(typeof body === "object" && "error" in body)
+            assert(typeof body === "object" && body !== null && "error" in body)
             expect(body.error).toBe("Invalid hitsPerPage parameter")
         })
 
@@ -204,14 +204,17 @@ describe("Search API endpoint", () => {
 
             expect(response.status).toBe(400)
             const body = await response.json()
-            assert(typeof body === "object" && "error" in body)
+            assert(typeof body === "object" && body !== null && "error" in body)
             expect(body.error).toBe("Invalid hitsPerPage parameter")
         })
     })
 
     describe("environment variables", () => {
         it("returns error when ALGOLIA_ID is missing", async () => {
-            const envWithoutId = { ...mockEnv, ALGOLIA_ID: undefined } as Env
+            const envWithoutId = {
+                ...mockEnv,
+                ALGOLIA_ID: undefined,
+            } as unknown as Env
             const request = new Request("http://localhost/api/search?q=test")
             const response = await onRequestGet({
                 request,
@@ -220,7 +223,7 @@ describe("Search API endpoint", () => {
 
             expect(response.status).toBe(500)
             const body = await response.json()
-            assert(typeof body === "object" && "error" in body)
+            assert(typeof body === "object" && body !== null && "error" in body)
             expect(body.error).toBe(
                 "An error occurred while processing the search request"
             )
@@ -230,7 +233,7 @@ describe("Search API endpoint", () => {
             const envWithoutKey = {
                 ...mockEnv,
                 ALGOLIA_SEARCH_KEY: undefined,
-            } as Env
+            } as unknown as Env
             const request = new Request("http://localhost/api/search?q=test")
             const response = await onRequestGet({
                 request,

--- a/functions/donation/_utils/checkout.ts
+++ b/functions/donation/_utils/checkout.ts
@@ -41,10 +41,10 @@ export async function createCheckoutSession(
         cancelUrl,
     } = donation
 
-    const amountRoundedCents = Math.floor(amount) * 100
+    const amountRoundedCents = Math.floor(amount!) * 100
 
     const metadata: Stripe.Metadata = {
-        name,
+        name: name ?? "",
         // showOnList is not strictly necessary since we could just rely on the
         // presence of a name to indicate the willingness to be shown on the
         // list (a name can only be filled in if showOnList is true). It might
@@ -170,7 +170,7 @@ export async function createCheckoutSession(
         return await stripe.checkout.sessions.create(options)
     } catch (error) {
         throw new JsonError(
-            `Error from our payments processor: ${error.message}`,
+            `Error from our payments processor: ${error instanceof Error ? error.message : String(error)}`,
             500
         )
     }

--- a/functions/grapher/by-uuid/[uuid].ts
+++ b/functions/grapher/by-uuid/[uuid].ts
@@ -85,17 +85,17 @@ async function handleConfigRequest(
         return new Response(null, { status: 304 })
     }
 
-    console.log("Grapher page response", grapherPageResp.grapherConfig.title)
+    console.log("Grapher page response", grapherPageResp.grapherConfig?.title)
 
     const cacheControl = shouldCache
         ? "s-maxage=300, max-age=0, must-revalidate"
         : "no-cache"
 
-    return Response.json(grapherPageResp.grapherConfig, {
-        headers: {
-            "content-type": "application/json",
-            "Cache-Control": cacheControl,
-            ETag: grapherPageResp.etag,
-        },
-    })
+    const headers: HeadersInit = {
+        "Content-Type": "application/json",
+        "Cache-Control": cacheControl,
+    }
+    if (grapherPageResp.etag) headers.ETag = grapherPageResp.etag
+
+    return Response.json(grapherPageResp.grapherConfig, { headers })
 }

--- a/functions/multi-dim/[slug].json.ts
+++ b/functions/multi-dim/[slug].json.ts
@@ -21,7 +21,7 @@ router.get("*", async (request, env, params) => {
     const grapherPageResp = await fetchUnparsedGrapherConfig(
         { type: "multi-dim-slug", id: slug },
         env,
-        etag
+        etag ?? undefined
     )
 
     if (grapherPageResp.status === 304) {

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -16,6 +16,7 @@
         "skipLibCheck": true,
         "resolveJsonModule": true,
 
+        "strict": true,
         "alwaysStrict": true,
         "allowJs": false,
         "jsx": "react-jsx",


### PR DESCRIPTION
We only recently added `functions/` to `yarn typecheck`, and forgot to enable `strict: true` which meant many kinds of potential errors were not caught by TS, see e.g. #5780