### PR TITLE
✨ disable timeline animation for some chart types

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/GrapherState.test.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.test.ts
@@ -576,6 +576,30 @@ describe("urls", () => {
         expect(grapher.activeTab).toEqual(GRAPHER_TAB_NAMES.WorldMap)
         expect(grapher.timelineHandleTimeBounds).toEqual([Infinity, Infinity])
     })
+
+    it("stops animation when switching to a tab where playback is disabled", () => {
+        const grapher = new GrapherState({
+            chartTypes: [
+                GRAPHER_CHART_TYPES.LineChart,
+                GRAPHER_CHART_TYPES.SlopeChart,
+            ],
+        })
+
+        // Animations are enabled for the default line chart tab
+        expect(grapher.disablePlay).toBe(false)
+
+        // Play the animation
+        void grapher.timelineController.play()
+
+        // Switch to the slope tab (where timeline animation is disabled)
+        const previousTab = grapher.activeTab
+        grapher.setTab(GRAPHER_TAB_NAMES.SlopeChart)
+        grapher.onTabChange(previousTab, GRAPHER_TAB_NAMES.SlopeChart)
+
+        // Animation should be stopped
+        expect(grapher.disablePlay).toBe(true)
+        expect(grapher.isTimelineAnimationPlaying).toBe(false)
+    })
 })
 
 describe("time domain tests", () => {

--- a/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
@@ -1789,6 +1789,11 @@ export class GrapherState
 
         this.ensureTimeHandlesAreSensibleForTab(newTab)
         this.ensureEntitySelectionIsSensibleForTab(newTab)
+
+        // Stop animation when switching to a tab where playback is disabled
+        if (this.disablePlay && this.isTimelineAnimationActive) {
+            this.timelineController.stop()
+        }
     }
 
     @action.bound syncEntitySelectionBetweenChartAndMap(
@@ -3668,7 +3673,9 @@ export class GrapherState
     }
 
     @computed get disablePlay(): boolean {
-        return false
+        return (
+            this.isOnTableTab || this.isOnSlopeChartTab || this.isOnMarimekkoTab
+        )
     }
 
     @computed get animationEndTime(): Time {

--- a/packages/@ourworldindata/grapher/src/timeline/TimelineController.ts
+++ b/packages/@ourworldindata/grapher/src/timeline/TimelineController.ts
@@ -329,7 +329,7 @@ export class TimelineController {
         this.updateEndTime(prevTime)
     }
 
-    @action.bound private stop(): void {
+    @action.bound stop(): void {
         this.manager.isTimelineAnimationPlaying = false
         this.manager.isTimelineAnimationActive = false
         this.manager.animationStartTime = undefined


### PR DESCRIPTION
Disabling chart animations for the worst offenders (table, slope, marimekko)