### PR TITLE
Improve filtering and sorting on the admin charts table

### DIFF
--- a/adminSiteClient/ChartList.tsx
+++ b/adminSiteClient/ChartList.tsx
@@ -28,7 +28,7 @@ import {
 import { TextField } from "./Forms.js"
 import { Tooltip } from "antd"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
-import { faInfoCircle } from "@fortawesome/free-solid-svg-icons"
+import { faFilter, faInfoCircle } from "@fortawesome/free-solid-svg-icons"
 import { deleteChart } from "./ChartEditor.js"
 
 // These properties are coming from OldChart.ts
@@ -60,10 +60,22 @@ export interface ChartListItem {
     referencesCount: number
 }
 
+export type SortField =
+    | "id"
+    | "type"
+    | "isPublished"
+    | "lastEditedAt"
+    | "publishedAt"
+    | "grapherViewsPerDay"
+    | "narrativeChartsCount"
+    | "referencesCount"
+
 export type SortConfig = {
-    field: "grapherViewsPerDay" | "narrativeChartsCount" | "referencesCount"
+    field: SortField
     direction: "asc" | "desc"
 } | null
+
+export type PublishedFilter = "all" | "published" | "drafts"
 
 interface ChartListProps {
     charts: ChartListItem[]
@@ -80,6 +92,7 @@ export class ChartList extends React.Component<ChartListProps> {
     maxVisibleCharts = 50
     sortConfig: SortConfig | undefined = undefined
     availableTags: DbChartTagJoin[] = []
+    publishedFilter: PublishedFilter = "all"
 
     constructor(props: ChartListProps) {
         super(props)
@@ -89,6 +102,7 @@ export class ChartList extends React.Component<ChartListProps> {
             maxVisibleCharts: observable,
             sortConfig: observable,
             availableTags: observable,
+            publishedFilter: observable,
         })
     }
 
@@ -162,8 +176,15 @@ export class ChartList extends React.Component<ChartListProps> {
     }
 
     @computed get chartsFiltered(): ChartListItem[] {
-        const { searchWords } = this
-        const { charts } = this.props
+        const { searchWords, publishedFilter } = this
+        let result = this.props.charts
+
+        if (publishedFilter === "published") {
+            result = result.filter((chart) => !!chart.isPublished)
+        } else if (publishedFilter === "drafts") {
+            result = result.filter((chart) => !chart.isPublished)
+        }
+
         if (searchWords.length > 0) {
             const filterFn = filterFunctionForSearchWords(
                 searchWords,
@@ -180,8 +201,10 @@ export class ChartList extends React.Component<ChartListProps> {
                     ...chart.tags.map((tag) => tag.name),
                 ]
             )
-            return charts.filter(filterFn)
-        } else return charts
+            result = result.filter(filterFn)
+        }
+
+        return result
     }
 
     @computed get chartsSorted(): ChartListItem[] {
@@ -189,17 +212,44 @@ export class ChartList extends React.Component<ChartListProps> {
         if (!this.sortConfig) return chartsFiltered
 
         const { direction, field } = this.sortConfig
-        const getValue =
-            field === "grapherViewsPerDay"
-                ? (chart: ChartListItem) => chart.grapherViewsPerDay
-                : field === "narrativeChartsCount"
-                  ? (chart: ChartListItem) => chart.narrativeChartsCount
-                  : (chart: ChartListItem) => chart.referencesCount
 
-        return sortNumeric(
-            [...chartsFiltered],
-            getValue,
-            direction === "asc" ? SortOrder.asc : SortOrder.desc
+        const numericFields: SortField[] = [
+            "id",
+            "grapherViewsPerDay",
+            "narrativeChartsCount",
+            "referencesCount",
+        ]
+        if (numericFields.includes(field)) {
+            const getValue = (chart: ChartListItem) =>
+                (chart[field as keyof ChartListItem] as number | undefined) ?? 0
+            return sortNumeric(
+                [...chartsFiltered],
+                getValue,
+                direction === "asc" ? SortOrder.asc : SortOrder.desc
+            )
+        }
+
+        if (field === "type") {
+            return _.orderBy(
+                chartsFiltered,
+                [(chart) => showChartType(chart).toLowerCase()],
+                [direction]
+            )
+        }
+
+        if (field === "isPublished") {
+            return _.orderBy(
+                chartsFiltered,
+                [(chart) => !!chart.isPublished],
+                [direction]
+            )
+        }
+
+        // Date fields stored as ISO strings sort lexicographically.
+        return _.orderBy(
+            chartsFiltered,
+            [(chart) => chart[field] || ""],
+            [direction]
         )
     }
 
@@ -210,6 +260,10 @@ export class ChartList extends React.Component<ChartListProps> {
     @action.bound onSearchInput(input: string) {
         this.searchInput = input
         this.setSearchInputInUrl(input)
+    }
+
+    @action.bound onPublishedFilterChange(filter: PublishedFilter) {
+        this.publishedFilter = filter
     }
 
     @action.bound onShowMore() {
@@ -223,58 +277,37 @@ export class ChartList extends React.Component<ChartListProps> {
             chartsToShow,
             numTotalCharts,
             searchInput,
+            publishedFilter,
         } = this
         const { availableTags } = this
 
         const highlight = highlightFunctionForSearchWords(this.searchWords)
         const hasMoreCharts = this.chartsFiltered.length > this.maxVisibleCharts
 
-        const getSortIndicator = () => {
-            if (!sortConfig || sortConfig.field !== "grapherViewsPerDay")
-                return ""
+        const getSortIndicator = (field: SortField) => {
+            if (!sortConfig || sortConfig.field !== field) return ""
             return sortConfig.direction === "desc" ? " ↓" : " ↑"
         }
 
-        const handleSortClick = () => {
-            if (!sortConfig || sortConfig.field !== "grapherViewsPerDay") {
-                onSort({ field: "grapherViewsPerDay", direction: "desc" })
+        const handleSortClick = (field: SortField) => {
+            if (!sortConfig || sortConfig.field !== field) {
+                onSort({ field, direction: "desc" })
             } else if (sortConfig.direction === "desc") {
-                onSort({ field: "grapherViewsPerDay", direction: "asc" })
+                onSort({ field, direction: "asc" })
             } else {
                 onSort(null)
             }
         }
 
-        const getNarrativeChartsSortIndicator = () => {
-            if (!sortConfig || sortConfig.field !== "narrativeChartsCount")
-                return ""
-            return sortConfig.direction === "desc" ? " ↓" : " ↑"
-        }
-
-        const handleNarrativeChartsSortClick = () => {
-            if (!sortConfig || sortConfig.field !== "narrativeChartsCount") {
-                onSort({ field: "narrativeChartsCount", direction: "desc" })
-            } else if (sortConfig.direction === "desc") {
-                onSort({ field: "narrativeChartsCount", direction: "asc" })
-            } else {
-                onSort(null)
-            }
-        }
-
-        const getReferencesCountSortIndicator = () => {
-            if (!sortConfig || sortConfig.field !== "referencesCount") return ""
-            return sortConfig.direction === "desc" ? " ↓" : " ↑"
-        }
-
-        const handleReferencesCountSortClick = () => {
-            if (!sortConfig || sortConfig.field !== "referencesCount") {
-                onSort({ field: "referencesCount", direction: "desc" })
-            } else if (sortConfig.direction === "desc") {
-                onSort({ field: "referencesCount", direction: "asc" })
-            } else {
-                onSort(null)
-            }
-        }
+        const sortableHeader = (label: React.ReactNode, field: SortField) => (
+            <th
+                style={{ cursor: "pointer" }}
+                onClick={() => handleSortClick(field)}
+            >
+                {label}
+                {getSortIndicator(field)}
+            </th>
+        )
 
         // if the first chart has inheritance information, we assume all charts have it
         const showInheritanceColumn =
@@ -283,58 +316,71 @@ export class ChartList extends React.Component<ChartListProps> {
         return (
             <div className="ChartList">
                 <div className="topRow">
-                    <span>
-                        Showing {chartsToShow.length} of {numTotalCharts} charts
-                        {searchInput && (
-                            <>
-                                {" "}
-                                for "{searchInput}" ({this.props.charts.length}{" "}
-                                total)
-                            </>
-                        )}
-                    </span>
                     <TextField
                         placeholder="Search all charts..."
                         value={searchInput}
                         onValue={this.onSearchInput}
                         autofocus={this.props.autofocusSearchInput}
                     />
+                    <div className="filters">
+                        <FontAwesomeIcon icon={faFilter} aria-hidden="true" />
+                        <select
+                            className="form-control"
+                            value={publishedFilter}
+                            onChange={(e) =>
+                                this.onPublishedFilterChange(
+                                    e.target.value as PublishedFilter
+                                )
+                            }
+                            aria-label="Filter by publication status"
+                        >
+                            <option value="all">All charts</option>
+                            <option value="published">Public only</option>
+                            <option value="drafts">Drafts only</option>
+                        </select>
+                    </div>
+                </div>
+                <div className="resultsCount">
+                    Showing {chartsToShow.length} of {numTotalCharts} charts
+                    {searchInput && (
+                        <>
+                            {" "}
+                            for "{searchInput}" ({this.props.charts.length}{" "}
+                            total)
+                        </>
+                    )}
                 </div>
                 <table className="table table-bordered">
                     <thead>
                         <tr>
                             <th></th>
                             <th>Chart</th>
-                            <th>Id</th>
-                            <th>Type</th>
+                            {sortableHeader("Id", "id")}
+                            {sortableHeader("Type", "type")}
                             {showInheritanceColumn && <th>Inheritance</th>}
                             <th>Tags</th>
-                            <th>Published</th>
-                            <th>Last Updated</th>
+                            {sortableHeader("Published", "isPublished")}
+                            {sortableHeader("Last Updated", "lastEditedAt")}
+                            {sortableHeader(
+                                "Grapher views/day",
+                                "grapherViewsPerDay"
+                            )}
+                            {sortableHeader(
+                                "narrative charts",
+                                "narrativeChartsCount"
+                            )}
                             <th
                                 style={{ cursor: "pointer" }}
-                                onClick={handleSortClick}
+                                onClick={() =>
+                                    handleSortClick("referencesCount")
+                                }
                             >
-                                Grapher views/day{getSortIndicator()}
-                            </th>
-                            <th
-                                style={{ cursor: "pointer" }}
-                                onClick={handleNarrativeChartsSortClick}
-                            >
-                                narrative charts
-                                {getNarrativeChartsSortIndicator()}
-                            </th>
-                            <th
-                                style={{ cursor: "pointer" }}
-                                onClick={handleReferencesCountSortClick}
-                            >
-                                references{getReferencesCountSortIndicator()}
+                                references{getSortIndicator("referencesCount")}
                                 <Tooltip title="Only considers published content. This number might differ from the chart editor count, which includes unpublished data insights.">
                                     <FontAwesomeIcon icon={faInfoCircle} />
                                 </Tooltip>
                             </th>
-                            <th></th>
-                            <th></th>
+                            <th>Actions</th>
                         </tr>
                     </thead>
                     <tbody>

--- a/adminSiteClient/ChartList.tsx
+++ b/adminSiteClient/ChartList.tsx
@@ -26,10 +26,23 @@ import {
     highlightFunctionForSearchWords,
 } from "../adminShared/search.js"
 import { TextField } from "./Forms.js"
-import { Tooltip } from "antd"
+import {
+    Badge,
+    Button,
+    DatePicker,
+    InputNumber,
+    Popover,
+    Select,
+    Tooltip,
+} from "antd"
+import dayjs, { Dayjs } from "dayjs"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faFilter, faInfoCircle } from "@fortawesome/free-solid-svg-icons"
 import { deleteChart } from "./ChartEditor.js"
+
+const MAP_FILTER_VALUE = "__map__"
+type ChartTypeFilterValue = GrapherChartType | typeof MAP_FILTER_VALUE
+type DateRange = [Dayjs | null, Dayjs | null] | null
 
 // These properties are coming from OldChart.ts
 export interface ChartListItem {
@@ -93,6 +106,13 @@ export class ChartList extends React.Component<ChartListProps> {
     sortConfig: SortConfig | undefined = undefined
     availableTags: DbChartTagJoin[] = []
     publishedFilter: PublishedFilter = "all"
+    chartTypes: ChartTypeFilterValue[] = []
+    publishedDateRange: DateRange = null
+    lastEditedDateRange: DateRange = null
+    referencesMin: number | null = null
+    referencesMax: number | null = null
+    narrativeChartsMin: number | null = null
+    narrativeChartsMax: number | null = null
 
     constructor(props: ChartListProps) {
         super(props)
@@ -103,6 +123,13 @@ export class ChartList extends React.Component<ChartListProps> {
             sortConfig: observable,
             availableTags: observable,
             publishedFilter: observable,
+            chartTypes: observable,
+            publishedDateRange: observable,
+            lastEditedDateRange: observable,
+            referencesMin: observable,
+            referencesMax: observable,
+            narrativeChartsMin: observable,
+            narrativeChartsMax: observable,
         })
     }
 
@@ -176,7 +203,17 @@ export class ChartList extends React.Component<ChartListProps> {
     }
 
     @computed get chartsFiltered(): ChartListItem[] {
-        const { searchWords, publishedFilter } = this
+        const {
+            searchWords,
+            publishedFilter,
+            chartTypes,
+            publishedDateRange,
+            lastEditedDateRange,
+            referencesMin,
+            referencesMax,
+            narrativeChartsMin,
+            narrativeChartsMax,
+        } = this
         let result = this.props.charts
 
         if (publishedFilter === "published") {
@@ -184,6 +221,46 @@ export class ChartList extends React.Component<ChartListProps> {
         } else if (publishedFilter === "drafts") {
             result = result.filter((chart) => !chart.isPublished)
         }
+
+        if (chartTypes.length > 0) {
+            result = result.filter((chart) =>
+                chartTypes.some((selected) => {
+                    if (selected === MAP_FILTER_VALUE)
+                        return !!chart.hasMapTab || !chart.type
+                    return chart.type === selected
+                })
+            )
+        }
+
+        result = filterByDateRange(
+            result,
+            (chart) => chart.publishedAt,
+            publishedDateRange
+        )
+        result = filterByDateRange(
+            result,
+            (chart) => chart.lastEditedAt,
+            lastEditedDateRange
+        )
+
+        if (referencesMin !== null)
+            result = result.filter(
+                (chart) => (chart.referencesCount ?? 0) >= referencesMin
+            )
+        if (referencesMax !== null)
+            result = result.filter(
+                (chart) => (chart.referencesCount ?? 0) <= referencesMax
+            )
+        if (narrativeChartsMin !== null)
+            result = result.filter(
+                (chart) =>
+                    (chart.narrativeChartsCount ?? 0) >= narrativeChartsMin
+            )
+        if (narrativeChartsMax !== null)
+            result = result.filter(
+                (chart) =>
+                    (chart.narrativeChartsCount ?? 0) <= narrativeChartsMax
+            )
 
         if (searchWords.length > 0) {
             const filterFn = filterFunctionForSearchWords(
@@ -205,6 +282,27 @@ export class ChartList extends React.Component<ChartListProps> {
         }
 
         return result
+    }
+
+    @computed get advancedFilterCount(): number {
+        let count = 0
+        if (
+            this.publishedDateRange &&
+            (this.publishedDateRange[0] || this.publishedDateRange[1])
+        )
+            count++
+        if (
+            this.lastEditedDateRange &&
+            (this.lastEditedDateRange[0] || this.lastEditedDateRange[1])
+        )
+            count++
+        if (this.referencesMin !== null || this.referencesMax !== null) count++
+        if (
+            this.narrativeChartsMin !== null ||
+            this.narrativeChartsMax !== null
+        )
+            count++
+        return count
     }
 
     @computed get chartsSorted(): ChartListItem[] {
@@ -266,6 +364,43 @@ export class ChartList extends React.Component<ChartListProps> {
         this.publishedFilter = filter
     }
 
+    @action.bound onChartTypesChange(types: ChartTypeFilterValue[]) {
+        this.chartTypes = types
+    }
+
+    @action.bound onPublishedDateRangeChange(range: DateRange) {
+        this.publishedDateRange = range
+    }
+
+    @action.bound onLastEditedDateRangeChange(range: DateRange) {
+        this.lastEditedDateRange = range
+    }
+
+    @action.bound onReferencesMinChange(value: number | null) {
+        this.referencesMin = value
+    }
+
+    @action.bound onReferencesMaxChange(value: number | null) {
+        this.referencesMax = value
+    }
+
+    @action.bound onNarrativeChartsMinChange(value: number | null) {
+        this.narrativeChartsMin = value
+    }
+
+    @action.bound onNarrativeChartsMaxChange(value: number | null) {
+        this.narrativeChartsMax = value
+    }
+
+    @action.bound onClearAdvancedFilters() {
+        this.publishedDateRange = null
+        this.lastEditedDateRange = null
+        this.referencesMin = null
+        this.referencesMax = null
+        this.narrativeChartsMin = null
+        this.narrativeChartsMax = null
+    }
+
     @action.bound onShowMore() {
         this.maxVisibleCharts += 100
     }
@@ -278,8 +413,91 @@ export class ChartList extends React.Component<ChartListProps> {
             numTotalCharts,
             searchInput,
             publishedFilter,
+            chartTypes,
+            publishedDateRange,
+            lastEditedDateRange,
+            referencesMin,
+            referencesMax,
+            narrativeChartsMin,
+            narrativeChartsMax,
+            advancedFilterCount,
         } = this
         const { availableTags } = this
+
+        const chartTypeOptions: {
+            label: string
+            value: ChartTypeFilterValue
+        }[] = [
+            ...Object.values(GRAPHER_CHART_TYPES).map((value) => ({
+                label: _.startCase(value),
+                value,
+            })),
+            { label: "Map", value: MAP_FILTER_VALUE },
+        ]
+
+        const advancedFiltersContent = (
+            <div className="ChartList__advancedFilters">
+                <label>
+                    <span>Published</span>
+                    <DatePicker.RangePicker
+                        value={publishedDateRange ?? undefined}
+                        onChange={this.onPublishedDateRangeChange}
+                        allowEmpty={[true, true]}
+                    />
+                </label>
+                <label>
+                    <span>Last edited</span>
+                    <DatePicker.RangePicker
+                        value={lastEditedDateRange ?? undefined}
+                        onChange={this.onLastEditedDateRangeChange}
+                        allowEmpty={[true, true]}
+                    />
+                </label>
+                <label>
+                    <span>References</span>
+                    <span className="ChartList__rangeInputs">
+                        <InputNumber
+                            placeholder="Min"
+                            min={0}
+                            value={referencesMin}
+                            onChange={this.onReferencesMinChange}
+                        />
+                        <InputNumber
+                            placeholder="Max"
+                            min={0}
+                            value={referencesMax}
+                            onChange={this.onReferencesMaxChange}
+                        />
+                    </span>
+                </label>
+                <label>
+                    <span>Narrative charts</span>
+                    <span className="ChartList__rangeInputs">
+                        <InputNumber
+                            placeholder="Min"
+                            min={0}
+                            value={narrativeChartsMin}
+                            onChange={this.onNarrativeChartsMinChange}
+                        />
+                        <InputNumber
+                            placeholder="Max"
+                            min={0}
+                            value={narrativeChartsMax}
+                            onChange={this.onNarrativeChartsMaxChange}
+                        />
+                    </span>
+                </label>
+                <div className="ChartList__advancedFiltersFooter">
+                    <Button
+                        size="small"
+                        onClick={this.onClearAdvancedFilters}
+                        disabled={advancedFilterCount === 0}
+                    >
+                        Clear
+                    </Button>
+                </div>
+            </div>
+        )
 
         const highlight = highlightFunctionForSearchWords(this.searchWords)
         const hasMoreCharts = this.chartsFiltered.length > this.maxVisibleCharts
@@ -338,6 +556,31 @@ export class ChartList extends React.Component<ChartListProps> {
                             <option value="published">Public only</option>
                             <option value="drafts">Drafts only</option>
                         </select>
+                        <Select
+                            className="ChartList__chartTypeSelect"
+                            mode="multiple"
+                            allowClear
+                            placeholder="Chart type"
+                            value={chartTypes}
+                            onChange={this.onChartTypesChange}
+                            options={chartTypeOptions}
+                            maxTagCount="responsive"
+                            aria-label="Filter by chart type"
+                        />
+                        <Popover
+                            trigger="click"
+                            placement="bottomRight"
+                            content={advancedFiltersContent}
+                            title="More filters"
+                        >
+                            <Badge
+                                count={advancedFilterCount}
+                                size="small"
+                                offset={[-4, 4]}
+                            >
+                                <Button>More filters</Button>
+                            </Badge>
+                        </Popover>
                     </div>
                 </div>
                 <div className="resultsCount">
@@ -407,6 +650,23 @@ export class ChartList extends React.Component<ChartListProps> {
             </div>
         )
     }
+}
+
+function filterByDateRange(
+    charts: ChartListItem[],
+    getDate: (chart: ChartListItem) => string | null | undefined,
+    range: DateRange
+): ChartListItem[] {
+    if (!range || (!range[0] && !range[1])) return charts
+    const [start, end] = range
+    return charts.filter((chart) => {
+        const raw = getDate(chart)
+        if (!raw) return false
+        const date = dayjs(raw)
+        if (start && date.isBefore(start, "day")) return false
+        if (end && date.isAfter(end, "day")) return false
+        return true
+    })
 }
 
 export function showChartType(chart: ChartListItem): string {

--- a/adminSiteClient/ChartRow.tsx
+++ b/adminSiteClient/ChartRow.tsx
@@ -144,7 +144,7 @@ export class ChartRow extends React.Component<ChartRowProps> {
                 <td>{chart.grapherViewsPerDay?.toLocaleString() ?? "0"}</td>
                 <td>{chart.narrativeChartsCount?.toLocaleString() ?? "0"}</td>
                 <td>{chart.referencesCount?.toLocaleString() ?? "0"}</td>
-                <td>
+                <td style={{ minWidth: "120px" }}>
                     <Link
                         to={`/charts/${chart.id}/edit`}
                         className="btn btn-primary"
@@ -168,10 +168,8 @@ export class ChartRow extends React.Component<ChartRowProps> {
                     >
                         Copy
                     </Dropdown.Button>
-                </td>
-                <td>
                     <button
-                        className="btn btn-danger"
+                        className="btn btn-danger mt-1"
                         onClick={() => this.props.onDelete(chart)}
                     >
                         Delete

--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -919,16 +919,34 @@ main:not(.ChartEditorPage):not(.GdocsEditPage):not(.MultiDimDetailPage) {
     .topRow {
         display: flex;
         align-items: center;
-        justify-content: space-between;
-        margin-bottom: 1em;
+        gap: 1em;
+        margin-bottom: 0.5em;
 
         .form-group {
             margin: 0;
+            flex: 1;
         }
 
         input {
-            width: 500px;
+            width: 100%;
         }
+
+        .filters {
+            display: flex;
+            align-items: center;
+            gap: 0.5em;
+            color: #666;
+        }
+
+        .filters select {
+            width: auto;
+        }
+    }
+
+    .resultsCount {
+        margin-bottom: 1em;
+        color: #666;
+        font-size: 0.9em;
     }
 }
 

--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -941,6 +941,10 @@ main:not(.ChartEditorPage):not(.GdocsEditPage):not(.MultiDimDetailPage) {
         .filters select {
             width: auto;
         }
+
+        .ChartList__chartTypeSelect {
+            min-width: 180px;
+        }
     }
 
     .resultsCount {
@@ -948,6 +952,41 @@ main:not(.ChartEditorPage):not(.GdocsEditPage):not(.MultiDimDetailPage) {
         color: #666;
         font-size: 0.9em;
     }
+}
+
+.ChartList__advancedFilters {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75em;
+    min-width: 320px;
+
+    label {
+        display: flex;
+        flex-direction: column;
+        gap: 0.25em;
+        margin: 0;
+        font-weight: 500;
+    }
+
+    label > span:first-child {
+        font-size: 0.85em;
+        color: #666;
+    }
+}
+
+.ChartList__rangeInputs {
+    display: flex;
+    gap: 0.5em;
+}
+
+.ChartList__rangeInputs .ant-input-number {
+    flex: 1;
+}
+
+.ChartList__advancedFiltersFooter {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 0.5em;
 }
 
 .ImportPage {


### PR DESCRIPTION
## Summary

Small improvements to the charts table used in the admin — both on the main `/admin/charts` listing and on the **Charts** tab of a dataset edit page (it's the same shared `ChartList` component).

| PROD | New |
|--------|--------|
| <img width="1559" height="501" alt="image" src="https://github.com/user-attachments/assets/85c226e4-7b2f-4c98-a4a8-0c9e18d2b279" /> | <img width="1541" height="529" alt="image" src="https://github.com/user-attachments/assets/2fd70cc6-3e66-46a1-8d5c-94f60f719c70" /> | 



**New filters**
- Publication status: All charts / Public only / Drafts only (default: All).
- Chart type: multi-select dropdown — pick one or more chart types, plus a synthetic "Map" option that matches any chart with a map tab.
- A **More filters** popover for less common filters, with a small badge showing how many advanced filters are active:
  - Published date range
  - Last edited date range
  - References count: min / max
  - Narrative charts count: min / max
  - A "Clear" button to reset all advanced filters at once.

**More sortable columns**
- Id, Type, Published, Last Updated columns are now click-to-sort, in addition to the existing Grapher views/day, narrative charts, and references.
- Click cycle is the same as before: `↓` → `↑` → unsorted, one column at a time.

**Cleaner row actions**
- The Edit, Copy, and Delete buttons used to take up two table columns (with empty headers). They're now grouped into a single **Actions** column, stacked vertically.

**Layout tweak**
- The header row used to push the search bar and filter to opposite ends of the screen. Now the search bar grows to fill, the filters group sits next to it, and the "Showing X of Y charts" text moved below to its own line.

No backend or data changes — all filtering and sorting happens client-side over the data the admin API already returns.

## Test plan
- [x] Visit `/admin/charts`. Try each filter individually and combined with the search box. Confirm row counts make sense.
- [x] Visit a dataset edit page → **Charts** tab. Same checks.
- [x] Click each newly sortable column header (Id, Type, Published, Last Updated) and confirm the indicator cycles `↓ → ↑ → off`.
- [x] Open the **More filters** popover, set a published / last-edited date range and a min/max for references / narrative charts. Confirm the badge count matches the number of active dimensions and **Clear** resets them.
- [ ] Confirm the Edit, Copy, and Delete buttons all still work in the new combined Actions column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)