### PR TITLE
Mark all skills as internal to prevent external indexing

### DIFF
--- a/.claude/skills/add-synonym/SKILL.md
+++ b/.claude/skills/add-synonym/SKILL.md
@@ -2,7 +2,7 @@
 name: add-synonym
 description: Add search synonyms to the Algolia synonym list. Use when someone wants to add, update, or extend synonym groups for site search.
 metadata:
-  internal: true
+    internal: true
 ---
 
 # Add Search Synonyms

--- a/.claude/skills/add-synonym/SKILL.md
+++ b/.claude/skills/add-synonym/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: add-synonym
 description: Add search synonyms to the Algolia synonym list. Use when someone wants to add, update, or extend synonym groups for site search.
+metadata:
+  internal: true
 ---
 
 # Add Search Synonyms

--- a/.claude/skills/create-migration/SKILL.md
+++ b/.claude/skills/create-migration/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: create-migration
 description: Create a new database migration file for the OWID MySQL database. Use when the user needs to create a database schema change or migration.
+metadata:
+  internal: true
 ---
 
 # Create Database Migration

--- a/.claude/skills/create-migration/SKILL.md
+++ b/.claude/skills/create-migration/SKILL.md
@@ -2,7 +2,7 @@
 name: create-migration
 description: Create a new database migration file for the OWID MySQL database. Use when the user needs to create a database schema change or migration.
 metadata:
-  internal: true
+    internal: true
 ---
 
 # Create Database Migration

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,8 @@ When you have completed implementing a big set of changes, run `yarn fixFormatCh
 
 When you want to create a git commit, refer to docs/agent-guidelines/commit-messages.md for instructions.
 
+When creating new skills in `.claude/skills/`, always include `metadata: { internal: true }` in the SKILL.md frontmatter unless explicitly asked for the skill to be public. This prevents external skill indexes from crawling and listing our internal skills.
+
 ## Code style
 
 - We use double quotes for string literals instead of single quotes


### PR DESCRIPTION
## Motivation

Our `create-migration` skill is [extremely popular](https://skillsmp.com/skills/owid-owid-grapher-claude-skills-create-migration-skill-md) with >1500 stars. No idea where they come from (clawds I guess?)

## Summary

- Added `metadata: { internal: true }` to both skills in `.claude/skills/` (add-synonym, create-migration)
- Added a rule to CLAUDE.md requiring this flag on new skills by default

External skill marketplaces (skills.sh, skillsmp.com) were crawling our public repo and listing our internal skills. The `metadata.internal` flag is the standard mechanism from the [skills CLI](https://github.com/vercel-labs/skills) to hide skills from discovery.

Skills still work normally for anyone with the repo cloned.

## Test plan

- [ ] Verify skills still load in Claude Code
- [ ] Confirm `npx skills add owid/owid-grapher --list` no longer shows skills (without `INSTALL_INTERNAL_SKILLS=1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)