### PR TITLE
🐛 fix CaptionedChart chartHeight calculation

### DIFF
--- a/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
@@ -257,7 +257,12 @@ abstract class AbstractCaptionedChart extends React.Component<CaptionedChartProp
         )
     }
 
+    @computed private get showHeader(): boolean {
+        return this.header.height > 0
+    }
+
     @computed private get headerHeightWithPadding(): number {
+        if (!this.showHeader) return 0
         return this.header.height + this.verticalPadding
     }
 
@@ -323,8 +328,15 @@ abstract class AbstractCaptionedChart extends React.Component<CaptionedChartProp
                 }}
             >
                 {/* #1 Header */}
-                <Header manager={this.manager} maxWidth={this.maxWidth} />
-                <VerticalSpace height={this.verticalPadding} />
+                {this.showHeader && (
+                    <>
+                        <Header
+                            manager={this.manager}
+                            maxWidth={this.maxWidth}
+                        />
+                        <VerticalSpace height={this.verticalPadding} />
+                    </>
+                )}
 
                 {this.manager.isReady ? (
                     <>

--- a/packages/@ourworldindata/grapher/src/header/Header.tsx
+++ b/packages/@ourworldindata/grapher/src/header/Header.tsx
@@ -288,7 +288,9 @@ abstract class AbstractHeader<
         )
     }
 
-    override render(): React.ReactElement {
+    override render(): React.ReactElement | null {
+        const hasContent = !!this.logo || this.showTitle || this.showSubtitle
+        if (!hasContent) return null
         return (
             <div
                 className="HeaderHTML"
@@ -335,9 +337,19 @@ export class StaticHeader extends AbstractHeader<StaticHeaderProps> {
         return 1.2
     }
 
-    override render(): React.ReactElement {
+    override render(): React.ReactElement | null {
         const { targetX: x, targetY: y } = this.props
-        const { title, logo, subtitle, manager, maxWidth } = this
+        const {
+            title,
+            logo,
+            subtitle,
+            manager,
+            maxWidth,
+            showTitle,
+            showSubtitle,
+        } = this
+        const hasContent = !!logo || showTitle || showSubtitle
+        if (!hasContent) return null
         return (
             <g id={makeFigmaId(GRAPHER_HEADER_CLASS)} className="HeaderView">
                 {logo &&


### PR DESCRIPTION
I've added a few more directives recently and one of them wasn't factored into the `chartHeight` calculation in CaptionedChart.

This ties it all together so that if title, subtitle, and logo are all hidden, the `VerticalSpace` won't render and `header.height` will be 0.