### PR TITLE
✨ Coviews-based related charts on data pages

### DIFF
--- a/baker/GrapherBaker.tsx
+++ b/baker/GrapherBaker.tsx
@@ -50,10 +50,7 @@ import { logErrorAndMaybeCaptureInSentry } from "../serverUtils/errorLog.js"
 
 import { deleteOldGraphers, getTagToSlugMap } from "./GrapherBakingUtils.js"
 import { knexRaw } from "../db/db.js"
-import {
-    getRelatedChartsForChart,
-    getRelatedChartsForVariable,
-} from "../db/model/Chart.js"
+import { getRelatedChartsForVariable } from "../db/model/Chart.js"
 import { getAllMultiDimDataPageSlugs } from "../db/model/MultiDimDataPage.js"
 import pMap from "p-map"
 import { stringify } from "safe-stable-stringify"
@@ -222,23 +219,14 @@ export async function renderDataPageV2(
     // If we're baking to an archival page, then we want to skip a bunch of sections
     // where the links would break
     if (archiveContext?.type !== "archive-page") {
-        // Get related charts, preferring coviews-based recommendations from
-        // the related_charts table (populated by the ETL related-charts CLI).
-        // Fall back to charts sharing this variable when no recommendations
-        // exist for this chart, and exclude the current chart to avoid
-        // duplicates.
-        let allCharts =
-            grapher && "id" in grapher
-                ? await getRelatedChartsForChart(knex, grapher.id as number)
-                : []
-        if (allCharts.length === 0) {
-            allCharts = await getRelatedChartsForVariable(
-                knex,
-                variableId,
-                grapher && "id" in grapher ? [grapher.id as number] : [],
-                true
-            )
-        }
+        // Get the charts this variable is being used in (aka "related charts")
+        // and exclude the current chart to avoid duplicates
+        const allCharts = await getRelatedChartsForVariable(
+            knex,
+            variableId,
+            grapher && "id" in grapher ? [grapher.id as number] : [],
+            true
+        )
         datapageData.allCharts = allCharts.map((chart) => ({
             ...chart,
             archiveContext: archiveContextDictionary?.[chart.chartId],

--- a/baker/GrapherBaker.tsx
+++ b/baker/GrapherBaker.tsx
@@ -50,7 +50,10 @@ import { logErrorAndMaybeCaptureInSentry } from "../serverUtils/errorLog.js"
 
 import { deleteOldGraphers, getTagToSlugMap } from "./GrapherBakingUtils.js"
 import { knexRaw } from "../db/db.js"
-import { getRelatedChartsForVariable } from "../db/model/Chart.js"
+import {
+    getRelatedChartsForChart,
+    getRelatedChartsForVariable,
+} from "../db/model/Chart.js"
 import { getAllMultiDimDataPageSlugs } from "../db/model/MultiDimDataPage.js"
 import pMap from "p-map"
 import { stringify } from "safe-stable-stringify"
@@ -219,14 +222,23 @@ export async function renderDataPageV2(
     // If we're baking to an archival page, then we want to skip a bunch of sections
     // where the links would break
     if (archiveContext?.type !== "archive-page") {
-        // Get the charts this variable is being used in (aka "related charts")
-        // and exclude the current chart to avoid duplicates
-        const allCharts = await getRelatedChartsForVariable(
-            knex,
-            variableId,
-            grapher && "id" in grapher ? [grapher.id as number] : [],
-            true
-        )
+        // Get related charts, preferring coviews-based recommendations from
+        // the related_charts table (populated by the ETL related-charts CLI).
+        // Fall back to charts sharing this variable when no recommendations
+        // exist for this chart, and exclude the current chart to avoid
+        // duplicates.
+        let allCharts =
+            grapher && "id" in grapher
+                ? await getRelatedChartsForChart(knex, grapher.id as number)
+                : []
+        if (allCharts.length === 0) {
+            allCharts = await getRelatedChartsForVariable(
+                knex,
+                variableId,
+                grapher && "id" in grapher ? [grapher.id as number] : [],
+                true
+            )
+        }
         datapageData.allCharts = allCharts.map((chart) => ({
             ...chart,
             archiveContext: archiveContextDictionary?.[chart.chartId],

--- a/db/docs/charts.yml
+++ b/db/docs/charts.yml
@@ -17,6 +17,10 @@ metadata:
       column: chartId
     - table: narrative_charts
       column: parentChartId
+    - table: related_charts
+      column: chartId
+    - table: related_charts
+      column: relatedChartId
 fields:
   id:
     description: Unique identifier for the chart

--- a/db/docs/related_charts.yml
+++ b/db/docs/related_charts.yml
@@ -1,0 +1,31 @@
+metadata:
+  description: |
+    Related-chart recommendations between standalone grapher charts, used to power the
+    "related charts" recommendations on data pages.
+
+    This table is populated automatically by the `etl related-charts` CLI and writes them with
+    `reviewer = 'production'`.
+fields:
+  id:
+    description: Unique identifier for the recommendation row
+  chartId:
+    description: Foreign key to charts table. The chart that the recommendation is shown on. ON DELETE CASCADE.
+  relatedChartId:
+    description: Foreign key to charts table. The chart being recommended as related to `chartId`. ON DELETE CASCADE.
+  label:
+    description: |
+      Quality label for the recommendation, e.g. 'good' or 'bad'. ETL-written production
+      rows use 'good'; the read path only surfaces 'good' rows. Other values can be written
+      during review (see the related charts wizard) to mark recommendations to exclude.
+  reviewer:
+    description: |
+      Who/what produced this recommendation. ETL-written rows use 'production'. Distinguishes
+      machine-written production rows (surfaced on the site) from rows written during manual
+      review. Part of the unique key so a given (chartId, relatedChartId) pair can carry one
+      row per reviewer.
+  score:
+    description: |
+      Relatedness score (higher is more related), computed by the ETL from coviews (jaccard,
+      with popularity regularization). Used to order recommendations. NULL if not scored.
+  updatedAt:
+    description: Timestamp when the row was inserted or last updated (maintained automatically by MySQL).

--- a/db/migration/1780562036000-AddRelatedChartsTable.ts
+++ b/db/migration/1780562036000-AddRelatedChartsTable.ts
@@ -8,10 +8,9 @@ export class AddRelatedChartsTable1780562036000 implements MigrationInterface {
                 chartId INT NOT NULL,
                 relatedChartId INT NOT NULL,
                 label VARCHAR(255) NOT NULL,
-                reviewer VARCHAR(255) DEFAULT NULL,
-                reason TEXT DEFAULT NULL,
+                reviewer VARCHAR(255) NOT NULL,
                 score DOUBLE DEFAULT NULL,
-                updatedAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                updatedAt DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
                 CONSTRAINT related_charts_ibfk_1
                     FOREIGN KEY (chartId) REFERENCES charts (id)
                     ON DELETE CASCADE

--- a/db/migration/1780562036000-AddRelatedChartsTable.ts
+++ b/db/migration/1780562036000-AddRelatedChartsTable.ts
@@ -1,0 +1,32 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class AddRelatedChartsTable1780562036000 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`-- sql
+            CREATE TABLE related_charts (
+                id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+                chartId INT NOT NULL,
+                relatedChartId INT NOT NULL,
+                label VARCHAR(255) NOT NULL,
+                reviewer VARCHAR(255) DEFAULT NULL,
+                reason TEXT DEFAULT NULL,
+                score DOUBLE DEFAULT NULL,
+                updatedAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                CONSTRAINT related_charts_ibfk_1
+                    FOREIGN KEY (chartId) REFERENCES charts (id)
+                    ON DELETE CASCADE
+                    ON UPDATE CASCADE,
+                CONSTRAINT related_charts_ibfk_2
+                    FOREIGN KEY (relatedChartId) REFERENCES charts (id)
+                    ON DELETE CASCADE
+                    ON UPDATE CASCADE,
+                KEY idx_related_charts_chartId (chartId),
+                UNIQUE KEY uq_chartId_relatedChartId_reviewer (chartId, relatedChartId, reviewer)
+            )
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP TABLE related_charts`)
+    }
+}

--- a/db/model/Chart.ts
+++ b/db/model/Chart.ts
@@ -21,6 +21,7 @@ import {
     DbRawChartConfig,
     DbEnrichedChartConfig,
     GrapherChartType,
+    RelatedChartsTableName,
 } from "@ourworldindata/types"
 import { OpenAI } from "openai"
 import { zodResponseFormat } from "openai/helpers/zod"
@@ -657,15 +658,8 @@ export const getRelatedChartsForVariable = async (
     )
 }
 
-/**
- * Get related charts for a chart from the `related_charts` table, which is
- * populated by the ETL `related-charts` CLI based on chart coviews
- * (charts viewed together in the same browsing session).
- *
- * Note: deliberately does not return `keyChartLevel` — the `RelatedCharts`
- * component re-sorts by it, which would scramble the score-based ranking
- * computed by the ETL.
- */
+// Currently only returns charts from ETL (i.e. with "production" as reviewer)
+// Can be changed if we we want manually-added related charts
 export const getRelatedChartsForChart = async (
     knex: db.KnexReadonlyTransaction,
     chartId: number,
@@ -679,19 +673,19 @@ export const getRelatedChartsForChart = async (
                 chart_configs.slug,
                 chart_configs.full->>"$.title" AS title,
                 chart_configs.full->>"$.variantName" AS variantName
-            FROM related_charts
-            JOIN charts ON charts.id = related_charts.relatedChartId
+            FROM ${RelatedChartsTableName} rc
+            JOIN charts ON charts.id = rc.relatedChartId
             JOIN chart_configs ON charts.configId = chart_configs.id
-            WHERE related_charts.chartId = ?
-                AND related_charts.reviewer = 'production'
-                AND related_charts.label = 'good'
+            WHERE rc.chartId = ?
+                AND rc.reviewer = 'production'
+                AND rc.label = 'good'
                 AND chart_configs.full->>"$.isPublished" = "true"
                 AND NOT EXISTS (
                     SELECT 1 FROM chart_tags ct
                     JOIN tags t ON ct.tagId = t.id
                     WHERE ct.chartId = charts.id AND t.name = 'Unlisted'
                 )
-            ORDER BY related_charts.score DESC
+            ORDER BY rc.score DESC
             LIMIT ?
         `,
         [chartId, limit]

--- a/db/model/Chart.ts
+++ b/db/model/Chart.ts
@@ -661,6 +661,10 @@ export const getRelatedChartsForVariable = async (
  * Get related charts for a chart from the `related_charts` table, which is
  * populated by the ETL `related-charts` CLI based on chart coviews
  * (charts viewed together in the same browsing session).
+ *
+ * Note: deliberately does not return `keyChartLevel` — the `RelatedCharts`
+ * component re-sorts by it, which would scramble the score-based ranking
+ * computed by the ETL.
  */
 export const getRelatedChartsForChart = async (
     knex: db.KnexReadonlyTransaction,
@@ -674,12 +678,10 @@ export const getRelatedChartsForChart = async (
                 charts.id AS chartId,
                 chart_configs.slug,
                 chart_configs.full->>"$.title" AS title,
-                chart_configs.full->>"$.variantName" AS variantName,
-                MAX(chart_tags.keyChartLevel) as keyChartLevel
+                chart_configs.full->>"$.variantName" AS variantName
             FROM related_charts
             JOIN charts ON charts.id = related_charts.relatedChartId
             JOIN chart_configs ON charts.configId = chart_configs.id
-            LEFT JOIN chart_tags ON charts.id = chart_tags.chartId
             WHERE related_charts.chartId = ?
                 AND related_charts.reviewer = 'production'
                 AND related_charts.label = 'good'
@@ -689,8 +691,7 @@ export const getRelatedChartsForChart = async (
                     JOIN tags t ON ct.tagId = t.id
                     WHERE ct.chartId = charts.id AND t.name = 'Unlisted'
                 )
-            GROUP BY charts.id
-            ORDER BY MAX(related_charts.score) DESC
+            ORDER BY related_charts.score DESC
             LIMIT ?
         `,
         [chartId, limit]

--- a/db/model/Chart.ts
+++ b/db/model/Chart.ts
@@ -657,6 +657,46 @@ export const getRelatedChartsForVariable = async (
     )
 }
 
+/**
+ * Get related charts for a chart from the `related_charts` table, which is
+ * populated by the ETL `related-charts` CLI based on chart coviews
+ * (charts viewed together in the same browsing session).
+ */
+export const getRelatedChartsForChart = async (
+    knex: db.KnexReadonlyTransaction,
+    chartId: number,
+    limit: number = 6
+): Promise<RelatedChart[]> => {
+    return db.knexRaw<RelatedChart>(
+        knex,
+        `-- sql
+            SELECT
+                charts.id AS chartId,
+                chart_configs.slug,
+                chart_configs.full->>"$.title" AS title,
+                chart_configs.full->>"$.variantName" AS variantName,
+                MAX(chart_tags.keyChartLevel) as keyChartLevel
+            FROM related_charts
+            JOIN charts ON charts.id = related_charts.relatedChartId
+            JOIN chart_configs ON charts.configId = chart_configs.id
+            LEFT JOIN chart_tags ON charts.id = chart_tags.chartId
+            WHERE related_charts.chartId = ?
+                AND related_charts.reviewer = 'production'
+                AND related_charts.label = 'good'
+                AND chart_configs.full->>"$.isPublished" = "true"
+                AND NOT EXISTS (
+                    SELECT 1 FROM chart_tags ct
+                    JOIN tags t ON ct.tagId = t.id
+                    WHERE ct.chartId = charts.id AND t.name = 'Unlisted'
+                )
+            GROUP BY charts.id
+            ORDER BY MAX(related_charts.score) DESC
+            LIMIT ?
+        `,
+        [chartId, limit]
+    )
+}
+
 export const getRedirectsByChartId = async (
     knex: db.KnexReadonlyTransaction,
     chartId: number

--- a/packages/@ourworldindata/types/src/dbTypes/RelatedCharts.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/RelatedCharts.ts
@@ -1,0 +1,12 @@
+export const RelatedChartsTableName = "related_charts"
+export interface DbInsertRelatedChart {
+    id?: number
+    chartId: number
+    relatedChartId: number
+    label: string
+    reviewer: string
+    score?: number | null
+    updatedAt?: Date
+}
+
+export type DbPlainRelatedChart = Required<DbInsertRelatedChart>

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -715,6 +715,12 @@ export {
 } from "./dbTypes/Redirects.js"
 
 export {
+    RelatedChartsTableName,
+    type DbInsertRelatedChart,
+    type DbPlainRelatedChart,
+} from "./dbTypes/RelatedCharts.js"
+
+export {
     ExplorerViewsTableName,
     type DbInsertExplorerView,
     type DbRawExplorerView,


### PR DESCRIPTION
> _Written by Claude Code — @Marigold at the wheel._

Resurrects the never-merged #4453 for the data-page redesign (#6530), so the new Related Content section can be fed by coviews-based recommendations. Paired with owid/etl#6199 (same branch name → shared staging site).

## What this does

- **Migration**: creates the `related_charts` table (`chartId`, `relatedChartId`, `label`, `reviewer`, `reason`, `score`, unique on `(chartId, relatedChartId, reviewer)`).
- **`getRelatedChartsForChart`** (`db/model/Chart.ts`): reads top recommendations (`reviewer='production'`, `label='good'`, published, not Unlisted) ordered by score. Deliberately doesn't return `keyChartLevel`, since the `RelatedCharts` component re-sorts by it (codex review).
- **No baker/UI changes** — current data pages are untouched. The new Related Content section in the data-page redesign (#6579) will consume `getRelatedChartsForChart`; wiring it into the existing "Explore charts that include this data" section would be semantically misleading for coview recommendations that don't share the data (codex review), and would interfere with the running all-charts-vs-featured-metrics experiment.

## How the table is populated

`etl related-charts` (owid/etl#6199) computes top-N related charts per chart from BigQuery coviews (`prod_google_analytics4.coviews_by_day_page`, 365-day window, min 3 sessions) and writes them with `reviewer='production'`. Quality can be eyeballed in the [Related charts wizard app](https://etl.owid.io/wizard/related_charts?slug=life-expectancy).

Context: this approach was validated in the 2025.1 cycle (#4435) — coviews top-5 recommendations were consistently strong. Known caveats tracked there: popularity bias on high-traffic charts (mitigated by score regularization), duplicate charts, and potential self-reinforcement once live.

## Test

- ✅ The migration ran on `staging-site-related-charts-coviews` and the table is populated via `etl related-charts`: **25,765 recommendations across 4,388 charts**.
- Data pages are unchanged by this PR (the redesign consumes the new query function), so the main thing to verify is the migration + the query below.

### Sample: related charts for `life-expectancy`

```sql
SELECT cc2.slug AS related_chart, cc2.full->>'$.title' AS title, ROUND(rc.score, 4) AS score
FROM related_charts rc
JOIN charts c1 ON c1.id = rc.chartId
JOIN chart_configs cc1 ON c1.configId = cc1.id
JOIN charts c2 ON c2.id = rc.relatedChartId
JOIN chart_configs cc2 ON c2.configId = cc2.id
WHERE cc1.slug = 'life-expectancy' AND rc.reviewer = 'production'
ORDER BY rc.score DESC;
```

| related_chart | title | score |
|---|---|---|
| child-mortality | Child mortality rate | 0.0172 |
| population-with-un-projections | Population | 0.0152 |
| cross-country-literacy-rates | Literacy rate | 0.0150 |
| children-born-per-woman | Fertility rate: births per woman | 0.0120 |
| share-of-population-in-extreme-poverty | Share of population living in extreme poverty | 0.0109 |
| gdp-per-capita-maddison-project-database | GDP per capita | 0.0097 |

(For comparison: in the 2025.1 review, "life-expectancy recommends GDP charts" was the canonical popularity-bias failure case — with jaccard scoring it now ranks last behind five topically tight recommendations.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
