### PR TITLE
🐛 fix regex loop in SVG comparison

### DIFF
--- a/devTools/svgTester/utils.ts
+++ b/devTools/svgTester/utils.ts
@@ -463,7 +463,7 @@ const replaceRegexes = [/id="react-select-\d+-.+"/g]
 async function prepareSvgForComparison(svg: string): Promise<string> {
     let current = svg
     for (const replaceRegex of replaceRegexes) {
-        current = svg.replace(replaceRegex, "")
+        current = current.replace(replaceRegex, "")
     }
     return await formatSvg(current)
 }


### PR DESCRIPTION
Fixed a bug in prepareSvgForComparison where the loop was replacing using the original `svg` variable instead of the accumulator `current`, causing only the last regex to be applied.