### PR TITLE
[preview, do not merge] Food-trade viz on preview R2 data

### DIFF
--- a/bespoke/projects/food-trade/src/data.ts
+++ b/bespoke/projects/food-trade/src/data.ts
@@ -10,7 +10,10 @@ import {
     TradeRow,
 } from "./types.js"
 
-const BASE_URL = "https://owid-public.owid.io/data/food-trade"
+// TEMPORARY (preview only — do not merge): points at the food-trade-preview R2 folder
+// so the staging server renders the flow-only JSONs produced by the ETL branch that drops
+// the SCL production/supply shares. Revert to "…/data/food-trade" before merging.
+const BASE_URL = "https://owid-public.owid.io/data/food-trade-preview"
 const METADATA_PATH = `${BASE_URL}/food-trade.metadata.json`
 const PRODUCT_DATA_PATH = (productId: number) =>
     `${BASE_URL}/food-trade.${productId}.json`


### PR DESCRIPTION
> _Written by Claude Code — @pabloarosado at the wheel._

**Temporary preview PR — do not merge.**

Points the food-trade bespoke viz at the `data/food-trade-preview` R2 folder instead of production `data/food-trade`, so this branch's staging server renders the new **flow-only** JSONs.

Those JSONs come from the ETL branch that removes the SCL dependency from the `food_trade` garden step (dropping the exporter-production and importer-domestic-supply columns that fed the now-retired percentage shares). The viz on `master` already stopped reading `production`/`supply` (commit `bfb8b6d031`), so this is a visual confirmation that the simplified data renders correctly end-to-end.

Only change: `BASE_URL` in `bespoke/projects/food-trade/src/data.ts`. Revert and close once the preview has been reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)