### PR TITLE
Fix author roles not showing for authors without a published author page

### DIFF
--- a/site/gdocs/components/Byline.tsx
+++ b/site/gdocs/components/Byline.tsx
@@ -1,7 +1,13 @@
 import { Fragment } from "react"
 import LinkedAuthor from "./LinkedAuthor.js"
 
-export const Byline = ({ names }: { names: string[] }) => {
+export const Byline = ({
+    names,
+    authorRoles,
+}: {
+    names: string[]
+    authorRoles?: Record<string, string>
+}) => {
     return (
         <>
             {"By "}
@@ -10,7 +16,7 @@ export const Byline = ({ names }: { names: string[] }) => {
                 const isSecondToLast = index === names.length - 2
                 return (
                     <Fragment key={name}>
-                        <LinkedAuthor name={name} />
+                        <LinkedAuthor name={name} role={authorRoles?.[name]} />
                         {/* Use Oxford comma when there are more than two authors. */}
                         {!isLast && names.length > 2 && ", "}
                         {isSecondToLast && names.length > 1 && " and "}

--- a/site/gdocs/components/LinkedAuthor.tsx
+++ b/site/gdocs/components/LinkedAuthor.tsx
@@ -11,12 +11,15 @@ export default function LinkedAuthor({
     className,
     name,
     includeImage,
+    role,
 }: {
     className?: string
     name: string
     includeImage?: boolean
+    role?: string
 }) {
     const author = useLinkedAuthor(name)
+    const displayRole = role ?? author.role
     const image =
         includeImage && author.featuredImage ? (
             <Image
@@ -39,7 +42,7 @@ export default function LinkedAuthor({
                 {image}
                 {author.name}
             </a>
-            {author.role && ` (${author.role})`}
+            {displayRole && ` (${displayRole})`}
         </span>
     )
 }

--- a/site/gdocs/components/OwidGdocHeader.tsx
+++ b/site/gdocs/components/OwidGdocHeader.tsx
@@ -118,7 +118,10 @@ function OwidArticleHeader({
                     >
                         {content.authors.length > 0 && (
                             <div>
-                                <Byline names={content.authors} />
+                                <Byline
+                                    names={content.authors}
+                                    authorRoles={content.authorRoles}
+                                />
                             </div>
                         )}
                         <div suppressHydrationWarning={true}>


### PR DESCRIPTION
## Summary
- When an author has a role (e.g. "visualization") but no published author page in the database, the role was silently dropped from the article byline
- The existing code applies roles to `LinkedAuthor` objects fetched from the DB — but authors without a published page aren't in that result, so their roles are lost
- This passes `authorRoles` from the article content directly through the Byline → LinkedAuthor component chain, bypassing the database lookup

## Test plan
- [x] `yarn testFormatChanged` passes
- [x] `yarn typecheck` passes
- [x] All unit tests pass (1800/1800, 1 pre-existing timezone failure)
- [x] Verify on staging that an article with a mix of authors (some with pages, some without) shows all roles correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)