### PR TITLE
Fix react-aria portal provider import

### DIFF
--- a/packages/@ourworldindata/grapher/src/controls/PortaledPopover.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/PortaledPopover.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from "react"
 import { Popover, type PopoverProps } from "react-aria-components"
-import { UNSAFE_PortalProvider } from "react-aria/PortalProvider"
+import { UNSAFE_PortalProvider } from "react-aria"
 
 export interface PortaledPopoverProps extends PopoverProps {
     portalContainer?: HTMLElement


### PR DESCRIPTION
## Summary
- import `UNSAFE_PortalProvider` from the public `react-aria` entrypoint instead of the unsupported `react-aria/PortalProvider` subpath
- fixes the Vite/Rolldown production build failure seen while building bespoke food-trade assets

## Testing
- `cd bespoke && yarn workspace @owid/bespoke-food-trade build`
- `cd bespoke && yarn build`
- `yarn testFormatChanged`
- `yarn testLintChanged`

Note: I did not run typecheck per agent instructions.