### PR TITLE
🎉 multi-dims in featured metrics

### DIFF
--- a/baker/algolia/utils/mdimViews.ts
+++ b/baker/algolia/utils/mdimViews.ts
@@ -193,11 +193,11 @@ async function getRecords(
         return {
             type: ChartRecordType.MultiDimView,
             objectID: `mdim-view-${id}`,
-            id: `mdim/${slug}${queryStr}`,
+            id: `mdim/${slug}${queryStr ? `?${queryStr}` : ""}`,
             chartId: -1,
             chartConfigId: view.fullConfigId,
             slug,
-            queryParams: queryStr,
+            queryParams: queryStr ? `?${queryStr}` : "",
             title,
             subtitle,
             variantName: chartConfig.variantName,

--- a/db/db.ts
+++ b/db/db.ts
@@ -44,6 +44,7 @@ import {
     TagsTableName,
     TagGraphTableName,
     ExplorersTableName,
+    MultiDimDataPagesTableName,
     OwidGdocMinimalPostInterface,
     DbRawPostGdoc,
 } from "@ourworldindata/types"
@@ -1150,7 +1151,7 @@ export const getFeaturedMetricsByParentTagName = async (
 }
 
 /**
- * Takes a URL and checks if it points to a valid grapher, explorer, or MDIM view.
+ * Takes a URL and checks if it points to a valid grapher, explorer, or multi-dim view.
  * Doesn't validate query params as this would be quite complicated / overkill for our needs
  */
 export async function validateChartSlug(
@@ -1191,11 +1192,17 @@ export async function validateChartSlug(
             [slug]
         ).then((rows) => rows[0])
 
-        if (!grapher)
-            return {
-                isValid: false,
-                reason: "Grapher not found or not published",
-            }
+        if (!grapher) {
+            const multiDim = await trx(MultiDimDataPagesTableName)
+                .where({ slug, published: true })
+                .first()
+
+            if (!multiDim)
+                return {
+                    isValid: false,
+                    reason: "Grapher not found or not published",
+                }
+        }
 
         return { isValid: true, reason: "" }
     }


### PR DESCRIPTION
## Context

Resolves https://github.com/owid/owid-grapher/issues/6054

`validateChartSlug` is called on every FM before we create the row, but it wasn't checking the multi-dim table to see if the chart existed there.

Also adds a `?` before the query string (like we do for explorer records) which allows `findMatchingRecordByPathnameAndQueryParams` to work.

## Testing guidance

1. Check this code out locally
2. Add a multi-dim featured metric
3. Confirm that it can be added
4. Run `indexExplorerViewsMdimViewsAndChartsToAlgolia` on your staging index
5. Confirm that the multi-dim shows up as an FM