### PR TITLE
🐛 fix ArticleBlock typechecking

### DIFF
--- a/site/gdocs/components/Image.tsx
+++ b/site/gdocs/components/Image.tsx
@@ -52,6 +52,7 @@ const containerSizes: Record<ImageParentContainer, string> = {
     ["summary"]: gridSpan6,
     ["thumbnail"]: "350px",
     ["datapage"]: gridSpan6,
+    ["data-insight"]: "100%",
     ["full-width"]: "100vw",
     ["key-insight"]: gridSpan5,
     ["about-page"]: gridSpan8,


### PR DESCRIPTION
Fixes TS again after f80998e4551236e4c9709399a6442a4e3be8a824 broke it.

For some reason, `yarn typecheck` didn't catch this breakage locally, so I'm making a PR for this to make sure it passes.