### PR TITLE
🐛 fix prominent links in key insight blocks

### DIFF
--- a/site/gdocs/components/topic-page.scss
+++ b/site/gdocs/components/topic-page.scss
@@ -145,10 +145,6 @@
         margin: 0;
     }
 
-    img {
-        width: 100%;
-    }
-
     .article-block__key-insights-content-column {
         max-height: 575px;
         overflow-y: auto;


### PR DESCRIPTION
Removes a CSS rule that was breaking prominent links that linked to charts. (The DOM renders differently for these 2)

I checked to see if image components were used in any of our key insights blocks and there are none, so I'm not sure what this rule was originally intended to fix.

| Before | After |
|--------|--------|
| <img width="558" height="512" alt="image" src="https://github.com/user-attachments/assets/01737cf3-898f-44d0-ba3e-87f6762dd9e2" /> | <img width="528" height="230" alt="image" src="https://github.com/user-attachments/assets/a4a5304d-c24a-4aba-81a4-18207b745c3f" />  | 
