### PR TITLE
🔨🤖 (time-interval) capitalize OwidTableSlugs member names

### DIFF
--- a/functions/_common/grapherTools.test.ts
+++ b/functions/_common/grapherTools.test.ts
@@ -25,7 +25,7 @@ describe("download", () => {
         const expectedSlugs = originalTable.columnSlugs.filter(
             (slug) =>
                 !originalYColumns.includes(slug) &&
-                slug !== OwidTableSlugs.entityId
+                slug !== OwidTableSlugs.EntityId
         )
         expect(slugs).toEqual(expectedSlugs)
     })
@@ -47,7 +47,7 @@ describe("download", () => {
             const expectedSlugs = [
                 ...originalOtherColumns,
                 ...ySlugs.split(" "),
-            ].filter((slug) => slug !== OwidTableSlugs.entityId)
+            ].filter((slug) => slug !== OwidTableSlugs.EntityId)
             expectUnorderedEqual(slugs, expectedSlugs)
         }
     })

--- a/functions/_common/metadataTools.ts
+++ b/functions/_common/metadataTools.ts
@@ -37,13 +37,13 @@ export const getColumnsForMetadata = (grapherState: GrapherState) => {
 
     const columnsToIgnore = new Set(
         [
-            OwidTableSlugs.entityId,
-            OwidTableSlugs.time,
-            OwidTableSlugs.entityColor,
-            OwidTableSlugs.entityName,
-            OwidTableSlugs.entityCode,
-            OwidTableSlugs.year,
-            OwidTableSlugs.day,
+            OwidTableSlugs.EntityId,
+            OwidTableSlugs.Time,
+            OwidTableSlugs.EntityColor,
+            OwidTableSlugs.EntityName,
+            OwidTableSlugs.EntityCode,
+            OwidTableSlugs.Year,
+            OwidTableSlugs.Day,
         ].map((slug) => slug.toString())
     )
 

--- a/packages/@ourworldindata/core-table/src/CoreTable.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTable.ts
@@ -473,7 +473,7 @@ export class CoreTable<
     @imemo get timeColumn(): TimeColumn | MissingColumn {
         // "time" is the canonical time column slug.
         // See LegacyToOwidTable where this column is injected for all Graphers.
-        const maybeTimeColumn = this.get(OwidTableSlugs.time)
+        const maybeTimeColumn = this.get(OwidTableSlugs.Time)
         if (maybeTimeColumn instanceof ColumnTypeMap.Time)
             return maybeTimeColumn
         // If a valid "time" column doesn't exist, find _some_ time column to use.

--- a/packages/@ourworldindata/core-table/src/CoreTableUtils.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTableUtils.ts
@@ -134,9 +134,9 @@ export const guessColumnDefFromSlugAndRow = (
             name: "Year",
         }
 
-    if (slug === OwidTableSlugs.entityName) return OwidEntityNameColumnDef
-    if (slug === OwidTableSlugs.entityCode) return OwidEntityCodeColumnDef
-    if (slug === OwidTableSlugs.entityId) return OwidEntityIdColumnDef
+    if (slug === OwidTableSlugs.EntityName) return OwidEntityNameColumnDef
+    if (slug === OwidTableSlugs.EntityCode) return OwidEntityCodeColumnDef
+    if (slug === OwidTableSlugs.EntityId) return OwidEntityIdColumnDef
 
     if (slug === "date")
         return {

--- a/packages/@ourworldindata/core-table/src/OwidTable.test.ts
+++ b/packages/@ourworldindata/core-table/src/OwidTable.test.ts
@@ -85,8 +85,8 @@ it("can group data by entity and time", () => {
 describe("timeColumn", () => {
     it("uses 'time' as the canonical timeColumn", () => {
         const columnStore = {
-            [OwidTableSlugs.entityName]: ["usa"],
-            [OwidTableSlugs.time]: [2000],
+            [OwidTableSlugs.EntityName]: ["usa"],
+            [OwidTableSlugs.Time]: [2000],
             year: [2000],
             day: ["2000-01-01"],
             x: [0],
@@ -101,7 +101,7 @@ describe("timeColumn", () => {
                 type: ColumnTypeNames.Day,
             },
             {
-                slug: OwidTableSlugs.time,
+                slug: OwidTableSlugs.Time,
                 type: ColumnTypeNames.Year,
             },
             {
@@ -110,7 +110,7 @@ describe("timeColumn", () => {
             },
         ]
         const table = new OwidTable(columnStore, colDefs)
-        expect(table.timeColumn.slug).toEqual(OwidTableSlugs.time)
+        expect(table.timeColumn.slug).toEqual(OwidTableSlugs.Time)
     })
 
     it("prefers a day column when both year and day are in the chart", () => {

--- a/packages/@ourworldindata/core-table/src/OwidTable.ts
+++ b/packages/@ourworldindata/core-table/src/OwidTable.ts
@@ -70,7 +70,7 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
     @imemo get entityNameColumn(): OwidColumn {
         return (
             this.getFirstColumnWithType(ColumnTypeNames.EntityName) ??
-            this.get(OwidTableSlugs.entityName)
+            this.get(OwidTableSlugs.EntityName)
         )
     }
 
@@ -81,7 +81,7 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
     @imemo get entityCodeColumn(): OwidColumn {
         return (
             this.getFirstColumnWithType(ColumnTypeNames.EntityCode) ??
-            this.get(OwidTableSlugs.entityCode)
+            this.get(OwidTableSlugs.EntityCode)
         )
     }
 
@@ -92,7 +92,7 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
     @imemo get entityIdColumn(): OwidColumn {
         return (
             this.getFirstColumnWithType(ColumnTypeNames.EntityId) ??
-            this.get(OwidTableSlugs.entityId)
+            this.get(OwidTableSlugs.EntityId)
         )
     }
 
@@ -211,7 +211,7 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
         const adjustedStart = start === Infinity ? this.maxTime! : start
         const adjustedEnd = end === -Infinity ? this.minTime : end
         // todo: we should set a time column onload so we don't have to worry about it again.
-        const timeColumnSlug = this.timeColumn?.slug || OwidTableSlugs.time
+        const timeColumnSlug = this.timeColumn?.slug || OwidTableSlugs.Time
 
         const description = `Keep only rows with Time between ${adjustedStart} - ${adjustedEnd}`
 
@@ -831,7 +831,7 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
     @imemo get entityNameColorIndex(): Map<EntityName, Color> {
         return this.valueIndex(
             this.entityNameSlug,
-            OwidTableSlugs.entityColor
+            OwidTableSlugs.EntityColor
         ) as Map<EntityName, Color>
     }
 
@@ -934,7 +934,7 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
         const timeColumnOfTable = !this.timeColumn.isMissing
             ? this.timeColumn
             : // CovidTable does not have a day or year column so we need to use time.
-              this.get(OwidTableSlugs.time)
+              this.get(OwidTableSlugs.Time)
 
         const maybeTimeColumnOfValue =
             getOriginalTimeColumnSlug(this, columnSlug) ??
@@ -1016,7 +1016,7 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
             getOriginalTimeColumnSlug(this, columnSlug) ??
             timeColumnSlugFromColumnDef(columnDef)
         const timeColumn =
-            this.get(maybeTimeColumnSlug) ?? this.get(OwidTableSlugs.time) // CovidTable does not have a day or year column so we need to use time.
+            this.get(maybeTimeColumnSlug) ?? this.get(OwidTableSlugs.Time) // CovidTable does not have a day or year column so we need to use time.
 
         const originalColumnSlug =
             makeOriginalValueSlugFromColumnSlug(columnSlug)
@@ -1258,8 +1258,8 @@ export const BlankOwidTable = (
     new OwidTable(
         undefined,
         [
-            { slug: OwidTableSlugs.entityName },
-            { slug: OwidTableSlugs.year, type: ColumnTypeNames.Year },
+            { slug: OwidTableSlugs.EntityName },
+            { slug: OwidTableSlugs.Year, type: ColumnTypeNames.Year },
         ],
         {
             tableDescription: BLANK_TABLE_MESSAGE + extraTableDescription,

--- a/packages/@ourworldindata/core-table/src/OwidTableSynthesizers.ts
+++ b/packages/@ourworldindata/core-table/src/OwidTableSynthesizers.ts
@@ -35,10 +35,10 @@ const SynthesizeOwidTable = (
     const { entityCount, columnDefs, timeRange, entityNames } = finalOptions
     const colSlugs = (
         [
-            OwidTableSlugs.entityName,
-            OwidTableSlugs.entityCode,
-            OwidTableSlugs.entityId,
-            OwidTableSlugs.year,
+            OwidTableSlugs.EntityName,
+            OwidTableSlugs.EntityCode,
+            OwidTableSlugs.EntityId,
+            OwidTableSlugs.Year,
         ] as ColumnSlug[]
     ).concat(columnDefs.map((col) => col.slug))
 

--- a/packages/@ourworldindata/core-table/src/OwidTableUtil.ts
+++ b/packages/@ourworldindata/core-table/src/OwidTableUtil.ts
@@ -10,12 +10,12 @@ import { CoreTable } from "./CoreTable.js"
 
 export function timeColumnSlugFromColumnDef(
     def: OwidColumnDef
-): OwidTableSlugs.day | OwidTableSlugs.year {
+): OwidTableSlugs.Day | OwidTableSlugs.Year {
     // Day-encoded (sub-yearly) time lands in the day bucket,
     // everything else in the year bucket
     return isSubYearly(getTimeInterval(def.display))
-        ? OwidTableSlugs.day
-        : OwidTableSlugs.year
+        ? OwidTableSlugs.Day
+        : OwidTableSlugs.Year
 }
 
 export function makeOriginalTimeSlugFromColumnSlug(slug: ColumnSlug): string {

--- a/packages/@ourworldindata/grapher/src/controls/entityPicker/EntityPicker.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/entityPicker/EntityPicker.tsx
@@ -212,7 +212,7 @@ export class EntityPicker extends React.Component<EntityPickerProps> {
         // If the slug is "entityName", then try to get it from grapherTable first, because it might
         // not be present in pickerTable (for indicator-powered explorers, for example).
         if (
-            this.metric === OwidTableSlugs.entityName &&
+            this.metric === OwidTableSlugs.EntityName &&
             this.grapherTable?.has(this.metric)
         )
             return this.grapherTable
@@ -547,7 +547,7 @@ export class EntityPicker extends React.Component<EntityPickerProps> {
             // If columnSlug is undefined, we're sorting by relevance, which is (mostly) by country name.
             // If the column is currently missing (not loaded yet), assume it is numeric.
             columnSlug !== undefined &&
-            columnSlug !== OwidTableSlugs.entityName &&
+            columnSlug !== OwidTableSlugs.EntityName &&
             (col === undefined ||
                 col.isMissing ||
                 col instanceof ColumnTypeMap.Numeric)

--- a/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
@@ -1213,7 +1213,7 @@ export class GrapherState
         // Fill in missing entity codes
         if (table.entityCodeColumn.numErrorValues > 0) {
             table = table.replaceCells(
-                [OwidTableSlugs.entityCode],
+                [OwidTableSlugs.EntityCode],
                 (value, index) => {
                     if (isNotErrorValueOrEmptyCell(value)) return value
 
@@ -1233,7 +1233,7 @@ export class GrapherState
             (code) => code && code !== ""
         )
         if (!hasEntityCodes) {
-            table = table.dropColumns([OwidTableSlugs.entityCode])
+            table = table.dropColumns([OwidTableSlugs.EntityCode])
         }
 
         return table

--- a/packages/@ourworldindata/grapher/src/core/GrapherValuesJson.test.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherValuesJson.test.ts
@@ -20,26 +20,26 @@ describe(makeDimensionValuesForTimeDirect, () => {
     const makeTestTable = (): OwidTable => {
         return new OwidTable([
             {
-                [OwidTableSlugs.entityName]: "France",
-                [OwidTableSlugs.time]: 2000,
+                [OwidTableSlugs.EntityName]: "France",
+                [OwidTableSlugs.Time]: 2000,
                 gdp: 1000,
                 population: 60,
             },
             {
-                [OwidTableSlugs.entityName]: "France",
-                [OwidTableSlugs.time]: 2010,
+                [OwidTableSlugs.EntityName]: "France",
+                [OwidTableSlugs.Time]: 2010,
                 gdp: 1500,
                 population: 65,
             },
             {
-                [OwidTableSlugs.entityName]: "Germany",
-                [OwidTableSlugs.time]: 2000,
+                [OwidTableSlugs.EntityName]: "Germany",
+                [OwidTableSlugs.Time]: 2000,
                 gdp: 2000,
                 population: 80,
             },
             {
-                [OwidTableSlugs.entityName]: "Germany",
-                [OwidTableSlugs.time]: 2010,
+                [OwidTableSlugs.EntityName]: "Germany",
+                [OwidTableSlugs.Time]: 2010,
                 gdp: 2500,
                 population: 82,
             },

--- a/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.test.ts
+++ b/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.test.ts
@@ -203,15 +203,15 @@ describe(legacyToOwidTableAndDimensions, () => {
         it("duplicates 'year' column into 'time'", () => {
             expect(table.columnSlugs).toEqual(
                 expect.arrayContaining([
-                    OwidTableSlugs.year,
-                    OwidTableSlugs.time,
+                    OwidTableSlugs.Year,
+                    OwidTableSlugs.Time,
                 ])
             )
             expect(
-                table.get(OwidTableSlugs.time) instanceof ColumnTypeMap.Year
+                table.get(OwidTableSlugs.Time) instanceof ColumnTypeMap.Year
             ).toBeTruthy()
-            expect(table.columnSlugs).not.toContain(OwidTableSlugs.day)
-            expect(table.get(OwidTableSlugs.time).valuesAscending).toEqual([
+            expect(table.columnSlugs).not.toContain(OwidTableSlugs.Day)
+            expect(table.get(OwidTableSlugs.Time).valuesAscending).toEqual([
                 2020, 2021, 2022, 2022, 2024,
             ])
         })
@@ -336,15 +336,15 @@ describe(legacyToOwidTableAndDimensions, () => {
         it("duplicates 'day' column into 'time'", () => {
             expect(table.columnSlugs).toEqual(
                 expect.arrayContaining([
-                    OwidTableSlugs.day,
-                    OwidTableSlugs.time,
+                    OwidTableSlugs.Day,
+                    OwidTableSlugs.Time,
                 ])
             )
             expect(
-                table.get(OwidTableSlugs.time) instanceof ColumnTypeMap.Day
+                table.get(OwidTableSlugs.Time) instanceof ColumnTypeMap.Day
             ).toBeTruthy()
-            expect(table.columnSlugs).not.toContain(OwidTableSlugs.year)
-            expect(table.get(OwidTableSlugs.time).valuesAscending).toEqual([
+            expect(table.columnSlugs).not.toContain(OwidTableSlugs.Year)
+            expect(table.get(OwidTableSlugs.Time).valuesAscending).toEqual([
                 -6, -5, 0, 1,
             ])
         })
@@ -393,26 +393,26 @@ describe(legacyToOwidTableAndDimensions, () => {
 
         it("routes timeInterval 'day' to a Day time column", () => {
             const table = buildTable({ timeInterval: TimeInterval.Day })
-            expect(table.columnSlugs).toContain(OwidTableSlugs.day)
-            expect(table.columnSlugs).not.toContain(OwidTableSlugs.year)
+            expect(table.columnSlugs).toContain(OwidTableSlugs.Day)
+            expect(table.columnSlugs).not.toContain(OwidTableSlugs.Year)
             expect(
-                table.get(OwidTableSlugs.time) instanceof ColumnTypeMap.Day
+                table.get(OwidTableSlugs.Time) instanceof ColumnTypeMap.Day
             ).toBeTruthy()
         })
 
         it("routes timeInterval 'year' to a Year time column", () => {
             const table = buildTable({ timeInterval: TimeInterval.Year })
-            expect(table.columnSlugs).toContain(OwidTableSlugs.year)
-            expect(table.columnSlugs).not.toContain(OwidTableSlugs.day)
+            expect(table.columnSlugs).toContain(OwidTableSlugs.Year)
+            expect(table.columnSlugs).not.toContain(OwidTableSlugs.Day)
             expect(
-                table.get(OwidTableSlugs.time) instanceof ColumnTypeMap.Year
+                table.get(OwidTableSlugs.Time) instanceof ColumnTypeMap.Year
             ).toBeTruthy()
         })
 
         it("still treats legacy yearIsDay: true as daily", () => {
             const table = buildTable({ yearIsDay: true })
             expect(
-                table.get(OwidTableSlugs.time) instanceof ColumnTypeMap.Day
+                table.get(OwidTableSlugs.Time) instanceof ColumnTypeMap.Day
             ).toBeTruthy()
         })
 
@@ -422,7 +422,7 @@ describe(legacyToOwidTableAndDimensions, () => {
                 yearIsDay: false,
             })
             expect(
-                table.get(OwidTableSlugs.time) instanceof ColumnTypeMap.Day
+                table.get(OwidTableSlugs.Time) instanceof ColumnTypeMap.Day
             ).toBeTruthy()
         })
 
@@ -434,9 +434,9 @@ describe(legacyToOwidTableAndDimensions, () => {
             ] as const
             for (const [interval, ColumnType] of cases) {
                 const table = buildTable({ timeInterval: interval })
-                expect(table.columnSlugs).toContain(OwidTableSlugs.day)
-                expect(table.columnSlugs).not.toContain(OwidTableSlugs.year)
-                const timeColumn = table.get(OwidTableSlugs.time)
+                expect(table.columnSlugs).toContain(OwidTableSlugs.Day)
+                expect(table.columnSlugs).not.toContain(OwidTableSlugs.Year)
+                const timeColumn = table.get(OwidTableSlugs.Time)
                 expect(timeColumn instanceof ColumnType).toBeTruthy()
                 // Sub-yearly columns are day-encoded
                 expect(timeColumn instanceof ColumnTypeMap.Day).toBeTruthy()
@@ -445,9 +445,9 @@ describe(legacyToOwidTableAndDimensions, () => {
 
         it("routes timeInterval 'decade' to the year bucket with a Decade column type", () => {
             const table = buildTable({ timeInterval: TimeInterval.Decade })
-            expect(table.columnSlugs).toContain(OwidTableSlugs.year)
-            expect(table.columnSlugs).not.toContain(OwidTableSlugs.day)
-            const timeColumn = table.get(OwidTableSlugs.time)
+            expect(table.columnSlugs).toContain(OwidTableSlugs.Year)
+            expect(table.columnSlugs).not.toContain(OwidTableSlugs.Day)
+            const timeColumn = table.get(OwidTableSlugs.Time)
             expect(timeColumn instanceof ColumnTypeMap.Decade).toBeTruthy()
             // Decade columns are year-encoded
             expect(timeColumn instanceof ColumnTypeMap.Year).toBeTruthy()
@@ -627,14 +627,14 @@ describe(legacyToOwidTableAndDimensions, () => {
         it("duplicates 'day' column into 'time'", () => {
             expect(table.columnSlugs).toEqual(
                 expect.arrayContaining([
-                    OwidTableSlugs.day,
-                    OwidTableSlugs.time,
+                    OwidTableSlugs.Day,
+                    OwidTableSlugs.Time,
                 ])
             )
             expect(
-                table.get(OwidTableSlugs.time) instanceof ColumnTypeMap.Day
+                table.get(OwidTableSlugs.Time) instanceof ColumnTypeMap.Day
             ).toBeTruthy()
-            expect(table.get(OwidTableSlugs.time).uniqValues).toEqual([
+            expect(table.get(OwidTableSlugs.Time).uniqValues).toEqual([
                 -5, 0, 1,
             ])
         })
@@ -817,12 +817,12 @@ describe("variables with mixed days & years with missing overlap and multiple po
 
     it("duplicates 'day' column into 'time'", () => {
         expect(table.columnSlugs).toEqual(
-            expect.arrayContaining([OwidTableSlugs.day, OwidTableSlugs.time])
+            expect.arrayContaining([OwidTableSlugs.Day, OwidTableSlugs.Time])
         )
         expect(
-            table.get(OwidTableSlugs.time) instanceof ColumnTypeMap.Day
+            table.get(OwidTableSlugs.Time) instanceof ColumnTypeMap.Day
         ).toBeTruthy()
-        expect(table.get(OwidTableSlugs.time).uniqValues).toEqual([
+        expect(table.get(OwidTableSlugs.Time).uniqValues).toEqual([
             1, 2, 3, 400, 800,
         ])
     })

--- a/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.ts
+++ b/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.ts
@@ -168,9 +168,9 @@ export const legacyToOwidTableAndDimensions = (
         }
 
         const columnStore: { [key: string]: any[] } = {
-            [OwidTableSlugs.entityId]: entityIds,
-            [OwidTableSlugs.entityCode]: entityCodes,
-            [OwidTableSlugs.entityName]: entityNames,
+            [OwidTableSlugs.EntityId]: entityIds,
+            [OwidTableSlugs.EntityCode]: entityCodes,
+            [OwidTableSlugs.EntityName]: entityNames,
             [timeColumnDef.slug]: times,
             [valueColumnDef.slug]: values,
         }
@@ -245,8 +245,8 @@ export const legacyToOwidTableAndDimensions = (
 
     // Merge all day based variables together (returns an empty table if there are none)
     const variablesJoinedByDay = fullJoinTables(variableTablesToJoinByDay, [
-        OwidTableSlugs.day,
-        OwidTableSlugs.entityId,
+        OwidTableSlugs.Day,
+        OwidTableSlugs.EntityId,
     ])
 
     let joinedVariablesTable: OwidTable
@@ -257,7 +257,7 @@ export const legacyToOwidTableAndDimensions = (
     ) {
         // Derive the year from the day column and add it to the joined days table
         const daysColumn = variablesJoinedByDay.getColumns([
-            OwidTableSlugs.day,
+            OwidTableSlugs.Day,
         ])[0]
         const getYearFromISOStringMemoized = _.memoize((dayValue: number) =>
             getYearFromISOStringAndDayOffset(EPOCH_DATE, dayValue)
@@ -268,8 +268,8 @@ export const legacyToOwidTableAndDimensions = (
 
         const newYearColumn = {
             ...daysColumn,
-            slug: OwidTableSlugs.year,
-            name: OwidTableSlugs.year,
+            slug: OwidTableSlugs.Year,
+            name: OwidTableSlugs.Year,
             values: yearsForDaysValues,
         } as OwidColumnDef
         const variablesJoinedByDayWithYearFilled =
@@ -282,10 +282,10 @@ export const legacyToOwidTableAndDimensions = (
         // trying to merge first by day+entity, then year+entity and finally entity only
         joinedVariablesTable = fullJoinTables(
             [variablesJoinedByDayWithYearFilled, ...variableTablesToJoinByYear],
-            [OwidTableSlugs.day, OwidTableSlugs.entityId],
+            [OwidTableSlugs.Day, OwidTableSlugs.EntityId],
             [
-                [OwidTableSlugs.year, OwidTableSlugs.entityId],
-                [OwidTableSlugs.entityId],
+                [OwidTableSlugs.Year, OwidTableSlugs.EntityId],
+                [OwidTableSlugs.EntityId],
             ]
         )
         // If we have scatter/marimekko variables that had a targetTime set
@@ -296,15 +296,15 @@ export const legacyToOwidTableAndDimensions = (
                     joinedVariablesTable,
                     ...variableTablesWithYearToJoinByEntityOnly,
                 ],
-                [OwidTableSlugs.day, OwidTableSlugs.entityId],
-                [[OwidTableSlugs.entityId]]
+                [OwidTableSlugs.Day, OwidTableSlugs.EntityId],
+                [[OwidTableSlugs.EntityId]]
             )
     } else if (variableTablesToJoinByYear.length > 0) {
         // If we only have year based variables then life is easy and we just join
         // those together without any special cases
         joinedVariablesTable = fullJoinTables(variableTablesToJoinByYear, [
-            OwidTableSlugs.year,
-            OwidTableSlugs.entityId,
+            OwidTableSlugs.Year,
+            OwidTableSlugs.EntityId,
         ])
 
         // If we have scatter/marimekko variables that had a targetTime set
@@ -315,8 +315,8 @@ export const legacyToOwidTableAndDimensions = (
                     joinedVariablesTable,
                     ...variableTablesWithYearToJoinByEntityOnly,
                 ],
-                [OwidTableSlugs.year, OwidTableSlugs.entityId],
-                [[OwidTableSlugs.entityId]]
+                [OwidTableSlugs.Year, OwidTableSlugs.EntityId],
+                [[OwidTableSlugs.EntityId]]
             )
     } else {
         // If we only have day variables life is also easy but this case is rare
@@ -330,18 +330,18 @@ export const legacyToOwidTableAndDimensions = (
                     joinedVariablesTable,
                     ...variableTablesWithYearToJoinByEntityOnly,
                 ],
-                [OwidTableSlugs.day, OwidTableSlugs.entityId],
-                [[OwidTableSlugs.entityId]]
+                [OwidTableSlugs.Day, OwidTableSlugs.EntityId],
+                [[OwidTableSlugs.EntityId]]
             )
     }
 
     // Inject a common "time" column that is used as the main time column for the table
     // e.g. for the timeline.
-    for (const dayOrYearSlug of [OwidTableSlugs.day, OwidTableSlugs.year]) {
+    for (const dayOrYearSlug of [OwidTableSlugs.Day, OwidTableSlugs.Year]) {
         if (joinedVariablesTable.columnSlugs.includes(dayOrYearSlug)) {
             joinedVariablesTable = joinedVariablesTable.duplicateColumn(
                 dayOrYearSlug,
-                { slug: OwidTableSlugs.time, name: OwidTableSlugs.time }
+                { slug: OwidTableSlugs.Time, name: OwidTableSlugs.Time }
             )
             // Do not inject multiple columns, terminate after one is successful
             break
@@ -350,7 +350,7 @@ export const legacyToOwidTableAndDimensions = (
 
     // Append the entity color column if we have selected entity colors
     if (!_.isEmpty(selectedEntityColors)) {
-        const entityColorColumnSlug = OwidTableSlugs.entityColor
+        const entityColorColumnSlug = OwidTableSlugs.EntityColor
 
         const valueFn = (
             entityName: EntityName | undefined
@@ -695,32 +695,32 @@ const columnDefFromOwidVariable = (
 // all share the `day` slug (days-since-epoch) so they join in the same bucket
 const TIME_COLUMN_DEF_BY_INTERVAL: Record<TimeInterval, OwidColumnDef> = {
     [TimeInterval.Day]: {
-        slug: OwidTableSlugs.day,
+        slug: OwidTableSlugs.Day,
         type: ColumnTypeNames.Day,
         name: "Day",
     },
     [TimeInterval.Week]: {
-        slug: OwidTableSlugs.day,
+        slug: OwidTableSlugs.Day,
         type: ColumnTypeNames.Week,
         name: "Week",
     },
     [TimeInterval.Month]: {
-        slug: OwidTableSlugs.day,
+        slug: OwidTableSlugs.Day,
         type: ColumnTypeNames.Month,
         name: "Month",
     },
     [TimeInterval.Quarter]: {
-        slug: OwidTableSlugs.day,
+        slug: OwidTableSlugs.Day,
         type: ColumnTypeNames.Quarter,
         name: "Quarter",
     },
     [TimeInterval.Year]: {
-        slug: OwidTableSlugs.year,
+        slug: OwidTableSlugs.Year,
         type: ColumnTypeNames.Year,
         name: "Year",
     },
     [TimeInterval.Decade]: {
-        slug: OwidTableSlugs.year,
+        slug: OwidTableSlugs.Year,
         type: ColumnTypeNames.Decade,
         name: "Decade",
     },
@@ -869,9 +869,9 @@ export function buildVariableTable(
     }
 
     const columnStore: { [key: string]: any[] } = {
-        [OwidTableSlugs.entityId]: entityIds,
-        [OwidTableSlugs.entityCode]: entityCodes,
-        [OwidTableSlugs.entityName]: entityNames,
+        [OwidTableSlugs.EntityId]: entityIds,
+        [OwidTableSlugs.EntityCode]: entityCodes,
+        [OwidTableSlugs.EntityName]: entityNames,
         [timeColumnDef.slug]: times,
         [valueColumnDef.slug]: values,
     }

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
@@ -715,7 +715,7 @@ export class DataTable extends React.Component<DataTableProps> {
                 })
                 .filter((col) => col)
 
-        const skips = new Set(Object.keys(OwidTableSlugs))
+        const skips = new Set<string>(Object.values(OwidTableSlugs))
         return this.table.columnsAsArray.filter(
             (column) =>
                 !skips.has(column.slug) &&

--- a/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
+++ b/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
@@ -1858,16 +1858,16 @@ function buildOwidTableForCatalogData(
     const originalTimeSlug = makeOriginalTimeSlugFromColumnSlug(slug)
 
     const rows = data.map((row) => ({
-        [OwidTableSlugs.entityName]: row.entity,
+        [OwidTableSlugs.EntityName]: row.entity,
         // The catalog data's max year is used as the time for all rows
-        [OwidTableSlugs.year]: maxYear,
+        [OwidTableSlugs.Year]: maxYear,
         [columnDef.slug]: row.value,
         [originalTimeSlug]: row.year,
     }))
 
     // Necessary to ensure correct formatting of the year values
     const yearColumnDef: OwidColumnDef = {
-        slug: OwidTableSlugs.year,
+        slug: OwidTableSlugs.Year,
         type: ColumnTypeNames.Year,
     }
     const originalTimeColumnDef: OwidColumnDef = {

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.test.ts
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.test.ts
@@ -373,7 +373,7 @@ it("assigns entity colors to series, overriding colorScale color", () => {
                 "y",
                 "color",
                 "size",
-                OwidTableSlugs.entityColor,
+                OwidTableSlugs.EntityColor,
             ],
             [1, "UK", "", 2000, 1, 2, "Europe", null, "#ccc"],
         ],

--- a/packages/@ourworldindata/types/src/domainTypes/CoreTableTypes.ts
+++ b/packages/@ourworldindata/types/src/domainTypes/CoreTableTypes.ts
@@ -115,14 +115,14 @@ type CoreVector = any[]
 export type CoreMatrix = CoreVector[]
 
 export enum OwidTableSlugs {
-    entityName = "entityName",
-    entityColor = "entityColor",
-    entityId = "entityId",
-    entityCode = "entityCode",
-    time = "time",
-    day = "day",
-    year = "year",
-    date = "date",
+    EntityName = "entityName",
+    EntityColor = "entityColor",
+    EntityId = "entityId",
+    EntityCode = "entityCode",
+    Time = "time",
+    Day = "day",
+    Year = "year",
+    Date = "date",
 }
 
 enum OwidTableNames {
@@ -270,18 +270,18 @@ export interface OwidColumnDef extends CoreColumnDef {
 
 export const OwidEntityNameColumnDef = {
     name: OwidTableNames.Entity,
-    slug: OwidTableSlugs.entityName,
+    slug: OwidTableSlugs.EntityName,
     type: ColumnTypeNames.EntityName,
 }
 
 export const OwidEntityIdColumnDef = {
-    slug: OwidTableSlugs.entityId,
+    slug: OwidTableSlugs.EntityId,
     type: ColumnTypeNames.EntityId,
 }
 
 export const OwidEntityCodeColumnDef = {
     name: OwidTableNames.Code,
-    slug: OwidTableSlugs.entityCode,
+    slug: OwidTableSlugs.EntityCode,
     type: ColumnTypeNames.EntityCode,
 }
 


### PR DESCRIPTION
Rename the OwidTableSlugs enum members to PascalCase (EntityName, Day,
Year, Time, …). The string values are unchanged, so behavior is identical
— this is a naming-consistency refactor.

<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 12 in a stack** made with GitButler:
- <kbd>&nbsp;12&nbsp;</kbd> #6752 
- <kbd>&nbsp;11&nbsp;</kbd> #6723 
- <kbd>&nbsp;10&nbsp;</kbd> #6722 
- <kbd>&nbsp;9&nbsp;</kbd> #6721 
- <kbd>&nbsp;8&nbsp;</kbd> #6699 
- <kbd>&nbsp;7&nbsp;</kbd> #6700 
- <kbd>&nbsp;6&nbsp;</kbd> #6696 
- <kbd>&nbsp;5&nbsp;</kbd> #6733 
- <kbd>&nbsp;4&nbsp;</kbd> #6751 
- <kbd>&nbsp;3&nbsp;</kbd> #6694 👈 
- <kbd>&nbsp;2&nbsp;</kbd> #6689 
- <kbd>&nbsp;1&nbsp;</kbd> #6688 
<!-- GitButler Footer Boundary Bottom -->

