### PR TITLE
🎉 add hideFullscreenButton

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -90,6 +90,7 @@ export interface GrapherProgrammaticInterface extends GrapherInterface {
     hideSubtitle?: boolean
     hideNote?: boolean
     hideOriginUrl?: boolean
+    hideFullscreenButton?: boolean
 
     hideEntityControls?: boolean
     forceHideAnnotationFieldsInTitle?: AnnotationFieldsInTitle

--- a/packages/@ourworldindata/grapher/src/core/GrapherState.test.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.test.ts
@@ -104,6 +104,13 @@ describe("toObject", () => {
     })
 })
 
+describe("hideFullScreenButton", () => {
+    it("respects the explicit hideFullscreenButton config", () => {
+        const grapher = new GrapherState({ hideFullscreenButton: true })
+        expect(grapher.hideFullScreenButton).toBe(true)
+    })
+})
+
 const unit = "% of children under 5"
 const name = "Some display name"
 const data = {

--- a/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
@@ -575,6 +575,7 @@ export class GrapherState
     hideSubtitle = false
     hideNote = false
     hideOriginUrl = false
+    hideFullscreenButton = false
     hideEntityControls = false
     hideShareButton = false
     hideExploreTheDataButton = true
@@ -731,6 +732,7 @@ export class GrapherState
             hideSubtitle: observable,
             hideNote: observable,
             hideOriginUrl: observable,
+            hideFullscreenButton: observable,
             hideEntityControls: observable,
             enableMapSelection: observable,
             forceHideAnnotationFieldsInTitle: observable,
@@ -3097,6 +3099,7 @@ export class GrapherState
     }
 
     @computed get hideFullScreenButton(): boolean {
+        if (this.hideFullscreenButton) return true
         if (this.isInFullScreenMode) return false
         if (!this.isSmall || !this.isMobile || !this.screenHeight) return false
 


### PR DESCRIPTION
An additional small directive for hiding another Grapher UI element (will be used in slideshows)

Easiest way to test is by replacing line 80 on `GrapherWithFallback.tsx` with `config={{ ...config, hideFullscreenButton: true }}`