### PR TITLE
🐛 disable time line animation for less than 3 time points

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
@@ -3675,7 +3675,10 @@ export class GrapherState
 
     @computed get disablePlay(): boolean {
         return (
-            this.isOnTableTab || this.isOnSlopeChartTab || this.isOnMarimekkoTab
+            this.isOnTableTab ||
+            this.isOnSlopeChartTab ||
+            this.isOnMarimekkoTab ||
+            (this.times.length > 0 && this.times.length <= 2)
         )
     }
 


### PR DESCRIPTION
The timeline animation doesn’t work for 2 time points. I don’t think it makes sense to fix it because an animation with a single step is not meaningful