### PR TITLE
🐛 show at least 2 labelled ticks for log axis

### DIFF
--- a/packages/@ourworldindata/grapher/src/axis/Axis.test.ts
+++ b/packages/@ourworldindata/grapher/src/axis/Axis.test.ts
@@ -123,6 +123,22 @@ it("creates compact labels", () => {
     ).toBeTruthy()
 })
 
+it("shows labelled ticks even when the domain doesn't span nice log values", () => {
+    const config: AxisConfigInterface = {
+        min: 11000,
+        max: 16000,
+        scaleType: ScaleType.log,
+    }
+    const axis = new AxisConfig(config).toVerticalAxis()
+    axis.range = [0, 200]
+
+    const ticks = axis.getTickValues()
+    const labelledTicks = ticks.filter((t) => !t.gridLineOnly)
+
+    // We should have at least 2 labelled ticks
+    expect(labelledTicks.length).toBeGreaterThanOrEqual(2)
+})
+
 describe("singleValueAxisPointAlign", () => {
     const testAlign = (
         align: AxisAlign | undefined,

--- a/packages/@ourworldindata/grapher/src/axis/Axis.ts
+++ b/packages/@ourworldindata/grapher/src/axis/Axis.ts
@@ -384,16 +384,16 @@ abstract class AbstractAxis {
 
             if (ticks.length > maxLabelledTicks) {
                 if (ticks.length <= maxTicks) {
-                    // Convert all "in-between" lines to faint grid lines without labels
-                    ticks = ticks.map((tick) => {
-                        if (tick.priority === 3)
-                            tick = {
-                                ...tick,
-                                faint: true,
-                                gridLineOnly: true,
-                            }
-                        return tick
-                    })
+                    // Convert all "in-between" lines to faint grid lines without labels,
+                    // but only do so if there are at least 2 labelled ticks
+                    const priorityTicks = ticks.filter((t) => t.priority < 3)
+                    if (priorityTicks.length >= 2) {
+                        ticks = ticks.map((tick) =>
+                            tick.priority === 3
+                                ? { ...tick, faint: true, gridLineOnly: true }
+                                : tick
+                        )
+                    }
                 } else {
                     // Remove some tickmarks again because the chart would get too overwhelming
                     // otherwise


### PR DESCRIPTION
Resolves #6114

Simply shows all tick labels if otherwise too few would be shown. Not ideal, but better than the current behaviour.