### PR TITLE
🐛 Admin origin URL autocomplete: treat spaces as dashes

### DIFF
--- a/adminSiteClient/EditorTextTab.tsx
+++ b/adminSiteClient/EditorTextTab.tsx
@@ -188,7 +188,9 @@ export class EditorTextTab<
     // Bold the substring matching the user's query in each dropdown option
     highlightMatch(text: string, query: string): JSX.Element | string {
         if (!query) return text
-        const idx = text.toLowerCase().indexOf(query.toLowerCase())
+        const idx = text
+            .toLowerCase()
+            .indexOf(query.toLowerCase().replace(/ /g, "-"))
         if (idx === -1) return text
         return (
             <>
@@ -341,7 +343,11 @@ export class EditorTextTab<
                             filterOption={(inputValue, option) =>
                                 option?.value
                                     .toLowerCase()
-                                    .includes(inputValue.toLowerCase()) ?? false
+                                    .includes(
+                                        inputValue
+                                            .toLowerCase()
+                                            .replace(/ /g, "-")
+                                    ) ?? false
                             }
                             optionRender={(option) => {
                                 const data = option.data as {

--- a/adminSiteClient/EditorTextTab.tsx
+++ b/adminSiteClient/EditorTextTab.tsx
@@ -176,7 +176,11 @@ export class EditorTextTab<
     }
 
     @action.bound onOriginUrlChange(value: string): void {
-        this.props.editor.grapherState.originUrl = value.trim() || undefined
+        // Store the raw value so trailing spaces survive mid-typing (e.g.
+        // "child " on the way to "child labor"). Treat whitespace-only as empty.
+        this.props.editor.grapherState.originUrl = value.trim()
+            ? value
+            : undefined
         // Reset so the custom URL hint reappears as the user types more
         this.isNavigatingDropdown = false
     }

--- a/adminSiteClient/EditorTextTab.tsx
+++ b/adminSiteClient/EditorTextTab.tsx
@@ -176,23 +176,15 @@ export class EditorTextTab<
     }
 
     @action.bound onOriginUrlChange(value: string): void {
-        // Store the raw value so trailing spaces survive mid-typing (e.g.
-        // "child " on the way to "child labor"). Treat whitespace-only as empty.
+        // Spaces get turned into dashes as the user types, so "child labor"
+        // becomes "child-labor" live and the stored URL never contains spaces
+        // or ends up URL-encoded as %20.
+        const normalized = value.replace(/ /g, "-")
         this.props.editor.grapherState.originUrl = value.trim()
-            ? value
+            ? normalized
             : undefined
         // Reset so the custom URL hint reappears as the user types more
         this.isNavigatingDropdown = false
-    }
-
-    @action.bound onOriginUrlBlur(): void {
-        // Spaces are a search aid only — never persist them in the stored URL.
-        // Normalize to dashes on blur so the committed value matches the
-        // slug-style options in the dropdown.
-        const { grapherState } = this.props.editor
-        if (grapherState.originUrl?.includes(" ")) {
-            grapherState.originUrl = grapherState.originUrl.replace(/ /g, "-")
-        }
     }
 
     @action.bound onDropdownNavigated(): void {
@@ -202,9 +194,7 @@ export class EditorTextTab<
     // Bold the substring matching the user's query in each dropdown option
     highlightMatch(text: string, query: string): JSX.Element | string {
         if (!query) return text
-        const idx = text
-            .toLowerCase()
-            .indexOf(query.toLowerCase().replace(/ /g, "-"))
+        const idx = text.toLowerCase().indexOf(query.toLowerCase())
         if (idx === -1) return text
         return (
             <>
@@ -357,11 +347,7 @@ export class EditorTextTab<
                             filterOption={(inputValue, option) =>
                                 option?.value
                                     .toLowerCase()
-                                    .includes(
-                                        inputValue
-                                            .toLowerCase()
-                                            .replace(/ /g, "-")
-                                    ) ?? false
+                                    .includes(inputValue.toLowerCase()) ?? false
                             }
                             optionRender={(option) => {
                                 const data = option.data as {
@@ -396,12 +382,10 @@ export class EditorTextTab<
                                     this.onDropdownNavigated()
                                 }
                             }}
-                            onBlur={this.onOriginUrlBlur}
                             dropdownRender={(menu) => {
                                 const val = grapherState.originUrl ?? ""
                                 const showHint =
                                     val.length > 4 &&
-                                    !val.includes(" ") &&
                                     !this.isNavigatingDropdown &&
                                     !this.originUrlOptions.some(
                                         (o) => o.value === val

--- a/adminSiteClient/EditorTextTab.tsx
+++ b/adminSiteClient/EditorTextTab.tsx
@@ -185,6 +185,16 @@ export class EditorTextTab<
         this.isNavigatingDropdown = false
     }
 
+    @action.bound onOriginUrlBlur(): void {
+        // Spaces are a search aid only — never persist them in the stored URL.
+        // Normalize to dashes on blur so the committed value matches the
+        // slug-style options in the dropdown.
+        const { grapherState } = this.props.editor
+        if (grapherState.originUrl?.includes(" ")) {
+            grapherState.originUrl = grapherState.originUrl.replace(/ /g, "-")
+        }
+    }
+
     @action.bound onDropdownNavigated(): void {
         this.isNavigatingDropdown = true
     }
@@ -386,10 +396,12 @@ export class EditorTextTab<
                                     this.onDropdownNavigated()
                                 }
                             }}
+                            onBlur={this.onOriginUrlBlur}
                             dropdownRender={(menu) => {
                                 const val = grapherState.originUrl ?? ""
                                 const showHint =
                                     val.length > 4 &&
+                                    !val.includes(" ") &&
                                     !this.isNavigatingDropdown &&
                                     !this.originUrlOptions.some(
                                         (o) => o.value === val


### PR DESCRIPTION
## Summary
In the chart editor → Text tab, the **Origin url** autocomplete now converts any space you type into a dash in real time, so typing `child labor` becomes `child-labor` in the input (and the dropdown filters to `/child-labor` as you go). The stored URL never contains a space and never ends up URL-encoded as `%20`.

The change is localized to [adminSiteClient/EditorTextTab.tsx](adminSiteClient/EditorTextTab.tsx): a one-line `replace(/ /g, "-")` in `onOriginUrlChange`. All other filter / highlight / dropdown logic stays as it was.

## Why
Every topic slug uses `-` as a separator. Forcing users to type the dash breaks the natural flow of searching; spacebar is the instinctive keystroke between words. Doing the conversion at input time keeps the saved value clean and avoids any chance of `%20` leaking into stored URLs.

## Test plan
- [x] Open any chart in the admin → **Text** tab.
- [x] In **Origin url**, type `child labor` (with a space). The input should display `child-labor` — each space should flip to a dash as it's typed.
- [x] `/child-labor` should appear in the dropdown with `child-labor` bolded.
- [x] Picking it from the dropdown stores `/child-labor` (no spaces, no `%20`).
- [x] Typing `child-labor` directly still works identically (regression check).
- [x] Typing an unrelated query (e.g. `zzz`) still falls back to the "Enter to use custom URL" hint.
- [x] Clearing the field still resets `originUrl` to `undefined`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)