### PR TITLE
✨ suppress hydration warning on dateline

### DIFF
--- a/site/gdocs/components/DataInsightDateline.tsx
+++ b/site/gdocs/components/DataInsightDateline.tsx
@@ -46,6 +46,7 @@ export default function DataInsightDateline({
                 className,
                 highlightClassName
             )}
+            suppressHydrationWarning={true}
         >
             <FontAwesomeIcon
                 className="data-insight-dateline__icon"

--- a/site/gdocs/components/OwidGdocHeader.tsx
+++ b/site/gdocs/components/OwidGdocHeader.tsx
@@ -121,7 +121,7 @@ function OwidArticleHeader({
                                 <Byline names={content.authors} />
                             </div>
                         )}
-                        <div>
+                        <div suppressHydrationWarning={true}>
                             {content.dateline ||
                                 (publishedAt && formatDate(publishedAt))}
                         </div>


### PR DESCRIPTION
Fixes footnotes breaking on articles published near midnight.

See also https://github.com/owid/owid-grapher/pull/6249 as an alternative solution to this.
