### PR TITLE
🎉 dumbbell tooltips

### DIFF
--- a/packages/@ourworldindata/grapher/src/chart/ChartUtils.tsx
+++ b/packages/@ourworldindata/grapher/src/chart/ChartUtils.tsx
@@ -22,6 +22,7 @@ import {
     SortBy,
     SortConfig,
     SortOrder,
+    OwidVariableRow,
 } from "@ourworldindata/types"
 import { LineChartSeries } from "../lineCharts/LineChartConstants"
 import { SelectionArray } from "../selection/SelectionArray"
@@ -364,4 +365,25 @@ export function textWidth(text: string, fontSettings: FontSettings): number {
 
 export function roundFontSize(fontSize: number): number {
     return Math.round(fontSize * 2) / 2
+}
+
+/**
+ * Checks whether a pair of observations spanning two points in time is valid
+ * given tolerance
+ */
+export function isToleranceDistanceValid(args: {
+    start: OwidVariableRow<number>
+    end: OwidVariableRow<number>
+    tolerance: number
+}): boolean {
+    const { start, end, tolerance } = args
+
+    if (start.originalTime >= end.originalTime) return false
+
+    const isToleranceAppliedToStart = start.originalTime !== start.time
+    const isToleranceAppliedToEnd = end.originalTime !== end.time
+    if (!isToleranceAppliedToStart && !isToleranceAppliedToEnd) return true
+
+    const minRequiredGap = Math.min(tolerance, end.time - start.time)
+    return end.originalTime - start.originalTime >= minRequiredGap
 }

--- a/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChart.tsx
+++ b/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChart.tsx
@@ -82,10 +82,6 @@ import {
     DumbbellTwoColumnTooltip,
 } from "./DumbbellTooltips.js"
 
-type SVGMouseOrTouchEvent =
-    | React.MouseEvent<SVGElement>
-    | React.TouchEvent<SVGElement>
-
 export type DumbbellChartProps = ChartComponentProps<DumbbellChartState>
 
 type TopLegendType = "inline" | "swatches" | "none"
@@ -611,13 +607,15 @@ export class DumbbellChart
 
     @action.bound private onSeriesMouseEnter(
         seriesName: string,
-        event: SVGMouseOrTouchEvent
+        event: React.MouseEvent<SVGElement>
     ): void {
         this.updateTooltipPosition(event)
         this.tooltipState.target = { seriesName }
     }
 
-    @action.bound private onSeriesMouseMove(event: SVGMouseOrTouchEvent): void {
+    @action.bound private onSeriesMouseMove(
+        event: React.MouseEvent<SVGElement>
+    ): void {
         this.updateTooltipPosition(event)
     }
 
@@ -625,7 +623,7 @@ export class DumbbellChart
         this.tooltipState.target = null
     }
 
-    private updateTooltipPosition(event: SVGMouseOrTouchEvent): void {
+    private updateTooltipPosition(event: React.MouseEvent<SVGElement>): void {
         const ref = this.manager.base?.current
         if (ref) this.tooltipState.position = getRelativeMouse(ref, event)
     }
@@ -799,8 +797,8 @@ function DumbbellHoverArea({
     height: number
     maxHeight?: number
     containerBounds: Bounds
-    onMouseEnter: (seriesName: string, ev: SVGMouseOrTouchEvent) => void
-    onMouseMove: (ev: SVGMouseOrTouchEvent) => void
+    onMouseEnter: (seriesName: string, ev: React.MouseEvent<SVGElement>) => void
+    onMouseMove: (ev: React.MouseEvent<SVGElement>) => void
     onMouseLeave: () => void
 }): React.ReactElement {
     const cappedHeight = Math.min(height, maxHeight)

--- a/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChart.tsx
+++ b/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChart.tsx
@@ -7,16 +7,19 @@ import {
     HorizontalAlign,
     makeFigmaId,
     exposeInstanceOnWindow,
+    PointVector,
     ScaleType,
     SeriesStrategy,
     formatValue,
+    getRelativeMouse,
+    guid,
     Pair,
 } from "@ourworldindata/utils"
 import {
     DumbbellValueLabelMode,
     TickFormattingOptions,
 } from "@ourworldindata/types"
-import { computed, makeObservable } from "mobx"
+import { action, computed, observable, makeObservable } from "mobx"
 import { observer } from "mobx-react"
 import {
     BASE_FONT_SIZE,
@@ -56,11 +59,13 @@ import {
 import { DumbbellChartState } from "./DumbbellChartState"
 import { ChartComponentProps } from "../chart/ChartTypeMap"
 import { resolveEmphasis } from "../interaction/Emphasis"
+import { InteractionState } from "../interaction/InteractionState"
 import { DumbbellChartRow } from "./DumbbellChartRow"
 import {
     AxisLayout,
     calculateAxisLayout,
     computePercentChange,
+    toLeftRight,
 } from "./DumbbellChartHelpers"
 import { AnimatedRows } from "../animation/AnimatedRows"
 import { roundFontSize, textWidth } from "../chart/ChartUtils.js"
@@ -73,6 +78,15 @@ import {
     HorizontalColorLegendManager,
 } from "../legend/HorizontalColorLegends.js"
 import { CategoricalBin } from "../color/ColorScaleBin.js"
+import { TooltipState } from "../tooltip/Tooltip"
+import {
+    DumbbellTimeRangeTooltip,
+    DumbbellTwoColumnTooltip,
+} from "./DumbbellTooltips.js"
+
+type SVGMouseOrTouchEvent =
+    | React.MouseEvent<SVGElement>
+    | React.TouchEvent<SVGElement>
 
 export type DumbbellChartProps = ChartComponentProps<DumbbellChartState>
 
@@ -83,9 +97,16 @@ export class DumbbellChart
     extends React.Component<DumbbellChartProps>
     implements ChartInterface, AxisManager, HorizontalColorLegendManager
 {
+    private readonly tooltipId = guid()
+    private readonly tooltipState = new TooltipState<{ seriesName: string }>({
+        fade: "immediate",
+    })
+
     constructor(props: DumbbellChartProps) {
         super(props)
-        makeObservable(this)
+        makeObservable<DumbbellChart, "tooltipState">(this, {
+            tooltipState: observable,
+        })
     }
 
     @computed get chartState(): DumbbellChartState {
@@ -357,9 +378,17 @@ export class DumbbellChart
             .filter((series) => series !== undefined)
     }
 
+    @computed private get hoveredSeriesName(): string | undefined {
+        return this.tooltipState.target?.seriesName
+    }
+
     @computed private get renderSeries(): RenderDumbbellSeries[] {
         return this.placedSeries.map((series) => {
-            const emphasis = resolveEmphasis({ focus: series.focus })
+            const hover = InteractionState.for(
+                series.seriesName,
+                this.hoveredSeriesName
+            )
+            const emphasis = resolveEmphasis({ hover, focus: series.focus })
             return { ...series, emphasis }
         })
     }
@@ -578,6 +607,31 @@ export class DumbbellChart
         return this.chartState.formatColumn.formatValueShort(value, options)
     }
 
+    @action.bound private dismissTooltip(): void {
+        this.tooltipState.target = null
+    }
+
+    @action.bound private onSeriesMouseEnter(
+        seriesName: string,
+        event: SVGMouseOrTouchEvent
+    ): void {
+        this.updateTooltipPosition(event)
+        this.tooltipState.target = { seriesName }
+    }
+
+    @action.bound private onSeriesMouseMove(event: SVGMouseOrTouchEvent): void {
+        this.updateTooltipPosition(event)
+    }
+
+    @action.bound private onSeriesMouseLeave(): void {
+        this.tooltipState.target = null
+    }
+
+    private updateTooltipPosition(event: SVGMouseOrTouchEvent): void {
+        const ref = this.manager.base?.current
+        if (ref) this.tooltipState.position = getRelativeMouse(ref, event)
+    }
+
     override componentDidMount(): void {
         exposeInstanceOnWindow(this)
     }
@@ -655,6 +709,35 @@ export class DumbbellChart
                     )}
                 />
                 {this.renderLegend()}
+                <g className="hit-areas">
+                    {this.placedSeries.map((series) => (
+                        <DumbbellHitArea
+                            key={series.seriesName}
+                            series={series}
+                            height={this.availableHeightPerSeries}
+                            onMouseEnter={this.onSeriesMouseEnter}
+                            onMouseMove={this.onSeriesMouseMove}
+                            onMouseLeave={this.onSeriesMouseLeave}
+                        />
+                    ))}
+                </g>
+                {this.chartState.seriesStrategy === SeriesStrategy.entity ? (
+                    <DumbbellTimeRangeTooltip
+                        id={this.tooltipId}
+                        chartState={this.chartState}
+                        tooltipState={this.tooltipState}
+                        series={this.sizedSeries}
+                        dismissTooltip={this.dismissTooltip}
+                    />
+                ) : (
+                    <DumbbellTwoColumnTooltip
+                        id={this.tooltipId}
+                        chartState={this.chartState}
+                        tooltipState={this.tooltipState}
+                        series={this.sizedSeries}
+                        dismissTooltip={this.dismissTooltip}
+                    />
+                )}
             </g>
         )
     }
@@ -700,5 +783,45 @@ function DumbbellChartAxis({
                 />
             )}
         </>
+    )
+}
+
+function DumbbellHitArea({
+    series,
+    height,
+    verticalPadding = 12,
+    onMouseEnter,
+    onMouseMove,
+    onMouseLeave,
+}: {
+    series: PlacedDumbbellSeries
+    height: number
+    verticalPadding?: number
+    onMouseEnter: (seriesName: string, ev: SVGMouseOrTouchEvent) => void
+    onMouseMove: (ev: SVGMouseOrTouchEvent) => void
+    onMouseLeave: () => void
+}): React.ReactElement {
+    const { left, right } = toLeftRight(series.start, series.end)
+
+    const leftEdge = left.label
+        ? left.x - left.label.padding - left.label.width
+        : left.x - left.radius
+    const rightEdge = right.label
+        ? right.x + right.label.padding + right.label.width
+        : right.x + right.radius
+
+    const bounds = Bounds.fromCorners(
+        new PointVector(leftEdge, series.y - height / 2),
+        new PointVector(rightEdge, series.y + height / 2)
+    ).expand({ left: verticalPadding, right: verticalPadding })
+
+    return (
+        <rect
+            {...bounds.toProps()}
+            fill="transparent"
+            onMouseEnter={(ev) => onMouseEnter(series.seriesName, ev)}
+            onMouseMove={onMouseMove}
+            onMouseLeave={onMouseLeave}
+        />
     )
 }

