### PR TITLE
✨ reverse order of entities in the No data section

### DIFF
--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
@@ -572,12 +572,14 @@ export class ScatterPlotChart
 
     @computed
     private get selectedEntitiesWithoutData(): string[] {
+        // Reversing the order so that newly added entities without data
+        // show up at the top of the no data section
         const entitiesWithoutData = _.uniq(
             _.difference(
                 this.selectedEntityNames,
                 this.series.map((s) => s.seriesName)
             )
-        )
+        ).reverse()
 
         return entitiesWithoutData.map((entityName) => {
             const shortName = getShortNameForEntity(entityName)

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
@@ -833,9 +833,12 @@ export class SlopeChart
             this.sidebarWidth,
             this.bounds.height
         )
-        const seriesNames = this.noDataSeries.map((series) =>
-            this.makeMissingDataLabel(series)
-        )
+
+        // Reversing the order so that newly added entities without data
+        // show up at the top of the no data section
+        const seriesNames = this.noDataSeries
+            .map((series) => this.makeMissingDataLabel(series))
+            .reverse()
 
         return (
             <NoDataSection


### PR DESCRIPTION
Reverses the order of entities listed in the No Data section of scatters and slope charts, so that newly added entities show up at the top of the list