### PR TITLE
🐛 fix entity selector sort column after switching mdims

### DIFF
--- a/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
+++ b/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
@@ -4,6 +4,7 @@ import { observer } from "mobx-react"
 import {
     computed,
     action,
+    comparer,
     reaction,
     when,
     IReactionDisposer,
@@ -247,8 +248,12 @@ export class EntitySelector extends React.Component<EntitySelectorProps> {
         // we need to change the sort config accordingly
         this.disposers.push(
             reaction(
-                () => this.sortOptions,
-                () => this.updateSortConfigIfOptionHasBecomeUnavailable()
+                () => ({
+                    slugs: this.sortOptions.map((option) => option.slug),
+                    isReady: this.manager.isReady,
+                }),
+                () => this.updateSortConfigIfOptionHasBecomeUnavailable(),
+                { equals: comparer.structural }
             )
         )
     }


### PR DESCRIPTION
Resolves https://github.com/owid/owid-grapher/issues/5242

Example: http://staging-site-fix-mdim-entity-selector-sor/grapher/religious-composition?tab=discrete-bar&time=latest&religion=jews&indicator=share (switch between the religions)