### PR TITLE
🎉 (dumbbell) add more sorting options

### DIFF
--- a/adminSiteClient/EditorCustomizeTab.tsx
+++ b/adminSiteClient/EditorCustomizeTab.tsx
@@ -220,6 +220,25 @@ interface SortOrderDropdownOption {
     display?: { name: string; displayName: string }
 }
 
+const SORT_BY_LABELS: Record<Exclude<SortBy, SortBy.column>, string> = {
+    [SortBy.entityName]: "Entity name",
+    [SortBy.total]: "Total value",
+    [SortBy.custom]: "Custom order (use specified entity order)",
+    [SortBy.change]: "Change",
+    [SortBy.startValue]: "Start value",
+    [SortBy.endValue]: "End value",
+}
+
+const SORT_BY_DISPLAY_ORDER: SortBy[] = [
+    SortBy.entityName,
+    SortBy.total,
+    SortBy.custom,
+    SortBy.change,
+    SortBy.startValue,
+    SortBy.endValue,
+    SortBy.column,
+]
+
 @observer
 class SortOrderSection<
     Editor extends AbstractChartEditor,
@@ -238,54 +257,50 @@ class SortOrderSection<
     }
 
     @computed get sortOptions(): SortOrderDropdownOption[] {
-        const { features } = this.props.editor
+        const availableSortKeys = new Set(
+            this.grapherState.availableSortKeysAcrossChartTypes
+        )
 
-        let dimensionSortOptions: SortOrderDropdownOption[] = []
-        if (features.canSortByColumn) {
-            dimensionSortOptions = this.grapherState.yColumnsFromDimensions.map(
-                (column): SortOrderDropdownOption => ({
-                    key: `column:${column.slug}`,
-                    label: column.displayName,
-                    display: {
-                        name: column.name,
-                        displayName: column.displayName,
+        return SORT_BY_DISPLAY_ORDER.flatMap(
+            (sortBy: SortBy): SortOrderDropdownOption[] => {
+                if (!availableSortKeys.has(sortBy)) return []
+
+                // Column sorting expands into one option per dimension.
+                if (sortBy === SortBy.column) {
+                    return this.grapherState.yColumnsFromDimensions.map(
+                        (column): SortOrderDropdownOption => ({
+                            key: `column:${column.slug}`,
+                            label: column.displayName,
+                            display: {
+                                name: column.name,
+                                displayName: column.displayName,
+                            },
+                            value: {
+                                sortBy: SortBy.column,
+                                sortColumnSlug: column.slug,
+                            } satisfies SortConfig,
+                        })
+                    )
+                }
+
+                return [
+                    {
+                        key: sortBy,
+                        label: SORT_BY_LABELS[sortBy],
+                        value: { sortBy },
                     },
-                    value: {
-                        sortBy: SortBy.column,
-                        sortColumnSlug: column.slug,
-                    } as SortConfig,
-                })
-            )
-        }
-
-        return [
-            {
-                key: "entityName",
-                label: "Entity name",
-                value: { sortBy: SortBy.entityName },
-            },
-            {
-                key: "total",
-                label: "Total value",
-                value: { sortBy: SortBy.total },
-            },
-            {
-                key: "custom",
-                label: "Custom order (use specified entity order)",
-                value: { sortBy: SortBy.custom },
-            },
-            ...dimensionSortOptions,
-        ]
+                ]
+            }
+        )
     }
 
     @computed get currentSortOptionKey(): string {
         const { sortBy, sortColumnSlug } = this.sortConfig
         if (sortBy === SortBy.column && sortColumnSlug)
             return `column:${sortColumnSlug}`
-        if (sortBy === SortBy.entityName) return "entityName"
-        if (sortBy === SortBy.total) return "total"
-        if (sortBy === SortBy.custom) return "custom"
-        return this.sortOptions[0]?.key ?? "entityName"
+        if (sortBy && this.sortOptions.some((opt) => opt.key === sortBy))
+            return sortBy
+        return this.sortOptions[0]?.key ?? SortBy.entityName
     }
 
     @action.bound onSortByChange(selectedKey: string) {

--- a/adminSiteClient/EditorFeatures.tsx
+++ b/adminSiteClient/EditorFeatures.tsx
@@ -1,4 +1,5 @@
 import { computed, makeObservable } from "mobx"
+import { SortBy } from "@ourworldindata/types"
 import { AbstractChartEditor } from "./AbstractChartEditor.js"
 
 // Responsible for determining what parts of the editor should be shown, based on the
@@ -112,20 +113,12 @@ export class EditorFeatures {
     }
 
     @computed get canSpecifySortOrder() {
-        return (
-            this.grapherState.hasStackedDiscreteBar ||
-            this.grapherState.hasDiscreteBar ||
-            this.grapherState.hasMarimekko ||
-            this.grapherState.hasDumbbellChart
-        )
+        return this.grapherState.availableSortKeysAcrossChartTypes.length > 0
     }
 
     @computed get canSortByColumn() {
-        return (
-            this.grapherState.hasStackedDiscreteBar ||
-            this.grapherState.hasMarimekko ||
-            (this.grapherState.hasDumbbellChart &&
-                this.grapherState.yColumnSlugs.length > 1)
+        return this.grapherState.availableSortKeysAcrossChartTypes.includes(
+            SortBy.column
         )
     }
 

--- a/packages/@ourworldindata/core-table/src/CoreTableColumns.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTableColumns.ts
@@ -558,6 +558,22 @@ export abstract class AbstractCoreColumn<
         })
         return valueByEntityNameAndTime
     }
