### PR TITLE
🐛 Remove relic minTime:latest that breaks the line tab

### DIFF
--- a/db/migration/1782293706138-RemoveLatestMinTimeFromLineCharts.ts
+++ b/db/migration/1782293706138-RemoveLatestMinTimeFromLineCharts.ts
@@ -1,0 +1,42 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class RemoveLatestMinTimeFromLineCharts1782293706138
+    implements MigrationInterface
+{
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        // `minTime: "latest"` collapses the selected time range to a single
+        // year. That's a no-op for the map and discrete-bar tabs (they only
+        // ever render the end time), but it breaks the line and slope tabs,
+        // which render a time range: they show a single point instead of a
+        // line.
+        //
+        // Remove the relic `minTime: "latest"` from charts that have a line or
+        // slope tab reachable. We deliberately leave it in place for charts
+        // without a line/slope tab (e.g. scatter-only charts), where pinning to
+        // the latest year is intentional.
+        //
+        // Note: when `chartTypes` is absent, Grapher defaults to
+        // [LineChart, DiscreteBar], i.e. a line tab is reachable, so those
+        // charts are included too.
+        await queryRunner.query(`
+            -- sql
+            UPDATE chart_configs
+            SET
+                full = JSON_REMOVE(full, '$.minTime'),
+                patch = JSON_REMOVE(patch, '$.minTime')
+            WHERE
+                full ->> '$.minTime' = 'latest'
+                AND (
+                    full ->> '$.chartTypes' IS NULL
+                    OR JSON_CONTAINS(full -> '$.chartTypes', '"LineChart"')
+                    OR JSON_CONTAINS(full -> '$.chartTypes', '"SlopeChart"')
+                )
+        `)
+    }
+
+    public async down(): Promise<void> {
+        // No-op: we can't reliably distinguish charts that had
+        // `minTime: "latest"` removed by this migration from those that never
+        // had it, and restoring it would reintroduce the bug.
+    }
+}

--- a/db/migration/1782293706138-RemoveLatestMinTimeFromLineCharts.ts
+++ b/db/migration/1782293706138-RemoveLatestMinTimeFromLineCharts.ts
@@ -1,8 +1,6 @@
 import { MigrationInterface, QueryRunner } from "typeorm"
 
