### PR TITLE
🐝 🤖 Clean up tsconfig base options

### DIFF
--- a/devTools/tsconfigs/tsconfig.base.json
+++ b/devTools/tsconfigs/tsconfig.base.json
@@ -1,9 +1,8 @@
 {
     "extends": "@tsconfig/node24/tsconfig.json",
     "compilerOptions": {
-        "module": "commonjs",
+        "module": "preserve",
         "resolveJsonModule": true,
-        "forceConsistentCasingInFileNames": true,
         "composite": true,
 
         "declaration": true,
@@ -26,11 +25,8 @@
 
         "types": ["@testing-library/jest-dom"],
 
-        "alwaysStrict": true,
         "noImplicitReturns": true,
         "noUnusedLocals": true,
-        "allowJs": false,
-        "sourceMap": true,
         "moduleResolution": "bundler",
         "jsx": "react-jsx",
 

--- a/devTools/worker/README.md
+++ b/devTools/worker/README.md
@@ -29,11 +29,6 @@ npx tsx --tsconfig tsconfig.tsx.json devTools/worker/explorerJobsWorker.ts
 
 # Loop mode - continuous polling
 npx tsx --tsconfig tsconfig.tsx.json devTools/worker/explorerJobsWorker.ts --loop
-
-# Or compile and run
-yarn tsc --project devTools/worker/tsconfig.json
-node devTools/worker/dist/explorerJobsWorker.js
-node devTools/worker/dist/explorerJobsWorker.js --loop
 ```
 
 ### Production
@@ -52,13 +47,6 @@ pm2 start --interpreter="npx" --interpreter-args="tsx --tsconfig tsconfig.tsx.js
 ```bash
 # Long-running service with continuous polling
 pm2 start --interpreter="npx" --interpreter-args="tsx --tsconfig tsconfig.tsx.json" devTools/worker/explorerJobsWorker.ts --name "explorer-jobs-worker" -- --loop
-```
-
-#### Option 3: System Cron
-
-```bash
-# Add to crontab for periodic execution
-*/5 * * * * /usr/bin/node /path/to/explorerJobsWorker.js
 ```
 
 ## Configuration


### PR DESCRIPTION
Switch `module` from `commonjs` to `preserve` so it matches our `bundler` module resolution and the ESM reality of our toolchain — the emitted JS is never run (tsx and Vite consume the TS source directly), so the previous CommonJS setting was both inert and inconsistent.

Drop options that are redundant with the inherited `@tsconfig/node24` base or with current TS defaults:
- `sourceMap` — emitted .js.map files are never used; nothing runs or debugs the tsc output.
- `alwaysStrict` — implied by the base's `strict: true`.
- `forceConsistentCasingInFileNames`, `allowJs` — already the defaults.