### PR TITLE
🔨🤖 Restrict fetchAllWork to article/topic-page types and include titles

### DIFF
--- a/adminSiteServer/apiRoutes/misc.ts
+++ b/adminSiteServer/apiRoutes/misc.ts
@@ -1,31 +1,38 @@
-// Get an ArchieML output of all the work produced by an author. This includes
-// gdoc articles, gdoc modular/linear topic pages and wordpress modular topic
-// pages. Data insights are excluded. This is used to manually populate the
-// [.secondary] section of the {.research-and-writing} block of author pages
-
-import { DbRawPostGdoc, JsonError } from "@ourworldindata/types"
+import {
+    DbRawPostGdoc,
+    JsonError,
+    OwidGdocPostContent,
+} from "@ourworldindata/types"
 
 import * as db from "../../db/db.js"
 import * as lodash from "lodash-es"
 import { expectInt } from "../../serverUtils/serverUtil.js"
 import { Request } from "../authentication.js"
 import { HandlerResponse } from "../FunctionalRouter.js"
+
+// Get an ArchieML output of all the work produced by an author. Includes only
+// gdoc articles and gdoc modular/linear topic pages — other gdoc types
+// (data-insight, fragment, about-page, author, etc.) are excluded. Each entry
+// is emitted as a :skip/:endskip ArchieML comment containing the gdoc title,
+// followed by the gdoc edit url. This is used to manually populate the
+// [.secondary] section of the {.research-and-writing} block of author pages
 // using the alternate template, which highlights topics rather than articles.
 export async function fetchAllWork(
     req: Request,
     res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ) {
-    type GdocRecord = Pick<DbRawPostGdoc, "id" | "publishedAt">
+    type GdocRecord = Pick<DbRawPostGdoc, "id" | "publishedAt"> &
+        Pick<OwidGdocPostContent, "title">
 
     const author = req.query.author
     const gdocs = await db.knexRaw<GdocRecord>(
         trx,
         `-- sql
-            SELECT id
+            SELECT id, content ->> '$.title' AS title
             FROM posts_gdocs
             WHERE JSON_CONTAINS(authors, ?)
-            AND type NOT IN ("data-insight", "fragment")
+            AND type IN ("article", "topic-page", "linear-topic-page")
             AND published = 1
             ORDER BY publishedAt DESC
     `,
@@ -33,7 +40,8 @@ export async function fetchAllWork(
     )
 
     const archieLines = gdocs.map(
-        (post) => `url: https://docs.google.com/document/d/${post.id}/edit`
+        (post) =>
+            `:skip\n${post.title}\n:endskip\nurl: https://docs.google.com/document/d/${post.id}/edit`
     )
 
     res.type("text/plain")


### PR DESCRIPTION
## Summary
- Restrict the `/api/all-work` endpoint to `article`, `topic-page`, and `linear-topic-page` (previously excluded `data-insight` and `fragment` only, which let through unrelated types like `about-page`, `author`, `homepage`, `announcement`, etc.)
- Pull the gdoc title from `content ->> '$.title'` and emit it as a `:skip` / `:endskip` ArchieML comment above each url, so the output is easier to scan when populating the `[.secondary]` section of an author page

## Context
The endpoint is used by editors to bulk-populate the `[.secondary]` list of an author's *Research & writing* block (alternate template, which highlights topics rather than articles). Previously the output was a flat list of urls with no titles, and included gdoc types that don't belong in that section (e.g. data insights were excluded but about-pages and announcements still slipped through). With this change the editor gets a titled, scannable list limited to articles and topic pages, ready to paste in.

## Test plan
- [x] Hit the endpoint for an author ([example](http://staging-site-restrict-fetch-all-work-type/admin/api/all-work?author=Pablo%20Rosado)) and confirm the output now contains `:skip` / `:endskip` blocks with titles, and excludes about/author/announcement/etc. types

🤖 Generated with [Claude Code](https://claude.com/claude-code)