### PR TITLE
✨ add focus state to bespoke time slider

### DIFF
--- a/bespoke/components/TimeSlider/TimeSlider.scss
+++ b/bespoke/components/TimeSlider/TimeSlider.scss
@@ -69,7 +69,8 @@
         background-clip: content-box !important;
 
         &[data-active],
-        &[data-dragging] {
+        &[data-dragging],
+        &[data-focus-visible] {
             .time-slider__knob {
                 transform: scale(1.3);
                 background: $active-knob;


### PR DESCRIPTION
The bespoke time slider's thumb currently doesn't have a focus state