### PR TITLE
Exclude featured metric records from general chart search

### DIFF
--- a/site/search/queries.ts
+++ b/site/search/queries.ts
@@ -142,6 +142,8 @@ export async function queryCharts(
             attributesToRetrieve: DATA_CATALOG_ATTRIBUTES,
             query: state.query,
             facetFilters: facetFilters,
+            // Exclude featured metric records (score > 10000) from general chart queries
+            filters: "score <= 10000",
             highlightPreTag: "<mark>",
             highlightPostTag: "</mark>",
             hitsPerPage: 9,


### PR DESCRIPTION
discussed in https://github.com/owid/owid-grapher/issues/6016 as an alternative

 ## Summary                                                                                                                        
  - Adds a score filter (`score <= 10000`) to `queryCharts` to exclude featured metric records                                      
  - Featured metrics have artificially boosted scores to promote them in topic-based searches (`queryDataTopics`)                   
  - In general chart search, these boosted scores cause featured metrics to rank above more relevant results                        
                                                                                                                                    
  ## Test plan                                                                                                                      
  - [ ] Verify general chart search results no longer show featured metric records ranking above relevant results                   
  - [ ] Verify topic-based searches (`queryDataTopics`) still surface featured metrics as expected  