### PR TITLE
🔨 extract chart tooltips into separate components

### DIFF
--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
@@ -7,11 +7,9 @@ import {
     PointVector,
     makeFigmaId,
     guid,
-    excludeUndefined,
     getRelativeMouse,
     dyFromAlign,
     domainExtent,
-    calculateTrendDirection,
 } from "@ourworldindata/utils"
 import { observable, computed, action, makeObservable } from "mobx"
 import { observer } from "mobx-react"
@@ -52,15 +50,8 @@ import {
     VerticalLabelsState,
     VerticalLabelsStateOptions,
 } from "../verticalLabels/VerticalLabelsState"
-import {
-    formatTooltipRangeValues,
-    makeTooltipRoundingNotice,
-    makeTooltipToleranceNotice,
-    Tooltip,
-    TooltipState,
-    TooltipValueRange,
-} from "../tooltip/Tooltip"
-import { TooltipFooterIcon } from "../tooltip/TooltipProps"
+import { TooltipState } from "../tooltip/Tooltip"
+import { SlopeChartTooltip } from "./SlopeChartTooltip"
 
 import { Halo } from "@ourworldindata/components"
 import { HorizontalColorLegendManager } from "../legend/HorizontalColorLegends"
@@ -726,95 +717,12 @@ export class SlopeChart
         return guid()
     }
 
-    @computed private get tooltip(): React.ReactElement | undefined {
-        const {
-            manager: { isRelativeMode },
-            tooltipState: { target, position, fading },
-            formatColumn,
-            startTime,
-            endTime,
-        } = this
-
-        const { series } = target || {}
-        if (!series) return
-
-        const formatTime = (time: Time) => formatColumn.formatTime(time)
-
-        const title = series.displayName
-        const titleAnnotation = series.annotation
-
-        const actualStartTime = series.start.originalTime
-        const actualEndTime = series.end.originalTime
-        const timeRange = `${formatTime(actualStartTime)} to ${formatTime(actualEndTime)}`
-        const timeLabel = isRelativeMode
-            ? `% change between ${formatColumn.formatTime(actualStartTime)} and ${formatColumn.formatTime(actualEndTime)}`
-            : timeRange
-
-        const constructTargetYearForToleranceNotice = () => {
-            const isStartValueOriginal = series.start.originalTime === startTime
-            const isEndValueOriginal = series.end.originalTime === endTime
-
-            if (!isStartValueOriginal && !isEndValueOriginal) {
-                return `${formatTime(startTime)} and ${formatTime(endTime)}`
-            } else if (!isStartValueOriginal) {
-                return formatTime(startTime)
-            } else if (!isEndValueOriginal) {
-                return formatTime(endTime)
-            } else {
-                return undefined
-            }
-        }
-
-        const targetYear = constructTargetYearForToleranceNotice()
-        const toleranceNotice = targetYear
-            ? {
-                  icon: TooltipFooterIcon.Notice,
-                  text: makeTooltipToleranceNotice(targetYear),
-              }
-            : undefined
-        const roundingNotice = series.column.roundsToSignificantFigures
-            ? {
-                  icon: TooltipFooterIcon.None,
-                  text: makeTooltipRoundingNotice(
-                      [series.column.numSignificantFigures],
-                      { plural: !isRelativeMode }
-                  ),
-              }
-            : undefined
-        const footer = excludeUndefined([toleranceNotice, roundingNotice])
-
-        const values = isRelativeMode
-            ? [series.end.value]
-            : [series.start.value, series.end.value]
-
+    @computed private get tooltip(): React.ReactElement | null {
         return (
-            <Tooltip
-                id={this.renderUid}
-                tooltipManager={this.props.chartState.manager}
-                x={position.x}
-                y={position.y}
-                offsetX={20}
-                offsetY={-16}
-                style={{ maxWidth: "250px" }}
-                title={title}
-                titleAnnotation={titleAnnotation}
-                subtitle={timeLabel}
-                subtitleFormat={targetYear ? "notice" : undefined}
-                dissolve={fading}
-                footer={footer}
-                dismiss={() => (this.tooltipState.target = null)}
-            >
-                <TooltipValueRange
-                    label={series.column.displayName}
-                    unit={series.column.displayUnit}
-                    values={formatTooltipRangeValues(values, series.column)}
-                    trend={calculateTrendDirection(...values)}
-                    isRoundedToSignificantFigures={
-                        series.column.roundsToSignificantFigures
-                    }
-                    labelVariant="unit-only"
-                />
-            </Tooltip>
+            <SlopeChartTooltip
+                chartState={this.chartState}
+                tooltipState={this.tooltipState}
+            />
         )
     }
 

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChartTooltip.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChartTooltip.tsx
@@ -1,0 +1,141 @@
+import React from "react"
+import { computed } from "mobx"
+import { observer } from "mobx-react"
+import {
+    excludeUndefined,
+    calculateTrendDirection,
+    Time,
+} from "@ourworldindata/utils"
+import { SlopeChartSeries } from "./SlopeChartConstants"
+import { SlopeChartState } from "./SlopeChartState"
+import {
+    formatTooltipRangeValues,
+    makeTooltipRoundingNotice,
+    makeTooltipToleranceNotice,
+    Tooltip,
+    TooltipState,
+    TooltipValueRange,
+} from "../tooltip/Tooltip"
+import { FooterItem, TooltipFooterIcon } from "../tooltip/TooltipProps"
+
+export interface SlopeChartTooltipProps {
+    chartState: SlopeChartState
+    tooltipState: TooltipState<{ series: SlopeChartSeries }>
+}
+
+@observer
+export class SlopeChartTooltip extends React.Component<SlopeChartTooltipProps> {
+    @computed private get chartState(): SlopeChartState {
+        return this.props.chartState
+    }
+
+    @computed private get series(): SlopeChartSeries | undefined {
+        return this.props.tooltipState.target?.series
+    }
+
+    @computed private get subtitle(): string | undefined {
+        const { series } = this
+        if (!series) return undefined
+
+        const { formatColumn, isRelativeMode } = this.chartState
+        const formatTime = (time: Time): string => formatColumn.formatTime(time)
+
+        const actualStartTime = series.start.originalTime
+        const actualEndTime = series.end.originalTime
+        const timeRange = `${formatTime(actualStartTime)} to ${formatTime(actualEndTime)}`
+
+        return isRelativeMode
+            ? `% change between ${formatTime(actualStartTime)} and ${formatTime(actualEndTime)}`
+            : timeRange
+    }
+
+    @computed private get toleranceNotice(): FooterItem | undefined {
+        const { series } = this
+        if (!series) return undefined
+
+        const { formatColumn, startTime, endTime } = this.chartState
+        const formatTime = (time: Time): string => formatColumn.formatTime(time)
+
+        const isStartValueOriginal = series.start.originalTime === startTime
+        const isEndValueOriginal = series.end.originalTime === endTime
+
+        let targetYear: string | undefined
+        if (!isStartValueOriginal && !isEndValueOriginal) {
+            targetYear = `${formatTime(startTime)} and ${formatTime(endTime)}`
+        } else if (!isStartValueOriginal) {
+            targetYear = formatTime(startTime)
+        } else if (!isEndValueOriginal) {
+            targetYear = formatTime(endTime)
+        }
+
+        if (!targetYear) return undefined
+
+        return {
+            icon: TooltipFooterIcon.Notice,
+            text: makeTooltipToleranceNotice(targetYear),
+        }
+    }
+
+    @computed private get roundingNotice(): FooterItem | undefined {
+        const { series } = this
+        if (!series) return undefined
+
+        if (!series.column.roundsToSignificantFigures) return undefined
+
+        return {
+            icon: TooltipFooterIcon.None,
+            text: makeTooltipRoundingNotice(
+                [series.column.numSignificantFigures],
+                { plural: !this.chartState.isRelativeMode }
+            ),
+        }
+    }
+
+    @computed private get footer(): FooterItem[] {
+        return excludeUndefined([this.toleranceNotice, this.roundingNotice])
+    }
+
+    override render(): React.ReactElement | null {
+        const { series } = this
+        const { target, position, fading } = this.props.tooltipState
+
+        if (!target || !series) return null
+
+        const { isRelativeMode } = this.chartState
+        const values = isRelativeMode
+            ? [series.end.value]
+            : [series.start.value, series.end.value]
+
+        const targetYear = this.toleranceNotice !== undefined
+
+        return (
+            <Tooltip
+                id="slopeTooltip"
+                tooltipManager={this.chartState.manager}
+                x={position.x}
+                y={position.y}
+                offsetX={20}
+                offsetY={-16}
+                style={{ maxWidth: "250px" }}
+                title={series.displayName}
+                titleAnnotation={series.annotation}
+                subtitle={this.subtitle}
+                subtitleFormat={targetYear ? "notice" : undefined}
+                dissolve={fading}
+                footer={this.footer}
+                dismiss={() => (this.props.tooltipState.target = null)}
+            >
+                <TooltipValueRange
+                    label={series.column.displayName}
+                    unit={series.column.displayUnit}
+                    values={formatTooltipRangeValues(values, series.column)}
+                    trend={calculateTrendDirection(...values)}
+                    isRoundedToSignificantFigures={
+                        series.column.roundsToSignificantFigures
+                    }
+                    labelVariant="unit-only"
+                />
+            </Tooltip>
+        )
+    }
+}

--- a/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChart.tsx
@@ -3,7 +3,6 @@ import React from "react"
 import * as R from "remeda"
 import {
     Bounds,
-    excludeUndefined,
     HorizontalAlign,
     Position,
     SortConfig,
@@ -30,24 +29,14 @@ import {
     VerticalAlign,
     ColorScaleConfigInterface,
 } from "@ourworldindata/types"
-import {
-    OwidTable,
-    CoreColumn,
-    ColumnTypeMap,
-} from "@ourworldindata/core-table"
+import { OwidTable, CoreColumn } from "@ourworldindata/core-table"
 import { getShortNameForEntity } from "../chart/ChartUtils"
 import {
     LEGEND_STYLE_FOR_STACKED_CHARTS,
     StackedSeries,
 } from "./StackedConstants"
-import { TooltipFooterIcon } from "../tooltip/TooltipProps.js"
-import {
-    Tooltip,
-    TooltipValue,
-    TooltipState,
-    makeTooltipRoundingNotice,
-    makeTooltipToleranceNotice,
-} from "../tooltip/Tooltip"
+import { TooltipState } from "../tooltip/Tooltip"
+import { MarimekkoChartTooltip } from "./MarimekkoChartTooltip"
 import {
     HorizontalCategoricalColorLegend,
     HorizontalColorLegendManager,
@@ -66,7 +55,6 @@ import {
     LabelCandidate,
     LabelWithPlacement,
     LabelCandidateWithElement,
-    Bar,
 } from "./MarimekkoChartConstants"
 import { MarimekkoChartState } from "./MarimekkoChartState"
 import { ChartComponentProps } from "../chart/ChartTypeMap.js"
@@ -411,6 +399,10 @@ export class MarimekkoChart
             addCountryMode !== EntitySelectionMode.Disabled) as boolean
     }
 
+    override componentDidMount(): void {
+        exposeInstanceOnWindow(this)
+    }
+
     @computed private get tooltipItem(): Item | undefined {
         const { target } = this.tooltipState
         return (
@@ -419,10 +411,6 @@ export class MarimekkoChart
                 ({ entityName }) => entityName === target.entityName
             )
         )
-    }
-
-    override componentDidMount(): void {
-        exposeInstanceOnWindow(this)
     }
 
     override render(): React.ReactElement {
@@ -435,91 +423,7 @@ export class MarimekkoChart
                 />
             )
 
