### PR TITLE
🐛 add static viz to baker prefetched attachments

### DIFF
--- a/db/db.ts
+++ b/db/db.ts
@@ -839,6 +839,19 @@ export async function getGrapherLinkTargets(
     )
 }
 
+export async function getStaticVizLinkTargets(
+    knex: KnexReadonlyTransaction
+): Promise<Pick<DbPlainPostGdocLink, "target">[]> {
+    return knexRaw<Pick<DbPlainPostGdocLink, "target">>(
+        knex,
+        `-- sql
+        SELECT DISTINCT target
+        FROM posts_gdocs_links
+        WHERE linkType = '${ContentGraphLinkType.StaticViz}'
+        `
+    )
+}
+
 /**
  * Get the slugs of all datapages that are linked to in KeyIndicator blocks
  * Optionally exclude homepage KeyIndicator blocks, because for prefetching (the one current usecase for this function)


### PR DESCRIPTION
## Context

Fixes my glaring oversight in the static viz PR that didn't hook it up correctly in the site baker.

## Screenshots / Videos / Diagrams

<img width="829" height="880" alt="image" src="https://github.com/user-attachments/assets/93191f52-c4c4-4be7-a5d5-2ac4445e8355" />