### PR TITLE
WIP: Improve Colorpicker UX (semantic tooltips, filter, reset)

### DIFF
--- a/adminSiteClient/Colorpicker.tsx
+++ b/adminSiteClient/Colorpicker.tsx
@@ -8,6 +8,7 @@ import cx from "classnames"
 import { ColorSchemeName, lastOfNonEmptyArray } from "@ourworldindata/utils"
 import {
     ColorSchemes,
+    ColorSemanticInfo,
     getColorNameOwidDistinctAndSemanticPalettes,
     getColorNameOwidDistinctLinesAndSemanticPalettes,
     OwidMapColors,
@@ -22,8 +23,7 @@ interface ColorpickerProps {
 
 interface PresetColor {
     color: string
-    lines: string[]
-    hasSemanticMapping: boolean
+    info: ColorSemanticInfo
 }
 
 @observer
@@ -51,8 +51,7 @@ export class Colorpicker extends Component<ColorpickerProps> {
             // to be used sparingly when needed (Taupe, Mustard, Tomato)
             return Object.entries(OwidMapColors).map(([name, color]) => ({
                 color,
-                lines: [name],
-                hasSemanticMapping: false,
+                info: { colorName: name },
             }))
         }
 
@@ -64,47 +63,58 @@ export class Colorpicker extends Component<ColorpickerProps> {
             ? getColorNameOwidDistinctLinesAndSemanticPalettes
             : getColorNameOwidDistinctAndSemanticPalettes
 
-        return lastOfNonEmptyArray(scheme.colorSets).map((color) => {
-            const lines = colorNameLookupFn(color)
-            // The first line is the colour name (🎨); any additional lines mean
-            // the colour is also used in a semantic palette (🌍 region, ⚡ energy)
-            return {
-                color,
-                lines,
-                hasSemanticMapping: lines.length > 1,
-            }
-        })
+        return lastOfNonEmptyArray(scheme.colorSets).map((color) => ({
+            color,
+            info: colorNameLookupFn(color),
+        }))
     }
 
     private renderPresetSwatch(preset: PresetColor) {
-        const { color, lines, hasSemanticMapping } = preset
+        const { color, info } = preset
+        const { colorName, region, energy } = info
+        const hasSemanticMapping = !!(region || energy)
         const isSelected =
             this.props.color !== undefined &&
             this.props.color.toLowerCase() === color.toLowerCase()
 
-        const tooltipContent =
-            lines.length > 0 ? (
-                <>
-                    {lines.map((line) => (
-                        <span
-                            key={line}
-                            className="colorpicker-presets__tooltip-line"
-                        >
-                            {line}
-                        </span>
-                    ))}
-                </>
-            ) : (
-                color
-            )
+        const ariaLabelParts = [
+            colorName,
+            region ? `Regions: ${region}` : undefined,
+            energy ? `Others: ${energy}` : undefined,
+        ].filter((x): x is string => !!x)
+
+        const tooltipContent = (
+            <div className="colorpicker-presets__tooltip">
+                <div className="colorpicker-presets__tooltip-title">
+                    {colorName ?? color}
+                </div>
+                {region && (
+                    <div className="colorpicker-presets__tooltip-row">
+                        <span className="colorpicker-presets__tooltip-label">
+                            Regions:
+                        </span>{" "}
+                        {region}
+                    </div>
+                )}
+                {energy && (
+                    <div className="colorpicker-presets__tooltip-row">
+                        <span className="colorpicker-presets__tooltip-label">
+                            Others:
+                        </span>{" "}
+                        {energy}
+                    </div>
+                )}
+            </div>
+        )
 
         return (
             <Tippy
-                key={color + lines.join("|")}
+                key={color}
                 content={tooltipContent}
                 delay={[100, 0]}
                 placement="top"
                 appendTo={() => document.body}
+                maxWidth={220}
             >
                 <button
                     type="button"
@@ -115,7 +125,7 @@ export class Colorpicker extends Component<ColorpickerProps> {
                     })}
                     style={{ backgroundColor: color }}
                     onClick={() => this.onColor(color)}
-                    aria-label={lines.join(", ") || color}
+                    aria-label={ariaLabelParts.join(", ") || color}
                 />
             </Tippy>
         )

--- a/adminSiteClient/Colorpicker.tsx
+++ b/adminSiteClient/Colorpicker.tsx
@@ -1,5 +1,5 @@
 import { Component, Fragment } from "react"
-import { action, computed, makeObservable, observable } from "mobx"
+import { action, makeObservable, observable } from "mobx"
 import { observer } from "mobx-react"
 import { SketchPicker } from "react-color"
 import Tippy from "@tippyjs/react"
@@ -50,8 +50,9 @@ function expandHex(input: string): string | undefined {
 }
 
 function hexToRgb(hex: string): { r: number; g: number; b: number } {
-    const expanded = expandHex(hex)
-    if (!expanded) return { r: 0, g: 0, b: 0 }
+    // Callers always pass effectiveColor, which is a valid 6-char hex
+    // (defaults to "#000000"), so expandHex never returns undefined.
+    const expanded = expandHex(hex)!
     return {
         r: parseInt(expanded.slice(0, 2), 16),
         g: parseInt(expanded.slice(2, 4), 16),
@@ -132,9 +133,10 @@ export class Colorpicker extends Component<ColorpickerProps> {
         this.hexInputDraft = undefined
     }
 
-    // NOTE: not @computed — these read this.props which is NOT observable,
-    // so MobX would cache stale results when props change without an
-    // observable changing alongside them.
+    // NOTE: none of the getters below are @computed. They read this.props,
+    // which is NOT observable, so MobX would cache the first result and
+    // never invalidate when props change. The @observer wrapper re-runs
+    // render() on prop changes, which is enough to keep the UI in sync.
     private get isCategoricalMap(): boolean {
         return this.props.baseColorScheme === ColorSchemeName.OwidCategoricalMap
     }
@@ -156,7 +158,7 @@ export class Colorpicker extends Component<ColorpickerProps> {
         return hexToRgb(this.effectiveColor)
     }
 
-    @computed private get presetColors(): PresetColor[] {
+    private get presetColors(): PresetColor[] {
         if (this.isCategoricalMap) {
             // We use OwidMapColors instead of the scheme's palette
             // because it includes three additional 'special' colors
@@ -236,7 +238,7 @@ export class Colorpicker extends Component<ColorpickerProps> {
                     "colorpicker-presets__swatch--dimmed": isDimmed,
                 })}
                 style={{ backgroundColor: color }}
-                onClick={isDimmed ? undefined : () => this.onColor(color)}
+                onClick={() => this.onColor(color)}
                 disabled={isDimmed}
                 aria-label={ariaLabelParts.join(", ") || color}
             />

--- a/adminSiteClient/Colorpicker.tsx
+++ b/adminSiteClient/Colorpicker.tsx
@@ -27,27 +27,68 @@ interface PresetColor {
     info: ColorSemanticInfo
 }
 
-type PresetFilter = "all" | "regions" | "others"
+type InputMode = "hex" | "rgb"
 
-const FILTER_OPTIONS: { value: PresetFilter; label: string }[] = [
-    { value: "all", label: "All" },
-    { value: "regions", label: "Regions" },
-    { value: "others", label: "Others" },
-]
+function expandHex(input: string): string | undefined {
+    const cleaned = input.trim().replace(/^#/, "")
+    const expanded =
+        cleaned.length === 3
+            ? cleaned
+                  .split("")
+                  .map((c) => c + c)
+                  .join("")
+            : cleaned
+    return /^[0-9a-fA-F]{6}$/.test(expanded)
+        ? expanded.toLowerCase()
+        : undefined
+}
+
+function hexToRgb(hex: string): { r: number; g: number; b: number } {
+    const expanded = expandHex(hex)
+    if (!expanded) return { r: 0, g: 0, b: 0 }
+    return {
+        r: parseInt(expanded.slice(0, 2), 16),
+        g: parseInt(expanded.slice(2, 4), 16),
+        b: parseInt(expanded.slice(4, 6), 16),
+    }
+}
+
+function rgbToHex(r: number, g: number, b: number): string {
+    const channel = (n: number) =>
+        Math.max(0, Math.min(255, Math.round(n)))
+            .toString(16)
+            .padStart(2, "0")
+    return "#" + channel(r) + channel(g) + channel(b)
+}
 
 @observer
 export class Colorpicker extends Component<ColorpickerProps> {
-    filter: PresetFilter = "all"
+    regionsFilter: boolean = false
+    othersFilter: boolean = false
+    inputMode: InputMode = "hex"
+    hexInputDraft: string | undefined = undefined
 
     constructor(props: ColorpickerProps) {
         super(props)
         makeObservable(this, {
-            filter: observable,
+            regionsFilter: observable,
+            othersFilter: observable,
+            inputMode: observable,
+            hexInputDraft: observable,
         })
     }
 
-    @action.bound private setFilter(filter: PresetFilter) {
-        this.filter = filter
+    @action.bound private toggleRegionsFilter() {
+        this.regionsFilter = !this.regionsFilter
+    }
+
+    @action.bound private toggleOthersFilter() {
+        this.othersFilter = !this.othersFilter
+    }
+
+    @action.bound private toggleInputMode() {
+        this.inputMode = this.inputMode === "hex" ? "rgb" : "hex"
+        this.hexInputDraft = undefined
     }
 
     @action.bound onColor(color: string) {
@@ -58,8 +99,41 @@ export class Colorpicker extends Component<ColorpickerProps> {
         }
     }
 
+    @action.bound private onHexInputChange(value: string) {
+        this.hexInputDraft = value
+        const expanded = expandHex(value)
+        if (expanded) this.props.onColor("#" + expanded)
+    }
+
+    @action.bound private onHexInputBlur() {
+        this.hexInputDraft = undefined
+    }
+
+    @action.bound private onRgbChannelChange(
+        channel: "r" | "g" | "b",
+        value: string
+    ) {
+        const num = Math.max(0, Math.min(255, parseInt(value, 10) || 0))
+        const current = this.displayedRgb ?? { r: 0, g: 0, b: 0 }
+        const next = { ...current, [channel]: num }
+        this.props.onColor(rgbToHex(next.r, next.g, next.b))
+    }
+
     @computed private get isCategoricalMap(): boolean {
         return this.props.baseColorScheme === ColorSchemeName.OwidCategoricalMap
+    }
+
+    @computed private get displayedHex(): string {
+        if (this.hexInputDraft !== undefined) return this.hexInputDraft
+        if (this.props.color === undefined) return ""
+        return this.props.color.replace(/^#/, "").toUpperCase()
+    }
+
+    @computed private get displayedRgb():
+        | { r: number; g: number; b: number }
+        | undefined {
+        if (this.props.color === undefined) return undefined
+        return hexToRgb(this.props.color)
     }
 
     @computed private get presetColors(): PresetColor[] {
@@ -88,14 +162,12 @@ export class Colorpicker extends Component<ColorpickerProps> {
     }
 
     private isPresetDimmed(preset: PresetColor): boolean {
-        switch (this.filter) {
-            case "regions":
-                return !preset.info.region
-            case "others":
-                return !preset.info.energy
-            default:
-                return false
-        }
+        const { regionsFilter, othersFilter } = this
+        if (!regionsFilter && !othersFilter) return false
+        // Show a swatch (don't dim) if it matches AT LEAST one active filter
+        const matchesRegions = regionsFilter && !!preset.info.region
+        const matchesOthers = othersFilter && !!preset.info.energy
+        return !(matchesRegions || matchesOthers)
     }
 
     private renderPresetSwatch(preset: PresetColor) {
@@ -161,31 +233,94 @@ export class Colorpicker extends Component<ColorpickerProps> {
                 placement="top"
                 appendTo={() => document.body}
                 maxWidth={220}
+                theme="light"
             >
                 {swatch}
             </Tippy>
         )
     }
 
-    private renderFilterTabs() {
+    private renderFilterPills() {
         if (this.isCategoricalMap) return null
         return (
-            <div className="colorpicker-filter" role="tablist">
-                {FILTER_OPTIONS.map(({ value, label }) => (
+            <div className="colorpicker-filter">
+                <button
+                    type="button"
+                    className={cx("colorpicker-filter__pill", {
+                        "colorpicker-filter__pill--active": this.regionsFilter,
+                    })}
+                    aria-pressed={this.regionsFilter}
+                    onClick={this.toggleRegionsFilter}
+                >
+                    Regions
+                </button>
+                <button
+                    type="button"
+                    className={cx("colorpicker-filter__pill", {
+                        "colorpicker-filter__pill--active": this.othersFilter,
+                    })}
+                    aria-pressed={this.othersFilter}
+                    onClick={this.toggleOthersFilter}
+                >
+                    Others
+                </button>
+            </div>
+        )
+    }
+
+    private renderColorInput() {
+        const otherMode = this.inputMode === "hex" ? "RGB" : "HEX"
+        return (
+            <div className="colorpicker-input">
+                <Tippy
+                    content={`Switch to ${otherMode}`}
+                    placement="top"
+                    appendTo={() => document.body}
+                    theme="light"
+                >
                     <button
-                        key={value}
                         type="button"
-                        role="tab"
-                        aria-selected={this.filter === value}
-                        className={cx("colorpicker-filter__tab", {
-                            "colorpicker-filter__tab--active":
-                                this.filter === value,
-                        })}
-                        onClick={() => this.setFilter(value)}
+                        className="colorpicker-input__mode"
+                        onClick={this.toggleInputMode}
+                        aria-label={`Switch to ${otherMode} input`}
                     >
-                        {label}
+                        {this.inputMode === "hex" ? "HEX" : "RGB"}
                     </button>
-                ))}
+                </Tippy>
+                {this.inputMode === "hex" ? (
+                    <input
+                        type="text"
+                        className="colorpicker-input__hex"
+                        value={this.displayedHex}
+                        placeholder="Default"
+                        onChange={(e) => this.onHexInputChange(e.target.value)}
+                        onBlur={this.onHexInputBlur}
+                        spellCheck={false}
+                        maxLength={7}
+                        aria-label="Hex value"
+                    />
+                ) : (
+                    <div className="colorpicker-input__rgb">
+                        {(["r", "g", "b"] as const).map((channel) => (
+                            <input
+                                key={channel}
+                                type="number"
+                                min={0}
+                                max={255}
+                                className="colorpicker-input__rgb-cell"
+                                value={this.displayedRgb?.[channel] ?? ""}
+                                placeholder="—"
+                                onChange={(e) =>
+                                    this.onRgbChannelChange(
+                                        channel,
+                                        e.target.value
+                                    )
+                                }
+                                aria-label={channel.toUpperCase()}
+                            />
+                        ))}
+                    </div>
+                )}
             </div>
         )
     }
@@ -193,18 +328,20 @@ export class Colorpicker extends Component<ColorpickerProps> {
     override render() {
         return (
             <Fragment>
+                <div className="colorpicker-header">Choose color</div>
+                <div className="colorpicker-presets">
+                    {this.presetColors.map((preset) =>
+                        this.renderPresetSwatch(preset)
+                    )}
+                </div>
+                {this.renderFilterPills()}
                 <SketchPicker
                     disableAlpha
                     presetColors={[]}
                     color={this.props.color}
                     onChange={(color) => this.onColor(color.hex)}
                 />
-                {this.renderFilterTabs()}
-                <div className="colorpicker-presets">
-                    {this.presetColors.map((preset) =>
-                        this.renderPresetSwatch(preset)
-                    )}
-                </div>
+                {this.renderColorInput()}
             </Fragment>
         )
     }

--- a/adminSiteClient/Colorpicker.tsx
+++ b/adminSiteClient/Colorpicker.tsx
@@ -106,8 +106,11 @@ export class Colorpicker extends Component<ColorpickerProps> {
     }
 
     @action.bound private onHexInputChange(value: string) {
-        this.hexInputDraft = value
-        const expanded = expandHex(value)
+        // The visible "#" prefix is rendered as a separate label, so strip
+        // any "#" the user might have typed/pasted, and cap at 6 chars.
+        const cleaned = value.replace(/#/g, "").slice(0, 6)
+        this.hexInputDraft = cleaned
+        const expanded = expandHex(cleaned)
         if (expanded) this.props.onColor("#" + expanded)
     }
 
@@ -311,16 +314,26 @@ export class Colorpicker extends Component<ColorpickerProps> {
                     </button>
                 </Tippy>
                 {this.inputMode === "hex" ? (
-                    <input
-                        type="text"
-                        className="colorpicker-input__hex"
-                        value={this.displayedHex}
-                        onChange={(e) => this.onHexInputChange(e.target.value)}
-                        onBlur={this.onHexInputBlur}
-                        spellCheck={false}
-                        maxLength={7}
-                        aria-label="Hex value"
-                    />
+                    <div className="colorpicker-input__hex-wrap">
+                        <span
+                            className="colorpicker-input__hex-prefix"
+                            aria-hidden="true"
+                        >
+                            #
+                        </span>
+                        <input
+                            type="text"
+                            className="colorpicker-input__hex"
+                            value={this.displayedHex}
+                            onChange={(e) =>
+                                this.onHexInputChange(e.target.value)
+                            }
+                            onBlur={this.onHexInputBlur}
+                            spellCheck={false}
+                            maxLength={6}
+                            aria-label="Hex value"
+                        />
+                    </div>
                 ) : (
                     <div className="colorpicker-input__rgb">
                         {(["r", "g", "b"] as const).map((channel) => (

--- a/adminSiteClient/Colorpicker.tsx
+++ b/adminSiteClient/Colorpicker.tsx
@@ -4,6 +4,8 @@ import { observer } from "mobx-react"
 import { SketchPicker } from "react-color"
 import Tippy from "@tippyjs/react"
 import cx from "classnames"
+import { faRotateLeft } from "@fortawesome/free-solid-svg-icons"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 
 import { ColorSchemeName, lastOfNonEmptyArray } from "@ourworldindata/utils"
 import {
@@ -114,9 +116,13 @@ export class Colorpicker extends Component<ColorpickerProps> {
         value: string
     ) {
         const num = Math.max(0, Math.min(255, parseInt(value, 10) || 0))
-        const current = this.displayedRgb ?? { r: 0, g: 0, b: 0 }
-        const next = { ...current, [channel]: num }
+        const next = { ...this.displayedRgb, [channel]: num }
         this.props.onColor(rgbToHex(next.r, next.g, next.b))
+    }
+
+    @action.bound private resetColor() {
+        this.props.onColor(undefined)
+        this.hexInputDraft = undefined
     }
 
     @computed private get isCategoricalMap(): boolean {
@@ -125,15 +131,12 @@ export class Colorpicker extends Component<ColorpickerProps> {
 
     @computed private get displayedHex(): string {
         if (this.hexInputDraft !== undefined) return this.hexInputDraft
-        if (this.props.color === undefined) return ""
-        return this.props.color.replace(/^#/, "").toUpperCase()
+        // Mirror SketchPicker's internal default (tinycolor maps undefined → "#000000")
+        return (this.props.color ?? "#000000").replace(/^#/, "").toUpperCase()
     }
 
-    @computed private get displayedRgb():
-        | { r: number; g: number; b: number }
-        | undefined {
-        if (this.props.color === undefined) return undefined
-        return hexToRgb(this.props.color)
+    @computed private get displayedRgb(): { r: number; g: number; b: number } {
+        return hexToRgb(this.props.color ?? "#000000")
     }
 
     @computed private get presetColors(): PresetColor[] {
@@ -164,10 +167,10 @@ export class Colorpicker extends Component<ColorpickerProps> {
     private isPresetDimmed(preset: PresetColor): boolean {
         const { regionsFilter, othersFilter } = this
         if (!regionsFilter && !othersFilter) return false
-        // Show a swatch (don't dim) if it matches AT LEAST one active filter
-        const matchesRegions = regionsFilter && !!preset.info.region
-        const matchesOthers = othersFilter && !!preset.info.energy
-        return !(matchesRegions || matchesOthers)
+        // AND filter: a swatch is shown only if it matches every active filter
+        if (regionsFilter && !preset.info.region) return true
+        if (othersFilter && !preset.info.energy) return true
+        return false
     }
 
     private renderPresetSwatch(preset: PresetColor) {
@@ -240,30 +243,36 @@ export class Colorpicker extends Component<ColorpickerProps> {
         )
     }
 
-    private renderFilterPills() {
-        if (this.isCategoricalMap) return null
+    private renderHeader() {
         return (
-            <div className="colorpicker-filter">
-                <button
-                    type="button"
-                    className={cx("colorpicker-filter__pill", {
-                        "colorpicker-filter__pill--active": this.regionsFilter,
-                    })}
-                    aria-pressed={this.regionsFilter}
-                    onClick={this.toggleRegionsFilter}
-                >
-                    Regions
-                </button>
-                <button
-                    type="button"
-                    className={cx("colorpicker-filter__pill", {
-                        "colorpicker-filter__pill--active": this.othersFilter,
-                    })}
-                    aria-pressed={this.othersFilter}
-                    onClick={this.toggleOthersFilter}
-                >
-                    Others
-                </button>
+            <div className="colorpicker-header">
+                <span className="colorpicker-header__title">Choose color</span>
+                {!this.isCategoricalMap && (
+                    <div className="colorpicker-header__filters">
+                        <button
+                            type="button"
+                            className={cx("colorpicker-filter__pill", {
+                                "colorpicker-filter__pill--active":
+                                    this.regionsFilter,
+                            })}
+                            aria-pressed={this.regionsFilter}
+                            onClick={this.toggleRegionsFilter}
+                        >
+                            Regions
+                        </button>
+                        <button
+                            type="button"
+                            className={cx("colorpicker-filter__pill", {
+                                "colorpicker-filter__pill--active":
+                                    this.othersFilter,
+                            })}
+                            aria-pressed={this.othersFilter}
+                            onClick={this.toggleOthersFilter}
+                        >
+                            Others
+                        </button>
+                    </div>
+                )}
             </div>
         )
     }
@@ -292,7 +301,6 @@ export class Colorpicker extends Component<ColorpickerProps> {
                         type="text"
                         className="colorpicker-input__hex"
                         value={this.displayedHex}
-                        placeholder="Default"
                         onChange={(e) => this.onHexInputChange(e.target.value)}
                         onBlur={this.onHexInputBlur}
                         spellCheck={false}
@@ -302,25 +310,46 @@ export class Colorpicker extends Component<ColorpickerProps> {
                 ) : (
                     <div className="colorpicker-input__rgb">
                         {(["r", "g", "b"] as const).map((channel) => (
-                            <input
+                            <div
                                 key={channel}
-                                type="number"
-                                min={0}
-                                max={255}
                                 className="colorpicker-input__rgb-cell"
-                                value={this.displayedRgb?.[channel] ?? ""}
-                                placeholder="—"
-                                onChange={(e) =>
-                                    this.onRgbChannelChange(
-                                        channel,
-                                        e.target.value
-                                    )
-                                }
-                                aria-label={channel.toUpperCase()}
-                            />
+                            >
+                                <span className="colorpicker-input__rgb-label">
+                                    {channel.toUpperCase()}
+                                </span>
+                                <input
+                                    type="number"
+                                    min={0}
+                                    max={255}
+                                    className="colorpicker-input__rgb-input"
+                                    value={this.displayedRgb[channel]}
+                                    onChange={(e) =>
+                                        this.onRgbChannelChange(
+                                            channel,
+                                            e.target.value
+                                        )
+                                    }
+                                    aria-label={channel.toUpperCase()}
+                                />
+                            </div>
                         ))}
                     </div>
                 )}
+                <Tippy
+                    content="Reset color"
+                    placement="top"
+                    appendTo={() => document.body}
+                    theme="light"
+                >
+                    <button
+                        type="button"
+                        className="colorpicker-input__reset"
+                        onClick={this.resetColor}
+                        aria-label="Reset color"
+                    >
+                        <FontAwesomeIcon icon={faRotateLeft} />
+                    </button>
+                </Tippy>
             </div>
         )
     }
@@ -328,13 +357,12 @@ export class Colorpicker extends Component<ColorpickerProps> {
     override render() {
         return (
             <Fragment>
-                <div className="colorpicker-header">Choose color</div>
+                {this.renderHeader()}
                 <div className="colorpicker-presets">
                     {this.presetColors.map((preset) =>
                         this.renderPresetSwatch(preset)
                     )}
                 </div>
-                {this.renderFilterPills()}
                 <SketchPicker
                     disableAlpha
                     presetColors={[]}

--- a/adminSiteClient/Colorpicker.tsx
+++ b/adminSiteClient/Colorpicker.tsx
@@ -1,5 +1,5 @@
 import { Component, Fragment } from "react"
-import { action, makeObservable } from "mobx"
+import { action, computed, makeObservable, observable } from "mobx"
 import { observer } from "mobx-react"
 import { SketchPicker } from "react-color"
 import Tippy from "@tippyjs/react"
@@ -27,11 +27,27 @@ interface PresetColor {
     info: ColorSemanticInfo
 }
 
+type PresetFilter = "all" | "regions" | "others"
+
+const FILTER_OPTIONS: { value: PresetFilter; label: string }[] = [
+    { value: "all", label: "All" },
+    { value: "regions", label: "Regions" },
+    { value: "others", label: "Others" },
+]
+
 @observer
 export class Colorpicker extends Component<ColorpickerProps> {
+    filter: PresetFilter = "all"
+
     constructor(props: ColorpickerProps) {
         super(props)
-        makeObservable(this)
+        makeObservable(this, {
+            filter: observable,
+        })
+    }
+
+    @action.bound private setFilter(filter: PresetFilter) {
+        this.filter = filter
     }
 
     @action.bound onColor(color: string) {
@@ -42,11 +58,12 @@ export class Colorpicker extends Component<ColorpickerProps> {
         }
     }
 
-    private get presetColors(): PresetColor[] {
-        const isOwidCategoricalMap =
-            this.props.baseColorScheme === ColorSchemeName.OwidCategoricalMap
+    @computed private get isCategoricalMap(): boolean {
+        return this.props.baseColorScheme === ColorSchemeName.OwidCategoricalMap
+    }
 
-        if (isOwidCategoricalMap) {
+    @computed private get presetColors(): PresetColor[] {
+        if (this.isCategoricalMap) {
             // We use OwidMapColors instead of the scheme's palette
             // because it includes three additional 'special' colors
             // to be used sparingly when needed (Taupe, Mustard, Tomato)
@@ -70,13 +87,24 @@ export class Colorpicker extends Component<ColorpickerProps> {
         }))
     }
 
+    private isPresetDimmed(preset: PresetColor): boolean {
+        switch (this.filter) {
+            case "regions":
+                return !preset.info.region
+            case "others":
+                return !preset.info.energy
+            default:
+                return false
+        }
+    }
+
     private renderPresetSwatch(preset: PresetColor) {
         const { color, info } = preset
         const { colorName, region, energy } = info
-        const hasSemanticMapping = !!(region || energy)
         const isSelected =
             this.props.color !== undefined &&
             this.props.color.toLowerCase() === color.toLowerCase()
+        const isDimmed = this.isPresetDimmed(preset)
 
         const ariaLabelParts = [
             colorName,
@@ -108,6 +136,23 @@ export class Colorpicker extends Component<ColorpickerProps> {
             </div>
         )
 
+        const swatch = (
+            <button
+                type="button"
+                className={cx("colorpicker-presets__swatch", {
+                    "colorpicker-presets__swatch--selected": isSelected,
+                    "colorpicker-presets__swatch--dimmed": isDimmed,
+                })}
+                style={{ backgroundColor: color }}
+                onClick={isDimmed ? undefined : () => this.onColor(color)}
+                disabled={isDimmed}
+                aria-label={ariaLabelParts.join(", ") || color}
+            />
+        )
+
+        // No tooltip for dimmed swatches — they're inactive in the current filter view
+        if (isDimmed) return <Fragment key={color}>{swatch}</Fragment>
+
         return (
             <Tippy
                 key={color}
@@ -117,18 +162,31 @@ export class Colorpicker extends Component<ColorpickerProps> {
                 appendTo={() => document.body}
                 maxWidth={220}
             >
-                <button
-                    type="button"
-                    className={cx("colorpicker-presets__swatch", {
-                        "colorpicker-presets__swatch--selected": isSelected,
-                        "colorpicker-presets__swatch--has-mapping":
-                            hasSemanticMapping,
-                    })}
-                    style={{ backgroundColor: color }}
-                    onClick={() => this.onColor(color)}
-                    aria-label={ariaLabelParts.join(", ") || color}
-                />
+                {swatch}
             </Tippy>
+        )
+    }
+
+    private renderFilterTabs() {
+        if (this.isCategoricalMap) return null
+        return (
+            <div className="colorpicker-filter" role="tablist">
+                {FILTER_OPTIONS.map(({ value, label }) => (
+                    <button
+                        key={value}
+                        type="button"
+                        role="tab"
+                        aria-selected={this.filter === value}
+                        className={cx("colorpicker-filter__tab", {
+                            "colorpicker-filter__tab--active":
+                                this.filter === value,
+                        })}
+                        onClick={() => this.setFilter(value)}
+                    >
+                        {label}
+                    </button>
+                ))}
+            </div>
         )
     }
 
@@ -141,6 +199,7 @@ export class Colorpicker extends Component<ColorpickerProps> {
                     color={this.props.color}
                     onChange={(color) => this.onColor(color.hex)}
                 />
+                {this.renderFilterTabs()}
                 <div className="colorpicker-presets">
                     {this.presetColors.map((preset) =>
                         this.renderPresetSwatch(preset)

--- a/adminSiteClient/Colorpicker.tsx
+++ b/adminSiteClient/Colorpicker.tsx
@@ -71,7 +71,7 @@ function rgbToHex(r: number, g: number, b: number): string {
 @observer
 export class Colorpicker extends Component<ColorpickerProps> {
     regionsFilter: boolean = false
-    othersFilter: boolean = false
+    energyFilter: boolean = false
     inputMode: InputMode = "hex"
     hexInputDraft: string | undefined = undefined
 
@@ -79,7 +79,7 @@ export class Colorpicker extends Component<ColorpickerProps> {
         super(props)
         makeObservable(this, {
             regionsFilter: observable,
-            othersFilter: observable,
+            energyFilter: observable,
             inputMode: observable,
             hexInputDraft: observable,
         })
@@ -89,8 +89,8 @@ export class Colorpicker extends Component<ColorpickerProps> {
         this.regionsFilter = !this.regionsFilter
     }
 
-    @action.bound private toggleOthersFilter() {
-        this.othersFilter = !this.othersFilter
+    @action.bound private toggleEnergyFilter() {
+        this.energyFilter = !this.energyFilter
     }
 
     @action.bound private toggleInputMode() {
@@ -184,13 +184,14 @@ export class Colorpicker extends Component<ColorpickerProps> {
     }
 
     private isPresetDimmed(preset: PresetColor): boolean {
-        const { regionsFilter, othersFilter } = this
-        if (!regionsFilter && !othersFilter) return false
+        const { regionsFilter, energyFilter } = this
+        if (!regionsFilter && !energyFilter) return false
         // AND filter: a swatch is shown only if it matches every active filter
         if (regionsFilter && !preset.info.region) return true
-        if (othersFilter && !preset.info.energy) return true
+        if (energyFilter && !preset.info.energy) return true
         return false
     }
+
 
     private renderPresetSwatch(preset: PresetColor) {
         const { color, info } = preset
@@ -203,7 +204,7 @@ export class Colorpicker extends Component<ColorpickerProps> {
         const ariaLabelParts = [
             colorName,
             region ? `Regions: ${region}` : undefined,
-            energy ? `Others: ${energy}` : undefined,
+            energy ? `Energy: ${energy}` : undefined,
         ].filter((x): x is string => !!x)
 
         const tooltipContent = (
@@ -222,7 +223,7 @@ export class Colorpicker extends Component<ColorpickerProps> {
                 {energy && (
                     <div className="colorpicker-presets__tooltip-row">
                         <span className="colorpicker-presets__tooltip-label">
-                            Others:
+                            Energy:
                         </span>{" "}
                         {energy}
                     </div>
@@ -283,12 +284,12 @@ export class Colorpicker extends Component<ColorpickerProps> {
                             type="button"
                             className={cx("colorpicker-filter__pill", {
                                 "colorpicker-filter__pill--active":
-                                    this.othersFilter,
+                                    this.energyFilter,
                             })}
-                            aria-pressed={this.othersFilter}
-                            onClick={this.toggleOthersFilter}
+                            aria-pressed={this.energyFilter}
+                            onClick={this.toggleEnergyFilter}
                         >
-                            Others
+                            Energy
                         </button>
                     </div>
                 )}

--- a/adminSiteClient/Colorpicker.tsx
+++ b/adminSiteClient/Colorpicker.tsx
@@ -2,6 +2,8 @@ import { Component, Fragment } from "react"
 import { action, makeObservable } from "mobx"
 import { observer } from "mobx-react"
 import { SketchPicker } from "react-color"
+import Tippy from "@tippyjs/react"
+import cx from "classnames"
 
 import { ColorSchemeName, lastOfNonEmptyArray } from "@ourworldindata/utils"
 import {
@@ -10,11 +12,17 @@ import {
     getColorNameOwidDistinctLinesAndSemanticPalettes,
     OwidMapColors,
 } from "@ourworldindata/grapher"
+
 interface ColorpickerProps {
     color?: string
     showLineChartColors: boolean
     baseColorScheme?: ColorSchemeName
     onColor: (color: string | undefined) => void
+}
+
+interface PresetColor {
+    color: string
+    lines: string[]
 }
 
 @observer
@@ -32,7 +40,7 @@ export class Colorpicker extends Component<ColorpickerProps> {
         }
     }
 
-    private get presetColors(): { color: string; title: string }[] {
+    private get presetColors(): PresetColor[] {
         const isOwidCategoricalMap =
             this.props.baseColorScheme === ColorSchemeName.OwidCategoricalMap
 
@@ -42,24 +50,65 @@ export class Colorpicker extends Component<ColorpickerProps> {
             // to be used sparingly when needed (Taupe, Mustard, Tomato)
             return Object.entries(OwidMapColors).map(([name, color]) => ({
                 color,
-                title: name,
-            }))
-        } else {
-            const scheme = this.props.showLineChartColors
-                ? ColorSchemes.get(ColorSchemeName.OwidDistinctLines)
-                : ColorSchemes.get(ColorSchemeName["owid-distinct"])
-
-            const colorNameLookupFn = (color: string) => {
-                const nameLines = this.props.showLineChartColors
-                    ? getColorNameOwidDistinctLinesAndSemanticPalettes(color)
-                    : getColorNameOwidDistinctAndSemanticPalettes(color)
-                return nameLines.join(" ")
-            }
-            return lastOfNonEmptyArray(scheme.colorSets).map((color) => ({
-                color,
-                title: colorNameLookupFn(color),
+                lines: [name],
             }))
         }
+
+        const scheme = this.props.showLineChartColors
+            ? ColorSchemes.get(ColorSchemeName.OwidDistinctLines)
+            : ColorSchemes.get(ColorSchemeName["owid-distinct"])
+
+        const colorNameLookupFn = this.props.showLineChartColors
+            ? getColorNameOwidDistinctLinesAndSemanticPalettes
+            : getColorNameOwidDistinctAndSemanticPalettes
+
+        return lastOfNonEmptyArray(scheme.colorSets).map((color) => ({
+            color,
+            lines: colorNameLookupFn(color),
+        }))
+    }
+
+    private renderPresetSwatch(preset: PresetColor) {
+        const { color, lines } = preset
+        const isSelected =
+            this.props.color !== undefined &&
+            this.props.color.toLowerCase() === color.toLowerCase()
+
+        const tooltipContent =
+            lines.length > 0 ? (
+                <>
+                    {lines.map((line) => (
+                        <span
+                            key={line}
+                            className="colorpicker-presets__tooltip-line"
+                        >
+                            {line}
+                        </span>
+                    ))}
+                </>
+            ) : (
+                color
+            )
+
+        return (
+            <Tippy
+                key={color + lines.join("|")}
+                content={tooltipContent}
+                delay={[100, 0]}
+                placement="top"
+                appendTo={() => document.body}
+            >
+                <button
+                    type="button"
+                    className={cx("colorpicker-presets__swatch", {
+                        "colorpicker-presets__swatch--selected": isSelected,
+                    })}
+                    style={{ backgroundColor: color }}
+                    onClick={() => this.onColor(color)}
+                    aria-label={lines.join(", ") || color}
+                />
+            </Tippy>
+        )
     }
 
     override render() {
@@ -67,10 +116,15 @@ export class Colorpicker extends Component<ColorpickerProps> {
             <Fragment>
                 <SketchPicker
                     disableAlpha
-                    presetColors={this.presetColors}
+                    presetColors={[]}
                     color={this.props.color}
                     onChange={(color) => this.onColor(color.hex)}
                 />
+                <div className="colorpicker-presets">
+                    {this.presetColors.map((preset) =>
+                        this.renderPresetSwatch(preset)
+                    )}
+                </div>
             </Fragment>
         )
     }

--- a/adminSiteClient/Colorpicker.tsx
+++ b/adminSiteClient/Colorpicker.tsx
@@ -125,17 +125,20 @@ export class Colorpicker extends Component<ColorpickerProps> {
         this.hexInputDraft = undefined
     }
 
-    @computed private get isCategoricalMap(): boolean {
+    // NOTE: not @computed — these read this.props which is NOT observable,
+    // so MobX would cache stale results when props change without an
+    // observable changing alongside them.
+    private get isCategoricalMap(): boolean {
         return this.props.baseColorScheme === ColorSchemeName.OwidCategoricalMap
     }
 
-    @computed private get displayedHex(): string {
+    private get displayedHex(): string {
         if (this.hexInputDraft !== undefined) return this.hexInputDraft
         // Mirror SketchPicker's internal default (tinycolor maps undefined → "#000000")
         return (this.props.color ?? "#000000").replace(/^#/, "").toUpperCase()
     }
 
-    @computed private get displayedRgb(): { r: number; g: number; b: number } {
+    private get displayedRgb(): { r: number; g: number; b: number } {
         return hexToRgb(this.props.color ?? "#000000")
     }
 

--- a/adminSiteClient/Colorpicker.tsx
+++ b/adminSiteClient/Colorpicker.tsx
@@ -23,6 +23,7 @@ interface ColorpickerProps {
 interface PresetColor {
     color: string
     lines: string[]
+    hasSemanticMapping: boolean
 }
 
 @observer
@@ -51,6 +52,7 @@ export class Colorpicker extends Component<ColorpickerProps> {
             return Object.entries(OwidMapColors).map(([name, color]) => ({
                 color,
                 lines: [name],
+                hasSemanticMapping: false,
             }))
         }
 
@@ -62,14 +64,20 @@ export class Colorpicker extends Component<ColorpickerProps> {
             ? getColorNameOwidDistinctLinesAndSemanticPalettes
             : getColorNameOwidDistinctAndSemanticPalettes
 
-        return lastOfNonEmptyArray(scheme.colorSets).map((color) => ({
-            color,
-            lines: colorNameLookupFn(color),
-        }))
+        return lastOfNonEmptyArray(scheme.colorSets).map((color) => {
+            const lines = colorNameLookupFn(color)
+            // The first line is the colour name (🎨); any additional lines mean
+            // the colour is also used in a semantic palette (🌍 region, ⚡ energy)
+            return {
+                color,
+                lines,
+                hasSemanticMapping: lines.length > 1,
+            }
+        })
     }
 
     private renderPresetSwatch(preset: PresetColor) {
-        const { color, lines } = preset
+        const { color, lines, hasSemanticMapping } = preset
         const isSelected =
             this.props.color !== undefined &&
             this.props.color.toLowerCase() === color.toLowerCase()
@@ -102,6 +110,8 @@ export class Colorpicker extends Component<ColorpickerProps> {
                     type="button"
                     className={cx("colorpicker-presets__swatch", {
                         "colorpicker-presets__swatch--selected": isSelected,
+                        "colorpicker-presets__swatch--has-mapping":
+                            hasSemanticMapping,
                     })}
                     style={{ backgroundColor: color }}
                     onClick={() => this.onColor(color)}

--- a/adminSiteClient/Colorpicker.tsx
+++ b/adminSiteClient/Colorpicker.tsx
@@ -192,7 +192,6 @@ export class Colorpicker extends Component<ColorpickerProps> {
         return false
     }
 
-
     private renderPresetSwatch(preset: PresetColor) {
         const { color, info } = preset
         const { colorName, region, energy } = info

--- a/adminSiteClient/Colorpicker.tsx
+++ b/adminSiteClient/Colorpicker.tsx
@@ -19,6 +19,10 @@ import {
 
 interface ColorpickerProps {
     color?: string
+    // When `color` is unset, this is shown as the displayed value. The
+    // parent should pass the chart's resolved scheme color so the popover
+    // matches what the chart is actually rendering.
+    defaultColor?: string
     showLineChartColors: boolean
     baseColorScheme?: ColorSchemeName
     onColor: (color: string | undefined) => void
@@ -132,14 +136,21 @@ export class Colorpicker extends Component<ColorpickerProps> {
         return this.props.baseColorScheme === ColorSchemeName.OwidCategoricalMap
     }
 
+    private get effectiveColor(): string {
+        return (
+            this.props.color ??
+            this.props.defaultColor ??
+            "#000000"
+        ).toLowerCase()
+    }
+
     private get displayedHex(): string {
         if (this.hexInputDraft !== undefined) return this.hexInputDraft
-        // Mirror SketchPicker's internal default (tinycolor maps undefined → "#000000")
-        return (this.props.color ?? "#000000").replace(/^#/, "").toUpperCase()
+        return this.effectiveColor.replace(/^#/, "").toUpperCase()
     }
 
     private get displayedRgb(): { r: number; g: number; b: number } {
-        return hexToRgb(this.props.color ?? "#000000")
+        return hexToRgb(this.effectiveColor)
     }
 
     @computed private get presetColors(): PresetColor[] {
@@ -369,7 +380,7 @@ export class Colorpicker extends Component<ColorpickerProps> {
                 <SketchPicker
                     disableAlpha
                     presetColors={[]}
-                    color={this.props.color}
+                    color={this.effectiveColor}
                     onChange={(color) => this.onColor(color.hex)}
                 />
                 {this.renderColorInput()}

--- a/adminSiteClient/Colorpicker.tsx
+++ b/adminSiteClient/Colorpicker.tsx
@@ -12,6 +12,7 @@ import {
     getColorNameOwidDistinctAndSemanticPalettes,
     getColorNameOwidDistinctLinesAndSemanticPalettes,
     OwidMapColors,
+    toColorDisplayName,
 } from "@ourworldindata/grapher"
 
 interface ColorpickerProps {
@@ -51,7 +52,7 @@ export class Colorpicker extends Component<ColorpickerProps> {
             // to be used sparingly when needed (Taupe, Mustard, Tomato)
             return Object.entries(OwidMapColors).map(([name, color]) => ({
                 color,
-                info: { colorName: name },
+                info: { colorName: toColorDisplayName(name) },
             }))
         }
 

--- a/adminSiteClient/DimensionCard.tsx
+++ b/adminSiteClient/DimensionCard.tsx
@@ -2,8 +2,12 @@ import * as _ from "lodash-es"
 import { Component, Fragment } from "react"
 import { observable, computed, action, makeObservable } from "mobx"
 import { observer } from "mobx-react"
-import { ChartDimension } from "@ourworldindata/grapher"
-import { OwidColumnDef, OwidVariableRoundingMode } from "@ourworldindata/types"
+import { ChartDimension, ColorSchemes } from "@ourworldindata/grapher"
+import {
+    ColorSchemeName,
+    OwidColumnDef,
+    OwidVariableRoundingMode,
+} from "@ourworldindata/types"
 import {
     Toggle,
     BindAutoString,
@@ -75,6 +79,27 @@ export class DimensionCard<
         return this.props.dimension.column.def.color
     }
 
+    // Approximate the chart's resolved scheme color for this dimension. Used
+    // as a fallback in the color popover when no explicit override is set,
+    // so the user sees the actual chart colour instead of black.
+    @computed get defaultColor(): string | undefined {
+        const { grapherState } = this.props.editor
+        const schemeName =
+            grapherState.baseColorScheme ??
+            (grapherState.isLineChart
+                ? ColorSchemeName.OwidDistinctLines
+                : ColorSchemeName["owid-distinct"])
+        const scheme = ColorSchemes.get(schemeName)
+        if (!scheme) return undefined
+        const dims = grapherState.filledDimensions
+        const dimIndex = dims.findIndex(
+            (d) => d.variableId === this.props.dimension.variableId
+        )
+        if (dimIndex < 0) return undefined
+        const colors = scheme.getDistinctColors(Math.max(dims.length, 1))
+        return colors[dimIndex]
+    }
+
     @computed get roundingMode(): OwidVariableRoundingMode {
         return (
             this.props.dimension.display.roundingMode ??
@@ -144,6 +169,7 @@ export class DimensionCard<
                         {isDndEnabled && <SortableList.DragHandle />}
                         <ColorBox
                             color={this.color}
+                            defaultColor={this.defaultColor}
                             onColor={this.onColor}
                             showLineChartColors={grapherState.isLineChart}
                         />

--- a/adminSiteClient/EditorDataTab.tsx
+++ b/adminSiteClient/EditorDataTab.tsx
@@ -5,6 +5,7 @@ import { computed, action, observable, makeObservable } from "mobx"
 import { observer } from "mobx-react"
 import cx from "classnames"
 import {
+    ColorSchemeName,
     EntitySelectionMode,
     MissingDataStrategy,
     PeerCountryStrategy,
@@ -12,6 +13,7 @@ import {
     SeriesName,
 } from "@ourworldindata/types"
 import {
+    ColorSchemes,
     GrapherState,
     selectPeerCountries,
     prepareEntitiesForPeerSelection,
@@ -72,6 +74,25 @@ class EntityListItem extends React.Component<EntityListItemProps> {
         return this.table.getColorForEntityName(this.props.entityName)
     }
 
+    // Approximate the chart's resolved scheme color for this entity. Used
+    // as a fallback in the color popover when no explicit override is set,
+    // so the user sees the actual chart colour instead of black.
+    @computed get defaultColor(): string | undefined {
+        const { grapherState } = this.props.editor
+        const schemeName =
+            grapherState.baseColorScheme ??
+            (grapherState.isLineChart
+                ? ColorSchemeName.OwidDistinctLines
+                : ColorSchemeName["owid-distinct"])
+        const scheme = ColorSchemes.get(schemeName)
+        if (!scheme) return undefined
+        const entities = grapherState.selection.selectedEntityNames
+        const idx = entities.indexOf(this.props.entityName)
+        if (idx < 0) return undefined
+        const colors = scheme.getDistinctColors(Math.max(entities.length, 1))
+        return colors[idx]
+    }
+
     @action.bound onColor(color: string | undefined) {
         const { grapherState } = this.props.editor
         grapherState.selectedEntityColors[this.props.entityName] = color
@@ -103,6 +124,7 @@ class EntityListItem extends React.Component<EntityListItemProps> {
                     {props.isDndEnabled && <SortableList.DragHandle />}
                     <ColorBox
                         color={color}
+                        defaultColor={this.defaultColor}
                         onColor={this.onColor}
                         showLineChartColors={editor.grapherState.isLineChart}
                     />

--- a/adminSiteClient/Forms.tsx
+++ b/adminSiteClient/Forms.tsx
@@ -29,7 +29,6 @@ import {
     faExclamationTriangle,
     faCircleInfo,
     faCopy,
-    faRotateLeft,
 } from "@fortawesome/free-solid-svg-icons"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 
@@ -692,22 +691,12 @@ export class ColorBox extends React.Component<ColorBoxProps> {
         return (
             <Tippy
                 content={
-                    <>
-                        <Colorpicker
-                            color={color}
-                            onColor={this.props.onColor}
-                            showLineChartColors={this.props.showLineChartColors}
-                            baseColorScheme={this.props.baseColorScheme}
-                        />
-                        <button
-                            type="button"
-                            className="colorpicker-reset"
-                            onClick={() => this.props.onColor(undefined)}
-                        >
-                            <FontAwesomeIcon icon={faRotateLeft} />
-                            <span>Reset color</span>
-                        </button>
-                    </>
+                    <Colorpicker
+                        color={color}
+                        onColor={this.props.onColor}
+                        showLineChartColors={this.props.showLineChartColors}
+                        baseColorScheme={this.props.baseColorScheme}
+                    />
                 }
                 placement="right"
                 interactive={true}

--- a/adminSiteClient/Forms.tsx
+++ b/adminSiteClient/Forms.tsx
@@ -675,6 +675,10 @@ export class EditableListItem extends React.Component<EditableListItemProps> {
 
 interface ColorBoxProps {
     color: string | undefined
+    // Color the chart actually uses when `color` is unset (the resolved
+    // scheme default). When provided, it is shown in the popover and
+    // ColorBox preview instead of falling back to black.
+    defaultColor?: string
     onColor: (color: string | undefined) => void
     showLineChartColors: boolean
     baseColorScheme?: ColorSchemeName
@@ -683,8 +687,12 @@ interface ColorBoxProps {
 @observer
 export class ColorBox extends React.Component<ColorBoxProps> {
     override render() {
-        const { color } = this.props
-
+        const { color, defaultColor } = this.props
+        // The preview only reflects the explicit override: paintbrush when
+        // no override is set, coloured square when there is one. The
+        // chart's resolved scheme colour (`defaultColor`) is only used
+        // inside the popover so the inputs/saturation match what the
+        // chart is actually rendering.
         const style =
             color !== undefined ? { backgroundColor: color } : undefined
 
@@ -693,6 +701,7 @@ export class ColorBox extends React.Component<ColorBoxProps> {
                 content={
                     <Colorpicker
                         color={color}
+                        defaultColor={defaultColor}
                         onColor={this.props.onColor}
                         showLineChartColors={this.props.showLineChartColors}
                         baseColorScheme={this.props.baseColorScheme}

--- a/adminSiteClient/Forms.tsx
+++ b/adminSiteClient/Forms.tsx
@@ -29,6 +29,7 @@ import {
     faExclamationTriangle,
     faCircleInfo,
     faCopy,
+    faRotateLeft,
 } from "@fortawesome/free-solid-svg-icons"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 
@@ -698,19 +699,14 @@ export class ColorBox extends React.Component<ColorBoxProps> {
                             showLineChartColors={this.props.showLineChartColors}
                             baseColorScheme={this.props.baseColorScheme}
                         />
-                        <div
-                            style={{
-                                display: "flex",
-                                alignItems: "center",
-                                flexDirection: "column",
-                            }}
+                        <button
+                            type="button"
+                            className="colorpicker-reset"
+                            onClick={() => this.props.onColor(undefined)}
                         >
-                            <Button
-                                onClick={() => this.props.onColor(undefined)}
-                            >
-                                Reset to color scheme default
-                            </Button>
-                        </div>
+                            <FontAwesomeIcon icon={faRotateLeft} />
+                            <span>Reset color</span>
+                        </button>
                     </>
                 }
                 placement="right"

--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -990,10 +990,25 @@ $nav-height: 45px;
     color: #1d1d1f;
 }
 
+.colorpicker-input__hex-wrap {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    align-items: center;
+}
+
+.colorpicker-input__hex-prefix {
+    padding-left: 8px;
+    font-size: 11px;
+    color: #9a9a9e;
+    pointer-events: none;
+    user-select: none;
+}
+
 .colorpicker-input__hex {
     flex: 1;
     min-width: 0;
-    padding: 6px 8px;
+    padding: 6px 8px 6px 2px;
     border: none;
     background: transparent;
     font-size: 11px;
@@ -1003,6 +1018,10 @@ $nav-height: 45px;
 }
 
 .colorpicker-input__hex:focus {
+    background: rgba(24, 101, 242, 0.05);
+}
+
+.colorpicker-input__hex-wrap:focus-within {
     background: rgba(24, 101, 242, 0.05);
 }
 

--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -872,6 +872,65 @@ $nav-height: 45px;
     }
 }
 
+.colorpicker-presets {
+    display: grid;
+    grid-template-columns: repeat(4, 22px);
+    justify-content: center;
+    gap: 6px;
+    padding: 10px;
+    background: #fff;
+    border-top: 1px solid #eee;
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
+}
+
+.colorpicker-presets__swatch {
+    width: 22px;
+    height: 22px;
+    border: none;
+    padding: 0;
+    border-radius: 3px;
+    cursor: pointer;
+    box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.15);
+    transition:
+        transform 80ms ease-out,
+        box-shadow 80ms ease-out;
+}
+
+.colorpicker-presets__swatch:hover {
+    transform: scale(1.15);
+    box-shadow:
+        inset 0 0 0 1px rgba(0, 0, 0, 0.25),
+        0 1px 4px rgba(0, 0, 0, 0.2);
+}
+
+.colorpicker-presets__swatch:focus-visible {
+    outline: none;
+    box-shadow:
+        inset 0 0 0 1px rgba(0, 0, 0, 0.25),
+        0 0 0 2px #1865f2;
+}
+
+.colorpicker-presets__swatch--selected {
+    box-shadow:
+        inset 0 0 0 2px #fff,
+        0 0 0 2px #1865f2;
+}
+
+.colorpicker-presets__swatch--selected:hover {
+    transform: scale(1.15);
+    box-shadow:
+        inset 0 0 0 2px #fff,
+        0 0 0 2px #1865f2,
+        0 1px 4px rgba(0, 0, 0, 0.2);
+}
+
+.colorpicker-presets__tooltip-line {
+    display: block;
+    line-height: 1.35;
+    white-space: nowrap;
+}
+
 .LoadingBlocker {
     position: fixed;
     top: 0;

--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -877,33 +877,39 @@ $nav-height: 45px;
     }
 }
 
-/* Visual order: header → grid → toggle filter pills → color map
-   (sketch-picker) → custom hex/rgb input → reset row */
+/* Visual order: header (with filter pills) → grid → color map (sketch-picker)
+   → custom hex/rgb input (with inline reset icon) */
 .colorpicker-tooltip .tippy-content > .colorpicker-header {
     order: 1;
 }
 .colorpicker-tooltip .tippy-content > .colorpicker-presets {
     order: 2;
 }
-.colorpicker-tooltip .tippy-content > .colorpicker-filter {
+.colorpicker-tooltip .tippy-content > .sketch-picker {
     order: 3;
 }
-.colorpicker-tooltip .tippy-content > .sketch-picker {
-    order: 4;
-}
 .colorpicker-tooltip .tippy-content > .colorpicker-input {
-    order: 5;
-}
-.colorpicker-tooltip .tippy-content > .colorpicker-reset {
-    order: 6;
+    order: 4;
 }
 
 .colorpicker-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
     padding: 9px 10px 6px;
+}
+
+.colorpicker-header__title {
     font-size: 11px;
     font-weight: 600;
     color: #1d1d1f;
     letter-spacing: 0.01em;
+}
+
+.colorpicker-header__filters {
+    display: flex;
+    gap: 4px;
 }
 
 /* Bigger saturation pointer (the dot you drag in the colour panel) */
@@ -996,12 +1002,6 @@ $nav-height: 45px;
     text-align: left;
 }
 
-.colorpicker-input__hex::placeholder,
-.colorpicker-input__rgb-cell::placeholder {
-    color: #9a9a9e;
-    font-style: italic;
-}
-
 .colorpicker-input__hex:focus {
     background: rgba(24, 101, 242, 0.05);
 }
@@ -1010,80 +1010,80 @@ $nav-height: 45px;
     flex: 1;
     display: flex;
     align-items: stretch;
+    min-width: 0;
 }
 
 .colorpicker-input__rgb-cell {
     flex: 1;
     width: 0;
-    padding: 6px 4px;
-    border: none;
+    display: flex;
+    align-items: center;
     border-left: 1px solid #d6d8da;
-    background: transparent;
-    font-size: 11px;
-    color: #1d1d1f;
-    outline: none;
-    text-align: center;
-    -moz-appearance: textfield;
 }
 
 .colorpicker-input__rgb-cell:first-child {
     border-left: none;
 }
 
-.colorpicker-input__rgb-cell:focus {
+.colorpicker-input__rgb-label {
+    padding-left: 6px;
+    font-size: 9px;
+    font-weight: 600;
+    color: #9a9a9e;
+    text-transform: uppercase;
+    pointer-events: none;
+}
+
+.colorpicker-input__rgb-input {
+    flex: 1;
+    width: 0;
+    padding: 6px 4px;
+    border: none;
+    background: transparent;
+    font-size: 11px;
+    color: #1d1d1f;
+    outline: none;
+    text-align: left;
+    -moz-appearance: textfield;
+}
+
+.colorpicker-input__rgb-input:focus {
     background: rgba(24, 101, 242, 0.05);
 }
 
-.colorpicker-input__rgb-cell::-webkit-outer-spin-button,
-.colorpicker-input__rgb-cell::-webkit-inner-spin-button {
+.colorpicker-input__rgb-input::-webkit-outer-spin-button,
+.colorpicker-input__rgb-input::-webkit-inner-spin-button {
     -webkit-appearance: none;
     margin: 0;
 }
 
-/* Reset color row at the bottom of the popover */
-.colorpicker-reset {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 6px;
-    width: 100%;
-    padding: 8px 10px;
+.colorpicker-input__reset {
+    flex-shrink: 0;
+    width: 28px;
     border: none;
-    border-top: 1px solid #eee;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
-    background: #fff;
-    color: #6e6e73;
-    font-size: 11px;
-    font-weight: 500;
+    border-left: 1px solid #d6d8da;
+    background: transparent;
+    color: #9a9a9e;
+    font-size: 10px;
     cursor: pointer;
     transition:
         background 80ms ease-out,
         color 80ms ease-out;
 }
 
-.colorpicker-reset:hover {
+.colorpicker-input__reset:hover {
     background: #f5f5f7;
     color: #1d1d1f;
 }
 
-.colorpicker-reset svg {
-    font-size: 11px;
-}
-
-/* Toggle pills below the grid — discrete, click to highlight matching swatches. */
-.colorpicker-filter {
-    display: flex;
-    gap: 6px;
-    padding: 0 10px 10px;
-}
-
+/* Filter toggle pills, sit inline at the right of the header. Click to
+   highlight matching swatches. */
 .colorpicker-filter__pill {
-    padding: 3px 9px;
+    padding: 2px 8px;
     border: 1px solid #d6d8da;
-    border-radius: 12px;
+    border-radius: 10px;
     background: transparent;
-    font-size: 10px;
+    font-size: 9px;
     font-weight: 500;
     color: #6e6e73;
     cursor: pointer;

--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -865,13 +865,45 @@ $nav-height: 45px;
 .colorpicker-tooltip {
     .tippy-content {
         padding: 0;
+        display: flex;
+        flex-direction: column;
 
         .sketch-picker {
             box-shadow: none !important;
-            padding: 12px 12px 8px !important;
+            padding: 10px 10px 6px !important;
             width: 220px !important;
+            border-top: 1px solid #eee !important;
         }
     }
+}
+
+/* Visual order: header → grid → toggle filter pills → color map
+   (sketch-picker) → custom hex/rgb input → reset row */
+.colorpicker-tooltip .tippy-content > .colorpicker-header {
+    order: 1;
+}
+.colorpicker-tooltip .tippy-content > .colorpicker-presets {
+    order: 2;
+}
+.colorpicker-tooltip .tippy-content > .colorpicker-filter {
+    order: 3;
+}
+.colorpicker-tooltip .tippy-content > .sketch-picker {
+    order: 4;
+}
+.colorpicker-tooltip .tippy-content > .colorpicker-input {
+    order: 5;
+}
+.colorpicker-tooltip .tippy-content > .colorpicker-reset {
+    order: 6;
+}
+
+.colorpicker-header {
+    padding: 9px 10px 6px;
+    font-size: 11px;
+    font-weight: 600;
+    color: #1d1d1f;
+    letter-spacing: 0.01em;
 }
 
 /* Bigger saturation pointer (the dot you drag in the colour panel) */
@@ -914,54 +946,98 @@ $nav-height: 45px;
     display: none !important;
 }
 
-/* Hex / R / G / B input row — labels inline-left INSIDE the input, grey,
-   values left-aligned. The sketch-picker's third child is the SketchFields
-   .flexbox-fix row. */
+/* react-color's hex/R/G/B row is hidden — we render our own single-mode
+   input below, with a clickable HEX/RGB toggle. */
 .colorpicker-tooltip .sketch-picker > div:nth-child(3) {
-    padding-top: 8px !important;
-    gap: 6px;
+    display: none !important;
 }
 
-.colorpicker-tooltip .sketch-picker > div:nth-child(3) > div {
-    padding-left: 0 !important;
+.colorpicker-input {
+    display: flex;
+    align-items: stretch;
+    margin: 0 10px 10px;
+    border-radius: 4px;
+    box-shadow: inset 0 0 0 1px #d6d8da;
+    overflow: hidden;
+    background: #fff;
 }
 
-.colorpicker-tooltip .sketch-picker > div:nth-child(3) input {
-    width: 100% !important;
-    box-sizing: border-box !important;
-    padding: 6px 5px 6px 18px !important;
-    border-radius: 4px !important;
-    border: none !important;
-    box-shadow: inset 0 0 0 1px #d6d8da !important;
-    font-size: 11px !important;
+.colorpicker-input__mode {
+    flex-shrink: 0;
+    padding: 6px 9px;
+    border: none;
+    border-right: 1px solid #d6d8da;
+    background: transparent;
+    color: #6e6e73;
+    font-size: 10px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    cursor: pointer;
+    transition:
+        background 80ms ease-out,
+        color 80ms ease-out;
+}
+
+.colorpicker-input__mode:hover {
+    background: #f5f5f7;
     color: #1d1d1f;
-    text-align: left !important;
 }
 
-/* HEX cell (first cell) needs more left padding to fit the 3-char label. */
-.colorpicker-tooltip .sketch-picker > div:nth-child(3) > div:first-child input {
-    padding-left: 32px !important;
+.colorpicker-input__hex {
+    flex: 1;
+    min-width: 0;
+    padding: 6px 8px;
+    border: none;
+    background: transparent;
+    font-size: 11px;
+    color: #1d1d1f;
+    outline: none;
+    text-align: left;
 }
 
-.colorpicker-tooltip .sketch-picker > div:nth-child(3) input:focus {
-    outline: none !important;
-    box-shadow: inset 0 0 0 1.5px #1865f2 !important;
+.colorpicker-input__hex::placeholder,
+.colorpicker-input__rgb-cell::placeholder {
+    color: #9a9a9e;
+    font-style: italic;
 }
 
-.colorpicker-tooltip .sketch-picker > div:nth-child(3) span {
-    position: absolute !important;
-    left: 8px !important;
-    top: 50% !important;
-    transform: translateY(-50%) !important;
-    font-size: 10px !important;
-    font-weight: 600 !important;
-    color: #9a9a9e !important;
-    text-transform: uppercase !important;
-    letter-spacing: 0.04em !important;
-    line-height: 1 !important;
-    margin: 0 !important;
-    padding: 0 !important;
-    pointer-events: none !important;
+.colorpicker-input__hex:focus {
+    background: rgba(24, 101, 242, 0.05);
+}
+
+.colorpicker-input__rgb {
+    flex: 1;
+    display: flex;
+    align-items: stretch;
+}
+
+.colorpicker-input__rgb-cell {
+    flex: 1;
+    width: 0;
+    padding: 6px 4px;
+    border: none;
+    border-left: 1px solid #d6d8da;
+    background: transparent;
+    font-size: 11px;
+    color: #1d1d1f;
+    outline: none;
+    text-align: center;
+    -moz-appearance: textfield;
+}
+
+.colorpicker-input__rgb-cell:first-child {
+    border-left: none;
+}
+
+.colorpicker-input__rgb-cell:focus {
+    background: rgba(24, 101, 242, 0.05);
+}
+
+.colorpicker-input__rgb-cell::-webkit-outer-spin-button,
+.colorpicker-input__rgb-cell::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
 }
 
 /* Reset color row at the bottom of the popover */
@@ -971,14 +1047,14 @@ $nav-height: 45px;
     justify-content: center;
     gap: 6px;
     width: 100%;
-    padding: 10px 12px;
+    padding: 8px 10px;
     border: none;
     border-top: 1px solid #eee;
     border-bottom-left-radius: 4px;
     border-bottom-right-radius: 4px;
     background: #fff;
     color: #6e6e73;
-    font-size: 12px;
+    font-size: 11px;
     font-weight: 500;
     cursor: pointer;
     transition:
@@ -995,51 +1071,51 @@ $nav-height: 45px;
     font-size: 11px;
 }
 
+/* Toggle pills below the grid — discrete, click to highlight matching swatches. */
 .colorpicker-filter {
     display: flex;
-    margin: 6px 12px 0;
-    padding: 2px;
-    background: #f0f0f2;
-    border-radius: 6px;
+    gap: 6px;
+    padding: 0 10px 10px;
 }
 
-.colorpicker-filter__tab {
-    flex: 1;
-    padding: 4px 8px;
-    border: none;
+.colorpicker-filter__pill {
+    padding: 3px 9px;
+    border: 1px solid #d6d8da;
+    border-radius: 12px;
     background: transparent;
-    border-radius: 4px;
-    font-size: 11px;
+    font-size: 10px;
     font-weight: 500;
     color: #6e6e73;
     cursor: pointer;
     transition:
         background 80ms ease-out,
         color 80ms ease-out,
-        box-shadow 80ms ease-out;
+        border-color 80ms ease-out;
 }
 
-.colorpicker-filter__tab:hover {
+.colorpicker-filter__pill:hover {
+    border-color: #6e6e73;
     color: #1d1d1f;
 }
 
-.colorpicker-filter__tab--active {
-    background: #fff;
-    color: #1d1d1f;
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+.colorpicker-filter__pill--active {
+    background: #1865f2;
+    border-color: #1865f2;
+    color: #fff;
 }
 
-.colorpicker-filter__tab--active:hover {
-    color: #1d1d1f;
+.colorpicker-filter__pill--active:hover {
+    background: #1865f2;
+    border-color: #1865f2;
+    color: #fff;
 }
 
 .colorpicker-presets {
     display: grid;
     grid-template-columns: repeat(8, 1fr);
-    gap: 6px;
-    padding: 10px 12px;
+    gap: 4px;
+    padding: 0 10px 8px;
     background: #fff;
-    border-top: 1px solid #eee;
 }
 
 .colorpicker-presets__swatch {

--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -868,24 +868,140 @@ $nav-height: 45px;
 
         .sketch-picker {
             box-shadow: none !important;
+            padding: 12px 12px 8px !important;
+            width: 220px !important;
         }
     }
 }
 
-.colorpicker-presets {
-    display: grid;
-    grid-template-columns: repeat(4, 22px);
+/* Bigger saturation pointer (the dot you drag in the colour panel) */
+.colorpicker-tooltip
+    .sketch-picker
+    .saturation-white
+    > div:not(.saturation-black)
+    > div {
+    width: 14px !important;
+    height: 14px !important;
+    transform: translate(-7px, -7px) !important;
+    box-shadow:
+        0 0 0 2px #fff,
+        0 0 0 3px rgba(0, 0, 0, 0.35),
+        0 1px 4px rgba(0, 0, 0, 0.25) !important;
+}
+
+/* Hue slider — turn the tiny white bar into a round draggable dot.
+   Allow it to overflow the 10px-tall hue track. */
+.colorpicker-tooltip .sketch-picker > div:nth-child(2) > div:nth-child(1) > div,
+.colorpicker-tooltip .sketch-picker .hue-horizontal {
+    overflow: visible !important;
+}
+
+.colorpicker-tooltip .sketch-picker .hue-horizontal > div > div {
+    width: 16px !important;
+    height: 16px !important;
+    margin-top: -3px !important;
+    border-radius: 50% !important;
+    background: #fff !important;
+    box-shadow:
+        0 0 0 1px rgba(0, 0, 0, 0.35),
+        0 1px 4px rgba(0, 0, 0, 0.25) !important;
+    transform: translateX(-8px) !important;
+}
+
+/* Hide the active-colour preview block to the right of the hue slider —
+   it's redundant given the saturation panel above. */
+.colorpicker-tooltip .sketch-picker > div:nth-child(2) > div:nth-child(2) {
+    display: none !important;
+}
+
+/* Hex / R / G / B input row — modernise spacing, alignment, label styling.
+   The sketch-picker's third child is the SketchFields .flexbox-fix row. */
+.colorpicker-tooltip .sketch-picker > div:nth-child(3) {
+    padding-top: 8px !important;
+    gap: 6px;
+}
+
+.colorpicker-tooltip .sketch-picker > div:nth-child(3) > div {
+    padding-left: 0 !important;
+}
+
+/* Each input wrapper renders <input> then <span> (label) — flex-reverse to
+   put the label above the input. */
+.colorpicker-tooltip .sketch-picker > div:nth-child(3) > div > div {
+    display: flex !important;
+    flex-direction: column-reverse !important;
+}
+
+.colorpicker-tooltip .sketch-picker > div:nth-child(3) input {
+    width: 100% !important;
+    box-sizing: border-box !important;
+    padding: 5px 6px !important;
+    border-radius: 4px !important;
+    border: none !important;
+    box-shadow: inset 0 0 0 1px #d6d8da !important;
+    font-size: 12px !important;
+    color: #1d1d1f;
+    text-align: center;
+}
+
+.colorpicker-tooltip .sketch-picker > div:nth-child(3) input:focus {
+    outline: none !important;
+    box-shadow: inset 0 0 0 1.5px #1865f2 !important;
+}
+
+.colorpicker-tooltip .sketch-picker > div:nth-child(3) span {
+    font-size: 10px !important;
+    font-weight: 600 !important;
+    color: #6e6e73 !important;
+    text-transform: uppercase !important;
+    letter-spacing: 0.05em !important;
+    text-align: center !important;
+    padding: 0 0 4px !important;
+}
+
+/* Reset color button (replaces the old "Reset to color scheme default" link) */
+.colorpicker-reset {
+    display: flex;
+    align-items: center;
     justify-content: center;
     gap: 6px;
-    padding: 10px;
-    background: #fff;
+    width: 100%;
+    padding: 10px 12px;
+    border: none;
     border-top: 1px solid #eee;
     border-bottom-left-radius: 4px;
     border-bottom-right-radius: 4px;
+    background: #fff;
+    color: #6e6e73;
+    font-size: 12px;
+    font-weight: 500;
+    cursor: pointer;
+    transition:
+        background 80ms ease-out,
+        color 80ms ease-out;
+}
+
+.colorpicker-reset:hover {
+    background: #f5f5f7;
+    color: #1d1d1f;
+}
+
+.colorpicker-reset svg {
+    font-size: 11px;
+}
+
+.colorpicker-presets {
+    display: grid;
+    grid-template-columns: repeat(6, 1fr);
+    gap: 6px;
+    padding: 10px 12px;
+    background: #fff;
+    border-top: 1px solid #eee;
 }
 
 .colorpicker-presets__swatch {
-    width: 22px;
+    position: relative;
+    width: 100%;
     height: 22px;
     border: none;
     padding: 0;
@@ -895,6 +1011,18 @@ $nav-height: 45px;
     transition:
         transform 80ms ease-out,
         box-shadow 80ms ease-out;
+}
+
+.colorpicker-presets__swatch--has-mapping::after {
+    content: "";
+    position: absolute;
+    bottom: 3px;
+    right: 3px;
+    width: 5px;
+    height: 5px;
+    border-radius: 50%;
+    background: #fff;
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.55);
 }
 
 .colorpicker-presets__swatch:hover {

--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -914,8 +914,9 @@ $nav-height: 45px;
     display: none !important;
 }
 
-/* Hex / R / G / B input row — modernise spacing, alignment, label styling.
-   The sketch-picker's third child is the SketchFields .flexbox-fix row. */
+/* Hex / R / G / B input row — labels inline-left INSIDE the input, grey,
+   values left-aligned. The sketch-picker's third child is the SketchFields
+   .flexbox-fix row. */
 .colorpicker-tooltip .sketch-picker > div:nth-child(3) {
     padding-top: 8px !important;
     gap: 6px;
@@ -925,23 +926,21 @@ $nav-height: 45px;
     padding-left: 0 !important;
 }
 
-/* Each input wrapper renders <input> then <span> (label) — flex-reverse to
-   put the label above the input. */
-.colorpicker-tooltip .sketch-picker > div:nth-child(3) > div > div {
-    display: flex !important;
-    flex-direction: column-reverse !important;
-}
-
 .colorpicker-tooltip .sketch-picker > div:nth-child(3) input {
     width: 100% !important;
     box-sizing: border-box !important;
-    padding: 5px 6px !important;
+    padding: 6px 5px 6px 18px !important;
     border-radius: 4px !important;
     border: none !important;
     box-shadow: inset 0 0 0 1px #d6d8da !important;
-    font-size: 12px !important;
+    font-size: 11px !important;
     color: #1d1d1f;
-    text-align: center;
+    text-align: left !important;
+}
+
+/* HEX cell (first cell) needs more left padding to fit the 3-char label. */
+.colorpicker-tooltip .sketch-picker > div:nth-child(3) > div:first-child input {
+    padding-left: 32px !important;
 }
 
 .colorpicker-tooltip .sketch-picker > div:nth-child(3) input:focus {
@@ -950,16 +949,22 @@ $nav-height: 45px;
 }
 
 .colorpicker-tooltip .sketch-picker > div:nth-child(3) span {
+    position: absolute !important;
+    left: 8px !important;
+    top: 50% !important;
+    transform: translateY(-50%) !important;
     font-size: 10px !important;
     font-weight: 600 !important;
-    color: #6e6e73 !important;
+    color: #9a9a9e !important;
     text-transform: uppercase !important;
-    letter-spacing: 0.05em !important;
-    text-align: center !important;
-    padding: 0 0 4px !important;
+    letter-spacing: 0.04em !important;
+    line-height: 1 !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    pointer-events: none !important;
 }
 
-/* Reset color button (replaces the old "Reset to color scheme default" link) */
+/* Reset color row at the bottom of the popover */
 .colorpicker-reset {
     display: flex;
     align-items: center;
@@ -990,9 +995,47 @@ $nav-height: 45px;
     font-size: 11px;
 }
 
+.colorpicker-filter {
+    display: flex;
+    margin: 6px 12px 0;
+    padding: 2px;
+    background: #f0f0f2;
+    border-radius: 6px;
+}
+
+.colorpicker-filter__tab {
+    flex: 1;
+    padding: 4px 8px;
+    border: none;
+    background: transparent;
+    border-radius: 4px;
+    font-size: 11px;
+    font-weight: 500;
+    color: #6e6e73;
+    cursor: pointer;
+    transition:
+        background 80ms ease-out,
+        color 80ms ease-out,
+        box-shadow 80ms ease-out;
+}
+
+.colorpicker-filter__tab:hover {
+    color: #1d1d1f;
+}
+
+.colorpicker-filter__tab--active {
+    background: #fff;
+    color: #1d1d1f;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+}
+
+.colorpicker-filter__tab--active:hover {
+    color: #1d1d1f;
+}
+
 .colorpicker-presets {
     display: grid;
-    grid-template-columns: repeat(6, 1fr);
+    grid-template-columns: repeat(8, 1fr);
     gap: 6px;
     padding: 10px 12px;
     background: #fff;
@@ -1002,34 +1045,31 @@ $nav-height: 45px;
 .colorpicker-presets__swatch {
     position: relative;
     width: 100%;
-    height: 22px;
+    aspect-ratio: 1;
     border: none;
     padding: 0;
     border-radius: 3px;
     cursor: pointer;
     box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.15);
     transition:
-        transform 80ms ease-out,
-        box-shadow 80ms ease-out;
+        box-shadow 80ms ease-out,
+        opacity 80ms ease-out;
 }
 
-.colorpicker-presets__swatch--has-mapping::after {
-    content: "";
-    position: absolute;
-    bottom: 3px;
-    right: 3px;
-    width: 5px;
-    height: 5px;
-    border-radius: 50%;
-    background: #fff;
-    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.55);
+/* Dimmed state: swatch is shown but inactive (filter excluded it) */
+.colorpicker-presets__swatch--dimmed {
+    opacity: 0.2;
+    cursor: not-allowed;
+}
+
+.colorpicker-presets__swatch--dimmed:hover {
+    box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.15);
 }
 
 .colorpicker-presets__swatch:hover {
-    transform: scale(1.15);
     box-shadow:
-        inset 0 0 0 1px rgba(0, 0, 0, 0.25),
-        0 1px 4px rgba(0, 0, 0, 0.2);
+        inset 0 0 0 1px rgba(0, 0, 0, 0.6),
+        0 0 0 2px rgba(0, 0, 0, 0.12);
 }
 
 .colorpicker-presets__swatch:focus-visible {
@@ -1046,11 +1086,10 @@ $nav-height: 45px;
 }
 
 .colorpicker-presets__swatch--selected:hover {
-    transform: scale(1.15);
     box-shadow:
         inset 0 0 0 2px #fff,
         0 0 0 2px #1865f2,
-        0 1px 4px rgba(0, 0, 0, 0.2);
+        0 0 0 4px rgba(24, 101, 242, 0.2);
 }
 
 .colorpicker-presets__tooltip {

--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -877,21 +877,6 @@ $nav-height: 45px;
     }
 }
 
-/* Visual order: header (with filter pills) → grid → color map (sketch-picker)
-   → custom hex/rgb input (with inline reset icon) */
-.colorpicker-tooltip .tippy-content > .colorpicker-header {
-    order: 1;
-}
-.colorpicker-tooltip .tippy-content > .colorpicker-presets {
-    order: 2;
-}
-.colorpicker-tooltip .tippy-content > .sketch-picker {
-    order: 3;
-}
-.colorpicker-tooltip .tippy-content > .colorpicker-input {
-    order: 4;
-}
-
 .colorpicker-header {
     display: flex;
     align-items: center;
@@ -1037,11 +1022,10 @@ $nav-height: 45px;
     width: 0;
     display: flex;
     align-items: center;
-    border-left: 1px solid #d6d8da;
 }
 
-.colorpicker-input__rgb-cell:first-child {
-    border-left: none;
+.colorpicker-input__rgb-cell + .colorpicker-input__rgb-cell {
+    border-left: 1px solid #d6d8da;
 }
 
 .colorpicker-input__rgb-label {
@@ -1112,18 +1096,12 @@ $nav-height: 45px;
         border-color 80ms ease-out;
 }
 
-.colorpicker-filter__pill:hover {
+.colorpicker-filter__pill:not(.colorpicker-filter__pill--active):hover {
     border-color: #6e6e73;
     color: #1d1d1f;
 }
 
 .colorpicker-filter__pill--active {
-    background: #1865f2;
-    border-color: #1865f2;
-    color: #fff;
-}
-
-.colorpicker-filter__pill--active:hover {
     background: #1865f2;
     border-color: #1865f2;
     color: #fff;
@@ -1157,11 +1135,7 @@ $nav-height: 45px;
     cursor: not-allowed;
 }
 
-.colorpicker-presets__swatch--dimmed:hover {
-    box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.15);
-}
-
-.colorpicker-presets__swatch:hover {
+.colorpicker-presets__swatch:not(.colorpicker-presets__swatch--dimmed):hover {
     box-shadow:
         inset 0 0 0 1px rgba(0, 0, 0, 0.6),
         0 0 0 2px rgba(0, 0, 0, 0.12);

--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -1053,10 +1053,25 @@ $nav-height: 45px;
         0 1px 4px rgba(0, 0, 0, 0.2);
 }
 
-.colorpicker-presets__tooltip-line {
-    display: block;
+.colorpicker-presets__tooltip {
     line-height: 1.35;
-    white-space: nowrap;
+    text-align: left;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+}
+
+.colorpicker-presets__tooltip-title {
+    font-weight: 600;
+    margin-bottom: 2px;
+}
+
+.colorpicker-presets__tooltip-row {
+    font-size: 12px;
+    opacity: 0.9;
+}
+
+.colorpicker-presets__tooltip-label {
+    opacity: 0.7;
 }
 
 .LoadingBlocker {

--- a/packages/@ourworldindata/grapher/src/color/CustomSchemes.ts
+++ b/packages/@ourworldindata/grapher/src/color/CustomSchemes.ts
@@ -861,58 +861,26 @@ export interface ColorSemanticInfo {
 }
 
 // Identifier-style names from the source dicts get presented to users via
-// tooltips, so we need readable display strings. Anything not in the map
-// passes through unchanged (already display-ready strings like "Africa",
-// "Europe (WHO)" or "Middle East, North Africa, Afghanistan and Pakistan (WB)").
-const COLOR_DISPLAY_NAMES: Record<string, string> = {
-    // OWID distinct palette
-    DarkOrange: "Dark Orange",
-    LightTeal: "Light Teal",
-    MidnightBlue: "Midnight Blue",
-    DustyCoral: "Dusty Coral",
-    DarkOliveGreen: "Dark Olive Green",
-    DarkCopper: "Dark Copper",
-    OliveGreen: "Olive Green",
-    TealishGreen: "Tealish Green",
-    RustyOrange: "Rusty Orange",
-    DarkMauve: "Dark Mauve",
-
-    // Continent / sub-region identifiers
-    NorthAmerica: "North America",
-    SouthAmerica: "South America",
+// tooltips, so we need readable display strings. The default transform is
+// CamelCase → "Camel Case"; the overrides below cover the few cases that
+// don't follow that rule (typo fix, inserted "and", lowercase "renewables").
+// Strings without a CamelCase boundary pass through unchanged — that's what
+// keeps already-display-ready inputs like "Africa", "Europe (WHO)" or
+// "Middle East, North Africa, Afghanistan and Pakistan (WB)" intact.
+const COLOR_DISPLAY_OVERRIDES: Record<string, string> = {
     SubSaharanAfrica: "Sub-Saharan Africa",
     MiddleEastNorthAfrica: "Middle East and North Africa",
-    CentralAsia: "Central Asia",
-    EastAsia: "East Asia",
-    SoutheastAsia: "Southeast Asia",
-    SouthAsia: "South Asia",
-    // Note: source key has a typo ("Carribean"); display name has the correct spelling.
+    // Source key has a typo ("Carribean"); display name uses the correct spelling.
     CentralAmericaAndCarribean: "Central America and Caribbean",
-    EasternEurope: "Eastern Europe",
-    WesternEurope: "Western Europe",
     AustralasiaAndOceania: "Australasia and Oceania",
-
-    // Energy types
     OtherRenewables: "Other renewables",
-
-    // OwidMap categorical palette
-    MutedDenim: "Muted Denim",
-    SoftOrange: "Soft Orange",
-    MutedTeal: "Muted Teal",
-    SoftPurple: "Soft Purple",
-    MutedCherry: "Muted Cherry",
-    LeafGreen: "Leaf Green",
-    SkyTurquoise: "Sky Turquoise",
-    LightDenim: "Light Denim",
-    LightOrange: "Light Orange",
-    LightPurple: "Light Purple",
-    LightSand: "Light Sand",
-    LightCherry: "Light Cherry",
-    LightGreen: "Light Green",
 }
 
 export function toColorDisplayName(name: string): string {
-    return COLOR_DISPLAY_NAMES[name] ?? name
+    return (
+        COLOR_DISPLAY_OVERRIDES[name] ??
+        name.replace(/([a-z])([A-Z])/g, "$1 $2")
+    )
 }
 
 export function getColorNameAndSemanticPalettes(

--- a/packages/@ourworldindata/grapher/src/color/CustomSchemes.ts
+++ b/packages/@ourworldindata/grapher/src/color/CustomSchemes.ts
@@ -860,6 +860,61 @@ export interface ColorSemanticInfo {
     energy?: string
 }
 
+// Identifier-style names from the source dicts get presented to users via
+// tooltips, so we need readable display strings. Anything not in the map
+// passes through unchanged (already display-ready strings like "Africa",
+// "Europe (WHO)" or "Middle East, North Africa, Afghanistan and Pakistan (WB)").
+const COLOR_DISPLAY_NAMES: Record<string, string> = {
+    // OWID distinct palette
+    DarkOrange: "Dark Orange",
+    LightTeal: "Light Teal",
+    MidnightBlue: "Midnight Blue",
+    DustyCoral: "Dusty Coral",
+    DarkOliveGreen: "Dark Olive Green",
+    DarkCopper: "Dark Copper",
+    OliveGreen: "Olive Green",
+    TealishGreen: "Tealish Green",
+    RustyOrange: "Rusty Orange",
+    DarkMauve: "Dark Mauve",
+
+    // Continent / sub-region identifiers
+    NorthAmerica: "North America",
+    SouthAmerica: "South America",
+    SubSaharanAfrica: "Sub-Saharan Africa",
+    MiddleEastNorthAfrica: "Middle East and North Africa",
+    CentralAsia: "Central Asia",
+    EastAsia: "East Asia",
+    SoutheastAsia: "Southeast Asia",
+    SouthAsia: "South Asia",
+    // Note: source key has a typo ("Carribean"); display name has the correct spelling.
+    CentralAmericaAndCarribean: "Central America and Caribbean",
+    EasternEurope: "Eastern Europe",
+    WesternEurope: "Western Europe",
+    AustralasiaAndOceania: "Australasia and Oceania",
+
+    // Energy types
+    OtherRenewables: "Other renewables",
+
+    // OwidMap categorical palette
+    MutedDenim: "Muted Denim",
+    SoftOrange: "Soft Orange",
+    MutedTeal: "Muted Teal",
+    SoftPurple: "Soft Purple",
+    MutedCherry: "Muted Cherry",
+    LeafGreen: "Leaf Green",
+    SkyTurquoise: "Sky Turquoise",
+    LightDenim: "Light Denim",
+    LightOrange: "Light Orange",
+    LightPurple: "Light Purple",
+    LightSand: "Light Sand",
+    LightCherry: "Light Cherry",
+    LightGreen: "Light Green",
+}
+
+export function toColorDisplayName(name: string): string {
+    return COLOR_DISPLAY_NAMES[name] ?? name
+}
+
 export function getColorNameAndSemanticPalettes(
     color: string,
     baseColorSchemeNames: Record<string, string>,
@@ -872,10 +927,13 @@ export function getColorNameAndSemanticPalettes(
     const lookup = (dict: Record<string, string>): string | undefined =>
         dict[color] ?? dict[color.toLowerCase()] ?? dict[color.toUpperCase()]
 
+    const colorName = lookup(baseColorSchemeNames)
+    const region = lookup(continentsColorSchemeNames)
+    const energy = lookup(energyColorSchemeNames)
     return {
-        colorName: lookup(baseColorSchemeNames),
-        region: lookup(continentsColorSchemeNames),
-        energy: lookup(energyColorSchemeNames),
+        colorName: colorName ? toColorDisplayName(colorName) : undefined,
+        region: region ? toColorDisplayName(region) : undefined,
+        energy: energy ? toColorDisplayName(energy) : undefined,
     }
 }
 

--- a/packages/@ourworldindata/grapher/src/color/CustomSchemes.ts
+++ b/packages/@ourworldindata/grapher/src/color/CustomSchemes.ts
@@ -423,8 +423,18 @@ export const ContinentColors = {
     "Low-income countries": IncomeGroupColors.LowIncome,
 } as const
 
-// Used for looking up color names from hex values
-const ContinentColorsNames = lazy(() => R.invert(ContinentColors))
+// Used for looking up color names from hex values.
+// Many regions share the same colour (e.g. all "Europe" variants use Denim);
+// we want the canonical short name first (`"Europe"`) rather than the last
+// declared variant (`"Europe and Central Asia (ILO)"`), which is what R.invert
+// would return.
+const ContinentColorsNames = lazy(() => {
+    const result: Record<string, string> = {}
+    for (const [key, value] of Object.entries(ContinentColors)) {
+        if (!(value in result)) result[value] = key
+    }
+    return result
+})
 
 const ContinentColorPalette = [
     ContinentColors.Africa,
@@ -844,33 +854,34 @@ export const MapContinentColors = {
 
 export const DefaultColorScheme = OwidDistinctColorScheme
 
+export interface ColorSemanticInfo {
+    colorName?: string
+    region?: string
+    energy?: string
+}
+
 export function getColorNameAndSemanticPalettes(
     color: string,
     baseColorSchemeNames: Record<string, string>,
     continentsColorSchemeNames: Record<string, string>,
     energyColorSchemeNames: Record<string, string>
-): string[] {
-    const colorNameStandardized = color.toUpperCase()
-    const owidDistinct =
-        colorNameStandardized in baseColorSchemeNames
-            ? `🎨 ${baseColorSchemeNames[colorNameStandardized]}`
-            : ""
-    const continents =
-        colorNameStandardized in continentsColorSchemeNames
-            ? `🌍 ${continentsColorSchemeNames[colorNameStandardized]}`
-            : ""
-    const energy =
-        colorNameStandardized in energyColorSchemeNames
-            ? `⚡ ${energyColorSchemeNames[colorNameStandardized]}`
-            : ""
-    const lines = [owidDistinct, continents, energy].filter((x) => x !== "")
+): ColorSemanticInfo {
+    // Lookup must be case-insensitive: hex codes can be stored in either case
+    // (e.g. OwidDistinctColors uses lowercase, OwidMapColors uses uppercase)
+    // and the user-supplied `color` may not match the dict's casing.
+    const lookup = (dict: Record<string, string>): string | undefined =>
+        dict[color] ?? dict[color.toLowerCase()] ?? dict[color.toUpperCase()]
 
-    return lines
+    return {
+        colorName: lookup(baseColorSchemeNames),
+        region: lookup(continentsColorSchemeNames),
+        energy: lookup(energyColorSchemeNames),
+    }
 }
 
 export function getColorNameOwidDistinctAndSemanticPalettes(
     color: string
-): string[] {
+): ColorSemanticInfo {
     return getColorNameAndSemanticPalettes(
         color,
         OwidDistinctColorsNames(),
@@ -881,7 +892,7 @@ export function getColorNameOwidDistinctAndSemanticPalettes(
 
 export function getColorNameOwidDistinctLinesAndSemanticPalettes(
     color: string
-): string[] {
+): ColorSemanticInfo {
     return getColorNameAndSemanticPalettes(
         color,
         OwidDistinctLinesColorNames(),

--- a/packages/@ourworldindata/grapher/src/index.ts
+++ b/packages/@ourworldindata/grapher/src/index.ts
@@ -51,6 +51,7 @@ export {
     getColorNameOwidDistinctAndSemanticPalettes,
     getColorNameOwidDistinctLinesAndSemanticPalettes,
 } from "./color/CustomSchemes"
+export type { ColorSemanticInfo } from "./color/CustomSchemes"
 export { ColorSchemes } from "./color/ColorSchemes"
 export { DimensionSlot } from "./chart/DimensionSlot"
 export { EntityPicker } from "./controls/entityPicker/EntityPicker"

--- a/packages/@ourworldindata/grapher/src/index.ts
+++ b/packages/@ourworldindata/grapher/src/index.ts
@@ -50,6 +50,7 @@ export { ColorScheme } from "./color/ColorScheme"
 export {
     getColorNameOwidDistinctAndSemanticPalettes,
     getColorNameOwidDistinctLinesAndSemanticPalettes,
+    toColorDisplayName,
 } from "./color/CustomSchemes"
 export type { ColorSemanticInfo } from "./color/CustomSchemes"
 export { ColorSchemes } from "./color/ColorSchemes"


### PR DESCRIPTION
## Summary

Improve the admin Colorpicker modal to make it easier to navigate colors, see where each one is used, and reduce wasted space.

- Tooltips on swatches surface semantic names (e.g. country/region or category) so editors know what each color represents. **Note:** It was also the case in old design, but i felt it was vuggy and some regions/categories were missing.
- Reset-to-default button with tooltip
- Tighter modal layout: hex/RGB inputs and swatches reorganized to better use the available real estate
- Re-organize elements in the colorpicker pane. The discrete color grid should be up top; that's the most used bit.

Screenshots (before / after) attached in the PR description by the author.

| PROD | New |
|--------|--------|
| <img width="233" height="365" alt="image" src="https://github.com/user-attachments/assets/d243d072-d94e-4995-9fab-42053d68844c" /> | <img width="247" height="369" alt="image" src="https://github.com/user-attachments/assets/6f9bdb03-8c3c-44aa-bd10-fb2e770d316c" /> | 

## Test plan

- [ ] Open a chart in the admin and edit a series/region color — verify swatches, tooltips, filter, and reset behave as expected
- [ ] Try with a categorical map (`OwidCategoricalMap`) and a regular chart to cover both code paths
- [ ] Confirm hex/RGB inputs still drive the picker correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)