### PR TITLE
🐛 classify related_charts in metadata export, catch missing tables in CI

### DIFF
--- a/db/exportMetadata.ts
+++ b/db/exportMetadata.ts
@@ -4,11 +4,14 @@
 // runs the Grapher stack locally, so it shouldn't contain anything sensitive.
 //
 // By default, only each table's structure is exported, with no rows.
-// For data to be exported, it must be explicitly included in the INCLUDE_DATA_TABLES list
+// For data to be exported, it must be explicitly included in the
+// INCLUDE_DATA_TABLES list in exportMetadataTables.ts.
 //
 // As a backstop, the script fails if it encounters a table that isn't
-// classified in any of the lists below, forcing whoever added it to make a
-// conscious include/exclude decision.
+// classified in any of those lists, forcing whoever added it to make a
+// conscious include/exclude decision. The db test suite runs the same check
+// against a freshly migrated database, so an unclassified table already
+// fails in CI when its migration is added (see db/tests/exportMetadata.test.ts).
 
 import * as db from "./db.js"
 import fs from "fs-extra"
@@ -22,90 +25,15 @@ import {
     GRAPHER_DB_PORT,
 } from "../settings/serverSettings.js"
 import { execWrapper } from "./execWrapper.js"
+import {
+    INCLUDE_DATA_TABLES,
+    SCHEMA_ONLY_TABLES,
+    findUnclassifiedTables,
+    unclassifiedTablesErrorMessage,
+} from "./exportMetadataTables.js"
 
 const argv = parseArgs(process.argv.slice(2))
 const filePath = argv._[0] || "/tmp/owid_metadata.sql"
