### PR TITLE
🔨 run bespoke tests in ci

### DIFF
--- a/.github/workflows/bespoke.yml
+++ b/.github/workflows/bespoke.yml
@@ -28,6 +28,23 @@ jobs:
       - name: Typecheck
         run: yarn typecheck
 
+  bespoke-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v5
+
+      - uses: ./.github/actions/setup-node-yarn-deps
+        with:
+          runPostinstallScripts: false
+          cacheDependencyPath: bespoke/yarn.lock
+
+      - name: Install bespoke dependencies
+        run: yarn --immutable
+
+      - name: Test
+        run: yarn test
+
   bespoke-build:
     runs-on: ubuntu-latest
     steps:

--- a/bespoke/package.json
+++ b/bespoke/package.json
@@ -8,6 +8,13 @@
     ],
     "scripts": {
         "build": "yarn workspaces foreach -A run build",
-        "typecheck": "yarn workspaces foreach -A run typecheck"
+        "typecheck": "yarn workspaces foreach -A run typecheck",
+        "test": "vitest run"
+    },
+    "devDependencies": {
+        "@rollup/plugin-swc": "^0.4.0",
+        "@vitejs/plugin-react": "^6.0.0",
+        "vite": "^8.0.5",
+        "vitest": "^4.1.2"
     }
 }

--- a/bespoke/vitest.config.ts
+++ b/bespoke/vitest.config.ts
@@ -1,0 +1,41 @@
+import { defineConfig } from "vitest/config"
+import { withFilter } from "vite"
+import pluginReact from "@vitejs/plugin-react"
+import pluginSwc from "@rollup/plugin-swc"
+
+export default defineConfig({
+    plugins: [
+        withFilter(
+            // Use swc to transform decorators, since rolldown/oxc doesn't
+            // support modern decorators yet. We could remove this once they do
+            // - see https://github.com/oxc-project/oxc/issues/9170.
+            pluginSwc({
+                swc: {
+                    jsc: {
+                        parser: {
+                            syntax: "typescript",
+                            decorators: true,
+                        },
+                        transform: {
+                            decoratorVersion: "2023-11",
+                            useDefineForClassFields: true,
+                        },
+                        // This setting we need to override from
+                        // @rollup/plugin-swc's default, otherwise it will not
+                        // put optional properties on classes (e.g.
+                        // `class A { optionalProp?: string }`), thereby breaking
+                        // mobx decorators
+                        loose: false,
+                        target: "esnext",
+                    },
+                },
+            }),
+            // Only run this transform if the file contains a decorator.
+            { transform: { code: /[^"]@/, id: /.*\.(ts|tsx)$/ } }
+        ),
+        pluginReact(),
+    ],
+    test: {
+        root: ".",
+    },
+})

--- a/bespoke/yarn.lock
+++ b/bespoke/yarn.lock
@@ -2768,6 +2768,11 @@ __metadata:
 "root-workspace-0b6124@workspace:.":
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
+  dependencies:
+    "@rollup/plugin-swc": "npm:^0.4.0"
+    "@vitejs/plugin-react": "npm:^6.0.0"
+    vite: "npm:^8.0.5"
+    vitest: "npm:^4.1.2"
   languageName: unknown
   linkType: soft
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
             "db/tests/**",
             "adminSiteServer/app.test.ts",
             "adminSiteServer/tests/**",
+            "bespoke/**",
         ],
         pool: "threads",
         setupFiles: ["devTools/vitest-setup.ts"],


### PR DESCRIPTION
Tests in the /bespoke folder used to run with `yarn test`. They're now separated into their own testing suite, and a new github action for running bespoke tests is added.