### PR TITLE
✨ add hoverable info icons to region labels

### DIFF
--- a/packages/@ourworldindata/components/src/MarkdownTextWrap/MarkdownTextWrap.tsx
+++ b/packages/@ourworldindata/components/src/MarkdownTextWrap/MarkdownTextWrap.tsx
@@ -674,6 +674,10 @@ export class MarkdownTextWrap extends React.Component<MarkdownTextWrapProps> {
         return htmlLines.length * this.singleLineHeight
     }
 
+    @computed get dimensions(): { width: number; height: number } {
+        return { width: this.width, height: this.height }
+    }
+
     @computed get style(): any {
         return {
             ...this.fontParams,
@@ -1150,14 +1154,18 @@ function appendReferenceNumbers(
 export function canAppendTextToLastLine({
     existingTextWrap,
     textToAppend,
+    reservedWidth = 0,
 }: {
     existingTextWrap: TextWrap | MarkdownTextWrap
     textToAppend: string
+    /** Width to reserve for non-text elements (e.g. icons) */
+    reservedWidth?: number
 }): boolean {
     const { maxWidth, lastLineWidth, fontSize, props } = existingTextWrap
 
     const spaceWidth = Bounds.forText(" ", { fontSize }).width
-    const availableWidthInLastLine = maxWidth - lastLineWidth - spaceWidth - 10
+    const availableWidthInLastLine =
+        maxWidth - lastLineWidth - spaceWidth - reservedWidth - 10
 
     const secondaryTextWrap = new MarkdownTextWrap({
         ...props,

--- a/packages/@ourworldindata/components/src/TextWrap/TextWrap.tsx
+++ b/packages/@ourworldindata/components/src/TextWrap/TextWrap.tsx
@@ -260,6 +260,10 @@ export class TextWrap {
         return _.max(this.lines.map((l) => l.width)) ?? 0
     }
 
+    @computed get dimensions(): { width: number; height: number } {
+        return { width: this.width, height: this.height }
+    }
+
     @computed get lastLineWidth(): number {
         return R.last(this.lines)?.width ?? 0
     }

--- a/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChartHelpers.ts
+++ b/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChartHelpers.ts
@@ -275,7 +275,8 @@ export function enrichSeriesWithLabels<
         return series.map((series, index) => ({
             ...series,
             label: SeriesLabelState.fromTextWrap(
-                wrappedLabels[index].labelWrap
+                wrappedLabels[index].labelWrap,
+                { showProviderIcon: true }
             ),
             annotationTextWrap: wrappedLabels[index].annotationWrap,
         }))
@@ -335,7 +336,9 @@ export function enrichSeriesWithLabels<
 
     return series.map((series, index) => ({
         ...series,
-        label: SeriesLabelState.fromTextWrap(truncatedLabels[index]),
+        label: SeriesLabelState.fromTextWrap(truncatedLabels[index], {
+            showProviderIcon: true,
+        }),
         annotationTextWrap: truncatedAnnotations[index],
     }))
 }

--- a/packages/@ourworldindata/grapher/src/core/RegionGroups.ts
+++ b/packages/@ourworldindata/grapher/src/core/RegionGroups.ts
@@ -171,14 +171,20 @@ export function groupEntitiesByRegionType(
     return entitiesByRegionGroup
 }
 
-export type ParsedLabel =
-    | { type: "plain"; name: string; suffix?: string }
-    | {
-          type: "regionWithProviderSuffix"
-          name: string
-          suffix: string
-          providerKey: AnyRegionDataProvider
-      }
+interface PlainParsedLabel {
+    type: "plain"
+    name: string
+    suffix?: string
+}
+
+export interface RegionWithProviderSuffixParsedLabel {
+    type: "regionWithProviderSuffix"
+    name: string
+    suffix: string
+    providerKey: AnyRegionDataProvider
+}
+
+export type ParsedLabel = PlainParsedLabel | RegionWithProviderSuffixParsedLabel
 
 export function parseLabelWithSuffix(entityName: string): ParsedLabel {
     const match = entityName.match(/^(.+)\s+\(([^)]+)\)$/)

--- a/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.tsx
+++ b/packages/@ourworldindata/grapher/src/lineLegend/LineLegend.tsx
@@ -139,7 +139,10 @@ class LineLabels extends React.Component<LineLabelsProps> {
 
     @computed private get textLabels(): React.ReactElement {
         return (
-            <g id={makeIdForHumanConsumption("text-labels")}>
+            <g
+                id={makeIdForHumanConsumption("text-labels")}
+                style={{ pointerEvents: "none" }}
+            >
                 {this.markers.map(({ series, labelText }, index) => {
                     return (
                         <Halo
@@ -180,7 +183,10 @@ class LineLabels extends React.Component<LineLabelsProps> {
         )
         if (!markersWithAnnotations) return
         return (
-            <g id={makeIdForHumanConsumption("text-annotations")}>
+            <g
+                id={makeIdForHumanConsumption("text-annotations")}
+                style={{ pointerEvents: "none" }}
+            >
                 {markersWithAnnotations.map(({ series, labelText }, index) => {
                     if (!series.annotationTextWrap) return
                     return (
@@ -219,7 +225,10 @@ class LineLabels extends React.Component<LineLabelsProps> {
     @computed private get connectorLines(): React.ReactElement | undefined {
         if (!this.props.needsConnectorLines) return
         return (
-            <g id={makeIdForHumanConsumption("connectors")}>
+            <g
+                id={makeIdForHumanConsumption("connectors")}
+                style={{ pointerEvents: "none" }}
+            >
                 {this.markers.map(({ series, connectorLine }, index) => {
                     const { x1, x2 } = connectorLine
                     const {
@@ -288,10 +297,10 @@ class LineLabels extends React.Component<LineLabelsProps> {
     override render(): React.ReactElement {
         return (
             <>
+                {!this.props.isStatic && this.interactions}
                 {this.connectorLines}
                 {this.textAnnotations}
                 {this.textLabels}
-                {!this.props.isStatic && this.interactions}
             </>
         )
     }
@@ -421,6 +430,7 @@ export class LineLegend extends React.Component<LineLegendProps> {
                 formattedValue: series.formattedValue,
                 placeFormattedValueInNewLine:
                     series.placeFormattedValueInNewLine,
+                showProviderIcon: true,
             })
 
             const annotationTextWrap = this.makeAnnotationTextWrap(series)


### PR DESCRIPTION
## Context

This PR adds provider icons to series labels in charts, enhancing the visual representation of data sources. When a data series comes from a specific provider (like WHO), the label now includes an info icon that displays additional information on hover.

## Screenshots / Videos / Diagrams

[Add screenshots showing the new provider icons in series labels]

## Testing guidance

1. Open a chart that includes data from external providers (e.g., WHO, World Bank)
2. Verify that provider names in series labels now include an info icon
3. Hover over the icon to confirm the tooltip appears with provider information
4. Check that the layout of series labels remains correct with the added icons
5. Test on different chart types (bar charts, line charts) to ensure consistent behavior

- [ ] Does the change work in the archive?
- [ ] Does the staging experience have sign-off from product stakeholders?

## Checklist

### Before merging

- [ ] Changes to CSS/HTML were checked on Desktop and Mobile Safari at all three breakpoints
- [ ] Changes to HTML were checked for accessibility concerns