### PR TITLE
Trigger Buildkite deploys directly

### DIFF
--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -2,6 +2,7 @@
 
 import { TaggableType } from "@ourworldindata/types"
 import { DeployQueueServer } from "../baker/DeployQueueServer.js"
+import { BuildkiteTrigger } from "../baker/BuildkiteTrigger.js"
 import {
     updateVariableAnnotations,
     getChartBulkUpdate,
@@ -77,6 +78,7 @@ import {
     handleDeleteChartRedirect,
 } from "./apiRoutes/redirects.js"
 import { triggerStaticBuild } from "../baker/GrapherBakingUtils.js"
+import { BUILDKITE_API_ACCESS_TOKEN } from "../settings/serverSettings.js"
 import {
     suggestGptTopics,
     suggestGptAltTextForCloudflareImage,
@@ -644,7 +646,9 @@ postRouteWithRWTransaction(apiRouter, "/slack/sendMessage", sendMessageToSlack)
 
 // Deploy helpers
 apiRouter.get("/deploys.json", async () => ({
-    deploys: await new DeployQueueServer().getDeploys(),
+    deploys: BUILDKITE_API_ACCESS_TOKEN
+        ? await new BuildkiteTrigger().getUnfinishedDeploys()
+        : await new DeployQueueServer().getDeploys(),
 }))
 
 apiRouter.put("/deploy", async (req, res) => {

--- a/adminSiteServer/apiRoutes/routeUtils.ts
+++ b/adminSiteServer/apiRoutes/routeUtils.ts
@@ -1,7 +1,11 @@
 import * as _ from "lodash-es"
 import { DbPlainUser } from "@ourworldindata/types"
 import { DeployQueueServer } from "../../baker/DeployQueueServer.js"
-import { BAKE_ON_CHANGE } from "../../settings/serverSettings.js"
+import { triggerBuildkiteDeploy } from "../../baker/BuildkiteDeployUtils.js"
+import {
+    BAKE_ON_CHANGE,
+    BUILDKITE_API_ACCESS_TOKEN,
+} from "../../settings/serverSettings.js"
 
 export const enqueueLightningChange = async (
     user: DbPlainUser,
@@ -15,13 +19,17 @@ export const enqueueLightningChange = async (
         return
     }
 
-    return new DeployQueueServer().enqueueChange({
+    const change = {
         timeISOString: new Date().toISOString(),
         authorName: user.fullName,
         authorEmail: user.email,
         message: commitMessage,
         slug,
-    })
+    }
+
+    if (BUILDKITE_API_ACCESS_TOKEN) return triggerBuildkiteDeploy([change])
+
+    return new DeployQueueServer().enqueueChange(change)
 }
 
 /**

--- a/baker/BuildkiteDeployUtils.ts
+++ b/baker/BuildkiteDeployUtils.ts
@@ -1,10 +1,7 @@
 import * as _ from "lodash-es"
 import { WebClient } from "@slack/web-api"
 import { DeployChange, DeployMetadata } from "@ourworldindata/utils"
-import {
-    ENV,
-    SLACK_BOT_OAUTH_TOKEN,
-} from "../settings/serverSettings.js"
+import { ENV, SLACK_BOT_OAUTH_TOKEN } from "../settings/serverSettings.js"
 import { BuildkiteTrigger } from "./BuildkiteTrigger.js"
 
 export const getChangesAuthorNames = (queueItems: DeployChange[]): string[] => {

--- a/baker/BuildkiteDeployUtils.ts
+++ b/baker/BuildkiteDeployUtils.ts
@@ -1,0 +1,130 @@
+import * as _ from "lodash-es"
+import { WebClient } from "@slack/web-api"
+import { DeployChange, DeployMetadata } from "@ourworldindata/utils"
+import {
+    ENV,
+    SLACK_BOT_OAUTH_TOKEN,
+} from "../settings/serverSettings.js"
+import { BuildkiteTrigger } from "./BuildkiteTrigger.js"
+
+export const getChangesAuthorNames = (queueItems: DeployChange[]): string[] => {
+    // Do not remove duplicates here, because we want to show the history of changes within a deploy
+    return queueItems
+        .map((item) => `${item.message} (by ${item.authorName})`)
+        .filter(Boolean)
+}
+
+export const getChangesSlackMentions = async (
+    queueItems: DeployChange[]
+): Promise<string[]> => {
+    const emailSlackMentionMap = await getEmailSlackMentionsMap(queueItems)
+
+    // Do not remove duplicates here, because we want to show the history of changes within a deploy
+    return queueItems.map(
+        (item) =>
+            `${item.message} (by ${
+                !item.authorEmail
+                    ? item.authorName
+                    : (emailSlackMentionMap.get(item.authorEmail) ??
+                      item.authorName)
+            })`
+    )
+}
+
+export const getDeployMetadata = async (
+    queueItems: DeployChange[]
+): Promise<DeployMetadata> => {
+    const changesAuthorNames = getChangesAuthorNames(queueItems)
+    const changesSlackMentions = await getChangesSlackMentions(queueItems)
+    return {
+        title: changesAuthorNames[0],
+        changesSlackMentions,
+    }
+}
+
+export const triggerBuildkiteDeploy = async (
+    queueItems: DeployChange[]
+): Promise<void> => {
+    if (!queueItems.length) return
+
+    const buildkite = new BuildkiteTrigger()
+    const deployMetadata = await getDeployMetadata(queueItems)
+
+    if (queueItems.every(isLightningChange)) {
+        await buildkite.triggerLightningBuild(
+            queueItems.map((change) => change.slug!),
+            deployMetadata
+        )
+    } else {
+        await buildkite.triggerFullBuild(deployMetadata)
+    }
+}
+
+const getEmailSlackMentionsMap = async (
+    queueItems: DeployChange[]
+): Promise<Map<string, string>> => {
+    if (ENV === "staging" || !SLACK_BOT_OAUTH_TOKEN) return new Map()
+
+    const slackClient = new WebClient(SLACK_BOT_OAUTH_TOKEN)
+
+    // Get unique author emails
+    const uniqueAuthorEmails = [
+        ...new Set(queueItems.map((item) => item.authorEmail)),
+    ]
+
+    // Get a Map of email -> Slack mention (e.g. "<@U123456>")
+    const emailSlackMentionMap = new Map()
+    await Promise.all(
+        uniqueAuthorEmails.map(async (authorEmail) => {
+            if (authorEmail) {
+                const slackId = await getSlackMentionByEmail(
+                    authorEmail,
+                    slackClient
+                )
+                if (slackId) {
+                    emailSlackMentionMap.set(authorEmail, slackId)
+                }
+            }
+        })
+    )
+
+    return emailSlackMentionMap
+}
+
+/**
+ * Get a Slack mention for a given email address. Format it according to the
+ * Slack API requirements to mention a user in a message
+ * (https://api.slack.com/reference/surfaces/formatting#mentioning-users).
+ * Slack has a tight limit of 20 requests per minute for email lookups, so we
+ * memoize this.
+ */
+const getSlackMentionByEmail = _.memoize(
+    async (
+        email: string | undefined,
+        slackClient: WebClient
+    ): Promise<string | undefined> => {
+        if (!email || email === "etl@ourworldindata.org") return
+
+        try {
+            const response = await slackClient.users.lookupByEmail({ email })
+            return response.user?.id ? `<@${response.user.id}>` : undefined
+        } catch (error) {
+            // Handle users_not_found gracefully - user might not be in Slack workspace
+            if (error && typeof error === "object" && "data" in error) {
+                const slackError = error as { data?: { error?: string } }
+                if (slackError.data?.error === "users_not_found") {
+                    console.warn(`User not found in Slack workspace: ${email}`)
+                    return undefined
+                }
+            }
+            // For other Slack API errors, log but don't fail the deploy
+            console.error(
+                `Warning: Could not look up email "${email}" in Slack:`,
+                error
+            )
+            return undefined
+        }
+    }
+)
+
+const isLightningChange = (item: DeployChange) => item.slug

--- a/baker/BuildkiteTrigger.ts
+++ b/baker/BuildkiteTrigger.ts
@@ -1,4 +1,4 @@
-import { DeployMetadata } from "@ourworldindata/utils"
+import { Deploy, DeployMetadata, DeployStatus } from "@ourworldindata/utils"
 import * as _ from "lodash-es"
 import {
     BUILDKITE_API_ACCESS_TOKEN,
@@ -6,7 +6,7 @@ import {
     BUILDKITE_BRANCH,
     BUILDKITE_DEPLOY_CONTENT_SLACK_CHANNEL,
 } from "../settings/serverSettings.js"
-import { defaultCommitMessage } from "./DeployUtils.js"
+import fs from "fs-extra"
 
 type BuildState =
     | "running"
@@ -21,28 +21,58 @@ type BuildState =
     | "not_run"
     | "finished"
 
+interface BuildkiteBuild {
+    number: number
+    state: BuildState
+    message?: string
+    created_at?: string
+    creator?: {
+        name?: string
+        email?: string
+    }
+}
+
+const queuedBuildStates: BuildState[] = ["scheduled"]
+const pendingBuildStates: BuildState[] = ["running", "canceling", "failing"]
+
+const defaultCommitMessage = async (): Promise<string> => {
+    let message = "Automated update"
+
+    // In the deploy.sh script, we write the current git rev to 'public/head.txt'
+    // and want to include it in the deploy commit message
+    try {
+        const sha = await fs.readFile("public/head.txt", "utf8")
+        message += `\nowid/owid-grapher@${sha}`
+    } catch (err) {
+        console.warn(err)
+    }
+
+    return message
+}
+
 export class BuildkiteTrigger {
     private readonly organizationSlug = "our-world-in-data"
     private readonly pipelineSlug = BUILDKITE_DEPLOY_CONTENT_PIPELINE_SLUG
     private readonly branch = BUILDKITE_BRANCH
+    private readonly buildsUrl = `https://api.buildkite.com/v2/organizations/${this.organizationSlug}/pipelines/${this.pipelineSlug}/builds`
+
+    private get headers(): Record<string, string> {
+        return {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${BUILDKITE_API_ACCESS_TOKEN}`,
+        }
+    }
 
     async triggerBuild(
         message: string,
         env: { [key: string]: string }
     ): Promise<number> {
         // Trigger buildkite build and return its number.
-        const url = `https://api.buildkite.com/v2/organizations/${this.organizationSlug}/pipelines/${this.pipelineSlug}/builds`
-
         const apiAccessToken = BUILDKITE_API_ACCESS_TOKEN
         if (!apiAccessToken) {
             throw new Error(
                 "BUILDKITE_API_ACCESS_TOKEN environment variable not set"
             )
-        }
-
-        const headers = {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${BUILDKITE_API_ACCESS_TOKEN}`,
         }
 
         const payload = {
@@ -52,15 +82,15 @@ export class BuildkiteTrigger {
             env: { ...env, BUILDKITE_DEPLOY_CONTENT_SLACK_CHANNEL },
         }
 
-        const response = await fetch(url, {
+        const response = await fetch(this.buildsUrl, {
             method: "POST",
-            headers: headers,
+            headers: this.headers,
             body: JSON.stringify(payload),
         })
 
         if (response.status === 201) {
             console.log("Build successfully triggered!")
-            const resp = await response.json()
+            const resp = (await response.json()) as BuildkiteBuild
             return resp.number
         } else {
             const errorText = await response.text()
@@ -70,30 +100,24 @@ export class BuildkiteTrigger {
 
     async waitForBuildToFinish(buildNumber: number): Promise<void> {
         // Wait for build to finish.
-        const url = `https://api.buildkite.com/v2/organizations/${this.organizationSlug}/pipelines/${this.pipelineSlug}/builds/${buildNumber}`
-
-        const headers = {
-            Authorization: `Bearer ${BUILDKITE_API_ACCESS_TOKEN}`,
-        }
+        const url = `${this.buildsUrl}/${buildNumber}`
 
         let state: BuildState = "scheduled"
 
-        while (
-            ["running", "scheduled", "canceling", "failing"].includes(state)
-        ) {
+        while ([...queuedBuildStates, ...pendingBuildStates].includes(state)) {
             // Wait for 10 seconds
             await new Promise((res) => setTimeout(res, 10000))
 
             const response = await fetch(url, {
                 method: "GET",
-                headers: headers,
+                headers: this.headers,
             })
             if (!response.ok) {
                 const errorText = await response.text()
                 throw new Error(`Error: ${response.status}\n${errorText}`)
             }
 
-            const buildData = await response.json()
+            const buildData = (await response.json()) as BuildkiteBuild
             state = buildData.state
         }
 
@@ -105,38 +129,120 @@ export class BuildkiteTrigger {
         }
     }
 
-    async runLightningBuild(
+    async getUnfinishedDeploys(): Promise<Deploy[]> {
+        const url = new URL(this.buildsUrl)
+        url.searchParams.set("branch", this.branch)
+        url.searchParams.set("per_page", "50")
+
+        const response = await fetch(url, {
+            method: "GET",
+            headers: this.headers,
+        })
+        if (!response.ok) {
+            const errorText = await response.text()
+            throw new Error(`Error: ${response.status}\n${errorText}`)
+        }
+
+        const builds = (await response.json()) as BuildkiteBuild[]
+        const queuedChanges = builds
+            .filter((build) => queuedBuildStates.includes(build.state))
+            .map((build) => this.buildkiteBuildToDeployChange(build))
+        const pendingChanges = builds
+            .filter((build) => pendingBuildStates.includes(build.state))
+            .map((build) => this.buildkiteBuildToDeployChange(build))
+
+        return [
+            ...(queuedChanges.length
+                ? [
+                      {
+                          status: DeployStatus.queued,
+                          changes: queuedChanges,
+                      },
+                  ]
+                : []),
+            ...(pendingChanges.length
+                ? [
+                      {
+                          status: DeployStatus.pending,
+                          changes: pendingChanges,
+                      },
+                  ]
+                : []),
+        ]
+    }
+
+    private buildkiteBuildToDeployChange(build: BuildkiteBuild) {
+        return {
+            timeISOString: build.created_at,
+            authorName: build.creator?.name ?? build.creator?.email,
+            authorEmail: build.creator?.email,
+            message: build.message ?? `Buildkite build #${build.number}`,
+        }
+    }
+
+    getLightningBuildMessage(
         gdocSlugs: string[],
-        { title, changesSlackMentions }: DeployMetadata
-    ): Promise<void> {
+        { title }: DeployMetadata
+    ): string {
         const uniqueGdocSlugs = _.uniq(gdocSlugs)
-        const message = `⚡️ ${title}${
+        return `⚡️ ${title}${
             uniqueGdocSlugs.length > 1
                 ? ` and ${uniqueGdocSlugs.length - 1} more updates`
                 : ""
         }`
-        const buildNumber = await this.triggerBuild(message, {
-            LIGHTNING_GDOC_SLUGS: uniqueGdocSlugs.join(" "),
-            CHANGES_SLACK_MENTIONS: changesSlackMentions.join("\n"),
-        })
+    }
+
+    async triggerLightningBuild(
+        gdocSlugs: string[],
+        deployMetadata: DeployMetadata
+    ): Promise<number> {
+        const uniqueGdocSlugs = _.uniq(gdocSlugs)
+        return this.triggerBuild(
+            this.getLightningBuildMessage(gdocSlugs, deployMetadata),
+            {
+                LIGHTNING_GDOC_SLUGS: uniqueGdocSlugs.join(" "),
+                CHANGES_SLACK_MENTIONS:
+                    deployMetadata.changesSlackMentions.join("\n"),
+            }
+        )
+    }
+
+    async runLightningBuild(
+        gdocSlugs: string[],
+        deployMetadata: DeployMetadata
+    ): Promise<void> {
+        const buildNumber = await this.triggerLightningBuild(
+            gdocSlugs,
+            deployMetadata
+        )
         await this.waitForBuildToFinish(buildNumber)
     }
 
-    async runFullBuild({
+    async getFullBuildMessage({
         title,
         changesSlackMentions,
-    }: DeployMetadata): Promise<void> {
-        const message = changesSlackMentions.length
+    }: DeployMetadata): Promise<string> {
+        return changesSlackMentions.length
             ? `🚚 ${title}${
                   changesSlackMentions.length > 1
                       ? ` and ${changesSlackMentions.length - 1} more updates`
                       : ""
               } `
             : await defaultCommitMessage()
+    }
 
-        const buildNumber = await this.triggerBuild(message, {
-            CHANGES_SLACK_MENTIONS: changesSlackMentions.join("\n"),
-        })
+    async triggerFullBuild(deployMetadata: DeployMetadata): Promise<number> {
+        return this.triggerBuild(
+            await this.getFullBuildMessage(deployMetadata),
+            {
+                CHANGES_SLACK_MENTIONS:
+                    deployMetadata.changesSlackMentions.join("\n"),
+            }
+        )
+    }
+
+    async runFullBuild(deployMetadata: DeployMetadata): Promise<void> {
+        const buildNumber = await this.triggerFullBuild(deployMetadata)
         await this.waitForBuildToFinish(buildNumber)
     }
 }

--- a/baker/DeployUtils.ts
+++ b/baker/DeployUtils.ts
@@ -1,35 +1,19 @@
-import * as _ from "lodash-es"
-import fs from "fs-extra"
-import { BuildkiteTrigger } from "../baker/BuildkiteTrigger.js"
 import { DeployQueueServer } from "./DeployQueueServer.js"
 import {
     BAKED_SITE_DIR,
     BAKED_BASE_URL,
     BUILDKITE_API_ACCESS_TOKEN,
-    SLACK_BOT_OAUTH_TOKEN,
-    ENV,
 } from "../settings/serverSettings.js"
 import { SiteBaker } from "../baker/SiteBaker.js"
-import { WebClient } from "@slack/web-api"
 import { DeployChange, DeployMetadata } from "@ourworldindata/utils"
 import { KnexReadonlyTransaction } from "../db/db.js"
+import {
+    getChangesAuthorNames,
+    getDeployMetadata,
+    triggerBuildkiteDeploy,
+} from "./BuildkiteDeployUtils.js"
 
 const deployQueueServer = new DeployQueueServer()
-
-export const defaultCommitMessage = async (): Promise<string> => {
-    let message = "Automated update"
-
-    // In the deploy.sh script, we write the current git rev to 'public/head.txt'
-    // and want to include it in the deploy commit message
-    try {
-        const sha = await fs.readFile("public/head.txt", "utf8")
-        message += `\nowid/owid-grapher@${sha}`
-    } catch (err) {
-        console.warn(err)
-    }
-
-    return message
-}
 
 /**
  * Initiate a deploy, without any checks. Throws error on failure.
@@ -42,15 +26,8 @@ const triggerBakeAndDeploy = async (
 ) => {
     // deploy to Buildkite if we're on master and BUILDKITE_API_ACCESS_TOKEN is set
     if (BUILDKITE_API_ACCESS_TOKEN) {
-        const buildkite = new BuildkiteTrigger()
-        if (lightningQueue?.length) {
-            await buildkite.runLightningBuild(
-                lightningQueue.map((change) => change.slug!),
-                deployMetadata
-            )
-        } else {
-            await buildkite.runFullBuild(deployMetadata)
-        }
+        const queueItems = lightningQueue ?? [{ message: deployMetadata.title }]
+        await triggerBuildkiteDeploy(queueItems)
     } else {
         // otherwise, bake locally. This is used for local development or staging servers
         const baker = new SiteBaker(BAKED_SITE_DIR, BAKED_BASE_URL)
@@ -68,98 +45,6 @@ const triggerBakeAndDeploy = async (
     }
 }
 
-const getChangesAuthorNames = (queueItems: DeployChange[]): string[] => {
-    // Do not remove duplicates here, because we want to show the history of changes within a deploy
-    return queueItems
-        .map((item) => `${item.message} (by ${item.authorName})`)
-        .filter(Boolean)
-}
-
-const getChangesSlackMentions = async (
-    queueItems: DeployChange[]
-): Promise<string[]> => {
-    const emailSlackMentionMap = await getEmailSlackMentionsMap(queueItems)
-
-    // Do not remove duplicates here, because we want to show the history of changes within a deploy
-    return queueItems.map(
-        (item) =>
-            `${item.message} (by ${
-                !item.authorEmail
-                    ? item.authorName
-                    : (emailSlackMentionMap.get(item.authorEmail) ??
-                      item.authorName)
-            })`
-    )
-}
-
-const getEmailSlackMentionsMap = async (
-    queueItems: DeployChange[]
-): Promise<Map<string, string>> => {
-    if (ENV === "staging" || !SLACK_BOT_OAUTH_TOKEN) return new Map()
-
-    const slackClient = new WebClient(SLACK_BOT_OAUTH_TOKEN)
-
-    // Get unique author emails
-    const uniqueAuthorEmails = [
-        ...new Set(queueItems.map((item) => item.authorEmail)),
-    ]
-
-    // Get a Map of email -> Slack mention (e.g. "<@U123456>")
-    const emailSlackMentionMap = new Map()
-    await Promise.all(
-        uniqueAuthorEmails.map(async (authorEmail) => {
-            if (authorEmail) {
-                const slackId = await getSlackMentionByEmail(
-                    authorEmail,
-                    slackClient
-                )
-                if (slackId) {
-                    emailSlackMentionMap.set(authorEmail, slackId)
-                }
-            }
-        })
-    )
-
-    return emailSlackMentionMap
-}
-
-/**
- *
- * Get a Slack mention for a given email address. Format it according to the
- * Slack API requirements to mention a user in a message
- * (https://api.slack.com/reference/surfaces/formatting#mentioning-users).
- * Slack has a tight limit of 20 requests per minute for email lookups, so we
- * memoize this.
- */
-const getSlackMentionByEmail = _.memoize(
-    async (
-        email: string | undefined,
-        slackClient: WebClient
-    ): Promise<string | undefined> => {
-        if (!email || email === "etl@ourworldindata.org") return
-
-        try {
-            const response = await slackClient.users.lookupByEmail({ email })
-            return response.user?.id ? `<@${response.user.id}>` : undefined
-        } catch (error) {
-            // Handle users_not_found gracefully - user might not be in Slack workspace
-            if (error && typeof error === "object" && "data" in error) {
-                const slackError = error as { data?: { error?: string } }
-                if (slackError.data?.error === "users_not_found") {
-                    console.warn(`User not found in Slack workspace: ${email}`)
-                    return undefined
-                }
-            }
-            // For other Slack API errors, log but don't fail the deploy
-            console.error(
-                `Warning: Could not look up email "${email}" in Slack:`,
-                error
-            )
-            return undefined
-        }
-    }
-)
-
 /**
  * Initiate deploy if no other deploy is currently pending, and there are changes
  * in the queue.
@@ -170,6 +55,8 @@ const getSlackMentionByEmail = _.memoize(
 export const deployIfQueueIsNotEmpty = async (
     knex: KnexReadonlyTransaction
 ) => {
+    if (BUILDKITE_API_ACCESS_TOKEN) return
+
     if (!(await deployQueueServer.queueIsEmpty())) {
         const deployContent =
             await deployQueueServer.readQueuedAndPendingFiles()
@@ -191,9 +78,8 @@ export const deployIfQueueIsNotEmpty = async (
             )}\n---`
         )
 
-        const changesSlackMentions = await getChangesSlackMentions(parsedQueue)
         await triggerBakeAndDeploy(
-            { title: changesAuthorNames[0], changesSlackMentions },
+            await getDeployMetadata(parsedQueue),
             knex,
             // If every DeployChange is a lightning change, then we can do a
             // lightning deploy. In the future, we might want to separate

--- a/baker/GrapherBakingUtils.ts
+++ b/baker/GrapherBakingUtils.ts
@@ -6,8 +6,12 @@ import * as db from "../db/db.js"
 import { DbPlainTag, DbPlainUser } from "@ourworldindata/utils"
 import { isPathRedirectedToExplorer } from "../explorerAdminServer/ExplorerRedirects.js"
 import { hashMd5 } from "../serverUtils/hash.js"
-import { BAKE_ON_CHANGE } from "../settings/serverSettings.js"
+import {
+    BAKE_ON_CHANGE,
+    BUILDKITE_API_ACCESS_TOKEN,
+} from "../settings/serverSettings.js"
 import { DeployQueueServer } from "./DeployQueueServer.js"
+import { triggerBuildkiteDeploy } from "./BuildkiteDeployUtils.js"
 
 // Combines a grapher slug, and potentially its query string, to _part_ of an export file
 // name. It's called fileKey and not fileName because the actual export filename also includes
@@ -97,10 +101,14 @@ export const triggerStaticBuild = async (
         return
     }
 
-    return new DeployQueueServer().enqueueChange({
+    const change = {
         timeISOString: new Date().toISOString(),
         authorName: user.fullName,
         authorEmail: user.email,
         message: commitMessage,
-    })
+    }
+
+    if (BUILDKITE_API_ACCESS_TOKEN) return triggerBuildkiteDeploy([change])
+
+    return new DeployQueueServer().enqueueChange(change)
 }


### PR DESCRIPTION
## Motivation

Buildkite is now the deploy orchestrator for these environments, so we should not keep a second custom deploy orchestrator in front of it. The legacy .queue/.pending files made sense for local baking, but in Buildkite-backed deploys they can fight with Buildkite's own queueing/skipping behavior. In particular, when Buildkite restarts services, restarting deploy-queue can make the legacy pending-file recovery trigger another Buildkite build.

## Summary

- Trigger Buildkite deploy-content builds directly from admin deploy requests when Buildkite is configured.
- Read unfinished Buildkite builds for the admin deploy status page instead of relying on local queue files in Buildkite-backed environments.
- Make the deploy queue worker a no-op in Buildkite-backed environments.
- Keep the legacy .queue/.pending deploy worker path for non-Buildkite/local baking only.

## Testing

- yarn test run --reporter dot baker/BuildkiteTrigger.test.ts baker/DeployQueueServer.test.ts
- yarn testLintChanged
- yarn testFormatChanged

I attempted ./db/tests/run-db-tests.sh locally, but Docker is not running in this environment, so I used the CI failure logs to fix the import/coupling issue instead.