-        const {
-            manager,
-            bounds,
-            dualAxis,
-            tooltipItem,
-            xColumn,
-            yColumns,
-            colorColumn,
-            colorScale,
-            manager: { endTime, xOverrideTime },
-            inputTable: { timeColumn },
-            tooltipState: { target, position, fading },
-        } = this
-
-        const { entityName, xPoint, bars } = tooltipItem ?? {}
-
-        const yValues =
-            bars?.map((bar: Bar) => {
-                const column = this.chartState.transformedTable.get(
-                    bar.columnSlug
-                )
-
-                const shouldShowYTimeNotice =
-                    bar.yPoint.value !== undefined &&
-                    bar.yPoint.time !== endTime
-
-                return {
-                    name: bar.seriesName,
-                    value: bar.yPoint.value,
-                    column,
-                    originalTime: shouldShowYTimeNotice
-                        ? column.formatTime(bar.yPoint.time)
-                        : undefined,
-                }
-            }) ?? []
-
-        // TODO: when we have proper time support to work across date/year variables then
-        // this should be set properly and the x axis time be passed in on it's own.
-        // For now we disable x axis notices when the xOverrideTime is set which is
-        // usually the case when matching day and year variables
-        const shouldShowXTimeNotice =
-            xPoint && xPoint.time !== endTime && xOverrideTime === undefined
-        const xOriginalTime = shouldShowXTimeNotice ? xPoint?.time : undefined
-        const xOriginalTimeFormatted = xOriginalTime
-            ? xColumn?.formatTime(xOriginalTime)
-            : undefined
-        const targetNotice =
-            xOriginalTime || yValues.some(({ originalTime }) => !!originalTime)
-                ? timeColumn.formatValue(endTime)
-                : undefined
-        const toleranceNotice = targetNotice
-            ? {
-                  icon: TooltipFooterIcon.Notice,
-                  text: makeTooltipToleranceNotice(targetNotice),
-              }
-            : undefined
-
-        const columns = excludeUndefined([xColumn, ...yColumns])
-        const allRoundedToSigFigs = columns.every(
-            (column) => column.roundsToSignificantFigures
-        )
-        const anyRoundedToSigFigs = columns.some(
-            (column) => column.roundsToSignificantFigures
-        )
-        const sigFigs = excludeUndefined(
-            columns.map((column) =>
-                column.roundsToSignificantFigures
-                    ? column.numSignificantFigures
-                    : undefined
-            )
-        )
-        const roundingNotice = anyRoundedToSigFigs
-            ? {
-                  icon: allRoundedToSigFigs
-                      ? TooltipFooterIcon.None
-                      : TooltipFooterIcon.Significance,
-                  text: makeTooltipRoundingNotice(sigFigs, {
-                      plural: sigFigs.length > 1,
-                  }),
-              }
-            : undefined
-        const superscript =
-            !!roundingNotice && roundingNotice.icon !== TooltipFooterIcon.None
-
-        const footer = excludeUndefined([toleranceNotice, roundingNotice])
+        const { manager, bounds, dualAxis } = this
 
         return (
             <g
@@ -548,70 +452,10 @@ export class MarimekkoChart
                 {this.renderBars()}
                 {this.labelLines}
                 {this.placedLabels}
-                {target && (
-                    <Tooltip
-                        id="marimekkoTooltip"
-                        tooltipManager={this.manager}
-                        x={position.x}
-                        y={position.y}
-                        style={{ maxWidth: "250px" }}
-                        offsetX={20}
-                        offsetY={-16}
-                        title={entityName}
-                        subtitle={timeColumn.formatValue(endTime)}
-                        footer={footer}
-                        dissolve={fading}
-                        dismiss={() => (this.tooltipState.target = null)}
-                    >
-                        {yValues.map(
-                            ({ name, value, column, originalTime }) => (
-                                <TooltipValue
-                                    key={name}
-                                    label={column.displayName}
-                                    unit={column.displayUnit}
-                                    value={column.formatValueShort(value)}
-                                    originalTime={originalTime}
-                                    isRoundedToSignificantFigures={
-                                        column.roundsToSignificantFigures
-                                    }
-                                    showSignificanceSuperscript={superscript}
-                                />
-                            )
-                        )}
-                        {xColumn && !xColumn.isMissing && (
-                            <TooltipValue
-                                label={xColumn.displayName}
-                                unit={xColumn.displayUnit}
-                                value={xColumn.formatValueShort(xPoint?.value)}
-                                originalTime={xOriginalTimeFormatted}
-                                isRoundedToSignificantFigures={
-                                    xColumn.roundsToSignificantFigures
-                                }
-                                showSignificanceSuperscript={superscript}
-                            />
-                        )}
-                        {colorColumn &&
-                            !colorColumn.isMissing &&
-                            tooltipItem?.entityColor &&
-                            !(
-                                colorColumn instanceof ColumnTypeMap.Continent
-                            ) && (
-                                <TooltipValue
-                                    label={
-                                        colorScale.legendDescription ??
-                                        colorColumn.displayName
-                                    }
-                                    value={
-                                        colorScale.getBinForValue(
-                                            tooltipItem.entityColor
-                                                .colorDomainValue
-                                        )?.label ??
-                                        tooltipItem.entityColor.colorDomainValue
-                                    }
-                                />
-                            )}
-                    </Tooltip>
-                )}
+                <MarimekkoChartTooltip
+                    chartState={this.chartState}
+                    tooltipState={this.tooltipState}
+                />
             </g>
         )
     }

