### PR TITLE
Use few-bin equal-size map binning instead of auto log bins

### DIFF
--- a/packages/@ourworldindata/grapher/src/color/BinningStrategies.test.ts
+++ b/packages/@ourworldindata/grapher/src/color/BinningStrategies.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest"
 import {
     mirrorBinsAroundMidpoint,
     pruneUnusedBins,
+    runBinningStrategy,
 } from "./BinningStrategies.js"
 
 describe(mirrorBinsAroundMidpoint, () => {
@@ -36,5 +37,27 @@ describe(pruneUnusedBins, () => {
         const bins = [0, 1, 2, 3, 4, 5]
         const prunedBins = pruneUnusedBins(bins, { minValue: 1, maxValue: 4.2 })
         expect(prunedBins).toEqual([1, 2, 3, 4, 5])
+    })
+})
+
+describe(runBinningStrategy, () => {
+    it("uses few-bins instead of log for wide positive ranges in auto mode", () => {
+        const sortedValues = [1, 2, 5, 10, 20, 50, 100, 300, 1000]
+
+        expect(
+            runBinningStrategy({
+                strategy: "auto",
+                sortedValues,
+                midpointMode: "none",
+                midpoint: 0,
+            }).bins
+        ).toEqual(
+            runBinningStrategy({
+                strategy: "equalSizeBins-few-bins",
+                sortedValues,
+                midpointMode: "none",
+                midpoint: 0,
+            }).bins
+        )
     })
 })

--- a/packages/@ourworldindata/grapher/src/color/BinningStrategies.ts
+++ b/packages/@ourworldindata/grapher/src/color/BinningStrategies.ts
@@ -470,7 +470,7 @@ const autoChooseBinningStrategy = (
         return "equalSizeBins-normal"
     }
 
-    return "log-auto"
+    return "equalSizeBins-few-bins"
 }
 
 export const mirrorBinsAroundMidpoint = (

--- a/packages/@ourworldindata/grapher/src/color/readme.md
+++ b/packages/@ourworldindata/grapher/src/color/readme.md
@@ -4,22 +4,25 @@ Grapher supports several automatic binning strategies, and can also automaticall
 One key input into choosing a suiting strategy is the (log10) magnitude difference, i.e. $\log_{10}(maxValue) - \log_{10}(minValue)$.
 For example, the magnitude difference between 4 and 400 is 2, because $4 \cdot 10^{\mathbf 2} = 400$.
 
-In general, if we have a high magnitude difference, we want to use a logarithmic binning strategy, and if we have a low one we want to use an equal-sized binning strategy.
+In general, if we have a low magnitude difference, we want to use an equal-sized binning strategy. For high magnitude differences, `auto` currently falls back to `equalSizeBins-few-bins` rather than choosing a logarithmic strategy directly.
 We only compute the magnitude difference based on positive values, and don't take the lowest and highest values directly, but rather some low and high quantiles.
 
 ```mermaid
 flowchart TD
-    A -->|small magnitude diff| E
-    S --> E[equalSizeBins]
+    A -->|small magnitude diff| E1
+    A -->|large magnitude diff| E2
     S(Binning Strategy) --> A[auto]
+    S --> E[equalSizeBins]
     S --> L[logarithmic]
-    A -->|large magnitude diff| L
 
-    E --> E1(Compute min, max value based on quantiles)
-    E1 --> E2(Find fitting, nice step size that produces a decent number of bins)
-    E2 -->|e.g. 10| E3(Compute bins; e.g. 0, 10, 20, 30, 40)
+    E1 --> E3(Use equalSizeBins-normal or percent)
+    E2 --> E4(Use equalSizeBins-few-bins)
+    E3 --> E5(Compute min, max value based on quantiles)
+    E4 --> E5
+    E5 --> E6(Find fitting, nice step size that produces a decent number of bins)
+    E6 --> E7(Compute bins; e.g. 0, 10, 20, 30, 40)
 
-    L --> L1(Compute min, max value based on quantiles)
+    L --> L1(Explicit log strategy)
     L1 --> L2(Decide specific strategy based on magnitude difference)
     L2 -->|log-1-2-5| L3(Compute bins; e.g. 0, 10, 20, 50, 100)
     L2 -->|log-1-3| L3


### PR DESCRIPTION
## Context

This changes the automatic map/color binning fallback for wide positive ranges.

Previously, `binningStrategy: "auto"` would switch to `log-auto` when the data span was large enough. This PR changes that fallback so auto now chooses `equalSizeBins-few-bins` instead.

It also updates the color binning docs and adds a regression test for the new behavior.

## Screenshots / Videos / Diagrams

Not needed — no UI layout changes.

## Testing guidance

1. Open a chart or map that uses automatic color binning and has a wide positive value range.
2. Confirm the legend now uses a small number of equal-size bins instead of log-spaced bins.
3. Verify percentage-like series still use the existing percent binning path.
4. Run:
   - `node_modules/.bin/vitest run --reporter dot packages/@ourworldindata/grapher/src/color/BinningStrategies.test.ts packages/@ourworldindata/grapher/src/color/BinningStrategyEqualSizeBins.test.ts packages/@ourworldindata/grapher/src/color/BinningStrategyLogarithmic.test.ts`

- [ ] Does the change work in the archive?
- [ ] Does the staging experience have sign-off from product stakeholders?

**Reminder to annotate the PR diff with design notes, alternatives you considered, and any other helpful context.**

## Checklist

None.
