### PR TITLE
🐛 (demography) only store changed values in url

### DIFF
--- a/bespoke/projects/demography/src/components/SimulationContent.tsx
+++ b/bespoke/projects/demography/src/components/SimulationContent.tsx
@@ -12,7 +12,10 @@ import {
     computeScenarioOverrides,
     type Simulation,
 } from "../helpers/useSimulation"
-import { updateWindowUrlForSimulationState } from "../helpers/urlState.js"
+import {
+    updateWindowUrlForSimulationState,
+    isControlPointModified,
+} from "../helpers/urlState.js"
 import { PopulationChart } from "./PopulationChart.js"
 import { DemographyParameterEditor } from "./DemographyParameterEditor.js"
 import { PopulationPyramid } from "./PopulationPyramid.js"
@@ -542,8 +545,11 @@ function AssumptionsTable({ simulation }: { simulation: Simulation }) {
                             const userVal = simulation.scenarioParams[key][yr]
                             const refVal =
                                 simulation.unwppScenarioParams[key][yr]
-                            const isModified =
-                                Math.abs(userVal - refVal) >= 0.01
+                            const isModified = isControlPointModified(
+                                userVal,
+                                refVal,
+                                key
+                            )
                             const direction =
                                 userVal > refVal ? "up" : ("down" as const)
                             return (

--- a/bespoke/projects/demography/src/helpers/parameterConfigs.ts
+++ b/bespoke/projects/demography/src/helpers/parameterConfigs.ts
@@ -12,7 +12,7 @@ import {
     getProjectionPopulationForYear,
     calculateTFR,
 } from "../model/model.js"
-import { Simulation } from "./useSimulation.js"
+import type { Simulation } from "./useSimulation.js"
 import { getDeathsForYear, getMigrationRateForYear } from "./utils.js"
 import { ParameterKey } from "./types.js"
 

--- a/bespoke/projects/demography/src/helpers/urlState.test.ts
+++ b/bespoke/projects/demography/src/helpers/urlState.test.ts
@@ -129,7 +129,24 @@ describe(simulationStateToQueryParams, () => {
             [DEMOGRAPHY_COUNTRY_PARAM]: "JPN",
             [DEMOGRAPHY_FERTILITY_PARAM]: "1.2,1.4,1.7",
             [DEMOGRAPHY_LIFE_EXPECTANCY_PARAM]: "84,88,92",
-            [DEMOGRAPHY_NET_MIGRATION_PARAM]: "-1.0,0.0,1.0",
+            // 2100 (1) matches baseline so it's omitted to avoid lossy round-trips
+            [DEMOGRAPHY_NET_MIGRATION_PARAM]: "-1.0,0.0,",
+        })
+    })
+
+    it("omits unchanged control points so reloads don't show false modifications", () => {
+        expect(
+            simulationStateToQueryParams({
+                ...baseWriteState,
+                baselineEntityName: "Japan",
+                scenarioParams: {
+                    fertilityRate: { 2030: 1.4, 2050: 2.0, 2100: 1.6 },
+                    lifeExpectancy: baselineScenarioParams.lifeExpectancy,
+                    netMigrationRate: baselineScenarioParams.netMigrationRate,
+                },
+            })
+        ).toEqual({
+            [DEMOGRAPHY_FERTILITY_PARAM]: ",2.0,",
         })
     })
 

--- a/bespoke/projects/demography/src/helpers/urlState.ts
+++ b/bespoke/projects/demography/src/helpers/urlState.ts
@@ -130,6 +130,7 @@ export function simulationStateToQueryParams(
         ) {
             params[config.param] = serializeAssumptionParam(
                 state.scenarioParams[parameterKey],
+                state.baselineScenarioParams[parameterKey],
                 config.decimals
             )
         }
