### PR TITLE
Remove unused summary gdoc field

### DIFF
--- a/adminSiteClient/GdocsIndexPage.tsx
+++ b/adminSiteClient/GdocsIndexPage.tsx
@@ -20,7 +20,6 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import {
     DbChartTagJoin,
     OwidGdocType,
-    spansToUnformattedPlainText,
     checkIsGdocPost,
     OwidGdocIndexItem,
 } from "@ourworldindata/utils"
@@ -247,16 +246,7 @@ export class GdocsIndexPage extends React.Component<RouteComponentProps> {
                     ]
 
                     if (checkIsGdocPost(gdoc)) {
-                        properties.push(
-                            gdoc.content.subtitle,
-                            gdoc.content.summary
-                                ? spansToUnformattedPlainText(
-                                      gdoc.content.summary.flatMap(
-                                          (block) => block.value
-                                      )
-                                  )
-                                : undefined
-                        )
+                        properties.push(gdoc.content.subtitle)
                     }
                     return properties
                 }

--- a/adminSiteClient/gdocsDeploy.ts
+++ b/adminSiteClient/gdocsDeploy.ts
@@ -85,7 +85,6 @@ export const checkIsLightningUpdate = (
         details: true,
         refs: true,
         subtitle: true,
-        summary: true,
         "sticky-nav": true,
         supertitle: true,
         toc: true,

--- a/db/model/Gdoc/GdocPost.ts
+++ b/db/model/Gdoc/GdocPost.ts
@@ -5,7 +5,6 @@ import {
     OwidGdocErrorMessageType,
     OwidGdocType,
     OwidEnrichedGdocBlock,
-    RawBlockText,
     RelatedChart,
     OwidGdocMinimalPostInterface,
     OwidGdocBaseInterface,
@@ -14,7 +13,6 @@ import {
 import { excludeNullish, generateToc } from "@ourworldindata/utils"
 import { formatCitation, generateStickyNav } from "./archieToEnriched.js"
 import { parseFaqs, parseLatestFeedExcerpt } from "./rawToEnriched.js"
-import { htmlToEnrichedTextBlock } from "./htmlToEnriched.js"
 import { GdocBase } from "./GdocBase.js"
 import { KnexReadonlyTransaction, knexRaw } from "../../db.js"
 import { getLatestArchivedChartPageVersionsIfEnabled } from "../ArchivedChartVersion.js"
@@ -84,12 +82,6 @@ export class GdocPost extends GdocBase implements OwidGdocPostInterface {
             content.body,
             isTocForSidebar || isLinearTopicPage
         )
-
-        if (content.summary) {
-            content.summary = content.summary.map((html: RawBlockText) =>
-                htmlToEnrichedTextBlock(html.value)
-            )
-        }
 
         if (content["latest-feed-excerpt"]) {
             content["latest-feed-excerpt"] = parseLatestFeedExcerpt(

--- a/db/model/Gdoc/archieToGdoc.ts
+++ b/db/model/Gdoc/archieToGdoc.ts
@@ -1,11 +1,6 @@
-import {
-    OwidGdocPostContent,
-    EnrichedBlockText,
-    EnrichedBlockSimpleText,
-} from "@ourworldindata/utils"
+import { OwidGdocPostContent } from "@ourworldindata/utils"
 import {
     propertyToArchieMLString,
-    encloseLinesAsPropertyPossiblyMultiline,
     OwidRawGdocBlockToArchieMLStringGenerator,
 } from "./rawToArchie.js"
 import { GDOCS_BACKPORTING_TARGET_FOLDER } from "../../../settings/serverSettings.js"
@@ -15,23 +10,6 @@ import { type drive_v3, drive as googleDrive } from "@googleapis/drive"
 import { OwidGoogleAuth } from "../../OwidGoogleAuth.js"
 import * as cheerio from "cheerio"
 import type { AnyNode } from "domhandler"
-
-function* yieldMultiBlockPropertyIfDefined(
-    property: keyof OwidGdocPostContent,
-    article: OwidGdocPostContent,
-    target: (EnrichedBlockText | EnrichedBlockSimpleText)[] | undefined
-): Generator<string, void, undefined> {
-    if (property in article && target) {
-        yield* encloseLinesAsPropertyPossiblyMultiline(
-            property,
-            target.flatMap((item) => [
-                ...OwidRawGdocBlockToArchieMLStringGenerator(
-                    enrichedBlockToRawBlock(item)
-                ),
-            ])
-        )
-    }
-}
 
 function* owidArticleToArchieMLStringGenerator(
     article: OwidGdocPostContent
@@ -55,7 +33,6 @@ function* owidArticleToArchieMLStringGenerator(
     yield* propertyToArchieMLString("heading-variant", article)
     yield* propertyToArchieMLString("hide-subscribe-banner", article)
     // TODO: inline refs
-    yieldMultiBlockPropertyIfDefined("summary", article, article.summary)
     yield* propertyToArchieMLString("hide-citation", article)
     yield* propertyToArchieMLString("cover-image", article)
     yield* propertyToArchieMLString("cover-color", article)

--- a/db/model/Gdoc/rawToArchie.ts
+++ b/db/model/Gdoc/rawToArchie.ts
@@ -76,24 +76,6 @@ export function appendDotEndIfMultiline(
     return line ?? ""
 }
 
-export function* encloseLinesAsPropertyPossiblyMultiline(
-    key: string,
-    lines: Iterable<string>
-): Generator<string, void, unknown> {
-    let first = true
-    let multiLine = false
-    for (const line of lines) {
-        if (first) {
-            yield `${key}: ${line}`
-            first = false
-        } else {
-            yield line
-            multiLine = true
-        }
-    }
-    if (multiLine) yield ":end"
-}
-
 export function keyValueToArchieMlString(
     key: string,
     val: string | undefined | null

--- a/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
@@ -495,7 +495,6 @@ export interface OwidGdocPostContent {
     dateline?: string
     excerpt?: string
     refs?: { definitions: RefDictionary; errors: OwidGdocErrorMessage[] }
-    summary?: EnrichedBlockText[]
     "deprecation-notice"?: EnrichedBlockText[]
     "latest-feed-featured-image"?: string
     "latest-feed-excerpt"?: EnrichedBlockText[]

--- a/site/gdocs/components/Image.tsx
+++ b/site/gdocs/components/Image.tsx
@@ -53,7 +53,6 @@ const containerSizes: Record<ImageParentContainer, string> = {
     ["sticky-left-left-column"]: gridSpan7,
     ["sticky-left-right-column"]: gridSpan5,
     ["side-by-side"]: gridSpan6,
-    ["summary"]: gridSpan6,
     ["thumbnail"]: "350px",
     ["datapage"]: gridSpan6,
     ["data-insight"]: "100%",

--- a/site/gdocs/components/centered-article.scss
+++ b/site/gdocs/components/centered-article.scss
@@ -237,10 +237,6 @@
     }
 }
 
-.article-summary {
-    margin-bottom: 32px;
-}
-
 .deprecation-notice {
     --bg-color: #fff5d8;
     position: sticky;

--- a/site/gdocs/components/layout.ts
+++ b/site/gdocs/components/layout.ts
@@ -9,7 +9,6 @@ export type Container =
     | "sticky-left-left-column"
     | "sticky-left-right-column"
     | "side-by-side"
-    | "summary"
     | "datapage"
     | "key-insight"
     | "about-page"
@@ -154,9 +153,6 @@ const layouts: { [key in Container]: Layouts} = {
         ["default"]: "span-cols-6 span-sm-cols-12",
         ["prominent-link"]: "grid grid-cols-6 span-cols-6 grid-sm-cols-12 span-sm-cols-12 ",
         ["cookie-notice"]: "span-cols-5 col-start-2 span-md-cols-6 col-md-start-1 span-sm-cols-12 col-sm-start-1"
-    },
-    ["summary"]: {
-        ["default"]: "col-start-5 span-cols-6 col-md-start-3 span-md-cols-10 span-sm-cols-12 col-sm-start-2",
     },
     ["data-insight"]: {
         // no grid containers or grid sizing for data insights - they're always just a single column

--- a/site/gdocs/pages/GdocPost.tsx
+++ b/site/gdocs/pages/GdocPost.tsx
@@ -128,18 +128,6 @@ export function GdocPost({
                     />
                 </nav>
             ) : null}
-            {content.summary ? (
-                <details
-                    className="article-summary col-start-5 span-cols-6 col-md-start-3 span-md-cols-10 col-sm-start-2 span-sm-cols-12"
-                    open={true}
-                >
-                    <summary>Summary</summary>
-                    <ArticleBlocks
-                        blocks={content.summary}
-                        containerType="summary"
-                    />
-                </details>
-            ) : null}
             {content.body ? (
                 <ArticleBlocks
                     toc={content.toc}


### PR DESCRIPTION
No gdocs currently use the field. Removed also all helpers that were only used by the summary code.

Resolves #6490
