### PR TITLE
🐛 (analytics) circumvent truncated grapher slugs

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/GrapherAnalytics.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherAnalytics.ts
@@ -43,9 +43,11 @@ export class GrapherAnalytics {
         slug: string,
         ctx?: { viewConfigId?: string; narrativeChartName?: string }
     ): void {
+        const { path, pathNext } = splitPathForGA4(`/grapher/${slug}`)
         this.logToGA({
             event: EventCategory.GrapherView,
-            grapherPath: `/grapher/${slug}`,
+            grapherPath: path,
+            grapherPathNext: pathNext,
             viewConfigId: ctx?.viewConfigId,
             narrativeChartName: ctx?.narrativeChartName,
         })
@@ -129,11 +131,15 @@ export class GrapherAnalytics {
             narrativeChartName?: string
         }
     ): void {
+        const { path, pathNext } = splitPathForGA4(
+            getPathname(ctx.grapherUrl) ?? ""
+        )
         this.logToGA({
             event: EventCategory.GrapherClick,
             eventAction: action,
             eventTarget: ctx.label,
-            grapherPath: getPathname(ctx.grapherUrl),
+            grapherPath: path,
+            grapherPathNext: pathNext,
             narrativeChartName: ctx.narrativeChartName,
         })
     }
@@ -207,12 +213,24 @@ function getPathname(url?: string): string | undefined {
         return undefined
     }
 }
+// GA4 truncates all string parameters at 100 characters.
+// If path exceeds this, split into path (first 100 chars) and pathNext (chars 101-200)
+export function splitPathForGA4(path: string): {
+    path: string
+    pathNext?: string
+} {
+    if (path.length <= 100) return { path }
+    return { path: path.slice(0, 100), pathNext: path.slice(100) }
+}
 
 function grapherAnalyticsContextToGAEventFields(
     ctx: GrapherAnalyticsContext
 ): Partial<GAEvent> {
+    const fullPath = ctx.slug ? `/grapher/${ctx.slug}` : undefined
+    const { path, pathNext } = splitPathForGA4(fullPath ?? "")
     return {
-        grapherPath: ctx.slug ? `/grapher/${ctx.slug}` : undefined,
+        grapherPath: path,
+        grapherPathNext: pathNext,
         viewConfigId: ctx.viewConfigId,
         narrativeChartName: ctx.narrativeChartName,
     }

--- a/packages/@ourworldindata/grapher/src/index.ts
+++ b/packages/@ourworldindata/grapher/src/index.ts
@@ -65,7 +65,7 @@ export {
     type GrapherManager,
 } from "./core/Grapher"
 export { GrapherState } from "./core/GrapherState"
-export { GrapherAnalytics } from "./core/GrapherAnalytics"
+export { GrapherAnalytics, splitPathForGA4 } from "./core/GrapherAnalytics"
 export { legacyToCurrentGrapherUrl } from "./core/GrapherUrlMigrations"
 export {
     legacyToOwidTableAndDimensions,

--- a/packages/@ourworldindata/types/src/analyticsTypes/analyticsTypes.ts
+++ b/packages/@ourworldindata/types/src/analyticsTypes/analyticsTypes.ts
@@ -165,6 +165,8 @@ export interface SiteGuidedChartLinkClickParams {
     eventAction: "click"
     /** Target URL or chart path */
     eventTarget: string
+    /** Continuation of eventTarget for URLs > 100 chars (characters 101-200) */
+    eventTargetNext?: string
     /** Grapher path of the linked chart (optional - may use eventTarget instead) */
     grapherPath?: string
 }
@@ -174,6 +176,8 @@ export interface SiteChartPreviewMouseoverParams {
     eventAction: "mouseover"
     /** Target chart URL */
     eventTarget: string
+    /** Continuation of eventTarget for URLs > 100 chars (characters 101-200) */
+    eventTargetNext?: string
     /** Explorer path if in explorer */
     explorerPath?: string
     /** Grapher path being previewed */
@@ -184,7 +188,9 @@ export interface SiteChartPreviewMouseoverParams {
 
 export interface GrapherViewParams {
     /** Grapher chart path (e.g., '/grapher/life-expectancy') */
-    grapherPath: string
+    grapherPath?: string
+    /** Continuation of grapherPath for URLs > 100 chars (characters 101-200) */
+    grapherPathNext?: string
     /** View configuration ID for multi-dimensional data pages */
     viewConfigId?: string
     /** Name of the narrative chart if embedded */
@@ -196,6 +202,8 @@ export interface GrapherClickParams {
     eventAction: GrapherImageDownloadEvent | string
     /** Grapher chart path */
     grapherPath?: string
+    /** Continuation of grapherPath for URLs > 100 chars (characters 101-200) */
+    grapherPathNext?: string
     /** View configuration ID */
     viewConfigId?: string
     /** Name of narrative chart */
@@ -211,6 +219,8 @@ export interface GrapherHoverParams {
     eventAction: GrapherInteractionEvent
     /** Grapher chart path */
     grapherPath?: string
+    /** Continuation of grapherPath for URLs > 100 chars (characters 101-200) */
+    grapherPathNext?: string
     /** View configuration ID */
     viewConfigId?: string
     /** Name of narrative chart */
@@ -226,6 +236,8 @@ export interface GrapherErrorParams {
     eventContext: string
     /** Grapher chart path */
     grapherPath?: string
+    /** Continuation of grapherPath for URLs > 100 chars (characters 101-200) */
+    grapherPathNext?: string
     /** View configuration ID */
     viewConfigId?: string
     /** Name of narrative chart */
@@ -237,6 +249,8 @@ export interface GrapherEntitySelectorParams {
     eventAction: EntitySelectorEvent
     /** Grapher chart path */
     grapherPath?: string
+    /** Continuation of grapherPath for URLs > 100 chars (characters 101-200) */
+    grapherPathNext?: string
     /** View configuration ID */
     viewConfigId?: string
     /** Name of narrative chart */

--- a/site/SiteAnalytics.ts
+++ b/site/SiteAnalytics.ts
@@ -1,5 +1,5 @@
 import * as _ from "lodash-es"
-import { GrapherAnalytics } from "@ourworldindata/grapher"
+import { GrapherAnalytics, splitPathForGA4 } from "@ourworldindata/grapher"
 import { EventCategory } from "@ourworldindata/types"
 import {
     type SearchChartHit,
@@ -140,18 +140,22 @@ export class SiteAnalytics extends GrapherAnalytics {
     }
 
     logGuidedChartLinkClick(url: string) {
+        const { path: target, pathNext: targetNext } = splitPathForGA4(url)
         this.logToGA({
             event: EventCategory.SiteGuidedChartLinkClick,
             eventAction: "click",
-            eventTarget: url,
+            eventTarget: target,
+            eventTargetNext: targetNext,
         })
     }
 
     logChartPreviewMouseover(chartUrl: string) {
+        const { path: target, pathNext: targetNext } = splitPathForGA4(chartUrl)
         this.logToGA({
             event: EventCategory.SiteChartPreviewMouseover,
             eventAction: "mouseover",
-            eventTarget: chartUrl,
+            eventTarget: target,
+            eventTargetNext: targetNext,
         })
     }
 


### PR DESCRIPTION
Resolves #5860

Adds `grapherPathNext` to send along the rest of the slug if `grapherPath` is truncated after 100 characters