### PR TITLE
feat: sync local query when global state changes

### DIFF
--- a/site/search/Search.tsx
+++ b/site/search/Search.tsx
@@ -16,7 +16,7 @@ import {
     getEffectiveResultType,
 } from "./searchUtils.js"
 import { useTagGraphTopics, useSearchAnalytics } from "./searchHooks.js"
-import { useSearchParamsState } from "./searchState.js"
+import { stateToSearchParams, useSearchParamsState } from "./searchState.js"
 
 // Components
 import { Searchbar } from "./Searchbar.js"
@@ -98,7 +98,19 @@ export const Search = ({
             }}
         >
             <div className="search-controls-container span-cols-12 col-start-2">
-                <Searchbar key={state.query} allTopics={eligibleTopics} />
+                <Searchbar
+                    // force a component re-mount to sync local query state when
+                    // global state updates. This is relevant in two cases:
+                    // - a new global query is set (e.g. via autocomplete
+                    //   selection)
+                    // - filters are added/removed while an uncommitted local
+                    //   query exists (e.g. selecting a country from the country
+                    //   selector). In this case, we want to reset the local
+                    //   query to match the global one, discarding any
+                    //   uncommitted changes.
+                    key={stateToSearchParams(state).toString()}
+                    allTopics={eligibleTopics}
+                />
                 <SearchDetectedFilters
                     eligibleRegionNames={eligibleRegionNames}
                 />

--- a/site/search/Searchbar.tsx
+++ b/site/search/Searchbar.tsx
@@ -29,8 +29,9 @@ export const Searchbar = ({ allTopics }: { allTopics: string[] }) => {
 
     const selectedRegionNames = useSelectedRegionNames(true)
     // Storing this in local state so that query params don't update during
-    // typing. Whenever the global query changes, we update the local query by
-    // triggering a re-render (see key prop on Searchbar in parent component).
+    // typing. Whenever the state semantically changes, we update the local
+    // query by triggering a re-mount (see key prop on Searchbar in parent
+    // component).
     const [localQuery, setLocalQuery] = useState(query)
 
     const inputRef = useRef<HTMLInputElement>(null)


### PR DESCRIPTION
fixes #5413 (or a variation of it, now that automatic filters don't allow for "poverty germany" to remain as a raw query - but the underlying problem of submitting a search while preserving an uncommitted query in the search bar remains and I decided to resolve the discrepancy by not committing the local query in this case, which feels more expected than the alternative)  

follow up to https://github.com/owid/owid-grapher/pull/5801#discussion_r2619629415

## Context

This PR fixes an issue with the search component where a _uncommitted_ local query in the Searchbar component is not properly reset to the global query when filters are added or removed outside of the autocomplete component (e.g. through the country selector or the "filter by" topic links).

## Testing guidance

1. Visit http://staging-site-search-sync-local-query/search?q=co2
2. Type "emissions" next to "co2" but don't press Enter (don't delete all characters either, as this updates the global query)
3. While the new text is in the search bar, select a country using the country selector
4. Verify that the search bar text resets to match the global query state (should be "co2")

- [x]  test added to the test suite