### PR TITLE
Lazy-load multi-dim gdoc embeds

### DIFF
--- a/site/DataPageV2Content.tsx
+++ b/site/DataPageV2Content.tsx
@@ -33,7 +33,7 @@ import { processRelatedResearch } from "./dataPage.js"
 import { GrapherWithFallback } from "./GrapherWithFallback.js"
 import { AttachmentsContext } from "./gdocs/AttachmentsContext.js"
 import { DocumentContext } from "./gdocs/DocumentContext.js"
-import { BlockQueryClientProvider } from "./gdocs/components/BlockQueryClientProvider.js"
+import { SiteQueryClientProvider } from "./SiteQueryClientProvider.js"
 import { useWindowQueryParams } from "./hooks.js"
 
 declare global {
@@ -269,14 +269,14 @@ export const DataPageV2Content = ({
                                         : ""
                                 }
                             >
-                                <BlockQueryClientProvider>
+                                <SiteQueryClientProvider>
                                     <FeaturedMetrics
                                         topicName={
                                             datapageData.primaryTopic.topicTag
                                         }
                                         isDataPage={true}
                                     />
-                                </BlockQueryClientProvider>
+                                </SiteQueryClientProvider>
                             </div>
                         )}
                     </div>

--- a/site/MultiDimEmbed.tsx
+++ b/site/MultiDimEmbed.tsx
@@ -1,74 +1,73 @@
-import { MultiDimDataPageConfigEnriched } from "@ourworldindata/types"
-import {
-    Url,
-    fetchWithRetry,
-    MultiDimDataPageConfig,
-} from "@ourworldindata/utils"
-import { useState, useEffect } from "react"
-import { MULTI_DIM_DYNAMIC_CONFIG_URL } from "../settings/clientSettings.js"
-import MultiDim from "./multiDim/MultiDim.js"
+import { useIntersectionObserver, useIsClient } from "usehooks-ts"
 import { GrapherProgrammaticInterface } from "@ourworldindata/grapher"
+import {
+    GRAPHER_PREVIEW_CLASS,
+    HIDE_IF_JS_ENABLED_CLASSNAME,
+} from "@ourworldindata/types"
+import { Url, MultiDimDataPageConfig } from "@ourworldindata/utils"
+import GrapherImage from "./GrapherImage.js"
+import { useMultiDimConfig } from "./multiDim/hooks.js"
+import MultiDim from "./multiDim/MultiDim.js"
 
