### PR TITLE
🐛 fix admin API returns

### DIFF
--- a/adminSiteServer/apiRoutes/bulkUpdates.ts
+++ b/adminSiteServer/apiRoutes/bulkUpdates.ts
@@ -26,11 +26,11 @@ import { saveGrapher } from "./charts.js"
 import * as db from "../../db/db.js"
 import * as lodash from "lodash-es"
 import { Request } from "../authentication.js"
-import e from "express"
+import { HandlerResponse } from "../FunctionalRouter.js"
 
 export async function getChartBulkUpdate(
     req: Request,
-    _res: e.Response<any, Record<string, any>>,
+    _res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ): Promise<BulkGrapherConfigResponse<BulkChartEditResponseRow>> {
     const context: OperationContext = {
@@ -91,7 +91,7 @@ export async function getChartBulkUpdate(
 
 export async function updateBulkChartConfigs(
     req: Request,
-    res: e.Response<any, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadWriteTransaction
 ) {
     const patchesList = req.body as GrapherConfigPatch[]
@@ -138,7 +138,7 @@ export async function updateBulkChartConfigs(
 
 export async function getVariableAnnotations(
     req: Request,
-    _res: e.Response<any, Record<string, any>>,
+    _res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ): Promise<BulkGrapherConfigResponse<VariableAnnotationsResponseRow>> {
     const context: OperationContext = {
@@ -201,7 +201,7 @@ export async function getVariableAnnotations(
 
 export async function updateVariableAnnotations(
     req: Request,
-    _res: e.Response<any, Record<string, any>>,
+    _res: HandlerResponse,
     trx: db.KnexReadWriteTransaction
 ) {
     const patchesList = req.body as GrapherConfigPatch[]

--- a/adminSiteServer/apiRoutes/chartConfigs.ts
+++ b/adminSiteServer/apiRoutes/chartConfigs.ts
@@ -1,11 +1,12 @@
-import { Request, Response } from "express"
+import { Request } from "express"
+import { HandlerResponse } from "../FunctionalRouter.js"
 import { JsonError } from "@ourworldindata/utils"
 import * as db from "../../db/db.js"
 import { getChartConfigById } from "../../db/model/ChartConfigs.js"
 
 export async function getChartConfig(
     req: Request,
-    res: Response,
+    res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ) {
     const { chartConfigId } = req.params

--- a/adminSiteServer/apiRoutes/charts.ts
+++ b/adminSiteServer/apiRoutes/charts.ts
@@ -66,7 +66,7 @@ import * as db from "../../db/db.js"
 import { getLogsByChartId } from "../getLogsByChartId.js"
 
 import { Request } from "../authentication.js"
-import e from "express"
+import { HandlerResponse } from "../FunctionalRouter.js"
 import { DataInsightMinimalInformation } from "../../adminShared/AdminTypes.js"
 import {
     validateNewGrapherSlug,
@@ -574,7 +574,7 @@ export async function updateGrapherConfigsInR2(
 
 export async function getChartsJson(
     req: Request,
-    res: e.Response<any, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ) {
     const limit = parseIntOrUndefined(req.query.limit as string) ?? 10000
@@ -603,7 +603,7 @@ export async function getChartsJson(
 
 export async function getChartsCsv(
     req: Request,
-    res: e.Response<any, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ) {
     const limit = parseIntOrUndefined(req.query.limit as string) ?? 10000
@@ -663,7 +663,7 @@ export async function getChartsCsv(
 
 export async function getChartConfigJson(
     req: Request,
-    res: e.Response<any, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ) {
     return expectChartById(trx, req.params.chartId)
@@ -671,7 +671,7 @@ export async function getChartConfigJson(
 
 export async function getChartParentJson(
     req: Request,
-    res: e.Response<any, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ) {
     const chartId = expectInt(req.params.chartId)
@@ -689,7 +689,7 @@ export async function getChartParentJson(
 
 export async function getChartPatchConfigJson(
     req: Request,
-    res: e.Response<any, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ) {
     const chartId = expectInt(req.params.chartId)
@@ -699,7 +699,7 @@ export async function getChartPatchConfigJson(
 
 export async function getChartLogsJson(
     req: Request,
-    res: e.Response<any, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ) {
     return {
@@ -712,7 +712,7 @@ export async function getChartLogsJson(
 
 export async function getChartReferencesJson(
     req: Request,
-    res: e.Response<any, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ) {
     const references = {
@@ -726,7 +726,7 @@ export async function getChartReferencesJson(
 
 export async function getChartRedirectsJson(
     req: Request,
-    res: e.Response<any, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ) {
     return {
@@ -739,7 +739,7 @@ export async function getChartRedirectsJson(
 
 export async function getChartPageviewsJson(
     req: Request,
-    res: e.Response<any, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ) {
     const slug = await getChartSlugById(
@@ -766,7 +766,7 @@ export async function getChartPageviewsJson(
 
 export async function getChartTagsJson(
     req: Request,
-    res: e.Response<any, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ) {
     const chartId = expectInt(req.params.chartId)
@@ -786,7 +786,7 @@ export async function getChartTagsJson(
 
 export async function createChart(
     req: Request,
-    res: e.Response<any, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadWriteTransaction
 ) {
     let shouldInherit: boolean | undefined
@@ -809,7 +809,7 @@ export async function createChart(
 
 export async function setChartTagsHandler(
     req: Request,
-    res: e.Response<any, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadWriteTransaction
 ) {
     const chartId = expectInt(req.params.chartId)
@@ -821,7 +821,7 @@ export async function setChartTagsHandler(
 
 export async function updateChart(
     req: Request,
-    res: e.Response<any, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadWriteTransaction
 ) {
     let shouldInherit: boolean | undefined
@@ -856,7 +856,7 @@ export async function updateChart(
 
 export async function deleteChart(
     req: Request,
-    res: e.Response<any, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadWriteTransaction
 ) {
     const chart = await expectChartById(trx, req.params.chartId)

--- a/adminSiteServer/apiRoutes/dataInsights.ts
+++ b/adminSiteServer/apiRoutes/dataInsights.ts
@@ -1,5 +1,5 @@
-import e from "express"
 import { Request } from "../authentication.js"
+import { HandlerResponse } from "../FunctionalRouter.js"
 import {
     DbPlainNarrativeChart,
     DbRawChartConfig,
@@ -45,7 +45,7 @@ type DataInsightRow = Pick<
 
 export async function getAllDataInsightIndexItems(
     _req: Request,
-    _res: e.Response<any, Record<string, any>>,
+    _res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ) {
     return getAllDataInsightIndexItemsOrderedByUpdatedAt(trx)
@@ -53,7 +53,7 @@ export async function getAllDataInsightIndexItems(
 
 export async function createDataInsightGDoc(
     req: Request,
-    res: e.Response<any, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadWriteTransaction
 ) {
     // Find the user's data insight folder

--- a/adminSiteServer/apiRoutes/datasets.ts
+++ b/adminSiteServer/apiRoutes/datasets.ts
@@ -21,11 +21,11 @@ import { triggerStaticBuild } from "../../baker/GrapherBakingUtils.js"
 import * as db from "../../db/db.js"
 import * as lodash from "lodash-es"
 import { Request } from "express"
-import * as e from "express"
+import { HandlerResponse } from "../FunctionalRouter.js"
 
 export async function getDatasets(
     req: Request,
-    _res: e.Response<any, Record<string, any>>,
+    _res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ) {
     const datasets = await db.knexRaw<Record<string, any>>(
@@ -85,7 +85,7 @@ export async function getDatasets(
 
 export async function getDataset(
     req: Request,
-    _res: e.Response<any, Record<string, any>>,
+    _res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ) {
     const datasetId = expectInt(req.params.datasetId)
@@ -328,7 +328,7 @@ export async function getDataset(
 
 export async function updateDataset(
     req: Request,
-    _res: e.Response<any, Record<string, any>>,
+    _res: HandlerResponse,
     trx: db.KnexReadWriteTransaction
 ) {
     // Only updates `nonRedistributable` and `tags`, other fields come from ETL
@@ -374,7 +374,7 @@ export async function updateDataset(
 
 export async function setArchived(
     req: Request,
-    _res: e.Response<any, Record<string, any>>,
+    _res: HandlerResponse,
     trx: db.KnexReadWriteTransaction
 ) {
     const datasetId = expectInt(req.params.datasetId)
@@ -409,7 +409,7 @@ export async function setArchived(
 
 export async function setTags(
     req: Request,
-    _res: e.Response<any, Record<string, any>>,
+    _res: HandlerResponse,
     trx: db.KnexReadWriteTransaction
 ) {
     const datasetId = expectInt(req.params.datasetId)
@@ -421,7 +421,7 @@ export async function setTags(
 
 export async function republishCharts(
     req: Request,
-    _res: e.Response<any, Record<string, any>>,
+    _res: HandlerResponse,
     trx: db.KnexReadWriteTransaction
 ) {
     const datasetId = expectInt(req.params.datasetId)

--- a/adminSiteServer/apiRoutes/dods.ts
+++ b/adminSiteServer/apiRoutes/dods.ts
@@ -3,7 +3,7 @@ import * as db from "../../db/db.js"
 import * as dodDb from "../../db/model/Dod.js"
 import { createDodLinkFromUrl } from "../../db/model/Link.js"
 import { Request } from "../authentication.js"
-import e from "express"
+import { HandlerResponse } from "../FunctionalRouter.js"
 import { DodLinksTableName, DodsTableName } from "@ourworldindata/types"
 import { extractLinksFromMarkdown } from "@ourworldindata/utils"
 
@@ -33,7 +33,7 @@ async function updateLinksFromInsertedDod(
 
 export async function getDods(
     _: Request,
-    res: e.Response<any, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ) {
     try {
@@ -54,7 +54,7 @@ export async function getDods(
  */
 export async function getParsedDods(
     _: Request,
-    res: e.Response<any, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ) {
     try {
@@ -71,7 +71,7 @@ export async function getParsedDods(
 
 export async function getDodsUsage(
     _: Request,
-    res: e.Response<any, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ) {
     try {
@@ -88,7 +88,7 @@ export async function getDodsUsage(
 
 export async function updateDod(
     req: Request,
-    res: e.Response<any, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadWriteTransaction
 ) {
     const id = Number(req.params.id)
@@ -125,7 +125,7 @@ export async function updateDod(
 
 export async function deleteDod(
     req: Request,
-    res: e.Response<any, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadWriteTransaction
 ) {
     const { id } = req.params
@@ -152,7 +152,7 @@ export async function deleteDod(
 
 export async function createDod(
     req: Request,
-    res: e.Response<any, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadWriteTransaction
 ) {
     const { content, name } = req.body

--- a/adminSiteServer/apiRoutes/explorer.ts
+++ b/adminSiteServer/apiRoutes/explorer.ts
@@ -3,7 +3,8 @@ import {
     DbPlainUser,
     ExplorersTableName,
 } from "@ourworldindata/types"
-import e, { Request, Response } from "express"
+import { Request } from "express"
+import { HandlerResponse } from "../FunctionalRouter.js"
 
 import { isValidSlug } from "../../serverUtils/serverUtil.js"
 
@@ -21,7 +22,7 @@ function validateExplorerSlug(slug: string): void {
 
 export async function addExplorerTags(
     req: Request,
-    _res: e.Response<any, Record<string, any>>,
+    _res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ) {
     const { slug } = req.params
@@ -43,7 +44,7 @@ export async function addExplorerTags(
 
 export async function deleteExplorerTags(
     req: Request,
-    _res: e.Response<any, Record<string, any>>,
+    _res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ) {
     const { slug } = req.params
@@ -56,7 +57,7 @@ export async function deleteExplorerTags(
 
 export async function handleGetExplorer(
     req: Request,
-    res: Response,
+    res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ) {
     const { slug } = req.params
@@ -70,7 +71,7 @@ export async function handleGetExplorer(
 
 export async function handlePutExplorer(
     req: Request,
-    res: e.Response<any, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadWriteTransaction
 ) {
     const { slug } = req.params
@@ -126,7 +127,7 @@ export async function handlePutExplorer(
 
 export async function handleDeleteExplorer(
     req: Request,
-    res: e.Response<any, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadWriteTransaction
 ) {
     const { slug } = req.params

--- a/adminSiteServer/apiRoutes/featuredMetrics.ts
+++ b/adminSiteServer/apiRoutes/featuredMetrics.ts
@@ -4,12 +4,12 @@ import {
     FeaturedMetricsTableName,
 } from "@ourworldindata/types"
 import { Request } from "express"
-import * as e from "express"
+import { HandlerResponse } from "../FunctionalRouter.js"
 import * as db from "../../db/db.js"
 
 export async function createFeaturedMetric(
     req: Request,
-    _res: e.Response<any, Record<string, any>>,
+    _res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ) {
     const { url, parentTagName, ranking, incomeGroup } = req.body
@@ -67,7 +67,7 @@ export async function createFeaturedMetric(
 
 export async function rerankFeaturedMetrics(
     req: Request,
-    _res: e.Response<any, Record<string, any>>,
+    _res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ) {
     const featuredMetrics = req.body
@@ -93,7 +93,7 @@ export async function rerankFeaturedMetrics(
 
 export async function deleteFeaturedMetric(
     req: Request,
-    _res: e.Response<any, Record<string, any>>,
+    _res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ) {
     const { id } = req.params
@@ -120,7 +120,7 @@ export async function deleteFeaturedMetric(
 
 export async function fetchFeaturedMetrics(
     _req: Request,
-    _res: e.Response<any, Record<string, any>>,
+    _res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ) {
     const featuredMetrics = await db.getFeaturedMetricsByParentTagName(trx)

--- a/adminSiteServer/apiRoutes/figma.ts
+++ b/adminSiteServer/apiRoutes/figma.ts
@@ -1,6 +1,6 @@
 import { JsonError } from "@ourworldindata/types"
 import { Request } from "express"
-import * as e from "express"
+import { HandlerResponse } from "../FunctionalRouter.js"
 import * as db from "../../db/db.js"
 import * as Figma from "figma-api"
 import { FIGMA_API_KEY } from "../../settings/serverSettings.js"
@@ -9,7 +9,7 @@ const figmaApi = new Figma.Api({ personalAccessToken: FIGMA_API_KEY })
 
 export async function getFigmaImageUrl(
     req: Request,
-    _res: e.Response<any, Record<string, any>>,
+    _res: HandlerResponse,
     _trx: db.KnexReadonlyTransaction
 ) {
     const { fileId, nodeId } = req.query as Record<string, string>

--- a/adminSiteServer/apiRoutes/files.ts
+++ b/adminSiteServer/apiRoutes/files.ts
@@ -7,14 +7,14 @@ import {
 import fs from "fs/promises"
 import * as db from "../../db/db.js"
 import { Request } from "../authentication.js"
-import e from "express"
+import { HandlerResponse } from "../FunctionalRouter.js"
 import { saveFileToAssetsR2 } from "../../serverUtils/r2/assetsR2Helpers.js"
 import path from "path"
 import { MULTER_UPLOADS_DIRECTORY } from "../../adminShared/validation.js"
 
 export async function getFiles(
     _req: Request,
-    _res: e.Response<any, Record<string, any>>,
+    _res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ): Promise<{ files: DbPlainFile[] }> {
     const files = await trx(FilesTableName).select("*")
@@ -23,7 +23,7 @@ export async function getFiles(
 
 export async function uploadFileToR2(
     req: Request & { file?: Express.Multer.File },
-    res: e.Response<any, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadWriteTransaction
 ): Promise<{ success: boolean; path: string }> {
     if (!req.file) {

--- a/adminSiteServer/apiRoutes/gdocs.ts
+++ b/adminSiteServer/apiRoutes/gdocs.ts
@@ -68,13 +68,13 @@ import { enqueueLightningChange } from "./routeUtils.js"
 import { triggerStaticBuild } from "../../baker/GrapherBakingUtils.js"
 import * as db from "../../db/db.js"
 import { Request } from "../authentication.js"
-import e from "express"
+import { HandlerResponse } from "../FunctionalRouter.js"
 import { GdocAnnouncement } from "../../db/model/Gdoc/GdocAnnouncement.js"
 import { GdocProfile } from "../../db/model/Gdoc/GdocProfile.js"
 
 export async function getAllGdocIndexItems(
     req: Request,
-    res: e.Response<any, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ) {
     return getAllGdocIndexItemsOrderedByUpdatedAt(trx)
@@ -82,7 +82,7 @@ export async function getAllGdocIndexItems(
 
 export async function getIndividualGdoc(
     req: Request,
-    res: e.Response<any, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadWriteTransaction
 ) {
     const id = req.params.id
@@ -105,18 +105,19 @@ export async function getIndividualGdoc(
         }
 
         res.set("Cache-Control", "no-store")
-        res.send(gdoc)
+        return gdoc
     } catch (error) {
         console.error("Error fetching gdoc", error)
-        res.status(500).json({
+        res.status(500)
+        return {
             error: { message: String(error), status: 500 },
-        })
+        }
     }
 }
 
 export async function getGdocCalloutCoverage(
     req: Request,
-    res: e.Response<any, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ) {
     const id = req.params.id
@@ -241,11 +242,11 @@ export async function getGdocCalloutCoverage(
         coverageByEntity[entity.code] = rowCoverage
     }
 
-    res.send({
+    return {
         rows,
         entities,
         coverageByEntity,
-    })
+    }
 }
 
 /**
@@ -255,7 +256,7 @@ export async function getGdocCalloutCoverage(
  */
 export async function getCalloutFunctionStrings(
     req: Request,
-    res: e.Response<any, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ) {
     const chartUrl = req.query.url as string | undefined
@@ -290,10 +291,10 @@ export async function getCalloutFunctionStrings(
         }
     }
 
-    res.send({
+    return {
         url: chartUrl,
         functionStringsByName,
-    })
+    }
 }
 
 /**
@@ -444,7 +445,7 @@ async function createRedirectForSlugChangeIfNeeded(
  */
 export async function createOrUpdateGdoc(
     req: Request,
-    res: e.Response<any, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadWriteTransaction
 ) {
     const { id } = req.params
@@ -501,7 +502,7 @@ async function validateTombstoneRelatedLinkUrl(
 
 export async function deleteGdoc(
     req: Request,
-    res: e.Response<any, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadWriteTransaction
 ) {
     const { id } = req.params
@@ -565,7 +566,7 @@ export async function deleteGdoc(
 
 export async function setGdocTags(
     req: Request,
-    res: e.Response<any, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadWriteTransaction
 ) {
     const { gdocId } = req.params
@@ -585,7 +586,7 @@ export async function setGdocTags(
  */
 export async function getPreviewGdocIndexRecords(
     _req: Request,
-    res: e.Response<PagesIndexRecordsResponse, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ): Promise<PagesIndexRecordsResponse> {
     const { id } = _req.params
@@ -657,7 +658,7 @@ export async function getPreviewGdocIndexRecords(
  */
 export async function getPublishedGdocTopicSlugs(
     _req: Request,
-    _res: e.Response<any, Record<string, any>>,
+    _res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ): Promise<{ slugs: string[] }> {
     const rows = await db.knexRaw<{ slug: string }>(

--- a/adminSiteServer/apiRoutes/images.ts
+++ b/adminSiteServer/apiRoutes/images.ts
@@ -12,28 +12,29 @@ import * as db from "../../db/db.js"
 import * as lodash from "lodash-es"
 
 import { Request } from "../authentication.js"
-import e from "express"
+import { HandlerResponse } from "../FunctionalRouter.js"
 
 export async function getImagesHandler(
     _: Request,
-    res: e.Response<any, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ) {
     try {
         const images = await db.getCloudflareImages(trx)
         res.set("Cache-Control", "no-store")
-        res.send({ images })
+        return { images }
     } catch (error) {
         console.error("Error fetching images", error)
-        res.status(500).json({
+        res.status(500)
+        return {
             error: { message: String(error), status: 500 },
-        })
+        }
     }
 }
 
 export async function postImageHandler(
     req: Request,
-    res: e.Response<any, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ) {
     const { filename, type, content } = validateImagePayload(req.body)
@@ -111,7 +112,7 @@ export async function postImageHandler(
  */
 export async function putImageHandler(
     req: Request,
-    res: e.Response<any, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ) {
     const { type, content } = validateImagePayload(req.body)
@@ -201,7 +202,7 @@ export async function putImageHandler(
 // Update alt text via patch
 export async function patchImageHandler(
     req: Request,
-    res: e.Response<any, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ) {
     const { id } = req.params
@@ -245,7 +246,7 @@ export async function patchImageHandler(
 
 export async function deleteImageHandler(
     req: Request,
-    _: e.Response<any, Record<string, any>>,
+    _: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ) {
     const { id } = req.params
@@ -283,7 +284,7 @@ export async function deleteImageHandler(
 
 export async function getImageUsageHandler(
     _: Request,
-    __: e.Response<any, Record<string, any>>,
+    __: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ) {
     const usage = await db.getImageUsage(trx)

--- a/adminSiteServer/apiRoutes/mdims.ts
+++ b/adminSiteServer/apiRoutes/mdims.ts
@@ -24,13 +24,13 @@ import {
 } from "../multiDim.js"
 import { triggerStaticBuild } from "../../baker/GrapherBakingUtils.js"
 import { Request } from "../authentication.js"
+import { HandlerResponse } from "../FunctionalRouter.js"
 import * as db from "../../db/db.js"
 import {
     validateNewGrapherSlug,
     validateMultiDimSlug,
     isValidCatalogPath,
 } from "../validation.js"
-import e from "express"
 import * as z from "zod"
 
 function buildRedirectTargetDescription(
@@ -194,7 +194,7 @@ async function createSlugChangeRedirect(
 
 export async function handleGetMultiDims(
     _req: Request,
-    _res: e.Response<any, Record<string, any>>,
+    _res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ) {
     try {
@@ -227,7 +227,7 @@ export async function handleGetMultiDims(
 
 export async function handleGetMultiDim(
     req: Request,
-    _res: e.Response<any, Record<string, any>>,
+    _res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ) {
     const id = expectInt(req.params.id)
@@ -248,7 +248,7 @@ export async function handleGetMultiDim(
 
 export async function handlePutMultiDim(
     req: Request,
-    res: e.Response<any, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadWriteTransaction
 ) {
     const { catalogPath } = req.params
@@ -277,7 +277,7 @@ export async function handlePutMultiDim(
 
 export async function handlePatchMultiDim(
     req: Request,
-    res: e.Response<any, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadWriteTransaction
 ) {
     const id = expectInt(req.params.id)
@@ -336,7 +336,7 @@ export async function handlePatchMultiDim(
 
 export async function handleGetMultiDimRedirects(
     req: Request,
-    _res: e.Response<any, Record<string, any>>,
+    _res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ) {
     const multiDimId = expectInt(req.params.id)
@@ -373,7 +373,7 @@ const postMultiDimRedirectSchema = z.object({
 
 export async function handlePostMultiDimRedirect(
     req: Request,
-    res: e.Response<any, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadWriteTransaction
 ) {
     const multiDimId = expectInt(req.params.id)
@@ -453,7 +453,7 @@ export async function handlePostMultiDimRedirect(
 
 export async function handleDeleteMultiDimRedirect(
     req: Request,
-    res: e.Response<any, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadWriteTransaction
 ) {
     const redirectId = expectInt(req.params.redirectId)
@@ -494,7 +494,7 @@ export async function handleDeleteMultiDimRedirect(
 
 export async function handleGetAllMultiDimRedirects(
     _req: Request,
-    _res: e.Response<any, Record<string, any>>,
+    _res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ) {
     const rows = await db.knexRaw<{

--- a/adminSiteServer/apiRoutes/misc.ts
+++ b/adminSiteServer/apiRoutes/misc.ts
@@ -9,11 +9,11 @@ import * as db from "../../db/db.js"
 import * as lodash from "lodash-es"
 import { expectInt } from "../../serverUtils/serverUtil.js"
 import { Request } from "../authentication.js"
-import e from "express"
+import { HandlerResponse } from "../FunctionalRouter.js"
 // using the alternate template, which highlights topics rather than articles.
 export async function fetchAllWork(
     req: Request,
-    res: e.Response<any, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ) {
     type GdocRecord = Pick<DbRawPostGdoc, "id" | "publishedAt">
@@ -42,7 +42,7 @@ export async function fetchAllWork(
 
 export async function fetchNamespaces(
     req: Request,
-    res: e.Response<any, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ) {
     const rows = await db.knexRaw<{
@@ -71,7 +71,7 @@ export async function fetchNamespaces(
 
 export async function fetchSourceById(
     req: Request,
-    res: e.Response<any, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ) {
     const sourceId = expectInt(req.params.sourceId)

--- a/adminSiteServer/apiRoutes/narrativeCharts.ts
+++ b/adminSiteServer/apiRoutes/narrativeCharts.ts
@@ -43,7 +43,7 @@ import {
 import * as db from "../../db/db.js"
 import { expectChartById } from "./charts.js"
 import { Request } from "../authentication.js"
-import e from "express"
+import { HandlerResponse } from "../FunctionalRouter.js"
 import { getPublishedLinksTo } from "../../db/model/Link.js"
 import { triggerStaticBuild } from "../../baker/GrapherBakingUtils.js"
 import { getChartConfigById as _getChartConfigById } from "../../db/model/ChartConfigs.js"
@@ -172,7 +172,7 @@ async function getViewDimensions(
 
 export async function getNarrativeCharts(
     req: Request,
-    _res: e.Response<any, Record<string, any>>,
+    _res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ) {
     type NarrativeChartRow = Pick<
@@ -250,7 +250,7 @@ export async function getNarrativeCharts(
 
 export async function getNarrativeChartById(
     req: Request,
-    res: e.Response<any, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ) {
     const id = expectInt(req.params.id)
@@ -425,7 +425,7 @@ const createNarrativeChartSchema = z.discriminatedUnion("type", [
 
 export async function createNarrativeChart(
     req: Request,
-    res: e.Response<any, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadWriteTransaction
 ) {
     const parseResult = createNarrativeChartSchema.safeParse(req.body)
@@ -468,7 +468,7 @@ export async function createNarrativeChart(
 
 export async function updateNarrativeChart(
     req: Request,
-    res: e.Response<any, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadWriteTransaction
 ) {
     const id = expectInt(req.params.id)
@@ -562,7 +562,7 @@ export async function updateNarrativeChart(
 
 export async function deleteNarrativeChart(
     req: Request,
-    _res: e.Response<any, Record<string, any>>,
+    _res: HandlerResponse,
     trx: db.KnexReadWriteTransaction
 ) {
     const id = expectInt(req.params.id)
@@ -607,7 +607,7 @@ export async function deleteNarrativeChart(
 
 export async function getNarrativeChartReferences(
     req: Request,
-    _res: e.Response<any, Record<string, any>>,
+    _res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ) {
     const id = expectInt(req.params.id)

--- a/adminSiteServer/apiRoutes/redirects.ts
+++ b/adminSiteServer/apiRoutes/redirects.ts
@@ -9,11 +9,11 @@ import { expectInt } from "../../serverUtils/serverUtil.js"
 import { triggerStaticBuild } from "../../baker/GrapherBakingUtils.js"
 import * as db from "../../db/db.js"
 import { Request } from "../authentication.js"
-import e from "express"
+import { HandlerResponse } from "../FunctionalRouter.js"
 
 export async function handleGetSiteRedirects(
     req: Request,
-    res: e.Response<any, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ) {
     return { redirects: await getRedirects(trx) }
@@ -21,7 +21,7 @@ export async function handleGetSiteRedirects(
 
 export async function handlePostNewSiteRedirect(
     req: Request,
-    res: e.Response<any, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadWriteTransaction
 ) {
     const { source, target } = req.body
@@ -63,7 +63,7 @@ export async function handlePostNewSiteRedirect(
 
 export async function handleDeleteSiteRedirect(
     req: Request,
-    res: e.Response<any, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadWriteTransaction
 ) {
     const id = expectInt(req.params.id)
@@ -81,7 +81,7 @@ export async function handleDeleteSiteRedirect(
 
 export async function handleGetRedirects(
     req: Request,
-    res: e.Response<any, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ) {
     return {
@@ -104,7 +104,7 @@ export async function handleGetRedirects(
 
 export async function handlePostNewChartRedirect(
     req: Request,
-    res: e.Response<any, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadWriteTransaction
 ) {
     const chartId = expectInt(req.params.chartId)
@@ -125,7 +125,7 @@ export async function handlePostNewChartRedirect(
 
 export async function handleDeleteChartRedirect(
     req: Request,
-    res: e.Response<any, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadWriteTransaction
 ) {
     const id = expectInt(req.params.id)

--- a/adminSiteServer/apiRoutes/slack.ts
+++ b/adminSiteServer/apiRoutes/slack.ts
@@ -1,12 +1,12 @@
-import e from "express"
 import * as db from "../../db/db.js"
 import { Request } from "../authentication.js"
+import { HandlerResponse } from "../FunctionalRouter.js"
 import { SLACK_BOT_OAUTH_TOKEN } from "../../settings/serverSettings"
 import { JsonError } from "@ourworldindata/types"
 
 export async function sendMessageToSlack(
     req: Request,
-    _res: e.Response<any, Record<string, any>>,
+    _res: HandlerResponse,
     _trx: db.KnexReadWriteTransaction
 ) {
     const url = "https://slack.com/api/chat.postMessage"

--- a/adminSiteServer/apiRoutes/staticViz.ts
+++ b/adminSiteServer/apiRoutes/staticViz.ts
@@ -12,13 +12,13 @@ import {
 import { expectInt } from "../../serverUtils/serverUtil.js"
 import * as db from "../../db/db.js"
 import * as lodash from "lodash-es"
-import e from "express"
 import { Request } from "../authentication.js"
+import { HandlerResponse } from "../FunctionalRouter.js"
 import { isSlugUsedInOtherGrapher } from "../validation.js"
 
 export async function getStaticVizListHandler(
     _req: Request,
-    _res: e.Response<any, Record<string, any>>,
+    _res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ) {
     return await getEnrichedStaticVizList(trx)
@@ -26,7 +26,7 @@ export async function getStaticVizListHandler(
 
 export async function getStaticVizByIdHandler(
     req: Request,
-    _res: e.Response<any, Record<string, any>>,
+    _res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ) {
     const staticVizId = expectInt(req.params.staticVizId)
@@ -40,7 +40,7 @@ export async function getStaticVizByIdHandler(
 
 export async function createStaticViz(
     req: Request,
-    res: e.Response<any, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadWriteTransaction
 ) {
     const parseResult = StaticVizInsertSchema.safeParse(req.body)
@@ -136,7 +136,7 @@ export async function createStaticViz(
 
 export async function updateStaticViz(
     req: Request,
-    res: e.Response<any, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadWriteTransaction
 ) {
     const staticVizId = expectInt(req.params.staticVizId)
@@ -259,7 +259,7 @@ export async function updateStaticViz(
 
 export async function deleteStaticViz(
     req: Request,
-    _res: e.Response<any, Record<string, any>>,
+    _res: HandlerResponse,
     trx: db.KnexReadWriteTransaction
 ) {
     const staticVizId = expectInt(req.params.staticVizId)

--- a/adminSiteServer/apiRoutes/suggest.ts
+++ b/adminSiteServer/apiRoutes/suggest.ts
@@ -11,12 +11,12 @@ import {
     fetchGptGeneratedTextFromImage,
 } from "../imagesHelpers.js"
 import * as db from "../../db/db.js"
-import e from "express"
 import { Request } from "../authentication.js"
+import { HandlerResponse } from "../FunctionalRouter.js"
 
 export async function suggestGptTopics(
     req: Request,
-    _res: e.Response<any, Record<string, any>>,
+    _res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ): Promise<Record<"topics", DbChartTagJoin[]>> {
     const chartId = parseIntOrUndefined(req.params.chartId)
@@ -37,7 +37,7 @@ export async function suggestGptTopics(
 
 export async function suggestGptAltTextForCloudflareImage(
     req: Request,
-    _res: e.Response<any, Record<string, any>>,
+    _res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ): Promise<{
     success: true
@@ -58,7 +58,7 @@ export async function suggestGptAltTextForCloudflareImage(
 
 export async function suggestGptAltText(
     req: Request,
-    _res: e.Response<any, Record<string, any>>,
+    _res: HandlerResponse,
     _trx: db.KnexReadonlyTransaction
 ): Promise<{
     success: true
@@ -96,7 +96,7 @@ export async function generateAltTextFromUrl(imageUrl: string): Promise<{
 
 export async function extractTextFromImage(
     req: Request,
-    _res: e.Response<any, Record<string, any>>
+    _res: HandlerResponse
 ): Promise<{
     success: true
     text: string

--- a/adminSiteServer/apiRoutes/tagGraph.ts
+++ b/adminSiteServer/apiRoutes/tagGraph.ts
@@ -2,11 +2,11 @@ import { JsonError, FlatTagGraph } from "@ourworldindata/types"
 import * as db from "../../db/db.js"
 import * as R from "remeda"
 import { Request } from "../authentication.js"
-import e from "express"
+import { HandlerResponse } from "../FunctionalRouter.js"
 
 export async function handleGetFlatTagGraph(
     req: Request,
-    res: e.Response<any, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ) {
     const flatTagGraph = await db.getFlatTagGraph(trx)
@@ -15,7 +15,7 @@ export async function handleGetFlatTagGraph(
 
 export async function handlePostTagGraph(
     req: Request,
-    res: e.Response<any, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadWriteTransaction
 ) {
     const tagGraph = req.body?.tagGraph as unknown
@@ -57,5 +57,5 @@ export async function handlePostTagGraph(
         throw new JsonError("Invalid tag graph provided", 400)
     }
     await db.updateTagGraph(trx, tagGraph)
-    res.send({ success: true })
+    return { success: true }
 }

--- a/adminSiteServer/apiRoutes/tags.ts
+++ b/adminSiteServer/apiRoutes/tags.ts
@@ -13,13 +13,13 @@ import { expectInt } from "../../serverUtils/serverUtil.js"
 import { UNCATEGORIZED_TAG_ID } from "../../settings/serverSettings.js"
 import * as db from "../../db/db.js"
 import * as lodash from "lodash-es"
-import e from "express"
 import { Request } from "../authentication.js"
+import { HandlerResponse } from "../FunctionalRouter.js"
 import * as R from "remeda"
 
 export async function getTagById(
     req: Request,
-    _res: e.Response<any, Record<string, any>>,
+    _res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ) {
     const tagId = expectInt(req.params.tagId) as number | null
@@ -160,7 +160,7 @@ export async function getTagById(
 
 export async function updateTag(
     req: Request,
-    _res: e.Response<any, Record<string, any>>,
+    _res: HandlerResponse,
     trx: db.KnexReadWriteTransaction
 ) {
     const tagId = expectInt(req.params.tagId)
@@ -205,7 +205,7 @@ You should probably just enable "Searchable in Algolia" for this tag and remove 
 
 export async function createTag(
     req: Request,
-    _res: e.Response<any, Record<string, any>>,
+    _res: HandlerResponse,
     trx: db.KnexReadWriteTransaction
 ) {
     const tag = req.body
@@ -249,7 +249,7 @@ export async function createTag(
 
 export async function getAllTags(
     req: Request,
-    _res: e.Response<any, Record<string, any>>,
+    _res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ) {
     return { tags: await db.getMinimalTagsWithIsTopic(trx) }
@@ -257,7 +257,7 @@ export async function getAllTags(
 
 export async function deleteTag(
     req: Request,
-    _res: e.Response<any, Record<string, any>>,
+    _res: HandlerResponse,
     trx: db.KnexReadWriteTransaction
 ) {
     const tagId = expectInt(req.params.tagId)

--- a/adminSiteServer/apiRoutes/users.ts
+++ b/adminSiteServer/apiRoutes/users.ts
@@ -5,10 +5,10 @@ import { getUserById, updateUser, insertUser } from "../../db/model/User.js"
 import { expectInt } from "../../serverUtils/serverUtil.js"
 import * as db from "../../db/db.js"
 import { Request } from "../authentication.js"
-import e from "express"
+import { HandlerResponse } from "../FunctionalRouter.js"
 export async function getUsers(
     req: Request,
-    _res: e.Response<any, Record<string, any>>,
+    _res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ) {
     return {
@@ -31,7 +31,7 @@ export async function getUsers(
 
 export async function getUserByIdHandler(
     req: Request,
-    _res: e.Response<any, Record<string, any>>,
+    _res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ) {
     const id = parseIntOrUndefined(req.params.userId)
@@ -42,7 +42,7 @@ export async function getUserByIdHandler(
 
 export async function deleteUser(
     req: Request,
-    res: e.Response<any, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadWriteTransaction
 ) {
     if (!res.locals.user.isSuperuser)
@@ -56,7 +56,7 @@ export async function deleteUser(
 
 export async function updateUserHandler(
     req: Request,
-    res: e.Response<any, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadWriteTransaction
 ) {
     if (!res.locals.user.isSuperuser)
@@ -76,7 +76,7 @@ export async function updateUserHandler(
 
 export async function addUser(
     req: Request,
-    res: e.Response<any, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadWriteTransaction
 ) {
     if (!res.locals.user.isSuperuser)
@@ -94,7 +94,7 @@ export async function addUser(
 
 export async function addImageToUser(
     req: Request,
-    _res: e.Response<any, Record<string, any>>,
+    _res: HandlerResponse,
     trx: db.KnexReadWriteTransaction
 ) {
     const userId = expectInt(req.params.userId)
@@ -105,7 +105,7 @@ export async function addImageToUser(
 
 export async function removeUserImage(
     req: Request,
-    _res: e.Response<any, Record<string, any>>,
+    _res: HandlerResponse,
     trx: db.KnexReadWriteTransaction
 ) {
     const userId = expectInt(req.params.userId)

--- a/adminSiteServer/apiRoutes/variables.ts
+++ b/adminSiteServer/apiRoutes/variables.ts
@@ -43,11 +43,11 @@ import { expectInt } from "../../serverUtils/serverUtil.js"
 import { triggerStaticBuild } from "../../baker/GrapherBakingUtils.js"
 import { updateGrapherConfigsInR2 } from "./charts.js"
 import { Request } from "../authentication.js"
-import e from "express"
+import { HandlerResponse } from "../FunctionalRouter.js"
 
 export async function getEditorVariablesJson(
     req: Request,
-    _res: e.Response<any, Record<string, any>>,
+    _res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ) {
     const datasets = []
@@ -116,7 +116,7 @@ export async function getEditorVariablesJson(
 
 export async function getVariableDataJson(
     req: Request,
-    _res: e.Response<any, Record<string, any>>,
+    _res: HandlerResponse,
     _trx: db.KnexReadonlyTransaction
 ) {
     const variableStr = req.params.variableStr as string
@@ -134,7 +134,7 @@ export async function getVariableDataJson(
 
 export async function getVariableMetadataJson(
     req: Request,
-    _res: e.Response<any, Record<string, any>>,
+    _res: HandlerResponse,
     _trx: db.KnexReadonlyTransaction
 ) {
     const variableStr = req.params.variableStr as string
@@ -152,7 +152,7 @@ export async function getVariableMetadataJson(
 
 export async function getVariablesJson(
     req: Request,
-    _res: e.Response<any, Record<string, any>>,
+    _res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ) {
     const limit = parseIntOrUndefined(req.query.limit as string) ?? 50
@@ -162,7 +162,7 @@ export async function getVariablesJson(
 
 export async function getVariablesUsagesJson(
     req: Request,
-    _res: e.Response<any, Record<string, any>>,
+    _res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ) {
     const query = `-- sql
@@ -183,7 +183,7 @@ export async function getVariablesUsagesJson(
 
 export async function getVariablesGrapherConfigETLPatchConfigJson(
     req: Request,
-    _res: e.Response<any, Record<string, any>>,
+    _res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ) {
     const variableId = expectInt(req.params.variableId)
@@ -196,7 +196,7 @@ export async function getVariablesGrapherConfigETLPatchConfigJson(
 
 export async function getVariablesGrapherConfigAdminPatchConfigJson(
     req: Request,
-    _res: e.Response<any, Record<string, any>>,
+    _res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ) {
     const variableId = expectInt(req.params.variableId)
@@ -209,7 +209,7 @@ export async function getVariablesGrapherConfigAdminPatchConfigJson(
 
 export async function getVariablesMergedGrapherConfigJson(
     req: Request,
-    _res: e.Response<any, Record<string, any>>,
+    _res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ) {
     const variableId = expectInt(req.params.variableId)
@@ -219,7 +219,7 @@ export async function getVariablesMergedGrapherConfigJson(
 
 export async function getVariablesVariableIdJson(
     req: Request,
-    _res: e.Response<any, Record<string, any>>,
+    _res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ) {
     const variableId = expectInt(req.params.variableId)
@@ -316,7 +316,7 @@ export async function getVariablesVariableIdJson(
 
 export async function putVariablesVariableIdGrapherConfigETL(
     req: Request,
-    res: e.Response<any, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadWriteTransaction
 ) {
     const variableId = expectInt(req.params.variableId)
@@ -363,7 +363,7 @@ export async function putVariablesVariableIdGrapherConfigETL(
 
 export async function deleteVariablesVariableIdGrapherConfigETL(
     req: Request,
-    res: e.Response<any, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadWriteTransaction
 ) {
     const variableId = expectInt(req.params.variableId)
@@ -445,7 +445,7 @@ export async function deleteVariablesVariableIdGrapherConfigETL(
 
 export async function putVariablesVariableIdGrapherConfigAdmin(
     req: Request,
-    res: e.Response<any, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadWriteTransaction
 ) {
     const variableId = expectInt(req.params.variableId)
@@ -492,7 +492,7 @@ export async function putVariablesVariableIdGrapherConfigAdmin(
 
 export async function deleteVariablesVariableIdGrapherConfigAdmin(
     req: Request,
-    res: e.Response<any, Record<string, any>>,
+    res: HandlerResponse,
     trx: db.KnexReadWriteTransaction
 ) {
     const variableId = expectInt(req.params.variableId)
@@ -565,7 +565,7 @@ export async function deleteVariablesVariableIdGrapherConfigAdmin(
 
 export async function getVariablesVariableIdChartsJson(
     req: Request,
-    _res: e.Response<any, Record<string, any>>,
+    _res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ) {
     const variableId = expectInt(req.params.variableId)

--- a/adminSiteServer/functionalRouterHelpers.ts
+++ b/adminSiteServer/functionalRouterHelpers.ts
@@ -1,5 +1,5 @@
-import { FunctionalRouter } from "./FunctionalRouter.js"
-import { Request, Response } from "express"
+import { FunctionalRouter, HandlerResponse } from "./FunctionalRouter.js"
+import { Request } from "express"
 import * as db from "../db/db.js"
 
 export function getRouteWithROTransaction<T>(
@@ -7,11 +7,11 @@ export function getRouteWithROTransaction<T>(
     targetPath: string,
     handler: (
         req: Request,
-        res: Response,
+        res: HandlerResponse,
         trx: db.KnexReadonlyTransaction
     ) => Promise<T>
 ) {
-    return router.get(targetPath, (req: Request, res: Response) => {
+    return router.get(targetPath, (req, res) => {
         return db.knexReadonlyTransaction((transaction) =>
             handler(req, res, transaction)
         )
@@ -27,11 +27,11 @@ export function getRouteNonIdempotentWithRWTransaction<T>(
     targetPath: string,
     handler: (
         req: Request,
-        res: Response,
+        res: HandlerResponse,
         trx: db.KnexReadWriteTransaction
     ) => Promise<T>
 ) {
-    return router.get(targetPath, (req: Request, res: Response) => {
+    return router.get(targetPath, (req, res) => {
         return db.knexReadWriteTransaction((transaction) =>
             handler(req, res, transaction)
         )
@@ -43,11 +43,11 @@ export function postRouteWithRWTransaction<T>(
     targetPath: string,
     handler: (
         req: Request,
-        res: Response,
+        res: HandlerResponse,
         trx: db.KnexReadWriteTransaction
     ) => Promise<T>
 ) {
-    return router.post(targetPath, (req: Request, res: Response) => {
+    return router.post(targetPath, (req, res) => {
         return db.knexReadWriteTransaction((transaction) =>
             handler(req, res, transaction)
         )
@@ -59,18 +59,15 @@ export function postFileUploadWithRWTransaction<T>(
     targetPath: string,
     handler: (
         req: Request,
-        res: Response,
+        res: HandlerResponse,
         trx: db.KnexReadWriteTransaction
     ) => Promise<T>
 ) {
-    return router.postWithFileUpload(
-        targetPath,
-        async (req: Request, res: Response) => {
-            return db.knexReadWriteTransaction((transaction) =>
-                handler(req, res, transaction)
-            )
-        }
-    )
+    return router.postWithFileUpload(targetPath, async (req, res) => {
+        return db.knexReadWriteTransaction((transaction) =>
+            handler(req, res, transaction)
+        )
+    })
 }
 
 export function putRouteWithRWTransaction<T>(
@@ -78,11 +75,11 @@ export function putRouteWithRWTransaction<T>(
     targetPath: string,
     handler: (
         req: Request,
-        res: Response,
+        res: HandlerResponse,
         trx: db.KnexReadWriteTransaction
     ) => Promise<T>
 ) {
-    return router.put(targetPath, (req: Request, res: Response) => {
+    return router.put(targetPath, (req, res) => {
         return db.knexReadWriteTransaction((transaction) =>
             handler(req, res, transaction)
         )
@@ -94,11 +91,11 @@ export function patchRouteWithRWTransaction<T>(
     targetPath: string,
     handler: (
         req: Request,
-        res: Response,
+        res: HandlerResponse,
         trx: db.KnexReadWriteTransaction
     ) => Promise<T>
 ) {
-    return router.patch(targetPath, (req: Request, res: Response) => {
+    return router.patch(targetPath, (req, res) => {
         return db.knexReadWriteTransaction((transaction) =>
             handler(req, res, transaction)
         )
@@ -110,11 +107,11 @@ export function deleteRouteWithRWTransaction<T>(
     targetPath: string,
     handler: (
         req: Request,
-        res: Response,
+        res: HandlerResponse,
         trx: db.KnexReadWriteTransaction
     ) => Promise<T>
 ) {
-    return router.delete(targetPath, (req: Request, res: Response) => {
+    return router.delete(targetPath, (req, res) => {
         return db.knexReadWriteTransaction((transaction) =>
             handler(req, res, transaction)
         )

--- a/adminSiteServer/publicApiRouter.ts
+++ b/adminSiteServer/publicApiRouter.ts
@@ -1,5 +1,4 @@
-import e from "express"
-import { FunctionalRouter } from "./FunctionalRouter.js"
+import { FunctionalRouter, HandlerResponse } from "./FunctionalRouter.js"
 import { Request, Response } from "./authentication.js"
 import * as db from "../db/db.js"
 import { getNarrativeChartNameConfigMap } from "../db/model/NarrativeChart.js"
@@ -31,7 +30,7 @@ getRouteWithROTransaction(
     "/narrative-chart-map",
     async (
         _req: Request,
-        _res: e.Response<any, Record<string, any>>,
+        _res: HandlerResponse,
         trx: db.KnexReadonlyTransaction
     ) => {
         const narrativeChartMap = await getNarrativeChartNameConfigMap(trx)


### PR DESCRIPTION
We occasionally get `Error: Cannot remove headers after they are sent to the client` in Sentry.

This PR fixes this genre of mistake once and for all by removing the `res.send()` method from the `Response` object that the `FunctionalRouter` passes, forcing devs to _return_ the response object from their API callbacks.