### PR TITLE
✨ Order the bespoke entity dropdown by user location

### DIFF
--- a/bespoke/components/EntityDropdown/EntityDropdown.tsx
+++ b/bespoke/components/EntityDropdown/EntityDropdown.tsx
@@ -1,7 +1,10 @@
 import { ComponentProps, useMemo } from "react"
 
-import { BasicDropdownOption, Dropdown } from "@ourworldindata/grapher"
+import { faLocationArrow } from "@fortawesome/free-solid-svg-icons"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import { BasicDropdownOption, Dropdown, GRAY_60 } from "@ourworldindata/grapher"
 import { getRegionByCode, UserCountryInformation } from "@ourworldindata/utils"
+import * as R from "remeda"
 
 import { useUserCountryInformation } from "../../hooks/useUserCountryInformation.js"
 import { InlineLabeledDropdown } from "../InlineLabeledDropdown/InlineLabeledDropdown.js"
@@ -27,8 +30,12 @@ export function EntityDropdown({
     const { data: userCountryInfo } = useUserCountryInformation()
 
     const options = useMemo(
-        () => groupByUserLocation([...availableEntities], userCountryInfo),
-        [availableEntities, userCountryInfo]
+        () =>
+            orderOptionsByRelevance([...availableEntities], {
+                userCountryInfo,
+                selectedValue: selectedEntityName,
+            }),
+        [availableEntities, userCountryInfo, selectedEntityName]
     )
 
     return (
@@ -42,48 +49,106 @@ export function EntityDropdown({
     )
 }
 
+/** Sortable string key for an option label. */
+function labelSortKey(option: BasicDropdownOption): string {
+    return typeof option.label === "string" ? option.label : option.value
+}
+
 /**
- * Splits a flat option list into a "Suggested" group (user's country +
- * their continental regions, excluding income groups) and an "All
- * countries and regions" group
+ * The location icon (matching the grapher entity selector) that marks the
+ * user's country and continent.
+ *
+ * The dropdown menu is portaled into the light DOM, so this project's
+ * shadow-scoped stylesheet can't reach it — the styling is inlined.
  */
-export function groupByUserLocation(
+function LocationIcon(): React.ReactElement {
+    return (
+        <span style={{ marginLeft: 6, color: GRAY_60 }}>
+            <FontAwesomeIcon
+                icon={faLocationArrow}
+                style={{ fontSize: "0.9em" }}
+                aria-label="Your current location"
+            />
+        </span>
+    )
+}
+
+/**
+ * Orders a flat option list into a single list:
+ * any `pinnedToTop` aggregates first (in the given order), then the currently
+ * selected entity, then the user's country and continental regions (income
+ * groups excluded), and finally everything else sorted alphabetically.
+ */
+export function orderOptionsByRelevance(
     options: BasicDropdownOption[],
-    userCountryInfo: UserCountryInformation | undefined,
-    alwaysSuggested: string[] = []
+    {
+        userCountryInfo,
+        pinnedToTop = [],
+        selectedValue,
+    }: {
+        userCountryInfo?: UserCountryInformation
+        pinnedToTop?: string[]
+        selectedValue?: string
+    } = {}
 ): DropdownCollection {
     const optionsByValue = new Map(
         options.map((option) => [option.value, option])
     )
 
-    const suggested: BasicDropdownOption[] = []
-    const addToSuggestions = (option: BasicDropdownOption | undefined) => {
-        if (option && !suggested.includes(option)) suggested.push(option)
-    }
-
-    for (const value of alwaysSuggested) {
-        addToSuggestions(optionsByValue.get(value))
-    }
+    // The user's country and continental regions (income groups excluded), in
+    // country-then-continent order
+    const userLocationNames = new Set<string>()
     if (userCountryInfo) {
-        addToSuggestions(optionsByValue.get(userCountryInfo.name))
-        if (userCountryInfo.regions) {
-            for (const code of userCountryInfo.regions) {
-                const region = getRegionByCode(code)
+        userLocationNames.add(userCountryInfo.name)
+        for (const code of userCountryInfo.regions ?? []) {
+            const region = getRegionByCode(code)
 
-                // Ignore income groups
-                if (!region || region.regionType === "income_group") continue
+            // Ignore income groups
+            if (!region || region.regionType === "income_group") continue
 
-                addToSuggestions(optionsByValue.get(region.name))
-            }
+            userLocationNames.add(region.name)
         }
     }
-    if (suggested.length === 0) return options
 
-    const suggestedSet = new Set(suggested.map((option) => option.value))
-    const rest = options.filter((option) => !suggestedSet.has(option.value))
+    // Values to surface at the top, in priority order, with undefined dropped
+    // and deduped — so a value that is e.g. both the selected entity and the
+    // user's country keeps only its highest slot
+    const topValues = R.pipe(
+        [...pinnedToTop, selectedValue, ...userLocationNames],
+        R.filter(R.isDefined),
+        R.unique()
+    )
+    const top = topValues
+        .map((value) => optionsByValue.get(value))
+        .filter(R.isDefined)
 
-    return [
-        { label: "Suggested", options: suggested },
-        { label: "All countries and regions", options: rest },
-    ]
+    // Nothing to surface → return the flat list unchanged.
+    if (top.length === 0) return options
+
+    // Everything else, sorted alphabetically.
+    const topValueSet = new Set(topValues)
+    const remaining = options
+        .filter((option) => !topValueSet.has(option.value))
+        .sort((a, b) => labelSortKey(a).localeCompare(labelSortKey(b)))
+
+    // Mark the user's country and continent with a location icon wherever they
+    // appear — including when one of them is the selected entity.
+    const withIconIfUserLocation = (
+        option: BasicDropdownOption
+    ): BasicDropdownOption =>
+        userLocationNames.has(option.value)
+            ? { ...option, label: withLocationIcon(option.label) }
+            : option
+
+    return [...top, ...remaining].map(withIconIfUserLocation)
+}
+
+/** Decorates an option label with the location icon. */
+function withLocationIcon(label: React.ReactNode): React.ReactNode {
+    return (
+        <span>
+            {label}
+            <LocationIcon />
+        </span>
+    )
 }

--- a/bespoke/projects/demography/src/components/InlineEntitySelector.tsx
+++ b/bespoke/projects/demography/src/components/InlineEntitySelector.tsx
@@ -18,7 +18,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { EntityName } from "@ourworldindata/types"
 
 import { useUserCountryInformation } from "../../../../hooks/useUserCountryInformation.js"
-import { groupByUserLocation } from "../../../../components/EntityDropdown/EntityDropdown.js"
+import { orderOptionsByRelevance } from "../../../../components/EntityDropdown/EntityDropdown.js"
 
 import { DemographyMetadata } from "../helpers/types.js"
 import { displayEntityName, entityNameForSentence } from "../helpers/utils.js"
@@ -100,8 +100,11 @@ function EntityListBox({
             value: name,
             label: displayEntityName(name),
         }))
-        return groupByUserLocation(flat, userCountryInfo) as OptionCollection
-    }, [availableCountries, userCountryInfo])
+        return orderOptionsByRelevance(flat, {
+            userCountryInfo,
+            selectedValue: selectedEntityName,
+        }) as OptionCollection
+    }, [availableCountries, userCountryInfo, selectedEntityName])
 
     return (
         <Autocomplete filter={contains}>
@@ -147,7 +150,7 @@ function EntityListBox({
                                     className="option"
                                     key={option.value}
                                     id={option.value}
-                                    textValue={option.label}
+                                    textValue={displayEntityName(option.value)}
                                 >
                                     {option.label}
                                 </ListBoxItem>
@@ -158,7 +161,7 @@ function EntityListBox({
                             className="option"
                             key={item.value}
                             id={item.value}
-                            textValue={item.label}
+                            textValue={displayEntityName(item.value)}
                         >
                             {item.label}
                         </ListBoxItem>

--- a/bespoke/projects/food-trade/src/components/FoodTradeControls.tsx
+++ b/bespoke/projects/food-trade/src/components/FoodTradeControls.tsx
@@ -14,7 +14,7 @@ import { articulateEntity, Tippy } from "@ourworldindata/utils"
 
 import { useTippyContainer } from "../../../../hooks/useTippyContainer.js"
 import { useUserCountryInformation } from "../../../../hooks/useUserCountryInformation.js"
-import { groupByUserLocation } from "../../../../components/EntityDropdown/EntityDropdown.js"
+import { orderOptionsByRelevance } from "../../../../components/EntityDropdown/EntityDropdown.js"
 import {
     type DropdownCollection,
     InlineLabeledDropdown,
@@ -180,11 +180,11 @@ function CountryDropdown({
             (option) => hasTradeData(metadata, option.value, product)
         )
 
-        const groupedOptions = groupByUserLocation(
-            optionsWithData,
+        const groupedOptions = orderOptionsByRelevance(optionsWithData, {
             userCountryInfo,
-            includeAllCountries ? [ALL_COUNTRIES] : []
-        )
+            pinnedToTop: includeAllCountries ? [ALL_COUNTRIES] : [],
+            selectedValue: country,
+        })
 
         if (optionsWithoutData.length === 0) return groupedOptions
 
@@ -200,7 +200,14 @@ function CountryDropdown({
         }
 
         return [...groupedOptions, ...optionsWithoutData]
-    }, [countryNames, product, metadata, userCountryInfo, includeAllCountries])
+    }, [
+        countryNames,
+        product,
+        country,
+        metadata,
+        userCountryInfo,
+        includeAllCountries,
+    ])
 
     const noDataValues = useMemo(
         () =>

--- a/bespoke/projects/migration/src/components/MigrationControls.tsx
+++ b/bespoke/projects/migration/src/components/MigrationControls.tsx
@@ -8,7 +8,7 @@ import {
 import { BasicDropdownOption } from "@ourworldindata/grapher"
 import { Tippy } from "@ourworldindata/utils"
 
-import { groupByUserLocation } from "../../../../components/EntityDropdown/EntityDropdown.js"
+import { orderOptionsByRelevance } from "../../../../components/EntityDropdown/EntityDropdown.js"
 import {
     type DropdownCollection,
     InlineLabeledDropdown,
@@ -131,8 +131,11 @@ function CountryDropdown({
             .filter((e) => e.name !== OTHERS_ENTITY_NAME)
             .map((e) => ({ value: e.name, label: e.name }))
             .sort((a, b) => a.label.localeCompare(b.label))
-        return groupByUserLocation(flat, userCountryInfo)
-    }, [metadata.entities, userCountryInfo])
+        return orderOptionsByRelevance(flat, {
+            userCountryInfo,
+            selectedValue: country,
+        })
+    }, [metadata.entities, userCountryInfo, country])
 
     return (
         <InlineLabeledDropdown

--- a/packages/@ourworldindata/grapher/src/index.ts
+++ b/packages/@ourworldindata/grapher/src/index.ts
@@ -57,6 +57,7 @@ export {
     GRAPHER_DENIM,
     GRAPHER_DARK_TEXT,
     GRAPHER_LIGHT_TEXT,
+    GRAY_60,
     GRAY_70,
     GRAY_80,
     GRAY_90,


### PR DESCRIPTION
Replaces the entity dropdown's grouped **Selected / Suggested / All** layout with a single ordered list. Options are ordered by relevance:

1. Any pinned aggregates (e.g. "All countries") — at the very top
2. The currently selected entity
3. The user's country and continent (income groups excluded)
4. Everything else, alphabetically

The user's country and continent are marked with the location icon (matching grapher's entity selector) wherever they appear — including when one of them is the selected entity.

### Notes
- `groupByUserLocation` → `orderOptionsByRelevance`, and the `alwaysSuggested` option → `pinnedToTop`, since the "Suggested" group is gone.
- The ordering logic was simplified (single priority list + remeda's `unique`/`isDefined`, no more per-bucket bookkeeping).
- The location icon is styled inline (color `GRAY_60`) because the dropdown menu is portaled into the light DOM, so this project's shadow-scoped styles can't reach it. A tooltip on the icon is deferred for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)