### PR TITLE
Adjust z-indices

### DIFF
--- a/packages/@ourworldindata/components/src/styles/variables.scss
+++ b/packages/@ourworldindata/components/src/styles/variables.scss
@@ -164,11 +164,12 @@ $zindex-sidebar: 20;
 $zindex-sidebar-page-overlay: $zindex-sidebar - 1;
 $zindex-popover: 100;
 $zindex-search-overlay: 100;
-$zindex-cookie-notice: 110;
 $zindex-site-header: 120;
 $zindex-extended-header: $zindex-site-header - 1; // ensures search overlays topic-page headers and ToC does not
 $zindex-tooltip: 1070;
-$zindex-lightbox: 99998;
+$zindex-lightbox: 99990;
+$zindex-autocomplete: $zindex-lightbox + 1;
+$zindex-cookie-notice: $zindex-lightbox + 2;
 $zindex-adminbar: 99999;
 
 /*******************************************************************************

--- a/site/search/Autocomplete.scss
+++ b/site/search/Autocomplete.scss
@@ -169,7 +169,7 @@
 }
 
 .aa-Panel {
-    z-index: $zindex-lightbox + 1;
+    z-index: $zindex-autocomplete;
     margin: 0;
     border-radius: 0;
     border: none;


### PR DESCRIPTION
- Make admin bar the highest.
- Make cookie notice the second highest. This fixes autocomplete obscuring the cookie notice buttons.

Fixes #5993
