### PR TITLE
💄 🤖 sentence-case /latest filter labels

### DIFF
--- a/packages/@ourworldindata/types/src/domainTypes/Latest.ts
+++ b/packages/@ourworldindata/types/src/domainTypes/Latest.ts
@@ -45,8 +45,8 @@ export type AnnouncementLatestType = (typeof ANNOUNCEMENT_LATEST_TYPES)[number]
 export const LATEST_TYPE_LABELS: Record<LatestType, string> = {
     "data-insight": "Data Insight",
     article: "Article",
-    "data-update": "Data Update",
-    "website-upgrade": "Website Upgrade",
+    "data-update": "Data update",
+    "website-upgrade": "Website upgrade",
     announcement: "Announcement",
 }
 


### PR DESCRIPTION
## Summary
- The /latest \"Filter by type\" dropdown rendered \"Data Updates\" and \"Website Upgrades\" in title case, violating the OWID style guide (sentence-case for non-product UI text).
- Updated the singular labels in \`LATEST_TYPE_LABELS\` to sentence case; the plural facet labels are derived from these via \`latestTypeLabelPlural\`.
- \"Data Insights\" intentionally kept title-cased — it's a product name.
- Other render sites for these labels (homepage announcement card, standalone announcement page, hit metadata kicker) wrap the text in \`.h6-black-caps\` which applies \`text-transform: uppercase\` via CSS, so the visible kicker text is unaffected.

Follow-up to #6533.

## Test plan
- [ ] Visit /latest and open the \"Filter by type\" dropdown — confirm \"Data updates\" and \"Website upgrades\" render in sentence case.
- [ ] Confirm \"Data Insights\" still appears title-cased.
- [ ] Confirm the kicker on the homepage announcement card, the standalone /announcement page, and the /latest hit cards still renders all-caps via CSS (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)