### PR TITLE
enhance: add none as peerCountryStrategy

### DIFF
--- a/adminSiteClient/EditorDataTab.tsx
+++ b/adminSiteClient/EditorDataTab.tsx
@@ -804,6 +804,7 @@ class PeerCountrySection<
             "Countries that represent the data range",
         [PeerCountryStrategy.DefaultSelection]: "Default selection",
         [PeerCountryStrategy.Neighbors]: "Neighboring countries",
+        [PeerCountryStrategy.None]: "No peer countries (useful in search)",
     }
 
     @computed get grapherState() {
@@ -819,7 +820,7 @@ class PeerCountrySection<
             label: this.peerCountryStrategyLabels[strategy],
         }))
 
-        return [{ value: undefined, label: "None" }, ...options]
+        return [{ value: undefined, label: "Unset" }, ...options]
     }
 
     @action.bound onSelectPeerCountryStrategy(value: string | undefined) {

--- a/packages/@ourworldindata/grapher/src/core/PeerCountrySelection.ts
+++ b/packages/@ourworldindata/grapher/src/core/PeerCountrySelection.ts
@@ -74,6 +74,7 @@ type SelectPeerCountriesParams =
       >
     | WithStrategy<SelectByDataRangeParams, PeerCountryStrategy.DataRange>
     | WithStrategy<SelectNeighborsAsPeersParams, PeerCountryStrategy.Neighbors>
+    | { peerCountryStrategy: PeerCountryStrategy.None }
 
 /** Check if the given string is a valid PeerCountryStrategy */
 function isValidPeerCountryStrategy(
@@ -145,6 +146,7 @@ export async function selectPeerCountries(
     params: SelectPeerCountriesParams
 ): Promise<EntityName[]> {
     return match(params)
+        .with({ peerCountryStrategy: PeerCountryStrategy.None }, () => [])
         .with(
             { peerCountryStrategy: PeerCountryStrategy.DefaultSelection },
             ({ defaultSelection }) => defaultSelection

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.009.yaml
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.009.yaml
@@ -227,6 +227,7 @@ properties:
             - "population": Use countries with similar population as peers
             - "dataRange": Use countries that represent the data range as peers
             - "neighbors": Use neighboring countries as peers
+            - "none": Don't automatically add peer countries (useful in search)
         enum:
             - defaultSelection
             - parentRegions
@@ -234,6 +235,7 @@ properties:
             - population
             - dataRange
             - neighbors
+            - none
     entityType:
         type: string
         default: country or region

--- a/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
+++ b/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
@@ -225,6 +225,8 @@ export enum PeerCountryStrategy {
     DefaultSelection = "defaultSelection",
     /** Use geographically neighboring countries as peers */
     Neighbors = "neighbors",
+    /** Don't automatically add any peer countries (useful in search) */
+    None = "none",
 }
 
 export type PeerCountryStrategyQueryParam = PeerCountryStrategy | "auto"


### PR DESCRIPTION
It can be useful to set the peerCountryStrategy to 'none' if no countries should be added as peers in search