+
+    // Not using owidRows for performance reasons
+    @imemo get latestValueByEntityName(): Map<EntityName, JS_TYPE> {
+        const map = new Map<EntityName, JS_TYPE>()
+
+        const entityNames = this.allEntityNames
+        const values = this.values
+
+        // The table is sorted by time, so later rows overwrite earlier ones,
+        // leaving each entity mapped to its latest value
+        for (let i = 0; i < values.length; i++) {
+            map.set(entityNames[i], values[i])
+        }
+
+        return map
+    }
 }
 
 export type CoreColumn<

--- a/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChartConstants.ts
+++ b/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChartConstants.ts
@@ -5,6 +5,7 @@ import {
     Color,
     CoreValueType,
     ProjectionColumnInfo,
+    SortBy,
     Time,
 } from "@ourworldindata/types"
 import { TextWrap } from "@ourworldindata/components"
@@ -106,3 +107,10 @@ export type YColumnMode =
 
 export const BACKGROUND_COLOR = "#fff"
 export const BAR_SPACING_FACTOR = 0.35
+
+export const DISCRETE_BAR_SORT_KEYS = [
+    SortBy.custom,
+    SortBy.entityName,
+    SortBy.total,
+] as const
+export type DiscreteBarSortKey = (typeof DISCRETE_BAR_SORT_KEYS)[number]

