### PR TITLE
🎉 support dumbbell charts in search

### DIFF
--- a/functions/_common/search/constructSearchResultDataTableContent.test.ts
+++ b/functions/_common/search/constructSearchResultDataTableContent.test.ts
@@ -366,6 +366,80 @@ describe("constructSearchResultDataTableContent for SlopeChart", () => {
     })
 })
 
+describe("constructSearchResultDataTableContent for DumbbellChart", () => {
+    it("compares a column's values across two time points (entity strategy)", () => {
+        const grapherState = createSingleIndicatorGrapherState({
+            chartTypes: [GRAPHER_CHART_TYPES.Dumbbell],
+        })
+
+        const dataTable = constructSearchResultDataTableContent({
+            grapherState,
+        })
+
+        expect(dataTable!.title).toBe("GDP")
+        expect(dataTable!.rows).toMatchObject([
+            {
+                label: "Philippines",
+                time: "2000–2009",
+                startValue: "$663.99 billion",
+                value: "$682.03 billion",
+                trend: "up",
+            },
+            {
+                label: "Benin",
+                time: "2000–2009",
+                startValue: "$252.54 billion",
+                value: "$233.42 billion",
+                trend: "down",
+            },
+            {
+                label: "Eritrea",
+                time: "2000–2009",
+                startValue: "$69.27 billion",
+                value: "$63.2 billion",
+                trend: "down",
+            },
+        ])
+    })
+
+    it("compares two columns at a single time point (column strategy)", () => {
+        const grapherState = createFruityMultipleIndicatorsGrapherState({
+            chartTypes: [GRAPHER_CHART_TYPES.Dumbbell],
+            addCountryMode: EntitySelectionMode.MultipleEntities,
+            selectedEntityNames: ["Benin", "Philippines", "Eritrea"],
+        })
+
+        const dataTable = constructSearchResultDataTableContent({
+            grapherState,
+        })
+
+        expect(dataTable!.title).toBe("Fruit vs. Vegetables")
+        expect(dataTable!.rows).toMatchObject([
+            {
+                label: "Philippines",
+                startValue: "844",
+                time: "2009",
+                timePreposition: "in",
+                value: "893",
+            },
+            {
+                label: "Benin",
+                startValue: "573",
+                time: "2009",
+                timePreposition: "in",
+                value: "542",
+            },
+            {
+                label: "Eritrea",
+                startValue: "479",
+                time: "2009",
+                timePreposition: "in",
+                value: "430",
+            },
+        ])
+    })
+})
+
 describe("constructSearchResultDataTableContent for StackedAreaChart", () => {
     it("lists entities when entities are plotted", () => {
         const grapherState = createSingleIndicatorGrapherState({

--- a/functions/_common/search/constructSearchResultDataTableContent.ts
+++ b/functions/_common/search/constructSearchResultDataTableContent.ts
@@ -20,6 +20,7 @@ import {
     isNoDataBin,
     NumericBin,
     ColorScaleBin,
+    darkenColorForText,
 } from "@ourworldindata/grapher"
 import { calculateTrendDirection, getDisplayUnit } from "@ourworldindata/utils"
 import {
@@ -355,7 +356,9 @@ function buildDataTableContentForDumbbellChart({
                     seriesName: series.seriesName,
                     label: series.displayName,
                     value: endColumn.formatValueShort(end.value),
+                    valueColor: darkenColorForText(end.color),
                     startValue: startColumn.formatValueShort(start.value),
+                    startValueColor: darkenColorForText(start.color),
                     time: startColumn.formatTime(endTime),
                     timePreposition: OwidTable.getPreposition(
                         chartState.transformedTable.timeColumn

--- a/functions/_common/search/constructSearchResultDataTableContent.ts
+++ b/functions/_common/search/constructSearchResultDataTableContent.ts
@@ -295,10 +295,89 @@ function buildDataTableContentForSlopeChart({
     return { rows, title }
 }
 
-function buildDataTableContentForDumbbellChart(
-    _args: Args<DumbbellChartState>
-): SearchChartHitDataTableProps {
-    return { rows: [], title: "" }
+function buildDataTableContentForDumbbellChart({
+    grapherState,
+    chartState,
+    maxRows,
+}: Args<DumbbellChartState>): SearchChartHitDataTableProps {
+    // Dumbbell charts have two modes:
+    // - entity strategy: compares one column's values across two time points
+    // - column strategy: compares two different columns at a single time point
+    const mode = chartState.isEntityStrategy ? "time-range" : "two-columns"
+
+    return match(mode)
+        .with("time-range", () => {
+            const formatColumn = chartState.formatColumn
+
+            let rows = chartState.series.map((series) => {
+                const { start, end } = series
+
+                const formattedStartValue = formatColumn.formatValueShort(
+                    start.value
+                )
+                const formattedEndValue = formatColumn.formatValueShort(
+                    end.value
+                )
+
+                const formattedStartTime = formatColumn.formatTime(start.time)
+                const formattedEndTime = formatColumn.formatTime(end.time)
+
+                const trend =
+                    // If both labels are the same, trivially show a right arrow
+                    formattedStartValue &&
+                    formattedStartValue === formattedEndValue
+                        ? "right"
+                        : // Otherwise, calculate based on numeric values
+                          calculateTrendDirection(start.value, end.value)
+
+                return {
+                    seriesName: series.seriesName,
+                    label: series.displayName,
+                    value: formattedEndValue,
+                    startValue: formattedStartValue,
+                    trend,
+                    time: `${formattedStartTime}–${formattedEndTime}`,
+                    timePreposition: "",
+                    muted: series.focus.background,
+                }
+            })
+
+            // Take the first X rows if maxRows is specified
+            if (maxRows && maxRows > 0) rows = _.take(rows, maxRows)
+
+            const title = makeTableTitle(grapherState, chartState, formatColumn)
+
+            return { rows, title }
+        })
+        .with("two-columns", () => {
+            const { endTime } = chartState
+            const [startColumn, endColumn] = chartState.yColumns
+
+            let rows = chartState.series.map((series) => {
+                const { start, end } = series
+                return {
+                    seriesName: series.seriesName,
+                    label: series.displayName,
+                    value: endColumn.formatValueShort(end.value),
+                    startValue: startColumn.formatValueShort(start.value),
+                    time: startColumn.formatTime(endTime),
+                    timePreposition: OwidTable.getPreposition(
+                        chartState.transformedTable.timeColumn
+                    ),
+                    muted: series.focus.background,
+                }
+            })
+
+            // Take the first X rows if maxRows is specified
+            if (maxRows && maxRows > 0) rows = _.take(rows, maxRows)
+
+            const startName = getColumnNameForDisplay(startColumn)
+            const endName = getColumnNameForDisplay(endColumn)
+            const title = `${startName} vs. ${endName}`
+
+            return { rows, title }
+        })
+        .exhaustive()
 }
 
 function buildDataTableContentForStackedDiscreteBarChart({

--- a/functions/_common/search/constructSearchResultDataTableContent.ts
+++ b/functions/_common/search/constructSearchResultDataTableContent.ts
@@ -12,6 +12,7 @@ import {
     StackedBarChartState,
     MarimekkoChartState,
     DumbbellChartState,
+    DumbbellMode,
     MapChartState,
     ChartState,
     makeChartState,
@@ -300,13 +301,8 @@ function buildDataTableContentForDumbbellChart({
     chartState,
     maxRows,
 }: Args<DumbbellChartState>): SearchChartHitDataTableProps {
-    // Dumbbell charts have two modes:
-    // - entity strategy: compares one column's values across two time points
-    // - column strategy: compares two different columns at a single time point
-    const mode = chartState.isEntityStrategy ? "time-range" : "two-columns"
-
-    return match(mode)
-        .with("time-range", () => {
+    return match(chartState.mode)
+        .with(DumbbellMode.TimeRange, () => {
             const formatColumn = chartState.formatColumn
 
             let rows = chartState.series.map((series) => {
@@ -349,7 +345,7 @@ function buildDataTableContentForDumbbellChart({
 
             return { rows, title }
         })
-        .with("two-columns", () => {
+        .with(DumbbellMode.TwoColumn, () => {
             const { endTime } = chartState
             const [startColumn, endColumn] = chartState.yColumns
 

--- a/functions/_common/search/constructSearchResultJson.ts
+++ b/functions/_common/search/constructSearchResultJson.ts
@@ -8,8 +8,11 @@ import {
     generateSelectedEntityNamesParam,
     GrapherState,
     mapGrapherTabNameToConfigOption,
+    makeChartState,
     MarimekkoChartState,
     ScatterPlotChartState,
+    DumbbellChartState,
+    DumbbellMode,
     WORLD_ENTITY_NAME,
     loadCatalogData,
 } from "@ourworldindata/grapher"
@@ -838,8 +841,22 @@ async function getGrapherQueryParamsForTab({
             getGrapherQueryParamsForMarimekko(grapherState)
         )
         .with(GRAPHER_TAB_NAMES.SlopeChart, () =>
-            getGrapherQueryParamsForSlopeChart(grapherState, { timeBounds })
+            getGrapherQueryParamsForTimeRangeChart(grapherState, { timeBounds })
         )
+        .with(GRAPHER_TAB_NAMES.Dumbbell, () => {
+            // Rebuild the chart state since the dumbbell chart might not be the active tab
+            const chartState = makeChartState(
+                GRAPHER_CHART_TYPES.Dumbbell,
+                grapherState
+            ) as DumbbellChartState
+
+            // Only time-range dumbbells need to adjust the time param
+            if (chartState.mode !== DumbbellMode.TimeRange) return undefined
+
+            return getGrapherQueryParamsForTimeRangeChart(grapherState, {
+                timeBounds,
+            })
+        })
         .with(GRAPHER_TAB_NAMES.WorldMap, () =>
             getGrapherQueryParamsForMap(grapherState)
         )
@@ -915,7 +932,16 @@ async function getGrapherQueryParamsForDiscreteBar(
     return { chartParams: overwriteParams, previewParams: overwriteParams }
 }
 
-function getGrapherQueryParamsForSlopeChart(
+/**
+ * Pins the time query param to the given time bounds.
+ *
+ * Needed for charts that only plot entities with data at both the start and end
+ * time (e.g. slope charts or time-range dumbbells). For entity-targeted
+ * searches we pass the user-picked entity's own data bounds, so the chart's
+ * default time window doesn't fall outside that entity's data and render an
+ * empty thumbnail.
+ */
+function getGrapherQueryParamsForTimeRangeChart(
     grapherState: GrapherState,
     { timeBounds }: { timeBounds?: TimeBounds }
 ):

--- a/packages/@ourworldindata/grapher/src/chart/ChartTabs.ts
+++ b/packages/@ourworldindata/grapher/src/chart/ChartTabs.ts
@@ -24,9 +24,9 @@ import { match } from "ts-pattern"
 export const VALID_CHART_TYPE_COMBINATIONS: GrapherChartType[][] = [
     [
         GRAPHER_CHART_TYPES.LineChart,
-        GRAPHER_CHART_TYPES.SlopeChart,
         GRAPHER_CHART_TYPES.DiscreteBar,
         GRAPHER_CHART_TYPES.Dumbbell,
+        GRAPHER_CHART_TYPES.SlopeChart,
         GRAPHER_CHART_TYPES.Marimekko,
         GRAPHER_CHART_TYPES.ScatterPlot,
     ],

--- a/packages/@ourworldindata/grapher/src/core/GrapherValuesJson.test.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherValuesJson.test.ts
@@ -1,7 +1,20 @@
 import { describe, expect, it } from "vitest"
-import { OwidTableSlugs } from "@ourworldindata/types"
-import { makeDimensionValuesForTimeDirect } from "./GrapherValuesJson"
-import { OwidTable } from "@ourworldindata/core-table"
+import {
+    DimensionProperty,
+    GRAPHER_CHART_TYPES,
+    OwidTableSlugs,
+} from "@ourworldindata/types"
+import {
+    constructGrapherValuesJson,
+    makeDimensionValuesForTimeDirect,
+} from "./GrapherValuesJson"
+import {
+    OwidTable,
+    SynthesizeGDPTable,
+    SampleColumnSlugs,
+} from "@ourworldindata/core-table"
+import { GrapherState } from "./GrapherState"
+import { GrapherProgrammaticInterface } from "./Grapher"
 
 describe(makeDimensionValuesForTimeDirect, () => {
     const makeTestTable = (): OwidTable => {
@@ -120,5 +133,114 @@ describe(makeDimensionValuesForTimeDirect, () => {
 
         expect(result?.y?.[0].columnSlug).toBe("gdp")
         expect(result?.y?.[0].value).toBeUndefined()
+    })
+})
+
+describe(constructGrapherValuesJson, () => {
+    const selectedEntityNames = ["Philippines", "Benin", "Eritrea"]
+
+    const makeGrapherState = (
+        overrides: GrapherProgrammaticInterface = {}
+    ): GrapherState => {
+        const table = SynthesizeGDPTable(
+            { entityCount: 5, timeRange: [2000, 2010] },
+            12 // Seed
+        )
+        return new GrapherState({
+            table,
+            selectedEntityNames,
+            dimensions: [
+                {
+                    slug: SampleColumnSlugs.GDP,
+                    property: DimensionProperty.y,
+                    variableId: SampleColumnSlugs.GDP as any,
+                },
+            ],
+            ...overrides,
+        })
+    }
+
+    it("extracts start and end values for the entity over the default time range", () => {
+        const result = constructGrapherValuesJson(
+            makeGrapherState(),
+            "Philippines"
+        )
+
+        expect(result.entityName).toBe("Philippines")
+        expect(result.startTime).toBe(2000)
+        expect(result.endTime).toBe(2009)
+        expect(result.startValues?.y).toHaveLength(1)
+        expect(result.startValues?.y[0]).toMatchObject({
+            columnSlug: SampleColumnSlugs.GDP,
+            time: 2000,
+            formattedValueShort: "$663.99 billion",
+        })
+        expect(result.endValues?.y[0]).toMatchObject({
+            columnSlug: SampleColumnSlugs.GDP,
+            time: 2009,
+            formattedValueShort: "$682.03 billion",
+        })
+    })
+
+    it("omits the start values for a single-time chart (two-column dumbbell)", () => {
+        // A two-column dumbbell compares two columns at a single time point,
+        // so there's no start time and hence no start values.
+        const grapherState = makeGrapherState({
+            chartTypes: [GRAPHER_CHART_TYPES.Dumbbell],
+            selectedEntityNames: ["Philippines"],
+            dimensions: [
+                {
+                    slug: SampleColumnSlugs.GDP,
+                    property: DimensionProperty.y,
+                    variableId: SampleColumnSlugs.GDP as any,
+                },
+                {
+                    slug: SampleColumnSlugs.Population,
+                    property: DimensionProperty.y,
+                    variableId: SampleColumnSlugs.Population as any,
+                },
+            ],
+        })
+
+        const result = constructGrapherValuesJson(grapherState, "Philippines")
+
+        expect(result.startTime).toBeUndefined()
+        expect(result.startValues).toBeUndefined()
+        expect(result.endTime).toBe(2009)
+        expect(result.endValues?.y).toHaveLength(2)
+        expect(result.endValues?.y[0].time).toBe(2009)
+    })
+
+    it("restores the original selection afterwards", () => {
+        const grapherState = makeGrapherState()
+        constructGrapherValuesJson(grapherState, "Benin")
+        expect(grapherState.selection.selectedEntityNames).toEqual(
+            selectedEntityNames
+        )
+    })
+
+    it("includes one y data point per y-column", () => {
+        const grapherState = makeGrapherState({
+            selectedEntityNames: ["Philippines"],
+            dimensions: [
+                {
+                    slug: SampleColumnSlugs.GDP,
+                    property: DimensionProperty.y,
+                    variableId: SampleColumnSlugs.GDP as any,
+                },
+                {
+                    slug: SampleColumnSlugs.Population,
+                    property: DimensionProperty.y,
+                    variableId: SampleColumnSlugs.Population as any,
+                },
+            ],
+        })
+
+        const result = constructGrapherValuesJson(grapherState, "Philippines")
+
+        expect(result.endValues?.y.map((d) => d.columnSlug)).toEqual([
+            SampleColumnSlugs.GDP,
+            SampleColumnSlugs.Population,
+        ])
     })
 })

--- a/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChart.tsx
+++ b/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChart.tsx
@@ -280,7 +280,7 @@ export class DumbbellChart
     @computed private get verticalScale() {
         return scalePoint<string>()
             .domain(this.series.map((s) => s.seriesName))
-            .range(this.innerBounds.yRange())
+            .range([this.innerBounds.top, this.innerBounds.bottom])
             .padding(0.5)
     }
 

--- a/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChart.tsx
+++ b/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChart.tsx
@@ -8,7 +8,6 @@ import {
     makeFigmaId,
     exposeInstanceOnWindow,
     ScaleType,
-    SeriesStrategy,
     formatValue,
     getRelativeMouse,
     guid,
@@ -41,6 +40,7 @@ import { HorizontalAxis } from "../axis/Axis"
 import { ChartInterface } from "../chart/ChartInterface"
 import {
     DumbbellChartManager,
+    DumbbellMode,
     DumbbellSeries,
     SizedDumbbellSeries,
     PlacedDumbbellSeries,
@@ -166,9 +166,10 @@ export class DumbbellChart
         return {
             text,
             width: textWidth(text, this.valueLabelStyle),
-            padding: this.chartState.isEntityStrategy
-                ? VALUE_LABEL_DOT_GAP
-                : VALUE_LABEL_DOT_GAP + this.dumbbellHeadRadius,
+            padding:
+                this.chartState.mode === DumbbellMode.TimeRange
+                    ? VALUE_LABEL_DOT_GAP
+                    : VALUE_LABEL_DOT_GAP + this.dumbbellHeadRadius,
         }
     }
 
@@ -180,7 +181,7 @@ export class DumbbellChart
             .with(DumbbellValueLabelMode.Absolute, () => {
                 // Only show one label if the values are the same
                 if (
-                    this.chartState.isEntityStrategy &&
+                    this.chartState.mode === DumbbellMode.TimeRange &&
                     startValue === endValue
                 ) {
                     return { start: this.formatValue(startValue) }
@@ -329,7 +330,7 @@ export class DumbbellChart
     }
 
     @computed private get dumbbellHeadRadius(): number {
-        return this.chartState.seriesStrategy === SeriesStrategy.entity
+        return this.chartState.mode === DumbbellMode.TimeRange
             ? _.clamp(Math.floor(this.availableHeightPerSeries / 2), 2, 4)
             : _.clamp(Math.floor(this.availableHeightPerSeries / 2), 2, 6.5)
     }
@@ -395,9 +396,9 @@ export class DumbbellChart
         if (!showLegend || this.series.length === 0) return undefined
 
         return (
-            match(this.chartState.seriesStrategy)
-                // In entity mode, the legend labels are the start and end times
-                .with(SeriesStrategy.entity, () => {
+            match(this.chartState.mode)
+                // In time-range mode, the legend labels are the start and end times
+                .with(DumbbellMode.TimeRange, () => {
                     const { formatColumn, startTime, endTime } = this.chartState
                     return {
                         start: {
@@ -412,8 +413,8 @@ export class DumbbellChart
                         } satisfies LegendLabel,
                     }
                 })
-                // In column mode, the legend labels are the two columns
-                .with(SeriesStrategy.column, () => {
+                // In two-column mode, the legend labels are the two columns
+                .with(DumbbellMode.TwoColumn, () => {
                     const [startColumn, endColumn] = this.chartState.yColumns
                     if (!startColumn || !endColumn) return undefined
                     return {
@@ -447,9 +448,11 @@ export class DumbbellChart
     @computed private get topLegendType(): TopLegendType {
         if (!this.legendLabels) return "none"
         if (this.inlineLegendFits) return "inline"
-        // In column mode, fall back to a categorical legend when the inline
-        // labels don't fit. In entity mode, no legend is shown in that case.
-        return this.chartState.isEntityStrategy ? "none" : "swatches"
+        // In two-column mode, fall back to a categorical legend when the inline
+        // labels don't fit. In time-range mode, no legend is shown in that case.
+        return this.chartState.mode === DumbbellMode.TimeRange
+            ? "none"
+            : "swatches"
     }
 
     @computed private get topLegendHeight(): number {
@@ -663,7 +666,7 @@ export class DumbbellChart
                         <DumbbellChartRow
                             key={series.seriesName}
                             series={series}
-                            seriesStrategy={this.chartState.seriesStrategy}
+                            mode={this.chartState.mode}
                             connectorStyle={this.chartState.connectorStyle}
                             range={this.xRange}
                             valueLabelStyle={this.valueLabelStyle}
@@ -678,7 +681,7 @@ export class DumbbellChart
 
     private renderInteractive(): React.ReactElement {
         const { xRange, valueLabelStyle } = this
-        const { seriesStrategy, connectorStyle } = this.chartState
+        const { mode, connectorStyle } = this.chartState
 
         return (
             <g>
@@ -710,7 +713,7 @@ export class DumbbellChart
                         <DumbbellChartRow
                             key={series.seriesName}
                             series={series}
-                            seriesStrategy={seriesStrategy}
+                            mode={mode}
                             connectorStyle={connectorStyle}
                             range={xRange}
                             valueLabelStyle={valueLabelStyle}
@@ -720,7 +723,7 @@ export class DumbbellChart
                     )}
                 />
                 {this.renderLegend()}
-                {this.chartState.seriesStrategy === SeriesStrategy.entity ? (
+                {this.chartState.mode === DumbbellMode.TimeRange ? (
                     <DumbbellTimeRangeTooltip
                         id={this.tooltipId}
                         chartState={this.chartState}

--- a/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChartConstants.ts
+++ b/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChartConstants.ts
@@ -36,6 +36,17 @@ export const LIGHT_DECREASE_COLOR = "#E78A96"
 export const START_COLUMN_COLOR = GRAPHER_DENIM
 export const END_COLUMN_COLOR = "#B13507"
 
+/**
+ * A dumbbell always plots one row per entity. What its two ends compare
+ * depends on the mode:
+ * - TimeRange: one column's values across two time points
+ * - TwoColumn: two different columns' values at a single time point
+ */
+export enum DumbbellMode {
+    TimeRange = "TimeRange",
+    TwoColumn = "TwoColumn",
+}
+
 export type DumbbellChartManager = ChartManager
 
 export interface DumbbellSeries extends ChartSeries {

--- a/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChartRow.tsx
+++ b/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChartRow.tsx
@@ -1,17 +1,14 @@
 import React from "react"
 import { makeFigmaId, dyFromAlign } from "@ourworldindata/utils"
 import { Halo, TextWrapSvg } from "@ourworldindata/components"
-import {
-    DumbbellConnectorStyle,
-    SeriesStrategy,
-    VerticalAlign,
-} from "@ourworldindata/types"
+import { DumbbellConnectorStyle, VerticalAlign } from "@ourworldindata/types"
 import { FontSettings } from "../core/GrapherConstants"
 import { SeriesLabel } from "../seriesLabel/SeriesLabel"
 import { TimeRangeDumbbell, TwoColumnDumbbell } from "./Dumbbell"
 import {
     LabelledDumbbellHead,
     RenderDumbbellSeries,
+    DumbbellMode,
     DUMBBELL_STYLE,
     PlacedDumbbellHead,
 } from "./DumbbellChartConstants"
@@ -22,7 +19,7 @@ import { GRAPHER_DARK_TEXT } from "../color/ColorConstants.js"
 
 export function DumbbellChartRow({
     series,
-    seriesStrategy,
+    mode,
     connectorStyle,
     y,
     range,
@@ -30,7 +27,7 @@ export function DumbbellChartRow({
     onInfoTooltipShow,
 }: {
     series: RenderDumbbellSeries
-    seriesStrategy: SeriesStrategy
+    mode: DumbbellMode
     connectorStyle: DumbbellConnectorStyle
     y: number
     range: [number, number]
@@ -83,7 +80,7 @@ export function DumbbellChartRow({
                 )}
 
             {/* Dumbbell */}
-            {seriesStrategy === SeriesStrategy.entity ? (
+            {mode === DumbbellMode.TimeRange ? (
                 <TimeRangeDumbbell series={series} />
             ) : (
                 <TwoColumnDumbbell

--- a/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChartState.test.ts
+++ b/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChartState.test.ts
@@ -1,12 +1,12 @@
 import { expect, it, describe } from "vitest"
 
 import { OwidTable } from "@ourworldindata/core-table"
-import { SeriesStrategy } from "@ourworldindata/types"
 import { DumbbellChartState } from "./DumbbellChartState"
 import {
     DECREASE_COLOR,
     INCREASE_COLOR,
     DumbbellChartManager,
+    DumbbellMode,
 } from "./DumbbellChartConstants"
 
 describe("entity strategy", () => {
@@ -86,11 +86,10 @@ describe("column strategy", () => {
             table,
             selection: table.availableEntityNames,
             yColumnSlugs: ["population", "gdp"],
-            seriesStrategy: SeriesStrategy.column,
         }
         const chartState = new DumbbellChartState({ manager })
 
-        expect(chartState.seriesStrategy).toEqual(SeriesStrategy.column)
+        expect(chartState.mode).toEqual(DumbbellMode.TwoColumn)
         expect(chartState.series.length).toEqual(1)
 
         const series = chartState.series[0]

--- a/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChartState.ts
+++ b/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChartState.ts
@@ -4,7 +4,6 @@ import {
     DumbbellConnectorStyle,
     DumbbellValueLabelMode,
     ScaleType,
-    SeriesStrategy,
     FacetStrategy,
     ChartErrorInfo,
     SortBy,
@@ -17,6 +16,7 @@ import {
     DECREASE_COLOR,
     DumbbellChartManager,
     DumbbellHead,
+    DumbbellMode,
     DumbbellSeries,
     END_COLUMN_COLOR,
     INCREASE_COLOR,
@@ -28,7 +28,6 @@ import {
 import { SelectionArray } from "../selection/SelectionArray"
 import { FocusArray } from "../focus/FocusArray"
 import {
-    autoDetectSeriesStrategy,
     autoDetectYColumnSlugs,
     getDefaultFailMessage,
     getShortNameForEntity,
@@ -109,15 +108,13 @@ export class DumbbellChartState implements ChartState {
 
     /**
      * Determines how dumbbell series are constructed:
-     * - entity: compares the same column's values across two time points
-     * - column: compares two different columns' values at a single time point
-     * */
-    @computed get seriesStrategy(): SeriesStrategy {
-        return autoDetectSeriesStrategy(this.manager)
-    }
-
-    @computed get isEntityStrategy(): boolean {
-        return this.seriesStrategy === SeriesStrategy.entity
+     * - TimeRange: compares one column's values across two time points
+     * - TwoColumn: compares two different columns' values at a single time point
+     */
+    @computed get mode(): DumbbellMode {
+        return this.yColumnSlugs.length > 1
+            ? DumbbellMode.TwoColumn
+            : DumbbellMode.TimeRange
     }
 
     @computed get connectorStyle(): DumbbellConnectorStyle {
@@ -286,7 +283,7 @@ export class DumbbellChartState implements ChartState {
     }
 
     @computed private get unsortedSeries(): DumbbellSeries[] {
-        return this.isEntityStrategy
+        return this.mode === DumbbellMode.TimeRange
             ? this.constructSeriesForTimeRange()
             : this.constructSeriesForTwoColumns()
     }

--- a/packages/@ourworldindata/grapher/src/index.ts
+++ b/packages/@ourworldindata/grapher/src/index.ts
@@ -54,6 +54,7 @@ export { ColorScale } from "./color/ColorScale"
 export { ColorScaleConfig } from "./color/ColorScaleConfig"
 export { ColorScheme } from "./color/ColorScheme"
 export { GRAPHER_BACKGROUND } from "./color/ColorConstants"
+export { darkenColorForText } from "./color/ColorUtils"
 export {
     getColorNameOwidDistinctAndSemanticPalettes,
     getColorNameOwidDistinctLinesAndSemanticPalettes,

--- a/packages/@ourworldindata/grapher/src/index.ts
+++ b/packages/@ourworldindata/grapher/src/index.ts
@@ -195,3 +195,5 @@ export {
 } from "./hooks.js"
 
 export { codeToEntityName, entityNameToCode } from "./core/EntityCodes.js"
+
+export { DumbbellMode } from "./dumbbellCharts/DumbbellChartConstants"

--- a/packages/@ourworldindata/types/src/endpointTypes/GrapherSearchResultJson.ts
+++ b/packages/@ourworldindata/types/src/endpointTypes/GrapherSearchResultJson.ts
@@ -28,7 +28,9 @@ interface TableRow {
     label: string
     color?: string
     value?: string
+    valueColor?: string
     startValue?: string
+    startValueColor?: string
     time?: string
     timePreposition?: string
     muted?: boolean

--- a/packages/@ourworldindata/utils/src/search/SearchHelpers.test.ts
+++ b/packages/@ourworldindata/utils/src/search/SearchHelpers.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "vitest"
+import {
+    GRAPHER_CHART_TYPES,
+    GrapherValuesJson,
+    GrapherValuesJsonDataPoint,
+} from "@ourworldindata/types"
+import { buildChartHitDataDisplayProps } from "./SearchHelpers.js"
+
+function makePoint(
+    columnSlug: string,
+    time: number,
+    value: number
+): GrapherValuesJsonDataPoint {
+    return {
+        columnSlug,
+        value,
+        formattedValueShort: String(value),
+        time,
+        formattedTime: String(time),
+    }
+}
+
+describe(buildChartHitDataDisplayProps, () => {
+    it("shows a single end value for charts that don't compare two time points", () => {
+        const chartInfo: GrapherValuesJson = {
+            source: "Source",
+            columns: { pop: { name: "Population" } },
+            startValues: { y: [makePoint("pop", 2000, 100)] },
+            endValues: { y: [makePoint("pop", 2020, 200)] },
+        }
+
+        const result = buildChartHitDataDisplayProps({
+            chartInfo,
+            chartType: GRAPHER_CHART_TYPES.LineChart,
+            entity: "France",
+        })
+
+        // Even though start values exist, a line chart only shows the end value
+        expect(result).toMatchObject({ endValue: "200", time: "2020" })
+        expect(result?.startValue).toBeUndefined()
+    })
+
+    it("shows a start–end range with trend for a time-range dumbbell", () => {
+        const chartInfo: GrapherValuesJson = {
+            source: "Source",
+            columns: { gdp: { name: "GDP", unit: "international-$" } },
+            startValues: { y: [makePoint("gdp", 2000, 100)] },
+            endValues: { y: [makePoint("gdp", 2020, 200)] },
+        }
+
+        const result = buildChartHitDataDisplayProps({
+            chartInfo,
+            chartType: GRAPHER_CHART_TYPES.Dumbbell,
+            entity: "France",
+        })
+
+        expect(result).toMatchObject({
+            entityName: "France",
+            startValue: "100",
+            endValue: "200",
+            time: "2000–2020",
+            trend: "up",
+            unit: "international-$",
+        })
+    })
+
+    it("returns undefined for a two-column dumbbell (more than one y-indicator)", () => {
+        const chartInfo: GrapherValuesJson = {
+            source: "Source",
+            columns: { fruit: { name: "Fruit" }, veg: { name: "Vegetables" } },
+            endValues: {
+                y: [makePoint("fruit", 2020, 10), makePoint("veg", 2020, 20)],
+            },
+        }
+
+        expect(
+            buildChartHitDataDisplayProps({
+                chartInfo,
+                chartType: GRAPHER_CHART_TYPES.Dumbbell,
+                entity: "France",
+            })
+        ).toBeUndefined()
+    })
+
+    it("shows a single value for scatter plots when the x-axis is GDP", () => {
+        const makeScatterInfo = (xColumn: {
+            slug: string
+            name: string
+        }): GrapherValuesJson => ({
+            source: "",
+            columns: {
+                life: { name: "Life expectancy" },
+                [xColumn.slug]: { name: xColumn.name },
+            },
+            endValues: {
+                y: [makePoint("life", 2020, 80)],
+                x: makePoint(xColumn.slug, 2020, 1000),
+            },
+        })
+
+        // Arbitrary x-axis -> no value display
+        expect(
+            buildChartHitDataDisplayProps({
+                chartInfo: makeScatterInfo({ slug: "pop", name: "Population" }),
+                chartType: GRAPHER_CHART_TYPES.ScatterPlot,
+                entity: "France",
+            })
+        ).toBeUndefined()
+
+        // GDP x-axis -> value display is shown
+        expect(
+            buildChartHitDataDisplayProps({
+                chartInfo: makeScatterInfo({
+                    slug: "gdp",
+                    name: "GDP per capita",
+                }),
+                chartType: GRAPHER_CHART_TYPES.ScatterPlot,
+                entity: "France",
+            })
+        ).toMatchObject({ endValue: "80" })
+    })
+})

--- a/packages/@ourworldindata/utils/src/search/SearchHelpers.ts
+++ b/packages/@ourworldindata/utils/src/search/SearchHelpers.ts
@@ -26,10 +26,12 @@ export function buildChartHitDataDisplayProps({
 }): SearchChartHitDataDisplayProps | undefined {
     if (!chartInfo) return undefined
 
-    // Showing a time range only makes sense for slope charts and connected scatter plots
+    // Showing a time range only makes sense for charts that compare two time
+    // points: slope charts, connected scatter plots, and time-range dumbbells
     const showTimeRange =
         chartType === GRAPHER_CHART_TYPES.SlopeChart ||
-        chartType === GRAPHER_CHART_TYPES.ScatterPlot
+        chartType === GRAPHER_CHART_TYPES.ScatterPlot ||
+        chartType === GRAPHER_CHART_TYPES.Dumbbell
 
     const endDatapoint = findDatapoint(chartInfo, "end")
     const startDatapoint = showTimeRange

--- a/site/search/SearchChartHitDataTable.tsx
+++ b/site/search/SearchChartHitDataTable.tsx
@@ -109,7 +109,15 @@ function Row({
                     <span className="search-chart-hit-table-row__value">
                         {row.startValue && (
                             <>
-                                {row.startValue}
+                                <span
+                                    style={
+                                        row.startValueColor
+                                            ? { color: row.startValueColor }
+                                            : undefined
+                                    }
+                                >
+                                    {row.startValue}
+                                </span>
                                 {row.trend ? (
                                     <GrapherTrendArrow
                                         className="search-chart-hit-table-row__arrow"
@@ -123,7 +131,15 @@ function Row({
                                 )}
                             </>
                         )}
-                        {row.value}
+                        <span
+                            style={
+                                row.valueColor
+                                    ? { color: row.valueColor }
+                                    : undefined
+                            }
+                        >
+                            {row.value}
+                        </span>
                         {row.time && (
                             <span className="search-chart-hit-table-row__time">
                                 {" "}


### PR DESCRIPTION
Adds support for dumbbell charts in search.

This includes:
- Constructing the data table rendered in search
- Making sure the big data value on the right is appropriate
    - Should say `Start value -> End value` in time-range mode (same as slope charts)
    - Otherwise, it should be hidden (we never show a value for multi-y charts)

The thumbnail PNGs (with imMinimal=0/1) look good as is, I think.

This is a bit difficult to test. I mainly looked at the various endpoints (`.search-result.json`, `values.json`) and added tests.

This PR also includes a refactor that drops the dumbbell's series strategy and replaces it with a custom `mode`. If the series strategy is set to `column`, search expects the series items to refer to columns, not entities. But dumbbell charts always plot entities, so the appropriate series strategy is `entity`, and we should differentiate between time-range and two-column mode separately.

### Follow-up work

* ~Dumbbell elements~
* ~New dumbbell-specific options: value labels, end points~
* ~In-chart legend, aligned with the top-most dots~
* ~Interaction (focus, hover, tooltips)~
* Color (hard-coded for now)
* More entity sorting options
* ~Dumbbell plots in search~ (addressed in this PR)
* ~Dumbbell chart thumbnails~ (addressed in this PR)
