### PR TITLE
🔨🤖 Tailored per-consumer content.toc (GdocToc data shape + migration)

### DIFF
--- a/db/migration/1780058394287-RegenerateTocAsTocItems.ts
+++ b/db/migration/1780058394287-RegenerateTocAsTocItems.ts
@@ -3,9 +3,19 @@ import { generateToc, traverseEnrichedBlock } from "@ourworldindata/utils"
 import {
     OwidEnrichedGdocBlock,
     OwidGdocPostContent,
-    TocHeadingWithTitleSupertitle,
 } from "@ourworldindata/types"
 import { gdocFromJSON } from "../model/Gdoc/GdocFactory.js"
+
+// The pre-Toc on-disk shape, frozen here next to its only consumer (down()
+// below). Kept out of the shared types package so a future refactor there can't
+// silently break this migration.
+interface TocHeadingWithTitleSupertitle {
+    text: string
+    slug: string
+    isSubheading: boolean
+    title: string
+    supertitle?: string
+}
 
 // down() only: strip the chart / narrative-chart anchorIds that
 // generateSidebarToc wrote onto the body.

--- a/db/migration/1780058394287-RegenerateTocAsTocItems.ts
+++ b/db/migration/1780058394287-RegenerateTocAsTocItems.ts
@@ -1,0 +1,102 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+import { generateToc, traverseEnrichedBlock } from "@ourworldindata/utils"
+import {
+    OwidEnrichedGdocBlock,
+    OwidGdocPostContent,
+    TocHeadingWithTitleSupertitle,
+} from "@ourworldindata/types"
+import { gdocFromJSON } from "../model/Gdoc/GdocFactory.js"
+
+// down() only: strip the chart / narrative-chart anchorIds that
+// generateSidebarToc wrote onto the body.
+function stripChartAnchorIds(body: OwidEnrichedGdocBlock[] | undefined): void {
+    body?.forEach((block) =>
+        traverseEnrichedBlock(block, (child) => {
+            if (child.type === "chart" || child.type === "narrative-chart")
+                delete child.anchorId
+        })
+    )
+}
+
+export class RegenerateTocAsTocItems1780058394287 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        // Regenerate content.toc in the new Toc shape via generateToc
+        // (same gating as the live enrichment path). No anchorId pre-strip
+        // needed: existing bodies have none — this stack introduces them, and
+        // the only re-run path is down()→up(), where down() strips.
+        //
+        // Profiles are excluded: they store un-instantiated templates and
+        // regenerate their toc per-entity at bake time
+        // (instantiateProfileForEntity).
+        const rows = (await queryRunner.query(`-- sql
+            SELECT id, content
+            FROM posts_gdocs
+            WHERE published = TRUE
+                AND type IN ('article', 'topic-page', 'linear-topic-page')
+        `)) as { id: string; content: string }[]
+
+        for (const row of rows) {
+            const gdoc = gdocFromJSON(row)
+            // All selected types are GdocPost, so content is a post.
+            const content = gdoc.content as OwidGdocPostContent
+
+            const toc = generateToc(content)
+            if (toc) content.toc = toc
+            // The old toc was generated unconditionally, so pages with no TOC
+            // consumer carry a stale one that must be removed.
+            else delete content.toc
+
+            await queryRunner.query(
+                `-- sql
+                UPDATE posts_gdocs SET content = ? WHERE id = ?`,
+                [JSON.stringify(content), gdoc.id]
+            )
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        // Reconstruct the previous TocHeadingWithTitleSupertitle[] shape from
+        // the new Toc and strip chart anchorIds. Pages up() left without a
+        // toc get an empty one — fine, every page re-derives its toc on next
+        // publish.
+        const rows = (await queryRunner.query(`-- sql
+            SELECT id, content
+            FROM posts_gdocs
+            WHERE published = TRUE
+                AND type IN ('article', 'topic-page', 'linear-topic-page')
+        `)) as { id: string; content: string }[]
+
+        for (const row of rows) {
+            const content = JSON.parse(row.content) as OwidGdocPostContent
+            const toc = content.toc
+
+            let legacyToc: TocHeadingWithTitleSupertitle[] = []
+            if (toc?.kind === "sidebar") {
+                legacyToc = toc.sections.map((section) => ({
+                    text: section.heading.text,
+                    slug: section.heading.slug,
+                    title: section.heading.text,
+                    supertitle: section.heading.supertitle ?? "",
+                    isSubheading: false,
+                }))
+            } else if (toc?.kind === "inline") {
+                legacyToc = toc.headings.map((heading) => ({
+                    text: heading.text,
+                    slug: heading.slug,
+                    title: heading.text,
+                    supertitle: heading.supertitle ?? "",
+                    isSubheading: heading.level === 3,
+                }))
+            }
+
+            stripChartAnchorIds(content.body)
+            content.toc = legacyToc as unknown as OwidGdocPostContent["toc"]
+
+            await queryRunner.query(
+                `-- sql
+                UPDATE posts_gdocs SET content = ? WHERE id = ?`,
+                [JSON.stringify(content), row.id]
+            )
+        }
+    }
+}

