### PR TITLE
search api: include timestamps in openapi docs

### DIFF
--- a/docs/search-api.openapi.yaml
+++ b/docs/search-api.openapi.yaml
@@ -320,12 +320,12 @@ components:
                         - "Marimekko"
                 publishedAt: 
                     type: string
-                    format: date
+                    format: date-time
                     description: Publication date of the chart (ISO 8601 format)
                     example: "2016-05-03T21:44:14.000Z"
                 updatedAt:
                     type: string
-                    format: date
+                    format: date-time
                     description: Last update date of the chart (ISO 8601 format)
                     example: "2025-12-20T15:23:24.000Z"
                 url:
@@ -397,12 +397,12 @@ components:
                     example: "https://ourworldindata.org/images/co2-thumbnail.jpg"
                 date:
                     type: string
-                    format: date
+                    format: date-time
                     description: Publication of the article (ISO 8601 format)
                     example: "2024-09-30T08:57:00.000Z"
                 modifiedDate:
                     type: string
-                    format: date
+                    format: date-time
                     description: Last update date (ISO 8601 format)
                     example: "2025-08-21T15:57:34.000Z"
                 content:


### PR DESCRIPTION
Include missing timestamp fields in openapi documentation.