### PR TITLE
Add multi-dim redirects

### DIFF
--- a/_routes.json
+++ b/_routes.json
@@ -3,6 +3,7 @@
     "include": ["/*"],
     "exclude": [
         "/grapher/_grapherRedirects.json",
+        "/explorers/_explorerRedirects.json",
         "/topicTagGraph.json",
         "/dods.json",
         "/*-logo.svg",

--- a/adminSiteClient/AdminApp.tsx
+++ b/adminSiteClient/AdminApp.tsx
@@ -48,6 +48,7 @@ import { ImageIndexPage } from "./ImagesIndexPage.js"
 import { FilesIndexPage } from "./FilesIndexPage.js"
 import { DataInsightIndexPage } from "./DataInsightIndexPage.js"
 import { MultiDimIndexPage } from "./MultiDimIndexPage.js"
+import { MultiDimDetailPage } from "./MultiDimDetailPage.js"
 import { FeaturedMetricsPage } from "./FeaturedMetricsPage.js"
 import { DodsIndexPage } from "./DodsIndexPage.js"
 import { StaticVizIndexPage } from "./StaticVizIndexPage.js"
@@ -202,6 +203,15 @@ export class AdminApp extends React.Component<{
                                     exact
                                     path="/multi-dims"
                                     component={MultiDimIndexPage}
+                                />
+                                <Route
+                                    exact
+                                    path="/multi-dims/:id"
+                                    render={({ match }) => (
+                                        <MultiDimDetailPage
+                                            id={parseInt(match.params.id)}
+                                        />
+                                    )}
                                 />
                                 <Route path="/dods" component={DodsIndexPage} />
 

--- a/adminSiteClient/MultiDimDetailPage.scss
+++ b/adminSiteClient/MultiDimDetailPage.scss
@@ -1,0 +1,91 @@
+.MultiDimDetailPage {
+    .admin-bar {
+        position: sticky;
+        top: 0;
+        z-index: 1;
+
+        &.draft {
+            @include draft-background;
+        }
+    }
+
+    .content-container {
+        display: flex;
+        height: calc(100% - 56px);
+    }
+
+    .redirects-sidebar {
+        min-width: 340px;
+        padding: 16px;
+        overflow-y: auto;
+        flex: 1;
+
+        .target-view-button {
+            padding: 0;
+            margin: 0;
+            white-space: normal;
+            word-break: break-all;
+            text-align: left;
+            height: auto;
+        }
+    }
+
+    .preview-container {
+        flex: 2;
+        display: flex;
+        justify-content: center;
+        background: #f2f2f2;
+        padding: 16px;
+        overflow: auto;
+
+        .preview-wrapper {
+            width: 100%;
+            max-width: 850px;
+            display: flex;
+            flex-direction: column;
+            gap: 16px;
+        }
+
+        .dimension-selectors {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 12px;
+            background: white;
+            padding: 16px;
+        }
+
+        .dimension-selector {
+            flex: 1;
+            min-width: 180px;
+            max-width: 280px;
+
+            &__label {
+                display: block;
+                font-size: 12px;
+                font-weight: 600;
+                color: #666;
+                margin-bottom: 4px;
+                text-transform: uppercase;
+                letter-spacing: 0.5px;
+            }
+        }
+
+        .preview-iframe {
+            width: 100%;
+            height: 660px;
+            border: none;
+            background: white;
+        }
+    }
+
+    .not-found,
+    .error {
+        padding: 32px;
+        text-align: center;
+        color: #666;
+    }
+
+    .error {
+        color: #ff4d4f;
+    }
+}

--- a/adminSiteClient/MultiDimDetailPage.tsx
+++ b/adminSiteClient/MultiDimDetailPage.tsx
@@ -1,0 +1,583 @@
+import { useQuery, useQueryClient, useMutation } from "@tanstack/react-query"
+import { useContext, useEffect, useState, useMemo } from "react"
+import {
+    Col,
+    Row,
+    Space,
+    Tag,
+    Typography,
+    Input,
+    Button,
+    Select,
+    Form,
+    Checkbox,
+    Table,
+    TableColumnsType,
+    Popconfirm,
+} from "antd"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import { faExternalLink, faTrash } from "@fortawesome/free-solid-svg-icons"
+import urljoin from "url-join"
+import { Admin } from "./Admin.js"
+import { AdminLayout } from "./AdminLayout.js"
+import { AdminAppContext } from "./AdminAppContext.js"
+import {
+    ADMIN_BASE_URL,
+    BAKED_GRAPHER_URL,
+} from "../settings/clientSettings.js"
+import {
+    dimensionsToViewId,
+    MultiDimDataPageConfig,
+    MultiDimDimensionChoices,
+    queryParamsToStr,
+} from "@ourworldindata/utils"
+import {
+    DimensionEnriched,
+    MultiDimDataPageConfigEnriched,
+} from "@ourworldindata/types"
+import { LoadingBlocker } from "./Forms.js"
+
+// Source path must start with /grapher/ or /explorers/ and cannot end with a slash.
+const SOURCE_PATH_PATTERN = /^\/(grapher|explorers)\/.*[^/]$/
+const INVALID_SOURCE_PATH_MESSAGE =
+    "Source must start with /grapher/ or /explorers/ and cannot end with a slash."
+
+function normalizeRedirectSource(source: string): string {
+    const sourceUrl = new URL(source, window.location.origin)
+    return sourceUrl.pathname
+}
+
+type ApiMultiDimDetail = {
+    id: number
+    catalogPath: string | null
+    slug: string | null
+    updatedAt: string
+    published: boolean
+    config: MultiDimDataPageConfigEnriched
+}
+
+type MultiDimDetail = Omit<ApiMultiDimDetail, "updatedAt"> & {
+    updatedAt: Date
+}
+
+type MultiDimRedirect = {
+    id: number
+    source: string
+    viewConfigId: string | null
+}
+
+function deserializeMultiDim(mdim: ApiMultiDimDetail): MultiDimDetail {
+    return {
+        ...mdim,
+        updatedAt: new Date(mdim.updatedAt),
+    }
+}
+
+function DimensionSelector({
+    dimension,
+    value,
+    onChange,
+}: {
+    dimension: DimensionEnriched
+    value: string
+    onChange: (value: string) => void
+}) {
+    const options = dimension.choices.map((choice) => ({
+        value: choice.slug,
+        label: choice.name,
+    }))
+
+    return (
+        <div className="dimension-selector">
+            <label className="dimension-selector__label">
+                {dimension.name}
+            </label>
+            <Select
+                className="w-100"
+                value={value}
+                onChange={onChange}
+                options={options}
+                disabled={dimension.choices.length <= 1}
+            />
+        </div>
+    )
+}
+
+async function fetchMultiDim(
+    admin: Admin,
+    id: number
+): Promise<MultiDimDetail> {
+    const { multiDim } = await admin.getJSON<{
+        multiDim: ApiMultiDimDetail
+    }>(`/api/multi-dims/${id}`)
+    return deserializeMultiDim(multiDim)
+}
+
+async function fetchMultiDimRedirects(
+    admin: Admin,
+    id: number
+): Promise<MultiDimRedirect[]> {
+    const { redirects } = await admin.getJSON<{
+        redirects: MultiDimRedirect[]
+    }>(`/api/multi-dims/${id}/redirects`)
+    return redirects
+}
+
+async function createMultiDimRedirect(
+    admin: Admin,
+    multiDimId: number,
+    source: string,
+    viewConfigId: string | null
+): Promise<MultiDimRedirect> {
+    const { redirect } = await admin.requestJSON<{
+        redirect: MultiDimRedirect
+    }>(
+        `/api/multi-dims/${multiDimId}/redirects`,
+        { source, viewConfigId },
+        "POST"
+    )
+    return redirect
+}
+
+async function deleteMultiDimRedirect(
+    admin: Admin,
+    multiDimId: number,
+    redirectId: number
+): Promise<void> {
+    await admin.requestJSON(
+        `/api/multi-dims/${multiDimId}/redirects/${redirectId}`,
+        {},
+        "DELETE"
+    )
+}
+
+type RedirectFormValues = {
+    source: string
+    redirectToSpecificView: boolean
+}
+
+function getRedirectColumns(ctx: {
+    config: MultiDimDataPageConfig | null
+    setSelectedDimensions: (dims: MultiDimDimensionChoices) => void
+    deleteRedirectMutation: ReturnType<
+        typeof useMutation<void, Error, number, unknown>
+    >
+}): TableColumnsType<MultiDimRedirect> {
+    const { config, setSelectedDimensions, deleteRedirectMutation } = ctx
+    return [
+        {
+            title: "Source",
+            dataIndex: "source",
+            key: "source",
+        },
+        {
+            title: "Target",
+            key: "target",
+            render: (_, redirect) => {
+                const isDefaultView = !redirect.viewConfigId
+                if (isDefaultView) {
+                    return (
+                        <Button
+                            className="target-view-button"
+                            type="link"
+                            size="small"
+                            onClick={() => setSelectedDimensions({})}
+                        >
+                            (default view)
+                        </Button>
+                    )
+                }
+                const viewDimensions = config?.findViewDimensionsByConfigId(
+                    redirect.viewConfigId!
+                )
+                const queryStr = viewDimensions
+                    ? queryParamsToStr(viewDimensions)
+                    : null
+                if (queryStr && viewDimensions) {
+                    return (
+                        <Button
+                            className="target-view-button"
+                            type="link"
+                            size="small"
+                            onClick={() =>
+                                setSelectedDimensions(viewDimensions)
+                            }
+                        >
+                            {queryStr}
+                        </Button>
+                    )
+                }
+                return (
+                    <Typography.Text type="secondary">
+                        (unknown view)
+                    </Typography.Text>
+                )
+            },
+        },
+        {
+            title: "",
+            key: "actions",
+            width: 50,
+            render: (_, redirect) => (
+                <Popconfirm
+                    title="Delete redirect"
+                    description="Are you sure you want to delete this redirect?"
+                    onConfirm={() => deleteRedirectMutation.mutate(redirect.id)}
+                    okText="Delete"
+                    okButtonProps={{ danger: true }}
+                >
+                    <Button
+                        type="text"
+                        danger
+                        size="small"
+                        icon={<FontAwesomeIcon icon={faTrash} />}
+                        loading={deleteRedirectMutation.isPending}
+                    />
+                </Popconfirm>
+            ),
+        },
+    ]
+}
+
+export function MultiDimDetailPage({ id }: { id: number }) {
+    const { admin } = useContext(AdminAppContext)
+    const queryClient = useQueryClient()
+    const [redirectForm] = Form.useForm<RedirectFormValues>()
+    const [selectedDimensions, setSelectedDimensions] =
+        useState<MultiDimDimensionChoices>({})
+
+    useEffect(() => {
+        admin.loadingIndicatorSetting = "off"
+        return () => {
+            admin.loadingIndicatorSetting = "default"
+        }
+    }, [admin])
+
+    const {
+        data: multiDim,
+        isLoading,
+        isError,
+    } = useQuery({
+        queryKey: ["multiDim", id],
+        queryFn: () => fetchMultiDim(admin, id),
+    })
+
+    const { data: redirects = [], isLoading: isLoadingRedirects } = useQuery({
+        queryKey: ["multiDimRedirects", id],
+        queryFn: () => fetchMultiDimRedirects(admin, id),
+    })
+
+    const createRedirectMutation = useMutation({
+        mutationFn: ({
+            source,
+            viewConfigId,
+        }: {
+            source: string
+            viewConfigId: string | null
+        }) => createMultiDimRedirect(admin, id, source, viewConfigId),
+        onSuccess: () => {
+            void queryClient.invalidateQueries({
+                queryKey: ["multiDimRedirects", id],
+            })
+            redirectForm.resetFields(["source"])
+        },
+    })
+
+    const deleteRedirectMutation = useMutation({
+        mutationFn: (redirectId: number) =>
+            deleteMultiDimRedirect(admin, id, redirectId),
+        onSuccess: () => {
+            void queryClient.invalidateQueries({
+                queryKey: ["multiDimRedirects", id],
+            })
+        },
+    })
+
+    const config = useMemo(
+        () =>
+            multiDim
+                ? MultiDimDataPageConfig.fromObject(multiDim.config)
+                : null,
+        [multiDim]
+    )
+
+    const { currentDimensions, availableSettings } = useMemo(() => {
+        if (!config) return { currentDimensions: null, availableSettings: null }
+        const { selectedChoices, dimensionsWithAvailableChoices } =
+            config.filterToAvailableChoices(selectedDimensions)
+        return {
+            currentDimensions: selectedChoices,
+            availableSettings: dimensionsWithAvailableChoices,
+        }
+    }, [config, selectedDimensions])
+
+    function handleDimensionChange(dimensionSlug: string, choiceSlug: string) {
+        setSelectedDimensions((prev) => ({
+            ...prev,
+            [dimensionSlug]: choiceSlug,
+        }))
+    }
+
+    const currentViewConfigId = useMemo(() => {
+        if (!config || !currentDimensions) return null
+        const viewId = dimensionsToViewId(currentDimensions)
+        const view = config.config.views.find(
+            (v) => dimensionsToViewId(v.dimensions) === viewId
+        )
+        return view?.fullConfigId ?? null
+    }, [config, currentDimensions])
+
+    const iframeSrc = useMemo(() => {
+        if (!multiDim?.catalogPath) return null
+        const baseUrl = urljoin(
+            ADMIN_BASE_URL,
+            `/admin/grapher/${encodeURIComponent(multiDim.catalogPath)}`
+        )
+        const params = new URLSearchParams()
+        params.set("hideControls", "true")
+        if (currentDimensions) {
+            for (const [key, value] of Object.entries(currentDimensions)) {
+                params.set(key, value)
+            }
+        }
+        return `${baseUrl}?${params.toString()}`
+    }, [multiDim?.catalogPath, currentDimensions])
+
+    function handleCreateRedirect(values: RedirectFormValues) {
+        const normalizedSource = normalizeRedirectSource(values.source.trim())
+        createRedirectMutation.mutate({
+            source: normalizedSource,
+            viewConfigId: values.redirectToSpecificView
+                ? currentViewConfigId
+                : null,
+        })
+    }
+
+    if (isLoading) {
+        return (
+            <AdminLayout>
+                <main className="MultiDimDetailPage">
+                    <LoadingBlocker />
+                </main>
+            </AdminLayout>
+        )
+    }
+
+    if (isError) {
+        return (
+            <AdminLayout title="Error">
+                <main className="MultiDimDetailPage">
+                    <div className="error">
+                        Failed to load multi-dimensional data page
+                    </div>
+                </main>
+            </AdminLayout>
+        )
+    }
+
+    if (!multiDim) {
+        return (
+            <AdminLayout title="Not Found">
+                <main className="MultiDimDetailPage">
+                    <div className="not-found">
+                        Multi-dimensional data page not found
+                    </div>
+                </main>
+            </AdminLayout>
+        )
+    }
+
+    const liveUrl =
+        multiDim.published && multiDim.slug
+            ? urljoin(BAKED_GRAPHER_URL, multiDim.slug)
+            : null
+
+    const previewUrl = multiDim.catalogPath
+        ? urljoin(
+              ADMIN_BASE_URL,
+              `/admin/grapher/${encodeURIComponent(multiDim.catalogPath)}`
+          )
+        : null
+
+    const title = multiDim.config.title.title
+
+    return (
+        <AdminLayout title={title}>
+            <main className="MultiDimDetailPage">
+                <Row
+                    className={`p-3 admin-bar ${multiDim.published ? "published" : "draft"}`}
+                    justify="space-between"
+                    align="middle"
+                    gutter={[0, 8]}
+                >
+                    <Col flex={1}>
+                        <Space>
+                            <Typography.Title className="mb-0" level={4}>
+                                {title}
+                            </Typography.Title>
+                            {multiDim.catalogPath && (
+                                <Typography.Text
+                                    type="secondary"
+                                    copyable={{ text: multiDim.catalogPath }}
+                                >
+                                    {multiDim.catalogPath}
+                                </Typography.Text>
+                            )}
+                            {!multiDim.published && (
+                                <Tag color="default">Draft</Tag>
+                            )}
+                        </Space>
+                    </Col>
+                    <Col>
+                        {liveUrl ? (
+                            <a
+                                className="ant-btn ant-btn-default"
+                                href={liveUrl}
+                                target="_blank"
+                                rel="noopener"
+                            >
+                                <Space>
+                                    <FontAwesomeIcon icon={faExternalLink} />
+                                    View live
+                                </Space>
+                            </a>
+                        ) : (
+                            previewUrl && (
+                                <a
+                                    className="ant-btn ant-btn-default"
+                                    href={previewUrl}
+                                    target="_blank"
+                                    rel="noopener"
+                                >
+                                    <Space>
+                                        <FontAwesomeIcon
+                                            icon={faExternalLink}
+                                        />
+                                        View preview
+                                    </Space>
+                                </a>
+                            )
+                        )}
+                    </Col>
+                </Row>
+
+                <div className="content-container">
+                    <div className="redirects-sidebar">
+                        <Typography.Title level={5}>
+                            Create a redirect
+                        </Typography.Title>
+
+                        <Form
+                            form={redirectForm}
+                            layout="vertical"
+                            onFinish={handleCreateRedirect}
+                            initialValues={{
+                                source: "",
+                                redirectToSpecificView: true,
+                            }}
+                        >
+                            <Form.Item
+                                label="Source"
+                                name="source"
+                                extra="Must start with /grapher/ or /explorers/."
+                                rules={[
+                                    {
+                                        required: true,
+                                        message:
+                                            "Please provide a source path.",
+                                    },
+                                    {
+                                        pattern: SOURCE_PATH_PATTERN,
+                                        message: INVALID_SOURCE_PATH_MESSAGE,
+                                    },
+                                ]}
+                            >
+                                <Input placeholder="/grapher/example" />
+                            </Form.Item>
+                            <Form.Item
+                                name="redirectToSpecificView"
+                                valuePropName="checked"
+                                extra="Uses the currently selected view as the target."
+                            >
+                                <Checkbox>Redirect to specific view</Checkbox>
+                            </Form.Item>
+                            <Form.Item
+                                shouldUpdate={(prev, cur) =>
+                                    prev.redirectToSpecificView !==
+                                    cur.redirectToSpecificView
+                                }
+                            >
+                                <Button
+                                    type="primary"
+                                    htmlType="submit"
+                                    disabled={createRedirectMutation.isPending}
+                                    loading={createRedirectMutation.isPending}
+                                >
+                                    Create
+                                </Button>
+                            </Form.Item>
+                        </Form>
+
+                        <Typography.Title level={5}>
+                            Existing redirects
+                        </Typography.Title>
+                        <Table<MultiDimRedirect>
+                            columns={getRedirectColumns({
+                                config,
+                                setSelectedDimensions,
+                                deleteRedirectMutation,
+                            })}
+                            dataSource={redirects}
+                            rowKey="id"
+                            size="small"
+                            pagination={false}
+                            loading={isLoadingRedirects}
+                            locale={{
+                                emptyText: (
+                                    <Typography.Text type="secondary">
+                                        No redirects configured yet.
+                                    </Typography.Text>
+                                ),
+                            }}
+                        />
+                    </div>
+
+                    <div className="preview-container">
+                        {availableSettings && currentDimensions && (
+                            <div className="preview-wrapper">
+                                <div className="dimension-selectors">
+                                    {Object.values(availableSettings).map(
+                                        (dimension) => (
+                                            <DimensionSelector
+                                                key={dimension.slug}
+                                                dimension={dimension}
+                                                value={
+                                                    currentDimensions[
+                                                        dimension.slug
+                                                    ]
+                                                }
+                                                onChange={(value) =>
+                                                    handleDimensionChange(
+                                                        dimension.slug,
+                                                        value
+                                                    )
+                                                }
+                                            />
+                                        )
+                                    )}
+                                </div>
+                                {iframeSrc && (
+                                    <iframe
+                                        className="preview-iframe"
+                                        src={iframeSrc}
+                                        title="Multi-dimensional chart preview"
+                                    />
+                                )}
+                            </div>
+                        )}
+                    </div>
+                </div>
+            </main>
+        </AdminLayout>
+    )
+}

--- a/adminSiteClient/MultiDimIndexPage.tsx
+++ b/adminSiteClient/MultiDimIndexPage.tsx
@@ -6,6 +6,7 @@ import {
 } from "@tanstack/react-query"
 import { useContext, useEffect, useMemo, useState } from "react"
 import {
+    Button,
     Flex,
     Input,
     Popconfirm,
@@ -250,6 +251,17 @@ function createColumns(
                 </Popconfirm>
             ),
             sorter: (a, b) => Number(b.published) - Number(a.published),
+        },
+        {
+            title: "Actions",
+            key: "actions",
+            width: 100,
+            render: (_, record) =>
+                record.published && (
+                    <Link to={`/multi-dims/${record.id}`}>
+                        <Button type="primary">Edit</Button>
+                    </Link>
+                ),
         },
     ]
 }

