### PR TITLE
fix: handle modal click outside when popover is open

### DIFF
--- a/packages/@ourworldindata/grapher/src/controls/Dropdown.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/Dropdown.tsx
@@ -60,6 +60,14 @@ export interface DropdownProps<DropdownOption extends BasicDropdownOption> {
     "aria-label"?: string
 }
 
+// This attribute and function are being used to detect whether a dropdown is currently open in order to prevent modals or drawers from being dismissed by their click-outside handler.
+// React-Aria portals popovers (used for the dropdown menu) to the end of the document body, so we can't rely on simple DOM containment checks to determine if a click is happening inside the dropdown or not.
+const owidDropdownDataAttribute = "data-owid-dropdown"
+
+export function isOwidDropdownOpen(): boolean {
+    return document.querySelector(`[${owidDropdownDataAttribute}]`) !== null
+}
+
 function isOptionGroup<DropdownOption extends BasicDropdownOption>(
     item: DropdownCollectionItem<DropdownOption>
 ): item is DropdownOptionGroup<DropdownOption> {
@@ -160,11 +168,8 @@ export function Dropdown<DropdownOption extends BasicDropdownOption>({
 
     const popover = (
         <Popover
-            className={cx(
-                "grapher-dropdown-menu",
-                "portaled-popover",
-                menuClassName
-            )}
+            className={cx("grapher-dropdown-menu", menuClassName)}
+            data-owid-dropdown=""
             offset={4}
         >
             {isSearchable ? (
@@ -231,8 +236,6 @@ export function Dropdown<DropdownOption extends BasicDropdownOption>({
                     aria-label="Clear selection"
                 />
             )}
-            {/* Note: "portaled-popover" class is used by SlideInDrawer to detect
-                clicks inside portaled popovers. Update both if renaming. */}
             {popover}
         </Select>
     )

--- a/packages/@ourworldindata/grapher/src/modal/Modal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/Modal.tsx
@@ -4,6 +4,7 @@ import {
     isElementInteractive,
     isTargetOutsideElement,
 } from "../chart/ChartUtils"
+import { isOwidDropdownOpen } from "../controls/Dropdown"
 
 export class Modal extends React.Component<{
     bounds: Bounds
@@ -32,7 +33,8 @@ export class Modal extends React.Component<{
             isTargetOutsideElement(e.target!, this.contentRef.current) &&
             // clicking on an interactive element should not dismiss the modal
             // (this is especially important for the suggested chart review tool)
-            !isElementInteractive(e.target as HTMLElement)
+            !isElementInteractive(e.target as HTMLElement) &&
+            !isOwidDropdownOpen()
         )
             this.props.onDismiss()
     }

--- a/packages/@ourworldindata/grapher/src/slideInDrawer/SlideInDrawer.tsx
+++ b/packages/@ourworldindata/grapher/src/slideInDrawer/SlideInDrawer.tsx
@@ -3,6 +3,7 @@ import cx from "classnames"
 import { computed, action, observable, makeObservable } from "mobx"
 import { observer } from "mobx-react"
 import { isTargetOutsideElement } from "../chart/ChartUtils"
+import { isOwidDropdownOpen } from "../controls/Dropdown"
 
 export const DrawerContext = React.createContext<{
     toggleDrawerVisibility?: () => void
@@ -83,18 +84,9 @@ export class SlideInDrawer extends React.Component<SlideInDrawerProps> {
             this.active &&
             this.drawerRef?.current &&
             isTargetOutsideElement(e.target!, this.drawerRef.current) &&
-            !this.isPortaledPopoverOpen()
+            !isOwidDropdownOpen()
         )
             this.toggleVisibility()
-    }
-
-    private isPortaledPopoverOpen(): boolean {
-        // React-aria popovers (e.g. dropdown menus) are portaled to document.body
-        // with a full-viewport underlay. While one is open, suppress drawer dismissal
-        // so that the first click closes the popover (handled by react-aria) and a
-        // subsequent click closes the drawer.
-        // Note: "portaled-popover" class is defined in Dropdown.tsx. Update both if renaming.
-        return document.querySelector(".portaled-popover") !== null
     }
 
     @action.bound toggleVisibility(e?: React.MouseEvent): void {


### PR DESCRIPTION
There was an issue where the entity selector modal would close when you click on the sort-by dropdown.


https://github.com/user-attachments/assets/2a559a9b-6c81-4b4e-b3e2-e2676911fcd8

