### PR TITLE
chore(deps): update itty-router & get rid of manual response-cloning

### DIFF
--- a/functions/_common/reusableHandlers.ts
+++ b/functions/_common/reusableHandlers.ts
@@ -14,11 +14,7 @@ export async function checkCache(
 
     console.log("Cache check result", maybeCached ? "hit" : "miss")
 
-    if (maybeCached) {
-        // Cached responses are immutable, so we have to clone them,
-        // so that the corsify middleware can add CORS headers
-        return new Response(maybeCached.body, maybeCached)
-    }
+    if (maybeCached) return maybeCached
 
     return null
 }

--- a/functions/package.json
+++ b/functions/package.json
@@ -11,7 +11,7 @@
         "@resvg/resvg-wasm": "^2.6.2",
         "@sentry/cloudflare": "^10.40.0",
         "cookie": "^1.0.2",
-        "itty-router": "^5.0.17",
+        "itty-router": "^5.0.23",
         "littlezipper": "^0.1.5",
         "lodash-es": "^4.17.23",
         "react": "^19.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12417,10 +12417,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"itty-router@npm:^5.0.17":
-  version: 5.0.17
-  resolution: "itty-router@npm:5.0.17"
-  checksum: 10/5af87433b7ce1dc5c72c70bbf75e9676082381e6c101ac14fd5621e9d8a7e25cae97506b8654812b508d7f717aa8a881393888b4091112e33089d7b1aabd53d3
+"itty-router@npm:^5.0.23":
+  version: 5.0.23
+  resolution: "itty-router@npm:5.0.23"
+  checksum: 10/29c0e63f21c9d410c1b400433de8f559b843894e971dcc37d3d795b06c957a3199d3142c44055b8c37a105912de63c9494e19755e36e5ad77abc1f204a3431c6
   languageName: node
   linkType: hard
 
@@ -14094,7 +14094,7 @@ __metadata:
     "@types/react": "npm:^19.2.14"
     "@types/react-dom": "npm:^19.2.3"
     cookie: "npm:^1.0.2"
-    itty-router: "npm:^5.0.17"
+    itty-router: "npm:^5.0.23"
     littlezipper: "npm:^0.1.5"
     lodash-es: "npm:^4.17.23"
     react: "npm:^19.2.4"


### PR DESCRIPTION
Now that https://github.com/kwhitley/itty-router/pull/252 was resolved, we can get rid of this extra call.

related to https://github.com/owid/owid-grapher/pull/4465.