### PR TITLE
🐛 Restrict table-tab data download to the selected time range

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/GrapherState.test.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.test.ts
@@ -433,6 +433,46 @@ describe("currentTitle", () => {
     })
 })
 
+describe("filteredTableForDownload", () => {
+    const makeGrapher = (): GrapherState => {
+        const table = SynthesizeGDPTable(
+            { entityCount: 2, timeRange: [2000, 2010] },
+            1
+        )
+        return new GrapherState({
+            table,
+            selectedEntityNames: [...table.availableEntityNames],
+            dimensions: [
+                {
+                    slug: SampleColumnSlugs.GDP,
+                    property: DimensionProperty.y,
+                    variableId: 1,
+                },
+            ],
+        })
+    }
+
+    it("restricts the download to the selected time range on the table tab", () => {
+        const grapher = makeGrapher()
+        grapher.setTab(GRAPHER_TAB_NAMES.Table)
+        grapher.timelineHandleTimeBounds = [2003, 2005]
+
+        const times = _.uniq(grapher.filteredTableForDownload.timeColumn.values)
+        expect(_.min(times)).toBe(2003)
+        expect(_.max(times)).toBe(2005)
+    })
+
+    it("does not restrict the full download table by the selected time range", () => {
+        const grapher = makeGrapher()
+        grapher.setTab(GRAPHER_TAB_NAMES.Table)
+        grapher.timelineHandleTimeBounds = [2003, 2005]
+
+        const times = _.uniq(grapher.tableForDownload.timeColumn.values)
+        expect(_.min(times)).toBe(2000)
+        expect(_.max(times)).toBe(2009)
+    })
+})
+
 describe("authors can use maxTime", () => {
     it("can can create a discretebar chart with correct maxtime", () => {
         const table = SynthesizeGDPTable({ timeRange: [2000, 2010] })

--- a/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
@@ -1122,11 +1122,20 @@ export class GrapherState
      * of the currently displayed data.
      */
     @computed get filteredTableForDownload(): OwidTable {
-        const table = this.isOnTableTab
-            ? this.tableForDisplay
-            : this.transformedTable
+        if (this.isOnTableTab) {
+            let table = this.tableForDisplay
 
-        return this.prepareTableForDownload(table)
+            // The data table only shows data within the selected time range,
+            // so restrict the download to that range as well
+            const { startTime, endTime } = this
+            if (startTime !== undefined && endTime !== undefined) {
+                table = table.filterByTimeRange(startTime, endTime)
+            }
+
+            return this.prepareTableForDownload(table)
+        }
+
+        return this.prepareTableForDownload(this.transformedTable)
     }
 
     private prepareTableForDownload(table: OwidTable): OwidTable {


### PR DESCRIPTION
On the data table tab, "Download displayed data" exported the full timeline instead of the currently selected time range (`time=...`), even though the table only shows the selected range. The chart/map tabs already filter correctly via `transformedTable`; the table tab used `tableForDisplay`, which never applied the user-selected `startTime`/`endTime`.

Fix: in `GrapherState.filteredTableForDownload`, filter `tableForDisplay` by `[startTime, endTime]` when on the table tab. This covers both the client-side download and the server-side CF function, since both read the same getter.

Added tests asserting the table-tab download is clamped to the selected range while the full download is unaffected.

Fixes #6602

🤖 Generated with [Claude Code](https://claude.com/claude-code)