### PR TITLE
Test removeWordsIfNoResults alone on charts search

### DIFF
--- a/baker/algolia/configureAlgolia.ts
+++ b/baker/algolia/configureAlgolia.ts
@@ -149,6 +149,11 @@ export const configureAlgolia = async () => {
             attributesToSnippet: ["subtitle:24"],
             attributeForDistinct: "id",
             optionalWords: ["vs"],
+            // If a query still returns nothing, retry treating all words as optional
+            // rather than showing a blank page — for a data site a topic match beats
+            // no results. Testing this alone (without hand-curated optionalWords) to
+            // see if it's sufficient on its own.
+            removeWordsIfNoResults: "allOptional",
 
             // These lines below essentially demote matches in the `subtitle` and `availableEntities` fields:
             // If we find a match (only) there, then it doesn't count towards `exact`, and is therefore ranked lower.


### PR DESCRIPTION
## Summary
- Experimental / staging-only test: adds `removeWordsIfNoResults: "allOptional"` to the charts Algolia index config, without hand-curating an `optionalWords` stopword list.
- Goal: check whether Algolia's built-in "retry with all words optional if a query returns zero results" behavior is sufficient on its own for queries like "malaria worldwide" that currently return no results, as an alternative to the manually curated list in `algolia-stopword-optional-words`.
- Not intended to merge as-is — this is for comparing search results on a staging index vs. production.

## Test plan
- [ ] Add `staging-algolia` label to spin up a staging server with a custom-prefixed Algolia index
- [ ] Wait for staging bake to reindex charts with this config
- [ ] Query the staging index vs. the production index with the same example queries and compare result counts/relevance