### PR TITLE
🐛 Fix top charts in all-charts block

### DIFF
--- a/site/gdocs/components/AllCharts.tsx
+++ b/site/gdocs/components/AllCharts.tsx
@@ -23,26 +23,20 @@ function sortRelatedCharts(
     relatedCharts: RelatedChart[],
     sortedSlugs: string[]
 ): RelatedChart[] {
-    const sortedRelatedCharts: RelatedChart[] = []
+    const chartBySlug = new Map(
+        relatedCharts.map((chart) => [chart.slug, chart])
+    )
 
-    // (We don't know if these slugs actually exist in relatedCharts)
-    // Try to find them in order and put them at the front of the list
-    sortedSlugs.forEach((slug) => {
-        const index = relatedCharts.findIndex((chart) => chart.slug === slug)
-        if (index !== -1) {
-            const relatedChart = relatedCharts.splice(index, 1)[0]
-            if (relatedChart) {
-                // a teeny hack to stop the RelatedCharts component from
-                // sorting these charts below the other key charts
-                relatedChart.keyChartLevel = KeyChartLevel.Top
-                sortedRelatedCharts.push(relatedChart)
-            }
+    const topCharts: RelatedChart[] = []
+    for (const slug of new Set(sortedSlugs)) {
+        const chart = chartBySlug.get(slug)
+        if (chart) {
+            topCharts.push({ ...chart, keyChartLevel: KeyChartLevel.Top })
+            chartBySlug.delete(slug)
         }
-    })
+    }
 
-    sortedRelatedCharts.push(...relatedCharts)
-
-    return sortedRelatedCharts
+    return [...topCharts, ...chartBySlug.values()]
 }
 
 export function AllCharts(props: AllChartsProps) {


### PR DESCRIPTION
## Context

https://github.com/owid/owid-grapher/pull/6137 broke the all-charts block `sortRelatedCharts` function which mutated data in the context (it has assumed it was safe to do, but the changes from the A/B test code cause the component to re-render and not find the original data anymore)

This PR updates the function to not mutate the original data.

## Screenshots / Videos / Diagrams

| Before | After |
|--------|--------|
| <img width="1307" height="599" alt="image" src="https://github.com/user-attachments/assets/16b0c2a3-a433-4ee2-ab45-3ac16840fa39" /> | <img width="1353" height="565" alt="image" src="https://github.com/user-attachments/assets/1388f20f-9c2a-4d87-a0ee-aec4cf798832" /> | 

## Testing guidance

You can check out the /democracy topic page on prod and staging, and confirm that the graphers specified in the `top` property in the page's gdoc aren't displayed on prod, but they are on staging.