### PR TITLE
Show validation errors in admin gdoc preview

### DIFF
--- a/adminSiteServer/appClass.tsx
+++ b/adminSiteServer/appClass.tsx
@@ -158,6 +158,7 @@ export class OwidAdminApp {
                                     gdoc={instantiatedProfile}
                                     debug
                                     isPreviewing
+                                    previewErrors={gdoc.errors}
                                 />
                             )
                         )
@@ -172,6 +173,7 @@ export class OwidAdminApp {
                                 gdoc={gdoc}
                                 debug
                                 isPreviewing
+                                previewErrors={gdoc.errors}
                             />
                         )
                     )

--- a/site/gdocs/OwidGdocPage.tsx
+++ b/site/gdocs/OwidGdocPage.tsx
@@ -23,9 +23,11 @@ import {
     ARCHIVED_THUMBNAIL_FILENAME,
     ArchiveContext,
     OwidGdocDataInsightInterface,
+    OwidGdocErrorMessage,
     OwidGdocPostInterface,
     OwidGdocProfileInterface,
 } from "@ourworldindata/types"
+import { PreviewErrorBanner } from "./PreviewErrorBanner.js"
 import {
     DATA_INSIGHT_ATOM_FEED_PROPS,
     DEFAULT_ATOM_FEED_PROPS,
@@ -152,12 +154,14 @@ export default function OwidGdocPage({
     debug,
     isPreviewing = false,
     archiveContext,
+    previewErrors,
 }: {
     baseUrl: string
     gdoc: OwidGdocUnionType
     debug?: boolean
     isPreviewing?: boolean
     archiveContext?: ArchiveContext
+    previewErrors?: OwidGdocErrorMessage[]
 }) {
     const { content, createdAt, publishedAt } = gdoc
 
@@ -240,6 +244,9 @@ export default function OwidGdocPage({
                 ></script>
             </Head>
             <body>
+                {previewErrors && previewErrors.length > 0 && (
+                    <PreviewErrorBanner errors={previewErrors} />
+                )}
                 <SiteHeader
                     isOnHomepage={gdoc.content.type === OwidGdocType.Homepage}
                     archiveInfo={isOnArchivalPage ? archiveContext : undefined}

--- a/site/gdocs/PreviewErrorBanner.scss
+++ b/site/gdocs/PreviewErrorBanner.scss
@@ -1,0 +1,72 @@
+.preview-error-banner {
+    position: sticky;
+    top: 0;
+    z-index: 1000;
+    background-color: $amber-10;
+    border-bottom: 2px solid $vermillion;
+    color: $blue-90;
+    padding: 12px 16px;
+    font-family:
+        -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    font-size: 13px;
+    line-height: 1.4;
+}
+
+.preview-error-banner__header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-weight: 700;
+    color: $vermillion;
+    margin-bottom: 8px;
+
+    .svg-inline--fa {
+        flex-shrink: 0;
+    }
+}
+
+.preview-error-banner__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    max-height: 200px;
+    overflow-y: auto;
+}
+
+.preview-error-banner__item {
+    display: flex;
+    align-items: flex-start;
+    gap: 6px;
+    padding: 4px 0;
+
+    & + & {
+        border-top: 1px solid $amber-110;
+    }
+
+    .svg-inline--fa {
+        margin-top: 3px;
+        flex-shrink: 0;
+    }
+}
+
+.preview-error-banner__item--error .svg-inline--fa {
+    color: $vermillion;
+}
+
+.preview-error-banner__item--warning .svg-inline--fa {
+    color: $amber;
+}
+
+.preview-error-banner__property {
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+    font-size: 12px;
+    color: $blue-60;
+    background-color: $white;
+    padding: 1px 6px;
+    border-radius: 3px;
+    flex-shrink: 0;
+}
+
+.preview-error-banner__message {
+    word-break: break-word;
+}

--- a/site/gdocs/PreviewErrorBanner.tsx
+++ b/site/gdocs/PreviewErrorBanner.tsx
@@ -1,0 +1,65 @@
+import {
+    OwidGdocErrorMessage,
+    OwidGdocErrorMessageType,
+} from "@ourworldindata/types"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import {
+    faTriangleExclamation,
+    faCircleExclamation,
+} from "@fortawesome/free-solid-svg-icons"
+
+export function PreviewErrorBanner({
+    errors,
+}: {
+    errors: OwidGdocErrorMessage[]
+}) {
+    if (!errors.length) return null
+
+    const errorCount = errors.filter(
+        (e) => e.type === OwidGdocErrorMessageType.Error
+    ).length
+    const warningCount = errors.length - errorCount
+
+    return (
+        <div
+            className="preview-error-banner"
+            role="alert"
+            data-no-snippet
+            data-testid="preview-error-banner"
+        >
+            <div className="preview-error-banner__header">
+                <FontAwesomeIcon icon={faTriangleExclamation} />
+                <span>
+                    Preview validation:{" "}
+                    {errorCount > 0 &&
+                        `${errorCount} error${errorCount === 1 ? "" : "s"}`}
+                    {errorCount > 0 && warningCount > 0 && ", "}
+                    {warningCount > 0 &&
+                        `${warningCount} warning${warningCount === 1 ? "" : "s"}`}
+                </span>
+            </div>
+            <ul className="preview-error-banner__list">
+                {errors.map((error, i) => (
+                    <li
+                        key={i}
+                        className={`preview-error-banner__item preview-error-banner__item--${error.type}`}
+                    >
+                        <FontAwesomeIcon
+                            icon={
+                                error.type === OwidGdocErrorMessageType.Error
+                                    ? faCircleExclamation
+                                    : faTriangleExclamation
+                            }
+                        />
+                        <span className="preview-error-banner__property">
+                            {error.property}
+                        </span>
+                        <span className="preview-error-banner__message">
+                            {error.message}
+                        </span>
+                    </li>
+                ))}
+            </ul>
+        </div>
+    )
+}

--- a/site/owid.scss
+++ b/site/owid.scss
@@ -170,6 +170,7 @@
 @import "./gdocs/components/Person.scss";
 @import "./gdocs/components/Socials.scss";
 @import "./gdocs/components/UserSurvey.scss";
+@import "./gdocs/PreviewErrorBanner.scss";
 @import "./AboutThisData.scss";
 @import "./DataPage.scss";
 @import "./DataPageContent.scss";


### PR DESCRIPTION
## Summary

- The `/admin/gdocs/:id/preview` page silently rendered the gdoc as if it were on the public site, so author-facing validation errors (e.g. *"Grapher chart with slug X is not published"*, already produced by `GdocBase.validate`) only showed up in the editor sidebar — not in preview.
- Authors who jumped straight to the preview hit blank chart embeds with no explanation: the dynamic `/grapher/<slug>.config.json` endpoint returns 404 for unpublished slugs (it reads from `config/by-slug-published/` in R2), and the embed renders empty.
- This PR adds a sticky banner at the top of the preview page that lists all `gdoc.errors` (errors + warnings) collected during `loadState()`. The banner is only rendered when `previewErrors` is non-empty, so it only shows up in admin previews.

## Test plan

- [ ] Open a gdoc in `/admin/gdocs/:id/preview` that embeds an unpublished chart — banner should appear at the top listing the error.
- [ ] Open a gdoc with no validation errors — no banner should be shown.
- [ ] Confirm the banner does not appear on the public-baked site (the prop is only passed in the admin preview handler).
- [ ] Verify a profile gdoc preview (`?entity=...`) also surfaces the original gdoc's errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)