### PR TITLE
🐛 Fix duplicate tag in search autocomplete (exact case match)

### DIFF
--- a/site/search/SearchAutocomplete.tsx
+++ b/site/search/SearchAutocomplete.tsx
@@ -158,7 +158,7 @@ export const SearchAutocomplete = ({
             <ul id={getSearchAutocompleteId()} role="listbox">
                 {suggestions.map((filter, index) => (
                     <li
-                        key={filter.name}
+                        key={`${filter.type}:${filter.name}`}
                         className={cx("search-autocomplete-item", {
                             "search-autocomplete-item--active":
                                 index === activeIndex,


### PR DESCRIPTION
Fixes #5524

## Problem

When typing a tag name with exact case (e.g. `Energy`) in the search bar:

1. The autocomplete shows both an **Energy topic** suggestion and an **Energy query** suggestion
2. Selecting the plain text query suggestion commits the search
3. Deleting a character (e.g. `Energ`) causes the **Energy tag to appear twice** in the autocomplete dropdown

## Root cause

Both the topic filter and query filter for "Energy" were rendered as `<li>` elements with `key={filter.name}` — both resolving to `key="Energy"`. When the suggestions updated (from the debounced query change), React's VDOM reconciliation failed to properly remove the stale duplicate element due to the non-unique keys.

## Fix

Changed the list item key from `filter.name` to `` `${filter.type}:${filter.name}` `` so that a topic suggestion and a query suggestion with the same name get distinct keys (e.g. `topic:Energy` vs `query:Energy`).

## Testing

1. Go to `/search`
2. Type `Energy` (exact case)
3. Select the plain text autocomplete suggestion (not the tag)
4. Delete 1 character → autocomplete should show `Energy` tag **only once**