### PR TITLE
🎉 Add Wikipedia archive: strip GTM and rewrite URLs from archived pages

### DIFF
--- a/.env.archive
+++ b/.env.archive
@@ -1,5 +1,6 @@
 IS_ARCHIVE=true
 ARCHIVE_BASE_URL=https://archive.ourworldindata.org
+WIKIPEDIA_ARCHIVE_BASE_URL=https://wikipedia-archive.ourworldindata.org
 ENVIRONMENT=production
 BAKED_BASE_URL=
 GRAPHER_DYNAMIC_THUMBNAIL_URL=

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ dist/
 cfstorage/
 vite.*.mjs
 archive/*
+wikipedia-archive/*
 
 # Playwright
 test-results/

--- a/Makefile
+++ b/Makefile
@@ -430,5 +430,9 @@ archive: node_modules
 	PRIMARY_ENV_FILE=.env.archive yarn buildViteArchive
 	PRIMARY_ENV_FILE=.env.archive yarn tsx --tsconfig tsconfig.tsx.json ./baker/archival/archiveChangedPages.ts --latestDir
 
+wikipedia-archive: archive
+	@echo '==> Creating Wikipedia archive (stripping analytics)'
+	PRIMARY_ENV_FILE=.env.archive yarn tsx --tsconfig tsconfig.tsx.json ./baker/archival/createWikipediaArchive.ts
+
 clean:
 	rm -rf node_modules

--- a/baker/archival/README.md
+++ b/baker/archival/README.md
@@ -186,3 +186,26 @@ After that, it sends the changed archive files to R2 (bucket `owid-archive`) usi
 ### Append-only nature of the archive
 
 Overall, the archive is essentially append-only. We don't delete any archived pages, any archived versions of a page, or any assets or variables that were ever created as part of an archive. This is important for the integrity of the archive, for the integrity of past citations, and to ensure that the JS code of past archived pages keeps working.
+
+## Wikipedia archive
+
+The Wikipedia archive is a copy of the main archive with Google Tag Manager (GTM) analytics scripts stripped out and archive URLs rewritten. This is needed because Wikipedia requires that embedded content does not include third-party tracking.
+
+The script `createWikipediaArchive.ts` post-processes the main archive:
+
+1. **HTML files**: Strips all `<script>` tags containing `googletagmanager` or `Google Tag Manager` (using regex), and rewrites `ARCHIVE_BASE_URL` → `WIKIPEDIA_ARCHIVE_BASE_URL`.
+2. **Non-HTML files**: Hard-linked from the main archive (no processing needed — archive URLs only appear in HTML).
+
+### Env variables
+
+- `WIKIPEDIA_ARCHIVE_BASE_URL`: The base URL for the Wikipedia-specific archive (e.g. `https://wikipedia-archive.ourworldindata.org`). Set in `.env.archive`.
+
+### Local usage
+
+```bash
+make wikipedia-archive   # runs after `make archive`
+```
+
+### Deployment
+
+The Wikipedia archive is deployed to R2 (bucket `owid-wikipedia-archive`) as part of every content deploy, after the main archive is built. See the `deploy-wikipedia-archive.sh` script in the ops repo.

--- a/baker/archival/createWikipediaArchive.test.ts
+++ b/baker/archival/createWikipediaArchive.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from "vitest"
+import {
+    stripGtmScripts,
+    rewriteArchiveUrls,
+} from "./createWikipediaArchive.js"
+
+describe("stripGtmScripts", () => {
+    it("removes GTM inline script (googletagmanager)", () => {
+        const html = `<html><head>
+            <script>window.dataLayer=window.dataLayer||[];(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-N2D4V8S');</script>
+            <title>Test</title>
+        </head><body>Hello</body></html>`
+        const result = stripGtmScripts(html)
+        expect(result).not.toContain("googletagmanager")
+        expect(result).toContain("<title>Test</title>")
+        expect(result).toContain("Hello")
+    })
+
+    it("removes GTM noscript/comment references (Google Tag Manager)", () => {
+        const html = `<html><head>
+            <script>/* Google Tag Manager */ (function(){})();</script>
+        </head><body>Content</body></html>`
+        const result = stripGtmScripts(html)
+        expect(result).not.toContain("Google Tag Manager")
+        expect(result).toContain("Content")
+    })
+
+    it("leaves non-GTM scripts untouched", () => {
+        const html = `<html><head>
+            <script src="/assets/owid.abc123.mjs" type="module"></script>
+            <script>console.log("hello")</script>
+        </head><body></body></html>`
+        const result = stripGtmScripts(html)
+        expect(result).toContain("owid.abc123.mjs")
+        expect(result).toContain('console.log("hello")')
+    })
+
+    it("handles HTML with no script tags", () => {
+        const html = `<html><head><title>No scripts</title></head><body>Plain</body></html>`
+        const result = stripGtmScripts(html)
+        expect(result).toContain("No scripts")
+        expect(result).toContain("Plain")
+    })
+
+    it("removes multiple GTM-related scripts", () => {
+        const html = `<html><head>
+            <script>window.dataLayer=window.dataLayer||[];(function(w,d,s,l,i){j.src='https://www.googletagmanager.com/gtm.js?id='+i;})(window,document,'script','dataLayer','GTM-N2D4V8S');</script>
+            <script>/* Google Tag Manager */ gtag('config', 'GTM-N2D4V8S');</script>
+            <script src="/assets/app.js"></script>
+        </head><body></body></html>`
+        const result = stripGtmScripts(html)
+        expect(result).not.toContain("googletagmanager")
+        expect(result).not.toContain("Google Tag Manager")
+        expect(result).toContain('<script src="/assets/app.js"></script>')
+    })
+
+    it("preserves surrounding HTML byte-for-byte", () => {
+        const html = `<html><head><meta name="viewport" content="width=device-width"/><script>googletagmanager</script></head><body><br/></body></html>`
+        const result = stripGtmScripts(html)
+        expect(result).not.toContain("googletagmanager")
+        expect(result).toContain(
+            '<meta name="viewport" content="width=device-width"/>'
+        )
+        expect(result).toContain("<br/>")
+    })
+
+    it("does not cross </script> boundaries when non-GTM script precedes GTM script", () => {
+        const html = `<html><head>
+            <script>console.log("app init")</script>
+            <script>/* Google Tag Manager */ loadGTM();</script>
+        </head><body></body></html>`
+        const result = stripGtmScripts(html)
+        expect(result).toContain('console.log("app init")')
+        expect(result).not.toContain("Google Tag Manager")
+    })
+
+    it("handles GTM script with attributes", () => {
+        const html = `<html><head>
+            <script type="text/javascript">/* Google Tag Manager */ init();</script>
+        </head><body></body></html>`
+        const result = stripGtmScripts(html)
+        expect(result).not.toContain("Google Tag Manager")
+    })
+
+    it("matches the exact GTM output from Head.tsx", () => {
+        const html = `<html><head>
+            <script>/* Prepare Google Tag Manager */
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag("consent","default",{"ad_storage":"denied","ad_user_data":"denied","ad_personalization":"denied","analytics_storage":"denied","wait_for_update":1000});
+</script>
+            <script>/* Load Google Tag Manager */
+(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-N2D4V8S');</script>
+            <script src="/assets/owid.abc123.mjs" type="module"></script>
+        </head><body></body></html>`
+        const result = stripGtmScripts(html)
+        expect(result).not.toContain("Google Tag Manager")
+        expect(result).not.toContain("googletagmanager")
+        expect(result).toContain("owid.abc123.mjs")
+    })
+})
+
+describe("rewriteArchiveUrls", () => {
+    const archiveUrl = "https://archive.ourworldindata.org"
+    const wikipediaUrl = "https://wikipedia-archive.ourworldindata.org"
+
+    it("rewrites archive URL in link tags", () => {
+        const html = `<link rel="archives" href="https://archive.ourworldindata.org/20250101-120000/grapher/life-expectancy.html">`
+        const result = rewriteArchiveUrls(html, archiveUrl, wikipediaUrl)
+        expect(result).toContain(
+            "https://wikipedia-archive.ourworldindata.org/20250101-120000/grapher/life-expectancy.html"
+        )
+        expect(result).not.toContain(archiveUrl)
+    })
+
+    it("rewrites archive URL in JSON context", () => {
+        const html = `<script>window._OWID_ARCHIVE_CONTEXT={"archiveUrl":"https://archive.ourworldindata.org/20250101-120000/grapher/life-expectancy.html"}</script>`
+        const result = rewriteArchiveUrls(html, archiveUrl, wikipediaUrl)
+        expect(result).toContain(
+            "https://wikipedia-archive.ourworldindata.org/20250101-120000/grapher/life-expectancy.html"
+        )
+    })
+
+    it("rewrites all occurrences", () => {
+        const html = `<div>
+            <a href="https://archive.ourworldindata.org/a">Link 1</a>
+            <a href="https://archive.ourworldindata.org/b">Link 2</a>
+        </div>`
+        const result = rewriteArchiveUrls(html, archiveUrl, wikipediaUrl)
+        const matches = result.match(/wikipedia-archive/g)
+        expect(matches).toHaveLength(2)
+        expect(result).not.toContain(archiveUrl)
+    })
+
+    it("does nothing when archive URL is not present", () => {
+        const html = `<html><body>No archive links here</body></html>`
+        const result = rewriteArchiveUrls(html, archiveUrl, wikipediaUrl)
+        expect(result).toBe(html)
+    })
+})

--- a/baker/archival/createWikipediaArchive.ts
+++ b/baker/archival/createWikipediaArchive.ts
@@ -1,0 +1,170 @@
+import path from "path"
+import fs from "fs-extra"
+import yargs from "yargs"
+import { hideBin } from "yargs/helpers"
+import pMap from "p-map"
+import { ARCHIVE_BASE_URL } from "../../settings/clientSettings.js"
+import { WIKIPEDIA_ARCHIVE_BASE_URL } from "../../settings/serverSettings.js"
+
+/**
+ * Strip all <script> tags whose content references Google Tag Manager.
+ * Uses a regex to match each <script> to its nearest </script> (the HTML
+ * parsing boundary), then checks the captured content for GTM markers.
+ */
+export function stripGtmScripts(html: string): string {
+    return html.replace(
+        /<script\b[^>]*>([\s\S]*?)<\/script>/g,
+        (match, content: string) => {
+            if (
+                content.includes("googletagmanager") ||
+                content.includes("Google Tag Manager")
+            ) {
+                return ""
+            }
+            return match
+        }
+    )
+}
+
+/**
+ * Replace all occurrences of the archive base URL with the Wikipedia archive
+ * base URL. Simple string replacement — archive URLs are unique and unambiguous
+ * in the HTML (they appear in <link>, JSON context, and citation text).
+ */
+export function rewriteArchiveUrls(
+    html: string,
+    archiveBaseUrl: string,
+    wikipediaBaseUrl: string
+): string {
+    return html.replaceAll(archiveBaseUrl, wikipediaBaseUrl)
+}
+
+async function processFile(
+    inputPath: string,
+    outputPath: string,
+    archiveBaseUrl: string,
+    wikipediaBaseUrl: string,
+    dryRun: boolean
+): Promise<void> {
+    if (inputPath.endsWith(".html")) {
+        let html = await fs.readFile(inputPath, "utf-8")
+        html = stripGtmScripts(html)
+        html = rewriteArchiveUrls(html, archiveBaseUrl, wikipediaBaseUrl)
+        if (!dryRun) {
+            await fs.ensureDir(path.dirname(outputPath))
+            await fs.writeFile(outputPath, html, "utf-8")
+        }
+    } else {
+        // Non-HTML files are identical — hard-link to save disk space
+        if (!dryRun) {
+            await fs.ensureDir(path.dirname(outputPath))
+            // Remove existing file if present (hard-link fails if target exists)
+            await fs.remove(outputPath)
+            await fs.link(inputPath, outputPath)
+        }
+    }
+}
+
+async function walkDir(dir: string): Promise<string[]> {
+    const entries = await fs.readdir(dir, {
+        withFileTypes: true,
+        recursive: true,
+    })
+    return entries
+        .filter((e) => e.isFile())
+        .map((e) => path.join(e.parentPath, e.name))
+}
+
+async function createWikipediaArchive(opts: {
+    inputDir: string
+    outputDir: string
+    dryRun: boolean
+}) {
+    const inputDir = path.resolve(opts.inputDir)
+    const outputDir = path.resolve(opts.outputDir)
+    const dryRun = opts.dryRun
+
+    if (!ARCHIVE_BASE_URL) {
+        console.error(
+            "ARCHIVE_BASE_URL is not set. Make sure .env.archive is loaded (PRIMARY_ENV_FILE=.env.archive)."
+        )
+        process.exit(1)
+    }
+    if (!WIKIPEDIA_ARCHIVE_BASE_URL) {
+        console.error(
+            "WIKIPEDIA_ARCHIVE_BASE_URL is not set. Make sure .env.archive is loaded."
+        )
+        process.exit(1)
+    }
+
+    console.log(`Input:  ${inputDir}`)
+    console.log(`Output: ${outputDir}`)
+    console.log(`Archive URL:   ${ARCHIVE_BASE_URL}`)
+    console.log(`Wikipedia URL: ${WIKIPEDIA_ARCHIVE_BASE_URL}`)
+    if (dryRun) console.log("(dry run — no files will be written)")
+
+    const files = await walkDir(inputDir)
+    const htmlFiles = files.filter((f) => f.endsWith(".html"))
+    const otherFiles = files.filter((f) => !f.endsWith(".html"))
+
+    console.log(
+        `Found ${files.length} files (${htmlFiles.length} HTML, ${otherFiles.length} other)`
+    )
+
+    let processed = 0
+    await pMap(
+        files,
+        async (file) => {
+            const relativePath = path.relative(inputDir, file)
+            const outputPath = path.join(outputDir, relativePath)
+            await processFile(
+                file,
+                outputPath,
+                ARCHIVE_BASE_URL!,
+                WIKIPEDIA_ARCHIVE_BASE_URL!,
+                dryRun
+            )
+            processed++
+            if (processed % 1000 === 0) {
+                console.log(`  Processed ${processed}/${files.length} files...`)
+            }
+        },
+        { concurrency: 50 }
+    )
+
+    console.log(`Done. Processed ${processed} files.`)
+}
+
+if (require.main === module) {
+    void yargs(hideBin(process.argv))
+        .command<{ inputDir: string; outputDir: string; dryRun: boolean }>(
+            "$0",
+            "Create a Wikipedia-specific archive with GTM scripts removed",
+            (yargs) => {
+                yargs
+                    .option("inputDir", {
+                        type: "string",
+                        default: "archive/",
+                        describe: "Path to the main archive directory",
+                    })
+                    .option("outputDir", {
+                        type: "string",
+                        default: "wikipedia-archive/",
+                        describe:
+                            "Path to the Wikipedia archive output directory",
+                    })
+                    .option("dryRun", {
+                        type: "boolean",
+                        default: false,
+                        describe: "Process files without writing output",
+                    })
+            },
+            async (opts) => {
+                await createWikipediaArchive(opts)
+                process.exit(0)
+            }
+        )
+        .help()
+        .alias("help", "h")
+        .strict().argv
+}

--- a/devTools/backpopulateWikipediaArchive.sh
+++ b/devTools/backpopulateWikipediaArchive.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+#
+#  backpopulateWikipediaArchive.sh
+#
+#  One-off migration: back-populate the Wikipedia archive R2 bucket from the
+#  main archive R2 bucket. Needed because the Wikipedia archive was introduced
+#  after the main archive had already accumulated data.
+#
+#  Run directly on the production server (as the owid user):
+#
+#    cd ~/owid-grapher
+#    ./devTools/backpopulateWikipediaArchive.sh
+#
+#  Steps:
+#  1. Server-side copy all non-HTML files (fast, R2→R2)
+#  2. Download all HTML files
+#  3. Strip GTM and rewrite URLs via createWikipediaArchive.ts
+#  4. Upload processed HTML to owid-wikipedia-archive
+#  5. Clean up local temp directories
+#
+
+set -o errexit
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+GRAPHER_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+TEMP_INPUT_DIR=/home/owid/wikipedia-tmp/backpopulate-input
+TEMP_OUTPUT_DIR=/home/owid/wikipedia-tmp/backpopulate-output
+
+# Load archive env vars (ARCHIVE_BASE_URL, WIKIPEDIA_ARCHIVE_BASE_URL, etc.)
+PRIMARY_ENV_FILE=.env.archive
+
+server_side_copy_assets() {
+    echo "--- Step 1: Server-side copying non-HTML files from owid-archive to owid-wikipedia-archive..."
+    rclone copy r2:owid-archive r2:owid-wikipedia-archive \
+        --exclude '*.html' \
+        --checkers=64 --transfers=64 \
+        --stats 30s
+}
+
+download_html() {
+    echo "--- Step 2: Downloading all HTML from owid-archive..."
+    rm -rf "$TEMP_INPUT_DIR"
+    mkdir -p "$TEMP_INPUT_DIR"
+    rclone copy r2:owid-archive "$TEMP_INPUT_DIR" \
+        --include '*.html' \
+        --checkers=64 --transfers=64 \
+        --stats 30s
+}
+
+process_html() {
+    echo "--- Step 3: Processing HTML (stripping GTM, rewriting URLs)..."
+    rm -rf "$TEMP_OUTPUT_DIR"
+    mkdir -p "$TEMP_OUTPUT_DIR"
+    cd "$GRAPHER_DIR"
+    PRIMARY_ENV_FILE=$PRIMARY_ENV_FILE \
+        yarn tsx --tsconfig tsconfig.tsx.json ./baker/archival/createWikipediaArchive.ts \
+            --inputDir "$TEMP_INPUT_DIR" \
+            --outputDir "$TEMP_OUTPUT_DIR"
+}
+
+upload_processed_html() {
+    echo "--- Step 4: Uploading processed HTML to owid-wikipedia-archive..."
+    rclone copy "$TEMP_OUTPUT_DIR" r2:owid-wikipedia-archive \
+        --checkers=64 --transfers=64 \
+        --stats 30s
+}
+
+cleanup() {
+    echo "--- Cleaning up temporary directories..."
+    rm -rf "$TEMP_INPUT_DIR" "$TEMP_OUTPUT_DIR"
+}
+
+main() {
+    echo "--- Back-populating Wikipedia archive from main archive"
+    trap cleanup EXIT
+
+    server_side_copy_assets
+    download_html
+    process_html
+    upload_processed_html
+
+    echo "--- Wikipedia archive back-population complete ✅"
+}
+
+main

--- a/features/wikipedia-archive.feature
+++ b/features/wikipedia-archive.feature
@@ -1,0 +1,12 @@
+Feature: Wikipedia archive
+
+    Charts served from the Wikipedia archive should not make requests
+    to Google servers, unlike the production archive.
+
+    Scenario: Production archive chart makes GTM requests
+        Given I open "life-expectancy" from the production archive
+        Then the page should make requests to Google Tag Manager
+
+    Scenario: Wikipedia archive chart does not make GTM requests
+        Given I open "life-expectancy" from the wikipedia archive
+        Then the page should not make requests to Google Tag Manager

--- a/features/wikipedia-archive.steps.ts
+++ b/features/wikipedia-archive.steps.ts
@@ -1,0 +1,54 @@
+import { expect, Page } from "@playwright/test"
+import { createBdd } from "playwright-bdd"
+
+const { Given, Then } = createBdd()
+
+const ARCHIVE_BASE = "http://localhost:8764"
+const WIKIPEDIA_ARCHIVE_BASE = "http://localhost:8765"
+
+function trackGtmRequests(page: Page): string[] {
+    const gtmRequests: string[] = []
+    page.on("request", (req) => {
+        if (req.url().includes("googletagmanager.com")) {
+            gtmRequests.push(req.url())
+        }
+    })
+    ;(page as any).__gtmRequests = gtmRequests
+    return gtmRequests
+}
+
+Given(
+    "I open {string} from the production archive",
+    async ({ page }, chart: string) => {
+        trackGtmRequests(page)
+        await page.goto(`${ARCHIVE_BASE}/latest/grapher/${chart}.html`)
+    }
+)
+
+Given(
+    "I open {string} from the wikipedia archive",
+    async ({ page }, chart: string) => {
+        trackGtmRequests(page)
+        await page.goto(
+            `${WIKIPEDIA_ARCHIVE_BASE}/latest/grapher/${chart}.html`
+        )
+    }
+)
+
+Then(
+    "the page should make requests to Google Tag Manager",
+    async ({ page }) => {
+        await page.waitForTimeout(3_000)
+        const gtmRequests = (page as any).__gtmRequests as string[]
+        expect(gtmRequests.length).toBeGreaterThan(0)
+    }
+)
+
+Then(
+    "the page should not make requests to Google Tag Manager",
+    async ({ page }) => {
+        await page.waitForTimeout(3_000)
+        const gtmRequests = (page as any).__gtmRequests as string[]
+        expect(gtmRequests).toEqual([])
+    }
+)

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -16,6 +16,18 @@ export default defineConfig({
     use: {
         baseURL: `${BAKED_BASE_URL}${ENV !== "development" ? ".tail6e23.ts.net" : ""}`,
     },
+    webServer: [
+        {
+            command: "http-server archive -p 8764 -c-1 --silent",
+            port: 8764,
+            reuseExistingServer: true,
+        },
+        {
+            command: "http-server wikipedia-archive -p 8765 -c-1 --silent",
+            port: 8765,
+            reuseExistingServer: true,
+        },
+    ],
     projects: [
         {
             name: "chromium",

--- a/settings/serverSettings.ts
+++ b/settings/serverSettings.ts
@@ -28,6 +28,9 @@ export const BAKED_BASE_URL: string = clientSettings.BAKED_BASE_URL
 
 export const ARCHIVE_BASE_URL: string | null = clientSettings.ARCHIVE_BASE_URL
 
+export const WIKIPEDIA_ARCHIVE_BASE_URL: string | null =
+    serverSettings.WIKIPEDIA_ARCHIVE_BASE_URL || null
+
 export const CLOUDFLARE_IMAGES_URL = clientSettings.CLOUDFLARE_IMAGES_URL
 
 export const VITE_PREVIEW: boolean = serverSettings.VITE_PREVIEW === "true"


### PR DESCRIPTION
## Context

Supersedes #6177. Simplified rewrite on a fresh branch.

Creates a secondary publishing target of the archive for Wikipedia ([#6099](https://github.com/owid/owid-grapher/issues/6099)). Wikipedia requires that embedded content does not include third-party tracking.

A new post-processing script (`createWikipediaArchive.ts`) takes the main archive output and produces a Wikipedia-specific copy:

- **HTML files**: regex-based stripping of GTM `<script>` tags (matching `googletagmanager` or `Google Tag Manager`), then rewrites `ARCHIVE_BASE_URL` → `WIKIPEDIA_ARCHIVE_BASE_URL`.
- **Non-HTML files**: Hard-linked from the main archive (no processing needed).

### Simplifications vs #6177

The previous PR (#6177) selectively filtered files: it skipped posts, images, and videos, and only processed data pages (grapher/explorer HTML). This PR deliberately keeps full parity with the main archive — every file is included. This is simpler (no `isDataPageHtml()`, `findPostFiles()`, `SKIP_DIRS` logic) and avoids the Wikipedia archive silently diverging from the main archive over time. The only difference between the two archives is the absence of GTM scripts and the rewritten base URL.

### Changes

| File | Change |
| --- | --- |
| `baker/archival/createWikipediaArchive.ts` | **New** — CLI script: strips GTM from HTML, rewrites archive URLs, hard-links non-HTML |
| `baker/archival/createWikipediaArchive.test.ts` | **New** — 13 unit tests for `stripGtmScripts` and `rewriteArchiveUrls` |
| `settings/clientSettings.ts` | Exports `ARCHIVE_BASE_URL` (client-side, used in `<link rel="archives">`) |
| `settings/serverSettings.ts` | Added `WIKIPEDIA_ARCHIVE_BASE_URL` (server-only) |
| `.env.archive` | Added `WIKIPEDIA_ARCHIVE_BASE_URL` |
| `Makefile` | Added `wikipedia-archive` target |
| `baker/archival/README.md` | Added Wikipedia archive documentation section |
| `devTools/backpopulateWikipediaArchive.sh` | **New** — One-off script to back-populate Wikipedia archive R2 bucket from main archive |
| `features/wikipedia-archive.feature` | **New** — BDD feature: asserts production archive makes GTM requests while Wikipedia archive does not |
| `features/wikipedia-archive.steps.ts` | **New** — Playwright step definitions |
| `playwright.config.ts` | Added webServer entries for archive/wikipedia-archive on ports 8764/8765 |
| `.gitignore` | Added `wikipedia-archive/*` |

> **Ops companion PR:** https://github.com/owid/ops/pull/408 (merge grapher PR first)

## Testing guidance

- [x] `yarn test run baker/archival/createWikipediaArchive.test.ts` — 13 tests pass
- [x] `yarn typecheck` — passes
- [x] No hardcoded `archive.ourworldindata.org` URLs in source code (only in db docs descriptions)
- [x] `make wikipedia-archive` — spot-check output: `grep -r "googletagmanager" wikipedia-archive/` returns zero matches
- [x] Backpopulate script tested against R2: downloaded 643 HTML files, processed (0 GTM refs, 0 bare archive URLs), uploaded successfully
- [x] BDD tests (`yarn testBdd`): 36/36 passed — Wikipedia archive scenarios verify GTM presence in production archive and absence in Wikipedia archive across 3 browsers

### Post-deploy task

- [x] Deploy https://github.com/owid/ops/pull/408
- [x] Pause/cancel deploy-content builds
- [ ] Run `devTools/backpopulateWikipediaArchive.sh` on the production server once after first deploy to populate the Wikipedia archive R2 bucket from the existing main archive
- [ ] Resume deploy-content builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)