### PR TITLE
Test removeWordsIfNoResults: lastWords on charts search

### DIFF
--- a/baker/algolia/configureAlgolia.ts
+++ b/baker/algolia/configureAlgolia.ts
@@ -149,6 +149,12 @@ export const configureAlgolia = async () => {
             attributesToSnippet: ["subtitle:24"],
             attributeForDistinct: "id",
             optionalWords: ["vs"],
+            // If a query still returns nothing, retry by progressively dropping words
+            // from the end of the query rather than showing a blank page — for a data
+            // site a topic match beats no results. Testing this against the
+            // "allOptional" variant (algolia-remove-words-if-no-results branch) to see
+            // whether the more conservative last-words-first drop order is preferable.
+            removeWordsIfNoResults: "lastWords",
 
             // These lines below essentially demote matches in the `subtitle` and `availableEntities` fields:
             // If we find a match (only) there, then it doesn't count towards `exact`, and is therefore ranked lower.


### PR DESCRIPTION
## Summary
- Experimental / staging-only test: adds `removeWordsIfNoResults: "lastWords"` to the charts Algolia index config.
- Alternative to `removeWordsIfNoResults: "allOptional"` tested in #6667 (branch `algolia-remove-words-if-no-results`) — `lastWords` progressively drops trailing query words instead of making all words optional at once, which may preserve relevance better for longer queries.
- Goal: compare result quality/relevance between the two drop strategies on zero-result chart queries like "malaria worldwide" or "life expectancy map".
- Not intended to merge as-is — this is for comparing search results on a staging index vs. production and vs. the `allOptional` variant.

## Test plan
- [ ] Add `staging-algolia` label to spin up a staging server with a custom-prefixed Algolia index
- [ ] Wait for staging bake to reindex charts with this config
- [ ] Query the staging index vs. production and vs. the `allOptional` staging index with the same example queries and compare result counts/relevance