### PR TITLE
🐛 (globe) fix tearing in Safari

### DIFF
--- a/packages/@ourworldindata/grapher/src/mapCharts/ChoroplethGlobe.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/ChoroplethGlobe.tsx
@@ -385,38 +385,26 @@ export class ChoroplethGlobe extends React.Component<{
         })
     }
 
-    private rotateFrameId: number | undefined
     @action.bound private rotateGlobe(targetCoords: [number, number]): void {
-        if (this.rotateFrameId) cancelAnimationFrame(this.rotateFrameId)
-        this.rotateFrameId = requestAnimationFrame(
-            action(() => {
-                this.mapConfig.globe.rotation = [
-                    -targetCoords[0],
-                    // Clamping the latitude to [-90, 90] would allow rotation up to the poles.
-                    // However, the panning strategy used doesn't work well around the poles.
-                    // That's why we clamp the latitude to a narrower range.
-                    -R.clamp(targetCoords[1], {
-                        min: GLOBE_LATITUDE_MIN,
-                        max: GLOBE_LATITUDE_MAX,
-                    }),
-                ]
-            })
-        )
+        this.mapConfig.globe.rotation = [
+            -targetCoords[0],
+            // Clamping the latitude to [-90, 90] would allow rotation up to the poles.
+            // However, the panning strategy used doesn't work well around the poles.
+            // That's why we clamp the latitude to a narrower range.
+            -R.clamp(targetCoords[1], {
+                min: GLOBE_LATITUDE_MIN,
+                max: GLOBE_LATITUDE_MAX,
+            }),
+        ]
     }
 
-    private zoomFrameId: number | undefined
     @action.bound private zoomGlobe(delta: number): void {
-        if (this.zoomFrameId) cancelAnimationFrame(this.zoomFrameId)
-        this.zoomFrameId = requestAnimationFrame(
-            action(() => {
-                const sensitivity = 0.01
-                const newZoom = this.zoomScale * (1 + delta * sensitivity)
-                this.mapConfig.globe.zoom = R.clamp(newZoom, {
-                    min: GLOBE_MIN_ZOOM,
-                    max: GLOBE_MAX_ZOOM,
-                })
-            })
-        )
+        const sensitivity = 0.01
+        const newZoom = this.zoomScale * (1 + delta * sensitivity)
+        this.mapConfig.globe.zoom = R.clamp(newZoom, {
+            min: GLOBE_MIN_ZOOM,
+            max: GLOBE_MAX_ZOOM,
+        })
     }
 
     @computed private get hoverFeature(): GlobeRenderFeature | undefined {
@@ -685,9 +673,6 @@ export class ChoroplethGlobe extends React.Component<{
         document.removeEventListener("touchstart", this.onDocumentClick, {
             capture: true,
         })
-
-        if (this.rotateFrameId) cancelAnimationFrame(this.rotateFrameId)
-        if (this.zoomFrameId) cancelAnimationFrame(this.zoomFrameId)
     }
 
     renderGlobeOutline(): React.ReactElement {


### PR DESCRIPTION
Resolves #5784 

Martin noticed violent tearing when rotating the globe on Safari. I can't reproduce in Safari, but when I throttle cpu to a mid tier device in Chrome, then I notice the same.

Claude suggested to drop the requestAnimationFrame arguing that D3 does this internally and thus requestAnimationFrame is pure overhead. It surprised me a bit but this does resolve the issues I see when throttled on Chrome and I also checked in with Martin and this makes the experience better for him as well.