### PR TITLE
✨🤖 (time-interval) interval-aware uniform spacing for stacked bar charts

### DIFF
--- a/packages/@ourworldindata/core-table/src/CoreTableColumns.test.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTableColumns.test.ts
@@ -1,6 +1,7 @@
 import { expect, it, describe } from "vitest"
 
 import { ColumnTypeNames } from "@ourworldindata/types"
+import { convertDateToDaysSinceEpoch, dayjs } from "@ourworldindata/utils"
 import { ColumnTypeMap } from "./CoreTableColumns.js"
 import { OwidTable } from "./OwidTable.js"
 
@@ -84,6 +85,120 @@ describe(ColumnTypeNames.Week, () => {
         expect(col.formatValue(-22)).toEqual("W1 2020")
         // day -20 = 2020-01-01 falls into the same week starting in 2019
         expect(col.formatValue(-20)).toEqual("W1 2020")
+    })
+})
+
+describe("getUniformlySpacedTimes", () => {
+    const table = new OwidTable()
+
+    const day = (iso: string): number =>
+        convertDateToDaysSinceEpoch(dayjs.utc(iso))
+
+    it("fills missing years for year columns", () => {
+        const col = new ColumnTypeMap.Year(table, { slug: "t" })
+        // GCD of the gaps is 1 (from 2000→2001), so the missing 2002 is filled
+        expect(col.getUniformlySpacedTimes([2000, 2001, 2003])).toEqual([
+            2000, 2001, 2002, 2003,
+        ])
+    })
+
+    it("respects a regular multi-year cadence (e.g. every 5 years)", () => {
+        const col = new ColumnTypeMap.Year(table, { slug: "t" })
+        // GCD of the gaps is 5
+        expect(col.getUniformlySpacedTimes([2000, 2005, 2010, 2025])).toEqual([
+            2000, 2005, 2010, 2015, 2020, 2025,
+        ])
+    })
+
+    it("fills missing days for day columns", () => {
+        const col = new ColumnTypeMap.Day(table, { slug: "t" })
+        expect(col.getUniformlySpacedTimes([0, 1, 3])).toEqual([0, 1, 2, 3])
+    })
+
+    it("fills one filler per missing week for week columns", () => {
+        const col = new ColumnTypeMap.Week(table, { slug: "t" })
+        // weeks are 7 days apart; a gap of 14 means one missing week
+        expect(col.getUniformlySpacedTimes([0, 7, 21])).toEqual([0, 7, 14, 21])
+    })
+
+    it("snaps observed days to the first of their month", () => {
+        const col = new ColumnTypeMap.Month(table, { slug: "t" })
+        expect(
+            col.getUniformlySpacedTimes([day("2021-01-31"), day("2021-02-28")])
+        ).toEqual([day("2021-01-01"), day("2021-02-01")])
+    })
+
+    it("fills one filler per missing month", () => {
+        const col = new ColumnTypeMap.Month(table, { slug: "t" })
+        // Jan and Feb present, March missing before April
+        const result = col.getUniformlySpacedTimes([
+            day("2021-01-01"),
+            day("2021-02-01"),
+            day("2021-04-01"),
+        ])
+        expect(result).toEqual([
+            day("2021-01-01"),
+            day("2021-02-01"),
+            day("2021-03-01"), // filler
+            day("2021-04-01"),
+        ])
+    })
+
+    it("respects a regular cadence (e.g. two points per year) without inserting fillers", () => {
+        const col = new ColumnTypeMap.Month(table, { slug: "t" })
+        // Two data points per year, 6 months apart
+        const input = [
+            day("2021-01-01"),
+            day("2021-07-01"),
+            day("2022-01-01"),
+            day("2022-07-01"),
+        ]
+        expect(col.getUniformlySpacedTimes(input)).toEqual(input)
+    })
+
+    it("handles months before the epoch date and across the epoch boundary", () => {
+        const col = new ColumnTypeMap.Month(table, { slug: "t" })
+        // EPOCH_DATE is 2020-01-21. Nov 2019, Dec 2019, Feb 2020 (Jan 2020
+        // missing) — all around/before the epoch, so month numbers go negative.
+        const result = col.getUniformlySpacedTimes([
+            day("2019-11-01"),
+            day("2019-12-01"),
+            day("2020-02-01"),
+        ])
+        expect(result).toEqual([
+            day("2019-11-01"),
+            day("2019-12-01"),
+            day("2020-01-01"), // filler
+            day("2020-02-01"),
+        ])
+    })
+
+    it("fills one filler per missing quarter", () => {
+        const col = new ColumnTypeMap.Quarter(table, { slug: "t" })
+        // Q1, Q2 and Q4 of 2021 present; Q3 missing
+        const result = col.getUniformlySpacedTimes([
+            day("2021-01-01"), // Q1
+            day("2021-04-01"), // Q2
+            day("2021-10-01"), // Q4
+        ])
+        expect(result).toEqual([
+            day("2021-01-01"), // Q1
+            day("2021-04-01"), // Q2
+            day("2021-07-01"), // Q3 filler
+            day("2021-10-01"), // Q4
+        ])
+    })
+
+    it("respects a regular quarterly cadence (e.g. semiannual) without inserting fillers", () => {
+        const col = new ColumnTypeMap.Quarter(table, { slug: "t" })
+        // Two data points per year, two quarters (6 months) apart
+        const input = [
+            day("2021-01-01"),
+            day("2021-07-01"),
+            day("2022-01-01"),
+            day("2022-07-01"),
+        ]
+        expect(col.getUniformlySpacedTimes(input)).toEqual(input)
     })
 })
 

