### PR TITLE
Improve admin /explorers: type column, sorting, filter, hide Create

### DIFF
--- a/adminSiteClient/ExplorersListPage.tsx
+++ b/adminSiteClient/ExplorersListPage.tsx
@@ -13,7 +13,7 @@ import {
 import { observer } from "mobx-react"
 import { Component } from "react"
 import {
-    DefaultNewExplorerSlug,
+    // DefaultNewExplorerSlug, // re-enable when restoring the Create button
     ExplorerChartCreationMode,
     ExplorersRouteResponse,
     EXPLORERS_PREVIEW_ROUTE,
@@ -320,14 +320,14 @@ export class ExplorersIndexPage extends Component<{
                             Show only published
                         </label>
                     </div>
-                    <div style={{ textAlign: "right" }}>
+                    {/* <div style={{ textAlign: "right" }}>
                         <a
                             className="btn btn-primary"
                             href={`/admin/${EXPLORERS_ROUTE_FOLDER}/${DefaultNewExplorerSlug}`}
                         >
                             Create
                         </a>
-                    </div>
+                    </div> */}
                 </div>
                 <ExplorerList
                     explorers={explorersToShow}

--- a/adminSiteClient/ExplorersListPage.tsx
+++ b/adminSiteClient/ExplorersListPage.tsx
@@ -46,6 +46,9 @@ function explorerTypeBadge(mode: ExplorerChartCreationMode): {
     }
 }
 
+type SortColumn = "type" | "lastUpdated"
+type SortDirection = "asc" | "desc"
+
 @observer
 class ExplorerRow extends Component<ExplorerRowProps> {
     override render() {
@@ -158,16 +161,37 @@ interface ExplorerListProps {
 
 @observer
 class ExplorerList extends Component<ExplorerListProps> {
+    sortIndicator(column: SortColumn) {
+        const { indexPage } = this.props
+        if (indexPage.sortBy !== column) return null
+        return indexPage.sortDirection === "asc" ? " ↑" : " ↓"
+    }
+
     override render() {
         const { props } = this
+        const { indexPage } = props
+        const sortableHeaderStyle = {
+            cursor: "pointer",
+            userSelect: "none" as const,
+        }
         return (
             <table className="table table-bordered">
                 <thead>
                     <tr>
                         <th>Slug</th>
                         <th>Title</th>
-                        <th>Type</th>
-                        <th>Last Updated</th>
+                        <th
+                            style={sortableHeaderStyle}
+                            onClick={() => indexPage.onSort("type")}
+                        >
+                            Type{this.sortIndicator("type")}
+                        </th>
+                        <th
+                            style={sortableHeaderStyle}
+                            onClick={() => indexPage.onSort("lastUpdated")}
+                        >
+                            Last Updated{this.sortIndicator("lastUpdated")}
+                        </th>
                         <th></th>
                         <th></th>
                         <th></th>
@@ -200,6 +224,9 @@ export class ExplorersIndexPage extends Component<{
     numTotalRows: number | undefined = undefined
     searchInput: string | undefined = undefined
     highlightSearch: string | undefined = undefined
+    sortBy: SortColumn = "lastUpdated"
+    sortDirection: SortDirection = "desc"
+    showOnlyPublished = false
 
     constructor(props: { manager?: AdminManager }) {
         super(props)
@@ -211,19 +238,40 @@ export class ExplorersIndexPage extends Component<{
             searchInput: observable,
             highlightSearch: observable,
             isReady: observable,
+            sortBy: observable,
+            sortDirection: observable,
+            showOnlyPublished: observable,
         })
     }
 
     @computed get explorersToShow(): ExplorerProgram[] {
-        return _.orderBy(
-            this.explorers,
-            (program) => dayjs(program.lastCommit?.date).unix(),
-            ["desc"]
-        )
+        const filtered = this.showOnlyPublished
+            ? this.explorers.filter((exp) => exp.isPublished)
+            : this.explorers
+        const sortValue =
+            this.sortBy === "type"
+                ? (program: ExplorerProgram) =>
+                      explorerTypeBadge(program.chartCreationMode).label
+                : (program: ExplorerProgram) =>
+                      dayjs(program.lastCommit?.date).unix()
+        return _.orderBy(filtered, sortValue, [this.sortDirection])
     }
 
     @action.bound onShowMore() {
         this.maxVisibleRows += 100
+    }
+
+    @action.bound onSort(column: SortColumn) {
+        if (this.sortBy === column) {
+            this.sortDirection = this.sortDirection === "asc" ? "desc" : "asc"
+        } else {
+            this.sortBy = column
+            this.sortDirection = column === "lastUpdated" ? "desc" : "asc"
+        }
+    }
+
+    @action.bound onToggleShowOnlyPublished() {
+        this.showOnlyPublished = !this.showOnlyPublished
     }
 
     override render() {
@@ -254,6 +302,23 @@ export class ExplorersIndexPage extends Component<{
                     <div>
                         Showing {explorersToShow.length} of {numTotalRows}{" "}
                         explorers
+                    </div>
+                    <div>
+                        <label
+                            style={{
+                                marginBottom: 0,
+                                cursor: "pointer",
+                                userSelect: "none",
+                            }}
+                        >
+                            <input
+                                type="checkbox"
+                                checked={this.showOnlyPublished}
+                                onChange={this.onToggleShowOnlyPublished}
+                                style={{ marginRight: 6 }}
+                            />
+                            Show only published
+                        </label>
                     </div>
                     <div style={{ textAlign: "right" }}>
                         <a

--- a/adminSiteClient/ExplorersListPage.tsx
+++ b/adminSiteClient/ExplorersListPage.tsx
@@ -14,6 +14,7 @@ import { observer } from "mobx-react"
 import { Component } from "react"
 import {
     DefaultNewExplorerSlug,
+    ExplorerChartCreationMode,
     ExplorersRouteResponse,
     EXPLORERS_PREVIEW_ROUTE,
     EXPLORERS_ROUTE_FOLDER,
@@ -29,6 +30,20 @@ interface ExplorerRowProps {
     explorer: ExplorerProgram
     indexPage: ExplorersIndexPage
     searchHighlight?: (text: string) => any
+}
+
+function explorerTypeBadge(mode: ExplorerChartCreationMode): {
+    label: string
+    className: string
+} {
+    switch (mode) {
+        case ExplorerChartCreationMode.FromVariableIds:
+            return { label: "Indicator", className: "badge badge-success" }
+        case ExplorerChartCreationMode.FromGrapherId:
+            return { label: "Grapher", className: "badge badge-secondary" }
+        case ExplorerChartCreationMode.FromExplorerTableColumnSlugs:
+            return { label: "CSV", className: "badge badge-secondary" }
+    }
 }
 
 @observer
@@ -87,6 +102,14 @@ class ExplorerRow extends Component<ExplorerRowProps> {
                     </div>
                 </td>
                 <td>
+                    {(() => {
+                        const { label, className } = explorerTypeBadge(
+                            explorer.chartCreationMode
+                        )
+                        return <span className={className}>{label}</span>
+                    })()}
+                </td>
+                <td>
                     <div>{lastCommit?.message}</div>
                     <div style={{ fontSize: "80%", opacity: 0.8 }}>
                         <a>
@@ -143,6 +166,7 @@ class ExplorerList extends Component<ExplorerListProps> {
                     <tr>
                         <th>Slug</th>
                         <th>Title</th>
+                        <th>Type</th>
                         <th>Last Updated</th>
                         <th></th>
                         <th></th>


### PR DESCRIPTION
## Summary

- Added a **Type** column to the admin explorers table — colored badge per explorer (Indicator / Grapher / CSV), derived from the existing `ExplorerProgram.chartCreationMode` getter (no server or DB changes).
- Made the **Type** and **Last Updated** column headers sortable, with ↑/↓ indicators. Default sort remains Last Updated descending.
- Added a **Show only published** checkbox in the page header to filter the list.
- Hid the **Create** button (commented out, not deleted) so it can be easily restored later.
  - Manual explorers are not being created anymore.


| **PROD** (status quo) |  **STAGING** |
|--|--|
|<img width="1331" height="398" alt="image" src="https://github.com/user-attachments/assets/3fc50b61-68d1-4ce0-9e33-891884612626" />|<img width="1329" height="425" alt="image" src="https://github.com/user-attachments/assets/b576ee68-e544-4ec0-b4b5-fd6736e6eaad" />|

## Why?
We are migrating explorers into ETL (https://github.com/owid/etl/issues/6028) and want to gradually migrate them to MDIMs later. Keeping a good track of explorers is important, including their types.

## Test plan

- [x] Visit `/admin/explorers` and confirm the new **Type** column appears between Title and Last Updated.
- [x] Spot-check a few explorers: ones using `yVariableIds` show **Indicator** (green), ones using `grapherId` show **Grapher**, ones using `tableSlug` / inline CSV show **CSV**.
- [x] Click the **Type** header — list re-sorts alphabetically; click again to reverse; ↑/↓ indicator updates.
- [x] Click **Last Updated** header — same toggling behavior.
- [x] Toggle **Show only published** — list filters down to published explorers and back.
- [x] Confirm the **Create** button is no longer visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)