### PR TITLE
✨ automatically expand latest page item when anchor tag present

### DIFF
--- a/site/latest/AnnouncementContent.tsx
+++ b/site/latest/AnnouncementContent.tsx
@@ -27,6 +27,7 @@ export const AnnouncementContent = ({
     body,
     cta,
     isStandalone,
+    shouldAutoExpand,
     selectedTopic,
     onReadMore,
 }: {
@@ -42,6 +43,7 @@ export const AnnouncementContent = ({
     /** When rendered as the standalone preview page: use h1, show full body
      * (no Read more truncation). */
     isStandalone?: boolean
+    shouldAutoExpand?: boolean
     selectedTopic?: string
     onReadMore?: () => void
 }) => {
@@ -92,7 +94,7 @@ export const AnnouncementContent = ({
                 <ExpandableText
                     blocks={body}
                     containerType="latest-announcement"
-                    alwaysExpanded={isStandalone}
+                    alwaysExpanded={shouldAutoExpand || isStandalone}
                     onReadMore={onReadMore}
                 >
                     {authorByline}

--- a/site/latest/LatestAnnouncementHit.tsx
+++ b/site/latest/LatestAnnouncementHit.tsx
@@ -13,10 +13,12 @@ export const LatestAnnouncementHit = ({
     hit,
     selectedTopic,
     position,
+    shouldAutoExpand,
 }: {
     hit: PageChronologicalAnnouncementRecord
     selectedTopic?: string
     position: number
+    shouldAutoExpand: boolean
 }) => {
     const { analytics } = useLatestContext()
     return (
@@ -43,6 +45,7 @@ export const LatestAnnouncementHit = ({
                     onReadMore={() =>
                         analytics.logLatestAnnouncementExpand(hit, position)
                     }
+                    shouldAutoExpand={shouldAutoExpand}
                 />
             </article>
         </AttachmentsContext.Provider>

--- a/site/latest/LatestHit.tsx
+++ b/site/latest/LatestHit.tsx
@@ -9,10 +9,16 @@ type LatestHitProps = {
     hit: PageChronologicalRecord
     selectedTopic?: string
     position: number
+    shouldAutoExpand: boolean
 }
 
 /** Dispatches to the appropriate per-type hit card. */
-export const LatestHit = ({ hit, selectedTopic, position }: LatestHitProps) => {
+export const LatestHit = ({
+    hit,
+    selectedTopic,
+    position,
+    shouldAutoExpand,
+}: LatestHitProps) => {
     return match(hit)
         .with({ type: OwidGdocType.Article }, (hit) => (
             <LatestArticleHit
@@ -33,6 +39,7 @@ export const LatestHit = ({ hit, selectedTopic, position }: LatestHitProps) => {
                 hit={hit}
                 selectedTopic={selectedTopic}
                 position={position}
+                shouldAutoExpand={shouldAutoExpand}
             />
         ))
         .with(

--- a/site/latest/LatestSearch.tsx
+++ b/site/latest/LatestSearch.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 import { useSearchParams } from "react-router-dom-v5-compat"
 import {
     LATEST_TYPE_VALUES,
@@ -37,6 +37,10 @@ export const LatestSearch = ({
     const [searchParams, setSearchParams] = useSearchParams()
 
     const { allAreas } = useTagGraphTopics(topicTagGraph)
+
+    const [autoExpandedSlug, setAutoExpandedSlug] = useState<null | string>(
+        null
+    )
 
     const state = useMemo(
         () => searchParamsToState(searchParams, allAreas),
@@ -122,6 +126,7 @@ export const LatestSearch = ({
         const el = document.getElementById(hash)
         if (el) {
             el.scrollIntoView()
+            setAutoExpandedSlug(hash)
             didScrollToHash.current = true
         }
         // Depend on `hits.length` rather than `hits` — `hits` is a fresh
@@ -176,6 +181,7 @@ export const LatestSearch = ({
                             hit={hit}
                             selectedTopic={topics[0]}
                             position={i + 1}
+                            shouldAutoExpand={hit.slug === autoExpandedSlug}
                         />
                     ))}
                     {/* Always render the signup block — with 0 or 1 hits it
@@ -191,6 +197,7 @@ export const LatestSearch = ({
                             hit={hit}
                             selectedTopic={topics[0]}
                             position={i + 3}
+                            shouldAutoExpand={hit.slug === autoExpandedSlug}
                         />
                     ))}
                     {hasNextPage && (


### PR DESCRIPTION
When clicking on a data announcement from the homepage, I think we should automatically expand the hit.