### PR TITLE
🐛 strip dod links from metadata

### DIFF
--- a/functions/_common/metadataTools.ts
+++ b/functions/_common/metadataTools.ts
@@ -7,6 +7,7 @@ import {
     getCitationShort,
     getAttributionFragmentsFromVariable,
     getCitationLong,
+    stripDetailOnDemandLinks,
 } from "@ourworldindata/utils"
 import { getGrapherFilters } from "./urlTools.js"
 
@@ -200,5 +201,7 @@ export function assembleMetadata(
         ),
     }
 
-    return fullMetadata
+    return _.cloneDeepWith(fullMetadata, (value) =>
+        typeof value === "string" ? stripDetailOnDemandLinks(value) : undefined
+    )
 }

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -1938,7 +1938,9 @@ export function lowercaseObjectKeys(
  * #dod:text_underscored-and-hyphenated
  * Duplicated in parser.ts
  */
-export const detailOnDemandRegex = /#dod:([\w\-_]+)/
+export const detailOnDemandRegex = /#dod:([A-Za-z0-9_-]+)/
+
+export const detailOnDemandLinkRegex = /\[([^\]]+)\]\(#dod:([A-Za-z0-9_-]+)\)/g
 
 export const guidedChartRegex = /#guide:(https?:\/\/[^\s]+)/
 
@@ -1957,6 +1959,10 @@ export function extractDetailsFromSyntax(str: string): string[] {
     return [...str.matchAll(new RegExp(detailOnDemandRegex, "g"))].map(
         ([_, term]) => term
     )
+}
+
+export function stripDetailOnDemandLinks(str: string): string {
+    return str.replace(detailOnDemandLinkRegex, "$1")
 }
 
 /**

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -132,6 +132,7 @@ export {
     guidedChartRegex,
     plaintextCalloutRegex,
     extractDetailsFromSyntax,
+    stripDetailOnDemandLinks,
     parseFloatOrUndefined,
     bind,
     merge,


### PR DESCRIPTION
Resolves https://github.com/owid/owid-grapher/issues/6393 by stripping dod links from every field in metadata.json files

Example: http://staging-site-strip-dod-in-metadata/grapher/refugee-population-by-country-or-territory-of-asylum.metadata.json