### PR TITLE
🔨 decouple hideLegend from map charts

### DIFF
--- a/packages/@ourworldindata/grapher/src/facet/FacetMap.tsx
+++ b/packages/@ourworldindata/grapher/src/facet/FacetMap.tsx
@@ -291,7 +291,7 @@ export class FacetMap
                 table,
                 transformedTable: transformedTableFromGrapher,
                 fontSize: facetFontSize,
-                showLegend: false,
+                hideMapLegend: true,
                 backgroundColor,
                 isStatic,
                 mapColumnSlug,

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
@@ -238,7 +238,7 @@ export class MapChart
             legendStyleConfig,
         } = this
 
-        if (this.manager.showLegend) return undefined
+        if (!this.manager.hideMapLegend) return undefined
 
         return {
             numericLegendData,
@@ -537,7 +537,8 @@ export class MapChart
         | undefined {
         if (this.manager.isDisplayedAlongsideComplementaryTable)
             return undefined
-        return this.manager.showLegend && this.categoricalLegendData.length > 1
+        return !this.manager.hideMapLegend &&
+            this.categoricalLegendData.length > 1
             ? new HorizontalCategoricalColorLegend({ manager: this })
             : undefined
     }
@@ -547,7 +548,7 @@ export class MapChart
         | undefined {
         if (this.manager.isDisplayedAlongsideComplementaryTable)
             return undefined
-        return this.manager.showLegend && this.numericLegendData.length > 1
+        return !this.manager.hideMapLegend && this.numericLegendData.length > 1
             ? new HorizontalNumericColorLegend({ manager: this })
             : undefined
     }

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapChartConstants.ts
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapChartConstants.ts
@@ -143,6 +143,7 @@ export interface MapChartManager extends ChartManager {
     highlightedTimesInTooltip?: [Time, Time]
     mapViewport?: MapViewport
     isFaceted?: boolean
+    hideMapLegend?: boolean
     logGrapherInteractionEvent?: (
         action: GrapherInteractionEvent,
         target?: string


### PR DESCRIPTION
Not really necessary now that `hideLegend` can't be set by authors, but still a good safety measure.

Dropping this because it doesn't serve a purpose anymore