### PR TITLE
Preserve searchbar remount while preventing autofocus on mobile

### DIFF
--- a/site/search/Search.tsx
+++ b/site/search/Search.tsx
@@ -3,11 +3,9 @@ import {
     FilterType,
     TemplateConfig,
     SearchResultType,
-    SearchState,
-    SearchUrlParam,
 } from "@ourworldindata/types"
 import { LiteClient } from "algoliasearch/lite"
-import { useMemo } from "react"
+import { useMemo, useRef } from "react"
 import { match } from "ts-pattern"
 import { useIsFetching } from "@tanstack/react-query"
 
@@ -35,15 +33,6 @@ import { buildSynonymMap } from "./synonymUtils.js"
 import { SiteAnalytics } from "../SiteAnalytics.js"
 import { PoweredBy } from "react-instantsearch"
 import { listedRegionsNames } from "@ourworldindata/utils"
-
-function makeSearchbarKey(state: SearchState): string {
-    const searchParams = stateToSearchParams(state)
-    // Don't re-render the searchbar when the result type changes to prevent
-    // autofocusing the input. It opened the keyboard on mobile.
-    // https://github.com/owid/owid-grapher/issues/5930
-    searchParams.delete(SearchUrlParam.RESULT_TYPE)
-    return searchParams.toString()
-}
 
 export const Search = ({
     topicTagGraph,
@@ -77,6 +66,13 @@ export const Search = ({
     useSearchAnalytics(state, analytics)
 
     const isFetching = useIsFetching()
+
+    // Only autofocus the searchbar on the very first mount, not on re-mounts
+    // triggered by state changes (which would open the keyboard on mobile).
+    // https://github.com/owid/owid-grapher/issues/5930
+    const isFirstMountRef = useRef(true)
+    const shouldAutoFocus = isFirstMountRef.current
+    isFirstMountRef.current = false
 
     // Derived state for template configuration
     const topicType = getSelectedTopicType(state.filters, eligibleAreas)
@@ -116,7 +112,8 @@ export const Search = ({
                     //   selector). In this case, we want to reset the local
                     //   query to match the global one, discarding any
                     //   uncommitted changes.
-                    key={makeSearchbarKey(state)}
+                    key={stateToSearchParams(state).toString()}
+                    autoFocus={shouldAutoFocus}
                     allTopics={eligibleTopics}
                 />
                 <SearchDetectedFilters

--- a/site/search/SearchInput.tsx
+++ b/site/search/SearchInput.tsx
@@ -13,6 +13,7 @@ export const SearchInput = forwardRef(
     (
         {
             value,
+            autoFocus,
             setLocalQuery,
             setGlobalQuery,
             onBackspaceEmpty,
@@ -20,6 +21,7 @@ export const SearchInput = forwardRef(
             resetButton,
         }: {
             value: string
+            autoFocus: boolean
             setLocalQuery: (query: string) => void
             setGlobalQuery: (query: string) => void
             onBackspaceEmpty: () => void
@@ -126,7 +128,7 @@ export const SearchInput = forwardRef(
                         enterKeyHint="search"
                         value={value}
                         role="combobox"
-                        autoFocus
+                        autoFocus={autoFocus}
                         aria-expanded={showSuggestions}
                         aria-controls={autocompleteId}
                         aria-activedescendant={activeOptionId}

--- a/site/search/Searchbar.tsx
+++ b/site/search/Searchbar.tsx
@@ -12,7 +12,13 @@ import { SearchResetButton } from "./SearchResetButton.js"
 import { useSearchContext } from "./SearchContext.js"
 import { useSelectedRegionNames } from "./searchHooks.js"
 
-export const Searchbar = ({ allTopics }: { allTopics: string[] }) => {
+export const Searchbar = ({
+    allTopics,
+    autoFocus,
+}: {
+    allTopics: string[]
+    autoFocus: boolean
+}) => {
     const {
         state,
         actions: {
@@ -70,6 +76,7 @@ export const Searchbar = ({ allTopics }: { allTopics: string[] }) => {
                     <SearchInput
                         ref={inputRef}
                         value={localQuery}
+                        autoFocus={autoFocus}
                         setLocalQuery={setLocalQuery}
                         setGlobalQuery={setQuery}
                         onBackspaceEmpty={removeLastFilter}


### PR DESCRIPTION
Fixes #5930

## Summary

The previous fix excluded `resultType` from the searchbar's React `key`, which prevented the mobile keyboard from popping up on tab switches. However, this also meant the searchbar wouldn't remount when the result type changed, so local input state (e.g. an uncommitted query) wouldn't reset.

This takes a different approach: keep the full state in the key so remounts work as expected, but control `autoFocus` explicitly — only autofocus the search input on the initial page load, not on re-mounts triggered by state changes.

- Adds an `autoFocus` prop threaded through `Search` → `Searchbar` → `SearchInput`
- Uses a ref in `Search` to track the first mount and pass `autoFocus={true}` only once
- Reverts the key back to the full `stateToSearchParams(state)`

## Test plan

- [x] On mobile (or with mobile emulation), go to `/search?q=climate`
- [x] Switch between All / Data / Writing tabs
- [x] Verify the keyboard does **not** pop up on tab switch
- [x] Type a partial query without submitting, then switch tabs — verify the uncommitted text resets

🤖 Generated with [Claude Code](https://claude.com/claude-code)