-
-const INCLUDE_DATA_TABLES = [
-    "admin_api_keys",
-    "analytics_popularity",
-    "archived_chart_versions",
-    "archived_explorer_versions",
-    "archived_multi_dim_versions",
-    "archived_post_versions",
-    "chart_configs",
-    "chart_diff_approvals",
-    "chart_diff_conflicts",
-    "chart_dimensions",
-    "chart_revisions",
-    "chart_slug_redirects",
-    "chart_tags",
-    "charts_x_entities",
-    "charts",
-    "dataset_tags",
-    "datasets",
-    "dod_links",
-    "dods",
-    "entities",
-    "explorer_charts",
-    "explorer_tags",
-    "explorer_variables",
-    "explorer_view_dimensions",
-    "explorer_views",
-    "explorers",
-    "featured_metrics",
-    "files",
-    "housekeeper_reviews",
-    "images",
-    "importer_additionalcountryinfo",
-    "jobs",
-    "migrations",
-    "multi_dim_data_pages",
-    "multi_dim_redirects",
-    "multi_dim_view_dimensions",
-    "multi_dim_x_chart_configs",
-    "namespaces",
-    "narrative_charts",
-    "origins_variables",
-    "origins",
-    "post_tags",
-    "posts_gdocs_components",
-    "posts_gdocs_links",
-    "posts_gdocs_tombstones",
-    "posts_gdocs_variables_faqs",
-    "posts_gdocs_x_images",
-    "posts_gdocs_x_tags",
-    "posts_gdocs",
-    "posts_links",
-    "posts",
-    "redirects",
-    "slideshow_links",
-    "slideshow_x_images",
-    "slideshows",
-    "sources",
-    "static_viz",
-    "tag_graph",
-    "tags_variables_topic_tags",
-    "tags",
-    "variables",
-]
-
-// Tables that are intentionally schema-only. Listing them here (rather than
-// relying on the default) documents *why* they're excluded and lets the
-// classification check below confirm every table has been considered. Keep
-// alphabetised.
-const SCHEMA_ONLY_TABLES = [
-    // The analytics_* tables ship schema-only here; their data travels in a
-    // private sidecar dump instead. Keep them in sync with analyticsTables in
-    // exportAnalyticsData.ts.
-    "analytics_chart_views", // internal analytics, large
-    "analytics_grapher_views", // internal analytics, large
-    "analytics_pageviews", // internal analytics, large
-    "donors", // donor PII
-]
-
-// The users table is exported with anonymised data (see anonymisedUsersSql).
-const USERS_TABLE = "users"
 
 async function assertAllTablesClassified(): Promise<void> {
     const knex = db.knexInstance()
@@ -116,20 +44,11 @@ async function assertAllTablesClassified(): Promise<void> {
         [GRAPHER_DB_NAME]
     )
     const allTables = rows.map((r) => r.TABLE_NAME)
-    const classified = new Set([
-        ...INCLUDE_DATA_TABLES,
-        ...SCHEMA_ONLY_TABLES,
-        USERS_TABLE,
-    ])
 
-    const unclassified = allTables.filter((t) => !classified.has(t))
+    const unclassified = findUnclassifiedTables(allTables)
     if (unclassified.length > 0) {
         throw new Error(
-            `exportMetadata: the following tables are not classified in ` +
-                `INCLUDE_DATA_TABLES or SCHEMA_ONLY_TABLES: ${unclassified.join(
-                    ", "
-                )}.\nAdd each one to exactly one of those lists (data will only ` +
-                `be exported for tables in INCLUDE_DATA_TABLES).`
+            `exportMetadata: ${unclassifiedTablesErrorMessage(unclassified)}`
         )
     }
 

--- a/db/exportMetadataTables.ts
+++ b/db/exportMetadataTables.ts
@@ -1,0 +1,111 @@
+// Classification of database tables for the public metadata export
+// (exportMetadata.ts). Kept in a separate module (without side effects) so
+// that the db test suite can verify that every table created by our
+// migrations is classified here.
+//
+// By default, only each table's structure is exported, with no rows.
+// For data to be exported, it must be explicitly included in the
+// INCLUDE_DATA_TABLES list. Keep both lists alphabetised.
+
+export const INCLUDE_DATA_TABLES = [
+    "admin_api_keys",
+    "analytics_popularity",
+    "archived_chart_versions",
+    "archived_explorer_versions",
+    "archived_multi_dim_versions",
+    "archived_post_versions",
+    "chart_configs",
+    "chart_diff_approvals",
+    "chart_diff_conflicts",
+    "chart_dimensions",
+    "chart_revisions",
+    "chart_slug_redirects",
+    "chart_tags",
+    "charts_x_entities",
+    "charts",
+    "dataset_tags",
+    "datasets",
+    "dod_links",
+    "dods",
+    "entities",
+    "explorer_charts",
+    "explorer_tags",
+    "explorer_variables",
+    "explorer_view_dimensions",
+    "explorer_views",
+    "explorers",
+    "featured_metrics",
+    "files",
+    "housekeeper_reviews",
+    "images",
+    "importer_additionalcountryinfo",
+    "jobs",
+    "migrations",
+    "multi_dim_data_pages",
+    "multi_dim_redirects",
+    "multi_dim_view_dimensions",
+    "multi_dim_x_chart_configs",
+    "namespaces",
+    "narrative_charts",
+    "origins_variables",
+    "origins",
+    "post_tags",
+    "posts_gdocs_components",
+    "posts_gdocs_links",
+    "posts_gdocs_tombstones",
+    "posts_gdocs_variables_faqs",
+    "posts_gdocs_x_images",
+    "posts_gdocs_x_tags",
+    "posts_gdocs",
+    "posts_links",
+    "posts",
+    "redirects",
+    "related_charts",
+    "slideshow_links",
+    "slideshow_x_images",
+    "slideshows",
+    "sources",
+    "static_viz",
+    "tag_graph",
+    "tags_variables_topic_tags",
+    "tags",
+    "variables",
+]
+
+// Tables that are intentionally schema-only. Listing them here (rather than
+// relying on the default) documents *why* they're excluded and lets the
+// classification check confirm every table has been considered. Keep
+// alphabetised.
+export const SCHEMA_ONLY_TABLES = [
+    // The analytics_* tables ship schema-only here; their data travels in a
+    // private sidecar dump instead. Keep them in sync with analyticsTables in
+    // exportAnalyticsData.ts.
+    "analytics_chart_views", // internal analytics, large
+    "analytics_grapher_views", // internal analytics, large
+    "analytics_pageviews", // internal analytics, large
+    "donors", // donor PII
+]
+
+// The users table is exported with anonymised data (see anonymisedUsersSql
+// in exportMetadata.ts).
+export const USERS_TABLE = "users"
+
+export function findUnclassifiedTables(allTables: string[]): string[] {
+    const classified = new Set([
+        ...INCLUDE_DATA_TABLES,
+        ...SCHEMA_ONLY_TABLES,
+        USERS_TABLE,
+    ])
+    return allTables.filter((t) => !classified.has(t))
+}
+
+export function unclassifiedTablesErrorMessage(unclassified: string[]): string {
+    return (
+        `the following tables are not classified in ` +
+        `INCLUDE_DATA_TABLES or SCHEMA_ONLY_TABLES: ${unclassified.join(
+            ", "
+        )}.\nAdd each one to exactly one of those lists in ` +
+        `db/exportMetadataTables.ts (data will only be exported for tables ` +
+        `in INCLUDE_DATA_TABLES).`
+    )
+}

--- a/db/tests/exportMetadata.test.ts
+++ b/db/tests/exportMetadata.test.ts
@@ -37,8 +37,7 @@ test("every table created by migrations is classified for the metadata export", 
     expect(allTables).toContain("charts")
 
     const unclassified = findUnclassifiedTables(allTables)
-    expect(
-        unclassified,
-        unclassifiedTablesErrorMessage(unclassified)
-    ).toEqual([])
+    expect(unclassified, unclassifiedTablesErrorMessage(unclassified)).toEqual(
+        []
+    )
 })

