### PR TITLE
Fix baking of data insights

### DIFF
--- a/db/model/Gdoc/GdocDataInsight.ts
+++ b/db/model/Gdoc/GdocDataInsight.ts
@@ -9,7 +9,7 @@ import {
 import { GdocBase } from "./GdocBase.js"
 import * as db from "../../../db/db.js"
 import {
-    getAndLoadLastPublishedDataInsights,
+    getAndLoadPublishedDataInsights,
     getLatestDataInsights,
 } from "./GdocFactory.js"
 
@@ -51,6 +51,6 @@ export class GdocDataInsight
     static async getPublishedDataInsights(
         knex: db.KnexReadonlyTransaction
     ): Promise<GdocDataInsight[]> {
-        return getAndLoadLastPublishedDataInsights(knex)
+        return getAndLoadPublishedDataInsights(knex)
     }
 }

--- a/db/model/Gdoc/GdocFactory.ts
+++ b/db/model/Gdoc/GdocFactory.ts
@@ -517,6 +517,15 @@ async function getAndLoadPublishedGdocs<T extends GdocBase>(
     return gdocs
 }
 
+export async function getAndLoadPublishedDataInsights(
+    knex: KnexReadonlyTransaction
+): Promise<GdocDataInsight[]> {
+    return await getAndLoadPublishedGdocs<GdocDataInsight>(
+        knex,
+        OwidGdocType.DataInsight
+    )
+}
+
 export async function getAndLoadLastPublishedDataInsights(
     knex: KnexReadonlyTransaction
 ): Promise<GdocDataInsight[]> {


### PR DESCRIPTION
We recently switched the baking to `getAndLoadLastPublishedDataInsights` by mistake, which only returns the last 20 data insights. Switch to a new function that returns all of them.
