### PR TITLE
Sanitize comparisonUrl to prevent reflected XSS in admin test pages

### DIFF
--- a/adminSiteServer/testPageRouter.test.ts
+++ b/adminSiteServer/testPageRouter.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest"
+
+import { getSafeComparisonUrl } from "./testPageRouter.js"
+
+describe("getSafeComparisonUrl", () => {
+    it("returns the default comparison URL when the query param is missing", () => {
+        expect(getSafeComparisonUrl(undefined)).toBe(
+            "https://ourworldindata.org"
+        )
+    })
+
+    it("returns an empty string for blank input", () => {
+        expect(getSafeComparisonUrl("   ")).toBe("")
+    })
+
+    it("returns an empty string for invalid URLs", () => {
+        expect(getSafeComparisonUrl("not a url")).toBe("")
+    })
+
+    it("returns an empty string for non-http protocols", () => {
+        expect(getSafeComparisonUrl("javascript:alert(1)")).toBe("")
+    })
+
+    it("normalizes valid http and https URLs to origin and path", () => {
+        expect(
+            getSafeComparisonUrl(
+                "https://example.com/grapher/chart-slug?foo=bar#section"
+            )
+        ).toBe("https://example.com/grapher/chart-slug")
+        expect(getSafeComparisonUrl("http://example.com/explorers/co2")).toBe(
+            "http://example.com/explorers/co2"
+        )
+    })
+
+    it("returns an empty string when Express provides repeated comparisonUrl params", () => {
+        expect(
+            getSafeComparisonUrl([
+                "https://example.com/one",
+                "https://example.com/two",
+            ])
+        ).toBe("")
+    })
+})

--- a/adminSiteServer/testPageRouter.tsx
+++ b/adminSiteServer/testPageRouter.tsx
@@ -47,16 +47,35 @@ interface ChartItem {
     slug: string
 }
 
+type QueryStringParam = string | string[] | undefined
+
 function checkHasComparisonView(comparisonUrl: string): boolean {
     if (!comparisonUrl) return false
     if (IS_LIVE && comparisonUrl === DEFAULT_COMPARISON_URL) return false
     return true
 }
 
+function getSafeComparisonUrl(comparisonUrl: QueryStringParam): string {
+    if (comparisonUrl === undefined) return DEFAULT_COMPARISON_URL
+    if (typeof comparisonUrl !== "string") return ""
+    if (!comparisonUrl.trim()) return ""
+
+    try {
+        const url = new URL(comparisonUrl)
+        if (url.protocol === "http:" || url.protocol === "https:") {
+            return Url.fromURL(comparisonUrl).originAndPath ?? ""
+        }
+    } catch {
+        return ""
+    }
+
+    return ""
+}
+
 function getViewPropsFromQueryParams(
     params: Omit<EmbedTestPageQueryParams, "originalUrl">
 ): Pick<EmbedTestPageProps, "comparisonUrl" | "hasComparisonView"> {
-    const comparisonUrl = params.comparisonUrl ?? DEFAULT_COMPARISON_URL
+    const comparisonUrl = getSafeComparisonUrl(params.comparisonUrl)
     const hasComparisonView = checkHasComparisonView(comparisonUrl)
 
     return { comparisonUrl, hasComparisonView }
@@ -90,7 +109,7 @@ function parseIntArrayOrUndefined(param: string | undefined): number[] {
 
 interface EmbedTestPageQueryParams {
     readonly originalUrl: string
-    readonly comparisonUrl?: string
+    readonly comparisonUrl?: QueryStringParam
     readonly perPage?: string
     readonly page?: string
     readonly random?: string
@@ -113,7 +132,7 @@ interface EmbedTestPageQueryParams {
 
 interface ExplorerTestPageQueryParams {
     readonly originalUrl?: string
-    readonly comparisonUrl?: string
+    readonly comparisonUrl?: QueryStringParam
     readonly type?: "grapher-ids" | "csv-files" | "indicators"
 }
 
@@ -822,4 +841,4 @@ function ExplorerTestPage(props: ExplorerTestPageProps) {
     )
 }
 
-export { testPageRouter }
+export { getSafeComparisonUrl, testPageRouter }


### PR DESCRIPTION
### Motivation
- Prevent a reflected XSS where an attacker-controlled `comparisonUrl` query parameter could be interpolated into iframe `src` attributes (e.g. `javascript:`/`data:` URLs) and execute script in the admin origin.

### Description
- Add `getSafeComparisonUrl()` to validate/normalize `comparisonUrl`, only allowing absolute `http:`/`https:` URLs and returning a normalized `origin + pathname`, otherwise returning an empty string (or the default when `undefined`); update `getViewPropsFromQueryParams()` to use the sanitized value so unsafe inputs disable the comparison iframe.

### Testing
- Ran `yarn install`, `yarn testFormatChanged`, `yarn testLintChanged`, and `yarn fixFormatChanged > /dev/null 2>&1 && yarn typecheck`, and all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69aff912a4c88328a9136162bbc47a7f)