### PR TITLE
feat: add plain text preview mode to index preview

### DIFF
--- a/adminSiteClient/GdocsPreviewPage.tsx
+++ b/adminSiteClient/GdocsPreviewPage.tsx
@@ -49,7 +49,11 @@ import { GdocsEditLink } from "./GdocsEditLink.js"
 import { openSuccessNotification } from "./gdocsNotifications.js"
 import { GdocsDiffButton } from "./GdocsDiffButton.js"
 import { GdocsDiff } from "./GdocsDiff.js"
-import { GdocsRecordsPreview } from "./GdocsRecordsPreview.js"
+import {
+    GdocsRecordsPreview,
+    RecordsPreviewModeToggle,
+    RecordsPreviewMode,
+} from "./GdocsRecordsPreview.js"
 import {
     BAKED_BASE_URL,
     PUBLISHED_AT_FORMAT,
@@ -86,6 +90,8 @@ export const GdocsPreviewPage = ({ match, history }: GdocsMatchProps) => {
     >()
     const [isDiffOpen, setDiffOpen] = useState(false)
     const [isRecordsOpen, setRecordsOpen] = useState(false)
+    const [recordsPreviewMode, setRecordsPreviewMode] =
+        useState<RecordsPreviewMode>("records")
     const [errors, setErrors] = React.useState<OwidGdocErrorMessage[]>()
     const { admin } = useContext(AdminAppContext)
     const store = useGdocsStore()
@@ -581,13 +587,20 @@ export const GdocsPreviewPage = ({ match, history }: GdocsMatchProps) => {
                 <Drawer
                     placement="bottom"
                     size="large"
-                    title="Algolia index preview"
+                    title="Index preview"
+                    extra={
+                        <RecordsPreviewModeToggle
+                            mode={recordsPreviewMode}
+                            onChange={setRecordsPreviewMode}
+                        />
+                    }
                     onClose={() => setRecordsOpen(false)}
                     open={isRecordsOpen}
                 >
                     <GdocsRecordsPreview
                         gdocId={currentGdoc.id}
                         open={isRecordsOpen}
+                        mode={recordsPreviewMode}
                     />
                 </Drawer>
 


### PR DESCRIPTION
## Context

This PR adds a new "Plain text" preview mode to the Algolia index preview drawer in the admin site. This allows users to view the raw text content extracted from a Google Doc, which can be useful for debugging search indexing issues.

## Screenshots / Videos / Diagrams


![Screenshot 2026-02-13 at 10.07.09.png](https://app.graphite.com/user-attachments/assets/34ee1f60-1e5f-400e-891d-f8e11d3f1ea5.png)

## Testing guidance

1. Open a Google Doc in the admin site
2. Click on the "Index" button to open the index preview drawer
3. Toggle between "Algolia records" and "Plain text" modes
4. Verify that both modes display the expected content
5. Verify that the loading states work correctly for both modes
