### PR TITLE
Exclude thumbnail pageviews from static image view counts

### DIFF
--- a/adminSiteClient/ImagesIndexPage.tsx
+++ b/adminSiteClient/ImagesIndexPage.tsx
@@ -51,17 +51,13 @@ type ImageMap = Record<string, DbEnrichedImageWithPageviews>
 
 type ImageTypeFilter =
     | "all"
-    | "featured-thumbnail-rw"
+    | "article-thumbnail"
     | "content"
     | "content-and-thumbnail"
     | "other"
 
 function isUsedAsThumbnail(image: DbEnrichedImageWithPageviews): boolean {
-    return (
-        image.isFeaturedImage === 1 ||
-        image.filename.toLowerCase().includes("thumbnail") ||
-        image.isInResearchAndWriting === 1
-    )
+    return image.isArticleThumbnail === 1
 }
 
 function getImageType(image: DbEnrichedImageWithPageviews): ImageTypeFilter {
@@ -76,7 +72,7 @@ function getImageType(image: DbEnrichedImageWithPageviews): ImageTypeFilter {
     }
 
     if (isUsedAsThumbnail(image)) {
-        return "featured-thumbnail-rw"
+        return "article-thumbnail"
     }
 
     return "other"
@@ -895,12 +891,12 @@ export function ImageIndexPage() {
                                     { value: "all", label: "All images" },
                                     { value: "content", label: "Content" },
                                     {
-                                        value: "featured-thumbnail-rw",
-                                        label: "Thumbnails or featured images",
+                                        value: "article-thumbnail",
+                                        label: "Article thumbnails",
                                     },
                                     {
                                         value: "content-and-thumbnail",
-                                        label: "Used in both content and thumbnail",
+                                        label: "Content and article thumbnails",
                                     },
                                     { value: "other", label: "Other" },
                                 ]}

--- a/adminSiteClient/ImagesIndexPage.tsx
+++ b/adminSiteClient/ImagesIndexPage.tsx
@@ -49,25 +49,36 @@ import { EditableTextarea } from "./EditableTextarea.js"
 
 type ImageMap = Record<string, DbEnrichedImageWithPageviews>
 
-type ImageTypeFilter = "all" | "featured-thumbnail-rw" | "content" | "other"
+type ImageTypeFilter =
+    | "all"
+    | "featured-thumbnail-rw"
+    | "content"
+    | "content-and-thumbnail"
+    | "other"
+
+function isUsedAsThumbnail(image: DbEnrichedImageWithPageviews): boolean {
+    return (
+        image.isFeaturedImage === 1 ||
+        image.filename.toLowerCase().includes("thumbnail") ||
+        image.isInResearchAndWriting === 1
+    )
+}
 
 function getImageType(image: DbEnrichedImageWithPageviews): ImageTypeFilter {
-    const isFeatured = image.isFeaturedImage === 1
-    const isThumbnail = image.filename.toLowerCase().includes("thumbnail")
-    const isInResearchAndWriting = image.isInResearchAndWriting === 1
     const isBodyContent = image.isBodyContent === 1
 
-    // If an image is used in both body content and featured/rw/thumbnail, keep it in content category
+    if (isBodyContent && isUsedAsThumbnail(image)) {
+        return "content-and-thumbnail"
+    }
+
     if (isBodyContent) {
         return "content"
     }
 
-    // Category for featured, thumbnails, and research-and-writing (only if not in body content)
-    if (isFeatured || isThumbnail || isInResearchAndWriting) {
+    if (isUsedAsThumbnail(image)) {
         return "featured-thumbnail-rw"
     }
 
-    // Everything else is other (fallback)
     return "other"
 }
 
@@ -838,9 +849,13 @@ export function ImageIndexPage() {
                 const matchesFilename = image.filename
                     .toLowerCase()
                     .includes(filenameSearchValue.toLowerCase())
+                const imageType = getImageType(image)
                 const matchesType =
                     imageTypeFilter === "all" ||
-                    getImageType(image) === imageTypeFilter
+                    imageType === imageTypeFilter ||
+                    // "content" includes images used only as content AND those used in both
+                    (imageTypeFilter === "content" &&
+                        imageType === "content-and-thumbnail")
                 return matchesFilename && matchesType
             }),
         [images, filenameSearchValue, imageTypeFilter]
