### PR TITLE
✨ (bespoke sankey) avoid scrolling tooltips

### DIFF
--- a/bespoke/projects/food-trade/src/variants/SankeyVariant.scss
+++ b/bespoke/projects/food-trade/src/variants/SankeyVariant.scss
@@ -50,3 +50,7 @@
 .food-trade-chart--narrow .food-trade-captioned-chart__chart-area {
     height: 380px;
 }
+
+.food-trade-chart .tooltip-container.fixed-bottom .content-and-endmatter {
+    max-height: min(230px, 35vh);
+}

--- a/bespoke/projects/migration/src/variants/SankeyVariant.scss
+++ b/bespoke/projects/migration/src/variants/SankeyVariant.scss
@@ -54,3 +54,7 @@
     padding: 24px;
     color: $error-text-color;
 }
+
+.migration-chart .tooltip-container.fixed-bottom .content-and-endmatter {
+    max-height: min(230px, 35vh);
+}


### PR DESCRIPTION
Make the tooltip a bit larger to avoid the content to be scrollable.