### PR TITLE
🐛 fix parsing footnotes in ignored sections

### DIFF
--- a/db/model/Gdoc/archieToEnriched.test.ts
+++ b/db/model/Gdoc/archieToEnriched.test.ts
@@ -1,6 +1,8 @@
 import { expect, it } from "vitest"
 
-import { extractRefs } from "./archieToEnriched.js"
+import { load } from "archieml"
+
+import { extractRefs, stripIgnoredArchieml } from "./archieToEnriched.js"
 
 it("Can extract a ref from some text", () => {
     expect(
@@ -103,6 +105,54 @@ it("Can extract an inline ref and an ID ref and then refer back to a previous in
                 id: "796885412908186a5e57f2e753ab697b85666afe",
             },
         ],
+    })
+})
+
+it("Drops everything after a :ignore line", () => {
+    expect(
+        stripIgnoredArchieml(
+            `live text\n:ignore\nignored text{ref}ignored_id{/ref}`
+        )
+    ).toEqual(`live text\n`)
+})
+
+it("Honours :ignore even inside a :skip block", () => {
+    expect(
+        stripIgnoredArchieml(
+            `live text\n:skip\nskipped{ref}skipped_id{/ref}\n:ignore\nignored{ref}ignored_id{/ref}`
+        )
+    ).toEqual(`live text\n:skip\n`)
+})
+
+it("Empties :skip / :endskip blocks but keeps the directive lines and surrounding text", () => {
+    expect(
+        stripIgnoredArchieml(
+            `before\n:skip\nskipped{ref}skipped_id{/ref}\n:endskip\nafter`
+        )
+    ).toEqual(`before\n:skip\n:endskip\nafter`)
+})
+
+it("Empties an unterminated :skip block but keeps the :skip directive", () => {
+    expect(
+        stripIgnoredArchieml(`before\n:skip\nskipped{ref}skipped_id{/ref}`)
+    ).toEqual(`before\n:skip\n`)
+})
+
+it("Preserves ArchieML buffer-flush semantics around a :skip block", () => {
+    // ArchieML discards the buffered multi-line continuation at :skip, so `dek`
+    // is just "first". Our pre-strip must keep the directive lines so load()
+    // still does this — deleting the block would splice "draft" onto the value.
+    const input = `dek: first\ndraft continuation\n:skip\nskipped\n:endskip\n:end`
+    expect(load(input).dek).toEqual("first")
+    expect(load(stripIgnoredArchieml(input)).dek).toEqual("first")
+})
+
+it("Ignores refs that appear after :ignore so footnote numbering is unaffected", () => {
+    const text = `real{ref}some_id{/ref}\n:ignore\nfake{ref}another_id{/ref}`
+    expect(extractRefs(stripIgnoredArchieml(text))).toEqual({
+        extractedText: `real<a class="ref" href="#note-1"><sup>1</sup></a>\n`,
+        refsByFirstAppearance: new Set(["some_id"]),
+        rawInlineRefs: [],
     })
 })
 

--- a/db/model/Gdoc/archieToEnriched.ts
+++ b/db/model/Gdoc/archieToEnriched.ts
@@ -104,6 +104,39 @@ export function formatCitation(
     return citationArray.map(htmlToSimpleTextBlock)
 }
 
+// Empty out the parts of an ArchieML document that the parser itself discards,
+// so that ref extraction (which scans the text before `load()` runs) doesn't see
+// refs the parser will throw away. Without this, a {ref} after :ignore or inside
+// a :skip block would still be picked up by extractRefs, polluting
+// refsByFirstAppearance, shifting footnote numbers, and rendering inline refs
+// that don't exist in the live document.
+//
+// IMPORTANT: the result is fed to `load()` as well as `extractRefs()`, and
+// ArchieML's own parsing depends on seeing the :skip/:endskip directive lines.
+// At :skip the parser flushes (discards) any buffered multi-line value; at :end
+// it commits it. So we must keep the directive lines exactly where they are and
+// only blank the content between them. If we instead deleted the directives and
+// spliced the surrounding lines together, a value like:
+// `dek: a\nb\n:skip\n…\n:endskip`
+// would wrongly append b to dek's value, yielding "a\nb" instead of "a"
+export function stripIgnoredArchieml(text: string): string {
+    // :ignore wins even inside a skip block, so handle it first. Everything from
+    // the :ignore line onward is discarded; there's nothing after it to splice
+    // back together, so dropping the line itself is safe (the buffered value is
+    // flushed identically whether the parser hits :ignore or the end of input).
+    const ignore = text.match(/^[ \t\r]*:[ \t\r]*ignore\b.*$/im)
+    if (ignore?.index !== undefined) text = text.slice(0, ignore.index)
+
+    // Empty :skip … :endskip blocks while preserving both directive lines (see
+    // note above). An unterminated :skip runs to the end of the document;
+    // `$(?![\s\S])` anchors that fallback to EOF, since `$` alone matches
+    // end-of-line under the `m` flag.
+    return text.replace(
+        /(^[ \t\r]*:[ \t\r]*skip\b.*$)[\s\S]*?(^[ \t\r]*:[ \t\r]*endskip\b.*$|$(?![\s\S]))/gim,
+        "$1\n$2"
+    )
+}
+
 // Match all curly bracket {ref}some_id{/ref} and {ref}I am an inline ref{/ref} syntax in the text
 // Iterate through them
 // If it's an inline ref, hash its contents to use as an ID and parse it
@@ -184,6 +217,12 @@ export const archieToEnriched = (
         content: Record<string, unknown>
     ) => void = _.identity
 ): OwidGdocPostContent => {
+    // Blank out content ArchieML discards (:skip blocks, anything after :ignore)
+    // before extracting refs, so phantom refs from those regions aren't picked
+    // up. The directive lines are preserved, so feeding this to load() below
+    // produces exactly the same parse as the original text.
+    text = stripIgnoredArchieml(text)
+
     const { extractedText, refsByFirstAppearance, rawInlineRefs } =
         extractRefs(text)
     text = extractedText


### PR DESCRIPTION
Fixes an issue where refs written after `:ignore` were still being parsed and included in the footer of articles.

Also fixes potential cases where refs are written within `:skip` `:endskip` boundaries.

[Example](https://ourworldindata.org/agricultural-productivity-crucial)

Once merged, republish:
1. `1ip6yYXW9VBBuUMDTHMGl-8vXWAT77wABRsqdfuG3dO4`
2. `1rEhPkFIeAvIQeOHj69HHlHLd1MygsBX7jb79MnpFJmI`