### PR TITLE
🔨 remove old explorer thumbnail code

### DIFF
--- a/packages/@ourworldindata/explorer/src/ExplorerGrammar.ts
+++ b/packages/@ourworldindata/explorer/src/ExplorerGrammar.ts
@@ -108,11 +108,6 @@ export const ExplorerGrammar: Grammar = {
         keyword: "hideControls",
         description: "Whether to hide the controls. Default is false.",
     },
-    thumbnail: {
-        ...UrlCellDef,
-        keyword: "thumbnail",
-        description: "URL to the social sharing thumbnail.",
-    },
     selection: {
         ...StringCellDef,
         keyword: "selection",

--- a/packages/@ourworldindata/explorer/src/ExplorerProgram.ts
+++ b/packages/@ourworldindata/explorer/src/ExplorerProgram.ts
@@ -164,10 +164,6 @@ export class ExplorerProgram extends GridProgram {
         return this.getLineValue(ExplorerGrammar.googleSheet.keyword)
     }
 
-    get thumbnail() {
-        return this.getLineValue(ExplorerGrammar.thumbnail.keyword)
-    }
-
     get explorerSubtitle() {
         return this.getLineValue(ExplorerGrammar.explorerSubtitle.keyword)
     }

--- a/site/ExplorerPage.tsx
+++ b/site/ExplorerPage.tsx
@@ -74,7 +74,7 @@ export const ExplorerPage = (props: ExplorerPageSettings) => {
         urlMigrationSpec,
         archiveContext,
     } = props
-    const { explorerTitle, explorerSubtitle, slug, thumbnail } = program
+    const { explorerTitle, explorerSubtitle, slug } = program
 
     const isOnArchivalPage = archiveContext?.type === "archive-page"
     const assetMaps = isOnArchivalPage ? archiveContext.assets : undefined
@@ -125,7 +125,6 @@ window.Explorer.renderSingleExplorerOnExplorerPage(
                 canonicalUrl={`${baseUrl}/${EXPLORERS_ROUTE_FOLDER}/${slug}`}
                 pageTitle={`${explorerTitle} Data Explorer`}
                 pageDesc={explorerSubtitle}
-                imageUrl={thumbnail}
                 baseUrl={baseUrl}
                 staticAssetMap={assetMaps?.static}
                 archiveContext={archiveContext}


### PR DESCRIPTION
Removes outdated and mostly unused explorer thumbnail code seeing as we use the dynamic thumbnail endpoint for thumbnail previews now.