### PR TITLE
✨ balanced headers in search results

### DIFF
--- a/site/search/SearchTopicPageHit.scss
+++ b/site/search/SearchTopicPageHit.scss
@@ -24,6 +24,7 @@
     margin: 0;
     color: $blue-90;
     margin-bottom: 8px;
+    text-wrap: balance;
 
     @include sm-only {
         font-size: 16px;


### PR DESCRIPTION
## Context

Sets `text-wrap: balance;` on topic page card headers in search, to prevent awkward cases where only the arrow wraps.

## Screenshots / Videos / Diagrams

| Before | After |
|--------|--------|
| <img width="437" height="183" alt="image" src="https://github.com/user-attachments/assets/94983073-c188-489f-8508-8523bd1119e9" /> | <img width="435" height="188" alt="image" src="https://github.com/user-attachments/assets/80c50a5b-2be3-41c2-b2b9-692b4300600c" /> | 