### PR TITLE
🐛 fix entity selector in slideshow previews

### DIFF
--- a/site/slideshows/SiteSlideGrapher.tsx
+++ b/site/slideshows/SiteSlideGrapher.tsx
@@ -38,6 +38,8 @@ export function SiteSlideGrapher(props: {
         <div
             ref={containerRef}
             className={cx("slideshow-slide__grapher-container", {
+                "slideshow-slide__grapher-container--interactive":
+                    interactiveCharts,
                 "slideshow-slide__grapher-container--non-interactive":
                     !interactiveCharts,
             })}

--- a/site/slideshows/SlideContent.scss
+++ b/site/slideshows/SlideContent.scss
@@ -135,6 +135,22 @@ $s-lato-font-size: px-to-cqh(24);
     }
 }
 
+.slideshow-slide__grapher-container--interactive {
+    .CaptionedChart {
+        padding: 16px 0;
+        border: 1px solid $gray-10;
+        &:has(~ .side-panel) {
+            border-right: none;
+        }
+    }
+    .side-panel {
+        border: 1px solid $gray-10;
+    }
+    .drawer.active {
+        border: 1px solid $gray-10;
+    }
+}
+
 .slideshow-slide--cover {
     background-color: $oxford-blue;
     color: white;

--- a/site/slideshows/slideshowUtils.ts
+++ b/site/slideshows/slideshowUtils.ts
@@ -42,6 +42,7 @@ const minimalGrapherConfig: Partial<GrapherProgrammaticInterface> = {
     hideControlsRow: true,
     hideDownloadButton: true,
     hideExploreTheDataButton: true,
+    hideEntityControls: true,
 }
 
 /** Additional config when charts should be interactive */


### PR DESCRIPTION
Ensures that the entity selector remains hidden even on large screens when `interactiveCharts` is off, and adds a border to the Grapher when it's on.