### PR TITLE
🐛 🤖 make the enriched → ArchieML write-back lossless

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,28 @@
+{
+    "version": "0.0.1",
+    "configurations": [
+        {
+            "name": "Docker (MySQL)",
+            "runtimeExecutable": "docker",
+            "runtimeArgs": [
+                "compose",
+                "-f",
+                "docker-compose.grapher.yml",
+                "up"
+            ],
+            "port": 3306
+        },
+        {
+            "name": "Admin dev server",
+            "runtimeExecutable": "yarn",
+            "runtimeArgs": ["startAdminDevServer"],
+            "port": 3030
+        },
+        {
+            "name": "Vite site server",
+            "runtimeExecutable": "yarn",
+            "runtimeArgs": ["startSiteFront"],
+            "port": 8090
+        }
+    ]
+}

--- a/baker/algolia/utils/pages.ts
+++ b/baker/algolia/utils/pages.ts
@@ -170,6 +170,7 @@ function getExcerptLongFromGdoc(
                     "span-bold",
                     "span-italic",
                     "span-underline",
+                    "span-strikethrough",
                     "span-subscript",
                     "span-superscript",
                 ].includes(block.value[0].spanType)

--- a/db/gdocTests.test.ts
+++ b/db/gdocTests.test.ts
@@ -12,9 +12,18 @@ import {
     EnrichedBlockSocials,
     SocialLinkType,
 } from "@ourworldindata/utils"
-import { spansToHtmlString } from "./model/Gdoc/gdocUtils.js"
+import {
+    spansToHtmlString,
+    spanToArchieMLSourceString,
+} from "./model/Gdoc/gdocUtils.js"
 import { archieToEnriched } from "./model/Gdoc/archieToEnriched.js"
 import { OwidRawGdocBlockToArchieMLString } from "./model/Gdoc/rawToArchie.js"
+import { owidArticleToArchieMLStringGenerator } from "./model/Gdoc/archieToGdoc.js"
+import {
+    OwidGdocPostContent,
+    OwidGdocType,
+    SpanRef,
+} from "@ourworldindata/types"
 import { enrichedBlockExamples } from "./model/Gdoc/exampleEnrichedBlocks.js"
 import { enrichedBlockToRawBlock } from "./model/Gdoc/enrichedToRaw.js"
 import { load } from "archieml"
@@ -620,4 +629,153 @@ level: 2
             )
         }
     )
+})
+
+describe("refs source-form serializer", () => {
+    it("emits {ref}id{/ref} for an ID-based SpanRef", () => {
+        const span: SpanRef = {
+            spanType: "span-ref",
+            url: "#note-1",
+            sourceForm: { kind: "id", id: "example_id" },
+            children: [
+                {
+                    spanType: "span-superscript",
+                    children: [{ spanType: "span-simple-text", text: "1" }],
+                },
+            ],
+        }
+        expect(spanToArchieMLSourceString(span)).toBe("{ref}example_id{/ref}")
+    })
+
+    it("emits {ref}content{/ref} for an inline SpanRef", () => {
+        const span: SpanRef = {
+            spanType: "span-ref",
+            url: "#note-2",
+            sourceForm: {
+                kind: "inline",
+                content: [{ spanType: "span-simple-text", text: "the body" }],
+            },
+            children: [
+                {
+                    spanType: "span-superscript",
+                    children: [{ spanType: "span-simple-text", text: "2" }],
+                },
+            ],
+        }
+        expect(spanToArchieMLSourceString(span)).toBe("{ref}the body{/ref}")
+    })
+
+    it("recurses through formatting in inline ref content", () => {
+        const span: SpanRef = {
+            spanType: "span-ref",
+            url: "#note-3",
+            sourceForm: {
+                kind: "inline",
+                content: [
+                    { spanType: "span-simple-text", text: "see " },
+                    {
+                        spanType: "span-bold",
+                        children: [
+                            {
+                                spanType: "span-simple-text",
+                                text: "this paper",
+                            },
+                        ],
+                    },
+                ],
+            },
+            children: [],
+        }
+        expect(spanToArchieMLSourceString(span)).toBe(
+            "{ref}see <b>this paper</b>{/ref}"
+        )
+    })
+
+    it("emits a [.refs] frontmatter block listing only ID-based refs used in the body", () => {
+        const content: OwidGdocPostContent = {
+            title: "T",
+            type: OwidGdocType.Article,
+            authors: ["A"],
+            excerpt: "E",
+            body: [
+                {
+                    type: "text",
+                    value: [
+                        {
+                            spanType: "span-ref",
+                            url: "#note-1",
+                            sourceForm: { kind: "id", id: "used_id" },
+                            children: [],
+                        },
+                        {
+                            spanType: "span-ref",
+                            url: "#note-2",
+                            sourceForm: {
+                                kind: "inline",
+                                content: [
+                                    {
+                                        spanType: "span-simple-text",
+                                        text: "inline body",
+                                    },
+                                ],
+                            },
+                            children: [],
+                        },
+                    ],
+                    parseErrors: [],
+                },
+            ],
+            refs: {
+                definitions: {
+                    used_id: {
+                        id: "used_id",
+                        index: 0,
+                        content: [
+                            {
+                                type: "text",
+                                value: [
+                                    {
+                                        spanType: "span-simple-text",
+                                        text: "Citation.",
+                                    },
+                                ],
+                                parseErrors: [],
+                            },
+                        ],
+                        parseErrors: [],
+                    },
+                    // An inline-ref dictionary entry (keyed by content hash);
+                    // must NOT appear in the emitted [.refs] block.
+                    abc123hash: {
+                        id: "abc123hash",
+                        index: 1,
+                        content: [
+                            {
+                                type: "text",
+                                value: [
+                                    {
+                                        spanType: "span-simple-text",
+                                        text: "inline body",
+                                    },
+                                ],
+                                parseErrors: [],
+                            },
+                        ],
+                        parseErrors: [],
+                    },
+                },
+                errors: [],
+            },
+        } as OwidGdocPostContent
+
+        const text = [...owidArticleToArchieMLStringGenerator(content)].join(
+            "\n"
+        )
+
+        expect(text).toContain("[.refs]")
+        expect(text).toContain("id: used_id")
+        expect(text).toContain("Citation.")
+        expect(text).not.toContain("id: abc123hash")
+        expect(text).not.toContain("inline body\n[]")
+    })
 })

