### PR TITLE
🔨 (analytics) add viewConfigId to more events

### DIFF
--- a/packages/@ourworldindata/explorer/src/Explorer.tsx
+++ b/packages/@ourworldindata/explorer/src/Explorer.tsx
@@ -564,6 +564,10 @@ export class Explorer
         return this.props.chartConfigIdByViewId?.[viewId]
     }
 
+    @computed get analyticsContext() {
+        return { viewConfigId: this.getChartConfigIdForCurrentParams() }
+    }
+
     @action.bound private setGrapherTable(table: OwidTable) {
         this.grapherState.inputTable = this.inputTableTransformer(table)
     }

--- a/packages/@ourworldindata/grapher/src/controls/entityPicker/EntityPicker.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/entityPicker/EntityPicker.tsx
@@ -136,7 +136,8 @@ export class EntityPicker extends React.Component<EntityPickerProps> {
         this.searchInput = ""
         this.manager.analytics?.logEntityPickerEvent(
             checked ? "select" : "deselect",
-            name
+            name,
+            this.manager.analyticsContext?.viewConfigId
         )
 
         this.mostRecentlySelectedEntityName = name
@@ -387,7 +388,11 @@ export class EntityPicker extends React.Component<EntityPickerProps> {
                 const name = this.focusedOption
                 this.selectEntity(name)
                 this.clearSearchInput()
-                this.manager.analytics?.logEntityPickerEvent("enter", name)
+                this.manager.analytics?.logEntityPickerEvent(
+                    "enter",
+                    name,
+                    this.manager.analyticsContext?.viewConfigId
+                )
                 break
             }
             case "ArrowUp":
@@ -527,7 +532,11 @@ export class EntityPicker extends React.Component<EntityPickerProps> {
                 ? SortOrder.desc
                 : SortOrder.asc,
         })
-        this.manager.analytics?.logEntityPickerEvent("sortBy", columnSlug)
+        this.manager.analytics?.logEntityPickerEvent(
+            "sortBy",
+            columnSlug,
+            this.manager.analyticsContext?.viewConfigId
+        )
     }
 
     private isColumnTypeNumeric(
@@ -571,7 +580,8 @@ export class EntityPicker extends React.Component<EntityPickerProps> {
                         })
                         this.manager.analytics?.logEntityPickerEvent(
                             "sortOrder",
-                            sortOrder
+                            sortOrder,
+                            this.manager.analyticsContext?.viewConfigId
                         )
                     }}
                 >

--- a/packages/@ourworldindata/grapher/src/controls/entityPicker/EntityPickerConstants.ts
+++ b/packages/@ourworldindata/grapher/src/controls/entityPicker/EntityPickerConstants.ts
@@ -18,6 +18,7 @@ export interface EntityPickerManager {
     grapherTable?: OwidTable
     entityType?: string
     analytics?: GrapherAnalytics
+    analyticsContext?: { viewConfigId?: string }
     availableEntityNames?: EntityName[]
     mapConfig?: MapConfig
 }

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -124,8 +124,8 @@ export type MinimalNarrativeChartInfo = Pick<
 >
 
 interface AnalyticsContext {
-    mdimSlug?: string
-    mdimViewConfigId?: string
+    slug?: string
+    viewConfigId?: string
 }
 
 export interface GrapherManager {
@@ -483,6 +483,8 @@ export class Grapher extends React.Component<GrapherProps> {
                     grapherUrl: this.grapherState.canonicalUrl,
                     narrativeChartName:
                         this.grapherState.narrativeChartInfo?.name,
+                    viewConfigId:
+                        this.grapherState.analyticsContext.viewConfigId,
                 })}
             >
                 {this.commandPalette}

--- a/packages/@ourworldindata/grapher/src/core/GrapherAnalytics.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherAnalytics.ts
@@ -81,11 +81,16 @@ export class GrapherAnalytics {
     }
 
     /** Logs events for the explorer's entity selector */
