### PR TITLE
🐛 fix slideshow links

### DIFF
--- a/packages/@ourworldindata/components/src/SimpleMarkdownText.tsx
+++ b/packages/@ourworldindata/components/src/SimpleMarkdownText.tsx
@@ -11,6 +11,7 @@ import type { Root, ElementContent } from "hast"
 type SimpleMarkdownTextProps = {
     text: string
     useParagraphs?: boolean // by default, text is wrapped in <p> tags
+    openLinksInNewTab?: boolean // by default, links open in the same tab
 }
 
 const transformDodLinks: Plugin<[], Root> = () => {
@@ -99,16 +100,24 @@ export class SimpleMarkdownText extends React.Component<SimpleMarkdownTextProps>
     }
 
     get markdownCustomComponents(): MarkdownComponents | undefined {
+        const components: MarkdownComponents = {}
+
         if (!this.useParagraphs) {
             // "unwrap" the text by rendering <p /> as a react fragment
-            return {
-                p: ({ children }) => (
-                    <React.Fragment>{children}</React.Fragment>
-                ),
-            }
+            components.p = ({ children }) => (
+                <React.Fragment>{children}</React.Fragment>
+            )
         }
 
-        return undefined
+        if (this.props.openLinksInNewTab) {
+            components.a = ({ children, ...props }) => (
+                <a {...props} target="_blank">
+                    {children}
+                </a>
+            )
+        }
+
+        return Object.keys(components).length > 0 ? components : undefined
     }
 
     override render(): React.ReactElement | null {

--- a/site/slideshows/SlideRenderer.tsx
+++ b/site/slideshows/SlideRenderer.tsx
@@ -43,6 +43,7 @@ export function SlideRenderer(props: {
                         {slide.subtitle && (
                             <span>
                                 <SimpleMarkdownText
+                                    openLinksInNewTab
                                     text={slide.subtitle}
                                     useParagraphs={false}
                                 />
@@ -53,6 +54,7 @@ export function SlideRenderer(props: {
                 )}
                 <h1 className="cover-title">
                     <SimpleMarkdownText
+                        openLinksInNewTab
                         text={slide.title}
                         useParagraphs={false}
                     />
@@ -68,6 +70,7 @@ export function SlideRenderer(props: {
                 {slide.slideTitle && (
                     <h1 className="slideshow-slide-title">
                         <SimpleMarkdownText
+                            openLinksInNewTab
                             text={slide.slideTitle}
                             useParagraphs={false}
                         />
@@ -84,7 +87,10 @@ export function SlideRenderer(props: {
                                 "slideshow-slide__text--large": slide.largeText,
                             })}
                         >
-                            <SimpleMarkdownText text={slide.text} />
+                            <SimpleMarkdownText
+                                text={slide.text}
+                                openLinksInNewTab
+                            />
                         </div>
                     )}
                 </div>
@@ -96,6 +102,7 @@ export function SlideRenderer(props: {
                 {slide.title && (
                     <h1 className="slideshow-slide-title">
                         <SimpleMarkdownText
+                            openLinksInNewTab
                             text={slide.title}
                             useParagraphs={false}
                         />
@@ -104,6 +111,7 @@ export function SlideRenderer(props: {
                 {slide.subtitle && (
                     <p className="slideshow-slide-subtitle">
                         <SimpleMarkdownText
+                            openLinksInNewTab
                             text={slide.subtitle}
                             useParagraphs={false}
                         />
@@ -126,7 +134,10 @@ export function SlideRenderer(props: {
                                 "slideshow-slide__text--large": slide.largeText,
                             })}
                         >
-                            <SimpleMarkdownText text={slide.text} />
+                            <SimpleMarkdownText
+                                text={slide.text}
+                                openLinksInNewTab
+                            />
                         </div>
                     )}
                 </div>
@@ -138,13 +149,14 @@ export function SlideRenderer(props: {
                 {slide.title && (
                     <h1 className="slideshow-slide-title">
                         <SimpleMarkdownText
+                            openLinksInNewTab
                             text={slide.title}
                             useParagraphs={false}
                         />
                     </h1>
                 )}
                 <div className="slideshow-slide-contents__list">
-                    <SimpleMarkdownText text={slide.text} />
+                    <SimpleMarkdownText text={slide.text} openLinksInNewTab />
                 </div>
             </div>
         ))
@@ -153,6 +165,7 @@ export function SlideRenderer(props: {
                 {!slide.hideLogo && <SlideLogo />}
                 <h1 className="slideshow-slide-statement__text">
                     <SimpleMarkdownText
+                        openLinksInNewTab
                         text={slide.text}
                         useParagraphs={false}
                     />
@@ -170,6 +183,7 @@ export function SlideRenderer(props: {
                 {slide.title && (
                     <h1 className="slideshow-slide-title">
                         <SimpleMarkdownText
+                            openLinksInNewTab
                             text={slide.title}
                             useParagraphs={false}
                         />
@@ -180,7 +194,7 @@ export function SlideRenderer(props: {
                         "slideshow-slide__text-body--large": slide.largeText,
                     })}
                 >
-                    <SimpleMarkdownText text={slide.text} />
+                    <SimpleMarkdownText text={slide.text} openLinksInNewTab />
                 </div>
             </div>
         ))
@@ -190,6 +204,7 @@ export function SlideRenderer(props: {
                 {slide.title && (
                     <h1 className="slideshow-slide-title">
                         <SimpleMarkdownText
+                            openLinksInNewTab
                             text={slide.title}
                             useParagraphs={false}
                         />
@@ -198,6 +213,7 @@ export function SlideRenderer(props: {
                 {slide.subtitle && (
                     <p className="slideshow-slide-subtitle">
                         <SimpleMarkdownText
+                            openLinksInNewTab
                             text={slide.subtitle}
                             useParagraphs={false}
                         />


### PR DESCRIPTION
Makes sure links open in a new tab for slideshows, so that in article iframe embeds, we don't open new pages within the iframe.