### PR TITLE
🐛 fix facet label position

### DIFF
--- a/packages/@ourworldindata/grapher/src/facet/FacetMap.tsx
+++ b/packages/@ourworldindata/grapher/src/facet/FacetMap.tsx
@@ -492,7 +492,7 @@ export class FacetMap
         // Move the label closer to the map if there is vertical padding
         if (mapHeight < bounds.height) {
             const shiftY = (bounds.height - mapHeight) / 2
-            labelY += shiftY - 3 * labelPadding
+            labelY = Math.max(labelY, labelY + shiftY - 3 * labelPadding)
         }
 
         return { x: labelX, y: labelY }


### PR DESCRIPTION
Fixes the facet label position in twitter thumbnails:
<img width="800" height="423" alt="Screenshot 2025-12-17 at 16 49 01" src="https://github.com/user-attachments/assets/2252eee2-ac16-4ef9-ab2c-47e9817e5b86" />
