### PR TITLE
Simplify article chart sizing

### DIFF
--- a/packages/@ourworldindata/explorer/src/Explorer.tsx
+++ b/packages/@ourworldindata/explorer/src/Explorer.tsx
@@ -248,6 +248,10 @@ export class Explorer
             isEmbeddedInAnOwidPage: this.props.isEmbeddedInAnOwidPage,
             adminBaseUrl: this.adminBaseUrl,
             canHideExternalControlsInEmbed: true,
+            // Iframe embeds are 600px tall when external controls are hidden.
+            // Explorer controls need another 96px, so the embed code we
+            // recommend for explorers with controls is 696px tall.
+            recommendedIframeEmbedHeight: 696,
             archiveContext: props.archiveContext,
             additionalDataLoaderFn: (catalogKey) =>
                 loadCatalogData(catalogKey, {

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -109,6 +109,7 @@ export interface GrapherProgrammaticInterface extends GrapherInterface {
     isConfigReady?: boolean
     isDataReady?: boolean
     canHideExternalControlsInEmbed?: boolean
+    recommendedIframeEmbedHeight?: number
 
     narrativeChartInfo?: MinimalNarrativeChartInfo
     archiveContext?: ArchiveContext

--- a/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
@@ -583,6 +583,7 @@ export class GrapherState
     hideControlsRow = false
     hideRelatedQuestion = false
     canHideExternalControlsInEmbed: boolean = false
+    recommendedIframeEmbedHeight?: number
     hideExternalControlsInEmbedUrl: boolean =
         this.canHideExternalControlsInEmbed
     forceHideAnnotationFieldsInTitle: AnnotationFieldsInTitle = {
@@ -712,6 +713,7 @@ export class GrapherState
             isConfigReady: observable,
             isDataReady: observable,
             canHideExternalControlsInEmbed: observable.ref,
+            recommendedIframeEmbedHeight: observable.ref,
             hideExternalControlsInEmbedUrl: observable.ref,
             isExportingToSvgOrPng: observable.ref,
             isWikimediaExport: observable.ref,
@@ -762,6 +764,7 @@ export class GrapherState
         this.setAuthoredVersion(options)
         this.canHideExternalControlsInEmbed =
             options.canHideExternalControlsInEmbed ?? false
+        this.recommendedIframeEmbedHeight = options.recommendedIframeEmbedHeight
         this.staticBounds = options.staticBounds ?? DEFAULT_GRAPHER_BOUNDS
 
         this.narrativeChartInfo = options.narrativeChartInfo

--- a/packages/@ourworldindata/grapher/src/modal/EmbedModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/EmbedModal.tsx
@@ -18,6 +18,7 @@ export interface EmbedModalManager {
     hideExternalControlsInEmbedUrl: boolean
     setHideExternalControlsInEmbedUrl: (value: boolean) => void
     frameBounds?: Bounds
+    recommendedIframeEmbedHeight?: number
 }
 
 interface EmbedModalProps {
@@ -94,8 +95,17 @@ export class EmbedModal extends React.Component<EmbedModalProps> {
         return opts
     }
 
+    @computed private get iframeEmbedHeight(): number {
+        // The base iframe embed height is 600px. Explorers and multi-dims can
+        // override this when their external controls are visible, because those
+        // controls live inside the iframe and need extra vertical space.
+        return this.manager.hideExternalControlsInEmbedUrl
+            ? 600
+            : (this.manager.recommendedIframeEmbedHeight ?? 600)
+    }
+
     private codeSnippetForUrl(url: string): string {
-        return `<iframe src="${url}" loading="lazy" style="width: 100%; height: 600px; border: 0px none;" allow="web-share; clipboard-write"></iframe>`
+        return `<iframe src="${url}" loading="lazy" style="width: 100%; height: ${this.iframeEmbedHeight}px; border: 0px none;" allow="web-share; clipboard-write"></iframe>`
     }
 
     @action.bound private onDismiss(): void {

--- a/site/MultiDimEmbed.tsx
+++ b/site/MultiDimEmbed.tsx
@@ -43,7 +43,7 @@ export function MultiDimEmbed({
     const shouldRenderMultiDim = isClient && hasBeenVisible && config
 
     return (
-        <div ref={ref}>
+        <div className="multi-dim-embed" ref={ref}>
             {shouldRenderMultiDim ? (
                 <MultiDim
                     slug={slug}

--- a/site/gdocs/components/Chart.scss
+++ b/site/gdocs/components/Chart.scss
@@ -6,8 +6,58 @@ html.js-disabled figure.chart.GrapherWithFallback__fallback {
     height: auto;
 }
 
-figure.explorer {
+.owid-chart-frame {
+    width: 100%;
+    height: $grapher-height;
+
+    figure,
+    .GrapherWithFallback,
+    .GrapherWithFallback > figure,
+    .multi-dim-embed,
+    .multi-dim-container,
+    .multi-dim-grapher-container,
+    .Explorer,
+    .ExplorerFigure {
+        width: 100%;
+        height: 100%;
+        margin: 0;
+    }
+
+    .GrapherComponent {
+        display: block;
+        margin: 0 auto;
+    }
+
+    .Explorer {
+        max-width: none;
+        min-height: 0;
+        max-height: none;
+    }
+
+    .ExplorerFigure {
+        min-height: 0;
+        max-height: none;
+    }
+}
+
+.owid-chart-frame--explorer-with-controls {
     height: 700px;
+}
+
+.owid-chart-frame--multi-dim-with-controls {
+    // Let the settings panel take as much space as it needs, while keeping the
+    // Grapher itself at the expected article embed height.
+    height: auto;
+
+    .multi-dim-embed,
+    .multi-dim-container {
+        height: auto;
+    }
+
+    .multi-dim-grapher-container {
+        flex: 0 0 auto;
+        height: $grapher-height;
+    }
 }
 
 div.margin-0 figure {

--- a/site/gdocs/components/Chart.tsx
+++ b/site/gdocs/components/Chart.tsx
@@ -11,6 +11,9 @@ import { MultiDimEmbed } from "../../MultiDimEmbed.js"
 import { useEmbedChart } from "../../hooks.js"
 import { useDocumentContext } from "../DocumentContext.js"
 
+const DEFAULT_CHART_HEIGHT = "575px"
+const CHART_WITH_EXTERNAL_CONTROLS_HEIGHT = "700px"
+
 export default function Chart({
     d,
     className,
@@ -75,6 +78,7 @@ export default function Chart({
         resolvedUrlParsed.queryParams.hideControls !== "true"
     const isExplorerWithControls = isExplorer && controlsAreVisible
     const isMultiDimWithControls = isMultiDim && controlsAreVisible
+    const hasExternalControls = isExplorerWithControls || isMultiDimWithControls
 
     const archivedChartVersion = linkedChart?.archivedPageVersion
     const shouldRenderArchiveEmbed =
@@ -120,7 +124,9 @@ export default function Chart({
 
     if (shouldRenderArchiveEmbed && archiveUrl) {
         const defaultHeight =
-            isMultiDimWithControls || isExplorerWithControls ? "680px" : "600px"
+            isExplorerWithControls || isMultiDimWithControls
+                ? CHART_WITH_EXTERNAL_CONTROLS_HEIGHT
+                : DEFAULT_CHART_HEIGHT
         return (
             <div
                 className={cx(className, {
@@ -158,45 +164,49 @@ export default function Chart({
             })}
             ref={refChartContainer}
         >
-            {isExplorer ? (
-                <figure
-                    // Use unique `key` to force React to re-render tree
-                    key={resolvedUrl}
-                    className={cx({
-                        [GRAPHER_PREVIEW_CLASS]: !isExplorer,
-                        chart:
-                            !isExplorerWithControls && !isMultiDimWithControls,
-                        explorer: isExplorerWithControls,
-                        "multi-dim": isMultiDimWithControls,
-                    })}
-                    data-grapher-src={isExplorer ? undefined : resolvedUrl}
-                    data-explorer-src={
-                        isExplorer ? resolvedUrlParsed.fullUrl : undefined
-                    }
-                    style={{
-                        width: "100%",
-                        border: "0px none",
-                        height: d.height,
-                    }}
-                >
-                    <div className="js--show-warning-block-if-js-disabled" />
-                </figure>
-            ) : isMultiDim ? (
-                <MultiDimEmbed
-                    url={resolvedUrlParsed.fullUrl}
-                    chartConfig={chartConfig}
-                    isPreviewing={isPreviewing}
-                />
-            ) : (
-                <GrapherWithFallback
-                    slug={slug}
-                    config={chartConfig}
-                    queryStr={queryStr}
-                    isEmbeddedInAnOwidPage={true}
-                    isEmbeddedInADataPage={false}
-                    isPreviewing={isPreviewing}
-                />
-            )}
+            <div
+                className={cx("owid-chart-frame", {
+                    "owid-chart-frame--explorer-with-controls":
+                        isExplorerWithControls,
+                    "owid-chart-frame--multi-dim-with-controls":
+                        isMultiDimWithControls,
+                })}
+                style={d.height ? { height: d.height } : undefined}
+            >
+                {isExplorer ? (
+                    <figure
+                        // Use unique `key` to force React to re-render tree
+                        key={resolvedUrl}
+                        className={cx({
+                            [GRAPHER_PREVIEW_CLASS]: !isExplorer,
+                            chart: !hasExternalControls,
+                            explorer: isExplorerWithControls,
+                            "multi-dim": isMultiDimWithControls,
+                        })}
+                        data-grapher-src={isExplorer ? undefined : resolvedUrl}
+                        data-explorer-src={
+                            isExplorer ? resolvedUrlParsed.fullUrl : undefined
+                        }
+                    >
+                        <div className="js--show-warning-block-if-js-disabled" />
+                    </figure>
+                ) : isMultiDim ? (
+                    <MultiDimEmbed
+                        url={resolvedUrlParsed.fullUrl}
+                        chartConfig={chartConfig}
+                        isPreviewing={isPreviewing}
+                    />
+                ) : (
+                    <GrapherWithFallback
+                        slug={slug}
+                        config={chartConfig}
+                        queryStr={queryStr}
+                        isEmbeddedInAnOwidPage={true}
+                        isEmbeddedInADataPage={false}
+                        isPreviewing={isPreviewing}
+                    />
+                )}
+            </div>
             {d.caption ? (
                 <figcaption>
                     <SpanElements spans={d.caption} />

--- a/site/gdocs/components/centered-article.scss
+++ b/site/gdocs/components/centered-article.scss
@@ -870,15 +870,6 @@ div.raw-html-table__container {
     width: 100%;
     margin: 32px 0 48px 0;
 
-    figure {
-        margin: 0;
-    }
-
-    .GrapherComponent {
-        display: block;
-        margin: 0 auto;
-    }
-
     .Explorer {
         label {
             margin-bottom: 0;

--- a/site/multiDim/MultiDim.scss
+++ b/site/multiDim/MultiDim.scss
@@ -1,11 +1,14 @@
 .multi-dim-container {
     display: flex;
     flex-direction: column;
+    width: 100%;
+    height: 100%;
 }
 
 .multi-dim-grapher-container {
-    flex-grow: 1;
-    min-height: $grapher-height;
+    flex: 1 1 auto;
+    min-height: 0;
+    width: 100%;
 }
 
 html.IsInIframe {

--- a/site/multiDim/hooks.ts
+++ b/site/multiDim/hooks.ts
@@ -30,6 +30,10 @@ export const useBaseGrapherConfig = (
             adminBaseUrl: ADMIN_BASE_URL,
             dataApiUrl: DATA_API_URL,
             canHideExternalControlsInEmbed: true,
+            // Iframe embeds are 600px tall when external controls are hidden.
+            // Multi-dim controls need another 74px, so the embed code we
+            // recommend for multi-dims with controls is 674px tall.
+            recommendedIframeEmbedHeight: 674,
             ...additionalConfig,
         }
     }, [additionalConfig])


### PR DESCRIPTION
- Use a shared article chart frame for Graphers, Explorers, and multi-dims.
- Let multi-dims fill their parent while the frame owns embed sizing. This fixes a bug where multi-dims could have extreme height in a
ChartStory.
- Adjust public iframe snippets so visible multi-dim and Explorer controls still leave about 600px for the Grapher.

## Context

[Slack ](https://owid.slack.com/archives/C03NV9Z3YSV/p1776624040140859)

## Testing guidance

In theory, check that all internal and external embeds of all chart types work correctly. I checked most of them already. Biggest difference is the ChartStory usage in SDGs, where we fix the sizing of normal graphers and multi-dims.

- [x] Does the change work in the archive?

## Checklist

(delete all that do not apply)

### Before merging

- [x] Changes to CSS/HTML were checked on Desktop and Mobile Safari at all three breakpoints
- [x] Changes to HTML were checked for accessibility concerns