--- a/db/gdocTests.test.ts
+++ b/db/gdocTests.test.ts
@@ -8,9 +8,11 @@ import {
     OwidRawGdocBlock,
     omitUndefinedValues,
     RawBlockText,
+    EnrichedBlockText,
     EnrichedBlockTopicPageIntro,
     EnrichedBlockSocials,
     SocialLinkType,
+    traverseEnrichedBlock,
 } from "@ourworldindata/utils"
 import {
     spansToHtmlString,
@@ -20,6 +22,7 @@ import { archieToEnriched } from "./model/Gdoc/archieToEnriched.js"
 import { OwidRawGdocBlockToArchieMLString } from "./model/Gdoc/rawToArchie.js"
 import { owidArticleToArchieMLStringGenerator } from "./model/Gdoc/archieToGdoc.js"
 import {
+    OwidEnrichedGdocBlock,
     OwidGdocPostContent,
     OwidGdocType,
     SpanRef,
@@ -27,25 +30,40 @@ import {
 import { enrichedBlockExamples } from "./model/Gdoc/exampleEnrichedBlocks.js"
 import { enrichedBlockToRawBlock } from "./model/Gdoc/enrichedToRaw.js"
 import { load } from "archieml"
-import {
-    parseRawBlocksToEnrichedBlocks,
-    parseSimpleText,
-} from "./model/Gdoc/rawToEnriched.js"
+import { parseSimpleText } from "./model/Gdoc/rawToEnriched.js"
 import { gdocToArchie } from "./model/Gdoc/gdocToArchie.js"
 import { docs_v1 } from "@googleapis/docs"
 import { documentContainsMixedStraightAndCurlyQuotes } from "./model/Gdoc/gdocValidation.js"
 
-function getArchieMLDocWithContent(content: string): string {
+function getArchieMLDocWithContent(
+    content: string,
+    extraFrontmatter: string = ""
+): string {
     return `title: Writing OWID Articles With Google Docs
 subtitle: This article documents how to use and configure the various built in features of our template system
 byline: Matthew Conlen
 dateline: June 30, 2022
 template: centered
-
+${extraFrontmatter}
 [+body]
 ${content}
 []
 `
+}
+
+// Builds a [.refs] frontmatter block in the same shape the write-back
+// emits, for use as extraFrontmatter above.
+function getRefsFrontmatter(refs: { id: string; content: string }[]): string {
+    return [
+        "[.refs]",
+        ...refs.flatMap((ref) => [
+            `id: ${ref.id}`,
+            "[.+content]",
+            ref.content,
+            "[]",
+        ]),
+        "[]",
+    ].join("\n")
 }
 
 describe(documentContainsMixedStraightAndCurlyQuotes, () => {
@@ -610,25 +628,258 @@ level: 2
             `
             const deserializedRawBlock = load(simpleArchieMLDocument)
             const bodyNodes: OwidRawGdocBlock[] = deserializedRawBlock.body
-            let deserializedEnrichedBlocks = bodyNodes.map(
-                parseRawBlocksToEnrichedBlocks
-            )
-            if (example.type === "simple-text") {
-                // RawBlockText blocks are always parsed to EnrichedBlockText, never automatically
-                // to EnrichedBlockSimpleText. So we need to manually parse them here.
-                deserializedEnrichedBlocks = [
-                    parseSimpleText(bodyNodes[0] as RawBlockText),
-                ]
-            }
-            expect(deserializedEnrichedBlocks).toHaveLength(1)
+            expect(bodyNodes).toHaveLength(1)
             expect(omitUndefinedValues(bodyNodes[0])).toEqual(
                 omitUndefinedValues(rawBlock)
             )
-            expect(omitUndefinedValues(deserializedEnrichedBlocks[0])).toEqual(
+
+            // Parse back through the full document pipeline rather than bare
+            // load(), so every block type also proves immune to the
+            // document-level text surgery (extractRefs, whitespace-link
+            // fixups, stripIgnoredArchieml).
+            const article = archieToEnriched(
+                getArchieMLDocWithContent(serializedRawBlock)
+            )
+            expect(article.body).toHaveLength(1)
+            // RawBlockText blocks are always parsed to EnrichedBlockText, never automatically
+            // to EnrichedBlockSimpleText. So we need to manually parse them here.
+            const deserializedEnrichedBlock =
+                example.type === "simple-text"
+                    ? parseSimpleText(bodyNodes[0] as RawBlockText)
+                    : article.body?.[0]
+            expect(omitUndefinedValues(deserializedEnrichedBlock)).toEqual(
                 omitUndefinedValues(example)
             )
         }
     )
+
+    it("round-trips a text block with an inline ref through the document pipeline", () => {
+        // Unlike the catalogue examples above, a span-ref can only round-trip
+        // through archieToEnriched: its serialized form `{ref}…{/ref}` is
+        // ArchieML-layer syntax that extractRefs resolves before load(), and
+        // its url/children (#note-1, <sup>1</sup>) are document-derived. This
+        // pins single-block fillInlineRefSourceContent behavior, including
+        // formatting inside the ref content.
+        const example: EnrichedBlockText = {
+            type: "text",
+            value: [
+                { spanType: "span-simple-text", text: "A claim" },
+                {
+                    spanType: "span-ref",
+                    url: "#note-1",
+                    sourceForm: {
+                        kind: "inline",
+                        content: [
+                            { spanType: "span-simple-text", text: "see " },
+                            {
+                                spanType: "span-bold",
+                                children: [
+                                    {
+                                        spanType: "span-simple-text",
+                                        text: "this paper",
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                    children: [
+                        {
+                            spanType: "span-superscript",
+                            children: [
+                                { spanType: "span-simple-text", text: "1" },
+                            ],
+                        },
+                    ],
+                },
+                { spanType: "span-simple-text", text: " and more." },
+            ],
+            parseErrors: [],
+        }
+        const serializedRawBlock = OwidRawGdocBlockToArchieMLString(
+            enrichedBlockToRawBlock(example)
+        )
+        const article = archieToEnriched(
+            getArchieMLDocWithContent(serializedRawBlock)
+        )
+        expect(article.body).toHaveLength(1)
+        expect(omitUndefinedValues(article.body?.[0])).toEqual(
+            omitUndefinedValues(example)
+        )
+    })
+})
+
+describe("document-level ArchieML round trip", () => {
+    // The inverse of archieToEnriched: full-document enriched → ArchieML
+    // write-back, including frontmatter and the [.refs] block.
+    const enrichedToArchieML = (content: OwidGdocPostContent): string =>
+        [...owidArticleToArchieMLStringGenerator(content)].join("\n")
+
+    // Asserts that parsing a handwritten ArchieML document and writing it
+    // back is a fixed point. The write-back canonicalizes formatting —
+    // property order, key casing, whitespace — without losing content, so the
+    // string comparison is against that canonical form rather than the
+    // handwritten input; content preservation is what the enriched-level
+    // comparison checks. Returns the first parse and its canonical write-back
+    // for fixture-specific assertions.
+    function expectDocToRoundTrip(archieml: string): {
+        first: OwidGdocPostContent
+        canonicalArchieML: string
+    } {
+        const first = archieToEnriched(archieml)
+        const canonicalArchieML = enrichedToArchieML(first)
+        const second = archieToEnriched(canonicalArchieML)
+        expect(omitUndefinedValues(second.body)).toEqual(
+            omitUndefinedValues(first.body)
+        )
+        expect(omitUndefinedValues(second.refs?.definitions)).toEqual(
+            omitUndefinedValues(first.refs?.definitions)
+        )
+        expect(enrichedToArchieML(second)).toEqual(canonicalArchieML)
+        return { first, canonicalArchieML }
+    }
+
+    const collectRefSpans = (
+        body: OwidEnrichedGdocBlock[] | undefined
+    ): SpanRef[] => {
+        const refs: SpanRef[] = []
+        for (const block of body ?? []) {
+            traverseEnrichedBlock(
+                block,
+                () => undefined,
+                (span) => {
+                    if (span.spanType === "span-ref") refs.push(span)
+                }
+            )
+        }
+        return refs
+    }
+
+    it("round-trips inline refs and fills their sourceForm content", () => {
+        const { first } = expectDocToRoundTrip(
+            getArchieMLDocWithContent(
+                `One claim{ref}An inline citation with spaces.{/ref} and another{ref}A second, <b>bolder</b> citation.{/ref}.`
+            )
+        )
+        const refSpans = collectRefSpans(first.body)
+        expect(refSpans.map((span) => span.sourceForm)).toEqual([
+            {
+                kind: "inline",
+                content: [
+                    {
+                        spanType: "span-simple-text",
+                        text: "An inline citation with spaces.",
+                    },
+                ],
+            },
+            {
+                kind: "inline",
+                content: [
+                    { spanType: "span-simple-text", text: "A second, " },
+                    {
+                        spanType: "span-bold",
+                        children: [
+                            { spanType: "span-simple-text", text: "bolder" },
+                        ],
+                    },
+                    { spanType: "span-simple-text", text: " citation." },
+                ],
+            },
+        ])
+    })
+
+    it("round-trips ID-based refs and regenerates the [.refs] frontmatter block", () => {
+        const doc = getArchieMLDocWithContent(
+            `A claim{ref}first_ref{/ref} and another{ref}second_ref{/ref}.`,
+            getRefsFrontmatter([
+                { id: "first_ref", content: "The first citation." },
+                { id: "second_ref", content: "The second citation." },
+            ])
+        )
+        const { first } = expectDocToRoundTrip(doc)
+        expect(Object.keys(first.refs?.definitions ?? {})).toEqual([
+            "first_ref",
+            "second_ref",
+        ])
+    })
+
+    it("keeps note numbering stable for interleaved inline and ID refs across blocks", () => {
+        const doc = getArchieMLDocWithContent(
+            `First paragraph{ref}An inline citation first.{/ref} of text.
+
+Second paragraph{ref}an_id_ref{/ref} of text.`,
+            getRefsFrontmatter([
+                { id: "an_id_ref", content: "The ID-based citation." },
+            ])
+        )
+        const { first } = expectDocToRoundTrip(doc)
+        const refSpans = collectRefSpans(first.body)
+        expect(refSpans.map((s) => s.url)).toEqual(["#note-1", "#note-2"])
+        expect(refSpans.map((s) => s.sourceForm.kind)).toEqual(["inline", "id"])
+    })
+
+    it("emits a single [.refs] entry and note number for a repeated ID ref", () => {
+        const doc = getArchieMLDocWithContent(
+            `A claim{ref}reused_ref{/ref} and the same claim again{ref}reused_ref{/ref}.`,
+            getRefsFrontmatter([
+                { id: "reused_ref", content: "The reused citation." },
+            ])
+        )
+        const { first, canonicalArchieML } = expectDocToRoundTrip(doc)
+        const refSpans = collectRefSpans(first.body)
+        expect(refSpans.map((s) => s.url)).toEqual(["#note-1", "#note-1"])
+        expect(canonicalArchieML.match(/id: reused_ref/g)).toHaveLength(1)
+    })
+
+    it("gives repeated identical inline refs one note number and fills both spans", () => {
+        const doc = getArchieMLDocWithContent(
+            `First{ref}The same citation text.{/ref} and second{ref}The same citation text.{/ref}.`
+        )
+        const { first } = expectDocToRoundTrip(doc)
+        expect(Object.keys(first.refs?.definitions ?? {})).toHaveLength(1)
+        const refSpans = collectRefSpans(first.body)
+        expect(refSpans.map((span) => span.url)).toEqual(["#note-1", "#note-1"])
+        const expectedSourceForm = {
+            kind: "inline",
+            content: [
+                {
+                    spanType: "span-simple-text",
+                    text: "The same citation text.",
+                },
+            ],
+        }
+        expect(refSpans.map((span) => span.sourceForm)).toEqual([
+            expectedSourceForm,
+            expectedSourceForm,
+        ])
+    })
+
+    it("fills inline ref content inside list items", () => {
+        const doc = getArchieMLDocWithContent(`[.list]
+* Item one{ref}A citation inside a list.{/ref}
+* Item two
+[]`)
+        const { first } = expectDocToRoundTrip(doc)
+        const refSpans = collectRefSpans(first.body)
+        expect(refSpans.map((span) => span.sourceForm)).toEqual([
+            {
+                kind: "inline",
+                content: [
+                    {
+                        spanType: "span-simple-text",
+                        text: "A citation inside a list.",
+                    },
+                ],
+            },
+        ])
+    })
+
+    it("round-trips rich spans at the document level", () => {
+        expectDocToRoundTrip(
+            getArchieMLDocWithContent(
+                `Plain, <b>bold</b>, <i>italic</i>, <u>underlined</u>, <s>struck</s>, H<sub>2</sub>O, E=mc<sup>2</sup> and <a href="https://ourworldindata.org">a link</a>.`
+            )
+        )
+    })
 })
 
 describe("refs source-form serializer", () => {

--- a/db/gdocTests.test.ts
+++ b/db/gdocTests.test.ts
@@ -787,6 +787,64 @@ describe("document-level ArchieML round trip", () => {
         ])
     })
 
+    it("round-trips multi-paragraph inline refs without gluing their paragraphs", () => {
+        const { first, canonicalArchieML } = expectDocToRoundTrip(
+            getArchieMLDocWithContent(
+                `One claim{ref}First citation, 283–295.\n\nSecond citation, 31–54.{/ref} and text after.`
+            )
+        )
+        // The definition keeps the two paragraphs as separate text blocks
+        const definitions = Object.values(first.refs?.definitions ?? {})
+        expect(definitions).toHaveLength(1)
+        expect(definitions[0].content).toHaveLength(2)
+        // The write-back reproduces the paragraph break inside {ref}…{/ref}
+        // instead of gluing "…295.Second citation…"
+        expect(canonicalArchieML).toContain(
+            "First citation, 283–295.\n\nSecond citation, 31–54."
+        )
+        expect(canonicalArchieML).not.toContain("295.Second")
+    })
+
+    it("re-escapes key-like prefixes in inline ref content", () => {
+        // "See:" at the start of a {ref} would be swallowed as an ArchieML
+        // key when extractRefs re-loads the content, so authors escape it as
+        // "See\:" in the gdoc — the write-back must do the same.
+        const { first, canonicalArchieML } = expectDocToRoundTrip(
+            getArchieMLDocWithContent(
+                `A claim{ref}See\\: (i) Feenstra, 2017. (ii) Khandelwal, 2016.{/ref} and after.`
+            )
+        )
+        const definitions = Object.values(first.refs?.definitions ?? {})
+        expect(definitions).toHaveLength(1)
+        expect(JSON.stringify(definitions[0].content)).toContain(
+            "See: (i) Feenstra"
+        )
+        expect(canonicalArchieML).toContain("{ref}See\\: (i) Feenstra")
+    })
+
+    it("round-trips detail-on-demand spans, including inside formatting", () => {
+        const { first, canonicalArchieML } = expectDocToRoundTrip(
+            getArchieMLDocWithContent(
+                `A rank of 1 means <u><a href="#dod:comparative-advantage">comparative advantage</a></u> applies.`
+            )
+        )
+        const spans: string[] = []
+        for (const block of first.body ?? [])
+            traverseEnrichedBlock(
+                block,
+                () => undefined,
+                (span) => {
+                    if (span.spanType === "span-dod") spans.push(span.id)
+                }
+            )
+        expect(spans).toEqual(["comparative-advantage"])
+        // The write-back emits the authoring form, not the site markup
+        expect(canonicalArchieML).toContain(
+            '<a href="#dod:comparative-advantage">'
+        )
+        expect(canonicalArchieML).not.toContain("dod-span")
+    })
+
     it("round-trips ID-based refs and regenerates the [.refs] frontmatter block", () => {
         const doc = getArchieMLDocWithContent(
             `A claim{ref}first_ref{/ref} and another{ref}second_ref{/ref}.`,

--- a/db/gdocTests.test.ts
+++ b/db/gdocTests.test.ts
@@ -22,6 +22,9 @@ import { archieToEnriched } from "./model/Gdoc/archieToEnriched.js"
 import { OwidRawGdocBlockToArchieMLString } from "./model/Gdoc/rawToArchie.js"
 import { owidArticleToArchieMLStringGenerator } from "./model/Gdoc/archieToGdoc.js"
 import {
+    getContentKeysForGdocType,
+    OWID_GDOC_DATA_INSIGHT_CONTENT_KEYS,
+    OWID_GDOC_POST_CONTENT_KEYS,
     OwidEnrichedGdocBlock,
     OwidGdocPostContent,
     OwidGdocType,
@@ -30,7 +33,10 @@ import {
 import { enrichedBlockExamples } from "./model/Gdoc/exampleEnrichedBlocks.js"
 import { enrichedBlockToRawBlock } from "./model/Gdoc/enrichedToRaw.js"
 import { load } from "archieml"
-import { parseSimpleText } from "./model/Gdoc/rawToEnriched.js"
+import {
+    parseLatestFeedExcerpt,
+    parseSimpleText,
+} from "./model/Gdoc/rawToEnriched.js"
 import { gdocToArchie } from "./model/Gdoc/gdocToArchie.js"
 import { docs_v1 } from "@googleapis/docs"
 import { documentContainsMixedStraightAndCurlyQuotes } from "./model/Gdoc/gdocValidation.js"
@@ -960,6 +966,113 @@ Second paragraph{ref}an_id_ref{/ref} of text.`,
                 `Plain, <b>bold</b>, <i>italic</i>, <u>underlined</u>, <s>struck</s>, H<sub>2</sub>O, E=mc<sup>2</sup> and <a href="https://ourworldindata.org">a link</a>.`
             )
         )
+    })
+
+    // Mirrors GdocPost._enrichSubclassContent for the one front-matter field
+    // whose enrichment lives in the subclass rather than archieToEnriched.
+    const enrichLikeGdocPost = (content: Record<string, any>): void => {
+        if (content["latest-feed-excerpt"]) {
+            content["latest-feed-excerpt"] = parseLatestFeedExcerpt(
+                content["latest-feed-excerpt"]
+            )
+        }
+    }
+
+    it("round-trips every front-matter key the spine classifies as emitted", () => {
+        const doc = `title: Full front-matter fixture
+supertitle: The supertitle
+subtitle: A subtitle
+authors: Jane Doe
+dateline: June 30, 2025
+excerpt: A short excerpt
+type: article
+sidebar-toc: true
+heading-variant: light
+hide-subscribe-banner: true
+hide-citation: true
+cover-image: cover.png
+cover-color: amber
+featured-image: featured.png
+atom-title: An atom title
+atom-excerpt: An atom excerpt
+latest-feed-featured-image: latest.png
+[.sticky-nav]
+target: #introduction
+text: Introduction
+[]
+[+deprecation-notice]
+This article is deprecated.
+[]
+[+latest-feed-excerpt]
+A feed excerpt with <b>bold</b> text.
+[]
+[.refs]
+id: a_ref
+[.+content]
+The canonical citation.
+[]
+[]
+[+body]
+Some text{ref}a_ref{/ref} with a reference.
+[]
+`
+        const first = archieToEnriched(doc, enrichLikeGdocPost)
+        const canonicalArchieML = enrichedToArchieML(first)
+        const second = archieToEnriched(canonicalArchieML, enrichLikeGdocPost)
+        const firstByKey = first as unknown as Record<string, unknown>
+        const secondByKey = second as unknown as Record<string, unknown>
+
+        for (const [key, fate] of Object.entries(OWID_GDOC_POST_CONTENT_KEYS)) {
+            if (fate !== "emitted") continue
+            expect(
+                secondByKey[key],
+                `front-matter key "${key}" should survive the round trip`
+            ).toBeDefined()
+            if (key === "body" || key === "refs") continue
+            expect(omitUndefinedValues(secondByKey[key])).toEqual(
+                omitUndefinedValues(firstByKey[key])
+            )
+        }
+        expect(omitUndefinedValues(second.body)).toEqual(
+            omitUndefinedValues(first.body)
+        )
+        expect(omitUndefinedValues(second.refs?.definitions)).toEqual(
+            omitUndefinedValues(first.refs?.definitions)
+        )
+        // The write-back of the second parse is a fixed point
+        expect(enrichedToArchieML(second)).toEqual(canonicalArchieML)
+    })
+
+    it("round-trips author roles authored in the authors field", () => {
+        const doc = `title: Roles fixture
+authors: Jane Doe (Editor), John Smith
+type: article
+[+body]
+Hello world.
+[]
+`
+        const first = archieToEnriched(doc)
+        const canonicalArchieML = enrichedToArchieML(first)
+        const second = archieToEnriched(canonicalArchieML)
+        expect(first.authorRoles).toEqual({ "Jane Doe": "Editor" })
+        expect(canonicalArchieML).toContain(
+            "authors: Jane Doe (Editor), John Smith"
+        )
+        expect(second.authors).toEqual(first.authors)
+        expect(second.authorRoles).toEqual(first.authorRoles)
+    })
+
+    it("maps gdoc types to their content-key classification", () => {
+        expect(getContentKeysForGdocType(OwidGdocType.Article)).toBe(
+            OWID_GDOC_POST_CONTENT_KEYS
+        )
+        expect(getContentKeysForGdocType(OwidGdocType.Fragment)).toBe(
+            OWID_GDOC_POST_CONTENT_KEYS
+        )
+        expect(getContentKeysForGdocType(OwidGdocType.DataInsight)).toBe(
+            OWID_GDOC_DATA_INSIGHT_CONTENT_KEYS
+        )
+        expect(getContentKeysForGdocType(OwidGdocType.Homepage)).toBeUndefined()
     })
 })
 

--- a/db/gdocTests.test.ts
+++ b/db/gdocTests.test.ts
@@ -845,6 +845,29 @@ describe("document-level ArchieML round trip", () => {
         expect(canonicalArchieML).not.toContain("dod-span")
     })
 
