### PR TITLE
Fix useTopicTagGraph in admin preview, no. 2

### DIFF
--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -85,6 +85,7 @@ import {
 } from "./apiRoutes/suggest.js"
 import {
     handleGetFlatTagGraph,
+    handleGetTopicTagGraph,
     handlePostTagGraph,
 } from "./apiRoutes/tagGraph.js"
 import {
@@ -538,6 +539,11 @@ getRouteWithROTransaction(
     apiRouter,
     "/flatTagGraph.json",
     handleGetFlatTagGraph
+)
+getRouteWithROTransaction(
+    apiRouter,
+    "/topicTagGraph.json",
+    handleGetTopicTagGraph
 )
 postRouteWithRWTransaction(apiRouter, "/tagGraph", handlePostTagGraph)
 getRouteWithROTransaction(apiRouter, "/tags/:tagId.json", getTagById)

--- a/adminSiteServer/apiRoutes/tagGraph.ts
+++ b/adminSiteServer/apiRoutes/tagGraph.ts
@@ -1,4 +1,4 @@
-import { JsonError, FlatTagGraph } from "@ourworldindata/types"
+import { JsonError, FlatTagGraph, TagGraphRoot } from "@ourworldindata/types"
 import * as db from "../../db/db.js"
 import * as R from "remeda"
 import { Request } from "../authentication.js"
@@ -11,6 +11,14 @@ export async function handleGetFlatTagGraph(
 ) {
     const flatTagGraph = await db.getFlatTagGraph(trx)
     return flatTagGraph
+}
+
+export async function handleGetTopicTagGraph(
+    req: Request,
+    res: HandlerResponse,
+    trx: db.KnexReadonlyTransaction
+): Promise<TagGraphRoot> {
+    return db.generateTopicTagGraph(trx)
 }
 
 export async function handlePostTagGraph(

--- a/site/SiteHeader.tsx
+++ b/site/SiteHeader.tsx
@@ -15,6 +15,7 @@ interface SiteHeaderProps {
 
     // If this is an archived page, we need to render a different version of the site header
     archiveInfo?: ArchiveMetaInformation
+    isPreviewing?: boolean
 }
 
 export const SiteHeaderNavigation = (props: SiteHeaderProps) => {
@@ -41,6 +42,7 @@ export const SiteHeaderNavigation = (props: SiteHeaderProps) => {
             <SiteNavigation
                 hideDonationFlag={props.hideDonationFlag}
                 isOnHomepage={props.isOnHomepage}
+                isPreviewing={props.isPreviewing}
             />
         </SiteQueryClientProvider>
     )

--- a/site/SiteNavigation.tsx
+++ b/site/SiteNavigation.tsx
@@ -35,13 +35,17 @@ const HAS_DONATION_FLAG = false
 export const SiteNavigation = ({
     hideDonationFlag,
     isOnHomepage,
+    isPreviewing,
 }: {
     hideDonationFlag?: boolean
     isOnHomepage?: boolean
+    isPreviewing?: boolean
 }) => {
     const [menu, setActiveMenu] = useState<Menu | null>(null)
     const [query, setQuery] = useState<string>("")
-    const { data: tagGraph } = useTopicTagGraph()
+    const { data: tagGraph } = useTopicTagGraph({
+        isPreviewing: Boolean(isPreviewing),
+    })
 
     const isActiveMobileMenu =
         menu !== null &&
@@ -189,6 +193,7 @@ export const SiteNavigation = ({
                                     isActive={menu === Menu.Search}
                                     onClose={closeOverlay}
                                     onActivate={setSearchAsActiveMenu}
+                                    isPreviewing={isPreviewing}
                                 />
                             )}
                             <SiteNavigationToggle

--- a/site/SiteSearchNavigation.tsx
+++ b/site/SiteSearchNavigation.tsx
@@ -5,10 +5,12 @@ export const SiteSearchNavigation = ({
     isActive,
     onClose,
     onActivate,
+    isPreviewing,
 }: {
     isActive: boolean
     onClose: VoidFunction
     onActivate: VoidFunction
+    isPreviewing?: boolean
 }) => {
     return (
         <div className={cx("SiteSearchNavigation", { active: isActive })}>
@@ -16,6 +18,7 @@ export const SiteSearchNavigation = ({
                 onActivate={onActivate}
                 onClose={onClose}
                 placeholder="Search for a topic, chart or article..."
+                isPreviewing={isPreviewing}
             />
         </div>
     )

--- a/site/gdocs/OwidGdocPage.tsx
+++ b/site/gdocs/OwidGdocPage.tsx
@@ -243,6 +243,7 @@ export default function OwidGdocPage({
                 <SiteHeader
                     isOnHomepage={gdoc.content.type === OwidGdocType.Homepage}
                     archiveInfo={isOnArchivalPage ? archiveContext : undefined}
+                    isPreviewing={isPreviewing}
                 />
                 <div id="owid-document-root">
                     <AriaAnnouncerProvider>

--- a/site/gdocs/components/HomepageSearch.tsx
+++ b/site/gdocs/components/HomepageSearch.tsx
@@ -1,6 +1,7 @@
 import { useContext } from "react"
 import { Autocomplete } from "../../search/Autocomplete.js"
 import { AttachmentsContext } from "../AttachmentsContext.js"
+import { useDocumentContext } from "../DocumentContext.js"
 import { commafyNumber } from "@ourworldindata/utils"
 import { SEARCH_BASE_PATH } from "../../search/searchUtils.js"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
@@ -14,6 +15,7 @@ import { BAKED_BASE_URL } from "../../../settings/clientSettings.js"
 
 export function HomepageSearch(props: { className?: string }) {
     const { homepageMetadata } = useContext(AttachmentsContext)
+    const { isPreviewing } = useDocumentContext()
     const chartCount = homepageMetadata?.chartCount
     const topicCount = homepageMetadata?.topicCount
     const explorerCount = homepageMetadata?.explorerCount
@@ -80,6 +82,7 @@ export function HomepageSearch(props: { className?: string }) {
             <Autocomplete
                 className="span-cols-6 col-start-5 span-md-cols-10 col-md-start-3 span-sm-cols-12 col-sm-start-2"
                 panelClassName="homepage-search__panel"
+                isPreviewing={isPreviewing}
             />
             <div className="span-cols-14 homepage-search__links-and-tagline">
                 {message}

--- a/site/runSiteFooterScripts.tsx
+++ b/site/runSiteFooterScripts.tsx
@@ -233,7 +233,13 @@ function runFootnotes() {
     })
 }
 
-function runSiteNavigation(hideDonationFlag?: boolean) {
+function runSiteNavigation({
+    hideDonationFlag,
+    isPreviewing,
+}: {
+    hideDonationFlag?: boolean
+    isPreviewing?: boolean
+} = {}) {
     const siteNavigationElem = document.querySelector(".site-navigation-root")
     if (siteNavigationElem) {
         let isOnHomepage = false
@@ -257,6 +263,7 @@ function runSiteNavigation(hideDonationFlag?: boolean) {
                         ? archiveInfo
                         : undefined
                 }
+                isPreviewing={isPreviewing}
             />
         )
     }
@@ -325,7 +332,7 @@ export const runSiteFooterScriptsForArchive = (args: SiteFooterScriptsArgs) => {
         case SiteFooterContext.dataPageV2:
             hydrateDataPageV2Content({ isPreviewing })
             // runAllGraphersLoadedListener()
-            runSiteNavigation()
+            runSiteNavigation({ isPreviewing })
             // runSiteTools()
             // runCookiePreferencesManager()
             void runDetailsOnDemand()
@@ -333,14 +340,14 @@ export const runSiteFooterScriptsForArchive = (args: SiteFooterScriptsArgs) => {
         case SiteFooterContext.multiDimDataPage:
             hydrateMultiDimDataPageContent(isPreviewing)
             // runAllGraphersLoadedListener()
-            runSiteNavigation()
+            runSiteNavigation({ isPreviewing })
             // runSiteTools()
             // runCookiePreferencesManager()
             void runDetailsOnDemand()
             break
         case SiteFooterContext.grapherPage:
         case SiteFooterContext.explorerPage:
-            runSiteNavigation()
+            runSiteNavigation({ isPreviewing })
             // runAllGraphersLoadedListener()
             // runSiteTools()
             // runCookiePreferencesManager()
@@ -349,7 +356,7 @@ export const runSiteFooterScriptsForArchive = (args: SiteFooterScriptsArgs) => {
         case SiteFooterContext.gdocsDocument:
             hydrateOwidGdoc(debug, isPreviewing)
             // runAllGraphersLoadedListener()
-            runSiteNavigation()
+            runSiteNavigation({ isPreviewing })
             runFootnotes()
             void runDetailsOnDemand()
             // runSiteTools()
@@ -375,7 +382,7 @@ export const runSiteFooterScripts = async (
         case SiteFooterContext.dataPageV2:
             hydrateDataPageV2Content({ isPreviewing })
             runAllGraphersLoadedListener()
-            runSiteNavigation(hideDonationFlag)
+            runSiteNavigation({ hideDonationFlag, isPreviewing })
             runSiteTools()
             runCookiePreferencesManager()
             runUserSurveyWidget()
@@ -384,7 +391,7 @@ export const runSiteFooterScripts = async (
         case SiteFooterContext.multiDimDataPage:
             hydrateMultiDimDataPageContent(isPreviewing)
             runAllGraphersLoadedListener()
-            runSiteNavigation(hideDonationFlag)
+            runSiteNavigation({ hideDonationFlag, isPreviewing })
             runSiteTools()
             runCookiePreferencesManager()
             runUserSurveyWidget()
@@ -392,7 +399,7 @@ export const runSiteFooterScripts = async (
             break
         case SiteFooterContext.grapherPage:
         case SiteFooterContext.explorerPage:
-            runSiteNavigation(hideDonationFlag)
+            runSiteNavigation({ hideDonationFlag, isPreviewing })
             runAllGraphersLoadedListener()
             runSiteTools()
             runCookiePreferencesManager()
@@ -401,14 +408,14 @@ export const runSiteFooterScripts = async (
             break
         case SiteFooterContext.explorerIndexPage:
             hydrateExplorerIndex()
-            runSiteNavigation()
+            runSiteNavigation({ isPreviewing })
             runCookiePreferencesManager()
             runSiteTools()
             break
         case SiteFooterContext.gdocsDocument:
             hydrateOwidGdoc(debug, isPreviewing)
             runAllGraphersLoadedListener()
-            runSiteNavigation(hideDonationFlag)
+            runSiteNavigation({ hideDonationFlag, isPreviewing })
             runFootnotes()
             void runDetailsOnDemand()
             runSiteTools()
@@ -417,7 +424,7 @@ export const runSiteFooterScripts = async (
             break
         case SiteFooterContext.latestPage:
             hydrateLatestPage()
-            runSiteNavigation(hideDonationFlag)
+            runSiteNavigation({ hideDonationFlag, isPreviewing })
             runSiteTools()
             runCookiePreferencesManager()
             void runDetailsOnDemand()
@@ -439,7 +446,7 @@ export const runSiteFooterScripts = async (
         default:
             // Features that were not ported over to gdocs, are only being run on WP pages:
             // - embedding charts through MultiEmbedderSingleton.embedAll()
-            runSiteNavigation(hideDonationFlag)
+            runSiteNavigation({ hideDonationFlag, isPreviewing })
             hydrateCodeSnippets()
             MultiEmbedderSingleton.embedAll(isPreviewing)
             runAllGraphersLoadedListener()

--- a/site/search/Autocomplete.tsx
+++ b/site/search/Autocomplete.tsx
@@ -436,17 +436,21 @@ export function Autocomplete({
     className,
     placeholder = DEFAULT_SEARCH_PLACEHOLDER,
     panelClassName,
+    isPreviewing,
 }: {
     onActivate?: () => void
     onClose?: () => void
     className?: string
     placeholder?: string
     panelClassName?: string
+    isPreviewing?: boolean
 }) {
     const containerRef = useRef<HTMLDivElement>(null)
     const panelRootRef = useRef<Root | null>(null)
     const rootRef = useRef<HTMLElement | null>(null)
-    const { data: topicTagGraph } = useTopicTagGraph()
+    const { data: topicTagGraph } = useTopicTagGraph({
+        isPreviewing: Boolean(isPreviewing),
+    })
     const { allTopics } = useTagGraphTopics(topicTagGraph)
 
     const synonymMap = useMemo(() => buildSynonymMap(), [])

--- a/site/search/searchHooks.ts
+++ b/site/search/searchHooks.ts
@@ -14,7 +14,6 @@ import type { SearchResponse } from "instantsearch.js"
 import { useEffect, useMemo, useRef } from "react"
 import type { TagGraphNode, TagGraphRoot } from "@ourworldindata/types"
 import { SiteAnalytics } from "../SiteAnalytics.js"
-import { BAKED_BASE_URL } from "../../settings/clientSettings.js"
 import * as R from "remeda"
 
 export const useSelectedTopic = (): string | undefined => {
@@ -208,14 +207,14 @@ export function useInfiniteSearch<T extends SearchResponse<U>, U>({
     }
 }
 
-export function useTopicTagGraph() {
+export function useTopicTagGraph({ isPreviewing }: { isPreviewing: boolean }) {
     return useQuery({
-        queryKey: ["topic-tag-graph"],
+        queryKey: ["topic-tag-graph", isPreviewing],
         queryFn: async () => {
-            const tagGraph = await fetchJson<TagGraphRoot>(
-                // We have to use an absolute URL for the admin preview.
-                `${BAKED_BASE_URL}/topicTagGraph.json`
-            )
+            const url = isPreviewing
+                ? "/admin/api/topicTagGraph.json"
+                : "/topicTagGraph.json"
+            const tagGraph = await fetchJson<TagGraphRoot>(url)
             return flattenNonTopicNodes(tagGraph)
         },
         staleTime: Infinity,


### PR DESCRIPTION
Use a same-origin admin API endpoint for preview mode instead of fetching the public baked JSON, avoiding CORS issues on admin. We take the same approach for details on demand.

This is a second attempt at the fix.

## Testing guidance

It's very hard to test it outside of prod because only there we run the admin on a different domain, but it should be a low risk change.