### PR TITLE
Fix CommandPalette

### DIFF
--- a/packages/@ourworldindata/grapher/src/controls/CommandPalette.scss
+++ b/packages/@ourworldindata/grapher/src/controls/CommandPalette.scss
@@ -3,9 +3,9 @@
 $linkColor: #0645ad;
 
 .CommandPalette {
-    position: fixed;
-    top: 30px;
-    left: 30px;
+    position: absolute;
+    top: 16px;
+    left: 16px;
     font-size: 0.8em;
     background: white;
     z-index: 1000;

--- a/packages/@ourworldindata/grapher/src/controls/CommandPalette.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/CommandPalette.tsx
@@ -1,73 +1,47 @@
 import * as _ from "lodash-es"
-import { BodyPortal } from "@ourworldindata/components"
-import { observer } from "mobx-react"
 import * as React from "react"
 
-declare type keyboardCombo = string
-
 export interface Command {
-    combo: keyboardCombo
+    combo: string
     fn: () => void
     title?: string
     category?: string
 }
 
-const CommandPaletteClassName = "CommandPalette"
-
 interface CommandPaletteProps {
     commands: Command[]
-    display: "none" | "block"
 }
 
-@observer
-export class CommandPalette extends React.Component<CommandPaletteProps> {
-    static togglePalette(): void {
-        const element = document.getElementsByClassName(
-            CommandPaletteClassName
-        )[0] as HTMLElement
-        if (element)
-            element.style.display =
-                element.style.display === "none" ? "block" : "none"
-    }
-
-    override render(): React.ReactElement {
-        const style: any = {
-            display: this.props.display,
-        }
-        let lastCat = ""
-        const commands = this.props.commands.filter(
-            (command) => command.title && command.category
-        )
-        const sortedCommands = _.sortBy(commands, "category").map(
-            (command, index) => {
-                let cat = undefined
-                if (command.category !== lastCat) {
-                    lastCat = command.category!
-                    cat = <div className="commandCategory">{lastCat}</div>
-                }
-                return (
-                    <div key={`command${index}`}>
-                        {cat}
-                        <div className="commandOption">
-                            <span className="commandCombo">
-                                {command.combo}
-                            </span>
-                            <a onClick={(): void => command.fn()}>
-                                {command.title}
-                            </a>
-                        </div>
-                    </div>
-                )
+export function CommandPalette({
+    commands,
+}: CommandPaletteProps): React.ReactElement {
+    let lastCat = ""
+    const filteredCommands = commands.filter(
+        (command) => command.title && command.category
+    )
+    const sortedCommands = _.sortBy(filteredCommands, "category").map(
+        (command, index) => {
+            let cat = undefined
+            if (command.category !== lastCat) {
+                lastCat = command.category!
+                cat = <div className="commandCategory">{lastCat}</div>
             }
-        )
-
-        return (
-            <BodyPortal>
-                <div className={CommandPaletteClassName} style={style}>
-                    <div className="paletteTitle">Keyboard Shortcuts</div>
-                    {sortedCommands}
+            return (
+                <div key={`command${index}`}>
+                    {cat}
+                    <div className="commandOption">
+                        <span className="commandCombo">{command.combo}</span>
+                        <a onClick={command.fn}>{command.title}</a>
+                    </div>
                 </div>
-            </BodyPortal>
-        )
-    }
+            )
+        }
+    )
+
+    return (
+        <div className="CommandPalette">
+            <div className="paletteTitle">Keyboard Shortcuts</div>
+            {sortedCommands}
+        </div>
+    )
 }

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -221,9 +221,15 @@ export class Grapher extends React.Component<GrapherProps> {
     }
 
     private get commandPalette(): React.ReactElement | null {
-        return this.props.grapherState.enableKeyboardShortcuts ? (
-            <CommandPalette commands={this.keyboardShortcuts} display="none" />
+        if (!this.props.grapherState.enableKeyboardShortcuts) return null
+        return this.grapherState.isCommandPaletteOpen ? (
+            <CommandPalette commands={this.keyboardShortcuts} />
         ) : null
+    }
+
+    @action.bound private toggleCommandPalette(): void {
+        this.grapherState.isCommandPaletteOpen =
+            !this.grapherState.isCommandPaletteOpen
     }
 
     @action.bound private toggleTabCommand(): void {
@@ -234,6 +240,37 @@ export class Grapher extends React.Component<GrapherProps> {
 
     @action.bound private togglePlayingCommand(): void {
         void this.grapherState.timelineController.togglePlay()
+    }
+
+    @action.bound private toggleSelectAllCommand(): void {
+        if (this.grapherState.selection.hasSelection) {
+            this.grapherState.selection.clearSelection()
+            this.grapherState.focusArray.clear()
+        } else {
+            this.grapherState.selection.setSelectedEntities(
+                this.grapherState.availableEntityNames
+            )
+        }
+    }
+
+    @action.bound private toggleFacetingCommand(): void {
+        this.grapherState.hideFacetControl = !this.grapherState.hideFacetControl
+    }
+
+    @action.bound private toggleSourcesModalCommand(): void {
+        const isSourcesModalOpen =
+            this.grapherState.activeModal === GrapherModal.Sources
+        this.grapherState.activeModal = isSourcesModalOpen
+            ? undefined
+            : GrapherModal.Sources
+    }
+
+    @action.bound private toggleDownloadModalCommand(): void {
+        const isDownloadModalOpen =
+            this.grapherState.activeModal === GrapherModal.Download
+        this.grapherState.activeModal = isDownloadModalOpen
+            ? undefined
+            : GrapherModal.Download
     }
 
     private get keyboardShortcuts(): Command[] {
@@ -247,28 +284,19 @@ export class Grapher extends React.Component<GrapherProps> {
             ...temporaryFacetTestCommands,
             {
                 combo: "t",
-                fn: (): void => this.toggleTabCommand(),
+                fn: this.toggleTabCommand,
                 title: "Toggle tab",
                 category: "Navigation",
             },
             {
                 combo: "?",
-                fn: (): void => CommandPalette.togglePalette(),
+                fn: this.toggleCommandPalette,
                 title: `Toggle Help`,
                 category: "Navigation",
             },
             {
                 combo: "a",
-                fn: (): void => {
-                    if (this.grapherState.selection.hasSelection) {
-                        this.grapherState.selection.clearSelection()
-                        this.grapherState.focusArray.clear()
-                    } else {
-                        this.grapherState.selection.setSelectedEntities(
-                            this.grapherState.availableEntityNames
-                        )
-                    }
-                },
+                fn: this.toggleSelectAllCommand,
                 title: this.grapherState.selection.hasSelection
                     ? `Select None`
                     : `Select All`,
@@ -276,16 +304,13 @@ export class Grapher extends React.Component<GrapherProps> {
             },
             {
                 combo: "f",
-                fn: (): void => {
-                    this.grapherState.hideFacetControl =
-                        !this.grapherState.hideFacetControl
-                },
+                fn: this.toggleFacetingCommand,
                 title: `Toggle Faceting`,
                 category: "Chart",
             },
             {
                 combo: "p",
-                fn: (): void => this.togglePlayingCommand(),
+                fn: this.togglePlayingCommand,
                 title: this.grapherState.isTimelineAnimationPlaying
                     ? `Pause`
                     : `Play`,
@@ -293,56 +318,44 @@ export class Grapher extends React.Component<GrapherProps> {
             },
             {
                 combo: "l",
-                fn: (): void => this.toggleYScaleTypeCommand(),
+                fn: this.toggleYScaleTypeCommand,
                 title: "Toggle Y log/linear",
                 category: "Chart",
             },
             {
                 combo: "w",
-                fn: (): void => this.toggleFullScreenMode(),
+                fn: this.toggleFullScreenMode,
                 title: `Toggle full-screen mode`,
                 category: "Chart",
             },
             {
                 combo: "s",
-                fn: (): void => {
-                    const isSourcesModalOpen =
-                        this.grapherState.activeModal === GrapherModal.Sources
-                    this.grapherState.activeModal = isSourcesModalOpen
-                        ? undefined
-                        : GrapherModal.Sources
-                },
+                fn: this.toggleSourcesModalCommand,
                 title: `Toggle sources modal`,
                 category: "Chart",
             },
             {
                 combo: "d",
-                fn: (): void => {
-                    const isDownloadModalOpen =
-                        this.grapherState.activeModal === GrapherModal.Download
-                    this.grapherState.activeModal = isDownloadModalOpen
-                        ? undefined
-                        : GrapherModal.Download
-                },
+                fn: this.toggleDownloadModalCommand,
                 title: "Toggle download modal",
                 category: "Chart",
             },
-            { combo: "esc", fn: (): void => this.clearErrors() },
+            { combo: "esc", fn: this.clearErrors },
             {
                 combo: "z",
-                fn: (): void => this.toggleTimelineCommand(),
+                fn: this.toggleTimelineCommand,
                 title: "Latest/Earliest/All period",
                 category: "Timeline",
             },
             {
                 combo: "shift+o",
-                fn: (): void => this.grapherState.clearQueryParams(),
+                fn: this.grapherState.clearQueryParams,
                 title: "Reset to original",
                 category: "Navigation",
             },
             {
                 combo: "g",
-                fn: (): void => this.grapherState.globeController.toggleGlobe(),
+                fn: this.grapherState.globeController.toggleGlobe,
                 title: "Toggle globe view",
                 category: "Map",
             },
@@ -352,13 +365,13 @@ export class Grapher extends React.Component<GrapherProps> {
             const slideShow = this.grapherState.slideShow
             shortcuts.push({
                 combo: "right",
-                fn: () => slideShow.playNext(),
+                fn: slideShow.playNext,
                 title: "Next chart",
                 category: "Browse",
             })
             shortcuts.push({
                 combo: "left",
-                fn: () => slideShow.playPrevious(),
+                fn: slideShow.playPrevious,
                 title: "Previous chart",
                 category: "Browse",
             })

--- a/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
@@ -560,6 +560,7 @@ export class GrapherState
     activeModal?: GrapherModal
     activeDownloadModalTab: DownloadModalTabName = DownloadModalTabName.Vis
     isShareMenuActive = false
+    isCommandPaletteOpen = false
 
     isTimelineAnimationPlaying = false
     /** True if the timeline animation is either playing or paused but not finished */
@@ -733,6 +734,7 @@ export class GrapherState
             slideShow: observable,
             _baseFontSize: observable,
             isShareMenuActive: observable,
+            isCommandPaletteOpen: observable,
             hideTitle: observable,
             hideSubtitle: observable,
             hideNote: observable,


### PR DESCRIPTION
- Fix styling: it rendered unstyled at the bottom of the page because the SCSS is scoped to `.GrapherComponent`. Since we use it only on standalone Grapher pages, it can render inside Grapher instead.
- Convert it to a plain function component.
- Replace imperative toggle with React state.
- Ensure all commands run in a MobX action.