### PR TITLE
🐛🤖 stop scheduled gdocs leaking into the chronological search index

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -421,6 +421,10 @@ reindex: node_modules
 	@echo '--- Running indexExplorerViewsMdimViewsAndChartsToAlgolia...'
 	yarn tsx --tsconfig tsconfig.tsx.json baker/algolia/indexExplorerViewsMdimViewsAndChartsToAlgolia.js
 
+index-scheduled: node_modules
+	@echo '==> Indexing scheduled (newly-live) gdocs into the pages-chronological Algolia index'
+	yarn tsx --tsconfig tsconfig.tsx.json baker/algolia/indexScheduledPagesChronologicalToAlgolia.js
+
 delete-algolia-index: node_modules
 	@echo '==> Deleting Algolia index'
 	yarn tsx --tsconfig tsconfig.tsx.json baker/algolia/deleteAlgoliaIndex.js

--- a/baker/algolia/indexScheduledPagesChronologicalToAlgolia.ts
+++ b/baker/algolia/indexScheduledPagesChronologicalToAlgolia.ts
@@ -1,0 +1,99 @@
+// This should be imported as early as possible so the global error handler is
+// set up before any errors are thrown.
+import "../../serverUtils/instrument.js"
+
+import * as Sentry from "@sentry/node"
+import { SearchClient } from "algoliasearch"
+import * as db from "../../db/db.js"
+import { ALGOLIA_INDEXING } from "../../settings/serverSettings.js"
+import { getAlgoliaClient } from "./configureAlgolia.js"
+import { getIndexName } from "../../site/search/searchClient.js"
+import {
+    CHRONOLOGICAL_INDEX_TYPE_VALUES,
+    SearchIndexName,
+} from "@ourworldindata/types"
+import { checkIsChronologicalGdoc } from "@ourworldindata/utils"
+import { getAndLoadGdocById } from "../../db/model/Gdoc/GdocFactory.js"
+import { indexIndividualGdocInChronological } from "./utils/pagesChronological.js"
+
+/**
+ * Indexes scheduled gdocs into the pages-chronological index once their
+ * `publishedAt` has passed. Intended to be run on a schedule (e.g. a Buildkite
+ * cron) at the bake cadence.
+ *
+ * The single-save path skips scheduled posts and the weekly full reindex
+ * excludes them, so this closes that gap by indexing recently-live posts that
+ * aren't in the index yet.
+ *
+ * Scoped to the chronological index for now. The regular pages index has the
+ * same gap for scheduled posts and the same approach would apply there — it
+ * just hasn't been wired up yet, so it keeps its weekly-batch behavior.
+ */
+const indexScheduledPagesChronologicalToAlgolia = async () => {
+    if (!ALGOLIA_INDEXING) {
+        console.log("Algolia indexing is disabled. Exiting.")
+        process.exit(0)
+    }
+
+    const client = getAlgoliaClient()
+    if (!client) {
+        console.error(
+            "Failed indexing newly-live scheduled gdocs (Algolia client not initialized)"
+        )
+        return
+    }
+
+    const indexName = getIndexName(SearchIndexName.PagesChronological)
+
+    await db.knexReadonlyTransaction(async (trx) => {
+        const ids = await db.getRecentlyPublishedGdocIds(trx, [
+            ...CHRONOLOGICAL_INDEX_TYPE_VALUES,
+        ])
+        if (!ids.length) {
+            console.log("No recently-published chronological gdocs to check.")
+            return
+        }
+
+        // Only index posts not already in the index (from a previous run or
+        // the save path), so we write each newly-live post once.
+        const missing = await getUnindexedObjectIds(client, indexName, ids)
+        console.log(
+            `${ids.length} recently-published gdocs, ${missing.length} missing from ${indexName}.`
+        )
+
+        for (const id of missing) {
+            const gdoc = await getAndLoadGdocById(trx, id)
+            if (checkIsChronologicalGdoc(gdoc)) {
+                await indexIndividualGdocInChronological(gdoc, trx)
+            }
+        }
+    }, db.TransactionCloseMode.Close)
+
+    process.exit(0)
+}
+
+/** Returns the subset of `objectIDs` that aren't yet present in `indexName`. */
+async function getUnindexedObjectIds(
+    client: SearchClient,
+    indexName: string,
+    objectIDs: string[]
+): Promise<string[]> {
+    if (!objectIDs.length) return []
+    const { results } = await client.getObjects<{ objectID: string } | null>({
+        requests: objectIDs.map((objectID) => ({
+            indexName,
+            objectID,
+            attributesToRetrieve: ["objectID"],
+        })),
+    })
+    // `results` is aligned positionally with the requests; a null means the
+    // object isn't in the index.
+    return objectIDs.filter((_, i) => results[i] === null)
+}
+
+indexScheduledPagesChronologicalToAlgolia().catch(async (e) => {
+    console.error("Error in indexScheduledPagesChronologicalToAlgolia:", e)
+    Sentry.captureException(e)
+    await Sentry.close()
+    process.exit(1)
+})