--- a/packages/@ourworldindata/core-table/src/CoreTableColumns.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTableColumns.ts
@@ -6,6 +6,8 @@ import {
     formatDay,
     convertDaysSinceEpochToDate,
     convertDateToDaysSinceEpoch,
+    EPOCH_DATE,
+    withUniformSpacing,
     sortNumeric,
     omitUndefinedValues,
     isPresent,
@@ -928,6 +930,15 @@ export abstract class TimeColumn<
     override parse(val: unknown): number | ErrorValue {
         return parseInt(String(val))
     }
+
+    /**
+     * Given the sorted, de-duplicated times present in the data, returns them
+     * with gaps filled so that positions are uniformly spaced (one filler per
+     * missing step)
+     */
+    getUniformlySpacedTimes(sortedTimes: number[]): number[] {
+        return withUniformSpacing(sortedTimes)
+    }
 }
 
 class YearColumn<
@@ -1037,6 +1048,39 @@ class MonthColumn<
     override formatForCsv(value: number): string {
         return memoFormatMonthCsv(value) // "2023-01"
     }
+
+    // The first of the epoch's month, used as the anchor for counting months.
+    private static readonly epochMonthStart = dayjs
+        .utc(EPOCH_DATE)
+        .startOf("month")
+
+    // Whole calendar months between the given day's month and the epoch's month.
+    private static monthsSinceEpoch(daysSinceEpoch: number): number {
+        return convertDaysSinceEpochToDate(daysSinceEpoch)
+            .startOf("month")
+            .diff(MonthColumn.epochMonthStart, "month")
+    }
+
+    // Inverse of monthsSinceEpoch: days-since-epoch for the first of that month.
+    private static daysAtStartOfMonth(monthsSinceEpoch: number): number {
+        const firstOfMonth = MonthColumn.epochMonthStart.add(
+            monthsSinceEpoch,
+            "month"
+        )
+        return convertDateToDaysSinceEpoch(firstOfMonth)
+    }
+
+    // Fill gaps one month at a time. We space in month-space (not the raw
+    // days-since-epoch of the base class) because months are 28–31 days apart,
+    // which would make the base GCD collapse to a daily grid. This also lets the
+    // GCD respect the cadence, so e.g. bi-monthly data isn't force-filled.
+    override getUniformlySpacedTimes(sortedTimes: number[]): number[] {
+        const months = new Set(
+            _.uniq(sortedTimes).map(MonthColumn.monthsSinceEpoch)
+        )
+        const spacedMonths = withUniformSpacing([...months])
+        return spacedMonths.map(MonthColumn.daysAtStartOfMonth)
+    }
 }
 
 // A sub-yearly week column, storing days-since-epoch
