### PR TITLE
🔨 remove animation-only clipPaths

### DIFF
--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
@@ -48,11 +48,9 @@ import {
 } from "./LineChartConstants"
 import { CoreColumn } from "@ourworldindata/core-table"
 import {
-    ClipPath,
     getHoverStateForSeries,
     getSeriesKey,
     isTargetOutsideElement,
-    makeClipPath,
 } from "../chart/ChartUtils"
 import { CategoricalBin, ColorScaleBin } from "../color/ColorScaleBin"
 import { ColorScale } from "../color/ColorScale"
@@ -398,20 +396,6 @@ export class LineChart
         ]
     }
 
-    @computed private get clipPathBounds(): Bounds {
-        const { dualAxis, boundsWithoutColorLegend } = this
-        return boundsWithoutColorLegend
-            .set({ x: dualAxis.innerBounds.x })
-            .expand(10)
-    }
-
-    @computed private get clipPath(): ClipPath {
-        return makeClipPath({
-            renderUid: this.renderUid,
-            box: this.clipPathBounds,
-        })
-    }
-
     @computed private get verticalLabelsState(): VerticalLabelsState {
         return new VerticalLabelsState(this.verticalLabelsSeries, {
             yAxis: () => this.yAxis,
@@ -500,9 +484,6 @@ export class LineChart
                 onTouchStart={this.onCursorMove}
                 onTouchMove={this.onCursorMove}
             >
-                {/* The tiny bit of extra space in the clippath is to ensure circles
-                    centered on the very edge are still fully visible */}
-                {this.clipPath.element}
                 <rect {...this.bounds.toProps()} fillOpacity="0">
                     {/* This <rect> ensures that the parent <g> is big enough such that
                         we get mouse hover events for the whole charting area, including
@@ -512,7 +493,7 @@ export class LineChart
                 </rect>
                 {this.renderColorLegend()}
                 {this.renderDualAxis()}
-                <g clipPath={this.clipPath.id}>{this.renderChartElements()}</g>
+                {this.renderChartElements()}
 
                 {(this.isTooltipActive || this.hasTimeHighlights) &&
                     this.activeXVerticalLines}

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
@@ -38,7 +38,6 @@ import {
     StackedSeries,
 } from "./StackedConstants"
 import {
-    makeClipPath,
     isTargetOutsideElement,
     getHoverStateForSeries,
 } from "../chart/ChartUtils"
@@ -595,17 +594,6 @@ export class StackedAreaChart
     }
 
     renderInteractive(): React.ReactElement {
-        const { bounds, dualAxis, renderUid } = this
-
-        const clipPath = makeClipPath({
-            renderUid,
-            box: {
-                ...bounds,
-                height: bounds.height * 2,
-                x: dualAxis.innerBounds.x,
-            },
-        })
-
         return (
             <g
                 ref={this.base}
@@ -617,21 +605,18 @@ export class StackedAreaChart
                 onTouchStart={this.onCursorMove}
                 onTouchMove={this.onCursorMove}
             >
-                {clipPath.element}
                 <rect {...this.bounds.toProps()} fillOpacity="0">
                     {/* This <rect> ensures that the parent <g> is big enough such that we get mouse hover events for the
                     whole charting area, including the axis, the entity labels, and the whitespace next to them.
                     We need these to be able to show the tooltip for the first/last year even if the mouse is outside the charting area. */}
                 </rect>
                 {this.renderAxis()}
-                <g clipPath={clipPath.id}>
-                    {this.renderVerticalLabels()}
-                    <StackedAreas
-                        series={this.renderSeries}
-                        onMouseEnter={this.onAreaMouseEnter}
-                        onMouseLeave={this.onAreaMouseLeave}
-                    />
-                </g>
+                {this.renderVerticalLabels()}
+                <StackedAreas
+                    series={this.renderSeries}
+                    onMouseEnter={this.onAreaMouseEnter}
+                    onMouseLeave={this.onAreaMouseLeave}
+                />
                 {this.isTooltipActive && this.activeXVerticalLine}
                 {this.tooltip}
             </g>

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChart.tsx
@@ -40,7 +40,7 @@ import {
 } from "./StackedConstants"
 import { DualAxis, HorizontalAxis, VerticalAxis } from "../axis/Axis"
 import { Color, HorizontalAlign, SeriesName } from "@ourworldindata/types"
-import { makeClipPath, getHoverStateForSeries } from "../chart/ChartUtils"
+import { getHoverStateForSeries } from "../chart/ChartUtils"
 import { InteractionState } from "../interaction/InteractionState"
 import { resolveEmphasis, Emphasis } from "../interaction/Emphasis"
 import {
@@ -519,13 +519,7 @@ export class StackedBarChart
     }
 
     renderInteractive(): React.ReactElement {
-        const { dualAxis, renderUid, bounds } = this
-        const { innerBounds } = dualAxis
-
-        const clipPath = makeClipPath({
-            renderUid: renderUid,
-            box: innerBounds,
-        })
+        const { bounds } = this
 
         return (
             <g
@@ -533,7 +527,6 @@ export class StackedBarChart
                 height={bounds.height}
                 onMouseMove={this.onMouseMove}
             >
-                {clipPath.element}
                 <rect
                     x={bounds.left}
                     y={bounds.top}
@@ -543,7 +536,7 @@ export class StackedBarChart
                     fill="rgba(255,255,255,0)"
                 />
                 {this.renderAxis()}
-                <g clipPath={clipPath.id}>{this.renderBars()}</g>
+                {this.renderBars()}
                 {this.renderLegend()}
                 {this.tooltip}
             </g>


### PR DESCRIPTION
## Summary
- Follow-up to #6290
- Removes clipPaths from LineChart, StackedAreaChart, and StackedBarChart that only existed to support the wipe-in intro animation (rect width from 0 → full)
- Their static renderings already worked without clipping, confirming these clipPaths served no other purpose
- Functional clipPaths in ScatterPlotChart, MapChart, and CustomComparisonLine are left intact

## Test plan
- [x] Verify line charts render correctly without visual clipping issues
- [x] Verify stacked area charts render correctly
- [x] Verify stacked bar charts render correctly
- [x] Check edge cases: charts with data near axis boundaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)