### PR TITLE
[codex] Add chart redirect target query params

### DIFF
--- a/adminSiteClient/EditorReferencesTab.tsx
+++ b/adminSiteClient/EditorReferencesTab.tsx
@@ -346,7 +346,7 @@ class AddRedirectForm<Editor extends AbstractChartEditor> extends Component<
                         }
                     />
                 </div>
-                <div className="input-group mb-3">
+                <div className="input-group mb-2">
                     <div className="input-group-prepend">
                         <span className="input-group-text">
                             Target query params (optional)
@@ -361,15 +361,15 @@ class AddRedirectForm<Editor extends AbstractChartEditor> extends Component<
                             this.onTargetQueryParamChange(event.target.value)
                         }
                     />
-                    <div className="input-group-append">
-                        <button
-                            className="btn btn-primary"
-                            type="submit"
-                            disabled={!this.slug || this.isLoading}
-                        >
-                            Add
-                        </button>
-                    </div>
+                </div>
+                <div className="text-right mb-3">
+                    <button
+                        className="btn btn-primary"
+                        type="submit"
+                        disabled={!this.slug || this.isLoading}
+                    >
+                        Add redirect
+                    </button>
                 </div>
                 {this.errorMessage && (
                     <div className="alert alert-danger">

--- a/adminSiteClient/EditorReferencesTab.tsx
+++ b/adminSiteClient/EditorReferencesTab.tsx
@@ -186,8 +186,7 @@ export class EditorReferencesTabForChart extends Component<{
                                         {redirect.targetQueryParam ? (
                                             <span className="text-muted">
                                                 {" "}
-                                                -&gt; ?
-                                                {redirect.targetQueryParam}
+                                                ➡️ ?{redirect.targetQueryParam}
                                             </span>
                                         ) : null}
                                     </li>
@@ -331,7 +330,7 @@ class AddRedirectForm<Editor extends AbstractChartEditor> extends Component<
                     void this.onSubmit()
                 }}
             >
-                <div className="input-group mb-3">
+                <div className="input-group mb-2">
                     <div className="input-group-prepend">
                         <span className="input-group-text" id="basic-addon3">
                             {BASE_URL}/
@@ -346,10 +345,17 @@ class AddRedirectForm<Editor extends AbstractChartEditor> extends Component<
                             this.onSlugChange(event.target.value)
                         }
                     />
+                </div>
+                <div className="input-group mb-3">
+                    <div className="input-group-prepend">
+                        <span className="input-group-text">
+                            Target query params (optional)
+                        </span>
+                    </div>
                     <input
                         type="text"
                         className="form-control"
-                        placeholder="Target query param, e.g. tab=map"
+                        placeholder="e.g. 'tab=map'"
                         value={this.targetQueryParam}
                         onChange={(event) =>
                             this.onTargetQueryParamChange(event.target.value)

--- a/adminSiteClient/EditorReferencesTab.tsx
+++ b/adminSiteClient/EditorReferencesTab.tsx
@@ -183,6 +183,13 @@ export class EditorReferencesTabForChart extends Component<{
                                         >
                                             <strong>{redirect.slug}</strong>
                                         </a>
+                                        {redirect.targetQueryParam ? (
+                                            <span className="text-muted">
+                                                {" "}
+                                                -&gt; ?
+                                                {redirect.targetQueryParam}
+                                            </span>
+                                        ) : null}
                                     </li>
                                 ))}
                             </ul>
@@ -261,6 +268,7 @@ class AddRedirectForm<Editor extends AbstractChartEditor> extends Component<
     declare context: AdminAppContextType
 
     slug: string | undefined = ""
+    targetQueryParam: string | undefined = ""
 
     isLoading: boolean = false
     errorMessage: string | undefined = undefined
@@ -270,13 +278,18 @@ class AddRedirectForm<Editor extends AbstractChartEditor> extends Component<
 
         makeObservable(this, {
             slug: observable,
+            targetQueryParam: observable,
             isLoading: observable,
             errorMessage: observable,
         })
     }
 
