### PR TITLE
🔨 fix enter-to-select in dropdowns inside shadow dom

### DIFF
--- a/packages/@ourworldindata/grapher/src/controls/Dropdown.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/Dropdown.tsx
@@ -75,6 +75,35 @@ function isOptionGroup<DropdownOption extends BasicDropdownOption>(
     return (item as DropdownOptionGroup<DropdownOption>).options !== undefined
 }
 
+// react-aria's Autocomplete triggers the focused option on Enter via
+// `document.getElementById(focusedNodeId)`, which doesn't pierce shadow roots.
+// When the popover is portaled into a shadow DOM (as our bespoke components do),
+// the lookup returns null and Enter silently no-ops, even though arrow-key
+// navigation still works. We replicate react-aria's behavior with a shadow-aware
+// lookup, but only when the option isn't reachable from `document` — so this is a
+// no-op in the light DOM, where react-aria handles Enter as usual.
+function handleSearchableEnterInShadowDom(e: React.KeyboardEvent): void {
+    if (e.key !== "Enter") return
+    // Ignore the Enter that confirms an in-progress IME composition (e.g. when
+    // typing Japanese or Chinese), otherwise we'd select an option before the
+    // user has finished editing their query.
+    if (e.nativeEvent.isComposing) return
+    const input = e.currentTarget.querySelector<HTMLInputElement>(
+        "input[aria-activedescendant]"
+    )
+    const activeId = input?.getAttribute("aria-activedescendant")
+    if (!activeId) return
+    if (document.getElementById(activeId)) return
+    const root = input!.getRootNode()
+    if (!(root instanceof ShadowRoot)) return
+    const item = root.getElementById(activeId)
+    if (!item) return
+    e.preventDefault()
+    item.dispatchEvent(
+        new PointerEvent("click", { bubbles: true, cancelable: true })
+    )
+}
+
 function flattenOptions<DropdownOption extends BasicDropdownOption>(
     options: DropdownCollection<DropdownOption>
 ): DropdownOption[] {
@@ -175,33 +204,41 @@ export function Dropdown<DropdownOption extends BasicDropdownOption>({
             data-owid-dropdown=""
             offset={4}
         >
-            {isSearchable ? (
-                // If inputValue is provided, the component is controlled
-                // and we expect the filtering to happen outside of it.
-                <Autocomplete filter={inputValue ? undefined : contains}>
-                    <SearchField
-                        className="grapher-dropdown-search"
-                        aria-label="Search"
-                        autoFocus
-                        value={inputValue}
-                        onChange={onInputChange}
-                    >
-                        <span className="grapher-dropdown-search-icon" />
-                        <Input
-                            className="grapher-dropdown-search-input"
-                            style={{
-                                fontSize: isTouchDevice() ? 16 : undefined,
-                            }}
-                        />
-                        <Button className="grapher-dropdown-search-reset">
-                            <FontAwesomeIcon icon={faTimesCircle} aria-hidden />
-                        </Button>
-                    </SearchField>
-                    {listBox}
-                </Autocomplete>
-            ) : (
-                listBox
-            )}
+            <div
+                className="grapher-dropdown-menu-content"
+                onKeyDownCapture={handleSearchableEnterInShadowDom}
+            >
+                {isSearchable ? (
+                    // If inputValue is provided, the component is controlled
+                    // and we expect the filtering to happen outside of it.
+                    <Autocomplete filter={inputValue ? undefined : contains}>
+                        <SearchField
+                            className="grapher-dropdown-search"
+                            aria-label="Search"
+                            autoFocus
+                            value={inputValue}
+                            onChange={onInputChange}
+                        >
+                            <span className="grapher-dropdown-search-icon" />
+                            <Input
+                                className="grapher-dropdown-search-input"
+                                style={{
+                                    fontSize: isTouchDevice() ? 16 : undefined,
+                                }}
+                            />
+                            <Button className="grapher-dropdown-search-reset">
+                                <FontAwesomeIcon
+                                    icon={faTimesCircle}
+                                    aria-hidden
+                                />
+                            </Button>
+                        </SearchField>
+                        {listBox}
+                    </Autocomplete>
+                ) : (
+                    listBox
+                )}
+            </div>
         </Popover>
     )
 


### PR DESCRIPTION
Fix Enter-to-select in searchable dropdowns rendered inside a Shadow DOM

## Problem

In the food-trade and migration bespoke viz, pressing Enter to select an option in a searchable dropdown did nothing — only arrow-key navigation worked. The same shared dropdown behaved correctly in causes-of-death.

## Root cause

The bespoke dropdowns are built on grapher's Dropdown, which uses react-aria-components' Autocomplete for the searchable case. When you press Enter on a virtually-focused option, react-aria's useAutocomplete fires the event at it via document.getElementById(focusedNodeId):

let item = document.getElementById(focusedNodeId);
item?.dispatchEvent(new PointerEvent('click', e.nativeEvent));

document.getElementById does not pierce shadow roots. Arrow keys work because they're dispatched to a React ref (collectionRef.current), not looked up by id.

The reason only food-trade and migration broke: they wrap their tree in UNSAFE_PortalProvider with a container that resolves to the ShadowRoot, so the dropdown popover — and its option elements — render inside the shadow DOM. causes-of-death has no such provider, so its popover portals to document.body (light DOM), where getElementById succeeds.

enableShadowDOM() doesn't help here: that flag only makes getActiveElement/getEventTarget/nodeContains shadow-aware. react-aria simply never made these getElementById calls shadow-aware — it's an upstream bug, still present in the latest react-aria (3.49.0), so upgrading wouldn't fix it.

## Fix

Added a small, guarded Enter handler in grapher's Dropdown, wired to the popover content via onKeyDownCapture. It re-implements react-aria's Enter-to-select using a shadow-aware lookup (ShadowRoot.getElementById), but only when the option isn't reachable frote no-op in the light DOM (grapher,admin, site), where react-aria continues to handle Enter as before. It runs in the capture phase, ahead of
react-aria's bubble-phase handler, so thact-aria's own lookup still returns nulland no-ops).

The popover stays inside the shadow DOM, preserving the scoped menu styling that UNSAFE_PortalProvider was
added for.