--- a/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChart.tsx
+++ b/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChart.tsx
@@ -7,7 +7,6 @@ import {
     HorizontalAlign,
     makeFigmaId,
     exposeInstanceOnWindow,
-    PointVector,
     ScaleType,
     SeriesStrategy,
     formatValue,
@@ -65,7 +64,6 @@ import {
     AxisLayout,
     calculateAxisLayout,
     computePercentChange,
-    toLeftRight,
 } from "./DumbbellChartHelpers"
 import { AnimatedRows } from "../animation/AnimatedRows"
 import { roundFontSize, textWidth } from "../chart/ChartUtils.js"
@@ -690,6 +688,19 @@ export class DumbbellChart
                     dataBounds={this.dataBounds}
                     axis={this.axis}
                 />
+                <g className="hover-areas">
+                    {this.placedSeries.map((series) => (
+                        <DumbbellHoverArea
+                            key={series.seriesName}
+                            series={series}
+                            height={this.availableHeightPerSeries}
+                            containerBounds={this.boundsWithoutLegend}
+                            onMouseEnter={this.onSeriesMouseEnter}
+                            onMouseMove={this.onSeriesMouseMove}
+                            onMouseLeave={this.onSeriesMouseLeave}
+                        />
+                    ))}
+                </g>
                 <AnimatedRows
                     items={this.renderSeries}
                     keyAccessor={(d: RenderDumbbellSeries): string =>
@@ -705,22 +716,11 @@ export class DumbbellChart
                             range={xRange}
                             valueLabelStyle={valueLabelStyle}
                             y={0}
+                            onInfoTooltipShow={this.dismissTooltip}
                         />
                     )}
                 />
                 {this.renderLegend()}
