### PR TITLE
🐛 fix filtered profile headings showing in toc

### DIFF
--- a/db/model/Gdoc/GdocProfile.ts
+++ b/db/model/Gdoc/GdocProfile.ts
@@ -8,6 +8,7 @@ import {
     OwidGdocProfileScope,
 } from "@ourworldindata/types"
 import {
+    generateToc,
     getRegionByNameOrVariantName,
     removeTrailingParenthetical,
     instantiateProfile,
@@ -158,6 +159,10 @@ export async function instantiateProfileForEntity(
         instantiatedContent,
         options
     )
+
+    if (content["sidebar-toc"]) {
+        content.toc = generateToc(content.body, true)
+    }
 
     return {
         ...profileTemplate,

--- a/packages/@ourworldindata/utils/src/profiles.test.ts
+++ b/packages/@ourworldindata/utils/src/profiles.test.ts
@@ -126,7 +126,7 @@ describe("instantiateProfile", () => {
         expect(instantiated.title).toEqual("France Energy Profile")
     })
 
-    it("regenerates the table of contents with replaced tokens", () => {
+    it("does not generate TOC (deferred to instantiateProfileForEntity)", () => {
         const country = getCountryByName("Canada") as Country
         const template: OwidGdocProfileContent = {
             ...buildProfileTemplate(),
@@ -148,11 +148,9 @@ describe("instantiateProfile", () => {
 
         const instantiated = instantiateProfile(template, country)
 
-        expect(instantiated.toc?.[0]).toMatchObject({
-            title: "How much does Canada emit?",
-            slug: "how-much-does-canada-emit",
-            isSubheading: false,
-        })
+        // TOC generation is now deferred to instantiateProfileForEntity,
+        // after data-callout blocks with missing data have been cleared
+        expect(instantiated.toc).toBeUndefined()
     })
 
     it("formats possessives for articulated names", () => {

--- a/packages/@ourworldindata/utils/src/profiles.ts
+++ b/packages/@ourworldindata/utils/src/profiles.ts
@@ -23,7 +23,7 @@ import {
     type OwidGdocProfileContent,
 } from "@ourworldindata/types"
 
-import { generateToc, traverseEnrichedBlock } from "./Util.js"
+import { traverseEnrichedBlock } from "./Util.js"
 import { Url } from "./urls/Url.js"
 
 export type ProfileEntity = Pick<Region, "name" | "code">
@@ -134,10 +134,6 @@ export const instantiateProfile = (
             ...region,
             isCountry: checkIsCountry(region),
         }
-    }
-
-    if (clonedContent["sidebar-toc"]) {
-        clonedContent.toc = generateToc(clonedContent.body, true)
     }
 
     return clonedContent


### PR DESCRIPTION
## Context

When a profile is instantiated for an entity, `data-callout` blocks that lack data for that entity are cleared (their content is set to []). However, the sidebar TOC is generated _before_ this clearing happens, so headings inside cleared data-callout blocks still appear in the sidebar navigation even though they don't render.

This PR fixes that by moving `generateToc()` from `instantiateProfile()` to `instantiateProfileForEntity()`, after `loadAndClearLinkedCallouts()` returns.

## Screenshots / Videos / Diagrams

| Before | After |
|--------|--------|
| <img width="948" height="432" alt="image" src="https://github.com/user-attachments/assets/e7f9ec3d-2030-48dc-838c-d778ed075380" /> | <img width="892" height="451" alt="image" src="https://github.com/user-attachments/assets/f74ee52a-2462-4ada-8e12-bc24877e4bcb" /> | 

## Testing guidance

You can use this [test gdoc](https://docs.google.com/document/d/1oSxIPftAu6-nsJqfrP0LkwH7fdGmeEMabMQswTETMfU/edit?tab=t.0)

Confirm that when on an entity that doesn't have data for the rubella vaccine callout, the Vaccination heading doesn't show up, but it does if on an entity with data.
