### PR TITLE
Rich editor M1: data insights end-to-end (publish, settings, comments, presence)

### DIFF
--- a/adminShared/RichEditorTypes.ts
+++ b/adminShared/RichEditorTypes.ts
@@ -4,7 +4,10 @@ import {
     OwidEnrichedGdocBlock,
     OwidGdocAuthoringMode,
     OwidGdocContent,
+    OwidGdocErrorMessage,
     OwidGdocMinimalPostInterface,
+    PostGdocCommentAnchorType,
+    PostGdocCommentThreadStatus,
     PostGdocRevisionKind,
 } from "@ourworldindata/types"
 
@@ -23,11 +26,22 @@ export interface RichEditorGdocResponse {
     updatedAt: string | null
 }
 
+export interface RichEditorCommentAnchorUpdate {
+    threadId: number
+    /** New ProseMirror positions in the saved draft doc; null if the anchor vanished */
+    anchorFrom: number | null
+    anchorTo: number | null
+    anchorText: string | null
+    orphaned: boolean
+}
+
 export interface RichEditorSaveBodyRequest {
     body: OwidEnrichedGdocBlock[]
     /** The draft revision this save is based on; null if no draft existed */
     baseRevisionId: number | null
     kind?: Extract<PostGdocRevisionKind, "autosave" | "manual">
+    /** Updated comment anchor positions, mapped through the client's edits */
+    commentAnchors?: RichEditorCommentAnchorUpdate[]
 }
 
 export interface RichEditorSaveBodyResponse {
@@ -82,4 +96,97 @@ export interface RichEditorResolveReferencesResponse {
     linkedCharts: Record<string, LinkedChart>
     imageMetadata: Record<string, ImageMetadata>
     linkedDocuments: Record<string, OwidGdocMinimalPostInterface>
+}
+
+// ── Publish ────────────────────────────────────────────────────────────────
+
+export interface RichEditorPublishRequest {
+    /** Concurrency check: the draft revision the author is looking at */
+    baseRevisionId: number | null
+}
+
+export interface RichEditorPublishResponse {
+    revisionId: number
+    published: boolean
+    publishedAt: string | null
+    slug: string
+}
+
+/** Returned with a 400 when validation errors block publishing */
+export interface RichEditorPublishValidationResponse {
+    error: {
+        message: string
+        status: 400
+    }
+    validationErrors: OwidGdocErrorMessage[]
+}
+
+// ── Settings (non-body content fields + row fields) ───────────────────────
+
+export interface RichEditorSaveSettingsRequest {
+    /** Content fields to merge into the draft (body is not allowed here) */
+    settings: Record<string, unknown>
+    /** Row-level fields; only editable while the doc is unpublished */
+    slug?: string
+    baseRevisionId: number | null
+}
+
+// ── Comments ───────────────────────────────────────────────────────────────
+
+export interface RichEditorComment {
+    id: number
+    threadId: number
+    userId: number | null
+    userFullName: string | null
+    text: string
+    createdAt: string
+    updatedAt: string
+}
+
+export interface RichEditorCommentThread {
+    id: number
+    gdocId: string
+    status: PostGdocCommentThreadStatus
+    anchorType: PostGdocCommentAnchorType
+    anchorFrom: number | null
+    anchorTo: number | null
+    anchorText: string | null
+    createdAt: string
+    createdBy: number | null
+    createdByFullName: string | null
+    resolvedAt: string | null
+    comments: RichEditorComment[]
+}
+
+export interface RichEditorCommentThreadsResponse {
+    threads: RichEditorCommentThread[]
+}
+
+export interface RichEditorCreateThreadRequest {
+    anchorType: PostGdocCommentAnchorType
+    anchorFrom?: number | null
+    anchorTo?: number | null
+    anchorText?: string | null
+    text: string
+}
+
+export interface RichEditorReplyRequest {
+    text: string
+}
+
+export interface RichEditorUpdateThreadRequest {
+    status: Extract<PostGdocCommentThreadStatus, "open" | "resolved">
+}
+
+// ── Presence ───────────────────────────────────────────────────────────────
+
+export interface RichEditorPresenceEditor {
+    userId: number
+    fullName: string
+    lastSeen: string
+}
+
+export interface RichEditorPresenceResponse {
+    /** Other users with the editor open on this doc (excludes the requester) */
+    editors: RichEditorPresenceEditor[]
 }

--- a/adminSiteClient/GdocsIndexPage.tsx
+++ b/adminSiteClient/GdocsIndexPage.tsx
@@ -306,23 +306,23 @@ export class GdocsIndexPage extends React.Component<RouteComponentProps> {
                                 className="btn btn-secondary"
                                 onClick={() =>
                                     this.props.history.push(
-                                        `${this.props.match.path}/new/edit`
-                                    )
-                                }
-                            >
-                                <FontAwesomeIcon icon={faCirclePlus} /> New
-                                native draft (beta)
-                            </button>
-                            <button
-                                className="btn btn-primary"
-                                onClick={() =>
-                                    this.props.history.push(
                                         `${this.props.match.path}/add`
                                     )
                                 }
                             >
                                 <FontAwesomeIcon icon={faCirclePlus} /> Add
-                                document
+                                Google Doc
+                            </button>
+                            <button
+                                className="btn btn-primary"
+                                onClick={() =>
+                                    this.props.history.push(
+                                        `${this.props.match.path}/new/edit`
+                                    )
+                                }
+                            >
+                                <FontAwesomeIcon icon={faCirclePlus} /> New data
+                                insight
                             </button>
                         </div>
                     </div>

--- a/adminSiteClient/GdocsPreviewPage.tsx
+++ b/adminSiteClient/GdocsPreviewPage.tsx
@@ -370,6 +370,20 @@ export const GdocsPreviewPage = ({ match, history }: GdocsMatchProps) => {
                     </Col>
                     <Col>
                         <Space>
+                            <Tippy
+                                content="Open this document in the in-admin rich editor. If it is still authored in Google Docs, you'll see a conversion report first."
+                                placement="bottom"
+                            >
+                                <Button
+                                    onClick={() =>
+                                        history.push(
+                                            `/gdocs/${currentGdoc.id}/edit`
+                                        )
+                                    }
+                                >
+                                    Rich editor (beta)
+                                </Button>
+                            </Tippy>
                             <GdocsSaveButtons
                                 published={currentGdoc.published}
                                 originalGdoc={originalGdoc}

--- a/adminSiteClient/richEditor/CommentsPanel.tsx
+++ b/adminSiteClient/richEditor/CommentsPanel.tsx
@@ -56,8 +56,10 @@ export function CommentsPanel(props: {
             if (
                 editor &&
                 request.anchorType === "range" &&
-                request.anchorFrom != null &&
-                request.anchorTo != null
+                request.anchorFrom !== null &&
+                request.anchorFrom !== undefined &&
+                request.anchorTo !== null &&
+                request.anchorTo !== undefined
             ) {
                 addCommentMark(
                     editor,

--- a/adminSiteClient/richEditor/CommentsPanel.tsx
+++ b/adminSiteClient/richEditor/CommentsPanel.tsx
@@ -1,0 +1,267 @@
+import { useContext, useState } from "react"
+import { Button, Empty, Input, Space, Tag, Tooltip, Typography } from "antd"
+import { Editor } from "@tiptap/core"
+import { dayjs } from "@ourworldindata/utils"
+import {
+    RichEditorCommentThread,
+    RichEditorCreateThreadRequest,
+} from "../../adminShared/RichEditorTypes.js"
+import { AdminAppContext } from "../AdminAppContext.js"
+import { addCommentMark, focusCommentThread } from "./comments.js"
+
+/**
+ * Right-rail comments panel: start threads on the current selection (or the
+ * document), reply, resolve/reopen. Range threads highlight their text in
+ * the canvas; deleted anchors show up as "orphaned" instead of vanishing.
+ */
+export function CommentsPanel(props: {
+    gdocId: string
+    threads: RichEditorCommentThread[]
+    editor: Editor | null
+    /** Selection state, updated by the page on editor selection changes */
+    hasTextSelection: boolean
+    onThreadsChanged: () => void
+}): React.ReactElement {
+    const { gdocId, threads, editor, hasTextSelection, onThreadsChanged } =
+        props
+    const { admin } = useContext(AdminAppContext)
+    const [newComment, setNewComment] = useState("")
+    const [submitting, setSubmitting] = useState(false)
+
+    const createThread = async (): Promise<void> => {
+        if (!newComment.trim()) return
+        setSubmitting(true)
+        try {
+            let request: RichEditorCreateThreadRequest
+            const selection = editor?.state.selection
+            if (editor && selection && !selection.empty && hasTextSelection) {
+                const { from, to } = selection
+                request = {
+                    anchorType: "range",
+                    anchorFrom: from,
+                    anchorTo: to,
+                    anchorText: editor.state.doc
+                        .textBetween(from, to, " ")
+                        .slice(0, 512),
+                    text: newComment,
+                }
+            } else {
+                request = { anchorType: "document", text: newComment }
+            }
+            const thread = (await admin.requestJSON(
+                `/api/gdocs/${gdocId}/comments`,
+                request,
+                "POST"
+            )) as unknown as RichEditorCommentThread
+            if (
+                editor &&
+                request.anchorType === "range" &&
+                request.anchorFrom != null &&
+                request.anchorTo != null
+            ) {
+                addCommentMark(
+                    editor,
+                    thread.id,
+                    request.anchorFrom,
+                    request.anchorTo
+                )
+            }
+            setNewComment("")
+            onThreadsChanged()
+        } finally {
+            setSubmitting(false)
+        }
+    }
+
+    const openThreads = threads.filter((thread) => thread.status === "open")
+    const orphanedThreads = threads.filter(
+        (thread) => thread.status === "orphaned"
+    )
+    const resolvedThreads = threads.filter(
+        (thread) => thread.status === "resolved"
+    )
+
+    return (
+        <div className="rich-editor-rail__panel">
+            <Typography.Title level={5}>Comments</Typography.Title>
+            <div className="rich-editor-comments__composer">
+                <Input.TextArea
+                    autoSize={{ minRows: 2 }}
+                    placeholder={
+                        hasTextSelection
+                            ? "Comment on the selected text…"
+                            : "Comment on this document…"
+                    }
+                    value={newComment}
+                    onChange={(event) => setNewComment(event.target.value)}
+                />
+                <Button
+                    type="primary"
+                    size="small"
+                    loading={submitting}
+                    disabled={!newComment.trim()}
+                    onClick={() => void createThread()}
+                >
+                    {hasTextSelection ? "Comment on selection" : "Comment"}
+                </Button>
+            </div>
+
+            {threads.length === 0 && (
+                <Empty
+                    image={Empty.PRESENTED_IMAGE_SIMPLE}
+                    description="No comments yet"
+                />
+            )}
+
+            {[...openThreads, ...orphanedThreads].map((thread) => (
+                <ThreadCard
+                    key={thread.id}
+                    gdocId={gdocId}
+                    thread={thread}
+                    editor={editor}
+                    onThreadsChanged={onThreadsChanged}
+                />
+            ))}
+
+            {resolvedThreads.length > 0 && (
+                <details className="rich-editor-comments__resolved">
+                    <summary>
+                        {resolvedThreads.length} resolved{" "}
+                        {resolvedThreads.length === 1 ? "thread" : "threads"}
+                    </summary>
+                    {resolvedThreads.map((thread) => (
+                        <ThreadCard
+                            key={thread.id}
+                            gdocId={gdocId}
+                            thread={thread}
+                            editor={editor}
+                            onThreadsChanged={onThreadsChanged}
+                        />
+                    ))}
+                </details>
+            )}
+        </div>
+    )
+}
+
+function ThreadCard(props: {
+    gdocId: string
+    thread: RichEditorCommentThread
+    editor: Editor | null
+    onThreadsChanged: () => void
+}): React.ReactElement {
+    const { gdocId, thread, editor, onThreadsChanged } = props
+    const { admin } = useContext(AdminAppContext)
+    const [reply, setReply] = useState("")
+    const [busy, setBusy] = useState(false)
+
+    const submitReply = async (): Promise<void> => {
+        if (!reply.trim()) return
+        setBusy(true)
+        try {
+            await admin.requestJSON(
+                `/api/gdocs/${gdocId}/comments/${thread.id}/replies`,
+                { text: reply },
+                "POST"
+            )
+            setReply("")
+            onThreadsChanged()
+        } finally {
+            setBusy(false)
+        }
+    }
+
+    const setStatus = async (status: "open" | "resolved"): Promise<void> => {
+        setBusy(true)
+        try {
+            await admin.requestJSON(
+                `/api/gdocs/${gdocId}/comments/${thread.id}`,
+                { status },
+                "PUT"
+            )
+            onThreadsChanged()
+        } finally {
+            setBusy(false)
+        }
+    }
+
+    return (
+        <div
+            className={`rich-editor-comments__thread rich-editor-comments__thread--${thread.status}`}
+        >
+            <div className="rich-editor-comments__thread-header">
+                <Space size="small">
+                    {thread.status === "orphaned" && (
+                        <Tooltip title="The commented text was deleted">
+                            <Tag color="orange">orphaned</Tag>
+                        </Tooltip>
+                    )}
+                    {thread.status === "resolved" && <Tag>resolved</Tag>}
+                </Space>
+                <Space size="small">
+                    {thread.status === "resolved" ? (
+                        <Button
+                            size="small"
+                            type="text"
+                            disabled={busy}
+                            onClick={() => void setStatus("open")}
+                        >
+                            Reopen
+                        </Button>
+                    ) : (
+                        <Button
+                            size="small"
+                            type="text"
+                            disabled={busy}
+                            onClick={() => void setStatus("resolved")}
+                        >
+                            Resolve
+                        </Button>
+                    )}
+                </Space>
+            </div>
+            {thread.anchorText && (
+                <blockquote
+                    className="rich-editor-comments__quote"
+                    onClick={() => {
+                        if (editor && thread.status === "open") {
+                            focusCommentThread(editor, thread.id)
+                        }
+                    }}
+                >
+                    {thread.anchorText}
+                </blockquote>
+            )}
+            {thread.comments.map((comment) => (
+                <div key={comment.id} className="rich-editor-comments__comment">
+                    <span className="rich-editor-comments__author">
+                        {comment.userFullName ?? "Unknown"}
+                    </span>{" "}
+                    <span className="rich-editor-comments__time">
+                        {dayjs(comment.createdAt).format("MMM D, HH:mm")}
+                    </span>
+                    <p>{comment.text}</p>
+                </div>
+            ))}
+            {thread.status !== "resolved" && (
+                <div className="rich-editor-comments__reply">
+                    <Input.TextArea
+                        autoSize={{ minRows: 1 }}
+                        placeholder="Reply…"
+                        value={reply}
+                        onChange={(event) => setReply(event.target.value)}
+                    />
+                    {reply.trim() && (
+                        <Button
+                            size="small"
+                            loading={busy}
+                            onClick={() => void submitReply()}
+                        >
+                            Reply
+                        </Button>
+                    )}
+                </div>
+            )}
+        </div>
+    )
+}

--- a/adminSiteClient/richEditor/RichEditor.scss
+++ b/adminSiteClient/richEditor/RichEditor.scss
@@ -362,3 +362,110 @@
     color: #8a8577;
     font-size: 13px;
 }
+
+.rich-editor-page__rail {
+    flex: 0 0 320px;
+    position: sticky;
+    top: 16px;
+    background: #faf9f6;
+    border: 1px solid #e5e1d8;
+    border-radius: 8px;
+    padding: 4px 12px 12px;
+    max-height: calc(100vh - 120px);
+    overflow-y: auto;
+}
+
+.rich-editor-rail__panel {
+    padding-top: 4px;
+}
+
+.rich-comment-highlight {
+    background: rgba(255, 213, 79, 0.4);
+    border-bottom: 2px solid #f0b429;
+    cursor: pointer;
+}
+
+.rich-editor-comments__composer {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    align-items: flex-end;
+    margin-bottom: 16px;
+
+    textarea {
+        width: 100%;
+    }
+}
+
+.rich-editor-comments__thread {
+    border: 1px solid #e5e1d8;
+    border-radius: 6px;
+    padding: 8px 10px;
+    margin-bottom: 10px;
+    background: #fff;
+}
+
+.rich-editor-comments__thread--resolved {
+    opacity: 0.7;
+}
+
+.rich-editor-comments__thread--orphaned {
+    border-color: #f0b429;
+}
+
+.rich-editor-comments__thread-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    min-height: 24px;
+}
+
+.rich-editor-comments__quote {
+    margin: 4px 0 8px;
+    padding: 2px 8px;
+    border-left: 3px solid #f0b429;
+    color: #6e6a5e;
+    font-size: 12px;
+    cursor: pointer;
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+}
+
+.rich-editor-comments__comment {
+    margin-bottom: 8px;
+    font-size: 13px;
+
+    p {
+        margin: 2px 0 0;
+        white-space: pre-wrap;
+    }
+}
+
+.rich-editor-comments__author {
+    font-weight: 600;
+    color: #1d2b3d;
+}
+
+.rich-editor-comments__time {
+    color: #8a8577;
+    font-size: 12px;
+}
+
+.rich-editor-comments__reply {
+    display: flex;
+    gap: 6px;
+    align-items: flex-end;
+}
+
+.rich-editor-comments__resolved {
+    margin-top: 12px;
+
+    summary {
+        cursor: pointer;
+        color: #8a8577;
+        font-size: 13px;
+        margin-bottom: 8px;
+    }
+}

--- a/adminSiteClient/richEditor/RichEditor.tsx
+++ b/adminSiteClient/richEditor/RichEditor.tsx
@@ -1,11 +1,12 @@
 import { RefObject, useMemo, useRef, useState } from "react"
 import { Editor, Extensions, Node } from "@tiptap/core"
 import { EditorContent, ReactNodeViewRenderer, useEditor } from "@tiptap/react"
-import { OwidEnrichedGdocBlock } from "@ourworldindata/types"
+import { OwidEnrichedGdocBlock, OwidGdocType } from "@ourworldindata/types"
 import { getRichEditorBaseExtensions } from "./extensions.js"
 import { pmNodeNames } from "./serialization/pmJson.js"
 import { enrichedBlocksToPmDoc } from "./serialization/serialization.js"
 import { SlashCommands } from "./SlashCommands.js"
+import { CommentMark } from "./comments.js"
 import { ImageBlockView } from "./nodeViews/ImageBlockView.js"
 import { CtaBlockView } from "./nodeViews/CtaBlockView.js"
 import { RawBlockView } from "./nodeViews/RawBlockView.js"
@@ -27,8 +28,20 @@ export function RichEditor(props: {
         ((insert: (filename: string) => void) => void) | null
     >
     onDirty: () => void
+    /** Restricts insertable blocks to those allowed in this document type */
+    docType?: OwidGdocType
+    onCreate?: (editor: Editor) => void
+    onSelectionChange?: (editor: Editor) => void
 }): React.ReactElement {
-    const { initialBody, editorRef, requestImageRef, onDirty } = props
+    const {
+        initialBody,
+        editorRef,
+        requestImageRef,
+        onDirty,
+        docType,
+        onCreate,
+        onSelectionChange,
+    } = props
 
     // Set when a slash-menu "Image" command is waiting for the user to pick
     // an image from the library
@@ -38,6 +51,10 @@ export function RichEditor(props: {
     // useEditor only reads the initial value; keep callbacks in refs
     const onDirtyRef = useRef(onDirty)
     onDirtyRef.current = onDirty
+    const onCreateRef = useRef(onCreate)
+    onCreateRef.current = onCreate
+    const onSelectionChangeRef = useRef(onSelectionChange)
+    onSelectionChangeRef.current = onSelectionChange
     if (requestImageRef) {
         requestImageRef.current = (insert) =>
             setPendingImageInsert(() => insert)
@@ -56,10 +73,14 @@ export function RichEditor(props: {
         })
         return [
             ...base,
+            CommentMark,
             SlashCommands.configure({
                 onRequestImage: (insert) => setPendingImageInsert(() => insert),
+                docType,
             }),
         ]
+        // the editor schema is fixed after mount
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
 
     const initialDoc = useMemo(() => {
@@ -76,9 +97,17 @@ export function RichEditor(props: {
     const editor = useEditor({
         extensions,
         content: initialDoc,
-        onUpdate: () => onDirtyRef.current(),
+        // transactions marked silent (e.g. applying comment highlights on
+        // load) must not trigger the autosave loop
+        onUpdate: ({ transaction }) => {
+            if (!transaction.getMeta("richEditorSilent")) onDirtyRef.current()
+        },
+        onSelectionUpdate: ({ editor: current }) => {
+            onSelectionChangeRef.current?.(current as Editor)
+        },
         onCreate: ({ editor: created }) => {
             editorRef.current = created
+            onCreateRef.current?.(created)
         },
         onDestroy: () => {
             editorRef.current = null

--- a/adminSiteClient/richEditor/RichEditor.tsx
+++ b/adminSiteClient/richEditor/RichEditor.tsx
@@ -103,7 +103,7 @@ export function RichEditor(props: {
             if (!transaction.getMeta("richEditorSilent")) onDirtyRef.current()
         },
         onSelectionUpdate: ({ editor: current }) => {
-            onSelectionChangeRef.current?.(current as Editor)
+            onSelectionChangeRef.current?.(current)
         },
         onCreate: ({ editor: created }) => {
             editorRef.current = created

--- a/adminSiteClient/richEditor/RichEditorPage.tsx
+++ b/adminSiteClient/richEditor/RichEditorPage.tsx
@@ -4,29 +4,40 @@ import {
     Alert,
     Button,
     Drawer,
+    Dropdown,
     Form,
     Input,
     List,
     Modal,
     Popconfirm,
     Space,
+    Tabs,
     Tag,
     Typography,
 } from "antd"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { Editor } from "@tiptap/core"
-import { OwidGdocAuthoringMode } from "@ourworldindata/types"
+import { OwidGdocAuthoringMode, OwidGdocType } from "@ourworldindata/types"
 import { dayjs } from "@ourworldindata/utils"
 import {
+    RichEditorCommentThreadsResponse,
     RichEditorGdocResponse,
+    RichEditorPresenceEditor,
+    RichEditorPresenceResponse,
+    RichEditorPublishResponse,
+    RichEditorPublishValidationResponse,
     RichEditorRevisionsResponse,
     RichEditorSaveBodyResponse,
 } from "../../adminShared/RichEditorTypes.js"
 import { AdminAppContext } from "../AdminAppContext.js"
 import { AdminLayout } from "../AdminLayout.js"
 import { RichEditor } from "./RichEditor.js"
-import { richEditorBlockItems } from "./blockRegistry.js"
+import { getBlockItemsForDocType } from "./blockRegistry.js"
 import { pmDocToEnrichedBlocks } from "./serialization/serialization.js"
+import { applyCommentMarks, collectCommentAnchors } from "./comments.js"
+import { computeConversionReport } from "./conversionReport.js"
+import { CommentsPanel } from "./CommentsPanel.js"
+import { SettingsPanel } from "./SettingsPanel.js"
 
 type SaveState =
     | { kind: "saved"; at: Date | null }
@@ -36,6 +47,7 @@ type SaveState =
     | { kind: "error"; message: string }
 
 const AUTOSAVE_DEBOUNCE_MS = 2000
+const PRESENCE_HEARTBEAT_MS = 20_000
 
 export function RichEditorPage(
     props: RouteComponentProps<{ id: string }>
@@ -103,7 +115,23 @@ function RichEditorPageForId(props: { id: string }): React.ReactElement {
         retry: false,
     })
 
+    const isNative =
+        gdocQuery.data?.authoringMode === OwidGdocAuthoringMode.Native
+
+    const threadsQuery = useQuery<RichEditorCommentThreadsResponse>({
+        queryKey: ["richEditorComments", id],
+        queryFn: () =>
+            admin.getJSON<RichEditorCommentThreadsResponse>(
+                `/api/gdocs/${id}/comments`
+            ),
+        enabled: isNative,
+    })
+    const threads = threadsQuery.data?.threads ?? []
+    const threadsRef = useRef(threads)
+    threadsRef.current = threads
+
     const editorRef = useRef<Editor | null>(null)
+    const [editorInstance, setEditorInstance] = useState<Editor | null>(null)
     const requestImageRef = useRef<
         ((insert: (filename: string) => void) => void) | null
     >(null)
@@ -116,12 +144,63 @@ function RichEditorPageForId(props: { id: string }): React.ReactElement {
         undefined
     )
     const [revisionsOpen, setRevisionsOpen] = useState(false)
+    const [hasTextSelection, setHasTextSelection] = useState(false)
+    const [activeEditors, setActiveEditors] = useState<
+        RichEditorPresenceEditor[]
+    >([])
+    const [publishing, setPublishing] = useState(false)
+
+    // Local overrides for fields the page mutates without refetching
+    const [published, setPublished] = useState<boolean | null>(null)
+    const [docTitle, setDocTitle] = useState<string | null>(null)
+    const [docSlug, setDocSlug] = useState<string | null>(null)
 
     useEffect(() => {
         if (gdocQuery.data) {
             baseRevisionIdRef.current = gdocQuery.data.draftRevisionId
         }
     }, [gdocQuery.data])
+
+    // Presence heartbeat while the editor is open
+    useEffect(() => {
+        if (!isNative) return undefined
+        let cancelled = false
+        const beat = async (): Promise<void> => {
+            try {
+                const response = await admin.rawRequest(
+                    `/api/gdocs/${id}/presence`,
+                    JSON.stringify({}),
+                    "POST"
+                )
+                if (!response.ok) return
+                const payload =
+                    (await response.json()) as RichEditorPresenceResponse
+                if (!cancelled) setActiveEditors(payload.editors)
+            } catch {
+                // presence is advisory; ignore failures
+            }
+        }
+        void beat()
+        const interval = setInterval(() => void beat(), PRESENCE_HEARTBEAT_MS)
+        return () => {
+            cancelled = true
+            clearInterval(interval)
+        }
+    }, [admin, id, isNative])
+
+    // Highlight comment ranges once both the editor and the threads are ready
+    const marksAppliedRef = useRef(false)
+    useEffect(() => {
+        if (
+            !marksAppliedRef.current &&
+            editorInstance &&
+            threadsQuery.data &&
+            threadsQuery.data.threads.length > 0
+        ) {
+            applyCommentMarks(editorInstance, threadsQuery.data.threads)
+            marksAppliedRef.current = true
+        }
+    }, [editorInstance, threadsQuery.data])
 
     const doSave = useCallback(
         async (kind: "autosave" | "manual") => {
@@ -130,12 +209,17 @@ function RichEditorPageForId(props: { id: string }): React.ReactElement {
             setSaveState({ kind: "saving" })
             try {
                 const body = pmDocToEnrichedBlocks(editor.getJSON())
+                const commentAnchors = collectCommentAnchors(
+                    editor,
+                    threadsRef.current
+                )
                 const response = await admin.rawRequest(
                     `/api/gdocs/${id}/body`,
                     JSON.stringify({
                         body,
                         baseRevisionId: baseRevisionIdRef.current,
                         kind,
+                        commentAnchors,
                     }),
                     "PUT"
                 )
@@ -160,6 +244,11 @@ function RichEditorPageForId(props: { id: string }): React.ReactElement {
                 await queryClient.invalidateQueries({
                     queryKey: ["richEditorRevisions", id],
                 })
+                if (commentAnchors.some((anchor) => anchor.orphaned)) {
+                    await queryClient.invalidateQueries({
+                        queryKey: ["richEditorComments", id],
+                    })
+                }
             } catch (error) {
                 setSaveState({ kind: "error", message: String(error) })
             }
@@ -176,6 +265,77 @@ function RichEditorPageForId(props: { id: string }): React.ReactElement {
             void doSave("autosave")
         }, AUTOSAVE_DEBOUNCE_MS)
     }, [doSave])
+
+    const doPublish = useCallback(async () => {
+        // flush pending edits first so the draft head is what gets published
+        if (saveTimeout.current) clearTimeout(saveTimeout.current)
+        await doSave("manual")
+        setPublishing(true)
+        try {
+            const response = await admin.rawRequest(
+                `/api/gdocs/${id}/publish`,
+                JSON.stringify({ baseRevisionId: baseRevisionIdRef.current }),
+                "POST"
+            )
+            if (response.status === 409) {
+                setSaveState({ kind: "conflict" })
+                return
+            }
+            const payload = await response.json()
+            if (!response.ok) {
+                const validation =
+                    payload as RichEditorPublishValidationResponse
+                Modal.error({
+                    title: "Publishing failed",
+                    content: (
+                        <div>
+                            <p>{payload?.error?.message ?? "Unknown error"}</p>
+                            {validation.validationErrors && (
+                                <ul>
+                                    {validation.validationErrors.map(
+                                        (error, index) => (
+                                            <li key={index}>
+                                                <strong>
+                                                    {error.property}
+                                                </strong>
+                                                : {error.message}
+                                            </li>
+                                        )
+                                    )}
+                                </ul>
+                            )}
+                        </div>
+                    ),
+                })
+                return
+            }
+            const publishResult = payload as RichEditorPublishResponse
+            baseRevisionIdRef.current = publishResult.revisionId
+            setPublished(publishResult.published)
+            Modal.success({
+                title: "Published",
+                content:
+                    "The document is queued for deployment and will be live in a few minutes.",
+            })
+            await queryClient.invalidateQueries({
+                queryKey: ["richEditorRevisions", id],
+            })
+        } catch (error) {
+            Modal.error({ title: "Publishing failed", content: String(error) })
+        } finally {
+            setPublishing(false)
+        }
+    }, [admin, doSave, id, queryClient])
+
+    const doUnpublish = useCallback(async () => {
+        setPublishing(true)
+        try {
+            await admin.requestJSON(`/api/gdocs/${id}/unpublish`, {}, "POST")
+            setPublished(false)
+        } finally {
+            setPublishing(false)
+        }
+    }, [admin, id])
 
     // flush pending changes when leaving the page
     useEffect(() => {
@@ -223,7 +383,10 @@ function RichEditorPageForId(props: { id: string }): React.ReactElement {
         )
     }
 
-    const title = gdoc.content.title ?? "Untitled"
+    const docType = gdoc.content.type as OwidGdocType | undefined
+    const isPublished = published ?? gdoc.published
+    const title = docTitle ?? gdoc.content.title ?? "Untitled"
+    const paletteItems = getBlockItemsForDocType(docType)
 
     return (
         <AdminLayout title={`Editing: ${title}`} noSidebar fixedNav={false}>
@@ -235,8 +398,8 @@ function RichEditorPageForId(props: { id: string }): React.ReactElement {
                         </Typography.Title>
                         <Space size="small">
                             <Tag color="blue">{gdoc.content.type}</Tag>
-                            <Tag color={gdoc.published ? "green" : "default"}>
-                                {gdoc.published ? "published" : "draft"}
+                            <Tag color={isPublished ? "green" : "default"}>
+                                {isPublished ? "published" : "draft"}
                             </Tag>
                             <SaveStatus state={saveState} />
                         </Space>
@@ -246,7 +409,6 @@ function RichEditorPageForId(props: { id: string }): React.ReactElement {
                             History
                         </Button>
                         <Button
-                            type="primary"
                             disabled={
                                 saveState.kind === "saving" ||
                                 saveState.kind === "conflict"
@@ -255,8 +417,67 @@ function RichEditorPageForId(props: { id: string }): React.ReactElement {
                         >
                             Save
                         </Button>
+                        {isPublished ? (
+                            <Dropdown.Button
+                                type="primary"
+                                loading={publishing}
+                                disabled={saveState.kind === "conflict"}
+                                onClick={() => void doPublish()}
+                                menu={{
+                                    items: [
+                                        {
+                                            key: "unpublish",
+                                            label: "Unpublish",
+                                            danger: true,
+                                            onClick: () => {
+                                                Modal.confirm({
+                                                    title: "Unpublish this document?",
+                                                    content:
+                                                        "It will be removed from the site with the next deploy.",
+                                                    okText: "Unpublish",
+                                                    okButtonProps: {
+                                                        danger: true,
+                                                    },
+                                                    onOk: () =>
+                                                        void doUnpublish(),
+                                                })
+                                            },
+                                        },
+                                    ],
+                                }}
+                            >
+                                Publish changes
+                            </Dropdown.Button>
+                        ) : (
+                            <Popconfirm
+                                title="Publish this document?"
+                                description="It will go live on the site with the next deploy."
+                                onConfirm={() => void doPublish()}
+                            >
+                                <Button
+                                    type="primary"
+                                    loading={publishing}
+                                    disabled={saveState.kind === "conflict"}
+                                >
+                                    Publish
+                                </Button>
+                            </Popconfirm>
+                        )}
                     </Space>
                 </header>
+
+                {activeEditors.length > 0 && (
+                    <Alert
+                        type="info"
+                        showIcon
+                        message={`${activeEditors
+                            .map((editor) => editor.fullName)
+                            .join(", ")} ${
+                            activeEditors.length === 1 ? "is" : "are"
+                        } also editing this document`}
+                        description="There is no real-time merging yet: the last save wins, and you will be warned if someone else saved first."
+                    />
+                )}
 
                 {saveState.kind === "conflict" && (
                     <Alert
@@ -294,7 +515,7 @@ function RichEditorPageForId(props: { id: string }): React.ReactElement {
                 <div className="rich-editor-page__workspace">
                     <aside className="rich-editor-page__palette">
                         <h4>Insert</h4>
-                        {richEditorBlockItems.map((item) => (
+                        {paletteItems.map((item) => (
                             <button
                                 key={item.key}
                                 type="button"
@@ -326,7 +547,83 @@ function RichEditorPageForId(props: { id: string }): React.ReactElement {
                         editorRef={editorRef}
                         requestImageRef={requestImageRef}
                         onDirty={onDirty}
+                        docType={docType}
+                        onCreate={setEditorInstance}
+                        onSelectionChange={(editor) =>
+                            setHasTextSelection(!editor.state.selection.empty)
+                        }
                     />
+                    <aside className="rich-editor-page__rail">
+                        <Tabs
+                            size="small"
+                            items={[
+                                {
+                                    key: "settings",
+                                    label: "Settings",
+                                    children: docType ? (
+                                        <SettingsPanel
+                                            gdocId={id}
+                                            docType={docType}
+                                            published={isPublished}
+                                            content={gdoc.content}
+                                            slug={docSlug ?? gdoc.slug}
+                                            getBaseRevisionId={() =>
+                                                baseRevisionIdRef.current
+                                            }
+                                            onSaved={(revisionId, values) => {
+                                                baseRevisionIdRef.current =
+                                                    revisionId
+                                                setDocTitle(values.title)
+                                                setDocSlug(values.slug)
+                                                void queryClient.invalidateQueries(
+                                                    {
+                                                        queryKey: [
+                                                            "richEditorRevisions",
+                                                            id,
+                                                        ],
+                                                    }
+                                                )
+                                            }}
+                                        />
+                                    ) : null,
+                                },
+                                {
+                                    key: "comments",
+                                    label:
+                                        threads.filter(
+                                            (thread) =>
+                                                thread.status !== "resolved"
+                                        ).length > 0
+                                            ? `Comments (${
+                                                  threads.filter(
+                                                      (thread) =>
+                                                          thread.status !==
+                                                          "resolved"
+                                                  ).length
+                                              })`
+                                            : "Comments",
+                                    children: (
+                                        <CommentsPanel
+                                            gdocId={id}
+                                            threads={threads}
+                                            editor={editorInstance}
+                                            hasTextSelection={hasTextSelection}
+                                            onThreadsChanged={() =>
+                                                void queryClient.invalidateQueries(
+                                                    {
+                                                        queryKey: [
+                                                            "richEditorComments",
+                                                            id,
+                                                        ],
+                                                    }
+                                                )
+                                            }
+                                        />
+                                    ),
+                                },
+                            ]}
+                        />
+                    </aside>
                 </div>
 
                 <RevisionsDrawer
@@ -373,6 +670,10 @@ function ConvertToNativePrompt(props: {
     const { admin } = useContext(AdminAppContext)
     const [converting, setConverting] = useState(false)
 
+    const report = computeConversionReport(gdoc.content.body ?? [])
+    const rawEntries = Object.entries(report.rawBlockCounts)
+    const canConvert = report.roundTripOk && !report.conversionError
+
     return (
         <AdminLayout title="Rich editor">
             <main className="rich-editor-page rich-editor-page--create">
@@ -384,13 +685,58 @@ function ConvertToNativePrompt(props: {
                     showIcon
                     title="This document is authored in Google Docs"
                     description={
+                        <p>
+                            Converting it to native editing makes the enriched
+                            content in the database the source of truth. The
+                            Google Doc will no longer be synced — edits made
+                            there will be ignored.
+                        </p>
+                    }
+                />
+                <Alert
+                    style={{ marginTop: 12 }}
+                    type={
+                        !canConvert
+                            ? "error"
+                            : rawEntries.length > 0
+                              ? "warning"
+                              : "success"
+                    }
+                    showIcon
+                    message="Conversion report"
+                    description={
                         <>
                             <p>
-                                Converting it to native editing makes the
-                                enriched content in the database the source of
-                                truth. The Google Doc will no longer be synced —
-                                edits made there will be ignored.
+                                {report.editableBlocks} of {report.totalBlocks}{" "}
+                                top-level blocks are fully editable in the rich
+                                editor.
                             </p>
+                            {rawEntries.length > 0 && (
+                                <p>
+                                    These blocks are not natively supported yet
+                                    and will be preserved as read-only raw
+                                    blocks (they can still be moved and
+                                    deleted):{" "}
+                                    {rawEntries
+                                        .map(
+                                            ([type, count]) =>
+                                                `${type} (${count})`
+                                        )
+                                        .join(", ")}
+                                </p>
+                            )}
+                            {report.conversionError ? (
+                                <p>
+                                    Conversion failed: {report.conversionError}
+                                </p>
+                            ) : (
+                                <p>
+                                    Lossless round-trip check:{" "}
+                                    {report.roundTripOk
+                                        ? "passed ✓"
+                                        : "FAILED — do not convert this document; please report it."}
+                                </p>
+                            )}
                             <Popconfirm
                                 title="Convert to native editing?"
                                 description="This is one-way. The Google Doc stops being synced."
@@ -408,7 +754,11 @@ function ConvertToNativePrompt(props: {
                                     }
                                 }}
                             >
-                                <Button type="primary" loading={converting}>
+                                <Button
+                                    type="primary"
+                                    loading={converting}
+                                    disabled={!canConvert}
+                                >
                                     Convert to native editing
                                 </Button>
                             </Popconfirm>

--- a/adminSiteClient/richEditor/RichEditorPage.tsx
+++ b/adminSiteClient/richEditor/RichEditorPage.tsx
@@ -470,7 +470,7 @@ function RichEditorPageForId(props: { id: string }): React.ReactElement {
                     <Alert
                         type="info"
                         showIcon
-                        message={`${activeEditors
+                        title={`${activeEditors
                             .map((editor) => editor.fullName)
                             .join(", ")} ${
                             activeEditors.length === 1 ? "is" : "are"
@@ -589,19 +589,17 @@ function RichEditorPageForId(props: { id: string }): React.ReactElement {
                                 },
                                 {
                                     key: "comments",
-                                    label:
-                                        threads.filter(
-                                            (thread) =>
-                                                thread.status !== "resolved"
-                                        ).length > 0
-                                            ? `Comments (${
-                                                  threads.filter(
-                                                      (thread) =>
-                                                          thread.status !==
-                                                          "resolved"
-                                                  ).length
-                                              })`
-                                            : "Comments",
+                                    label: threads.some(
+                                        (thread) => thread.status !== "resolved"
+                                    )
+                                        ? `Comments (${
+                                              threads.filter(
+                                                  (thread) =>
+                                                      thread.status !==
+                                                      "resolved"
+                                              ).length
+                                          })`
+                                        : "Comments",
                                     children: (
                                         <CommentsPanel
                                             gdocId={id}
@@ -703,7 +701,7 @@ function ConvertToNativePrompt(props: {
                               : "success"
                     }
                     showIcon
-                    message="Conversion report"
+                    title="Conversion report"
                     description={
                         <>
                             <p>

--- a/adminSiteClient/richEditor/SettingsPanel.tsx
+++ b/adminSiteClient/richEditor/SettingsPanel.tsx
@@ -1,0 +1,173 @@
+import { useContext, useState } from "react"
+import { Alert, Button, Form, Input, Select, Space, Typography } from "antd"
+import { OwidGdocContent, OwidGdocType } from "@ourworldindata/types"
+import {
+    RichEditorSaveBodyResponse,
+    RichEditorSaveSettingsRequest,
+} from "../../adminShared/RichEditorTypes.js"
+import { AdminAppContext } from "../AdminAppContext.js"
+
+interface SettingsFormValues {
+    title: string
+    authors: string[]
+    slug: string
+    grapherUrl?: string
+    narrativeChart?: string
+    figmaUrl?: string
+}
+
+/**
+ * Right-rail form for the non-body document settings. Saves go through the
+ * same draft/revision mechanics as body saves, so History covers settings
+ * changes too.
+ */
+export function SettingsPanel(props: {
+    gdocId: string
+    docType: OwidGdocType
+    published: boolean
+    content: OwidGdocContent
+    slug: string
+    getBaseRevisionId: () => number | null
+    onSaved: (revisionId: number, values: SettingsFormValues) => void
+}): React.ReactElement {
+    const { gdocId, docType, published, content, slug, getBaseRevisionId } =
+        props
+    const { admin } = useContext(AdminAppContext)
+    const [saving, setSaving] = useState(false)
+    const [error, setError] = useState<string | null>(null)
+    const isDataInsight = docType === OwidGdocType.DataInsight
+
+    const contentFields = content as unknown as Record<string, unknown>
+    const initialValues: SettingsFormValues = {
+        title: content.title ?? "",
+        authors: content.authors ?? [],
+        slug,
+        grapherUrl: contentFields["grapher-url"] as string | undefined,
+        narrativeChart: contentFields["narrative-chart"] as string | undefined,
+        figmaUrl: contentFields["figma-url"] as string | undefined,
+    }
+
+    const onFinish = async (values: SettingsFormValues): Promise<void> => {
+        setSaving(true)
+        setError(null)
+        try {
+            const request: RichEditorSaveSettingsRequest = {
+                settings: {
+                    title: values.title,
+                    authors: values.authors,
+                    ...(isDataInsight
+                        ? {
+                              "grapher-url": values.grapherUrl || null,
+                              "narrative-chart": values.narrativeChart || null,
+                              "figma-url": values.figmaUrl || null,
+                          }
+                        : {}),
+                },
+                slug: values.slug,
+                baseRevisionId: getBaseRevisionId(),
+            }
+            const response = await admin.rawRequest(
+                `/api/gdocs/${gdocId}/editorSettings`,
+                JSON.stringify(request),
+                "PUT"
+            )
+            if (response.status === 409) {
+                setError(
+                    "Someone else saved a newer version of this draft. Reload before changing settings."
+                )
+                return
+            }
+            if (!response.ok) {
+                const payload = await response.json().catch(() => ({}))
+                setError(
+                    payload?.error?.message ??
+                        `Saving settings failed (${response.status})`
+                )
+                return
+            }
+            const saved = (await response.json()) as RichEditorSaveBodyResponse
+            props.onSaved(saved.revisionId, values)
+        } catch (saveError) {
+            setError(String(saveError))
+        } finally {
+            setSaving(false)
+        }
+    }
+
+    return (
+        <div className="rich-editor-rail__panel">
+            <Typography.Title level={5}>Settings</Typography.Title>
+            {error && (
+                <Alert
+                    type="error"
+                    showIcon
+                    message={error}
+                    style={{ marginBottom: 12 }}
+                />
+            )}
+            <Form<SettingsFormValues>
+                layout="vertical"
+                size="small"
+                initialValues={initialValues}
+                onFinish={(values) => void onFinish(values)}
+            >
+                <Form.Item
+                    label="Title"
+                    name="title"
+                    rules={[{ required: true }]}
+                >
+                    <Input.TextArea autoSize />
+                </Form.Item>
+                <Form.Item
+                    label="Authors"
+                    name="authors"
+                    rules={[{ required: true }]}
+                >
+                    <Select
+                        mode="tags"
+                        tokenSeparators={[","]}
+                        placeholder="Author names"
+                        open={false}
+                    />
+                </Form.Item>
+                <Form.Item
+                    label="Slug"
+                    name="slug"
+                    rules={[{ required: true }]}
+                    extra={
+                        published
+                            ? "The slug of a published document cannot be changed here."
+                            : undefined
+                    }
+                >
+                    <Input disabled={published} />
+                </Form.Item>
+                {isDataInsight && (
+                    <>
+                        <Form.Item
+                            label="Grapher URL"
+                            name="grapherUrl"
+                            extra="Chart the insight is based on; shown as the data source."
+                        >
+                            <Input placeholder="https://ourworldindata.org/grapher/…" />
+                        </Form.Item>
+                        <Form.Item
+                            label="Narrative chart"
+                            name="narrativeChart"
+                        >
+                            <Input placeholder="Name of a narrative chart" />
+                        </Form.Item>
+                        <Form.Item label="Figma URL" name="figmaUrl">
+                            <Input placeholder="https://www.figma.com/…" />
+                        </Form.Item>
+                    </>
+                )}
+                <Space>
+                    <Button type="primary" htmlType="submit" loading={saving}>
+                        Save settings
+                    </Button>
+                </Space>
+            </Form>
+        </div>
+    )
+}

--- a/adminSiteClient/richEditor/SettingsPanel.tsx
+++ b/adminSiteClient/richEditor/SettingsPanel.tsx
@@ -101,7 +101,7 @@ export function SettingsPanel(props: {
                 <Alert
                     type="error"
                     showIcon
-                    message={error}
+                    title={error}
                     style={{ marginBottom: 12 }}
                 />
             )}

--- a/adminSiteClient/richEditor/SlashCommands.ts
+++ b/adminSiteClient/richEditor/SlashCommands.ts
@@ -1,5 +1,6 @@
 import { Editor, Extension, Range } from "@tiptap/core"
 import { Suggestion, SuggestionProps } from "@tiptap/suggestion"
+import { OwidGdocType } from "@ourworldindata/types"
 import { RichEditorBlockItem, filterBlockItems } from "./blockRegistry.js"
 
 // "/" opens an inline block inserter at the caret. Rendered with plain DOM
@@ -7,6 +8,8 @@ import { RichEditorBlockItem, filterBlockItems } from "./blockRegistry.js"
 
 export interface SlashCommandsOptions {
     onRequestImage: (insert: (filename: string) => void) => void
+    /** Restricts the offered blocks to those allowed in this document type */
+    docType?: OwidGdocType
 }
 
 interface SlashMenuState {
@@ -85,6 +88,7 @@ export const SlashCommands = Extension.create<SlashCommandsOptions>({
     addOptions() {
         return {
             onRequestImage: () => undefined,
+            docType: undefined,
         }
     },
 
@@ -97,7 +101,7 @@ export const SlashCommands = Extension.create<SlashCommandsOptions>({
                 editor: this.editor,
                 char: "/",
                 allowSpaces: false,
-                items: ({ query }) => filterBlockItems(query),
+                items: ({ query }) => filterBlockItems(query, options.docType),
                 command: ({ editor, range, props: item }) => {
                     executeItem(item, editor, range, options)
                 },

--- a/adminSiteClient/richEditor/blockRegistry.ts
+++ b/adminSiteClient/richEditor/blockRegistry.ts
@@ -1,4 +1,5 @@
 import { Editor, Range } from "@tiptap/core"
+import { OwidGdocType } from "@ourworldindata/types"
 import { pmNodeNames } from "./serialization/pmJson.js"
 
 // The insertable block types, ranked by real-world usage per document type
@@ -12,12 +13,25 @@ export interface RichEditorBlockItem {
     /** Monochrome glyph shown in menus */
     glyph: string
     keywords: string[]
+    /** Document types this block can be inserted into; undefined = all */
+    docTypes?: OwidGdocType[]
     command: (ctx: {
         editor: Editor
         range?: Range
         onRequestImage: (insert: (filename: string) => void) => void
     }) => void
 }
+
+// Data insights are a deliberately small surface: text, images and CTAs
+// cover ~99% of production usage.
+const ARTICLE_LIKE_TYPES = [
+    OwidGdocType.Article,
+    OwidGdocType.TopicPage,
+    OwidGdocType.LinearTopicPage,
+    OwidGdocType.AboutPage,
+    OwidGdocType.Announcement,
+    OwidGdocType.Fragment,
+]
 
 function deleteRangeIfAny(editor: Editor, range?: Range): void {
     if (range) editor.chain().focus().deleteRange(range).run()
@@ -26,6 +40,7 @@ function deleteRangeIfAny(editor: Editor, range?: Range): void {
 export const richEditorBlockItems: RichEditorBlockItem[] = [
     {
         key: "heading",
+        docTypes: ARTICLE_LIKE_TYPES,
         title: "Heading",
         description: "Section heading",
         glyph: "H",
@@ -101,6 +116,7 @@ export const richEditorBlockItems: RichEditorBlockItem[] = [
     },
     {
         key: "blockquote",
+        docTypes: ARTICLE_LIKE_TYPES,
         title: "Quote",
         description: "Block quotation with optional citation",
         glyph: "❝",
@@ -112,6 +128,7 @@ export const richEditorBlockItems: RichEditorBlockItem[] = [
     },
     {
         key: "callout",
+        docTypes: ARTICLE_LIKE_TYPES,
         title: "Callout",
         description: "Highlighted info box",
         glyph: "!",
@@ -123,6 +140,7 @@ export const richEditorBlockItems: RichEditorBlockItem[] = [
     },
     {
         key: "horizontalRule",
+        docTypes: ARTICLE_LIKE_TYPES,
         title: "Divider",
         description: "Horizontal rule",
         glyph: "—",
@@ -138,10 +156,23 @@ export const richEditorBlockItems: RichEditorBlockItem[] = [
     },
 ]
 
-export function filterBlockItems(query: string): RichEditorBlockItem[] {
-    const q = query.trim().toLowerCase()
-    if (!q) return richEditorBlockItems
+export function getBlockItemsForDocType(
+    docType: OwidGdocType | undefined
+): RichEditorBlockItem[] {
+    if (!docType) return richEditorBlockItems
     return richEditorBlockItems.filter(
+        (item) => !item.docTypes || item.docTypes.includes(docType)
+    )
+}
+
+export function filterBlockItems(
+    query: string,
+    docType?: OwidGdocType
+): RichEditorBlockItem[] {
+    const items = getBlockItemsForDocType(docType)
+    const q = query.trim().toLowerCase()
+    if (!q) return items
+    return items.filter(
         (item) =>
             item.title.toLowerCase().includes(q) ||
             item.keywords.some((keyword) => keyword.includes(q))

--- a/adminSiteClient/richEditor/comments.ts
+++ b/adminSiteClient/richEditor/comments.ts
@@ -51,7 +51,7 @@ export function applyCommentMarks(
     for (const thread of threads) {
         if (thread.anchorType !== "range" || thread.status === "orphaned")
             continue
-        if (thread.anchorFrom == null || thread.anchorTo == null) continue
+        if (thread.anchorFrom === null || thread.anchorTo === null) continue
         const from = Math.max(0, Math.min(thread.anchorFrom, doc.content.size))
         const to = Math.max(0, Math.min(thread.anchorTo, doc.content.size))
         if (from >= to) continue

--- a/adminSiteClient/richEditor/comments.ts
+++ b/adminSiteClient/richEditor/comments.ts
@@ -1,0 +1,153 @@
+import { Editor, Mark } from "@tiptap/core"
+import { RichEditorCommentAnchorUpdate } from "../../adminShared/RichEditorTypes.js"
+import type { RichEditorCommentThread } from "../../adminShared/RichEditorTypes.js"
+
+// Comment threads are anchored to text ranges via an editor-only `comment`
+// mark carrying the thread id. Marks move naturally with edits, survive
+// splits/joins and undo; they are stripped during serialization
+// (EDITOR_ONLY_MARKS), so they never leak into the enriched content. The
+// canonical anchor positions live server-side and are refreshed with every
+// save from the marks' current positions.
+
+export const COMMENT_MARK_NAME = "comment"
+
+export const CommentMark = Mark.create({
+    name: COMMENT_MARK_NAME,
+
+    // typing at the edge of a comment should not extend it
+    inclusive: false,
+
+    addAttributes() {
+        return { threadId: { default: null } }
+    },
+
+    parseHTML() {
+        return [{ tag: "span[data-rich-comment-thread]" }]
+    },
+
+    renderHTML({ mark }) {
+        return [
+            "span",
+            {
+                "data-rich-comment-thread": String(mark.attrs.threadId ?? ""),
+                class: "rich-comment-highlight",
+            },
+            0,
+        ]
+    },
+})
+
+const MAX_ANCHOR_TEXT_LENGTH = 512
+
+/** Apply comment marks for range threads loaded from the server. */
+export function applyCommentMarks(
+    editor: Editor,
+    threads: RichEditorCommentThread[]
+): void {
+    const markType = editor.schema.marks[COMMENT_MARK_NAME]
+    if (!markType) return
+    const { tr, doc } = editor.state
+    let changed = false
+    for (const thread of threads) {
+        if (thread.anchorType !== "range" || thread.status === "orphaned")
+            continue
+        if (thread.anchorFrom == null || thread.anchorTo == null) continue
+        const from = Math.max(0, Math.min(thread.anchorFrom, doc.content.size))
+        const to = Math.max(0, Math.min(thread.anchorTo, doc.content.size))
+        if (from >= to) continue
+        tr.addMark(from, to, markType.create({ threadId: thread.id }))
+        changed = true
+    }
+    if (changed) {
+        tr.setMeta("addToHistory", false)
+        tr.setMeta("richEditorSilent", true)
+        editor.view.dispatch(tr)
+    }
+}
+
+/** Add a comment mark for a freshly created thread on the given range. */
+export function addCommentMark(
+    editor: Editor,
+    threadId: number,
+    from: number,
+    to: number
+): void {
+    const markType = editor.schema.marks[COMMENT_MARK_NAME]
+    if (!markType) return
+    const { tr } = editor.state
+    tr.addMark(from, to, markType.create({ threadId }))
+    tr.setMeta("addToHistory", false)
+    editor.view.dispatch(tr)
+}
+
+interface MarkRange {
+    from: number
+    to: number
+}
+
+/** Find the current position of every comment mark in the doc. */
+export function findCommentMarkRanges(editor: Editor): Map<number, MarkRange> {
+    const ranges = new Map<number, MarkRange>()
+    editor.state.doc.descendants((node, pos) => {
+        for (const mark of node.marks) {
+            if (mark.type.name !== COMMENT_MARK_NAME) continue
+            const threadId = Number(mark.attrs.threadId)
+            if (!threadId) continue
+            const existing = ranges.get(threadId)
+            const from = existing ? Math.min(existing.from, pos) : pos
+            const to = existing
+                ? Math.max(existing.to, pos + node.nodeSize)
+                : pos + node.nodeSize
+            ranges.set(threadId, { from, to })
+        }
+    })
+    return ranges
+}
+
+/**
+ * Compute the anchor updates to send with a save: the current position of
+ * every range thread's mark, and orphaned status for threads whose mark was
+ * deleted along with its text.
+ */
+export function collectCommentAnchors(
+    editor: Editor,
+    threads: RichEditorCommentThread[]
+): RichEditorCommentAnchorUpdate[] {
+    const ranges = findCommentMarkRanges(editor)
+    const updates: RichEditorCommentAnchorUpdate[] = []
+    for (const thread of threads) {
+        if (thread.anchorType !== "range") continue
+        const range = ranges.get(thread.id)
+        if (range) {
+            updates.push({
+                threadId: thread.id,
+                anchorFrom: range.from,
+                anchorTo: range.to,
+                anchorText: editor.state.doc
+                    .textBetween(range.from, range.to, " ")
+                    .slice(0, MAX_ANCHOR_TEXT_LENGTH),
+                orphaned: false,
+            })
+        } else if (thread.status !== "orphaned") {
+            updates.push({
+                threadId: thread.id,
+                anchorFrom: null,
+                anchorTo: null,
+                anchorText: thread.anchorText,
+                orphaned: true,
+            })
+        }
+    }
+    return updates
+}
+
+/** Scroll to and briefly flash a thread's highlight in the canvas. */
+export function focusCommentThread(editor: Editor, threadId: number): void {
+    const range = findCommentMarkRanges(editor).get(threadId)
+    if (!range) return
+    editor.chain().focus().setTextSelection(range.from).run()
+    const dom = editor.view.dom.querySelector(
+        `[data-rich-comment-thread="${threadId}"]`
+    )
+    dom?.scrollIntoView({ behavior: "smooth", block: "center" })
+}

--- a/adminSiteClient/richEditor/conversionReport.ts
+++ b/adminSiteClient/richEditor/conversionReport.ts
@@ -1,0 +1,57 @@
+import { OwidEnrichedGdocBlock } from "@ourworldindata/types"
+import { pmNodeNames } from "./serialization/pmJson.js"
+import {
+    enrichedBlockToPmNode,
+    enrichedBlocksToPmDoc,
+    pmDocToEnrichedBlocks,
+} from "./serialization/serialization.js"
+import { enrichedBodiesMatch } from "./serialization/normalizeForComparison.js"
+
+// Computed before converting a gdoc to native editing so the author knows
+// exactly what they get: which blocks are fully editable, which are carried
+// as read-only raw blocks, and whether the round-trip is lossless.
+
+export interface ConversionReport {
+    totalBlocks: number
+    editableBlocks: number
+    /** Top-level blocks that fall back to opaque passthrough, by type */
+    rawBlockCounts: Record<string, number>
+    /** Whether enriched → ProseMirror → enriched reproduces the body */
+    roundTripOk: boolean
+    /** Set when the conversion itself threw — do not convert */
+    conversionError?: string
+}
+
+export function computeConversionReport(
+    body: OwidEnrichedGdocBlock[]
+): ConversionReport {
+    const rawBlockCounts: Record<string, number> = {}
+    let editableBlocks = 0
+
+    try {
+        for (const block of body) {
+            const node = enrichedBlockToPmNode(block)
+            if (node.type === pmNodeNames.rawBlock) {
+                rawBlockCounts[block.type] =
+                    (rawBlockCounts[block.type] ?? 0) + 1
+            } else {
+                editableBlocks += 1
+            }
+        }
+        const roundTripped = pmDocToEnrichedBlocks(enrichedBlocksToPmDoc(body))
+        return {
+            totalBlocks: body.length,
+            editableBlocks,
+            rawBlockCounts,
+            roundTripOk: enrichedBodiesMatch(body, roundTripped),
+        }
+    } catch (error) {
+        return {
+            totalBlocks: body.length,
+            editableBlocks,
+            rawBlockCounts,
+            roundTripOk: false,
+            conversionError: String(error),
+        }
+    }
+}

--- a/adminSiteClient/richEditor/serialization/serialization.ts
+++ b/adminSiteClient/richEditor/serialization/serialization.ts
@@ -105,10 +105,16 @@ function runsToPmInline(runs: SpanRun[]): PmNodeJson[] {
     return nodes
 }
 
+// Marks that only exist in the editing surface (e.g. comment highlights) and
+// must never leak into the enriched content
+const EDITOR_ONLY_MARKS = new Set<string>(["comment"])
+
 function pmInlineToRuns(nodes: PmNodeJson[] | undefined): SpanRun[] {
     const runs: SpanRun[] = []
     for (const node of nodes ?? []) {
-        const marks = (node.marks ?? []).map(pmMarkToRunMark)
+        const marks = (node.marks ?? [])
+            .filter((mark) => !EDITOR_ONLY_MARKS.has(mark.type))
+            .map(pmMarkToRunMark)
         if (node.type === pmNodeNames.text) {
             if (node.text) runs.push({ kind: "text", text: node.text, marks })
         } else if (node.type === pmNodeNames.hardBreak) {

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -55,11 +55,19 @@ import {
     createNativeGdoc,
     getGdocForEditor,
     saveGdocBody,
+    saveGdocEditorSettings,
     getGdocRevisions,
     getGdocRevision,
     restoreGdocRevision,
     convertGdocToNative,
     resolveEditorReferences,
+    publishNativeGdoc,
+    unpublishNativeGdoc,
+    getGdocCommentThreads,
+    createGdocCommentThread,
+    replyToGdocCommentThread,
+    updateGdocCommentThread,
+    heartbeatGdocPresence,
 } from "./apiRoutes/richEditor.js"
 import {
     getImagesHandler,
@@ -434,6 +442,42 @@ postRouteWithRWTransaction(
     apiRouter,
     "/editor/resolveReferences",
     resolveEditorReferences
+)
+postRouteWithRWTransaction(apiRouter, "/gdocs/:id/publish", publishNativeGdoc)
+postRouteWithRWTransaction(
+    apiRouter,
+    "/gdocs/:id/unpublish",
+    unpublishNativeGdoc
+)
+putRouteWithRWTransaction(
+    apiRouter,
+    "/gdocs/:id/editorSettings",
+    saveGdocEditorSettings
+)
+getRouteWithROTransaction(
+    apiRouter,
+    "/gdocs/:id/comments",
+    getGdocCommentThreads
+)
+postRouteWithRWTransaction(
+    apiRouter,
+    "/gdocs/:id/comments",
+    createGdocCommentThread
+)
+postRouteWithRWTransaction(
+    apiRouter,
+    "/gdocs/:id/comments/:threadId/replies",
+    replyToGdocCommentThread
+)
+putRouteWithRWTransaction(
+    apiRouter,
+    "/gdocs/:id/comments/:threadId",
+    updateGdocCommentThread
+)
+postRouteWithRWTransaction(
+    apiRouter,
+    "/gdocs/:id/presence",
+    heartbeatGdocPresence
 )
 
 // Data insight routes

--- a/adminSiteServer/apiRoutes/gdocs.ts
+++ b/adminSiteServer/apiRoutes/gdocs.ts
@@ -16,6 +16,7 @@ import {
     RedirectsTableName,
     OwidGdocType,
     OwidGdocAuthoringMode,
+    DbRawPostGdoc,
 } from "@ourworldindata/types"
 import {
     checkIsChronologicalGdoc,
@@ -337,7 +338,7 @@ function checkIsProfile(gdoc: { content: { type?: OwidGdocType } }): boolean {
  * - Updating (index and bake (potentially via lightning deploy))
  * - Unpublishing (remove from index and bake)
  */
-async function indexAndBakeGdocIfNeccesary(
+export async function indexAndBakeGdocIfNeccesary(
     trx: db.KnexReadWriteTransaction,
     user: Required<DbInsertUser>,
     prevGdoc:
@@ -427,7 +428,7 @@ async function indexAndBakeGdocIfNeccesary(
         .exhaustive()
 }
 
-async function validateSlugCollisionsIfPublishing(
+export async function validateSlugCollisionsIfPublishing(
     trx: db.KnexReadonlyTransaction,
     gdoc:
         | GdocPost
@@ -530,6 +531,26 @@ export async function createOrUpdateGdoc(
     if (!prevGdoc) throw new JsonError(`No Google Doc with id ${id} found`)
 
     const nextGdoc = gdocFromJSON(req.body)
+
+    // Natively-edited docs own their body and publish state through the rich
+    // editor endpoints; the settings PUT must not clobber either.
+    const nativeRow = await trx
+        .table(PostsGdocsTableName)
+        .where({ id })
+        .first<
+            | Pick<DbRawPostGdoc, "authoringMode" | "content" | "published">
+            | undefined
+        >("authoringMode", "content", "published")
+    if (nativeRow?.authoringMode === OwidGdocAuthoringMode.Native) {
+        nextGdoc.content.body = JSON.parse(nativeRow.content).body
+        if (!!nextGdoc.published !== !!nativeRow.published) {
+            throw new JsonError(
+                "The publish state of natively-edited documents is managed by the rich editor",
+                400
+            )
+        }
+    }
+
     await nextGdoc.loadState(trx)
 
     await validateSlugCollisionsIfPublishing(trx, nextGdoc)

--- a/adminSiteServer/apiRoutes/richEditor.ts
+++ b/adminSiteServer/apiRoutes/richEditor.ts
@@ -5,11 +5,15 @@ import {
     OwidEnrichedGdocBlock,
     OwidGdocAuthoringMode,
     OwidGdocContent,
+    OwidGdocErrorMessageType,
     OwidGdocType,
+    PostsGdocsCommentThreadsTableName,
+    PostsGdocsCommentsTableName,
     PostsGdocsDraftsTableName,
     PostsGdocsRevisionsTableName,
     PostsGdocsTableName,
     DbRawPostGdoc,
+    DbRawPostGdocCommentThread,
     DbRawPostGdocDraft,
     DbRawPostGdocRevision,
 } from "@ourworldindata/types"
@@ -17,17 +21,34 @@ import { slugify } from "@ourworldindata/utils"
 import { randomUUID } from "crypto"
 import * as db from "../../db/db.js"
 import {
+    GdocLinkUpdateMode,
     gdocFromJSON,
+    getAndLoadGdocById,
+    setImagesInContentGraph,
+    setLinksForGdoc,
     updateDerivedGdocPostsComponents,
+    upsertGdoc,
 } from "../../db/model/Gdoc/GdocFactory.js"
+import {
+    indexAndBakeGdocIfNeccesary,
+    validateSlugCollisionsIfPublishing,
+} from "./gdocs.js"
 import {
     getMinimalGdocPostsByIds,
     loadLinkedChartsForSlugs,
 } from "../../db/model/Gdoc/GdocBase.js"
 import { getImagesByFilenames } from "../../db/model/Image.js"
 import {
+    RichEditorCommentThread,
+    RichEditorCommentThreadsResponse,
     RichEditorCreateNativeGdocRequest,
+    RichEditorCreateThreadRequest,
     RichEditorGdocResponse,
+    RichEditorPresenceResponse,
+    RichEditorPublishRequest,
+    RichEditorPublishResponse,
+    RichEditorPublishValidationResponse,
+    RichEditorReplyRequest,
     RichEditorResolveReferencesRequest,
     RichEditorResolveReferencesResponse,
     RichEditorRevisionResponse,
@@ -35,6 +56,8 @@ import {
     RichEditorSaveBodyRequest,
     RichEditorSaveBodyResponse,
     RichEditorSaveConflictResponse,
+    RichEditorSaveSettingsRequest,
+    RichEditorUpdateThreadRequest,
 } from "../../adminShared/RichEditorTypes.js"
 import { Request } from "../authentication.js"
 import { HandlerResponse } from "../FunctionalRouter.js"
@@ -249,6 +272,7 @@ export async function saveGdocBody(
         body,
         baseRevisionId,
         kind = "autosave",
+        commentAnchors,
     } = req.body as RichEditorSaveBodyRequest
 
     const row = await getGdocRowOrThrow(trx, id)
@@ -287,6 +311,31 @@ export async function saveGdocBody(
         kind,
         res.locals.user.id
     )
+
+    // The client maps comment anchors through its edits and reports the new
+    // positions with every save; anchors that vanished become orphaned.
+    for (const anchor of commentAnchors ?? []) {
+        await trx
+            .table(PostsGdocsCommentThreadsTableName)
+            .where({ id: anchor.threadId, gdocId: id })
+            .update({
+                anchorFrom: anchor.anchorFrom,
+                anchorTo: anchor.anchorTo,
+                anchorText: anchor.anchorText,
+            })
+        if (anchor.orphaned) {
+            await trx
+                .table(PostsGdocsCommentThreadsTableName)
+                .where({ id: anchor.threadId, gdocId: id, status: "open" })
+                .update({ status: "orphaned" })
+        } else {
+            await trx
+                .table(PostsGdocsCommentThreadsTableName)
+                .where({ id: anchor.threadId, gdocId: id, status: "orphaned" })
+                .update({ status: "open" })
+        }
+    }
+
     return { revisionId, updatedAt: updatedAt.toISOString() }
 }
 
@@ -414,6 +463,449 @@ export async function convertGdocToNative(
         content,
         draftRevisionId: revisionId,
         updatedAt: new Date().toISOString(),
+    }
+}
+
+async function getDraftOrThrow(
+    trx: db.KnexReadonlyTransaction,
+    id: string
+): Promise<DbRawPostGdocDraft> {
+    const draft = await trx
+        .table(PostsGdocsDraftsTableName)
+        .where({ gdocId: id })
+        .first<DbRawPostGdocDraft | undefined>()
+    if (!draft)
+        throw new JsonError(`Document ${id} has no draft to work with`, 400)
+    return draft
+}
+
+function makeConflictResponse(
+    res: HandlerResponse,
+    draft: DbRawPostGdocDraft
+): RichEditorSaveConflictResponse {
+    res.status(409)
+    return {
+        error: {
+            message:
+                "The draft has been changed since you loaded it. Reload to get the newest version.",
+            status: 409,
+        },
+        currentRevisionId: Number(draft.revisionId),
+        updatedAt: new Date(draft.updatedAt).toISOString(),
+    }
+}
+
+/**
+ * Promotes the draft to the live content (posts_gdocs.content) and publishes
+ * the doc, reusing the same machinery as the gdocs settings save: links,
+ * image graph, derived tables, Algolia indexing, and bake/lightning deploy.
+ */
+export async function publishNativeGdoc(
+    req: Request,
+    res: HandlerResponse,
+    trx: db.KnexReadWriteTransaction
+): Promise<
+    | RichEditorPublishResponse
+    | RichEditorSaveConflictResponse
+    | RichEditorPublishValidationResponse
+> {
+    const { id } = req.params
+    const { baseRevisionId } = req.body as RichEditorPublishRequest
+
+    const row = await getGdocRowOrThrow(trx, id)
+    assertNativeAuthoringMode(row)
+    if (!row.slug) throw new JsonError("Set a slug before publishing", 400)
+
+    const draft = await getDraftOrThrow(trx, id)
+    if (Number(draft.revisionId) !== (baseRevisionId ?? null)) {
+        return makeConflictResponse(res, draft)
+    }
+
+    const content: OwidGdocContent = JSON.parse(draft.content)
+
+    const prevGdoc = await getAndLoadGdocById(trx, id)
+    const prevJson = prevGdoc.toJSON()
+    const publishedAt = prevJson.publishedAt
+        ? new Date(prevJson.publishedAt)
+        : new Date()
+    publishedAt.setSeconds(0, 0)
+
+    const nextGdoc = gdocFromJSON({
+        ...prevJson,
+        content,
+        published: true,
+        publishedAt,
+    })
+    await nextGdoc.loadState(trx)
+
+    const validationErrors = nextGdoc.errors.filter(
+        (error) => error.type === OwidGdocErrorMessageType.Error
+    )
+    if (validationErrors.length > 0) {
+        res.status(400)
+        return {
+            error: {
+                message:
+                    "The document has validation errors that block publishing",
+                status: 400,
+            },
+            validationErrors,
+        }
+    }
+
+    await validateSlugCollisionsIfPublishing(trx, nextGdoc)
+    await setImagesInContentGraph(trx, nextGdoc)
+    await setLinksForGdoc(
+        trx,
+        nextGdoc.id,
+        nextGdoc.links,
+        GdocLinkUpdateMode.DeleteAndInsert
+    )
+    await upsertGdoc(trx, nextGdoc)
+
+    // Record an immutable publish revision. The row is already published at
+    // this point, so this does not overwrite the live content again.
+    const { revisionId } = await insertRevisionAndUpdateDraft(
+        trx,
+        { ...row, published: 1 },
+        content,
+        "publish",
+        res.locals.user.id,
+        "Published"
+    )
+
+    await indexAndBakeGdocIfNeccesary(trx, res.locals.user, prevGdoc, nextGdoc)
+
+    return {
+        revisionId,
+        published: true,
+        publishedAt: publishedAt.toISOString(),
+        slug: nextGdoc.slug,
+    }
+}
+
+export async function unpublishNativeGdoc(
+    req: Request,
+    res: HandlerResponse,
+    trx: db.KnexReadWriteTransaction
+): Promise<RichEditorPublishResponse> {
+    const { id } = req.params
+    const row = await getGdocRowOrThrow(trx, id)
+    assertNativeAuthoringMode(row)
+    if (!row.published)
+        throw new JsonError(`Document ${id} is not published`, 400)
+
+    const prevGdoc = await getAndLoadGdocById(trx, id)
+    const nextGdoc = gdocFromJSON({
+        ...prevGdoc.toJSON(),
+        published: false,
+        publishedAt: null,
+    })
+    await nextGdoc.loadState(trx)
+
+    await setLinksForGdoc(
+        trx,
+        nextGdoc.id,
+        nextGdoc.links,
+        GdocLinkUpdateMode.DeleteOnly
+    )
+    await upsertGdoc(trx, nextGdoc)
+    await indexAndBakeGdocIfNeccesary(trx, res.locals.user, prevGdoc, nextGdoc)
+
+    const draft = await trx
+        .table(PostsGdocsDraftsTableName)
+        .where({ gdocId: id })
+        .first<DbRawPostGdocDraft | undefined>()
+
+    return {
+        revisionId: draft ? Number(draft.revisionId) : 0,
+        published: false,
+        publishedAt: null,
+        slug: row.slug,
+    }
+}
+
+/**
+ * Saves non-body content fields (title, authors, grapher-url, …) into the
+ * draft, going through the same revision mechanics as body saves. Row-level
+ * fields (slug) are only editable while the doc is unpublished.
+ */
+export async function saveGdocEditorSettings(
+    req: Request,
+    res: HandlerResponse,
+    trx: db.KnexReadWriteTransaction
+): Promise<RichEditorSaveBodyResponse | RichEditorSaveConflictResponse> {
+    const { id } = req.params
+    const { settings, slug, baseRevisionId } =
+        req.body as RichEditorSaveSettingsRequest
+
+    if (!settings || typeof settings !== "object")
+        throw new JsonError("settings must be an object", 400)
+    if ("body" in settings)
+        throw new JsonError(
+            "body cannot be changed via the settings endpoint",
+            400
+        )
+    if ("type" in settings)
+        throw new JsonError("the document type cannot be changed", 400)
+
+    let row = await getGdocRowOrThrow(trx, id)
+    assertNativeAuthoringMode(row)
+
+    const draft = await getDraftOrThrow(trx, id)
+    if (Number(draft.revisionId) !== (baseRevisionId ?? null)) {
+        return makeConflictResponse(res, draft)
+    }
+
+    if (slug !== undefined && slug !== row.slug) {
+        if (row.published)
+            throw new JsonError(
+                "The slug of a published document cannot be changed here",
+                400
+            )
+        await trx.table(PostsGdocsTableName).where({ id }).update({ slug })
+        row = { ...row, slug }
+    }
+
+    const content: OwidGdocContent = JSON.parse(draft.content)
+    const mutableContent = content as unknown as Record<string, unknown>
+    for (const [key, value] of Object.entries(settings)) {
+        if (value === null || value === undefined) {
+            delete mutableContent[key]
+        } else {
+            mutableContent[key] = value
+        }
+    }
+
+    const { revisionId, updatedAt } = await insertRevisionAndUpdateDraft(
+        trx,
+        row,
+        content,
+        "manual",
+        res.locals.user.id,
+        "Settings"
+    )
+    return { revisionId, updatedAt: updatedAt.toISOString() }
+}
+
+// ── Comments ───────────────────────────────────────────────────────────────
+
+async function queryCommentThreads(
+    trx: db.KnexReadonlyTransaction,
+    gdocId: string,
+    threadId?: number
+): Promise<RichEditorCommentThread[]> {
+    const threadRows = await db.knexRaw<
+        DbRawPostGdocCommentThread & { createdByFullName: string | null }
+    >(
+        trx,
+        `-- sql
+        SELECT t.*, u.fullName AS createdByFullName
+        FROM posts_gdocs_comment_threads t
+        LEFT JOIN users u ON u.id = t.createdBy
+        WHERE t.gdocId = ? ${threadId ? "AND t.id = ?" : ""}
+        ORDER BY t.createdAt ASC`,
+        threadId ? [gdocId, threadId] : [gdocId]
+    )
+    if (threadRows.length === 0) return []
+
+    const commentRows = await db.knexRaw<{
+        id: number
+        threadId: number
+        userId: number | null
+        userFullName: string | null
+        text: string
+        createdAt: Date
+        updatedAt: Date
+    }>(
+        trx,
+        `-- sql
+        SELECT c.id, c.threadId, c.userId, u.fullName AS userFullName,
+            c.text, c.createdAt, c.updatedAt
+        FROM posts_gdocs_comments c
+        LEFT JOIN users u ON u.id = c.userId
+        WHERE c.threadId IN (${threadRows.map(() => "?").join(", ")})
+        ORDER BY c.createdAt ASC`,
+        threadRows.map((thread) => thread.id)
+    )
+    const commentsByThread = _.groupBy(commentRows, "threadId")
+
+    return threadRows.map((thread) => ({
+        id: Number(thread.id),
+        gdocId: thread.gdocId,
+        status: thread.status,
+        anchorType: thread.anchorType,
+        anchorFrom: thread.anchorFrom,
+        anchorTo: thread.anchorTo,
+        anchorText: thread.anchorText,
+        createdAt: new Date(thread.createdAt).toISOString(),
+        createdBy: thread.createdBy,
+        createdByFullName: thread.createdByFullName,
+        resolvedAt: thread.resolvedAt
+            ? new Date(thread.resolvedAt).toISOString()
+            : null,
+        comments: (commentsByThread[thread.id] ?? []).map((comment) => ({
+            id: Number(comment.id),
+            threadId: Number(comment.threadId),
+            userId: comment.userId,
+            userFullName: comment.userFullName,
+            text: comment.text,
+            createdAt: new Date(comment.createdAt).toISOString(),
+            updatedAt: new Date(comment.updatedAt).toISOString(),
+        })),
+    }))
+}
+
+export async function getGdocCommentThreads(
+    req: Request,
+    res: HandlerResponse,
+    trx: db.KnexReadonlyTransaction
+): Promise<RichEditorCommentThreadsResponse> {
+    const { id } = req.params
+    await getGdocRowOrThrow(trx, id)
+    return { threads: await queryCommentThreads(trx, id) }
+}
+
+export async function createGdocCommentThread(
+    req: Request,
+    res: HandlerResponse,
+    trx: db.KnexReadWriteTransaction
+): Promise<RichEditorCommentThread> {
+    const { id } = req.params
+    const {
+        anchorType,
+        anchorFrom = null,
+        anchorTo = null,
+        anchorText = null,
+        text,
+    } = req.body as RichEditorCreateThreadRequest
+
+    if (!text?.trim()) throw new JsonError("Comment text is required", 400)
+    if (!["range", "block", "document"].includes(anchorType))
+        throw new JsonError(`Invalid anchorType ${anchorType}`, 400)
+    await getGdocRowOrThrow(trx, id)
+
+    const [threadId] = await trx
+        .table(PostsGdocsCommentThreadsTableName)
+        .insert({
+            gdocId: id,
+            anchorType,
+            anchorFrom,
+            anchorTo,
+            anchorText,
+            createdBy: res.locals.user.id,
+        })
+    await trx.table(PostsGdocsCommentsTableName).insert({
+        threadId,
+        userId: res.locals.user.id,
+        text: text.trim(),
+    })
+
+    const [thread] = await queryCommentThreads(trx, id, threadId)
+    return thread
+}
+
+export async function replyToGdocCommentThread(
+    req: Request,
+    res: HandlerResponse,
+    trx: db.KnexReadWriteTransaction
+): Promise<RichEditorCommentThread> {
+    const { id, threadId } = req.params
+    const { text } = req.body as RichEditorReplyRequest
+    if (!text?.trim()) throw new JsonError("Comment text is required", 400)
+
+    const thread = await trx
+        .table(PostsGdocsCommentThreadsTableName)
+        .where({ id: Number(threadId), gdocId: id })
+        .first<DbRawPostGdocCommentThread | undefined>()
+    if (!thread)
+        throw new JsonError(`No thread ${threadId} on document ${id}`, 404)
+
+    await trx.table(PostsGdocsCommentsTableName).insert({
+        threadId: Number(threadId),
+        userId: res.locals.user.id,
+        text: text.trim(),
+    })
+
+    const [updated] = await queryCommentThreads(trx, id, Number(threadId))
+    return updated
+}
+
+export async function updateGdocCommentThread(
+    req: Request,
+    res: HandlerResponse,
+    trx: db.KnexReadWriteTransaction
+): Promise<RichEditorCommentThread> {
+    const { id, threadId } = req.params
+    const { status } = req.body as RichEditorUpdateThreadRequest
+    if (!["open", "resolved"].includes(status))
+        throw new JsonError(`Invalid status ${status}`, 400)
+
+    const thread = await trx
+        .table(PostsGdocsCommentThreadsTableName)
+        .where({ id: Number(threadId), gdocId: id })
+        .first<DbRawPostGdocCommentThread | undefined>()
+    if (!thread)
+        throw new JsonError(`No thread ${threadId} on document ${id}`, 404)
+
+    await trx
+        .table(PostsGdocsCommentThreadsTableName)
+        .where({ id: Number(threadId) })
+        .update(
+            status === "resolved"
+                ? {
+                      status,
+                      resolvedAt: new Date(),
+                      resolvedBy: res.locals.user.id,
+                  }
+                : { status, resolvedAt: null, resolvedBy: null }
+        )
+
+    const [updated] = await queryCommentThreads(trx, id, Number(threadId))
+    return updated
+}
+
+// ── Presence ───────────────────────────────────────────────────────────────
+
+// In-memory presence: fine for a single admin server process, resets on
+// restart. Advisory only — the 409 optimistic-concurrency check is the
+// actual protection against overwriting someone else's work.
+const PRESENCE_TTL_MS = 60_000
+const presenceByGdocId = new Map<
+    string,
+    Map<number, { fullName: string; lastSeen: number }>
+>()
+
+export async function heartbeatGdocPresence(
+    req: Request,
+    res: HandlerResponse,
+    trx: db.KnexReadWriteTransaction
+): Promise<RichEditorPresenceResponse> {
+    const { id } = req.params
+    const user = res.locals.user
+    await getGdocRowOrThrow(trx, id)
+
+    const now = Date.now()
+    let editors = presenceByGdocId.get(id)
+    if (!editors) {
+        editors = new Map()
+        presenceByGdocId.set(id, editors)
+    }
+    editors.set(user.id, { fullName: user.fullName, lastSeen: now })
+
+    const active = [...editors.entries()].filter(
+        ([, editor]) => now - editor.lastSeen < PRESENCE_TTL_MS
+    )
+    presenceByGdocId.set(id, new Map(active))
+
+    return {
+        editors: active
+            .filter(([userId]) => userId !== user.id)
+            .map(([userId, editor]) => ({
+                userId,
+                fullName: editor.fullName,
+                lastSeen: new Date(editor.lastSeen).toISOString(),
+            })),
     }
 }
 

--- a/adminSiteServer/tests/rich-editor.test.ts
+++ b/adminSiteServer/tests/rich-editor.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 import {
     OwidGdocAuthoringMode,
+    PostsGdocsCommentThreadsTableName,
     PostsGdocsDraftsTableName,
     PostsGdocsRevisionsTableName,
     PostsGdocsTableName,
@@ -188,6 +189,305 @@ describe("rich editor API", { timeout: 20000 }, () => {
             }),
         })
         expect(save.revisionId).toBeGreaterThan(0)
+    })
+
+    it("publishes and unpublishes a native doc via the dedicated endpoints", async () => {
+        const created = await createNativeDoc("Publish test")
+        const save = await env.request({
+            method: "PUT",
+            path: `/gdocs/${created.id}/body`,
+            body: JSON.stringify({
+                body: [makeTextBlock("Ready to publish")],
+                baseRevisionId: created.draftRevisionId,
+                kind: "manual",
+            }),
+        })
+
+        // publishing against a stale revision is rejected
+        const stale = await rawRequest({
+            method: "POST",
+            path: `/gdocs/${created.id}/publish`,
+            body: JSON.stringify({
+                baseRevisionId: created.draftRevisionId,
+            }),
+        })
+        expect(stale.status).toBe(409)
+
+        const published = await env.request({
+            method: "POST",
+            path: `/gdocs/${created.id}/publish`,
+            body: JSON.stringify({ baseRevisionId: save.revisionId }),
+        })
+        expect(published.published).toBe(true)
+        expect(published.publishedAt).toBeTruthy()
+
+        let row = (await env
+            .testKnex(PostsGdocsTableName)
+            .where({ id: created.id })
+            .first()) as DbRawPostGdoc
+        expect(row.published).toBe(1)
+        expect(row.publishedAt).toBeTruthy()
+        expect(row.authoringMode).toBe("native")
+        expect(JSON.parse(row.content).body[0].value[0].text).toBe(
+            "Ready to publish"
+        )
+
+        const revisionRows = await env
+            .testKnex(PostsGdocsRevisionsTableName)
+            .where({ gdocId: created.id, kind: "publish" })
+        expect(revisionRows).toHaveLength(1)
+
+        // draft edits after publishing must not touch the live content
+        await env.request({
+            method: "PUT",
+            path: `/gdocs/${created.id}/body`,
+            body: JSON.stringify({
+                body: [makeTextBlock("Unpublished edit")],
+                baseRevisionId: published.revisionId,
+                kind: "manual",
+            }),
+        })
+        row = (await env
+            .testKnex(PostsGdocsTableName)
+            .where({ id: created.id })
+            .first()) as DbRawPostGdoc
+        expect(JSON.parse(row.content).body[0].value[0].text).toBe(
+            "Ready to publish"
+        )
+
+        const unpublished = await env.request({
+            method: "POST",
+            path: `/gdocs/${created.id}/unpublish`,
+        })
+        expect(unpublished.published).toBe(false)
+        row = (await env
+            .testKnex(PostsGdocsTableName)
+            .where({ id: created.id })
+            .first()) as DbRawPostGdoc
+        expect(row.published).toBe(0)
+    })
+
+    it("saves settings without touching the body, with slug rules", async () => {
+        const created = await createNativeDoc("Settings test")
+        const save = await env.request({
+            method: "PUT",
+            path: `/gdocs/${created.id}/body`,
+            body: JSON.stringify({
+                body: [makeTextBlock("Body stays")],
+                baseRevisionId: created.draftRevisionId,
+                kind: "manual",
+            }),
+        })
+
+        const settingsSave = await env.request({
+            method: "PUT",
+            path: `/gdocs/${created.id}/editorSettings`,
+            body: JSON.stringify({
+                settings: {
+                    title: "Settings test (renamed)",
+                    "grapher-url":
+                        "https://ourworldindata.org/grapher/life-expectancy",
+                },
+                slug: "settings-test-renamed",
+                baseRevisionId: save.revisionId,
+            }),
+        })
+        expect(settingsSave.revisionId).toBeGreaterThan(save.revisionId)
+
+        const editorView = await env.fetchJson(`/gdocs/${created.id}/editor`)
+        expect(editorView.content.title).toBe("Settings test (renamed)")
+        expect(editorView.content["grapher-url"]).toBe(
+            "https://ourworldindata.org/grapher/life-expectancy"
+        )
+        expect(editorView.content.body[0].value[0].text).toBe("Body stays")
+        expect(editorView.slug).toBe("settings-test-renamed")
+
+        // clearing a field via null removes it
+        const cleared = await env.request({
+            method: "PUT",
+            path: `/gdocs/${created.id}/editorSettings`,
+            body: JSON.stringify({
+                settings: { "grapher-url": null },
+                baseRevisionId: settingsSave.revisionId,
+            }),
+        })
+        expect(cleared.revisionId).toBeGreaterThan(settingsSave.revisionId)
+        const clearedView = await env.fetchJson(`/gdocs/${created.id}/editor`)
+        expect(clearedView.content["grapher-url"]).toBeUndefined()
+
+        // body changes via the settings endpoint are rejected
+        const bodyRejected = await rawRequest({
+            method: "PUT",
+            path: `/gdocs/${created.id}/editorSettings`,
+            body: JSON.stringify({
+                settings: { body: [] },
+                baseRevisionId: cleared.revisionId,
+            }),
+        })
+        expect(bodyRejected.status).toBe(400)
+    })
+
+    it("prevents the gdocs settings PUT from clobbering native body or publish state", async () => {
+        const created = await createNativeDoc("Guard test")
+        await env.request({
+            method: "PUT",
+            path: `/gdocs/${created.id}/body`,
+            body: JSON.stringify({
+                body: [makeTextBlock("Native body")],
+                baseRevisionId: created.draftRevisionId,
+                kind: "manual",
+            }),
+        })
+
+        const gdoc = await env.fetchJson(`/gdocs/${created.id}`)
+
+        // publish-state change through the legacy endpoint is rejected
+        const publishAttempt = await rawRequest({
+            method: "PUT",
+            path: `/gdocs/${created.id}`,
+            body: JSON.stringify({
+                ...gdoc,
+                published: true,
+                publishedAt: new Date(),
+            }),
+        })
+        expect(publishAttempt.status).toBe(400)
+
+        // body sent through the legacy endpoint is ignored in favor of the DB
+        await env.request({
+            method: "PUT",
+            path: `/gdocs/${created.id}`,
+            body: JSON.stringify({
+                ...gdoc,
+                content: {
+                    ...gdoc.content,
+                    title: "Guard test (renamed)",
+                    body: [makeTextBlock("Should be ignored")],
+                },
+            }),
+        })
+        const row = (await env
+            .testKnex(PostsGdocsTableName)
+            .where({ id: created.id })
+            .first()) as DbRawPostGdoc
+        const content = JSON.parse(row.content)
+        expect(content.title).toBe("Guard test (renamed)")
+        expect(content.body[0].value[0].text).toBe("Native body")
+    })
+
+    it("supports comment threads: create, reply, resolve, orphan via anchors", async () => {
+        const created = await createNativeDoc("Comments test")
+        const save = await env.request({
+            method: "PUT",
+            path: `/gdocs/${created.id}/body`,
+            body: JSON.stringify({
+                body: [makeTextBlock("Some commented text")],
+                baseRevisionId: created.draftRevisionId,
+                kind: "manual",
+            }),
+        })
+
+        const thread = await env.request({
+            method: "POST",
+            path: `/gdocs/${created.id}/comments`,
+            body: JSON.stringify({
+                anchorType: "range",
+                anchorFrom: 1,
+                anchorTo: 10,
+                anchorText: "Some comm",
+                text: "Is this number right?",
+            }),
+        })
+        expect(thread.status).toBe("open")
+        expect(thread.comments).toHaveLength(1)
+        expect(thread.comments[0].userFullName).toBe("Admin")
+
+        const replied = await env.request({
+            method: "POST",
+            path: `/gdocs/${created.id}/comments/${thread.id}/replies`,
+            body: JSON.stringify({ text: "Checked — it is." }),
+        })
+        expect(replied.comments).toHaveLength(2)
+
+        const resolved = await env.request({
+            method: "PUT",
+            path: `/gdocs/${created.id}/comments/${thread.id}`,
+            body: JSON.stringify({ status: "resolved" }),
+        })
+        expect(resolved.status).toBe("resolved")
+        expect(resolved.resolvedAt).toBeTruthy()
+
+        const reopened = await env.request({
+            method: "PUT",
+            path: `/gdocs/${created.id}/comments/${thread.id}`,
+            body: JSON.stringify({ status: "open" }),
+        })
+        expect(reopened.status).toBe("open")
+
+        // a body save reporting the anchor as gone orphans the thread…
+        const orphanSave = await env.request({
+            method: "PUT",
+            path: `/gdocs/${created.id}/body`,
+            body: JSON.stringify({
+                body: [makeTextBlock("Rewritten")],
+                baseRevisionId: save.revisionId,
+                kind: "manual",
+                commentAnchors: [
+                    {
+                        threadId: thread.id,
+                        anchorFrom: null,
+                        anchorTo: null,
+                        anchorText: "Some comm",
+                        orphaned: true,
+                    },
+                ],
+            }),
+        })
+        let threadRow = await env
+            .testKnex(PostsGdocsCommentThreadsTableName)
+            .where({ id: thread.id })
+            .first()
+        expect(threadRow.status).toBe("orphaned")
+
+        // …and a save reporting it back (e.g. after undo) reopens it
+        await env.request({
+            method: "PUT",
+            path: `/gdocs/${created.id}/body`,
+            body: JSON.stringify({
+                body: [makeTextBlock("Some commented text again")],
+                baseRevisionId: orphanSave.revisionId,
+                kind: "manual",
+                commentAnchors: [
+                    {
+                        threadId: thread.id,
+                        anchorFrom: 1,
+                        anchorTo: 10,
+                        anchorText: "Some comm",
+                        orphaned: false,
+                    },
+                ],
+            }),
+        })
+        threadRow = await env
+            .testKnex(PostsGdocsCommentThreadsTableName)
+            .where({ id: thread.id })
+            .first()
+        expect(threadRow.status).toBe("open")
+        expect(threadRow.anchorFrom).toBe(1)
+
+        const list = await env.fetchJson(`/gdocs/${created.id}/comments`)
+        expect(list.threads).toHaveLength(1)
+        expect(list.threads[0].comments).toHaveLength(2)
+    })
+
+    it("answers presence heartbeats", async () => {
+        const created = await createNativeDoc("Presence test")
+        const presence = await env.request({
+            method: "POST",
+            path: `/gdocs/${created.id}/presence`,
+        })
+        // the requester is excluded, and no one else is editing
+        expect(presence.editors).toEqual([])
     })
 
     it("resolves image references", async () => {

--- a/db/docs/posts_gdocs_comment_threads.yml
+++ b/db/docs/posts_gdocs_comment_threads.yml
@@ -1,0 +1,26 @@
+metadata:
+  description: |
+    Comment threads on natively-edited gdocs (rich editor collaboration). A thread is anchored to a text range or a block via ProseMirror positions in the draft document, or to the document as a whole. Threads whose anchor was deleted become 'orphaned' rather than disappearing, so no discussion is ever silently lost. The individual messages live in posts_gdocs_comments.
+fields:
+  id:
+    description: Auto-incrementing thread id
+  gdocId:
+    description: Foreign key to posts_gdocs
+  status:
+    description: "'open', 'resolved' (dismissed by an author, can be reopened) or 'orphaned' (the anchored text/block was deleted)"
+  anchorType:
+    description: "'range' (a text selection), 'block' (an atom block such as an image) or 'document' (no specific anchor)"
+  anchorFrom:
+    description: ProseMirror start position of the anchor in the draft doc; null for document-level threads
+  anchorTo:
+    description: ProseMirror end position of the anchor in the draft doc; null for document-level threads
+  anchorText:
+    description: Snapshot of the anchored text, used for display and as context when a thread is orphaned
+  createdAt:
+    description: When the thread was created
+  createdBy:
+    description: Foreign key to users; who started the thread
+  resolvedAt:
+    description: When the thread was resolved; null while open
+  resolvedBy:
+    description: Foreign key to users; who resolved the thread

--- a/db/docs/posts_gdocs_comments.yml
+++ b/db/docs/posts_gdocs_comments.yml
@@ -1,0 +1,16 @@
+metadata:
+  description: |
+    Individual comments within a comment thread on a natively-edited gdoc (see posts_gdocs_comment_threads). The first comment of a thread is created together with the thread; further rows are replies.
+fields:
+  id:
+    description: Auto-incrementing comment id
+  threadId:
+    description: Foreign key to posts_gdocs_comment_threads
+  userId:
+    description: Foreign key to users; the comment author
+  text:
+    description: The comment text (plain text)
+  createdAt:
+    description: When the comment was written
+  updatedAt:
+    description: When the comment was last edited

--- a/db/exportMetadataTables.ts
+++ b/db/exportMetadataTables.ts
@@ -100,6 +100,9 @@ export const PRIVATE_DATA_TABLES = [
     // content is internal (published content ships via posts_gdocs).
     "posts_gdocs_drafts",
     "posts_gdocs_revisions",
+    // Editorial discussion on drafts, never part of the public site
+    "posts_gdocs_comment_threads",
+    "posts_gdocs_comments",
 ]
 
 // Tables that are intentionally schema-only: their structure ships publicly

--- a/db/migration/1783000643648-AddGdocCommentTables.ts
+++ b/db/migration/1783000643648-AddGdocCommentTables.ts
@@ -1,0 +1,59 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class AddGdocCommentTables1783000643648 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        // Comment threads on natively-edited gdocs. A thread is anchored to a
+        // text range or a block (via ProseMirror positions in the draft doc),
+        // or to the document as a whole. Threads whose anchor text/block was
+        // deleted become "orphaned" rather than disappearing.
+        await queryRunner.query(`-- sql
+            CREATE TABLE posts_gdocs_comment_threads (
+                id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+                gdocId VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_as_cs NOT NULL,
+                status ENUM('open', 'resolved', 'orphaned') NOT NULL DEFAULT 'open',
+                anchorType ENUM('range', 'block', 'document') NOT NULL DEFAULT 'range',
+                anchorFrom INT NULL,
+                anchorTo INT NULL,
+                anchorText VARCHAR(512) NULL,
+                createdAt DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                createdBy INT NULL,
+                resolvedAt DATETIME NULL,
+                resolvedBy INT NULL,
+                PRIMARY KEY (id),
+                KEY idx_posts_gdocs_comment_threads_gdocId (gdocId, status),
+                CONSTRAINT posts_gdocs_comment_threads_gdocId_fk FOREIGN KEY (gdocId)
+                    REFERENCES posts_gdocs (id) ON DELETE CASCADE ON UPDATE CASCADE,
+                CONSTRAINT posts_gdocs_comment_threads_createdBy_fk FOREIGN KEY (createdBy)
+                    REFERENCES users (id) ON DELETE SET NULL,
+                CONSTRAINT posts_gdocs_comment_threads_resolvedBy_fk FOREIGN KEY (resolvedBy)
+                    REFERENCES users (id) ON DELETE SET NULL
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_as_cs
+        `)
+
+        await queryRunner.query(`-- sql
+            CREATE TABLE posts_gdocs_comments (
+                id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+                threadId BIGINT UNSIGNED NOT NULL,
+                userId INT NULL,
+                text TEXT NOT NULL,
+                createdAt DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updatedAt DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                PRIMARY KEY (id),
+                KEY idx_posts_gdocs_comments_threadId (threadId),
+                CONSTRAINT posts_gdocs_comments_threadId_fk FOREIGN KEY (threadId)
+                    REFERENCES posts_gdocs_comment_threads (id) ON DELETE CASCADE,
+                CONSTRAINT posts_gdocs_comments_userId_fk FOREIGN KEY (userId)
+                    REFERENCES users (id) ON DELETE SET NULL
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_as_cs
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`-- sql
+            DROP TABLE IF EXISTS posts_gdocs_comments
+        `)
+        await queryRunner.query(`-- sql
+            DROP TABLE IF EXISTS posts_gdocs_comment_threads
+        `)
+    }
+}

--- a/db/tests/testHelpers.ts
+++ b/db/tests/testHelpers.ts
@@ -13,6 +13,8 @@ import {
     JobsTableName,
     MultiDimDataPagesTableName,
     MultiDimXChartConfigsTableName,
+    PostsGdocsCommentThreadsTableName,
+    PostsGdocsCommentsTableName,
     PostsGdocsDraftsTableName,
     PostsGdocsRevisionsTableName,
     PostsGdocsTableName,
@@ -39,6 +41,8 @@ export const TABLES_IN_USE = [
     VariablesTableName,
     ChartConfigsTableName,
     DatasetsTableName,
+    PostsGdocsCommentsTableName, // Must come before PostsGdocsCommentThreadsTableName due to foreign key
+    PostsGdocsCommentThreadsTableName, // Must come before PostsGdocsTableName due to foreign key
     PostsGdocsDraftsTableName, // Must come before PostsGdocsRevisionsTableName due to foreign key
     PostsGdocsRevisionsTableName, // Must come before PostsGdocsTableName due to foreign key
     PostsGdocsTableName,

--- a/packages/@ourworldindata/types/src/dbTypes/PostsGdocsComments.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/PostsGdocsComments.ts
@@ -1,0 +1,36 @@
+export const PostsGdocsCommentThreadsTableName = "posts_gdocs_comment_threads"
+export const PostsGdocsCommentsTableName = "posts_gdocs_comments"
+
+export type PostGdocCommentThreadStatus = "open" | "resolved" | "orphaned"
+
+export type PostGdocCommentAnchorType = "range" | "block" | "document"
+
+export interface DbInsertPostGdocCommentThread {
+    id?: number
+    gdocId: string
+    status?: PostGdocCommentThreadStatus
+    anchorType?: PostGdocCommentAnchorType
+    anchorFrom?: number | null
+    anchorTo?: number | null
+    anchorText?: string | null
+    createdBy?: number | null
+    resolvedAt?: Date | null
+    resolvedBy?: number | null
+}
+
+export type DbRawPostGdocCommentThread =
+    Required<DbInsertPostGdocCommentThread> & {
+        createdAt: Date
+    }
+
+export interface DbInsertPostGdocComment {
+    id?: number
+    threadId: number
+    userId?: number | null
+    text: string
+}
+
+export type DbRawPostGdocComment = Required<DbInsertPostGdocComment> & {
+    createdAt: Date
+    updatedAt: Date
+}

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -606,6 +606,16 @@ export {
     PostsGdocsRevisionsTableName,
 } from "./dbTypes/PostsGdocsRevisions.js"
 export {
+    type PostGdocCommentThreadStatus,
+    type PostGdocCommentAnchorType,
+    type DbInsertPostGdocCommentThread,
+    type DbRawPostGdocCommentThread,
+    type DbInsertPostGdocComment,
+    type DbRawPostGdocComment,
+    PostsGdocsCommentThreadsTableName,
+    PostsGdocsCommentsTableName,
+} from "./dbTypes/PostsGdocsComments.js"
+export {
     type DbPlainPostGdocLink,
     type DbInsertPostGdocLink,
     PostsGdocsLinksTableName,

--- a/yarn.lock
+++ b/yarn.lock
@@ -13143,6 +13143,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rope-sequence@npm:^1.3.0":
+  version: 1.3.4
+  resolution: "rope-sequence@npm:1.3.4"
+  checksum: 10/57b5dd8c28ece05bb5f33eea6ea56facb00d4893269bb83aa8656f69065c1bc0707ec9bb816bce0e5f4d489d88942c7f0f0a1c3655773753ef158c9dd0e9456d
+  languageName: node
+  linkType: hard
+
 "router@npm:^2.2.0":
   version: 2.2.0
   resolution: "router@npm:2.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13143,13 +13143,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rope-sequence@npm:^1.3.0":
-  version: 1.3.4
-  resolution: "rope-sequence@npm:1.3.4"
-  checksum: 10/57b5dd8c28ece05bb5f33eea6ea56facb00d4893269bb83aa8656f69065c1bc0707ec9bb816bce0e5f4d489d88942c7f0f0a1c3655773753ef158c9dd0e9456d
-  languageName: node
-  linkType: hard
-
 "router@npm:^2.2.0":
   version: 2.2.0
   resolution: "router@npm:2.2.0"


### PR DESCRIPTION
Stacked on #6684 (M0 foundation). Implements **Milestone 1 — Data insights GA** from [`rich-editing-technical-plan.md`](https://github.com/owid/owid-grapher/blob/rich-editing-m1/rich-editing-technical-plan.md) §10.

## What this adds

### Publish path
- `POST /gdocs/:id/publish` promotes the draft head to `posts_gdocs.content` and reuses the existing gdocs machinery end-to-end: link + image-graph updates, derived tables, Algolia indexing, and bake/lightning deploy via `indexAndBakeGdocIfNeccesary`. Server-side validation via `GdocBase.loadState()`; blocking errors are returned and shown in a dialog. Stale `baseRevisionId` → 409. Every publish records an immutable `publish` revision.
- `POST /gdocs/:id/unpublish` mirrors the legacy settings-based unpublish.
- The legacy settings PUT (`/gdocs/:id`) now refuses publish-state changes for native docs and always preserves the DB body — the two authoring surfaces can no longer clobber each other.

### Settings rail
- `PUT /gdocs/:id/editorSettings` merges non-body content fields (title, authors, grapher-url, narrative-chart, figma-url) and the slug (unpublished only) into the draft, through the same revision mechanics as body saves — History covers settings changes.
- Right-rail **Settings** tab in the editor with the DI form.

### Comments v1 (plan §6)
- New tables `posts_gdocs_comment_threads` + `posts_gdocs_comments`; CRUD endpoints (create thread, reply, resolve/reopen, list).
- Threads anchor to a **text range** (ProseMirror positions), a block, or the document. In the editor, range threads are an editor-only `comment` mark: it moves with edits, survives undo, and is stripped during serialization so it never leaks into enriched content. Each body save reports the marks' current positions; threads whose text was deleted become **orphaned** (never silently dropped) and reopen if the text comes back.
- Right-rail **Comments** tab: comment on the current selection or the document, reply, resolve; click a quote to jump to the highlight.

### Presence
- `POST /gdocs/:id/presence` in-memory heartbeat (20s); banner shows who else has the doc open. Advisory — the 409 check remains the actual protection.

### Conversion + native-first creation
- The convert-to-native prompt now shows a **conversion report** (computed client-side from the serialization layer): how many blocks are fully editable, which fall back to opaque raw blocks, and whether the lossless round-trip check passes. Conversion is blocked if it fails.
- The gdocs index makes "New data insight" (native) the primary button; adding a Google Doc is secondary.
- The DI block palette / slash menu is filtered per doc type (text, image, CTA, lists).

## Verification
- 10 db/API tests in `adminSiteServer/tests/rich-editor.test.ts` (5 new: publish/unpublish incl. live-content protection for published docs, settings + slug rules, legacy-PUT guard, comment lifecycle incl. orphaning/reopening, presence). Full db suite: 82/82 green.
- Browser smoke test against the real admin + MySQL: create DI → type (autosave) → DI-filtered palette → settings rename → selection-anchored comment with canvas highlight → reply/resolve → publish (topbar flips to published / "Publish changes").

## Notes / deferred
- Slack notifications for comments and the image-reupload polish are not in this PR.
- Presence is per-process in-memory (fine for the single admin server; resets on deploy).
- Block-anchored threads are supported by the schema/API; the editor UI currently creates range + document threads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)