### PR TITLE
🔨 add SeriesLabel component for consistent label rendering

### DIFF
--- a/packages/@ourworldindata/components/src/MarkdownTextWrap/MarkdownTextWrap.tsx
+++ b/packages/@ourworldindata/components/src/MarkdownTextWrap/MarkdownTextWrap.tsx
@@ -556,22 +556,14 @@ export class MarkdownTextWrap extends React.Component<MarkdownTextWrapProps> {
             })
         }
 
-        // if newLine is set to 'avoid-wrap', we first try to fit the secondary text
+        // If newLine is set to 'avoid-wrap', we first try to fit the secondary text
         // on the same line as the main text. If it doesn't fit, we place it on a new line.
-
         const mainTextWrap = new MarkdownTextWrap({ ...main, ...textWrapProps })
-        const secondaryTextWrap = new MarkdownTextWrap({
-            text: secondaryMarkdownText,
-            ...textWrapProps,
-            maxWidth:
-                mainTextWrap.maxWidth -
-                mainTextWrap.lastLineWidth -
-                Bounds.forText(" ", textWrapProps).width -
-                10, // arbitrary wiggle room
+        const secondaryTextFitsOnSameLine = canAppendTextToLastLine({
+            existingTextWrap: mainTextWrap,
+            textToAppend: secondaryMarkdownText,
         })
 
-        const secondaryTextFitsOnSameLine =
-            secondaryTextWrap.svgLines.length === 1
         if (secondaryTextFitsOnSameLine) {
             return new MarkdownTextWrap({
                 text: combinedTextContinued,
@@ -1153,6 +1145,27 @@ function appendReferenceNumbers(
     )
 
     return appendedTokens
+}
+
+export function canAppendTextToLastLine({
+    existingTextWrap,
+    textToAppend,
+}: {
+    existingTextWrap: TextWrap | MarkdownTextWrap
+    textToAppend: string
+}): boolean {
+    const { maxWidth, lastLineWidth, fontSize, props } = existingTextWrap
+
+    const spaceWidth = Bounds.forText(" ", { fontSize }).width
+    const availableWidthInLastLine = maxWidth - lastLineWidth - spaceWidth - 10
+
+    const secondaryTextWrap = new MarkdownTextWrap({
+        ...props,
+        text: textToAppend,
+        maxWidth: availableWidthInLastLine,
+    })
+
+    return secondaryTextWrap.svgLines.length === 1
 }
 
 function maybeBoldMarkdownText({

--- a/packages/@ourworldindata/components/src/index.ts
+++ b/packages/@ourworldindata/components/src/index.ts
@@ -4,6 +4,7 @@ export {
     MarkdownTextWrap,
     sumTextWrapHeights,
     toPlaintext,
+    canAppendTextToLastLine,
 } from "./MarkdownTextWrap/MarkdownTextWrap.js"
 
 export {

--- a/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChart.tsx
@@ -19,6 +19,7 @@ import {
     GRAPHER_FONT_SCALE_12,
     GRAPHER_AREA_OPACITY_DEFAULT,
     GRAPHER_AREA_OPACITY_MUTE,
+    FontSettings,
 } from "../core/GrapherConstants"
 import { NoDataModal } from "../noDataModal/NoDataModal"
 import { HorizontalAxisZeroLine } from "../axis/AxisViews"
@@ -28,7 +29,6 @@ import {
     BAR_SPACING_FACTOR,
     DiscreteBarChartManager,
     DiscreteBarSeries,
-    FontSettings,
     PlacedDiscreteBarSeries,
     SizedDiscreteBarSeries,
 } from "./DiscreteBarChartConstants"
@@ -43,6 +43,7 @@ import {
     makeProjectedDataPatternId,
     enrichSeriesWithLabels,
 } from "./DiscreteBarChartHelpers"
+import { SeriesLabel } from "../seriesLabel/SeriesLabel.js"
 import { OwidTable } from "@ourworldindata/core-table"
 import { HorizontalAxis } from "../axis/Axis"
 import { GRAPHER_DARK_TEXT } from "../color/ColorConstants"
@@ -413,15 +414,18 @@ export class DiscreteBarChart
     }): React.ReactElement | null {
         if (!series.label) return null
 
-        return series.label.renderSVG(series.entityLabelX, barY + labelY, {
-            textProps: {
-                fill: "#555",
-                textAnchor: "end",
-                opacity: series.focus.background
-                    ? GRAPHER_AREA_OPACITY_MUTE
-                    : 1,
-            },
-        })
+        return (
+            <SeriesLabel
+                state={series.label}
+                x={series.entityLabelX}
+                y={barY + labelY}
+                fill="#555"
+                textAnchor="end"
+                opacity={
+                    series.focus.background ? GRAPHER_AREA_OPACITY_MUTE : 1
+                }
+            />
+        )
     }
 
     private renderEntityAnnotation({

--- a/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChartConstants.ts
+++ b/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChartConstants.ts
@@ -4,6 +4,7 @@ import { ChartSeries } from "../chart/ChartInterface"
 import { Color, CoreValueType, Time } from "@ourworldindata/types"
 import { TextWrap } from "@ourworldindata/components"
 import { InteractionState } from "../interaction/InteractionState.js"
+import { SeriesLabelState } from "../seriesLabel/SeriesLabelState.js"
 
 export interface DiscreteBarSeries extends ChartSeries {
     entityName: string
@@ -17,7 +18,7 @@ export interface DiscreteBarSeries extends ChartSeries {
 }
 
 export interface SizedDiscreteBarSeries extends DiscreteBarSeries {
-    label: TextWrap
+    label: SeriesLabelState
     annotationTextWrap?: TextWrap
 }
 
@@ -48,12 +49,6 @@ export interface DiscreteBarItem {
     time: number
     colorValue?: CoreValueType
     color?: Color
-}
-
-export interface FontSettings {
-    fontSize: number
-    fontWeight: number
-    lineHeight: number
 }
 
 export const BACKGROUND_COLOR = "#fff"

--- a/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChartHelpers.ts
+++ b/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChartHelpers.ts
@@ -1,7 +1,8 @@
 import * as _ from "lodash-es"
 import { TextWrap, shortenWithEllipsis } from "@ourworldindata/components"
 import { EntityName } from "@ourworldindata/types"
-import { FontSettings } from "./DiscreteBarChartConstants.js"
+import { FontSettings } from "../core/GrapherConstants.js"
+import { SeriesLabelState } from "../seriesLabel/SeriesLabelState.js"
 
 const ANNOTATION_PADDING = 2
 
@@ -200,7 +201,7 @@ export function enrichSeriesWithLabels<
     maxLabelWidth: number
     fontSettings: FontSettings
     annotationFontSettings?: FontSettings
-}): (TSeries & { label: TextWrap; annotationTextWrap?: TextWrap })[] {
+}): (TSeries & { label: SeriesLabelState; annotationTextWrap?: TextWrap })[] {
     // Wrap labels and annotations to fit within the available space
     const wrappedLabels = series.map((series) => {
         const label = series.shortEntityName ?? series.entityName
@@ -273,7 +274,9 @@ export function enrichSeriesWithLabels<
     if (!needsTruncation)
         return series.map((series, index) => ({
             ...series,
-            label: wrappedLabels[index].labelWrap,
+            label: SeriesLabelState.fromTextWrap(
+                wrappedLabels[index].labelWrap
+            ),
             annotationTextWrap: wrappedLabels[index].annotationWrap,
         }))
 
@@ -332,7 +335,7 @@ export function enrichSeriesWithLabels<
 
     return series.map((series, index) => ({
         ...series,
-        label: truncatedLabels[index],
+        label: SeriesLabelState.fromTextWrap(truncatedLabels[index]),
         annotationTextWrap: truncatedAnnotations[index],
     }))
 }

--- a/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
@@ -173,3 +173,9 @@ export const CHART_TYPES_THAT_SHOW_ALL_ENTITIES: GrapherChartType[] = [
     GRAPHER_CHART_TYPES.ScatterPlot,
     GRAPHER_CHART_TYPES.Marimekko,
 ]
+
+export interface FontSettings {
+    fontSize: number
+    fontWeight: number
+    lineHeight: number
+}

--- a/packages/@ourworldindata/grapher/src/core/RegionGroups.ts
+++ b/packages/@ourworldindata/grapher/src/core/RegionGroups.ts
@@ -147,7 +147,7 @@ export function groupEntitiesByRegionType(
 
     const entitiesByProvider = new Map<AnyRegionDataProvider, EntityName[]>()
     for (const entityName of availableEntityNames) {
-        const parsedEntityName = parseEntityName(entityName)
+        const parsedEntityName = parseLabelWithSuffix(entityName)
         if (parsedEntityName.type === "regionWithProviderSuffix") {
             const providerKey = parsedEntityName.providerKey
             if (!entitiesByProvider.get(providerKey))
@@ -171,7 +171,7 @@ export function groupEntitiesByRegionType(
     return entitiesByRegionGroup
 }
 
-type ParsedEntityName =
+export type ParsedLabel =
     | { type: "plain"; name: string; suffix?: string }
     | {
           type: "regionWithProviderSuffix"
@@ -180,7 +180,7 @@ type ParsedEntityName =
           providerKey: AnyRegionDataProvider
       }
 
-export function parseEntityName(entityName: string): ParsedEntityName {
+export function parseLabelWithSuffix(entityName: string): ParsedLabel {
     const match = entityName.match(/^(.+)\s+\(([^)]+)\)$/)
     if (!match) return { type: "plain", name: entityName }
 
@@ -190,7 +190,7 @@ export function parseEntityName(entityName: string): ParsedEntityName {
 
     const providerKey = toProviderKey(suffix)
     if (!providerKey || !isRegionDataProviderKey(providerKey))
-        return { type: "plain", name: entityName, suffix }
+        return { type: "plain", name, suffix }
 
     return {
         type: "regionWithProviderSuffix",

--- a/packages/@ourworldindata/grapher/src/lineLegend/LineLegendTypes.ts
+++ b/packages/@ourworldindata/grapher/src/lineLegend/LineLegendTypes.ts
@@ -1,4 +1,5 @@
-import { MarkdownTextWrap, TextWrap } from "@ourworldindata/components"
+import { TextWrap } from "@ourworldindata/components"
+import { SeriesLabelState } from "../seriesLabel/SeriesLabelState.js"
 import { Bounds } from "@ourworldindata/utils"
 import { ChartSeries } from "../chart/ChartInterface"
 import { InteractionState } from "../interaction/InteractionState"
@@ -15,7 +16,7 @@ export interface LineLabelSeries extends ChartSeries {
 }
 
 export interface SizedSeries extends LineLabelSeries {
-    textWrap: TextWrap | MarkdownTextWrap
+    seriesLabel: SeriesLabelState
     annotationTextWrap?: TextWrap
     width: number
     height: number

--- a/packages/@ourworldindata/grapher/src/seriesLabel/SeriesLabel.tsx
+++ b/packages/@ourworldindata/grapher/src/seriesLabel/SeriesLabel.tsx
@@ -1,0 +1,173 @@
+import { GRAPHER_LIGHT_TEXT } from "../color/ColorConstants.js"
+import { FragmentLayout, SeriesLabelState } from "./SeriesLabelState.js"
+
+export interface SeriesLabelProps {
+    state: SeriesLabelState
+    x: number
+    y: number
+    id?: string
+    fill?: string
+    opacity?: number
+    textAnchor?: "start" | "end"
+    onMouseEnter?: React.MouseEventHandler<SVGTextElement>
+    onMouseLeave?: React.MouseEventHandler<SVGTextElement>
+}
+
+/**
+ * Renders a series label with up to three fragments: name, suffix, and value.
+ *
+ * Fragments:
+ * - Name: The main label text, which may wrap across multiple lines
+ * - Suffix: Parenthetical text like "(WHO)" rendered in muted gray
+ * - Value: Optional formatted value
+ *
+ * Examples:
+ * - "France" -> Name only
+ * - "Europe (WB)" -> Name with suffix
+ * - "United States 45,000" -> Name and value
+ * - "Middle East and North Africa (WHO) 2,500" -> Name with suffix and value
+ */
+export function SeriesLabel({
+    state,
+    x,
+    y,
+    id,
+    fill,
+    opacity,
+    textAnchor = "start",
+    onMouseEnter,
+    onMouseLeave,
+}: SeriesLabelProps): React.ReactElement {
+    const { nameWrap, suffixLayout, valueLayout } = state
+
+    const textProps: React.SVGProps<SVGTextElement> = {
+        fill,
+        opacity,
+        textAnchor,
+    }
+
+    const suffixTextProps = { ...textProps, fill: GRAPHER_LIGHT_TEXT }
+
+    // Calculate x position for a fragment
+    const fragmentX = (layout: FragmentLayout) => {
+        return x + (textAnchor === "end" ? -1 : 1) * layout.position.dx
+    }
+
+    // Calculate y position for a fragment
+    const fragmentY = (layout: FragmentLayout) => {
+        return y + layout.position.dy
+    }
+
+    // When textAnchor="end" and a fragment is on the same line as the name,
+    // we need special rendering to ensure proper right-alignment
+    const needsManualEndAlignment =
+        textAnchor === "end" &&
+        ((suffixLayout && !suffixLayout.onNewLine) ||
+            (valueLayout && !valueLayout.onNewLine))
+    if (needsManualEndAlignment) {
+        return (
+            <g id={id} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
+                <ManuallyEndAlignedLabel
+                    state={state}
+                    x={x}
+                    y={y}
+                    textProps={textProps}
+                />
+
+                {/* Only render fragments on new lines.
+                    If they are on the same line as the name,
+                    they are rendered inside ManuallyEndAlignedLabel above */}
+                {suffixLayout?.onNewLine &&
+                    suffixLayout?.textWrap.renderSVG(
+                        fragmentX(suffixLayout),
+                        fragmentY(suffixLayout),
+                        { textProps: suffixTextProps }
+                    )}
+                {valueLayout?.onNewLine &&
+                    valueLayout?.textWrap.renderSVG(
+                        fragmentX(valueLayout),
+                        fragmentY(valueLayout),
+                        { textProps }
+                    )}
+            </g>
+        )
+    }
+
+    return (
+        <g id={id} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
+            {nameWrap.renderSVG(x, y, { textProps })}
+
+            {suffixLayout?.textWrap.renderSVG(
+                fragmentX(suffixLayout),
+                fragmentY(suffixLayout),
+                { textProps: suffixTextProps }
+            )}
+
+            {valueLayout?.textWrap.renderSVG(
+                fragmentX(valueLayout),
+                fragmentY(valueLayout),
+                { textProps }
+            )}
+        </g>
+    )
+}
+
+/**
+ * Renders the name and suffix/value fragments if one fragment is placed on the
+ * same line as the name. This ensures proper alignment when textAnchor is set
+ * to "end"
+ */
+function ManuallyEndAlignedLabel({
+    state,
+    x,
+    y,
+    textProps,
+}: {
+    state: SeriesLabelState
+    x: number
+    y: number
+    textProps: React.SVGProps<SVGTextElement>
+}): React.ReactElement {
+    const { nameWrap, suffixLayout, valueLayout } = state
+    const { lines, singleLineHeight, fontSize, fontWeight } = nameWrap
+
+    // Get the corrected y position from TextWrap
+    const [, renderY] = nameWrap.getPositionForSvgRendering(x, y)
+
+    const allButLastLine = lines.slice(0, -1)
+    const lastLine = lines[lines.length - 1]
+    const lastLineY = renderY + (lines.length - 1) * singleLineHeight
+
+    return (
+        <text
+            fontSize={fontSize.toFixed(2)}
+            fontWeight={fontWeight}
+            {...textProps}
+        >
+            {/* Render all lines except the last one normally */}
+            {allButLastLine.map((line, i) => (
+                <tspan key={i} x={x} y={renderY + i * singleLineHeight}>
+                    {line.text}
+                </tspan>
+            ))}
+
+            {/* Last line of the name + any same-line fragments */}
+            <tspan x={x} y={lastLineY}>
+                {lastLine.text}{" "}
+                {suffixLayout && !suffixLayout.onNewLine && (
+                    <tspan
+                        fill={GRAPHER_LIGHT_TEXT}
+                        fontWeight={suffixLayout.textWrap.fontWeight}
+                    >
+                        {suffixLayout.textWrap.text}
+                    </tspan>
+                )}
+                {valueLayout && !valueLayout.onNewLine && (
+                    <tspan fontWeight={valueLayout.textWrap.fontWeight}>
+                        {valueLayout.textWrap.text}
+                    </tspan>
+                )}
+            </tspan>
+        </text>
+    )
+}

--- a/packages/@ourworldindata/grapher/src/seriesLabel/SeriesLabelState.ts
+++ b/packages/@ourworldindata/grapher/src/seriesLabel/SeriesLabelState.ts
@@ -1,0 +1,260 @@
+import { computed, makeObservable } from "mobx"
+import { Bounds, RequiredBy } from "@ourworldindata/utils"
+import { canAppendTextToLastLine, TextWrap } from "@ourworldindata/components"
+import { ParsedLabel, parseLabelWithSuffix } from "../core/RegionGroups.js"
+import { FontSettings } from "../core/GrapherConstants.js"
+import { match } from "ts-pattern"
+
+export interface SeriesLabelStateOptions {
+    text: string
+    maxWidth: number
+    fontSize: number
+    fontWeight?: number
+    lineHeight?: number
+    formattedValue?: string
+    placeFormattedValueInNewLine?: boolean
+}
+
+interface RelativePosition {
+    dx: number
+    dy: number
+}
+
+export interface FragmentLayout {
+    onNewLine: boolean
+    position: RelativePosition
+    textWrap: TextWrap
+}
+
+/**
+ * Manages the layout for a series label in charts.
+ *
+ * A series label can consist of up to three parts:
+ * 1. **Name**: The main label text (e.g. "United States")
+ * 2. **Suffix**: An optional parenthetical suffix parsed from the name
+ *                (e.g. "(historical)" or "(WHO)")
+ * 3. **Value**: An optional formatted value to display alongside the name
+ *                (e.g. "45.2%")
+ */
+export class SeriesLabelState {
+    private initialOptions: SeriesLabelStateOptions
+
+    private defaultOptions = {
+        fontWeight: 400,
+        lineHeight: 1.1,
+        placeFormattedValueInNewLine: false,
+    } as const satisfies Partial<SeriesLabelStateOptions>
+
+    constructor(options: SeriesLabelStateOptions) {
+        this.initialOptions = options
+        makeObservable(this)
+    }
+
+    static fromTextWrap(textWrap: TextWrap): SeriesLabelState {
+        return new SeriesLabelState({
+            text: textWrap.text,
+            maxWidth: textWrap.maxWidth,
+            fontSize: textWrap.fontSize,
+            fontWeight: textWrap?.fontWeight,
+            lineHeight: textWrap?.lineHeight,
+        })
+    }
+
+    @computed private get options(): RequiredBy<
+        SeriesLabelStateOptions,
+        keyof typeof this.defaultOptions
+    > {
+        return { ...this.defaultOptions, ...this.initialOptions }
+    }
+
+    @computed get text(): string {
+        return this.options.text
+    }
+
+    @computed private get parsedText(): ParsedLabel {
+        return parseLabelWithSuffix(this.text)
+    }
+
+    @computed private get name(): string {
+        return match(this.parsedText)
+            .with({ type: "plain" }, (parsedText) => {
+                const { name, suffix } = parsedText
+                return suffix ? `${name} (${suffix})` : name
+            })
+            .with(
+                { type: "regionWithProviderSuffix" },
+                (parsedText) => parsedText.name
+            )
+            .exhaustive()
+    }
+
+    @computed get nameWrap(): TextWrap {
+        return new TextWrap({
+            text: this.name,
+            maxWidth: this.options.maxWidth,
+            ...this.fontSettings,
+        })
+    }
+
+    @computed get fontSettings(): FontSettings {
+        return {
+            fontSize: this.options.fontSize,
+            lineHeight: this.options.lineHeight,
+            fontWeight: this.options.fontWeight,
+        }
+    }
+
+    @computed get singleLineHeight(): number {
+        return this.nameWrap.singleLineHeight
+    }
+
+    @computed private get isRegionWithProviderSuffix(): boolean {
+        return this.parsedText.type === "regionWithProviderSuffix"
+    }
+
+    @computed get suffixLayout(): FragmentLayout | undefined {
+        if (!this.isRegionWithProviderSuffix) return undefined
+
+        const text = `(${this.parsedText.suffix})`
+
+        const fitsOnSameLineAsName = canAppendTextToLastLine({
+            existingTextWrap: this.nameWrap,
+            textToAppend: text,
+        })
+
+        const position = calculateRelativeAppendPosition({
+            existingTextWrap: this.nameWrap,
+            fitsOnLastLine: fitsOnSameLineAsName,
+        })
+
+        const maxWidth = fitsOnSameLineAsName ? Infinity : this.options.maxWidth
+        const fontSettings = { ...this.fontSettings, fontWeight: 400 }
+        const textWrap = new TextWrap({
+            text,
+            maxWidth,
+            ...fontSettings,
+        })
+
+        return { onNewLine: !fitsOnSameLineAsName, position, textWrap }
+    }
+
+    @computed get valueLayout(): FragmentLayout | undefined {
+        const text = this.options.formattedValue
+
+        if (!text) return undefined
+
+        const fontSettings = { ...this.fontSettings, fontWeight: 400 }
+        const fullWidthTextWrap = new TextWrap({
+            text,
+            maxWidth: this.options.maxWidth,
+            ...fontSettings,
+        })
+
+        // Always place on new line if there is a suffix
+        if (this.suffixLayout) {
+            const dy = this.suffixLayout.onNewLine
+                ? this.nameWrap.height + this.suffixLayout.textWrap.height
+                : this.nameWrap.height
+
+            return {
+                onNewLine: true,
+                position: { dx: 0, dy },
+                textWrap: fullWidthTextWrap,
+            }
+        }
+
+        // Always place on new line if requested
+        if (this.options.placeFormattedValueInNewLine) {
+            return {
+                onNewLine: true,
+                position: calculateRelativeAppendPosition({
+                    existingTextWrap: this.nameWrap,
+                    fitsOnLastLine: false,
+                }),
+                textWrap: fullWidthTextWrap,
+            }
+        }
+
+        const fitsOnSameLineAsName = canAppendTextToLastLine({
+            existingTextWrap: this.nameWrap,
+            textToAppend: text,
+        })
+
+        const position = calculateRelativeAppendPosition({
+            existingTextWrap: this.nameWrap,
+            fitsOnLastLine: fitsOnSameLineAsName,
+        })
+
+        const maxWidth = fitsOnSameLineAsName ? Infinity : this.options.maxWidth
+        const textWrap = new TextWrap({
+            text,
+            maxWidth,
+            ...fontSettings,
+        })
+
+        return { onNewLine: !fitsOnSameLineAsName, position, textWrap }
+    }
+
+    private getFragmentWidth(layout: FragmentLayout | undefined): number {
+        if (!layout) return 0
+
+        let width = layout.textWrap.width
+
+        // If the fragment doesn't start on a new line, add the name's last line width
+        if (!layout.onNewLine) width += this.nameWrap.lastLineWidth
+
+        return width
+    }
+
+    @computed get width(): number {
+        const widths = [
+            this.nameWrap.width,
+            this.getFragmentWidth(this.suffixLayout),
+            this.getFragmentWidth(this.valueLayout),
+        ]
+        return Math.max(...widths)
+    }
+
+    @computed get height(): number {
+        let height = this.nameWrap.height
+
+        if (this.suffixLayout?.onNewLine) {
+            height += this.suffixLayout.textWrap.height
+        }
+
+        if (this.valueLayout?.onNewLine) {
+            height += this.valueLayout.textWrap.height
+        }
+
+        return height
+    }
+}
+
+/**
+ * Calculate the position for appending text after an existing TextWrap.
+ * Returns position on the same line if it fits, otherwise on a new line.
+ */
+function calculateRelativeAppendPosition({
+    existingTextWrap,
+    fitsOnLastLine,
+}: {
+    existingTextWrap: TextWrap
+    fitsOnLastLine: boolean
+}): RelativePosition {
+    const { fontSize, lineHeight, lastLineWidth } = existingTextWrap
+
+    const spaceWidth = Bounds.forText(" ", { fontSize }).width
+    const singleLineHeight = fontSize * lineHeight
+
+    const { lineCount } = existingTextWrap
+    if (fitsOnLastLine) {
+        const lastLineIndex = lineCount - 1
+        return {
+            dx: lastLineWidth + spaceWidth,
+            dy: lastLineIndex * singleLineHeight,
+        }
+    } else {
+        const newLineIndex = lineCount
+        return { dx: 0, dy: newLineIndex * singleLineHeight }
+    }
+}

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedConstants.ts
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedConstants.ts
@@ -10,8 +10,8 @@ import {
     GRAPHER_AREA_OPACITY_FOCUS,
     GRAPHER_AREA_OPACITY_MUTE,
 } from "../core/GrapherConstants"
-import { TextWrap } from "@ourworldindata/components"
 import { InteractionState } from "../interaction/InteractionState.js"
+import { SeriesLabelState } from "../seriesLabel/SeriesLabelState.js"
 import { LegendStyleConfig } from "../legend/LegendInteractionState"
 
 export const AREA_OPACITY = {
@@ -101,7 +101,7 @@ export interface Item {
 }
 
 export interface SizedItem extends Item {
-    label: TextWrap
+    label: SeriesLabelState
 }
 
 export interface PlacedItem extends SizedItem {

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBars.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBars.tsx
@@ -53,6 +53,7 @@ import { HashMap, NodeGroup } from "react-move"
 import { easeQuadOut } from "d3-ease"
 import { StackedDiscreteBarChartState } from "./StackedDiscreteBarChartState"
 import { enrichSeriesWithLabels } from "../barCharts/DiscreteBarChartHelpers.js"
+import { SeriesLabel } from "../seriesLabel/SeriesLabel.js"
 
 const BAR_SPACING_FACTOR = 0.35
 
@@ -372,19 +373,17 @@ export class StackedDiscreteBars
                         onMouseLeave={this.onEntityMouseLeave}
                     />
                 ))}
-                {label.renderSVG(
-                    yAxis.place(this.x0) - labelToBarPadding,
-                    -label.height / 2,
-                    {
-                        textProps: {
-                            textAnchor: "end",
-                            fill: "#555",
-                            onMouseEnter: (): void =>
-                                this.onEntityMouseEnter(label.text),
-                            onMouseLeave: this.onEntityMouseLeave,
-                        },
+                <SeriesLabel
+                    state={label}
+                    x={yAxis.place(this.x0) - labelToBarPadding}
+                    y={-label.height / 2}
+                    textAnchor="end"
+                    fill="#555"
+                    onMouseEnter={(): void =>
+                        this.onEntityMouseEnter(label.text)
                     }
-                )}
+                    onMouseLeave={this.onEntityMouseLeave}
+                />
                 {this.showTotalValueLabel && (
                     <text
                         transform={`translate(${

--- a/packages/@ourworldindata/grapher/src/verticalLabels/VerticalLabelsState.ts
+++ b/packages/@ourworldindata/grapher/src/verticalLabels/VerticalLabelsState.ts
@@ -1,5 +1,5 @@
 import * as R from "remeda"
-import { computed } from "mobx"
+import { computed, makeObservable } from "mobx"
 import { Bounds, RequiredBy, VerticalAlign } from "@ourworldindata/utils"
 import { TextWrap } from "@ourworldindata/components"
 
@@ -65,6 +65,7 @@ export class VerticalLabelsState {
     ) {
         this.initialSeries = series
         this.initialOptions = options
+        makeObservable(this)
     }
 
     @computed private get options(): RequiredBy<


### PR DESCRIPTION
## Context

This PR introduces a new `SeriesLabel` component to improve the rendering of series labels in charts. The component handles complex label layouts with support for name, suffix, and value fragments, ensuring proper alignment and positioning.

## Screenshots / Videos / Diagrams

N/A - This is an internal refactoring that maintains the same visual appearance.

## Testing guidance

1. Test charts with different types of series labels:
   - Simple labels (e.g., "France")
   - Labels with suffixes (e.g., "Europe (WB)")
   - Labels with values (e.g., "United States 45,000")
   - Labels with both suffix and value (e.g., "Middle East and North Africa (WHO) 2,500")

2. Verify that labels render correctly with different alignments:
   - Left-aligned labels
   - Right-aligned labels
   - Labels that wrap to multiple lines

3. Check that labels maintain proper spacing and alignment when:
   - The chart is resized
   - Different font sizes are used
   - Labels have different lengths

- [ ] Does the change work in the archive?
- [ ] Does the staging experience have sign-off from product stakeholders?

## Checklist

### Before merging

- [ ] Changes to CSS/HTML were checked on Desktop and Mobile Safari at all three breakpoints
- [ ] Changes to HTML were checked for accessibility concerns