### PR TITLE
fix: make religion charts indexable and update tag

### DIFF
--- a/db/migration/1767981403635-makeReligionChartsIndexable.ts
+++ b/db/migration/1767981403635-makeReligionChartsIndexable.ts
@@ -1,0 +1,41 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class MakeReligionChartsIndexable1767981403635
+    implements MigrationInterface
+{
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        // Set Religion tag (1862) parent to "Living Conditions, Community and Wellbeing" (1835)
+        await queryRunner.query(`-- sql
+            UPDATE tags
+            SET parentId = 1835
+            WHERE id = 1862`)
+
+        // Make all charts tagged with Religion indexable
+        await queryRunner.query(`-- sql
+            UPDATE charts
+            SET isIndexable = 1
+            WHERE id IN (
+                SELECT chartId
+                FROM chart_tags
+                WHERE tagId = 1862
+            )`)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        // Revert Religion tag parent to NULL
+        await queryRunner.query(`-- sql
+            UPDATE tags
+            SET parentId = NULL
+            WHERE id = 1862`)
+
+        // Revert charts back to not indexable
+        await queryRunner.query(`-- sql
+            UPDATE charts
+            SET isIndexable = 0
+            WHERE id IN (
+                SELECT chartId
+                FROM chart_tags
+                WHERE tagId = 1862
+            )`)
+    }
+}


### PR DESCRIPTION
## Context

This PR adds a database migration to make religion charts indexable by search engines. It updates the Religion tag (ID 1862) to be a child of the "Living Conditions, Community and Wellbeing" tag (ID 1835) and sets all charts tagged with Religion to be indexable.

It does not make any changes to the tag graph, this PR only alters the deprecated tag structure, which is still driving the indexability of charts.

This is to address https://github.com/owid/owid-grapher/issues/5901 (short term)

More context in this [slack discussion](https://owid.slack.com/archives/C0900K216RG/p1767828782485239).