### PR TITLE
🔨 remove focus mode as user-facing feature

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
@@ -1577,10 +1577,11 @@ export class GrapherState
     @computed get isAdmin(): boolean {
         if (typeof window === "undefined") return false
         if (this.isAdminObjectAvailable) return true
+
         // Using this.isAdminObjectAvailable is not enough because it's not
         // available in gdoc previews, which render in an iframe without the
         // admin scaffolding.
-        if (this.adminBaseUrl) {
+        if (this.adminBaseUrl && this.isInIFrame) {
             try {
                 const adminUrl = new URL(this.adminBaseUrl)
                 const currentUrl = new URL(window.location.href)
@@ -1589,6 +1590,7 @@ export class GrapherState
                 return false
             }
         }
+
         return false
     }
 

--- a/packages/@ourworldindata/grapher/src/facet/FacetChart.tsx
+++ b/packages/@ourworldindata/grapher/src/facet/FacetChart.tsx
@@ -805,21 +805,6 @@ export class FacetChart
         this.legendHoverBin = undefined
     }
 
-    @action.bound onLegendClick(bin: ColorScaleBin): void {
-        if (!this.manager.focusArray || !this.isFocusModeSupported) return
-
-        // find all series (of all facets) that are contained in the bin
-        const seriesNames = _.uniq(
-            this.intermediateChartInstances.flatMap((chartInstance) =>
-                chartInstance.chartState.series
-                    .filter((series) => bin.contains(series.seriesName))
-                    .map((series) => series.seriesName)
-            )
-        )
-
-        this.manager.focusArray.toggle(...seriesNames)
-    }
-
     getLegendBinState(bin: ColorScaleBin): LegendInteractionState {
         if (!this.activeColors && !this.hoverColors)
             return LegendInteractionState.Default
@@ -851,13 +836,6 @@ export class FacetChart
 
     @computed private get legend(): HorizontalColorLegend {
         return new this.LegendClass({ manager: this })
-    }
-
-    @computed private get isFocusModeSupported(): boolean {
-        return (
-            this.chartTypeName === GRAPHER_CHART_TYPES.LineChart ||
-            this.chartTypeName === GRAPHER_CHART_TYPES.SlopeChart
-        )
     }
 
     /**

--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
@@ -10,7 +10,6 @@ import {
     isMobile,
     Bounds,
     HorizontalAlign,
-    isTouchDevice,
 } from "@ourworldindata/utils"
 import { computed, action, observable, makeObservable } from "mobx"
 import { observer } from "mobx-react"
@@ -472,10 +471,6 @@ export class LineChart
         this.clearHighlightedSeries()
     }
 
-    @action.bound private onLineLegendClick(seriesName: SeriesName): void {
-        this.chartState.focusArray.toggle(seriesName)
-    }
-
     @computed private get hoveredSeriesNames(): string[] {
         const { externalLegendHoverBin } = this.manager
         const hoveredSeriesNames = excludeUndefined([
@@ -499,10 +494,6 @@ export class LineChart
             // the currently hovered series
             (!!this.manager.externalLegendHoverBin && !this.hasColorScale)
         )
-    }
-
-    @computed private get canToggleFocusMode(): boolean {
-        return !isTouchDevice() && this.series.length > 1
     }
 
     @computed private get hasTimeHighlights(): boolean {
@@ -654,11 +645,6 @@ export class LineChart
                         isStatic={this.isStatic}
                         onMouseOver={this.onLineLegendMouseOver}
                         onMouseLeave={this.onLineLegendMouseLeave}
-                        onClick={
-                            this.canToggleFocusMode
-                                ? this.onLineLegendClick
-                                : undefined
-                        }
                     />
                 )}
                 <Lines

--- a/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.tsx
+++ b/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.tsx
@@ -324,7 +324,6 @@ export interface LineLegendProps {
 
     // interactions
     isStatic?: boolean // don't add interactions if true
-    onClick?: (key: SeriesName) => void
     onMouseOver?: (key: SeriesName) => void
     onMouseLeave?: () => void
 }
@@ -494,9 +493,6 @@ export class LineLegend extends React.Component<LineLegendProps> {
     }
     @computed get onMouseLeave(): any {
         return this.props.onMouseLeave ?? _.noop
-    }
-    @computed get onClick(): any {
-        return this.props.onClick ?? _.noop
     }
 
     @computed get legendX(): number {
@@ -711,11 +707,9 @@ export class LineLegend extends React.Component<LineLegendProps> {
                     onMouseOver={(series): void =>
                         this.onMouseOver(series.seriesName)
                     }
-                    onClick={(series): void => this.onClick(series.seriesName)}
                     onMouseLeave={(series): void =>
                         this.onMouseLeave(series.seriesName)
                     }
-                    cursor={this.props.onClick ? "pointer" : "default"}
                 />
             </g>
         )

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
@@ -10,7 +10,6 @@ import {
     excludeUndefined,
     getRelativeMouse,
     dyFromAlign,
-    isTouchDevice,
     domainExtent,
     calculateTrendDirection,
 } from "@ourworldindata/utils"
@@ -163,10 +162,6 @@ export class SlopeChart
             // the currently hovered series
             !!this.manager.externalLegendHoverBin
         )
-    }
-
-    @computed private get canToggleFocusMode(): boolean {
-        return !isTouchDevice() && this.series.length > 1
     }
 
     @computed private get startTime(): Time {
@@ -378,9 +373,6 @@ export class SlopeChart
             textOutlineColor: this.backgroundColor,
             onMouseOver: this.onLineLegendMouseOver,
             onMouseLeave: this.onLineLegendMouseLeave,
-            onClick: this.canToggleFocusMode
-                ? this.onLineLegendClick
-                : undefined,
         }
     }
 
@@ -702,10 +694,6 @@ export class SlopeChart
         this.hoverTimer = window.setTimeout(() => {
             this.clearHoveredSeries()
         }, 200)
-    }
-
-    @action.bound onLineLegendClick(seriesName: SeriesName): void {
-        this.focusArray.toggle(seriesName)
     }
 
     @action.bound onSlopeMouseOver(series: SlopeChartSeries): void {


### PR DESCRIPTION
Drops support for focus mode as user-facing feature by removing click event handlers that allowed to focus/unfocus entities. We don't think there's a strong reason for exposing focus mode to users and this simplifies the UX before adding focus mode for more chart types.

This also makes adding focus mode for authors more cumbersome:
- They can add focused entities/columns in the admin (but that isn't an option for explorers and mdims)
- They can manually add `focus=Italy` to the URL, so for example in country profiles, we could do `?country=$countryCode&focus=$countryCode&peerCountries=auto`

If a user lands on an interactive chart in focus mode, making any change to the selection or switching views gets them out of it.

Example: http://staging-site-disable-user-focus/grapher/life-expectancy?focus=Asia