### PR TITLE
✨ Cache gdoc-independent queries in GDoc validate() to speed up baking

### DIFF
--- a/db/model/Gdoc/GdocBase.ts
+++ b/db/model/Gdoc/GdocBase.ts
@@ -1143,16 +1143,13 @@ export class GdocBase implements OwidGdocBaseInterface {
             getAllNarrativeChartNames(knex),
             getDods(knex).then((dods) => indexBy(dods, (dod) => dod.name)),
             getEnrichedStaticVizList(knex),
-            getMultiDimRedirectTargets(
-                knex,
-                this.linkedChartSlugs.grapher,
-                "/grapher/"
-            ),
-            getMultiDimRedirectTargets(
-                knex,
-                this.linkedChartSlugs.explorer,
-                "/explorers/"
-            ),
+            // Fetch the full (gdoc-independent) redirect maps so the result is
+            // cached for the whole transaction. Passing the gdoc's own slugs
+            // would issue an uncached query per gdoc during baking; the full
+            // maps are supersets keyed identically, so the .get(link.target)
+            // lookups below are unchanged.
+            getMultiDimRedirectTargets(knex, undefined, "/grapher/"),
+            getMultiDimRedirectTargets(knex, undefined, "/explorers/"),
         ])
 
         const linkErrors: OwidGdocErrorMessage[] = []

--- a/db/model/MultiDimRedirects.ts
+++ b/db/model/MultiDimRedirects.ts
@@ -47,6 +47,27 @@ export async function getMultiDimRedirectTargets(
     const redirectMap = new Map<string, MultiDimRedirectTarget>()
     if (slugs && slugs.length === 0) return redirectMap
 
+    // When fetching all redirects for a prefix (slugs === undefined), cache the
+    // result for the lifetime of the transaction. This is the gdoc-independent
+    // case used during baking (validate() of every gdoc), so caching it avoids
+    // re-running the query once per gdoc.
+    if (!slugs) {
+        return db.cachedInTransaction(
+            knex,
+            `multiDimRedirectTargets:${sourcePrefix}`,
+            () => fetchMultiDimRedirectTargets(knex, undefined, sourcePrefix)
+        )
+    }
+    return fetchMultiDimRedirectTargets(knex, slugs, sourcePrefix)
+}
+
+async function fetchMultiDimRedirectTargets(
+    knex: db.KnexReadonlyTransaction,
+    slugs: string[] | undefined,
+    sourcePrefix: MultiDimRedirectSourcePrefix
+): Promise<Map<string, MultiDimRedirectTarget>> {
+    const redirectMap = new Map<string, MultiDimRedirectTarget>()
+
     let whereClause: string
     let params: string[]
     if (!slugs) {

--- a/db/model/StaticViz.ts
+++ b/db/model/StaticViz.ts
@@ -137,8 +137,13 @@ export async function getEnrichedStaticVizById(
 export async function getEnrichedStaticVizList(
     trx: db.KnexReadonlyTransaction
 ): Promise<DbEnrichedStaticViz[]> {
-    const vizList = await db.knexRaw<StaticVizRow>(trx, BASE_STATIC_VIZ_QUERY)
-    return vizList.map(rowToEnrichedStaticViz)
+    return db.cachedInTransaction(trx, "enrichedStaticVizList", async () => {
+        const vizList = await db.knexRaw<StaticVizRow>(
+            trx,
+            BASE_STATIC_VIZ_QUERY
+        )
+        return vizList.map(rowToEnrichedStaticViz)
+    })
 }
 
 /**


### PR DESCRIPTION
## Problem

`bakeGDocPosts` validates every published gdoc serially. `GdocBase.validate()` re-issued several **gdoc-independent** DB queries *per gdoc*:

- `getEnrichedStaticVizList` (global, uncached)
- `getMultiDimRedirectTargets` ×2 (grapher + explorer)

The whole bake runs in a single read-only transaction — i.e. **one connection** — so these queries can't overlap; each is a serialized round-trip. Locally (localhost DB) that's cheap, but in production the per-query RTT dominates, which is why the gdoc-posts step takes ~140s there vs ~15s locally.

## Change

Cache the gdoc-independent results for the lifetime of the transaction (the same `cachedInTransaction` pattern already used by `mapSlugsToIds`, `getDods`, etc. — safe because the bake transaction is read-only):

- `getMultiDimRedirectTargets` now caches the **full-prefix** fetch (`slugs === undefined`). `validate()` requests the full maps instead of the gdoc's own slugs. The full map is a strict superset keyed identically, so the `.get(link.target)` lookups in `validate()` are unchanged. Slug-specific callers (archival, `loadLinkedCharts`) are untouched.
- `getEnrichedStaticVizList` wrapped in `cachedInTransaction`.

## Verification

| Check | Result |
|---|---|
| Baked HTML output | **690/690 posts byte-identical** to master |
| DB queries during a local gdocPosts bake | **1,371 → 3** (681 multidim + 690 staticViz → 2 + 1) |
| Format / lint | pass |

The ~1,368 eliminated round-trips are the production win; at a typical remote RTT this should shave a substantial chunk off the gdoc-posts bake step. Local wall-clock is unchanged because localhost has no latency to recover.

Out of scope: the remaining bake cost is React rendering + in-memory attachment picking (CPU-bound), which would need parallelism rather than caching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)