### PR TITLE
✨ Make datapages view mergeable to speed up baking

### DIFF
--- a/db/migration/1780649349564-MakeDatapagesViewMergeable.ts
+++ b/db/migration/1780649349564-MakeDatapagesViewMergeable.ts
@@ -17,9 +17,7 @@ import { MigrationInterface, QueryRunner } from "typeorm"
  * improvement: ties on `order` among y-dimensions are now broken
  * deterministically by id (ROW_NUMBER previously picked an arbitrary row).
  */
-export class MakeDatapagesViewMergeable1780649349564
-    implements MigrationInterface
-{
+export class MakeDatapagesViewMergeable1780649349564 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`DROP VIEW IF EXISTS datapages`)
         await queryRunner.query(`-- sql

--- a/db/migration/1780649349564-MakeDatapagesViewMergeable.ts
+++ b/db/migration/1780649349564-MakeDatapagesViewMergeable.ts
@@ -1,0 +1,120 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+/**
+ * Recreate the `datapages` view without window-function CTEs.
+ *
+ * MySQL cannot merge views that contain window functions or derived tables,
+ * so `SELECT ... FROM datapages WHERE chartId = ?` materialized the whole
+ * view (a scan over all of chart_dimensions, three times) on every call.
+ * The baker runs this query once per chart (~7k times per bake), which made
+ * baking painfully slow.
+ *
+ * Expressing the same logic with correlated subqueries keeps the view
+ * mergeable (ALGORITHM=MERGE), so the chartId predicate is pushed down and
+ * each lookup becomes a handful of indexed reads.
+ *
+ * The result set is identical to the previous definition, with one
+ * improvement: ties on `order` among y-dimensions are now broken
+ * deterministically by id (ROW_NUMBER previously picked an arbitrary row).
+ */
+export class MakeDatapagesViewMergeable1780649349564
+    implements MigrationInterface
+{
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP VIEW IF EXISTS datapages`)
+        await queryRunner.query(`-- sql
+            CREATE VIEW datapages AS
+            SELECT
+                c.id AS chartId,
+                cd.variableId AS variableId
+            FROM charts c
+            JOIN chart_configs cc ON cc.id = c.configId
+            JOIN chart_dimensions cd ON cd.chartId = c.id AND cd.property = 'y'
+            JOIN variables v ON v.id = cd.variableId
+            WHERE
+                -- first y-dimension by \`order\`
+                cd.id = (
+                    SELECT cd2.id
+                    FROM chart_dimensions cd2
+                    WHERE cd2.chartId = c.id AND cd2.property = 'y'
+                    ORDER BY cd2.\`order\`, cd2.id
+                    LIMIT 1
+                )
+                AND (
+                    c.forceDatapage = 1
+                    OR (
+                        (
+                            SELECT COUNT(*)
+                            FROM chart_dimensions cd3
+                            WHERE cd3.chartId = c.id AND cd3.property = 'y'
+                        ) = 1
+                        AND NOT (
+                            cc.chartType = 'ScatterPlot'
+                            AND EXISTS (
+                                SELECT 1
+                                FROM chart_dimensions cd4
+                                WHERE cd4.chartId = c.id AND cd4.property = 'x'
+                            )
+                        )
+                        AND v.schemaVersion >= 2
+                        AND (
+                            (v.descriptionShort IS NOT NULL AND v.descriptionShort != '')
+                            OR (v.descriptionProcessing IS NOT NULL AND v.descriptionProcessing != '')
+                            OR (v.descriptionKey IS NOT NULL AND v.descriptionKey != '' AND v.descriptionKey != '[]')
+                            OR (v.descriptionFromProducer IS NOT NULL AND v.descriptionFromProducer != '')
+                            OR (v.titlePublic IS NOT NULL AND v.titlePublic != '')
+                        )
+                    )
+                )
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP VIEW IF EXISTS datapages`)
+        await queryRunner.query(`-- sql
+            CREATE VIEW datapages AS
+            WITH y_dimensions AS (
+                SELECT
+                    chartId,
+                    variableId,
+                    ROW_NUMBER() OVER (PARTITION BY chartId ORDER BY \`order\`) AS rn
+                FROM chart_dimensions
+                WHERE property = 'y'
+            ),
+            y_counts AS (
+                SELECT chartId, COUNT(*) AS num_y
+                FROM chart_dimensions
+                WHERE property = 'y'
+                GROUP BY chartId
+            ),
+            has_x_dimension AS (
+                SELECT DISTINCT chartId
+                FROM chart_dimensions
+                WHERE property = 'x'
+            )
+            SELECT
+                c.id AS chartId,
+                yd.variableId AS variableId
+            FROM charts c
+            JOIN chart_configs cc ON cc.id = c.configId
+            JOIN y_dimensions yd ON yd.chartId = c.id AND yd.rn = 1
+            JOIN y_counts yc ON yc.chartId = c.id
+            LEFT JOIN has_x_dimension hx ON hx.chartId = c.id
+            JOIN variables v ON v.id = yd.variableId
+            WHERE
+                c.forceDatapage = 1
+                OR (
+                    yc.num_y = 1
+                    AND NOT (cc.chartType = 'ScatterPlot' AND hx.chartId IS NOT NULL)
+                    AND v.schemaVersion >= 2
+                    AND (
+                        (v.descriptionShort IS NOT NULL AND v.descriptionShort != '')
+                        OR (v.descriptionProcessing IS NOT NULL AND v.descriptionProcessing != '')
+                        OR (v.descriptionKey IS NOT NULL AND v.descriptionKey != '' AND v.descriptionKey != '[]')
+                        OR (v.descriptionFromProducer IS NOT NULL AND v.descriptionFromProducer != '')
+                        OR (v.titlePublic IS NOT NULL AND v.titlePublic != '')
+                    )
+                )
+        `)
+    }
+}


