### PR TITLE
🎉 dumbbell legend

### DIFF
--- a/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChart.tsx
+++ b/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChart.tsx
@@ -405,17 +405,17 @@ export class DumbbellChart
     }
 
     @computed private get topLegendHeight(): number {
-        // We can't use `pairLegendState` here due to a circular dependency
-        if (!this.legendLabels) return 0
-
         if (this.shouldShowCategoricalLegend)
             return this.categoricalLegend.height
 
-        // The pair legend doesn't linebreak
-        return (
-            this.pairLegendLabelStyle.fontSize *
-            this.pairLegendLabelStyle.lineHeight
-        )
+        if (this.shouldShowPairLegend)
+            // The pair legend doesn't linebreak
+            return (
+                this.pairLegendLabelStyle.fontSize *
+                this.pairLegendLabelStyle.lineHeight
+            )
+
+        return 0
     }
 
     @computed private get topLegendHeightWithPadding(): number {
@@ -521,20 +521,31 @@ export class DumbbellChart
         ]
     }
 
-    @computed private get shouldShowCategoricalLegend(): boolean {
+    /**
+     * Whether the pair legend labels can fit side by side. Note that we
+     * can't use `pairLegendState.hasOverlap` here due to a circular dependency.
+     */
+    @computed private get pairLegendFits(): boolean {
         if (!this.legendLabels) return false
-        if (this.chartState.seriesStrategy === SeriesStrategy.entity)
-            return false
-
-        // Check if the two labels fit next to each other. If not, show the
-        // categorical legend instead of the in-chart pair legend. Note that
-        // we can't use `pairLegendState.hasOverlap` here due to a circular
-        // dependency
         const { start, end } = this.legendLabels
         const labelWidths =
             textWidth(start.text, this.pairLegendLabelStyle) +
             textWidth(end.text, this.pairLegendLabelStyle)
-        return labelWidths + MIN_LEGEND_LABEL_GAP > this.bounds.width
+        return labelWidths + MIN_LEGEND_LABEL_GAP <= this.bounds.width
+    }
+
+    @computed private get shouldShowPairLegend(): boolean {
+        return this.pairLegendFits && !!this.pairLegendState
+    }
+
+    @computed private get shouldShowCategoricalLegend(): boolean {
+        // In column mode, fall back to a categorical legend when the pair
+        // labels don't fit. In entity mode, no legend is shown in that case.
+        return (
+            !!this.legendLabels &&
+            !this.pairLegendFits &&
+            this.chartState.seriesStrategy === SeriesStrategy.column
+        )
     }
 
     @computed
@@ -556,7 +567,7 @@ export class DumbbellChart
     private renderLegend(): React.ReactElement | null {
         if (this.shouldShowCategoricalLegend)
             return <HorizontalCategoricalColorLegend manager={this} />
-        if (this.pairLegendState)
+        if (this.shouldShowPairLegend && this.pairLegendState)
             return (
                 <HorizontalLabelPair
                     state={this.pairLegendState}

--- a/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChart.tsx
+++ b/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChart.tsx
@@ -481,26 +481,40 @@ export class DumbbellChart
                 )
                 .exhaustive()
 
+        // Shift outward-anchored labels inward by a bit
+        const offsetMagnitude = Math.floor(
+            Math.abs(topSeries.end.x - topSeries.start.x) / 4
+        )
+        const inwardOffset = (textAnchor: HorizontalAlign): number =>
+            match(textAnchor)
+                .with(HorizontalAlign.right, () => offsetMagnitude)
+                .with(HorizontalAlign.left, () => -offsetMagnitude)
+                .with(HorizontalAlign.center, () => 0)
+                .exhaustive()
+
+        const startAnchor = resolveTextAnchor({
+            label: legendLabels.start,
+            head: topSeries.start,
+            otherHead: topSeries.end,
+        })
+        const endAnchor = resolveTextAnchor({
+            label: legendLabels.end,
+            head: topSeries.end,
+            otherHead: topSeries.start,
+        })
+
         return [
             {
                 text: legendLabels.start.text,
-                x: topSeries.start.x,
+                x: topSeries.start.x + inwardOffset(startAnchor),
                 color: legendLabels.start.color,
-                textAnchor: resolveTextAnchor({
-                    label: legendLabels.start,
-                    head: topSeries.start,
-                    otherHead: topSeries.end,
-                }),
+                textAnchor: startAnchor,
             },
             {
                 text: legendLabels.end.text,
-                x: topSeries.end.x,
+                x: topSeries.end.x + inwardOffset(endAnchor),
                 color: legendLabels.end.color,
-                textAnchor: resolveTextAnchor({
-                    label: legendLabels.end,
-                    head: topSeries.end,
-                    otherHead: topSeries.start,
-                }),
+                textAnchor: endAnchor,
             },
         ]
     }

--- a/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChart.tsx
+++ b/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChart.tsx
@@ -4,11 +4,13 @@ import React from "react"
 import { match } from "ts-pattern"
 import {
     Bounds,
+    HorizontalAlign,
     makeFigmaId,
     exposeInstanceOnWindow,
     ScaleType,
     SeriesStrategy,
     formatValue,
+    Pair,
 } from "@ourworldindata/utils"
 import {
     DumbbellValueLabelMode,
@@ -44,6 +46,11 @@ import {
     VALUE_LABEL_DOT_GAP,
     ENTITY_LABEL_CHART_GAP,
     DumbbellValueLabel,
+    TOP_LEGEND_BOTTOM_PADDING,
+    START_COLUMN_COLOR,
+    END_COLUMN_COLOR,
+    LegendLabel,
+    PlacedDumbbellHead,
 } from "./DumbbellChartConstants"
 import { DumbbellChartState } from "./DumbbellChartState"
 import { ChartComponentProps } from "../chart/ChartTypeMap"
@@ -57,6 +64,9 @@ import {
 import { AnimatedRows } from "../animation/AnimatedRows"
 import { roundFontSize, textWidth } from "../chart/ChartUtils.js"
 import { GRAPHER_LIGHT_TEXT } from "../color/ColorConstants.js"
+import { HorizontalLabelPair } from "../horizontalLabelPair/HorizontalLabelPair.js"
+import { HorizontalLabelPairState } from "../horizontalLabelPair/HorizontalLabelPairState.js"
+import { InitialHorizontalLabel } from "../horizontalLabelPair/HorizontalLabelPairTypes.js"
 
 export type DumbbellChartProps = ChartComponentProps<DumbbellChartState>
 
@@ -83,6 +93,10 @@ export class DumbbellChart
         return (this.props.bounds ?? DEFAULT_GRAPHER_BOUNDS).padBottom(2)
     }
 
+    @computed private get boundsWithoutLegend(): Bounds {
+        return this.bounds.padTop(this.legendHeightWithPadding)
+    }
+
     @computed get fontSize(): number {
         return this.manager.fontSize ?? BASE_FONT_SIZE
     }
@@ -92,14 +106,19 @@ export class DumbbellChart
     }
 
     @computed private get availableHeightPerSeries(): number {
-        return this.bounds.height / this.series.length
+        return this.boundsWithoutLegend.height / this.series.length
     }
 
     @computed private get entityLabelStyle(): FontSettings {
+        // Slightly overestimates the height available for a series
+        // because `bounds` is used instead of `boundsWithoutLegend`
+        // due to a circular dependency
+        const availableHeightPerSeries = this.bounds.height / this.series.length
+
         const fontSize = roundFontSize(
             Math.min(
                 GRAPHER_FONT_SCALE_12 * this.fontSize,
-                1.1 * this.availableHeightPerSeries
+                availableHeightPerSeries
             )
         )
 
@@ -110,6 +129,14 @@ export class DumbbellChart
         const fontSize = this.entityLabelStyle.fontSize - 0.5
 
         return { fontSize, fontWeight: 400, lineHeight: 1 }
+    }
+
+    @computed private get legendLabelStyle(): FontSettings {
+        return {
+            fontSize: this.valueLabelStyle.fontSize,
+            fontWeight: 700,
+            lineHeight: 1,
+        }
     }
 
     private buildValueLabel(text: string): DumbbellValueLabel {
@@ -264,7 +291,7 @@ export class DumbbellChart
 
     /** Bounds minus entity labels */
     @computed get axisBounds(): Bounds {
-        return this.bounds.padLeft(
+        return this.boundsWithoutLegend.padLeft(
             this.entityLabelMaxWidth + ENTITY_LABEL_CHART_GAP
         )
     }
@@ -329,6 +356,118 @@ export class DumbbellChart
         })
     }
 
