### PR TITLE
Block inactive superuser impersonation via admin API key

### DIFF
--- a/adminSiteServer/authentication.ts
+++ b/adminSiteServer/authentication.ts
@@ -135,6 +135,17 @@ export async function apiKeyAuthMiddleware(
         }
 
         if (user.isSuperuser && actAsUserId !== undefined) {
+            if (!user.isActive) {
+                console.error(
+                    "Inactive superuser attempted to use x-act-as-user.",
+                    {
+                        userId: user.id,
+                        actAsUserId,
+                    }
+                )
+                return
+            }
+
             const actAsUser = await trx<DbPlainUser>(UsersTableName)
                 .where({ id: actAsUserId })
                 .first()

--- a/adminSiteServer/tests/api-key-auth.test.ts
+++ b/adminSiteServer/tests/api-key-auth.test.ts
@@ -156,4 +156,60 @@ describe("Admin API key auth", { timeout: 10000 }, () => {
         expect(updatedPrimaryUser?.lastSeen).toBeNull()
         expect(updatedActAsUser?.lastSeen).toBeNull()
     })
+
+    it("rejects x-act-as-user for inactive superusers", async () => {
+        const [inactiveSuperuserId] = await env
+            .testKnex(UsersTableName)
+            .insert({
+                email: "inactive-superuser@example.com",
+                fullName: "Inactive Superuser",
+                isActive: 0,
+                isSuperuser: 1,
+                createdAt: new Date(),
+                updatedAt: new Date(),
+                lastSeen: null,
+            })
+
+        const [actAsUserId] = await env.testKnex(UsersTableName).insert({
+            email: "active-target@example.com",
+            fullName: "Active Target",
+            isActive: 1,
+            isSuperuser: 0,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            lastSeen: null,
+        })
+
+        const { apiKey, id } = await seedApiKeyForUser(
+            inactiveSuperuserId as number
+        )
+
+        const response = await fetch(`${env.baseUrl}/users.json`, {
+            headers: {
+                Authorization: `Bearer ${apiKey}`,
+                "x-act-as-user": String(actAsUserId),
+            },
+        })
+
+        expect(response.status).toBe(401)
+
+        const apiKeyRow = await env
+            .testKnex(AdminApiKeysTableName)
+            .where({ id })
+            .first()
+
+        const updatedInactiveSuperuser = await env
+            .testKnex(UsersTableName)
+            .where({ id: inactiveSuperuserId as number })
+            .first<DbPlainUser>()
+
+        const updatedActAsUser = await env
+            .testKnex(UsersTableName)
+            .where({ id: actAsUserId as number })
+            .first<DbPlainUser>()
+
+        expect(apiKeyRow?.lastUsedAt).toBeNull()
+        expect(updatedInactiveSuperuser?.lastSeen).toBeNull()
+        expect(updatedActAsUser?.lastSeen).toBeNull()
+    })
 })


### PR DESCRIPTION
### Motivation
- The API key auth middleware allowed a superuser holding a (still-valid) API key to impersonate another user via `x-act-as-user` without checking whether the API key owner was active. 
- Because downstream admin auth checks only `res.locals.user.isActive` (which becomes the impersonated user), an inactive superuser could regain admin access by acting as an active user.

### Description
- Add an explicit check in `apiKeyAuthMiddleware` to reject `x-act-as-user` requests when the API key owner (`user`) is not active, returning early and logging an error. 
- Add a regression test `rejects x-act-as-user for inactive superusers` that seeds an inactive superuser and an active target and asserts the act-as attempt is rejected (`401`) with no `lastUsedAt`/`lastSeen` updates. 
- Keep existing behavior for active superusers and for non-superusers (non-superusers are still forbidden from using `x-act-as-user`).

### Testing
- Ran `yarn fixFormatChanged` and `yarn testFormatChanged` and verified formatting issues were fixed (succeeded). 
- Ran `yarn typecheck` and `yarn testLintChanged` and both completed successfully. 
- Attempted to run the new test file directly with `yarn test run --reporter dot adminSiteServer/tests/api-key-auth.test.ts`, but this repo's vitest config excludes `adminSiteServer/tests/**`, so that targeted run reported no test files found; the test itself is present as a regression case for environments that include these tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b005231a2c8328bd2cd7bb1a0400a8)