### PR TITLE
✨ (stacked bar) align legend and chart area in relative mode

### DIFF
--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChart.tsx
@@ -579,7 +579,8 @@ export class StackedBarChart
     }
 
     @computed get legendY(): number {
-        return this.bounds.top
+        // Small offset aligns the legend with the chart area's top edge in relative mode
+        return this.bounds.top + 3
     }
 
     @computed get legendX(): number {


### PR DESCRIPTION
Pushing down the color legend a bit as a small visual correction

| Before | After |
|--------|--------|
| <img width="920" height="649" alt="Screenshot 2026-01-29 at 12 23 33" src="https://github.com/user-attachments/assets/cc771862-7982-4030-97e4-8f9736b87590" /> | <img width="920" height="649" alt="Screenshot 2026-01-29 at 12 23 20" src="https://github.com/user-attachments/assets/57fa07dd-c4a8-423f-a5db-0afe028895f4" /> | 