### PR TITLE
🐛 fix react-aria/PortalProvider deep import

### DIFF
--- a/packages/@ourworldindata/grapher/src/controls/PortaledPopover.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/PortaledPopover.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from "react"
 import { Popover, type PopoverProps } from "react-aria-components"
-import { UNSAFE_PortalProvider } from "react-aria/PortalProvider"
+import { UNSAFE_PortalProvider } from "react-aria"
 
 export interface PortaledPopoverProps extends PopoverProps {
     portalContainer?: HTMLElement


### PR DESCRIPTION
## Summary

- The deep import `react-aria/PortalProvider` is not declared in `react-aria@3.45.0`'s `exports` field (only `.` and `./i18n` are exposed).
- Vite resolves it leniently, so the website builds fine — but Node's ESM resolver (used by `tsx`) refuses it with `ERR_PACKAGE_PATH_NOT_EXPORTED`, breaking every tsx-based dev script (`yarn query`, `yarn refreshExplorerViews`, etc.) on `master`.
- `UNSAFE_PortalProvider` is also re-exported from the bare `"react-aria"` entry point — same form already used in `bespoke/projects/demography/src/components/DemographyParameterEditor.tsx:9`.

Introduced in #6488.

## Test plan

- [ ] `yarn query "SELECT 1"` succeeds (currently throws `ERR_PACKAGE_PATH_NOT_EXPORTED` on `master`)
- [ ] Site dev server still builds and the popover still renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)