### PR TITLE
feat: include h2 in the sidebar toc

### DIFF
--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -48,6 +48,9 @@ import {
     FEATURED_DATA_INSIGHTS_ID,
     EXPLORE_DATA_SECTION_DEFAULT_TITLE,
     EXPLORE_DATA_SECTION_ID,
+    FEATURED_METRICS_ID,
+    RESEARCH_AND_WRITING_ID,
+    RESEARCH_AND_WRITING_DEFAULT_HEADING,
     CHRONOLOGICAL_INDEX_TYPES,
     LATEST_FEED_TYPES,
 } from "@ourworldindata/types"
@@ -1853,6 +1856,10 @@ export function spansToUnformattedPlainText(spans: Span[]): string {
         .join("")
 }
 
+export function getResearchAndWritingId(heading?: string): string {
+    return heading ? slugify(heading) : RESEARCH_AND_WRITING_ID
+}
+
 export function generateToc(
     body: OwidEnrichedGdocBlock[] | undefined,
     isTocForSidebar: boolean = false
@@ -1886,8 +1893,27 @@ export function generateToc(
 
             if (child.type === "all-charts") {
                 toc.push({
-                    title: child.heading,
+                    title: "Key charts",
                     slug: ALL_CHARTS_ID,
+                    isSubheading: false,
+                })
+                return
+            }
+
+            if (child.type === "featured-metrics") {
+                toc.push({
+                    title: "Featured data",
+                    slug: FEATURED_METRICS_ID,
+                    isSubheading: false,
+                })
+                return
+            }
+
+            if (child.type === "research-and-writing") {
+                const { heading } = child
+                toc.push({
+                    title: heading || RESEARCH_AND_WRITING_DEFAULT_HEADING,
+                    slug: getResearchAndWritingId(heading),
                     isSubheading: false,
                 })
                 return

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -1859,10 +1859,10 @@ export function generateToc(
 ): TocHeadingWithSupertitle[] {
     if (!body) return []
 
-    // For linear topic pages, we record only h1s
+    // For linear topic pages, we record h1s and h2s
     // For the sdg-toc, we record h2s & h3s (as it was developed before we decided to use h1s as our top level heading)
     // It would be nice to standardise this but it would require a migration, updating CSS, updating Gdocs, etc.
-    const [primary, secondary] = isTocForSidebar ? [1, undefined] : [2, 3]
+    const [primary, secondary] = isTocForSidebar ? [1, 2] : [2, 3]
     const toc: TocHeadingWithSupertitle[] = []
 
     body.forEach((block) =>

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -94,6 +94,7 @@ export {
     traverseEnrichedBlock,
     checkNodeIsSpan,
     generateToc,
+    getResearchAndWritingId,
     extractLinksFromMarkdown,
     getPaginationPageNumbers,
     spansToUnformattedPlainText,

--- a/site/gdocs/components/ResearchAndWriting.tsx
+++ b/site/gdocs/components/ResearchAndWriting.tsx
@@ -3,10 +3,9 @@ import cx from "clsx"
 import {
     EnrichedBlockResearchAndWriting,
     EnrichedBlockResearchAndWritingLink,
-    RESEARCH_AND_WRITING_ID,
     formatAuthors,
     formatDate,
-    slugify,
+    getResearchAndWritingId,
 } from "@ourworldindata/utils"
 import { useLinkedDocument } from "../utils.js"
 import Image, { ImageParentContainer } from "./Image.js"
@@ -191,7 +190,7 @@ export function ResearchAndWriting(props: ResearchAndWritingProps) {
         className,
     } = props
 
-    const slug = heading ? slugify(heading) : RESEARCH_AND_WRITING_ID
+    const slug = getResearchAndWritingId(heading)
 
     // Get the URLs from the links of the featured work section. These will be
     // excluded from the latest work section below to avoid duplication.


### PR DESCRIPTION
## Context

Makes the linear topic-page / sidebar table of contents list more of what's on the page.

- **H2 subheadings now appear**, nested under their H1 section. Previously the sidebar TOC listed only the H1 sections.
- **More standalone blocks get their own entry:**
  - the all-charts block, now labelled **"Key charts"** (previously it echoed the block's own heading)
  - the featured-metrics block, as **"Featured data"**
  - the research-and-writing block, under its own heading (or **"Research & Writing"** when it has none)

On their own these changes just make the existing table of contents more complete; the entries feed the redesigned sidebar in #6664 upstack.

**Rollout is gradual, by design.** The table of contents is computed when a page is (re)published, so nothing changes for existing pages until they're next republished — until then they keep showing H1s only, exactly as now. This lets us migrate deliberately, page by page, giving authors a chance to check whether the H2s that surface in the table of contents read well or need editing before they go live.

## Testing guidance

On a linear topic page that has H2s under its sections plus all-charts / featured-metrics / research-and-writing blocks:

1. The table of contents lists each H2 indented under its H1 section.
2. "Key charts", "Featured data", and the research-and-writing heading each show up as their own entries.
3. Clicking each entry scrolls to the matching section.
