### PR TITLE
🔨 add new tab options to config schema

### DIFF
--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.010.yaml
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.010.yaml
@@ -281,6 +281,9 @@ properties:
             - discrete-bar
             - marimekko
             - scatter
+            - stacked-area
+            - stacked-bar
+            - stacked-discrete-bar
     xAxis:
         $ref: "#/$defs/axis"
     yAxis:


### PR DESCRIPTION
I forgot to extend the allowed values for the `tab` config when I added switching between stacked charts