--- a/adminSiteClient/SiteRedirectsIndexPage.tsx
+++ b/adminSiteClient/SiteRedirectsIndexPage.tsx
@@ -219,13 +219,26 @@ export default function SiteRedirectsIndexPage() {
                             <>
                                 <Typography.Paragraph>
                                     This page is used to create and delete
-                                    redirects for the site. Don't use this page
-                                    to create redirects for charts, use the{" "}
-                                    <Link to="/redirects">
-                                        chart redirects page
-                                    </Link>{" "}
-                                    instead.
+                                    redirects for the site.
                                 </Typography.Paragraph>
+                                <ul>
+                                    <li>
+                                        For redirects to <strong>charts</strong>
+                                        , create redirects on the edit page of
+                                        the target chart ref tab, and delete
+                                        redirects on{" "}
+                                        <Link to="/redirects">
+                                            the chart redirects page
+                                        </Link>
+                                        .
+                                    </li>
+                                    <li>
+                                        For redirects to{" "}
+                                        <strong>multi-dims</strong>,
+                                        create/delete redirects on the edit page
+                                        of the target multi-dim.
+                                    </li>
+                                </ul>
                                 <Typography.Paragraph>
                                     The source has to start with a slash. Any
                                     query parameters (/war-and-peace

--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -2,6 +2,16 @@
 
 @import "../public/fonts.css";
 @import "bootstrap/scss/bootstrap";
+
+@mixin draft-background {
+    background: repeating-linear-gradient(
+        135deg,
+        #f7f7f7,
+        #f7f7f7 10px,
+        #fff 10px,
+        #fff 20px
+    );
+}
 @import "styles/react-tag-autocomplete";
 
 @import "tippy.js/dist/tippy.css";
@@ -16,6 +26,7 @@
 @import "./DodsIndexPage.scss";
 @import "./SortableList.scss";
 @import "./StaticViz.scss";
+@import "./MultiDimDetailPage.scss";
 
 html {
     font-size: 14px;
@@ -769,7 +780,7 @@ $nav-height: 45px;
     }
 }
 
-main:not(.ChartEditorPage):not(.GdocsEditPage) {
+main:not(.ChartEditorPage):not(.GdocsEditPage):not(.MultiDimDetailPage) {
     padding: 2em;
 }
 
@@ -1183,13 +1194,7 @@ main:not(.ChartEditorPage):not(.GdocsEditPage) {
             rgba(0, 0, 0, 0.24) 0px 1px 2px;
         background: #fff;
         &.draft {
-            background: repeating-linear-gradient(
-                135deg,
-                #f7f7f7,
-                #f7f7f7 10px,
-                #fff 10px,
-                #fff 20px
-            );
+            @include draft-background;
         }
     }
 

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -50,8 +50,12 @@ import {
 import { getFiles, uploadFileToR2 } from "./apiRoutes/files.js"
 import {
     handlePutMultiDim,
+    handleGetMultiDim,
     handleGetMultiDims,
     handlePatchMultiDim,
+    handleGetMultiDimRedirects,
+    handlePostMultiDimRedirect,
+    handleDeleteMultiDimRedirect,
 } from "./apiRoutes/mdims.js"
 import {
     fetchAllWork,
@@ -368,12 +372,28 @@ getRouteWithROTransaction(apiRouter, "/images/usage", getImageUsageHandler)
 
 // Mdim routes
 getRouteWithROTransaction(apiRouter, "/multi-dims.json", handleGetMultiDims)
+getRouteWithROTransaction(apiRouter, "/multi-dims/:id", handleGetMultiDim)
 putRouteWithRWTransaction(
     apiRouter,
     "/multi-dims/:catalogPath",
     handlePutMultiDim
 )
 patchRouteWithRWTransaction(apiRouter, "/multi-dims/:id", handlePatchMultiDim)
+getRouteWithROTransaction(
+    apiRouter,
+    "/multi-dims/:id/redirects",
+    handleGetMultiDimRedirects
+)
+postRouteWithRWTransaction(
+    apiRouter,
+    "/multi-dims/:id/redirects",
+    handlePostMultiDimRedirect
+)
+deleteRouteWithRWTransaction(
+    apiRouter,
+    "/multi-dims/:id/redirects/:redirectId",
+    handleDeleteMultiDimRedirect
+)
 
 // Explorer routes
 getRouteWithROTransaction(apiRouter, "/explorers/:slug", handleGetExplorer)

--- a/adminSiteServer/apiRoutes/mdims.ts
+++ b/adminSiteServer/apiRoutes/mdims.ts
@@ -1,10 +1,21 @@
 import {
+    ChartSlugRedirectsTableName,
+    DbEnrichedMultiDimDataPage,
     DbPlainMultiDimDataPage,
+    DbInsertMultiDimRedirect,
+    DbPlainMultiDimRedirect,
     JsonError,
     MultiDimDataPageConfigRaw,
     MultiDimDataPagesTableName,
+    MultiDimRedirectsTableName,
 } from "@ourworldindata/types"
+import {
+    MultiDimDataPageConfig,
+    queryParamsToStr,
+    Url,
+} from "@ourworldindata/utils"
 import { getMultiDimDataPageById } from "../../db/model/MultiDimDataPage.js"
+import { redirectWithSourceExists } from "../../db/model/Redirect.js"
 import { expectInt } from "../../serverUtils/serverUtil.js"
 import {
     upsertMultiDim,
@@ -20,6 +31,166 @@ import {
     isValidCatalogPath,
 } from "../validation.js"
 import e from "express"
+import * as z from "zod"
+
+function buildRedirectTargetDescription(
+    multiDim: DbEnrichedMultiDimDataPage,
+    viewConfigId: string | null
+): string {
+    let targetDescription = `/grapher/${multiDim.slug}`
+    if (viewConfigId) {
+        const mdimConfig = MultiDimDataPageConfig.fromObject(multiDim.config)
+        const dimensions = mdimConfig.findViewDimensionsByConfigId(viewConfigId)
+        if (dimensions) {
+            targetDescription += queryParamsToStr(dimensions)
+        }
+    }
+    return targetDescription
+}
+
+async function validatePathIsNotRedirectSource(
+    trx: db.KnexReadonlyTransaction,
+    path: string
+): Promise<void> {
+    if (await redirectWithSourceExists(trx, path)) {
+        throw new JsonError(
+            `'${path}' is already a source of an existing site redirect`,
+            400
+        )
+    }
+    const existingMultiDimRedirect = await trx<{ id: number }>(
+        MultiDimRedirectsTableName
+    )
+        .select("id")
+        .where("source", path)
+        .first()
+    if (existingMultiDimRedirect) {
+        throw new JsonError(
+            `'${path}' is already a source of an existing multi-dim redirect`,
+            400
+        )
+    }
+    const slug = Url.fromURL(path).slug
+    const existingChartSlugRedirect = await trx<{ id: number }>(
+        ChartSlugRedirectsTableName
+    )
+        .select("id")
+        .where("slug", slug)
+        .first()
+    if (existingChartSlugRedirect) {
+        throw new JsonError(
+            `'${path}' is already a source of an existing chart slug redirect`,
+            400
+        )
+    }
+}
+
+async function validateMultiDimRedirect(
+    trx: db.KnexReadonlyTransaction,
+    source: string,
+    targetSlug: string
+): Promise<void> {
+    const targetPath = `/grapher/${targetSlug}`
+
+    // Check source is not already a redirect source
+    await validatePathIsNotRedirectSource(trx, source)
+
+    // Check source is not already a redirect target (would create chain: X -> source -> target)
+    const sourceIsTargetOfSiteRedirect = await trx<{ id: number }>("redirects")
+        .select("id")
+        .where("target", source)
+        .first()
+    if (sourceIsTargetOfSiteRedirect) {
+        throw new JsonError(
+            `Creating this redirect would form a redirect chain: '${source}' is already a target of an existing site redirect`,
+            400
+        )
+    }
+    const sourceSlug = Url.fromURL(source).slug
+    // Multi-dim targets are always at /grapher/ paths, so only check if source is a /grapher/ path
+    if (source.startsWith("/grapher/")) {
+        const sourceIsMultiDimTarget = await db.knexRaw<{ source: string }>(
+            trx,
+            `-- sql
+            SELECT mdr.source
+            FROM ${MultiDimRedirectsTableName} mdr
+            JOIN ${MultiDimDataPagesTableName} mdp ON mdr.multiDimId = mdp.id
+            WHERE mdp.slug = ?
+            LIMIT 1`,
+            [sourceSlug]
+        )
+        if (sourceIsMultiDimTarget.length > 0) {
+            throw new JsonError(
+                `Creating this redirect would form a redirect chain: '${source}' is already a target of redirect '${sourceIsMultiDimTarget[0].source}'`,
+                400
+            )
+        }
+    }
+    // Check if source matches a chart's current slug that has old slugs redirecting to it
+    const sourceIsChartSlugTarget = await db.knexRaw<{ slug: string }>(
+        trx,
+        `-- sql
+        SELECT csr.slug
+        FROM ${ChartSlugRedirectsTableName} csr
+        JOIN charts c ON csr.chart_id = c.id
+        JOIN chart_configs cc ON c.configId = cc.id
+        WHERE cc.slug = ?
+        LIMIT 1`,
+        [sourceSlug]
+    )
+    if (sourceIsChartSlugTarget.length > 0) {
+        throw new JsonError(
+            `Creating this redirect would form a redirect chain: '${source}' is already a target of chart slug redirect '${sourceIsChartSlugTarget[0].slug}'`,
+            400
+        )
+    }
+
+    // Check target is not already a redirect source (would create chain: source -> target -> Y)
+    if (await redirectWithSourceExists(trx, targetPath)) {
+        throw new JsonError(
+            `Creating this redirect would form a redirect chain: target '${targetPath}' is already a source of an existing site redirect`,
+            400
+        )
+    }
+    const targetInMultiDim = await trx<{ id: number }>(
+        MultiDimRedirectsTableName
+    )
+        .select("id")
+        .where("source", targetPath)
+        .first()
+    if (targetInMultiDim) {
+        throw new JsonError(
+            `Creating this redirect would form a redirect chain: target '${targetPath}' is already a source of an existing multi-dim redirect`,
+            400
+        )
+    }
+    const targetInChartSlug = await trx<{ id: number }>(
+        ChartSlugRedirectsTableName
+    )
+        .select("id")
+        .where("slug", targetSlug)
+        .first()
+    if (targetInChartSlug) {
+        throw new JsonError(
+            `Creating this redirect would form a redirect chain: target '${targetPath}' is already a source of an existing chart slug redirect`,
+            400
+        )
+    }
+}
+
+async function createSlugChangeRedirect(
+    trx: db.KnexReadWriteTransaction,
+    multiDim: DbEnrichedMultiDimDataPage,
+    previousSlug: string
+): Promise<void> {
+    const source = `/grapher/${previousSlug}`
+    await validateMultiDimRedirect(trx, source, multiDim.slug!)
+    await trx(MultiDimRedirectsTableName).insert({
+        source,
+        multiDimId: multiDim.id,
+        viewConfigId: null,
+    })
+}
 
 export async function handleGetMultiDims(
     _req: Request,
@@ -52,6 +223,27 @@ export async function handleGetMultiDims(
     } catch (error) {
         throw new JsonError("Failed to fetch multi-dims", 500, { cause: error })
     }
+}
+
+export async function handleGetMultiDim(
+    req: Request,
+    _res: e.Response<any, Record<string, any>>,
+    trx: db.KnexReadonlyTransaction
+) {
+    const id = expectInt(req.params.id)
+    const row = await trx<DbPlainMultiDimDataPage>(MultiDimDataPagesTableName)
+        .select("id", "catalogPath", "slug", "config", "updatedAt", "published")
+        .where("id", id)
+        .first()
+    if (!row) {
+        throw new JsonError("Multi-dimensional data page not found", 404)
+    }
+    const multiDim = {
+        ...row,
+        config: JSON.parse(row.config),
+        published: Boolean(row.published),
+    }
+    return { multiDim }
 }
 
 export async function handlePutMultiDim(
@@ -95,18 +287,40 @@ export async function handlePatchMultiDim(
     }
     const { published, slug } = req.body
     let action
+    let previousSlug: string | undefined
     if (slug !== undefined && slug !== multiDim.slug) {
+        previousSlug = multiDim.slug ?? undefined
         await validateNewGrapherSlug(trx, slug)
+        const newSlugSource = `/grapher/${slug}`
+        await validatePathIsNotRedirectSource(trx, newSlugSource)
         multiDim = await setMultiDimSlug(trx, multiDim, slug)
         if (multiDim.published) {
             action = "publish"
         }
     }
+    if (previousSlug && multiDim.published) {
+        await createSlugChangeRedirect(trx, multiDim, previousSlug)
+    }
+
     // Note: Keep this change last, since we don't want to update the configs
     // in R2 when a previous operation fails.
     if (published !== undefined && published !== multiDim.published) {
         if (published) {
             await validateMultiDimSlug(trx, multiDim.slug)
+        } else {
+            const existingRedirects = await trx<DbPlainMultiDimRedirect>(
+                MultiDimRedirectsTableName
+            )
+                .select("source")
+                .where("multiDimId", id)
+                .limit(1)
+
+            if (existingRedirects.length > 0) {
+                throw new JsonError(
+                    `Cannot unpublish multi-dim: redirects exist pointing to this multi-dim (e.g., '${existingRedirects[0].source}'). Please delete the redirects first.`,
+                    400
+                )
+            }
         }
         multiDim = await setMultiDimPublished(trx, multiDim, published)
         action = published ? "publish" : "unpublish"
@@ -118,4 +332,162 @@ export async function handlePatchMultiDim(
         )
     }
     return { success: true, multiDim }
+}
+
+export async function handleGetMultiDimRedirects(
+    req: Request,
+    _res: e.Response<any, Record<string, any>>,
+    trx: db.KnexReadonlyTransaction
+) {
+    const multiDimId = expectInt(req.params.id)
+
+    const redirects = await db.knexRaw<{
+        id: number
+        source: string
+        viewConfigId: string | null
+    }>(
+        trx,
+        `-- sql
+        SELECT
+            mdr.id,
+            mdr.source,
+            mdr.viewConfigId
+        FROM ${MultiDimRedirectsTableName} mdr
+        WHERE mdr.multiDimId = ?
+        ORDER BY mdr.createdAt DESC`,
+        [multiDimId]
+    )
+
+    return { redirects }
+}
+
+const postMultiDimRedirectSchema = z.object({
+    source: z
+        .string()
+        .regex(
+            /^\/(grapher|explorers)\/.*[^/]$/,
+            "Source must start with either /grapher/ or /explorers/ and cannot end with a slash"
+        ),
+    viewConfigId: z.string().nullable().optional(),
+})
+
+export async function handlePostMultiDimRedirect(
+    req: Request,
+    res: e.Response<any, Record<string, any>>,
+    trx: db.KnexReadWriteTransaction
+) {
+    const multiDimId = expectInt(req.params.id)
+    const parseResult = postMultiDimRedirectSchema.safeParse(req.body)
+    if (!parseResult.success) {
+        throw new JsonError(
+            `Invalid request: ${parseResult.error.message}`,
+            400
+        )
+    }
+    const { source, viewConfigId } = parseResult.data
+
+    const multiDim = await getMultiDimDataPageById(trx, multiDimId)
+    if (!multiDim) {
+        throw new JsonError("Multi-dimensional data page not found", 404)
+    }
+    if (!multiDim.slug) {
+        throw new JsonError(
+            "Target multi-dim must have a slug before adding redirects",
+            400
+        )
+    }
+    if (!multiDim.published) {
+        throw new JsonError(
+            "Target multi-dim must be published before adding redirects",
+            400
+        )
+    }
+
+    if (viewConfigId) {
+        const mdimConfig = MultiDimDataPageConfig.fromObject(multiDim.config)
+        const dimensions = mdimConfig.findViewDimensionsByConfigId(viewConfigId)
+        if (!dimensions) {
+            throw new JsonError(
+                `View config '${viewConfigId}' not found for this multi-dim`,
+                404
+            )
+        }
+    }
+
+    if (source === `/grapher/${multiDim.slug}`) {
+        throw new JsonError(
+            "Creating this redirect would redirect to the same page.",
+            400
+        )
+    }
+
+    await validateMultiDimRedirect(trx, source, multiDim.slug)
+
+    const [insertId] = await trx<DbInsertMultiDimRedirect>(
+        MultiDimRedirectsTableName
+    ).insert({
+        source,
+        multiDimId,
+        viewConfigId,
+    })
+
+    const targetDescription = buildRedirectTargetDescription(
+        multiDim,
+        viewConfigId ?? null
+    )
+
+    await triggerStaticBuild(
+        res.locals.user,
+        `Creating multi-dim redirect from '${source}' to '${targetDescription}'`
+    )
+
+    return {
+        success: true,
+        redirect: {
+            id: insertId,
+            source,
+            viewConfigId: viewConfigId ?? null,
+        },
+    }
+}
+
+export async function handleDeleteMultiDimRedirect(
+    req: Request,
+    res: e.Response<any, Record<string, any>>,
+    trx: db.KnexReadWriteTransaction
+) {
+    const redirectId = expectInt(req.params.redirectId)
+
+    const redirect = await trx<DbPlainMultiDimRedirect>(
+        MultiDimRedirectsTableName
+    )
+        .select("*")
+        .where("id", redirectId)
+        .first()
+
+    if (!redirect) {
+        throw new JsonError(`Redirect with id ${redirectId} not found`, 404)
+    }
+
+    const multiDim = await getMultiDimDataPageById(trx, redirect.multiDimId)
+    if (!multiDim) {
+        throw new JsonError("Multi-dimensional data page not found", 404)
+    }
+
+    const viewConfigId = redirect.viewConfigId ?? null
+
+    await trx<DbPlainMultiDimRedirect>(MultiDimRedirectsTableName)
+        .where("id", redirectId)
+        .delete()
+
+    const targetDescription = buildRedirectTargetDescription(
+        multiDim,
+        viewConfigId
+    )
+    await triggerStaticBuild(
+        res.locals.user,
+        `Deleting multi-dim redirect from '${redirect.source}' to '${targetDescription}'`
+    )
+
+    return { success: true }
 }

--- a/baker/algolia/utils/pageviews.test.ts
+++ b/baker/algolia/utils/pageviews.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest"
+import { getMaxViews7d } from "./pageviews.js"
+
+describe(getMaxViews7d, () => {
+    it("returns 0 for empty inputs", () => {
+        const pageviews = {}
+        expect(getMaxViews7d(pageviews, [])).toBe(0)
+    })
+
+    it("ignores missing urls", () => {
+        const pageviews = {
+            "/grapher/exists": { views_7d: 42 },
+        }
+        expect(getMaxViews7d(pageviews, ["/grapher/missing"])).toBe(0)
+    })
+
+    it("returns the max views across urls", () => {
+        const pageviews = {
+            "/grapher/a": { views_7d: 10 },
+            "/grapher/b": { views_7d: 25 },
+            "/grapher/c": { views_7d: 5 },
+        }
+        expect(getMaxViews7d(pageviews, ["/grapher/a", "/grapher/b"])).toBe(25)
+    })
+
+    it("handles mixed present and missing urls", () => {
+        const pageviews = {
+            "/grapher/a": { views_7d: 7 },
+        }
+        expect(
+            getMaxViews7d(pageviews, ["/grapher/missing", "/grapher/a"])
+        ).toBe(7)
+    })
+})

--- a/baker/algolia/utils/pageviews.ts
+++ b/baker/algolia/utils/pageviews.ts
@@ -1,0 +1,13 @@
+export type PageviewsByUrl = Record<string, { views_7d: number }>
+
+export function getMaxViews7d(
+    pageviews: PageviewsByUrl,
+    urls: string[]
+): number {
+    let maxViews = 0
+    for (const url of urls) {
+        const views = pageviews[url]?.views_7d ?? 0
+        if (views > maxViews) maxViews = views
+    }
+    return maxViews
+}

--- a/baker/formatWordpressPost.tsx
+++ b/baker/formatWordpressPost.tsx
@@ -7,7 +7,7 @@ import { FormattedPost, FullPost, TocHeading, Url } from "@ourworldindata/utils"
 import { Footnote } from "../site/Footnote.js"
 import { PROMINENT_LINK_CLASSNAME } from "../site/blocks/ProminentLink.js"
 import { DEEP_LINK_CLASS, formatImages } from "./formatting.js"
-import { replaceIframesWithExplorerRedirectsInWordPressPost } from "./replaceExplorerRedirects.js"
+import { DEPRECATED_replaceIframesWithExplorerRedirectsInWordPressPost } from "./replaceExplorerRedirects.js"
 import { EXPLORERS_ROUTE_FOLDER } from "@ourworldindata/explorer"
 import { renderHelp } from "../site/blocks/renderHelp.js"
 import { formatUrls, getBodyHtml } from "../site/formatting.js"
@@ -89,7 +89,7 @@ export const formatWordpressPost = async (
     }
 
     // Replace URLs pointing to Explorer redirect URLs with the destination URLs
-    replaceIframesWithExplorerRedirectsInWordPressPost(cheerioEl)
+    DEPRECATED_replaceIframesWithExplorerRedirectsInWordPressPost(cheerioEl)
 
     const grapherIframes = cheerioEl("iframe")
         .toArray()

--- a/baker/redirectsFromDb.ts
+++ b/baker/redirectsFromDb.ts
@@ -1,25 +1,25 @@
 import * as _ from "lodash-es"
 import * as db from "../db/db.js"
-import { getRedirectsFromDb } from "../db/model/Redirect.js"
+import { getSiteRedirects } from "../db/model/Redirect.js"
+import { getMultiDimRedirectTargets } from "../db/model/MultiDimRedirects.js"
 
-export async function getRecentGrapherRedirects(
+// Prevent Cloudflare from serving outdated pages, which can remain in the
+// cache for up to a week. This is necessary since in the Cloudflare Functions
+// we take into consideration the grapher and multi-dim redirects only when the
+// route returns a 404, which won't be the case if the page is still cached.
+// https://developers.cloudflare.com/pages/configuration/serving-pages/#asset-retention
+export async function getRecentChartSlugRedirects(
     knex: db.KnexReadonlyTransaction
-) {
-    // Prevent Cloudflare from serving outdated grapher pages, which can remain
-    // in the cache for up to a week. This is necessary, since we take into
-    // consideration the grapher redirects only when the route returns a 404,
-    // which won't be the case if the page is still cached.
-    //
-    // https://developers.cloudflare.com/pages/configuration/serving-pages/#asset-retention
-    return await db.knexRaw<{
+): Promise<Array<{ source: string; target: string }>> {
+    return db.knexRaw<{
         source: string
         target: string
     }>(
         knex,
         `-- sql
         SELECT
-            chart_slug_redirects.slug as source,
-            chart_configs.slug as target
+            CONCAT('/grapher/', chart_slug_redirects.slug) as source,
+            CONCAT('/grapher/', chart_configs.slug) as target
         FROM chart_slug_redirects
         INNER JOIN charts ON charts.id=chart_id
         INNER JOIN chart_configs ON chart_configs.id=charts.configId
@@ -30,11 +30,27 @@ export async function getRecentGrapherRedirects(
     )
 }
 
-export const getGrapherRedirectsMap = async (
+export const getGrapherToChartAndMultiDimRedirects = async (
     knex: db.KnexReadonlyTransaction,
     urlPrefix: string = "/grapher/"
-) => {
-    const chartRedirectRows = (await db.knexRaw<{
+): Promise<Map<string, string>> => {
+    const grapherToChartRedirects = await getGrapherToChartRedirects(
+        knex,
+        urlPrefix
+    )
+    const grapherToMultiDimRedirects = await getGrapherToMultiDimRedirects(
+        knex,
+        urlPrefix
+    )
+
+    return new Map([...grapherToChartRedirects, ...grapherToMultiDimRedirects])
+}
+
+export const getGrapherToChartRedirects = async (
+    knex: db.KnexReadonlyTransaction,
+    urlPrefix: string = "/grapher/"
+): Promise<Map<string, string>> => {
+    const chartRedirectRows = await db.knexRaw<{
         oldSlug: string
         newSlug: string
     }>(
@@ -45,7 +61,7 @@ export const getGrapherRedirectsMap = async (
             INNER JOIN charts ON charts.id=chart_id
             INNER JOIN chart_configs ON chart_configs.id=charts.configId
         `
-    )) as Array<{ oldSlug: string; newSlug: string }>
+    )
 
     return new Map(
         chartRedirectRows
@@ -57,25 +73,70 @@ export const getGrapherRedirectsMap = async (
     )
 }
 
-export const getWordpressRedirectsMap = async (
-    knex: db.KnexReadonlyTransaction
-) => {
-    const redirectsFromDb = await getRedirectsFromDb(knex)
+export const getGrapherToMultiDimRedirects = async (
+    knex: db.KnexReadonlyTransaction,
+    urlPrefix: string = "/grapher/"
+): Promise<Map<string, string>> => {
+    const redirects = new Map<string, string>()
+    const targets = await getMultiDimRedirectTargets(
+        knex,
+        undefined,
+        "/grapher/"
+    )
 
-    return new Map(redirectsFromDb.map((row) => [row.source, row.target]))
+    for (const [sourceSlug, target] of targets.entries()) {
+        const targetPath = `${urlPrefix}${target.targetSlug}${
+            target.queryStr ? `?${target.queryStr}` : ""
+        }`
+        redirects.set(`${urlPrefix}${sourceSlug}`, targetPath)
+    }
+    return redirects
 }
 
-export const getGrapherAndWordpressRedirectsMap = _.memoize(
+export async function getExplorerToMultiDimRedirects(
+    knex: db.KnexReadonlyTransaction,
+    urlPrefix: string = "/explorers/"
+): Promise<Map<string, string>> {
+    const redirects = new Map<string, string>()
+    const targets = await getMultiDimRedirectTargets(
+        knex,
+        undefined,
+        "/explorers/"
+    )
+
+    for (const [sourceSlug, target] of targets.entries()) {
+        const targetPath = `/grapher/${target.targetSlug}${
+            target.queryStr ? `?${target.queryStr}` : ""
+        }`
+        redirects.set(`${urlPrefix}${sourceSlug}`, targetPath)
+    }
+    return redirects
+}
+
+export const DEPRECATED_getSiteRedirectsMap = async (
+    knex: db.KnexReadonlyTransaction
+) => {
+    const siteRedirects = await getSiteRedirects(knex)
+
+    return new Map(siteRedirects.map((row) => [row.source, row.target]))
+}
+
+export const DEPRECATED_getAllRedirectsMap = _.memoize(
     async (knex: db.KnexReadonlyTransaction): Promise<Map<string, string>> => {
         // source: pathnames only (e.g. /transport)
         // target: pathnames with or without origins (e.g. /transport-new or https://ourworldindata.org/transport-new)
 
-        const grapherRedirects = await getGrapherRedirectsMap(knex)
-        const wordpressRedirects = await getWordpressRedirectsMap(knex)
+        const grapherRedirects =
+            await getGrapherToChartAndMultiDimRedirects(knex)
+        const explorerRedirects = await getExplorerToMultiDimRedirects(knex)
+        const siteRedirects = await DEPRECATED_getSiteRedirectsMap(knex)
 
-        // The order the redirects are added to the map is important. Adding the
-        // Wordpress redirects last means that Wordpress redirects can overwrite
-        // grapher redirects.
-        return new Map([...grapherRedirects, ...wordpressRedirects])
+        // The order matters: site redirects can override both grapher and
+        // explorer redirects.
+        return new Map([
+            ...grapherRedirects,
+            ...explorerRedirects,
+            ...siteRedirects,
+        ])
     }
 )

--- a/baker/replaceExplorerRedirects.ts
+++ b/baker/replaceExplorerRedirects.ts
@@ -6,20 +6,20 @@ import { getExplorerRedirectForPath } from "../explorerAdminServer/ExplorerRedir
 import { Url } from "@ourworldindata/utils"
 import { CheerioAPI } from "cheerio"
 
-export const replaceIframesWithExplorerRedirectsInWordPressPost = (
+export const DEPRECATED_replaceIframesWithExplorerRedirectsInWordPressPost = (
     cheerio: CheerioAPI
 ) =>
     cheerio("iframe")
         .toArray()
         .forEach((el) => {
             const srcUrl = Url.fromURL(el.attribs["src"].trim())
-            const resolvedUrl = resolveExplorerRedirect(srcUrl)
+            const resolvedUrl = DEPRECATED_resolveExplorerRedirect(srcUrl)
             if (srcUrl === resolvedUrl) return
 
             el.attribs["src"] = resolvedUrl.fullUrl
         })
 
-export const resolveExplorerRedirect = (url: Url): Url => {
+export const DEPRECATED_resolveExplorerRedirect = (url: Url): Url => {
     if (!url.pathname) return url
 
     let tmpUrl

--- a/baker/siteRenderers.tsx
+++ b/baker/siteRenderers.tsx
@@ -79,7 +79,7 @@ import {
     getEnrichedChartById,
 } from "../db/model/Chart.js"
 import { ExplorerAdminServer } from "../explorerAdminServer/ExplorerAdminServer.js"
-import { resolveInternalRedirect } from "./redirects.js"
+import { DEPRECATED_resolveInternalRedirectForWordpressProminentLinks } from "./redirects.js"
 import {
     getBlockContentFromSnapshot,
     getFullPostBySlugFromSnapshot,
@@ -515,10 +515,11 @@ export const renderProminentLinks = async (
             const formattedUrlString = $block.find("link-url").text() // never empty, see prominent-link.php
             const formattedUrl = Url.fromURL(formattedUrlString)
 
-            const resolvedUrl = await resolveInternalRedirect(
-                formattedUrl,
-                knex
-            )
+            const resolvedUrl =
+                await DEPRECATED_resolveInternalRedirectForWordpressProminentLinks(
+                    formattedUrl,
+                    knex
+                )
             const resolvedUrlString = resolvedUrl.fullUrl
 
             const style = $block.attr("style")

--- a/db/docs/README.md
+++ b/db/docs/README.md
@@ -10,6 +10,7 @@ The most important tables are:
 - dods: Our Detail-on-Demands entry that our website uses to explain many technical terms when hovering over them
 - explorers: Our data explorers (collections of multiple charts with drop-downs to switch between them), published at https://ourworldindata.org/explorers/SLUG
 - multi_dim_data_pages: Our new multi-dim charts that also live under https://ourworldindata.org/grapher/SLUG. Similar to explorers in functionality but support data page features.
+- multi_dim_redirects: Redirects from graphers, explorers or multi-dims to multi-dims. Important to consider when resolving URLs that point to any of the aforementioned types of content.
 - origins: Describe data sources (e.g. a UN division, the WHO, an academic group that published a paper)
 - posts_gdocs: The heart of our CMS. This table stores practically all the text on our website. The original text is written in Google Docs using ArchieML. This table contains the ArchieML content serialized to JSON.
 - posts: legacy wordpress content. This is almost entirely obsolete. Only use this table when you have a good reason - by default you want to query posts_gdocs instead.

--- a/db/docs/multi_dim_redirects.yml
+++ b/db/docs/multi_dim_redirects.yml
@@ -1,0 +1,16 @@
+metadata:
+    description: |
+        Redirects from legacy sources (e.g. grapher slugs or other paths) to multi-dim pages. Each row maps a source identifier either to the multi-dim page's default view (when viewConfigId is NULL) or to a specific multi-dim view (identified by its chart config id in chart_configs).
+fields:
+    id:
+        description: Unique identifier for the redirect
+    source:
+        description: Source path that should redirect to a multi-dim page or view (unique)
+    multiDimId:
+        description: Foreign key to multi_dim_data_pages.id identifying the target multi-dim page
+    viewConfigId:
+        description: Optional foreign key to chart_configs.id identifying a specific view config. When NULL, redirects to the multi-dim page's default view.
+    createdAt:
+        description: Timestamp when the redirect was created
+    updatedAt:
+        description: Timestamp when the redirect was last updated

--- a/db/migration/1764156630580-CreateMultiDimRedirects.ts
+++ b/db/migration/1764156630580-CreateMultiDimRedirects.ts
@@ -1,0 +1,26 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class CreateMultiDimRedirects1764156630580
+    implements MigrationInterface
+{
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`-- sql
+            CREATE TABLE multi_dim_redirects (
+                id INT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+                source VARCHAR(512) NOT NULL UNIQUE,
+                multiDimId INT UNSIGNED NOT NULL,
+                viewConfigId CHAR(36) NULL,
+                createdAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                updatedAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                CONSTRAINT fk_multi_dim_redirects_multi_dim_id FOREIGN KEY (multiDimId) REFERENCES multi_dim_data_pages(id),
+                CONSTRAINT fk_multi_dim_redirects_view_config_id FOREIGN KEY (viewConfigId) REFERENCES chart_configs(id)
+            )
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`-- sql
+            DROP TABLE multi_dim_redirects
+        `)
+    }
+}

--- a/db/model/Gdoc/GdocBase.ts
+++ b/db/model/Gdoc/GdocBase.ts
@@ -51,6 +51,7 @@ import {
     getMultiDimDataPageBySlug,
     multiDimDataPageExists,
 } from "../MultiDimDataPage.js"
+import { getMultiDimRedirectTargets } from "../MultiDimRedirects.js"
 import {
     ARCHIVED_THUMBNAIL_FILENAME,
     ChartConfigType,
@@ -139,6 +140,8 @@ export async function loadLinkedChartsForSlugs(
         archivedChartVersions,
         archivedMultiDimVersions,
         archivedExplorerVersions,
+        grapherMultiDimRedirects,
+        explorerMultiDimRedirects,
     ] = await Promise.all([
         getLatestArchivedChartPageVersionsIfEnabled(
             knex,
@@ -146,11 +149,32 @@ export async function loadLinkedChartsForSlugs(
         ),
         getLatestArchivedMultiDimPageVersionsIfEnabled(knex),
         getLatestArchivedExplorerPageVersionsIfEnabled(knex, explorerSlugs),
+        getMultiDimRedirectTargets(knex, grapherSlugs, "/grapher/"),
+        getMultiDimRedirectTargets(knex, explorerSlugs, "/explorers/"),
     ])
 
     // TODO: rewrite this as a single query instead of N queries
     const linkedGrapherCharts = await Promise.all(
         grapherSlugs.map(async (originalSlug) => {
+            const multiDimRedirect = grapherMultiDimRedirects.get(originalSlug)
+
+            if (multiDimRedirect) {
+                const targetSlug = multiDimRedirect.targetSlug
+                const multiDim = await getMultiDimDataPageBySlug(
+                    knex,
+                    targetSlug,
+                    { onlyPublished: false }
+                )
+                if (!multiDim) return
+
+                return makeMultiDimLinkedChart(multiDim.config, originalSlug, {
+                    archivedPageVersion:
+                        archivedMultiDimVersions[multiDim.id] || undefined,
+                    queryStr: multiDimRedirect.queryStr,
+                    resolvedSlug: targetSlug,
+                })
+            }
+
             const chartId = slugToIdMap[originalSlug]
             if (chartId) {
                 const chart = await getChartConfigById(knex, chartId)
@@ -184,14 +208,41 @@ export async function loadLinkedChartsForSlugs(
     const publishedExplorersBySlug = await db.getPublishedExplorersBySlug(knex)
 
     const linkedExplorerCharts = excludeNullish(
-        explorerSlugs.map((originalSlug) => {
-            const explorer = publishedExplorersBySlug[originalSlug]
-            if (!explorer) return
-            return makeExplorerLinkedChart(explorer, originalSlug, {
-                archivedPageVersion:
-                    archivedExplorerVersions[originalSlug] || undefined,
+        await Promise.all(
+            explorerSlugs.map(async (originalSlug) => {
+                const multiDimRedirect =
+                    explorerMultiDimRedirects.get(originalSlug)
+
+                if (multiDimRedirect) {
+                    const targetSlug = multiDimRedirect.targetSlug
+                    const multiDim = await getMultiDimDataPageBySlug(
+                        knex,
+                        targetSlug,
+                        { onlyPublished: false }
+                    )
+                    if (!multiDim) return
+
+                    return makeMultiDimLinkedChart(
+                        multiDim.config,
+                        originalSlug,
+                        {
+                            archivedPageVersion:
+                                archivedMultiDimVersions[multiDim.id] ||
+                                undefined,
+                            queryStr: multiDimRedirect.queryStr,
+                            resolvedSlug: targetSlug,
+                        }
+                    )
+                }
+
+                const explorer = publishedExplorersBySlug[originalSlug]
+                if (!explorer) return
+                return makeExplorerLinkedChart(explorer, originalSlug, {
+                    archivedPageVersion:
+                        archivedExplorerVersions[originalSlug] || undefined,
+                })
             })
-        })
+        )
     )
 
     return [...linkedGrapherCharts, ...linkedExplorerCharts]
@@ -1011,12 +1062,24 @@ export class GdocBase implements OwidGdocBaseInterface {
             narrativeChartNames,
             dods,
             staticViz,
+            grapherMultiDimRedirects,
+            explorerMultiDimRedirects,
         ] = await Promise.all([
             mapSlugsToIds(knex),
             db.getPublishedExplorersBySlug(knex),
             getAllNarrativeChartNames(knex),
             getDods(knex).then((dods) => indexBy(dods, (dod) => dod.name)),
             getEnrichedStaticVizList(knex),
+            getMultiDimRedirectTargets(
+                knex,
+                this.linkedChartSlugs.grapher,
+                "/grapher/"
+            ),
+            getMultiDimRedirectTargets(
+                knex,
+                this.linkedChartSlugs.explorer,
+                "/explorers/"
+            ),
         ])
 
         const linkErrors: OwidGdocErrorMessage[] = []
@@ -1039,8 +1102,17 @@ export class GdocBase implements OwidGdocBaseInterface {
                     }
                 })
                 .with({ linkType: ContentGraphLinkType.Grapher }, async () => {
+                    const grapherRedirect = grapherMultiDimRedirects.get(
+                        link.target
+                    )
+                    const hasMultiDimRedirect =
+                        grapherRedirect !== undefined &&
+                        (grapherRedirect.targetSlug !== link.target ||
+                            !!grapherRedirect.queryStr)
+
                     if (
                         !chartIdsBySlug[link.target] &&
+                        !hasMultiDimRedirect &&
                         !(await multiDimDataPageExists(knex, {
                             slug: link.target,
                             published: true,
@@ -1053,8 +1125,23 @@ export class GdocBase implements OwidGdocBaseInterface {
                         })
                     }
                 })
-                .with({ linkType: ContentGraphLinkType.Explorer }, () => {
-                    if (!publishedExplorersBySlug[link.target]) {
+                .with({ linkType: ContentGraphLinkType.Explorer }, async () => {
+                    const explorerRedirect = explorerMultiDimRedirects.get(
+                        link.target
+                    )
+                    const hasMultiDimRedirect =
+                        explorerRedirect !== undefined &&
+                        (explorerRedirect.targetSlug !== link.target ||
+                            !!explorerRedirect.queryStr)
+
+                    if (
+                        !publishedExplorersBySlug[link.target] &&
+                        !hasMultiDimRedirect &&
+                        !(await multiDimDataPageExists(knex, {
+                            slug: link.target,
+                            published: true,
+                        }))
+                    ) {
                         linkErrors.push({
                             property: "content",
                             message: `Explorer chart with slug ${link.target} does not exist or is not published`,
@@ -1334,20 +1421,30 @@ export function makeExplorerLinkedChart(
 
 export function makeMultiDimLinkedChart(
     config: MultiDimDataPageConfigEnriched,
-    slug: string,
-    { archivedPageVersion }: { archivedPageVersion?: ArchivedPageVersion } = {}
+    originalSlug: string,
+    {
+        archivedPageVersion,
+        queryStr,
+        resolvedSlug,
+    }: {
+        archivedPageVersion?: ArchivedPageVersion
+        queryStr?: string
+        resolvedSlug?: string
+    } = {}
 ): LinkedChart {
     let title = config.title.title
     const titleVariant = config.title.titleVariant
     if (titleVariant) {
         title = `${title} ${titleVariant}`
     }
+    const slug = resolvedSlug ?? originalSlug
+    const resolvedUrl = `${BASE_URL}/grapher/${slug}${queryStr ? `?${queryStr}` : ""}`
     return {
         configType: ChartConfigType.MultiDim,
-        originalSlug: slug,
+        originalSlug,
         title,
         dimensionSlugs: config.dimensions.map((d) => d.slug),
-        resolvedUrl: `${BASE_URL}/grapher/${slug}`,
+        resolvedUrl,
         tags: [],
         archivedPageVersion,
     }

--- a/db/model/MultiDimRedirects.ts
+++ b/db/model/MultiDimRedirects.ts
@@ -1,0 +1,138 @@
+import * as db from "../db.js"
+import {
+    MultiDimDataPageConfigEnriched,
+    MultiDimRedirectsTableName,
+} from "@ourworldindata/types"
+import { MultiDimDataPageConfig } from "@ourworldindata/utils"
+
+export type MultiDimRedirectSourcePrefix = "/grapher/" | "/explorers/"
+
+export interface MultiDimRedirectTarget {
+    targetSlug: string
+    queryStr?: string
+}
+
+function buildQueryStrFromConfig(
+    viewConfigId: string | null,
+    config: string,
+    multiDimSlug: string
+): string | undefined {
+    if (!viewConfigId) return undefined
+
+    const parsedConfig = JSON.parse(config) as MultiDimDataPageConfigEnriched
+    const mdimConfig = MultiDimDataPageConfig.fromObject(parsedConfig)
+    const dimensions = mdimConfig.findViewDimensionsByConfigId(viewConfigId)
+    if (!dimensions) {
+        throw new Error(
+            `No matching view found for viewConfigId ${viewConfigId} on multi-dim ${multiDimSlug}`
+        )
+    }
+
+    const params = new URLSearchParams()
+    const sortedDimensions = Object.entries(dimensions).sort(([keyA], [keyB]) =>
+        keyA.localeCompare(keyB)
+    )
+    for (const [dimension, choice] of sortedDimensions) {
+        params.set(dimension, choice)
+    }
+    const queryStr = params.toString()
+    return queryStr || undefined
+}
+
+export async function getMultiDimRedirectTargets(
+    knex: db.KnexReadonlyTransaction,
+    slugs: string[] | undefined,
+    sourcePrefix: MultiDimRedirectSourcePrefix
+): Promise<Map<string, MultiDimRedirectTarget>> {
+    const redirectMap = new Map<string, MultiDimRedirectTarget>()
+    if (slugs && slugs.length === 0) return redirectMap
+
+    let whereClause: string
+    let params: string[]
+    if (!slugs) {
+        whereClause = "mdr.source LIKE ?"
+        params = [`${sourcePrefix}%`]
+    } else {
+        whereClause = `mdr.source IN (${slugs.map(() => "?").join(",")})`
+        params = slugs.map((slug) => `${sourcePrefix}${slug}`)
+    }
+
+    const redirects = await db.knexRaw<{
+        sourceSlug: string
+        multiDimSlug: string
+        viewConfigId: string | null
+        config: string
+    }>(
+        knex,
+        `-- sql
+        SELECT
+            REPLACE(mdr.source, ?, '') as sourceSlug,
+            mddp.slug as multiDimSlug,
+            mdr.viewConfigId as viewConfigId,
+            mddp.config as config
+        FROM ${MultiDimRedirectsTableName} mdr
+        JOIN multi_dim_data_pages mddp ON mddp.id = mdr.multiDimId
+        WHERE mddp.published = TRUE
+            AND mddp.slug IS NOT NULL
+            AND ${whereClause}
+        `,
+        [sourcePrefix, ...params]
+    )
+
+    for (const redirect of redirects) {
+        const queryStr = buildQueryStrFromConfig(
+            redirect.viewConfigId,
+            redirect.config,
+            redirect.multiDimSlug
+        )
+        redirectMap.set(redirect.sourceSlug, {
+            targetSlug: redirect.multiDimSlug,
+            queryStr,
+        })
+    }
+
+    return redirectMap
+}
+
+export async function getRecentMultiDimRedirects(
+    knex: db.KnexReadonlyTransaction
+): Promise<Array<{ source: string; target: string }>> {
+    const redirects = await db.knexRaw<{
+        source: string
+        multiDimSlug: string
+        viewConfigId: string | null
+        config: string
+    }>(
+        knex,
+        `-- sql
+        SELECT
+            mdr.source as source,
+            mddp.slug as multiDimSlug,
+            mdr.viewConfigId as viewConfigId,
+            mddp.config as config
+        FROM ${MultiDimRedirectsTableName} mdr
+        JOIN multi_dim_data_pages mddp ON mddp.id = mdr.multiDimId
+        WHERE mddp.published = TRUE
+            AND mddp.slug IS NOT NULL
+            AND COALESCE(mdr.updatedAt, mdr.createdAt) > (NOW() - INTERVAL 1 WEEK)
+        `
+    )
+
+    const result: Array<{ source: string; target: string }> = []
+    for (const redirect of redirects) {
+        const queryStr = buildQueryStrFromConfig(
+            redirect.viewConfigId,
+            redirect.config,
+            redirect.multiDimSlug
+        )
+        const target = `/grapher/${redirect.multiDimSlug}${
+            queryStr ? `?${queryStr}` : ""
+        }`
+        result.push({
+            source: redirect.source,
+            target,
+        })
+    }
+
+    return result
+}

--- a/db/model/Redirect.ts
+++ b/db/model/Redirect.ts
@@ -1,7 +1,7 @@
 import { DbPlainRedirect } from "@ourworldindata/types"
 import * as db from "../db"
 
-export const getRedirectsFromDb = async (
+export const getSiteRedirects = async (
     knex: db.KnexReadonlyTransaction
 ): Promise<Pick<DbPlainRedirect, "source" | "target" | "code">[]> => {
     return await db.knexRaw(knex, `SELECT source, target, code FROM redirects`)

--- a/functions/_common/redirectTools.ts
+++ b/functions/_common/redirectTools.ts
@@ -1,12 +1,18 @@
 import { Env, extensions } from "./env.js"
 
 export function createRedirectResponse(
-    redirSlug: string,
-    currentUrl: URL
+    currentUrl: URL,
+    targetPath: string,
+    targetParams?: URLSearchParams
 ): Response {
+    const mergedParams = new URLSearchParams(targetParams)
+    for (const [key, value] of currentUrl.searchParams.entries()) {
+        mergedParams.set(key, value)
+    }
+    const url = `${targetPath}${mergedParams.toString() ? `?${mergedParams.toString()}` : ""}`
     return new Response(null, {
         status: 302,
-        headers: { Location: `/grapher/${redirSlug}${currentUrl.search}` },
+        headers: { Location: url },
     })
 }
 
@@ -25,22 +31,31 @@ export async function getRedirectForUrl(env: Env, url: URL) {
     const extension = matchResult?.groups?.extension ?? ""
 
     if (slug.toLowerCase() !== slug)
-        return createRedirectResponse(`${slug.toLowerCase()}${extension}`, url)
+        return createRedirectResponse(
+            url,
+            `/grapher/${slug.toLowerCase()}${extension}`
+        )
 
     console.log("Looking up slug and extension", {
         slug,
         extension,
     })
 
-    const redirectSlug = await getOptionalRedirectForSlug(slug, url, {
+    const target = await getOptionalGrapherRedirectForSlug(slug, url, {
         ...env,
         url,
     })
-    console.log("Redirect slug", redirectSlug)
+    console.log("Redirect target", target)
+    const [redirectSlug, redirectParams] = target?.split("?", 2) ?? []
     if (redirectSlug && redirectSlug !== slug) {
-        return createRedirectResponse(`${redirectSlug}${extension}`, url)
+        return createRedirectResponse(
+            url,
+            `/grapher/${redirectSlug}${extension}`,
+            redirectParams ? new URLSearchParams(redirectParams) : undefined
+        )
     }
 }
+
 export async function handlePageNotFound(
     env: Env,
     response: Response
@@ -50,7 +65,8 @@ export async function handlePageNotFound(
     const redirect = await getRedirectForUrl(env, url)
     return redirect || response
 }
-export async function getOptionalRedirectForSlug(
+
+export async function getOptionalGrapherRedirectForSlug(
     slug: string,
     baseUrl: URL,
     env: Env
@@ -65,4 +81,78 @@ export async function getOptionalRedirectForSlug(
             return {}
         })
     return redirects[slug]
+}
+
+export async function getRedirectForExplorerUrl(
+    env: Env,
+    url: URL
+): Promise<Response | undefined> {
+    const fullslug = url.pathname.split("/").pop()
+
+    const allExtensions = Object.values(extensions)
+        .map((ext) => ext.replace(".", "\\."))
+        .join("|")
+    const regexForKnownExtensions = new RegExp(
+        `^(?<slug>.*?)(?<extension>${allExtensions})?$`
+    )
+
+    const matchResult = fullslug?.match(regexForKnownExtensions)
+    const slug = matchResult?.groups?.slug ?? fullslug
+    const extension = matchResult?.groups?.extension ?? ""
+
+    if (slug && slug.toLowerCase() !== slug)
+        return createRedirectResponse(
+            url,
+            `/explorers/${slug.toLowerCase()}${extension}`
+        )
+
+    console.log("Looking up explorer slug and extension", {
+        slug,
+        extension,
+    })
+
+    // Explorer redirects contain full target paths (e.g. /grapher/slug?params)
+    const target = await getOptionalExplorerRedirectForSlug(slug, url, env)
+    console.log("Explorer redirect target", target)
+    if (target) {
+        const [targetPath, targetParams] = target.split("?", 2)
+        // Append extension to the target path if present
+        const targetPathWithExtension = extension
+            ? `${targetPath}${extension}`
+            : targetPath
+        return createRedirectResponse(
+            url,
+            targetPathWithExtension,
+            targetParams ? new URLSearchParams(targetParams) : undefined
+        )
+    }
+    return undefined
+}
+
+async function getOptionalExplorerRedirectForSlug(
+    slug: string | undefined,
+    baseUrl: URL,
+    env: Env
+): Promise<string | undefined> {
+    if (!slug) return undefined
+    const redirects: Record<string, string> = await env.ASSETS.fetch(
+        new URL("/explorers/_explorerRedirects.json", baseUrl),
+        { cf: { cacheTtl: 2 * 60 } }
+    )
+        .then((r): Promise<Record<string, string>> => r.json())
+        .catch((e) => {
+            console.error("Error fetching explorer redirects", e)
+            return {}
+        })
+    return redirects[slug]
+}
+
+export async function handleExplorerPageNotFound(
+    env: Env,
+    response: Response
+): Promise<Response> {
+    const url = new URL(response.url)
+    console.log("Handling explorer 404 for", url.pathname)
+    const redirect = await getRedirectForExplorerUrl(env, url)
+    return redirect || response
 }

--- a/functions/grapher/[slug].ts
+++ b/functions/grapher/[slug].ts
@@ -130,10 +130,8 @@ export const onRequest: PagesFunction<Env> = async (context) => {
             context
         )
         .catch(async (e) => {
-            // Here we do a unified after the fact handling of 404s to check
-            // if we have a redirect in the _grapherRedirects.json file.
-            // This is done as a catch handler that checks for 404 pages
-            // so that the common, happy path does not have to fetch the redirects file.
+            // Only check _grapherRedirects.json for redirects if a 404 occurs.
+            // Otherwise, skip the extra fetch in the happy path.
             console.log("Handling error", e)
             if (e instanceof StatusError && e.status === 404) {
                 console.log("Handling 404 for", url.pathname)

--- a/packages/@ourworldindata/types/src/dbTypes/MultiDimRedirects.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/MultiDimRedirects.ts
@@ -1,0 +1,19 @@
+export const MultiDimRedirectsTableName = "multi_dim_redirects"
+
+export interface DbInsertMultiDimRedirect {
+    id?: number
+    source: string
+    multiDimId: number
+    viewConfigId?: string | null
+    createdAt?: Date
+    updatedAt?: Date | null
+}
+
+export interface DbPlainMultiDimRedirect {
+    id: number
+    source: string
+    multiDimId: number
+    viewConfigId: string | null
+    createdAt: Date
+    updatedAt: Date | null
+}

--- a/packages/@ourworldindata/types/src/domainTypes/Archive.ts
+++ b/packages/@ourworldindata/types/src/domainTypes/Archive.ts
@@ -93,6 +93,18 @@ export interface ExplorerChecksumsObjectWithHash {
     checksumsHashed: string
 }
 
+export interface NarrativeChartChecksums {
+    chartConfigMd5: string
+    queryParamsForParentChartMd5: string
+    indicators: IndicatorChecksums
+}
+
+export interface NarrativeChartChecksumsResult {
+    narrativeChartId: number
+    narrativeChartName: string
+    checksums: NarrativeChartChecksums
+}
+
 export interface PostChecksums {
     postContentMd5: string
     indicators: IndicatorChecksums // Shared across all chart types

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -572,6 +572,11 @@ export {
     ChartSlugRedirectsTableName,
 } from "./dbTypes/ChartSlugRedirects.js"
 export {
+    type DbPlainMultiDimRedirect,
+    type DbInsertMultiDimRedirect,
+    MultiDimRedirectsTableName,
+} from "./dbTypes/MultiDimRedirects.js"
+export {
     type DbPlainChartTag,
     type DbInsertChartTag,
     ChartTagsTableName,
@@ -892,6 +897,8 @@ export {
     type MultiDimChecksumsObjectWithHash,
     type ExplorerChecksums,
     type ExplorerChecksumsObjectWithHash,
+    type NarrativeChartChecksums,
+    type NarrativeChartChecksumsResult,
     type PostChecksums,
     type PostChecksumsObjectWithHash,
 } from "./domainTypes/Archive.js"

--- a/packages/@ourworldindata/utils/src/MultiDimDataPageConfig.ts
+++ b/packages/@ourworldindata/utils/src/MultiDimDataPageConfig.ts
@@ -168,6 +168,15 @@ export class MultiDimDataPageConfig {
         )
     }
 
+    findViewDimensionsByConfigId(
+        viewConfigId: string
+    ): MultiDimDimensionChoices | null {
+        const view = this.config.views.find(
+            (v) => v.fullConfigId === viewConfigId
+        )
+        return view?.dimensions ?? null
+    }
+
     static viewToDimensionsConfig(
         view?: View<IndicatorsAfterPreProcessing>
     ): OwidChartDimensionInterface[] {

--- a/site/gdocs/components/ArticleBlock.tsx
+++ b/site/gdocs/components/ArticleBlock.tsx
@@ -77,6 +77,9 @@ function ArticleBlockInternal({
     const { tags } = useContext(AttachmentsContext)
     block.type = block.type.toLowerCase() as any // this comes from the user and may not be all lowercase, enforce it here
 
+    const { linkedChart } = useLinkedChart(
+        block.type === "chart" ? block.url : ""
+    )
     // Special handling for mdims in side-by-side blocks to align them with
     // other charts.
     const isSideBySide = block.type === "side-by-side"
@@ -128,8 +131,9 @@ function ArticleBlockInternal({
             />
         ))
         .with({ type: "chart" }, (block) => {
-            const { isExplorer, queryStr } = Url.fromURL(block.url)
-            const areControlsHidden = queryStr.includes("hideControls=true")
+            const resolvedUrl = linkedChart?.resolvedUrl ?? block.url
+            const { isExplorer, queryParams } = Url.fromURL(resolvedUrl)
+            const areControlsHidden = queryParams.hideControls === "true"
             const size = block.size ?? BlockSize.Wide
             const layoutSubtype =
                 isExplorer && !areControlsHidden

--- a/site/gdocs/components/Chart.tsx
+++ b/site/gdocs/components/Chart.tsx
@@ -39,7 +39,6 @@ export default function Chart({
     // This means we can link to the same chart multiple times with different querystrings
     // and it should all resolve correctly via the same linkedChart
     const { linkedChart } = useLinkedChart(d.url)
-    const url = Url.fromURL(d.url)
     const resolvedUrl = linkedChart?.resolvedUrl ?? ""
     const resolvedUrlParsed = useMemo(
         () => Url.fromURL(resolvedUrl),
@@ -57,7 +56,7 @@ export default function Chart({
     const configType = linkedChart?.configType
     const isExplorer = configType === ChartConfigType.Explorer
     const isMultiDim = configType === ChartConfigType.MultiDim
-    const hasControls = url.queryParams.hideControls !== "true"
+    const hasControls = resolvedUrlParsed.queryParams.hideControls !== "true"
     const isExplorerWithControls = isExplorer && hasControls
     const isMultiDimWithControls = isMultiDim && hasControls
 
@@ -167,7 +166,7 @@ export default function Chart({
                 </figure>
             ) : isMultiDim ? (
                 <MultiDimEmbed
-                    url={d.url}
+                    url={resolvedUrl}
                     chartConfig={chartConfig}
                     isPreviewing={isPreviewing}
                 />

--- a/site/gdocs/utils.ts
+++ b/site/gdocs/utils.ts
@@ -143,7 +143,7 @@ export const useLinkedChart = (
     const linkType = getLinkType(url)
     if (linkType !== "grapher" && linkType !== "explorer") return {}
 
-    const queryString = Url.fromURL(url).queryStr
+    const parsedOriginalUrl = Url.fromURL(url)
     const urlTarget = getUrlTarget(url)
     const linkedChart = linkedCharts?.[urlTarget]
     if (!linkedChart) {
@@ -152,14 +152,13 @@ export const useLinkedChart = (
         }
     }
 
-    return {
-        linkedChart: {
-            ...linkedChart,
-            // linkedCharts doesn't store any querystring information, because it's indexed by slug
-            // Instead we get the querystring from the original URL and append it to resolvedUrl
-            resolvedUrl: `${linkedChart.resolvedUrl}${queryString}`,
-        },
-    }
+    const parsedResolvedUrl = Url.fromURL(linkedChart.resolvedUrl)
+    const resolvedUrl = parsedResolvedUrl.setQueryParams({
+        ...parsedResolvedUrl.queryParams,
+        ...parsedOriginalUrl.queryParams,
+    }).fullUrl
+
+    return { linkedChart: { ...linkedChart, resolvedUrl } }
 }
 
 export const useLinkedIndicator = (


### PR DESCRIPTION
## Overview

Add admin API and UI to create, read, and delete redirects and integrate them throughout the code base.

Source of a multi-dim redirect can be:

- grapher
- explorer
- multi-dim

Target of a multi-dim redirect can be:

- default view of a multi-dim
- specific view of a multi-dim, i.e. multi-dim URL with query params

Multi-dim redirects affect:

- URL resolution in Cloudflare Pages and Functions: data pages, configs, thumbnails, etc.
- URL resolution during baking: if an article includes a chart that redirects to a multi-dim, it should use the multi-dim instead
- Dependency tracking in the archive: archived page checksums should be calculated using the resolved redirect targets

## Context

Resolves #5211

The implementation diverges from the initial design mostly by usinng a single table for storage, instead of separate tables based on the type of the source (the source might no longer exist).

## Future work

- Index page in admin to list all multi-dim redirects, similar to chart and site redirects
- Support for mapping explorer view query params to multi-dim view query params

## Screenshots / Videos / Diagrams

<img width="2560" height="1408" alt="image" src="https://github.com/user-attachments/assets/e72f3b95-14ed-4c84-ac57-a14b046d3b86" />

## Testing guidance

There is a ton of stuff that we should test, unfortunately. I already tested most of it manually, but double checking it would be great. Not sure if trying to list it from manually here is worthwile, see what places we touch in code.

- [x] Does the change work in the archive?
- [ ] Does the staging experience have sign-off from product stakeholders?

## Checklist

### Before merging

If DB migrations exists:

- [x] The DB type definitions have been updated
- [ ] The DB types in the ETL have been updated
- [ ] If tables/views were added/removed, the Datasette export has been updated to take this into account
- [x] Update the documentation in db/docs