### PR TITLE
🎉 allow focusing columns in stacked discrete bar charts

### DIFF
--- a/packages/@ourworldindata/grapher/src/interaction/HighlightState.ts
+++ b/packages/@ourworldindata/grapher/src/interaction/HighlightState.ts
@@ -1,0 +1,29 @@
+import { InteractionState } from "./InteractionState"
+
+/** The visual state of a chart element */
+export enum HighlightState {
+    /** Actively highlighted */
+    Focus = "focus",
+    /** No interaction is active; normal appearance */
+    Default = "default",
+    /** Pushed to background */
+    Muted = "muted",
+}
+
+/**
+ * Combines two interaction dimensions into a single visual state.
+ *
+ * The override state takes precedence when active (e.g. hover overrides focus).
+ * When the override state is idle, the primary state determines the result.
+ */
+export function resolveHighlightState(
+    primaryState: InteractionState,
+    overrideState?: InteractionState
+): HighlightState {
+    const state =
+        !overrideState || overrideState.idle ? primaryState : overrideState
+
+    if (state.active) return HighlightState.Focus
+    if (state.background) return HighlightState.Muted
+    return HighlightState.Default
+}

--- a/packages/@ourworldindata/grapher/src/interaction/InteractionState.ts
+++ b/packages/@ourworldindata/grapher/src/interaction/InteractionState.ts
@@ -71,12 +71,4 @@ export class InteractionState {
     get background(): boolean {
         return this._isInteractionModeActive && !this._isInteractedWith
     }
-
-    /**
-     * Returns an interaction state representing no interaction.
-     * Useful when a dimension doesn't apply (e.g., no series interaction for labels).
-     */
-    static none(): InteractionState {
-        return new InteractionState(false, false)
-    }
 }

--- a/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoBarsForOneEntity.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoBarsForOneEntity.tsx
@@ -7,7 +7,7 @@ import {
     MarimekkoBarProps,
 } from "./MarimekkoChartConstants"
 import { InteractionState } from "../interaction/InteractionState.js"
