### PR TITLE
🐛 center narrative chart in articles

### DIFF
--- a/site/gdocs/components/NarrativeChart.tsx
+++ b/site/gdocs/components/NarrativeChart.tsx
@@ -79,31 +79,31 @@ export default function NarrativeChart({
             })}
             ref={refChartContainer}
         >
-            <figure
-                key={metadataStringified}
-                className={cx(GRAPHER_PREVIEW_CLASS, "chart")}
-                style={{
-                    width: "100%",
-                    border: "0px none",
-                    height: d.height,
-                }}
-                // MultiEmbedder should not kick in on archival pages.
-                {...(!isOnArchivalPage && {
-                    [GRAPHER_NARRATIVE_CHART_CONFIG_FIGURE_ATTR]:
-                        metadataStringified,
-                })}
+            <div
+                className="owid-chart-frame"
+                style={d.height ? { height: d.height } : undefined}
             >
-                <a href={linkTarget}>
-                    <img
-                        className="GrapherImage"
-                        src={imageSrc}
-                        alt={viewMetadata.title}
-                        width={DEFAULT_GRAPHER_WIDTH}
-                        height={DEFAULT_GRAPHER_HEIGHT}
-                        loading="lazy"
-                    />
-                </a>
-            </figure>
+                <figure
+                    key={metadataStringified}
+                    className={cx(GRAPHER_PREVIEW_CLASS, "chart")}
+                    // MultiEmbedder should not kick in on archival pages.
+                    {...(!isOnArchivalPage && {
+                        [GRAPHER_NARRATIVE_CHART_CONFIG_FIGURE_ATTR]:
+                            metadataStringified,
+                    })}
+                >
+                    <a href={linkTarget}>
+                        <img
+                            className="GrapherImage"
+                            src={imageSrc}
+                            alt={viewMetadata.title}
+                            width={DEFAULT_GRAPHER_WIDTH}
+                            height={DEFAULT_GRAPHER_HEIGHT}
+                            loading="lazy"
+                        />
+                    </a>
+                </figure>
+            </div>
             {d.caption ? (
                 <figcaption>
                     <SpanElements spans={d.caption} />

--- a/site/gdocs/components/NarrativeChart.tsx
+++ b/site/gdocs/components/NarrativeChart.tsx
@@ -81,7 +81,17 @@ export default function NarrativeChart({
         >
             <div
                 className="owid-chart-frame"
-                style={d.height ? { height: d.height } : undefined}
+                // On archival pages the static image is the permanent rendering,
+                // so let it dictate the height instead of forcing the live-Grapher
+                // default (which leaves blank space when the image's aspect ratio
+                // doesn't match the frame's, e.g. in column layouts).
+                style={
+                    isOnArchivalPage
+                        ? { height: "auto" }
+                        : d.height
+                          ? { height: d.height }
+                          : undefined
+                }
             >
                 <figure
                     key={metadataStringified}


### PR DESCRIPTION
## Summary

- Wrap the narrative-chart figure in `.owid-chart-frame` so it inherits the same centering rules as regular `Chart` embeds.
- Without the wrapper, the live `.GrapherComponent` kept its default `inline-block` ([grapher.scss:98-99](https://github.com/owid/owid-grapher/blob/master/packages/%40ourworldindata/grapher/src/core/grapher.scss#L98-L99)) and anchored at the left edge of the column. The `.owid-chart-frame .GrapherComponent { display: block; margin: 0 auto }` rule in `Chart.scss` now centers it the same way it does for regular charts.

## Pages with narrative charts to compare

Each of these articles uses both narrative charts and regular grapher embeds, so you can verify centering and that the two block types visually agree:

- https://narrative-chart-centering.owid.pages.dev/why-do-women-live-longer-than-men
- https://narrative-chart-centering.owid.pages.dev/democratic-rights
- https://narrative-chart-centering.owid.pages.dev/what-is-the-gini-coefficient

## Test plan

- [ ] On staging, confirm narrative charts on the three articles above are horizontally centered in their grid column (both before JS hydration, briefly visible, and after, when the live Grapher mounts).
- [ ] On the same articles, confirm regular Chart embeds, explorers, and any multi-dim charts are unchanged — they already use `.owid-chart-frame`, so this should be a no-op for them.
- [ ] Check at desktop and mobile widths (the outer wrapper still has `full-width-on-mobile`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
