### PR TITLE
Style-check user-visible copy

### DIFF
--- a/bespoke/projects/demography/src/components/PopulationChart.tsx
+++ b/bespoke/projects/demography/src/components/PopulationChart.tsx
@@ -809,4 +809,3 @@ function AxisY({
         </>
     )
 }
-

--- a/bespoke/projects/demography/src/components/ProjectionLegend.tsx
+++ b/bespoke/projects/demography/src/components/ProjectionLegend.tsx
@@ -10,7 +10,7 @@ import { useTippyContainer } from "../../../../hooks/useTippyContainer.js"
 
 export function ProjectionLegend({
     userLabel = "Your projection",
-    benchmarkLabel = "UN WPP Medium projection",
+    benchmarkLabel = "UN medium projection",
     userTooltip,
     benchmarkTooltip,
     modified = false,

--- a/bespoke/projects/demography/src/components/SimulationContent.tsx
+++ b/bespoke/projects/demography/src/components/SimulationContent.tsx
@@ -31,9 +31,9 @@ import { parameterConfigByKey } from "../helpers/parameterConfigs.js"
 import { useTippyContainer } from "../../../../hooks/useTippyContainer.js"
 
 const PARAMETER_TAB_LABELS: Record<ParameterKey, string> = {
-    fertilityRate: "Fertility Rate",
-    lifeExpectancy: "Life Expectancy",
-    netMigrationRate: "Net Migration",
+    fertilityRate: "Fertility rate",
+    lifeExpectancy: "Life expectancy",
+    netMigrationRate: "Net migration",
 }
 
 export function SimulationContent({
@@ -165,11 +165,11 @@ export function SimulationContent({
                     <ChartPanel
                         className="population-panel"
                         title="Population"
-                        subtitle="Historical estimates and projections of total population"
+                        subtitle="Historical estimates and projections of total population."
                         header={
                             <ProjectionLegend
                                 modified={hasUserChanges}
-                                userTooltip="This projection is based on the fertility, life expectancy, and migration assumptions you set. Change them in the panel on the left to see how they affect population projections."
+                                userTooltip="This projection is based on the fertility, life expectancy, and migration assumptions you set. Change them in the assumptions panel to see how they affect population projections."
                             />
                         }
                     >
@@ -203,8 +203,8 @@ function AgeStructurePanel({
     barColor?: { female: string; male: string } | string
     populationPyramidUnit?: "percent" | "absolute"
 }) {
-    const title = `Age Structure in ${year}`
-    const subtitle = "Population by age and sex"
+    const title = `Age structure in ${year}`
+    const subtitle = "Population by age and sex."
     const slider = (
         <SimpleYearSlider selectedYear={year} onChange={onYearChange} />
     )
@@ -307,7 +307,7 @@ export function InputChartPanel({
                 showLegend ? (
                     <ProjectionLegend
                         userLabel="Your assumptions"
-                        benchmarkLabel="UN WPP assumptions"
+                        benchmarkLabel="UN assumptions"
                         modified={isParameterModified}
                     />
                 ) : undefined

--- a/bespoke/projects/demography/src/helpers/parameterConfigs.ts
+++ b/bespoke/projects/demography/src/helpers/parameterConfigs.ts
@@ -44,14 +44,14 @@ export const parameterConfigByKey: Record<ParameterKey, ParameterConfig> = {
     fertilityRate: {
         shortTitle: "Fertility",
         extraShortTitle: "Fertility",
-        title: "Fertility Rate",
+        title: "Fertility rate",
         unit: "births per woman",
         axisUnit: "births per woman",
         yPadding: 2,
         yFloor: 0,
         step: 0.1,
         decimals: 1,
-        subtitle: () => "Average number of births per woman",
+        subtitle: () => "Average number of births per woman.",
         tooltipContent:
             "Total fertility rate is the number of births a woman would have, if she experienced the birth rates of women of each age group in one particular year across her childbearing years.",
         formatValue: (v) =>
@@ -97,9 +97,9 @@ export const parameterConfigByKey: Record<ParameterKey, ParameterConfig> = {
         },
     },
     lifeExpectancy: {
-        shortTitle: "Life Expectancy",
-        extraShortTitle: "Life Exp.",
-        title: "Life Expectancy at Birth",
+        shortTitle: "Life expectancy",
+        extraShortTitle: "Life exp.",
+        title: "Life expectancy at birth",
         unit: "years",
         axisUnit: "years",
         yPadding: 10,
@@ -108,7 +108,7 @@ export const parameterConfigByKey: Record<ParameterKey, ParameterConfig> = {
         step: 1,
         decimals: 0,
         subtitle: () =>
-            "Years a newborn is expected to live, given current mortality rates",
+            "Years a newborn is expected to live, given current mortality rates.",
         tooltipContent:
             "Period life expectancy is the number of years the average person born in a certain year would live if they experienced the same chances of dying at each age as people did that year.",
         formatValue: (v) =>
@@ -172,18 +172,18 @@ export const parameterConfigByKey: Record<ParameterKey, ParameterConfig> = {
     netMigrationRate: {
         shortTitle: "Migration",
         extraShortTitle: "Migration",
-        title: "Net Migration Rate",
+        title: "Net migration rate",
         unit: "per 1,000 population",
         axisUnit: "‰",
         yPadding: 5,
         step: 0.1,
         decimals: 1,
         subtitle: (entityName: string) => {
-            if (entityName === "World") return "Not applicable"
+            if (entityName === "World") return "Not applicable."
             const region = getRegionByName(entityName)
             if (region?.regionType === "aggregate")
-                return "Difference between people entering and leaving the continent, per 1,000 population"
-            return "Difference between people entering and leaving the country, per 1,000 population"
+                return "Difference between people entering and leaving the continent, per 1,000 population."
+            return "Difference between people entering and leaving the country, per 1,000 population."
         },
         tooltipContent:
             "Net migration is the difference in immigration (people entering the country) and emigration (people leaving). This number is positive if more people are entering than leaving. This difference is given per 1,000 population.",

--- a/bespoke/projects/demography/src/variants/ParametersVariant.tsx
+++ b/bespoke/projects/demography/src/variants/ParametersVariant.tsx
@@ -139,7 +139,7 @@ function CaptionedParametersVariant({
     )
     const subtitle =
         subtitleOverride ??
-        "Assumptions about fertility, life expectancy, and migration that underlie the UN's population medium projection"
+        "Assumptions about fertility, life expectancy, and migration that underlie the UN's population medium projection."
 
     return (
         <Frame className="demography-captioned-chart demography-parameters">

--- a/bespoke/projects/demography/src/variants/PopulationPyramidVariant.tsx
+++ b/bespoke/projects/demography/src/variants/PopulationPyramidVariant.tsx
@@ -167,7 +167,7 @@ function CaptionedPopulationPyramidVariant({
     )
     const subtitle =
         subtitleOverride ??
-        `The population of ${entityNameForSentence(data.country)}, broken down by age and sex based on future projections. These are based on the user's fertility, life expectancy, and migration inputs to a demographic model.`
+        `Population of ${entityNameForSentence(data.country)}, broken down by age and sex based on future projections. These are based on the user's fertility, life expectancy, and migration inputs to a demographic model.`
 
     return (
         <Frame className="demography-captioned-chart demography-population-pyramid">

--- a/bespoke/projects/demography/src/variants/PopulationVariant.tsx
+++ b/bespoke/projects/demography/src/variants/PopulationVariant.tsx
@@ -151,7 +151,7 @@ function CaptionedPopulationVariant({
     )
     const subtitle =
         subtitleOverride ??
-        "Historical estimates and projections of total population"
+        "Historical estimates and projections of total population."
 
     return (
         <Frame className="demography-captioned-chart demography-population-variant">


### PR DESCRIPTION
Stacked on top of #6255 so the base PR stays clean — merge into `bespoke-demography` whenever convenient.

Pure copy changes, no logic touched:

- Sentence-case chart titles, tab labels, and table headers ("Fertility rate", "Life expectancy at birth", "Net migration rate", "Age structure in {year}", "Life exp.")
- Periods added to chart subtitles
- Dropped "WPP" from user-facing labels: "UN WPP assumptions" → "UN assumptions", "UN WPP Medium projection" → "UN medium projection"
- Pyramid subtitle: "The population of {country}..." → "Population of {country}..."
- Replaced "panel on the left" tooltip reference with "assumptions panel" (style guide: no left/right because content stacks vertically on mobile)

All "UN WPP" mentions that remain are in code comments / console warnings, not user-visible.