### PR TITLE
🎉 data-callout-group component

### DIFF
--- a/db/model/Gdoc/GdocBase.ts
+++ b/db/model/Gdoc/GdocBase.ts
@@ -894,7 +894,8 @@ export class GdocBase implements OwidGdocBaseInterface {
                         "latest-data-insights",
                         "socials", // only external links
                         "subscribe-banner",
-                        "bespoke-component"
+                        "bespoke-component",
+                        "data-callout-group"
                     ),
                 },
                 () => []

--- a/db/model/Gdoc/dataCallouts.ts
+++ b/db/model/Gdoc/dataCallouts.ts
@@ -14,6 +14,7 @@ import {
     DimensionProperty,
     OwidGdocProfileContent,
     EnrichedBlockDataCallout,
+    EnrichedBlockDataCalloutGroup,
 } from "@ourworldindata/types"
 import {
     makeLinkedCalloutKey,
@@ -431,7 +432,7 @@ export function computeLinkedCalloutsFromPreparedTables(
 
 /**
  * Check if a profile should be rendered.
- * Returns false if there are data-callouts and ALL of them are hidden.
+ * Returns false if there are data-callouts (or data-callout-groups) and ALL of them are hidden.
  * Returns true if there are no data-callouts, or if at least one callout is visible.
  */
 export function checkShouldProfileRender(content: {
@@ -440,29 +441,45 @@ export function checkShouldProfileRender(content: {
     if (!content.body || content.body.length === 0) return false
 
     const dataCallouts: EnrichedBlockDataCallout[] = []
+    const dataCalloutGroups: EnrichedBlockDataCalloutGroup[] = []
     content.body.forEach((node) => {
         traverseEnrichedBlock(node, (block) => {
             if (block.type === "data-callout") {
                 dataCallouts.push(block)
             }
+            if (block.type === "data-callout-group") {
+                dataCalloutGroups.push(block)
+            }
         })
     })
 
-    // No data-callouts means the profile has other content and is renderable
-    if (dataCallouts.length === 0) return true
+    // No data-callouts or groups means the profile has other content and is renderable
+    if (dataCallouts.length === 0 && dataCalloutGroups.length === 0) return true
 
-    // If there are data-callouts, at least one must be visible
-    return dataCallouts.some((callout) => callout.content.length > 0)
+    // If there are standalone data-callouts, at least one must be visible
+    const anyCalloutVisible = dataCallouts.some(
+        (callout) => callout.content.length > 0
+    )
+
+    // A cleared group has empty content; a visible group still has content
+    const anyGroupVisible = dataCalloutGroups.some(
+        (group) => group.content.length > 0
+    )
+
+    return anyCalloutVisible || anyGroupVisible
 }
 
 /**
  * Clear data-callout blocks that have incomplete data.
+ * For data-callout-group blocks, if ALL child data-callouts are cleared,
+ * the entire group's content is cleared (hiding the heading/prose too).
  * This should be called after linkedCallouts are generated.
  */
 export function clearIncompleteDataCallouts(
     content: { body?: OwidEnrichedGdocBlock[] },
     linkedCallouts: LinkedCallouts
 ): void {
+    // First pass: clear individual data-callout blocks with incomplete data
     content.body?.forEach((node) => {
         traverseEnrichedBlock(node, (block) => {
             if (block.type === "data-callout") {
@@ -472,8 +489,26 @@ export function clearIncompleteDataCallouts(
                     linkedCallouts
                 )
                 if (!shouldRender) {
-                    // Clear the content so it renders as empty
                     dataCalloutBlock.content = []
+                }
+            }
+        })
+    })
+
+    // Second pass: clear data-callout-group blocks where all child
+    // data-callouts have been cleared (no entity has data for any chart)
+    content.body?.forEach((node) => {
+        traverseEnrichedBlock(node, (block) => {
+            if (block.type === "data-callout-group") {
+                const childCallouts = block.content.filter(
+                    (child): child is EnrichedBlockDataCallout =>
+                        child.type === "data-callout"
+                )
+                const anyVisible = childCallouts.some(
+                    (callout) => callout.content.length > 0
+                )
+                if (childCallouts.length > 0 && !anyVisible) {
+                    block.content = []
                 }
             }
         })

--- a/db/model/Gdoc/dataCallouts.ts
+++ b/db/model/Gdoc/dataCallouts.ts
@@ -434,6 +434,15 @@ export function computeLinkedCalloutsFromPreparedTables(
  * Check if a profile should be rendered.
  * Returns false if there are data-callouts (or data-callout-groups) and ALL of them are hidden.
  * Returns true if there are no data-callouts, or if at least one callout is visible.
+ *
+ * Precondition: `content` must already have been passed through
+ * `clearIncompleteDataCallouts`, which empties callouts/groups whose data is
+ * unavailable for the current entity. This function reads `content.length` to
+ * detect that emptied state — running it on un-cleared content will report
+ * false positives (treating hidden groups as visible).
+ *
+ * In practice this is guaranteed by `instantiateProfileForEntity`, which
+ * clears as its final step before returning.
  */
 export function checkShouldProfileRender(content: {
     body?: OwidEnrichedGdocBlock[]

--- a/db/model/Gdoc/enrichedToIndexableText.ts
+++ b/db/model/Gdoc/enrichedToIndexableText.ts
@@ -201,6 +201,9 @@ export function enrichedBlockToIndexableText(
                 }
                 return enrichedBlocksToIndexableText(b.content, nestedOptions)
             })
+            .with({ type: "data-callout-group" }, (b): string | undefined =>
+                enrichedBlocksToIndexableText(b.content, options)
+            )
             .with({ type: "expandable-paragraph" }, (b): string | undefined =>
                 enrichedBlocksToIndexableText(b.items, options)
             )
@@ -444,9 +447,6 @@ export function enrichedBlockToIndexableText(
                     ),
                 },
                 (): undefined => undefined
-            )
-            .with({ type: "data-callout-group" }, (b): string | undefined =>
-                enrichedBlocksToIndexableText(b.content, options)
             )
             .exhaustive()
     )

--- a/db/model/Gdoc/enrichedToIndexableText.ts
+++ b/db/model/Gdoc/enrichedToIndexableText.ts
@@ -445,6 +445,9 @@ export function enrichedBlockToIndexableText(
                 },
                 (): undefined => undefined
             )
+            .with({ type: "data-callout-group" }, (b): string | undefined =>
+                enrichedBlocksToIndexableText(b.content, options)
+            )
             .exhaustive()
     )
 }

--- a/db/model/Gdoc/enrichedToMarkdown.ts
+++ b/db/model/Gdoc/enrichedToMarkdown.ts
@@ -603,6 +603,9 @@ ${links}`
                 nestedOptions
             )
         })
+        .with({ type: "data-callout-group" }, (b): string | undefined =>
+            enrichedBlocksToMarkdown(b.content, exportComponents, options)
+        )
         .with({ type: "country-profile-selector" }, () => undefined)
         .with(
             { type: "bespoke-component" },
@@ -640,8 +643,5 @@ ${links}`
                 ) || undefined
             )
         })