+    @computed get legendLabels():
+        | { start: LegendLabel; end: LegendLabel }
+        | undefined {
+        const { showLegend = true } = this.manager
+
+        if (!showLegend || this.series.length === 0) return undefined
+
+        return match(this.chartState.seriesStrategy)
+            .with(SeriesStrategy.entity, () => {
+                const { formatColumn, startTime, endTime } = this.chartState
+                return {
+                    start: {
+                        text: formatColumn.formatTime(startTime),
+                        color: GRAPHER_LIGHT_TEXT,
+                        textAnchor: "center",
+                    } satisfies LegendLabel,
+                    end: {
+                        text: formatColumn.formatTime(endTime),
+                        color: GRAPHER_LIGHT_TEXT,
+                        textAnchor: "center",
+                    } satisfies LegendLabel,
+                }
+            })
+            .with(SeriesStrategy.column, () => {
+                const [startColumn, endColumn] = this.chartState.yColumns
+                if (!startColumn || !endColumn) return undefined
+                return {
+                    start: {
+                        text: startColumn.nonEmptyDisplayName,
+                        color: START_COLUMN_COLOR,
+                        textAnchor: "outward",
+                    } satisfies LegendLabel,
+                    end: {
+                        text: endColumn.nonEmptyDisplayName,
+                        color: END_COLUMN_COLOR,
+                        textAnchor: "outward",
+                    } satisfies LegendLabel,
+                }
+            })
+            .exhaustive()
+    }
+
+    @computed private get legendHeight(): number {
+        // We can't use `legendState` here due to a circular dependency
+        if (!this.legendLabels) return 0
+        // Since the legend doesn't linebreak
+        return this.legendLabelStyle.fontSize * this.legendLabelStyle.lineHeight
+    }
+
+    @computed private get legendHeightWithPadding(): number {
+        return this.legendHeight
+            ? this.legendHeight + TOP_LEGEND_BOTTOM_PADDING
+            : 0
+    }
+
+    @computed private get legendSeries():
+        | Pair<InitialHorizontalLabel>
+        | undefined {
+        if (!this.legendLabels) return undefined
+
+        const labels = this.legendLabels
+        const sortedSeries = _.sortBy(this.placedSeries, (series) => series.y)
+
+        // Find the top-most series that has a visible change
+        const topSeries =
+            sortedSeries.find((s) => s.start.x !== s.end.x) ?? sortedSeries[0]
+
+        if (!labels || !topSeries) return undefined
+
+        const resolveTextAnchor = (
+            label: LegendLabel,
+            head: PlacedDumbbellHead,
+            otherHead: PlacedDumbbellHead
+        ): HorizontalAlign => {
+            if (label.textAnchor === "center") return HorizontalAlign.center
+            const startIsLeft = head.x <= otherHead.x
+            return startIsLeft ? HorizontalAlign.right : HorizontalAlign.left
+        }
+
+        return [
+            {
+                text: labels.start.text,
+                x: topSeries.start.x,
+                color: labels.start.color,
+                textAnchor: resolveTextAnchor(
+                    labels.start,
+                    topSeries.start,
+                    topSeries.end
+                ),
+            },
+            {
+                text: labels.end.text,
+                x: topSeries.end.x,
+                color: labels.end.color,
+                textAnchor: resolveTextAnchor(
+                    labels.end,
+                    topSeries.end,
+                    topSeries.start
+                ),
+            },
+        ]
+    }
+
+    @computed private get legendState(): HorizontalLabelPairState | undefined {
+        if (!this.legendSeries) return undefined
+
+        return new HorizontalLabelPairState(this.legendSeries, {
+            xRange: [this.bounds.left, this.bounds.right],
+            fontSettings: this.legendLabelStyle,
+        })
+    }
+
     private formatValue(
         value: number,
         options?: TickFormattingOptions
@@ -344,7 +483,7 @@ export class DumbbellChart
         return (
             <>
                 <DumbbellChartAxis
-                    bounds={this.bounds}
+                    bounds={this.boundsWithoutLegend}
                     dataBounds={this.dataBounds}
                     axis={this.axis}
                 />
@@ -361,6 +500,12 @@ export class DumbbellChart
                         />
                     ))}
                 </g>
+                {this.legendState && (
+                    <HorizontalLabelPair
+                        state={this.legendState}
+                        y={this.bounds.top}
+                    />
+                )}
             </>
         )
     }
@@ -372,7 +517,7 @@ export class DumbbellChart
         return (
             <g>
                 <DumbbellChartAxis
-                    bounds={this.bounds}
+                    bounds={this.boundsWithoutLegend}
                     dataBounds={this.dataBounds}
                     axis={this.axis}
                 />
@@ -394,6 +539,12 @@ export class DumbbellChart
                         />
                     )}
                 />
+                {this.legendState && (
+                    <HorizontalLabelPair
+                        state={this.legendState}
+                        y={this.bounds.top}
+                    />
+                )}
             </g>
         )
     }

--- a/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChart.tsx
+++ b/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChart.tsx
@@ -67,7 +67,7 @@ import { roundFontSize, textWidth } from "../chart/ChartUtils.js"
 import { GRAPHER_LIGHT_TEXT } from "../color/ColorConstants.js"
 import { HorizontalLabelPair } from "../horizontalLabelPair/HorizontalLabelPair.js"
 import { HorizontalLabelPairState } from "../horizontalLabelPair/HorizontalLabelPairState.js"