--- a/baker/algolia/utils/pagesChronological.ts
+++ b/baker/algolia/utils/pagesChronological.ts
@@ -302,6 +302,13 @@ export async function indexIndividualGdocInChronological(
 ): Promise<void> {
     if (!ALGOLIA_INDEXING) return
 
+    // Don't index scheduled posts (publishedAt in the future); they're picked
+    // up by indexScheduledPagesChronologicalToAlgolia once they go live.
+    const isScheduled = gdoc.publishedAt
+        ? gdoc.publishedAt.getTime() > Date.now()
+        : false
+    if (isScheduled) return
+
     const client = getAlgoliaClient()
     if (!client) {
         console.error(

--- a/db/db.ts
+++ b/db/db.ts
@@ -512,6 +512,26 @@ export const getPublishedGdocsWithTags = async (
     }).then((rows) => rows.map(parsePostsGdocsWithTagsRow))
 }
 
+// Ids of published gdocs of the given types that went live in the last
+// `withinHours`.
+export const getRecentlyPublishedGdocIds = async (
+    knex: KnexReadonlyTransaction,
+    gdocTypes: OwidGdocType[],
+    withinHours = 24
+): Promise<string[]> => {
+    const rows = await knexRaw<{ id: string }>(
+        knex,
+        `-- sql
+        SELECT id FROM posts_gdocs
+        WHERE published = 1
+          AND type IN (:gdocTypes)
+          AND publishedAt <= NOW()
+          AND publishedAt > (NOW() - INTERVAL :hours HOUR)`,
+        { gdocTypes, hours: withinHours }
+    )
+    return rows.map((r) => r.id)
+}
+
 export const getNonGrapherExplorerViewCount = (
     knex: KnexReadonlyTransaction
 ): Promise<number> => {


### PR DESCRIPTION
> Stops scheduled (embargoed) articles from leaking into the public `pages-chronological` search index, and adds a scheduled script that indexes them into it once they actually go live.

## What & why

The `/latest` feed is powered by the Algolia `pages-chronological` index. Scheduled posts (`published = 1` but `publishedAt` in the future) leaked into that **public** index on save: `indexIndividualGdocInChronological` had no scheduled guard (unlike the pages/profile index paths), so embargoed titles, excerpts, bodies and thumbnails were readable by anyone querying Algolia directly — even though the `/latest` card itself was hidden client-side. The weekly full reindex meanwhile *excludes* scheduled posts, so the two indexers fought each other (save adds → batch removes).

## Changes

- **Plug the leak:** `indexIndividualGdocInChronological` now skips scheduled posts, matching the existing guards in `indexIndividualGdocPost` / `indexIndividualProfile`. Embargoed content no longer enters the index on save.
- **Index once live:** new `indexScheduledPagesChronologicalToAlgolia` script (run via `make index-scheduled`, meant to run on a Buildkite schedule at the bake cadence) indexes scheduled posts into the chronological index once their `publishedAt` passes. It uses the index itself as an idempotency ledger (a batched `getObjects`), so each newly-live post is written exactly once, while still retrying until success across the lookback window.
- **New db helper:** `getRecentlyPublishedGdocIds` returns published chronological gdocs that went live in the last N hours.

Scoped to the chronological index only — the regular pages index keeps its existing weekly-batch behavior for scheduled posts (same gap, same approach would apply, just not wired up yet).

## Test plan

- `yarn typecheck`, `yarn testLintChanged`, `yarn testFormatChanged` all pass.
- Verified end-to-end against a real index with a scheduled article:
  - before go-live → no candidates (query gate excludes future `publishedAt`)
  - after go-live, first run → `1 recently-published gdocs, 1 missing` → indexed
  - immediate re-run → `1 recently-published gdocs, 0 missing` → no redundant write (exactly-once)

## Rollout tasks (this PR drives both repos)

- [x] **owid-grapher (this PR):** `indexScheduledPagesChronologicalToAlgolia` script + `make index-scheduled` target.
- [x] **ops:** merge owid/ops#492 (the `grapher-algolia-scheduled` Buildkite pipeline YAML).
- [x] **Buildkite UI:** create a `grapher-algolia-scheduled` pipeline (paste the loader snippet into its Steps; it `pipeline upload`s `.buildkite/grapher/algolia_scheduled.yml`).
- [x] **Buildkite UI:** add a ~6h **Schedule** to that pipeline.

Until the pipeline + schedule exist, scheduled posts still reach `pages-chronological` via the existing weekly full reindex — just with up to a week of latency. The leak fix itself is effective as soon as this PR merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)