--- a/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChartTooltip.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChartTooltip.tsx
@@ -1,0 +1,222 @@
+import React from "react"
+import { computed } from "mobx"
+import { observer } from "mobx-react"
+import { excludeUndefined } from "@ourworldindata/utils"
+import { ColumnTypeMap } from "@ourworldindata/core-table"
+import { MarimekkoChartState } from "./MarimekkoChartState"
+import { Item, Bar } from "./MarimekkoChartConstants"
+import { TooltipFooterIcon, FooterItem } from "../tooltip/TooltipProps.js"
+import {
+    Tooltip,
+    TooltipValue,
+    TooltipState,
+    makeTooltipRoundingNotice,
+    makeTooltipToleranceNotice,
+} from "../tooltip/Tooltip"
+
+export interface MarimekkoChartTooltipProps {
+    chartState: MarimekkoChartState
+    tooltipState: TooltipState<{ entityName: string }>
+}
+
+interface YValue {
+    name: string
+    value: number | undefined
+    column: ReturnType<MarimekkoChartState["transformedTable"]["get"]>
+    originalTime: string | undefined
+}
+
+@observer
+export class MarimekkoChartTooltip extends React.Component<MarimekkoChartTooltipProps> {
+    @computed private get chartState(): MarimekkoChartState {
+        return this.props.chartState
+    }
+
+    @computed private get tooltipItem(): Item | undefined {
+        const { target } = this.props.tooltipState
+        return (
+            target &&
+            this.chartState.items.find(
+                ({ entityName }) => entityName === target.entityName
+            )
+        )
+    }
+
+    @computed private get yValues(): YValue[] {
+        const { tooltipItem } = this
+        if (!tooltipItem) return []
+
+        const endTime = this.chartState.manager.endTime
+
+        return tooltipItem.bars.map((bar: Bar) => {
+            const column = this.chartState.transformedTable.get(bar.columnSlug)
+
+            const shouldShowYTimeNotice =
+                bar.yPoint.value !== undefined && bar.yPoint.time !== endTime
+
+            return {
+                name: bar.seriesName,
+                value: bar.yPoint.value,
+                column,
+                originalTime: shouldShowYTimeNotice
+                    ? column.formatTime(bar.yPoint.time)
+                    : undefined,
+            }
+        })
+    }
+
+    @computed private get xOriginalTimeFormatted(): string | undefined {
+        const { tooltipItem } = this
+        if (!tooltipItem) return undefined
+
+        const { xColumn } = this.chartState
+        const endTime = this.chartState.manager.endTime
+        const xOverrideTime = this.chartState.manager.xOverrideTime
+
+        const shouldShowXTimeNotice =
+            tooltipItem.xPoint &&
+            tooltipItem.xPoint.time !== endTime &&
+            xOverrideTime === undefined
+
+        if (!shouldShowXTimeNotice || !tooltipItem.xPoint) return undefined
+
+        return xColumn?.formatTime(tooltipItem.xPoint.time)
+    }
+
+    @computed private get toleranceNotice(): FooterItem | undefined {
+        const endTime = this.chartState.manager.endTime
+        const { timeColumn } = this.chartState.inputTable
+
+        const xOriginalTime = this.xOriginalTimeFormatted !== undefined
+        const hasYNotice = this.yValues.some(
+            ({ originalTime }) => !!originalTime
+        )
+
+        if (!xOriginalTime && !hasYNotice) return undefined
+
+        const targetNotice = timeColumn.formatValue(endTime)
+        return {
+            icon: TooltipFooterIcon.Notice,
+            text: makeTooltipToleranceNotice(targetNotice),
+        }
+    }
+
+    @computed private get roundingNotice(): FooterItem | undefined {
+        const { xColumn, yColumns } = this.chartState
+        const columns = excludeUndefined([xColumn, ...yColumns])
+
+        const allRoundedToSigFigs = columns.every(
+            (column) => column.roundsToSignificantFigures
+        )
+        const anyRoundedToSigFigs = columns.some(
+            (column) => column.roundsToSignificantFigures
+        )
+
+        if (!anyRoundedToSigFigs) return undefined
+
+        const sigFigs = excludeUndefined(
+            columns.map((column) =>
+                column.roundsToSignificantFigures
+                    ? column.numSignificantFigures
+                    : undefined
+            )
+        )
+
+        return {
+            icon: allRoundedToSigFigs
+                ? TooltipFooterIcon.None
+                : TooltipFooterIcon.Significance,
+            text: makeTooltipRoundingNotice(sigFigs, {
+                plural: sigFigs.length > 1,
+            }),
+        }
+    }
+
+    @computed private get showSignificanceSuperscript(): boolean {
+        return (
+            !!this.roundingNotice &&
+            this.roundingNotice.icon !== TooltipFooterIcon.None
+        )
+    }
+
+    @computed private get footer(): FooterItem[] {
+        return excludeUndefined([this.toleranceNotice, this.roundingNotice])
+    }
+
+    override render(): React.ReactElement | null {
+        const { target, position, fading } = this.props.tooltipState
+        const { tooltipItem, yValues, showSignificanceSuperscript } = this
+
+        if (!target || !tooltipItem) return null
+
+        const { xColumn, colorColumn, colorScale } = this.chartState
+        const endTime = this.chartState.manager.endTime
+        const { timeColumn } = this.chartState.inputTable
+
+        return (
+            <Tooltip
+                id="marimekkoTooltip"
+                tooltipManager={this.chartState.manager}
+                x={position.x}
+                y={position.y}
+                style={{ maxWidth: "250px" }}
+                offsetX={20}
+                offsetY={-16}
+                title={tooltipItem.entityName}
+                subtitle={timeColumn.formatValue(endTime)}
+                footer={this.footer}
+                dissolve={fading}
+                dismiss={() => (this.props.tooltipState.target = null)}
+            >
+                {yValues.map(({ name, value, column, originalTime }) => (
+                    <TooltipValue
+                        key={name}
+                        label={column.displayName}
+                        unit={column.displayUnit}
+                        value={column.formatValueShort(value)}
+                        originalTime={originalTime}
+                        isRoundedToSignificantFigures={
+                            column.roundsToSignificantFigures
+                        }
+                        showSignificanceSuperscript={
+                            showSignificanceSuperscript
+                        }
+                    />
+                ))}
+                {xColumn && !xColumn.isMissing && (
+                    <TooltipValue
+                        label={xColumn.displayName}
+                        unit={xColumn.displayUnit}
+                        value={xColumn.formatValueShort(
+                            tooltipItem.xPoint?.value
+                        )}
+                        originalTime={this.xOriginalTimeFormatted}
+                        isRoundedToSignificantFigures={
+                            xColumn.roundsToSignificantFigures
+                        }
+                        showSignificanceSuperscript={
+                            showSignificanceSuperscript
+                        }
+                    />
+                )}
+                {colorColumn &&
+                    !colorColumn.isMissing &&
+                    tooltipItem.entityColor &&
+                    !(colorColumn instanceof ColumnTypeMap.Continent) && (
+                        <TooltipValue
+                            label={
+                                colorScale.legendDescription ??
+                                colorColumn.displayName
+                            }
+                            value={
+                                colorScale.getBinForValue(
+                                    tooltipItem.entityColor.colorDomainValue
+                                )?.label ??
+                                tooltipItem.entityColor.colorDomainValue
+                            }
+                        />
+                    )}
+            </Tooltip>
+        )
+    }
+}

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
@@ -1,6 +1,5 @@
 import * as _ from "lodash-es"
 import * as React from "react"