-import { InitialHorizontalLabel } from "../horizontalLabelPair/HorizontalLabelPairTypes.js"
+import { HorizontalLabel } from "../horizontalLabelPair/HorizontalLabelPairTypes.js"
 import {
     HorizontalCategoricalColorLegend,
     HorizontalColorLegendManager,
@@ -75,6 +75,8 @@ import {
 import { CategoricalBin } from "../color/ColorScaleBin.js"
 
 export type DumbbellChartProps = ChartComponentProps<DumbbellChartState>
+
+type TopLegendType = "inline" | "categorical" | "none"
 
 @observer
 export class DumbbellChart
@@ -369,53 +371,75 @@ export class DumbbellChart
 
         if (!showLegend || this.series.length === 0) return undefined
 
-        return match(this.chartState.seriesStrategy)
-            .with(SeriesStrategy.entity, () => {
-                const { formatColumn, startTime, endTime } = this.chartState
-                return {
-                    start: {
-                        text: formatColumn.formatTime(startTime),
-                        color: GRAPHER_LIGHT_TEXT,
-                        textAnchor: "center",
-                    } satisfies LegendLabel,
-                    end: {
-                        text: formatColumn.formatTime(endTime),
-                        color: GRAPHER_LIGHT_TEXT,
-                        textAnchor: "center",
-                    } satisfies LegendLabel,
-                }
-            })
-            .with(SeriesStrategy.column, () => {
-                const [startColumn, endColumn] = this.chartState.yColumns
-                if (!startColumn || !endColumn) return undefined
-                return {
-                    start: {
-                        text: startColumn.nonEmptyDisplayName,
-                        color: START_COLUMN_COLOR,
-                        textAnchor: "outward",
-                    } satisfies LegendLabel,
-                    end: {
-                        text: endColumn.nonEmptyDisplayName,
-                        color: END_COLUMN_COLOR,
-                        textAnchor: "outward",
-                    } satisfies LegendLabel,
-                }
-            })
-            .exhaustive()
+        return (
+            match(this.chartState.seriesStrategy)
+                // In entity mode, the legend labels are the start and end times
+                .with(SeriesStrategy.entity, () => {
+                    const { formatColumn, startTime, endTime } = this.chartState
+                    return {
+                        start: {
+                            text: formatColumn.formatTime(startTime),
+                            color: GRAPHER_LIGHT_TEXT,
+                            textAnchor: "center",
+                        } satisfies LegendLabel,
+                        end: {
+                            text: formatColumn.formatTime(endTime),
+                            color: GRAPHER_LIGHT_TEXT,
+                            textAnchor: "center",
+                        } satisfies LegendLabel,
+                    }
+                })
+                // In column mode, the legend labels are the two columns
+                .with(SeriesStrategy.column, () => {
+                    const [startColumn, endColumn] = this.chartState.yColumns
+                    if (!startColumn || !endColumn) return undefined
+                    return {
+                        start: {
+                            text: startColumn.nonEmptyDisplayName,
+                            color: START_COLUMN_COLOR,
+                            textAnchor: "outward",
+                        } satisfies LegendLabel,
+                        end: {
+                            text: endColumn.nonEmptyDisplayName,
+                            color: END_COLUMN_COLOR,
+                            textAnchor: "outward",
+                        } satisfies LegendLabel,
+                    }
+                })
+                .exhaustive()
+        )
+    }
+
+    /** Whether the inline legend labels can fit side by side */
+    @computed private get inlineLegendFits(): boolean {
+        if (!this.legendLabels) return false
+        const { start, end } = this.legendLabels
+        // We can't use `inlineLegendState.hasOverlap` here due to a circular dependency
+        const labelWidths =
+            textWidth(start.text, this.inlineLegendLabelStyle) +
+            textWidth(end.text, this.inlineLegendLabelStyle)
+        return labelWidths + MIN_LEGEND_LABEL_GAP <= this.bounds.width
+    }
+
+    @computed private get topLegendType(): TopLegendType {
+        if (!this.legendLabels) return "none"
+        if (this.inlineLegendFits) return "inline"
+        // In column mode, fall back to a categorical legend when the inline
+        // labels don't fit. In entity mode, no legend is shown in that case.
+        return this.chartState.isEntityStrategy ? "none" : "categorical"
     }
 
     @computed private get topLegendHeight(): number {
-        if (this.shouldShowCategoricalLegend)
-            return this.categoricalLegend.height
-
-        if (this.shouldShowInlineLegend)
-            // The inline legend doesn't linebreak
-            return (
-                this.inlineLegendLabelStyle.fontSize *
-                this.inlineLegendLabelStyle.lineHeight
+        return match(this.topLegendType)
+            .with(
+                "inline",
+                () =>
+                    this.inlineLegendLabelStyle.fontSize *
+                    this.inlineLegendLabelStyle.lineHeight
             )
-
-        return 0
+            .with("categorical", () => this.categoricalLegend.height)
+            .with("none", () => 0)
+            .exhaustive()
     }
 
     @computed private get topLegendHeightWithPadding(): number {
@@ -425,49 +449,58 @@ export class DumbbellChart
     }
 
     @computed private get inlineLegendSeries():
-        | Pair<InitialHorizontalLabel>
+        | Pair<HorizontalLabel>
         | undefined {
-        if (!this.legendLabels) return undefined
+        const { legendLabels, topLegendType } = this
 
-        const labels = this.legendLabels
+        if (!legendLabels || topLegendType !== "inline") return undefined
+
         const sortedSeries = _.sortBy(this.placedSeries, (series) => series.y)
 
         // Find the top-most series that has a visible change
         const topSeries =
             sortedSeries.find((s) => s.start.x !== s.end.x) ?? sortedSeries[0]
 
-        if (!labels || !topSeries) return undefined
+        if (!topSeries) return undefined
 
-        const resolveTextAnchor = (
-            label: LegendLabel,
-            head: PlacedDumbbellHead,
+        const resolveTextAnchor = ({
+            label,
+            head,
+            otherHead,
+        }: {
+            label: LegendLabel
+            head: PlacedDumbbellHead
             otherHead: PlacedDumbbellHead
-        ): HorizontalAlign => {
-            if (label.textAnchor === "center") return HorizontalAlign.center
-            const startIsLeft = head.x <= otherHead.x
-            return startIsLeft ? HorizontalAlign.right : HorizontalAlign.left
-        }
+        }): HorizontalAlign =>
+            match(label.textAnchor)
+                .with("center", () => HorizontalAlign.center)
+                .with("outward", () =>
+                    head.x <= otherHead.x
+                        ? HorizontalAlign.right
+                        : HorizontalAlign.left
+                )
+                .exhaustive()
 
         return [
             {
-                text: labels.start.text,
+                text: legendLabels.start.text,
                 x: topSeries.start.x,
-                color: labels.start.color,
-                textAnchor: resolveTextAnchor(
-                    labels.start,
-                    topSeries.start,
-                    topSeries.end
-                ),
+                color: legendLabels.start.color,
+                textAnchor: resolveTextAnchor({
+                    label: legendLabels.start,
+                    head: topSeries.start,
+                    otherHead: topSeries.end,
+                }),
             },
             {
-                text: labels.end.text,
+                text: legendLabels.end.text,
                 x: topSeries.end.x,
-                color: labels.end.color,
-                textAnchor: resolveTextAnchor(
-                    labels.end,
-                    topSeries.end,
-                    topSeries.start
-                ),
+                color: legendLabels.end.color,
+                textAnchor: resolveTextAnchor({
+                    label: legendLabels.end,
+                    head: topSeries.end,
+                    otherHead: topSeries.start,
+                }),
             },
         ]
     }
@@ -483,8 +516,6 @@ export class DumbbellChart
             minGap: MIN_LEGEND_LABEL_GAP,
         })
     }
-
-    // HorizontalColorLegendManager
 
     @computed get legendX(): number {
         return this.bounds.left
@@ -503,7 +534,8 @@ export class DumbbellChart
     }
 
     @computed get categoricalLegendData(): CategoricalBin[] {
-        if (!this.legendLabels) return []
+        if (!this.legendLabels || this.topLegendType !== "categorical")
+            return []
         const { start, end } = this.legendLabels
         return [
             new CategoricalBin({
@@ -519,33 +551,6 @@ export class DumbbellChart
                 color: end.color,
             }),
         ]
-    }
-
-    /**
-     * Whether the inline legend labels can fit side by side. Note that we
-     * can't use `inlineLegendState.hasOverlap` here due to a circular dependency.
-     */
-    @computed private get inlineLegendFits(): boolean {
-        if (!this.legendLabels) return false
-        const { start, end } = this.legendLabels
-        const labelWidths =
-            textWidth(start.text, this.inlineLegendLabelStyle) +
-            textWidth(end.text, this.inlineLegendLabelStyle)
-        return labelWidths + MIN_LEGEND_LABEL_GAP <= this.bounds.width
-    }
-
-    @computed private get shouldShowInlineLegend(): boolean {
-        return !!this.legendLabels && this.inlineLegendFits
-    }
-
-    @computed private get shouldShowCategoricalLegend(): boolean {
-        // In column mode, fall back to a categorical legend when the inline
-        // labels don't fit. In entity mode, no legend is shown in that case.
-        return (
-            !!this.legendLabels &&
-            !this.inlineLegendFits &&
-            this.chartState.seriesStrategy === SeriesStrategy.column
-        )
     }
 
     @computed
