### PR TITLE
✨ allow single-time stacked bar/area charts

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
@@ -1883,8 +1883,6 @@ export class GrapherState
         return [
             GRAPHER_TAB_NAMES.LineChart,
             GRAPHER_TAB_NAMES.SlopeChart,
-            GRAPHER_TAB_NAMES.StackedArea,
-            GRAPHER_TAB_NAMES.StackedBar,
         ].includes(tabName as any)
     }
 


### PR DESCRIPTION
Resolves #6113

No strong reason not to allow single-time stacked bar/area charts. These checks were less impactful before we changed the timeline behaviour to allow/disallow single time / time range per chart type.