### PR TITLE
🐛 fix explorer prominent links and thumbnails

### DIFF
--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -394,7 +394,15 @@ export class SiteBaker {
                 .getAllPublishedExplorersBySlugCached(knex)
                 .then((results) =>
                     _.mapValues(results, (explorer) => {
-                        return makeExplorerLinkedChart(explorer, explorer.slug)
+                        return makeExplorerLinkedChart(
+                            {
+                                slug: explorer.slug,
+                                title: explorer.explorerTitle,
+                                subtitle: explorer.explorerSubtitle,
+                                thumbnail: explorer.thumbnail,
+                            },
+                            explorer.slug
+                        )
                     })
                 )
             console.log(

--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -399,7 +399,6 @@ export class SiteBaker {
                                 slug: explorer.slug,
                                 title: explorer.explorerTitle,
                                 subtitle: explorer.explorerSubtitle,
-                                thumbnail: explorer.thumbnail,
                             },
                             explorer.slug
                         )

--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -410,7 +410,6 @@ export class SiteBaker {
                                 slug: explorer.slug,
                                 title: explorer.explorerTitle,
                                 subtitle: explorer.explorerSubtitle,
-                                thumbnail: explorer.thumbnail,
                             },
                             explorer.slug
                         )

--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -405,7 +405,15 @@ export class SiteBaker {
                 .getAllPublishedExplorersBySlugCached(knex)
                 .then((results) =>
                     _.mapValues(results, (explorer) => {
-                        return makeExplorerLinkedChart(explorer, explorer.slug)
+                        return makeExplorerLinkedChart(
+                            {
+                                slug: explorer.slug,
+                                title: explorer.explorerTitle,
+                                subtitle: explorer.explorerSubtitle,
+                                thumbnail: explorer.thumbnail,
+                            },
+                            explorer.slug
+                        )
                     })
                 )
             console.log(

--- a/db/model/Gdoc/GdocBase.ts
+++ b/db/model/Gdoc/GdocBase.ts
@@ -31,6 +31,7 @@ import { archieToEnriched } from "./archieToEnriched.js"
 import { getChartConfigById, mapSlugsToIds } from "../Chart.js"
 import {
     BAKED_BASE_URL,
+    EXPLORER_DYNAMIC_THUMBNAIL_URL,
     GRAPHER_DYNAMIC_THUMBNAIL_URL,
     IS_ARCHIVE,
 } from "../../../settings/clientSettings.js"
@@ -58,7 +59,6 @@ import {
     ChartConfigType,
     NarrativeChartInfo,
     ContentGraphLinkType,
-    DEFAULT_THUMBNAIL_FILENAME,
     GrapherInterface,
     LatestDataInsight,
     LinkedAuthor,
@@ -1533,7 +1533,6 @@ export function makeExplorerLinkedChart(
         slug: string
         title?: string
         subtitle?: string
-        thumbnail?: string
         tags?: string[]
     },
     originalSlug: string,
@@ -1548,9 +1547,7 @@ export function makeExplorerLinkedChart(
         title: explorer.title ?? "",
         subtitle: explorer.subtitle ?? "",
         resolvedUrl: `${BASE_URL}/${EXPLORERS_ROUTE_FOLDER}/${originalSlug}`,
-        thumbnail:
-            explorer.thumbnail ||
-            `${BAKED_BASE_URL}/${DEFAULT_THUMBNAIL_FILENAME}`,
+        thumbnail: `${EXPLORER_DYNAMIC_THUMBNAIL_URL}/${originalSlug}.png`,
         tags: explorer.tags ?? [],
         archivedPageVersion: options?.archivedPageVersion,
     }

--- a/db/model/Gdoc/GdocBase.ts
+++ b/db/model/Gdoc/GdocBase.ts
@@ -31,6 +31,7 @@ import { archieToEnriched } from "./archieToEnriched.js"
 import { getChartConfigById, mapSlugsToIds } from "../Chart.js"
 import {
     BAKED_BASE_URL,
+    EXPLORER_DYNAMIC_THUMBNAIL_URL,
     GRAPHER_DYNAMIC_THUMBNAIL_URL,
     IS_ARCHIVE,
 } from "../../../settings/clientSettings.js"
@@ -58,7 +59,6 @@ import {
     ChartConfigType,
     NarrativeChartInfo,
     ContentGraphLinkType,
-    DEFAULT_THUMBNAIL_FILENAME,
     GrapherInterface,
     LatestDataInsight,
     LinkedAuthor,
@@ -1525,7 +1525,6 @@ export function makeExplorerLinkedChart(
         slug: string
         title?: string
         subtitle?: string
-        thumbnail?: string
         tags?: string[]
     },
     originalSlug: string,
@@ -1540,9 +1539,7 @@ export function makeExplorerLinkedChart(
         title: explorer.title ?? "",
         subtitle: explorer.subtitle ?? "",
         resolvedUrl: `${BASE_URL}/${EXPLORERS_ROUTE_FOLDER}/${originalSlug}`,
-        thumbnail:
-            explorer.thumbnail ||
-            `${BAKED_BASE_URL}/${DEFAULT_THUMBNAIL_FILENAME}`,
+        thumbnail: `${EXPLORER_DYNAMIC_THUMBNAIL_URL}/${originalSlug}.png`,
         tags: explorer.tags ?? [],
         archivedPageVersion: options?.archivedPageVersion,
     }

--- a/packages/@ourworldindata/explorer/src/ExplorerGrammar.ts
+++ b/packages/@ourworldindata/explorer/src/ExplorerGrammar.ts
@@ -108,11 +108,6 @@ export const ExplorerGrammar: Grammar = {
         keyword: "hideControls",
         description: "Whether to hide the controls. Default is false.",
     },
-    thumbnail: {
-        ...UrlCellDef,
-        keyword: "thumbnail",
-        description: "URL to the social sharing thumbnail.",
-    },
     selection: {
         ...StringCellDef,
         keyword: "selection",

--- a/packages/@ourworldindata/explorer/src/ExplorerProgram.ts
+++ b/packages/@ourworldindata/explorer/src/ExplorerProgram.ts
@@ -164,10 +164,6 @@ export class ExplorerProgram extends GridProgram {
         return this.getLineValue(ExplorerGrammar.googleSheet.keyword)
     }
 
-    get thumbnail() {
-        return this.getLineValue(ExplorerGrammar.thumbnail.keyword)
-    }
-
     get explorerSubtitle() {
         return this.getLineValue(ExplorerGrammar.explorerSubtitle.keyword)
     }

--- a/site/ExplorerPage.tsx
+++ b/site/ExplorerPage.tsx
@@ -74,7 +74,7 @@ export const ExplorerPage = (props: ExplorerPageSettings) => {
         urlMigrationSpec,
         archiveContext,
     } = props
-    const { explorerTitle, explorerSubtitle, slug, thumbnail } = program
+    const { explorerTitle, explorerSubtitle, slug } = program
 
     const isOnArchivalPage = archiveContext?.type === "archive-page"
     const assetMaps = isOnArchivalPage ? archiveContext.assets : undefined
@@ -125,7 +125,6 @@ window.Explorer.renderSingleExplorerOnExplorerPage(
                 canonicalUrl={`${baseUrl}/${EXPLORERS_ROUTE_FOLDER}/${slug}`}
                 pageTitle={`${explorerTitle} Data Explorer`}
                 pageDesc={explorerSubtitle}
-                imageUrl={thumbnail}
                 baseUrl={baseUrl}
                 staticAssetMap={assetMaps?.static}
                 archiveContext={archiveContext}

--- a/site/gdocs/components/Thumbnail.tsx
+++ b/site/gdocs/components/Thumbnail.tsx
@@ -2,7 +2,10 @@ import {
     ARCHIVED_THUMBNAIL_FILENAME,
     DEFAULT_THUMBNAIL_FILENAME,
 } from "@ourworldindata/types"
-import { GRAPHER_DYNAMIC_THUMBNAIL_URL } from "../../../settings/clientSettings"
+import {
+    EXPLORER_DYNAMIC_THUMBNAIL_URL,
+    GRAPHER_DYNAMIC_THUMBNAIL_URL,
+} from "../../../settings/clientSettings"
 import Image from "./Image"
 
 export const Thumbnail = ({
@@ -23,6 +26,8 @@ export const Thumbnail = ({
     if (
         (GRAPHER_DYNAMIC_THUMBNAIL_URL &&
             thumbnail.startsWith(GRAPHER_DYNAMIC_THUMBNAIL_URL)) ||
+        (EXPLORER_DYNAMIC_THUMBNAIL_URL &&
+            thumbnail.startsWith(EXPLORER_DYNAMIC_THUMBNAIL_URL)) ||
         thumbnail.endsWith(ARCHIVED_THUMBNAIL_FILENAME) ||
         thumbnail.endsWith(DEFAULT_THUMBNAIL_FILENAME)
     ) {


### PR DESCRIPTION
The SQL query that resolves explorer configs in the site baker remaps the title and subtitle, so `makeExplorerLinkedChart` was failing, leading to prominent links with no title/subtitle on the baked site. This PR fixes that.


Also updates the code so that prominent links / recircs will use the dynamic explorer thumbnail endpoint instead of the deprecated `thumbnail` field on the explorer program.

| Before | After |
|--------|--------|
| <img width="650" height="271" alt="image" src="https://github.com/user-attachments/assets/7ba8a2d2-0497-4b3d-979d-6281e60602e7" /> | <img width="667" height="327" alt="image" src="https://github.com/user-attachments/assets/77bb0fb0-3239-4cdd-993a-dd8a920864d0" /> | 