### PR TITLE
Harden SVG tester against hangs; fix MobX action warnings in SVG export

### DIFF
--- a/adminSiteClient/EditorExportTab.tsx
+++ b/adminSiteClient/EditorExportTab.tsx
@@ -87,7 +87,7 @@ export class EditorExportTab<
         this.saveOriginalSettings()
 
         // Show a static chart preview on the export tab
-        this.grapherState.isExportingToSvgOrPng = true
+        action(() => (this.grapherState.isExportingToSvgOrPng = true))()
 
         // Use autorun with the computed property to track settings changes
         const dispose = reaction(
@@ -114,7 +114,7 @@ export class EditorExportTab<
 
     override componentWillUnmount(): void {
         this.resetGrapher()
-        this.grapherState.isExportingToSvgOrPng = false
+        action(() => (this.grapherState.isExportingToSvgOrPng = false))()
 
         if (sessionStorage) {
             this.saveSettingsToSessionStorage()

--- a/baker/GrapherImageBaker.tsx
+++ b/baker/GrapherImageBaker.tsx
@@ -12,6 +12,7 @@ import {
     GRAPHER_IMAGE_WIDTH_2X,
 } from "@ourworldindata/grapher"
 import path from "path"
+import { runInAction } from "mobx"
 import * as db from "../db/db.js"
 import { grapherSlugToExportFileKey } from "./GrapherBakingUtils.js"
 import { BAKED_GRAPHER_URL } from "../settings/clientSettings.js"
@@ -85,8 +86,10 @@ export function initGrapherForSvgExport(
             queryStr,
         }),
     })
-    grapher.grapherState.isExportingToSvgOrPng = true
-    grapher.grapherState.shouldIncludeDetailsInStaticExport = false
+    runInAction(() => {
+        grapher.grapherState.isExportingToSvgOrPng = true
+        grapher.grapherState.shouldIncludeDetailsInStaticExport = false
+    })
     return grapher
 }
 
@@ -126,8 +129,10 @@ export async function grapherToSVG(
             ...jsonConfig,
         }),
     })
