### PR TITLE
✨ Better datelines

### DIFF
--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -1229,13 +1229,13 @@ export const getIndexableKeys = Object.keys as <T extends object>(
     obj: T
 ) => Array<keyof T>
 
-/** Formats a date like this: "October 10, 2024"
+/** Formats a date like this: "October 6, 2024"
  */
 export const formatDate = (date: Date): string => {
     return date.toLocaleDateString("en-US", {
         year: "numeric",
         month: "long",
-        day: "2-digit",
+        day: "numeric",
     })
 }
 

--- a/site/DataInsightsIndexPageContent.tsx
+++ b/site/DataInsightsIndexPageContent.tsx
@@ -59,6 +59,7 @@ export const DataInsightsIndexPageContent = (
                 key={dataInsight.id}
                 anchor={id}
                 shouldLinkTitle
+                shouldHideYearInDateline
                 {...dataInsight}
             />
         )

--- a/site/gdocs/components/DataInsightDateline.tsx
+++ b/site/gdocs/components/DataInsightDateline.tsx
@@ -9,7 +9,7 @@ export default function DataInsightDateline({
     publishedAt,
     formatOptions = {
         month: "long",
-        day: "2-digit",
+        day: "numeric",
     },
     highlightToday,
 }: {
@@ -30,9 +30,11 @@ export default function DataInsightDateline({
         } else if (date.isYesterday()) {
             formattedDate = "Yesterday"
         } else {
-            formattedDate = date
-                .toDate()
-                .toLocaleDateString("en-US", formatOptions)
+            const options =
+                date.year() !== dayjs().year()
+                    ? { ...formatOptions, year: "numeric" as const }
+                    : formatOptions
+            formattedDate = date.toDate().toLocaleDateString("en-US", options)
         }
     } else {
         formattedDate = "Unpublished"

--- a/site/gdocs/pages/Announcement.tsx
+++ b/site/gdocs/pages/Announcement.tsx
@@ -18,14 +18,7 @@ export const AnnouncementPageContent = (props: AnnouncementProps) => {
         <div className="announcement-page-content span-cols-6 col-start-5 span-md-cols-8 col-md-start-4 span-sm-cols-14 col-sm-start-1">
             <header className="span-cols-6 col-start-5 span-md-cols-8 col-md-start-4 span-sm-cols-14 col-sm-start-1">
                 <div className="announcement-page-header-meta">
-                    <DataInsightDateline
-                        publishedAt={publishedAt}
-                        formatOptions={{
-                            year: "numeric",
-                            month: "long",
-                            day: "2-digit",
-                        }}
-                    />
+                    <DataInsightDateline publishedAt={publishedAt} />
                     <span className="announcement-page-kicker h6-black-caps">
                         {props.content.kicker}
                     </span>

--- a/site/gdocs/pages/DataInsight.tsx
+++ b/site/gdocs/pages/DataInsight.tsx
@@ -100,6 +100,9 @@ export const DataInsightBody = (
         anchor?: string
         publishedAt: Date | string | null
         shouldLinkTitle?: boolean
+        // Hide the year on /data-insights index pages when published in the current year.
+        // Show it on individual data insight pages.
+        shouldHideYearInDateline?: boolean
     }
 ) => {
     const shouldLinkTitle = props.shouldLinkTitle
@@ -115,11 +118,15 @@ export const DataInsightBody = (
                 <DataInsightDateline
                     className="data-insight__dateline"
                     publishedAt={publishedAt}
-                    formatOptions={{
-                        year: "numeric",
-                        month: "long",
-                        day: "2-digit",
-                    }}
+                    formatOptions={
+                        props.shouldHideYearInDateline
+                            ? { month: "long", day: "numeric" }
+                            : {
+                                  year: "numeric",
+                                  month: "long",
+                                  day: "2-digit",
+                              }
+                    }
                 />
                 {shouldLinkTitle ? (
                     <a


### PR DESCRIPTION
- Removes leading zeros from all our formatted dates
- Hides the year on the data insights index page and latest page if the post is from the current year (e.g. `2026-03-11` → `March 11` vs. `2025-12-12` → `December 12, 2025`)

---

Somewhat related, our interfaces are a bit confusing when it comes to Dates.

They don't acknowledge the fact that sometimes our Dates have been serialized to strings and sometimes they're actual Date objects, and so there's redundant coercion where we turn something into a Date and then into a string and then back into a Date. It would be nice to clean all that up, but not in this PR 🙂 