### PR TITLE
🐛 fix missing country param in archive url

### DIFF
--- a/packages/@ourworldindata/explorer/src/Explorer.test.ts
+++ b/packages/@ourworldindata/explorer/src/Explorer.test.ts
@@ -60,6 +60,32 @@ describe(Explorer, () => {
             "Relative to world total": "false",
         })
     })
+
+    it("includes country param in archived embed URL after switching views", async () => {
+        const explorer = SampleExplorerOfGraphers({
+            queryStr: "?country=~GBR",
+            archiveContext: {
+                type: "archived-page-version",
+                archiveUrl: "https://archive.org/example",
+                archivalDate: "20240101-000000",
+            },
+        })
+
+        await explorer.componentDidMount()
+
+        // Verify initial state has country param
+        expect(explorer.grapherState.changedParams.country).toEqual("~GBR")
+        const initialUrl = explorer.grapherState.embedArchivedUrl
+        expect(initialUrl).toContain("country=~GBR")
+
+        // Switch to a different view
+        await explorer.onChangeChoice("Gas")("All GHGs (CO₂eq)")
+
+        // Verify country param is still present after switching
+        expect(explorer.grapherState.changedParams.country).toEqual("~GBR")
+        const afterSwitchUrl = explorer.grapherState.embedArchivedUrl
+        expect(afterSwitchUrl).toContain("country=~GBR")
+    })
 })
 
 describe("inline data explorer", () => {

--- a/packages/@ourworldindata/explorer/src/Explorer.tsx
+++ b/packages/@ourworldindata/explorer/src/Explorer.tsx
@@ -413,7 +413,14 @@ export class Explorer
         // will reset and initialize the grapherState and then the data loading will be awaited inside the function.
         // We don't want to wait for the data loading to finish as we only care about the non-data loading
         // part to run (the data loading can finish whenever)
+
+        // Preserve selection before updateGrapherFromExplorer, as it calls reset() which clears the shared selection array
+        const preservedSelection = this.selection.selectedEntityNames.slice()
+
         void this.updateGrapherFromExplorer()
+
+        // Restore selection after reset
+        this.selection.setSelectedEntities(preservedSelection)
 
         // Do the rest of the initialization
         this.grapherState.populateFromQueryParams(url.queryParams)
@@ -510,12 +517,18 @@ export class Explorer
 
         const previousTab = this.grapherState.activeTab
 
+        // Preserve selection before updateGrapherFromExplorer, as it calls reset() which clears the shared selection array
+        const preservedSelection = this.selection.selectedEntityNames.slice()
+
         await this.updateGrapherFromExplorer()
+
+        // Restore selection after reset
+        this.selection.setSelectedEntities(preservedSelection)
 
         newGrapherParams.tab =
             this.grapherState.mapGrapherTabToQueryParam(previousTab)
 
-        // reset map state if switching to a chart
+        // Reset map state if switching to a chart
         if (newGrapherParams.tab !== GRAPHER_TAB_QUERY_PARAMS.map) {
             newGrapherParams.globe = "0"
             newGrapherParams.mapSelect = ""
@@ -597,11 +610,6 @@ export class Explorer
             enableMapSelection: this.enableMapSelection,
         }
 
-        // if not empty, respect the explorer's selection
-        if (this.selection.hasSelection) {
-            config.selectedEntityNames = this.selection.selectedEntityNames
-        }
-
         grapherState.setAuthoredVersion(config)
         grapherState.reset()
         grapherState.inputTable = BlankOwidTable()
@@ -658,11 +666,6 @@ export class Explorer
             adminBaseUrl: this.adminBaseUrl,
             hideEntityControls: this.showExplorerControls,
             enableMapSelection: this.enableMapSelection,
-        }
-
-        // If not empty, respect the explorer's selection
-        if (this.selection.hasSelection) {
-            config.selectedEntityNames = this.selection.selectedEntityNames
         }
 
         // Indicator-based explorers support two types of dimensions for creating charts:
@@ -829,11 +832,6 @@ export class Explorer
             adminBaseUrl: this.adminBaseUrl,
             hideEntityControls: this.showExplorerControls,
             enableMapSelection: this.enableMapSelection,
-        }
-
-        // if not empty, respect the explorer's selection
-        if (this.selection.hasSelection) {
-            config.selectedEntityNames = this.selection.selectedEntityNames
         }
 
         grapherState.setAuthoredVersion(config)


### PR DESCRIPTION
Fixes #5898

When switching between explorer views, the archived embed URL would lose the country parameter, even though the regular embed URL preserved it correctly.

The updateGrapherFromExplorer methods were adding selectedEntityNames to the config passed to setAuthoredVersion(). This made the selection part of the authored config, so GrapherState's areSelectedEntitiesDifferentThanAuthors returned false, excluding the country parameter from changedParams and thus from the archived embed URL.

Don't know if there's a better way?