### PR TITLE
fix(admin): set authored version so we can know the author's "intended time"

### DIFF
--- a/adminSiteClient/ChartEditorView.tsx
+++ b/adminSiteClient/ChartEditorView.tsx
@@ -10,6 +10,7 @@ import {
     reaction,
     IReactionDisposer,
     makeObservable,
+    comparer,
 } from "mobx"
 import { Prompt, Redirect } from "react-router-dom"
 import {
@@ -370,6 +371,19 @@ export class ChartEditorView<
                     this.grapherState.staticBounds = this.staticBounds
                     this.grapherState.externalBounds = this.bounds
                 }
+            )
+        )
+        this.disposers.push(
+            reaction(
+                () => this.editor?.fullConfig,
+                () => {
+                    // Update the authoredVersion, as it's being used for "author's minTime & maxTime" in some places.
+                    if (this.editor?.fullConfig)
+                        this.editor?.grapherState.setAuthoredVersion(
+                            this.editor?.fullConfig
+                        )
+                },
+                { equals: comparer.structural }
             )
         )
     }


### PR DESCRIPTION
Fixes an edge case where the admin & published chart would show different times, because `authoredVersion` was different between the two.

Chart: https://admin.owid.io/admin/charts/6701/edit?tab=revisions

Built by sophia & ike & me.