### PR TITLE
🔨 (typescript) check for unused locals

### DIFF
--- a/adminSiteServer/appClass.tsx
+++ b/adminSiteServer/appClass.tsx
@@ -269,6 +269,7 @@ export class OwidAdminApp {
 
     connectToDatabases = async () => {
         try {
+            // @ts-expect-error tests the database connection
             const _ = db.knexInstance()
         } catch (error) {
             // grapher database is in fact required, but we will not fail now in case it

--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -18,7 +18,6 @@ import {
     makeAtomFeed,
     feedbackPage,
     renderNotFoundPage,
-    renderPost,
     renderGdoc,
     makeAtomFeedNoTopicPages,
     renderDynamicCollectionPage,
@@ -33,7 +32,6 @@ import {
 } from "../baker/siteRenderers.js"
 import { makeSitemap } from "../baker/sitemap.js"
 import {
-    FullPost,
     LinkedAuthor,
     LinkedChart,
     LinkedIndicator,
@@ -318,15 +316,6 @@ export class SiteBaker {
             "deleted",
             `${tombstone.slug}.html`
         )
-        await this.stageWrite(outPath, html)
-    }
-
-    // Bake an individual post/page
-    private async bakePost(post: FullPost, knex: db.KnexReadonlyTransaction) {
-        const html = await renderPost(post, knex, this.baseUrl)
-
-        const outPath = path.join(this.bakedSiteDir, `${post.slug}.html`)
-        await fs.mkdirp(path.dirname(outPath))
         await this.stageWrite(outPath, html)
     }
 

--- a/db/migration/1653646292637-ArchiveDatasets.ts
+++ b/db/migration/1653646292637-ArchiveDatasets.ts
@@ -143,8 +143,8 @@ const archiveDatasets = async (
     )
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const deleteDatasets = async (
+// @ts-expect-error unused but keep for reference
+const _deleteDatasets = async (
     queryRunner: QueryRunner,
     datasetIds: number[]
 ): Promise<void> => {

--- a/db/migration/1701450183524-TagTopicSlug.ts
+++ b/db/migration/1701450183524-TagTopicSlug.ts
@@ -182,8 +182,8 @@ async function writeToSlugMap(path: string, slug: string): Promise<void> {
     return
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-async function resolveSlugs(): Promise<void> {
+// @ts-expect-error unused but keep for reference
+async function _resolveSlugs(): Promise<void> {
     console.log("Resolving slugs 🚀")
     const slugMap = await readSlugMap()
     for (const topicTagName of topicTagNames) {

--- a/devTools/tsconfigs/tsconfig.base.json
+++ b/devTools/tsconfigs/tsconfig.base.json
@@ -28,6 +28,7 @@
 
         "alwaysStrict": true,
         "noImplicitReturns": true,
+        "noUnusedLocals": true,
         "allowJs": false,
         "sourceMap": true,
         "moduleResolution": "bundler",

--- a/packages/@ourworldindata/core-table/src/CoreTableColumns.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTableColumns.ts
@@ -1068,7 +1068,4 @@ export const ColumnTypeMap = {
 // Keep this in. This is used as a compile-time check that ColumnTypeMap covers all
 // column names defined in ColumnTypeNames, since that is quite difficult to ensure
 // otherwise without losing inferred type information.
-
-const _ColumnTypeMap: {
-    [key in ColumnTypeNames]: unknown
-} = ColumnTypeMap
+ColumnTypeMap satisfies { [key in ColumnTypeNames]: unknown }

--- a/packages/@ourworldindata/explorer/src/gridLang/GridCell.ts
+++ b/packages/@ourworldindata/explorer/src/gridLang/GridCell.ts
@@ -169,18 +169,6 @@ export class GridCell implements ParsedCell {
         return row === numRows
     }
 
-    private get suggestions() {
-        return []
-    }
-
-    private get definitionLinks(): CellPosition[] {
-        return []
-    }
-
-    private get implementationLinks(): CellPosition[] {
-        return []
-    }
-
     @imemo get cellDef(): CellDef {
         const def = this.cellTerminalTypeDefinition
         if (def) return def

--- a/packages/@ourworldindata/grapher/src/core/GrapherAnalytics.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherAnalytics.ts
@@ -31,12 +31,10 @@ type GAConsent = ["consent", "default" | "update", GAConsentParams]
 // Note: consent-based blocking dealt with at the Google Tag Manager level.
 // Events are discarded if consent not given.
 export class GrapherAnalytics {
-    constructor(environment: string = "", version = "1.0.0") {
+    constructor(environment: string = "") {
         this.isDev = environment === "development"
-        this.version = version
     }
 
-    private readonly version: string // Ideally the Git hash commit
     private readonly isDev: boolean
 
     logGrapherView(

--- a/packages/@ourworldindata/grapher/src/core/GrapherQueryParamParser.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherQueryParamParser.ts
@@ -402,18 +402,16 @@ type ParsedValueTypeMap = {
     peerCountries: PeerCountryStrategyQueryParam
 }
 
-/**
- * Compile-time check: ensures ParsedValueTypeMap has all keys from GrapherQueryParams.
- * If a key is added to GrapherQueryParams but not ParsedValueTypeMap, this will cause
- * a type error.
- */
+// Compile-time check: ensures ParsedValueTypeMap has all keys from GrapherQueryParams.
+// If a key is added to GrapherQueryParams but not ParsedValueTypeMap, this will cause
+// a type error.
 type _AssertAllKeysPresent =
     keyof GrapherQueryParams extends keyof ParsedValueTypeMap
         ? keyof ParsedValueTypeMap extends keyof GrapherQueryParams
             ? true
             : never
         : never
-const _assertAllKeysPresent: _AssertAllKeysPresent = true
+void (true satisfies _AssertAllKeysPresent)
 
 /** Container for all parsed query parameters */
 export type ParsedGrapherQueryParams = {

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
@@ -30,14 +30,12 @@ import {
     joinTitleFragments,
     FuzzySearch,
 } from "@ourworldindata/utils"
-import { SelectionArray } from "../selection/SelectionArray"
 import {
     DEFAULT_GRAPHER_BOUNDS,
     DEFAULT_GRAPHER_ENTITY_TYPE,
     SVG_STYLE_PROPS,
 } from "../core/GrapherConstants"
 import * as R from "remeda"
-import { makeSelectionArray } from "../chart/ChartUtils"
 import { isEntityRegionGroupKey } from "../core/RegionGroups"
 import { NoDataModal } from "../noDataModal/NoDataModal"
 import {
@@ -106,10 +104,6 @@ export class DataTable extends React.Component<DataTableProps> {
 
     @computed get manager(): DataTableManager {
         return this.props.manager
-    }
-
-    @computed private get selectionArray(): SelectionArray {
-        return makeSelectionArray(this.manager.dataTableSelection)
     }
 
     @computed private get tableConfig(): DataTableConfig {

--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
@@ -46,7 +46,6 @@ import {
     DEFAULT_MARKER_RADIUS,
     LINE_CHART_CLASS_NAME,
 } from "./LineChartConstants"
-import { CoreColumn } from "@ourworldindata/core-table"
 import {
     getHoverStateForSeries,
     getSeriesKey,
@@ -529,14 +528,6 @@ export class LineChart
 
     @computed protected get yColumnSlugs(): string[] {
         return this.chartState.yColumnSlugs
-    }
-
-    @computed private get colorColumn(): CoreColumn {
-        return this.chartState.colorColumn
-    }
-
-    @computed private get formatColumn(): CoreColumn {
-        return this.chartState.formatColumn
     }
 
     @computed private get hasColorScale(): boolean {

--- a/packages/@ourworldindata/grapher/src/mapCharts/ChoroplethGlobe.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/ChoroplethGlobe.tsx
@@ -875,7 +875,7 @@ export class ChoroplethGlobe extends React.Component<{
     }
 
     renderInteractive(): React.ReactElement {
-        // this needs to be referenced here or it will be recomputed on every mousemove
+        // @ts-expect-error this needs to be referenced here or it will be recomputed on every mousemove
         const _cachedCentroids = this.quadtree
 
         return (

--- a/packages/@ourworldindata/grapher/src/mapCharts/ChoroplethMap.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/ChoroplethMap.tsx
@@ -593,7 +593,7 @@ export class ChoroplethMap extends React.Component<{
     renderInteractive(): React.ReactElement {
         const { bounds, matrixTransform } = this
 
-        // this needs to be referenced here or it will be recomputed on every mousemove
+        // @ts-expect-error this needs to be referenced here or it will be recomputed on every mousemove
         const _cachedCentroids = this.quadtree
 
         // SVG layering is based on order of appearance in the element tree (later elements rendered on top)

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChartThumbnail.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChartThumbnail.tsx
@@ -13,11 +13,7 @@ import {
     DEFAULT_GRAPHER_BOUNDS,
 } from "../core/GrapherConstants"
 import { AxisConfig, AxisManager } from "../axis/AxisConfig"
-import {
-    SCATTER_LINE_MIN_WIDTH,
-    SCATTER_POINT_MIN_RADIUS,
-    ScatterPlotManager,
-} from "./ScatterPlotChartConstants"
+import { ScatterPlotManager } from "./ScatterPlotChartConstants"
 import { toSizeRange } from "./ScatterUtils"
 import { DualAxisComponent } from "../axis/AxisViews"
 import { ScatterPointsWithLabels } from "./ScatterPointsWithLabels"
@@ -93,22 +89,6 @@ export class ScatterPlotChartThumbnail
         return scaleSqrt()
             .domain(this.chartState.sizeDomain)
             .range(this.sizeRange)
-    }
-
-    private getPointRadius(value: number | undefined): number {
-        const radius =
-            value !== undefined
-                ? this.sizeScale(value)
-                : this.sizeScale.range()[0]
-
-        // We are enforcing the minimum radius/width just before render,
-        // it should not be enforced earlier than that.
-        return Math.max(
-            radius,
-            this.props.chartState.isConnected
-                ? SCATTER_LINE_MIN_WIDTH
-                : SCATTER_POINT_MIN_RADIUS
-        )
     }
 
     override render(): React.ReactElement {


### PR DESCRIPTION
I noticed that some unused private computed properties are currently not reported by CI, so I added `noUnusedLocals` to the ts config.