### PR TITLE
Add age pyramid tooltip

### DIFF
--- a/bespoke/projects/demography/src/components/PopulationPyramid.tsx
+++ b/bespoke/projects/demography/src/components/PopulationPyramid.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo, useRef } from "react"
+import { useState, useCallback, useMemo } from "react"
 import { useParentSize } from "@visx/responsive"
 import { scaleLinear, scaleBand } from "@visx/scale"
 import { Bar } from "@visx/shape"
@@ -22,20 +22,25 @@ import { TextWrap } from "@ourworldindata/components"
 import { BezierArrow } from "../../../../components/BezierArrow/BezierArrow.js"
 import { computeMaxAgeGroupPopulation } from "../model/projectionRunner"
 import {
-    groupByAgeRange,
-    calculateMedianAge,
-    findAgeGroup,
     formatPopulationValueShort,
     formatPopulationAxisLabelShort,
+    getPopulationPyramidAgeBucketsBySex,
+    getTotalPopulationFromPyramidAgeBuckets,
+    convertPopulationPyramidAgeBucketsToUnit,
 } from "../helpers/utils"
 import { Bounds } from "@ourworldindata/utils"
 import type { AgeZone, AgeZoneWithBounds } from "../helpers/types.js"
 import { toBreakpoint, useBreakpoint } from "../helpers/useBreakpoint.js"
-import { useDismissOnTouchOutside } from "../../../../hooks/useDismissOnTouchOutside.js"
+import { usePinnedTooltip } from "../../../../hooks/usePinnedTooltip.js"
 import {
     getPopulationPyramidFonts,
     type PopulationPyramidFonts,
 } from "../helpers/fonts.js"
+import { localPoint } from "@visx/event"
+import {
+    PopulationPyramidTooltip,
+    type PopulationPyramidTooltipState,
+} from "./PopulationPyramidTooltip.js"
 
 // Labels reversed so 0-4 at bottom, oldest at top
 const AGE_GROUP_LABELS = [...PYRAMID_AGE_GROUPS].reverse()