@@ -882,6 +897,10 @@ export function ImageIndexPage() {
                                     {
                                         value: "featured-thumbnail-rw",
                                         label: "Thumbnails or featured images",
+                                    },
+                                    {
+                                        value: "content-and-thumbnail",
+                                        label: "Used in both content and thumbnail",
                                     },
                                     { value: "other", label: "Other" },
                                 ]}

--- a/db/db.ts
+++ b/db/db.ts
@@ -938,19 +938,7 @@ export function getCloudflareImages(
         `-- sql
         SELECT
             i.*,
-            COALESCE(SUM(CASE WHEN
-                -- Only count views from pages where the image is genuinely used as content,
-                -- not just referenced as a thumbnail for another article (e.g. in R&W blocks)
-                i.filename = pg.content->>'$."featured-image"'
-                OR (
-                    JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body') IS NOT NULL
-                    AND JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].primary[*].value.filename') IS NULL
-                    AND JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].secondary[*].value.filename') IS NULL
-                    AND JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].rows[*].articles[*].value.filename') IS NULL
-                    AND JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].more.articles[*].value.filename') IS NULL
-                    AND JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].latest.articles[*].value.filename') IS NULL
-                )
-                THEN pv.views_365d ELSE 0 END), 0) AS views_365d,
+            COALESCE(SUM(CASE WHEN pxi.context = 'content' THEN pv.views_365d ELSE 0 END), 0) AS views_365d,
             MAX(CASE WHEN i.filename = pg.content->>'$."featured-image"' THEN 1 ELSE 0 END) AS isFeaturedImage,
             MAX(CASE WHEN
                 JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body') IS NOT NULL

--- a/db/db.ts
+++ b/db/db.ts
@@ -938,7 +938,19 @@ export function getCloudflareImages(
         `-- sql
         SELECT
             i.*,
-            COALESCE(SUM(pv.views_365d), 0) AS views_365d,
+            COALESCE(SUM(CASE WHEN
+                -- Only count views from pages where the image is genuinely used as content,
+                -- not just referenced as a thumbnail for another article (e.g. in R&W blocks)
+                i.filename = pg.content->>'$."featured-image"'
+                OR (
+                    JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body') IS NOT NULL
+                    AND JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].primary[*].value.filename') IS NULL
+                    AND JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].secondary[*].value.filename') IS NULL
+                    AND JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].rows[*].articles[*].value.filename') IS NULL
+                    AND JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].more.articles[*].value.filename') IS NULL
+                    AND JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].latest.articles[*].value.filename') IS NULL
+                )
+                THEN pv.views_365d ELSE 0 END), 0) AS views_365d,
             MAX(CASE WHEN i.filename = pg.content->>'$."featured-image"' THEN 1 ELSE 0 END) AS isFeaturedImage,
             MAX(CASE WHEN
                 JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body') IS NOT NULL

--- a/db/db.ts
+++ b/db/db.ts
@@ -904,29 +904,16 @@ export async function selectReplacementChainForImage(
 export function getCloudflareImages(
     trx: KnexReadonlyTransaction,
     options?: {
-        excludeFeaturedImages?: boolean
-        excludeThumbnails?: boolean
-        excludeResearchAndWriting?: boolean
+        excludeArticleThumbnails?: boolean
     }
 ): Promise<DbEnrichedImageWithPageviews[]> {
-    const {
-        excludeFeaturedImages = false,
-        excludeThumbnails = false,
-        excludeResearchAndWriting = false,
-    } = options || {}
+    const { excludeArticleThumbnails = false } = options || {}
 
     let havingClause = ""
     const conditions: string[] = []
 
-    if (excludeFeaturedImages) {
-        conditions.push("isFeaturedImage = 0")
-        conditions.push("isBodyContent = 1")
-    }
-    if (excludeThumbnails) {
-        conditions.push("i.filename NOT LIKE '%thumbnail%'")
-    }
-    if (excludeResearchAndWriting) {
-        conditions.push("isInResearchAndWriting = 0")
+    if (excludeArticleThumbnails) {
+        conditions.push("isArticleThumbnail = 0")
     }
 
     if (conditions.length > 0) {
@@ -939,9 +926,8 @@ export function getCloudflareImages(
         SELECT
             i.*,
             COALESCE(SUM(CASE WHEN pxi.context = 'content' THEN pv.views_365d ELSE 0 END), 0) AS views_365d,
-            MAX(CASE WHEN i.filename = pg.content->>'$."featured-image"' THEN 1 ELSE 0 END) AS isFeaturedImage,
             MAX(CASE WHEN pxi.context = 'content' THEN 1 ELSE 0 END) AS isBodyContent,
-            MAX(CASE WHEN pxi.context = 'article-thumbnail' THEN 1 ELSE 0 END) AS isInResearchAndWriting
+            MAX(CASE WHEN pxi.context = 'article-thumbnail' THEN 1 ELSE 0 END) AS isArticleThumbnail
         FROM images i
         LEFT JOIN posts_gdocs_x_images pxi ON i.id = pxi.imageId
         LEFT JOIN posts_gdocs pg ON pxi.gdocId = pg.id AND pg.published = 1

--- a/db/db.ts
+++ b/db/db.ts
@@ -940,23 +940,8 @@ export function getCloudflareImages(
             i.*,
             COALESCE(SUM(CASE WHEN pxi.context = 'content' THEN pv.views_365d ELSE 0 END), 0) AS views_365d,
             MAX(CASE WHEN i.filename = pg.content->>'$."featured-image"' THEN 1 ELSE 0 END) AS isFeaturedImage,
-            MAX(CASE WHEN
-                JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body') IS NOT NULL
-                AND (
-                    JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].primary[*].value.filename') IS NULL
-                    AND JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].secondary[*].value.filename') IS NULL
-                    AND JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].rows[*].articles[*].value.filename') IS NULL
-                    AND JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].more.articles[*].value.filename') IS NULL
-                    AND JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].latest.articles[*].value.filename') IS NULL
-                )
-            THEN 1 ELSE 0 END) AS isBodyContent,
-            MAX(CASE WHEN
-                JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].primary[*].value.filename') IS NOT NULL
-                OR JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].secondary[*].value.filename') IS NOT NULL
-                OR JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].rows[*].articles[*].value.filename') IS NOT NULL
-                OR JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].more.articles[*].value.filename') IS NOT NULL
-                OR JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].latest.articles[*].value.filename') IS NOT NULL
-            THEN 1 ELSE 0 END) AS isInResearchAndWriting
+            MAX(CASE WHEN pxi.context = 'content' THEN 1 ELSE 0 END) AS isBodyContent,
+            MAX(CASE WHEN pxi.context = 'article-thumbnail' THEN 1 ELSE 0 END) AS isInResearchAndWriting
         FROM images i
         LEFT JOIN posts_gdocs_x_images pxi ON i.id = pxi.imageId
         LEFT JOIN posts_gdocs pg ON pxi.gdocId = pg.id AND pg.published = 1

