### PR TITLE
🐛 only adjust time when scatter is a secondary tab

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
@@ -1922,7 +1922,8 @@ export class GrapherState
         tabName: GrapherTabName
     ): boolean => {
         // Scatter plots can show a time range, but a single time is preferred
-        return [GRAPHER_TAB_NAMES.ScatterPlot].includes(tabName as any)
+        // when the scatter is not the main chart, but a secondary tab
+        return !this.isScatter && tabName === GRAPHER_TAB_NAMES.ScatterPlot
     }
 
     @action.bound ensureTimeHandlesAreSensibleForTab(
@@ -1943,6 +1944,9 @@ export class GrapherState
     ): void {
         // No-op if the current tab is a map or table tab
         if (!isChartTab(tab)) return
+
+        // No-op if there is only a single chart tab
+        if (this.validChartTypes.length < 2) return
 
         const isChartTypeThatShowsAllEntities =
             this.isChartTypeThatShowsAllEntities(tab)


### PR DESCRIPTION
Resolves #6280

Fixes a bug that surfaced in search by accidentally setting a single time point for time-range scatters. This happened because the time was adjusted too eagerly whenever the tab changes. Setting a sensible time for scatters on tab change should only happen when the scatter is a secondary tab, not the main chart.

Example: http://staging-site-fix-scatter-sensible-time/grapher/solar-pv-prices-vs-cumulative-capacity