### PR TITLE
Fix article excerpts in search

### DIFF
--- a/packages/@ourworldindata/types/src/domainTypes/Search.ts
+++ b/packages/@ourworldindata/types/src/domainTypes/Search.ts
@@ -193,7 +193,8 @@ export type FlatArticleHit = {
     date: string
     slug: string
     type: OwidGdocType.Article | OwidGdocType.AboutPage
-    content: string
+    content?: string
+    excerpt?: string
     authors: string[]
     objectID: string
     __position: number
@@ -204,7 +205,7 @@ export type StackedArticleHit = {
     thumbnailUrl: string
     slug: string
     type: OwidGdocType.Article | OwidGdocType.AboutPage
-    content: string
+    excerpt: string
     objectID: string
     __position: number
 }

--- a/site/search/SearchFlatArticleHit.tsx
+++ b/site/search/SearchFlatArticleHit.tsx
@@ -49,14 +49,20 @@ export function SearchFlatArticleHit({
                                 by {formatAuthors(hit.authors)} —{" "}
                             </span>
                         )}
-                        <Snippet
-                            classNames={{
-                                root: "search-flat-article-hit__excerpt",
-                            }}
-                            attribute="content"
-                            highlightedTagName="strong"
-                            hit={hit}
-                        />
+                        {hit.excerpt ? (
+                            <span className="search-flat-article-hit__excerpt">
+                                {hit.excerpt}
+                            </span>
+                        ) : (
+                            <Snippet
+                                classNames={{
+                                    root: "search-flat-article-hit__excerpt",
+                                }}
+                                attribute="content"
+                                highlightedTagName="strong"
+                                hit={hit}
+                            />
+                        )}
                     </div>
                 </div>
             </article>

--- a/site/search/SearchStackedArticleHit.tsx
+++ b/site/search/SearchStackedArticleHit.tsx
@@ -1,5 +1,4 @@
 import { getCanonicalPath } from "@ourworldindata/components"
-import { Snippet } from "react-instantsearch"
 import { StackedArticleHit } from "@ourworldindata/types"
 
 export function SearchStackedArticleHit({
@@ -27,14 +26,11 @@ export function SearchStackedArticleHit({
                 <h3 className="search-stacked-article-hit__title">
                     {hit.title}
                 </h3>
-                <Snippet
-                    classNames={{
-                        root: "search-stacked-article-hit__excerpt",
-                    }}
-                    attribute="content"
-                    highlightedTagName="strong"
-                    hit={hit}
-                />
+                {hit.excerpt && (
+                    <span className="search-stacked-article-hit__excerpt">
+                        {hit.excerpt}
+                    </span>
+                )}
             </article>
         </a>
     )

--- a/site/search/queries.ts
+++ b/site/search/queries.ts
@@ -255,6 +255,7 @@ export async function queryArticles(
     )
     const hasCountry = selectedCountryNames.size > 0
     const selectedTopics = getFilterNamesOfType(state.filters, FilterType.TOPIC)
+    const isFilterOnly = state.query.trim() === ""
     // Using the selected countries as query search terms until articles
     // are tagged with countries.
     const query = [
@@ -285,7 +286,7 @@ export async function queryArticles(
                 "date",
                 "slug",
                 "type",
-                "content",
+                isFilterOnly ? "excerpt" : "content",
                 "authors",
             ],
             highlightPreTag: "<mark>",
@@ -492,7 +493,7 @@ export async function queryWritingTopics(
                     "title",
                     "slug",
                     "thumbnailUrl",
-                    "content",
+                    "excerpt",
                     "type",
                 ],
                 filters: `type:${OwidGdocType.Article} OR type:${OwidGdocType.AboutPage}`,


### PR DESCRIPTION
Use the excerpt as defined in the gdoc when there is no search query, i.e. empty search or topic/country filters only.

This is how it was supposed to be the whole time, and somehow we realized only now. See [Slack](https://owid.slack.com/archives/C6C0MCXU0/p1782234703301219).