+    it("round-trips a data insight, including its specific frontmatter", () => {
+        const doc = `title: Test data insight
+authors: OWID Team
+type: data-insight
+grapher-url: https://ourworldindata.org/grapher/life-expectancy
+figma-url: https://www.figma.com/design/abc/def
+[+body]
+A one-paragraph insight with <b>bold</b> text.
+[]
+`
+        const { first, canonicalArchieML } = expectDocToRoundTrip(doc)
+        expect(first.type).toBe(OwidGdocType.DataInsight)
+        expect(canonicalArchieML).toContain("type: data-insight")
+        expect(canonicalArchieML).toContain(
+            "grapher-url: https://ourworldindata.org/grapher/life-expectancy"
+        )
+        expect(canonicalArchieML).toContain(
+            "figma-url: https://www.figma.com/design/abc/def"
+        )
+        // post-only frontmatter is not emitted for data insights
+        expect(canonicalArchieML).not.toContain("sidebar-toc")
+    })
+
     it("round-trips ID-based refs and regenerates the [.refs] frontmatter block", () => {
         const doc = getArchieMLDocWithContent(
             `A claim{ref}first_ref{/ref} and another{ref}second_ref{/ref}.`,

--- a/db/gdocTests.test.ts
+++ b/db/gdocTests.test.ts
@@ -337,6 +337,54 @@ level: 2
         expect(matches.length).toBe(1)
     })
 
+    it("reads underline text style into <u> tags", async () => {
+        const doc: docs_v1.Schema$Document = {
+            body: {
+                content: [
+                    {
+                        paragraph: {
+                            elements: [
+                                {
+                                    textRun: {
+                                        content: "Underlined",
+                                        textStyle: { underline: true },
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                ],
+            },
+        }
+
+        const { text } = await gdocToArchie(doc)
+        expect(text).toContain(`<u>Underlined</u>`)
+    })
+
+    it("reads strikethrough text style into <s> tags", async () => {
+        const doc: docs_v1.Schema$Document = {
+            body: {
+                content: [
+                    {
+                        paragraph: {
+                            elements: [
+                                {
+                                    textRun: {
+                                        content: "Strikethrough",
+                                        textStyle: { strikethrough: true },
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                ],
+            },
+        }
+
+        const { text } = await gdocToArchie(doc)
+        expect(text).toContain(`<s>Strikethrough</s>`)
+    })
+
     it("keeps consecutive links to different targets separate", async () => {
         const url1 = "http://ourworldindata.org/grapher/life-expectancy"
         const url2 = "http://ourworldindata.org/grapher/co2-emissions"

--- a/db/model/Gdoc/archieToEnriched.test.ts
+++ b/db/model/Gdoc/archieToEnriched.test.ts
@@ -199,3 +199,15 @@ it("Can index intermingled inline and ID refs correctly", () => {
         ],
     })
 })
+
+it("Treats a ref without whitespace as an ID ref, not an inline ref", () => {
+    // The inline-vs-ID distinction rests on the content containing a space.
+    // Pinned so a future change is conscious: if write-back ever emitted an
+    // inline ref whose content has no spaces, re-parsing would silently flip
+    // it into an ID ref with no definition.
+    expect(extractRefs(`some text{ref}single_token.{/ref}`)).toEqual({
+        extractedText: `some text${idRef(1, "single_token.")}`,
+        refsByFirstAppearance: new Set(["single_token."]),
+        rawInlineRefs: [],
+    })
+})

--- a/db/model/Gdoc/archieToEnriched.test.ts
+++ b/db/model/Gdoc/archieToEnriched.test.ts
@@ -4,11 +4,19 @@ import { load } from "archieml"
 
 import { extractRefs, stripIgnoredArchieml } from "./archieToEnriched.js"
 
+// extractRefs annotates the post-extraction <a class="ref"> tag with
+// data-ref-kind (and data-ref-id for ID-based refs) so that htmlToEnriched
+// can preserve the source-form distinction into SpanRef.sourceForm.
+const idRef = (note: number, id: string): string =>
+    `<a class="ref" href="#note-${note}" data-ref-kind="id" data-ref-id="${id}"><sup>${note}</sup></a>`
+const inlineRef = (note: number): string =>
+    `<a class="ref" href="#note-${note}" data-ref-kind="inline"><sup>${note}</sup></a>`
+
 it("Can extract a ref from some text", () => {
     expect(
         extractRefs(`I am a thing{ref}some_id{/ref} and some follow up`)
     ).toEqual({
-        extractedText: `I am a thing<a class="ref" href="#note-1"><sup>1</sup></a> and some follow up`,
+        extractedText: `I am a thing${idRef(1, "some_id")} and some follow up`,
         refsByFirstAppearance: new Set(["some_id"]),
         rawInlineRefs: [],
     })
@@ -20,7 +28,7 @@ it("Can extract multiple refs from some text", () => {
             `I am a thing{ref}some_id{/ref} and some follow up{ref}another_id{/ref}`
         )
     ).toEqual({
-        extractedText: `I am a thing<a class="ref" href="#note-1"><sup>1</sup></a> and some follow up<a class="ref" href="#note-2"><sup>2</sup></a>`,
+        extractedText: `I am a thing${idRef(1, "some_id")} and some follow up${idRef(2, "another_id")}`,
         refsByFirstAppearance: new Set(["some_id", "another_id"]),
         rawInlineRefs: [],
     })
@@ -32,7 +40,7 @@ it("Can extract multiple refs from some text and refer to an earlier footnote wh
             `I am a thing{ref}some_id{/ref} and some follow up{ref}another_id{/ref}. I refer to a ref that has already been referenced once{ref}some_id{/ref}`
         )
     ).toEqual({
-        extractedText: `I am a thing<a class="ref" href="#note-1"><sup>1</sup></a> and some follow up<a class="ref" href="#note-2"><sup>2</sup></a>. I refer to a ref that has already been referenced once<a class="ref" href="#note-1"><sup>1</sup></a>`,
+        extractedText: `I am a thing${idRef(1, "some_id")} and some follow up${idRef(2, "another_id")}. I refer to a ref that has already been referenced once${idRef(1, "some_id")}`,
         refsByFirstAppearance: new Set(["some_id", "another_id"]),
         rawInlineRefs: [],
     })
@@ -40,7 +48,7 @@ it("Can extract multiple refs from some text and refer to an earlier footnote wh
 
 it("Can extract an inline ref", () => {
     expect(extractRefs(`I am a thing{ref}I am an inline ref{/ref}`)).toEqual({
-        extractedText: `I am a thing<a class="ref" href="#note-1"><sup>1</sup></a>`,
+        extractedText: `I am a thing${inlineRef(1)}`,
         refsByFirstAppearance: new Set([
             "796885412908186a5e57f2e753ab697b85666afe",
         ]),
@@ -64,7 +72,7 @@ it("Can extract an inline ref and an ID ref", () => {
             `I am a thing{ref}I am an inline ref{/ref} and another thing{ref}some_id{/ref}`
         )
     ).toEqual({
-        extractedText: `I am a thing<a class="ref" href="#note-1"><sup>1</sup></a> and another thing<a class="ref" href="#note-2"><sup>2</sup></a>`,
+        extractedText: `I am a thing${inlineRef(1)} and another thing${idRef(2, "some_id")}`,
         refsByFirstAppearance: new Set([
             "796885412908186a5e57f2e753ab697b85666afe",
             "some_id",
@@ -89,7 +97,7 @@ it("Can extract an inline ref and an ID ref and then refer back to a previous in
             `I am a thing{ref}I am an inline ref{/ref} and another thing{ref}some_id{/ref} and me again{ref}I am an inline ref{/ref}`
         )
     ).toEqual({
-        extractedText: `I am a thing<a class="ref" href="#note-1"><sup>1</sup></a> and another thing<a class="ref" href="#note-2"><sup>2</sup></a> and me again<a class="ref" href="#note-1"><sup>1</sup></a>`,
+        extractedText: `I am a thing${inlineRef(1)} and another thing${idRef(2, "some_id")} and me again${inlineRef(1)}`,
         refsByFirstAppearance: new Set([
             "796885412908186a5e57f2e753ab697b85666afe",
             "some_id",
@@ -150,7 +158,7 @@ it("Preserves ArchieML buffer-flush semantics around a :skip block", () => {
 it("Ignores refs that appear after :ignore so footnote numbering is unaffected", () => {
     const text = `real{ref}some_id{/ref}\n:ignore\nfake{ref}another_id{/ref}`
     expect(extractRefs(stripIgnoredArchieml(text))).toEqual({
-        extractedText: `real<a class="ref" href="#note-1"><sup>1</sup></a>\n`,
+        extractedText: `real${idRef(1, "some_id")}\n`,
         refsByFirstAppearance: new Set(["some_id"]),
         rawInlineRefs: [],
     })
@@ -162,7 +170,7 @@ it("Can index intermingled inline and ID refs correctly", () => {
             `I am a thing{ref}some_id{/ref} and another thing{ref}An inline ref{/ref} with more {ref}another_id{/ref} and even more{ref}Another inline ref{/ref}`
         )
     ).toEqual({
-        extractedText: `I am a thing<a class="ref" href="#note-1"><sup>1</sup></a> and another thing<a class="ref" href="#note-2"><sup>2</sup></a> with more <a class="ref" href="#note-3"><sup>3</sup></a> and even more<a class="ref" href="#note-4"><sup>4</sup></a>`,
+        extractedText: `I am a thing${idRef(1, "some_id")} and another thing${inlineRef(2)} with more ${idRef(3, "another_id")} and even more${inlineRef(4)}`,
         refsByFirstAppearance: new Set([
             "some_id",
             "3d708842b0da8d18eabe4d2212ba27646ed20f49",

--- a/db/model/Gdoc/archieToEnriched.ts
+++ b/db/model/Gdoc/archieToEnriched.ts
@@ -167,7 +167,18 @@ function fillInlineRefSourceContent(
     for (const ref of Object.values(definitions)) {
         const spans: Span[] = []
         for (const block of ref.content) {
-            if (block.type === "text") spans.push(...block.value)
+            // Skip non-text and empty text blocks (the latter serialize to
+            // nothing, so emitting a separator for them would produce a
+            // double "\n\n" that does not survive a round trip)
+            if (block.type !== "text" || block.value.length === 0) continue
+            // Preserve the paragraph boundary between the definition's text
+            // blocks: the ArchieML write-back joins these spans without any
+            // separator, so an explicit "\n\n" span is what keeps a
+            // multi-paragraph {ref} from being glued into one paragraph —
+            // and keeps its content hash (the ref's id) stable.
+            if (spans.length > 0)
+                spans.push({ spanType: "span-simple-text", text: "\n\n" })
+            spans.push(...block.value)
         }
         byIndex.set(ref.index, spans)
     }
@@ -214,8 +225,13 @@ export function extractRefs(text: string): {
         ) as RegExpMatchArray
         const contentOrId = match[1]
 
+        // Hash the trimmed content: the span parser trims leading/trailing
+        // whitespace anyway, so hashing it raw would give `{ref} x {/ref}`
+        // and `{ref}x{/ref}` different ids even though they parse to the
+        // same footnote — and would make the id unstable across a
+        // write-back round trip (which can only serialize the trimmed form).
         const id = isInlineRef
-            ? createHash("sha1").update(contentOrId).digest("hex")
+            ? createHash("sha1").update(contentOrId.trim()).digest("hex")
             : contentOrId
 
         refsByFirstAppearance.add(id)

--- a/db/model/Gdoc/archieToEnriched.ts
+++ b/db/model/Gdoc/archieToEnriched.ts
@@ -10,10 +10,16 @@ import {
     checkNodeIsSpan,
     EnrichedBlockSimpleText,
     lowercaseObjectKeys,
+    traverseEnrichedBlock,
     ALL_CHARTS_ID,
     KEY_INSIGHTS_ID,
     RESEARCH_AND_WRITING_ID,
 } from "@ourworldindata/utils"
+import type {
+    OwidEnrichedGdocBlock,
+    RefDictionary,
+    Span,
+} from "@ourworldindata/types"
 import { convertHeadingTextToId } from "@ourworldindata/components"
 import {
     parseRawBlocksToEnrichedBlocks,
@@ -137,6 +143,50 @@ export function stripIgnoredArchieml(text: string): string {
     )
 }
 
+// Minimal HTML attribute escaping for ref IDs that get embedded in the
+// data-ref-id attribute of the post-extraction <a> tag.
+function escapeRefAttr(s: string): string {
+    return s
+        .replace(/&/g, "&amp;")
+        .replace(/"/g, "&quot;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+}
+
+// Post-pass after the body has been enriched and refs parsed. Walks every
+// SpanRef and fills in `sourceForm.content` for inline refs by looking up
+// the canonical content in the RefDictionary via the url's #note-N suffix.
+// Idempotent: skips any SpanRef whose content is already non-empty or
+// whose kind is "id".
+function fillInlineRefSourceContent(
+    body: OwidEnrichedGdocBlock[] | undefined,
+    definitions: RefDictionary
+): void {
+    if (!body || body.length === 0) return
+    const byIndex = new Map<number, Span[]>()
+    for (const ref of Object.values(definitions)) {
+        const spans: Span[] = []
+        for (const block of ref.content) {
+            if (block.type === "text") spans.push(...block.value)
+        }
+        byIndex.set(ref.index, spans)
+    }
+    const fillSpan = (span: Span): void => {
+        if (span.spanType !== "span-ref") return
+        if (span.sourceForm.kind !== "inline") return
+        if (span.sourceForm.content.length > 0) return
+        const m = span.url?.match(/^#note-(\d+)$/)
+        if (!m) return
+        const spans = byIndex.get(parseInt(m[1], 10) - 1)
+        if (!spans) return
+        span.sourceForm = { kind: "inline", content: spans }
+    }
+    const noop = (_b: OwidEnrichedGdocBlock): void => undefined
+    for (const block of body) {
+        traverseEnrichedBlock(block, noop, fillSpan)
+    }
+}
+
 // Match all curly bracket {ref}some_id{/ref} and {ref}I am an inline ref{/ref} syntax in the text
 // Iterate through them
 // If it's an inline ref, hash its contents to use as an ID and parse it
@@ -181,9 +231,17 @@ export function extractRefs(text: string): {
         // deepest level of nesting (see the readElements function) we can be confident
         // that this will work as expected in this case and is much simpler than handling
         // this later.
+        //
+        // data-ref-kind (and data-ref-id for ID-based) preserve the ID-vs-inline
+        // distinction through htmlToEnriched into SpanRef.sourceForm. Inline
+        // content survives via the RefDictionary (looked up by url=#note-N) in
+        // a post-pass below.
+        const dataAttrs = isInlineRef
+            ? `data-ref-kind="inline"`
+            : `data-ref-kind="id" data-ref-id="${escapeRefAttr(contentOrId)}"`
         extractedText = extractedText.replace(
             rawRef,
-            `<a class="ref" href="#note-${footnoteNumber}"><sup>${footnoteNumber}</sup></a>`
+            `<a class="ref" href="#note-${footnoteNumber}" ${dataAttrs}><sup>${footnoteNumber}</sup></a>`
         )
 
         if (isInlineRef) {
@@ -274,6 +332,12 @@ export const archieToEnriched = (
         refsByFirstAppearance,
     })
     parsed.refs = parsedRefs
+
+    // Fill in SpanRef.sourceForm.content for inline refs from the just-built
+    // RefDictionary. extractRefs / htmlToEnriched flag inline refs with
+    // `kind: "inline"` and an empty content array — the canonical content
+    // lives in the dictionary, keyed by #note-N url → index.
+    fillInlineRefSourceContent(parsed.body, parsedRefs.definitions)
 
     // this property was originally named byline even though it was a comma-separated list of authors
     // once this has been deployed for a while and we've migrated the property name in all gdocs,

--- a/db/model/Gdoc/archieToGdoc.ts
+++ b/db/model/Gdoc/archieToGdoc.ts
@@ -11,7 +11,7 @@ import { OwidGoogleAuth } from "../../OwidGoogleAuth.js"
 import * as cheerio from "cheerio"
 import type { AnyNode } from "domhandler"
 
-function* owidArticleToArchieMLStringGenerator(
+export function* owidArticleToArchieMLStringGenerator(
     article: OwidGdocPostContent
 ): Generator<string, void, undefined> {
     yield* propertyToArchieMLString("title", article)
@@ -152,7 +152,7 @@ function* lineToBatchUpdates(line: Line): Generator<docs_v1.Schema$Request> {
     }
 }
 
-function articleToBatchUpdates(
+export function articleToBatchUpdates(
     content: OwidGdocPostContent
 ): docs_v1.Schema$Request[] {
     const archieMlLines = [...owidArticleToArchieMLStringGenerator(content)]
@@ -192,7 +192,7 @@ function articleToBatchUpdates(
     return batchUpdates.toReversed()
 }
 
-async function deleteGdocContent(
+export async function deleteGdocContent(
     client: docs_v1.Docs,
     existingGdocId: string
 ): Promise<void> {

--- a/db/model/Gdoc/archieToGdoc.ts
+++ b/db/model/Gdoc/archieToGdoc.ts
@@ -1,4 +1,8 @@
-import { OwidGdocPostContent } from "@ourworldindata/utils"
+import {
+    OwidGdocPostContent,
+    traverseEnrichedBlock,
+} from "@ourworldindata/utils"
+import type { OwidEnrichedGdocBlock, Span } from "@ourworldindata/types"
 import {
     propertyToArchieMLString,
     OwidRawGdocBlockToArchieMLStringGenerator,
@@ -10,6 +14,54 @@ import { type drive_v3, drive as googleDrive } from "@googleapis/drive"
 import { OwidGoogleAuth } from "../../OwidGoogleAuth.js"
 import * as cheerio from "cheerio"
 import type { AnyNode } from "domhandler"
+
+// Collect the set of ref IDs that appear as ID-based refs in the body.
+// These are the entries that need to live in the [.refs] frontmatter
+// block. Inline refs are NOT collected — their content is emitted inline
+// as `{ref}content{/ref}` by spanToArchieMLSourceString, with no
+// frontmatter definition required.
+function collectIdBasedRefIds(
+    body: OwidEnrichedGdocBlock[] | undefined
+): Set<string> {
+    const ids = new Set<string>()
+    if (!body) return ids
+    const visitSpan = (span: Span): void => {
+        if (span.spanType === "span-ref" && span.sourceForm.kind === "id") {
+            ids.add(span.sourceForm.id)
+        }
+    }
+    const noop = (_b: OwidEnrichedGdocBlock): void => undefined
+    for (const block of body) {
+        traverseEnrichedBlock(block, noop, visitSpan)
+    }
+    return ids
+}
+
+// Emit a [.refs] frontmatter block listing each ID-based ref's id +
+// content. Order follows the order in which ID-based refs first appear
+// in the body, which is deterministic and matches what extractRefs sees
+// on the way back in. Skipped entirely when there are no ID-based refs.
+function* yieldRefsBlockIfDefined(
+    article: OwidGdocPostContent
+): Generator<string, void, undefined> {
+    const definitions = article.refs?.definitions
+    if (!definitions) return
+    const idBased = collectIdBasedRefIds(article.body)
+    if (idBased.size === 0) return
+    yield "[.refs]"
+    for (const id of idBased) {
+        const ref = definitions[id]
+        if (!ref) continue
+        yield `id: ${id}`
+        yield "[.+content]"
+        for (const block of ref.content) {
+            const rawBlock = enrichedBlockToRawBlock(block)
+            yield* OwidRawGdocBlockToArchieMLStringGenerator(rawBlock)
+        }
+        yield "[]"
+    }
+    yield "[]"
+}
 
 export function* owidArticleToArchieMLStringGenerator(
     article: OwidGdocPostContent
@@ -32,11 +84,11 @@ export function* owidArticleToArchieMLStringGenerator(
     yield* propertyToArchieMLString("sidebar-toc", article)
     yield* propertyToArchieMLString("heading-variant", article)
     yield* propertyToArchieMLString("hide-subscribe-banner", article)
-    // TODO: inline refs
     yield* propertyToArchieMLString("hide-citation", article)
     yield* propertyToArchieMLString("cover-image", article)
     yield* propertyToArchieMLString("cover-color", article)
     yield* propertyToArchieMLString("featured-image", article)
+    yield* yieldRefsBlockIfDefined(article)
     yield ""
     if (article.body) {
         yield "[+body]"

--- a/db/model/Gdoc/archieToGdoc.ts
+++ b/db/model/Gdoc/archieToGdoc.ts
@@ -2,7 +2,12 @@ import {
     OwidGdocPostContent,
     traverseEnrichedBlock,
 } from "@ourworldindata/utils"
-import type { OwidEnrichedGdocBlock, Span } from "@ourworldindata/types"
+import {
+    OwidGdocType,
+    type OwidGdocDataInsightContent,
+    type OwidEnrichedGdocBlock,
+    type Span,
+} from "@ourworldindata/types"
 import {
     propertyToArchieMLString,
     OwidRawGdocBlockToArchieMLStringGenerator,
@@ -63,32 +68,48 @@ function* yieldRefsBlockIfDefined(
     yield "[]"
 }
 
+/** Content shapes the ArchieML write-back layer knows how to serialize. */
+export type ArchieMlWritableContent =
+    | OwidGdocPostContent
+    | OwidGdocDataInsightContent
+
 export function* owidArticleToArchieMLStringGenerator(
-    article: OwidGdocPostContent
+    article: ArchieMlWritableContent
 ): Generator<string, void, undefined> {
-    yield* propertyToArchieMLString("title", article)
-    yield* propertyToArchieMLString("subtitle", article)
-    yield* propertyToArchieMLString("supertitle", article)
-    yield* propertyToArchieMLString("authors", article)
-    yield* propertyToArchieMLString("dateline", article)
-    yield* propertyToArchieMLString("excerpt", article)
-    yield* propertyToArchieMLString("type", article)
-    if (article["sticky-nav"]) {
-        yield "[.sticky-nav]"
-        for (const item of article["sticky-nav"]) {
-            yield* propertyToArchieMLString("target", item)
-            yield* propertyToArchieMLString("text", item)
+    if (article.type === OwidGdocType.DataInsight) {
+        const dataInsight: OwidGdocDataInsightContent = article
+        yield* propertyToArchieMLString("title", dataInsight)
+        yield* propertyToArchieMLString("authors", dataInsight)
+        yield* propertyToArchieMLString("type", dataInsight)
+        yield* propertyToArchieMLString("grapher-url", dataInsight)
+        yield* propertyToArchieMLString("narrative-chart", dataInsight)
+        yield* propertyToArchieMLString("figma-url", dataInsight)
+    } else {
+        const post = article
+        yield* propertyToArchieMLString("title", post)
+        yield* propertyToArchieMLString("subtitle", post)
+        yield* propertyToArchieMLString("supertitle", post)
+        yield* propertyToArchieMLString("authors", post)
+        yield* propertyToArchieMLString("dateline", post)
+        yield* propertyToArchieMLString("excerpt", post)
+        yield* propertyToArchieMLString("type", post)
+        if (post["sticky-nav"]) {
+            yield "[.sticky-nav]"
+            for (const item of post["sticky-nav"]) {
+                yield* propertyToArchieMLString("target", item)
+                yield* propertyToArchieMLString("text", item)
+            }
+            yield "[]"
         }
-        yield "[]"
+        yield* propertyToArchieMLString("sidebar-toc", post)
+        yield* propertyToArchieMLString("heading-variant", post)
+        yield* propertyToArchieMLString("hide-subscribe-banner", post)
+        yield* propertyToArchieMLString("hide-citation", post)
+        yield* propertyToArchieMLString("cover-image", post)
+        yield* propertyToArchieMLString("cover-color", post)
+        yield* propertyToArchieMLString("featured-image", post)
+        yield* yieldRefsBlockIfDefined(post)
     }
-    yield* propertyToArchieMLString("sidebar-toc", article)
-    yield* propertyToArchieMLString("heading-variant", article)
-    yield* propertyToArchieMLString("hide-subscribe-banner", article)
-    yield* propertyToArchieMLString("hide-citation", article)
-    yield* propertyToArchieMLString("cover-image", article)
-    yield* propertyToArchieMLString("cover-color", article)
-    yield* propertyToArchieMLString("featured-image", article)
-    yield* yieldRefsBlockIfDefined(article)
     yield ""
     if (article.body) {
         yield "[+body]"
@@ -205,7 +226,7 @@ function* lineToBatchUpdates(line: Line): Generator<docs_v1.Schema$Request> {
 }
 
 export function articleToBatchUpdates(
-    content: OwidGdocPostContent
+    content: ArchieMlWritableContent
 ): docs_v1.Schema$Request[] {
     const archieMlLines = [...owidArticleToArchieMLStringGenerator(content)]
 
@@ -300,7 +321,7 @@ async function createGdoc(
 }
 
 export async function createGdocAndInsertOwidGdocPostContent(
-    content: OwidGdocPostContent,
+    content: ArchieMlWritableContent,
     existingGdocId: string | null
 ): Promise<string> {
     const batchUpdates = articleToBatchUpdates(content)

--- a/db/model/Gdoc/archieToGdoc.ts
+++ b/db/model/Gdoc/archieToGdoc.ts
@@ -4,6 +4,7 @@ import {
 } from "@ourworldindata/utils"
 import {
     OwidGdocType,
+    type EnrichedBlockText,
     type OwidGdocDataInsightContent,
     type OwidEnrichedGdocBlock,
     type Span,
@@ -40,6 +41,37 @@ function collectIdBasedRefIds(
         traverseEnrichedBlock(block, noop, visitSpan)
     }
     return ids
+}
+
+// Emit the authors line in its authoring form, reconstructing the
+// "Name (Role)" annotations that parseAuthors extracted into authorRoles —
+// otherwise roles authored in the document are lost on write-back.
+function* yieldAuthorsWithRoles(content: {
+    authors?: string[]
+    authorRoles?: Record<string, string>
+}): Generator<string, void, undefined> {
+    if (!content.authors?.length) return
+    const authors = content.authors.map((name) => {
+        const role = content.authorRoles?.[name]
+        return role ? `${name} (${role})` : name
+    })
+    yield `authors: ${authors.join(", ")}`
+}
+
+// Emit a [+key] freeform frontmatter block for a text-blocks field
+// (deprecation-notice, latest-feed-excerpt), mirroring the body emission.
+function* yieldTextBlocksIfDefined(
+    key: string,
+    blocks: EnrichedBlockText[] | undefined
+): Generator<string, void, undefined> {
+    if (!blocks?.length) return
+    yield `[+${key}]`
+    for (const block of blocks) {
+        const rawBlock = enrichedBlockToRawBlock(block)
+        yield* OwidRawGdocBlockToArchieMLStringGenerator(rawBlock)
+        yield ""
+    }
+    yield "[]"
 }
 
 // Emit a [.refs] frontmatter block listing each ID-based ref's id +
@@ -79,7 +111,7 @@ export function* owidArticleToArchieMLStringGenerator(
     if (article.type === OwidGdocType.DataInsight) {
         const dataInsight: OwidGdocDataInsightContent = article
         yield* propertyToArchieMLString("title", dataInsight)
-        yield* propertyToArchieMLString("authors", dataInsight)
+        yield* yieldAuthorsWithRoles(dataInsight)
         yield* propertyToArchieMLString("type", dataInsight)
         yield* propertyToArchieMLString("grapher-url", dataInsight)
         yield* propertyToArchieMLString("narrative-chart", dataInsight)
@@ -89,7 +121,7 @@ export function* owidArticleToArchieMLStringGenerator(
         yield* propertyToArchieMLString("title", post)
         yield* propertyToArchieMLString("subtitle", post)
         yield* propertyToArchieMLString("supertitle", post)
-        yield* propertyToArchieMLString("authors", post)
+        yield* yieldAuthorsWithRoles(post)
         yield* propertyToArchieMLString("dateline", post)
         yield* propertyToArchieMLString("excerpt", post)
         yield* propertyToArchieMLString("type", post)
@@ -108,6 +140,17 @@ export function* owidArticleToArchieMLStringGenerator(
         yield* propertyToArchieMLString("cover-image", post)
         yield* propertyToArchieMLString("cover-color", post)
         yield* propertyToArchieMLString("featured-image", post)
+        yield* propertyToArchieMLString("atom-title", post)
+        yield* propertyToArchieMLString("atom-excerpt", post)
+        yield* propertyToArchieMLString("latest-feed-featured-image", post)
+        yield* yieldTextBlocksIfDefined(
+            "deprecation-notice",
+            post["deprecation-notice"]
+        )
+        yield* yieldTextBlocksIfDefined(
+            "latest-feed-excerpt",
+            post["latest-feed-excerpt"]
+        )
         yield* yieldRefsBlockIfDefined(post)
     }
     yield ""

--- a/db/model/Gdoc/archieToGdoc.ts
+++ b/db/model/Gdoc/archieToGdoc.ts
@@ -11,7 +11,7 @@ import { OwidGoogleAuth } from "../../OwidGoogleAuth.js"
 import * as cheerio from "cheerio"
 import type { AnyNode } from "domhandler"
 
-function* owidArticleToArchieMLStringGenerator(
+export function* owidArticleToArchieMLStringGenerator(
     article: OwidGdocPostContent
 ): Generator<string, void, undefined> {
     yield* propertyToArchieMLString("title", article)
@@ -153,7 +153,7 @@ function* lineToBatchUpdates(line: Line): Generator<docs_v1.Schema$Request> {
     }
 }
 
-function articleToBatchUpdates(
+export function articleToBatchUpdates(
     content: OwidGdocPostContent
 ): docs_v1.Schema$Request[] {
     const archieMlLines = [...owidArticleToArchieMLStringGenerator(content)]
@@ -193,7 +193,7 @@ function articleToBatchUpdates(
     return batchUpdates.toReversed()
 }
 
-async function deleteGdocContent(
+export async function deleteGdocContent(
     client: docs_v1.Docs,
     existingGdocId: string
 ): Promise<void> {

--- a/db/model/Gdoc/archieToGdoc.ts
+++ b/db/model/Gdoc/archieToGdoc.ts
@@ -4,6 +4,7 @@ import {
 } from "@ourworldindata/utils"
 import {
     OwidGdocType,
+    type EnrichedBlockText,
     type OwidGdocDataInsightContent,
     type OwidEnrichedGdocBlock,
     type Span,
@@ -40,6 +41,37 @@ function collectIdBasedRefIds(
         traverseEnrichedBlock(block, noop, visitSpan)
     }
     return ids
+}
+
+// Emit the authors line in its authoring form, reconstructing the
+// "Name (Role)" annotations that parseAuthors extracted into authorRoles —
+// otherwise roles authored in the document are lost on write-back.
+function* yieldAuthorsWithRoles(content: {
+    authors?: string[]
+    authorRoles?: Record<string, string>
+}): Generator<string, void, undefined> {
+    if (!content.authors?.length) return
+    const authors = content.authors.map((name) => {
+        const role = content.authorRoles?.[name]
+        return role ? `${name} (${role})` : name
+    })
+    yield `authors: ${authors.join(", ")}`
+}
+
+// Emit a [+key] freeform frontmatter block for a text-blocks field
+// (deprecation-notice, latest-feed-excerpt), mirroring the body emission.
+function* yieldTextBlocksIfDefined(
+    key: string,
+    blocks: EnrichedBlockText[] | undefined
+): Generator<string, void, undefined> {
+    if (!blocks?.length) return
+    yield `[+${key}]`
+    for (const block of blocks) {
+        const rawBlock = enrichedBlockToRawBlock(block)
+        yield* OwidRawGdocBlockToArchieMLStringGenerator(rawBlock)
+        yield ""
+    }
+    yield "[]"
 }
 
 // Emit a [.refs] frontmatter block listing each ID-based ref's id +
@@ -79,7 +111,7 @@ export function* owidArticleToArchieMLStringGenerator(
     if (article.type === OwidGdocType.DataInsight) {
         const dataInsight: OwidGdocDataInsightContent = article
         yield* propertyToArchieMLString("title", dataInsight)
-        yield* propertyToArchieMLString("authors", dataInsight)
+        yield* yieldAuthorsWithRoles(dataInsight)
         yield* propertyToArchieMLString("type", dataInsight)
         yield* propertyToArchieMLString("grapher-url", dataInsight)
         yield* propertyToArchieMLString("narrative-chart", dataInsight)
@@ -89,7 +121,7 @@ export function* owidArticleToArchieMLStringGenerator(
         yield* propertyToArchieMLString("title", post)
         yield* propertyToArchieMLString("subtitle", post)
         yield* propertyToArchieMLString("supertitle", post)
-        yield* propertyToArchieMLString("authors", post)
+        yield* yieldAuthorsWithRoles(post)
         yield* propertyToArchieMLString("dateline", post)
         yield* propertyToArchieMLString("excerpt", post)
         yield* propertyToArchieMLString("type", post)
@@ -109,6 +141,17 @@ export function* owidArticleToArchieMLStringGenerator(
         yield* propertyToArchieMLString("cover-image", post)
         yield* propertyToArchieMLString("cover-color", post)
         yield* propertyToArchieMLString("featured-image", post)
+        yield* propertyToArchieMLString("atom-title", post)
+        yield* propertyToArchieMLString("atom-excerpt", post)
+        yield* propertyToArchieMLString("latest-feed-featured-image", post)
+        yield* yieldTextBlocksIfDefined(
+            "deprecation-notice",
+            post["deprecation-notice"]
+        )
+        yield* yieldTextBlocksIfDefined(
+            "latest-feed-excerpt",
+            post["latest-feed-excerpt"]
+        )
         yield* yieldRefsBlockIfDefined(post)
     }
     yield ""

--- a/db/model/Gdoc/archieToGdoc.ts
+++ b/db/model/Gdoc/archieToGdoc.ts
@@ -1,4 +1,8 @@
-import { OwidGdocPostContent } from "@ourworldindata/utils"
+import {
+    OwidGdocPostContent,
+    traverseEnrichedBlock,
+} from "@ourworldindata/utils"
+import type { OwidEnrichedGdocBlock, Span } from "@ourworldindata/types"
 import {
     propertyToArchieMLString,
     OwidRawGdocBlockToArchieMLStringGenerator,
@@ -10,6 +14,54 @@ import { type drive_v3, drive as googleDrive } from "@googleapis/drive"
 import { OwidGoogleAuth } from "../../OwidGoogleAuth.js"
 import * as cheerio from "cheerio"
 import type { AnyNode } from "domhandler"
+
+// Collect the set of ref IDs that appear as ID-based refs in the body.
+// These are the entries that need to live in the [.refs] frontmatter
+// block. Inline refs are NOT collected — their content is emitted inline
+// as `{ref}content{/ref}` by spanToArchieMLSourceString, with no
+// frontmatter definition required.
+function collectIdBasedRefIds(
+    body: OwidEnrichedGdocBlock[] | undefined
+): Set<string> {
+    const ids = new Set<string>()
+    if (!body) return ids
+    const visitSpan = (span: Span): void => {
+        if (span.spanType === "span-ref" && span.sourceForm.kind === "id") {
+            ids.add(span.sourceForm.id)
+        }
+    }
+    const noop = (_b: OwidEnrichedGdocBlock): void => undefined
+    for (const block of body) {
+        traverseEnrichedBlock(block, noop, visitSpan)
+    }
+    return ids
+}
+
+// Emit a [.refs] frontmatter block listing each ID-based ref's id +
+// content. Order follows the order in which ID-based refs first appear
+// in the body, which is deterministic and matches what extractRefs sees
+// on the way back in. Skipped entirely when there are no ID-based refs.
+function* yieldRefsBlockIfDefined(
+    article: OwidGdocPostContent
+): Generator<string, void, undefined> {
+    const definitions = article.refs?.definitions
+    if (!definitions) return
+    const idBased = collectIdBasedRefIds(article.body)
+    if (idBased.size === 0) return
+    yield "[.refs]"
+    for (const id of idBased) {
+        const ref = definitions[id]
+        if (!ref) continue
+        yield `id: ${id}`
+        yield "[.+content]"
+        for (const block of ref.content) {
+            const rawBlock = enrichedBlockToRawBlock(block)
+            yield* OwidRawGdocBlockToArchieMLStringGenerator(rawBlock)
+        }
+        yield "[]"
+    }
+    yield "[]"
+}
 
 export function* owidArticleToArchieMLStringGenerator(
     article: OwidGdocPostContent
@@ -33,11 +85,11 @@ export function* owidArticleToArchieMLStringGenerator(
     yield* propertyToArchieMLString("sidebar-toc-h1-only", article)
     yield* propertyToArchieMLString("heading-variant", article)
     yield* propertyToArchieMLString("hide-subscribe-banner", article)
-    // TODO: inline refs
     yield* propertyToArchieMLString("hide-citation", article)
     yield* propertyToArchieMLString("cover-image", article)
     yield* propertyToArchieMLString("cover-color", article)
     yield* propertyToArchieMLString("featured-image", article)
+    yield* yieldRefsBlockIfDefined(article)
     yield ""
     if (article.body) {
         yield "[+body]"

--- a/db/model/Gdoc/archieToGdoc.ts
+++ b/db/model/Gdoc/archieToGdoc.ts
@@ -2,7 +2,12 @@ import {
     OwidGdocPostContent,
     traverseEnrichedBlock,
 } from "@ourworldindata/utils"
-import type { OwidEnrichedGdocBlock, Span } from "@ourworldindata/types"
+import {
+    OwidGdocType,
+    type OwidGdocDataInsightContent,
+    type OwidEnrichedGdocBlock,
+    type Span,
+} from "@ourworldindata/types"
 import {
     propertyToArchieMLString,
     OwidRawGdocBlockToArchieMLStringGenerator,
@@ -63,33 +68,49 @@ function* yieldRefsBlockIfDefined(
     yield "[]"
 }
 
+/** Content shapes the ArchieML write-back layer knows how to serialize. */
+export type ArchieMlWritableContent =
+    | OwidGdocPostContent
+    | OwidGdocDataInsightContent
+
 export function* owidArticleToArchieMLStringGenerator(
-    article: OwidGdocPostContent
+    article: ArchieMlWritableContent
 ): Generator<string, void, undefined> {
-    yield* propertyToArchieMLString("title", article)
-    yield* propertyToArchieMLString("subtitle", article)
-    yield* propertyToArchieMLString("supertitle", article)
-    yield* propertyToArchieMLString("authors", article)
-    yield* propertyToArchieMLString("dateline", article)
-    yield* propertyToArchieMLString("excerpt", article)
-    yield* propertyToArchieMLString("type", article)
-    if (article["sticky-nav"]) {
-        yield "[.sticky-nav]"
-        for (const item of article["sticky-nav"]) {
-            yield* propertyToArchieMLString("target", item)
-            yield* propertyToArchieMLString("text", item)
+    if (article.type === OwidGdocType.DataInsight) {
+        const dataInsight: OwidGdocDataInsightContent = article
+        yield* propertyToArchieMLString("title", dataInsight)
+        yield* propertyToArchieMLString("authors", dataInsight)
+        yield* propertyToArchieMLString("type", dataInsight)
+        yield* propertyToArchieMLString("grapher-url", dataInsight)
+        yield* propertyToArchieMLString("narrative-chart", dataInsight)
+        yield* propertyToArchieMLString("figma-url", dataInsight)
+    } else {
+        const post = article
+        yield* propertyToArchieMLString("title", post)
+        yield* propertyToArchieMLString("subtitle", post)
+        yield* propertyToArchieMLString("supertitle", post)
+        yield* propertyToArchieMLString("authors", post)
+        yield* propertyToArchieMLString("dateline", post)
+        yield* propertyToArchieMLString("excerpt", post)
+        yield* propertyToArchieMLString("type", post)
+        if (post["sticky-nav"]) {
+            yield "[.sticky-nav]"
+            for (const item of post["sticky-nav"]) {
+                yield* propertyToArchieMLString("target", item)
+                yield* propertyToArchieMLString("text", item)
+            }
+            yield "[]"
         }
-        yield "[]"
+        yield* propertyToArchieMLString("sidebar-toc", post)
+        yield* propertyToArchieMLString("sidebar-toc-h1-only", post)
+        yield* propertyToArchieMLString("heading-variant", post)
+        yield* propertyToArchieMLString("hide-subscribe-banner", post)
+        yield* propertyToArchieMLString("hide-citation", post)
+        yield* propertyToArchieMLString("cover-image", post)
+        yield* propertyToArchieMLString("cover-color", post)
+        yield* propertyToArchieMLString("featured-image", post)
+        yield* yieldRefsBlockIfDefined(post)
     }
-    yield* propertyToArchieMLString("sidebar-toc", article)
-    yield* propertyToArchieMLString("sidebar-toc-h1-only", article)
-    yield* propertyToArchieMLString("heading-variant", article)
-    yield* propertyToArchieMLString("hide-subscribe-banner", article)
-    yield* propertyToArchieMLString("hide-citation", article)
-    yield* propertyToArchieMLString("cover-image", article)
-    yield* propertyToArchieMLString("cover-color", article)
-    yield* propertyToArchieMLString("featured-image", article)
-    yield* yieldRefsBlockIfDefined(article)
     yield ""
     if (article.body) {
         yield "[+body]"
@@ -206,7 +227,7 @@ function* lineToBatchUpdates(line: Line): Generator<docs_v1.Schema$Request> {
 }
 
 export function articleToBatchUpdates(
-    content: OwidGdocPostContent
+    content: ArchieMlWritableContent
 ): docs_v1.Schema$Request[] {
     const archieMlLines = [...owidArticleToArchieMLStringGenerator(content)]
 
@@ -301,7 +322,7 @@ async function createGdoc(
 }
 
 export async function createGdocAndInsertOwidGdocPostContent(
-    content: OwidGdocPostContent,
+    content: ArchieMlWritableContent,
     existingGdocId: string | null
 ): Promise<string> {
     const batchUpdates = articleToBatchUpdates(content)

--- a/db/model/Gdoc/enrichedToIndexableText.test.ts
+++ b/db/model/Gdoc/enrichedToIndexableText.test.ts
@@ -68,6 +68,7 @@ describe(enrichedBlocksToIndexableText, () => {
                 {
                     spanType: "span-ref",
                     url: "#note-4",
+                    sourceForm: { kind: "id", id: "example_id" },
                     children: [
                         {
                             spanType: "span-superscript",

--- a/db/model/Gdoc/enrichedToIndexableText.ts
+++ b/db/model/Gdoc/enrichedToIndexableText.ts
@@ -102,6 +102,7 @@ function spanToIndexableText(
                     "span-italic",
                     "span-bold",
                     "span-underline",
+                    "span-strikethrough",
                     "span-subscript",
                     "span-superscript",
                     "span-quote",

--- a/db/model/Gdoc/enrichedToMarkdown.ts
+++ b/db/model/Gdoc/enrichedToMarkdown.ts
@@ -94,6 +94,7 @@ export function spanToMarkdown(
                 spanType: P.union(
                     "span-ref",
                     "span-underline",
+                    "span-strikethrough",
                     "span-subscript",
                     "span-superscript",
                     "span-quote",

--- a/db/model/Gdoc/enrichedToRaw.ts
+++ b/db/model/Gdoc/enrichedToRaw.ts
@@ -122,6 +122,7 @@ export function enrichedBlockToRawBlock(
             (b): RawBlockCallout => ({
                 type: b.type,
                 value: {
+                    icon: b.icon,
                     title: b.title,
                     text: b.text.map(
                         (enriched) =>
@@ -246,6 +247,7 @@ export function enrichedBlockToRawBlock(
                     filename: b.filename,
                     caption: b.caption ? spansToHtmlText(b.caption) : undefined,
                     shouldLoop: String(b.shouldLoop),
+                    shouldAutoplay: String(b.shouldAutoplay),
                     visibility: b.visibility ? b.visibility : undefined,
                 },
             })

--- a/db/model/Gdoc/enrichedToRaw.ts
+++ b/db/model/Gdoc/enrichedToRaw.ts
@@ -68,12 +68,17 @@ import {
     RawBlockChartRows,
     RawBlockPullChart,
 } from "@ourworldindata/types"
-import { spanToHtmlString } from "./gdocUtils.js"
+import { spanToArchieMLSourceString } from "./gdocUtils.js"
 import { match, P } from "ts-pattern"
 import * as R from "remeda"
 
+// enrichedBlockToRawBlock is part of the write-back path (enriched →
+// ArchieML text), so spans must be serialized in their *source* form —
+// notably emitting `{ref}id_or_content{/ref}` for span-ref rather than
+// the post-extractRefs HTML form. See spanToArchieMLSourceString for the
+// only point where this and the HTML serializer diverge.
 function spansToHtmlText(spans: Span[]): string {
-    return spans.map(spanToHtmlString).join("")
+    return spans.map(spanToArchieMLSourceString).join("")
 }
 export function enrichedBlockToRawBlock(
     block: OwidEnrichedGdocBlock

--- a/db/model/Gdoc/enrichedToRaw.ts
+++ b/db/model/Gdoc/enrichedToRaw.ts
@@ -107,6 +107,7 @@ export function enrichedBlockToRawBlock(
         .with({ type: "callout" }, (b): RawBlockCallout => ({
             type: b.type,
             value: {
+                icon: b.icon,
                 title: b.title,
                 text: b.text.map(
                     (enriched) =>
@@ -199,6 +200,7 @@ export function enrichedBlockToRawBlock(
                 filename: b.filename,
                 caption: b.caption ? spansToHtmlText(b.caption) : undefined,
                 shouldLoop: String(b.shouldLoop),
+                shouldAutoplay: String(b.shouldAutoplay),
                 visibility: b.visibility ? b.visibility : undefined,
             },
         }))

--- a/db/model/Gdoc/enrichedToRaw.ts
+++ b/db/model/Gdoc/enrichedToRaw.ts
@@ -67,12 +67,17 @@ import {
     RawBlockChartRows,
     RawBlockPullChart,
 } from "@ourworldindata/types"
-import { spanToHtmlString } from "./gdocUtils.js"
+import { spanToArchieMLSourceString } from "./gdocUtils.js"
 import { match, P } from "ts-pattern"
 import * as R from "remeda"
 
+// enrichedBlockToRawBlock is part of the write-back path (enriched →
+// ArchieML text), so spans must be serialized in their *source* form —
+// notably emitting `{ref}id_or_content{/ref}` for span-ref rather than
+// the post-extractRefs HTML form. See spanToArchieMLSourceString for the
+// only point where this and the HTML serializer diverge.
 function spansToHtmlText(spans: Span[]): string {
-    return spans.map(spanToHtmlString).join("")
+    return spans.map(spanToArchieMLSourceString).join("")
 }
 export function enrichedBlockToRawBlock(
     block: OwidEnrichedGdocBlock

--- a/db/model/Gdoc/exampleEnrichedBlocks.ts
+++ b/db/model/Gdoc/exampleEnrichedBlocks.ts
@@ -43,6 +43,71 @@ const enrichedBlockText: EnrichedBlockText = {
     parseErrors: [],
 }
 
+// A text block exercising the full set of inline span types that round-trip
+// through the ArchieML serializers (see the round-trip test in gdocTests).
+// Kept separate from boldLinkExampleText, which many other examples embed.
+const richSpansExampleText: Span[] = [
+    ...boldLinkExampleText,
+    {
+        spanType: "span-simple-text",
+        text: ", ",
+    },
+    {
+        spanType: "span-italic",
+        children: [{ spanType: "span-simple-text", text: "italic" }],
+    },
+    {
+        spanType: "span-simple-text",
+        text: ", ",
+    },
+    {
+        spanType: "span-underline",
+        children: [{ spanType: "span-simple-text", text: "underlined" }],
+    },
+    {
+        spanType: "span-simple-text",
+        text: " and ",
+    },
+    {
+        spanType: "span-strikethrough",
+        children: [{ spanType: "span-simple-text", text: "struck-through" }],
+    },
+    {
+        spanType: "span-simple-text",
+        text: " text, H",
+    },
+    {
+        spanType: "span-subscript",
+        children: [{ spanType: "span-simple-text", text: "2" }],
+    },
+    {
+        spanType: "span-simple-text",
+        text: "O, E=mc",
+    },
+    {
+        spanType: "span-superscript",
+        children: [{ spanType: "span-simple-text", text: "2" }],
+    },
+    {
+        spanType: "span-simple-text",
+        text: " and ",
+    },
+    {
+        spanType: "span-quote",
+        children: [{ spanType: "span-simple-text", text: "a quote" }],
+    },
+    {
+        spanType: "span-simple-text",
+        text: ".",
+    },
+]
+
+const enrichedBlockRichText: EnrichedBlockText = {
+    type: "text",
+    value: richSpansExampleText,
+    parseErrors: [],
+}
+
 const enrichedChart: EnrichedBlockChart = {
     type: "chart",
     url: "https://ourworldindata.org/grapher/total-cases-covid-19",
@@ -91,7 +156,7 @@ export const enrichedBlockExamples: Record<
     OwidEnrichedGdocBlock["type"],
     OwidEnrichedGdocBlock
 > = {
-    text: enrichedBlockText,
+    text: enrichedBlockRichText,
     "simple-text": {
         type: "simple-text",
         value: {

--- a/db/model/Gdoc/exampleEnrichedBlocks.ts
+++ b/db/model/Gdoc/exampleEnrichedBlocks.ts
@@ -284,6 +284,7 @@ export const enrichedBlockExamples: Record<
     },
     callout: {
         type: "callout",
+        icon: "info",
         parseErrors: [],
         text: [
             {
@@ -352,7 +353,7 @@ export const enrichedBlockExamples: Record<
         filename: "https://ourworldindata.org/assets/images/example-poster.jpg",
         caption: boldLinkExampleText,
         shouldLoop: true,
-        shouldAutoplay: false,
+        shouldAutoplay: true,
         visibility: "mobile",
         parseErrors: [],
     },
@@ -591,6 +592,12 @@ export const enrichedBlockExamples: Record<
             type: "topic-page-intro-download-button",
         },
         relatedTopics: [
+            {
+                // a gdoc-linked topic carries no text — it must not swallow
+                // the following topic's fields when serialized to ArchieML
+                url: "https://docs.google.com/document/d/abcd1234",
+                type: "topic-page-intro-related-topic",
+            },
             {
                 text: "Poverty",
                 url: "https://ourworldindata.org/poverty",
@@ -954,6 +961,14 @@ export const enrichedBlockExamples: Record<
         type: "homepage-intro",
         featuredWork: [
             {
+                // a title-less gdoc-linked tile, deliberately first: it must
+                // survive the ArchieML round trip as its own item instead of
+                // absorbing the next tile's title
+                url: "https://docs.google.com/document/d/abcd1234",
+                kicker: "Announcement",
+                isNew: false,
+            },
+            {
                 url: "https://ourworldindata.org/optimism-and-pessimism",
                 title: "Optimism & Pessimism",
                 description:
@@ -980,13 +995,6 @@ export const enrichedBlockExamples: Record<
                 kicker: "Article - 10 Mins",
                 filename: "featured-image.jpg",
                 authors: ["Max Roser"],
-                isNew: false,
-            },
-            {
-                url: "https://ourworldindata.org/front-end-engineer",
-                title: "We’re looking for a front-end engineer to join our team.",
-                kicker: "Announcement",
-                authors: ["Our World In Data"],
                 isNew: false,
             },
         ],

--- a/db/model/Gdoc/exampleEnrichedBlocks.ts
+++ b/db/model/Gdoc/exampleEnrichedBlocks.ts
@@ -293,6 +293,7 @@ export const enrichedBlockExamples: Record<
     },
     callout: {
         type: "callout",
+        icon: "info",
         parseErrors: [],
         text: [
             {
@@ -361,7 +362,7 @@ export const enrichedBlockExamples: Record<
         filename: "https://ourworldindata.org/assets/images/example-poster.jpg",
         caption: boldLinkExampleText,
         shouldLoop: true,
-        shouldAutoplay: false,
+        shouldAutoplay: true,
         visibility: "mobile",
         parseErrors: [],
     },
@@ -600,6 +601,12 @@ export const enrichedBlockExamples: Record<
             type: "topic-page-intro-download-button",
         },
         relatedTopics: [
+            {
+                // a gdoc-linked topic carries no text — it must not swallow
+                // the following topic's fields when serialized to ArchieML
+                url: "https://docs.google.com/document/d/abcd1234",
+                type: "topic-page-intro-related-topic",
+            },
             {
                 text: "Poverty",
                 url: "https://ourworldindata.org/poverty",
@@ -984,6 +991,14 @@ export const enrichedBlockExamples: Record<
         type: "homepage-intro",
         featuredWork: [
             {
+                // a title-less gdoc-linked tile, deliberately first: it must
+                // survive the ArchieML round trip as its own item instead of
+                // absorbing the next tile's title
+                url: "https://docs.google.com/document/d/abcd1234",
+                kicker: "Announcement",
+                isNew: false,
+            },
+            {
                 url: "https://ourworldindata.org/optimism-and-pessimism",
                 title: "Optimism & Pessimism",
                 description:
@@ -1010,13 +1025,6 @@ export const enrichedBlockExamples: Record<
                 kicker: "Article - 10 Mins",
                 filename: "featured-image.jpg",
                 authors: ["Max Roser"],
-                isNew: false,
-            },
-            {
-                url: "https://ourworldindata.org/front-end-engineer",
-                title: "We’re looking for a front-end engineer to join our team.",
-                kicker: "Announcement",
-                authors: ["Our World In Data"],
                 isNew: false,
             },
         ],

--- a/db/model/Gdoc/gdocToArchie.ts
+++ b/db/model/Gdoc/gdocToArchie.ts
@@ -38,6 +38,15 @@ function applyTextStyles(
     if (textStyle.bold) {
         styledSpan = { spanType: "span-bold", children: [styledSpan] }
     }
+    if (textStyle.underline) {
+        styledSpan = { spanType: "span-underline", children: [styledSpan] }
+    }
+    if (textStyle.strikethrough) {
+        styledSpan = {
+            spanType: "span-strikethrough",
+            children: [styledSpan],
+        }
+    }
     if (textStyle.baselineOffset === "SUPERSCRIPT") {
         styledSpan = { spanType: "span-superscript", children: [styledSpan] }
     }
@@ -307,6 +316,12 @@ function parseParagraph(
         }
         if (textRun.textStyle.bold) {
             span = { spanType: "span-bold", children: [span] }
+        }
+        if (textRun.textStyle.underline) {
+            span = { spanType: "span-underline", children: [span] }
+        }
+        if (textRun.textStyle.strikethrough) {
+            span = { spanType: "span-strikethrough", children: [span] }
         }
         if (textRun.textStyle.baselineOffset === "SUPERSCRIPT") {
             span = { spanType: "span-superscript", children: [span] }

--- a/db/model/Gdoc/gdocUtils.ts
+++ b/db/model/Gdoc/gdocUtils.ts
@@ -10,6 +10,7 @@ import {
 } from "@ourworldindata/utils"
 import {
     SpanCallout,
+    SpanRef,
     CalloutFunction,
     CALLOUT_FUNCTIONS,
 } from "@ourworldindata/types"
@@ -43,69 +44,66 @@ export function spanToSimpleString(s: Span): string {
         .exhaustive()
 }
 
-export function spanToHtmlString(s: Span): string {
+// Every span case except span-ref is identical between the HTML serializer
+// (for site rendering, Algolia indexing, etc.) and the ArchieML-source
+// serializer (for write-back into a gdoc). The only divergence is how
+// span-ref renders: HTML form (<a class="ref">...</a>) vs source form
+// ({ref}id_or_content{/ref}). Each wrapper passes its own children
+// recursion so the two trees never mix modes mid-traversal.
+function nonRefSpanToString(
+    s: Exclude<Span, SpanRef>,
+    recurse: (children: Span[]) => string
+): string {
     return match(s)
         .with({ spanType: "span-simple-text" }, (span) => span.text)
         .with(
             { spanType: "span-link" },
-            (span) =>
-                `<a href="${span.url}">${spansToHtmlString(span.children)}</a>`
-        )
-        .with(
-            { spanType: "span-ref" },
-            (span) =>
-                `<a href="${span.url}" class="ref">${spansToHtmlString(
-                    span.children
-                )}</a>`
+            (span) => `<a href="${span.url}">${recurse(span.children)}</a>`
         )
         .with(
             { spanType: "span-dod" },
             (span) =>
                 `<span><a href="#dod-${span.id}" data-dod-id="${
                     span.id
-                }"  class="dod-span">${spansToHtmlString(
-                    span.children
-                )}</a></span>`
+                }"  class="dod-span">${recurse(span.children)}</a></span>`
         )
         .with(
             { spanType: "span-guided-chart-link" },
             (span) =>
-                `<a href="#guide:${span.url}" class="guided-chart-link">${spansToHtmlString(
-                    span.children
-                )}</a>`
+                `<a href="#guide:${span.url}" class="guided-chart-link">${recurse(span.children)}</a>`
         )
         .with({ spanType: "span-newline" }, () => "<br/>")
         .with(
             { spanType: "span-italic" },
-            (span) => `<i>${spansToHtmlString(span.children)}</i>`
+            (span) => `<i>${recurse(span.children)}</i>`
         )
         .with(
             { spanType: "span-bold" },
-            (span) => `<b>${spansToHtmlString(span.children)}</b>`
+            (span) => `<b>${recurse(span.children)}</b>`
         )
         .with(
             { spanType: "span-underline" },
-            (span) => `<u>${spansToHtmlString(span.children)}</u>`
+            (span) => `<u>${recurse(span.children)}</u>`
         )
         .with(
             { spanType: "span-strikethrough" },
-            (span) => `<s>${spansToHtmlString(span.children)}</s>`
+            (span) => `<s>${recurse(span.children)}</s>`
         )
         .with(
             { spanType: "span-subscript" },
-            (span) => `<sub>${spansToHtmlString(span.children)}</sub>`
+            (span) => `<sub>${recurse(span.children)}</sub>`
         )
         .with(
             { spanType: "span-superscript" },
-            (span) => `<sup>${spansToHtmlString(span.children)}</sup>`
+            (span) => `<sup>${recurse(span.children)}</sup>`
         )
         .with(
             { spanType: "span-quote" },
-            (span) => `<q>${spansToHtmlString(span.children)}</q>`
+            (span) => `<q>${recurse(span.children)}</q>`
         )
         .with(
             { spanType: "span-fallback" },
-            (span) => `<span>${spansToHtmlString(span.children)}</span>`
+            (span) => `<span>${recurse(span.children)}</span>`
         )
         .with(
             { spanType: "span-callout" },
@@ -114,12 +112,35 @@ export function spanToHtmlString(s: Span): string {
         .exhaustive()
 }
 
+// HTML serializer: emits post-extractRefs HTML for span-ref, suitable for
+// site rendering and any other consumer that wants the rendered form.
+export function spanToHtmlString(s: Span): string {
+    if (s.spanType === "span-ref")
+        return `<a href="${s.url}" class="ref">${spansToHtmlString(s.children)}</a>`
+    return nonRefSpanToString(s, spansToHtmlString)
+}
+
 export function spansToHtmlString(spans: Span[]): string {
     if (spans.length === 0) return ""
-    else {
-        const result = spans.map(spanToHtmlString).join("")
-        return result
+    return spans.map(spanToHtmlString).join("")
+}
+
+// ArchieML-source serializer: emits the source `{ref}id_or_content{/ref}`
+// for span-ref. Used by the write-back path so a Claude-mediated edit
+// produces gdoc text that an author would recognise — and that the next
+// parse round-trips back to the same SpanRef structure.
+export function spanToArchieMLSourceString(s: Span): string {
+    if (s.spanType === "span-ref") {
+        return s.sourceForm.kind === "id"
+            ? `{ref}${s.sourceForm.id}{/ref}`
+            : `{ref}${spansToArchieMLSourceString(s.sourceForm.content)}{/ref}`
     }
+    return nonRefSpanToString(s, spansToArchieMLSourceString)
+}
+
+export function spansToArchieMLSourceString(spans: Span[]): string {
+    if (spans.length === 0) return ""
+    return spans.map(spanToArchieMLSourceString).join("")
 }
 
 export function spansToSimpleString(spans: Span[]): string {

--- a/db/model/Gdoc/gdocUtils.ts
+++ b/db/model/Gdoc/gdocUtils.ts
@@ -30,6 +30,7 @@ export function spanToSimpleString(s: Span): string {
                     "span-italic",
                     "span-bold",
                     "span-underline",
+                    "span-strikethrough",
                     "span-subscript",
                     "span-superscript",
                     "span-quote",
@@ -85,6 +86,10 @@ export function spanToHtmlString(s: Span): string {
         .with(
             { spanType: "span-underline" },
             (span) => `<u>${spansToHtmlString(span.children)}</u>`
+        )
+        .with(
+            { spanType: "span-strikethrough" },
+            (span) => `<s>${spansToHtmlString(span.children)}</s>`
         )
         .with(
             { spanType: "span-subscript" },

--- a/db/model/Gdoc/gdocUtils.ts
+++ b/db/model/Gdoc/gdocUtils.ts
@@ -10,6 +10,7 @@ import {
 } from "@ourworldindata/utils"
 import {
     SpanCallout,
+    SpanDod,
     SpanRef,
     CalloutFunction,
     CALLOUT_FUNCTIONS,
@@ -44,14 +45,16 @@ export function spanToSimpleString(s: Span): string {
         .exhaustive()
 }
 
-// Every span case except span-ref is identical between the HTML serializer
-// (for site rendering, Algolia indexing, etc.) and the ArchieML-source
-// serializer (for write-back into a gdoc). The only divergence is how
-// span-ref renders: HTML form (<a class="ref">...</a>) vs source form
-// ({ref}id_or_content{/ref}). Each wrapper passes its own children
-// recursion so the two trees never mix modes mid-traversal.
-function nonRefSpanToString(
-    s: Exclude<Span, SpanRef>,
+// Every span case except span-ref and span-dod is identical between the HTML
+// serializer (for site rendering, Algolia indexing, etc.) and the
+// ArchieML-source serializer (for write-back into a gdoc). The divergent two
+// render differently per mode: span-ref as <a class="ref">...</a> vs
+// {ref}id_or_content{/ref}, span-dod as the site markup vs the authoring form
+// <a href="#dod:id">...</a> (which is what the parser recognises). Each
+// wrapper passes its own children recursion so the two trees never mix modes
+// mid-traversal.
+function sharedSpanToString(
+    s: Exclude<Span, SpanRef | SpanDod>,
     recurse: (children: Span[]) => string
 ): string {
     return match(s)
@@ -59,13 +62,6 @@ function nonRefSpanToString(
         .with(
             { spanType: "span-link" },
             (span) => `<a href="${span.url}">${recurse(span.children)}</a>`
-        )
-        .with(
-            { spanType: "span-dod" },
-            (span) =>
-                `<span><a href="#dod-${span.id}" data-dod-id="${
-                    span.id
-                }"  class="dod-span">${recurse(span.children)}</a></span>`
         )
         .with(
             { spanType: "span-guided-chart-link" },
@@ -112,12 +108,17 @@ function nonRefSpanToString(
         .exhaustive()
 }
 
-// HTML serializer: emits post-extractRefs HTML for span-ref, suitable for
-// site rendering and any other consumer that wants the rendered form.
+// HTML serializer: emits post-extractRefs HTML for span-ref and the site
+// markup for span-dod, suitable for site rendering and any other consumer
+// that wants the rendered form.
 export function spanToHtmlString(s: Span): string {
     if (s.spanType === "span-ref")
         return `<a href="${s.url}" class="ref">${spansToHtmlString(s.children)}</a>`
-    return nonRefSpanToString(s, spansToHtmlString)
+    if (s.spanType === "span-dod")
+        return `<span><a href="#dod-${s.id}" data-dod-id="${
+            s.id
+        }"  class="dod-span">${spansToHtmlString(s.children)}</a></span>`
+    return sharedSpanToString(s, spansToHtmlString)
 }
 
 export function spansToHtmlString(spans: Span[]): string {
@@ -125,17 +126,31 @@ export function spansToHtmlString(spans: Span[]): string {
     return spans.map(spanToHtmlString).join("")
 }
 
+// Inline ref content is re-parsed by extractRefs through its own ArchieML
+// template, where every paragraph sits at the start of a line. A paragraph
+// beginning like a key ("See: something") would be swallowed as a key/value
+// pair there, so escape the colon the same way authors do in gdocs (and the
+// parse un-escapes): `See\: something`.
+function escapeArchieKeyPrefixes(text: string): string {
+    return text.replace(/^(\s*\w+)\s*:/gm, "$1\\:")
+}
+
 // ArchieML-source serializer: emits the source `{ref}id_or_content{/ref}`
-// for span-ref. Used by the write-back path so a Claude-mediated edit
-// produces gdoc text that an author would recognise — and that the next
-// parse round-trips back to the same SpanRef structure.
+// for span-ref and the authoring form `<a href="#dod:id">` for span-dod (the
+// form htmlToSpans recognises). Used by the write-back path so a
+// Claude-mediated edit produces gdoc text that an author would recognise —
+// and that the next parse round-trips back to the same span structure.
 export function spanToArchieMLSourceString(s: Span): string {
     if (s.spanType === "span-ref") {
         return s.sourceForm.kind === "id"
             ? `{ref}${s.sourceForm.id}{/ref}`
-            : `{ref}${spansToArchieMLSourceString(s.sourceForm.content)}{/ref}`
+            : `{ref}${escapeArchieKeyPrefixes(
+                  spansToArchieMLSourceString(s.sourceForm.content)
+              )}{/ref}`
     }
-    return nonRefSpanToString(s, spansToArchieMLSourceString)
+    if (s.spanType === "span-dod")
+        return `<a href="#dod:${s.id}">${spansToArchieMLSourceString(s.children)}</a>`
+    return sharedSpanToString(s, spansToArchieMLSourceString)
 }
 
 export function spansToArchieMLSourceString(spans: Span[]): string {

--- a/db/model/Gdoc/htmlToEnriched.ts
+++ b/db/model/Gdoc/htmlToEnriched.ts
@@ -154,7 +154,24 @@ function cheerioToSpan(element: AnyNode): Span | undefined {
                     const children =
                         _.compact(element.children?.map(cheerioToSpan)) ?? []
                     if (className === "ref") {
-                        return { spanType: "span-ref", children, url }
+                        // extractRefs annotates the post-extraction HTML with
+                        // data-ref-kind (and data-ref-id for ID-based refs) so
+                        // we can preserve the source form here. Inline content
+                        // is filled in by a post-pass once the RefDictionary
+                        // is built — see fillInlineRefSourceContent in
+                        // archieToEnriched.
+                        const kind = element.attribs["data-ref-kind"]
+                        const refId = element.attribs["data-ref-id"]
+                        const sourceForm: SpanRef["sourceForm"] =
+                            kind === "id" && refId
+                                ? { kind: "id", id: refId }
+                                : { kind: "inline", content: [] }
+                        return {
+                            spanType: "span-ref",
+                            children,
+                            url,
+                            sourceForm,
+                        }
                     }
                     const dod = url?.match(detailOnDemandRegex)
                     if (dod) {

--- a/db/model/Gdoc/htmlToEnriched.ts
+++ b/db/model/Gdoc/htmlToEnriched.ts
@@ -11,6 +11,7 @@ import {
     SpanSuperscript,
     SpanSubscript,
     SpanUnderline,
+    SpanStrikethrough,
     SpanRef,
     SpanDod,
     EnrichedBlockSimpleText,
@@ -220,6 +221,11 @@ function cheerioToSpan(element: AnyNode): Span | undefined {
                 const children =
                     _.compact(element.children?.map(cheerioToSpan)) ?? []
                 return { spanType: "span-underline", children }
+            })
+            .with("s", (): SpanStrikethrough => {
+                const children =
+                    _.compact(element.children?.map(cheerioToSpan)) ?? []
+                return { spanType: "span-strikethrough", children }
             })
             .with("wbr", () => spanFallback(element))
             .otherwise(() => {

--- a/db/model/Gdoc/htmlToEnriched.ts
+++ b/db/model/Gdoc/htmlToEnriched.ts
@@ -11,6 +11,7 @@ import {
     SpanSuperscript,
     SpanSubscript,
     SpanUnderline,
+    SpanStrikethrough,
     SpanRef,
     SpanDod,
     EnrichedBlockSimpleText,
@@ -212,6 +213,11 @@ function cheerioToSpan(element: AnyNode): Span | undefined {
                 const children =
                     _.compact(element.children?.map(cheerioToSpan)) ?? []
                 return { spanType: "span-underline", children }
+            })
+            .with("s", (): SpanStrikethrough => {
+                const children =
+                    _.compact(element.children?.map(cheerioToSpan)) ?? []
+                return { spanType: "span-strikethrough", children }
             })
             .with("wbr", () => spanFallback(element))
             .otherwise(() => {

--- a/db/model/Gdoc/rawToArchie.ts
+++ b/db/model/Gdoc/rawToArchie.ts
@@ -181,6 +181,7 @@ function* rawBlockCalloutToArchieMLString(
 ): Generator<string, void, undefined> {
     yield "{.callout}"
     if (typeof block.value !== "string") {
+        yield* propertyToArchieMLString("icon", block.value)
         yield* propertyToArchieMLString("title", block.value)
         yield "[.+text]"
         for (const rawBlock of block.value.text) {
@@ -214,6 +215,7 @@ function* rawBlockVideoToArchieMLString(
     yield* propertyToArchieMLString("url", block.value)
     yield* propertyToArchieMLString("filename", block.value)
     yield* propertyToArchieMLString("shouldLoop", block.value)
+    yield* propertyToArchieMLString("shouldAutoplay", block.value)
     yield* propertyToArchieMLString("caption", block.value)
     yield* propertyToArchieMLString("visibility", block.value)
     yield "{}"
@@ -691,8 +693,11 @@ function* rawBlockTopicPageIntroToArchieMLString(
     if (relatedTopics?.length) {
         yield "[.related-topics]"
         for (const relatedTopic of relatedTopics) {
-            yield* propertyToArchieMLString("text", relatedTopic)
+            // url first: it is the always-present key, and ArchieML delimits
+            // array items by key repetition — starting with an optional key
+            // (text) would merge a text-less topic into its predecessor.
             yield* propertyToArchieMLString("url", relatedTopic)
+            yield* propertyToArchieMLString("text", relatedTopic)
         }
         yield "[]"
     }
@@ -985,9 +990,12 @@ function* rawBlockHomepageIntroToArchieMLString(
     if (Array.isArray(featuredWork) && featuredWork.length) {
         yield "[.featured-work]"
         for (const post of featuredWork) {
+            // url first: it is the always-present key, and ArchieML delimits
+            // array items by key repetition — starting with an optional key
+            // (title) would merge a title-less post into its predecessor.
+            yield* propertyToArchieMLString("url", post)
             yield* propertyToArchieMLString("title", post)
             yield* propertyToArchieMLString("description", post)
-            yield* propertyToArchieMLString("url", post)
             yield* propertyToArchieMLString("filename", post)
             yield* propertyToArchieMLString("kicker", post)
             yield* propertyToArchieMLString("authors", post)

--- a/db/model/Gdoc/rawToArchie.ts
+++ b/db/model/Gdoc/rawToArchie.ts
@@ -180,6 +180,7 @@ function* rawBlockCalloutToArchieMLString(
 ): Generator<string, void, undefined> {
     yield "{.callout}"
     if (typeof block.value !== "string") {
+        yield* propertyToArchieMLString("icon", block.value)
         yield* propertyToArchieMLString("title", block.value)
         yield "[.+text]"
         for (const rawBlock of block.value.text) {
@@ -213,6 +214,7 @@ function* rawBlockVideoToArchieMLString(
     yield* propertyToArchieMLString("url", block.value)
     yield* propertyToArchieMLString("filename", block.value)
     yield* propertyToArchieMLString("shouldLoop", block.value)
+    yield* propertyToArchieMLString("shouldAutoplay", block.value)
     yield* propertyToArchieMLString("caption", block.value)
     yield* propertyToArchieMLString("visibility", block.value)
     yield "{}"
@@ -691,8 +693,11 @@ function* rawBlockTopicPageIntroToArchieMLString(
     if (relatedTopics?.length) {
         yield "[.related-topics]"
         for (const relatedTopic of relatedTopics) {
-            yield* propertyToArchieMLString("text", relatedTopic)
+            // url first: it is the always-present key, and ArchieML delimits
+            // array items by key repetition — starting with an optional key
+            // (text) would merge a text-less topic into its predecessor.
             yield* propertyToArchieMLString("url", relatedTopic)
+            yield* propertyToArchieMLString("text", relatedTopic)
         }
         yield "[]"
     }
@@ -977,9 +982,12 @@ function* rawBlockHomepageIntroToArchieMLString(
     if (Array.isArray(featuredWork) && featuredWork.length) {
         yield "[.featured-work]"
         for (const post of featuredWork) {
+            // url first: it is the always-present key, and ArchieML delimits
+            // array items by key repetition — starting with an optional key
+            // (title) would merge a title-less post into its predecessor.
+            yield* propertyToArchieMLString("url", post)
             yield* propertyToArchieMLString("title", post)
             yield* propertyToArchieMLString("description", post)
-            yield* propertyToArchieMLString("url", post)
             yield* propertyToArchieMLString("filename", post)
             yield* propertyToArchieMLString("kicker", post)
             yield* propertyToArchieMLString("authors", post)

--- a/devTools/gdocs/test-roundtrip.ts
+++ b/devTools/gdocs/test-roundtrip.ts
@@ -55,6 +55,8 @@ const formattedLine: Span[] = [
     span(" "),
     wrap("span-underline", [span("Underline.")]),
     span(" "),
+    wrap("span-strikethrough", [span("Strikethrough.")]),
+    span(" "),
     wrap("span-superscript", [span("sup")]),
     span("/"),
     wrap("span-subscript", [span("sub")]),
@@ -66,6 +68,23 @@ const formattedLine: Span[] = [
     ]),
     span("."),
 ]
+
+// Probe-only: not asserted, just logged. Drives the future refs-handling
+// commit by measuring whether `href="#note-N"` fragment URLs survive gdoc
+// storage and how the round-trip degrades the ref structure today.
+const refsProbeLine: Span[] = [
+    span("Probe: a sentence with a footnote"),
+    wrap("span-ref", [wrap("span-superscript", [span("1")])], {
+        url: "#note-1",
+    }),
+    span(" referenced inline."),
+]
+
+const refsProbeBlock: EnrichedBlockText = {
+    type: "text",
+    value: refsProbeLine,
+    parseErrors: [],
+}
 
 const textBlock: EnrichedBlockText = {
     type: "text",
@@ -91,7 +110,7 @@ const content: OwidGdocPostContent = {
     type: OwidGdocType.Article,
     authors: ["OWID Test Bot"],
     excerpt: "Exercising the archieToGdoc → gdocToArchie loop.",
-    body: [textBlock, headingBlock, trailingBlock],
+    body: [textBlock, headingBlock, trailingBlock, refsProbeBlock],
 } as OwidGdocPostContent
 
 // --- Driver ---
@@ -120,9 +139,7 @@ async function main(): Promise<void> {
 
     // --- Insert fresh content ---
     const requests = articleToBatchUpdates(content)
-    process.stdout.write(
-        `Submitting ${requests.length} batchUpdate requests… `
-    )
+    process.stdout.write(`Submitting ${requests.length} batchUpdate requests… `)
     await client.documents.batchUpdate({
         documentId: TARGET_DOC_ID,
         requestBody: { requests },
@@ -135,19 +152,34 @@ async function main(): Promise<void> {
         documentId: TARGET_DOC_ID,
         suggestionsViewMode: "PREVIEW_WITHOUT_SUGGESTIONS",
     })
-    const { text: archieMlOutput } = await gdocToArchie(after.data)
+    const { text: rawArchieMlOutput } = await gdocToArchie(after.data)
+    // archieToGdoc's insert pattern produces one leading blank line in the
+    // gdoc; strip it so the line-by-line comparison reflects content-level
+    // equality, not the off-by-one. Cosmetic issue separate from formatting.
+    const archieMlOutput = rawArchieMlOutput.replace(/^\n/, "")
     console.log("done.")
 
     // --- Compare ---
+    // Refs-probe lines aren't expected to round-trip cleanly yet (refs are a
+    // future commit). Detect them on the input side via `class="ref"` and
+    // report them separately so the assertion only reflects the formatting
+    // fixes we're shipping in this commit.
     const inputLines = archieMlInput.split("\n")
     const outputLines = archieMlOutput.split("\n")
     const max = Math.max(inputLines.length, outputLines.length)
+    const isProbeLine = (line: string) => line.includes(`class="ref"`)
 
     let mismatches = 0
     const diffRows: string[] = []
+    const probeRows: string[] = []
     for (let i = 0; i < max; i++) {
         const a = inputLines[i] ?? ""
         const b = outputLines[i] ?? ""
+        if (isProbeLine(a)) {
+            probeRows.push(`-IN  ${i + 1}: ${a}`)
+            probeRows.push(`+OUT ${i + 1}: ${b}`)
+            continue
+        }
         if (a === b) {
             diffRows.push(`     ${i + 1}: ${a}`)
         } else {
@@ -161,8 +193,14 @@ async function main(): Promise<void> {
     console.log(archieMlInput)
     console.log("\n--- archieMlOutput ---")
     console.log(archieMlOutput)
-    console.log("\n--- line-by-line diff ---")
+    console.log("\n--- line-by-line diff (excludes refs probe) ---")
     console.log(diffRows.join("\n"))
+    if (probeRows.length > 0) {
+        console.log(
+            "\n--- refs probe (informational; refs handling is a future commit) ---"
+        )
+        console.log(probeRows.join("\n"))
+    }
     console.log(
         `\n${mismatches === 0 ? "✓ identical" : `✗ ${mismatches} differing line(s)`}`
     )

--- a/devTools/gdocs/test-roundtrip.ts
+++ b/devTools/gdocs/test-roundtrip.ts
@@ -69,20 +69,32 @@ const formattedLine: Span[] = [
     span("."),
 ]
 
-// Probe-only: not asserted, just logged. Drives the future refs-handling
-// commit by measuring whether `href="#note-N"` fragment URLs survive gdoc
-// storage and how the round-trip degrades the ref structure today.
-const refsProbeLine: Span[] = [
-    span("Probe: a sentence with a footnote"),
-    wrap("span-ref", [wrap("span-superscript", [span("1")])], {
-        url: "#note-1",
-    }),
-    span(" referenced inline."),
-]
-
-const refsProbeBlock: EnrichedBlockText = {
+// Enriched-form refs: exercises the new SpanRef.sourceForm serializer.
+// Each SpanRef should emit `{ref}id_or_content{/ref}` on the body side,
+// and the ID-based one should also produce a `[.refs]` entry in the
+// frontmatter (looked up via content.refs.definitions).
+const enrichedRefsBlock: EnrichedBlockText = {
     type: "text",
-    value: refsProbeLine,
+    value: [
+        span("Enriched: an ID-based ref "),
+        {
+            spanType: "span-ref",
+            url: "#note-1",
+            sourceForm: { kind: "id", id: "example_ref_id" },
+            children: [wrap("span-superscript", [span("1")])],
+        },
+        span(" and an inline ref "),
+        {
+            spanType: "span-ref",
+            url: "#note-2",
+            sourceForm: {
+                kind: "inline",
+                content: [span("The inline footnote text.")],
+            },
+            children: [wrap("span-superscript", [span("2")])],
+        },
+        span(" should both round-trip."),
+    ],
     parseErrors: [],
 }
 
@@ -110,7 +122,26 @@ const content: OwidGdocPostContent = {
     type: OwidGdocType.Article,
     authors: ["OWID Test Bot"],
     excerpt: "Exercising the archieToGdoc → gdocToArchie loop.",
-    body: [textBlock, headingBlock, trailingBlock, refsProbeBlock],
+    body: [textBlock, headingBlock, trailingBlock, enrichedRefsBlock],
+    refs: {
+        definitions: {
+            example_ref_id: {
+                id: "example_ref_id",
+                index: 0,
+                content: [
+                    {
+                        type: "text",
+                        value: [
+                            span("The ID-based footnote's stored content."),
+                        ],
+                        parseErrors: [],
+                    },
+                ],
+                parseErrors: [],
+            },
+        },
+        errors: [],
+    },
 } as OwidGdocPostContent
 
 // --- Driver ---
@@ -160,26 +191,15 @@ async function main(): Promise<void> {
     console.log("done.")
 
     // --- Compare ---
-    // Refs-probe lines aren't expected to round-trip cleanly yet (refs are a
-    // future commit). Detect them on the input side via `class="ref"` and
-    // report them separately so the assertion only reflects the formatting
-    // fixes we're shipping in this commit.
     const inputLines = archieMlInput.split("\n")
     const outputLines = archieMlOutput.split("\n")
     const max = Math.max(inputLines.length, outputLines.length)
-    const isProbeLine = (line: string) => line.includes(`class="ref"`)
 
     let mismatches = 0
     const diffRows: string[] = []
-    const probeRows: string[] = []
     for (let i = 0; i < max; i++) {
         const a = inputLines[i] ?? ""
         const b = outputLines[i] ?? ""
-        if (isProbeLine(a)) {
-            probeRows.push(`-IN  ${i + 1}: ${a}`)
-            probeRows.push(`+OUT ${i + 1}: ${b}`)
-            continue
-        }
         if (a === b) {
             diffRows.push(`     ${i + 1}: ${a}`)
         } else {
@@ -193,14 +213,8 @@ async function main(): Promise<void> {
     console.log(archieMlInput)
     console.log("\n--- archieMlOutput ---")
     console.log(archieMlOutput)
-    console.log("\n--- line-by-line diff (excludes refs probe) ---")
+    console.log("\n--- line-by-line diff ---")
     console.log(diffRows.join("\n"))
-    if (probeRows.length > 0) {
-        console.log(
-            "\n--- refs probe (informational; refs handling is a future commit) ---"
-        )
-        console.log(probeRows.join("\n"))
-    }
     console.log(
         `\n${mismatches === 0 ? "✓ identical" : `✗ ${mismatches} differing line(s)`}`
     )

--- a/devTools/gdocs/test-roundtrip.ts
+++ b/devTools/gdocs/test-roundtrip.ts
@@ -1,0 +1,178 @@
+/**
+ * Round-trip test through the gdoc layer:
+ *
+ *   enriched content
+ *     ── owidArticleToArchieMLStringGenerator ──▶ archieMlInput  (reference)
+ *     ── articleToBatchUpdates ──▶ gdoc batchUpdate
+ *                                  ── documents.batchUpdate ──▶ live gdoc
+ *                                  ── documents.get ──▶ gdoc JSON
+ *                                  ── gdocToArchie ──▶ archieMlOutput
+ *
+ * Compares archieMlInput vs archieMlOutput for a curated sample exercising
+ * inline character styles (bold, italic, underline, strike, sup/sub, links)
+ * and a couple of structural blocks. Reuses the same target gdoc across
+ * runs by deleting its body before re-inserting.
+ *
+ * Usage:
+ *   yarn tsx --tsconfig tsconfig.tsx.json devTools/gdocs/test-roundtrip.ts
+ *
+ * Required env: GDOCS_PRIVATE_KEY, GDOCS_CLIENT_EMAIL, GDOCS_CLIENT_ID
+ *   (already in .env for normal admin runs)
+ *
+ * The target doc id is hard-coded below — edit if you want to point at a
+ * different test doc. The OWID service account must have edit access to it.
+ */
+
+import { docs as googleDocs } from "@googleapis/docs"
+import { OwidGoogleAuth } from "../../db/OwidGoogleAuth.js"
+import {
+    articleToBatchUpdates,
+    deleteGdocContent,
+    owidArticleToArchieMLStringGenerator,
+} from "../../db/model/Gdoc/archieToGdoc.js"
+import { gdocToArchie } from "../../db/model/Gdoc/gdocToArchie.js"
+import {
+    OwidGdocPostContent,
+    OwidGdocType,
+    EnrichedBlockText,
+    EnrichedBlockHeading,
+    Span,
+} from "@ourworldindata/types"
+
+const TARGET_DOC_ID = "1aa53-xlxKMx7XV-C-ISczrmy2HXtRLfuYhBrA5e95K8"
+
+// --- Test content: a small post exercising inline styles + a heading. ---
+
+const span = (text: string): Span => ({ spanType: "span-simple-text", text })
+const wrap = (type: Span["spanType"], children: Span[], extra: any = {}) =>
+    ({ spanType: type, children, ...extra }) as Span
+
+const formattedLine: Span[] = [
+    span("Plain. "),
+    wrap("span-bold", [span("Bold.")]),
+    span(" "),
+    wrap("span-italic", [span("Italic.")]),
+    span(" "),
+    wrap("span-underline", [span("Underline.")]),
+    span(" "),
+    wrap("span-superscript", [span("sup")]),
+    span("/"),
+    wrap("span-subscript", [span("sub")]),
+    span(" "),
+    wrap("span-bold", [
+        wrap("span-link", [span("bold link")], {
+            url: "https://ourworldindata.org",
+        }),
+    ]),
+    span("."),
+]
+
+const textBlock: EnrichedBlockText = {
+    type: "text",
+    value: formattedLine,
+    parseErrors: [],
+}
+
+const headingBlock: EnrichedBlockHeading = {
+    type: "heading",
+    level: 2,
+    text: [span("A heading at level 2")],
+    parseErrors: [],
+}
+
+const trailingBlock: EnrichedBlockText = {
+    type: "text",
+    value: [span("A trailing paragraph with no formatting.")],
+    parseErrors: [],
+}
+
+const content: OwidGdocPostContent = {
+    title: "Round-trip test",
+    type: OwidGdocType.Article,
+    authors: ["OWID Test Bot"],
+    excerpt: "Exercising the archieToGdoc → gdocToArchie loop.",
+    body: [textBlock, headingBlock, trailingBlock],
+} as OwidGdocPostContent
+
+// --- Driver ---
+
+async function main(): Promise<void> {
+    if (!OwidGoogleAuth.areGdocAuthKeysSet()) {
+        console.error(
+            "Missing GDOCS_PRIVATE_KEY / GDOCS_CLIENT_EMAIL / GDOCS_CLIENT_ID. " +
+                "Run from a shell that has the OWID admin .env loaded."
+        )
+        process.exit(1)
+    }
+
+    const auth = OwidGoogleAuth.getGoogleReadWriteAuth()
+    const client = googleDocs({ version: "v1", auth })
+
+    // --- Reference ArchieML (input side) ---
+    const archieMlInput = [
+        ...owidArticleToArchieMLStringGenerator(content),
+    ].join("\n")
+
+    // --- Wipe existing body ---
+    process.stdout.write("Wiping existing doc body… ")
+    await deleteGdocContent(client, TARGET_DOC_ID)
+    console.log("done.")
+
+    // --- Insert fresh content ---
+    const requests = articleToBatchUpdates(content)
+    process.stdout.write(
+        `Submitting ${requests.length} batchUpdate requests… `
+    )
+    await client.documents.batchUpdate({
+        documentId: TARGET_DOC_ID,
+        requestBody: { requests },
+    })
+    console.log("inserted.")
+
+    // --- Re-fetch and convert back ---
+    process.stdout.write("Re-fetching and running gdocToArchie… ")
+    const after = await client.documents.get({
+        documentId: TARGET_DOC_ID,
+        suggestionsViewMode: "PREVIEW_WITHOUT_SUGGESTIONS",
+    })
+    const { text: archieMlOutput } = await gdocToArchie(after.data)
+    console.log("done.")
+
+    // --- Compare ---
+    const inputLines = archieMlInput.split("\n")
+    const outputLines = archieMlOutput.split("\n")
+    const max = Math.max(inputLines.length, outputLines.length)
+
+    let mismatches = 0
+    const diffRows: string[] = []
+    for (let i = 0; i < max; i++) {
+        const a = inputLines[i] ?? ""
+        const b = outputLines[i] ?? ""
+        if (a === b) {
+            diffRows.push(`     ${i + 1}: ${a}`)
+        } else {
+            mismatches++
+            diffRows.push(`-IN  ${i + 1}: ${a}`)
+            diffRows.push(`+OUT ${i + 1}: ${b}`)
+        }
+    }
+
+    console.log("\n--- archieMlInput ---")
+    console.log(archieMlInput)
+    console.log("\n--- archieMlOutput ---")
+    console.log(archieMlOutput)
+    console.log("\n--- line-by-line diff ---")
+    console.log(diffRows.join("\n"))
+    console.log(
+        `\n${mismatches === 0 ? "✓ identical" : `✗ ${mismatches} differing line(s)`}`
+    )
+    console.log(
+        `Open: https://docs.google.com/document/d/${TARGET_DOC_ID}/edit`
+    )
+    process.exit(mismatches === 0 ? 0 : 1)
+}
+
+void main().catch((err) => {
+    console.error(err)
+    process.exit(1)
+})

--- a/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
@@ -561,6 +561,112 @@ export interface OwidGdocPostContent {
 
 export type OwidGdocStickyNavItem = { target: string; text: string }
 
+/**
+ * What the ArchieML write-back layer (db/model/Gdoc/archieToGdoc.ts) does
+ * with a content key:
+ * - "emitted": serialized back into the ArchieML document
+ * - "derived": computed from other content during enrichment, never authored
+ * - "unsupported": authored content the write-back cannot serialize yet —
+ *   writing a document that uses it would silently lose it, so the gate
+ *   refuses such writes
+ */
+export type GdocContentKeyFate = "emitted" | "derived" | "unsupported"
+
+/** Write-back fate of every OwidGdocPostContent key. The `satisfies` clause
+ *  breaks the build when the interface gains a key whose fate has not been
+ *  declared here. */
+export const OWID_GDOC_POST_CONTENT_KEYS = {
+    body: "emitted",
+    type: "emitted",
+    title: "emitted",
+    supertitle: "emitted",
+    subtitle: "emitted",
+    authors: "emitted",
+    dateline: "emitted",
+    excerpt: "emitted",
+    refs: "emitted",
+    "deprecation-notice": "emitted",
+    "latest-feed-featured-image": "emitted",
+    "latest-feed-excerpt": "emitted",
+    "hide-citation": "emitted",
+    "cover-image": "emitted",
+    "featured-image": "emitted",
+    "atom-title": "emitted",
+    "atom-excerpt": "emitted",
+    "sidebar-toc": "emitted",
+    "heading-variant": "emitted",
+    "hide-subscribe-banner": "emitted",
+    "cover-color": "emitted",
+    "sticky-nav": "emitted",
+    authorRoles: "derived", // from authors
+    toc: "derived", // from body
+    parsedFaqs: "derived", // from faqs
+    details: "unsupported",
+    faqs: "unsupported",
+} as const satisfies Record<keyof OwidGdocPostContent, GdocContentKeyFate>
+
+/** Write-back fate of every OwidGdocDataInsightContent key. */
+export const OWID_GDOC_DATA_INSIGHT_CONTENT_KEYS = {
+    body: "emitted",
+    type: "emitted",
+    title: "emitted",
+    authors: "emitted",
+    "narrative-chart": "emitted",
+    "grapher-url": "emitted",
+    "figma-url": "emitted",
+    authorRoles: "derived", // from authors
+} as const satisfies Record<
+    keyof OwidGdocDataInsightContent,
+    GdocContentKeyFate
+>
+
+/** Gdoc properties that live on the posts_gdocs row (or its attachments)
+ *  rather than in the ArchieML content — managed in the admin, never
+ *  authored in the document. */
+export const OWID_GDOC_BASE_ROW_KEYS = Object.keys({
+    id: true,
+    slug: true,
+    contentMd5: true,
+    published: true,
+    createdAt: true,
+    publishedAt: true,
+    updatedAt: true,
+    revisionId: true,
+    publicationContext: true,
+    manualBreadcrumbs: true,
+    linkedAuthors: true,
+    linkedDocuments: true,
+    linkedCharts: true,
+    linkedNarrativeCharts: true,
+    linkedStaticViz: true,
+    linkedIndicators: true,
+    linkedCallouts: true,
+    imageMetadata: true,
+    relatedCharts: true,
+    tags: true,
+    errors: true,
+    breadcrumbs: true,
+    markdown: true,
+} satisfies Record<Exclude<keyof OwidGdocBaseInterface, "content">, true>)
+
+/** The content-key classification for a gdoc type, or undefined for types
+ *  the ArchieML write-back layer does not handle. */
+export function getContentKeysForGdocType(
+    type: OwidGdocType
+): Record<string, GdocContentKeyFate> | undefined {
+    switch (type) {
+        case OwidGdocType.Article:
+        case OwidGdocType.TopicPage:
+        case OwidGdocType.LinearTopicPage:
+        case OwidGdocType.Fragment:
+            return OWID_GDOC_POST_CONTENT_KEYS
+        case OwidGdocType.DataInsight:
+            return OWID_GDOC_DATA_INSIGHT_CONTENT_KEYS
+        default:
+            return undefined
+    }
+}
+
 export type GdocsPatch = Partial<OwidGdocPostInterface>
 
 export enum GdocsContentSource {

--- a/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
@@ -569,6 +569,113 @@ export interface OwidGdocPostContent {
 
 export type OwidGdocStickyNavItem = { target: string; text: string }
 
+/**
+ * What the ArchieML write-back layer (db/model/Gdoc/archieToGdoc.ts) does
+ * with a content key:
+ * - "emitted": serialized back into the ArchieML document
+ * - "derived": computed from other content during enrichment, never authored
+ * - "unsupported": authored content the write-back cannot serialize yet —
+ *   writing a document that uses it would silently lose it, so the gate
+ *   refuses such writes
+ */
+export type GdocContentKeyFate = "emitted" | "derived" | "unsupported"
+
+/** Write-back fate of every OwidGdocPostContent key. The `satisfies` clause
+ *  breaks the build when the interface gains a key whose fate has not been
+ *  declared here. */
+export const OWID_GDOC_POST_CONTENT_KEYS = {
+    body: "emitted",
+    type: "emitted",
+    title: "emitted",
+    supertitle: "emitted",
+    subtitle: "emitted",
+    authors: "emitted",
+    dateline: "emitted",
+    excerpt: "emitted",
+    refs: "emitted",
+    "deprecation-notice": "emitted",
+    "latest-feed-featured-image": "emitted",
+    "latest-feed-excerpt": "emitted",
+    "hide-citation": "emitted",
+    "cover-image": "emitted",
+    "featured-image": "emitted",
+    "atom-title": "emitted",
+    "atom-excerpt": "emitted",
+    "sidebar-toc": "emitted",
+    "sidebar-toc-h1-only": "emitted",
+    "heading-variant": "emitted",
+    "hide-subscribe-banner": "emitted",
+    "cover-color": "emitted",
+    "sticky-nav": "emitted",
+    authorRoles: "derived", // from authors
+    toc: "derived", // from body
+    parsedFaqs: "derived", // from faqs
+    details: "unsupported",
+    faqs: "unsupported",
+} as const satisfies Record<keyof OwidGdocPostContent, GdocContentKeyFate>
+
+/** Write-back fate of every OwidGdocDataInsightContent key. */
+export const OWID_GDOC_DATA_INSIGHT_CONTENT_KEYS = {
+    body: "emitted",
+    type: "emitted",
+    title: "emitted",
+    authors: "emitted",
+    "narrative-chart": "emitted",
+    "grapher-url": "emitted",
+    "figma-url": "emitted",
+    authorRoles: "derived", // from authors
+} as const satisfies Record<
+    keyof OwidGdocDataInsightContent,
+    GdocContentKeyFate
+>
+
+/** Gdoc properties that live on the posts_gdocs row (or its attachments)
+ *  rather than in the ArchieML content — managed in the admin, never
+ *  authored in the document. */
+export const OWID_GDOC_BASE_ROW_KEYS = Object.keys({
+    id: true,
+    slug: true,
+    contentMd5: true,
+    published: true,
+    createdAt: true,
+    publishedAt: true,
+    updatedAt: true,
+    revisionId: true,
+    publicationContext: true,
+    manualBreadcrumbs: true,
+    linkedAuthors: true,
+    linkedDocuments: true,
+    linkedCharts: true,
+    linkedNarrativeCharts: true,
+    linkedStaticViz: true,
+    linkedIndicators: true,
+    linkedCallouts: true,
+    imageMetadata: true,
+    relatedCharts: true,
+    tags: true,
+    errors: true,
+    breadcrumbs: true,
+    markdown: true,
+} satisfies Record<Exclude<keyof OwidGdocBaseInterface, "content">, true>)
+
+/** The content-key classification for a gdoc type, or undefined for types
+ *  the ArchieML write-back layer does not handle. */
+export function getContentKeysForGdocType(
+    type: OwidGdocType
+): Record<string, GdocContentKeyFate> | undefined {
+    switch (type) {
+        case OwidGdocType.Article:
+        case OwidGdocType.TopicPage:
+        case OwidGdocType.LinearTopicPage:
+        case OwidGdocType.Fragment:
+            return OWID_GDOC_POST_CONTENT_KEYS
+        case OwidGdocType.DataInsight:
+            return OWID_GDOC_DATA_INSIGHT_CONTENT_KEYS
+        default:
+            return undefined
+    }
+}
+
 export type GdocsPatch = Partial<OwidGdocPostInterface>
 
 export enum GdocsContentSource {

--- a/packages/@ourworldindata/types/src/gdocTypes/Spans.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/Spans.ts
@@ -18,6 +18,12 @@ export type SpanRef = {
     spanType: "span-ref"
     children: Span[]
     url: string
+    // Source form preserved so the enriched → ArchieML write-back serializer
+    // can emit `{ref}id_or_content{/ref}` rather than the post-extractRefs
+    // HTML form `<a class="ref" href="#note-N"><sup>N</sup></a>`. The HTML
+    // form is internal to site rendering; authors write the source form,
+    // and write-back must produce the source form.
+    sourceForm: { kind: "id"; id: string } | { kind: "inline"; content: Span[] }
 }
 
 export type SpanDod = {

--- a/packages/@ourworldindata/types/src/gdocTypes/Spans.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/Spans.ts
@@ -65,6 +65,11 @@ export type SpanUnderline = {
     children: Span[]
 }
 
+export type SpanStrikethrough = {
+    spanType: "span-strikethrough"
+    children: Span[]
+}
+
 export type SpanSubscript = {
     spanType: "span-subscript"
     children: Span[]
@@ -92,6 +97,7 @@ export type Span =
     | SpanItalic
     | SpanBold
     | SpanUnderline
+    | SpanStrikethrough
     | SpanSubscript
     | SpanSuperscript
     | SpanQuote

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -237,6 +237,11 @@ export {
     type TopicPageOrphanReport,
     type NarrativeChartInfo,
     type OwidGdocDataInsightIndexItem,
+    type GdocContentKeyFate,
+    OWID_GDOC_POST_CONTENT_KEYS,
+    OWID_GDOC_DATA_INSIGHT_CONTENT_KEYS,
+    OWID_GDOC_BASE_ROW_KEYS,
+    getContentKeysForGdocType,
 } from "./gdocTypes/Gdoc.js"
 
 export {

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -266,6 +266,7 @@ export {
     type SpanQuote,
     type SpanRef,
     type SpanSimpleText,
+    type SpanStrikethrough,
     type SpanSubscript,
     type SpanSuperscript,
     type SpanUnderline,

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -242,6 +242,11 @@ export {
     type TopicPageOrphanReport,
     type NarrativeChartInfo,
     type OwidGdocDataInsightIndexItem,
+    type GdocContentKeyFate,
+    OWID_GDOC_POST_CONTENT_KEYS,
+    OWID_GDOC_DATA_INSIGHT_CONTENT_KEYS,
+    OWID_GDOC_BASE_ROW_KEYS,
+    getContentKeysForGdocType,
 } from "./gdocTypes/Gdoc.js"
 
 export {

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -271,6 +271,7 @@ export {
     type SpanQuote,
     type SpanRef,
     type SpanSimpleText,
+    type SpanStrikethrough,
     type SpanSubscript,
     type SpanSuperscript,
     type SpanUnderline,

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -1850,6 +1850,7 @@ export function spansToUnformattedPlainText(spans: Span[]): string {
                             "span-superscript",
                             "span-subscript",
                             "span-underline",
+                            "span-strikethrough",
                             "span-ref",
                             "span-dod",
                             "span-guided-chart-link"

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -1706,6 +1706,11 @@ export function traverseEnrichedBlock(
         })
         .with({ type: "table" }, (table) => {
             callback(table)
+            if (spanCallback && table.caption) {
+                table.caption.forEach((span) =>
+                    traverseEnrichedSpan(span, spanCallback)
+                )
+            }
             table.rows.forEach((row) => {
                 row.cells.forEach((cell) => {
                     cell.content.forEach((node) => {
@@ -1786,18 +1791,34 @@ export function traverseEnrichedBlock(
         })
         .with(
             {
+                // Blocks whose only spans live in an optional caption
                 type: P.union(
-                    "chart-story",
                     "chart",
                     "narrative-chart",
+                    "image",
+                    "video",
+                    "static-viz"
+                ),
+            },
+            (block) => {
+                callback(block)
+                if (spanCallback && block.caption) {
+                    block.caption.forEach((span) =>
+                        traverseEnrichedSpan(span, spanCallback)
+                    )
+                }
+            }
+        )
+        .with(
+            {
+                type: P.union(
+                    "chart-story",
                     "code",
                     "cookie-notice",
                     "cta",
                     "donors",
                     "horizontal-rule",
                     "html",
-                    "image",
-                    "video",
                     "missing-data",
                     "prominent-link",
                     "pull-quote",
@@ -1819,7 +1840,6 @@ export function traverseEnrichedBlock(
                     "featured-data-insights",
                     "latest-data-insights",
                     "socials",
-                    "static-viz",
                     "country-profile-selector",
                     "bespoke-component"
                 ),

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -1926,6 +1926,7 @@ export function spansToUnformattedPlainText(spans: Span[]): string {
                             "span-superscript",
                             "span-subscript",
                             "span-underline",
+                            "span-strikethrough",
                             "span-ref",
                             "span-dod",
                             "span-guided-chart-link"

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -1783,6 +1783,11 @@ export function traverseEnrichedBlock(
         })
         .with({ type: "table" }, (table) => {
             callback(table)
+            if (spanCallback && table.caption) {
+                table.caption.forEach((span) =>
+                    traverseEnrichedSpan(span, spanCallback)
+                )
+            }
             table.rows.forEach((row) => {
                 row.cells.forEach((cell) => {
                     cell.content.forEach((node) => {
@@ -1863,18 +1868,34 @@ export function traverseEnrichedBlock(
         })
         .with(
             {
+                // Blocks whose only spans live in an optional caption
                 type: P.union(
-                    "chart-story",
                     "chart",
                     "narrative-chart",
+                    "image",
+                    "video",
+                    "static-viz"
+                ),
+            },
+            (block) => {
+                callback(block)
+                if (spanCallback && block.caption) {
+                    block.caption.forEach((span) =>
+                        traverseEnrichedSpan(span, spanCallback)
+                    )
+                }
+            }
+        )
+        .with(
+            {
+                type: P.union(
+                    "chart-story",
                     "code",
                     "cookie-notice",
                     "cta",
                     "donors",
                     "horizontal-rule",
                     "html",
-                    "image",
-                    "video",
                     "missing-data",
                     "prominent-link",
                     "pull-quote",
@@ -1895,7 +1916,6 @@ export function traverseEnrichedBlock(
                     "featured-data-insights",
                     "latest-data-insights",
                     "socials",
-                    "static-viz",
                     "country-profile-selector",
                     "bespoke-component"
                 ),

--- a/site/gdocs/components/SpanElement.tsx
+++ b/site/gdocs/components/SpanElement.tsx
@@ -143,6 +143,14 @@ export default function SpanElement({
                 />
             </u>
         ))
+        .with({ spanType: "span-strikethrough" }, (span) => (
+            <s>
+                <SpanElements
+                    spans={span.children}
+                    shouldRenderLinks={shouldRenderLinks}
+                />
+            </s>
+        ))
         .with({ spanType: "span-subscript" }, (span) => (
             <sub>
                 <SpanElements


### PR DESCRIPTION
## Context

Second PR of the **claude-cms** stack (on #6543, under #6702). For agent-mediated
editing, content must survive the full loop — enriched → ArchieML → gdoc
`batchUpdate` → `documents.get` → ArchieML → enriched — with **nothing silently
lost**. This PR makes the write-back layer lossless and proves it from both
ends.

## What you can observe

Round-tripping a document through the write-back no longer drops content:

- **Inline formatting & footnotes.** Underline and strikethrough survived the
  write but were never read back, so every round trip stripped them
  (strikethrough was also missing on the enriched side entirely — now a first
  class span, `<s>` on the site). References were re-serialized in their
  rendered HTML form and degraded to plain links; they now round-trip in their
  authoring syntax (`{ref}…{/ref}` + a regenerated `[.refs]` block).
- **Data insights** now write back their own frontmatter (`grapher-url`,
  `narrative-chart`, `figma-url`).
- **Previously-dropped post frontmatter** — `deprecation-notice`,
  `latest-feed-excerpt`, `latest-feed-featured-image`, `atom-title`,
  `atom-excerpt`, and author roles (`authors: Jane Doe (Editor)`) — was emitted
  by nothing and vanished on any write. All of it round-trips now.

The only visible site change: strikethrough text authored in a gdoc now renders
as `<s>` (it was previously dropped).

A second batch of drops surfaced when #6716 started validating the registry
examples through the write gate: callout `icon` and video `shouldAutoplay`
were never emitted, and `topic-page-intro` / `homepage-intro` serialized
their object arrays optional-key-first — ArchieML delimits array items by
key repetition, so a text-less/title-less item silently absorbed the next
item's fields. Fixed here, with round-trip fixtures that now cover exactly
those shapes.

## Architecture

- **A write-back fate classification lives next to the content interfaces** —
  every content key is declared `emitted` / `derived` / `unsupported`, with a
  `satisfies` clause that breaks the build when an interface gains a key whose
  fate hasn't been decided. This is the single source of truth the validation
  gate (#6702) later consumes; it makes "field silently dropped on write" a
  compile error rather than a production surprise.
- **Two layers of proof.** A live harness writes a curated sample into a real
  test doc and diffs the ArchieML read back — the only place the gdoc storage
  layer's style normalization can be exercised, and what surfaced the bugs
  above. Offline, the per-block and document-level suites assert
  `archieToEnriched ∘ writeBack` is a fixed point (including a fully-populated
  frontmatter fixture that fails if any `emitted` key stops surviving).

## Testing guidance

- `yarn test run db/gdocTests.test.ts db/model/Gdoc/archieToEnriched.test.ts`
  — offline round-trip suites
- `yarn tsx --tsconfig tsconfig.tsx.json devTools/gdocs/test-roundtrip.ts`
  — live storage round trip (needs `GDOCS_*` env + edit access to the test
  doc); expect `✓ identical`
- Optionally preview an article with footnotes / strikethrough to confirm
  rendering is unchanged (strikethrough now present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


