### PR TITLE
🔨 refactor isDisplayedAlongsideComplementaryTable

### DIFF
--- a/functions/_common/explorerHandlers.ts
+++ b/functions/_common/explorerHandlers.ts
@@ -66,9 +66,9 @@ async function initGrapherForExplorerView(
 
     if (options.grapherProps?.variant)
         explorer.grapherState.variant = options.grapherProps.variant
-    if (options.grapherProps?.isDisplayedAlongsideComplementaryTable)
-        explorer.grapherState.isDisplayedAlongsideComplementaryTable =
-            options.grapherProps.isDisplayedAlongsideComplementaryTable
+    if (options.grapherProps?.useMinimalLabeling)
+        explorer.grapherState.useMinimalLabeling =
+            options.grapherProps.useMinimalLabeling
     explorer.grapherState.initialOptions = { baseFontSize: options.fontSize }
 
     return {

--- a/functions/_common/imageOptions.ts
+++ b/functions/_common/imageOptions.ts
@@ -90,7 +90,7 @@ const getThumbnailOptions = (params: URLSearchParams): ImageOptions => {
 
     if (params.has("imMinimal")) {
         if (!options.grapherProps) options.grapherProps = {}
-        options.grapherProps.isDisplayedAlongsideComplementaryTable =
+        options.grapherProps.useMinimalLabeling =
             params.get("imMinimal")! === "1"
     }
 
@@ -128,7 +128,7 @@ export const extractOptions = (params: URLSearchParams): ImageOptions => {
         if (!options.grapherProps) options.grapherProps = {}
         options.grapherProps.variant = GrapherVariant.Uncaptioned
         if (params.has("imMinimal")) {
-            options.grapherProps.isDisplayedAlongsideComplementaryTable =
+            options.grapherProps.useMinimalLabeling =
                 params.get("imMinimal")! === "1"
         }
     }

--- a/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChart.tsx
@@ -728,11 +728,7 @@ export class DiscreteBarChart
     }
 
     @computed private get showColorLegend(): boolean {
-        return (
-            this.hasColorLegend &&
-            !!this.manager.showLegend &&
-            !this.manager.isDisplayedAlongsideComplementaryTable
-        )
+        return this.hasColorLegend && !!this.manager.showLegend
     }
 
     @computed get legendX(): number {

--- a/packages/@ourworldindata/grapher/src/chart/ChartManager.ts
+++ b/packages/@ourworldindata/grapher/src/chart/ChartManager.ts
@@ -33,7 +33,7 @@ export interface ChartManager {
     transformedTable?: OwidTable
 
     variant?: GrapherVariant
-    isDisplayedAlongsideComplementaryTable?: boolean
+    useMinimalLabeling?: boolean
     chartAreaPadding?: number
 
     isExportingToSvgOrPng?: boolean

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -85,7 +85,7 @@ export interface GrapherProgrammaticInterface extends GrapherInterface {
     baseFontSize?: number
     staticBounds?: Bounds
     variant?: GrapherVariant
-    isDisplayedAlongsideComplementaryTable?: boolean
+    useMinimalLabeling?: boolean
 
     hideTitle?: boolean
     hideSubtitle?: boolean

--- a/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
@@ -526,11 +526,12 @@ export class GrapherState
     hideLegend: boolean | undefined = false
 
     /**
-     * Indicates whether the chart is embedded alongside a complementary table.
-     * If that's the case, the chart can be simplified (e.g. hide legends or
-     * annotations) since the table serves as an additional source of information.
+     * Minimal labeling is used in search when a thumbnail is embedded
+     * alongside a complementary table because the table already provides a lot
+     * of information, which is why the chart can be simplified to avoid
+     * redundancy and visual clutter
      */
-    isDisplayedAlongsideComplementaryTable = false
+    useMinimalLabeling = false
 
     // Bounds
     staticBounds: Bounds = DEFAULT_GRAPHER_BOUNDS
@@ -736,7 +737,7 @@ export class GrapherState
             hasTableTab: observable,
             hideShareButton: observable,
             hideExploreTheDataButton: observable,
-            isDisplayedAlongsideComplementaryTable: observable,
+            useMinimalLabeling: observable,
         })
 
         this.updateFromObject(options)
@@ -1451,6 +1452,9 @@ export class GrapherState
     }
 
     @computed get showLegend(): boolean {
+        // Don't show any legends in minimal mode
+        if (this.useMinimalLabeling) return false
+
         // Hide the legend for stacked bar charts if the legend only ever shows a single entity
         if (this.isOnStackedBarTab) {
             const seriesStrategy =

--- a/packages/@ourworldindata/grapher/src/facet/FacetChart.tsx
+++ b/packages/@ourworldindata/grapher/src/facet/FacetChart.tsx
@@ -642,7 +642,7 @@ export class FacetChart
     @computed private get showLegend(): boolean {
         const { isNumericLegend, categoricalLegendData, numericLegendData } =
             this
-        if (this.manager.isDisplayedAlongsideComplementaryTable) return false
+        if (this.manager.useMinimalLabeling) return false
         const hasBins =
             categoricalLegendData.length > 0 || numericLegendData.length > 0
         if (!hasBins) return false

--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
@@ -738,11 +738,7 @@ export class LineChart
     }
 
     @computed private get hasColorLegend(): boolean {
-        return (
-            this.hasColorScale &&
-            !!this.manager.showLegend &&
-            !this.manager.isDisplayedAlongsideComplementaryTable
-        )
+        return this.hasColorScale && !!this.manager.showLegend
     }
 
     @computed get legendX(): number {

--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChartThumbnail.tsx
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChartThumbnail.tsx
@@ -263,8 +263,7 @@ export class LineChartThumbnail
         | undefined {
         if (!this.manager.showSeriesLabels) return undefined
 
-        const showEntityNames =
-            !this.manager.isDisplayedAlongsideComplementaryTable
+        const showValueLabelsOnly = this.manager.useMinimalLabeling
 
         let labelCandidateSeries = this.chartState.series
 
@@ -298,9 +297,9 @@ export class LineChartThumbnail
                 const value = startPoint?.y ?? 0
 
                 const yPosition = this.outerBoundsVerticalAxis.place(value)
-                const label = showEntityNames
-                    ? seriesName
-                    : this.formatLabel(value)
+                const label = showValueLabelsOnly
+                    ? this.formatLabel(value)
+                    : seriesName
 
                 const color = this.chartState.hasColorScale
                     ? darkenColorForLine(
@@ -324,8 +323,10 @@ export class LineChartThumbnail
         return new SimpleVerticalLabelsState(series, {
             fontSize: this.labelFontSize,
             fontWeight: 500,
-            maxWidth: showEntityNames ? 0.25 * this.bounds.width : undefined,
-            minSpacing: showEntityNames ? 5 : 2,
+            maxWidth: showValueLabelsOnly
+                ? undefined
+                : 0.25 * this.bounds.width,
+            minSpacing: showValueLabelsOnly ? 2 : 5,
             yRange: this.labelsRange,
             resolveCollision: (
                 s1: InitialSimpleLabelSeries,

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
@@ -533,8 +533,6 @@ export class MapChart
     @computed private get categoryLegend():
         | HorizontalCategoricalColorLegend
         | undefined {
-        if (this.manager.isDisplayedAlongsideComplementaryTable)
-            return undefined
         return this.manager.showLegend && this.categoricalLegendData.length > 1
             ? new HorizontalCategoricalColorLegend({ manager: this })
             : undefined
@@ -543,8 +541,6 @@ export class MapChart
     @computed private get numericLegend():
         | HorizontalNumericColorLegend
         | undefined {
-        if (this.manager.isDisplayedAlongsideComplementaryTable)
-            return undefined
         return this.manager.showLegend && this.numericLegendData.length > 1
             ? new HorizontalNumericColorLegend({ manager: this })
             : undefined

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
@@ -288,7 +288,7 @@ export class ScatterPlotChart
             this.xColumn.isTimeColumn ||
             this.yColumn.isTimeColumn ||
             this.manager.isRelativeMode ||
-            this.manager.isDisplayedAlongsideComplementaryTable
+            !this.manager.showLegend
         )
             return undefined
 
@@ -324,10 +324,7 @@ export class ScatterPlotChart
     @computed private get verticalColorLegend():
         | VerticalColorLegend
         | undefined {
-        if (
-            this.categoricalLegendData.length === 0 ||
-            this.manager.isDisplayedAlongsideComplementaryTable
-        )
+        if (this.categoricalLegendData.length === 0 || !this.manager.showLegend)
             return undefined
         return new VerticalColorLegend({ manager: this })
     }
@@ -568,6 +565,8 @@ export class ScatterPlotChart
 
     @computed private get sizeLegend(): ScatterSizeLegend | undefined {
         if (this.chartState.isConnected || this.sizeColumn.isMissing)
+            return undefined
+        if (!this.manager.showLegend && !this.manager.useMinimalLabeling)
             return undefined
         return new ScatterSizeLegend(this)
     }

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChartThumbnail.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChartThumbnail.tsx
@@ -246,15 +246,16 @@ export class SlopeChartThumbnail
         | undefined {
         if (!this.manager.showSeriesLabels) return undefined
 
-        const showEntityNames =
-            !this.manager.isDisplayedAlongsideComplementaryTable
+        const showValueLabelsOnly = this.manager.useMinimalLabeling
 
         const series = this.labelCandidateSeries.map((series) => {
             const { seriesName, color } = series
             const firstPoint = series.start
             const value = firstPoint?.value ?? 0
             const yPosition = this.outerBoundsVerticalAxis.place(value)
-            const label = showEntityNames ? seriesName : this.formatLabel(value)
+            const label = showValueLabelsOnly
+                ? this.formatLabel(value)
+                : seriesName
             return {
                 seriesName,
                 value,
@@ -268,8 +269,10 @@ export class SlopeChartThumbnail
         return new SimpleVerticalLabelsState(series, {
             fontSize: this.labelFontSize,
             fontWeight: 500,
-            maxWidth: showEntityNames ? 0.25 * this.bounds.width : undefined,
-            minSpacing: showEntityNames ? 5 : 2,
+            maxWidth: showValueLabelsOnly
+                ? undefined
+                : 0.25 * this.bounds.width,
+            minSpacing: showValueLabelsOnly ? 2 : 5,
             yRange: this.labelsRange,
             resolveCollision: (
                 s1: InitialSimpleLabelSeries,

--- a/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChart.tsx
@@ -367,7 +367,7 @@ export class MarimekkoChart
     @computed private get showLegend(): boolean {
         return (
             (!!this.colorColumnSlug || this.categoricalLegendData.length > 1) &&
-            !this.manager.isDisplayedAlongsideComplementaryTable
+            !!this.manager.showLegend
         )
     }
 

--- a/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChartThumbnail.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChartThumbnail.tsx
@@ -68,7 +68,7 @@ export class MarimekkoChartThumbnail
     }
 
     @computed private get shouldShowVerticalAxis(): boolean {
-        return !!this.manager.isDisplayedAlongsideComplementaryTable
+        return !!this.manager.useMinimalLabeling
     }
 
     @computed private get yAxisConfig(): AxisConfig {

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
@@ -198,8 +198,7 @@ export class StackedAreaChart
 
     @computed private get showLegend(): boolean {
         return (
-            !!this.manager.showSeriesLabels &&
-            !this.manager.isDisplayedAlongsideComplementaryTable
+            !!this.manager.showSeriesLabels && !this.manager.useMinimalLabeling
         )
     }
 

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChartThumbnail.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChartThumbnail.tsx
@@ -128,10 +128,7 @@ export class StackedAreaChartThumbnail
     @computed private get verticalLabelsState():
         | SimpleVerticalLabelsState
         | undefined {
-        if (
-            !this.manager.showSeriesLabels ||
-            this.manager.isDisplayedAlongsideComplementaryTable
-        )
+        if (!this.manager.showSeriesLabels || this.manager.useMinimalLabeling)
             return undefined
 
         const series = excludeUndefined(

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChart.tsx
@@ -303,10 +303,7 @@ export class StackedBarChart
     }
 
     @computed private get showLegend(): boolean {
-        return (
-            !!this.manager.showLegend &&
-            !this.manager.isDisplayedAlongsideComplementaryTable
-        )
+        return !!this.manager.showLegend
     }
 
     @computed private get sidebarWidth(): number {

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChartThumbnail.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChartThumbnail.tsx
@@ -133,11 +133,7 @@ export class StackedBarChartThumbnail
     @computed private get verticalLabelsState():
         | SimpleVerticalLabelsState
         | undefined {
-        if (
-            !this.manager.showLegend ||
-            this.manager.isDisplayedAlongsideComplementaryTable
-        )
-            return undefined
+        if (!this.manager.showLegend) return undefined
 
         const series = excludeUndefined(
             this.chartState.series.map((series, seriesIndex) => {

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBarChart.tsx
@@ -129,11 +129,7 @@ export class StackedDiscreteBarChart
     }
 
     @computed private get showLegend(): boolean {
-        return (
-            !this.props.hideLegend &&
-            !!this.manager.showLegend &&
-            !this.manager.isDisplayedAlongsideComplementaryTable
-        )
+        return !this.props.hideLegend && !!this.manager.showLegend
     }
 
     @computed private get boundsWithoutLegend(): Bounds {


### PR DESCRIPTION
## Context

This PR refactors the chart legend and labeling system by splitting the overloaded `hideLegend` property and renaming `isDisplayedAlongsideComplementaryTable` to `useMinimalLabeling` for better semantic clarity.

The main issues addressed:
- `hideLegend` was controlling both entity name labels (line endpoints) and categorical legends (color swatches), causing bugs where line chart settings would affect map legends
- `isDisplayedAlongsideComplementaryTable` had an unclear name that described context rather than functionality

## Screenshots / Videos / Diagrams

No UI changes - this is a refactoring that maintains existing visual behavior while improving the underlying architecture.

## Testing guidance

- [ ] Verify that line charts with `hideLegend: true` still hide endpoint labels correctly
- [ ] Verify that stacked bar charts with `hideLegend: true` still hide categorical legends
- [ ] Verify that map charts are no longer affected by line chart legend settings
- [ ] Test thumbnail generation with `imMinimal=1` parameter to ensure minimal labeling works
- [ ] Check that faceted charts properly suppress legends in child components
- [ ] Verify scatter plot size legends appear correctly in minimal thumbnail mode
- [ ] Does the change work in the archive?
- [ ] Does the staging experience have sign-off from product stakeholders?

## Checklist

### Before merging

- [ ] The DB types in the ETL have been updated (if applicable for the renamed property)