### PR TITLE
🎉 Migration viz: click-to-select country and population-share tooltip

### DIFF
--- a/bespoke/components/Sankey/SplitFlowSankey.tsx
+++ b/bespoke/components/Sankey/SplitFlowSankey.tsx
@@ -128,6 +128,12 @@ interface SplitFlowSankeyProps {
      * color map is derived from the currently displayed nodes.
      */
     colorMap?: Map<string, string>
+    /**
+     * When set, partner nodes and the flows touching them become clickable;
+     * clicking calls back with the partner entity. The central entity and the
+     * aggregated "Other" bucket are never selectable.
+     */
+    onSelectPartner?: (partner: string) => void
 }
 
 export function SplitFlowSankey({
@@ -144,6 +150,7 @@ export function SplitFlowSankey({
     minNodeShare = DEFAULT_MIN_NODE_SHARE,
     formatValue,
     colorMap: colorMapOverride,
+    onSelectPartner,
 }: SplitFlowSankeyProps) {
     const showIncoming = view === "both" || view === "incoming"
     const showOutgoing = view === "both" || view === "outgoing"
@@ -342,6 +349,7 @@ export function SplitFlowSankey({
                         fontSettings={fontSettings}
                         nodeColor={getNodeColor}
                         linkColor={getLinkColor}
+                        onSelectPartner={onSelectPartner}
                     />
                 )}
                 {showOutgoing && (
@@ -356,6 +364,7 @@ export function SplitFlowSankey({
                         fontSettings={fontSettings}
                         nodeColor={getNodeColor}
                         linkColor={getLinkColor}
+                        onSelectPartner={onSelectPartner}
                     />
                 )}
             </div>
@@ -404,6 +413,7 @@ function SankeyHalfChart({
     fontSettings,
     nodeColor,
     linkColor,
+    onSelectPartner,
 }: {
     direction: "incoming" | "outgoing"
     half: SankeyHalf
@@ -415,11 +425,39 @@ function SankeyHalfChart({
     fontSettings: FontSettings
     nodeColor: (node: SankeyNode) => string
     linkColor: (link: SankeyLink) => string
+    onSelectPartner?: (partner: string) => void
 }) {
     const innerMargin =
         direction === "incoming"
             ? { left: sharedOuterMargin }
             : { right: sharedOuterMargin }
+
+    // A partner is selectable when it resolves to a named entity — never the
+    // central node (no prefix → null) or the aggregated "Other" bucket.
+    const partnerFromLink = (link: SankeyLink): string | null =>
+        getPartnerFromNodeId(link.source) ?? getPartnerFromNodeId(link.target)
+    const isSelectablePartner = (partner: string | null): partner is string =>
+        partner !== null && partner !== OTHER_KEY
+
+    const onLinkClick = onSelectPartner
+        ? (link: SankeyLink) => {
+              const partner = partnerFromLink(link)
+              if (isSelectablePartner(partner)) onSelectPartner(partner)
+          }
+        : undefined
+    const isLinkClickable = onSelectPartner
+        ? (link: SankeyLink) => isSelectablePartner(partnerFromLink(link))
+        : undefined
+    const onNodeClick = onSelectPartner
+        ? (node: SankeyNode) => {
+              const partner = getPartnerFromNodeId(node.id)
+              if (isSelectablePartner(partner)) onSelectPartner(partner)
+          }
+        : undefined
+    const isNodeClickable = onSelectPartner
+        ? (node: SankeyNode) =>
+              isSelectablePartner(getPartnerFromNodeId(node.id))
+        : undefined
 
     const getLinkTooltip =
         half.getTooltip && build
@@ -462,6 +500,10 @@ function SankeyHalfChart({
                             isNodeHoverable={(node) =>
                                 node.id !== centralEntity
                             }
+                            onLinkClick={onLinkClick}
+                            isLinkClickable={isLinkClickable}
+                            onNodeClick={onNodeClick}
+                            isNodeClickable={isNodeClickable}
                         />
                     )}
                 </div>

--- a/bespoke/projects/migration/src/components/MigrationChart.tsx
+++ b/bespoke/projects/migration/src/components/MigrationChart.tsx
@@ -15,8 +15,10 @@ export function MigrationChart({
     sex,
     immigrantsTotal,
     emigrantsTotal,
+    population,
     view,
     setView,
+    setCountry,
     colorMap,
     isLoading,
 }: {
@@ -27,8 +29,10 @@ export function MigrationChart({
     sex: Sex
     immigrantsTotal: number
     emigrantsTotal: number
+    population?: number
     view: MigrationView
     setView: (view: MigrationView) => void
+    setCountry: (name: string) => void
     colorMap?: Map<string, string>
     isLoading?: boolean
 }) {
@@ -49,8 +53,10 @@ export function MigrationChart({
                     sex={sex}
                     immigrantsTotal={immigrantsTotal}
                     emigrantsTotal={emigrantsTotal}
+                    population={population}
                     view={view}
                     setView={setView}
+                    setCountry={setCountry}
                     colorMap={colorMap}
                 />
             ) : (

--- a/bespoke/projects/migration/src/components/MigrationSankey.scss
+++ b/bespoke/projects/migration/src/components/MigrationSankey.scss
@@ -65,3 +65,31 @@
     font-size: 12px;
     padding: 4px 0 0;
 }
+
+.migration-sankey__count {
+    cursor: help;
+    text-decoration: underline dotted;
+    text-underline-offset: 3px;
+    text-decoration-thickness: 1px;
+
+    &:focus-visible {
+        outline: 1px solid $blue-50;
+        outline-offset: 2px;
+        border-radius: 2px;
+    }
+}
+
+.migration-sankey__count-tooltip {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    text-align: left;
+}
+
+.migration-sankey__count-tooltip-value {
+    font-weight: 700;
+}
+
+.migration-sankey__count-tooltip-share {
+    color: $light-text;
+}

--- a/bespoke/projects/migration/src/components/MigrationSankey.tsx
+++ b/bespoke/projects/migration/src/components/MigrationSankey.tsx
@@ -4,7 +4,7 @@ import cx from "classnames"
 import * as R from "remeda"
 import { match } from "ts-pattern"
 
-import { articulateEntity } from "@ourworldindata/utils"
+import { articulateEntity, Tippy } from "@ourworldindata/utils"
 import {
     TooltipTable,
     TooltipValue,
@@ -17,6 +17,7 @@ import {
     STACKED_MAX_NODES_TO_SHRINK_OTHER,
 } from "../../../../components/Sankey/SankeyHelpers.js"
 import { SankeyTooltip } from "../../../../components/Sankey/Sankey.js"
+import { useTippyContainer } from "../../../../hooks/useTippyContainer.js"
 import {
     DEFAULT_FONT_SETTINGS,
     MOBILE_BREAKPOINT,
@@ -43,8 +44,10 @@ export function MigrationSankey({
     sex,
     immigrantsTotal,
     emigrantsTotal,
+    population,
     view = "both",
     setView,
+    setCountry,
     colorMap,
 }: {
     immigrants: MigrationFlow[]
@@ -54,8 +57,10 @@ export function MigrationSankey({
     sex: Sex
     immigrantsTotal: number
     emigrantsTotal: number
+    population?: number
     view?: MigrationView
     setView: (view: MigrationView) => void
+    setCountry: (name: string) => void
     colorMap?: Map<string, string>
 }) {
     const { parentRef, width, height } = useParentSize()
@@ -91,6 +96,7 @@ export function MigrationSankey({
         view,
         isPairedSentence,
         sex,
+        population,
         setView,
     }
 
@@ -131,6 +137,7 @@ export function MigrationSankey({
                 formatValue={formatPeople}
                 view={splitView}
                 colorMap={colorMap}
+                onSelectPartner={setCountry}
                 isStacked={isStacked}
                 fontSettings={
                     isStacked ? MOBILE_FONT_SETTINGS : DEFAULT_FONT_SETTINGS
@@ -152,6 +159,7 @@ function buildSankeyHalf({
     view,
     isPairedSentence,
     sex,
+    population,
     otherHasData,
     setView,
 }: {
@@ -163,6 +171,7 @@ function buildSankeyHalf({
     view: MigrationView
     isPairedSentence: boolean
     sex: Sex
+    population?: number
     otherHasData: boolean
     setView: (view: MigrationView) => void
 }) {
@@ -189,6 +198,7 @@ function buildSankeyHalf({
               label: makeHeadingLabel({
                   direction,
                   total,
+                  population,
                   shortEntityNameWithArticle,
                   isPairedSentence,
                   sexAdjective: adjective,
@@ -241,18 +251,26 @@ function buildSankeyHalf({
 function makeHeadingLabel({
     direction,
     total,
+    population,
     shortEntityNameWithArticle,
     isPairedSentence,
     sexAdjective,
 }: {
     direction: "incoming" | "outgoing"
     total: number
+    population?: number
     shortEntityNameWithArticle: string
     isPairedSentence: boolean
     sexAdjective?: string
 }): ReactNode {
-    const count = formatPeople(total, { unit: false })
     const peopleNoun = getSexNoun(sexAdjective)
+    const count = (
+        <PeopleCount
+            total={total}
+            population={population}
+            shortEntityNameWithArticle={shortEntityNameWithArticle}
+        />
+    )
     if (direction === "incoming") {
         return (
             <>
@@ -272,6 +290,47 @@ function makeHeadingLabel({
                 live abroad
             </strong>
         </>
+    )
+}
+
+/**
+ * The migrant count in a heading, with a tooltip that states the full number
+ * and — when population is known — its share of the country's total population.
+ */
+function PeopleCount({
+    total,
+    population,
+    shortEntityNameWithArticle,
+}: {
+    total: number
+    population?: number
+    shortEntityNameWithArticle: string
+}): React.ReactElement {
+    const { ref, getTippyContainer } = useTippyContainer<HTMLSpanElement>()
+
+    const share = population && population > 0 ? total / population : undefined
+    const formattedShare = share !== undefined ? formatShare(share) : ""
+
+    const content = (
+        <span className="migration-sankey__count-tooltip">
+            <span className="migration-sankey__count-tooltip-value">
+                {formatPeople(total)}
+            </span>
+            {formattedShare && (
+                <span className="migration-sankey__count-tooltip-share">
+                    {formattedShare} of the population of{" "}
+                    {shortEntityNameWithArticle}
+                </span>
+            )}
+        </span>
+    )
+
+    return (
+        <Tippy content={content} appendTo={getTippyContainer} placement="top">
+            <span ref={ref} className="migration-sankey__count" tabIndex={0}>
+                {formatPeople(total, { unit: false })}
+            </span>
+        </Tippy>
     )
 }
 

--- a/bespoke/projects/migration/src/helpers.ts
+++ b/bespoke/projects/migration/src/helpers.ts
@@ -3,7 +3,7 @@ import { match } from "ts-pattern"
 import { formatValue } from "@ourworldindata/utils"
 import { OwidVariableRoundingMode } from "@ourworldindata/types"
 
-import { GenderOption, Sex } from "./types.js"
+import { GenderOption, MigrationMetadata, Sex } from "./types.js"
 
 /** Map a raw metadata gender name onto the semantic `Sex` enum. */
 export function sexFromName(name: string): Sex {
@@ -48,6 +48,21 @@ export function formatShare(share: number): string {
         roundingMode: OwidVariableRoundingMode.significantFigures,
         numSignificantFigures: 2,
     })
+}
+
+/** Resolve a country's total population at a given year from the metadata.
+ *  The per-entity `population` array is aligned with `metadata.times`. */
+export function getPopulation(
+    metadata: MigrationMetadata,
+    countryName: string,
+    year: number
+): number | undefined {
+    const entity = metadata.entities.find((e) => e.name === countryName)
+    if (!entity) return undefined
+    const index = metadata.times.indexOf(year)
+    if (index < 0) return undefined
+    const population = entity.population[index]
+    return Number.isFinite(population) ? population : undefined
 }
 
 /** Cap a list to 8 visible items, returning the remainder count */

--- a/bespoke/projects/migration/src/variants/SankeyVariant.tsx
+++ b/bespoke/projects/migration/src/variants/SankeyVariant.tsx
@@ -26,7 +26,12 @@ import {
 import { SankeyVariantConfig, VariantProps } from "../config.js"
 import { MigrationFlow, MigrationRow, MigrationView, Sex } from "../types.js"
 import { useMigrationData, useMigrationMetadata } from "../data.js"
-import { formatPeople, getSexAdjective, getSexNoun } from "../helpers.js"
+import {
+    formatPeople,
+    getPopulation,
+    getSexAdjective,
+    getSexNoun,
+} from "../helpers.js"
 import { MigrationChart } from "../components/MigrationChart.js"
 import { MigrationControls } from "../components/MigrationControls.js"
 
@@ -269,6 +274,8 @@ function CaptionedSankeyVariant({
     const shouldHideChrome =
         config.hideControls || !!config.title || !!config.subtitle
 
+    const population = getPopulation(metadata, displayedCountry, year)
+
     return (
         <>
             {!shouldHideChrome && (
@@ -315,8 +322,10 @@ function CaptionedSankeyVariant({
                     sex={sex}
                     immigrantsTotal={immigrantsTotal}
                     emigrantsTotal={emigrantsTotal}
+                    population={population}
                     view={view}
                     setView={setView}
+                    setCountry={setCountry}
                     colorMap={colorMap}
                     isLoading={isLoading}
                 />


### PR DESCRIPTION
## What

Two improvements to the migration bespoke viz:

1. **Click a flow to change the selected country.** Clicking a flow (or a partner node) now switches the selected country to that partner — the origin for incoming flows, the destination for outgoing flows. The central (currently selected) entity and the aggregated "Other" bucket are not selectable.

2. **Population-share tooltip on the migrant count.** The migrant count in each Sankey half heading (e.g. "1 million people in the United States were born elsewhere") now has a tooltip showing the full number alongside its share of the country's total population — e.g. if a country has 10 million people and 1 million were born elsewhere, the tooltip on "1 million" reads "1 million people, 10% of the population of the United States".

## How

- Added an optional `onSelectPartner` prop to the shared `SplitFlowSankey` component (used by both the migration and food-trade projects). It forwards `onLinkClick`/`onNodeClick` and clickability guards to the underlying `Sankey`, mapping a clicked link/node to its partner entity. Non-breaking: food-trade doesn't pass it, so its behavior is unchanged.
- Wired `setCountry` through `SankeyVariant → MigrationChart → MigrationSankey → SplitFlowSankey` as `onSelectPartner`.
- Added a `PeopleCount` component in `MigrationSankey` that wraps the count in a `Tippy` tooltip (the same component already used elsewhere in the bespoke projects, e.g. demography and the migration view switcher), portaled into the Shadow DOM via `useTippyContainer`.
- Added a `getPopulation` helper that reads the per-entity population (aligned with `metadata.times`) for the displayed country and year.

## Notes

- I was unable to run `yarn typecheck` / `yarn testLintChanged` / `yarn fixFormatChanged` in this environment because dependencies aren't installed and Yarn 4 couldn't be fetched via Corepack (network-restricted). The changes were reviewed manually against the project's style conventions.

https://claude.ai/code/session_01UutXa2KbkJcC8QtjDdJcKG

---
_Generated by [Claude Code](https://claude.ai/code/session_01UutXa2KbkJcC8QtjDdJcKG)_