### PR TITLE
🔨 (admin) clean up editor features

### DIFF
--- a/adminSiteClient/EditorCustomizeTab.tsx
+++ b/adminSiteClient/EditorCustomizeTab.tsx
@@ -300,10 +300,6 @@ class SortOrderSection<
     override render() {
         return (
             <Section name="Sort Order">
-                <small className="form-text text-muted">
-                    For line charts the sort order is only applied when it's
-                    collapsed to a bar chart.
-                </small>
                 <div className="form-group">
                     Sort by
                     <Select
@@ -463,7 +459,7 @@ class TimelineSection<
         return (
             <Section name="Timeline selection">
                 <FieldsRow>
-                    {features.timeDomain && (
+                    {features.canSelectTimeRange && (
                         <TimeField
                             store={this.grapherState}
                             field="minTime"
@@ -482,7 +478,7 @@ class TimelineSection<
                         store={this.grapherState}
                         field="maxTime"
                         label={
-                            features.timeDomain
+                            features.canSelectTimeRange
                                 ? "Selection end"
                                 : "Selected year"
                         }
@@ -494,47 +490,45 @@ class TimelineSection<
                         allowLinking={editor.canPropertyBeInherited("maxTime")}
                     />
                 </FieldsRow>
-                {features.timelineRange && (
-                    <FieldsRow>
-                        <TimeField
-                            store={this.grapherState}
-                            field="timelineMinTime"
-                            label="Timeline min"
-                            defaultValue={TimeBoundValue.negativeInfinity}
-                            parentValue={minTimeBoundFromJSONOrNegativeInfinity(
-                                editor.activeParentConfig?.timelineMinTime
-                            )}
-                            isInherited={editor.isPropertyInherited(
-                                "timelineMinTime"
-                            )}
-                            allowLinking={editor.canPropertyBeInherited(
-                                "timelineMinTime"
-                            )}
-                        />
-                        <TimeField
-                            store={this.grapherState}
-                            field="timelineMaxTime"
-                            label="Timeline max"
-                            defaultValue={TimeBoundValue.positiveInfinity}
-                            parentValue={maxTimeBoundFromJSONOrPositiveInfinity(
-                                editor.activeParentConfig?.timelineMaxTime
-                            )}
-                            isInherited={editor.isPropertyInherited(
-                                "timelineMaxTime"
-                            )}
-                            allowLinking={editor.canPropertyBeInherited(
-                                "timelineMaxTime"
-                            )}
-                        />
-                    </FieldsRow>
-                )}
+                <FieldsRow>
+                    <TimeField
+                        store={this.grapherState}
+                        field="timelineMinTime"
+                        label="Timeline min"
+                        defaultValue={TimeBoundValue.negativeInfinity}
+                        parentValue={minTimeBoundFromJSONOrNegativeInfinity(
+                            editor.activeParentConfig?.timelineMinTime
+                        )}
+                        isInherited={editor.isPropertyInherited(
+                            "timelineMinTime"
+                        )}
+                        allowLinking={editor.canPropertyBeInherited(
+                            "timelineMinTime"
+                        )}
+                    />
+                    <TimeField
+                        store={this.grapherState}
+                        field="timelineMaxTime"
+                        label="Timeline max"
+                        defaultValue={TimeBoundValue.positiveInfinity}
+                        parentValue={maxTimeBoundFromJSONOrPositiveInfinity(
+                            editor.activeParentConfig?.timelineMaxTime
+                        )}
+                        isInherited={editor.isPropertyInherited(
+                            "timelineMaxTime"
+                        )}
+                        allowLinking={editor.canPropertyBeInherited(
+                            "timelineMaxTime"
+                        )}
+                    />
+                </FieldsRow>
                 <FieldsRow>
                     <Toggle
                         label="Hide timeline"
                         value={!!grapherState.hideTimeline}
                         onValue={this.onToggleHideTimeline}
                     />
-                    {features.showYearLabels && (
+                    {features.canToggleShowYearLabels && (
                         <Toggle
                             label="Always show year labels"
                             value={!!grapherState.showYearLabels}
@@ -567,11 +561,11 @@ class ComparisonLineSection<
 
         const options = []
 
-        if (features.customComparisonLine) {
+        if (features.canSpecifyCustomComparisonLines) {
             options.push({ label: "y", value: "yEquals" })
         }
 
-        if (features.verticalComparisonLine) {
+        if (features.canSpecifyVerticalComparisonLines) {
             options.push({ label: "x", value: "xEquals" })
         }
 
@@ -979,7 +973,7 @@ export class EditorCustomizeTab<
                         </FieldsRow>
                     </Section>
                 )}
-                {features.comparisonLine && (
+                {features.canSpecifyComparisonLines && (
                     <ComparisonLineSection editor={this.props.editor} />
                 )}
             </div>

--- a/adminSiteClient/EditorFeatures.tsx
+++ b/adminSiteClient/EditorFeatures.tsx
@@ -15,20 +15,20 @@ export class EditorFeatures {
     }
 
     @computed get canCustomizeXAxisScale() {
-        return this.grapherState.isScatter || this.grapherState.isMarimekko
+        return this.grapherState.hasScatter || this.grapherState.hasMarimekko
     }
 
     @computed get canCustomizeYAxisLabel() {
-        return this.grapherState.isScatter
+        return this.grapherState.hasScatter
     }
 
     @computed get canCustomizeXAxisLabel() {
         return (
-            this.grapherState.isLineChart ||
-            this.grapherState.isScatter ||
-            this.grapherState.isMarimekko ||
-            this.grapherState.isStackedArea ||
-            this.grapherState.isStackedBar
+            this.grapherState.hasLineChart ||
+            this.grapherState.hasScatter ||
+            this.grapherState.hasMarimekko ||
+            this.grapherState.hasStackedArea ||
+            this.grapherState.hasStackedBar
         )
     }
 
@@ -37,97 +37,95 @@ export class EditorFeatures {
     }
 
     @computed get canRemovePointsOutsideAxisDomain() {
-        return this.grapherState.isScatter
+        return this.grapherState.hasScatter
     }
 
     @computed get canEnableLogLinearToggle() {
         return (
-            !this.grapherState.isStackedArea &&
-            !this.grapherState.isStackedBar &&
-            !this.grapherState.isDiscreteBar &&
-            !this.grapherState.isStackedDiscreteBar &&
-            !this.grapherState.isMarimekko
+            this.grapherState.hasLineChart ||
+            this.grapherState.hasSlopeChart ||
+            this.grapherState.hasScatter
         )
     }
 
-    @computed get timeDomain() {
-        return !this.grapherState.isDiscreteBar
+    @computed get canSelectTimeRange() {
+        return (
+            this.grapherState.hasLineChart ||
+            this.grapherState.hasSlopeChart ||
+            this.grapherState.hasStackedBar ||
+            this.grapherState.hasStackedArea ||
+            this.grapherState.hasScatter
+        )
     }
 
-    @computed get timelineRange() {
-        return !this.grapherState.isDiscreteBar
-    }
-
-    @computed get showYearLabels() {
-        return this.grapherState.isDiscreteBar
+    @computed get canToggleShowYearLabels() {
+        return this.grapherState.hasDiscreteBar
     }
 
     @computed get hideLegend() {
         return (
-            this.grapherState.isLineChart ||
-            this.grapherState.isSlopeChart ||
-            this.grapherState.isStackedArea ||
-            this.grapherState.isStackedDiscreteBar
+            this.grapherState.hasLineChart ||
+            this.grapherState.hasSlopeChart ||
+            this.grapherState.hasStackedArea ||
+            this.grapherState.hasStackedDiscreteBar
         )
-    }
-
-    @computed get stackedArea() {
-        return this.grapherState.isStackedArea
     }
 
     @computed get relativeModeToggle() {
         return (
-            this.grapherState.isStackedArea ||
-            this.grapherState.isStackedBar ||
-            this.grapherState.isStackedDiscreteBar ||
-            this.grapherState.isLineChart ||
-            this.grapherState.isSlopeChart ||
-            this.grapherState.isScatter ||
-            this.grapherState.isMarimekko
+            this.grapherState.hasStackedArea ||
+            this.grapherState.hasStackedBar ||
+            this.grapherState.hasStackedDiscreteBar ||
+            this.grapherState.hasLineChart ||
+            this.grapherState.hasSlopeChart ||
+            this.grapherState.hasScatter ||
+            this.grapherState.hasMarimekko
         )
     }
 
-    @computed get customComparisonLine() {
+    @computed get canSpecifyCustomComparisonLines() {
         return (
-            this.grapherState.isLineChart ||
-            this.grapherState.isScatter ||
-            this.grapherState.isStackedArea ||
-            this.grapherState.isStackedBar ||
-            this.grapherState.isMarimekko
+            this.grapherState.hasLineChart ||
+            this.grapherState.hasScatter ||
+            this.grapherState.hasStackedArea ||
+            this.grapherState.hasStackedBar ||
+            this.grapherState.hasMarimekko
         )
     }
 
-    @computed get verticalComparisonLine() {
+    @computed get canSpecifyVerticalComparisonLines() {
         return (
-            this.grapherState.isLineChart ||
-            this.grapherState.isScatter ||
-            this.grapherState.isStackedArea ||
-            this.grapherState.isStackedBar
+            this.grapherState.hasLineChart ||
+            this.grapherState.hasScatter ||
+            this.grapherState.hasStackedArea ||
+            this.grapherState.hasStackedBar
         )
     }
 
-    @computed get comparisonLine() {
-        return this.customComparisonLine || this.verticalComparisonLine
+    @computed get canSpecifyComparisonLines() {
+        return (
+            this.canSpecifyCustomComparisonLines ||
+            this.canSpecifyVerticalComparisonLines
+        )
     }
 
     @computed get canSpecifySortOrder() {
         return (
-            this.grapherState.isStackedDiscreteBar ||
-            this.grapherState.isLineChart ||
-            this.grapherState.isDiscreteBar ||
-            this.grapherState.isMarimekko
+            this.grapherState.hasStackedDiscreteBar ||
+            this.grapherState.hasDiscreteBar ||
+            this.grapherState.hasMarimekko
         )
     }
 
     @computed get canSortByColumn() {
         return (
-            this.grapherState.isStackedDiscreteBar ||
-            this.grapherState.isMarimekko
+            this.grapherState.hasStackedDiscreteBar ||
+            this.grapherState.hasMarimekko
         )
     }
 
     @computed get canHideTotalValueLabel() {
-        return this.grapherState.isStackedDiscreteBar
+        return this.grapherState.hasStackedDiscreteBar
     }
 
     @computed get canCustomizeVariableType() {
@@ -138,16 +136,16 @@ export class EditorFeatures {
         if (!this.grapherState.hasMultipleYColumns) return false
 
         if (
-            this.grapherState.isStackedArea ||
-            this.grapherState.isStackedBar ||
-            this.grapherState.isStackedDiscreteBar
+            this.grapherState.hasStackedArea ||
+            this.grapherState.hasStackedBar ||
+            this.grapherState.hasStackedDiscreteBar
         ) {
             return true
         }
 
-        // for line and slope charts, specifying a missing data strategy only makes sense
-        // if there are multiple entities
-        if (this.grapherState.isLineChart || this.grapherState.isSlopeChart) {
+        // For line and slope charts, specifying a missing data strategy
+        // only makes sense if there are multiple entities
+        if (this.grapherState.hasLineChart || this.grapherState.hasSlopeChart) {
             return (
                 this.grapherState.canChangeEntity ||
                 this.grapherState.canSelectMultipleEntities
@@ -159,7 +157,8 @@ export class EditorFeatures {
 
     @computed get showChangeInPrefixToggle() {
         return (
-            (this.grapherState.isLineChart || this.grapherState.isSlopeChart) &&
+            (this.grapherState.hasLineChart ||
+                this.grapherState.hasSlopeChart) &&
             (this.grapherState.isRelativeMode ||
                 this.grapherState.canToggleRelativeMode)
         )
@@ -176,9 +175,9 @@ export class EditorFeatures {
         return (
             !this.grapherState.hasTimeline ||
             !(
-                this.grapherState.isDiscreteBar ||
-                this.grapherState.isStackedDiscreteBar ||
-                this.grapherState.isMarimekko
+                this.grapherState.hasDiscreteBar ||
+                this.grapherState.hasStackedDiscreteBar ||
+                this.grapherState.hasMarimekko
             )
         )
     }

--- a/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
@@ -2759,6 +2759,20 @@ export class GrapherState
         return this.validChartTypeSet.has(GRAPHER_CHART_TYPES.ScatterPlot)
     }
 
+    @computed get hasStackedArea(): boolean {
+        return this.validChartTypeSet.has(GRAPHER_CHART_TYPES.StackedArea)
+    }
+
+    @computed get hasStackedBar(): boolean {
+        return this.validChartTypeSet.has(GRAPHER_CHART_TYPES.StackedBar)
+    }
+
+    @computed get hasStackedDiscreteBar(): boolean {
+        return this.validChartTypeSet.has(
+            GRAPHER_CHART_TYPES.StackedDiscreteBar
+        )
+    }
+
     @computed get supportsMultipleYColumns(): boolean {
         return !this.isScatter
     }
@@ -3224,14 +3238,17 @@ export class GrapherState
 
     @computed get sortConfig(): SortConfig {
         const sortConfig = { ...this._sortConfig }
-        // In relative mode, where the values for every entity sum up to 100%, sorting by total
-        // doesn't make sense. It's also jumpy because of some rounding errors. For this reason,
-        // we sort by entity name instead.
-        // Marimekko charts are special and there we don't do this forcing of sort order
+        // In relative mode, where the values for every entity sum up to 100%,
+        // sorting by total doesn't make sense. It's also jumpy because of some
+        // rounding errors. For this reason, we sort by entity name instead
         if (
-            !this.isOnMarimekkoTab &&
             this.isRelativeMode &&
-            sortConfig.sortBy === SortBy.total
+            sortConfig.sortBy === SortBy.total &&
+            // No need to do this for Marimekko and discrete bar charts
+            // since relative mode means something else for Marimekko charts
+            // and discrete bar charts don't support relative mode
+            !this.isOnMarimekkoTab &&
+            !this.isOnDiscreteBarTab
         ) {
             sortConfig.sortBy = SortBy.entityName
             sortConfig.sortOrder = SortOrder.asc


### PR DESCRIPTION
I went through all checks in EditorFeatures and checked if they're still sensible. For most of them, I just switched from `isChartTypeX` to `hasChartTypeX`. The main difference is that `isChartTypeX` only applies when a chart type is the first in the list (the main/primary chart type), while `hasChartTypeX` applies whenever a chart type is currently enabled (either as the primary or secondary tab).

I added comments in the PR wherever there are behavioural changes.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 4 in a stack** made with GitButler:
- <kbd>&nbsp;4&nbsp;</kbd> #6152 
- <kbd>&nbsp;3&nbsp;</kbd> #6136 
- <kbd>&nbsp;2&nbsp;</kbd> #6135 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #6046 
<!-- GitButler Footer Boundary Bottom -->

