### PR TITLE
🐛 add charts index shrinking to fit algolia's max record size

### DIFF
--- a/baker/algolia/indexExplorerViewsMdimViewsAndChartsToAlgolia.ts
+++ b/baker/algolia/indexExplorerViewsMdimViewsAndChartsToAlgolia.ts
@@ -14,6 +14,7 @@ import {
     createFeaturedMetricRecords,
     MAX_NON_FM_RECORD_SCORE,
     scaleRecordScores,
+    shrinkRecordsToFitAlgoliaLimit,
 } from "./utils/shared.js"
 import { getChartsRecords } from "./utils/charts.js"
 import { createBaseIndexingContext } from "./utils/context.js"
@@ -22,7 +23,10 @@ import { getMdimViewRecords } from "./utils/mdimViews.js"
 import { reportFeaturedMetricFailuresToSlack } from "./utils/slackReport.js"
 
 const indexExplorerViewsMdimViewsAndChartsToAlgolia = async () => {
-    if (!ALGOLIA_INDEXING) return
+    if (!ALGOLIA_INDEXING) {
+        console.log("ALGOLIA_INDEXING is not enabled. Skipping indexing.")
+        return
+    }
     const indexName = CHARTS_INDEX
     console.log(
         `Indexing explorer views and charts to the "${indexName}" index on Algolia`
@@ -63,11 +67,12 @@ const indexExplorerViewsMdimViewsAndChartsToAlgolia = async () => {
                 ...scaledExplorerViews,
                 ...scaledMdimViews,
             ]
+            const shrunkRecords = shrinkRecordsToFitAlgoliaLimit(records)
             const { records: featuredMetricRecords, failures } =
-                await createFeaturedMetricRecords(trx, records)
+                await createFeaturedMetricRecords(trx, shrunkRecords)
 
             return {
-                records: [...records, ...featuredMetricRecords],
+                records: [...shrunkRecords, ...featuredMetricRecords],
                 failures,
             }
         },

--- a/baker/algolia/utils/shared.ts
+++ b/baker/algolia/utils/shared.ts
@@ -64,6 +64,56 @@ export const processAvailableEntities = (
     )
 }
 
+// Algolia rejects records larger than 20,000 bytes. We aim for a slightly lower
+// target to leave headroom for any size differences between our serialization
+// and Algolia's. Records exceeding this are almost always blown up by a very
+// long `availableEntities` array (e.g. the "fish-stocks" explorer), so we shrink that
+// field — which is pre-sorted by priority in `processAvailableEntities` — until
+// the record fits.
+const ALGOLIA_TARGET_RECORD_BYTES = 19500
+
+const byteLength = (value: unknown): number =>
+    Buffer.byteLength(JSON.stringify(value), "utf8")
+
+export function shrinkRecordsToFitAlgoliaLimit<
+    T extends { availableEntities: string[]; objectID: string },
+>(records: T[]): T[] {
+    return records.map(shrinkRecordToFitAlgoliaLimit)
+}
+
+function shrinkRecordToFitAlgoliaLimit<
+    T extends { availableEntities: string[]; objectID: string },
+>(record: T): T {
+    const size = byteLength(record)
+    if (size <= ALGOLIA_TARGET_RECORD_BYTES) return record
+
+    const baseSize = byteLength({ ...record, availableEntities: [] })
+    const entitiesBudget = ALGOLIA_TARGET_RECORD_BYTES - baseSize
+
+    if (entitiesBudget <= 0) {
+        console.warn(
+            `Record ${record.objectID} exceeds Algolia size limit (${size} bytes) even with availableEntities removed (${baseSize} bytes). Algolia may reject it.`
+        )
+        return { ...record, availableEntities: [] }
+    }
+
+    const truncated: string[] = []
+    // Account for surrounding `[]`
+    let runningSize = 2
+    for (const entity of record.availableEntities) {
+        const entrySize = byteLength(entity) + (truncated.length > 0 ? 1 : 0) // comma
+        if (runningSize + entrySize > entitiesBudget) break
+        truncated.push(entity)
+        runningSize += entrySize
+    }
+
+    console.warn(
+        `Record ${record.objectID} exceeded Algolia size limit (${size} bytes); kept ${truncated.length}/${record.availableEntities.length} availableEntities to fit.`
+    )
+
+    return { ...record, availableEntities: truncated }
+}
+
 export const parseJsonStringArray = (
     raw: string | null | undefined
 ): string[] => {


### PR DESCRIPTION
The [fish stocks explorer](https://ourworldindata.org/explorers/fish-stocks) was recently migrated to be indicator-based, which fixed its metadata such that its `availableEntities` are now included in its Algolia records. This drove its records' size over Algolia's maximum of 20,000 bytes, which crashed the indexing script.

This PR fixes that by adding a "shrink records" function which serializes records and, if the record is too large, clears `availableEntities` and adds them one-by-one till it's at the max size.

For now, this will only affect the fish stocks explorer, which is already a weird case to support because no one will search `country:Albacore Tuna`, but at least we're future-proofed against such cases in the future.