### PR TITLE
✨ render the default tab as thumbnail instead of an empty table

### DIFF
--- a/functions/_common/grapherRenderer.ts
+++ b/functions/_common/grapherRenderer.ts
@@ -17,6 +17,7 @@ import {
     GrapherIdentifier,
     initGrapher,
 } from "./grapherTools.js"
+import { GRAPHER_TAB_NAMES } from "@ourworldindata/types"
 import { fetchInputTableForConfig } from "@ourworldindata/grapher"
 import ReactDOMServer from "react-dom/server"
 
@@ -47,6 +48,11 @@ async function fetchAndRenderGrapherToSvg(
         searchParams,
         env
     )
+
+    // Prefer to render the default tab rather than an empty table
+    if (grapher.grapherState.activeTab === GRAPHER_TAB_NAMES.Table) {
+        grapher.grapherState.resetToDefaultTab()
+    }
 
     grapherLogger.log("initGrapher")
     const promises = []

--- a/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
@@ -1248,6 +1248,10 @@ export class GrapherState
         return GRAPHER_TAB_NAMES.Table
     }
 
+    @action.bound resetToDefaultTab(): void {
+        this.setTab(this.defaultTab)
+    }
+
     @computed get chartType(): GrapherChartType | undefined {
         return this.validChartTypes[0]
     }


### PR DESCRIPTION
Resolves #5103 

Render the default map/chart tab if a thumbnail is requested for the table tab

[prod](https://ourworldindata.org/grapher/life-expectancy.svg?tab=table) / [staging](http://staging-site-thumbnail-tables/grapher/life-expectancy.svg?tab=table)

https://ourworldindata.org/grapher/life-expectancy.svg?tab=table currently shows:

![life-expectancy (1)](https://github.com/user-attachments/assets/f09d02b2-bacc-4102-bed1-c41b3e7b2c89)