### PR TITLE
🐛 fix single-time line charts in search

### DIFF
--- a/db/migration/1767611505051-FixSingleTimeLineCharts.ts
+++ b/db/migration/1767611505051-FixSingleTimeLineCharts.ts
@@ -1,0 +1,31 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class FixSingleTimeLineCharts1767611505051
+    implements MigrationInterface
+{
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`-- sql
+            UPDATE chart_configs cc
+            SET
+                full = JSON_REMOVE(full, '$.minTime'),
+                patch = JSON_REMOVE(patch, '$.minTime')
+            WHERE
+                -- Only update charts that have both a line chart and a map
+                (
+                    cc.full ->> '$.chartTypes' is null
+                    OR (
+                        JSON_SEARCH(cc.full -> '$.chartTypes', 'one', 'LineChart') IS NOT NULL
+                        AND cc.full ->> '$.hasMapTab' = 'true'
+                    )
+                )
+                -- Only update charts where the default view is a map
+                AND cc.full ->> '$.tab' = 'map'
+                -- Only update charts with identical minTime and maxTime
+                AND COALESCE(cc.full ->> '$.minTime', 'earliest') = COALESCE(cc.full ->> '$.maxTime', 'latest')
+     `)
+    }
+
+    public async down(): Promise<void> {
+        // The migration is irreversible
+    }
+}


### PR DESCRIPTION
For map charts that have the same minTime and maxTime, linking to the line chart currently shows a line chart with a single time point: https://ourworldindata.org/grapher/human-development-index?tab=line

Setting the same minTime and maxTime doesn’t have an effect if the default view is the map. (It used to be sensible when we didn’t have tabs because then clicking on the ‘Chart’ tab would default to the bar chart)

Since setting both minTime and maxTime doesn’t make sense in these cases, I opted for a data migration rather than a code fix. If this comes up in the future, we could consider a code fix as well.