### PR TITLE
🔨 remove empty comparisonLines from configs

### DIFF
--- a/adminSiteClient/EditorCustomizeTab.tsx
+++ b/adminSiteClient/EditorCustomizeTab.tsx
@@ -575,13 +575,17 @@ class ComparisonLineSection<
     @action.bound onAddComparisonLine() {
         const { grapherState } = this.props.editor
         if (!grapherState.comparisonLines) grapherState.comparisonLines = []
-        grapherState.comparisonLines.push({})
+
+        // Default to adding a custom comparison line
+        grapherState.comparisonLines.push({ yEquals: "x" })
     }
 
     @action.bound onRemoveComparisonLine(index: number) {
         const { grapherState } = this.props.editor
-        if (!grapherState.comparisonLines) grapherState.comparisonLines = []
+        if (!grapherState.comparisonLines) return
         grapherState.comparisonLines.splice(index, 1)
+        if (grapherState.comparisonLines.length === 0)
+            grapherState.comparisonLines = undefined
     }
 
     @action.bound onComparisonLineTypeChange(

--- a/db/migration/1776176663970-RemoveEmptyComparisonLines.ts
+++ b/db/migration/1776176663970-RemoveEmptyComparisonLines.ts
@@ -1,0 +1,30 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class RemoveEmptyComparisonLines1776176663970 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        // Remove comparisonLines from chart configs where the value is
+        // an empty array ([]) or an array with only an empty object ([{}])
+        await queryRunner.query(`
+            -- sql
+            UPDATE chart_configs
+            SET
+                full = JSON_REMOVE(full, '$.comparisonLines')
+            WHERE
+                JSON_EXTRACT(full, '$.comparisonLines') = CAST('[]' AS JSON)
+                OR JSON_EXTRACT(full, '$.comparisonLines') = CAST('[{}]' AS JSON)
+        `)
+        await queryRunner.query(`
+            -- sql
+            UPDATE chart_configs
+            SET
+                patch = JSON_REMOVE(patch, '$.comparisonLines')
+            WHERE
+                JSON_EXTRACT(patch, '$.comparisonLines') = CAST('[]' AS JSON)
+                OR JSON_EXTRACT(patch, '$.comparisonLines') = CAST('[{}]' AS JSON)
+        `)
+    }
+
+    public async down(): Promise<void> {
+        // No-op, can't restore the removed empty comparisonLines
+    }
+}


### PR DESCRIPTION
I noticed that we write empty comparisonLines arrays into chart configs. Sometimes `[]`, but also `[{}]`.

The DB migration cleans up existing configs. The code changes make sure this doesn't happen in the future.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #6360 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #6359 
<!-- GitButler Footer Boundary Bottom -->