@@ -1080,6 +1124,39 @@ class QuarterColumn<
 
     override formatForCsv(value: number): string {
         return memoFormatQuarterCsv(value) // "2023-Q1"
+    }
+
+    // The first of the epoch's quarter, used as the anchor for counting quarters.
+    private static readonly epochQuarterStart = dayjs
+        .utc(EPOCH_DATE)
+        .startOf("quarter")
+
+    // Whole calendar quarters between the given day's quarter and the epoch's.
+    private static quartersSinceEpoch(daysSinceEpoch: number): number {
+        return convertDaysSinceEpochToDate(daysSinceEpoch)
+            .startOf("quarter")
+            .diff(QuarterColumn.epochQuarterStart, "quarter")
+    }
+
+    // Inverse of quartersSinceEpoch: days-since-epoch for the first of that quarter.
+    private static daysAtStartOfQuarter(quartersSinceEpoch: number): number {
+        const firstOfQuarter = QuarterColumn.epochQuarterStart.add(
+            quartersSinceEpoch,
+            "quarter"
+        )
+        return convertDateToDaysSinceEpoch(firstOfQuarter)
+    }
+
+    // Fill gaps one quarter at a time. We space in quarter-space (not the raw
+    // days-since-epoch of the base class) because quarters are 90–92 days apart,
+    // which would make the base GCD collapse to a daily grid. This also lets the
+    // GCD respect the cadence, so e.g. semiannual data isn't force-filled.
+    override getUniformlySpacedTimes(sortedTimes: number[]): number[] {
+        const quarters = new Set(
+            _.uniq(sortedTimes).map(QuarterColumn.quartersSinceEpoch)
+        )
+        const spacedQuarters = withUniformSpacing([...quarters])
+        return spacedQuarters.map(QuarterColumn.daysAtStartOfQuarter)
     }
 }
 

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChartState.ts
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChartState.ts
@@ -3,7 +3,7 @@ import { computed, makeObservable } from "mobx"
 import { AbstractStackedChartState } from "./AbstractStackedChartState.js"
 import { ChartState } from "../chart/ChartInterface.js"
 import { StackedSeries } from "./StackedConstants.js"
