### PR TITLE
🐛 (admin) overwrite indicator-level rounding mode

### DIFF
--- a/adminSiteClient/DimensionCard.tsx
+++ b/adminSiteClient/DimensionCard.tsx
@@ -201,16 +201,10 @@ export class DimensionCard<
                         />
                         <SelectField
                             label="Rounding mode"
-                            value={dimension.display.roundingMode}
+                            value={this.roundingMode}
                             onValue={(value) => {
-                                const roundingMode =
-                                    value as OwidVariableRoundingMode
                                 this.props.dimension.display.roundingMode =
-                                    roundingMode !==
-                                    OwidVariableRoundingMode.decimalPlaces
-                                        ? roundingMode
-                                        : undefined
-
+                                    value as OwidVariableRoundingMode
                                 this.onChange()
                             }}
                             options={Object.keys(OwidVariableRoundingMode).map(


### PR DESCRIPTION
Fixes #6432

In the admin, switching the rounding mode from "Significant Figures" to "Decimal Places" silently no-ops on charts whose underlying indicator has `display.roundingMode = significantFigures`.

The handler in `DimensionCard` stored `undefined` for the implicit `decimalPlaces` default. That `undefined` then got stripped by `trimObject` during the indicator/dimension display merge in `LegacyToOwidTable`, so the indicator's `significantFigures` value persisted and the dimension never actually overrode it.

Main drawback is that we now write decimal places into the config although it's the default, but I don't think that's a big deal.
