### PR TITLE
🎉 Add catalogPath to charts (ETL identity)

### DIFF
--- a/adminSiteServer/apiRoutes/charts.ts
+++ b/adminSiteServer/apiRoutes/charts.ts
@@ -1033,6 +1033,10 @@ export async function putChartsChartIdEtlConfig(
 ) {
     const chartId = expectInt(req.params.chartId)
 
+    // ETL's stable identity for this chart (mirrors `multi_dim_data_pages.catalogPath`).
+    // Optional so other callers don't clobber it; persisted via COALESCE below.
+    const catalogPath = (req.query.catalogPath as string | undefined) ?? null
+
     let etlConfig: GrapherInterface
     try {
         etlConfig = migrateGrapherConfigToLatestVersionAndFailOnError(req.body)
@@ -1097,7 +1101,8 @@ export async function putChartsChartIdEtlConfig(
                 cc.etlConfig = ?,
                 cc.full = ?,
                 cc.updatedAt = ?,
-                c.updatedAt = ?
+                c.updatedAt = ?,
+                c.catalogPath = COALESCE(?, c.catalogPath)
             WHERE c.id = ?
         `,
         [
@@ -1106,6 +1111,7 @@ export async function putChartsChartIdEtlConfig(
             serializeChartConfig(newFullConfig),
             now,
             now,
+            catalogPath,
             chartId,
         ]
     )

--- a/db/migration/1780587927881-AddCatalogPathToCharts.ts
+++ b/db/migration/1780587927881-AddCatalogPathToCharts.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class AddCatalogPathToCharts1780587927881 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        // Links an ETL-authored chart to the ETL step that produced it, mirroring
+        // `multi_dim_data_pages.catalogPath`. This is the chart's stable ETL identity
+        // (e.g. `animal_welfare/latest/banning_of_chick_culling#banning_of_chick_culling`),
+        // distinct from the mutable, admin-managed `slug`. NULL for hand-authored charts.
+        await queryRunner.query(
+            `-- sql
+            ALTER TABLE charts
+            ADD COLUMN catalogPath VARCHAR(767) NULL AFTER configId,
+            ADD UNIQUE INDEX idx_charts_catalog_path (catalogPath)`
+        )
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `-- sql
+            ALTER TABLE charts
+            DROP INDEX idx_charts_catalog_path,
+            DROP COLUMN catalogPath`
+        )
+    }
+}

--- a/packages/@ourworldindata/types/src/dbTypes/Charts.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/Charts.ts
@@ -1,6 +1,7 @@
 export const ChartsTableName = "charts"
 export interface DbInsertChart {
     configId: string
+    catalogPath?: string | null
     createdAt?: Date
     forceDatapage?: boolean
     id?: number


### PR DESCRIPTION
> _Written by Claude Code — @pabloarosado at the wheel._

Small, isolated PR into the chart-config feature branch (`etl-chart-config`), so it can be reviewed on its own.

## What

Adds a nullable, unique **`catalogPath`** column to the `charts` table, linking an ETL-authored chart to the ETL step that produced it — mirroring `multi_dim_data_pages.catalogPath`. This is the chart's **stable ETL identity** (e.g. `animal_welfare/latest/banning_of_chick_culling#banning_of_chick_culling`), distinct from the mutable, admin-managed `slug`.

Motivation: a single chart is a zero-dimension mdim, and mdims are already identified by `catalogPath` (slug is nullable/secondary there). Giving `charts` the same column lets the two be keyed identically — the foundation for unifying charts and mdims (owid/etl#6069).

## Changes

- **Migration** `1780587927881-AddCatalogPathToCharts` — `ADD COLUMN catalogPath VARCHAR(767) NULL` + `UNIQUE INDEX`. NULL allowed for hand-authored charts (multiple NULLs are fine under a MySQL unique index).
- **Type** — `catalogPath?: string \| null` on `DbInsertChart`.
- **Endpoint** — `putChartsChartIdEtlConfig` reads `?catalogPath=` and persists it via `COALESCE(?, c.catalogPath)` (so non-ETL callers never null it). This is the single chokepoint ETL hits on every push.

## Notes

- No change to `createChart`: the bootstrap row is created with `catalogPath = NULL`, then the etlConfig call fills it in within the same upsert.
- **chart-sync → prod** does not yet carry `catalogPath` (it writes `chart_configs.patch`, not the etlConfig endpoint). Out of scope here; tracked as a follow-up.

Pairs with the ETL-side PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)