--- a/db/docs/posts_gdocs_x_images.yml
+++ b/db/docs/posts_gdocs_x_images.yml
@@ -7,3 +7,5 @@ fields:
         description: Foreign key to posts_gdocs table
     imageId:
         description: Foreign key to images table
+    context:
+        description: How the image is used in the article. 'content' means the image is genuine inline content (image block, video, etc.) or the article's own featured/cover image. 'article-thumbnail' means the image appears only as a thumbnail for a linked article (research-and-writing block, prominent-link), i.e. it represents another article rather than being content in its own right.

--- a/db/docs/posts_gdocs_x_images.yml
+++ b/db/docs/posts_gdocs_x_images.yml
@@ -8,4 +8,4 @@ fields:
     imageId:
         description: Foreign key to images table
     context:
-        description: How the image is used in the article. 'content' means the image is genuine inline content (image block, video, etc.) or the article's own featured/cover image. 'article-thumbnail' means the image appears only as a thumbnail for a linked article (research-and-writing block, prominent-link), i.e. it represents another article rather than being content in its own right.
+        description: How the image is used in the article. 'content' means the image is genuine inline body content (image block, video, etc.). 'article-thumbnail' means the image is used as a thumbnail — either as the article's own featured/cover image, or as a thumbnail for a linked article (research-and-writing block, prominent-link).

