### PR TITLE
🎉 (scatters) add support for hiding entity labels

### DIFF
--- a/adminSiteClient/EditorFeatures.tsx
+++ b/adminSiteClient/EditorFeatures.tsx
@@ -66,7 +66,8 @@ export class EditorFeatures {
         return (
             this.grapherState.hasLineChart ||
             this.grapherState.hasSlopeChart ||
-            this.grapherState.hasStackedArea
+            this.grapherState.hasStackedArea ||
+            this.grapherState.hasScatter
         )
     }
 

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
@@ -513,6 +513,7 @@ export class ScatterPlotChart
                 tooltipSeriesName={this.tooltipSeries?.seriesName}
                 disableIntroAnimation={this.manager.disableIntroAnimation}
                 hideScatterLabels={this.hideScatterLabels}
+                hideEntityLabels={!this.manager.showSeriesLabels}
                 onMouseEnter={this.onScatterMouseEnter}
                 onMouseLeave={this.onScatterMouseLeave}
                 onClick={this.onScatterClick}

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChartConstants.ts
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChartConstants.ts
@@ -142,6 +142,7 @@ export interface ScatterPointsWithLabelsProps {
     noDataModalManager: NoDataModalManager
     disableIntroAnimation?: boolean
     hideScatterLabels?: boolean
+    hideEntityLabels?: boolean
     quadtree?: Quadtree<ScatterPointQuadtreeNode>
     backgroundColor?: Color
     hideFocusRing?: boolean

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPointsWithLabels.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPointsWithLabels.tsx
@@ -129,6 +129,10 @@ export class ScatterPointsWithLabels extends React.Component<ScatterPointsWithLa
         return !!this.props.hideScatterLabels
     }
 
+    @computed private get hideEntityLabels(): boolean {
+        return !!this.props.hideEntityLabels
+    }
+
     private getPointRadius(value: number | undefined): number {
         const radius =
             value !== undefined
@@ -257,10 +261,14 @@ export class ScatterPointsWithLabels extends React.Component<ScatterPointsWithLa
             (l) => labelPriority(l),
             SortOrder.desc
         )
-        if (this.focusedSeriesNames.length > 0)
+        if (this.focusedSeriesNames.length > 0) {
             this.hideUnselectedLabels(labelsByPriority)
+        }
         if (this.hideScatterLabels) {
             this.hideLabels(labelsByPriority, this.hoveredSeriesNames.length)
+        }
+        if (this.hideEntityLabels) {
+            this.hideEndLabels(labelsByPriority)
         }
 
         this.hideCollidingLabelsByPriority(labelsByPriority)
@@ -274,6 +282,12 @@ export class ScatterPointsWithLabels extends React.Component<ScatterPointsWithLa
     ): void {
         labelsByPriority
             .filter((label) => !(label.series.isHover && nHoveredLabels === 1))
+            .forEach((label) => (label.isHidden = true))
+    }
+
+    private hideEndLabels(labelsByPriority: ScatterLabel[]): void {
+        labelsByPriority
+            .filter((label) => label.isEnd)
             .forEach((label) => (label.isHidden = true))
     }
 


### PR DESCRIPTION
Resolves https://github.com/owid/owid-grapher/issues/6055

Adds `hideSeriesLabels` support for scatter plots. There is also `hideScatterLabels` which hides all labels. `hideSeriesLabels` only hides the entity labels.

Example: http://staging-site-hide-entity-labels-in-scatte/admin/charts/625/edit?tab=customize