### PR TITLE
✨ use shared start and end time positions across facets

### DIFF
--- a/packages/@ourworldindata/grapher/src/chart/ChartInterface.ts
+++ b/packages/@ourworldindata/grapher/src/chart/ChartInterface.ts
@@ -5,6 +5,7 @@ import {
     SeriesStrategy,
     Color,
     ChartErrorInfo,
+    SideWidths,
 } from "@ourworldindata/types"
 import { ColorScale } from "../color/ColorScale"
 import { HorizontalAxis, VerticalAxis } from "../axis/Axis"
@@ -80,4 +81,10 @@ export interface ChartInterface {
      * Only relevant for StackedBar charts.
      */
     shouldUseValueBasedColorScheme?: boolean
+
+    /**
+     * Width of the vertical labels rendered on each side of the chart's
+     * plotting area.
+     */
+    verticalLabelWidths?: SideWidths
 }

--- a/packages/@ourworldindata/grapher/src/facet/FacetChart.tsx
+++ b/packages/@ourworldindata/grapher/src/facet/FacetChart.tsx
@@ -29,6 +29,7 @@ import {
     FacetStrategy,
     SeriesColorMap,
     SeriesStrategy,
+    SideWidths,
     AxisConfigInterface,
     ChartErrorInfo,
 } from "@ourworldindata/types"
@@ -482,6 +483,18 @@ export class FacetChart
             }
         })
 
+        // Make sure that all slope facets use the same start and end point
+        let sharedVerticalLabelWidths: SideWidths | undefined
+        if (this.chartTypeName === GRAPHER_CHART_TYPES.SlopeChart) {
+            const widths = excludeUndefined(
+                intermediateChartInstances.map((c) => c.verticalLabelWidths)
+            )
+            sharedVerticalLabelWidths = {
+                left: _.max(widths.map((w) => w.left)) ?? 0,
+                right: _.max(widths.map((w) => w.right)) ?? 0,
+            }
+        }
+
         // Allocate space for shared axes, so that the content areas of charts are all equal.
         // If the axes are "shared", then an axis will only plotted on the facets that are on the
         // same side as the axis.
