### PR TITLE
🐛 (regions updater) avoid empty strings written into members array

### DIFF
--- a/devTools/regionsUpdater/update.ts
+++ b/devTools/regionsUpdater/update.ts
@@ -145,7 +145,7 @@ function csvToJson(val: string, col: string) {
             return val === "True"
 
         case "members":
-            return val?.split(";") || undefined
+            return val ? val.split(";") : undefined
 
         default:
             return val


### PR DESCRIPTION
See https://github.com/owid/owid-grapher/pull/6363/changes

Not sure why this started happening now