### PR TITLE
🐛 avoid hard-coding years when switching between views

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
@@ -1883,11 +1883,11 @@ export class GrapherState
     @action.bound private ensureHandlesAreOnDifferentTimes(): void {
         if (!this.areHandlesOnSameTime) return
 
-        const time = this.startTime // startTime = endTime
-        if (time === this.closestTimelineMinTime) {
-            this.timelineHandleTimeBounds = [time ?? -Infinity, Infinity]
+        const timeBound = this.endHandleTimeBound // same as startHandleTimeBound
+        if (this.startTime === this.closestTimelineMinTime) {
+            this.timelineHandleTimeBounds = [timeBound ?? -Infinity, Infinity]
         } else {
-            this.timelineHandleTimeBounds = [-Infinity, time ?? Infinity]
+            this.timelineHandleTimeBounds = [-Infinity, timeBound ?? Infinity]
         }
     }
 


### PR DESCRIPTION
Resolves #6306

<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #6338 👈 
- <kbd>&nbsp;2&nbsp;</kbd> #6327 
- <kbd>&nbsp;1&nbsp;</kbd> #6324 
<!-- GitButler Footer Boundary Bottom -->

