### PR TITLE
Switch useTopicTagGraph to useQuery

### DIFF
--- a/site/SiteHeader.tsx
+++ b/site/SiteHeader.tsx
@@ -4,6 +4,7 @@ import {
     ArchiveDataNavigation,
 } from "./archive/ArchiveNavigation.js"
 import { SiteNavigation } from "./SiteNavigation.js"
+import { SiteQueryClientProvider } from "./SiteQueryClientProvider.js"
 
 interface SiteHeaderProps {
     hideDonationFlag?: boolean
@@ -36,10 +37,12 @@ export const SiteHeaderNavigation = (props: SiteHeaderProps) => {
     }
 
     return (
-        <SiteNavigation
-            hideDonationFlag={props.hideDonationFlag}
-            isOnHomepage={props.isOnHomepage}
-        />
+        <SiteQueryClientProvider>
+            <SiteNavigation
+                hideDonationFlag={props.hideDonationFlag}
+                isOnHomepage={props.isOnHomepage}
+            />
+        </SiteQueryClientProvider>
     )
 }
 

--- a/site/SiteMobileMenu.tsx
+++ b/site/SiteMobileMenu.tsx
@@ -19,7 +19,7 @@ export const SiteMobileMenu = ({
     toggleMenu,
     className,
 }: {
-    tagGraph: TagGraphRoot | null
+    tagGraph?: TagGraphRoot
     menu: Menu | null
     toggleMenu: (menu: Menu) => void
     className?: string

--- a/site/SiteNavigation.tsx
+++ b/site/SiteNavigation.tsx
@@ -41,7 +41,7 @@ export const SiteNavigation = ({
 }) => {
     const [menu, setActiveMenu] = useState<Menu | null>(null)
     const [query, setQuery] = useState<string>("")
-    const tagGraph = useTopicTagGraph()
+    const { data: tagGraph } = useTopicTagGraph()
 
     const isActiveMobileMenu =
         menu !== null &&

--- a/site/SiteNavigationTopics.tsx
+++ b/site/SiteNavigationTopics.tsx
@@ -14,7 +14,7 @@ export const SiteNavigationTopics = ({
     onClose,
     className,
 }: {
-    tagGraph: TagGraphRoot | null
+    tagGraph?: TagGraphRoot
     onClose: () => void
     className?: string
 }) => {

--- a/site/search/Autocomplete.tsx
+++ b/site/search/Autocomplete.tsx
@@ -446,7 +446,8 @@ export function Autocomplete({
     const containerRef = useRef<HTMLDivElement>(null)
     const panelRootRef = useRef<Root | null>(null)
     const rootRef = useRef<HTMLElement | null>(null)
-    const { allTopics } = useTagGraphTopics(useTopicTagGraph())
+    const { data: topicTagGraph } = useTopicTagGraph()
+    const { allTopics } = useTagGraphTopics(topicTagGraph)
 
     const synonymMap = useMemo(() => buildSynonymMap(), [])
 

--- a/site/search/searchHooks.ts
+++ b/site/search/searchHooks.ts
@@ -7,11 +7,11 @@ import {
 } from "./searchUtils.js"
 import { DEFAULT_SEARCH_STATE } from "./searchState.js"
 import { useSearchContext } from "./SearchContext.js"
-import { flattenNonTopicNodes } from "@ourworldindata/utils"
-import { useInfiniteQuery } from "@tanstack/react-query"
+import { fetchJson, flattenNonTopicNodes } from "@ourworldindata/utils"
+import { useInfiniteQuery, useQuery } from "@tanstack/react-query"
 import { LiteClient } from "algoliasearch/lite"
 import type { SearchResponse } from "instantsearch.js"
-import { useState, useEffect, useMemo, useRef } from "react"
+import { useEffect, useMemo, useRef } from "react"
 import type { TagGraphNode, TagGraphRoot } from "@ourworldindata/types"
 import { SiteAnalytics } from "../SiteAnalytics.js"
 import * as R from "remeda"
@@ -30,7 +30,7 @@ export const useSelectedRegionNames = (): string[] => {
  * Extracts and memoizes area names and all searchable tags from the topic tag graph.
  * Searchable tags include both topics (tags with a topic page) and tags with searchableInAlgolia set.
  */
-export function useTagGraphTopics(topicTagGraph: TagGraphRoot | null): {
+export function useTagGraphTopics(topicTagGraph?: TagGraphRoot): {
     allAreas: string[]
     allTopics: string[]
 } {
@@ -207,21 +207,15 @@ export function useInfiniteSearch<T extends SearchResponse<U>, U>({
     }
 }
 
-export const useTopicTagGraph = () => {
-    const [tagGraph, setTagGraph] = useState<TagGraphRoot | null>(null)
-
-    useEffect(() => {
-        const fetchTagGraph = async () => {
-            const response = await fetch("/topicTagGraph.json")
-            const tagGraph = await response.json()
-            setTagGraph(flattenNonTopicNodes(tagGraph))
-        }
-        if (!tagGraph) {
-            fetchTagGraph().catch((err) => {
-                throw new Error(`Failed to fetch tag graph: ${err}`)
-            })
-        }
-    }, [tagGraph, setTagGraph])
-
-    return tagGraph
+export function useTopicTagGraph() {
+    return useQuery({
+        queryKey: ["topic-tag-graph"],
+        queryFn: async () => {
+            const tagGraph = await fetchJson<TagGraphRoot>(
+                "/topicTagGraph.json"
+            )
+            return flattenNonTopicNodes(tagGraph)
+        },
+        staleTime: Infinity,
+    })
 }


### PR DESCRIPTION
Avoids duplicate requests from two call sites and duplicating the data on the application level.