### PR TITLE
Improve HTML semantics

### DIFF
--- a/site/NewsletterSubscription.tsx
+++ b/site/NewsletterSubscription.tsx
@@ -142,7 +142,7 @@ export const NewsletterSubscriptionForm = ({
                 <label htmlFor={idBiweekly}>
                     <span className="newsletter-subscription-form__label-title">
                         The OWID Brief
-                    </span>
+                    </span>{" "}
                     <span className="newsletter-subscription-form__label-frequency note-12-medium">
                         Twice a month
                     </span>
@@ -177,7 +177,7 @@ export const NewsletterSubscriptionForm = ({
                 <label htmlFor={idDataInsights}>
                     <span className="newsletter-subscription-form__label-title">
                         Data Insights
-                    </span>
+                    </span>{" "}
                     <span className="newsletter-subscription-form__label-frequency note-12-medium">
                         Every few days
                     </span>

--- a/site/css/newsletter-subscription.scss
+++ b/site/css/newsletter-subscription.scss
@@ -18,7 +18,7 @@
 .newsletter-subscription-form__label-frequency {
     display: none;
     color: $blue-60;
-    margin-left: 8px;
+    margin-left: 4px;
 }
 
 .newsletter-subscription-form__label-text {

--- a/site/gdocs/OwidGdoc.test.tsx
+++ b/site/gdocs/OwidGdoc.test.tsx
@@ -1,0 +1,43 @@
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it } from "vitest"
+import { OwidGdocType } from "@ourworldindata/types"
+import type { OwidGdocPageProps } from "@ourworldindata/utils"
+import { OwidGdoc } from "./OwidGdoc.js"
+
+const fragmentProps: OwidGdocPageProps = {
+    id: "test-gdoc-id",
+    slug: "test-fragment",
+    content: {
+        type: OwidGdocType.Fragment,
+        title: "Test fragment",
+        authors: [],
+        body: [],
+    },
+    contentMd5: "test-content-md5",
+    createdAt: new Date("2026-03-10T00:00:00Z"),
+    updatedAt: null,
+    published: true,
+    publishedAt: null,
+    breadcrumbs: [],
+    manualBreadcrumbs: null,
+    tags: [],
+    linkedAuthors: [],
+    linkedDocuments: {},
+    linkedStaticViz: {},
+    linkedCharts: {},
+    linkedNarrativeCharts: {},
+    linkedIndicators: {},
+    linkedCallouts: {},
+    imageMetadata: {},
+    relatedCharts: [],
+}
+
+describe("OwidGdoc", () => {
+    it("does not render admin links into the server HTML", () => {
+        const html = renderToStaticMarkup(<OwidGdoc {...fragmentProps} />)
+
+        expect(html).not.toContain('class="gdoc-admin-bar"')
+        expect(html).not.toContain('id="gdoc-link"')
+        expect(html).not.toContain('id="admin-link"')
+    })
+})

--- a/site/gdocs/OwidGdoc.tsx
+++ b/site/gdocs/OwidGdoc.tsx
@@ -3,6 +3,7 @@ import * as React from "react"
 import { OwidGdocType, ArchiveContext } from "@ourworldindata/types"
 import { OwidGdocPageProps } from "@ourworldindata/utils"
 import { match, P } from "ts-pattern"
+import { useIsClient } from "usehooks-ts"
 import { GdocPost } from "./pages/GdocPost.js"
 import { DataInsightPage } from "./pages/DataInsight.js"
 import { Fragment } from "./pages/Fragment.js"
@@ -13,24 +14,47 @@ import { AttachmentsContext } from "./AttachmentsContext.js"
 import { DocumentContext } from "./DocumentContext.js"
 import { AnnouncementPage } from "./pages/Announcement.js"
 import { Profile } from "./pages/Profile.js"
-
-function AdminLinks() {
-    return (
-        <div id="gdoc-admin-bar">
-            <a href="#" id="gdoc-link">
-                Gdoc
-            </a>
-            <span>/</span>
-            <a href="#" id="admin-link">
-                Admin
-            </a>
-        </div>
-    )
-}
+import { ADMIN_BASE_URL } from "../../settings/clientSettings.js"
+import { CookieKey } from "@ourworldindata/grapher"
 
 type OwidGdocProps = OwidGdocPageProps & {
     isPreviewing?: boolean
     archiveContext?: ArchiveContext
+}
+
+function hasAdminCookie(): boolean {
+    try {
+        return document.cookie.includes(CookieKey.isAdmin)
+    } catch {
+        return false
+    }
+}
+
+function AdminLinks({ id }: Pick<OwidGdocPageProps, "id">) {
+    const isClient = useIsClient()
+    if (!isClient || !id || !hasAdminCookie()) return null
+
+    return (
+        <div className="gdoc-admin-bar">
+            <a
+                href={`https://docs.google.com/document/d/${id}/edit`}
+                id="gdoc-link"
+                target="_blank"
+                rel="noopener"
+            >
+                Gdoc
+            </a>
+            <span>/</span>
+            <a
+                href={`${ADMIN_BASE_URL}/admin/gdocs/${id}/preview`}
+                id="admin-link"
+                target="_blank"
+                rel="noopener"
+            >
+                Admin
+            </a>
+        </div>
+    )
 }
 
 export function OwidGdoc({
@@ -112,7 +136,7 @@ export function OwidGdoc({
             }}
         >
             <DocumentContext.Provider value={{ isPreviewing, archiveContext }}>
-                <AdminLinks />
+                <AdminLinks id={props.id} />
                 {content}
             </DocumentContext.Provider>
         </AttachmentsContext.Provider>

--- a/site/gdocs/components/ExplorerTiles.scss
+++ b/site/gdocs/components/ExplorerTiles.scss
@@ -23,6 +23,9 @@
     }
     .explorer-tiles-grid {
         row-gap: var(--grid-gap);
+        list-style: none;
+        margin: 0;
+        padding: 0;
         @include md-down {
             grid-template-rows: repeat(2, 1fr);
             column-gap: var(--grid-gap);
@@ -33,6 +36,8 @@
         background-image: url("https://ourworldindata.org/explorer-thumbnail.webp");
         background-size: cover;
         background-position: center;
+        width: 100%;
+        height: 100%;
         padding: 16px;
         display: flex;
         flex-wrap: wrap;

--- a/site/gdocs/components/ExplorerTiles.tsx
+++ b/site/gdocs/components/ExplorerTiles.tsx
@@ -27,18 +27,20 @@ function ExplorerTile({ url }: { url: string }) {
     ) : null
 
     return (
-        <a
-            className="explorer-tile span-cols-3 span-md-cols-6"
-            href={linkedChart.resolvedUrl}
-        >
-            {icon}
-            <div className="explorer-tile__text-container">
-                <p className="h3-bold explorer-tile__title">
-                    {linkedChart.title}
-                </p>
-                <p className="h3-bold explorer-tile__suffix"> Data Explorer</p>
-            </div>
-        </a>
+        <li className="span-cols-3 span-md-cols-6">
+            <a className="explorer-tile" href={linkedChart.resolvedUrl}>
+                {icon}
+                <div className="explorer-tile__text-container">
+                    <p className="h3-bold explorer-tile__title">
+                        {linkedChart.title}
+                    </p>
+                    <p className="h3-bold explorer-tile__suffix">
+                        {" "}
+                        Data Explorer
+                    </p>
+                </div>
+            </a>
+        </li>
     )
 }
 
@@ -67,11 +69,11 @@ export function ExplorerTiles({
             <p className="body-2-regular explorer-tiles__subtitle span-cols-8 span-md-cols-7 span-sm-cols-12">
                 {subtitle}
             </p>
-            <div className="span-cols-12 grid explorer-tiles-grid">
+            <ul className="span-cols-12 grid explorer-tiles-grid">
                 {explorers.map((explorer) => (
                     <ExplorerTile key={explorer.url} {...explorer} />
                 ))}
-            </div>
+            </ul>
         </div>
     )
 }

--- a/site/gdocs/components/HomepageIntro.scss
+++ b/site/gdocs/components/HomepageIntro.scss
@@ -39,12 +39,14 @@
 }
 
 .homepage-intro__featured-tile {
+    display: block;
     border: 1px solid $blue-10;
     padding: 16px;
     color: $blue-90;
     align-self: start;
     margin-bottom: 24px;
     transition: border-color 0.125s;
+
     &:hover {
         border-color: $blue-30;
     }
@@ -76,7 +78,7 @@
     color: $vermillion;
     padding: 2px 4px;
     border-radius: 2px;
-    margin-right: 8px;
+    margin-right: 5px;
 }
 
 .homepage-intro__featured-work-kicker {
@@ -253,7 +255,7 @@
 
     .newsletter-subscription-form__label-frequency {
         display: inline;
-        margin-left: 6px;
+        margin-left: 2px;
     }
 
     .newsletter-subscription-form__email-submit {

--- a/site/gdocs/components/HomepageIntro.tsx
+++ b/site/gdocs/components/HomepageIntro.tsx
@@ -84,7 +84,11 @@ function FeaturedWorkTile({
             {kicker && (
                 <span className="h6-black-caps homepage-intro__featured-work-kicker">
                     {isNew && (
-                        <span className="homepage-intro__new-tag">New</span>
+                        <>
+                            <span className="homepage-intro__new-tag">
+                                New
+                            </span>{" "}
+                        </>
                     )}
                     {kicker}
                 </span>

--- a/site/gdocs/components/HomepageSearch.tsx
+++ b/site/gdocs/components/HomepageSearch.tsx
@@ -20,29 +20,35 @@ export function HomepageSearch(props: { className?: string }) {
     const message =
         chartCount && topicCount && explorerCount ? (
             <div>
-                <div className="homepage-search__links">
-                    <a
-                        className="homepage-search__link body-3-medium"
-                        href={SEARCH_BASE_PATH}
-                    >
-                        <FontAwesomeIcon icon={faChartLine} />
-                        {commafyNumber(chartCount)} Charts
-                    </a>
-                    <a
-                        className="homepage-search__link body-3-medium"
-                        href="#all-topics"
-                    >
-                        <FontAwesomeIcon icon={faBookmark} />
-                        {commafyNumber(topicCount)} Topic Pages
-                    </a>
-                    <a
-                        className="homepage-search__link body-3-medium"
-                        href="/explorers"
-                    >
-                        <FontAwesomeIcon icon={faMagnifyingGlassChart} />
-                        {commafyNumber(explorerCount)} Data Explorers
-                    </a>
-                </div>
+                <ul className="homepage-search__links">
+                    <li>
+                        <a
+                            className="homepage-search__link body-3-medium"
+                            href={SEARCH_BASE_PATH}
+                        >
+                            <FontAwesomeIcon icon={faChartLine} />
+                            {commafyNumber(chartCount)} Charts
+                        </a>
+                    </li>
+                    <li>
+                        <a
+                            className="homepage-search__link body-3-medium"
+                            href="#all-topics"
+                        >
+                            <FontAwesomeIcon icon={faBookmark} />
+                            {commafyNumber(topicCount)} Topic Pages
+                        </a>
+                    </li>
+                    <li>
+                        <a
+                            className="homepage-search__link body-3-medium"
+                            href="/explorers"
+                        >
+                            <FontAwesomeIcon icon={faMagnifyingGlassChart} />
+                            {commafyNumber(explorerCount)} Data Explorers
+                        </a>
+                    </li>
+                </ul>
                 <div className="homepage-search__links--mobile">
                     <a href="/data" className="body-3-medium">
                         {commafyNumber(chartCount)} Charts

--- a/site/gdocs/components/KeyIndicatorCollection.scss
+++ b/site/gdocs/components/KeyIndicatorCollection.scss
@@ -141,7 +141,7 @@
     .key-indicator-header__title {
         @include body-2-semibold;
         color: $blue-90;
-        margin-right: 8px;
+        margin-right: 4px;
 
         @include sm-only-or-no-js {
             line-height: 1.2;

--- a/site/gdocs/components/KeyIndicatorCollection.tsx
+++ b/site/gdocs/components/KeyIndicatorCollection.tsx
@@ -271,9 +271,12 @@ function KeyIndicatorHeader({
                         {linkedIndicator.title}
                     </span>
                     {source && (
-                        <span className="key-indicator-header__source">
-                            {source}
-                        </span>
+                        <>
+                            {" "}
+                            <span className="key-indicator-header__source">
+                                {source}
+                            </span>
+                        </>
                     )}
                 </div>
             </div>

--- a/site/gdocs/components/LatestDataInsights.scss
+++ b/site/gdocs/components/LatestDataInsights.scss
@@ -25,9 +25,13 @@ html:not(.js-enabled) .latest-data-insights__viewport {
     display: flex;
     gap: var(--grid-gap);
     scrollbar-width: thin;
+    list-style: none;
+    margin: 0;
+    padding: 0;
 }
 
 .latest-data-insights__card {
+    flex: 0 0 845px;
     height: 322px;
     transition:
         opacity 0.2s ease-in-out,
@@ -48,8 +52,8 @@ html:not(.js-enabled) .latest-data-insights__card,
 
 .latest-data-insights__card__data-insight {
     display: flex;
+    height: 100%;
     gap: 16px 24px;
-    flex: 0 0 845px;
     color: $blue-90;
     background: $blue-20;
     padding: 16px;
@@ -79,7 +83,8 @@ html:not(.js-enabled) .latest-data-insights__card,
     }
 }
 
-.latest-data-insights__card__data-insight.is-snapped {
+.latest-data-insights__card.is-snapped
+    .latest-data-insights__card__data-insight {
     box-shadow: 0 4px 24px 0 rgba(0, 0, 0, 0.08);
 }
 

--- a/site/gdocs/components/LatestDataInsights.tsx
+++ b/site/gdocs/components/LatestDataInsights.tsx
@@ -77,7 +77,7 @@ export default function LatestDataInsights({
     return (
         <div className={cx("latest-data-insights", className)}>
             <div className="latest-data-insights__viewport" ref={emblaRef}>
-                <div className="latest-data-insights__card-container">
+                <ul className="latest-data-insights__card-container">
                     {dataInsights.map((dataInsight, index) => (
                         <DataInsightCard
                             key={dataInsight.id}
@@ -94,14 +94,16 @@ export default function LatestDataInsights({
                     {isSmallScreen && (
                         // Normal way to hide the last slide would be a CSS media
                         // query with `display: none`, but that breaks Embla.
-                        <Button
-                            className="latest-data-insights__card latest-data-insights__card__see-all body-3-medium"
-                            href="/data-insights"
-                            text="See all our Data Insights"
-                            theme="outline-vermillion"
-                        />
+                        <li className="latest-data-insights__card">
+                            <Button
+                                className="latest-data-insights__card__see-all body-3-medium"
+                                href="/data-insights"
+                                text="See all our Data Insights"
+                                theme="outline-vermillion"
+                            />
+                        </li>
                     )}
-                </div>
+                </ul>
             </div>
             {canScrollPrev && (
                 <Button
@@ -158,51 +160,56 @@ const DataInsightCard = memo(function DataInsightCard({
         | undefined
     const otherBlocks = body.filter((_, index) => index !== firstImageIndex)
     return (
-        <a
-            className="latest-data-insights__card latest-data-insights__card__data-insight"
-            href={href}
-            aria-labelledby={titleId}
-        >
-            {firstImageBlock && (
-                <Image
-                    className="latest-data-insights__card-left"
-                    filename={
-                        firstImageBlock.smallFilename ||
-                        firstImageBlock.filename
-                    }
-                    containerType="span-5"
-                    shouldLightbox={false}
-                />
-            )}
-            <div className="latest-data-insights__card-right">
-                {publishedAt && (
-                    <DataInsightDateline
-                        className="latest-data-insights__card-dateline"
-                        publishedAt={publishedAt}
-                        highlightToday={true}
+        <li className="latest-data-insights__card">
+            <a
+                className="latest-data-insights__card__data-insight"
+                href={href}
+                aria-labelledby={titleId}
+            >
+                {firstImageBlock && (
+                    <Image
+                        className="latest-data-insights__card-left"
+                        filename={
+                            firstImageBlock.smallFilename ||
+                            firstImageBlock.filename
+                        }
+                        containerType="span-5"
+                        shouldLightbox={false}
                     />
                 )}
-                <h3 id={titleId} className="latest-data-insights__card-title">
-                    {title}
-                </h3>
-                <div className="latest-data-insights__card-body">
-                    <ArticleBlocks
-                        blocks={otherBlocks}
-                        containerType="data-insight"
-                        shouldRenderLinks={false}
-                    />
+                <div className="latest-data-insights__card-right">
+                    {publishedAt && (
+                        <DataInsightDateline
+                            className="latest-data-insights__card-dateline"
+                            publishedAt={publishedAt}
+                            highlightToday={true}
+                        />
+                    )}
+                    <h3
+                        id={titleId}
+                        className="latest-data-insights__card-title"
+                    >
+                        {title}
+                    </h3>
+                    <div className="latest-data-insights__card-body">
+                        <ArticleBlocks
+                            blocks={otherBlocks}
+                            containerType="data-insight"
+                            shouldRenderLinks={false}
+                        />
+                    </div>
+                    <div className="latest-data-insights__card-continue">
+                        <span className="body-3-medium-underlined">
+                            Continue reading
+                        </span>{" "}
+                        <FontAwesomeIcon
+                            icon={faArrowRight}
+                            style={{ fontSize: "10px" }}
+                        />
+                    </div>
                 </div>
-                <div className="latest-data-insights__card-continue">
-                    <span className="body-3-medium-underlined">
-                        Continue reading
-                    </span>{" "}
-                    <FontAwesomeIcon
-                        icon={faArrowRight}
-                        style={{ fontSize: "10px" }}
-                    />
-                </div>
-            </div>
-        </a>
+            </a>
+        </li>
     )
 })
 

--- a/site/gdocs/components/ResearchAndWriting.scss
+++ b/site/gdocs/components/ResearchAndWriting.scss
@@ -92,6 +92,7 @@ $rw-margin-bottom-grid-cell: 4px;
 }
 
 .research-and-writing-link {
+    display: block;
     color: $blue-90;
 
     &:hover .research-and-writing-link__title {

--- a/site/gdocs/components/centered-article.scss
+++ b/site/gdocs/components/centered-article.scss
@@ -1,5 +1,4 @@
-#gdoc-admin-bar {
-    display: none;
+.gdoc-admin-bar {
     position: absolute;
     right: 8px;
     margin-top: 8px;
@@ -1280,6 +1279,14 @@ div.raw-html-table__container {
         display: flex;
         justify-content: center;
         gap: 16px;
+        list-style: none;
+        margin: 0;
+        padding: 0;
+
+        > li {
+            display: flex;
+        }
+
         @include sm-only {
             display: none;
         }

--- a/site/owid.entry.ts
+++ b/site/owid.entry.ts
@@ -16,10 +16,9 @@ import { runFeedbackPage } from "./Feedback.js"
 import { runDonateForm } from "./runDonateForm.js"
 import { runTableOfContents } from "./runTableOfContents.js"
 import { Explorer } from "@ourworldindata/explorer"
-import { ENV, ADMIN_BASE_URL } from "../settings/clientSettings.js"
+import { ENV } from "../settings/clientSettings.js"
 import {
     Grapher,
-    CookieKey,
     renderSingleGrapherOnGrapherPage,
     GrapherState,
 } from "@ourworldindata/grapher"
@@ -52,33 +51,6 @@ runMonkeyPatchForGoogleTranslate()
 const analytics = new SiteAnalytics(ENV)
 
 document.documentElement?.classList.add("js-loaded")
-
-try {
-    // Cookie access can be restricted by iframe sandboxing, in which case the below code will throw an error
-    // see https://github.com/owid/owid-grapher/pull/2452
-
-    if (document.cookie.includes(CookieKey.isAdmin)) {
-        const gdocAdminBar = document.getElementById("gdoc-admin-bar")
-        if (gdocAdminBar) {
-            gdocAdminBar.style.display = "initial"
-            const id = window._OWID_GDOC_PROPS?.id
-            if (id) {
-                const gdocLink = `https://docs.google.com/document/d/${id}/edit`
-                const adminLink = `${ADMIN_BASE_URL}/admin/gdocs/${id}/preview`
-                const admin = gdocAdminBar.querySelector("#admin-link")
-                const gdoc = gdocAdminBar.querySelector("#gdoc-link")
-                if (admin && gdoc) {
-                    admin.setAttribute("href", adminLink)
-                    admin.setAttribute("target", "_blank")
-                    gdoc.setAttribute("href", gdocLink)
-                    gdoc.setAttribute("target", "_blank")
-                }
-            }
-        }
-    }
-} catch {
-    // ignore
-}
 
 analytics.startClickTracking()
 analytics.startDetectingBrowserTranslation()


### PR DESCRIPTION
Fixes issues I noticed in the markdown generated by Cloudflare across our major content types.

- Changes several components to be HTML lists where appropriate.
- Adds actual space between inline elements where CSS was used to add only visual space. This should fix missing whitespace between these elements in the markdown.
- Changes links that contain block elements to be a block themselves. This might fix missing spaces between the elements inside the link in the markdown.
- Render admin links only on the client - to exclude them from the markdown.

https://developers.cloudflare.com/fundamentals/reference/markdown-for-agents/

## Testing guidance

You can double-check that the changed components remain visually same/very similar as before.

- [x] Does the change work in the archive?

## Checklist

### Before merging

- [x] Changes to CSS/HTML were checked on Desktop and Mobile Safari at all three breakpoints
- [x] Changes to HTML were checked for accessibility concerns