### PR TITLE
🧪 Experiment: sticky topnav

### DIFF
--- a/packages/@ourworldindata/types/src/analyticsTypes/analyticsTypes.ts
+++ b/packages/@ourworldindata/types/src/analyticsTypes/analyticsTypes.ts
@@ -51,6 +51,7 @@ export enum EventCategory {
     SiteChartPreviewMouseover = "owid.site_chart_preview_mouseover",
     SiteStaticVizDownload = "owid.site_static_viz_download",
     SiteUserSurvey = "owid.site_user_survey",
+    SiteTopnavView = "owid.site_topnav_view",
     TranslatePage = "owid.translate_page",
 }
 
@@ -79,6 +80,7 @@ export type EventParamsMap = {
     [EventCategory.SiteChartPreviewMouseover]: SiteChartPreviewMouseoverParams
     [EventCategory.SiteStaticVizDownload]: SiteStaticVizDownloadParams
     [EventCategory.SiteUserSurvey]: SiteUserSurveyParams
+    [EventCategory.SiteTopnavView]: SiteTopnavViewParams
     [EventCategory.SiteClick]: SiteClickParams
     [EventCategory.SiteFormSubmit]: SiteFormSubmitParams
     [EventCategory.SiteInstantSearchClick]: SiteInstantSearchClickParams
@@ -193,6 +195,13 @@ export interface SiteErrorParams {
     eventAction: string
     /** Error details or URL */
     eventContext: string
+}
+
+export interface SiteTopnavViewParams {
+    /** Always 'view' for this event */
+    eventAction: "view"
+    /** Experiment arm: 'sticky' or 'show-on-scroll-up' */
+    experimentArm: string
 }
 
 export interface SiteGuidedChartLinkClickParams {

--- a/packages/@ourworldindata/utils/src/experiments/config.ts
+++ b/packages/@ourworldindata/utils/src/experiments/config.ts
@@ -81,4 +81,26 @@ export const experiments: Experiment[] = [
         ],
         paths: ["/"],
     }),
+    /*
+     * Experiment: topnav-v1
+     *
+     * Tests whether keeping the site topnav persistently visible improves
+     * navigation discoverability. Same path surface as the popup survey
+     * (paths: ["/"] matches every URL under RFC 6265 cookie-path semantics).
+     *
+     * Conditions:
+     * - (a) control: status quo, position: relative
+     * - (b) sticky: position: sticky; top: 0
+     * - (c) show-on-scroll-up: sticky, hidden on scroll-down, shown on scroll-up
+     */
+    new Experiment({
+        id: "topnav-v1",
+        expires: "2026-12-31T00:00:00.000Z",
+        arms: [
+            { id: "control", fraction: 0.0 },
+            { id: "sticky", fraction: 0.5 },
+            { id: "show-on-scroll-up", fraction: 0.5 },
+        ],
+        paths: ["/"],
+    }),
 ]

--- a/site/SiteAnalytics.ts
+++ b/site/SiteAnalytics.ts
@@ -27,6 +27,14 @@ export class SiteAnalytics extends GrapherAnalytics {
         })
     }
 
+    logTopnavView(experimentArm: string) {
+        this.logToGA({
+            event: EventCategory.SiteTopnavView,
+            eventAction: "view",
+            experimentArm,
+        })
+    }
+
     logInstantSearchClick({
         query,
         url,

--- a/site/SiteNavigation.scss
+++ b/site/SiteNavigation.scss
@@ -5,6 +5,26 @@
     }
 }
 
+// Experiment topnav-v1: sticky arm — header stays pinned to the top of the viewport.
+body.exp-topnav-v1--sticky .site-header {
+    position: sticky;
+    top: 0;
+}
+
+// Experiment topnav-v1: show-on-scroll-up arm — sticky, but slides out of view
+// on scroll-down and slides back in on scroll-up. The .site-header--hidden class
+// is toggled by a scroll listener in SiteNavigation.tsx.
+body.exp-topnav-v1--show-on-scroll-up .site-header {
+    position: sticky;
+    top: 0;
+    transition: transform 0.2s ease-in-out;
+    will-change: transform;
+}
+
+body.exp-topnav-v1--show-on-scroll-up .site-header.site-header--hidden {
+    transform: translateY(-100%);
+}
+
 .site-navigation {
     position: relative;
     z-index: $zindex-lightbox;

--- a/site/SiteNavigation.scss
+++ b/site/SiteNavigation.scss
@@ -35,6 +35,15 @@ body.exp-topnav-v1--show-on-scroll-up {
     }
 }
 
