### PR TITLE
Update static viz description field with markdown note and more rows

### DIFF
--- a/adminSiteClient/StaticVizEditPage.tsx
+++ b/adminSiteClient/StaticVizEditPage.tsx
@@ -376,7 +376,7 @@ export function StaticVizEditPage() {
                         <h4>Description</h4>
                         <p className="static-viz-edit-form__description">
                             Explain how this visualization was created.{" "}
-                            <strong>This field accepts markdown.</strong>
+                            <strong>This field accepts Markdown.</strong>
                         </p>
                         <Form.Item name="description">
                             <TextArea


### PR DESCRIPTION
Added a note indicating the description field accepts markdown and increased the textarea rows from 3 to 10 to improve usability for longer inputs.