### PR TITLE
Capture Cloudflare bot-detection signals on analytics events

### DIFF
--- a/functions/_common/analytics.test.ts
+++ b/functions/_common/analytics.test.ts
@@ -15,7 +15,12 @@ describe(getCommonEventParams, () => {
         )
         // Cloudflare populates request.cf in production; simulate it here.
         Object.assign(request, {
-            cf: { asOrganization: "Amazon.com", asn: 16509 },
+            cf: {
+                asOrganization: "Amazon.com",
+                asn: 16509,
+                botManagement: { verifiedBot: true, score: 30 },
+                verifiedBotCategory: "Search Engine Crawler",
+            },
         })
 
         const params = getCommonEventParams(request, {
@@ -31,6 +36,9 @@ describe(getCommonEventParams, () => {
         expect(params.sampling).toBe(0.25)
         expect(params.as_org).toBe("Amazon.com")
         expect(params.asn).toBe(16509)
+        expect(params.bot_score).toBe(30)
+        expect(params.verified_bot).toBe(1)
+        expect(params.verified_bot_category).toBe("Search Engine Crawler")
 
         expect(params.q_bar).toBe("baz")
         expect(params.q_country).toBe("DE")

--- a/functions/_common/analytics.ts
+++ b/functions/_common/analytics.ts
@@ -68,6 +68,24 @@ export function getCommonEventParams(
     const as_org = (request.cf?.asOrganization || "").slice(0, 100)
     const asn = request.cf?.asn ?? 0
 
+    // Cloudflare bot-detection signals, also on `request.cf`. We're on Super Bot
+    // Fight Mode (Pro/Business), NOT Enterprise Bot Management, so the numeric
+    // `score` and JA3/JA4 fingerprints are very likely absent — these fields are
+    // captured to empirically confirm what actually populates on our plan, and
+    // would start carrying real data automatically if we ever add the Enterprise
+    // add-on. `bot_score` uses a -1 sentinel so "field absent" stays
+    // distinguishable from a real score (which is always 1–99). `verified_bot`
+    // flags Cloudflare's Verified Bots program (authoritative Googlebot/Bingbot/
+    // etc.), with the category in `verified_bot_category`. Not PII.
+    const bot_score = request.cf?.botManagement?.score ?? -1
+    const verified_bot = request.cf?.botManagement?.verifiedBot ? 1 : 0
+    // verifiedBotCategory isn't in this @cloudflare/workers-types version yet, so
+    // it surfaces via the cf index signature as `unknown`; String() keeps it
+    // type-safe without an `as` cast.
+    const verified_bot_category = String(
+        request.cf?.verifiedBotCategory ?? "",
+    ).slice(0, 100)
+
     const params: Record<string, string | number> = {
         host: url.hostname,
         pathname: url.pathname,
@@ -77,6 +95,9 @@ export function getCommonEventParams(
         country: request.headers.get("cf-ipcountry") || "",
         as_org,
         asn,
+        bot_score,
+        verified_bot,
+        verified_bot_category,
         // Stamp the sampling rate that was active when this event fired, so periods
         // with different rates can be combined correctly downstream
         // (events / sampling ≈ unbiased request count).

--- a/functions/_common/analytics.ts
+++ b/functions/_common/analytics.ts
@@ -83,7 +83,7 @@ export function getCommonEventParams(
     // it surfaces via the cf index signature as `unknown`; String() keeps it
     // type-safe without an `as` cast.
     const verified_bot_category = String(
-        request.cf?.verifiedBotCategory ?? "",
+        request.cf?.verifiedBotCategory ?? ""
     ).slice(0, 100)
 
     const params: Record<string, string | number> = {


### PR DESCRIPTION
## What

Adds three fields to `cf_function_invocation` GA4 events, read from `request.cf` (the same source as `as_org`/`asn` from #6566):

- **`bot_score`** — `request.cf.botManagement.score` (1–99 bot-likelihood), with a **-1 sentinel** when absent.
- **`verified_bot`** — `request.cf.botManagement.verifiedBot` as 0/1 (Cloudflare's Verified Bots program — authoritative Googlebot/Bingbot/etc.).
- **`verified_bot_category`** — `request.cf.verifiedBotCategory` (string).

## Why

We want a stronger bot signal than UA-string heuristics. The catch: OWID's zone is on **Super Bot Fight Mode** (Pro/Business), **not** Enterprise Bot Management — so `score` and the JA3/JA4 fingerprints are very likely *not* populated for Workers. Rather than assume, this captures the fields so we can **empirically confirm** what actually arrives on our plan (the `-1`/empty-string defaults make "field absent" unambiguous). If OWID ever adds the Enterprise Bot Management add-on, these fields start carrying real data with zero further code change.

`verified_bot` / `verified_bot_category` tie to the free Verified Bots program and have a real chance of populating even on our plan — that's the main thing we're testing.

## Notes

- `verifiedBotCategory` isn't in our pinned `@cloudflare/workers-types` version yet, so it surfaces via the cf index signature as `unknown`; wrapped in `String()` to stay type-safe without an `as` cast (consistent with #6566's no-cast approach).
- Fields are sent as separate scalars rather than a stringified `botManagement` object, because GA4 MP hard-truncates param values at 100 chars (a full object, esp. with JA4 + detectionIds on Enterprise, would truncate into invalid JSON).
- Mirrored in cloudflare-workers (companion PR) so the proxy workers stay in sync.
- No PII: ASN org + bot classification only, no client IP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)