### PR TITLE
✨ fallback to descriptionSnapshot when description is missing

### DIFF
--- a/packages/@ourworldindata/utils/src/metadataHelpers.ts
+++ b/packages/@ourworldindata/utils/src/metadataHelpers.ts
@@ -145,7 +145,7 @@ const prepareOriginForDisplay = (origin: OwidOrigin): DisplaySource => {
 
     return {
         label,
-        description: origin.description,
+        description: origin.description || origin.descriptionSnapshot,
         retrievedOn: origin.dateAccessed,
         retrievedFrom: origin.urlMain,
         citation: origin.citationFull,


### PR DESCRIPTION
Resolves https://github.com/owid/owid-grapher/issues/6447

Makes `descriptionSnapshot` show up in Grapher's sources modal and on data/mdim pages if `description` is empty.

@Marigold, is this what you had in mind? Any where else `descriptionSnapshot` should show up?

Example: [Prod](https://ourworldindata.org/grapher/banning-of-chick-culling) / [Staging](http://staging-site-use-snapshot-description-fal/grapher/banning-of-chick-culling)