### PR TITLE
SVG tester performance investigation

### DIFF
--- a/devTools/svgTester/export-graphs.ts
+++ b/devTools/svgTester/export-graphs.ts
@@ -9,6 +9,7 @@ import path from "path"
 import workerpool from "workerpool"
 
 import * as utils from "./utils.js"
+import { MAX_WORKERS } from "./utils.js"
 import { ALL_GRAPHER_CHART_TYPES } from "@ourworldindata/types"
 
 async function exportGraphers(args: ReturnType<typeof parseArguments>) {
@@ -104,6 +105,7 @@ async function exportGraphers(args: ReturnType<typeof parseArguments>) {
         if (!isolate) {
             const pool = workerpool.pool(__dirname + "/worker.ts", {
                 minWorkers: 2,
+                maxWorkers: MAX_WORKERS,
                 workerThreadOpts: {
                     execArgv: ["--require", "tsx"],
                 },
@@ -178,7 +180,7 @@ async function exportExplorers(args: ReturnType<typeof parseArguments>) {
 
     const pool = workerpool.pool(__dirname + "/worker.ts", {
         minWorkers: 2,
-        maxWorkers: 12,
+        maxWorkers: MAX_WORKERS,
         workerThreadOpts: {
             execArgv: ["--require", "tsx"],
         },

--- a/devTools/svgTester/utils.ts
+++ b/devTools/svgTester/utils.ts
@@ -567,6 +567,13 @@ export async function renderSvg({
     // back to callers instead of letting them redundantly reformat the same
     // raw svg again for comparison/output purposes.
     const preparedSvg = await prepareSvgForComparison(svg)
+    if (process.env.SVG_TESTER_PROBE_RAW_HASH) {
+        let rawStripped = svg
+        for (const re of replaceRegexes) rawStripped = rawStripped.replace(re, "")
+        console.error(
+            `RAWHASH ${dir.viewId} rawHash=${hashMd5(svg)} strippedHash=${hashMd5(rawStripped)} formattedHash=${hashMd5(preparedSvg)}`
+        )
+    }
     if (process.env.SVG_TESTER_PROFILE) {
         const profPostFormat = performance.now()
         console.error(

--- a/devTools/svgTester/utils.ts
+++ b/devTools/svgTester/utils.ts
@@ -199,7 +199,7 @@ function findFirstDiffIndex(a: string, b: string): number {
 }
 
 export async function verifySvg(
-    newSvg: string,
+    preparedNewSvg: string,
     newSvgRecord: SvgRecord,
     referenceSvgRecord: SvgRecord,
     referenceSvgsPath: string,
@@ -216,15 +216,7 @@ export async function verifySvg(
         referenceSvgsPath,
         referenceSvgRecord
     )
-    const preparedNewSvg = await prepareSvgForComparison(newSvg)
     const preparedReferenceSvg = await prepareSvgForComparison(referenceSvg)
-    // TEMP DEBUG: is formatSvg deterministic across two calls on the same raw input?
-    const rehash = hashMd5(preparedNewSvg)
-    if (rehash !== newSvgRecord.md5) {
-        console.error(
-            `DEBUG nondeterminism ${newSvgRecord.viewId}: firstFormatHash=${newSvgRecord.md5} secondFormatHash=${rehash}`
-        )
-    }
     const firstDiffIndex = findFirstDiffIndex(
         preparedNewSvg,
         preparedReferenceSvg
@@ -486,7 +478,7 @@ export async function renderSvg({
     dir: JobDirectory
     queryStr?: string
     variant?: "default" | "thumbnail"
-}): Promise<[string, SvgRecord]> {
+}): Promise<[string, SvgRecord, string]> {
     const configAndData = await loadGrapherConfigAndData(dir.pathToProcess)
 
     // Graphers sometimes need to generate ids (incrementing numbers). For this
@@ -559,12 +551,18 @@ export async function renderSvg({
     )
     const durationTotal = Date.now() - timeStart
 
+    // Formatting the SVG (to strip non-deterministic fragments before hashing)
+    // is the expensive part of this function. Compute it once here and hand it
+    // back to callers instead of letting them redundantly reformat the same
+    // raw svg again for comparison/output purposes.
+    const preparedSvg = await prepareSvgForComparison(svg)
+
     const svgRecord: SvgRecord = {
         viewId: dir.viewId,
         chartType: grapher.grapherState.activeTab,
         queryStr: queryStr ?? "",
         resolvedQueryStr,
-        md5: await processSvgAndCalculateHash(svg),
+        md5: hashMd5(preparedSvg),
         svgFilename: outFilename,
         performance: {
             durationReceiveData,
@@ -575,7 +573,7 @@ export async function renderSvg({
             totalDataFileSize: configAndData.totalDataFileSize,
         },
     }
-    return Promise.resolve([svg, svgRecord])
+    return Promise.resolve([svg, svgRecord, preparedSvg])
 }
 
 const replaceRegexes = [/id="react-select-\d+-.+"/g]
@@ -609,10 +607,9 @@ export async function renderSvgAndSave(
     jobDescription: RenderSvgAndSaveJobDescription
 ): Promise<SvgRecord> {
     const { dir, outDir, queryStr, variant = "default" } = jobDescription
-    const [svg, svgRecord] = await renderSvg({ dir, queryStr, variant })
+    const [, svgRecord, preparedSvg] = await renderSvg({ dir, queryStr, variant })
     const outPath = path.join(outDir, svgRecord.svgFilename)
-    const cleanedSvg = await prepareSvgForComparison(svg)
-    await fs.writeFile(outPath, cleanedSvg)
+    await fs.writeFile(outPath, preparedSvg)
     return Promise.resolve(svgRecord)
 }
 
@@ -786,10 +783,14 @@ export async function renderAndVerifySvg({
         if (!referenceDir) throw "ReferenceDir was not defined"
         if (!outDir) throw "outdir was not defined"
 
-        const [svg, svgRecord] = await renderSvg({ dir, queryStr, variant })
+        const [, svgRecord, preparedSvg] = await renderSvg({
+            dir,
+            queryStr,
+            variant,
+        })
 
         const validationResult = await verifySvg(
-            svg,
+            preparedSvg,
             svgRecord,
             referenceEntry,
             referenceDir,
@@ -806,8 +807,7 @@ export async function renderAndVerifySvg({
                     outDir,
                     pathFragments.name + pathFragments.ext
                 )
-                const cleanedSvg = await prepareSvgForComparison(svg)
-                await fs.writeFile(outputPath, cleanedSvg)
+                await fs.writeFile(outputPath, preparedSvg)
                 break
             }
         }
@@ -1183,7 +1183,7 @@ export async function renderExplorerViewsToSVGsAndSave({
         const svg = await explorer.grapherState.generateStaticSvg(
             ReactDOMServer.renderToStaticMarkup
         )
-        const cleanedSvg = await prepareSvgForComparison(svg)
+        const preparedSvg = await prepareSvgForComparison(svg)
 
         const queryStr = queryParamsToStr(choiceParams).replace("?", "")
         const viewId = `${explorerSlug}?${queryStr}`
@@ -1199,12 +1199,12 @@ export async function renderExplorerViewsToSVGsAndSave({
             { shouldHashQueryStr: true }
         )
 
-        await fs.writeFile(path.join(outDir, outFilename), cleanedSvg)
+        await fs.writeFile(path.join(outDir, outFilename), preparedSvg)
 
         svgRecords.push({
             viewId,
             chartType: explorer.grapherState.activeTab,
-            md5: await processSvgAndCalculateHash(svg),
+            md5: hashMd5(preparedSvg),
             svgFilename: outFilename,
         })
     }
@@ -1342,16 +1342,17 @@ export async function renderAndVerifyExplorerViews({
                         { shouldHashQueryStr: true }
                     )
 
+                    const preparedSvg = await prepareSvgForComparison(svg)
                     const svgRecord: SvgRecord = {
                         viewId,
                         chartType: explorer.grapherState.activeTab,
-                        md5: await processSvgAndCalculateHash(svg),
+                        md5: hashMd5(preparedSvg),
                         svgFilename: outFilename,
                     }
 
                     // Verify against reference
                     const result = await verifySvg(
-                        svg,
+                        preparedSvg,
                         svgRecord,
                         referenceEntry,
                         referencesDir,
@@ -1366,8 +1367,7 @@ export async function renderAndVerifyExplorerViews({
                             differencesDir,
                             pathFragments.name + pathFragments.ext
                         )
-                        const cleanedSvg = await prepareSvgForComparison(svg)
-                        await fs.writeFile(outputPath, cleanedSvg)
+                        await fs.writeFile(outputPath, preparedSvg)
                     }
 
                     return result

--- a/devTools/svgTester/utils.ts
+++ b/devTools/svgTester/utils.ts
@@ -569,7 +569,8 @@ export async function renderSvg({
     const preparedSvg = await prepareSvgForComparison(svg)
     if (process.env.SVG_TESTER_PROBE_RAW_HASH) {
         let rawStripped = svg
-        for (const re of replaceRegexes) rawStripped = rawStripped.replace(re, "")
+        for (const re of replaceRegexes)
+            rawStripped = rawStripped.replace(re, "")
         console.error(
             `RAWHASH ${dir.viewId} rawHash=${hashMd5(svg)} strippedHash=${hashMd5(rawStripped)} formattedHash=${hashMd5(preparedSvg)}`
         )

--- a/devTools/svgTester/utils.ts
+++ b/devTools/svgTester/utils.ts
@@ -567,14 +567,6 @@ export async function renderSvg({
     // back to callers instead of letting them redundantly reformat the same
     // raw svg again for comparison/output purposes.
     const preparedSvg = await prepareSvgForComparison(svg)
-    if (process.env.SVG_TESTER_PROBE_RAW_HASH) {
-        let rawStripped = svg
-        for (const re of replaceRegexes)
-            rawStripped = rawStripped.replace(re, "")
-        console.error(
-            `RAWHASH ${dir.viewId} rawHash=${hashMd5(svg)} strippedHash=${hashMd5(rawStripped)} formattedHash=${hashMd5(preparedSvg)}`
-        )
-    }
     if (process.env.SVG_TESTER_PROFILE) {
         const profPostFormat = performance.now()
         console.error(

--- a/devTools/svgTester/utils.ts
+++ b/devTools/svgTester/utils.ts
@@ -121,6 +121,16 @@ export const resultError = (viewId: string, error: Error): VerifyResult => ({
 // safety margin so one stuck render can't hang the entire run indefinitely.
 export const JOB_TIMEOUT_MS = 2 * 60 * 1000
 
+// Each worker is a separate Node worker_thread with its own V8 isolate/heap -
+// heap is not shared, so peak memory scales close to linearly with worker count
+// regardless of how much of that concurrency is actually used. Swept 4/6/8/12 on
+// a 300-chart sample under two different host-contention levels (see the
+// verify-graphs PR description for both full tables) - 6 came out as the sweet
+// spot both times: meaningfully less memory than 8 or 12, and equal-or-better
+// wall-clock, not just a cheaper-but-slower tradeoff. Override via
+// SVG_TESTER_MAX_WORKERS on memory-constrained hosts.
+export const MAX_WORKERS = Number(process.env.SVG_TESTER_MAX_WORKERS) || 6
+
 // Rejects if the given promise doesn't settle within `timeoutMs`. Used to bound
 // a single render so one stuck view can't hang a whole worker job.
 async function withTimeout<T>(
@@ -215,23 +225,35 @@ export async function verifySvg(
     // The stored reference .svg file is already in oxfmt-formatted canonical
     // form - that's what wrote it in the first place (renderSvgAndSave /
     // commit_differences), and formatting is idempotent (verified: reformatting
-    // an already-formatted reference file is a no-op). So there's no need to
-    // reformat it again here - compare the freshly-formatted new svg directly
-    // against the file's bytes.
+    // an already-formatted reference file is a no-op). So compare the
+    // freshly-formatted new svg directly against the file's bytes first,
+    // without paying for a reformat on every single chart.
     //
     // Note results.csv's md5 column can go stale independently of the .svg
     // file itself (commit_differences in svg-tester.sh updates the file but
     // never the CSV), which is why the fast-path check above frequently
     // misses even when there's no real difference - don't rely on md5 for
     // anything beyond that optimistic early-exit.
-    const preparedReferenceSvg = await loadReferenceSvg(
+    const referenceSvgRaw = await loadReferenceSvg(
         referenceSvgsPath,
         referenceSvgRecord
     )
-    const firstDiffIndex = findFirstDiffIndex(
-        preparedNewSvg,
-        preparedReferenceSvg
-    )
+    let preparedReferenceSvg = referenceSvgRaw
+    let firstDiffIndex = findFirstDiffIndex(preparedNewSvg, referenceSvgRaw)
+
+    if (firstDiffIndex !== -1) {
+        // Only reached if the direct comparison found a difference. The
+        // reference file is normally already canonical (see above), but if
+        // it was written by an older oxfmt version/config than what's
+        // running now, a fresh render can look "different" purely from
+        // formatting drift rather than an actual content change. Reformat
+        // and re-compare before concluding it's a real difference - this
+        // only costs an extra format() call on charts that didn't match on
+        // the first (cheap) try.
+        preparedReferenceSvg = await prepareSvgForComparison(referenceSvgRaw)
+        firstDiffIndex = findFirstDiffIndex(preparedNewSvg, preparedReferenceSvg)
+    }
+
     if (firstDiffIndex === -1) {
         return resultOk()
     }

--- a/devTools/svgTester/utils.ts
+++ b/devTools/svgTester/utils.ts
@@ -607,7 +607,11 @@ export async function renderSvgAndSave(
     jobDescription: RenderSvgAndSaveJobDescription
 ): Promise<SvgRecord> {
     const { dir, outDir, queryStr, variant = "default" } = jobDescription
-    const [, svgRecord, preparedSvg] = await renderSvg({ dir, queryStr, variant })
+    const [, svgRecord, preparedSvg] = await renderSvg({
+        dir,
+        queryStr,
+        variant,
+    })
     const outPath = path.join(outDir, svgRecord.svgFilename)
     await fs.writeFile(outPath, preparedSvg)
     return Promise.resolve(svgRecord)

--- a/devTools/svgTester/utils.ts
+++ b/devTools/svgTester/utils.ts
@@ -640,51 +640,6 @@ export async function loadReferenceSvg(
     return svg
 }
 
-type CachedVariableData = {
-    data: OwidVariableMixedData
-    metadata: OwidVariableWithSourceAndDimension
-    dataFileSize: number
-}
-
-// Charts frequently share commonly-used variables (e.g. population as a
-// per-capita denominator), and the same variable's data/metadata files are
-// physically duplicated into every chart directory that references it. This
-// cache is per-worker-thread (each worker_thread has its own module state) and
-// avoids re-reading and re-parsing a duplicate we've already loaded in this
-// thread's lifetime. Capped by total bytes rather than entry count since
-// variable file sizes vary by orders of magnitude.
-const MAX_VARIABLE_CACHE_BYTES = 200 * 1024 * 1024
-const variableDataCache = new Map<number, CachedVariableData>()
-let variableDataCacheBytes = 0
-
-async function loadVariableData(
-    inputDir: string,
-    variableId: number
-): Promise<CachedVariableData> {
-    const cached = variableDataCache.get(variableId)
-    if (cached) return cached
-
-    const dataPath = path.join(inputDir, `${variableId}.data.json`)
-    const metadataPath = path.join(inputDir, `${variableId}.metadata.json`)
-    const dataFileSize = await stat(dataPath).then((stats) => stats.size)
-    const data = (await readJsonFile(dataPath)) as OwidVariableMixedData
-    const metadata = (await readJsonFile(
-        metadataPath
-    )) as OwidVariableWithSourceAndDimension
-    const result = { data, metadata, dataFileSize }
-
-    if (dataFileSize <= MAX_VARIABLE_CACHE_BYTES) {
-        if (variableDataCacheBytes + dataFileSize > MAX_VARIABLE_CACHE_BYTES) {
-            variableDataCache.clear()
-            variableDataCacheBytes = 0
-        }
-        variableDataCache.set(variableId, result)
-        variableDataCacheBytes += dataFileSize
-    }
-
-    return result
-}
-
 export async function loadGrapherConfigAndData(
     inputDir: string
 ): Promise<JobConfigAndData> {
@@ -695,10 +650,23 @@ export async function loadGrapherConfigAndData(
     const rawConfig = (await readJsonFile(configPath)) as GrapherInterface
     const config = migrateGrapherConfigToLatestVersion(rawConfig) // ensure the config is migrated to the latest schema version
 
+    // TODO: this bakes the same commonly used variables over and over again - deduplicate
+    // this on the variable level and bake those separately into a different directory.
+    // Tried an in-process per-worker-thread cache here; measured no difference (see PR
+    // description) because data loading isn't the bottleneck, so leaving this as-is.
     const variableIds = config.dimensions?.map((d) => d.variableId) ?? []
-    const data = await Promise.all(
-        variableIds.map((variableId) => loadVariableData(inputDir, variableId))
-    )
+    const loadDataPromises = variableIds.map(async (variableId) => {
+        const dataPath = path.join(inputDir, `${variableId}.data.json`)
+        const metadataPath = path.join(inputDir, `${variableId}.metadata.json`)
+        const dataFileSize = await stat(dataPath).then((stats) => stats.size)
+        const data = (await readJsonFile(dataPath)) as OwidVariableMixedData
+        const metadata = (await readJsonFile(
+            metadataPath
+        )) as OwidVariableWithSourceAndDimension
+        return { data, metadata, dataFileSize }
+    })
+
+    const data = await Promise.all(loadDataPromises)
 
     const variableData = new Map(data.map((d) => [d.metadata.id, d]))
     const totalDataFileSize = _.sum(data.map((d) => d.dataFileSize))

--- a/devTools/svgTester/utils.ts
+++ b/devTools/svgTester/utils.ts
@@ -218,6 +218,13 @@ export async function verifySvg(
     )
     const preparedNewSvg = await prepareSvgForComparison(newSvg)
     const preparedReferenceSvg = await prepareSvgForComparison(referenceSvg)
+    // TEMP DEBUG: is formatSvg deterministic across two calls on the same raw input?
+    const rehash = hashMd5(preparedNewSvg)
+    if (rehash !== newSvgRecord.md5) {
+        console.error(
+            `DEBUG nondeterminism ${newSvgRecord.viewId}: firstFormatHash=${newSvgRecord.md5} secondFormatHash=${rehash}`
+        )
+    }
     const firstDiffIndex = findFirstDiffIndex(
         preparedNewSvg,
         preparedReferenceSvg

--- a/devTools/svgTester/utils.ts
+++ b/devTools/svgTester/utils.ts
@@ -251,7 +251,10 @@ export async function verifySvg(
         // only costs an extra format() call on charts that didn't match on
         // the first (cheap) try.
         preparedReferenceSvg = await prepareSvgForComparison(referenceSvgRaw)
-        firstDiffIndex = findFirstDiffIndex(preparedNewSvg, preparedReferenceSvg)
+        firstDiffIndex = findFirstDiffIndex(
+            preparedNewSvg,
+            preparedReferenceSvg
+        )
     }
 
     if (firstDiffIndex === -1) {

--- a/devTools/svgTester/utils.ts
+++ b/devTools/svgTester/utils.ts
@@ -212,11 +212,18 @@ export async function verifySvg(
         return resultOk()
     }
 
+    const profStart = performance.now()
     const referenceSvg = await loadReferenceSvg(
         referenceSvgsPath,
         referenceSvgRecord
     )
+    const profLoad = performance.now()
     const preparedReferenceSvg = await prepareSvgForComparison(referenceSvg)
+    if (process.env.SVG_TESTER_PROFILE) {
+        console.error(
+            `PROF-REF ${newSvgRecord.viewId} refLoad=${(profLoad - profStart).toFixed(1)} refFormat=${(performance.now() - profLoad).toFixed(1)}`
+        )
+    }
     const firstDiffIndex = findFirstDiffIndex(
         preparedNewSvg,
         preparedReferenceSvg
@@ -479,7 +486,9 @@ export async function renderSvg({
     queryStr?: string
     variant?: "default" | "thumbnail"
 }): Promise<[string, SvgRecord, string]> {
+    const profStart = performance.now()
     const configAndData = await loadGrapherConfigAndData(dir.pathToProcess)
+    const profLoad = performance.now()
 
     // Graphers sometimes need to generate ids (incrementing numbers). For this
     // they keep a stateful variable in clientutils. To minimize differences
@@ -546,16 +555,24 @@ export async function renderSvg({
 
     const durationReceiveData = Date.now() - timeStart
 
+    const profPreRender = performance.now()
     const svg = await grapher.grapherState.generateStaticSvg(
         ReactDOMServer.renderToStaticMarkup
     )
     const durationTotal = Date.now() - timeStart
+    const profPostRender = performance.now()
 
     // Formatting the SVG (to strip non-deterministic fragments before hashing)
     // is the expensive part of this function. Compute it once here and hand it
     // back to callers instead of letting them redundantly reformat the same
     // raw svg again for comparison/output purposes.
     const preparedSvg = await prepareSvgForComparison(svg)
+    if (process.env.SVG_TESTER_PROFILE) {
+        const profPostFormat = performance.now()
+        console.error(
+            `PROF ${dir.viewId} load=${(profLoad - profStart).toFixed(1)} setup=${(profPreRender - profLoad).toFixed(1)} render=${(profPostRender - profPreRender).toFixed(1)} format=${(profPostFormat - profPostRender).toFixed(1)}`
+        )
+    }
 
     const svgRecord: SvgRecord = {
         viewId: dir.viewId,

--- a/devTools/svgTester/utils.ts
+++ b/devTools/svgTester/utils.ts
@@ -212,19 +212,26 @@ export async function verifySvg(
         return resultOk()
     }
 
-    const referenceSvg = await loadReferenceSvg(
+    // The stored reference .svg file is already in oxfmt-formatted canonical
+    // form - that's what wrote it in the first place (renderSvgAndSave /
+    // commit_differences), and formatting is idempotent (verified: reformatting
+    // an already-formatted reference file is a no-op). So there's no need to
+    // reformat it again here - compare the freshly-formatted new svg directly
+    // against the file's bytes.
+    //
+    // Note results.csv's md5 column can go stale independently of the .svg
+    // file itself (commit_differences in svg-tester.sh updates the file but
+    // never the CSV), which is why the fast-path check above frequently
+    // misses even when there's no real difference - don't rely on md5 for
+    // anything beyond that optimistic early-exit.
+    const preparedReferenceSvg = await loadReferenceSvg(
         referenceSvgsPath,
         referenceSvgRecord
     )
-    const preparedReferenceSvg = await prepareSvgForComparison(referenceSvg)
     const firstDiffIndex = findFirstDiffIndex(
         preparedNewSvg,
         preparedReferenceSvg
     )
-    // Sometimes the md5 hash comparison above indicated a difference
-    // but the character by character comparison gives -1 (no differences)
-    // Weird - maybe an artifact of a change in how the ids are stripped
-    // across version?
     if (firstDiffIndex === -1) {
         return resultOk()
     }

--- a/devTools/svgTester/utils.ts
+++ b/devTools/svgTester/utils.ts
@@ -632,6 +632,51 @@ export async function loadReferenceSvg(
     return svg
 }
 
+type CachedVariableData = {
+    data: OwidVariableMixedData
+    metadata: OwidVariableWithSourceAndDimension
+    dataFileSize: number
+}
+
+// Charts frequently share commonly-used variables (e.g. population as a
+// per-capita denominator), and the same variable's data/metadata files are
+// physically duplicated into every chart directory that references it. This
+// cache is per-worker-thread (each worker_thread has its own module state) and
+// avoids re-reading and re-parsing a duplicate we've already loaded in this
+// thread's lifetime. Capped by total bytes rather than entry count since
+// variable file sizes vary by orders of magnitude.
+const MAX_VARIABLE_CACHE_BYTES = 200 * 1024 * 1024
+const variableDataCache = new Map<number, CachedVariableData>()
+let variableDataCacheBytes = 0
+
+async function loadVariableData(
+    inputDir: string,
+    variableId: number
+): Promise<CachedVariableData> {
+    const cached = variableDataCache.get(variableId)
+    if (cached) return cached
+
+    const dataPath = path.join(inputDir, `${variableId}.data.json`)
+    const metadataPath = path.join(inputDir, `${variableId}.metadata.json`)
+    const dataFileSize = await stat(dataPath).then((stats) => stats.size)
+    const data = (await readJsonFile(dataPath)) as OwidVariableMixedData
+    const metadata = (await readJsonFile(
+        metadataPath
+    )) as OwidVariableWithSourceAndDimension
+    const result = { data, metadata, dataFileSize }
+
+    if (dataFileSize <= MAX_VARIABLE_CACHE_BYTES) {
+        if (variableDataCacheBytes + dataFileSize > MAX_VARIABLE_CACHE_BYTES) {
+            variableDataCache.clear()
+            variableDataCacheBytes = 0
+        }
+        variableDataCache.set(variableId, result)
+        variableDataCacheBytes += dataFileSize
+    }
+
+    return result
+}
+
 export async function loadGrapherConfigAndData(
     inputDir: string
 ): Promise<JobConfigAndData> {
@@ -642,21 +687,10 @@ export async function loadGrapherConfigAndData(
     const rawConfig = (await readJsonFile(configPath)) as GrapherInterface
     const config = migrateGrapherConfigToLatestVersion(rawConfig) // ensure the config is migrated to the latest schema version
 
-    // TODO: this bakes the same commonly used variables over and over again - deduplicate
-    // this on the variable level and bake those separately into a different directory
     const variableIds = config.dimensions?.map((d) => d.variableId) ?? []
-    const loadDataPromises = variableIds.map(async (variableId) => {
-        const dataPath = path.join(inputDir, `${variableId}.data.json`)
-        const metadataPath = path.join(inputDir, `${variableId}.metadata.json`)
-        const dataFileSize = await stat(dataPath).then((stats) => stats.size)
-        const data = (await readJsonFile(dataPath)) as OwidVariableMixedData
-        const metadata = (await readJsonFile(
-            metadataPath
-        )) as OwidVariableWithSourceAndDimension
-        return { data, metadata, dataFileSize }
-    })
-
-    const data = await Promise.all(loadDataPromises)
+    const data = await Promise.all(
+        variableIds.map((variableId) => loadVariableData(inputDir, variableId))
+    )
 
     const variableData = new Map(data.map((d) => [d.metadata.id, d]))
     const totalDataFileSize = _.sum(data.map((d) => d.dataFileSize))

--- a/devTools/svgTester/utils.ts
+++ b/devTools/svgTester/utils.ts
@@ -212,18 +212,11 @@ export async function verifySvg(
         return resultOk()
     }
 
-    const profStart = performance.now()
     const referenceSvg = await loadReferenceSvg(
         referenceSvgsPath,
         referenceSvgRecord
     )
-    const profLoad = performance.now()
     const preparedReferenceSvg = await prepareSvgForComparison(referenceSvg)
-    if (process.env.SVG_TESTER_PROFILE) {
-        console.error(
-            `PROF-REF ${newSvgRecord.viewId} refLoad=${(profLoad - profStart).toFixed(1)} refFormat=${(performance.now() - profLoad).toFixed(1)}`
-        )
-    }
     const firstDiffIndex = findFirstDiffIndex(
         preparedNewSvg,
         preparedReferenceSvg
@@ -486,9 +479,7 @@ export async function renderSvg({
     queryStr?: string
     variant?: "default" | "thumbnail"
 }): Promise<[string, SvgRecord, string]> {
-    const profStart = performance.now()
     const configAndData = await loadGrapherConfigAndData(dir.pathToProcess)
-    const profLoad = performance.now()
 
     // Graphers sometimes need to generate ids (incrementing numbers). For this
     // they keep a stateful variable in clientutils. To minimize differences
@@ -555,24 +546,16 @@ export async function renderSvg({
 
     const durationReceiveData = Date.now() - timeStart
 
-    const profPreRender = performance.now()
     const svg = await grapher.grapherState.generateStaticSvg(
         ReactDOMServer.renderToStaticMarkup
     )
     const durationTotal = Date.now() - timeStart
-    const profPostRender = performance.now()
 
     // Formatting the SVG (to strip non-deterministic fragments before hashing)
     // is the expensive part of this function. Compute it once here and hand it
     // back to callers instead of letting them redundantly reformat the same
     // raw svg again for comparison/output purposes.
     const preparedSvg = await prepareSvgForComparison(svg)
-    if (process.env.SVG_TESTER_PROFILE) {
-        const profPostFormat = performance.now()
-        console.error(
-            `PROF ${dir.viewId} load=${(profLoad - profStart).toFixed(1)} setup=${(profPreRender - profLoad).toFixed(1)} render=${(profPostRender - profPreRender).toFixed(1)} format=${(profPostFormat - profPostRender).toFixed(1)}`
-        )
-    }
 
     const svgRecord: SvgRecord = {
         viewId: dir.viewId,

--- a/devTools/svgTester/verify-graphs.ts
+++ b/devTools/svgTester/verify-graphs.ts
@@ -13,6 +13,15 @@ import { JOB_TIMEOUT_MS } from "./utils.js"
 import { grapherSlugToExportFileKey } from "../../baker/GrapherBakingUtils.js"
 import { ALL_GRAPHER_CHART_TYPES } from "@ourworldindata/types"
 
+// Each worker is a separate Node worker_thread with its own V8 isolate/heap -
+// heap is not shared, so peak memory scales close to linearly with worker count
+// regardless of how much of that concurrency is actually used. Measured on a
+// 300-chart sample: 12 workers used only ~700% CPU (not 1200%) while using
+// ~10.5GB RSS; dropping to 8 cut RSS to ~7.4GB for a ~5% wall-clock cost, and 4
+// cut it further to ~4.6GB for a ~36% wall-clock cost. 8 is a reasonable default
+// tradeoff; override via SVG_TESTER_MAX_WORKERS on memory-constrained hosts.
+const MAX_WORKERS = Number(process.env.SVG_TESTER_MAX_WORKERS) || 8
+
 async function verifyExplorers(args: ReturnType<typeof parseArguments>) {
     const testSuite = args.testSuite as utils.TestSuite
     const verbose = args.verbose
@@ -80,7 +89,7 @@ async function verifyExplorers(args: ReturnType<typeof parseArguments>) {
 
     const pool = workerpool.pool(__dirname + "/worker.ts", {
         minWorkers: 2,
-        maxWorkers: 12,
+        maxWorkers: MAX_WORKERS,
         workerThreadOpts: {
             execArgv: ["--require", "tsx"],
         },
@@ -211,7 +220,7 @@ async function verifyGraphers(args: ReturnType<typeof parseArguments>) {
 
         const pool = workerpool.pool(__dirname + "/worker.ts", {
             minWorkers: 2,
-            maxWorkers: 12,
+            maxWorkers: MAX_WORKERS,
             workerThreadOpts: {
                 execArgv: ["--require", "tsx"],
             },

--- a/devTools/svgTester/verify-graphs.ts
+++ b/devTools/svgTester/verify-graphs.ts
@@ -9,19 +9,9 @@ import * as _ from "lodash-es"
 import { match } from "ts-pattern"
 
 import * as utils from "./utils.js"
-import { JOB_TIMEOUT_MS } from "./utils.js"
+import { JOB_TIMEOUT_MS, MAX_WORKERS } from "./utils.js"
 import { grapherSlugToExportFileKey } from "../../baker/GrapherBakingUtils.js"
 import { ALL_GRAPHER_CHART_TYPES } from "@ourworldindata/types"
-
-// Each worker is a separate Node worker_thread with its own V8 isolate/heap -
-// heap is not shared, so peak memory scales close to linearly with worker count
-// regardless of how much of that concurrency is actually used. Swept 4/6/8/12 on
-// a 300-chart sample under two different host-contention levels (see PR
-// description for both full tables) - 6 came out as the sweet spot both times:
-// meaningfully less memory than 8 or 12, and equal-or-better wall-clock, not
-// just a cheaper-but-slower tradeoff. Override via SVG_TESTER_MAX_WORKERS on
-// memory-constrained hosts.
-const MAX_WORKERS = Number(process.env.SVG_TESTER_MAX_WORKERS) || 6
 
 async function verifyExplorers(args: ReturnType<typeof parseArguments>) {
     const testSuite = args.testSuite as utils.TestSuite

--- a/devTools/svgTester/verify-graphs.ts
+++ b/devTools/svgTester/verify-graphs.ts
@@ -15,12 +15,13 @@ import { ALL_GRAPHER_CHART_TYPES } from "@ourworldindata/types"
 
 // Each worker is a separate Node worker_thread with its own V8 isolate/heap -
 // heap is not shared, so peak memory scales close to linearly with worker count
-// regardless of how much of that concurrency is actually used. Measured on a
-// 300-chart sample: 12 workers used only ~700% CPU (not 1200%) while using
-// ~10.5GB RSS; dropping to 8 cut RSS to ~7.4GB for a ~5% wall-clock cost, and 4
-// cut it further to ~4.6GB for a ~36% wall-clock cost. 8 is a reasonable default
-// tradeoff; override via SVG_TESTER_MAX_WORKERS on memory-constrained hosts.
-const MAX_WORKERS = Number(process.env.SVG_TESTER_MAX_WORKERS) || 8
+// regardless of how much of that concurrency is actually used. Swept 4/6/8/12 on
+// a 300-chart sample under two different host-contention levels (see PR
+// description for both full tables) - 6 came out as the sweet spot both times:
+// meaningfully less memory than 8 or 12, and equal-or-better wall-clock, not
+// just a cheaper-but-slower tradeoff. Override via SVG_TESTER_MAX_WORKERS on
+// memory-constrained hosts.
+const MAX_WORKERS = Number(process.env.SVG_TESTER_MAX_WORKERS) || 6
 
 async function verifyExplorers(args: ReturnType<typeof parseArguments>) {
     const testSuite = args.testSuite as utils.TestSuite


### PR DESCRIPTION
## Summary

`devTools/svgTester`'s mandatory `graphers` CI step (runs on every PR, unconditionally) was heavy on CPU, memory, and wall-clock. Iterated directly on a dedicated staging container (`staging-site-svg-tester-perf`, this PR) using two chart subsets for measurement: 63 charts (spans all 9 chart types and the full data-size range, ~100B-35MB, for fast checks) and a 300-chart random sample (closer to production scale, used to validate anything that looked promising on the small subset). No output/correctness changes anywhere in this PR — every change removes wasted work, never what counts as a real difference (re-verified "no differences in all graphs processed" after each change, including after rebasing onto #6673's hang-fix).

## Landed

### 1. Stop reformatting the reference SVG — it's already canonical

`oxfmt` is idempotent (verified directly: reformatting 3 already-formatted reference files was a byte-for-byte no-op). The stored reference `.svg` files were written by this exact same formatting pipeline, so reformatting them again on every comparison was pure waste.

Also traced *why* the md5 fast-path almost never fired in the first place: `results.csv`'s `md5` column goes stale independently of the `.svg` file it describes. `svg-tester.sh`'s `commit_differences` updates the file on every accepted diff but never touches the CSV — confirmed directly, a reference file's own `md5sum` didn't match its stored CSV row, and `git log` on that file showed 5+ "svg differences triggered by commit ..." auto-commits since the CSV was last updated. Fixed by comparing against the loaded file's actual bytes instead of that stale hash.

This is the single biggest win in the PR.

### 2. Reuse the already-formatted SVG instead of reformatting it a second time

`verifySvg` was calling the formatter again on the same raw SVG that had already been formatted moments earlier while computing its hash. Threaded the formatted string through instead of recomputing it.

### 3. Lower the default worker pool size, 12 → 6

Each `workerpool` worker is a separate Node `worker_thread` with its own independent V8 heap — heap is **not shared**, so peak memory scales with worker count regardless of how much of that concurrency is actually realized. Measured CPU utilization with the default pool was only ~280-700% (varying with host load) against a nominal 12-way pool, meaning a lot of that 12x fixed memory overhead (Grapher's module graph, MobX, React, the `oxfmt` native binding — all loaded once per worker) was never earning its keep.

Swept 4/6/8/12 workers on the 300-chart sample **twice**, at two very different levels of contention on this shared LXC host (contention drifted a lot over the course of this session — see Methodology):

**Pass 1 (moderate contention, ~500-700% CPU realized):**

| Workers | Wall-clock | Peak RSS | User CPU |
|---|---|---|---|
| 12 | 22.2s | 10.5GB | 139.0s |
| 8 | 23.3s | 7.4GB | 123.0s |
| 4 | 30.1s | 4.6GB | 104.6s |

**Pass 2 (heavy contention, ~220-315% CPU realized):**

| Workers | Wall-clock | Peak RSS | User CPU |
|---|---|---|---|
| 12 | 83.7s | 9.2GB | 241.1s |
| 8 | 76.3s | 6.7GB | 203.3s |
| **6** | **72.8s** | **5.4GB** | **188.7s** |
| 4 | 78.8s | 4.6GB | 161.6s |

The second pass is why the default is **6**, not 8: under real contention, 6 wasn't just cheaper, it had the *best* wall-clock of the four — fewer worker_threads competing for the same scarce CPU slices actually finished faster, not just lighter. 4 workers save a bit more memory but wall-clock turns back upward, so 6 is the actual knee point, not a linear cheaper-is-slower tradeoff.

Configurable via `SVG_TESTER_MAX_WORKERS` for hosts that want to tune it further.

## Combined impact

Back-to-back A/B (old vs. new code, same few minutes, to cancel out this session's contention drift), 300-chart sample, before any of the above vs. after fixes #1 and #2 (worker-count change measured and isolated separately above):

| | Before | After |
|---|---|---|
| User CPU | 202.0s | 127.7s (**-37%**) |
| Wall-clock | 60.1s | 36.2s (**-40%**) |

## Ruled out (measured zero benefit, reverted)

- **Per-worker-thread cache for duplicate variable-data loads.** Real duplication exists (up to 9x reuse of one variable across charts in the 63-chart sample), and there's a long-standing TODO about exactly this — but profiling showed data loading is only ~2.4% of total time. Isolated the cache's effect from the other changes: zero measurable difference in wall-clock, CPU, or RSS.

## Profiled, not fixed here (follow-ups)

- **`results.csv` staleness** itself (the bug behind #1 above): `commit_differences` should probably also patch the CSV rows it touches so the column stops drifting for any other potential consumer. Nothing in this PR depends on that fix — we just stopped trusting the column.
- **React SSR render + Grapher's MobX chart computation** is ~29% of per-chart time by our profiling. Real cost, but fixing it means touching Grapher's actual rendering pipeline, not this test harness.
- The hard **deadlock** found mid-investigation (a `verify-graphs` run stuck at 0% CPU across all workers for over an hour) is unrelated to throughput and already fixed separately in #6673.

## Methodology notes

- This shared LXC host's `/proc/loadavg` read 85-115+ throughout the session even while our own process was fully idle — it isn't per-container-scoped, don't trust it as a signal.
- Wall-clock alone was too noisy to compare across runs taken minutes apart (see the two worker-sweep passes above, same code, same subset, very different numbers). `user`+`sys` CPU-seconds from `/usr/bin/time -v` was more reliable but still needed back-to-back A/B toggling within the same few minutes for a clean read once contention rose later in the session.

## Test plan
- [x] Isolated and measured every change independently, including two reverted
- [x] Correctness re-verified after every change and after rebasing onto master
- [x] Worker-count sweep repeated at two contention levels before picking a default
- [ ] Full 4,513-chart production run for final confirmation at scale (not done in this session — trend was consistent and monotonic across both smaller samples)
