### PR TITLE
🔨 use internal set for SelectionArray

### DIFF
--- a/packages/@ourworldindata/grapher/src/focus/FocusArray.ts
+++ b/packages/@ourworldindata/grapher/src/focus/FocusArray.ts
@@ -3,14 +3,11 @@ import { SeriesName } from "@ourworldindata/types"
 import { InteractionState } from "../interaction/InteractionState.js"
 
 export class FocusArray {
-    constructor() {
-        makeObservable<FocusArray, "store">(this, {
-            store: observable,
-        })
-        this.store = new Set()
-    }
+    private store: Set<SeriesName> = new Set()
 
-    private store: Set<SeriesName>
+    constructor() {
+        makeObservable<FocusArray, "store">(this, { store: observable })
+    }
 
     @computed get seriesNameSet(): Set<SeriesName> {
         return this.store


### PR DESCRIPTION
Refactors SelectionArray to use a set internally (instead of a list). Seems like the more appropriate data model to me. I can't think of any reason we'd ever want duplicate entries in the SelectionArray. And sets do respect insertion order, so I think we should be ok there too. I can't think of any other way this can hurt us