--- a/db/migration/1776165276305-AddContextToPostsGdocsXImages.ts
+++ b/db/migration/1776165276305-AddContextToPostsGdocsXImages.ts
@@ -9,7 +9,7 @@ export class AddContextToPostsGdocsXImages1776165276305 implements MigrationInte
 
         // Backfill: mark existing rows as 'article-thumbnail' where the image
         // appears only in article-reference slots (R&W blocks, prominent-link
-        // thumbnails) and not as genuine content (featured-image or inline body).
+        // thumbnails) and not as genuine inline body content.
         await queryRunner.query(`-- sql
             UPDATE posts_gdocs_x_images pxi
             JOIN posts_gdocs pg ON pxi.gdocId = pg.id
@@ -33,6 +33,32 @@ export class AddContextToPostsGdocsXImages1776165276305 implements MigrationInte
                 AND i.filename != COALESCE(pg.content->>'$."featured-image"', '')
                 AND i.filename != COALESCE(pg.content->>'$."cover-image"', '')
                 -- And does NOT appear as genuine inline body content
+                AND NOT (
+                    JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body') IS NOT NULL
+                    AND JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].primary[*].value.filename') IS NULL
+                    AND JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].secondary[*].value.filename') IS NULL
+                    AND JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].rows[*].articles[*].value.filename') IS NULL
+                    AND JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].more.articles[*].value.filename') IS NULL
+                    AND JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].latest.articles[*].value.filename') IS NULL
+                    AND JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].thumbnail') IS NULL
+                    AND JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].left[*].thumbnail') IS NULL
+                    AND JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].right[*].thumbnail') IS NULL
+                    AND JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].insights[*].content[*].thumbnail') IS NULL
+                )
+        `)
+
+        // Backfill: mark featured-image and cover-image rows as 'article-thumbnail'
+        // unless the same image also appears as genuine inline body content.
+        await queryRunner.query(`-- sql
+            UPDATE posts_gdocs_x_images pxi
+            JOIN posts_gdocs pg ON pxi.gdocId = pg.id
+            JOIN images i ON pxi.imageId = i.id
+            SET pxi.context = 'article-thumbnail'
+            WHERE
+                (
+                    i.filename = pg.content->>'$."featured-image"'
+                    OR i.filename = pg.content->>'$."cover-image"'
+                )
                 AND NOT (
                     JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body') IS NOT NULL
                     AND JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].primary[*].value.filename') IS NULL

--- a/db/migration/1776165276305-AddContextToPostsGdocsXImages.ts
+++ b/db/migration/1776165276305-AddContextToPostsGdocsXImages.ts
@@ -1,8 +1,6 @@
 import { MigrationInterface, QueryRunner } from "typeorm"
 
-export class AddContextToPostsGdocsXImages1776165276305
-    implements MigrationInterface
-{
+export class AddContextToPostsGdocsXImages1776165276305 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`-- sql
             ALTER TABLE posts_gdocs_x_images

--- a/db/migration/1776165276305-AddContextToPostsGdocsXImages.ts
+++ b/db/migration/1776165276305-AddContextToPostsGdocsXImages.ts
@@ -1,6 +1,8 @@
 import { MigrationInterface, QueryRunner } from "typeorm"
 
-export class AddContextToPostsGdocsXImages1776165276305 implements MigrationInterface {
+export class AddContextToPostsGdocsXImages1776165276305
+    implements MigrationInterface
+{
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`-- sql
             ALTER TABLE posts_gdocs_x_images
@@ -17,12 +19,17 @@ export class AddContextToPostsGdocsXImages1776165276305 implements MigrationInte
             SET pxi.context = 'article-thumbnail'
             WHERE
                 -- Appears in at least one article-reference slot
+                -- (R&W links or prominent-link thumbnails)
                 (
                     JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].primary[*].value.filename') IS NOT NULL
                     OR JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].secondary[*].value.filename') IS NOT NULL
                     OR JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].rows[*].articles[*].value.filename') IS NOT NULL
                     OR JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].more.articles[*].value.filename') IS NOT NULL
                     OR JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].latest.articles[*].value.filename') IS NOT NULL
+                    OR JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].thumbnail') IS NOT NULL
+                    OR JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].left[*].thumbnail') IS NOT NULL
+                    OR JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].right[*].thumbnail') IS NOT NULL
+                    OR JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].insights[*].content[*].thumbnail') IS NOT NULL
                 )
                 -- But is NOT the article's own featured image
                 AND i.filename != COALESCE(pg.content->>'$."featured-image"', '')
@@ -35,6 +42,10 @@ export class AddContextToPostsGdocsXImages1776165276305 implements MigrationInte
                     AND JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].rows[*].articles[*].value.filename') IS NULL
                     AND JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].more.articles[*].value.filename') IS NULL
                     AND JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].latest.articles[*].value.filename') IS NULL
+                    AND JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].thumbnail') IS NULL
+                    AND JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].left[*].thumbnail') IS NULL
+                    AND JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].right[*].thumbnail') IS NULL
+                    AND JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].insights[*].content[*].thumbnail') IS NULL
                 )
         `)
     }

--- a/db/migration/1776165276305-AddContextToPostsGdocsXImages.ts
+++ b/db/migration/1776165276305-AddContextToPostsGdocsXImages.ts
@@ -6,6 +6,37 @@ export class AddContextToPostsGdocsXImages1776165276305 implements MigrationInte
             ALTER TABLE posts_gdocs_x_images
             ADD COLUMN context ENUM('content', 'article-thumbnail') NOT NULL DEFAULT 'content'
         `)
+
+        // Backfill: mark existing rows as 'article-thumbnail' where the image
+        // appears only in article-reference slots (R&W blocks, prominent-link
+        // thumbnails) and not as genuine content (featured-image or inline body).
+        await queryRunner.query(`-- sql
+            UPDATE posts_gdocs_x_images pxi
+            JOIN posts_gdocs pg ON pxi.gdocId = pg.id
+            JOIN images i ON pxi.imageId = i.id
+            SET pxi.context = 'article-thumbnail'
+            WHERE
+                -- Appears in at least one article-reference slot
+                (
+                    JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].primary[*].value.filename') IS NOT NULL
+                    OR JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].secondary[*].value.filename') IS NOT NULL
+                    OR JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].rows[*].articles[*].value.filename') IS NOT NULL
+                    OR JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].more.articles[*].value.filename') IS NOT NULL
+                    OR JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].latest.articles[*].value.filename') IS NOT NULL
+                )
+                -- But is NOT the article's own featured image
+                AND i.filename != COALESCE(pg.content->>'$."featured-image"', '')
+                AND i.filename != COALESCE(pg.content->>'$."cover-image"', '')
+                -- And does NOT appear as genuine inline body content
+                AND NOT (
+                    JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body') IS NOT NULL
+                    AND JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].primary[*].value.filename') IS NULL
+                    AND JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].secondary[*].value.filename') IS NULL
+                    AND JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].rows[*].articles[*].value.filename') IS NULL
+                    AND JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].more.articles[*].value.filename') IS NULL
+                    AND JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].latest.articles[*].value.filename') IS NULL
+                )
+        `)
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {

--- a/db/migration/1776165276305-AddContextToPostsGdocsXImages.ts
+++ b/db/migration/1776165276305-AddContextToPostsGdocsXImages.ts
@@ -33,17 +33,15 @@ export class AddContextToPostsGdocsXImages1776165276305 implements MigrationInte
                 AND i.filename != COALESCE(pg.content->>'$."featured-image"', '')
                 AND i.filename != COALESCE(pg.content->>'$."cover-image"', '')
                 -- And does NOT appear as genuine inline body content
+                -- (image/video block, key-insights insight image, chart-rows image,
+                --  pull-chart image, person image, homepage-intro featured work)
                 AND NOT (
-                    JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body') IS NOT NULL
-                    AND JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].primary[*].value.filename') IS NULL
-                    AND JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].secondary[*].value.filename') IS NULL
-                    AND JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].rows[*].articles[*].value.filename') IS NULL
-                    AND JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].more.articles[*].value.filename') IS NULL
-                    AND JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].latest.articles[*].value.filename') IS NULL
-                    AND JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].thumbnail') IS NULL
-                    AND JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].left[*].thumbnail') IS NULL
-                    AND JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].right[*].thumbnail') IS NULL
-                    AND JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].insights[*].content[*].thumbnail') IS NULL
+                    JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].filename') IS NOT NULL
+                    OR JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].smallFilename') IS NOT NULL
+                    OR JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].insights[*].filename') IS NOT NULL
+                    OR JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].featuredWork[*].filename') IS NOT NULL
+                    OR JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].rows[*].image') IS NOT NULL
+                    OR JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].image') IS NOT NULL
                 )
         `)
 