-import { ColumnTypeMap } from "@ourworldindata/core-table"
+import { TimeColumn } from "@ourworldindata/core-table"
 import {
     stackSeriesInBothDirections,
     withMissingValuesAsZeroes,
@@ -12,8 +12,16 @@ import { ColorScaleManager } from "../color/ColorScale.js"
 import {
     ColorScaleConfigInterface,
     ColorSchemeName,
+    ColumnTypeNames,
 } from "@ourworldindata/types"
 import { ChartManager } from "../chart/ChartManager.js"
+
+// Whether daily data should get uniform spacing (one filler per missing day).
+// Disabled during the transition to explicit time intervals: some monthly and
+// quarterly indicators are currently still marked as daily, and their 28–92-day
+// gaps collapse the GCD to a daily grid, flooding the chart with fillers.
+// Flip to `true` once those indicators carry their proper timeInterval.
+const ENABLE_DAILY_UNIFORM_SPACING = false
 
 export class StackedBarChartState
     extends AbstractStackedChartState
@@ -30,14 +38,26 @@ export class StackedBarChartState
 
     @computed
     get unstackedSeriesWithMissingValuesAsZeroes(): StackedSeries<number>[] {
-        // TODO: remove once monthly data is supported (https://github.com/owid/owid-grapher/issues/2007)
-        const enforceUniformSpacing = !(
-            this.transformedTable.timeColumn instanceof ColumnTypeMap.Day
-        )
+        // Fill gaps with zeroes so bars are evenly spaced. Each time column
+        // knows how to space its own encoding. Daily data is skipped for
+        // now — see ENABLE_DAILY_UNIFORM_SPACING.
+        const { timeColumn } = this.transformedTable
+        const columnType = timeColumn.def.type
+        const isDayEncoded =
+            columnType === ColumnTypeNames.Day ||
+            columnType === ColumnTypeNames.Date
 
-        return withMissingValuesAsZeroes(this.unstackedSeries, {
-            enforceUniformSpacing,
-        })
+        if (
+            timeColumn instanceof TimeColumn &&
+            (ENABLE_DAILY_UNIFORM_SPACING || !isDayEncoded)
+        ) {
+            return withMissingValuesAsZeroes(this.unstackedSeries, {
+                enforceUniformSpacing: true,
+                timeColumn,
+            })
+        }
+
+        return withMissingValuesAsZeroes(this.unstackedSeries)
     }
 
     @computed get series(): readonly StackedSeries<number>[] {

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedUtils.test.ts
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedUtils.test.ts
@@ -1,10 +1,10 @@
 import { expect, it, describe } from "vitest"
 
+import { ColumnTypeMap, OwidTable } from "@ourworldindata/core-table"
 import {
     stackSeries,
     stackSeriesInBothDirections,
     withMissingValuesAsZeroes,
-    withUniformSpacing,
 } from "./StackedUtils"
 
 const seriesArr = [
@@ -61,20 +61,6 @@ const seriesArrWithNegativeValues = [
     },
 ]
 
-describe(withUniformSpacing, () => {
-    it("can add values to make an array evenly spaced", () => {
-        expect(withUniformSpacing([])).toEqual([])
-        expect(withUniformSpacing([5])).toEqual([5])
-        expect(withUniformSpacing([5, 10])).toEqual([5, 10])
-        expect(withUniformSpacing([5, 10, 15])).toEqual([5, 10, 15])
-        expect(withUniformSpacing([2, 4, 8])).toEqual([2, 4, 6, 8])
-        expect(withUniformSpacing([1, 2, 4, 8])).toEqual([
-            1, 2, 3, 4, 5, 6, 7, 8,
-        ])
-        expect(withUniformSpacing([7, 12, 17])).toEqual([7, 12, 17])
-    })
-})
-
 describe(withMissingValuesAsZeroes, () => {
     it("can add fake points", () => {
         expect(seriesArr[1].points[1]).toEqual(undefined)
@@ -86,8 +72,12 @@ describe(withMissingValuesAsZeroes, () => {
         expect(seriesArr[1].points[1]).toEqual(undefined)
         expect(seriesArr[1].points[2]).toEqual(undefined)
         expect(seriesArr[1].points[3]).toEqual(undefined)
+        const timeColumn = new ColumnTypeMap.Year(new OwidTable(), {
+            slug: "year",
+        })
         const series = withMissingValuesAsZeroes(seriesArr, {
             enforceUniformSpacing: true,
+            timeColumn,
         })
         expect(series[1].points[1].position).toEqual(2001)
         expect(series[1].points[2].position).toEqual(2002)

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedUtils.ts
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedUtils.ts
@@ -3,8 +3,6 @@ import * as _ from "lodash-es"
 import {
     sortNumeric,
     isArrayOfNumbers,
-    findGreatestCommonDivisorOfArray,
-    rollingMap,
     omitUndefinedValues,
     AxisConfigInterface,
     lastOfNonEmptyArray,
@@ -19,6 +17,7 @@ import {
 } from "./StackedConstants"
 import { DualAxis } from "../axis/Axis"
 import { Time } from "@ourworldindata/types"
+import { TimeColumn } from "@ourworldindata/core-table"
 import { StackedBarChartState } from "./StackedBarChartState.js"
 
 // This method shift up the Y Values of a Series with Points in place.
@@ -61,20 +60,19 @@ export const stackSeriesInBothDirections = <
     return seriesArr
 }
 
-// Makes sure that values are evenly spaced
-export function withUniformSpacing(values: number[]): number[] {
-    const deltas = rollingMap(values, (a, b) => b - a)
-    const gcd = findGreatestCommonDivisorOfArray(deltas)
-    if (gcd === null) return values
-    return _.range(values[0], values[values.length - 1] + gcd, gcd)
-}
+// When enforcing uniform spacing, a `timeColumn` is required: its
+// `getUniformlySpacedTimes` fills gaps so positions are evenly spaced (e.g. one
+// position per missing month).
+type WithMissingValuesAsZeroesOptions =
+    | { enforceUniformSpacing: true; timeColumn: TimeColumn }
+    | { enforceUniformSpacing?: false }
 
 // Adds a Y = 0 value for each missing x value (where X is usually Time)
 export const withMissingValuesAsZeroes = <
     PositionType extends StackedPointPositionType,
 >(
     seriesArr: readonly StackedSeries<PositionType>[],
-    { enforceUniformSpacing = false }: { enforceUniformSpacing?: boolean } = {}
+    options: WithMissingValuesAsZeroesOptions = {}
 ): StackedSeries<PositionType>[] => {
     let allXValuesSorted = sortNumeric(
         _.uniq(
@@ -84,8 +82,8 @@ export const withMissingValuesAsZeroes = <
         )
     )
 
-    if (enforceUniformSpacing && isArrayOfNumbers(allXValuesSorted)) {
-        allXValuesSorted = withUniformSpacing(
+    if (options.enforceUniformSpacing && isArrayOfNumbers(allXValuesSorted)) {
+        allXValuesSorted = options.timeColumn.getUniformlySpacedTimes(
             allXValuesSorted
         ) as PositionType[]
     }

--- a/packages/@ourworldindata/utils/src/Util.test.ts
+++ b/packages/@ourworldindata/utils/src/Util.test.ts
@@ -26,6 +26,7 @@ import {
     slugify,
     greatestCommonDivisor,
     findGreatestCommonDivisorOfArray,
+    withUniformSpacing,
     traverseEnrichedBlock,
     cartesian,
     formatInlineList,
@@ -683,6 +684,19 @@ describe(convertDateToDaysSinceEpoch, () => {
     })
 })
 
+describe(withUniformSpacing, () => {
+    it("can add values to make an array evenly spaced", () => {
+        expect(withUniformSpacing([])).toEqual([])
+        expect(withUniformSpacing([5])).toEqual([5])
+        expect(withUniformSpacing([5, 10])).toEqual([5, 10])
+        expect(withUniformSpacing([5, 10, 15])).toEqual([5, 10, 15])
+        expect(withUniformSpacing([2, 4, 8])).toEqual([2, 4, 6, 8])
+        expect(withUniformSpacing([1, 2, 4, 8])).toEqual([
+            1, 2, 3, 4, 5, 6, 7, 8,
+        ])
+        expect(withUniformSpacing([7, 12, 17])).toEqual([7, 12, 17])
+    })
+})
 describe(snapToIntervalStart, () => {
     const day = (iso: string): number =>
         diffDatesInDays(dayjs.utc(iso), epochDate())

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -2048,6 +2048,15 @@ export function findGreatestCommonDivisorOfArray(arr: number[]): number | null {
     return _.uniq(arr).reduce((acc, num) => greatestCommonDivisor(acc, num))
 }
 
+// Makes sure that values are evenly spaced by inserting values at the greatest
+// common divisor of the gaps between consecutive values.
+export function withUniformSpacing(values: number[]): number[] {
+    const deltas = rollingMap(values, (a, b) => b - a)
+    const gcd = findGreatestCommonDivisorOfArray(deltas)
+    if (gcd === null) return values
+    return _.range(values[0], values[values.length - 1] + gcd, gcd)
+}
+
 export function lowercaseObjectKeys(
     obj: Record<string, unknown>
 ): Record<string, unknown> {

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -102,6 +102,7 @@ export {
     isArrayOfNumbers,
     greatestCommonDivisor,
     findGreatestCommonDivisorOfArray,
+    withUniformSpacing,
     type NodeWithUrl,
     traverseEnrichedSpan,
     copyToClipboard,


### PR DESCRIPTION
Stacked bar charts ensure that bars are uniformly spaced by filling in missing time points. For example, if the data contains 2010, 2011, and 2013, then 2012 is inserted automatically.

This behavior had previously been disabled for daily data because weekly and monthly indicators were incorrectly tagged as daily. Enforcing uniform spacing in those cases resulted in many empty slots being inserted between real data points.

This PR extends the same behavior to the new sub-yearly intervals. It remains disabled for daily data for now, since during the transition there are still some indicators incorrectly marked as daily. Once the migration is complete, we can remove the flag.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 6 in a stack** made with GitButler:
- <kbd>&nbsp;6&nbsp;</kbd> #6752 
- <kbd>&nbsp;5&nbsp;</kbd> #6843 
- <kbd>&nbsp;4&nbsp;</kbd> #6823 
- <kbd>&nbsp;3&nbsp;</kbd> #6733 
- <kbd>&nbsp;2&nbsp;</kbd> #6696 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #6700 
<!-- GitButler Footer Boundary Bottom -->