### PR TITLE
🐛 (map tooltip) fix duplicate react keys

### DIFF
--- a/packages/@ourworldindata/grapher/src/axis/Axis.ts
+++ b/packages/@ourworldindata/grapher/src/axis/Axis.ts
@@ -321,22 +321,21 @@ abstract class AbstractAxis {
         if (this.config.ticks) {
             // If custom ticks are supplied, use them without any transformations or additions.
             const [minValue, maxValue] = d3_scale.domain()
-            return (
-                this.config.ticks
-                    // replace ±Infinity with minimum/maximum
-                    .map((tick) => {
-                        if (tick.value === -Infinity)
-                            return { ...tick, value: minValue }
-                        if (tick.value === Infinity)
-                            return { ...tick, value: maxValue }
-                        return tick
-                    })
-                    // filter out custom ticks outside the plottable area
-                    .filter(
-                        (tick) =>
-                            tick.value >= minValue && tick.value <= maxValue
-                    )
-            )
+            const processedTicks = this.config.ticks
+                // replace ±Infinity with minimum/maximum
+                .map((tick) => {
+                    if (tick.value === -Infinity)
+                        return { ...tick, value: minValue }
+                    if (tick.value === Infinity)
+                        return { ...tick, value: maxValue }
+                    return tick
+                })
+                // filter out custom ticks outside the plottable area
+                .filter(
+                    (tick) => tick.value >= minValue && tick.value <= maxValue
+                )
+
+            return _.uniqBy(processedTicks, (tick) => tick.value)
         } else if (this.isLogScale) {
             // Show a bit more ticks for log axes
             const maxLabelledTicks = Math.round(this.totalTicksTarget * 1.25)

--- a/packages/@ourworldindata/grapher/src/axis/AxisViews.tsx
+++ b/packages/@ourworldindata/grapher/src/axis/AxisViews.tsx
@@ -49,11 +49,14 @@ export class VerticalAxisGridLines extends React.Component<VerticalAxisGridLines
                           : TICK_COLOR
                     const dasharray = this.props.dashPattern ?? "4,4"
 
+                    const className = t.value === 0 ? "zero-line" : undefined
+
                     return (
                         <line
                             id={makeIdForHumanConsumption(
                                 verticalAxis.formatTick(t.value)
                             )}
+                            className={className}
                             key={t.value}
                             x1={bounds.left.toFixed(2)}
                             y1={axis.place(t.value)}

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapTooltip.scss
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapTooltip.scss
@@ -21,8 +21,7 @@
                 stroke: $gray-30;
             }
 
-            // the zero line
-            line:nth-child(2) {
+            line.zero-line {
                 stroke: #787878;
             }
         }


### PR DESCRIPTION
Fixes duplicate react keys in map sparkline