### PR TITLE
Changes for Node 24

### DIFF
--- a/.clinerules/GENERAL-RULES.md
+++ b/.clinerules/GENERAL-RULES.md
@@ -21,7 +21,7 @@ When you want to create a git commit, refer to docs/agent-guidelines/commit-mess
 
 # Codebase overview
 
-This is a sort of monorepo for the Our World In Data website, including our custom data viz react component, Grapher. The codebase is in typescript, uses React 19 and Node 22.
+This is a sort of monorepo for the Our World In Data website, including our custom data viz react component, Grapher. The codebase is in typescript, uses React 19 and Node 24.
 
 Some key directories, going roughly along the dependency chain from the most standalone pieces to the one with the most dependencies:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ When creating new skills in `.claude/skills/`, always include `metadata: { inter
 
 # Codebase overview
 
-This is a sort of monorepo for the Our World In Data website, including our custom data viz react component, Grapher. The codebase is in typescript, uses React 19 and Node 22.
+This is a sort of monorepo for the Our World In Data website, including our custom data viz react component, Grapher. The codebase is in typescript, uses React 19 and Node 24.
 
 Some key directories, going roughly along the dependency chain from the most standalone pieces to the one with the most dependencies:
 

--- a/baker/GrapherBakingUtils.ts
+++ b/baker/GrapherBakingUtils.ts
@@ -1,6 +1,5 @@
 import * as _ from "lodash-es"
 import fs from "fs-extra"
-import { glob } from "glob"
 
 import * as db from "../db/db.js"
 import { DbPlainTag, DbPlainUser } from "@ourworldindata/utils"
@@ -68,8 +67,8 @@ export async function deleteOldGraphers(
     newSlugs: string[]
 ) {
     // Delete any that are missing from the database
-    const oldSlugs = glob
-        .sync(`${bakedSiteDir}/grapher/*.html`)
+    const oldSlugs = fs
+        .globSync(`${bakedSiteDir}/grapher/*.html`)
         .map((slug) =>
             slug.replace(`${bakedSiteDir}/grapher/`, "").replace(".html", "")
         )

--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -5,7 +5,6 @@ import "../serverUtils/instrument.js"
 import * as _ from "lodash-es"
 import fs from "fs-extra"
 import path from "path"
-import { glob } from "glob"
 import ProgressBar from "progress"
 import { stringify } from "safe-stable-stringify"
 import * as db from "../db/db.js"
@@ -319,8 +318,8 @@ export class SiteBaker {
     // Among all existing slugs on the filesystem, some are not coming from WP. They are baked independently and should not
     // be deleted if WP does not list them (e.g. grapher/*).
     private getPostSlugsToRemove(postSlugsFromDb: string[]) {
-        const existingSlugs = glob
-            .sync(`${this.bakedSiteDir}/**/*.html`)
+        const existingSlugs = fs
+            .globSync(`${this.bakedSiteDir}/**/*.html`)
             .map((path) =>
                 path.replace(`${this.bakedSiteDir}/`, "").replace(".html", "")
             )

--- a/devTools/flagUpdater/update.ts
+++ b/devTools/flagUpdater/update.ts
@@ -2,7 +2,7 @@ import { Region, regions } from "@ourworldindata/utils"
 
 import path from "path"
 import fs from "fs-extra"
-import { glob } from "glob"
+import { glob } from "fs/promises"
 import findProjectBaseDir from "../../settings/findBaseDir.ts"
 
 const BASE_DIR = findProjectBaseDir(__dirname)
@@ -15,7 +15,7 @@ const main = async () => {
     const failedBecauseNoFlag: Region[] = []
     let successfulCount: number = 0
 
-    for (const f of await glob(`${FLAG_TARGET_DIR}/*.svg`)) {
+    for await (const f of glob(`${FLAG_TARGET_DIR}/*.svg`)) {
         await fs.remove(f)
     }
 

--- a/docs/local-typescript-setup.md
+++ b/docs/local-typescript-setup.md
@@ -6,7 +6,7 @@ This local environment requires some manual setup. For a faster way to get start
 
 You need the following to be able to compile the grapher project and run the tests:
 
-- [Node 22](https://nodejs.org/en/)
+- [Node 24](https://nodejs.org/en/)
 - [Yarn](https://yarnpkg.com/)
 
 All further dependencies will be automatically installed by the yarn package manager.

--- a/package.json
+++ b/package.json
@@ -125,7 +125,6 @@
         "filenamify": "^6.0.0",
         "fparser": "^3.1.0",
         "fs-extra": "^11.3.4",
-        "glob": "^13.0.6",
         "google-auth-library": "^10.6.2",
         "handsontable": "^15.1.0",
         "history": "4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9855,7 +9855,6 @@ __metadata:
     flag-icons: "npm:^7.5.0"
     fparser: "npm:^3.1.0"
     fs-extra: "npm:^11.3.4"
-    glob: "npm:^13.0.6"
     google-auth-library: "npm:^10.6.2"
     handsontable: "npm:^15.1.0"
     happy-dom: "npm:^20.8.9"


### PR DESCRIPTION
These are optional changes that we can now make, now that we are switching to Node 24.
Can merge this anytime after Node 24 lands, and ideally not right away in case we need to roll it back for some reason.