@@ -565,16 +570,20 @@ export class DumbbellChart
     }
 
     private renderLegend(): React.ReactElement | null {
-        if (this.shouldShowCategoricalLegend)
-            return <HorizontalCategoricalColorLegend manager={this} />
-        if (this.shouldShowInlineLegend && this.inlineLegendState)
-            return (
-                <HorizontalLabelPair
-                    state={this.inlineLegendState}
-                    y={this.bounds.top}
-                />
+        return match(this.topLegendType)
+            .with("categorical", () => (
+                <HorizontalCategoricalColorLegend manager={this} />
+            ))
+            .with("inline", () =>
+                this.inlineLegendState ? (
+                    <HorizontalLabelPair
+                        state={this.inlineLegendState}
+                        y={this.bounds.top}
+                    />
+                ) : null
             )
-        return null
+            .with("none", () => null)
+            .exhaustive()
     }
 
     private renderStatic(): React.ReactElement {

--- a/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChart.tsx
+++ b/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChart.tsx
@@ -51,6 +51,7 @@ import {
     END_COLUMN_COLOR,
     LegendLabel,
     PlacedDumbbellHead,
+    MIN_LEGEND_LABEL_GAP,
 } from "./DumbbellChartConstants"
 import { DumbbellChartState } from "./DumbbellChartState"
 import { ChartComponentProps } from "../chart/ChartTypeMap"
@@ -67,13 +68,18 @@ import { GRAPHER_LIGHT_TEXT } from "../color/ColorConstants.js"
 import { HorizontalLabelPair } from "../horizontalLabelPair/HorizontalLabelPair.js"
 import { HorizontalLabelPairState } from "../horizontalLabelPair/HorizontalLabelPairState.js"
 import { InitialHorizontalLabel } from "../horizontalLabelPair/HorizontalLabelPairTypes.js"
+import {
+    HorizontalCategoricalColorLegend,
+    HorizontalColorLegendManager,
+} from "../legend/HorizontalColorLegends.js"
+import { CategoricalBin } from "../color/ColorScaleBin.js"
 
 export type DumbbellChartProps = ChartComponentProps<DumbbellChartState>
 
 @observer
 export class DumbbellChart
     extends React.Component<DumbbellChartProps>
-    implements ChartInterface, AxisManager
+    implements ChartInterface, AxisManager, HorizontalColorLegendManager
 {
     constructor(props: DumbbellChartProps) {
         super(props)
@@ -94,7 +100,7 @@ export class DumbbellChart
     }
 
     @computed private get boundsWithoutLegend(): Bounds {
-        return this.bounds.padTop(this.legendHeightWithPadding)
+        return this.bounds.padTop(this.topLegendHeightWithPadding)
     }
 
     @computed get fontSize(): number {
@@ -131,7 +137,7 @@ export class DumbbellChart
         return { fontSize, fontWeight: 400, lineHeight: 1 }
     }
 
-    @computed private get legendLabelStyle(): FontSettings {
+    @computed private get pairLegendLabelStyle(): FontSettings {
         return {
             fontSize: this.valueLabelStyle.fontSize,
             fontWeight: 700,
@@ -398,20 +404,27 @@ export class DumbbellChart
             .exhaustive()
     }
 
-    @computed private get legendHeight(): number {
-        // We can't use `legendState` here due to a circular dependency
+    @computed private get topLegendHeight(): number {
+        // We can't use `pairLegendState` here due to a circular dependency
         if (!this.legendLabels) return 0
-        // Since the legend doesn't linebreak
-        return this.legendLabelStyle.fontSize * this.legendLabelStyle.lineHeight
+
+        if (this.shouldShowCategoricalLegend)
+            return this.categoricalLegend.height
+
+        // The pair legend doesn't linebreak
+        return (
+            this.pairLegendLabelStyle.fontSize *
+            this.pairLegendLabelStyle.lineHeight
+        )
     }
 
-    @computed private get legendHeightWithPadding(): number {
-        return this.legendHeight
-            ? this.legendHeight + TOP_LEGEND_BOTTOM_PADDING
+    @computed private get topLegendHeightWithPadding(): number {
+        return this.topLegendHeight
+            ? this.topLegendHeight + TOP_LEGEND_BOTTOM_PADDING
             : 0
     }
 
-    @computed private get legendSeries():
+    @computed private get pairLegendSeries():
         | Pair<InitialHorizontalLabel>
         | undefined {
         if (!this.legendLabels) return undefined
@@ -459,13 +472,74 @@ export class DumbbellChart
         ]
     }
 
-    @computed private get legendState(): HorizontalLabelPairState | undefined {
-        if (!this.legendSeries) return undefined
+    @computed private get pairLegendState():
+        | HorizontalLabelPairState
+        | undefined {
+        if (!this.pairLegendSeries) return undefined
 
-        return new HorizontalLabelPairState(this.legendSeries, {
+        return new HorizontalLabelPairState(this.pairLegendSeries, {
             xRange: [this.bounds.left, this.bounds.right],
-            fontSettings: this.legendLabelStyle,
+            fontSettings: this.pairLegendLabelStyle,
+            minGap: MIN_LEGEND_LABEL_GAP,
         })
+    }
+
+    // HorizontalColorLegendManager
+
+    @computed get legendX(): number {
+        return this.bounds.left
+    }
+
+    @computed get categoryLegendY(): number {
+        return this.bounds.top
+    }
+
+    @computed get legendWidth(): number {
+        return this.bounds.width
+    }
+
+    @computed get legendAlign(): HorizontalAlign {
+        return HorizontalAlign.left
+    }
+
+    @computed get categoricalLegendData(): CategoricalBin[] {
+        if (!this.legendLabels) return []
+        const { start, end } = this.legendLabels
+        return [
+            new CategoricalBin({
+                index: 0,
+                value: start.text,
+                label: start.text,
+                color: start.color,
+            }),
+            new CategoricalBin({
+                index: 1,
+                value: end.text,
+                label: end.text,
+                color: end.color,
+            }),
+        ]
+    }
+
+    @computed private get shouldShowCategoricalLegend(): boolean {
+        if (!this.legendLabels) return false
+        if (this.chartState.seriesStrategy === SeriesStrategy.entity)
+            return false
+
+        // Check if the two labels fit next to each other. If not, show the
+        // categorical legend instead of the in-chart pair legend. Note that
+        // we can't use `pairLegendState.hasOverlap` here due to a circular
+        // dependency
+        const { start, end } = this.legendLabels
+        const labelWidths =
+            textWidth(start.text, this.pairLegendLabelStyle) +
+            textWidth(end.text, this.pairLegendLabelStyle)
+        return labelWidths + MIN_LEGEND_LABEL_GAP > this.bounds.width
+    }
+
+    @computed
+    private get categoricalLegend(): HorizontalCategoricalColorLegend {
+        return new HorizontalCategoricalColorLegend({ manager: this })
     }
 
     private formatValue(
@@ -477,6 +551,19 @@ export class DumbbellChart
 
     override componentDidMount(): void {
         exposeInstanceOnWindow(this)
+    }
+
+    private renderLegend(): React.ReactElement | null {
+        if (this.shouldShowCategoricalLegend)
+            return <HorizontalCategoricalColorLegend manager={this} />
+        if (this.pairLegendState)
+            return (
+                <HorizontalLabelPair
+                    state={this.pairLegendState}
+                    y={this.bounds.top}
+                />
+            )
+        return null
     }
 
     private renderStatic(): React.ReactElement {
@@ -500,12 +587,7 @@ export class DumbbellChart
                         />
                     ))}
                 </g>
-                {this.legendState && (
-                    <HorizontalLabelPair
-                        state={this.legendState}
-                        y={this.bounds.top}
-                    />
-                )}
+                {this.renderLegend()}
             </>
         )
     }
@@ -539,12 +621,7 @@ export class DumbbellChart
                         />
                     )}
                 />
-                {this.legendState && (
-                    <HorizontalLabelPair
-                        state={this.legendState}
-                        y={this.bounds.top}
-                    />
-                )}
+                {this.renderLegend()}
             </g>
         )
     }

--- a/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChart.tsx
+++ b/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChart.tsx
@@ -76,7 +76,7 @@ import { CategoricalBin } from "../color/ColorScaleBin.js"
 
 export type DumbbellChartProps = ChartComponentProps<DumbbellChartState>
 
-type TopLegendType = "inline" | "categorical" | "none"
+type TopLegendType = "inline" | "swatches" | "none"
 
 @observer
 export class DumbbellChart
@@ -426,7 +426,7 @@ export class DumbbellChart
         if (this.inlineLegendFits) return "inline"
         // In column mode, fall back to a categorical legend when the inline
         // labels don't fit. In entity mode, no legend is shown in that case.
-        return this.chartState.isEntityStrategy ? "none" : "categorical"
+        return this.chartState.isEntityStrategy ? "none" : "swatches"
     }
 
     @computed private get topLegendHeight(): number {
@@ -437,7 +437,7 @@ export class DumbbellChart
                     this.inlineLegendLabelStyle.fontSize *
                     this.inlineLegendLabelStyle.lineHeight
             )
-            .with("categorical", () => this.categoricalLegend.height)
+            .with("swatches", () => this.categoricalLegend.height)
             .with("none", () => 0)
             .exhaustive()
     }
