### PR TITLE
🐛 (search) skip picking regions for scatters and marimekkos

### DIFF
--- a/functions/_common/search/constructSearchResultJson.test.ts
+++ b/functions/_common/search/constructSearchResultJson.test.ts
@@ -376,22 +376,4 @@ describe(selectRegionGroupByPriority, () => {
 
         expect(selectedRegions).not.toContain(WORLD_ENTITY_NAME)
     })
-
-    it("includes World when includeWorld option is true", () => {
-        const availableEntities = [
-            WORLD_ENTITY_NAME,
-            "Europe",
-            "Asia",
-            "Italy",
-            "Africa (WHO)",
-        ]
-
-        const selectedRegions = selectRegionGroupByPriority(availableEntities, {
-            includeWorld: true,
-        })
-
-        expect(selectedRegions).toContain(WORLD_ENTITY_NAME)
-        expect(selectedRegions).toContain("Europe")
-        expect(selectedRegions).toContain("Asia")
-    })
 })

--- a/functions/_common/search/constructSearchResultJson.ts
+++ b/functions/_common/search/constructSearchResultJson.ts
@@ -399,13 +399,6 @@ async function pickDisplayEntitiesForScatterPlot({
 }): Promise<EntityName[]> {
     const { series, colorColumnSlug, sizeColumnSlug } = chartState
 
-    // Pick income groups or continents if available
-    const regions = selectRegionGroupByPriority(
-        grapherState.availableEntityNames,
-        { includeWorld: true }
-    )
-    if (regions.length > 0) return regions
-
     // Helper functions
     type ScatterSeries = ScatterPlotChartState["series"][number]
     const getName = (series: ScatterSeries) => series.seriesName
@@ -475,13 +468,6 @@ async function pickDisplayEntitiesForMarimekko({
     entity?: EntityName
 }): Promise<EntityName[]> {
     const { items, colorColumnSlug, xColumnSlug } = chartState
-
-    // Pick income groups or continents if available
-    const regions = selectRegionGroupByPriority(
-        grapherState.availableEntityNames,
-        { includeWorld: true }
-    )
-    if (regions.length > 0) return regions
 
     // Helper functions
     type MarimekkoItem = MarimekkoChartState["items"][number]
@@ -1077,8 +1063,7 @@ function findAvailableSiblingRegions({
  * regions as defined by the WHO or WB, for example
  */
 export function selectRegionGroupByPriority(
-    availableEntities: EntityName[],
-    { includeWorld }: { includeWorld: boolean } = { includeWorld: false }
+    availableEntities: EntityName[]
 ): EntityName[] {
     const availableEntitySet = new Set(availableEntities)
 
@@ -1110,14 +1095,7 @@ export function selectRegionGroupByPriority(
             .filter((region) => availableEntitySet.has(region.name))
             .map((region) => region.name)
 
-        if (matchingRegions.length > 0) {
-            // Add the World entity if requested and available
-            if (includeWorld && availableEntitySet.has(WORLD_ENTITY_NAME)) {
-                matchingRegions.push(WORLD_ENTITY_NAME)
-            }
-
-            return matchingRegions
-        }
+        if (matchingRegions.length > 0) return matchingRegions
     }
 
     return []


### PR DESCRIPTION
> [!NOTE]
> Check more examples 

Picking regions for scatters and Marimekkos often doesn't make much sense:

<img width="2600" height="1022" alt="image" src="https://github.com/user-attachments/assets/730c70fa-8344-4169-8e26-abb5cc91cfef" />