--- a/db/model/Gdoc/GdocPost.ts
+++ b/db/model/Gdoc/GdocPost.ts
@@ -76,12 +76,9 @@ export class GdocPost extends GdocBase implements OwidGdocPostInterface {
     }
 
     override _enrichSubclassContent = (content: Record<string, any>): void => {
-        const isTocForSidebar = content["sidebar-toc"]
-        const isLinearTopicPage = content.type === OwidGdocType.LinearTopicPage
-        content.toc = generateToc(
-            content.body,
-            isTocForSidebar || isLinearTopicPage
-        )
+        // Pages with no TOC consumer ship no toc at all.
+        const toc = generateToc(content)
+        if (toc) content.toc = toc
 
         if (content["latest-feed-excerpt"]) {
             content["latest-feed-excerpt"] = parseLatestFeedExcerpt(

--- a/db/model/Gdoc/GdocProfile.ts
+++ b/db/model/Gdoc/GdocProfile.ts
@@ -160,9 +160,9 @@ export async function instantiateProfileForEntity(
         options
     )
 
-    if (content["sidebar-toc"]) {
-        content.toc = generateToc(content.body, true)
-    }
+    // Same gating as GdocPost so profiles render TOCs identically.
+    const toc = generateToc(content)
+    if (toc) content.toc = toc
 
     return {
         ...profileTemplate,

--- a/docs/agent-guidelines/gdocs-class-hierarchy.md
+++ b/docs/agent-guidelines/gdocs-class-hierarchy.md
@@ -25,7 +25,7 @@ This note complements the Google Docs CMS pipeline overview by mapping the serve
 ### `GdocPost` (`db/model/Gdoc/GdocPost.ts`)
 
 - Represents the majority of articles (article, topic page, linear topic page, fragment).
-- Generates derived structures: table of contents (`generateToc`), sticky nav (`generateStickyNav`), citations (`formatCitation`), FAQ parsing (`parseFaqs`), and summary text blocks.
+- Generates derived structures: table of contents, sticky nav (`generateStickyNav`), citations (`formatCitation`), FAQ parsing (`parseFaqs`), and summary text blocks. The `content.toc` is only generated when the page actually renders a TOC, tailored to that consumer: `generateSidebarToc` (`{ kind: "sidebar", sections }`) when the `sidebar-toc` flag or an `ltp-toc` block is present, `generateInlineToc` (`{ kind: "inline", headings }`) for an `sdg-toc` block, and omitted otherwise.
 - Exposes FAQ, reference, and deprecation notice blocks via `_getSubclassEnrichedBlocks` for markdown conversion.
 - Validates required tags for certain components and ensures linked charts/indicators are present.
 

--- a/packages/@ourworldindata/components/src/GdocsUtils.ts
+++ b/packages/@ourworldindata/components/src/GdocsUtils.ts
@@ -67,6 +67,12 @@ export function getUrlTarget(urlString: string): string {
     return urlString
 }
 
+/**
+ * Text-only heading slug, used to match special sections (Key Insights etc.) by
+ * their text regardless of any supertitle. For the canonical rendered-anchor id
+ * (shared by ArticleBlock and the TOC generator) see {@link convertHeadingToId}
+ * in utils.
+ */
 export function convertHeadingTextToId(headingText: Span[]): string {
     return urlSlug(spansToUnformattedPlainText(headingText))
 }

--- a/packages/@ourworldindata/types/src/domainTypes/Toc.ts
+++ b/packages/@ourworldindata/types/src/domainTypes/Toc.ts
@@ -1,3 +1,6 @@
+import type { BlockVisibility } from "../gdocTypes/archieMLComponents/generic.js"
+import type { EnrichedBlockHeading } from "../gdocTypes/archieMLComponents/Heading.js"
+
 export interface TocHeading {
     text: string
     slug: string
@@ -8,3 +11,44 @@ export interface TocHeadingWithTitleSupertitle extends TocHeading {
     title: string
     supertitle?: string
 }
+
+/** A heading entry in a {@link Toc}. */
+export interface TocHeadingItem {
+    level: EnrichedBlockHeading["level"]
+    text: string
+    slug: string
+    supertitle?: string
+}
+
+/**
+ * A chart bullet under a sidebar section. `anchorId` ("chart-<slug>", "-2", …
+ * for repeats) matches the `id` rendered on the chart wrapper.
+ */
+export type TocChartEntry =
+    | {
+          kind: "chart"
+          url: string
+          anchorId: string
+          visibility?: BlockVisibility
+      }
+    | { kind: "narrative-chart"; name: string; anchorId: string }
+
+/** One H1 section plus the chart bullets that belong to it. */
+export interface TocSidebarSection {
+    heading: TocHeadingItem
+    charts: TocChartEntry[]
+}
+
+/**
+ * The table of contents stored on a gdoc's content, tailored to the one TOC
+ * consumer the page has (if any):
+ *
+ * - `"sidebar"` — the topic-page / profile sidebar and the `ltp-toc`
+ *   "Sections" block: H1 sections carrying their chart bullets.
+ * - `"inline"` — the `sdg-toc` block's `<details>` list of H2/H3 headings.
+ *
+ * Pages with no TOC consumer store no `toc` at all.
+ */
+export type Toc =
+    | { kind: "sidebar"; sections: TocSidebarSection[] }
+    | { kind: "inline"; headings: TocHeadingItem[] }

--- a/packages/@ourworldindata/types/src/domainTypes/Toc.ts
+++ b/packages/@ourworldindata/types/src/domainTypes/Toc.ts
@@ -7,11 +7,6 @@ export interface TocHeading {
     isSubheading: boolean
 }
 
-export interface TocHeadingWithTitleSupertitle extends TocHeading {
-    title: string
-    supertitle?: string
-}
-
 /** A heading entry in a {@link Toc}. */
 export interface TocHeadingItem {
     level: EnrichedBlockHeading["level"]

--- a/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
@@ -4,7 +4,7 @@ import {
     RelatedChart,
 } from "../grapherTypes/GrapherTypes.js"
 import { BreadcrumbItem } from "../domainTypes/Site.js"
-import { TocHeadingWithTitleSupertitle } from "../domainTypes/Toc.js"
+import { Toc } from "../domainTypes/Toc.js"
 import { ImageMetadata } from "./Image.js"
 import {
     EnrichedBlockSocials,
@@ -287,7 +287,7 @@ export interface OwidGdocProfileContent {
     excerpt?: string
     "featured-image"?: string
     "sidebar-toc"?: boolean
-    toc?: TocHeadingWithTitleSupertitle[]
+    toc?: Toc
     body: OwidEnrichedGdocBlock[]
     refs?: { definitions: RefDictionary; errors: OwidGdocErrorMessage[] }
     instantiatedEntity?: OwidGdocProfileEntitySummary
@@ -499,7 +499,7 @@ export interface OwidGdocPostContent {
     "latest-feed-featured-image"?: string
     "latest-feed-excerpt"?: EnrichedBlockText[]
     "hide-citation"?: boolean
-    toc?: TocHeadingWithTitleSupertitle[]
+    toc?: Toc
     "cover-image"?: string
     "featured-image"?: string
     "atom-title"?: string

--- a/packages/@ourworldindata/types/src/gdocTypes/archieMLComponents/Chart.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/archieMLComponents/Chart.ts
@@ -30,4 +30,7 @@ export type EnrichedBlockChart = {
     caption?: Span[]
     visibility?: BlockVisibility
     peerCountries?: PeerCountryStrategyQueryParam
+    // TOC anchor id (e.g. "chart-life-expectancy"), assigned by
+    // generateSidebarToc and rendered as the chart wrapper's `id`
+    anchorId?: string
 } & EnrichedBlockWithParseErrors

--- a/packages/@ourworldindata/types/src/gdocTypes/archieMLComponents/NarrativeChart.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/archieMLComponents/NarrativeChart.ts
@@ -21,4 +21,7 @@ export type EnrichedBlockNarrativeChart = {
     height?: string
     size: BlockSize
     caption?: Span[]
+    // TOC anchor id (e.g. "chart-population-by-age"), assigned by
+    // generateSidebarToc and rendered as the chart wrapper's `id`
+    anchorId?: string
 } & EnrichedBlockWithParseErrors

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -43,6 +43,10 @@ export { type IndexPost, type FullPost } from "./domainTypes/Posts.js"
 export {
     type TocHeading,
     type TocHeadingWithTitleSupertitle,
+    type TocHeadingItem,
+    type TocChartEntry,
+    type TocSidebarSection,
+    type Toc,
 } from "./domainTypes/Toc.js"
 
 export {

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -42,7 +42,6 @@ export { type IndexPost, type FullPost } from "./domainTypes/Posts.js"
 
 export {
     type TocHeading,
-    type TocHeadingWithTitleSupertitle,
     type TocHeadingItem,
     type TocChartEntry,
     type TocSidebarSection,

--- a/packages/@ourworldindata/utils/src/Util.test.ts
+++ b/packages/@ourworldindata/utils/src/Util.test.ts
@@ -33,11 +33,13 @@ import {
     normaliseToSingleDigitNumber,
     getUniqueNamesFromTagHierarchies,
     stripOuterParentheses,
+    convertHeadingToId,
 } from "./Util.js"
 import {
     BlockSize,
     OwidEnrichedGdocBlock,
     SortOrder,
+    Span,
     TagGraphRoot,
 } from "@ourworldindata/types"
 
@@ -1083,5 +1085,45 @@ describe(stripOuterParentheses, () => {
 
     it("trims whitespace before checking for parentheses", () => {
         expect(stripOuterParentheses("   (trimmed)   ")).toBe("trimmed")
+    })
+})
+
+describe(convertHeadingToId, () => {
+    const span = (text: string): Span => ({
+        spanType: "span-simple-text",
+        text,
+    })
+
+    it("slugs an H1 from its text only, ignoring any supertitle", () => {
+        expect(
+            convertHeadingToId({
+                level: 1,
+                text: [span("Life expectancy")],
+                supertitle: [span("Ignored")],
+            })
+        ).toBe("life-expectancy")
+    })
+
+    it("folds the supertitle into an H2/H3 id (matching the rendered heading)", () => {
+        expect(
+            convertHeadingToId({
+                level: 2,
+                text: [span("Title")],
+                supertitle: [span("Super")],
+            })
+        ).toBe("super-title")
+        expect(
+            convertHeadingToId({
+                level: 3,
+                text: [span("Title")],
+                supertitle: [span("Super")],
+            })
+        ).toBe("super-title")
+    })
+
+    it("slugs a supertitle-less heading from its text", () => {
+        expect(
+            convertHeadingToId({ level: 2, text: [span("By country")] })
+        ).toBe("by-country")
     })
 })

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -4,6 +4,7 @@ import { extent } from "d3-array"
 import dayjs from "./dayjs.js"
 import { formatLocale, FormatLocaleObject } from "d3-format"
 import striptags from "striptags"
+import urlSlug from "url-slug"
 import {
     type Integer,
     IDEAL_PLOT_ASPECT_RATIO,
@@ -43,18 +44,12 @@ import {
     OwidGdocHomepageInterface,
     PrimitiveType,
     GrapherTrendArrowDirection,
-    TocHeadingWithTitleSupertitle,
-    ALL_CHARTS_ID,
-    FEATURED_DATA_INSIGHTS_ID,
-    EXPLORE_DATA_SECTION_DEFAULT_TITLE,
-    EXPLORE_DATA_SECTION_ID,
     CHRONOLOGICAL_INDEX_TYPES,
     LATEST_FEED_TYPES,
 } from "@ourworldindata/types"
 import { Point, PointVector } from "./PointVector.js"
 import * as React from "react"
 import { match, P } from "ts-pattern"
-import urlSlug from "url-slug"
 
 export type NoUndefinedValues<T> = {
     [P in keyof T]: Required<NonNullable<T[P]>>
@@ -1826,75 +1821,24 @@ export function spansToUnformattedPlainText(spans: Span[]): string {
         .join("")
 }
 
-export function generateToc(
-    body: OwidEnrichedGdocBlock[] | undefined,
-    isTocForLinearTopicPage: boolean = false
-): TocHeadingWithTitleSupertitle[] {
-    if (!body) return []
-
-    // For linear topic pages, we record only h1s
-    // For the sdg-toc, we record h2s & h3s (as it was developed before we decided to use h1s as our top level heading)
-    // It would be nice to standardise this but it would require a migration, updating CSS, updating Gdocs, etc.
-    const [primary, secondary] = isTocForLinearTopicPage
-        ? [1, undefined]
-        : [2, 3]
-    const toc: TocHeadingWithTitleSupertitle[] = []
-
-    body.forEach((block) =>
-        traverseEnrichedBlock(block, (child) => {
-            if (child.type === "heading") {
-                const { level, text, supertitle } = child
-                const titleString = spansToUnformattedPlainText(text)
-                const supertitleString = supertitle
-                    ? spansToUnformattedPlainText(supertitle)
-                    : ""
-                if (titleString && (level === primary || level === secondary)) {
-                    toc.push({
-                        title: titleString,
-                        supertitle: supertitleString,
-                        text: titleString,
-                        slug: urlSlug(`${supertitleString} ${titleString}`),
-                        isSubheading: level === secondary,
-                    })
-                }
-            }
-            if (!isTocForLinearTopicPage) return
-
-            if (child.type === "all-charts") {
-                toc.push({
-                    title: child.heading,
-                    text: child.heading,
-                    slug: ALL_CHARTS_ID,
-                    isSubheading: false,
-                })
-                return
-            }
-
-            if (child.type === "featured-data-insights") {
-                const title = "Data insights"
-                toc.push({
-                    title,
-                    text: title,
-                    slug: FEATURED_DATA_INSIGHTS_ID,
-                    isSubheading: false,
-                })
-                return
-            }
-
-            if (child.type === "explore-data-section") {
-                const title = child.title || EXPLORE_DATA_SECTION_DEFAULT_TITLE
-                toc.push({
-                    title,
-                    text: title,
-                    slug: EXPLORE_DATA_SECTION_ID,
-                    isSubheading: false,
-                })
-                return
-            }
-        })
-    )
-
-    return toc
+/**
+ * The canonical heading-text → anchor-`id` rule, shared by the renderer
+ * (ArticleBlock's <h1>–<h5>) and the TOC generators (generateToc.ts), so the
+ * ids the TOC links to can never drift from the ids that get rendered.
+ *
+ * H2/H3 fold their supertitle into the id; other headings are text-only.
+ */
+export function convertHeadingToId(heading: {
+    text: Span[]
+    supertitle?: Span[]
+    level: number
+}): string {
+    const text = spansToUnformattedPlainText(heading.text)
+    if ((heading.level === 2 || heading.level === 3) && heading.supertitle) {
+        const supertitle = spansToUnformattedPlainText(heading.supertitle)
+        return urlSlug(`${supertitle}-${text}`)
+    }
+    return urlSlug(text)
 }
 
 export function checkIsOwidGdocType(

--- a/packages/@ourworldindata/utils/src/generateToc.test.ts
+++ b/packages/@ourworldindata/utils/src/generateToc.test.ts
@@ -1,0 +1,458 @@
+import { expect, it, describe } from "vitest"
+import { generateSidebarToc, generateInlineToc } from "./generateToc.js"
+import {
+    BlockSize,
+    EnrichedBlockChart,
+    EnrichedBlockHeading,
+    EnrichedBlockNarrativeChart,
+    EXPLORE_DATA_SECTION_ID,
+    FEATURED_DATA_INSIGHTS_ID,
+    OwidEnrichedGdocBlock,
+    Span,
+} from "@ourworldindata/types"
+
+const span = (text: string): Span => ({
+    spanType: "span-simple-text",
+    text,
+})
+const heading = (
+    level: number,
+    text: string,
+    supertitle?: string
+): EnrichedBlockHeading => ({
+    type: "heading",
+    level,
+    text: [span(text)],
+    ...(supertitle ? { supertitle: [span(supertitle)] } : {}),
+    parseErrors: [],
+})
+const chart = (
+    url: string,
+    visibility?: EnrichedBlockChart["visibility"]
+): EnrichedBlockChart => ({
+    type: "chart",
+    url,
+    size: BlockSize.Wide,
+    ...(visibility ? { visibility } : {}),
+    parseErrors: [],
+})
+const narrativeChart = (name: string): EnrichedBlockNarrativeChart => ({
+    type: "narrative-chart",
+    name,
+    size: BlockSize.Wide,
+    parseErrors: [],
+})
+
+describe(generateSidebarToc, () => {
+    it("groups chart bullets under their H1 section and drops sub-H1 headings", () => {
+        const sections = generateSidebarToc([
+            heading(1, "Life expectancy"),
+            chart("https://ourworldindata.org/grapher/life-expectancy"),
+            heading(2, "By country"),
+        ])
+        expect(sections).toEqual([
+            {
+                heading: {
+                    level: 1,
+                    text: "Life expectancy",
+                    slug: "life-expectancy",
+                },
+                charts: [
+                    {
+                        kind: "chart",
+                        url: "https://ourworldindata.org/grapher/life-expectancy",
+                        anchorId: "chart-life-expectancy",
+                    },
+                ],
+            },
+        ])
+    })
+
+    it("slugs an H1 section from its text only (matching the rendered <h1> id) and keeps the supertitle as a field", () => {
+        // A rendered <h1>'s id is text only, so the section slug must not fold
+        // in the supertitle or the link would target a nonexistent anchor.
+        const [section] = generateSidebarToc([heading(1, "Title", "Super")])
+        expect(section.heading).toEqual({
+            level: 1,
+            text: "Title",
+            slug: "title",
+            supertitle: "Super",
+        })
+    })
+
+    it("disambiguates the same chart across non-adjacent sections", () => {
+        const first = chart("https://ourworldindata.org/grapher/median-age")
+        const second = chart("https://ourworldindata.org/grapher/median-age")
+        const sections = generateSidebarToc([
+            heading(1, "A"),
+            first,
+            heading(1, "B"),
+            second,
+        ])
+        expect(first.anchorId).toBe("chart-median-age")
+        expect(second.anchorId).toBe("chart-median-age-2")
+        expect(sections[0].charts.map((c) => c.anchorId)).toEqual([
+            "chart-median-age",
+        ])
+        expect(sections[1].charts.map((c) => c.anchorId)).toEqual([
+            "chart-median-age-2",
+        ])
+    })
+
+    it("collapses adjacent duplicate charts to one bullet but keeps distinct anchors", () => {
+        const first = chart("https://ourworldindata.org/grapher/foo")
+        const second = chart("https://ourworldindata.org/grapher/foo")
+        const [section] = generateSidebarToc([heading(1, "A"), first, second])
+        // Both blocks get unique anchors (HTML uniqueness) ...
+        expect(first.anchorId).toBe("chart-foo")
+        expect(second.anchorId).toBe("chart-foo-2")
+        // ... but only the first becomes a bullet.
+        expect(section.charts).toHaveLength(1)
+    })
+
+    it("keeps adjacent responsive chart variants as separate bullets", () => {
+        const desktop = chart(
+            "https://ourworldindata.org/grapher/population",
+            "desktop"
+        )
+        const mobile = chart(
+            "https://ourworldindata.org/grapher/population",
+            "mobile"
+        )
+        const [section] = generateSidebarToc([heading(1, "A"), desktop, mobile])
+        expect(desktop.anchorId).toBe("chart-population")
+        expect(mobile.anchorId).toBe("chart-population-2")
+        expect(section.charts).toEqual([
+            {
+                kind: "chart",
+                url: "https://ourworldindata.org/grapher/population",
+                anchorId: "chart-population",
+                visibility: "desktop",
+            },
+            {
+                kind: "chart",
+                url: "https://ourworldindata.org/grapher/population",
+                anchorId: "chart-population-2",
+                visibility: "mobile",
+            },
+        ])
+    })
+
+    it("collapses a duplicate chart separated by non-heading content (only headings reset the run)", () => {
+        const first = chart("https://ourworldindata.org/grapher/foo")
+        const second = chart("https://ourworldindata.org/grapher/foo")
+        const paragraph: OwidEnrichedGdocBlock = {
+            type: "text",
+            value: [span("A paragraph between the two charts")],
+            parseErrors: [],
+        }
+        const [section] = generateSidebarToc([
+            heading(1, "A"),
+            first,
+            paragraph,
+            second,
+        ])
+        // Both still get unique anchors ...
+        expect(first.anchorId).toBe("chart-foo")
+        expect(second.anchorId).toBe("chart-foo-2")
+        // ... but the paragraph doesn't reset the run, so it stays one bullet.
+        expect(section.charts).toHaveLength(1)
+    })
+
+    it("keeps charts under their H1 across an intervening sub-heading", () => {
+        const sections = generateSidebarToc([
+            heading(1, "Section"),
+            chart("https://ourworldindata.org/grapher/a"),
+            heading(2, "Subsection"),
+            chart("https://ourworldindata.org/grapher/b"),
+        ])
+        expect(sections).toHaveLength(1)
+        expect(sections[0].charts.map((c) => c.anchorId)).toEqual([
+            "chart-a",
+            "chart-b",
+        ])
+    })
+
+    it("re-emits an identical chart that recurs after a sub-heading", () => {
+        // The sub-heading resets adjacent-dup tracking even though it isn't
+        // surfaced, so the second occurrence is a distinct bullet.
+        const first = chart("https://ourworldindata.org/grapher/a")
+        const second = chart("https://ourworldindata.org/grapher/a")
+        const [section] = generateSidebarToc([
+            heading(1, "Section"),
+            first,
+            heading(2, "Subsection"),
+            second,
+        ])
+        expect(first.anchorId).toBe("chart-a")
+        expect(second.anchorId).toBe("chart-a-2")
+        expect(section.charts.map((c) => c.anchorId)).toEqual([
+            "chart-a",
+            "chart-a-2",
+        ])
+    })
+
+    it("namespaces chart anchors so they can't collide with heading slugs", () => {
+        const fooChart = chart("https://ourworldindata.org/grapher/foo")
+        const [section] = generateSidebarToc([heading(1, "Foo"), fooChart])
+        expect(section.heading.slug).toBe("foo")
+        expect(fooChart.anchorId).toBe("chart-foo")
+        expect(section.charts[0].anchorId).toBe("chart-foo")
+    })
+
+    it("skips the all-charts block itself but not the content around it", () => {
+        const sections = generateSidebarToc([
+            heading(1, "Section"),
+            {
+                type: "all-charts",
+                heading: "Interactive charts on X",
+                top: [],
+                parseErrors: [],
+            },
+            chart("https://ourworldindata.org/grapher/after"),
+        ])
+        expect(sections).toHaveLength(1)
+        expect(sections[0].charts).toEqual([
+            {
+                kind: "chart",
+                url: "https://ourworldindata.org/grapher/after",
+                anchorId: "chart-after",
+            },
+        ])
+    })
+
+    it("opens synthetic H1 sections for featured-data-insights and explore-data-section, and excludes all-charts", () => {
+        const sections = generateSidebarToc([
+            {
+                type: "all-charts",
+                heading: "Interactive charts on X",
+                top: [],
+                parseErrors: [],
+            },
+            { type: "featured-data-insights", parseErrors: [] },
+            {
+                type: "explore-data-section",
+                title: "Explore the data",
+                align: "left",
+                content: [],
+                parseErrors: [],
+            },
+        ])
+        expect(sections.map((s) => s.heading)).toEqual([
+            {
+                level: 1,
+                text: "Data insights",
+                slug: FEATURED_DATA_INSIGHTS_ID,
+            },
+            {
+                level: 1,
+                text: "Explore the data",
+                slug: EXPLORE_DATA_SECTION_ID,
+            },
+        ])
+    })
+
+    it("skips featured-metrics entirely", () => {
+        const sections = generateSidebarToc([
+            heading(1, "Section"),
+            { type: "featured-metrics", parseErrors: [] },
+        ])
+        expect(sections).toHaveLength(1)
+        expect(sections[0].charts).toEqual([])
+    })
+
+    it("includes charts nested inside container blocks", () => {
+        const nestedChart = chart("https://ourworldindata.org/grapher/nested")
+        const keyInsightChart = chart(
+            "https://ourworldindata.org/grapher/insight"
+        )
+        const stickyRight: OwidEnrichedGdocBlock = {
+            type: "sticky-right",
+            left: [nestedChart],
+            right: [],
+            parseErrors: [],
+        }
+        const keyInsights: OwidEnrichedGdocBlock = {
+            type: "key-insights",
+            heading: "Key insights",
+            insights: [
+                {
+                    type: "key-insight-slide",
+                    title: "Slide",
+                    content: [keyInsightChart],
+                },
+            ],
+            parseErrors: [],
+        }
+        const [section] = generateSidebarToc([
+            heading(1, "Section"),
+            stickyRight,
+            keyInsights,
+        ])
+        expect(nestedChart.anchorId).toBe("chart-nested")
+        expect(keyInsightChart.anchorId).toBe("chart-insight")
+        expect(section.charts).toEqual([
+            {
+                kind: "chart",
+                url: "https://ourworldindata.org/grapher/nested",
+                anchorId: "chart-nested",
+            },
+            {
+                kind: "chart",
+                url: "https://ourworldindata.org/grapher/insight",
+                anchorId: "chart-insight",
+            },
+        ])
+    })
+
+    it("includes narrative-chart bullets with a namespaced anchor", () => {
+        const nc = narrativeChart("Population by age")
+        const [section] = generateSidebarToc([heading(1, "Section"), nc])
+        expect(nc.anchorId).toBe("chart-population-by-age")
+        expect(section.charts[0]).toEqual({
+            kind: "narrative-chart",
+            name: "Population by age",
+            anchorId: "chart-population-by-age",
+        })
+    })
+
+    it("drops charts that precede the first H1 but still assigns their anchorId", () => {
+        const orphan = chart("https://ourworldindata.org/grapher/orphan")
+        const sections = generateSidebarToc([
+            orphan,
+            heading(1, "Section"),
+            chart("https://ourworldindata.org/grapher/a"),
+        ])
+        // The orphan still gets an anchorId (for HTML uniqueness) ...
+        expect(orphan.anchorId).toBe("chart-orphan")
+        // ... but has no parent section, so it isn't a bullet.
+        expect(sections).toHaveLength(1)
+        expect(sections[0].charts.map((c) => c.anchorId)).toEqual(["chart-a"])
+    })
+
+    it("returns no sections when there are no H1s", () => {
+        expect(
+            generateSidebarToc([
+                heading(2, "Just a subsection"),
+                chart("https://ourworldindata.org/grapher/a"),
+            ])
+        ).toEqual([])
+    })
+
+    it("emits a bullet for an explorer URL, anchored by its slug", () => {
+        // Explorers embed via the same chart block.
+        const c = chart("https://ourworldindata.org/explorers/co2")
+        const [section] = generateSidebarToc([heading(1, "Emissions"), c])
+        expect(c.anchorId).toBe("chart-co2")
+        expect(section.charts[0]).toEqual({
+            kind: "chart",
+            url: "https://ourworldindata.org/explorers/co2",
+            anchorId: "chart-co2",
+        })
+    })
+
+    it("treats a multi-dim /grapher URL like any chart (mdim-ness is resolved at render, invisible here)", () => {
+        const c = chart("https://ourworldindata.org/grapher/education-spending")
+        const [section] = generateSidebarToc([heading(1, "Education"), c])
+        expect(c.anchorId).toBe("chart-education-spending")
+        expect(section.charts[0].anchorId).toBe("chart-education-spending")
+    })
+
+    it("collapses adjacent same-slug charts even when query params differ (dedup is slug-only)", () => {
+        const first = chart("https://ourworldindata.org/grapher/foo?tab=map")
+        const second = chart("https://ourworldindata.org/grapher/foo?tab=table")
+        const [section] = generateSidebarToc([heading(1, "A"), first, second])
+        expect(first.anchorId).toBe("chart-foo")
+        expect(second.anchorId).toBe("chart-foo-2")
+        expect(section.charts).toHaveLength(1)
+    })
+
+    it("re-emits a same-slug chart with different query params when a different chart breaks the run (anchors stay query-blind)", () => {
+        const first = chart(
+            "https://ourworldindata.org/grapher/life-expectancy?tab=map"
+        )
+        const middle = chart("https://ourworldindata.org/grapher/gdp")
+        const second = chart(
+            "https://ourworldindata.org/grapher/life-expectancy?tab=table"
+        )
+        const [section] = generateSidebarToc([
+            heading(1, "A"),
+            first,
+            middle,
+            second,
+        ])
+        expect(first.anchorId).toBe("chart-life-expectancy")
+        expect(second.anchorId).toBe("chart-life-expectancy-2")
+        // Two life-expectancy bullets with identical labels at different anchors.
+        expect(section.charts.map((c) => c.anchorId)).toEqual([
+            "chart-life-expectancy",
+            "chart-gdp",
+            "chart-life-expectancy-2",
+        ])
+    })
+})
+
+describe(generateInlineToc, () => {
+    it("lists only sub-H1 headings, in document order", () => {
+        const headings = generateInlineToc([
+            heading(1, "Top"),
+            heading(2, "Two"),
+            heading(3, "Three"),
+            heading(2, "Two b"),
+        ])
+        expect(headings).toEqual([
+            { level: 2, text: "Two", slug: "two" },
+            { level: 3, text: "Three", slug: "three" },
+            { level: 2, text: "Two b", slug: "two-b" },
+        ])
+    })
+
+    it("preserves a heading's supertitle in the slug and entry", () => {
+        const [entry] = generateInlineToc([heading(2, "Title", "Super")])
+        expect(entry).toEqual({
+            level: 2,
+            text: "Title",
+            slug: "super-title",
+            supertitle: "Super",
+        })
+    })
+
+    it("surfaces only H2 and H3 — H1 and H4+ are excluded", () => {
+        const headings = generateInlineToc([
+            heading(1, "One"),
+            heading(2, "Two"),
+            heading(3, "Three"),
+            heading(4, "Four"),
+            heading(5, "Five"),
+        ])
+        expect(headings.map((h) => h.text)).toEqual(["Two", "Three"])
+    })
+
+    it("ignores charts entirely — no entry and no anchorId mutation", () => {
+        const c = chart("https://ourworldindata.org/grapher/foo")
+        const nc = narrativeChart("Some chart")
+        const headings = generateInlineToc([heading(2, "Section"), c, nc])
+        expect(headings).toEqual([
+            { level: 2, text: "Section", slug: "section" },
+        ])
+        expect(c.anchorId).toBeUndefined()
+        expect(nc.anchorId).toBeUndefined()
+    })
+
+    it("ignores featured-data-insights and explore-data-section", () => {
+        const headings = generateInlineToc([
+            { type: "featured-data-insights", parseErrors: [] },
+            {
+                type: "explore-data-section",
+                title: "Explore the data",
+                align: "left",
+                content: [],
+                parseErrors: [],
+            },
+            heading(2, "Section"),
+        ])
+        expect(headings).toEqual([
+            { level: 2, text: "Section", slug: "section" },
+        ])
+    })
+})

--- a/packages/@ourworldindata/utils/src/generateToc.ts
+++ b/packages/@ourworldindata/utils/src/generateToc.ts
@@ -1,0 +1,207 @@
+import urlSlug from "url-slug"
+import {
+    OwidEnrichedGdocBlock,
+    EnrichedBlockHeading,
+    TocHeadingItem,
+    TocSidebarSection,
+    TocChartEntry,
+    Toc,
+    FEATURED_DATA_INSIGHTS_ID,
+    EXPLORE_DATA_SECTION_ID,
+    EXPLORE_DATA_SECTION_DEFAULT_TITLE,
+} from "@ourworldindata/types"
+import {
+    traverseEnrichedBlock,
+    spansToUnformattedPlainText,
+    convertHeadingToId,
+} from "./Util.js"
+import { Url } from "./urls/Url.js"
+
+/** Does `body` (recursively) contain a block of the given type? */
+function bodyContainsBlockType(
+    body: OwidEnrichedGdocBlock[] | undefined,
+    type: OwidEnrichedGdocBlock["type"]
+): boolean {
+    let found = false
+    body?.forEach((block) =>
+        traverseEnrichedBlock(block, (node) => {
+            if (node.type === type) found = true
+        })
+    )
+    return found
+}
+
+/** Build a heading entry from a heading block, or undefined when it has no text. */
+function headingItem(
+    heading: EnrichedBlockHeading
+): TocHeadingItem | undefined {
+    const text = spansToUnformattedPlainText(heading.text)
+    if (!text) return undefined
+    const supertitle = heading.supertitle
+        ? spansToUnformattedPlainText(heading.supertitle)
+        : ""
+    return {
+        level: heading.level,
+        text,
+        // The same rule ArticleBlock uses for the rendered heading id, so TOC
+        // links always resolve to a real anchor.
+        slug: convertHeadingToId(heading),
+        ...(supertitle ? { supertitle } : {}),
+    }
+}
+
+/**
+ * Build the sidebar table of contents: H1 sections (plus synthetic ones for
+ * featured-data-insights and explore-data-section), each carrying the chart /
+ * narrative-chart bullets that appear under it in document order, including
+ * charts nested inside container blocks. Used by the topic-page / profile
+ * sidebar and the `ltp-toc` "Sections" block.
+ *
+ * Side effect: mutates every chart / narrative-chart block with a unique,
+ * namespaced `anchorId` ("chart-foo", "chart-foo-2", …) rendered as the `id`
+ * on the chart wrapper. Dedup is by base slug (URL path only, query params
+ * ignored) plus visibility: a chart repeated since the last heading collapses
+ * to one bullet unless the duplicate is a responsive variant.
+ * Charts before the first H1 have no section and produce no bullet.
+ */
+export function generateSidebarToc(
+    body: OwidEnrichedGdocBlock[] | undefined
+): TocSidebarSection[] {
+    if (!body) return []
+
+    const sections: TocSidebarSection[] = []
+    const anchorCounts = new Map<string, number>()
+    // Dedup key of the most recently emitted bullet; any heading resets it.
+    let lastEmittedChartKey: string | undefined
+
+    const openSection = (heading: TocHeadingItem): void => {
+        lastEmittedChartKey = undefined
+        sections.push({ heading, charts: [] })
+    }
+
+    const assignAnchorId = (baseSlug: string): string => {
+        const namespaced = `chart-${baseSlug}`
+        const count = (anchorCounts.get(namespaced) ?? 0) + 1
+        anchorCounts.set(namespaced, count)
+        return count === 1 ? namespaced : `${namespaced}-${count}`
+    }
+
+    const chartDedupKey = (
+        baseSlug: string,
+        visibility: Extract<TocChartEntry, { kind: "chart" }>["visibility"]
+    ): string => `chart:${baseSlug}:${visibility ?? "all"}`
+
+    // Add a bullet to the open section, suppressing consecutive duplicates.
+    const addBulletIfUnique = (
+        dedupKey: string,
+        entry: TocChartEntry
+    ): void => {
+        if (dedupKey === lastEmittedChartKey) return
+        lastEmittedChartKey = dedupKey
+        sections.at(-1)?.charts.push(entry)
+    }
+
+    body.forEach((block) =>
+        traverseEnrichedBlock(block, (node) => {
+            if (node.type === "heading") {
+                // Any heading resets dup tracking, even the sub-H1 headings
+                // the sidebar doesn't surface.
+                lastEmittedChartKey = undefined
+                if (node.level !== 1) return
+                const heading = headingItem(node)
+                if (heading) openSection(heading)
+                return
+            }
+            if (node.type === "featured-data-insights") {
+                openSection({
+                    level: 1,
+                    text: "Data insights",
+                    slug: FEATURED_DATA_INSIGHTS_ID,
+                })
+                return
+            }
+            if (node.type === "explore-data-section") {
+                openSection({
+                    level: 1,
+                    text: node.title || EXPLORE_DATA_SECTION_DEFAULT_TITLE,
+                    slug: EXPLORE_DATA_SECTION_ID,
+                })
+                return
+            }
+            if (node.type === "chart") {
+                const baseSlug = Url.fromURL(node.url).slug
+                if (!baseSlug) return
+                node.anchorId = assignAnchorId(baseSlug)
+                addBulletIfUnique(chartDedupKey(baseSlug, node.visibility), {
+                    kind: "chart",
+                    url: node.url,
+                    anchorId: node.anchorId,
+                    ...(node.visibility ? { visibility: node.visibility } : {}),
+                })
+                return
+            }
+            if (node.type === "narrative-chart") {
+                const baseSlug = urlSlug(node.name)
+                if (!baseSlug) return
+                node.anchorId = assignAnchorId(baseSlug)
+                addBulletIfUnique(`narrative-chart:${baseSlug}`, {
+                    kind: "narrative-chart",
+                    name: node.name,
+                    anchorId: node.anchorId,
+                })
+                return
+            }
+        })
+    )
+
+    return sections
+}
+
+/**
+ * Build the inline `<details>` table of contents (the `sdg-toc` block): the H2
+ * and H3 headings in document order. The inline list styles exactly two levels
+ * (H3 renders as a sub-item), so H4+ are not surfaced.
+ */
+export function generateInlineToc(
+    body: OwidEnrichedGdocBlock[] | undefined
+): TocHeadingItem[] {
+    if (!body) return []
+
+    const headings: TocHeadingItem[] = []
+    body.forEach((block) =>
+        traverseEnrichedBlock(block, (node) => {
+            if (node.type !== "heading" || node.level < 2 || node.level > 3)
+                return
+            const heading = headingItem(node)
+            if (heading) headings.push(heading)
+        })
+    )
+    return headings
+}
+
+/**
+ * Decide the single TOC a page renders (if any) and build it, tailored to that
+ * consumer — the one source of truth for the gating rule, shared by the
+ * enrichment paths (GdocPost, GdocProfile) and the migration:
+ *
+ *  - `sidebar-toc` flag OR an `ltp-toc` block → `{ kind: "sidebar", sections }`
+ *  - an `sdg-toc` block                        → `{ kind: "inline", headings }`
+ *  - neither                                    → `undefined` (no toc)
+ *
+ * Only the sidebar branch assigns chart `anchorId`s, so callers must pass a
+ * body without stale ones — true of all current callers, which work on freshly
+ * parsed or instantiated bodies.
+ */
+export function generateToc(content: {
+    body?: OwidEnrichedGdocBlock[]
+    "sidebar-toc"?: boolean
+}): Toc | undefined {
+    const { body } = content
+    if (content["sidebar-toc"] || bodyContainsBlockType(body, "ltp-toc")) {
+        return { kind: "sidebar", sections: generateSidebarToc(body) }
+    }
+    if (bodyContainsBlockType(body, "sdg-toc")) {
+        return { kind: "inline", headings: generateInlineToc(body) }
+    }
+    return undefined
+}

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -92,10 +92,10 @@ export {
     recursivelyMapArticleContent,
     traverseEnrichedBlock,
     checkNodeIsSpan,
-    generateToc,
     extractLinksFromMarkdown,
     getPaginationPageNumbers,
     spansToUnformattedPlainText,
+    convertHeadingToId,
     checkIsOwidGdocType,
     isArrayOfNumbers,
     greatestCommonDivisor,
@@ -141,6 +141,8 @@ export {
     stripOuterParentheses,
     dimensionsToViewId,
 } from "./Util.js"
+
+export { generateToc } from "./generateToc.js"
 
 export {
     getOriginAttributionFragments,

--- a/site/gdocs/components/ArticleBlock.tsx
+++ b/site/gdocs/components/ArticleBlock.tsx
@@ -19,13 +19,14 @@ import {
     EXPERIMENT_PREFIX,
     OwidEnrichedGdocBlock,
     spansToUnformattedPlainText,
-    TocHeadingWithTitleSupertitle,
+    convertHeadingToId,
+    Toc,
     Url,
     defaultExperimentState,
     getExperimentState,
     ExperimentState,
 } from "@ourworldindata/utils"
-import { CodeSnippet, convertHeadingTextToId } from "@ourworldindata/components"
+import { CodeSnippet } from "@ourworldindata/components"
 import SDGGrid from "./SDGGrid.js"
 import { BlockErrorBoundary, BlockErrorFallback } from "./BlockErrorBoundary.js"
 import { match } from "ts-pattern"
@@ -33,7 +34,6 @@ import SpanElements from "./SpanElements.js"
 import Paragraph from "./Paragraph.js"
 import People from "./People.js"
 import InlineTableOfContents from "./InlineTableOfContents.js"
-import urlSlug from "url-slug"
 import { MissingData } from "./MissingData.js"
 import { AdditionalCharts } from "./AdditionalCharts.js"
 import { ProminentLink } from "./ProminentLink.js"
@@ -80,7 +80,7 @@ function ArticleBlockInternal({
 }: {
     b: OwidEnrichedGdocBlock
     containerType?: Container
-    toc?: TocHeadingWithTitleSupertitle[]
+    toc?: Toc
     shouldRenderLinks?: boolean
     interactiveImages?: boolean
 }) {
@@ -231,6 +231,7 @@ function ArticleBlockInternal({
                         }
                     )}
                     d={block}
+                    id={block.anchorId}
                     fullWidthOnMobile={true}
                 />
             )
@@ -244,6 +245,7 @@ function ArticleBlockInternal({
                         getLayout(`chart--${size}`, containerType)
                     )}
                     d={block}
+                    id={block.anchorId}
                     fullWidthOnMobile={true}
                 />
             )
@@ -400,36 +402,29 @@ function ArticleBlockInternal({
             )
         })
         .with({ type: "simple-text" }, (block) => <>{block.value.text}</>)
-        .with({ type: "heading", level: 1 }, (block) => (
-            <h1
-                className={cx(
-                    "h1-semibold",
-                    getLayout("heading", containerType)
-                )}
-                id={convertHeadingTextToId(block.text)}
-            >
-                <SpanElements
-                    spans={block.text}
-                    shouldRenderLinks={shouldRenderLinks}
-                />
-                {shouldRenderLinks && (
-                    <a
-                        className="deep-link"
-                        href={`#${convertHeadingTextToId(block.text)}`}
+        .with({ type: "heading", level: 1 }, (block) => {
+            const id = convertHeadingToId(block)
+            return (
+                <h1
+                    className={cx(
+                        "h1-semibold",
+                        getLayout("heading", containerType)
+                    )}
+                    id={id}
+                >
+                    <SpanElements
+                        spans={block.text}
+                        shouldRenderLinks={shouldRenderLinks}
                     />
-                )}
-            </h1>
-        ))
+                    {shouldRenderLinks && (
+                        <a className="deep-link" href={`#${id}`} />
+                    )}
+                </h1>
+            )
+        })
         .with({ type: "heading", level: 2 }, (block) => {
             const { supertitle, text } = block
-
-            const id = supertitle
-                ? urlSlug(
-                      `${spansToUnformattedPlainText(
-                          supertitle
-                      )}-${spansToUnformattedPlainText(text)}`
-                  )
-                : convertHeadingTextToId(block.text)
+            const id = convertHeadingToId(block)
 
             return (
                 <>
@@ -466,13 +461,7 @@ function ArticleBlockInternal({
         })
         .with({ type: "heading", level: 3 }, (block) => {
             const { supertitle, text } = block
-            const id = supertitle
-                ? urlSlug(
-                      `${spansToUnformattedPlainText(
-                          supertitle
-                      )}-${spansToUnformattedPlainText(text)}`
-                  )
-                : convertHeadingTextToId(block.text)
+            const id = convertHeadingToId(block)
             return (
                 <h3
                     className={cx(
@@ -511,7 +500,7 @@ function ArticleBlockInternal({
                     "h4-semibold",
                     getLayout("heading", containerType)
                 )}
-                id={convertHeadingTextToId(block.text)}
+                id={convertHeadingToId(block)}
             >
                 <SpanElements
                     spans={block.text}
@@ -525,7 +514,7 @@ function ArticleBlockInternal({
                     "overline-black-caps",
                     getLayout("heading", containerType)
                 )}
-                id={convertHeadingTextToId(block.text)}
+                id={convertHeadingToId(block)}
             >
                 <SpanElements
                     spans={block.text}
@@ -737,15 +726,19 @@ function ArticleBlockInternal({
             />
         ))
         .with({ type: "sdg-toc" }, () => {
-            return toc ? (
+            if (toc?.kind !== "inline") return null
+
+            return (
                 <InlineTableOfContents
                     toc={toc}
                     title="List of targets and indicators"
                     className={getLayout("toc", containerType)}
                 />
-            ) : null
+            )
         })
         .with({ type: "ltp-toc" }, (block) => {
+            if (toc?.kind !== "sidebar") return null
+
             const layoutClassName = getLayout("ltp-toc", containerType)
             const tagName = tags[0]?.name
 
@@ -762,14 +755,14 @@ function ArticleBlockInternal({
                 )
             }
 
-            return toc?.length ? (
+            return (
                 <LTPTableOfContents
                     title={block.title}
                     toc={toc}
                     tagName={tagName}
                     className={layoutClassName}
                 />
-            ) : null
+            )
         })
         .with({ type: "missing-data" }, () => (
             <MissingData className={getLayout("missing-data", containerType)} />
@@ -1036,7 +1029,7 @@ export default function ArticleBlock({
 }: {
     b: OwidEnrichedGdocBlock
     containerType?: Container
-    toc?: TocHeadingWithTitleSupertitle[]
+    toc?: Toc
     shouldRenderLinks?: boolean
     interactiveImages?: boolean
 }) {

--- a/site/gdocs/components/ArticleBlocks.tsx
+++ b/site/gdocs/components/ArticleBlocks.tsx
@@ -1,10 +1,7 @@
 import ArticleBlock from "./ArticleBlock.js"
 import { injectAutomaticSubscribeBanner } from "./gdocComponentUtils.js"
 import { Container } from "./layout.js"
-import {
-    OwidEnrichedGdocBlock,
-    TocHeadingWithTitleSupertitle,
-} from "@ourworldindata/utils"
+import { OwidEnrichedGdocBlock, Toc } from "@ourworldindata/utils"
 
 /**
  * Renders a list of article blocks.
@@ -26,7 +23,7 @@ export const ArticleBlocks = ({
 }: {
     blocks: OwidEnrichedGdocBlock[]
     containerType?: Container
-    toc?: TocHeadingWithTitleSupertitle[]
+    toc?: Toc
     shouldRenderLinks?: boolean
     interactiveImages?: boolean
     automaticSubscribeBanner?: boolean

--- a/site/gdocs/components/Chart.tsx
+++ b/site/gdocs/components/Chart.tsx
@@ -19,11 +19,14 @@ export default function Chart({
     className,
     fullWidthOnMobile = false,
     hideControls = false,
+    id,
 }: {
     d: EnrichedBlockChart
     className?: string
     fullWidthOnMobile?: boolean
     hideControls?: boolean
+    // TOC anchor id, rendered on the chart wrapper so the sidebar TOC can link to it
+    id?: string
 }) {
     const { isPreviewing, archiveContext } = useDocumentContext()
     const refChartContainer = useRef<HTMLDivElement>(null)
@@ -129,6 +132,7 @@ export default function Chart({
                 : DEFAULT_CHART_HEIGHT
         return (
             <div
+                id={id}
                 className={cx(className, {
                     "full-width-on-mobile":
                         !isExplorerWithControls && fullWidthOnMobile,
@@ -158,6 +162,7 @@ export default function Chart({
 
     return (
         <div
+            id={id}
             className={cx(className, {
                 "full-width-on-mobile":
                     !isExplorerWithControls && fullWidthOnMobile,

--- a/site/gdocs/components/InlineTableOfContents.tsx
+++ b/site/gdocs/components/InlineTableOfContents.tsx
@@ -1,4 +1,4 @@
-import { TocHeadingWithTitleSupertitle } from "@ourworldindata/utils"
+import { Toc } from "@ourworldindata/utils"
 import { faArrowDown, faPlus, faMinus } from "@fortawesome/free-solid-svg-icons"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import cx from "classnames"
@@ -8,10 +8,12 @@ export default function InlineTableOfContents({
     className = "",
     title,
 }: {
-    toc: TocHeadingWithTitleSupertitle[]
+    toc: Extract<Toc, { kind: "inline" }>
     className?: string
     title: string
 }) {
+    const { headings } = toc
+
     return (
         <nav className={cx(className, "inline-toc")}>
             <details className="inline-toc__details-wrapper span-cols-6 span-md-cols-8 span-sm-cols-10">
@@ -31,33 +33,38 @@ export default function InlineTableOfContents({
                 </summary>
                 <div className="inline-toc__content">
                     <ul>
-                        {toc.map(
-                            (
-                                { title, supertitle, isSubheading, slug },
-                                i: number
-                            ) => (
-                                <li
-                                    key={i}
-                                    className={
-                                        isSubheading ? "subsection" : "section"
-                                    }
-                                >
-                                    <a
-                                        href={`#${slug}`}
-                                        data-track-note="toc_link"
+                        {headings.map(
+                            ({ level, slug, supertitle, text }, i: number) => {
+                                const isSubheading = level >= 3
+
+                                return (
+                                    <li
+                                        key={i}
+                                        className={
+                                            isSubheading
+                                                ? "subsection"
+                                                : "section"
+                                        }
                                     >
-                                        {supertitle ? (
-                                            <span className="supertitle">
-                                                {supertitle}
-                                            </span>
-                                        ) : null}
-                                        {title}
-                                    </a>
-                                    {!isSubheading && (
-                                        <FontAwesomeIcon icon={faArrowDown} />
-                                    )}
-                                </li>
-                            )
+                                        <a
+                                            href={`#${slug}`}
+                                            data-track-note="toc_link"
+                                        >
+                                            {supertitle ? (
+                                                <span className="supertitle">
+                                                    {supertitle}
+                                                </span>
+                                            ) : null}
+                                            {text}
+                                        </a>
+                                        {!isSubheading && (
+                                            <FontAwesomeIcon
+                                                icon={faArrowDown}
+                                            />
+                                        )}
+                                    </li>
+                                )
+                            }
                         )}
                     </ul>
                 </div>

--- a/site/gdocs/components/LTPTableOfContents.tsx
+++ b/site/gdocs/components/LTPTableOfContents.tsx
@@ -5,7 +5,7 @@ import {
     faBook,
     faChartSimple,
 } from "@fortawesome/free-solid-svg-icons"
-import { TocHeadingWithTitleSupertitle } from "@ourworldindata/utils"
+import { Toc } from "@ourworldindata/utils"
 import { SearchResultType, SearchState } from "@ourworldindata/types"
 import {
     createTopicFilter,
@@ -32,20 +32,20 @@ const SECONDARY_CARDS = [
     },
 ] as const
 
-type Props = {
-    toc?: TocHeadingWithTitleSupertitle[]
-    className?: string
-    title?: string
-    tagName: string
-}
-
 export const LTPTableOfContents = ({
     toc,
     className,
     title,
     tagName,
-}: Props) => {
-    if (!toc || toc.length === 0) return null
+}: {
+    toc: Extract<Toc, { kind: "sidebar" }>
+    className?: string
+    title?: string
+    tagName: string
+}) => {
+    const headings = toc.sections.map((section) => section.heading)
+
+    if (headings.length === 0) return null
 
     const resolvedTitle = title ?? DEFAULT_TITLE
     const resourceSectionTitle = `All our work on ${tagName}`
@@ -62,9 +62,9 @@ export const LTPTableOfContents = ({
             </p>
             <div className="ltp-toc__primary col-start-2 span-cols-7 col-md-start-1 span-md-cols-8 span-sm-cols-12">
                 <ul className="ltp-toc__primary-list">
-                    {toc.map(({ slug, title: headingTitle, text }) => {
-                        const displayTitle = headingTitle || text
-                        if (!slug || !displayTitle) return null
+                    {headings.map((heading) => {
+                        const { slug, text } = heading
+                        if (!slug || !text) return null
                         return (
                             <li key={slug} className="ltp-toc__primary-item">
                                 <FontAwesomeIcon icon={faArrowDown} />
@@ -73,7 +73,7 @@ export const LTPTableOfContents = ({
                                     className="ltp-toc__primary-link"
                                     data-track-note="toc_link"
                                 >
-                                    {displayTitle}
+                                    {text}
                                 </a>
                             </li>
                         )

--- a/site/gdocs/components/NarrativeChart.tsx
+++ b/site/gdocs/components/NarrativeChart.tsx
@@ -26,10 +26,13 @@ export default function NarrativeChart({
     d,
     className,
     fullWidthOnMobile = false,
+    id,
 }: {
     d: EnrichedBlockNarrativeChart
     className?: string
     fullWidthOnMobile?: boolean
+    // TOC anchor id, rendered on the chart wrapper so the sidebar TOC can link to it
+    id?: string
 }) {
     const refChartContainer = useRef<HTMLDivElement>(null)
     const { isPreviewing, archiveContext } = useDocumentContext()
@@ -78,6 +81,7 @@ export default function NarrativeChart({
 
     return (
         <div
+            id={id}
             className={cx(className, {
                 "full-width-on-mobile": fullWidthOnMobile,
             })}

--- a/site/gdocs/pages/GdocPost.tsx
+++ b/site/gdocs/pages/GdocPost.tsx
@@ -113,9 +113,16 @@ export function GdocPost({
             {isDeprecated && content["deprecation-notice"] && (
                 <DeprecationNotice blocks={content["deprecation-notice"]} />
             )}
-            {hasSidebarToc && content.toc ? (
+            {hasSidebarToc && content.toc?.kind === "sidebar" ? (
                 <SidebarTableOfContents
-                    headings={content.toc}
+                    // Bridge until the sidebar rewrite (PR3): project the
+                    // sidebar sections down to the legacy h1-only TocHeading[]
+                    // shape this sidebar still expects.
+                    headings={content.toc.sections.map((section) => ({
+                        text: section.heading.text,
+                        slug: section.heading.slug,
+                        isSubheading: false,
+                    }))}
                     headingLevels={{ primary: 1, secondary: 2 }}
                     pageTitle={content.title || ""}
                 />

--- a/site/gdocs/pages/Profile.tsx
+++ b/site/gdocs/pages/Profile.tsx
@@ -91,9 +91,16 @@ export function Profile({ content, publishedAt, slug }: ProfileProps) {
                     </a>
                 </div>
             </header>
-            {hasSidebarToc && content.toc ? (
+            {hasSidebarToc && content.toc?.kind === "sidebar" ? (
                 <SidebarTableOfContents
-                    headings={content.toc}
+                    // Bridge until the sidebar rewrite (PR3): project the
+                    // sidebar sections down to the legacy h1-only TocHeading[]
+                    // shape this sidebar still expects.
+                    headings={content.toc.sections.map((section) => ({
+                        text: section.heading.text,
+                        slug: section.heading.slug,
+                        isSubheading: false,
+                    }))}
                     headingLevels={{ primary: 1, secondary: 2 }}
                     pageTitle={content.title || ""}
                 />

--- a/site/gdocs/pages/Profile.tsx
+++ b/site/gdocs/pages/Profile.tsx
@@ -105,7 +105,9 @@ export function Profile({ content, publishedAt, slug }: ProfileProps) {
                     pageTitle={content.title || ""}
                 />
             ) : null}
-            {content.body ? <ArticleBlocks blocks={content.body} /> : null}
+            {content.body ? (
+                <ArticleBlocks toc={content.toc} blocks={content.body} />
+            ) : null}
             {content.refs && !_.isEmpty(content.refs.definitions) ? (
                 <Footnotes definitions={content.refs.definitions} />
             ) : null}


### PR DESCRIPTION
Second PR in the sidebar-TOC-v2 stack — the data-shape layer.

`content.toc` becomes a tailored discriminated union, `GdocToc`, generated **only for pages that render a TOC** and shaped to exactly what that page's consumer needs:

- **sidebar** — pages with the `sidebar-toc` flag or an `ltp-toc` block (in practice, linear topic pages) → H1 sections, each carrying its chart bullets;
- **inline** — `sdg-toc` articles → a flat H2/H3 heading list;
- **otherwise** → no toc.

`generateGdocToc` is the single source of truth for this gating, so the consumers are dumb 1:1 renderers. Chart blocks gain an `anchorId` so the sidebar can deep-link into the page. A migration backfills the new shape for published pages.

#6578 swaps in the chart-aware sidebar that consumes this shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)