### PR TITLE
🐛 pass catalogPath to search result construction

### DIFF
--- a/functions/_common/downloadFunctions.ts
+++ b/functions/_common/downloadFunctions.ts
@@ -347,11 +347,12 @@ export async function fetchSearchResultDataForGrapher(
     })
     if (inputTable) grapher.grapherState.inputTable = inputTable
 
+    const catalogUrl = env.CATALOG_URL
     const searchResult = await assembleSearchResultData(grapher.grapherState, {
         variant,
         pickedEntities,
         numDataTableRowsPerColumn,
-        dataApiUrl,
+        catalogUrl,
     })
 
     if (searchResult === undefined)
@@ -375,7 +376,7 @@ export async function assembleSearchResultData(
         variant: RichDataVariant
         pickedEntities: EntityName[]
         numDataTableRowsPerColumn: number
-        dataApiUrl: string
+        catalogUrl: string
     }
 ): Promise<GrapherSearchResultJson | undefined> {
     // Find Grapher tabs to display and bring them in the right order

--- a/functions/_common/explorerHandlers.ts
+++ b/functions/_common/explorerHandlers.ts
@@ -31,7 +31,6 @@ import {
     prepareSearchParamsBeforeExtractingDataValues,
 } from "./downloadFunctions.js"
 import { assembleMetadata } from "./metadataTools.js"
-import { getDataApiUrl } from "./grapherTools.js"
 import { checkCache } from "./reusableHandlers.js"
 
 async function initGrapherForExplorerView(
@@ -351,12 +350,12 @@ export async function fetchSearchResultDataForExplorerView(
         const shouldIgnoreProjections = searchParams.has("ignoreProjections")
         if (shouldIgnoreProjections) dropProjectionColumns(grapherState)
 
-        const dataApiUrl = getDataApiUrl(env)
+        const catalogUrl = env.CATALOG_URL
         const searchResult = await assembleSearchResultData(grapherState, {
             variant,
             pickedEntities,
             numDataTableRowsPerColumn,
-            dataApiUrl,
+            catalogUrl,
         })
 
         if (searchResult === undefined)

--- a/functions/_common/search/constructSearchResultJson.test.ts
+++ b/functions/_common/search/constructSearchResultJson.test.ts
@@ -167,6 +167,7 @@ describe(pickDisplayEntities, () => {
 
             const displayEntities = await pickDisplayEntities(grapherState, {
                 pickedEntities,
+                catalogUrl: "",
             })
 
             expect(displayEntities).toEqual(defaultEntities)
@@ -185,7 +186,7 @@ describe(pickDisplayEntities, () => {
 
                 const displayEntities = await pickDisplayEntities(
                     grapherState,
-                    { pickedEntities }
+                    { pickedEntities, catalogUrl: "" }
                 )
 
                 pickedEntities.forEach((pickedEntity) =>
@@ -204,6 +205,7 @@ describe(pickDisplayEntities, () => {
 
             const displayEntities = await pickDisplayEntities(grapherState, {
                 pickedEntities,
+                catalogUrl: "",
             })
 
             expect(displayEntities).toEqual([pickedEntities[0]])
@@ -217,6 +219,7 @@ describe(pickDisplayEntities, () => {
 
             const displayEntities = await pickDisplayEntities(grapherState, {
                 pickedEntities: [],
+                catalogUrl: "",
             })
 
             expect(displayEntities).toEqual([defaultEntities[0]])
@@ -233,6 +236,7 @@ describe(pickDisplayEntities, () => {
 
             const displayEntities = await pickDisplayEntities(grapherState, {
                 pickedEntities,
+                catalogUrl: "",
             })
 
             expect(displayEntities).toEqual(pickedEntities)
@@ -247,6 +251,7 @@ describe(pickDisplayEntities, () => {
 
             const displayEntities = await pickDisplayEntities(grapherState, {
                 pickedEntities: [],
+                catalogUrl: "",
             })
 
             expect(displayEntities).toEqual([defaultEntities[0]])
@@ -265,6 +270,7 @@ describe(pickDisplayEntities, () => {
 
             const displayEntities = await pickDisplayEntities(grapherState, {
                 pickedEntities,
+                catalogUrl: "",
             })
 
             expect(displayEntities).toEqual(pickedEntities)
@@ -278,6 +284,7 @@ describe(pickDisplayEntities, () => {
 
             const displayEntities = await pickDisplayEntities(grapherState, {
                 pickedEntities,
+                catalogUrl: "",
             })
 
             expect(displayEntities).toEqual([
@@ -294,6 +301,7 @@ describe(pickDisplayEntities, () => {
 
             const displayEntities = await pickDisplayEntities(grapherState, {
                 pickedEntities,
+                catalogUrl: "",
             })
 
             expect(displayEntities).toEqual([

--- a/functions/_common/search/constructSearchResultJson.ts
+++ b/functions/_common/search/constructSearchResultJson.ts
@@ -257,7 +257,7 @@ export async function pickDisplayEntities(
     {
         pickedEntities,
         catalogUrl,
-    }: { pickedEntities: EntityName[]; catalogUrl?: string }
+    }: { pickedEntities: EntityName[]; catalogUrl: string }
 ): Promise<EntityName[]> {
     const { ScatterPlot, Marimekko } = GRAPHER_CHART_TYPES
     const {
@@ -400,7 +400,7 @@ async function pickDisplayEntitiesForScatterPlot({
 }: {
     grapherState: GrapherState
     chartState: ScatterPlotChartState
-    catalogUrl?: string
+    catalogUrl: string
     entity?: EntityName
 }): Promise<EntityName[]> {
     const { series, colorColumnSlug, sizeColumnSlug } = chartState
@@ -477,7 +477,7 @@ async function pickDisplayEntitiesForMarimekko({
 }: {
     grapherState: GrapherState
     chartState: MarimekkoChartState
-    catalogUrl?: string
+    catalogUrl: string
     entity?: EntityName
 }): Promise<EntityName[]> {
     const { items, colorColumnSlug, xColumnSlug } = chartState
@@ -517,7 +517,7 @@ async function pickDisplayEntitiesForMarimekko({
 
     // When only the color dimension is available, select the entity with the
     // largest population from each color group
-    if (colorColumnSlug && catalogUrl) {
+    if (colorColumnSlug) {
         const populationByEntityName = await fetchLatestPopulationData({
             catalogUrl,
         })


### PR DESCRIPTION
The catalog path isn't currently passed through to where it's needed in search