### PR TITLE
Update GDP per capita indicator to WDI 2026-02-27

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
@@ -100,7 +100,7 @@ export const isWorldEntityName = (entityName: EntityName): boolean =>
 
 export const CONTINENTS_INDICATOR_ID = 900801 // "Countries Continent"
 export const POPULATION_INDICATOR_ID_USED_IN_ADMIN = 953899 // "Population (various sources, 2024-07-15)"
-export const GDP_PER_CAPITA_INDICATOR_ID_USED_IN_ADMIN = 1144914 // "GDP per capita, PPP (constant 2021 international $)"
+export const GDP_PER_CAPITA_INDICATOR_ID_USED_IN_ADMIN = 1204826 // "GDP per capita, PPP (constant 2021 international $)"
 
 export const isContinentsVariableId = (id: string | number): boolean =>
     id.toString() === CONTINENTS_INDICATOR_ID.toString()


### PR DESCRIPTION
## Summary
- Update `GDP_PER_CAPITA_INDICATOR_ID_USED_IN_ADMIN` from `1144914` (WDI 2026-01-29) to `1204826` (WDI 2026-02-27)
- This is the default x-axis indicator auto-populated when creating scatter charts in the admin

@codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)