### PR TITLE
Harden GitHub Actions workflow security with zizmor

### DIFF
--- a/.github/workflows/bespoke.yml
+++ b/.github/workflows/bespoke.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-node-yarn-deps
         with:
@@ -33,6 +35,8 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-node-yarn-deps
         with:
@@ -50,6 +54,8 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-node-yarn-deps
         with:

--- a/.github/workflows/bespoke.yml
+++ b/.github/workflows/bespoke.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 defaults:
   run:
     working-directory: bespoke

--- a/.github/workflows/buildkite.yml
+++ b/.github/workflows/buildkite.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/buildkite.yml
+++ b/.github/workflows/buildkite.yml
@@ -5,6 +5,9 @@ on:
     types:
       - closed
 
+permissions:
+  contents: read
+
 jobs:
   destroy_staging:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-default-grapher-config.yml
+++ b/.github/workflows/check-default-grapher-config.yml
@@ -8,6 +8,9 @@ on:
       - "packages/@ourworldindata/grapher/src/schema/**"
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   commit-default-config:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-default-grapher-config.yml
+++ b/.github/workflows/check-default-grapher-config.yml
@@ -16,6 +16,7 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          persist-credentials: false
           ref: ${{ github.head_ref }}
 
       - uses: ./.github/actions/setup-node-yarn-deps
@@ -50,7 +51,19 @@ jobs:
       - name: Run formatter
         run: yarn fixFormatAll
 
-      - uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0
-        with:
-          commit_message: "🤖 update default grapher config"
-          file_pattern: "packages/@ourworldindata/grapher/src/schema/defaultGrapherConfig.ts"
+      - name: Commit default grapher config
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git add packages/@ourworldindata/grapher/src/schema/defaultGrapherConfig.ts
+
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+            exit 0
+          fi
+
+          branch="${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git commit -m "🤖 update default grapher config"
+          git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:$branch"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   # Checks for prettify errors, TypeScript errors and runs vitest tests.
   "test-db":

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,3 +126,19 @@ jobs:
 
       - name: BundleMon
         uses: lironer/bundlemon-action@4b47df0793e18e3899eeb07f19b7c88c92c2490e # v1.4.0
+
+  zizmor:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        with:
+          # Avanced Security mode is a bit too complicated for our use case, but
+          # we might want to switch to it in the future.
+          advanced-security: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-node-yarn-deps
 
@@ -30,6 +32,8 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-node-yarn-deps
 
@@ -42,6 +46,8 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-node-yarn-deps
         with:
@@ -56,6 +62,8 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-node-yarn-deps
         with:
@@ -70,6 +78,8 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-node-yarn-deps
         with:
@@ -84,6 +94,8 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-node-yarn-deps
         with:
@@ -99,6 +111,8 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-node-yarn-deps
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -49,6 +49,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: write
+
 # Runs `oxfmt` on a pull request so everything is nice and formatted!
 # If something's wrong, a new commit fixing the issues will automatically be pushed to the PR branch.
 

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -16,6 +16,7 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          persist-credentials: false
           ref: ${{ github.head_ref }}
 
       - uses: ./.github/actions/setup-node-yarn-deps
@@ -25,6 +26,19 @@ jobs:
       - name: Run formatter
         run: yarn fixFormatAll
 
-      - uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0
-        with:
-          commit_message: "🤖 style: format code"
+      - name: Commit formatting changes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git add -A
+
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+            exit 0
+          fi
+
+          branch="${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git commit -m "🤖 style: format code"
+          git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:$branch"

--- a/.github/workflows/project-automations.yml
+++ b/.github/workflows/project-automations.yml
@@ -13,6 +13,8 @@ on:
       - review_requested
       - closed
 
+permissions: {}
+
 jobs:
   prio:
     name: Sync issue priority to project board
@@ -32,6 +34,8 @@ jobs:
     name: Add "needs triage" label
     runs-on: ubuntu-latest
     if: github.event_name == 'issues' && github.event.action == 'opened'
+    permissions:
+      issues: write
     steps:
       - name: Label issue
         uses: andymckay/labeler@e6c4322d0397f3240f0e7e30a33b5c5df2d39e90 # 1.0.4
