### PR TITLE
✨ hide tick marks when x-axis is shared

### DIFF
--- a/packages/@ourworldindata/grapher/src/axis/Axis.ts
+++ b/packages/@ourworldindata/grapher/src/axis/Axis.ts
@@ -621,16 +621,20 @@ export class HorizontalAxis extends AbstractAxis {
         return this.rangeSize
     }
 
-    // note that we intentionally don't take `hideAxisLabels` into account here.
-    // tick labels might be hidden in faceted charts. when faceted, it's important
-    // the axis size doesn't change as a result of hiding the axis labels, or else
-    // we might end up with misaligned axes.
     @computed get height(): number {
-        if (this.hideAxis) return 0
-        const { labelOffset, tickPadding } = this
+        const {
+            hideAxis,
+            labelOffset,
+            tickPadding,
+            config: { minSize = 0 },
+        } = this
+
+        if (hideAxis) return 0
+
         const maxTickHeight = _.max(this.tickLabels.map((tick) => tick.height))
-        const tickHeight = maxTickHeight ? maxTickHeight + tickPadding : 0
-        return Math.max(tickHeight + labelOffset, this.config.minSize ?? 0)
+        const paddedTickHeight = maxTickHeight ? maxTickHeight + tickPadding : 0
+
+        return Math.max(paddedTickHeight + labelOffset, minSize)
     }
 
     @computed get size(): number {
@@ -743,17 +747,19 @@ export class VerticalAxis extends AbstractAxis {
         return this.labelHeight
     }
 
-    // note that we intentionally don't take `hideAxisLabels` into account here.
-    // tick labels might be hidden in faceted charts. when faceted, it's important
-    // the axis size doesn't change as a result of hiding the axis labels, or else
-    // we might end up with misaligned axes.
     @computed get width(): number {
-        if (this.hideAxis) return 0
-        const { tickPadding } = this
+        const {
+            hideAxis,
+            tickPadding,
+            config: { minSize = 0 },
+        } = this
+
+        if (hideAxis) return 0
+
         const maxTickWidth = _.max(this.tickLabels.map((tick) => tick.width))
-        const tickWidth =
-            maxTickWidth !== undefined ? maxTickWidth + tickPadding : 0
-        return Math.max(tickWidth, this.config.minSize ?? 0)
+        const paddedTickWidth = maxTickWidth ? maxTickWidth + tickPadding : 0
+
+        return Math.max(paddedTickWidth, minSize)
     }
 
     @computed get height(): number {

--- a/packages/@ourworldindata/grapher/src/facet/FacetChart.test.ts
+++ b/packages/@ourworldindata/grapher/src/facet/FacetChart.test.ts
@@ -135,16 +135,40 @@ describe("uniform axes", () => {
     it("x axis is shown on all facets", () => {
         expect(xAxisConfigs.every((config) => !config?.hideAxis)).toBeTruthy()
     })
+})
 
-    // it("shared bottom axis is shown in first row of facets", () => {
-    //     const first = chart.placedSeries[0]
-    //     const last = chart.placedSeries[xAxisConfigs.length - 1]
-    //     expect(first.bounds.height).toBeGreaterThan(last.bounds.height)
-    //     expect(first.bounds.height).toBeCloseTo(
-    //         last.bounds.height + (xAxisConfigs[0]?.minSize ?? 0),
-    //         0
-    //     )
-    // })
+describe("shared x axis", () => {
+    const table = SynthesizeGDPTable({
+        timeRange: [2000, 2010],
+        entityCount: 12,
+    })
+    const manager: ChartManager = {
+        table,
+        selection: table.availableEntityNames,
+        facetStrategy: FacetStrategy.entity,
+        yAxisConfig: {
+            facetDomain: FacetAxisDomain.shared,
+        },
+    }
+    const chart = new FacetChart({
+        manager,
+        chartTypeName: GRAPHER_CHART_TYPES.StackedBar,
+    })
+    const xAxisConfigs = chart.placedSeries.map(
+        (series) => series.manager.xAxisConfig
+    )
+
+    it("some x axes are hidden", () => {
+        expect(
+            xAxisConfigs.some((config) => config?.hideAxis === true)
+        ).toBeTruthy()
+    })
+
+    it("bottom-row facets have taller bounds than inner facets", () => {
+        const first = chart.placedSeries[0]
+        const last = chart.placedSeries[chart.placedSeries.length - 1]
+        expect(last.bounds.height).toBeGreaterThan(first.bounds.height)
+    })
 })
 
 describe("config overrides", () => {

--- a/packages/@ourworldindata/grapher/src/facet/FacetChart.tsx
+++ b/packages/@ourworldindata/grapher/src/facet/FacetChart.tsx
@@ -382,24 +382,24 @@ export class FacetChart
 
     @computed private get isSharedYAxis(): boolean {
         // When the Y axis is uniform for all facets:
-        // - for most charts, we want to only show the axis on the left-most facet charts, and omit
-        //   it on the others
-        // - for bar charts the Y axis is plotted horizontally, so we don't want to omit it
-        return (
-            this.uniformYAxis &&
-            ![
-                GRAPHER_CHART_TYPES.StackedDiscreteBar,
-                GRAPHER_CHART_TYPES.DiscreteBar,
-            ].includes(this.chartTypeName as any)
-        )
+        // - For most charts, we want to only show the axis on the left-most
+        //   facet charts, and omit it on the others
+        // - For bar charts, the Y axis is plotted horizontally, so we don't
+        //   want to omit it
+        const isHorizontalYAxis =
+            this.chartTypeName === GRAPHER_CHART_TYPES.DiscreteBar ||
+            this.chartTypeName === GRAPHER_CHART_TYPES.StackedDiscreteBar
+
+        return this.uniformYAxis && !isHorizontalYAxis
     }
 
     @computed private get isSharedXAxis(): boolean {
         return (
             this.uniformXAxis &&
-            // TODO: do this for stacked area charts and line charts as well?
-            this.chartTypeName === GRAPHER_CHART_TYPES.StackedBar &&
-            this.facetCount >= SHARED_X_AXIS_MIN_FACET_COUNT
+            this.facetCount >= SHARED_X_AXIS_MIN_FACET_COUNT &&
+            (this.chartTypeName === GRAPHER_CHART_TYPES.LineChart ||
+                this.chartTypeName === GRAPHER_CHART_TYPES.StackedBar ||
+                this.chartTypeName === GRAPHER_CHART_TYPES.StackedArea)
         )
     }
 

--- a/packages/@ourworldindata/grapher/src/facet/FacetChart.tsx
+++ b/packages/@ourworldindata/grapher/src/facet/FacetChart.tsx
@@ -230,11 +230,7 @@ export class FacetChart
     }
 
     @computed private get facetGridPadding(): SplitBoundsPadding {
-        const { isSharedXAxis, facetFontSize } = this
-        return getFacetGridPadding({
-            baseFontSize: facetFontSize,
-            shouldAddRowPadding: !isSharedXAxis,
-        })
+        return getFacetGridPadding({ baseFontSize: this.facetFontSize })
     }
 
     @computed private get hideFacetLegends(): boolean {
@@ -473,9 +469,7 @@ export class FacetChart
                     ])
                     config.minSize = size
                     if (shared) {
-                        const sharedAxisSize =
-                            axis.orient === Position.bottom ? 0 : size
-                        sharedAxesSizes[axis.orient] = sharedAxisSize
+                        sharedAxesSizes[axis.orient] = size
                     }
                 }
             } else if (axisWithMaxSize) {
@@ -487,8 +481,6 @@ export class FacetChart
         // If the axes are "shared", then an axis will only plotted on the facets that are on the
         // same side as the axis.
         // For example, a vertical Y axis would be plotted on the left-most charts only.
-        // An exception is the bottom axis, which gets plotted on the top row of charts, instead of
-        // the bottom row of charts.
         const fullBounds = this.facetsContainerBounds.pad(sharedAxesSizes)
         const gridBoundsArr = fullBounds.grid(
             this.gridParams,
@@ -511,15 +503,7 @@ export class FacetChart
                 ...series.manager,
                 useValueBasedColorScheme,
                 xAxisConfig: {
-                    // For now, sharing an x axis means hiding the tick labels of inner facets.
-                    // This means that none of the x axes are actually hidden (we just don't plot their tick labels).
-                    // If we ever allow shared x axes to be actually hidden, we need to be careful with how we determine
-                    // the `minSize` – in the intermediate series (at this time) all axes are shown in
-                    // order to find the one with maximum size, but in the placed series, some axes are
-                    // hidden. This expands the available area for the chart, which can in turn increase
-                    // the number of ticks shown, which can make the size of the axis in the placed
-                    // series greater than the one in the intermediate series.
-                    hideTickLabels: shouldHideFacetAxis(
+                    hideAxis: shouldHideFacetAxis(
                         xAxis,
                         cellEdges,
                         sharedAxesSizes


### PR DESCRIPTION
For faceted stacked bar charts with 12 facets or more, we currently declutter by hiding the x-tick labels, but not the tick marks. I think it’s cleaner to hide the entire axis.

I also enabled shared x-axes for stacked area charts and line charts.