### PR TITLE
✨ (slope) default yAxis.min to 0

### DIFF
--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChartHelpers.ts
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChartHelpers.ts
@@ -115,11 +115,11 @@ export function getYAxisConfigDefaults(
 ): AxisConfigInterface {
     return {
         nice: config?.scaleType !== ScaleType.log,
-        // if we only have a single y value (probably 0), we want the
+        // If we only have a single y value (probably 0), we want the
         // horizontal axis to be at the bottom of the chart.
         // see https://github.com/owid/owid-grapher/pull/975#issuecomment-890798547
         singleValueAxisPointAlign: AxisAlign.start,
-        // default to 0 if not set
+        // Default to 0 if not set
         min: 0,
     }
 }

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.009.yaml
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.009.yaml
@@ -606,7 +606,7 @@ $defs:
             min:
                 description: |
                     Minimum domain value of the axis. Inferred from data if set to "auto".
-                    Usually defaults to "auto", but defaults to 0 for line charts on the y-axis.
+                    Usually defaults to "auto", but defaults to 0 for line and slope charts on the y-axis.
                 oneOf:
                     - type: number
                     - type: string

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChartHelpers.ts
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChartHelpers.ts
@@ -19,7 +19,11 @@ import {
 export function getYAxisConfigDefaults(
     config?: AxisConfigInterface
 ): AxisConfigInterface {
-    return { nice: config?.scaleType !== ScaleType.log }
+    return {
+        nice: config?.scaleType !== ScaleType.log,
+        // Default to 0 if not set
+        min: 0,
+    }
 }
 
 export function toPlacedSlopeChartSeries(


### PR DESCRIPTION
yAxis.min now defaults to 0 for slope charts.

Bit surprised the SVG tester doesn't report changes, but tested in the admin and seems to work