### PR TITLE
🔨 refactor sorting by sortConfig

### DIFF
--- a/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChartState.ts
+++ b/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChartState.ts
@@ -16,6 +16,7 @@ import {
 import { ColorScale, ColorScaleManager } from "../color/ColorScale"
 import { SelectionArray } from "../selection/SelectionArray"
 import {
+    sortByConfig,
     autoDetectSeriesStrategy,
     autoDetectYColumnSlugs,
     combineHistoricalAndProjectionColumns,
@@ -37,7 +38,6 @@ import {
     SeriesStrategy,
     SortBy,
     SortConfig,
-    SortOrder,
 } from "@ourworldindata/types"
 import { OWID_ERROR_COLOR, OWID_NO_DATA_GRAY } from "../color/ColorConstants"
 import { ColorScheme } from "../color/ColorScheme"
@@ -358,31 +358,19 @@ export class DiscreteBarChartState implements ChartState, ColorScaleManager {
                 ? this.entitiesAsSeries
                 : this.columnsAsSeries
 
-        let sortByFunc: (item: DiscreteBarItem) => number | string | undefined
-        switch (this.sortConfig.sortBy) {
-            case SortBy.custom:
-                if (this.seriesStrategy === SeriesStrategy.entity) {
-                    sortByFunc = (item: DiscreteBarItem): number =>
-                        this.selectionArray.selectedEntityNames.indexOf(
-                            item.seriesName
-                        )
-                } else {
-                    sortByFunc = (): undefined => undefined
-                }
-                break
-            case SortBy.entityName:
-                sortByFunc = (item: DiscreteBarItem): string => item.seriesName
-                break
-            default:
-            case SortBy.total:
-            case SortBy.column: // we only have one yColumn, so total and column are the same
-                sortByFunc = (item: DiscreteBarItem): number => item.value
-                break
-        }
-        const sortedSeries = _.sortBy(raw, sortByFunc)
-        const sortOrder = this.sortConfig.sortOrder ?? SortOrder.desc
-        if (sortOrder === SortOrder.desc) return sortedSeries.toReversed()
-        else return sortedSeries
+        return sortByConfig(raw, this.sortConfig, {
+            [SortBy.custom]:
+                this.seriesStrategy === SeriesStrategy.entity
+                    ? (item): number =>
+                          this.selectionArray.selectedEntityNames.indexOf(
+                              item.seriesName
+                          )
+                    : (): undefined => undefined,
+            [SortBy.entityName]: (item): string => item.seriesName,
+            // We only have one yColumn, so total and column are the same
+            [SortBy.column]: (item): number => item.value,
+            [SortBy.total]: (item): number => item.value,
+        })
     }
 
     @computed private get valuesToColorsMap(): Map<number, string> {

--- a/packages/@ourworldindata/grapher/src/chart/ChartUtils.tsx
+++ b/packages/@ourworldindata/grapher/src/chart/ChartUtils.tsx
@@ -1,3 +1,4 @@
+import * as _ from "lodash-es"
 import * as React from "react"
 import {
     Box,
@@ -17,6 +18,9 @@ import {
     PrimitiveType,
     ColumnTypeNames,
     Time,
+    SortBy,
+    SortConfig,
+    SortOrder,
 } from "@ourworldindata/types"
 import { LineChartSeries } from "../lineCharts/LineChartConstants"
 import { SelectionArray } from "../selection/SelectionArray"
@@ -361,4 +365,22 @@ export function getChartSvgProps({
             backgroundColor: backgroundColor ?? GRAPHER_BACKGROUND_DEFAULT,
         },
     }
+}
+
+type SortKeyFn<T> = (item: T) => number | string | undefined
+
+export type SortKeyFunctions<T> = Record<SortBy, SortKeyFn<T>>
+
+export function sortByConfig<T>(
+    items: readonly T[],
+    sortConfig: SortConfig,
+    keyFns: SortKeyFunctions<T>
+): T[] {
+    const sortByKey = sortConfig.sortBy ?? SortBy.total
+    const sortByFunc = keyFns[sortByKey]
+    const sortOrder = sortConfig.sortOrder ?? SortOrder.desc
+
+    const sortedRows = _.sortBy(items, sortByFunc)
+
+    return sortOrder === SortOrder.desc ? sortedRows.toReversed() : sortedRows
 }

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.010.yaml
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.010.yaml
@@ -541,7 +541,12 @@ properties:
             - metric
     sortBy:
         type: string
-        description: Sort criterion (used by stacked bar charts and marimekko)
+        description: |
+            Sort criterion (used by discrete bar, stacked discrete bar, and marimekko charts).
+            - column: sort by the value of a specific column, identified by sortColumnSlug
+            - total: sort by the total across all columns
+            - entityName: sort alphabetically by entity name
+            - custom: preserve the specified entity order
         default: total
         enum:
             - column

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBarChartState.ts
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBarChartState.ts
@@ -9,11 +9,10 @@ import {
     EntityName,
     FacetStrategy,
     MissingDataStrategy,
-    SortBy,
     SortConfig,
-    SortOrder,
 } from "@ourworldindata/types"
 import {
+    sortByConfig,
     autoDetectYColumnSlugs,
     getDefaultFailMessage,
     getShortNameForEntity,
@@ -150,9 +149,10 @@ export class StackedDiscreteBarChartState implements ChartState {
     }
 
     @computed get sortColumn(): CoreColumn | undefined {
-        return this.sortColumnSlug
-            ? this.transformedTable.getColumns([this.sortColumnSlug])[0]
-            : undefined
+        if (!this.sortColumnSlug) return undefined
+        const sortColumn = this.transformedTable.get(this.sortColumnSlug)
+        if (sortColumn && !sortColumn.isMissing) return sortColumn
+        return undefined
     }
 
     @computed get sortConfig(): SortConfig {
@@ -242,31 +242,14 @@ export class StackedDiscreteBarChartState implements ChartState {
     }
 
     @computed get sortedRows(): readonly DiscreteBarRow[] {
-        let sortByFunc: (row: DiscreteBarRow) => number | string | undefined
-        switch (this.sortConfig.sortBy) {
-            case SortBy.custom:
-                sortByFunc = (): undefined => undefined
-                break
-            case SortBy.entityName:
-                sortByFunc = (row: DiscreteBarRow): string => row.entityName
-                break
-            case SortBy.column: {
-                const owidRowsByEntityName =
-                    this.sortColumn?.owidRowsByEntityName
-                sortByFunc = (row: DiscreteBarRow): number => {
-                    const rows = owidRowsByEntityName?.get(row.entityName)
-                    return rows?.[0]?.value ?? 0
-                }
-                break
-            }
-            default:
-            case SortBy.total:
-                sortByFunc = (row: DiscreteBarRow): number => row.totalValue
-        }
-        const sortedRows = _.sortBy(this.rows, sortByFunc)
-        const sortOrder = this.sortConfig.sortOrder ?? SortOrder.desc
-        if (sortOrder === SortOrder.desc) return sortedRows.toReversed()
-        else return sortedRows
+        return sortByConfig(this.rows, this.sortConfig, {
+            custom: () => undefined,
+            entityName: (row): string => row.entityName,
+            column: (row): number =>
+                this.sortColumn?.owidRowsByEntityName?.get(row.entityName)?.[0]
+                    ?.value ?? 0,
+            total: (row): number => row.totalValue,
+        })
     }
 
     @computed get availableFacetStrategies(): FacetStrategy[] {

--- a/packages/@ourworldindata/types/src/domainTypes/CoreTableTypes.ts
+++ b/packages/@ourworldindata/types/src/domainTypes/CoreTableTypes.ts
@@ -17,11 +17,6 @@ import { Integer } from "./Various.js"
 export type TableSlug = string // a url friendly name for a table
 export type ColumnSlugs = string // slugs cannot have spaces, so this is a space delimited array of ColumnSlugs
 
-export enum SortOrder {
-    asc = "asc",
-    desc = "desc",
-}
-
 /**
  * A concrete point in time (year or date). It's always supposed to be a finite number, but we
  * cannot enforce this in TypeScript.

--- a/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
+++ b/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
@@ -32,16 +32,19 @@ export interface Box {
     height: number
 }
 
-// TODO: remove duplicate definition, also available in CoreTable
 export enum SortOrder {
     asc = "asc",
     desc = "desc",
 }
 
 export enum SortBy {
+    /** Preserve the specified entity order */
     custom = "custom",
+    /** Sort alphabetically by entity name */
     entityName = "entityName",
+    /** Sort by the value of a specific column, identified by sortColumnSlug */
     column = "column",
+    /** Sort by the total across all columns */
     total = "total",
 }
 


### PR DESCRIPTION
This PR refactors sorting logic for discrete bar charts and stacked discrete bar charts by extracting common sorting functionality into a reusable utility function. The changes consolidate duplicate sorting code and improve maintainability across chart components. Marimekkos are not refactored because we'll drop support for sorting soon when we drop support for multiple y-indicators.