### PR TITLE
feat: add dataset filters to featured metrics component

### DIFF
--- a/db/model/Gdoc/enrichedToMarkdown.ts
+++ b/db/model/Gdoc/enrichedToMarkdown.ts
@@ -575,9 +575,19 @@ ${links}`
                 .filter((item) => item !== "")
                 .join("\n")
         })
-        .with({ type: "featured-metrics" }, (_): string | undefined =>
-            markdownComponent("FeaturedMetrics", {}, exportComponents)
-        )
+        .with({ type: "featured-metrics" }, (b): string | undefined => {
+            const serializeFilters = (values: string[]): string | undefined =>
+                values.length ? values.join("~") : undefined
+            return markdownComponent(
+                "FeaturedMetrics",
+                {
+                    datasetProducts: serializeFilters(b.datasetProducts),
+                    datasetNamespaces: serializeFilters(b.datasetNamespaces),
+                    datasetVersions: serializeFilters(b.datasetVersions),
+                },
+                exportComponents
+            )
+        })
         .with({ type: "featured-data-insights" }, (_): string | undefined =>
             markdownComponent("FeaturedDataInsights", {}, exportComponents)
         )

--- a/db/model/Gdoc/enrichedToRaw.ts
+++ b/db/model/Gdoc/enrichedToRaw.ts
@@ -724,13 +724,19 @@ export function enrichedBlockToRawBlock(
                 },
             }
         })
-        .with(
-            { type: "featured-metrics" },
-            (_): RawBlockFeaturedMetrics => ({
+        .with({ type: "featured-metrics" }, (b): RawBlockFeaturedMetrics => {
+            const serializeFilters = (values: string[]): string | undefined =>
+                values.length ? values.join("~") : undefined
+
+            return {
                 type: "featured-metrics",
-                value: {},
-            })
-        )
+                value: {
+                    "dataset-products": serializeFilters(b.datasetProducts),
+                    "dataset-namespaces": serializeFilters(b.datasetNamespaces),
+                    "dataset-versions": serializeFilters(b.datasetVersions),
+                },
+            }
+        })
         .with(
             { type: "featured-data-insights" },
             (_): RawBlockFeaturedDataInsights => ({

--- a/db/model/Gdoc/exampleEnrichedBlocks.ts
+++ b/db/model/Gdoc/exampleEnrichedBlocks.ts
@@ -877,6 +877,9 @@ export const enrichedBlockExamples: Record<
     },
     "featured-metrics": {
         type: "featured-metrics",
+        datasetProducts: [],
+        datasetNamespaces: [],
+        datasetVersions: [],
         parseErrors: [],
     },
     "featured-data-insights": {

--- a/db/model/Gdoc/rawToArchie.ts
+++ b/db/model/Gdoc/rawToArchie.ts
@@ -975,9 +975,12 @@ function* rawBlockHomepageIntroToArchieMLString(
 }
 
 function* rawBlockFeaturedMetricsToArchieMLString(
-    _: RawBlockFeaturedMetrics
+    block: RawBlockFeaturedMetrics
 ): Generator<string, void, undefined> {
     yield "{.featured-metrics}"
+    yield* propertyToArchieMLString("dataset-products", block.value)
+    yield* propertyToArchieMLString("dataset-namespaces", block.value)
+    yield* propertyToArchieMLString("dataset-versions", block.value)
     yield "{}"
 }
 

--- a/db/model/Gdoc/rawToEnriched.ts
+++ b/db/model/Gdoc/rawToEnriched.ts
@@ -2865,10 +2865,23 @@ function parseHomepageSearch(
 }
 
 function parseFeaturedMetrics(
-    _: RawBlockFeaturedMetrics
+    raw: RawBlockFeaturedMetrics
 ): EnrichedBlockFeaturedMetrics {
+    const parseDatasetFilterList = (rawList: string | undefined): string[] => {
+        if (!rawList) return []
+        return rawList
+            .split("~")
+            .map((entry) => entry.trim())
+            .filter(Boolean)
+    }
+
     return {
         type: "featured-metrics",
+        datasetProducts: parseDatasetFilterList(raw.value["dataset-products"]),
+        datasetNamespaces: parseDatasetFilterList(
+            raw.value["dataset-namespaces"]
+        ),
+        datasetVersions: parseDatasetFilterList(raw.value["dataset-versions"]),
         parseErrors: [],
     }
 }

--- a/packages/@ourworldindata/types/src/gdocTypes/ArchieMlComponents.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/ArchieMlComponents.ts
@@ -1066,11 +1066,18 @@ export type EnrichedBlockHomepageIntro = {
 
 export type RawBlockFeaturedMetrics = {
     type: "featured-metrics"
-    value: Record<string, never>
+    value: {
+        "dataset-products"?: string
+        "dataset-namespaces"?: string
+        "dataset-versions"?: string
+    }
 }
 
 export type EnrichedBlockFeaturedMetrics = {
     type: "featured-metrics"
+    datasetProducts: string[]
+    datasetNamespaces: string[]
+    datasetVersions: string[]
 } & EnrichedBlockWithParseErrors
 
 export type RawBlockFeaturedDataInsights = {

--- a/site/gdocs/components/ArticleBlock.tsx
+++ b/site/gdocs/components/ArticleBlock.tsx
@@ -879,27 +879,17 @@ function ArticleBlockInternal({
                 />
             )
         })
-        .with({ type: "featured-metrics" }, () => {
+        .with({ type: "featured-metrics" }, (block) => {
             const layoutClassName = getLayout("featured-metrics", containerType)
             const topicName = tags[0]?.name
-
-            if (!topicName) {
-                return (
-                    <BlockErrorFallback
-                        className={layoutClassName}
-                        error={{
-                            name: `Error in ${block.type}`,
-                            message:
-                                "Featured metrics requires at least one tag on the document.",
-                        }}
-                    />
-                )
-            }
 
             return (
                 <BlockQueryClientProvider>
                     <FeaturedMetrics
                         topicName={topicName}
+                        datasetProducts={block.datasetProducts}
+                        datasetNamespaces={block.datasetNamespaces}
+                        datasetVersions={block.datasetVersions}
                         className={layoutClassName}
                     />
                 </BlockQueryClientProvider>

--- a/site/search/queries.ts
+++ b/site/search/queries.ts
@@ -158,7 +158,7 @@ export async function queryCharts(
         ...datasetNamespaceFacetFilters,
         ...datasetVersionFacetFilters,
         ...datasetProducerFacetFilters,
-    ]
+    ].filter((filter) => !Array.isArray(filter) || filter.length > 0)
 
     const searchParams = [
         {


### PR DESCRIPTION
## Context

This PR adds filtering capabilities to the Featured Metrics block, with the intent of using it outside of linear topic pages. It allows filtering metrics by dataset products, namespaces, and versions (in addition to the topic tag inherited when placed in a linear topic page context).

This PR also changes the "missing tag for featured metrics block" error:
- before: shown in-situ (with FM block hidden if tag missing on the document)
- after: shown as a validation error in the settings drawer in the admin

## Testing guidance

1. Create an ArchieML with a featured metrics block (or reuse the [demo gdoc](https://docs.google.com/document/d/1e3TIldBPIRqCCNFuuSP7X7cc550b_ayT30iIvb5X5qY/edit?tab=t.0))
2. Add filters to the block using the new parameters:
   - dataset-products
   - dataset-namespaces
   - dataset-versions

```
{.featured-metrics}
dataset-namespaces: un~faostat
dataset-products: 
dataset-versions: 2025-03-18
{}

```

3. Verify that the featured metrics display correctly with the applied filters
4. Test a linear topic page with a featured metrics block but no tags - verify that an error message appears in the drawer

- [ ] Does the staging experience have sign-off from product stakeholders?
