### PR TITLE
refreshAnalytics: read from the analytics (semantic) Datasette DB

### DIFF
--- a/db/refreshAnalyticsFromDatasette.ts
+++ b/db/refreshAnalyticsFromDatasette.ts
@@ -60,7 +60,9 @@ async function refreshTable(
     const { tableName, columns, keyColumn } = config
     console.log(`\n==> Refreshing ${tableName}`)
 
-    const csvUrl = `http://analytics/private/${tableName}.csv?_stream=on&_size=max`
+    // The internal Datasette's `analytics` (semantic-layer) database; the former `private`
+    // database is being retired (see owid/analytics#810) and these two tables now live here.
+    const csvUrl = `http://analytics/analytics/${tableName}.csv?_stream=on&_size=max`
     const response = await fetch(csvUrl)
 
     if (!response.ok) {
@@ -107,7 +109,7 @@ async function refreshTable(
 async function refreshAllAnalytics(
     knex: db.KnexReadWriteTransaction
 ): Promise<void> {
-    // Fetch CSV from private Datasette and insert it to a local MySQL. This function
+    // Fetch CSV from the internal Datasette and insert it to a local MySQL. This function
     // exists because `make refresh` uses MySQL dump that excludes analytics tables.
     // That's why it's necessary to call `make refresh.analytics` separately.
     for (const table of tables) {

--- a/db/refreshAnalyticsFromDatasette.ts
+++ b/db/refreshAnalyticsFromDatasette.ts
@@ -62,7 +62,7 @@ async function refreshTable(
 
     // The internal Datasette's `analytics` (semantic-layer) database; the former `private`
     // database is being retired (see owid/analytics#810) and these two tables now live here.
-    const csvUrl = `http://analytics/analytics/${tableName}.csv?_stream=on&_size=max`
+    const csvUrl = `http://analytics.owid.io/analytics/${tableName}.csv?_stream=on&_size=max`
     const response = await fetch(csvUrl)
 
     if (!response.ok) {


### PR DESCRIPTION
## Why

The analytics team is retiring the internal Datasette's `private` database (the `private.duckdb` mirror — see owid/analytics#810). `make refresh.analytics` is its last regular consumer: staging servers and local devs pull `analytics_pageviews.csv` / `analytics_grapher_views.csv` from it to populate grapher MySQL.

Both tables are now also mirrored into the **`analytics` (semantic-layer) database** on the same Datasette instance (owid/analytics#811) — same table names, same columns, same streaming table-CSV endpoint. This PR just switches the path: `http://analytics/private/…` → `http://analytics/analytics/…`.

## Sequencing (why this is a draft)

1. owid/analytics#811 merges + the nightly analytics build publishes the tables into the `analytics` database ← **not live yet**
2. this PR — staging/dev refresh keeps working unchanged
3. owid/analytics#810 removes the `private` database

I'll mark it ready once step 1 is deployed. Until then the old URL keeps working, so there's no urgency — but merging this **before** step 3 is what keeps staging refreshes unbroken.

## Test

After step 1 deploys: `make refresh.analytics` (or `yarn refreshAnalytics`) on a machine with Tailscale — both tables should refresh as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)