+// Experiment topnav-v1: opt out of sticky behavior on pages that already have
+// their own sticky nav (data pages, longform posts, gdoc posts with sticky-nav).
+// Letting two sticky bars pin to top: 0 produces overlapping/jarring chrome,
+// so we fall back to the static control behavior on those pages.
+body.exp-topnav-v1--sticky:has(.sticky-nav) .site-header,
+body.exp-topnav-v1--show-on-scroll-up:has(.sticky-nav) .site-header {
+    position: static;
+}
+
 .site-navigation {
     position: relative;
     z-index: $zindex-lightbox;

--- a/site/SiteNavigation.scss
+++ b/site/SiteNavigation.scss
@@ -44,6 +44,20 @@ body.exp-topnav-v1--show-on-scroll-up:has(.sticky-nav) .site-header {
     position: static;
 }
 
+// Experiment topnav-v1: when the topnav is pinned, other top-pinned chrome
+// (ToC sidebar on linear topic pages and centered articles) needs to dock
+// below it instead of fighting for top: 0. Height matches the reduced topnav
+// above: 8px + $search-cta-height (40px) + 8px + $header-border-height (4px).
+// Excluded when the page has its own .sticky-nav — there the topnav is
+// non-sticky, so the ToC should stay at top: 0.
+body.exp-topnav-v1--sticky:not(:has(.sticky-nav)),
+body.exp-topnav-v1--show-on-scroll-up:not(:has(.sticky-nav)) {
+    .toc-wrapper,
+    .entry-sidebar .entry-toc {
+        top: 60px;
+    }
+}
+
 .site-navigation {
     position: relative;
     z-index: $zindex-lightbox;

--- a/site/SiteNavigation.scss
+++ b/site/SiteNavigation.scss
@@ -25,6 +25,16 @@ body.exp-topnav-v1--show-on-scroll-up .site-header.site-header--hidden {
     transform: translateY(-100%);
 }
 
+// Experiment topnav-v1: trim vertical padding on sticky arms so the pinned
+// header takes up less viewport real estate.
+body.exp-topnav-v1--sticky,
+body.exp-topnav-v1--show-on-scroll-up {
+    .site-navigation-bar {
+        padding-top: 8px;
+        padding-bottom: 8px;
+    }
+}
+
 .site-navigation {
     position: relative;
     z-index: $zindex-lightbox;

--- a/site/SiteNavigation.tsx
+++ b/site/SiteNavigation.tsx
@@ -113,12 +113,14 @@ export const SiteNavigation = ({
     useTriggerOnEscape(closeOverlay, { active: menu !== null })
 
     // Experiment topnav-v1: log a one-shot view event for treatment arms so we
-    // can split engagement metrics by arm in GA.
+    // can split engagement metrics by arm in GA. Skip on pages where the
+    // sticky behavior is disabled (own .sticky-nav present) — the user
+    // isn't actually experiencing the treatment there.
     useEffect(() => {
         const arm = getExperimentState()[TOPNAV_EXPERIMENT_ID]?.arm
-        if (arm === "sticky" || arm === "show-on-scroll-up") {
-            analytics.logTopnavView(arm)
-        }
+        if (arm !== "sticky" && arm !== "show-on-scroll-up") return
+        if (document.querySelector(".sticky-nav")) return
+        analytics.logTopnavView(arm)
     }, [])
 
     // Experiment topnav-v1, show-on-scroll-up arm: hide the header on scroll-down,
@@ -129,6 +131,10 @@ export const SiteNavigation = ({
     useEffect(() => {
         const arm = getExperimentState()[TOPNAV_EXPERIMENT_ID]?.arm
         if (arm !== "show-on-scroll-up") return
+        // Skip when the page has its own sticky nav — the CSS opts out of
+        // position: sticky there, so translating the header would just slide
+        // a static element off-screen.
+        if (document.querySelector(".sticky-nav")) return
 
         const header = document.querySelector<HTMLElement>(".site-header")
         if (!header) return

--- a/site/SiteNavigation.tsx
+++ b/site/SiteNavigation.tsx
@@ -39,6 +39,42 @@ const TOPNAV_EXPERIMENT_ID = "exp-topnav-v1"
 const TOPNAV_HIDE_THRESHOLD_PX = 120
 const TOPNAV_SCROLL_DELTA_PX = 6
 
+// Query param that lets us preview an arm of the topnav-v1 experiment without
+// relying on cookie assignment — useful for QA on staging.
+//   ?topnav=control               → behave like the control arm (non-sticky)
+//   ?topnav=sticky                → behave like the sticky arm
+//   ?topnav=show-on-scroll-up     → behave like the show-on-scroll-up arm
+const TOPNAV_OVERRIDE_PARAM = "topnav"
+
+type TopnavArm = "control" | "sticky" | "show-on-scroll-up"
+
+const TOPNAV_VALID_ARMS: readonly TopnavArm[] = [
+    "control",
+    "sticky",
+    "show-on-scroll-up",
+]
+
+const TOPNAV_BODY_CLASS_PREFIX = `${TOPNAV_EXPERIMENT_ID}--`
+
+function getTopnavArmFromUrl(): TopnavArm | null {
+    if (typeof window === "undefined") return null
+    const value = new URLSearchParams(window.location.search).get(
+        TOPNAV_OVERRIDE_PARAM
+    )
+    return (TOPNAV_VALID_ARMS as readonly string[]).includes(value ?? "")
+        ? (value as TopnavArm)
+        : null
+}
+
+function getActiveTopnavArm(): TopnavArm | undefined {
+    const override = getTopnavArmFromUrl()
+    if (override) return override
+    const arm = getExperimentState()[TOPNAV_EXPERIMENT_ID]?.arm
+    return (TOPNAV_VALID_ARMS as readonly string[]).includes(arm ?? "")
+        ? (arm as TopnavArm)
+        : undefined
+}
+
 const analytics = new SiteAnalytics()
 
 export const SiteNavigation = ({
@@ -112,12 +148,34 @@ export const SiteNavigation = ({
 
     useTriggerOnEscape(closeOverlay, { active: menu !== null })
 
+    // Experiment topnav-v1: when ?topnav=<arm> is present, swap the body
+    // class so the CSS rules match the requested arm regardless of the
+    // cookie-assigned arm set by the CF middleware. Server-rendered pages
+    // always start with the cookie's class (if any); this effect reconciles
+    // client-side.
+    useEffect(() => {
+        const override = getTopnavArmFromUrl()
+        if (!override) return
+        for (const cls of Array.from(document.body.classList)) {
+            if (cls.startsWith(TOPNAV_BODY_CLASS_PREFIX)) {
+                document.body.classList.remove(cls)
+            }
+        }
+        if (override !== "control") {
+            document.body.classList.add(
+                `${TOPNAV_BODY_CLASS_PREFIX}${override}`
+            )
+        }
+    }, [])
+
     // Experiment topnav-v1: log a one-shot view event for treatment arms so we
     // can split engagement metrics by arm in GA. Skip on pages where the
     // sticky behavior is disabled (own .sticky-nav present) — the user
-    // isn't actually experiencing the treatment there.
+    // isn't actually experiencing the treatment there. Also skip when the
+    // URL overrides the arm (QA/staging traffic shouldn't pollute data).
     useEffect(() => {
-        const arm = getExperimentState()[TOPNAV_EXPERIMENT_ID]?.arm
+        if (getTopnavArmFromUrl()) return
+        const arm = getActiveTopnavArm()
         if (arm !== "sticky" && arm !== "show-on-scroll-up") return
         if (document.querySelector(".sticky-nav")) return
         analytics.logTopnavView(arm)
@@ -129,7 +187,7 @@ export const SiteNavigation = ({
     const menuRef = useRef(menu)
     menuRef.current = menu
     useEffect(() => {
-        const arm = getExperimentState()[TOPNAV_EXPERIMENT_ID]?.arm
+        const arm = getActiveTopnavArm()
         if (arm !== "show-on-scroll-up") return
         // Skip when the page has its own sticky nav — the CSS opts out of
         // position: sticky there, so translating the header would just slide

--- a/site/SiteNavigation.tsx
+++ b/site/SiteNavigation.tsx
@@ -1,4 +1,6 @@
-import { useState, useCallback, useEffect } from "react"
+import { useState, useCallback, useEffect, useRef } from "react"
+import { getExperimentState } from "@ourworldindata/utils"
+import { SiteAnalytics } from "./SiteAnalytics.js"
 import {
     faListUl,
     faBars,
@@ -32,6 +34,12 @@ import { SEARCH_BASE_PATH } from "./search/searchUtils.js"
 // Note: tranforming the flag from an env string to a boolean in
 // clientSettings.ts is convoluted due to the two-pass SSR/Vite build process.
 const HAS_DONATION_FLAG = false
+
+const TOPNAV_EXPERIMENT_ID = "exp-topnav-v1"
+const TOPNAV_HIDE_THRESHOLD_PX = 120
+const TOPNAV_SCROLL_DELTA_PX = 6
+
+const analytics = new SiteAnalytics()
 
 export const SiteNavigation = ({
     hideDonationFlag,
@@ -103,6 +111,68 @@ export const SiteNavigation = ({
     }, [query])
 
     useTriggerOnEscape(closeOverlay, { active: menu !== null })
+
+    // Experiment topnav-v1: log a one-shot view event for treatment arms so we
+    // can split engagement metrics by arm in GA.
+    useEffect(() => {
+        const arm = getExperimentState()[TOPNAV_EXPERIMENT_ID]?.arm
+        if (arm === "sticky" || arm === "show-on-scroll-up") {
+            analytics.logTopnavView(arm)
+        }
+    }, [])
+
+    // Experiment topnav-v1, show-on-scroll-up arm: hide the header on scroll-down,
+    // reveal it on scroll-up. Body class .exp-topnav-v1--show-on-scroll-up is set
+    // by the CF middleware; this effect adds/removes .site-header--hidden.
+    const menuRef = useRef(menu)
+    menuRef.current = menu
+    useEffect(() => {
+        const arm = getExperimentState()[TOPNAV_EXPERIMENT_ID]?.arm
+        if (arm !== "show-on-scroll-up") return
+
+        const header = document.querySelector<HTMLElement>(".site-header")
+        if (!header) return
+
+        let lastY = window.scrollY
+        let ticking = false
+
+        const update = () => {
+            ticking = false
+            const y = window.scrollY
+            const delta = y - lastY
+            if (Math.abs(delta) < TOPNAV_SCROLL_DELTA_PX) return
+            // Keep the header visible while a menu/dropdown is open so its
+            // anchor doesn't slide out from under the user.
+            if (menuRef.current !== null) {
+                header.classList.remove("site-header--hidden")
+            } else if (delta > 0 && y > TOPNAV_HIDE_THRESHOLD_PX) {
+                header.classList.add("site-header--hidden")
+            } else if (delta < 0) {
+                header.classList.remove("site-header--hidden")
+            }
+            lastY = y
+        }
+
+        const onScroll = () => {
+            if (!ticking) {
+                window.requestAnimationFrame(update)
+                ticking = true
+            }
+        }
+
+        window.addEventListener("scroll", onScroll, { passive: true })
+        return () => {
+            window.removeEventListener("scroll", onScroll)
+            header.classList.remove("site-header--hidden")
+        }
+    }, [])
+
+    // Whenever a menu opens, immediately reveal the header.
+    useEffect(() => {
+        if (menu === null) return
+        const header = document.querySelector<HTMLElement>(".site-header")
+        header?.classList.remove("site-header--hidden")
+    }, [menu])
 
     return (
         <>


### PR DESCRIPTION
## 🧑‍🦱  Context

Implements an A/B experiment of a sticky topnav vs "show topnav on scroll up" vs status quo.

## 🤖 Summary

Introduces a new A/B experiment (`topnav-v1`) that keeps the site topnav visible while the user scrolls, to see whether persistent navigation chrome improves discoverability. Two treatment arms split 50/50 with control held at 0% for the initial ramp:

- **`sticky`** — `position: sticky; top: 0`. The topnav stays pinned at all times.
- **`show-on-scroll-up`** — also sticky, but slides out of view on scroll-down and re-appears on scroll-up.

Wired up via the existing experiment infrastructure: CF middleware in `functions/_common/experiments.ts` assigns each visitor an arm cookie and injects an `exp-topnav-v1--<arm>` class onto `<body>`, and the CSS/JS in `site/SiteNavigation.{scss,tsx}` picks that up.

A one-shot `owid.site_topnav_view` GA event fires on mount for the two treatment arms so we can split engagement metrics by arm.

## Commits

| # | Commit | What it does |
|---|---|---|
| 1 | 🎉 Add topnav-v1 experiment | The experiment itself — config, body-class CSS for both arms, scroll listener for `show-on-scroll-up`, and the GA view-event hook. |
| 2 | ✨ Trim header padding on sticky arms | Drop `.site-navigation-bar` vertical padding from 12px to 8px on the two sticky arms only. Total header height: ~68px → ~60px. Control unchanged. |
| 3 | 🐛 Skip sticky behavior on pages with own sticky nav | Data pages, longform posts, and gdoc topic pages already render a `.sticky-nav` pinned at `top: 0`. Layering the topnav on top creates overlapping chrome, so we opt out via `:has(.sticky-nav)` and bail the scroll listener / view-event log accordingly. |
| 4 | 🐛 Offset sticky ToCs below the pinned topnav | `.toc-wrapper` and `.entry-sidebar .entry-toc` (linear topic pages + centered articles) get pushed down to `top: 60px` so the ToC doesn't slip behind the topnav. Skipped on `:has(.sticky-nav)` pages where the topnav is non-sticky. |
| 5 | 🎉 `?topnav=` query param | Lets QA force an arm without touching cookies: `?topnav=control \| sticky \| show-on-scroll-up`. Strips any existing `exp-topnav-v1--*` body class and reapplies the requested one client-side. View-event analytics bail when an override is present so QA traffic doesn't pollute experiment data. |

## How to QA on staging

On any page:

- `?topnav=sticky` — preview the sticky arm
- `?topnav=show-on-scroll-up` — preview the show-on-scroll-up arm (scroll down to hide, scroll up to reveal)
- `?topnav=control` — preview the control arm (even if your cookie put you in a treatment)

Things worth poking at:

- **Homepage / linear topic pages** — topnav should pin; ToC sidebar on linear topic pages docks at `top: 60px` so both are visible.
- **Data pages, longform posts, modular topic pages** — sticky topnav is suppressed; only the page's own `.sticky-nav` should pin. Override via `?topnav=…` does nothing visible on these pages (intentional).
- **Dropdown menus** (Browse by topic, Resources, About, Subscribe) — opening a menu while scrolling should force the header visible; closing and scrolling down again should let it hide.
- **Mobile (sm-only)** — sticky behavior should still work; the search/donate row collapses normally.

## Test plan

- [ ] Sticky arm pins the header on the homepage at all scroll positions.
- [ ] Show-on-scroll-up arm hides the header on scroll-down past ~120px, reveals it on scroll-up.
- [ ] Header stays visible when a dropdown is open, regardless of scroll direction.
- [ ] Data pages and modular topic pages do not double up sticky bars — only the section nav pins.
- [ ] Linear topic page ToC is fully readable (top entry not clipped) with the topnav pinned.
- [ ] `?topnav=sticky`, `?topnav=show-on-scroll-up`, `?topnav=control` each render as expected regardless of cookie state.
- [ ] No GA `site_topnav_view` events fired when `?topnav=` is set or when `.sticky-nav` is on the page.
- [ ] Mobile (sm-only) viewport: sticky behavior works, no layout regressions.

## Known issues / follow-ups

- Top-left rounded-corner artifact reported during local review hasn't been fixed yet — couldn't reproduce from CSS inspection; need a screenshot to diagnose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
