### PR TITLE
✨ disable post-install scripts

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -15,3 +15,4 @@ npmPreapprovedPackages:
     - typescript
     - vite
     - vitest
+enableScripts: false


### PR DESCRIPTION
Resolves https://github.com/owid/owid-grapher/issues/5444

The affected deps:

```
@parcel/watcher@npm:2.5.1
@sentry-internal/node-cpu-profiler@npm:2.2.0
@sentry/cli@npm:2.57.0
core-js@npm:3.37.1
esbuild@npm:0.27.0
sharp@npm:0.34.5
unrs-resolver@npm:1.11.1
workerd@npm:1.20260120.0
```

All of these except core-js (which runs a donation message) are to make sure various binaries are installed (with fallbacks if not)

For example, the `@sentry/cli` install script checks to make sure that its optional dependencies have been installed (which might not be the case if `yarn install` was run with `--no-optional`)

Because we don't run `--no-optional`, all these checks are redundant.

Here's a claude-generated audit of these scripts which I verified 
[post_install_documentation.md](https://github.com/user-attachments/files/24943745/post_install_documentation.md)
