### PR TITLE
🎉 (admin) add refresh DIs button

### DIFF
--- a/adminSiteClient/DataInsightIndexPage.tsx
+++ b/adminSiteClient/DataInsightIndexPage.tsx
@@ -82,6 +82,7 @@ type PublicationFilter = "published" | "scheduled" | "draft"
 type Layout = "list" | "gallery"
 
 const DEFAULT_LAYOUT: Layout = "list"
+const PAGE_SIZE = 10
 
 const editIcon = <FontAwesomeIcon icon={faPen} size="sm" />
 const linkIcon = <FontAwesomeIcon icon={faUpRightFromSquare} size="sm" />
@@ -307,11 +308,15 @@ export function DataInsightIndexPage() {
         PublicationFilter | undefined
     >()
     const [layout, setLayout] = useState<Layout>(DEFAULT_LAYOUT)
+    const [currentPage, setCurrentPage] = useState(1)
 
     const [dataInsightForImageUpload, setDataInsightForImageUpload] =
         useState<DataInsightIndexItemThatCanBeUploaded>()
 
     const [isCreateModalOpen, setIsCreateModalOpen] = useState(false)
+
+    // True while new content is being refreshed from Google Docs
+    const [isRefreshing, setIsRefreshing] = useState(false)
 
     const [notificationApi, notificationContextHolder] =
         notification.useNotification()
@@ -382,6 +387,62 @@ export function DataInsightIndexPage() {
         publicationFilter,
         searchWords,
     ])