@@ -60,16 +58,12 @@ export class AddContextToPostsGdocsXImages1776165276305 implements MigrationInte
                     OR i.filename = pg.content->>'$."cover-image"'
                 )
                 AND NOT (
-                    JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body') IS NOT NULL
-                    AND JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].primary[*].value.filename') IS NULL
-                    AND JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].secondary[*].value.filename') IS NULL
-                    AND JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].rows[*].articles[*].value.filename') IS NULL
-                    AND JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].more.articles[*].value.filename') IS NULL
-                    AND JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].latest.articles[*].value.filename') IS NULL
-                    AND JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].thumbnail') IS NULL
-                    AND JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].left[*].thumbnail') IS NULL
-                    AND JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].right[*].thumbnail') IS NULL
-                    AND JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].insights[*].content[*].thumbnail') IS NULL
+                    JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].filename') IS NOT NULL
+                    OR JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].smallFilename') IS NOT NULL
+                    OR JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].insights[*].filename') IS NOT NULL
+                    OR JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].featuredWork[*].filename') IS NOT NULL
+                    OR JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].rows[*].image') IS NOT NULL
+                    OR JSON_SEARCH(pg.content, 'one', i.filename, NULL, '$.body[*].image') IS NOT NULL
                 )
         `)
     }

--- a/db/migration/1776165276305-AddContextToPostsGdocsXImages.ts
+++ b/db/migration/1776165276305-AddContextToPostsGdocsXImages.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class AddContextToPostsGdocsXImages1776165276305
+    implements MigrationInterface
+{
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`-- sql
+            ALTER TABLE posts_gdocs_x_images
+            ADD COLUMN context ENUM('content', 'article-thumbnail') NOT NULL DEFAULT 'content'
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`-- sql
+            ALTER TABLE posts_gdocs_x_images
+            DROP COLUMN context
+        `)
+    }
+}

