### PR TITLE
✨ add `searchableInAlgolia` to our tags table

### DIFF
--- a/adminSiteClient/TagEditPage.tsx
+++ b/adminSiteClient/TagEditPage.tsx
@@ -4,7 +4,7 @@ import { observable, computed, runInAction, makeObservable } from "mobx"
 import { Prompt, Redirect } from "react-router-dom"
 import { DbChartTagJoin } from "@ourworldindata/utils"
 import { AdminLayout } from "./AdminLayout.js"
-import { BindString, Timeago } from "./Forms.js"
+import { BindString, Timeago, Toggle } from "./Forms.js"
 import { DatasetList, DatasetListItem } from "./DatasetList.js"
 import { ChartList, ChartListItem } from "./ChartList.js"
 import { TagBadge } from "./TagBadge.js"
@@ -19,16 +19,19 @@ interface TagPageData {
     charts: ChartListItem[]
     children: DbChartTagJoin[]
     slug: string | null
+    searchableInAlgolia: boolean
 }
 
 class TagEditable {
     name: string = ""
     slug: string | null = null
+    searchableInAlgolia: boolean = false
 
     constructor(json: TagPageData) {
         makeObservable(this, {
             name: observable,
             slug: observable,
+            searchableInAlgolia: observable,
         })
         for (const key in this) {
             this[key] = (json as any)[key]
@@ -145,7 +148,22 @@ class TagEditor extends Component<{ tag: TagPageData }> {
                             label="Slug"
                             helpText="The slug for this tag's topic page, e.g. trade-and-globalization. If specified, we assume this tag is a topic. Must be unique"
                         />
-                        <div>
+                        <Toggle
+                            label="Searchable in Algolia"
+                            value={newtag.searchableInAlgolia || !!newtag.slug}
+                            onValue={(value) =>
+                                runInAction(
+                                    () => (newtag.searchableInAlgolia = value)
+                                )
+                            }
+                            disabled={!!newtag.slug}
+                            secondaryLabel={
+                                newtag.slug
+                                    ? "Tags with a slug are always searchable in Algolia"
+                                    : "When enabled, this tag will appear in search filters even without a topic page"
+                            }
+                        />
+                        <div style={{ marginTop: 16 }}>
                             <input
                                 type="submit"
                                 disabled={!this.isModified || !newtag.name}

--- a/adminSiteClient/TagGraphPage.tsx
+++ b/adminSiteClient/TagGraphPage.tsx
@@ -406,6 +406,7 @@ export class TagGraphPage extends React.Component {
             weight: 100,
             slug: tag.slug,
             isTopic: tag.isTopic,
+            isSearchable: tag.isSearchable,
         }
         if (siblings) {
             this.flatTagGraph[parentId] = insertChildAndSort(siblings, child)

--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -1036,6 +1036,14 @@ main:not(.ChartEditorPage):not(.GdocsEditPage) {
     }
 }
 
+.TagEditPage {
+    .form-check-label {
+        &:has(input:disabled) {
+            cursor: default;
+        }
+    }
+}
+
 .DeploysPage {
     .all-published-notice {
         font-size: 18px;

--- a/adminSiteServer/apiRoutes/tags.ts
+++ b/adminSiteServer/apiRoutes/tags.ts
@@ -33,12 +33,18 @@ export async function getTagById(
     const tag: any = await db.knexRawFirst<
         Pick<
             DbPlainTag,
-            "id" | "name" | "specialType" | "updatedAt" | "parentId" | "slug"
+            | "id"
+            | "name"
+            | "specialType"
+            | "updatedAt"
+            | "parentId"
+            | "slug"
+            | "searchableInAlgolia"
         >
     >(
         trx,
         `-- sql
-        SELECT t.id, t.name, t.specialType, t.updatedAt, t.parentId, t.slug
+        SELECT t.id, t.name, t.specialType, t.updatedAt, t.parentId, t.slug, t.searchableInAlgolia
         FROM tags t LEFT JOIN tags p ON t.parentId=p.id
         WHERE t.id = ?
     `,
@@ -172,8 +178,14 @@ export async function updateTag(
     const tag = (req.body as { tag: any }).tag
     await db.knexRaw(
         trx,
-        `UPDATE tags SET name=?, updatedAt=?, slug=? WHERE id=?`,
-        [tag.name, new Date(), tag.slug, tagId]
+        `UPDATE tags SET name=?, updatedAt=?, slug=?, searchableInAlgolia=? WHERE id=?`,
+        [
+            tag.name,
+            new Date(),
+            tag.slug,
+            tag.searchableInAlgolia ?? false,
+            tagId,
+        ]
     )
     if (tag.slug) {
         // See if there's a published gdoc with a matching slug.

--- a/adminSiteServer/tests/tags.test.ts
+++ b/adminSiteServer/tests/tags.test.ts
@@ -84,36 +84,42 @@ describe("Tag graph and breadcrumbs", { timeout: 15000 }, () => {
                     isTopic: 0,
                     name: "Climate & Air",
                     slug: null,
+                    isSearchable: 0,
                 },
                 {
                     id: 5,
                     isTopic: 1,
                     name: "CO2 & Greenhouse Gas Emissions",
                     slug: "co2-and-greenhouse-gas-emissions",
+                    isSearchable: 1,
                 },
                 {
                     id: 3,
                     isTopic: 1,
                     name: "Energy",
                     slug: "energy",
+                    isSearchable: 1,
                 },
                 {
                     id: 2,
                     isTopic: 0,
                     name: "Energy and Environment",
                     slug: null,
+                    isSearchable: 0,
                 },
                 {
                     id: 4,
                     isTopic: 1,
                     name: "Nuclear Energy",
                     slug: "nuclear-energy",
+                    isSearchable: 1,
                 },
                 {
                     id: 1,
                     isTopic: 0,
                     name: "tag-graph-root",
                     slug: null,
+                    isSearchable: 0,
                 },
             ],
         })
@@ -193,6 +199,7 @@ describe("Tag graph and breadcrumbs", { timeout: 15000 }, () => {
                     slug: null,
                     parentId: 1,
                     weight: 100,
+                    isSearchable: 0,
                 },
             ],
             "2": [
@@ -203,6 +210,7 @@ describe("Tag graph and breadcrumbs", { timeout: 15000 }, () => {
                     slug: "energy",
                     parentId: 2,
                     weight: 110,
+                    isSearchable: 1,
                 },
                 {
                     childId: 6,
@@ -211,6 +219,7 @@ describe("Tag graph and breadcrumbs", { timeout: 15000 }, () => {
                     slug: null,
                     parentId: 2,
                     weight: 100,
+                    isSearchable: 0,
                 },
             ],
             "3": [
@@ -221,6 +230,7 @@ describe("Tag graph and breadcrumbs", { timeout: 15000 }, () => {
                     slug: "nuclear-energy",
                     parentId: 3,
                     weight: 100,
+                    isSearchable: 1,
                 },
             ],
             "5": [
@@ -231,6 +241,7 @@ describe("Tag graph and breadcrumbs", { timeout: 15000 }, () => {
                     slug: "nuclear-energy",
                     parentId: 5,
                     weight: 100,
+                    isSearchable: 1,
                 },
             ],
             "6": [
@@ -241,6 +252,7 @@ describe("Tag graph and breadcrumbs", { timeout: 15000 }, () => {
                     parentId: 6,
                     slug: "co2-and-greenhouse-gas-emissions",
                     weight: 100,
+                    isSearchable: 1,
                 },
             ],
             __rootId: 1,

--- a/db/docs/tags.yml
+++ b/db/docs/tags.yml
@@ -32,6 +32,8 @@ fields:
         description: Timestamp when the tag was last updated
     parentId:
         description: Foreign key to tags table for parent tag (self-referential for hierarchy)
+    searchableInAlgolia:
+        description: When true, this tag is included in Algolia search filters even if it doesn't have an associated topic page. Used for non-topic tags like "Crime" that should still be searchable.
     specialType:
         description: Special type designation for the tag (e.g., 'unlisted' for hidden content)
     slug:

--- a/db/migration/1767820831537-AddSearchableInAlgoliaToTags.ts
+++ b/db/migration/1767820831537-AddSearchableInAlgoliaToTags.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class AddSearchableInAlgoliaToTags1767820831537
+    implements MigrationInterface
+{
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`-- sql
+            ALTER TABLE tags
+            ADD COLUMN searchableInAlgolia BOOLEAN NOT NULL DEFAULT FALSE
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`-- sql
+            ALTER TABLE tags
+            DROP COLUMN searchableInAlgolia
+        `)
+    }
+}

--- a/packages/@ourworldindata/types/src/dbTypes/Tags.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/Tags.ts
@@ -5,6 +5,7 @@ export interface DbInsertTag {
     id?: number
     parentId?: number | null
     name: string
+    searchableInAlgolia?: boolean
     slug?: string | null
     specialType?: string | null
     updatedAt?: Date | null
@@ -18,4 +19,5 @@ export type MinimalTag = Pick<DbPlainTag, "id" | "name" | "slug">
 // Used in the tag graph
 export type MinimalTagWithIsTopic = MinimalTag & {
     isTopic: boolean
+    isSearchable: boolean
 }

--- a/packages/@ourworldindata/types/src/domainTypes/ContentGraph.ts
+++ b/packages/@ourworldindata/types/src/domainTypes/ContentGraph.ts
@@ -29,6 +29,7 @@ export const TagGraphRootName = "tag-graph-root" as const
 export type FlatTagGraphNode = Pick<DbPlainTag, "name" | "slug"> & {
     weight: number
     isTopic: boolean
+    isSearchable: boolean
     parentId: number
     childId: number
     slug: string | null
@@ -40,6 +41,7 @@ export interface TagGraphNode {
     children: TagGraphNode[]
     id: number
     isTopic: boolean
+    isSearchable: boolean
     name: string
     path: number[]
     slug: string | null
@@ -50,6 +52,7 @@ export type TagGraphRoot = TagGraphNode & {
     children: TagGraphNode[]
     id: number
     isTopic: false
+    isSearchable: false
     name: typeof TagGraphRootName
     path: [number]
     slug: null

--- a/packages/@ourworldindata/utils/src/Util.test.ts
+++ b/packages/@ourworldindata/utils/src/Util.test.ts
@@ -847,6 +847,7 @@ describe(flattenNonTopicNodes, () => {
                                     children: [],
                                     id: 4,
                                     isTopic: true,
+                                    isSearchable: true,
                                     name: "Life Expectancy",
                                     path: [1, 2, 3, 4],
                                     slug: "life-expectancy",
@@ -855,6 +856,7 @@ describe(flattenNonTopicNodes, () => {
                             ],
                             id: 3,
                             isTopic: false,
+                            isSearchable: false,
                             name: "Life & Death",
                             path: [1, 2, 3],
                             slug: null,
@@ -863,6 +865,7 @@ describe(flattenNonTopicNodes, () => {
                     ],
                     id: 2,
                     isTopic: false,
+                    isSearchable: false,
                     name: "Health",
                     path: [1, 2],
                     slug: null,
@@ -871,6 +874,7 @@ describe(flattenNonTopicNodes, () => {
             ],
             id: 1,
             isTopic: false,
+            isSearchable: false,
             name: "tag-graph-root",
             path: [1],
             slug: null,
@@ -882,13 +886,14 @@ describe(flattenNonTopicNodes, () => {
         )
     })
 
-    it("Removes non-area non-topic nodes that don't have children", () => {
+    it("Removes non-area non-searchable nodes that don't have children", () => {
         const root: TagGraphRoot = {
             id: 1,
             name: "tag-graph-root",
             slug: null,
             weight: 0,
             isTopic: false,
+            isSearchable: false,
             path: [1],
             children: [
                 {
@@ -897,6 +902,7 @@ describe(flattenNonTopicNodes, () => {
                     slug: null,
                     weight: 0,
                     isTopic: false,
+                    isSearchable: false,
                     children: [
                         {
                             id: 3,
@@ -904,6 +910,7 @@ describe(flattenNonTopicNodes, () => {
                             slug: null,
                             weight: 0,
                             isTopic: false,
+                            isSearchable: false,
                             children: [],
                             path: [1, 2, 3],
                         },

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -2092,6 +2092,7 @@ export function createTagGraph(
         name: TagGraphRootName,
         slug: null,
         isTopic: false,
+        isSearchable: false,
         path: [rootId],
         weight: 0,
         children: [],
@@ -2108,6 +2109,7 @@ export function createTagGraph(
                 name: child.name,
                 slug: child.slug,
                 isTopic: child.isTopic,
+                isSearchable: child.isSearchable,
                 weight: child.weight,
                 children: [],
             }
@@ -2130,20 +2132,21 @@ export const getAllChildrenOfArea = (area: TagGraphNode): TagGraphNode[] => {
 }
 
 /**
- * topicTagGraph.json includes sub-areas: non-topic tags that have topic children
+ * topicTagGraph.json includes sub-areas: non-searchable tags that have searchable children
  * e.g. "Health" is an area, "Life & Death" is a sub-area, and "Life Expectancy" is a topic,
  * This function flattens the graph by removing sub-areas and moving their children up to the area level
  * e.g. "Life Expectancy" becomes a child of "Health" instead of "Life & Death"
  * We need this because the all-topics section on the homepage renders sub-areas, but the site nav doesn't
  * Note that topics can have children (e.g. "Air Pollution" is a topic, and "Indoor Air Pollution" is a sub-topic)
  * Such cases are not flattened here, but in the frontend with getAllChildrenOfArea
+ * Searchable tags include both topics (tags with a topic page) and tags with searchableInAlgolia set
  */
 export function flattenNonTopicNodes(tagGraph: TagGraphRoot): TagGraphRoot {
     const flattenNodes = (nodes: TagGraphNode[]): TagGraphNode[] =>
         nodes.flatMap((node) =>
-            !node.isTopic && node.children.length
+            !node.isSearchable && node.children.length
                 ? flattenNodes(node.children)
-                : node.isTopic
+                : node.isSearchable
                   ? [{ ...node, children: flattenNodes(node.children) }]
                   : []
         )

--- a/site/SiteMobileArea.tsx
+++ b/site/SiteMobileArea.tsx
@@ -30,9 +30,14 @@ export const SiteMobileArea = ({
                 onToggle={() => toggleArea(area)}
                 dropdown={
                     <ul>
-                        {getAllChildrenOfArea(area).map((topic) => (
-                            <SiteNavigationTopic key={topic.id} topic={topic} />
-                        ))}
+                        {getAllChildrenOfArea(area)
+                            .filter((topic) => topic.slug)
+                            .map((topic) => (
+                                <SiteNavigationTopic
+                                    key={topic.id}
+                                    topic={topic}
+                                />
+                            ))}
                     </ul>
                 }
                 withCaret={true}

--- a/site/SiteNavigationTopics.tsx
+++ b/site/SiteNavigationTopics.tsx
@@ -28,7 +28,9 @@ export const SiteNavigationTopics = ({
     // using useLayoutEffect to avoid a flash of the wrong number of columns when switching categories
     useLayoutEffect(() => {
         if (activeArea) {
-            const topics = getAllChildrenOfArea(activeArea)
+            const topics = getAllChildrenOfArea(activeArea).filter(
+                (topic) => topic.slug
+            )
             const numColumns = Math.ceil(topics.length / 10)
             setNumTopicColumns(numColumns)
         }
@@ -79,9 +81,11 @@ export const SiteNavigationTopics = ({
                     })}
                     onClick={stopPropagation}
                 >
-                    {getAllChildrenOfArea(activeArea).map((topic) => (
-                        <SiteNavigationTopic key={topic.id} topic={topic} />
-                    ))}
+                    {getAllChildrenOfArea(activeArea)
+                        .filter((topic) => topic.slug)
+                        .map((topic) => (
+                            <SiteNavigationTopic key={topic.id} topic={topic} />
+                        ))}
                 </ul>
             )}
         </div>

--- a/site/gdocs/pages/Homepage.tsx
+++ b/site/gdocs/pages/Homepage.tsx
@@ -15,9 +15,10 @@ const AllTopicsSection = () => {
     if (!tagGraph) return null
 
     // We have to flatten the areas because we can't nest <ul> elements and have them render correctly
+    // Filter to only include topics (tags with slugs) - searchable non-topic tags shouldn't appear here
     const flattenedAreas = tagGraph.children.map((area) => ({
         ...area,
-        children: getAllChildrenOfArea(area),
+        children: getAllChildrenOfArea(area).filter((topic) => topic.isTopic),
     }))
 
     return (

--- a/site/search/searchHooks.ts
+++ b/site/search/searchHooks.ts
@@ -27,7 +27,8 @@ export const useSelectedRegionNames = (): string[] => {
 }
 
 /**
- * Extracts and memoizes area names and all topics from the topic tag graph
+ * Extracts and memoizes area names and all searchable tags from the topic tag graph.
+ * Searchable tags include both topics (tags with a topic page) and tags with searchableInAlgolia set.
  */
 export function useTagGraphTopics(topicTagGraph: TagGraphRoot | null): {
     allAreas: string[]
@@ -41,19 +42,19 @@ export function useTagGraphTopics(topicTagGraph: TagGraphRoot | null): {
     const allTopics = useMemo(() => {
         if (!topicTagGraph) return []
 
-        function getAllTopics(node: TagGraphNode): Set<string> {
+        function getAllSearchableTopics(node: TagGraphNode): Set<string> {
             return node.children.reduce((acc, child) => {
-                if (child.isTopic) {
+                if (child.isSearchable) {
                     acc.add(child.name)
                 }
                 if (child.children.length) {
-                    const topics = getAllTopics(child)
+                    const topics = getAllSearchableTopics(child)
                     topics.forEach((topic) => acc.add(topic))
                 }
                 return acc
             }, new Set<string>())
         }
-        return [...getAllTopics(topicTagGraph)]
+        return [...getAllSearchableTopics(topicTagGraph)]
     }, [topicTagGraph])
 
     return { allAreas, allTopics }


### PR DESCRIPTION
Resolves https://github.com/owid/owid-grapher/issues/5827

Adds a "Searchable in Algolia" checkbox to the tag admin page. When true, this field means a non-topic tag is for all intents and purposes treated as a topic tag in Search.

## Screenshots / Videos / Diagrams

Admin page:
<img width="1267" height="391" alt="image" src="https://github.com/user-attachments/assets/ee9b9789-2924-43b3-aa6a-f72e674ac9d9" />

Searchbar:
<img width="534" height="97" alt="image" src="https://github.com/user-attachments/assets/6d58e431-8e83-460b-acc8-d9f059f01e79" />


## Testing guidance

Switch it on for a given tag, then write an index from `indexChartsToAlgolia.ts` to a local JSON file, and see the tag is now present in the records' tags arrays. Also confirm that the tag now works in autocomplete.

- [ ] Does the staging experience have sign-off from product stakeholders?

## Checklist

- [x] The DB type definitions have been updated
- [x] Update the documentation in db/docs