@@ -114,30 +119,24 @@ function PopulationPyramidContent({
             : simulation.getPopulationForYear
     )(year)
 
-    const { ageBucketsBySex } = useMemo(() => {
-        const male = populationBySex?.male ?? []
-        const female = populationBySex?.female ?? []
-        const totalPop =
-            male.reduce((a, b) => a + b, 0) + female.reduce((a, b) => a + b, 0)
-        const toBuckets = (buckets: Record<string, number>) => {
-            if (unit === "absolute") return buckets
-            const result: Record<string, number> = {}
-            for (const [k, v] of Object.entries(buckets)) {
-                result[k] = totalPop > 0 ? (v / totalPop) * 100 : 0
+    const { ageBucketsBySex, absoluteAgeBucketsBySex, totalPopulation } =
+        useMemo(() => {
+            const absoluteAgeBucketsBySex =
+                getPopulationPyramidAgeBucketsBySex(populationBySex)
+            const totalPopulation = getTotalPopulationFromPyramidAgeBuckets(
+                absoluteAgeBucketsBySex
+            )
+
+            return {
+                ageBucketsBySex: convertPopulationPyramidAgeBucketsToUnit(
+                    absoluteAgeBucketsBySex,
+                    totalPopulation,
+                    unit
+                ),
+                absoluteAgeBucketsBySex,
+                totalPopulation,
             }
-            return result
-        }
-        return {
-            ageBucketsBySex: {
-                male: toBuckets(groupByAgeRange(male)),
-                female: toBuckets(groupByAgeRange(female)),
-            },
-            medianAgeBucketBySex: {
-                male: findAgeGroup(calculateMedianAge(male)),
-                female: findAgeGroup(calculateMedianAge(female)),
-            },
-        }
-    }, [populationBySex, unit])
+        }, [populationBySex, unit])
 
     const xAxisMax = useMemo(() => {
         if (xAxisScaleMode === "adaptive") {
@@ -183,32 +182,57 @@ function PopulationPyramidContent({
         [ageZones, yScale, innerHeight, margin.left, width]
     )
 
-    const [hoveredAgeGroup, setHoveredAgeGroup] = useState<string | null>(null)
-    const svgRef = useRef<SVGSVGElement>(null)
-    const dismissHover = useCallback(() => setHoveredAgeGroup(null), [])
-    useDismissOnTouchOutside(svgRef, hoveredAgeGroup !== null, dismissHover)
+    const [tooltipState, setTooltipState] =
+        useState<PopulationPyramidTooltipState | null>(null)
+    const hoveredAgeGroup = tooltipState?.ageGroup ?? null
+    const dismissHover = useCallback(() => setTooltipState(null), [])
+    const { ref: chartRef, isPinned: pinTooltipToBottom } =
+        usePinnedTooltip<HTMLDivElement>(tooltipState !== null, dismissHover)
+
+    const showTooltip = useCallback((e: React.PointerEvent, group: string) => {
+        const point = localPoint(e)
+        if (!point) return
+        setTooltipState({
+            ageGroup: group,
+            position: { x: point.x, y: point.y },
+        })
+    }, [])
 
     const handlePointerEnter = useCallback(
         (e: React.PointerEvent, group: string) => {
-            if (e.pointerType === "mouse") setHoveredAgeGroup(group)
+            if (e.pointerType === "mouse") showTooltip(e, group)
         },
-        []
+        [showTooltip]
+    )
+    const handlePointerMove = useCallback(
+        (e: React.PointerEvent, group: string) => {
+            if (e.pointerType === "mouse") showTooltip(e, group)
+        },
+        [showTooltip]
     )
     const handlePointerLeave = useCallback((e: React.PointerEvent) => {
-        if (e.pointerType === "mouse") setHoveredAgeGroup(null)
+        if (e.pointerType === "mouse") setTooltipState(null)
     }, [])
     const handlePointerDown = useCallback(
         (e: React.PointerEvent, group: string) => {
             if (e.pointerType === "touch") {
                 e.stopPropagation()
-                setHoveredAgeGroup((prev) => (prev === group ? null : group))
+                setTooltipState((prev) => {
+                    if (prev?.ageGroup === group) return null
+                    const point = localPoint(e)
+                    if (!point) return prev
+                    return {
+                        ageGroup: group,
+                        position: { x: point.x, y: point.y },
+                    }
+                })
             }
         },
         []
     )
     return (
-        <div style={{ position: "relative" }}>
-            <svg ref={svgRef} width={width} height={height} overflow="visible">
+        <div ref={chartRef} style={{ position: "relative" }}>
+            <svg width={width} height={height} overflow="visible">
                 <Group top={margin.top}>
                     {ageZonesWithBounds && (
                         <AgeZoneBackgroundBands ageZones={ageZonesWithBounds} />
@@ -280,6 +304,7 @@ function PopulationPyramidContent({
                                 height={bottom - y}
                                 fill="transparent"
                                 onPointerEnter={(e) => handlePointerEnter(e, g)}
+                                onPointerMove={(e) => handlePointerMove(e, g)}
                                 onPointerLeave={handlePointerLeave}
                                 onPointerDown={(e) => handlePointerDown(e, g)}
                             />
@@ -287,6 +312,16 @@ function PopulationPyramidContent({
                     })}
                 </Group>
             </svg>
+            <PopulationPyramidTooltip
+                tooltipState={tooltipState}
+                ageBucketsBySex={absoluteAgeBucketsBySex}
+                totalPopulation={totalPopulation}
+                width={width}
+                height={height}
+                maleColor={defaultBarColor}
+                femaleColor={defaultBarColor}
+                pinToBottom={pinTooltipToBottom}
+            />
         </div>
     )
 }

--- a/bespoke/projects/demography/src/components/PopulationPyramid.tsx
+++ b/bespoke/projects/demography/src/components/PopulationPyramid.tsx
@@ -189,14 +189,50 @@ function PopulationPyramidContent({
     const { ref: chartRef, isPinned: pinTooltipToBottom } =
         usePinnedTooltip<HTMLDivElement>(tooltipState !== null, dismissHover)
 
-    const showTooltip = useCallback((e: React.PointerEvent, group: string) => {
-        const point = localPoint(e)
-        if (!point) return
-        setTooltipState({
-            ageGroup: group,
-            position: { x: point.x, y: point.y },
-        })
-    }, [])
+    // Anchor the tooltip to the hovered bar's outer end so it doesn't follow
+    // the cursor along a wide hit row. The cursor's horizontal position picks
+    // which side (male/female) to anchor to.
+    const computeTooltipState = useCallback(
+        (
+            point: { x: number; y: number },
+            group: string
+        ): PopulationPyramidTooltipState => {
+            const verticalCenterX = centerX + centerGap / 2
+            const isFemaleSide = point.x > verticalCenterX
+            const buckets = isFemaleSide
+                ? ageBucketsBySex.female
+                : ageBucketsBySex.male
+            const barValue = buckets[group] ?? 0
+            const anchorX = isFemaleSide
+                ? centerX + centerGap + xScale.female(barValue)
+                : margin.left + xScale.male(barValue)
+            const anchorY =
+                margin.top + (yScale(group) ?? 0) + yScale.bandwidth() / 2
+            return {
+                ageGroup: group,
+                position: { x: anchorX, y: anchorY },
+                offsetXDirection: isFemaleSide ? "right" : "left",
+            }
+        },
+        [
+            ageBucketsBySex,
+            centerX,
+            centerGap,
+            margin.left,
+            margin.top,
+            xScale,
+            yScale,
+        ]
+    )
+
+    const showTooltip = useCallback(
+        (e: React.PointerEvent, group: string) => {
+            const point = localPoint(e)
+            if (!point) return
+            setTooltipState(computeTooltipState(point, group))
+        },
+        [computeTooltipState]
+    )
 
     const handlePointerEnter = useCallback(
         (e: React.PointerEvent, group: string) => {
@@ -217,18 +253,15 @@ function PopulationPyramidContent({
         (e: React.PointerEvent, group: string) => {
             if (e.pointerType === "touch") {
                 e.stopPropagation()
+                const point = localPoint(e)
                 setTooltipState((prev) => {
                     if (prev?.ageGroup === group) return null
-                    const point = localPoint(e)
                     if (!point) return prev
-                    return {
-                        ageGroup: group,
-                        position: { x: point.x, y: point.y },
-                    }
+                    return computeTooltipState(point, group)
                 })
             }
         },
-        []
+        [computeTooltipState]
     )
     return (
         <div ref={chartRef} style={{ position: "relative" }}>

--- a/bespoke/projects/demography/src/components/PopulationPyramidHorizontal.tsx
+++ b/bespoke/projects/demography/src/components/PopulationPyramidHorizontal.tsx
@@ -145,14 +145,51 @@ function PopulationPyramidHorizontalContent({
     const { ref: chartRef, isPinned: pinTooltipToBottom } =
         usePinnedTooltip<HTMLDivElement>(tooltipState !== null, dismissHover)
 
-    const showTooltip = useCallback((e: React.PointerEvent, group: string) => {
-        const point = localPoint(e)
-        if (!point) return
-        setTooltipState({
-            ageGroup: group,
-            position: { x: point.x, y: point.y },
-        })
-    }, [])
+    // Anchor the tooltip to the hovered bar's outer end so it doesn't follow
+    // the cursor along a tall hit column. The cursor's vertical position picks
+    // which side (female/male) to anchor to.
+    const computeTooltipState = useCallback(
+        (
+            point: { x: number; y: number },
+            group: string
+        ): PopulationPyramidTooltipState => {
+            const horizontalCenterY = margin.top + centerY
+            const isFemaleSide = point.y < horizontalCenterY
+            const buckets = isFemaleSide
+                ? ageBucketsBySex.female
+                : ageBucketsBySex.male
+            const barValue = buckets[group] ?? 0
+            const { startAge } = parseAgeGroup(group)
+            const anchorX =
+                margin.left + xScale(startAge + PYRAMID_AGE_GROUP_SIZE / 2)
+            const anchorY =
+                margin.top +
+                (isFemaleSide ? yScaleFemale(barValue) : yScaleMale(barValue))
+            return {
+                ageGroup: group,
+                position: { x: anchorX, y: anchorY },
+                offsetYDirection: isFemaleSide ? "upward" : "downward",
+            }
+        },
+        [
+            ageBucketsBySex,
+            centerY,
+            margin.left,
+            margin.top,
+            xScale,
+            yScaleFemale,
+            yScaleMale,
+        ]
+    )
+
+    const showTooltip = useCallback(
+        (e: React.PointerEvent, group: string) => {
+            const point = localPoint(e)
+            if (!point) return
+            setTooltipState(computeTooltipState(point, group))
+        },
+        [computeTooltipState]
+    )
 
     const handlePointerEnter = useCallback(
         (e: React.PointerEvent, group: string) => {
@@ -173,18 +210,15 @@ function PopulationPyramidHorizontalContent({
         (e: React.PointerEvent, group: string) => {
             if (e.pointerType === "touch") {
                 e.stopPropagation()
+                const point = localPoint(e)
                 setTooltipState((prev) => {
                     if (prev?.ageGroup === group) return null
-                    const point = localPoint(e)
                     if (!point) return prev
-                    return {
-                        ageGroup: group,
-                        position: { x: point.x, y: point.y },
-                    }
+                    return computeTooltipState(point, group)
                 })
             }
         },
-        []
+        [computeTooltipState]
     )
 
     return (

--- a/bespoke/projects/demography/src/components/PopulationPyramidHorizontal.tsx
+++ b/bespoke/projects/demography/src/components/PopulationPyramidHorizontal.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo, useRef } from "react"
+import { useState, useCallback, useMemo } from "react"
 import { useParentSize } from "@visx/responsive"
 import { scaleLinear } from "@visx/scale"
 import { Group } from "@visx/group"
@@ -17,16 +17,23 @@ import {
 import { GRAPHER_LIGHT_TEXT } from "@ourworldindata/grapher/src/color/ColorConstants.js"
 import { computeMaxAgeGroupPopulation } from "../model/projectionRunner"
 import {
-    groupByAgeRange,
     parseAgeGroup,
     formatPopulationValueShort,
     formatPopulationAxisLabelShort,
+    getPopulationPyramidAgeBucketsBySex,
+    getTotalPopulationFromPyramidAgeBuckets,
+    convertPopulationPyramidAgeBucketsToUnit,
 } from "../helpers/utils"
 import { Bounds, formatValue } from "@ourworldindata/utils"
 import { Halo, TextWrap, TextWrapSvg } from "@ourworldindata/components"
 import { toBreakpoint, useBreakpoint } from "../helpers/useBreakpoint.js"
-import { useDismissOnTouchOutside } from "../../../../hooks/useDismissOnTouchOutside.js"
+import { usePinnedTooltip } from "../../../../hooks/usePinnedTooltip.js"
 import { getHorizontalPyramidFonts } from "../helpers/fonts.js"
+import { localPoint } from "@visx/event"
+import {
+    PopulationPyramidTooltip,
+    type PopulationPyramidTooltipState,
+} from "./PopulationPyramidTooltip.js"
 
 export interface PopulationPyramidHorizontalProps {
     simulation: Simulation
@@ -69,24 +76,24 @@ function PopulationPyramidHorizontalContent({
             : simulation.getPopulationForYear
     )(year)
 
-    const ageBucketsBySex = useMemo(() => {
-        const male = populationBySex?.male ?? []
-        const female = populationBySex?.female ?? []
-        const totalPop =
-            male.reduce((a, b) => a + b, 0) + female.reduce((a, b) => a + b, 0)
-        const toBuckets = (buckets: Record<string, number>) => {
-            if (unit === "absolute") return buckets
-            const result: Record<string, number> = {}
-            for (const [k, v] of Object.entries(buckets)) {
-                result[k] = totalPop > 0 ? (v / totalPop) * 100 : 0
+    const { ageBucketsBySex, absoluteAgeBucketsBySex, totalPopulation } =
+        useMemo(() => {
+            const absoluteAgeBucketsBySex =
+                getPopulationPyramidAgeBucketsBySex(populationBySex)
+            const totalPopulation = getTotalPopulationFromPyramidAgeBuckets(
+                absoluteAgeBucketsBySex
+            )
+
+            return {
+                ageBucketsBySex: convertPopulationPyramidAgeBucketsToUnit(
+                    absoluteAgeBucketsBySex,
+                    totalPopulation,
+                    unit
+                ),
+                absoluteAgeBucketsBySex,
+                totalPopulation,
             }
-            return result
-        }
-        return {
-            male: toBuckets(groupByAgeRange(male)),
-            female: toBuckets(groupByAgeRange(female)),
-        }
-    }, [populationBySex, unit])
+        }, [populationBySex, unit])
 
     const xScale = useMemo(
         () =>
@@ -131,144 +138,182 @@ function PopulationPyramidHorizontalContent({
         [centerY, centerGap, innerHeight, yMax]
     )
 
-    const [hoveredAgeGroup, setHoveredAgeGroup] = useState<string | null>(null)
-    const svgRef = useRef<SVGSVGElement>(null)
-    const dismissHover = useCallback(() => setHoveredAgeGroup(null), [])
-    useDismissOnTouchOutside(svgRef, hoveredAgeGroup !== null, dismissHover)
+    const [tooltipState, setTooltipState] =
+        useState<PopulationPyramidTooltipState | null>(null)
+    const hoveredAgeGroup = tooltipState?.ageGroup ?? null
+    const dismissHover = useCallback(() => setTooltipState(null), [])
+    const { ref: chartRef, isPinned: pinTooltipToBottom } =
+        usePinnedTooltip<HTMLDivElement>(tooltipState !== null, dismissHover)
+
+    const showTooltip = useCallback((e: React.PointerEvent, group: string) => {
+        const point = localPoint(e)
+        if (!point) return
+        setTooltipState({
+            ageGroup: group,
+            position: { x: point.x, y: point.y },
+        })
+    }, [])
 
     const handlePointerEnter = useCallback(
         (e: React.PointerEvent, group: string) => {
-            if (e.pointerType === "mouse") setHoveredAgeGroup(group)
+            if (e.pointerType === "mouse") showTooltip(e, group)
         },
-        []
+        [showTooltip]
+    )
+    const handlePointerMove = useCallback(
+        (e: React.PointerEvent, group: string) => {
+            if (e.pointerType === "mouse") showTooltip(e, group)
+        },
+        [showTooltip]
     )
     const handlePointerLeave = useCallback((e: React.PointerEvent) => {
-        if (e.pointerType === "mouse") setHoveredAgeGroup(null)
+        if (e.pointerType === "mouse") setTooltipState(null)
     }, [])
     const handlePointerDown = useCallback(
         (e: React.PointerEvent, group: string) => {
             if (e.pointerType === "touch") {
                 e.stopPropagation()
-                setHoveredAgeGroup((prev) => (prev === group ? null : group))
+                setTooltipState((prev) => {
+                    if (prev?.ageGroup === group) return null
+                    const point = localPoint(e)
+                    if (!point) return prev
+                    return {
+                        ageGroup: group,
+                        position: { x: point.x, y: point.y },
+                    }
+                })
             }
         },
         []
     )
 
     return (
-        <svg ref={svgRef} width={width} height={height} overflow="visible">
-            <Group top={margin.top} left={margin.left}>
-                <HorizontalGridLines
-                    yScale={yScaleFemale}
-                    innerWidth={innerWidth}
-                />
-                <HorizontalGridLines
-                    yScale={yScaleMale}
-                    innerWidth={innerWidth}
-                />
-                <GridLabels
-                    yScale={yScaleFemale}
-                    innerWidth={innerWidth}
-                    innerHeight={innerHeight}
-                    fontSize={fonts.yTick}
-                    labelColor={GRID_LABEL_COLOR}
-                    position="above"
-                    unit={unit}
-                />
-                <GridLabels
-                    yScale={yScaleMale}
-                    innerWidth={innerWidth}
-                    innerHeight={innerHeight}
-                    fontSize={fonts.yTick}
-                    labelColor={GRID_LABEL_COLOR}
-                    position="below"
-                    unit={unit}
-                />
+        <div ref={chartRef} style={{ position: "relative" }}>
+            <svg width={width} height={height} overflow="visible">
+                <Group top={margin.top} left={margin.left}>
+                    <HorizontalGridLines
+                        yScale={yScaleFemale}
+                        innerWidth={innerWidth}
+                    />
+                    <HorizontalGridLines
+                        yScale={yScaleMale}
+                        innerWidth={innerWidth}
+                    />
+                    <GridLabels
+                        yScale={yScaleFemale}
+                        innerWidth={innerWidth}
+                        innerHeight={innerHeight}
+                        fontSize={fonts.yTick}
+                        labelColor={GRID_LABEL_COLOR}
+                        position="above"
+                        unit={unit}
+                    />
+                    <GridLabels
+                        yScale={yScaleMale}
+                        innerWidth={innerWidth}
+                        innerHeight={innerHeight}
+                        fontSize={fonts.yTick}
+                        labelColor={GRID_LABEL_COLOR}
+                        position="below"
+                        unit={unit}
+                    />
 
-                <AgeGroupBars
-                    xScale={xScale}
-                    yScale={yScaleFemale}
-                    ageBuckets={ageBucketsBySex.female}
-                    color={effectiveFemaleColor}
-                    hoveredAgeGroup={hoveredAgeGroup}
-                />
-                <AgeGroupBars
-                    xScale={xScale}
-                    yScale={yScaleMale}
-                    ageBuckets={ageBucketsBySex.male}
-                    color={effectiveMaleColor}
-                    hoveredAgeGroup={hoveredAgeGroup}
-                />
-                <VerticalDividers
-                    xScale={xScale}
-                    tickValues={[25, 50, 75, 100, 125]}
-                    femaleBaseline={centerY - centerGap / 2}
-                    maleBaseline={centerY + centerGap / 2}
-                    innerHeight={innerHeight}
-                />
+                    <AgeGroupBars
+                        xScale={xScale}
+                        yScale={yScaleFemale}
+                        ageBuckets={ageBucketsBySex.female}
+                        color={effectiveFemaleColor}
+                        hoveredAgeGroup={hoveredAgeGroup}
+                    />
+                    <AgeGroupBars
+                        xScale={xScale}
+                        yScale={yScaleMale}
+                        ageBuckets={ageBucketsBySex.male}
+                        color={effectiveMaleColor}
+                        hoveredAgeGroup={hoveredAgeGroup}
+                    />
+                    <VerticalDividers
+                        xScale={xScale}
+                        tickValues={[25, 50, 75, 100, 125]}
+                        femaleBaseline={centerY - centerGap / 2}
+                        maleBaseline={centerY + centerGap / 2}
+                        innerHeight={innerHeight}
+                    />
 
-                <BarValueLabel
-                    xScale={xScale}
-                    yScale={yScaleFemale}
-                    ageBuckets={ageBucketsBySex.female}
-                    color={effectiveFemaleColor}
-                    hoveredAgeGroup={hoveredAgeGroup}
-                    fontSize={fonts.hoverLabel}
-                    unit={unit}
-                />
-                <BarValueLabel
-                    xScale={xScale}
-                    yScale={yScaleMale}
-                    ageBuckets={ageBucketsBySex.male}
-                    color={effectiveMaleColor}
-                    hoveredAgeGroup={hoveredAgeGroup}
-                    fontSize={fonts.hoverLabel}
-                    unit={unit}
-                />
-                <HoverHitRects
-                    xScale={xScale}
-                    innerHeight={innerHeight}
-                    onPointerEnter={handlePointerEnter}
-                    onPointerLeave={handlePointerLeave}
-                    onPointerDown={handlePointerDown}
-                />
+                    <BarValueLabel
+                        xScale={xScale}
+                        yScale={yScaleFemale}
+                        ageBuckets={ageBucketsBySex.female}
+                        color={effectiveFemaleColor}
+                        hoveredAgeGroup={hoveredAgeGroup}
+                        fontSize={fonts.hoverLabel}
+                        unit={unit}
+                    />
+                    <BarValueLabel
+                        xScale={xScale}
+                        yScale={yScaleMale}
+                        ageBuckets={ageBucketsBySex.male}
+                        color={effectiveMaleColor}
+                        hoveredAgeGroup={hoveredAgeGroup}
+                        fontSize={fonts.hoverLabel}
+                        unit={unit}
+                    />
+                    <HoverHitRects
+                        xScale={xScale}
+                        innerHeight={innerHeight}
+                        onPointerEnter={handlePointerEnter}
+                        onPointerMove={handlePointerMove}
+                        onPointerLeave={handlePointerLeave}
+                        onPointerDown={handlePointerDown}
+                    />
 
-                <AgeAxisCenter
-                    xScale={xScale}
-                    centerY={centerY}
-                    centerGap={centerGap}
-                    innerWidth={innerWidth}
-                    tickValues={[25, 50, 75, 100, 125]}
-                    fontSize={fonts.xTick}
-                />
+                    <AgeAxisCenter
+                        xScale={xScale}
+                        centerY={centerY}
+                        centerGap={centerGap}
+                        innerWidth={innerWidth}
+                        tickValues={[25, 50, 75, 100, 125]}
+                        fontSize={fonts.xTick}
+                    />
 
-                {/* Sex labels in the center gap */}
-                <text
-                    x={0}
-                    y={centerY}
-                    dy={-1}
-                    dominantBaseline="auto"
-                    fontSize={fonts.sexLabel}
-                    fill={effectiveFemaleColor}
-                    fontWeight={700}
-                    style={{ pointerEvents: "none" }}
-                >
-                    WOMEN
-                </text>
-                <text
-                    x={0}
-                    y={centerY}
-                    dy={1}
-                    dominantBaseline="hanging"
-                    fontSize={fonts.sexLabel}
-                    fill={effectiveMaleColor}
-                    fontWeight={700}
-                    style={{ pointerEvents: "none" }}
-                >
-                    MEN
-                </text>
-            </Group>
-        </svg>
+                    {/* Sex labels in the center gap */}
+                    <text
+                        x={0}
+                        y={centerY}
+                        dy={-1}
+                        dominantBaseline="auto"
+                        fontSize={fonts.sexLabel}
+                        fill={effectiveFemaleColor}
+                        fontWeight={700}
+                        style={{ pointerEvents: "none" }}
+                    >
+                        WOMEN
+                    </text>
+                    <text
+                        x={0}
+                        y={centerY}
+                        dy={1}
+                        dominantBaseline="hanging"
+                        fontSize={fonts.sexLabel}
+                        fill={effectiveMaleColor}
+                        fontWeight={700}
+                        style={{ pointerEvents: "none" }}
+                    >
+                        MEN
+                    </text>
+                </Group>
+            </svg>
+            <PopulationPyramidTooltip
+                tooltipState={tooltipState}
+                ageBucketsBySex={absoluteAgeBucketsBySex}
+                totalPopulation={totalPopulation}
+                width={width}
+                height={height}
+                maleColor={effectiveMaleColor}
+                femaleColor={effectiveFemaleColor}
+                pinToBottom={pinTooltipToBottom}
+            />
+        </div>
     )
 }
 
@@ -394,12 +439,14 @@ function HoverHitRects({
     xScale,
     innerHeight,
     onPointerEnter,
+    onPointerMove,
     onPointerLeave,
     onPointerDown,
 }: {
     xScale: ReturnType<typeof scaleLinear<number>>
     innerHeight: number
     onPointerEnter: (e: React.PointerEvent, g: string) => void
+    onPointerMove: (e: React.PointerEvent, g: string) => void
     onPointerLeave: (e: React.PointerEvent) => void
     onPointerDown: (e: React.PointerEvent, g: string) => void
 }) {
@@ -420,6 +467,7 @@ function HoverHitRects({
                         height={innerHeight}
                         fill="transparent"
                         onPointerEnter={(e) => onPointerEnter(e, g)}
+                        onPointerMove={(e) => onPointerMove(e, g)}
                         onPointerLeave={onPointerLeave}
                         onPointerDown={(e) => onPointerDown(e, g)}
                     />

--- a/bespoke/projects/demography/src/components/PopulationPyramidTooltip.tsx
+++ b/bespoke/projects/demography/src/components/PopulationPyramidTooltip.tsx
@@ -1,5 +1,4 @@
 import type { ReactElement } from "react"
-import { GRAPHER_LIGHT_TEXT } from "@ourworldindata/grapher/src/color/ColorConstants.js"
 import { TooltipCard } from "@ourworldindata/grapher/src/tooltip/TooltipCard.js"
 import { TooltipValue } from "@ourworldindata/grapher/src/tooltip/TooltipContents.js"
 import { GrapherTooltipAnchor } from "@ourworldindata/utils"
@@ -9,6 +8,10 @@ import {
     parseAgeGroup,
     type PopulationPyramidAgeBucketsBySex,
 } from "../helpers/utils.js"
+
+// Match the offset used by the main population curve tooltip.
+const TOOLTIP_OFFSET_X = 15
+const TOOLTIP_OFFSET_Y = -10
 
 export interface PopulationPyramidTooltipState {
     ageGroup: string
@@ -41,9 +44,14 @@ export function PopulationPyramidTooltip({
     const { ageGroup, position } = tooltipState
     const malePopulation = ageBucketsBySex.male[ageGroup] ?? 0
     const femalePopulation = ageBucketsBySex.female[ageGroup] ?? 0
-    const ageGroupPopulation = malePopulation + femalePopulation
-    const populationShare =
-        totalPopulation > 0 ? (ageGroupPopulation / totalPopulation) * 100 : 0
+    const malePopulationShare = getShareOfTotalPopulation(
+        malePopulation,
+        totalPopulation
+    )
+    const femalePopulationShare = getShareOfTotalPopulation(
+        femalePopulation,
+        totalPopulation
+    )
     const labels = getSexLabels(ageGroup)
 
     return (
@@ -51,29 +59,44 @@ export function PopulationPyramidTooltip({
             id="population-pyramid-tooltip"
             x={position.x}
             y={position.y}
-            offsetX={15}
-            offsetY={-10}
+            offsetX={TOOLTIP_OFFSET_X}
+            offsetY={TOOLTIP_OFFSET_Y}
             title={`Ages ${formatAgeGroup(ageGroup)}`}
             anchor={pinToBottom ? GrapherTooltipAnchor.Bottom : undefined}
             containerBounds={pinToBottom ? undefined : { width, height }}
         >
             <TooltipValue
-                label="Share of population"
-                value={formatPopulationShare(populationShare, 3)}
-                color={GRAPHER_LIGHT_TEXT}
-            />
-            <TooltipValue
                 label={labels.male}
-                value={formatPopulationValueLong(malePopulation, 3)}
+                value={formatSexPopulationValue(
+                    malePopulationShare,
+                    malePopulation
+                )}
                 color={maleColor}
             />
             <TooltipValue
                 label={labels.female}
-                value={formatPopulationValueLong(femalePopulation, 3)}
+                value={formatSexPopulationValue(
+                    femalePopulationShare,
+                    femalePopulation
+                )}
                 color={femaleColor}
             />
         </TooltipCard>
     )
+}
+
+function getShareOfTotalPopulation(
+    population: number,
+    totalPopulation: number
+): number {
+    return totalPopulation > 0 ? (population / totalPopulation) * 100 : 0
+}
+
+function formatSexPopulationValue(
+    populationShare: number,
+    population: number
+): string {
+    return `${formatPopulationShare(populationShare, 3)} · ${formatPopulationValueLong(population, 3)}`
 }
 
 function getSexLabels(ageGroup: string): { male: string; female: string } {

--- a/bespoke/projects/demography/src/components/PopulationPyramidTooltip.tsx
+++ b/bespoke/projects/demography/src/components/PopulationPyramidTooltip.tsx
@@ -1,0 +1,89 @@
+import type { ReactElement } from "react"
+import { GRAPHER_LIGHT_TEXT } from "@ourworldindata/grapher/src/color/ColorConstants.js"
+import { TooltipCard } from "@ourworldindata/grapher/src/tooltip/TooltipCard.js"
+import { TooltipValue } from "@ourworldindata/grapher/src/tooltip/TooltipContents.js"
+import { GrapherTooltipAnchor } from "@ourworldindata/utils"
+import {
+    formatPopulationShare,
+    formatPopulationValueLong,
+    parseAgeGroup,
+    type PopulationPyramidAgeBucketsBySex,
+} from "../helpers/utils.js"
+
+export interface PopulationPyramidTooltipState {
+    ageGroup: string
+    position: { x: number; y: number }
+}
+
+interface PopulationPyramidTooltipProps {
+    tooltipState: PopulationPyramidTooltipState | null
+    ageBucketsBySex: PopulationPyramidAgeBucketsBySex
+    totalPopulation: number
+    width: number
+    height: number
+    maleColor: string
+    femaleColor: string
+    pinToBottom?: boolean
+}
+
+export function PopulationPyramidTooltip({
+    tooltipState,
+    ageBucketsBySex,
+    totalPopulation,
+    width,
+    height,
+    maleColor,
+    femaleColor,
+    pinToBottom = false,
+}: PopulationPyramidTooltipProps): ReactElement | null {
+    if (!tooltipState) return null
+
+    const { ageGroup, position } = tooltipState
+    const malePopulation = ageBucketsBySex.male[ageGroup] ?? 0
+    const femalePopulation = ageBucketsBySex.female[ageGroup] ?? 0
+    const ageGroupPopulation = malePopulation + femalePopulation
+    const populationShare =
+        totalPopulation > 0 ? (ageGroupPopulation / totalPopulation) * 100 : 0
+    const labels = getSexLabels(ageGroup)
+
+    return (
+        <TooltipCard
+            id="population-pyramid-tooltip"
+            x={position.x}
+            y={position.y}
+            offsetX={15}
+            offsetY={-10}
+            title={`Ages ${formatAgeGroup(ageGroup)}`}
+            anchor={pinToBottom ? GrapherTooltipAnchor.Bottom : undefined}
+            containerBounds={pinToBottom ? undefined : { width, height }}
+        >
+            <TooltipValue
+                label="Share of population"
+                value={formatPopulationShare(populationShare, 3)}
+                color={GRAPHER_LIGHT_TEXT}
+            />
+            <TooltipValue
+                label={labels.male}
+                value={formatPopulationValueLong(malePopulation, 3)}
+                color={maleColor}
+            />
+            <TooltipValue
+                label={labels.female}
+                value={formatPopulationValueLong(femalePopulation, 3)}
+                color={femaleColor}
+            />
+        </TooltipCard>
+    )
+}
+
+function getSexLabels(ageGroup: string): { male: string; female: string } {
+    const { startAge, endAge } = parseAgeGroup(ageGroup)
+
+    if (endAge < 18) return { male: "Boys", female: "Girls" }
+    if (startAge >= 18) return { male: "Men", female: "Women" }
+    return { male: "Men and boys", female: "Women and girls" }
+}
+
+function formatAgeGroup(ageGroup: string): string {
+    return ageGroup.replace("-", "–")
+}

--- a/bespoke/projects/demography/src/components/PopulationPyramidTooltip.tsx
+++ b/bespoke/projects/demography/src/components/PopulationPyramidTooltip.tsx
@@ -9,13 +9,17 @@ import {
     type PopulationPyramidAgeBucketsBySex,
 } from "../helpers/utils.js"
 
-// Match the offset used by the main population curve tooltip.
 const TOOLTIP_OFFSET_X = 15
-const TOOLTIP_OFFSET_Y = -10
+const TOOLTIP_OFFSET_Y = 10
 
 export interface PopulationPyramidTooltipState {
     ageGroup: string
+    // Anchor point for the tooltip, in SVG-relative coordinates.
+    // Anchored to the hovered bar's outer edge so the tooltip doesn't follow
+    // the cursor within a single row/column.
     position: { x: number; y: number }
+    offsetXDirection?: "left" | "right"
+    offsetYDirection?: "upward" | "downward"
 }
 
 interface PopulationPyramidTooltipProps {
@@ -41,7 +45,12 @@ export function PopulationPyramidTooltip({
 }: PopulationPyramidTooltipProps): ReactElement | null {
     if (!tooltipState) return null
 
-    const { ageGroup, position } = tooltipState
+    const { ageGroup, position, offsetXDirection, offsetYDirection } =
+        tooltipState
+    // With no offsetYDirection, the tooltip's top is placed at `position.y + offsetY`,
+    // so a negative offsetY gives the population-curve-style gap. With an explicit
+    // direction, the offsetY magnitude is the gap from the anchor edge.
+    const offsetY = offsetYDirection ? TOOLTIP_OFFSET_Y : -TOOLTIP_OFFSET_Y
     const malePopulation = ageBucketsBySex.male[ageGroup] ?? 0
     const femalePopulation = ageBucketsBySex.female[ageGroup] ?? 0
     const malePopulationShare = getShareOfTotalPopulation(
@@ -60,7 +69,9 @@ export function PopulationPyramidTooltip({
             x={position.x}
             y={position.y}
             offsetX={TOOLTIP_OFFSET_X}
-            offsetY={TOOLTIP_OFFSET_Y}
+            offsetY={offsetY}
+            offsetXDirection={offsetXDirection}
+            offsetYDirection={offsetYDirection}
             title={`Ages ${formatAgeGroup(ageGroup)}`}
             anchor={pinToBottom ? GrapherTooltipAnchor.Bottom : undefined}
             containerBounds={pinToBottom ? undefined : { width, height }}

--- a/bespoke/projects/demography/src/helpers/utils.ts
+++ b/bespoke/projects/demography/src/helpers/utils.ts
@@ -56,11 +56,26 @@ export function formatPopulationValueShort(value: number): string {
     })
 }
 
-export function formatPopulationValueLong(value: number): string {
+export function formatPopulationValueLong(
+    value: number,
+    numSignificantFigures = 2
+): string {
     return formatValue(value, {
         roundingMode: OwidVariableRoundingMode.significantFigures,
-        numSignificantFigures: 2,
+        numSignificantFigures,
         numberAbbreviation: "long",
+    })
+}
+
+export function formatPopulationShare(
+    value: number,
+    numSignificantFigures = 3
+): string {
+    return formatValue(value, {
+        roundingMode: OwidVariableRoundingMode.significantFigures,
+        numSignificantFigures,
+        numberAbbreviation: false,
+        unit: "%",
     })
 }
 
@@ -136,6 +151,50 @@ export function groupByAgeRange(
         grouped[ageGroup] = sum
     }
     return grouped
+}
+
+export interface PopulationPyramidAgeBucketsBySex {
+    female: Record<string, number>
+    male: Record<string, number>
+}
+
+export function getPopulationPyramidAgeBucketsBySex(
+    populationBySex: PopulationBySex | null | undefined
+): PopulationPyramidAgeBucketsBySex {
+    return {
+        male: groupByAgeRange(populationBySex?.male ?? []),
+        female: groupByAgeRange(populationBySex?.female ?? []),
+    }
+}
+
+export function getTotalPopulationFromPyramidAgeBuckets(
+    ageBucketsBySex: PopulationPyramidAgeBucketsBySex
+): number {
+    return (
+        Object.values(ageBucketsBySex.male).reduce((a, b) => a + b, 0) +
+        Object.values(ageBucketsBySex.female).reduce((a, b) => a + b, 0)
+    )
+}
+
+export function convertPopulationPyramidAgeBucketsToUnit(
+    ageBucketsBySex: PopulationPyramidAgeBucketsBySex,
+    totalPopulation: number,
+    unit: "percent" | "absolute"
+): PopulationPyramidAgeBucketsBySex {
+    const toBuckets = (buckets: Record<string, number>) => {
+        if (unit === "absolute") return { ...buckets }
+
+        const result: Record<string, number> = {}
+        for (const [k, v] of Object.entries(buckets)) {
+            result[k] = totalPopulation > 0 ? (v / totalPopulation) * 100 : 0
+        }
+        return result
+    }
+
+    return {
+        male: toBuckets(ageBucketsBySex.male),
+        female: toBuckets(ageBucketsBySex.female),
+    }
 }
 
 export function combineStatuses(...statuses: QueryStatus[]): QueryStatus {


### PR DESCRIPTION
## Summary

Adds a Grapher-style tooltip to the bespoke demography age pyramid charts. When hovering or tapping an age bracket, the tooltip now shows:

- men's/boys' share of the total population and absolute population in the bracket
- women's/girls' share of the total population and absolute population in the bracket

The tooltip works on both the vertical pyramid and horizontal age distribution variants, and uses 3 significant figures for the share and absolute population values.

## Screenshot

<img src="https://gist.githubusercontent.com/danyx23/cd8490756217f828171a8d97b4ff312b/raw/81576cf3824efae15e9b0f66c76ab335d572d0b6/population-pyramid-tooltip.png" alt="Population pyramid tooltip showing share of population and absolute men and women values for ages 60–64" width="800" />

## Implementation notes

- Reuses shared demography formatting helpers by allowing `formatPopulationValueLong` to take a significant-figures override.
- Adds `formatPopulationShare` and shared age-bucket helpers so the pyramid components can keep absolute bucket values for the tooltip while still rendering either percent or absolute chart units.
- Extracts the tooltip UI into `PopulationPyramidTooltip` for reuse across both pyramid orientations.

## Testing

- `yarn fixFormatChanged > /dev/null 2>&1 && yarn typecheck`
- `yarn testLintChanged`
- `yarn testFormatChanged`