-        .with({ type: "data-callout-group" }, (b): string | undefined =>
-            enrichedBlocksToMarkdown(b.content, exportComponents, options)
-        )
         .exhaustive()
 }

--- a/db/model/Gdoc/enrichedToMarkdown.ts
+++ b/db/model/Gdoc/enrichedToMarkdown.ts
@@ -640,5 +640,8 @@ ${links}`
                 ) || undefined
             )
         })
+        .with({ type: "data-callout-group" }, (b): string | undefined =>
+            enrichedBlocksToMarkdown(b.content, exportComponents, options)
+        )
         .exhaustive()
 }

--- a/db/model/Gdoc/enrichedToRaw.ts
+++ b/db/model/Gdoc/enrichedToRaw.ts
@@ -790,6 +790,12 @@ export function enrichedBlockToRawBlock(
                 ) as RawBlockText[],
             },
         }))
+        .with({ type: "data-callout-group" }, (b) => ({
+            type: "data-callout-group" as const,
+            value: {
+                content: b.content.map(enrichedBlockToRawBlock),
+            },
+        }))
         .with(
             { type: "country-profile-selector" },
             (b): RawBlockCountryProfileSelector => ({
@@ -815,12 +821,6 @@ export function enrichedBlockToRawBlock(
                 },
             }
         })
-        .with({ type: "data-callout-group" }, (b) => ({
-            type: "data-callout-group" as const,
-            value: {
-                content: b.content.map(enrichedBlockToRawBlock),
-            },
-        }))
         .exhaustive()
 }
 

--- a/db/model/Gdoc/enrichedToRaw.ts
+++ b/db/model/Gdoc/enrichedToRaw.ts
@@ -815,6 +815,12 @@ export function enrichedBlockToRawBlock(
                 },
             }
         })
+        .with({ type: "data-callout-group" }, (b) => ({
+            type: "data-callout-group" as const,
+            value: {
+                content: b.content.map(enrichedBlockToRawBlock),
+            },
+        }))
         .exhaustive()
 }
 

--- a/db/model/Gdoc/exampleEnrichedBlocks.ts
+++ b/db/model/Gdoc/exampleEnrichedBlocks.ts
@@ -962,6 +962,29 @@ export const enrichedBlockExamples: Record<
         ],
         parseErrors: [],
     },
+    "data-callout-group": {
+        type: "data-callout-group",
+        content: [
+            {
+                type: "data-callout",
+                url: "https://ourworldindata.org/grapher/life-expectancy?country=KEN",
+                content: [
+                    {
+                        type: "text",
+                        value: [
+                            {
+                                spanType: "span-simple-text",
+                                text: "Example callout text",
+                            },
+                        ],
+                        parseErrors: [],
+                    },
+                ],
+                parseErrors: [],
+            },
+        ],
+        parseErrors: [],
+    },
     "data-callout": {
         type: "data-callout",
         url: "https://ourworldindata.org/grapher/life-expectancy?country=KEN",

--- a/db/model/Gdoc/extractGdocComponentInfo.ts
+++ b/db/model/Gdoc/extractGdocComponentInfo.ts
@@ -438,7 +438,8 @@ export function enumerateGdocComponentsWithoutChildren(
                         "static-viz",
                         "data-callout",
                         "country-profile-selector",
-                        "bespoke-component"
+                        "bespoke-component",
+                        "data-callout-group"
                     ),
                 },
                 (c) => handleComponent(c, [], parentPath, path)

--- a/db/model/Gdoc/gdocUtils.ts
+++ b/db/model/Gdoc/gdocUtils.ts
@@ -302,6 +302,7 @@ export function extractFilenamesFromBlock(
                     "text",
                     "topic-page-intro",
                     "data-callout",
+                    "data-callout-group",
                     "country-profile-selector",
                     "bespoke-component"
                 ),

--- a/db/model/Gdoc/rawToArchie.ts
+++ b/db/model/Gdoc/rawToArchie.ts
@@ -60,6 +60,7 @@ import {
     RawBlockStaticViz,
     RawBlockConditionalSection,
     RawBlockDataCallout,
+    RawBlockDataCalloutGroup,
     RawBlockCountryProfileSelector,
     RawBlockBespokeComponent,
     RawBlockChartRows,
@@ -1061,6 +1062,20 @@ function* rawBlockDataCalloutToArchieMLString(
     yield "{}"
 }
 
+function* rawBlockDataCalloutGroupToArchieMLString(
+    block: RawBlockDataCalloutGroup
+): Generator<string, void, undefined> {
+    yield "{.data-callout-group}"
+    if (block.value.content) {
+        yield "[.+content]"
+        for (const contentBlock of block.value.content) {
+            yield* OwidRawGdocBlockToArchieMLStringGenerator(contentBlock)
+        }
+        yield "[]"
+    }
+    yield "{}"
+}
+
 function* rawBlockCountryProfileSelectorToArchieMLString(
     block: RawBlockCountryProfileSelector
 ): Generator<string, void, undefined> {
@@ -1207,6 +1222,10 @@ export function* OwidRawGdocBlockToArchieMLStringGenerator(
         )
         .with({ type: "socials" }, rawBlockSocialsToArchieMLString)
         .with({ type: "data-callout" }, rawBlockDataCalloutToArchieMLString)
+        .with(
+            { type: "data-callout-group" },
+            rawBlockDataCalloutGroupToArchieMLString
+        )
         .with(
             { type: "country-profile-selector" },
             rawBlockCountryProfileSelectorToArchieMLString

--- a/db/model/Gdoc/rawToEnriched.ts
+++ b/db/model/Gdoc/rawToEnriched.ts
@@ -4,6 +4,7 @@ import {
     EnrichedBlockAside,
     EnrichedBlockCallout,
     EnrichedBlockDataCallout,
+    EnrichedBlockDataCalloutGroup,
     EnrichedBlockChart,
     EnrichedBlockChartStory,
     EnrichedBlockDonorList,
@@ -48,6 +49,7 @@ import {
     RawBlockAside,
     RawBlockCallout,
     RawBlockDataCallout,
+    RawBlockDataCalloutGroup,
     RawBlockChart,
     RawBlockChartStory,
     RawBlockDonorList,
@@ -214,6 +216,7 @@ export function parseRawBlocksToEnrichedBlocks(
         .with({ type: "blockquote" }, parseBlockquote)
         .with({ type: "callout" }, parseCallout)
         .with({ type: "data-callout" }, parseDataCallout)
+        .with({ type: "data-callout-group" }, parseDataCalloutGroup)
         .with({ type: "chart" }, parseChart)
         .with({ type: "narrative-chart" }, parseNarrativeChart)
         .with({ type: "code" }, parseCode)
@@ -2124,6 +2127,52 @@ function parseDataCallout(raw: RawBlockDataCallout): EnrichedBlockDataCallout {
         type: "data-callout",
         url: url.fullUrl,
         content: transformedContent,
+        parseErrors: [],
+    }
+}
+
+function parseDataCalloutGroup(
+    raw: RawBlockDataCalloutGroup
+): EnrichedBlockDataCalloutGroup {
+    const createError = (error: ParseError): EnrichedBlockDataCalloutGroup => ({
+        type: "data-callout-group",
+        parseErrors: [error],
+        content: [],
+    })
+
+    if (!raw.value.content) {
+        return createError({
+            message: "Missing content for data-callout-group block",
+        })
+    }
+
+    if (!_.isArray(raw.value.content)) {
+        return createError({
+            message:
+                "Content must be provided as an array e.g. inside a [.+content] block",
+        })
+    }
+
+    const enrichedContent = raw.value.content.map(
+        parseRawBlocksToEnrichedBlocks
+    )
+
+    const content = excludeNullish(enrichedContent)
+
+    const hasDataCallout = content.some(
+        (block) => block.type === "data-callout"
+    )
+
+    if (!hasDataCallout) {
+        return createError({
+            message:
+                "data-callout-group must contain at least one data-callout block",
+        })
+    }
+
+    return {
+        type: "data-callout-group",
+        content,
         parseErrors: [],
     }
 }

--- a/packages/@ourworldindata/types/src/gdocTypes/ArchieMlComponents.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/ArchieMlComponents.ts
@@ -49,7 +49,9 @@ import type {
 import type { EnrichedBlockCta, RawBlockCta } from "./archieMLComponents/Cta.js"
 import type {
     EnrichedBlockDataCallout,
+    EnrichedBlockDataCalloutGroup,
     RawBlockDataCallout,
+    RawBlockDataCalloutGroup,
 } from "./archieMLComponents/DataCallout.js"
 import type {
     EnrichedBlockDonorList,
@@ -249,6 +251,7 @@ export type OwidRawGdocBlock =
     | RawBlockAside
     | RawBlockCallout
     | RawBlockDataCallout
+    | RawBlockDataCalloutGroup
     | RawBlockChart
     | RawBlockExpander
     | RawBlockNarrativeChart
@@ -315,6 +318,7 @@ export type OwidEnrichedGdocBlock =
     | EnrichedBlockAside
     | EnrichedBlockCallout
     | EnrichedBlockDataCallout
+    | EnrichedBlockDataCalloutGroup
     | EnrichedBlockChart
     | EnrichedBlockExpander
     | EnrichedBlockNarrativeChart

--- a/packages/@ourworldindata/types/src/gdocTypes/archieMLComponents/DataCallout.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/archieMLComponents/DataCallout.ts
@@ -17,3 +17,15 @@ export type EnrichedBlockDataCallout = {
     url: string
     content: OwidEnrichedGdocBlock[]
 } & EnrichedBlockWithParseErrors
+
+export type RawBlockDataCalloutGroup = {
+    type: "data-callout-group"
+    value: {
+        content?: OwidRawGdocBlock[]
+    }
+}
+
+export type EnrichedBlockDataCalloutGroup = {
+    type: "data-callout-group"
+    content: OwidEnrichedGdocBlock[]
+} & EnrichedBlockWithParseErrors

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -1733,6 +1733,12 @@ export function traverseEnrichedBlock(
                 traverseEnrichedBlock(node, callback, spanCallback)
             }
         })
+        .with({ type: "data-callout-group" }, (dataCalloutGroup) => {
+            callback(dataCalloutGroup)
+            for (const node of dataCalloutGroup.content) {
+                traverseEnrichedBlock(node, callback, spanCallback)
+            }
+        })
         .with({ type: "chart-rows" }, (block) => {
             callback(block)
             for (const row of block.rows) {

--- a/site/gdocs/components/ArticleBlock.tsx
+++ b/site/gdocs/components/ArticleBlock.tsx
@@ -69,6 +69,7 @@ import { BlockQueryClientProvider } from "./BlockQueryClientProvider.js"
 import { ExploreDataSection } from "./ExploreDataSection.js"
 import { LTPTableOfContents } from "./LTPTableOfContents.js"
 import { DataCallout } from "./DataCallout.js"
+import { DataCalloutGroup } from "./DataCalloutGroup.js"
 import { CountryProfileSelector } from "./CountryProfileSelector.js"
 
 function ArticleBlockInternal({
@@ -1014,6 +1015,9 @@ function ArticleBlockInternal({
         ))
         .with({ type: "data-callout" }, (block) => (
             <DataCallout block={block} containerType={containerType} />
+        ))
+        .with({ type: "data-callout-group" }, (block) => (
+            <DataCalloutGroup block={block} containerType={containerType} />
         ))
         .with({ type: "country-profile-selector" }, (block) => (
             <CountryProfileSelector

--- a/site/gdocs/components/DataCalloutGroup.tsx
+++ b/site/gdocs/components/DataCalloutGroup.tsx
@@ -1,0 +1,30 @@
+import { EnrichedBlockDataCalloutGroup } from "@ourworldindata/types"
+import { Container, getLayout } from "./layout.js"
+import ArticleBlock from "./ArticleBlock.js"
+
+/**
+ * DataCalloutGroup is a logical container that wraps editorial content
+ * (e.g. headings) together with data-callout blocks. During baking,
+ * if none of the child data-callouts have data for the current entity,
+ * the entire group's content is cleared — hiding the heading too.
+ *
+ * At render time, it simply renders its children; the visibility logic
+ * has already been applied server-side.
+ */
+export function DataCalloutGroup({
+    block,
+    containerType = "default",
+}: {
+    block: EnrichedBlockDataCalloutGroup
+    containerType?: Container
+}) {
+    return (
+        <div className={getLayout("data-callout-group", containerType)}>
+            {block.content.map((child, index) => (
+                <ArticleBlock key={index} b={child} />
+            ))}
+        </div>
+    )
+}
+
+export default DataCalloutGroup

--- a/site/gdocs/components/layout.ts
+++ b/site/gdocs/components/layout.ts
@@ -38,6 +38,7 @@ const layouts: { [key in Container]: Layouts} = {
         ["cta"]: "col-start-5 span-cols-6 col-md-start-3 span-md-cols-10 span-sm-cols-12 col-sm-start-2",
         ["country-profile-selector"]: "span-cols-14 grid grid-cols-12-full-width",
         ["data-callout"]: "span-cols-14 grid grid-cols-12-full-width",
+        ["data-callout-group"]: "span-cols-14 grid grid-cols-12-full-width",
         ["default"]: "col-start-5 span-cols-6 col-md-start-3 span-md-cols-10 span-sm-cols-12 col-sm-start-2",
         ["divider"]: "col-start-2 span-cols-12",
         ["explorer"]: "col-start-2 span-cols-12",


### PR DESCRIPTION
## Context

Adds a component intended to house multiple `data-callout` sections alongside additional content (e.g. headings) and hides **all** of the content if none of the data-callout sections are rendering.

This will fix cases like the [Maternal Mortality section for Niue's Health profile](https://ourworldindata.org/profile/health/niue#maternal-health):

<img width="1431" height="344" alt="image" src="https://github.com/user-attachments/assets/7adc594d-8c53-4c15-bbaf-43635186567e" />


## Screenshots / Videos / Diagrams

## Testing guidance
 You can use this [test gdoc](https://docs.google.com/document/d/1xUD6DmZ_dzwDb6gt1GRJkIo39qhmyDAP-qI_l_YonFg/edit?tab=t.0) or the following Archie:
```
{.data-callout-group}
[.+content]
I am a heading for this section

{.data-callout}
url: https://ourworldindata.org/grapher/maternal-mortality?tab=line&country=$entityCode

[.+content]
$latestValue() in $latestTime()
[]
{}

{.data-callout}
url: https://ourworldindata.org/grapher/number-of-maternal-deaths?tab=line&country=$entityCode

[.+content]
$latestValue() in $latestTime()
[]
{}

[]
{}
```

Add it to a test document with `type: profile`, `scope: countries`, and `sidebar-toc: true` in the front matter.


Step-by-step instructions on how to test this change

1. In the preview, confirm that everything renders correctly for a country with correct data coverage
2. Confirm the coverage matrix (`/admin/gdocs/1xUD6DmZ_dzwDb6gt1GRJkIo39qhmyDAP-qI_l_YonFg/coverage?contentSource=gdocs`) calculates correctly
3. For a country that only has partial coverage (e.g. Aruba) confirm that the data callout and outer header still render
4. For a country with no coverage (e.g. Niue) confirm that none of the content in the group renders
5. Confirm that the sidebar TOC takes this into account in both instances
6. Confirm this works correctly on baked pages, also

- [ ] Does the change work in the archive? N/A