### PR TITLE
✨🤖 (time-interval) add timeInterval metadata, deprecate yearIsDay

### DIFF
--- a/adminSiteClient/VariableEditPage.tsx
+++ b/adminSiteClient/VariableEditPage.tsx
@@ -240,7 +240,11 @@ class VariableEditor extends Component<{
                             </FieldsRow>
                             <FieldsRow>
                                 <ReadOnlyField
-                                    label="Treat year column as day series"
+                                    label="Time interval"
+                                    value={variable.display?.timeInterval}
+                                />
+                                <ReadOnlyField
+                                    label="Treat year column as day series (deprecated)"
                                     value={
                                         variable.display?.yearIsDay
                                             ? "Yes"

--- a/adminSiteServer/testPageRouter.tsx
+++ b/adminSiteServer/testPageRouter.tsx
@@ -221,7 +221,10 @@ async function propsFromQueryParams(
             `
             (
                 SELECT COUNT(DISTINCT CASE
-                    WHEN variables.display->"$.yearIsDay" IS NULL
+                    WHEN (
+                        variables.display->"$.yearIsDay" IS NULL
+                        OR variables.display->"$.timeInterval" = "year"
+                    )
                     THEN "year"
                     ELSE "day"
                 END) as timeTypeCount

--- a/docs/chart-api.openapi.yaml
+++ b/docs/chart-api.openapi.yaml
@@ -1036,9 +1036,15 @@ components:
         isProjection:
           type: boolean
           description: Whether this column contains projected data.
-        yearIsDay:
-          type: boolean
-          description: Whether the time column represents days instead of years.
+        timeInterval:
+          type: string
+          enum:
+            - day
+            - year
+          description: >-
+            Resolution at which the time values should be interpreted and
+            formatted. "day" means the time values are days since a reference
+            date; "year" means they are literal years.
 
     GrapherValuesJsonDataPoints:
       type: object

--- a/packages/@ourworldindata/core-table/src/CoreTableColumns.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTableColumns.ts
@@ -20,6 +20,7 @@ import {
     ToleranceStrategy,
     IndicatorTitleWithFragments,
     stripOuterParentheses,
+    getTimeInterval,
 } from "@ourworldindata/utils"
 import { CoreTable } from "./CoreTable.js"
 import type { OwidTable } from "./OwidTable.js"
@@ -34,6 +35,7 @@ import {
     OwidVariableRow,
     ErrorValue,
     OwidVariableRoundingMode,
+    TimeInterval,
 } from "@ourworldindata/types"
 import { ErrorValueTypes, isNotErrorValue } from "./ErrorValues.js"
 import {
@@ -103,6 +105,10 @@ export abstract class AbstractCoreColumn<
 
     @imemo get display(): OwidVariableDisplayConfigInterface | undefined {
         return this.def.display
+    }
+
+    @imemo get timeInterval(): TimeInterval {
+        return getTimeInterval(this.display)
     }
 
     abstract formatValue(

--- a/packages/@ourworldindata/explorer/src/Explorer.sample.ts
+++ b/packages/@ourworldindata/explorer/src/Explorer.sample.ts
@@ -1,5 +1,5 @@
 import { DimensionProperty } from "@ourworldindata/utils"
-import { GRAPHER_TAB_CONFIG_OPTIONS } from "@ourworldindata/types"
+import { GRAPHER_TAB_CONFIG_OPTIONS, TimeInterval } from "@ourworldindata/types"
 import {
     GrapherProgrammaticInterface,
     legacyToOwidTableAndDimensionsWithMandatorySlug,
@@ -56,7 +56,10 @@ export const SampleExplorerOfGraphers = (props?: Partial<ExplorerProps>) => {
                 },
                 metadata: {
                     id: 142609,
-                    display: { zeroDay: "2020-01-21", yearIsDay: true },
+                    display: {
+                        zeroDay: "2020-01-21",
+                        timeInterval: TimeInterval.Day,
+                    },
                     dimensions: {
                         entities: {
                             values: [

--- a/packages/@ourworldindata/grapher/src/core/GrapherValuesJson.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherValuesJson.ts
@@ -150,7 +150,7 @@ const makeColumnInfo = (
         unit: column.unit,
         shortUnit: column.shortUnit,
         isProjection: column.isProjection ? true : undefined,
-        yearIsDay: column.display?.yearIsDay ? true : undefined,
+        timeInterval: column.timeInterval,
     })
 }
 

--- a/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.test.ts
+++ b/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.test.ts
@@ -5,8 +5,14 @@ import {
     OwidTableSlugs,
     StandardOwidColumnDefs,
     LegacyGrapherInterface,
+    OwidVariableDisplayConfigInterface,
+    TimeInterval,
 } from "@ourworldindata/types"
-import { ColumnTypeMap, ErrorValueTypes } from "@ourworldindata/core-table"
+import {
+    ColumnTypeMap,
+    ErrorValueTypes,
+    OwidTable,
+} from "@ourworldindata/core-table"
 import {
     legacyToOwidTableAndDimensions,
     legacyToOwidTableAndDimensionsWithMandatorySlug,
@@ -233,7 +239,7 @@ describe(legacyToOwidTableAndDimensions, () => {
                         metadata: {
                             id: 2,
                             display: {
-                                yearIsDay: true,
+                                timeInterval: TimeInterval.Day,
                                 zeroDay: "2020-01-21",
                             },
                             dimensions: {
@@ -274,7 +280,7 @@ describe(legacyToOwidTableAndDimensions, () => {
                         metadata: {
                             id: 3,
                             display: {
-                                yearIsDay: true,
+                                timeInterval: TimeInterval.Day,
                                 zeroDay: "2020-01-19",
                             },
                             dimensions: {
@@ -344,6 +350,83 @@ describe(legacyToOwidTableAndDimensions, () => {
         })
     })
 
+    describe("timeInterval resolution", () => {
+        const buildTable = (
+            display: OwidVariableDisplayConfigInterface
+        ): OwidTable => {
+            const config: MultipleOwidVariableDataDimensionsMap = new Map([
+                [
+                    2,
+                    {
+                        data: {
+                            entities: [1, 1],
+                            values: [8, 9],
+                            years: [0, 1],
+                        },
+                        metadata: {
+                            id: 2,
+                            display,
+                            dimensions: {
+                                entities: {
+                                    values: [
+                                        {
+                                            name: "World",
+                                            code: "OWID_WRL",
+                                            id: 1,
+                                        },
+                                    ],
+                                },
+                                years: {
+                                    values: [{ id: 0 }, { id: 1 }],
+                                },
+                            },
+                        },
+                    },
+                ],
+            ])
+            return legacyToOwidTableAndDimensionsWithMandatorySlug(
+                config,
+                [{ variableId: 2, property: DimensionProperty.y }],
+                {}
+            )
+        }
+
+        it("routes timeInterval 'day' to a Day time column", () => {
+            const table = buildTable({ timeInterval: TimeInterval.Day })
+            expect(table.columnSlugs).toContain(OwidTableSlugs.day)
+            expect(table.columnSlugs).not.toContain(OwidTableSlugs.year)
+            expect(
+                table.get(OwidTableSlugs.time) instanceof ColumnTypeMap.Day
+            ).toBeTruthy()
+        })
+
+        it("routes timeInterval 'year' to a Year time column", () => {
+            const table = buildTable({ timeInterval: TimeInterval.Year })
+            expect(table.columnSlugs).toContain(OwidTableSlugs.year)
+            expect(table.columnSlugs).not.toContain(OwidTableSlugs.day)
+            expect(
+                table.get(OwidTableSlugs.time) instanceof ColumnTypeMap.Year
+            ).toBeTruthy()
+        })
+
+        it("still treats legacy yearIsDay: true as daily", () => {
+            const table = buildTable({ yearIsDay: true })
+            expect(
+                table.get(OwidTableSlugs.time) instanceof ColumnTypeMap.Day
+            ).toBeTruthy()
+        })
+
+        it("lets timeInterval win over a conflicting yearIsDay flag", () => {
+            const table = buildTable({
+                timeInterval: TimeInterval.Day,
+                yearIsDay: false,
+            })
+            expect(
+                table.get(OwidTableSlugs.time) instanceof ColumnTypeMap.Day
+            ).toBeTruthy()
+        })
+    })
+
     describe("variables with mixed days & years", () => {
         const legacyVariableConfig: MultipleOwidVariableDataDimensionsMap =
             new Map([
@@ -358,7 +441,7 @@ describe(legacyToOwidTableAndDimensions, () => {
                         metadata: {
                             id: 2,
                             display: {
-                                yearIsDay: true,
+                                timeInterval: TimeInterval.Day,
                                 zeroDay: "2020-01-21",
                             },
                             dimensions: {
@@ -502,7 +585,7 @@ describe("variables with mixed days & years with missing overlap and multiple po
                     metadata: {
                         id: 2,
                         display: {
-                            yearIsDay: true,
+                            timeInterval: TimeInterval.Day,
                             zeroDay: "2020-01-21",
                         },
                         dimensions: {

--- a/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.ts
+++ b/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.ts
@@ -13,6 +13,7 @@ import {
     OwidChartDimensionInterfaceWithMandatorySlug,
     OwidChartDimensionInterface,
     EntityName,
+    TimeInterval,
 } from "@ourworldindata/types"
 import {
     OwidTable,
@@ -33,6 +34,7 @@ import {
     ColumnSlug,
     EPOCH_DATE,
     OwidVariableType,
+    getTimeInterval,
 } from "@ourworldindata/utils"
 import { isContinentsVariableId } from "./GrapherConstants"
 import * as R from "remeda"
@@ -209,7 +211,9 @@ export const legacyToOwidTableAndDimensions = (
             // on entity only (disregarding the year since we already filtered all other years out for
             // those variables)
             variableTablesWithYearToJoinByEntityOnly.push(variableTable)
-        } else if (variable.metadata.display?.yearIsDay)
+        } else if (
+            getTimeInterval(variable.metadata.display) === TimeInterval.Day
+        )
             variableTablesToJoinByDay.push(variableTable)
         else variableTablesToJoinByYear.push(variableTable)
     }
@@ -651,10 +655,12 @@ const columnDefFromOwidVariable = (
             ? getSortFromDimensions(variable.dimensions)
             : undefined
 
+    const isDailyMeasurement = getTimeInterval(display) === TimeInterval.Day
+
     return {
         name,
         slug,
-        isDailyMeasurement: display?.yearIsDay,
+        isDailyMeasurement,
         unit,
         shortUnit,
         description,
@@ -691,7 +697,7 @@ const columnDefFromOwidVariable = (
 const timeColumnDefFromOwidVariable = (
     variableMetadata: OwidVariableWithSource
 ): OwidColumnDef => {
-    return variableMetadata.display?.yearIsDay
+    return getTimeInterval(variableMetadata.display) === TimeInterval.Day
         ? {
               slug: OwidTableSlugs.day,
               type: ColumnTypeNames.Day,
@@ -712,7 +718,7 @@ const timeColumnValuesFromOwidVariable = (
     const { years } = variableData
     const yearsNeedTransform =
         display &&
-        display.yearIsDay &&
+        getTimeInterval(display) === TimeInterval.Day &&
         display.zeroDay !== undefined &&
         display.zeroDay !== EPOCH_DATE
     const yearsRaw = years || []
@@ -723,7 +729,7 @@ const timeColumnValuesFromOwidVariable = (
 
 const convertLegacyYears = (years: number[], zeroDay: string): number[] => {
     // Only shift years if the variable zeroDay is different from EPOCH_DATE
-    // When the dataset uses days (`yearIsDay == true`), the days are expressed as integer
+    // When the dataset uses days, the days are expressed as integer
     // days since the specified `zeroDay`, which can be different for different variables.
     // In order to correctly join variables with different `zeroDay`s in a single chart, we
     // normalize all days to be in reference to a single epoch date.

--- a/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
+++ b/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
@@ -73,6 +73,7 @@ import {
     OwidTableSlugs,
     ProjectionColumnInfo,
     Time,
+    TimeInterval,
     ToleranceStrategy,
     type EntitySelectorEvent,
 } from "@ourworldindata/types"
@@ -516,7 +517,7 @@ export class EntitySelector extends React.Component<EntitySelectorProps> {
 
     @computed private get chartHasDailyData(): boolean {
         return this.numericalChartColumns.some(
-            (column) => column.display?.yearIsDay
+            (column) => column.timeInterval === TimeInterval.Day
         )
     }
 
@@ -550,7 +551,10 @@ export class EntitySelector extends React.Component<EntitySelectorProps> {
 
         // When the chart uses daily dates but this column is yearly, convert
         // the lookup time back to a year before formatting the label
-        if (this.chartHasDailyData && !column.display?.yearIsDay) {
+        if (
+            this.chartHasDailyData &&
+            column.timeInterval === TimeInterval.Year
+        ) {
             return convertDaysSinceEpochToDate(lookupTime).year()
         }
 

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.010.yaml
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.010.yaml
@@ -134,10 +134,17 @@ properties:
             entityAnnotationsMap:
               type: string
               description: Entity annotations
+            timeInterval:
+              type: string
+              default: year
+              description: Resolution at which the time values should be interpreted and formatted.
+              enum:
+                - day
+                - year
             yearIsDay:
               type: boolean
               default: false
-              description: Switch to indicate if the number in the year column represents a day (since zeroDay) or not i.e. a year
+              description: "(Deprecated, use timeInterval instead) Switch to indicate if the number in the year column represents a day (since zeroDay) or not i.e. a year"
             color:
               type: string
               description: Default color for this time series
@@ -175,7 +182,7 @@ properties:
               default: 3
             zeroDay:
               type: string
-              description: Iso date day string for the starting date if yearIsDay is used
+              description: Iso date day string used as the reference date for day-encoded values
               default: "2020-01-21"
           additionalProperties: false
         variableId:

--- a/packages/@ourworldindata/types/src/OwidVariableDisplayConfigInterface.ts
+++ b/packages/@ourworldindata/types/src/OwidVariableDisplayConfigInterface.ts
@@ -15,6 +15,8 @@ export interface OwidVariableDisplayConfigInterface {
     numDecimalPlaces?: number
     numSignificantFigures?: number
     tolerance?: number
+    timeInterval?: TimeInterval
+    /** Deprecated: Use `timeInterval: "day"` instead. */
     yearIsDay?: boolean
     zeroDay?: string
     entityAnnotationsMap?: string
@@ -33,6 +35,16 @@ export interface OwidVariableDataTableConfigInterface {
 export enum OwidVariableRoundingMode {
     decimalPlaces = "decimalPlaces",
     significantFigures = "significantFigures",
+}
+
+/**
+ * Time resolution at which an indicator's time values should be interpreted and
+ * formatted. Sub-yearly intervals are encoded as days-since-epoch; `year` values
+ * are literal years.
+ */
+export enum TimeInterval {
+    Day = "day",
+    Year = "year",
 }
 
 export interface OwidChartDimensionInterface {

--- a/packages/@ourworldindata/types/src/endpointTypes/GrapherValuesJson.ts
+++ b/packages/@ourworldindata/types/src/endpointTypes/GrapherValuesJson.ts
@@ -1,5 +1,6 @@
 import { EntityName } from "../domainTypes/CoreTableTypes"
 import { PrimitiveType, ColumnSlug, Time } from "../grapherTypes/GrapherTypes"
+import { TimeInterval } from "../OwidVariableDisplayConfigInterface"
 
 /** Type definition for data retrieved from the `/grapher/slug.values.json` endpoint */
 export interface GrapherValuesJson {
@@ -18,7 +19,7 @@ export interface GrapherValuesJsonDimension {
     unit?: string
     shortUnit?: string
     isProjection?: boolean
-    yearIsDay?: boolean
+    timeInterval?: TimeInterval
 }
 
 export interface GrapherValuesJsonDataPoints {

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -321,6 +321,7 @@ export {
     type OwidVariableDisplayConfigInterface,
     type OwidVariableDataTableConfigInterface,
     OwidVariableRoundingMode,
+    TimeInterval,
     type OwidChartDimensionInterface,
     type OwidChartDimensionInterfaceWithMandatorySlug,
 } from "./OwidVariableDisplayConfigInterface.js"

--- a/packages/@ourworldindata/utils/src/OwidVariable.ts
+++ b/packages/@ourworldindata/utils/src/OwidVariable.ts
@@ -11,6 +11,7 @@ import {
     OwidVariableDataTableConfigInterface,
     OwidVariableDisplayConfigInterface,
     OwidVariableRoundingMode,
+    TimeInterval,
 } from "@ourworldindata/types"
 
 class OwidVariableDisplayConfigDefaults {
@@ -23,6 +24,7 @@ class OwidVariableDisplayConfigDefaults {
     numDecimalPlaces: number | undefined = undefined
     numSignificantFigures: number | undefined = undefined
     tolerance: number | undefined = undefined
+    timeInterval: TimeInterval | undefined = undefined
     yearIsDay: boolean | undefined = undefined
     zeroDay: string | undefined = undefined
     entityAnnotationsMap: string | undefined = undefined
@@ -42,6 +44,7 @@ class OwidVariableDisplayConfigDefaults {
             numDecimalPlaces: observable,
             numSignificantFigures: observable,
             tolerance: observable,
+            timeInterval: observable,
             yearIsDay: observable,
             zeroDay: observable,
             entityAnnotationsMap: observable,

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -54,6 +54,8 @@ import {
     RESEARCH_AND_WRITING_DEFAULT_HEADING,
     CHRONOLOGICAL_INDEX_TYPES,
     LATEST_FEED_TYPES,
+    TimeInterval,
+    type OwidVariableDisplayConfigInterface,
 } from "@ourworldindata/types"
 import { Point, PointVector } from "./PointVector.js"
 import * as React from "react"
@@ -219,6 +221,19 @@ export function formatDay(
 ): string {
     const format = options?.format ?? "MMM D, YYYY"
     return convertDaysSinceEpochToDate(dayAsYear).format(format)
+}
+
+/**
+ * Resolves the time interval of an indicator from its display config, falling
+ * back to the deprecated `yearIsDay` flag when `timeInterval` is not set.
+ */
+export function getTimeInterval(
+    display?: OwidVariableDisplayConfigInterface
+): TimeInterval {
+    return (
+        display?.timeInterval ??
+        (display?.yearIsDay ? TimeInterval.Day : TimeInterval.Year)
+    )
 }
 
 export const formatYear = (year: number): string => {

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -128,6 +128,7 @@ export {
     getUserNavigatorLanguages,
     getUserNavigatorLanguagesNonEnglish,
     convertDaysSinceEpochToDate,
+    getTimeInterval,
     logPerf,
     sleep,
     lowercaseObjectKeys,


### PR DESCRIPTION
First step of migrating `yearIsDay` to `timeInterval` ([technical write-up](https://app.notion.com/p/owid/2026-02-16-Supporting-More-Time-Intervals-30974b71f92e801db7dcc0bc4cd79cb4?source=copy_link)): Adds support for `timeInterval` alongside `yearIsDay`.

Stacked PRs add support for more time intervals (week, month, quarter, decade), before dropping `yearIsDay`. After that, some more work is done to actually improve Grapher's presentation of non-yearly data.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 12 in a stack** made with GitButler:
- <kbd>&nbsp;12&nbsp;</kbd> #6752 
- <kbd>&nbsp;11&nbsp;</kbd> #6723 
- <kbd>&nbsp;10&nbsp;</kbd> #6722 
- <kbd>&nbsp;9&nbsp;</kbd> #6721 
- <kbd>&nbsp;8&nbsp;</kbd> #6699 
- <kbd>&nbsp;7&nbsp;</kbd> #6700 
- <kbd>&nbsp;6&nbsp;</kbd> #6696 
- <kbd>&nbsp;5&nbsp;</kbd> #6733 
- <kbd>&nbsp;4&nbsp;</kbd> #6751 
- <kbd>&nbsp;3&nbsp;</kbd> #6694 
- <kbd>&nbsp;2&nbsp;</kbd> #6689 
- <kbd>&nbsp;1&nbsp;</kbd> #6688 👈 
<!-- GitButler Footer Boundary Bottom -->

