### PR TITLE
🐛🤖 (search) fix topic page results layout

### DIFF
--- a/site/search/SearchWritingResults.scss
+++ b/site/search/SearchWritingResults.scss
@@ -18,11 +18,10 @@
     gap: var(--grid-gap);
 }
 
-.search-writing-results__overflow {
+.search-writing-results__topics--full-width {
     grid-column: 1 / -1;
     display: grid;
-    grid-template-columns: subgrid;
-    gap: var(--grid-gap);
+    grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
 .search-writing-results__single-column {

--- a/site/search/SearchWritingResults.tsx
+++ b/site/search/SearchWritingResults.tsx
@@ -1,3 +1,4 @@
+import cx from "classnames"
 import { useMediaQuery } from "usehooks-ts"
 import * as _ from "lodash-es"
 
@@ -137,21 +138,13 @@ function MultiColumnResults({
 }) {
     const { analytics } = useSearchContext()
 
-    // Profiles appear before topic pages in the tiles
+    // Profiles appear before topic pages in the tiles.
     const allTopicOrProfileHits: TopicOrProfileHit[] = [...profiles, ...topics]
+    const hasArticles = articles.length > 0
 
-    // Calculate interleaved layout: 4 topics for every 5 articles (ratio
-    // maintained proportionally).
-    const interleavedCount = Math.round((articles.length * 4) / 5)
-    const interleavedTopicOrProfileHits = allTopicOrProfileHits.slice(
-        0,
-        interleavedCount
-    )
-    const remainingTopicOrProfileHits =
-        allTopicOrProfileHits.slice(interleavedCount)
     return (
         <div className="search-writing-results__grid">
-            {articles.length > 0 && (
+            {hasArticles && (
                 <div className="search-writing-results__articles">
                     {articles.map((hit, index) => (
                         <SearchFlatArticleHit
@@ -167,24 +160,17 @@ function MultiColumnResults({
                     ))}
                 </div>
             )}
-            {interleavedTopicOrProfileHits.length > 0 && (
-                <div className="search-writing-results__topics">
-                    {interleavedTopicOrProfileHits.map((hit, index) =>
+            {allTopicOrProfileHits.length > 0 && (
+                <div
+                    className={cx("search-writing-results__topics", {
+                        "search-writing-results__topics--full-width":
+                            !hasArticles,
+                    })}
+                >
+                    {allTopicOrProfileHits.map((hit, index) =>
                         renderTopicOrProfileHit(
                             hit,
                             index,
-                            hasLargeTopic,
-                            analytics
-                        )
-                    )}
-                </div>
-            )}
-            {remainingTopicOrProfileHits.length > 0 && (
-                <div className="search-writing-results__overflow">
-                    {remainingTopicOrProfileHits.map((hit, index) =>
-                        renderTopicOrProfileHit(
-                            hit,
-                            interleavedTopicOrProfileHits.length + index,
                             hasLargeTopic,
                             analytics
                         )


### PR DESCRIPTION
Keep all topic pages cards on the right when articles are present.

Fixes #5681

## Screenshots / Videos / Diagrams

| Before | After |
|--------|--------|
| <img width="2560" height="1408" alt="image" src="https://github.com/user-attachments/assets/9164f850-404e-4ead-b318-e7cd983aac5b" /> | <img width="2560" height="1408" alt="image" src="https://github.com/user-attachments/assets/24c836d0-f632-4fdf-a713-052eed36f672" /> |

## Testing guidance

Compare the layout of these searches in prod and after the fix:

- Should stay the same: https://ourworldindata.org/search?topics=Health&countries=Armenia&resultType=writing
- Should make all topic cards go on the right: https://ourworldindata.org/search?topics=Clean+Water+%26+Sanitation&resultType=all