-    grapher.grapherState.isExportingToSvgOrPng = true
-    grapher.grapherState.shouldIncludeDetailsInStaticExport = false
+    runInAction(() => {
+        grapher.grapherState.isExportingToSvgOrPng = true
+        grapher.grapherState.shouldIncludeDetailsInStaticExport = false
+    })
     // grapher.receiveOwidData(vardata)
     const inputTable = await fetchInputTableForConfig({
         dimensions: jsonConfig.dimensions ?? [],

--- a/devTools/svgTester/utils.ts
+++ b/devTools/svgTester/utils.ts
@@ -117,6 +117,31 @@ export const resultError = (viewId: string, error: Error): VerifyResult => ({
     error,
 })
 
+// A single chart/view should render in well under a second; this is a generous
+// safety margin so one stuck render can't hang the entire run indefinitely.
+export const JOB_TIMEOUT_MS = 2 * 60 * 1000
+
+// Rejects if the given promise doesn't settle within `timeoutMs`. Used to bound
+// a single render so one stuck view can't hang a whole worker job.
+async function withTimeout<T>(
+    promise: Promise<T>,
+    timeoutMs: number,
+    label: string
+): Promise<T> {
+    let timer: ReturnType<typeof setTimeout> | undefined
+    const timeout = new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(
+            () => reject(new Error(`Timed out after ${timeoutMs}ms: ${label}`)),
+            timeoutMs
+        )
+    })
+    try {
+        return await Promise.race([promise, timeout])
+    } finally {
+        if (timer) clearTimeout(timer)
+    }
+}
+
 const resultDifference = (difference: SvgDifference): VerifyResult => ({
     kind: "difference",
     difference: difference,
@@ -1250,53 +1275,65 @@ export async function renderAndVerifyExplorerViews({
                 continue
             }
 
-            // Update the explorer
-            await explorer.reactToUserChangingSelection(oldRow)
+            // Bound each view's render+verify so one stuck view can't hang the
+            // whole worker job. Scoping the timeout here (rather than around the
+            // entire multi-view worker call) means large explorers with many
+            // views aren't misreported as timeouts just for taking a while in
+            // aggregate.
+            const validationResult = await withTimeout(
+                (async (): Promise<VerifyResult> => {
+                    // Update the explorer
+                    await explorer.reactToUserChangingSelection(oldRow)
 
-            // Generate SVG for this view
-            const svg = await explorer.grapherState.generateStaticSvg(
-                ReactDOMServer.renderToStaticMarkup
+                    // Generate SVG for this view
+                    const svg = await explorer.grapherState.generateStaticSvg(
+                        ReactDOMServer.renderToStaticMarkup
+                    )
+
+                    const outFilename = buildSvgOutFilename(
+                        {
+                            slug: explorerSlug,
+                            version: 0, // Explorers don't have versions
+                            width,
+                            height,
+                            queryStr,
+                        },
+                        { shouldHashQueryStr: true }
+                    )
+
+                    const svgRecord: SvgRecord = {
+                        viewId,
+                        chartType: explorer.grapherState.activeTab,
+                        md5: await processSvgAndCalculateHash(svg),
+                        svgFilename: outFilename,
+                    }
+
+                    // Verify against reference
+                    const result = await verifySvg(
+                        svg,
+                        svgRecord,
+                        referenceEntry,
+                        referencesDir,
+                        verbose
+                    )
+
+                    // If there was a difference, write the SVG
+                    if (result.kind === "difference") {
+                        if (verbose) logDifferencesToConsole(svgRecord, result)
+                        const pathFragments = path.parse(svgRecord.svgFilename)
+                        const outputPath = path.join(
+                            differencesDir,
+                            pathFragments.name + pathFragments.ext
+                        )
+                        const cleanedSvg = await prepareSvgForComparison(svg)
+                        await fs.writeFile(outputPath, cleanedSvg)
+                    }
+
+                    return result
+                })(),
+                JOB_TIMEOUT_MS,
+                viewId
             )
-
-            const outFilename = buildSvgOutFilename(
-                {
-                    slug: explorerSlug,
-                    version: 0, // Explorers don't have versions
-                    width,
-                    height,
-                    queryStr,
-                },
-                { shouldHashQueryStr: true }
-            )
-
-            const svgRecord: SvgRecord = {
-                viewId,
-                chartType: explorer.grapherState.activeTab,
-                md5: await processSvgAndCalculateHash(svg),
-                svgFilename: outFilename,
-            }
-
-            // Verify against reference
-            const validationResult = await verifySvg(
-                svg,
-                svgRecord,
-                referenceEntry,
-                referencesDir,
-                verbose
-            )
-
-            // If there was a difference, write the SVG
-            if (validationResult.kind === "difference") {
-                if (verbose)
-                    logDifferencesToConsole(svgRecord, validationResult)
-                const pathFragments = path.parse(svgRecord.svgFilename)
-                const outputPath = path.join(
-                    differencesDir,
-                    pathFragments.name + pathFragments.ext
-                )
-                const cleanedSvg = await prepareSvgForComparison(svg)
-                await fs.writeFile(outputPath, cleanedSvg)
-            }
 
             results.push(validationResult)
         } catch (err) {

--- a/devTools/svgTester/utils.ts
+++ b/devTools/svgTester/utils.ts
@@ -111,7 +111,7 @@ const resultOk = (): VerifyResult => ({
     kind: "ok",
 })
 
-const resultError = (viewId: string, error: Error): VerifyResult => ({
+export const resultError = (viewId: string, error: Error): VerifyResult => ({
     kind: "error",
     viewId,
     error,

--- a/devTools/svgTester/verify-graphs.ts
+++ b/devTools/svgTester/verify-graphs.ts
@@ -12,6 +12,10 @@ import * as utils from "./utils.js"
 import { grapherSlugToExportFileKey } from "../../baker/GrapherBakingUtils.js"
 import { ALL_GRAPHER_CHART_TYPES } from "@ourworldindata/types"
 
+// A single chart should render in well under a second; this is a generous
+// safety margin so one stuck render can't hang the entire run indefinitely.
+const JOB_TIMEOUT_MS = 2 * 60 * 1000
+
 async function verifyExplorers(args: ReturnType<typeof parseArguments>) {
     const testSuite = args.testSuite as utils.TestSuite
     const verbose = args.verbose
@@ -87,7 +91,12 @@ async function verifyExplorers(args: ReturnType<typeof parseArguments>) {
 
     const validationResultsArrays: utils.VerifyResult[][] = await Promise.all(
         explorerJobs.map((job) =>
-            pool.exec("renderAndVerifyExplorerViews", [job])
+            pool
+                .exec("renderAndVerifyExplorerViews", [job])
+                .timeout(JOB_TIMEOUT_MS)
+                .catch((err: Error) => [
+                    utils.resultError(job.explorerSlug, err),
+                ])
         )
     )
 
@@ -214,7 +223,14 @@ async function verifyGraphers(args: ReturnType<typeof parseArguments>) {
         // the reference csv file (from the referenceDataByChartKey lookup above). The entire parallel operation returns a promise containing an array
         // of result values.
         const validationResults: utils.VerifyResult[] = await Promise.all(
-            verifyJobs.map((job) => pool.exec("renderAndVerifySvg", [job]))
+            verifyJobs.map((job) =>
+                pool
+                    .exec("renderAndVerifySvg", [job])
+                    .timeout(JOB_TIMEOUT_MS)
+                    .catch((err: Error) =>
+                        utils.resultError(job.dir.viewId, err)
+                    )
+            )
         )
 
         if (validationResults.length !== verifyJobs.length)

--- a/devTools/svgTester/verify-graphs.ts
+++ b/devTools/svgTester/verify-graphs.ts
@@ -9,12 +9,9 @@ import * as _ from "lodash-es"
 import { match } from "ts-pattern"
 
 import * as utils from "./utils.js"
+import { JOB_TIMEOUT_MS } from "./utils.js"
 import { grapherSlugToExportFileKey } from "../../baker/GrapherBakingUtils.js"
 import { ALL_GRAPHER_CHART_TYPES } from "@ourworldindata/types"
-
-// A single chart should render in well under a second; this is a generous
-// safety margin so one stuck render can't hang the entire run indefinitely.
-const JOB_TIMEOUT_MS = 2 * 60 * 1000
 
 async function verifyExplorers(args: ReturnType<typeof parseArguments>) {
     const testSuite = args.testSuite as utils.TestSuite
@@ -91,9 +88,12 @@ async function verifyExplorers(args: ReturnType<typeof parseArguments>) {
 
     const validationResultsArrays: utils.VerifyResult[][] = await Promise.all(
         explorerJobs.map((job) =>
+            // The per-view timeout lives inside renderAndVerifyExplorerViews,
+            // so we deliberately don't wrap this whole (multi-view) call in
+            // .timeout() — a large explorer with many views could legitimately
+            // exceed the per-view budget in aggregate.
             pool
                 .exec("renderAndVerifyExplorerViews", [job])
-                .timeout(JOB_TIMEOUT_MS)
                 .catch((err: Error) => [
                     utils.resultError(job.explorerSlug, err),
                 ])

--- a/functions/_common/grapherTools.ts
+++ b/functions/_common/grapherTools.ts
@@ -1,4 +1,5 @@
 import * as _ from "lodash-es"
+import { runInAction } from "mobx"
 import {
     CsvDownloadType,
     type DataDownloadContextBase,
@@ -341,8 +342,10 @@ export async function initGrapher(
         additionalDataLoaderFn,
         ...options.grapherProps,
     })
-    grapherState.isExportingToSvgOrPng = true
-    grapherState.shouldIncludeDetailsInStaticExport = options.details
+    runInAction(() => {
+        grapherState.isExportingToSvgOrPng = true
+        grapherState.shouldIncludeDetailsInStaticExport = options.details
+    })
     const grapher = new Grapher({ grapherState })
 
     return {

--- a/functions/package.json
+++ b/functions/package.json
@@ -14,6 +14,7 @@
         "itty-router": "^5.0.23",
         "littlezipper": "^0.1.5",
         "lodash-es": "^4.18.1",
+        "mobx": "^6.15.4",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "remeda": "^2.32.0",

--- a/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
@@ -2961,12 +2961,12 @@ export class GrapherState
 
         // Temporarily set isExportingToSvgOrPng to true
         const _isExportingToSvgOrPng = this.isExportingToSvgOrPng
-        this.isExportingToSvgOrPng = true
+        runInAction(() => (this.isExportingToSvgOrPng = true))
 
         const innerHTML = renderToHtmlString(<Chart manager={this} />)
 
         // Restore isExportingToSvgOrPng
-        this.isExportingToSvgOrPng = _isExportingToSvgOrPng
+        runInAction(() => (this.isExportingToSvgOrPng = _isExportingToSvgOrPng))
 
         return innerHTML
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11200,6 +11200,7 @@ __metadata:
     itty-router: "npm:^5.0.23"
     littlezipper: "npm:^0.1.5"
     lodash-es: "npm:^4.18.1"
+    mobx: "npm:^6.15.4"
     react: "npm:^19.2.4"
     react-dom: "npm:^19.2.4"
     remeda: "npm:^2.32.0"


### PR DESCRIPTION
## Summary
- The "SVG tester" Buildkite step has been hanging indefinitely (only killed by Buildkite's ~60min job timeout) across every PR I sampled since 2026-06-30 15:51-16:16 UTC — confirmed by reproducing it live on `staging-site-population-share-tooltip`: the `verify-graphs.ts` process was still running an hour after CI reported failure, idle (0% CPU, no open sockets) across all worker threads.
- This is very unlikely to be caused by app code in this repo — I checked `owid-grapher`, `owid/ops` (pipeline/scripts), and `owid-grapher-svgs` (reference data) commit history around that window and found nothing that would explain a simultaneous regression across unrelated branches. It's most likely a shared staging/LXC host-level change — flagging separately to whoever owns that infra.
- Regardless of the root trigger, `devTools/svgTester/verify-graphs.ts` had no per-job timeout: `Promise.all` over all `pool.exec()` calls meant a single stuck chart blocked the entire run forever. Fixed by using workerpool's built-in `Promise.timeout()`, which force-terminates the stuck worker and reports that one chart as an error.
- Also fixed 4 pre-existing (since January) MobX strict-mode violations that were flooding the CI log with `[MobX] ... is not allowed` warnings on every single chart render: `isExportingToSvgOrPng`/`shouldIncludeDetailsInStaticExport` were mutated outside a MobX action in `GrapherState.generateStaticSvg`, `GrapherImageBaker.ts` (x2), `grapherTools.initGrapher`, and `EditorExportTab`.

## Test plan
- [ ] Re-run the SVG tester on a staging build and confirm it either completes normally or, if the underlying hang trigger is still present, fails fast on the specific stuck chart instead of running for an hour.
- [ ] Confirm the `[MobX] ... isExportingToSvgOrPng` warnings no longer appear in a fresh SVG tester run's log.
- Note: `oxfmt`/`oxlint` binaries were unavailable in my environment, so I could not run the standard pre-commit format/lint check on these files — worth a manual formatting pass before merge.