### PR TITLE
🐛 load GrapherTrendArrow css in grapher.scss

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/grapher.scss
+++ b/packages/@ourworldindata/grapher/src/core/grapher.scss
@@ -67,6 +67,7 @@
 // so we can't scope them to be grapher-only
 @import "../controls/entityPicker/EntityPicker.scss";
 @import "../fullScreen/FullScreen.scss";
+@import "../../../components/src/GrapherTrendArrow.scss";
 @import "../../../components/src/Checkbox.scss";
 @import "../../../components/src/RadioButton.scss";
 @import "../../../components/src/loadingIndicator/LoadingIndicator.scss";

--- a/packages/@ourworldindata/grapher/src/tooltip/Tooltip.scss
+++ b/packages/@ourworldindata/grapher/src/tooltip/Tooltip.scss
@@ -157,6 +157,7 @@
                             .GrapherTrendArrow {
                                 height: 14px;
                                 padding-right: 0.15em;
+                                transform: translateY(1px);
                             }
                         }
 


### PR DESCRIPTION
GrapherTrendArrow.scss needs to be loaded in grapher.scss or else the styles don't apply in some context.