### PR TITLE
Add Tag Maintenance admin page

### DIFF
--- a/adminSiteClient/AdminApp.tsx
+++ b/adminSiteClient/AdminApp.tsx
@@ -56,6 +56,7 @@ import { FeaturedMetricsPage } from "./FeaturedMetricsPage.js"
 import { DodsIndexPage } from "./DodsIndexPage.js"
 import { StaticVizIndexPage } from "./StaticVizIndexPage.js"
 import { StaticVizEditPage } from "./StaticVizEditPage.js"
+import { TagMaintenancePage } from "./TagMaintenancePage.js"
 
 const queryClient = new QueryClient({
     defaultOptions: {
@@ -367,6 +368,11 @@ export class AdminApp extends React.Component<{
                                     exact
                                     path="/tag-graph"
                                     component={TagGraphPage}
+                                />
+                                <Route
+                                    exact
+                                    path="/tag-maintenance"
+                                    component={TagMaintenancePage}
                                 />
                                 <Route
                                     exact

--- a/adminSiteClient/AdminSidebar.tsx
+++ b/adminSiteClient/AdminSidebar.tsx
@@ -143,6 +143,11 @@ export const AdminSidebar = (): React.ReactElement => (
                 </Link>
             </li>
             <li>
+                <Link to="/tag-maintenance">
+                    <FontAwesomeIcon icon={faTag} fixedWidth /> Tag Maintenance
+                </Link>
+            </li>
+            <li>
                 <Link to="/bulk-downloads">
                     <FontAwesomeIcon icon={faDownload} fixedWidth /> Bulk
                     downloads

--- a/adminSiteClient/ChartList.tsx
+++ b/adminSiteClient/ChartList.tsx
@@ -69,6 +69,8 @@ interface ChartListProps {
     charts: ChartListItem[]
     autofocusSearchInput?: boolean
     onDelete?: (chart: ChartListItem) => void
+    /** When true, don't read/write the search query to the URL (e.g. when embedded in a drawer) */
+    disableUrlSync?: boolean
 }
 
 @observer
@@ -144,7 +146,9 @@ export class ChartList extends React.Component<ChartListProps> {
     }
 
     override componentDidMount() {
-        this.searchInput = this.getSearchInputFromUrl()
+        if (!this.props.disableUrlSync) {
+            this.searchInput = this.getSearchInputFromUrl()
+        }
         void this.getTags()
     }
 
@@ -209,7 +213,9 @@ export class ChartList extends React.Component<ChartListProps> {
 
     @action.bound onSearchInput(input: string) {
         this.searchInput = input
-        this.setSearchInputInUrl(input)
+        if (!this.props.disableUrlSync) {
+            this.setSearchInputInUrl(input)
+        }
     }
 
     @action.bound onShowMore() {

--- a/adminSiteClient/TagEditPage.tsx
+++ b/adminSiteClient/TagEditPage.tsx
@@ -5,13 +5,15 @@ import { Prompt, Redirect } from "react-router-dom"
 import { DbChartTagJoin } from "@ourworldindata/utils"
 import { AdminLayout } from "./AdminLayout.js"
 import { BindString, Timeago, Toggle } from "./Forms.js"
-import { DatasetList, DatasetListItem } from "./DatasetList.js"
-import { ChartList, ChartListItem } from "./ChartList.js"
+import { DatasetListItem } from "./DatasetList.js"
+import { ChartListItem } from "./ChartList.js"
 import { TagBadge } from "./TagBadge.js"
 import { AdminAppContext, AdminAppContextType } from "./AdminAppContext.js"
-import { AutoComplete } from "antd"
+import { AutoComplete, Flex, Table, TableColumnsType, Tag, Tabs } from "antd"
 
-interface TagPageData {
+export type DrawerTab = "gdocs" | "charts" | "datasets" | "explorers"
+
+export interface TagPageData {
     id: number
     name: string
     specialType?: string
@@ -19,6 +21,18 @@ interface TagPageData {
     datasets: DatasetListItem[]
     charts: ChartListItem[]
     children: DbChartTagJoin[]
+    gdocs: {
+        id: string
+        title: string
+        slug: string
+        type: string
+        published: number
+    }[]
+    explorers: {
+        slug: string
+        title: string
+        isPublished: number
+    }[]
     slug: string | null
     searchableInAlgolia: boolean
 }
@@ -41,9 +55,12 @@ class TagEditable {
 }
 
 @observer
-class TagEditor extends Component<{
+export class TagEditor extends Component<{
     tag: TagPageData
     publishedGdocTopicSlugs: string[]
+    activeTab?: DrawerTab | null
+    /** When true, child lists won't sync search state to the URL */
+    embedded?: boolean
 }> {
     static override contextType = AdminAppContext
     declare context: AdminAppContextType
@@ -54,6 +71,8 @@ class TagEditor extends Component<{
     constructor(props: {
         tag: TagPageData
         publishedGdocTopicSlugs: string[]
+        activeTab?: DrawerTab | null
+        embedded?: boolean
     }) {
         super(props)
 
@@ -128,8 +147,270 @@ class TagEditor extends Component<{
     }
 
     override render() {
-        const { tag } = this.props
+        const { tag, activeTab } = this.props
         const { newtag } = this
+
+        const gdocColumns: TableColumnsType<TagPageData["gdocs"][number]> = [
+            {
+                title: "Title",
+                dataIndex: "title",
+                key: "title",
+                render: (title: string, record) => (
+                    <a href={`/admin/gdocs/${record.id}/preview`}>
+                        {title || record.slug}
+                    </a>
+                ),
+            },
+            {
+                title: "Type",
+                dataIndex: "type",
+                key: "type",
+                width: 160,
+            },
+            {
+                title: "Status",
+                dataIndex: "published",
+                key: "published",
+                width: 120,
+                render: (published: number) =>
+                    published ? (
+                        <Tag color="green">Published</Tag>
+                    ) : (
+                        <Tag>Unpublished</Tag>
+                    ),
+            },
+        ]
+
+        const chartColumns: TableColumnsType<ChartListItem> = [
+            {
+                title: "Title",
+                key: "title",
+                render: (_, record) => (
+                    <a href={`/admin/charts/${record.id}/edit`}>
+                        {record.title}
+                        {record.variantName && (
+                            <span style={{ color: "#999", marginLeft: 4 }}>
+                                — {record.variantName}
+                            </span>
+                        )}
+                    </a>
+                ),
+            },
+            {
+                title: "Id",
+                dataIndex: "id",
+                key: "id",
+                width: 60,
+            },
+            {
+                title: "Status",
+                key: "status",
+                width: 120,
+                render: (_, record) =>
+                    record.publishedAt ? (
+                        <Tag color="green">Published</Tag>
+                    ) : (
+                        <Tag>Draft</Tag>
+                    ),
+            },
+        ]
+
+        const datasetColumns: TableColumnsType<DatasetListItem> = [
+            {
+                title: "Dataset",
+                key: "name",
+                render: (_, record) => (
+                    <a href={`/admin/datasets/${record.id}`}>{record.name}</a>
+                ),
+            },
+            {
+                title: "Namespace",
+                dataIndex: "namespace",
+                key: "namespace",
+                width: 120,
+            },
+            {
+                title: "Uploaded",
+                dataIndex: "dataEditedAt",
+                key: "dataEditedAt",
+                width: 160,
+                render: (val: Date) => <Timeago time={val} />,
+            },
+        ]
+
+        const explorerColumns: TableColumnsType<
+            TagPageData["explorers"][number]
+        > = [
+            {
+                title: "Title",
+                dataIndex: "title",
+                key: "title",
+                render: (title: string, record) => (
+                    <a href={`/admin/explorers/${record.slug}`}>{title}</a>
+                ),
+            },
+            {
+                title: "Status",
+                dataIndex: "isPublished",
+                key: "isPublished",
+                width: 120,
+                render: (isPublished: number) =>
+                    isPublished ? (
+                        <Tag color="green">Published</Tag>
+                    ) : (
+                        <Tag>Unpublished</Tag>
+                    ),
+            },
+        ]
+
+        const tableProps = {
+            size: "small" as const,
+            pagination: false as const,
+        }
+
+        const tabItems = [
+            {
+                key: "gdocs" as DrawerTab,
+                label: `Gdocs (${tag.gdocs.length})`,
+                children: (
+                    <Table
+                        {...tableProps}
+                        columns={gdocColumns}
+                        dataSource={tag.gdocs}
+                        rowKey="id"
+                    />
+                ),
+            },
+            {
+                key: "charts" as DrawerTab,
+                label: `Charts (${tag.charts.length})`,
+                children: (
+                    <Table
+                        {...tableProps}
+                        columns={chartColumns}
+                        dataSource={tag.charts}
+                        rowKey="id"
+                    />
+                ),
+            },
+            {
+                key: "datasets" as DrawerTab,
+                label: `Datasets (${tag.datasets.length})`,
+                children: (
+                    <Table
+                        {...tableProps}
+                        columns={datasetColumns}
+                        dataSource={tag.datasets}
+                        rowKey="id"
+                    />
+                ),
+            },
+            {
+                key: "explorers" as DrawerTab,
+                label: `Explorers (${tag.explorers.length})`,
+                children: (
+                    <Table
+                        {...tableProps}
+                        columns={explorerColumns}
+                        dataSource={tag.explorers}
+                        rowKey="slug"
+                    />
+                ),
+            },
+        ]
+
+        const { embedded } = this.props
+
+        const canDelete =
+            tag.datasets.length === 0 &&
+            tag.charts.length === 0 &&
+            tag.gdocs.length === 0 &&
+            tag.explorers.length === 0 &&
+            tag.children.length === 0 &&
+            !tag.specialType
+
+        const slugField = (
+            <div className="form-group" style={{ marginBottom: 0 }}>
+                <label>Slug</label>
+                <AutoComplete
+                    style={{ width: "100%" }}
+                    value={newtag.slug ?? ""}
+                    onChange={(value) =>
+                        runInAction(() => (newtag.slug = value || null))
+                    }
+                    options={this.props.publishedGdocTopicSlugs.map((slug) => ({
+                        value: slug,
+                        label: slug,
+                    }))}
+                    filterOption={(inputValue, option) =>
+                        option?.value
+                            .toLowerCase()
+                            .includes(inputValue.toLowerCase()) ?? false
+                    }
+                    allowClear
+                />
+                {!embedded && (
+                    <small className="form-text text-muted">
+                        The slug for this tag's topic page, e.g.
+                        trade-and-globalization.
+                    </small>
+                )}
+            </div>
+        )
+
+        const nameField = (
+            <BindString
+                field="name"
+                store={newtag}
+                label="Name"
+                helpText={
+                    embedded
+                        ? undefined
+                        : "Tag names must be unique and should be able to be understood without context"
+                }
+            />
+        )
+
+        const searchableToggle = (
+            <Toggle
+                label="Searchable in Algolia (must exist in tag graph)"
+                value={
+                    newtag.searchableInAlgolia ||
+                    this.slugMatchesPublishedTopicPage
+                }
+                onValue={(value) =>
+                    runInAction(() => (newtag.searchableInAlgolia = value))
+                }
+                disabled={this.slugMatchesPublishedTopicPage}
+                secondaryLabel={
+                    embedded
+                        ? undefined
+                        : this.slugMatchesPublishedTopicPage
+                          ? "This slug matches a published topic page, so charts with this tag will be indexed in Algolia"
+                          : "When enabled, charts with this tag will be indexed in Algolia even without matching a published topic page"
+                }
+            />
+        )
+
+        const actionButtons = (
+            <>
+                <input
+                    type="submit"
+                    disabled={!this.isModified || !newtag.name}
+                    className="btn btn-success"
+                    value="Update tag"
+                />{" "}
+                {canDelete && (
+                    <button
+                        className="btn btn-danger"
+                        type="button"
+                        onClick={() => this.deleteTag()}
+                    >
+                        Delete tag
+                    </button>
+                )}
+            </>
+        )
 
         return (
             <main className="TagEditPage">
@@ -137,12 +418,14 @@ class TagEditor extends Component<{
                     when={this.isModified}
                     message="Are you sure you want to leave? Unsaved changes will be lost."
                 />
-                <section>
-                    <h1>Tag: {tag.name}</h1>
-                    <p>
-                        Last updated <Timeago time={tag.updatedAt} />
-                    </p>
-                </section>
+                {!embedded && (
+                    <section>
+                        <h1>Tag: {tag.name}</h1>
+                        <p>
+                            Last updated <Timeago time={tag.updatedAt} />
+                        </p>
+                    </section>
+                )}
                 <section>
                     <form
                         onSubmit={(e) => {
@@ -150,78 +433,31 @@ class TagEditor extends Component<{
                             void this.save()
                         }}
                     >
-                        <BindString
-                            field="name"
-                            store={newtag}
-                            label="Name"
-                            helpText="Tag names must be unique and should be able to be understood without context"
-                        />
-                        <div className="form-group">
-                            <label>Slug</label>
-                            <AutoComplete
-                                style={{ width: "100%" }}
-                                value={newtag.slug ?? ""}
-                                onChange={(value) =>
-                                    runInAction(
-                                        () => (newtag.slug = value || null)
-                                    )
-                                }
-                                options={this.props.publishedGdocTopicSlugs.map(
-                                    (slug) => ({
-                                        value: slug,
-                                        label: slug,
-                                    })
-                                )}
-                                filterOption={(inputValue, option) =>
-                                    option?.value
-                                        .toLowerCase()
-                                        .includes(inputValue.toLowerCase()) ??
-                                    false
-                                }
-                                allowClear
-                            />
-                            <small className="form-text text-muted">
-                                The slug for this tag's topic page, e.g.
-                                trade-and-globalization.
-                            </small>
-                        </div>
-                        <Toggle
-                            label="Searchable in Algolia (must exist in tag graph)"
-                            value={
-                                newtag.searchableInAlgolia ||
-                                this.slugMatchesPublishedTopicPage
-                            }
-                            onValue={(value) =>
-                                runInAction(
-                                    () => (newtag.searchableInAlgolia = value)
-                                )
-                            }
-                            disabled={this.slugMatchesPublishedTopicPage}
-                            secondaryLabel={
-                                this.slugMatchesPublishedTopicPage
-                                    ? "This slug matches a published topic page, so charts with this tag will be indexed in Algolia"
-                                    : "When enabled, charts with this tag will be indexed in Algolia even without matching a published topic page"
-                            }
-                        />
-                        <div style={{ marginTop: 16 }}>
-                            <input
-                                type="submit"
-                                disabled={!this.isModified || !newtag.name}
-                                className="btn btn-success"
-                                value="Update tag"
-                            />{" "}
-                            {tag.datasets.length === 0 &&
-                                tag.children.length === 0 &&
-                                !tag.specialType && (
-                                    <button
-                                        className="btn btn-danger"
-                                        type="button"
-                                        onClick={() => this.deleteTag()}
-                                    >
-                                        Delete tag
-                                    </button>
-                                )}
-                        </div>
+                        {embedded ? (
+                            <>
+                                <Flex gap={12}>
+                                    <div style={{ flex: 1 }}>{nameField}</div>
+                                    <div style={{ flex: 1 }}>
+                                        {slugField}
+                                        <div style={{ marginTop: 4 }}>
+                                            {searchableToggle}
+                                        </div>
+                                    </div>
+                                </Flex>
+                                <div style={{ marginTop: 8 }}>
+                                    {actionButtons}
+                                </div>
+                            </>
+                        ) : (
+                            <>
+                                {nameField}
+                                {slugField}
+                                {searchableToggle}
+                                <div style={{ marginTop: 16 }}>
+                                    {actionButtons}
+                                </div>
+                            </>
+                        )}
                     </form>
                 </section>
                 {tag.children.length > 0 && (
@@ -232,15 +468,10 @@ class TagEditor extends Component<{
                         ))}
                     </section>
                 )}
-                <section>
-                    <h3>Datasets</h3>
-                    <DatasetList datasets={tag.datasets} />
-                </section>
-
-                <section>
-                    <h3>Charts</h3>
-                    <ChartList charts={tag.charts} />
-                </section>
+                <Tabs
+                    defaultActiveKey={activeTab ?? "gdocs"}
+                    items={tabItems}
+                />
                 {this.isDeleted && <Redirect to={`/tags`} />}
             </main>
         )

--- a/adminSiteClient/TagMaintenancePage.tsx
+++ b/adminSiteClient/TagMaintenancePage.tsx
@@ -1,0 +1,391 @@
+import { useQuery } from "@tanstack/react-query"
+import { useContext, useEffect, useMemo, useState } from "react"
+import { Flex, Input, Table, TableColumnsType, Tag, Typography } from "antd"
+import { AdminAppContext } from "./AdminAppContext.js"
+import { AdminLayout } from "./AdminLayout.js"
+import { Link } from "./Link.js"
+import { Admin } from "./Admin.js"
+
+type TagUsageRow = {
+    id: number
+    name: string
+    slug: string | null
+    searchableInAlgolia: number
+    hasTopicPage: number
+    topicPageCount: number
+    topicPageSlugs: string | null
+    inTagGraph: number
+    publishedGdocCount: number
+    unpublishedGdocCount: number
+    publishedChartCount: number
+    unpublishedChartCount: number
+    activeDatasetCount: number
+    archivedDatasetCount: number
+    publishedExplorerCount: number
+    unpublishedExplorerCount: number
+}
+
+type PresetKey =
+    | "all"
+    | "unused"
+    | "onlyArchivedUnpublished"
+    | "notInTagGraph"
+    | "searchableButEmpty"
+    | "contentButNotSearchable"
+    | "slugMismatch"
+    | "multipleTopicPages"
+
+function hasAnyPublishedContent(tag: TagUsageRow): boolean {
+    return (
+        tag.publishedGdocCount > 0 ||
+        tag.publishedChartCount > 0 ||
+        tag.activeDatasetCount > 0 ||
+        tag.publishedExplorerCount > 0
+    )
+}
+
+function hasAnyAssociation(tag: TagUsageRow): boolean {
+    return (
+        tag.publishedGdocCount > 0 ||
+        tag.unpublishedGdocCount > 0 ||
+        tag.publishedChartCount > 0 ||
+        tag.unpublishedChartCount > 0 ||
+        tag.activeDatasetCount > 0 ||
+        tag.archivedDatasetCount > 0 ||
+        tag.publishedExplorerCount > 0 ||
+        tag.unpublishedExplorerCount > 0
+    )
+}
+
+function isSearchable(tag: TagUsageRow): boolean {
+    return !!tag.searchableInAlgolia || !!tag.hasTopicPage
+}
+
+function hasSlugMismatch(tag: TagUsageRow): boolean {
+    if (!tag.slug) return false
+    // Tag has a slug but no associated topic page at all
+    if (tag.topicPageCount === 0) return true
+    // Tag has a slug and associated topic pages, but slug doesn't match any of them
+    const associatedSlugs = tag.topicPageSlugs?.split(", ") ?? []
+    return !associatedSlugs.includes(tag.slug)
+}
+
+const PRESETS: {
+    key: PresetKey
+    label: string
+    description: string
+    filter: (tag: TagUsageRow) => boolean
+}[] = [
+    {
+        key: "all",
+        label: "All",
+        description: "Show all leaf tags",
+        filter: () => true,
+    },
+    {
+        key: "unused",
+        label: "Unused",
+        description:
+            "Zero associations across all dimensions — safe delete candidates",
+        filter: (tag) => !hasAnyAssociation(tag),
+    },
+    {
+        key: "onlyArchivedUnpublished",
+        label: "Only archived/unpublished",
+        description:
+            "Has associations, but all are unpublished or archived — effectively dead",
+        filter: (tag) => hasAnyAssociation(tag) && !hasAnyPublishedContent(tag),
+    },
+    {
+        key: "notInTagGraph",
+        label: "Not in tag graph",
+        description:
+            "Not placed in the tag hierarchy — needs placement or cleanup",
+        filter: (tag) => !tag.inTagGraph,
+    },
+    {
+        key: "searchableButEmpty",
+        label: "Searchable but empty",
+        description:
+            "Appears as a filter option in search (via Algolia flag or topic page) but has zero published content — leads to empty results",
+        filter: (tag) => isSearchable(tag) && !hasAnyPublishedContent(tag),
+    },
+    {
+        key: "contentButNotSearchable",
+        label: "Content but not searchable",
+        description:
+            "Has published content but not searchable and no slug — users can't discover it",
+        filter: (tag) => hasAnyPublishedContent(tag) && !isSearchable(tag),
+    },
+    {
+        key: "slugMismatch",
+        label: "Slug mismatch",
+        description:
+            "Tag slug doesn't match any of its associated topic page slugs, or has a slug but no associated topic page — the slug-based and tag-based relationships are out of sync",
+        filter: (tag) => hasSlugMismatch(tag),
+    },
+    {
+        key: "multipleTopicPages",
+        label: "Multiple topic pages",
+        description:
+            "Slug matches more than one published topic page — should be a one-to-one relationship",
+        filter: (tag) => tag.topicPageCount > 1,
+    },
+]
+
+async function fetchTagUsageSummary(admin: Admin) {
+    const { tags } = await admin.getJSON<{ tags: TagUsageRow[] }>(
+        "/api/tags/usage-summary.json"
+    )
+    return tags
+}
+
+function renderCountWithSecondary(
+    primary: number,
+    secondary: number,
+    secondaryLabel: string
+): React.ReactNode {
+    return (
+        <>
+            {primary}
+            {secondary > 0 && (
+                <span style={{ color: "#999", marginLeft: 4 }}>
+                    +{secondary} {secondaryLabel}
+                </span>
+            )}
+        </>
+    )
+}
+
+function createColumns(): TableColumnsType<TagUsageRow> {
+    return [
+        {
+            title: "Tag name",
+            dataIndex: "name",
+            key: "name",
+            sorter: (a, b) => a.name.localeCompare(b.name),
+            defaultSortOrder: "ascend",
+            render: (name: string, record) => (
+                <Link to={`/tags/${record.id}`}>{name}</Link>
+            ),
+        },
+        {
+            title: "Slug",
+            dataIndex: "slug",
+            key: "slug",
+            render: (slug: string | null) =>
+                slug ? (
+                    <Typography.Text code>{slug}</Typography.Text>
+                ) : (
+                    <span style={{ color: "#ccc" }}>&mdash;</span>
+                ),
+        },
+        {
+            title: "Searchable",
+            key: "searchable",
+            width: 120,
+            align: "center",
+            sorter: (a, b) => {
+                const aVal =
+                    (a.searchableInAlgolia ? 1 : 0) + (a.hasTopicPage ? 2 : 0)
+                const bVal =
+                    (b.searchableInAlgolia ? 1 : 0) + (b.hasTopicPage ? 2 : 0)
+                return aVal - bVal
+            },
+            render: (_, record) => {
+                if (record.hasTopicPage) return "Topic page"
+                if (record.searchableInAlgolia) return "Algolia"
+                return <span style={{ color: "#ccc" }}>&mdash;</span>
+            },
+        },
+        {
+            title: "Topic pages",
+            key: "topicPages",
+            width: 200,
+            sorter: (a, b) => a.topicPageCount - b.topicPageCount,
+            render: (_, record) => {
+                if (record.topicPageCount === 0)
+                    return <span style={{ color: "#ccc" }}>&mdash;</span>
+                const slugs = record.topicPageSlugs?.split(", ") ?? []
+                const isMismatch = record.slug && !slugs.includes(record.slug)
+                return (
+                    <span
+                        style={
+                            record.topicPageCount > 1 || isMismatch
+                                ? { color: "#cf1322" }
+                                : undefined
+                        }
+                    >
+                        {slugs.map((s, i) => (
+                            <span key={s}>
+                                {i > 0 && ", "}
+                                <Typography.Text code>{s}</Typography.Text>
+                            </span>
+                        ))}
+                    </span>
+                )
+            },
+        },
+        {
+            title: "In tag graph",
+            dataIndex: "inTagGraph",
+            key: "inTagGraph",
+            width: 110,
+            align: "center",
+            sorter: (a, b) => a.inTagGraph - b.inTagGraph,
+            render: (val: number) =>
+                val ? "✓" : <span style={{ color: "#ccc" }}>&mdash;</span>,
+        },
+        {
+            title: "Gdocs",
+            key: "gdocs",
+            sorter: (a, b) =>
+                a.publishedGdocCount +
+                a.unpublishedGdocCount -
+                (b.publishedGdocCount + b.unpublishedGdocCount),
+            render: (_, record) =>
+                renderCountWithSecondary(
+                    record.publishedGdocCount,
+                    record.unpublishedGdocCount,
+                    "unpub"
+                ),
+        },
+        {
+            title: "Charts",
+            key: "charts",
+            sorter: (a, b) =>
+                a.publishedChartCount +
+                a.unpublishedChartCount -
+                (b.publishedChartCount + b.unpublishedChartCount),
+            render: (_, record) =>
+                renderCountWithSecondary(
+                    record.publishedChartCount,
+                    record.unpublishedChartCount,
+                    "unpub"
+                ),
+        },
+        {
+            title: "Datasets",
+            key: "datasets",
+            sorter: (a, b) =>
+                a.activeDatasetCount +
+                a.archivedDatasetCount -
+                (b.activeDatasetCount + b.archivedDatasetCount),
+            render: (_, record) =>
+                renderCountWithSecondary(
+                    record.activeDatasetCount,
+                    record.archivedDatasetCount,
+                    "archived"
+                ),
+        },
+        {
+            title: "Explorers",
+            key: "explorers",
+            sorter: (a, b) =>
+                a.publishedExplorerCount +
+                a.unpublishedExplorerCount -
+                (b.publishedExplorerCount + b.unpublishedExplorerCount),
+            render: (_, record) =>
+                renderCountWithSecondary(
+                    record.publishedExplorerCount,
+                    record.unpublishedExplorerCount,
+                    "unpub"
+                ),
+        },
+    ]
+}
+
+export function TagMaintenancePage() {
+    const { admin } = useContext(AdminAppContext)
+
+    useEffect(() => {
+        admin.loadingIndicatorSetting = "off"
+        return () => {
+            admin.loadingIndicatorSetting = "default"
+        }
+    }, [admin])
+
+    const { data: tags } = useQuery({
+        queryKey: ["tagUsageSummary"],
+        queryFn: () => fetchTagUsageSummary(admin),
+    })
+
+    const [search, setSearch] = useState("")
+    const [activePreset, setActivePreset] = useState<PresetKey>("all")
+
+    const activePresetConfig = PRESETS.find((p) => p.key === activePreset)!
+
+    const filteredTags = useMemo(() => {
+        const query = search.trim().toLowerCase()
+        return tags
+            ?.filter(activePresetConfig.filter)
+            .filter(
+                (tag) =>
+                    !query ||
+                    tag.name.toLowerCase().includes(query) ||
+                    tag.slug?.toLowerCase().includes(query)
+            )
+    }, [tags, search, activePresetConfig])
+
+    const columns = useMemo(() => createColumns(), [])
+
+    return (
+        <AdminLayout title="Tag Maintenance">
+            <main>
+                <Flex gap={8} wrap="wrap" style={{ marginBottom: 16 }}>
+                    {PRESETS.map((preset) => (
+                        <Tag.CheckableTag
+                            key={preset.key}
+                            checked={activePreset === preset.key}
+                            onChange={() => setActivePreset(preset.key)}
+                            style={{
+                                padding: "4px 12px",
+                                fontSize: 13,
+                                border: "1px solid #d9d9d9",
+                            }}
+                        >
+                            {preset.label}
+                        </Tag.CheckableTag>
+                    ))}
+                </Flex>
+                {activePreset !== "all" && (
+                    <Typography.Text
+                        type="secondary"
+                        style={{ display: "block", marginBottom: 12 }}
+                    >
+                        {activePresetConfig.description}
+                    </Typography.Text>
+                )}
+                <Flex
+                    align="center"
+                    justify="space-between"
+                    gap={24}
+                    style={{ marginBottom: 16 }}
+                >
+                    <Input
+                        placeholder="Search by tag name or slug"
+                        value={search}
+                        onChange={(e) => setSearch(e.target.value)}
+                        style={{ width: 400 }}
+                        autoFocus
+                    />
+                    <Typography.Text>
+                        Showing {filteredTags?.length ?? 0} of{" "}
+                        {tags?.length ?? 0} leaf tags
+                    </Typography.Text>
+                </Flex>
+                <Table
+                    columns={columns}
+                    dataSource={filteredTags}
+                    rowKey="id"
+                    loading={!tags}
+                    pagination={{
+                        defaultPageSize: 50,
+                        showSizeChanger: true,
+                        pageSizeOptions: ["20", "50", "100", "200"],
+                    }}
+                />
+            </main>
+        </AdminLayout>
+    )
+}

--- a/adminSiteClient/TagMaintenancePage.tsx
+++ b/adminSiteClient/TagMaintenancePage.tsx
@@ -1,10 +1,20 @@
-import { useQuery } from "@tanstack/react-query"
+import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { useContext, useEffect, useMemo, useState } from "react"
-import { Flex, Input, Table, TableColumnsType, Tag, Typography } from "antd"
+import {
+    Badge,
+    Drawer,
+    Flex,
+    Input,
+    Spin,
+    Table,
+    TableColumnsType,
+    Tag,
+    Typography,
+} from "antd"
 import { AdminAppContext } from "./AdminAppContext.js"
 import { AdminLayout } from "./AdminLayout.js"
-import { Link } from "./Link.js"
 import { Admin } from "./Admin.js"
+import { TagEditor, TagPageData, DrawerTab } from "./TagEditPage.js"
 
 type TagUsageRow = {
     id: number
@@ -24,6 +34,12 @@ type TagUsageRow = {
     publishedExplorerCount: number
     unpublishedExplorerCount: number
 }
+
+type DrawerState = {
+    tagId: number
+    tagName: string
+    tab?: DrawerTab
+} | null
 
 type PresetKey =
     | "all"
@@ -157,7 +173,39 @@ function renderCountWithSecondary(
     )
 }
 
-function createColumns(): TableColumnsType<TagUsageRow> {
+function clickableCount(
+    record: TagUsageRow,
+    primary: number,
+    secondary: number,
+    secondaryLabel: string,
+    onClick: (record: TagUsageRow, tab?: DrawerTab) => void,
+    tab?: DrawerTab
+): React.ReactNode {
+    const total = primary + secondary
+    return (
+        <a
+            href="#"
+            onClick={(e) => {
+                e.preventDefault()
+                onClick(record, tab)
+            }}
+            style={{
+                display: "block",
+                padding: "8px 4px",
+                margin: "-8px -4px",
+                color: total === 0 ? "#ccc" : undefined,
+            }}
+        >
+            {total === 0
+                ? "0"
+                : renderCountWithSecondary(primary, secondary, secondaryLabel)}
+        </a>
+    )
+}
+
+function createColumns(
+    onTagClick: (record: TagUsageRow, tab?: DrawerTab) => void
+): TableColumnsType<TagUsageRow> {
     return [
         {
             title: "Tag name",
@@ -166,7 +214,15 @@ function createColumns(): TableColumnsType<TagUsageRow> {
             sorter: (a, b) => a.name.localeCompare(b.name),
             defaultSortOrder: "ascend",
             render: (name: string, record) => (
-                <Link to={`/tags/${record.id}`}>{name}</Link>
+                <a
+                    href="#"
+                    onClick={(e) => {
+                        e.preventDefault()
+                        onTagClick(record)
+                    }}
+                >
+                    {name}
+                </a>
             ),
         },
         {
@@ -244,10 +300,13 @@ function createColumns(): TableColumnsType<TagUsageRow> {
                 a.unpublishedGdocCount -
                 (b.publishedGdocCount + b.unpublishedGdocCount),
             render: (_, record) =>
-                renderCountWithSecondary(
+                clickableCount(
+                    record,
                     record.publishedGdocCount,
                     record.unpublishedGdocCount,
-                    "unpub"
+                    "unpub",
+                    onTagClick,
+                    "gdocs"
                 ),
         },
         {
@@ -258,10 +317,13 @@ function createColumns(): TableColumnsType<TagUsageRow> {
                 a.unpublishedChartCount -
                 (b.publishedChartCount + b.unpublishedChartCount),
             render: (_, record) =>
-                renderCountWithSecondary(
+                clickableCount(
+                    record,
                     record.publishedChartCount,
                     record.unpublishedChartCount,
-                    "unpub"
+                    "unpub",
+                    onTagClick,
+                    "charts"
                 ),
         },
         {
@@ -272,10 +334,13 @@ function createColumns(): TableColumnsType<TagUsageRow> {
                 a.archivedDatasetCount -
                 (b.activeDatasetCount + b.archivedDatasetCount),
             render: (_, record) =>
-                renderCountWithSecondary(
+                clickableCount(
+                    record,
                     record.activeDatasetCount,
                     record.archivedDatasetCount,
-                    "archived"
+                    "archived",
+                    onTagClick,
+                    "datasets"
                 ),
         },
         {
@@ -286,10 +351,13 @@ function createColumns(): TableColumnsType<TagUsageRow> {
                 a.unpublishedExplorerCount -
                 (b.publishedExplorerCount + b.unpublishedExplorerCount),
             render: (_, record) =>
-                renderCountWithSecondary(
+                clickableCount(
+                    record,
                     record.publishedExplorerCount,
                     record.unpublishedExplorerCount,
-                    "unpub"
+                    "unpub",
+                    onTagClick,
+                    "explorers"
                 ),
         },
     ]
@@ -297,6 +365,7 @@ function createColumns(): TableColumnsType<TagUsageRow> {
 
 export function TagMaintenancePage() {
     const { admin } = useContext(AdminAppContext)
+    const queryClient = useQueryClient()
 
     useEffect(() => {
         admin.loadingIndicatorSetting = "off"
@@ -312,6 +381,7 @@ export function TagMaintenancePage() {
 
     const [search, setSearch] = useState("")
     const [activePreset, setActivePreset] = useState<PresetKey>("all")
+    const [drawerState, setDrawerState] = useState<DrawerState>(null)
 
     const activePresetConfig = PRESETS.find((p) => p.key === activePreset)!
 
@@ -327,26 +397,76 @@ export function TagMaintenancePage() {
             )
     }, [tags, search, activePresetConfig])
 
-    const columns = useMemo(() => createColumns(), [])
+    const presetCounts = useMemo(() => {
+        if (!tags) return {} as Record<PresetKey, number>
+        return Object.fromEntries(
+            PRESETS.map((preset) => [
+                preset.key,
+                tags.filter(preset.filter).length,
+            ])
+        ) as Record<PresetKey, number>
+    }, [tags])
+
+    const handleTagClick = (record: TagUsageRow, tab?: DrawerTab) => {
+        setDrawerState({ tagId: record.id, tagName: record.name, tab })
+    }
+
+    const handleDrawerClose = () => {
+        setDrawerState(null)
+        void queryClient.invalidateQueries({ queryKey: ["tagUsageSummary"] })
+    }
+
+    const columns = useMemo(() => createColumns(handleTagClick), [])
+
+    const tagDetailQuery = useQuery({
+        queryKey: ["tagDetail", drawerState?.tagId],
+        queryFn: async () => {
+            const [tagJson, slugsJson] = await Promise.all([
+                admin.getJSON<{ tag: TagPageData }>(
+                    `/api/tags/${drawerState!.tagId}.json`
+                ),
+                admin.getJSON<{ slugs: string[] }>(
+                    "/api/gdocs/publishedTopicSlugs"
+                ),
+            ])
+            return {
+                tag: tagJson.tag,
+                publishedGdocTopicSlugs: slugsJson.slugs,
+            }
+        },
+        enabled: !!drawerState,
+    })
 
     return (
         <AdminLayout title="Tag Maintenance">
             <main>
-                <Flex gap={8} wrap="wrap" style={{ marginBottom: 16 }}>
-                    {PRESETS.map((preset) => (
-                        <Tag.CheckableTag
-                            key={preset.key}
-                            checked={activePreset === preset.key}
-                            onChange={() => setActivePreset(preset.key)}
-                            style={{
-                                padding: "4px 12px",
-                                fontSize: 13,
-                                border: "1px solid #d9d9d9",
-                            }}
-                        >
-                            {preset.label}
-                        </Tag.CheckableTag>
-                    ))}
+                <Flex gap={12} wrap="wrap" style={{ marginBottom: 16 }}>
+                    {PRESETS.map((preset) => {
+                        const tag = (
+                            <Tag.CheckableTag
+                                checked={activePreset === preset.key}
+                                onChange={() => setActivePreset(preset.key)}
+                                style={{
+                                    padding: "4px 12px",
+                                    fontSize: 13,
+                                    border: "1px solid #d9d9d9",
+                                }}
+                            >
+                                {preset.label}
+                            </Tag.CheckableTag>
+                        )
+                        if (preset.key === "all") {
+                            return <span key={preset.key}>{tag}</span>
+                        }
+                        return (
+                            <Badge
+                                key={preset.key}
+                                count={presetCounts[preset.key] ?? 0}
+                            >
+                                {tag}
+                            </Badge>
+                        )
+                    })}
                 </Flex>
                 {activePreset !== "all" && (
                     <Typography.Text
@@ -385,6 +505,35 @@ export function TagMaintenancePage() {
                         pageSizeOptions: ["20", "50", "100", "200"],
                     }}
                 />
+                <Drawer
+                    title={drawerState?.tagName}
+                    open={!!drawerState}
+                    onClose={handleDrawerClose}
+                    width="60%"
+                    styles={{ body: { padding: 16 } }}
+                    destroyOnClose
+                >
+                    {drawerState &&
+                        (tagDetailQuery.isLoading ? (
+                            <Flex
+                                justify="center"
+                                align="center"
+                                style={{ padding: 48 }}
+                            >
+                                <Spin size="large" />
+                            </Flex>
+                        ) : tagDetailQuery.data ? (
+                            <TagEditor
+                                key={drawerState.tagId}
+                                tag={tagDetailQuery.data.tag}
+                                publishedGdocTopicSlugs={
+                                    tagDetailQuery.data.publishedGdocTopicSlugs
+                                }
+                                activeTab={drawerState.tab}
+                                embedded
+                            />
+                        ) : null)}
+                </Drawer>
             </main>
         </AdminLayout>
     )

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -94,6 +94,7 @@ import {
     getAllTags,
     deleteTag,
     getTagUsageSummary,
+    getTagDetail,
 } from "./apiRoutes/tags.js"
 import {
     getUsers,
@@ -542,6 +543,7 @@ getRouteWithROTransaction(
     "/tags/usage-summary.json",
     getTagUsageSummary
 )
+getRouteWithROTransaction(apiRouter, "/tags/:tagId/detail.json", getTagDetail)
 getRouteWithROTransaction(apiRouter, "/tags/:tagId.json", getTagById)
 putRouteWithRWTransaction(apiRouter, "/tags/:tagId", updateTag)
 postRouteWithRWTransaction(apiRouter, "/tags/new", createTag)

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -93,6 +93,7 @@ import {
     createTag,
     getAllTags,
     deleteTag,
+    getTagUsageSummary,
 } from "./apiRoutes/tags.js"
 import {
     getUsers,
@@ -536,6 +537,11 @@ getRouteWithROTransaction(
     handleGetFlatTagGraph
 )
 postRouteWithRWTransaction(apiRouter, "/tagGraph", handlePostTagGraph)
+getRouteWithROTransaction(
+    apiRouter,
+    "/tags/usage-summary.json",
+    getTagUsageSummary
+)
 getRouteWithROTransaction(apiRouter, "/tags/:tagId.json", getTagById)
 putRouteWithRWTransaction(apiRouter, "/tags/:tagId", updateTag)
 postRouteWithRWTransaction(apiRouter, "/tags/new", createTag)

--- a/adminSiteServer/apiRoutes/tags.ts
+++ b/adminSiteServer/apiRoutes/tags.ts
@@ -63,6 +63,7 @@ export async function getTagById(
             | "dataEditedAt"
             | "isPrivate"
             | "nonRedistributable"
+            | "isArchived"
         > & { dataEditedByUserName: string }
     >(
         trx,
@@ -77,8 +78,9 @@ export async function getTagById(
             d.dataEditedAt,
             du.fullName AS dataEditedByUserName,
             d.isPrivate,
-            d.nonRedistributable
-        FROM active_datasets d
+            d.nonRedistributable,
+            d.isArchived
+        FROM datasets d
         JOIN users du ON du.id=d.dataEditedByUserId
         LEFT JOIN dataset_tags dt ON dt.datasetId = d.id
         WHERE dt.tagId ${uncategorized ? "IS NULL" : "= ?"}
@@ -139,6 +141,48 @@ export async function getTagById(
     tag.charts = charts
 
     await assignTagsForCharts(trx, charts)
+
+    // Gdocs tagged with this tag
+    const gdocs = uncategorized
+        ? []
+        : await db.knexRaw<{
+              id: string
+              title: string
+              slug: string
+              type: string
+              published: number
+          }>(
+              trx,
+              `-- sql
+            SELECT pg.id, pg.content->>'$.title' as title, pg.slug, pg.type, pg.published
+            FROM posts_gdocs_x_tags pgt
+            JOIN posts_gdocs pg ON pg.id = pgt.gdocId
+            WHERE pgt.tagId = ?
+            ORDER BY pg.published DESC, pg.slug
+        `,
+              [tagId]
+          )
+    tag.gdocs = gdocs
+
+    // Explorers tagged with this tag
+    const explorers = uncategorized
+        ? []
+        : await db.knexRaw<{
+              slug: string
+              title: string
+              isPublished: number
+          }>(
+              trx,
+              `-- sql
+            SELECT e.slug, COALESCE(e.config->>'$.explorerTitle', e.slug) as title, e.isPublished
+            FROM explorer_tags et
+            JOIN explorers e ON e.slug = et.explorerSlug
+            WHERE et.tagId = ?
+            ORDER BY e.isPublished DESC, e.slug
+        `,
+              [tagId]
+          )
+    tag.explorers = explorers
 
     // Subcategories (children in tag_graph)
     const children = await db.knexRaw<{ id: number; name: string }>(
@@ -326,6 +370,82 @@ export async function getTagUsageSummary(
     `
     )
     return { tags: rows }
+}
+
+export async function getTagDetail(
+    req: Request,
+    _res: HandlerResponse,
+    trx: db.KnexReadonlyTransaction
+) {
+    const tagId = expectInt(req.params.tagId)
+
+    const gdocs = await db.knexRaw<{
+        id: string
+        title: string
+        slug: string
+        type: string
+        published: number
+    }>(
+        trx,
+        `SELECT pg.id, pg.content->>'$.title' as title, pg.slug, pg.type, pg.published
+        FROM posts_gdocs_x_tags pgt
+        JOIN posts_gdocs pg ON pg.id = pgt.gdocId
+        WHERE pgt.tagId = ?
+        ORDER BY pg.published DESC, pg.slug`,
+        [tagId]
+    )
+
+    const charts = await db.knexRaw<{
+        id: number
+        title: string
+        slug: string
+        publishedAt: string | null
+        lastEditedAt: string
+    }>(
+        trx,
+        `SELECT c.id,
+            chart_configs.full->>'$.title' as title,
+            chart_configs.slug,
+            c.publishedAt,
+            c.lastEditedAt
+        FROM chart_tags ct
+        JOIN charts c ON c.id = ct.chartId
+        JOIN chart_configs ON chart_configs.id = c.configId
+        WHERE ct.tagId = ?
+        ORDER BY c.publishedAt IS NULL, chart_configs.slug`,
+        [tagId]
+    )
+
+    const datasets = await db.knexRaw<{
+        id: number
+        name: string
+        isArchived: number
+        dataEditedAt: string
+    }>(
+        trx,
+        `SELECT d.id, d.name, d.isArchived, d.dataEditedAt
+        FROM dataset_tags dt
+        JOIN datasets d ON d.id = dt.datasetId
+        WHERE dt.tagId = ?
+        ORDER BY d.isArchived, d.name`,
+        [tagId]
+    )
+
+    const explorers = await db.knexRaw<{
+        slug: string
+        title: string
+        isPublished: number
+    }>(
+        trx,
+        `SELECT e.slug, COALESCE(e.config->>'$.explorerTitle', e.slug) as title, e.isPublished
+        FROM explorer_tags et
+        JOIN explorers e ON e.slug = et.explorerSlug
+        WHERE et.tagId = ?
+        ORDER BY e.isPublished DESC, e.slug`,
+        [tagId]
+    )
+
+    return { gdocs, charts, datasets, explorers }
 }
 
 export async function deleteTag(

--- a/adminSiteServer/apiRoutes/tags.ts
+++ b/adminSiteServer/apiRoutes/tags.ts
@@ -252,6 +252,82 @@ export async function getAllTags(
     return { tags: await db.getMinimalTagsWithIsTopic(trx) }
 }
 
+export async function getTagUsageSummary(
+    _req: Request,
+    _res: HandlerResponse,
+    trx: db.KnexReadonlyTransaction
+) {
+    const rows = await db.knexRaw<{
+        id: number
+        name: string
+        slug: string | null
+        searchableInAlgolia: number
+        hasTopicPage: number
+        topicPageCount: number
+        topicPageSlugs: string | null
+        inTagGraph: number
+        publishedGdocCount: number
+        unpublishedGdocCount: number
+        publishedChartCount: number
+        unpublishedChartCount: number
+        activeDatasetCount: number
+        archivedDatasetCount: number
+        publishedExplorerCount: number
+        unpublishedExplorerCount: number
+    }>(
+        trx,
+        `-- sql
+        SELECT
+            t.id,
+            t.name,
+            t.slug,
+            t.searchableInAlgolia,
+            EXISTS(
+                SELECT 1 FROM posts_gdocs tp
+                WHERE tp.slug = t.slug
+                AND tp.published = TRUE
+                AND tp.type IN ('topic-page', 'linear-topic-page')
+            ) as hasTopicPage,
+            (
+                SELECT COUNT(*) FROM posts_gdocs_x_tags tpgt
+                JOIN posts_gdocs tp ON tp.id = tpgt.gdocId
+                WHERE tpgt.tagId = t.id
+                AND tp.published = TRUE
+                AND tp.type IN ('topic-page', 'linear-topic-page')
+            ) as topicPageCount,
+            (
+                SELECT GROUP_CONCAT(tp.slug ORDER BY tp.slug SEPARATOR ', ')
+                FROM posts_gdocs_x_tags tpgt
+                JOIN posts_gdocs tp ON tp.id = tpgt.gdocId
+                WHERE tpgt.tagId = t.id
+                AND tp.published = TRUE
+                AND tp.type IN ('topic-page', 'linear-topic-page')
+            ) as topicPageSlugs,
+            EXISTS(SELECT 1 FROM tag_graph tg WHERE tg.childId = t.id) as inTagGraph,
+            (SELECT COUNT(*) FROM posts_gdocs_x_tags pgt JOIN posts_gdocs pg ON pg.id = pgt.gdocId
+                WHERE pgt.tagId = t.id AND pg.published = 1) as publishedGdocCount,
+            (SELECT COUNT(*) FROM posts_gdocs_x_tags pgt JOIN posts_gdocs pg ON pg.id = pgt.gdocId
+                WHERE pgt.tagId = t.id AND pg.published = 0) as unpublishedGdocCount,
+            (SELECT COUNT(*) FROM chart_tags ct JOIN charts c ON c.id = ct.chartId
+                WHERE ct.tagId = t.id AND c.publishedAt IS NOT NULL) as publishedChartCount,
+            (SELECT COUNT(*) FROM chart_tags ct JOIN charts c ON c.id = ct.chartId
+                WHERE ct.tagId = t.id AND c.publishedAt IS NULL) as unpublishedChartCount,
+            (SELECT COUNT(*) FROM dataset_tags dt JOIN datasets d ON d.id = dt.datasetId
+                WHERE dt.tagId = t.id AND d.isArchived = 0) as activeDatasetCount,
+            (SELECT COUNT(*) FROM dataset_tags dt JOIN datasets d ON d.id = dt.datasetId
+                WHERE dt.tagId = t.id AND d.isArchived = 1) as archivedDatasetCount,
+            (SELECT COUNT(*) FROM explorer_tags et JOIN explorers e ON e.slug = et.explorerSlug
+                WHERE et.tagId = t.id AND e.isPublished = 1) as publishedExplorerCount,
+            (SELECT COUNT(*) FROM explorer_tags et JOIN explorers e ON e.slug = et.explorerSlug
+                WHERE et.tagId = t.id AND e.isPublished = 0) as unpublishedExplorerCount
+        FROM tags t
+        WHERE NOT EXISTS (SELECT 1 FROM tag_graph tg WHERE tg.parentId = t.id)
+        ORDER BY t.name
+    `
+    )
+    return { tags: rows }
+}
+
 export async function deleteTag(
     req: Request,
     _res: HandlerResponse,


### PR DESCRIPTION
## Context

New admin page at `/admin/tag-maintenance` that shows all leaf tags (tags not used as parents in the tag graph) with usage counts across gdocs, charts, datasets, and explorers. Helps identify orphaned or underused tags for cleanup.

## Screenshots / Videos / Diagrams

![Screenshot 2026-03-16 at 12.01.57.png](https://app.graphite.com/user-attachments/assets/8ced2d23-dc82-42b5-b7ef-5b73460f934b.png)



## Testing guidance

1. Navigate to `/admin/tag-maintenance` in the admin
2. Verify the table loads with all leaf tags
3. Test search filtering by tag name and slug
4. Test column sorting (name, gdoc count, chart count, etc.)
5. Verify counts show published primary + unpublished secondary numbers

## Checklist

### Before merging

- [ ] Changes to CSS/HTML were checked on Desktop and Mobile Safari at all three breakpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)