### PR TITLE
 Updating Featured Metrics FAQ 

### DIFF
--- a/adminSiteClient/FeaturedMetricsPage.tsx
+++ b/adminSiteClient/FeaturedMetricsPage.tsx
@@ -416,7 +416,7 @@ function FeaturedMetricsExplainer() {
                         <>
                             <p>
                                 Featured Metrics get indexed by the weekly
-                                Algolia sync, which runs every Friday at 19:00
+                                Algolia sync, which runs every Monday at 19:00
                                 UTC.
                             </p>
                         </>


### PR DESCRIPTION
## Context

Algolia indexing now happens on Mondays at 1900 UTC, as this is when new topic pages are published. This simply updates the FAQ to reflect that. 

## Screenshots / Videos / Diagrams

<img width="449" height="184" alt="Screenshot 2026-02-02 at 10 57 20" src="https://github.com/user-attachments/assets/67025491-6110-4cde-b8ae-5f6ed30a0f1b" />

