### PR TITLE
fix(iframe): display left & right borders in iframe

### DIFF
--- a/site/gdocs/components/Chart.scss
+++ b/site/gdocs/components/Chart.scss
@@ -11,7 +11,7 @@ div.margin-0 figure {
 }
 
 @include sm-only {
-    .full-width-on-mobile {
+    html:not(.IsInIframe) .full-width-on-mobile {
         width: auto;
         margin-left: calc(-1 * var(--grid-gap) / 2);
         margin-right: calc(-1 * var(--grid-gap) / 2);


### PR DESCRIPTION
Fixes an issue where the left/right border wasn't properly shown inside iframes of charts that are a data page.

<img width="1085" height="696" alt="CleanShot 2026-03-18 at 11 22 51" src="https://github.com/user-attachments/assets/cb2c2d95-d119-4dc2-bfe5-9d735198bf67" />
