### PR TITLE
Add user survey widget

### DIFF
--- a/functions/_common/env.ts
+++ b/functions/_common/env.ts
@@ -30,6 +30,7 @@ export interface Env {
     ALGOLIA_SEARCH_KEY: string
     ALGOLIA_INDEX_PREFIX?: string
     CATALOG_URL: string
+    USER_SURVEYS_R2?: R2Bucket
 }
 // We collect the possible extensions here so we can easily take them into account
 // when handling redirects

--- a/functions/api/user-survey/index.ts
+++ b/functions/api/user-survey/index.ts
@@ -1,0 +1,145 @@
+import * as Sentry from "@sentry/cloudflare"
+import { Env } from "../../_common/env.js"
+import * as z from "zod"
+
+const RESPONSE_HEADERS: HeadersInit = {
+    "Content-Type": "application/json",
+}
+
+const allowedSurveyNames = ["user-role-v1"] as const
+
+const roleAnswerSchema = z.discriminatedUnion("experimentArm", [
+    z.object({
+        experimentArm: z.literal("free-form"),
+        freeFormInput: z.string().min(1).max(200),
+    }),
+    z.object({
+        experimentArm: z.literal("long-list"),
+        optionId: z.string().min(1).max(200),
+        optionLabel: z.string().min(1).max(200),
+        optionIndex: z.number().int().nonnegative(),
+        freeFormInput: z.string().trim().min(1).max(200).optional(),
+    }),
+    z.object({
+        experimentArm: z.literal("short-list"),
+        optionId: z.string().min(1).max(200),
+        optionLabel: z.string().min(1).max(200),
+        optionIndex: z.number().int().nonnegative(),
+        freeFormInput: z.string().trim().min(1).max(200).optional(),
+    }),
+])
+
+const userSurveyPayloadSchema = z.object({
+    surveyName: z.enum(allowedSurveyNames),
+    responseId: z.uuid(),
+    feedbackAnswer: z.string().trim().min(1).max(2000),
+    roleAnswer: roleAnswerSchema,
+})
+
+type UserSurveyPayload = z.infer<typeof userSurveyPayloadSchema>
+
+function buildStorageKey(surveyName: string, responseId: string): string {
+    return `responses/${surveyName}/${responseId}.json`
+}
+
+function getRequestMetadata(request: Request): Record<string, string> {
+    return {
+        cfIpCountry: request.headers.get("cf-ipcountry") ?? "",
+        referer: request.headers.get("referer") ?? "",
+        userAgent: request.headers.get("user-agent") ?? "",
+    }
+}
+
+function buildRecord({
+    payload,
+    request,
+    receivedAtIso,
+}: {
+    payload: UserSurveyPayload
+    request: Request
+    receivedAtIso: string
+}): Record<string, unknown> {
+    return {
+        ...payload,
+        receivedAt: receivedAtIso,
+        requestMetadata: getRequestMetadata(request),
+    }
+}
+
+export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
+    if (!env.USER_SURVEYS_R2) {
+        return new Response(
+            JSON.stringify({
+                error: "Failed to store user survey response",
+            }),
+            {
+                headers: RESPONSE_HEADERS,
+                status: 500,
+            }
+        )
+    }
+
+    let rawPayload: unknown
+    try {
+        rawPayload = await request.json()
+    } catch {
+        return new Response(
+            JSON.stringify({
+                error: "Malformed JSON payload",
+            }),
+            {
+                headers: RESPONSE_HEADERS,
+                status: 400,
+            }
+        )
+    }
+
+    const parsedPayload = userSurveyPayloadSchema.safeParse(rawPayload)
+    if (!parsedPayload.success) {
+        return new Response(
+            JSON.stringify({
+                error: "Invalid request payload",
+                details: z.prettifyError(parsedPayload.error),
+            }),
+            {
+                headers: RESPONSE_HEADERS,
+                status: 400,
+            }
+        )
+    }
+
+    try {
+        const receivedAtIso = new Date().toISOString()
+        const storageKey = buildStorageKey(
+            parsedPayload.data.surveyName,
+            parsedPayload.data.responseId
+        )
+        const record = buildRecord({
+            payload: parsedPayload.data,
+            request,
+            receivedAtIso,
+        })
+
+        await env.USER_SURVEYS_R2.put(storageKey, JSON.stringify(record), {
+            httpMetadata: {
+                contentType: "application/json",
+            },
+        })
+
+        return new Response(JSON.stringify({ ok: true }), {
+            headers: RESPONSE_HEADERS,
+            status: 200,
+        })
+    } catch (error) {
+        Sentry.captureException(error)
+        return new Response(
+            JSON.stringify({
+                error: "Failed to store user survey response",
+            }),
+            {
+                headers: RESPONSE_HEADERS,
+                status: 500,
+            }
+        )
+    }
+}

--- a/functions/grapher/[slug].ts
+++ b/functions/grapher/[slug].ts
@@ -207,31 +207,12 @@ async function handleHtmlPageRequest(
             experimentClassNames
         )
     }
