### PR TITLE
Prevent Grapher initial bounds flash

### DIFF
--- a/packages/@ourworldindata/grapher/package.json
+++ b/packages/@ourworldindata/grapher/package.json
@@ -46,6 +46,7 @@
         "topojson-client": "^3.1.0",
         "ts-pattern": "^5.8.0",
         "url-join": "^5.0.0",
+        "usehooks-ts": "^3.1.1",
         "versor": "^0.2.0"
     },
     "devDependencies": {

--- a/packages/@ourworldindata/grapher/src/core/FetchingGrapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/FetchingGrapher.tsx
@@ -8,6 +8,7 @@ import { unstable_batchedUpdates } from "react-dom"
 import { migrateGrapherConfigToLatestVersion } from "../schema/migrations/migrate.js"
 import { useMaybeGlobalGrapherStateRef } from "../chart/guidedChartUtils.js"
 import { loadCatalogData } from "./loadCatalogData.js"
+import { useIsomorphicLayoutEffect } from "usehooks-ts"
 
 export interface FetchingGrapherProps {
     config?: GrapherProgrammaticInterface
@@ -44,7 +45,9 @@ export function FetchingGrapher(
         isConfigReady: !props.configUrl,
     })
 
-    React.useEffect(() => {
+    // Keep the MobX state in sync before paint so Grapher doesn't render a
+    // frame at stale/default bounds.
+    useIsomorphicLayoutEffect(() => {
         if (props.externalBounds) {
             grapherState.current.externalBounds = props.externalBounds
         }

--- a/packages/@ourworldindata/grapher/src/hooks.ts
+++ b/packages/@ourworldindata/grapher/src/hooks.ts
@@ -10,6 +10,7 @@ import {
     type DataDownloadContextBase,
     type DataDownloadContextServerSide,
 } from "./download.js"
+import { useIsomorphicLayoutEffect } from "usehooks-ts"
 
 /**
  * Like useState, but clearing (setting to undefined) is debounced.
@@ -91,19 +92,52 @@ export function useDataApiDownloadConfig({
 
 // Auto-updating Bounds object based on ResizeObserver
 // Optionally throttles the bounds updates
-export const useElementBounds = (
+export function useElementBounds(ref: RefObject<HTMLElement | null>): Bounds
+export function useElementBounds(
     ref: RefObject<HTMLElement | null>,
-    initialValue: Bounds = DEFAULT_GRAPHER_BOUNDS,
-    throttleTime: number | undefined = 100
-) => {
-    const [bounds, setBounds] = useState<Bounds>(initialValue)
+    initialValue: Bounds,
+    throttleTime?: number
+): Bounds
+export function useElementBounds(
+    ref: RefObject<HTMLElement | null>,
+    initialValue: undefined,
+    throttleTime?: number
+): Bounds | undefined
+export function useElementBounds(
+    ref: RefObject<HTMLElement | null>,
+    ...options:
+        | []
+        | [initialValue: Bounds, throttleTime?: number]
+        | [initialValue: undefined, throttleTime?: number]
+): Bounds | undefined {
+    const initialValue =
+        options.length === 0 ? DEFAULT_GRAPHER_BOUNDS : options[0]
+    const throttleTime = options[1] ?? 100
+    const [bounds, setBounds] = useState<Bounds | undefined>(initialValue)
 
     const updateBoundsImmediately = useCallback(
         (width: number, height: number) => {
-            setBounds(new Bounds(0, 0, width, height))
+            setBounds((currentBounds) => {
+                if (
+                    currentBounds?.width === width &&
+                    currentBounds.height === height
+                ) {
+                    return currentBounds
+                }
+
+                return new Bounds(0, 0, width, height)
+            })
         },
         []
     )
+
+    useIsomorphicLayoutEffect(() => {
+        const element = ref.current
+        if (!element) return
+
+        const { width, height } = element.getBoundingClientRect()
+        updateBoundsImmediately(width, height)
+    }, [ref, updateBoundsImmediately])
 
     const updateBoundsThrottled = useMemo(
         () =>

--- a/packages/@ourworldindata/grapher/src/hooks.ts
+++ b/packages/@ourworldindata/grapher/src/hooks.ts
@@ -92,28 +92,16 @@ export function useDataApiDownloadConfig({
 
 // Auto-updating Bounds object based on ResizeObserver
 // Optionally throttles the bounds updates
-export function useElementBounds(ref: RefObject<HTMLElement | null>): Bounds
-export function useElementBounds(
+//
+// The `T` type parameter narrows the return type based on `initialValue`:
+// passing `null` widens the return to `Bounds | null` (so callers can detect
+// the pre-measurement state); omitting it keeps the return as `Bounds`.
+export function useElementBounds<T extends Bounds | null = Bounds>(
     ref: RefObject<HTMLElement | null>,
-    initialValue: Bounds,
-    throttleTime?: number
-): Bounds
-export function useElementBounds(
-    ref: RefObject<HTMLElement | null>,
-    initialValue: undefined,
-    throttleTime?: number
-): Bounds | undefined
-export function useElementBounds(
-    ref: RefObject<HTMLElement | null>,
-    ...options:
-        | []
-        | [initialValue: Bounds, throttleTime?: number]
-        | [initialValue: undefined, throttleTime?: number]
-): Bounds | undefined {
-    const initialValue =
-        options.length === 0 ? DEFAULT_GRAPHER_BOUNDS : options[0]
-    const throttleTime = options[1] ?? 100
-    const [bounds, setBounds] = useState<Bounds | undefined>(initialValue)
+    initialValue: T = DEFAULT_GRAPHER_BOUNDS as T,
+    throttleTime: number = 100
+): Bounds | T {
+    const [bounds, setBounds] = useState<Bounds | T>(initialValue)
 
     const updateBoundsImmediately = useCallback(
         (width: number, height: number) => {

--- a/site/GrapherFigureView.tsx
+++ b/site/GrapherFigureView.tsx
@@ -35,7 +35,10 @@ export function GrapherFigureView(
     }
 
     const base = useRef<HTMLDivElement>(null)
-    const bounds = useElementBounds(base)
+    // Wait for the figure to be measured before mounting Grapher. Otherwise,
+    // embedded charts briefly render at DEFAULT_GRAPHER_BOUNDS (850px wide)
+    // before ResizeObserver reports the actual container size.
+    const bounds = useElementBounds(base, undefined)
 
     const config: GrapherProgrammaticInterface = useMemo(() => {
         return {

--- a/site/GrapherFigureView.tsx
+++ b/site/GrapherFigureView.tsx
@@ -38,7 +38,7 @@ export function GrapherFigureView(
     // Wait for the figure to be measured before mounting Grapher. Otherwise,
     // embedded charts briefly render at DEFAULT_GRAPHER_BOUNDS (850px wide)
     // before ResizeObserver reports the actual container size.
-    const bounds = useElementBounds(base, undefined)
+    const bounds = useElementBounds(base, null)
 
     const config: GrapherProgrammaticInterface = useMemo(() => {
         return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3156,6 +3156,7 @@ __metadata:
     topojson-client: "npm:^3.1.0"
     ts-pattern: "npm:^5.8.0"
     url-join: "npm:^5.0.0"
+    usehooks-ts: "npm:^3.1.1"
     versor: "npm:^0.2.0"
     vitest: "npm:^4.1.2"
   languageName: unknown


### PR DESCRIPTION
Measure embedded Grapher figures before mounting and sync external bounds before paint, so data page and GDoc embeds don't briefly render at the default 850px width.