@@ -42,6 +46,8 @@ jobs:
     name: Add "staging-viz" label to Sophia's PRs
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' && github.event.action == 'opened' && github.actor == 'sophiamersmann'
+    permissions:
+      issues: write
     steps:
       - uses: andymckay/labeler@e6c4322d0397f3240f0e7e30a33b5c5df2d39e90 # 1.0.4
         with:

--- a/.github/workflows/project-automations.yml
+++ b/.github/workflows/project-automations.yml
@@ -20,14 +20,14 @@ jobs:
     name: Sync issue priority to project board
     runs-on: ubuntu-latest
     steps:
-      - uses: owid/actions/assign-priority@main
+      - uses: owid/actions/assign-priority@main # zizmor: ignore[unpinned-uses] internal unversioned actions repo
         with:
           PROJECT_ISSUES_TOKEN: ${{ secrets.PROJECT_ISSUES_TOKEN }}
   status:
     name: Set status based on event
     runs-on: ubuntu-latest
     steps:
-      - uses: owid/actions/set-project-status@main
+      - uses: owid/actions/set-project-status@main # zizmor: ignore[unpinned-uses] internal unversioned actions repo
         with:
           PROJECT_ISSUES_TOKEN: ${{ secrets.PROJECT_ISSUES_TOKEN }}
   needs_triage:

--- a/.github/workflows/sentry.yml
+++ b/.github/workflows/sentry.yml
@@ -10,6 +10,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Create Sentry release
         uses: getsentry/action-release@ff07929a6537bac57790c3451cf4d364aca38528 # v3.7.0

--- a/.github/workflows/sentry.yml
+++ b/.github/workflows/sentry.yml
@@ -1,6 +1,9 @@
 name: Sentry Release
 on: push
 
+permissions:
+  contents: read
+
 jobs:
   create-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/sync-grapher-schema-to-r2.yml
+++ b/.github/workflows/sync-grapher-schema-to-r2.yml
@@ -7,6 +7,9 @@ on:
       - "packages/@ourworldindata/grapher/src/schema/**"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   upload:
     runs-on: ubuntu-latest

--- a/.github/workflows/sync-grapher-schema-to-r2.yml
+++ b/.github/workflows/sync-grapher-schema-to-r2.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-node-yarn-deps
 

--- a/.github/workflows/todo-checker.yml
+++ b/.github/workflows/todo-checker.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 
+permissions:
+  contents: read
+  pull-requests: write
+  statuses: write
+
 jobs:
   find_todos:
     runs-on: ubuntu-latest

--- a/.github/workflows/todo-checker.yml
+++ b/.github/workflows/todo-checker.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Check for Todos
         uses: phntmxyz/pr_todo_checker@ca2891552a6cd4069c6afb83c955133e77dac685 # v1.2.0

--- a/.github/workflows/update-regions.yml
+++ b/.github/workflows/update-regions.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-node-yarn-deps
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -31,5 +31,8 @@
     },
     "[typescript]": {
         "editor.defaultFormatter": "oxc.oxc-vscode"
+    },
+    "[github-actions-workflow]": {
+        "editor.defaultFormatter": "oxc.oxc-vscode"
     }
 }


### PR DESCRIPTION
### TL;DR

Harden GitHub Actions workflows against supply-chain and credential-leakage attacks by adding least-privilege permissions, disabling credential persistence on checkout, replacing `stefanzweifel/git-auto-commit-action` with inline push steps, and introducing a new `zizmor` security-scanning workflow.

### How to test?

Open a pull request and verify that the `Zizmor` check appears in the CI status list and that the `format` and `check-default-grapher-config` jobs still auto-commit formatting/config changes correctly without relying on `stefanzweifel/git-auto-commit-action`.

### Why make this change?

Unpinned or overly-privileged workflow steps are a common vector for supply-chain attacks. Persisted checkout credentials can be exfiltrated by malicious steps later in a job. Using a dedicated security scanner (`zizmor`) as a required CI check makes it easier to catch these issues automatically going forward, and the inline push approach removes a third-party action dependency while keeping the same auto-commit behaviour.

Part of #6483