### PR TITLE
🔨 (svg tester) only log when verbose

### DIFF
--- a/devTools/svgTester/export-graphs.ts
+++ b/devTools/svgTester/export-graphs.ts
@@ -30,6 +30,7 @@ async function exportGraphers(args: ReturnType<typeof parseArguments>) {
             await utils.loadManifestViewIds(testSuite, {
                 targetViewIds,
                 manifestName: args.manifest,
+                verbose: args.verbose,
             })
 
         // Chart configurations to test

--- a/devTools/svgTester/utils.ts
+++ b/devTools/svgTester/utils.ts
@@ -957,8 +957,11 @@ export async function loadManifestViewIds(
     options: {
         targetViewIds?: string[]
         manifestName?: string
+        verbose?: boolean
     }
 ): Promise<{ viewIds: string[] | null; dataDir: string }> {
+    const { verbose = false } = options
+
     const testSuiteDir = path.join(SVG_REPO_PATH, testSuite)
     const defaultDataDir = path.join(testSuiteDir, "data")
 
@@ -975,14 +978,18 @@ export async function loadManifestViewIds(
 
             // viewIds are explicitly provided
             if (options.targetViewIds) {
-                console.log(`Using data directory: ${manifest.dataDir}`)
+                logIfVerbose(
+                    verbose,
+                    `Using data directory: ${manifest.dataDir}`
+                )
                 return { viewIds: null, dataDir }
             }
 
-            console.log(
+            logIfVerbose(
+                verbose,
                 `Read ${manifest.slugs.length} chart slugs from manifest: ${manifestName}`
             )
-            console.log(`Using data directory: ${manifest.dataDir}`)
+            logIfVerbose(verbose, `Using data directory: ${manifest.dataDir}`)
 
             return { viewIds: manifest.slugs, dataDir }
         } else {
@@ -1006,10 +1013,11 @@ export async function loadManifestViewIds(
 
         if (manifest) {
             const dataDir = path.join(testSuiteDir, manifest.dataDir)
-            console.log(
+            logIfVerbose(
+                verbose,
                 `Read ${manifest.slugs.length} chart slugs from manifest: ${options.manifestName}`
             )
-            console.log(`Using data directory: ${manifest.dataDir}`)
+            logIfVerbose(verbose, `Using data directory: ${manifest.dataDir}`)
             return { viewIds: manifest.slugs, dataDir }
         } else {
             console.warn(`Warning: Manifest not found at ${manifestPath}`)

--- a/devTools/svgTester/verify-graphs.ts
+++ b/devTools/svgTester/verify-graphs.ts
@@ -125,6 +125,7 @@ async function verifyGraphers(args: ReturnType<typeof parseArguments>) {
             await utils.loadManifestViewIds(testSuite, {
                 targetViewIds,
                 manifestName: args.manifest,
+                verbose: args.verbose,
             })
 
         // Chart configurations to test


### PR DESCRIPTION
Only log when verbose (otherwise the ops svg tester gets confsued)