-    const grapherPageWithUpdatedMetaTags = rewriteMetaTags(
+    return rewriteMetaTags(
         url,
         openGraphThumbnailUrl,
         twitterThumbnailUrl,
         grapherPageWithExperimentClasses
     )
-
-    if (cookiesToSet && cookiesToSet.length) {
-        const headers = new Headers(grapherPageWithUpdatedMetaTags.headers)
-        for (const serverCookie of cookiesToSet) {
-            const cookieString = cookie.serialize(
-                serverCookie.name,
-                serverCookie.value,
-                serverCookie.options
-            )
-            headers.append("Set-Cookie", cookieString)
-        }
-        return new Response(grapherPageWithUpdatedMetaTags.body, {
-            status: grapherPageWithUpdatedMetaTags.status,
-            statusText: grapherPageWithUpdatedMetaTags.statusText,
-            headers,
-        })
-    }
-
-    return grapherPageWithUpdatedMetaTags
 }
 
 async function handleConfigRequest(

--- a/packages/@ourworldindata/types/src/analyticsTypes/analyticsTypes.ts
+++ b/packages/@ourworldindata/types/src/analyticsTypes/analyticsTypes.ts
@@ -47,6 +47,7 @@ export enum EventCategory {
     SiteGuidedChartLinkClick = "owid.site_guided_chart_link_click",
     SiteChartPreviewMouseover = "owid.site_chart_preview_mouseover",
     SiteStaticVizDownload = "owid.site_static_viz_download",
+    SiteUserSurvey = "owid.site_user_survey",
     TranslatePage = "owid.translate_page",
 }
 
@@ -71,6 +72,7 @@ export type EventParamsMap = {
     [EventCategory.SiteGuidedChartLinkClick]: SiteGuidedChartLinkClickParams
     [EventCategory.SiteChartPreviewMouseover]: SiteChartPreviewMouseoverParams
     [EventCategory.SiteStaticVizDownload]: SiteStaticVizDownloadParams
+    [EventCategory.SiteUserSurvey]: SiteUserSurveyParams
     [EventCategory.SiteClick]: SiteClickParams
     [EventCategory.SiteFormSubmit]: SiteFormSubmitParams
     [EventCategory.SiteInstantSearchClick]: SiteInstantSearchClickParams
@@ -194,6 +196,103 @@ export interface SiteStaticVizDownloadParams {
     /** Additional context (e.g., 'desktop' or 'mobile' for images, URL for data/source) */
     eventContext?: string
 }
+
+export type UserSurveyExperimentArm = "long-list" | "short-list" | "free-form"
+
+export type UserSurveyRoleAnswer =
+    | {
+          experimentArm: "free-form"
+          freeFormInput: string
+      }
+    | {
+          experimentArm: "long-list" | "short-list"
+          optionId: string
+          optionLabel: string
+          optionIndex: number
+          freeFormInput?: string
+      }
+
+export type SiteUserSurveyParams =
+    | {
+          /** Always 'user_role_show' for this event */
+          eventAction: "user_role_show"
+          /** Survey name identifier */
+          surveyName: string
+          /** Survey instance identifier generated with uuidv7 */
+          responseId: string
+          /** First-screen arm for this survey */
+          experimentArm: UserSurveyExperimentArm
+      }
+    | {
+          /** Always 'thank_you_show' for this event */
+          eventAction: "thank_you_show"
+          /** Survey name identifier */
+          surveyName: string
+          /** Survey instance identifier generated with uuidv7 */
+          responseId: string
+          /** First-screen arm for this survey */
+          experimentArm: UserSurveyExperimentArm
+      }
+    | {
+          /** Always 'user_role_submit' for this event */
+          eventAction: "user_role_submit"
+          /** Survey name identifier */
+          surveyName: string
+          /** Survey instance identifier generated with uuidv7 */
+          responseId: string
+          /** Free-form arm name */
+          experimentArm: "free-form"
+          /** Text field input from the first screen */
+          freeFormInput: string
+      }
+    | {
+          /** Always 'user_role_submit' for this event */
+          eventAction: "user_role_submit"
+          /** Survey name identifier */
+          surveyName: string
+          /** Survey instance identifier generated with uuidv7 */
+          responseId: string
+          /** Choice-based arm names */
+          experimentArm: "long-list" | "short-list"
+          /** Option id from predefined options */
+          optionId: string
+          /** Option label from predefined options */
+          optionLabel: string
+          /** 0-based index of selected option in randomized list */
+          optionIndex: number
+          /** Optional text field input from the "other" option */
+          freeFormInput?: string
+      }
+    | {
+          /** Always 'feedback_submit' for this event */
+          eventAction: "feedback_submit"
+          /** Survey name identifier */
+          surveyName: string
+          /** Survey instance identifier generated with uuidv7 */
+          responseId: string
+          /** First-screen arm for this survey */
+          experimentArm: UserSurveyExperimentArm
+      }
+    | {
+          /** Always 'user_role_dismiss' for this event */
+          eventAction: "user_role_dismiss"
+          /** Survey name identifier */
+          surveyName: string
+          /** Survey instance identifier generated with uuidv7 */
+          responseId: string
+          /** First-screen arm for this survey */
+          experimentArm: UserSurveyExperimentArm
+      }
+    | {
+          /** Always 'thank_you_dismiss' for this event */
+          eventAction: "thank_you_dismiss"
+          /** Survey name identifier */
+          surveyName: string
+          /** Survey instance identifier generated with uuidv7 */
+          responseId: string
+          /** First-screen arm for this survey */
+          experimentArm: UserSurveyExperimentArm
+      }
 
 // Grapher Events
 

--- a/packages/@ourworldindata/utils/src/experiments/config.ts
+++ b/packages/@ourworldindata/utils/src/experiments/config.ts
@@ -6,6 +6,16 @@ import { Experiment } from "./Experiment.js"
  */
 export const experiments: Experiment[] = [
     new Experiment({
+        id: "user-survey-role-v1",
+        expires: "2026-03-20T00:00:00.000Z",
+        arms: [
+            { id: "long-list", fraction: 1 / 3 },
+            { id: "short-list", fraction: 1 / 3 },
+            { id: "free-form", fraction: 1 / 3 },
+        ],
+        paths: ["/"],
+    }),
+    new Experiment({
         /*
          * Experiment: data-page-insight-btns-2
          *

--- a/site/SiteAnalytics.ts
+++ b/site/SiteAnalytics.ts
@@ -9,6 +9,8 @@ import {
     type DataInsightHit,
     type StackedArticleHit,
     FilterType,
+    type UserSurveyExperimentArm,
+    type UserSurveyRoleAnswer,
 } from "@ourworldindata/types"
 import { getFilterNamesOfType } from "./search/searchUtils.js"
 import { findDOMParent } from "@ourworldindata/utils"
@@ -176,6 +178,129 @@ export class SiteAnalytics extends GrapherAnalytics {
             eventAction: action,
             eventTarget: staticVizName,
             eventContext: context,
+        })
+    }
+
+    logUserSurveyRoleSubmit(
+        params: UserSurveyRoleAnswer & {
+            surveyName: string
+            responseId: string
+        }
+    ): void {
+        if (params.experimentArm === "free-form") {
+            this.logToGA({
+                event: EventCategory.SiteUserSurvey,
+                eventAction: "user_role_submit",
+                surveyName: params.surveyName,
+                responseId: params.responseId,
+                experimentArm: "free-form",
+                freeFormInput: params.freeFormInput,
+            })
+            return
+        }
+
+        this.logToGA({
+            event: EventCategory.SiteUserSurvey,
+            eventAction: "user_role_submit",
+            surveyName: params.surveyName,
+            responseId: params.responseId,
+            experimentArm: params.experimentArm,
+            optionId: params.optionId,
+            optionLabel: params.optionLabel,
+            optionIndex: params.optionIndex,
+            ...(params.freeFormInput !== undefined
+                ? { freeFormInput: params.freeFormInput }
+                : {}),
+        })
+    }
+
+    logUserSurveyRoleShow({
+        surveyName,
+        responseId,
+        experimentArm,
+    }: {
+        surveyName: string
+        responseId: string
+        experimentArm: UserSurveyExperimentArm
+    }): void {
+        this.logToGA({
+            event: EventCategory.SiteUserSurvey,
+            eventAction: "user_role_show",
+            surveyName,
+            responseId,
+            experimentArm,
+        })
+    }
+
+    logUserSurveyThankYouShow({
+        surveyName,
+        responseId,
+        experimentArm,
+    }: {
+        surveyName: string
+        responseId: string
+        experimentArm: UserSurveyExperimentArm
+    }): void {
+        this.logToGA({
+            event: EventCategory.SiteUserSurvey,
+            eventAction: "thank_you_show",
+            surveyName,
+            responseId,
+            experimentArm,
+        })
+    }
+
+    logUserSurveyFeedbackSubmit({
+        surveyName,
+        responseId,
+        experimentArm,
+    }: {
+        surveyName: string
+        responseId: string
+        experimentArm: UserSurveyExperimentArm
+    }): void {
+        this.logToGA({
+            event: EventCategory.SiteUserSurvey,
+            eventAction: "feedback_submit",
+            surveyName,
+            responseId,
+            experimentArm,
+        })
+    }
+
+    logUserSurveyRoleDismiss({
+        surveyName,
+        responseId,
+        experimentArm,
+    }: {
+        surveyName: string
+        responseId: string
+        experimentArm: UserSurveyExperimentArm
+    }): void {
+        this.logToGA({
+            event: EventCategory.SiteUserSurvey,
+            eventAction: "user_role_dismiss",
+            surveyName,
+            responseId,
+            experimentArm,
+        })
+    }
+
+    logUserSurveyThankYouDismiss({
+        surveyName,
+        responseId,
+        experimentArm,
+    }: {
+        surveyName: string
+        responseId: string
+        experimentArm: UserSurveyExperimentArm
+    }): void {
+        this.logToGA({
+            event: EventCategory.SiteUserSurvey,
+            eventAction: "thank_you_dismiss",
+            surveyName,
+            responseId,
+            experimentArm,
         })
     }
 

--- a/site/gdocs/components/UserSurvey.scss
+++ b/site/gdocs/components/UserSurvey.scss
@@ -1,0 +1,385 @@
+.user-survey {
+    color: $blue-90;
+    position: fixed;
+    left: 16px;
+    bottom: 16px;
+    z-index: 20;
+    display: flex;
+    flex-direction: column;
+    background: $white;
+    border-radius: 4px;
+    box-shadow: 0 4px 10px 4px rgba(0, 0, 0, 0.08);
+
+    &:focus,
+    &:focus-visible {
+        outline: none;
+    }
+
+    &--long-list {
+        width: 368px;
+        height: 442px;
+        overflow: hidden;
+    }
+
+    &--short-list {
+        width: 352px;
+        overflow: hidden;
+    }
+
+    &--free-form {
+        width: 352px;
+        overflow: hidden;
+    }
+
+    &--follow-up {
+        width: 352px;
+    }
+}
+
+.user-survey__header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 12px 16px;
+    background: $blue-5;
+}
+
+.user-survey__title {
+    @include h3-bold;
+    margin: 0;
+}
+
+.user-survey__close-button {
+    flex-shrink: 0;
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    border-color: $blue-20;
+    background: transparent;
+    color: $blue-50;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    &:hover {
+        border-color: $blue-20;
+        background: $blue-20;
+        color: $blue-90;
+    }
+
+    &:focus-visible {
+        outline: 2px solid $blue-30;
+        outline-offset: 2px;
+    }
+
+    svg {
+        width: 13px;
+        height: 13px;
+    }
+}
+
+.user-survey__form,
+.user-survey__short-form {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+}
+
+.user-survey__short-body {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 16px;
+}
+
+.user-survey__short-legend {
+    @include body-3-bold;
+    color: $blue-90;
+}
+
+.user-survey__free-input {
+    width: 100%;
+    height: 40px;
+    border: 1px solid $blue-20;
+    padding: 8px 16px;
+    @include body-3-medium;
+    color: $blue-90;
+}
+
+.user-survey__free-input,
+.user-survey__follow-up-textarea {
+    &::placeholder {
+        color: $blue-40;
+    }
+
+    &:focus,
+    &:focus-visible {
+        border-color: $blue-30;
+        outline: none;
+    }
+}
+
+.user-survey__fieldset {
+    margin: 0;
+    padding: 0 16px;
+    border: 0;
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+    scrollbar-width: thin;
+    scrollbar-color: $blue-20 $gray-10;
+
+    &::-webkit-scrollbar {
+        width: 4px;
+    }
+
+    &::-webkit-scrollbar-track {
+        background: $gray-10;
+    }
+
+    &::-webkit-scrollbar-thumb {
+        background: $blue-20;
+    }
+}
+
+.user-survey__legend {
+    @include body-3-bold;
+    margin: 0;
+    padding: 16px 0 12px;
+    display: block;
+}
+
+.user-survey__options {
+    display: flex;
+    flex-direction: column;
+}
+
+.user-survey__option {
+    padding: 12px 0;
+    border-bottom: none;
+
+    &:first-child {
+        padding-top: 0;
+    }
+
+    &:not(:last-child) {
+        border-bottom: 1px solid $gray-20;
+    }
+}
+
+.user-survey__radio-button {
+    .label {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        color: $blue-90;
+    }
+
+    .outer {
+        top: 1px;
+    }
+}
+
+.user-survey__radio-button--short-list {
+    .label {
+        @include body-3-regular;
+        color: $blue-90;
+    }
+}
+
+.user-survey__option-text {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.user-survey__option-title {
+    @include label-2-regular;
+}
+
+.user-survey__option-description {
+    @include note-2-regular;
+    color: $blue-50;
+}
+
+.user-survey__other-input-wrapper {
+    position: relative;
+    width: calc(100% - 24px);
+    margin: 12px 0 0 24px;
+}
+
+.user-survey__other-input {
+    width: 100%;
+    height: 32px;
+    padding: 0 28px 0 8px;
+    border: 1px solid $gray-20;
+    border-radius: 4px;
+    color: $blue-90;
+    @include label-2-regular;
+    font-size: 0.8125rem;
+    line-height: 1;
+    letter-spacing: 0.01em;
+
+    &::placeholder {
+        color: $blue-40;
+    }
+
+    &:focus,
+    &:focus-visible {
+        border-color: $blue-30;
+        outline: none;
+    }
+}
+
+.user-survey__other-input-wrapper:focus-within .user-survey__other-input {
+    border-color: $blue-30;
+}
+
+.user-survey__other-input-clear-button {
+    position: absolute;
+    top: 50%;
+    right: 8px;
+    transform: translateY(-50%);
+    width: 16px;
+    height: 16px;
+    border: 0;
+    padding: 0;
+    background: transparent;
+    color: $gray-70;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+
+    &:hover {
+        color: $gray-80;
+    }
+
+    svg {
+        width: 12px;
+        height: 12px;
+    }
+
+    &:focus-visible {
+        outline: 2px solid $blue-30;
+        outline-offset: 2px;
+        border-radius: 50%;
+    }
+}
+
+.user-survey__submit-row {
+    padding: 12px 0 16px;
+}
+
+.user-survey__submit-row--sticky {
+    position: sticky;
+    bottom: 0;
+    z-index: 1;
+    background: $white;
+}
+
+.user-survey__submit-button {
+    width: 100%;
+
+    &:disabled {
+        opacity: 0.5;
+    }
+}
+
+.user-survey__follow-up-close-button {
+    margin-left: auto;
+}
+
+.user-survey__follow-up-body {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    padding: 16px;
+}
+
+.user-survey__follow-up-top-row {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+    width: 100%;
+    margin-bottom: 12px;
+}
+
+.user-survey__follow-up-checkmark {
+    width: 62px;
+    height: 62px;
+    border-radius: 50%;
+    background: #c9edcb;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #008211;
+    font-size: 26px;
+}
+
+.user-survey__follow-up-title {
+    @include body-1-bold;
+    margin: 0;
+    margin-bottom: 4px;
+}
+
+.user-survey__follow-up-description {
+    @include body-3-regular;
+    margin: 0;
+    margin-bottom: 20px;
+}
+
+.user-survey__follow-up-label {
+    @include body-3-bold;
+    color: $blue-50;
+    margin-bottom: 12px;
+}
+
+.user-survey__follow-up-textarea {
+    width: 100%;
+    height: 131px;
+    border: 1px solid $gray-20;
+    border-radius: 4px;
+    margin-bottom: 16px;
+    padding: 8px 16px 8px 8px;
+    resize: none;
+    @include label-2-regular;
+    color: $blue-90;
+}
+
+.user-survey__follow-up-error {
+    @include note-1-regular;
+    color: $error-text-color;
+    margin: -8px 0 16px;
+}
+
+.user-survey__follow-up-actions {
+    display: flex;
+    gap: 16px;
+}
+
+.user-survey__follow-up-no-thanks-button {
+    width: 166px;
+    background-color: transparent;
+
+    &:hover {
+        background-color: $blue-20;
+    }
+}
+
+.user-survey__follow-up-submit-button {
+    width: 137px;
+}
+
+@include md-down {
+    .user-survey--long-list,
+    .user-survey--short-list,
+    .user-survey--free-form,
+    .user-survey--follow-up {
+        display: none;
+    }
+}

--- a/site/gdocs/components/UserSurvey.tsx
+++ b/site/gdocs/components/UserSurvey.tsx
@@ -1,0 +1,837 @@
+import {
+    faCheck,
+    faCircleXmark,
+    faXmark,
+} from "@fortawesome/free-solid-svg-icons"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import cx from "classnames"
+import * as _ from "lodash-es"
+import {
+    type FormEvent,
+    type ReactNode,
+    useEffect,
+    useRef,
+    useState,
+} from "react"
+import { Form } from "react-aria-components"
+import { match } from "ts-pattern"
+import { uuidv7 } from "uuidv7"
+import { Button, RadioButton } from "@ourworldindata/components"
+import {
+    type UserSurveyExperimentArm,
+    type UserSurveyRoleAnswer,
+} from "@ourworldindata/types"
+import { getExperimentState } from "@ourworldindata/utils"
+import { SiteAnalytics } from "../../SiteAnalytics.js"
+import {
+    getUserSurveyWidgetEligibility,
+    markUserSurveyAnswered,
+    markUserSurveyDismissed,
+} from "../../userSurvey.js"
+import { useTriggerOnEscape } from "../../hooks.js"
+
+const FEEDBACK_EMAIL_API_URL = "https://feedback.owid.io"
+const FEEDBACK_STORAGE_API_URL = "/api/user-survey"
+const USER_SURVEY_NAME = "user-role-v1"
+const USER_SURVEY_EXPERIMENT_ID = "exp-user-survey-role-v1"
+const USER_SURVEY_FREE_FORM_INPUT_ID = "user-survey-free-form-input"
+const USER_SURVEY_FOLLOW_UP_INPUT_ID = "user-survey-follow-up-input"
+const USER_SURVEY_TITLE_ID = "user-survey-title"
+const USER_SURVEY_FOLLOW_UP_TITLE_ID = "user-survey-follow-up-title"
+const USER_SURVEY_FOLLOW_UP_DESCRIPTION_ID = "user-survey-follow-up-description"
+
+const siteAnalytics = new SiteAnalytics()
+const responseId = uuidv7()
+
+type RoleOption = {
+    id: string
+    label: string
+    description?: string
+    hasInlineInput?: boolean
+}
+
+type SurveyState =
+    | { phase: "hidden" }
+    | { phase: "role"; experimentArm: UserSurveyExperimentArm }
+    | { phase: "thankYou"; roleAnswer: UserSurveyRoleAnswer }
+
+type UserSurveyRoleStepProps = {
+    onDismiss: () => void
+    onAnswered: (roleAnswer: UserSurveyRoleAnswer) => void
+}
+
+const LONG_LIST_OPTIONS: RoleOption[] = _.shuffle<RoleOption>([
+    {
+        id: "policy-professional",
+        label: "Public policy professional",
+        description:
+            "Policy advisor, government official, or consultant working on public policy",
+    },
+    {
+        id: "journalist-or-media-professional",
+        label: "Journalist or media professional",
+        description:
+            "Reporting, writing, editing, or publishing for media or online platforms",
+    },
+    {
+        id: "educator",
+        label: "Educator",
+        description: "Teacher, lecturer, or professor",
+    },
+    {
+        id: "student",
+        label: "Student",
+        description: "School or university student",
+    },
+    {
+        id: "researcher-or-scientist",
+        label: "Researcher or scientist",
+        description: "Academic or applied research, including think tanks",
+    },
+    {
+        id: "ngo-or-civil-society-professional",
+        label: "NGO or civil society professional",
+        description: "Working in a local or international nonprofit",
+    },
+    {
+        id: "business-or-investment-professional",
+        label: "Business or investment professional",
+        description:
+            "Working in the private sector, including finance, industry, or startups",
+    },
+    {
+        id: "interested-member-of-the-public",
+        label: "Interested member of the public",
+        description:
+            "Using the site to learn, explore, or inform personal decisions",
+    },
+    {
+        id: "health-professional",
+        label: "Health professional",
+        description: "Clinician, public health worker, health practitioner",
+    },
+]).concat([{ id: "other", label: "Other", hasInlineInput: true }])
+
+const SHORT_LIST_OPTIONS: RoleOption[] = _.shuffle<RoleOption>([
+    {
+        id: "government-civil-society-professional",
+        label: "Government or civil society professional",
+    },
+    {
+        id: "researcher-educator-student",
+        label: "Researcher, educator, or student",
+    },
+    {
+        id: "business-professional",
+        label: "Business professional",
+    },
+    {
+        id: "media-professional-or-journalist",
+        label: "Media professional or journalist",
+    },
+    {
+        id: "interested-member-of-public",
+        label: "Interested member of the public",
+    },
+]).concat([{ id: "other", label: "Other", hasInlineInput: true }])
+
+function getAssignedExperimentArm() {
+    const assignedArm =
+        getExperimentState().assignedExperiments[USER_SURVEY_EXPERIMENT_ID]
+    if (
+        assignedArm === "long-list" ||
+        assignedArm === "short-list" ||
+        assignedArm === "free-form"
+    )
+        return assignedArm
+    return null
+}
+
+function isValidRoleAnswer(
+    selectedOptionId: string | null,
+    otherInput: string
+) {
+    return (
+        selectedOptionId !== null &&
+        (selectedOptionId !== "other" || otherInput.trim().length > 0)
+    )
+}
+
+function getFreeFormInput(selectedOptionId: string, otherInput: string) {
+    if (selectedOptionId !== "other") return undefined
+    return otherInput.trim()
+}
+
+function getSelectedOptionMeta(
+    selectedOptionId: string,
+    options: readonly { id: string; label: string }[]
+) {
+    const selectedOptionIndex = options.findIndex(
+        (option) => option.id === selectedOptionId
+    )
+    if (selectedOptionIndex === -1) return undefined
+
+    return {
+        optionIndex: selectedOptionIndex,
+        optionLabel: options[selectedOptionIndex].label,
+    }
+}
+
+function getFeedbackEnvironment() {
+    return `Current URL: ${window.location.href}\nUser Agent: ${navigator.userAgent}\nViewport: ${window.innerWidth}x${window.innerHeight}`
+}
+
+async function sendFeedbackEmail({ message }: { message: string }) {
+    const response = await fetch(FEEDBACK_EMAIL_API_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+            name: "",
+            email: "",
+            message,
+            environment: getFeedbackEnvironment(),
+        }),
+    })
+
+    if (!response.ok) {
+        throw new Error(
+            `Sending user survey feedback failed: ${response.status} ${response.statusText}`
+        )
+    }
+}
+
+async function storeFeedback({
+    surveyName,
+    responseId,
+    feedbackAnswer,
+    roleAnswer,
+}: {
+    surveyName: string
+    responseId: string
+    feedbackAnswer: string
+    roleAnswer: UserSurveyRoleAnswer
+}) {
+    const response = await fetch(FEEDBACK_STORAGE_API_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+            surveyName,
+            responseId,
+            feedbackAnswer,
+            roleAnswer,
+        }),
+    })
+
+    if (!response.ok) {
+        throw new Error(
+            `Storing user survey feedback failed: ${response.status} ${response.statusText}`
+        )
+    }
+}
+
+async function submitFeedback({
+    surveyName,
+    responseId,
+    feedbackAnswer,
+    roleAnswer,
+}: {
+    surveyName: string
+    responseId: string
+    feedbackAnswer: string
+    roleAnswer: UserSurveyRoleAnswer
+}) {
+    await Promise.all([
+        sendFeedbackEmail({
+            message: buildFeedbackMessage({
+                surveyName,
+                responseId,
+                feedbackAnswer,
+                roleAnswer,
+            }),
+        }),
+        storeFeedback({
+            surveyName,
+            responseId,
+            feedbackAnswer,
+            roleAnswer,
+        }),
+    ])
+}
+
+function buildFeedbackMessage({
+    surveyName,
+    responseId,
+    feedbackAnswer,
+    roleAnswer,
+}: {
+    surveyName: string
+    responseId: string
+    feedbackAnswer: string
+    roleAnswer: UserSurveyRoleAnswer
+}) {
+    const messageLines = [
+        "User survey context:",
+        `survey_name: ${surveyName}`,
+        `response_id: ${responseId}`,
+        `experiment_arm: ${roleAnswer.experimentArm}`,
+    ]
+
+    if (roleAnswer.freeFormInput !== undefined) {
+        messageLines.push(`free_form_input: ${roleAnswer.freeFormInput}`)
+    }
+    if ("optionId" in roleAnswer) {
+        messageLines.push(`option_id: ${roleAnswer.optionId}`)
+        messageLines.push(`option_label: ${roleAnswer.optionLabel}`)
+        messageLines.push(`option_index: ${roleAnswer.optionIndex}`)
+    }
+
+    messageLines.push("", "Follow-up feedback:", feedbackAnswer)
+    return messageLines.join("\n")
+}
+
+function logRoleSubmit({
+    surveyName,
+    responseId,
+    roleAnswer,
+}: {
+    surveyName: string
+    responseId: string
+    roleAnswer: UserSurveyRoleAnswer
+}) {
+    if (roleAnswer.experimentArm === "free-form") {
+        siteAnalytics.logUserSurveyRoleSubmit({
+            surveyName,
+            responseId,
+            experimentArm: roleAnswer.experimentArm,
+            freeFormInput: roleAnswer.freeFormInput,
+        })
+        return
+    }
+
+    siteAnalytics.logUserSurveyRoleSubmit({
+        surveyName,
+        responseId,
+        experimentArm: roleAnswer.experimentArm,
+        optionId: roleAnswer.optionId,
+        optionLabel: roleAnswer.optionLabel,
+        optionIndex: roleAnswer.optionIndex,
+        ...(roleAnswer.freeFormInput !== undefined
+            ? { freeFormInput: roleAnswer.freeFormInput }
+            : {}),
+    })
+}
+
+function submitRoleAnswer({
+    roleAnswer,
+    onAnswered,
+}: {
+    roleAnswer: UserSurveyRoleAnswer
+    onAnswered: (roleAnswer: UserSurveyRoleAnswer) => void
+}) {
+    logRoleSubmit({
+        surveyName: USER_SURVEY_NAME,
+        responseId,
+        roleAnswer,
+    })
+    onAnswered(roleAnswer)
+}
+
+function buildListRoleAnswer({
+    experimentArm,
+    selectedOptionId,
+    otherInput,
+    options,
+}: {
+    experimentArm: "long-list" | "short-list"
+    selectedOptionId: string | null
+    otherInput: string
+    options: readonly { id: string; label: string }[]
+}): UserSurveyRoleAnswer | undefined {
+    if (selectedOptionId === null) return undefined
+
+    const selectedOption = getSelectedOptionMeta(selectedOptionId, options)
+    if (!selectedOption) return undefined
+
+    const freeFormInput = getFreeFormInput(selectedOptionId, otherInput)
+    return {
+        experimentArm,
+        freeFormInput,
+        optionId: selectedOptionId,
+        optionLabel: selectedOption.optionLabel,
+        optionIndex: selectedOption.optionIndex,
+    }
+}
+
+function UserSurveyDialog({
+    className,
+    title,
+    onDismiss,
+    children,
+}: {
+    className: string
+    title: string
+    onDismiss: () => void
+    children: ReactNode
+}) {
+    return (
+        <aside
+            className={cx("user-survey", className)}
+            role="region"
+            aria-labelledby={USER_SURVEY_TITLE_ID}
+        >
+            <div className="user-survey__header">
+                <h3 id={USER_SURVEY_TITLE_ID} className="user-survey__title">
+                    {title}
+                </h3>
+                <Button
+                    className="user-survey__close-button"
+                    theme="outline-light-blue"
+                    onClick={onDismiss}
+                    ariaLabel="Close"
+                    icon={faXmark}
+                />
+            </div>
+            {children}
+        </aside>
+    )
+}
+
+function ThankYouStep({
+    onDismiss,
+    onSuccess,
+    surveyName,
+    responseId,
+    roleAnswer,
+}: {
+    onDismiss: () => void
+    onSuccess: () => void
+    surveyName: string
+    responseId: string
+    roleAnswer: UserSurveyRoleAnswer
+}) {
+    const [feedback, setFeedback] = useState<string>("")
+    const [isSubmitting, setIsSubmitting] = useState<boolean>(false)
+    const [submitError, setSubmitError] = useState<string | null>(null)
+    const isSubmitDisabled = isSubmitting || feedback.trim().length === 0
+    const headingRef = useRef<HTMLHeadingElement>(null)
+    useTriggerOnEscape(onDismiss)
+
+    // Move focus to the heading on mount so screen readers announce the phase
+    // transition from the role question to this thank-you step (WCAG 4.1.3).
+    useEffect(() => {
+        headingRef.current?.focus()
+    }, [])
+
+    function handleSubmit() {
+        const feedbackAnswer = feedback.trim()
+        if (feedbackAnswer.length === 0) {
+            onDismiss()
+            return
+        }
+
+        setIsSubmitting(true)
+        setSubmitError(null)
+
+        void submitFeedback({
+            surveyName,
+            responseId,
+            feedbackAnswer,
+            roleAnswer,
+        })
+            .then(() => {
+                siteAnalytics.logUserSurveyFeedbackSubmit({
+                    surveyName,
+                    responseId,
+                    experimentArm: roleAnswer.experimentArm,
+                })
+                onSuccess()
+            })
+            .catch(() => {
+                setSubmitError(
+                    "Something went wrong while sending feedback. Please try again."
+                )
+            })
+            .finally(() => {
+                setIsSubmitting(false)
+            })
+    }
+
+    return (
+        <aside
+            className="user-survey user-survey--follow-up"
+            role="region"
+            aria-labelledby={USER_SURVEY_FOLLOW_UP_TITLE_ID}
+            aria-describedby={USER_SURVEY_FOLLOW_UP_DESCRIPTION_ID}
+        >
+            <div className="user-survey__follow-up-body">
+                <div className="user-survey__follow-up-top-row">
+                    <div className="user-survey__follow-up-checkmark">
+                        <FontAwesomeIcon icon={faCheck} />
+                    </div>
+                    <Button
+                        className="user-survey__close-button user-survey__follow-up-close-button"
+                        theme="outline-light-blue"
+                        onClick={onDismiss}
+                        ariaLabel="Close"
+                        icon={faXmark}
+                    />
+                </div>
+                <h3
+                    ref={headingRef}
+                    id={USER_SURVEY_FOLLOW_UP_TITLE_ID}
+                    className="user-survey__follow-up-title"
+                    tabIndex={-1}
+                >
+                    Thank you for answering our survey.
+                </h3>
+                <p
+                    id={USER_SURVEY_FOLLOW_UP_DESCRIPTION_ID}
+                    className="user-survey__follow-up-description"
+                >
+                    This will help us improve our website for our users.
+                </p>
+                <label
+                    className="user-survey__follow-up-label"
+                    htmlFor={USER_SURVEY_FOLLOW_UP_INPUT_ID}
+                >
+                    Do you have any other feedback?
+                </label>
+                <textarea
+                    id={USER_SURVEY_FOLLOW_UP_INPUT_ID}
+                    className="user-survey__follow-up-textarea"
+                    value={feedback}
+                    disabled={isSubmitting}
+                    maxLength={2000}
+                    onChange={(event) => {
+                        setFeedback(event.target.value)
+                    }}
+                    placeholder="Let us know here..."
+                />
+                {submitError && (
+                    <p className="user-survey__follow-up-error" role="alert">
+                        {submitError}
+                    </p>
+                )}
+                <div className="user-survey__follow-up-actions">
+                    <Button
+                        className="user-survey__follow-up-no-thanks-button"
+                        theme="outline-light-blue"
+                        disabled={isSubmitting}
+                        onClick={onDismiss}
+                        text="No thanks"
+                        icon={null}
+                    />
+                    <Button
+                        className="user-survey__follow-up-submit-button"
+                        theme="solid-light-blue"
+                        disabled={isSubmitDisabled}
+                        onClick={handleSubmit}
+                        text={isSubmitting ? "Submitting..." : "Submit"}
+                        icon={null}
+                    />
+                </div>
+            </div>
+        </aside>
+    )
+}
+
+function ListRoleStep({
+    experimentArm,
+    options,
+    className,
+    radioButtonGroup,
+    radioButtonClassName,
+    onDismiss,
+    onAnswered,
+}: UserSurveyRoleStepProps & {
+    experimentArm: "long-list" | "short-list"
+    options: RoleOption[]
+    className: string
+    radioButtonGroup: string
+    radioButtonClassName?: string
+}) {
+    const [selectedOptionId, setSelectedOptionId] = useState<string | null>(
+        null
+    )
+    const [otherInput, setOtherInput] = useState<string>("")
+    const otherInputRef = useRef<HTMLInputElement>(null)
+
+    function handleSubmit(event: FormEvent<HTMLFormElement>) {
+        event.preventDefault()
+        if (!isSubmitEnabled) return
+        const roleAnswer = buildListRoleAnswer({
+            experimentArm,
+            selectedOptionId,
+            otherInput,
+            options,
+        })
+        if (!roleAnswer) return
+
+        submitRoleAnswer({ roleAnswer, onAnswered })
+    }
+
+    const isSubmitEnabled = isValidRoleAnswer(selectedOptionId, otherInput)
+
+    return (
+        <UserSurveyDialog
+            className={className}
+            title="Which of the following best describes you?"
+            onDismiss={onDismiss}
+        >
+            <Form className="user-survey__form" onSubmit={handleSubmit}>
+                <fieldset className="user-survey__fieldset">
+                    <legend className="user-survey__legend">I am a:</legend>
+                    <div className="user-survey__options">
+                        {options.map((option) => {
+                            const isSelected = selectedOptionId === option.id
+
+                            return (
+                                <div
+                                    className="user-survey__option"
+                                    key={option.id}
+                                >
+                                    <RadioButton
+                                        className={cx(
+                                            "user-survey__radio-button",
+                                            radioButtonClassName
+                                        )}
+                                        id={`user-survey-${radioButtonGroup}-${option.id}`}
+                                        group={radioButtonGroup}
+                                        checked={isSelected}
+                                        onChange={() =>
+                                            setSelectedOptionId(option.id)
+                                        }
+                                        label={
+                                            option.description ? (
+                                                <span className="user-survey__option-text">
+                                                    <span className="user-survey__option-title">
+                                                        {option.label}
+                                                    </span>
+                                                    <span className="user-survey__option-description">
+                                                        {option.description}
+                                                    </span>
+                                                </span>
+                                            ) : (
+                                                option.label
+                                            )
+                                        }
+                                    />
+                                    {option.hasInlineInput && (
+                                        <div className="user-survey__other-input-wrapper">
+                                            <input
+                                                ref={otherInputRef}
+                                                className="user-survey__other-input"
+                                                type="text"
+                                                value={otherInput}
+                                                maxLength={200}
+                                                onFocus={() => {
+                                                    setSelectedOptionId(
+                                                        option.id
+                                                    )
+                                                }}
+                                                onChange={(event) => {
+                                                    setSelectedOptionId(
+                                                        option.id
+                                                    )
+                                                    setOtherInput(
+                                                        event.target.value
+                                                    )
+                                                }}
+                                                placeholder="Please specify..."
+                                                aria-label="Please specify"
+                                            />
+                                            {otherInput.length > 0 && (
+                                                <button
+                                                    className="user-survey__other-input-clear-button"
+                                                    type="button"
+                                                    onClick={() => {
+                                                        setOtherInput("")
+                                                        setSelectedOptionId(
+                                                            option.id
+                                                        )
+                                                        otherInputRef.current?.focus()
+                                                    }}
+                                                    aria-label="Clear other details"
+                                                >
+                                                    <FontAwesomeIcon
+                                                        icon={faCircleXmark}
+                                                    />
+                                                </button>
+                                            )}
+                                        </div>
+                                    )}
+                                </div>
+                            )
+                        })}
+                    </div>
+                    <div
+                        className={cx("user-survey__submit-row", {
+                            "user-survey__submit-row--sticky":
+                                selectedOptionId !== null,
+                        })}
+                    >
+                        <Button
+                            className="user-survey__submit-button"
+                            type="submit"
+                            disabled={!isSubmitEnabled}
+                            text="Submit"
+                            theme="solid-light-blue"
+                            icon={null}
+                        />
+                    </div>
+                </fieldset>
+            </Form>
+        </UserSurveyDialog>
+    )
+}
+
+function FreeFormRoleStep({ onDismiss, onAnswered }: UserSurveyRoleStepProps) {
+    const [value, setValue] = useState<string>("")
+
+    function handleSubmit(event: FormEvent<HTMLFormElement>) {
+        event.preventDefault()
+        if (!isSubmitEnabled) return
+        const freeFormInput = value.trim()
+        const roleAnswer: UserSurveyRoleAnswer = {
+            experimentArm: "free-form",
+            freeFormInput,
+        }
+        submitRoleAnswer({ roleAnswer, onAnswered })
+    }
+
+    const isSubmitEnabled = value.trim().length > 0
+
+    return (
+        <UserSurveyDialog
+            className="user-survey--free-form"
+            title="How would you describe your main occupation?"
+            onDismiss={onDismiss}
+        >
+            <Form className="user-survey__short-form" onSubmit={handleSubmit}>
+                <div className="user-survey__short-body">
+                    <label
+                        className="user-survey__short-legend"
+                        htmlFor={USER_SURVEY_FREE_FORM_INPUT_ID}
+                    >
+                        I am a:
+                    </label>
+                    <input
+                        id={USER_SURVEY_FREE_FORM_INPUT_ID}
+                        className="user-survey__free-input"
+                        type="text"
+                        value={value}
+                        maxLength={200}
+                        onChange={(event) => setValue(event.target.value)}
+                        placeholder="eg. journalist, policy professional, educator..."
+                    />
+                    <Button
+                        className="user-survey__submit-button"
+                        type="submit"
+                        disabled={!isSubmitEnabled}
+                        text="Submit"
+                        theme="solid-light-blue"
+                        icon={null}
+                    />
+                </div>
+            </Form>
+        </UserSurveyDialog>
+    )
+}
+
+export default function UserSurvey() {
+    const [surveyState, setSurveyState] = useState<SurveyState>(() => {
+        const experimentArm = getUserSurveyWidgetEligibility()
+            ? getAssignedExperimentArm()
+            : null
+        if (experimentArm === null) return { phase: "hidden" }
+        return { phase: "role", experimentArm }
+    })
+
+    useEffect(() => {
+        if (surveyState.phase === "role") {
+            siteAnalytics.logUserSurveyRoleShow({
+                surveyName: USER_SURVEY_NAME,
+                responseId,
+                experimentArm: surveyState.experimentArm,
+            })
+        } else if (surveyState.phase === "thankYou") {
+            siteAnalytics.logUserSurveyThankYouShow({
+                surveyName: USER_SURVEY_NAME,
+                responseId,
+                experimentArm: surveyState.roleAnswer.experimentArm,
+            })
+        }
+    }, [surveyState])
+
+    function handleRoleAnswered(answer: UserSurveyRoleAnswer) {
+        if (surveyState.phase !== "role") return
+        setSurveyState({
+            phase: "thankYou",
+            roleAnswer: answer,
+        })
+        markUserSurveyAnswered()
+    }
+
+    function handleDismiss() {
+        if (surveyState.phase === "hidden") return
+        if (surveyState.phase === "role") {
+            markUserSurveyDismissed()
+            siteAnalytics.logUserSurveyRoleDismiss({
+                surveyName: USER_SURVEY_NAME,
+                responseId,
+                experimentArm: surveyState.experimentArm,
+            })
+        } else {
+            siteAnalytics.logUserSurveyThankYouDismiss({
+                surveyName: USER_SURVEY_NAME,
+                responseId,
+                experimentArm: surveyState.roleAnswer.experimentArm,
+            })
+        }
+        setSurveyState({ phase: "hidden" })
+    }
+
+    if (surveyState.phase === "hidden") return null
+    if (surveyState.phase === "thankYou") {
+        return (
+            <ThankYouStep
+                onDismiss={handleDismiss}
+                onSuccess={() => {
+                    setSurveyState({ phase: "hidden" })
+                }}
+                surveyName={USER_SURVEY_NAME}
+                responseId={responseId}
+                roleAnswer={surveyState.roleAnswer}
+            />
+        )
+    }
+    return match(surveyState.experimentArm)
+        .with("long-list", () => (
+            <ListRoleStep
+                experimentArm="long-list"
+                options={LONG_LIST_OPTIONS}
+                className="user-survey--long-list"
+                radioButtonGroup="user-survey-long-role"
+                onDismiss={handleDismiss}
+                onAnswered={handleRoleAnswered}
+            />
+        ))
+        .with("short-list", () => (
+            <ListRoleStep
+                experimentArm="short-list"
+                options={SHORT_LIST_OPTIONS}
+                className="user-survey--short-list"
+                radioButtonGroup="user-survey-short-role"
+                radioButtonClassName="user-survey__radio-button--short-list"
+                onDismiss={handleDismiss}
+                onAnswered={handleRoleAnswered}
+            />
+        ))
+        .with("free-form", () => (
+            <FreeFormRoleStep
+                onDismiss={handleDismiss}
+                onAnswered={handleRoleAnswered}
+            />
+        ))
+        .exhaustive()
+}

--- a/site/owid.scss
+++ b/site/owid.scss
@@ -161,6 +161,7 @@
 @import "./gdocs/components/People.scss";
 @import "./gdocs/components/Person.scss";
 @import "./gdocs/components/Socials.scss";
+@import "./gdocs/components/UserSurvey.scss";
 @import "./AboutThisData.scss";
 @import "./DataPage.scss";
 @import "./DataPageContent.scss";

--- a/site/runSiteFooterScripts.tsx
+++ b/site/runSiteFooterScripts.tsx
@@ -5,6 +5,7 @@ import {
     DATA_INSIGHTS_INDEX_PAGE_SIZE,
     DataPageV2ContentFields,
     deserializeOwidGdocPageData,
+    isInIFrame,
     MultiDimDataPageConfig,
     OwidGdocType,
     parseIntOrUndefined,
@@ -48,6 +49,7 @@ import { DataInsightsIndexPageProps } from "./DataInsightsIndexPage.js"
 import { NewsletterSubscriptionForm } from "./NewsletterSubscription.js"
 import { NewsletterSubscriptionContext } from "./newsletter.js"
 import { SUBSCRIBE_PAGE_FORM_CONTAINER_ID } from "@ourworldindata/types"
+import UserSurvey from "./gdocs/components/UserSurvey.js"
 
 function runSearchPage() {
     const root = document.getElementById("search-page-root")
@@ -165,6 +167,19 @@ function runCookiePreferencesManager() {
 
     const root = createRoot(div)
     root.render(<CookiePreferencesManager initialState={getInitialState()} />)
+}
+
+const USER_SURVEY_ROOT_ID = "user-survey-root"
+
+function runUserSurveyWidget() {
+    if (isInIFrame()) return
+    if (window._OWID_ARCHIVE_CONTEXT?.type === "archive-page") return
+    if (document.getElementById(USER_SURVEY_ROOT_ID)) return
+
+    const div = document.createElement("div")
+    div.id = USER_SURVEY_ROOT_ID
+    document.body.appendChild(div)
+    createRoot(div).render(<UserSurvey />)
 }
 
 interface FootnoteContent {
@@ -348,6 +363,7 @@ export const runSiteFooterScripts = async (
             runSiteNavigation(hideDonationFlag)
             runSiteTools()
             runCookiePreferencesManager()
+            runUserSurveyWidget()
             void runDetailsOnDemand()
             break
         case SiteFooterContext.multiDimDataPage:
@@ -356,6 +372,7 @@ export const runSiteFooterScripts = async (
             runSiteNavigation(hideDonationFlag)
             runSiteTools()
             runCookiePreferencesManager()
+            runUserSurveyWidget()
             void runDetailsOnDemand()
             break
         case SiteFooterContext.grapherPage:
@@ -364,6 +381,7 @@ export const runSiteFooterScripts = async (
             runAllGraphersLoadedListener()
             runSiteTools()
             runCookiePreferencesManager()
+            runUserSurveyWidget()
             void runDetailsOnDemand()
             break
         case SiteFooterContext.explorerIndexPage:
@@ -380,6 +398,7 @@ export const runSiteFooterScripts = async (
             void runDetailsOnDemand()
             runSiteTools()
             runCookiePreferencesManager()
+            runUserSurveyWidget()
             break
         case SiteFooterContext.dynamicCollectionPage:
             // Don't break, run default case too

--- a/site/userSurvey.test.ts
+++ b/site/userSurvey.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest"
+import {
+    isUserSurveyEligible,
+    USER_SURVEY_MIN_VISIT_COUNT,
+    USER_SURVEY_RETURNING_USER_MIN_AGE_MS,
+} from "./userSurvey.js"
+
+const nowTimestampMs = 2_000_000
+
+describe("user survey widget eligibility", () => {
+    it("is ineligible when analytics consent is missing", () => {
+        const result = isUserSurveyEligible({
+            hasAnalyticsConsent: false,
+            response: undefined,
+            visitCount: USER_SURVEY_MIN_VISIT_COUNT,
+            firstVisitTimestampMs:
+                nowTimestampMs - USER_SURVEY_RETURNING_USER_MIN_AGE_MS,
+            nowTimestampMs,
+        })
+
+        expect(result).toEqual(false)
+    })
+
+    it("is ineligible when user already answered or dismissed", () => {
+        const result = isUserSurveyEligible({
+            hasAnalyticsConsent: true,
+            response: "dismissed",
+            visitCount: USER_SURVEY_MIN_VISIT_COUNT,
+            firstVisitTimestampMs:
+                nowTimestampMs - USER_SURVEY_RETURNING_USER_MIN_AGE_MS,
+            nowTimestampMs,
+        })
+
+        expect(result).toEqual(false)
+    })
+
+    it("is ineligible before the fifth visit", () => {
+        const result = isUserSurveyEligible({
+            hasAnalyticsConsent: true,
+            response: undefined,
+            visitCount: USER_SURVEY_MIN_VISIT_COUNT - 1,
+            firstVisitTimestampMs:
+                nowTimestampMs - USER_SURVEY_RETURNING_USER_MIN_AGE_MS,
+            nowTimestampMs,
+        })
+
+        expect(result).toEqual(false)
+    })
+
+    it("is ineligible before 24 hours have passed since first visit", () => {
+        const result = isUserSurveyEligible({
+            hasAnalyticsConsent: true,
+            response: undefined,
+            visitCount: USER_SURVEY_MIN_VISIT_COUNT,
+            firstVisitTimestampMs:
+                nowTimestampMs - USER_SURVEY_RETURNING_USER_MIN_AGE_MS + 1,
+            nowTimestampMs,
+        })
+
+        expect(result).toEqual(false)
+    })
+
+    it("is ineligible when first visit timestamp is unknown", () => {
+        const result = isUserSurveyEligible({
+            hasAnalyticsConsent: true,
+            response: undefined,
+            visitCount: USER_SURVEY_MIN_VISIT_COUNT,
+            firstVisitTimestampMs: undefined,
+            nowTimestampMs,
+        })
+
+        expect(result).toEqual(false)
+    })
+
+    it("is eligible when all conditions are met", () => {
+        const result = isUserSurveyEligible({
+            hasAnalyticsConsent: true,
+            response: undefined,
+            visitCount: USER_SURVEY_MIN_VISIT_COUNT,
+            firstVisitTimestampMs:
+                nowTimestampMs - USER_SURVEY_RETURNING_USER_MIN_AGE_MS,
+            nowTimestampMs,
+        })
+
+        expect(result).toEqual(true)
+    })
+})

--- a/site/userSurvey.ts
+++ b/site/userSurvey.ts
@@ -1,0 +1,170 @@
+import { getPreferenceValue, PreferenceType } from "./cookiePreferences.js"
+
+export const USER_SURVEY_MIN_VISIT_COUNT = 5
+export const USER_SURVEY_RETURNING_USER_MIN_AGE_MS = 24 * 60 * 60 * 1000 // 24 hours
+
+export const USER_SURVEY_FIRST_VISIT_TIMESTAMP_STORAGE_KEY =
+    "owid.userSurvey.roleV1.firstVisitTimestampMs"
+export const USER_SURVEY_VISIT_COUNT_STORAGE_KEY =
+    "owid.userSurvey.roleV1.visitCount"
+export const USER_SURVEY_ROLE_V1_RESPONSE_STORAGE_KEY =
+    "owid.userSurvey.roleV1.response"
+
+export type UserSurveyResponse = "answered" | "dismissed"
+
+export function isUserSurveyEligible({
+    hasAnalyticsConsent,
+    response,
+    visitCount,
+    firstVisitTimestampMs,
+    nowTimestampMs,
+}: {
+    hasAnalyticsConsent: boolean
+    response: UserSurveyResponse | undefined
+    visitCount: number
+    firstVisitTimestampMs: number | undefined
+    nowTimestampMs: number
+}): boolean {
+    if (!hasAnalyticsConsent) {
+        return false
+    }
+
+    if (response) {
+        return false
+    }
+
+    if (visitCount < USER_SURVEY_MIN_VISIT_COUNT) {
+        return false
+    }
+
+    if (
+        firstVisitTimestampMs === undefined ||
+        nowTimestampMs - firstVisitTimestampMs <
+            USER_SURVEY_RETURNING_USER_MIN_AGE_MS
+    ) {
+        return false
+    }
+
+    return true
+}
+
+export function getUserSurveyWidgetEligibility(
+    nowTimestampMs: number = Date.now()
+): boolean {
+    const hasAnalyticsConsent = getPreferenceValue(PreferenceType.Analytics)
+    const response = getUserSurveyResponse()
+
+    if (!hasAnalyticsConsent) {
+        return false
+    }
+    if (response) {
+        return false
+    }
+
+    const visitCount = incrementAndGetUserSurveyVisitCount()
+    const firstVisitTimestampMs =
+        getOrSetUserSurveyFirstVisitTimestampMs(nowTimestampMs)
+
+    return isUserSurveyEligible({
+        hasAnalyticsConsent,
+        response,
+        visitCount,
+        firstVisitTimestampMs,
+        nowTimestampMs,
+    })
+}
+
+export function markUserSurveyAnswered(): void {
+    setUserSurveyResponse("answered")
+}
+
+export function markUserSurveyDismissed(): void {
+    setUserSurveyResponse("dismissed")
+}
+
+function parseUserSurveyResponse(
+    value: string | null
+): UserSurveyResponse | undefined {
+    if (value === "answered" || value === "dismissed") return value
+    return undefined
+}
+
+function getUserSurveyResponse(): UserSurveyResponse | undefined {
+    return parseUserSurveyResponse(
+        getFromLocalStorage(USER_SURVEY_ROLE_V1_RESPONSE_STORAGE_KEY)
+    )
+}
+
+function setUserSurveyResponse(response: UserSurveyResponse): void {
+    setInLocalStorage(USER_SURVEY_ROLE_V1_RESPONSE_STORAGE_KEY, response)
+}
+
+function getUserSurveyVisitCount(): number {
+    const value = getFromLocalStorage(USER_SURVEY_VISIT_COUNT_STORAGE_KEY)
+    if (!value) return 0
+
+    const parsed = Number.parseInt(value, 10)
+    if (!Number.isFinite(parsed) || parsed < 0) return 0
+    return parsed
+}
+
+function setUserSurveyVisitCount(visitCount: number): void {
+    setInLocalStorage(USER_SURVEY_VISIT_COUNT_STORAGE_KEY, String(visitCount))
+}
+
+function incrementAndGetUserSurveyVisitCount(): number {
+    const currentVisitCount = getUserSurveyVisitCount()
+    if (currentVisitCount >= USER_SURVEY_MIN_VISIT_COUNT) {
+        return currentVisitCount
+    }
+
+    const nextVisitCount = currentVisitCount + 1
+    setUserSurveyVisitCount(nextVisitCount)
+    return nextVisitCount
+}
+
+function getUserSurveyFirstVisitTimestampMs(): number | undefined {
+    const value = getFromLocalStorage(
+        USER_SURVEY_FIRST_VISIT_TIMESTAMP_STORAGE_KEY
+    )
+    if (!value) return undefined
+
+    const parsed = Number.parseInt(value, 10)
+    if (!Number.isFinite(parsed)) return undefined
+    return parsed
+}
+
+function setUserSurveyFirstVisitTimestampMs(timestampMs: number): void {
+    setInLocalStorage(
+        USER_SURVEY_FIRST_VISIT_TIMESTAMP_STORAGE_KEY,
+        String(timestampMs)
+    )
+}
+
+function getOrSetUserSurveyFirstVisitTimestampMs(
+    nowTimestampMs: number
+): number {
+    const firstVisitTimestampMs = getUserSurveyFirstVisitTimestampMs()
+    if (firstVisitTimestampMs !== undefined) return firstVisitTimestampMs
+
+    setUserSurveyFirstVisitTimestampMs(nowTimestampMs)
+    return nowTimestampMs
+}
+
+function getFromLocalStorage(key: string): string | null {
+    try {
+        if (typeof window === "undefined") return null
+        return window.localStorage.getItem(key)
+    } catch {
+        return null
+    }
+}
+
+function setInLocalStorage(key: string, value: string): void {
+    try {
+        if (typeof window === "undefined") return
+        window.localStorage.setItem(key, value)
+    } catch {
+        // ignore
+    }
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -14,6 +14,12 @@
 
     "pages_build_output_dir": "./localBake",
 
+    "r2_buckets": [
+        {
+            "bucket_name": "owid-user-surveys-staging",
+            "binding": "USER_SURVEYS_R2",
+        },
+    ],
     "vars": {
         // Vars that should be available in all envs, including local dev
         "ENV": "development",
@@ -25,6 +31,12 @@
     },
     "env": {
         "preview": {
+            "r2_buckets": [
+                {
+                    "bucket_name": "owid-user-surveys-staging",
+                    "binding": "USER_SURVEYS_R2",
+                },
+            ],
             "vars": {
                 // Overrides for CF preview deployments
                 "MAILGUN_DOMAIN": "mg.ourworldindata.org",
@@ -42,6 +54,12 @@
         "production": {
             // Overrides for CF production deployment
             "compatibility_date": "2025-05-05",
+            "r2_buckets": [
+                {
+                    "bucket_name": "owid-user-surveys",
+                    "binding": "USER_SURVEYS_R2",
+                },
+            ],
             "vars": {
                 "ENV": "production",
                 "MAILGUN_DOMAIN": "mg.ourworldindata.org",


### PR DESCRIPTION
## Description

- Configure the `user-survey-role-v1` experiment with three arms
- Add a new `UserSurvey` site widget (long-list, short-list, free-form experiment arms) with a follow-up feedback step
- Render the widget on eligible page contexts, skipping iframes and archive pages
- Add eligibility logic based on analytics consent, visit count, and first-visit age
- Add analytics event types and `SiteAnalytics` logging for submitting/dismissing the survey steps
- Add `POST /api/user-survey` in Cloudflare Functions with zod payload validation, Sentry error capture, and R2 persistence
- Add `USER_SURVEYS_R2` bucket bindings
- Centralize experiment cookie setting in middleware response handling (GET-only), extend static-asset skip to include `webp`

## Context

- [Notion](https://www.notion.so/owid/2026-01-21-User-survey-to-self-identify-as-a-certain-kind-of-user-2ef74b71f92e80c6a391ff7868671cea)
- [Figma](https://www.figma.com/design/PLD1bWikKmeDKSkEzqbUKf/User-Surveys?node-id=90-673&m=dev)

## Screenshots / Videos / Diagrams

### Long list variant

<img width="2934" height="1968" alt="image" src="https://github.com/user-attachments/assets/b6ef9d3f-b2c2-441c-8d35-cc91c20d508a" />

### Short list variant

<img width="2934" height="1968" alt="image" src="https://github.com/user-attachments/assets/0492fda2-6b2a-4a0d-8682-26582675281c" />

### Free-form variant

<img width="2934" height="1968" alt="image" src="https://github.com/user-attachments/assets/379c351d-49e5-4a80-a880-30cf574601bc" />

### Success screen

Shared for all variants.

<img width="2934" height="1968" alt="image" src="https://github.com/user-attachments/assets/54ac2c36-a930-4143-82bb-2448ca46e354" />

## Testing guidance

Focus on code structure and logical soundness. I'll double-check behavior, business logic, and interactions in the UI on a call with Bobbie.

- [x] Does the staging experience have sign-off from product stakeholders?

## Checklist

### Before merging

- [x] Google Analytics events were adapted to fit the changes in this PR
- [x] Changes to HTML were checked for accessibility concerns
- [x] Change the `expires` date of the experiment to be a month after launch