-    logEntityPickerEvent(action: EntitySelectorEvent, note?: string): void {
+    logEntityPickerEvent(
+        action: EntitySelectorEvent,
+        note?: string,
+        viewConfigId?: string
+    ): void {
         this.logToGA({
             event: EventCategory.ExplorerCountrySelector,
             eventAction: action,
             eventContext: note,
+            viewConfigId,
         })
     }
 
@@ -132,6 +137,7 @@ export class GrapherAnalytics {
             label?: string
             grapherUrl?: string
             narrativeChartName?: string
+            viewConfigId?: string
         }
     ): void {
         const { path, pathNext } = splitPathForGA4(
@@ -144,6 +150,7 @@ export class GrapherAnalytics {
             grapherPath: path,
             grapherPathNext: pathNext,
             narrativeChartName: ctx.narrativeChartName,
+            viewConfigId: ctx.viewConfigId,
         })
     }
 

--- a/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
@@ -3241,11 +3241,11 @@ export class GrapherState
         return this.base.current || undefined
     }
 
-    @computed private get analyticsContext(): GrapherAnalyticsContext {
+    @computed get analyticsContext(): GrapherAnalyticsContext {
         const ctx = this.manager?.analyticsContext
         return {
-            slug: ctx?.mdimSlug ?? this.slug,
-            viewConfigId: ctx?.mdimViewConfigId,
+            slug: ctx?.slug ?? this.slug,
+            viewConfigId: ctx?.viewConfigId,
             narrativeChartName: this.narrativeChartInfo?.name,
         }
     }

--- a/packages/@ourworldindata/types/src/analyticsTypes/analyticsTypes.ts
+++ b/packages/@ourworldindata/types/src/analyticsTypes/analyticsTypes.ts
@@ -387,6 +387,8 @@ export interface ExplorerCountrySelectorParams {
     eventContext?: string
     /** Explorer path */
     explorerPath?: string
+    /** Chart config ID of the explorer view */
+    viewConfigId?: string
 }
 
 // Shared Events

--- a/site/SiteAnalytics.ts
+++ b/site/SiteAnalytics.ts
@@ -322,6 +322,7 @@ export class SiteAnalytics extends GrapherAnalytics {
                         | {
                               grapherUrl: string
                               narrativeChartName: string
+                              viewConfigId?: string
                           }
                         | undefined
                     try {
@@ -336,6 +337,7 @@ export class SiteAnalytics extends GrapherAnalytics {
                             grapherUrl: grapherUrlObj?.grapherUrl,
                             narrativeChartName:
                                 grapherUrlObj?.narrativeChartName,
+                            viewConfigId: grapherUrlObj?.viewConfigId,
                         }
                     )
                 } else

--- a/site/multiDim/MultiDim.tsx
+++ b/site/multiDim/MultiDim.tsx
@@ -170,8 +170,8 @@ export default function MultiDim({
                 ? `variables/${variables[0].id}/config`
                 : undefined
         const analyticsContext = {
-            mdimSlug: slug ?? undefined,
-            mdimViewConfigId: newView.fullConfigId,
+            slug: slug ?? undefined,
+            viewConfigId: newView.fullConfigId,
         }
         manager.current.adminEditPath = adminEditPath
         manager.current.analyticsContext = analyticsContext

--- a/site/multiDim/MultiDimDataPageContent.tsx
+++ b/site/multiDim/MultiDimDataPageContent.tsx
@@ -208,8 +208,8 @@ export function DataPageContent({
                     ? `variables/${variables[0].id}/config`
                     : undefined
             const analyticsContext = {
-                mdimSlug: slug!,
-                mdimViewConfigId: grapherConfigUuid,
+                slug: slug!,
+                viewConfigId: grapherConfigUuid,
             }
             managerRef.current.adminEditPath = adminEditPath
             managerRef.current.analyticsContext = analyticsContext


### PR DESCRIPTION
Resolves https://github.com/owid/owid-grapher/issues/6355

Adds `viewConfigId` to more Grapher analytics events by:
- setting the `analyticsContext` for explorers
- adding `viewConfigId` to the `data-track-note` mechanism