### PR TITLE
Delete the pages-chronological index on staging teardown

### DIFF
--- a/baker/algolia/deleteAlgoliaIndex.tsx
+++ b/baker/algolia/deleteAlgoliaIndex.tsx
@@ -1,7 +1,11 @@
 import { ALGOLIA_INDEXING } from "../../settings/serverSettings.js"
 import { ALGOLIA_INDEX_PREFIX } from "../../settings/clientSettings.js"
 import { getAlgoliaClient } from "./configureAlgolia.js"
-import { PAGES_INDEX, CHARTS_INDEX } from "../../site/search/searchUtils.js"
+import {
+    PAGES_INDEX,
+    CHARTS_INDEX,
+    PAGES_CHRONOLOGICAL_INDEX,
+} from "../../site/search/searchUtils.js"
 
 const deleteAlgoliaIndex = async () => {
     if (!ALGOLIA_INDEXING) return
@@ -19,7 +23,11 @@ const deleteAlgoliaIndex = async () => {
         return
     }
 
-    for (const indexName of [PAGES_INDEX, CHARTS_INDEX]) {
+    for (const indexName of [
+        PAGES_INDEX,
+        CHARTS_INDEX,
+        PAGES_CHRONOLOGICAL_INDEX,
+    ]) {
         try {
             await client.deleteIndex({ indexName })
             console.log(`Index '${indexName}' removed successfully`)


### PR DESCRIPTION
`deleteAlgoliaIndex` (run by `make delete-algolia-index` on staging teardown) only removed `PAGES_INDEX` and `CHARTS_INDEX` — never `PAGES_CHRONOLOGICAL_INDEX`. So every torn-down algolia staging left its `<prefix>-pages-chronological` index behind.

These orphans accumulate one-per-staging and contributed to exhausting the Algolia **record quota** (which blocks new staging search-index builds). A quick audit found ~10 stranded `*-pages-chronological` indices from long-merged PRs.

Fix: add `PAGES_CHRONOLOGICAL_INDEX` to the deletion set so teardown removes all three indices a staging actually builds (pages, charts, pages-chronological).

Companion to owid/ops#539, which fixes the *other* leak (orphan-pruned containers skipping the delete entirely because the `staging-algolia` label check failed on `PR_LABELS=''`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)