### PR TITLE
🐛 (scatter) arrow legend in square exports

### DIFF
--- a/packages/@ourworldindata/grapher/src/scatterCharts/ConnectedScatterLegend.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ConnectedScatterLegend.tsx
@@ -5,6 +5,7 @@ import { TextWrap } from "@ourworldindata/components"
 import { BASE_FONT_SIZE } from "../core/GrapherConstants"
 import { makeIdForHumanConsumption } from "@ourworldindata/utils"
 import * as _ from "lodash-es"
+import { GRAPHER_DARK_TEXT, GRAY_70 } from "../color/ColorConstants.js"
 
 export interface ConnectedScatterLegendManager {
     sidebarWidth: number
@@ -12,23 +13,38 @@ export interface ConnectedScatterLegendManager {
     displayEndTime: string
     fontSize?: number
     compareEndPointsOnly?: boolean
+    isStaticAndSmall?: boolean
 }
 
 export class ConnectedScatterLegend {
     manager: ConnectedScatterLegendManager
+
+    private lineToLabelSpacing = 8
+    private dotRadius = 2
+    private arrowRadius = 3
+    private padding = this.arrowRadius
+    private textColor = GRAPHER_DARK_TEXT
+    private arrowColor = GRAY_70
+    private outlineColor = "#fff"
+    private outlineWidth = 0.2
+
     constructor(manager: ConnectedScatterLegendManager) {
         makeObservable(this)
         this.manager = manager
     }
 
     @computed get fontSize(): number {
-        return 0.7 * (this.manager.fontSize ?? BASE_FONT_SIZE)
+        const baseFontSize = this.manager.fontSize ?? BASE_FONT_SIZE
+        const fontScale = this.manager.isStaticAndSmall ? 0.5 : 0.7
+        return fontScale * baseFontSize
     }
-    @computed get fontColor(): string {
-        return "#333"
+
+    @computed get width(): number {
+        return this.manager.sidebarWidth
     }
+
     @computed get maxLabelWidth(): number {
-        return this.manager.sidebarWidth / 3
+        return (this.width - 2) / 2
     }
 
     @computed get startLabel(): TextWrap {
@@ -51,12 +67,12 @@ export class ConnectedScatterLegend {
         })
     }
 
-    @computed get width(): number {
-        return this.manager.sidebarWidth
+    @computed get maxLabelHeight(): number {
+        return Math.max(this.startLabel.height, this.endLabel.height)
     }
 
     @computed get height(): number {
-        return Math.max(this.startLabel.height, this.endLabel.height)
+        return this.maxLabelHeight + this.padding + this.lineToLabelSpacing
     }
 
     render(
@@ -64,11 +80,19 @@ export class ConnectedScatterLegend {
         targetY: number,
         renderOptions: React.SVGAttributes<SVGGElement> = {}
     ): React.ReactElement {
-        const { manager, startLabel, endLabel, fontColor } = this
+        const { startLabel, endLabel, padding, lineToLabelSpacing, width } =
+            this
 
-        const lineLeft = targetX + startLabel.width + 5
-        const lineRight = targetX + manager.sidebarWidth - endLabel.width - 5
-        const lineY = targetY + this.height / 2 - 0.5
+        // Arrow line
+        const lineLeft = targetX + padding
+        const lineRight = targetX + width - padding
+        const lineY = targetY + padding
+
+        // Labels below the line
+        const labelY = lineY + lineToLabelSpacing
+        const labelStartX = targetX
+        const labelEndX = targetX + width - endLabel.width
+        const labelProps = { textProps: { fill: this.textColor } }
 
         return (
             <g
@@ -84,58 +108,52 @@ export class ConnectedScatterLegend {
                     fill="#fff"
                     opacity={0}
                 />
-                {startLabel.renderSVG(targetX, targetY, {
-                    textProps: { fill: fontColor },
-                })}
-                {endLabel.renderSVG(
-                    targetX + manager.sidebarWidth - endLabel.width,
-                    targetY,
-                    { textProps: { fill: fontColor } }
-                )}
+                {startLabel.renderSVG(labelStartX, labelY, labelProps)}
+                {endLabel.renderSVG(labelEndX, labelY, labelProps)}
                 <line
                     x1={lineLeft}
                     y1={lineY}
                     x2={lineRight}
                     y2={lineY}
-                    stroke="#666"
+                    stroke={this.arrowColor}
                     strokeWidth={1}
                 />
                 <circle
                     cx={lineLeft}
                     cy={lineY}
-                    r={2}
-                    fill="#666"
-                    stroke="#ccc"
-                    strokeWidth={0.2}
+                    r={this.dotRadius}
+                    fill={this.arrowColor}
+                    stroke={this.outlineColor}
+                    strokeWidth={this.outlineWidth}
                 />
-                {!manager.compareEndPointsOnly && (
+                {!this.manager.compareEndPointsOnly && (
                     <React.Fragment>
                         <circle
                             cx={lineLeft + (lineRight - lineLeft) / 3}
                             cy={lineY}
-                            r={2}
-                            fill="#666"
-                            stroke="#ccc"
-                            strokeWidth={0.2}
+                            r={this.dotRadius}
+                            fill={this.arrowColor}
+                            stroke={this.outlineColor}
+                            strokeWidth={this.outlineWidth}
                         />
                         <circle
                             cx={lineLeft + (2 * (lineRight - lineLeft)) / 3}
                             cy={lineY}
-                            r={2}
-                            fill="#666"
-                            stroke="#ccc"
-                            strokeWidth={0.2}
+                            r={this.dotRadius}
+                            fill={this.arrowColor}
+                            stroke={this.outlineColor}
+                            strokeWidth={this.outlineWidth}
                         />
                     </React.Fragment>
                 )}
                 <Triangle
                     cx={lineRight}
                     cy={lineY}
-                    r={3}
+                    r={this.arrowRadius}
                     rotation={90}
-                    fill="#666"
-                    stroke="#ccc"
-                    strokeWidth={0.2}
+                    fill={this.arrowColor}
+                    stroke={this.outlineColor}
+                    strokeWidth={this.outlineWidth}
                 />
             </g>
         )

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
@@ -193,6 +193,10 @@ export class ScatterPlotChart
         return this.manager.fontSize ?? BASE_FONT_SIZE
     }
 
+    @computed get isStaticAndSmall(): boolean {
+        return !!this.manager.isStaticAndSmall
+    }
+
     @action.bound onLegendMouseOver(bin: ColorScaleBin): void {
         if (isTouchDevice()) return
         this.hoveredLegendColor = bin.color
@@ -345,6 +349,7 @@ export class ScatterPlotChart
     @computed.struct get sidebarWidth(): number {
         const { sidebarMinWidth, sidebarMaxWidth } = this
 
+        // No sidebar needed if there are no legends
         if (
             !this.verticalColorLegend &&
             !this.sizeLegend &&
@@ -353,10 +358,9 @@ export class ScatterPlotChart
         )
             return 0
 
-        return Math.max(
-            Math.min(this.verticalColorLegend?.width ?? 0, sidebarMaxWidth),
-            sidebarMinWidth
-        )
+        const colorLegendWidth = this.verticalColorLegend?.width ?? 0
+
+        return _.clamp(colorLegendWidth, sidebarMinWidth, sidebarMaxWidth)
     }
 
     @computed get dualAxis(): DualAxis {


### PR DESCRIPTION
Resolves https://github.com/owid/owid-grapher/issues/5989

I decided to rearrange the layout to make it better fit in smaller spaces. Sometimes the arrow legend is now quite long if we're unlucky. Marwa suggested a max width but that also looked awkward and in the typical case (color is continents) full width looks ok, so I decided to keep it as is.

Some of the charts reported by the SVG tester are not supposed to have arrow legends, but I think that's a data issue, so I raised with the data team

| Before | After |
|--------|--------|
| <img width="533" height="531" alt="Screenshot 2026-01-29 at 14 07 31" src="https://github.com/user-attachments/assets/16c7b6af-ed86-423f-abc9-34df744accad" /> | <img width="533" height="531" alt="Screenshot 2026-01-29 at 14 07 43" src="https://github.com/user-attachments/assets/1632d407-e09b-4ce0-a0e4-53b22df4edbf" /> | 

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #6025 
- <kbd>&nbsp;1&nbsp;</kbd> #6024 👈 
<!-- GitButler Footer Boundary Bottom -->

