### PR TITLE
✨ automatic redirect creation on published gdoc slug change

### DIFF
--- a/packages/@ourworldindata/types/src/dbTypes/Redirects.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/Redirects.ts
@@ -1,3 +1,5 @@
+export const RedirectsTableName = "redirects"
+
 export enum RedirectCode {
     MOVED_PERMANENTLY = 301,
     FOUND = 302,

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -821,7 +821,11 @@ export {
     type License,
 } from "./dbTypes/Variables.js"
 
-export { RedirectCode, type DbPlainRedirect } from "./dbTypes/Redirects.js"
+export {
+    RedirectsTableName,
+    RedirectCode,
+    type DbPlainRedirect,
+} from "./dbTypes/Redirects.js"
 
 export {
     ExplorerViewsTableName,


### PR DESCRIPTION
Fixes https://github.com/owid/owid-grapher/issues/5582

You can test it locally by publishing a local test document with a custom slug (e.g. `test-a`) and republishing it repeatedly with `test-b`, `test-c`, and back to `test-a`) checking the redirects table each time.

Doesn't support the case where an article is republished as a data insight, team page, or announcement (where its slug would stay the same, but its canonical URL would change) because I don't think an author would ever do that.