### PR TITLE
🔨 rename `makeIdForHumanConsumption` to `makeFigmaId`

### DIFF
--- a/packages/@ourworldindata/grapher/src/axis/AxisViews.tsx
+++ b/packages/@ourworldindata/grapher/src/axis/AxisViews.tsx
@@ -9,7 +9,7 @@ import {
     VerticalAlign,
     dyFromAlign,
     textAnchorFromAlign,
-    makeIdForHumanConsumption,
+    makeFigmaId,
 } from "@ourworldindata/utils"
 import { VerticalAxis, HorizontalAxis, DualAxis } from "./Axis"
 import classNames from "classnames"
@@ -38,7 +38,7 @@ export class VerticalAxisGridLines extends React.Component<VerticalAxisGridLines
 
         return (
             <g
-                id={makeIdForHumanConsumption("horizontal-grid-lines")}
+                id={makeFigmaId("horizontal-grid-lines")}
                 className={classNames("AxisGridLines", "horizontalLines")}
             >
                 {axis.getTickValues().map((t) => {
@@ -53,9 +53,7 @@ export class VerticalAxisGridLines extends React.Component<VerticalAxisGridLines
 
                     return (
                         <line
-                            id={makeIdForHumanConsumption(
-                                verticalAxis.formatTick(t.value)
-                            )}
+                            id={makeFigmaId(verticalAxis.formatTick(t.value))}
                             className={className}
                             key={t.value}
                             x1={bounds.left.toFixed(2)}
@@ -99,7 +97,7 @@ export class HorizontalAxisGridLines extends React.Component<HorizontalAxisGridL
 
         return (
             <g
-                id={makeIdForHumanConsumption("vertical-grid-lines")}
+                id={makeFigmaId("vertical-grid-lines")}
                 className={classNames("AxisGridLines", "verticalLines")}
             >
                 {axis.getTickValues().map((t) => {
@@ -112,9 +110,7 @@ export class HorizontalAxisGridLines extends React.Component<HorizontalAxisGridL
 
                     return (
                         <line
-                            id={makeIdForHumanConsumption(
-                                horizontalAxis.formatTick(t.value)
-                            )}
+                            id={makeFigmaId(horizontalAxis.formatTick(t.value))}
                             key={t.value}
                             x1={axis.place(t.value)}
                             y1={bounds.bottom.toFixed(2)}
@@ -162,7 +158,7 @@ export class HorizontalAxisZeroLine extends React.Component<HorizontalAxisZeroLi
 
         return (
             <line
-                id={makeIdForHumanConsumption("vertical-zero-line")}
+                id={makeFigmaId("vertical-zero-line")}
                 x1={x.toFixed(2)}
                 y1={bounds.bottom.toFixed(2)}
                 x2={x.toFixed(2)}
@@ -200,7 +196,7 @@ export class VerticalAxisZeroLine extends React.Component<VerticalAxisZeroLinePr
 
         return (
             <line
-                id={makeIdForHumanConsumption("horizontal-zero-line")}
+                id={makeFigmaId("horizontal-zero-line")}
                 x1={bounds.left.toFixed(2)}
                 y1={y.toFixed(2)}
                 x2={bounds.right.toFixed(2)}
@@ -347,16 +343,11 @@ export class VerticalAxisComponent extends React.Component<VerticalAxisComponent
             bounds.left + verticalAxis.width - verticalAxis.tickPadding
 
         return (
-            <g
-                id={makeIdForHumanConsumption("vertical-axis")}
-                className="VerticalAxis"
-            >
+            <g id={makeFigmaId("vertical-axis")} className="VerticalAxis">
                 {shouldShowLogNotice && logNoticeTextWrap && (
                     <React.Fragment key={logNoticeTextWrap.text}>
                         {logNoticeTextWrap.renderSVG(tickX, bounds.top, {
-                            id: makeIdForHumanConsumption(
-                                "vertical-axis-log-notice"
-                            ),
+                            id: makeFigmaId("vertical-axis-log-notice"),
                             textProps: {
                                 fill: tickColor || GRAPHER_DARK_TEXT,
                                 textAnchor: textAnchorFromAlign(
@@ -371,9 +362,7 @@ export class VerticalAxisComponent extends React.Component<VerticalAxisComponent
                 {labelTextWrap && (
                     <React.Fragment key={labelTextWrap.text}>
                         {labelTextWrap.renderSVG(bounds.left, bounds.top, {
-                            id: makeIdForHumanConsumption(
-                                "vertical-axis-label"
-                            ),
+                            id: makeFigmaId("vertical-axis-label"),
                             textProps: {
                                 fill: labelColor || GRAPHER_DARK_TEXT,
                             },
@@ -382,12 +371,10 @@ export class VerticalAxisComponent extends React.Component<VerticalAxisComponent
                     </React.Fragment>
                 )}
                 {showTickMarks && (
-                    <g id={makeIdForHumanConsumption("tick-marks")}>
+                    <g id={makeFigmaId("tick-marks")}>
                         {visibleTickLabels.map((label) => (
                             <VerticalAxisTickMark
-                                id={makeIdForHumanConsumption(
-                                    label.formattedValue
-                                )}
+                                id={makeFigmaId(label.formattedValue)}
                                 key={label.value}
                                 tickMarkYPosition={verticalAxis.place(
                                     label.value
@@ -401,7 +388,7 @@ export class VerticalAxisComponent extends React.Component<VerticalAxisComponent
                     </g>
                 )}
                 {!config.hideTickLabels && (
-                    <g id={makeIdForHumanConsumption("tick-labels")}>
+                    <g id={makeFigmaId("tick-labels")}>
                         {visibleTickLabels.map((label) => {
                             const { value, y, xAlign, yAlign, formattedValue } =
                                 label
@@ -509,16 +496,11 @@ export class HorizontalAxisComponent extends React.Component<{
         }
 
         return (
-            <g
-                id={makeIdForHumanConsumption("horizontal-axis")}
-                className="HorizontalAxis"
-            >
+            <g id={makeFigmaId("horizontal-axis")} className="HorizontalAxis">
                 {label && (
                     <React.Fragment key={label.text}>
                         {label.renderSVG(axis.rangeCenter, labelYPosition, {
-                            id: makeIdForHumanConsumption(
-                                "horizontal-axis-label"
-                            ),
+                            id: makeFigmaId("horizontal-axis-label"),
                             textProps: {
                                 fill: labelColor || GRAPHER_DARK_TEXT,
                                 textAnchor: "middle",
@@ -528,13 +510,11 @@ export class HorizontalAxisComponent extends React.Component<{
                     </React.Fragment>
                 )}
                 {showTickMarks && (
-                    <g id={makeIdForHumanConsumption("tick-marks")}>
+                    <g id={makeFigmaId("tick-marks")}>
                         {visibleTickLabels.map((label) => (
                             <line
                                 key={label.value}
-                                id={makeIdForHumanConsumption(
-                                    label.formattedValue
-                                )}
+                                id={makeFigmaId(label.formattedValue)}
                                 x1={axis.place(label.value)}
                                 y1={tickMarksYPosition - tickMarkWidth / 2}
                                 x2={axis.place(label.value)}
@@ -546,7 +526,7 @@ export class HorizontalAxisComponent extends React.Component<{
                     </g>
                 )}
                 {showTickLabels && (
-                    <g id={makeIdForHumanConsumption("tick-labels")}>
+                    <g id={makeFigmaId("tick-labels")}>
                         {visibleTickLabels.map((label) => (
                             <text
                                 key={label.value}

--- a/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChart.tsx
@@ -7,7 +7,7 @@ import {
     Time,
     HorizontalAlign,
     AxisAlign,
-    makeIdForHumanConsumption,
+    makeFigmaId,
     dyFromAlign,
 } from "@ourworldindata/utils"
 import { computed, makeObservable } from "mobx"
@@ -387,7 +387,7 @@ export class DiscreteBarChart
             <rect
                 key={`bar-${series.seriesName}`}
                 className="bar"
-                id={makeIdForHumanConsumption(series.seriesName)}
+                id={makeFigmaId(series.seriesName)}
                 x={0}
                 y={0}
                 transform={`translate(${series.barX}, ${barY + yOffset})`}
@@ -494,7 +494,7 @@ export class DiscreteBarChart
     private renderBars(): React.ReactElement {
         const yOffset = -this.barHeight / 2
         return (
-            <g id={makeIdForHumanConsumption("bars")}>
+            <g id={makeFigmaId("bars")}>
                 {this.placedSeries.map((series) =>
                     this.renderBar({ series, barY: series.barY, yOffset })
                 )}
@@ -504,7 +504,7 @@ export class DiscreteBarChart
 
     private renderEntityLabels(): React.ReactElement {
         return (
-            <g id={makeIdForHumanConsumption("entity-labels")}>
+            <g id={makeFigmaId("entity-labels")}>
                 {this.placedSeries.map((series) => {
                     const labelY = series.entityLabelY - series.barY
                     return (
@@ -532,7 +532,7 @@ export class DiscreteBarChart
         if (!hasAnnotations) return null
 
         return (
-            <g id={makeIdForHumanConsumption("entity-annotations")}>
+            <g id={makeFigmaId("entity-annotations")}>
                 {this.placedSeries.map((series) => {
                     const annotationY = series.annotationY
                         ? series.annotationY - series.barY
@@ -549,7 +549,7 @@ export class DiscreteBarChart
 
     private renderValueLabels(): React.ReactElement {
         return (
-            <g id={makeIdForHumanConsumption("value-labels")}>
+            <g id={makeFigmaId("value-labels")}>
                 {this.placedSeries.map((series) => {
                     const label = this.formatValue(series)
                     const labelY = 0 // Value label is centered on the bar
@@ -646,7 +646,7 @@ export class DiscreteBarChart
                 update={handlePositionUpdate}
             >
                 {(nodes): React.ReactElement => (
-                    <g id={makeIdForHumanConsumption("bar-rows")}>
+                    <g id={makeFigmaId("bar-rows")}>
                         {nodes.map((node) =>
                             this.renderRow({
                                 series: node.data,
@@ -701,7 +701,7 @@ export class DiscreteBarChart
         return (
             <g
                 ref={this.base}
-                id={makeIdForHumanConsumption("discrete-bar-chart")}
+                id={makeFigmaId("discrete-bar-chart")}
                 className="DiscreteBarChart"
             >
                 {this.renderDefs()}

--- a/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
@@ -5,7 +5,7 @@ import { observer } from "mobx-react"
 import {
     Bounds,
     exposeInstanceOnWindow,
-    makeIdForHumanConsumption,
+    makeFigmaId,
 } from "@ourworldindata/utils"
 import { MarkdownTextWrap, LoadingIndicator } from "@ourworldindata/components"
 import { Header, StaticHeader } from "../header/Header"
@@ -444,7 +444,7 @@ export class StaticCaptionedChart extends AbstractCaptionedChart {
         return (
             <>
                 <line
-                    id={makeIdForHumanConsumption("separator-line")}
+                    id={makeFigmaId("separator-line")}
                     x1={this.framePaddingHorizontal}
                     y1={this.bounds.height}
                     x2={
@@ -455,7 +455,7 @@ export class StaticCaptionedChart extends AbstractCaptionedChart {
                     stroke="#e7e7e7"
                 ></line>
                 <g
-                    id={makeIdForHumanConsumption("details")}
+                    id={makeFigmaId("details")}
                     transform={`translate(15, ${
                         // + padding below the grey line
                         this.bounds.height + this.framePaddingVertical

--- a/packages/@ourworldindata/grapher/src/captionedChart/Logos.tsx
+++ b/packages/@ourworldindata/grapher/src/captionedChart/Logos.tsx
@@ -6,7 +6,7 @@ import {
     SMALL_OWID_LOGO_SVG,
 } from "./LogosSVG"
 import { LogoOption } from "@ourworldindata/types"
-import { makeIdForHumanConsumption } from "@ourworldindata/utils"
+import { makeFigmaId } from "@ourworldindata/utils"
 
 interface LogoAttributes {
     svg: string
@@ -92,7 +92,7 @@ export class Logo {
             (this.spec.svg.match(/<svg>(.*)<\/svg>/) || "")[1] || this.spec.svg
         return (
             <g
-                id={makeIdForHumanConsumption("logo")}
+                id={makeFigmaId("logo")}
                 transform={`translate(${Math.round(
                     targetX
                 )}, ${targetY}) scale(${parseFloat(scale.toFixed(2))})`}

--- a/packages/@ourworldindata/grapher/src/chart/ChartAreaContent.tsx
+++ b/packages/@ourworldindata/grapher/src/chart/ChartAreaContent.tsx
@@ -5,7 +5,7 @@ import {
     Bounds,
     GRAPHER_MAP_TYPE,
     GrapherChartOrMapType,
-    makeIdForHumanConsumption,
+    makeFigmaId,
 } from "@ourworldindata/utils"
 import { DataTable } from "../dataTable/DataTable"
 import { CaptionedChartManager } from "../captionedChart/CaptionedChart"
@@ -150,7 +150,7 @@ export class ChartAreaContent extends React.Component<ChartAreaContentProps> {
 
         return (
             <g
-                id={makeIdForHumanConsumption(GRAPHER_CHART_AREA_CLASS)}
+                id={makeFigmaId(GRAPHER_CHART_AREA_CLASS)}
                 style={{ pointerEvents: "none" }}
             >
                 {this.renderReadyChartOrMap()}

--- a/packages/@ourworldindata/grapher/src/comparisonLine/CustomComparisonLine.tsx
+++ b/packages/@ourworldindata/grapher/src/comparisonLine/CustomComparisonLine.tsx
@@ -2,11 +2,7 @@ import * as React from "react"
 import { computed, makeObservable } from "mobx"
 import { observer } from "mobx-react"
 import { line as d3_line, curveLinear } from "d3-shape"
-import {
-    guid,
-    PointVector,
-    makeIdForHumanConsumption,
-} from "@ourworldindata/utils"
+import { guid, PointVector, makeFigmaId } from "@ourworldindata/utils"
 import { CustomComparisonLineConfig } from "@ourworldindata/types"
 import { generateComparisonLinePoints } from "./ComparisonLineGenerator"
 import { Halo } from "@ourworldindata/components"
@@ -140,7 +136,7 @@ export class CustomComparisonLine extends React.Component<
 
         return (
             <g
-                id={makeIdForHumanConsumption(
+                id={makeFigmaId(
                     "comparison-line",
                     this.props.comparisonLine.label
                 )}

--- a/packages/@ourworldindata/grapher/src/comparisonLine/VerticalComparisonLine.tsx
+++ b/packages/@ourworldindata/grapher/src/comparisonLine/VerticalComparisonLine.tsx
@@ -5,7 +5,7 @@ import * as _ from "lodash-es"
 import {
     Bounds,
     dyFromAlign,
-    makeIdForHumanConsumption,
+    makeFigmaId,
     VerticalAlign,
 } from "@ourworldindata/utils"
 import {
@@ -188,12 +188,7 @@ export class VerticalComparisonLine extends React.Component<
         const { x, y1, y2 } = this.lineCoordinates
 
         return (
-            <g
-                id={makeIdForHumanConsumption(
-                    "comparison-line",
-                    this.lineConfig.label
-                )}
-            >
+            <g id={makeFigmaId("comparison-line", this.lineConfig.label)}>
                 <line
                     x1={x}
                     y1={y1}

--- a/packages/@ourworldindata/grapher/src/facet/FacetChart.tsx
+++ b/packages/@ourworldindata/grapher/src/facet/FacetChart.tsx
@@ -12,7 +12,7 @@ import {
     PositionMap,
     HorizontalAlign,
     Color,
-    makeIdForHumanConsumption,
+    makeFigmaId,
     exposeInstanceOnWindow,
     SplitBoundsPadding,
 } from "@ourworldindata/utils"
@@ -945,7 +945,7 @@ export class FacetChart
                                     labelPadding
                                 }
                             />
-                            <g id={makeIdForHumanConsumption(seriesName)}>
+                            <g id={makeFigmaId(seriesName)}>
                                 <ChartComponent
                                     manager={facetChart.manager}
                                     chartType={this.chartTypeName}

--- a/packages/@ourworldindata/grapher/src/facet/FacetMap.tsx
+++ b/packages/@ourworldindata/grapher/src/facet/FacetMap.tsx
@@ -5,7 +5,7 @@ import {
     GridParameters,
     HorizontalAlign,
     Color,
-    makeIdForHumanConsumption,
+    makeFigmaId,
     exposeInstanceOnWindow,
     SplitBoundsPadding,
 } from "@ourworldindata/utils"
@@ -587,7 +587,7 @@ export class FacetMap
                             >
                                 {seriesName}
                             </text>
-                            <g id={makeIdForHumanConsumption(seriesName)}>
+                            <g id={makeFigmaId(seriesName)}>
                                 <ChartComponent
                                     manager={series.manager}
                                     chartType={GRAPHER_MAP_TYPE}

--- a/packages/@ourworldindata/grapher/src/footer/Footer.tsx
+++ b/packages/@ourworldindata/grapher/src/footer/Footer.tsx
@@ -4,7 +4,7 @@ import { observer } from "mobx-react"
 import {
     Bounds,
     getRelativeMouse,
-    makeIdForHumanConsumption,
+    makeFigmaId,
     Url,
 } from "@ourworldindata/utils"
 import {
@@ -770,19 +770,19 @@ export class StaticFooter extends AbstractFooter<StaticFooterProps> {
 
         return (
             <g
-                id={makeIdForHumanConsumption(GRAPHER_FOOTER_CLASS)}
+                id={makeFigmaId(GRAPHER_FOOTER_CLASS)}
                 className="SourcesFooter"
                 style={{ fill: this.textColor }}
             >
                 {sources.renderSVG(targetX, targetY, {
-                    id: makeIdForHumanConsumption("sources"),
+                    id: makeFigmaId("sources"),
                 })}
                 {this.showNote &&
                     note.renderSVG(
                         targetX,
                         targetY + sources.height + this.verticalPadding,
                         {
-                            id: makeIdForHumanConsumption("note"),
+                            id: makeFigmaId("note"),
                             detailsMarker: this.manager.detailsMarkerInSvg,
                         }
                     )}
@@ -790,7 +790,7 @@ export class StaticFooter extends AbstractFooter<StaticFooterProps> {
                     ? licenseAndOriginUrl.renderSVG(
                           targetX + maxWidth - licenseAndOriginUrl.width,
                           targetY,
-                          { id: makeIdForHumanConsumption("origin-url") }
+                          { id: makeFigmaId("origin-url") }
                       )
                     : licenseAndOriginUrl.renderSVG(
                           targetX,
@@ -800,7 +800,7 @@ export class StaticFooter extends AbstractFooter<StaticFooterProps> {
                                   ? note.height + this.verticalPadding
                                   : 0) +
                               this.verticalPadding,
-                          { id: makeIdForHumanConsumption("origin-url") }
+                          { id: makeFigmaId("origin-url") }
                       )}
             </g>
         )

--- a/packages/@ourworldindata/grapher/src/header/Header.tsx
+++ b/packages/@ourworldindata/grapher/src/header/Header.tsx
@@ -2,7 +2,7 @@ import * as _ from "lodash-es"
 import * as React from "react"
 import {
     LogoOption,
-    makeIdForHumanConsumption,
+    makeFigmaId,
     Bounds,
     FontFamily,
 } from "@ourworldindata/utils"
@@ -326,16 +326,13 @@ export class StaticHeader extends AbstractHeader<StaticHeaderProps> {
         const { targetX: x, targetY: y } = this.props
         const { title, logo, subtitle, manager, maxWidth } = this
         return (
-            <g
-                id={makeIdForHumanConsumption(GRAPHER_HEADER_CLASS)}
-                className="HeaderView"
-            >
+            <g id={makeFigmaId(GRAPHER_HEADER_CLASS)} className="HeaderView">
                 {logo &&
                     logo.height > 0 &&
                     logo.renderSVG(x + maxWidth - logo.width, y)}
                 {this.showTitle && (
                     <a
-                        id={makeIdForHumanConsumption("title")}
+                        id={makeFigmaId("title")}
                         href={manager.canonicalUrl}
                         style={{
                             fontFamily:
@@ -359,7 +356,7 @@ export class StaticHeader extends AbstractHeader<StaticHeaderProps> {
                                 ? title.height + this.subtitleMarginTop
                                 : 0),
                         {
-                            id: makeIdForHumanConsumption("subtitle"),
+                            id: makeFigmaId("subtitle"),
                             textProps: { fill: GRAPHER_DARK_TEXT },
                             detailsMarker: this.manager.detailsMarkerInSvg,
                         }

--- a/packages/@ourworldindata/grapher/src/legend/HorizontalColorLegends.tsx
+++ b/packages/@ourworldindata/grapher/src/legend/HorizontalColorLegends.tsx
@@ -9,7 +9,7 @@ import {
     Bounds,
     HorizontalAlign,
     VerticalAlign,
-    makeIdForHumanConsumption,
+    makeFigmaId,
 } from "@ourworldindata/utils"
 import { TextWrap } from "@ourworldindata/components"
 import {
@@ -503,16 +503,16 @@ export class HorizontalNumericColorLegend extends HorizontalColorLegend {
         return (
             <g
                 ref={this.base}
-                id={makeIdForHumanConsumption("numeric-color-legend")}
+                id={makeFigmaId("numeric-color-legend")}
                 className="numericColorLegend"
             >
-                <g id={makeIdForHumanConsumption("lines")}>
+                <g id={makeFigmaId("lines")}>
                     {numericLabels.map((label, index) => {
                         const style = this.getMarkerStyleConfig(label.bin)
                         return (
                             <line
                                 key={index}
-                                id={makeIdForHumanConsumption(label.text)}
+                                id={makeFigmaId(label.text)}
                                 x1={label.bounds.x + label.bounds.width / 2}
                                 y1={bottomY - numericBinSize}
                                 x2={label.bounds.x + label.bounds.width / 2}
@@ -533,7 +533,7 @@ export class HorizontalNumericColorLegend extends HorizontalColorLegend {
                         )
                     })}
                 </g>
-                <g id={makeIdForHumanConsumption("swatches")}>
+                <g id={makeFigmaId("swatches")}>
                     {_.sortBy(
                         positionedBins.map((positionedBin, index) => {
                             const bin = positionedBin.bin
@@ -577,7 +577,7 @@ export class HorizontalNumericColorLegend extends HorizontalColorLegend {
                         (rect) => rect.props["strokeWidth"]
                     )}
                 </g>
-                <g id={makeIdForHumanConsumption("labels")}>
+                <g id={makeFigmaId("labels")}>
                     {numericLabels.map((label, index) => {
                         const style = this.getTextStyleConfig(label.bin)
                         return (
@@ -802,7 +802,7 @@ export class HorizontalCategoricalColorLegend extends HorizontalColorLegend {
         const { marks } = this
 
         return (
-            <g id={makeIdForHumanConsumption("labels")}>
+            <g id={makeFigmaId("labels")}>
                 {marks.map((mark, index) => {
                     const style = this.getTextStyleConfig(mark.bin)
 
@@ -831,7 +831,7 @@ export class HorizontalCategoricalColorLegend extends HorizontalColorLegend {
         const { marks } = this
 
         return (
-            <g id={makeIdForHumanConsumption("swatches")}>
+            <g id={makeFigmaId("swatches")}>
                 {marks.map((mark, index) => {
                     const style = this.getMarkerStyleConfig(mark.bin)
 
@@ -841,7 +841,7 @@ export class HorizontalCategoricalColorLegend extends HorizontalColorLegend {
 
                     return (
                         <rect
-                            id={makeIdForHumanConsumption(mark.label.text)}
+                            id={makeFigmaId(mark.label.text)}
                             key={`${mark.label}-${index}`}
                             x={this.legendX + mark.x}
                             y={this.categoryLegendY + mark.y}
@@ -911,7 +911,7 @@ export class HorizontalCategoricalColorLegend extends HorizontalColorLegend {
     override render(): React.ReactElement {
         return (
             <g
-                id={makeIdForHumanConsumption("categorical-color-legend")}
+                id={makeFigmaId("categorical-color-legend")}
                 className="categoricalColorLegend"
             >
                 {this.renderSwatches()}

--- a/packages/@ourworldindata/grapher/src/legend/VerticalColorLegend.tsx
+++ b/packages/@ourworldindata/grapher/src/legend/VerticalColorLegend.tsx
@@ -1,6 +1,6 @@
 import * as _ from "lodash-es"
 import * as React from "react"
-import { makeIdForHumanConsumption } from "@ourworldindata/utils"
+import { makeFigmaId } from "@ourworldindata/utils"
 import { TextWrap } from "@ourworldindata/components"
 import { computed, makeObservable } from "mobx"
 import { observer } from "mobx-react"
@@ -183,7 +183,7 @@ export class VerticalColorLegend extends React.Component<{
         const { series, rectSize, rectPadding } = this
 
         return (
-            <g id={makeIdForHumanConsumption("labels")}>
+            <g id={makeFigmaId("labels")}>
                 {series.map((series) => {
                     const style = this.getTextStyleConfig(series.bin)
 
@@ -206,7 +206,7 @@ export class VerticalColorLegend extends React.Component<{
         const { series, rectSize, rectPadding } = this
 
         return (
-            <g id={makeIdForHumanConsumption("swatches")}>
+            <g id={makeFigmaId("swatches")}>
                 {series.map((series) => {
                     const style = this.getMarkerStyleConfig(series.bin)
 
@@ -217,7 +217,7 @@ export class VerticalColorLegend extends React.Component<{
 
                     return (
                         <rect
-                            id={makeIdForHumanConsumption(series.textWrap.text)}
+                            id={makeFigmaId(series.textWrap.text)}
                             key={series.textWrap.text}
                             x={this.legendX}
                             y={renderedTextPosition[1] - rectSize}
@@ -279,7 +279,7 @@ export class VerticalColorLegend extends React.Component<{
     override render(): React.ReactElement {
         return (
             <g
-                id={makeIdForHumanConsumption("vertical-color-legend")}
+                id={makeFigmaId("vertical-color-legend")}
                 className="ScatterColorLegend clickable"
             >
                 {this.title &&

--- a/packages/@ourworldindata/grapher/src/lineCharts/Lines.tsx
+++ b/packages/@ourworldindata/grapher/src/lineCharts/Lines.tsx
@@ -3,7 +3,7 @@ import React from "react"
 import {
     Bounds,
     PointVector,
-    makeIdForHumanConsumption,
+    makeFigmaId,
     pointsToPath,
 } from "@ourworldindata/utils"
 import { computed, makeObservable } from "mobx"
@@ -111,7 +111,7 @@ export class Lines extends React.Component<LinesProps> {
 
         const outline = (
             <LinePath
-                id={makeIdForHumanConsumption("outline", series.displayName)}
+                id={makeFigmaId("outline", series.displayName)}
                 placedPoints={series.placedPoints}
                 stroke={outlineColor}
                 strokeWidth={outlineWidth.toFixed(1)}
@@ -120,7 +120,7 @@ export class Lines extends React.Component<LinesProps> {
 
         const line = this.props.multiColor ? (
             <MultiColorPolyline
-                id={makeIdForHumanConsumption("line", series.seriesName)}
+                id={makeFigmaId("line", series.seriesName)}
                 points={series.placedPoints}
                 strokeLinejoin="round"
                 strokeWidth={strokeWidth.toFixed(1)}
@@ -129,7 +129,7 @@ export class Lines extends React.Component<LinesProps> {
             />
         ) : (
             <LinePath
-                id={makeIdForHumanConsumption("line", series.seriesName)}
+                id={makeFigmaId("line", series.seriesName)}
                 placedPoints={series.placedPoints}
                 stroke={color}
                 strokeWidth={strokeWidth.toFixed(1)}
@@ -175,12 +175,10 @@ export class Lines extends React.Component<LinesProps> {
             : undefined
 
         return (
-            <g id={makeIdForHumanConsumption("datapoints", series.displayName)}>
+            <g id={makeFigmaId("datapoints", series.displayName)}>
                 {series.placedPoints.map((value, index) => (
                     <circle
-                        id={makeIdForHumanConsumption(
-                            horizontalAxis.formatTick(value.time)
-                        )}
+                        id={makeFigmaId(horizontalAxis.formatTick(value.time))}
                         key={index}
                         cx={value.x}
                         cy={value.y}
@@ -209,9 +207,7 @@ export class Lines extends React.Component<LinesProps> {
     }
 
     private renderStatic(): React.ReactElement {
-        return (
-            <g id={makeIdForHumanConsumption("lines")}>{this.renderLines()}</g>
-        )
+        return <g id={makeFigmaId("lines")}>{this.renderLines()}</g>
     }
 
     private renderInteractive(): React.ReactElement {

--- a/packages/@ourworldindata/grapher/src/mapCharts/ChoroplethGlobe.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/ChoroplethGlobe.tsx
@@ -15,7 +15,7 @@ import { zoom } from "d3-zoom"
 // @ts-expect-error no types available
 import versor from "versor"
 import {
-    makeIdForHumanConsumption,
+    makeFigmaId,
     Bounds,
     isTouchDevice,
     getRelativeMouse,
@@ -675,14 +675,14 @@ export class ChoroplethGlobe extends React.Component<{
         return (
             <>
                 <circle
-                    id={makeIdForHumanConsumption("globe-sphere")}
+                    id={makeFigmaId("globe-sphere")}
                     cx={this.globeCenter[0]}
                     cy={this.globeCenter[1]}
                     r={this.globeRadius}
                     fill="#fafafa"
                 />
                 <path
-                    id={makeIdForHumanConsumption("globe-graticule")}
+                    id={makeFigmaId("globe-graticule")}
                     d={this.graticulePath}
                     stroke="#e7e7e7"
                     strokeWidth={1}
@@ -690,7 +690,7 @@ export class ChoroplethGlobe extends React.Component<{
                     style={{ pointerEvents: "none" }}
                 />
                 <path
-                    id={makeIdForHumanConsumption("globe-equator")}
+                    id={makeFigmaId("globe-equator")}
                     d={this.equatorPath}
                     stroke="#dadada"
                     strokeWidth={1}
@@ -705,7 +705,7 @@ export class ChoroplethGlobe extends React.Component<{
         if (this.backgroundFeatures.length === 0) return
 
         return (
-            <g id={makeIdForHumanConsumption("countries-background")}>
+            <g id={makeFigmaId("countries-background")}>
                 {this.backgroundFeatures.map((feature) => (
                     <BackgroundCountry
                         key={feature.id}
@@ -724,7 +724,7 @@ export class ChoroplethGlobe extends React.Component<{
 
         return (
             <g
-                id={makeIdForHumanConsumption("countries-without-data")}
+                id={makeFigmaId("countries-without-data")}
                 className="noDataFeatures"
             >
                 <defs>
@@ -758,7 +758,7 @@ export class ChoroplethGlobe extends React.Component<{
         if (this.sortedFeaturesWithData.length === 0) return
 
         return (
-            <g id={makeIdForHumanConsumption("countries-with-data")}>
+            <g id={makeFigmaId("countries-with-data")}>
                 {this.manager.hasProjectedData && (
                     <defs>
                         {/* Pattern used by the map legend for the projected data bin */}
@@ -819,7 +819,7 @@ export class ChoroplethGlobe extends React.Component<{
         if (this.internalAnnotations.length === 0) return
 
         return (
-            <g id={makeIdForHumanConsumption("annotations-internal")}>
+            <g id={makeFigmaId("annotations-internal")}>
                 {this.internalAnnotations.map((annotation) => (
                     <InternalValueAnnotation
                         key={annotation.id}
@@ -838,7 +838,7 @@ export class ChoroplethGlobe extends React.Component<{
 
         return (
             <g
-                id={makeIdForHumanConsumption("annotations-external")}
+                id={makeFigmaId("annotations-external")}
                 className="ExternalAnnotations"
             >
                 {this.externalAnnotations.map((annotation) => (
@@ -863,7 +863,7 @@ export class ChoroplethGlobe extends React.Component<{
         return (
             <>
                 {this.renderGlobeOutline()}
-                <g id={makeIdForHumanConsumption("globe")}>
+                <g id={makeFigmaId("globe")}>
                     {this.renderFeaturesInBackground()}
                     {this.renderFeaturesWithNoData()}
                     {this.renderFeaturesWithData()}

--- a/packages/@ourworldindata/grapher/src/mapCharts/ChoroplethMap.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/ChoroplethMap.tsx
@@ -2,7 +2,7 @@ import * as _ from "lodash-es"
 import React from "react"
 import {
     Bounds,
-    makeIdForHumanConsumption,
+    makeFigmaId,
     excludeUndefined,
     EntityName,
     MapRegionName,
@@ -413,7 +413,7 @@ export class ChoroplethMap extends React.Component<{
         if (this.internalAnnotations.length === 0) return
 
         return (
-            <g id={makeIdForHumanConsumption("annotations-internal")}>
+            <g id={makeFigmaId("annotations-internal")}>
                 {this.internalAnnotations.map((annotation) => (
                     <InternalValueAnnotation
                         key={annotation.id}
@@ -433,7 +433,7 @@ export class ChoroplethMap extends React.Component<{
 
         return (
             <g
-                id={makeIdForHumanConsumption("annotations-external")}
+                id={makeFigmaId("annotations-external")}
                 className="ExternalAnnotations"
             >
                 {this.externalAnnotations.map((annotation) => (
@@ -459,7 +459,7 @@ export class ChoroplethMap extends React.Component<{
         if (this.backgroundFeatures.length === 0) return
 
         return (
-            <g id={makeIdForHumanConsumption("countries-background")}>
+            <g id={makeFigmaId("countries-background")}>
                 {this.backgroundFeatures.map((feature) => (
                     <BackgroundCountry key={feature.id} feature={feature} />
                 ))}
@@ -473,7 +473,7 @@ export class ChoroplethMap extends React.Component<{
 
         return (
             <g
-                id={makeIdForHumanConsumption("countries-without-data")}
+                id={makeFigmaId("countries-without-data")}
                 className="noDataFeatures"
             >
                 <defs>
@@ -510,7 +510,7 @@ export class ChoroplethMap extends React.Component<{
         if (this.sortedFeaturesWithData.length === 0) return
 
         return (
-            <g id={makeIdForHumanConsumption("countries-with-data")}>
+            <g id={makeFigmaId("countries-with-data")}>
                 {this.manager.hasProjectedData && (
                     <defs>
                         {/* Pattern used by the map legend for the projected data bin */}
@@ -570,10 +570,7 @@ export class ChoroplethMap extends React.Component<{
 
     renderStatic(): React.ReactElement {
         return (
-            <g
-                id={makeIdForHumanConsumption("map")}
-                transform={this.matrixTransform}
-            >
+            <g id={makeFigmaId("map")} transform={this.matrixTransform}>
                 {this.renderFeaturesInBackground()}
                 {this.renderFeaturesWithoutData()}
                 {this.renderFeaturesWithData()}

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapComponents.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapComponents.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { makeIdForHumanConsumption } from "@ourworldindata/utils"
+import { makeFigmaId } from "@ourworldindata/utils"
 import {
     BLUR_FILL_OPACITY,
     BLUR_STROKE_OPACITY,
@@ -33,7 +33,7 @@ export function BackgroundCountry<Feature extends RenderFeature>({
 }): React.ReactElement {
     return (
         <path
-            id={makeIdForHumanConsumption(feature.id)}
+            id={makeFigmaId(feature.id)}
             d={isMapRenderFeature(feature) ? feature.path : path}
             strokeWidth={strokeWidth}
             stroke="#aaa"
@@ -78,7 +78,7 @@ export function CountryWithData<Feature extends RenderFeature>({
 
     return (
         <path
-            id={makeIdForHumanConsumption(feature.id)}
+            id={makeFigmaId(feature.id)}
             data-feature-id={feature.id}
             d={isMapRenderFeature(feature) ? feature.path : path}
             strokeWidth={strokeWidth}
@@ -125,7 +125,7 @@ export function CountryWithNoData<Feature extends RenderFeature>({
 
     return (
         <path
-            id={makeIdForHumanConsumption(feature.id)}
+            id={makeFigmaId(feature.id)}
             data-feature-id={feature.id}
             d={isMapRenderFeature(feature) ? feature.path : path}
             strokeWidth={strokeWidth}
@@ -244,7 +244,7 @@ export function InternalValueAnnotation({
     return (
         <Halo id={id} outlineWidth={3} show={showHalo}>
             <text
-                id={makeIdForHumanConsumption(id)}
+                id={makeFigmaId(id)}
                 x={placedBounds.topLeft.x}
                 y={placedBounds.topLeft.y + placedBounds.height - 1}
                 fontSize={fontSize}
@@ -279,7 +279,7 @@ export function ExternalValueAnnotation({
     })
 
     return (
-        <g id={makeIdForHumanConsumption(id)}>
+        <g id={makeFigmaId(id)}>
             <line
                 x1={markerStart[0]}
                 y1={markerStart[1]}

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ConnectedScatterLegend.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ConnectedScatterLegend.tsx
@@ -3,7 +3,7 @@ import { computed, makeObservable } from "mobx"
 import { Triangle } from "./Triangle"
 import { TextWrap } from "@ourworldindata/components"
 import { BASE_FONT_SIZE } from "../core/GrapherConstants"
-import { makeIdForHumanConsumption } from "@ourworldindata/utils"
+import { makeFigmaId } from "@ourworldindata/utils"
 import * as _ from "lodash-es"
 import { GRAPHER_DARK_TEXT, GRAY_70 } from "../color/ColorConstants.js"
 
@@ -96,7 +96,7 @@ export class ConnectedScatterLegend {
 
         return (
             <g
-                id={makeIdForHumanConsumption("arrow-legend")}
+                id={makeFigmaId("arrow-legend")}
                 className="ConnectedScatterLegend"
                 {...renderOptions}
             >

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
@@ -14,7 +14,7 @@ import {
     PointVector,
     Bounds,
     isTouchDevice,
-    makeIdForHumanConsumption,
+    makeFigmaId,
     guid,
 } from "@ourworldindata/utils"
 import { observer } from "mobx-react"
@@ -643,7 +643,7 @@ export class ScatterPlotChart
         const separatorLine = (y: number): React.ReactElement | null =>
             y > bounds.top ? (
                 <line
-                    id={makeIdForHumanConsumption("separator")}
+                    id={makeFigmaId("separator")}
                     x1={this.legendX}
                     y1={y - 0.5 * legendPadding}
                     x2={bounds.right}

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPoints.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPoints.tsx
@@ -1,5 +1,5 @@
 import * as R from "remeda"
-import { PointVector, makeIdForHumanConsumption } from "@ourworldindata/utils"
+import { PointVector, makeFigmaId } from "@ourworldindata/utils"
 import { observer } from "mobx-react"
 import * as React from "react"
 import { MultiColorPolyline } from "./MultiColorPolyline"
@@ -47,7 +47,7 @@ export class ScatterPoint extends React.Component<ScatterPointProps> {
 
         return (
             <g
-                id={makeIdForHumanConsumption(series.seriesName, "datapoint")}
+                id={makeFigmaId(series.seriesName, "datapoint")}
                 key={series.displayKey}
                 className={series.displayKey}
                 onMouseEnter={
@@ -114,10 +114,7 @@ export class ScatterLine extends React.Component<ScatterLineProps> {
 
         return (
             <g
-                id={makeIdForHumanConsumption(
-                    "scatter-line",
-                    series.displayKey
-                )}
+                id={makeFigmaId("scatter-line", series.displayKey)}
                 key={series.displayKey}
                 className={series.displayKey}
             >

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPointsWithLabels.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPointsWithLabels.tsx
@@ -12,7 +12,7 @@ import {
     getRelativeMouse,
     intersection,
     guid,
-    makeIdForHumanConsumption,
+    makeFigmaId,
 } from "@ourworldindata/utils"
 import { computed, action, observable, makeObservable } from "mobx"
 import { observer } from "mobx-react"
@@ -422,7 +422,7 @@ export class ScatterPointsWithLabels extends React.Component<ScatterPointsWithLa
         if (hideConnectedScatterLines) return null
 
         return (
-            <g id={makeIdForHumanConsumption("points")}>
+            <g id={makeFigmaId("points")}>
                 {backgroundSeries.map((series) => (
                     <ScatterLine
                         key={series.seriesName}
@@ -440,7 +440,7 @@ export class ScatterPointsWithLabels extends React.Component<ScatterPointsWithLa
         const { isLayerMode } = this
         return (
             <g
-                id={makeIdForHumanConsumption("labels")}
+                id={makeFigmaId("labels")}
                 className="backgroundLabels"
                 fill={!isLayerMode ? "#333" : "#aaa"}
             >
@@ -450,20 +450,14 @@ export class ScatterPointsWithLabels extends React.Component<ScatterPointsWithLa
                         .map((label) => (
                             <Halo
                                 key={series.displayKey + "-endLabel"}
-                                id={makeIdForHumanConsumption(
-                                    "outline",
-                                    series.seriesName
-                                )}
+                                id={makeFigmaId("outline", series.seriesName)}
                                 outlineWidth={
                                     GRAPHER_TEXT_OUTLINE_FACTOR * label.fontSize
                                 }
                                 outlineColor={this.props.backgroundColor}
                             >
                                 <text
-                                    id={makeIdForHumanConsumption(
-                                        "label",
-                                        label.text
-                                    )}
+                                    id={makeFigmaId("label", label.text)}
                                     x={label.bounds.x.toFixed(2)}
                                     y={(
                                         label.bounds.y + label.bounds.height
@@ -489,7 +483,7 @@ export class ScatterPointsWithLabels extends React.Component<ScatterPointsWithLa
     private renderForegroundSeries(): React.ReactElement {
         const { isSubtleForeground, hideConnectedScatterLines } = this
         return (
-            <g id={makeIdForHumanConsumption("points")}>
+            <g id={makeFigmaId("points")}>
                 {this.foregroundSeries.map((series) => {
                     const lastPoint = R.last(series.points)!
                     const strokeWidth =
@@ -525,10 +519,7 @@ export class ScatterPointsWithLabels extends React.Component<ScatterPointsWithLa
                     if (series.offsetVector.x < 0) rotation = -rotation
                     return (
                         <g
-                            id={makeIdForHumanConsumption(
-                                "time-scatter",
-                                series.displayKey
-                            )}
+                            id={makeFigmaId("time-scatter", series.displayKey)}
                             key={series.displayKey}
                             className={series.displayKey}
                         >
@@ -592,16 +583,13 @@ export class ScatterPointsWithLabels extends React.Component<ScatterPointsWithLa
 
     private renderForegroundLabels(): React.ReactElement {
         return (
-            <g id={makeIdForHumanConsumption("labels")}>
+            <g id={makeFigmaId("labels")}>
                 {this.foregroundSeries.map((series) => {
                     return series.allLabels
                         .filter((label) => !label.isHidden)
                         .map((label, index) => (
                             <Halo
-                                id={makeIdForHumanConsumption(
-                                    "outline",
-                                    series.seriesName
-                                )}
+                                id={makeFigmaId("outline", series.seriesName)}
                                 key={`${series.displayKey}-label-${index}`}
                                 outlineWidth={
                                     GRAPHER_TEXT_OUTLINE_FACTOR * label.fontSize
@@ -609,10 +597,7 @@ export class ScatterPointsWithLabels extends React.Component<ScatterPointsWithLa
                                 outlineColor={this.props.backgroundColor}
                             >
                                 <text
-                                    id={makeIdForHumanConsumption(
-                                        "label",
-                                        series.seriesName
-                                    )}
+                                    id={makeFigmaId("label", series.seriesName)}
                                     x={label.bounds.x.toFixed(2)}
                                     y={(
                                         label.bounds.y + label.bounds.height
@@ -673,7 +658,7 @@ export class ScatterPointsWithLabels extends React.Component<ScatterPointsWithLa
         return (
             <g
                 ref={this.base}
-                id={makeIdForHumanConsumption("scatter-points")}
+                id={makeFigmaId("scatter-points")}
                 className="PointsWithLabels clickable"
                 clipPath={`url(#scatterBounds-${renderUid})`}
                 onMouseMove={this.onMouseMove}

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterSizeLegend.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterSizeLegend.tsx
@@ -5,7 +5,7 @@ import { scaleLinear, ScaleLinear } from "d3-scale"
 import { TextWrap, Halo } from "@ourworldindata/components"
 import {
     Color,
-    makeIdForHumanConsumption,
+    makeFigmaId,
     OwidVariableRoundingMode,
 } from "@ourworldindata/utils"
 import {
@@ -234,7 +234,7 @@ export class ScatterSizeLegend {
     ): React.ReactElement {
         const centerX = targetX + this.maxWidth / 2
         return (
-            <g id={makeIdForHumanConsumption("size-legend")} {...renderOptions}>
+            <g id={makeFigmaId("size-legend")} {...renderOptions}>
                 {this.renderLegend(targetX, targetY)}
                 {this.label.renderSVG(
                     centerX,

--- a/packages/@ourworldindata/grapher/src/slopeCharts/MarkX.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/MarkX.tsx
@@ -1,8 +1,4 @@
-import {
-    dyFromAlign,
-    makeIdForHumanConsumption,
-    VerticalAlign,
-} from "@ourworldindata/utils"
+import { dyFromAlign, makeFigmaId, VerticalAlign } from "@ourworldindata/utils"
 import { GRAPHER_DARK_TEXT } from "../color/ColorConstants"
 
 export function MarkX({
@@ -23,7 +19,7 @@ export function MarkX({
     return (
         <>
             <line
-                id={makeIdForHumanConsumption(label)}
+                id={makeFigmaId(label)}
                 x1={x}
                 y1={top}
                 x2={x}

--- a/packages/@ourworldindata/grapher/src/slopeCharts/Slope.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/Slope.tsx
@@ -1,4 +1,4 @@
-import { makeIdForHumanConsumption, PointVector } from "@ourworldindata/utils"
+import { makeFigmaId, PointVector } from "@ourworldindata/utils"
 import { GRAPHER_OPACITY_MUTE } from "../core/GrapherConstants"
 import { RenderSlopeChartSeries } from "./SlopeChartConstants"
 
@@ -34,7 +34,7 @@ export function Slope({
         <>
             {showOutline && (
                 <LineWithDots
-                    id={makeIdForHumanConsumption("outline", displayName)}
+                    id={makeFigmaId("outline", displayName)}
                     startPoint={startPoint}
                     endPoint={endPoint}
                     radius={dotRadius + 2 * outlineWidth}
@@ -43,7 +43,7 @@ export function Slope({
                 />
             )}
             <LineWithDots
-                id={makeIdForHumanConsumption("slope", displayName)}
+                id={makeFigmaId("slope", displayName)}
                 startPoint={startPoint}
                 endPoint={endPoint}
                 radius={dotRadius}
@@ -75,21 +75,21 @@ function LineWithDots({
     return (
         <g id={id} opacity={opacity} className="slope">
             <circle
-                id={makeIdForHumanConsumption("start-point")}
+                id={makeFigmaId("start-point")}
                 cx={startPoint.x}
                 cy={startPoint.y}
                 r={radius}
                 fill={color}
             />
             <circle
-                id={makeIdForHumanConsumption("end-point")}
+                id={makeFigmaId("end-point")}
                 cx={endPoint.x}
                 cy={endPoint.y}
                 r={radius}
                 fill={color}
             />
             <line
-                id={makeIdForHumanConsumption("line")}
+                id={makeFigmaId("line")}
                 x1={startPoint.x}
                 y1={startPoint.y}
                 x2={endPoint.x}

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
@@ -5,7 +5,7 @@ import {
     Bounds,
     exposeInstanceOnWindow,
     PointVector,
-    makeIdForHumanConsumption,
+    makeFigmaId,
     guid,
     excludeUndefined,
     getRelativeMouse,
@@ -876,7 +876,7 @@ export class SlopeChart
 
     private renderSlopes() {
         return (
-            <g id={makeIdForHumanConsumption("slopes")}>
+            <g id={makeFigmaId("slopes")}>
                 {this.renderSeries.map((series) => (
                     <Slope
                         key={series.seriesName}
@@ -1019,7 +1019,7 @@ export class SlopeChart
         const { startX, endX } = this
 
         return (
-            <g id={makeIdForHumanConsumption("horizontal-axis")}>
+            <g id={makeFigmaId("horizontal-axis")}>
                 <MarkX
                     label={this.formattedStartTime}
                     x={startX}

--- a/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoBarsForOneEntity.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoBarsForOneEntity.tsx
@@ -1,4 +1,4 @@
-import { makeIdForHumanConsumption } from "@ourworldindata/utils"
+import { makeFigmaId } from "@ourworldindata/utils"
 import { DualAxis } from "../axis/Axis"
 import {
     Bar,
@@ -87,7 +87,7 @@ export function MarimekkoBarsForOneEntity(
     return (
         <g
             key={entityName}
-            id={makeIdForHumanConsumption("bar", entityName)}
+            id={makeFigmaId("bar", entityName)}
             className="bar"
             transform={`translate(${currentX}, ${labelYOffset})`}
             onMouseOver={(ev): void => onEntityMouseOver?.(entityName, ev)}

--- a/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChart.tsx
@@ -10,7 +10,7 @@ import {
     SortOrder,
     getRelativeMouse,
     EntitySelectionMode,
-    makeIdForHumanConsumption,
+    makeFigmaId,
     dyFromAlign,
     exposeInstanceOnWindow,
 } from "@ourworldindata/utils"
@@ -528,7 +528,7 @@ export class MarimekkoChart
         return (
             <g
                 ref={this.base}
-                id={makeIdForHumanConsumption("marimekko-chart")}
+                id={makeFigmaId("marimekko-chart")}
                 className="MarimekkoChart"
                 onMouseMove={(ev): void => this.onMouseMove(ev)}
                 onMouseLeave={(): void => this.dismissTooltip()}
@@ -1003,10 +1003,7 @@ export class MarimekkoChart
                         : markerNetHeight - directionUnawareMakerYMid
                 labelLines.push(
                     <g
-                        id={makeIdForHumanConsumption(
-                            "label-line",
-                            item.labelKey
-                        )}
+                        id={makeFigmaId("label-line", item.labelKey)}
                         className="indicator"
                         key={`labelline-${item.labelKey}`}
                     >
@@ -1032,7 +1029,7 @@ export class MarimekkoChart
 
             labelLines.push(
                 <g
-                    id={makeIdForHumanConsumption("label-line", item.labelKey)}
+                    id={makeFigmaId("label-line", item.labelKey)}
                     className="indicator"
                     key={`labelline-${item.labelKey}`}
                 >
@@ -1058,7 +1055,7 @@ export class MarimekkoChart
         const placedLabels = this.labelsWithPlacementInfo.map((item) => (
             <g
                 key={`label-${item.labelKey}`}
-                id={makeIdForHumanConsumption("label", item.labelKey)}
+                id={makeFigmaId("label", item.labelKey)}
                 className="bar-label"
                 transform={`translate(${item.correctedPlacement}, ${labelOffset})`}
             >

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreas.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreas.tsx
@@ -5,7 +5,7 @@ import {
     makeSafeForCSS,
     Time,
     lastOfNonEmptyArray,
-    makeIdForHumanConsumption,
+    makeFigmaId,
     bind,
 } from "@ourworldindata/utils"
 import { computed, makeObservable } from "mobx"
@@ -147,7 +147,7 @@ export class StackedAreas extends React.Component<AreasProps> {
 
             return (
                 <path
-                    id={makeIdForHumanConsumption(series.seriesName)}
+                    id={makeFigmaId(series.seriesName)}
                     className={makeSafeForCSS(series.seriesName) + "-area"}
                     key={series.seriesName + "-area"}
                     strokeLinecap="round"
@@ -186,7 +186,7 @@ export class StackedAreas extends React.Component<AreasProps> {
 
             return (
                 <path
-                    id={makeIdForHumanConsumption(placedSeries.seriesName)}
+                    id={makeFigmaId(placedSeries.seriesName)}
                     className={
                         makeSafeForCSS(placedSeries.seriesName) + "-border"
                     }
@@ -211,12 +211,9 @@ export class StackedAreas extends React.Component<AreasProps> {
 
     override render(): React.ReactElement {
         return (
-            <g
-                className="Areas"
-                id={makeIdForHumanConsumption("stacked-areas")}
-            >
-                <g id={makeIdForHumanConsumption("areas")}>{this.areas}</g>
-                <g id={makeIdForHumanConsumption("borders")}>{this.borders}</g>
+            <g className="Areas" id={makeFigmaId("stacked-areas")}>
+                <g id={makeFigmaId("areas")}>{this.areas}</g>
+                <g id={makeFigmaId("borders")}>{this.borders}</g>
             </g>
         )
     }

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChart.tsx
@@ -7,7 +7,7 @@ import {
     Time,
     getRelativeMouse,
     excludeUndefined,
-    makeIdForHumanConsumption,
+    makeFigmaId,
     guid,
     exposeInstanceOnWindow,
 } from "@ourworldindata/utils"
@@ -509,9 +509,7 @@ export class StackedBarChart
         return (
             <>
                 {this.renderAxis()}
-                <g id={makeIdForHumanConsumption("bars")}>
-                    {this.renderBars()}
-                </g>
+                <g id={makeFigmaId("bars")}>{this.renderBars()}</g>
                 {this.renderLegend()}
             </>
         )

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedBars.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedBars.tsx
@@ -4,10 +4,7 @@ import { observer } from "mobx-react"
 import { SeriesName, Time } from "@ourworldindata/types"
 import { DualAxis } from "../axis/Axis"
 import { BAR_OPACITY, StackedPoint, StackedSeries } from "./StackedConstants"
-import {
-    makeIdForHumanConsumption,
-    makeSafeForCSS,
-} from "@ourworldindata/utils"
+import { makeFigmaId, makeSafeForCSS } from "@ourworldindata/utils"
 import { StackedBarSegment } from "./StackedBarSegment"
 import { CoreColumn } from "@ourworldindata/core-table"
 
@@ -61,7 +58,7 @@ export class StackedBars extends React.Component<StackedBarsProps> {
                     return (
                         <g
                             key={index}
-                            id={makeIdForHumanConsumption(series.seriesName)}
+                            id={makeFigmaId(series.seriesName)}
                             className={
                                 makeSafeForCSS(series.seriesName) + "-segments"
                             }
@@ -78,7 +75,7 @@ export class StackedBars extends React.Component<StackedBarsProps> {
                                 return (
                                     <StackedBarSegment
                                         key={index}
-                                        id={makeIdForHumanConsumption(
+                                        id={makeFigmaId(
                                             formatColumn.formatTime(bar.time)
                                         )}
                                         bar={bar}

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBars.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBars.tsx
@@ -7,7 +7,7 @@ import {
     Time,
     HorizontalAlign,
     EntityName,
-    makeIdForHumanConsumption,
+    makeFigmaId,
     dyFromAlign,
     exposeInstanceOnWindow,
     bind,
@@ -362,7 +362,7 @@ export class StackedDiscreteBars
         return (
             <g
                 key={entityName}
-                id={makeIdForHumanConsumption(entityName)}
+                id={makeFigmaId(entityName)}
                 className="bar"
                 transform={`translate(0, ${state.translateY ?? 0})`}
                 opacity={opacity}
@@ -437,7 +437,7 @@ export class StackedDiscreteBars
         return (
             <>
                 {this.renderAxis()}
-                <g id={makeIdForHumanConsumption("bars")}>
+                <g id={makeFigmaId("bars")}>
                     {this.placedItems.map((item) =>
                         this.renderRow({
                             data: item,
@@ -522,14 +522,14 @@ export class StackedDiscreteBars
 
         return (
             <g
-                id={makeIdForHumanConsumption(bar.seriesName)}
+                id={makeFigmaId(bar.seriesName)}
                 onMouseEnter={(): void =>
                     props?.onMouseEnter(entity, bar.seriesName)
                 }
                 onMouseLeave={props?.onMouseLeave}
             >
                 <rect
-                    id={makeIdForHumanConsumption("bar")}
+                    id={makeFigmaId("bar")}
                     x={0}
                     y={0}
                     transform={`translate(${barX}, ${-barHeight / 2})`}

--- a/packages/@ourworldindata/grapher/src/verticalLabels/VerticalLabels.tsx
+++ b/packages/@ourworldindata/grapher/src/verticalLabels/VerticalLabels.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { makeIdForHumanConsumption } from "@ourworldindata/utils"
+import { makeFigmaId } from "@ourworldindata/utils"
 import { SeriesName } from "@ourworldindata/types"
 import { SeriesLabel } from "../seriesLabel/SeriesLabel.js"
 import { darkenColorForText } from "../color/ColorUtils.js"
@@ -28,10 +28,7 @@ export function VerticalLabels({
     const { renderSeries, annotatedSeries, textAnchor } = state
 
     return (
-        <g
-            id={makeIdForHumanConsumption("vertical-labels")}
-            transform={`translate(${x}, 0)`}
-        >
+        <g id={makeFigmaId("vertical-labels")} transform={`translate(${x}, 0)`}>
             {interactive && (
                 <InteractionOverlays
                     series={state.placedSeries}
@@ -65,19 +62,13 @@ function Labels({
     onMouseLeave?: (key: SeriesName) => void
 }): React.ReactElement {
     return (
-        <g
-            id={makeIdForHumanConsumption("text-labels")}
-            style={{ pointerEvents: "none" }}
-        >
+        <g id={makeFigmaId("text-labels")} style={{ pointerEvents: "none" }}>
             {series.map((series, index) => {
                 const color = darkenColorForText(series.color)
                 return (
                     <SeriesLabel
                         key={getSeriesKey(series, index)}
-                        id={makeIdForHumanConsumption(
-                            "label",
-                            series.seriesName
-                        )}
+                        id={makeFigmaId("label", series.seriesName)}
                         state={series.seriesLabel}
                         x={series.labelCoords.x}
                         y={series.labelCoords.y}
@@ -101,7 +92,7 @@ function Annotations({
 }): React.ReactElement | null {
     return (
         <g
-            id={makeIdForHumanConsumption("text-annotations")}
+            id={makeFigmaId("text-annotations")}
             style={{ pointerEvents: "none" }}
         >
             {series.map((series, index) => {
@@ -135,10 +126,7 @@ function ConnectorLines({
     series: RenderLabelSeries[]
 }): React.ReactElement {
     return (
-        <g
-            id={makeIdForHumanConsumption("connectors")}
-            style={{ pointerEvents: "none" }}
-        >
+        <g id={makeFigmaId("connectors")} style={{ pointerEvents: "none" }}>
             {series.map((series, index) => {
                 const { startX, endX } = series.connectorLineCoords
                 const {
@@ -158,7 +146,7 @@ function ConnectorLines({
 
                 return (
                     <path
-                        id={makeIdForHumanConsumption(series.seriesName)}
+                        id={makeFigmaId(series.seriesName)}
                         key={getSeriesKey(series, index)}
                         d={d}
                         stroke={lineColor}

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -192,9 +192,7 @@ function makeSafeForFigma(name: string): string {
  *
  * Note that these IDs are not meant to be used in CSS!
  */
-export function makeIdForHumanConsumption(
-    ...unsafeKeys: (string | undefined)[]
-): string {
+export function makeFigmaId(...unsafeKeys: (string | undefined)[]): string {
     return makeSafeForFigma(unsafeKeys.filter((key) => key).join("__"))
 }
 

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -10,7 +10,7 @@ export {
     getRelativeMouse,
     exposeInstanceOnWindow,
     makeSafeForCSS,
-    makeIdForHumanConsumption,
+    makeFigmaId,
     formatDay,
     formatYear,
     numberMagnitude,


### PR DESCRIPTION
## Context

This PR refactors the ID generation for SVG elements in the grapher by renaming `makeIdForHumanConsumption` to `makeFigmaId` to better reflect its purpose of creating IDs that are useful for design tools like Figma.

## Testing guidance

Step-by-step instructions on how to test this change:

1. Verify that all chart types render correctly with proper SVG element IDs
2. Check that exported SVGs maintain readable element IDs for design tools
3. Test various chart configurations (line charts, bar charts, scatter plots, maps, etc.)
4. Ensure no functionality is broken since this is purely a naming change

- [ ] Does the change work in the archive?
- [ ] Does the staging experience have sign-off from product stakeholders?

## Checklist

### Before merging

- [ ] Changes to CSS/HTML were checked on Desktop and Mobile Safari at all three breakpoints
- [ ] Changes to HTML were checked for accessibility concerns