### PR TITLE
Fix autocomplete dropdown position

### DIFF
--- a/site/SiteNavigation.tsx
+++ b/site/SiteNavigation.tsx
@@ -21,7 +21,10 @@ import { SiteNavigationToggle } from "./SiteNavigationToggle.js"
 import classnames from "classnames"
 import { useTriggerOnEscape } from "./hooks.js"
 import { useTopicTagGraph } from "./search/searchHooks.js"
-import { AUTOCOMPLETE_CONTAINER_ID } from "./search/Autocomplete.js"
+import {
+    AUTOCOMPLETE_CONTAINER_ID,
+    DETACHED_MODE_MAX_WIDTH,
+} from "./search/Autocomplete.js"
 import { Menu } from "./SiteConstants.js"
 import { SEARCH_BASE_PATH } from "./search/searchUtils.js"
 
@@ -59,7 +62,7 @@ export const SiteNavigation = ({
         // Fortunately we only have to do this when it mounts - it takes care of resizes
         setTimeout(() => {
             // Only run when screen size is large, .aa-DetachedContainer gets positioned correctly
-            if (window.innerWidth < 768) return
+            if (window.innerWidth <= DETACHED_MODE_MAX_WIDTH) return
             const [panel, autocompleteContainer] = [
                 ".aa-Panel",
                 AUTOCOMPLETE_CONTAINER_ID,

--- a/site/search/Autocomplete.tsx
+++ b/site/search/Autocomplete.tsx
@@ -51,6 +51,13 @@ import { SearchFilterPill } from "./SearchFilterPill.js"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faLineChart, faSearch } from "@fortawesome/free-solid-svg-icons"
 
+export const AUTOCOMPLETE_CONTAINER_ID = "#autocomplete"
+// A magic number slightly higher than our $md breakpoint to ensure there's
+// enough room for everything in the site nav between 960-1045px. Related to
+// vars in Autocomplete.scss.
+export const DETACHED_MODE_MAX_WIDTH = 1045
+const DETACHED_MEDIA_QUERY = `(max-width: ${DETACHED_MODE_MAX_WIDTH}px)`
+
 const siteAnalytics = new SiteAnalytics()
 type BaseItem = Record<string, unknown>
 
@@ -423,23 +430,17 @@ const createProfileSource = (
     templates: algoliaItemTemplate,
 })
 
-export const AUTOCOMPLETE_CONTAINER_ID = "#autocomplete"
-
 export function Autocomplete({
     onActivate,
     onClose,
     className,
     placeholder = DEFAULT_SEARCH_PLACEHOLDER,
-    // A magic number slightly higher than our $md breakpoint to ensure there's enough room
-    // for everything in the site nav between 960-1045px. Mirrored in Autocomplete.scss
-    detachedMediaQuery = "(max-width: 1045px)",
     panelClassName,
 }: {
     onActivate?: () => void
     onClose?: () => void
     className?: string
     placeholder?: string
-    detachedMediaQuery?: string
     panelClassName?: string
 }) {
     const containerRef = useRef<HTMLDivElement>(null)
@@ -467,7 +468,7 @@ export function Autocomplete({
             // characters may be deleted when typing.
             // https://support.algolia.com/hc/en-us/articles/35765245191057-Why-are-characters-being-deleted-from-Autocomplete-when-typing-on-a-Samsung-device
             enterKeyHint: "search",
-            detachedMediaQuery,
+            detachedMediaQuery: DETACHED_MEDIA_QUERY,
             container: containerRef.current,
             classNames: {
                 panel: panelClassName,
@@ -557,7 +558,6 @@ export function Autocomplete({
         onActivate,
         onClose,
         placeholder,
-        detachedMediaQuery,
         panelClassName,
         containerRef,
         allTopics,


### PR DESCRIPTION
There was a range of widths at which we were manually setting the dropdown position when we shouldn't have.

Fixes #5073