### PR TITLE
Tweaks to the food-trade sankey diagram

### DIFF
--- a/bespoke/components/Sankey/BilateralFlowSankey.tsx
+++ b/bespoke/components/Sankey/BilateralFlowSankey.tsx
@@ -15,7 +15,6 @@ import {
     aggregateBySide,
     assignColors,
     DEFAULT_MAX_NODES,
-    DEFAULT_MIN_LINK_SHARE,
     DEFAULT_MIN_NODE_SHARE,
     getEntityFromNodeId,
     getEntityShortLabel,
@@ -34,7 +33,6 @@ interface BilateralFlowSankeyProps {
     height: number
     maxNodes?: number
     minNodeShare?: number
-    minLinkShare?: number
     getTooltip?: (args: BilateralTooltipArgs) => SankeyTooltip | undefined
     onSelectEntity?: (entity: string, side: LinkSide) => void
     formatValue: (value: number) => string
@@ -53,7 +51,6 @@ export function BilateralFlowSankey({
     height,
     maxNodes = DEFAULT_MAX_NODES,
     minNodeShare = DEFAULT_MIN_NODE_SHARE,
-    minLinkShare = DEFAULT_MIN_LINK_SHARE,
     getTooltip,
     onSelectEntity,
     formatValue,
@@ -64,10 +61,9 @@ export function BilateralFlowSankey({
                 flows,
                 maxNodes,
                 minNodeShare,
-                minLinkShare,
                 formatValue,
             }),
-        [flows, maxNodes, minNodeShare, minLinkShare, formatValue]
+        [flows, maxNodes, minNodeShare, formatValue]
     )
 
     const getEntityIdsFromNodes = (nodes: SankeyNode[]) =>
@@ -257,13 +253,11 @@ function buildBilateral({
     flows,
     maxNodes,
     minNodeShare,
-    minLinkShare,
     formatValue,
 }: {
     flows: Flow[]
     maxNodes: number
     minNodeShare: number
-    minLinkShare: number
     formatValue: (value: number) => string
 }): {
     sourceNodes: SankeyNode[]
@@ -307,16 +301,9 @@ function buildBilateral({
     }
 
     // Drop links below the floor
-    const positivePairs = Array.from(pairsByKey.values()).filter(
+    const visiblePairs = Array.from(pairsByKey.values()).filter(
         (p) => p.value > 0
     )
-    const filteredPairs = positivePairs.filter((p) => {
-        const involvesOther = p.source === OTHER_KEY || p.target === OTHER_KEY
-        if (involvesOther) return true
-        return p.value / total >= minLinkShare
-    })
-    const visiblePairs =
-        filteredPairs.length > 0 ? filteredPairs : positivePairs
 
     const sourceNodes = buildColumnNodes({
         selection: sourceSelection,

--- a/bespoke/components/Sankey/BilateralFlowSankey.tsx
+++ b/bespoke/components/Sankey/BilateralFlowSankey.tsx
@@ -36,6 +36,7 @@ interface BilateralFlowSankeyProps {
     getTooltip?: (args: BilateralTooltipArgs) => SankeyTooltip | undefined
     onSelectEntity?: (entity: string, side: LinkSide) => void
     formatValue: (value: number) => string
+    linkLowVolumeThreshold?: number
 }
 
 export type BilateralTooltipArgs = {
@@ -54,8 +55,9 @@ export function BilateralFlowSankey({
     getTooltip,
     onSelectEntity,
     formatValue,
+    linkLowVolumeThreshold,
 }: BilateralFlowSankeyProps) {
-    const { sourceNodes, targetNodes, links } = useMemo(
+    const { sourceNodes, targetNodes, links, totalFlowVolume } = useMemo(
         () =>
             buildBilateral({
                 flows,
@@ -170,6 +172,8 @@ export function BilateralFlowSankey({
             links={links}
             width={width}
             height={height}
+            totalFlowVolume={totalFlowVolume}
+            linkLowVolumeThreshold={linkLowVolumeThreshold}
             nodeColor={getNodeColor}
             linkColor={getLinkColor}
             getLinkTooltip={getLinkTooltip}
@@ -263,6 +267,7 @@ function buildBilateral({
     sourceNodes: SankeyNode[]
     targetNodes: SankeyNode[]
     links: SankeyLink[]
+    totalFlowVolume: number
 } {
     const sourceSelection = selectTopEntities({
         flows,
@@ -278,7 +283,13 @@ function buildBilateral({
     })
 
     const total = Math.max(sourceSelection.total, targetSelection.total)
-    if (total === 0) return { sourceNodes: [], targetNodes: [], links: [] }
+    if (total === 0)
+        return {
+            sourceNodes: [],
+            targetNodes: [],
+            links: [],
+            totalFlowVolume: 0,
+        }
 
     const topSources = new Set(sourceSelection.top.map((d) => d.entity))
     const topTargets = new Set(targetSelection.top.map((d) => d.entity))
@@ -339,7 +350,7 @@ function buildBilateral({
             return sourceIndexA - sourceIndexB
         })
 
-    return { sourceNodes, targetNodes, links }
+    return { sourceNodes, targetNodes, links, totalFlowVolume: total }
 }
 
 function buildColumnNodes({

--- a/bespoke/components/Sankey/Sankey.scss
+++ b/bespoke/components/Sankey/Sankey.scss
@@ -13,6 +13,10 @@
     cursor: default;
     pointer-events: none;
 
+    &.sankey__link--low-volume {
+        fill-opacity: 0.3;
+    }
+
     &.sankey__link--hovered,
     &.sankey__link--active {
         fill-opacity: 1;

--- a/bespoke/components/Sankey/Sankey.tsx
+++ b/bespoke/components/Sankey/Sankey.tsx
@@ -50,6 +50,8 @@ interface SankeyProps {
     links: SankeyLink[]
     width: number
     height: number
+    totalFlowVolume?: number
+    linkLowVolumeThreshold?: number
     nodeColor?: (node: SankeyNode) => string
     linkColor?: (link: SankeyLink) => string
     /** Outer padding around the whole visualization */
@@ -135,6 +137,8 @@ export function Sankey({
     links,
     width,
     height,
+    totalFlowVolume,
+    linkLowVolumeThreshold,
     nodeColor,
     linkColor,
     margin = DEFAULT_MARGIN,
@@ -485,6 +489,8 @@ export function Sankey({
                             linkColor={linkColor}
                             isHovered={hoveredLink === link}
                             isActive={activeLinks.has(link)}
+                            totalFlowVolume={totalFlowVolume}
+                            linkLowVolumeThreshold={linkLowVolumeThreshold}
                         />
                     ))}
                 </g>
@@ -538,20 +544,30 @@ function SankeyLink({
     linkColor,
     isHovered,
     isActive,
+    totalFlowVolume,
+    linkLowVolumeThreshold,
 }: {
     link: LaidOutLink
     linkColor?: (link: SankeyLink) => string
     isHovered?: boolean
     isActive?: boolean
+    totalFlowVolume?: number
+    linkLowVolumeThreshold?: number
 }): React.ReactElement | null {
     const path = makeSankeyRibbonPath(link)
     if (!path) return null
 
     const color = linkColor?.(toLinkData(link)) ?? GRAPHER_DENIM
 
+    const isLowVolume =
+        totalFlowVolume &&
+        linkLowVolumeThreshold &&
+        link.value / totalFlowVolume < linkLowVolumeThreshold
+
     const className = cx("sankey__link", {
         "sankey__link--hovered": isHovered,
         "sankey__link--active": isActive,
+        "sankey__link--low-volume": isLowVolume,
     })
 
     return <path className={className} d={path} fill={color} />

--- a/bespoke/components/Sankey/SankeyHelpers.ts
+++ b/bespoke/components/Sankey/SankeyHelpers.ts
@@ -23,7 +23,6 @@ export const DEFAULT_MAX_NODES_TO_SHRINK_OTHER = 10
 export const STACKED_MAX_NODES_TO_SHRINK_OTHER = 10
 /** Smallest share of the column total a node may have and still be drawn on its own */
 export const DEFAULT_MIN_NODE_SHARE = 0.01
-export const DEFAULT_MIN_LINK_SHARE = 0.01
 
 export const OTHER_KEY = "__other__"
 

--- a/bespoke/components/Sankey/SplitFlowSankey.tsx
+++ b/bespoke/components/Sankey/SplitFlowSankey.tsx
@@ -97,6 +97,7 @@ export type SankeyHalfTooltipArgs = {
 export type SankeyHalfBuild = {
     nodes: SankeyNode[]
     links: SankeyLink[]
+    totalFlowVolume: number
     /** Entities folded into this half's Other bucket */
     otherBreakdown?: EntityTotal[]
 }
@@ -129,6 +130,7 @@ interface SplitFlowSankeyProps {
      */
     colorMap?: Map<string, string>
     entitiesToSortLast?: string[]
+    linkLowVolumeThreshold?: number
 }
 
 export function SplitFlowSankey({
@@ -146,6 +148,7 @@ export function SplitFlowSankey({
     formatValue,
     colorMap: colorMapOverride,
     entitiesToSortLast,
+    linkLowVolumeThreshold,
 }: SplitFlowSankeyProps) {
     const showIncoming = view === "both" || view === "incoming"
     const showOutgoing = view === "both" || view === "outgoing"
@@ -348,6 +351,7 @@ export function SplitFlowSankey({
                         fontSettings={fontSettings}
                         nodeColor={getNodeColor}
                         linkColor={getLinkColor}
+                        linkLowVolumeThreshold={linkLowVolumeThreshold}
                     />
                 )}
                 {showOutgoing && (
@@ -362,6 +366,7 @@ export function SplitFlowSankey({
                         fontSettings={fontSettings}
                         nodeColor={getNodeColor}
                         linkColor={getLinkColor}
+                        linkLowVolumeThreshold={linkLowVolumeThreshold}
                     />
                 )}
             </div>
@@ -410,6 +415,7 @@ function SankeyHalfChart({
     fontSettings,
     nodeColor,
     linkColor,
+    linkLowVolumeThreshold,
 }: {
     direction: "incoming" | "outgoing"
     half: SankeyHalf
@@ -421,6 +427,7 @@ function SankeyHalfChart({
     fontSettings: FontSettings
     nodeColor: (node: SankeyNode) => string
     linkColor: (link: SankeyLink) => string
+    linkLowVolumeThreshold?: number
 }) {
     const innerMargin =
         direction === "incoming"
@@ -457,6 +464,8 @@ function SankeyHalfChart({
                             links={build.links}
                             width={width}
                             height={height}
+                            totalFlowVolume={build.totalFlowVolume}
+                            linkLowVolumeThreshold={linkLowVolumeThreshold}
                             nodeColor={nodeColor}
                             linkColor={linkColor}
                             innerMargin={innerMargin}
@@ -709,6 +718,7 @@ function buildSankeyHalf({
     return {
         nodes,
         links,
+        totalFlowVolume: selection.total,
         otherBreakdown: otherPartner ? selection.other : undefined,
     }
 }

--- a/bespoke/projects/food-trade/src/components/FoodTradeBilateralSankey.tsx
+++ b/bespoke/projects/food-trade/src/components/FoodTradeBilateralSankey.tsx
@@ -63,6 +63,7 @@ export function FoodTradeBilateralSankey({
                 flows={flows}
                 width={width}
                 height={height}
+                maxNodes={isNarrow ? 8 : 10} // show fewer nodes on mobile to avoid overcrowding
                 linkLowVolumeThreshold={BILATERAL_LOW_VOLUME_THRESHOLD}
                 formatValue={formatValue}
                 getTooltip={getTooltip}

--- a/bespoke/projects/food-trade/src/components/FoodTradeBilateralSankey.tsx
+++ b/bespoke/projects/food-trade/src/components/FoodTradeBilateralSankey.tsx
@@ -58,6 +58,7 @@ export function FoodTradeBilateralSankey({
                 flows={flows}
                 width={width}
                 height={height}
+                linkLowVolumeThreshold={0.01} // decrease opacity for flows below 1% of the total
                 formatValue={formatValue}
                 getTooltip={getTooltip}
                 onSelectEntity={handleSelectEntity}

--- a/bespoke/projects/food-trade/src/components/FoodTradeBilateralSankey.tsx
+++ b/bespoke/projects/food-trade/src/components/FoodTradeBilateralSankey.tsx
@@ -18,7 +18,12 @@ import {
 import { MOBILE_BREAKPOINT } from "../../../../components/Sankey/SplitFlowSankey.js"
 
 import { type TradeRow } from "../types.js"
-import { capItems, formatTrade, tradesToFlows } from "../helpers.js"
+import {
+    capItems,
+    formatTrade,
+    tradesToFlows,
+    BILATERAL_LOW_VOLUME_THRESHOLD,
+} from "../helpers.js"
 
 export function FoodTradeBilateralSankey({
     trades,
@@ -58,7 +63,7 @@ export function FoodTradeBilateralSankey({
                 flows={flows}
                 width={width}
                 height={height}
-                linkLowVolumeThreshold={0.01} // decrease opacity for flows below 1% of the total
+                linkLowVolumeThreshold={BILATERAL_LOW_VOLUME_THRESHOLD}
                 formatValue={formatValue}
                 getTooltip={getTooltip}
                 onSelectEntity={handleSelectEntity}

--- a/bespoke/projects/food-trade/src/components/FoodTradeChart.tsx
+++ b/bespoke/projects/food-trade/src/components/FoodTradeChart.tsx
@@ -6,8 +6,8 @@ import { articulateEntity } from "@ourworldindata/utils"
 
 import { Spinner } from "../../../../components/Spinner/Spinner.js"
 import { Flow } from "../config.js"
-import { ALL_COUNTRIES, isAllCountry } from "../helpers.js"
-import { ProductTradeData } from "../types.js"
+import { ALL_COUNTRIES } from "../helpers.js"
+import { ProductTradeData, Mode } from "../types.js"
 import { FoodTradeBilateralSankey } from "./FoodTradeBilateralSankey.js"
 import { FoodTradeSplitSankey } from "./FoodTradeSplitSankey.js"
 
@@ -17,6 +17,7 @@ export function FoodTradeChart({
     product,
     year,
     view,
+    mode,
     isLoading,
     hideFlowSwitcher,
     setCountry,
@@ -27,6 +28,7 @@ export function FoodTradeChart({
     product: string
     year: number
     view: Flow
+    mode: Mode
     isLoading?: boolean
     hideFlowSwitcher?: boolean
     setCountry: (value: string) => void
@@ -39,10 +41,6 @@ export function FoodTradeChart({
         incomingFlowsByCountry,
         outgoingFlowsByCountry,
     } = productData
-
-    const mode: "bilateral" | "split" = isAllCountry(country)
-        ? "bilateral"
-        : "split"
 
     const handleSelectEntity = useCallback(
         (entity: string, side: "exporter" | "importer") => {

--- a/bespoke/projects/food-trade/src/helpers.ts
+++ b/bespoke/projects/food-trade/src/helpers.ts
@@ -52,3 +52,6 @@ export function capItems<T>(items: T[]): { visible: T[]; hiddenCount: number } {
     const visible = showAll ? items : items.slice(0, 8)
     return { visible, hiddenCount: items.length - visible.length }
 }
+
+// decrease opacity for bilateral flows below 1% of the total
+export const BILATERAL_LOW_VOLUME_THRESHOLD = 0.01

--- a/bespoke/projects/food-trade/src/types.ts
+++ b/bespoke/projects/food-trade/src/types.ts
@@ -48,3 +48,5 @@ export type FoodTradeMetadata = {
     productByName: Map<string, Product>
     hasTradeData: (entityName: string, productName: string) => boolean
 }
+
+export type Mode = "bilateral" | "split"

--- a/bespoke/projects/food-trade/src/variants/SankeyVariant.tsx
+++ b/bespoke/projects/food-trade/src/variants/SankeyVariant.tsx
@@ -12,11 +12,16 @@ import { ChartHeader } from "../../../../components/ChartHeader/ChartHeader.js"
 import { ChartFooter } from "../../../../components/ChartFooter/ChartFooter.js"
 
 import { SankeyVariantConfig, Flow, VariantProps } from "../config.js"
-import { FoodTradeMetadata, ProductTradeData, TradeRow } from "../types.js"
+import { FoodTradeMetadata, ProductTradeData, Mode } from "../types.js"
 import { useFoodTradeMetadata, useProductTradeData } from "../data.js"
 import { FoodTradeControls } from "../components/FoodTradeControls.js"
 import { FoodTradeChart } from "../components/FoodTradeChart.js"
-import { ALL_COUNTRIES, formatTrade, isAllCountry } from "../helpers.js"
+import {
+    ALL_COUNTRIES,
+    formatTrade,
+    isAllCountry,
+    BILATERAL_LOW_VOLUME_THRESHOLD,
+} from "../helpers.js"
 import { useUrlState } from "../../../../hooks/useUrlState.js"
 import { useDelayedLoading } from "../../../../hooks/useDelayedLoading.js"
 import { useContainerWidth } from "../../../../hooks/useContainerWidth.js"
@@ -193,6 +198,16 @@ function CaptionedSankeyVariant({
     // as a placeholder
     const displayedProduct = productData.product
 
+    const mode = useMemo<Mode>(
+        () => (isAllCountry(country) ? "bilateral" : "split"),
+        [country]
+    )
+
+    const tradedTotal = useMemo(
+        () => R.sumBy(productData.flows, (d) => d.value),
+        [productData.flows]
+    )
+
     return (
         <>
             {!shouldHideChrome && (
@@ -227,7 +242,8 @@ function CaptionedSankeyVariant({
                     product={displayedProduct}
                     year={metadata.year}
                     view={view}
-                    flows={productData.flows}
+                    tradedTotal={tradedTotal}
+                    mode={mode}
                 />
                 <FoodTradeChart
                     productData={productData}
@@ -235,6 +251,7 @@ function CaptionedSankeyVariant({
                     product={displayedProduct}
                     year={metadata.year}
                     view={view}
+                    mode={mode}
                     isLoading={isLoading}
                     hideFlowSwitcher={config.hideFlowSwitcher}
                     setCountry={setCountry}
@@ -244,6 +261,8 @@ function CaptionedSankeyVariant({
                     source={metadata.source}
                     country={country}
                     view={view}
+                    tradedTotal={tradedTotal}
+                    mode={mode}
                 />
             </Frame>
         </>
@@ -256,20 +275,18 @@ function FoodTradeChartHeader({
     product,
     year,
     view,
-    flows,
+    mode,
+    tradedTotal,
 }: {
     config: SankeyVariantConfig
     country: string
     product: string
     year: number
     view: Flow
-    flows: TradeRow[]
+    mode: Mode
+    tradedTotal: number
 }) {
-    const mode: "bilateral" | "centered" = isAllCountry(country)
-        ? "bilateral"
-        : "centered"
-    const hasAnyTrade = flows.length > 0
-    const tradedTotal = useMemo(() => R.sumBy(flows, (d) => d.value), [flows])
+    const hasAnyTrade = tradedTotal > 0
 
     const defaultTitle =
         mode === "bilateral"
@@ -281,17 +298,17 @@ function FoodTradeChartHeader({
                 : `${product} trade through ${articulateEntity(country)} in ${year}`
 
     const defaultSubtitle: React.ReactNode =
-        mode === "centered" && view === "both" ? (
+        mode === "split" && view === "both" ? (
             <>
                 Imports and exports of {R.uncapitalize(product)}, as reported by
                 importing countries.
             </>
-        ) : mode === "centered" && view === "import" ? (
+        ) : mode === "split" && view === "import" ? (
             <>
                 {product} imported into {articulateEntity(country)}, as reported
                 by the importing country.
             </>
-        ) : mode === "centered" && view === "export" ? (
+        ) : mode === "split" && view === "export" ? (
             <>
                 {product} exported by {articulateEntity(country)}, as reported
                 by importing countries.
@@ -315,10 +332,14 @@ function FoodTradeChartFooter({
     source,
     country,
     view,
+    mode,
+    tradedTotal,
 }: {
     source: string
     country: string
     view: Flow
+    mode: Mode
+    tradedTotal: number
 }) {
     const topPartners =
         'Only the largest partners are shown; the rest are grouped as "Other".'
@@ -329,7 +350,17 @@ function FoodTradeChartFooter({
               ? "Figures reflect data reported by importing countries, which may differ from export records."
               : "Figures reflect trade reported by importers, which may differ from export records."
 
-    return <ChartFooter source={source} note={`${topPartners} ${reporting}`} />
+    const lowVolumeLinksTotal = tradedTotal * BILATERAL_LOW_VOLUME_THRESHOLD
+    const smallFlowsNote =
+        mode === "bilateral"
+            ? `Trade flows smaller than ${formatTrade(lowVolumeLinksTotal)} (${BILATERAL_LOW_VOLUME_THRESHOLD * 100}% of the total trade volume) are shown with reduced opacity.`
+            : ""
+
+    const note = [topPartners, reporting, smallFlowsNote]
+        .filter(Boolean)
+        .join(" ")
+
+    return <ChartFooter source={source} note={note} />
 }
 
 function FoodTradeSkeleton() {


### PR DESCRIPTION
- **enhance(bespoke-sankey): get rid of `minLinkShare`**
- **enhance(bespoke-sankey): fade small flows <1% in bilateral food trade**
- **enhance(bespoke-sankey): add footnote about low-opacity flows**
- **enhance(bespoke-sankey): show fewer nodes in bilateral sankey on mobile**
