### PR TITLE
🐛 fix selectPeerCountriesForGrapher when targetCountry is provided

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/PeerCountrySelection.ts
+++ b/packages/@ourworldindata/grapher/src/core/PeerCountrySelection.ts
@@ -93,8 +93,9 @@ export function isValidPeerCountryStrategyQueryParam(
 /**
  * Selects peer countries for a grapher based on the configured strategy.
  *
- * The target country is the one currently selected in the grapher. This only
- * takes effect when exactly one entity is selected.
+ * If targetCountry is provided in options, it will be used directly.
+ * Otherwise, the target country is inferred from the grapher's selection,
+ * which requires exactly one entity to be selected.
  */
 export async function selectPeerCountriesForGrapher(
     grapherState: GrapherState,
@@ -103,7 +104,12 @@ export async function selectPeerCountriesForGrapher(
         targetCountry?: EntityName
     }
 ): Promise<EntityName[]> {
-    if (grapherState.selection.numSelectedEntities !== 1) return []
+    // If targetCountry is not explicitly provided, require exactly one entity selected
+    if (!options?.targetCountry) {
+        if (grapherState.selection.numSelectedEntities !== 1) {
+            return []
+        }
+    }
 
     const targetCountry =
         options?.targetCountry ?? grapherState.selection.selectedEntityNames[0]


### PR DESCRIPTION
## Context
The `selectPeerCountriesForGrapher` function handles peer selection for search results. It has an early return that bails out if the grapher doesn't have exactly one entity selected:

```ts
if (grapherState.selection.numSelectedEntities !== 1) return []
```

When called from search result generation (`enrichPickedEntities`), the caller passes the target country explicitly via options, but the `grapherState` hasn't been populated with a selection yet. This caused the function to always return `[]`, falling back to the chart's default selection instead of computing relevant peers.


The fix is to skip the `numSelectedEntities` check when `targetCountry` is explicitly provided:
```ts
  if (!options?.targetCountry) {
      if (grapherState.selection.numSelectedEntities !== 1) return []
  }
```

This preserves the original behavior when no target is provided (infer from `grapherState` selection), while allowing peer selection to work when the caller explicitly specifies which country they want peers for.
 

## Testing guidance
1. Locally, on master, go to http://localhost:8788/grapher/life-expectancy.search-result.json?entities=ESP&nocache
2. Confirm that the peer countries are just regions from the default selection
3. Checkout this branch
5. Go to http://localhost:8788/grapher/life-expectancy.search-result.json?entities=ESP&nocache
6. Confirm that Spain's parent regions (Europe, HIC, and World) are the peer countries