### PR TITLE
Fix height of data insight image on /latest

### DIFF
--- a/site/LatestPage.scss
+++ b/site/LatestPage.scss
@@ -95,12 +95,26 @@
 }
 
 .latest-page__data-insight-image {
-    // Magic number from Figma
-    flex: 0 0 214px;
+    height: 214px;
+
+    picture {
+        display: flex;
+        height: 100%;
+    }
+
+    img {
+        height: 100%;
+        width: auto;
+        max-width: initial;
+    }
+
     @include sm-only {
+        height: auto;
         margin-bottom: 16px;
-        picture {
-            display: flex;
+
+        img {
+            height: auto;
+            max-width: 100%;
         }
     }
 }


### PR DESCRIPTION
Cap the image height so it doesn't stretch the whole card when it's tall and narrow. It should behave similarly to the latest data image card on homepage.

[Slack](https://owid.slack.com/archives/C46U9LXRR/p1767689802131799)

