### PR TITLE
🎉 add region provider tooltips

### DIFF
--- a/adminSiteClient/EntityPresets.ts
+++ b/adminSiteClient/EntityPresets.ts
@@ -48,6 +48,7 @@ const ADDITIONAL_REGION_DATA_PROVIDER_LABELS: Record<
     oecd: "OECD regions",
     unsd: "UNSD regions",
     unm49: "UN M49 regions",
+    maddison: "Maddison regions",
 }
 
 /** Extracts entities matching a custom source pattern like "Africa (FAO)" */

--- a/packages/@ourworldindata/grapher/package.json
+++ b/packages/@ourworldindata/grapher/package.json
@@ -41,6 +41,7 @@
     "react-move": "^6.5.0",
     "remeda": "^2.32.0",
     "simple-statistics": "^7.8.8",
+    "tippy.js": "^6.3.7",
     "topojson-client": "^3.1.0",
     "ts-pattern": "^5.8.0",
     "url-join": "^5.0.0",

--- a/packages/@ourworldindata/grapher/src/color/CustomSchemes.ts
+++ b/packages/@ourworldindata/grapher/src/color/CustomSchemes.ts
@@ -395,6 +395,16 @@ export const ContinentColors = {
     "Latin America-Caribbean (Pew)": OwidDistinctColors.Maroon,
     "Middle East-North Africa (Pew)": OwidDistinctColors.Camel,
 
+    // UN SDG regions
+    "Australia and New Zealand (UN SDG)": OwidDistinctColors.Teal,
+    "Central and Southern Asia (UN SDG)": OwidDistinctColors.OliveGreen,
+    "Eastern and South-Eastern Asia (UN SDG)": OwidDistinctColors.Copper,
+    "Europe and Northern America (UN SDG)": OwidDistinctColors.Denim,
+    "Latin America and the Caribbean (UN SDG)": OwidDistinctColors.Maroon,
+    "Northern Africa and Western Asia (UN SDG)": OwidDistinctColors.Camel,
+    "Oceania (UN SDG)": OwidDistinctColors.Turquoise,
+    "Sub-Saharan Africa (UN SDG)": OwidDistinctColors.DarkMauve,
+
     // Income groups
     "High-income countries": IncomeGroupColors.HighIncome,
     "Upper-middle-income countries": IncomeGroupColors.UpperMiddleIncome,

--- a/packages/@ourworldindata/grapher/src/controls/DataTableSearchField.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/DataTableSearchField.tsx
@@ -5,7 +5,7 @@ import a from "indefinite"
 import { DataTableConfig } from "../dataTable/DataTableConstants"
 import { SearchField } from "./SearchField"
 import { DEFAULT_GRAPHER_ENTITY_TYPE } from "../core/GrapherConstants"
-import { isRegionDataProviderKey } from "../core/RegionGroups"
+import { isAnyRegionDataProviderKey } from "../core/RegionGroups"
 import { match } from "ts-pattern"
 
 export interface DataTableSearchFieldManager {
@@ -45,7 +45,7 @@ export class DataTableSearchField extends React.Component<{
     }
 
     @computed private get placeholderEntityType(): string {
-        if (isRegionDataProviderKey(this.config.filter)) return "region"
+        if (isAnyRegionDataProviderKey(this.config.filter)) return "region"
 
         return match(this.config.filter)
             .with("all", () => this.entityType)

--- a/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
@@ -138,6 +138,7 @@ export const ADDITIONAL_REGION_DATA_PROVIDERS = [
     "oecd",
     "unsd",
     "unm49",
+    "maddison",
 ] as const
 
 export type AdditionalRegionDataProvider =

--- a/packages/@ourworldindata/grapher/src/core/RegionGroups.ts
+++ b/packages/@ourworldindata/grapher/src/core/RegionGroups.ts
@@ -61,6 +61,7 @@ export const regionGroupLabels: Record<RegionGroupKey, string> = {
     un_m49_3: "United Nations regions",
 
     // Regions defined by an institution, but we don't have region definitions in regions.json for these (we recognize them by their suffix)
+    maddison: "Maddison Project Database regions",
     unsdg: "UN Sustainable Development Goals regions",
     unm49: "United Nations M49 regions",
     unsd: "UN Statistics Division regions",
@@ -81,7 +82,7 @@ function toProviderKey(
     providerSuffix: string
 ): AnyRegionDataProvider | undefined {
     const candidate = providerSuffix.toLowerCase().replaceAll(" ", "")
-    return isRegionDataProviderKey(candidate) ? candidate : undefined
+    return isAnyRegionDataProviderKey(candidate) ? candidate : undefined
 }
 
 export function groupEntitiesByRegionType(
@@ -189,13 +190,13 @@ export function parseLabel(raw: string): ParsedLabel {
     if (!suffix) return { raw, name: raw }
 
     const providerKey = toProviderKey(suffix)
-    if (!providerKey || !isRegionDataProviderKey(providerKey))
+    if (!providerKey || !isAnyRegionDataProviderKey(providerKey))
         return { raw, name, suffix }
 
     return { raw, name, suffix, providerKey }
 }
 
-export function isRegionDataProviderKey(
+export function isAnyRegionDataProviderKey(
     candidate: string
 ): candidate is AnyRegionDataProvider {
     return regionDataProviderSet.has(candidate as any)

--- a/packages/@ourworldindata/grapher/src/core/grapher.scss
+++ b/packages/@ourworldindata/grapher/src/core/grapher.scss
@@ -87,6 +87,7 @@ $zindex-controls-drawer: 150;
 @import "../../../components/src/Checkbox.scss";
 @import "../../../components/src/RadioButton.scss";
 @import "../../../components/src/loadingIndicator/LoadingIndicator.scss";
+@import "../seriesLabel/RegionTooltip.scss";
 
 @import "../../../components/src/closeButton/CloseButton.scss";
 @import "../../../components/src/OverlayHeader.scss";

--- a/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
+++ b/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
@@ -77,7 +77,7 @@ import {
     EntitiesByRegionGroup,
     RegionGroupKey,
     RegionGroup,
-    isRegionDataProviderKey,
+    isAnyRegionDataProviderKey,
     parseLabel,
 } from "../core/RegionGroups"
 import { SearchField } from "../controls/SearchField"
@@ -582,7 +582,7 @@ export class EntitySelector extends React.Component<EntitySelectorProps> {
     }
 
     @computed private get searchPlaceholderEntityType(): string {
-        if (isRegionDataProviderKey(this.entityFilter)) return "region"
+        if (isAnyRegionDataProviderKey(this.entityFilter)) return "region"
 
         return match(this.entityFilter)
             .with("all", () => this.entityType.singular)

--- a/packages/@ourworldindata/grapher/src/hooks.ts
+++ b/packages/@ourworldindata/grapher/src/hooks.ts
@@ -1,0 +1,30 @@
+import { useCallback, useRef, useState } from "react"
+
+/**
+ * Like useState, but clearing (setting to undefined) is debounced.
+ * Setting a value is always immediate and cancels any pending clear.
+ */
+export function useStateWithDebouncedClear<T>(
+    initialValue: T | undefined,
+    clearDelay = 200
+): [value: T | undefined, set: (value: T) => void, clear: () => void] {
+    const [value, setValue] = useState<T | undefined>(initialValue)
+    const timerRef = useRef<ReturnType<typeof setTimeout> | undefined>(
+        undefined
+    )
+
+    const set = useCallback(
+        (newValue: T) => {
+            if (timerRef.current) clearTimeout(timerRef.current)
+            setValue(newValue)
+        },
+        [setValue]
+    )
+
+    const clear = useCallback(() => {
+        if (timerRef.current) clearTimeout(timerRef.current)
+        timerRef.current = setTimeout(() => setValue(undefined), clearDelay)
+    }, [setValue, clearDelay])
+
+    return [value, set, clear]
+}

--- a/packages/@ourworldindata/grapher/src/interaction/InteractionState.ts
+++ b/packages/@ourworldindata/grapher/src/interaction/InteractionState.ts
@@ -27,6 +27,20 @@ export class InteractionState {
     }
 
     /**
+     * Creates an InteractionState by comparing a given value against the
+     * currently active value
+     */
+    static for<T>(
+        currentValue: T | undefined,
+        activeValue: T | undefined
+    ): InteractionState {
+        const isInteractedWith =
+            activeValue !== undefined && currentValue === activeValue
+        const isInteractionModeActive = activeValue !== undefined
+        return new InteractionState(isInteractedWith, isInteractionModeActive)
+    }
+
+    /**
      * Whether the chart is in an idle state, i.e. no series are currently
      * being interacted with
      */

--- a/packages/@ourworldindata/grapher/src/seriesLabel/RegionMap.tsx
+++ b/packages/@ourworldindata/grapher/src/seriesLabel/RegionMap.tsx
@@ -1,0 +1,76 @@
+import React, { useMemo } from "react"
+import cx from "classnames"
+import { Bounds, EntityName, MapRegionName } from "@ourworldindata/utils"
+import { getGeoFeaturesForMap } from "../mapCharts/GeoFeatures"
+import { InteractionState } from "../interaction/InteractionState.js"
+import { GRAY_10 } from "../color/ColorConstants.js"
+
+const NO_DATA_COLOR = GRAY_10
+
+export function RegionMap({
+    countries,
+    highlightedRegion,
+    onRegionHover,
+    onRegionLeave,
+}: {
+    countries: Map<EntityName, { region: EntityName; color: string }>
+    highlightedRegion?: EntityName
+    onRegionHover?: (regionName: EntityName) => void
+    onRegionLeave?: () => void
+}): React.ReactElement {
+    const features = getGeoFeaturesForMap(MapRegionName.World)
+
+    const viewBox = useMemo(() => {
+        const allBounds = features.map((f) => f.projBounds)
+        return Bounds.merge(allBounds).toViewBox()
+    }, [features])
+
+    return (
+        <svg className="map" viewBox={viewBox} onPointerLeave={onRegionLeave}>
+            {features.map((feature) => {
+                const entry = countries.get(feature.id)
+                return (
+                    <CountryPath
+                        key={feature.id}
+                        path={feature.path}
+                        color={entry?.color ?? NO_DATA_COLOR}
+                        interaction={InteractionState.for(
+                            entry?.region,
+                            highlightedRegion
+                        )}
+                        onPointerEnter={
+                            entry
+                                ? () => onRegionHover?.(entry.region)
+                                : onRegionLeave
+                        }
+                        onPointerLeave={onRegionLeave}
+                    />
+                )
+            })}
+        </svg>
+    )
+}
+
+function CountryPath({
+    path,
+    color,
+    interaction,
+    onPointerEnter,
+    onPointerLeave,
+}: {
+    path: string
+    color: string
+    interaction: InteractionState
+    onPointerEnter?: () => void
+    onPointerLeave?: () => void
+}): React.ReactElement {
+    return (
+        <path
+            className={cx({ muted: interaction.background })}
+            d={path}
+            fill={color}
+            onPointerEnter={onPointerEnter}
+            onPointerLeave={onPointerLeave}
+        />
+    )
+}

--- a/packages/@ourworldindata/grapher/src/seriesLabel/RegionTooltip.scss
+++ b/packages/@ourworldindata/grapher/src/seriesLabel/RegionTooltip.scss
@@ -1,0 +1,61 @@
+.region-tooltip {
+    $muted-opacity: 0.3;
+    $outline: #333333;
+
+    max-width: 320px;
+    color: $gray-100;
+    font-size: 0.875rem;
+
+    a {
+        @include owid-link-90;
+        color: inherit;
+    }
+
+    p {
+        margin: 0;
+    }
+
+    .map-container {
+        margin: 8px 0;
+    }
+
+    .map {
+        width: 100%;
+        height: auto;
+        display: block;
+
+        path {
+            stroke: $outline;
+            stroke-width: 0.3;
+        }
+    }
+
+    .legend {
+        color: $dark-text;
+        font-size: 0.9em;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 4px 12px;
+    }
+
+    .legend-item {
+        display: inline-flex;
+        align-items: baseline;
+        gap: 4px;
+        line-height: 1.2;
+        cursor: default;
+    }
+
+    .swatch {
+        width: 0.8em;
+        height: 0.8em;
+        flex-shrink: 0;
+        position: relative;
+        top: 1px; // Small visual correction
+        outline: 0.5px solid $outline;
+    }
+
+    .muted {
+        opacity: $muted-opacity;
+    }
+}

--- a/packages/@ourworldindata/grapher/src/seriesLabel/RegionTooltip.tsx
+++ b/packages/@ourworldindata/grapher/src/seriesLabel/RegionTooltip.tsx
@@ -1,0 +1,106 @@
+import React, { useMemo } from "react"
+import cx from "classnames"
+import { SimpleMarkdownText } from "@ourworldindata/components"
+import { InteractionState } from "../interaction/InteractionState.js"
+import { RegionMap } from "./RegionMap"
+import { buildCountryMap, TooltipRegion } from "./RegionTooltipData.js"
+import { useStateWithDebouncedClear } from "../hooks.js"
+
+export function RegionTooltip({
+    description,
+    regions,
+    initiallyHighlightedRegion,
+}: {
+    description: string
+    regions: TooltipRegion[]
+    initiallyHighlightedRegion: string
+}): React.ReactElement {
+    const [activeRegion, setActiveRegion, clearActiveRegion] =
+        useStateWithDebouncedClear(initiallyHighlightedRegion)
+
+    const countries = useMemo(() => buildCountryMap(regions), [regions])
+
+    return (
+        <div
+            className="region-tooltip"
+            // Stop mouse events from bubbling through the React portal boundary.
+            // Without this, events reach the parent chart's handlers (e.g. LineChart's
+            // onMouseMove) because React portals propagate synthetic events through
+            // the React component tree, not the DOM tree
+            onMouseMove={(e) => e.stopPropagation()}
+            onMouseEnter={(e) => e.stopPropagation()}
+            onMouseLeave={(e) => e.stopPropagation()}
+        >
+            <SimpleMarkdownText text={description} />
+            <div className="map-container">
+                <RegionMap
+                    countries={countries}
+                    highlightedRegion={activeRegion}
+                    onRegionHover={setActiveRegion}
+                    onRegionLeave={clearActiveRegion}
+                />
+            </div>
+            <RegionLegend
+                regions={regions}
+                highlightedRegion={activeRegion}
+                onRegionHover={setActiveRegion}
+                onRegionLeave={clearActiveRegion}
+            />
+        </div>
+    )
+}
+
+function RegionLegend({
+    regions,
+    highlightedRegion,
+    onRegionHover,
+    onRegionLeave,
+}: {
+    regions: TooltipRegion[]
+    highlightedRegion?: string
+    onRegionHover: (name: string) => void
+    onRegionLeave: () => void
+}): React.ReactElement {
+    return (
+        <ul className="legend">
+            {regions.map((region) => (
+                <RegionLegendItem
+                    key={region.name}
+                    region={region}
+                    interaction={InteractionState.for(
+                        region.name,
+                        highlightedRegion
+                    )}
+                    onPointerEnter={() => onRegionHover(region.name)}
+                    onPointerLeave={onRegionLeave}
+                />
+            ))}
+        </ul>
+    )
+}
+
+function RegionLegendItem({
+    region,
+    interaction,
+    onPointerEnter,
+    onPointerLeave,
+}: {
+    region: TooltipRegion
+    interaction: InteractionState
+    onPointerEnter: () => void
+    onPointerLeave: () => void
+}): React.ReactElement {
+    return (
+        <li
+            className={cx("legend-item", { muted: interaction.background })}
+            onPointerEnter={onPointerEnter}
+            onPointerLeave={onPointerLeave}
+        >
+            <span
+                className="swatch"
+                style={{ backgroundColor: region.color }}
+            />
+            {region.displayName}
+        </li>
+    )
+}

--- a/packages/@ourworldindata/grapher/src/seriesLabel/RegionTooltipData.ts
+++ b/packages/@ourworldindata/grapher/src/seriesLabel/RegionTooltipData.ts
@@ -1,0 +1,152 @@
+import * as R from "remeda"
+import {
+    checkIsAggregate,
+    EntityName,
+    getAggregatesByProvider,
+    getIncomeGroups,
+    Region,
+    RegionDataProvider,
+} from "@ourworldindata/utils"
+import { ContinentColors } from "../color/CustomSchemes.js"
+import { AnyRegionDataProvider, parseLabel } from "../core/RegionGroups.js"
+import { getCountriesByRegion } from "../mapCharts/MapHelpers.js"
+
+// We only support a subset of region data providers for the tooltip,
+// based on whether we have the necessary data to show in the tooltip
+const providersWithTooltipData = [
+    "wb",
+    "un",
+    "who",
+    "unsdg",
+    "pew",
+] as const satisfies RegionDataProvider[]
+
+const providersWithTooltipDataAsSet = new Set<string>(providersWithTooltipData)
+
+export type RegionProviderWithTooltipData =
+    (typeof providersWithTooltipData)[number]
+
+export type TooltipKey = RegionProviderWithTooltipData | "incomeGroups"
+
+export interface TooltipRegion {
+    name: EntityName
+    displayName: string
+    color: string
+    members: string[]
+}
+
+const continentColorsMap = ContinentColors as Record<EntityName, string>
+
+const descriptions: Record<TooltipKey, string> = {
+    wb: "The **World Bank (WB)** defines [seven world regions](https://ourworldindata.org/world-region-map-definitions#world-bank-wb-continents):",
+    un: "The **United Nations Statistical Division (UNSD)** establishes and maintains a geoscheme based on the [M49 coding classification](https://unstats.un.org/unsd/methodology/m49). At the highest level, the M49 classification categorizes countries into [six principal regions](https://ourworldindata.org/world-region-map-definitions#united-nations-un):",
+    who: "The **World Health Organization (WHO)** defines [six world regions](https://ourworldindata.org/world-region-map-definitions#world-health-organization-who):",
+    unsdg: "When reporting data on the Sustainable Development Goals, the **United Nations (UN)** defines [eight world regions](https://ourworldindata.org/world-region-map-definitions#united-nations-sustainable-development-goals-un-sdg):",
+    pew: "The **Pew Research Center (Pew)** defines [six world regions](https://ourworldindata.org/world-region-map-definitions#pew-research-center-pew):",
+    incomeGroups:
+        "The **World Bank** defines [four income groups](https://ourworldindata.org/world-bank-income-groups-explained):",
+}
+
+// Geographic display order: left-to-right on the map
+const regionDisplayOrder: Record<TooltipKey, string[]> = {
+    wb: [
+        "North America (WB)",
+        "Latin America and Caribbean (WB)",
+        "Sub-Saharan Africa (WB)",
+        "Middle East, North Africa, Afghanistan and Pakistan (WB)",
+        "Europe and Central Asia (WB)",
+        "South Asia (WB)",
+        "East Asia and Pacific (WB)",
+    ],
+    un: [
+        "Northern America (UN)",
+        "Latin America and the Caribbean (UN)",
+        "Africa (UN)",
+        "Europe (UN)",
+        "Asia (UN)",
+        "Oceania (UN)",
+    ],
+    who: [
+        "Americas (WHO)",
+        "Africa (WHO)",
+        "Eastern Mediterranean (WHO)",
+        "Europe (WHO)",
+        "South-East Asia (WHO)",
+        "Western Pacific (WHO)",
+    ],
+    unsdg: [
+        "Europe and Northern America (UN SDG)",
+        "Latin America and the Caribbean (UN SDG)",
+        "Sub-Saharan Africa (UN SDG)",
+        "Northern Africa and Western Asia (UN SDG)",
+        "Central and Southern Asia (UN SDG)",
+        "Eastern and South-Eastern Asia (UN SDG)",
+        "Australia and New Zealand (UN SDG)",
+        "Oceania (UN SDG)",
+    ],
+    pew: [
+        "North America (Pew)",
+        "Latin America-Caribbean (Pew)",
+        "Sub-Saharan Africa (Pew)",
+        "Middle East-North Africa (Pew)",
+        "Europe (Pew)",
+        "Asia-Pacific (Pew)",
+    ],
+    incomeGroups: [
+        "Low-income countries",
+        "Lower-middle-income countries",
+        "Upper-middle-income countries",
+        "High-income countries",
+    ],
+}
+
+export function hasTooltipData(
+    providerKey: AnyRegionDataProvider,
+    region: Region
+): providerKey is RegionProviderWithTooltipData {
+    if (!providersWithTooltipDataAsSet.has(providerKey)) return false
+
+    // Verify the regions entry has the right definedBy field
+    // This is important for cases like the "UN" suffix which could refer to
+    // multiple provider schemes (e.g. un, un_m49_1, un_m49_2, un_m49_3)
+    return checkIsAggregate(region) && region.definedBy === providerKey
+}
+
+export function getDescriptionForKey(key: TooltipKey): string {
+    return descriptions[key]
+}
+
+export function getRegionsForKey(key: TooltipKey): TooltipRegion[] {
+    const orderIndex = new Map(
+        regionDisplayOrder[key].map((name, i) => [name, i])
+    )
+
+    const regions =
+        key === "incomeGroups"
+            ? getIncomeGroups()
+            : getAggregatesByProvider(key)
+
+    return R.pipe(
+        regions,
+        R.sortBy((region) => orderIndex.get(region.name) ?? Infinity),
+        R.map((region) => ({
+            name: region.name,
+            displayName: parseLabel(region.name).name, // Strip suffix
+            color: continentColorsMap[region.name],
+            members: [...(getCountriesByRegion(region.name) ?? [])],
+        }))
+    )
+}
+
+/** Build a map from country name to its color and region */
+export function buildCountryMap(
+    regions: TooltipRegion[]
+): Map<EntityName, { region: EntityName; color: string }> {
+    const map = new Map<string, { color: string; region: string }>()
+    for (const region of regions) {
+        for (const country of region.members) {
+            map.set(country, { color: region.color, region: region.name })
+        }
+    }
+    return map
+}

--- a/packages/@ourworldindata/grapher/src/seriesLabel/SeriesLabelState.test.ts
+++ b/packages/@ourworldindata/grapher/src/seriesLabel/SeriesLabelState.test.ts
@@ -202,4 +202,22 @@ describe("SeriesLabelState", () => {
             { type: "icon", tooltipKey: "incomeGroups" },
         ])
     })
+
+    it("resolves region from a short entity name", () => {
+        const label = new SeriesLabelState({
+            text: "MENA, Afghanistan and Pakistan (WB)", // Short name
+            maxWidth: Infinity,
+            fontSize: FONT_SIZE,
+            showRegionTooltip: true,
+        })
+
+        const iconFragment = label.positionedFragments.find(
+            (f) => f.type === "icon"
+        )
+
+        // The region name should be resolved correctly even if the label uses a shorter name
+        expect(iconFragment?.regionName).toBe(
+            "Middle East, North Africa, Afghanistan and Pakistan (WB)"
+        )
+    })
 })

--- a/packages/@ourworldindata/utils/src/Bounds.ts
+++ b/packages/@ourworldindata/utils/src/Bounds.ts
@@ -336,6 +336,10 @@ export class Bounds {
         ]
     }
 
+    toViewBox(): string {
+        return `${this.x} ${this.y} ${this.width} ${this.height}`
+    }
+
     xRange(): [number, number] {
         return [this.left, this.right]
     }

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -227,10 +227,12 @@ export {
     checkHasMembers,
     getRegionByName,
     getRegionBySlug,
+    getRegionByShortName,
     getParentRegions,
     getSiblingRegions,
     getContinentForCountry,
     articulateEntity,
+    isRegionDataProvider,
 } from "./regions.js"
 export {
     instantiateProfile,

--- a/packages/@ourworldindata/utils/src/regions.ts
+++ b/packages/@ourworldindata/utils/src/regions.ts
@@ -86,6 +86,10 @@ export const REGION_DATA_PROVIDERS = [
 ] as const
 export type RegionDataProvider = (typeof REGION_DATA_PROVIDERS)[number]
 
+export function isRegionDataProvider(key: string): key is RegionDataProvider {
+    return REGION_DATA_PROVIDERS.includes(key as RegionDataProvider)
+}
+
 export function checkIsOwidIncomeGroupCode(
     code: string
 ): code is OwidIncomeGroupCode {
@@ -183,6 +187,14 @@ const regionsBySlug = lazy(() =>
 
 const regionsByCode = lazy(() =>
     Object.fromEntries(regions.map((region) => [region.code, region]))
+)
+
+const regionsByShortName = lazy(() =>
+    Object.fromEntries(
+        regions
+            .filter((region) => region.shortName)
+            .map((region) => [region.shortName, region])
+    )
 )
 
 export const countriesByName = lazy(() =>
@@ -325,6 +337,9 @@ export const getRegionBySlug = (slug: string): Region | undefined =>
 
 const getRegionByCode = (code: string): Region | undefined =>
     regionsByCode()[code]
+
+export const getRegionByShortName = (shortName: string): Region | undefined =>
+    regionsByShortName()[shortName]
 
 export const getRegionByNameOrVariantName = (
     nameOrVariantName: string

--- a/yarn.lock
+++ b/yarn.lock
@@ -3146,6 +3146,7 @@ __metadata:
     react-move: "npm:^6.5.0"
     remeda: "npm:^2.32.0"
     simple-statistics: "npm:^7.8.8"
+    tippy.js: "npm:^6.3.7"
     topojson-client: "npm:^3.1.0"
     ts-pattern: "npm:^5.8.0"
     url-join: "npm:^5.0.0"
@@ -17248,7 +17249,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tippy.js@npm:^6.3.1":
+"tippy.js@npm:^6.3.1, tippy.js@npm:^6.3.7":
   version: 6.3.7
   resolution: "tippy.js@npm:6.3.7"
   dependencies:


### PR DESCRIPTION
Resolves https://github.com/owid/owid-grapher/issues/5518

Renders region tooltips that contain:
- A short description (checked in with D&R)
- An interactive map
- A legend

For now, this is only supported for a specific subset of region providers, but I'm looking into making this a bit more flexible in the next PR.