### PR TITLE
data pages: metadata box A/B experiment (data-page-metadata-v1)

### DIFF
--- a/baker/GrapherBaker.tsx
+++ b/baker/GrapherBaker.tsx
@@ -6,6 +6,8 @@ import {
     excludeUndefined,
     mergeGrapherConfigs,
     Url,
+    isUrlInActiveExperiment,
+    DATA_PAGE_METADATA_EXPERIMENT_ID,
 } from "@ourworldindata/utils"
 import fs from "fs-extra"
 import {
@@ -25,6 +27,7 @@ import {
     DimensionProperty,
     OwidVariableWithSource,
     OwidChartDimensionInterface,
+    AdditionalIndicator,
     FaqEntryData,
     ImageMetadata,
     DbPlainChart,
@@ -38,6 +41,7 @@ import {
     getVariableDistribution,
     getMergedGrapherConfigForVariable,
     getVariableOfDatapageIfApplicable,
+    getVariableMetadata,
 } from "../db/model/Variable.js"
 import {
     fetchAndParseFaqs,
@@ -102,6 +106,12 @@ const renderDatapageIfApplicable = async (
 
 /**
  * Render a datapage if available, otherwise render a grapher page.
+ *
+ * Charts enrolled in the data-page metadata experiment are forced to bake
+ * as data pages — otherwise an enrolled grapher that wouldn't normally
+ * qualify (e.g. one without a primary datapage indicator) would fall
+ * through to `renderGrapherPage` and never see the metadata-box treatment
+ * the experiment is supposed to test.
  */
 export const renderDataPageOrGrapherPage = async (
     grapher: GrapherInterface,
@@ -114,9 +124,17 @@ export const renderDataPageOrGrapherPage = async (
         archiveContextDictionary?: Record<number, ArchiveContext | undefined>
     } = {}
 ): Promise<string> => {
+    const forceDatapage =
+        !!grapher.slug &&
+        isUrlInActiveExperiment(
+            DATA_PAGE_METADATA_EXPERIMENT_ID,
+            `/grapher/${grapher.slug}`
+        )
+
     const datapage = await renderDatapageIfApplicable(grapher, false, knex, {
         imageMetadataDictionary,
         archiveContextDictionary,
+        forceDatapage,
     })
     if (datapage) return datapage
     return renderGrapherPage(grapher, knex, {
@@ -159,30 +177,39 @@ export async function renderDataPageV2(
         ? mergeGrapherConfigs(grapherConfigForVariable ?? {}, pageGrapher ?? {})
         : (pageGrapher ?? {})
 
-    const faqDocIds = _.compact(
-        _.uniq(variableMetadata.presentation?.faqs?.map((faq) => faq.gdocId))
-    )
-
-    const faqGdocs = await fetchAndParseFaqs(knex, faqDocIds, { isPreviewing })
-
-    const { resolvedFaqs, errors: faqResolveErrors } = resolveFaqsForVariable(
-        faqGdocs,
-        variableMetadata
-    )
-
-    if (faqResolveErrors.length > 0) {
-        for (const error of faqResolveErrors) {
-            await logErrorAndMaybeCaptureInSentry(
-                new Error(
-                    `Data page error in finding FAQs for variable ${variableId}: ${error.error}`
+    // Resolve the FAQ blocks for a single variable. Factored out so we can
+    // resolve FAQs both for the primary indicator and, on charts enrolled in
+    // the metadata box experiment, for each additional Y-indicator.
+    const resolveFaqsForOneVariable = async (
+        metadata: OwidVariableWithSource,
+        idForLog: number
+    ): Promise<FaqEntryData> => {
+        const faqDocIds = _.compact(
+            _.uniq(metadata.presentation?.faqs?.map((faq) => faq.gdocId))
+        )
+        const faqGdocs = await fetchAndParseFaqs(knex, faqDocIds, {
+            isPreviewing,
+        })
+        const { resolvedFaqs, errors: faqResolveErrors } =
+            resolveFaqsForVariable(faqGdocs, metadata)
+        if (faqResolveErrors.length > 0) {
+            for (const error of faqResolveErrors) {
+                await logErrorAndMaybeCaptureInSentry(
+                    new Error(
+                        `Data page error in finding FAQs for variable ${idForLog}: ${error.error}`
+                    )
                 )
-            )
+            }
+        }
+        return {
+            faqs: resolvedFaqs?.flatMap((faq) => faq.enrichedFaq.content) ?? [],
         }
     }
 
-    const faqEntries: FaqEntryData = {
-        faqs: resolvedFaqs?.flatMap((faq) => faq.enrichedFaq.content) ?? [],
-    }
+    const faqEntries = await resolveFaqsForOneVariable(
+        variableMetadata,
+        variableId
+    )
 
     // If we are rendering this in the context of an indicator page preview or similar,
     // then the chart config might be entirely empty. Make sure that dimensions is
@@ -201,7 +228,67 @@ export async function renderDataPageV2(
         _.compact(grapher.dimensions.map(({ variableId }) => variableId))
     )
     const distribution = await getVariableDistribution(knex, variableIds)
-    const datapageData = getDatapageDataV2(variableMetadata, grapher)
+
+    // The metadata box experiment renders an indicator switcher over all of a
+    // chart's Y-indicators. Only the enrolled charts (the experiment's `paths`)
+    // pay the cost of loading the extra per-indicator metadata; everything else
+    // bakes exactly as before with `additionalIndicators` left undefined. The
+    // experiment's `paths` list is the single source of truth, shared with the
+    // React component that decides whether to emit the dual-arm markup.
+    const isInMetadataExperiment =
+        !!grapher.slug &&
+        isUrlInActiveExperiment(
+            DATA_PAGE_METADATA_EXPERIMENT_ID,
+            `/grapher/${grapher.slug}`
+        )
+
+    // For multi-indicator charts the per-dimension `display.name` (set by the
+    // chart author) is the right per-indicator label — the chart-level `title`
+    // describes the whole chart, not any one indicator. Only used on enrolled
+    // charts so non-enrolled data pages keep their existing title resolution
+    // (which falls back to `grapherConfig.title`).
+    const indicatorTitleOverrideFor = (varId: number): string | undefined =>
+        grapher.dimensions?.find(
+            (d) => d.property === DimensionProperty.y && d.variableId === varId
+        )?.display?.name
+
+    const datapageData = getDatapageDataV2(
+        variableMetadata,
+        grapher,
+        isInMetadataExperiment
+            ? { indicatorTitleOverride: indicatorTitleOverrideFor(variableId) }
+            : undefined
+    )
+
+    let additionalIndicators: AdditionalIndicator[] | undefined
+    if (isInMetadataExperiment) {
+        const additionalYVariableIds = _.uniq(
+            _.compact(
+                grapher.dimensions
+                    .filter((d) => d.property === DimensionProperty.y)
+                    .map((d) => d.variableId)
+            )
+        ).filter((id) => id !== variableId)
+
+        additionalIndicators = await pMap(
+            additionalYVariableIds,
+            async (id) => {
+                // noCache to match how the primary indicator's metadata is
+                // fetched (getVariableOfDatapageIfApplicable), so a bake always
+                // reflects the latest variable metadata.
+                const metadata = await getVariableMetadata(id, {
+                    noCache: true,
+                })
+                return {
+                    datapageData: getDatapageDataV2(metadata, grapher, {
+                        indicatorTitleOverride: indicatorTitleOverrideFor(id),
+                    }),
+                    faqEntries: await resolveFaqsForOneVariable(metadata, id),
+                }
+            },
+            { concurrency: 5 }
+        )
+    }
 
     datapageData.primaryTopic = await getPrimaryTopic(
         knex,
@@ -260,6 +347,7 @@ export async function renderDataPageV2(
         <DataPageV2
             grapher={grapher}
             datapageData={datapageData}
+            additionalIndicators={additionalIndicators}
             canonicalUrl={canonicalUrl}
             baseUrl={BAKED_BASE_URL}
             isPreviewing={isPreviewing}
@@ -284,9 +372,20 @@ export const renderPreviewDataPageOrGrapherPage = async (
 ) => {
     const archiveContextDictionary =
         await getLatestArchivedChartPageVersionsIfEnabled(knex)
+    // Force data-page rendering for experiment-enrolled charts (same as the
+    // production bake path in `renderDataPageOrGrapherPage`), so admin
+    // previews show the metadata box on enrolled charts even if they
+    // wouldn't normally qualify as data pages.
+    const forceDatapage =
+        options?.forceDatapage ||
+        (!!grapher.slug &&
+            isUrlInActiveExperiment(
+                DATA_PAGE_METADATA_EXPERIMENT_ID,
+                `/grapher/${grapher.slug}`
+            ))
     const datapage = await renderDatapageIfApplicable(grapher, true, knex, {
         archiveContextDictionary,
-        forceDatapage: options?.forceDatapage,
+        forceDatapage,
     })
     if (datapage) return datapage
 

--- a/db/model/Variable.ts
+++ b/db/model/Variable.ts
@@ -588,6 +588,12 @@ export async function getAllChartsForIndicator(
 /**
  * Returns the indicator ID to use for datapage metadata if the grapher is
  * eligible for a datapage, otherwise undefined.
+ *
+ * An explicit `datapages` row always wins when present — `forceDatapage` only
+ * comes into play when no row exists, in which case it falls back to the first
+ * y-dimension variable. Prevents `forceDatapage=true` from silently swapping
+ * the bake's primary variable on a chart that has an explicitly configured
+ * datapage indicator.
  */
 export async function getDatapageIndicatorId(
     knex: db.KnexReadonlyTransaction,
@@ -596,7 +602,24 @@ export async function getDatapageIndicatorId(
         forceDatapage?: boolean
     }
 ): Promise<number | undefined> {
-    // If a data page is forced, simply return the first y-dimension
+    if (grapher.id) {
+        const row = await knexRawFirst<DbPlainDatapage>(
+            knex,
+            `-- sql
+                SELECT variableId
+                FROM datapages
+                WHERE chartId = ?
+            `,
+            [grapher.id]
+        )
+        if (row) return row.variableId
+    } else if (!options?.forceDatapage) {
+        console.warn(
+            "Grapher must have an ID to check for datapage eligibility"
+        )
+        return undefined
+    }
+
     if (options?.forceDatapage) {
         const yVariableIds = grapher
             .dimensions!.filter((d) => d.property === DimensionProperty.y)
@@ -604,24 +627,7 @@ export async function getDatapageIndicatorId(
         return yVariableIds[0]
     }
 
-    if (!grapher.id) {
-        console.warn(
-            "Grapher must have an ID to check for datapage eligibility"
-        )
-        return undefined
-    }
-
-    const row = await knexRawFirst<DbPlainDatapage>(
-        knex,
-        `-- sql
-            SELECT variableId
-            FROM datapages
-            WHERE chartId = ?
-        `,
-        [grapher.id]
-    )
-
-    return row?.variableId
+    return undefined
 }
 
 // TODO: these are domain functions and should live somewhere else

--- a/packages/@ourworldindata/grapher/src/footer/Footer.scss
+++ b/packages/@ourworldindata/grapher/src/footer/Footer.scss
@@ -20,10 +20,63 @@
     .sources a.learn-more-about-data,
     .note a {
         text-decoration: underline;
+        cursor: pointer;
 
         &:hover {
             text-decoration: none;
         }
+    }
+
+    // --- Metadata box A/B experiment: source line variants on data pages ---
+    // The Footer.tsx render emits BOTH variants inside <p class="sources">
+    // on data pages — control ("Data source: … — Learn more about this
+    // data") and treatment (source text itself is the link, no suffix).
+    // Toggled via the experiment's body class. We don't use the generic
+    // experiment --show/--hide classes here because their active rule sets
+    // `display: block` + 24px margin, which is meant for big section blocks
+    // and would break the inline footer layout. Using inline-friendly
+    // BEM modifier classes scoped to .sources keeps the styling local and
+    // explicit about the layout constraint.
+
+    // Default state (no experiment cookie, control arm assigned, or chart
+    // not enrolled): show the control variant only.
+    .sources__variant--treatment {
+        display: none;
+    }
+
+    // Treatment arm: swap which variant is visible. `inline` preserves the
+    // footer's text flow inside the <p>.
+    body.exp-data-page-metadata-v1--treatment & {
+        .sources__variant--control {
+            display: none;
+        }
+        .sources__variant--treatment {
+            display: inline;
+        }
+    }
+
+    // In the treatment arm the source text itself is the link
+    // (`learn-more-about-data--datapage-link`). The last
+    // markdown-text-wrap line is `display: inline-block` (see rule below),
+    // which creates its own text-decoration scope so the underline from
+    // the <a> doesn't visually pass through. Apply underline to every
+    // line of markdown text inside the link so the whole source reads as
+    // a link — but exclude the leading "Data source:" <strong> so the
+    // label itself isn't underlined (the user clicks the source name,
+    // not the prefix).
+    .sources a.learn-more-about-data--datapage-link .markdown-text-wrap__line {
+        text-decoration: underline;
+    }
+    .sources
+        a.learn-more-about-data--datapage-link:hover
+        .markdown-text-wrap__line {
+        text-decoration: none;
+    }
+    .sources a.learn-more-about-data--datapage-link strong {
+        // inline-block creates a new text-decoration scope so the
+        // underline from the line above doesn't visually pass through.
+        display: inline-block;
+        text-decoration: none;
     }
 
     // show "Learn more about this data" link on the same line

--- a/packages/@ourworldindata/grapher/src/footer/Footer.tsx
+++ b/packages/@ourworldindata/grapher/src/footer/Footer.tsx
@@ -10,6 +10,7 @@ import {
 } from "@ourworldindata/utils"
 import {
     DATAPAGE_ABOUT_THIS_DATA_SECTION_ID,
+    DATAPAGE_SOURCES_AND_PROCESSING_SECTION_ID,
     MarkdownTextWrap,
     MarkdownTextWrapHtml,
     MarkdownTextWrapSvg,
@@ -446,6 +447,90 @@ abstract class AbstractFooter<
             lineHeight: this.lineHeight,
         })
 
+        // Builds the click handler that scrolls (or opens the modal as a
+        // fallback) for the source-line link. Parameterized by which
+        // section to scroll to so the treatment variant on data pages can
+        // jump directly to "Data sources" without changing the existing
+        // "About this data" behavior on non-enrolled data pages.
+        const makeOnClickSources = (
+            datapageSectionId: string
+        ): ((e: React.MouseEvent) => void) =>
+            action((e: React.MouseEvent) => {
+                e.stopPropagation()
+
+                // if embedded (and not on a data page), open the sources modal
+                if (
+                    this.manager.isEmbeddedInAnOwidPage ||
+                    this.manager.isInIFrame
+                ) {
+                    this.manager.activeModal = GrapherModal.Sources
+                    return
+                }
+
+                const sourcesElement =
+                    document.getElementById(datapageSectionId)
+                if (sourcesElement && sourcesElement.scrollIntoView) {
+                    sourcesElement.scrollIntoView({ behavior: "smooth" })
+                    this.manager.isInFullScreenMode = false
+                } else if (sourcesElement) {
+                    window.location.hash = "#" + datapageSectionId
+                    this.manager.isInFullScreenMode = false
+                } else {
+                    this.manager.activeModal = GrapherModal.Sources
+                }
+            })
+
+        // Control variant + non-data-page grapher pages: existing behavior —
+        // scroll to (or open the modal if absent) "About this data".
+        const onClickSourcesControl = makeOnClickSources(
+            DATAPAGE_ABOUT_THIS_DATA_SECTION_ID
+        )
+
+        if (this.manager.isEmbeddedInADataPage) {
+            // Render BOTH variants inside the same <p>. Custom class names
+            // (NOT the generic experiment show/hide classes — those apply
+            // `display: block` + 24px margin meant for big section blocks
+            // and break inline footer layout). The CSS toggle lives in
+            // Footer.scss, keyed off the experiment's body class:
+            // - default / control arm / non-enrolled data pages:
+            //   "Data source: … — Learn more about this data" visible,
+            //   click scrolls to "About this data" (unchanged).
+            // - treatment arm (body has
+            //   `exp-data-page-metadata-v1--treatment`): source text
+            //   itself is the link, no trailing "Learn more about this
+            //   data", click scrolls straight to "Data sources" inside
+            //   the metadata box.
+            const onClickSourcesTreatment = makeOnClickSources(
+                DATAPAGE_SOURCES_AND_PROCESSING_SECTION_ID
+            )
+            return (
+                <p className="sources" style={sources.style}>
+                    <span className="sources__variant sources__variant--control">
+                        <MarkdownTextWrapHtml textWrap={sources} />
+                        {" – "}
+                        <a
+                            className="learn-more-about-data"
+                            data-track-note="chart_click_sources"
+                            tabIndex={0}
+                            onClick={onClickSourcesControl}
+                        >
+                            Learn more about this data
+                        </a>
+                    </span>
+                    <span className="sources__variant sources__variant--treatment">
+                        <a
+                            className="learn-more-about-data learn-more-about-data--datapage-link"
+                            data-track-note="chart_click_sources"
+                            tabIndex={0}
+                            onClick={onClickSourcesTreatment}
+                        >
+                            <MarkdownTextWrapHtml textWrap={sources} />
+                        </a>
+                    </span>
+                </p>
+            )
+        }
+
         return (
             <p className="sources" style={sources.style}>
                 <MarkdownTextWrapHtml textWrap={sources} />
@@ -454,37 +539,7 @@ abstract class AbstractFooter<
                     className="learn-more-about-data"
                     data-track-note="chart_click_sources"
                     tabIndex={0}
-                    onClick={action((e) => {
-                        e.stopPropagation()
-
-                        // if embbedded, open the sources modal
-                        if (
-                            this.manager.isEmbeddedInAnOwidPage ||
-                            this.manager.isInIFrame
-                        ) {
-                            this.manager.activeModal = GrapherModal.Sources
-                            return
-                        }
-
-                        // on data pages, scroll to the "Sources and Processing" section
-                        // on grapher pages, open the sources modal
-                        const datapageSectionId =
-                            DATAPAGE_ABOUT_THIS_DATA_SECTION_ID
-                        const sourcesElement =
-                            document.getElementById(datapageSectionId)
-                        if (sourcesElement && sourcesElement.scrollIntoView) {
-                            sourcesElement.scrollIntoView({
-                                behavior: "smooth",
-                            })
-                            this.manager.isInFullScreenMode = false
-                        } else if (sourcesElement) {
-                            window.location.hash = "#" + datapageSectionId
-                            this.manager.isInFullScreenMode = false
-                        } else {
-                            // on grapher pages, open the sources modal
-                            this.manager.activeModal = GrapherModal.Sources
-                        }
-                    })}
+                    onClick={onClickSourcesControl}
                 >
                     Learn more about this data
                 </a>

--- a/packages/@ourworldindata/types/src/gdocTypes/Datapage.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/Datapage.ts
@@ -64,6 +64,15 @@ export type Distribution =
 
 export interface DataPageV2ContentFields {
     datapageData: DataPageDataV2
+    /**
+     * Per-indicator metadata for the non-primary Y-indicators of a chart.
+     * Populated at bake time only for charts enrolled in the data page metadata
+     * experiment (see DATA_PAGE_METADATA_EXPERIMENT_ID); left undefined for
+     * ordinary single-indicator data pages. The metadata box renders an
+     * indicator switcher over `[primary, ...additionalIndicators]` when this is
+     * non-empty.
+     */
+    additionalIndicators?: AdditionalIndicator[]
     faqEntries: FaqEntryData | undefined
     // TODO: add gdocs for FAQs
     isPreviewing?: boolean
@@ -72,6 +81,11 @@ export interface DataPageV2ContentFields {
     imageMetadata: Record<string, ImageMetadata>
     archiveContext?: ArchiveContext
     distribution: Distribution
+}
+
+export interface AdditionalIndicator {
+    datapageData: DataPageDataV2
+    faqEntries?: FaqEntryData
 }
 
 export interface DisplaySource {

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -237,6 +237,7 @@ export {
 export {
     type Distribution,
     type DataPageV2ContentFields,
+    type AdditionalIndicator,
     type DataPageDataV2,
     type DataPageRelatedResearch,
     type PrimaryTopic,

--- a/packages/@ourworldindata/utils/src/experiments/config.ts
+++ b/packages/@ourworldindata/utils/src/experiments/config.ts
@@ -43,6 +43,12 @@ export const experiments: Experiment[] = [
             "/grapher/carbon-intensity-electricity",
             "/grapher/share-electricity-renewables",
             "/grapher/unemployment-rate",
+            "/grapher/economic-inequality-gini-index",
+            "/grapher/child-mortality",
+            "/grapher/cross-country-literacy-rates",
+            "/grapher/gender-inequality-index-from-the-human-development-report",
+            "/grapher/daily-per-capita-caloric-supply",
+            "/grapher/number-of-measles-cases",
             // multi-indicator data pages
             "/grapher/annual-number-of-deaths-by-cause",
             "/grapher/electricity-prod-source-stacked",
@@ -50,6 +56,10 @@ export const experiments: Experiment[] = [
             "/grapher/global-energy-substitution",
             "/grapher/population-growth-rates",
             "/grapher/temperature-anomaly",
+            "/grapher/annual-deaths-by-age",
+            "/grapher/measles-cases-and-death-rate",
+            "/grapher/urban-vs-rural-majority",
+            "/grapher/population-by-age-group-with-projections",
         ],
     }),
     /*

--- a/packages/@ourworldindata/utils/src/experiments/config.ts
+++ b/packages/@ourworldindata/utils/src/experiments/config.ts
@@ -1,9 +1,57 @@
 import { Experiment } from "./Experiment.js"
+import {
+    DATA_PAGE_METADATA_EXPERIMENT_ID,
+    EXPERIMENT_PREFIX,
+} from "./constants.js"
 
 /*
  * Hard-coded active experiments.
  */
 export const experiments: Experiment[] = [
+    /*
+     * Experiment: data-page-metadata-v1
+     *
+     * Trials a redesigned "metadata box" beneath the chart on data pages. The
+     * box consolidates "What you should know about this indicator", FAQs, data
+     * sources, and citation guidance into a single collapsible block, with an
+     * indicator switcher for charts that plot multiple Y-indicators.
+     *
+     * Conditions:
+     * - (a) control: the current data page (AboutThisData + Sources/Reuse sections)
+     * - (b) treatment: the new metadata box in place of those sections
+     */
+    new Experiment({
+        id: DATA_PAGE_METADATA_EXPERIMENT_ID,
+        expires: "2026-12-31T00:00:00.000Z",
+        arms: [
+            { id: "control", fraction: 0.0 },
+            { id: "treatment", fraction: 1.0 },
+        ],
+        paths: [
+            // single indicator data pages
+            "/grapher/democracy-index-eiu",
+            "/grapher/gdp-per-capita-worldbank",
+            "/grapher/gdp-per-capita-maddison-project-database",
+            "/grapher/life-expectancy",
+            "/grapher/co-emissions-per-capita",
+            "/grapher/human-development-index",
+            "/grapher/population",
+            "/grapher/human-rights-index-vdem",
+            "/grapher/per-capita-energy-use",
+            "/grapher/share-of-population-in-extreme-poverty",
+            "/grapher/oil-production-by-country",
+            "/grapher/carbon-intensity-electricity",
+            "/grapher/share-electricity-renewables",
+            "/grapher/unemployment-rate",
+            // multi-indicator data pages
+            "/grapher/annual-number-of-deaths-by-cause",
+            "/grapher/electricity-prod-source-stacked",
+            "/grapher/population-with-un-projections",
+            "/grapher/global-energy-substitution",
+            "/grapher/population-growth-rates",
+            "/grapher/temperature-anomaly",
+        ],
+    }),
     /*
      * Experiment: all-charts-vs-featured-v1
      *
@@ -82,3 +130,16 @@ export const experiments: Experiment[] = [
         paths: ["/"],
     }),
 ]
+
+/**
+ * True iff an experiment with the given raw id (i.e. without the `exp-`
+ * prefix the `Experiment` constructor adds) is registered, not expired, and
+ * the given url is in its `paths` list. Centralises the lookup so callers
+ * don't need to know about the prefix convention or the expiry semantics.
+ * The actual path-matching is delegated to `Experiment.isUrlInPaths`.
+ */
+export function isUrlInActiveExperiment(rawId: string, url: string): boolean {
+    const id = `${EXPERIMENT_PREFIX}-${rawId}`
+    const exp = experiments.find((e) => e.id === id)
+    return !!exp && !exp.isExpired() && exp.isUrlInPaths(url)
+}

--- a/packages/@ourworldindata/utils/src/experiments/constants.ts
+++ b/packages/@ourworldindata/utils/src/experiments/constants.ts
@@ -2,3 +2,11 @@
 
 export const EXPERIMENT_ARM_SEPARATOR = "--"
 export const EXPERIMENT_PREFIX = "exp"
+
+// Raw id (without the `exp-` prefix) of the data page metadata box experiment.
+// Shared between the baker (to decide which charts get the extra per-indicator
+// metadata loaded) and the data page React component (to gate the dual-arm
+// markup), so the experiment's `paths` list is the single source of truth for
+// which graphers are enrolled.
+export const DATA_PAGE_METADATA_EXPERIMENT_ID = "data-page-metadata-v1"
+export const DATA_PAGE_METADATA_EXPERIMENT_TREATMENT_ARM = "treatment"

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -353,7 +353,7 @@ export {
     parseArchivalDate,
 } from "./archival/archivalDate.js"
 
-export { experiments } from "./experiments/config.js"
+export { experiments, isUrlInActiveExperiment } from "./experiments/config.js"
 export {
     Experiment,
     validateUniqueExperimentIds,
@@ -367,6 +367,8 @@ export {
 export {
     EXPERIMENT_ARM_SEPARATOR,
     EXPERIMENT_PREFIX,
+    DATA_PAGE_METADATA_EXPERIMENT_ID,
+    DATA_PAGE_METADATA_EXPERIMENT_TREATMENT_ARM,
 } from "./experiments/constants.js"
 
 export {

--- a/site/DataPageV2.tsx
+++ b/site/DataPageV2.tsx
@@ -31,7 +31,11 @@ import { SiteHeader } from "./SiteHeader.js"
 import { IFrameDetector } from "./IframeDetector.js"
 import { DebugProvider } from "./gdocs/DebugProvider.js"
 import { Html } from "./Html.js"
-import { ArchiveContext, Distribution } from "@ourworldindata/types"
+import {
+    AdditionalIndicator,
+    ArchiveContext,
+    Distribution,
+} from "@ourworldindata/types"
 import { DEFAULT_PAGE_DESCRIPTION } from "./dataPage.js"
 import { makeJsonLdGrapherImageUrl } from "./jsonLdHelpers.js"
 import { JsonLdDataPage } from "./jsonLd.js"
@@ -39,6 +43,7 @@ import { JsonLdDataPage } from "./jsonLd.js"
 export const DataPageV2 = (props: {
     grapher: GrapherInterface | undefined
     datapageData: DataPageDataV2
+    additionalIndicators?: AdditionalIndicator[]
     baseUrl: string
     canonicalUrl: string
     isPreviewing: boolean
@@ -52,6 +57,7 @@ export const DataPageV2 = (props: {
     const {
         grapher,
         datapageData,
+        additionalIndicators,
         baseUrl,
         canonicalUrl,
         isPreviewing,
@@ -174,6 +180,7 @@ export const DataPageV2 = (props: {
                             __html: `window._OWID_DATAPAGEV2_PROPS = ${JSON.stringify(
                                 {
                                     datapageData,
+                                    additionalIndicators,
                                     faqEntries,
                                     canonicalUrl,
                                     tagToSlugMap: minimalTagToSlugMap,
@@ -187,6 +194,7 @@ export const DataPageV2 = (props: {
                         <DebugProvider debug={isPreviewing}>
                             <DataPageV2Content
                                 datapageData={datapageData}
+                                additionalIndicators={additionalIndicators}
                                 grapherConfig={grapherConfig}
                                 imageMetadata={imageMetadata}
                                 isPreviewing={isPreviewing}

--- a/site/DataPageV2Content.tsx
+++ b/site/DataPageV2Content.tsx
@@ -190,7 +190,25 @@ export const DataPageV2Content = ({
                     />
                 </div>
                 <div className="DataPageContent grid grid-cols-12-full-width">
-                    <div className="bg-blue-10 span-cols-14">
+                    {/*
+                     * On multi-indicator charts in the metadata-box treatment
+                     * arm, the page-level header names only the primary
+                     * indicator while the box's own indicator switcher and
+                     * title row already cover indicator identification, so the
+                     * page H1 reads as misleading (it doesn't reflect the
+                     * currently-selected indicator). Hide it via the experiment
+                     * --hide class so the body class set by the Cloudflare
+                     * middleware controls visibility per arm. Single-indicator
+                     * treatment pages keep the header — the H1 is accurate.
+                     * Non-enrolled / control charts are unaffected.
+                     */}
+                    <div
+                        className={`bg-blue-10 span-cols-14${
+                            additionalIndicators?.length
+                                ? ` ${metadataTreatmentHideClass}`
+                                : ""
+                        }`}
+                    >
                         <div className="header__wrapper grid grid-cols-12-full-width">
                             <div className="header__left col-start-2 span-cols-8 col-sm-start-2 span-sm-cols-12">
                                 <div className="header__supertitle">Data</div>

--- a/site/DataPageV2Content.tsx
+++ b/site/DataPageV2Content.tsx
@@ -8,6 +8,9 @@ import {
 import {
     EXPERIMENT_ARM_SEPARATOR,
     EXPERIMENT_PREFIX,
+    DATA_PAGE_METADATA_EXPERIMENT_ID,
+    DATA_PAGE_METADATA_EXPERIMENT_TREATMENT_ARM,
+    isUrlInActiveExperiment,
     DataPageV2ContentFields,
     GrapherInterface,
     joinTitleFragments,
@@ -25,8 +28,11 @@ import {
     BAKED_GRAPHER_URL,
 } from "../settings/clientSettings.js"
 import AboutThisData from "./AboutThisData.js"
+import MetadataSectionCollapsible from "./MetadataSectionCollapsible.js"
 import DataPageResearchAndWriting from "./DataPageResearchAndWriting.js"
-import { type DownloadSectionProps } from "./DownloadSection.js"
+import DownloadSection, {
+    type DownloadSectionProps,
+} from "./DownloadSection.js"
 import MetadataSection from "./MetadataSection.js"
 import TopicTags from "./TopicTags.js"
 import { processRelatedResearch } from "./dataPage.js"
@@ -46,6 +52,7 @@ export const OWID_DATAPAGE_CONTENT_ROOT_ID = "owid-datapageJson-root"
 
 export const DataPageV2Content = ({
     datapageData,
+    additionalIndicators,
     grapherConfig,
     isPreviewing = false,
     faqEntries,
@@ -59,6 +66,24 @@ export const DataPageV2Content = ({
     imageMetadata: Record<string, ImageMetadata>
 }) => {
     const slug = grapherConfig.slug
+
+    // Whether this chart is enrolled in the metadata box experiment. Both arms
+    // are baked into the static HTML; CSS (site/experiments.scss) shows the one
+    // matching the body class the Cloudflare middleware sets. Derived from the
+    // experiment's `paths` — the same source of truth the baker uses to decide
+    // whether to load the per-indicator metadata — so we never render the
+    // treatment markup for a chart that wasn't baked with its data.
+    const inMetadataExperiment =
+        !!slug &&
+        isUrlInActiveExperiment(
+            DATA_PAGE_METADATA_EXPERIMENT_ID,
+            `/grapher/${slug}`
+        )
+    const metadataArmClass = `${EXPERIMENT_PREFIX}-${DATA_PAGE_METADATA_EXPERIMENT_ID}${EXPERIMENT_ARM_SEPARATOR}${DATA_PAGE_METADATA_EXPERIMENT_TREATMENT_ARM}`
+    // Shown only in the treatment arm; hidden by default.
+    const metadataTreatmentShowClass = `${metadataArmClass}${EXPERIMENT_ARM_SEPARATOR}show`
+    // Shown by default; hidden in the treatment arm (the box subsumes these).
+    const metadataTreatmentHideClass = `${metadataArmClass}${EXPERIMENT_ARM_SEPARATOR}hide`
     const queryStr =
         typeof window !== "undefined" ? window?.location?.search : undefined
     const reactiveQueryStr = useWindowQueryParams()
@@ -183,7 +208,21 @@ export const DataPageV2Content = ({
                             />
                         </div>
                     </div>
-                    <nav className="sticky-nav sticky-nav--dark span-cols-14 grid grid-cols-12-full-width">
+                    {/*
+                     * In the metadata-box treatment arm the box subsumes
+                     * AboutThisData, Sources & Processing, and Reuse This Work,
+                     * so most of the sticky-nav targets would resolve to
+                     * display:none elements. Hide the nav entirely in treatment
+                     * via the experiment CSS until we decide what a treatment-
+                     * specific nav should expose.
+                     */}
+                    <nav
+                        className={`sticky-nav sticky-nav--dark span-cols-14 grid grid-cols-12-full-width${
+                            inMetadataExperiment
+                                ? ` ${metadataTreatmentHideClass}`
+                                : ""
+                        }`}
+                    >
                         <StickyNav
                             className="span-cols-12 col-start-2"
                             links={stickyNavLinks}
@@ -209,7 +248,25 @@ export const DataPageV2Content = ({
                                 datapageData={datapageData}
                                 hasFaq={!!faqEntries?.faqs.length}
                                 id={DATAPAGE_ABOUT_THIS_DATA_SECTION_ID}
+                                className={
+                                    inMetadataExperiment
+                                        ? metadataTreatmentHideClass
+                                        : undefined
+                                }
                             />
+                            {inMetadataExperiment && (
+                                <div className={metadataTreatmentShowClass}>
+                                    <MetadataSectionCollapsible
+                                        datapageData={datapageData}
+                                        additionalIndicators={
+                                            additionalIndicators
+                                        }
+                                        faqEntries={faqEntries}
+                                        canonicalUrl={canonicalUrl}
+                                        archiveContext={archiveContext}
+                                    />
+                                </div>
+                            )}
                         </div>
                     </div>
                     <div className="col-start-2 span-cols-12">
@@ -281,6 +338,11 @@ export const DataPageV2Content = ({
                         )}
                     </div>
                     <MetadataSection
+                        className={
+                            inMetadataExperiment
+                                ? metadataTreatmentHideClass
+                                : undefined
+                        }
                         attributionShort={datapageData.attributionShort}
                         attributions={datapageData.attributions}
                         canonicalUrl={canonicalUrl}
@@ -297,6 +359,26 @@ export const DataPageV2Content = ({
                         archiveContext={archiveContext}
                         downloadProps={downloadProps}
                     />
+                    {/*
+                     * Treatment arm: the metadata box replaces the FAQs /
+                     * sources / citations of MetadataSection above (hidden by
+                     * --hide), but the page still needs a Download section at
+                     * the bottom. Render it standalone, gated by the treatment
+                     * --show class so the matching DownloadSection inside
+                     * the (hidden) MetadataSection above isn't duplicated.
+                     */}
+                    {inMetadataExperiment && downloadProps && (
+                        <div
+                            className={`MetadataSection span-cols-14 grid grid-cols-12-full-width ${metadataTreatmentShowClass}`}
+                        >
+                            <div className="col-start-2 span-cols-12">
+                                <DownloadSection
+                                    {...downloadProps}
+                                    archivedChartInfo={archiveContext}
+                                />
+                            </div>
+                        </div>
+                    )}
                 </div>
             </DocumentContext.Provider>
         </AttachmentsContext.Provider>

--- a/site/DetailedDetailsOnDemand.tsx
+++ b/site/DetailedDetailsOnDemand.tsx
@@ -1,0 +1,86 @@
+import { ReactNode, KeyboardEvent, useId, useState } from "react"
+import cx from "classnames"
+import { Modal, ModalOverlay, Dialog } from "react-aria-components"
+import { faExpand } from "@fortawesome/free-solid-svg-icons"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import { CloseButton } from "@ourworldindata/components"
+
+export default function DetailedDetailsOnDemand({
+    title,
+    triggerText,
+    children,
+    className,
+    triggerClassName,
+}: {
+    title: string
+    triggerText: string
+    children: ReactNode
+    className?: string
+    triggerClassName?: string
+}) {
+    const [isOpen, setIsOpen] = useState(false)
+    const titleId = useId()
+
+    const onTriggerKeyDown = (event: KeyboardEvent<HTMLSpanElement>) => {
+        if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault()
+            setIsOpen(true)
+        }
+    }
+
+    return (
+        <>
+            <span
+                className={cx(
+                    "DetailedDetailsOnDemand__trigger",
+                    triggerClassName
+                )}
+                role="button"
+                tabIndex={0}
+                aria-haspopup="dialog"
+                onClick={() => setIsOpen(true)}
+                onKeyDown={onTriggerKeyDown}
+            >
+                <span>{triggerText}</span>
+                <FontAwesomeIcon
+                    className="DetailedDetailsOnDemand__trigger-icon"
+                    icon={faExpand}
+                    aria-hidden
+                />
+            </span>
+            <ModalOverlay
+                className="DetailedDetailsOnDemand__overlay"
+                isDismissable
+                isOpen={isOpen}
+                onOpenChange={setIsOpen}
+            >
+                <Modal className="DetailedDetailsOnDemand__modal">
+                    <Dialog
+                        aria-labelledby={titleId}
+                        className={cx("DetailedDetailsOnDemand", className)}
+                    >
+                        {({ close }) => (
+                            <>
+                                <div className="DetailedDetailsOnDemand__header">
+                                    <h3
+                                        className="DetailedDetailsOnDemand__title"
+                                        id={titleId}
+                                    >
+                                        {title}
+                                    </h3>
+                                    <CloseButton
+                                        className="DetailedDetailsOnDemand__close-button"
+                                        onClick={() => close()}
+                                    />
+                                </div>
+                                <div className="DetailedDetailsOnDemand__content">
+                                    {children}
+                                </div>
+                            </>
+                        )}
+                    </Dialog>
+                </Modal>
+            </ModalOverlay>
+        </>
+    )
+}

--- a/site/MetadataSection.tsx
+++ b/site/MetadataSection.tsx
@@ -43,6 +43,7 @@ export default function MetadataSection({
     titleVariant,
     archiveContext,
     downloadProps,
+    className,
 }: {
     attributionShort?: string
     attributions: string[]
@@ -57,6 +58,7 @@ export default function MetadataSection({
     titleVariant?: string
     archiveContext?: ArchiveContext
     downloadProps?: DownloadSectionProps
+    className?: string
 }) {
     const sourcesForDisplay = prepareSourcesForDisplay({ origins, source })
     const citationUrl = archiveContext?.archiveUrl ?? canonicalUrl
@@ -99,7 +101,11 @@ export default function MetadataSection({
         }`,
     ]).join(" ")
     return (
-        <div className="MetadataSection span-cols-14 grid grid-cols-12-full-width">
+        <div
+            className={`MetadataSection span-cols-14 grid grid-cols-12-full-width${
+                className ? ` ${className}` : ""
+            }`}
+        >
             <div className="col-start-2 span-cols-12">
                 {!!faqEntries?.faqs.length && (
                     <div className="section-wrapper section-wrapper__faqs grid">

--- a/site/MetadataSectionCollapsible.scss
+++ b/site/MetadataSectionCollapsible.scss
@@ -1264,13 +1264,21 @@
     border: 1px solid $blue-20;
     color: $blue-70;
     cursor: pointer;
+    // min-height (not height) + inline-flex centring lets the pill grow
+    // when its label wraps to a second line on narrow viewports. The
+    // border-radius is intentionally larger than the tallest expected
+    // pill height so wrapped pills still read as stadium-shaped.
     padding: 4px 14px;
-    height: 30px;
+    min-height: 30px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
     border-radius: 999px;
     font-family: $sans-serif-font-stack;
     font-size: 0.8125rem;
     font-weight: 500;
-    line-height: 1;
+    line-height: 1.2;
     transition:
         background-color 120ms ease,
         border-color 120ms ease,

--- a/site/MetadataSectionCollapsible.scss
+++ b/site/MetadataSectionCollapsible.scss
@@ -1,0 +1,1410 @@
+// Styles for MetadataSectionCollapsible. Targets only .MetadataSectionCollapsible__*
+// classes (or descendants of .MetadataSectionCollapsible), so the rules apply
+// only inside the rendered metadata box.
+
+.MetadataSectionCollapsible-wrap {
+    position: relative;
+    margin-bottom: 32px;
+
+    @include sm-up {
+        margin-bottom: 48px;
+    }
+
+    // Match the grapher's visible chart width (excluding the entity-selector
+    // panel that renders to the right of the chart on wide viewports). The
+    // grapher switches the entity selector from a side panel to a drawer
+    // when its chart frame crosses ~940px — which, on the data-page layout,
+    // happens at a viewport of 988px. Above that, the chart proper
+    // occupies ~9 of the 12 inner cols (75%); below it, the chart takes
+    // the full 12 cols and the metadata box can grow to match.
+    @media (min-width: 988px) {
+        max-width: 75%;
+        margin-left: 0;
+        margin-right: auto;
+    }
+}
+
+// Inline "Show less" affordance inside the header row (__above-switcher).
+// Pushed to the right via flexbox below. Hidden by default; revealed when
+// the box is open via `:has(.MetadataSectionCollapsible[open])` on the wrap.
+// Click target is the surrounding __above row, not this span — so this is
+// purely visual feedback. Small + $blue-50: meant to read as a quiet
+// "close" hint, not a primary action (the bottom "Show less" bar still
+// renders for users who scrolled deep into the open box).
+.MetadataSectionCollapsible__inline-show-less {
+    display: none;
+    align-items: center;
+    gap: 4px;
+    color: $blue-50;
+    font-family: $sans-serif-font-stack;
+    font-size: 0.75rem;
+    font-weight: 500;
+    line-height: 1;
+    margin-left: auto;
+}
+
+.MetadataSectionCollapsible-wrap:has(.MetadataSectionCollapsible[open])
+    .MetadataSectionCollapsible__inline-show-less {
+    display: inline-flex;
+}
+
+// Whole header row is the click target for collapsing when open — cursor
+// pointer so users know they can click it.
+.MetadataSectionCollapsible-wrap:has(.MetadataSectionCollapsible[open])
+    .MetadataSectionCollapsible__above {
+    cursor: pointer;
+}
+
+// Header strip sitting above the box. Now a flex column containing:
+//   1) `__above-switcher`: the title / dropdown / h-tabs row
+//   2) the short description ("TLDR")
+//   3) the stat factoids row
+// Styled to read as a header subsection of the metadata block — same
+// surface as the box below, attached with shared borders.
+// One pane per indicator wraps each per-indicator section. ALL indicators'
+// metadata are rendered at all times so AI agents / unmodified-HTML
+// consumers can read every indicator's data on a single GET; only the
+// active pane is visible to the human user. `display: contents` lets the
+// active pane's children participate in the parent's flex/grid layout as
+// if there were no wrapper element.
+.MetadataSectionCollapsible__indicator-pane {
+    display: none;
+}
+.MetadataSectionCollapsible__indicator-pane--active {
+    display: contents;
+}
+
+.MetadataSectionCollapsible__above {
+    display: flex;
+    flex-direction: column;
+    // Slightly looser than the previous 8px so the prefixes ("Short
+    // description", "Data source", and the factoid row) get a bit more
+    // breathing room and the closed view doesn't feel cramped.
+    gap: 12px;
+    // Same surface as the collapsible box below — the whole metadata block
+    // reads as one flat $blue-5 panel (Figma has no border / no radius / no
+    // visual seam between the header strip and the body).
+    background-color: $blue-5;
+    border: 0;
+    border-radius: 0;
+    // Top 24 sets the outer-box top inset; bottom 16 + summary's top 16 +
+    // 1px divider = symmetric ~16px above and below the header divider.
+    padding: 24px 24px 16px;
+}
+
+// Inner row of the header: prefix + switcher (+ variant) on one
+// baseline-aligned line that wraps on narrow viewports.
+.MetadataSectionCollapsible__above-switcher {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 8px 12px;
+}
+
+// Multi-indicator header for h-tabs and h-pills variants — "About this
+// data ({N} indicators)" label + the switcher row, rendered OUTSIDE the
+// $blue-5 box so the row reads as a header for the whole box (the
+// selected indicator's title appears as the first line inside the box).
+.MetadataSectionCollapsible__multi-header {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+
+    // Override the small-caps title-prefix treatment when it lives inside
+    // the multi-header: at this position the label IS the section header
+    // for the box below, so it should match the data page's other h2 tags
+    // (serif h2-bold 20px). The "(N indicators)" count keeps its smaller
+    // sans treatment beside the heading.
+    .MetadataSectionCollapsible__indicator-header-group {
+        align-items: baseline;
+        gap: 8px;
+    }
+
+    .MetadataSectionCollapsible__indicator-title-prefix {
+        @include h2-bold;
+        & {
+            margin: 0;
+            color: $blue-90;
+            text-transform: none;
+            letter-spacing: 0;
+            white-space: normal;
+        }
+    }
+
+    .MetadataSectionCollapsible__indicator-count {
+        font-style: normal;
+        color: $blue-50;
+        font-size: 0.875rem;
+    }
+}
+
+// h-tabs: the tab row is flush with the box top so the active tab can
+// visually fuse with the box. No gap between header and box.
+.MetadataSectionCollapsible-wrap--h-tabs
+    .MetadataSectionCollapsible__multi-header {
+    margin-bottom: 0;
+}
+
+// h-pills: a small gap between the pill row and the box so the pills
+// clearly read as "above" the box rather than attached to it.
+.MetadataSectionCollapsible-wrap--h-pills
+    .MetadataSectionCollapsible__multi-header {
+    margin-bottom: 12px;
+}
+
+// `__main` is the row that holds the (optional) vertical-tab aside and the
+// collapsible box. Single column by default; flex row for the v-tabs variant.
+.MetadataSectionCollapsible__main {
+    display: block;
+}
+
+.MetadataSectionCollapsible-wrap--v-tabs .MetadataSectionCollapsible__main {
+    display: flex;
+    align-items: stretch;
+}
+
+// Figma: the outer box is just $blue-5 fill with 24px padding — no border,
+// no rounded corners. (The v-tabs aside still needs a left border to seam
+// with its sidebar; preserved via the modifier below.)
+.MetadataSectionCollapsible {
+    background-color: $blue-5;
+    border: 0;
+    border-radius: 0;
+    overflow: hidden;
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
+// The wrapping `.chart-key-info` defines its own 24/80px padding (used on
+// data pages without the collapsible metadata box). On the experiment we
+// let the box's own margin-bottom be the source of truth for the spacing
+// between the metadata block and what follows — avoids doubled spacing.
+.DataPageContent .chart-key-info:has(.MetadataSectionCollapsible-wrap) {
+    padding-bottom: 0;
+}
+
+.MetadataSectionCollapsible__summary {
+    cursor: pointer;
+    display: block;
+    // 1px #d0dae3 divider above the bullets (Figma "Line 55"). Drawn as a
+    // pseudo-element so it sits inset from the box edges (matches the
+    // Figma — the line is 24px short of the outer box on each side, not
+    // flush to the margins). Bottom padding intentionally small so the
+    // "Show more" chip below the fading bullets sits in a tight final
+    // strip, symmetric with the 12px flex-gap above it.
+    position: relative;
+    padding: 16px 24px 12px;
+    list-style: none;
+    transition: background-color 120ms ease;
+
+    &::before {
+        content: "";
+        position: absolute;
+        top: 0;
+        left: 24px;
+        right: 24px;
+        height: 1px;
+        background-color: #d0dae3;
+    }
+
+    &::marker,
+    &::-webkit-details-marker {
+        display: none;
+    }
+}
+
+// Subtle hover hint that the (collapsed) block is clickable. The hex
+// sits ~3% darker than $blue-5 (#f0f4fa) while preserving blue
+// saturation, mirroring the idiom used by .data-page-related-content
+// (which hovers $blue-20 → #cfdaeb). Apply across the whole wrap (the
+// header strip, the v-tabs aside, and the box) so the entire component
+// reads as one hoverable unit. `:has()` keeps the effect off when the
+// box is already open OR when the multi-header (out-of-box "About this
+// data" + switcher row) is the actual hover target — those are not part
+// of the box surface, they're a label/control row above it.
+.MetadataSectionCollapsible-wrap:not(
+        :has(.MetadataSectionCollapsible[open])
+    ):hover:not(:has(.MetadataSectionCollapsible__multi-header:hover)) {
+    cursor: pointer;
+
+    .MetadataSectionCollapsible__above,
+    .MetadataSectionCollapsible__v-tabs,
+    .MetadataSectionCollapsible {
+        background-color: #e3ebf5;
+    }
+}
+
+// When expanded, only the "Show less" toggle collapses on click (the
+// click handler on <summary> preventDefaults clicks elsewhere). Shift
+// the cursor cue accordingly.
+// When the box is open, the summary holds the "What you should know"
+// prose — let the cursor default to the browser's natural per-element
+// behavior (text I-beam over prose so users can select, arrow over
+// non-text), instead of the `default` arrow that would mask the text
+// affordance.
+.MetadataSectionCollapsible[open] .MetadataSectionCollapsible__summary {
+    cursor: auto;
+}
+
+.MetadataSectionCollapsible__summary-key-data {
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+// --- Stat factoids (Unit, Last updated, Managed by) ---
+// Rendered inside the metadata box (since the stats describe the indicator,
+// they belong with the rest of its metadata). Plain inline label-value pairs,
+// separated by middots — no pill chrome, since these aren't clickable.
+
+.MetadataSectionCollapsible__factoids {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    // Horizontal spacing between factoids is set via column-gap on the
+    // parent (not margin-left on consecutive children) so that wrapped
+    // items start flush at the left edge instead of getting an extra
+    // 16px indent on the new line.
+    column-gap: 20px;
+    row-gap: 4px;
+}
+
+// Figma: factoid row is Lato-Medium 13/16, labels in $blue-50, values in
+// $blue-90. The whole row sits on a single line — "Unit Tonnes per person
+// · Last updated November 13, 2025 · …".
+.MetadataSectionCollapsible__summary-stat {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 6px;
+    min-width: 0;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    line-height: calc(16 / 13);
+}
+
+// (Horizontal spacing between consecutive factoids is set via
+// `.__factoids` `column-gap` above so wrapped items don't get an indent.)
+
+.MetadataSectionCollapsible__summary-stat-title {
+    color: $blue-50;
+    white-space: nowrap;
+    font-weight: 500;
+    letter-spacing: 0;
+    text-transform: none;
+}
+
+.MetadataSectionCollapsible__summary-stat-value {
+    color: $blue-90;
+    min-width: 0;
+    font-weight: 500;
+}
+
+// --- Toggle (Show more / Show less) ---
+// - Show more: centered chip at the bottom of the summary, only when collapsed.
+// - Show less: same slot at the bottom, only when expanded.
+// No background or hover styling on the chip itself; the whole summary
+// changes color on hover (collapsed only) to hint at clickability.
+
+// Figma: Show more / Show less is Lato-SemiBold 16/24 in $vermillion.
+// Plain inline layout (not inline-flex) so the chevron uses FontAwesome's
+// own `vertical-align: -.125em`, which lines it up with the text x-height
+// the way the existing `key-info__learn-more` link does.
+.MetadataSectionCollapsible__toggle {
+    font-family: $sans-serif-font-stack;
+    font-size: 1rem;
+    font-weight: 600;
+    line-height: calc(24 / 16);
+    color: $vermillion;
+}
+
+.MetadataSectionCollapsible__toggle--show-more {
+    align-self: center;
+    // No extra vertical margin/padding — the 12px flex-gap above (in
+    // __summary-key-data) and the 12px __summary padding-bottom below
+    // already give the chip a symmetric ~12px frame, so it reads as
+    // vertically centered in the small final strip beneath the fade.
+    margin: 0;
+    padding: 0;
+}
+
+// Full-width clickable bottom bar — direct child of <details>, sitting
+// below `__content` so it spans the box's full inner width. The whole
+// strip collapses the box; hover hint mirrors the overall hover color so
+// the bar reads as part of the same action.
+.MetadataSectionCollapsible__toggle--show-less {
+    @include body-3-medium;
+    appearance: none;
+    background: transparent;
+    border: 0;
+    cursor: pointer;
+    width: 100%;
+    padding: 10px 16px;
+    color: $blue-60;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    transition: background-color 120ms ease;
+
+    @include sm-up {
+        padding: 12px 24px;
+    }
+
+    &:hover,
+    &:focus-visible {
+        background-color: #e3ebf5;
+        color: $blue-90;
+        outline: none;
+    }
+}
+
+.MetadataSectionCollapsible__toggle-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.MetadataSectionCollapsible__icon {
+    font-size: 0.75rem;
+    transition: transform 160ms ease;
+}
+
+// In the inline Show-more chip, the chevron sits to the right of the text
+// with a 6px gap. FontAwesome's default `vertical-align: -.125em` does the
+// optical centering with the text x-height for us — same idiom as
+// `.key-info__learn-more` elsewhere on the data page.
+.MetadataSectionCollapsible__toggle--show-more
+    .MetadataSectionCollapsible__icon {
+    margin-left: 6px;
+}
+
+.MetadataSectionCollapsible__icon--up {
+    transform: rotate(180deg);
+}
+
+.MetadataSectionCollapsible[open]
+    .MetadataSectionCollapsible__toggle--show-more {
+    display: none;
+}
+
+// --- Body content ---
+
+.MetadataSectionCollapsible__content {
+    // Figma Frame 899: 32px itemSpacing between major sections, 24px
+    // outer-box padding (top is contributed by __summary above).
+    padding: 0 24px 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 32px;
+
+    > * {
+        margin: 0;
+    }
+}
+
+// --- Indicator title + variant + (multi) pill, rendered above the box ---
+// Title, variant, and optional "Indicator:" pill are direct children of
+// `.MetadataSectionCollapsible__above`, so their layout comes from that row.
+
+// Figma (Lato-Bold 16/21, #1d3d63 = $blue-90, no caps).
+// Wrapper around the indicator title + optional variant. Inline-flex with
+// baseline alignment so the variant sits on the title's baseline (the
+// __above-switcher's `align-items: center` was centering each span on its
+// own box midline, which doesn't match when the two have different font
+// sizes).
+.MetadataSectionCollapsible__indicator-title-line {
+    display: inline-flex;
+    align-items: baseline;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.MetadataSectionCollapsible__indicator-title {
+    font-family: $sans-serif-font-stack;
+    font-size: 1rem;
+    font-weight: 700;
+    line-height: calc(21 / 16);
+    letter-spacing: 0;
+    color: $blue-90;
+    text-transform: none;
+}
+
+.MetadataSectionCollapsible__indicator-title-variant {
+    @include h6-black-caps;
+    color: $blue-50;
+    font-weight: 600;
+    font-size: 0.75rem;
+    letter-spacing: 0.05em;
+}
+
+// --- Multi-indicator: indicator title is a dropdown trigger ---
+// On multi-indicator data pages, the indicator title is rendered as a
+// MDIM-style pill button (mirrors .md-settings__dropdown-toggle in
+// site/multiDim/DimensionDropdown.scss).
+
+.MetadataSectionCollapsible__indicator-title-trigger {
+    @include body-3-medium;
+    appearance: none;
+    background: $white;
+    border: 1px solid $gray-20;
+    color: $blue-90;
+    cursor: pointer;
+    padding: 4px 10px 4px 12px;
+    height: 32px;
+    border-radius: 4px;
+    text-align: left;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    max-width: 100%;
+    min-width: 0;
+    line-height: 1;
+    letter-spacing: 0.01em;
+    transition:
+        background-color 120ms ease,
+        border-color 120ms ease;
+
+    &:hover {
+        background: $gray-5;
+        border-color: $blue-30;
+    }
+
+    &:focus-visible {
+        outline: none;
+        border-color: $blue-50;
+    }
+
+    // Open state — matches MDIM's pressed/[data-pressed] look so the
+    // pill reads as "active control" while the popover is showing.
+    &[aria-expanded="true"] {
+        background: #dbe5f0;
+        border-color: #dbe5f0;
+        color: $blue-90;
+        cursor: default;
+    }
+}
+
+// "About this data (N indicators)" inline pair in the switcher row.
+// The v-tabs aside overrides this to stack vertically (label on top,
+// count below) via the `__v-tabs-label` modifier.
+.MetadataSectionCollapsible__indicator-header-group {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 4px;
+}
+
+.MetadataSectionCollapsible__indicator-header-group.MetadataSectionCollapsible__v-tabs-label {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0;
+}
+
+.MetadataSectionCollapsible__indicator-count {
+    color: $blue-50;
+    font-size: 0.75rem;
+    font-style: italic;
+    white-space: nowrap;
+}
+
+// In the v-tabs aside the count sits underneath the label, not as an
+// inline caption — drop the italic and add bottom spacing before the
+// tabs themselves.
+.MetadataSectionCollapsible__v-tabs-label
+    .MetadataSectionCollapsible__indicator-count {
+    font-style: normal;
+    margin-bottom: 8px;
+}
+
+// "About this data" label sits outside the switcher control. Typography
+// mirrors `__short-description-label` (small caps, $blue-50, weight 700),
+// but a step bigger so it reads as a section heading rather than a tag.
+.MetadataSectionCollapsible__indicator-title-prefix {
+    color: $blue-50;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    font-size: 0.75rem;
+    font-weight: 700;
+    white-space: nowrap;
+}
+
+// Override the existing block-level title styling when it's rendered
+// inside the pill — we want sentence-case, body-3-medium scale so the
+// pill reads as a control rather than a page heading.
+.MetadataSectionCollapsible__indicator-title-trigger
+    .MetadataSectionCollapsible__indicator-title {
+    color: $blue-90;
+    font-weight: 500;
+    font-size: inherit;
+    letter-spacing: inherit;
+    text-transform: none;
+    display: inline;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
+    line-height: 1;
+}
+
+.MetadataSectionCollapsible__indicator-title-caret {
+    color: $blue-50;
+    font-size: 0.75rem;
+    margin-left: auto;
+    transition: transform 160ms ease;
+}
+
+.MetadataSectionCollapsible__indicator-title-trigger[aria-expanded="true"]
+    .MetadataSectionCollapsible__indicator-title-caret {
+    transform: rotate(180deg);
+    color: $blue-70;
+}
+
+// Rendered via React Portal to document.body so it can extend past the
+// rounded metadata box (which has overflow: hidden) without being clipped.
+// Styling mirrors .md-menu for visual consistency with the multi-dim
+// dimension dropdown.
+.MetadataSectionCollapsible__indicator-title-popover {
+    background: $white;
+    border-radius: 4px;
+    box-shadow: 0 4px 23px 4px rgba($oxford-blue, 0.06);
+    padding: 8px 16px;
+    max-width: min(480px, calc(100vw - 24px));
+    max-height: 360px;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    z-index: $zindex-popover;
+    display: flex;
+    flex-direction: column;
+}
+
+.MetadataSectionCollapsible__indicator-title-option {
+    @include body-3-medium;
+    appearance: none;
+    background: transparent;
+    border: 0;
+    color: $blue-90;
+    cursor: pointer;
+    text-align: left;
+    padding: 12px 0;
+    line-height: 1.4;
+    border-radius: 0;
+    transition: color 120ms ease;
+
+    & + & {
+        border-top: 1px solid $gray-20;
+    }
+
+    &:hover {
+        color: $blue-50;
+    }
+
+    &:focus-visible {
+        outline: none;
+        color: $blue-50;
+    }
+}
+
+.MetadataSectionCollapsible__indicator-title-option--active {
+    color: $blue-90;
+    font-weight: 700;
+    cursor: default;
+}
+
+// --- Short description (label + text matches stat row treatment) ---
+
+// Figma: "Short description" label + body text are both Lato-Medium 13/16
+// (line-height equals font-size so the text reads compactly stacked on two
+// lines). Label is $blue-50, text is $blue-90. The wrapper is a flex column
+// so the label sits on its own line above the text.
+.MetadataSectionCollapsible__short-description {
+    font-family: $sans-serif-font-stack;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    line-height: calc(16 / 13);
+    color: $blue-90;
+    display: flex;
+    flex-direction: column;
+}
+
+.MetadataSectionCollapsible__short-description-label {
+    color: $blue-50;
+    font-weight: 500;
+    font-size: 0.8125rem;
+    line-height: calc(16 / 13);
+    letter-spacing: 0;
+    text-transform: none;
+    margin-bottom: 4px;
+}
+
+.MetadataSectionCollapsible__short-description-text {
+    color: $blue-90;
+}
+
+// Source attribution line, just below the short description. Mirrors the
+// "Data source: …" footnote that appears beneath the grapher chart. Same
+// type scale as the short description (13/16) so they read as one unit.
+.MetadataSectionCollapsible__source-line {
+    display: flex;
+    flex-direction: column;
+    font-family: $sans-serif-font-stack;
+    font-size: 0.8125rem;
+    line-height: calc(16 / 13);
+}
+
+.MetadataSectionCollapsible__source-line-label {
+    color: $blue-50;
+    font-weight: 500;
+    margin-bottom: 4px;
+}
+
+.MetadataSectionCollapsible__source-line-text {
+    color: $blue-90;
+    font-weight: 500;
+}
+
+// --- Section headings ---
+// Figma: "Data sources" / "How to cite" use Lato-Bold 16/21, $blue-90, no
+// caps. Same treatment for the `--minor` modifier (FAQ sub-headings), kept
+// as a no-op alias to avoid touching every call site.
+.MetadataSectionCollapsible__section-heading,
+.MetadataSectionCollapsible__section-heading--minor {
+    font-family: $sans-serif-font-stack;
+    font-size: 1rem;
+    font-weight: 700;
+    line-height: calc(21 / 16);
+    letter-spacing: 0;
+    text-transform: none;
+    margin: 0 0 16px; // Figma Frame 902 itemSpacing: 16px between heading and items
+    color: $blue-90;
+}
+
+// Extra breathing room above sub-subsection headings — they sit after a
+// heavier major section, so the visual hierarchy benefits from a slightly
+// larger gap than the default `__content` flex gap.
+.MetadataSectionCollapsible__faqs
+    > .MetadataSectionCollapsible__section-heading,
+.MetadataSectionCollapsible__processing-notes
+    > .MetadataSectionCollapsible__section-heading {
+    margin-top: 16px;
+}
+
+// --- Markdown link styling (raw <a> elements only) ---
+// Apply OWID link styling to plain anchors inside the metadata box. Skip
+// purpose-styled buttons that carry their own class names.
+
+.MetadataSectionCollapsible__short-description a:not([class]),
+.MetadataSectionCollapsible__description-key a:not([class]),
+.MetadataSectionCollapsible__processing-notes-body a:not([class]),
+.MetadataSectionCollapsible__faqs-preamble a:not([class]),
+.MetadataSectionCollapsible .ExpandableToggle__content a:not([class]) {
+    @include owid-link-90;
+}
+
+// --- Description key (markdown bullets / paragraphs) ---
+// Lives inside <summary> so it's visible in both states. When collapsed,
+// we clip + fade the bottom to invite the user to expand for the rest.
+
+.MetadataSectionCollapsible__description-key {
+    position: relative;
+    // Preview ~9 lines of bullets before the fade (bullets are 16/24 so
+    // 13em ≈ 9 lines).
+    max-height: 13em;
+    overflow: hidden;
+    -webkit-mask-image: linear-gradient(180deg, #000 50%, transparent 100%);
+    mask-image: linear-gradient(180deg, #000 50%, transparent 100%);
+
+    // Figma: bullet body text is Lato-Regular 16/24 in $blue-90.
+    font-family: $sans-serif-font-stack;
+    font-size: 1rem;
+    font-weight: 400;
+    line-height: calc(24 / 16);
+    color: $blue-90;
+
+    .key-info__key-description {
+        margin: 0;
+
+        ul,
+        ol {
+            padding-left: 1em;
+            margin: 1em 0;
+
+            li {
+                margin-bottom: 1em;
+
+                &:last-child {
+                    margin-bottom: 0;
+                }
+            }
+        }
+
+        > *:first-child {
+            margin-top: 0;
+        }
+
+        > *:last-child {
+            margin-bottom: 0;
+        }
+
+        p + p {
+            margin-top: 12px;
+        }
+    }
+}
+
+.MetadataSectionCollapsible[open] .MetadataSectionCollapsible__description-key {
+    max-height: none;
+    overflow: visible;
+    -webkit-mask-image: none;
+    mask-image: none;
+}
+
+// --- Expandable items (sources, citations, FAQs) — shared treatment ---
+// Figma reports Playfair Display SemiBold 16/22 in $blue-60. In the browser
+// our serif stack falls back to system serifs (or synthesizes weight) when
+// SemiBold isn't available, which renders visibly heavier than the Figma
+// frame; weight 400 (Regular) matches the Figma's actual rendered weight
+// better than 600.
+.MetadataSectionCollapsible__sources-list,
+.MetadataSectionCollapsible__citation-toggles,
+.MetadataSectionCollapsible__faqs-items {
+    display: flex;
+    flex-direction: column;
+    --expandable-toggle-title-size: 1rem;
+
+    // When two adjacent rows are BOTH open, their $blue-20 panels would
+    // touch and the divider between them disappears. Insert a 4px strip
+    // (parent's $blue-5 shows through) only in that specific case — closed
+    // rows continue to sit flush against each other.
+    details.ExpandableToggle[open] + details.ExpandableToggle[open] {
+        margin-top: 4px;
+    }
+
+    // Match the component's own 3-class selector
+    // (`details.ExpandableToggle .ExpandableToggle__button .ExpandableToggle__title`)
+    // so the override actually wins.
+    details.ExpandableToggle .ExpandableToggle__title {
+        font-family: $serif-font-stack;
+        font-weight: 400;
+        line-height: calc(22 / 16);
+        color: $blue-60;
+    }
+}
+
+// All multi-item collapsible lists in the metadata section (sources, FAQs,
+// citation questions): Figma renders every row with a 1px #d0dae3 top
+// divider; the open row additionally has a 1px bottom divider and a
+// $blue-20 tinted background. The "+ / -" icon is at the far right (the
+// component's default `justify-content: space-between` — don't override it
+// with flex-start, that collapses the row onto the icon).
+.MetadataSectionCollapsible__sources-list,
+.MetadataSectionCollapsible__faqs-items,
+.MetadataSectionCollapsible__citation-toggles {
+    details.ExpandableToggle {
+        border-top: 1px solid #d0dae3;
+        border-bottom: 0;
+        border-radius: 0;
+
+        // The last row in each list needs its OWN bottom divider since
+        // there's no next sibling whose top border would close the visual
+        // stack. (Non-last rows: their bottom is closed by the next row's
+        // top border.)
+        &:last-child {
+            border-bottom: 1px solid #d0dae3;
+        }
+
+        .ExpandableToggle__button {
+            padding: 16px;
+            gap: 8px;
+        }
+
+        .ExpandableToggle__icon {
+            margin: 0;
+            flex-shrink: 0;
+        }
+
+        // Open state: tinted $blue-20 panel; the top + bottom borders are
+        // already in place (from the per-row top border and the last-child
+        // bottom border above), so we only add bg + tighten padding here.
+        &[open] {
+            background: $blue-20;
+
+            .ExpandableToggle__button {
+                padding-bottom: 8px;
+            }
+
+            .ExpandableToggle__content {
+                padding: 0 16px 24px;
+            }
+        }
+    }
+}
+
+// "How to cite" puts the license-blurb between the section heading and the
+// citation toggles, so the toggles don't sit right under the heading's
+// margin-bottom — give the list its own top margin so the first divider has
+// breathing room from the license text above. Sources and FAQs sit
+// immediately under their headings and already inherit the heading's
+// margin-bottom; no extra top margin needed there.
+.MetadataSectionCollapsible__citation-toggles {
+    margin-top: 16px;
+}
+
+// --- Processing notes (matches descriptionKey styling) ---
+
+.MetadataSectionCollapsible__processing-notes-body {
+    color: $blue-70;
+
+    p {
+        margin: 0 0 12px;
+    }
+
+    p:last-child {
+        margin-bottom: 0;
+    }
+
+    ul,
+    ol {
+        padding-left: 1em;
+        margin: 1em 0;
+
+        li {
+            margin-bottom: 1em;
+
+            &:last-child {
+                margin-bottom: 0;
+            }
+        }
+    }
+}
+
+// --- Citation guidance ---
+
+.MetadataSectionCollapsible__citation-guidance {
+    scroll-margin-top: 24px;
+}
+
+.MetadataSectionCollapsible__citation-lead {
+    @include body-3-regular;
+    color: $blue-70;
+    margin: 0 0 12px;
+}
+
+// "License blurb" — fine-print legal boilerplate that sits beneath the
+// citation toggles. No bullets, muted text, slightly smaller, generous
+// gap from the toggles above so it reads as a footnote.
+.MetadataSectionCollapsible__license-blurb {
+    color: $blue-60;
+    font-size: 0.8125rem;
+    line-height: 1.5;
+    list-style: none;
+    margin: 16px 0 0;
+    padding: 0;
+
+    li + li {
+        margin-top: 6px;
+    }
+
+    a {
+        @include owid-link-60;
+        color: inherit;
+    }
+}
+
+// Inside a citation toggle, the "In-line citation" / "Full citation"
+// labels render as inline <span>s by default — force a line break so
+// they don't run into the following description text.
+.MetadataSectionCollapsible .citation__type {
+    display: block;
+    color: $blue-90;
+    margin-bottom: 4px;
+}
+
+// Citation collapsibles' first paragraph (`.citation__paragraph`) gets
+// stacked right under the button title. The component's own padding
+// already leaves room, so drop the paragraph's own top margin to avoid
+// the doubled gap the user flagged.
+.MetadataSectionCollapsible__citation-toggles .ExpandableToggle__content {
+    .citation__paragraph:first-child,
+    > p:first-child {
+        margin-top: 0;
+    }
+}
+
+// --- Per-source detail panel (rendered by MetadataSingleSource inside
+//     each data source's ExpandableToggle) ---
+// The shared `.indicator-sources` styling gives the description a 16px
+// bottom margin that reads as too much white space before the inline
+// "Retrieved on …" line — tighten it. Add a margin between successive
+// .source-key-data-blocks rows so "Source attribution" doesn't crash into
+// the row above. Render the attribution text as a smaller, muted block
+// because it's fine-print attribution, not main content.
+
+.MetadataSectionCollapsible .indicator-sources .description {
+    margin-top: 8px;
+    margin-bottom: 6px;
+}
+
+.MetadataSectionCollapsible
+    .indicator-sources
+    .source-key-data-blocks
+    + .source-key-data-blocks {
+    // Vertical gap between consecutive subsections of the source detail.
+    // Each titled subsection (producer-description, about-source, citation)
+    // also adds 8px above its own title via the rule below, so the visible
+    // gap between blocks ends up ~16px without the wrapper margin alone
+    // having to be that big — keeps the "Retrieved on" → next-block
+    // transition tighter when the next block is the bare description.
+    margin-top: 8px;
+}
+
+// "Source attribution", "How is this data described by its producer?" and
+// "About the source" subsections share a quiet small-caps header and
+// readable body. The previous citation-only treatment is generalised here
+// so the producer-description block doesn't end up with a bigger header
+// than its own markdown sub-headings.
+.MetadataSectionCollapsible .indicator-sources .source-key-data-citation,
+.MetadataSectionCollapsible
+    .indicator-sources
+    .source-key-data-producer-description,
+.MetadataSectionCollapsible .indicator-sources .source-key-data-about-source {
+    .source-key-data__title {
+        @include h5-black-caps;
+        color: $blue-50;
+        // Consistent top margin separates each titled subsection from the
+        // block above it (e.g. "Retrieved on …" or the previous
+        // subsection's content).
+        margin-top: 8px;
+        margin-bottom: 6px;
+        // The default rule sets `white-space: nowrap` which clips long
+        // titles ("How is this data described by its producer?"). Unset
+        // it so multi-word small-caps titles can wrap.
+        white-space: normal;
+    }
+}
+
+// Producer description + About-the-source body: readable prose size,
+// $blue-90. Override any nested markdown headings so they don't render
+// LARGER than the section's small-caps title above them.
+.MetadataSectionCollapsible
+    .indicator-sources
+    .source-key-data-producer-description,
+.MetadataSectionCollapsible .indicator-sources .source-key-data-about-source {
+    .source-key-data__content {
+        font-size: 0.8125rem;
+        color: $blue-90;
+
+        h1,
+        h2,
+        h3,
+        h4,
+        h5,
+        h6 {
+            font-family: $sans-serif-font-stack;
+            font-size: 0.8125rem;
+            font-weight: 700;
+            line-height: calc(16 / 13);
+            margin: 12px 0 4px;
+            text-transform: none;
+            letter-spacing: 0;
+        }
+
+        p {
+            margin: 0 0 8px;
+            &:last-child {
+                margin-bottom: 0;
+            }
+        }
+    }
+}
+
+// Source attribution is fine-print attribution — make it visibly smaller
+// + quieter than the prose blocks above.
+.MetadataSectionCollapsible .indicator-sources .source-key-data-citation {
+    .source-key-data__content {
+        font-size: 0.6875rem;
+        line-height: calc(15 / 11);
+        color: $blue-50;
+    }
+}
+
+// --- Compact bullets inside any expandable content ---
+
+.MetadataSectionCollapsible .ExpandableToggle__content {
+    ul,
+    ol {
+        padding-left: 1.5em;
+        margin: 8px 0;
+
+        li + li {
+            margin-top: 4px;
+        }
+    }
+}
+
+// --- Blockquotes inside descriptionKey + DDoD content ---
+
+.MetadataSectionCollapsible .key-info__key-description blockquote,
+.DetailedDetailsOnDemand__content blockquote {
+    margin: 12px 0;
+    padding: 12px 14px;
+    border: 1px solid $blue-20;
+    border-radius: 6px;
+
+    p {
+        margin: 0;
+    }
+
+    p + p {
+        margin-top: 8px;
+    }
+}
+
+// --- Inline DDoD trigger styles (used by source links + (how?) trigger) ---
+
+.DetailedDetailsOnDemand__trigger,
+.MetadataMarkdownText__source-trigger,
+.MetadataSectionCollapsible__citation-how-trigger {
+    @include body-3-medium;
+    color: $blue-60;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    text-decoration: underline;
+    text-underline-offset: 3px;
+
+    &:hover,
+    &:focus-visible {
+        color: $blue-70;
+    }
+}
+
+.DetailedDetailsOnDemand__trigger-icon {
+    font-size: 0.75em;
+    opacity: 0.9;
+}
+
+// --- DDoD modal (rendered via portal) ---
+
+.DetailedDetailsOnDemand__overlay {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: flex-end;
+    justify-content: center;
+    padding: 16px;
+    background: rgba(0, 0, 0, 0.45);
+    z-index: $zindex-lightbox;
+}
+
+.DetailedDetailsOnDemand__modal {
+    width: min(760px, 100%);
+    max-height: 100%;
+}
+
+.DetailedDetailsOnDemand {
+    display: flex;
+    flex-direction: column;
+    background: $white;
+    border-radius: 8px;
+    box-shadow: 0 12px 30px rgba($oxford-blue, 0.2);
+    max-height: calc(100vh - 32px);
+    overflow: hidden;
+    color: $blue-90;
+}
+
+.DetailedDetailsOnDemand__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 16px 20px;
+    border-bottom: 1px solid $blue-20;
+    background: $blue-5;
+}
+
+.DetailedDetailsOnDemand__title {
+    @include h5-black-caps;
+    margin: 0;
+}
+
+.DetailedDetailsOnDemand__close-button {
+    color: $blue-50;
+    border: 1px solid $blue-50;
+    background-color: transparent;
+
+    &:hover,
+    &:focus-visible {
+        color: $blue-70;
+        border-color: $blue-70;
+        background-color: transparent;
+    }
+}
+
+.DetailedDetailsOnDemand__content {
+    @include body-3-regular;
+    padding: 20px;
+    overflow-y: auto;
+}
+
+.MetadataMarkdownText__source-content {
+    .sources-list {
+        margin-bottom: 0;
+    }
+}
+
+// Trim the trailing margin off the OwidProcessingBlurb / per-source content
+// when they're rendered inside a DetailedDetailsOnDemand modal.
+.DetailedDetailsOnDemand__content {
+    .indicator-processing {
+        margin-bottom: 0;
+    }
+}
+
+@include sm-up {
+    .DetailedDetailsOnDemand__overlay {
+        align-items: center;
+        padding: 24px;
+    }
+
+    .DetailedDetailsOnDemand {
+        max-height: calc(100vh - 48px);
+    }
+
+    .DetailedDetailsOnDemand__header {
+        padding: 20px 24px;
+    }
+
+    .DetailedDetailsOnDemand__content {
+        padding: 24px;
+    }
+}
+
+// --- Horizontal-tabs switcher variant ---
+// A row of pill-style tab buttons in place of the dropdown. The active tab
+// reads as the current indicator; the row wraps on narrow screens.
+
+// h-tabs: tabs sitting directly on top of the box, with the active tab
+// taking on the box's own $blue-5 background so it visually fuses into
+// the box below. Reads as "this tab is the section currently open".
+.MetadataSectionCollapsible__h-tabs {
+    display: flex;
+    flex-wrap: wrap;
+    width: 100%;
+    gap: 2px;
+}
+
+.MetadataSectionCollapsible__h-tab {
+    appearance: none;
+    background: transparent;
+    // Idle tabs get a 1px $blue-20 ring on top/left/right — the open
+    // bottom edge lets the tab visually "open" downward into the box
+    // below, the classic browser-tab look.
+    border: 1px solid $blue-20;
+    border-bottom: 0;
+    color: $blue-50;
+    cursor: pointer;
+    padding: 8px 14px;
+    font-family: $sans-serif-font-stack;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    line-height: 1.4;
+    border-radius: 6px 6px 0 0;
+    transition:
+        background-color 120ms ease,
+        border-color 120ms ease,
+        color 120ms ease;
+
+    &:hover {
+        color: $blue-90;
+        // Match the metadata box's own hover color (the wrap-wide hover
+        // rule uses #e3ebf5) so a hovered tab feels continuous with the
+        // box's hovered state.
+        background: #e3ebf5;
+        border-color: $blue-30;
+    }
+
+    &:focus-visible {
+        outline: none;
+        background: #e3ebf5;
+        border-color: $blue-30;
+    }
+}
+
+// Active tab: same bg as the box below so the two appear as one
+// continuous shape; bottom corners stay sharp so they butt against the
+// (square) box corner.
+.MetadataSectionCollapsible__h-tab--active {
+    background: $blue-5;
+    border-color: $blue-20;
+    color: $blue-90;
+    font-weight: 600;
+    cursor: default;
+
+    &:hover {
+        background: $blue-5;
+        border-color: $blue-20;
+        color: $blue-90;
+    }
+}
+
+// h-pills: rounded pill switcher with middle-ground saturation. The
+// active pill uses $blue-70 (one notch lighter than $blue-90) so it
+// reads as the active button without competing with chart-entity colors
+// or the box title.
+.MetadataSectionCollapsible__h-pills {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.MetadataSectionCollapsible__h-pill {
+    appearance: none;
+    background: $blue-5;
+    border: 1px solid $blue-20;
+    color: $blue-70;
+    cursor: pointer;
+    padding: 4px 14px;
+    height: 30px;
+    border-radius: 999px;
+    font-family: $sans-serif-font-stack;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    line-height: 1;
+    transition:
+        background-color 120ms ease,
+        border-color 120ms ease,
+        color 120ms ease;
+
+    &:hover {
+        // Match the metadata box's own hover bg (#e3ebf5) so a hovered
+        // pill reads as part of the same hover surface as the box.
+        background: #e3ebf5;
+        border-color: $blue-30;
+        color: $blue-90;
+    }
+
+    &:focus-visible {
+        outline: none;
+        border-color: $blue-50;
+    }
+}
+
+.MetadataSectionCollapsible__h-pill--active {
+    background: $blue-70;
+    border-color: $blue-70;
+    color: $white;
+    cursor: default;
+
+    &:hover {
+        background: $blue-70;
+        border-color: $blue-70;
+        color: $white;
+    }
+}
+
+// "More ▾" overflow trigger inside the h-tabs / h-pills row — same chrome
+// as the other tabs/pills, plus a small gap between the label and the
+// caret icon (without this the caret sits flush against the "More" text).
+.MetadataSectionCollapsible__h-tab--more,
+.MetadataSectionCollapsible__h-pill--more {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    cursor: pointer;
+}
+
+// --- Vertical-tabs switcher variant ---
+// An aside sitting to the left of the collapsible box. Tabs read as a list
+// of indicators; the active one is highlighted with a left rule + bold text.
+
+.MetadataSectionCollapsible__v-tabs {
+    flex: 0 0 200px;
+    display: flex;
+    flex-direction: column;
+    align-self: stretch;
+    // Same surface as the header + box.
+    background-color: $blue-5;
+    border: 1px solid $blue-20;
+    border-top: 0;
+    border-radius: 0 0 0 8px;
+    padding: 12px;
+
+    @include sm-up {
+        flex-basis: 220px;
+        padding: 12px 16px;
+    }
+}
+
+// "Indicator:" label inside the v-tabs aside — reuse the dropdown prefix
+// styling so the label reads consistently across variants.
+.MetadataSectionCollapsible__v-tabs-label {
+    margin-bottom: 8px;
+}
+
+.MetadataSectionCollapsible__v-tab {
+    @include body-3-medium;
+    appearance: none;
+    background: transparent;
+    border: 0;
+    color: $blue-70;
+    cursor: pointer;
+    text-align: left;
+    padding: 8px 10px;
+    border-radius: 4px;
+    line-height: 1.3;
+    transition:
+        background-color 120ms ease,
+        color 120ms ease;
+
+    &:hover {
+        background: $blue-5;
+        color: $blue-90;
+    }
+
+    &:focus-visible {
+        outline: none;
+        background: $blue-5;
+        color: $blue-90;
+    }
+}
+
+.MetadataSectionCollapsible__v-tab--active {
+    background: $blue-10;
+    color: $blue-90;
+    font-weight: 700;
+    cursor: default;
+
+    &:hover {
+        background: $blue-10;
+    }
+}
+
+// "More ▾" overflow trigger inside the v-tabs aside — same row chrome as
+// other v-tabs, plus the caret aligned to the right.
+.MetadataSectionCollapsible__v-tab--more {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    cursor: pointer;
+}
+
+// On narrow viewports collapse the v-tabs aside above the box instead of
+// next to it, so it doesn't squeeze the content. Still attached to header
+// above + box below — keep the seamless surface treatment.
+@media (max-width: 767px) {
+    .MetadataSectionCollapsible-wrap--v-tabs .MetadataSectionCollapsible__main {
+        flex-direction: column;
+    }
+
+    .MetadataSectionCollapsible__v-tabs {
+        flex: 1 1 auto;
+        border-radius: 0;
+    }
+
+    .MetadataSectionCollapsible-wrap--v-tabs .MetadataSectionCollapsible {
+        border-left: 1px solid $blue-20;
+        border-radius: 0 0 8px 8px;
+    }
+}

--- a/site/MetadataSectionCollapsible.tsx
+++ b/site/MetadataSectionCollapsible.tsx
@@ -1,0 +1,1292 @@
+import { ReactNode, useEffect, useRef, useState } from "react"
+import { createPortal } from "react-dom"
+import * as _ from "lodash-es"
+import cx from "classnames"
+import {
+    faChevronDown,
+    faChevronUp,
+    faCaretDown,
+} from "@fortawesome/free-solid-svg-icons"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import dayjs from "dayjs"
+import {
+    DATAPAGE_ABOUT_THIS_DATA_SECTION_ID,
+    DATAPAGE_SOURCES_AND_PROCESSING_SECTION_ID,
+    ExpandableToggle,
+    CodeSnippet,
+    DataCitation,
+    HtmlOrSimpleMarkdownText,
+    SimpleMarkdownText,
+    makeLastUpdated,
+    makeNextUpdate,
+    makeDateRange,
+    makeUnit,
+} from "@ourworldindata/components"
+import {
+    AdditionalIndicator,
+    ArchiveContext,
+    DataPageDataV2,
+    DisplaySource,
+    FaqEntryData,
+    OwidEnrichedGdocBlock,
+} from "@ourworldindata/types"
+import {
+    prepareSourcesForDisplay,
+    getCitationShort,
+    getCitationLong,
+    excludeUndefined,
+    getPhraseForArchivalDate,
+    spansToUnformattedPlainText,
+} from "@ourworldindata/utils"
+import { ArticleBlocks } from "./gdocs/components/ArticleBlocks.js"
+import { MetadataSingleSource } from "./MetadataSingleSource.js"
+
+// Anchor ids for in-page navigation. The grapher's "Cite" action button
+// scrolls to CITATION_GUIDANCE_ID; the inline "Learn more in the FAQs" link
+// scrolls to FAQS_ID; and the "Source" callout (when used) scrolls to the
+// shared DATAPAGE_SOURCES_AND_PROCESSING_SECTION_ID.
+const CITATION_GUIDANCE_ID = "citation-guidance"
+const FAQS_ID = "faqs"
+
+type FaqGroup = { question: string; body: OwidEnrichedGdocBlock[] }
+
+// Flatten "expandable-paragraph" blocks into their inner items so the FAQ
+// answers render in full instead of with a "Show more" truncation —
+// once the user has expanded a question, they've already opted in to read
+// the whole answer.
+const flattenExpandableParagraphs = (
+    blocks: OwidEnrichedGdocBlock[]
+): OwidEnrichedGdocBlock[] =>
+    blocks.flatMap((block) =>
+        block.type === "expandable-paragraph" ? block.items : [block]
+    )
+
+const groupFaqsByHeading = (
+    blocks: OwidEnrichedGdocBlock[]
+): { groups: FaqGroup[]; preamble: OwidEnrichedGdocBlock[] } => {
+    const groups: FaqGroup[] = []
+    const preamble: OwidEnrichedGdocBlock[] = []
+    let current: FaqGroup | null = null
+    for (const block of blocks) {
+        if (block.type === "heading") {
+            current = {
+                question: spansToUnformattedPlainText(block.text),
+                body: [],
+            }
+            groups.push(current)
+        } else if (current) {
+            current.body.push(block)
+        } else {
+            preamble.push(block)
+        }
+    }
+    return {
+        groups: groups.map((g) => ({
+            ...g,
+            body: flattenExpandableParagraphs(g.body),
+        })),
+        preamble: flattenExpandableParagraphs(preamble),
+    }
+}
+
+const StatItem = ({ title, value }: { title: ReactNode; value: ReactNode }) => (
+    <div className="MetadataSectionCollapsible__summary-stat">
+        <span className="MetadataSectionCollapsible__summary-stat-title">
+            {title}
+        </span>
+        <span className="MetadataSectionCollapsible__summary-stat-value">
+            {value}
+        </span>
+    </div>
+)
+
+const SummaryStats = ({ datapageData }: { datapageData: DataPageDataV2 }) => {
+    const lastUpdated = makeLastUpdated(datapageData)
+    const nextUpdate = makeNextUpdate(datapageData)
+    const dateRange = makeDateRange(datapageData)
+    const unit = makeUnit(datapageData)
+
+    return (
+        <>
+            {unit && <StatItem title="Unit" value={unit} />}
+            {dateRange && <StatItem title="Date range" value={dateRange} />}
+            {lastUpdated && (
+                <StatItem title="Last updated" value={lastUpdated} />
+            )}
+            {nextUpdate && (
+                <StatItem title="Next expected update" value={nextUpdate} />
+            )}
+        </>
+    )
+}
+
+// Wraps a per-indicator slice of the box's content (title, factoid row,
+// bullets, sources, etc.) so that ALL indicators' metadata sit in the
+// rendered HTML at the same time — only the active one is visible to the
+// user (via `display: contents` vs `display: none`), while the others are
+// available to AI agents / unmodified-HTML consumers on a plain GET.
+const IndicatorPane = ({
+    index,
+    active,
+    children,
+}: {
+    index: number
+    active: boolean
+    children: ReactNode
+}) => (
+    <div
+        className={cx("MetadataSectionCollapsible__indicator-pane", {
+            "MetadataSectionCollapsible__indicator-pane--active": active,
+        })}
+        data-indicator-index={index}
+        aria-hidden={!active}
+    >
+        {children}
+    </div>
+)
+
+const labelForIndicator = (datapageData: DataPageDataV2): string => {
+    const title = datapageData.title.title
+    const variant = datapageData.titleVariant
+    return variant && !title.includes(variant) ? `${title} – ${variant}` : title
+}
+
+// Feature flag for which indicator-switcher UI to render on multi-indicator
+// data pages. Override per-request via the URL query string,
+// e.g. `?switcher=h-tabs` or `?switcher=v-tabs`.
+export type SwitcherVariant = "dropdown" | "h-tabs" | "v-tabs" | "h-pills"
+const DEFAULT_SWITCHER_VARIANT: SwitcherVariant = "h-tabs"
+const ALL_SWITCHER_VARIANTS: readonly SwitcherVariant[] = [
+    "dropdown",
+    "h-tabs",
+    "v-tabs",
+    "h-pills",
+]
+
+const useSwitcherVariant = (): SwitcherVariant => {
+    const [variant, setVariant] = useState<SwitcherVariant>(
+        DEFAULT_SWITCHER_VARIANT
+    )
+    useEffect(() => {
+        if (typeof window === "undefined") return
+        const sp = new URLSearchParams(window.location.search)
+        const v = sp.get("switcher")
+        if (v && ALL_SWITCHER_VARIANTS.includes(v as SwitcherVariant)) {
+            setVariant(v as SwitcherVariant)
+        }
+    }, [])
+    return variant
+}
+
+type IndicatorEntry = { datapageData: DataPageDataV2 }
+
+// Label that sits next to (or above) the indicator switcher. Renders as
+// "ABOUT THIS DATA (3 indicators)" or just "ABOUT THIS DATA" in the
+// single-indicator case. Used by all three switcher variants — the
+// shared component keeps the wording + counting logic in one place.
+const IndicatorAboutLabel = ({
+    indicatorCount,
+    className,
+}: {
+    indicatorCount: number
+    className?: string
+}) => (
+    <span
+        className={cx(
+            "MetadataSectionCollapsible__indicator-header-group",
+            className
+        )}
+    >
+        <span className="MetadataSectionCollapsible__indicator-title-prefix">
+            About this data
+        </span>
+        {indicatorCount > 1 && (
+            <span className="MetadataSectionCollapsible__indicator-count">
+                ({indicatorCount} indicators)
+            </span>
+        )}
+    </span>
+)
+
+// Cap on how many tab buttons render before the rest collapse into a
+// "More ▾" overflow dropdown. With many-indicator charts (e.g.
+// annual-number-of-deaths-by-cause has ~30) an uncapped tab row gets
+// unwieldy in both horizontal and vertical layouts. Mobile h-tabs use a
+// lower cap because the row wraps too aggressively otherwise.
+const MAX_VISIBLE_TABS_DESKTOP = 5
+const MAX_VISIBLE_TABS_MOBILE = 3
+
+// Matches the SCSS `@media (max-width: 767px)` breakpoint used elsewhere
+// in this component (e.g. the v-tabs responsive stack).
+const MOBILE_MEDIA_QUERY = "(max-width: 767px)"
+
+const useIsMobile = (): boolean => {
+    const [isMobile, setIsMobile] = useState(false)
+    useEffect(() => {
+        if (typeof window === "undefined" || !window.matchMedia) return
+        const mq = window.matchMedia(MOBILE_MEDIA_QUERY)
+        const update = () => setIsMobile(mq.matches)
+        update()
+        mq.addEventListener("change", update)
+        return () => mq.removeEventListener("change", update)
+    }, [])
+    return isMobile
+}
+
+const splitForOverflow = (
+    indicators: IndicatorEntry[],
+    max: number
+): {
+    visible: IndicatorEntry[]
+    overflow: IndicatorEntry[]
+    overflowStartIndex: number
+} => {
+    if (indicators.length <= max) {
+        return {
+            visible: indicators,
+            overflow: [],
+            overflowStartIndex: indicators.length,
+        }
+    }
+    const visibleCount = max - 1
+    return {
+        visible: indicators.slice(0, visibleCount),
+        overflow: indicators.slice(visibleCount),
+        overflowStartIndex: visibleCount,
+    }
+}
+
+// Position a fixed popover anchored to a trigger button, with outside-click
+// + Esc dismissal and reflow on scroll/resize. Shared by the dropdown
+// variant and the tabs' overflow "More" menu.
+const usePopoverAnchor = (
+    triggerRef: React.RefObject<HTMLElement | null>,
+    popoverRef: React.RefObject<HTMLElement | null>,
+    open: boolean,
+    setOpen: (o: boolean) => void,
+    { matchTriggerWidth = false }: { matchTriggerWidth?: boolean } = {}
+): React.CSSProperties => {
+    const [popoverStyle, setPopoverStyle] = useState<React.CSSProperties>({})
+    useEffect(() => {
+        if (!open) return
+        const updatePos = () => {
+            if (!triggerRef.current) return
+            const r = triggerRef.current.getBoundingClientRect()
+            setPopoverStyle({
+                position: "fixed",
+                top: r.bottom + 4,
+                left: r.left,
+                ...(matchTriggerWidth ? { minWidth: r.width } : {}),
+            })
+        }
+        updatePos()
+        const onDocMouseDown = (e: MouseEvent) => {
+            const target = e.target as Node
+            if (
+                popoverRef.current?.contains(target) ||
+                triggerRef.current?.contains(target)
+            )
+                return
+            setOpen(false)
+        }
+        const onKey = (e: KeyboardEvent) => {
+            if (e.key === "Escape") setOpen(false)
+        }
+        document.addEventListener("mousedown", onDocMouseDown)
+        document.addEventListener("keydown", onKey)
+        window.addEventListener("scroll", updatePos, true)
+        window.addEventListener("resize", updatePos)
+        return () => {
+            document.removeEventListener("mousedown", onDocMouseDown)
+            document.removeEventListener("keydown", onKey)
+            window.removeEventListener("scroll", updatePos, true)
+            window.removeEventListener("resize", updatePos)
+        }
+    }, [open, triggerRef, popoverRef, setOpen, matchTriggerWidth])
+    return popoverStyle
+}
+
+const IndicatorDropdown = ({
+    activeDatapageData,
+    indicators,
+    activeIndex,
+    onIndicatorChange,
+}: {
+    activeDatapageData: DataPageDataV2
+    indicators: IndicatorEntry[]
+    activeIndex: number
+    onIndicatorChange: (i: number) => void
+}) => {
+    const [open, setOpen] = useState(false)
+    const triggerRef = useRef<HTMLButtonElement>(null)
+    const popoverRef = useRef<HTMLDivElement>(null)
+    const popoverStyle = usePopoverAnchor(
+        triggerRef,
+        popoverRef,
+        open,
+        setOpen,
+        {
+            matchTriggerWidth: true,
+        }
+    )
+
+    const indicatorTitle = activeDatapageData.title.title
+    if (!indicatorTitle) return null
+    const titleVariant = activeDatapageData.titleVariant?.trim()
+
+    return (
+        <>
+            <IndicatorAboutLabel indicatorCount={indicators.length} />
+            <button
+                type="button"
+                ref={triggerRef}
+                className="MetadataSectionCollapsible__indicator-title-trigger"
+                aria-expanded={open}
+                aria-haspopup="listbox"
+                data-track-note="metadata_box_indicator_switch"
+                onClick={() => setOpen((o) => !o)}
+            >
+                <span className="MetadataSectionCollapsible__indicator-title">
+                    {indicatorTitle}
+                </span>
+                <FontAwesomeIcon
+                    icon={faCaretDown}
+                    className="MetadataSectionCollapsible__indicator-title-caret"
+                />
+            </button>
+            {titleVariant && (
+                <span className="MetadataSectionCollapsible__indicator-title-variant">
+                    {titleVariant}
+                </span>
+            )}
+            {open &&
+                typeof document !== "undefined" &&
+                createPortal(
+                    <div
+                        ref={popoverRef}
+                        className="MetadataSectionCollapsible__indicator-title-popover"
+                        style={popoverStyle}
+                        role="listbox"
+                    >
+                        {indicators.map((ind, i) => (
+                            <button
+                                type="button"
+                                key={i}
+                                role="option"
+                                aria-selected={i === activeIndex}
+                                className={cx(
+                                    "MetadataSectionCollapsible__indicator-title-option",
+                                    {
+                                        "MetadataSectionCollapsible__indicator-title-option--active":
+                                            i === activeIndex,
+                                    }
+                                )}
+                                onClick={() => {
+                                    onIndicatorChange(i)
+                                    setOpen(false)
+                                }}
+                            >
+                                {labelForIndicator(ind.datapageData)}
+                            </button>
+                        ))}
+                    </div>,
+                    document.body
+                )}
+        </>
+    )
+}
+
+// Renders the overflow "More ▾" trigger + its popover. The trigger reads
+// as a normal tab button (so it sits inline with the rest of the tab row)
+// and inherits its baseClassName + activeClassName from the parent variant.
+const IndicatorMoreDropdown = ({
+    overflow,
+    overflowStartIndex,
+    activeIndex,
+    onIndicatorChange,
+    baseClassName,
+    activeClassName,
+}: {
+    overflow: IndicatorEntry[]
+    overflowStartIndex: number
+    activeIndex: number
+    onIndicatorChange: (i: number) => void
+    baseClassName: string
+    activeClassName: string
+}) => {
+    const [open, setOpen] = useState(false)
+    const triggerRef = useRef<HTMLButtonElement>(null)
+    const popoverRef = useRef<HTMLDivElement>(null)
+    const popoverStyle = usePopoverAnchor(triggerRef, popoverRef, open, setOpen)
+    const isActiveInOverflow = activeIndex >= overflowStartIndex
+    const label = isActiveInOverflow
+        ? labelForIndicator(
+              overflow[activeIndex - overflowStartIndex].datapageData
+          )
+        : "More"
+    return (
+        <>
+            <button
+                ref={triggerRef}
+                type="button"
+                aria-expanded={open}
+                aria-haspopup="listbox"
+                className={cx(baseClassName, `${baseClassName}--more`, {
+                    [activeClassName]: isActiveInOverflow,
+                })}
+                onClick={() => setOpen((o) => !o)}
+                data-track-note="metadata_box_indicator_switch"
+            >
+                {label}
+                <FontAwesomeIcon
+                    icon={faCaretDown}
+                    className="MetadataSectionCollapsible__indicator-title-caret"
+                />
+            </button>
+            {open &&
+                typeof document !== "undefined" &&
+                createPortal(
+                    <div
+                        ref={popoverRef}
+                        className="MetadataSectionCollapsible__indicator-title-popover"
+                        style={popoverStyle}
+                        role="listbox"
+                    >
+                        {overflow.map((ind, i) => {
+                            const idx = overflowStartIndex + i
+                            return (
+                                <button
+                                    type="button"
+                                    key={idx}
+                                    role="option"
+                                    aria-selected={idx === activeIndex}
+                                    className={cx(
+                                        "MetadataSectionCollapsible__indicator-title-option",
+                                        {
+                                            "MetadataSectionCollapsible__indicator-title-option--active":
+                                                idx === activeIndex,
+                                        }
+                                    )}
+                                    onClick={() => {
+                                        onIndicatorChange(idx)
+                                        setOpen(false)
+                                    }}
+                                >
+                                    {labelForIndicator(ind.datapageData)}
+                                </button>
+                            )
+                        })}
+                    </div>,
+                    document.body
+                )}
+        </>
+    )
+}
+
+const IndicatorTabsHorizontal = ({
+    indicators,
+    activeIndex,
+    onIndicatorChange,
+    variant = "tabs",
+}: {
+    indicators: IndicatorEntry[]
+    activeIndex: number
+    onIndicatorChange: (i: number) => void
+    // "tabs" = underline-tab strip attached to the box (h-tabs variant);
+    // "pills" = rounded pill buttons (h-pills variant). Both use the same
+    // logic and overflow handling; only the class names differ so the
+    // SCSS can style them independently.
+    variant?: "tabs" | "pills"
+}) => {
+    const isMobile = useIsMobile()
+    const { visible, overflow, overflowStartIndex } = splitForOverflow(
+        indicators,
+        isMobile ? MAX_VISIBLE_TABS_MOBILE : MAX_VISIBLE_TABS_DESKTOP
+    )
+    const containerClass =
+        variant === "pills"
+            ? "MetadataSectionCollapsible__h-pills"
+            : "MetadataSectionCollapsible__h-tabs"
+    const itemClass =
+        variant === "pills"
+            ? "MetadataSectionCollapsible__h-pill"
+            : "MetadataSectionCollapsible__h-tab"
+    const itemActiveClass =
+        variant === "pills"
+            ? "MetadataSectionCollapsible__h-pill--active"
+            : "MetadataSectionCollapsible__h-tab--active"
+    return (
+        <div
+            className={containerClass}
+            role="tablist"
+            aria-label="About this data"
+        >
+            {visible.map((ind, i) => (
+                <button
+                    key={i}
+                    type="button"
+                    role="tab"
+                    aria-selected={i === activeIndex}
+                    className={cx(itemClass, {
+                        [itemActiveClass]: i === activeIndex,
+                    })}
+                    onClick={() => onIndicatorChange(i)}
+                    data-track-note="metadata_box_indicator_switch"
+                >
+                    {labelForIndicator(ind.datapageData)}
+                </button>
+            ))}
+            {overflow.length > 0 && (
+                <IndicatorMoreDropdown
+                    overflow={overflow}
+                    overflowStartIndex={overflowStartIndex}
+                    activeIndex={activeIndex}
+                    onIndicatorChange={onIndicatorChange}
+                    baseClassName={itemClass}
+                    activeClassName={itemActiveClass}
+                />
+            )}
+        </div>
+    )
+}
+
+const IndicatorTabsVertical = ({
+    indicators,
+    activeIndex,
+    onIndicatorChange,
+}: {
+    indicators: IndicatorEntry[]
+    activeIndex: number
+    onIndicatorChange: (i: number) => void
+}) => {
+    const { visible, overflow, overflowStartIndex } = splitForOverflow(
+        indicators,
+        MAX_VISIBLE_TABS_DESKTOP
+    )
+    return (
+        <aside
+            className="MetadataSectionCollapsible__v-tabs"
+            role="tablist"
+            aria-orientation="vertical"
+            aria-label="Indicator"
+        >
+            <IndicatorAboutLabel
+                indicatorCount={indicators.length}
+                className="MetadataSectionCollapsible__v-tabs-label"
+            />
+            {visible.map((ind, i) => (
+                <button
+                    key={i}
+                    type="button"
+                    role="tab"
+                    aria-selected={i === activeIndex}
+                    className={cx("MetadataSectionCollapsible__v-tab", {
+                        "MetadataSectionCollapsible__v-tab--active":
+                            i === activeIndex,
+                    })}
+                    onClick={() => onIndicatorChange(i)}
+                    data-track-note="metadata_box_indicator_switch"
+                >
+                    {labelForIndicator(ind.datapageData)}
+                </button>
+            ))}
+            {overflow.length > 0 && (
+                <IndicatorMoreDropdown
+                    overflow={overflow}
+                    overflowStartIndex={overflowStartIndex}
+                    activeIndex={activeIndex}
+                    onIndicatorChange={onIndicatorChange}
+                    baseClassName="MetadataSectionCollapsible__v-tab"
+                    activeClassName="MetadataSectionCollapsible__v-tab--active"
+                />
+            )}
+        </aside>
+    )
+}
+
+// "What you should know" key takeaways, rendered inside <summary> so the
+// preview is visible in both collapsed and expanded states (clipped + faded
+// when collapsed via CSS). A single bullet renders as a paragraph; multiple
+// bullets render as a <ul>.
+const DescriptionKey = ({ descriptionKey }: { descriptionKey: string[] }) => {
+    if (descriptionKey.length === 0) return null
+    const body =
+        descriptionKey.length === 1 ? (
+            <SimpleMarkdownText text={descriptionKey[0].trim()} />
+        ) : (
+            <ul>
+                {descriptionKey.map((text, i) => (
+                    <li key={i}>
+                        <SimpleMarkdownText
+                            text={text.trim()}
+                            useParagraphs={false}
+                        />
+                    </li>
+                ))}
+            </ul>
+        )
+    return (
+        <section className="MetadataSectionCollapsible__description-key">
+            <div className="key-info__key-description">{body}</div>
+        </section>
+    )
+}
+
+const ShortDescription = ({
+    datapageData,
+}: {
+    datapageData: DataPageDataV2
+}) => {
+    if (!datapageData.descriptionShort) return null
+    return (
+        <div className="MetadataSectionCollapsible__short-description">
+            <span className="MetadataSectionCollapsible__short-description-label">
+                Short description
+            </span>
+            <span className="MetadataSectionCollapsible__short-description-text">
+                <SimpleMarkdownText
+                    text={datapageData.descriptionShort}
+                    useParagraphs={false}
+                />
+            </span>
+        </div>
+    )
+}
+
+// Source attribution line shown right under the short description. Matches
+// the grapher's "Data source:" footnote text so the user sees the same
+// attribution in both places. Hyperlinked to the data-sources anchor so
+// the user can jump straight to the source detail.
+const buildSourceLineText = (attributions: readonly string[]): string => {
+    const unique = _.uniq(_.compact(attributions))
+    if (unique.length === 0) return ""
+    if (unique.length > 3) return `${unique[0]} and other sources`
+    return unique.join("; ")
+}
+
+const SourceLine = ({ datapageData }: { datapageData: DataPageDataV2 }) => {
+    const text = buildSourceLineText(datapageData.attributions ?? [])
+    if (!text) return null
+    return (
+        <div className="MetadataSectionCollapsible__source-line">
+            <span className="MetadataSectionCollapsible__source-line-label">
+                Data source
+            </span>
+            <span className="MetadataSectionCollapsible__source-line-text">
+                {text}
+            </span>
+        </div>
+    )
+}
+
+const ProcessingNotesCallout = ({
+    descriptionProcessing,
+}: {
+    descriptionProcessing: string
+}) => (
+    <section className="MetadataSectionCollapsible__processing-notes">
+        <h3 className="MetadataSectionCollapsible__section-heading MetadataSectionCollapsible__section-heading--minor">
+            How we processed this indicator
+        </h3>
+        <div className="MetadataSectionCollapsible__processing-notes-body">
+            <HtmlOrSimpleMarkdownText text={descriptionProcessing.trim()} />
+        </div>
+    </section>
+)
+
+const FaqsSection = ({
+    faqEntries,
+    anchorId,
+}: {
+    faqEntries: FaqEntryData
+    // Optional: only the primary indicator's pane sets the anchor id (one
+    // per box, since ids must be unique in the document).
+    anchorId?: string
+}) => {
+    const { groups, preamble } = groupFaqsByHeading(faqEntries.faqs)
+    if (!groups.length && !preamble.length) return null
+    return (
+        <section className="MetadataSectionCollapsible__faqs">
+            <h3
+                className="MetadataSectionCollapsible__section-heading MetadataSectionCollapsible__section-heading--minor"
+                id={anchorId}
+            >
+                Frequently Asked Questions
+            </h3>
+            {preamble.length > 0 && (
+                <div className="MetadataSectionCollapsible__faqs-preamble">
+                    <ArticleBlocks blocks={preamble} containerType="datapage" />
+                </div>
+            )}
+            <div className="MetadataSectionCollapsible__faqs-items">
+                {groups.map((group, i) => (
+                    <ExpandableToggle
+                        key={`${group.question}-${i}`}
+                        label={group.question}
+                        content={
+                            <ArticleBlocks
+                                blocks={group.body}
+                                containerType="datapage"
+                            />
+                        }
+                        isStacked={i < groups.length - 1}
+                    />
+                ))}
+            </div>
+        </section>
+    )
+}
+
+const DataSourcesList = ({
+    sources,
+    anchorId,
+    descriptionFromProducer,
+}: {
+    sources: DisplaySource[]
+    // Optional: only the primary indicator's pane sets the anchor id.
+    anchorId?: string
+    // Indicator-level producer description, folded into the FIRST source's
+    // detail panel rather than rendered as its own subsection of the box.
+    descriptionFromProducer?: string
+}) => {
+    if (sources.length === 0) return null
+    const heading = sources.length === 1 ? "Data source" : "Data sources"
+    return (
+        <section
+            className="MetadataSectionCollapsible__sources-section"
+            id={anchorId}
+        >
+            <h3 className="MetadataSectionCollapsible__section-heading">
+                {heading}
+            </h3>
+            <div className="MetadataSectionCollapsible__sources-list">
+                {sources.map((source, i) => (
+                    <ExpandableToggle
+                        key={`${source.label}-${i}`}
+                        label={source.label}
+                        content={
+                            <MetadataSingleSource
+                                source={source}
+                                descriptionFromProducer={
+                                    i === 0
+                                        ? descriptionFromProducer
+                                        : undefined
+                                }
+                            />
+                        }
+                        isStacked={i < sources.length - 1}
+                    />
+                ))}
+            </div>
+        </section>
+    )
+}
+
+// "How to cite" subsection inside the metadata box. We deliberately fall
+// back to the existing "Reuse this work" structure — license blurb up top,
+// then linear citation subsections — instead of an expandable Q&A
+// treatment, since this communicates the citation rules more directly.
+const CitationGuidance = ({
+    anchorId,
+    citationShort,
+    citationLong,
+    citationDatapage,
+}: {
+    // Optional: only the primary indicator's pane sets the anchor id.
+    anchorId?: string
+    citationShort: string
+    citationLong: string
+    citationDatapage: string
+}) => {
+    const hasAnyCitation = !!(citationShort || citationLong || citationDatapage)
+    return (
+        <section
+            className="MetadataSectionCollapsible__citation-guidance"
+            id={anchorId}
+        >
+            <h3 className="MetadataSectionCollapsible__section-heading">
+                How to cite
+            </h3>
+            <ul className="MetadataSectionCollapsible__license-blurb">
+                <li>
+                    All data produced by third-party providers and made
+                    available by Our World in Data are subject to the license
+                    terms from the original providers. Our work would not be
+                    possible without the data providers we rely on, so we ask
+                    you to always cite them appropriately (see below). This is
+                    crucial to allow data providers to continue doing their
+                    work, enhancing, maintaining and updating valuable data.
+                </li>
+                <li>
+                    All data, visualizations, and code produced by Our World in
+                    Data are completely open access under the{" "}
+                    <a
+                        href="https://creativecommons.org/licenses/by/4.0/"
+                        className="reuse__link"
+                    >
+                        Creative Commons BY license
+                    </a>
+                    . You have the permission to use, distribute, and reproduce
+                    these in any medium, provided the source and authors are
+                    credited.
+                </li>
+            </ul>
+            {hasAnyCitation && (
+                <div className="MetadataSectionCollapsible__citation-toggles">
+                    {citationDatapage && (
+                        <ExpandableToggle
+                            label="How to cite this page"
+                            content={
+                                <div className="citations-section">
+                                    <p className="citation__paragraph">
+                                        To cite this page overall, including any
+                                        descriptions, FAQs or explanations of
+                                        the data authored by Our World in Data,
+                                        please use the following citation:
+                                    </p>
+                                    <CodeSnippet
+                                        code={citationDatapage}
+                                        theme="light"
+                                        useMarkdown={true}
+                                    />
+                                </div>
+                            }
+                            isStacked={!!(citationShort || citationLong)}
+                        />
+                    )}
+                    {(citationShort || citationLong) && (
+                        <ExpandableToggle
+                            label="How to cite this data"
+                            content={
+                                <DataCitation
+                                    citationLong={citationLong}
+                                    citationShort={citationShort}
+                                />
+                            }
+                        />
+                    )}
+                </div>
+            )}
+        </section>
+    )
+}
+
+export default function MetadataSectionCollapsible({
+    className,
+    datapageData: primaryDatapageData,
+    additionalIndicators,
+    faqEntries: primaryFaqEntries,
+    canonicalUrl,
+    archiveContext,
+}: {
+    className?: string
+    datapageData: DataPageDataV2
+    additionalIndicators?: AdditionalIndicator[]
+    faqEntries?: FaqEntryData
+    canonicalUrl: string
+    archiveContext?: ArchiveContext
+}) {
+    const indicators: {
+        datapageData: DataPageDataV2
+        faqEntries?: FaqEntryData
+    }[] = [
+        { datapageData: primaryDatapageData, faqEntries: primaryFaqEntries },
+        ...(additionalIndicators ?? []),
+    ]
+    const [activeIndex, setActiveIndex] = useState(0)
+    // Guard against the active indicator being unmounted between renders (e.g.
+    // if the upstream data shrinks). Falls back to the primary indicator.
+    const safeIndex = Math.min(Math.max(activeIndex, 0), indicators.length - 1)
+    const active = indicators[safeIndex]
+    const datapageData = active.datapageData
+    const isMulti = indicators.length > 1
+    const switcherVariant = useSwitcherVariant()
+    // h-tabs and h-pills share the same out-of-box "About this data" +
+    // switcher header layout, with the selected indicator's title shown as
+    // the first line inside the box (same treatment as single-indicator).
+    const isHorizontalSwitcher =
+        isMulti &&
+        (switcherVariant === "h-tabs" || switcherVariant === "h-pills")
+
+    // Open the collapsible whenever the user switches indicator — the click
+    // was a request to *see* that indicator's metadata, so keeping the box
+    // collapsed afterwards would hide the very thing they asked for. Skip
+    // the initial render so the section doesn't auto-open on page load.
+    const detailsRef = useRef<HTMLDetailsElement>(null)
+    const isFirstActiveIndexRef = useRef(true)
+    useEffect(() => {
+        if (isFirstActiveIndexRef.current) {
+            isFirstActiveIndexRef.current = false
+            return
+        }
+        if (detailsRef.current) detailsRef.current.open = true
+    }, [safeIndex])
+
+    // Compute everything derivable per-indicator ONCE for each indicator in
+    // the chart, so the same pre-computed values can be re-used at each
+    // place per-indicator content gets rendered (title, tldr, bullets,
+    // FAQs, sources, citation).
+    const currentYear = dayjs().year()
+    const maybeAddPeriod = (s: string) =>
+        s.endsWith("?") || s.endsWith(".") ? s : `${s}.`
+    const archivalString = getPhraseForArchivalDate(
+        archiveContext?.archivalDate
+    )
+    const indicatorPaneData = indicators.map((ind) => {
+        const dp = ind.datapageData
+        const producers = _.uniq(dp.origins.map((o) => `${o.producer}`))
+        // Dedupe by label: multi-Y charts often share origins across
+        // indicators (e.g. children-per-woman-un has one UN WPP origin per
+        // Y variable), which would otherwise render the same source 10+
+        // times in the Data sources list.
+        const sourcesForDisplay = _.uniqBy(
+            prepareSourcesForDisplay({
+                origins: dp.origins,
+                source: dp.source,
+            }),
+            "label"
+        )
+        const citationUrl = archiveContext?.archiveUrl ?? canonicalUrl
+        const citationShort = getCitationShort(
+            dp.origins,
+            dp.attributions,
+            dp.owidProcessingLevel
+        )
+        const citationLong = getCitationLong(
+            dp.title,
+            dp.origins,
+            dp.source,
+            dp.attributions,
+            dp.attributionShort,
+            dp.titleVariant,
+            dp.owidProcessingLevel,
+            citationUrl,
+            archiveContext?.archivalDate
+        )
+        const adaptedFrom =
+            producers.length > 0 ? producers.join(", ") : dp.source?.name
+        const primaryTopicCitation = maybeAddPeriod(
+            dp.primaryTopic?.citation ?? ""
+        )
+        const citationDatapage = excludeUndefined([
+            dp.primaryTopic
+                ? `“Data Page: ${dp.title.title}”, part of the following publication: ${primaryTopicCitation}`
+                : `“Data Page: ${dp.title.title}”. Our World in Data (${currentYear}).`,
+            adaptedFrom ? `Data adapted from ${adaptedFrom}.` : undefined,
+            `Retrieved from ${citationUrl} [online resource]${
+                archivalString ? ` ${archivalString}` : ""
+            }`,
+        ]).join(" ")
+        return {
+            ind,
+            sourcesForDisplay,
+            citationShort,
+            citationLong,
+            citationDatapage,
+        }
+    })
+
+    // The indicator title (+ optional variant) wrapped in a baseline-aligned
+    // inline-flex span so the variant sits on the same baseline as the title
+    // text. Shared between the in-box title line and (for v-tabs) the
+    // summary-key-data area.
+    const renderIndicatorTitleLine = (dp: DataPageDataV2 = datapageData) => {
+        const title = dp.title.title
+        const variant = dp.titleVariant?.trim()
+        if (!title) return null
+        return (
+            <span className="MetadataSectionCollapsible__indicator-title-line">
+                <span className="MetadataSectionCollapsible__indicator-title">
+                    {title}
+                </span>
+                {variant && (
+                    <span className="MetadataSectionCollapsible__indicator-title-variant">
+                        {variant}
+                    </span>
+                )}
+            </span>
+        )
+    }
+
+    // Render the title row inside the box's header strip (__above-switcher).
+    // - Single indicator + h-tabs/h-pills (multi): renders ONE pane per
+    //   indicator; the active pane is visible, others sit in the DOM
+    //   hidden via CSS so AI agents reading raw HTML can still see each
+    //   indicator's metadata.
+    // - Dropdown variant: a single dropdown pill (no panes — the
+    //   trigger's text already updates with the active indicator, and the
+    //   other indicators are reachable through the popover).
+    // - V-tabs: nothing here (the aside renders the tab list, and the
+    //   per-indicator title row is rendered inside __summary-key-data
+    //   below since the v-tabs variant skips the inline header).
+    const renderHeaderSwitcher = () => {
+        if (!isMulti || isHorizontalSwitcher) {
+            return indicators.map((ind, i) => (
+                <IndicatorPane key={i} index={i} active={i === safeIndex}>
+                    {renderIndicatorTitleLine(ind.datapageData)}
+                </IndicatorPane>
+            ))
+        }
+        if (switcherVariant === "dropdown") {
+            return (
+                <IndicatorDropdown
+                    activeDatapageData={datapageData}
+                    indicators={indicators}
+                    activeIndex={safeIndex}
+                    onIndicatorChange={setActiveIndex}
+                />
+            )
+        }
+        return null
+    }
+
+    // The v-tabs aside renders the switcher beside the box, so no need for a
+    // header strip above the row. For dropdown / h-tabs we pull the TLDR
+    // bits (short description + factoids) up into the header so users can
+    // tell at a glance what the box hides.
+    const showInlineHeader = !(isMulti && switcherVariant === "v-tabs")
+    const renderTldr = (dp: DataPageDataV2 = datapageData) => (
+        <>
+            <ShortDescription datapageData={dp} />
+            <SourceLine datapageData={dp} />
+            <div className="MetadataSectionCollapsible__factoids">
+                <SummaryStats datapageData={dp} />
+            </div>
+        </>
+    )
+    // Loop helper: render one IndicatorPane per indicator and let `body`
+    // pull the right per-indicator data + derived values out of each pane.
+    const renderIndicatorPanes = (
+        body: (
+            pane: (typeof indicatorPaneData)[number],
+            index: number
+        ) => ReactNode
+    ) =>
+        indicatorPaneData.map((pane, i) => (
+            <IndicatorPane key={i} index={i} active={i === safeIndex}>
+                {body(pane, i)}
+            </IndicatorPane>
+        ))
+    const collapse = () => {
+        if (detailsRef.current) detailsRef.current.open = false
+    }
+    // Expand when the user clicks anywhere on the wrap (outside an
+    // interactive child like a tab button or link) while collapsed. Pairs
+    // with the wrap-wide hover styling so the whole component reads as
+    // clickable, not just the <summary>. Skip clicks inside <summary> —
+    // the <details>/<summary> native toggle already handles those, and
+    // setting `open = true` here would race with the native toggle and
+    // leave the box closed.
+    const onWrapClick = (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!detailsRef.current || detailsRef.current.open) return
+        const target = e.target as HTMLElement
+        if (target.closest("button, a, input, select, textarea, label")) return
+        if (target.closest("summary")) return
+        detailsRef.current.open = true
+    }
+    // Summary click handler. React onClick fires before the native
+    // <details> toggle, so `details.open` here reflects the state *before*
+    // the click. We let native handle expand (collapsed → open), and
+    // preventDefault on expand (open → collapsed) so reading the summary
+    // body doesn't accidentally close the section — collapsing happens
+    // only via the inline "Show less" affordance in the header row above.
+    const onSummaryClick = (e: React.MouseEvent<HTMLElement>) => {
+        // Keyboard-triggered clicks have detail === 0; let those toggle
+        // normally so keyboard UX matches the native <details> behaviour.
+        if (e.detail === 0) return
+        if (!detailsRef.current?.open) return
+        e.preventDefault()
+    }
+    // Click anywhere on the header row (__above) while the box is open to
+    // collapse it. Stop propagation so the wrap-level onClick (which would
+    // see `open === false` post-collapse and re-open the box) doesn't fire.
+    // Skip clicks on interactive children (e.g. the multi-indicator switcher
+    // dropdown) — they handle their own behavior.
+    const onAboveClick = (e: React.MouseEvent<HTMLElement>) => {
+        if (!detailsRef.current?.open) return
+        e.stopPropagation()
+        const target = e.target as HTMLElement
+        if (target.closest("button, a, input, select, textarea, label")) return
+        collapse()
+    }
+    return (
+        <div
+            className={cx(
+                "MetadataSectionCollapsible-wrap",
+                `MetadataSectionCollapsible-wrap--${switcherVariant}`,
+                {
+                    "MetadataSectionCollapsible-wrap--no-above":
+                        !showInlineHeader,
+                },
+                className
+            )}
+            onClick={onWrapClick}
+        >
+            {/*
+             * Horizontal-switcher variants render "About this data" + the
+             * tab/pill row OUTSIDE the box, so the row reads as a header
+             * for the whole box. The selected indicator's title is then
+             * shown as the first line INSIDE the box (handled inside
+             * renderHeaderSwitcher).
+             */}
+            {isHorizontalSwitcher && (
+                <div className="MetadataSectionCollapsible__multi-header">
+                    <IndicatorAboutLabel indicatorCount={indicators.length} />
+                    <IndicatorTabsHorizontal
+                        indicators={indicators}
+                        activeIndex={safeIndex}
+                        onIndicatorChange={setActiveIndex}
+                        variant={
+                            switcherVariant === "h-pills" ? "pills" : "tabs"
+                        }
+                    />
+                </div>
+            )}
+            {showInlineHeader && (
+                <header
+                    className="MetadataSectionCollapsible__above"
+                    onClick={onAboveClick}
+                >
+                    <div className="MetadataSectionCollapsible__above-switcher">
+                        {renderHeaderSwitcher()}
+                        {/* Inline "Show less" affordance — pushed to the right
+                            via flexbox in SCSS, visible only when the box is
+                            open (controlled via :has() in SCSS). Click target
+                            is the whole __above row above, not the span. */}
+                        <span
+                            className="MetadataSectionCollapsible__inline-show-less"
+                            aria-hidden="true"
+                        >
+                            Show less
+                            <FontAwesomeIcon
+                                className="MetadataSectionCollapsible__icon"
+                                icon={faChevronUp}
+                            />
+                        </span>
+                    </div>
+                    {renderIndicatorPanes((pane) =>
+                        renderTldr(pane.ind.datapageData)
+                    )}
+                </header>
+            )}
+            <div className="MetadataSectionCollapsible__main">
+                {isMulti && switcherVariant === "v-tabs" && (
+                    <IndicatorTabsVertical
+                        indicators={indicators}
+                        activeIndex={safeIndex}
+                        onIndicatorChange={setActiveIndex}
+                    />
+                )}
+                <details
+                    ref={detailsRef}
+                    className="MetadataSectionCollapsible"
+                >
+                    <summary
+                        className="MetadataSectionCollapsible__summary"
+                        onClick={onSummaryClick}
+                    >
+                        <div className="MetadataSectionCollapsible__summary-key-data">
+                            {!showInlineHeader &&
+                                renderIndicatorPanes((pane) =>
+                                    renderIndicatorTitleLine(
+                                        pane.ind.datapageData
+                                    )
+                                )}
+                            {!showInlineHeader &&
+                                renderIndicatorPanes((pane) =>
+                                    renderTldr(pane.ind.datapageData)
+                                )}
+                            {renderIndicatorPanes((pane) => (
+                                <DescriptionKey
+                                    descriptionKey={
+                                        pane.ind.datapageData.descriptionKey ??
+                                        []
+                                    }
+                                />
+                            ))}
+                            <span className="MetadataSectionCollapsible__toggle MetadataSectionCollapsible__toggle--show-more">
+                                Show more
+                                <FontAwesomeIcon
+                                    className="MetadataSectionCollapsible__icon"
+                                    icon={faChevronDown}
+                                />
+                            </span>
+                        </div>
+                    </summary>
+
+                    <div
+                        className="MetadataSectionCollapsible__content"
+                        id={DATAPAGE_ABOUT_THIS_DATA_SECTION_ID}
+                    >
+                        {/*
+                         * One pane per indicator for each section. Anchor
+                         * ids only live on the PRIMARY indicator's pane
+                         * (index 0) — they're singletons in the DOM, the
+                         * primary's pane is the default-visible one, and
+                         * giving multiple panes the same id would be
+                         * invalid HTML.
+                         */}
+                        {renderIndicatorPanes((pane, i) =>
+                            pane.ind.faqEntries ? (
+                                <FaqsSection
+                                    faqEntries={pane.ind.faqEntries}
+                                    anchorId={i === 0 ? FAQS_ID : undefined}
+                                />
+                            ) : null
+                        )}
+
+                        {renderIndicatorPanes((pane) =>
+                            pane.ind.datapageData.descriptionProcessing ? (
+                                <ProcessingNotesCallout
+                                    descriptionProcessing={
+                                        pane.ind.datapageData
+                                            .descriptionProcessing
+                                    }
+                                />
+                            ) : null
+                        )}
+
+                        {renderIndicatorPanes((pane, i) => (
+                            <DataSourcesList
+                                sources={pane.sourcesForDisplay}
+                                anchorId={
+                                    i === 0
+                                        ? DATAPAGE_SOURCES_AND_PROCESSING_SECTION_ID
+                                        : undefined
+                                }
+                                descriptionFromProducer={
+                                    pane.ind.datapageData
+                                        .descriptionFromProducer
+                                }
+                            />
+                        ))}
+
+                        {renderIndicatorPanes((pane, i) => (
+                            <CitationGuidance
+                                anchorId={
+                                    i === 0 ? CITATION_GUIDANCE_ID : undefined
+                                }
+                                citationShort={pane.citationShort}
+                                citationLong={pane.citationLong}
+                                citationDatapage={pane.citationDatapage}
+                            />
+                        ))}
+                    </div>
+                    <button
+                        type="button"
+                        className="MetadataSectionCollapsible__toggle MetadataSectionCollapsible__toggle--show-less"
+                        onClick={collapse}
+                    >
+                        <span className="MetadataSectionCollapsible__toggle-label">
+                            Show less
+                            <FontAwesomeIcon
+                                className="MetadataSectionCollapsible__icon MetadataSectionCollapsible__icon--up"
+                                icon={faChevronDown}
+                            />
+                        </span>
+                    </button>
+                </details>
+            </div>
+        </div>
+    )
+}

--- a/site/MetadataSectionCollapsible.tsx
+++ b/site/MetadataSectionCollapsible.tsx
@@ -155,7 +155,7 @@ const labelForIndicator = (datapageData: DataPageDataV2): string => {
 // data pages. Override per-request via the URL query string,
 // e.g. `?switcher=h-tabs` or `?switcher=v-tabs`.
 export type SwitcherVariant = "dropdown" | "h-tabs" | "v-tabs" | "h-pills"
-const DEFAULT_SWITCHER_VARIANT: SwitcherVariant = "h-tabs"
+const DEFAULT_SWITCHER_VARIANT: SwitcherVariant = "h-pills"
 const ALL_SWITCHER_VARIANTS: readonly SwitcherVariant[] = [
     "dropdown",
     "h-tabs",

--- a/site/MetadataSingleSource.tsx
+++ b/site/MetadataSingleSource.tsx
@@ -1,0 +1,134 @@
+import * as React from "react"
+import { DisplaySource } from "@ourworldindata/types"
+import { SimpleMarkdownText } from "@ourworldindata/components"
+import { formatSourceDate } from "@ourworldindata/utils"
+
+// Renders the `<a>` for a source-retrieved-from URL with a tidy display
+// (strips scheme), opens in a new tab.
+const SourceLink = ({ href }: { href: string }): React.ReactElement => {
+    const displayText = href.replace(/^https?:\/\//, "")
+    return (
+        <a href={href} target="_blank" rel="noreferrer">
+            {displayText}
+        </a>
+    )
+}
+
+// Detail panel for a single source — used inside each row of the data
+// sources list when the user expands a source. Renders the retrieved-on
+// line first, then (optionally) the indicator-level "How is this data
+// described by its producer?" text folded in for the primary source, the
+// source's own description (with an "About the source" header when both
+// are present), the dataPublishedBy field, and the source-attribution
+// citation as fine-print at the end.
+export const MetadataSingleSource = ({
+    source,
+    descriptionFromProducer,
+}: {
+    source: DisplaySource
+    // Indicator-level producer description, folded into a single source's
+    // detail panel (the primary one) instead of rendering as its own
+    // top-level subsection of the metadata box.
+    descriptionFromProducer?: string
+}): React.ReactElement => {
+    const retrievedOn = formatSourceDate(source.retrievedOn, "MMMM D, YYYY")
+
+    return (
+        <div className="indicator-sources indicator-sources--single">
+            <div className="source">
+                {(retrievedOn || source.retrievedFrom) && (
+                    <div className="source-key-data-blocks">
+                        <div className="source-key-data source-key-data--span-2 source-key-data--retrieved">
+                            <div className="source-key-data__content">
+                                {retrievedOn && source.retrievedFrom ? (
+                                    <>
+                                        Retrieved on {retrievedOn} from{" "}
+                                        <SourceLink
+                                            href={source.retrievedFrom}
+                                        />
+                                    </>
+                                ) : retrievedOn ? (
+                                    <>Retrieved on {retrievedOn}</>
+                                ) : (
+                                    <>
+                                        Retrieved from{" "}
+                                        <SourceLink
+                                            href={source.retrievedFrom!}
+                                        />
+                                    </>
+                                )}
+                            </div>
+                        </div>
+                    </div>
+                )}
+                {descriptionFromProducer && (
+                    <div className="source-key-data-blocks">
+                        <div className="source-key-data source-key-data--span-2 source-key-data-producer-description">
+                            <div className="source-key-data__title">
+                                How is this data described by its producer?
+                            </div>
+                            <div className="source-key-data__content">
+                                <SimpleMarkdownText
+                                    text={descriptionFromProducer.trim()}
+                                />
+                            </div>
+                        </div>
+                    </div>
+                )}
+                {source.description &&
+                    (descriptionFromProducer ? (
+                        // When descriptionFromProducer is present we have
+                        // two prose blocks back-to-back — give the source's
+                        // own description an "About the source" header so
+                        // the two are clearly distinct sections.
+                        <div className="source-key-data-blocks">
+                            <div className="source-key-data source-key-data--span-2 source-key-data-about-source">
+                                <div className="source-key-data__title">
+                                    About the source
+                                </div>
+                                <div className="source-key-data__content">
+                                    <SimpleMarkdownText
+                                        text={source.description.trim()}
+                                    />
+                                </div>
+                            </div>
+                        </div>
+                    ) : (
+                        <div className="description">
+                            <SimpleMarkdownText
+                                text={source.description.trim()}
+                            />
+                        </div>
+                    ))}
+                {source.dataPublishedBy && (
+                    <div className="source-key-data-blocks">
+                        <div className="source-key-data source-key-data--span-2">
+                            <div className="source-key-data__title">
+                                Data published by
+                            </div>
+                            <div className="source-key-data__content">
+                                <SimpleMarkdownText
+                                    text={source.dataPublishedBy.trim()}
+                                />
+                            </div>
+                        </div>
+                    </div>
+                )}
+                {source.citation && (
+                    <div className="source-key-data-blocks">
+                        <div className="source-key-data source-key-data-citation source-key-data--span-2">
+                            <div className="source-key-data__title">
+                                Source attribution
+                            </div>
+                            <div className="source-key-data__content">
+                                <SimpleMarkdownText
+                                    text={source.citation.trim()}
+                                />
+                            </div>
+                        </div>
+                    </div>
+                )}
+            </div>
+        </div>
+    )
+}

--- a/site/dataPage.ts
+++ b/site/dataPage.ts
@@ -29,7 +29,14 @@ export function processRelatedResearch(
 }
 export function getDatapageDataV2(
     variableMetadata: OwidVariableWithSource,
-    partialGrapherConfig: GrapherInterface
+    partialGrapherConfig: GrapherInterface,
+    opts?: {
+        // Per-indicator title to prefer over the chart-level title when the
+        // variable has no `presentation.titlePublic`. Used for the additional
+        // indicators of a multi-indicator chart, where the chart title
+        // describes the whole chart rather than any single indicator.
+        indicatorTitleOverride?: string
+    }
 ): DataPageDataV2 {
     const lastUpdated = getLastUpdatedFromVariable(variableMetadata) ?? ""
     const nextUpdate = getNextUpdateFromVariable(variableMetadata)
@@ -44,6 +51,7 @@ export function getDatapageDataV2(
               })
             : {
                   title:
+                      opts?.indicatorTitleOverride ??
                       partialGrapherConfig.title ??
                       variableMetadata.display?.name ??
                       variableMetadata.name ??

--- a/site/experiments.scss
+++ b/site/experiments.scss
@@ -20,6 +20,10 @@ $experiments: (
         all-charts,
         featured-metrics,
     ),
+    exp-data-page-metadata-v1: (
+        control,
+        treatment,
+    ),
 );
 
 @each $exp, $arms in $experiments {

--- a/site/owid.scss
+++ b/site/owid.scss
@@ -192,6 +192,7 @@
 @import "./KeyDataTable.scss";
 @import "./DownloadSection.scss";
 @import "./MetadataSection.scss";
+@import "./MetadataSectionCollapsible.scss";
 @import "./TopicTags.scss";
 @import "./detailsOnDemand.scss";
 


### PR DESCRIPTION
## 👨 Context

Move all data page metadata into a "metadata box" on a selection of ~20 data pages (including 6 multi-indicator pages to be rendered as data pages). Implemented as an A/B experiment as a way to roll out to just this subset of pages at first.

### TODO before merging

- [ ] implement desired click tracking analytics (e.g. "show more / less", expand/collapse data sources).
- [ ] change arm probabilities (we don't actually want 100% assigned to treatment)
- [ ] revise experiment end date.
- [ ] ...tbd

---

## 🤖 Summary

Introduces a new collapsible "metadata box" UI on data pages, gated behind an A/B experiment (`data-page-metadata-v1`). Both arms are baked into the static HTML; a Cloudflare middleware sets a body class that decides which one is visible per request. No visible change for non-enrolled charts.

The box subsumes today's `AboutThisData` + `MetadataSection` (FAQs / sources / processing / citation) into a single collapsible component with:
- a TL;DR header strip (short description, source line, factoids) that's visible whether the box is open or closed,
- an indicator switcher for multi-indicator charts (4 layout variants behind `?switcher=…` for design iteration),
- expandable subsections for FAQs, processing notes, data sources, and "How to cite",
- a modal-based "Detailed details on demand" affordance for source-level metadata.

## Commits

The PR is structured to read top-down by dependency. Each commit is independently buildable / testable.

1. **`experiments: scaffold data-page-metadata-v1 A/B + isUrlInActiveExperiment helper`** — defines the experiment + reusable enrolment helper (shared by baker and React tree as a single source of truth).
2. **`types: AdditionalIndicator for multi-indicator data pages`** — shared type.
3. **`dataPage: indicatorTitleOverride opt on getDatapageDataV2`** — lets the baker pass a per-indicator title (defaults preserve existing behavior).
4. **`baker: multi-indicator metadata + force-datapage for metadata box experiment`** — loads per-Y-variable metadata for enrolled charts, forces non-datapage charts to bake as data pages when enrolled, and fixes a latent bug in `getDatapageIndicatorId` (explicit `datapages` row now wins over `forceDatapage`). Non-enrolled charts: no extra S3 fetches, no behavior change.
5. **`metadata box: new collapsible data-page furniture (component + styles)`** — adds `MetadataSectionCollapsible`, `MetadataSingleSource`, `DetailedDetailsOnDemand`, plus SCSS. Component only — no wire-up.
6. **`grapher footer: source-line treatment variant for metadata box experiment`** — adds the treatment-arm variant of the chart-footer "Data source" line (source text itself becomes the link, jumps to the box's Data sources section). Control + non-enrolled charts unchanged.
7. **`dataPage: wire metadata box into DataPageV2 for the experiment treatment arm`** — the integration: renders both arms into the DOM with show/hide modifier classes, threads `additionalIndicators` from baker → React tree → client hydration.

## Behavior on non-enrolled charts

No visible change. Verify by spot-checking a few non-enrolled data pages — they should render identically to master.

## Behavior on enrolled charts (treatment arm)

- New collapsible box renders in place of `AboutThisData` + `MetadataSection`.
- For multi-Y charts: indicator switcher renders above the box (default `h-tabs` variant; try `?switcher=dropdown|h-tabs|v-tabs|h-pills` to compare).
- Grapher footer's "Data source: …" line becomes a single link on the source text itself, scrolling to "Data sources" inside the box (control arm keeps the separate "Learn more about this data" affordance scrolling to "About this data").

## Things reviewers should sanity-check

- **Doubled metadata payload on enrolled charts**: both control and treatment markup sit in the DOM, CSS hides one. ~2× metadata HTML size for enrolled pages. We accepted this so AI agents reading raw HTML see both representations.
- **`DownloadSection` rendered twice in treatment**: once inside the hidden `MetadataSection`, once standalone with `--show`. Only one is visible. Worth confirming this is OK vs. refactoring `MetadataSection` to make the download optional.
- **Sticky-nav hidden in treatment**: deliberate (its anchors point to now-hidden elements). A treatment-specific nav is a deliberate follow-up.
- **`MetadataSectionCollapsible.tsx` is ~1300 lines in one file** containing ~15 sub-components. Co-located helpers; could be split into a folder structure post-experiment if we keep this UI. Easier to review in current shape since the whole flow is in one place.
- **Indicator switcher**: 4 layout variants ship. The default (`h-tabs`) is what we plan to expose; the others are for design comparison and live behind `?switcher=…`. Worth deciding whether to strip the unused variants before merge or after experiment results.

## Test plan

- [ ] **Non-enrolled chart** (e.g. open any random `/grapher/<slug>`): renders identically to master.
- [ ] **Enrolled chart, control arm**: render identical to master, source-line click scrolls to "About this data" as before.
- [ ] **Enrolled chart, treatment arm**: metadata box renders; collapsed state shows TL;DR; expand reveals FAQs / processing / sources / cite; source-line click in grapher footer scrolls to the box's Data sources section.
- [ ] **Multi-indicator chart in treatment**: indicator switcher renders; switching tabs swaps visible content; URL params `?switcher=dropdown|v-tabs|h-pills` switch layout variants.
- [ ] **Single-indicator enrolled chart in treatment**: no switcher renders; box reads as a single block.
- [ ] **Admin preview**: enrolled chart previews render the treatment arm (the baker change forces datapage in preview too).
- [ ] **No layout shift / broken anchors** on non-enrolled charts.

## Out of scope (deferred)

- A Sentry profiler fix for Node 24 (`serverUtils/instrument.ts`) is sitting in the working tree but intentionally not in this PR — it's unrelated and lands separately.
- Treatment-specific sticky-nav: hidden for now, will revisit once the box layout is finalized.