### PR DESCRIPTION
## Problem

Staging bakes have gotten much slower — build 30611 took **36 minutes**. Per-line timestamps in the Buildkite log point at two steps:

| Step | Time |
|---|---|
| Baking profile pages | 572s (345s of it in "Prefetching charts", 2,586 charts @ ~7.5/s) |
| Baking all grapher pages | 893s (4,505 pages @ ~5/s) |

The common bottleneck is `getDatapageIndicatorId`, which since #6350 (c3d63c320f) queries the `datapages` **view**:

```sql
SELECT variableId FROM datapages WHERE chartId = ?
```

The view is built from CTEs with a `ROW_NUMBER()` window function. MySQL cannot merge such views, so the `chartId` predicate is **not pushed down** — every call materializes all of `chart_dimensions` into three derived temp tables (one with filesort) and only then filters. `EXPLAIN` confirms three `DERIVED` scans of the full table per call (~44ms locally, ~130ms+ on the staging LXC containers).

The baker runs this query once per chart: ~2.6k times in the `SiteBaker` prefetch and ~4.5k times when baking grapher pages — roughly **15 minutes of bake time** spent re-materializing the same view.

## Fix

Recreate the view itself (migration) with correlated subqueries instead of window-function CTEs. MySQL's MERGE algorithm only bails on aggregates/window functions/derived tables at the view's top level — correlated subqueries in `WHERE` are fine — so the view stays mergeable, the `chartId` predicate is pushed down, and each lookup becomes a few indexed reads. No application code changes; the view remains the single source of truth for datapage eligibility.

- `EXPLAIN` after the migration: no `DERIVED` temp tables — `charts`/`chart_configs`/`chart_dimensions`/`variables` are all const/PK lookups and the three subqueries are `DEPENDENT SUBQUERY` with `ref` access on the chartId index.
- `EXPLAIN ANALYZE` per-chart lookup: **~44ms → ~0ms** ("rows fetched before execution"); the win on staging is larger since the old query was CPU-bound on temp-table materialization under 10–20 concurrent bake workers.
- Full-view scans are unaffected (~99ms vs ~65ms for all 3,109 rows).

One intentional micro-difference: ties on `order` among y-dimensions are now broken deterministically by `id` (`ROW_NUMBER()` previously picked an arbitrary row).

## Verification

- Ran a full row-by-row comparison on a live DB: the new definition returns the **identical result set** to the old one (3,109 rows, 0 differences in either direction, NULL-safe).
- Identical `COUNT(*)` and `SUM(variableId)` checksums through the actual migrated view.
- The `NOT (chartType = 'ScatterPlot' AND EXISTS(...))` form preserves the original's three-valued logic for `chartType IS NULL` (`EXISTS` returns TRUE/FALSE exactly like the old `hx.chartId IS NOT NULL` on the LEFT JOIN).

Note: `datapages` is also exposed downstream (e.g. the analytics/Datasette sync) — the columns and semantics are unchanged, but if anything snapshots the view *definition* (owid/etl, owid/analytics), it may want updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
