### PR TITLE
✨ Show net migration rate as % instead of ‰

### DIFF
--- a/bespoke/projects/demography/src/components/DemographyParameterEditor.tsx
+++ b/bespoke/projects/demography/src/components/DemographyParameterEditor.tsx
@@ -384,6 +384,7 @@ function DemographyParameterEditorContent({
                         minValue={minValue}
                         yScale={yScale}
                         axisUnit={config.axisUnit}
+                        displayScale={config.displayScale}
                         fontSize={fonts.yTick}
                     />
 
@@ -651,9 +652,18 @@ function DemographyParameterEditorContent({
                         <ControlPointEditor
                             value={controlPoints[editing.year]}
                             step={config.step}
-                            decimals={config.decimals}
+                            decimals={config.displayDecimals ?? config.decimals}
                             min={config.inputMin ?? yScale.domain()[0]}
                             max={config.inputMax ?? yScale.domain()[1]}
+                            displayScale={config.displayScale}
+                            // Pass the unit only for scaled params (e.g. ‰→%) so
+                            // the editor renders it (natively, for "%"); unscaled
+                            // params keep a bare number.
+                            unit={
+                                config.displayScale
+                                    ? config.axisUnit
+                                    : undefined
+                            }
                             modified={isModified}
                             onCommit={(value) =>
                                 handleChange({
@@ -878,6 +888,8 @@ function ControlPointEditor({
     decimals,
     min,
     max,
+    displayScale = 1,
+    unit,
     modified,
     onCommit,
     onClose,
@@ -887,6 +899,9 @@ function ControlPointEditor({
     decimals: number
     min: number
     max: number
+    // Factor to scale the internal value by for display; onCommit converts back.
+    displayScale?: number
+    unit?: string
     modified: boolean
     onCommit: (value: number) => void
     onClose: () => void
@@ -901,6 +916,31 @@ function ControlPointEditor({
         onInteractOutside: onClose,
     })
 
+    // Convert between the stored value and the value react-aria displays.
+    // For "%", Intl's "percent" style renders value×100 with a "%" suffix, so
+    // the display value is a fraction; otherwise it's the scaled value shown as
+    // a plain decimal. The transform is linear through the origin, so it applies
+    // to min/max/step too. clean() strips floating-point noise (e.g. 0.1×0.1 =
+    // 0.010000000000000002) that would otherwise corrupt react-aria's stepper,
+    // which counts a step's decimal places via step.toString().
+    const isPercent = unit === "%"
+    const clean = (n: number): number => Number(n.toPrecision(12))
+    const toDisplay = (v: number): number =>
+        clean(isPercent ? (v * displayScale) / 100 : v * displayScale)
+    const fromDisplay = (v: number): number =>
+        clean(isPercent ? (v * 100) / displayScale : v / displayScale)
+    const formatOptions: Intl.NumberFormatOptions = isPercent
+        ? {
+              style: "percent",
+              minimumFractionDigits: decimals,
+              maximumFractionDigits: decimals,
+          }
+        : {
+              minimumFractionDigits: decimals,
+              maximumFractionDigits: decimals,
+              useGrouping: false,
+          }
+
     return (
         <div
             ref={containerRef}
@@ -910,16 +950,12 @@ function ControlPointEditor({
             }
         >
             <NumberField
-                value={value}
-                onChange={onCommit}
-                minValue={min}
-                maxValue={max}
-                step={step}
-                formatOptions={{
-                    minimumFractionDigits: decimals,
-                    maximumFractionDigits: decimals,
-                    useGrouping: false,
-                }}
+                value={toDisplay(value)}
+                onChange={(v) => onCommit(fromDisplay(v))}
+                minValue={toDisplay(min)}
+                maxValue={toDisplay(max)}
+                step={toDisplay(step)}
+                formatOptions={formatOptions}
                 autoFocus
                 aria-label="Value"
                 onKeyDown={(e) => {
@@ -1143,6 +1179,7 @@ function YAxisGridLines({
     minValue,
     yScale,
     axisUnit,
+    displayScale = 1,
     fontSize,
 }: {
     maxGridLines: number | undefined
@@ -1151,6 +1188,7 @@ function YAxisGridLines({
     minValue: number
     yScale: ReturnType<typeof scaleLinear<number>>
     axisUnit: string
+    displayScale?: number
     fontSize: number
 }) {
     const defaultCount = innerHeight < 80 ? 2 : 3
@@ -1179,9 +1217,9 @@ function YAxisGridLines({
                             fontSize={fontSize}
                             fill={GRID_LABEL_COLOR}
                         >
-                            {Math.round(tick * 10) / 10}
-                            {axisUnit === "‰"
-                                ? "‰"
+                            {Math.round(tick * displayScale * 100) / 100}
+                            {axisUnit === "%"
+                                ? "%"
                                 : tick === topTick
                                   ? ` ${axisUnit}`
                                   : ""}

--- a/bespoke/projects/demography/src/helpers/parameterConfigs.ts
+++ b/bespoke/projects/demography/src/helpers/parameterConfigs.ts
@@ -28,7 +28,17 @@ interface ParameterConfig {
     inputMin?: number
     inputMax?: number
     step: number
+    // Precision of the stored (internal-unit) value; used for URL serialization
+    // and modified-vs-baseline comparison, so it must match the stored scale.
     decimals: number
+    // Factor to multiply the internal (stored) value by for display only. The
+    // data and model stay in the internal unit; this only scales what the user
+    // sees (axis ticks, value editor). Defaults to 1 when omitted.
+    displayScale?: number
+    // Decimal places to show in the value editor, in display units. Defaults to
+    // `decimals` when omitted. When displayScale shifts the decimal point (e.g.
+    // ‰→%, /10), this is `decimals + 1` to keep the same effective granularity.
+    displayDecimals?: number
     subtitle: (entityName: string) => string
     tooltipContent: string
     formatValue: (value: number) => string
@@ -179,29 +189,32 @@ export const parameterConfigByKey: Record<ParameterKey, ParameterConfig> = {
         shortTitle: "Migration",
         extraShortTitle: "Migration",
         title: "Net migration rate",
-        unit: "per 1,000 population",
-        axisUnit: "‰",
+        unit: "% of population",
+        axisUnit: "%",
         yPadding: 5,
         inputMin: -20,
         inputMax: 20,
         step: 0.1,
         decimals: 1,
+        // Stored per 1,000 population; displayed as a percentage (divide by 10).
+        displayScale: 0.1,
+        displayDecimals: 2,
         subtitle: (entityName: string) => {
             if (entityName === "World") return "Not applicable."
             const region = getRegionByName(entityName)
             if (region?.regionType === "aggregate")
-                return "Difference between people entering and leaving the continent, per 1,000 population."
-            return "Difference between people entering and leaving the country, per 1,000 population."
+                return "Difference between people entering and leaving the continent, as a percentage of the population."
+            return "Difference between people entering and leaving the country, as a percentage of the population."
         },
         tooltipContent:
-            "Net migration is the difference in immigration (people entering the country) and emigration (people leaving). This number is positive if more people are entering than leaving. This difference is given per 1,000 population.",
+            "Net migration is the difference in immigration (people entering the country) and emigration (people leaving). This number is positive if more people are entering than leaving. This difference is shown as a percentage of the population.",
         formatValue: (v) =>
-            formatValue(v, {
-                numDecimalPlaces: 1,
+            formatValue(v / 10, {
+                numDecimalPlaces: 2,
                 numberAbbreviation: false,
                 showPlus: true,
                 trailingZeroes: true,
-            }) + "‰",
+            }) + "%",
         computeHistorical: (simulation) => {
             const points = R.pipe(
                 HISTORICAL_TIME_RANGE,


### PR DESCRIPTION
Per mille (‰) isn't widely understood, so the demography (population) tool now displays the net migration rate as a percentage.

This is a display-only change — the stored data and the simulation model stay in per-1,000 units, and values are converted (divide by 10) only at the display boundaries:

- `parameterConfigs.ts`: `netMigrationRate` now uses `axisUnit: "%"`, a `formatValue` that does `v / 10 + "%"`, 2 decimals, and reworded subtitle/tooltip copy. Adds an optional `displayScale` config field (defaults to 1, so other parameters are unchanged).
- `DemographyParameterEditor.tsx`: the y-axis ticks and the editable value box (a react-aria `NumberField`, which can't use `formatValue`) scale by `displayScale` and show `%`; the editor converts back to per-1,000 on commit.
- `styles.scss`: `%` unit adornment in the value editor.

## Verification

- `yarn typecheck` passes.
- Demography unit tests pass (133) — the per-1,000 model math is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)