### PR TITLE
Index DIs in search immediately after (un)publishing

### DIFF
--- a/adminSiteServer/apiRoutes/gdocs.ts
+++ b/adminSiteServer/apiRoutes/gdocs.ts
@@ -340,14 +340,16 @@ async function indexAndBakeGdocIfNeccesary(
     const nextJson = nextGdoc.toJSON()
     const hasChanges = checkHasChanges(prevGdoc, nextGdoc)
     const action = getPublishingAction(prevJson, nextJson)
-    const isGdocPost = checkIsGdocPostExcludingFragments(nextJson)
+    const shouldIndexInPages =
+        checkIsGdocPostExcludingFragments(nextJson) ||
+        checkIsDataInsight(nextJson)
     const isProfile = checkIsProfile(nextJson)
     const isChronologicalPost = checkIsChronologicalGdoc(nextJson)
 
     await match(action)
         .with(GdocPublishingAction.SavingDraft, _.noop)
         .with(GdocPublishingAction.Publishing, async () => {
-            if (isGdocPost) {
+            if (shouldIndexInPages) {
                 await indexIndividualGdocPost(
                     nextJson,
                     trx,
@@ -365,7 +367,7 @@ async function indexAndBakeGdocIfNeccesary(
             await triggerStaticBuild(user, `${action} ${nextJson.slug}`)
         })
         .with(GdocPublishingAction.Updating, async () => {
-            if (isGdocPost) {
+            if (shouldIndexInPages) {
                 await indexIndividualGdocPost(nextJson, trx, prevGdoc.slug)
             }
             if (isProfile) {
@@ -385,8 +387,8 @@ async function indexAndBakeGdocIfNeccesary(
             }
         })
         .with(GdocPublishingAction.Unpublishing, async () => {
-            if (isGdocPost) {
-                await removeIndividualGdocPostFromIndex(nextJson)
+            if (shouldIndexInPages) {
+                await removeIndividualGdocPostFromIndex(nextJson.slug)
             }
             if (isProfile) {
                 await removeIndividualProfileFromIndex(nextGdoc as GdocProfile)
@@ -588,8 +590,11 @@ export async function deleteGdoc(
         .where({ gdocId: id })
         .delete()
     if (gdoc.published) {
-        if (checkIsGdocPostExcludingFragments(gdoc)) {
-            await removeIndividualGdocPostFromIndex(gdoc)
+        if (
+            checkIsGdocPostExcludingFragments(gdoc) ||
+            gdoc.content.type === OwidGdocType.DataInsight
+        ) {
+            await removeIndividualGdocPostFromIndex(gdoc.slug)
         }
         if (checkIsProfile(gdoc)) {
             await removeIndividualProfileFromIndex(

--- a/adminSiteServer/apiRoutes/gdocs.ts
+++ b/adminSiteServer/apiRoutes/gdocs.ts
@@ -35,8 +35,8 @@ import {
     checkIsLightningUpdate,
 } from "../../adminSiteClient/gdocsDeploy.js"
 import {
-    indexIndividualGdocPost,
-    removeIndividualGdocPostFromIndex,
+    indexIndividualGdoc,
+    removeIndividualGdocFromIndex,
     getIndividualGdocRecords,
     getPreprocessedIndexableText,
     indexIndividualProfile,
@@ -355,7 +355,7 @@ async function indexAndBakeGdocIfNeccesary(
         .with(GdocPublishingAction.SavingDraft, _.noop)
         .with(GdocPublishingAction.Publishing, async () => {
             if (shouldIndexInPages) {
-                await indexIndividualGdocPost(
+                await indexIndividualGdoc(
                     nextJson,
                     trx,
                     // If the gdoc is being published for the first time, prevGdoc.slug will be undefined
@@ -373,7 +373,7 @@ async function indexAndBakeGdocIfNeccesary(
         })
         .with(GdocPublishingAction.Updating, async () => {
             if (shouldIndexInPages) {
-                await indexIndividualGdocPost(nextJson, trx, prevGdoc.slug)
+                await indexIndividualGdoc(nextJson, trx, prevGdoc.slug)
             }
             if (isProfile) {
                 await indexIndividualProfile(nextGdoc as GdocProfile, trx)
@@ -393,7 +393,7 @@ async function indexAndBakeGdocIfNeccesary(
         })
         .with(GdocPublishingAction.Unpublishing, async () => {
             if (wasIndexedInPages) {
-                await removeIndividualGdocPostFromIndex(prevJson.slug)
+                await removeIndividualGdocFromIndex(prevJson.slug)
             }
             if (wasProfile) {
                 await removeIndividualProfileFromIndex(prevGdoc as GdocProfile)
@@ -599,7 +599,7 @@ export async function deleteGdoc(
             checkIsGdocPostExcludingFragments(gdoc) ||
             gdoc.content.type === OwidGdocType.DataInsight
         ) {
-            await removeIndividualGdocPostFromIndex(gdoc.slug)
+            await removeIndividualGdocFromIndex(gdoc.slug)
         }
         if (checkIsProfile(gdoc)) {
             await removeIndividualProfileFromIndex(

--- a/adminSiteServer/apiRoutes/gdocs.ts
+++ b/adminSiteServer/apiRoutes/gdocs.ts
@@ -340,10 +340,15 @@ async function indexAndBakeGdocIfNeccesary(
     const nextJson = nextGdoc.toJSON()
     const hasChanges = checkHasChanges(prevGdoc, nextGdoc)
     const action = getPublishingAction(prevJson, nextJson)
+    const wasIndexedInPages =
+        checkIsGdocPostExcludingFragments(prevJson) ||
+        checkIsDataInsight(prevJson)
     const shouldIndexInPages =
         checkIsGdocPostExcludingFragments(nextJson) ||
         checkIsDataInsight(nextJson)
+    const wasProfile = checkIsProfile(prevJson)
     const isProfile = checkIsProfile(nextJson)
+    const wasChronologicalPost = checkIsChronologicalGdoc(prevJson)
     const isChronologicalPost = checkIsChronologicalGdoc(nextJson)
 
     await match(action)
@@ -387,14 +392,14 @@ async function indexAndBakeGdocIfNeccesary(
             }
         })
         .with(GdocPublishingAction.Unpublishing, async () => {
-            if (shouldIndexInPages) {
-                await removeIndividualGdocPostFromIndex(nextJson.slug)
+            if (wasIndexedInPages) {
+                await removeIndividualGdocPostFromIndex(prevJson.slug)
             }
-            if (isProfile) {
-                await removeIndividualProfileFromIndex(nextGdoc as GdocProfile)
+            if (wasProfile) {
+                await removeIndividualProfileFromIndex(prevGdoc as GdocProfile)
             }
-            if (isChronologicalPost) {
-                await removeIndividualGdocFromChronological(nextJson.id)
+            if (wasChronologicalPost) {
+                await removeIndividualGdocFromChronological(prevJson.id)
             }
             await triggerStaticBuild(user, `${action} ${nextJson.slug}`)
         })

--- a/baker/algolia/utils/pages.ts
+++ b/baker/algolia/utils/pages.ts
@@ -499,7 +499,7 @@ async function getExistingRecordsForSlug(
  * - We can't filter by objectID because filters require exact matches and we can't know the objectIDs beforehand
  *   - They're of the form `${gdoc.id}-c${chunkNumber}` but we don't know how many chunks exist
  */
-export async function indexIndividualGdocPost(
+export async function indexIndividualGdoc(
     gdoc: OwidGdocPostInterface | OwidGdocDataInsightInterface,
     knex: db.KnexReadonlyTransaction,
     indexedSlug: string
@@ -619,7 +619,7 @@ export async function getIndividualGdocRecords(
     )
 }
 
-export async function removeIndividualGdocPostFromIndex(slug: string) {
+export async function removeIndividualGdocFromIndex(slug: string) {
     if (!ALGOLIA_INDEXING) return
     const client = getAlgoliaClient()
     if (!client) {

--- a/baker/algolia/utils/pages.ts
+++ b/baker/algolia/utils/pages.ts
@@ -500,7 +500,7 @@ async function getExistingRecordsForSlug(
  *   - They're of the form `${gdoc.id}-c${chunkNumber}` but we don't know how many chunks exist
  */
 export async function indexIndividualGdocPost(
-    gdoc: OwidGdocPostInterface,
+    gdoc: OwidGdocPostInterface | OwidGdocDataInsightInterface,
     knex: db.KnexReadonlyTransaction,
     indexedSlug: string
 ) {
@@ -614,9 +614,7 @@ export async function getIndividualGdocRecords(
     )
 }
 
-export async function removeIndividualGdocPostFromIndex(
-    gdoc: OwidGdocPostInterface
-) {
+export async function removeIndividualGdocPostFromIndex(slug: string) {
     if (!ALGOLIA_INDEXING) return
     const client = getAlgoliaClient()
     if (!client) {
@@ -629,16 +627,16 @@ export async function removeIndividualGdocPostFromIndex(
     const existingRecordsForPost: Hit[] = await getExistingRecordsForSlug(
         client,
         indexName,
-        gdoc.slug
+        slug
     )
 
     try {
-        console.log("Removing Gdoc post from Algolia index", gdoc.slug)
+        console.log("Removing Gdoc post from Algolia index", slug)
         await client.deleteObjects({
             indexName,
             objectIDs: existingRecordsForPost.map((r) => r.objectID),
         })
-        console.log("Removed Gdoc post from Algolia index", gdoc.slug)
+        console.log("Removed Gdoc post from Algolia index", slug)
     } catch (e) {
         console.error("Error removing Gdoc post from Algolia index: ", e)
     }

--- a/baker/algolia/utils/pages.ts
+++ b/baker/algolia/utils/pages.ts
@@ -552,7 +552,7 @@ export async function indexIndividualGdocPost(
         return
     }
 
-    const records = await getIndividualGdocRecords(gdoc, knex)
+    const records = await getIndividualGdocRecords(gdoc, knex, indexedSlug)
 
     try {
         if (
@@ -594,15 +594,20 @@ export async function getIndividualGdocRecords(
     const cloudflareImagesByFilename =
         await db.getCloudflareImagesByFilename(knex)
 
+    const currentPath = getPrefixedGdocPath("", gdoc)
     // Use indexedSlug if provided (for slug changes), otherwise use gdoc.slug
-    const existingPageviews = pageviews[`/${indexedSlug ?? gdoc.slug}`]
+    const indexedPath = getPrefixedGdocPath("", {
+        slug: indexedSlug ?? gdoc.slug,
+        content: gdoc.content,
+    })
+    const existingPageviews = pageviews[indexedPath]
     const pageviewsForGdoc = {
-        [gdoc.slug]: existingPageviews || {
+        [currentPath]: existingPageviews || {
             views_7d: 0,
             views_14d: 0,
             views_365d: 0,
             day: new Date(),
-            url: gdoc.slug,
+            url: currentPath,
         },
     }
 


### PR DESCRIPTION
Fixes #6564

## Testing guidance

1. Set up Alogia indexing locally
2. Publish an unpublished data insight and check that it gets added to the pages index
3. Unpublish it and check that it gets removed