### PR TITLE
✨ (scatter) add 'Time vs Time' suffix

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
@@ -2401,22 +2401,12 @@ export class GrapherState
             !this.forceHideAnnotationFieldsInTitle?.time &&
             this.isReady &&
             (showTimeAnnotation ||
-                this.isOnScatterWithTimeOverride ||
                 (this.hasTimeline &&
                     // Chart types that refer to the current time only in the timeline
                     (this.isOnDiscreteBarTab ||
                         this.isOnStackedDiscreteBarTab ||
                         this.isOnMarimekkoTab ||
                         this.isOnMapTab)))
-        )
-    }
-
-    @computed
-    private get isOnScatterWithTimeOverride(): boolean {
-        return !!(
-            this.isOnScatterTab &&
-            this.xColumnSlug !== undefined &&
-            this.xOverrideTime
         )
     }
 
@@ -2628,6 +2618,19 @@ export class GrapherState
 
     @computed private get yScaleType(): ScaleType | undefined {
         return this.yAxis.scaleType
+    }
+
+    @computed
+    private get isOnScatterWithTimeOverride(): boolean {
+        const xColumn = this.inputTable.get(this.xColumnSlug)
+        const yColumn = this.inputTable.get(this.yColumnSlug)
+
+        return !!(
+            this.isOnScatterTab &&
+            xColumn.def.owidVariableId !== undefined &&
+            xColumn.def.owidVariableId === yColumn.def.owidVariableId &&
+            this.xOverrideTime
+        )
     }
 
     @computed private get timeTitleSuffix(): string | undefined {


### PR DESCRIPTION
Resolves https://github.com/owid/owid-grapher/issues/6128

Charts for which this is relevant:

```
  SELECT
    c.id AS chartId,
    cc.slug,
    JSON_UNQUOTE(JSON_EXTRACT(cc.full, '$.title')) AS title,
    cc.full ->> '$.hideAnnotationFieldsInTitle.time',
    dx.variableId AS shared_variableId
  FROM charts c
  JOIN chart_configs cc ON c.configId = cc.id
  JOIN chart_dimensions dx ON dx.chartId = c.id AND dx.property = 'x'
  JOIN chart_dimensions dy ON dy.chartId = c.id AND dy.property = 'y'
  WHERE JSON_CONTAINS(cc.full->'$.chartTypes', '"ScatterPlot"')
    AND dx.variableId = dy.variableId
  AND cc.full ->> '$.isPublished' = 'true'
  ORDER BY c.id
```

To do:
- ~Update configs manually~
- [x] Run test on all explorer charts 