--- a/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChartState.ts
+++ b/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChartState.ts
@@ -19,7 +19,7 @@ import { ColorScale, ColorScaleManager } from "../color/ColorScale"
 import { SelectionArray } from "../selection/SelectionArray"
 import {
     sortByConfig,
-    SortKeyFn,
+    SortKey,
     keepInputOrder,
     autoDetectSeriesStrategy,
     autoDetectYColumnSlugs,
@@ -364,7 +364,7 @@ export class DiscreteBarChartState implements ChartState, ColorScaleManager {
 
         const keyFns: Record<
             DiscreteBarSortKey | SortBy.column,
-            SortKeyFn<DiscreteBarItem>
+            SortKey<DiscreteBarItem>
         > = {
             [SortBy.custom]:
                 this.seriesStrategy === SeriesStrategy.entity

--- a/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChartState.ts
+++ b/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChartState.ts
@@ -3,9 +3,11 @@ import { computed, makeObservable } from "mobx"
 import { match } from "ts-pattern"
 import { ChartState } from "../chart/ChartInterface"
 import {
+    DISCRETE_BAR_SORT_KEYS,
     DiscreteBarChartManager,
     DiscreteBarItem,
     DiscreteBarSeries,
+    DiscreteBarSortKey,
     YColumnMode,
 } from "./DiscreteBarChartConstants"
 import {
@@ -17,6 +19,8 @@ import { ColorScale, ColorScaleManager } from "../color/ColorScale"
 import { SelectionArray } from "../selection/SelectionArray"
 import {
     sortByConfig,
+    SortKeyFn,
+    keepInputOrder,
     autoDetectSeriesStrategy,
     autoDetectYColumnSlugs,
     combineHistoricalAndProjectionColumns,
@@ -358,19 +362,29 @@ export class DiscreteBarChartState implements ChartState, ColorScaleManager {
                 ? this.entitiesAsSeries
                 : this.columnsAsSeries
 
-        return sortByConfig(raw, this.sortConfig, {
+        const keyFns: Record<
+            DiscreteBarSortKey | SortBy.column,
+            SortKeyFn<DiscreteBarItem>
+        > = {
             [SortBy.custom]:
                 this.seriesStrategy === SeriesStrategy.entity
                     ? (item): number =>
                           this.selectionArray.selectedEntityNames.indexOf(
                               item.seriesName
                           )
-                    : (): undefined => undefined,
+                    : keepInputOrder,
             [SortBy.entityName]: (item): string => item.seriesName,
-            // We only have one yColumn, so total and column are the same
-            [SortBy.column]: (item): number => item.value,
             [SortBy.total]: (item): number => item.value,
-        })
+            // We only have one yColumn, so 'column' is the same as 'total'
+            // (keep for backwards compatibility)
+            [SortBy.column]: (item): number => item.value,
+        }
+
+        return sortByConfig(raw, this.sortConfig, keyFns)
+    }
+
+    @computed get availableSortKeys(): DiscreteBarSortKey[] {
+        return [...DISCRETE_BAR_SORT_KEYS]
     }
 
     @computed private get valuesToColorsMap(): Map<number, string> {

--- a/packages/@ourworldindata/grapher/src/chart/ChartInterface.ts
+++ b/packages/@ourworldindata/grapher/src/chart/ChartInterface.ts
@@ -6,6 +6,7 @@ import {
     Color,
     ChartErrorInfo,
     SideWidths,
+    SortBy,
 } from "@ourworldindata/types"
 import { ColorScale } from "../color/ColorScale"
 import { HorizontalAxis, VerticalAxis } from "../axis/Axis"
@@ -61,6 +62,9 @@ export interface ChartState {
      * doesn't make sense.
      */
     availableFacetStrategies?: FacetStrategy[]
+
+    /** Sort keys this chart type supports */
+    availableSortKeys?: SortBy[]
 }
 
 /** Interface implemented by all chart component classes */

--- a/packages/@ourworldindata/grapher/src/chart/ChartUtils.tsx
+++ b/packages/@ourworldindata/grapher/src/chart/ChartUtils.tsx
@@ -40,6 +40,7 @@ import {
 } from "../core/GrapherConstants"
 import { ChartSeries } from "./ChartInterface"
 import {
+    CoreColumn,
     ErrorValueTypes,
     isNotErrorValueOrEmptyCell,
     OwidTable,
@@ -341,9 +342,22 @@ export function getChartSvgProps({
     }
 }
 
-type SortKeyFn<T> = (item: T) => number | string | undefined
+export type SortKeyFn<T> = (item: T) => number | string | undefined
 
-export type SortKeyFunctions<T> = Record<SortBy, SortKeyFn<T>>
+export type SortKeyFunctions<T> = Partial<Record<SortBy, SortKeyFn<T>>>
+
+/** A sort key that leaves items in their input order */
+export const keepInputOrder: SortKeyFn<unknown> = () => undefined
+
+/** Sort key that orders items by their value in `sortColumn` */
+export function sortByColumnValue<T>(
+    sortColumn: CoreColumn | undefined,
+    getEntityName: (item: T) => EntityName
+): SortKeyFn<T> {
+    return (item) =>
+        sortColumn?.owidRowsByEntityName.get(getEntityName(item))?.[0]?.value ??
+        0
+}
 
 export function sortByConfig<T>(
     items: readonly T[],
@@ -351,7 +365,7 @@ export function sortByConfig<T>(
     keyFns: SortKeyFunctions<T>
 ): T[] {
     const sortByKey = sortConfig.sortBy ?? SortBy.total
-    const sortByFunc = keyFns[sortByKey]
+    const sortByFunc = keyFns[sortByKey] ?? keepInputOrder
     const sortOrder = sortConfig.sortOrder ?? SortOrder.desc
 
     const sortedRows = _.sortBy(items, sortByFunc)

--- a/packages/@ourworldindata/grapher/src/chart/ChartUtils.tsx
+++ b/packages/@ourworldindata/grapher/src/chart/ChartUtils.tsx
@@ -344,10 +344,12 @@ export function getChartSvgProps({
 
 export type SortKeyFn<T> = (item: T) => number | string | undefined
 
-export type SortKeyFunctions<T> = Partial<Record<SortBy, SortKeyFn<T>>>
-
 /** A sort key that leaves items in their input order */
-export const keepInputOrder: SortKeyFn<unknown> = () => undefined
+export const keepInputOrder = Symbol("keepInputOrder")
+
+export type SortKey<T> = SortKeyFn<T> | typeof keepInputOrder
+
+export type SortKeyFunctions<T> = Partial<Record<SortBy, SortKey<T>>>
 
 /** Sort key that orders items by their value in `sortColumn` */
 export function sortByColumnValue<T>(
@@ -355,8 +357,7 @@ export function sortByColumnValue<T>(
     getEntityName: (item: T) => EntityName
 ): SortKeyFn<T> {
     return (item) =>
-        sortColumn?.owidRowsByEntityName.get(getEntityName(item))?.[0]?.value ??
-        0
+        sortColumn?.latestValueByEntityName.get(getEntityName(item)) ?? 0
 }
 
 export function sortByConfig<T>(
@@ -367,6 +368,9 @@ export function sortByConfig<T>(
     const sortByKey = sortConfig.sortBy ?? SortBy.total
     const sortByFunc = keyFns[sortByKey] ?? keepInputOrder
     const sortOrder = sortConfig.sortOrder ?? SortOrder.desc
+
+    if (sortByFunc === keepInputOrder)
+        return sortOrder === SortOrder.desc ? items.toReversed() : [...items]
 
     const sortedRows = _.sortBy(items, sortByFunc)
 

--- a/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
@@ -3517,6 +3517,14 @@ export class GrapherState
         )
     }
 
+    @computed get availableSortKeysAcrossChartTypes(): SortBy[] {
+        const keys = this.validChartTypes.flatMap(
+            (chartType) =>
+                makeChartState(chartType, this).availableSortKeys ?? []
+        )
+        return _.uniq(keys)
+    }
+
     @computed get isInFullScreenMode(): boolean {
         return this._isInFullScreenMode
     }

--- a/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChartConstants.ts
+++ b/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChartConstants.ts
@@ -2,7 +2,7 @@ import { ChartManager } from "../chart/ChartManager"
 import { ChartSeries } from "../chart/ChartInterface"
 import { InteractionState } from "../interaction/InteractionState"
 import { Emphasis } from "../interaction/Emphasis"
-import { EntityName } from "@ourworldindata/types"
+import { EntityName, SortBy } from "@ourworldindata/types"
 import { TextWrap } from "@ourworldindata/components"
 import { SeriesLabelState } from "../seriesLabel/SeriesLabelState"
 import { GRAPHER_OPACITY_MUTED } from "../core/GrapherConstants.js"
@@ -132,3 +132,14 @@ export interface LegendLabel {
     color: string
     textAnchor: "center" | "outward"
 }
+
+export const DUMBBELL_SORT_KEYS = [
+    SortBy.custom,
+    SortBy.entityName,
+    SortBy.total,
+    SortBy.column,
+    SortBy.change,
+    SortBy.startValue,
+    SortBy.endValue,
+] as const
+export type DumbbellSortKey = (typeof DUMBBELL_SORT_KEYS)[number]

--- a/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChartState.ts
+++ b/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChartState.ts
@@ -1,3 +1,4 @@
+import * as R from "remeda"
 import { computed, makeObservable } from "mobx"
 import {
     ColumnSlug,
@@ -14,10 +15,12 @@ import { domainExtent } from "@ourworldindata/utils"
 import { ChartState } from "../chart/ChartInterface"
 import {
     DECREASE_COLOR,
+    DUMBBELL_SORT_KEYS,
     DumbbellChartManager,
     DumbbellHead,
     DumbbellMode,
     DumbbellSeries,
+    DumbbellSortKey,
     END_COLUMN_COLOR,
     INCREASE_COLOR,
     LIGHT_DECREASE_COLOR,
@@ -34,6 +37,8 @@ import {
     isToleranceDistanceValid,
     makeSelectionArray,
     sortByConfig,
+    SortKeyFn,
+    sortByColumnValue,
 } from "../chart/ChartUtils"
 import {
     AnnotationsMap,
@@ -289,7 +294,7 @@ export class DumbbellChartState implements ChartState {
     }
 
     @computed get series(): DumbbellSeries[] {
-        return sortByConfig(this.unsortedSeries, this.sortConfig, {
+        const keyFns: Record<DumbbellSortKey, SortKeyFn<DumbbellSeries>> = {
             [SortBy.custom]: (series): number =>
                 this.selectionArray.selectedEntityNames.indexOf(
                     series.entityName
@@ -297,11 +302,24 @@ export class DumbbellChartState implements ChartState {
             [SortBy.entityName]: (series): string => series.entityName,
             [SortBy.total]: (series): number =>
                 series.start.value + series.end.value,
-            [SortBy.column]: (series): number =>
-                this.sortColumn?.owidRowsByEntityName?.get(
-                    series.entityName
-                )?.[0]?.value ?? 0,
-        })
+            [SortBy.change]: (series): number =>
+                series.end.value - series.start.value,
+            [SortBy.startValue]: (series): number => series.start.value,
+            [SortBy.endValue]: (series): number => series.end.value,
+            [SortBy.column]: sortByColumnValue(
+                this.sortColumn,
+                (series) => series.entityName
+            ),
+        }
+        return sortByConfig(this.unsortedSeries, this.sortConfig, keyFns)
+    }
+
+    @computed get availableSortKeys(): DumbbellSortKey[] {
+        const excluded =
+            this.mode === DumbbellMode.TwoColumn
+                ? [SortBy.startValue, SortBy.endValue]
+                : [SortBy.column]
+        return R.difference([...DUMBBELL_SORT_KEYS], excluded)
     }
 
     @computed get allValues(): number[] {

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.010.yaml
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.010.yaml
@@ -577,26 +577,32 @@ properties:
   sortBy:
     type: string
     description: |
-      Sort criterion (used by discrete bar, stacked discrete bar, and marimekko charts).
+      Sort criterion (used by discrete bar, stacked discrete bar, marimekko, and dumbbell charts).
       - column: sort by the value of a specific column, identified by sortColumnSlug
       - total: sort by the total across all columns
       - entityName: sort alphabetically by entity name
       - custom: preserve the specified entity order
+      - change: sort by the change between the start and end values (dumbbell charts only)
+      - startValue: sort by the start value (dumbbell charts only)
+      - endValue: sort by the end value (dumbbell charts only)
     default: total
     enum:
       - column
       - total
       - entityName
       - custom
+      - change
+      - startValue
+      - endValue
   sortOrder:
     type: string
-    description: Sort order (used by stacked bar charts and marimekko)
+    description: Sort order
     default: desc
     enum:
       - desc
       - asc
   sortColumnSlug:
-    description: Sort column if sortBy is column (used by stacked bar charts and marimekko)
+    description: Sort column if sortBy is column
     type: string
   comparisonLines:
     description: List of comparison lines to draw

--- a/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChartConstants.ts
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChartConstants.ts
@@ -2,6 +2,7 @@ import { ChartManager } from "../chart/ChartManager"
 
 import {
     Color,
+    SortBy,
     SortConfig,
     Time,
     Bounds,
@@ -111,3 +112,11 @@ export interface MarimekkoBarProps {
     y0: number
     dualAxis: DualAxis
 }
+
+export const MARIMEKKO_SORT_KEYS = [
+    SortBy.custom,
+    SortBy.entityName,
+    SortBy.total,
+    SortBy.column,
+] as const
+export type MarimekkoSortKey = (typeof MARIMEKKO_SORT_KEYS)[number]

--- a/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChartState.ts
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChartState.ts
@@ -8,7 +8,9 @@ import {
     BarShape,
     EntityColorData,
     Item,
+    MARIMEKKO_SORT_KEYS,
     MarimekkoChartManager,
+    MarimekkoSortKey,
     SimpleChartSeries,
     SimplePoint,
 } from "./MarimekkoChartConstants"
@@ -381,6 +383,10 @@ export class MarimekkoChartState implements ChartState, ColorScaleManager {
         )
 
         return [...itemsWithValues, ...itemsWithoutValues]
+    }
+
+    @computed get availableSortKeys(): MarimekkoSortKey[] {
+        return [...MARIMEKKO_SORT_KEYS]
     }
 
     @computed get selectedItems(): Item[] {

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBarChartConstants.ts
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBarChartConstants.ts
@@ -1,10 +1,9 @@
-import { Color, EntityName } from "@ourworldindata/types"
+import { Color, EntityName, SortBy } from "@ourworldindata/types"
 import { StackedPoint } from "./StackedConstants.js"
 import { Emphasis } from "../interaction/Emphasis.js"
 import { InteractionState } from "../interaction/InteractionState.js"
 import { SeriesLabelState } from "../seriesLabel/SeriesLabelState.js"
 import { GRAPHER_AREA_OPACITY_MUTED } from "../core/GrapherConstants.js"
-
 interface LabelStyleConfig {
     opacity: number
 }
@@ -57,3 +56,12 @@ export interface RenderBarSegment extends PlacedBarSegment {
     hover: InteractionState
     emphasis: Emphasis
 }
+
+export const STACKED_DISCRETE_BAR_SORT_KEYS = [
+    SortBy.custom,
+    SortBy.entityName,
+    SortBy.total,
+    SortBy.column,
+] as const
+export type StackedDiscreteBarSortKey =
+    (typeof STACKED_DISCRETE_BAR_SORT_KEYS)[number]

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBarChartState.ts
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBarChartState.ts
@@ -14,7 +14,7 @@ import {
 } from "@ourworldindata/types"
 import {
     sortByConfig,
-    SortKeyFn,
+    SortKey,
     keepInputOrder,
     sortByColumnValue,
     autoDetectYColumnSlugs,
@@ -252,7 +252,7 @@ export class StackedDiscreteBarChartState implements ChartState {
     @computed get sortedRows(): readonly DiscreteBarRow[] {
         const keyFns: Record<
             StackedDiscreteBarSortKey,
-            SortKeyFn<DiscreteBarRow>
+            SortKey<DiscreteBarRow>
         > = {
             [SortBy.custom]: keepInputOrder,
             [SortBy.entityName]: (row): string => row.entityName,

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBarChartState.ts
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBarChartState.ts
@@ -9,10 +9,14 @@ import {
     EntityName,
     FacetStrategy,
     MissingDataStrategy,
+    SortBy,
     SortConfig,
 } from "@ourworldindata/types"
 import {
     sortByConfig,
+    SortKeyFn,
+    keepInputOrder,
+    sortByColumnValue,
     autoDetectYColumnSlugs,
     getDefaultFailMessage,
     getShortNameForEntity,
@@ -20,7 +24,11 @@ import {
 } from "../chart/ChartUtils"
 import { SelectionArray } from "../selection/SelectionArray"
 import { StackedSeries } from "./StackedConstants"
-import { DiscreteBarRow } from "./StackedDiscreteBarChartConstants.js"
+import {
+    DiscreteBarRow,
+    STACKED_DISCRETE_BAR_SORT_KEYS,
+    StackedDiscreteBarSortKey,
+} from "./StackedDiscreteBarChartConstants.js"
 import {
     stackSeriesInBothDirections,
     withMissingValuesAsZeroes,
@@ -242,14 +250,23 @@ export class StackedDiscreteBarChartState implements ChartState {
     }
 
     @computed get sortedRows(): readonly DiscreteBarRow[] {
-        return sortByConfig(this.rows, this.sortConfig, {
-            custom: () => undefined,
-            entityName: (row): string => row.entityName,
-            column: (row): number =>
-                this.sortColumn?.owidRowsByEntityName?.get(row.entityName)?.[0]
-                    ?.value ?? 0,
-            total: (row): number => row.totalValue,
-        })
+        const keyFns: Record<
+            StackedDiscreteBarSortKey,
+            SortKeyFn<DiscreteBarRow>
+        > = {
+            [SortBy.custom]: keepInputOrder,
+            [SortBy.entityName]: (row): string => row.entityName,
+            [SortBy.column]: sortByColumnValue(
+                this.sortColumn,
+                (row) => row.entityName
+            ),
+            [SortBy.total]: (row): number => row.totalValue,
+        }
+        return sortByConfig(this.rows, this.sortConfig, keyFns)
+    }
+
+    @computed get availableSortKeys(): StackedDiscreteBarSortKey[] {
+        return [...STACKED_DISCRETE_BAR_SORT_KEYS]
     }
 
     @computed get availableFacetStrategies(): FacetStrategy[] {

--- a/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
+++ b/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
@@ -46,6 +46,12 @@ export enum SortBy {
     column = "column",
     /** Sort by the total across all columns */
     total = "total",
+    /** Sort by the change between the start and end values (dumbbell charts) */
+    change = "change",
+    /** Sort by the start value (dumbbell charts) */
+    startValue = "startValue",
+    /** Sort by the end value (dumbbell charts) */
+    endValue = "endValue",
 }
 
 export interface SortConfig {


### PR DESCRIPTION
Adds three more sorting options for dumbbell plots: by start and end value, and by change.

Also refactors the sorting code a bit: Chart types now expose `availableSortKeys`, which is then used in the admin to construct dropdown options, and to narrow the type for the object specifying the sorting options.

Marimekkos are excluded from the refactor because their sorting is intermingled with other code, and sooner or later we'll rewrite the Marimekko chart component anyway.

### Follow-up work

* ~Dumbbell elements~
* ~New dumbbell-specific options: value labels, end points~
* ~In-chart legend, aligned with the top-most dots~
* ~Interaction (focus, hover, tooltips)~
* Color (hard-coded for now)
* ~More entity sorting options~
* ~Dumbbell plots in search~
* ~Dumbbell chart thumbnails~