### PR TITLE
fix: dedup CI runs in PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
-on: [push, pull_request]
+on:
+    pull_request:
+    push:
+        branches:
+            - master
 
 jobs:
     # Checks for prettify errors, TypeScript errors and runs vitest tests.


### PR DESCRIPTION
## Context

This PR updates the GitHub Actions workflow configuration to only run CI jobs on pull requests once, while preserving CI on pushes to master.