### PR TITLE
Add option to force a chart to be a datapage

### DIFF
--- a/adminSiteClient/ChartEditor.ts
+++ b/adminSiteClient/ChartEditor.ts
@@ -70,6 +70,7 @@ export interface ChartEditorManager extends AbstractChartEditorManager {
     views?: DbPlainAnalyticsGrapherView
     tags?: DbChartTagJoin[]
     availableTags?: DbChartTagJoin[]
+    forceDatapage?: boolean
 }
 
 export class ChartEditor extends AbstractChartEditor<ChartEditorManager> {
@@ -107,6 +108,10 @@ export class ChartEditor extends AbstractChartEditor<ChartEditorManager> {
 
     @computed get availableTags() {
         return this.manager.availableTags
+    }
+
+    @computed get forceDatapage() {
+        return this.manager.forceDatapage ?? false
     }
 
     /** parent variable id, derived from the config */
@@ -183,6 +188,7 @@ export class ChartEditor extends AbstractChartEditor<ChartEditorManager> {
 
         const query = new URLSearchParams({
             inheritance: shouldEnableInheritance ? "enable" : "disable",
+            forceDatapage: String(this.forceDatapage),
         })
         const targetUrl = isNewGrapher
             ? `/api/charts?${query}`
@@ -228,6 +234,7 @@ export class ChartEditor extends AbstractChartEditor<ChartEditorManager> {
 
         const query = new URLSearchParams({
             inheritance: shouldEnableInheritance ? "enable" : "disable",
+            forceDatapage: String(this.forceDatapage),
         })
         const targetUrl = `/api/charts?${query}`
 

--- a/adminSiteClient/ChartEditorPage.tsx
+++ b/adminSiteClient/ChartEditorPage.tsx
@@ -43,6 +43,7 @@ export class ChartEditorPage
             views: observable,
             tags: observable,
             availableTags: observable,
+            forceDatapage: observable.ref,
         })
     }
 
@@ -52,6 +53,7 @@ export class ChartEditorPage
     views: DbPlainAnalyticsGrapherView | undefined = undefined
     tags: DbChartTagJoin[] | undefined = undefined
     availableTags: MinimalTagWithIsTopic[] | undefined = undefined
+    forceDatapage: boolean | undefined = undefined
 
     patchConfig: GrapherInterface = {}
     parentConfig: GrapherInterface | undefined = undefined
@@ -72,11 +74,17 @@ export class ChartEditorPage
     async fetchParentConfig(): Promise<void> {
         const { grapherId, grapherConfig } = this.props
         if (grapherId !== undefined) {
-            const parent = await this.context.admin.getJSON(
-                `/api/charts/${grapherId}.parent.json`
-            )
+            const [parent, settings] = await Promise.all([
+                this.context.admin.getJSON(
+                    `/api/charts/${grapherId}.parent.json`
+                ),
+                this.context.admin.getJSON(
+                    `/api/charts/${grapherId}.settings.json`
+                ),
+            ])
             this.parentConfig = parent?.config
             this.isInheritanceEnabled = parent?.isActive ?? true
+            this.forceDatapage = settings?.forceDatapage ?? false
         } else if (grapherConfig) {
             const parentIndicatorId =
                 getParentVariableIdFromChartConfig(grapherConfig)
@@ -87,8 +95,10 @@ export class ChartEditorPage
                 )
             }
             this.isInheritanceEnabled = true
+            this.forceDatapage = false
         } else {
             this.isInheritanceEnabled = true
+            this.forceDatapage = false
         }
     }
 

--- a/adminSiteClient/EditorTextTab.tsx
+++ b/adminSiteClient/EditorTextTab.tsx
@@ -352,6 +352,17 @@ export class EditorTextTab<
                         placeholder="e.g. IHME"
                         helpText="Optional variant name for distinguishing charts with the same title"
                     />
