### PR TITLE
Modernize deprecated code

### DIFF
--- a/.oxlintrc.jsonc
+++ b/.oxlintrc.jsonc
@@ -164,6 +164,7 @@
                 "fixMixedExportsWithInlineTypeSpecifier": true
             }
         ],
+        "typescript/no-deprecated": "warn",
         "typescript/no-duplicate-enum-values": "error",
         "typescript/no-empty-interface": "warn",
         "typescript/no-empty-object-type": "error",

--- a/adminSiteClient/DodsIndexPage.tsx
+++ b/adminSiteClient/DodsIndexPage.tsx
@@ -21,7 +21,7 @@ import { EditableTextarea } from "./EditableTextarea.js"
 import * as R from "remeda"
 import { Admin } from "./Admin.js"
 import { fromMarkdown } from "mdast-util-from-markdown"
-import { Content, PhrasingContent } from "mdast"
+import { PhrasingContent, RootContent } from "mdast"
 import { renderToStaticMarkup } from "react-dom/server"
 import {
     MarkdownTextWrap,
@@ -38,7 +38,7 @@ type ValidPhrasingContent = Extract<
 >
 
 function validateParagraphChildren(
-    children: Content[],
+    children: RootContent[],
     dods: Record<string, DbPlainDod> | undefined
 ): children is ValidPhrasingContent[] {
     return children.every((child) => {

--- a/adminSiteClient/FilesIndexPage.tsx
+++ b/adminSiteClient/FilesIndexPage.tsx
@@ -1,4 +1,4 @@
-import * as R from "remeda"
+import * as _ from "lodash-es"
 import React, { useContext, useState, useMemo, useEffect } from "react"
 import { useHistory, useLocation } from "react-router-dom"
 import { Flex, Input, Breadcrumb, Space, Tooltip } from "antd"
@@ -18,8 +18,10 @@ import {
     highlightFunctionForSearchWords,
 } from "../adminShared/search.js"
 
+type FileMapOrFile = DbPlainFile | FileMap
+
 type FileMap = {
-    [key: string]: DbPlainFile | FileMap
+    [key: string]: FileMapOrFile
 }
 
 async function fetchFiles(admin: Admin): Promise<FileMap> {
@@ -43,7 +45,7 @@ async function fetchFiles(admin: Admin): Promise<FileMap> {
     }, {} as FileMap)
 }
 
-function checkIsFile(node: FileMap[string]): node is DbPlainFile {
+function checkIsFile(node: FileMapOrFile): node is DbPlainFile {
     return "filename" in node
 }
 
@@ -124,7 +126,7 @@ function FileMapViewer({
     }
 
     const pathSegments = currentPath.split("/").filter(Boolean)
-    const currentNode = R.pathOr(fileMap, pathSegments as any, fileMap)
+    const currentNode: FileMapOrFile = _.get(fileMap, pathSegments, fileMap)
 
     return (
         <div>

--- a/adminSiteServer/app.ts
+++ b/adminSiteServer/app.ts
@@ -9,7 +9,7 @@ import {
 } from "../settings/serverSettings.js"
 import { OwidAdminApp } from "./appClass.js"
 
-if (!module.parent)
+if (require.main === module)
     void new OwidAdminApp({
         isDev: ENV === "development",
     }).startListening(ADMIN_SERVER_PORT, ADMIN_SERVER_HOST)

--- a/devTools/mapAnnotations/generate.ts
+++ b/devTools/mapAnnotations/generate.ts
@@ -1,6 +1,6 @@
 import { writeFile } from "fs/promises"
 import { Position } from "geojson"
-import { format, FormatOptions } from "oxfmt"
+import { format, type FormatConfig } from "oxfmt"
 import oxfmtConfig from "../../.oxfmtrc.json"
 import * as R from "remeda"
 import {
@@ -38,7 +38,7 @@ async function prettifiedJson(obj: any): Promise<string> {
     const result = await format(
         "input.json",
         JSON.stringify(obj),
-        oxfmtConfig as FormatOptions
+        oxfmtConfig as FormatConfig
     )
     return result.code
 }

--- a/devTools/regionsUpdater/update.ts
+++ b/devTools/regionsUpdater/update.ts
@@ -7,7 +7,7 @@ import {
     type Polygon,
     type MultiPolygon,
 } from "geojson"
-import { format, FormatOptions } from "oxfmt"
+import { format, type FormatConfig } from "oxfmt"
 import oxfmtConfig from "../../.oxfmtrc.json"
 import * as _ from "lodash-es"
 import * as R from "remeda"
@@ -132,7 +132,7 @@ async function prettifiedTs(content: string): Promise<string> {
     const result = await format(
         "input.ts",
         content,
-        oxfmtConfig as FormatOptions
+        oxfmtConfig as FormatConfig
     )
     return result.code
 }

--- a/devTools/svgTester/utils.ts
+++ b/devTools/svgTester/utils.ts
@@ -47,7 +47,7 @@ import {
     GRAPHER_THUMBNAIL_HEIGHT,
     mapGrapherTabNameToQueryParam,
 } from "@ourworldindata/grapher"
-import { format, FormatOptions } from "oxfmt"
+import { format, type FormatConfig } from "oxfmt"
 import oxfmtConfig from "../../.oxfmtrc.json"
 import { hashMd5 } from "../../serverUtils/hash.js"
 import * as R from "remeda"
@@ -558,7 +558,7 @@ async function prepareSvgForComparison(svg: string): Promise<string> {
 }
 
 async function formatSvg(svg: string): Promise<string> {
-    const result = await format("input.html", svg, oxfmtConfig as FormatOptions)
+    const result = await format("input.html", svg, oxfmtConfig as FormatConfig)
     return result.code
 }
 

--- a/packages/@ourworldindata/components/src/MarkdownTextWrap/MarkdownTextWrap.tsx
+++ b/packages/@ourworldindata/components/src/MarkdownTextWrap/MarkdownTextWrap.tsx
@@ -10,7 +10,7 @@ import {
 } from "@ourworldindata/utils"
 import { type ITextWrap } from "../TextWrap/TextWrap.js"
 import { fromMarkdown } from "mdast-util-from-markdown"
-import type { Content, Root } from "mdast"
+import type { Root, RootContent } from "mdast"
 import { match } from "ts-pattern"
 import { urlRegex } from "../markdown/remarkPlainLinks.js"
 import * as R from "remeda"
@@ -737,7 +737,7 @@ export function convertMarkdownToIRTokens(
 // When using mdast types version 4 this should be typed as:
 // node: RootContentMap[keyof RootContentMap]
 function convertMarkdownNodeToIRTokens(
-    node: Content,
+    node: RootContent,
     fontParams: IRFontParams = {}
 ): IRToken[] {
     const converted = match(node)

--- a/packages/@ourworldindata/core-table/src/CoreTableUtils.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTableUtils.ts
@@ -35,7 +35,7 @@ export const columnStoreToRows = (
 
 // If string exceeds maxLength, will replace the end char with a ... and drop the rest
 export const truncate = (str: string, maxLength: number): string =>
-    str.length > maxLength ? `${str.substr(0, maxLength - 3)}...` : str
+    str.length > maxLength ? `${str.slice(0, maxLength - 3)}...` : str
 
 // Picks a type for each column from the first row then autotypes all rows after that so all values in
 // a column will have the same type. Only chooses between strings and numbers.

--- a/packages/@ourworldindata/core-table/src/OwidTableSynthesizers.ts
+++ b/packages/@ourworldindata/core-table/src/OwidTableSynthesizers.ts
@@ -46,7 +46,7 @@ const SynthesizeOwidTable = (
         ? entityNames.map((name) => {
               return {
                   name,
-                  code: name.substr(0, 3).toUpperCase(),
+                  code: name.slice(0, 3).toUpperCase(),
               }
           })
         : sampleFrom(countries, entityCount, seed)

--- a/packages/@ourworldindata/grapher/package.json
+++ b/packages/@ourworldindata/grapher/package.json
@@ -37,6 +37,7 @@
         "mobx-react": "^7.6.0",
         "mousetrap": "^1.6.5",
         "react": "^19.2.4",
+        "react-aria": "^3.48.0",
         "react-aria-components": "^1.17.0",
         "react-dom": "^19.2.4",
         "react-flip-toolkit": "^7.2.4",

--- a/packages/@ourworldindata/grapher/src/color/ColorUtils.ts
+++ b/packages/@ourworldindata/grapher/src/color/ColorUtils.ts
@@ -69,8 +69,8 @@ function darkenColorToTargetYiq(colorHex: Color, targetYiq: number): Color {
     const c = color(colorHex)?.rgb()
     if (!c) return colorHex
     const darkenCoeff = getYiq(c) / targetYiq - 1.0
-    if (darkenCoeff > 0) return c.darker(darkenCoeff).hex()
-    return c.hex()
+    if (darkenCoeff > 0) return c.darker(darkenCoeff).formatHex()
+    return c.formatHex()
 }
 
 export function darkenColorForLine(colorHex: Color): Color {

--- a/packages/@ourworldindata/grapher/src/controls/Dropdown.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/Dropdown.tsx
@@ -10,7 +10,6 @@ import {
     ListBox,
     ListBoxItem,
     ListBoxSection,
-    Popover,
     SearchField,
     Select,
     SelectValue,
@@ -19,6 +18,7 @@ import {
 import { faTimesCircle } from "@fortawesome/free-solid-svg-icons"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { isTouchDevice } from "@ourworldindata/utils"
+import { PortaledPopover } from "./PortaledPopover"
 
 export interface BasicDropdownOption {
     trackNote?: string
@@ -160,13 +160,53 @@ export function Dropdown<DropdownOption extends BasicDropdownOption>({
         </ListBox>
     )
 
+    const popover = (
+        <PortaledPopover
+            className={cx(
+                "grapher-dropdown-menu",
+                "portaled-popover",
+                menuClassName
+            )}
+            offset={4}
+            portalContainer={portalContainer}
+        >
+            {isSearchable ? (
+                // If inputValue is provided, the component is controlled
+                // and we expect the filtering to happen outside of it.
+                <Autocomplete filter={inputValue ? undefined : contains}>
+                    <SearchField
+                        className="grapher-dropdown-search"
+                        aria-label="Search"
+                        autoFocus
+                        value={inputValue}
+                        onChange={onInputChange}
+                    >
+                        <span className="grapher-dropdown-search-icon" />
+                        <Input
+                            className="grapher-dropdown-search-input"
+                            style={{
+                                fontSize: isTouchDevice() ? 16 : undefined,
+                            }}
+                        />
+                        <Button className="grapher-dropdown-search-reset">
+                            <FontAwesomeIcon icon={faTimesCircle} aria-hidden />
+                        </Button>
+                    </SearchField>
+                    {listBox}
+                </Autocomplete>
+            ) : (
+                listBox
+            )}
+        </PortaledPopover>
+    )
+
     return (
         <Select
             className={cx("grapher-dropdown", className)}
             // null means no selection, undefined means the component is
             // uncontrolled, so we need to set it explicitly.
-            selectedKey={value?.value ?? null}
-            onSelectionChange={handleSelectionChange}
+            value={value?.value ?? null}
+            onChange={handleSelectionChange}
             placeholder={placeholder}
             isDisabled={isDisabled}
             {...otherProps}
@@ -196,46 +236,7 @@ export function Dropdown<DropdownOption extends BasicDropdownOption>({
             )}
             {/* Note: "portaled-popover" class is used by SlideInDrawer to detect
                 clicks inside portaled popovers. Update both if renaming. */}
-            <Popover
-                className={cx(
-                    "grapher-dropdown-menu",
-                    "portaled-popover",
-                    menuClassName
-                )}
-                offset={4}
-                UNSTABLE_portalContainer={portalContainer}
-            >
-                {isSearchable ? (
-                    // If inputValue is provided, the component is controlled
-                    // and we expect the filtering to happen outside of it.
-                    <Autocomplete filter={inputValue ? undefined : contains}>
-                        <SearchField
-                            className="grapher-dropdown-search"
-                            aria-label="Search"
-                            autoFocus
-                            value={inputValue}
-                            onChange={onInputChange}
-                        >
-                            <span className="grapher-dropdown-search-icon" />
-                            <Input
-                                className="grapher-dropdown-search-input"
-                                style={{
-                                    fontSize: isTouchDevice() ? 16 : undefined,
-                                }}
-                            />
-                            <Button className="grapher-dropdown-search-reset">
-                                <FontAwesomeIcon
-                                    icon={faTimesCircle}
-                                    aria-hidden
-                                />
-                            </Button>
-                        </SearchField>
-                        {listBox}
-                    </Autocomplete>
-                ) : (
-                    listBox
-                )}
-            </Popover>
+            {popover}
         </Select>
     )
 }

--- a/packages/@ourworldindata/grapher/src/controls/Dropdown.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/Dropdown.tsx
@@ -10,6 +10,7 @@ import {
     ListBox,
     ListBoxItem,
     ListBoxSection,
+    Popover,
     SearchField,
     Select,
     SelectValue,
@@ -18,7 +19,6 @@ import {
 import { faTimesCircle } from "@fortawesome/free-solid-svg-icons"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { isTouchDevice } from "@ourworldindata/utils"
-import { PortaledPopover } from "./PortaledPopover"
 
 export interface BasicDropdownOption {
     trackNote?: string
@@ -56,7 +56,6 @@ export interface DropdownProps<DropdownOption extends BasicDropdownOption> {
         option: DropdownOption | null
     ) => React.ReactNode | undefined
     renderMenuOption?: (option: DropdownOption) => React.ReactNode
-    portalContainer?: HTMLElement
     "data-track-note"?: string
     "aria-label"?: string
 }
@@ -93,7 +92,6 @@ export function Dropdown<DropdownOption extends BasicDropdownOption>({
     isSearchable,
     renderTriggerValue,
     renderMenuOption,
-    portalContainer,
     ...otherProps
 }: DropdownProps<DropdownOption>): React.ReactElement {
     const { contains } = useFilter({ sensitivity: "base" })
@@ -161,14 +159,13 @@ export function Dropdown<DropdownOption extends BasicDropdownOption>({
     )
 
     const popover = (
-        <PortaledPopover
+        <Popover
             className={cx(
                 "grapher-dropdown-menu",
                 "portaled-popover",
                 menuClassName
             )}
             offset={4}
-            portalContainer={portalContainer}
         >
             {isSearchable ? (
                 // If inputValue is provided, the component is controlled
@@ -197,7 +194,7 @@ export function Dropdown<DropdownOption extends BasicDropdownOption>({
             ) : (
                 listBox
             )}
-        </PortaledPopover>
+        </Popover>
     )
 
     return (

--- a/packages/@ourworldindata/grapher/src/controls/PortaledPopover.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/PortaledPopover.tsx
@@ -1,0 +1,24 @@
+import type { ReactElement } from "react"
+import { Popover, type PopoverProps } from "react-aria-components"
+import { UNSAFE_PortalProvider } from "react-aria/PortalProvider"
+
+export interface PortaledPopoverProps extends PopoverProps {
+    portalContainer?: HTMLElement
+}
+
+// Popover wrapper that optionally portals overlays into a caller-provided DOM node.
+// This is useful for cases where the popover is used inside an auto-closing element like a modal or drawer, and we want the auto-closing logic to be unchanged.
+export function PortaledPopover({
+    portalContainer,
+    children,
+    ...props
+}: PortaledPopoverProps): ReactElement {
+    const popover = <Popover {...props}>{children}</Popover>
+
+    if (!portalContainer) return popover
+    return (
+        <UNSAFE_PortalProvider getContainer={() => portalContainer}>
+            {popover}
+        </UNSAFE_PortalProvider>
+    )
+}

--- a/packages/@ourworldindata/grapher/src/controls/entityPicker/EntityPicker.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/entityPicker/EntityPicker.tsx
@@ -379,9 +379,8 @@ export class EntityPicker extends React.Component<EntityPickerProps> {
         this.blockHover()
         switch (event.key) {
             case "Enter": {
-                if (event.keyCode === 229) {
+                if (event.nativeEvent.isComposing) {
                     // ignore the keydown event from an Input Method Editor(IME)
-                    // ref. https://www.w3.org/TR/uievents/#determine-keydown-keyup-keyCode
                     break
                 }
                 if (!this.focusedOption) return

--- a/packages/@ourworldindata/grapher/src/tabs/TabsWithDropdown.tsx
+++ b/packages/@ourworldindata/grapher/src/tabs/TabsWithDropdown.tsx
@@ -1,16 +1,11 @@
 import * as R from "remeda"
 import cx from "classnames"
-import { useState } from "react"
-import {
-    Button,
-    MenuTrigger,
-    Popover,
-    Menu,
-    MenuItem,
-} from "react-aria-components"
+import { useState, type Key } from "react"
+import { Button, MenuTrigger, Menu, MenuItem } from "react-aria-components"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faEllipsisVertical } from "@fortawesome/free-solid-svg-icons"
 import { TabItem, Tabs } from "./Tabs"
+import { PortaledPopover } from "../controls/PortaledPopover"
 
 export const TabsWithDropdown = <TabKey extends string = string>({
     items,
@@ -50,10 +45,37 @@ export const TabsWithDropdown = <TabKey extends string = string>({
             .concat(lastVisibleItem)
     }
 
-    const handleSelect = (key: React.Key) => {
+    const handleSelect = (key: Key) => {
         if (typeof key === "string") onChange(key as TabKey)
         setIsOpen(false)
     }
+
+    // We need to portal this popover to the containing modal so that the modal-closing logic can detect clicks outside of it. Otherwise, clicking on the popover would close the modal immediately.
+    const popover = (
+        <PortaledPopover
+            className="TabsWithDropdown__Popover"
+            placement="bottom end"
+            portalContainer={portalContainer}
+        >
+            <Menu className="TabsWithDropdown__Menu" onAction={handleSelect}>
+                {hiddenItems.map((item) => (
+                    <MenuItem
+                        key={item.key}
+                        id={item.key}
+                        className={cx(
+                            "TabsWithDropdown__MenuItem",
+                            item.buttonProps?.className
+                        )}
+                        data-track-note={item.buttonProps?.dataTrackNote}
+                        aria-label={item.buttonProps?.ariaLabel}
+                        ref={item.buttonProps?.ref}
+                    >
+                        {item.element}
+                    </MenuItem>
+                ))}
+            </Menu>
+        </PortaledPopover>
+    )
 
     return (
         <div className={cx("TabsWithDropdown", className)}>
@@ -78,34 +100,7 @@ export const TabsWithDropdown = <TabKey extends string = string>({
                             />
                             <span>More</span>
                         </Button>
-                        <Popover
-                            className="TabsWithDropdown__Popover"
-                            placement="bottom end"
-                            UNSTABLE_portalContainer={portalContainer}
-                        >
-                            <Menu
-                                className="TabsWithDropdown__Menu"
-                                onAction={handleSelect}
-                            >
-                                {hiddenItems.map((item) => (
-                                    <MenuItem
-                                        key={item.key}
-                                        id={item.key}
-                                        className={cx(
-                                            "TabsWithDropdown__MenuItem",
-                                            item.buttonProps?.className
-                                        )}
-                                        data-track-note={
-                                            item.buttonProps?.dataTrackNote
-                                        }
-                                        aria-label={item.buttonProps?.ariaLabel}
-                                        ref={item.buttonProps?.ref}
-                                    >
-                                        {item.element}
-                                    </MenuItem>
-                                ))}
-                            </Menu>
-                        </Popover>
+                        {popover}
                     </MenuTrigger>
                 )}
             </div>

--- a/packages/@ourworldindata/grapher/src/tabs/TabsWithDropdown.tsx
+++ b/packages/@ourworldindata/grapher/src/tabs/TabsWithDropdown.tsx
@@ -1,7 +1,13 @@
 import * as R from "remeda"
 import cx from "classnames"
-import { useState, type Key } from "react"
-import { Button, MenuTrigger, Menu, MenuItem } from "react-aria-components"
+import { useState } from "react"
+import {
+    Button,
+    MenuTrigger,
+    Menu,
+    MenuItem,
+    type Key,
+} from "react-aria-components"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faEllipsisVertical } from "@fortawesome/free-solid-svg-icons"
 import { TabItem, Tabs } from "./Tabs"

--- a/packages/@ourworldindata/utils/src/Bounds.ts
+++ b/packages/@ourworldindata/utils/src/Bounds.ts
@@ -34,7 +34,7 @@ export class Bounds {
         return this.fromProps(bbox)
     }
 
-    static fromRect(rect: ClientRect): Bounds {
+    static fromRect(rect: DOMRect): Bounds {
         return new Bounds(rect.left, rect.top, rect.width, rect.height)
     }
 

--- a/packages/@ourworldindata/utils/src/PromiseSwitcher.test.ts
+++ b/packages/@ourworldindata/utils/src/PromiseSwitcher.test.ts
@@ -16,9 +16,9 @@ it("handles fulfilling single promise", async () => {
     const onResolve = vi.fn(() => undefined)
     const selector = new PromiseSwitcher({ onResolve })
     await selector.set(Promise.resolve("done"))
-    expect(onResolve).toBeCalledWith("done")
+    expect(onResolve).toHaveBeenCalledWith("done")
     await selector.set(Promise.resolve("done"))
-    expect(onResolve).toBeCalledTimes(2)
+    expect(onResolve).toHaveBeenCalledTimes(2)
 })
 
 it("selecting a new promise while one is pending discards the pending promise", async () => {

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -1354,6 +1354,7 @@ export async function copyToClipboard(text: string): Promise<boolean> {
         textarea.select()
 
         try {
+            // oxlint-disable-next-line typescript/no-deprecated we're using a deprecated API only as a fallback here
             return document.execCommand("copy")
         } catch (err) {
             console.error("Failed to copy text to clipboard", err)

--- a/site/multiDim/DimensionDropdown.tsx
+++ b/site/multiDim/DimensionDropdown.tsx
@@ -71,8 +71,8 @@ export default function DimensionDropdown({
             isDisabled={isDisabled}
             isOpen={isOpen}
             onOpenChange={setIsOpen}
-            selectedKey={value}
-            onSelectionChange={(key) => {
+            value={value}
+            onChange={(key) => {
                 if (typeof key === "string") onChange(key)
             }}
             aria-label={dimension.name}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3031,6 +3031,7 @@ __metadata:
     mobx-react: "npm:^7.6.0"
     mousetrap: "npm:^1.6.5"
     react: "npm:^19.2.4"
+    react-aria: "npm:^3.48.0"
     react-aria-components: "npm:^1.17.0"
     react-dom: "npm:^19.2.4"
     react-flip-toolkit: "npm:^7.2.4"
@@ -13508,7 +13509,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-aria@npm:3.48.0":
+"react-aria@npm:3.48.0, react-aria@npm:^3.48.0":
   version: 3.48.0
   resolution: "react-aria@npm:3.48.0"
   dependencies:


### PR DESCRIPTION
## Summary

Enables the `no-deprecated` oxlint rule and fixes all related issues.

The changes update deprecated TypeScript/API usage across utility code, admin pages, dev tools, core-table, Grapher, and multi-dim controls. The React Aria dropdown/popover changes now use the newer `Select` `value`/`onChange` API and a reusable `PortaledPopover` wrapper backed by `UNSAFE_PortalProvider` for custom portal containers.

## Things tested

- Tab overflow menus using `TabsWithDropdown`, including cases where the selected tab is initially hidden and the menu is portaled into a custom container. ✅
- Sources modal interactions, since it passes a `portalContainer` into controls rendered inside the modal container. ✅
- Multi-dimensional data page dimension dropdowns after moving from `selectedKey`/`onSelectionChange` to `value`/`onChange`. ✅
- Admin file browser path navigation after replacing `R.pathOr` with typed file-map traversal. ✅