### PR TITLE
Fix link of multi-dim used in gdoc without controls

### DIFF
--- a/site/MultiDimEmbed.tsx
+++ b/site/MultiDimEmbed.tsx
@@ -2,15 +2,10 @@ import { MultiDimDataPageConfigEnriched } from "@ourworldindata/types"
 import {
     Url,
     fetchWithRetry,
-    searchParamsToMultiDimView,
     MultiDimDataPageConfig,
 } from "@ourworldindata/utils"
 import { useState, useEffect } from "react"
-import {
-    MULTI_DIM_DYNAMIC_CONFIG_URL,
-    GRAPHER_DYNAMIC_CONFIG_URL,
-} from "../settings/clientSettings.js"
-import { GrapherWithFallback } from "./GrapherWithFallback.js"
+import { MULTI_DIM_DYNAMIC_CONFIG_URL } from "../settings/clientSettings.js"
 import MultiDim from "./multiDim/MultiDim.js"
 import { GrapherProgrammaticInterface } from "@ourworldindata/grapher"
 
@@ -65,25 +60,6 @@ export const MultiDimEmbed: React.FC<MultiDimEmbedProps> = (
 
     if (!config || !slug) {
         return <div>Loading...</div>
-    }
-
-    if (embedUrl.queryParams.hideControls === "true") {
-        const view = searchParamsToMultiDimView(
-            config,
-            new URLSearchParams(queryStr)
-        )
-        const configUrl = `${GRAPHER_DYNAMIC_CONFIG_URL}/by-uuid/${view.fullConfigId}.config.json${isPreviewing ? "?nocache" : ""}`
-
-        return (
-            <GrapherWithFallback
-                configUrl={configUrl}
-                queryStr={queryStr}
-                config={props.chartConfig}
-                isEmbeddedInAnOwidPage={true}
-                isEmbeddedInADataPage={false}
-                isPreviewing={isPreviewing}
-            />
-        )
     }
 
     return (


### PR DESCRIPTION
We had a separate code path to render a multi-dim in a gdoc when it has `hideControls=true`. It didn't correctly propagate the slug to the Grapher state and it seems to be unnecessary. If we instead let the `MultiDim` component handle that case, it correctly sets the slug.

## Context

[Slack](https://owid.slack.com/archives/C46U9LXRR/p1769687891518369)

## Testing guidance

- [x] Does the change work in the archive?

@danyx23 do you remember why did we introduce the special case? IIRC `MultiDim` already handled the `hideControls=true` case, but we have a special case for it in `MultiEmbedder` so maybe an LLM got confused and thought it was necessary also in `MultiDimEmbed`?