### PR TITLE
enhance: only show suggestions on user focus

### DIFF
--- a/site/search/SearchAutocomplete.tsx
+++ b/site/search/SearchAutocomplete.tsx
@@ -3,7 +3,6 @@ import { useEffect, useCallback, useState } from "react"
 import { match } from "ts-pattern"
 import {
     suggestFiltersFromQuerySuffix,
-    createQueryFilter,
     getSearchAutocompleteId,
     getSearchAutocompleteItemId,
     getFilterAriaLabel,
@@ -16,15 +15,6 @@ import { Filter, FilterType } from "@ourworldindata/types"
 import { useSearchContext } from "./SearchContext.js"
 import { listedRegionsNames } from "@ourworldindata/utils"
 import { useDebounceValue } from "usehooks-ts"
-
-// Default search suggestions to show when there's no query or filters
-const DEFAULT_SEARCHES = [
-    "gdp per capita",
-    "co2 emissions",
-    "life expectancy",
-    "child mortality",
-    "energy consumption",
-]
 
 export const SearchAutocomplete = ({
     localQuery,
@@ -58,12 +48,6 @@ export const SearchAutocomplete = ({
     } = useSearchAutocomplete()
 
     useEffect(() => {
-        if (!debouncedLocalQuery && !filters.length) {
-            setSuggestions(DEFAULT_SEARCHES.map(createQueryFilter))
-            setUnmatchedQuery("")
-            return
-        }
-
         const result = suggestFiltersFromQuerySuffix(
             debouncedLocalQuery,
             listedRegionsNames(),

--- a/site/search/SearchInput.tsx
+++ b/site/search/SearchInput.tsx
@@ -57,7 +57,6 @@ export const SearchInput = forwardRef(
             if (e.key === "Backspace" && value === "") {
                 e.preventDefault()
                 onBackspaceEmpty()
-                setActiveIndex(-1)
                 return
             }
 
@@ -136,7 +135,6 @@ export const SearchInput = forwardRef(
                             setLocalQuery(e.target.value)
                             if (e.target.value === "") {
                                 setGlobalQuery("")
-                                setActiveIndex(-1) // not highlighting the first default search
                             } else {
                                 setShowSuggestions(true)
                                 setActiveIndex(0)
@@ -148,7 +146,7 @@ export const SearchInput = forwardRef(
                             // This prevents showing suggestions on initial autofocus
                             if (hasUserInteracted.current) {
                                 setShowSuggestions(true)
-                                setActiveIndex(value ? 0 : -1)
+                                setActiveIndex(0)
                             }
                         }}
                         onBlur={() => {


### PR DESCRIPTION
fixes #5757

## Context

This PR improves the search autocomplete behavior by removing default search suggestions and not showing suggestions on page load without user interaction - while preserving autofocus in the search bar.

Technically, removing default search suggestions was not necessary anymore to fix the iOS issue mentioned in #5757 once suggestions are not shown on page load, but this doesn't address the second issue mentioned in #5757: default searches being shown whenever the query is cleared. For that reason, I still chose to remove them altogether.

## Testing guidance

Test suite: https://low-code.browserstack.com/projects/919768/builds/1ygtrm9rbyqbubnkia2d4kkmdlbccyyvesyjm6q2

1. Open the [search page](https://suggestions-focus.owid.pages.dev/search) and verify that default suggestions no longer appear when the field is empty
2. Test focus behavior:
    - Verify that suggestions don't appear on initial page load while the search input is autofocused (e.g. https://suggestions-focus.owid.pages.dev/search?q=co2&countries=France)
    - Verify that suggestions appear when you focus the search after interacting with it (e.g. type "gdp")

- [x] Does the staging experience have sign-off from product stakeholders?

## Checklist

### Before merging

- [x] Changes to CSS/HTML were checked on Desktop and Mobile Safari at all three breakpoints
- [x] Changes to HTML were checked for accessibility concerns