### PR TITLE
Fix .pi skills path and create branch-matched staging test

### DIFF
--- a/.pi/settings.json
+++ b/.pi/settings.json
@@ -1,3 +1,3 @@
 {
-    "skills": [".claude/skills"]
+    "skills": ["../.claude/skills"]
 }


### PR DESCRIPTION
## Summary
- update `.pi/settings.json` to use `../.claude/skills` instead of `.claude/skills`

## Why
This uses the existing local change and sets up a test branch in `owid-grapher` that matches the `ops` test branch name.

Paired ops PR: https://github.com/owid/ops/pull/446
