### PR TITLE
Disable GA4 analytics on preview deployments

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -63,7 +63,12 @@
                 "DATA_API_URL_PARTIAL_PREFIX": "https://api-staging.owid.io/staging-site-",
                 "DATA_API_URL_PARTIAL_POSTFIX": "/v1/indicators/",
                 "DATA_API_URL_COMPLETE": "",
-                "CLOUDFLARE_GOOGLE_ANALYTICS_SAMPLING_RATE": "1",
+                // Disable GA4 analytics on preview/staging deployments. Previews
+                // are 100%-sampled while prod is 1%, so their hits (esp. bulk
+                // crawlers like ClaudeBot hammering *.owid.pages.dev) badly skew
+                // any raw event count. "0" passes env validation but shouldSample
+                // (Math.random() < 0) is always false, so no events are sent.
+                "CLOUDFLARE_GOOGLE_ANALYTICS_SAMPLING_RATE": "0",
                 "CATALOG_URL": "https://catalog.ourworldindata.org"
             }
         },


### PR DESCRIPTION
## What

Sets `CLOUDFLARE_GOOGLE_ANALYTICS_SAMPLING_RATE` to `"0"` in the **preview** env block of `wrangler.jsonc` (was `"1"`). Production keeps `"0.01"`.

## Why

Preview/staging deployments were sampled at **100%** while prod is at **1%**. That asymmetry means preview hits — overwhelmingly bulk crawlers like ClaudeBot hammering `*.owid.pages.dev` — landed in GA4 at 100× the relative weight of real prod traffic, badly skewing any raw `cf_function_invocation` event count and mixing preview noise into prod analytics. We don't want preview analytics at all.

## How it works

Setting the rate to `"0"`:
- still passes `validateAnalyticsEnvVariables` (it only checks the var is a non-empty string), so nothing else in the middleware changes;
- makes `shouldSample` → `Math.random() < parseFloat("0")` → `Math.random() < 0` → **always false**, so `analyticsMiddleware` returns `context.next()` without ever calling `sendEventToGA4`.

Net effect: zero analytics events emitted from any preview/staging deployment, applied automatically to all current and future preview branches. No code path changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)