### PR TITLE
🎉 Add Views, Pageviews columns, and published filter to multi-dim index page

### DIFF
--- a/adminSiteClient/MultiDimIndexPage.tsx
+++ b/adminSiteClient/MultiDimIndexPage.tsx
@@ -36,6 +36,8 @@ type ApiMultiDim = {
     slug: string | null
     updatedAt: string
     published: boolean
+    mdimViews: number
+    pageviews: number
 }
 
 type MultiDim = Omit<ApiMultiDim, "updatedAt"> & {
@@ -202,6 +204,22 @@ function createColumns(
                 if (b.slug === null) return -1
                 return a.slug.localeCompare(b.slug)
             },
+        },
+        {
+            title: "Mdim views",
+            dataIndex: "mdimViews",
+            key: "mdimViews",
+            align: "right",
+            render: (views) => views?.toLocaleString(),
+            sorter: (a, b) => a.mdimViews - b.mdimViews,
+        },
+        {
+            title: "Pageviews",
+            dataIndex: "pageviews",
+            key: "pageviews",
+            align: "right",
+            render: (views) => views?.toLocaleString(),
+            sorter: (a, b) => a.pageviews - b.pageviews,
         },
         {
             title: "Last updated",

--- a/adminSiteClient/MultiDimIndexPage.tsx
+++ b/adminSiteClient/MultiDimIndexPage.tsx
@@ -7,6 +7,7 @@ import {
 import { useContext, useEffect, useMemo, useState } from "react"
 import {
     Button,
+    Checkbox,
     Flex,
     Input,
     Popconfirm,
@@ -345,14 +346,17 @@ export function MultiDimIndexPage() {
         },
     })
 
+    const [showOnlyPublished, setShowOnlyPublished] = useState(false)
+
     const filteredMdims = useMemo(() => {
         const query = search.trim().toLowerCase()
-        return data?.filter((mdim) =>
-            [mdim.title, mdim.slug ?? ""].some((field) =>
+        return data?.filter((mdim) => {
+            if (showOnlyPublished && !mdim.published) return false
+            return [mdim.title, mdim.slug ?? ""].some((field) =>
                 field.toLowerCase().includes(query)
             )
-        )
-    }, [data, search])
+        })
+    }, [data, search, showOnlyPublished])
 
     const columns = createColumns(slugMutation, publishMutation)
 
@@ -362,13 +366,23 @@ export function MultiDimIndexPage() {
             <main>
                 <Space orientation="vertical" size="middle">
                     <Flex align="center" justify="space-between" gap={24}>
-                        <Input
-                            placeholder="Search by title or slug"
-                            value={search}
-                            onChange={(e) => setSearch(e.target.value)}
-                            style={{ width: 500 }}
-                            autoFocus
-                        />
+                        <Space size="middle">
+                            <Input
+                                placeholder="Search by title or slug"
+                                value={search}
+                                onChange={(e) => setSearch(e.target.value)}
+                                style={{ width: 500 }}
+                                autoFocus
+                            />
+                            <Checkbox
+                                checked={showOnlyPublished}
+                                onChange={(e) =>
+                                    setShowOnlyPublished(e.target.checked)
+                                }
+                            >
+                                Show only published
+                            </Checkbox>
+                        </Space>
                         <Space>
                             <a
                                 href={urljoin(

--- a/adminSiteServer/apiRoutes/mdims.ts
+++ b/adminSiteServer/apiRoutes/mdims.ts
@@ -203,22 +203,30 @@ export async function handleGetMultiDims(
             Pick<
                 DbPlainMultiDimDataPage,
                 "id" | "catalogPath" | "slug" | "updatedAt" | "published"
-            > & { title: string }
+            > & { title: string; pageviews: number; mdimViews: number }
         >(
             trx,
             `-- sql
             SELECT
-                id,
-                catalogPath,
-                slug,
-                config->>'$.title.title' as title,
-                updatedAt,
-                published
-            FROM ${MultiDimDataPagesTableName}`
+                mdp.id,
+                mdp.catalogPath,
+                mdp.slug,
+                mdp.config->>'$.title.title' as title,
+                mdp.updatedAt,
+                mdp.published,
+                COALESCE(agv.views_365d, 0) as pageviews,
+                COALESCE(JSON_LENGTH(mdp.config, '$.views'), 0) as mdimViews
+            FROM ${MultiDimDataPagesTableName} mdp
+            LEFT JOIN analytics_grapher_views agv ON (
+                agv.grapher_slug = mdp.slug
+                AND agv.day = (SELECT MAX(day) FROM analytics_grapher_views)
+            )`
         )
         const multiDims = results.map((row) => ({
             ...row,
             published: Boolean(row.published),
+            pageviews: Number(row.pageviews),
+            mdimViews: Number(row.mdimViews),
         }))
         return { multiDims }
     } catch (error) {


### PR DESCRIPTION
This PR adds the Views and Pageviews columns to the Multidimensional Data Pages index page in the admin, along with a client-side filter to show only published multi-dims.