### PR TITLE
🐛 (thumbnail) fix incorrectly placed dot

### DIFF
--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChartThumbnail.tsx
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChartThumbnail.tsx
@@ -133,7 +133,9 @@ export class LineChartThumbnail
                     // Only show start points for historical series, not projected ones
                     !series.isProjection
             )
-            .map((series) => _.minBy(series.placedPoints, (point) => point.x))
+            .map((series) =>
+                _.minBy(series.placedPoints, (point) => point.time)
+            )
             .filter((point) => point !== undefined)
     }
 
@@ -147,7 +149,9 @@ export class LineChartThumbnail
                     // for the projected series. Otherwise, show end dots for all series
                     (!this.hasProjectedSeries || series.isProjection)
             )
-            .map((series) => _.maxBy(series.placedPoints, (point) => point.x))
+            .map((series) =>
+                _.maxBy(series.placedPoints, (point) => point.time)
+            )
             .filter((point) => point !== undefined)
     }
 


### PR DESCRIPTION
Fixes https://ourworldindata.org/search?q=carbon+dioxide&resultType=all

For long time series the x rounds to the same value for different times

<img width="720" height="164" alt="image" src="https://github.com/user-attachments/assets/82ebccad-a5db-4dd9-8396-f0bcb2756050" />
