### PR TITLE
🐛 fix dateline day hopping because of UTC

### DIFF
--- a/packages/@ourworldindata/utils/src/Util.test.ts
+++ b/packages/@ourworldindata/utils/src/Util.test.ts
@@ -3,6 +3,7 @@ import { expect, it, describe, vi } from "vitest"
 import timezoneMock from "timezone-mock"
 import {
     findClosestTime,
+    formatDate,
     formatDay,
     retryPromise,
     rollingMap,
@@ -183,6 +184,20 @@ describe(formatDay, () => {
         it("handles decrements", () => {
             expect(formatDay(-21)).toEqual("Dec 31, 2019")
         })
+    })
+})
+
+describe(formatDate, () => {
+    it("formats publication dates consistently across timezones", () => {
+        const publishedAt = new Date("2026-03-16T00:00:00.000Z")
+
+        timezoneMock.register("US/Pacific")
+        expect(formatDate(publishedAt)).toEqual("March 16, 2026")
+        timezoneMock.unregister()
+
+        timezoneMock.register("Australia/Adelaide")
+        expect(formatDate(publishedAt)).toEqual("March 16, 2026")
+        timezoneMock.unregister()
     })
 })
 

--- a/packages/@ourworldindata/utils/src/Util.test.ts
+++ b/packages/@ourworldindata/utils/src/Util.test.ts
@@ -5,6 +5,7 @@ import {
     findClosestTime,
     formatDate,
     formatDay,
+    formatRelativeDate,
     retryPromise,
     rollingMap,
     next,
@@ -198,6 +199,52 @@ describe(formatDate, () => {
         timezoneMock.register("Australia/Adelaide")
         expect(formatDate(publishedAt)).toEqual("March 16, 2026")
         timezoneMock.unregister()
+    })
+})
+
+describe(formatRelativeDate, () => {
+    it("returns Today for the same UTC calendar day", () => {
+        expect(
+            formatRelativeDate({
+                publishedAt: new Date("2026-03-16T00:00:00.000Z"),
+                now: new Date("2026-03-16T23:59:59.000Z"),
+            })
+        ).toEqual("Today")
+    })
+
+    it("returns Yesterday for the previous UTC calendar day", () => {
+        expect(
+            formatRelativeDate({
+                publishedAt: new Date("2026-03-15T23:59:59.000Z"),
+                now: new Date("2026-03-16T00:00:00.000Z"),
+            })
+        ).toEqual("Yesterday")
+    })
+
+    it("formats older dates consistently across timezones", () => {
+        const publishedAt = new Date("2026-03-14T00:00:00.000Z")
+        const now = new Date("2026-03-16T12:00:00.000Z")
+
+        timezoneMock.register("US/Pacific")
+        expect(formatRelativeDate({ publishedAt, now })).toEqual("March 14")
+        timezoneMock.unregister()
+
+        timezoneMock.register("Australia/Adelaide")
+        expect(formatRelativeDate({ publishedAt, now })).toEqual("March 14")
+        timezoneMock.unregister()
+    })
+
+    it("includes the year when the published date is in a different UTC year", () => {
+        expect(
+            formatRelativeDate({
+                publishedAt: new Date("2025-12-31T00:00:00.000Z"),
+                now: new Date("2026-01-02T12:00:00.000Z"),
+            })
+        ).toEqual("December 31, 2025")
+    })
+
+    it("returns Unpublished when publishedAt is null", () => {
+        expect(formatRelativeDate({ publishedAt: null })).toEqual("Unpublished")
     })
 })
 

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -1229,13 +1229,17 @@ export const getIndexableKeys = Object.keys as <T extends object>(
     obj: T
 ) => Array<keyof T>
 
-/** Formats a date like this: "October 6, 2024"
+/** Formats a date like this: "October 6, 2024".
+ *
+ * We pin the formatter to UTC so publication dates render as the same calendar
+ * day during SSR, baking, and client hydration.
  */
 export const formatDate = (date: Date): string => {
     return date.toLocaleDateString("en-US", {
         year: "numeric",
         month: "long",
         day: "numeric",
+        timeZone: "UTC",
     })
 }
 

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -1229,10 +1229,13 @@ export const getIndexableKeys = Object.keys as <T extends object>(
     obj: T
 ) => Array<keyof T>
 
