### PR TITLE
🐝 more oxfmt vscode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,8 @@
     "editor.tabSize": 4,
     "editor.detectIndentation": false,
     "editor.defaultFormatter": "oxc.oxc-vscode",
+
+    "oxc.fmt.configPath": ".oxfmtrc.json",
     "files.insertFinalNewline": false,
     "search.exclude": {
         ".yarn": true,
@@ -20,13 +22,18 @@
     "typescript.preferences.importModuleSpecifierEnding": "js",
     "javascript.preferences.importModuleSpecifierEnding": "js",
     "[sql]": {
-        "editor.defaultFormatter": "inferrinizzard.prettier-sql-vscode"
+        "editor.defaultFormatter": "ReneSaarsoo.sql-formatter-vsc"
     },
-    "Prettier-SQL.keywordCase": "upper",
-    "Prettier-SQL.SQLFlavourOverride": "mysql",
-    "Prettier-SQL.expressionWidth": 80,
-    "oxc.formatting.enable": true,
+    "SQL-Formatter-VSCode.denseOperators": true,
+    "SQL-Formatter-VSCode.linesBetweenQueries": 1,
+    "SQL-Formatter-VSCode.insertSpacesOverride": true,
+    "SQL-Formatter-VSCode.ignoreTabSettings": true,
+    "SQL-Formatter-VSCode.tabSizeOverride": 2,
+    "SQL-Formatter-VSCode.dialect": "mysql",
     "[typescriptreact]": {
+        "editor.defaultFormatter": "oxc.oxc-vscode"
+    },
+    "[typescript]": {
         "editor.defaultFormatter": "oxc.oxc-vscode"
     }
 }

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ If you want to enable pre-commit hooks, run `yarn husky`.
 
 [Visual Studio Code](https://code.visualstudio.com/) is recommended for autocompletion and other awesome editor analysis features enabled by static typing.
 
+- We don't have many plain SQL files, but for formatting, we use the [SQL Formatter VSCode](https://marketplace.visualstudio.com/items?itemName=ReneSaarsoo.sql-formatter-vsc) extension.
+
 ## Why did we start this project?
 
 The following is an excerpt explaining the origin of this repo and what the alternatives tried were (source: [Max Roser's Reddit AMA on Oct 17, 2017](https://www.reddit.com/r/dataisbeautiful/comments/76yknx/hi_reddit_i_am_max_roser_founder_of_the_online/doicj1j?utm_source=share&utm_medium=web2x&context=3))

--- a/db/migration/pre-migrations-schema.sql
+++ b/db/migration/pre-migrations-schema.sql
@@ -3,22 +3,18 @@
 -- typeorm migrations. I.e. if you initialize an empty DB with this then
 -- you can run all existing migrations and will end up with an empty database
 -- with the most recent schema.
-
 -- There are a few minor differences between what must have been the state before
 -- migrations began and what this file achives. They are enumerated below.
-
 -- One difference is that we assume Mysql 8 already from the start and create all
 -- tables with charset utf8mb4 and collation utf8mb4_0900_as_cs. Historically
 -- that was not the case and there is an explicit migration that changed this but that
 -- just becomes a no-op now.
-
 -- Another difference is that the user_invitations table gets dropped at some point
 -- in the migrations and I didn't want to bother searching for the original create
 -- statement so we just create a dummy table with that name so that the drop works.
-
 CREATE TABLE `user_invitations` (
-    `id` int unsigned NOT NULL AUTO_INCREMENT,
-    PRIMARY KEY (`id`)
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_as_cs;
 
 CREATE TABLE `knex_migrations` (
@@ -81,8 +77,8 @@ CREATE TABLE `posts` (
   `type` mediumtext COLLATE utf8mb4_0900_as_cs NOT NULL,
   `status` mediumtext COLLATE utf8mb4_0900_as_cs NOT NULL,
   `content` longtext COLLATE utf8mb4_0900_as_cs NOT NULL,
---   `archieml` json DEFAULT NULL,
---   `archieml_update_statistics` json DEFAULT NULL,
+  --   `archieml` json DEFAULT NULL,
+  --   `archieml_update_statistics` json DEFAULT NULL,
   `published_at` datetime DEFAULT NULL,
   `updated_at` datetime NOT NULL,
   PRIMARY KEY (`id`)
@@ -133,7 +129,6 @@ CREATE TABLE `importer_importhistory` (
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_as_cs;
 
-
 CREATE TABLE `datasets` (
   `id` int NOT NULL AUTO_INCREMENT,
   `name` varchar(512) COLLATE utf8mb4_0900_as_cs DEFAULT NULL,
@@ -148,13 +143,13 @@ CREATE TABLE `datasets` (
   `dataEditedAt` datetime NOT NULL,
   `dataEditedByUserId` int NOT NULL,
   -- `nonRedistributable` tinyint(1) NOT NULL DEFAULT '0',
---   `isArchived` tinyint(1) NOT NULL DEFAULT '0',
---   `sourceChecksum` varchar(64) COLLATE utf8mb4_0900_as_cs DEFAULT NULL,
---   `shortName` varchar(255) COLLATE utf8mb4_0900_as_cs DEFAULT NULL,
---   `version` varchar(255) COLLATE utf8mb4_0900_as_cs DEFAULT NULL,
+  --   `isArchived` tinyint(1) NOT NULL DEFAULT '0',
+  --   `sourceChecksum` varchar(64) COLLATE utf8mb4_0900_as_cs DEFAULT NULL,
+  --   `shortName` varchar(255) COLLATE utf8mb4_0900_as_cs DEFAULT NULL,
+  --   `version` varchar(255) COLLATE utf8mb4_0900_as_cs DEFAULT NULL,
   PRIMARY KEY (`id`),
-  UNIQUE KEY `datasets_name_namespace_d3d60d22_uniq` (`name`,`namespace`),
---   UNIQUE KEY `unique_short_name_version_namespace` (`shortName`,`version`,`namespace`),
+  UNIQUE KEY `datasets_name_namespace_d3d60d22_uniq` (`name`, `namespace`),
+  --   UNIQUE KEY `unique_short_name_version_namespace` (`shortName`,`version`,`namespace`),
   KEY `datasets_metadataEditedByUserId` (`metadataEditedByUserId`),
   KEY `datasets_dataEditedByUserId` (`dataEditedByUserId`),
   KEY `datasets_createdByUserId` (`createdByUserId`),
@@ -162,7 +157,6 @@ CREATE TABLE `datasets` (
   CONSTRAINT `datasets_dataEditedByUserId` FOREIGN KEY (`dataEditedByUserId`) REFERENCES `users` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
   CONSTRAINT `datasets_metadataEditedByUserId` FOREIGN KEY (`metadataEditedByUserId`) REFERENCES `users` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_as_cs;
-
 
 CREATE TABLE `sources` (
   `id` int NOT NULL AUTO_INCREMENT,
@@ -192,14 +186,14 @@ CREATE TABLE `variables` (
   `display` json NOT NULL,
   `columnOrder` int NOT NULL DEFAULT '0',
   `originalMetadata` json DEFAULT NULL,
---   `grapherConfig` json DEFAULT NULL,
---   `shortName` varchar(255) COLLATE utf8mb4_0900_as_cs DEFAULT NULL,
---   `catalogPath` text COLLATE utf8mb4_0900_as_cs,
---   `dimensions` json DEFAULT NULL,
+  --   `grapherConfig` json DEFAULT NULL,
+  --   `shortName` varchar(255) COLLATE utf8mb4_0900_as_cs DEFAULT NULL,
+  --   `catalogPath` text COLLATE utf8mb4_0900_as_cs,
+  --   `dimensions` json DEFAULT NULL,
   PRIMARY KEY (`id`),
-  UNIQUE KEY `variables_name_fk_dst_id_f7453c33_uniq` (`name`,`datasetId`),
-  UNIQUE KEY `variables_code_fk_dst_id_7bde8c2a_uniq` (`code`,`datasetId`),
---   UNIQUE KEY `unique_short_name_per_dataset` (`shortName`,`datasetId`),
+  UNIQUE KEY `variables_name_fk_dst_id_f7453c33_uniq` (`name`, `datasetId`),
+  UNIQUE KEY `variables_code_fk_dst_id_7bde8c2a_uniq` (`code`, `datasetId`),
+  --   UNIQUE KEY `unique_short_name_per_dataset` (`shortName`,`datasetId`),
   KEY `variables_sourceId_31fce80a_fk_sources_id` (`sourceId`),
   KEY `variables_datasetId_50a98bfd_fk_datasets_id` (`datasetId`),
   CONSTRAINT `variables_datasetId_50a98bfd_fk_datasets_id` FOREIGN KEY (`datasetId`) REFERENCES `datasets` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
@@ -234,11 +228,10 @@ CREATE TABLE `tags` (
   `isBulkImport` tinyint(1) NOT NULL DEFAULT '0',
   `specialType` varchar(255) COLLATE utf8mb4_0900_as_cs DEFAULT NULL,
   PRIMARY KEY (`id`),
-  UNIQUE KEY `dataset_subcategories_name_fk_dst_cat_id_6ce1cc36_uniq` (`name`,`parentId`),
+  UNIQUE KEY `dataset_subcategories_name_fk_dst_cat_id_6ce1cc36_uniq` (`name`, `parentId`),
   KEY `parentId` (`parentId`),
   CONSTRAINT `tags_ibfk_1` FOREIGN KEY (`parentId`) REFERENCES `tags` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_as_cs;
-
 
 CREATE TABLE `chart_dimensions` (
   `id` int NOT NULL AUTO_INCREMENT,
@@ -279,21 +272,19 @@ CREATE TABLE `chart_slug_redirects` (
 CREATE TABLE `chart_tags` (
   `chartId` int NOT NULL,
   `tagId` int NOT NULL,
---   `isKey` tinyint unsigned DEFAULT NULL,
-  PRIMARY KEY (`chartId`,`tagId`),
+  --   `isKey` tinyint unsigned DEFAULT NULL,
+  PRIMARY KEY (`chartId`, `tagId`),
   KEY `FK_chart_tags_tagId` (`tagId`),
   CONSTRAINT `FK_chart_tags_chartId` FOREIGN KEY (`chartId`) REFERENCES `charts` (`id`) ON DELETE CASCADE ON UPDATE RESTRICT,
   CONSTRAINT `FK_chart_tags_tagId` FOREIGN KEY (`tagId`) REFERENCES `tags` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_as_cs;
-
-
 
 CREATE TABLE `country_latest_data` (
   `country_code` varchar(255) COLLATE utf8mb4_0900_as_cs DEFAULT NULL,
   `variable_id` int DEFAULT NULL,
   `year` int DEFAULT NULL,
   `value` varchar(255) COLLATE utf8mb4_0900_as_cs DEFAULT NULL,
-  UNIQUE KEY `country_latest_data_country_code_variable_id_unique` (`country_code`,`variable_id`),
+  UNIQUE KEY `country_latest_data_country_code_variable_id_unique` (`country_code`, `variable_id`),
   KEY `country_latest_data_variable_id_foreign` (`variable_id`),
   CONSTRAINT `country_latest_data_variable_id_foreign` FOREIGN KEY (`variable_id`) REFERENCES `variables` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_as_cs;
@@ -352,8 +343,8 @@ CREATE TABLE `data_values` (
   `year` int NOT NULL,
   `entityId` int NOT NULL,
   `variableId` int NOT NULL,
-  PRIMARY KEY (`variableId`,`entityId`,`year`),
-  UNIQUE KEY `data_values_fk_ent_id_fk_var_id_year_e0eee895_uniq` (`entityId`,`variableId`,`year`),
+  PRIMARY KEY (`variableId`, `entityId`, `year`),
+  UNIQUE KEY `data_values_fk_ent_id_fk_var_id_year_e0eee895_uniq` (`entityId`, `variableId`, `year`),
   KEY `data_values_variableId_variables_id` (`variableId`),
   KEY `data_values_year` (`year`),
   CONSTRAINT `data_values_entityId_entities_id` FOREIGN KEY (`entityId`) REFERENCES `entities` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
@@ -371,7 +362,7 @@ CREATE TABLE `dataset_files` (
 CREATE TABLE `dataset_tags` (
   `datasetId` int NOT NULL,
   `tagId` int NOT NULL,
-  PRIMARY KEY (`datasetId`,`tagId`),
+  PRIMARY KEY (`datasetId`, `tagId`),
   KEY `FK_2e330c9e1074b457d1d238b2dac` (`tagId`),
   CONSTRAINT `FK_2e330c9e1074b457d1d238b2dac` FOREIGN KEY (`tagId`) REFERENCES `tags` (`id`) ON DELETE CASCADE ON UPDATE RESTRICT,
   CONSTRAINT `FK_fa434de5c36953f4efce6b073b3` FOREIGN KEY (`datasetId`) REFERENCES `datasets` (`id`) ON DELETE CASCADE ON UPDATE RESTRICT
@@ -386,26 +377,14 @@ CREATE TABLE `dataset_tags` (
 --   PRIMARY KEY (`id`),
 --   UNIQUE KEY `category` (`category`,`term`)
 -- ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_as_cs;
-
-
-
-
-
-
-
-
-
-
 CREATE TABLE `post_tags` (
   `post_id` int NOT NULL,
   `tag_id` int NOT NULL,
-  PRIMARY KEY (`post_id`,`tag_id`),
+  PRIMARY KEY (`post_id`, `tag_id`),
   KEY `FK_post_tags_tag_id` (`tag_id`),
   CONSTRAINT `FK_post_tags_post_id` FOREIGN KEY (`post_id`) REFERENCES `posts` (`id`) ON DELETE CASCADE ON UPDATE RESTRICT,
   CONSTRAINT `FK_post_tags_tag_id` FOREIGN KEY (`tag_id`) REFERENCES `tags` (`id`) ON DELETE CASCADE ON UPDATE RESTRICT
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_as_cs;
-
-
 
 -- CREATE TABLE `posts_gdocs` (
 --   `id` varchar(255) COLLATE utf8mb4_0900_as_cs NOT NULL,
@@ -419,9 +398,6 @@ CREATE TABLE `post_tags` (
 --   `revisionId` varchar(255) COLLATE utf8mb4_0900_as_cs DEFAULT NULL,
 --   PRIMARY KEY (`id`)
 -- ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_as_cs;
-
-
-
 -- CREATE TABLE `suggested_chart_revisions` (
 --   `id` bigint NOT NULL AUTO_INCREMENT,
 --   `chartId` int NOT NULL,


### PR DESCRIPTION
Adds a `defaultFormatter` rule for TS files, which VSCode seems to need for format on save to work as expected.

I also noticed our SQL formatter (only used for `db/migration/pre-migrations-schema.sql`) was no longer supported, so I updated it to a [newer one](https://marketplace.visualstudio.com/items?itemName=ReneSaarsoo.sql-formatter-vsc) and configured it to minimize the diff as best I could.