### PR TITLE
Make empty scope/meta words optional in charts search

### DIFF
--- a/baker/algolia/configureAlgolia.ts
+++ b/baker/algolia/configureAlgolia.ts
@@ -148,7 +148,34 @@ export const configureAlgolia = async () => {
             ],
             attributesToSnippet: ["subtitle:24"],
             attributeForDistinct: "id",
-            optionalWords: ["vs"],
+            // Generic, semantically-empty words that OWID's globally-scoped chart
+            // catalogue never contains literally: scope qualifiers ("worldwide")
+            // and "give me data / a chart" meta-words. Left mandatory, they make
+            // otherwise-good queries return ZERO results ("malaria worldwide" ->
+            // no chart title contains "worldwide" -> blank page). As optional
+            // words they no longer gate the match but still boost where present.
+            // (Analysis: ~2% of chart-search volume carries one of these; the
+            // failures are hard zero-result pages. `removeStopWords: ["en"]` does
+            // not catch them — Algolia's stopword dictionary is function words.)
+            optionalWords: [
+                "vs",
+                "worldwide",
+                "statistics",
+                "stats",
+                "chart",
+                "charts",
+                "graph",
+                "graphs",
+                "map",
+                "maps",
+                "dataset",
+                "figures",
+                "data",
+            ],
+            // Safety net for the unenumerated long tail: if a query still returns
+            // nothing, retry treating all words as optional rather than showing a
+            // blank page — for a data site a topic match beats no results.
+            removeWordsIfNoResults: "allOptional",
 
             // These lines below essentially demote matches in the `subtitle` and `availableEntities` fields:
             // If we find a match (only) there, then it doesn't count towards `exact`, and is therefore ranked lower.


### PR DESCRIPTION
## What

Adds a set of semantically-empty words to the charts index `optionalWords`, and enables `removeWordsIfNoResults: "allOptional"` on that index.

## Why

OWID's chart catalogue is inherently global and is *entirely* charts/data, so words like **`worldwide`**, **`statistics`**, **`chart`**, **`map`**, **`dataset`** add no discriminative value — yet today they're treated as mandatory query terms. Since no chart record literally contains them, they turn otherwise-good queries into **zero-result pages**:

| query | today (keyword) | with fix |
|---|---|---|
| `malaria worldwide` | ∅ blank page | ✅ malaria charts |
| `share of children vaccinated by vaccine worldwide` | ∅ blank page | ✅ the exact chart |
| `mental illness map` | ∅ blank page | ✅ mental-illness charts |
| `international smoking statistics` | ∅ blank page | ✅ smoking charts |

`removeStopWords: ["en"]` does **not** catch these — Algolia's English stopword dictionary is function words (the, of, by…), not content tokens.

This mirrors the existing `optionalWords: ["vs"]` precedent (added so "X vs Y" scatter queries don't require the literal "vs").

## How it was scoped

Derived from 30 days of real chart-index search demand: for each candidate the top real queries were diffed (results with vs without the word) on both the live keyword engine and the staging Typesense hybrid. The words added here are the ones that are (a) semantically empty for OWID and (b) currently cause hard zero-result failures on the keyword engine. Deliberately **excluded**:

- `world` / `global` — Algolia already largely ignores them (adding risks regressing legit phrases like *global burden of disease*, *world happiness report*).
- `annual`, `number`, `rate`, `total`, `per` — look like filler but encode real OWID distinctions (annual vs cumulative, number vs rate vs share, per capita).

The two changes are complementary: `optionalWords` fixes the known high-volume offenders in the primary query (with proper ranking); `removeWordsIfNoResults: "allOptional"` is a safety net that only kicks in on an otherwise-empty result set, catching the unenumerated long tail.

## Deploy / testing

These are **query-time** settings — applied by re-running `configureAlgolia` (no reindex of records needed), effective on the next search. Suggest a quick before/after check on the queries in the table above.

## Scope note

`removeWordsIfNoResults: "allOptional"` changes zero-result behaviour for the whole charts index (a topic match instead of a blank page). If reviewers prefer to land only the conservative, targeted `optionalWords` change first, that line can be dropped without affecting the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



## Relation to hybrid search

This is an **interim fix for the keyword engine**. The same queries already return relevant results on the staging **Typesense hybrid** engine *with the word still present* — the vector arm matches on meaning and never collapses to zero hits. So shipping hybrid search solves this whole class of blank-page failure; this change just closes the gap in the meantime.

