### PR TITLE
🔨 extract line chart tooltip

### DIFF
--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
@@ -3,7 +3,6 @@ import React from "react"
 import * as R from "remeda"
 import {
     guid,
-    excludeNullish,
     getRelativeMouse,
     exposeInstanceOnWindow,
     excludeUndefined,
@@ -19,16 +18,9 @@ import { DualAxisComponent } from "../axis/AxisViews"
 import { DualAxis, HorizontalAxis, VerticalAxis } from "../axis/Axis"
 import { VerticalLabels } from "../verticalLabels/VerticalLabels"
 import { VerticalLabelsState } from "../verticalLabels/VerticalLabelsState"
-import { TooltipFooterIcon } from "../tooltip/TooltipProps.js"
-import {
-    Tooltip,
-    TooltipState,
-    TooltipTable,
-    makeTooltipRoundingNotice,
-    toTooltipTableColumns,
-} from "../tooltip/Tooltip"
+import { TooltipState } from "../tooltip/Tooltip"
+import { LineChartTooltip } from "./LineChartTooltip"
 import { NoDataModal } from "../noDataModal/NoDataModal"
-import { extent } from "d3-array"
 import { SeriesName, VerticalAlign, Time } from "@ourworldindata/types"
 import {
     BASE_FONT_SIZE,
@@ -72,9 +64,7 @@ import {
     HorizontalNumericColorLegend,
 } from "../legend/HorizontalColorLegends"
 import {
-    AnnotationsMap,
     getAnnotationsForSeries,
-    getAnnotationsMap,
     getYAxisConfigDefaults,
     toPlacedLineChartSeries,
     toRenderLineChartSeries,
@@ -123,13 +113,6 @@ export class LineChart
 
     @computed get detailsOrderedByReference(): string[] {
         return this.manager.detailsOrderedByReference ?? []
-    }
-
-    @computed get annotationsMap(): AnnotationsMap | undefined {
-        return getAnnotationsMap(
-            this.chartState.inputTable,
-            this.yColumnSlugs[0]
-        )
     }
 
     @action.bound private dismissTooltip(): void {
@@ -302,148 +285,6 @@ export class LineChart
 
     @computed private get isTooltipActive(): boolean {
         return this.manager.tooltip?.get()?.id === this.tooltipId
-    }
-
-    @computed private get tooltip(): React.ReactElement | undefined {
-        const { formatColumn, colorColumn, hasColorScale } = this
-        const { target, position, fading } = this.tooltipState
-
-        if (!target) return undefined
-
-        // Duplicate seriesNames will be present if there is a projected-values line
-        const seriesSegments = _.mapValues(
-            _.groupBy(this.series, "seriesName"),
-            (segments) =>
-                segments.find((series) =>
-                    // Ideally pick series with a defined value at the target time
-                    series.points.find((point) => point.x === target.time)
-                ) ??
-                segments.find((series): boolean | void => {
-                    // Otherwise pick the series whose start & end contains the target time
-                    // and display a "No data" notice.
-                    const [startX, endX] = extent(series.points, ({ x }) => x)
-                    return (
-                        _.isNumber(startX) &&
-                        _.isNumber(endX) &&
-                        startX < target.time &&
-                        target.time < endX
-                    )
-                }) ??
-                null // If neither series matches, exclude the entity from the tooltip altogether
-        )
-
-        const sortedData = _.sortBy(
-            excludeNullish(R.values(seriesSegments)),
-            (series) => {
-                const value = series.points.find(
-                    (point) => point.x === target.time
-                )
-                return value !== undefined ? -value.y : Infinity
-            }
-        )
-
-        const formattedTime = formatColumn.formatTime(target.time),
-            { displayUnit: unitLabel } = formatColumn,
-            { isRelativeMode, startTime } = this.manager
-
-        const title = formattedTime
-        const titleAnnotation = this.xAxis.label ? `(${this.xAxis.label})` : ""
-
-        const columns = [formatColumn]
-        if (hasColorScale && colorColumn.slug !== formatColumn.slug)
-            columns.push(colorColumn)
-
-        const subtitle =
-            isRelativeMode && startTime
-                ? `% change since ${formatColumn.formatTime(startTime)}`
-                : unitLabel
-        const subtitleFormat = subtitle === unitLabel ? "unit" : undefined
-
-        const projectionNotice = sortedData.some(
-            (series) => series.isProjection
-        )
-            ? { icon: TooltipFooterIcon.Stripes, text: "Projected data" }
-            : undefined
-        const roundingNotice = formatColumn.roundsToSignificantFigures
-            ? {
-                  icon: TooltipFooterIcon.None,
-                  text: makeTooltipRoundingNotice([
-                      formatColumn.numSignificantFigures,
-                  ]),
-              }
-            : undefined
-        const footer = excludeUndefined([projectionNotice, roundingNotice])
-
-        return (
-            <Tooltip
-                id={this.tooltipId}
-                tooltipManager={this.manager}
-                x={position.x}
-                y={position.y}
-                style={{ maxWidth: "400px" }}
-                offsetXDirection="left"
-                offsetX={20}
-                offsetY={-16}
-                title={title}
-                titleAnnotation={titleAnnotation}
-                subtitle={subtitle}
-                subtitleFormat={subtitleFormat}
-                footer={footer}
-                dissolve={fading}
-                dismiss={this.dismissTooltip}
-            >
-                <TooltipTable
-                    columns={toTooltipTableColumns(columns)}
-                    rows={sortedData.map((series) => {
-                        const {
-                            seriesName,
-                            displayName,
-                            isProjection: striped,
-                        } = series
-                        const annotation = getAnnotationsForSeries(
-                            this.annotationsMap,
-                            seriesName
-                        )
-
-                        const point = series.points.find(
-                            (point) => point.x === target.time
-                        )
-
-                        const seriesEmphasis = resolveEmphasis({
-                            hover: this.hoverStateForSeries(series),
-                            focus: series.focus,
-                        })
-                        const blurred =
-                            seriesEmphasis === Emphasis.Muted ||
-                            point === undefined
-
-                        const color = this.hasColorScale
-                            ? darkenColorForLine(
-                                  this.chartState.getColorScaleColor(
-                                      point?.colorValue
-                                  )
-                              )
-                            : series.color
-                        const opacity = blurred ? GRAPHER_OPACITY_MUTED : 1
-                        const swatch = { color, opacity }
-
-                        const values = excludeUndefined([
-                            point?.y,
-                            point?.colorValue as undefined | number,
-                        ])
-
-                        return {
-                            name: displayName,
-                            annotation,
-                            swatch,
-                            blurred,
-                            striped,
-                            values,
-                        }
-                    })}
-                />
-            </Tooltip>
-        )
     }
 
     @action.bound private onVerticalLabelMouseEnter(
@@ -698,7 +539,14 @@ export class LineChart
 
                 {(this.isTooltipActive || this.hasTimeHighlights) &&
                     this.activeXVerticalLines}
-                {this.tooltip}
+                <LineChartTooltip
+                    id={this.tooltipId}
+                    chartState={this.chartState}
+                    tooltipState={this.tooltipState}
+                    series={this.renderSeries}
+                    xAxisLabel={this.xAxis.label}
+                    dismissTooltip={this.dismissTooltip}
+                />
             </g>
         )
     }
@@ -855,7 +703,7 @@ export class LineChart
                 seriesName,
                 label: !this.manager.showSeriesLabels ? "" : displayName,
                 annotation: getAnnotationsForSeries(
-                    this.annotationsMap,
+                    this.chartState.annotationsMap,
                     seriesName
                 ),
                 yValue: lastValue,

--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChartState.ts
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChartState.ts
@@ -39,7 +39,13 @@ import { ColorScale, ColorScaleManager } from "../color/ColorScale"
 import { ColorScaleConfig } from "../color/ColorScaleConfig"
 import { OWID_NO_DATA_GRAY } from "../color/ColorConstants"
 import { CategoricalColorAssigner } from "../color/CategoricalColorAssigner"
-import { getColorKey, getDisplayName, getSeriesName } from "./LineChartHelpers"
+import {
+    AnnotationsMap,
+    getAnnotationsMap,
+    getColorKey,
+    getDisplayName,
+    getSeriesName,
+} from "./LineChartHelpers"
 import { FocusArray } from "../focus/FocusArray"
 import { AxisConfig } from "../axis/AxisConfig"
 import { HorizontalAxis, VerticalAxis } from "../axis/Axis"
@@ -206,6 +212,10 @@ export class LineChartState implements ChartState, ColorScaleManager {
 
     getColorScaleColor(value: CoreValueType | undefined): Color {
         return this.colorScale.getColor(value) ?? DEFAULT_LINE_COLOR
+    }
+
+    @computed get annotationsMap(): AnnotationsMap | undefined {
+        return getAnnotationsMap(this.inputTable, this.yColumnSlugs[0])
     }
 
     @computed get hasNoDataBin(): boolean {

--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChartTooltip.tsx
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChartTooltip.tsx
@@ -1,0 +1,223 @@
+import * as _ from "lodash-es"
+import React from "react"
+import { observer } from "mobx-react"
+import { excludeUndefined } from "@ourworldindata/utils"
+import { Time } from "@ourworldindata/types"
+import { extent } from "d3-array"
+import { RenderLineChartSeries } from "./LineChartConstants"
+import { LineChartState } from "./LineChartState.js"
+import { getAnnotationsForSeries } from "./LineChartHelpers"
+import {
+    Tooltip,
+    TooltipState,
+    TooltipTable,
+    makeTooltipRoundingNotice,
+    toTooltipTableColumns,
+} from "../tooltip/Tooltip"
+import {
+    FooterItem,
+    TooltipFooterIcon,
+    TooltipProps,
+    TooltipTableProps,
+} from "../tooltip/TooltipProps.js"
+import { GRAPHER_OPACITY_MUTED } from "../core/GrapherConstants"
+import { darkenColorForLine } from "../color/ColorUtils"
+import { Emphasis } from "../interaction/Emphasis"
+import { CoreColumn } from "@ourworldindata/core-table"
+
+export interface LineChartTooltipProps {
+    id: number
+    chartState: LineChartState
+    tooltipState: TooltipState<{ time: Time }>
+    series: RenderLineChartSeries[]
+    xAxisLabel?: string
+    dismissTooltip: () => void
+}
+
+@observer
+export class LineChartTooltip extends React.Component<LineChartTooltipProps> {
+    private get chartState(): LineChartState {
+        return this.props.chartState
+    }
+
+    private get target(): { time: Time } | undefined {
+        return this.props.tooltipState.target ?? undefined
+    }
+
+    private get series(): RenderLineChartSeries[] {
+        const { target } = this
+        if (!target) return []
+
+        // Duplicate seriesNames will be present if there is a projected-values line
+        const grouped = _.groupBy(this.props.series, "seriesName")
+
+        return excludeUndefined(
+            Object.values(grouped).map(
+                (segments) =>
+                    // Ideally pick series with a defined value at the target time
+                    segments.find((series) =>
+                        series.points.find((point) => point.x === target.time)
+                    ) ??
+                    // Otherwise pick the series whose start & end contains the target time
+                    // and display a "No data" notice.
+                    segments.find((series): boolean | void => {
+                        const [startX, endX] = extent(
+                            series.points,
+                            ({ x }) => x
+                        )
+                        return (
+                            _.isNumber(startX) &&
+                            _.isNumber(endX) &&
+                            startX < target.time &&
+                            target.time < endX
+                        )
+                    })
+            )
+        )
+    }
+
+    private get hasProjectedSeries(): boolean {
+        return this.series.some((series) => series.isProjection)
+    }
+
+    private get sortedSeries(): RenderLineChartSeries[] {
+        const { target, series } = this
+        if (!target) return []
+
+        return _.sortBy(series, (series) => {
+            const value = series.points.find((point) => point.x === target.time)
+            return value !== undefined ? -value.y : Infinity
+        })
+    }
+
+    private get projectionNotice(): FooterItem | undefined {
+        if (!this.hasProjectedSeries) return undefined
+
+        return { icon: TooltipFooterIcon.Stripes, text: "Projected data" }
+    }
+
+    private get roundingNotice(): FooterItem | undefined {
+        const { formatColumn } = this.chartState
+
+        if (!formatColumn.roundsToSignificantFigures) return undefined
+
+        return {
+            icon: TooltipFooterIcon.None,
+            text: makeTooltipRoundingNotice([
+                formatColumn.numSignificantFigures,
+            ]),
+        }
+    }
+
+    private get footer(): FooterItem[] {
+        return excludeUndefined([this.projectionNotice, this.roundingNotice])
+    }
+
+    private get title(): string {
+        const { target } = this
+        if (!target) return ""
+        return this.chartState.formatColumn.formatTime(target.time)
+    }
+
+    private get titleAnnotation(): string {
+        return this.props.xAxisLabel ? `(${this.props.xAxisLabel})` : ""
+    }
+
+    private get subtitle(): string | undefined {
+        const { isRelativeMode, startTime } = this.chartState.manager
+        const { formatColumn } = this.chartState
+
+        return isRelativeMode && startTime
+            ? `% change since ${formatColumn.formatTime(startTime)}`
+            : formatColumn.displayUnit
+    }
+
+    private get subtitleFormat(): TooltipProps["subtitleFormat"] {
+        return this.subtitle === this.chartState.formatColumn.displayUnit
+            ? "unit"
+            : undefined
+    }
+
+    private get columns(): CoreColumn[] {
+        const { formatColumn, colorColumn, hasColorScale } = this.chartState
+
+        const columns = [formatColumn]
+        if (hasColorScale && colorColumn.slug !== formatColumn.slug)
+            columns.push(colorColumn)
+
+        return columns
+    }
+
+    private toTooltipTableRow(
+        series: RenderLineChartSeries
+    ): TooltipTableProps["rows"][number] {
+        const { target } = this
+
+        const { seriesName, displayName, isProjection: striped } = series
+        const annotation = getAnnotationsForSeries(
+            this.chartState.annotationsMap,
+            seriesName
+        )
+
+        const point = series.points.find((point) => point.x === target!.time)
+
+        const blurred =
+            series.emphasis === Emphasis.Muted || point === undefined
+
+        const color = this.chartState.hasColorScale
+            ? darkenColorForLine(
+                  this.chartState.getColorScaleColor(point?.colorValue)
+              )
+            : series.color
+        const opacity = blurred ? GRAPHER_OPACITY_MUTED : 1
+        const swatch = { color, opacity }
+
+        const values = excludeUndefined([
+            point?.y,
+            point?.colorValue as undefined | number,
+        ])
+
+        return {
+            name: displayName,
+            annotation,
+            swatch,
+            blurred,
+            striped,
+            values,
+        }
+    }
+
+    override render(): React.ReactElement | null {
+        const { target } = this
+        const { position, fading } = this.props.tooltipState
+
+        if (!target) return null
+
+        return (
+            <Tooltip
+                id={this.props.id}
+                tooltipManager={this.chartState.manager}
+                x={position.x}
+                y={position.y}
+                style={{ maxWidth: "400px" }}
+                offsetXDirection="left"
+                offsetX={20}
+                offsetY={-16}
+                title={this.title}
+                titleAnnotation={this.titleAnnotation}
+                subtitle={this.subtitle}
+                subtitleFormat={this.subtitleFormat}
+                footer={this.footer}
+                dissolve={fading}
+                dismiss={this.props.dismissTooltip}
+            >
+                <TooltipTable
+                    columns={toTooltipTableColumns(this.columns)}
+                    rows={this.sortedSeries.map((series) =>
+                        this.toTooltipTableRow(series)
+                    )}
+                />
+            </Tooltip>
+        )
+    }
+}


### PR DESCRIPTION
Extract the line chart tooltip into its own component to make it reusable