### PR TITLE
🐛 (thumbnail) skip zero line for log axis

### DIFF
--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChartThumbnail.tsx
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChartThumbnail.tsx
@@ -393,10 +393,12 @@ export class LineChartThumbnail
 
         return (
             <>
-                <VerticalAxisZeroLine
-                    verticalAxis={this.dualAxis.verticalAxis}
-                    bounds={this.dualAxis.innerBounds}
-                />
+                {!this.dualAxis.verticalAxis.isLogScale && (
+                    <VerticalAxisZeroLine
+                        verticalAxis={this.dualAxis.verticalAxis}
+                        bounds={this.dualAxis.innerBounds}
+                    />
+                )}
                 <HorizontalAxisComponent
                     axis={this.dualAxis.horizontalAxis}
                     bounds={this.dualAxis.bounds}


### PR DESCRIPTION
Don't render a zero line for log axes in thumbnails.

Example: http://staging-site-skip-zero-line-on-log-axis/search?q=solar+price