### PR TITLE
🐛 Qualify variable catalog path in admin search

### DIFF
--- a/db/model/Variable.ts
+++ b/db/model/Variable.ts
@@ -998,7 +998,7 @@ export const searchVariables = async (
         SELECT
             v.id,
             v.name,
-            catalogPath,
+            v.catalogPath AS catalogPath,
             d.id AS datasetId,
             d.name AS datasetName,
             d.isPrivate AS isPrivate,


### PR DESCRIPTION
## Summary

Fixes `/api/variables.json` failing with `Column 'catalogPath' in field list is ambiguous` after `active_datasets` exposed `datasets.catalogPath`.

The variable search query joins `variables` and `active_datasets`, both of which can now provide `catalogPath`, so the SELECT now explicitly uses `v.catalogPath`.

## Motivation

The admin variables index currently 500s because the query selected `catalogPath` without saying whether it meant the variable or dataset column. `variables.catalogPath` was added years ago, and `datasets.catalogPath` was added later; the recent `active_datasets` view recreation made the dataset column visible through the joined view, turning the formerly valid query into an ambiguous one.

The endpoint is meant to show indicator-level catalog paths, so the query should explicitly read from `variables`.

## Testing

- `yarn testFormatChanged`
- `yarn testLintChanged`

Skipped typecheck per local agent instruction not to run it automatically.
