### PR TITLE
🐛 fix image usage for images with multiple versions

### DIFF
--- a/adminSiteServer/apiRoutes/images.ts
+++ b/adminSiteServer/apiRoutes/images.ts
@@ -1,4 +1,8 @@
-import { DbEnrichedImage, JsonError } from "@ourworldindata/types"
+import {
+    DbEnrichedImage,
+    JsonError,
+    PostsGdocsXImagesTableName,
+} from "@ourworldindata/types"
 import pMap from "p-map"
 import {
     validateImagePayload,
@@ -192,6 +196,10 @@ export async function putImageHandler(
     await trx<DbEnrichedImage>("images").where("id", "=", id).update({
         replacedBy: newImageId,
     })
+
+    await trx(PostsGdocsXImagesTableName)
+        .where("imageId", "=", id)
+        .update({ imageId: newImageId })
 
     const updated = await db.getCloudflareImage(trx, originalFilename)
 

--- a/db/migration/1774539886828-resyncPostsGdocsXImages.ts
+++ b/db/migration/1774539886828-resyncPostsGdocsXImages.ts
@@ -1,0 +1,42 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class ResyncPostsGdocsXImages1774539886828 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        // Some rows in posts_gdocs_x_images point to old image IDs whose
+        // replacedBy column is non-null. We need to follow the replacement
+        // chain to find the current (leaf) image and update the reference.
+        //
+        // The recursive CTE walks from every replaced image to the end of
+        // its chain (where replacedBy IS NULL), then we join back to update
+        // any stale rows in the join table.
+        await queryRunner.query(`-- sql
+            UPDATE posts_gdocs_x_images pxi
+            JOIN (
+                WITH RECURSIVE current_image AS (
+                    -- Seed: every image that has been replaced
+                    SELECT id AS originalId, replacedBy AS nextId
+                    FROM images
+                    WHERE replacedBy IS NOT NULL
+
+                    UNION ALL
+
+                    -- Walk the chain until we reach the current version
+                    SELECT ci.originalId, i.replacedBy AS nextId
+                    FROM current_image ci
+                    JOIN images i ON i.id = ci.nextId
+                    WHERE i.replacedBy IS NOT NULL
+                )
+                -- The final step: map each original to the leaf (current) image
+                SELECT ci.originalId, ci.nextId AS currentId
+                FROM current_image ci
+                JOIN images i ON i.id = ci.nextId
+                WHERE i.replacedBy IS NULL
+            ) AS mapping ON pxi.imageId = mapping.originalId
+            SET pxi.imageId = mapping.currentId
+        `)
+    }
+
+    public async down(_queryRunner: QueryRunner): Promise<void> {
+        // N/A
+    }
+}


### PR DESCRIPTION
Fixes an issue with `posts_gdocs_x_images` not updating when a new version of an image was uploaded.

e.g. 

1. gdoc `1` links to image `a` 
2. upload a new version of image `a` (image `b`)
3. `posts_gdocs_x_images` table still says that gdoc `1` references image `a`

This PR changes the put handler so that the table will get updated to say that gdoc `1` references image `b` now

Also adds a migration that resyncs the `posts_gdocs_x_images` table with a recursive CTE to catch such cases.