@@ -174,11 +175,14 @@ function parseAssumptionParam(
 
 function serializeAssumptionParam(
     points: Record<number, number>,
+    baseline: Record<number, number>,
     decimals: number
 ): string {
-    return CONTROL_YEARS.map((year) =>
-        formatNumber(points[year], decimals)
-    ).join(",")
+    return CONTROL_YEARS.map((year) => {
+        const formatted = formatNumber(points[year], decimals)
+        if (formatted === formatNumber(baseline[year], decimals)) return ""
+        return formatted
+    }).join(",")
 }
 
 function areControlPointsEqual(

--- a/bespoke/projects/demography/src/helpers/urlState.ts
+++ b/bespoke/projects/demography/src/helpers/urlState.ts
@@ -3,6 +3,7 @@ import { codeToEntityName, entityNameToCode } from "@ourworldindata/grapher"
 
 import { CONTROL_YEARS, START_YEAR, END_YEAR } from "./constants.js"
 import { isValidParameterKey, type ParameterKey } from "./types.js"
+import { parameterConfigByKey } from "./parameterConfigs.js"
 import type { ScenarioParams } from "../model/scenarios.js"
 
 export const DEMOGRAPHY_COUNTRY_PARAM = "demographyCountry"
@@ -21,29 +22,18 @@ const DEMOGRAPHY_URL_PARAM_KEYS = [
     DEMOGRAPHY_YEAR_PARAM,
 ] as const
 
-const ASSUMPTION_PARAM_CONFIG = {
-    fertilityRate: {
-        param: DEMOGRAPHY_FERTILITY_PARAM,
-        decimals: 1,
-    },
-    lifeExpectancy: {
-        param: DEMOGRAPHY_LIFE_EXPECTANCY_PARAM,
-        decimals: 0,
-    },
-    netMigrationRate: {
-        param: DEMOGRAPHY_NET_MIGRATION_PARAM,
-        decimals: 1,
-    },
-} as const
-
-type AssumptionParamKey = keyof typeof ASSUMPTION_PARAM_CONFIG
+const ASSUMPTION_URL_PARAMS: Record<ParameterKey, string> = {
+    fertilityRate: DEMOGRAPHY_FERTILITY_PARAM,
+    lifeExpectancy: DEMOGRAPHY_LIFE_EXPECTANCY_PARAM,
+    netMigrationRate: DEMOGRAPHY_NET_MIGRATION_PARAM,
+}
 
 export function isControlPointModified(
     userVal: number,
     refVal: number,
-    parameterKey: AssumptionParamKey
+    parameterKey: ParameterKey
 ): boolean {
-    const { decimals } = ASSUMPTION_PARAM_CONFIG[parameterKey]
+    const { decimals } = parameterConfigByKey[parameterKey]
     return formatNumber(userVal, decimals) !== formatNumber(refVal, decimals)
 }
 
@@ -130,19 +120,20 @@ export function simulationStateToQueryParams(
         params[DEMOGRAPHY_COUNTRY_PARAM] = entityNameToCode(state.entityName)
     }
 
-    for (const [key, config] of Object.entries(ASSUMPTION_PARAM_CONFIG)) {
-        const parameterKey = key as keyof typeof ASSUMPTION_PARAM_CONFIG
+    for (const [key, param] of Object.entries(ASSUMPTION_URL_PARAMS)) {
+        const parameterKey = key as ParameterKey
+        const { decimals } = parameterConfigByKey[parameterKey]
         if (
             !areControlPointsEqual(
                 state.scenarioParams[parameterKey],
                 state.baselineScenarioParams[parameterKey],
-                config.decimals
+                decimals
             )
         ) {
-            params[config.param] = serializeAssumptionParam(
+            params[param] = serializeAssumptionParam(
                 state.scenarioParams[parameterKey],
                 state.baselineScenarioParams[parameterKey],
-                config.decimals
+                decimals
             )
         }
     }

--- a/bespoke/projects/demography/src/helpers/urlState.ts
+++ b/bespoke/projects/demography/src/helpers/urlState.ts
@@ -36,6 +36,17 @@ const ASSUMPTION_PARAM_CONFIG = {
     },
 } as const
 
+type AssumptionParamKey = keyof typeof ASSUMPTION_PARAM_CONFIG
+
+export function isControlPointModified(
+    userVal: number,
+    refVal: number,
+    parameterKey: AssumptionParamKey
+): boolean {
+    const { decimals } = ASSUMPTION_PARAM_CONFIG[parameterKey]
+    return formatNumber(userVal, decimals) !== formatNumber(refVal, decimals)
+}
+
 export interface SimulationUrlState {
     entityName?: string
     fertilityRateAssumptions?: Record<number, number>

--- a/bespoke/projects/demography/src/helpers/useSimulation.ts
+++ b/bespoke/projects/demography/src/helpers/useSimulation.ts
@@ -47,6 +47,7 @@ import {
     type ScenarioConstants,
 } from "../model/scenarios"
 import { runProjectionResults } from "../model/projectionRunner"
+import { isControlPointModified } from "./urlState"
 
 const SCENARIO_CONSTANTS: ScenarioConstants = {
     HISTORICAL_END_YEAR,
@@ -446,10 +447,12 @@ export function useSimulation(
         if (!core || !effectiveScenarioParams) return modified
         const un = core.defaultScenario
         for (const key of PARAMETER_KEYS) {
-            const isModified = CONTROL_YEARS.some(
-                (y) =>
-                    Math.abs(effectiveScenarioParams[key][y] - un[key][y]) >=
-                    0.01
+            const isModified = CONTROL_YEARS.some((y) =>
+                isControlPointModified(
+                    effectiveScenarioParams[key][y],
+                    un[key][y],
+                    key
+                )
             )
             if (isModified) modified.add(key)
         }


### PR DESCRIPTION
There's currently a bug where:
- A single control point is changed
- Refresh
- All control points are shown as changed in the summary table