### PR TITLE
✨🤖 (search) show indicator titleVariant in search results

### DIFF
--- a/baker/algolia/utils/charts.ts
+++ b/baker/algolia/utils/charts.ts
@@ -190,6 +190,17 @@ async function getRawChartsRecords(
                      INNER JOIN indexable_charts ic ON ic.id = ct.chartId
                      LEFT JOIN tags t on ct.tagId = t.id
             GROUP BY ct.chartId
+        ),
+        -- titleVariants of y-indicators, only for charts with exactly one y-dimension
+        title_variants AS (
+            SELECT cd.chartId,
+                   MAX(v.titleVariant) AS titleVariant
+            FROM chart_dimensions cd
+                     INNER JOIN indexable_charts ic ON ic.id = cd.chartId
+                     LEFT JOIN variables v ON cd.variableId = v.id
+            WHERE cd.property = 'y'
+            GROUP BY cd.chartId
+            HAVING COUNT(*) = 1
         )
         SELECT c.id,
                c.slug,
@@ -203,13 +214,15 @@ async function getRawChartsRecords(
                COALESCE(ddc.datasetProducts, '[]') AS datasetProducts,
                COALESCE(ddc.datasetProducers, '[]') AS datasetProducers,
                ctn.tags,
-               COALESCE(kct.keyChartForTags, '[]') AS keyChartForTags
+               COALESCE(kct.keyChartForTags, '[]') AS keyChartForTags,
+               tv.titleVariant AS titleVariant
         FROM indexable_charts c
                  LEFT JOIN entity_names en ON c.id = en.chartId
                  LEFT JOIN dataset_dimensions_by_chart ddc ON c.id = ddc.chartId
                  INNER JOIN chart_tag_counts tc ON c.id = tc.chartId
                  LEFT JOIN chart_tags_names ctn ON c.id = ctn.chartId
                  LEFT JOIN key_chart_tags kct ON c.id = kct.chartId
+                 LEFT JOIN title_variants tv ON c.id = tv.chartId
         WHERE tc.tagCount >= 1
     `
     )
@@ -257,6 +270,7 @@ async function buildChartRecord(
         slug: chart.slug,
         title,
         variantName: chart.config.variantName ?? "",
+        titleVariant: chart.titleVariant || undefined,
         subtitle: plaintextSubtitle,
         availableEntities: chart.entityNames,
         numDimensions: parseInt(chart.numDimensions),

--- a/baker/algolia/utils/mdimViews.ts
+++ b/baker/algolia/utils/mdimViews.ts
@@ -147,6 +147,10 @@ async function getRecords(
                 "",
             grapherState.shouldAddChangeInPrefixToTitle
         )
+        const titleVariant =
+            view.indicators.y.length === 1
+                ? metadata.presentation?.titleVariant
+                : undefined
         const containerTitle = multiDim.config.title.title
         const subtitle = toPlaintext(
             metadata.descriptionShort || chartConfig.subtitle || ""
@@ -191,6 +195,7 @@ async function getRecords(
             containerTitle,
             subtitle,
             variantName: chartConfig.variantName,
+            titleVariant,
             availableTabs: grapherState.availableTabs,
             keyChartForTags: [],
             tags,

--- a/baker/algolia/utils/types.ts
+++ b/baker/algolia/utils/types.ts
@@ -32,6 +32,7 @@ export interface RawChartRecordRow {
     datasetVersions: JsonArrayString
     datasetProducts: JsonArrayString
     datasetProducers: JsonArrayString
+    titleVariant: string | null
 }
 
 export type ParsedChartRecordRow = {
@@ -44,6 +45,7 @@ export type ParsedChartRecordRow = {
     entityNames: string[]
     tags: string[]
     keyChartForTags: string[]
+    titleVariant: string | null
 } & DatasetChartRecordDimensions
 
 /** Explorers */

--- a/packages/@ourworldindata/types/src/domainTypes/Search.ts
+++ b/packages/@ourworldindata/types/src/domainTypes/Search.ts
@@ -57,6 +57,7 @@ export interface ChartRecord {
     containerTitle?: string
     subtitle: string | undefined
     variantName: string
+    titleVariant?: string
     availableTabs: GrapherTabName[]
     keyChartForTags: string[]
     tags: string[]
@@ -107,6 +108,7 @@ interface BaseSearchChartHit {
     originalAvailableEntities?: string[]
     objectID: string
     variantName?: string
+    titleVariant?: string
     subtitle?: string
     availableTabs: GrapherTabName[]
     /**

--- a/site/search/SearchChartHitHeader.scss
+++ b/site/search/SearchChartHitHeader.scss
@@ -72,6 +72,10 @@
                 line-clamp: 2;
             }
         }
+
+        .search-chart-hit-header__title-variant {
+            font-style: italic;
+        }
     }
 
     &:hover .search-chart-hit-header__title {

--- a/site/search/SearchChartHitHeader.tsx
+++ b/site/search/SearchChartHitHeader.tsx
@@ -1,4 +1,5 @@
 import cx from "clsx"
+import * as _ from "lodash-es"
 import { Highlight } from "react-instantsearch"
 import { CHARTS_INDEX } from "./searchUtils.js"
 import { SearchChartHit } from "@ourworldindata/types"
@@ -54,20 +55,7 @@ export function SearchChartHitHeader({
                             </span>
                         )}
                     </div>
-                    {subtitle && subtitle !== hit.subtitle ? (
-                        <div className="search-chart-hit-header__subtitle">
-                            {subtitle}
-                        </div>
-                    ) : hit.subtitle ? (
-                        <Highlight
-                            hit={hit}
-                            attribute="subtitle"
-                            highlightedTagName="strong"
-                            classNames={{
-                                root: "search-chart-hit-header__subtitle",
-                            }}
-                        />
-                    ) : null}
+                    <SearchChartHitSubtitle hit={hit} subtitle={subtitle} />
                     {source && (
                         <span className="search-chart-hit-header__source search-chart-hit-header__source--mobile">
                             Source: {source}
@@ -76,5 +64,41 @@ export function SearchChartHitHeader({
                 </div>
             </div>
         </a>
+    )
+}
+
+function SearchChartHitSubtitle({
+    hit,
+    subtitle,
+}: {
+    hit: SearchChartHit
+    subtitle?: string // fresh subtitle from the live-fetched grapher
+}) {
+    const hasSubtitle = !!subtitle || !!hit.subtitle
+
+    if (!hit.titleVariant && !hasSubtitle) return null
+
+    // Prefer the fresh subtitle when it differs from the indexed one
+    const shouldUseFreshSubtitle = !!subtitle && subtitle !== hit.subtitle
+
+    return (
+        <div className="search-chart-hit-header__subtitle">
+            {hit.titleVariant && (
+                <span className="search-chart-hit-header__title-variant">
+                    {_.upperFirst(hit.titleVariant)}
+                </span>
+            )}
+            {/* Separator only when a subtitle follows the variant */}
+            {hit.titleVariant && hasSubtitle ? " – " : null}
+            {shouldUseFreshSubtitle ? (
+                subtitle
+            ) : hit.subtitle ? (
+                <Highlight
+                    hit={hit}
+                    attribute="subtitle"
+                    highlightedTagName="strong"
+                />
+            ) : null}
+        </div>
     )
 }

--- a/site/search/searchUtils.tsx
+++ b/site/search/searchUtils.tsx
@@ -368,6 +368,7 @@ export const DATA_CATALOG_ATTRIBUTES = [
     "availableEntities",
     "originalAvailableEntities",
     "variantName",
+    "titleVariant",
     "type",
     "queryParams",
     "availableTabs",


### PR DESCRIPTION
For single-y-indicator charts and multi-dim views, index the y-indicator's
titleVariant and display it (italic, sentence-cased) as a prefix to the
subtitle, disambiguating otherwise identical-looking results.

Examples:
- http://staging-site-search-title-variant/search?q=New+infections+of+HIV+per+1%2C000+people
- http://staging-site-search-title-variant/search?q=Number+of+people+who+are+moderately+or+severely+food+insecure
- http://staging-site-search-title-variant/search?topics=Life+Expectancy

Resolves #5800