### PR TITLE
🔨 Ignore archived datasets when resolving latest variable by catalog path

### DIFF
--- a/adminSiteClient/ChartEditorPage.tsx
+++ b/adminSiteClient/ChartEditorPage.tsx
@@ -169,7 +169,7 @@ export class ChartEditorPage
     async fetchVariableIdsByCatalogPath(): Promise<void> {
         const { admin } = this.context
         const json = await admin.getJSON<Record<string, number | null>>(
-            "/api/variables/latestByCatalogPath.json",
+            "/api/variables.latestByCatalogPath.json",
             {
                 catalogPaths: [
                     GDP_PER_CAPITA_CATALOG_PATH,

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -614,7 +614,7 @@ getRouteWithROTransaction(
 )
 getRouteWithROTransaction(
     apiRouter,
-    "/variables/latestByCatalogPath.json",
+    "/variables.latestByCatalogPath.json",
     getLatestVariableIdsByCatalogPathJson
 )
 getRouteWithROTransaction(

--- a/db/model/Variable.ts
+++ b/db/model/Variable.ts
@@ -25,6 +25,7 @@ import {
     GrapherInterface,
     DbRawVariable,
     VariablesTableName,
+    DatasetsTableName,
     DbRawChartConfig,
     DbPlainDatapage,
     parseChartConfig,
@@ -1238,10 +1239,23 @@ export const getLatestVariableIdsByCatalogPath = async (
                 )
                 .join("/")
 
-            const rows: Pick<DbRawVariable, "id" | "catalogPath">[] = await knex
-                .select("id", "catalogPath")
-                .from(VariablesTableName)
-                .where("catalogPath", "like", likePattern)
+            const rows: Pick<DbRawVariable, "id" | "catalogPath">[] =
+                await knex(VariablesTableName)
+                    .join(
+                        DatasetsTableName,
+                        `${VariablesTableName}.datasetId`,
+                        `${DatasetsTableName}.id`
+                    )
+                    .where(
+                        `${VariablesTableName}.catalogPath`,
+                        "like",
+                        likePattern
+                    )
+                    .where(`${DatasetsTableName}.isArchived`, 0) // Ignore archived datasets
+                    .select(
+                        `${VariablesTableName}.id`,
+                        `${VariablesTableName}.catalogPath`
+                    )
 
             // Pick the most recent version
             const latest = _.maxBy(rows, (row) => getVersion(row.catalogPath))


### PR DESCRIPTION
Follow-up to #6581

When resolving a version-agnostic catalog path to the latest variable id (used for the admin scatter-plot default indicators), join with `datasets` and filter out archived ones (`isArchived = 0`). This avoids ever defaulting to a variable from a dataset that is no longer maintained. Unlikely in practice, but possible.