-import { BAR_OPACITY } from "./StackedConstants"
+import { barOpacityByState } from "./StackedConstants"
 
 interface MarimekkoBarsProps {
     entityName: string
@@ -124,14 +124,14 @@ function MarimekkoBar({
     const strokeWidth = isHovered || isSelected ? 1 : 0.5
     const strokeOpacity = isPlaceholder ? 0.8 : isFaint ? 0.2 : 1.0
     const fillOpacity = isHovered
-        ? BAR_OPACITY.focus
+        ? barOpacityByState.focus
         : isFaint
-          ? BAR_OPACITY.muted
+          ? barOpacityByState.muted
           : isSelected
             ? isPlaceholder
                 ? 0.3
-                : BAR_OPACITY.default
-            : BAR_OPACITY.default
+                : barOpacityByState.default
+            : barOpacityByState.default
     const overalOpacity = isPlaceholder ? 0.2 : 1.0
 
     let barY: number

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
@@ -30,7 +30,7 @@ import {
     toTooltipTableColumns,
 } from "../tooltip/Tooltip"
 import { StackedAreaChartState } from "./StackedAreaChartState.js"
-import { AREA_OPACITY, StackedSeries } from "./StackedConstants"
+import { areaOpacityByState, StackedSeries } from "./StackedConstants"
 import {
     makeClipPath,
     isTargetOutsideElement,
@@ -249,11 +249,11 @@ export class StackedAreaChart
                 categoricalLegendData,
                 legendStyleConfig: {
                     marker: {
-                        default: { opacity: AREA_OPACITY.default },
-                        focused: { opacity: AREA_OPACITY.focus },
-                        muted: { opacity: AREA_OPACITY.muted },
+                        default: { opacity: areaOpacityByState.default },
+                        focused: { opacity: areaOpacityByState.focus },
+                        muted: { opacity: areaOpacityByState.muted },
                     },
-                    text: { muted: { opacity: AREA_OPACITY.muted } },
+                    text: { muted: { opacity: areaOpacityByState.muted } },
                 },
             }
         }
@@ -506,8 +506,8 @@ export class StackedAreaChart
                         const focused = name === target.series
                         const values = [point?.fake ? undefined : point?.value]
                         const opacity = focused
-                            ? AREA_OPACITY.focus
-                            : AREA_OPACITY.default
+                            ? areaOpacityByState.focus
+                            : areaOpacityByState.default
                         const swatch = { color, opacity }
 
                         return {

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreas.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreas.tsx
@@ -14,9 +14,9 @@ import { observer } from "mobx-react"
 import { DualAxis } from "../axis/Axis"
 import { rgb } from "d3-color"
 import {
-    AREA_OPACITY,
-    BORDER_OPACITY,
-    BORDER_WIDTH,
+    areaOpacityByState,
+    borderOpacityByState,
+    borderWidthByState,
     StackedPlacedPoint,
     StackedPlacedSeries,
     StackedPoint,
@@ -139,11 +139,11 @@ export class StackedAreas extends React.Component<AreasProps> {
             const points = [...placedPoints, ...prevPoints.toReversed()]
             const opacity =
                 !this.isHoverModeActive && !this.isFocusModeActive
-                    ? AREA_OPACITY.default // normal opacity
+                    ? areaOpacityByState.default // normal opacity
                     : hoveredSeriesName === series.seriesName ||
                         series.focus?.active
-                      ? AREA_OPACITY.focus // hovered or focused
-                      : AREA_OPACITY.muted // background
+                      ? areaOpacityByState.focus // hovered or focused
+                      : areaOpacityByState.muted // background
 
             return (
                 <path
@@ -173,16 +173,16 @@ export class StackedAreas extends React.Component<AreasProps> {
         return placedSeriesArr.map((placedSeries) => {
             const opacity =
                 !this.isHoverModeActive && !this.isFocusModeActive
-                    ? BORDER_OPACITY.DEFAULT // normal opacity
+                    ? borderOpacityByState.default // normal opacity
                     : hoveredSeriesName === placedSeries.seriesName ||
                         placedSeries.focus?.active
-                      ? BORDER_OPACITY.FOCUS // hovered or focused
-                      : BORDER_OPACITY.MUTE // background
+                      ? borderOpacityByState.focus // hovered or focused
+                      : borderOpacityByState.muted // background
             const strokeWidth =
                 hoveredSeriesName === placedSeries.seriesName ||
                 placedSeries.focus?.active
-                    ? BORDER_WIDTH.FOCUS
-                    : BORDER_WIDTH.DEFAULT
+                    ? borderWidthByState.focus
+                    : borderWidthByState.default
 
             return (
                 <path

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChart.tsx
@@ -31,7 +31,7 @@ import {
 } from "../core/GrapherConstants"
 import { StackedBarChartState } from "./StackedBarChartState.js"
 import {
-    BAR_OPACITY,
+    barOpacityByState,
     LEGEND_STYLE_FOR_STACKED_CHARTS,
     StackedPoint,
     StackedSeries,
@@ -423,8 +423,8 @@ export class StackedBarChart
 
                             const color = point?.color ?? seriesColor
                             const opacity = focused
-                                ? BAR_OPACITY.focus
-                                : BAR_OPACITY.default
+                                ? barOpacityByState.focus
+                                : barOpacityByState.default
                             const swatch = { color, opacity }
 
                             return { name, swatch, blurred, focused, values }

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarSegment.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarSegment.tsx
@@ -3,7 +3,11 @@ import * as React from "react"
 import { computed, action, observable, makeObservable } from "mobx"
 import { observer } from "mobx-react"
 import { Time } from "@ourworldindata/utils"
-import { BAR_OPACITY, StackedPoint, StackedSeries } from "./StackedConstants"
+import {
+    barOpacityByState,
+    StackedPoint,
+    StackedSeries,
+} from "./StackedConstants"
 import { VerticalAxis } from "../axis/Axis"
 
 interface StackedBarSegmentProps extends React.SVGAttributes<SVGGElement> {
@@ -52,7 +56,7 @@ export class StackedBarSegment extends React.Component<StackedBarSegmentProps> {
     }
 
     @computed get trueOpacity(): number {
-        return this.mouseOver ? BAR_OPACITY.focus : this.props.opacity
+        return this.mouseOver ? barOpacityByState.focus : this.props.opacity
     }
 
     @action.bound onBarMouseOver(): void {

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedBars.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedBars.tsx
@@ -3,7 +3,11 @@ import { makeObservable } from "mobx"
 import { observer } from "mobx-react"
 import { SeriesName, Time } from "@ourworldindata/types"
 import { DualAxis } from "../axis/Axis"
-import { BAR_OPACITY, StackedPoint, StackedSeries } from "./StackedConstants"
+import {
+    barOpacityByState,
+    StackedPoint,
+    StackedSeries,
+} from "./StackedConstants"
 import { makeFigmaId, makeSafeForCSS } from "@ourworldindata/utils"
 import { StackedBarSegment } from "./StackedBarSegment"
 import { CoreColumn } from "@ourworldindata/core-table"
@@ -52,8 +56,8 @@ export class StackedBars extends React.Component<StackedBarsProps> {
                     const opacity =
                         (isLegendHovered || hoveredSeriesNames.length === 0) &&
                         !series.focus?.background
-                            ? BAR_OPACITY.default
-                            : BAR_OPACITY.muted
+                            ? barOpacityByState.default
+                            : barOpacityByState.muted
 
                     return (
                         <g
@@ -67,11 +71,11 @@ export class StackedBars extends React.Component<StackedBarsProps> {
                                 const xPos =
                                     horizontalAxis.place(bar.position) -
                                     barWidth / 2
-                                const barOpacity =
+                                const finalOpacity =
                                     bar === hoveredBar ||
                                     series.focus?.active ||
                                     isLegendHovered
-                                        ? BAR_OPACITY.focus
+                                        ? barOpacityByState.focus
                                         : opacity
 
                                 return (
@@ -83,7 +87,7 @@ export class StackedBars extends React.Component<StackedBarsProps> {
                                         bar={bar}
                                         color={bar.color ?? series.color}
                                         xOffset={xPos}
-                                        opacity={barOpacity}
+                                        opacity={finalOpacity}
                                         yAxis={verticalAxis}
                                         series={series}
                                         onBarMouseOver={onBarMouseOver}

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedConstants.ts
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedConstants.ts
@@ -11,38 +11,38 @@ import {
     GRAPHER_AREA_OPACITY_MUTE,
 } from "../core/GrapherConstants"
 import { InteractionState } from "../interaction/InteractionState.js"
+import { HighlightState } from "../interaction/HighlightState.js"
 import { SeriesLabelState } from "../seriesLabel/SeriesLabelState.js"
 import { LegendStyleConfig } from "../legend/LegendInteractionState"
 
-export type HighlightState = "focus" | "default" | "muted"
-
-export const AREA_OPACITY: Record<HighlightState, number> = {
+export const areaOpacityByState: Record<HighlightState, number> = {
     default: GRAPHER_AREA_OPACITY_DEFAULT,
     focus: GRAPHER_AREA_OPACITY_FOCUS,
     muted: GRAPHER_AREA_OPACITY_MUTE,
 } as const
 
-export const BAR_OPACITY = AREA_OPACITY
+export const barOpacityByState = areaOpacityByState
 
-export const BORDER_OPACITY = {
-    DEFAULT: 0.7,
-    FOCUS: 1,
-    MUTE: 0.3,
+export const borderOpacityByState: Record<HighlightState, number> = {
+    default: 0.7,
+    focus: 1,
+    muted: 0.3,
 } as const
 
-export const BORDER_WIDTH = {
-    DEFAULT: 0.5,
-    FOCUS: 1.5,
+export const borderWidthByState: Record<HighlightState, number> = {
+    default: 0.5,
+    focus: 1.5,
+    muted: 0.5,
 } as const
 
 export const LEGEND_STYLE_FOR_STACKED_CHARTS: LegendStyleConfig = {
     marker: {
-        default: { opacity: AREA_OPACITY.default },
-        focused: { opacity: AREA_OPACITY.focus },
-        muted: { opacity: AREA_OPACITY.muted },
+        default: { opacity: areaOpacityByState.default },
+        focused: { opacity: areaOpacityByState.focus },
+        muted: { opacity: areaOpacityByState.muted },
     },
     text: {
-        muted: { opacity: AREA_OPACITY.muted },
+        muted: { opacity: areaOpacityByState.muted },
     },
 }
 

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBarChart.tsx
@@ -147,8 +147,7 @@ export class StackedDiscreteBarChart
             chartState: { hasFocusedColumn, focusArray },
         } = this
 
-        // If no column focus or legend hover is active, all items are default
-        // (entity focus doesn't affect the legend)
+        // No column is focused and no legend item is hovered
         if (!legendHoverSeriesName && !hasFocusedColumn) {
             return LegendInteractionState.Default
         }


### PR DESCRIPTION
## Context

This PR improves the interaction state handling in stacked discrete bar charts by implementing a more consistent highlighting system that properly handles multiple interaction types (legend hover, column focus, entity focus).

## Changes

- Added `InteractionState.none()` static method to create a neutral interaction state
- Refactored opacity constants to use a typed `HighlightState` enum (`focus`, `default`, `muted`)
- Improved bar highlighting logic to properly handle combinations of:
  - Legend hover
  - Column focus
  - Entity focus
  - Bar hover
- Added `hasFocusedColumn` helper to detect column-specific focus
- Renamed `focusSeriesName` to `legendHoverSeriesName` for clarity
- Implemented consistent opacity handling for both bars and labels

## Testing guidance

1. Open a stacked discrete bar chart (e.g., a chart with multiple series and entities)
2. Test the following interactions and verify highlighting works correctly:
   - Hover over legend items (should highlight corresponding bars)
   - Click on legend items (should focus those bars)
   - Hover over bars (should highlight that specific bar)
   - Click on entity labels (should highlight that entity's bars)
   - Test combinations of the above (e.g., legend hover while an entity is focused)

- [ ] Does the change work in the archive?
- [ ] Does the staging experience have sign-off from product stakeholders?

## Checklist

### Before merging

- [ ] Changes to CSS/HTML were checked on Desktop and Mobile Safari at all three breakpoints
- [ ] Changes to HTML were checked for accessibility concerns