### PR TITLE
Fix double-firing of grapher_view event on multi-dim pages

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -601,6 +601,9 @@ export class Grapher extends React.Component<GrapherProps> {
                             if (!this.hasLoggedGAViewEvent) {
                                 this.hasLoggedGAViewEvent = true
 
+                                // On multi-dim pages, the useMultiDimAnalytics hook
+                                // already fires grapher_view with viewConfigId — skip
+                                // here to avoid double-counting.
                                 if (this.grapherState.narrativeChartInfo) {
                                     this.grapherState.analytics.logGrapherView(
                                         this.grapherState.narrativeChartInfo
@@ -611,12 +614,13 @@ export class Grapher extends React.Component<GrapherProps> {
                                                     .narrativeChartInfo.name,
                                         }
                                     )
-                                    this.hasLoggedGAViewEvent = true
-                                } else if (this.grapherState.slug) {
+                                } else if (
+                                    this.grapherState.slug &&
+                                    !this.grapherState.isMultiDim
+                                ) {
                                     this.grapherState.analytics.logGrapherView(
                                         this.grapherState.slug
                                     )
-                                    this.hasLoggedGAViewEvent = true
                                 }
                             }
 

--- a/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
@@ -3207,6 +3207,10 @@ export class GrapherState
         return this.base.current || undefined
     }
 
+    @computed get isMultiDim(): boolean {
+        return !!this.manager?.analyticsContext?.mdimSlug
+    }
+
     @computed private get analyticsContext(): GrapherAnalyticsContext {
         const ctx = this.manager?.analyticsContext
         return {


### PR DESCRIPTION
## Summary

- On multi-dim pages, the `owid.grapher_view` GA event fires **twice** per page load: once from the `useMultiDimAnalytics` hook (with `viewConfigId`) and once from the Grapher component's IntersectionObserver (without `viewConfigId`)
- Due to a race condition between `useEffect` timing and IntersectionObserver callbacks, the duplicate fires ~10-20% of the time (not 50-50%) — it only occurs when the observer fires before `updateGrapher` sets `analyticsContext` on the manager
- Skip the Grapher's own `grapher_view` event when embedded in a multi-dim page, since the hook already handles it

Fixes #6347. Context: [owid/analytics#726](https://github.com/owid/analytics/issues/726)

## Test plan

- [ ] Visit a multi-dim page (e.g. `/grapher/energy`) and verify only one `grapher_view` event fires in the dataLayer (with `viewConfigId` set)
- [ ] Visit a regular grapher page (e.g. `/grapher/life-expectancy`) and verify `grapher_view` still fires as before
- [ ] Change dimension settings on an mdim page and verify subsequent `grapher_view` events fire (from the hook) with updated `viewConfigId`
- [ ] Verify narrative charts still fire `grapher_view` with `narrativeChartName`

🤖 Generated with [Claude Code](https://claude.com/claude-code)