### PR TITLE
✨ db migration: fill missing entity codes from regions.json

### DIFF
--- a/db/migration/1767980196000-FillEntityCodesFromRegions.ts
+++ b/db/migration/1767980196000-FillEntityCodesFromRegions.ts
@@ -49,7 +49,9 @@ export class FillEntityCodesFromRegions1767980196000
                 )
                 existingCodeSet.add(code) // Track newly added codes
                 updatedCount++
-                console.log(`Updated entity "${entity.name}" with code "${code}"`)
+                console.log(
+                    `Updated entity "${entity.name}" with code "${code}"`
+                )
             }
         }
 


### PR DESCRIPTION
## Summary

- We're missing some entity codes because those entities existed way before continent codes were a thing
- Adds a migration that fills in missing `code` values in the `entities` table using data from `regions.json`
- Some entities (e.g., Africa, Europe, Asia, continents, income groups, WHO/UN/WB regions) had `null` codes even though they exist in `regions.json` with proper codes
- The migration skips entities where the code already exists in another entity to avoid duplicate key errors

**Results from running locally:**
- Updated 58 entities with codes
- Skipped 4 entities where the code was already in use (e.g., "Kingdom of Bavaria" skipped because "Bavaria" already has `OWID_BAV`)

## Test plan

- [x] Run `make migrate` locally - migration applied successfully
- [x] Verify entities like Africa now have codes: `SELECT * FROM entities WHERE name = 'Africa'` shows `code = 'OWID_AFR'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)