### PR TITLE
🐛 Move announcement byline before last image using CSS order

### DIFF
--- a/site/latest/AnnouncementContent.scss
+++ b/site/latest/AnnouncementContent.scss
@@ -12,7 +12,6 @@
     align-items: center;
     gap: 4px 16px;
     color: $blue-60;
-    margin-top: 16px;
 }
 
 .announcement-content__author {
@@ -55,6 +54,21 @@
 
         .article-block__image {
             margin: 16px 0 16px;
+        }
+
+        // Move the author byline to sit just before the last image in the
+        // trailing area of an expanded announcement. The outer
+        // `:has(.article-block__image)` guard ensures the rule only fires when
+        // there is at least one image; otherwise every child would match the
+        // inner selector and the byline would float to the top
+        > .article-block__expandable-text:has(.article-block__image) {
+            // selects the last image and everything after it
+            > *:not(:has(~ .article-block__image)) {
+                order: 2;
+            }
+            > *:has(.announcement-content__authors) {
+                order: 1;
+            }
         }
     }
 }


### PR DESCRIPTION
## Context

In an expanded announcement card on `/latest`, the author byline rendered at the very end of the body. The design target is for it to sit just above the **last image** in the trailing area, with any blocks that happen to follow the last image staying after it.

`ExpandableText` is a generic component (`children` is the byline slot, rendered last). We don't want to bake announcement-specific layout into it, and the `injectAutomaticSubscribeBanner` pattern doesn't fit here because the byline is React-only (`<LinkedAuthor>` with images and announcement-flavored classes), not a real enriched block.

CSS-only via `:has()` + grid `order` solves it without touching the DOM.

## Testing guidance

- [x] Open `/latest`, find an announcement card whose body contains multiple images. Click "Read more" and confirm the byline appears just above the last image, with any text after the last image staying after it.
- [x] Open `/latest/announcement/<slug>` (standalone preview, `alwaysExpanded`) and confirm the same placement applies.

## Fallback behavior

- **No image in trailing**: outer `:has()` guard fails → no `order` rules → byline at end.
- **Firefox <120 (no** **`:has()`** **support)**: every `:has()` selector is dropped by the browser → byline at end. Same as today.
- **No byline (`children`** **empty)**: wrapper isn't rendered, no layout shift.

## Checklist

### Before merging

- [x] Changes to CSS were checked on Desktop and Mobile Safari at all three breakpoints