### PR TITLE
Harmonize homepage copy to sentence case

### DIFF
--- a/site/SiteConstants.ts
+++ b/site/SiteConstants.ts
@@ -107,7 +107,7 @@ export enum Menu {
 }
 
 export const ABOUT_LINKS = [
-    { title: "About Us", url: "/about" },
+    { title: "About us", url: "/about" },
     { title: "Organization", url: "/organization" },
     { title: "Funding", url: "/funding" },
     { title: "Team", url: "/team" },

--- a/site/gdocs/components/HomepageIntro.tsx
+++ b/site/gdocs/components/HomepageIntro.tsx
@@ -211,7 +211,7 @@ function HomepageAnnouncements() {
         <div className="homepage-intro__announcements span-cols-1 span-md-cols-2">
             <div className="homepage-intro__announcements-header">
                 <AnnouncementsIcon />
-                <h4 className="h3-bold">Updates and Announcements</h4>
+                <h4 className="h3-bold">Updates and announcements</h4>
             </div>
             <ul className="homepage-intro__announcements-list">
                 {announcements.map((announcement, i) => (

--- a/site/gdocs/components/HomepageSearch.tsx
+++ b/site/gdocs/components/HomepageSearch.tsx
@@ -27,7 +27,7 @@ export function HomepageSearch(props: { className?: string }) {
                             href={SEARCH_BASE_PATH}
                         >
                             <FontAwesomeIcon icon={faChartLine} />
-                            {commafyNumber(chartCount)} Charts
+                            {commafyNumber(chartCount)} charts
                         </a>
                     </li>
                     <li>
@@ -36,7 +36,7 @@ export function HomepageSearch(props: { className?: string }) {
                             href="#all-topics"
                         >
                             <FontAwesomeIcon icon={faBookmark} />
-                            {commafyNumber(topicCount)} Topic Pages
+                            {commafyNumber(topicCount)} topic pages
                         </a>
                     </li>
                     <li>
@@ -45,13 +45,13 @@ export function HomepageSearch(props: { className?: string }) {
                             href="/explorers"
                         >
                             <FontAwesomeIcon icon={faMagnifyingGlassChart} />
-                            {commafyNumber(explorerCount)} Data Explorers
+                            {commafyNumber(explorerCount)} data explorers
                         </a>
                     </li>
                 </ul>
                 <div className="homepage-search__links--mobile">
                     <a href="/data" className="body-3-medium">
-                        {commafyNumber(chartCount)} Charts
+                        {commafyNumber(chartCount)} charts
                     </a>{" "}
                     across {commafyNumber(topicCount)} topics
                 </div>


### PR DESCRIPTION
## Summary
- Lowercased "Charts", "Topic Pages", "Data Explorers" in the search stats below the search bar
- Changed "Updates and Announcements" → "Updates and announcements"
- Changed "About Us" → "About us" in the footer

## Test plan
- [x] Verify homepage search stats render correctly
- [x] Verify announcements section heading
- [x] Verify footer "About us" link

🤖 Generated with [Claude Code](https://claude.com/claude-code)