### PR TITLE
✨ render single-point line charts

### DIFF
--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChartState.ts
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChartState.ts
@@ -383,14 +383,6 @@ export class LineChartState implements ChartState, ColorScaleManager {
     @computed get errorInfo(): ChartErrorInfo {
         const message = getDefaultFailMessage(this.manager)
         if (message) return { reason: message }
-        if (
-            this.manager.startTime !== undefined &&
-            this.manager.startTime === this.manager.endTime
-        )
-            return {
-                reason: "Two time points needed",
-                help: "Click the timeline to select a second time point",
-            }
 
         const { entityTypePlural = "entities" } = this.manager
         if (!this.series.length)


### PR DESCRIPTION
We used to show an error/help message, but it’s probably better to show what we have.

Example: [prod](https://ourworldindata.org/grapher/hpv-vaccination-coverage-in-15-year-olds?country=~ALB) / [staging](http://staging-site-single-point-line-charts/grapher/hpv-vaccination-coverage-in-15-year-olds?country=~ALB)