@@ -548,8 +548,7 @@ export class DumbbellChart
     }
 
     @computed get categoricalLegendData(): CategoricalBin[] {
-        if (!this.legendLabels || this.topLegendType !== "categorical")
-            return []
+        if (!this.legendLabels || this.topLegendType !== "swatches") return []
         const { start, end } = this.legendLabels
         return [
             new CategoricalBin({
@@ -585,7 +584,7 @@ export class DumbbellChart
 
     private renderLegend(): React.ReactElement | null {
         return match(this.topLegendType)
-            .with("categorical", () => (
+            .with("swatches", () => (
                 <HorizontalCategoricalColorLegend manager={this} />
             ))
             .with("inline", () =>

--- a/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChart.tsx
+++ b/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChart.tsx
@@ -137,7 +137,7 @@ export class DumbbellChart
         return { fontSize, fontWeight: 400, lineHeight: 1 }
     }
 
-    @computed private get pairLegendLabelStyle(): FontSettings {
+    @computed private get inlineLegendLabelStyle(): FontSettings {
         return {
             fontSize: this.valueLabelStyle.fontSize,
             fontWeight: 700,
@@ -408,11 +408,11 @@ export class DumbbellChart
         if (this.shouldShowCategoricalLegend)
             return this.categoricalLegend.height
 
-        if (this.shouldShowPairLegend)
-            // The pair legend doesn't linebreak
+        if (this.shouldShowInlineLegend)
+            // The inline legend doesn't linebreak
             return (
-                this.pairLegendLabelStyle.fontSize *
-                this.pairLegendLabelStyle.lineHeight
+                this.inlineLegendLabelStyle.fontSize *
+                this.inlineLegendLabelStyle.lineHeight
             )
 
         return 0
@@ -424,7 +424,7 @@ export class DumbbellChart
             : 0
     }
 
-    @computed private get pairLegendSeries():
+    @computed private get inlineLegendSeries():
         | Pair<InitialHorizontalLabel>
         | undefined {
         if (!this.legendLabels) return undefined
@@ -472,14 +472,14 @@ export class DumbbellChart
         ]
     }
 
-    @computed private get pairLegendState():
+    @computed private get inlineLegendState():
         | HorizontalLabelPairState
         | undefined {
-        if (!this.pairLegendSeries) return undefined
+        if (!this.inlineLegendSeries) return undefined
 
-        return new HorizontalLabelPairState(this.pairLegendSeries, {
+        return new HorizontalLabelPairState(this.inlineLegendSeries, {
             xRange: [this.bounds.left, this.bounds.right],
-            fontSettings: this.pairLegendLabelStyle,
+            fontSettings: this.inlineLegendLabelStyle,
             minGap: MIN_LEGEND_LABEL_GAP,
         })
     }
@@ -522,28 +522,28 @@ export class DumbbellChart
     }
 
     /**
-     * Whether the pair legend labels can fit side by side. Note that we
-     * can't use `pairLegendState.hasOverlap` here due to a circular dependency.
+     * Whether the inline legend labels can fit side by side. Note that we
+     * can't use `inlineLegendState.hasOverlap` here due to a circular dependency.
      */
-    @computed private get pairLegendFits(): boolean {
+    @computed private get inlineLegendFits(): boolean {
         if (!this.legendLabels) return false
         const { start, end } = this.legendLabels
         const labelWidths =
-            textWidth(start.text, this.pairLegendLabelStyle) +
-            textWidth(end.text, this.pairLegendLabelStyle)
+            textWidth(start.text, this.inlineLegendLabelStyle) +
+            textWidth(end.text, this.inlineLegendLabelStyle)
         return labelWidths + MIN_LEGEND_LABEL_GAP <= this.bounds.width
     }
 
-    @computed private get shouldShowPairLegend(): boolean {
-        return this.pairLegendFits && !!this.pairLegendState
+    @computed private get shouldShowInlineLegend(): boolean {
+        return !!this.legendLabels && this.inlineLegendFits
     }
 
     @computed private get shouldShowCategoricalLegend(): boolean {
-        // In column mode, fall back to a categorical legend when the pair
+        // In column mode, fall back to a categorical legend when the inline
         // labels don't fit. In entity mode, no legend is shown in that case.
         return (
             !!this.legendLabels &&
-            !this.pairLegendFits &&
+            !this.inlineLegendFits &&
             this.chartState.seriesStrategy === SeriesStrategy.column
         )
     }
@@ -567,10 +567,10 @@ export class DumbbellChart
     private renderLegend(): React.ReactElement | null {
         if (this.shouldShowCategoricalLegend)
             return <HorizontalCategoricalColorLegend manager={this} />
-        if (this.shouldShowPairLegend && this.pairLegendState)
+        if (this.shouldShowInlineLegend && this.inlineLegendState)
             return (
                 <HorizontalLabelPair
-                    state={this.pairLegendState}
+                    state={this.inlineLegendState}
                     y={this.bounds.top}
                 />
             )

--- a/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChartConstants.ts
+++ b/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChartConstants.ts
@@ -14,6 +14,9 @@ export const VALUE_LABEL_DOT_GAP = 6
 /** Horizontal gap between entity labels and the chart area */
 export const ENTITY_LABEL_CHART_GAP = 8
 
+/** Vertical gap between the top legend and the chart area */
+export const TOP_LEGEND_BOTTOM_PADDING = 4
+
 export const NO_CHANGE_COLOR = OWID_NO_DATA_GRAY
 
 export const INCREASE_COLOR = "#00875E"
@@ -93,4 +96,10 @@ export const DUMBBELL_STYLE: Record<Emphasis, DumbbellStyle> = {
     [Emphasis.Elevated]: DEFAULT_DUMBBELL_STYLE,
     [Emphasis.Highlighted]: DEFAULT_DUMBBELL_STYLE,
     [Emphasis.Muted]: { opacity: GRAPHER_OPACITY_MUTED },
+}
+
+export interface LegendLabel {
+    text: string
+    color: string
+    textAnchor: "center" | "outward"
 }

--- a/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChartConstants.ts
+++ b/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChartConstants.ts
@@ -17,6 +17,9 @@ export const ENTITY_LABEL_CHART_GAP = 8
 /** Vertical gap between the top legend and the chart area */
 export const TOP_LEGEND_BOTTOM_PADDING = 4
 
+/** Minimum horizontal gap between legend labels */
+export const MIN_LEGEND_LABEL_GAP = 8
+
 export const NO_CHANGE_COLOR = OWID_NO_DATA_GRAY
 
 export const INCREASE_COLOR = "#00875E"

--- a/packages/@ourworldindata/grapher/src/horizontalLabelPair/HorizontalLabelPair.tsx
+++ b/packages/@ourworldindata/grapher/src/horizontalLabelPair/HorizontalLabelPair.tsx
@@ -1,0 +1,27 @@
+import React from "react"
+import { TextWrapSvg } from "@ourworldindata/components"
+import { makeFigmaId } from "@ourworldindata/utils"
+import { HorizontalLabelPairState } from "./HorizontalLabelPairState.js"
+import { GRAPHER_DARK_TEXT } from "../color/ColorConstants.js"
+
+export function HorizontalLabelPair({
+    state,
+    y,
+}: {
+    state: HorizontalLabelPairState
+    y: number
+}): React.ReactElement {
+    return (
+        <g id={makeFigmaId("horizontal-label-pair")}>
+            {state.placedSeries.map((series, i) => (
+                <TextWrapSvg
+                    key={`${series}-${i}`}
+                    textWrap={series.textWrap}
+                    x={series.bounds.left}
+                    y={y}
+                    fill={series.color ?? GRAPHER_DARK_TEXT}
+                />
+            ))}
+        </g>
+    )
+}

--- a/packages/@ourworldindata/grapher/src/horizontalLabelPair/HorizontalLabelPair.tsx
+++ b/packages/@ourworldindata/grapher/src/horizontalLabelPair/HorizontalLabelPair.tsx
@@ -7,9 +7,11 @@ import { GRAPHER_DARK_TEXT } from "../color/ColorConstants.js"
 export function HorizontalLabelPair({
     state,
     y,
+    color = GRAPHER_DARK_TEXT,
 }: {
     state: HorizontalLabelPairState
     y: number
+    color?: string
 }): React.ReactElement {
     return (
         <g id={makeFigmaId("horizontal-label-pair")}>
@@ -19,7 +21,7 @@ export function HorizontalLabelPair({
                     textWrap={series.textWrap}
                     x={series.bounds.left}
                     y={y}
-                    fill={series.color ?? GRAPHER_DARK_TEXT}
+                    fill={series.color ?? color}
                 />
             ))}
         </g>

--- a/packages/@ourworldindata/grapher/src/horizontalLabelPair/HorizontalLabelPairState.test.ts
+++ b/packages/@ourworldindata/grapher/src/horizontalLabelPair/HorizontalLabelPairState.test.ts
@@ -1,0 +1,277 @@
+import { describe, expect, it } from "vitest"
+import { HorizontalAlign, Pair } from "@ourworldindata/utils"
+import {
+    HorizontalLabelPairOptions,
+    HorizontalLabelPairState,
+} from "./HorizontalLabelPairState"
+import { InitialHorizontalLabel } from "./HorizontalLabelPairTypes"
+import { textWidth } from "../chart/ChartUtils.js"
+
+const defaultFontSettings = { fontSize: 12, fontWeight: 400, lineHeight: 1 }
+
+const makeHorizontalLabelPairState = (
+    series: Pair<InitialHorizontalLabel>,
+    options: Partial<HorizontalLabelPairOptions> = {}
+): HorizontalLabelPairState => {
+    return new HorizontalLabelPairState(series, {
+        xRange: options.xRange ?? [0, 1000],
+        fontSettings: defaultFontSettings,
+        ...options,
+    })
+}
+
+it("honors textAnchor", () => {
+    const state = makeHorizontalLabelPairState([
+        { text: "Left", x: 200, textAnchor: HorizontalAlign.left },
+        { text: "Right", x: 800, textAnchor: HorizontalAlign.right },
+    ])
+    expect(state.placedSeries[0].bounds.left).toBe(200)
+    expect(state.placedSeries[1].bounds.right).toBeCloseTo(800)
+
+    // Center anchor
+    const centered = makeHorizontalLabelPairState([
+        { text: "Centered left", x: 200, textAnchor: HorizontalAlign.center },
+        { text: "Centered right", x: 800, textAnchor: HorizontalAlign.center },
+    ])
+    expect(centered.placedSeries[0].bounds.centerX).toBeCloseTo(200)
+    expect(centered.placedSeries[1].bounds.centerX).toBeCloseTo(800)
+})
+
+it("returns labels in left-to-right spatial order", () => {
+    // Pass inputs in reversed spatial order; output should still be left-first
+    const state = makeHorizontalLabelPairState([
+        { text: "Right", x: 900 },
+        { text: "Left", x: 100 },
+    ])
+    expect(state.placedSeries[0].text).toEqual("Left")
+    expect(state.placedSeries[1].text).toEqual("Right")
+})
+
+it("clamps labels that would overflow xRange", () => {
+    const xRange: [number, number] = [0, 1000]
+
+    const state = makeHorizontalLabelPairState(
+        [
+            { text: "Left label", x: 1, textAnchor: HorizontalAlign.center },
+            { text: "Right label", x: 999, textAnchor: HorizontalAlign.center },
+        ],
+        { xRange }
+    )
+    expect(state.placedSeries[0].bounds.left).toBe(xRange[0])
+    expect(state.placedSeries[1].bounds.right).toBe(xRange[1])
+})
+
+it("enforces minGap between overlapping labels", () => {
+    const minGap = 10
+    const state = makeHorizontalLabelPairState(
+        [
+            { text: "Left", x: 500, textAnchor: HorizontalAlign.center },
+            { text: "Right", x: 500, textAnchor: HorizontalAlign.center },
+        ],
+        { minGap }
+    )
+    const [left, right] = state.placedSeries
+    expect(right.bounds.left - left.bounds.right).toBeCloseTo(minGap)
+})
+
+it("reports hasOverlap when minGap can't be satisfied", () => {
+    const state = makeHorizontalLabelPairState(
+        [
+            {
+                text: "Some long label",
+                x: 50,
+                textAnchor: HorizontalAlign.right,
+            },
+            {
+                text: "Another long label",
+                x: 50,
+                textAnchor: HorizontalAlign.left,
+            },
+        ],
+        // Not enough horizontal space to fit both labels with the required minGap
+        { xRange: [0, 150], minGap: 10 }
+    )
+
+    expect(state.hasOverlap).toBe(true)
+})
+
+describe("label placement when textAnchor is center", () => {
+    // Enough space to fit both labels below
+    const xRange: [number, number] = [0, 500]
+    const minGap = 10
+
+    const firstLabel = "First label"
+    const secondLabel = "Second label"
+
+    const firstLabelWidth = textWidth(firstLabel, defaultFontSettings)
+
+    it("places labels at their anchor positions when there's no overlap", () => {
+        const state = makeHorizontalLabelPairState(
+            [
+                {
+                    text: firstLabel,
+                    x: 100,
+                    textAnchor: HorizontalAlign.center,
+                },
+                {
+                    text: secondLabel,
+                    x: 400,
+                    textAnchor: HorizontalAlign.center,
+                },
+            ],
+            { xRange, minGap }
+        )
+
+        expect(state.hasOverlap).toBe(false)
+        expect(state.placedSeries[0].bounds.centerX).toBeCloseTo(100)
+        expect(state.placedSeries[1].bounds.centerX).toBeCloseTo(400)
+    })
+
+    it("resolves overlap between labels", () => {
+        const state = makeHorizontalLabelPairState(
+            [
+                {
+                    text: firstLabel,
+                    x: 250,
+                    textAnchor: HorizontalAlign.center,
+                },
+                {
+                    text: secondLabel,
+                    x: 250,
+                    textAnchor: HorizontalAlign.center,
+                },
+            ],
+
+            { xRange, minGap }
+        )
+
+        expect(state.hasOverlap).toBe(false)
+        expect(state.placedSeries[0].bounds.centerX).toBeCloseTo(215, 0)
+        expect(state.placedSeries[1].bounds.centerX).toBeCloseTo(285, 0)
+    })
+
+    it("resolves overlap close to the left edge", () => {
+        const state = makeHorizontalLabelPairState(
+            [
+                { text: firstLabel, x: 5, textAnchor: HorizontalAlign.center },
+                {
+                    text: secondLabel,
+                    x: 10,
+                    textAnchor: HorizontalAlign.center,
+                },
+            ],
+            { xRange, minGap }
+        )
+
+        expect(state.hasOverlap).toBe(false)
+        expect(state.placedSeries[0].bounds.left).toBe(0)
+        expect(state.placedSeries[1].bounds.left).toBeCloseTo(
+            firstLabelWidth + minGap
+        )
+    })
+
+    it("resolves overlap close to the right edge", () => {
+        const state = makeHorizontalLabelPairState(
+            [
+                {
+                    text: firstLabel,
+                    x: 495,
+                    textAnchor: HorizontalAlign.center,
+                },
+                {
+                    text: secondLabel,
+                    x: 490,
+                    textAnchor: HorizontalAlign.center,
+                },
+            ],
+
+            { xRange, minGap }
+        )
+
+        expect(state.hasOverlap).toBe(false)
+        expect(state.placedSeries[0].bounds.right).toBeCloseTo(
+            xRange[1] - firstLabelWidth - minGap
+        )
+        expect(state.placedSeries[1].bounds.right).toBe(xRange[1])
+    })
+})
+
+describe("label placement when textAnchors are left and right", () => {
+    // Enough space to fit both labels
+    const xRange: [number, number] = [0, 500]
+    const minGap = 10
+
+    // Anchored on its right edge (sits to the left of its target x)
+    const leftLabel = "Left label"
+    const leftLabelWidth = textWidth(leftLabel, defaultFontSettings)
+
+    // Anchored on its left edge (sits to the right of its target x)
+    const rightLabel = "Right label"
+    const rightLabelWidth = textWidth(rightLabel, defaultFontSettings)
+
+    it("places labels at their anchor positions when there's no overlap", () => {
+        const state = makeHorizontalLabelPairState(
+            [
+                { text: leftLabel, x: 100, textAnchor: HorizontalAlign.right },
+                { text: rightLabel, x: 400, textAnchor: HorizontalAlign.left },
+            ],
+            { xRange, minGap }
+        )
+
+        expect(state.hasOverlap).toBe(false)
+        expect(state.placedSeries[0].bounds.right).toBe(100)
+        expect(state.placedSeries[1].bounds.left).toBe(400)
+    })
+
+    it("resolves overlap between labels", () => {
+        // Anchor positions are 260 and 240 (midpoint 250). The 30px overlap is
+        // split equally so the gap ends up centered on the midpoint.
+        const state = makeHorizontalLabelPairState(
+            [
+                { text: leftLabel, x: 260, textAnchor: HorizontalAlign.right },
+                { text: rightLabel, x: 240, textAnchor: HorizontalAlign.left },
+            ],
+            { xRange, minGap }
+        )
+
+        expect(state.hasOverlap).toBe(false)
+        expect(state.placedSeries[0].bounds.right).toBeCloseTo(250 - minGap / 2)
+        expect(state.placedSeries[1].bounds.left).toBeCloseTo(250 + minGap / 2)
+    })
+
+    it("resolves overlap close to the left edge", () => {
+        // The left label is pinned to the left edge of xRange,
+        // so the right label has to absorb the full shift.
+        const state = makeHorizontalLabelPairState(
+            [
+                { text: leftLabel, x: 20, textAnchor: HorizontalAlign.right },
+                { text: rightLabel, x: 10, textAnchor: HorizontalAlign.left },
+            ],
+            { xRange, minGap }
+        )
+
+        expect(state.hasOverlap).toBe(false)
+        expect(state.placedSeries[0].bounds.left).toBe(0)
+        expect(state.placedSeries[1].bounds.left).toBeCloseTo(
+            leftLabelWidth + minGap
+        )
+    })
+
+    it("resolves overlap close to the right edge", () => {
+        // The right label is pinned to the right edge of xRange,
+        // so the left label has to absorb the full shift.
+        const state = makeHorizontalLabelPairState(
+            [
+                { text: leftLabel, x: 450, textAnchor: HorizontalAlign.right },
+                { text: rightLabel, x: 499, textAnchor: HorizontalAlign.left },
+            ],
+            { xRange, minGap }
+        )
+
+        expect(state.hasOverlap).toBe(false)
+        expect(state.placedSeries[1].bounds.right).toBe(xRange[1])
+        expect(state.placedSeries[0].bounds.right).toBeCloseTo(
+            xRange[1] - rightLabelWidth - minGap
+        )
+    })
+})

--- a/packages/@ourworldindata/grapher/src/horizontalLabelPair/HorizontalLabelPairState.test.ts
+++ b/packages/@ourworldindata/grapher/src/horizontalLabelPair/HorizontalLabelPairState.test.ts
@@ -4,13 +4,13 @@ import {
     HorizontalLabelPairOptions,
     HorizontalLabelPairState,
 } from "./HorizontalLabelPairState"
-import { InitialHorizontalLabel } from "./HorizontalLabelPairTypes"
+import { HorizontalLabel } from "./HorizontalLabelPairTypes"
 import { textWidth } from "../chart/ChartUtils.js"
 
 const defaultFontSettings = { fontSize: 12, fontWeight: 400, lineHeight: 1 }
 
 const makeHorizontalLabelPairState = (
-    series: Pair<InitialHorizontalLabel>,
+    series: Pair<HorizontalLabel>,
     options: Partial<HorizontalLabelPairOptions> = {}
 ): HorizontalLabelPairState => {
     return new HorizontalLabelPairState(series, {

--- a/packages/@ourworldindata/grapher/src/horizontalLabelPair/HorizontalLabelPairState.ts
+++ b/packages/@ourworldindata/grapher/src/horizontalLabelPair/HorizontalLabelPairState.ts
@@ -1,0 +1,159 @@
+import * as _ from "lodash-es"
+import { computed, makeObservable } from "mobx"
+import { match } from "ts-pattern"
+import {
+    Bounds,
+    HorizontalAlign,
+    Pair,
+    RequiredBy,
+} from "@ourworldindata/utils"
+import { TextWrap } from "@ourworldindata/components"
+import { BASE_FONT_SIZE, FontSettings } from "../core/GrapherConstants.js"
+import {
+    InitialHorizontalLabel,
+    PlacedHorizontalLabel,
+    SizedHorizontalLabel,
+} from "./HorizontalLabelPairTypes.js"
+
+export interface HorizontalLabelPairOptions {
+    fontSettings?: FontSettings
+    /** Horizontal range for label placement */
+    xRange: [number, number]
+    /** Minimum horizontal gap between adjacent labels */
+    minGap?: number
+}
+
+/**
+ * Manages the state of two labels that are placed horizontally,
+ * ensuring they do not overlap and stay within a specified horizontal range.
+ */
+export class HorizontalLabelPairState {
+    private readonly initialSeries: Pair<InitialHorizontalLabel>
+    private readonly initialOptions: HorizontalLabelPairOptions
+
+    private readonly defaultOptions = {
+        fontSettings: {
+            fontSize: BASE_FONT_SIZE,
+            fontWeight: 400,
+            lineHeight: 1,
+        },
+        minGap: 8,
+    } as const satisfies Partial<HorizontalLabelPairOptions>
+
+    constructor(
+        series: Pair<InitialHorizontalLabel>,
+        options: HorizontalLabelPairOptions
+    ) {
+        this.initialSeries = series
+        this.initialOptions = options
+        makeObservable(this)
+    }
+
+    @computed private get options(): RequiredBy<
+        HorizontalLabelPairOptions,
+        keyof typeof this.defaultOptions
+    > {
+        return { ...this.defaultOptions, ...this.initialOptions }
+    }
+
+    @computed get sizedSeries(): Pair<SizedHorizontalLabel> {
+        const { fontSettings } = this.options
+        return this.initialSeries.map((series) => {
+            const textWrap = new TextWrap({
+                ...fontSettings,
+                text: series.text,
+                maxWidth: Infinity, // No line breaks
+            })
+            return { ...series, textWrap } satisfies SizedHorizontalLabel
+        }) as unknown as Pair<SizedHorizontalLabel>
+    }
+
+    @computed get placedSeries(): Pair<PlacedHorizontalLabel> {
+        const {
+            minGap,
+            xRange: [minX, maxX],
+        } = this.options
+
+        // Place each label at its target x, adjusted for text anchor
+        const placedSeries = this.sizedSeries.map((series) => {
+            const {
+                x,
+                textWrap: { width, height },
+                textAnchor = HorizontalAlign.left,
+            } = series
+
+            // Resolve textAnchor to the x coordinate of the label's left edge
+            const resolvedX = match(textAnchor)
+                .with(HorizontalAlign.left, () => x)
+                .with(HorizontalAlign.right, () => x - width)
+                .with(HorizontalAlign.center, () => x - width / 2)
+                .exhaustive()
+
+            return {
+                ...series,
+                bounds: new Bounds(resolvedX, 0, width, height),
+            }
+        })
+
+        // Shift labels that overflow the given horizontal range back within it
+        for (const series of placedSeries) {
+            const clampedX = _.clamp(
+                series.bounds.x,
+                minX,
+                maxX - series.bounds.width
+            )
+
+            if (clampedX !== series.bounds.x)
+                series.bounds = series.bounds.set({ x: clampedX })
+        }
+
+        const [leftLabel, rightLabel] = _.sortBy(
+            placedSeries,
+            (series) => series.bounds.x
+        )
+
+        // Check for overlap, enforcing a minimum gap between the two labels
+        const overlap = leftLabel.bounds.right + minGap - rightLabel.bounds.left
+
+        // If the labels are overlapping, shift them apart just enough to
+        // resolve the overlap
+        if (overlap > 0) {
+            // Calculate how much each label can be shifted
+            const leftAvailableShift = leftLabel.bounds.x - minX
+            const rightAvailableShift = maxX - rightLabel.bounds.right
+
+            // Split the required shift between the two labels
+            let leftShift = Math.min(overlap / 2, leftAvailableShift)
+            const rightShift = Math.min(
+                overlap - leftShift,
+                rightAvailableShift
+            )
+
+            // If the right side couldn't take its share, let the left side
+            // absorb the remainder (if it has capacity)
+            if (leftShift + rightShift < overlap) {
+                leftShift = Math.min(overlap - rightShift, leftAvailableShift)
+            }
+
+            // Update label positions
+            leftLabel.bounds = leftLabel.bounds.set({
+                x: leftLabel.bounds.x - leftShift,
+            })
+            rightLabel.bounds = rightLabel.bounds.set({
+                x: rightLabel.bounds.x + rightShift,
+            })
+        }
+
+        return [leftLabel, rightLabel]
+    }
+
+    /** True if the two labels overlap horizontally after placement */
+    @computed get hasOverlap(): boolean {
+        const { minGap } = this.options
+        const [leftLabel, rightLabel] = this.placedSeries
+        const gap = rightLabel.bounds.left - leftLabel.bounds.right
+        // Small tolerance to avoid false positives from floating-point noise
+        // when the placement logic resolves an overlap to exactly minGap
+        return gap < minGap - 1e-6
+    }
+}

--- a/packages/@ourworldindata/grapher/src/horizontalLabelPair/HorizontalLabelPairState.ts
+++ b/packages/@ourworldindata/grapher/src/horizontalLabelPair/HorizontalLabelPairState.ts
@@ -10,7 +10,7 @@ import {
 import { TextWrap } from "@ourworldindata/components"
 import { BASE_FONT_SIZE, FontSettings } from "../core/GrapherConstants.js"
 import {
-    InitialHorizontalLabel,
+    HorizontalLabel,
     PlacedHorizontalLabel,
     SizedHorizontalLabel,
 } from "./HorizontalLabelPairTypes.js"
@@ -18,8 +18,8 @@ import {
 export interface HorizontalLabelPairOptions {
     fontSettings?: FontSettings
     /** Horizontal range for label placement */
-    xRange: [number, number]
-    /** Minimum horizontal gap between adjacent labels */
+    xRange?: [number, number]
+    /** Minimum horizontal gap between the two labels */
     minGap?: number
 }
 
@@ -28,7 +28,7 @@ export interface HorizontalLabelPairOptions {
  * ensuring they do not overlap and stay within a specified horizontal range.
  */
 export class HorizontalLabelPairState {
-    private readonly initialSeries: Pair<InitialHorizontalLabel>
+    private readonly initialSeries: Pair<HorizontalLabel>
     private readonly initialOptions: HorizontalLabelPairOptions
 
     private readonly defaultOptions = {
@@ -37,11 +37,12 @@ export class HorizontalLabelPairState {
             fontWeight: 400,
             lineHeight: 1,
         },
+        xRange: [-Infinity, Infinity],
         minGap: 8,
     } as const satisfies Partial<HorizontalLabelPairOptions>
 
     constructor(
-        series: Pair<InitialHorizontalLabel>,
+        series: Pair<HorizontalLabel>,
         options: HorizontalLabelPairOptions
     ) {
         this.initialSeries = series
@@ -65,7 +66,7 @@ export class HorizontalLabelPairState {
                 maxWidth: Infinity, // No line breaks
             })
             return { ...series, textWrap } satisfies SizedHorizontalLabel
-        }) as unknown as Pair<SizedHorizontalLabel>
+        }) as Pair<SizedHorizontalLabel>
     }
 
     @computed get placedSeries(): Pair<PlacedHorizontalLabel> {
@@ -153,7 +154,6 @@ export class HorizontalLabelPairState {
         const [leftLabel, rightLabel] = this.placedSeries
         const gap = rightLabel.bounds.left - leftLabel.bounds.right
         // Small tolerance to avoid false positives from floating-point noise
-        // when the placement logic resolves an overlap to exactly minGap
         return gap < minGap - 1e-6
     }
 }

--- a/packages/@ourworldindata/grapher/src/horizontalLabelPair/HorizontalLabelPairTypes.ts
+++ b/packages/@ourworldindata/grapher/src/horizontalLabelPair/HorizontalLabelPairTypes.ts
@@ -1,14 +1,14 @@
 import { Bounds, HorizontalAlign } from "@ourworldindata/utils"
 import { TextWrap } from "@ourworldindata/components"
 
-export interface InitialHorizontalLabel {
+export interface HorizontalLabel {
     text: string
     x: number
     color?: string
     textAnchor?: HorizontalAlign
 }
 
-export interface SizedHorizontalLabel extends InitialHorizontalLabel {
+export interface SizedHorizontalLabel extends HorizontalLabel {
     textWrap: TextWrap
 }
 

--- a/packages/@ourworldindata/grapher/src/horizontalLabelPair/HorizontalLabelPairTypes.ts
+++ b/packages/@ourworldindata/grapher/src/horizontalLabelPair/HorizontalLabelPairTypes.ts
@@ -1,0 +1,17 @@
+import { Bounds, HorizontalAlign } from "@ourworldindata/utils"
+import { TextWrap } from "@ourworldindata/components"
+
+export interface InitialHorizontalLabel {
+    text: string
+    x: number
+    color?: string
+    textAnchor?: HorizontalAlign
+}
+
+export interface SizedHorizontalLabel extends InitialHorizontalLabel {
+    textWrap: TextWrap
+}
+
+export interface PlacedHorizontalLabel extends SizedHorizontalLabel {
+    bounds: Bounds
+}

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -110,6 +110,8 @@ export type RequiredBy<T, K extends keyof T> = Omit<T, K> & Required<Pick<T, K>>
 // PartialRecord<A, B> = Partial<Record<A, B>>
 export type PartialRecord<K extends keyof any, V> = Partial<Record<K, V>>
 
+export type Pair<T> = [T, T]
+
 // d3 v6 changed the default minus sign used in d3-format to "−" (Unicode minus sign), which looks
 // nicer but can cause issues when copy-pasting values into a spreadsheet or script.
 // For that reason we change that back to a plain old hyphen.

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -141,6 +141,7 @@ export {
     getDisplayUnit,
     stripOuterParentheses,
     dimensionsToViewId,
+    type Pair,
 } from "./Util.js"
 
 export {


### PR DESCRIPTION
[Cycle issue](https://github.com/owid/owid-grapher/issues/6169) / [Designs](https://www.figma.com/design/dCB69o19cAVtuk283STAcY/Dumbbell-Plots?node-id=1-31&m=dev)

Implements the chart legend for dumbbell plots.

### Description

If possible, an in-chart legend is plotted above the chart where the two legend labels are aligned with the top-most dots.

- If series strategy = entity (one indicator, time range): show in-chart legend if possible, hide legend otherwise (two dates not fitting next to each other is rare, and the arrow design makes the start/end dots relatively clear)
- If series strategy = column (two indicators, time point); show in-chart legend if possible, horizontal categorical legend otherwise

There's a new component `HorizontalLabelPair` for plotting the in-chart legend. It currently only works for exactly two labels because that's what I needed here.

### Follow-up work

* ~Dumbbell elements~
* ~New dumbbell-specific options: value labels, end points~
* ~In-chart legend, aligned with the top-most dots~
* Color (hard-coded for now)
* Interaction (focus, hover, tooltips)
* More entity sorting options
* Dumbbell plots in search
* Dumbbell chart thumbnails