### PR TITLE
🔨 drop unused stack modes from chart configs

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
@@ -421,7 +421,7 @@ export class GrapherState
      */
     hideTimeline: boolean | undefined = undefined
 
-    /** Stack mode. Only absolute and relative are actively used. */
+    /** Stack mode */
     stackMode = StackMode.absolute
 
     /** Whether to zoom to the selected data points */

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.009.yaml
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.009.yaml
@@ -486,8 +486,6 @@ properties:
         enum:
             - absolute
             - relative
-            - grouped
-            - stacked
     zoomToSelection:
         type: boolean
         default: false


### PR DESCRIPTION
The two `stackMode` options `grouped` and `stacked` don't have an implementation and no chart configs in the db have this setting