-    @action.bound onChange(slug: string) {
+    @action.bound onSlugChange(slug: string) {
         this.slug = slug
+    }
+
+    @action.bound onTargetQueryParamChange(targetQueryParam: string) {
+        this.targetQueryParam = targetQueryParam
     }
 
     @action.bound async onSubmit() {
@@ -286,7 +299,10 @@ class AddRedirectForm<Editor extends AbstractChartEditor> extends Component<
                 const chartId = this.props.editor.grapherState.id
                 const result = await this.context.admin.requestJSON(
                     `/api/charts/${chartId}/redirects/new`,
-                    { slug: this.slug },
+                    {
+                        slug: this.slug,
+                        targetQueryParam: this.targetQueryParam,
+                    },
                     "POST",
                     { onFailure: "continue" }
                 )
@@ -294,6 +310,7 @@ class AddRedirectForm<Editor extends AbstractChartEditor> extends Component<
                 runInAction(() => {
                     this.isLoading = false
                     this.slug = ""
+                    this.targetQueryParam = ""
                     this.errorMessage = undefined
                 })
                 this.props.onSuccess(redirect)
@@ -325,7 +342,18 @@ class AddRedirectForm<Editor extends AbstractChartEditor> extends Component<
                         className="form-control"
                         placeholder="URL"
                         value={this.slug}
-                        onChange={(event) => this.onChange(event.target.value)}
+                        onChange={(event) =>
+                            this.onSlugChange(event.target.value)
+                        }
+                    />
+                    <input
+                        type="text"
+                        className="form-control"
+                        placeholder="Target query param, e.g. tab=map"
+                        value={this.targetQueryParam}
+                        onChange={(event) =>
+                            this.onTargetQueryParamChange(event.target.value)
+                        }
                     />
                     <div className="input-group-append">
                         <button

--- a/adminSiteClient/RedirectsIndexPage.tsx
+++ b/adminSiteClient/RedirectsIndexPage.tsx
@@ -9,6 +9,7 @@ interface RedirectListItem {
     slug: string
     chartId: number
     chartSlug: string
+    targetQueryParam: string | null
 }
 
 interface RedirectRowProps {
@@ -23,6 +24,9 @@ function RedirectRow({ redirect, onDelete }: RedirectRowProps) {
             <td>
                 <Link to={`/charts/${redirect.chartId}/edit`}>
                     {redirect.chartSlug}
+                    {redirect.targetQueryParam
+                        ? `?${redirect.targetQueryParam}`
+                        : ""}
                 </Link>
             </td>
             <td>

--- a/adminSiteServer/apiRoutes/redirects.ts
+++ b/adminSiteServer/apiRoutes/redirects.ts
@@ -11,6 +11,13 @@ import * as db from "../../db/db.js"
 import { Request } from "../authentication.js"
 import { HandlerResponse } from "../FunctionalRouter.js"
 
+function normalizeTargetQueryParam(
+    targetQueryParam: string | undefined
+): string | null {
+    const normalized = targetQueryParam?.trim().replace(/^\?/, "")
+    return normalized || null
+}
+
 export async function handleGetSiteRedirects(
     req: Request,
     res: HandlerResponse,
@@ -92,6 +99,7 @@ export async function handleGetRedirects(
                     r.id,
                     r.slug,
                     r.chart_id as chartId,
+                    r.target_query_param as targetQueryParam,
                     chart_configs.slug AS chartSlug
                 FROM chart_slug_redirects AS r
                 JOIN charts ON charts.id = r.chart_id
@@ -108,16 +116,32 @@ export async function handlePostNewChartRedirect(
     trx: db.KnexReadWriteTransaction
 ) {
     const chartId = expectInt(req.params.chartId)
-    const fields = req.body as { slug: string }
+    const fields = req.body as {
+        slug: string
+        targetQueryParam?: string
+    }
+    const targetQueryParam = normalizeTargetQueryParam(fields.targetQueryParam)
     const result = await db.knexRawInsert(
         trx,
-        `INSERT INTO chart_slug_redirects (chart_id, slug) VALUES (?, ?)`,
-        [chartId, fields.slug]
+        `INSERT INTO chart_slug_redirects (chart_id, slug, target_query_param) VALUES (?, ?, ?)`,
+        [chartId, fields.slug, targetQueryParam]
     )
     const redirectId = result.insertId
-    const redirect = await db.knexRaw<DbPlainChartSlugRedirect>(
+    const redirect = await db.knexRawFirst<
+        Pick<DbPlainChartSlugRedirect, "id" | "slug"> & {
+            chartId: number
+            targetQueryParam: string | null
+        }
+    >(
         trx,
-        `SELECT * FROM chart_slug_redirects WHERE id = ?`,
+        `-- sql
+        SELECT
+            id,
+            slug,
+            chart_id as chartId,
+            target_query_param as targetQueryParam
+        FROM chart_slug_redirects
+        WHERE id = ?`,
         [redirectId]
     )
     return { success: true, redirect: redirect }

--- a/baker/redirectsFromDb.ts
+++ b/baker/redirectsFromDb.ts
@@ -19,7 +19,16 @@ export async function getRecentChartSlugRedirects(
         `-- sql
         SELECT
             CONCAT('/grapher/', chart_slug_redirects.slug) as source,
-            CONCAT('/grapher/', chart_configs.slug) as target
+            CONCAT(
+                '/grapher/',
+                chart_configs.slug,
+                IF(
+                    chart_slug_redirects.target_query_param IS NULL
+                    OR chart_slug_redirects.target_query_param = '',
+                    '',
+                    CONCAT('?', chart_slug_redirects.target_query_param)
+                )
+            ) as target
         FROM chart_slug_redirects
         INNER JOIN charts ON charts.id=chart_id
         INNER JOIN chart_configs ON chart_configs.id=charts.configId
@@ -53,10 +62,14 @@ export const getGrapherToChartRedirects = async (
     const chartRedirectRows = await db.knexRaw<{
         oldSlug: string
         newSlug: string
+        targetQueryParam: string | null
     }>(
         knex,
         `-- sql
-            SELECT chart_slug_redirects.slug as oldSlug, chart_configs.slug as newSlug
+            SELECT
+                chart_slug_redirects.slug as oldSlug,
+                chart_configs.slug as newSlug,
+                chart_slug_redirects.target_query_param as targetQueryParam
             FROM chart_slug_redirects
             INNER JOIN charts ON charts.id=chart_id
             INNER JOIN chart_configs ON chart_configs.id=charts.configId
@@ -68,7 +81,9 @@ export const getGrapherToChartRedirects = async (
             .filter((row) => row.oldSlug !== row.newSlug)
             .map((row) => [
                 `${urlPrefix}${row.oldSlug}`,
-                `${urlPrefix}${row.newSlug}`,
+                `${urlPrefix}${row.newSlug}${
+                    row.targetQueryParam ? `?${row.targetQueryParam}` : ""
+                }`,
             ])
     )
 }

--- a/db/docs/chart_slug_redirects.yml
+++ b/db/docs/chart_slug_redirects.yml
@@ -10,6 +10,8 @@ fields:
     description: Old slug that should redirect to the new chart location (unique constraint)
   chart_id:
     description: Foreign key to charts table. Target chart ID for the redirect.
+  target_query_param:
+    description: Optional query string to append to the target chart URL, stored without the leading question mark.
   createdAt:
     description: Timestamp when the redirect was created
   updatedAt:

--- a/db/migration/1782901735673-AddChartSlugRedirectTargetQueryParam.ts
+++ b/db/migration/1782901735673-AddChartSlugRedirectTargetQueryParam.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class AddChartSlugRedirectTargetQueryParam1782901735673 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`-- sql
+            ALTER TABLE chart_slug_redirects
+            ADD COLUMN target_query_param VARCHAR(2047) NULL AFTER chart_id
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`-- sql
+            ALTER TABLE chart_slug_redirects
+            DROP COLUMN target_query_param
+        `)
+    }
+}

--- a/db/model/Chart.ts
+++ b/db/model/Chart.ts
@@ -699,7 +699,11 @@ export const getRedirectsByChartId = async (
     await db.knexRaw(
         knex,
         `-- sql
-        SELECT id, slug, chart_id as chartId
+        SELECT
+            id,
+            slug,
+            chart_id as chartId,
+            target_query_param as targetQueryParam
         FROM chart_slug_redirects
         WHERE chart_id = ?
         ORDER BY id ASC`,

--- a/packages/@ourworldindata/types/src/dbTypes/ChartSlugRedirects.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/ChartSlugRedirects.ts
@@ -4,6 +4,7 @@ export interface DbInsertChartSlugRedirect {
     createdAt?: Date
     id?: number
     slug: string
+    target_query_param?: string | null
     updatedAt?: Date
 }
 export type DbPlainChartSlugRedirect = Required<DbInsertChartSlugRedirect>

--- a/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
+++ b/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
@@ -818,6 +818,7 @@ export interface ChartRedirect {
     id: number
     slug: string
     chartId: number
+    targetQueryParam: string | null
 }
 
 export enum GrapherWindowType {


### PR DESCRIPTION
## Summary

Adds an optional `target_query_param` field to `chart_slug_redirects` so chart slug redirects can point at a chart with a specific target query string.

This enables scenarios like redirecting a chart to `?tab=scatter`.