### PR TITLE
🎉 (admin) enhance entity selection

### DIFF
--- a/adminSiteClient/EditorDataTab.tsx
+++ b/adminSiteClient/EditorDataTab.tsx
@@ -1,6 +1,10 @@
 import * as _ from "lodash-es"
 import * as React from "react"
-import { differenceOfSets } from "@ourworldindata/utils"
+import {
+    differenceOfSets,
+    getRegionByName,
+    checkIsCountry,
+} from "@ourworldindata/utils"
 import { computed, action, observable, makeObservable } from "mobx"
 import { observer } from "mobx-react"
 import cx from "classnames"
@@ -11,7 +15,15 @@ import {
     EntityName,
     SeriesName,
 } from "@ourworldindata/types"
-import { GrapherState } from "@ourworldindata/grapher"
+import {
+    GrapherState,
+    selectPeerCountries,
+    prepareEntitiesForPeerSelection,
+} from "@ourworldindata/grapher"
+import {
+    getAvailablePresets,
+    sortEntitiesByLastValue,
+} from "./EntityPresets.js"
 import {
     ColorBox,
     SelectField,
@@ -20,6 +32,7 @@ import {
     BindString,
 } from "./Forms.js"
 import {
+    faDice,
     faLink,
     faMinus,
     faTimes,
@@ -142,6 +155,294 @@ class SeriesListItem extends React.Component<SeriesListItemProps> {
 }
 
 @observer
+class QuickAddSection extends React.Component<{
+    editor: AbstractChartEditor
+}> {
+    @computed get grapherState() {
+        return this.props.editor.grapherState
+    }
+
+    @computed get availablePresets() {
+        return getAvailablePresets(this.grapherState.availableEntityNames)
+    }
+
+    @action.bound onSelectPreset(entities: EntityName[]) {
+        const { grapherState } = this
+        const dataColumn = grapherState.table.get(grapherState.yColumnSlug)
+        const sortedEntities = sortEntitiesByLastValue(entities, dataColumn)
+        grapherState.selection.setSelectedEntities(sortedEntities)
+    }
+
+    @action.bound async onSetDataRange() {
+        const { grapherState } = this
+        const dataColumn = grapherState.table.get(grapherState.yColumnSlug)
+        if (!dataColumn || dataColumn.isMissing || dataColumn.isEmpty) return
+
+        const additionalDataLoaderFn = grapherState.additionalDataLoaderFn
+        if (!additionalDataLoaderFn) return
+
+        const targetCount =
+            grapherState.isDiscreteBar || grapherState.isStackedDiscreteBar
+                ? 12
+                : 6
+
+        const availableEntities = prepareEntitiesForPeerSelection(grapherState)
+        const entities = await selectPeerCountries({
+            peerCountryStrategy: PeerCountryStrategy.DataRange,
+            availableEntities,
+            dataColumn,
+            additionalDataLoaderFn,
+            targetCount,
+            randomize: true,
+        })
+        grapherState.selection.setSelectedEntities(entities)
+    }
+
+    @computed private get shouldShow() {
+        // Presets don't make sense for single entity selection
+        const isSingleEntityMode =
+            this.grapherState.addCountryMode ===
+            EntitySelectionMode.SingleEntity
+
+        // No need for presets if the chart type typically has an empty selection
+        const isChartTypeThatShowsAllEntities =
+            this.grapherState.isScatter || this.grapherState.isMarimekko
+
+        if (isSingleEntityMode || isChartTypeThatShowsAllEntities) return false
+
+        // Check if there's at least one preset to show
+        return (
+            this.availablePresets.length > 0 || this.shouldShowDataRangeButton
+        )
+    }
+
+    @computed private get shouldShowDataRangeButton() {
+        // Data range selection doesn't make sense for stacked charts
+        if (this.grapherState.isStackedArea || this.grapherState.isStackedBar)
+            return false
+
+        // Data range selection doesn't make sense for charts with multiple y-columns
+        const hasMultipleYColumns = this.grapherState.yColumnSlugs.length > 1
+        if (hasMultipleYColumns) return false
+
+        // Data range selection is only supported for countries
+        const availableCountries =
+            this.grapherState.availableEntityNames.filter((entityName) => {
+                const region = getRegionByName(entityName)
+                return region && checkIsCountry(region)
+            })
+        if (availableCountries.length < 10) return false
+
+        const dataColumn = this.grapherState.table.get(
+            this.grapherState.yColumnSlug
+        )
+
+        // Check if a data column exists and has data
+        return dataColumn && !dataColumn.isMissing && !dataColumn.isEmpty
+    }
+
+    override render() {
+        if (!this.shouldShow) return null
+
+        return (
+            <div className="QuickAddSection">
+                <span className="quick-add-label">
+                    Presets{" "}
+                    <span className="quick-add-hint">(replaces selection)</span>
+                    :
+                </span>
+                <div className="quick-add-buttons">
+                    {this.availablePresets.map(({ preset, entities }) => (
+                        <button
+                            key={preset.id}
+                            className="btn btn-outline-secondary"
+                            onClick={() => this.onSelectPreset(entities)}
+                            title={`Replace current selection with ${preset.description}`}
+                        >
+                            {preset.label}
+                        </button>
+                    ))}
+                    {this.shouldShowDataRangeButton && (
+                        <button
+                            className="btn btn-outline-secondary"
+                            onClick={this.onSetDataRange}
+                            title="Replace current selection with countries representing the data range. Click multiple times for different results."
+                        >
+                            <FontAwesomeIcon icon={faDice} /> Data range
+                        </button>
+                    )}
+                </div>
+            </div>
+        )
+    }
+}
+
+@observer
+class AddPeersSection extends React.Component<{
+    editor: AbstractChartEditor
+}> {
+    chosenTargetCountry: EntityName | undefined = undefined
+
+    constructor(props: { editor: AbstractChartEditor }) {
+        super(props)
+        makeObservable(this, { chosenTargetCountry: observable.ref })
+    }
+
+    @computed get grapherState() {
+        return this.props.editor.grapherState
+    }
+
+    /** All selected entities that are countries (not aggregates) */
+    @computed get selectedCountries(): EntityName[] {
+        const { selection } = this.grapherState
+        return selection.selectedEntityNames.filter((entityName) => {
+            const region = getRegionByName(entityName)
+            return region && checkIsCountry(region)
+        })
+    }
+
+    /** The country to use as target for peer selection */
+    @computed get effectiveTargetCountry(): EntityName | undefined {
+        const { selectedCountries, chosenTargetCountry } = this
+        if (selectedCountries.length === 0) return undefined
+
+        // Use the chosen target country if it's still in the selection
+        if (
+            chosenTargetCountry &&
+            selectedCountries.includes(chosenTargetCountry)
+        ) {
+            return chosenTargetCountry
+        }
+
+        // Otherwise, just use the first selected country
+        return selectedCountries[0]
+    }
+
+    @computed get availableEntities(): EntityName[] {
+        return this.grapherState.availableEntityNames
+    }
+
+    private async getParentRegionPeersForCountry(
+        targetCountry: EntityName
+    ): Promise<EntityName[]> {
+        const availableEntities = prepareEntitiesForPeerSelection(
+            this.grapherState
+        )
+        return selectPeerCountries({
+            peerCountryStrategy: PeerCountryStrategy.ParentRegions,
+            targetCountry,
+            availableEntities,
+        })
+    }
+
+    @action.bound onTargetCountryChange(entityName: EntityName) {
+        this.chosenTargetCountry = entityName
+    }
+
+    @action.bound async onAddParentRegionPeers() {
+        if (!this.effectiveTargetCountry) return
+
+        const peers = await this.getParentRegionPeersForCountry(
+            this.effectiveTargetCountry
+        )
+
+        this.grapherState.selection.addToSelection(peers)
+    }
+
+    @action.bound async onAddGdpPerCapitaPeers() {
+        if (!this.effectiveTargetCountry) return
+
+        const availableEntities = prepareEntitiesForPeerSelection(
+            this.grapherState
+        )
+        const peers = await selectPeerCountries({
+            peerCountryStrategy: PeerCountryStrategy.GdpPerCapita,
+            targetCountry: this.effectiveTargetCountry,
+            availableEntities,
+            additionalDataLoaderFn: this.grapherState.additionalDataLoaderFn,
+        })
+
+        this.grapherState.selection.addToSelection(peers)
+    }
+
+    @action.bound async onAddPopulationPeers() {
+        if (!this.effectiveTargetCountry) return
+
+        const availableEntities = prepareEntitiesForPeerSelection(
+            this.grapherState
+        )
+        const peers = await selectPeerCountries({
+            peerCountryStrategy: PeerCountryStrategy.Population,
+            targetCountry: this.effectiveTargetCountry,
+            availableEntities,
+            additionalDataLoaderFn: this.grapherState.additionalDataLoaderFn,
+        })
+
+        this.grapherState.selection.addToSelection(peers)
+    }
+
+    @computed private get shouldShow() {
+        const isSingleEntityMode =
+            this.grapherState.addCountryMode ===
+            EntitySelectionMode.SingleEntity
+
+        return this.effectiveTargetCountry && !isSingleEntityMode
+    }
+
+    override render() {
+        const { effectiveTargetCountry, selectedCountries } = this
+
+        if (!this.shouldShow) return null
+
+        return (
+            <div className="AddPeersSection">
+                <div className="add-peers-header">
+                    Add peers for{" "}
+                    {selectedCountries.length > 1 ? (
+                        <select
+                            className="form-select form-select-sm add-peers-country-select"
+                            value={effectiveTargetCountry}
+                            onChange={(e) =>
+                                this.onTargetCountryChange(e.target.value)
+                            }
+                        >
+                            {selectedCountries.map((country) => (
+                                <option key={country} value={country}>
+                                    {country}
+                                </option>
+                            ))}
+                        </select>
+                    ) : (
+                        <strong>{effectiveTargetCountry}</strong>
+                    )}
+                    :
+                </div>
+                <div className="add-peers-buttons">
+                    <button
+                        className="btn btn-outline-secondary"
+                        onClick={this.onAddParentRegionPeers}
+                    >
+                        + Parent regions
+                    </button>
+                    <button
+                        className="btn btn-outline-secondary"
+                        onClick={this.onAddGdpPerCapitaPeers}
+                    >
+                        + Similar by GDP
+                    </button>
+                    <button
+                        className="btn btn-outline-secondary"
+                        onClick={this.onAddPopulationPeers}
+                    >
+                        + Similar by population
+                    </button>
+                </div>
+            </div>
+        )
+    }
+}
+
+@observer
 export class EntitySelectionSection extends React.Component<{
     editor: AbstractChartEditor
 }> {
@@ -159,6 +460,17 @@ export class EntitySelectionSection extends React.Component<{
         return this.props.editor
     }
 
+    @computed get liveSelection() {
+        return this.editor.originalGrapherConfig.selectedEntityNames ?? []
+    }
+
+    @computed get isSelectionDifferentFromLive() {
+        const { liveSelection } = this
+        const currentSelection =
+            this.editor.grapherState.selection.selectedEntityNames
+        return !_.isEqual(liveSelection, currentSelection)
+    }
+
     @action.bound onAddKey(entityName: EntityName) {
         this.editor.grapherState.selection.selectEntity(entityName)
         this.editor.removeInvalidFocusedSeriesNames()
@@ -167,6 +479,16 @@ export class EntitySelectionSection extends React.Component<{
     @action.bound onRemoveKey(entityName: EntityName) {
         this.editor.grapherState.selection.deselectEntity(entityName)
         this.editor.removeInvalidFocusedSeriesNames()
+    }
+
+    @action.bound onClearSelection() {
+        this.editor.grapherState.selection.clearSelection()
+    }
+
+    @action.bound onResetToLive() {
+        this.editor.grapherState.selection.setSelectedEntities(
+            this.liveSelection
+        )
     }
 
     @action.bound onDragEnd(items: { entityName: EntityName }[]) {
@@ -203,7 +525,7 @@ export class EntitySelectionSection extends React.Component<{
         const unselectedEntityNames = _.difference(
             grapherState.availableEntityNames,
             selectedEntityNames
-        )
+        ).sort()
 
         const isEntitySelectionInherited = editor.isPropertyInherited(
             "selectedEntityNames"
@@ -238,6 +560,7 @@ export class EntitySelectionSection extends React.Component<{
                         </button>
                     )}
                 </FieldsRow>
+                <QuickAddSection editor={editor} />
                 <SortableList<SortableListItemType>
                     items={listItems}
                     onChange={this.onDragEnd}
@@ -255,6 +578,28 @@ export class EntitySelectionSection extends React.Component<{
                         </SortableList.Item>
                     )}
                 />
+                <AddPeersSection editor={editor} />
+                <div className="SelectionResetButtons">
+                    {this.liveSelection.length > 0 &&
+                        this.isSelectionDifferentFromLive && (
+                            <button
+                                className="btn btn-secondary"
+                                onClick={this.onResetToLive}
+                                title="Reset to the published selection"
+                            >
+                                Reset to live
+                            </button>
+                        )}
+                    {!selection.isEmpty && (
+                        <button
+                            className="btn btn-secondary"
+                            onClick={this.onClearSelection}
+                            title="Clear current selection"
+                        >
+                            Clear
+                        </button>
+                    )}
+                </div>
                 {isEntitySelectionInherited && (
                     <p style={{ marginTop: "0.5em" }}>
                         <i>
@@ -320,9 +665,9 @@ export class FocusSection extends React.Component<{
         if (focusedSeriesNameSet.size === 0 && availableSeriesNameSet.size < 2)
             return null
 
-        const availableSeriesNames: SeriesName[] = _.sortBy(
-            Array.from(availableSeriesNameSet)
-        )
+        const availableSeriesNames: SeriesName[] = Array.from(
+            availableSeriesNameSet
+        ).sort()
 
         const invalidFocusedSeriesNames = differenceOfSets([
             focusedSeriesNameSet,

--- a/adminSiteClient/EntityPresets.ts
+++ b/adminSiteClient/EntityPresets.ts
@@ -1,0 +1,172 @@
+import { EntityName } from "@ourworldindata/types"
+import {
+    getContinents,
+    getIncomeGroups,
+    getAggregatesBySource,
+    AggregateSource,
+    AGGREGATE_SOURCES,
+} from "@ourworldindata/utils"
+import {
+    CUSTOM_REGION_SOURCE_IDS,
+    CustomAggregateSource,
+} from "@ourworldindata/grapher"
+import { CoreColumn } from "@ourworldindata/core-table"
+import * as _ from "lodash-es"
+
+export interface EntityPreset {
+    id: string
+    label: string
+    description: string
+    entities: EntityName[]
+}
+
+const AGGREGATE_SOURCE_LABELS: Record<AggregateSource, string> = {
+    un: "UN regions",
+    wb: "WB regions",
+    who: "WHO regions",
+    un_m49_1: "UN M49 (top)",
+    un_m49_2: "UN M49 (mid)",
+    un_m49_3: "UN M49 (detailed)",
+    pew: "Pew regions",
+    unsdg: "UN SDG regions",
+}
+
+const CUSTOM_SOURCE_LABELS: Record<CustomAggregateSource, string> = {
+    fao: "FAO regions",
+    ei: "EI regions",
+    pip: "PIP regions",
+    ember: "Ember regions",
+    gcp: "GCP regions",
+    niaid: "NIAID regions",
+    unicef: "UNICEF regions",
+    unaids: "UNAIDS regions",
+    undp: "UNDP regions",
+    wid: "WID regions",
+    oecd: "OECD regions",
+    unsd: "UNSD regions",
+    unm49: "UN M49 regions",
+}
+
+/** Extracts entities matching a custom source pattern like "Africa (FAO)" */
+function getEntitiesForCustomSource(
+    availableEntities: EntityName[],
+    sourceId: CustomAggregateSource
+): EntityName[] {
+    const suffix = ` (${sourceId.toLowerCase()})`
+    return availableEntities.filter((name) =>
+        name.trim().toLowerCase().endsWith(suffix)
+    )
+}
+
+/**
+ * Sorts entities by their last data point value in ascending order
+ * (smallest first). Entities without data are placed at the end.
+ */
+export function sortEntitiesByLastValue(
+    entities: EntityName[],
+    dataColumn: CoreColumn | undefined
+): EntityName[] {
+    if (!dataColumn) return entities
+
+    const rowsByEntity = dataColumn.owidRowsByEntityName
+
+    return _.sortBy(entities, (entity) => {
+        const rows = rowsByEntity.get(entity)
+
+        // Entities without data go to the end
+        if (!rows?.length) return Infinity
+
+        // Sort by latest value
+        const lastRow = _.maxBy(rows, (row) => row.time)
+        return lastRow ? lastRow.value : Infinity
+    })
+}
+
+/**
+ * Entity presets in priority order.
+ *
+ * When auto-selecting entities, we try these in order and use the first
+ * one that has enough available entities.
+ */
+export const STATIC_ENTITY_PRESETS: EntityPreset[] = [
+    {
+        id: "continents",
+        label: "Continents",
+        description: "OWID continents (Africa, Asia, Europe, etc.)",
+        entities: getContinents().map((r) => r.name),
+    },
+    {
+        id: "income_groups",
+        label: "Income groups",
+        description: "World Bank income groups",
+        entities: getIncomeGroups().map((r) => r.name),
+    },
+    // Add all aggregate sources
+    ...AGGREGATE_SOURCES.map(
+        (source): EntityPreset => ({
+            id: source,
+            label: AGGREGATE_SOURCE_LABELS[source],
+            description: `Regions defined by ${source.toUpperCase()}`,
+            entities: getAggregatesBySource(source).map((r) => r.name),
+        })
+    ),
+]
+
+export interface AvailablePreset {
+    preset: EntityPreset
+    entities: EntityName[]
+}
+
+/**
+ * Returns all entity presets that exist for the given available entities.
+ * Includes both static presets (continents, income groups, etc.) and
+ * dynamic presets for custom region sources detected in the data.
+ */
+export function getAvailablePresets(
+    availableEntityNames: EntityName[]
+): AvailablePreset[] {
+    const availableSet = new Set(availableEntityNames)
+
+    // Check static presets
+    const staticPresets = STATIC_ENTITY_PRESETS.map((preset) => {
+        const availableEntities = preset.entities.filter((name) =>
+            availableSet.has(name)
+        )
+        return { preset, entities: availableEntities }
+    }).filter(({ entities }) => entities.length >= 3)
+
+    // Check custom region sources (entities like "Africa (FAO)")
+    const customPresets = CUSTOM_REGION_SOURCE_IDS.map((sourceId) => {
+        const entities = getEntitiesForCustomSource(
+            availableEntityNames,
+            sourceId
+        )
+        const preset: EntityPreset = {
+            id: `custom_${sourceId}`,
+            label: CUSTOM_SOURCE_LABELS[sourceId],
+            description: `Regions defined by ${sourceId.toUpperCase()}`,
+            entities,
+        }
+        return { preset, entities }
+    }).filter(({ entities }) => entities.length >= 3)
+
+    return [...staticPresets, ...customPresets]
+}
+
+/**
+ * Tries presets in priority order and returns entities from the first
+ * preset that has enough available entities.
+ */
+export function pickFirstAvailablePreset(
+    availableEntityNames: EntityName[]
+): EntityName[] | undefined {
+    const availableSet = new Set(availableEntityNames)
+
+    const entityPresets = getAvailablePresets(availableEntityNames)
+
+    for (const preset of entityPresets) {
+        return preset.entities.filter((name) => availableSet.has(name))
+    }
+
+    return undefined
+}

--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -647,6 +647,78 @@ $nav-height: 45px;
     .btn-clear-selection {
         margin-bottom: 0.7rem;
     }
+
+    .QuickAddSection {
+        margin-bottom: 1rem;
+
+        .quick-add-label {
+            font-size: 0.85rem;
+            color: #666;
+            white-space: nowrap;
+            padding-top: 0.3rem; // align with button text
+
+            .quick-add-hint {
+                font-size: 0.8rem;
+                color: #999;
+            }
+        }
+
+        .quick-add-buttons {
+            margin-top: 0.3rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+
+            .btn {
+                font-size: 0.85rem;
+                padding: 0.25rem 0.5rem;
+            }
+        }
+    }
+
+    .AddPeersSection {
+        margin-top: 1rem;
+        padding: 0.75rem;
+        background: #fdfdfd;
+        border-radius: 3px;
+        border: 1px solid #e9ecef;
+
+        .add-peers-header {
+            font-size: 0.9rem;
+            margin-bottom: 0.5rem;
+
+            .add-peers-country-select {
+                display: inline-block;
+                width: auto;
+                font-weight: 600;
+                padding: 0.1rem 0.4rem;
+                font-size: 0.9rem;
+            }
+        }
+
+        .add-peers-buttons {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+
+            .btn {
+                font-size: 0.85rem;
+                padding: 0.25rem 0.5rem;
+            }
+        }
+    }
+
+    .SelectionResetButtons {
+        display: flex;
+        justify-content: flex-end;
+        gap: 0.5rem;
+        margin-top: 0.75rem;
+
+        .btn {
+            font-size: 0.85rem;
+            padding: 0.25rem 0.5rem;
+        }
+    }
 }
 
 /* Reusable utility classes */

--- a/packages/@ourworldindata/grapher/src/core/EntitiesByRegionType.ts
+++ b/packages/@ourworldindata/grapher/src/core/EntitiesByRegionType.ts
@@ -7,13 +7,16 @@ import {
     excludeUndefined,
     getRegionByName,
 } from "@ourworldindata/utils"
-import { CUSTOM_REGION_SOURCE_IDS, isWorldEntityName } from "./GrapherConstants"
+import {
+    CUSTOM_REGION_SOURCE_IDS,
+    CustomAggregateSource,
+    isWorldEntityName,
+} from "./GrapherConstants"
 import * as R from "remeda"
 
 const customAggregateSources = CUSTOM_REGION_SOURCE_IDS.filter(
     (source) => !AGGREGATE_SOURCES.includes(source as AggregateSource)
 )
-type CustomAggregateSource = (typeof customAggregateSources)[number]
 
 const entityRegionTypes = [
     "countries",

--- a/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
@@ -140,6 +140,8 @@ export const CUSTOM_REGION_SOURCE_IDS = [
     "unm49",
 ] as const
 
+export type CustomAggregateSource = (typeof CUSTOM_REGION_SOURCE_IDS)[number]
+
 export const isPopulationVariableETLPath = (path: string): boolean => {
     return population_regex.test(path)
 }

--- a/packages/@ourworldindata/grapher/src/index.ts
+++ b/packages/@ourworldindata/grapher/src/index.ts
@@ -36,6 +36,8 @@ export {
     latestGrapherConfigSchema,
     DEFAULT_GRAPHER_BOUNDS,
     DEFAULT_GRAPHER_BOUNDS_SQUARE,
+    CUSTOM_REGION_SOURCE_IDS,
+    type CustomAggregateSource,
 } from "./core/GrapherConstants"
 export {
     getVariableDataRoute,
@@ -143,7 +145,9 @@ export type { MarimekkoChartState } from "./stackedCharts/MarimekkoChartState"
 
 export {
     selectPeerCountriesForGrapher,
+    selectPeerCountries,
     isValidPeerCountryStrategyQueryParam,
+    prepareEntitiesForPeerSelection,
 } from "./core/PeerCountrySelection.js"
 
 export { loadCatalogData, getCatalogAssetKey } from "./core/loadCatalogData.js"

--- a/packages/@ourworldindata/grapher/src/selection/SelectionArray.ts
+++ b/packages/@ourworldindata/grapher/src/selection/SelectionArray.ts
@@ -20,6 +20,14 @@ export class SelectionArray {
         return this.numSelectedEntities > 0
     }
 
+    @computed get isEmpty(): boolean {
+        return this.store.size === 0
+    }
+
+    has(entityName: EntityName): boolean {
+        return this.store.has(entityName)
+    }
+
     @computed get numSelectedEntities(): number {
         return this.store.size
     }

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -207,6 +207,7 @@ export {
     getContinents,
     type Continent,
     getAggregates,
+    getAggregatesBySource,
     type Aggregate,
     type AggregateSource,
     AGGREGATE_SOURCES,

--- a/packages/@ourworldindata/utils/src/regions.ts
+++ b/packages/@ourworldindata/utils/src/regions.ts
@@ -161,6 +161,9 @@ export const getIncomeGroups = lazy(
         ) as IncomeGroup[]
 )
 
+export const getAggregatesBySource = (source: AggregateSource): Aggregate[] =>
+    getAggregates().filter((r) => r.definedBy === source)
+
 const regionsByName = lazy(() =>
     Object.fromEntries(regions.map((region) => [region.name, region]))
 )


### PR DESCRIPTION
Improves entity selection in the admin. 

Authors will be able to:
- Select from a list of presets (continents, income groups, WB regions, etc.)
- Select a random set of entities that represent the available data range
- For each selected country, add its peers based on one of the available strategies:
    - Adding parent regions (for example Europe and World for France)
    - Adding countries with similar population
    - Adding countries with similar GDP per capita
- Reset the selection to the currently live selection (or whatever is in the db)
- Clear the selection