### PR TITLE
Remove onClick analytics from search

### DIFF
--- a/packages/@ourworldindata/types/src/domainTypes/Search.ts
+++ b/packages/@ourworldindata/types/src/domainTypes/Search.ts
@@ -147,9 +147,6 @@ export type SearchChartHit =
 export interface SearchChartHitComponentProps {
     hit: SearchChartHit
     selectedRegionNames?: string[] | undefined
-    // Search uses a global onClick handler to track analytics
-    // But the data catalog passes a function to this component explicitly
-    onClick: (vizType: string | null) => void
 }
 
 export type SearchChartHitComponentVariant = "large" | "medium" | "small"

--- a/site/FeaturedDataInsights.tsx
+++ b/site/FeaturedDataInsights.tsx
@@ -84,7 +84,6 @@ export const FeaturedDataInsights = ({
                                 key={hit.objectID}
                                 className="article-block__featured-data-insights__hit"
                                 hit={hit}
-                                onClick={() => undefined}
                             />
                         ))}
                     </div>

--- a/site/FeaturedMetrics.tsx
+++ b/site/FeaturedMetrics.tsx
@@ -89,7 +89,6 @@ export const FeaturedMetrics = ({
                                         hit={hit}
                                         variant={variant}
                                         selectedRegionNames={[]}
-                                        onClick={() => undefined}
                                     />
                                 </li>
                             )

--- a/site/search/SearchChartHitCaptionedLink.tsx
+++ b/site/search/SearchChartHitCaptionedLink.tsx
@@ -3,13 +3,11 @@ import cx from "classnames"
 export function CaptionedLink({
     url,
     className,
-    onClick,
     children,
     caption,
 }: {
     url: string
     className?: string
-    onClick?: () => void
     children: React.ReactNode
     caption: React.ReactNode
 }): React.ReactElement {
@@ -17,7 +15,6 @@ export function CaptionedLink({
         <a
             href={url}
             className={cx("search-chart-hit-captioned-link", className)}
-            onClick={onClick}
         >
             {children}
             <div className="search-chart-hit-captioned-link__label">

--- a/site/search/SearchChartHitCaptionedTable.tsx
+++ b/site/search/SearchChartHitCaptionedTable.tsx
@@ -17,7 +17,6 @@ export function CaptionedTable({
     entityType,
     entityTypePlural,
     className,
-    onClick,
 }: {
     chartUrl: string
     dataTableContent?: SearchChartHitDataTableProps
@@ -26,7 +25,6 @@ export function CaptionedTable({
     entityType: string
     entityTypePlural: string
     className?: string
-    onClick?: () => void
 }): React.ReactElement | null {
     if (!dataTableContent) return null
 
@@ -47,7 +45,6 @@ export function CaptionedTable({
             caption={captionWithIcon}
             url={chartUrl}
             className={className}
-            onClick={onClick}
         >
             <div className="search-chart-hit-table-wrapper">
                 <div className="search-chart-hit-table-wrapper-content">

--- a/site/search/SearchChartHitCaptionedThumbnail.tsx
+++ b/site/search/SearchChartHitCaptionedThumbnail.tsx
@@ -12,7 +12,6 @@ export function CaptionedThumbnail({
     imageWidth,
     imageHeight,
     className,
-    onClick,
 }: {
     chartType: GrapherTabName
     chartUrl: string
@@ -21,7 +20,6 @@ export function CaptionedThumbnail({
     imageWidth?: number
     imageHeight?: number
     className?: string
-    onClick?: () => void
 }): React.ReactElement {
     const caption = makeLabelForGrapherTab(chartType, { format: "long" })
     const hoverOverlayText = isSmallSlot ? "Explore" : "Click to explore"
@@ -38,7 +36,6 @@ export function CaptionedThumbnail({
             caption={captionWithIcon}
             url={chartUrl}
             className={className}
-            onClick={onClick}
         >
             <SearchChartHitThumbnail
                 previewUrl={previewUrl}

--- a/site/search/SearchChartHitHeader.tsx
+++ b/site/search/SearchChartHitHeader.tsx
@@ -10,7 +10,6 @@ interface SearchChartHitHeaderProps {
     url: string
     source?: string
     isLarge?: boolean
-    onClick: (vizType: null) => void
 }
 
 export function SearchChartHitHeader({
@@ -20,7 +19,6 @@ export function SearchChartHitHeader({
     url,
     source,
     isLarge = false,
-    onClick,
 }: SearchChartHitHeaderProps) {
     return (
         <a
@@ -28,7 +26,6 @@ export function SearchChartHitHeader({
                 "search-chart-hit-header--large": isLarge,
             })}
             href={url}
-            onClick={() => onClick(null)}
             data-algolia-index={getIndexName(
                 SearchIndexName.ExplorerViewsMdimViewsAndCharts
             )}

--- a/site/search/SearchChartHitRichData.tsx
+++ b/site/search/SearchChartHitRichData.tsx
@@ -61,7 +61,6 @@ const SCATTER_NUM_DATA_TABLE_ROWS_PER_COLUMN_IN_MEDIUM_VARIANT = 6
 export function SearchChartHitRichData({
     hit,
     selectedRegionNames,
-    onClick,
     variant,
 }: SearchChartHitComponentProps & {
     variant: RichDataComponentVariant
@@ -113,7 +112,6 @@ export function SearchChartHitRichData({
             <SearchChartHitRichDataFallback
                 hit={hit}
                 selectedRegionNames={selectedRegionNames}
-                onClick={onClick}
             />
         )
     }
@@ -131,7 +129,6 @@ export function SearchChartHitRichData({
                         hit={hit}
                         url={chartUrl}
                         isLarge={isLargeVariant}
-                        onClick={onClick}
                     />
                     <SearchChartHitHeaderActionButtons
                         isLarge={isLargeVariant}
@@ -174,7 +171,6 @@ export function SearchChartHitRichData({
                     url={chartUrl}
                     source={data.source}
                     isLarge={isLargeVariant}
-                    onClick={onClick}
                 />
                 <SearchChartHitHeaderActionButtons
                     isLarge={isLargeVariant}
@@ -231,7 +227,6 @@ export function SearchChartHitRichData({
                                 entityType={data.entityType}
                                 entityTypePlural={data.entityTypePlural}
                                 className={className}
-                                onClick={() => onClick(grapherTab)}
                             />
                         ) : (
                             <CaptionedThumbnail
@@ -243,7 +238,6 @@ export function SearchChartHitRichData({
                                 imageWidth={imageWidth}
                                 imageHeight={imageHeight}
                                 className={className}
-                                onClick={() => onClick(grapherTab)}
                             />
                         )
                     }

--- a/site/search/SearchChartHitRichDataFallback.tsx
+++ b/site/search/SearchChartHitRichDataFallback.tsx
@@ -31,7 +31,6 @@ import {
 export function SearchChartHitRichDataFallback({
     hit,
     selectedRegionNames,
-    onClick,
 }: SearchChartHitComponentProps) {
     const hasScatter = hit.availableTabs.includes(GRAPHER_TAB_NAMES.ScatterPlot)
 
@@ -93,7 +92,6 @@ export function SearchChartHitRichDataFallback({
                     hit={hit}
                     url={chartUrl}
                     source={chartInfo?.source}
-                    onClick={onClick}
                 />
                 <div className="search-chart-hit-rich-data__header-actions">
                     <Button
@@ -140,7 +138,6 @@ export function SearchChartHitRichDataFallback({
                             chartUrl={chartUrl}
                             previewUrl={previewUrl}
                             className={className}
-                            onClick={() => onClick(grapherTab)}
                         />
                     )
                 })}

--- a/site/search/SearchChartHitSmall.tsx
+++ b/site/search/SearchChartHitSmall.tsx
@@ -28,7 +28,6 @@ import { SMALL_BREAKPOINT_MEDIA_QUERY } from "../SiteConstants.js"
 export function SearchChartHitSmall({
     hit,
     selectedRegionNames,
-    onClick,
 }: SearchChartHitComponentProps) {
     const isSmallScreen = useMediaQuery(SMALL_BREAKPOINT_MEDIA_QUERY)
 
@@ -83,7 +82,6 @@ export function SearchChartHitSmall({
                     hit={hit}
                     url={chartUrl}
                     source={chartInfo?.source}
-                    onClick={onClick}
                 />
                 <div className="search-chart-hit-small__tabs-container">
                     {hit.availableTabs.map((tab) => {
@@ -105,11 +103,7 @@ export function SearchChartHitSmall({
                                 theme="dark"
                                 disabled={isSmallScreen}
                             >
-                                <a
-                                    href={chartUrl}
-                                    onClick={() => onClick(tab)}
-                                    aria-label={label}
-                                >
+                                <a href={chartUrl} aria-label={label}>
                                     <GrapherTabIcon tab={tab} />
                                 </a>
                             </Tippy>

--- a/site/search/SearchDataInsightHit.tsx
+++ b/site/search/SearchDataInsightHit.tsx
@@ -6,11 +6,9 @@ import { OwidGdocType, DataInsightHit } from "@ourworldindata/types"
 export const SearchDataInsightHit = ({
     hit,
     className,
-    onClick,
 }: {
     hit: DataInsightHit
     className?: string
-    onClick: VoidFunction
 }) => {
     const href = getCanonicalUrl("", {
         slug: hit.slug,
@@ -18,11 +16,7 @@ export const SearchDataInsightHit = ({
     })
 
     return (
-        <a
-            className={cx("search-data-insight-hit", className)}
-            href={href}
-            onClick={onClick}
-        >
+        <a className={cx("search-data-insight-hit", className)} href={href}>
             <article>
                 {hit.thumbnailUrl && (
                     <div className="search-data-insight-hit__image-container">

--- a/site/search/SearchDataInsightsResults.tsx
+++ b/site/search/SearchDataInsightsResults.tsx
@@ -12,10 +12,8 @@ import { SearchResultHeader } from "./SearchResultHeader.js"
 import { useInfiniteSearch } from "./searchHooks.js"
 import { SearchDataInsightsResultsSkeleton } from "./SearchDataInsightsResultsSkeleton.js"
 import { SearchHorizontalDivider } from "./SearchHorizontalDivider.js"
-import { useSearchContext } from "./SearchContext.js"
 
 export function SearchDataInsightsResults() {
-    const { analytics } = useSearchContext()
     const isSmallScreen = useMediaQuery(SMALL_BREAKPOINT_MEDIA_QUERY)
     const query = useInfiniteSearch<SearchDataInsightResponse, DataInsightHit>({
         queryKey: (state) => searchQueryKeys.dataInsights(state),
@@ -53,19 +51,10 @@ export function SearchDataInsightsResults() {
                             ref={container}
                             className="search-data-insights-results__hits"
                         >
-                            {hits.map((hit: DataInsightHit, index) => (
+                            {hits.map((hit: DataInsightHit) => (
                                 <SearchDataInsightHit
                                     key={hit.objectID}
                                     hit={hit}
-                                    onClick={() => {
-                                        analytics.logSiteSearchResultClick(
-                                            hit,
-                                            {
-                                                position: index + 1,
-                                                source: "search",
-                                            }
-                                        )
-                                    }}
                                 />
                             ))}
                             {query.hasNextPage && (

--- a/site/search/SearchDataResults.tsx
+++ b/site/search/SearchDataResults.tsx
@@ -9,14 +9,12 @@ import {
 import { SearchDataResultsSkeleton } from "./SearchDataResultsSkeleton.js"
 import { SearchChartHitComponent } from "./SearchChartHitComponent.js"
 import { SearchHorizontalDivider } from "./SearchHorizontalDivider.js"
-import { useSearchContext } from "./SearchContext.js"
 
 export const SearchDataResults = ({
     isFirstChartLarge,
 }: {
     isFirstChartLarge: boolean
 }) => {
-    const { analytics } = useSearchContext()
     const selectedRegionNames = useSelectedRegionNames()
 
     const query = useInfiniteSearch<SearchChartsResponse, SearchChartHit>({
@@ -51,14 +49,6 @@ export const SearchDataResults = ({
                                           ? "medium"
                                           : "small"
 
-                                const onClick = (vizType: string | null) => {
-                                    analytics.logSiteSearchResultClick(hit, {
-                                        position: hitIndex + 1,
-                                        source: "search",
-                                        vizType,
-                                    })
-                                }
-
                                 return (
                                     <li
                                         className="search-data-results__hit"
@@ -70,7 +60,6 @@ export const SearchDataResults = ({
                                             selectedRegionNames={
                                                 selectedRegionNames
                                             }
-                                            onClick={onClick}
                                         />
                                     </li>
                                 )

--- a/site/search/SearchDataTopic.tsx
+++ b/site/search/SearchDataTopic.tsx
@@ -14,7 +14,6 @@ export const SearchDataTopic = ({
 }) => {
     const {
         actions: { setTopic },
-        analytics,
     } = useSearchContext()
 
     const selectedRegionNames = useSelectedRegionNames()
@@ -56,14 +55,6 @@ export const SearchDataTopic = ({
                             <SearchChartHitComponent
                                 hit={hit}
                                 variant={hitIndex === 0 ? "medium" : "small"}
-                                onClick={(vizType?: string | null) => {
-                                    analytics.logSiteSearchResultClick(hit, {
-                                        position: hitIndex + 1,
-                                        source: "ribbon",
-                                        ribbonTag: title,
-                                        vizType,
-                                    })
-                                }}
                                 selectedRegionNames={selectedRegionNames}
                             />
                         </li>

--- a/site/search/SearchFlatArticleHit.tsx
+++ b/site/search/SearchFlatArticleHit.tsx
@@ -7,11 +7,9 @@ import { formatAuthors, formatDate } from "@ourworldindata/utils"
 export function SearchFlatArticleHit({
     className,
     hit,
-    onClick,
 }: {
     className?: string
     hit: FlatArticleHit
-    onClick: VoidFunction
 }) {
     const isArticle = hit.type === OwidGdocType.Article
 
@@ -19,7 +17,6 @@ export function SearchFlatArticleHit({
         <a
             className={cx("search-flat-article-hit", className)}
             href={getCanonicalPath(hit.slug, hit.type)}
-            onClick={onClick}
         >
             <article className="search-flat-article-hit__content">
                 {hit.thumbnailUrl && (

--- a/site/search/SearchStackedArticleHit.tsx
+++ b/site/search/SearchStackedArticleHit.tsx
@@ -2,18 +2,11 @@ import { getCanonicalPath } from "@ourworldindata/components"
 import { Snippet } from "react-instantsearch"
 import { StackedArticleHit } from "@ourworldindata/types"
 
-export function SearchStackedArticleHit({
-    hit,
-    onClick,
-}: {
-    hit: StackedArticleHit
-    onClick: VoidFunction
-}) {
+export function SearchStackedArticleHit({ hit }: { hit: StackedArticleHit }) {
     return (
         <a
             className="search-stacked-article-hit"
             href={getCanonicalPath(hit.slug, hit.type)}
-            onClick={onClick}
         >
             <article>
                 {hit.thumbnailUrl && (

--- a/site/search/SearchTopicPageHit.tsx
+++ b/site/search/SearchTopicPageHit.tsx
@@ -33,17 +33,14 @@ export const SearchTopicPageHit = ({
     className,
     hit,
     variant = "small",
-    onClick,
 }: {
     className?: string
     hit: TopicPageHit
     variant?: "small" | "large"
-    onClick: VoidFunction
 }) => (
     <a
         className={cx("search-topic-page-hit", className)}
         href={getCanonicalPath(hit.slug, hit.type)}
-        onClick={onClick}
     >
         <div className="search-topic-page-hit__tag">Topic page</div>
         <h3 className="search-topic-page-hit__title">

--- a/site/search/SearchWritingResults.tsx
+++ b/site/search/SearchWritingResults.tsx
@@ -16,7 +16,6 @@ import { SearchFlatArticleHit } from "./SearchFlatArticleHit.js"
 import { SearchTopicPageHit } from "./SearchTopicPageHit.js"
 import { SearchWritingResultsSkeleton } from "./SearchWritingResultsSkeleton.js"
 import { SearchHorizontalDivider } from "./SearchHorizontalDivider.js"
-import { useSearchContext } from "./SearchContext.js"
 
 function SingleColumnResults({
     articlePages,
@@ -27,8 +26,6 @@ function SingleColumnResults({
     topicPages: SearchTopicPageResponse[]
     hasLargeTopic: boolean
 }) {
-    const { analytics } = useSearchContext()
-
     const allHits = _.zip(articlePages, topicPages).flatMap(
         ([articlePage, topicPage]) => [
             ...(articlePage?.hits || []),
@@ -37,7 +34,7 @@ function SingleColumnResults({
     )
     return (
         <div className="search-writing-results__single-column">
-            {allHits.map((hit, index) => {
+            {allHits.map((hit) => {
                 if (
                     hit.type === OwidGdocType.TopicPage ||
                     hit.type === OwidGdocType.LinearTopicPage
@@ -47,12 +44,6 @@ function SingleColumnResults({
                             key={hit.objectID}
                             hit={hit}
                             variant={hasLargeTopic ? "large" : undefined}
-                            onClick={() => {
-                                analytics.logSiteSearchResultClick(hit, {
-                                    position: index + 1,
-                                    source: "search",
-                                })
-                            }}
                         />
                     )
                 } else {
@@ -60,12 +51,6 @@ function SingleColumnResults({
                         <SearchFlatArticleHit
                             key={hit.objectID}
                             hit={hit as FlatArticleHit}
-                            onClick={() => {
-                                analytics.logSiteSearchResultClick(hit, {
-                                    position: index + 1,
-                                    source: "search",
-                                })
-                            }}
                         />
                     )
                 }
@@ -83,7 +68,6 @@ function MultiColumnResults({
     topics: TopicPageHit[]
     hasLargeTopic: boolean
 }) {
-    const { analytics } = useSearchContext()
     // Calculate interleaved layout: 4 topics for every 5 articles (ratio
     // maintained proportionally).
     const interleavedTopicsCount = Math.round((articles.length * 4) / 5)
@@ -93,51 +77,29 @@ function MultiColumnResults({
         <div className="search-writing-results__grid">
             {articles.length > 0 && (
                 <div className="search-writing-results__articles">
-                    {articles.map((hit, index) => (
-                        <SearchFlatArticleHit
-                            key={hit.objectID}
-                            hit={hit}
-                            onClick={() => {
-                                analytics.logSiteSearchResultClick(hit, {
-                                    position: index + 1,
-                                    source: "search",
-                                })
-                            }}
-                        />
+                    {articles.map((hit) => (
+                        <SearchFlatArticleHit key={hit.objectID} hit={hit} />
                     ))}
                 </div>
             )}
             {interleavedTopics.length > 0 && (
                 <div className="search-writing-results__topics">
-                    {interleavedTopics.map((hit, index) => (
+                    {interleavedTopics.map((hit) => (
                         <SearchTopicPageHit
                             key={hit.objectID}
                             hit={hit}
                             variant={hasLargeTopic ? "large" : undefined}
-                            onClick={() => {
-                                analytics.logSiteSearchResultClick(hit, {
-                                    position: index + 1,
-                                    source: "search",
-                                })
-                            }}
                         />
                     ))}
                 </div>
             )}
             {remainingTopics.length > 0 && (
                 <div className="search-writing-results__overflow">
-                    {remainingTopics.map((hit, index) => (
+                    {remainingTopics.map((hit) => (
                         <SearchTopicPageHit
                             key={hit.objectID}
                             hit={hit}
                             variant={hasLargeTopic ? "large" : undefined}
-                            onClick={() => {
-                                analytics.logSiteSearchResultClick(hit, {
-                                    position:
-                                        interleavedTopics.length + index + 1,
-                                    source: "search",
-                                })
-                            }}
                         />
                     ))}
                 </div>

--- a/site/search/SearchWritingTopic.tsx
+++ b/site/search/SearchWritingTopic.tsx
@@ -13,7 +13,6 @@ export const SearchWritingTopic = ({
 }) => {
     const {
         actions: { setTopic },
-        analytics,
     } = useSearchContext()
 
     if (result.totalCount === 0) return null
@@ -50,20 +49,10 @@ export const SearchWritingTopic = ({
                             Featured articles
                         </h3>
                         <div className="search-writing-featured-articles__list">
-                            {result.articles.hits.map((hit, index) => (
+                            {result.articles.hits.map((hit) => (
                                 <SearchStackedArticleHit
                                     key={hit.objectID}
                                     hit={hit}
-                                    onClick={() => {
-                                        analytics.logSiteSearchResultClick(
-                                            hit,
-                                            {
-                                                position: index + 1,
-                                                source: "ribbon",
-                                                ribbonTag: result.title,
-                                            }
-                                        )
-                                    }}
                                 />
                             ))}
                         </div>
@@ -76,7 +65,7 @@ export const SearchWritingTopic = ({
                             Featured topic pages
                         </h3>
                         <ul className="search-writing-featured-topics__list">
-                            {result.topicPages.hits.map((hit, index) => (
+                            {result.topicPages.hits.map((hit) => (
                                 <li
                                     key={hit.objectID}
                                     className="search-writing-featured-topics__list-item"
@@ -87,16 +76,6 @@ export const SearchWritingTopic = ({
                                             hit.slug,
                                             hit.type
                                         )}
-                                        onClick={() => {
-                                            analytics.logSiteSearchResultClick(
-                                                hit,
-                                                {
-                                                    position: index + 1,
-                                                    source: "ribbon",
-                                                    ribbonTag: result.title,
-                                                }
-                                            )
-                                        }}
                                     >
                                         {hit.title}
                                         <FontAwesomeIcon


### PR DESCRIPTION
## Context

Links to issues, Figma, Slack, and a technical introduction to the work.

## Screenshots / Videos / Diagrams

Add if relevant, i.e. might not be necessary when there are no UI changes.

## Testing guidance

Step-by-step instructions on how to test this change

- [ ] Does the change work in the archive?
- [ ] Does the staging experience have sign-off from product stakeholders?

**Reminder to annotate the PR diff with design notes, alternatives you considered, and any other helpful context.**

## Checklist

(delete all that do not apply)

### Before merging

- [ ] Google Analytics events were adapted to fit the changes in this PR
- [ ] Changes to CSS/HTML were checked on Desktop and Mobile Safari at all three breakpoints
- [ ] Changes to HTML were checked for accessibility concerns

If DB migrations exists:

- [ ] If columns have been added/deleted, all necessary views were recreated
- [ ] The DB type definitions have been updated
- [ ] The DB types in the ETL have been updated
- [ ] If tables/views were added/removed, the Datasette export has been updated to take this into account
- [ ] Update the documentation in db/docs

### After merging

- [ ] If a table was touched that is synced to R2, the sync script to update R2 has been run
