### PR TITLE
🐛 (admin) avoid resetting entity selection on switching to the Basic tab

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
@@ -1680,13 +1680,21 @@ export class GrapherState
     }
 
     @action.bound private applyOriginalFocusAsAuthored(): void {
-        if (this.focusedSeriesNames?.length)
-            this.focusArray.clearAllAndAdd(...this.focusedSeriesNames)
+        const authoredSeriesNames =
+            this.legacyConfigAsAuthored.focusedSeriesNames ??
+            this.focusedSeriesNames
+
+        if (authoredSeriesNames?.length)
+            this.focusArray.clearAllAndAdd(...authoredSeriesNames)
     }
 
     @action.bound private applyOriginalSelectionAsAuthored(): void {
-        if (this.selectedEntityNames?.length)
-            this.selection.setSelectedEntities(this.selectedEntityNames)
+        const authoredEntityNames =
+            this.legacyConfigAsAuthored.selectedEntityNames ??
+            this.selectedEntityNames
+
+        if (authoredEntityNames?.length)
+            this.selection.setSelectedEntities(authoredEntityNames)
     }
 
     @computed get hasData(): boolean {


### PR DESCRIPTION
Fixes #6485

In the chart editor, selecting entities and then navigating back to the "Basic" tab caused the selection to be reset.

When the user edits the selection in the admin, `legacyConfigAsAuthored` is updated to match. The `selectedEntityNames` property on GrapherState, however, is only set at construction. On switching to the basic tab, `EditorBasicTab` reloaded data, the inputTable setter saw "selection == authored" and called `applyOriginalSelectionAsAuthored`, which then reset to the stale `selectedEntityNames` value rather than the live authored selection.