-import * as R from "remeda"
 import {
     getRelativeMouse,
     excludeUndefined,
@@ -21,20 +20,16 @@ import { DualAxis, HorizontalAxis, VerticalAxis } from "../axis/Axis"
 import { VerticalLabels } from "../verticalLabels/VerticalLabels"
 import { VerticalLabelsState } from "../verticalLabels/VerticalLabelsState"
 import { NoDataModal } from "../noDataModal/NoDataModal"
-import { TooltipFooterIcon } from "../tooltip/TooltipProps.js"
+import { TooltipState } from "../tooltip/Tooltip"
 import {
-    Tooltip,
-    TooltipState,
-    TooltipTable,
-    makeTooltipRoundingNotice,
-    toTooltipTableColumns,
-} from "../tooltip/Tooltip"
+    StackedAreaChartTooltip,
+    STACKED_AREA_TOOLTIP_ID,
+} from "./StackedAreaChartTooltip"
 import { StackedAreaChartState } from "./StackedAreaChartState.js"
 import {
     LEGEND_STYLE_FOR_STACKED_CHARTS,
     PlacedStackedAreaSeries,
     RenderStackedAreaSeries,
-    STACKED_AREA_STYLE,
     StackedSeries,
 } from "./StackedConstants"
 import {
@@ -44,7 +39,6 @@ import {
 } from "../chart/ChartUtils"
 import { AxisConfig, AxisManager } from "../axis/AxisConfig.js"
 import { LabelSeries } from "../verticalLabels/VerticalLabelsTypes"
-import { Emphasis, resolveEmphasis } from "../interaction/Emphasis"
 import { easeLinear } from "d3-ease"
 import { select, type BaseType, type Selection } from "d3-selection"
 import { ChartInterface } from "../chart/ChartInterface"
@@ -54,6 +48,7 @@ import { HorizontalColorLegendManager } from "../legend/HorizontalColorLegends"
 import { CategoricalBin } from "../color/ColorScaleBin"
 import { ChartComponentProps } from "../chart/ChartTypeMap.js"
 import { InteractionState } from "../interaction/InteractionState"
+import { resolveEmphasis } from "../interaction/Emphasis"
 import { resolveCollision, toPlacedStackedAreaSeries } from "./StackedUtils"
 
 const STACKED_AREA_CHART_CLASS_NAME = "StackedArea"
@@ -442,92 +437,19 @@ export class StackedAreaChart
         )
     }
 
