### PR TITLE
enhance(mdim): set canonical url, include mdim views in sitemap for some mdims, and include mdim title in page title

### DIFF
--- a/baker/sitemap.ts
+++ b/baker/sitemap.ts
@@ -85,6 +85,14 @@ async function getPublishedGdocPosts(knex: db.KnexReadonlyTransaction) {
     )
 }
 
+const MDIM_INDEX_INDIVIDUAL_VIEWS: Record<
+    string,
+    boolean | Record<string, string>
+> = {
+    "vaccination-coverage-who-unicef": true,
+    "years-of-schooling": { sex: "both" }, // only index all views with sex=both
+}
+
 export const makeSitemap = async (
     explorerAdminServer: ExplorerAdminServer,
     knex: db.KnexReadonlyTransaction
@@ -175,22 +183,44 @@ export const makeSitemap = async (
 
                 const { slug, config } = multiDim
                 if (!slug) return []
-                if (!config.views || !Array.isArray(config.views)) {
+
+                const indexIndividualViews = MDIM_INDEX_INDIVIDUAL_VIEWS[slug]
+
+                if (!indexIndividualViews) {
                     return [
                         {
                             loc: urljoin(BAKED_GRAPHER_URL, slug),
                             lastmod,
                         },
                     ]
+                } else {
+                    return config.views.flatMap((view) => {
+                        if (
+                            typeof indexIndividualViews === "object" &&
+                            Object.entries(indexIndividualViews).some(
+                                ([dimension, value]) =>
+                                    view.dimensions[dimension] !== value
+                            )
+                        ) {
+                            return []
+                        }
+
+                        const searchParams = new URLSearchParams(
+                            view.dimensions
+                        )
+                        searchParams.sort()
+                        const queryStr = searchParams.toString()
+                        return [
+                            {
+                                loc: urljoin(
+                                    BAKED_GRAPHER_URL,
+                                    `${slug}?${queryStr}`
+                                ),
+                                lastmod,
+                            },
+                        ]
+                    })
                 }
-                return config.views.map((view) => {
-                    const searchParams = new URLSearchParams(view.dimensions)
-                    const queryStr = searchParams.toString()
-                    return {
-                        loc: urljoin(BAKED_GRAPHER_URL, `${slug}?${queryStr}`),
-                        lastmod,
-                    }
-                })
             })
         )
         .concat(

--- a/baker/sitemap.ts
+++ b/baker/sitemap.ts
@@ -6,10 +6,8 @@ import {
 import { dayjs, countries, getEntitiesForProfile } from "@ourworldindata/utils"
 import {
     DbPlainChart,
-    DbPlainMultiDimDataPage,
     DbPlainSlideshow,
     DbRawPostGdoc,
-    MultiDimDataPagesTableName,
     OwidGdocType,
     SlideshowsTableName,
 } from "@ourworldindata/types"
@@ -20,6 +18,7 @@ import {
 import * as db from "../db/db.js"
 import urljoin from "url-join"
 import { ExplorerAdminServer } from "../explorerAdminServer/ExplorerAdminServer.js"
+import { getAllPublishedMultiDimDataPages } from "../db/model/MultiDimDataPage.js"
 
 import { getMinimalAuthors } from "../db/model/Gdoc/GdocAuthor.js"
 import {
@@ -86,16 +85,6 @@ async function getPublishedGdocPosts(knex: db.KnexReadonlyTransaction) {
     )
 }
 
-async function getPublishedMultiDims(knex: db.KnexReadonlyTransaction) {
-    // Published multi-dims must have a slug.
-    return knex<DbPlainMultiDimDataPage & { slug: string }>(
-        MultiDimDataPagesTableName
-    )
-        .select("slug", "updatedAt")
-        .where("published", true)
-        .orderBy("updatedAt", "desc")
-}
-
 export const makeSitemap = async (
     explorerAdminServer: ExplorerAdminServer,
     knex: db.KnexReadonlyTransaction
@@ -129,7 +118,7 @@ export const makeSitemap = async (
     ]
 
     const explorers = await explorerAdminServer.getAllPublishedExplorers(knex)
-    const multiDims = await getPublishedMultiDims(knex)
+    const multiDims = await getAllPublishedMultiDimDataPages(knex)
     const slideshows = await knex<DbPlainSlideshow>(SlideshowsTableName)
         .select("slug", "updatedAt")
         .where("isPublished", 1)
@@ -181,10 +170,28 @@ export const makeSitemap = async (
         )
         .concat(explorers.map(explorerToSitemapUrl))
         .concat(
-            multiDims.map((multiDim) => ({
-                loc: urljoin(BAKED_GRAPHER_URL, multiDim.slug),
-                lastmod: dayjs(multiDim.updatedAt).format("YYYY-MM-DD"),
-            }))
+            multiDims.flatMap((multiDim) => {
+                const lastmod = dayjs(multiDim.updatedAt).format("YYYY-MM-DD")
+
+                const { slug, config } = multiDim
+                if (!slug) return []
+                if (!config.views || !Array.isArray(config.views)) {
+                    return [
+                        {
+                            loc: urljoin(BAKED_GRAPHER_URL, slug),
+                            lastmod,
+                        },
+                    ]
+                }
+                return config.views.map((view) => {
+                    const searchParams = new URLSearchParams(view.dimensions)
+                    const queryStr = searchParams.toString()
+                    return {
+                        loc: urljoin(BAKED_GRAPHER_URL, `${slug}?${queryStr}`),
+                        lastmod,
+                    }
+                })
+            })
         )
         .concat(
             authorPages.map((a) => ({

--- a/functions/_common/grapherTools.ts
+++ b/functions/_common/grapherTools.ts
@@ -417,13 +417,13 @@ export function rewriteMetaTags(
                     try {
                         const searchParams = url.searchParams
                         const newSearchParams = new URLSearchParams()
-                        // Ensure that the dimensions are set in dimension order, so we always have a consistent order.
                         for (const [dim, defaultChoice] of Object.entries(
                             mdimDimensionsObj
                         )) {
                             const value = searchParams.get(dim) ?? defaultChoice
                             newSearchParams.set(dim, value)
                         }
+                        newSearchParams.sort() // Sort parameters for consistent ordering in the URL
                         if (newSearchParams.toString()) {
                             element.setAttribute(
                                 "href",

--- a/functions/_common/grapherTools.ts
+++ b/functions/_common/grapherTools.ts
@@ -366,7 +366,7 @@ export function rewriteMetaTags(
     // Take the origin (e.g. https://ourworldindata.org) from the canonical URL, which should appear before the image elements.
     // If we fail to capture the origin, we end up with relative image URLs, which should also be okay.
     let origin = ""
-    let mdimDimensions: string[] | undefined = undefined
+    let mdimDimensionsObj: Record<string, string> | undefined = undefined
 
     const thumbnailUrl = `${url.pathname}.png${url.search}`
     const downloadCtxBase = getDownloadContextBase(url)
@@ -392,11 +392,19 @@ export function rewriteMetaTags(
         })
         .on("head", {
             element: (element) => {
-                const dimensionsAttr = element.getAttribute(
-                    "data-owid-mdim-dimensions"
-                )
+                // HTMLRewriter doesn't un-encode &quot; in attribute values, so we need to replace them before parsing the JSON.
+                const dimensionsAttr = element
+                    .getAttribute("data-owid-mdim-dimensions")
+                    ?.replaceAll("&quot;", '"')
+
                 if (dimensionsAttr) {
-                    mdimDimensions = dimensionsAttr.split(",")
+                    try {
+                        mdimDimensionsObj = JSON.parse(
+                            dimensionsAttr
+                        ) as Record<string, string>
+                    } catch (e) {
+                        console.error("Error parsing dimensions JSON", e)
+                    }
                 }
             },
         })
@@ -405,16 +413,16 @@ export function rewriteMetaTags(
             // This ensures search engines index specific dimension configurations separately while ignoring other query parameters.
             element: (element) => {
                 const href = element.getAttribute("href")
-                if (href && mdimDimensions) {
+                if (href && mdimDimensionsObj) {
                     try {
                         const searchParams = url.searchParams
                         const newSearchParams = new URLSearchParams()
                         // Ensure that the dimensions are set in dimension order, so we always have a consistent order.
-                        for (const dim of mdimDimensions) {
-                            const value = searchParams.get(dim)
-                            if (value) {
-                                newSearchParams.set(dim, value)
-                            }
+                        for (const [dim, defaultChoice] of Object.entries(
+                            mdimDimensionsObj
+                        )) {
+                            const value = searchParams.get(dim) ?? defaultChoice
+                            newSearchParams.set(dim, value)
                         }
                         if (newSearchParams.toString()) {
                             element.setAttribute(

--- a/functions/_common/grapherTools.ts
+++ b/functions/_common/grapherTools.ts
@@ -394,7 +394,7 @@ export function rewriteMetaTags(
             element: (element) => {
                 // HTMLRewriter doesn't un-encode &quot; in attribute values, so we need to replace them before parsing the JSON.
                 const dimensionsAttr = element
-                    .getAttribute("data-owid-mdim-dimensions")
+                    .getAttribute("data-owid-mdim-initial-view-dimensions")
                     ?.replaceAll("&quot;", '"')
 
                 if (dimensionsAttr) {

--- a/functions/_common/grapherTools.ts
+++ b/functions/_common/grapherTools.ts
@@ -366,6 +366,7 @@ export function rewriteMetaTags(
     // Take the origin (e.g. https://ourworldindata.org) from the canonical URL, which should appear before the image elements.
     // If we fail to capture the origin, we end up with relative image URLs, which should also be okay.
     let origin = ""
+    let mdimDimensions: string[] | undefined = undefined
 
     const thumbnailUrl = `${url.pathname}.png${url.search}`
     const downloadCtxBase = getDownloadContextBase(url)
@@ -386,6 +387,44 @@ export function rewriteMetaTags(
             element: (img) => {
                 if (thumbnailUrl) {
                     img.setAttribute("src", thumbnailUrl)
+                }
+            },
+        })
+        .on("head", {
+            element: (element) => {
+                const dimensionsAttr = element.getAttribute(
+                    "data-owid-mdim-dimensions"
+                )
+                if (dimensionsAttr) {
+                    mdimDimensions = dimensionsAttr.split(",")
+                }
+            },
+        })
+        .on('link[rel="canonical"]', {
+            // Rewrite the canonical URL for Multi-Dim pages to preserve only the valid dimension query parameters.
+            // This ensures search engines index specific dimension configurations separately while ignoring other query parameters.
+            element: (element) => {
+                const href = element.getAttribute("href")
+                if (href && mdimDimensions) {
+                    try {
+                        const searchParams = url.searchParams
+                        const newSearchParams = new URLSearchParams()
+                        // Ensure that the dimensions are set in dimension order, so we always have a consistent order.
+                        for (const dim of mdimDimensions) {
+                            const value = searchParams.get(dim)
+                            if (value) {
+                                newSearchParams.set(dim, value)
+                            }
+                        }
+                        if (newSearchParams.toString()) {
+                            element.setAttribute(
+                                "href",
+                                href + "?" + newSearchParams.toString()
+                            )
+                        }
+                    } catch (e) {
+                        console.error("Error rewriting canonical URL", e)
+                    }
                 }
             },
         })

--- a/site/Head.tsx
+++ b/site/Head.tsx
@@ -54,7 +54,7 @@ export const Head = (props: {
     const { canonicalUrl, baseUrl } = props
     const pageTitle = props.pageTitle || `Our World in Data`
     const fullPageTitle = props.pageTitle
-        ? `${props.pageTitle} - Our World in Data`
+        ? `${props.pageTitle} | Our World in Data`
         : `Our World in Data`
     const pageDesc =
         props.pageDesc ||

--- a/site/Head.tsx
+++ b/site/Head.tsx
@@ -49,7 +49,7 @@ export const Head = (props: {
     }
     staticAssetMap?: AssetMap
     archiveContext?: ArchiveContext
-    attrs?: Record<string, string>
+    attrs?: Record<string, string | undefined>
 }) => {
     const { canonicalUrl, baseUrl } = props
     const pageTitle = props.pageTitle || `Our World in Data`

--- a/site/Head.tsx
+++ b/site/Head.tsx
@@ -49,6 +49,7 @@ export const Head = (props: {
     }
     staticAssetMap?: AssetMap
     archiveContext?: ArchiveContext
+    attrs?: Record<string, string>
 }) => {
     const { canonicalUrl, baseUrl } = props
     const pageTitle = props.pageTitle || `Our World in Data`
@@ -74,7 +75,7 @@ export const Head = (props: {
     }
 
     return (
-        <head>
+        <head {...props.attrs}>
             <meta
                 name="viewport"
                 content="width=device-width, initial-scale=1, minimum-scale=1"

--- a/site/multiDim/MultiDimDataPage.tsx
+++ b/site/multiDim/MultiDimDataPage.tsx
@@ -71,6 +71,8 @@ export function MultiDimDataPage({
         : undefined
     const canonicalUrlForHead = liveUrlIfIsArchive ?? canonicalUrl
 
+    const mdimDimensions = configObj.dimensions.map((d) => d.slug).join(",")
+
     return (
         <Html>
             <Head
@@ -81,6 +83,7 @@ export function MultiDimDataPage({
                 baseUrl={baseUrl}
                 staticAssetMap={assetMaps?.static}
                 archiveContext={archiveContext}
+                attrs={{ "data-owid-mdim-dimensions": mdimDimensions }}
             >
                 <meta property="og:image:width" content={imageWidth} />
                 <meta property="og:image:height" content={imageHeight} />

--- a/site/multiDim/MultiDimDataPage.tsx
+++ b/site/multiDim/MultiDimDataPage.tsx
@@ -71,7 +71,9 @@ export function MultiDimDataPage({
         : undefined
     const canonicalUrlForHead = liveUrlIfIsArchive ?? canonicalUrl
 
-    const mdimDimensions = configObj.dimensions.map((d) => d.slug).join(",")
+    const mdimDimensions = initialViewDimensions
+        ? JSON.stringify(initialViewDimensions)
+        : undefined
 
     return (
         <Html>

--- a/site/multiDim/MultiDimDataPage.tsx
+++ b/site/multiDim/MultiDimDataPage.tsx
@@ -19,6 +19,7 @@ import {
     MultiDimDataPageData,
 } from "./MultiDimDataPageContent.js"
 import { DEFAULT_PAGE_DESCRIPTION } from "../dataPage.js"
+import { useMemo } from "react"
 
 export function MultiDimDataPage({
     baseUrl,
@@ -75,6 +76,13 @@ export function MultiDimDataPage({
         ? JSON.stringify(initialViewDimensions)
         : undefined
 
+    const headAttrs = useMemo(
+        () => ({
+            "data-owid-mdim-initial-view-dimensions": mdimDimensions,
+        }),
+        [mdimDimensions]
+    )
+
     return (
         <Html>
             <Head
@@ -85,7 +93,7 @@ export function MultiDimDataPage({
                 baseUrl={baseUrl}
                 staticAssetMap={assetMaps?.static}
                 archiveContext={archiveContext}
-                attrs={{ "data-owid-mdim-dimensions": mdimDimensions }}
+                attrs={headAttrs}
             >
                 <meta property="og:image:width" content={imageWidth} />
                 <meta property="og:image:height" content={imageHeight} />

--- a/site/multiDim/MultiDimDataPageContent.tsx
+++ b/site/multiDim/MultiDimDataPageContent.tsx
@@ -363,11 +363,20 @@ export function DataPageContent({
         !!grapherStateRef.current
     )
 
+    const fullTitle = useMemo(() => {
+        const grapherTitle = grapherCurrentTitle
+        if (!grapherTitle) return undefined
+        const mdimTitle = titleFragments
+            ? `${config.config.title.title} - ${titleFragments}`
+            : config.config.title.title
+        return `${grapherTitle} | ${mdimTitle} | Our World in Data`
+    }, [grapherCurrentTitle, titleFragments, config.config.title.title])
+
     useEffect(() => {
-        if (grapherCurrentTitle) {
-            document.title = grapherCurrentTitle
+        if (fullTitle) {
+            document.title = fullTitle
         }
-    }, [grapherCurrentTitle])
+    }, [fullTitle])
 
     const bounds = useElementBounds(grapherFigureRef)
 


### PR DESCRIPTION
We noticed that some Mdim views, like [`Number of newborns who have had a hepatitis B vaccine dose within the first 24 hours of delivery`](https://ourworldindata.org/grapher/vaccination-coverage-who-unicef?metric=vaccinated&antigen=hepb_bd), are not findable on Google _at all_ currently.

This PR makes three changes to Mdims, essentially:
- Set `<link rel="canonical">` in CF Functions, to ensure that the Mdim dimension choices are included in the canonical URL (so a `?metric=total` would be part of the canonical URL, but a `?tab=map` wouldn't)
- Enumerate all of these views in the sitemap
- Include the Mdim name in the page title, so we e.g. get `Share of children vaccinated, by vaccine, World | Childhood vaccination coverage - by vaccine | Our World in Data`


The sitemap change could have some negative SEO repercussions potentially, if Google finds that they don't like us indexing so many different views. But it's hard to know.

Antigravity says this:
> Including hundreds of similar page variations in a sitemap wastes crawl budget and causes keyword cannibalization, diluting the domain's overall search authority. To mitigate this, ensure all variations have self-referential canonical tags and only list the default and select, high-value variations rather than every possible permutation.

### Demo links:
- [Childhood vaccination Mdim](http://staging-site-mdim-canonical-url/grapher/vaccination-coverage-who-unicef?metric=unvaccinated&antigen=comparison)
- [Sitemap](http://staging-site-mdim-canonical-url/sitemap.xml)

TODO after merge:
- [x] Add a [Search Console annotation](https://support.google.com/webmasters/answer/16530728?hl=en)