### PR TITLE
🐛🤖 Deduplicate lightning GDoc bake slugs

### DIFF
--- a/baker/BuildkiteTrigger.test.ts
+++ b/baker/BuildkiteTrigger.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { BuildkiteTrigger } from "./BuildkiteTrigger.js"
+
+describe(BuildkiteTrigger, () => {
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    it("deduplicates gdoc slugs for lightning builds", async () => {
+        const buildkite = new BuildkiteTrigger()
+        const triggerBuild = vi
+            .spyOn(buildkite, "triggerBuild")
+            .mockResolvedValue(123)
+        const waitForBuildToFinish = vi
+            .spyOn(buildkite, "waitForBuildToFinish")
+            .mockResolvedValue(undefined)
+
+        await buildkite.runLightningBuild(
+            ["hiring-writer-2026", "hiring-writer-2026"],
+            {
+                title: "Lightning update hiring-writer-2026",
+                changesSlackMentions: [],
+            }
+        )
+
+        expect(triggerBuild).toHaveBeenCalledWith(
+            "⚡️ Lightning update hiring-writer-2026",
+            {
+                LIGHTNING_GDOC_SLUGS: "hiring-writer-2026",
+                CHANGES_SLACK_MENTIONS: "",
+            }
+        )
+        expect(waitForBuildToFinish).toHaveBeenCalledWith(123)
+    })
+})

--- a/baker/BuildkiteTrigger.ts
+++ b/baker/BuildkiteTrigger.ts
@@ -1,4 +1,5 @@
 import { DeployMetadata } from "@ourworldindata/utils"
+import * as _ from "lodash-es"
 import {
     BUILDKITE_API_ACCESS_TOKEN,
     BUILDKITE_DEPLOY_CONTENT_PIPELINE_SLUG,
@@ -108,13 +109,14 @@ export class BuildkiteTrigger {
         gdocSlugs: string[],
         { title, changesSlackMentions }: DeployMetadata
     ): Promise<void> {
+        const uniqueGdocSlugs = _.uniq(gdocSlugs)
         const message = `⚡️ ${title}${
-            gdocSlugs.length > 1
-                ? ` and ${gdocSlugs.length - 1} more updates`
+            uniqueGdocSlugs.length > 1
+                ? ` and ${uniqueGdocSlugs.length - 1} more updates`
                 : ""
         }`
         const buildNumber = await this.triggerBuild(message, {
-            LIGHTNING_GDOC_SLUGS: gdocSlugs.join(" "),
+            LIGHTNING_GDOC_SLUGS: uniqueGdocSlugs.join(" "),
             CHANGES_SLACK_MENTIONS: changesSlackMentions.join("\n"),
         })
         await this.waitForBuildToFinish(buildNumber)

--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -661,6 +661,7 @@ export class SiteBaker {
     async bakeGDocPosts(knex: db.KnexReadonlyTransaction, slugs?: string[]) {
         if (!this.bakeSteps.has("gdocPosts")) return
         this.progressBar.tick({ name: "Baking Google doc posts" })
+        const slugsToBake = slugs === undefined ? undefined : _.uniq(slugs)
         // We don't need to call `load` on these, because we prefetch all attachments
         const publishedGdocs = await db
             .getPublishedGdocsWithTags(knex)
@@ -670,8 +671,10 @@ export class SiteBaker {
             await db.getTagHierarchiesByChildName(knex)
 
         const gdocsToBake =
-            slugs !== undefined
-                ? publishedGdocs.filter((gdoc) => slugs.includes(gdoc.slug))
+            slugsToBake !== undefined
+                ? publishedGdocs.filter((gdoc) =>
+                      slugsToBake.includes(gdoc.slug)
+                  )
                 : publishedGdocs
 
         const gdocIds = gdocsToBake.map((gdoc) => gdoc.id)
@@ -685,12 +688,12 @@ export class SiteBaker {
                 : {}
 
         // Ensure we have a published gdoc for each slug given
-        if (slugs !== undefined && slugs.length !== gdocsToBake.length) {
-            const slugsNotFound = slugs.filter(
+        if (slugsToBake && slugsToBake.length !== gdocsToBake.length) {
+            const slugsNotFound = slugsToBake.filter(
                 (slug) => !gdocsToBake.some((gdoc) => gdoc.slug === slug)
             )
             throw new Error(
-                `Some of the gdoc slugs were not found or are not published: ${slugsNotFound}`
+                `Some of the gdoc slugs were not found or are not published: ${slugsNotFound.join(", ")}`
             )
         }
 


### PR DESCRIPTION
Deduplicate GDoc slugs before triggering Buildkite lightning builds and before validating targeted bakes. Add a regression test for duplicate lightning deploy slugs.

Resolves ADMIN-GY

## Context

[Buildkite](https://buildkite.com/our-world-in-data/owid-deploy-content-master/builds/17636/steps/canvas)