### PR TITLE
🐛 fix layout shift on mobile due to hiding the full screen button

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -673,6 +673,7 @@ export class Grapher extends React.Component<GrapherProps> {
         const updateWindowDimensions = action((): void => {
             this.grapherState.windowInnerWidth = window.innerWidth
             this.grapherState.windowInnerHeight = window.innerHeight
+            this.grapherState.screenHeight = window.screen.height
         })
         const onResize = _.debounce(updateWindowDimensions, 400, {
             leading: true,

--- a/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
@@ -97,6 +97,7 @@ import {
     checkIsIncomeGroup,
     checkHasMembers,
     sortNumeric,
+    isMobile,
 } from "@ourworldindata/utils"
 import Cookies from "js-cookie"
 import * as _ from "lodash-es"
@@ -590,6 +591,7 @@ export class GrapherState
     _isInFullScreenMode = false
     windowInnerWidth: number | undefined = undefined
     windowInnerHeight: number | undefined = undefined
+    screenHeight: number | undefined = undefined
 
     enableKeyboardShortcuts: boolean = false
     bindUrlToWindow: boolean = false
@@ -673,6 +675,7 @@ export class GrapherState
             _isInFullScreenMode: observable.ref,
             windowInnerWidth: observable.ref,
             windowInnerHeight: observable.ref,
+            screenHeight: observable.ref,
             bakedGrapherURL: observable,
             externalQueryParams: observable.ref,
             _inputTable: observable.ref,
@@ -2773,6 +2776,10 @@ export class GrapherState
         return isTouchDevice()
     }
 
+    @computed private get isMobile(): boolean {
+        return isMobile()
+    }
+
     /** externalBounds should be set to the available plotting area for a
         Grapher that resizes itself to fit. When this area changes,
         externalBounds should be updated. Updating externalBounds can
@@ -2870,10 +2877,14 @@ export class GrapherState
 
     @computed get hideFullScreenButton(): boolean {
         if (this.isInFullScreenMode) return false
-        if (!this.isSmall) return false
+        if (!this.isSmall || !this.isMobile || !this.screenHeight) return false
+
+        // Approximate full screen height on mobile devices
+        // that doesn't update when browser UI is shown/hidden
+        const fullScreenHeight = this.screenHeight
+
         // Hide the full screen button if the full screen height
         // is barely larger than the current chart height
-        const fullScreenHeight = this.windowInnerHeight!
         return fullScreenHeight < this.frameBounds.height + 80
     }
 


### PR DESCRIPTION
Fixes [this issue](https://owid.slack.com/archives/C03NV9Z3YSV/p1768909368150849) noticed by Marwa

Using window.screen.height instead of window.innerHeight because it’s stable and doesn’t update when the browser’s navbar is shown/hidden