### PR TITLE
feat(search): keep autocomplete panel open while typing

### DIFF
--- a/site/search/Autocomplete.scss
+++ b/site/search/Autocomplete.scss
@@ -178,8 +178,13 @@
 }
 
 .aa-PanelLayout {
-    margin: 6px;
+    margin: 0;
     padding: 0;
+}
+
+// Only add spacing when there are actual suggestion items (otherwise an empty panel is shown)
+.aa-PanelLayout:has(.aa-Item) {
+    margin: 6px;
 }
 
 /*

--- a/site/search/Autocomplete.tsx
+++ b/site/search/Autocomplete.tsx
@@ -374,6 +374,13 @@ export function Autocomplete({
                     onClose()
                 }
             },
+            // Keep the panel open while typing even if there are no suggestions (would otherwise close by default)
+            shouldPanelOpen({ state }) {
+                if (state.query) return true
+                return state.collections.some(
+                    (collection) => collection.items.length > 0
+                )
+            },
             onSubmit({ state, navigator }) {
                 if (!state.query) return
                 navigator.navigate({


### PR DESCRIPTION
fixes #5916

## Context

This PR improves the search autocomplete panel behavior by:
1. Keeping the panel open while typing even when there are no suggestions

## Screenshots / Videos / Diagrams

- Before: The autocomplete panel would close when there were no suggestions
- After: The panel stays open (active) while typing regardless of suggestions

## Testing guidance

1. Open the search box and start typing
2. Test with queries that have no results to verify the panel stays open

## Checklist

### Before merging

- [x] Changes to CSS/HTML were checked on Desktop and Mobile Safari at all three breakpoints
- [x] Changes to HTML were checked for accessibility concerns