### PR TITLE
🐛 info tooltip rendered behind settings popup

### DIFF
--- a/packages/@ourworldindata/components/package.json
+++ b/packages/@ourworldindata/components/package.json
@@ -23,6 +23,7 @@
         "mobx": "^6.13.7",
         "mobx-react": "^7.6.0",
         "react": "^19.2.0",
+        "react-aria-components": "1.13.0",
         "react-dom": "^19.2.0",
         "react-markdown": "^10.1.0",
         "remeda": "^2.32.0",

--- a/packages/@ourworldindata/components/src/LabeledSwitch/LabeledSwitch.scss
+++ b/packages/@ourworldindata/components/src/LabeledSwitch/LabeledSwitch.scss
@@ -106,4 +106,23 @@ $lato: $sans-serif-font-stack;
             }
         }
     }
+
+    // Info icon that triggers tooltip
+    label .tooltip-trigger {
+        display: inline;
+        background: none;
+        border: none;
+        padding: 0;
+        margin: 0;
+        cursor: default;
+        color: inherit;
+        vertical-align: middle;
+
+        svg {
+            color: $gray-60;
+            height: 13px;
+            padding: 0 0.333em;
+            vertical-align: baseline;
+        }
+    }
 }

--- a/packages/@ourworldindata/components/src/LabeledSwitch/LabeledSwitch.tsx
+++ b/packages/@ourworldindata/components/src/LabeledSwitch/LabeledSwitch.tsx
@@ -2,7 +2,12 @@ import * as React from "react"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faInfoCircle } from "@fortawesome/free-solid-svg-icons"
 import cx from "classnames"
-import { Tippy } from "@ourworldindata/utils"
+import {
+    TooltipTrigger,
+    Tooltip,
+    Button,
+    OverlayArrow,
+} from "react-aria-components"
 
 export const LabeledSwitch = ({
     className,
@@ -42,14 +47,26 @@ export const LabeledSwitch = ({
                 </div>
                 {label}
                 {tooltip && (
-                    <Tippy
-                        content={tooltip}
-                        theme="grapher-explanation"
-                        placement="top"
-                        maxWidth={338}
-                    >
-                        <FontAwesomeIcon icon={faInfoCircle} />
-                    </Tippy>
+                    <TooltipTrigger delay={0}>
+                        <Button
+                            className="tooltip-trigger"
+                            aria-label="More information about this setting"
+                        >
+                            <FontAwesomeIcon icon={faInfoCircle} />
+                        </Button>
+                        <Tooltip
+                            className="react-aria-tooltip"
+                            placement="top"
+                            offset={8}
+                        >
+                            <OverlayArrow className="react-aria-tooltip__overlay-arrow">
+                                <svg width={8} height={8} viewBox="0 0 8 8">
+                                    <path d="M0 0 L4 4 L8 0" />
+                                </svg>
+                            </OverlayArrow>
+                            {tooltip}
+                        </Tooltip>
+                    </TooltipTrigger>
                 )}
             </label>
             {tooltip && (

--- a/packages/@ourworldindata/grapher/src/controls/SettingsMenu.scss
+++ b/packages/@ourworldindata/grapher/src/controls/SettingsMenu.scss
@@ -41,7 +41,7 @@ $control-row-height: 32px;
         //
         // shared button coloring & behaviors
         //
-        button {
+        button:not(.tooltip-trigger) {
             display: flex;
             align-items: center;
             color: $light-text;

--- a/packages/@ourworldindata/grapher/src/core/grapher.scss
+++ b/packages/@ourworldindata/grapher/src/core/grapher.scss
@@ -226,6 +226,29 @@ $zindex-controls-drawer: 150;
     }
 }
 
+// React Aria Tooltip
+// Matches the styling of .tippy-box[data-theme="grapher-explanation"]
+.react-aria-tooltip {
+    background: white;
+    color: $gray-80;
+    font: 400 14px/1.5 $sans-serif-font-stack;
+    box-shadow: 0px 4px 40px 0px rgba(0, 0, 0, 0.15);
+    border-radius: 4px;
+    padding: 15px;
+    max-width: 338px;
+
+    // Small triangle arrow that point to the info icon
+    .react-aria-tooltip__overlay-arrow {
+        position: absolute;
+
+        svg {
+            display: block;
+            fill: white;
+            stroke: none;
+        }
+    }
+}
+
 .markdown-text-wrap__line {
     display: block;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3076,6 +3076,7 @@ __metadata:
     mobx: "npm:^6.13.7"
     mobx-react: "npm:^7.6.0"
     react: "npm:^19.2.0"
+    react-aria-components: "npm:1.13.0"
     react-dom: "npm:^19.2.0"
     react-markdown: "npm:^10.1.0"
     remeda: "npm:^2.32.0"
@@ -15548,7 +15549,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-aria-components@npm:^1.13.0":
+"react-aria-components@npm:1.13.0, react-aria-components@npm:^1.13.0":
   version: 1.13.0
   resolution: "react-aria-components@npm:1.13.0"
   dependencies:


### PR DESCRIPTION
The info tooltip is currently shown behind the settings popup. Fixing this with Tippy was surprisingly annoying, so I just switched to React aria.

[Prod](https://ourworldindata.org/grapher/types-violent-crime-rate-us) / [Staging](http://staging-site-fix-tooltip-in-settings-popu/grapher/types-violent-crime-rate-us)

<img width="1023" height="694" alt="Screenshot 2026-01-21 at 23 10 05" src="https://github.com/user-attachments/assets/bcf62498-f6a2-4a5f-86bf-4cf4efe61958" />
