### PR TITLE
Make Playwright archive dirs environment-aware for staging

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -10,6 +10,13 @@ const testDir = defineBddConfig({
     },
 })
 
+const archiveDir =
+    ENV === "development" ? "archive" : "/home/owid/live-data/archive"
+const wikipediaArchiveDir =
+    ENV === "development"
+        ? "wikipedia-archive"
+        : "/home/owid/live-data/wikipedia-archive"
+
 export default defineConfig({
     testDir,
     reporter: ENV === "development" ? [["line"]] : [["dot"]],
@@ -18,12 +25,12 @@ export default defineConfig({
     },
     webServer: [
         {
-            command: "http-server archive -p 8764 -c-1 --silent",
+            command: `http-server ${archiveDir} -p 8764 -c-1 --silent`,
             port: 8764,
             reuseExistingServer: true,
         },
         {
-            command: "http-server wikipedia-archive -p 8765 -c-1 --silent",
+            command: `http-server ${wikipediaArchiveDir} -p 8765 -c-1 --silent`,
             port: 8765,
             reuseExistingServer: true,
         },


### PR DESCRIPTION
## Context

BDD tests for the Wikipedia archive need to find archive directories at different paths depending on the environment:
- **Dev**: `archive/` and `wikipedia-archive/` (relative to project root)
- **Staging**: `/home/owid/live-data/archive` and `/home/owid/live-data/wikipedia-archive`

## Changes

- **`playwright.config.ts`**: Uses `ENV` to select the correct archive directory paths for Playwright's `http-server` commands

## Companion PR

**Merge owid/ops#413 first** — it adds the `create-wikipedia-archive.sh` script to staging so the directory actually exists:
- owid/ops#413 — adds Wikipedia archive creation to staging servers

## Testing guidance

- `yarn typecheck` passes
- `yarn testBdd` passes locally (39/39 tests)