### PR TITLE
Always hide controls of charts in ChartStory

### DIFF
--- a/site/gdocs/components/Chart.tsx
+++ b/site/gdocs/components/Chart.tsx
@@ -15,10 +15,12 @@ export default function Chart({
     d,
     className,
     fullWidthOnMobile = false,
+    hideControls = false,
 }: {
     d: EnrichedBlockChart
     className?: string
     fullWidthOnMobile?: boolean
+    hideControls?: boolean
 }) {
     const { isPreviewing, archiveContext } = useDocumentContext()
     const refChartContainer = useRef<HTMLDivElement>(null)
@@ -39,6 +41,10 @@ export default function Chart({
     // This means we can link to the same chart multiple times with different querystrings
     // and it should all resolve correctly via the same linkedChart
     const { linkedChart } = useLinkedChart(d.url)
+    const configType = linkedChart?.configType
+    const isExplorer = configType === ChartConfigType.Explorer
+    const isMultiDim = configType === ChartConfigType.MultiDim
+    const shouldApplyHideControls = hideControls && (isExplorer || isMultiDim)
     const resolvedUrl = linkedChart?.resolvedUrl ?? ""
     const resolvedUrlParsed = useMemo(() => {
         let baseUrl = Url.fromURL(resolvedUrl)
@@ -50,8 +56,12 @@ export default function Chart({
             })
         }
 
+        if (shouldApplyHideControls) {
+            baseUrl = baseUrl.updateQueryParams({ hideControls: "true" })
+        }
+
         return baseUrl
-    }, [resolvedUrl, d.peerCountries])
+    }, [resolvedUrl, d.peerCountries, shouldApplyHideControls])
     const resolvedQueryParams = useMemo(() => {
         return { ...resolvedUrlParsed.queryParams }
     }, [resolvedUrlParsed])
@@ -61,12 +71,10 @@ export default function Chart({
         }),
         [linkedChart?.archivedPageVersion]
     )
-    const configType = linkedChart?.configType
-    const isExplorer = configType === ChartConfigType.Explorer
-    const isMultiDim = configType === ChartConfigType.MultiDim
-    const hasControls = resolvedUrlParsed.queryParams.hideControls !== "true"
-    const isExplorerWithControls = isExplorer && hasControls
-    const isMultiDimWithControls = isMultiDim && hasControls
+    const controlsAreVisible =
+        resolvedUrlParsed.queryParams.hideControls !== "true"
+    const isExplorerWithControls = isExplorer && controlsAreVisible
+    const isMultiDimWithControls = isMultiDim && controlsAreVisible
 
     const archivedChartVersion = linkedChart?.archivedPageVersion
     const shouldRenderArchiveEmbed =
@@ -175,7 +183,7 @@ export default function Chart({
                 </figure>
             ) : isMultiDim ? (
                 <MultiDimEmbed
-                    url={resolvedUrl}
+                    url={resolvedUrlParsed.fullUrl}
                     chartConfig={chartConfig}
                     isPreviewing={isPreviewing}
                 />

--- a/site/gdocs/components/ChartStory.tsx
+++ b/site/gdocs/components/ChartStory.tsx
@@ -56,7 +56,11 @@ export default function ChartStory({
                 {/* We use the key to reset the state of multi-dims when they
                 only differ by query params. Consider lifting the state up to
                 avoid re-rendering the whole component. */}
-                <Chart key={currentSlide.chart.url} d={currentSlide.chart} />
+                <Chart
+                    key={currentSlide.chart.url}
+                    d={currentSlide.chart}
+                    hideControls
+                />
             </div>
             {showDetails ? (
                 <>


### PR DESCRIPTION
Even if the user doesn't specify it manually, we hide the controls (dropdowns of explorers and multi-dims) since they compete with ChartStory's own controls (arrows).  
  
[Slack](https://owid.slack.com/archives/C03NV9Z3YSV/p1776718193993799?thread_ts=1776624040.140859&cid=C03NV9Z3YSV)