### PR TITLE
Test removeWordsIfNoResults alone on charts search

### DIFF
--- a/baker/algolia/configureAlgolia.ts
+++ b/baker/algolia/configureAlgolia.ts
@@ -149,6 +149,11 @@ export const configureAlgolia = async () => {
             attributesToSnippet: ["subtitle:24"],
             attributeForDistinct: "id",
             optionalWords: ["vs"],
+            // If a query still returns nothing, retry treating all words as optional
+            // rather than showing a blank page — for a data site a topic match beats
+            // no results. Testing this alone (without hand-curated optionalWords) to
+            // see if it's sufficient on its own.
+            removeWordsIfNoResults: "allOptional",
 
             // These lines below essentially demote matches in the `subtitle` and `availableEntities` fields:
             // If we find a match (only) there, then it doesn't count towards `exact`, and is therefore ranked lower.


### PR DESCRIPTION
Replaces #6667, which was auto-closed when its branch was renamed.

`removeWordsIfNoResults` alone on the charts index (no stopword-optional change). Renamed from `algolia-remove-words-if-no-results` → `algolia-removewords-only` because the original branch name truncated to the *same* staging hostname as #6669 (`…-lastwords`), so the two couldn't be deployed side by side. The shorter name gives it a distinct `staging-site-algolia-removewords-only` host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)