### PR TITLE
✨ improve discrete bar charts with projections

### DIFF
--- a/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChart.tsx
@@ -377,7 +377,7 @@ export class DiscreteBarChart
         barY: number
         yOffset: number
     }): React.ReactElement {
-        const barColor = series.yColumn.isProjection
+        const barColor = series.isProjection
             ? `url(#${makeProjectedDataPatternId(series.color)})`
             : series.color
 
@@ -562,9 +562,7 @@ export class DiscreteBarChart
     }
 
     private renderDefs(): React.ReactElement | null {
-        const projections = this.series.filter(
-            (series) => series.yColumn.isProjection
-        )
+        const projections = this.series.filter((series) => series.isProjection)
         const uniqProjections = _.uniqBy(projections, (series) => series.color)
         if (projections.length === 0) return null
 

--- a/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChartConstants.ts
+++ b/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChartConstants.ts
@@ -1,9 +1,15 @@
 import { ChartManager } from "../chart/ChartManager"
 import { CoreColumn } from "@ourworldindata/core-table"
 import { ChartSeries } from "../chart/ChartInterface"
-import { Color, CoreValueType, Time } from "@ourworldindata/types"
+import {
+    Color,
+    CoreValueType,
+    ProjectionColumnInfo,
+    Time,
+} from "@ourworldindata/types"
 import { TextWrap } from "@ourworldindata/components"
 import { InteractionState } from "../interaction/InteractionState.js"
+import { ColumnSlug } from "@ourworldindata/utils"
 
 export interface DiscreteBarSeries extends ChartSeries {
     entityName: string
@@ -14,6 +20,7 @@ export interface DiscreteBarSeries extends ChartSeries {
     colorValue?: CoreValueType
     annotation?: string
     focus: InteractionState
+    isProjection?: boolean
 }
 
 export interface SizedDiscreteBarSeries extends DiscreteBarSeries {
@@ -39,6 +46,7 @@ export interface DiscreteBarChartManager extends ChartManager {
     endTime?: Time
     hasLineChart?: boolean // used to pick color scheme
     hasSlopeChart?: boolean // used to pick color scheme
+    projectionColumnInfoBySlug?: Map<ColumnSlug, ProjectionColumnInfo>
 }
 
 export interface DiscreteBarItem {
@@ -48,7 +56,19 @@ export interface DiscreteBarItem {
     time: number
     colorValue?: CoreValueType
     color?: Color
+    isProjection?: boolean
 }
+
+/**
+ * Describes how Y columns are handled.
+ *
+ * - "independent": Each Y column is treated independently and plotted as its own series.
+ * - "combined": A historical and projection column pair are merged into a single
+ *   series, with projections indicated appropriately.
+ */
+export type YColumnMode =
+    | { type: "independent"; slugs: ColumnSlug[] }
+    | { type: "combined"; slugs: ColumnSlug[]; info: ProjectionColumnInfo }
 
 export interface FontSettings {
     fontSize: number


### PR DESCRIPTION
In discrete bar charts, if there's exactly one projected column with a historical counterpart, then these columns are stitched together and plotted as a single time series.

Examples:
- [prod](https://ourworldindata.org/grapher/life-expectancy-at-birth-including-the-un-projections?tab=discrete-bar&time=latest&facet=entity) / [staging](http://staging-site-discrete-bar-projections/grapher/life-expectancy-at-birth-including-the-un-projections?tab=discrete-bar&time=latest&facet=entity)
- [prod](https://ourworldindata.org/grapher/population-with-un-projections?tab=discrete-bar&time=latest&country=OWID_WRL~DEU~UN_EUR) / [staging](http://staging-site-discrete-bar-projections/grapher/population-with-un-projections?tab=discrete-bar&time=latest&country=OWID_WRL~DEU~UN_EUR)

In Search: [prod](https://ourworldindata.org/search) / [staging](http://staging-site-discrete-bar-projections/search) (see the small discrete bar chart in the first result)