### PR TITLE
🐛🤖 disable CF cacheEverything for R2 and propagate config fetch error statuses

### DIFF
--- a/functions/grapher/by-uuid/[uuid].ts
+++ b/functions/grapher/by-uuid/[uuid].ts
@@ -85,6 +85,20 @@ async function handleConfigRequest(
         return new Response(null, { status: 304 })
     }
 
+    if (grapherPageResp.status !== 200) {
+        console.log(
+            "Returning non-200 config response for uuid",
+            uuid,
+            grapherPageResp.status
+        )
+        return new Response(null, {
+            status: grapherPageResp.status,
+            headers: {
+                "Cache-Control": "no-cache",
+            },
+        })
+    }
+
     console.log("Grapher page response", grapherPageResp.grapherConfig?.title)
 
     const cacheControl = shouldCache
@@ -97,5 +111,8 @@ async function handleConfigRequest(
     }
     if (grapherPageResp.etag) headers.ETag = grapherPageResp.etag
 
-    return Response.json(grapherPageResp.grapherConfig, { headers })
+    return Response.json(grapherPageResp.grapherConfig, {
+        status: grapherPageResp.status,
+        headers,
+    })
 }


### PR DESCRIPTION
On 2026-02-20 around 12:40 UTC we [realized](https://owid.slack.com/archives/C46U9LXRR/p1771595085885999) that some thumbnails and embedded charts no longer render correctly. Not all geo locations exhibited this error, but several team members in Europe were affected. We assumed a temporary Cloudflare issues and waited a while.

At 17:00 UTC the error still persisted. This temporary fix turns off internal Cloudflare caching which is the likely immediate source of the error. 

This PR also fixes internal handling of status codes from internal fetches, where we ended up returning status code 200 even though the internal fetch failed and the request was therefore invalid. This disabled a lot of our error detection handlers and should be kept in place after reverting disabling of the cache.