### PR TITLE
🎉🤖 Add owners JSON column to datasets

### DIFF
--- a/db/docs/datasets.yml
+++ b/db/docs/datasets.yml
@@ -48,3 +48,5 @@ fields:
     description: Path in the ETL data catalog system
   tables:
     description: Tables within the dataset (for multi-table datasets)
+  owners:
+    description: JSON array of OWID team-member display names who maintain this dataset. The first entry is the accountable owner / point of contact for issues with the data page. Populated from ETL via `DatasetMeta.owners`.

--- a/db/migration/1779129544597-AddOwnersToDatasets.ts
+++ b/db/migration/1779129544597-AddOwnersToDatasets.ts
@@ -7,9 +7,20 @@ export class AddOwnersToDatasets1779129544597 implements MigrationInterface {
         await queryRunner.query(
             "ALTER TABLE `datasets` ADD COLUMN `owners` JSON NULL DEFAULT NULL"
         )
+        // The active_datasets view is defined as `SELECT *`, which MySQL
+        // freezes into an explicit column list at creation time, so it must be
+        // recreated to expose the new column.
+        await queryRunner.query(
+            "ALTER VIEW active_datasets AS SELECT * FROM datasets WHERE not isArchived"
+        )
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
+        // Drop the column first, then recreate the view so its frozen column
+        // list no longer references `owners`.
         await queryRunner.query("ALTER TABLE `datasets` DROP COLUMN `owners`")
+        await queryRunner.query(
+            "ALTER VIEW active_datasets AS SELECT * FROM datasets WHERE not isArchived"
+        )
     }
 }

--- a/db/migration/1779129544597-AddOwnersToDatasets.ts
+++ b/db/migration/1779129544597-AddOwnersToDatasets.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class AddOwnersToDatasets1779129544597 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        // List of OWID team members who maintain each dataset; first entry is
+        // the accountable owner. Populated from ETL via DatasetMeta.owners.
+        await queryRunner.query(
+            "ALTER TABLE `datasets` ADD COLUMN `owners` JSON NULL DEFAULT NULL"
+        )
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query("ALTER TABLE `datasets` DROP COLUMN `owners`")
+    }
+}

--- a/packages/@ourworldindata/types/src/dbTypes/Datasets.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/Datasets.ts
@@ -1,3 +1,5 @@
+import { JsonString } from "../domainTypes/Various.js"
+
 export const DatasetsTableName = "datasets"
 export interface DbInsertDataset {
     createdAt?: Date
@@ -13,6 +15,10 @@ export interface DbInsertDataset {
     name: string
     namespace: string
     nonRedistributable?: number
+    // JSON array of OWID team-member display names who maintain this dataset;
+    // the first entry is the accountable owner. Populated from ETL via
+    // DatasetMeta.owners. Stored as a JSON string; parse before use.
+    owners?: JsonString | null
     shortName?: string | null
     sourceChecksum?: string | null
     updatedAt?: Date


### PR DESCRIPTION
> _Written by Claude Code — @Marigold at the wheel._

Pairs with owid/etl#6143 (branch `dataset-owners` on both repos so they share `staging-site-dataset-owners`).

## Summary

- New JSON column `datasets.owners`: a list of OWID team-member display names who maintain the dataset; first entry is the accountable owner / contact for the data page.
- Populated from ETL via `DatasetMeta.owners` (see the matching ETL PR).
- Schema docs entry added to `db/docs/datasets.yml`.
- Added `owners` to the `DbInsertDataset` / `DbPlainDataset` knex row types (`packages/@ourworldindata/types/src/dbTypes/Datasets.ts`) so consumers can read it type-safely. Typed as `JsonString | null` to match the existing JSON-column convention — it is stored as a serialized JSON string and must be `JSON.parse`d before use. (There is no live TypeORM entity for `datasets`; the `@Entity` class in `db/model/Dataset.ts` is commented out, so this row interface is the de-facto model. Pre-existing `catalogPath`/`tables` drift in that interface is left untouched to keep this PR scoped.)

## Test plan

- [ ] `yarn runDbMigrations` on staging applies cleanly
- [ ] Run an ETL grapher step on staging (via owid/etl#6143) and verify `SELECT shortName, owners FROM datasets WHERE owners IS NOT NULL`
- [ ] `yarn revertLastDbMigration` works on staging (drops the column cleanly)

## Production rollout

Merge this PR **before** owid/etl#6143 reaches a prod grapher upsert; otherwise SQLAlchemy will hit a missing column.