### PR TITLE
✨ Unify chart algolia scoring

### DIFF
--- a/baker/algolia/indexExplorerViewsMdimViewsAndChartsToAlgolia.ts
+++ b/baker/algolia/indexExplorerViewsMdimViewsAndChartsToAlgolia.ts
@@ -1,3 +1,4 @@
+import fs from "fs/promises"
 // This should be imported as early as possible so the global error handler is
 // set up before any errors are thrown.
 import "../../serverUtils/instrument.js"
@@ -12,6 +13,7 @@ import {
 } from "./utils/explorerViews.js"
 import {
     createFeaturedMetricRecords,
+    getFeaturedMetricSlugs,
     MAX_NON_FM_RECORD_SCORE,
     scaleRecordScores,
 } from "./utils/shared.js"
@@ -38,12 +40,20 @@ const indexExplorerViewsMdimViewsAndChartsToAlgolia = async () => {
         async (trx) => {
             // Create shared base context once for all record getters
             const baseContext = await createBaseIndexingContext(trx)
+            const fmSlugs = await getFeaturedMetricSlugs(trx)
             const explorerViews = await getExplorerViewRecords(trx, {
                 skipGrapherViews: true,
                 baseContext,
+                fmSlugs,
             })
-            const mdimViews = await getMdimViewRecords(trx, { baseContext })
-            const grapherViews = await getChartsRecords(trx, { baseContext })
+            const mdimViews = await getMdimViewRecords(trx, {
+                baseContext,
+                fmSlugs,
+            })
+            const grapherViews = await getChartsRecords(trx, {
+                baseContext,
+                fmSlugs,
+            })
             // Scale grapher records and the default explorer views between 1000 and 10000,
             // Scale the remaining explorer views between 0 and 1000.
             // This is because Graphers are generally higher quality than Explorers and we don't want
@@ -74,12 +84,17 @@ const indexExplorerViewsMdimViewsAndChartsToAlgolia = async () => {
         db.TransactionCloseMode.Close
     )
 
-    console.log(`Indexing ${records.length} records`)
-    await client.replaceAllObjects({
-        indexName,
-        objects: records as Array<Record<string, any>>,
-    })
-    console.log(`Indexing complete`)
+    await fs.writeFile(
+        `./${indexName}-records-adjusted.json`,
+        JSON.stringify(records, null, 2)
+    )
+
+    // console.log(`Indexing ${records.length} records`)
+    // await client.replaceAllObjects({
+    //     indexName,
+    //     objects: records as Array<Record<string, any>>,
+    // })
+    // console.log(`Indexing complete`)
 
     await reportFeaturedMetricFailuresToSlack(failures)
 }

--- a/baker/algolia/utils/charts.ts
+++ b/baker/algolia/utils/charts.ts
@@ -18,6 +18,7 @@ import {
     getUniqueNamesFromTagHierarchies,
 } from "@ourworldindata/utils"
 import {
+    computeRecordScore,
     maybeAddChangeInPrefix,
     processAvailableEntities,
     parseJsonStringArray,
@@ -27,11 +28,6 @@ import { toPlaintext } from "@ourworldindata/components"
 import { getMaxViews7d } from "./pageviews.js"
 import { createChartsIndexingContext } from "./context.js"
 import pMap from "p-map"
-
-const computeChartScore = (
-    numRelatedArticles: number,
-    views_7d: number
-): number => numRelatedArticles * 500 + views_7d
 
 const parseRawChartRecord = (
     rawRecord: RawChartRecordRow
@@ -238,7 +234,8 @@ async function getRawChartsRecords(
 async function buildChartRecord(
     knex: db.KnexReadonlyTransaction,
     chart: ParsedChartRecordRow,
-    context: ChartsIndexingContext
+    context: ChartsIndexingContext,
+    fmSlugs: Set<string>
 ): Promise<ChartRecord | null> {
     const grapherState = new GrapherState(chart.config)
 
@@ -291,7 +288,12 @@ async function buildChartRecord(
         datasetVersions: chart.datasetVersions,
         datasetProducts: chart.datasetProducts,
         datasetProducers: chart.datasetProducers,
-        score: computeChartScore(numRelatedArticles, views_7d),
+        score: computeRecordScore(
+            numRelatedArticles,
+            views_7d,
+            fmSlugs.has(chart.slug),
+            chart.config.title?.length ?? 0
+        ),
     }
 }
 
@@ -300,9 +302,13 @@ async function buildChartRecord(
  */
 export const getChartsRecords = async (
     knex: db.KnexReadonlyTransaction,
-    options?: { chartIds?: number[]; baseContext?: IndexingContext }
+    options?: {
+        chartIds?: number[]
+        baseContext?: IndexingContext
+        fmSlugs?: Set<string>
+    }
 ): Promise<ChartRecord[]> => {
-    const { chartIds, baseContext } = options ?? {}
+    const { chartIds, baseContext, fmSlugs = new Set<string>() } = options ?? {}
 
     const context = await createChartsIndexingContext(
         knex,
@@ -314,7 +320,7 @@ export const getChartsRecords = async (
     const parsedCharts = rawChartsRecords.map(parseRawChartRecord)
     const recordsOrNull = await pMap(
         parsedCharts,
-        (chart) => buildChartRecord(knex, chart, context),
+        (chart) => buildChartRecord(knex, chart, context, fmSlugs),
         { concurrency: 10 }
     )
 

--- a/baker/algolia/utils/explorerViews.ts
+++ b/baker/algolia/utils/explorerViews.ts
@@ -17,6 +17,7 @@ import { parseDelimited } from "@ourworldindata/core-table"
 import { toPlaintext } from "@ourworldindata/components"
 import {
     ColumnTypeNames,
+    ContentGraphLinkType,
     CoreRow,
     MinimalExplorerInfo,
     OwidColumnDef,
@@ -46,6 +47,7 @@ import {
     FinalizedExplorerRecord,
 } from "./types.js"
 import {
+    computeRecordScore,
     EMPTY_DATASET_CHART_RECORD_DIMENSIONS,
     MAX_NON_FM_RECORD_SCORE,
     maybeAddChangeInPrefix,
@@ -54,6 +56,7 @@ import {
     scaleRecordScores,
     uniqNonEmptyStrings,
 } from "./shared.js"
+import { getPublishedLinksTo } from "../../../db/model/Link.js"
 
 /**
  * Matches "duplicate 1234", to catch the (hacky) rows that are using the `duplicate` transformation to create
@@ -319,15 +322,6 @@ async function getEntitiesPerColumnPerTable(
         // Merge all these objects together
     ).then((results) => Object.assign({}, ...results))
 }
-
-const computeExplorerViewScore = (record: {
-    views_7d: number
-    numNonDefaultSettings: number
-    titleLength: number
-}) =>
-    (record.views_7d || 0) * 10 -
-    record.numNonDefaultSettings * 50 -
-    record.titleLength
 
 const parseYVariableIds = (matrixRow: CoreRow): (string | number)[] => {
     return (
@@ -665,7 +659,9 @@ async function finalizeRecords(
     records: EnrichedExplorerRecord[],
     slug: string,
     pageviews: Record<string, { views_7d: number }>,
-    explorerInfo: MinimalExplorerInfo
+    explorerInfo: MinimalExplorerInfo,
+    numRelatedArticles: number,
+    isFMSource: boolean
 ): Promise<FinalizedExplorerRecord[]> {
     const withCleanSubtitles = processSubtitles(records)
 
@@ -688,7 +684,7 @@ async function finalizeRecords(
                 updatedAt: explorerInfo.updatedAt.toISOString(),
                 keyChartForTags: [],
                 numDimensions: record.yVariableIds.length,
-                numRelatedArticles: 0,
+                numRelatedArticles,
                 title: record.viewTitle as string,
                 containerTitle: explorerInfo.title,
                 subtitle: record.viewSubtitle!,
@@ -698,7 +694,12 @@ async function finalizeRecords(
                 tags: explorerInfo.tags,
                 objectID: `${explorerInfo.slug}-${i}`,
                 id: `explorer/${explorerInfo.slug}${record.viewQueryParams}`,
-                score: computeExplorerViewScore(record),
+                score: computeRecordScore(
+                    numRelatedArticles,
+                    record.views_7d,
+                    isFMSource,
+                    record.titleLength
+                ),
                 views_7d: record.views_7d,
                 availableEntities: record.availableEntities,
                 titleLength: record.titleLength,
@@ -714,7 +715,7 @@ async function finalizeRecords(
 
     const sortedByScore = _.orderBy(
         unsortedFinalRecords,
-        computeExplorerViewScore,
+        "score",
         "desc"
     ) as Omit<FinalizedExplorerRecord, "viewTitleIndexWithinExplorer">[]
 
@@ -736,7 +737,8 @@ export const getExplorerViewRecordsForExplorer = async (
     explorerInfo: MinimalExplorerInfo,
     pageviews: Record<string, { views_7d: number }>,
     explorerAdminServer: ExplorerAdminServer,
-    skipGrapherViews: boolean
+    skipGrapherViews: boolean,
+    fmSlugs: Set<string>
 ): Promise<FinalizedExplorerRecord[]> => {
     const { slug } = explorerInfo
     const explorerProgram = await explorerAdminServer.getExplorerFromSlug(
@@ -819,8 +821,23 @@ export const getExplorerViewRecordsForExplorer = async (
         ...enrichedCsvRecords,
     ]
 
+    const linksFromGdocs = await getPublishedLinksTo(
+        trx,
+        [slug],
+        ContentGraphLinkType.Explorer
+    )
+    const numRelatedArticles = linksFromGdocs.length
+    const isFMSource = fmSlugs.has(slug)
+
     // Finalize records with titles, sorting, and grouping
-    return finalizeRecords(enrichedRecords, slug, pageviews, explorerInfo)
+    return finalizeRecords(
+        enrichedRecords,
+        slug,
+        pageviews,
+        explorerInfo,
+        numRelatedArticles,
+        isFMSource
+    )
 }
 
 async function getExplorersWithInheritedTags(
@@ -861,9 +878,15 @@ export const getExplorerViewRecords = async (
         slug?: string
         skipGrapherViews?: boolean
         baseContext?: IndexingContext
+        fmSlugs?: Set<string>
     }
 ): Promise<FinalizedExplorerRecord[]> => {
-    const { slug, skipGrapherViews = false, baseContext } = options ?? {}
+    const {
+        slug,
+        skipGrapherViews = false,
+        baseContext,
+        fmSlugs = new Set<string>(),
+    } = options ?? {}
 
     console.log("Getting explorer view records")
     if (skipGrapherViews) {
@@ -886,7 +909,8 @@ export const getExplorerViewRecords = async (
                 explorerInfo,
                 context.pageviews,
                 explorerAdminServer,
-                skipGrapherViews
+                skipGrapherViews,
+                fmSlugs
             ),
         { concurrency: 1 }
     ).then((records) => records.flat())

--- a/baker/algolia/utils/mdimViews.ts
+++ b/baker/algolia/utils/mdimViews.ts
@@ -17,6 +17,7 @@ import { logErrorAndMaybeCaptureInSentry } from "../../../serverUtils/errorLog.j
 import {
     ChartRecord,
     ChartRecordType,
+    ContentGraphLinkType,
     IndexingContext,
 } from "@ourworldindata/types"
 import { createMdimIndexingContext } from "./context.js"
@@ -26,11 +27,13 @@ import {
 } from "../../MultiDimBaker.js"
 import { GrapherState } from "@ourworldindata/grapher"
 import {
+    computeRecordScore,
     maybeAddChangeInPrefix,
     parseJsonStringArray,
     uniqNonEmptyStrings,
 } from "./shared.js"
 import { getMultiDimRedirectTargets } from "../../../db/model/MultiDimRedirects.js"
+import { getPublishedLinksTo } from "../../../db/model/Link.js"
 import { getMaxViews7d, PageviewsByUrl } from "./pageviews.js"
 import { DatasetDimensionsForVariable } from "./types.js"
 
@@ -110,7 +113,8 @@ async function getRecords(
     tags: string[],
     pageviews: PageviewsByUrl,
     redirectSourcesByTarget: RedirectSourcesByTarget,
-    redirectSourcesBySlug: RedirectSourcesBySlug
+    redirectSourcesBySlug: RedirectSourcesBySlug,
+    fmSlugs: Set<string>
 ) {
     const { slug } = multiDim
     console.log(
@@ -126,6 +130,13 @@ async function getRecords(
         await getRelevantVariableMetadata(relevantVariableIds)
     const datasetDimensionsByVariableId =
         await getDatasetDimensionsByVariableIds(trx, [...relevantVariableIds])
+    const linksFromGdocs = await getPublishedLinksTo(
+        trx,
+        [slug],
+        ContentGraphLinkType.Grapher
+    )
+    const numRelatedArticles = linksFromGdocs.length
+    const isFMSource = fmSlugs.has(slug)
     return multiDim.config.views.map((view) => {
         const viewId = dimensionsToViewId(view.dimensions)
         const id = multiDimXChartConfigIdMap.get(`${multiDim.id}-${viewId}`)
@@ -173,7 +184,12 @@ async function getRecords(
             `/grapher/${slug}`,
             ...redirectSources,
         ])
-        const score = views_7d * 10 - title.length
+        const score = computeRecordScore(
+            numRelatedArticles,
+            views_7d,
+            isFMSource,
+            title.length
+        )
 
         const datasetDimensions = view.indicators.y
             .map((ind) => datasetDimensionsByVariableId.get(ind.id))
@@ -211,7 +227,7 @@ async function getRecords(
             updatedAt: new Date().toISOString(),
             numDimensions: chartConfig.dimensions?.length ?? 0,
             titleLength: title.length,
-            numRelatedArticles: 0,
+            numRelatedArticles,
             views_7d,
             score,
             isIncomeGroupSpecificFM: false,
@@ -262,9 +278,10 @@ export async function getMdimViewRecords(
     options?: {
         id?: number
         baseContext?: IndexingContext
+        fmSlugs?: Set<string>
     }
 ) {
-    const { id, baseContext } = options ?? {}
+    const { id, baseContext, fmSlugs = new Set<string>() } = options ?? {}
 
     console.log("Getting mdim view records")
 
@@ -327,7 +344,8 @@ export async function getMdimViewRecords(
                 tags,
                 context.pageviews,
                 redirectSourcesByTarget,
-                redirectSourcesBySlug
+                redirectSourcesBySlug,
+                fmSlugs
             )
         )
     )

--- a/baker/algolia/utils/shared.ts
+++ b/baker/algolia/utils/shared.ts
@@ -29,6 +29,7 @@ import {
 } from "./types.js"
 import { EXPLORERS_ROUTE_FOLDER } from "@ourworldindata/explorer"
 import { GRAPHER_ROUTE_FOLDER } from "@ourworldindata/grapher"
+import * as db from "../../../db/db.js"
 
 const countriesWithVariantNames = new Set(
     countries
@@ -129,6 +130,27 @@ function findMatchingRecordByPathnameAndQueryParams(
 }
 
 export const MAX_NON_FM_RECORD_SCORE = 10000
+
+const FM_SOURCE_BONUS = 500
+
+/**
+ * Unified score formula for all record types (charts, multi-dim views, explorer views).
+ * Uses the number of related articles as the primary editorial signal,
+ * pageviews as a secondary signal, a bonus for records whose slug
+ * is used as a featured metric, and a small penalty for longer titles
+ * to downrank more specific variants (e.g. "Male life expectancy, 16-24"
+ * ranks below "Life expectancy").
+ */
+export const computeRecordScore = (
+    numRelatedArticles: number,
+    views_7d: number,
+    isFMSource: boolean,
+    titleLength: number
+): number =>
+    numRelatedArticles * 500 +
+    views_7d +
+    (isFMSource ? FM_SOURCE_BONUS : 0) -
+    titleLength
 
 /**
  * All featured metrics start at a score of 11000, which places them above all
@@ -325,3 +347,23 @@ export const EMPTY_DATASET_CHART_RECORD_DIMENSIONS: DatasetChartRecordDimensions
         datasetProducts: [],
         datasetProducers: [],
     }
+
+/**
+ * Returns a set of slugs that are used as featured metrics.
+ * This is used to give a scoring bonus to records whose underlying
+ * chart/explorer/multi-dim is editorially featured.
+ */
+export async function getFeaturedMetricSlugs(
+    trx: db.KnexReadonlyTransaction
+): Promise<Set<string>> {
+    const rows = await db.knexRaw<{ url: string }>(
+        trx,
+        `SELECT DISTINCT url FROM featured_metrics`
+    )
+    const slugs = new Set<string>()
+    for (const row of rows) {
+        const url = Url.fromURL(row.url)
+        if (url.slug) slugs.add(url.slug)
+    }
+    return slugs
+}


### PR DESCRIPTION
We currently have 3 different scoring formulas for charts, explorer views, and multi-dim views.

These get applied to each, and are then each normalized between a range of 1000 to 11000

Because multi-dims' scores are very dependent on pageviews, and our current analytics table aggregates all pageviews for multi-dims into a single slug, multi-dim scores can become very skewed, placing its top charts at 10999, above everything else.

This PR aims to try and fix this problem with a single shared score formula that depends on related articles, FM status, and pageviews.

I've asked Bobbie if we can get disaggregated pageviews in the DB which will also reduce the distortion for multi-dims. If/once that's in place, we can incorporate it here and hopefully get an even more even spread of records.