### PR TITLE
Fix author roles not showing for authors without a published page

### DIFF
--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -614,13 +614,22 @@ export class SiteBaker {
                     this._prefetchedAttachmentsCache.linkedIndicators,
                     linkedIndicatorIds
                 ),
-                linkedAuthors: this._prefetchedAttachmentsCache.linkedAuthors
-                    .filter((author) => authorNames.includes(author.name))
-                    .map((author) => {
-                        const role = authorRoles?.[author.name]
-                        if (role) return { ...author, role }
-                        return author
-                    }),
+                linkedAuthors: authorNames.map((name) => {
+                    const cached =
+                        this._prefetchedAttachmentsCache!.linkedAuthors.find(
+                            (a) => a.name === name
+                        )
+                    const role = authorRoles?.[name]
+                    if (cached) {
+                        return role ? { ...cached, role } : cached
+                    }
+                    return {
+                        name,
+                        slug: null,
+                        featuredImage: null,
+                        ...(role ? { role } : {}),
+                    }
+                }),
                 linkedNarrativeCharts: _.pick(
                     this._prefetchedAttachmentsCache.linkedNarrativeCharts,
                     linkedNarrativeChartNames

--- a/db/model/Gdoc/GdocBase.ts
+++ b/db/model/Gdoc/GdocBase.ts
@@ -397,9 +397,7 @@ export class GdocBase implements OwidGdocBaseInterface {
         const authorRoles = this.content.authorRoles
         // Build the full list of linked authors, including those without
         // a published author page (they still need their role applied).
-        const dbAuthorsByName = new Map(
-            dbAuthors.map((a) => [a.name, a])
-        )
+        const dbAuthorsByName = new Map(dbAuthors.map((a) => [a.name, a]))
         const authors: LinkedAuthor[] = this.content.authors.map((name) => {
             const dbAuthor = dbAuthorsByName.get(name)
             const role = authorRoles?.[name]

--- a/db/model/Gdoc/GdocBase.ts
+++ b/db/model/Gdoc/GdocBase.ts
@@ -390,17 +390,30 @@ export class GdocBase implements OwidGdocBaseInterface {
     }
 
     async loadLinkedAuthors(knex: db.KnexReadonlyTransaction): Promise<void> {
-        const authors = await getMinimalAuthorsByNames(
+        const dbAuthors = await getMinimalAuthorsByNames(
             knex,
             this.content.authors
         )
         const authorRoles = this.content.authorRoles
-        if (authorRoles) {
-            for (const author of authors) {
-                const role = authorRoles[author.name]
-                if (role) author.role = role
+        // Build the full list of linked authors, including those without
+        // a published author page (they still need their role applied).
+        const dbAuthorsByName = new Map(
+            dbAuthors.map((a) => [a.name, a])
+        )
+        const authors: LinkedAuthor[] = this.content.authors.map((name) => {
+            const dbAuthor = dbAuthorsByName.get(name)
+            const role = authorRoles?.[name]
+            if (dbAuthor) {
+                if (role) dbAuthor.role = role
+                return dbAuthor
             }
-        }
+            return {
+                name,
+                slug: null,
+                featuredImage: null,
+                ...(role ? { role } : {}),
+            }
+        })
         this.linkedAuthors = authors
     }
 

--- a/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
@@ -38,9 +38,9 @@ export interface LatestDataInsight {
 
 export interface LinkedAuthor {
     name: string
-    slug: string
+    slug: string | null
     featuredImage: string | null
-    updatedAt: Date
+    updatedAt?: Date
     role?: string
 }
 


### PR DESCRIPTION
## Summary

Author roles (e.g. "writing", "visualization", "data") were silently dropped from the byline when the author didn't have a published author page in the database.

**Root cause:** `getMinimalAuthorsByNames` queries `posts_gdocs WHERE type = 'author'` — so authors without a published page (like Sophia Mersmann) are simply not returned. Both `loadLinkedAuthors` (used by admin preview and individual baking) and the SiteBaker prefetch path then had no `LinkedAuthor` entry for these authors, meaning their role was never applied. The frontend fallback in `useLinkedAuthor` returns `{ name, slug: null, featuredImage: null }` with no `role` field.

**Example:** For `authors: Hannah Ritchie (writing), Sophia Mersmann (visualization), Fiona Spooner (data)`, the rendered byline showed:
> By Hannah Ritchie (writing), Sophia Mersmann, and Fiona Spooner (data)

...with Sophia's "(visualization)" role missing.

## Changes

- **`db/model/Gdoc/GdocBase.ts`** — `loadLinkedAuthors` now iterates over `this.content.authors` instead of only the DB results, creating fallback `LinkedAuthor` entries (with roles) for authors not found in the DB.
- **`baker/SiteBaker.tsx`** — Same fix for the prefetched attachments path used during full site baking.
- **`packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts`** — Made `LinkedAuthor.slug` nullable and `updatedAt` optional, since authors without published pages don't have these fields.

## Test plan

- [x] `npx vitest run site/gdocs/` — all 15 tests pass
- [x] `npx vitest run db/model/Gdoc/gdocUtils.test.ts` — all 6 tests pass
- [x] `npx tsc --noEmit` — no type errors
- [ ] Verify on a local preview that an article with a mix of authors (some with pages, some without) shows all roles correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)