### PR TITLE
🎉 country-profile-selector component

### DIFF
--- a/db/model/Gdoc/GdocBase.ts
+++ b/db/model/Gdoc/GdocBase.ts
@@ -817,6 +817,14 @@ export class GdocBase implements OwidGdocBaseInterface {
                 }
                 return links
             })
+            .with({ type: "country-profile-selector" }, (block) => [
+                createLinkFromUrl({
+                    url: block.url,
+                    sourceId: this.id,
+                    componentType: block.type,
+                    text: block.title ?? "Country profile selector",
+                }),
+            ])
             .with(
                 {
                     // no urls directly on any of these blocks
@@ -1133,10 +1141,12 @@ export class GdocBase implements OwidGdocBaseInterface {
                     }
 
                     // Validate profile links: must have ?entity=X with a valid, available entity
+                    // (skip for country-profile-selector, which links to the profile itself)
                     if (
                         linkedDoc?.type === OwidGdocType.Profile &&
                         doesGdocExist &&
-                        isGdocPublished
+                        isGdocPublished &&
+                        link.componentType !== "country-profile-selector"
                     ) {
                         const queryParams = Url.fromURL(
                             link.queryString

--- a/db/model/Gdoc/enrichedToIndexableText.ts
+++ b/db/model/Gdoc/enrichedToIndexableText.ts
@@ -425,7 +425,8 @@ export function enrichedBlockToIndexableText(
                         "sdg-grid",
                         "sdg-toc",
                         "socials",
-                        "subscribe-banner"
+                        "subscribe-banner",
+                        "country-profile-selector"
                     ),
                 },
                 (): undefined => undefined

--- a/db/model/Gdoc/enrichedToMarkdown.ts
+++ b/db/model/Gdoc/enrichedToMarkdown.ts
@@ -608,5 +608,6 @@ ${links}`
                 nestedOptions
             )
         })
+        .with({ type: "country-profile-selector" }, () => undefined)
         .exhaustive()
 }

--- a/db/model/Gdoc/enrichedToRaw.ts
+++ b/db/model/Gdoc/enrichedToRaw.ts
@@ -64,6 +64,7 @@ import {
     RawBlockStaticViz,
     RawBlockLTPToc,
     RawBlockConditionalSection,
+    RawBlockCountryProfileSelector,
 } from "@ourworldindata/types"
 import { spanToHtmlString } from "./gdocUtils.js"
 import { match, P } from "ts-pattern"
@@ -757,6 +758,20 @@ export function enrichedBlockToRawBlock(
                 ) as RawBlockText[],
             },
         }))
+        .with(
+            { type: "country-profile-selector" },
+            (b): RawBlockCountryProfileSelector => ({
+                type: "country-profile-selector",
+                value: {
+                    url: b.url,
+                    title: b.title,
+                    description: b.description,
+                    defaultCountries: b.defaultCountries.length
+                        ? b.defaultCountries.join(", ")
+                        : undefined,
+                },
+            })
+        )
         .exhaustive()
 }
 

--- a/db/model/Gdoc/exampleEnrichedBlocks.ts
+++ b/db/model/Gdoc/exampleEnrichedBlocks.ts
@@ -947,4 +947,19 @@ export const enrichedBlockExamples: Record<
         ],
         parseErrors: [],
     },
+    "country-profile-selector": {
+        type: "country-profile-selector",
+        url: "https://docs.google.com/document/d/ABC123/edit",
+        title: "Country profiles",
+        description: "Explore key metrics on energy consumption and sources.",
+        defaultCountries: [
+            "United Kingdom",
+            "United States",
+            "China",
+            "Nigeria",
+            "India",
+            "Brazil",
+        ],
+        parseErrors: [],
+    },
 }

--- a/db/model/Gdoc/extractGdocComponentInfo.ts
+++ b/db/model/Gdoc/extractGdocComponentInfo.ts
@@ -393,7 +393,8 @@ export function enumerateGdocComponentsWithoutChildren(
                         "subscribe-banner",
                         "narrative-chart",
                         "static-viz",
-                        "data-callout"
+                        "data-callout",
+                        "country-profile-selector"
                     ),
                 },
                 (c) => handleComponent(c, [], parentPath, path)

--- a/db/model/Gdoc/gdocUtils.ts
+++ b/db/model/Gdoc/gdocUtils.ts
@@ -288,7 +288,8 @@ export function extractFilenamesFromBlock(
                     "table",
                     "text",
                     "topic-page-intro",
-                    "data-callout"
+                    "data-callout",
+                    "country-profile-selector"
                 ),
             },
             _.noop

--- a/db/model/Gdoc/rawToArchie.ts
+++ b/db/model/Gdoc/rawToArchie.ts
@@ -61,6 +61,7 @@ import {
     RawBlockStaticViz,
     RawBlockConditionalSection,
     RawBlockDataCallout,
+    RawBlockCountryProfileSelector,
 } from "@ourworldindata/types"
 import { match } from "ts-pattern"
 
@@ -1019,6 +1020,17 @@ function* rawBlockDataCalloutToArchieMLString(
     yield "{}"
 }
 
+function* rawBlockCountryProfileSelectorToArchieMLString(
+    block: RawBlockCountryProfileSelector
+): Generator<string, void, undefined> {
+    yield "{.country-profile-selector}"
+    yield* propertyToArchieMLString("url", block.value)
+    yield* propertyToArchieMLString("title", block.value)
+    yield* propertyToArchieMLString("description", block.value)
+    yield* propertyToArchieMLString("defaultCountries", block.value)
+    yield "{}"
+}
+
 export function* OwidRawGdocBlockToArchieMLStringGenerator(
     block: OwidRawGdocBlock | RawBlockTableRow
 ): Generator<string, void, undefined> {
@@ -1136,6 +1148,10 @@ export function* OwidRawGdocBlockToArchieMLStringGenerator(
         )
         .with({ type: "socials" }, rawBlockSocialsToArchieMLString)
         .with({ type: "data-callout" }, rawBlockDataCalloutToArchieMLString)
+        .with(
+            { type: "country-profile-selector" },
+            rawBlockCountryProfileSelectorToArchieMLString
+        )
         .exhaustive()
     yield* content
 }

--- a/db/model/Gdoc/rawToEnriched.ts
+++ b/db/model/Gdoc/rawToEnriched.ts
@@ -152,6 +152,8 @@ import {
     RawBlockCookieNotice,
     PullQuoteAlignment,
     pullquoteAlignments,
+    RawBlockCountryProfileSelector,
+    EnrichedBlockCountryProfileSelector,
     RawBlockExpander,
     EnrichedBlockExpander,
     blockAlignments,
@@ -286,6 +288,7 @@ export function parseRawBlocksToEnrichedBlocks(
         .with({ type: "featured-data-insights" }, parseFeaturedDataInsights)
         .with({ type: "homepage-intro" }, parseHomepageIntro)
         .with({ type: "socials" }, parseSocials)
+        .with({ type: "country-profile-selector" }, parseCountryProfileSelector)
         .exhaustive()
 }
 
@@ -3098,5 +3101,34 @@ export const parseScript = (raw: RawBlockScript): EnrichedBlockScript => {
         type: "script",
         lines: goodText.map((text) => spansToSimpleString(text.value)),
         parseErrors: [],
+    }
+}
+
+function parseCountryProfileSelector(
+    raw: RawBlockCountryProfileSelector
+): EnrichedBlockCountryProfileSelector {
+    const parseErrors: ParseError[] = []
+    const val = raw.value
+
+    if (!val.url) {
+        parseErrors.push({
+            message: "country-profile-selector block is missing a url field",
+        })
+    }
+
+    const defaultCountries = val.defaultCountries
+        ? val.defaultCountries
+              .split(",")
+              .map((s) => s.trim())
+              .filter((s) => s.length > 0)
+        : []
+
+    return {
+        type: "country-profile-selector",
+        url: extractUrl(val.url ?? ""),
+        title: val.title,
+        description: val.description,
+        defaultCountries,
+        parseErrors,
     }
 }

--- a/packages/@ourworldindata/types/src/gdocTypes/ArchieMlComponents.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/ArchieMlComponents.ts
@@ -1161,6 +1161,24 @@ export type EnrichedBlockSocials = {
     links: EnrichedSocialLink[]
 } & EnrichedBlockWithParseErrors
 
+export type RawBlockCountryProfileSelector = {
+    type: "country-profile-selector"
+    value: {
+        url?: string
+        title?: string
+        description?: string
+        defaultCountries?: string
+    }
+}
+
+export type EnrichedBlockCountryProfileSelector = {
+    type: "country-profile-selector"
+    url: string
+    title?: string
+    description?: string
+    defaultCountries: string[]
+} & EnrichedBlockWithParseErrors
+
 export type OwidRawGdocBlock =
     | RawBlockAllCharts
     | RawBlockAside
@@ -1222,6 +1240,7 @@ export type OwidRawGdocBlock =
     | RawBlockCta
     | RawBlockSocials
     | RawBlockStaticViz
+    | RawBlockCountryProfileSelector
 
 export type OwidEnrichedGdocBlock =
     | EnrichedBlockAllCharts
@@ -1286,6 +1305,7 @@ export type OwidEnrichedGdocBlock =
     | EnrichedBlockCta
     | EnrichedBlockSocials
     | EnrichedBlockStaticViz
+    | EnrichedBlockCountryProfileSelector
 
 /**
  * A map of all possible block types, with the type as the key and the block type as the value

--- a/packages/@ourworldindata/types/src/gdocTypes/raycastSnippets.json
+++ b/packages/@ourworldindata/types/src/gdocTypes/raycastSnippets.json
@@ -258,5 +258,10 @@
         "name": "featured-metrics",
         "text": "{.featured-metrics}\n{}",
         "keyword": "+featured-metrics"
+    },
+    {
+        "name": "country-profile-selector",
+        "text": "{.country-profile-selector}\nurl: \n{}",
+        "keyword": "+country-profile-selector"
     }
 ]

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -347,6 +347,8 @@ export {
     type RawBlockNarrativeChart,
     type EnrichedBlockNarrativeChart,
     type OwidEnrichedGdocBlockTypeMap,
+    type RawBlockCountryProfileSelector,
+    type EnrichedBlockCountryProfileSelector,
 } from "./gdocTypes/ArchieMlComponents.js"
 export {
     ChartConfigType,

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -1821,7 +1821,8 @@ export function traverseEnrichedBlock(
                     "featured-data-insights",
                     "latest-data-insights",
                     "socials",
-                    "static-viz"
+                    "static-viz",
+                    "country-profile-selector"
                 ),
             },
             callback

--- a/site/css/grid-margin-overrides.scss
+++ b/site/css/grid-margin-overrides.scss
@@ -67,9 +67,10 @@
         margin-top: 0;
     }
 
-    /* Set the bottom margin of any element that comes before an image or chart to 0 */
+    /* Set the bottom margin of any element that comes before various block elements to 0 */
     [class*="article-block__"]:has(+ .article-block__image),
     [class*="article-block__"]:has(+ .article-block__static-viz),
+    [class*="article-block__"]:has(+ .article-block__country-profile-selector),
     [class*="article-block__"]:has(+ .article-block__chart) {
         margin-bottom: 0;
     }

--- a/site/gdocs/components/ArticleBlock.tsx
+++ b/site/gdocs/components/ArticleBlock.tsx
@@ -61,6 +61,7 @@ import { BlockQueryClientProvider } from "./BlockQueryClientProvider.js"
 import { ExploreDataSection } from "./ExploreDataSection.js"
 import { LTPTableOfContents } from "./LTPTableOfContents.js"
 import { DataCallout } from "./DataCallout.js"
+import { CountryProfileSelector } from "./CountryProfileSelector.js"
 
 function ArticleBlockInternal({
     b: block,
@@ -942,6 +943,12 @@ function ArticleBlockInternal({
         ))
         .with({ type: "data-callout" }, (block) => (
             <DataCallout block={block} containerType={containerType} />
+        ))
+        .with({ type: "country-profile-selector" }, (block) => (
+            <CountryProfileSelector
+                block={block}
+                className={getLayout("country-profile-selector", containerType)}
+            />
         ))
         .exhaustive()
 }

--- a/site/gdocs/components/CountryProfileSelector.scss
+++ b/site/gdocs/components/CountryProfileSelector.scss
@@ -1,0 +1,144 @@
+.centered-article-container--topic-page,
+.centered-article-container--article {
+    .article-block__country-profile-selector {
+        background-color: $blue-5;
+        margin: 36px 0;
+        padding: 48px;
+        @include sm-only {
+            padding: 24px 0;
+        }
+        .country-profile-selector__panel {
+            background-color: #fff;
+        }
+    }
+}
+
+.centered-article-container--linear-topic-page {
+    @include sm-only {
+        &.centered-article-container--heading-variant-light
+            .article-block__country-profile-selector
+            + .article-block__heading {
+            &:before {
+                top: -32px;
+            }
+            margin-top: 56px;
+        }
+    }
+
+    .article-block__country-profile-selector {
+        margin: 48px 0;
+        @include sm-only {
+            margin: 24px 0;
+        }
+        .country-profile-selector__panel {
+            background-color: $blue-5;
+            @include sm-only {
+                padding: 16px;
+            }
+        }
+    }
+}
+
+.country-profile-selector__title {
+    color: $blue-90;
+    margin-bottom: 16px;
+    margin-top: 0;
+}
+
+.country-profile-selector__description {
+    color: $blue-60;
+}
+
+.country-profile-selector__panel {
+    padding: 24px;
+    @include md-up {
+        margin-left: calc(-1 * var(--grid-gap));
+    }
+}
+
+.country-profile-selector__search-wrapper {
+    position: relative;
+    margin-bottom: 24px;
+}
+.country-profile-selector__search-icon {
+    position: absolute;
+    left: 12px;
+    top: 50%;
+    transform: translateY(-50%);
+    color: $blue-30;
+    pointer-events: none;
+    font-size: 14px;
+}
+
+.country-profile-selector__search {
+    padding: 10px;
+    padding-left: 36px; // to make space for the search icon
+    padding-right: 32px; // to make space for the clear button
+    width: 100%;
+    color: $blue-50;
+    border: 1px solid $blue-10;
+    &::placeholder {
+        color: $blue-50;
+    }
+    :focus,
+    &:focus-visible {
+        outline: none;
+        border-color: $blue-50;
+    }
+}
+
+.country-profile-selector__clear-button {
+    position: absolute;
+    right: 12px;
+    top: 50%;
+    transform: translateY(-50%);
+    font-size: 14px;
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+    padding: 0;
+    border: none;
+    background-color: transparent;
+    color: $blue-30;
+    &:hover {
+        color: $blue-50;
+    }
+}
+
+.country-profile-selector__grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+}
+
+.country-profile-selector__country {
+    display: flex;
+    align-items: center;
+    white-space: nowrap;
+    flex: 1 1 calc(50% - 8px); // target 2 columns (8px = half of 16px gap)
+    min-width: min-content; // don't shrink below text width — wraps to own row instead
+    max-width: 100%;
+}
+
+.country-profile-selector__flag {
+    height: 16px;
+    margin-right: 8px;
+    outline: 1px solid $blue-10;
+}
+
+.country-profile-selector__country-name {
+    color: $blue-90;
+    &:hover {
+        text-decoration: underline;
+    }
+}
+
+.country-profile-selector__arrow {
+    margin-left: 8px;
+    font-size: 11px;
+}
+
+.country-profile-selector__no-results {
+    margin-top: 0;
+    grid-column: span 2;
+}

--- a/site/gdocs/components/CountryProfileSelector.tsx
+++ b/site/gdocs/components/CountryProfileSelector.tsx
@@ -1,0 +1,264 @@
+import { useState, useMemo, ReactNode } from "react"
+import { EnrichedBlockCountryProfileSelector } from "@ourworldindata/types"
+import {
+    FuzzySearch,
+    getRegionByCode,
+    getRegionByNameOrVariantName,
+} from "@ourworldindata/utils"
+import { useLinkedDocument } from "../utils.js"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome/index.js"
+import {
+    faArrowRight,
+    faMagnifyingGlass,
+    faTimesCircle,
+} from "@fortawesome/free-solid-svg-icons"
+import { IS_ARCHIVE } from "../../../settings/clientSettings.js"
+import { PROD_URL } from "../../SiteConstants.js"
+import urlJoin from "url-join"
+
+interface CountryItem {
+    name: string
+    code: string
+    slug: string
+    searchKeys: string[]
+}
+
+interface FilteredCountryItem {
+    country: CountryItem
+    highlightIndexes?: number[]
+}
+
+const FALLBACK_DEFAULT_COUNTRY_NAMES = [
+    "United Kingdom",
+    "United States",
+    "China",
+    "Nigeria",
+    "India",
+    "Brazil",
+]
+
+function resolveCountriesToItems(entityCodes: string[]): CountryItem[] {
+    return entityCodes
+        .map((code) => {
+            const region = getRegionByCode(code)
+            if (!region) return undefined
+            return {
+                name: region.name,
+                code: region.code,
+                slug: region.slug,
+                searchKeys: [
+                    region.name,
+                    ...(region.shortName ? [region.shortName] : []),
+                    ...("variantNames" in region
+                        ? (region.variantNames ?? [])
+                        : []),
+                ],
+            }
+        })
+        .filter((item): item is CountryItem => !!item)
+        .sort((a, b) => a.name.localeCompare(b.name))
+}
+
+function resolveDefaultCountries(
+    defaultCountryNames: string[],
+    allCountries: CountryItem[]
+): CountryItem[] {
+    const allByCode = new Map(allCountries.map((c) => [c.code, c]))
+    return defaultCountryNames
+        .map((name) => {
+            const region = getRegionByNameOrVariantName(name)
+            if (!region) return undefined
+            return allByCode.get(region.code)
+        })
+        .filter((item): item is CountryItem => !!item)
+}
+
+export function CountryProfileSelector({
+    block,
+    className,
+}: {
+    block: EnrichedBlockCountryProfileSelector
+    className?: string
+}) {
+    const { linkedDocument, errorMessage } = useLinkedDocument(block.url)
+    const [searchTerm, setSearchTerm] = useState("")
+
+    const allCountries = useMemo(() => {
+        if (!linkedDocument?.availableEntityCodes) return []
+        return resolveCountriesToItems(linkedDocument.availableEntityCodes)
+    }, [linkedDocument?.availableEntityCodes])
+
+    const defaultCountries = useMemo(() => {
+        const names = block.defaultCountries.length
+            ? block.defaultCountries
+            : FALLBACK_DEFAULT_COUNTRY_NAMES
+        return resolveDefaultCountries(names, allCountries)
+    }, [block.defaultCountries, allCountries])
+
+    const fuzzyCountrySearch = useMemo(
+        () =>
+            FuzzySearch.withKeyArray(
+                allCountries,
+                (country) => country.searchKeys,
+                (country) => country.code,
+                { limit: 6 }
+            ),
+        [allCountries]
+    )
+
+    const filteredCountries = useMemo<FilteredCountryItem[]>(() => {
+        const term = searchTerm.trim()
+        if (!term) {
+            return defaultCountries.map((country) => ({ country }))
+        }
+
+        return fuzzyCountrySearch.search(term).map((country) => ({
+            country,
+            highlightIndexes: fuzzyCountrySearch.single(term, country.name)
+                ?.indexes,
+        }))
+    }, [searchTerm, defaultCountries, fuzzyCountrySearch])
+
+    if (errorMessage) {
+        return (
+            <div className={className}>
+                <p className="country-profile-selector__error">
+                    {errorMessage}
+                </p>
+            </div>
+        )
+    }
+
+    if (!linkedDocument) return null
+
+    const profileBaseUrl = urlJoin(
+        // We currently don't archive topic pages or profiles, so this component shouldn't appear in an archive
+        // but if it does (in an article, for some reason) we want to make sure the links point to the live site, not the archive.
+        IS_ARCHIVE ? PROD_URL : "/",
+        "profile",
+        linkedDocument.slug
+    )
+    const title = block.title ?? "Country profiles"
+    const description =
+        block.description ??
+        "Explore key metrics on energy consumption and sources of energy in your country, and more than 200 other countries."
+
+    return (
+        <div className={className}>
+            <div className="country-profile-selector grid grid-cols-12 col-start-2 span-cols-12">
+                <div className="country-profile-selector__info span-cols-5 span-sm-cols-12">
+                    <h2 className="country-profile-selector__title h1-semibold">
+                        {title}
+                    </h2>
+                    <p className="country-profile-selector__description body-2-regular">
+                        {description}
+                    </p>
+                </div>
+                <div className="country-profile-selector__panel col-start-8 span-cols-4 col-md-start-7 span-md-cols-6 span-sm-cols-12">
+                    <div className="country-profile-selector__search-wrapper">
+                        <FontAwesomeIcon
+                            icon={faMagnifyingGlass}
+                            className="country-profile-selector__search-icon"
+                        />
+
+                        <input
+                            type="text"
+                            className="country-profile-selector__search"
+                            placeholder="Search for a country..."
+                            value={searchTerm}
+                            onChange={(e) => setSearchTerm(e.target.value)}
+                        />
+                        {searchTerm && (
+                            <button
+                                className="country-profile-selector__clear-button"
+                                aria-label="Clear search"
+                                onClick={() => setSearchTerm("")}
+                            >
+                                <FontAwesomeIcon icon={faTimesCircle} />
+                            </button>
+                        )}
+                    </div>
+                    <div className="country-profile-selector__grid">
+                        {filteredCountries.length > 0 ? (
+                            filteredCountries.map((country) => (
+                                <CountryProfileLink
+                                    key={country.country.code}
+                                    country={country.country}
+                                    highlightIndexes={country.highlightIndexes}
+                                    profileBaseUrl={profileBaseUrl}
+                                />
+                            ))
+                        ) : searchTerm.trim() ? (
+                            <NoResults searchTerm={searchTerm} />
+                        ) : null}
+                    </div>
+                </div>
+            </div>
+        </div>
+    )
+}
+
+/**
+ * Takes e.g. "United States" and [0, 7]
+ * returns [<strong>U</strong>, "nited ", <strong>S</strong>, "tates"]
+ */
+function highlightMatch(text: string, highlightIndexes?: number[]): ReactNode {
+    if (!highlightIndexes?.length) return text
+
+    const highlighted = new Set(highlightIndexes)
+    const parts: ReactNode[] = []
+    let start = 0
+
+    while (start < text.length) {
+        const isMatch = highlighted.has(start)
+        let end = start + 1
+        while (end < text.length && highlighted.has(end) === isMatch) {
+            end++
+        }
+
+        const chunk = text.slice(start, end)
+        parts.push(isMatch ? <strong key={start}>{chunk}</strong> : chunk)
+        start = end
+    }
+
+    return parts
+}
+
+function CountryProfileLink({
+    country,
+    highlightIndexes,
+    profileBaseUrl,
+}: {
+    country: CountryItem
+    highlightIndexes?: number[]
+    profileBaseUrl: string
+}) {
+    return (
+        <a
+            href={`${profileBaseUrl}/${country.slug}`}
+            className="country-profile-selector__country"
+        >
+            <img
+                className="country-profile-selector__flag"
+                src={`/images/flags/${country.code}.svg`}
+                alt=""
+                loading="lazy"
+            />
+            <span className="country-profile-selector__country-name body-3-medium">
+                {highlightMatch(country.name, highlightIndexes)}
+                <FontAwesomeIcon
+                    className="country-profile-selector__arrow"
+                    icon={faArrowRight}
+                />
+            </span>
+        </a>
+    )
+}
+
+function NoResults({ searchTerm }: { searchTerm: string }) {
+    return (
+        <p className="country-profile-selector__no-results body-3-medium">
+            No country profiles found for &ldquo;{searchTerm}&rdquo;
+        </p>
+    )
+}

--- a/site/gdocs/components/layout.ts
+++ b/site/gdocs/components/layout.ts
@@ -32,6 +32,7 @@ const layouts: { [key in Container]: Layouts} = {
         ["chart--wide"]: "col-start-4 span-cols-8 col-md-start-3 span-md-cols-10 span-sm-cols-12 col-sm-start-2",
         ["chart--widest"]: "col-start-2 span-cols-12 col-md-start-2 span-md-cols-12",
         ["cta"]: "col-start-5 span-cols-6 col-md-start-3 span-md-cols-10 span-sm-cols-12 col-sm-start-2",
+        ["country-profile-selector"]: "span-cols-14 grid grid-cols-12-full-width",
         ["data-callout"]: "span-cols-14 grid grid-cols-12-full-width",
         ["default"]: "col-start-5 span-cols-6 col-md-start-3 span-md-cols-10 span-sm-cols-12 col-sm-start-2",
         ["divider"]: "col-start-2 span-cols-12",

--- a/site/gdocs/utils.ts
+++ b/site/gdocs/utils.ts
@@ -142,23 +142,21 @@ export const useLinkedDocument = (
         errorMessage = `Article with slug "${linkedDocument.slug}" isn't published.`
     }
 
-    // Validate profile-type docs: must have ?entity=X with a valid entity
+    // Validate ?entity=X for profile-type docs (when provided)
     const parsedUrl = Url.fromURL(url)
     const entityParam = parsedUrl.queryParams.entity
-    if (linkedDocument.type === OwidGdocType.Profile && !errorMessage) {
-        if (!entityParam) {
-            errorMessage = `Profile link must include a ?entity= parameter (e.g. ?entity=France).`
-        } else {
-            const region = getRegionByNameOrVariantName(entityParam)
-            if (!region) {
-                errorMessage = `Unknown country name "${entityParam}" in profile link.`
-            } else if (!linkedDocument.availableEntityCodes) {
-                errorMessage = `Unable to determine available countries for profile "${linkedDocument.slug}".`
-            } else if (
-                !linkedDocument.availableEntityCodes.includes(region.code)
-            ) {
-                errorMessage = `Country "${entityParam}" is not available for profile "${linkedDocument.slug}".`
-            }
+    if (
+        linkedDocument.type === OwidGdocType.Profile &&
+        entityParam &&
+        !errorMessage
+    ) {
+        const region = getRegionByNameOrVariantName(entityParam)
+        if (!region) {
+            errorMessage = `Unknown entity name "${entityParam}" in profile link.`
+        } else if (!linkedDocument.availableEntityCodes) {
+            errorMessage = `Unable to determine available entities for profile "${linkedDocument.slug}".`
+        } else if (!linkedDocument.availableEntityCodes.includes(region.code)) {
+            errorMessage = `Entity "${entityParam}" is not available for profile "${linkedDocument.slug}".`
         }
     }
 

--- a/site/owid.scss
+++ b/site/owid.scss
@@ -125,6 +125,7 @@
 @import "./gdocs/components/centered-article.scss";
 @import "./gdocs/components/topic-page.scss";
 @import "./gdocs/components/Callout.scss";
+@import "./gdocs/components/CountryProfileSelector.scss";
 @import "./gdocs/components/ChartPreview.scss";
 @import "./gdocs/components/DataInsightDateline.scss";
 @import "./gdocs/components/Donors.scss";


### PR DESCRIPTION
## Context

[Figma](https://www.figma.com/design/50j5XbYEx9YuFcD7GZcd6F/Country-Profiles?node-id=1536-3845&p=f&t=GQL95axvRUHdVnJE-0)

Adds a new component to allow users to discover country profiles from topic pages

## Screenshots / Videos / Diagrams

### TP
<img width="1409" height="474" alt="image" src="https://github.com/user-attachments/assets/1dde3576-16ae-45fc-b771-bc3b677870e8" />

### LTP
<img width="1401" height="517" alt="image" src="https://github.com/user-attachments/assets/7701d166-5f3b-404c-af39-e86d2c0f69dd" />


## Testing guidance

[You can use this test gdoc](https://docs.google.com/document/d/1--wI7ctAgxAnEaSdRzIT2z3CzseYk32fLJ7_W8JBD4U/edit?tab=t.0)

Be sure to check the designs for both `linear-topic-page` and `topic-page` formats

- [x] Does the staging experience have sign-off from product stakeholders?

**Reminder to annotate the PR diff with design notes, alternatives you considered, and any other helpful context.**

## Checklist

### Before merging

- [x] Changes to CSS/HTML were checked on Desktop and Mobile Safari at all three breakpoints
- [x] Changes to HTML were checked for accessibility concerns