### PR TITLE
Add useDocumentContext hook

### DIFF
--- a/site/blocks/RelatedCharts.tsx
+++ b/site/blocks/RelatedCharts.tsx
@@ -1,5 +1,5 @@
 import * as _ from "lodash-es"
-import { useState, useRef, useContext } from "react"
+import { useState, useRef } from "react"
 import * as React from "react"
 import { RelatedChart } from "@ourworldindata/utils"
 import { GRAPHER_PREVIEW_CLASS } from "@ourworldindata/types"
@@ -7,7 +7,7 @@ import { GalleryArrow } from "./GalleryArrow.js"
 import { GalleryArrowDirection } from "../SiteConstants.js"
 import { AllChartsListItem } from "./AllChartsListItem.js"
 import { GrapherWithFallback } from "../GrapherWithFallback.js"
-import { DocumentContext } from "../gdocs/DocumentContext.js"
+import { useDocumentContext } from "../gdocs/DocumentContext.js"
 
 export const RELATED_CHARTS_CLASS_NAME = "related-charts"
 
@@ -20,7 +20,7 @@ export const RelatedCharts = ({
 }) => {
     const refChartContainer = useRef<HTMLDivElement>(null)
     const [activeChartIdx, setActiveChartIdx] = useState(0)
-    const { isPreviewing } = useContext(DocumentContext)
+    const { isPreviewing } = useDocumentContext()
 
     const chartsToShow = showKeyChartsOnly
         ? charts.filter((chart) => !!chart.keyChartLevel)

--- a/site/gdocs/DocumentContext.tsx
+++ b/site/gdocs/DocumentContext.tsx
@@ -1,4 +1,4 @@
-import { createContext } from "react"
+import { createContext, useContext } from "react"
 import { ArchiveContext } from "@ourworldindata/types"
 
 export const DocumentContext = createContext<{
@@ -7,3 +7,7 @@ export const DocumentContext = createContext<{
 }>({
     isPreviewing: false,
 })
+
+export function useDocumentContext() {
+    return useContext(DocumentContext)
+}

--- a/site/gdocs/components/Chart.tsx
+++ b/site/gdocs/components/Chart.tsx
@@ -9,7 +9,7 @@ import cx from "classnames"
 import { GrapherWithFallback } from "../../GrapherWithFallback.js"
 import { MultiDimEmbed } from "../../MultiDimEmbed.js"
 import { useEmbedChart } from "../../hooks.js"
-import { DocumentContext } from "../DocumentContext.js"
+import { useDocumentContext } from "../DocumentContext.js"
 
 export default function Chart({
     d,
@@ -20,7 +20,7 @@ export default function Chart({
     className?: string
     fullWidthOnMobile?: boolean
 }) {
-    const { isPreviewing, archiveContext } = useContext(DocumentContext)
+    const { isPreviewing, archiveContext } = useDocumentContext()
     const refChartContainer = useRef<HTMLDivElement>(null)
     const archiveIframeRef = useRef<HTMLIFrameElement | null>(null)
     useEmbedChart(0, refChartContainer, isPreviewing)

--- a/site/gdocs/components/ExplorerTiles.tsx
+++ b/site/gdocs/components/ExplorerTiles.tsx
@@ -1,13 +1,12 @@
 import { EnrichedBlockExplorerTiles } from "@ourworldindata/types"
 import { Button } from "@ourworldindata/components"
-import { useContext } from "react"
 import { useLinkedChart } from "../utils.js"
-import { DocumentContext } from "../DocumentContext.js"
+import { useDocumentContext } from "../DocumentContext.js"
 import { BAKED_BASE_URL } from "../../../settings/clientSettings.js"
 
 function ExplorerTile({ url }: { url: string }) {
     const { linkedChart, errorMessage } = useLinkedChart(url)
-    const { isPreviewing } = useContext(DocumentContext)
+    const { isPreviewing } = useDocumentContext()
     if (errorMessage && isPreviewing) {
         return <p>{errorMessage}</p>
     }

--- a/site/gdocs/components/HomepageIntro.tsx
+++ b/site/gdocs/components/HomepageIntro.tsx
@@ -7,7 +7,7 @@ import {
 } from "@ourworldindata/types"
 import { dayjs, formatAuthors } from "@ourworldindata/utils"
 import { useLinkedChart, useLinkedDocument } from "../utils.js"
-import { DocumentContext } from "../DocumentContext.js"
+import { useDocumentContext } from "../DocumentContext.js"
 import Image, { ImageParentContainer } from "./Image.js"
 import { BlockErrorFallback } from "./BlockErrorBoundary.js"
 import * as R from "remeda"
@@ -43,7 +43,7 @@ function FeaturedWorkTile({
     id,
 }: FeaturedWorkTileProps) {
     const { linkedDocument, errorMessage } = useLinkedDocument(url)
-    const { isPreviewing } = useContext(DocumentContext)
+    const { isPreviewing } = useDocumentContext()
     const linkedDocumentFeaturedImage = linkedDocument?.["featured-image"]
     const thumbnailFilename = filename ?? linkedDocumentFeaturedImage
     const href = linkedDocument?.url ?? url

--- a/site/gdocs/components/Image.tsx
+++ b/site/gdocs/components/Image.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useContext, useState } from "react"
+import { useCallback, useState } from "react"
 import {
     AssetMap,
     generateSourceProps,
@@ -8,7 +8,7 @@ import {
 } from "@ourworldindata/utils"
 import cx from "classnames"
 import { CLOUDFLARE_IMAGES_URL } from "../../../settings/clientSettings.js"
-import { DocumentContext } from "../DocumentContext.js"
+import { useDocumentContext } from "../DocumentContext.js"
 import { useImage } from "../utils.js"
 import { BlockErrorFallback } from "./BlockErrorBoundary.js"
 import { SMALL_BREAKPOINT_MEDIA_QUERY } from "../../SiteConstants.js"
@@ -109,7 +109,7 @@ export default function Image(props: {
     // Whether we should show the lightbox and a download button
     const isInteractive = shouldLightbox && containerType !== "thumbnail"
 
-    const { archiveContext, isPreviewing } = useContext(DocumentContext)
+    const { archiveContext, isPreviewing } = useDocumentContext()
     const isOnArchivalPage = archiveContext?.type === "archive-page"
     const assetMap = isOnArchivalPage
         ? archiveContext?.assets?.runtime

--- a/site/gdocs/components/LinkedA.tsx
+++ b/site/gdocs/components/LinkedA.tsx
@@ -1,4 +1,3 @@
-import { useContext } from "react"
 import { getLinkType } from "@ourworldindata/components"
 import { SpanLink } from "@ourworldindata/types"
 import { useLinkedDocument, useLinkedChart } from "../utils.js"
@@ -9,13 +8,13 @@ import { ChartPreview } from "./ChartPreview.js"
 import { SiteAnalytics } from "../../SiteAnalytics.js"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faChartLine } from "@fortawesome/free-solid-svg-icons"
-import { DocumentContext } from "../DocumentContext.js"
+import { useDocumentContext } from "../DocumentContext.js"
 
 const analytics = new SiteAnalytics()
 
 export default function LinkedA({ span }: { span: SpanLink }) {
     const linkType = getLinkType(span.url)
-    const { archiveContext } = useContext(DocumentContext)
+    const { archiveContext } = useDocumentContext()
     const isOnArchivalPage = archiveContext?.type === "archive-page"
     const { linkedDocument } = useLinkedDocument(span.url)
     const { linkedChart } = useLinkedChart(span.url)

--- a/site/gdocs/components/NarrativeChart.tsx
+++ b/site/gdocs/components/NarrativeChart.tsx
@@ -1,4 +1,4 @@
-import { useContext, useRef } from "react"
+import { useRef } from "react"
 import { useEmbedChart } from "../../hooks.js"
 import {
     EnrichedBlockNarrativeChart,
@@ -8,7 +8,7 @@ import { useLinkedNarrativeChart } from "../utils.js"
 import cx from "classnames"
 import { BlockErrorFallback } from "./BlockErrorBoundary.js"
 import SpanElements from "./SpanElements.js"
-import { DocumentContext } from "../DocumentContext.js"
+import { useDocumentContext } from "../DocumentContext.js"
 import {
     DEFAULT_GRAPHER_HEIGHT,
     DEFAULT_GRAPHER_WIDTH,
@@ -30,7 +30,7 @@ export default function NarrativeChart({
     fullWidthOnMobile?: boolean
 }) {
     const refChartContainer = useRef<HTMLDivElement>(null)
-    const { isPreviewing, archiveContext } = useContext(DocumentContext)
+    const { isPreviewing, archiveContext } = useDocumentContext()
     useEmbedChart(0, refChartContainer, isPreviewing)
 
     const viewMetadata = useLinkedNarrativeChart(d.name)

--- a/site/gdocs/components/OwidGdocHeader.tsx
+++ b/site/gdocs/components/OwidGdocHeader.tsx
@@ -1,5 +1,5 @@
 import cx from "classnames"
-import { useContext, useState } from "react"
+import { useState } from "react"
 import {
     BreadcrumbItem,
     CITATION_ID,
@@ -18,7 +18,7 @@ import { Byline } from "./Byline.js"
 import { VersionsDrawer } from "../../archive/VersionsDrawer.js"
 import { useArchiveVersions } from "../../archive/versions.js"
 import { useWindowQueryParams } from "../../hooks.js"
-import { DocumentContext } from "../DocumentContext.js"
+import { useDocumentContext } from "../DocumentContext.js"
 
 function OwidArticleHeader({
     content,
@@ -36,7 +36,7 @@ function OwidArticleHeader({
         : undefined
 
     const breadcrumbColor = breadcrumbColorForCoverColor(content["cover-color"])
-    const { archiveContext } = useContext(DocumentContext)
+    const { archiveContext } = useDocumentContext()
     const isOnArchivePage = archiveContext?.type === "archive-page"
     const versionsFileUrl =
         archiveContext?.versionsFileUrl ??

--- a/site/gdocs/components/PillRow.tsx
+++ b/site/gdocs/components/PillRow.tsx
@@ -1,11 +1,10 @@
 import { EnrichedBlockPillRow } from "@ourworldindata/types"
-import { useContext } from "react"
 import { useLinkedDocument } from "../utils.js"
-import { DocumentContext } from "../DocumentContext.js"
+import { useDocumentContext } from "../DocumentContext.js"
 
 function Pill(props: { text?: string; url: string }) {
     const { linkedDocument, errorMessage } = useLinkedDocument(props.url)
-    const { isPreviewing } = useContext(DocumentContext)
+    const { isPreviewing } = useDocumentContext()
     const url = linkedDocument?.url ?? props.url
     const text = props.text ?? linkedDocument?.title
 

--- a/site/gdocs/components/ProminentLink.tsx
+++ b/site/gdocs/components/ProminentLink.tsx
@@ -1,8 +1,7 @@
 import cx from "classnames"
 import { HybridLinkList } from "./HybridLinkList.js"
 import { useLinkedChart, useLinkedDocument } from "../utils.js"
-import { useContext } from "react"
-import { DocumentContext } from "../DocumentContext.js"
+import { useDocumentContext } from "../DocumentContext.js"
 import { BlockErrorFallback } from "./BlockErrorBoundary.js"
 
 export const ProminentLink = (props: {
@@ -15,7 +14,7 @@ export const ProminentLink = (props: {
     const { errorMessage: documentErrorMessage } = useLinkedDocument(props.url)
     const { errorMessage: linkedChartErrorMessage } = useLinkedChart(props.url)
     const errorMessage = documentErrorMessage || linkedChartErrorMessage
-    const { isPreviewing } = useContext(DocumentContext)
+    const { isPreviewing } = useDocumentContext()
 
     if (errorMessage) {
         if (isPreviewing) {

--- a/site/gdocs/components/ResearchAndWriting.tsx
+++ b/site/gdocs/components/ResearchAndWriting.tsx
@@ -10,7 +10,7 @@ import {
 } from "@ourworldindata/utils"
 import { useLinkedDocument } from "../utils.js"
 import Image, { ImageParentContainer } from "./Image.js"
-import { DocumentContext } from "../DocumentContext.js"
+import { useDocumentContext } from "../DocumentContext.js"
 import { AttachmentsContext } from "../AttachmentsContext.js"
 import { Button } from "@ourworldindata/components"
 import {
@@ -84,7 +84,7 @@ function ResearchAndWritingLink(
         className,
     } = props
     const { linkedDocument, errorMessage } = useLinkedDocument(url)
-    const { isPreviewing } = useContext(DocumentContext)
+    const { isPreviewing } = useDocumentContext()
 
     if (errorMessage) {
         if (isPreviewing) {

--- a/site/gdocs/components/StaticViz.tsx
+++ b/site/gdocs/components/StaticViz.tsx
@@ -1,15 +1,8 @@
 import cx from "classnames"
 import { useLinkedStaticViz } from "../utils.js"
 import Image, { ImageParentContainer } from "./Image.js"
-import { DocumentContext } from "../DocumentContext.js"
-import {
-    useCallback,
-    useContext,
-    useMemo,
-    useState,
-    useId,
-    type MouseEvent,
-} from "react"
+import { useDocumentContext } from "../DocumentContext.js"
+import { useCallback, useMemo, useState, useId, type MouseEvent } from "react"
 import { BlockErrorFallback } from "./BlockErrorBoundary.js"
 import { MarkdownTextWrap, OverlayHeader } from "@ourworldindata/components"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
@@ -35,7 +28,7 @@ export default function StaticViz(props: StaticVizProps) {
         hasOutline = true,
     } = props
     const staticViz = useLinkedStaticViz(name)
-    const { isPreviewing } = useContext(DocumentContext)
+    const { isPreviewing } = useDocumentContext()
     const [isDownloadModalOpen, setIsDownloadModalOpen] = useState(false)
 
     if (!staticViz) {

--- a/site/gdocs/components/TopicPageIntro.tsx
+++ b/site/gdocs/components/TopicPageIntro.tsx
@@ -2,9 +2,8 @@ import {
     EnrichedTopicPageIntroRelatedTopic,
     EnrichedBlockTopicPageIntro,
 } from "@ourworldindata/utils"
-import { useContext } from "react"
 import { useLinkedDocument } from "../utils.js"
-import { DocumentContext } from "../DocumentContext.js"
+import { useDocumentContext } from "../DocumentContext.js"
 import Paragraph from "./Paragraph.js"
 
 type TopicPageIntroProps = EnrichedBlockTopicPageIntro & {
@@ -16,7 +15,7 @@ function TopicPageRelatedTopic({
     url,
 }: EnrichedTopicPageIntroRelatedTopic) {
     const { linkedDocument, errorMessage } = useLinkedDocument(url)
-    const { isPreviewing } = useContext(DocumentContext)
+    const { isPreviewing } = useDocumentContext()
     if (errorMessage && isPreviewing) {
         return <li>{errorMessage}</li>
     }

--- a/site/gdocs/components/Video.tsx
+++ b/site/gdocs/components/Video.tsx
@@ -1,4 +1,3 @@
-import { useContext } from "react"
 import cx from "classnames"
 import {
     LARGEST_IMAGE_WIDTH,
@@ -8,7 +7,7 @@ import {
 import { useImage } from "../utils.js"
 import SpanElements from "./SpanElements.js"
 import { CLOUDFLARE_IMAGES_URL } from "../../../settings/clientSettings.js"
-import { DocumentContext } from "../DocumentContext.js"
+import { useDocumentContext } from "../DocumentContext.js"
 
 interface VideoProps {
     url: string
@@ -22,7 +21,7 @@ interface VideoProps {
 export default function Video(props: VideoProps) {
     const { url, caption, className, shouldLoop, shouldAutoplay, filename } =
         props
-    const { archiveContext } = useContext(DocumentContext)
+    const { archiveContext } = useDocumentContext()
     const isOnArchivalPage = archiveContext?.type === "archive-page"
     const assetMap = isOnArchivalPage
         ? archiveContext?.assets?.runtime

--- a/site/gdocs/pages/GdocPost.tsx
+++ b/site/gdocs/pages/GdocPost.tsx
@@ -20,8 +20,7 @@ import { OwidGdocHeader } from "../components/OwidGdocHeader.js"
 import StickyNav from "../../blocks/StickyNav.js"
 import { getShortPageCitation } from "../utils.js"
 import { TableOfContents } from "../../TableOfContents.js"
-import { useContext } from "react"
-import { DocumentContext } from "../DocumentContext.js"
+import { useDocumentContext } from "../DocumentContext.js"
 import { PROD_URL } from "../../SiteConstants.js"
 
 const BASE_URL = IS_ARCHIVE ? PROD_URL : ""
@@ -62,7 +61,7 @@ export function GdocPost({
     breadcrumbs,
     manualBreadcrumbs,
 }: GdocPostProps) {
-    const { archiveContext } = useContext(DocumentContext)
+    const { archiveContext } = useDocumentContext()
     const postType = content.type ?? OwidGdocType.Article
     const citationDescription = citationDescriptionsByArticleType[postType]
     const shortPageCitation = getShortPageCitation(


### PR DESCRIPTION
Small QoL improvement to only import one thing instead of two when accessing the DocumentContext.