### PR TITLE
🎉 validate record lengths before indexing

### DIFF
--- a/baker/algolia/indexPagesChronologicalToAlgolia.ts
+++ b/baker/algolia/indexPagesChronologicalToAlgolia.ts
@@ -9,6 +9,9 @@ import { getAlgoliaClient } from "./configureAlgolia.js"
 import { getIndexName } from "../../site/search/searchClient.js"
 import { SearchIndexName } from "@ourworldindata/types"
 import { getPagesChronologicalRecords } from "./utils/pagesChronological.js"
+import { ensureRecordFitsAlgoliaLimit } from "./utils/shared.js"
+import { partition } from "remeda"
+import { logErrorAndMaybeCaptureInSentry } from "../../serverUtils/errorLog.js"
 
 const indexPagesChronologicalToAlgolia = async () => {
     if (!ALGOLIA_INDEXING) {
@@ -31,9 +34,20 @@ const indexPagesChronologicalToAlgolia = async () => {
         db.TransactionCloseMode.Close
     )
 
+    const [fittedRecords, unfittedRecords] = partition(
+        records,
+        ensureRecordFitsAlgoliaLimit
+    )
+    if (unfittedRecords.length > 0) {
+        await logErrorAndMaybeCaptureInSentry(
+            `${getIndexName(SearchIndexName.PagesChronological)}: ${unfittedRecords.length} records exceed Algolia size limit and will not be indexed.
+Gdoc IDs: ${unfittedRecords.map((r) => r.objectID).join(", ")}`
+        )
+    }
+
     await client.replaceAllObjects({
         indexName,
-        objects: records as Array<Record<string, unknown>>,
+        objects: fittedRecords as Array<Record<string, unknown>>,
     })
 
     console.log(`Indexed ${records.length} records to ${indexName}`)

--- a/baker/algolia/indexPagesToAlgolia.tsx
+++ b/baker/algolia/indexPagesToAlgolia.tsx
@@ -8,6 +8,11 @@ import { ALGOLIA_INDEXING } from "../../settings/serverSettings.js"
 import { getAlgoliaClient } from "./configureAlgolia.js"
 import { PAGES_INDEX } from "../../site/search/searchUtils.js"
 import { getPagesRecords } from "./utils/pages.js"
+import { ensureRecordFitsAlgoliaLimit } from "./utils/shared.js"
+import { partition } from "remeda"
+import { logErrorAndMaybeCaptureInSentry } from "../../serverUtils/errorLog.js"
+import { getIndexName } from "../../site/search/searchClient.js"
+import { SearchIndexName } from "@ourworldindata/types"
 
 const indexPagesToAlgolia = async () => {
     if (!ALGOLIA_INDEXING) {
@@ -26,10 +31,20 @@ const indexPagesToAlgolia = async () => {
         getPagesRecords,
         db.TransactionCloseMode.Close
     )
+    const [fittedRecords, unfittedRecords] = partition(
+        records,
+        ensureRecordFitsAlgoliaLimit
+    )
+    if (unfittedRecords.length > 0) {
+        await logErrorAndMaybeCaptureInSentry(
+            `${getIndexName(SearchIndexName.Pages)}: ${unfittedRecords.length} records exceed Algolia size limit and will not be indexed.
+ObjectIDs: ${unfittedRecords.map((r) => r.objectID).join(", ")}`
+        )
+    }
 
     await client.replaceAllObjects({
         indexName,
-        objects: records as Array<Record<string, any>>,
+        objects: fittedRecords as Array<Record<string, any>>,
     })
 
     process.exit(0)

--- a/baker/algolia/utils/charts.ts
+++ b/baker/algolia/utils/charts.ts
@@ -36,19 +36,9 @@ const computeChartScore = (
 const parseRawChartRecord = (
     rawRecord: RawChartRecordRow
 ): ParsedChartRecordRow => {
-    let parsedEntities: string[] = []
-    if (rawRecord.entityNames !== null) {
-        // This is a very rough way to check for the Algolia record size limit, but it's better than the update failing
-        // because we exceed the 20KB record size limit
-        if (rawRecord.entityNames.length < 12000)
-            parsedEntities = JSON.parse(rawRecord.entityNames) as string[]
-        else {
-            console.info(
-                `Chart ${rawRecord.id} has too many entities, skipping its entities`
-            )
-        }
-    }
-    const entityNames = processAvailableEntities(parsedEntities)
+    const entityNames = processAvailableEntities(
+        JSON.parse(rawRecord.entityNames)
+    )
 
     const tags = JSON.parse(rawRecord.tags) as string[]
     const keyChartForTags = JSON.parse(rawRecord.keyChartForTags) as string[]

--- a/baker/algolia/utils/shared.ts
+++ b/baker/algolia/utils/shared.ts
@@ -72,8 +72,15 @@ export const processAvailableEntities = (
 // the record fits.
 const ALGOLIA_TARGET_RECORD_BYTES = 19500
 
-const byteLength = (value: unknown): number =>
+const checkByteLength = (value: unknown): number =>
     Buffer.byteLength(JSON.stringify(value), "utf8")
+
+export function ensureRecordFitsAlgoliaLimit<T extends { objectID: string }>(
+    record: T
+): boolean {
+    const size = checkByteLength(record)
+    return size <= ALGOLIA_TARGET_RECORD_BYTES
+}
 
 export function shrinkRecordsToFitAlgoliaLimit<
     T extends { availableEntities: string[]; objectID: string },
@@ -84,10 +91,10 @@ export function shrinkRecordsToFitAlgoliaLimit<
 function shrinkRecordToFitAlgoliaLimit<
     T extends { availableEntities: string[]; objectID: string },
 >(record: T): T {
-    const size = byteLength(record)
+    const size = checkByteLength(record)
     if (size <= ALGOLIA_TARGET_RECORD_BYTES) return record
 
-    const baseSize = byteLength({ ...record, availableEntities: [] })
+    const baseSize = checkByteLength({ ...record, availableEntities: [] })
     const entitiesBudget = ALGOLIA_TARGET_RECORD_BYTES - baseSize
 
     if (entitiesBudget <= 0) {
@@ -101,7 +108,8 @@ function shrinkRecordToFitAlgoliaLimit<
     // Account for surrounding `[]`
     let runningSize = 2
     for (const entity of record.availableEntities) {
-        const entrySize = byteLength(entity) + (truncated.length > 0 ? 1 : 0) // comma
+        const entrySize =
+            checkByteLength(entity) + (truncated.length > 0 ? 1 : 0) // comma
         if (runningSize + entrySize > entitiesBudget) break
         truncated.push(entity)
         runningSize += entrySize


### PR DESCRIPTION
Resolves https://github.com/owid/owid-grapher/issues/6535

Charts with IDs `5879`, `8149`, and `8150` used to trigger the old `"too many entities, skipping its entities"` warning.

The entities are AI models (`"Llama 2-70B", "Llama 2-7B"` etc) so it's not useful for them to be indexed, but I checked to see their size with the new `shrinkRecords` technique and all 3 are around ~17500 in length now.