### PR TITLE
🐛 Escape embedded JSON before inlining in script tags

### DIFF
--- a/packages/@ourworldindata/utils/src/serializers.test.ts
+++ b/packages/@ourworldindata/utils/src/serializers.test.ts
@@ -19,4 +19,21 @@ describe("encode and decode json", () => {
             )
         ).toEqual(undefined)
     })
+
+    it("should escape inline-script breaking content", () => {
+        const payload = {
+            title: "</script><script>alert(1)</script>",
+            text: "line separator:  and paragraph separator: ",
+        }
+
+        const serialized = serializeJSONForHTML(payload)
+
+        expect(serialized).not.toContain("</script>")
+        expect(serialized).toContain("\\u003c/script>")
+        expect(serialized).toContain("\\u2028")
+        expect(serialized).toContain("\\u2029")
+        expect(deserializeJSONFromHTML(`<html>${serialized}</html>`)).toEqual(
+            payload
+        )
+    })
 })

--- a/packages/@ourworldindata/utils/src/serializers.ts
+++ b/packages/@ourworldindata/utils/src/serializers.ts
@@ -1,11 +1,20 @@
 const jsonCommentDelimiter = "\n//EMBEDDED_JSON\n"
+
+const escapeJSONStringForInlineScript = (json: string): string =>
+    json
+        .replace(/</g, "\\u003c")
+        .replace(/\u2028/g, "\\u2028")
+        .replace(/\u2029/g, "\\u2029")
+
 // Stringifies JSON for placing into an arbitrary doc, for later extraction without parsing the whole doc
 export const serializeJSONForHTML = (
     obj: unknown,
     delimiter = jsonCommentDelimiter
 ): string =>
     `${delimiter}${
-        obj === undefined ? "" : JSON.stringify(obj, null, 2)
+        obj === undefined
+            ? ""
+            : escapeJSONStringForInlineScript(JSON.stringify(obj, null, 2))
     }${delimiter}`
 export const deserializeJSONFromHTML = (
     html: string,


### PR DESCRIPTION
### Motivation
- Prevent a stored XSS vector introduced by inlining raw `JSON.stringify` output into `<script>` tags which allowed `</script>` sequences from gdoc-derived content to break out of the script.

### Description
- Harden `serializeJSONForHTML` to escape `<`, U+2028 and U+2029 in the serialized JSON before embedding it in HTML and add a regression test that verifies `</script>` is not present in the serialized output while deserialization still round-trips.

### Testing
- Ran `yarn test run --reporter dot packages/@ourworldindata/utils/src/serializers.test.ts` (tests passed), `yarn fixFormatChanged > /dev/null 2>&1 && yarn typecheck` (passed), and `yarn testLintChanged` (passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69aff5e53cec832882de288cf4d365ef)