### PR TITLE
🎉 add new slack channel for broken featured metrics

### DIFF
--- a/.env.example-full
+++ b/.env.example-full
@@ -66,6 +66,7 @@ DATA_API_URL= # optional
 
 SLACK_BOT_OAUTH_TOKEN= # optional
 SLACK_DI_PITCHES_CHANNEL_ID= # optional; #data-insight-pitches channel id
+SLACK_ALGOLIA_INDEXING_CHANNEL_ID= # optional; channel for Algolia indexing failure reports
 
 # for remote dev on tailscale without localhost + port forwarding
 ADMIN_SERVER_HOST= # optional; e.g: YOURMACHINE.TAILXXX.ts.net (find this in the tailscale admin panel)

--- a/baker/algolia/utils/slackReport.ts
+++ b/baker/algolia/utils/slackReport.ts
@@ -1,0 +1,65 @@
+import type { KnownBlock } from "@slack/web-api"
+import { postToSlack } from "../../../serverUtils/slackClient.js"
+import { SLACK_ALGOLIA_INDEXING_CHANNEL_ID } from "../../../settings/serverSettings.js"
+import type { FeaturedMetricFailure } from "./shared.js"
+import { unique } from "remeda"
+
+export async function reportFeaturedMetricFailuresToSlack(
+    failures: FeaturedMetricFailure[]
+): Promise<void> {
+    if (failures.length === 0) return
+
+    const uniqueUrls = unique(failures.map((f) => f.url))
+    const bullets = uniqueUrls.map((url) => `• ${url}`)
+
+    const sections: string[] = []
+    const MAX_SECTION_LENGTH = 3000 // Slack's block text limit
+    let currentChunk: string[] = []
+    let currentLength = 0
+
+    for (const bullet of bullets) {
+        if (
+            currentChunk.length > 0 &&
+            currentLength + bullet.length + 1 > MAX_SECTION_LENGTH
+        ) {
+            sections.push(currentChunk.join("\n"))
+            currentChunk = []
+            currentLength = 0
+        }
+        currentChunk.push(bullet)
+        currentLength += bullet.length + 1 // +1 for the newline
+    }
+    if (currentChunk.length > 0) {
+        sections.push(currentChunk.join("\n"))
+    }
+
+    const bulletBlocks: KnownBlock[] = sections.map((sectionText) => ({
+        type: "section",
+        text: {
+            type: "mrkdwn" as const,
+            text: sectionText,
+        },
+    }))
+
+    const blocks: KnownBlock[] = [
+        {
+            type: "header",
+            text: {
+                type: "plain_text",
+                text: "Algolia Featured Metric Indexing Failures",
+            },
+        },
+        {
+            type: "section",
+            text: {
+                type: "mrkdwn" as const,
+                text: `The following featured metrics failed to match during Algolia indexing. <https://admin.owid.io/admin/featured-metrics|Please investigate and fix the underlying issues> to ensure these metrics are properly indexed.`,
+            },
+        },
+        ...bulletBlocks,
+    ]
+
+    const fallbackText = `Algolia Featured Metric Indexing Failures: ${uniqueUrls.length} featured metric(s) failed to match`
+
+    await postToSlack(SLACK_ALGOLIA_INDEXING_CHANNEL_ID, blocks, fallbackText)
+}

--- a/serverUtils/slackClient.ts
+++ b/serverUtils/slackClient.ts
@@ -1,0 +1,27 @@
+import { WebClient, type Block, type KnownBlock } from "@slack/web-api"
+import { SLACK_BOT_OAUTH_TOKEN } from "../settings/serverSettings.js"
+import { logErrorAndMaybeCaptureInSentry } from "./errorLog.js"
+
+export async function postToSlack(
+    channelId: string,
+    blocks: (Block | KnownBlock)[],
+    text: string
+): Promise<void> {
+    if (!SLACK_BOT_OAUTH_TOKEN || !channelId) {
+        console.warn(
+            "Slack notification skipped: missing SLACK_BOT_OAUTH_TOKEN or channel ID"
+        )
+        return
+    }
+
+    try {
+        const client = new WebClient(SLACK_BOT_OAUTH_TOKEN)
+        await client.chat.postMessage({
+            channel: channelId,
+            blocks,
+            text,
+        })
+    } catch (error) {
+        await logErrorAndMaybeCaptureInSentry(error)
+    }
+}

--- a/settings/serverSettings.ts
+++ b/settings/serverSettings.ts
@@ -158,6 +158,9 @@ export const OPENAI_API_KEY: string = serverSettings.OPENAI_API_KEY ?? ""
 export const SLACK_BOT_OAUTH_TOKEN: string =
     serverSettings.SLACK_BOT_OAUTH_TOKEN ?? ""
 
+export const SLACK_ALGOLIA_INDEXING_CHANNEL_ID: string =
+    serverSettings.SLACK_ALGOLIA_INDEXING_CHANNEL_ID ?? ""
+
 export const LEGACY_WORDPRESS_IMAGE_URL: string =
     serverSettings.LEGACY_WORDPRESS_IMAGE_URL ??
     "https://assets.ourworldindata.org/uploads"


### PR DESCRIPTION
## Context

Adds a new integration with Slack to post a report of failed featured metrics after each weekly index.

We'd been logging these to Sentry but it hadn't been working well: Our authors didn't know where to check and the URLs weren't being deduplicated after expanding the FMs, so there was a lot of spam.

I could have just improved the Sentry experience, but Slack seems like a better place for one or two data people to monitor each week.

## Screenshot

<img width="675" height="149" alt="image" src="https://github.com/user-attachments/assets/ea675d97-b716-4332-af95-60ebed7c5ea2" />
