### PR TITLE
🪓 drop social media export option

### DIFF
--- a/docs/chart-api.openapi.yaml
+++ b/docs/chart-api.openapi.yaml
@@ -671,7 +671,6 @@ components:
                     - og
                     - thumbnail
                     - square
-                    - social-media-square
                     - uncaptioned
             example: "og"
 

--- a/functions/README.md
+++ b/functions/README.md
@@ -299,14 +299,13 @@ All of the below options can be given as query parameters, e.g. `?imType=og&noca
         <td><code>imType</code></td>
         <td>
           <code>twitter</code> or <code>og</code> (short for
-          <a href="https://ogp.me">Open Graph</a>) or <code>social-media-square</code>
+          <a href="https://ogp.me">Open Graph</a>)
         </td>
         <td>
           If present, will use fitting defaults for the generated image size:
           <ul>
             <li><code>twitter</code>: 800x418</li>
             <li><code>og</code>: 1200x628</li>
-            <li><code>social-media-square</code>: 2160x2160, customizable using <code>imSquareSize=[number]</code></li>
           </ul>
           All below options will be ignored if <code>imType</code> is set to one of these values.
         </td>

--- a/functions/_common/explorerHandlers.ts
+++ b/functions/_common/explorerHandlers.ts
@@ -64,9 +64,6 @@ async function initGrapherForExplorerView(
     await explorer.updateGrapherFromExplorer()
     explorer.grapherState.populateFromQueryParams(urlObj.queryParams)
 
-    if (options.grapherProps?.isSocialMediaExport)
-        explorer.grapherState.isSocialMediaExport =
-            options.grapherProps.isSocialMediaExport
     if (options.grapherProps?.variant)
         explorer.grapherState.variant = options.grapherProps.variant
     if (options.grapherProps?.isDisplayedAlongsideComplementaryTable)

--- a/functions/_common/imageOptions.ts
+++ b/functions/_common/imageOptions.ts
@@ -55,16 +55,8 @@ const getSquareOptions = (params: URLSearchParams): ImageOptions => {
         details: false,
         fontSize: undefined,
         grapherProps: {
-            isSocialMediaExport: false,
             staticBounds: DEFAULT_GRAPHER_BOUNDS_SQUARE,
         } as Partial<GrapherProgrammaticInterface>,
-    }
-
-    const imType = params.get("imType")
-
-    if (imType === "social-media-square") {
-        if (!options.grapherProps) options.grapherProps = {}
-        options.grapherProps.isSocialMediaExport = true
     }
 
     if (params.has("imSquareSize")) {
@@ -130,8 +122,7 @@ export const extractOptions = (params: URLSearchParams): ImageOptions => {
     if (imType === "twitter") return TWITTER_OPTIONS
     else if (imType === "og") return OPEN_GRAPH_OPTIONS
     else if (imType === "thumbnail") return getThumbnailOptions(params)
-    else if (imType === "square" || imType === "social-media-square")
-        return getSquareOptions(params)
+    else if (imType === "square") return getSquareOptions(params)
 
     if (imType === "uncaptioned") {
         if (!options.grapherProps) options.grapherProps = {}

--- a/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
@@ -74,7 +74,6 @@ export interface CaptionedChartManager
     isOnTableTab?: boolean
     activeChartType?: GrapherChartType
     isFaceted?: boolean
-    isExportingForSocialMedia?: boolean
     isExportingForWikimedia?: boolean
 
     // timeline

--- a/packages/@ourworldindata/grapher/src/chart/ChartManager.ts
+++ b/packages/@ourworldindata/grapher/src/chart/ChartManager.ts
@@ -103,7 +103,6 @@ export interface ChartManager {
     isStatic?: boolean
     isSemiNarrow?: boolean
     isStaticAndSmall?: boolean
-    isExportingForSocialMedia?: boolean
     isExportingForWikimedia?: boolean
     backgroundColor?: Color
     shouldPinTooltipToBottom?: boolean

--- a/packages/@ourworldindata/grapher/src/color/ColorConstants.ts
+++ b/packages/@ourworldindata/grapher/src/color/ColorConstants.ts
@@ -11,7 +11,6 @@ export const GRAY_10 = "#f2f2f2"
 export const GRAY_5 = "#f7f7f7"
 
 export const GRAPHER_BACKGROUND_DEFAULT = "#ffffff"
-export const GRAPHER_BACKGROUND_BEIGE = "#fbf9f3"
 
 export const GRAPHER_DARK_TEXT = GRAY_80
 export const GRAPHER_LIGHT_TEXT = GRAY_70

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -97,7 +97,6 @@ export interface GrapherProgrammaticInterface extends GrapherInterface {
     hideShareButton?: boolean
     hideExploreTheDataButton?: boolean
     hideRelatedQuestion?: boolean
-    isSocialMediaExport?: boolean
     enableMapSelection?: boolean
 
     enableKeyboardShortcuts?: boolean

--- a/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
@@ -139,7 +139,6 @@ import {
 import { DimensionSlot } from "../chart/DimensionSlot.js"
 import {
     GRAPHER_LIGHT_TEXT,
-    GRAPHER_BACKGROUND_BEIGE,
     GRAPHER_BACKGROUND_DEFAULT,
 } from "../color/ColorConstants.js"
 import { ColorScaleConfig } from "../color/ColorScaleConfig.js"
@@ -582,7 +581,6 @@ export class GrapherState
     enableMapSelection = false
 
     isExportingToSvgOrPng = false
-    isSocialMediaExport = false
     isWikimediaExport = false
     shouldIncludeDetailsInStaticExport = true
 
@@ -685,7 +683,6 @@ export class GrapherState
             canHideExternalControlsInEmbed: observable.ref,
             hideExternalControlsInEmbedUrl: observable.ref,
             isExportingToSvgOrPng: observable.ref,
-            isSocialMediaExport: observable.ref,
             isWikimediaExport: observable.ref,
             variant: observable.ref,
             staticBounds: observable,
@@ -3278,22 +3275,12 @@ export class GrapherState
         return staticPixelCount < 0.66 * idealPixelCount
     }
 
-    @computed get isExportingForSocialMedia(): boolean {
-        return (
-            this.isExportingToSvgOrPng &&
-            this.isStaticAndSmall &&
-            this.isSocialMediaExport
-        )
-    }
-
     @computed get isExportingForWikimedia(): boolean {
         return this.isExportingToSvgOrPng && this.isWikimediaExport
     }
 
     @computed get backgroundColor(): Color {
-        return this.isExportingForSocialMedia
-            ? GRAPHER_BACKGROUND_BEIGE
-            : GRAPHER_BACKGROUND_DEFAULT
+        return GRAPHER_BACKGROUND_DEFAULT
     }
 
     @computed get shouldPinTooltipToBottom(): boolean {

--- a/packages/@ourworldindata/grapher/src/footer/FooterManager.ts
+++ b/packages/@ourworldindata/grapher/src/footer/FooterManager.ts
@@ -21,6 +21,5 @@ export interface FooterManager extends TooltipManager, ActionButtonsManager {
     hideNote?: boolean
     hideOriginUrl?: boolean
     isStaticAndSmall?: boolean
-    isSocialMediaExport?: boolean
     detailsMarkerInSvg?: DetailsMarker
 }

--- a/packages/@ourworldindata/grapher/src/header/Header.tsx
+++ b/packages/@ourworldindata/grapher/src/header/Header.tsx
@@ -18,7 +18,7 @@ import {
     GRAPHER_FRAME_PADDING_VERTICAL,
     GRAPHER_HEADER_CLASS,
 } from "../core/GrapherConstants"
-import { GRAPHER_DARK_TEXT, GRAY_100, GRAY_80 } from "../color/ColorConstants"
+import { GRAPHER_DARK_TEXT, GRAY_100 } from "../color/ColorConstants"
 
 interface HeaderProps {
     manager: HeaderManager
@@ -358,11 +358,7 @@ export class StaticHeader extends AbstractHeader<StaticHeaderProps> {
                                 : 0),
                         {
                             id: makeIdForHumanConsumption("subtitle"),
-                            textProps: {
-                                fill: this.manager.isSocialMediaExport
-                                    ? GRAY_80
-                                    : GRAPHER_DARK_TEXT,
-                            },
+                            textProps: { fill: GRAPHER_DARK_TEXT },
                             detailsMarker: this.manager.detailsMarkerInSvg,
                         }
                     )}

--- a/packages/@ourworldindata/grapher/src/header/HeaderManager.ts
+++ b/packages/@ourworldindata/grapher/src/header/HeaderManager.ts
@@ -23,6 +23,5 @@ export interface HeaderManager {
     hideTitle?: boolean
     hideSubtitle?: boolean
     isStaticAndSmall?: boolean
-    isSocialMediaExport?: boolean
     detailsMarkerInSvg?: DetailsMarker
 }

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
@@ -76,7 +76,6 @@ export interface DownloadModalManager {
     isOnArchivalPage?: boolean
     hasArchivedPage?: boolean
     showAdminControls?: boolean
-    isSocialMediaExport?: boolean
     isWikimediaExport?: boolean
     isPublished?: boolean
     activeColumnSlugs?: string[]
@@ -252,10 +251,6 @@ export class DownloadModalVisTab extends React.Component<DownloadModalProps> {
         )
     }
 
-    @computed private get isSocialMediaExport(): boolean {
-        return this.manager.isSocialMediaExport ?? false
-    }
-
     @computed private get isWikimediaExport(): boolean {
         return this.manager.isWikimediaExport ?? false
     }
@@ -343,10 +338,6 @@ export class DownloadModalVisTab extends React.Component<DownloadModalProps> {
         this.manager.staticBounds = this.isExportingSquare
             ? DEFAULT_GRAPHER_BOUNDS
             : DEFAULT_GRAPHER_BOUNDS_SQUARE
-    }
-
-    @action.bound private toggleExportForUseInSocialMedia(): void {
-        this.manager.isSocialMediaExport = !this.isSocialMediaExport
     }
 
     @action.bound private toggleExportForUseOnWikimedia(): void {
@@ -517,30 +508,6 @@ export class DownloadModalVisTab extends React.Component<DownloadModalProps> {
                                         onChange={action((): void => {
                                             this.reset()
                                             this.toggleExportFormat()
-
-                                            if (!this.isExportingSquare) {
-                                                this.manager.isSocialMediaExport = false
-                                            }
-
-                                            this.export()
-                                        })}
-                                    />
-                                )}
-                                {this.manager.showAdminControls && (
-                                    <Checkbox
-                                        checked={this.isSocialMediaExport}
-                                        label="For use in social media (internal)"
-                                        onChange={action((): void => {
-                                            this.reset()
-                                            this.toggleExportForUseInSocialMedia()
-
-                                            // set reasonable defaults for social media exports
-                                            if (this.isSocialMediaExport) {
-                                                this.manager.staticBounds =
-                                                    DEFAULT_GRAPHER_BOUNDS_SQUARE
-                                                this.shouldIncludeDetails = false
-                                            }
-
                                             this.export()
                                         })}
                                     />


### PR DESCRIPTION
Drops social media specific exports because they're unused

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #5886 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #5885 
<!-- GitButler Footer Boundary Bottom -->