-    @computed private get tooltipId(): number {
-        return this.renderUid
-    }
-
     @computed private get isTooltipActive(): boolean {
-        return this.manager.tooltip?.get()?.id === this.tooltipId
+        return this.manager.tooltip?.get()?.id === STACKED_AREA_TOOLTIP_ID
     }
 
-    @computed private get tooltip(): React.ReactElement | undefined {
-        const { target, position, fading } = this.tooltipState
-        if (!target) return undefined
-
-        // Grab the first value to get the year from
-        const { series } = this
-        const hoveredPointIndex = target.index
-        const bottomSeriesPoint = series[0].points[hoveredPointIndex]
-        if (!bottomSeriesPoint) return undefined
-
-        const formatColumn = this.chartState.formatColumn,
-            formattedTime = formatColumn.formatTime(bottomSeriesPoint.position),
-            { displayUnit } = formatColumn
-
-        const title = formattedTime
-        const titleAnnotation = this.xAxis.label ? `(${this.xAxis.label})` : ""
-
-        const lastStackedPoint = R.last(series)!.points[hoveredPointIndex]
-        if (!lastStackedPoint) return undefined
-        const totalValue = lastStackedPoint.value + lastStackedPoint.valueOffset
-
-        const roundingNotice = formatColumn.roundsToSignificantFigures
-            ? {
-                  icon: TooltipFooterIcon.None,
-                  text: makeTooltipRoundingNotice([
-                      formatColumn.numSignificantFigures,
-                  ]),
-              }
-            : undefined
-        const footer = excludeUndefined([roundingNotice])
-
+    @computed private get tooltip(): React.ReactElement | null {
         return (
-            <Tooltip
-                id={this.tooltipId}
-                tooltipManager={this.manager}
-                x={position.x}
-                y={position.y}
-                offsetY={-16}
-                offsetX={20}
-                offsetXDirection="left"
-                style={{ maxWidth: "50%" }}
-                title={title}
-                titleAnnotation={titleAnnotation}
-                subtitle={displayUnit}
-                subtitleFormat="unit"
-                footer={footer}
-                dissolve={fading}
-                dismiss={this.dismissTooltip}
-            >
-                <TooltipTable
-                    columns={toTooltipTableColumns(formatColumn)}
-                    totals={[totalValue]}
-                    rows={series.toReversed().map((series) => {
-                        const { seriesName: name, color, points } = series
-                        const point = points[hoveredPointIndex]
-                        const focused = name === target.series
-                        const values = [
-                            point?.missing || point?.interpolated
-                                ? undefined
-                                : point?.value,
-                        ]
-
-                        const emphasis = focused
-                            ? Emphasis.Highlighted
-                            : Emphasis.Default
-                        const opacity = STACKED_AREA_STYLE[emphasis].fillOpacity
-
-                        const swatch = { color, opacity }
-
-                        return {
-                            name,
-                            swatch,
-                            focused,
-                            values,
-                        }
-                    })}
-                />
-            </Tooltip>
+            <StackedAreaChartTooltip
+                chartState={this.chartState}
+                tooltipState={this.tooltipState}
+                series={this.series}
+                xAxisLabel={this.xAxis.label}
+                dismissTooltip={this.dismissTooltip}
+            />
         )
     }
 

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChartTooltip.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChartTooltip.tsx
@@ -1,0 +1,124 @@
+import * as R from "remeda"
+import React from "react"
+import { computed } from "mobx"
+import { observer } from "mobx-react"
+import { excludeUndefined } from "@ourworldindata/utils"
+import { SeriesName, Time } from "@ourworldindata/types"
+import { StackedAreaChartState } from "./StackedAreaChartState.js"
+import { STACKED_AREA_STYLE, StackedSeries } from "./StackedConstants"
+import { TooltipFooterIcon, FooterItem } from "../tooltip/TooltipProps.js"
+import {
+    Tooltip,
+    TooltipState,
+    TooltipTable,
+    makeTooltipRoundingNotice,
+    toTooltipTableColumns,
+} from "../tooltip/Tooltip"
+import { Emphasis } from "../interaction/Emphasis"
+
+export const STACKED_AREA_TOOLTIP_ID = "stackedAreaTooltip"
+
+export interface StackedAreaChartTooltipProps {
+    chartState: StackedAreaChartState
+    tooltipState: TooltipState<{
+        index: number
+        series?: SeriesName
+    }>
+    series: readonly StackedSeries<Time>[]
+    xAxisLabel?: string
+    dismissTooltip: () => void
+}
+
+@observer
+export class StackedAreaChartTooltip extends React.Component<StackedAreaChartTooltipProps> {
+    @computed private get chartState(): StackedAreaChartState {
+        return this.props.chartState
+    }
+
+    @computed private get roundingNotice(): FooterItem | undefined {
+        const { formatColumn } = this.chartState
+        if (!formatColumn.roundsToSignificantFigures) return undefined
+
+        return {
+            icon: TooltipFooterIcon.None,
+            text: makeTooltipRoundingNotice([
+                formatColumn.numSignificantFigures,
+            ]),
+        }
+    }
+
+    @computed private get footer(): FooterItem[] {
+        return excludeUndefined([this.roundingNotice])
+    }
+
+    override render(): React.ReactElement | null {
+        const { target, position, fading } = this.props.tooltipState
+        if (!target) return null
+
+        const { series } = this.props
+        const hoveredPointIndex = target.index
+        const bottomSeriesPoint = series[0]?.points[hoveredPointIndex]
+        if (!bottomSeriesPoint) return null
+
+        const { formatColumn } = this.chartState
+        const formattedTime = formatColumn.formatTime(
+            bottomSeriesPoint.position
+        )
+        const titleAnnotation = this.props.xAxisLabel
+            ? `(${this.props.xAxisLabel})`
+            : ""
+
+        const lastStackedPoint = R.last(series)!.points[hoveredPointIndex]
+        if (!lastStackedPoint) return null
+        const totalValue = lastStackedPoint.value + lastStackedPoint.valueOffset
+
+        return (
+            <Tooltip
+                id={STACKED_AREA_TOOLTIP_ID}
+                tooltipManager={this.chartState.manager}
+                x={position.x}
+                y={position.y}
+                offsetY={-16}
+                offsetX={20}
+                offsetXDirection="left"
+                style={{ maxWidth: "50%" }}
+                title={formattedTime}
+                titleAnnotation={titleAnnotation}
+                subtitle={formatColumn.displayUnit}
+                subtitleFormat="unit"
+                footer={this.footer}
+                dissolve={fading}
+                dismiss={this.props.dismissTooltip}
+            >
+                <TooltipTable
+                    columns={toTooltipTableColumns(formatColumn)}
+                    totals={[totalValue]}
+                    rows={series.toReversed().map((series) => {
+                        const { seriesName: name, color, points } = series
+                        const point = points[hoveredPointIndex]
+                        const focused = name === target.series
+                        const values = [
+                            point?.missing || point?.interpolated
+                                ? undefined
+                                : point?.value,
+                        ]
+
+                        const emphasis = focused
+                            ? Emphasis.Highlighted
+                            : Emphasis.Default
+                        const opacity = STACKED_AREA_STYLE[emphasis].fillOpacity
+
+                        const swatch = { color, opacity }
+
+                        return {
+                            name,
+                            swatch,
+                            focused,
+                            values,
+                        }
+                    })}
+                />
+            </Tooltip>
+        )
+    }
+}

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChart.tsx
@@ -17,14 +17,8 @@ import {
     VerticalColorLegend,
     VerticalColorLegendManager,
 } from "../legend/VerticalColorLegend"
-import { TooltipFooterIcon } from "../tooltip/TooltipProps.js"
-import {
-    Tooltip,
-    TooltipState,
-    TooltipTable,
-    makeTooltipRoundingNotice,
-    toTooltipTableColumns,
-} from "../tooltip/Tooltip"
+import { TooltipState } from "../tooltip/Tooltip"
+import { StackedBarChartTooltip } from "./StackedBarChartTooltip"
 import {
     BASE_FONT_SIZE,
     DEFAULT_GRAPHER_BOUNDS,
@@ -36,7 +30,6 @@ import {
     StackedSeries,
     PlacedStackedBarSeries,
     RenderStackedBarSeries,
-    STACKED_BAR_STYLE,
 } from "./StackedConstants"
 import { DualAxis, HorizontalAxis, VerticalAxis } from "../axis/Axis"
 import { Color, HorizontalAlign, SeriesName } from "@ourworldindata/types"
@@ -353,99 +346,13 @@ export class StackedBarChart
         return undefined
     }
 
-    @computed private get tooltip(): React.ReactElement | undefined {
-        const {
-            tooltipState: { target, position, fading },
-            series,
-        } = this
-        const { formatColumn } = this.chartState
-
-        const { bar: hoverBar, series: hoverSeries } = target ?? {}
-        let hoverTime: number
-        if (hoverBar !== undefined) {
-            hoverTime = hoverBar.position
-        } else return
-
-        const title = formatColumn.formatTime(hoverTime)
-        const titleAnnotation = this.xAxis.label ? `(${this.xAxis.label})` : ""
-
-        const { displayUnit } = formatColumn
-
-        const totalValue = _.sum(
-            series.map(
-                ({ points }) =>
-                    points.find((bar) => bar.position === hoverTime)?.value ?? 0
-            )
-        )
-
-        const roundingNotice = formatColumn.roundsToSignificantFigures
-            ? {
-                  icon: TooltipFooterIcon.None,
-                  text: makeTooltipRoundingNotice([
-                      formatColumn.numSignificantFigures,
-                  ]),
-              }
-            : undefined
-        const footer = excludeUndefined([roundingNotice])
-
-        const hoverPoints = series.map((series) => {
-            const point = series.points.find(
-                (bar) => bar.position === hoverTime
-            )
-            return {
-                seriesName: series.seriesName,
-                seriesColor: series.color,
-                point,
-            }
-        })
-        const [positivePoints, negativePoints] = _.partition(
-            hoverPoints,
-            ({ point }) => (point?.value ?? 0) >= 0
-        )
-        const sortedHoverPoints = [
-            ...positivePoints.toReversed(),
-            ...negativePoints,
-        ]
-
+    @computed private get tooltip(): React.ReactElement | null {
         return (
-            <Tooltip
-                id={this.renderUid}
-                tooltipManager={this.manager}
-                x={position.x}
-                y={position.y}
-                style={{ maxWidth: "500px" }}
-                offsetX={20}
-                offsetY={-16}
-                title={title}
-                titleAnnotation={titleAnnotation}
-                subtitle={displayUnit}
-                subtitleFormat="unit"
-                footer={footer}
-                dissolve={fading}
-                dismiss={() => (this.tooltipState.target = null)}
-            >
-                <TooltipTable
-                    columns={toTooltipTableColumns(formatColumn)}
-                    totals={[totalValue]}
-                    rows={sortedHoverPoints.map(
-                        ({ point, seriesName: name, seriesColor }) => {
-                            const focused = hoverSeries?.seriesName === name
-                            const fake = point?.missing || point?.interpolated
-                            const blurred = fake ?? true
-                            const values = [fake ? undefined : point?.value]
-
-                            const color = point?.color ?? seriesColor
-                            const emphasis = focused
-                                ? Emphasis.Highlighted
-                                : Emphasis.Default
-                            const opacity = STACKED_BAR_STYLE[emphasis].opacity
-                            const swatch = { color, opacity }
-
-                            return { name, swatch, blurred, focused, values }
-                        }
-                    )}
-                />
-            </Tooltip>
+            <StackedBarChartTooltip
+                chartState={this.chartState}
+                tooltipState={this.tooltipState}
+                xAxisLabel={this.xAxis.label}
+            />
         )
     }
 

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChartTooltip.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChartTooltip.tsx
@@ -1,0 +1,138 @@
+import * as _ from "lodash-es"
+import React from "react"
+import { computed } from "mobx"
+import { observer } from "mobx-react"
+import { excludeUndefined, Time } from "@ourworldindata/utils"
+import { StackedBarChartState } from "./StackedBarChartState.js"
+import {
+    StackedPoint,
+    StackedSeries,
+    STACKED_BAR_STYLE,
+} from "./StackedConstants"
+import { TooltipFooterIcon, FooterItem } from "../tooltip/TooltipProps.js"
+import {
+    Tooltip,
+    TooltipState,
+    TooltipTable,
+    makeTooltipRoundingNotice,
+    toTooltipTableColumns,
+} from "../tooltip/Tooltip"
+import { Emphasis } from "../interaction/Emphasis"
+
+export interface StackedBarChartTooltipProps {
+    chartState: StackedBarChartState
+    tooltipState: TooltipState<{
+        bar: StackedPoint<Time>
+        series: StackedSeries<Time>
+    }>
+    xAxisLabel?: string
+}
+
+@observer
+export class StackedBarChartTooltip extends React.Component<StackedBarChartTooltipProps> {
+    @computed private get chartState(): StackedBarChartState {
+        return this.props.chartState
+    }
+
+    @computed private get hoverTime(): number | undefined {
+        return this.props.tooltipState.target?.bar.position
+    }
+
+    @computed private get roundingNotice(): FooterItem | undefined {
+        const { formatColumn } = this.chartState
+        if (!formatColumn.roundsToSignificantFigures) return undefined
+
+        return {
+            icon: TooltipFooterIcon.None,
+            text: makeTooltipRoundingNotice([
+                formatColumn.numSignificantFigures,
+            ]),
+        }
+    }
+
+    @computed private get footer(): FooterItem[] {
+        return excludeUndefined([this.roundingNotice])
+    }
+
+    override render(): React.ReactElement | null {
+        const { target, position, fading } = this.props.tooltipState
+        const { hoverTime } = this
+
+        if (!target || hoverTime === undefined) return null
+
+        const { formatColumn, series } = this.chartState
+        const hoverSeries = target.series
+
+        const title = formatColumn.formatTime(hoverTime)
+        const titleAnnotation = this.props.xAxisLabel
+            ? `(${this.props.xAxisLabel})`
+            : ""
+
+        const totalValue = _.sum(
+            series.map(
+                ({ points }) =>
+                    points.find((bar) => bar.position === hoverTime)?.value ?? 0
+            )
+        )
+
+        const hoverPoints = series.map((series) => {
+            const point = series.points.find(
+                (bar) => bar.position === hoverTime
+            )
+            return {
+                seriesName: series.seriesName,
+                seriesColor: series.color,
+                point,
+            }
+        })
+        const [positivePoints, negativePoints] = _.partition(
+            hoverPoints,
+            ({ point }) => (point?.value ?? 0) >= 0
+        )
+        const sortedHoverPoints = [
+            ...positivePoints.toReversed(),
+            ...negativePoints,
+        ]
+
+        return (
+            <Tooltip
+                id="stackedBarTooltip"
+                tooltipManager={this.chartState.manager}
+                x={position.x}
+                y={position.y}
+                style={{ maxWidth: "500px" }}
+                offsetX={20}
+                offsetY={-16}
+                title={title}
+                titleAnnotation={titleAnnotation}
+                subtitle={formatColumn.displayUnit}
+                subtitleFormat="unit"
+                footer={this.footer}
+                dissolve={fading}
+                dismiss={() => (this.props.tooltipState.target = null)}
+            >
+                <TooltipTable
+                    columns={toTooltipTableColumns(formatColumn)}
+                    totals={[totalValue]}
+                    rows={sortedHoverPoints.map(
+                        ({ point, seriesName: name, seriesColor }) => {
+                            const focused = hoverSeries?.seriesName === name
+                            const fake = point?.missing || point?.interpolated
+                            const blurred = fake ?? true
+                            const values = [fake ? undefined : point?.value]
+
+                            const color = point?.color ?? seriesColor
+                            const emphasis = focused
+                                ? Emphasis.Highlighted
+                                : Emphasis.Default
+                            const opacity = STACKED_BAR_STYLE[emphasis].opacity
+                            const swatch = { color, opacity }
+
+                            return { name, swatch, blurred, focused, values }
+                        }
+                    )}
+                />
+            </Tooltip>
+        )
+    }
+}

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBarChart.tsx
@@ -6,7 +6,6 @@ import {
     Time,
     HorizontalAlign,
     EntityName,
-    excludeUndefined,
     numberMagnitude,
     getRelativeMouse,
     exposeInstanceOnWindow,
@@ -32,15 +31,8 @@ import { NoDataModal } from "../noDataModal/NoDataModal"
 import { ChartInterface } from "../chart/ChartInterface"
 import { ChartManager } from "../chart/ChartManager"
 import { OwidTable, CoreColumn } from "@ourworldindata/core-table"
-import { TooltipFooterIcon } from "../tooltip/TooltipProps.js"
-import {
-    Tooltip,
-    TooltipState,
-    TooltipTable,
-    makeTooltipRoundingNotice,
-    makeTooltipToleranceNotice,
-    toTooltipTableColumns,
-} from "../tooltip/Tooltip"
+import { TooltipState } from "../tooltip/Tooltip"
+import { StackedDiscreteBarChartTooltip } from "./StackedDiscreteBarChartTooltip"
 import {
     LEGEND_STYLE_FOR_STACKED_CHARTS,
     StackedPoint,
@@ -513,87 +505,12 @@ export class StackedDiscreteBarChart
         this.clearTooltip()
     }
 
-    @computed private get tooltip(): React.ReactElement | undefined {
-        const {
-                tooltipState: { target, position, fading },
-                formatColumn: { displayUnit },
-                manager: { endTime: targetTime },
-                inputTable: { timeColumn },
-            } = this,
-            item = this.placedRows.find(
-                ({ entityName }) => entityName === target?.entityName
-            ),
-            hasNotice = item?.bars.some(
-                ({ point }) =>
-                    !point.missing &&
-                    !point.interpolated &&
-                    point.time !== targetTime
-            ),
-            targetNotice = hasNotice
-                ? timeColumn.formatValue(targetTime)
-                : undefined
-
-        const toleranceNotice = targetNotice
-            ? {
-                  icon: TooltipFooterIcon.Notice,
-                  text: makeTooltipToleranceNotice(targetNotice),
-              }
-            : undefined
-        const roundingNotice = this.formatColumn.roundsToSignificantFigures
-            ? {
-                  icon: TooltipFooterIcon.None,
-                  text: makeTooltipRoundingNotice([
-                      this.formatColumn.numSignificantFigures,
-                  ]),
-              }
-            : undefined
-        const footer = excludeUndefined([toleranceNotice, roundingNotice])
-
+    @computed private get tooltip(): React.ReactElement | null {
         return (
-            target &&
-            item && (
-                <Tooltip
-                    id="stackedDiscreteBarTooltip"
-                    tooltipManager={this.manager}
-                    x={position.x}
-                    y={position.y}
-                    style={{ maxWidth: "400px" }}
-                    offsetX={20}
-                    offsetY={-16}
-                    title={target.entityName}
-                    subtitle={displayUnit}
-                    subtitleFormat="unit"
-                    footer={footer}
-                    dissolve={fading}
-                    dismiss={() => (this.tooltipState.target = null)}
-                >
-                    <TooltipTable
-                        columns={toTooltipTableColumns(this.formatColumn)}
-                        totals={[item.totalValue]}
-                        rows={item.bars.map((bar) => {
-                            const {
-                                seriesName: name,
-                                color,
-                                point: { value, time, missing, interpolated },
-                            } = bar
-
-                            const blurred = missing || interpolated
-
-                            return {
-                                name,
-                                swatch: { color },
-                                blurred,
-                                focused: name === target.seriesName,
-                                values: [!blurred ? value : undefined],
-                                originalTime:
-                                    !blurred && time !== targetTime
-                                        ? timeColumn.formatValue(time)
-                                        : undefined,
-                            }
-                        })}
-                    ></TooltipTable>
-                </Tooltip>
-            )
+            <StackedDiscreteBarChartTooltip
+                chartState={this.chartState}
+                tooltipState={this.tooltipState}
+            />
         )
     }
 

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBarChartTooltip.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBarChartTooltip.tsx
@@ -1,0 +1,132 @@
+import React from "react"
+import { computed } from "mobx"
+import { observer } from "mobx-react"
+import { excludeUndefined } from "@ourworldindata/utils"
+import { StackedDiscreteBarChartState } from "./StackedDiscreteBarChartState"
+import { DiscreteBarRow } from "./StackedDiscreteBarChartConstants.js"
+import { TooltipFooterIcon, FooterItem } from "../tooltip/TooltipProps.js"
+import {
+    Tooltip,
+    TooltipState,
+    TooltipTable,
+    makeTooltipRoundingNotice,
+    makeTooltipToleranceNotice,
+    toTooltipTableColumns,
+} from "../tooltip/Tooltip"
+
+export interface StackedDiscreteBarChartTooltipProps {
+    chartState: StackedDiscreteBarChartState
+    tooltipState: TooltipState<{
+        entityName: string
+        seriesName?: string
+    }>
+}
+
+@observer
+export class StackedDiscreteBarChartTooltip extends React.Component<StackedDiscreteBarChartTooltipProps> {
+    @computed private get chartState(): StackedDiscreteBarChartState {
+        return this.props.chartState
+    }
+
+    @computed private get item(): DiscreteBarRow | undefined {
+        const { target } = this.props.tooltipState
+        if (!target) return undefined
+        return this.chartState.sortedRows.find(
+            ({ entityName }) => entityName === target.entityName
+        )
+    }
+
+    @computed private get toleranceNotice(): FooterItem | undefined {
+        const { item } = this
+        if (!item) return undefined
+
+        const targetTime = this.chartState.manager.endTime
+        const { timeColumn } = this.chartState.inputTable
+
+        const hasNotice = item.bars.some(
+            ({ point }) =>
+                !point.missing &&
+                !point.interpolated &&
+                point.time !== targetTime
+        )
+
+        if (!hasNotice) return undefined
+
+        const targetNotice = timeColumn.formatValue(targetTime)
+        return {
+            icon: TooltipFooterIcon.Notice,
+            text: makeTooltipToleranceNotice(targetNotice),
+        }
+    }
+
+    @computed private get roundingNotice(): FooterItem | undefined {
+        const { formatColumn } = this.chartState
+        if (!formatColumn.roundsToSignificantFigures) return undefined
+
+        return {
+            icon: TooltipFooterIcon.None,
+            text: makeTooltipRoundingNotice([
+                formatColumn.numSignificantFigures,
+            ]),
+        }
+    }
+
+    @computed private get footer(): FooterItem[] {
+        return excludeUndefined([this.toleranceNotice, this.roundingNotice])
+    }
+
+    override render(): React.ReactElement | null {
+        const { target, position, fading } = this.props.tooltipState
+        const { item } = this
+
+        if (!target || !item) return null
+
+        const { formatColumn } = this.chartState
+        const targetTime = this.chartState.manager.endTime
+        const { timeColumn } = this.chartState.inputTable
+
+        return (
+            <Tooltip
+                id="stackedDiscreteBarTooltip"
+                tooltipManager={this.chartState.manager}
+                x={position.x}
+                y={position.y}
+                style={{ maxWidth: "400px" }}
+                offsetX={20}
+                offsetY={-16}
+                title={target.entityName}
+                subtitle={formatColumn.displayUnit}
+                subtitleFormat="unit"
+                footer={this.footer}
+                dissolve={fading}
+                dismiss={() => (this.props.tooltipState.target = null)}
+            >
+                <TooltipTable
+                    columns={toTooltipTableColumns(formatColumn)}
+                    totals={[item.totalValue]}
+                    rows={item.bars.map((bar) => {
+                        const {
+                            seriesName: name,
+                            color,
+                            point: { value, time, missing, interpolated },
+                        } = bar
+
+                        const blurred = missing || interpolated
+
+                        return {
+                            name,
+                            swatch: { color },
+                            blurred,
+                            focused: name === target.seriesName,
+                            values: [!blurred ? value : undefined],
+                            originalTime:
+                                !blurred && time !== targetTime
+                                    ? timeColumn.formatValue(time)
+                                    : undefined,
+                        }
+                    })}
+                />
+            </Tooltip>
+        )
+    }
+}


### PR DESCRIPTION
## Context

This PR extracts tooltip logic from chart components into dedicated tooltip components to improve code organization and maintainability. The refactoring affects LineChart, SlopeChart, MarimekkoChart, StackedAreaChart, StackedBarChart, and StackedDiscreteBarChart.

## Screenshots / Videos / Diagrams

No UI changes - this is a pure refactoring that maintains existing tooltip functionality.

## Testing guidance

Test tooltip functionality across all affected chart types:

- [ ] LineChart tooltips display correctly with proper formatting and annotations
- [ ] SlopeChart tooltips show value ranges and trend information
- [ ] MarimekkoChart tooltips include entity data and time notices
- [ ] StackedAreaChart tooltips show series breakdown with totals
- [ ] StackedBarChart tooltips display stacked values correctly
- [ ] StackedDiscreteBarChart tooltips handle missing/interpolated data properly
- [ ] All tooltip positioning, styling, and dismissal behavior works as expected
- [ ] Does the change work in the archive?
- [ ] Does the staging experience have sign-off from product stakeholders?

## Checklist

### Before merging

- [ ] Changes to CSS/HTML were checked on Desktop and Mobile Safari at all three breakpoints
- [ ] Changes to HTML were checked for accessibility concerns