### PR TITLE
Optimize data page re-renders

### DIFF
--- a/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.scss
+++ b/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.scss
@@ -226,6 +226,8 @@
             position: relative;
             z-index: 0;
             background: #fff;
+            content-visibility: auto;
+            contain-intrinsic-block-size: 34px;
         }
 
         ul {

--- a/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
+++ b/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
@@ -1439,7 +1439,7 @@ export class EntitySelector extends React.Component<EntitySelectorProps> {
                             name={entity.name}
                             type={this.isMultiMode ? "checkbox" : "radio"}
                             checked={this.isEntitySelected(entity)}
-                            bar={this.getBarConfigForEntity(entity)}
+                            {...this.getBarPropsForEntity(entity)}
                             onChange={this.onChange}
                             isLocal={entity.isLocal}
                             isMuted={this.isEntityMuted(entity.name)}
@@ -1463,7 +1463,7 @@ export class EntitySelector extends React.Component<EntitySelectorProps> {
                                 name={entity.name}
                                 type="radio"
                                 checked={this.isEntitySelected(entity)}
-                                bar={this.getBarConfigForEntity(entity)}
+                                {...this.getBarPropsForEntity(entity)}
                                 onChange={this.onChange}
                                 isLocal={entity.isLocal}
                                 isMuted={this.isEntityMuted(entity.name)}
@@ -1498,25 +1498,23 @@ export class EntitySelector extends React.Component<EntitySelectorProps> {
             .range([0, 1])
     }
 
-    private getBarConfigForEntity(
-        entity: SearchableEntity
-    ): BarConfig | undefined {
+    private getBarPropsForEntity(entity: SearchableEntity): BarProps {
         const { selectedSortColumn, barScale } = this
 
-        if (!selectedSortColumn) return undefined
+        if (!selectedSortColumn) return {}
 
         const value = entity.sortColumnValues[selectedSortColumn.slug]
 
-        if (!isFiniteWithGuard(value)) return { formattedValue: "No data" }
+        if (!isFiniteWithGuard(value)) return { barFormattedValue: "No data" }
 
-        const formattedValue =
+        const barFormattedValue =
             selectedSortColumn.formatValueShortWithAbbreviations(value)
 
-        if (value < 0) return { formattedValue, width: 0 }
+        if (value < 0) return { barFormattedValue, barWidth: 0 }
 
         return {
-            formattedValue,
-            width: R.clamp(barScale(value), { min: 0, max: 1 }),
+            barFormattedValue,
+            barWidth: R.clamp(barScale(value), { min: 0, max: 1 }),
         }
     }
 
@@ -1563,24 +1561,20 @@ export class EntitySelector extends React.Component<EntitySelectorProps> {
                         </Flipped>
                     )}
                     <ul>
-                        {selectedEntities.map((entity, entityIndex) => (
-                            <FlippedListItem
-                                index={entityIndex}
+                        {selectedEntities.map((entity) => (
+                            <SelectableEntityListItem
                                 key={entity.name}
                                 flipId={`selected_${makeSafeForCSS(
                                     entity.name
                                 )}`}
-                            >
-                                <SelectableEntity
-                                    name={entity.name}
-                                    type="checkbox"
-                                    checked={true}
-                                    bar={this.getBarConfigForEntity(entity)}
-                                    onChange={this.onChange}
-                                    isLocal={entity.isLocal}
-                                    isMuted={this.isEntityMuted(entity.name)}
-                                />
-                            </FlippedListItem>
+                                name={entity.name}
+                                type="checkbox"
+                                checked={true}
+                                {...this.getBarPropsForEntity(entity)}
+                                onChange={this.onChange}
+                                isLocal={entity.isLocal}
+                                isMuted={this.isEntityMuted(entity.name)}
+                            />
                         ))}
                     </ul>
                 </div>
@@ -1606,33 +1600,21 @@ export class EntitySelector extends React.Component<EntitySelectorProps> {
                         )}
 
                         <ul>
-                            {filteredAvailableEntities.map(
-                                (entity, entityIndex) => (
-                                    <FlippedListItem
-                                        index={entityIndex}
-                                        key={entity.name}
-                                        flipId={`available_${makeSafeForCSS(
-                                            entity.name
-                                        )}`}
-                                    >
-                                        <SelectableEntity
-                                            name={entity.name}
-                                            type="checkbox"
-                                            checked={this.isEntitySelected(
-                                                entity
-                                            )}
-                                            bar={this.getBarConfigForEntity(
-                                                entity
-                                            )}
-                                            onChange={this.onChange}
-                                            isLocal={entity.isLocal}
-                                            isMuted={this.isEntityMuted(
-                                                entity.name
-                                            )}
-                                        />
-                                    </FlippedListItem>
-                                )
-                            )}
+                            {filteredAvailableEntities.map((entity) => (
+                                <SelectableEntityListItem
+                                    key={entity.name}
+                                    flipId={`available_${makeSafeForCSS(
+                                        entity.name
+                                    )}`}
+                                    name={entity.name}
+                                    type="checkbox"
+                                    checked={this.isEntitySelected(entity)}
+                                    {...this.getBarPropsForEntity(entity)}
+                                    onChange={this.onChange}
+                                    isLocal={entity.isLocal}
+                                    isMuted={this.isEntityMuted(entity.name)}
+                                />
+                            ))}
                         </ul>
                     </div>
                 )}
@@ -1672,33 +1654,26 @@ export class EntitySelector extends React.Component<EntitySelectorProps> {
     }
 }
 
-type BarConfig = { formattedValue: string; width?: number }
+// Bar props are flattened into primitives (rather than a `bar` object) so that
+// the default `React.memo` shallow comparison works without a hand-written
+// equality function. A freshly-allocated object would fail reference equality
+// on every render and defeat memoization.
+interface BarProps {
+    barFormattedValue?: string
+    barWidth?: number
+}
 
-function SelectableEntity({
-    name,
-    checked,
-    type,
-    bar,
-    onChange,
-    isLocal,
-    isMuted,
-}: {
+interface SelectableEntityProps extends BarProps {
     name: string
     checked: boolean
     type: "checkbox" | "radio"
-    bar?: BarConfig
     onChange: (entityName: EntityName) => void
     isLocal?: boolean
     isMuted?: boolean
-}) {
-    const Input = {
-        checkbox: Checkbox,
-        radio: RadioButton,
-    }[type]
+}
 
-    const { name: displayName, suffix } = parseLabel(name)
-
-    const locationIcon = (
+function LocationIcon() {
+    return (
         <span className="location-icon">
             {/* Non-breaking space prevents the icon from wrapping to a new line alone */}
             {"\u00A0"}
@@ -1711,62 +1686,76 @@ function SelectableEntity({
             </Tippy>
         </span>
     )
+}
+
+const SelectableEntity = React.memo(function SelectableEntity({
+    name,
+    checked,
+    type,
+    barFormattedValue,
+    barWidth,
+    onChange,
+    isLocal,
+    isMuted,
+}: SelectableEntityProps) {
+    const Input = type === "checkbox" ? Checkbox : RadioButton
+    const { name: displayName, suffix } = parseLabel(name)
 
     const label = (
         <span>
             {displayName}
             {suffix && <span className="suffix"> ({suffix})</span>}
-            {isLocal && locationIcon}
+            {isLocal && <LocationIcon />}
         </span>
     )
 
     return (
         <div
             className={cx("selectable-entity", {
-                "selectable-entity--with-bar": bar && bar.width !== undefined,
+                "selectable-entity--with-bar": barWidth !== undefined,
                 "selectable-entity--muted": isMuted,
             })}
         >
-            {bar && bar.width !== undefined && (
-                <div className="bar" style={{ width: `${bar.width * 100}%` }} />
+            {barWidth !== undefined && (
+                <div className="bar" style={{ width: `${barWidth * 100}%` }} />
             )}
             <Input
                 label={label}
                 checked={checked}
                 onChange={() => onChange(name)}
             />
-            {bar && (
+            {barFormattedValue !== undefined && (
                 <span className="value grapher_label-1-regular">
-                    {bar.formattedValue}
+                    {barFormattedValue}
                 </span>
             )}
         </div>
     )
+})
+
+const flippedListItemSpring = { stiffness: 300, damping: 33 }
+
+type SelectableEntityListItemProps = SelectableEntityProps & {
+    flipId: string
 }
 
-function FlippedListItem({
+const SelectableEntityListItem = React.memo(function SelectableEntityListItem({
     flipId,
-    index = 0,
-    children,
-}: {
-    flipId: string
-    index?: number
-    children: React.ReactNode
-}) {
+    ...selectableEntityProps
+}: SelectableEntityListItemProps) {
     return (
         <Flipped
             flipId={flipId}
             translate
             opacity
-            spring={{
-                stiffness: Math.max(300 - index, 180),
-                damping: 33,
-            }}
+            spring={flippedListItemSpring}
         >
-            <li>{children}</li>
+            <li>
+                <SelectableEntity {...selectableEntityProps} />
+            </li>
         </Flipped>
     )
-}
+})
 
 function renderSortTriggerValue(
     option: SortDropdownOption | null

--- a/site/DataPageV2Content.tsx
+++ b/site/DataPageV2Content.tsx
@@ -19,7 +19,9 @@ import {
 } from "../settings/clientSettings.js"
 import AboutThisData from "./AboutThisData.js"
 import DataPageResearchAndWriting from "./DataPageResearchAndWriting.js"
-import { type DownloadSectionProps } from "./DownloadSection.js"
+import DownloadSection, {
+    type DownloadSectionProps,
+} from "./DownloadSection.js"
 import MetadataSection from "./MetadataSection.js"
 import { processRelatedResearch } from "./dataPage.js"
 import { GrapherWithFallback } from "./GrapherWithFallback.js"
@@ -35,6 +37,31 @@ declare global {
     }
 }
 export const OWID_DATAPAGE_CONTENT_ROOT_ID = "owid-datapageJson-root"
+
+type DataPageDownloadSectionProps = Pick<
+    DownloadSectionProps,
+    "archivedChartInfo" | "baseUrl" | "distribution" | "slug"
+>
+
+function DataPageDownloadSection({
+    archivedChartInfo,
+    baseUrl,
+    distribution,
+    slug,
+}: DataPageDownloadSectionProps) {
+    const reactiveQueryStr = useWindowQueryParams()
+    const searchParams = new URLSearchParams(reactiveQueryStr)
+
+    return (
+        <DownloadSection
+            slug={slug}
+            baseUrl={baseUrl}
+            searchParams={searchParams}
+            distribution={distribution}
+            archivedChartInfo={archivedChartInfo}
+        />
+    )
+}
 
 export const DataPageV2Content = ({
     datapageData,
@@ -52,7 +79,6 @@ export const DataPageV2Content = ({
     const slug = grapherConfig.slug
     const queryStr =
         typeof window !== "undefined" ? window?.location?.search : undefined
-    const reactiveQueryStr = useWindowQueryParams()
 
     // Initialize the grapher for client-side rendering
     const mergedGrapherConfig: GrapherProgrammaticInterface = useMemo(
@@ -84,27 +110,18 @@ export const DataPageV2Content = ({
         }
     }, [])
 
-    const downloadProps: DownloadSectionProps | undefined = useMemo(() => {
-        if (!slug) return undefined
-
-        // Note: yColumns is not passed here, which means the short column names
-        // option won't be visible in the download section on data pages.
-        //
-        // To enable this feature on data pages, we would need to:
-        // 1. Load variable metadata on the server to get column definitions with shortName
-        // 2. Pass that data through to this component (similar to how datapageData is passed)
-        // 3. Extract yColumns from the variable metadata and pass them here
-        //
-        // Without yColumns, users can still download data via the API URLs shown
-        // in the "Data API" section, where they can manually add
-        // &useColumnShortNames=true
-        return {
-            slug,
-            baseUrl: `${BAKED_GRAPHER_URL}/${slug}`,
-            searchParams: new URLSearchParams(reactiveQueryStr),
-            distribution,
-        }
-    }, [distribution, reactiveQueryStr, slug])
+    // Note: yColumns is not passed here, which means the short column names
+    // option won't be visible in the download section on data pages. To enable
+    // this feature, we'd need to load variable metadata on the server and pass
+    // the column definitions through to this component.
+    const downloadSection = slug ? (
+        <DataPageDownloadSection
+            slug={slug}
+            baseUrl={`${BAKED_GRAPHER_URL}/${slug}`}
+            distribution={distribution}
+            archivedChartInfo={archiveContext}
+        />
+    ) : undefined
 
     return (
         <AttachmentsContext.Provider
@@ -237,7 +254,7 @@ export const DataPageV2Content = ({
                         title={datapageData.title}
                         titleVariant={datapageData.titleVariant}
                         archiveContext={archiveContext}
-                        downloadProps={downloadProps}
+                        downloadSection={downloadSection}
                     />
                 </div>
             </DocumentContext.Provider>

--- a/site/MetadataSection.tsx
+++ b/site/MetadataSection.tsx
@@ -1,5 +1,6 @@
 import * as _ from "lodash-es"
 import dayjs from "dayjs"
+import { type ReactNode } from "react"
 
 import {
     DATAPAGE_SOURCES_AND_PROCESSING_SECTION_ID,
@@ -25,9 +26,6 @@ import {
     getPhraseForArchivalDate,
 } from "@ourworldindata/utils"
 import { ArticleBlocks } from "./gdocs/components/ArticleBlocks.js"
-import DownloadSection, {
-    type DownloadSectionProps,
-} from "./DownloadSection.js"
 
 export default function MetadataSection({
     attributionShort,
@@ -42,7 +40,7 @@ export default function MetadataSection({
     title,
     titleVariant,
     archiveContext,
-    downloadProps,
+    downloadSection,
 }: {
     attributionShort?: string
     attributions: string[]
@@ -56,7 +54,7 @@ export default function MetadataSection({
     title: IndicatorTitleWithFragments
     titleVariant?: string
     archiveContext?: ArchiveContext
-    downloadProps?: DownloadSectionProps
+    downloadSection?: ReactNode
 }) {
     const sourcesForDisplay = prepareSourcesForDisplay({ origins, source })
     const citationUrl = archiveContext?.archiveUrl ?? canonicalUrl
@@ -216,12 +214,7 @@ export default function MetadataSection({
                             </div>
                         </div>
                     )}
-                    {downloadProps && (
-                        <DownloadSection
-                            {...downloadProps}
-                            archivedChartInfo={archiveContext}
-                        />
-                    )}
+                    {downloadSection}
                 </div>
             </div>
         </div>

--- a/site/multiDim/MultiDimDataPageContent.tsx
+++ b/site/multiDim/MultiDimDataPageContent.tsx
@@ -36,6 +36,7 @@ import {
 import AboutThisData from "../AboutThisData.js"
 import TopicTags from "../TopicTags.js"
 import MetadataSection from "../MetadataSection.js"
+import DownloadSection from "../DownloadSection.js"
 import GrapherImage from "../GrapherImage.js"
 import { useMobxStateToReactState } from "../hooks.js"
 import { MultiDimSettingsPanel } from "./MultiDimDataPageSettingsPanel.js"
@@ -424,18 +425,19 @@ export function DataPageContent({
         !!grapherStateRef.current
     )
 
-    const downloadProps = slug
-        ? {
-              slug,
-              baseUrl: `${BAKED_GRAPHER_URL}/${slug}`,
-              searchParams: displayedSearchParams,
-              externalQueryParams: displayedSettings,
-              tableForDownload,
-              filteredTableForDownload,
-              yColumns,
-              hideRowCounts: !isClient,
-          }
-        : undefined
+    const downloadSection = slug ? (
+        <DownloadSection
+            slug={slug}
+            baseUrl={`${BAKED_GRAPHER_URL}/${slug}`}
+            searchParams={displayedSearchParams}
+            externalQueryParams={displayedSettings}
+            tableForDownload={tableForDownload}
+            filteredTableForDownload={filteredTableForDownload}
+            yColumns={yColumns}
+            hideRowCounts={!isClient}
+            archivedChartInfo={archiveContext}
+        />
+    ) : undefined
 
     return (
         <AttachmentsContext.Provider
@@ -543,7 +545,7 @@ export function DataPageContent({
                         title={varDatapageData.title}
                         titleVariant={varDatapageData.titleVariant}
                         archiveContext={archiveContext}
-                        downloadProps={downloadProps}
+                        downloadSection={downloadSection}
                     />
                 )}
             </div>


### PR DESCRIPTION
## Description

Reduce unnecessary re-renders in the entity selector and data page metadata section.

EntitySelector:
- Wrap SelectableEntity and the new SelectableEntityListItem in React.memo. Flatten the `bar` config object into primitive `barFormattedValue`/`barWidth` props so the default shallow comparison works without a custom equality function — a freshly allocated `bar` object would fail reference equality every render and defeat memoization.
- Inline FlippedListItem into SelectableEntityListItem and use a constant flip spring instead of an index-derived one, so list items no longer re-render when their index shifts.
- Add `content-visibility: auto` / `contain-intrinsic-block-size` to skip layout/paint for off-screen rows.

Data pages:
- Move the `useWindowQueryParams` subscription out of DataPageV2Content into a dedicated DataPageDownloadSection component, and pass a pre-rendered `downloadSection` node to MetadataSection instead of `downloadProps`. This keeps query-param changes from re-rendering the whole metadata section. MultiDimDataPageContent is updated to the same `downloadSection` prop.

## Testing

I tested the changes by comparing the performance reporting in Chrome Dev Tools between production and staging on http://staging-site-grapher-inp/grapher/life-expectancy using a 4x CPU slowdown. I switched between all tabs from left to right and then selected and unselected Germany on the bar tab. Table tab is still slow, but other interactions got faster.

| Prod | Staging |
|--------|--------|
| <img width="921" height="314" alt="image" src="https://github.com/user-attachments/assets/3e8e8811-3e8b-4be0-93ad-c08409dca886" /> | <img width="925" height="348" alt="image" src="https://github.com/user-attachments/assets/8f8d6f30-7235-45ca-8d4c-e891989d1476" /> |