### PR TITLE
🐛 fix component snippets test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,20 @@ jobs:
       - name: Run oxlint
         run: yarn testLint
 
+  raycast-snippets:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v5
+
+      - uses: ./.github/actions/setup-node-yarn-deps
+        with:
+          runPostinstallScripts: false
+
+      - name: Check Raycast snippets are in sync
+        run: yarn checkRaycastSnippets
+
   # Runs `bundlemon` on the code to see if our Vite build assets exceed a given file size.
   bundlemon:
     runs-on: ubuntu-latest

--- a/devTools/gdocs/raycastSnippets/generateRaycastSnippets.ts
+++ b/devTools/gdocs/raycastSnippets/generateRaycastSnippets.ts
@@ -113,39 +113,83 @@ async function main() {
         snippets.map((snippet) => [snippet.name, snippet])
     )
 
-    const missing = getAllExampleBlocks()
-        .filter((block) => !snippetsByName.has(block.type))
+    const expectedSnippets = getAllExampleBlocks()
         .filter((block) => !EXEMPT_BLOCK_TYPES.includes(block.type))
         .map(blockToSnippet)
-        .sort((a, b) => a.name.localeCompare(b.name))
+    const expectedByName = new Map(
+        expectedSnippets.map((snippet) => [snippet.name, snippet])
+    )
+
+    const missing: RaycastSnippet[] = []
+    const outdated: RaycastSnippet[] = []
+    for (const expected of expectedSnippets) {
+        const actual = snippetsByName.get(expected.name)
+        if (!actual) {
+            missing.push(expected)
+        } else if (
+            actual.text !== expected.text ||
+            actual.keyword !== expected.keyword
+        ) {
+            outdated.push(expected)
+        }
+    }
+    missing.sort((a, b) => a.name.localeCompare(b.name))
+    outdated.sort((a, b) => a.name.localeCompare(b.name))
 
     if (checkMode) {
-        if (missing.length) {
+        if (missing.length || outdated.length) {
+            if (missing.length) {
+                console.error(
+                    `Missing ${missing.length} ArchieML snippet(s): ${missing
+                        .map((snippet) => snippet.name)
+                        .join(", ")}`
+                )
+            }
+            if (outdated.length) {
+                console.error(
+                    `Outdated ${outdated.length} ArchieML snippet(s): ${outdated
+                        .map((snippet) => snippet.name)
+                        .join(", ")}`
+                )
+            }
             console.error(
-                `Missing ${missing.length} ArchieML snippet(s): ${missing
-                    .map((snippet) => snippet.name)
-                    .join(", ")}`
+                "Run 'yarn generateRaycastSnippets' to regenerate the snippets file."
             )
-            console.error("Run 'yarn generateRaycastSnippets' to add them.")
             process.exitCode = 1
             return
         }
-        console.log("All ArchieML components already have snippets.")
+        console.log("All ArchieML components have up-to-date snippets.")
         return
     }
 
-    if (missing.length === 0) {
-        console.log("No new ArchieML snippets to append.")
+    if (missing.length === 0 && outdated.length === 0) {
+        console.log("ArchieML snippets are already up to date.")
         return
     }
 
-    const updatedSnippets = [...snippets, ...missing]
-    await writeSnippetsFile(updatedSnippets)
-    console.log(
-        `Appended ${missing.length} ArchieML snippet(s): ${missing
-            .map((snippet) => snippet.name)
-            .join(", ")}`
+    // Replace outdated entries in place; append newly-missing ones at the end.
+    // Snippets whose name doesn't match any example block (e.g. custom-keyword
+    // entries like `+srwc`, `+html`) are left untouched.
+    const updatedSnippets = snippets.map(
+        (snippet) => expectedByName.get(snippet.name) ?? snippet
     )
+    updatedSnippets.push(...missing)
+    await writeSnippetsFile(updatedSnippets)
+
+    if (missing.length) {
+        console.log(
+            `Appended ${missing.length} ArchieML snippet(s): ${missing
+                .map((snippet) => snippet.name)
+                .join(", ")}`
+        )
+    }
+    if (outdated.length) {
+        console.log(
+            `Updated ${outdated.length} ArchieML snippet(s): ${outdated
+                .map((snippet) => snippet.name)
+                .join(", ")}`
+        )
+    }
 }
 
 main().catch((error) => {

--- a/packages/@ourworldindata/types/src/gdocTypes/raycastSnippets.json
+++ b/packages/@ourworldindata/types/src/gdocTypes/raycastSnippets.json
@@ -26,12 +26,12 @@
     },
     {
         "name": "callout",
-        "text": "{.callout}\ntitle: \n[.+text]\n\n[]\n{}",
+        "text": "{.callout}\ntitle: \n[.+text]\n\n\n[.list]\n* \n[]\n{.heading}\ntext: \nlevel: \n{}\n[]\n{}",
         "keyword": "+callout"
     },
     {
         "name": "chart",
-        "text": "{.chart}\nurl: \ncaption: \npeerCountries: \n{}",
+        "text": "{.chart}\nurl: \nheight: \nsize: \ncaption: \n{}",
         "keyword": "+chart"
     },
     {
@@ -81,7 +81,7 @@
     },
     {
         "name": "guided-chart",
-        "text": "[.+guided-chart]\n{.chart}\nurl: \n{}\n\n[]",
+        "text": "[.+guided-chart]\n{.chart}\nurl: \nsize: \n{}\n\n[]",
         "keyword": "+guided-chart"
     },
     {
@@ -96,7 +96,7 @@
     },
     {
         "name": "image",
-        "text": "{.image}\nfilename: \ncaption: \nsize: \n{}",
+        "text": "{.image}\nfilename: \ncaption: \nsize: \nhasOutline: \nalt: \nvisibility: \n{}",
         "keyword": "+image"
     },
     {
@@ -126,7 +126,7 @@
     },
     {
         "name": "narrative-chart",
-        "text": "{.narrative-chart}\nname: \ncaption: \n{}",
+        "text": "{.narrative-chart}\nname: \nheight: \nsize: \ncaption: \n{}",
         "keyword": "+narrative-chart"
     },
     {
@@ -136,7 +136,7 @@
     },
     {
         "name": "prominent-link",
-        "text": "{.prominent-link}\nurl: \n{}",
+        "text": "{.prominent-link}\nurl: \ntitle: \ndescription: \nthumbnail: \n{}",
         "keyword": "+prominent-link"
     },
     {
@@ -151,7 +151,7 @@
     },
     {
         "name": "research-and-writing",
-        "text": "{.research-and-writing}\nheading: \nhide-authors: \nhide-date: \n[.primary]\nurl: \n[]\n[.secondary]\nurl: \nurl: \n[]\n{.more}\nheading: \n[.articles]\nurl: \nurl: \nauthors: \ntitle: \nfilename: \nurl: \nauthors: \ntitle: \nfilename: \n[]\n{}\n{.latest}\nheading: \n{}\n[.rows]\nheading: \n[.articles]\nurl: \nurl: \nauthors: \ntitle: \nfilename: \n[]\n[]\n{}",
+        "text": "{.research-and-writing}\nheading: \nhide-authors: \nhide-date: \nvariant: \n[.primary]\nurl: \n[]\n[.secondary]\nurl: \nurl: \n[]\n{.more}\nheading: \n[.articles]\nurl: \nurl: \nauthors: \ntitle: \nfilename: \nurl: \nauthors: \ntitle: \nfilename: \n[]\n{}\n{.latest}\nheading: \n{}\n[.rows]\nheading: \n[.articles]\nurl: \nurl: \nauthors: \ntitle: \nfilename: \n[]\n[]\n{}",
         "keyword": "+research-and-writing"
     },
     {
@@ -191,7 +191,7 @@
     },
     {
         "name": "table",
-        "text": "{.table}\ntemplate: \nsize: \ncaption: \n\n{}",
+        "text": "{.table}\ntemplate: \nsize: \ncaption: \n[.+rows]\n{.table-row}\n[.+cells]\n[.+table-cell]\n\n\n[]\n[.+table-cell]\n\n\n[]\n[.+table-cell]\n\n\n[]\n[]\n{}\n[]\n{}",
         "keyword": "+table"
     },
     {
@@ -201,7 +201,7 @@
     },
     {
         "name": "video",
-        "text": "{.video}\nurl: \nfilename: \nshouldLoop: \ncaption: \n{}",
+        "text": "{.video}\nurl: \nfilename: \nshouldLoop: \ncaption: \nvisibility: \n{}",
         "keyword": "+video"
     },
     {
@@ -226,7 +226,7 @@
     },
     {
         "name": "static-viz",
-        "text": "{.static-viz}\nname: \nsize: \nhasOutline: \ncaption:\n{}",
+        "text": "{.static-viz}\nname: \nsize: \nhasOutline: \ncaption: \n{}",
         "keyword": "+static-viz"
     },
     {
@@ -256,7 +256,27 @@
     },
     {
         "name": "country-profile-selector",
-        "text": "{.country-profile-selector}\nurl: \n{}",
+        "text": "{.country-profile-selector}\nurl: \ntitle: \ndescription: \ndefaultCountries: \n{}",
         "keyword": "+country-profile-selector"
+    },
+    {
+        "name": "bespoke-component",
+        "text": "{.bespoke-component}\nbundle: \nvariant: \nsize: \n{.config}\nfoo: \n{}\n{}",
+        "keyword": "+bespoke-component"
+    },
+    {
+        "name": "chart-rows",
+        "text": "{.chart-rows}\nkicker: \ntitle: \nsource: \n[.rows]\nimage: \nurl: \n[.+content]\n\n[]\nimage: \nurl: \n[.+content]\n\n[]\n[]\n{}",
+        "keyword": "+chart-rows"
+    },
+    {
+        "name": "data-callout-group",
+        "text": "{.data-callout-group}\n[.+content]\n{.data-callout}\nurl: \n[.+content]\n\n[]\n{}\n[]\n{}",
+        "keyword": "+data-callout-group"
+    },
+    {
+        "name": "pull-chart",
+        "text": "{.pull-chart}\nalign: \nimage: \nurl: \n[.+content]\n\n[]\n{}",
+        "keyword": "+pull-chart"
     }
 ]


### PR DESCRIPTION
This test wasn't properly running in CI, allowing `raycastSnippets.json` to fall out of sync. All our devs need to do is run `yarn generateRaycastSnippets` whenever they define a new component, so it shouldn't be too hard to maintain this going forward.