### PR TITLE
🐛 show right trend arrow when rounded to the same value

### DIFF
--- a/functions/_common/search/constructSearchResultDataTableContent.ts
+++ b/functions/_common/search/constructSearchResultDataTableContent.ts
@@ -253,14 +253,24 @@ function buildDataTableContentForSlopeChart({
                 series.column.nonEmptyDisplayName
             ) ?? series.color
 
+        const formattedStartValue = formatColumn.formatValueShort(start.value)
+        const formattedEndValue = formatColumn.formatValueShort(end.value)
+
+        const trend =
+            // If both labels are the same, trivially show a right arrow
+            formattedStartValue && formattedStartValue === formattedEndValue
+                ? "right"
+                : // Otherwise, calculate based on numeric values
+                  calculateTrendDirection(start.value, end.value)
+
         return {
             seriesName: series.seriesName,
             label: series.displayName,
             endValue: series.end.value,
             color,
-            value: formatColumn.formatValueShort(end.value),
-            startValue: formatColumn.formatValueShort(start.value),
-            trend: calculateTrendDirection(start.value, end.value),
+            value: formattedEndValue,
+            startValue: formattedStartValue,
+            trend,
             time: `${formattedStartTime}–${formattedEndTime}`,
             timePreposition: "",
             muted: series.focus.background,

--- a/packages/@ourworldindata/utils/src/search/SearchHelpers.ts
+++ b/packages/@ourworldindata/utils/src/search/SearchHelpers.ts
@@ -60,10 +60,15 @@ export function buildChartHitDataDisplayProps({
     const time = startDatapoint?.formattedTime
         ? `${startDatapoint?.formattedTime}–${endDatapoint.formattedTime}`
         : endDatapoint.formattedTime
-    const trend = calculateTrendDirection(
-        startDatapoint?.value,
-        endDatapoint?.value
-    )
+    const trend =
+        // If both labels are the same, trivially show a right arrow
+        startValue !== undefined && startValue === endValue
+            ? "right"
+            : // Otherwise, calculate based on numeric values
+              calculateTrendDirection(
+                  startDatapoint?.value,
+                  endDatapoint?.value
+              )
     const showLocationIcon =
         isEntityPickedByUser && getRegionByName(entity) !== undefined
 


### PR DESCRIPTION
To prevent up/down arrows where values are rounded to the same value:

<img width="1291" height="284" alt="Screenshot 2026-01-12 at 13 52 48" src="https://github.com/user-attachments/assets/31d54825-d047-411b-b894-c1f0147aa885" />
