### PR TITLE
🐛 (admin) always show time annotation toggle

### DIFF
--- a/adminSiteClient/EditorFeatures.tsx
+++ b/adminSiteClient/EditorFeatures.tsx
@@ -171,17 +171,6 @@ export class EditorFeatures {
         )
     }
 
-    @computed get showTimeAnnotationInTitleToggle() {
-        return (
-            !this.grapherState.hasTimeline ||
-            !(
-                this.grapherState.hasDiscreteBar ||
-                this.grapherState.hasStackedDiscreteBar ||
-                this.grapherState.hasMarimekko
-            )
-        )
-    }
-
     @computed get canHighlightSeries() {
         return (
             !this.grapherState.isScatter &&

--- a/adminSiteClient/EditorTextTab.tsx
+++ b/adminSiteClient/EditorTextTab.tsx
@@ -123,15 +123,6 @@ export class EditorTextTab<
         return !isNarrativeChartEditorInstance(this.props.editor)
     }
 
-    @computed get showAnyAnnotationFieldInTitleToggle() {
-        const { features } = this.props.editor
-        return (
-            features.showEntityAnnotationInTitleToggle ||
-            features.showTimeAnnotationInTitleToggle ||
-            features.showChangeInPrefixToggle
-        )
-    }
-
     @computed get hasCopyAdminURLButton() {
         return !!this.props.editor.grapherState.id
     }
@@ -241,20 +232,16 @@ export class EditorTextTab<
                             onValue={this.onToggleTitleAnnotationEntity}
                         />
                     )}
-                    {features.showTimeAnnotationInTitleToggle && (
-                        <Toggle
-                            label="Hide automatic time"
-                            secondaryLabel={
-                                "grapherState makes sure to include the current time in the title if " +
-                                "omitting it would lead to SVG exports with no reference " +
-                                "to the time. In such cases, your preference is ignored."
-                            }
-                            value={
-                                !!grapherState.hideAnnotationFieldsInTitle?.time
-                            }
-                            onValue={this.onToggleTitleAnnotationTime}
-                        />
-                    )}
+                    <Toggle
+                        label="Hide automatic time"
+                        secondaryLabel={
+                            "Grapher makes sure to include the current time in the title if " +
+                            "omitting it would lead to SVG exports with no reference " +
+                            "to the time. In such cases, your preference is ignored."
+                        }
+                        value={!!grapherState.hideAnnotationFieldsInTitle?.time}
+                        onValue={this.onToggleTitleAnnotationTime}
+                    />
                     {features.showChangeInPrefixToggle && (
                         <Toggle
                             label="Don't prepend 'Change in' in relative line charts"
@@ -265,7 +252,7 @@ export class EditorTextTab<
                             onValue={this.onToggleTitleAnnotationChangeInPrefix}
                         />
                     )}
-                    {this.showAnyAnnotationFieldInTitleToggle && <hr />}
+                    <hr />
                     {this.showChartSlug && (
                         <AutoTextField
                             label="/grapher/"

--- a/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
@@ -2426,7 +2426,10 @@ export class GrapherState
                     (this.isOnDiscreteBarTab ||
                         this.isOnStackedDiscreteBarTab ||
                         this.isOnMarimekkoTab ||
-                        this.isOnMapTab)))
+                        this.isOnMapTab ||
+                        (this.isOnScatterTab &&
+                            !this.isTimeScatter &&
+                            !this.isConnectedScatter))))
         )
     }
 


### PR DESCRIPTION
We sometimes hide the 'Hide time suffix' toggle in the admin, which has been a source of confusion. 