### PR TITLE
Show entity picker for embedded charts at `size: widest`

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
@@ -4064,14 +4064,7 @@ export class GrapherState
     }
 
     @computed get shouldShowEntitySelectorAs(): GrapherWindowType {
-        if (
-            this.frameBounds.width > 940 &&
-            // Don't use the panel if the grapher is embedded
-            ((!this.isInIFrame && !this.isEmbeddedInAnOwidPage) ||
-                // unless we're in full-screen mode
-                this.isInFullScreenMode)
-        )
-            return GrapherWindowType.panel
+        if (this.frameBounds.width > 940) return GrapherWindowType.panel
 
         return this.isSemiNarrow
             ? GrapherWindowType.modal


### PR DESCRIPTION
Allows the entity selector to use the panel layout whenever the chart frame is wider than 940px, including embedded OWID-page charts at `size: widest`. It also now shows them for external iframes.

**You can try this out here:** http://staging-site-embedded-chart-entity-picker/gdocs/1Oz04bsdqIe2gVlylvyUewUIW9W6cDEf-LgNQ3XRE3yM/preview

## Layout context

The relevant gdoc article chart widths from `site/gdocs/components/layout.ts` and `site/css/grid.scss` are:

| viewport range | `narrow` | `wide` | `widest` |
|---|---:|---:|---:|
| `> 1280px` | `628px` | `845px` | `1280px` |
| `961px - 1280px` | up to `604px` | up to `813px` | up to `1232px` |
| `769px - 960px` | up to `756px` | up to `756px` | up to `912px` |
| `<= 768px` | up to `736px` grid area | up to `736px` grid area | up to `736px` grid area |

This means that we can only reach the 940px threshold at `size: widest`; other chart sizes will only go up to `845px` at most.

<img width="1372" height="2459" alt="CleanShot 2026-05-21 at 10 44 03" src="https://github.com/user-attachments/assets/12fba484-6bf2-4824-8b84-a979d2423686" />