+
+    // Reset to page 1 when filters change
+    useEffect(() => {
+        setCurrentPage(1)
+    }, [searchValue, topicTagFilter, chartTypeFilter, publicationFilter])
+
+    const visibleDataInsights = useMemo(
+        () =>
+            filteredDataInsights.slice(
+                (currentPage - 1) * PAGE_SIZE,
+                currentPage * PAGE_SIZE
+            ),
+        [filteredDataInsights, currentPage]
+    )
+
+    const refreshDataFromGdocs = useCallback(async () => {
+        // Only refresh unpublished data insights. Published ones may have
+        // pending edits in Google Docs that aren't ready to go live yet,
+        // so we skip them to avoid re-publishing
+        const gdocIds = visibleDataInsights
+            .filter((di) => !di.published)
+            .map((di) => di.id)
+
+        if (gdocIds.length === 0) return
+
+        setIsRefreshing(true)
+        try {
+            const result = await admin.requestJSON(
+                "/api/dataInsights/refresh",
+                { gdocIds },
+                "POST"
+            )
+
+            // Fetch the latest data if any items were updated
+            if (result.updated > 0) await refreshDataInsights()
+
+            // Show a notification if any items failed to sync
+            if (result.errored > 0) {
+                notificationApi.error({
+                    message: "Failed to refresh some data insights",
+                    description: `${result.errored} of ${gdocIds.length} data insights could not be refreshed from Google Docs.`,
+                    placement: "bottomRight",
+                })
+            }
+        } catch (error) {
+            // Show a notification if the entire sync operation failed
+            notificationApi.error({
+                message: "Failed to refresh data insights",
+                description:
+                    error instanceof Error ? error.message : "Unknown error",
+                placement: "bottomRight",
+            })
+        } finally {
+            setIsRefreshing(false)
+        }
+    }, [admin, notificationApi, refreshDataInsights, visibleDataInsights])
 
     const updateTags = useCallback(
         async (gdocId: string, tags: MinimalTag[]) => {
@@ -555,6 +616,17 @@ export function DataInsightIndexPage() {
                             </Button>
                         </Flex>
                         <Flex gap="small">
+                            {layout === "list" && (
+                                <Tooltip title="Fetch latest content from Google Docs">
+                                    <Button
+                                        icon={rotateIcon}
+                                        onClick={refreshDataFromGdocs}
+                                        loading={isRefreshing}
+                                    >
+                                        Refresh
+                                    </Button>
+                                </Tooltip>
+                            )}
                             <Radio.Group
                                 defaultValue="list"
                                 onChange={(e) => setLayout(e.target.value)}
@@ -579,6 +651,14 @@ export function DataInsightIndexPage() {
                             columns={columns}
                             dataSource={filteredDataInsights}
                             rowKey={(dataInsight) => dataInsight.id}
+                            pagination={{
+                                current: currentPage,
+                                pageSize: PAGE_SIZE,
+                                showSizeChanger: false,
+                            }}
+                            onChange={(pagination) => {
+                                setCurrentPage(pagination.current ?? 1)
+                            }}
                         />
                     )}
                     {layout === "gallery" && (

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -151,6 +151,7 @@ import { getChartConfig } from "./apiRoutes/chartConfigs.js"
 import {
     createDataInsightGDoc,
     getAllDataInsightIndexItems,
+    refreshDataInsights,
 } from "./apiRoutes/dataInsights.js"
 import { getFigmaImageUrl } from "./apiRoutes/figma.js"
 import { sendMessageToSlack } from "./apiRoutes/slack.js"
@@ -388,6 +389,11 @@ postRouteWithRWTransaction(
     apiRouter,
     "/dataInsights/create",
     createDataInsightGDoc
+)
+postRouteWithRWTransaction(
+    apiRouter,
+    "/dataInsights/refresh",
+    refreshDataInsights
 )
 
 // Images routes

--- a/adminSiteServer/apiRoutes/dataInsights.ts
+++ b/adminSiteServer/apiRoutes/dataInsights.ts
@@ -5,20 +5,26 @@ import {
     DbRawChartConfig,
     DbRawImage,
     DbRawPostGdoc,
+    GdocsContentSource,
     GRAPHER_MAP_TYPE,
     GRAPHER_TAB_NAMES,
     GrapherChartOrMapType,
     GrapherInterface,
     MinimalTag,
+    OwidGdocBaseInterface,
     OwidGdocDataInsightContent,
     OwidGdocDataInsightIndexItem,
     parseChartConfig,
     parsePostGdocContent,
+    parsePostsGdocsRow,
+    PostsGdocsTableName,
 } from "@ourworldindata/types"
 import * as db from "../../db/db.js"
 import {
     createOrLoadGdocById,
     getTagsGroupedByGdocId,
+    loadGdocFromGdocBase,
+    updateGdocContentOnly,
 } from "../../db/model/Gdoc/GdocFactory.js"
 import {
     createGdocFromTemplate,
@@ -272,4 +278,64 @@ export function getChartTypeFromConfigAndQueryParams(
         return GRAPHER_MAP_TYPE
 
     return undefined
+}
+
+export async function refreshDataInsights(
+    req: Request,
+    _res: HandlerResponse,
+    trx: db.KnexReadWriteTransaction
+): Promise<{
+    success: boolean
+    updated: number
+    errored: number
+    errors: Array<{ id: string; message: string }>
+}> {
+    const gdocIds: string[] = req.body.gdocIds
+
+    // No-op if no IDs were provided
+    if (gdocIds.length === 0)
+        return { success: true, updated: 0, errored: 0, errors: [] }
+
+    // Fetch the requested data insights from the database
+    const rows = await trx
+        .table<DbRawPostGdoc>(PostsGdocsTableName)
+        .where("type", "data-insight")
+        .where("published", 0) // Only refresh unpublished data insights
+        .whereIn("id", gdocIds)
+
+    const records: OwidGdocBaseInterface[] = rows.map((row) =>
+        parsePostsGdocsRow(row)
+    )
+
+    let updated = 0
+    const errors: Array<{ id: string; message: string }> = []
+
+    // Fetch fresh content from Google Docs for each data insight
+    await Promise.all(
+        records.map(async (record) => {
+            try {
+                const gdoc = await loadGdocFromGdocBase(
+                    trx,
+                    record,
+                    GdocsContentSource.Gdocs,
+                    false,
+                    { loadState: false }
+                )
+
+                // Only write to DB if the revision id changed
+                if (gdoc.revisionId !== record.revisionId) {
+                    await updateGdocContentOnly(trx, gdoc.id, gdoc)
+                    updated++
+                }
+            } catch (error) {
+                errors.push({
+                    id: record.id,
+                    message:
+                        error instanceof Error ? error.message : String(error),
+                })
+            }
+        })
+    )
+
+    return { success: true, updated, errored: errors.length, errors }
 }


### PR DESCRIPTION
Resolves https://github.com/owid/owid-grapher/issues/4804

There’s currently a limitation where new content from gdocs is only fetched when the admin preview is visited, so DIs shown on the DI index page in the admin can go stale. 

Authors sometimes update the `figma-url` field in the gdoc and expect the ‘Figma URL’ and ‘Update image’ buttons to appear on the DI index page. One workaround is to visit the DI preview page in the admin, but this keeps coming up, so I thought it was time to fix it.

I went with a ‘Refresh’ button, instead of refreshing automatically in the background on page load, because it’s much simpler and means I don’t have to worry about things like debouncing while typing in the search input, etc