### PR TITLE
🐛 Resolve multi-dim redirects in SiteBaker prefetch step

### DIFF
--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -471,11 +471,19 @@ export class SiteBaker {
             }
 
             const multiDims = await getAllLinkedPublishedMultiDimDataPages(knex)
-            for (const { id, slug, config } of multiDims) {
+            for (const {
+                id,
+                slug,
+                config,
+                originalSlug,
+                queryStr,
+            } of multiDims) {
                 publishedCharts.push(
-                    makeMultiDimLinkedChart(config, slug, {
+                    makeMultiDimLinkedChart(config, originalSlug, {
                         archivedPageVersion:
                             archivedVersions.multiDims[id] || undefined,
+                        queryStr,
+                        resolvedSlug: originalSlug !== slug ? slug : undefined,
                     })
                 )
             }

--- a/db/model/MultiDimDataPage.ts
+++ b/db/model/MultiDimDataPage.ts
@@ -12,6 +12,7 @@ import {
     JsonString,
     MultiDimDataPageConfigEnriched,
 } from "@ourworldindata/types"
+import { buildQueryStrFromConfig } from "./MultiDimRedirects.js"
 
 /**
  * Returns zero if none of the inserted columns differs from the existing ones,
@@ -69,12 +70,23 @@ export const getAllPublishedMultiDimDataPagesBySlug = async (
     return new Map(multiDims.map((multiDim) => [multiDim.slug!, multiDim]))
 }
 
+export interface LinkedMultiDimDataPage {
+    id: number
+    slug: string
+    config: MultiDimDataPageConfigEnriched
+    /** The slug the gdoc author linked to. Equals `slug` for direct links,
+     *  or the old/redirected slug for links resolved via multi_dim_redirects. */
+    originalSlug: string
+    /** Query string derived from the viewConfigId in multi_dim_redirects,
+     *  only present for redirected links that target a specific view. */
+    queryStr?: string
+}
+
 export async function getAllLinkedPublishedMultiDimDataPages(
     knex: KnexReadonlyTransaction
-): Promise<
-    { id: number; slug: string; config: MultiDimDataPageConfigEnriched }[]
-> {
-    const rows = await knexRaw<
+): Promise<LinkedMultiDimDataPage[]> {
+    // 1. Direct links: the gdoc links to the multi-dim's current slug
+    const directRows = await knexRaw<
         Pick<DbPlainMultiDimDataPage, "config"> & { id: number; slug: string }
     >(
         knex,
@@ -88,7 +100,55 @@ export async function getAllLinkedPublishedMultiDimDataPages(
         WHERE pgl.linkType = '${ContentGraphLinkType.Grapher}'
         AND mddp.published = true`
     )
-    return rows.map(enrichRow)
+
+    // 2. Redirected links: the gdoc links to an old slug that redirects to a
+    //    multi-dim via multi_dim_redirects
+    const redirectedRows = await knexRaw<
+        Pick<DbPlainMultiDimDataPage, "config"> & {
+            id: number
+            slug: string
+            originalSlug: string
+            viewConfigId: string | null
+        }
+    >(
+        knex,
+        `-- sql
+        SELECT
+            mddp.id as id,
+            mddp.slug as slug,
+            mddp.config as config,
+            pgl.target as originalSlug,
+            mdr.viewConfigId as viewConfigId
+        FROM multi_dim_redirects mdr
+        JOIN multi_dim_data_pages mddp ON mddp.id = mdr.multiDimId
+        JOIN posts_gdocs_links pgl
+            ON pgl.target = REPLACE(mdr.source, '/grapher/', '')
+        WHERE pgl.linkType = '${ContentGraphLinkType.Grapher}'
+        AND mddp.published = true
+        AND mdr.source LIKE '/grapher/%'`
+    )
+
+    const directResults: LinkedMultiDimDataPage[] = directRows.map((row) => {
+        const enriched = enrichRow(row)
+        return { ...enriched, originalSlug: enriched.slug }
+    })
+
+    const redirectedResults: LinkedMultiDimDataPage[] = redirectedRows.map(
+        (row) => {
+            const { viewConfigId, originalSlug, ...rest } = row
+            const enriched = enrichRow(rest)
+            const queryStr = viewConfigId
+                ? buildQueryStrFromConfig(
+                      viewConfigId,
+                      rest.config,
+                      enriched.slug
+                  )
+                : undefined
+            return { ...enriched, originalSlug, queryStr }
+        }
+    )
+
+    return [...directResults, ...redirectedResults]
 }
 
 export async function getAllMultiDimDataPageSlugs(


### PR DESCRIPTION
## Context

The prefetcher wasn't interacting with `multi_dim_redirects`, so gdoc charts using URLs that had since been redirected to multi-dims were broken.

This PR fixes that by also resolving redirects in `getAllLinkedPublishedMultiDimDataPages` :

1. We find all multi-dim links in the `posts_gdocs_links` table
2. Resolve the corresponding multi-dim configs, keyed by their slugs
3. Select all multi-dim redirects whose `source` column matches a `posts_gdocs_link` target
4. Resolve the corresponding multi-dim configs, keyed by the original slug

This means that a gdoc that links to `/grapher/some-old-slug` will still resolve to `/grapher/the-new-multi-dim-slug`

But now I really want to work on https://github.com/owid/owid-grapher/issues/5951 next 😫 

## Testing guidance

Possibly fastest to test locally:
1. (On master) publish a test document with a `chart` component that links to a grapher
2. `yarn buildLocalBake --steps gdocPosts` and `yarn startLocalBakeServer`
4. Visit http://localhost:3000/your-test-article-slug and confirm the grapher renders
5. Create a redirect for that slug to some multi-dim in http://localhost:3030/admin/multi-dim-redirects
6. `yarn buildLocalBake --steps gdocPosts` and `yarn startLocalBakeServer`
7. Visit http://localhost:3000/your-test-article-slug and confirm that the chart doesn't resolve (it won't appear; you can also check `_OWID_GDOC_PROPS.linkedCharts` in the browser console)
8. Checkout this branch
9. `yarn buildLocalBake --steps gdocPosts` and `yarn startLocalBakeServer`
10. Visit http://localhost:3000/your-test-article-slug and confirm the chart resolves (It won't load properly because the localBakeServer doesn't serve multi-dim configs, but an empty Grapher component will appear and it will exist on `_OWID_GDOC_PROPS.linkedCharts`)

- [x] Does the change work in the archive? **I think the archive system works correctly**