-export class RemoveLatestMinTimeFromLineCharts1782293706138
-    implements MigrationInterface
-{
+export class RemoveLatestMinTimeFromLineCharts1782293706138 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
         // `minTime: "latest"` collapses the selected time range to a single
         // year. That's a no-op for the map and discrete-bar tabs (they only

--- a/db/migration/1782293706138-RemoveLatestMinTimeFromLineCharts.ts
+++ b/db/migration/1782293706138-RemoveLatestMinTimeFromLineCharts.ts
@@ -4,18 +4,25 @@ export class RemoveLatestMinTimeFromLineCharts1782293706138 implements Migration
     public async up(queryRunner: QueryRunner): Promise<void> {
         // `minTime: "latest"` collapses the selected time range to a single
         // year. That's a no-op for the map and discrete-bar tabs (they only
-        // ever render the end time), but it breaks the line and slope tabs,
-        // which render a time range: they show a single point instead of a
-        // line.
+        // ever render the end time), but it breaks any tab that renders a time
+        // range — line, slope, and single-indicator dumbbell charts — which end
+        // up showing a single point instead of a line. The symptom is most
+        // visible wherever the range view is rendered directly, without a
+        // tab-switch (e.g. country profiles, `?tab=line` deep links), since the
+        // standalone UI silently expands the range when you switch tabs.
         //
-        // Remove the relic `minTime: "latest"` from charts that have a line or
-        // slope tab reachable. We deliberately leave it in place for charts
-        // without a line/slope tab (e.g. scatter-only charts), where pinning to
-        // the latest year is intentional.
+        // Remove the relic `minTime: "latest"` from charts that have such a tab
+        // reachable. We deliberately leave it in place for charts without one
+        // (e.g. scatter-only charts), where pinning to the latest year is
+        // intentional.
         //
-        // Note: when `chartTypes` is absent, Grapher defaults to
-        // [LineChart, DiscreteBar], i.e. a line tab is reachable, so those
-        // charts are included too.
+        // Notes:
+        // - When `chartTypes` is absent, Grapher defaults to
+        //   [LineChart, DiscreteBar], i.e. a line tab is reachable.
+        // - Dumbbell charts render a time range when plotting a single
+        //   indicator and a single time otherwise; removing `minTime` fixes the
+        //   former and is a no-op for the latter (single-time selection forces
+        //   start == end regardless), so it's safe to include all of them.
         await queryRunner.query(`
             -- sql
             UPDATE chart_configs
@@ -28,6 +35,7 @@ export class RemoveLatestMinTimeFromLineCharts1782293706138 implements Migration
                     full ->> '$.chartTypes' IS NULL
                     OR JSON_CONTAINS(full -> '$.chartTypes', '"LineChart"')
                     OR JSON_CONTAINS(full -> '$.chartTypes', '"SlopeChart"')
+                    OR JSON_CONTAINS(full -> '$.chartTypes', '"Dumbbell"')
                 )
         `)
     }


### PR DESCRIPTION
## See the problem

Open the Ghana health country profile: https://ourworldindata.org/profile/health/ghana — several charts there render as a **single dot for the latest year** instead of a line over time (e.g. the youth mortality and stunting charts).

The charts embedded in country profiles load their line view *directly*, with the stored config and no tab-switch. Those configs have `minTime: "latest"`, which pins the selected time range to a single year, so the line collapses to one point.

## Why it's mostly invisible on standalone charts

In the standalone interactive chart, switching tabs runs `ensureHandlesAreOnDifferentTimes`, which expands `[latest, latest]` to `earliest..latest` — so e.g. [fossil-fuels-per-capita](https://ourworldindata.org/grapher/fossil-fuels-per-capita?tab=line) looks fine. But any context that renders the line view *without* a user tab-switch keeps the collapsed range: country profiles, deep links like `?tab=line`, and thumbnail/embed renders.

`minTime: "latest"` is also a plain no-op for the map and discrete-bar tabs these charts default to — they only render the end year. It's a relic with no purpose on a chart that has a line tab.

## The fix

Remove `minTime: "latest"` from the **147** charts that have a reachable time-range tab — line, slope, or single-indicator dumbbell. The start handle falls back to `earliest`, so those views span the full range in every context; the map/bar default views are unchanged. Scatter-only charts keep it (pinning to the latest year is intentional there).

Data-only migration. `down()` is a no-op — we can't tell which charts originally had `minTime`, and restoring it would reintroduce the bug.

## ⚠️ Deployment step required

This migration edits `chart_configs` directly in the DB. Chart configs are served to Grapher from **R2** (`<slug>.config.json`), which is only refreshed via the admin API or a manual resync — **a raw SQL migration does not republish to R2.** Until R2 is resynced, the served config keeps `minTime: "latest"` and charts still render a single point (verified on branch staging: DB had `minTime` removed, but the served `.config.json` still showed `"latest"`).

**After the migration runs on master, run:**

```
yarn syncGraphersToR2
```

It diffs `fullMd5` (DB vs R2) and re-uploads only the changed configs. (If the production deploy already runs this after migrations, this is a no-op — but it didn't run on the branch staging, so please confirm.)

## Alternatives considered

There are three layers this could be fixed at; this PR is **A**.

- **A. Update the charts (this PR).** Fixes the bug in *every* context — country profiles, `?tab=line` deep links, embeds, thumbnails — since they all read the config. Safe (no-op for the map/bar default views). One-time fix, so a newly authored `minTime:latest` chart could reintroduce it.
- **B. Change country-profile logic** (e.g. append `time=earliest..latest` to embedded chart URLs). Rejected: it only fixes profiles and leaves every other direct-render surface broken — it special-cases a generic chart-rendering bug in the wrong layer.
- **C. Fix Grapher core** — expand a collapsed range on *initial load* of a range chart, the way `ensureHandlesAreOnDifferentTimes` already does on tab-switch (which is why standalone charts self-heal but profiles don't). This is the truest root fix and prevents recurrence, but it's a global behavior change that deserves its own carefully-tested PR. Worth a follow-up if recurrence becomes a concern (chart #9080 is recent, so authors still produce these).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