-                <g className="hit-areas">
-                    {this.placedSeries.map((series) => (
-                        <DumbbellHitArea
-                            key={series.seriesName}
-                            series={series}
-                            height={this.availableHeightPerSeries}
-                            onMouseEnter={this.onSeriesMouseEnter}
-                            onMouseMove={this.onSeriesMouseMove}
-                            onMouseLeave={this.onSeriesMouseLeave}
-                        />
-                    ))}
-                </g>
                 {this.chartState.seriesStrategy === SeriesStrategy.entity ? (
                     <DumbbellTimeRangeTooltip
                         id={this.tooltipId}
@@ -786,38 +786,30 @@ function DumbbellChartAxis({
     )
 }
 
-function DumbbellHitArea({
+function DumbbellHoverArea({
     series,
     height,
-    verticalPadding = 12,
+    maxHeight = 60,
+    containerBounds,
     onMouseEnter,
     onMouseMove,
     onMouseLeave,
 }: {
     series: PlacedDumbbellSeries
     height: number
-    verticalPadding?: number
+    maxHeight?: number
+    containerBounds: Bounds
     onMouseEnter: (seriesName: string, ev: SVGMouseOrTouchEvent) => void
     onMouseMove: (ev: SVGMouseOrTouchEvent) => void
     onMouseLeave: () => void
 }): React.ReactElement {
-    const { left, right } = toLeftRight(series.start, series.end)
-
-    const leftEdge = left.label
-        ? left.x - left.label.padding - left.label.width
-        : left.x - left.radius
-    const rightEdge = right.label
-        ? right.x + right.label.padding + right.label.width
-        : right.x + right.radius
-
-    const bounds = Bounds.fromCorners(
-        new PointVector(leftEdge, series.y - height / 2),
-        new PointVector(rightEdge, series.y + height / 2)
-    ).expand({ left: verticalPadding, right: verticalPadding })
-
+    const cappedHeight = Math.min(height, maxHeight)
     return (
         <rect
-            {...bounds.toProps()}
+            x={containerBounds.left}
+            y={series.y - cappedHeight / 2}
+            width={containerBounds.width}
+            height={cappedHeight}
             fill="transparent"
             onMouseEnter={(ev) => onMouseEnter(series.seriesName, ev)}
             onMouseMove={onMouseMove}

--- a/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChart.tsx
+++ b/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChart.tsx
@@ -609,6 +609,7 @@ export class DumbbellChart
         seriesName: string,
         event: React.MouseEvent<SVGElement>
     ): void {
+        this.chartState.focusArray.clear()
         this.updateTooltipPosition(event)
         this.tooltipState.target = { seriesName }
     }

--- a/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChartConstants.ts
+++ b/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChartConstants.ts
@@ -6,7 +6,12 @@ import { EntityName } from "@ourworldindata/types"
 import { TextWrap } from "@ourworldindata/components"
 import { SeriesLabelState } from "../seriesLabel/SeriesLabelState"
 import { GRAPHER_OPACITY_MUTED } from "../core/GrapherConstants.js"
-import { GRAPHER_DENIM, OWID_NO_DATA_GRAY } from "../color/ColorConstants.js"
+import {
+    GRAPHER_DARK_TEXT,
+    GRAPHER_DENIM,
+    GRAPHER_LIGHT_TEXT,
+    OWID_NO_DATA_GRAY,
+} from "../color/ColorConstants.js"
 
 /** Horizontal gap between the value label and the dumbbell */
 export const VALUE_LABEL_DOT_GAP = 6
@@ -90,15 +95,25 @@ export type LabelledDumbbellHead = PlacedDumbbellHead & {
 
 interface DumbbellStyle {
     opacity: number
+    labelColor: string
 }
 
-const DEFAULT_DUMBBELL_STYLE: DumbbellStyle = { opacity: 1 }
+const DEFAULT_DUMBBELL_STYLE: DumbbellStyle = {
+    opacity: 1,
+    labelColor: GRAPHER_LIGHT_TEXT,
+}
 
 export const DUMBBELL_STYLE: Record<Emphasis, DumbbellStyle> = {
     [Emphasis.Default]: DEFAULT_DUMBBELL_STYLE,
     [Emphasis.Elevated]: DEFAULT_DUMBBELL_STYLE,
-    [Emphasis.Highlighted]: DEFAULT_DUMBBELL_STYLE,
-    [Emphasis.Muted]: { opacity: GRAPHER_OPACITY_MUTED },
+    [Emphasis.Highlighted]: {
+        ...DEFAULT_DUMBBELL_STYLE,
+        labelColor: GRAPHER_DARK_TEXT,
+    },
+    [Emphasis.Muted]: {
+        ...DEFAULT_DUMBBELL_STYLE,
+        opacity: GRAPHER_OPACITY_MUTED,
+    },
 }
 
 export interface LegendLabel {

--- a/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChartRow.tsx
+++ b/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChartRow.tsx
@@ -18,10 +18,7 @@ import {
 import { toLeftRight } from "./DumbbellChartHelpers"
 import { GRID_LINE_DASH_PATTERN, TICK_COLOR } from "../axis/AxisViews.js"
 import { darkenColorForText } from "../color/ColorUtils.js"
-import {
-    GRAPHER_DARK_TEXT,
-    GRAPHER_LIGHT_TEXT,
-} from "../color/ColorConstants.js"
+import { GRAPHER_DARK_TEXT } from "../color/ColorConstants.js"
 
 export function DumbbellChartRow({
     series,
@@ -68,7 +65,7 @@ export function DumbbellChartRow({
                     state={series.label}
                     x={series.labelPosition.x}
                     y={series.labelPosition.yOffset}
-                    color={{ name: GRAPHER_LIGHT_TEXT }}
+                    color={{ name: style.labelColor }}
                     onInfoTooltipShow={onInfoTooltipShow}
                 />
             )}

--- a/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChartRow.tsx
+++ b/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChartRow.tsx
@@ -30,6 +30,7 @@ export function DumbbellChartRow({
     y,
     range,
     valueLabelStyle,
+    onInfoTooltipShow,
 }: {
     series: RenderDumbbellSeries
     seriesStrategy: SeriesStrategy
@@ -37,6 +38,7 @@ export function DumbbellChartRow({
     y: number
     range: [number, number]
     valueLabelStyle: FontSettings
+    onInfoTooltipShow?: () => void
 }): React.ReactElement {
     const style = DUMBBELL_STYLE[series.emphasis]
     const { left: leftHead, right: rightHead } = toLeftRight(
@@ -49,6 +51,7 @@ export function DumbbellChartRow({
             id={makeFigmaId(series.seriesName)}
             transform={`translate(0, ${y})`}
             opacity={style.opacity}
+            style={{ pointerEvents: "none" }}
         >
             {/* Gray background line spanning the full chart width */}
             <line
@@ -66,6 +69,7 @@ export function DumbbellChartRow({
                     x={series.labelPosition.x}
                     y={series.labelPosition.yOffset}
                     color={{ name: GRAPHER_LIGHT_TEXT }}
+                    onInfoTooltipShow={onInfoTooltipShow}
                 />
             )}
 

--- a/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChartState.ts
+++ b/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChartState.ts
@@ -174,6 +174,22 @@ export class DumbbellChartState implements ChartState {
                 )
                     return undefined
 
+                // Sanity check (possible if tolerance is enabled)
+                if (startRow.originalTime >= endRow.originalTime)
+                    return undefined
+
+                // If tolerance was applied to either endpoint, require the
+                // original observation times to be at least `tolerance` apart
+                const isToleranceAppliedToStart =
+                    startRow.originalTime !== startTime
+                const isToleranceAppliedToEnd = endRow.originalTime !== endTime
+                if (
+                    (isToleranceAppliedToStart || isToleranceAppliedToEnd) &&
+                    endRow.originalTime - startRow.originalTime <
+                        yColumn.tolerance
+                )
+                    return undefined
+
                 // The color of the dumbbell is determined by whether
                 // the value has increased or decreased over time
                 const [color, lightColor] =

--- a/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChartState.ts
+++ b/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChartState.ts
@@ -32,6 +32,7 @@ import {
     autoDetectYColumnSlugs,
     getDefaultFailMessage,
     getShortNameForEntity,
+    isToleranceDistanceValid,
     makeSelectionArray,
     sortByConfig,
 } from "../chart/ChartUtils"
@@ -174,19 +175,12 @@ export class DumbbellChartState implements ChartState {
                 )
                     return undefined
 
-                // Sanity check (possible if tolerance is enabled)
-                if (startRow.originalTime >= endRow.originalTime)
-                    return undefined
-
-                // If tolerance was applied to either endpoint, require the
-                // original observation times to be at least `tolerance` apart
-                const isToleranceAppliedToStart =
-                    startRow.originalTime !== startTime
-                const isToleranceAppliedToEnd = endRow.originalTime !== endTime
                 if (
-                    (isToleranceAppliedToStart || isToleranceAppliedToEnd) &&
-                    endRow.originalTime - startRow.originalTime <
-                        yColumn.tolerance
+                    !isToleranceDistanceValid({
+                        start: startRow,
+                        end: endRow,
+                        tolerance: yColumn.tolerance,
+                    })
                 )
                     return undefined
 

--- a/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellTooltips.tsx
+++ b/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellTooltips.tsx
@@ -228,6 +228,7 @@ export class DumbbellTwoColumnTooltip extends React.Component<DumbbellTooltipPro
         if (!target) return null
 
         const [startColumn, endColumn] = this.columns
+        const { endTime } = this.chartState
         const footer = excludeUndefined([
             this.toleranceNotice,
             this.roundingNotice,
@@ -244,7 +245,6 @@ export class DumbbellTwoColumnTooltip extends React.Component<DumbbellTooltipPro
                 style={{ maxWidth: "300px" }}
                 title={target.displayName}
                 subtitle={this.subtitle}
-                subtitleFormat={this.toleranceNotice ? "notice" : undefined}
                 footer={footer}
                 dissolve={fading}
                 dismiss={this.props.dismissTooltip}
@@ -254,6 +254,11 @@ export class DumbbellTwoColumnTooltip extends React.Component<DumbbellTooltipPro
                     unit={startColumn.displayUnit}
                     value={startColumn.formatValueShort(target.start.value)}
                     color={target.start.color}
+                    originalTime={
+                        target.start.time !== endTime
+                            ? startColumn.formatTime(target.start.time)
+                            : undefined
+                    }
                     isRoundedToSignificantFigures={
                         startColumn.roundsToSignificantFigures
                     }
@@ -264,6 +269,11 @@ export class DumbbellTwoColumnTooltip extends React.Component<DumbbellTooltipPro
                     unit={endColumn.displayUnit}
                     value={endColumn.formatValueShort(target.end.value)}
                     color={target.end.color}
+                    originalTime={
+                        target.end.time !== endTime
+                            ? endColumn.formatTime(target.end.time)
+                            : undefined
+                    }
                     isRoundedToSignificantFigures={
                         endColumn.roundsToSignificantFigures
                     }

--- a/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellTooltips.tsx
+++ b/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellTooltips.tsx
@@ -184,24 +184,46 @@ export class DumbbellTwoColumnTooltip extends React.Component<DumbbellTooltipPro
     }
 
     @computed private get roundingNotice(): FooterItem | undefined {
-        const [startColumn, endColumn] = this.columns
-        const numSigFigs = excludeUndefined([
-            startColumn.roundsToSignificantFigures
-                ? startColumn.numSignificantFigures
-                : undefined,
-            endColumn.roundsToSignificantFigures
-                ? endColumn.numSignificantFigures
-                : undefined,
-        ])
-        if (numSigFigs.length === 0) return undefined
+        const entries = excludeUndefined([...this.columns, this.changeRow])
+
+        const allRoundedToSigFigs = entries.every(
+            (entry) => entry.roundsToSignificantFigures
+        )
+        const anyRoundedToSigFigs = entries.some(
+            (entry) => entry.roundsToSignificantFigures
+        )
+
+        if (!anyRoundedToSigFigs) return undefined
+
+        const sigFigs = excludeUndefined(
+            entries.map((entry) =>
+                entry.roundsToSignificantFigures
+                    ? entry.numSignificantFigures
+                    : undefined
+            )
+        )
+
         return {
-            icon: TooltipFooterIcon.None,
-            text: makeTooltipRoundingNotice(numSigFigs),
+            icon: allRoundedToSigFigs
+                ? TooltipFooterIcon.None
+                : TooltipFooterIcon.Significance,
+            text: makeTooltipRoundingNotice(sigFigs, {
+                plural: sigFigs.length > 1,
+            }),
         }
     }
 
+    @computed private get showSignificanceSuperscript(): boolean {
+        return this.roundingNotice?.icon === TooltipFooterIcon.Significance
+    }
+
     @computed private get changeRow():
-        | { label: string; value: string }
+        | {
+              label: string
+              value: string
+              roundsToSignificantFigures: boolean
+              numSignificantFigures: number
+          }
         | undefined {
         const { valueLabelMode } = this.chartState
 
@@ -214,12 +236,24 @@ export class DumbbellTwoColumnTooltip extends React.Component<DumbbellTooltipPro
         const value = this.target?.end.label?.text
         if (value === undefined) return undefined
 
-        const label = match(valueLabelMode)
-            .with(DumbbellValueLabelMode.Change, () => "Change")
-            .with(DumbbellValueLabelMode.PercentChange, () => "Percent change")
+        const [startColumn] = this.columns
+        return match(valueLabelMode)
+            .with(DumbbellValueLabelMode.Change, () => ({
+                label: "Change",
+                value,
+                // Formatted via startColumn (= formatColumn)
+                roundsToSignificantFigures:
+                    startColumn.roundsToSignificantFigures,
+                numSignificantFigures: startColumn.numSignificantFigures,
+            }))
+            .with(DumbbellValueLabelMode.PercentChange, () => ({
+                label: "Percent change",
+                value,
+                // Formatted with numDecimalPlaces: 1
+                roundsToSignificantFigures: false,
+                numSignificantFigures: 0,
+            }))
             .exhaustive()
-
-        return { label, value }
     }
 
     override render(): React.ReactElement | null {
@@ -262,6 +296,9 @@ export class DumbbellTwoColumnTooltip extends React.Component<DumbbellTooltipPro
                     isRoundedToSignificantFigures={
                         startColumn.roundsToSignificantFigures
                     }
+                    showSignificanceSuperscript={
+                        this.showSignificanceSuperscript
+                    }
                     labelVariant="label+unit"
                 />
                 <TooltipValue
@@ -277,6 +314,9 @@ export class DumbbellTwoColumnTooltip extends React.Component<DumbbellTooltipPro
                     isRoundedToSignificantFigures={
                         endColumn.roundsToSignificantFigures
                     }
+                    showSignificanceSuperscript={
+                        this.showSignificanceSuperscript
+                    }
                     labelVariant="label+unit"
                 />
                 {this.changeRow && (
@@ -284,6 +324,12 @@ export class DumbbellTwoColumnTooltip extends React.Component<DumbbellTooltipPro
                         label={this.changeRow.label}
                         value={this.changeRow.value}
                         color={GRAY_90}
+                        isRoundedToSignificantFigures={
+                            this.changeRow.roundsToSignificantFigures
+                        }
+                        showSignificanceSuperscript={
+                            this.showSignificanceSuperscript
+                        }
                     />
                 )}
             </Tooltip>

--- a/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellTooltips.tsx
+++ b/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellTooltips.tsx
@@ -1,0 +1,282 @@
+import React from "react"
+import { computed, makeObservable } from "mobx"
+import { observer } from "mobx-react"
+import {
+    calculateTrendDirection,
+    excludeUndefined,
+} from "@ourworldindata/utils"
+import { CoreColumn } from "@ourworldindata/core-table"
+import { DumbbellValueLabelMode } from "@ourworldindata/types"
+import {
+    formatTooltipRangeValues,
+    makeTooltipRoundingNotice,
+    makeTooltipToleranceNotice,
+    Tooltip,
+    TooltipState,
+    TooltipValue,
+    TooltipValueRange,
+} from "../tooltip/Tooltip"
+import { FooterItem, TooltipFooterIcon } from "../tooltip/TooltipProps.js"
+import { GRAY_90 } from "../color/ColorConstants.js"
+import { DumbbellChartState } from "./DumbbellChartState"
+import { SizedDumbbellSeries } from "./DumbbellChartConstants"
+import { match } from "ts-pattern"
+
+interface DumbbellTooltipProps {
+    id: number
+    chartState: DumbbellChartState
+    tooltipState: TooltipState<{ seriesName: string }>
+    series: SizedDumbbellSeries[]
+    dismissTooltip: () => void
+}
+
+@observer
+export class DumbbellTimeRangeTooltip extends React.Component<DumbbellTooltipProps> {
+    constructor(props: DumbbellTooltipProps) {
+        super(props)
+        makeObservable(this)
+    }
+
+    @computed private get chartState(): DumbbellChartState {
+        return this.props.chartState
+    }
+
+    @computed private get target(): SizedDumbbellSeries | undefined {
+        const seriesName = this.props.tooltipState.target?.seriesName
+        if (!seriesName) return undefined
+        return this.props.series.find((s) => s.seriesName === seriesName)
+    }
+
+    @computed private get subtitle(): string {
+        const { formatColumn, startTime, endTime } = this.chartState
+        const { target } = this
+
+        const originalStartTime = target?.start.time ?? startTime
+        const originalEndTime = target?.end.time ?? endTime
+
+        const formattedStartTime = formatColumn.formatTime(originalStartTime)
+        const formattedEndTime = formatColumn.formatTime(originalEndTime)
+
+        return `${formattedStartTime} to ${formattedEndTime}`
+    }
+
+    @computed private get toleranceNotice(): FooterItem | undefined {
+        const { target } = this
+        if (!target) return undefined
+
+        const { formatColumn, startTime, endTime } = this.chartState
+        const isStartOriginal = target.start.time === startTime
+        const isEndOriginal = target.end.time === endTime
+
+        if (isStartOriginal && isEndOriginal) return undefined
+
+        const formatTime = (t: number) => formatColumn.formatTime(t)
+        const targetYear =
+            !isStartOriginal && !isEndOriginal
+                ? `${formatTime(startTime)} and ${formatTime(endTime)}`
+                : !isStartOriginal
+                  ? formatTime(startTime)
+                  : formatTime(endTime)
+
+        return {
+            icon: TooltipFooterIcon.Notice,
+            text: makeTooltipToleranceNotice(targetYear, {
+                plural: !isStartOriginal && !isEndOriginal,
+            }),
+        }
+    }
+
+    @computed private get roundingNotice(): FooterItem | undefined {
+        const { formatColumn } = this.chartState
+        if (!formatColumn.roundsToSignificantFigures) return undefined
+        return {
+            icon: TooltipFooterIcon.None,
+            text: makeTooltipRoundingNotice([
+                formatColumn.numSignificantFigures,
+            ]),
+        }
+    }
+
+    override render(): React.ReactElement | null {
+        const { target } = this
+        const { position, fading } = this.props.tooltipState
+        if (!target) return null
+
+        const { formatColumn } = this.chartState
+        const values: [number, number] = [target.start.value, target.end.value]
+        const footer = excludeUndefined([
+            this.toleranceNotice,
+            this.roundingNotice,
+        ])
+
+        return (
+            <Tooltip
+                id={this.props.id}
+                tooltipManager={this.chartState.manager}
+                x={position.x}
+                y={position.y}
+                offsetX={20}
+                offsetY={-16}
+                style={{ maxWidth: "300px" }}
+                title={target.displayName}
+                subtitle={this.subtitle}
+                subtitleFormat={this.toleranceNotice ? "notice" : undefined}
+                footer={footer}
+                dissolve={fading}
+                dismiss={this.props.dismissTooltip}
+            >
+                <TooltipValueRange
+                    label={formatColumn.displayName}
+                    unit={formatColumn.displayUnit}
+                    values={formatTooltipRangeValues(values, formatColumn)}
+                    trend={calculateTrendDirection(...values)}
+                    isRoundedToSignificantFigures={
+                        formatColumn.roundsToSignificantFigures
+                    }
+                    labelVariant="unit-only"
+                />
+            </Tooltip>
+        )
+    }
+}
+
+@observer
+export class DumbbellTwoColumnTooltip extends React.Component<DumbbellTooltipProps> {
+    constructor(props: DumbbellTooltipProps) {
+        super(props)
+        makeObservable(this)
+    }
+
+    @computed private get chartState(): DumbbellChartState {
+        return this.props.chartState
+    }
+
+    @computed private get target(): SizedDumbbellSeries | undefined {
+        const seriesName = this.props.tooltipState.target?.seriesName
+        if (!seriesName) return undefined
+        return this.props.series.find((s) => s.seriesName === seriesName)
+    }
+
+    @computed private get columns(): [CoreColumn, CoreColumn] {
+        const [startColumn, endColumn] = this.chartState.yColumns
+        return [startColumn, endColumn]
+    }
+
+    @computed private get subtitle(): string {
+        const { formatColumn, endTime } = this.chartState
+        return formatColumn.formatTime(endTime)
+    }
+
+    @computed private get toleranceNotice(): FooterItem | undefined {
+        const { target } = this
+        if (!target) return undefined
+
+        const { formatColumn, endTime } = this.chartState
+        const isStartOriginal = target.start.time === endTime
+        const isEndOriginal = target.end.time === endTime
+
+        if (isStartOriginal && isEndOriginal) return undefined
+
+        return {
+            icon: TooltipFooterIcon.Notice,
+            text: makeTooltipToleranceNotice(formatColumn.formatTime(endTime)),
+        }
+    }
+
+    @computed private get roundingNotice(): FooterItem | undefined {
+        const [startColumn, endColumn] = this.columns
+        const numSigFigs = excludeUndefined([
+            startColumn.roundsToSignificantFigures
+                ? startColumn.numSignificantFigures
+                : undefined,
+            endColumn.roundsToSignificantFigures
+                ? endColumn.numSignificantFigures
+                : undefined,
+        ])
+        if (numSigFigs.length === 0) return undefined
+        return {
+            icon: TooltipFooterIcon.None,
+            text: makeTooltipRoundingNotice(numSigFigs),
+        }
+    }
+
+    @computed private get changeRow():
+        | { label: string; value: string }
+        | undefined {
+        const { valueLabelMode } = this.chartState
+
+        const valueLabelIsChange =
+            valueLabelMode === DumbbellValueLabelMode.Change ||
+            valueLabelMode === DumbbellValueLabelMode.PercentChange
+
+        if (!valueLabelIsChange) return undefined
+
+        const value = this.target?.end.label?.text
+        if (value === undefined) return undefined
+
+        const label = match(valueLabelMode)
+            .with(DumbbellValueLabelMode.Change, () => "Change")
+            .with(DumbbellValueLabelMode.PercentChange, () => "Percent change")
+            .exhaustive()
+
+        return { label, value }
+    }
+
+    override render(): React.ReactElement | null {
+        const { target } = this
+        const { position, fading } = this.props.tooltipState
+        if (!target) return null
+
+        const [startColumn, endColumn] = this.columns
+        const footer = excludeUndefined([
+            this.toleranceNotice,
+            this.roundingNotice,
+        ])
+
+        return (
+            <Tooltip
+                id={this.props.id}
+                tooltipManager={this.chartState.manager}
+                x={position.x}
+                y={position.y}
+                offsetX={20}
+                offsetY={-16}
+                style={{ maxWidth: "300px" }}
+                title={target.displayName}
+                subtitle={this.subtitle}
+                subtitleFormat={this.toleranceNotice ? "notice" : undefined}
+                footer={footer}
+                dissolve={fading}
+                dismiss={this.props.dismissTooltip}
+            >
+                <TooltipValue
+                    label={startColumn.displayName}
+                    unit={startColumn.displayUnit}
+                    value={startColumn.formatValueShort(target.start.value)}
+                    color={target.start.color}
+                    isRoundedToSignificantFigures={
+                        startColumn.roundsToSignificantFigures
+                    }
+                    labelVariant="label+unit"
+                />
+                <TooltipValue
+                    label={endColumn.displayName}
+                    unit={endColumn.displayUnit}
+                    value={endColumn.formatValueShort(target.end.value)}
+                    color={target.end.color}
+                    isRoundedToSignificantFigures={
+                        endColumn.roundsToSignificantFigures
+                    }
+                    labelVariant="label+unit"
+                />
+                {this.changeRow && (
+                    <TooltipValue
+                        label={this.changeRow.label}
+                        value={this.changeRow.value}
+                        color={GRAY_90}
+                    />
+                )}
+            </Tooltip>
+        )
+    }
+}

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChartConstants.ts
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChartConstants.ts
@@ -17,8 +17,8 @@ export interface SlopeChartSeries extends ChartSeries {
     column: CoreColumn
     entityName: EntityName
     displayName: string
-    start: Pick<OwidVariableRow<number>, "value" | "originalTime">
-    end: Pick<OwidVariableRow<number>, "value" | "originalTime">
+    start: OwidVariableRow<number>
+    end: OwidVariableRow<number>
     annotation?: string
     focus: InteractionState
 }

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChartState.ts
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChartState.ts
@@ -24,6 +24,7 @@ import {
     autoDetectYColumnSlugs,
     getDefaultFailMessage,
     getShortNameForEntity,
+    isToleranceDistanceValid,
     makeSelectionArray,
 } from "../chart/ChartUtils"
 import { ColorScheme } from "../color/ColorScheme"
@@ -276,20 +277,7 @@ export class SlopeChartState implements ChartState {
         // if the start or end value is missing, we can't draw the slope
         if (start?.value === undefined || end?.value === undefined) return false
 
-        // sanity check (might happen if tolerance is enabled)
-        if (start.originalTime >= end.originalTime) return false
-
-        const isToleranceAppliedToStartValue =
-            start.originalTime !== this.startTime
-        const isToleranceAppliedToEndValue = end.originalTime !== this.endTime
-
-        // if tolerance has been applied to one of the values, then we require
-        // a minimal distance between the original times
-        if (isToleranceAppliedToStartValue || isToleranceAppliedToEndValue) {
-            return end.originalTime - start.originalTime >= tolerance
-        }
-
-        return true
+        return isToleranceDistanceValid({ start, end, tolerance })
     }
 
     // Usually we drop rows with missing data in the transformTable function.


### PR DESCRIPTION
[Cycle issue](https://github.com/owid/owid-grapher/issues/6169) / [Designs](https://www.figma.com/design/dCB69o19cAVtuk283STAcY/Dumbbell-Plots?node-id=1-31&m=dev)

Implements hover, focus and tooltips for dumbbell plots.

### Description

* Focus mode is only available to authors, i.e. via the admin or by editing the URL params directly
    * Hovering and updating the selection clears focus (this is how it works for other chart types as well)
* The hovered dumbbell is highlighted by muting all other dumbbells
    * I wasn’t sure whether it’s better to use the entire row, including the label and whitespace on the left and right, as the hover hit area, or only the actual dumbbell. I opted for the former because it makes hovering a bit easier I think
* The two modes, entity and column series strategy, have different tooltips:
    * If series strategy = entity, the tooltip is similar to the slope tooltip (start value -> end value)
    * If series strategy = column, the tooltip is similar to the scatter tooltip (start and end value on separate rows)
        * The change value is also shown if it’s used to label the dumbbell

### Follow-up work

* ~Dumbbell elements~
* ~New dumbbell-specific options: value labels, end points~
* ~In-chart legend, aligned with the top-most dots~
* ~Interaction (focus, hover, tooltips)~
* Color (hard-coded for now)
* More entity sorting options
* Dumbbell plots in search
* Dumbbell chart thumbnails