### PR TITLE
refactor: apply auto filters atomically

### DIFF
--- a/packages/@ourworldindata/types/src/domainTypes/Search.ts
+++ b/packages/@ourworldindata/types/src/domainTypes/Search.ts
@@ -271,10 +271,7 @@ export interface SearchActions {
     removeFilter: (filter: Filter) => void
     toggleRequireAllCountries: () => void
     setResultType: (resultType: SearchResultType) => void
-    replaceQueryWithFilters: (
-        filters: Filter[],
-        matchedPositions: number[]
-    ) => void
+    replaceQueryWithFilter: (filter: ScoredFilterPositioned) => void
     reset: () => void
 }
 

--- a/site/search/Searchbar.tsx
+++ b/site/search/Searchbar.tsx
@@ -1,6 +1,6 @@
 import { faSearch } from "@fortawesome/free-solid-svg-icons"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
-import { useState, useEffect, useCallback, useRef } from "react"
+import { useState, useCallback, useRef } from "react"
 import { SearchInput } from "./SearchInput.js"
 import { SearchActiveFilters } from "./SearchActiveFilters.js"
 import { SearchAutocomplete } from "./SearchAutocomplete.js"
@@ -14,7 +14,7 @@ import { useSelectedRegionNames } from "./searchHooks.js"
 
 export const Searchbar = ({ allTopics }: { allTopics: string[] }) => {
     const {
-        state: { filters, query, requireAllCountries },
+        state,
         actions: {
             setQuery,
             addCountry,
@@ -25,14 +25,13 @@ export const Searchbar = ({ allTopics }: { allTopics: string[] }) => {
         },
     } = useSearchContext()
 
-    //
+    const { filters, query, requireAllCountries } = state
+
     const selectedRegionNames = useSelectedRegionNames(true)
-    // Storing this in local state so that query params don't update during typing
+    // Storing this in local state so that query params don't update during
+    // typing. Whenever the global query changes, we update the local query by
+    // triggering a re-render (see key prop on Searchbar in parent component).
     const [localQuery, setLocalQuery] = useState(query)
-    // sync local query with global query when browser navigation occurs
-    useEffect(() => {
-        setLocalQuery(query)
-    }, [query])
 
     const inputRef = useRef<HTMLInputElement>(null)
 

--- a/site/search/searchState.ts
+++ b/site/search/searchState.ts
@@ -1,9 +1,12 @@
 import {
+    ScoredFilterPositioned,
     SearchState,
     Filter,
     SearchResultType,
     SearchUrlParam,
     FilterType,
+    SynonymMap,
+    SearchActions,
 } from "@ourworldindata/types"
 import {
     deserializeSet,
@@ -12,7 +15,14 @@ import {
     isValidResultType,
     serializeSet,
     getFilterNamesOfType,
+    extractFiltersFromQuery,
+    splitIntoWords,
+    removeMatchedWordsWithStopWords,
+    createFilter,
 } from "./searchUtils.js"
+import { useMemo, useEffect, useCallback } from "react"
+import { useSearchParams } from "react-router-dom-v5-compat"
+import { intersectionOfSets } from "@ourworldindata/utils"
 
 export const DEFAULT_SEARCH_STATE: SearchState = {
     query: "",
@@ -22,20 +32,233 @@ export const DEFAULT_SEARCH_STATE: SearchState = {
 }
 
 /**
- * Derives SearchState from URLSearchParams. Sanitizes parameters before using them.
- * If parameters are missing, defaults are used.
+ * Hook that manages search state via URL search params.
+ *
+ * Key design principle: URL is the source of truth. State is derived
+ * synchronously from URL params, including automatic filter detection.
+ */
+
+export function useSearchParamsState(
+    eligibleRegionNames: string[],
+    eligibleTopicsAndAreas: string[],
+    synonymMap: SynonymMap
+): {
+    state: SearchState
+    actions: SearchActions
+} {
+    const [searchParams, setSearchParams] = useSearchParams()
+
+    // Derive state from URL, applying automatic filters as part of derivation.
+    // This ensures state consistency when URLs are manually edited.
+    const state = useMemo(() => {
+        const rawState = searchParamsToState(
+            searchParams,
+            eligibleRegionNames,
+            eligibleTopicsAndAreas
+        )
+        return applyAutomaticFilters(rawState, eligibleRegionNames, synonymMap)
+    }, [searchParams, eligibleRegionNames, eligibleTopicsAndAreas, synonymMap])
+
+    // Sanitize URL in the following cases:
+    // - automatic filters have been applied
+    // - query params are invalid (e.g. "countryes=France")
+    // - query params contain invalid values (e.g. "countries=Franc")
+    useEffect(() => {
+        if (urlNeedsSanitization(searchParams, state)) {
+            // replace current entry in browser history to keep it clean.
+            setSearchParams(stateToSearchParams(state), { replace: true })
+        }
+    }, [searchParams, state, setSearchParams])
+
+    const updateParams = useCallback(
+        (
+            updater: (current: SearchState) => SearchState,
+            options?: { replace?: boolean }
+        ) => {
+            const newState = updater(state)
+            // Update URL atomically by applying auto-filters before setting search
+            // params. This ensures the unicity of browser history entries, query execution
+            // and analytics event per user action.
+            const stateWithAutoFilters = applyAutomaticFilters(
+                newState,
+                eligibleRegionNames,
+                synonymMap
+            )
+            setSearchParams(stateToSearchParams(stateWithAutoFilters), options)
+        },
+        [setSearchParams, state, eligibleRegionNames, synonymMap]
+    )
+
+    const actions = useMemo<SearchActions>(
+        () => ({
+            setQuery: (query: string) => {
+                updateParams((s) => ({ ...s, query: query.trim() }))
+            },
+
+            addCountry: (country: string) => {
+                updateParams((s) => {
+                    const exists = s.filters.some(
+                        (f) =>
+                            f.type === FilterType.COUNTRY && f.name === country
+                    )
+                    if (exists) return s
+                    return {
+                        ...s,
+                        filters: [...s.filters, createCountryFilter(country)],
+                    }
+                })
+            },
+
+            // Compound action to ensure a single entry in the browser history.
+            addCountryAndSetQuery: (country: string, query: string) => {
+                updateParams((s) => {
+                    const exists = s.filters.some(
+                        (f) =>
+                            f.type === FilterType.COUNTRY && f.name === country
+                    )
+                    return {
+                        ...s,
+                        query: query.trim(),
+                        filters: exists
+                            ? s.filters
+                            : [...s.filters, createCountryFilter(country)],
+                    }
+                })
+            },
+
+            removeCountry: (country: string) => {
+                updateParams((s) => {
+                    const newFilters = s.filters.filter(
+                        (f) =>
+                            !(
+                                f.type === FilterType.COUNTRY &&
+                                f.name === country
+                            )
+                    )
+                    const hasCountryFilters = newFilters.some(
+                        (f) => f.type === FilterType.COUNTRY
+                    )
+                    return {
+                        ...s,
+                        filters: newFilters,
+                        requireAllCountries: hasCountryFilters
+                            ? s.requireAllCountries
+                            : false,
+                    }
+                })
+            },
+
+            setTopic: (topic: string) => {
+                updateParams((s) => {
+                    const newFilters = s.filters.filter(
+                        (f) => f.type !== FilterType.TOPIC
+                    )
+                    return {
+                        ...s,
+                        filters: [...newFilters, createTopicFilter(topic)],
+                    }
+                })
+            },
+
+            // Compound action to ensure a single entry in the browser history.
+            setTopicAndClearQuery: (topic: string) => {
+                updateParams((s) => {
+                    const newFilters = s.filters.filter(
+                        (f) => f.type !== FilterType.TOPIC
+                    )
+                    return {
+                        ...s,
+                        query: "",
+                        filters: [...newFilters, createTopicFilter(topic)],
+                    }
+                })
+            },
+
+            removeTopic: (topic: string) => {
+                updateParams((s) => ({
+                    ...s,
+                    filters: s.filters.filter(
+                        (f) =>
+                            !(f.type === FilterType.TOPIC && f.name === topic)
+                    ),
+                }))
+            },
+
+            addFilter: (filter: Filter) => {
+                updateParams((s) => {
+                    const exists = s.filters.some(
+                        (f) => f.type === filter.type && f.name === filter.name
+                    )
+                    if (exists) return s
+                    return { ...s, filters: [...s.filters, filter] }
+                })
+            },
+
+            removeFilter: (filter: Filter) => {
+                updateParams((s) => {
+                    const newFilters = s.filters.filter(
+                        (f) =>
+                            !(f.type === filter.type && f.name === filter.name)
+                    )
+                    const hasCountryFilters = newFilters.some(
+                        (f) => f.type === FilterType.COUNTRY
+                    )
+                    return {
+                        ...s,
+                        filters: newFilters,
+                        requireAllCountries:
+                            filter.type === FilterType.COUNTRY &&
+                            !hasCountryFilters
+                                ? false
+                                : s.requireAllCountries,
+                    }
+                })
+            },
+
+            toggleRequireAllCountries: () => {
+                updateParams((s) => ({
+                    ...s,
+                    requireAllCountries: !s.requireAllCountries,
+                }))
+            },
+
+            setResultType: (resultType: SearchResultType) => {
+                updateParams((s) => ({ ...s, resultType }))
+            },
+
+            replaceQueryWithFilter: (filter: ScoredFilterPositioned) => {
+                updateParams((s) => replaceQueryWordsWithFilters(s, [filter]), {
+                    replace: true,
+                })
+            },
+
+            reset: () => {
+                setSearchParams(new URLSearchParams())
+            },
+        }),
+        [updateParams, setSearchParams]
+    )
+
+    return { state, actions }
+}
+
+/**
+ * Derives SearchState from URLSearchParams. Sanitizes parameters before using
+ * them. If parameters are missing, defaults are used.
  */
 export function searchParamsToState(
     searchParams: URLSearchParams,
-    validRegions: Set<string>,
-    validTopics: Set<string>
+    eligibleRegionNames: string[],
+    eligibleTopicsAndAreas: string[]
 ): SearchState {
-    const topicsSet = deserializeSet(searchParams.get("topics")).intersection(
-        validTopics
-    )
-    const countriesSet = deserializeSet(
-        searchParams.get("countries")
-    ).intersection(validRegions)
+    const topicsSet = intersectionOfSets([
+        deserializeSet(searchParams.get("topics")),
+        new Set(eligibleTopicsAndAreas),
+    ])
+    const countriesSet = intersectionOfSets([
+        deserializeSet(searchParams.get("countries")),
+        new Set(eligibleRegionNames),
+    ])
 
     const filters: Filter[] = [
         [...topicsSet].map((topic) => createTopicFilter(topic)),
@@ -102,4 +325,67 @@ export function urlNeedsSanitization(
 ): boolean {
     const sanitizedParams = stateToSearchParams(state)
     return searchParams.toString() !== sanitizedParams.toString()
+}
+
+/**
+ * Core logic for replacing query words with filters.
+ * Used by both automatic filter detection and manual filter suggestions.
+ */
+export function replaceQueryWordsWithFilters(
+    state: SearchState,
+    filtersWithPositions: ScoredFilterPositioned[]
+): SearchState {
+    if (filtersWithPositions.length === 0) return state
+
+    // Collect all positions that need to be removed from the query
+    const allPositions = filtersWithPositions.flatMap((f) => f.positions)
+
+    // Remove matched words from query
+    const queryWords = splitIntoWords(state.query)
+    const newQuery = removeMatchedWordsWithStopWords(queryWords, allPositions)
+
+    // Add new filters (avoiding duplicates)
+    const existingFilterKeys = new Set(
+        state.filters.map((f) => `${f.type}:${f.name}`)
+    )
+    const newFilters = filtersWithPositions
+        .filter((f) => !existingFilterKeys.has(`${f.type}:${f.name}`))
+        // do not include positions in the state, which would break assumptions
+        // for deep equality in analytics logging when automatic filters are applied
+        .map((f) => createFilter(f.type)(f.name))
+
+    return {
+        ...state,
+        query: newQuery.trim(),
+        filters: [...state.filters, ...newFilters],
+    }
+}
+
+/**
+ * Applies automatic country filters detected in the query.
+ * Extracts exact country name matches from the query and adds them as filters,
+ * removing the matched words from the query string.
+ */
+export function applyAutomaticFilters(
+    state: SearchState,
+    allRegionNames: string[],
+    synonymMap: SynonymMap
+): SearchState {
+    if (!state.query) return state
+
+    const matches = extractFiltersFromQuery(
+        state.query,
+        allRegionNames,
+        [], // do not suggest topics for auto-detection
+        state.filters,
+        { threshold: 1, limit: 1 }, // only exact matches
+        synonymMap
+    )
+
+    // Only auto-apply exact country matches
+    const countryMatches = matches.filter(
+        (match) => match.type === FilterType.COUNTRY
+    )
+
+    return replaceQueryWordsWithFilters(state, countryMatches)
 }


### PR DESCRIPTION
## Context

related to #5614, #5777 and #5765

fixes #5580

alternative to #5765 and #5778 (which this PR supersedes)

This PR refactors the search automatic filter detection system to make the application of automatic filters atomic. This prevents:

- polluting the browser history with intermediate states
- firing an unnecessary query that will be immediately discarded
- polluting analytics with the intermediate state transition

Instead of dealing with the deduplication on all those levels, this PR moves the application of automatic filters into the state, which additionally allows for automatic filters to be applied from manual changes in the URL (which covers search queries coming from the homepage/nav bar autocomplete, e.g. "co2 france germany").

## Testing guidance

Two categories of things need to be tested:
- UI and URL. This following test suite checks those. It has been run manually on the latest commit of this branch (Dec 11, 12:45 CEST): https://low-code.browserstack.com/projects/919768/builds/owgcd2z7c3abbedfvuxnuanan4nxnbg7usmcooz0
- Side-effects (events sent to Algolia and analytics) need to be checked manually. 

Below are some manual tests in those two categories:
1. Search for country names in the search bar and verify that exact matches are automatically converted to filters
    - Try "united States", "france", "brazil", etc.
2. Search for partial country names and verify that suggestions appear below the search bar
    - Try "united", "south k", etc.
3. Test with multiple countries in a single query
    - Try "gdp of united States and china"
4. Verify that browser navigation (back/forward) ignores intermediary states
5. Verifiy that only a single `owid.site_search` event is being sent
6. Verifiy that only a single `owid.site_search` event is being sent when automatic filters are applied from outside the app  (e.g. use homepage autocomplete with "co2 france" or https://search-auto-filters.owid.pages.dev/?q=co2+france)
7. Verify that a single query is being sent out to Algolia

- [ ] Does the staging experience have sign-off from product stakeholders?

## Checklist

### Before merging

- [ ] Changes to CSS/HTML were checked on Desktop and Mobile Safari at all three breakpoints