### PR TITLE
🐛 (search) don't fallback to default entities as peers

### DIFF
--- a/functions/_common/search/constructSearchResultJson.test.ts
+++ b/functions/_common/search/constructSearchResultJson.test.ts
@@ -6,6 +6,7 @@ import {
     FacetStrategy,
     DimensionProperty,
     GRAPHER_CHART_TYPES,
+    PeerCountryStrategy,
 } from "@ourworldindata/types"
 import {
     GrapherState,
@@ -114,6 +115,7 @@ describe(pickDisplayEntities, () => {
         "Mexico",
         "Brazil",
         "Argentina",
+        "World",
     ]
 
     function createSingleIndicatorGrapherState(
@@ -291,27 +293,11 @@ describe(pickDisplayEntities, () => {
             expect(displayEntities).toEqual(pickedEntities)
         })
 
-        it("should combine picked and default entities", async () => {
-            const grapherState = createSingleIndicatorGrapherState({
-                selectedEntityNames: defaultEntities,
-                addCountryMode: EntitySelectionMode.MultipleEntities,
-            })
-
-            const displayEntities = await pickDisplayEntities(grapherState, {
-                pickedEntities,
-                catalogUrl: "",
-            })
-
-            expect(displayEntities).toEqual([
-                ...pickedEntities,
-                ...defaultEntities,
-            ])
-        })
-
         it("should return a unique list of entities, with picked entities first", async () => {
             const grapherState = createSingleIndicatorGrapherState({
                 selectedEntityNames: [...defaultEntities, ...pickedEntities],
                 addCountryMode: EntitySelectionMode.MultipleEntities,
+                peerCountryStrategy: PeerCountryStrategy.ParentRegions,
             })
 
             const displayEntities = await pickDisplayEntities(grapherState, {
@@ -319,10 +305,7 @@ describe(pickDisplayEntities, () => {
                 catalogUrl: "",
             })
 
-            expect(displayEntities).toEqual([
-                ...pickedEntities,
-                ...defaultEntities,
-            ])
+            expect(displayEntities).toEqual([...pickedEntities, "World"])
         })
     })
 })

--- a/functions/_common/search/constructSearchResultJson.ts
+++ b/functions/_common/search/constructSearchResultJson.ts
@@ -274,16 +274,10 @@ export async function pickDisplayEntities(
     const enrichPickedEntities = async () => {
         if (pickedEntities.length === 0) return defaultEntities
 
-        const pickedComparisonEntities = await selectPeerEntitiesForSearch({
+        const comparisonEntities = await selectPeerEntitiesForSearch({
             grapherState,
             targetEntity: pickedEntities[0],
         })
-
-        // Default to the default entities if no comparison entities could be found
-        const comparisonEntities =
-            pickedComparisonEntities.length > 0
-                ? pickedComparisonEntities
-                : defaultEntities
 
         // It's important to prepend the picked entities because we later
         // take the first N entities to render if there are space constraints


### PR DESCRIPTION
If no peer countries have been found, we currently fallback to using the default entities as peers. This makes it so that the 'None' peer strategy isn't respected