### PR TITLE
🐛 (explorer) update query params when choices unavailable

### DIFF
--- a/packages/@ourworldindata/explorer/src/Explorer.test.ts
+++ b/packages/@ourworldindata/explorer/src/Explorer.test.ts
@@ -61,6 +61,29 @@ describe(Explorer, () => {
         })
     })
 
+    it("resolves query params when URL requests unavailable choice combination", () => {
+        // "Consumption-based" accounting is only available for CO₂,
+        // so requesting it for Methane should fall back to "Production-based"
+        const explorer = SampleExplorerOfGraphers({
+            queryStr: "?Gas=Methane&Accounting=Consumption-based",
+        })
+
+        expect(explorer.queryParams).toMatchObject({
+            Gas: "Methane",
+            Accounting: "Production-based",
+        })
+    })
+
+    it("resolves query params to first available option when URL contains invalid choice value", () => {
+        const explorer = SampleExplorerOfGraphers({
+            queryStr: "?Gas=InvalidGas",
+        })
+
+        // "InvalidGas" doesn't exist, so it should fall back to the
+        // first available option "CO₂"
+        expect(explorer.queryParams.Gas).toEqual("CO₂")
+    })
+
     it("includes country param in archived embed URL after switching views", async () => {
         const explorer = SampleExplorerOfGraphers({
             queryStr: "?country=~GBR",

--- a/packages/@ourworldindata/explorer/src/Explorer.tsx
+++ b/packages/@ourworldindata/explorer/src/Explorer.tsx
@@ -876,7 +876,7 @@ export class Explorer
 
     @computed private get currentChoiceParams(): ExplorerChoiceParams {
         const { decisionMatrix } = this.explorerProgram
-        return decisionMatrix.currentParams
+        return decisionMatrix.toConstrainedOptions()
     }
 
     @computed get queryParams(): ExplorerFullQueryParams {
@@ -934,7 +934,10 @@ export class Explorer
                 () =>
                     this.grapher?.debounceMode
                         ? debouncedPushParams()
-                        : pushParams()
+                        : pushParams(),
+                // Fire immediately to update the URL if initial params were
+                // invalid (e.g. an unavailable choice was requested)
+                { fireImmediately: true }
             )
         )
     }


### PR DESCRIPTION
[Slack context](https://owid.slack.com/archives/C04VBQ00HQR/p1771383416949719)

Update explorer query params if the choices are invalid/unavailable

Example:
- Prod: https://ourworldindata.org/explorers/covid?Metric=Share+of+positive+tests&Interval=Cumulative&Relative+to+population=true
- Staging: http://staging-site-explorer-query-params/explorers/covid?Metric=Share+of+positive+tests&Interval=Cumulative&Relative+to+population=true

This metric doesn't have a cumulative indicator, so on prod it locks to 7-day rolling average but the URL stays the same. On staging, the URL changes to the currently rendered combinatin.
