### PR TITLE
🎉 (explorer) add rounding options

### DIFF
--- a/packages/@ourworldindata/explorer/src/ColumnGrammar.ts
+++ b/packages/@ourworldindata/explorer/src/ColumnGrammar.ts
@@ -3,6 +3,7 @@ import {
     automaticBinningStrategies,
     ColorSchemeName,
     ColumnTypeNames,
+    OwidVariableRoundingMode,
 } from "@ourworldindata/types"
 import { ToleranceStrategy } from "@ourworldindata/utils"
 import {
@@ -13,6 +14,7 @@ import {
     Grammar,
     IntegerCellDef,
     NumericCellDef,
+    PositiveIntegerCellDef,
     SlugDeclarationCellDef,
     StringCellDef,
     UrlCellDef,
@@ -89,6 +91,32 @@ export const ColumnGrammar: Grammar<ColumnCellDef> = {
         ...StringCellDef,
         keyword: "shortUnit",
         description: "Short (axis) unit",
+        isDisplayProperty: true,
+    },
+    roundingMode: {
+        ...EnumCellDef,
+        keyword: "roundingMode",
+        terminalOptions: Object.values(OwidVariableRoundingMode).map(
+            (mode) => ({
+                keyword: mode,
+                description: "",
+                cssClass: "",
+            })
+        ),
+        description:
+            "How to round numbers: by decimal places or by significant figures",
+        isDisplayProperty: true,
+    },
+    numDecimalPlaces: {
+        ...PositiveIntegerCellDef,
+        keyword: "numDecimalPlaces",
+        description: "Number of decimal places to display",
+        isDisplayProperty: true,
+    },
+    numSignificantFigures: {
+        ...PositiveIntegerCellDef,
+        keyword: "numSignificantFigures",
+        description: "Number of significant figures to display",
         isDisplayProperty: true,
     },
     notes: {

--- a/packages/@ourworldindata/explorer/src/gridLang/GridLangConstants.ts
+++ b/packages/@ourworldindata/explorer/src/gridLang/GridLangConstants.ts
@@ -137,6 +137,16 @@ export const IntegerCellDef: CellDef = {
     parse: (value: any) => parseInt(value),
 }
 
+export const PositiveIntegerCellDef: CellDef = {
+    keyword: "",
+    cssClass: "IntegerCellDef",
+    description: "",
+    regex: /^[0-9]+$/,
+    requirementsDescription: `Must be a positive integer`,
+    valuePlaceholder: "1",
+    parse: (value: any) => parseInt(value),
+}
+
 export const PositiveIntegersCellDef: CellDef = {
     keyword: "",
     cssClass: "IntegerCellDef",


### PR DESCRIPTION
Adds rounding options (roundingMode, numDecimalPlaces, numSigFigs) to explorer configs.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #6384 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #6382 
<!-- GitButler Footer Boundary Bottom -->

