### PR TITLE
🐛 (explorer) fix display settings not being inherited

### DIFF
--- a/packages/@ourworldindata/core-table/src/CoreTable.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTable.ts
@@ -5,6 +5,7 @@ import {
     ColumnSlug,
     PrimitiveType,
     imemo,
+    merge,
 } from "@ourworldindata/utils"
 import {
     CoreColumn,
@@ -105,7 +106,7 @@ export class CoreTable<
             const sourceDef = this.inputColumnDefs.find(
                 (def) => def.slug === sourceSlug
             )
-            return { ...sourceDef, ...def }
+            return merge(sourceDef, def)
         })
 
         // If any values were passed in, copy those to column store now and then remove them from column definitions.


### PR DESCRIPTION
Fixes a bug where display settings weren't passed through for dimensions that duplicated another indicators in an explorer.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #6384 
- <kbd>&nbsp;1&nbsp;</kbd> #6382 👈 
<!-- GitButler Footer Boundary Bottom -->

