### PR TITLE
🐛 fix linked chart previews not working on the /latest page

### DIFF
--- a/packages/@ourworldindata/types/src/domainTypes/Various.ts
+++ b/packages/@ourworldindata/types/src/domainTypes/Various.ts
@@ -37,6 +37,7 @@ export enum SiteFooterContext {
     explorerIndexPage = "explorerIndexPage",
     default = "default",
     dataInsightsIndexPage = "data-insights-index-page",
+    latestPage = "latestPage",
     searchPage = "search-page",
     subscribePage = "subscribe-page",
 }

--- a/site/LatestPage.tsx
+++ b/site/LatestPage.tsx
@@ -2,155 +2,23 @@ import { Head } from "./Head.js"
 import { SiteHeader } from "./SiteHeader.js"
 import { SiteFooter } from "./SiteFooter.js"
 import {
-    formatAuthors,
     ImageMetadata,
-    LatestDataInsight,
     LatestPageItem,
     LinkedAuthor,
     LinkedChart,
-    OwidGdocAnnouncementInterface,
     OwidGdocMinimalPostInterface,
-    OwidGdocType,
+    serializeJSONForHTML,
+    SiteFooterContext,
 } from "@ourworldindata/utils"
 import { Html } from "./Html.js"
-import { AttachmentsContext } from "./gdocs/AttachmentsContext.js"
-import { AnnouncementPageContent } from "./gdocs/pages/Announcement.js"
-import { getPrefixedGdocPath } from "@ourworldindata/components"
-import Image from "./gdocs/components/Image.js"
-import { ArticleBlocks } from "./gdocs/components/ArticleBlocks.js"
-import DataInsightDateline from "./gdocs/components/DataInsightDateline.js"
-import cx from "classnames"
-import { Pagination } from "./Pagination.js"
-import { NewsletterSubscriptionContext } from "./newsletter.js"
-import { NewsletterSignupBlock } from "./NewsletterSignupBlock.js"
+import {
+    LatestPageContent,
+    LatestPageContentProps,
+    LATEST_PAGE_CONTAINER_ID,
+    _OWID_LATEST_PAGE_DATA,
+} from "./LatestPageContent.js"
 
