### PR TITLE
🔨 (core table) improve type safety

### DIFF
--- a/packages/@ourworldindata/core-table/src/index.ts
+++ b/packages/@ourworldindata/core-table/src/index.ts
@@ -17,7 +17,7 @@ export {
     TimeColumn,
 } from "./CoreTableColumns.js"
 
-export { OwidTable, BlankOwidTable } from "./OwidTable.js"
+export { OwidTable, BlankOwidTable, type OwidColumn } from "./OwidTable.js"
 
 export {
     DroppedForTesting,


### PR DESCRIPTION
Improve type safety of CoreTable and OwidTable and cleans up the boundary between the two.

- The CoreTable's column storage is now typed
- Generic/Non-owid methods are moved from OwidTable to CoreTable: dropRowsWithErrorValuesForAnyColumn, dropRowsWithErrorValuesForAllColumns
- Entity methods are moved from CoreTable to OwidTable
    - Comment in the code suggest to also move time-related stuff to OwidTable, but I haven't done that