+                    {isChartEditorInstance(editor) && (
+                        <Toggle
+                            label="Force to be a data page"
+                            secondaryLabel="Use metadata from the first Y indicator (same behavior as multi-dimensional data pages)."
+                            value={editor.forceDatapage}
+                            onValue={action(
+                                (value: boolean) =>
+                                    (editor.manager.forceDatapage = value)
+                            )}
+                        />
+                    )}
                 </Section>
                 {(this.hasCopyAdminURLButton ||
                     this.hasCopyGrapherURLButton) && (

--- a/adminSiteServer/adminRouter.tsx
+++ b/adminSiteServer/adminRouter.tsx
@@ -163,6 +163,7 @@ getPlainRouteWithROTransaction(
                 await renderPreviewDataPageOrGrapherPage(
                     chart.config,
                     chart.id,
+                    chart.forceDatapage,
                     trx
                 )
             res.send(previewDataPageOrGrapherPage)
@@ -189,6 +190,7 @@ getPlainRouteWithROTransaction(
                 await renderPreviewDataPageOrGrapherPage(
                     chart.config,
                     chart.id,
+                    chart.forceDatapage,
                     trx
                 )
             res.send(previewDataPageOrGrapherPage)

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -134,6 +134,7 @@ import {
     getChartsCsv,
     getChartConfigJson,
     getChartParentJson,
+    getChartSettingsJson,
     getChartPatchConfigJson,
     getChartLogsJson,
     getChartReferencesJson,
@@ -207,6 +208,11 @@ getRouteWithROTransaction(
     apiRouter,
     "/charts/:chartId.parent.json",
     getChartParentJson
+)
+getRouteWithROTransaction(
+    apiRouter,
+    "/charts/:chartId.settings.json",
+    getChartSettingsJson
 )
 getRouteWithROTransaction(
     apiRouter,

--- a/adminSiteServer/apiRoutes/charts.ts
+++ b/adminSiteServer/apiRoutes/charts.ts
@@ -30,6 +30,7 @@ import { NarrativeChartMinimalInformation } from "../../adminSiteClient/ChartEdi
 import { denormalizeLatestCountryData } from "../../baker/countryIndexes.js"
 import {
     getChartConfigById,
+    getForceDatapageByChartId,
     getPatchConfigByChartId,
     getParentByChartConfig,
     isInheritanceEnabledForChart,
@@ -240,9 +241,15 @@ const saveNewChart = async (
     {
         config,
         user,
+        forceDatapage = false,
         // new charts inherit by default
         shouldInherit = true,
-    }: { config: GrapherInterface; user: DbPlainUser; shouldInherit?: boolean }
+    }: {
+        config: GrapherInterface
+        user: DbPlainUser
+        forceDatapage?: boolean
+        shouldInherit?: boolean
+    }
 ): Promise<{
     chartConfigId: Base64String
     patchConfig: GrapherInterface
@@ -278,10 +285,10 @@ const saveNewChart = async (
     const result = await db.knexRawInsert(
         knex,
         `-- sql
-            INSERT INTO charts (configId, isInheritanceEnabled, lastEditedAt, lastEditedByUserId)
-            VALUES (?, ?, ?, ?)
+            INSERT INTO charts (configId, isInheritanceEnabled, forceDatapage, lastEditedAt, lastEditedByUserId)
+            VALUES (?, ?, ?, ?, ?)
         `,
-        [chartConfigId, shouldInherit, new Date(), user.id]
+        [chartConfigId, shouldInherit, forceDatapage, new Date(), user.id]
     )
 
     // The chart config itself has an id field that should store the id of the chart - update the chart now so this is true
@@ -312,6 +319,7 @@ const updateExistingChart = async (
         config: GrapherInterface
         user: DbPlainUser
         chartId: number
+        forceDatapage?: boolean
         // if undefined, keep inheritance as is.
         // if true or false, enable or disable inheritance
         shouldInherit?: boolean
@@ -354,15 +362,18 @@ const updateExistingChart = async (
         fullConfig
     )
 
+    const forceDatapage =
+        params.forceDatapage ?? (await getForceDatapageByChartId(knex, chartId))
+
     // update charts row
     await db.knexRaw(
         knex,
         `-- sql
             UPDATE charts
-            SET isInheritanceEnabled=?, updatedAt=?, lastEditedAt=?, lastEditedByUserId=?
+            SET isInheritanceEnabled=?, forceDatapage=?, updatedAt=?, lastEditedAt=?, lastEditedByUserId=?
             WHERE id = ?
         `,
-        [shouldInherit, now, now, user.id, chartId]
+        [shouldInherit, forceDatapage, now, now, user.id, chartId]
     )
 
     return { chartConfigId, patchConfig, fullConfig }
@@ -374,12 +385,14 @@ export const saveGrapher = async (
         user,
         newConfig,
         existingConfig,
+        forceDatapage,
         shouldInherit,
         referencedVariablesMightChange = true,
     }: {
         user: DbPlainUser
         newConfig: GrapherInterface
         existingConfig?: GrapherInterface
+        forceDatapage?: boolean
         // if undefined, keep inheritance as is.
         // if true or false, enable or disable inheritance
         shouldInherit?: boolean
@@ -449,6 +462,7 @@ export const saveGrapher = async (
             config: newConfig,
             user,
             chartId,
+            forceDatapage,
             shouldInherit,
         })
         chartConfigId = configs.chartConfigId
@@ -458,6 +472,7 @@ export const saveGrapher = async (
         const configs = await saveNewChart(knex, {
             config: newConfig,
             user,
+            forceDatapage,
             shouldInherit,
         })
         chartConfigId = configs.chartConfigId
@@ -685,6 +700,16 @@ export async function getChartParentJson(
     })
 }
 
+export async function getChartSettingsJson(
+    req: Request,
+    res: HandlerResponse,
+    trx: db.KnexReadonlyTransaction
+) {
+    const chartId = expectInt(req.params.chartId)
+    const forceDatapage = await getForceDatapageByChartId(trx, chartId)
+    return { forceDatapage }
+}
+
 export async function getChartPatchConfigJson(
     req: Request,
     res: HandlerResponse,
@@ -791,11 +816,16 @@ export async function createChart(
     if (req.query.inheritance) {
         shouldInherit = req.query.inheritance === "enable"
     }
+    let forceDatapage: boolean | undefined
+    if (req.query.forceDatapage) {
+        forceDatapage = req.query.forceDatapage === "true"
+    }
 
     try {
         const { chartId } = await saveGrapher(trx, {
             user: res.locals.user,
             newConfig: req.body,
+            forceDatapage,
             shouldInherit,
         })
 
@@ -826,6 +856,10 @@ export async function updateChart(
     if (req.query.inheritance) {
         shouldInherit = req.query.inheritance === "enable"
     }
+    let forceDatapage: boolean | undefined
+    if (req.query.forceDatapage) {
+        forceDatapage = req.query.forceDatapage === "true"
+    }
 
     const existingConfig = await expectChartById(trx, req.params.chartId)
 
@@ -834,6 +868,7 @@ export async function updateChart(
             user: res.locals.user,
             newConfig: req.body,
             existingConfig,
+            forceDatapage,
             shouldInherit,
         })
 

--- a/adminSiteServer/mockSiteRouter.ts
+++ b/adminSiteServer/mockSiteRouter.ts
@@ -283,6 +283,7 @@ getPlainRouteWithROTransaction(
                 await renderPreviewDataPageOrGrapherPage(
                     chartRow.config,
                     chartRow.id,
+                    chartRow.forceDatapage,
                     trx
                 )
             res.send(previewDataPageOrGrapherPage)

--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -434,6 +434,7 @@ export class SiteBaker {
                                 chart.config,
                                 chart.slug,
                                 {
+                                    forceDatapage: chart.forceDatapage,
                                     archivedPageVersion:
                                         archivedVersions.charts[chart.id] ||
                                         undefined,

--- a/db/docs/charts.yml
+++ b/db/docs/charts.yml
@@ -24,6 +24,8 @@ fields:
         description: Foreign key to chart_configs table. Charts store their configuration separately to enable inheritance and efficient updates. The chart_configs table contains the actual config, the slug of the chart etc., so in many queries, these two tables have to be joined.
     isInheritanceEnabled:
         description: When true, chart inherits configuration from parent variable's grapherConfigIdAdmin or grapherConfigIdETL. This allows variables to define default chart settings that are automatically applied to all inheriting charts.
+    forceDatapage:
+        description: When true, force rendering this chart as a data page using metadata from the first Y indicator.
     createdAt:
         description: Timestamp when the chart was created
     updatedAt:

--- a/db/migration/1772209929306-AddForceDatapageToCharts.ts
+++ b/db/migration/1772209929306-AddForceDatapageToCharts.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class AddForceDatapageToCharts1772209929306
+    implements MigrationInterface
+{
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE charts
+            ADD COLUMN forceDatapage TINYINT(1) NOT NULL DEFAULT 0 AFTER isInheritanceEnabled
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE charts
+            DROP COLUMN forceDatapage
+        `)
+    }
+}

--- a/db/model/Chart.ts
+++ b/db/model/Chart.ts
@@ -66,18 +66,30 @@ export async function mapSlugsToIds(
 // ]
 export async function mapSlugsToConfigs(
     knex: db.KnexReadonlyTransaction
-): Promise<{ slug: string; id: number; config: GrapherInterface }[]> {
+): Promise<
+    {
+        slug: string
+        id: number
+        forceDatapage: boolean
+        config: GrapherInterface
+    }[]
+> {
     return db
-        .knexRaw<{ slug: string; config: string; id: number }>(
+        .knexRaw<{
+            slug: string
+            config: string
+            id: number
+            forceDatapage: number
+        }>(
             knex,
             `-- sql
-                SELECT csr.slug AS slug, cc.full AS config, c.id AS id
+                SELECT csr.slug AS slug, cc.full AS config, c.id AS id, c.forceDatapage AS forceDatapage
                 FROM chart_slug_redirects csr
                 JOIN charts c ON csr.chart_id = c.id
                 JOIN chart_configs cc ON cc.id = c.configId
                 WHERE cc.full ->> "$.isPublished" = "true"
                 UNION
-                SELECT cc.slug, cc.full AS config, c.id AS id
+                SELECT cc.slug, cc.full AS config, c.id AS id, c.forceDatapage AS forceDatapage
                 FROM charts c
                 JOIN chart_configs cc ON cc.id = c.configId
                 WHERE cc.full ->> "$.isPublished" = "true"
@@ -86,6 +98,7 @@ export async function mapSlugsToConfigs(
         .then((results) =>
             results.map((result) => ({
                 ...result,
+                forceDatapage: Boolean(result.forceDatapage),
                 config: JSON.parse(result.config),
             }))
         )
@@ -233,15 +246,19 @@ export const getChartConfigById = async (
     knex: db.KnexReadonlyTransaction,
     grapherId: number
 ): Promise<
-    | (Pick<DbPlainChart, "id"> & { config: DbEnrichedChartConfig["full"] })
+    | (Pick<DbPlainChart, "id" | "forceDatapage"> & {
+          config: DbEnrichedChartConfig["full"]
+      })
     | undefined
 > => {
     const grapher = await db.knexRawFirst<
-        Pick<DbPlainChart, "id"> & { config: DbRawChartConfig["full"] }
+        Pick<DbPlainChart, "id" | "forceDatapage"> & {
+            config: DbRawChartConfig["full"]
+        }
     >(
         knex,
         `-- sql
-            SELECT c.id, cc.full as config
+            SELECT c.id, c.forceDatapage, cc.full as config
             FROM charts c
             JOIN chart_configs cc ON c.configId = cc.id
             WHERE c.id=?
@@ -253,6 +270,7 @@ export const getChartConfigById = async (
 
     return {
         id: grapher.id,
+        forceDatapage: Boolean(grapher.forceDatapage),
         config: parseChartConfig(grapher.config),
     }
 }
@@ -261,14 +279,18 @@ export async function getChartConfigBySlug(
     knex: db.KnexReadonlyTransaction,
     slug: string
 ): Promise<
-    Pick<DbPlainChart, "id"> & { config: DbEnrichedChartConfig["full"] }
+    Pick<DbPlainChart, "id" | "forceDatapage"> & {
+        config: DbEnrichedChartConfig["full"]
+    }
 > {
     const row = await db.knexRawFirst<
-        Pick<DbPlainChart, "id"> & { config: DbRawChartConfig["full"] }
+        Pick<DbPlainChart, "id" | "forceDatapage"> & {
+            config: DbRawChartConfig["full"]
+        }
     >(
         knex,
         `-- sql
-            SELECT c.id, cc.full as config
+            SELECT c.id, c.forceDatapage, cc.full as config
             FROM charts c
             JOIN chart_configs cc ON c.configId = cc.id
             WHERE cc.slug = ?`,
@@ -277,7 +299,27 @@ export async function getChartConfigBySlug(
 
     if (!row) throw new JsonError(`No chart found for slug ${slug}`, 404)
 
-    return { id: row.id, config: parseChartConfig(row.config) }
+    return {
+        id: row.id,
+        forceDatapage: Boolean(row.forceDatapage),
+        config: parseChartConfig(row.config),
+    }
+}
+
+export async function getForceDatapageByChartId(
+    knex: db.KnexReadonlyTransaction,
+    chartId: number
+): Promise<boolean> {
+    const row = await db.knexRawFirst<Pick<DbPlainChart, "forceDatapage">>(
+        knex,
+        `-- sql
+            SELECT forceDatapage
+            FROM charts
+            WHERE id = ?
+        `,
+        [chartId]
+    )
+    return !!row?.forceDatapage
 }
 
 export async function isInheritanceEnabledForChart(

--- a/db/model/Gdoc/GdocBase.ts
+++ b/db/model/Gdoc/GdocBase.ts
@@ -187,6 +187,7 @@ export async function loadLinkedChartsForSlugs(
                     chart.config,
                     originalSlug,
                     {
+                        forceDatapage: chart.forceDatapage,
                         archivedPageVersion:
                             archivedChartVersions[chartId] || undefined,
                     }
@@ -1395,14 +1396,22 @@ export async function makeGrapherLinkedChart(
     knex: db.KnexReadonlyTransaction,
     config: GrapherInterface,
     originalSlug: string,
-    { archivedPageVersion }: { archivedPageVersion?: ArchivedPageVersion } = {}
+    {
+        forceDatapage,
+        archivedPageVersion,
+    }: {
+        forceDatapage?: boolean
+        archivedPageVersion?: ArchivedPageVersion
+    } = {}
 ): Promise<LinkedChart> {
     const resolvedSlug = config.slug ?? ""
     const resolvedTitle = config.title ?? ""
     const subtitle = toPlaintext(config.subtitle ?? "")
     const resolvedUrl = `${BASE_URL}/grapher/${resolvedSlug}`
     const tab = config.tab ?? GRAPHER_TAB_CONFIG_OPTIONS.chart
-    const indicatorId = await getDatapageIndicatorId(knex, config)
+    const indicatorId = await getDatapageIndicatorId(knex, config, {
+        forceDatapage,
+    })
 
     return {
         configType: ChartConfigType.Grapher,

--- a/db/model/Variable.ts
+++ b/db/model/Variable.ts
@@ -578,14 +578,20 @@ export async function getAllChartsForIndicator(
  * Returns the indicator ID to use for datapage metadata if the grapher is
  * eligible for a datapage, otherwise undefined.
  *
- * If we have a single Y indicator and it has schema version >= 2, meaning it
- * has the metadata necessary to render a datapage, AND if the metadata includes
- * text for at least one of the description* fields or titlePublic, then we can
- * use it in a datapage.
+ * By default, datapages require exactly one Y indicator.
+ *
+ * If `forceDatapage` is enabled, we instead use the first Y indicator for
+ * metadata (same behavior as mdims), even when there are multiple Y indicators.
+ *
+ * The selected indicator must have schema version >= 2 and include text for at
+ * least one of the description* fields or titlePublic.
  */
 export async function getDatapageIndicatorId(
     knex: db.KnexReadonlyTransaction,
-    grapher: GrapherInterface
+    grapher: GrapherInterface,
+    options?: {
+        forceDatapage?: boolean
+    }
 ): Promise<number | undefined> {
     const yVariableIds = grapher
         .dimensions!.filter((d) => d.property === DimensionProperty.y)
@@ -598,33 +604,39 @@ export async function getDatapageIndicatorId(
     // is a special case where time is the X axis. Marimekko charts are the other chart that uses
     // the X dimension but there we usually map population on X which should not prevent us from
     // showing a data page.
-    if (
-        yVariableIds.length === 1 &&
-        (grapher.chartTypes?.[0] !== GRAPHER_CHART_TYPES.ScatterPlot ||
-            xVariableIds.length === 0)
-    ) {
-        const variableId = yVariableIds[0]
-        const result = await knexRawFirst<{ id: number }>(
-            knex,
-            `-- sql
-                SELECT id
-                FROM variables
-                WHERE id = ?
-                  AND schemaVersion >= 2
-                  AND (
-                    (descriptionShort IS NOT NULL AND descriptionShort != '') OR
-                    (descriptionProcessing IS NOT NULL AND descriptionProcessing != '') OR
-                    (descriptionKey IS NOT NULL AND descriptionKey != '' AND descriptionKey != '[]') OR
-                    (descriptionFromProducer IS NOT NULL AND descriptionFromProducer != '') OR
-                    (titlePublic IS NOT NULL AND titlePublic != '')
-                  )
-            `,
-            [variableId]
-        )
+    const isScatterWithMappedX =
+        grapher.chartTypes?.[0] === GRAPHER_CHART_TYPES.ScatterPlot &&
+        xVariableIds.length > 0
 
-        return result?.id
+    let variableId: number | undefined
+    if (
+        options?.forceDatapage ||
+        (yVariableIds.length === 1 && !isScatterWithMappedX)
+    ) {
+        variableId = yVariableIds[0]
     }
-    return undefined
+
+    if (!variableId) return undefined
+
+    const result = await knexRawFirst<{ id: number }>(
+        knex,
+        `-- sql
+            SELECT id
+            FROM variables
+            WHERE id = ?
+              AND schemaVersion >= 2
+              AND (
+                (descriptionShort IS NOT NULL AND descriptionShort != '') OR
+                (descriptionProcessing IS NOT NULL AND descriptionProcessing != '') OR
+                (descriptionKey IS NOT NULL AND descriptionKey != '' AND descriptionKey != '[]') OR
+                (descriptionFromProducer IS NOT NULL AND descriptionFromProducer != '') OR
+                (titlePublic IS NOT NULL AND titlePublic != '')
+              )
+        `,
+        [variableId]
+    )
+
+    return result?.id
 }
 
 // TODO: these are domain functions and should live somewhere else
@@ -917,7 +929,10 @@ export const readSQLasDF = async (
 
 export async function getVariableOfDatapageIfApplicable(
     knex: db.KnexReadonlyTransaction,
-    grapher: GrapherInterface
+    grapher: GrapherInterface,
+    options?: {
+        forceDatapage?: boolean
+    }
 ): Promise<
     | {
           id: number
@@ -925,7 +940,7 @@ export async function getVariableOfDatapageIfApplicable(
       }
     | undefined
 > {
-    const indicatorId = await getDatapageIndicatorId(knex, grapher)
+    const indicatorId = await getDatapageIndicatorId(knex, grapher, options)
     if (indicatorId) {
         const fullMetadata = await getVariableMetadata(indicatorId, {
             noCache: true,

--- a/packages/@ourworldindata/types/src/dbTypes/Charts.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/Charts.ts
@@ -2,6 +2,7 @@ export const ChartsTableName = "charts"
 export interface DbInsertChart {
     configId: string
     createdAt?: Date
+    forceDatapage?: boolean
     id?: number
     isInheritanceEnabled?: boolean
     lastEditedAt: Date


### PR DESCRIPTION
## Context

Resolves #5060

## Screenshots / Videos / Diagrams

<img width="2560" height="1408" alt="image" src="https://github.com/user-attachments/assets/f3fe96af-f2ef-4dbf-9c39-e4e661f7b18a" />

## Testing guidance

Find a multi-indicator chart in the admin and try enabling the "Force to be a datapage" checkbox. For example, `life-expectancy-men-women` (even though it might not make sense to use it there without other changes). Check that it renders (bakes) into a data page.

- [x] Does the change work in the archive?

## Checklist

- [x] The DB type definitions have been updated
- [x] The DB types in the ETL have been updated
- [x] Update the documentation in db/docs