### PR TITLE
🎉 add entity annotations to discrete bar charts

### DIFF
--- a/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChartConstants.ts
+++ b/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChartConstants.ts
@@ -12,18 +12,25 @@ export interface DiscreteBarSeries extends ChartSeries {
     value: number
     time: Time
     colorValue?: CoreValueType
-    label?: TextWrap
+    annotation?: string
     focus: InteractionState
 }
 
-export interface PlacedDiscreteBarSeries extends DiscreteBarSeries {
+export interface SizedDiscreteBarSeries extends DiscreteBarSeries {
+    label: TextWrap
+    annotationTextWrap?: TextWrap
+}
+
+export interface PlacedDiscreteBarSeries extends SizedDiscreteBarSeries {
     // data bar
     barX: number
     barY: number
     barWidth: number
 
-    // entity and value labels
+    // entity label, annotation, and value label positions
     entityLabelX: number
+    entityLabelY: number
+    annotationY?: number
     valueLabelX: number
 }
 
@@ -41,6 +48,12 @@ export interface DiscreteBarItem {
     time: number
     colorValue?: CoreValueType
     color?: Color
+}
+
+export interface FontSettings {
+    fontSize: number
+    fontWeight: number
+    lineHeight: number
 }
 
 export const BACKGROUND_COLOR = "#fff"

--- a/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChartState.ts
+++ b/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChartState.ts
@@ -21,6 +21,11 @@ import {
     makeSelectionArray,
 } from "../chart/ChartUtils"
 import {
+    AnnotationsMap,
+    getAnnotationsForSeries,
+    getAnnotationsMap,
+} from "../lineCharts/LineChartHelpers"
+import {
     ChartErrorInfo,
     ColorScaleConfigInterface,
     ColorSchemeName,
@@ -114,6 +119,12 @@ export class DiscreteBarChartState implements ChartState, ColorScaleManager {
 
     @computed get formatColumn(): CoreColumn {
         return this.yColumns[0]
+    }
+
+    @computed get annotationsMap(): AnnotationsMap | undefined {
+        const yColumnSlug = this.yColumnSlugs[0]
+        if (!yColumnSlug) return undefined
+        return getAnnotationsMap(this.inputTable, yColumnSlug)
     }
 
     @computed get hasProjectedData(): boolean {
@@ -286,6 +297,10 @@ export class DiscreteBarChartState implements ChartState, ColorScaleManager {
                 seriesName,
                 entityName: seriesName,
                 shortEntityName: getShortNameForEntity(seriesName),
+                annotation: getAnnotationsForSeries(
+                    this.annotationsMap,
+                    seriesName
+                ),
                 // the error color should never be used but I prefer it here instead of throwing an exception if something goes wrong
                 color:
                     color ??


### PR DESCRIPTION
Resolves #4244

Adds entity annotations to discrete bar charts.

Examples:
- http://staging-site-annotations-entity-label-sep/grapher/self-reported-trust-attitudes?tab=discrete-bar&time=latest&country=DEU~CAN~USA~FRA~MEX~PER~EGY~ETH~GBR~ISL
- http://staging-site-annotations-entity-label-sep/grapher/historical-gov-spending-gdp?tab=discrete-bar&time=1922&country=JPN~USA~DEU~CHN~FRA~ESP~BRA~NOR~SWE
- http://staging-site-annotations-entity-label-sep/grapher/maternal-mortality?tab=discrete-bar&time=latest&country=OWID_EUR~DEU~USA~OWID_LMC~BFA~ETH~COG~HTI~ZWE~MDG~OWID_LIC
- http://staging-site-annotations-entity-label-sep/grapher/augmented-human-development-index?tab=discrete-bar&time=2020&country=Western+offshoots+%28AHDI%29~DEU~AUS~ISL~NOR~EST
- http://staging-site-annotations-entity-label-sep/grapher/daily-covid-19-tests-smoothed-7-day?tab=discrete-bar&time=latest&country=IND~GBR~ZAF~IDN~NZL~USA~COL~QAT~SGP~ARE