### PR TITLE
Add dumbbell chart link to admin test index

### DIFF
--- a/adminSiteClient/TestIndexPage.tsx
+++ b/adminSiteClient/TestIndexPage.tsx
@@ -102,6 +102,15 @@ export function TestIndexPage() {
                             Stacked Discrete Bar
                         </Link>
                     </li>
+                    <li>
+                        <Link
+                            native
+                            target="_blank"
+                            to="/test/embeds?type=Dumbbell"
+                        >
+                            Dumbbell
+                        </Link>
+                    </li>
 
                     <li>
                         <Link


### PR DESCRIPTION
Surface the existing `type=Dumbbell` embed test view on the admin test index page (`/admin/test`), alongside the other chart-type links.

No backend change was needed: `testPageRouter`'s `type` query param already filters generically by `cc.chartType`, and `Dumbbell` is a valid `GrapherChartType`. This just adds the link so the view is discoverable from the test index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)