### PR TITLE
🎉 Add "topic-update" announcement type to /latest

### DIFF
--- a/packages/@ourworldindata/types/src/domainTypes/Latest.ts
+++ b/packages/@ourworldindata/types/src/domainTypes/Latest.ts
@@ -23,6 +23,7 @@ export const LATEST_TYPE_VALUES = [
     "data-insight",
     "article",
     "data-update",
+    "topic-update",
     "website-upgrade",
     "announcement",
 ] as const
@@ -33,6 +34,7 @@ export type LatestType = (typeof LATEST_TYPE_VALUES)[number]
 // so unrecognized kickers can't reach a published announcement.
 export const ANNOUNCEMENT_LATEST_TYPES = [
     "data-update",
+    "topic-update",
     "website-upgrade",
     "announcement",
 ] as const satisfies readonly LatestType[]
@@ -46,6 +48,7 @@ export const LATEST_TYPE_LABELS: Record<LatestType, string> = {
     "data-insight": "Data Insight",
     article: "Article",
     "data-update": "Data update",
+    "topic-update": "Topic update",
     "website-upgrade": "Website upgrade",
     announcement: "Announcement",
 }

--- a/site/latest/LatestHitMetadata.tsx
+++ b/site/latest/LatestHitMetadata.tsx
@@ -4,6 +4,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import {
     faArrowPointer,
     faBook,
+    faBookmark,
     faChartLine,
     faLightbulb,
     faNewspaper,
@@ -17,6 +18,7 @@ const LATEST_TYPE_ICONS: Record<LatestType, IconDefinition> = {
     article: faBook,
     "data-insight": faLightbulb,
     "data-update": faChartLine,
+    "topic-update": faBookmark,
     "website-upgrade": faArrowPointer,
     announcement: faNewspaper,
 }


### PR DESCRIPTION
## What

Adds a new `topic-update` announcement kicker type that surfaces as its own **"Topic update"** format on `/latest`, working exactly like the existing `data-update` and `website-upgrade` types.

An announcement gdoc with `kicker: topic-update` now:
- Appears under its own **"Topic updates"** entry in the `/latest` "Filter by type" dropdown
- Renders with the bookmark icon (`faBookmark`) — the same icon already used for the topic-pages count pill in search/homepage, so it's visually consistent
- Is accepted as a valid kicker at publish time

## How

The `/latest` type system is centralized in `Latest.ts`, so this is just constants plus the icon map:

- **`Latest.ts`** — added `"topic-update"` to `LATEST_TYPE_VALUES` (dropdown slot), `ANNOUNCEMENT_LATEST_TYPES` (valid publishable kicker + validation), and `LATEST_TYPE_LABELS` (`"Topic update"`; the dropdown plural auto-derives to "Topic updates")
- **`LatestHitMetadata.tsx`** — mapped `topic-update` → `faBookmark` in the icon record

Everything downstream — the dropdown rendering, publish-time validation in `GdocAnnouncement`, `deriveAnnouncementLatestType`, the Algolia indexer, the Zod record schema, and URL encode/decode — reads from these shared constants and needed no changes. The two `Record<LatestType, …>` maps (labels + icons) make the new value compiler-enforced.

## Go-live notes

- Editors enable it by writing `kicker: topic-update` in an announcement's Google Doc (the kicker field is read-only in the admin, as with the other types).
- The `/latest` Algolia chronological index needs a rebuild for the new bucket to appear.

## Testing

- `yarn typecheck` ✅
- `yarn testLintChanged` ✅
- `yarn testFormatChanged` ✅
- `latestUtils` unit tests 11/11 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)