### PR TITLE
🎉 🤖 Add "Download SVG" button to bespoke demo pages

### DIFF
--- a/bespoke/server/component-demo.css
+++ b/bespoke/server/component-demo.css
@@ -20,6 +20,8 @@ body {
 }
 
 .variant-label {
+    display: flex;
+    align-items: center;
     font-size: 0.75rem;
     text-transform: uppercase;
     letter-spacing: 0.05em;
@@ -37,6 +39,25 @@ body {
 .variant-label-name {
     font-weight: 600;
     color: #555;
+}
+
+.variant-download {
+    font-family: inherit;
+    font-size: 0.6875rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-left: auto;
+    padding: 2px 8px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    background: #fff;
+    color: #555;
+    cursor: pointer;
+}
+
+.variant-download:hover {
+    border-color: #999;
+    color: #1d1d1d;
 }
 
 .demo-error-message {

--- a/bespoke/server/component-demo.html
+++ b/bespoke/server/component-demo.html
@@ -16,6 +16,7 @@
         <script type="module">
             import * as ComponentModule from "/{{PROJECT}}/{{ENTRYPOINT_JS}}"
             import { mountBespokeComponentInShadow } from "/__bespoke/shared/bespokeComponentShadowDom.ts"
+            import { downloadSvg } from "/__bespoke/shared/exportSvg.ts"
 
             const SIZE_CLASSES = {
                 narrow: "col-start-5 span-cols-6 col-md-start-3 span-md-cols-10 span-sm-cols-12 col-sm-start-2",
@@ -50,6 +51,22 @@
                     name.textContent = variant.name
                     label.appendChild(prefix)
                     label.appendChild(name)
+
+                    const container = document.createElement("div")
+
+                    const downloadButton = document.createElement("button")
+                    downloadButton.className = "variant-download"
+                    downloadButton.type = "button"
+                    downloadButton.textContent = "Download SVG"
+                    downloadButton.addEventListener("click", () => {
+                        const shadowRoot = container.shadowRoot
+                        if (!shadowRoot) return
+                        downloadSvg(
+                            shadowRoot,
+                            `{{PROJECT}}-${variant.name}.svg`
+                        )
+                    })
+                    label.appendChild(downloadButton)
                     wrapper.appendChild(label)
 
                     const gridContainer = document.createElement("div")
@@ -58,7 +75,6 @@
                     const gridCell = document.createElement("div")
                     gridCell.className = SIZE_CLASSES[size] ?? SIZE_CLASSES.wide
 
-                    const container = document.createElement("div")
                     gridCell.appendChild(container)
                     gridContainer.appendChild(gridCell)
                     wrapper.appendChild(gridContainer)

--- a/bespoke/shared/exportSvg.ts
+++ b/bespoke/shared/exportSvg.ts
@@ -1,0 +1,103 @@
+/** Export a bespoke viz as a standalone SVG */
+
+// Paint and text properties to inline so the SVG is self-contained
+const STYLE_PROPS = [
+    "fill",
+    "fill-opacity",
+    "fill-rule",
+    "stroke",
+    "stroke-width",
+    "stroke-opacity",
+    "stroke-linecap",
+    "stroke-linejoin",
+    "stroke-dasharray",
+    "stroke-dashoffset",
+    "stroke-miterlimit",
+    "opacity",
+    "color",
+    "visibility",
+    "mix-blend-mode",
+    "paint-order",
+    "font-family",
+    "font-size",
+    "font-weight",
+    "font-style",
+    "font-variant",
+    "letter-spacing",
+    "word-spacing",
+    "text-anchor",
+    "text-decoration",
+    "dominant-baseline",
+    "alignment-baseline",
+]
+
+const renderedArea = (el: Element): number => {
+    const rect = el.getBoundingClientRect()
+    return rect.width * rect.height
+}
+
+/** Find the largest <svg> by rendered area, descending into shadow roots. */
+function findLargestSvg(root: ParentNode): SVGSVGElement | undefined {
+    const svgs: SVGSVGElement[] = []
+    const collect = (node: ParentNode): void => {
+        for (const el of node.querySelectorAll("*")) {
+            if (el instanceof SVGSVGElement) svgs.push(el)
+            if (el.shadowRoot) collect(el.shadowRoot)
+        }
+    }
+    collect(root)
+    return svgs.sort((a, b) => renderedArea(b) - renderedArea(a))[0]
+}
+
+/** Clone an SVG with its computed styles inlined so it stands on its own. */
+function serializeStandaloneSvg(source: SVGSVGElement): string {
+    const clone = source.cloneNode(true) as SVGSVGElement
+
+    // Walk source and clone in lockstep. Iterate back-to-front so removing a
+    // hidden node doesn't shift the indices of nodes we've yet to visit.
+    const sourceNodes = [source, ...source.querySelectorAll("*")]
+    const cloneNodes = [clone, ...clone.querySelectorAll("*")]
+    for (let i = sourceNodes.length - 1; i >= 0; i--) {
+        const dest = cloneNodes[i]
+        if (!(dest instanceof SVGElement)) continue
+        const style = getComputedStyle(sourceNodes[i])
+        if (style.display === "none") {
+            dest.remove() // drop hover tooltips, inactive states, etc.
+            continue
+        }
+        let inline = dest.getAttribute("style") ?? ""
+        for (const prop of STYLE_PROPS) {
+            const value = style.getPropertyValue(prop)
+            if (value && value !== "normal" && value !== "auto") {
+                inline += `${prop}:${value};`
+            }
+        }
+        if (inline) dest.setAttribute("style", inline)
+    }
+
+    clone.setAttribute("xmlns", "http://www.w3.org/2000/svg")
+    if (!clone.getAttribute("viewBox")) {
+        const rect = source.getBoundingClientRect()
+        clone.setAttribute("viewBox", `0 0 ${rect.width} ${rect.height}`)
+    }
+
+    return new XMLSerializer().serializeToString(clone)
+}
+
+/** Find the largest viz SVG under `root` and download it as a standalone file. */
+export function downloadSvg(root: ParentNode, filename: string): void {
+    const svg = findLargestSvg(root)
+    if (!svg) {
+        console.error("downloadSvg: no <svg> found under the given root.")
+        return
+    }
+    const blob = new Blob([serializeStandaloneSvg(svg)], {
+        type: "image/svg+xml",
+    })
+    const url = URL.createObjectURL(blob)
+    const link = document.createElement("a")
+    link.href = url
+    link.download = filename
+    link.click()
+    URL.revokeObjectURL(url)
+}


### PR DESCRIPTION
Adds a 'Download SVG' button to bespoke demo pages (see the upper right corner in the screenshot):

<img width="1338" height="474" alt="Screenshot 2026-06-29 at 13 57 51" src="https://github.com/user-attachments/assets/fb35be82-7e5d-4974-b382-04795e16039f" />

A few caveats:
- The snippet exports the largest svg available (if the viz is composed of multiple SVGs, like Sankeys on mobile, only the bigger one is downloaded)
- The snipper only exports SVG, and not html elements like the header or footer, or annotations outside of the svg