### PR TITLE
✨ (auto map brackets) pick log scales less often

### DIFF
--- a/packages/@ourworldindata/grapher/src/color/BinningStrategies.ts
+++ b/packages/@ourworldindata/grapher/src/color/BinningStrategies.ts
@@ -70,10 +70,11 @@ interface BinningStrategyOutput {
     midpoint?: number
 }
 
-// If the log10 difference between the min and max values is less than or equal to 1.2,
-// the data is considered to be close enough in magnitude to use equal-size bins.
-// This threshold was chosen empirically.
-const AUTO_EQUAL_BINS_MAX_MAGNITUDE_DIFF = 1.2
+// If the log10 difference between the min and max values is less than or equal
+// to 3, the data is considered to be close enough in magnitude to use equal-size bins.
+// This threshold was chosen empirically by aiming for a 75% / 25% split between
+// equal-size and log bins across our charts.
+const AUTO_EQUAL_BINS_MAX_MAGNITUDE_DIFF = 3
 
 /**
  * Calculates the log10 difference between two numbers, i.e. compute x such that lowerValue * 10^x = upperValue.


### PR DESCRIPTION
AUTO_EQUAL_BINS_MAX_MAGNITUDE_DIFF is chosen such that the split between linear/log is 75%/25% for our Grapher charts (context: [Notion doc](https://www.notion.so/owid/2026-05-12-Map-bracket-auto-binning-Default-to-log-scales-less-often-35e74b71f92e802999d5e752e33ce0b7?source=copy_link))