### PR TITLE
Add 'Copy for social' button to Data Insight pages

### DIFF
--- a/site/gdocs/components/CopySocialButton.tsx
+++ b/site/gdocs/components/CopySocialButton.tsx
@@ -3,7 +3,7 @@ import { copyToClipboard } from "@ourworldindata/utils"
 import { CookieKey } from "@ourworldindata/grapher"
 import { useIsClient } from "usehooks-ts"
 
-export function CopySocialButton() {
+export function CopySocialButton({ text }: { text: string }) {
     const isClient = useIsClient()
     const [label, setLabel] = useState("Copy for social")
 
@@ -15,52 +15,7 @@ export function CopySocialButton() {
     }
 
     function handleClick() {
-        let title =
-            document.querySelector<HTMLElement>(
-                ".data-insight-body .display-3-semibold"
-            )?.innerText ?? ""
-        if (!title.includes("—")) {
-            title += "—"
-        }
-
-        const bodyEl = document.querySelector<HTMLElement>(
-            ".data-insight-blocks"
-        )
-
-        const ctaLinkEl =
-            bodyEl?.querySelector<HTMLAnchorElement>(".cta a") ?? null
-        const paragraphs = bodyEl?.querySelectorAll("p") ?? []
-        const body = Array.from(paragraphs)
-            .map((p) => p.innerText)
-            .join("\n\n")
-
-        const authorEls = document.querySelectorAll<HTMLElement>(
-            ".data-insight-author"
-        )
-        const authors = Array.from(authorEls).map((el) => el.innerText.trim())
-
-        const parts = [title, body]
-
-        if (authors.length === 1) {
-            parts.push(`(This Data Insight was written by ${authors[0]}.)`)
-        } else if (authors.length === 2) {
-            parts.push(
-                `(This Data Insight was written by ${authors[0]} and ${authors[1]}.)`
-            )
-        } else if (authors.length > 2) {
-            const last = authors.pop()
-            parts.push(
-                `(This Data Insight was written by ${authors.join(", ")}, and ${last}.)`
-            )
-        }
-
-        if (ctaLinkEl) {
-            const ctaText = ctaLinkEl.innerText.trim().replace(/[.:]+$/, "")
-            const ctaUrl = ctaLinkEl.href
-            parts.push(`${ctaText}: ${ctaUrl}`)
-        }
-
-        void copyToClipboard(parts.join("\n\n"))
+        void copyToClipboard(text)
         setLabel("Copied!")
         setTimeout(() => setLabel("Copy for social"), 1000)
     }

--- a/site/gdocs/pages/DataInsight.tsx
+++ b/site/gdocs/pages/DataInsight.tsx
@@ -2,9 +2,15 @@ import cx from "classnames"
 import {
     LatestDataInsight,
     OwidGdocDataInsightInterface,
+    OwidEnrichedGdocBlock,
+    OwidGdocMinimalPostInterface,
     copyToClipboard,
+    formatInlineList,
     MinimalTag,
+    Span,
 } from "@ourworldindata/utils"
+import { getLinkType, getUrlTarget } from "@ourworldindata/components"
+import { ContentGraphLinkType } from "@ourworldindata/types"
 import { useContext, useState } from "react"
 import * as React from "react"
 import {
@@ -20,6 +26,7 @@ import DataInsightDateline from "../components/DataInsightDateline.js"
 import LatestDataInsights from "../components/LatestDataInsights.js"
 import { AttachmentsContext } from "../AttachmentsContext.js"
 import { BAKED_BASE_URL } from "../../../settings/clientSettings.js"
+import { getLinkedDocumentUrl } from "../utils.js"
 import { CopySocialButton } from "../components/CopySocialButton.js"
 
 export const LatestDataInsightCards = (props: {
@@ -96,6 +103,66 @@ function CopyLinkButton(props: { slug: string }) {
     )
 }
 
+function spansToPlainText(spans: Span[]): string {
+    return spans
+        .map((span): string => {
+            if (span.spanType === "span-simple-text") return span.text
+            if (span.spanType === "span-newline") return "\n"
+            return spansToPlainText(span.children)
+        })
+        .join("")
+}
+
+function resolveCtaUrl(
+    rawUrl: string,
+    linkedDocuments: Record<string, OwidGdocMinimalPostInterface>
+): string {
+    if (getLinkType(rawUrl) !== ContentGraphLinkType.Gdoc) return rawUrl
+    const target = getUrlTarget(rawUrl)
+    const doc = linkedDocuments[target]
+    if (!doc) return rawUrl
+    return getLinkedDocumentUrl(doc, rawUrl)
+}
+
+function buildSocialText(
+    title: string,
+    body: OwidEnrichedGdocBlock[],
+    authors: string[],
+    linkedDocuments: Record<string, OwidGdocMinimalPostInterface>
+): string {
+    let titleText = title
+    if (!titleText.includes("—")) {
+        titleText += "—"
+    }
+
+    const paragraphs: string[] = []
+    let ctaText: string | undefined
+    let ctaUrl: string | undefined
+
+    for (const block of body) {
+        if (block.type === "text") {
+            paragraphs.push(spansToPlainText(block.value))
+        } else if (block.type === "cta") {
+            ctaText = block.text.replace(/[.:]+$/, "")
+            ctaUrl = resolveCtaUrl(block.url, linkedDocuments)
+        }
+    }
+
+    const parts = [titleText, paragraphs.join("\n\n")]
+
+    if (authors.length > 0) {
+        parts.push(
+            `(This Data Insight was written by ${formatInlineList(authors, "and")}.)`
+        )
+    }
+
+    if (ctaText && ctaUrl) {
+        parts.push(`${ctaText}: ${ctaUrl}`)
+    }
+
+    return parts.join("\n\n")
+}
+
 export const DataInsightBody = (
     props: DataInsightProps & {
         anchor?: string
@@ -106,6 +173,7 @@ export const DataInsightBody = (
         shouldHideYearInDateline?: boolean
     }
 ) => {
+    const { linkedDocuments } = useContext(AttachmentsContext)
     const shouldLinkTitle = props.shouldLinkTitle
     const publishedAt = props.publishedAt ? new Date(props.publishedAt) : null
     return (
@@ -162,7 +230,14 @@ export const DataInsightBody = (
                 <div className="data-insight-footer">
                     <RelatedTopicsList tags={props.tags ?? undefined} />
                     <CopyLinkButton slug={props.slug} />
-                    <CopySocialButton />
+                    <CopySocialButton
+                        text={buildSocialText(
+                            props.content.title,
+                            props.content.body,
+                            props.content.authors,
+                            linkedDocuments
+                        )}
+                    />
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary

- Adds an admin-only "Copy for social" button in the Data Insight footer (next to "Copy link")
- On click, copies a plain-text version of the DI to clipboard: title, body (HTML stripped), author attribution, and CTA with inlined URL
- Saves Charlie a few minutes of manual reformatting every time we publish a DI

## Test plan

- [x] Log in as admin, open any Data Insight page
- [x] Verify "Copy for social" button appears in the footer
- [x] Click it, paste into a text editor, check formatting matches what we post on social
- [x] Verify it handles multi-author DIs correctly
- [x] Log out, verify button is not visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)