-interface MultiDimEmbedProps {
+export function MultiDimEmbed({
+    url,
+    chartConfig,
+    isPreviewing,
+}: {
     url: string
     chartConfig: Partial<GrapherProgrammaticInterface>
     isPreviewing?: boolean
-}
-
-export const MultiDimEmbed: React.FC<MultiDimEmbedProps> = (
-    props: MultiDimEmbedProps
-) => {
-    const { url, isPreviewing } = props
-    const [config, setConfig] = useState<MultiDimDataPageConfigEnriched | null>(
-        null
-    )
-    const [error, setError] = useState<string | null>(null)
+}) {
+    const isClient = useIsClient()
+    const { ref, isIntersecting: hasBeenVisible } = useIntersectionObserver({
+        rootMargin: "400px",
+        freezeOnceVisible: true,
+    })
 
     const embedUrl = Url.fromURL(url)
     const { queryStr, slug } = embedUrl
+    const {
+        data: config,
+        error,
+        isError,
+    } = useMultiDimConfig({
+        slug,
+        isPreviewing,
+        enabled: hasBeenVisible,
+    })
 
-    useEffect(() => {
-        let ignore = false
-        if (!slug) {
-            setError("No slug found in URL")
-            return
-        }
-
-        const fetchConfig = async () => {
-            try {
-                const mdimConfigUrl = `${MULTI_DIM_DYNAMIC_CONFIG_URL}/${slug}.json${isPreviewing ? "?nocache" : ""}`
-                const multiDimConfig = await fetchWithRetry(mdimConfigUrl).then(
-                    (res) => res.json()
-                )
-                if (ignore) return
-                setConfig(multiDimConfig)
-            } catch {
-                setError("Failed to load chart configuration")
-            }
-        }
-
-        void fetchConfig()
-
-        return () => {
-            ignore = true
-        }
-    }, [isPreviewing, slug])
-
-    if (error) {
-        return <div>Error: {error}</div>
+    if (!slug) {
+        return <div>Error: No slug found in URL</div>
     }
 
-    if (!config || !slug) {
-        return <div>Loading...</div>
-    }
+    const shouldRenderMultiDim = isClient && hasBeenVisible && config
 
     return (
-        <MultiDim
-            slug={slug}
-            config={MultiDimDataPageConfig.fromObject(config)}
-            localGrapherConfig={props.chartConfig}
-            queryStr={queryStr}
-            isPreviewing={isPreviewing}
-        />
+        <div ref={ref}>
+            {shouldRenderMultiDim ? (
+                <MultiDim
+                    slug={slug}
+                    config={MultiDimDataPageConfig.fromObject(config)}
+                    localGrapherConfig={chartConfig}
+                    queryStr={queryStr}
+                    isPreviewing={isPreviewing}
+                />
+            ) : (
+                <>
+                    <figure
+                        className={`${GRAPHER_PREVIEW_CLASS} GrapherWithFallback__fallback`}
+                        aria-hidden={isClient}
+                    >
+                        {!isClient && (
+                            <GrapherImage
+                                className={HIDE_IF_JS_ENABLED_CLASSNAME}
+                                url={url}
+                            />
+                        )}
+                    </figure>
+                    {isError ? <div>Error: {error.message}</div> : null}
+                </>
+            )}
+        </div>
     )
 }

--- a/site/SiteQueryClientProvider.tsx
+++ b/site/SiteQueryClientProvider.tsx
@@ -1,9 +1,9 @@
 import { PropsWithChildren } from "react"
 import { QueryClientProvider } from "@tanstack/react-query"
-import { getSearchQueryClient } from "../../search/searchClients.js"
+import { getSiteQueryClient } from "./queryClient.js"
 
-export const BlockQueryClientProvider = ({ children }: PropsWithChildren) => {
-    const queryClient = getSearchQueryClient()
+export const SiteQueryClientProvider = ({ children }: PropsWithChildren) => {
+    const queryClient = getSiteQueryClient()
 
     return (
         <QueryClientProvider client={queryClient}>

--- a/site/gdocs/OwidGdoc.tsx
+++ b/site/gdocs/OwidGdoc.tsx
@@ -16,6 +16,7 @@ import { AnnouncementPage } from "./pages/Announcement.js"
 import { Profile } from "./pages/Profile.js"
 import { ADMIN_BASE_URL } from "../../settings/clientSettings.js"
 import { CookieKey } from "@ourworldindata/grapher"
+import { SiteQueryClientProvider } from "../SiteQueryClientProvider.js"
 
 type OwidGdocProps = OwidGdocPageProps & {
     isPreviewing?: boolean
@@ -136,8 +137,10 @@ export function OwidGdoc({
             }}
         >
             <DocumentContext.Provider value={{ isPreviewing, archiveContext }}>
-                <AdminLinks id={props.id} />
-                {content}
+                <SiteQueryClientProvider>
+                    <AdminLinks id={props.id} />
+                    {content}
+                </SiteQueryClientProvider>
             </DocumentContext.Provider>
         </AttachmentsContext.Provider>
     )

--- a/site/gdocs/components/ArticleBlock.tsx
+++ b/site/gdocs/components/ArticleBlock.tsx
@@ -65,7 +65,6 @@ import { Cta } from "./Cta.js"
 import { AttachmentsContext } from "../AttachmentsContext.js"
 import { FeaturedMetrics } from "../../FeaturedMetrics.js"
 import { FeaturedDataInsights } from "../../FeaturedDataInsights.js"
-import { BlockQueryClientProvider } from "./BlockQueryClientProvider.js"
 import { ExploreDataSection } from "./ExploreDataSection.js"
 import { LTPTableOfContents } from "./LTPTableOfContents.js"
 import { DataCallout } from "./DataCallout.js"
@@ -190,28 +189,24 @@ function ArticleBlockInternal({
                             `${EXPERIMENT_PREFIX}-all-charts-vs-featured-v1${EXPERIMENT_ARM_SEPARATOR}featured-metrics--hide`
                         )}
                     />
-                    <>
-                        <BlockQueryClientProvider>
-                            <FeaturedMetrics
-                                id={
-                                    experimentState &&
-                                    experimentState[
-                                        `${EXPERIMENT_PREFIX}-all-charts-vs-featured-v1`
-                                    ]?.isPageInExperiment &&
-                                    experimentState[
-                                        `${EXPERIMENT_PREFIX}-all-charts-vs-featured-v1`
-                                    ]?.arm === "featured-metrics"
-                                        ? "all-charts"
-                                        : ""
-                                }
-                                topicName={topicName}
-                                className={cx(
-                                    layoutClassName,
-                                    `${EXPERIMENT_PREFIX}-all-charts-vs-featured-v1${EXPERIMENT_ARM_SEPARATOR}featured-metrics--show`
-                                )}
-                            />
-                        </BlockQueryClientProvider>
-                    </>
+                    <FeaturedMetrics
+                        id={
+                            experimentState &&
+                            experimentState[
+                                `${EXPERIMENT_PREFIX}-all-charts-vs-featured-v1`
+                            ]?.isPageInExperiment &&
+                            experimentState[
+                                `${EXPERIMENT_PREFIX}-all-charts-vs-featured-v1`
+                            ]?.arm === "featured-metrics"
+                                ? "all-charts"
+                                : ""
+                        }
+                        topicName={topicName}
+                        className={cx(
+                            layoutClassName,
+                            `${EXPERIMENT_PREFIX}-all-charts-vs-featured-v1${EXPERIMENT_ARM_SEPARATOR}featured-metrics--show`
+                        )}
+                    />
                 </>
             )
         })
@@ -969,12 +964,10 @@ function ArticleBlockInternal({
             }
 
             return (
-                <BlockQueryClientProvider>
-                    <FeaturedMetrics
-                        topicName={topicName}
-                        className={layoutClassName}
-                    />
-                </BlockQueryClientProvider>
+                <FeaturedMetrics
+                    topicName={topicName}
+                    className={layoutClassName}
+                />
             )
         })
         .with({ type: "featured-data-insights" }, () => {
@@ -998,12 +991,10 @@ function ArticleBlockInternal({
             }
 
             return (
-                <BlockQueryClientProvider>
-                    <FeaturedDataInsights
-                        topicName={topicName}
-                        className={layoutClassName}
-                    />
-                </BlockQueryClientProvider>
+                <FeaturedDataInsights
+                    topicName={topicName}
+                    className={layoutClassName}
+                />
             )
         })
         .with({ type: "socials" }, (block) => (

--- a/site/gdocs/components/Chart.tsx
+++ b/site/gdocs/components/Chart.tsx
@@ -161,7 +161,6 @@ export default function Chart({
                         explorer: isExplorerWithControls,
                         "multi-dim": isMultiDimWithControls,
                     })}
-                    data-is-multi-dim={isMultiDim || undefined}
                     data-grapher-src={isExplorer ? undefined : resolvedUrl}
                     data-explorer-src={
                         isExplorer ? resolvedUrlParsed.fullUrl : undefined

--- a/site/multiDim/MultiDim.tsx
+++ b/site/multiDim/MultiDim.tsx
@@ -128,7 +128,7 @@ export default function MultiDim({
         [handleBaseSettingsChange]
     )
 
-    useMultiDimAnalytics(slug, config, settings)
+    useMultiDimAnalytics(slug, config, settings, grapherContainerRef)
 
     // Register with GuidedChartContext for guided chart link support
     const guidedChartContext = useContext(GuidedChartContext)

--- a/site/multiDim/api.ts
+++ b/site/multiDim/api.ts
@@ -3,10 +3,18 @@ import { getVariableMetadataRoute } from "@ourworldindata/grapher"
 import {
     AssetMap,
     GrapherInterface,
+    MultiDimDataPageConfigEnriched,
     OwidVariableWithSourceAndDimension,
 } from "@ourworldindata/types"
-import { fetchWithRetry, readFromAssetMap } from "@ourworldindata/utils"
-import { DATA_API_URL } from "../../settings/clientSettings.js"
+import {
+    fetchJson,
+    fetchWithRetry,
+    readFromAssetMap,
+} from "@ourworldindata/utils"
+import {
+    DATA_API_URL,
+    MULTI_DIM_DYNAMIC_CONFIG_URL,
+} from "../../settings/clientSettings.js"
 
 export const cachedGetVariableMetadata = _.memoize(
     async (
@@ -40,3 +48,11 @@ export const cachedGetGrapherConfigByUuid = _.memoize(
         return await response.json()
     }
 )
+
+export async function getMultiDimConfigBySlug(
+    slug: string,
+    isPreviewing: boolean
+): Promise<MultiDimDataPageConfigEnriched> {
+    const url = `${MULTI_DIM_DYNAMIC_CONFIG_URL}/${slug}.json${isPreviewing ? "?nocache" : ""}`
+    return fetchJson<MultiDimDataPageConfigEnriched>(url)
+}

--- a/site/multiDim/hooks.ts
+++ b/site/multiDim/hooks.ts
@@ -1,5 +1,5 @@
 import * as _ from "lodash-es"
-import { useEffect, useMemo, useRef } from "react"
+import { RefObject, useEffect, useMemo, useRef, useState } from "react"
 
 import {
     GrapherAnalytics,
@@ -7,11 +7,13 @@ import {
 } from "@ourworldindata/grapher"
 import { MultiDimDimensionChoices } from "@ourworldindata/types"
 import { MultiDimDataPageConfig } from "@ourworldindata/utils"
+import { useQuery } from "@tanstack/react-query"
 import {
     ADMIN_BASE_URL,
     BAKED_GRAPHER_URL,
     DATA_API_URL,
 } from "../../settings/clientSettings.js"
+import { getMultiDimConfigBySlug } from "./api.js"
 
 export const analytics = new GrapherAnalytics()
 
@@ -33,17 +35,73 @@ export const useBaseGrapherConfig = (
     }, [additionalConfig])
 }
 
+export function useMultiDimConfig({
+    slug,
+    isPreviewing,
+    enabled = true,
+}: {
+    slug?: string
+    isPreviewing?: boolean
+    enabled?: boolean
+}) {
+    return useQuery({
+        queryKey: ["multi-dim-config", slug, Boolean(isPreviewing)],
+        queryFn: () => {
+            if (!slug) {
+                throw new Error("Slug is required")
+            }
+            return getMultiDimConfigBySlug(slug, Boolean(isPreviewing))
+        },
+        enabled: Boolean(slug) && enabled,
+        staleTime: Infinity,
+    })
+}
+
 export function useMultiDimAnalytics(
     slug: string | null,
     config: MultiDimDataPageConfig,
-    settings: MultiDimDimensionChoices
+    settings: MultiDimDimensionChoices,
+    containerRef?: RefObject<HTMLElement | null>
 ) {
     // Settings might be a different object with the same properties, so we
     // can't rely on React's equality check.
     const oldSettingsRef = useRef<MultiDimDimensionChoices | null>(null)
+    const [hasBeenVisible, setHasBeenVisible] = useState(false)
+
     useEffect(() => {
-        // Log analytics event on page load and when the settings change.
-        if (slug && !_.isEqual(settings, oldSettingsRef.current)) {
+        if (!containerRef) {
+            setHasBeenVisible(true)
+            return undefined
+        }
+
+        const container = containerRef.current
+        if (!container) return undefined
+
+        if ("IntersectionObserver" in window) {
+            const observer = new IntersectionObserver((entries) => {
+                entries.forEach((entry) => {
+                    if (entry.isIntersecting) {
+                        setHasBeenVisible(true)
+                        observer.disconnect()
+                    }
+                })
+            })
+            observer.observe(container)
+            return () => observer.disconnect()
+        }
+
+        setHasBeenVisible(true)
+        return undefined
+    }, [containerRef])
+
+    useEffect(() => {
+        // Log analytics event on page load and when the settings change, but
+        // only once the multi-dim has become visible.
+        if (
+            slug &&
+            hasBeenVisible &&
+            !_.isEqual(settings, oldSettingsRef.current)
+        ) {
             const newView = config.findViewByDimensions(settings)
             if (newView) {
                 analytics.logGrapherView(slug, {
@@ -52,5 +110,5 @@ export function useMultiDimAnalytics(
             }
             oldSettingsRef.current = { ...settings }
         }
-    }, [config, slug, settings])
+    }, [config, hasBeenVisible, slug, settings])
 }

--- a/site/multiembedder/MultiEmbedder.tsx
+++ b/site/multiembedder/MultiEmbedder.tsx
@@ -12,8 +12,6 @@ import {
     Url,
     fetchWithRetry,
     NarrativeChartInfo,
-    searchParamsToMultiDimView,
-    MultiDimDataPageConfig,
 } from "@ourworldindata/utils"
 import { action, makeObservable } from "mobx"
 import {
@@ -22,24 +20,19 @@ import {
     EXPLORER_EMBEDDED_FIGURE_SELECTOR,
     buildExplorerProps,
 } from "@ourworldindata/explorer"
-import {
-    GRAPHER_PREVIEW_CLASS,
-    MultiDimDataPageConfigEnriched,
-} from "@ourworldindata/types"
+import { GRAPHER_PREVIEW_CLASS } from "@ourworldindata/types"
 import {
     ADMIN_BASE_URL,
     BAKED_GRAPHER_URL,
     CATALOG_URL,
     DATA_API_URL,
     GRAPHER_DYNAMIC_CONFIG_URL,
-    MULTI_DIM_DYNAMIC_CONFIG_URL,
 } from "../../settings/clientSettings.js"
 // import { embedDynamicCollectionGrapher } from "../collections/DynamicCollection.js"
 import { match } from "ts-pattern"
-import MultiDim from "../multiDim/MultiDim.js"
 import { createRoot } from "react-dom/client"
 
-type EmbedType = "grapher" | "explorer" | "multiDim" | "narrativeChart"
+type EmbedType = "grapher" | "explorer" | "narrativeChart"
 
 const figuresFromDOM = (
     container: HTMLElement | Document = document,
@@ -197,57 +190,6 @@ class MultiEmbedder {
         })
     }
 
-    async _renderMultiDimWithControlsIntoFigure(
-        figure: Element,
-        multiDimConfig: MultiDimDataPageConfigEnriched,
-        slug: string,
-        queryStr: string
-    ) {
-        figure.classList.remove(GRAPHER_PREVIEW_CLASS)
-        const root = createRoot(figure)
-        root.render(
-            <MultiDim
-                slug={slug}
-                config={MultiDimDataPageConfig.fromObject(multiDimConfig)}
-                queryStr={queryStr}
-                isPreviewing={this.isPreviewing}
-            />
-        )
-    }
-
-    async renderMultiDimIntoFigure(figure: Element) {
-        const embedUrlRaw = figure.getAttribute(GRAPHER_EMBEDDED_FIGURE_ATTR)
-        if (!embedUrlRaw) return
-        const embedUrl = Url.fromURL(embedUrlRaw)
-
-        const { queryStr, slug } = embedUrl
-        if (!slug) return
-
-        const mdimConfigUrl = `${MULTI_DIM_DYNAMIC_CONFIG_URL}/${slug}.json${this.isPreviewing ? "?nocache" : ""}`
-        const multiDimConfig = await fetchWithRetry(mdimConfigUrl).then((res) =>
-            res.json()
-        )
-
-        if (embedUrl.queryParams.hideControls === "true") {
-            const view = searchParamsToMultiDimView(
-                multiDimConfig,
-                new URLSearchParams(queryStr)
-            )
-            const configUrl = `${GRAPHER_DYNAMIC_CONFIG_URL}/by-uuid/${view.fullConfigId}.config.json${this.isPreviewing ? "?nocache" : ""}`
-            await this._renderGrapherComponentIntoFigure(figure, {
-                configUrl,
-                embedUrl,
-            })
-        } else {
-            await this._renderMultiDimWithControlsIntoFigure(
-                figure,
-                multiDimConfig,
-                slug,
-                queryStr
-            )
-        }
-    }
-
     async renderNarrativeChartIntoFigure(figure: Element) {
         const narrativeChartInfoRaw = figure.getAttribute(
             GRAPHER_NARRATIVE_CHART_CONFIG_FIGURE_ATTR
@@ -276,25 +218,21 @@ class MultiEmbedder {
         const isExplorer = figure.hasAttribute(
             EXPLORER_EMBEDDED_FIGURE_SELECTOR
         )
-        const isMultiDim = figure.hasAttribute("data-is-multi-dim")
         const isNarrativeChart = figure.hasAttribute(
             GRAPHER_NARRATIVE_CHART_CONFIG_FIGURE_ATTR
         )
 
         const embedType: EmbedType = isExplorer
             ? "explorer"
-            : isMultiDim
-              ? "multiDim"
-              : isNarrativeChart
-                ? "narrativeChart"
-                : "grapher"
+            : isNarrativeChart
+              ? "narrativeChart"
+              : "grapher"
 
         // Stop observing visibility as soon as possible
         this.figuresObserver?.unobserve(figure)
 
         await match(embedType)
             .with("explorer", () => this.renderExplorerIntoFigure(figure))
-            .with("multiDim", () => this.renderMultiDimIntoFigure(figure))
             .with("narrativeChart", () =>
                 this.renderNarrativeChartIntoFigure(figure)
             )

--- a/site/queryClient.ts
+++ b/site/queryClient.ts
@@ -1,0 +1,38 @@
+import { QueryClient, QueryCache } from "@tanstack/react-query"
+import * as Sentry from "@sentry/react"
+
+let queryClient: QueryClient | null = null
+
+// Shared site-wide React Query client. Individual queries should override
+// staleTime as appropriate (e.g. Infinity for static config).
+export const getSiteQueryClient = (): QueryClient => {
+    if (!queryClient) {
+        queryClient = new QueryClient({
+            defaultOptions: {
+                queries: {
+                    staleTime: 60 * 60 * 1000, // 1 hour
+                },
+            },
+            // Manually sending errors to Sentry as React Query silently captures
+            // errors. Some things to consider before setting up an error handling
+            // strategy:
+            // - throwOnError (v5) or useErrorBoundary (v4) defined at the query client
+            //   level means that errors in queries are thrown and can be caught by an
+            //   error boundary.
+            // - however, a global error boundary around the search component means that
+            //   a single fetch error (e.g. in SearchChartHitSmall) crashes the whole
+            //   search results page. This calls for a more fine-grained approach.
+            //
+            // Logging is not a substitute for actual error handling, but rather a way
+            // to gauge the prevalence of fetch errors in a React Query world, where
+            // queries are now automatically retried (3 times by default) before
+            // actually failing.
+            queryCache: new QueryCache({
+                onError: (error) => {
+                    Sentry.captureException(error)
+                },
+            }),
+        })
+    }
+    return queryClient
+}

--- a/site/search/SearchWrapper.tsx
+++ b/site/search/SearchWrapper.tsx
@@ -1,14 +1,15 @@
 import { TagGraphRoot } from "@ourworldindata/types"
 import { QueryClientProvider } from "@tanstack/react-query"
 import { Search } from "./Search.js"
-import { getLiteSearchClient, getSearchQueryClient } from "./searchClients.js"
+import { getLiteSearchClient } from "./searchClients.js"
+import { getSiteQueryClient } from "../queryClient.js"
 
 export const SearchWrapper = ({
     topicTagGraph,
 }: {
     topicTagGraph: TagGraphRoot
 }) => {
-    const queryClient = getSearchQueryClient()
+    const queryClient = getSiteQueryClient()
     const liteSearchClient = getLiteSearchClient()
 
     return (

--- a/site/search/searchClients.ts
+++ b/site/search/searchClients.ts
@@ -1,47 +1,8 @@
-import { QueryClient, QueryCache } from "@tanstack/react-query"
 import { liteClient, LiteClient } from "algoliasearch/lite"
-import * as Sentry from "@sentry/react"
 import {
     ALGOLIA_ID,
     ALGOLIA_SEARCH_KEY,
 } from "../../settings/clientSettings.js"
-
-let queryClient: QueryClient | null = null
-
-export const getSearchQueryClient = (): QueryClient => {
-    if (!queryClient) {
-        queryClient = new QueryClient({
-            defaultOptions: {
-                queries: {
-                    // In practice, stale queries do not result in another network
-                    // request, due to Algolia's caching. React Query's caching
-                    // (staleTime) should be considered a second line of defense.
-                    staleTime: 60 * 1000, // 1 minute
-                },
-            },
-            // Manually sending errors to Sentry as React Query silently captures
-            // errors. Some things to consider before setting up an error handling
-            // strategy:
-            // - throwOnError (v5) or useErrorBoundary (v4) defined at the query client
-            //   level means that errors in queries are thrown and can be caught by an
-            //   error boundary.
-            // - however, a global error boundary around the search component means that
-            //   a single fetch error (e.g. in SearchChartHitSmall) crashes the whole
-            //   search results page. This calls for a more fine-grained approach.
-            //
-            // Logging is not a substitute for actual error handling, but rather a way
-            // to gauge the prevalence of fetch errors in a React Query world, where
-            // queries are now automatically retried (3 times by default) before
-            // actually failing.
-            queryCache: new QueryCache({
-                onError: (error) => {
-                    Sentry.captureException(error)
-                },
-            }),
-        })
-    }
-    return queryClient
-}
 
 let liteSearchClient: LiteClient | null = null
 


### PR DESCRIPTION
## Description

- Use react-query to fetch the multi-dim config
- Defer loading the config until the embed scrolls near the viewport, similar to `GrapherWithFallback`
- Show a fallback image when JS is disabled
- Log multi-dim analytics event only when the multi-dim becomes visible, similar to `Grapher`
- Introduce a single site-wide `QueryClient `and a `SiteQueryClientProvider` and use the provider on the top level for all gdocs instead of the previous nested usage

Fixes #6353

## Testing guidance

Validate that a multi-dim in a gdoc loads only when it gets close to the viewport and the analytics logs only when it becomes visible, e.g. in [the global education topic page](http://staging-site-lazy-load-multi-dims/global-education).
