### PR TITLE
🐛 (scatter) fix overflowing legend labels on smaller screens

### DIFF
--- a/packages/@ourworldindata/grapher/src/legend/VerticalColorLegend.tsx
+++ b/packages/@ourworldindata/grapher/src/legend/VerticalColorLegend.tsx
@@ -78,6 +78,7 @@ export class VerticalColorLegend extends React.Component<{
             fontWeight: 700,
             lineHeight: 1,
             text: this.manager.legendTitle,
+            separators: [" ", "-"],
         })
     }
 
@@ -114,6 +115,7 @@ export class VerticalColorLegend extends React.Component<{
                 fontSize,
                 lineHeight: 1,
                 text: label,
+                separators: [" ", "-"],
             })
             const width = rectSize + rectPadding + textWrap.width
             const height = Math.max(textWrap.height, rectSize)


### PR DESCRIPTION
Resolves #6011 

Example: http://staging-site-fix-overflowing-legend/grapher/smoking-deaths-1990-2017

<img width="377" height="670" alt="Screenshot 2026-01-27 at 11 47 56" src="https://github.com/user-attachments/assets/3b216cb3-df34-46a8-812a-4de5e2734738" />
