### PR TITLE
🔨 (explorer) respect column description

### DIFF
--- a/packages/@ourworldindata/explorer/src/ColumnGrammar.ts
+++ b/packages/@ourworldindata/explorer/src/ColumnGrammar.ts
@@ -78,7 +78,6 @@ export const ColumnGrammar: Grammar<ColumnCellDef> = {
         ...StringCellDef,
         keyword: "description",
         description: "Describe the column",
-        isDisplayProperty: true,
     },
     unit: {
         ...StringCellDef,


### PR DESCRIPTION
Fixes a bug where the description field didn't show up in explorers.

Example: [Prod](https://ourworldindata.org/explorers/poverty-explorer?tab=table&overlay=sources&Indicator=Share+in+poverty&Poverty+line=%243+per+day%3A+International+Poverty+Line&Household+survey+data+type=Show+data+from+both+income+and+consumption+surveys&Show+breaks+between+less+comparable+surveys=false&country=BGD~BOL~KEN~MOZ~NGA~ZMB) / [Staging](http://staging-site-fix-explorer-column-descript/explorers/poverty-explorer?tab=table&overlay=sources&Indicator=Share+in+poverty&Poverty+line=%243+per+day%3A+International+Poverty+Line&Household+survey+data+type=Show+data+from+both+income+and+consumption+surveys&Show+breaks+between+less+comparable+surveys=false&country=BGD~BOL~KEN~MOZ~NGA~ZMB)