--- a/db/model/Gdoc/GdocBase.ts
+++ b/db/model/Gdoc/GdocBase.ts
@@ -39,6 +39,7 @@ import { EXPLORERS_ROUTE_FOLDER } from "@ourworldindata/explorer"
 import { match, P } from "ts-pattern"
 import {
     extractFilenamesFromBlock,
+    type FilenameWithContext,
     extractUrl,
     getAllLinksFromResearchAndWritingBlock,
     spansToSimpleString,
@@ -347,26 +348,36 @@ export class GdocBase implements OwidGdocBaseInterface {
         }
     }
 
-    get filenames(): string[] {
-        const filenames: Set<string> = new Set()
+    get filenamesWithContext(): FilenameWithContext[] {
+        const results = new Map<string, FilenameWithContext>()
 
         for (const filename of this.typeSpecificFilenames()) {
             if (filename) {
-                filenames.add(filename)
+                results.set(filename, { filename, context: "content" })
             }
         }
 
         for (const enrichedBlockSource of this.enrichedBlockSources) {
             enrichedBlockSource.forEach((block) =>
                 traverseEnrichedBlock(block, (block) => {
-                    for (const filename of extractFilenamesFromBlock(block)) {
-                        filenames.add(filename)
+                    for (const item of extractFilenamesFromBlock(block)) {
+                        // Prefer 'content' if the same filename appears in multiple contexts
+                        if (
+                            !results.has(item.filename) ||
+                            item.context === "content"
+                        ) {
+                            results.set(item.filename, item)
+                        }
                     }
                 })
             )
         }
 
-        return [...filenames]
+        return [...results.values()]
+    }
+
+    get filenames(): string[] {
+        return this.filenamesWithContext.map((item) => item.filename)
     }
 
     get details(): string[] {

--- a/db/model/Gdoc/GdocBase.ts
+++ b/db/model/Gdoc/GdocBase.ts
@@ -353,7 +353,10 @@ export class GdocBase implements OwidGdocBaseInterface {
 
         for (const filename of this.typeSpecificFilenames()) {
             if (filename) {
-                results.set(filename, { filename, context: "content" })
+                results.set(filename, {
+                    filename,
+                    context: "article-thumbnail",
+                })
             }
         }
 

--- a/db/model/Gdoc/GdocFactory.ts
+++ b/db/model/Gdoc/GdocFactory.ts
@@ -575,7 +575,7 @@ export async function getLatestDataInsights(
     for (const dataInsight of dataInsights) {
         for (const block of dataInsight.content.body) {
             traverseEnrichedBlock(block, (block) => {
-                for (const filename of extractFilenamesFromBlock(block)) {
+                for (const { filename } of extractFilenamesFromBlock(block)) {
                     filenames.add(filename)
                 }
             })
@@ -803,16 +803,22 @@ export async function setImagesInContentGraph(
     const id = gdoc.id
     // Deleting and recreating these is simpler than tracking orphans over the next code block
     await trx.table(PostsGdocsXImagesTableName).where({ gdocId: id }).delete()
-    const filenames = gdoc.filenames
+    const filenamesWithContext = gdoc.filenamesWithContext
 
     // Includes fragments so that images in data pages are also tracked
-    if (filenames.length && gdoc.published) {
-        const images = await getImageMetadataByFilenames(trx, filenames)
+    if (filenamesWithContext.length && gdoc.published) {
+        const contextByFilename = new Map(
+            filenamesWithContext.map((item) => [item.filename, item.context])
+        )
+        const images = await getImageMetadataByFilenames(trx, [
+            ...contextByFilename.keys(),
+        ])
         const gdocXImagesToInsert: DbInsertPostGdocXImage[] = []
         for (const image of Object.values(images)) {
             gdocXImagesToInsert.push({
                 gdocId: gdoc.id,
                 imageId: image.id,
+                context: contextByFilename.get(image.filename) ?? "content",
             })
         }
         try {

--- a/db/model/Gdoc/gdocUtils.ts
+++ b/db/model/Gdoc/gdocUtils.ts
@@ -13,6 +13,7 @@ import {
     SpanCallout,
     CalloutFunction,
     CALLOUT_FUNCTIONS,
+    type ImageContext,
 } from "@ourworldindata/types"
 import { match, P } from "ts-pattern"
 import * as cheerio from "cheerio"
@@ -199,29 +200,39 @@ export function calculateDataInsightIndexPageCount(
     return Math.ceil(publishedDataInsightCount / DATA_INSIGHTS_INDEX_PAGE_SIZE)
 }
 
+export type FilenameWithContext = { filename: string; context: ImageContext }
+
 export function extractFilenamesFromBlock(
     item: OwidEnrichedGdocBlock
-): string[] {
-    const filenames = new Set<string>()
+): FilenameWithContext[] {
+    const results = new Map<string, FilenameWithContext>()
+
+    function add(filename: string, context: ImageContext): void {
+        // Prefer 'content' if the same filename appears in multiple contexts
+        if (!results.has(filename) || context === "content") {
+            results.set(filename, { filename, context })
+        }
+    }
+
     match(item)
         .with({ type: "image" }, (item) => {
-            if (item.filename) filenames.add(item.filename)
-            if (item.smallFilename) filenames.add(item.smallFilename)
+            if (item.filename) add(item.filename, "content")
+            if (item.smallFilename) add(item.smallFilename, "content")
         })
         .with({ type: "person" }, (item) => {
-            if (item.image) filenames.add(item.image)
+            if (item.image) add(item.image, "content")
         })
         .with({ type: "prominent-link" }, (item) => {
-            if (item.thumbnail) filenames.add(item.thumbnail)
+            if (item.thumbnail) add(item.thumbnail, "article-thumbnail")
         })
         .with({ type: "video" }, (item) => {
-            if (item.filename) filenames.add(item.filename)
+            if (item.filename) add(item.filename, "content")
         })
         .with({ type: "research-and-writing" }, (item) => {
             getAllLinksFromResearchAndWritingBlock(item).forEach(
                 (link: EnrichedBlockResearchAndWritingLink) => {
                     if (link.value.filename) {
-                        filenames.add(link.value.filename)
+                        add(link.value.filename, "article-thumbnail")
                     }
                 }
             )
@@ -229,7 +240,7 @@ export function extractFilenamesFromBlock(
         .with({ type: "key-insights" }, (item) => {
             item.insights.forEach((insight) => {
                 if (insight.filename) {
-                    filenames.add(insight.filename)
+                    add(insight.filename, "content")
                 }
             })
         })
@@ -240,7 +251,7 @@ export function extractFilenamesFromBlock(
             (item) => {
                 item.featuredWork.forEach((featuredWork) => {
                     if (featuredWork.filename) {
-                        filenames.add(featuredWork.filename)
+                        add(featuredWork.filename, "content")
                     }
                 })
             }
@@ -310,14 +321,14 @@ export function extractFilenamesFromBlock(
         )
         .with({ type: "chart-rows" }, (item) => {
             item.rows.forEach((row) => {
-                if (row.image) filenames.add(row.image)
+                if (row.image) add(row.image, "content")
             })
         })
         .with({ type: "pull-chart" }, (item) => {
-            if (item.image) filenames.add(item.image)
+            if (item.image) add(item.image, "content")
         })
         .exhaustive()
-    return [...filenames]
+    return [...results.values()]
 }
 
 /**

--- a/packages/@ourworldindata/types/src/dbTypes/Images.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/Images.ts
@@ -37,9 +37,8 @@ export type DbEnrichedImageWithUserId = DbEnrichedImage & {
 
 export type DbEnrichedImageWithPageviews = DbEnrichedImageWithUserId & {
     views_365d: number
-    isFeaturedImage: number
     isBodyContent: number
-    isInResearchAndWriting: number
+    isArticleThumbnail: number
 }
 
 export function parseImageRow(row: DbRawImage): DbEnrichedImage {

--- a/packages/@ourworldindata/types/src/dbTypes/PostsGdocsXImages.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/PostsGdocsXImages.ts
@@ -1,7 +1,11 @@
 export const PostsGdocsXImagesTableName = "posts_gdocs_x_images"
+
+export type ImageContext = "content" | "article-thumbnail"
+
 export interface DbInsertPostGdocXImage {
     gdocId: string
     id?: number
     imageId: number
+    context: ImageContext
 }
 export type DbPlainPostGdocXImage = Required<DbInsertPostGdocXImage>

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -590,6 +590,7 @@ export {
 export {
     type DbPlainPostGdocXImage,
     type DbInsertPostGdocXImage,
+    type ImageContext,
     PostsGdocsXImagesTableName,
 } from "./dbTypes/PostsGdocsXImages.js"
 export {


### PR DESCRIPTION
## Context

Some older articles use static images as thumbnails in R&W blocks. This is an outdated practice but it significantly inflates view counts for a small number of affected images. For example, `Famine-victims-and-world-population-since-1860.png` currently accumulated views from the Population Growth topic page simply because it appears there as a small, unreadable thumbnail. These are not meaningful views.

Although we no longer do this, these instances still exist and we should exclude them so we can correctly identify our most viewed static images. 

This PR makes them easier to identify and excludes their views from the pageview count. 

## What this PR does

1. Adds a `context` column (`'content'` | `'article-thumbnail'`) to `posts_gdocs_x_images`, recording how each image is used per article. The same image can be `'content'` in one article and `'article-thumbnail'` in another.
2. `views_365d` now only sums pageviews where `context = 'content'`. Featured/cover images are also classified as `'article-thumbnail'`.
3. Adds a **"Used in both content and thumbnail"** filter to the admin images page so we can easily find these cases.

## Testing guidance

1. Go to `/admin/images`
2. Images with "thumbnail" in their name (e.g. `risk-ratios-thumbnail.png`) should appear only under **Thumbnails or featured images** with **Views per day** of 0
3. `Population-cartogram_World.png` — used as inline content on its own article but also as an R&W thumbnail on Population Growth — should appear under **Content** but now the views should reflect only its own article (much lower in many cases as in admin). A few more examples to check:
   - `Population-Pyramid-1950-to-2100.jpg`
   - `Emissions-by-sector-–-pie-charts.png`
   - `Demographic-Impact-of-China's-Great-Leap-Forward-Famine.png`

4. **"Used in both content and thumbnail"** filter should show the same images as above genuine content in one article but a thumbnail reference in another. This filter is also useful for finding instances where we may want to replace the thumbnails on those articles. 

Note: the `'article-thumbnail'` classification also covers featured images on author pages, which are not really the problem we're solving here. It's unclear whether this is worth solving given there are relatively few such cases. 

This code was largely written by Claude. I reviewed it by looking for edge cases and verifying the exclusions, but a thorough review would be appreciated and any improvements are welcome.