@@ -507,6 +520,7 @@ export class FacetChart
             const manager = {
                 ...series.manager,
                 useValueBasedColorScheme,
+                sharedVerticalLabelWidths,
                 xAxisConfig: {
                     hideAxis: shouldHideFacetAxis(
                         xAxis,

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
@@ -88,6 +88,7 @@ type SVGMouseOrTouchEvent =
 const TIME_LABEL_PADDING = 4
 const VERTICAL_LABELS_PADDING = 4
 const SIDEBAR_MARGIN = 10
+const ZERO_LABEL_PADDING = 8
 
 export type SlopeChartProps = ChartComponentProps<SlopeChartState>
 
@@ -125,11 +126,16 @@ export class SlopeChart
         return this.props.bounds ?? DEFAULT_GRAPHER_BOUNDS
     }
 
-    @computed private get innerBounds(): Bounds {
+    @computed private get boundsWithVerticalPadding(): Bounds {
         return this.bounds
             .padTop(6) // Leave room for overflowing dots
             .padBottom(this.xAxisHeight + 3)
+    }
+
+    @computed private get innerBounds(): Bounds {
+        return this.boundsWithVerticalPadding
             .padRight(this.sidebarWidth + SIDEBAR_MARGIN)
+            .padLeft(this.zeroLineLabelWidth + ZERO_LABEL_PADDING)
     }
 
     /**
@@ -606,6 +612,35 @@ export class SlopeChart
         )
     }
 
+    @computed private get zeroLineLabelFontSize(): number {
+        return GRAPHER_FONT_SCALE_12 * this.fontSize
+    }
+
+    @computed private get shouldShowZeroLine(): boolean {
+        const hasAnyNonZeroStartValue = this.chartState.series.some(
+            (series) => series.start.value !== 0
+        )
+        const isZeroInDomain = this.yDomain[0] <= 0 && this.yDomain[1] >= 0
+
+        return (
+            !this.chartState.isRelativeMode &&
+            hasAnyNonZeroStartValue &&
+            isZeroInDomain
+        )
+    }
+
+    @computed private get zeroLineLabel(): string {
+        return this.chartState.yColumns[0].formatForTick(0)
+    }
+
+    @computed private get zeroLineLabelWidth(): number {
+        if (!this.shouldShowZeroLine) return 0
+
+        return Bounds.forText(this.zeroLineLabel, {
+            fontSize: this.zeroLineLabelFontSize,
+        }).width
+    }
+
     override componentDidMount() {
         exposeInstanceOnWindow(this)
     }
@@ -894,48 +929,29 @@ export class SlopeChart
     }
 
     private renderZeroLine(): React.ReactElement | null {
-        // Don't draw a zero line if all start values are zero,
-        // which is trivially true in relative mode
-        if (this.chartState.isRelativeMode) return null
+        if (!this.shouldShowZeroLine) return null
 
-        // Don't draw a zero line if all start values are zero
-        const areAllStartValuesZero = !this.chartState.series.some(
-            (series) => series.start.value !== 0
-        )
-        if (areAllStartValuesZero) return null
-
-        // Don't show a zero line if it's not in the domain
-        const isZeroInDomain =
-            this.yAxis.domain[0] <= 0 && this.yAxis.domain[1] >= 0
-        if (!isZeroInDomain) return null
-
-        const fontSize = GRAPHER_FONT_SCALE_12 * this.fontSize
-        const tickLabelOffset = 5
-
-        const tickLabel = this.yAxis.formatTick(0)
-        const tickLabelLength = Bounds.forText(tickLabel, { fontSize }).width
-        const bounds = this.innerBounds.padLeft(
-            tickLabelLength + tickLabelOffset
-        )
+        const bounds = this.boundsWithVerticalPadding
+        const boundsForLine = bounds.padLeft(this.zeroLineLabelWidth + 2)
 
         return (
             <>
                 {!this.yAxis.hideGridlines && (
                     <VerticalAxisZeroLine
-                        bounds={bounds}
+                        bounds={boundsForLine}
                         axis={this.yAxis}
                         stroke="#ddd"
                         strokeDasharray="3,2"
                     />
                 )}
                 <text
-                    x={this.innerBounds.left}
+                    x={bounds.left}
                     y={this.yAxis.place(0).toFixed(2)}
                     dy={dyFromAlign(VerticalAlign.middle)}
-                    fontSize={fontSize}
+                    fontSize={this.zeroLineLabelFontSize}
                     fill={GRAPHER_DARK_TEXT}
                 >
-                    {tickLabel}
+                    {this.zeroLineLabel}
                 </text>
             </>
         )

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
@@ -27,6 +27,7 @@ import {
     MissingDataStrategy,
     Time,
     SeriesStrategy,
+    SideWidths,
     VerticalAlign,
     HorizontalAlign,
 } from "@ourworldindata/types"
@@ -443,6 +444,11 @@ export class SlopeChart
             : this.rightLabelsState.stableWidth
     }
 
+    // Consumed by FacetChart to align gridlines across facets
+    @computed get verticalLabelWidths(): SideWidths {
+        return { left: this.leftLabelsWidth, right: this.rightLabelsWidth }
+    }
+
     @computed
     private get visibleRightLabels(): Set<SeriesName> {
         return new Set(this.rightLabelsState?.visibleSeriesNames ?? [])
@@ -467,9 +473,18 @@ export class SlopeChart
             })
     }
 
+    @computed private get effectiveLabelWidths(): SideWidths {
+        const shared = this.manager.sharedVerticalLabelWidths
+        return {
+            left: Math.max(shared?.left ?? 0, this.leftLabelsWidth),
+            right: Math.max(shared?.right ?? 0, this.rightLabelsWidth),
+        }
+    }
+
     @computed private get xRange(): [number, number] {
-        const leftLabelsWidth = this.leftLabelsWidth + VERTICAL_LABELS_PADDING
-        const rightLabelsWidth = this.rightLabelsWidth + VERTICAL_LABELS_PADDING
+        const { left, right } = this.effectiveLabelWidths
+        const leftLabelsWidth = left + VERTICAL_LABELS_PADDING
+        const rightLabelsWidth = right + VERTICAL_LABELS_PADDING
         const chartAreaWidth = this.innerBounds.width
 
         // start and end value when the slopes are as wide as possible

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChartConstants.ts
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChartConstants.ts
@@ -1,5 +1,5 @@
 import { PartialBy, PointVector } from "@ourworldindata/utils"
-import { EntityName, OwidVariableRow } from "@ourworldindata/types"
+import { EntityName, OwidVariableRow, SideWidths } from "@ourworldindata/types"
 import { ChartSeries } from "../chart/ChartInterface"
 import { CoreColumn } from "@ourworldindata/core-table"
 import { ChartManager } from "../chart/ChartManager"
@@ -10,6 +10,7 @@ export interface SlopeChartManager extends ChartManager {
     canSelectMultipleEntities?: boolean // used to pick an appropriate series name
     hasTimeline?: boolean // used to filter the table for the entity selector
     hideNoDataSection?: boolean
+    sharedVerticalLabelWidths?: SideWidths
 }
 
 export interface SlopeChartSeries extends ChartSeries {

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChartThumbnail.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChartThumbnail.tsx
@@ -3,6 +3,7 @@ import * as _ from "remeda"
 import { computed, makeObservable } from "mobx"
 import { observer } from "mobx-react"
 import { ChartInterface } from "../chart/ChartInterface"
+import { SideWidths } from "@ourworldindata/types"
 import { SlopeChartState } from "./SlopeChartState.js"
 import { type SlopeChartProps } from "./SlopeChart.js"
 import {
@@ -325,14 +326,27 @@ export class SlopeChartThumbnail
         return this.startLabelsState?.width ?? 0
     }
 
+    // Consumed by FacetChart to align gridlines across facets
+    @computed get verticalLabelWidths(): SideWidths {
+        return { left: this.startLabelsWidth, right: this.endLabelsWidth }
+    }
+
+    @computed private get effectiveLabelWidths(): SideWidths {
+        const shared = this.manager.sharedVerticalLabelWidths
+        return {
+            left: Math.max(shared?.left ?? 0, this.startLabelsWidth),
+            right: Math.max(shared?.right ?? 0, this.endLabelsWidth),
+        }
+    }
+
     @computed private get paddedEndLabelsWidth(): number {
-        return this.endLabelsWidth > 0 ? this.endLabelsWidth + LABEL_PADDING : 0
+        const width = this.effectiveLabelWidths.right
+        return width > 0 ? width + LABEL_PADDING : 0
     }
 
     @computed private get paddedStartLabelsWidth(): number {
-        return this.startLabelsWidth > 0
-            ? this.startLabelsWidth + LABEL_PADDING
-            : 0
+        const width = this.effectiveLabelWidths.left
+        return width > 0 ? width + LABEL_PADDING : 0
     }
 
     override render(): React.ReactElement {

--- a/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
+++ b/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
@@ -780,6 +780,8 @@ export enum GrapherWindowType {
 
 export type GrapherTrendArrowDirection = "up" | "right" | "down"
 
+export type SideWidths = { left: number; right: number }
+
 /** Function type for loading additional indicator data from the catalog */
 export type AdditionalGrapherDataFetchFn = <K extends CatalogKey>(
     catalogKey: K

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -763,6 +763,7 @@ export {
 export {
     type AdditionalGrapherDataFetchFn,
     type GrapherTrendArrowDirection,
+    type SideWidths,
 } from "./grapherTypes/GrapherTypes.js"
 export {
     type CatalogKey,


### PR DESCRIPTION
Start and end points in faceted slope charts are currently not guaranteed to be aligned. If all start/end values have the same width, this isn't an issue, but if they don't, then different start and end points for each facet make it difficult to compare slopes.

Example: http://staging-site-slope-facet-shared-x-axis/grapher/democracy-index-eiu?tab=slope&yScale=log&facet=entity&uniformYAxis=0&country=ARG~AUS~BWA~CHN~NOR~OWID_EUR~DEU~SWE~NZL~DNK~FIN~CHE~LUX~NLD~IRL