### PR TITLE
Add create-migration Claude skill

### DIFF
--- a/.claude/skills/create-migration/SKILL.md
+++ b/.claude/skills/create-migration/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: create-migration
+description: Create a new database migration file for the OWID MySQL database. Use when the user needs to create a database schema change or migration.
+---
+
+# Create Database Migration
+
+Create a new database migration file for the OWID MySQL 8 database.
+
+## Steps
+
+1. Run `yarn createDbMigration db/migration/<NewMigrationName>` where `<NewMigrationName>` is a descriptive name for the migration
+2. The generated filename will contain a timestamp prefix, so scan the `db/migration/` directory to find the actual path of the new file
+3. Report the new file path to the user
+
+## Naming Guidelines
+
+Choose a descriptive name for the migration that clearly indicates what schema change is being made (e.g., `AddUserEmailIndex`, `CreateAuditLogTable`, `RemoveDeprecatedColumns`).

--- a/.codex/skills
+++ b/.codex/skills
@@ -1,0 +1,1 @@
+../.claude/skills

--- a/db/CLAUDE.md
+++ b/db/CLAUDE.md
@@ -1,6 +1,6 @@
 This folder contains the database access code for the OWID admin. The database used is MySQL 8.
 
-The migration subfolder contains the pre-migrations-schema.sql file that describes the original Mysql database schema ca 2018. Building on this state, the various \*.ts files describe the migrations since then (the filenames are prefixed by unix timestamp so can be listed alphabetically to see the correct order). To create new migrations, run the `yarn createDbMigration db/migration/<NewMigrationName>` which will create a new migration file. Choose a descriptive name for the migration. The generated filename will contain a timestamp, so you have to scan the directory to know the actual path of the new file.
+The migration subfolder contains the pre-migrations-schema.sql file that describes the original Mysql database schema ca 2018. Building on this state, the various \*.ts files describe the migrations since then (the filenames are prefixed by unix timestamp so can be listed alphabetically to see the correct order). To create new migrations, use the `create-migration` skill.
 
 The model folder contains helper functions to query most tables (not all tables are used by the Grapher admin - some are used by auxiliary systems). The most complex models are those related to our GDocs based CMS, represented in the posts_gdocs table. The related model classes are in the model/GDoc subfolder and contain substantial business logic and a class hierarchy.
 


### PR DESCRIPTION
And symlink it also for Codex. They share the same definition, but not the same location. Opencode also finds the skill.

I find that models usually don't use the script to create a migration and I'm hoping this will increase the chance and is probably a better way to specify it.
