### PR TITLE
chore: update yarn

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,11 +1,15 @@
+approvedGitRepositories: []
+
 compressionLevel: mixed
 
 enableGlobalCache: false
+
+enableScripts: false
 
 logFilters:
   - code: YN0013
     level: discard
 
 nodeLinker: node-modules
-npmMinimalAgeGate: 4320 # 72 hours
-enableScripts: false
+
+npmMinimalAgeGate: 72h

--- a/bespoke/package.json
+++ b/bespoke/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
-    "packageManager": "yarn@4.10.3",
+    "packageManager": "yarn@4.14.1",
     "workspaces": [
         "components/",
         "hooks/",

--- a/bespoke/yarn.lock
+++ b/bespoke/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 8
+  version: 9
   cacheKey: 10
 
 "@formatjs/ecma402-abstract@npm:2.3.6":

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "engines": {
         "node": ">=22.0"
     },
-    "packageManager": "yarn@4.10.3",
+    "packageManager": "yarn@4.14.1",
     "scripts": {
         "batchTagWithGpt": "tsx --tsconfig tsconfig.tsx.json baker/batchTagWithGpt.ts",
         "buildArchive": "tsx --tsconfig tsconfig.tsx.json baker/archival/archiveChangedPages.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 8
+  version: 9
   cacheKey: 10
 
 "@adobe/css-tools@npm:^4.4.0":


### PR DESCRIPTION
the updated yarn sets `enableScripts: false` by default, and enables disallowing git repos as a source
