### PR TITLE
✨ ChartsAPI: add timestamps to API

### DIFF
--- a/functions/api/search/searchApi.ts
+++ b/functions/api/search/searchApi.ts
@@ -85,6 +85,8 @@ const DATA_CATALOG_ATTRIBUTES = [
     "availableEntities",
     "originalAvailableEntities",
     "availableTabs",
+    "publishedAt",
+    "updatedAt",
 ]
 
 function getFilterNamesOfType(
@@ -300,6 +302,7 @@ const PAGE_ATTRIBUTES = [
     "type",
     "content",
     "authors",
+    "modifiedDate",
 ]
 
 export async function searchPages(


### PR DESCRIPTION
## Add Timestamp Fields to Site Search API

### Summary

Adds `publishedAt` and `updatedAt` timestamp fields to the site search API responses for both charts and pages. These fields enable content versioning and tracking when search results were last modified.

### Changes

**Chart Search (`/api/search?type=charts`):**
- ✨ Added `publishedAt` - ISO 8601 timestamp of original publication
- ✨ Added `updatedAt` - ISO 8601 timestamp of last modification

**Page Search (`/api/search?type=pages`):**
- ✨ Added `modifiedDate` - ISO 8601 timestamp of last modification
- ✅ Kept existing `date` field (publishedAt) for backward compatibility

### Motivation

This change supports better content versioning and tracking across OWID systems. 

API consumers can now better choose the result they are interested in. Related to owid/etl#5373

### Technical Details

- All timestamp fields were already indexed in Algolia - this PR simply exposes them via the API
- TypeScript types automatically pick up new fields via `Pick<>` utility types
- No database or indexing changes required
- Zero performance impact (fields already retrieved from Algolia)

### Example Responses

**Before:**
```json
{
  "title": "COVID-19 deaths",
  "slug": "covid-deaths"
  ...
}
```

**After (Charts):**
```json
{
  "title": "COVID-19 deaths",
  "slug": "covid-deaths",
  ...
  "publishedAt": "2020-03-15T10:30:00.000Z",
  "updatedAt": "2024-12-01T14:45:00.000Z"
}
```

**After (Pages):**
```json
{
  "title": "Coronavirus Pandemic",
  "slug": "coronavirus",
  ...
  "date": "2020-03-15T10:30:00.000Z",
  "modifiedDate": "2024-12-01T14:45:00.000Z"
}
```

### Backward Compatibility

✅ **Fully backward compatible** - only adds new fields, doesn't modify or remove existing ones

### Testing

- ✅ TypeScript compilation passes (`yarn typecheck`)
- 📝 Tested on staging server: `staging-site-latest-edit-sitesearch-api`

**Test commands for staging:**
```bash
# Charts - verify publishedAt and updatedAt are present
curl "http://staging-site-latest-edit-sitesearch-api/api/search?q=covid" | jq '.results[0] | {title, publishedAt, updatedAt}'

# Pages - verify modifiedDate is present
curl "http://staging-site-latest-edit-sitesearch-api/api/search?q=covid&type=pages" | jq '.results[0] | {title, date, modifiedDate}'
```

### Related

- owid/etl#5373 - Catalog API versioning improvements
