### PR TITLE
Drop approved-by field from data insights

### DIFF
--- a/adminSiteClient/DataInsightIndexPage.tsx
+++ b/adminSiteClient/DataInsightIndexPage.tsx
@@ -158,7 +158,7 @@ function createColumns(ctx: {
             dataIndex: "authors",
             key: "authors",
             width: 150,
-            render: (authors: string[], dataInsight) => (
+            render: (authors: string[]) => (
                 <>
                     {authors.map((author, index) => (
                         <Fragment key={author}>
@@ -166,8 +166,6 @@ function createColumns(ctx: {
                             {index < authors.length - 1 ? ", " : ""}
                         </Fragment>
                     ))}
-                    {dataInsight.approvedBy &&
-                        ` (approved by ${dataInsight.approvedBy})`}
                 </>
             ),
         },

--- a/adminSiteClient/GdocsSettingsForms.tsx
+++ b/adminSiteClient/GdocsSettingsForms.tsx
@@ -187,12 +187,7 @@ export const GdocInsightSettings = ({
         <form className="GdocsSettingsForm">
             <GdocCommonErrors
                 errors={errors}
-                errorsToFilter={[
-                    "approved-by",
-                    "grapher-url",
-                    "narrative-chart",
-                    "figma-url",
-                ]}
+                errorsToFilter={["grapher-url", "narrative-chart", "figma-url"]}
             />
             <GdocCommonSettings
                 gdoc={gdoc}
@@ -202,11 +197,6 @@ export const GdocInsightSettings = ({
             />
             <div className="form-group">
                 <h3 className="form-section-heading">Data insight settings</h3>
-                <GdocsSettingsContentField
-                    property="approved-by"
-                    gdoc={gdoc}
-                    errors={errors}
-                />
                 <GdocsPublicationContext
                     gdoc={gdoc}
                     setCurrentGdoc={setCurrentGdoc}
@@ -246,12 +236,7 @@ export const GdocAnnouncementSettings = ({
         <form className="GdocsSettingsForm">
             <GdocCommonErrors
                 errors={errors}
-                errorsToFilter={[
-                    "approved-by",
-                    "grapher-url",
-                    "narrative-chart",
-                    "figma-url",
-                ]}
+                errorsToFilter={["grapher-url", "narrative-chart", "figma-url"]}
             />
             <GdocCommonSettings
                 gdoc={gdoc}

--- a/adminSiteClient/gdocsDeploy.ts
+++ b/adminSiteClient/gdocsDeploy.ts
@@ -107,7 +107,6 @@ export const checkIsLightningUpdate = (
         boolean
     > = {
         ["grapher-url"]: true,
-        ["approved-by"]: true,
         ["narrative-chart"]: true,
         ["figma-url"]: true,
         title: false, // requires rebaking the feed

--- a/adminSiteClient/gdocsValidation.ts
+++ b/adminSiteClient/gdocsValidation.ts
@@ -173,19 +173,6 @@ function validateManualBreadcrumbs(
     }
 }
 
-function validateApprovedBy(
-    gdoc: OwidGdocDataInsightInterface,
-    errors: OwidGdocErrorMessage[]
-) {
-    if (!gdoc.content["approved-by"]) {
-        errors.push({
-            property: "approved-by",
-            type: OwidGdocErrorMessageType.Error,
-            message: `This data insight hasn't been approved by anyone yet. Please have someone approve it and add "approved-by: their name" to the front-matter.`,
-        })
-    }
-}
-
 function validateGrapherUrl(
     gdoc: OwidGdocDataInsightInterface,
     errors: OwidGdocErrorMessage[]
@@ -307,7 +294,6 @@ export const getErrors = (gdoc: OwidGdoc): OwidGdocErrorMessage[] => {
         validateManualBreadcrumbs(gdoc, errors)
         validateAtomFields(gdoc, errors)
     } else if (checkIsDataInsight(gdoc)) {
-        validateApprovedBy(gdoc, errors)
         validateGrapherUrl(gdoc, errors)
         validateDataInsightImage(gdoc, errors)
     } else if (checkIsAuthor(gdoc)) {

--- a/adminSiteServer/apiRoutes/dataInsights.ts
+++ b/adminSiteServer/apiRoutes/dataInsights.ts
@@ -225,7 +225,6 @@ function extractDataInsightIndexItem(
         markdown: dataInsight.markdown,
         title: content.title ?? "",
         authors: content.authors,
-        approvedBy: content["approved-by"],
         narrativeChart,
         grapherUrl,
         explorerUrl,

--- a/db/model/Gdoc/GdocDataInsight.ts
+++ b/db/model/Gdoc/GdocDataInsight.ts
@@ -1,6 +1,4 @@
 import {
-    OwidGdocErrorMessage,
-    OwidGdocErrorMessageType,
     OwidGdocDataInsightContent,
     OwidGdocDataInsightInterface,
     OwidGdocMinimalPostInterface,
@@ -38,18 +36,6 @@ export class GdocDataInsight
 
     protected override typeSpecificUrls(): string[] {
         return excludeNullish([this.content["grapher-url"]])
-    }
-
-    override _validateSubclass = async (): Promise<OwidGdocErrorMessage[]> => {
-        const errors: OwidGdocErrorMessage[] = []
-        if (!this.content["approved-by"]) {
-            errors.push({
-                type: OwidGdocErrorMessageType.Error,
-                property: "approved-by",
-                message: "Missing an approved-by field in the front-matter",
-            })
-        }
-        return errors
     }
 
     override _loadSubclassAttachments = async (

--- a/docs/agent-guidelines/gdocs-class-hierarchy.md
+++ b/docs/agent-guidelines/gdocs-class-hierarchy.md
@@ -32,7 +32,7 @@ This note complements the Google Docs CMS pipeline overview by mapping the serve
 ### `GdocDataInsight` (`db/model/Gdoc/GdocDataInsight.ts`)
 
 - Focused on short-form insights highlighting a single chart or dataset.
-- Enforces presence of `approved-by` metadata and tracks optional URLs (`grapher-url`, `narrative-chart`, `figma-url`).
+- Tracks optional URLs (`grapher-url`, `narrative-chart`, `figma-url`).
 - Loads latest data insight metadata and companion image information for preview panels.
 
 ### `GdocHomepage` (`db/model/Gdoc/GdocHomepage.ts`)

--- a/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
@@ -203,7 +203,6 @@ export interface OwidGdocDataInsightContent {
     ["narrative-chart"]?: string
     ["grapher-url"]?: string
     ["figma-url"]?: string
-    ["approved-by"]: string // can't publish an insight unless this is set
     body: OwidEnrichedGdocBlock[]
     type: OwidGdocType.DataInsight
 }
@@ -213,7 +212,6 @@ export type OwidGdocDataInsightIndexItem = Pick<
     "id" | "slug" | "tags" | "published" | "publishedAt" | "markdown"
 > &
     Pick<OwidGdocDataInsightContent, "title" | "authors"> & {
-        approvedBy?: OwidGdocDataInsightContent["approved-by"]
         grapherUrl?: OwidGdocDataInsightContent["grapher-url"]
         explorerUrl?: OwidGdocDataInsightContent["grapher-url"]
         narrativeChart?: Pick<


### PR DESCRIPTION
## Summary
- We no longer use the ArchieML `approved-by` mechanism — approvals are tracked outside the gdocs flow, so the publish-time validation was pure friction.
- Removes the field from the type definitions, the admin UI (input field and \"approved by X\" display on the index page), the client + server validation, and the lightning-prop map.
- ArchieML accepts unknown keys, so existing data insights that still have `approved-by: …` in their front-matter keep parsing unchanged — the value just isn't surfaced anywhere.

## Test plan
- [x] `yarn typecheck` passes (verified locally).
- [x] `yarn testLintChanged` / `yarn testFormatChanged` clean (verified locally).
- [x] On staging, open a data insight with no `approved-by` front-matter: no error/warning shown, **Publish** button enabled.
- [x] Open a data insight that still has `approved-by` in its gdoc: page loads without error; the admin index no longer shows \"(approved by …)\".
- [x] Publish a data insight end-to-end and confirm the resulting page renders normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)