### PR TITLE
🎉 add population/gdp strategies

### DIFF
--- a/adminSiteClient/AbstractChartEditor.ts
+++ b/adminSiteClient/AbstractChartEditor.ts
@@ -2,7 +2,6 @@ import * as _ from "lodash-es"
 import {
     GrapherInterface,
     diffGrapherConfigs,
-    loadCatalogVariableData,
     mergeGrapherConfigs,
     PostReference,
     SeriesName,
@@ -23,6 +22,7 @@ import {
     defaultGrapherConfig,
     getCachingInputTableFetcher,
     GrapherState,
+    loadCatalogData,
 } from "@ourworldindata/grapher"
 import { NarrativeChartMinimalInformation } from "./ChartEditor.js"
 import { IndicatorChartInfo } from "./IndicatorChartEditor.js"
@@ -80,7 +80,7 @@ export abstract class AbstractChartEditor<
 
     grapherState = new GrapherState({
         additionalDataLoaderFn: (catalogKey) =>
-            loadCatalogVariableData(catalogKey, { baseUrl: CATALOG_URL }),
+            loadCatalogData(catalogKey, { baseUrl: CATALOG_URL }),
     })
     cachingGrapherDataLoader = getCachingInputTableFetcher(
         DATA_API_URL,

--- a/adminSiteClient/EditorDataTab.tsx
+++ b/adminSiteClient/EditorDataTab.tsx
@@ -433,6 +433,9 @@ class PeerCountrySection<
         [key in PeerCountryStrategy]: string
     } = {
         [PeerCountryStrategy.ParentRegions]: "Continent, income group & World",
+        [PeerCountryStrategy.GdpPerCapita]:
+            "Countries with similar GDP per capita",
+        [PeerCountryStrategy.Population]: "Countries with similar population",
         [PeerCountryStrategy.DefaultSelection]: "Default selection",
     }
 

--- a/adminSiteClient/GrapherConfigGridEditor.tsx
+++ b/adminSiteClient/GrapherConfigGridEditor.tsx
@@ -4,7 +4,6 @@ import {
     Bounds,
     stringifyUnknownError,
     excludeUndefined,
-    loadCatalogVariableData,
     moveArrayItemToIndex,
     getWindowUrl,
     setWindowUrl,
@@ -44,6 +43,7 @@ import {
     Grapher,
     GrapherProgrammaticInterface,
     GrapherState,
+    loadCatalogData,
     MapChartState,
 } from "@ourworldindata/grapher"
 import { BindString, SelectField, Toggle } from "./Forms.js"
@@ -156,9 +156,7 @@ export class GrapherConfigGridEditor extends React.Component<GrapherConfigGridEd
 
     grapherState = new GrapherState({
         additionalDataLoaderFn: (catalogKey) =>
-            loadCatalogVariableData(catalogKey, {
-                baseUrl: CATALOG_URL,
-            }),
+            loadCatalogData(catalogKey, { baseUrl: CATALOG_URL }),
         bounds: new Bounds(0, 0, 480, 500),
 
         // workaround to enforce `useIdealBounds == false`

--- a/adminSiteClient/VariableEditPage.tsx
+++ b/adminSiteClient/VariableEditPage.tsx
@@ -31,7 +31,6 @@ import {
     DimensionProperty,
     EPOCH_DATE,
     getETLPathComponents,
-    loadCatalogVariableData,
     OwidProcessingLevel,
     OwidOrigin,
     OwidSource,
@@ -51,6 +50,7 @@ import {
     fetchInputTableForConfig,
     Grapher,
     GrapherState,
+    loadCatalogData,
 } from "@ourworldindata/grapher"
 import { faCircleInfo } from "@fortawesome/free-solid-svg-icons"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
@@ -756,9 +756,7 @@ class VariableEditor extends Component<{
         this.grapherState = new GrapherState({
             ...this.grapherConfig,
             additionalDataLoaderFn: (catalogKey: CatalogKey) =>
-                loadCatalogVariableData(catalogKey, {
-                    baseUrl: CATALOG_URL,
-                }),
+                loadCatalogData(catalogKey, { baseUrl: CATALOG_URL }),
         })
         void fetchInputTableForConfig({
             dimensions: this.grapherConfig.dimensions,

--- a/baker/archival/ArchivalBaker.ts
+++ b/baker/archival/ArchivalBaker.ts
@@ -58,10 +58,8 @@ import {
     ArchivalTimestamp,
     convertToArchivalDateStringIfNecessary,
     getAllVariableIds,
-    getCatalogAssetKey,
     LARGE_THUMBNAIL_WIDTH,
     LARGEST_IMAGE_WIDTH,
-    loadCatalogVariableData,
 } from "@ourworldindata/utils"
 import { PROD_URL } from "../../site/SiteConstants.js"
 import { getParsedDodsDictionary } from "../../db/model/Dod.js"
@@ -82,7 +80,11 @@ import {
     getArchivedPostVersionsByPostId,
     getLatestArchivedPostVersions,
 } from "../../db/model/ArchivedPostVersion.js"
-import { EXTERNAL_SORT_INDICATOR_DEFINITIONS } from "@ourworldindata/grapher"
+import {
+    EXTERNAL_SORT_INDICATOR_DEFINITIONS,
+    getCatalogAssetKey,
+    loadCatalogData,
+} from "@ourworldindata/grapher"
 
 export interface MinimalChartInfo {
     chartId: number
@@ -170,7 +172,7 @@ export const bakeCatalogData = async (
     await fs.mkdirp(path.join(archiveDir, "catalog"))
 
     for (const { catalogKey } of EXTERNAL_SORT_INDICATOR_DEFINITIONS) {
-        const data = await loadCatalogVariableData(catalogKey, {
+        const data = await loadCatalogData(catalogKey, {
             baseUrl: CATALOG_URL,
         })
 

--- a/db/model/ExplorerViews.ts
+++ b/db/model/ExplorerViews.ts
@@ -25,6 +25,7 @@ import {
     ADMIN_BASE_URL,
     BAKED_BASE_URL,
     BAKED_GRAPHER_URL,
+    CATALOG_URL,
     DATA_API_URL,
 } from "../../settings/clientSettings.js"
 
@@ -163,6 +164,7 @@ function createExplorerForViews(
         bakedBaseUrl: BAKED_BASE_URL,
         bakedGrapherUrl: BAKED_GRAPHER_URL,
         dataApiUrl: DATA_API_URL,
+        catalogUrl: CATALOG_URL,
         loadMetadataOnly,
         throwOnMissingGrapher: true,
         setupGrapher: false, // We will set up the grapher later in iterateExplorerViews

--- a/devTools/svgTester/utils.ts
+++ b/devTools/svgTester/utils.ts
@@ -417,7 +417,7 @@ export async function renderSvg({
     )
     const durationReceiveData = Date.now() - timeStart
 
-    const svg = grapher.grapherState.generateStaticSvg(
+    const svg = await grapher.grapherState.generateStaticSvg(
         ReactDOMServer.renderToStaticMarkup
     )
     const durationTotal = Date.now() - timeStart
@@ -875,6 +875,7 @@ export async function renderExplorerViewsToSVGsAndSave({
         bakedBaseUrl: "https://ourworldindata.org",
         bakedGrapherUrl: "https://ourworldindata.org/grapher",
         dataApiUrl: "https://api.ourworldindata.org/v1/indicators", // Unused
+        catalogUrl: "https://catalog.ourworldindata.org", // Unused
         partialGrapherConfigs,
         bounds,
         staticBounds: bounds,
@@ -910,7 +911,7 @@ export async function renderExplorerViewsToSVGsAndSave({
         await explorer.reactToUserChangingSelection(oldRow)
 
         // Generate SVG for this view
-        const svg = explorer.grapherState.generateStaticSvg(
+        const svg = await explorer.grapherState.generateStaticSvg(
             ReactDOMServer.renderToStaticMarkup
         )
         const cleanedSvg = await prepareSvgForComparison(svg)
@@ -993,6 +994,7 @@ export async function renderAndVerifyExplorerViews({
         bakedBaseUrl: "https://ourworldindata.org",
         bakedGrapherUrl: "https://ourworldindata.org/grapher",
         dataApiUrl: "https://api.ourworldindata.org/v1/indicators", // Unused
+        catalogUrl: "https://catalog.ourworldindata.org", // Unused
         partialGrapherConfigs,
         bounds,
         staticBounds: bounds,
@@ -1049,7 +1051,7 @@ export async function renderAndVerifyExplorerViews({
             await explorer.reactToUserChangingSelection(oldRow)
 
             // Generate SVG for this view
-            const svg = explorer.grapherState.generateStaticSvg(
+            const svg = await explorer.grapherState.generateStaticSvg(
                 ReactDOMServer.renderToStaticMarkup
             )
 

--- a/functions/_common/env.ts
+++ b/functions/_common/env.ts
@@ -29,6 +29,7 @@ export interface Env {
     ALGOLIA_ID: string
     ALGOLIA_SEARCH_KEY: string
     ALGOLIA_INDEX_PREFIX?: string
+    CATALOG_URL: string
 }
 // We collect the possible extensions here so we can easily take them into account
 // when handling redirects

--- a/functions/_common/explorerHandlers.ts
+++ b/functions/_common/explorerHandlers.ts
@@ -91,7 +91,7 @@ export async function handleThumbnailRequestForExplorerView(
             explorerEnv,
             options
         )
-        const svg = grapherState.generateStaticSvg(
+        const svg = await grapherState.generateStaticSvg(
             ReactDOMServer.renderToStaticMarkup
         )
         if (extension === "svg") {

--- a/functions/_common/grapherRenderer.ts
+++ b/functions/_common/grapherRenderer.ts
@@ -82,7 +82,7 @@ async function fetchAndRenderGrapherToSvg(
     const inputTable = results[0]
     if (inputTable) grapher.grapherState.inputTable = inputTable
 
-    const svg = grapher.grapherState.generateStaticSvg(
+    const svg = await grapher.grapherState.generateStaticSvg(
         ReactDOMServer.renderToStaticMarkup
     )
     grapherLogger.log("generateStaticSvg")

--- a/functions/_common/grapherTools.ts
+++ b/functions/_common/grapherTools.ts
@@ -3,11 +3,13 @@ import {
     generateGrapherImageSrcSet,
     Grapher,
     GrapherState,
+    loadCatalogData,
 } from "@ourworldindata/grapher"
 import {
     GrapherInterface,
     MultiDimDataPageConfigEnriched,
     R2GrapherConfigDirectory,
+    CatalogKey,
 } from "@ourworldindata/types"
 import {
     excludeUndefined,
@@ -264,6 +266,9 @@ export async function initGrapher(
         throw new StatusError(grapherConfigResponse.status)
     }
 
+    const additionalDataLoaderFn = async (catalogKey: CatalogKey) =>
+        loadCatalogData(catalogKey, { baseUrl: env.CATALOG_URL })
+
     const bounds = new Bounds(0, 0, options.svgWidth, options.svgHeight)
     const grapherState = new GrapherState({
         ...grapherConfigResponse.grapherConfig,
@@ -277,6 +282,7 @@ export async function initGrapher(
             // Set the baseUrl to ensure mdims have correct canonical URL in the metadata json
             baseUrl: `${grapherBaseUrl}/${identifier.id}`,
         },
+        additionalDataLoaderFn,
         ...options.grapherProps,
     })
     grapherState.isExportingToSvgOrPng = true

--- a/packages/@ourworldindata/explorer/src/Explorer.sample.ts
+++ b/packages/@ourworldindata/explorer/src/Explorer.sample.ts
@@ -122,6 +122,7 @@ export const SampleExplorerOfGraphers = (props?: Partial<ExplorerProps>) => {
         bakedBaseUrl: "",
         bakedGrapherUrl: "",
         dataApiUrl: "",
+        catalogUrl: "",
         ...props,
     })
 }
@@ -155,6 +156,7 @@ export const SampleInlineDataExplorer = (props?: Partial<ExplorerProps>) => {
         bakedBaseUrl: "",
         bakedGrapherUrl: "",
         dataApiUrl: "",
+        catalogUrl: "",
         ...props,
     })
 }
@@ -182,6 +184,7 @@ export const SampleIndicatorBasedExplorer = (
         bakedBaseUrl: "",
         bakedGrapherUrl: "",
         dataApiUrl: "",
+        catalogUrl: "",
         ...props,
     })
 }

--- a/packages/@ourworldindata/explorer/src/Explorer.tsx
+++ b/packages/@ourworldindata/explorer/src/Explorer.tsx
@@ -34,6 +34,7 @@ import {
     GrapherState,
     fetchInputTableForConfig,
     FetchInputTableForConfigFn,
+    loadCatalogData,
 } from "@ourworldindata/grapher"
 import {
     Bounds,
@@ -93,6 +94,7 @@ export interface ExplorerProps extends SerializedGridProgram {
     bakedBaseUrl: string
     bakedGrapherUrl: string
     dataApiUrl: string
+    catalogUrl: string
     bounds?: Bounds
     staticBounds?: Bounds
     loadMetadataOnly?: boolean
@@ -233,6 +235,7 @@ export class Explorer
         ).initDecisionMatrix(this.initialQueryParams)
         const { archiveContext } = props
         const isOnArchivalPage = archiveContext?.type === "archive-page"
+        const assetMaps = isOnArchivalPage ? archiveContext?.assets : undefined
         this.isOnArchivalPage = isOnArchivalPage
         this.grapherState = new GrapherState({
             staticBounds: props.staticBounds,
@@ -243,6 +246,11 @@ export class Explorer
             adminBaseUrl: this.adminBaseUrl,
             canHideExternalControlsInEmbed: true,
             archiveContext: props.archiveContext,
+            additionalDataLoaderFn: (catalogKey) =>
+                loadCatalogData(catalogKey, {
+                    baseUrl: this.props.catalogUrl,
+                    assetMap: assetMaps?.runtime,
+                }),
         })
 
         if (props.setupGrapher !== false)
@@ -315,6 +323,7 @@ export class Explorer
 
     bakedBaseUrl = this.props.bakedBaseUrl
     dataApiUrl = this.props.dataApiUrl
+    catalogUrl = this.props.catalogUrl
     adminBaseUrl = this.props.adminBaseUrl
     bakedGrapherUrl = this.props.bakedGrapherUrl
 

--- a/packages/@ourworldindata/explorer/src/ExplorerUtils.ts
+++ b/packages/@ourworldindata/explorer/src/ExplorerUtils.ts
@@ -53,6 +53,7 @@ export async function buildExplorerProps(
         bakedBaseUrl: explorerConstants.bakedBaseUrl,
         bakedGrapherUrl: explorerConstants.bakedGrapherUrl,
         dataApiUrl: explorerConstants.dataApiUrl,
+        catalogUrl: explorerConstants.catalogUrl,
         grapherConfigs,
         partialGrapherConfigs,
         chartConfigIdByViewId,

--- a/packages/@ourworldindata/grapher/src/core/FetchingGrapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/FetchingGrapher.tsx
@@ -1,12 +1,13 @@
 import { GrapherInterface, ArchiveContext } from "@ourworldindata/types"
 import React from "react"
 import { Grapher, GrapherProgrammaticInterface } from "./Grapher.js"
-import { Bounds, loadCatalogVariableData } from "@ourworldindata/utils"
+import { Bounds } from "@ourworldindata/utils"
 import { fetchInputTableForConfig } from "./loadGrapherTableHelpers.js"
 import { legacyToCurrentGrapherQueryParams } from "./GrapherUrlMigrations.js"
 import { unstable_batchedUpdates } from "react-dom"
 import { migrateGrapherConfigToLatestVersion } from "../schema/migrations/migrate.js"
 import { useMaybeGlobalGrapherStateRef } from "../chart/guidedChartUtils.js"
+import { loadCatalogData } from "./loadCatalogData.js"
 
 export interface FetchingGrapherProps {
     config?: GrapherProgrammaticInterface
@@ -31,7 +32,7 @@ export function FetchingGrapher(
     const grapherState = useMaybeGlobalGrapherStateRef({
         ...props.config,
         additionalDataLoaderFn: (catalogKey) =>
-            loadCatalogVariableData(catalogKey, {
+            loadCatalogData(catalogKey, {
                 baseUrl: props.catalogUrl,
                 assetMap:
                     props.archiveContext?.type === "archive-page"

--- a/packages/@ourworldindata/grapher/src/core/GrapherUseHelpers.tsx
+++ b/packages/@ourworldindata/grapher/src/core/GrapherUseHelpers.tsx
@@ -1,5 +1,5 @@
 import { debounce } from "lodash-es"
-import { GrapherProgrammaticInterface } from "../index.js"
+import { GrapherProgrammaticInterface, loadCatalogData } from "../index.js"
 import * as Sentry from "@sentry/react"
 import { createRoot } from "react-dom/client"
 import { FetchingGrapher } from "./FetchingGrapher.js"
@@ -8,7 +8,7 @@ import {
     ArchiveContext,
     CatalogKey,
 } from "@ourworldindata/types"
-import { Bounds, loadCatalogVariableData } from "@ourworldindata/utils"
+import { Bounds } from "@ourworldindata/utils"
 
 export function renderGrapherIntoContainer({
     config,
@@ -45,7 +45,7 @@ export function renderGrapherIntoContainer({
             additionalDataLoaderFn: (
                 catalogKey: CatalogKey
             ): ReturnType<AdditionalGrapherDataFetchFn> =>
-                loadCatalogVariableData(catalogKey, { baseUrl: catalogUrl }),
+                loadCatalogData(catalogKey, { baseUrl: catalogUrl }),
         }
 
         reactRoot.render(

--- a/packages/@ourworldindata/grapher/src/core/PeerCountrySelection.test.ts
+++ b/packages/@ourworldindata/grapher/src/core/PeerCountrySelection.test.ts
@@ -1,0 +1,70 @@
+import { expect, it, describe } from "vitest"
+import { findClosestByValue } from "./PeerCountrySelection.js"
+
+describe(findClosestByValue, () => {
+    it("finds entities with values closest to target using logarithmic distance", () => {
+        // GDP per capita-like values
+        const values = new Map([
+            ["Germany", 48_000],
+            ["United Kingdom", 46_000],
+            ["France", 42_000],
+            ["Italy", 35_000],
+            ["Spain", 30_000],
+            ["Poland", 18_000],
+        ])
+
+        const result = findClosestByValue({ target: "United Kingdom", values })
+
+        expect(result).toEqual(["Germany", "France", "Italy"])
+    })
+
+    it("returns no peers when target is isolated beyond maxPeerRatio", () => {
+        const values = new Map([
+            ["Vatican", 500],
+            ["Poland", 38_000_000],
+            ["Germany", 84_000_000],
+        ])
+
+        const result = findClosestByValue({ target: "Vatican", values })
+
+        expect(result).toEqual([])
+    })
+
+    it("prefers proportionally closer peers over absolutely closer ones", () => {
+        const values = new Map([
+            ["Large", 200_000_000], // 2x larger, 100M absolute diff, log diff = 0.3
+            ["Target", 100_000_000],
+            ["Small", 30_000_000], // 3.3x smaller, 70M absolute diff, log diff = 0.52
+        ])
+
+        const result = findClosestByValue({
+            target: "Target",
+            values,
+            targetCount: 1,
+            maxPeerRatio: 5,
+        })
+
+        // Log distance: Large (2x) is closer than Small (3.3x)
+        expect(result).toEqual(["Large"])
+    })
+
+    it("falls back to global search when no same-continent peers exist", () => {
+        // Australia has high GDP in Oceania, other Oceania countries are too far
+        const values = new Map([
+            ["Australia", 50_000],
+            ["New Zealand", 35_000], // 1.43x smaller - outside 1.25x threshold
+            ["Papua New Guinea", 3_000], // 16.7x smaller - way outside threshold
+            ["Germany", 48_000],
+            ["France", 42_000],
+        ])
+
+        const result = findClosestByValue({
+            target: "Australia",
+            values,
+            maxPeerRatio: 1.25,
+        })
+
+        // Australia has no Oceania peers within threshold, falls back to global
+        expect(result).toEqual(["Germany", "France"])
+    })
+})

--- a/packages/@ourworldindata/grapher/src/core/PeerCountrySelection.ts
+++ b/packages/@ourworldindata/grapher/src/core/PeerCountrySelection.ts
@@ -1,4 +1,7 @@
+import * as R from "remeda"
 import {
+    AdditionalGrapherDataFetchFn,
+    CatalogKey,
     EntityName,
     PeerCountryStrategy,
     PeerCountryStrategyQueryParam,
@@ -6,6 +9,7 @@ import {
 import {
     checkIsCountry,
     getAggregates,
+    getContinentForCountry,
     getContinents,
     getIncomeGroups,
     getParentRegions,
@@ -36,9 +40,9 @@ export function isValidPeerCountryStrategyQueryParam(
  * The target country is the one currently selected in the grapher. This only
  * takes effect when exactly one entity is selected.
  */
-export function selectPeerCountriesForGrapher(
+export async function selectPeerCountriesForGrapher(
     grapherState: GrapherState
-): EntityName[] {
+): Promise<EntityName[]> {
     if (grapherState.selection.numSelectedEntities !== 1) return []
 
     const targetCountry = grapherState.selection.selectedEntityNames[0]
@@ -54,32 +58,69 @@ export function selectPeerCountriesForGrapher(
     const regionInfo = getRegionByName(targetCountry)
     if (!regionInfo || !checkIsCountry(regionInfo)) return []
 
+    const additionalDataLoaderFn = grapherState.additionalDataLoaderFn
+
     return selectPeerCountries({
         peerCountryStrategy,
         targetCountry,
         defaultSelection,
         availableEntities,
+        additionalDataLoaderFn,
     })
 }
 
 /** Selects peer countries based on the specified strategy and target entity */
-export function selectPeerCountries({
+export async function selectPeerCountries({
     peerCountryStrategy,
     targetCountry,
     defaultSelection,
     availableEntities,
+    additionalDataLoaderFn,
 }: {
     peerCountryStrategy: PeerCountryStrategy
     targetCountry: EntityName
     defaultSelection: EntityName[]
     availableEntities: EntityName[]
-}): EntityName[] {
+    additionalDataLoaderFn?: AdditionalGrapherDataFetchFn
+}): Promise<EntityName[]> {
     return match(peerCountryStrategy)
         .with(PeerCountryStrategy.DefaultSelection, () => defaultSelection)
         .with(PeerCountryStrategy.ParentRegions, () =>
             selectParentRegionsAsPeers({ targetCountry, availableEntities })
         )
+        .with(PeerCountryStrategy.GdpPerCapita, async () => {
+            if (!isDataLoaderAvailable(additionalDataLoaderFn)) return []
+            return selectPeerCountriesByClosestValue({
+                targetCountry,
+                availableEntities,
+                additionalDataLoaderFn,
+                catalogKey: "gdp",
+                maxPeerRatio: 1.25,
+            })
+        })
+        .with(PeerCountryStrategy.Population, async () => {
+            if (!isDataLoaderAvailable(additionalDataLoaderFn)) return []
+            return selectPeerCountriesByClosestValue({
+                targetCountry,
+                availableEntities,
+                additionalDataLoaderFn,
+                catalogKey: "population",
+                maxPeerRatio: 1.5,
+            })
+        })
         .exhaustive()
+}
+
+function isDataLoaderAvailable(
+    additionalDataLoaderFn?: AdditionalGrapherDataFetchFn
+): additionalDataLoaderFn is AdditionalGrapherDataFetchFn {
+    if (!additionalDataLoaderFn) {
+        console.warn(
+            `additionalDataLoaderFn not available for peer selection. Not selecting any peer countries.`
+        )
+        return false
+    }
+    return true
 }
 
 /**
@@ -155,4 +196,170 @@ export function selectRegionGroupByPriority(
         }
     }
     return []
+}
+
+/** Finds countries with similar values to the target country */
+async function selectPeerCountriesByClosestValue({
+    targetCountry,
+    availableEntities,
+    additionalDataLoaderFn,
+    catalogKey,
+    targetCount = 3,
+    maxPeerRatio = 1.5,
+}: {
+    targetCountry: EntityName
+    availableEntities: EntityName[]
+    additionalDataLoaderFn: AdditionalGrapherDataFetchFn
+    catalogKey: CatalogKey
+    /** Number of peer entities to select */
+    targetCount?: number
+    /** Maximum ratio difference allowed */
+    maxPeerRatio?: number
+}): Promise<EntityName[]> {
+    try {
+        // Load data
+        const data = await additionalDataLoaderFn(catalogKey)
+
+        // Only consider _countries_ as candidates for peer selection
+        // (e.g. exclude aggregates like continents or income groups)
+        const candidates = availableEntities.filter((entityName) => {
+            const region = getRegionByName(entityName)
+            const isCountry = region && checkIsCountry(region)
+            return isCountry && entityName !== targetCountry
+        })
+
+        // Create a map of entity names to their values
+        const values = new Map(data.map((row) => [row.entity, row.value]))
+
+        return findClosestByValue({
+            target: targetCountry,
+            candidates,
+            values,
+            targetCount,
+            maxPeerRatio,
+        })
+    } catch (error) {
+        console.error(
+            "Failed to select peer countries by closest value:",
+            error
+        )
+        return []
+    }
+}
+
+/** Finds entities with values closest to a target entity using logarithmic distance */
+export function findClosestByValue({
+    target,
+    candidates,
+    values,
+    targetCount = 3,
+    maxPeerRatio = 1.5,
+}: {
+    target: EntityName
+    candidates?: EntityName[]
+    values: Map<EntityName, number>
+    /** Number of peer entities to select */
+    targetCount?: number
+    /** Maximum ratio difference allowed */
+    maxPeerRatio?: number
+}): EntityName[] {
+    // Check that the target entity has a value
+    const targetValue = values.get(target)
+    if (targetValue === undefined) {
+        console.warn(`Target entity ${target} not found in values`)
+        return []
+    }
+
+    // Settings for finding peers
+    const settings = { targetValue, targetCount, maxPeerRatio }
+
+    // Default to all available entities as candidates
+    const availableEntities = Array.from(values.keys()).filter(
+        (entityName) => entityName !== target
+    )
+    const candidatesToUse = candidates ?? availableEntities
+
+    // Get the target's continent for filtering
+    const targetContinent = getContinentForCountry(target)
+
+    // If the target continent is unknown, search all candidates
+    if (!targetContinent) {
+        return findClosestByLogDistance({
+            values,
+            candidates: candidatesToUse,
+            ...settings,
+        })
+    }
+
+    // Find candidates on the same continent vs other continents
+    const [sameContinentCandidates, otherContinentsCandidates] = R.partition(
+        candidatesToUse,
+        (name) => getContinentForCountry(name) === targetContinent
+    )
+
+    // First try finding peer countries on the same continent
+    const sameContinentPeers = findClosestByLogDistance({
+        values,
+        candidates: sameContinentCandidates,
+        ...settings,
+    })
+
+    // If we have enough same-continent peers, return them
+    if (sameContinentPeers.length >= targetCount) return sameContinentPeers
+
+    // Otherwise, fill up with peers from other continents
+    const remainingCount = targetCount - sameContinentPeers.length
+    const otherContinentPeers = findClosestByLogDistance({
+        values,
+        candidates: otherContinentsCandidates,
+        ...settings,
+        targetCount: remainingCount,
+    })
+
+    const combinedPeers = [...sameContinentPeers, ...otherContinentPeers]
+
+    if (combinedPeers.length === 0) {
+        console.warn(
+            `No peers found within ${maxPeerRatio}x for ${target} (value: ${targetValue})`
+        )
+    }
+
+    return combinedPeers
+}
+
+const findClosestByLogDistance = ({
+    values,
+    candidates,
+    targetValue,
+    targetCount = 3,
+    maxPeerRatio = 1.25,
+}: {
+    values: Map<EntityName, number>
+    candidates: EntityName[]
+    targetValue: number
+    targetCount: number
+    maxPeerRatio: number
+}): EntityName[] => {
+    const targetLogValue = Math.log(targetValue)
+    const maxLogDistance = Math.log(maxPeerRatio)
+
+    return R.pipe(
+        candidates,
+        R.map((entityName) => {
+            const value = values.get(entityName)
+            if (value === undefined) return undefined
+            return {
+                entityName,
+                // Log distance: |log(value) - log(target)| = |log(value/target)|
+                // Log distance so that 2x larger and 2x smaller are equidistant
+                difference: Math.abs(Math.log(value) - targetLogValue),
+            }
+        }),
+        R.filter(R.isDefined),
+        // Exclude peers that are more than maxPeerRatio times larger/smaller
+        R.filter(({ difference }) => difference <= maxLogDistance),
+        R.sortBy((item) => item.difference),
+        R.take(targetCount),
+        R.map((item) => item.entityName)
+    )
 }

--- a/packages/@ourworldindata/grapher/src/index.ts
+++ b/packages/@ourworldindata/grapher/src/index.ts
@@ -146,3 +146,5 @@ export {
     selectRegionGroupByPriority,
     isValidPeerCountryStrategyQueryParam,
 } from "./core/PeerCountrySelection.js"
+
+export { loadCatalogData, getCatalogAssetKey } from "./core/loadCatalogData.js"

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.009.yaml
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.009.yaml
@@ -223,9 +223,13 @@ properties:
             Strategy for selecting peer countries for comparison
             - "defaultSelection": Use the chart's default selection as peers
             - "parentRegions": Use the containing continent, income group, and World as peers
+            - "gdpPerCapita": Use countries with similar GDP per capita as peers
+            - "population": Use countries with similar population as peers
         enum:
             - defaultSelection
             - parentRegions
+            - gdpPerCapita
+            - population
     entityType:
         type: string
         default: country or region

--- a/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
+++ b/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
@@ -215,6 +215,10 @@ export enum ScatterPointLabelStrategy {
 export enum PeerCountryStrategy {
     /** Use the containing continent, income group and World as peers */
     ParentRegions = "parentRegions",
+    /** Use countries with similar GDP per capita as peers */
+    GdpPerCapita = "gdpPerCapita",
+    /** Use countries with similar population as peers */
+    Population = "population",
     /** Use the chart's default selection as peers */
     DefaultSelection = "defaultSelection",
 }

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -225,6 +225,7 @@ export {
     getRegionBySlug,
     getParentRegions,
     getSiblingRegions,
+    getContinentForCountry,
     articulateEntity,
 } from "./regions.js"
 export {
@@ -355,9 +356,3 @@ export {
 
 export { placeGrapherTabsInLargeVariantGrid } from "./search/LargeVariantRichDataHelpers.js"
 export { placeGrapherTabsInMediumVariantGridLayout } from "./search/MediumVariantRichDataHelpers.js"
-
-export {
-    loadCatalogVariableData,
-    columnDefsByCatalogKey,
-    getCatalogAssetKey,
-} from "./loadCatalogData.js"

--- a/packages/@ourworldindata/utils/src/regions.ts
+++ b/packages/@ourworldindata/utils/src/regions.ts
@@ -237,6 +237,18 @@ export const getSiblingRegions = (regionName: string): Region[] => {
         .filter((region) => region && region.name !== regionName) as Region[]
 }
 
+/**
+ * Gets the OWID continent name for a country.
+ * Returns undefined if the entity is not a country or has no continent.
+ */
+export function getContinentForCountry(
+    countryName: EntityName
+): string | undefined {
+    const parentRegions = getParentRegions(countryName)
+    const continent = parentRegions.find((r) => checkIsOwidContinent(r))
+    return continent?.name
+}
+
 const getCountryNamesForRegionRecursive = (region: Region): string[] => {
     if (!checkHasMembers(region)) return [region.name]
     return region.members.reduce<string[]>((countryNames, memberCode) => {

--- a/site/ExplorerPage.tsx
+++ b/site/ExplorerPage.tsx
@@ -26,6 +26,7 @@ import {
     ADMIN_BASE_URL,
     BAKED_BASE_URL,
     BAKED_GRAPHER_URL,
+    CATALOG_URL,
     DATA_API_URL,
 } from "../settings/clientSettings.js"
 
@@ -109,6 +110,7 @@ const explorerConstants = ${serializeJSONForHTML(
             bakedBaseUrl: BAKED_BASE_URL,
             bakedGrapherUrl: BAKED_GRAPHER_URL,
             dataApiUrl: DATA_API_URL,
+            catalogUrl: CATALOG_URL,
         },
         EXPLORER_CONSTANTS_DELIMITER
     )}

--- a/site/multiDim/MultiDim.tsx
+++ b/site/multiDim/MultiDim.tsx
@@ -14,12 +14,12 @@ import {
     GrapherProgrammaticInterface,
     useMaybeGlobalGrapherStateRef,
     GuidedChartContext,
+    loadCatalogData,
 } from "@ourworldindata/grapher"
 import {
     extractMultiDimChoicesFromSearchParams,
     GRAPHER_TAB_QUERY_PARAMS,
     GrapherQueryParams,
-    loadCatalogVariableData,
     MultiDimDataPageConfig,
     MultiDimDimensionChoices,
 } from "@ourworldindata/utils"
@@ -58,7 +58,7 @@ export default function MultiDim({
         manager: manager.current,
         queryStr,
         additionalDataLoaderFn: (catalogKey) =>
-            loadCatalogVariableData(catalogKey, {
+            loadCatalogData(catalogKey, {
                 baseUrl: CATALOG_URL,
                 assetMap,
             }),

--- a/site/multiDim/MultiDimDataPageContent.tsx
+++ b/site/multiDim/MultiDimDataPageContent.tsx
@@ -8,11 +8,11 @@ import {
     GrapherState,
     getCachingInputTableFetcher,
     GrapherManager,
+    loadCatalogData,
 } from "@ourworldindata/grapher"
 import {
     DataPageDataV2,
     joinTitleFragments,
-    loadCatalogVariableData,
     MultiDimDataPageConfig,
     extractMultiDimChoicesFromSearchParams,
     isInIFrame,
@@ -114,7 +114,7 @@ export function DataPageContent({
     const grapherStateRef = useRef<GrapherState>(
         new GrapherState({
             additionalDataLoaderFn: (catalogKey) =>
-                loadCatalogVariableData(catalogKey, {
+                loadCatalogData(catalogKey, {
                     baseUrl: CATALOG_URL,
                     assetMap,
                 }),

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -21,6 +21,7 @@
         "GRAPHER_CONFIG_R2_BUCKET_FALLBACK_URL": "https://grapher-configs.owid.io",
         "GRAPHER_CONFIG_R2_BUCKET_FALLBACK_PATH": "v1",
         "DATA_API_URL_COMPLETE": "https://api.ourworldindata.org/v1/indicators/",
+        "CATALOG_URL": "https://catalog.ourworldindata.org",
     },
     "env": {
         "preview": {


### PR DESCRIPTION
Adds strategies based on external indicators:
- `population`: Adds countries with similar population as peers
- `gdpPerCapita`: Adds countries with similar GDP per capita

For both strategies, countries on the same continent are preferred. And both strategies use log differences (as opposed to absolute differences) to measure proportional similarity (how many times larger/smaller one value is compared to another).

Population and GDP per capita data is loaded from the OWID catalog ([example](https://catalog.ourworldindata.org/external/owid_grapher/latest/population/population.json)), which makes the selectPeerCountries function async. In the browser, I think it's safe to fire and forget without awaiting the promise, but in Cloudflare functions, we need to await the selection of peer countries before exporting the static SVG. I didn't want to make the input table asynchronous, as that would spread throughout the codebase. Instead, I used a cached promise. It's a bit hacky, but it seemed like the least bad option to me.

Context: https://www.notion.so/owid/2026-01-20-Peer-country-selection-2ea74b71f92e8091a975ff85cb04e16c?source=copy_link