### PR TITLE
🔨 clean up downloaded csv files

### DIFF
--- a/functions/_common/downloadFunctions.ts
+++ b/functions/_common/downloadFunctions.ts
@@ -18,7 +18,6 @@ import { assembleMetadata, getColumnsForMetadata } from "./metadataTools.js"
 import { Env } from "./env.js"
 import {
     getDataApiUrl,
-    getGrapherTableWithRelevantColumns,
     GrapherIdentifier,
     initGrapher,
 } from "./grapherTools.js"
@@ -127,11 +126,11 @@ export function assembleCsv(
         searchParams.get("useColumnShortNames") === "true"
     const shouldUseFilteredTable = searchParams.get("csvType") === "filtered"
 
-    const table = getGrapherTableWithRelevantColumns(grapherState, {
-        shouldUseFilteredTable,
-    })
+    const table = shouldUseFilteredTable
+        ? grapherState.filteredTableForDownload
+        : grapherState.tableForDownload
 
-    return table.toPrettyCsv(shouldUseShortNames)
+    return table.toPrettyCsv({ useShortNames: shouldUseShortNames })
 }
 
 export async function fetchCsvForGrapher(

--- a/functions/_common/grapherTools.test.ts
+++ b/functions/_common/grapherTools.test.ts
@@ -1,13 +1,13 @@
 import { expect, it, describe, DeeplyAllowMatchers } from "vitest"
 
-import { getGrapherTableWithRelevantColumns } from "./grapherTools"
 import {
     SampleColumnSlugs,
     SynthesizeGDPTable,
 } from "@ourworldindata/core-table"
 import { GrapherState } from "@ourworldindata/grapher"
+import { OwidTableSlugs } from "@ourworldindata/types"
 
-describe(getGrapherTableWithRelevantColumns, () => {
+describe("download", () => {
     const originalTable = SynthesizeGDPTable()
     const originalYColumns: string[] = [
         SampleColumnSlugs.GDP,
@@ -20,13 +20,13 @@ describe(getGrapherTableWithRelevantColumns, () => {
 
     it("doesn't include any y-columns when none are specified", () => {
         const grapherState = new GrapherState({ table: SynthesizeGDPTable() })
-        const resultTable = getGrapherTableWithRelevantColumns(grapherState)
-        const slugs = resultTable.columnSlugs
-        expect(slugs).toEqual(
-            originalTable.columnSlugs.filter(
-                (slug) => !originalYColumns.includes(slug)
-            )
+        const slugs = grapherState.tableForDownload.columnSlugs
+        const expectedSlugs = originalTable.columnSlugs.filter(
+            (slug) =>
+                !originalYColumns.includes(slug) &&
+                slug !== OwidTableSlugs.entityId
         )
+        expect(slugs).toEqual(expectedSlugs)
     })
 
     it("only includes the chart's y-columns", () => {
@@ -42,12 +42,12 @@ describe(getGrapherTableWithRelevantColumns, () => {
                 table: SynthesizeGDPTable(),
                 ySlugs,
             })
-            const resultTable = getGrapherTableWithRelevantColumns(grapherState)
-            const slugs = resultTable.columnSlugs
-            expectUnorderedEqual(slugs, [
+            const slugs = grapherState.tableForDownload.columnSlugs
+            const expectedSlugs = [
                 ...originalOtherColumns,
                 ...ySlugs.split(" "),
-            ])
+            ].filter((slug) => slug !== OwidTableSlugs.entityId)
+            expectUnorderedEqual(slugs, expectedSlugs)
         }
     })
 })

--- a/functions/_common/grapherTools.ts
+++ b/functions/_common/grapherTools.ts
@@ -8,19 +8,12 @@ import {
     GrapherInterface,
     MultiDimDataPageConfigEnriched,
     R2GrapherConfigDirectory,
-    OwidTableSlugs,
 } from "@ourworldindata/types"
 import {
     excludeUndefined,
     Bounds,
     searchParamsToMultiDimView,
-    makeAnnotationsSlug,
 } from "@ourworldindata/utils"
-import {
-    OwidTable,
-    makeOriginalTimeSlugFromColumnSlug,
-    makeOriginalValueSlugFromColumnSlug,
-} from "@ourworldindata/core-table"
 import { StatusError } from "itty-router"
 import { Env } from "./env.js"
 import { ImageOptions } from "./imageOptions.js"
@@ -372,54 +365,4 @@ export function addClassNamesToBody(page: Response, classNames: string[]) {
     })
 
     return rewriter.transform(page)
-}
-
-export function getGrapherTableWithRelevantColumns(
-    grapherState: GrapherState,
-    options?: { shouldUseFilteredTable: boolean }
-): OwidTable {
-    // Extract table from Grapher
-    const fullTable = grapherState.inputTable
-    const filteredTable = grapherState.isOnTableTab
-        ? grapherState.tableForDisplay
-        : grapherState.transformedTable
-    const table = options?.shouldUseFilteredTable ? filteredTable : fullTable
-
-    // Trim table to only include columns that are relevant to the current
-    // grapher view. This filtering is necessary for CSV-based data explorers
-    // because the full table contains columns for all possible views.
-    const entityNameSlugs = [
-        OwidTableSlugs.entityName,
-        OwidTableSlugs.entityCode,
-        OwidTableSlugs.entityId,
-        table.entityNameColumn.slug,
-    ]
-    const timeSlugs = [
-        OwidTableSlugs.time,
-        OwidTableSlugs.year,
-        OwidTableSlugs.date,
-        OwidTableSlugs.day,
-        table.timeColumn.slug,
-    ]
-    const valueSlugs = excludeUndefined([
-        ...grapherState.yColumnSlugs,
-        grapherState.xColumnSlug,
-        grapherState.colorColumnSlug,
-        grapherState.sizeColumnSlug,
-    ])
-    const extraSlugs = valueSlugs.flatMap((slug) => [
-        makeAnnotationsSlug(slug),
-        makeOriginalTimeSlugFromColumnSlug(slug),
-        makeOriginalValueSlugFromColumnSlug(slug),
-    ])
-    const slugs = [
-        ...entityNameSlugs,
-        ...timeSlugs,
-        ...valueSlugs,
-        ...extraSlugs,
-    ].filter((slug) => slug && table.has(slug)) as string[]
-
-    const uniqueSlugs = _.uniq(slugs)
-
-    return table.select(uniqueSlugs)
 }

--- a/functions/_common/metadataTools.ts
+++ b/functions/_common/metadataTools.ts
@@ -13,7 +13,6 @@ import {
     getCitationLong,
 } from "@ourworldindata/utils"
 import { getGrapherFilters } from "./urlTools.js"
-import { getGrapherTableWithRelevantColumns } from "./grapherTools.js"
 
 type MetadataColumn = {
     titleShort: string
@@ -37,7 +36,7 @@ type MetadataColumn = {
 }
 
 export const getColumnsForMetadata = (grapherState: GrapherState) => {
-    const table = getGrapherTableWithRelevantColumns(grapherState)
+    const table = grapherState.tableForDownload
 
     const columnsToIgnore = new Set(
         [

--- a/packages/@ourworldindata/core-table/src/CoreTable.test.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTable.test.ts
@@ -573,41 +573,6 @@ describe("debug tools", () => {
     })
 })
 
-describe("printing", () => {
-    it("can export a clean csv with dates", () => {
-        const table = new CoreTable(
-            [
-                { entityName: "Aruba", day: 1, annotation: "Something, foo" },
-                { entityName: "Canada", day: 2 },
-            ],
-            [
-                { slug: "entityName" },
-                { slug: "day", type: "Day" as any },
-                { slug: "annotation" },
-            ]
-        )
-
-        expect(table.toCsvWithColumnNames()).toEqual(`entityName,day,annotation
-Aruba,2020-01-22,"Something, foo"
-Canada,2020-01-23,`)
-    })
-
-    it("can format a value", () => {
-        const table = new CoreTable(
-            `growthRate
-123`,
-            [
-                {
-                    slug: "growthRate",
-                    display: { unit: "%" },
-                    type: ColumnTypeNames.Numeric,
-                },
-            ]
-        )
-        expect(table.get("growthRate").formatValueShort(20)).toEqual("20%")
-    })
-})
-
 describe("value operations", () => {
     it("can detect all integers", () => {
         const table = new CoreTable(`gdp,perCapita

--- a/packages/@ourworldindata/core-table/src/OwidTableUtil.ts
+++ b/packages/@ourworldindata/core-table/src/OwidTableUtil.ts
@@ -27,6 +27,9 @@ export function makeOriginalValueSlugFromColumnSlug(slug: ColumnSlug): string {
     return `${slug}-originalValue`
 }
 
+export const makeAnnotationsSlug = (columnSlug: string): string =>
+    `${columnSlug}-annotations`
+
 export function getOriginalTimeColumnSlug(
     table: CoreTable,
     slug: ColumnSlug

--- a/packages/@ourworldindata/core-table/src/index.ts
+++ b/packages/@ourworldindata/core-table/src/index.ts
@@ -69,6 +69,7 @@ export {
     timeColumnSlugFromColumnDef,
     makeOriginalTimeSlugFromColumnSlug,
     makeOriginalValueSlugFromColumnSlug,
+    makeAnnotationsSlug,
     getOriginalTimeColumnSlug,
     toPercentageColumnDef,
 } from "./OwidTableUtil.js"

--- a/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.test.ts
+++ b/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.test.ts
@@ -827,10 +827,10 @@ describe("creating a table from legacy", () => {
     })
 
     it("can export legacy to CSV", () => {
-        const expected = `Entity,Code,Year,"Prevalence of wasting, weight for height (% of children under 5)"
-Cape Verde,CPV,1985,4.2
-Kiribati,KIR,1985,12.6
-Papua New Guinea,PNG,1983,5.5`
+        const expected = `Entity,Code,Year,Some Display Name,Year,entityColor
+Cape Verde,CPV,1985,4.2,1985,blue
+Kiribati,KIR,1985,12.6,1985,
+Papua New Guinea,PNG,1983,5.5,1983,`
         expect(table.toPrettyCsv()).toEqual(expected)
     })
 

--- a/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.ts
+++ b/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.ts
@@ -18,12 +18,12 @@ import {
     OwidTable,
     ErrorValueTypes,
     makeKeyFn,
+    makeAnnotationsSlug,
 } from "@ourworldindata/core-table"
 import {
     diffDateISOStringInDays,
     getYearFromISOStringAndDayOffset,
     intersection,
-    makeAnnotationsSlug,
     trimObject,
     OwidEntityKey,
     MultipleOwidVariableDataDimensionsMap,
@@ -337,10 +337,7 @@ export const legacyToOwidTableAndDimensions = (
         if (joinedVariablesTable.columnSlugs.includes(dayOrYearSlug)) {
             joinedVariablesTable = joinedVariablesTable.duplicateColumn(
                 dayOrYearSlug,
-                {
-                    slug: OwidTableSlugs.time,
-                    name: OwidTableSlugs.time,
-                }
+                { slug: OwidTableSlugs.time, name: OwidTableSlugs.time }
             )
             // Do not inject multiple columns, terminate after one is successful
             break
@@ -738,17 +735,17 @@ const annotationMapAndDefFromOwidVariable = (
     variable: OwidVariableWithSourceAndDimension
 ): [Map<string, string>, OwidColumnDef] | [] => {
     if (variable.display?.entityAnnotationsMap) {
-        const slug = makeAnnotationsSlug(variable.id.toString())
+        const slug = variable.id.toString()
+        const annotationsSlug = makeAnnotationsSlug(slug)
         const annotationMap = annotationsToMap(
             variable.display.entityAnnotationsMap
         )
-        const columnDef = {
-            slug,
+        const columnDef: OwidColumnDef = {
+            slug: annotationsSlug,
             type: ColumnTypeNames.SeriesAnnotation,
-            name: slug,
-            display: {
-                includeInTable: false,
-            },
+            name: annotationsSlug,
+            display: { includeInTable: false },
+            derivedFrom: { columnSlug: slug, relationship: "annotations" },
         }
         return [annotationMap, columnDef]
     }

--- a/packages/@ourworldindata/types/src/domainTypes/CoreTableTypes.ts
+++ b/packages/@ourworldindata/types/src/domainTypes/CoreTableTypes.ts
@@ -198,6 +198,15 @@ export interface CoreColumnDef extends ColumnColorScale {
     tolerance?: number // If set, some charts can use this for an interpolation strategy.
     toleranceStrategy?: ToleranceStrategy // Tolerance strategy to use for interpolation
     skipParsing?: boolean // If set, the values will never run through the type parser
+    // Denotes the relationship of this column to another column
+    derivedFrom?: {
+        columnSlug: ColumnSlug
+        relationship:
+            | "annotations"
+            | "originalTime"
+            | "originalStartTime"
+            | "originalValue"
+    }
 
     // Column information used for display only
     name?: string // The display name for the column

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -331,9 +331,6 @@ export const cagr = (
     )
 }
 
-export const makeAnnotationsSlug = (columnSlug: string): string =>
-    `${columnSlug}-annotations`
-
 // Take an arbitrary string and turn it into a nice url slug
 export const slugify = (str: string, allowSlashes?: boolean): string => {
     // Convert subscript and superscript numbers to regular numbers

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -25,7 +25,6 @@ export {
     previous,
     domainExtent,
     cagr,
-    makeAnnotationsSlug,
     slugify,
     slugifySameCase,
     guid,


### PR DESCRIPTION
Cleans up downloaded CSV files.

- Resolves https://github.com/owid/owid-grapher/issues/5645
- Resolves https://github.com/owid/owid-grapher/issues/5773
- Resolves https://github.com/owid/owid-grapher/issues/4595

Columns in downloaded CSV files:
- Entity: always present
- Code: always present (but might be empty if no code exists)
- Year or Day: always present
- Data columns: x, y, color, size (e.g. 'Life expectancy')
- Original time columns for each data column (e.g. 'Life expectancy (Original time)' (only original times that differ from the current time are listed)
    - If there's only a single y-column, then the original time column is just used as 'Year'/'Day' column
- Entity annotations column (if exists)

Notable changes:
- The full data table for download used to be `inputTable`, now it's `table`. Given that the author might have excluded certain times and entities for good reason, this seems more sensible to me
- The column name (if not short) used to be `column.name` but now is `col.nonEmptyDisplayName` since that's typically a bit nicer and corresponds to the names used in the chart
    - For original time colunns, the suffix '(Original Year/Day)' is added
    - For annotations columns, the suffix '(Annotations)' is added
    - For projections, the suffix '(Projected)' is added
    - For columns with a specified target time, the suffix 'in XXXX' is added
- I added a few sentences to the README that explains the Original time columns and the concept of tolerance 