### PR TITLE
🐛 fix overlapping vertical comparison labels

### DIFF
--- a/packages/@ourworldindata/grapher/src/axis/Axis.ts
+++ b/packages/@ourworldindata/grapher/src/axis/Axis.ts
@@ -21,13 +21,12 @@ import { MarkdownTextWrap } from "@ourworldindata/components"
 import { CoreColumn } from "@ourworldindata/core-table"
 import {
     DEFAULT_GRAPHER_BOUNDS,
-    GRAPHER_FONT_SCALE_10_5,
     GRAPHER_FONT_SCALE_11,
     GRAPHER_FONT_SCALE_12,
 } from "../core/GrapherConstants.js"
 import { makeAxisLabel } from "./AxisUtils.js"
 import * as R from "remeda"
-import { isValidVerticalComparisonLineConfig } from "../comparisonLine/ComparisonLineHelpers"
+import { ComparisonLines } from "../comparisonLine/ComparisonLines"
 
 interface TickLabelPlacement {
     value: number
@@ -867,6 +866,7 @@ interface DualAxisProps {
 // space to work with, and vice versa
 export class DualAxis {
     private readonly props: DualAxisProps
+
     constructor(props: DualAxisProps) {
         makeObservable(this)
         this.props = props
@@ -911,7 +911,7 @@ export class DualAxis {
                 // Make space for the y-axis label if plotted above the axis
                 .padTop(this.props.verticalAxis.labelOffsetTop)
                 // Make space for vertical comparison line labels if any
-                .padTop(this.comparisonLineLabelOffset)
+                .padTop(this.comparisonLines.topPadding)
                 .padTop(
                     this.shouldShowLogNotice
                         ? this.props.verticalAxis.logNoticeHeight
@@ -924,24 +924,11 @@ export class DualAxis {
         return this.props.bounds ?? DEFAULT_GRAPHER_BOUNDS
     }
 
-    @computed get comparisonLines(): ComparisonLineConfig[] {
-        return this.props.comparisonLines ?? []
-    }
-
-    @computed get comparisonLineLabelFontSize(): number {
-        return Math.floor(
-            GRAPHER_FONT_SCALE_10_5 * this.props.verticalAxis.fontSize
-        )
-    }
-
-    @computed private get comparisonLineLabelOffset(): number {
-        const hasVerticalComparisonLines = this.comparisonLines.some((line) =>
-            isValidVerticalComparisonLineConfig(line)
-        )
-
-        if (!hasVerticalComparisonLines) return 0
-
-        return this.comparisonLineLabelFontSize
+    @computed get comparisonLines(): ComparisonLines {
+        return new ComparisonLines(this.props.comparisonLines ?? [], {
+            dualAxis: this,
+            fontSize: this.props.verticalAxis.fontSize,
+        })
     }
 
     @computed private get shouldShowLogNotice(): boolean {

--- a/packages/@ourworldindata/grapher/src/axis/AxisViews.tsx
+++ b/packages/@ourworldindata/grapher/src/axis/AxisViews.tsx
@@ -286,14 +286,16 @@ export class DualAxisComponent extends React.Component<DualAxisViewProps> {
             />
         )
 
-        const comparisonLines = dualAxis.comparisonLines.map((line, index) => (
-            <ComparisonLine
-                key={`${line.label}-${index}`}
-                dualAxis={dualAxis}
-                comparisonLine={line}
-                backgroundColor={backgroundColor}
-            />
-        ))
+        const comparisonLines = dualAxis.comparisonLines.lines.map(
+            (line, index) => (
+                <ComparisonLine
+                    key={`${line.label}-${index}`}
+                    dualAxis={dualAxis}
+                    comparisonLine={line}
+                    backgroundColor={backgroundColor}
+                />
+            )
+        )
 
         return (
             <>

--- a/packages/@ourworldindata/grapher/src/comparisonLine/ComparisonLines.ts
+++ b/packages/@ourworldindata/grapher/src/comparisonLine/ComparisonLines.ts
@@ -1,0 +1,130 @@
+import * as _ from "lodash-es"
+import { computed, makeObservable } from "mobx"
+import { Bounds } from "@ourworldindata/utils"
+import {
+    ComparisonLineConfig,
+    VerticalComparisonLineConfig,
+    VerticalComparisonLineLabelPlacement,
+} from "@ourworldindata/types"
+import { isValidVerticalComparisonLineConfig } from "./ComparisonLineHelpers"
+import { GRAPHER_FONT_SCALE_10_5 } from "../core/GrapherConstants.js"
+import type { DualAxis } from "../axis/Axis"
+
+/** Manages comparison line configs and their layout */
+export class ComparisonLines {
+    private readonly dualAxis: DualAxis
+    readonly lines: ComparisonLineConfig[]
+    private readonly baseFontSize: number
+
+    constructor(
+        lines: ComparisonLineConfig[],
+        options: { fontSize: number; dualAxis: DualAxis }
+    ) {
+        makeObservable(this)
+
+        this.lines = lines
+        this.dualAxis = options.dualAxis
+        this.baseFontSize = options.fontSize
+    }
+
+    @computed get fontSize(): number {
+        return Math.floor(GRAPHER_FONT_SCALE_10_5 * this.baseFontSize)
+    }
+
+    /** Space reserved above the chart area for vertical comparison line labels */
+    @computed get topPadding(): number {
+        const hasVerticalComparisonLines = this.lines.some((line) =>
+            isValidVerticalComparisonLineConfig(line)
+        )
+
+        if (!hasVerticalComparisonLines) return 0
+
+        return this.fontSize
+    }
+
+    @computed get verticalLineLabelPlacements(): Map<
+        number,
+        VerticalComparisonLineLabelPlacement | undefined
+    > {
+        // Line label placements keyed by the xEquals
+        const placements = new Map<
+            number,
+            VerticalComparisonLineLabelPlacement | undefined
+        >()
+
+        // Get unique vertical lines by xEquals (lines with the same xEquals are ignored)
+        const verticalLines = _.uniqBy(
+            this.lines.filter((line): line is VerticalComparisonLineConfig =>
+                isValidVerticalComparisonLineConfig(line)
+            ),
+            (line) => line.xEquals
+        )
+
+        if (verticalLines.length === 0) return placements
+
+        const { horizontalAxis, innerBounds } = this.dualAxis
+        const [minX, maxX] = horizontalAxis.domain
+        const fontSize = this.fontSize
+        const padding = 4
+
+        // Sort by x position and filter to lines within bounds
+        const sortedLines = _.sortBy(
+            verticalLines.filter(
+                (line) => line.xEquals >= minX && line.xEquals <= maxX
+            ),
+            (line) => line.xEquals
+        )
+
+        // Track the rightmost x-coordinate already claimed by a placed label
+        let occupiedRight = innerBounds.left
+
+        for (let i = 0; i < sortedLines.length; i++) {
+            const line = sortedLines[i]
+
+            const x = horizontalAxis.place(line.xEquals)
+
+            // No need to place a label if there isn't one, but we still
+            // need to prevent future labels from overlapping the line itself
+            if (!line.label) {
+                occupiedRight = Math.max(occupiedRight, x)
+                continue
+            }
+
+            const labelWidth = Bounds.forText(line.label, { fontSize }).width
+
+            // Right boundary: next line's position, or chart edge
+            const nextLineX =
+                i < sortedLines.length - 1
+                    ? horizontalAxis.place(sortedLines[i + 1].xEquals)
+                    : innerBounds.right
+
+            const rightBound = Math.min(nextLineX, innerBounds.right)
+            const leftBound = Math.max(occupiedRight, innerBounds.left)
+
+            const availableRight = rightBound - x - 2 * padding
+            const availableLeft = x - leftBound - 2 * padding
+
+            if (labelWidth <= availableRight) {
+                // Prefer placing the label to the right of the line, if there's space
+                placements.set(line.xEquals, {
+                    x: x + padding,
+                    anchor: "start",
+                })
+
+                // Claim the space this label occupies
+                occupiedRight = x + padding + labelWidth + padding
+            } else if (labelWidth <= availableLeft) {
+                // Otherwise, if there's space on the left, place it there
+                placements.set(line.xEquals, { x: x - padding, anchor: "end" })
+
+                // Prevent future labels from overlapping the line itself
+                occupiedRight = Math.max(occupiedRight, x)
+            } else {
+                // Prevent future labels from overlapping the line itself
+                occupiedRight = Math.max(occupiedRight, x)
+            }
+        }
+
+        return placements
+    }
+}

--- a/packages/@ourworldindata/grapher/src/comparisonLine/CustomComparisonLine.tsx
+++ b/packages/@ourworldindata/grapher/src/comparisonLine/CustomComparisonLine.tsx
@@ -27,7 +27,7 @@ export class CustomComparisonLine extends React.Component<
     }
 
     @computed private get fontSize(): number {
-        return this.props.dualAxis.comparisonLineLabelFontSize
+        return this.props.dualAxis.comparisonLines.fontSize
     }
 
     @computed private get haloOutlineWidth(): number {

--- a/packages/@ourworldindata/grapher/src/comparisonLine/VerticalComparisonLine.tsx
+++ b/packages/@ourworldindata/grapher/src/comparisonLine/VerticalComparisonLine.tsx
@@ -1,20 +1,17 @@
 import * as React from "react"
 import { computed, makeObservable } from "mobx"
 import { observer } from "mobx-react"
-import * as _ from "lodash-es"
-import {
-    Bounds,
-    dyFromAlign,
-    makeFigmaId,
-    VerticalAlign,
-} from "@ourworldindata/utils"
+import { dyFromAlign, makeFigmaId, VerticalAlign } from "@ourworldindata/utils"
 import {
     COMPARISON_LINE_STYLE,
     COMPARISON_LINE_LABEL_STYLE,
 } from "./ComparisonLineConstants"
 import { ComparisonLineProps } from "./ComparisonLine"
-import { VerticalComparisonLineConfig } from "@ourworldindata/types"
-import { isValidVerticalComparisonLineConfig } from "./ComparisonLineHelpers"
+import {
+    VerticalComparisonLineConfig,
+    VerticalComparisonLineLabelPlacement,
+} from "@ourworldindata/types"
+import { ComparisonLines } from "./ComparisonLines"
 
 @observer
 export class VerticalComparisonLine extends React.Component<
@@ -25,8 +22,20 @@ export class VerticalComparisonLine extends React.Component<
         makeObservable(this)
     }
 
+    @computed private get comparisonLines(): ComparisonLines {
+        return this.props.dualAxis.comparisonLines
+    }
+
     @computed private get fontSize(): number {
-        return this.props.dualAxis.comparisonLineLabelFontSize
+        return this.comparisonLines.fontSize
+    }
+
+    @computed private get placement():
+        | VerticalComparisonLineLabelPlacement
+        | undefined {
+        return this.comparisonLines.verticalLineLabelPlacements.get(
+            this.lineConfig.xEquals
+        )
     }
 
     @computed private get labelHeight(): number {
@@ -36,71 +45,6 @@ export class VerticalComparisonLine extends React.Component<
 
     @computed private get lineConfig(): VerticalComparisonLineConfig {
         return this.props.comparisonLine
-    }
-
-    @computed
-    private get otherVerticalComparisonLines(): VerticalComparisonLineConfig[] {
-        return this.props.dualAxis.comparisonLines.filter(
-            (lineConfig): lineConfig is VerticalComparisonLineConfig =>
-                isValidVerticalComparisonLineConfig(lineConfig) &&
-                lineConfig.xEquals !== this.props.comparisonLine.xEquals
-        )
-    }
-
-    /** Nearest comparison line to the left of this line */
-    @computed private get closestLeftLine():
-        | VerticalComparisonLineConfig
-        | undefined {
-        const linesOnTheLeft = this.otherVerticalComparisonLines.filter(
-            (otherLine) => otherLine.xEquals < this.lineConfig.xEquals
-        )
-        return _.maxBy(linesOnTheLeft, (line) => line.xEquals)
-    }
-
-    /** Nearest comparison line to the right of this line */
-    @computed private get closestRightLine():
-        | VerticalComparisonLineConfig
-        | undefined {
-        const linesOnTheRight = this.otherVerticalComparisonLines.filter(
-            (otherLine) => otherLine.xEquals > this.lineConfig.xEquals
-        )
-        return _.minBy(linesOnTheRight, (line) => line.xEquals)
-    }
-
-    /**
-     * X-coordinate of the leftmost boundary for label placement.
-     *
-     * Either the position of the nearest comparison line on the left
-     * or the chart's bound.
-     */
-    @computed private get leftBoundX(): number {
-        const { closestLeftLine } = this
-        const { innerBounds, horizontalAxis } = this.props.dualAxis
-
-        if (!closestLeftLine) return innerBounds.left
-
-        return Math.max(
-            horizontalAxis.place(closestLeftLine.xEquals),
-            innerBounds.left
-        )
-    }
-
-    /**
-     * X-coordinate of the rightmost boundary for label placement.
-     *
-     * Either the position of the nearest comparison line on the right
-     * or the chart's bound.
-     */
-    @computed private get rightBoundX(): number {
-        const { closestRightLine } = this
-        const { innerBounds, horizontalAxis } = this.props.dualAxis
-
-        if (!closestRightLine) return innerBounds.right
-
-        return Math.min(
-            horizontalAxis.place(closestRightLine.xEquals),
-            innerBounds.right
-        )
     }
 
     /** Screen coordinates for rendering the vertical line */
@@ -129,38 +73,15 @@ export class VerticalComparisonLine extends React.Component<
     @computed private get labelPosition():
         | { x: number; y: number; anchor: "start" | "end" }
         | undefined {
-        const { fontSize, lineCoordinates, rightBoundX, leftBoundX } = this
-        const { label } = this.lineConfig
+        const { lineCoordinates, placement } = this
 
-        if (!label || !lineCoordinates) return undefined
+        if (!lineCoordinates || !placement) return undefined
 
-        const { x, y1: y } = lineCoordinates
-
-        // Calculate available space on both sides
-        const padding = 4 // padding between label and line
-        const availableSpaceRight = rightBoundX - x - 2 * padding
-        const availableSpaceLeft = x - leftBoundX - 2 * padding
-
-        // Determine label placement:
-        // - Prefer the right side if there's enough space
-        // - Otherwise, try placing the label on the left side
-        // - If neither side has enough space, hide the label
-        const labelWidth = Bounds.forText(label, { fontSize }).width
-        const side =
-            labelWidth <= availableSpaceRight
-                ? "right"
-                : labelWidth <= availableSpaceLeft
-                  ? "left"
-                  : null
-
-        // Can't fit the label
-        if (side === null) return undefined
-
-        // Add a bit of padding between label and line and determine text anchor
-        const labelX = side === "right" ? x + padding : x - padding
-        const anchor = side === "right" ? "start" : "end"
-
-        return { x: labelX, y, anchor }
+        return {
+            x: placement.x,
+            y: lineCoordinates.y1,
+            anchor: placement.anchor,
+        }
     }
 
     private renderLabel(): React.ReactElement | null {
@@ -183,7 +104,7 @@ export class VerticalComparisonLine extends React.Component<
     }
 
     override render(): React.ReactElement | null {
-        if (!this.lineCoordinates || !this.labelPosition) return null
+        if (!this.lineCoordinates) return null
 
         const { x, y1, y2 } = this.lineCoordinates
 

--- a/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
+++ b/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
@@ -364,6 +364,11 @@ export type ComparisonLineConfig =
     | VerticalComparisonLineConfig
     | CustomComparisonLineConfig
 
+export interface VerticalComparisonLineLabelPlacement {
+    x: number
+    anchor: "start" | "end"
+}
+
 export enum LogoOption {
     owid = "owid",
     "core+owid" = "core+owid",

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -121,6 +121,7 @@ export {
     type ComparisonLineConfig,
     type VerticalComparisonLineConfig,
     type CustomComparisonLineConfig,
+    type VerticalComparisonLineLabelPlacement,
     type AxisConfigInterface,
     type ColorSchemeInterface,
     type Tickmark,


### PR DESCRIPTION
Resolves #6267 by hiding overlapping labels.

We could/should improve the placing algorithm by stacking labels vertically if they overlap, and potentially line-breaking single labels to make them fit (since we do have some long-ish labels)

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #6360 
- <kbd>&nbsp;1&nbsp;</kbd> #6359 👈 
<!-- GitButler Footer Boundary Bottom -->

