### PR TITLE
🐛 (explorer) show display name in entity selector sort dropdown

### DIFF
--- a/packages/@ourworldindata/grapher/src/controls/entityPicker/EntityPicker.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/entityPicker/EntityPicker.tsx
@@ -176,16 +176,12 @@ export class EntityPicker extends React.Component<EntityPickerProps> {
                     value: entityNameColumn?.slug,
                 },
             ...this.pickerColumnDefs.map(
-                (
-                    col
-                ): {
-                    label: string
-                    value: string
-                } => {
-                    return {
-                        label: col.name || col.slug,
-                        value: col.slug,
-                    }
+                (columnDef): { label: string; value: string } => {
+                    const label =
+                        columnDef?.display?.name ||
+                        columnDef.name ||
+                        columnDef.slug
+                    return { label, value: columnDef.slug }
                 }
             ),
         ])


### PR DESCRIPTION
Fixes an issue where the slug was used as label in the explorer's entity picker

<img width="1213" height="793" alt="Screenshot 2026-01-26 at 13 55 01" src="https://github.com/user-attachments/assets/b53e9114-8b4e-48b3-b4b4-deeab1d804e0" />
