### PR TITLE
Improve GrapherWithFallback logic

### DIFF
--- a/site/GrapherFigureView.tsx
+++ b/site/GrapherFigureView.tsx
@@ -70,6 +70,10 @@ export function GrapherFigureView(
         <figure className="chart grapher-component" ref={base}>
             {bounds && (
                 <FetchingGrapher
+                    // Remount when switching between chart configs (e.g. related charts)
+                    // so we don't briefly render the previous GrapherState while
+                    // fetching the new config/data.
+                    key={configUrl ?? slug}
                     config={config}
                     configUrl={configUrl}
                     dataApiUrl={DATA_API_URL}

--- a/site/GrapherImage.tsx
+++ b/site/GrapherImage.tsx
@@ -27,12 +27,14 @@ function GrapherImageSource({
 }
 
 export default function GrapherImage(props: {
+    className?: string
     url: string
     alt?: string
     noFormatting?: boolean
     enablePopulatingUrlParams?: boolean
 }): React.ReactElement
 export default function GrapherImage(props: {
+    className?: string
     slug: string
     queryString?: string
     alt?: string
@@ -40,6 +42,7 @@ export default function GrapherImage(props: {
     enablePopulatingUrlParams?: boolean
 }): React.ReactElement
 export default function GrapherImage(props: {
+    className?: string
     url?: string
     slug?: string
     queryString?: string
@@ -63,6 +66,7 @@ export default function GrapherImage(props: {
     const defaultSrc = `${GRAPHER_DYNAMIC_THUMBNAIL_URL}/${slug}.png${queryString}`
     return (
         <picture
+            className={props.className}
             // This tells our Cloudflare functions to replace the src with the dynamic thumbnail URL, including URL params like `?time=2020`.
             // Enabling this option only makes sense if this is the _main_ chart on a _standalone_ grapher/data page - it will pass on the URL params from the page to the thumbnail.
             data-owid-populate-url-params={props.enablePopulatingUrlParams}

--- a/site/GrapherWithFallback.tsx
+++ b/site/GrapherWithFallback.tsx
@@ -1,4 +1,4 @@
-import { GRAPHER_PREVIEW_CLASS } from "@ourworldindata/types"
+import { HIDE_IF_JS_ENABLED_CLASSNAME } from "@ourworldindata/types"
 import { GrapherFigureView } from "./GrapherFigureView.js"
 import cx from "classnames"
 import GrapherImage from "./GrapherImage.js"
@@ -19,9 +19,7 @@ export interface GrapherWithFallbackProps {
     isPreviewing?: boolean
 }
 
-export function GrapherWithFallback(
-    props: GrapherWithFallbackProps
-): React.ReactElement {
+export function GrapherWithFallback(props: GrapherWithFallbackProps) {
     const { slug, className, id, config, queryStr, isPreviewing } = props
 
     if (!slug && !props.configUrl) {
@@ -31,35 +29,10 @@ export function GrapherWithFallback(
     }
 
     const isClient = useIsClient()
-    const { ref, isIntersecting: hasBeenVisible } = useIntersectionObserver({
+    const { ref, isIntersecting: shouldLoadGrapher } = useIntersectionObserver({
         rootMargin: "400px",
-        // Only trigger once
         freezeOnceVisible: true,
     })
-
-    // Render fallback png when javascript disabled or while
-    // grapher is loading
-    const imageFallback = (
-        <figure
-            className={cx(
-                GRAPHER_PREVIEW_CLASS,
-                "GrapherWithFallback__fallback"
-            )}
-        >
-            {props.configUrl ? (
-                <GrapherImage
-                    url={props.configUrl}
-                    enablePopulatingUrlParams={props.enablePopulatingUrlParams}
-                />
-            ) : (
-                <GrapherImage
-                    slug={slug!}
-                    queryString={queryStr}
-                    enablePopulatingUrlParams={props.enablePopulatingUrlParams}
-                />
-            )}
-        </figure>
-    )
 
     return (
         <div
@@ -71,9 +44,7 @@ export function GrapherWithFallback(
             id={id}
             ref={ref}
         >
-            {!isClient ? (
-                imageFallback
-            ) : hasBeenVisible ? (
+            {isClient && shouldLoadGrapher ? (
                 <GrapherFigureView
                     slug={slug}
                     configUrl={props.configUrl}
@@ -85,8 +56,34 @@ export function GrapherWithFallback(
                     isPreviewing={isPreviewing}
                 />
             ) : (
-                // Optional loading placeholder while waiting to come into view
-                imageFallback
+                <figure
+                    className={cx(
+                        "chart",
+                        "GrapherWithFallback__fallback",
+                        className
+                    )}
+                    aria-hidden={isClient}
+                >
+                    {!isClient &&
+                        (props.configUrl ? (
+                            <GrapherImage
+                                className={HIDE_IF_JS_ENABLED_CLASSNAME}
+                                url={props.configUrl}
+                                enablePopulatingUrlParams={
+                                    props.enablePopulatingUrlParams
+                                }
+                            />
+                        ) : (
+                            <GrapherImage
+                                className={HIDE_IF_JS_ENABLED_CLASSNAME}
+                                slug={slug!}
+                                queryString={queryStr}
+                                enablePopulatingUrlParams={
+                                    props.enablePopulatingUrlParams
+                                }
+                            />
+                        ))}
+                </figure>
             )}
         </div>
     )

--- a/site/blocks/RelatedCharts.test.tsx
+++ b/site/blocks/RelatedCharts.test.tsx
@@ -3,7 +3,7 @@
  */
 
 import { expect, it } from "vitest"
-import { render, screen, fireEvent, getByRole } from "@testing-library/react"
+import { render, screen, fireEvent } from "@testing-library/react"
 import { GRAPHER_DYNAMIC_THUMBNAIL_URL } from "../../settings/clientSettings.js"
 import { KeyChartLevel } from "@ourworldindata/utils"
 import { RelatedCharts } from "./RelatedCharts.js"
@@ -42,23 +42,10 @@ it("renders active chart links and loads respective chart on click", () => {
     expect(links).toHaveLength(2)
 
     links.forEach((link, i) => {
-        // Chart 2 has a higher priority, so the charts should be in reverse order: `Chart 2, Chart 1`
-        const expectedChartIdx = 1 - i
         fireEvent.click(link)
-
         expect(screen.getByText(`Chart ${i + 1} of 2`)).toBeTruthy()
-
-        // The GrapherWithFallback component might not be rendered immediately
-        // or might be rendered with a different class name
-        const grapher = screen.getByRole("figure")
-        const img = getByRole(grapher, "img")
-        expect(img).toBeTruthy()
-
-        // Check if the slug is in the src attribute or data attributes
-        const src =
-            img.getAttribute("data-grapher-src") || img.getAttribute("src")
-
-        expect(src).toContain(charts[expectedChartIdx].slug)
+        expect(listItems[i].classList.contains("active")).toBe(true)
+        expect(document.getElementById(`related-chart-${i}`)).toBeTruthy()
     })
 
     expect(

--- a/site/css/content.scss
+++ b/site/css/content.scss
@@ -57,6 +57,10 @@
     height: $grapher-height;
 }
 
+html.js-disabled .article-content figure.GrapherWithFallback__fallback {
+    height: auto;
+}
+
 figure[data-explorer-src] {
     position: relative;
 }

--- a/site/gdocs/components/Chart.scss
+++ b/site/gdocs/components/Chart.scss
@@ -2,6 +2,10 @@ figure.chart:not(.grapherPreview) {
     height: $grapher-height;
 }
 
+html.js-disabled figure.chart.GrapherWithFallback__fallback {
+    height: auto;
+}
+
 figure.explorer {
     height: 700px;
 }


### PR DESCRIPTION
- Show fallback image only when JS is disabled
- Otherwise, render Grapher, which has its own loading indicator

This should improve the UX especially on data pages, where the image previously flashed for a brief moment before the Grapher started loading.

## Context

[Slack](https://owid.slack.com/archives/C46U9LXRR/p1775055275597579)

## Testing guidance

Check that the behavior is correct in data pages and articles.

- [x] Does the change work in the archive?
  - Yes, but we don't load fallback images there.
