### PR TITLE
fix: fix full-width grid sizing in Chrome 145+

### DIFF
--- a/site/css/grid.scss
+++ b/site/css/grid.scss
@@ -64,10 +64,18 @@ $grid-responsive: (lg, md, sm);
 // Use this when you want a full-page-width grid container
 // 1 (auto) | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 (auto)
 .grid-cols-12-full-width {
-    --outer-column-width: calc((50vw - 640px - var(--grid-gap)));
-    grid-template-columns: var(--outer-column-width) repeat(12, 1fr) var(
-            --outer-column-width
-        );
+    --inner-cols-max-total-width: 1280px;
+
+    // This is the max width of a single column so that 12 of them, plus the 11 gaps between them,
+    // will fit within the inner max total width
+    --single-col-max-width: calc(
+        (var(--inner-cols-max-total-width) - 11 * var(--grid-gap)) / 12
+    );
+
+    grid-template-columns:
+        1fr
+        repeat(12, minmax(0, var(--single-col-max-width)))
+        1fr;
 }
 
 // Use this on an item you want to span till the end of whichever container it's in


### PR DESCRIPTION
Fixes #6036.

[In Chrome 145+](https://www.bram.us/2026/01/15/100vw-horizontal-overflow-no-more/), the value of `50vw` used in the column width definition would change depending on whether we have `html { scrollbar-gutter: stable }` present or not (which React Aria puts when the dropdown is open), which would then cause a content reflow.

Turns out, there is a more straightforward way to write the grid col definition in the first place!

There is a slight visual change now - but that's just because the inner grid cols are now _actually_ 1280px, not 1265 which they were before (because the scrollbar width got substracted).