### PR TITLE
✨ standardize prominent-link and recirc design

### DIFF
--- a/packages/@ourworldindata/components/src/styles/mixins.scss
+++ b/packages/@ourworldindata/components/src/styles/mixins.scss
@@ -581,11 +581,3 @@
         (100% - (var(--grid-gap) * #{$items-per-row - 1})) / #{$items-per-row}
     );
 }
-
-@mixin prominent-link-dark-style {
-    background-color: $blue-20;
-    color: $blue-65;
-    .prominent-link__heading-wrapper {
-        color: $blue-90;
-    }
-}

--- a/packages/@ourworldindata/types/src/gdocTypes/ArchieMlComponents.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/ArchieMlComponents.ts
@@ -388,6 +388,7 @@ export type EnrichedHybridLink = {
     url: string
     title?: string
     subtitle?: string
+    thumbnail?: string
     type: "hybrid-link"
 }
 

--- a/site/gdocs/components/ExploreDataSection.scss
+++ b/site/gdocs/components/ExploreDataSection.scss
@@ -24,7 +24,7 @@
     }
 
     .article-block__prominent-link {
-        @include prominent-link-dark-style;
+        background-color: $blue-20;
     }
 }
 

--- a/site/gdocs/components/HybridLinkList.tsx
+++ b/site/gdocs/components/HybridLinkList.tsx
@@ -11,7 +11,8 @@ function HybridGdocLink(props: EnrichedHybridLink) {
     if (!linkedDocument?.slug) return null
 
     const title = props.title || linkedDocument.title
-    const subtitle = props.subtitle || linkedDocument.subtitle
+    const subtitle =
+        props.subtitle || linkedDocument.excerpt || linkedDocument.subtitle
 
     return (
         <li className="hybrid-link-item">
@@ -56,6 +57,12 @@ function HybridExternalLink(props: EnrichedHybridLink) {
     return (
         <li className="hybrid-link-item hybrid-link-item--external">
             <a href={props.url}>
+                {props.thumbnail && (
+                    <Thumbnail
+                        thumbnail={props.thumbnail}
+                        className="hybrid-link-thumbnail"
+                    />
+                )}
                 <div className="hybrid-link-item-text">
                     <h4>
                         {props.title}

--- a/site/gdocs/components/KeyInsights.scss
+++ b/site/gdocs/components/KeyInsights.scss
@@ -152,7 +152,7 @@ $slide-content-height: $grapher-height;
 }
 
 .article-block__key-insights-content-column {
-    p {
+    @include text-block-override {
         @include body-2-regular;
     }
 }

--- a/site/gdocs/components/ProminentLink.scss
+++ b/site/gdocs/components/ProminentLink.scss
@@ -1,0 +1,16 @@
+.prominent-link {
+    --thumbnail-width: 70px;
+    background-color: $gray-5;
+    padding: 16px;
+    padding-bottom: 8px;
+    align-self: start;
+    margin-bottom: 24px;
+    display: flex;
+    flex-direction: column;
+    grid-row: span 10;
+
+    // Last consecutive sibling.
+    &:has(+ :not(.prominent-link)) {
+        margin-bottom: 32px;
+    }
+}

--- a/site/gdocs/components/ProminentLink.tsx
+++ b/site/gdocs/components/ProminentLink.tsx
@@ -1,14 +1,9 @@
-import { useContext } from "react"
 import cx from "classnames"
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
-import { faArrowUpRightFromSquare } from "@fortawesome/free-solid-svg-icons"
-import { getLinkType } from "@ourworldindata/components"
-
-import { isExternalUrl, useLinkedChart, useLinkedDocument } from "../utils.js"
+import { HybridLinkList } from "./HybridLinkList.js"
+import { useLinkedChart, useLinkedDocument } from "../utils.js"
+import { useContext } from "react"
 import { DocumentContext } from "../DocumentContext.js"
 import { BlockErrorFallback } from "./BlockErrorBoundary.js"
-import { ContentGraphLinkType } from "@ourworldindata/types"
-import { Thumbnail } from "./Thumbnail.js"
 
 export const ProminentLink = (props: {
     url: string
@@ -17,12 +12,9 @@ export const ProminentLink = (props: {
     description?: string
     thumbnail?: string
 }) => {
-    const linkType = getLinkType(props.url)
-    const { linkedDocument, errorMessage: linkedDocumentErrorMessage } =
-        useLinkedDocument(props.url)
-    const { linkedChart, errorMessage: linkedChartErrorMessage } =
-        useLinkedChart(props.url)
-    const errorMessage = linkedDocumentErrorMessage || linkedChartErrorMessage
+    const { errorMessage: documentErrorMessage } = useLinkedDocument(props.url)
+    const { errorMessage: linkedChartErrorMessage } = useLinkedChart(props.url)
+    const errorMessage = documentErrorMessage || linkedChartErrorMessage
     const { isPreviewing } = useContext(DocumentContext)
 
     if (errorMessage) {
@@ -41,69 +33,20 @@ export const ProminentLink = (props: {
         } else return null
     }
 
-    // If the link points to a gdoc_post or chart, we can use its metadata
-    // But we still allow for overrides written in archie
-    let href: string = props.url
-    let title: string | undefined = props.title
-    let description: string | undefined = props.description
-    let thumbnail: string | undefined = props.thumbnail
-    if (linkedDocument) {
-        href = linkedDocument.url
-        title ??= linkedDocument.title
-        description ??= linkedDocument.excerpt
-        thumbnail ??= linkedDocument["featured-image"]
-    } else if (linkType === ContentGraphLinkType.Grapher) {
-        href = `${linkedChart?.resolvedUrl}`
-        title ??= linkedChart?.title
-        thumbnail ??= linkedChart?.thumbnail
-        description ??= "See the data in our interactive visualization"
-    } else if (linkType === ContentGraphLinkType.Explorer) {
-        href = `${linkedChart?.resolvedUrl}`
-        title ??= `${linkedChart?.title} Data Explorer`
-        thumbnail ??= linkedChart?.thumbnail
-        description ??= linkedChart?.subtitle
-    }
-
-    const textContainerClassName = thumbnail
-        ? "col-sm-start-4 col-md-start-3 col-start-2 col-end-limit"
-        : "col-start-1 col-end-limit"
-
-    const shouldVerticallyCenter = !description
-    const isExternal = isExternalUrl(linkType, href)
-
     return (
-        <a className={cx(props.className, "prominent-link")} href={href}>
-            {thumbnail ? (
-                <div
-                    className={cx(
-                        "span-sm-cols-3 span-md-cols-2 prominent-link__image",
-                        {
-                            "prominent-link__image--centered":
-                                shouldVerticallyCenter,
-                        }
-                    )}
-                >
-                    <Thumbnail thumbnail={thumbnail} />
-                </div>
-            ) : null}
-            <div
-                className={cx(textContainerClassName, {
-                    "prominent-link__text--centered": shouldVerticallyCenter,
-                })}
-            >
-                <div className="prominent-link__heading-wrapper">
-                    <h3 className="h3-bold">{title}</h3>
-                    {isExternal && (
-                        <FontAwesomeIcon
-                            className="prominent-link__icon-external"
-                            icon={faArrowUpRightFromSquare}
-                        />
-                    )}
-                </div>
-                {description ? (
-                    <p className="body-3-medium">{description}</p>
-                ) : null}
-            </div>
-        </a>
+        <div className={cx("prominent-link", props.className)}>
+            <HybridLinkList
+                links={[
+                    // Map the prominent link props to a single hybrid link
+                    {
+                        url: props.url,
+                        title: props.title,
+                        subtitle: props.description,
+                        thumbnail: props.thumbnail,
+                        type: "hybrid-link",
+                    },
+                ]}
+            />
+        </div>
     )
 }

--- a/site/gdocs/components/centered-article.scss
+++ b/site/gdocs/components/centered-article.scss
@@ -1093,64 +1093,6 @@ div.raw-html-table__container {
     }
 }
 
-.article-block__prominent-link {
-    margin-bottom: 8px;
-    color: $blue-90;
-    background-color: $gray-5;
-    padding: 16px;
-
-    > .prominent-link__image {
-        height: 100%;
-        width: 100%;
-        margin-top: 4px;
-    }
-
-    .prominent-link__image--centered,
-    .prominent-link__text--centered {
-        display: flex;
-        flex-direction: column;
-        justify-content: center;
-    }
-
-    .prominent-link__heading-wrapper {
-        display: flex;
-        justify-content: space-between;
-        gap: 8px;
-    }
-
-    .prominent-link__icon-external {
-        color: $blue-60;
-        margin-top: 4px;
-    }
-
-    &:hover .prominent-link__icon-external {
-        color: $blue-90;
-    }
-
-    p {
-        margin: 0;
-        @include sm-only {
-            overflow: hidden;
-            display: -webkit-box;
-            -webkit-box-orient: vertical;
-            -webkit-line-clamp: 3;
-        }
-    }
-
-    h3 {
-        display: inline-block;
-        margin: 0 0 4px 0;
-        &:hover {
-            text-decoration: underline;
-        }
-    }
-
-    // Last consecutive sibling.
-    &:has(+ :not(.article-block__prominent-link)) {
-        margin-bottom: 32px;
-    }
-}
-
 .article-block__text + .article-block__prominent-link {
     margin-top: 16px; // makes 32px gap with the default 16px bottom margin of text blocks, for symmetry with bottom margin 👆
     @include sm-only {

--- a/site/gdocs/components/topic-page.scss
+++ b/site/gdocs/components/topic-page.scss
@@ -158,7 +158,7 @@
             }
         }
 
-        ul {
+        .article-block__list {
             margin-bottom: 32px;
             li {
                 @include body-2-regular;

--- a/site/owid.scss
+++ b/site/owid.scss
@@ -133,6 +133,7 @@
 @import "./gdocs/components/DataInsightsNewsletter.scss";
 @import "./gdocs/components/Donors.scss";
 @import "./gdocs/components/GuidedChart.scss";
+@import "./gdocs/components/ProminentLink.scss";
 @import "./gdocs/components/Image.scss";
 @import "./gdocs/components/StaticVizDownload.scss";
 @import "./gdocs/components/LatestDataInsights.scss";


### PR DESCRIPTION
## Context

Resolves https://github.com/owid/owid-grapher/issues/5836

## Screenshots / Videos / Diagrams

<img width="518" height="674" alt="image" src="https://github.com/user-attachments/assets/df6c475f-ad4d-45c0-ab9f-f4d7042373dc" />


## Testing guidance
I looked at all these posts that have prominent links in them and made sure they rendered with the correct data.

```
covid-mobility-trends
stunting-definition
covid-deaths-by-vaccination
instagram-in-spanish
the-future-is-vast
crop-yields-climate-impact
micronutrient-deficiency
much-better-awful-can-be-better
human-development-index
billions-of-chickens-ducks-and-pigs-are-slaughtered-for-meat-every-year
human-rights
```