### PR TITLE
(demography) Allow wider value range in manual parameter entry

### DIFF
--- a/bespoke/projects/demography/src/components/DemographyParameterEditor.tsx
+++ b/bespoke/projects/demography/src/components/DemographyParameterEditor.tsx
@@ -566,8 +566,8 @@ function DemographyParameterEditorContent({
                                     controlLabelFontSize={fonts.controlLabel}
                                     yScale={yScale}
                                     marginTop={margin.top}
-                                    min={config.inputMin}
-                                    max={config.inputMax}
+                                    min={config.dragMin ?? config.inputMin}
+                                    max={config.dragMax ?? config.inputMax}
                                     onValueChange={(value) =>
                                         handleChange({
                                             ...controlPoints,

--- a/bespoke/projects/demography/src/components/DemographyParameterEditor.tsx
+++ b/bespoke/projects/demography/src/components/DemographyParameterEditor.tsx
@@ -130,22 +130,26 @@ function DemographyParameterEditorContent({
         (y) => initialControlPoints[y]
     )
 
+    const controlValues = CONTROL_YEARS.map((y) => controlPoints[y])
+
     const minValue =
         yMinOverride ??
         Math.max(
-            config.yFloor ?? -Infinity,
+            config.inputMin ?? config.yFloor ?? -Infinity,
             Math.min(
                 Math.min(...unwppValues) - config.yPadding,
                 Math.min(...historicalValues),
-                Math.min(...initialControlValues) - config.yPadding
+                Math.min(...initialControlValues) - config.yPadding,
+                Math.min(...controlValues)
             )
         )
     const maxValue = Math.min(
-        config.yCeiling ?? Infinity,
+        config.inputMax ?? config.yCeiling ?? Infinity,
         Math.max(
             Math.max(...unwppValues) + config.yPadding,
             Math.max(...historicalValues),
-            Math.max(...initialControlValues) + config.yPadding
+            Math.max(...initialControlValues) + config.yPadding,
+            Math.max(...controlValues)
         )
     )
 
@@ -646,8 +650,8 @@ function DemographyParameterEditorContent({
                             value={controlPoints[editing.year]}
                             step={config.step}
                             decimals={config.decimals}
-                            min={yScale.domain()[0]}
-                            max={yScale.domain()[1]}
+                            min={config.inputMin ?? yScale.domain()[0]}
+                            max={config.inputMax ?? yScale.domain()[1]}
                             modified={isModified}
                             onCommit={(value) =>
                                 handleChange({

--- a/bespoke/projects/demography/src/components/DemographyParameterEditor.tsx
+++ b/bespoke/projects/demography/src/components/DemographyParameterEditor.tsx
@@ -135,7 +135,7 @@ function DemographyParameterEditorContent({
     const minValue =
         yMinOverride ??
         Math.max(
-            config.inputMin ?? config.yFloor ?? -Infinity,
+            config.yFloor ?? -Infinity,
             Math.min(
                 Math.min(...unwppValues) - config.yPadding,
                 Math.min(...historicalValues),
@@ -144,7 +144,7 @@ function DemographyParameterEditorContent({
             )
         )
     const maxValue = Math.min(
-        config.inputMax ?? config.yCeiling ?? Infinity,
+        config.yCeiling ?? Infinity,
         Math.max(
             Math.max(...unwppValues) + config.yPadding,
             Math.max(...historicalValues),
@@ -566,6 +566,8 @@ function DemographyParameterEditorContent({
                                     controlLabelFontSize={fonts.controlLabel}
                                     yScale={yScale}
                                     marginTop={margin.top}
+                                    min={config.inputMin}
+                                    max={config.inputMax}
                                     onValueChange={(value) =>
                                         handleChange({
                                             ...controlPoints,
@@ -715,6 +717,8 @@ function DraggableControlPoint({
     formatValue,
     yScale,
     marginTop,
+    min = -Infinity,
+    max = Infinity,
     dragArrowFontSize,
     controlLabelFontSize,
     onValueChange,
@@ -732,6 +736,8 @@ function DraggableControlPoint({
     formatValue: (v: number) => string
     yScale: { invert: (y: number) => number }
     marginTop: number
+    min?: number
+    max?: number
     dragArrowFontSize: number
     controlLabelFontSize: number
     onValueChange: (value: number) => void
@@ -783,7 +789,8 @@ function DraggableControlPoint({
                         info.didMove = true
                         setIsDragging(true)
                     }
-                    onValueChange(yScale.invert(point.y - marginTop))
+                    const value = yScale.invert(point.y - marginTop)
+                    onValueChange(Math.min(max, Math.max(min, value)))
                 }}
                 onPointerUp={() => {
                     const info = pressInfoRef.current

--- a/bespoke/projects/demography/src/components/DemographyParameterEditor.tsx
+++ b/bespoke/projects/demography/src/components/DemographyParameterEditor.tsx
@@ -566,8 +566,8 @@ function DemographyParameterEditorContent({
                                     controlLabelFontSize={fonts.controlLabel}
                                     yScale={yScale}
                                     marginTop={margin.top}
-                                    min={config.dragMin ?? config.inputMin}
-                                    max={config.dragMax ?? config.inputMax}
+                                    min={config.inputMin}
+                                    max={config.inputMax}
                                     onValueChange={(value) =>
                                         handleChange({
                                             ...controlPoints,

--- a/bespoke/projects/demography/src/helpers/parameterConfigs.ts
+++ b/bespoke/projects/demography/src/helpers/parameterConfigs.ts
@@ -51,7 +51,7 @@ export const parameterConfigByKey: Record<ParameterKey, ParameterConfig> = {
         axisUnit: "births per woman",
         yPadding: 2,
         yFloor: 0,
-        inputMin: 0.1,
+        inputMin: 0,
         inputMax: 10,
         step: 0.1,
         decimals: 1,

--- a/bespoke/projects/demography/src/helpers/parameterConfigs.ts
+++ b/bespoke/projects/demography/src/helpers/parameterConfigs.ts
@@ -27,8 +27,6 @@ interface ParameterConfig {
     yCeiling?: number
     inputMin?: number
     inputMax?: number
-    dragMin?: number
-    dragMax?: number
     step: number
     decimals: number
     subtitle: (entityName: string) => string
@@ -184,10 +182,8 @@ export const parameterConfigByKey: Record<ParameterKey, ParameterConfig> = {
         unit: "per 1,000 population",
         axisUnit: "‰",
         yPadding: 5,
-        inputMin: -100,
-        inputMax: 100,
-        dragMin: -20,
-        dragMax: 20,
+        inputMin: -20,
+        inputMax: 20,
         step: 0.1,
         decimals: 1,
         subtitle: (entityName: string) => {

--- a/bespoke/projects/demography/src/helpers/parameterConfigs.ts
+++ b/bespoke/projects/demography/src/helpers/parameterConfigs.ts
@@ -27,6 +27,8 @@ interface ParameterConfig {
     yCeiling?: number
     inputMin?: number
     inputMax?: number
+    dragMin?: number
+    dragMax?: number
     step: number
     decimals: number
     subtitle: (entityName: string) => string
@@ -182,8 +184,10 @@ export const parameterConfigByKey: Record<ParameterKey, ParameterConfig> = {
         unit: "per 1,000 population",
         axisUnit: "‰",
         yPadding: 5,
-        inputMin: -20,
-        inputMax: 20,
+        inputMin: -100,
+        inputMax: 100,
+        dragMin: -20,
+        dragMax: 20,
         step: 0.1,
         decimals: 1,
         subtitle: (entityName: string) => {

--- a/bespoke/projects/demography/src/helpers/parameterConfigs.ts
+++ b/bespoke/projects/demography/src/helpers/parameterConfigs.ts
@@ -25,6 +25,8 @@ interface ParameterConfig {
     yPadding: number
     yFloor?: number
     yCeiling?: number
+    inputMin?: number
+    inputMax?: number
     step: number
     decimals: number
     subtitle: (entityName: string) => string
@@ -49,6 +51,8 @@ export const parameterConfigByKey: Record<ParameterKey, ParameterConfig> = {
         axisUnit: "births per woman",
         yPadding: 2,
         yFloor: 0,
+        inputMin: 0.1,
+        inputMax: 10,
         step: 0.1,
         decimals: 1,
         subtitle: () => "Average number of births per woman.",
@@ -105,6 +109,8 @@ export const parameterConfigByKey: Record<ParameterKey, ParameterConfig> = {
         yPadding: 10,
         yFloor: 0,
         yCeiling: 130,
+        inputMin: 10,
+        inputMax: 150,
         step: 1,
         decimals: 0,
         subtitle: () =>
@@ -176,6 +182,8 @@ export const parameterConfigByKey: Record<ParameterKey, ParameterConfig> = {
         unit: "per 1,000 population",
         axisUnit: "‰",
         yPadding: 5,
+        inputMin: -20,
+        inputMax: 20,
         step: 0.1,
         decimals: 1,
         subtitle: (entityName: string) => {


### PR DESCRIPTION
This PR extends the range of values you can enter via the manual text entry box and the +/- icons of that box when clicking icons. The drag range stays more limited, but the manual entry can go to pretty extreme values.

You can play with it [here](http://staging-site-demography-wider-manual-entr/population-simulation-tool)

GPT 5.5. generated overview below

## Problem

The manual text input on each control-point dot was bounded by the chart's auto-computed domain — e.g. ~110 years for South Korea's life expectancy — making it impossible to explore scenarios beyond the data-driven range. The cap wasn't intentional; it was an accidental consequence of passing `yScale.domain()` directly as `min`/`max` to the `NumberField`.

## Changes

**`helpers/parameterConfigs.ts`**
- Add `inputMin` / `inputMax` to the `ParameterConfig` interface for manual text-entry limits
- Add optional `dragMin` / `dragMax` limits for parameters where dragging should stay within a narrower range than manual entry
- Set absolute manual-entry limits per parameter:
  - Life expectancy: 10 – 150 years
  - Fertility rate: 0 – 10 births per woman
  - Net migration rate: −100 – +100‰
- Keep drag limits for net migration at −20 – +20‰

**`components/DemographyParameterEditor.tsx`**
- Pass `config.inputMin` / `config.inputMax` to react-aria's `NumberField` instead of the chart domain bounds — manual entry now accepts the configured full range; the +/− step buttons respect the same limits
- Include the current user-set control-point values in the chart domain calculation, so the chart rescales automatically when a typed value falls outside the auto-computed range
- Keep source/reference values in the chart domain calculation, so unusually high/low source migration rates remain visible
- Clamp dragging with the configured drag limits where present, falling back to manual-entry limits otherwise

## Behaviour preserved / clarified

Dragging a control point continues to clamp via `yScale.clamp: true` and the configured drag/input bounds, so dots stay within the rendered chart. For net migration, manual entry can use the wider −100 – +100‰ range, while dragging remains limited to −20 – +20‰.

The chart domain still respects parameter-specific visual caps such as `yFloor` / `yCeiling`; for example, life expectancy remains visually capped at 130 years even though manual entry accepts values up to 150. Resetting to UN WPP values returns the chart to its normal auto-scaled range.
