### PR TITLE
🐛 vertically center icon-only tabs in content switcher

### DIFF
--- a/packages/@ourworldindata/grapher/src/controls/ContentSwitchers.scss
+++ b/packages/@ourworldindata/grapher/src/controls/ContentSwitchers.scss
@@ -51,6 +51,7 @@ $active-icon: $blue-50;
 
         .ContentSwitchers__TabContent {
             display: flex;
+            height: 100%;
             align-items: center;
             gap: $icon-padding;
         }

--- a/packages/@ourworldindata/grapher/src/controls/Controls.scss
+++ b/packages/@ourworldindata/grapher/src/controls/Controls.scss
@@ -129,6 +129,11 @@ nav.controlsRow .controls {
     .ContentSwitchers .Tabs__Tab .label {
         display: none;
     }
+
+    // center the icon now that it's the only content in the tab
+    .ContentSwitchers .Tabs__Tab .ContentSwitchers__TabContent {
+        justify-content: center;
+    }
 }
 
 // reduce the horizontal padding of a content switcher tab based on grapher's size


### PR DESCRIPTION
Fixes misaligned icon-only tabs on mobile.