### PR TITLE
🎉🤖 (line-facets) add tooltips to line chart thumbnails

### DIFF
--- a/.bundlemonrc.json
+++ b/.bundlemonrc.json
@@ -4,7 +4,7 @@
     "files": [
         {
             "path": "owid.mjs",
-            "maxSize": "785kB",
+            "maxSize": "790kB",
             "maxPercentIncrease": 2
         },
         {

--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
@@ -6,7 +6,6 @@ import {
     getRelativeMouse,
     exposeInstanceOnWindow,
     excludeUndefined,
-    isMobile,
     Bounds,
     HorizontalAlign,
 } from "@ourworldindata/utils"
@@ -24,7 +23,6 @@ import { SeriesName, VerticalAlign, Time } from "@ourworldindata/types"
 import {
     BASE_FONT_SIZE,
     DEFAULT_GRAPHER_BOUNDS,
-    GRAPHER_OPACITY_MUTED,
 } from "../core/GrapherConstants"
 import { ChartInterface } from "../chart/ChartInterface"
 import {
@@ -49,30 +47,29 @@ import {
 } from "./LineChartConstants"
 import {
     getHoverStateForSeries,
-    getSeriesKey,
     isTargetOutsideElement,
 } from "../chart/ChartUtils"
 import { CategoricalBin, ColorScaleBin } from "../color/ColorScaleBin"
 import { ColorScale } from "../color/ColorScale"
-import { GRAPHER_BACKGROUND } from "../color/ColorConstants"
-import { darkenColorForLine } from "../color/ColorUtils"
 import {
     HorizontalColorLegendManager,
     HorizontalNumericColorLegend,
 } from "../legend/HorizontalColorLegends"
 import {
+    findClosestTimeAtMouse,
     getAnnotationsForSeries,
     getYAxisConfigDefaults,
     toPlacedLineChartSeries,
     toRenderLineChartSeries,
 } from "./LineChartHelpers"
+import { LineChartActiveTimeMarkers } from "./LineChartActiveTimeMarkers"
 import { LabelSeries } from "../verticalLabels/VerticalLabelsTypes"
 import { Lines } from "./Lines"
 import { LineChartState } from "./LineChartState.js"
 import { AxisConfig, AxisManager } from "../axis/AxisConfig"
 import { ChartComponentProps } from "../chart/ChartTypeMap.js"
 import { InteractionState } from "../interaction/InteractionState"
-import { resolveEmphasis, Emphasis } from "../interaction/Emphasis"
+import { resolveEmphasis } from "../interaction/Emphasis"
 import { LegendStyleConfig } from "../legend/LegendStyleConfig"
 
 export type LineChartProps = ChartComponentProps<LineChartState>
@@ -133,7 +130,7 @@ export class LineChart
         const ref = this.base.current,
             parentRef = this.manager.base?.current
 
-        // the tooltip's origin needs to be in the parent's coordinates
+        // The tooltip's origin needs to be in the parent's coordinates
         if (parentRef) {
             this.tooltipState.position = getRelativeMouse(parentRef, ev)
         }
@@ -141,25 +138,15 @@ export class LineChart
         if (!ref) return
 
         const mouse = getRelativeMouse(ref, ev)
-        const boxPadding = isMobile() ? 44 : 25
 
-        // expand the box width, so it's easier to see the tooltip for the first & last timepoints
-        const boundedBox = this.dualAxis.innerBounds.expand({
-            left: boxPadding,
-            right: boxPadding,
+        const hoverTime = findClosestTimeAtMouse({
+            mouse,
+            innerBounds: this.dualAxis.innerBounds,
+            horizontalAxis: this.dualAxis.horizontalAxis,
+            allValues: this.allValues,
         })
 
-        let hoverTime
-        if (boundedBox.contains(mouse)) {
-            const invertedX = this.dualAxis.horizontalAxis.invert(mouse.x)
-
-            const closestValue = _.minBy(this.allValues, (point) =>
-                Math.abs(invertedX - point.x)
-            )
-            hoverTime = closestValue?.x
-        }
-
-        // be sure all lines are un-dimmed if the cursor is above the graph itself
+        // Be sure all lines are un-dimmed if the cursor is above the graph itself
         if (this.dualAxis.innerBounds.contains(mouse)) {
             this.clearVerticalLabelHover()
         }
@@ -209,69 +196,17 @@ export class LineChart
     }
 
     @computed get activeTimes(): Time[] {
-        const { highlightedTimesInLineChart = [] } = this.manager
+        const tooltipTime = this.tooltipState.target?.time
+        const highlightedTimes = this.manager.highlightedTimesInLineChart ?? []
         return _.uniq(
-            this.tooltipState.target?.time
-                ? [
-                      this.tooltipState.target.time,
-                      ...highlightedTimesInLineChart,
-                  ]
-                : highlightedTimesInLineChart
+            tooltipTime !== undefined
+                ? [tooltipTime, ...highlightedTimes]
+                : highlightedTimes
         )
     }
 
-    @computed private get activeXVerticalLines(): React.ReactElement | null {
-        const { activeTimes, dualAxis } = this
-        const { horizontalAxis, verticalAxis } = dualAxis
-
-        if (!activeTimes) return null
-
-        return (
-            <>
-                {activeTimes.map((time) => (
-                    <g className="hoverIndicator" key={time}>
-                        <line
-                            x1={horizontalAxis.place(time)}
-                            y1={verticalAxis.range[0]}
-                            x2={horizontalAxis.place(time)}
-                            y2={verticalAxis.range[1]}
-                            stroke="rgba(180,180,180,.4)"
-                        />
-                        {this.renderSeries.map((series, index) => {
-                            const point = series.points.find(
-                                (point) => point.x === time
-                            )
-                            if (!point || series.hover.background) return null
-
-                            const valueColor = this.hasColorScale
-                                ? darkenColorForLine(
-                                      this.chartState.getColorScaleColor(
-                                          point.colorValue
-                                      )
-                                  )
-                                : series.color
-                            const opacity =
-                                series.emphasis === Emphasis.Muted
-                                    ? GRAPHER_OPACITY_MUTED
-                                    : 1
-
-                            return (
-                                <circle
-                                    key={getSeriesKey(series, index)}
-                                    cx={horizontalAxis.place(point.x)}
-                                    cy={verticalAxis.place(point.y)}
-                                    r={this.lineStrokeWidth / 2 + 3.5}
-                                    fill={valueColor}
-                                    fillOpacity={opacity}
-                                    stroke={GRAPHER_BACKGROUND}
-                                    strokeWidth={0.5}
-                                />
-                            )
-                        })}
-                    </g>
-                ))}
-            </>
-        )
+    @computed private get activeTimeCircleRadius(): number {
+        return this.lineStrokeWidth / 2 + 3.5
     }
 
     @computed private get tooltipId(): number {
@@ -339,8 +274,8 @@ export class LineChart
     }
 
     @action.bound private onDocumentClick(e: MouseEvent): void {
-        // only dismiss the tooltip if the click is outside of the chart area
-        // and outside of the chart areas of neighbouring facets
+        // Only dismiss the tooltip if the click is outside of the chart area
+        // and outside of the chart areas of neighboring facets
         const chartContainer = this.manager.base?.current
         if (!chartContainer) return
         const chartAreas = chartContainer.getElementsByClassName(
@@ -491,8 +426,15 @@ export class LineChart
                 {this.renderDualAxis()}
                 {this.renderChartElements()}
 
-                {(this.isTooltipActive || this.hasTimeHighlights) &&
-                    this.activeXVerticalLines}
+                {(this.isTooltipActive || this.hasTimeHighlights) && (
+                    <LineChartActiveTimeMarkers
+                        times={this.activeTimes}
+                        renderSeries={this.renderSeries}
+                        dualAxis={this.dualAxis}
+                        chartState={this.chartState}
+                        dotRadius={this.activeTimeCircleRadius}
+                    />
+                )}
                 <LineChartTooltip
                     id={this.tooltipId}
                     chartState={this.chartState}

--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChartActiveTimeMarkers.tsx
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChartActiveTimeMarkers.tsx
@@ -1,0 +1,78 @@
+import React from "react"
+import { Time } from "@ourworldindata/types"
+import { DualAxis } from "../axis/Axis"
+import { LineChartState } from "./LineChartState"
+import { RenderLineChartSeries } from "./LineChartConstants"
+import { darkenColorForLine } from "../color/ColorUtils"
+import { Emphasis } from "../interaction/Emphasis"
+import { GRAPHER_OPACITY_MUTED } from "../core/GrapherConstants"
+import { getSeriesKey } from "../chart/ChartUtils"
+import { GRAPHER_BACKGROUND } from "../color/ColorConstants"
+
+interface LineChartActiveTimeMarkersProps {
+    times: Time[]
+    renderSeries: RenderLineChartSeries[]
+    dualAxis: DualAxis
+    chartState: LineChartState
+    dotRadius: number
+}
+
+/** Vertical reference line and series-value circles drawn at each active time */
+export function LineChartActiveTimeMarkers({
+    times,
+    renderSeries,
+    dualAxis,
+    chartState,
+    dotRadius,
+}: LineChartActiveTimeMarkersProps): React.ReactElement | null {
+    const { horizontalAxis, verticalAxis } = dualAxis
+
+    if (times.length === 0) return null
+
+    return (
+        <>
+            {times.map((time) => (
+                <g className="hoverIndicator" key={time}>
+                    <line
+                        x1={horizontalAxis.place(time)}
+                        y1={verticalAxis.range[0]}
+                        x2={horizontalAxis.place(time)}
+                        y2={verticalAxis.range[1]}
+                        stroke="rgba(180,180,180,.4)"
+                    />
+                    {renderSeries.map((series, index) => {
+                        const point = series.points.find(
+                            (point) => point.x === time
+                        )
+                        if (!point || series.hover.background) return null
+
+                        const valueColor = chartState.hasColorScale
+                            ? darkenColorForLine(
+                                  chartState.getColorScaleColor(
+                                      point.colorValue
+                                  )
+                              )
+                            : series.color
+                        const opacity =
+                            series.emphasis === Emphasis.Muted
+                                ? GRAPHER_OPACITY_MUTED
+                                : 1
+
+                        return (
+                            <circle
+                                key={getSeriesKey(series, index)}
+                                cx={horizontalAxis.place(point.x)}
+                                cy={verticalAxis.place(point.y)}
+                                r={dotRadius}
+                                fill={valueColor}
+                                fillOpacity={opacity}
+                                stroke={GRAPHER_BACKGROUND}
+                                strokeWidth={0.5}
+                            />
+                        )
+                    })}
+                </g>
+            ))}
+        </>
+    )
+}

--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChartHelpers.ts
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChartHelpers.ts
@@ -1,4 +1,5 @@
 import * as _ from "lodash-es"
+import { Bounds, isMobile, PointVector } from "@ourworldindata/utils"
 import { OwidTable } from "@ourworldindata/core-table"
 import {
     AxisAlign,
@@ -9,14 +10,16 @@ import {
     ScaleType,
     SeriesName,
     SeriesStrategy,
+    Time,
 } from "@ourworldindata/types"
 import {
     LineChartSeries,
+    LinePoint,
     PlacedLineChartSeries,
     PlacedPoint,
     RenderLineChartSeries,
 } from "./LineChartConstants"
-import { DualAxis } from "../axis/Axis"
+import { DualAxis, HorizontalAxis } from "../axis/Axis"
 import { LineChartState } from "./LineChartState"
 import { darkenColorForLine } from "../color/ColorUtils"
 import {
@@ -148,6 +151,35 @@ export function toPlacedLineChartSeries(
         })
         return { ...series, placedPoints }
     })
+}
+
+/**
+ * Find the time of the data point whose x is closest to the mouse position.
+ * Returns undefined if the mouse is outside the bounds.
+ */
+export function findClosestTimeAtMouse({
+    mouse,
+    innerBounds,
+    horizontalAxis,
+    allValues,
+}: {
+    mouse: PointVector
+    innerBounds: Bounds
+    horizontalAxis: HorizontalAxis
+    allValues: LinePoint[]
+}): Time | undefined {
+    // Expand the hit box so the first/last timepoints are easy to hover
+    const hoverMargin = isMobile() ? 44 : 25
+    const boundedBox = innerBounds.expand({
+        left: hoverMargin,
+        right: hoverMargin,
+    })
+
+    if (!boundedBox.contains(mouse)) return undefined
+
+    const invertedX = horizontalAxis.invert(mouse.x)
+    const closest = _.minBy(allValues, (point) => Math.abs(invertedX - point.x))
+    return closest?.x
 }
 
 export function toRenderLineChartSeries(

--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChartThumbnail.tsx
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChartThumbnail.tsx
@@ -1,10 +1,15 @@
 import React from "react"
-import { computed, makeObservable } from "mobx"
+import { action, computed, makeObservable, observable } from "mobx"
 import { observer } from "mobx-react"
 import * as _ from "lodash-es"
 import { scaleLinear } from "d3-scale"
-import { Bounds, SeriesName } from "@ourworldindata/utils"
-import { SideWidths } from "@ourworldindata/types"
+import {
+    Bounds,
+    SeriesName,
+    guid,
+    getRelativeMouse,
+} from "@ourworldindata/utils"
+import { SideWidths, Time } from "@ourworldindata/types"
 import { ChartInterface } from "../chart/ChartInterface"
 import { LineChartState } from "./LineChartState"
 import { LineChartProps } from "./LineChart.js"
@@ -12,6 +17,7 @@ import { DualAxis, HorizontalAxis, VerticalAxis } from "../axis/Axis"
 import {
     CATEGORICAL_LEGEND_STYLE,
     LINE_STYLE,
+    LINE_CHART_CLASS_NAME,
     LineChartManager,
     LineChartSeries,
     LinePoint,
@@ -28,10 +34,10 @@ import {
 } from "../core/GrapherConstants"
 import { Emphasis, resolveEmphasis } from "../interaction/Emphasis"
 import { InteractionState } from "../interaction/InteractionState"
-import { getHoverStateForSeries } from "../chart/ChartUtils"
 import { AxisConfig, AxisManager } from "../axis/AxisConfig"
 import { Lines } from "./Lines"
 import {
+    findClosestTimeAtMouse,
     getYAxisConfigDefaults,
     toPlacedLineChartSeries,
     toRenderLineChartSeries,
@@ -48,15 +54,30 @@ import { darkenColorForLine } from "../color/ColorUtils.js"
 import { NoDataMessage } from "../noDataMessage/NoDataMessage"
 import { HorizontalColorLegendManager } from "../legend/HorizontalColorLegends.js"
 import { CategoricalBin } from "../color/ColorScaleBin.js"
+import {
+    getHoverStateForSeries,
+    isTargetOutsideElement,
+} from "../chart/ChartUtils"
+import { TooltipState } from "../tooltip/Tooltip"
+import { LineChartTooltip } from "./LineChartTooltip"
+import { LineChartActiveTimeMarkers } from "./LineChartActiveTimeMarkers"
 
 @observer
 export class LineChartThumbnail
     extends React.Component<LineChartProps>
     implements ChartInterface, AxisManager
 {
+    private readonly base = React.createRef<SVGGElement>()
+
+    private readonly tooltipState = new TooltipState<{ time: Time }>({
+        fade: "immediate",
+    })
+
     constructor(props: LineChartProps) {
         super(props)
-        makeObservable(this)
+        makeObservable<LineChartThumbnail, "tooltipState">(this, {
+            tooltipState: observable,
+        })
     }
 
     @computed get chartState(): LineChartState {
@@ -636,16 +657,88 @@ export class LineChartThumbnail
         return min <= 0 && max >= 0
     }
 
-    override render(): React.ReactElement {
-        if (this.chartState.errorInfo.reason)
-            return (
-                <NoDataMessage
-                    manager={this.manager}
-                    bounds={this.bounds}
-                    message={this.chartState.errorInfo.reason}
-                />
-            )
+    @computed private get allValues(): LinePoint[] {
+        return this.placedSeries.flatMap((series) => series.points)
+    }
 
+    @computed get activeTimes(): Time[] {
+        const tooltipTime = this.tooltipState.target?.time
+        return tooltipTime !== undefined ? [tooltipTime] : []
+    }
+
+    @computed private get renderUid(): number {
+        return guid()
+    }
+
+    @computed private get tooltipId(): number {
+        return this.renderUid
+    }
+
+    @computed private get isTooltipActive(): boolean {
+        return this.manager.tooltip?.get()?.id === this.tooltipId
+    }
+
+    @action.bound private dismissTooltip(): void {
+        this.tooltipState.target = null
+    }
+
+    @action.bound private onCursorLeave(): void {
+        if (!this.manager.shouldPinTooltipToBottom) this.dismissTooltip()
+    }
+
+    @action.bound private onCursorMove(
+        ev: React.MouseEvent | React.TouchEvent
+    ): void {
+        const ref = this.base.current,
+            parentRef = this.manager.base?.current
+
+        // The tooltip's origin needs to be in the parent's coordinates
+        if (parentRef) {
+            this.tooltipState.position = getRelativeMouse(parentRef, ev)
+        }
+
+        if (!ref) return
+
+        const hoverTime = findClosestTimeAtMouse({
+            mouse: getRelativeMouse(ref, ev),
+            innerBounds: this.dualAxis.innerBounds,
+            horizontalAxis: this.dualAxis.horizontalAxis,
+            allValues: this.allValues,
+        })
+
+        this.tooltipState.target =
+            hoverTime === undefined ? null : { time: hoverTime }
+    }
+
+    @action.bound private onDocumentClick(e: MouseEvent): void {
+        // Only dismiss the tooltip if the click is outside of the chart area
+        // and outside of the chart areas of neighboring facets
+        const chartContainer = this.manager.base?.current
+        if (!chartContainer) return
+        const chartAreas = chartContainer.getElementsByClassName(
+            LINE_CHART_CLASS_NAME
+        )
+        const isTargetOutsideChartAreas = Array.from(chartAreas).every(
+            (chartArea) => isTargetOutsideElement(e.target!, chartArea)
+        )
+        if (isTargetOutsideChartAreas) {
+            this.dismissTooltip()
+        }
+    }
+
+    override componentDidMount(): void {
+        document.addEventListener("click", this.onDocumentClick, {
+            capture: true,
+        })
+    }
+
+    override componentWillUnmount(): void {
+        document.removeEventListener("click", this.onDocumentClick, {
+            capture: true,
+        })
+    }
+
+    private renderChartElements(): React.ReactElement {
         return (
             <>
                 {this.shouldShowZeroLine ? (
@@ -694,6 +787,66 @@ export class LineChartThumbnail
                 )}
             </>
         )
+    }
+
+    private renderStatic(): React.ReactElement {
+        return this.renderChartElements()
+    }
+
+    private renderInteractive(): React.ReactElement {
+        return (
+            <g
+                ref={this.base}
+                className={LINE_CHART_CLASS_NAME}
+                onMouseLeave={this.onCursorLeave}
+                onTouchEnd={this.onCursorLeave}
+                onTouchCancel={this.onCursorLeave}
+                onMouseMove={this.onCursorMove}
+                onTouchStart={this.onCursorMove}
+                onTouchMove={this.onCursorMove}
+            >
+                <rect {...this.bounds.toProps()} fillOpacity="0">
+                    {/* This <rect> ensures that the parent <g> is big enough such that
+                        we get mouse hover events for the whole charting area, including
+                        the axis, the entity labels, and the whitespace next to them.
+                        We need these to be able to show the tooltip for the first/last
+                        year even if the mouse is outside the charting area. */}
+                </rect>
+                {this.renderChartElements()}
+                {this.isTooltipActive && (
+                    <LineChartActiveTimeMarkers
+                        times={this.activeTimes}
+                        renderSeries={this.renderSeries}
+                        dualAxis={this.dualAxis}
+                        chartState={this.chartState}
+                        dotRadius={4}
+                    />
+                )}
+                <LineChartTooltip
+                    id={this.tooltipId}
+                    chartState={this.chartState}
+                    tooltipState={this.tooltipState}
+                    series={this.renderSeries}
+                    xAxisLabel={this.xAxis.label}
+                    dismissTooltip={this.dismissTooltip}
+                />
+            </g>
+        )
+    }
+
+    override render(): React.ReactElement {
+        if (this.chartState.errorInfo.reason)
+            return (
+                <NoDataMessage
+                    manager={this.manager}
+                    bounds={this.bounds}
+                    message={this.chartState.errorInfo.reason}
+                />
+            )
+
+        return this.manager.isStatic
+            ? this.renderStatic()
+            : this.renderInteractive()
     }
 }
 

--- a/packages/@ourworldindata/grapher/src/tooltip/TooltipContainer.tsx
+++ b/packages/@ourworldindata/grapher/src/tooltip/TooltipContainer.tsx
@@ -51,7 +51,11 @@ export class Tooltip extends React.Component<ManagedTooltipProps> {
     }
 
     @action.bound private removeToolTipFromContainer(): void {
-        this.props.tooltipManager.tooltip?.set(undefined)
+        const { tooltip } = this.props.tooltipManager
+        // Clear the shared tooltip only if this instance still owns it.
+        // This prevents an older tooltip (e.g. from another facet) from
+        // clearing the active one and causing flicker while moving between facets.
+        if (tooltip?.get()?.id === this.props.id) tooltip.set(undefined)
     }
 
     override componentDidUpdate(): void {


### PR DESCRIPTION
Adds interactive tooltips to line chart thumbnails (used in faceted line charts), matching the behavior of the regular line chart. Hovering over a facet now shows the value tooltip and highlights the active time across all series in that facet.

## Examples

- http://staging-site-interactive-line-chart-thumb/grapher/global-mine-production-minerals?country=Bauxite~Salt~Mica+%28sheet%29~Gypsum~Coal~Potash~Feldspar~Copper~Manganese~Zinc~Fluorspar~Nickel~Graphite~Lithium~Niobium~Antimony~Vanadium~Cobalt~Garnet~Asbestos~Tin
- http://staging-site-interactive-line-chart-thumb/grapher/co2-emissions-and-gdp-per-capita?uniformYAxis=0&country=GBR~SWE~USA~OWID_WRL~LTU~LKA~TTO~TUR~SEN~SAU~TJK~TZA~ARG~ARM~BEN~AZE~DEU~FRA~GRC~OWID_HIC
- http://staging-site-interactive-line-chart-thumb/grapher/age-at-marriage-women?country=DNK~NOR~NLD~BEL~PRT~ITA~SVN~CHE~KOR~GRC~AUS~SVK~HRV~LTU~BGR~CZE~ISR~CYP~TUR~ROU
- http://staging-site-interactive-line-chart-thumb/grapher/annual-research-and-development-funding-for-technologies-infectious-diseases?time=earliest..2023

🤖 Generated with [Claude Code](https://claude.com/claude-code)
