### PR TITLE
🔨 add datapages view

### DIFF
--- a/adminSiteServer/adminRouter.tsx
+++ b/adminSiteServer/adminRouter.tsx
@@ -166,8 +166,8 @@ getPlainRouteWithROTransaction(
                 await renderPreviewDataPageOrGrapherPage(
                     chart.config,
                     chart.id,
-                    forceDatapage,
-                    trx
+                    trx,
+                    { forceDatapage }
                 )
             res.send(previewDataPageOrGrapherPage)
             return
@@ -193,7 +193,6 @@ getPlainRouteWithROTransaction(
                 await renderPreviewDataPageOrGrapherPage(
                     chart.config,
                     chart.id,
-                    chart.forceDatapage,
                     trx
                 )
             res.send(previewDataPageOrGrapherPage)

--- a/adminSiteServer/mockSiteRouter.ts
+++ b/adminSiteServer/mockSiteRouter.ts
@@ -278,7 +278,6 @@ getPlainRouteWithROTransaction(
                 await renderPreviewDataPageOrGrapherPage(
                     chartRow.config,
                     chartRow.id,
-                    chartRow.forceDatapage,
                     trx
                 )
             res.send(previewDataPageOrGrapherPage)

--- a/baker/GrapherBaker.tsx
+++ b/baker/GrapherBaker.tsx
@@ -50,10 +50,7 @@ import { logErrorAndMaybeCaptureInSentry } from "../serverUtils/errorLog.js"
 
 import { deleteOldGraphers, getTagToSlugMap } from "./GrapherBakingUtils.js"
 import { knexRaw } from "../db/db.js"
-import {
-    getForceDatapageByChartId,
-    getRelatedChartsForVariable,
-} from "../db/model/Chart.js"
+import { getRelatedChartsForVariable } from "../db/model/Chart.js"
 import { getAllMultiDimDataPageSlugs } from "../db/model/MultiDimDataPage.js"
 import pMap from "p-map"
 import { stringify } from "safe-stable-stringify"
@@ -74,14 +71,8 @@ const renderDatapageIfApplicable = async (
         forceDatapage?: boolean
     } = {}
 ) => {
-    const shouldForceDatapage =
-        forceDatapage !== undefined
-            ? forceDatapage
-            : grapher.id !== undefined
-              ? await getForceDatapageByChartId(knex, grapher.id)
-              : false
     const variable = await getVariableOfDatapageIfApplicable(knex, grapher, {
-        forceDatapage: shouldForceDatapage,
+        forceDatapage,
     })
 
     if (!variable) return undefined
@@ -110,27 +101,22 @@ const renderDatapageIfApplicable = async (
 }
 
 /**
- *
  * Render a datapage if available, otherwise render a grapher page.
  */
-
 export const renderDataPageOrGrapherPage = async (
     grapher: GrapherInterface,
     knex: db.KnexReadonlyTransaction,
     {
         imageMetadataDictionary,
         archiveContextDictionary,
-        forceDatapage,
     }: {
         imageMetadataDictionary?: Record<string, DbEnrichedImage>
         archiveContextDictionary?: Record<number, ArchiveContext | undefined>
-        forceDatapage?: boolean
     } = {}
 ): Promise<string> => {
     const datapage = await renderDatapageIfApplicable(grapher, false, knex, {
         imageMetadataDictionary,
         archiveContextDictionary,
-        forceDatapage,
     })
     if (datapage) return datapage
     return renderGrapherPage(grapher, knex, {
@@ -293,14 +279,14 @@ export async function renderDataPageV2(
 export const renderPreviewDataPageOrGrapherPage = async (
     grapher: GrapherInterface,
     chartId: number,
-    forceDatapage: boolean,
-    knex: db.KnexReadonlyTransaction
+    knex: db.KnexReadonlyTransaction,
+    options?: { forceDatapage?: boolean }
 ) => {
     const archiveContextDictionary =
         await getLatestArchivedChartPageVersionsIfEnabled(knex)
     const datapage = await renderDatapageIfApplicable(grapher, true, knex, {
         archiveContextDictionary,
-        forceDatapage,
+        forceDatapage: options?.forceDatapage,
     })
     if (datapage) return datapage
 
@@ -396,7 +382,6 @@ const bakeGrapherPage = async (
     await fs.writeFile(
         outPath,
         await renderDataPageOrGrapherPage(grapher, knex, {
-            forceDatapage: args.forceDatapage,
             imageMetadataDictionary: args.imageMetadataDictionary,
             archiveContextDictionary: args.archiveContextDictionary,
         })
@@ -408,7 +393,6 @@ export interface BakeSingleGrapherChartArguments {
     config: string
     bakedSiteDir: string
     slug: string
-    forceDatapage: boolean
     imageMetadataDictionary: Record<string, DbEnrichedImage>
     archiveContextDictionary: Record<number, ArchiveContext | undefined>
 }
@@ -439,7 +423,6 @@ export const bakeAllChangedGrapherPagesAndDeleteRemovedGraphers = async (
         Pick<DbPlainChart, "id"> & {
             config: DbRawChartConfig["full"]
             slug: string
-            forceDatapage: boolean
         }
     >(
         knex,
@@ -447,8 +430,7 @@ export const bakeAllChangedGrapherPagesAndDeleteRemovedGraphers = async (
         SELECT
             c.id,
             cc.full as config,
-            cc.slug,
-            c.forceDatapage
+            cc.slug
         FROM charts c
         JOIN chart_configs cc ON c.configId = cc.id
         WHERE JSON_EXTRACT(cc.full, "$.isPublished")=true
@@ -471,7 +453,6 @@ export const bakeAllChangedGrapherPagesAndDeleteRemovedGraphers = async (
         config: row.config,
         bakedSiteDir: bakedSiteDir,
         slug: row.slug,
-        forceDatapage: Boolean(row.forceDatapage),
         imageMetadataDictionary,
         archiveContextDictionary,
     }))

--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -460,7 +460,6 @@ export class SiteBaker {
                                 chart.config,
                                 chart.slug,
                                 {
-                                    forceDatapage: chart.forceDatapage,
                                     archivedPageVersion:
                                         archivedVersions.charts[chart.id] ||
                                         undefined,

--- a/db/docs/datapages.yml
+++ b/db/docs/datapages.yml
@@ -1,0 +1,15 @@
+metadata:
+    description: |
+        View that identifies which charts render as data pages and which indicator they use for metadata.
+        A chart appearing in this view is a data page; charts not in this view are not.
+
+        A chart qualifies as a data page when:
+        1. Dimension eligibility: the chart has exactly one Y indicator and is not a scatter plot with a mapped X variable.
+        2. Metadata check: the selected Y indicator has schemaVersion >= 2 and at least one of descriptionShort, descriptionProcessing, descriptionKey, descriptionFromProducer, or titlePublic populated.
+
+        If charts.forceDatapage is true, then the chart is a data page regardless of the above criteria.
+fields:
+    chartId:
+        description: Foreign key to charts table. Identifies the chart.
+    variableId:
+        description: Foreign key to variables table. The indicator whose metadata is used for the data page.

--- a/db/migration/1775825559304-AddDatapagesView.ts
+++ b/db/migration/1775825559304-AddDatapagesView.ts
@@ -1,0 +1,55 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class AddDatapagesView1775825559304 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`-- sql
+            CREATE VIEW datapages AS
+            WITH y_dimensions AS (
+                SELECT
+                    chartId,
+                    variableId,
+                    ROW_NUMBER() OVER (PARTITION BY chartId ORDER BY \`order\`) AS rn
+                FROM chart_dimensions
+                WHERE property = 'y'
+            ),
+            y_counts AS (
+                SELECT chartId, COUNT(*) AS num_y
+                FROM chart_dimensions
+                WHERE property = 'y'
+                GROUP BY chartId
+            ),
+            has_x_dimension AS (
+                SELECT DISTINCT chartId
+                FROM chart_dimensions
+                WHERE property = 'x'
+            )
+            SELECT
+                c.id AS chartId,
+                yd.variableId AS variableId
+            FROM charts c
+            JOIN chart_configs cc ON cc.id = c.configId
+            JOIN y_dimensions yd ON yd.chartId = c.id AND yd.rn = 1
+            JOIN y_counts yc ON yc.chartId = c.id
+            LEFT JOIN has_x_dimension hx ON hx.chartId = c.id
+            JOIN variables v ON v.id = yd.variableId
+            WHERE
+                c.forceDatapage = 1
+                OR (
+                    yc.num_y = 1
+                    AND NOT (cc.chartType = 'ScatterPlot' AND hx.chartId IS NOT NULL)
+                    AND v.schemaVersion >= 2
+                    AND (
+                        (v.descriptionShort IS NOT NULL AND v.descriptionShort != '')
+                        OR (v.descriptionProcessing IS NOT NULL AND v.descriptionProcessing != '')
+                        OR (v.descriptionKey IS NOT NULL AND v.descriptionKey != '' AND v.descriptionKey != '[]')
+                        OR (v.descriptionFromProducer IS NOT NULL AND v.descriptionFromProducer != '')
+                        OR (v.titlePublic IS NOT NULL AND v.titlePublic != '')
+                    )
+                )
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP VIEW IF EXISTS datapages`)
+    }
+}

--- a/db/model/Chart.ts
+++ b/db/model/Chart.ts
@@ -70,7 +70,6 @@ export async function mapSlugsToConfigs(
     {
         slug: string
         id: number
-        forceDatapage: boolean
         config: GrapherInterface
     }[]
 > {
@@ -79,17 +78,16 @@ export async function mapSlugsToConfigs(
             slug: string
             config: string
             id: number
-            forceDatapage: number
         }>(
             knex,
             `-- sql
-                SELECT csr.slug AS slug, cc.full AS config, c.id AS id, c.forceDatapage AS forceDatapage
+                SELECT csr.slug AS slug, cc.full AS config, c.id AS id
                 FROM chart_slug_redirects csr
                 JOIN charts c ON csr.chart_id = c.id
                 JOIN chart_configs cc ON cc.id = c.configId
                 WHERE cc.full ->> "$.isPublished" = "true"
                 UNION
-                SELECT cc.slug, cc.full AS config, c.id AS id, c.forceDatapage AS forceDatapage
+                SELECT cc.slug, cc.full AS config, c.id AS id
                 FROM charts c
                 JOIN chart_configs cc ON cc.id = c.configId
                 WHERE cc.full ->> "$.isPublished" = "true"
@@ -98,7 +96,6 @@ export async function mapSlugsToConfigs(
         .then((results) =>
             results.map((result) => ({
                 ...result,
-                forceDatapage: Boolean(result.forceDatapage),
                 config: JSON.parse(result.config),
             }))
         )
@@ -279,7 +276,7 @@ export async function getChartConfigBySlug(
     knex: db.KnexReadonlyTransaction,
     slug: string
 ): Promise<
-    Pick<DbPlainChart, "id" | "forceDatapage"> & {
+    Pick<DbPlainChart, "id"> & {
         config: DbEnrichedChartConfig["full"]
     }
 > {
@@ -290,7 +287,7 @@ export async function getChartConfigBySlug(
     >(
         knex,
         `-- sql
-            SELECT c.id, c.forceDatapage, cc.full as config
+            SELECT c.id, cc.full as config
             FROM charts c
             JOIN chart_configs cc ON c.configId = cc.id
             WHERE cc.slug = ?`,
@@ -299,11 +296,7 @@ export async function getChartConfigBySlug(
 
     if (!row) throw new JsonError(`No chart found for slug ${slug}`, 404)
 
-    return {
-        id: row.id,
-        forceDatapage: Boolean(row.forceDatapage),
-        config: parseChartConfig(row.config),
-    }
+    return { id: row.id, config: parseChartConfig(row.config) }
 }
 
 export async function getForceDatapageByChartId(

--- a/db/model/Gdoc/GdocBase.ts
+++ b/db/model/Gdoc/GdocBase.ts
@@ -192,7 +192,6 @@ export async function loadLinkedChartsForSlugs(
                     chart.config,
                     originalSlug,
                     {
-                        forceDatapage: chart.forceDatapage,
                         archivedPageVersion:
                             archivedChartVersions[chartId] || undefined,
                     }
@@ -1497,22 +1496,14 @@ export async function makeGrapherLinkedChart(
     knex: db.KnexReadonlyTransaction,
     config: GrapherInterface,
     originalSlug: string,
-    {
-        forceDatapage,
-        archivedPageVersion,
-    }: {
-        forceDatapage?: boolean
-        archivedPageVersion?: ArchivedPageVersion
-    } = {}
+    { archivedPageVersion }: { archivedPageVersion?: ArchivedPageVersion } = {}
 ): Promise<LinkedChart> {
     const resolvedSlug = config.slug ?? ""
     const resolvedTitle = config.title ?? ""
     const subtitle = toPlaintext(config.subtitle ?? "")
     const resolvedUrl = `${BASE_URL}/grapher/${resolvedSlug}`
     const tab = config.tab ?? GRAPHER_TAB_CONFIG_OPTIONS.chart
-    const indicatorId = await getDatapageIndicatorId(knex, config, {
-        forceDatapage,
-    })
+    const indicatorId = await getDatapageIndicatorId(knex, config)
 
     return {
         configType: ChartConfigType.Grapher,

--- a/db/model/Variable.ts
+++ b/db/model/Variable.ts
@@ -21,12 +21,12 @@ import {
     OwidVariableMixedData,
     OwidVariableWithSourceAndDimension,
     OwidVariableId,
-    GRAPHER_CHART_TYPES,
     DimensionProperty,
     GrapherInterface,
     DbRawVariable,
     VariablesTableName,
     DbRawChartConfig,
+    DbPlainDatapage,
     parseChartConfig,
     DbEnrichedChartConfig,
     DbEnrichedVariable,
@@ -578,14 +578,6 @@ export async function getAllChartsForIndicator(
 /**
  * Returns the indicator ID to use for datapage metadata if the grapher is
  * eligible for a datapage, otherwise undefined.
- *
- * By default, datapages require exactly one Y indicator.
- *
- * If `forceDatapage` is enabled, we instead use the first Y indicator for
- * metadata (same behavior as mdims), even when there are multiple Y indicators.
- *
- * The selected indicator must have schema version >= 2 and include text for at
- * least one of the description* fields or titlePublic.
  */
 export async function getDatapageIndicatorId(
     knex: db.KnexReadonlyTransaction,
@@ -594,50 +586,32 @@ export async function getDatapageIndicatorId(
         forceDatapage?: boolean
     }
 ): Promise<number | undefined> {
-    const yVariableIds = grapher
-        .dimensions!.filter((d) => d.property === DimensionProperty.y)
-        .map((d) => d.variableId)
-    const xVariableIds = grapher
-        .dimensions!.filter((d) => d.property === DimensionProperty.x)
-        .map((d) => d.variableId)
-
-    // For scatter plots we want to only show a data page if it has no X indicator mapped, which
-    // is a special case where time is the X axis. Marimekko charts are the other chart that uses
-    // the X dimension but there we usually map population on X which should not prevent us from
-    // showing a data page.
-    const isScatterWithMappedX =
-        grapher.chartTypes?.[0] === GRAPHER_CHART_TYPES.ScatterPlot &&
-        xVariableIds.length > 0
-
-    let variableId: number | undefined
-    if (
-        options?.forceDatapage ||
-        (yVariableIds.length === 1 && !isScatterWithMappedX)
-    ) {
-        variableId = yVariableIds[0]
+    // If a data page is forced, simply return the first y-dimension
+    if (options?.forceDatapage) {
+        const yVariableIds = grapher
+            .dimensions!.filter((d) => d.property === DimensionProperty.y)
+            .map((d) => d.variableId)
+        return yVariableIds[0]
     }
 
-    if (!variableId) return undefined
+    if (!grapher.id) {
+        console.warn(
+            "Grapher must have an ID to check for datapage eligibility"
+        )
+        return undefined
+    }
 
-    const result = await knexRawFirst<{ id: number }>(
+    const row = await knexRawFirst<DbPlainDatapage>(
         knex,
         `-- sql
-            SELECT id
-            FROM variables
-            WHERE id = ?
-              AND schemaVersion >= 2
-              AND (
-                (descriptionShort IS NOT NULL AND descriptionShort != '') OR
-                (descriptionProcessing IS NOT NULL AND descriptionProcessing != '') OR
-                (descriptionKey IS NOT NULL AND descriptionKey != '' AND descriptionKey != '[]') OR
-                (descriptionFromProducer IS NOT NULL AND descriptionFromProducer != '') OR
-                (titlePublic IS NOT NULL AND titlePublic != '')
-              )
+            SELECT variableId
+            FROM datapages
+            WHERE chartId = ?
         `,
-        [variableId]
+        [grapher.id]
     )
 
-    return result?.id
+    return row?.variableId
 }
 
 // TODO: these are domain functions and should live somewhere else
@@ -929,15 +903,9 @@ export const readSQLasDF = async (
 export async function getVariableOfDatapageIfApplicable(
     knex: db.KnexReadonlyTransaction,
     grapher: GrapherInterface,
-    options?: {
-        forceDatapage?: boolean
-    }
+    options?: { forceDatapage?: boolean }
 ): Promise<
-    | {
-          id: number
-          metadata: OwidVariableWithSourceAndDimension
-      }
-    | undefined
+    { id: number; metadata: OwidVariableWithSourceAndDimension } | undefined
 > {
     const indicatorId = await getDatapageIndicatorId(knex, grapher, options)
     if (indicatorId) {

--- a/packages/@ourworldindata/types/src/dbTypes/Datapages.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/Datapages.ts
@@ -1,0 +1,6 @@
+export const DatapagesTableName = "datapages"
+
+export interface DbPlainDatapage {
+    chartId: number
+    variableId: number
+}

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -437,6 +437,10 @@ export {
     type DbPlainChartXEntity,
 } from "./dbTypes/ChartsXEntities.js"
 export {
+    type DbPlainDatapage,
+    DatapagesTableName,
+} from "./dbTypes/Datapages.js"
+export {
     type DbPlainDataset,
     type DbInsertDataset,
     DatasetsTableName,


### PR DESCRIPTION
Resolves #6315 

Adds a new `datapages` view with two columns: `chartId` and `variableId`, where `variableId` is the main indicator id for the data page. I also considered a simple isDatapage flag, but I think having an explicit mapping from chart ID to data page indicator ID in the DB is convenient.

This isn’t a pure refactor, there’s also a behavioural change when `forceDatapage` is true. `forceDatapage` used to only kick in if the metadata checks passed (so it might have been set, but no datapage showed because those checks failed), which acted as an extra safety net. I think it’s reasonable to just trust the author if they want to force a particular chart to be a data page. I also checked and we have sensible fallbacks for everything, so nothing bad happens if some of the metadata fields are missing.