--- a/db/tests/exportMetadata.test.ts
+++ b/db/tests/exportMetadata.test.ts
@@ -1,0 +1,44 @@
+import { expect, beforeAll, test, afterAll } from "vitest"
+
+import knex, { Knex } from "knex"
+import { dbTestConfig } from "./dbTestConfig.js"
+import {
+    findUnclassifiedTables,
+    unclassifiedTablesErrorMessage,
+} from "../exportMetadataTables.js"
+
+let knexInstance: Knex<any, unknown[]> | undefined = undefined
+
+beforeAll(() => {
+    knexInstance = knex(dbTestConfig)
+})
+
+afterAll(async () => {
+    await knexInstance?.destroy()
+})
+
+// The test database has all migrations applied, so this catches a migration
+// that adds a table without classifying it in db/exportMetadataTables.ts —
+// otherwise the nightly metadata export (exportMetadata.ts) fails in
+// production instead.
+test("every table created by migrations is classified for the metadata export", async () => {
+    const rows: { TABLE_NAME: string }[] = await knexInstance!
+        .select("TABLE_NAME")
+        .from("information_schema.TABLES")
+        .where("TABLE_SCHEMA", knexInstance!.raw("DATABASE()"))
+        .andWhere("TABLE_TYPE", "BASE TABLE")
+
+    // _test_db_ready is a marker table created by the test database bootstrap
+    // (devTools/docker/create-test-db.sh); it never exists in production.
+    const allTables = rows
+        .map((r) => r.TABLE_NAME)
+        .filter((t) => t !== "_test_db_ready")
+    // Sanity check that we're looking at a migrated database
+    expect(allTables).toContain("charts")
+
+    const unclassified = findUnclassifiedTables(allTables)
+    expect(
+        unclassified,
+        unclassifiedTablesErrorMessage(unclassified)
+    ).toEqual([])
+})


### PR DESCRIPTION
## What

The nightly `mysql-export` Buildkite job failed:

```
Error: exportMetadata: the following tables are not classified in INCLUDE_DATA_TABLES or SCHEMA_ONLY_TABLES: related_charts.
```

The `related_charts` table (added in 165b956339) was never classified in `exportMetadata.ts`, so the script's backstop stopped the export.

- **Fix:** add `related_charts` to `INCLUDE_DATA_TABLES`. It's small and non-sensitive (chart→chart recommendation pairs with a score, written by the `etl related-charts` CLI, read by the data-page baker), so the public dump should carry its data.
- **CI guard:** move the classification lists into a side-effect-free module (`db/exportMetadataTables.ts` — `exportMetadata.ts` runs the export on import, so it can't be imported by tests) and add `db/tests/exportMetadata.test.ts`, which runs the same classification check against the freshly migrated test database. A PR that adds a `CREATE TABLE` migration without classifying the table now fails `make dbtest` in CI with the same actionable message, instead of breaking the nightly export.

## Verification

Ran `make dbtest` locally: the new test initially (and correctly) flagged `_test_db_ready`, the marker table created by the test-DB bootstrap — proving the detection works; it's now excluded as test infrastructure. Full suite passes: 71 tests in 11 files.

Caveat: the test only covers tables created by migrations. A table created directly in prod by an external system would still only surface at export time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)