### PR TITLE
Remove sessionCookieAuthMiddleware

### DIFF
--- a/adminSiteServer/appClass.tsx
+++ b/adminSiteServer/appClass.tsx
@@ -10,7 +10,6 @@ import {
     cloudflareAuthMiddleware,
     tailscaleAuthMiddleware,
     devAuthMiddleware,
-    sessionCookieAuthMiddleware,
     requireAdminAuthMiddleware,
 } from "./authentication.js"
 import { apiRouter } from "./apiRouter.js"
@@ -66,7 +65,6 @@ export class OwidAdminApp {
 
         app.use(express.urlencoded({ extended: true, limit: "50mb" }))
 
-        app.use("/admin", sessionCookieAuthMiddleware)
         app.use("/admin", apiKeyAuthMiddleware)
 
         if (ENV === "staging") {

--- a/db/docs/sessions.yml
+++ b/db/docs/sessions.yml
@@ -1,9 +1,0 @@
-metadata:
-    description: User session management table for the OWID admin interface authentication system. Stores session data for logged-in users to maintain authentication state across requests. Uses Django-style session management with session keys, serialized data, and expiration timestamps.
-fields:
-    session_key:
-        description: Primary key. Unique session identifier token (40 characters) that identifies the user session.
-    session_data:
-        description: Serialized session data containing user authentication information and session variables. Stored as longtext to accommodate varying amounts of session data.
-    expire_date:
-        description: Timestamp when the session expires and should be considered invalid. Sessions past this date are automatically cleaned up.

--- a/db/exportMetadata.ts
+++ b/db/exportMetadata.ts
@@ -16,7 +16,7 @@ import { execWrapper } from "./execWrapper.js"
 const argv = parseArgs(process.argv.slice(2))
 const filePath = argv._[0] || "/tmp/owid_metadata.sql"
 
-const excludeTables = ["analytics_pageviews", "donors", "sessions"]
+const excludeTables = ["analytics_pageviews", "donors"]
 
 async function dataExport(): Promise<void> {
     console.log(`Exporting database structure and metadata to ${filePath}...`)

--- a/db/migration/1768915812013-RemoveSessionsTable.ts
+++ b/db/migration/1768915812013-RemoveSessionsTable.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class RemoveSessionsTable1768915812013 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`-- sql
+            DROP TABLE IF EXISTS sessions;
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`-- sql
+            CREATE TABLE sessions (
+                session_key varchar(40) NOT NULL,
+                session_data longtext NOT NULL,
+                expire_date datetime NOT NULL,
+                PRIMARY KEY (session_key),
+                KEY django_session_expire_date_a5c62663 (expire_date)
+            );
+        `)
+    }
+}

--- a/packages/@ourworldindata/types/src/dbTypes/Sessions.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/Sessions.ts
@@ -1,1 +1,0 @@
-export const SessionsTableName = "sessions"

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -768,7 +768,6 @@ export {
     type DbInsertPostTag,
     PostTagsTableName,
 } from "./dbTypes/PostTags.js"
-export { SessionsTableName } from "./dbTypes/Sessions.js"
 export {
     AdminApiKeysTableName,
     type DbAdminApiKey,


### PR DESCRIPTION
Nothing should be using it anymore after the ETL migrated to the new API key auth.

## Context

Follow up to #5906

## Checklist

- [x] The DB type definitions have been updated
- [x] The DB types in the ETL have been updated
- [x] If tables/views were added/removed, the Datasette export has been updated to take this into account
- [x] Update the documentation in db/docs

FYI @Marigold 