### PR TITLE
🎉 🤖 add admin components reference gallery

### DIFF
--- a/adminSiteClient/AdminApp.tsx
+++ b/adminSiteClient/AdminApp.tsx
@@ -5,6 +5,7 @@ import { ChartEditorPage } from "./ChartEditorPage.js"
 import { action } from "mobx"
 import { observer } from "mobx-react"
 import { ChartIndexPage } from "./ChartIndexPage.js"
+import { ComponentsIndexPage } from "./ComponentsIndexPage.js"
 import { UsersIndexPage } from "./UsersIndexPage.js"
 import { DatasetsIndexPage } from "./DatasetsIndexPage.js"
 import { UserEditPage } from "./UserEditPage.js"
@@ -176,6 +177,11 @@ export class AdminApp extends React.Component<{
                                     exact
                                     path="/charts"
                                     component={ChartIndexPage}
+                                />
+                                <Route
+                                    exact
+                                    path="/components"
+                                    component={ComponentsIndexPage}
                                 />
                                 <Route
                                     exact

--- a/adminSiteClient/AdminSidebar.tsx
+++ b/adminSiteClient/AdminSidebar.tsx
@@ -26,6 +26,7 @@ import {
     faMonument,
     faDisplay,
     faLinkSlash,
+    faPuzzlePiece,
 } from "@fortawesome/free-solid-svg-icons"
 
 import { ETL_WIZARD_URL } from "../settings/clientSettings.js"
@@ -71,6 +72,12 @@ export const AdminSidebar = (): React.ReactElement => (
                 <Link to="/orphaned-articles">
                     <FontAwesomeIcon icon={faLinkSlash} fixedWidth /> Orphaned
                     articles
+                </Link>
+            </li>
+            <li>
+                <Link to="/components">
+                    <FontAwesomeIcon icon={faPuzzlePiece} fixedWidth />{" "}
+                    Components
                 </Link>
             </li>
             <li>

--- a/adminSiteClient/ComponentsIndexPage.scss
+++ b/adminSiteClient/ComponentsIndexPage.scss
@@ -1,0 +1,193 @@
+.components-index-page {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 24px;
+}
+
+.components-index-page__header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 16px;
+    margin-bottom: 20px;
+}
+
+.components-index-page__heading {
+    font-size: 22px;
+    font-weight: 600;
+    margin: 0;
+}
+
+.components-index-page__count {
+    font-size: 13px;
+    color: $gray-70;
+    margin-top: 2px;
+}
+
+.components-index-page__gallery {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+    gap: 12px;
+}
+
+.components-index-page__card {
+    display: block;
+    text-align: left;
+    width: 100%;
+    background: #fff;
+    border: 1px solid $gray-20;
+    border-radius: 6px;
+    padding: 14px;
+    cursor: pointer;
+    transition:
+        border-color 0.1s ease,
+        box-shadow 0.1s ease;
+
+    &:hover {
+        border-color: $blue-40;
+    }
+
+    &:focus-visible {
+        outline: 2px solid $blue-60;
+        outline-offset: 2px;
+    }
+}
+
+.components-index-page__card-title {
+    font-size: 15px;
+    font-weight: 600;
+    color: $blue-90;
+}
+
+.components-index-page__card-id {
+    display: inline-block;
+    margin: 4px 0;
+    font-family: var(--font-mono, monospace);
+    font-size: 13px;
+    color: $blue-60;
+}
+
+.components-index-page__card-type {
+    font-family: var(--font-mono, monospace);
+    font-size: 11px;
+    color: $gray-60;
+}
+
+.components-index-page__card-description {
+    margin: 8px 0 0;
+    font-size: 13px;
+    line-height: 1.4;
+    color: $gray-80;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+.components-index-page__detail {
+    max-width: 760px;
+}
+
+.components-index-page__back {
+    background: none;
+    border: none;
+    padding: 0;
+    margin-bottom: 16px;
+    color: $blue-60;
+    cursor: pointer;
+    font-size: 14px;
+}
+
+.components-index-page__detail-title {
+    font-size: 26px;
+    font-weight: 600;
+    margin: 0;
+}
+
+.components-index-page__detail-id {
+    display: inline-block;
+    margin: 6px 0;
+    font-family: var(--font-mono, monospace);
+    font-size: 15px;
+    color: $blue-60;
+}
+
+.components-index-page__detail-type {
+    font-family: var(--font-mono, monospace);
+    font-size: 12px;
+    color: $gray-60;
+}
+
+.components-index-page__detail-links {
+    display: flex;
+    gap: 16px;
+    margin: 14px 0 24px;
+    font-size: 13px;
+}
+
+.components-index-page__body {
+    line-height: 1.55;
+
+    h2 {
+        font-size: 18px;
+        font-weight: 600;
+        margin: 24px 0 8px;
+    }
+
+    h3 {
+        font-size: 15px;
+        font-weight: 600;
+        margin: 20px 0 6px;
+    }
+
+    code {
+        font-family: var(--font-mono, monospace);
+        font-size: 0.9em;
+        background: $gray-10;
+        padding: 1px 4px;
+        border-radius: 3px;
+    }
+}
+
+.components-index-page__code {
+    position: relative;
+    margin: 12px 0;
+
+    pre {
+        background: $gray-100;
+        color: $gray-5;
+        border-radius: 6px;
+        padding: 14px 16px;
+        overflow-x: auto;
+        margin: 0;
+    }
+
+    code {
+        background: none;
+        padding: 0;
+        color: inherit;
+        font-size: 13px;
+    }
+}
+
+.components-index-page__copy-button {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    background: rgba(255, 255, 255, 0.15);
+    border: none;
+    border-radius: 4px;
+    color: #fff;
+    font-size: 12px;
+    padding: 4px 8px;
+    cursor: pointer;
+
+    &:hover {
+        background: rgba(255, 255, 255, 0.3);
+    }
+}
+
+.components-index-page__empty {
+    color: $gray-70;
+    font-style: italic;
+}

--- a/adminSiteClient/ComponentsIndexPage.tsx
+++ b/adminSiteClient/ComponentsIndexPage.tsx
@@ -1,0 +1,259 @@
+import { Component, useState } from "react"
+import { observer } from "mobx-react"
+import { observable, action, computed, runInAction, makeObservable } from "mobx"
+import Markdown, { type Components as MarkdownComponents } from "react-markdown"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import {
+    faCopy,
+    faCheck,
+    faArrowLeft,
+    faPenToSquare,
+    faCode,
+} from "@fortawesome/free-solid-svg-icons"
+import { ComponentDoc } from "@ourworldindata/types"
+import { AdminLayout } from "./AdminLayout.js"
+import { SearchField } from "./Forms.js"
+import { AdminAppContext, AdminAppContextType } from "./AdminAppContext.js"
+
+// Component docs live as .md sidecars in the repo, gated by CI; the detail view
+// links technical editors to the GitHub web editor to propose changes.
+const GITHUB_REPO = "https://github.com/owid/owid-grapher"
+const githubEditUrl = (sidecarFile: string): string =>
+    `${GITHUB_REPO}/edit/master/${sidecarFile}`
+const githubBlobUrl = (sourceFile: string): string =>
+    `${GITHUB_REPO}/blob/master/${sourceFile}`
+
+// First paragraph of the markdown body, used as the card description.
+function describeComponent(doc: ComponentDoc): string {
+    const firstParagraph = doc.body.split("\n\n")[0] ?? ""
+    return firstParagraph.replace(/\s+/g, " ").trim()
+}
+
+function matchesSearch(doc: ComponentDoc, query: string): boolean {
+    const haystack = [doc.title, doc.id, doc.typeName, doc.body]
+        .join("\n")
+        .toLowerCase()
+    return haystack.includes(query)
+}
+
+// A fenced code block in the rendered markdown body, with a Copy button. The
+// fenced blocks are the paste-ready ArchieML examples; this is also the seam
+// where a future phase can render the live component instead of its source.
+function CopyableCodeBlock({ code }: { code: string }): React.ReactElement {
+    const [copied, setCopied] = useState(false)
+    const onCopy = (): void => {
+        void navigator.clipboard.writeText(code).then(() => {
+            setCopied(true)
+            setTimeout(() => setCopied(false), 1500)
+        })
+    }
+    return (
+        <div className="components-index-page__code">
+            <button
+                className="components-index-page__copy-button"
+                type="button"
+                onClick={onCopy}
+            >
+                <FontAwesomeIcon icon={copied ? faCheck : faCopy} />{" "}
+                {copied ? "Copied" : "Copy"}
+            </button>
+            <pre>
+                <code>{code}</code>
+            </pre>
+        </div>
+    )
+}
+
+// react-markdown passes the <code> element as the <pre>'s child; pull its text
+// out so we can attach a Copy button to each example.
+function extractCodeText(children: React.ReactNode): string {
+    const codeElement = children as
+        | React.ReactElement<{ children?: React.ReactNode }>
+        | undefined
+    const codeChildren = codeElement?.props?.children
+    return typeof codeChildren === "string"
+        ? codeChildren.replace(/\n$/, "")
+        : ""
+}
+
+const markdownComponents: MarkdownComponents = {
+    pre: ({ children }) => (
+        <CopyableCodeBlock code={extractCodeText(children)} />
+    ),
+}
+
+@observer
+export class ComponentsIndexPage extends Component {
+    static override contextType = AdminAppContext
+    declare context: AdminAppContextType
+
+    components: ComponentDoc[] = []
+    searchInput: string = ""
+    selectedId: string | undefined = undefined
+
+    constructor(props: Record<string, never>) {
+        super(props)
+        makeObservable(this, {
+            components: observable,
+            searchInput: observable,
+            selectedId: observable,
+        })
+    }
+
+    @computed get filteredComponents(): ComponentDoc[] {
+        const query = this.searchInput.trim().toLowerCase()
+        if (!query) return this.components
+        return this.components.filter((doc) => matchesSearch(doc, query))
+    }
+
+    @computed get selectedComponent(): ComponentDoc | undefined {
+        return this.components.find((doc) => doc.id === this.selectedId)
+    }
+
+    @action.bound private selectComponent(id: string): void {
+        this.selectedId = id
+        window.location.hash = id
+    }
+
+    @action.bound private clearSelection(): void {
+        this.selectedId = undefined
+        window.location.hash = ""
+    }
+
+    @action.bound private onSearch(value: string): void {
+        this.searchInput = value
+    }
+
+    private renderCard(doc: ComponentDoc): React.ReactElement {
+        return (
+            <button
+                key={doc.id}
+                className="components-index-page__card"
+                type="button"
+                onClick={() => this.selectComponent(doc.id)}
+            >
+                <div className="components-index-page__card-title">
+                    {doc.title}
+                </div>
+                <code className="components-index-page__card-id">
+                    {`{.${doc.id}}`}
+                </code>
+                <div className="components-index-page__card-type">
+                    {doc.typeName}
+                </div>
+                <p className="components-index-page__card-description">
+                    {describeComponent(doc)}
+                </p>
+            </button>
+        )
+    }
+
+    private renderGallery(): React.ReactElement {
+        const { filteredComponents, components } = this
+        return (
+            <>
+                <div className="components-index-page__header">
+                    <div>
+                        <h1 className="components-index-page__heading">
+                            ArchieML components
+                        </h1>
+                        <div className="components-index-page__count">
+                            {filteredComponents.length === components.length
+                                ? `${components.length} components`
+                                : `${filteredComponents.length} of ${components.length} components`}
+                        </div>
+                    </div>
+                    <SearchField
+                        placeholder="Search by name, id, type, or description"
+                        value={this.searchInput}
+                        onValue={this.onSearch}
+                        autofocus
+                    />
+                </div>
+                <div className="components-index-page__gallery">
+                    {filteredComponents.map((doc) => this.renderCard(doc))}
+                </div>
+            </>
+        )
+    }
+
+    private renderDetail(doc: ComponentDoc): React.ReactElement {
+        const hasExamples = doc.examples.length > 0
+        return (
+            <div className="components-index-page__detail" id={doc.id}>
+                <button
+                    className="components-index-page__back"
+                    type="button"
+                    onClick={this.clearSelection}
+                >
+                    <FontAwesomeIcon icon={faArrowLeft} /> All components
+                </button>
+                <h1 className="components-index-page__detail-title">
+                    {doc.title}
+                </h1>
+                <code className="components-index-page__detail-id">
+                    {`{.${doc.id}}`}
+                </code>
+                <div className="components-index-page__detail-type">
+                    {doc.typeName}
+                </div>
+                <div className="components-index-page__detail-links">
+                    <a
+                        href={githubEditUrl(doc.sidecarFile)}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        <FontAwesomeIcon icon={faPenToSquare} /> Suggest an edit
+                    </a>
+                    <a
+                        href={githubBlobUrl(doc.sourceFile)}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        <FontAwesomeIcon icon={faCode} /> View type definition
+                    </a>
+                </div>
+                <div className="components-index-page__body">
+                    <Markdown components={markdownComponents}>
+                        {doc.body}
+                    </Markdown>
+                </div>
+                {!hasExamples && (
+                    <p className="components-index-page__empty">
+                        This component has no standalone ArchieML example — it
+                        only appears nested inside other components.
+                    </p>
+                )}
+            </div>
+        )
+    }
+
+    override render(): React.ReactElement {
+        const { selectedComponent } = this
+        return (
+            <AdminLayout title="Components">
+                <main className="components-index-page">
+                    {selectedComponent
+                        ? this.renderDetail(selectedComponent)
+                        : this.renderGallery()}
+                </main>
+            </AdminLayout>
+        )
+    }
+
+    async getData(): Promise<void> {
+        const { components } = await this.context.admin.getJSON<{
+            components: ComponentDoc[]
+        }>("/api/components.json")
+        runInAction(() => {
+            this.components = components
+            const hash = window.location.hash.replace(/^#/, "")
+            if (hash && components.some((doc) => doc.id === hash))
+                this.selectedId = hash
+        })
+    }
+
+    override componentDidMount(): void {
+        void this.getData()
+    }
+}

--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -35,6 +35,7 @@
 @import "./StaticViz.scss";
 @import "./MultiDimDetailPage.scss";
 @import "./slideshows/SlideshowAdmin.scss";
+@import "./ComponentsIndexPage.scss";
 // Slide content styles reused for slideshow preview
 @import "../site/slideshows/SlideContent.scss";
 

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -60,6 +60,7 @@ import {
     getImageUsageHandler,
 } from "./apiRoutes/images.js"
 import { getFiles, uploadFileToR2 } from "./apiRoutes/files.js"
+import { getComponentsReference } from "./apiRoutes/components.js"
 import {
     handlePutMultiDim,
     handleGetMultiDim,
@@ -677,6 +678,9 @@ getRouteWithROTransaction(apiRouter, "/figma/image", getFigmaImageUrl)
 
 // Slack routes
 postRouteWithRWTransaction(apiRouter, "/slack/sendMessage", sendMessageToSlack)
+
+// ArchieML component reference (served from the committed registry JSON)
+apiRouter.get("/components.json", getComponentsReference)
 
 // Deploy helpers
 apiRouter.get("/deploys.json", async () => ({

--- a/adminSiteServer/apiRoutes/components.ts
+++ b/adminSiteServer/apiRoutes/components.ts
@@ -1,0 +1,13 @@
+import { ComponentDoc } from "@ourworldindata/types"
+
+// The ArchieML component registry is generated in CI by
+// devTools/gdocs/generate-components-reference.ts and committed to the repo, so
+// we can serve it directly to the admin components reference page without
+// touching the database. See docs/component-reference-admin-plan.md.
+import componentsRegistry from "../../docs/components.registry.generated.json"
+
+export async function getComponentsReference(): Promise<{
+    components: ComponentDoc[]
+}> {
+    return { components: componentsRegistry as ComponentDoc[] }
+}

--- a/docs/component-reference-admin-mockup.html
+++ b/docs/component-reference-admin-mockup.html
@@ -1,0 +1,636 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>ArchieML component reference — mockup</title>
+        <link
+            rel="stylesheet"
+            href="https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@3.21.0/dist/tabler-icons.min.css"
+        />
+        <style>
+            :root {
+                --color-text-primary: #1a1a18;
+                --color-text-secondary: #5f5e5a;
+                --color-text-tertiary: #888780;
+                --color-text-info: #185fa5;
+                --color-text-success: #0f6e56;
+                --color-text-danger: #a32d2d;
+                --color-text-warning: #854f0b;
+                --color-background-primary: #ffffff;
+                --color-background-secondary: #f4f3ee;
+                --color-background-tertiary: #eceae2;
+                --color-background-info: #e6f1fb;
+                --color-background-success: #e1f5ee;
+                --color-background-danger: #fcebeb;
+                --color-background-warning: #faeeda;
+                --color-border-tertiary: rgba(0, 0, 0, 0.15);
+                --color-border-secondary: rgba(0, 0, 0, 0.3);
+                --color-border-info: #378add;
+                --font-sans:
+                    ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto,
+                    Helvetica, Arial, sans-serif;
+                --font-mono:
+                    ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+                --font-serif: Georgia, "Times New Roman", serif;
+                --border-radius-md: 8px;
+                --border-radius-lg: 12px;
+            }
+            @media (prefers-color-scheme: dark) {
+                :root {
+                    --color-text-primary: #ececec;
+                    --color-text-secondary: #a8a79f;
+                    --color-text-tertiary: #777;
+                    --color-background-primary: #1f1f1d;
+                    --color-background-secondary: #2a2a27;
+                    --color-background-tertiary: #333330;
+                    --color-border-tertiary: rgba(255, 255, 255, 0.15);
+                    --color-border-secondary: rgba(255, 255, 255, 0.3);
+                }
+            }
+            * {
+                box-sizing: border-box;
+            }
+            body {
+                font-family: var(--font-sans);
+                color: var(--color-text-primary);
+                background: var(--color-background-tertiary);
+                margin: 0;
+                padding: 24px;
+            }
+            .wrap {
+                max-width: 720px;
+                margin: 0 auto;
+                background: var(--color-background-tertiary);
+            }
+            .sr-only {
+                position: absolute;
+                width: 1px;
+                height: 1px;
+                overflow: hidden;
+                clip: rect(0 0 0 0);
+            }
+            input {
+                height: 36px;
+                border-radius: var(--border-radius-md);
+                border: 0.5px solid var(--color-border-secondary);
+                background: var(--color-background-primary);
+                color: var(--color-text-primary);
+                font-size: 14px;
+                padding: 0 10px;
+                outline: none;
+            }
+            input:focus {
+                box-shadow: 0 0 0 2px var(--color-border-info);
+            }
+            button {
+                font-family: inherit;
+                border-radius: var(--border-radius-md);
+                border: 0.5px solid var(--color-border-secondary);
+                background: transparent;
+                color: var(--color-text-primary);
+            }
+            button:hover {
+                background: var(--color-background-secondary);
+            }
+            pre {
+                margin: 0;
+            }
+        </style>
+    </head>
+    <body>
+        <div class="wrap">
+            <h2 class="sr-only">
+                ArchieML component reference: a searchable, filterable gallery
+                of components that opens to a detail view pairing the rendered
+                output with paste-ready archie source.
+            </h2>
+
+            <div
+                style="
+                    display: flex;
+                    align-items: center;
+                    gap: 12px;
+                    margin-bottom: 14px;
+                "
+            >
+                <div style="flex: 1">
+                    <div
+                        style="
+                            font-size: 18px;
+                            font-weight: 500;
+                            color: var(--color-text-primary);
+                        "
+                    >
+                        ArchieML components
+                    </div>
+                    <div
+                        id="countline"
+                        style="
+                            font-size: 13px;
+                            color: var(--color-text-secondary);
+                        "
+                    >
+                        65 components
+                    </div>
+                </div>
+                <div style="position: relative; width: 230px">
+                    <i
+                        class="ti ti-search"
+                        aria-hidden="true"
+                        style="
+                            position: absolute;
+                            left: 10px;
+                            top: 9px;
+                            font-size: 16px;
+                            color: var(--color-text-tertiary);
+                        "
+                    ></i>
+                    <input
+                        id="q"
+                        type="text"
+                        placeholder="Search  &#8984;K"
+                        aria-label="Search components"
+                        style="width: 100%; padding-left: 32px"
+                    />
+                </div>
+            </div>
+
+            <div
+                id="cats"
+                style="
+                    display: flex;
+                    flex-wrap: wrap;
+                    gap: 6px;
+                    margin-bottom: 16px;
+                "
+            ></div>
+
+            <div
+                id="gallery"
+                style="
+                    display: grid;
+                    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+                    gap: 10px;
+                "
+            ></div>
+            <div id="detail" style="display: none"></div>
+        </div>
+
+        <script>
+            const C = [
+                {
+                    id: "side-by-side",
+                    title: "Side by side",
+                    type: "EnrichedBlockSideBySideContainer",
+                    cat: "Layout",
+                    usage: 142,
+                    desc: "Two-column layout with left and right columns of roughly equal weight.",
+                    use: [
+                        "Pairing two charts, or a chart and explanatory text, at equal weight.",
+                    ],
+                    not: [
+                        "One column should dominate — use {.sticky-left} / {.sticky-right} instead.",
+                    ],
+                    vars: ["accepts: [.+left], [.+right]"],
+                    prev: `<div style="display:flex; gap:6px; height:100%;"><div style="flex:1; background:var(--color-background-primary); border:0.5px solid var(--color-border-secondary); border-radius:4px;"></div><div style="flex:1; background:var(--color-background-primary); border:0.5px solid var(--color-border-secondary); border-radius:4px;"></div></div>`,
+                    ex: [
+                        {
+                            name: "Basic two columns",
+                            archie: "{.side-by-side}\n[.+left]\nI am content on the left.\n[]\n[.+right]\nI am content on the right.\n[]\n{}",
+                        },
+                    ],
+                },
+
+                {
+                    id: "sticky-right",
+                    title: "Sticky right",
+                    type: "EnrichedBlockStickyRightContainer",
+                    cat: "Layout",
+                    usage: 88,
+                    desc: "Two-column layout where the right column sticks to the viewport as the reader scrolls through the left.",
+                    use: [
+                        "A chart that should stay visible while the reader scrolls long explanatory text.",
+                    ],
+                    not: ["Both columns are short — use {.side-by-side}."],
+                    vars: ["accepts: [.+left], [.+right]"],
+                    prev: `<div style="display:flex; gap:6px; height:100%;"><div style="flex:1.3; display:flex; flex-direction:column; gap:3px; justify-content:center;"><span style="height:4px;background:var(--color-border-secondary);border-radius:2px;"></span><span style="height:4px;width:80%;background:var(--color-border-secondary);border-radius:2px;"></span><span style="height:4px;width:90%;background:var(--color-border-secondary);border-radius:2px;"></span></div><div style="flex:1; background:var(--color-background-info); border:0.5px solid var(--color-border-info); border-radius:4px;"></div></div>`,
+                    ex: [
+                        {
+                            name: "Chart sticky beside text",
+                            archie: "{.sticky-right}\n[.+left]\nLots of explanatory text here that scrolls...\n[]\n[.+right]\n{.chart}\nurl: https://ourworldindata.org/grapher/life-expectancy\n{}\n[]\n{}",
+                        },
+                    ],
+                },
+
+                {
+                    id: "chart",
+                    title: "Chart",
+                    type: "EnrichedBlockChart",
+                    cat: "Charts & data",
+                    usage: 980,
+                    desc: "A Grapher chart, explorer, or MDIM embed.",
+                    use: [
+                        "Embedding any interactive Grapher chart by its URL.",
+                    ],
+                    not: [
+                        "You want a static, non-interactive image — use {.image} or {.static-viz}.",
+                    ],
+                    vars: [
+                        "url",
+                        "title (override)",
+                        "subtitle",
+                        "tab",
+                        "position",
+                    ],
+                    prev: `<svg viewBox="0 0 100 48" style="width:100%;height:100%"><polyline points="4,40 22,28 40,32 58,16 76,20 94,6" fill="none" stroke="#185FA5" stroke-width="2.5"/><line x1="4" y1="44" x2="96" y2="44" stroke="var(--color-border-secondary)" stroke-width="1"/></svg>`,
+                    ex: [
+                        {
+                            name: "Single chart by URL",
+                            archie: "{.chart}\nurl: https://ourworldindata.org/grapher/military-expenditure-share-gdp\n{}",
+                        },
+                    ],
+                },
+
+                {
+                    id: "chart-story",
+                    title: "Chart story",
+                    type: "EnrichedBlockChartStory",
+                    cat: "Charts & data",
+                    usage: 31,
+                    desc: "A carousel of charts, each paired with a narrative caption and a block of technical text.",
+                    use: [
+                        "Walking readers through a sequence of chart states as a guided narrative.",
+                    ],
+                    not: ["A single chart suffices — use {.chart}."],
+                    vars: ["narrative", "chart", "{.technical}"],
+                    prev: `<div style="display:flex;flex-direction:column;gap:4px;height:100%;"><div style="flex:1;background:var(--color-background-primary);border:0.5px solid var(--color-border-secondary);border-radius:4px;"></div><div style="display:flex;gap:4px;justify-content:center;"><span style="width:5px;height:5px;border-radius:50%;background:var(--color-text-secondary);"></span><span style="width:5px;height:5px;border-radius:50%;background:var(--color-border-secondary);"></span><span style="width:5px;height:5px;border-radius:50%;background:var(--color-border-secondary);"></span></div></div>`,
+                    ex: [
+                        {
+                            name: "Two-slide story",
+                            archie: "[.chart-story]\nnarrative: Text for slide 1, an overview of the world\nchart: https://ourworldindata.org/grapher/military-expenditure-share-gdp\n{.technical}\nExtreme poverty is defined as living below $1.90 per day.\n{}\n\nnarrative: Slide two looks at Africa\nchart: https://ourworldindata.org/grapher/military-expenditure-share-gdp?region=Africa\n{.technical}\nData is measured in international-$.\n{}\n[]",
+                        },
+                    ],
+                },
+
+                {
+                    id: "key-insights",
+                    title: "Key insights",
+                    type: "EnrichedBlockKeyInsights",
+                    cat: "Callouts",
+                    usage: 64,
+                    desc: "A slide carousel of the core takeaways of a topic page.",
+                    use: [
+                        "Summarising the 3–6 headline findings of a topic at the top of the page.",
+                    ],
+                    not: ["A single highlight — use {.callout}."],
+                    vars: [
+                        "heading",
+                        "[.insights] (title, url | filename | narrativeChartName, [.+content])",
+                    ],
+                    prev: `<div style="display:flex;gap:5px;height:100%;align-items:stretch;"><div style="flex:1;background:var(--color-background-secondary);border-radius:4px;"></div><div style="flex:2;display:flex;flex-direction:column;gap:3px;justify-content:center;"><span style="height:5px;width:60%;background:var(--color-text-secondary);border-radius:2px;"></span><span style="height:4px;background:var(--color-border-secondary);border-radius:2px;"></span><span style="height:4px;width:85%;background:var(--color-border-secondary);border-radius:2px;"></span></div></div>`,
+                    ex: [
+                        {
+                            name: "Carousel with mixed slides",
+                            archie: "{.key-insights}\nheading: Key Insights on Poverty\n[.insights]\n\ntitle: The age dependency ratio changes by country\nurl: https://ourworldindata.org/grapher/age-dependency-breakdown\n[.+content]\nAll sorts of content can go in here.\n[]\n\ntitle: This slide uses an image\nfilename: default-featured-image.png\n[.+content]\nBlah blah.\n[]\n\n[]\n{}",
+                        },
+                    ],
+                },
+
+                {
+                    id: "callout",
+                    title: "Callout",
+                    type: "EnrichedBlockCallout",
+                    cat: "Callouts",
+                    usage: 210,
+                    desc: "A small gray-background block used to draw attention to meta-textual information.",
+                    use: [
+                        "Notes about data vintage, caveats, or editorial asides.",
+                    ],
+                    not: [
+                        "Highlighting a key finding — use {.key-insights} or {.pull-quote}.",
+                    ],
+                    vars: ["title", "icon: info | …", "[.+text]"],
+                    prev: `<div style="height:100%;background:var(--color-background-secondary);border-radius:6px;display:flex;align-items:center;gap:8px;padding:0 10px;"><i class="ti ti-info-circle" style="font-size:18px;color:var(--color-text-secondary);"></i><div style="flex:1;display:flex;flex-direction:column;gap:3px;"><span style="height:4px;width:40%;background:var(--color-text-secondary);border-radius:2px;"></span><span style="height:4px;background:var(--color-border-secondary);border-radius:2px;"></span></div></div>`,
+                    ex: [
+                        {
+                            name: "Info callout",
+                            archie: "{.callout}\ntitle: Update\nicon: info\n[.+text]\nThis article uses data from 2020\n\nBut the conclusions are solid.\n[]\n{}",
+                        },
+                    ],
+                },
+
+                {
+                    id: "prominent-link",
+                    title: "Prominent link",
+                    type: "EnrichedBlockProminentLink",
+                    cat: "Callouts",
+                    usage: 155,
+                    desc: "A visually prominent link tile.",
+                    use: [
+                        "Driving readers to a single important related article or resource.",
+                    ],
+                    not: [
+                        "Several links of equal weight — use {.pill-row} or {.recirc}.",
+                    ],
+                    vars: [
+                        "url",
+                        "title (override)",
+                        "description",
+                        "thumbnail",
+                    ],
+                    prev: `<div style="height:100%;background:var(--color-background-primary);border:0.5px solid var(--color-border-secondary);border-radius:6px;display:flex;align-items:center;justify-content:space-between;padding:0 10px;"><div style="display:flex;flex-direction:column;gap:3px;flex:1;"><span style="height:4px;width:55%;background:var(--color-text-secondary);border-radius:2px;"></span><span style="height:4px;width:80%;background:var(--color-border-secondary);border-radius:2px;"></span></div><i class="ti ti-arrow-right" style="font-size:18px;color:var(--color-text-info);"></i></div>`,
+                    ex: [
+                        {
+                            name: "Link by URL",
+                            archie: "{.prominent-link}\nurl: https://ourworldindata.org/grapher/life-expectancy\n{}",
+                        },
+                    ],
+                },
+
+                {
+                    id: "pull-quote",
+                    title: "Pull quote",
+                    type: "EnrichedBlockPullQuote",
+                    cat: "Text",
+                    usage: 47,
+                    desc: "A centered, italicized h1 used to re-emphasize a phrase from the surrounding body text.",
+                    use: [
+                        "Re-emphasising a striking sentence already present in the prose.",
+                    ],
+                    not: ["Quoting an external source — use {.blockquote}."],
+                    vars: [
+                        "quote",
+                        "align: left-center | center",
+                        "[.+content]",
+                    ],
+                    prev: `<div style="height:100%;display:flex;align-items:center;gap:8px;padding:0 8px;"><span style="font-family:var(--font-serif);font-size:34px;line-height:1;color:var(--color-border-secondary);">&ldquo;</span><div style="flex:1;display:flex;flex-direction:column;gap:4px;"><span style="height:5px;width:90%;background:var(--color-text-secondary);border-radius:2px;"></span><span style="height:5px;width:70%;background:var(--color-text-secondary);border-radius:2px;"></span></div></div>`,
+                    ex: [
+                        {
+                            name: "Left-center quote",
+                            archie: "{.pull-quote}\nquote: I am a left-center aligned quote that should span multiple lines.\nalign: left-center\n[.+content]\nSuspendisse commodo turpis nunc, sit amet cursus odio porttitor.\n[]\n{}",
+                        },
+                    ],
+                },
+
+                {
+                    id: "image",
+                    title: "Image",
+                    type: "EnrichedBlockImage",
+                    cat: "Media",
+                    usage: 520,
+                    desc: "A static image uploaded to the OWID admin.",
+                    use: [
+                        "Photographs, diagrams, or any non-interactive visual.",
+                    ],
+                    not: ["An interactive chart — use {.chart}."],
+                    vars: [
+                        "filename",
+                        "alt",
+                        "size: narrow | wide",
+                        "caption",
+                        "hasOutline",
+                        "visibility",
+                    ],
+                    prev: `<div style="height:100%;background:var(--color-background-secondary);border-radius:4px;display:flex;align-items:center;justify-content:center;"><i class="ti ti-photo" style="font-size:26px;color:var(--color-text-tertiary);"></i></div>`,
+                    ex: [
+                        {
+                            name: "Narrow image with caption",
+                            archie: "{.image}\nfilename: default-featured-image.png\nalt: my alt text that is optional\nsize: narrow\ncaption: I am a caption that would appear below the image\nhasOutline: true\nvisibility: desktop\n{}",
+                        },
+                    ],
+                },
+
+                {
+                    id: "people-rows",
+                    title: "People rows",
+                    type: "EnrichedBlockPeopleRows",
+                    cat: "People",
+                    usage: 9,
+                    desc: "A grid of person cards, used on about pages to present team members.",
+                    use: ["Team / contributor listings on about pages."],
+                    not: ["A single person — use {.person}."],
+                    vars: ["columns", "[.people] of {.person}"],
+                    prev: `<div style="display:flex;gap:8px;height:100%;align-items:center;justify-content:center;">${[0, 1, 2].map(() => '<div style="display:flex;flex-direction:column;align-items:center;gap:3px;"><span style="width:18px;height:18px;border-radius:50%;background:var(--color-background-secondary);"></span><span style="width:22px;height:3px;background:var(--color-border-secondary);border-radius:2px;"></span></div>').join("")}</div>`,
+                    ex: [
+                        {
+                            name: "Team grid",
+                            archie: "{.people-rows}\ncolumns: 4\n[.people]\n{.person}\nname: Max Roser\ntitle: Founder\n[.+text]\nBio text here.\n[]\n{}\n[]\n{}",
+                        },
+                    ],
+                },
+
+                {
+                    id: "topic-page-intro",
+                    title: "Topic page intro",
+                    type: "EnrichedBlockTopicPageIntro",
+                    cat: "Page structure",
+                    usage: 58,
+                    desc: "The introduction section of a topic page.",
+                    use: ["The canonical opening block of any topic page."],
+                    not: [
+                        "Article or data-insight pages — they have their own intro patterns.",
+                    ],
+                    vars: [
+                        "[.+content]",
+                        "[.downloadButton]",
+                        "[.relatedTopics]",
+                    ],
+                    prev: `<div style="display:flex;flex-direction:column;gap:5px;height:100%;justify-content:center;"><span style="height:7px;width:55%;background:var(--color-text-secondary);border-radius:2px;"></span><span style="height:4px;background:var(--color-border-secondary);border-radius:2px;"></span><span style="height:4px;width:85%;background:var(--color-border-secondary);border-radius:2px;"></span></div>`,
+                    ex: [
+                        {
+                            name: "Topic intro",
+                            archie: "{.topic-page-intro}\n[.+content]\nThis page presents the data on poverty...\n[]\n[.relatedTopics]\nurl: https://ourworldindata.org/economic-growth\n[]\n{}",
+                        },
+                    ],
+                },
+
+                {
+                    id: "expandable-paragraph",
+                    title: "Expandable paragraph",
+                    type: "EnrichedBlockExpandableParagraph",
+                    cat: "Layout",
+                    usage: 38,
+                    desc: "Displays a short preview with a Show more button that reveals the rest.",
+                    use: [
+                        "Long methodological detail you want collapsed by default.",
+                    ],
+                    not: ["Content that should always be visible."],
+                    vars: ["[.+content]"],
+                    prev: `<div style="display:flex;flex-direction:column;gap:4px;height:100%;justify-content:center;"><span style="height:4px;background:var(--color-border-secondary);border-radius:2px;"></span><span style="height:4px;width:88%;background:var(--color-border-secondary);border-radius:2px;"></span><span style="font-size:11px;color:var(--color-text-info);">Show more</span></div>`,
+                    ex: [
+                        {
+                            name: "Collapsed detail",
+                            archie: "{.expandable-paragraph}\n[.+content]\nA long methodological note that is collapsed until the reader expands it.\n[]\n{}",
+                        },
+                    ],
+                },
+            ]
+
+            const CATS = [
+                "All",
+                "Layout",
+                "Charts & data",
+                "Callouts",
+                "Text",
+                "Media",
+                "People",
+                "Page structure",
+            ]
+            let activeCat = "All",
+                query = ""
+
+            const catsEl = document.getElementById("cats")
+            const galEl = document.getElementById("gallery")
+            const detEl = document.getElementById("detail")
+            const countEl = document.getElementById("countline")
+
+            function catCount(c) {
+                return c === "All" ? 65 : C.filter((x) => x.cat === c).length
+            }
+
+            function renderCats() {
+                catsEl.innerHTML = CATS.map((c) => {
+                    const on = c === activeCat
+                    return `<button data-cat="${c}" style="font-size:13px; padding:5px 11px; border-radius:999px; border:0.5px solid ${on ? "var(--color-border-info)" : "var(--color-border-tertiary)"}; background:${on ? "var(--color-background-info)" : "transparent"}; color:${on ? "var(--color-text-info)" : "var(--color-text-secondary)"}; cursor:pointer;">${c} <span style="opacity:.6">${catCount(c)}</span></button>`
+                }).join("")
+                catsEl.querySelectorAll("button").forEach(
+                    (b) =>
+                        (b.onclick = () => {
+                            activeCat = b.dataset.cat
+                            renderGallery()
+                        })
+                )
+            }
+
+            function matches(c) {
+                const inCat = activeCat === "All" || c.cat === activeCat
+                const q = query.trim().toLowerCase()
+                const inQ =
+                    !q ||
+                    c.title.toLowerCase().includes(q) ||
+                    c.id.includes(q) ||
+                    c.desc.toLowerCase().includes(q)
+                return inCat && inQ
+            }
+
+            function usageBadge(n) {
+                const label =
+                    n >= 300 ? "Common" : n >= 40 ? "Frequent" : "Rare"
+                const ramp =
+                    n >= 300
+                        ? [
+                              "var(--color-background-success)",
+                              "var(--color-text-success)",
+                          ]
+                        : n >= 40
+                          ? [
+                                "var(--color-background-secondary)",
+                                "var(--color-text-secondary)",
+                            ]
+                          : [
+                                "var(--color-background-warning)",
+                                "var(--color-text-warning)",
+                            ]
+                return `<span style="font-size:11px; padding:2px 7px; border-radius:4px; background:${ramp[0]}; color:${ramp[1]};">${label} · ${n}</span>`
+            }
+
+            function renderGallery() {
+                detEl.style.display = "none"
+                galEl.style.display = "grid"
+                renderCats()
+                const list = C.filter(matches)
+                countEl.textContent = `${list.length} of 65 components${activeCat !== "All" ? " · " + activeCat : ""}`
+                galEl.innerHTML =
+                    list
+                        .map(
+                            (c) => `
+    <div data-id="${c.id}" role="button" tabindex="0" style="background:var(--color-background-primary); border:0.5px solid var(--color-border-tertiary); border-radius:var(--border-radius-lg); padding:10px; cursor:pointer;">
+      <div style="height:62px; margin-bottom:9px;">${c.prev}</div>
+      <div style="display:flex; align-items:center; justify-content:space-between; gap:6px;">
+        <span style="font-size:14px; font-weight:500; color:var(--color-text-primary);">${c.title}</span>
+        ${usageBadge(c.usage)}
+      </div>
+      <div style="font-family:var(--font-mono); font-size:11px; color:var(--color-text-tertiary); margin:2px 0 5px;">{.${c.id}}</div>
+      <div style="font-size:12px; color:var(--color-text-secondary); line-height:1.45;">${c.desc}</div>
+    </div>`
+                        )
+                        .join("") ||
+                    `<div style="color:var(--color-text-secondary); font-size:14px;">No components match.</div>`
+                galEl.querySelectorAll("[data-id]").forEach((el) => {
+                    el.onclick = () => openDetail(el.dataset.id)
+                    el.onkeydown = (e) => {
+                        if (e.key === "Enter") openDetail(el.dataset.id)
+                    }
+                })
+            }
+
+            function esc(s) {
+                return s
+                    .replace(/&/g, "&amp;")
+                    .replace(/</g, "&lt;")
+                    .replace(/>/g, "&gt;")
+            }
+
+            function openDetail(id) {
+                const c = C.find((x) => x.id === id)
+                galEl.style.display = "none"
+                detEl.style.display = "block"
+                detEl.innerHTML = `
+    <button id="back" style="font-size:13px; padding:5px 10px; margin-bottom:12px; cursor:pointer;"><i class="ti ti-arrow-left" aria-hidden="true"></i> All components</button>
+    <div style="display:flex; align-items:center; gap:10px; flex-wrap:wrap; margin-bottom:4px;">
+      <span style="font-size:18px; font-weight:500;">${c.title}</span>
+      ${usageBadge(c.usage)}
+      <span style="font-family:var(--font-mono); font-size:12px; color:var(--color-text-tertiary);">${c.type}</span>
+    </div>
+    <div style="font-size:15px; color:var(--color-text-secondary); line-height:1.6; margin-bottom:16px;">${c.desc}</div>
+
+    <div style="display:grid; grid-template-columns:1fr 1fr; gap:10px; margin-bottom:16px;">
+      <div style="background:var(--color-background-success); border-radius:var(--border-radius-md); padding:10px 12px;">
+        <div style="font-size:12px; font-weight:500; color:var(--color-text-success); margin-bottom:5px;"><i class="ti ti-check" aria-hidden="true"></i> When to use</div>
+        ${c.use.map((u) => `<div style="font-size:13px; color:var(--color-text-success); line-height:1.5;">${u}</div>`).join("")}
+      </div>
+      <div style="background:var(--color-background-danger); border-radius:var(--border-radius-md); padding:10px 12px;">
+        <div style="font-size:12px; font-weight:500; color:var(--color-text-danger); margin-bottom:5px;"><i class="ti ti-x" aria-hidden="true"></i> When not to</div>
+        ${c.not.map((u) => `<div style="font-size:13px; color:var(--color-text-danger); line-height:1.5;">${u}</div>`).join("")}
+      </div>
+    </div>
+
+    <div style="margin-bottom:16px;">
+      <div style="font-size:12px; color:var(--color-text-secondary); margin-bottom:6px;">Fields &amp; structure</div>
+      <div style="display:flex; flex-wrap:wrap; gap:6px;">${c.vars.map((v) => `<span style="font-family:var(--font-mono); font-size:12px; padding:3px 8px; border-radius:4px; background:var(--color-background-secondary); color:var(--color-text-secondary);">${esc(v)}</span>`).join("")}</div>
+    </div>
+
+    <div style="font-size:12px; color:var(--color-text-secondary); margin-bottom:6px;">Example · ${esc(c.ex[0].name)}</div>
+    <div style="display:grid; grid-template-columns:1fr 1fr; gap:10px; align-items:stretch;">
+      <div style="background:var(--color-background-secondary); border-radius:var(--border-radius-md); padding:14px; display:flex; align-items:center;">
+        <div style="width:100%; height:90px;">${c.prev}</div>
+      </div>
+      <div style="position:relative; background:var(--color-background-primary); border:0.5px solid var(--color-border-tertiary); border-radius:var(--border-radius-md); overflow:hidden;">
+        <button id="copy" aria-label="Copy archie" style="position:absolute; top:6px; right:6px; font-size:12px; padding:3px 8px; cursor:pointer; background:var(--color-background-primary);"><i class="ti ti-copy" aria-hidden="true"></i> Copy</button>
+        <pre style="margin:0; padding:12px; font-family:var(--font-mono); font-size:11.5px; line-height:1.55; color:var(--color-text-primary); white-space:pre-wrap; word-break:break-word;">${esc(c.ex[0].archie)}</pre>
+      </div>
+    </div>
+    <div style="margin-top:14px; font-size:13px; color:var(--color-text-secondary);"><i class="ti ti-link" aria-hidden="true"></i> Seen in <span style="color:var(--color-text-info);">${Math.max(2, Math.round(c.usage / 20))} published articles</span> · deep-link: <span style="font-family:var(--font-mono); font-size:12px;">/admin/components#${c.id}</span></div>
+  `
+                document.getElementById("back").onclick = renderGallery
+                document.getElementById("copy").onclick = () => {
+                    navigator.clipboard &&
+                        navigator.clipboard.writeText(c.ex[0].archie)
+                    const b = document.getElementById("copy")
+                    b.innerHTML = '<i class="ti ti-check"></i> Copied'
+                    setTimeout(
+                        () => (b.innerHTML = '<i class="ti ti-copy"></i> Copy'),
+                        1400
+                    )
+                }
+            }
+
+            document.getElementById("q").addEventListener("input", (e) => {
+                query = e.target.value
+                renderGallery()
+            })
+            renderGallery()
+        </script>
+    </body>
+</html>

--- a/docs/component-reference-admin-plan.md
+++ b/docs/component-reference-admin-plan.md
@@ -1,0 +1,214 @@
+# ArchieML component reference — admin screen handoff brief
+
+> **Status:** planning handoff. This document is the starting point for a Claude Code
+> session to plan and implement an in-admin browsable reference for our ArchieML gdoc
+> components. It captures the goal, a design critique of the prototype, the target UX,
+> and a concrete implementation map grounded in our actual admin conventions. Nothing
+> here is built yet — treat it as a brief, not a spec to follow literally.
+
+## 1. Goal & context
+
+Authors write our articles in Google Docs using ArchieML components. Their three recurring
+pain points are: (1) not knowing **which components exist**, (2) the ArchieML documentation
+(currently a single gdoc) is **hard to navigate**, and (3) not knowing the **canonical
+structure** for the type of content they're writing.
+
+This screen targets pain points 1 and 2 — the **browsing reference** ("what exists / what's
+it called / what does it look like"). It is a read-only, internal admin page that renders the
+component registry we already generate in CI.
+
+We chose the admin (a persistent, linkable URL) over an ephemeral Claude session because:
+it gives a stable URL that error messages, Slack answers, and onboarding docs can deep-link
+into; and the admin is the only place we get **real component renders for free** via the
+existing gdoc rendering pipeline.
+
+A visual prototype of the target UX lives next to this file:
+`docs/component-reference-admin-mockup.html` (open in a browser). It demonstrates the
+gallery → detail flow, the render↔archie pairing, search/filter, usage badges, and
+"when to use / when not". The previews in that file are CSS approximations — see §3,
+recommendation 1, for why the admin version should render real components instead.
+
+## 2. The asset we're building on
+
+Everything is derived from one CI-maintained artifact — no hand-authored content that can rot:
+
+- **Registry JSON:** `docs/components.registry.generated.json` (65 components today).
+- **Generator:** `devTools/gdocs/generate-components-reference.ts`
+  (`yarn generateComponentsReference`). Parses the `OwidEnrichedGdocBlock` union via the
+  TypeScript AST, reads each component's `.md` sidecar
+  (`packages/@ourworldindata/types/src/gdocTypes/archieMLComponents/*.md`), validates every
+  example through `archieToEnriched()`, and emits the JSON.
+- **CI auto-heal:** the `regenerate-components-reference` job in
+  `.github/workflows/format.yml` regenerates the JSON and auto-commits any drift back to the
+  branch (including direct edits on master via the GitHub web editor), so the committed JSON
+  stays current without anyone running the generator locally.
+
+Per-component shape (`ComponentDoc`):
+
+```ts
+type ComponentDoc = {
+    id: string // "chart", "side-by-side"  — the {.id} authors type
+    title: string // "Chart"
+    typeName: string // "EnrichedBlockChart"
+    sourceFile: string
+    sidecarFile: string
+    body: string // markdown: description, When to use / When NOT to use, Variations, notes
+    examples: { name: string; archie: string }[] // can be empty
+}
+```
+
+Note: ~13 of 65 components have **no examples** (e.g. `additional-charts`, `table`, `heading`,
+`simple-text`) — some structurally cannot have a standalone archie example. The UI must handle
+empty `examples` gracefully (see §3).
+
+## 3. Design critique of the prototype
+
+Critique of the gallery + detail prototype, using the standard framework. Stage: early/refinement.
+
+### Overall impression
+
+The gallery-first layout reads immediately as a browsable catalog, and the render↔archie
+pairing with a Copy button is the right atomic unit for authors who ultimately paste ArchieML.
+The biggest opportunity is replacing the faked previews with real renders, which the admin
+uniquely makes cheap.
+
+### Usability
+
+| Finding                                             | Severity    | Recommendation                                                                                                                                                               |
+| --------------------------------------------------- | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Previews are CSS approximations, not real renders   | 🔴 Critical | Render real components via the gdoc pipeline (see priority 1). This is the whole point of "what does it look like".                                                          |
+| Prototype only shows components that have examples  | 🔴 Critical | Show all 65. For empty `examples`, render the sidecar `body` (which still has description + when-to-use) and an explanatory empty state instead of a blank code panel.       |
+| Search only matches title/id/description            | 🟡 Moderate | Also match `typeName` and `body`; add a `⌘K` shortcut to focus search. Mirror the debounced search pattern in `VariablesIndexPage`.                                          |
+| Container components don't reveal what nests inside | 🟡 Moderate | For `side-by-side`, `sticky-left/right`, `key-insights`, `chart-story`, show an "accepts" line listing valid children, linking to their detail. Bridges toward pain point 3. |
+| Detail shows only the first example                 | 🟢 Minor    | Tab or stack all named examples, each with its own Copy.                                                                                                                     |
+
+### Visual hierarchy
+
+- **What draws the eye first:** the preview thumbnail, then the title — correct for visual scanning.
+- **Reading flow:** category filter → grid → card → detail is a natural drill-down.
+- Keep the monospace `{.id}` prominent on each card — it is effectively the component's "API name" and the string authors type.
+
+### Consistency
+
+- The prototype uses Tabler icons, custom pills, and a bespoke input. The admin uses
+  **antd + Bootstrap**, **FontAwesome** icons, the **`AdminLayout`** wrapper, and the shared
+  **`SearchField`** (`adminSiteClient/Forms.js`). The real screen must adopt these — do not port
+  the prototype's styling verbatim.
+- Use BEM in a companion `.scss` (see §4) rather than the prototype's inline styles.
+
+### Accessibility
+
+- Severity/when-to-use uses color **plus** icon + label — good; keep text labels, never color alone.
+- Ensure visible focus rings on cards and that cards are keyboard-activable (the prototype's
+  `tabindex`/Enter handling is the right idea).
+- Check contrast on the tertiary monospace text against the card background.
+
+### What works well
+
+- Gallery-first discovery; the render↔archie split; Copy as the primary CTA.
+- Usage badges and "seen in N articles" answer "is this blessed or a dead end?".
+- Deep-linkable `#component-id` anchors so other surfaces can link in.
+
+### Priority recommendations
+
+1. **Render real components, not approximations.** `archieToEnriched()`
+   (`db/model/Gdoc/archieToEnriched.ts`) + the `ArticleBlock` renderer
+   (`site/gdocs/components/ArticleBlock.tsx`) already exist. Parse each example's archie to an
+   enriched block and render it. Decide where parsing runs (see §5 — `archieToEnriched` sits in
+   `db/` and may pull server-only deps; a small admin endpoint that returns enriched JSON is the
+   safe path). This single change delivers most of the "what does it look like" value.
+2. **Cover all 65 components, including example-less ones**, and render the **full sidecar
+   `body` markdown** in the detail view (it carries When-NOT-to-use, Variations, and notes the
+   prototype omits).
+3. **Adopt the admin design system** (antd/`SearchField`/`AdminLayout`/FontAwesome) and add a
+   persistent category sidebar + `⌘K` focus for navigation at 65+ items.
+
+## 4. Implementation map (admin conventions)
+
+Mirror `adminSiteClient/ChartIndexPage.tsx` (simple) and `VariablesIndexPage.tsx` (search/filter).
+
+| Purpose                  | Path                                                                                                  | New? |
+| ------------------------ | ----------------------------------------------------------------------------------------------------- | ---- |
+| Page component           | `adminSiteClient/ComponentsIndexPage.tsx`                                                             | new  |
+| Page styles (BEM)        | `adminSiteClient/ComponentsIndexPage.scss`                                                            | new  |
+| Style import             | `adminSiteClient/admin.scss` (`@import "./ComponentsIndexPage.scss";`)                                | edit |
+| Route                    | `adminSiteClient/AdminApp.tsx` (`<Route exact path="/components" component={ComponentsIndexPage} />`) | edit |
+| Sidebar link             | `adminSiteClient/AdminSidebar.tsx` (FontAwesome icon + `<Link to="/components">`)                     | edit |
+| API endpoint (if chosen) | `adminSiteServer/apiRoutes/components.ts`                                                             | new  |
+| API registration         | `adminSiteServer/apiRouter.ts`                                                                        | edit |
+
+Page skeleton (MobX class component, our nonstandard `makeObservable` setup per CLAUDE.md):
+
+```tsx
+@observer
+export class ComponentsIndexPage extends Component {
+    static override contextType = AdminAppContext
+    declare context: AdminAppContextType
+    components: ComponentDoc[] = []
+    searchInput: string = ""
+
+    constructor(props: Record<string, never>) {
+        super(props)
+        makeObservable(this, {
+            components: observable,
+            searchInput: observable,
+        })
+    }
+    // getData() via this.context.admin.getJSON(...), AdminLayout wrapper, etc.
+}
+```
+
+SCSS blocks (full BEM class names, no `&__` concatenation per CLAUDE.md):
+
+```scss
+.components-index-page {
+}
+.components-index-page__gallery {
+}
+.components-index-page__card {
+}
+.components-index-page__card-preview {
+}
+.components-index-page__detail {
+}
+```
+
+## 5. Key decisions to resolve during planning
+
+1. **How the client gets the registry.** Options:
+    - **(a) Direct JSON import** — `import registry from "../docs/components.registry.generated.json"`.
+      Simplest; bundles into the admin build. Check tsconfig `resolveJsonModule` and bundle-size impact.
+    - **(b) Admin API endpoint** — `GET /api/components.json` reads the file server-side. Consistent
+      with how other admin data loads; required anyway if the endpoint also returns enriched/rendered
+      output (see below). **Likely preferred.**
+2. **Where archie→enriched parsing runs.** `archieToEnriched` lives in `db/` and may depend on
+   server-only modules. Safer to parse server-side in the `/api/components.json` endpoint and return
+   enriched blocks alongside each example, so the client only needs `ArticleBlock` to render.
+   Verify `ArticleBlock`'s required context/attachments (see `docs/agent-guidelines/gdocs-attachments.md`)
+   — examples that reference charts/images may need stubbed or fetched attachments. Charts can fall
+   back to existing thumbnail CF functions if live embeds are too heavy for a gallery.
+3. **Usage data (optional, high value).** A datasette/SQL pass over `posts_gdocs` content can produce
+   per-component usage counts and example article URLs for the badges and "seen in" links. Decide
+   whether to include in v1 or defer.
+4. **Scope of v1.** Recommend: all 65 components, real renders where attachments allow (thumbnail
+   fallback otherwise), full sidecar body, search + category filter, Copy archie, deep-link anchors.
+   Defer: usage badges, container "accepts"/anatomy view, `⌘K` palette.
+
+## 6. Suggested phasing
+
+1. **Data path:** add `/api/components.json` (registry + optionally enriched examples); wire route,
+   page shell, sidebar link. Render the raw gallery from titles/descriptions.
+2. **Detail view:** full sidebar `body` markdown, examples with Copy, deep-link anchors, empty states.
+3. **Real renders:** integrate `ArticleBlock` for examples; resolve attachment/context needs; thumbnail
+   fallback for chart-bearing components.
+4. **Navigation polish:** category sidebar, debounced search across title/id/typeName/body, `⌘K`.
+5. **Enhancements (optional):** usage badges from `posts_gdocs`, container "accepts" links.
+
+## 7. Verification
+
+- `yarn typecheck`, `yarn testLintChanged`, `yarn testFormatChanged`.
+- Confirm all 65 components list and that example-less components render without a broken panel.
+- Spot-check a container (`side-by-side`), a chart component (`chart`), and a media component
+  (`image`) render or fall back correctly.
+- Confirm Copy yields valid archie (round-trip through `archieToEnriched` without error — the
+  generator already validates this, so committed examples should pass).

--- a/package.json
+++ b/package.json
@@ -145,6 +145,7 @@
         "react-dom": "^19.2.4",
         "react-horizontal-scrolling-menu": "^8.2.0",
         "react-instantsearch": "^7.35.0",
+        "react-markdown": "^10.1.0",
         "react-router": "^5.3.4",
         "react-router-dom": "^5.3.4",
         "react-router-dom-v5-compat": "^6.30.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8965,6 +8965,7 @@ __metadata:
     react-dom: "npm:^19.2.4"
     react-horizontal-scrolling-menu: "npm:^8.2.0"
     react-instantsearch: "npm:^7.35.0"
+    react-markdown: "npm:^10.1.0"
     react-router: "npm:^5.3.4"
     react-router-dom: "npm:^5.3.4"
     react-router-dom-v5-compat: "npm:^6.30.0"


### PR DESCRIPTION
## Context

Second PR of the **claude-cms** stack (on #6543, under #6544). Surfaces the
generated component registry inside the admin so editors have a live,
searchable reference to the ArchieML blocks they can use — the in-app
replacement for the "Writing OWID Articles" Google Doc.

## What you can observe

- A new **Components** entry in the admin sidebar, opening a `/components`
  gallery page.
- Each block is listed with its description, *When to use / When NOT to use*,
  variations, and its examples as **copyable ArchieML** code blocks.
- Free-text search filters across names and descriptions.
- Each entry links out to its sidecar `.md` and its type definition on GitHub,
  so fixing the docs is one click away.

## Architecture

- The page fetches `GET /admin/api/components.json`, which serves the committed
  `docs/components.registry.generated.json` from #6543 verbatim — **no database
  access, no server-side rendering of docs**. The registry is the contract
  between the generator and the UI.
- Pure client-side React (admin MobX conventions); no schema or data changes.

## Testing guidance

- Open the admin, click **Components** in the sidebar.
- Search for a block, expand it, copy an example, confirm the GitHub edit links
  resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
