### PR TITLE
✨ hide continent in scatter and marimekko tooltips

### DIFF
--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotTooltip.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotTooltip.tsx
@@ -10,7 +10,7 @@ import {
     Time,
     RequiredBy,
 } from "@ourworldindata/utils"
-import { CoreColumn } from "@ourworldindata/core-table"
+import { ColumnTypeMap, CoreColumn } from "@ourworldindata/core-table"
 import {
     Tooltip,
     TooltipState,
@@ -321,7 +321,8 @@ function TooltipValueColor({
 }: TooltipValueRangeProps): React.ReactElement | null {
     const { colorColumn, colorScale } = chartState
 
-    if (colorColumn.isMissing) return null
+    if (colorColumn.isMissing || colorColumn instanceof ColumnTypeMap.Continent)
+        return null
 
     const value = values.at(-1)
     const colorValue = value?.color

--- a/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChart.tsx
@@ -30,7 +30,11 @@ import {
     VerticalAlign,
     ColorScaleConfigInterface,
 } from "@ourworldindata/types"
-import { OwidTable, CoreColumn } from "@ourworldindata/core-table"
+import {
+    OwidTable,
+    CoreColumn,
+    ColumnTypeMap,
+} from "@ourworldindata/core-table"
 import { getShortNameForEntity } from "../chart/ChartUtils"
 import {
     LEGEND_STYLE_FOR_STACKED_CHARTS,
@@ -593,7 +597,10 @@ export class MarimekkoChart
                         )}
                         {colorColumn &&
                             !colorColumn.isMissing &&
-                            tooltipItem?.entityColor && (
+                            tooltipItem?.entityColor &&
+                            !(
+                                colorColumn instanceof ColumnTypeMap.Continent
+                            ) && (
                                 <TooltipValue
                                     label={
                                         colorScale.legendDescription ??


### PR DESCRIPTION
Hides the colour value in scatter and marimekko tooltips if it's one of our continents. The information is a bit too trivial to show and using up so much space for it isn't justified