### PR TITLE
🐛🤖 Fix EntitySelector Fast Refresh invalidation

### DIFF
--- a/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
+++ b/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
@@ -91,6 +91,10 @@ import {
 import { SearchField } from "../controls/SearchField"
 import { MAP_REGION_LABELS } from "../mapCharts/MapChartConstants.js"
 import { columnDefsByCatalogKey } from "../core/loadCatalogData.js"
+import {
+    EXTERNAL_SORT_INDICATOR_DEFINITIONS,
+    type ExternalSortIndicatorDefinition,
+} from "./EntitySelectorConstants.js"
 
 export type CoreColumnBySlug = Record<ColumnSlug, CoreColumn>
 
@@ -175,22 +179,6 @@ interface FilterDropdownOption {
     count: number
     trackNote?: string // unused
 }
-
-export const EXTERNAL_SORT_INDICATOR_DEFINITIONS = [
-    {
-        catalogKey: "population" satisfies NumericCatalogKey,
-        slug: columnDefsByCatalogKey["population"].slug,
-        label: "Population",
-    },
-    {
-        catalogKey: "gdp" satisfies NumericCatalogKey,
-        slug: columnDefsByCatalogKey["gdp"].slug,
-        label: "GDP per capita (int. $)",
-    },
-] as const
-
-type ExternalSortIndicatorDefinition =
-    (typeof EXTERNAL_SORT_INDICATOR_DEFINITIONS)[number]
 
 const regionNamesSet = new Set(regions.map((region) => region.name))
 

--- a/packages/@ourworldindata/grapher/src/entitySelector/EntitySelectorConstants.ts
+++ b/packages/@ourworldindata/grapher/src/entitySelector/EntitySelectorConstants.ts
@@ -1,0 +1,19 @@
+import type { NumericCatalogKey } from "@ourworldindata/types"
+import { columnDefsByCatalogKey } from "../core/loadCatalogData.js"
+
+/** Catalog indicators that can be loaded on demand for sorting in EntitySelector */
+export const EXTERNAL_SORT_INDICATOR_DEFINITIONS = [
+    {
+        catalogKey: "population" satisfies NumericCatalogKey,
+        slug: columnDefsByCatalogKey["population"].slug,
+        label: "Population",
+    },
+    {
+        catalogKey: "gdp" satisfies NumericCatalogKey,
+        slug: columnDefsByCatalogKey["gdp"].slug,
+        label: "GDP per capita (int. $)",
+    },
+] as const
+
+export type ExternalSortIndicatorDefinition =
+    (typeof EXTERNAL_SORT_INDICATOR_DEFINITIONS)[number]

--- a/packages/@ourworldindata/grapher/src/index.ts
+++ b/packages/@ourworldindata/grapher/src/index.ts
@@ -133,7 +133,7 @@ export { GeoFeatures } from "./mapCharts/GeoFeatures"
 export { isValidVerticalComparisonLineConfig } from "./comparisonLine/ComparisonLineHelpers"
 export { hasValidConfigForBinningStrategy } from "./color/BinningStrategies"
 export { Dropdown } from "./controls/Dropdown"
-export { EXTERNAL_SORT_INDICATOR_DEFINITIONS } from "./entitySelector/EntitySelector.js"
+export { EXTERNAL_SORT_INDICATOR_DEFINITIONS } from "./entitySelector/EntitySelectorConstants.js"
 
 export { makeChartState } from "./chart/ChartTypeMap"
 export type { ChartState } from "./chart/ChartInterface"


### PR DESCRIPTION
Move EXTERNAL_SORT_INDICATOR_DEFINITIONS out of the React component module and into the catalog-data module. Vite Fast Refresh expects component modules to export only components, so the previous non-component export caused HMR invalidation warnings while editing EntitySelector.