-const COMMON_CLASSES =
-    "grid grid-cols-6 span-cols-6 col-start-5 span-md-cols-10 col-md-start-2 span-sm-cols-14 col-sm-start-1"
-
-const LatestPageDataInsight = (props: { data: LatestDataInsight }) => {
-    const href = getPrefixedGdocPath("", {
-        slug: props.data.slug,
-        content: { type: OwidGdocType.DataInsight },
-    })
-    const firstImage = props.data.content.body.find(
-        (block) => block.type === "image"
-    )
-    const otherBlocks = props.data.content.body.filter(
-        (block) => block !== firstImage
-    )
-
-    return (
-        <article
-            id={props.data.slug}
-            className={cx("latest-page__data-insight", COMMON_CLASSES)}
-        >
-            <DataInsightDateline
-                publishedAt={props.data.publishedAt}
-                className="latest-page__item-dateline h6-black-caps span-cols-4"
-            />
-            <p className="latest-page__item-type h6-black-caps span-cols-2 col-start-5">
-                Data Insight
-            </p>
-            <a
-                href={href}
-                aria-label={props.data.content.title}
-                className="latest-page__data-insight-link span-cols-6"
-            >
-                {firstImage && (
-                    <Image
-                        className="latest-page__data-insight-image"
-                        filename={firstImage.filename}
-                        containerType="span-5"
-                        shouldLightbox={false}
-                    />
-                )}
-                <div className="latest-page__data-insight-content">
-                    <h2 className="latest-page__data-insight-title body-1-bold">
-                        {props.data.content.title}
-                    </h2>
-                    <div className="latest-page__data-insight-blocks">
-                        <ArticleBlocks
-                            blocks={otherBlocks}
-                            shouldRenderLinks={false}
-                        />
-                    </div>
-                </div>
-            </a>
-        </article>
-    )
-}
-
-const LatestPageArticle = (props: { data: OwidGdocMinimalPostInterface }) => {
-    const featuredImage = props.data["featured-image"]
-    const href = getPrefixedGdocPath("", {
-        slug: props.data.slug,
-        content: { type: OwidGdocType.Article },
-    })
-    return (
-        <article
-            id={props.data.slug}
-            className={cx("latest-page__article", COMMON_CLASSES)}
-        >
-            <DataInsightDateline
-                publishedAt={new Date(props.data.publishedAt!)}
-                className="latest-page__item-dateline h6-black-caps span-cols-4"
-            />
-            <p className="latest-page__item-type h6-black-caps span-cols-2 col-start-5">
-                Article
-            </p>
-            <a
-                href={href}
-                aria-label={props.data.title}
-                className="latest-page__article-link span-cols-6"
-            >
-                {featuredImage && (
-                    <Image
-                        filename={featuredImage}
-                        className="latest-page__article-image"
-                        shouldLightbox={false}
-                    />
-                )}
-                <div className="latest-page__article-content">
-                    <h2 className="latest-page__article-title">
-                        {props.data.title}
-                    </h2>
-                    <p className="latest-page__article-excerpt">
-                        {props.data.excerpt}
-                    </p>
-                    <p className="latest-page__article-authors">
-                        {formatAuthors(props.data.authors)}
-                    </p>
-                </div>
-            </a>
-        </article>
-    )
-}
-
-const LatestPageAnnouncement = (props: {
-    data: OwidGdocAnnouncementInterface
-}) => {
-    return (
-        <article
-            id={props.data.slug}
-            className={cx(
-                "latest-page__announcement span-cols-6 col-start-5 span-md-cols-10 col-md-start-2 span-sm-cols-14 col-sm-start-1"
-            )}
-        >
-            <AnnouncementPageContent {...props.data} />
-        </article>
-    )
-}
-
-export const LatestPageItemComponent = (props: { item: LatestPageItem }) => {
-    switch (props.item.type) {
-        case OwidGdocType.Article:
-            return <LatestPageArticle data={props.item.data} />
-        case OwidGdocType.DataInsight:
-            return <LatestPageDataInsight data={props.item.data} />
-        case OwidGdocType.Announcement:
-            return <LatestPageAnnouncement data={props.item.data} />
-    }
-}
+export { LatestPageItemComponent } from "./LatestPageContent.js"
 
 export const LatestPage = (props: {
     posts: LatestPageItem[]
@@ -162,12 +30,18 @@ export const LatestPage = (props: {
     numPages: number
     baseUrl: string
 }) => {
-    const { pageNum, baseUrl, numPages, posts } = props
+    const { pageNum, baseUrl } = props
     const pageTitle = "Latest"
 
-    const renderLatestPageItem = (item: LatestPageItem) => (
-        <LatestPageItemComponent key={item.data.id} item={item} />
-    )
+    const contentProps: LatestPageContentProps = {
+        posts: props.posts,
+        imageMetadata: props.imageMetadata,
+        linkedAuthors: props.linkedAuthors,
+        linkedCharts: props.linkedCharts,
+        linkedDocuments: props.linkedDocuments,
+        pageNum: props.pageNum,
+        numPages: props.numPages,
+    }
 
     return (
         <Html>
@@ -181,43 +55,18 @@ export const LatestPage = (props: {
             />
             <body>
                 <SiteHeader />
-                <AttachmentsContext.Provider
-                    value={{
-                        imageMetadata: props.imageMetadata,
-                        linkedAuthors: props.linkedAuthors,
-                        linkedCharts: props.linkedCharts,
-                        linkedDocuments: props.linkedDocuments,
-                        linkedIndicators: {},
-                        relatedCharts: [],
-                        tags: [],
-                    }}
+                <main
+                    id={LATEST_PAGE_CONTAINER_ID}
+                    className="latest-page grid grid-cols-12-full-width grid-md-cols-12"
                 >
-                    <main className="latest-page grid grid-cols-12-full-width grid-md-cols-12">
-                        <header className="latest-page-header span-cols-14 grid grid-cols-12-full-width">
-                            <h1 className="display-2-semibold span-cols-6 col-start-5 col-md-start-3 span-md-cols-10 col-sm-start-2 span-sm-cols-12">
-                                Latest
-                            </h1>
-                            <p className="latest-page__header-subtitle body-1-regular span-cols-6 col-start-5 col-md-start-3 span-md-cols-10 col-sm-start-2 span-sm-cols-12">
-                                Our latest articles, data updates, and
-                                announcements
-                            </p>
-                        </header>
-                        {posts.slice(0, 2).map(renderLatestPageItem)}
-                        <NewsletterSignupBlock
-                            className="latest-page__newsletter-signup col-start-11 span-cols-3 col-md-start-2 span-md-cols-10 col-sm-start-1 span-sm-cols-14"
-                            context={NewsletterSubscriptionContext.Latest}
-                        />
-                        {posts.slice(2).map(renderLatestPageItem)}
-                        <Pagination
-                            pageNumber={pageNum}
-                            totalPageCount={numPages}
-                            basePath="/latest"
-                            usePagePrefix={true}
-                            className="span-cols-6 col-start-5 span-md-cols-10 col-md-start-2 span-sm-cols-14 col-sm-start-1"
-                        />
-                    </main>
-                </AttachmentsContext.Provider>
-                <SiteFooter />
+                    <LatestPageContent {...contentProps} />
+                </main>
+                <SiteFooter context={SiteFooterContext.latestPage} />
+                <script
+                    dangerouslySetInnerHTML={{
+                        __html: `window.${_OWID_LATEST_PAGE_DATA} = ${serializeJSONForHTML(contentProps)}`,
+                    }}
+                />
             </body>
         </Html>
     )

--- a/site/LatestPageContent.tsx
+++ b/site/LatestPageContent.tsx
@@ -1,58 +1,206 @@
 import {
+    formatAuthors,
     ImageMetadata,
+    LatestDataInsight,
     LatestPageItem,
     LinkedAuthor,
+    LinkedChart,
     OwidGdocAnnouncementInterface,
+    OwidGdocMinimalPostInterface,
     OwidGdocType,
 } from "@ourworldindata/utils"
 import { AttachmentsContext } from "./gdocs/AttachmentsContext.js"
 import { AnnouncementPageContent } from "./gdocs/pages/Announcement.js"
+import { getPrefixedGdocPath } from "@ourworldindata/components"
+import Image from "./gdocs/components/Image.js"
+import { ArticleBlocks } from "./gdocs/components/ArticleBlocks.js"
+import DataInsightDateline from "./gdocs/components/DataInsightDateline.js"
+import cx from "classnames"
+import { Pagination } from "./Pagination.js"
+import { NewsletterSubscriptionContext } from "./newsletter.js"
+import { NewsletterSignupBlock } from "./NewsletterSignupBlock.js"
 
+export const LATEST_PAGE_CONTAINER_ID = "latest-page-container"
 export const _OWID_LATEST_PAGE_DATA = "_OWID_LATEST_PAGE_DATA"
 
-export interface LatestPageProps {
+export interface LatestPageContentProps {
     posts: LatestPageItem[]
     imageMetadata: Record<string, ImageMetadata>
     linkedAuthors: LinkedAuthor[]
+    linkedCharts: Record<string, LinkedChart>
+    linkedDocuments: Record<string, OwidGdocMinimalPostInterface>
+    pageNum: number
+    numPages: number
+}
+
+const COMMON_CLASSES =
+    "grid grid-cols-6 span-cols-6 col-start-5 span-md-cols-10 col-md-start-2 span-sm-cols-14 col-sm-start-1"
+
+const LatestPageDataInsight = (props: { data: LatestDataInsight }) => {
+    const href = getPrefixedGdocPath("", {
+        slug: props.data.slug,
+        content: { type: OwidGdocType.DataInsight },
+    })
+    const firstImage = props.data.content.body.find(
+        (block) => block.type === "image"
+    )
+    const otherBlocks = props.data.content.body.filter(
+        (block) => block !== firstImage
+    )
+
+    return (
+        <article
+            id={props.data.slug}
+            className={cx("latest-page__data-insight", COMMON_CLASSES)}
+        >
+            <DataInsightDateline
+                publishedAt={props.data.publishedAt}
+                className="latest-page__item-dateline h6-black-caps span-cols-4"
+            />
+            <p className="latest-page__item-type h6-black-caps span-cols-2 col-start-5">
+                Data Insight
+            </p>
+            <a
+                href={href}
+                aria-label={props.data.content.title}
+                className="latest-page__data-insight-link span-cols-6"
+            >
+                {firstImage && (
+                    <Image
+                        className="latest-page__data-insight-image"
+                        filename={firstImage.filename}
+                        containerType="span-5"
+                        shouldLightbox={false}
+                    />
+                )}
+                <div className="latest-page__data-insight-content">
+                    <h2 className="latest-page__data-insight-title body-1-bold">
+                        {props.data.content.title}
+                    </h2>
+                    <div className="latest-page__data-insight-blocks">
+                        <ArticleBlocks
+                            blocks={otherBlocks}
+                            shouldRenderLinks={false}
+                        />
+                    </div>
+                </div>
+            </a>
+        </article>
+    )
+}
+
+const LatestPageArticle = (props: { data: OwidGdocMinimalPostInterface }) => {
+    const featuredImage = props.data["featured-image"]
+    const href = getPrefixedGdocPath("", {
+        slug: props.data.slug,
+        content: { type: OwidGdocType.Article },
+    })
+    return (
+        <article
+            id={props.data.slug}
+            className={cx("latest-page__article", COMMON_CLASSES)}
+        >
+            <DataInsightDateline
+                publishedAt={new Date(props.data.publishedAt!)}
+                className="latest-page__item-dateline h6-black-caps span-cols-4"
+            />
+            <p className="latest-page__item-type h6-black-caps span-cols-2 col-start-5">
+                Article
+            </p>
+            <a
+                href={href}
+                aria-label={props.data.title}
+                className="latest-page__article-link span-cols-6"
+            >
+                {featuredImage && (
+                    <Image
+                        filename={featuredImage}
+                        className="latest-page__article-image"
+                        shouldLightbox={false}
+                    />
+                )}
+                <div className="latest-page__article-content">
+                    <h2 className="latest-page__article-title">
+                        {props.data.title}
+                    </h2>
+                    <p className="latest-page__article-excerpt">
+                        {props.data.excerpt}
+                    </p>
+                    <p className="latest-page__article-authors">
+                        {formatAuthors(props.data.authors)}
+                    </p>
+                </div>
+            </a>
+        </article>
+    )
 }
 
 const LatestPageAnnouncement = (props: {
     data: OwidGdocAnnouncementInterface
 }) => {
     return (
-        <article className="latest-page__announcement span-cols-6 col-start-5 span-md-cols-10 col-md-start-2 span-sm-cols-14 col-sm-start-1">
+        <article
+            id={props.data.slug}
+            className={cx(
+                "latest-page__announcement span-cols-6 col-start-5 span-md-cols-10 col-md-start-2 span-sm-cols-14 col-sm-start-1"
+            )}
+        >
             <AnnouncementPageContent {...props.data} />
         </article>
     )
 }
 
-export const LatestPageContent = (props: LatestPageProps) => {
-    const { posts, imageMetadata, linkedAuthors } = props
+export const LatestPageItemComponent = (props: { item: LatestPageItem }) => {
+    switch (props.item.type) {
+        case OwidGdocType.Article:
+            return <LatestPageArticle data={props.item.data} />
+        case OwidGdocType.DataInsight:
+            return <LatestPageDataInsight data={props.item.data} />
+        case OwidGdocType.Announcement:
+            return <LatestPageAnnouncement data={props.item.data} />
+    }
+}
 
-    // Filter only announcements that need hydration (have images with interactive elements)
-    const announcements = posts.filter(
-        (post): post is LatestPageItem & { type: OwidGdocType.Announcement } =>
-            post.type === OwidGdocType.Announcement
+export const LatestPageContent = (props: LatestPageContentProps) => {
+    const { pageNum, numPages, posts } = props
+
+    const renderLatestPageItem = (item: LatestPageItem) => (
+        <LatestPageItemComponent key={item.data.id} item={item} />
     )
 
     return (
         <AttachmentsContext.Provider
             value={{
-                imageMetadata,
-                linkedAuthors,
-                linkedCharts: {},
-                linkedDocuments: {},
+                imageMetadata: props.imageMetadata,
+                linkedAuthors: props.linkedAuthors,
+                linkedCharts: props.linkedCharts,
+                linkedDocuments: props.linkedDocuments,
                 linkedIndicators: {},
                 relatedCharts: [],
                 tags: [],
             }}
         >
-            {announcements.map((announcement) => (
-                <LatestPageAnnouncement
-                    key={announcement.data.id}
-                    data={announcement.data}
-                />
-            ))}
+            <header className="latest-page-header span-cols-14 grid grid-cols-12-full-width">
+                <h1 className="display-2-semibold span-cols-6 col-start-5 col-md-start-3 span-md-cols-10 col-sm-start-2 span-sm-cols-12">
+                    Latest
+                </h1>
+                <p className="latest-page__header-subtitle body-1-regular span-cols-6 col-start-5 col-md-start-3 span-md-cols-10 col-sm-start-2 span-sm-cols-12">
+                    Our latest articles, data updates, and announcements
+                </p>
+            </header>
+            {posts.slice(0, 2).map(renderLatestPageItem)}
+            <NewsletterSignupBlock
+                className="latest-page__newsletter-signup col-start-11 span-cols-3 col-md-start-2 span-md-cols-10 col-sm-start-1 span-sm-cols-14"
+                context={NewsletterSubscriptionContext.Latest}
+            />
+            {posts.slice(2).map(renderLatestPageItem)}
+            <Pagination
+                pageNumber={pageNum}
+                totalPageCount={numPages}
+                basePath="/latest"
+                usePagePrefix={true}
+                className="span-cols-6 col-start-5 span-md-cols-10 col-md-start-2 span-sm-cols-14 col-sm-start-1"
+            />
         </AttachmentsContext.Provider>
     )
 }

--- a/site/gdocs/components/DataInsightDateline.tsx
+++ b/site/gdocs/components/DataInsightDateline.tsx
@@ -30,10 +30,9 @@ export default function DataInsightDateline({
         } else if (date.isYesterday()) {
             formattedDate = "Yesterday"
         } else {
-            formattedDate = publishedAt.toLocaleDateString(
-                "en-US",
-                formatOptions
-            )
+            formattedDate = date
+                .toDate()
+                .toLocaleDateString("en-US", formatOptions)
         }
     } else {
         formattedDate = "Unpublished"

--- a/site/runSiteFooterScripts.tsx
+++ b/site/runSiteFooterScripts.tsx
@@ -27,6 +27,12 @@ import {
     _OWID_DATA_INSIGHTS_INDEX_PAGE_DATA,
     DataInsightsIndexPageContent,
 } from "./DataInsightsIndexPageContent.js"
+import {
+    _OWID_LATEST_PAGE_DATA,
+    LatestPageContent,
+    LatestPageContentProps,
+    LATEST_PAGE_CONTAINER_ID,
+} from "./LatestPageContent.js"
 import { runAllGraphersLoadedListener } from "./runAllGraphersLoadedListener.js"
 import {
     __OWID_EXPLORER_INDEX_PAGE_PROPS,
@@ -124,6 +130,17 @@ async function hydrateDataInsightsIndexPage() {
                 <DataInsightsIndexPageContent {...props} />
             </DebugProvider>
         )
+    }
+}
+
+function hydrateLatestPage() {
+    const props: LatestPageContentProps = (window as any)[
+        _OWID_LATEST_PAGE_DATA
+    ]
+    const container = document.querySelector(`#${LATEST_PAGE_CONTAINER_ID}`)
+
+    if (container && props) {
+        hydrateRoot(container, <LatestPageContent {...props} />)
     }
 }
 
@@ -399,6 +416,13 @@ export const runSiteFooterScripts = async (
             runSiteTools()
             runCookiePreferencesManager()
             runUserSurveyWidget()
+            break
+        case SiteFooterContext.latestPage:
+            hydrateLatestPage()
+            runSiteNavigation(hideDonationFlag)
+            runSiteTools()
+            runCookiePreferencesManager()
+            void runDetailsOnDemand()
             break
         case SiteFooterContext.dynamicCollectionPage:
             // Don't break, run default case too


### PR DESCRIPTION
## Context

Problem: The `/latest` page wasn't being hydrated on the client, so interactive features like `LinkedA` chart preview tooltips  didn't work.

This PR splits the `LatestPage` component into a `LatestPage` wrapper and a `LatestPageContent` so that we can hydrate it like other pages.

There already was an orphaned `LatestPageContent` component lying around. During the development of the latest page, I realized (mistakenly, hence this PR) we didn't need hydration and then forgot to delete it.

It's a shame we now have to embed 90kB (~20kB gzipped) of JSON into each latest page. An alternative would be to write a simple `hydrateLinkedCharts` function that just handles the tippy part, but then the latest page would be its own weird thing that you'd have to remember to check anytime we added a new interactive component in archie.

## Screenshots / Videos / Diagrams

<img width="699" height="814" alt="image" src="https://github.com/user-attachments/assets/5d848011-e24a-48e3-a1b0-f8b4f5fe14fa" />


## Testing guidance

- Publish an announcement that links to a chart
- See it on the /latest page and ensure the preview tooltip shows
- Make sure other /latest page items aren't broken in any way (images still show, links still work, authors still appear, etc)