-/** Formats a date like this: "October 6, 2024".
+/**
+ * Formats a date like this: "October 6, 2024".
  *
  * We pin the formatter to UTC so publication dates render as the same calendar
- * day during SSR, baking, and client hydration.
+ * day during SSR, baking, and client hydration. Use this for absolute date
+ * displays. For publication labels that can render "Today" or "Yesterday",
+ * use formatRelativeDate().
  */
 export const formatDate = (date: Date): string => {
     return date.toLocaleDateString("en-US", {
@@ -1241,6 +1244,42 @@ export const formatDate = (date: Date): string => {
         day: "numeric",
         timeZone: "UTC",
     })
+}
+
+/**
+ * Returns a UTC-based publication label. This can be a relative label
+ * ("Today", "Yesterday") or a UTC-formatted absolute date for older content.
+ */
+export const formatRelativeDate = ({
+    publishedAt,
+    now = new Date(),
+    formatOptions = {
+        month: "long",
+        day: "numeric",
+    },
+}: {
+    publishedAt: Date | null
+    now?: Date
+    formatOptions?: Intl.DateTimeFormatOptions
+}): string => {
+    if (!publishedAt) return "Unpublished"
+
+    const publishedDate = dayjs.utc(publishedAt.getTime())
+    const currentDate = dayjs.utc(now.getTime())
+
+    if (publishedDate.isSame(currentDate, "day")) return "Today"
+    if (publishedDate.isSame(currentDate.subtract(1, "day"), "day"))
+        return "Yesterday"
+
+    const options =
+        publishedDate.year() !== currentDate.year()
+            ? { ...formatOptions, year: "numeric" as const }
+            : formatOptions
+
+    return new Intl.DateTimeFormat("en-US", {
+        ...options,
+        timeZone: "UTC",
+    }).format(publishedAt)
 }
 
 /**

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -90,6 +90,7 @@ export {
     extractGdocPageData,
     deserializeOwidGdocPageData,
     formatDate,
+    formatRelativeDate,
     canWriteToClipboard,
     isNegativeInfinity,
     isPositiveInfinity,

--- a/site/gdocs/components/DataInsightDateline.tsx
+++ b/site/gdocs/components/DataInsightDateline.tsx
@@ -1,8 +1,7 @@
 import cx from "classnames"
 import { faCalendarDay } from "@fortawesome/free-solid-svg-icons"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
-
-import { dayjs } from "@ourworldindata/utils"
+import { formatRelativeDate } from "@ourworldindata/utils"
 
 export default function DataInsightDateline({
     className,
@@ -18,30 +17,16 @@ export default function DataInsightDateline({
     formatOptions?: Intl.DateTimeFormatOptions
     highlightToday?: boolean
 }) {
-    const date = dayjs.utc(publishedAt)
-    let highlightClassName
-    let formattedDate
-    if (publishedAt) {
-        if (date.isSame(dayjs.utc(), "day")) {
-            formattedDate = "Today"
-            if (highlightToday) {
-                highlightClassName = "data-insight-dateline--is-today"
-            }
-        } else if (date.isSame(dayjs.utc().subtract(1, "day"), "day")) {
-            formattedDate = "Yesterday"
-        } else {
-            const options =
-                date.year() !== dayjs.utc().year()
-                    ? { ...formatOptions, year: "numeric" as const }
-                    : formatOptions
-            formattedDate = date.toDate().toLocaleDateString("en-US", {
-                ...options,
-                timeZone: "UTC",
-            })
-        }
-    } else {
-        formattedDate = "Unpublished"
-    }
+    const formattedDate = formatRelativeDate({
+        publishedAt,
+        now: new Date(),
+        formatOptions,
+    })
+    const highlightClassName =
+        highlightToday && publishedAt && formattedDate === "Today"
+            ? "data-insight-dateline--is-today"
+            : undefined
+
     return (
         <p
             className={cx(

--- a/site/gdocs/components/DataInsightDateline.tsx
+++ b/site/gdocs/components/DataInsightDateline.tsx
@@ -18,23 +18,26 @@ export default function DataInsightDateline({
     formatOptions?: Intl.DateTimeFormatOptions
     highlightToday?: boolean
 }) {
-    const date = dayjs(publishedAt)
+    const date = dayjs.utc(publishedAt)
     let highlightClassName
     let formattedDate
     if (publishedAt) {
-        if (date.isToday()) {
+        if (date.isSame(dayjs.utc(), "day")) {
             formattedDate = "Today"
             if (highlightToday) {
                 highlightClassName = "data-insight-dateline--is-today"
             }
-        } else if (date.isYesterday()) {
+        } else if (date.isSame(dayjs.utc().subtract(1, "day"), "day")) {
             formattedDate = "Yesterday"
         } else {
             const options =
-                date.year() !== dayjs().year()
+                date.year() !== dayjs.utc().year()
                     ? { ...formatOptions, year: "numeric" as const }
                     : formatOptions
-            formattedDate = date.toDate().toLocaleDateString("en-US", options)
+            formattedDate = date.toDate().toLocaleDateString("en-US", {
+                ...options,
+                timeZone: "UTC",
+            })
         }
     } else {
         formattedDate = "Unpublished"


### PR DESCRIPTION
### Problem

`publishedAt` is authored and stored as a UTC timestamp, but clients were formatting it with the runtime's local timezone via `toLocaleDateString()`.

The baked HTML could render one calendar day on the server and a different day in the browser during hydration, causing a hydration error.

e.g.
1. A post gets published on 17 March 2026 06:00 UTC
2. The page is baked on our server whose system timezone is UTC, so the HTML says 17 March, 2026
3. A user in Baker Island (UTC-12) looks at the post; the dateline gets converted to their local timezone and formatted as 16 March 2026 18:00 UTC-12
4. This discrepancy throws a React error, and tooltips break.

### Fix

`formatDate()` now always formats in UTC. This means that for the user in Baker Island, posts can appear as if they're published "tomorrow" so I want to check with Ed that this is okay.

#### Addendum
I also lifted the data insights date formatting logic into a helper util so that we can write tests for it.