### PR TITLE
Improve scroll to selected topic in /latest

### DIFF
--- a/site/latest/LatestTopicFacets.tsx
+++ b/site/latest/LatestTopicFacets.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useRef } from "react"
+import React, { useCallback, useContext } from "react"
 import cx from "clsx"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import {
@@ -33,12 +33,16 @@ const TopicPill = ({ itemId: _itemId, ...props }: TopicPillProps) => {
     return <ToggleButton {...props} />
 }
 
-function scrollPillIntoView(node: HTMLButtonElement | null): void {
+function scrollPillIntoView(node: Element | null): void {
     node?.scrollIntoView({
         behavior: "smooth",
         inline: "center",
         block: "nearest",
     })
+}
+
+function scrollFocusedPillIntoView(event: React.FocusEvent<Element>): void {
+    scrollPillIntoView(event.currentTarget)
 }
 
 const LeftArrow = () => {
@@ -132,9 +136,6 @@ export const LatestTopicFacets = ({
     disabledTypes: Set<LatestType>
     disabledTopics: Set<string>
 }) => {
-    type ScrollApiType = React.ContextType<typeof VisibilityContext>
-    const apiRef = useRef({} as ScrollApiType)
-
     // Topic selection on /latest is single-select in the UI: clicking a
     // topic replaces the current selection (or clears it when re-clicked).
     // The underlying state and query layers still model topics as a
@@ -158,13 +159,6 @@ export const LatestTopicFacets = ({
         [onTopicsChange]
     )
 
-    const handlePillFocus = useCallback((id: string) => {
-        const item = apiRef.current.getItemById?.(id)
-        if (item) {
-            apiRef.current.scrollToItem(item, "smooth", "nearest")
-        }
-    }, [])
-
     return (
         <div className="latest-topic-facets">
             <div className="latest-topic-facets__filters">
@@ -174,18 +168,14 @@ export const LatestTopicFacets = ({
                     selectedKeys={selectedKeys}
                     onSelectionChange={handleSelectionChange}
                 >
-                    <ScrollMenu
-                        LeftArrow={LeftArrow}
-                        RightArrow={RightArrow}
-                        apiRef={apiRef}
-                    >
+                    <ScrollMenu LeftArrow={LeftArrow} RightArrow={RightArrow}>
                         {[
                             <TopicPill
                                 key="all"
                                 itemId="all"
                                 id="all"
                                 className="latest-topic-facets__topic-pill"
-                                onFocus={() => handlePillFocus("all")}
+                                onFocus={scrollFocusedPillIntoView}
                                 aria-label="All topics"
                             >
                                 All
@@ -202,7 +192,7 @@ export const LatestTopicFacets = ({
                                     }
                                     className="latest-topic-facets__topic-pill"
                                     isDisabled={disabledTopics.has(topic)}
-                                    onFocus={() => handlePillFocus(topic)}
+                                    onFocus={scrollFocusedPillIntoView}
                                 >
                                     {topic}
                                 </TopicPill>

--- a/site/latest/LatestTopicFacets.tsx
+++ b/site/latest/LatestTopicFacets.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useEffect, useRef } from "react"
+import React, { useCallback, useContext, useRef } from "react"
 import cx from "clsx"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import {
@@ -17,7 +17,6 @@ import {
     ToggleButton,
     ToggleButtonGroup,
     type Key,
-    type ToggleButtonProps,
 } from "react-aria-components"
 import { LATEST_TYPE_VALUES, LatestType } from "@ourworldindata/types"
 import { latestTypeLabelPlural } from "./latestUtils.js"
@@ -26,11 +25,20 @@ import { latestTypeLabelPlural } from "./latestUtils.js"
  * Wrapper that accepts the `itemId` prop required by
  * react-horizontal-scrolling-menu while rendering a react-aria ToggleButton.
  */
-const TopicPill = ({
-    itemId: _itemId,
-    ...props
-}: { itemId: string } & ToggleButtonProps) => {
+type TopicPillProps = React.ComponentProps<typeof ToggleButton> & {
+    itemId: string
+}
+
+const TopicPill = ({ itemId: _itemId, ...props }: TopicPillProps) => {
     return <ToggleButton {...props} />
+}
+
+function scrollPillIntoView(node: HTMLButtonElement | null): void {
+    node?.scrollIntoView({
+        behavior: "smooth",
+        inline: "center",
+        block: "nearest",
+    })
 }
 
 const LeftArrow = () => {
@@ -146,13 +154,6 @@ export const LatestTopicFacets = ({
                 .filter((k) => k !== "all")
                 .map((k) => String(k))
             onTopicsChange(next)
-            const focusKey = next[0]
-            if (focusKey) {
-                const item = apiRef.current.getItemById?.(focusKey)
-                if (item) {
-                    apiRef.current.scrollToItem(item, "smooth", "center")
-                }
-            }
         },
         [onTopicsChange]
     )
@@ -163,27 +164,6 @@ export const LatestTopicFacets = ({
             apiRef.current.scrollToItem(item, "smooth", "nearest")
         }
     }, [])
-
-    // Scroll the selected topic into view on initial load
-    useEffect(() => {
-        const topic = selectedTopics[0]
-        if (!topic) return
-        let rafId = 0
-        let attempts = 0
-        const MAX_ATTEMPTS = 30
-        const tryScroll = () => {
-            const item = apiRef.current.getItemById?.(topic)
-            if (item?.entry) {
-                apiRef.current.scrollToItem(item, "smooth", "center")
-                return
-            }
-            if (attempts++ < MAX_ATTEMPTS) {
-                rafId = requestAnimationFrame(tryScroll)
-            }
-        }
-        rafId = requestAnimationFrame(tryScroll)
-        return () => cancelAnimationFrame(rafId)
-    }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
     return (
         <div className="latest-topic-facets">
@@ -215,6 +195,11 @@ export const LatestTopicFacets = ({
                                     key={topic}
                                     itemId={topic}
                                     id={topic}
+                                    ref={
+                                        topic === selectedTopics[0]
+                                            ? scrollPillIntoView
+                                            : undefined
+                                    }
                                     className="latest-topic-facets__topic-pill"
                                     isDisabled={disabledTopics.has(topic)}
                                     onFocus={() => handlePillFocus(topic)}


### PR DESCRIPTION
Move the scroll to selected topic to a callback ref. This now works both for on load and on selection change.

We can use the element from the focus event as a scroll target. Also switch from "nearest" to "center", since otherwise the whole pill might not be visible.
