### PR TITLE
Remove obsolete commit.md slash command

### DIFF
--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -1,8 +1,0 @@
----
-allowed-tools: Bash(git log:*), Bash(git commit:*), Bash(git add:*), Bash(git status:*)
-description: Create a git commit according to our git styleguide (assumes code was written by an agent)
----
-
-Create a git commit about the work that is currently not commited in this repo.
-
-refer to the docs/agent-guidelines/commit-messages.md file for instructions on how to craft commit messages.


### PR DESCRIPTION
Whenever I want commit, Claude is asking whether to load `commit` skill (function) which is annoying. Guidelines for committing `docs/agent-guidelines/commit-messages.md` are already referenced in CLAUDE.md.