### PR TITLE
Show chart view rank in admin editor

### DIFF
--- a/adminSiteClient/ChartEditor.ts
+++ b/adminSiteClient/ChartEditor.ts
@@ -7,7 +7,7 @@
 
 import * as _ from "lodash-es"
 import {
-    type DbPlainAnalyticsGrapherView,
+    type AnalyticsGrapherViewWithRank,
     ChartRedirect,
     Json,
     GrapherInterface,
@@ -67,7 +67,7 @@ export interface ChartEditorManager extends AbstractChartEditorManager {
     logs: Log[]
     references: References | undefined
     redirects: ChartRedirect[]
-    views?: DbPlainAnalyticsGrapherView
+    views?: AnalyticsGrapherViewWithRank
     tags?: DbChartTagJoin[]
     availableTags?: DbChartTagJoin[]
     forceDatapage?: boolean

--- a/adminSiteClient/ChartEditorPage.tsx
+++ b/adminSiteClient/ChartEditorPage.tsx
@@ -3,7 +3,7 @@ import { observer } from "mobx-react"
 import { observable, computed, runInAction, action, makeObservable } from "mobx"
 import { getParentVariableIdFromChartConfig } from "@ourworldindata/utils"
 import {
-    type DbPlainAnalyticsGrapherView,
+    type AnalyticsGrapherViewWithRank,
     GrapherInterface,
     ChartRedirect,
     MinimalTagWithIsTopic,
@@ -50,7 +50,7 @@ export class ChartEditorPage
     logs: Log[] = []
     references: References | undefined = undefined
     redirects: ChartRedirect[] = []
-    views: DbPlainAnalyticsGrapherView | undefined = undefined
+    views: AnalyticsGrapherViewWithRank | undefined = undefined
     tags: DbChartTagJoin[] | undefined = undefined
     availableTags: MinimalTagWithIsTopic[] | undefined = undefined
     forceDatapage: boolean | undefined = undefined

--- a/adminSiteClient/EditorReferencesTab.tsx
+++ b/adminSiteClient/EditorReferencesTab.tsx
@@ -84,7 +84,7 @@ export class EditorReferencesTabForChart extends Component<{
         this.props.editor.manager.redirects.push(redirect)
     }
 
-    renderViewCount(views: number | undefined, rank?: number, total?: number) {
+    renderViewCount(views?: number, rank?: number, total?: number) {
         if (views === undefined) return "No data"
         const viewsStr = formatValue(views, { unit: "views" })
         if (rank !== undefined && total !== undefined) {

--- a/adminSiteClient/EditorReferencesTab.tsx
+++ b/adminSiteClient/EditorReferencesTab.tsx
@@ -84,10 +84,13 @@ export class EditorReferencesTabForChart extends Component<{
         this.props.editor.manager.redirects.push(redirect)
     }
 
-    renderViewCount(views: number | undefined) {
-        return views !== undefined
-            ? formatValue(views, { unit: "views" })
-            : "No data"
+    renderViewCount(views: number | undefined, rank?: number, total?: number) {
+        if (views === undefined) return "No data"
+        const viewsStr = formatValue(views, { unit: "views" })
+        if (rank !== undefined && total !== undefined) {
+            return `${viewsStr} (#${formatValue(rank, {})} of ${formatValue(total, {})})`
+        }
+        return viewsStr
     }
 
     override render() {
@@ -98,15 +101,27 @@ export class EditorReferencesTabForChart extends Component<{
                     <div>
                         <div>
                             <strong>Last 7 days:</strong>{" "}
-                            {this.renderViewCount(this.views?.views_7d)}
+                            {this.renderViewCount(
+                                this.views?.views_7d,
+                                this.views?.rank_7d,
+                                this.views?.total_charts
+                            )}
                         </div>
                         <div>
                             <strong>Last 14 days:</strong>{" "}
-                            {this.renderViewCount(this.views?.views_14d)}
+                            {this.renderViewCount(
+                                this.views?.views_14d,
+                                this.views?.rank_14d,
+                                this.views?.total_charts
+                            )}
                         </div>
                         <div>
                             <strong>Last 365 days:</strong>{" "}
-                            {this.renderViewCount(this.views?.views_365d)}
+                            {this.renderViewCount(
+                                this.views?.views_365d,
+                                this.views?.rank_365d,
+                                this.views?.total_charts
+                            )}
                         </div>
                         <div>
                             <strong>

--- a/adminSiteServer/apiRoutes/charts.ts
+++ b/adminSiteServer/apiRoutes/charts.ts
@@ -764,6 +764,10 @@ export async function getChartViewsJson(
                 RANK() OVER (ORDER BY views_365d DESC) AS rank_365d
             FROM
                 analytics_grapher_views v
+            JOIN chart_configs cc
+                ON cc.slug = v.grapher_slug
+                AND cc.full ->> "$.isPublished" = "true"
+            JOIN charts c ON c.configId = cc.id
         ) ranked
         WHERE
             grapher_slug = ?`,

--- a/adminSiteServer/apiRoutes/charts.ts
+++ b/adminSiteServer/apiRoutes/charts.ts
@@ -755,9 +755,14 @@ export async function getChartViewsJson(
     const viewsBySlug = await db.knexRawFirst(
         trx,
         `-- sql
-        SELECT *
+        SELECT
+            v.*,
+            (SELECT COUNT(*) FROM analytics_grapher_views) AS total_charts,
+            RANK() OVER (ORDER BY views_7d DESC) AS rank_7d,
+            RANK() OVER (ORDER BY views_14d DESC) AS rank_14d,
+            RANK() OVER (ORDER BY views_365d DESC) AS rank_365d
         FROM
-            analytics_grapher_views
+            analytics_grapher_views v
         WHERE
             grapher_slug = ?`,
         [slug]

--- a/adminSiteServer/apiRoutes/charts.ts
+++ b/adminSiteServer/apiRoutes/charts.ts
@@ -1,3 +1,4 @@
+import * as R from "remeda"
 import { migrateGrapherConfigToLatestVersionAndFailOnError } from "@ourworldindata/grapher"
 import {
     GrapherInterface,
@@ -13,6 +14,8 @@ import {
     DbChartTagJoin,
     ContentGraphLinkType,
     StaticVizTableName,
+    DbPlainAnalyticsGrapherView,
+    AnalyticsGrapherViewWithRank,
 } from "@ourworldindata/types"
 import {
     diffGrapherConfigs,
@@ -752,31 +755,47 @@ export async function getChartViewsJson(
     const slug = await getChartSlugById(trx, parseInt(req.params.chartId))
     if (!slug) return {}
 
-    const viewsBySlug = await db.knexRawFirst(
+    const viewsBySlug = await db.knexRawFirst<
+        DbPlainAnalyticsGrapherView & {
+            total_charts: number | null
+            rank_7d: number | null
+            rank_14d: number | null
+            rank_365d: number | null
+        }
+    >(
         trx,
         `-- sql
-        SELECT * FROM (
+        SELECT
+            v.*,
+            ranked.total_charts,
+            ranked.rank_7d,
+            ranked.rank_14d,
+            ranked.rank_365d
+        FROM analytics_grapher_views v
+        LEFT JOIN (
             SELECT
-                v.*,
+                v.grapher_slug,
                 COUNT(*) OVER () AS total_charts,
-                RANK() OVER (ORDER BY views_7d DESC) AS rank_7d,
-                RANK() OVER (ORDER BY views_14d DESC) AS rank_14d,
-                RANK() OVER (ORDER BY views_365d DESC) AS rank_365d
-            FROM
-                analytics_grapher_views v
+                RANK() OVER (ORDER BY v.views_7d DESC) AS rank_7d,
+                RANK() OVER (ORDER BY v.views_14d DESC) AS rank_14d,
+                RANK() OVER (ORDER BY v.views_365d DESC) AS rank_365d
+            FROM analytics_grapher_views v
             JOIN chart_configs cc
                 ON cc.slug = v.grapher_slug
                 AND cc.full ->> "$.isPublished" = "true"
             JOIN charts c ON c.configId = cc.id
-        ) ranked
-        WHERE
-            grapher_slug = ?`,
+        ) ranked ON ranked.grapher_slug = v.grapher_slug
+        WHERE v.grapher_slug = ?`,
         [slug]
     )
 
-    return {
-        views: viewsBySlug ?? undefined,
-    }
+    if (!viewsBySlug) return {}
+
+    const views: AnalyticsGrapherViewWithRank = R.omitBy(
+        viewsBySlug,
+        (value): value is null => value === null
+    )
+    return { views }
 }
 
 export async function getChartTagsJson(

--- a/adminSiteServer/apiRoutes/charts.ts
+++ b/adminSiteServer/apiRoutes/charts.ts
@@ -755,14 +755,16 @@ export async function getChartViewsJson(
     const viewsBySlug = await db.knexRawFirst(
         trx,
         `-- sql
-        SELECT
-            v.*,
-            (SELECT COUNT(*) FROM analytics_grapher_views) AS total_charts,
-            RANK() OVER (ORDER BY views_7d DESC) AS rank_7d,
-            RANK() OVER (ORDER BY views_14d DESC) AS rank_14d,
-            RANK() OVER (ORDER BY views_365d DESC) AS rank_365d
-        FROM
-            analytics_grapher_views v
+        SELECT * FROM (
+            SELECT
+                v.*,
+                COUNT(*) OVER () AS total_charts,
+                RANK() OVER (ORDER BY views_7d DESC) AS rank_7d,
+                RANK() OVER (ORDER BY views_14d DESC) AS rank_14d,
+                RANK() OVER (ORDER BY views_365d DESC) AS rank_365d
+            FROM
+                analytics_grapher_views v
+        ) ranked
         WHERE
             grapher_slug = ?`,
         [slug]

--- a/packages/@ourworldindata/types/src/dbTypes/AnalyticsGrapherViews.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/AnalyticsGrapherViews.ts
@@ -6,3 +6,10 @@ export interface DbPlainAnalyticsGrapherView {
     views_14d: number
     views_365d: number
 }
+
+export interface AnalyticsGrapherViewWithRank extends DbPlainAnalyticsGrapherView {
+    rank_7d: number
+    rank_14d: number
+    rank_365d: number
+    total_charts: number
+}

--- a/packages/@ourworldindata/types/src/dbTypes/AnalyticsGrapherViews.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/AnalyticsGrapherViews.ts
@@ -8,8 +8,8 @@ export interface DbPlainAnalyticsGrapherView {
 }
 
 export interface AnalyticsGrapherViewWithRank extends DbPlainAnalyticsGrapherView {
-    rank_7d: number
-    rank_14d: number
-    rank_365d: number
-    total_charts: number
+    rank_7d?: number
+    rank_14d?: number
+    rank_365d?: number
+    total_charts?: number
 }

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -356,6 +356,7 @@ export {
 } from "./dbTypes/AnalyticsPageviews.js"
 export {
     type DbPlainAnalyticsGrapherView,
+    type AnalyticsGrapherViewWithRank,
     AnalyticsGrapherViewsTableName,
 } from "./dbTypes/AnalyticsGrapherViews.js"
 export {


### PR DESCRIPTION
## Summary
- Adds rank display to the chart editor's Refs tab for each time period (7d, 14d, 365d)
- Example: `32,688 views (#127 of 4,128)` where rank 1 = most viewed
- Uses SQL `RANK()` window functions in the existing views API endpoint
- Denominator is total charts with analytics data

## Test plan
- [x] Open a chart in the admin editor, go to the Refs tab
- [x] Verify rank shows for all three time periods (7d, 14d, 365d)
- [x] Verify rank is accurate for at least 1 chart
- [x] Verify formatting with comma separators for large numbers

🤖 Generated with [Claude Code](https://claude.com/claude-code)