### PR TITLE
Remove getPrimaryTopic error logging

### DIFF
--- a/adminSiteServer/mockSiteRouter.ts
+++ b/adminSiteServer/mockSiteRouter.ts
@@ -323,17 +323,16 @@ getPlainRouteWithROTransaction(
     "/data-insights{/:pageNumberOrSlug}",
     async (req, res, trx) => {
         const topicName = req.query.topic as string | undefined
-        let topicTag: TopicTag | undefined
-        try {
-            topicTag = topicName
+        const topicSlug = topicName
+            ? await getSlugForTopicTag(trx, topicName)
+            : undefined
+        let topicTag: TopicTag | undefined =
+            topicName && topicSlug
                 ? {
                       name: topicName,
-                      slug: await getSlugForTopicTag(trx, topicName),
+                      slug: topicSlug,
                   }
                 : undefined
-        } catch {
-            topicTag = undefined
-        }
 
         const totalPageCount = calculateDataInsightIndexPageCount(
             await db.getPublishedDataInsightCount(trx, topicTag?.slug)

--- a/baker/GrapherBaker.tsx
+++ b/baker/GrapherBaker.tsx
@@ -207,8 +207,7 @@ export async function renderDataPageV2(
 
     datapageData.primaryTopic = await getPrimaryTopic(
         knex,
-        datapageData.topicTagsLinks,
-        grapher.slug
+        datapageData.topicTagsLinks
     )
 
     let imageMetadata: Record<string, ImageMetadata> = {}

--- a/baker/GrapherBakingUtils.ts
+++ b/baker/GrapherBakingUtils.ts
@@ -84,22 +84,14 @@ export async function getTagsWithDataInsights(
 }
 
 /**
- * Given a topic tag's name or ID, return its slug
- * Throws an error if no slug is found so we can log it in Sentry
+ * Given a topic tag's name or ID, return its slug.
  */
 export async function getSlugForTopicTag(
     knex: db.KnexReadonlyTransaction,
     identifier: string | number
-): Promise<string> {
-    const propertyToMatch = typeof identifier === "string" ? "slug" : "id"
+): Promise<string | undefined> {
     const tagsByIdAndName = await getTagToSlugMap(knex)
     const slug = tagsByIdAndName[identifier]
-
-    if (!slug) {
-        throw new Error(
-            `No slug found for tag with ${propertyToMatch}: "${identifier}"`
-        )
-    }
 
     return slug
 }

--- a/baker/MultiDimBaker.tsx
+++ b/baker/MultiDimBaker.tsx
@@ -132,11 +132,7 @@ export async function renderMultiDimDataPageFromConfig({
     const faqEntries = await getFaqEntries(knex, variableIds)
 
     // PRIMARY TOPIC
-    const primaryTopic = await getPrimaryTopic(
-        knex,
-        config.topicTags,
-        slug ?? undefined
-    )
+    const primaryTopic = await getPrimaryTopic(knex, config.topicTags)
 
     let tagToSlugMap: Record<string, string> = {}
     let relatedResearchCandidates: DataPageRelatedResearch[] = []


### PR DESCRIPTION
We now get a ton of false positives from this check when authors work on a new topic page, which introduces a new tag that gets a slug added only after publication, thus the check is no longer useful.

[Sentry](https://our-world-in-data.sentry.io/issues/37405224/)