### PR TITLE
Rich editor M3: in-situ chart editing — live canvas graphers, rail-embedded chart editor

### DIFF
--- a/adminShared/RichEditorTypes.ts
+++ b/adminShared/RichEditorTypes.ts
@@ -96,11 +96,17 @@ export interface RichEditorResolveReferencesRequest {
     narrativeChartNames?: string[]
 }
 
+/**
+ * NarrativeChartInfo (the shared site attachment shape) plus the numeric id,
+ * which the rich editor needs to open the narrative chart in the chart editor.
+ */
+export type RichEditorNarrativeChartInfo = NarrativeChartInfo & { id: number }
+
 export interface RichEditorResolveReferencesResponse {
     linkedCharts: Record<string, LinkedChart>
     imageMetadata: Record<string, ImageMetadata>
     linkedDocuments: Record<string, OwidGdocMinimalPostInterface>
-    narrativeCharts: Record<string, NarrativeChartInfo>
+    narrativeCharts: Record<string, RichEditorNarrativeChartInfo>
 }
 
 // ── Publish ────────────────────────────────────────────────────────────────

--- a/adminSiteClient/AbstractChartEditor.ts
+++ b/adminSiteClient/AbstractChartEditor.ts
@@ -58,6 +58,12 @@ export interface AbstractChartEditorManager {
     parentConfig?: GrapherInterface
     isInheritanceEnabled?: boolean
     variableIdsByCatalogPath?: Record<string, number | null>
+    /**
+     * True when the editor is mounted inside another page (e.g. the rich
+     * article editor's side rail) rather than on its own editor page.
+     * Embedded editors must not read or write the page URL.
+     */
+    embedded?: boolean
 }
 
 export interface References {
@@ -123,8 +129,10 @@ export abstract class AbstractChartEditor<
                 ? "mobile"
                 : "desktop"
 
-        this.readInitialTabFromUrl()
-        this.setupTabUrlSync()
+        if (!this.manager.embedded) {
+            this.readInitialTabFromUrl()
+            this.setupTabUrlSync()
+        }
 
         when(
             () => this.manager.parentConfig !== undefined,

--- a/adminSiteClient/ChartEditorEnvironment.ts
+++ b/adminSiteClient/ChartEditorEnvironment.ts
@@ -1,0 +1,346 @@
+import * as _ from "lodash-es"
+import {
+    observable,
+    computed,
+    runInAction,
+    action,
+    reaction,
+    IReactionDisposer,
+    makeObservable,
+    comparer,
+} from "mobx"
+import {
+    DetailDictionary,
+    extractDetailsFromSyntax,
+    getIndexableKeys,
+} from "@ourworldindata/utils"
+import {
+    GrapherInterface,
+    DimensionProperty,
+    ORIGIN_URL_REGEX_PATTERNS,
+} from "@ourworldindata/types"
+import {
+    GrapherState,
+    hasValidConfigForBinningStrategy,
+} from "@ourworldindata/grapher"
+import { Admin } from "./Admin.js"
+import { runDetailsOnDemand } from "../site/detailsOnDemand.js"
+import { AbstractChartEditor } from "./AbstractChartEditor.js"
+import {
+    ErrorMessages,
+    ErrorMessagesForDimensions,
+    FieldWithDetailReferences,
+} from "./ChartEditorTypes.js"
+
+interface Variable {
+    id: number
+    name: string
+}
+
+export interface Dataset {
+    id: number
+    name: string
+    namespace: string
+    version: string | undefined
+    variables: Variable[]
+    isPrivate: boolean
+    nonRedistributable: boolean
+}
+
+export interface Namespace {
+    name: string
+    description?: string
+    isArchived: boolean
+}
+
+// This contains the dataset/variable metadata for the entire database
+// Used for variable selector interface
+export interface NamespaceData {
+    datasets: Dataset[]
+}
+
+export class EditorDatabase {
+    namespaces: Namespace[]
+    variableUsageCounts: Map<number, number> = new Map()
+    dataByNamespace: Map<string, NamespaceData> = new Map()
+
+    constructor(json: any) {
+        makeObservable(this, {
+            namespaces: observable.ref,
+            variableUsageCounts: observable.ref,
+            dataByNamespace: observable,
+        })
+        this.namespaces = json.namespaces
+    }
+}
+
+export type DetailReferences = Record<FieldWithDetailReferences, string[]>
+
+export interface ChartEditorEnvironmentManager<Editor> {
+    admin: Admin
+    editor: Editor
+}
+
+/**
+ * Editor-session state shared by every host of the chart editor form
+ * (the standalone ChartEditorView pages and the rich editor's embedded
+ * panel): the dataset/variable database, the details-on-demand dictionary,
+ * validation error messages, and the reactions that keep the editor's
+ * grapherState in sync with its config. Hosts own bounds and rendering.
+ */
+export class ChartEditorEnvironment<Editor extends AbstractChartEditor> {
+    database = new EditorDatabase({})
+    details: DetailDictionary = {}
+
+    private manager: ChartEditorEnvironmentManager<Editor>
+    private onGrapherUpdated?: () => void
+    private disposers: IReactionDisposer[] = []
+    private _isDbSet = false
+
+    constructor(props: {
+        manager: ChartEditorEnvironmentManager<Editor>
+        /** called after the grapher was (re)initialized from the editor's config */
+        onGrapherUpdated?: () => void
+    }) {
+        makeObservable<ChartEditorEnvironment<Editor>, "_isDbSet">(this, {
+            database: observable.ref,
+            details: observable,
+            _isDbSet: observable,
+        })
+        this.manager = props.manager
+        this.onGrapherUpdated = props.onGrapherUpdated
+    }
+
+    @computed get grapherState(): GrapherState {
+        return this.manager.editor.grapherState
+    }
+
+    @computed get isReady(): boolean {
+        return this._isDbSet
+    }
+
+    @computed get editor(): Editor | undefined {
+        if (!this.isReady) return undefined
+
+        return this.manager.editor
+    }
+
+    @action.bound async updateGrapher(): Promise<void> {
+        // the embedded host's editor is created asynchronously (and cleared
+        // between editing sessions), so it can legitimately be absent here
+        if (!this.manager.editor) return
+        const config = this.manager.editor.originalGrapherConfig
+        this.manager.editor.grapherState.updateFromObject(config)
+        await this.manager.editor.reloadGrapherData()
+        this.onGrapherUpdated?.()
+    }
+
+    @action.bound private setDb(json: any): void {
+        this.database = new EditorDatabase(json)
+        this._isDbSet = true
+    }
+
+    async fetchData(): Promise<void> {
+        const { admin } = this.manager
+
+        const [namespaces, variables] = await Promise.all([
+            admin.getJSON(`/api/editorData/namespaces.json`),
+            admin.getJSON(`/api/editorData/variables.json`),
+        ])
+
+        this.setDb(namespaces)
+
+        const groupedByNamespace = _.groupBy(
+            variables.datasets,
+            (d) => d.namespace
+        )
+        for (const namespace in groupedByNamespace) {
+            this.database.dataByNamespace.set(namespace, {
+                datasets: groupedByNamespace[namespace] as Dataset[],
+            })
+        }
+
+        const usageData = await admin.getJSON<
+            {
+                variableId: number
+                usageCount: number
+            }[]
+        >(`/api/variables.usages.json`)
+        this.database.variableUsageCounts = new Map(
+            usageData.map(({ variableId, usageCount }) => [
+                variableId,
+                +usageCount,
+            ])
+        )
+    }
+
+    async fetchDetails(): Promise<void> {
+        await runDetailsOnDemand({ shouldFetchFromAdminApi: true })
+
+        runInAction(() => {
+            if (window.details) this.details = window.details
+        })
+    }
+
+    @action.bound refresh(): void {
+        void this.fetchDetails()
+        void this.fetchData()
+    }
+
+    /** fetch data and register the reactions that keep grapherState in sync */
+    start(): void {
+        this.refresh()
+        this.disposers.push(
+            reaction(
+                () => this.editor,
+                () => {
+                    void this.updateGrapher()
+                }
+            )
+        )
+        this.disposers.push(
+            reaction(
+                () => this.editor?.fullConfig,
+                () => {
+                    // Update the authoredVersion, as it's being used for "author's minTime & maxTime" in some places.
+                    if (this.editor?.fullConfig)
+                        this.editor?.grapherState.setAuthoredVersion(
+                            this.editor?.fullConfig
+                        )
+                },
+                { equals: comparer.structural }
+            )
+        )
+    }
+
+    dispose(): void {
+        this.disposers.forEach((dispose) => dispose())
+        this.disposers.length = 0
+    }
+
+    // unvalidated terms extracted from the subtitle and note fields
+    // these may point to non-existent details e.g. ["not_a_real_term", "pvotery"]
+    @computed
+    get currentDetailReferences(): DetailReferences {
+        const { grapherState } = this.manager.editor
+        return {
+            subtitle: extractDetailsFromSyntax(grapherState.currentSubtitle),
+            note: extractDetailsFromSyntax(grapherState.note ?? ""),
+            axisLabelX: extractDetailsFromSyntax(
+                grapherState.xAxisConfig.label ?? ""
+            ),
+            axisLabelY: extractDetailsFromSyntax(
+                grapherState.yAxisConfig.label ?? ""
+            ),
+        }
+    }
+
+    // the actual Detail objects, indexed by category.term
+    @computed get currentlyReferencedDetails(): GrapherInterface["details"] {
+        const grapherConfigDetails: GrapherInterface["details"] = {}
+        const allReferences = Object.values(this.currentDetailReferences).flat()
+
+        allReferences.forEach((term) => {
+            const detail = _.get(this.details, term)
+            if (detail) {
+                _.set(grapherConfigDetails, term, detail)
+            }
+        })
+
+        return grapherConfigDetails
+    }
+
+    @computed
+    get invalidDetailReferences(): DetailReferences {
+        const { subtitle, note, axisLabelX, axisLabelY } =
+            this.currentDetailReferences
+        return {
+            subtitle: subtitle.filter((term) => !this.details[term]),
+            note: note.filter((term) => !this.details[term]),
+            axisLabelX: axisLabelX.filter((term) => !this.details[term]),
+            axisLabelY: axisLabelY.filter((term) => !this.details[term]),
+        }
+    }
+
+    @computed get errorMessages(): ErrorMessages {
+        const { invalidDetailReferences } = this
+
+        const errorMessages: ErrorMessages = {}
+
+        // add error messages for each field with invalid detail references
+        getIndexableKeys(invalidDetailReferences).forEach(
+            (key: FieldWithDetailReferences) => {
+                const references = invalidDetailReferences[key]
+                if (references.length) {
+                    errorMessages[key] =
+                        `Invalid DoD(s) specified: ${references.join(", ")}`
+                }
+            }
+        )
+
+        // add an error message if any focused series names are invalid
+        const { invalidFocusedSeriesNames = [] } = this.editor ?? {}
+        if (invalidFocusedSeriesNames.length > 0) {
+            const invalidNames = invalidFocusedSeriesNames.join(", ")
+            const message = `Invalid focus state. The following entities/indicators are not plotted: ${invalidNames}`
+            errorMessages.focusedSeriesNames = message
+        }
+
+        // Check the two colorScale configs (esp. binning strategies) for any errors
+        const colorScaleKeys = ["colorScale", "map.colorScale"] as const
+        colorScaleKeys.forEach((key) => {
+            const colorScaleConfig = _.get(this.grapherState, key)
+
+            if (colorScaleConfig.binningStrategy === "manual") return
+
+            const validationResult = hasValidConfigForBinningStrategy(
+                colorScaleConfig.binningStrategy,
+                colorScaleConfig
+            )
+            if (!validationResult.valid) {
+                errorMessages[`${key}.${validationResult.field}`] =
+                    validationResult.reason
+            }
+        })
+
+        if (
+            this.grapherState.originUrl &&
+            !ORIGIN_URL_REGEX_PATTERNS.some((regex) =>
+                regex.test(this.grapherState.originUrl ?? "")
+            )
+        ) {
+            errorMessages.originUrl =
+                "Invalid origin URL. If it's a relative URL, make sure it starts with /"
+        }
+
+        return errorMessages
+    }
+
+    @computed
+    get errorMessagesForDimensions(): ErrorMessagesForDimensions {
+        const errorMessages: ErrorMessagesForDimensions = {
+            [DimensionProperty.y]: [],
+            [DimensionProperty.x]: [],
+            [DimensionProperty.color]: [],
+            [DimensionProperty.size]: [],
+            [DimensionProperty.table]: [], // not used
+        }
+
+        this.grapherState.dimensionSlots.forEach((slot) => {
+            slot.dimensions.forEach((dimension, dimensionIndex) => {
+                const details = extractDetailsFromSyntax(
+                    dimension.display.name ?? ""
+                )
+                const hasDetailsInDisplayName = details.length > 0
+
+                // add error message if details are referenced in the display name
+                if (hasDetailsInDisplayName) {
+                    errorMessages[slot.property][dimensionIndex] =
+                        `Detail syntax is not supported for display names of indicators: ${dimension.display.name}`
+                }
+            })
+        })
+
+        return errorMessages
+    }
+}

--- a/adminSiteClient/ChartEditorEnvironment.ts
+++ b/adminSiteClient/ChartEditorEnvironment.ts
@@ -92,9 +92,9 @@ export class ChartEditorEnvironment<Editor extends AbstractChartEditor> {
     database = new EditorDatabase({})
     details: DetailDictionary = {}
 
-    private manager: ChartEditorEnvironmentManager<Editor>
-    private onGrapherUpdated?: () => void
-    private disposers: IReactionDisposer[] = []
+    private readonly manager: ChartEditorEnvironmentManager<Editor>
+    private readonly onGrapherUpdated?: () => void
+    private readonly disposers: IReactionDisposer[] = []
     private _isDbSet = false
 
     constructor(props: {

--- a/adminSiteClient/ChartEditorSettingsPanel.tsx
+++ b/adminSiteClient/ChartEditorSettingsPanel.tsx
@@ -1,0 +1,128 @@
+import * as _ from "lodash-es"
+import * as React from "react"
+import { observer } from "mobx-react"
+import { getFullReferencesCount, isChartEditorInstance } from "./ChartEditor.js"
+import { EditorBasicTab } from "./EditorBasicTab.js"
+import { EditorDataTab } from "./EditorDataTab.js"
+import { EditorTextTab } from "./EditorTextTab.js"
+import { EditorCustomizeTab } from "./EditorCustomizeTab.js"
+import { EditorScatterTab } from "./EditorScatterTab.js"
+import { EditorMapTab } from "./EditorMapTab.js"
+import { EditorHistoryTab } from "./EditorHistoryTab.js"
+import { EditorReferencesTab } from "./EditorReferencesTab.js"
+import { EditorDebugTab } from "./EditorDebugTab.js"
+import { EditorMarimekkoTab } from "./EditorMarimekkoTab.js"
+import { EditorExportTab } from "./EditorExportTab.js"
+import { SaveButtons } from "./SaveButtons.js"
+import { AbstractChartEditor } from "./AbstractChartEditor.js"
+import { ChartEditorEnvironment } from "./ChartEditorEnvironment.js"
+
+interface ChartEditorSettingsPanelProps<Editor extends AbstractChartEditor> {
+    editor: Editor
+    environment: ChartEditorEnvironment<Editor>
+}
+
+/**
+ * The chart editor form: the tab bar (basic/data/text/…), the active tab's
+ * settings, and the save buttons. Shared by the standalone editor pages
+ * (via ChartEditorView) and the rich editor's embedded chart editor panel.
+ */
+@observer
+export class ChartEditorSettingsPanel<
+    Editor extends AbstractChartEditor,
+> extends React.Component<ChartEditorSettingsPanelProps<Editor>> {
+    override render(): React.ReactElement {
+        const { editor, environment } = this.props
+        const { grapherState, availableTabs } = editor
+
+        const chartEditor = isChartEditorInstance(editor) ? editor : undefined
+
+        return (
+            <>
+                <div className="p-2">
+                    <ul className="nav nav-tabs">
+                        {availableTabs.map((tab) => (
+                            <li key={tab} className="nav-item">
+                                <a
+                                    className={
+                                        "nav-link" +
+                                        (tab === editor.tab ? " active" : "")
+                                    }
+                                    onClick={() => {
+                                        editor.tab = tab
+                                        editor.showStaticPreview =
+                                            tab === "export"
+                                    }}
+                                >
+                                    {_.capitalize(tab)}
+                                    {tab === "refs" && editor?.references
+                                        ? ` (${getFullReferencesCount(
+                                              editor.references
+                                          )})`
+                                        : ""}
+                                </a>
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+                <div className="innerForm container">
+                    {editor.tab === "basic" && (
+                        <EditorBasicTab
+                            editor={editor}
+                            database={environment.database}
+                            errorMessagesForDimensions={
+                                environment.errorMessagesForDimensions
+                            }
+                        />
+                    )}
+                    {editor.tab === "text" && (
+                        <EditorTextTab
+                            editor={editor}
+                            errorMessages={environment.errorMessages}
+                        />
+                    )}
+                    {editor.tab === "data" && <EditorDataTab editor={editor} />}
+                    {editor.tab === "customize" && (
+                        <EditorCustomizeTab
+                            editor={editor}
+                            errorMessages={environment.errorMessages}
+                        />
+                    )}
+                    {editor.tab === "scatter" && (
+                        <EditorScatterTab editor={editor} />
+                    )}
+                    {editor.tab === "marimekko" && (
+                        <EditorMarimekkoTab grapherState={grapherState} />
+                    )}
+                    {editor.tab === "map" && (
+                        <EditorMapTab
+                            editor={editor}
+                            errorMessages={environment.errorMessages}
+                        />
+                    )}
+                    {chartEditor && chartEditor.tab === "revisions" && (
+                        <EditorHistoryTab editor={chartEditor} />
+                    )}
+                    {editor.tab === "refs" && (
+                        <EditorReferencesTab editor={editor} />
+                    )}
+                    {editor.tab === "export" && (
+                        <EditorExportTab editor={editor} />
+                    )}
+                    {editor.tab === "debug" && (
+                        <EditorDebugTab editor={editor} />
+                    )}
+                </div>
+                {editor.tab !== "export" && (
+                    <SaveButtons
+                        editor={editor}
+                        errorMessages={environment.errorMessages}
+                        errorMessagesForDimensions={
+                            environment.errorMessagesForDimensions
+                        }
+                    />
+                )}
+            </>
+        )
+    }
+}

--- a/adminSiteClient/ChartEditorView.tsx
+++ b/adminSiteClient/ChartEditorView.tsx
@@ -1,48 +1,24 @@
 /* eslint-disable react-refresh/only-export-components */
-import * as _ from "lodash-es"
 import * as React from "react"
 import { observer } from "mobx-react"
 import {
     observable,
     computed,
-    runInAction,
     action,
     reaction,
     IReactionDisposer,
     makeObservable,
-    comparer,
 } from "mobx"
 import { Prompt, Redirect } from "react-router-dom"
-import {
-    Bounds,
-    DetailDictionary,
-    extractDetailsFromSyntax,
-    getIndexableKeys,
-} from "@ourworldindata/utils"
-import {
-    GrapherInterface,
-    DimensionProperty,
-    ORIGIN_URL_REGEX_PATTERNS,
-} from "@ourworldindata/types"
+import { Bounds } from "@ourworldindata/utils"
 import {
     DEFAULT_GRAPHER_BOUNDS,
     DEFAULT_GRAPHER_BOUNDS_SQUARE,
     Grapher,
     GrapherState,
-    hasValidConfigForBinningStrategy,
 } from "@ourworldindata/grapher"
 import { Admin } from "./Admin.js"
-import { getFullReferencesCount, isChartEditorInstance } from "./ChartEditor.js"
-import { EditorBasicTab } from "./EditorBasicTab.js"
-import { EditorDataTab } from "./EditorDataTab.js"
-import { EditorTextTab } from "./EditorTextTab.js"
-import { EditorCustomizeTab } from "./EditorCustomizeTab.js"
-import { EditorScatterTab } from "./EditorScatterTab.js"
-import { EditorMapTab } from "./EditorMapTab.js"
-import { EditorHistoryTab } from "./EditorHistoryTab.js"
-import { EditorReferencesTab } from "./EditorReferencesTab.js"
-import { EditorDebugTab } from "./EditorDebugTab.js"
-import { SaveButtons } from "./SaveButtons.js"
+import { isChartEditorInstance } from "./ChartEditor.js"
 import { LoadingBlocker } from "./Forms.js"
 import { AdminLayout } from "./AdminLayout.js"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
@@ -53,59 +29,19 @@ import {
     VisionDeficiencyDropdown,
     VisionDeficiencyEntity,
 } from "./VisionDeficiencies.js"
-import { EditorMarimekkoTab } from "./EditorMarimekkoTab.js"
-import { EditorExportTab } from "./EditorExportTab.js"
-import { runDetailsOnDemand } from "../site/detailsOnDemand.js"
 import { AbstractChartEditor } from "./AbstractChartEditor.js"
-import {
-    ErrorMessages,
-    ErrorMessagesForDimensions,
-    FieldWithDetailReferences,
-} from "./ChartEditorTypes.js"
+import { ChartEditorEnvironment } from "./ChartEditorEnvironment.js"
+import { ChartEditorSettingsPanel } from "./ChartEditorSettingsPanel.js"
 
-interface Variable {
-    id: number
-    name: string
-}
-
-export interface Dataset {
-    id: number
-    name: string
-    namespace: string
-    version: string | undefined
-    variables: Variable[]
-    isPrivate: boolean
-    nonRedistributable: boolean
-}
-
-export interface Namespace {
-    name: string
-    description?: string
-    isArchived: boolean
-}
-
-// This contains the dataset/variable metadata for the entire database
-// Used for variable selector interface
-export interface NamespaceData {
-    datasets: Dataset[]
-}
-
-export class EditorDatabase {
-    namespaces: Namespace[]
-    variableUsageCounts: Map<number, number> = new Map()
-    dataByNamespace: Map<string, NamespaceData> = new Map()
-
-    constructor(json: any) {
-        makeObservable(this, {
-            namespaces: observable.ref,
-            variableUsageCounts: observable.ref,
-            dataByNamespace: observable,
-        })
-        this.namespaces = json.namespaces
-    }
-}
-
-export type DetailReferences = Record<FieldWithDetailReferences, string[]>
+// Re-exported for compatibility: these used to be defined here and are
+// imported from this module by EditorBasicTab, VariableSelector, etc.
+export { EditorDatabase } from "./ChartEditorEnvironment.js"
+export type {
+    Dataset,
+    Namespace,
+    NamespaceData,
+    DetailReferences,
+} from "./ChartEditorEnvironment.js"
 
 export interface ChartEditorViewManager<Editor> {
     admin: Admin
@@ -120,17 +56,20 @@ interface ChartEditorViewProps<Editor> {
 export class ChartEditorView<
     Editor extends AbstractChartEditor,
 > extends React.Component<ChartEditorViewProps<Editor>> {
-    database = new EditorDatabase({})
-    details: DetailDictionary = {}
+    environment: ChartEditorEnvironment<Editor>
 
     constructor(props: ChartEditorViewProps<Editor>) {
         super(props)
 
-        makeObservable<ChartEditorView<Editor>, "_isDbSet">(this, {
-            database: observable.ref,
-            details: observable,
+        makeObservable(this, {
             simulateVisionDeficiency: observable,
-            _isDbSet: observable,
+        })
+
+        this.environment = new ChartEditorEnvironment({
+            manager: props.manager,
+            onGrapherUpdated: action(() => {
+                this.grapherState.externalBounds = this.bounds
+            }),
         })
     }
 
@@ -142,64 +81,6 @@ export class ChartEditorView<
 
     @computed private get manager(): ChartEditorViewManager<Editor> {
         return this.props.manager
-    }
-
-    private _isDbSet = false
-    @computed get isReady(): boolean {
-        return this._isDbSet
-    }
-    @action.bound async updateGrapher(): Promise<void> {
-        const config = this.manager.editor.originalGrapherConfig
-        this.manager.editor.grapherState.updateFromObject(config)
-        await this.manager.editor.reloadGrapherData()
-        this.grapherState.externalBounds = this.bounds
-    }
-
-    @action.bound private setDb(json: any): void {
-        this.database = new EditorDatabase(json)
-        this._isDbSet = true
-    }
-
-    async fetchData(): Promise<void> {
-        const { admin } = this.manager
-
-        const [namespaces, variables] = await Promise.all([
-            admin.getJSON(`/api/editorData/namespaces.json`),
-            admin.getJSON(`/api/editorData/variables.json`),
-        ])
-
-        this.setDb(namespaces)
-
-        const groupedByNamespace = _.groupBy(
-            variables.datasets,
-            (d) => d.namespace
-        )
-        for (const namespace in groupedByNamespace) {
-            this.database.dataByNamespace.set(namespace, {
-                datasets: groupedByNamespace[namespace] as Dataset[],
-            })
-        }
-
-        const usageData = await admin.getJSON<
-            {
-                variableId: number
-                usageCount: number
-            }[]
-        >(`/api/variables.usages.json`)
-        this.database.variableUsageCounts = new Map(
-            usageData.map(({ variableId, usageCount }) => [
-                variableId,
-                +usageCount,
-            ])
-        )
-    }
-
-    async fetchDetails(): Promise<void> {
-        await runDetailsOnDemand({ shouldFetchFromAdminApi: true })
-
-        runInAction(() => {
-            if (window.details) this.details = window.details
-        })
     }
 
     @computed private get isMobilePreview(): boolean {
@@ -217,153 +98,12 @@ export class ChartEditorView<
             : DEFAULT_GRAPHER_BOUNDS
     }
 
-    // unvalidated terms extracted from the subtitle and note fields
-    // these may point to non-existent details e.g. ["not_a_real_term", "pvotery"]
-    @computed
-    get currentDetailReferences(): DetailReferences {
-        const { grapherState } = this.manager.editor
-        return {
-            subtitle: extractDetailsFromSyntax(grapherState.currentSubtitle),
-            note: extractDetailsFromSyntax(grapherState.note ?? ""),
-            axisLabelX: extractDetailsFromSyntax(
-                grapherState.xAxisConfig.label ?? ""
-            ),
-            axisLabelY: extractDetailsFromSyntax(
-                grapherState.yAxisConfig.label ?? ""
-            ),
-        }
-    }
-
-    // the actual Detail objects, indexed by category.term
-    @computed get currentlyReferencedDetails(): GrapherInterface["details"] {
-        const grapherConfigDetails: GrapherInterface["details"] = {}
-        const allReferences = Object.values(this.currentDetailReferences).flat()
-
-        allReferences.forEach((term) => {
-            const detail = _.get(this.details, term)
-            if (detail) {
-                _.set(grapherConfigDetails, term, detail)
-            }
-        })
-
-        return grapherConfigDetails
-    }
-
-    @computed
-    get invalidDetailReferences(): DetailReferences {
-        const { subtitle, note, axisLabelX, axisLabelY } =
-            this.currentDetailReferences
-        return {
-            subtitle: subtitle.filter((term) => !this.details[term]),
-            note: note.filter((term) => !this.details[term]),
-            axisLabelX: axisLabelX.filter((term) => !this.details[term]),
-            axisLabelY: axisLabelY.filter((term) => !this.details[term]),
-        }
-    }
-
-    @computed get errorMessages(): ErrorMessages {
-        const { invalidDetailReferences } = this
-
-        const errorMessages: ErrorMessages = {}
-
-        // add error messages for each field with invalid detail references
-        getIndexableKeys(invalidDetailReferences).forEach(
-            (key: FieldWithDetailReferences) => {
-                const references = invalidDetailReferences[key]
-                if (references.length) {
-                    errorMessages[key] =
-                        `Invalid DoD(s) specified: ${references.join(", ")}`
-                }
-            }
-        )
-
-        // add an error message if any focused series names are invalid
-        const { invalidFocusedSeriesNames = [] } = this.editor ?? {}
-        if (invalidFocusedSeriesNames.length > 0) {
-            const invalidNames = invalidFocusedSeriesNames.join(", ")
-            const message = `Invalid focus state. The following entities/indicators are not plotted: ${invalidNames}`
-            errorMessages.focusedSeriesNames = message
-        }
-
-        // Check the two colorScale configs (esp. binning strategies) for any errors
-        const colorScaleKeys = ["colorScale", "map.colorScale"] as const
-        colorScaleKeys.forEach((key) => {
-            const colorScaleConfig = _.get(this.grapherState, key)
-
-            if (colorScaleConfig.binningStrategy === "manual") return
-
-            const validationResult = hasValidConfigForBinningStrategy(
-                colorScaleConfig.binningStrategy,
-                colorScaleConfig
-            )
-            if (!validationResult.valid) {
-                errorMessages[`${key}.${validationResult.field}`] =
-                    validationResult.reason
-            }
-        })
-
-        if (
-            this.grapherState.originUrl &&
-            !ORIGIN_URL_REGEX_PATTERNS.some((regex) =>
-                regex.test(this.grapherState.originUrl ?? "")
-            )
-        ) {
-            errorMessages.originUrl =
-                "Invalid origin URL. If it's a relative URL, make sure it starts with /"
-        }
-
-        return errorMessages
-    }
-
-    @computed
-    get errorMessagesForDimensions(): ErrorMessagesForDimensions {
-        const errorMessages: ErrorMessagesForDimensions = {
-            [DimensionProperty.y]: [],
-            [DimensionProperty.x]: [],
-            [DimensionProperty.color]: [],
-            [DimensionProperty.size]: [],
-            [DimensionProperty.table]: [], // not used
-        }
-
-        this.grapherState.dimensionSlots.forEach((slot) => {
-            slot.dimensions.forEach((dimension, dimensionIndex) => {
-                const details = extractDetailsFromSyntax(
-                    dimension.display.name ?? ""
-                )
-                const hasDetailsInDisplayName = details.length > 0
-
-                // add error message if details are referenced in the display name
-                if (hasDetailsInDisplayName) {
-                    errorMessages[slot.property][dimensionIndex] =
-                        `Detail syntax is not supported for display names of indicators: ${dimension.display.name}`
-                }
-            })
-        })
-
-        return errorMessages
-    }
-
     @computed get editor(): Editor | undefined {
-        if (!this.isReady) return undefined
-
-        return this.manager.editor
-    }
-
-    @action.bound refresh(): void {
-        void this.fetchDetails()
-        void this.fetchData()
+        return this.environment.editor
     }
 
     override componentDidMount(): void {
-        this.refresh()
-        this.disposers.push(
-            reaction(
-                () => this.editor,
-                () => {
-                    void this.updateGrapher()
-                }
-            )
-        )
+        this.environment.start()
         this.disposers.push(
             reaction(
                 () => this.editor && this.editor.previewMode,
@@ -373,24 +113,12 @@ export class ChartEditorView<
                 }
             )
         )
-        this.disposers.push(
-            reaction(
-                () => this.editor?.fullConfig,
-                () => {
-                    // Update the authoredVersion, as it's being used for "author's minTime & maxTime" in some places.
-                    if (this.editor?.fullConfig)
-                        this.editor?.grapherState.setAuthoredVersion(
-                            this.editor?.fullConfig
-                        )
-                },
-                { equals: comparer.structural }
-            )
-        )
     }
 
     disposers: IReactionDisposer[] = []
     override componentWillUnmount(): void {
         this.disposers.forEach((dispose) => dispose())
+        this.environment.dispose()
         this.editor?.dispose()
     }
 
@@ -407,7 +135,7 @@ export class ChartEditorView<
     }
 
     renderReady(editor: Editor): React.ReactElement {
-        const { grapherState, availableTabs } = editor
+        const { grapherState } = editor
 
         const chartEditor = isChartEditorInstance(editor) ? editor : undefined
         const queryParams = chartEditor?.forceDatapage
@@ -426,93 +154,10 @@ export class ChartEditorView<
                     <Redirect to={`/charts/${chartEditor.newChartId}/edit`} />
                 )}
                 <div className="chart-editor-settings">
-                    <div className="p-2">
-                        <ul className="nav nav-tabs">
-                            {availableTabs.map((tab) => (
-                                <li key={tab} className="nav-item">
-                                    <a
-                                        className={
-                                            "nav-link" +
-                                            (tab === editor.tab
-                                                ? " active"
-                                                : "")
-                                        }
-                                        onClick={() => {
-                                            editor.tab = tab
-                                            editor.showStaticPreview =
-                                                tab === "export"
-                                        }}
-                                    >
-                                        {_.capitalize(tab)}
-                                        {tab === "refs" && editor?.references
-                                            ? ` (${getFullReferencesCount(
-                                                  editor.references
-                                              )})`
-                                            : ""}
-                                    </a>
-                                </li>
-                            ))}
-                        </ul>
-                    </div>
-                    <div className="innerForm container">
-                        {editor.tab === "basic" && (
-                            <EditorBasicTab
-                                editor={editor}
-                                database={this.database}
-                                errorMessagesForDimensions={
-                                    this.errorMessagesForDimensions
-                                }
-                            />
-                        )}
-                        {editor.tab === "text" && (
-                            <EditorTextTab
-                                editor={editor}
-                                errorMessages={this.errorMessages}
-                            />
-                        )}
-                        {editor.tab === "data" && (
-                            <EditorDataTab editor={editor} />
-                        )}
-                        {editor.tab === "customize" && (
-                            <EditorCustomizeTab
-                                editor={editor}
-                                errorMessages={this.errorMessages}
-                            />
-                        )}
-                        {editor.tab === "scatter" && (
-                            <EditorScatterTab editor={editor} />
-                        )}
-                        {editor.tab === "marimekko" && (
-                            <EditorMarimekkoTab grapherState={grapherState} />
-                        )}
-                        {editor.tab === "map" && (
-                            <EditorMapTab
-                                editor={editor}
-                                errorMessages={this.errorMessages}
-                            />
-                        )}
-                        {chartEditor && chartEditor.tab === "revisions" && (
-                            <EditorHistoryTab editor={chartEditor} />
-                        )}
-                        {editor.tab === "refs" && (
-                            <EditorReferencesTab editor={editor} />
-                        )}
-                        {editor.tab === "export" && (
-                            <EditorExportTab editor={editor} />
-                        )}
-                        {editor.tab === "debug" && (
-                            <EditorDebugTab editor={editor} />
-                        )}
-                    </div>
-                    {editor.tab !== "export" && (
-                        <SaveButtons
-                            editor={editor}
-                            errorMessages={this.errorMessages}
-                            errorMessagesForDimensions={
-                                this.errorMessagesForDimensions
-                            }
-                        />
-                    )}
+                    <ChartEditorSettingsPanel
+                        editor={editor}
+                        environment={this.environment}
+                    />
                 </div>
                 <div className="chart-editor-view">
                     {grapherState.id && (

--- a/adminSiteClient/SaveButtons.tsx
+++ b/adminSiteClient/SaveButtons.tsx
@@ -116,6 +116,11 @@ class SaveButtonsForChart extends Component<SaveButtonsProps<ChartEditor>> {
         const hasEditingErrors = editingErrors.length > 0
         const isSavingDisabled = grapherState.hasFatalErrors || hasEditingErrors
 
+        // Embedded in another page (e.g. the rich article editor's rail):
+        // deleting navigates the whole page away, and "save as narrative
+        // chart" is replaced by the host's own block-aware flow.
+        const isEmbedded = !!editor.manager.embedded
+
         return (
             <div className="SaveButtons">
                 <div>
@@ -148,16 +153,18 @@ class SaveButtonsForChart extends Component<SaveButtonsProps<ChartEditor>> {
                                     ? "Unpublish"
                                     : "Publish"}
                             </button>{" "}
-                            <button
-                                className="btn btn-danger"
-                                onClick={this.onDeleteChart}
-                            >
-                                Delete
-                            </button>
+                            {!isEmbedded && (
+                                <button
+                                    className="btn btn-danger"
+                                    onClick={this.onDeleteChart}
+                                >
+                                    Delete
+                                </button>
+                            )}
                         </>
                     )}
                 </div>
-                {!isNewGrapher && (
+                {!isNewGrapher && !isEmbedded && (
                     <div className="mt-2">
                         <button
                             className="btn btn-primary"

--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -315,6 +315,41 @@ $nav-height: 45px;
     display: flex;
     flex-grow: 1;
 
+    > .chart-editor-settings {
+        min-width: 550px;
+        width: 550px;
+        min-height: 100%;
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+    }
+
+    .innerForm {
+        overflow-y: scroll;
+        flex-grow: 1;
+    }
+
+    > .chart-editor-view {
+        display: flex;
+        flex-direction: column;
+        flex-grow: 1;
+        align-items: center;
+        justify-content: center;
+        position: relative;
+
+        a.preview {
+            position: absolute;
+            top: 8px;
+            right: 16px;
+        }
+    }
+}
+
+// The chart editor form is also embedded outside the standalone editor pages
+// (in the rich article editor's right rail as .chart-editor-embedded), so
+// the form styling is shared while the page layout above stays page-only.
+.ChartEditorPage,
+.chart-editor-embedded {
     .btn-group .btn {
         width: 50px;
     }
@@ -333,37 +368,8 @@ $nav-height: 45px;
         padding-right: 0.75rem;
     }
 
-    > .chart-editor-settings {
-        min-width: 550px;
-        width: 550px;
-        min-height: 100%;
-        display: flex;
-        flex-direction: column;
-        overflow: hidden;
-    }
-
-    .innerForm {
-        overflow-y: scroll;
-        flex-grow: 1;
-    }
-
     .SaveButtons {
         padding: 24px;
-    }
-
-    > .chart-editor-view {
-        display: flex;
-        flex-direction: column;
-        flex-grow: 1;
-        align-items: center;
-        justify-content: center;
-        position: relative;
-
-        a.preview {
-            position: absolute;
-            top: 8px;
-            right: 16px;
-        }
     }
 
     section {

--- a/adminSiteClient/richEditor/BlockInspector.tsx
+++ b/adminSiteClient/richEditor/BlockInspector.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useMemo, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import {
     Alert,
     AutoComplete,
@@ -12,52 +12,25 @@ import {
     Space,
     Typography,
 } from "antd"
-import { useQuery } from "@tanstack/react-query"
 import {
     EnrichedBlockResearchAndWritingLink,
     EnrichedHybridLink,
     Span,
 } from "@ourworldindata/types"
 import { spansToUnformattedPlainText } from "@ourworldindata/utils"
-import { AdminAppContext } from "../AdminAppContext.js"
 import { ImageSelectorModal } from "../ImageSelectorModal.js"
 import { InspectedBlock } from "./inspection.js"
+import { GRAPHER_URL_PREFIX, useChartList } from "./useChartList.js"
+import {
+    ChartBlockActions,
+    NarrativeChartBlockActions,
+} from "./chartEditing/ChartBlockActions.js"
 
 // The right-rail block inspector (stage A of the in-situ chart editing
 // plan): opened by selecting a component in the canvas, it shows typed
 // fields for the props of each block type, plus a raw-JSON editor covering
 // everything else. Edits are applied as ProseMirror attribute updates, so
 // undo/redo covers them.
-
-const GRAPHER_URL_PREFIX = "https://ourworldindata.org/grapher/"
-
-interface ChartListItem {
-    id: number
-    title: string
-    slug: string
-    isPublished: boolean
-}
-
-function useChartList(): ChartListItem[] {
-    const { admin } = useContext(AdminAppContext)
-    const chartsQuery = useQuery({
-        queryKey: ["richEditorChartList"],
-        // fail-soft: without the chart list the field still accepts pasted
-        // grapher URLs, so a failing list endpoint must not break the editor
-        queryFn: async () => {
-            const response = await admin.rawRequest(
-                "/api/charts.json",
-                undefined,
-                "GET"
-            )
-            if (!response.ok) return { charts: [] }
-            return (await response.json()) as { charts: ChartListItem[] }
-        },
-        staleTime: Infinity,
-        retry: false,
-    })
-    return chartsQuery.data?.charts ?? []
-}
 
 function ChartUrlField(props: {
     value: string
@@ -460,6 +433,10 @@ export function BlockInspector(props: {
                                 }
                             />
                         </Form.Item>
+                        <ChartBlockActions
+                            inspected={inspected}
+                            chartUrl={String(draft.url ?? "")}
+                        />
                     </>
                 )
             case "narrative-chart":
@@ -491,6 +468,10 @@ export function BlockInspector(props: {
                                 }
                             />
                         </Form.Item>
+                        <NarrativeChartBlockActions
+                            inspected={inspected}
+                            name={String(draft.name ?? "")}
+                        />
                     </>
                 )
             case "image":

--- a/adminSiteClient/richEditor/BlockInspector.tsx
+++ b/adminSiteClient/richEditor/BlockInspector.tsx
@@ -20,6 +20,7 @@ import {
 import { spansToUnformattedPlainText } from "@ourworldindata/utils"
 import { ImageSelectorModal } from "../ImageSelectorModal.js"
 import { InspectedBlock } from "./inspection.js"
+import { parseGrapherUrl } from "./grapherUrls.js"
 import { GRAPHER_URL_PREFIX, useChartList } from "./useChartList.js"
 import {
     ChartBlockActions,
@@ -37,31 +38,62 @@ function ChartUrlField(props: {
     onChange: (url: string) => void
 }): React.ReactElement {
     const charts = useChartList()
-    const [search, setSearch] = useState("")
+    // What the input currently shows. Typing must NOT write the block's url
+    // (a half-typed search would break the chart in the canvas): the value is
+    // only committed when an option is picked or a valid grapher URL is
+    // pasted; anything else is reverted on blur.
+    const [text, setText] = useState(props.value)
+
+    useEffect(() => {
+        setText(props.value)
+        // re-sync when a different block is inspected or the url is changed
+        // from elsewhere (e.g. the JSON editor)
+    }, [props.value])
+
     const options = useMemo(() => {
-        const query = search.trim().toLowerCase()
-        if (!query) return []
+        const raw = text.trim()
+        if (!raw || raw === props.value) return []
+        // pasted grapher URLs search by their slug
+        const query = (parseGrapherUrl(raw)?.slug ?? raw).toLowerCase()
         return charts
             .filter((chart) => chart.isPublished && chart.slug)
             .filter(
                 (chart) =>
-                    chart.title?.toLowerCase().includes(query) ||
-                    chart.slug?.toLowerCase().includes(query)
+                    chart.slug.toLowerCase().includes(query) ||
+                    String(chart.id) === query
             )
             .slice(0, 20)
             .map((chart) => ({
                 value: `${GRAPHER_URL_PREFIX}${chart.slug}`,
-                label: `${chart.title} (${chart.slug})`,
+                label: `${chart.slug} — ${chart.title}`,
             }))
-    }, [charts, search])
+    }, [charts, text, props.value])
+
+    const commitOrRevert = (): void => {
+        const raw = text.trim()
+        // allow clearing the block's chart explicitly
+        if (raw === "") {
+            if (props.value !== "") props.onChange("")
+            return
+        }
+        if (raw !== props.value && parseGrapherUrl(raw)) {
+            props.onChange(raw)
+            return
+        }
+        setText(props.value)
+    }
 
     return (
         <AutoComplete
-            value={props.value}
+            value={text}
             options={options}
-            showSearch={{ onSearch: setSearch }}
-            onChange={(value) => props.onChange(String(value))}
-            placeholder="Search published charts or paste a grapher URL"
+            showSearch={{ onSearch: setText }}
+            onSelect={(value) => {
+                setText(String(value))
+                props.onChange(String(value))
+            }}
+            onBlur={commitOrRevert}
+            placeholder="Search by chart slug or id, or paste a grapher URL"
         />
     )
 }

--- a/adminSiteClient/richEditor/RichEditor.scss
+++ b/adminSiteClient/richEditor/RichEditor.scss
@@ -512,8 +512,59 @@ $canvas-wide-measure: 1280px;
     overflow-y: auto;
 }
 
+// wider while the embedded chart editor tab is active: the chart editor
+// form is designed for the standalone page's 550px settings column
+.rich-editor-page__rail--wide {
+    flex: 0 0 600px;
+}
+
 .rich-editor-rail__panel {
     padding-top: 4px;
+}
+
+// ── embedded chart editor (rail "Chart editor" tab) ─────────────────────────
+
+.chart-editor-embedded {
+    display: flex;
+    flex-direction: column;
+    // scroll the form inside the rail so header/warning stay put
+    max-height: calc(100vh - 190px);
+
+    .innerForm {
+        overflow-y: auto;
+        flex-grow: 1;
+    }
+
+    .SaveButtons {
+        padding: 16px 8px;
+        border-top: 1px solid #e5e1d8;
+    }
+}
+
+.chart-editor-embedded__header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 8px;
+    padding: 4px 0 8px;
+}
+
+.chart-editor-embedded__title {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.chart-editor-embedded__warning {
+    margin-bottom: 8px;
+}
+
+.chart-editor-embedded__loading {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 24px 0;
+    color: #8a8577;
 }
 
 .rich-comment-highlight {
@@ -663,10 +714,26 @@ $canvas-wide-measure: 1280px;
     }
 }
 
+.rich-atom-block--narrow {
+    max-width: $canvas-text-measure;
+}
+
 .rich-atom-block__chart-frame {
     display: block;
     width: 100%;
     border: none;
+}
+
+// container for the live in-page <Grapher> (charts render as real grapher
+// components in the canvas, not iframes)
+.rich-atom-block__grapher {
+    position: relative;
+
+    figure[data-grapher-src],
+    .GrapherComponent {
+        width: 100%;
+        height: 100%;
+    }
 }
 
 .rich-atom-block__placeholder,

--- a/adminSiteClient/richEditor/RichEditorPage.tsx
+++ b/adminSiteClient/richEditor/RichEditorPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useContext, useEffect, useRef, useState } from "react"
-import { RouteComponentProps } from "react-router-dom"
+import { RouteComponentProps, useHistory } from "react-router-dom"
 import {
     Alert,
     Button,
@@ -52,6 +52,9 @@ import {
     replaceSelectedBlockWithCursor,
     selectionBlockKey,
 } from "./inspection.js"
+import { ChartEditingContext } from "./chartEditing/ChartEditingContext.js"
+import { useChartEditingState } from "./chartEditing/useChartEditingState.js"
+import { EmbeddedChartEditorPanel } from "./chartEditing/EmbeddedChartEditorPanel.js"
 
 type SaveState =
     | { kind: "saved"; at: Date | null }
@@ -183,6 +186,35 @@ function RichEditorPageForId(props: { id: string }): React.ReactElement {
     // rebuilt when the selection moves to a different block
     const inspectedKeyRef = useRef<string | null>(null)
     const [railTab, setRailTab] = useState("settings")
+    const history = useHistory()
+    // Rebuild the inspector from the live selection. Needed when a block's
+    // node type changed under an unchanged selection (converting a chart
+    // block to a narrative chart) — TipTap emits no selectionUpdate then.
+    const syncInspector = useCallback(() => {
+        const editor = editorRef.current
+        if (!editor) return
+        const key = selectionBlockKey(editor)
+        inspectedKeyRef.current = key
+        setInspected(key ? inspectedBlockFromSelection(editor) : null)
+    }, [])
+    const chartEditing = useChartEditingState({
+        admin,
+        tiptapEditor: editorInstance,
+        history,
+        onSessionOpened: () => {
+            syncInspector()
+            setRailTab("chart")
+        },
+        onSessionClosed: () =>
+            setRailTab((current) =>
+                current === "chart"
+                    ? inspectedKeyRef.current
+                        ? "block"
+                        : "settings"
+                    : current
+            ),
+    })
+    const chartEditingSession = chartEditing.contextValue.session
     // set while the replace-or-insert-below dialog is open (a palette item
     // was clicked while a component was selected)
     const [pendingInsert, setPendingInsert] =
@@ -581,169 +613,223 @@ function RichEditorPageForId(props: { id: string }): React.ReactElement {
                     />
                 )}
 
-                <div className="rich-editor-page__workspace">
-                    <aside className="rich-editor-page__palette">
-                        <h4>Insert</h4>
-                        {paletteItems.map((item) => (
-                            <button
-                                key={item.key}
-                                type="button"
-                                className="rich-editor-page__palette-item"
-                                title={item.description}
-                                onClick={() => {
-                                    const editor = editorRef.current
-                                    if (!editor) return
-                                    // with a component selected, ask whether
-                                    // to replace it or insert below it
-                                    if (selectionBlockKey(editor)) {
-                                        setPendingInsert(item)
-                                        return
-                                    }
-                                    runInsertItem(item)
+                <ChartEditingContext.Provider value={chartEditing.contextValue}>
+                    <div className="rich-editor-page__workspace">
+                        <aside className="rich-editor-page__palette">
+                            <h4>Insert</h4>
+                            {paletteItems.map((item) => (
+                                <button
+                                    key={item.key}
+                                    type="button"
+                                    className="rich-editor-page__palette-item"
+                                    title={item.description}
+                                    onClick={() => {
+                                        const editor = editorRef.current
+                                        if (!editor) return
+                                        // with a component selected, ask whether
+                                        // to replace it or insert below it
+                                        if (selectionBlockKey(editor)) {
+                                            setPendingInsert(item)
+                                            return
+                                        }
+                                        runInsertItem(item)
+                                    }}
+                                >
+                                    <span className="rich-editor-page__palette-glyph">
+                                        {item.glyph}
+                                    </span>
+                                    {item.title}
+                                </button>
+                            ))}
+                            <p className="rich-editor-page__palette-hint">
+                                Tip: type <code>/</code> in the text to insert
+                                blocks without leaving the keyboard.
+                            </p>
+                        </aside>
+                        <div className="rich-editor-page__canvas-col">
+                            <FormatToolbar
+                                editor={editorInstance}
+                                selectionVersion={selectionVersion}
+                            />
+                            <InlineTitleField
+                                key={`title-${id}`}
+                                gdocId={id}
+                                title={title}
+                                getBaseRevisionId={() =>
+                                    baseRevisionIdRef.current
+                                }
+                                onSaved={(revisionId, newTitle) => {
+                                    baseRevisionIdRef.current = revisionId
+                                    setDocTitle(newTitle)
                                 }}
-                            >
-                                <span className="rich-editor-page__palette-glyph">
-                                    {item.glyph}
-                                </span>
-                                {item.title}
-                            </button>
-                        ))}
-                        <p className="rich-editor-page__palette-hint">
-                            Tip: type <code>/</code> in the text to insert
-                            blocks without leaving the keyboard.
-                        </p>
-                    </aside>
-                    <div className="rich-editor-page__canvas-col">
-                        <FormatToolbar
-                            editor={editorInstance}
-                            selectionVersion={selectionVersion}
-                        />
-                        <InlineTitleField
-                            key={`title-${id}`}
-                            gdocId={id}
-                            title={title}
-                            getBaseRevisionId={() => baseRevisionIdRef.current}
-                            onSaved={(revisionId, newTitle) => {
-                                baseRevisionIdRef.current = revisionId
-                                setDocTitle(newTitle)
-                            }}
-                        />
-                        <RichEditor
-                            initialBody={gdoc.content.body ?? []}
-                            editorRef={editorRef}
-                            requestImageRef={requestImageRef}
-                            onDirty={onDirty}
-                            docType={docType}
-                            onCreate={setEditorInstance}
-                            onSelectionChange={(editor) => {
-                                setHasTextSelection(
-                                    hasTextRangeSelection(editor)
-                                )
-                                setSelectionVersion((version) => version + 1)
-                                // selecting a component (via its hover
-                                // border or body) opens it in the right rail
-                                const key = selectionBlockKey(editor)
-                                if (key === inspectedKeyRef.current) return
-                                inspectedKeyRef.current = key
-                                const block =
-                                    inspectedBlockFromSelection(editor)
-                                setInspected(block)
-                                setRailTab((current) =>
-                                    block
-                                        ? "block"
-                                        : current === "block"
-                                          ? "settings"
-                                          : current
-                                )
-                            }}
-                        />
-                    </div>
-                    <aside className="rich-editor-page__rail">
-                        <Tabs
-                            size="small"
-                            activeKey={railTab}
-                            onChange={setRailTab}
-                            items={[
-                                ...(inspected
-                                    ? [
-                                          {
-                                              key: "block",
-                                              label: "Block",
-                                              children: (
-                                                  <BlockInspector
-                                                      inspected={inspected}
-                                                      onClose={closeInspector}
-                                                  />
-                                              ),
-                                          },
-                                      ]
-                                    : []),
-                                {
-                                    key: "settings",
-                                    label: "Settings",
-                                    children: docType ? (
-                                        <SettingsPanel
-                                            gdocId={id}
-                                            docType={docType}
-                                            published={isPublished}
-                                            content={gdoc.content}
-                                            slug={docSlug ?? gdoc.slug}
-                                            getBaseRevisionId={() =>
-                                                baseRevisionIdRef.current
-                                            }
-                                            onSaved={(revisionId, values) => {
-                                                baseRevisionIdRef.current =
-                                                    revisionId
-                                                setDocTitle(values.title)
-                                                setDocSlug(values.slug)
-                                                void queryClient.invalidateQueries(
-                                                    {
-                                                        queryKey: [
-                                                            "richEditorRevisions",
-                                                            id,
-                                                        ],
-                                                    }
-                                                )
-                                            }}
-                                        />
-                                    ) : null,
-                                },
-                                {
-                                    key: "comments",
-                                    label: threads.some(
-                                        (thread) => thread.status !== "resolved"
+                            />
+                            <RichEditor
+                                initialBody={gdoc.content.body ?? []}
+                                editorRef={editorRef}
+                                requestImageRef={requestImageRef}
+                                onDirty={onDirty}
+                                docType={docType}
+                                onCreate={setEditorInstance}
+                                onSelectionChange={(editor) => {
+                                    setHasTextSelection(
+                                        hasTextRangeSelection(editor)
                                     )
-                                        ? `Comments (${
-                                              threads.filter(
-                                                  (thread) =>
-                                                      thread.status !==
-                                                      "resolved"
-                                              ).length
-                                          })`
-                                        : "Comments",
-                                    children: (
-                                        <CommentsPanel
-                                            gdocId={id}
-                                            threads={threads}
-                                            editor={editorInstance}
-                                            hasTextSelection={hasTextSelection}
-                                            onThreadsChanged={() =>
-                                                void queryClient.invalidateQueries(
-                                                    {
-                                                        queryKey: [
-                                                            "richEditorComments",
-                                                            id,
-                                                        ],
-                                                    }
-                                                )
-                                            }
-                                        />
-                                    ),
-                                },
-                            ]}
-                        />
-                    </aside>
-                </div>
+                                    setSelectionVersion(
+                                        (version) => version + 1
+                                    )
+                                    // selecting a component (via its hover
+                                    // border or body) opens it in the right rail
+                                    const key = selectionBlockKey(editor)
+                                    if (key === inspectedKeyRef.current) return
+                                    inspectedKeyRef.current = key
+                                    const block =
+                                        inspectedBlockFromSelection(editor)
+                                    setInspected(block)
+                                    const selectionPos =
+                                        editor.state.selection.from
+                                    setRailTab((current) => {
+                                        // while the embedded chart editor is open,
+                                        // interacting with its own block (or
+                                        // deselecting) must not switch tabs
+                                        if (
+                                            current === "chart" &&
+                                            (!block ||
+                                                chartEditingSession?.blockPos ===
+                                                    selectionPos)
+                                        )
+                                            return current
+                                        return block
+                                            ? "block"
+                                            : current === "block"
+                                              ? "settings"
+                                              : current
+                                    })
+                                }}
+                            />
+                        </div>
+                        <aside
+                            className={
+                                "rich-editor-page__rail" +
+                                (railTab === "chart" && chartEditingSession
+                                    ? " rich-editor-page__rail--wide"
+                                    : "")
+                            }
+                        >
+                            <Tabs
+                                size="small"
+                                activeKey={railTab}
+                                onChange={setRailTab}
+                                items={[
+                                    ...(inspected
+                                        ? [
+                                              {
+                                                  key: "block",
+                                                  label: "Block",
+                                                  children: (
+                                                      <BlockInspector
+                                                          inspected={inspected}
+                                                          onClose={
+                                                              closeInspector
+                                                          }
+                                                      />
+                                                  ),
+                                              },
+                                          ]
+                                        : []),
+                                    ...(chartEditingSession
+                                        ? [
+                                              {
+                                                  key: "chart",
+                                                  label: "Chart editor",
+                                                  children: (
+                                                      <EmbeddedChartEditorPanel
+                                                          session={
+                                                              chartEditingSession
+                                                          }
+                                                          environment={
+                                                              chartEditing.environment
+                                                          }
+                                                          onClose={() =>
+                                                              void chartEditing.contextValue.closeSession()
+                                                          }
+                                                      />
+                                                  ),
+                                              },
+                                          ]
+                                        : []),
+                                    {
+                                        key: "settings",
+                                        label: "Settings",
+                                        children: docType ? (
+                                            <SettingsPanel
+                                                gdocId={id}
+                                                docType={docType}
+                                                published={isPublished}
+                                                content={gdoc.content}
+                                                slug={docSlug ?? gdoc.slug}
+                                                getBaseRevisionId={() =>
+                                                    baseRevisionIdRef.current
+                                                }
+                                                onSaved={(
+                                                    revisionId,
+                                                    values
+                                                ) => {
+                                                    baseRevisionIdRef.current =
+                                                        revisionId
+                                                    setDocTitle(values.title)
+                                                    setDocSlug(values.slug)
+                                                    void queryClient.invalidateQueries(
+                                                        {
+                                                            queryKey: [
+                                                                "richEditorRevisions",
+                                                                id,
+                                                            ],
+                                                        }
+                                                    )
+                                                }}
+                                            />
+                                        ) : null,
+                                    },
+                                    {
+                                        key: "comments",
+                                        label: threads.some(
+                                            (thread) =>
+                                                thread.status !== "resolved"
+                                        )
+                                            ? `Comments (${
+                                                  threads.filter(
+                                                      (thread) =>
+                                                          thread.status !==
+                                                          "resolved"
+                                                  ).length
+                                              })`
+                                            : "Comments",
+                                        children: (
+                                            <CommentsPanel
+                                                gdocId={id}
+                                                threads={threads}
+                                                editor={editorInstance}
+                                                hasTextSelection={
+                                                    hasTextSelection
+                                                }
+                                                onThreadsChanged={() =>
+                                                    void queryClient.invalidateQueries(
+                                                        {
+                                                            queryKey: [
+                                                                "richEditorComments",
+                                                                id,
+                                                            ],
+                                                        }
+                                                    )
+                                                }
+                                            />
+                                        ),
+                                    },
+                                ]}
+                            />
+                        </aside>
+                    </div>
+                </ChartEditingContext.Provider>
 
                 <RevisionsDrawer
                     id={id}

--- a/adminSiteClient/richEditor/chartEditing/ChartBlockActions.tsx
+++ b/adminSiteClient/richEditor/chartEditing/ChartBlockActions.tsx
@@ -1,0 +1,207 @@
+import { useContext, useState } from "react"
+import * as _ from "lodash-es"
+import { Button, Popconfirm, Space, Typography, message } from "antd"
+import { useQueryClient } from "@tanstack/react-query"
+import { NARRATIVE_CHART_PROPS_TO_OMIT } from "@ourworldindata/types"
+import { AdminAppContext } from "../../AdminAppContext.js"
+import { NarrativeChartNameModal } from "../../NarrativeChartNameModal.js"
+import { InspectedBlock } from "../inspection.js"
+import { parseGrapherUrl } from "../grapherUrls.js"
+import { useChartList } from "../useChartList.js"
+import { useChartEditing } from "./ChartEditingContext.js"
+import { useNarrativeChartInfo } from "./useNarrativeChartInfo.js"
+
+// In-situ chart editing entry points in the block inspector (stage B of the
+// plan): edit the parent chart or a narrative chart in the rail's embedded
+// chart editor, or derive a new narrative chart from the embedded chart.
+
+/** Actions for a selected `chart` block */
+export function ChartBlockActions(props: {
+    inspected: InspectedBlock
+    chartUrl: string
+}): React.ReactElement | null {
+    const { inspected, chartUrl } = props
+    const { admin } = useContext(AdminAppContext)
+    const queryClient = useQueryClient()
+    const chartEditing = useChartEditing()
+    const charts = useChartList()
+    const [nameModalOpen, setNameModalOpen] = useState(false)
+    const [nameError, setNameError] = useState<string | undefined>(undefined)
+
+    const parsedUrl = parseGrapherUrl(chartUrl)
+    const chart = parsedUrl
+        ? charts.find((item) => item.slug === parsedUrl.slug)
+        : undefined
+
+    if (!parsedUrl) return null
+
+    const unresolvedHint = !chart
+        ? charts.length
+            ? "This chart couldn’t be matched to an editable chart (redirected slugs aren’t supported yet) — use the full chart editor instead."
+            : "Loading the chart list…"
+        : undefined
+
+    const openEditor = (): void => {
+        const blockPos = inspected.getPos()
+        if (!chart || blockPos === null) return
+        void chartEditing.openChartSession({
+            chartId: chart.id,
+            slug: parsedUrl.slug,
+            blockPos,
+        })
+    }
+
+    const createNarrativeChart = async (name: string): Promise<void> => {
+        if (!chart) return
+        try {
+            const fullConfig = await admin.getJSON(
+                `/api/charts/${chart.id}.config.json`
+            )
+            const response = await admin.requestJSON(
+                "/api/narrative-charts",
+                {
+                    type: "chart",
+                    name,
+                    parentChartId: chart.id,
+                    config: _.omit(fullConfig, NARRATIVE_CHART_PROPS_TO_OMIT),
+                },
+                "POST"
+            )
+            if (!response.success) {
+                setNameError(response.errorMsg as string)
+                return
+            }
+            setNameModalOpen(false)
+            const blockPos = inspected.convertToNarrativeChart?.(name) ?? null
+            await queryClient.invalidateQueries({
+                queryKey: ["richEditorNarrativeChart", name],
+            })
+            if (blockPos !== null) {
+                await chartEditing.openNarrativeChartSession({
+                    narrativeChartId: response.narrativeChartId as number,
+                    name,
+                    blockPos,
+                })
+            } else {
+                void message.warning(
+                    "Narrative chart created, but the block could not be converted"
+                )
+            }
+        } catch (error) {
+            console.error(error)
+            void message.error("Couldn’t create the narrative chart")
+        }
+    }
+
+    return (
+        <div className="rich-editor-inspector__chart-actions">
+            <Space orientation="vertical" style={{ width: "100%" }}>
+                <Space wrap>
+                    <Popconfirm
+                        title="Edit the chart itself?"
+                        description={
+                            <div style={{ maxWidth: 320 }}>
+                                Changes affect the chart everywhere it appears —
+                                its grapher page and every article that embeds
+                                it. To customize it only for this article,
+                                create a narrative chart instead.
+                            </div>
+                        }
+                        okText="Edit chart"
+                        onConfirm={openEditor}
+                        disabled={!chart}
+                    >
+                        <Button
+                            size="small"
+                            disabled={!chart}
+                            loading={chartEditing.isOpeningSession}
+                        >
+                            Edit chart…
+                        </Button>
+                    </Popconfirm>
+                    <Button
+                        size="small"
+                        type="primary"
+                        ghost
+                        disabled={!chart}
+                        onClick={() => {
+                            setNameError(undefined)
+                            setNameModalOpen(true)
+                        }}
+                    >
+                        Create narrative chart…
+                    </Button>
+                    {chart && (
+                        <a
+                            href={`/admin/charts/${chart.id}/edit`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                        >
+                            Open in full editor
+                        </a>
+                    )}
+                </Space>
+                {unresolvedHint && (
+                    <Typography.Text type="secondary">
+                        {unresolvedHint}
+                    </Typography.Text>
+                )}
+            </Space>
+            <NarrativeChartNameModal
+                isOpen={nameModalOpen}
+                initialName={parsedUrl.slug}
+                errorMsg={nameError}
+                onSubmit={createNarrativeChart}
+                onCancel={() => setNameModalOpen(false)}
+            />
+        </div>
+    )
+}
+
+/** Actions for a selected `narrative-chart` block */
+export function NarrativeChartBlockActions(props: {
+    inspected: InspectedBlock
+    name: string
+}): React.ReactElement | null {
+    const { inspected, name } = props
+    const chartEditing = useChartEditing()
+    const { info, isLoading } = useNarrativeChartInfo(name)
+
+    if (!name) return null
+
+    const openEditor = (): void => {
+        const blockPos = inspected.getPos()
+        if (!info || blockPos === null) return
+        void chartEditing.openNarrativeChartSession({
+            narrativeChartId: info.id,
+            name,
+            blockPos,
+        })
+    }
+
+    return (
+        <div className="rich-editor-inspector__chart-actions">
+            <Space wrap>
+                <Button
+                    size="small"
+                    type="primary"
+                    ghost
+                    disabled={!info}
+                    loading={isLoading || chartEditing.isOpeningSession}
+                    onClick={openEditor}
+                >
+                    Edit narrative chart…
+                </Button>
+                {info && (
+                    <a
+                        href={`/admin/narrative-charts/${info.id}/edit`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        Open in full editor
+                    </a>
+                )}
+            </Space>
+        </div>
+    )
+}

--- a/adminSiteClient/richEditor/chartEditing/ChartEditingContext.tsx
+++ b/adminSiteClient/richEditor/chartEditing/ChartEditingContext.tsx
@@ -1,0 +1,76 @@
+import { createContext, useContext } from "react"
+import type { GrapherState } from "@ourworldindata/grapher"
+import type { EmbeddedEditorHost } from "./EmbeddedChartEditorHosts.js"
+
+/**
+ * An in-situ chart editing session: the embedded chart editor in the right
+ * rail is editing the chart of one specific block on the canvas. The block's
+ * NodeView renders the session's live grapherState (so form edits update the
+ * chart in place) instead of fetching the saved config.
+ */
+export interface ChartEditingSession {
+    kind: "chart" | "narrative-chart"
+    /**
+     * Current ProseMirror position of the block being edited; remapped
+     * whenever the doc changes, null once the block was deleted.
+     */
+    blockPos: number | null
+    /** chart slug (chart blocks) or narrative chart name, as a sanity check */
+    identity: string
+    /** fully initialized editor host (editor is constructed before a session is exposed) */
+    host: EmbeddedEditorHost
+}
+
+export interface OpenChartSessionArgs {
+    chartId: number
+    slug: string
+    blockPos: number
+}
+
+export interface OpenNarrativeChartSessionArgs {
+    narrativeChartId: number
+    name: string
+    blockPos: number
+}
+
+export interface ChartEditingContextValue {
+    session: ChartEditingSession | null
+    /** true while a session is being opened (configs are fetching) */
+    isOpeningSession: boolean
+    openChartSession: (args: OpenChartSessionArgs) => Promise<void>
+    openNarrativeChartSession: (
+        args: OpenNarrativeChartSessionArgs
+    ) => Promise<void>
+    closeSession: () => Promise<void>
+}
+
+export const ChartEditingContext = createContext<ChartEditingContextValue>({
+    session: null,
+    isOpeningSession: false,
+    openChartSession: async () => undefined,
+    openNarrativeChartSession: async () => undefined,
+    closeSession: async () => undefined,
+})
+
+export function useChartEditing(): ChartEditingContextValue {
+    return useContext(ChartEditingContext)
+}
+
+/**
+ * The live grapher state to render for the block at the given position, if
+ * an editing session is active for exactly this block.
+ */
+export function useEditingSessionGrapherState(args: {
+    getPos: () => number | undefined
+    kind: "chart" | "narrative-chart"
+    identity: string
+}): GrapherState | undefined {
+    const { session } = useChartEditing()
+    if (!session || session.kind !== args.kind) return undefined
+    if (session.blockPos === null || session.blockPos !== args.getPos())
+        return undefined
+    // position matching is authoritative; the identity check only guards
+    // against stale positions after unexpected doc changes
+    if (session.identity !== args.identity) return undefined
+    return session.host.editor?.grapherState
+}

--- a/adminSiteClient/richEditor/chartEditing/EmbeddedChartEditorHosts.ts
+++ b/adminSiteClient/richEditor/chartEditing/EmbeddedChartEditorHosts.ts
@@ -117,9 +117,7 @@ export class EmbeddedChartEditorHost implements ChartEditorManager {
     }
 }
 
-export class EmbeddedNarrativeChartEditorHost
-    implements NarrativeChartEditorManager
-{
+export class EmbeddedNarrativeChartEditorHost implements NarrativeChartEditorManager {
     readonly embedded = true
     admin: Admin
     history: History

--- a/adminSiteClient/richEditor/chartEditing/EmbeddedChartEditorHosts.ts
+++ b/adminSiteClient/richEditor/chartEditing/EmbeddedChartEditorHosts.ts
@@ -1,0 +1,186 @@
+import { observable, runInAction, makeObservable } from "mobx"
+import type { History } from "history"
+import {
+    GrapherInterface,
+    ChartRedirect,
+    DbChartTagJoin,
+    type AnalyticsGrapherViewWithRank,
+} from "@ourworldindata/types"
+import { Admin } from "../../Admin.js"
+import { ChartEditor, ChartEditorManager, Log } from "../../ChartEditor.js"
+import {
+    NarrativeChartEditor,
+    NarrativeChartEditorManager,
+} from "../../NarrativeChartEditor.js"
+import { References } from "../../AbstractChartEditor.js"
+import {
+    GDP_PER_CAPITA_CATALOG_PATH,
+    POPULATION_CATALOG_PATH,
+} from "../../constants.js"
+
+// Managers for chart editors embedded in the rich editor's right rail.
+// Unlike the standalone editor pages (which fetch piecemeal while the page
+// shows a loading blocker), a host fetches everything in init() and only
+// constructs its editor once the data is there — an editing session is
+// handed to React fully initialized.
+
+export class EmbeddedChartEditorHost implements ChartEditorManager {
+    readonly embedded = true
+    admin: Admin
+    chartId: number
+
+    patchConfig: GrapherInterface = {}
+    parentConfig: GrapherInterface | undefined = undefined
+    isInheritanceEnabled: boolean | undefined = undefined
+    variableIdsByCatalogPath: Record<string, number | null> | undefined =
+        undefined
+
+    // saveGrapher unshifts into logs, and EditorReferencesTab pushes into
+    // redirects, so both must be observable arrays
+    logs: Log[] = []
+    references: References | undefined = undefined
+    redirects: ChartRedirect[] = []
+    views: AnalyticsGrapherViewWithRank | undefined = undefined
+    tags: DbChartTagJoin[] | undefined = undefined
+    availableTags: DbChartTagJoin[] | undefined = undefined
+    forceDatapage: boolean | undefined = undefined
+
+    editor: ChartEditor | undefined = undefined
+
+    constructor(admin: Admin, chartId: number) {
+        makeObservable(this, {
+            patchConfig: observable.ref,
+            parentConfig: observable.ref,
+            isInheritanceEnabled: observable.ref,
+            variableIdsByCatalogPath: observable.ref,
+            logs: observable,
+            references: observable,
+            redirects: observable,
+            views: observable,
+            tags: observable,
+            availableTags: observable,
+            forceDatapage: observable.ref,
+            editor: observable.ref,
+        })
+        this.admin = admin
+        this.chartId = chartId
+    }
+
+    /** fetch everything the editor's tabs need, then construct the editor */
+    async init(): Promise<void> {
+        const { admin, chartId } = this
+        const [
+            patchConfig,
+            parent,
+            settings,
+            logs,
+            refs,
+            redirects,
+            views,
+            tags,
+            availableTags,
+            variableIdsByCatalogPath,
+        ] = await Promise.all([
+            admin.getJSON(`/api/charts/${chartId}.patchConfig.json`),
+            admin.getJSON(`/api/charts/${chartId}.parent.json`),
+            admin.getJSON(`/api/charts/${chartId}.settings.json`),
+            admin.getJSON(`/api/charts/${chartId}.logs.json`),
+            admin.getJSON(`/api/charts/${chartId}.references.json`),
+            admin.getJSON(`/api/charts/${chartId}.redirects.json`),
+            admin.getJSON(`/api/charts/${chartId}.views.json`),
+            admin.getJSON(`/api/charts/${chartId}.tags.json`),
+            admin.getJSON(`/api/tags.json`),
+            admin.getJSON<Record<string, number | null>>(
+                "/api/variables.latestByCatalogPath.json",
+                {
+                    catalogPaths: [
+                        GDP_PER_CAPITA_CATALOG_PATH,
+                        POPULATION_CATALOG_PATH,
+                    ].join(","),
+                }
+            ),
+        ])
+        runInAction(() => {
+            this.patchConfig = patchConfig
+            this.parentConfig = parent?.config
+            this.isInheritanceEnabled = parent?.isActive ?? true
+            this.forceDatapage = settings?.forceDatapage ?? false
+            this.logs = logs?.logs ?? []
+            this.references = refs?.references
+            this.redirects = redirects?.redirects ?? []
+            this.views = views?.views
+            this.tags = tags?.tags
+            this.availableTags = availableTags?.tags
+            this.variableIdsByCatalogPath = variableIdsByCatalogPath
+            this.editor = new ChartEditor({ manager: this })
+        })
+    }
+}
+
+export class EmbeddedNarrativeChartEditorHost
+    implements NarrativeChartEditorManager
+{
+    readonly embedded = true
+    admin: Admin
+    history: History
+    narrativeChartId: number
+
+    name: string | undefined = undefined
+    nameError: string | undefined = undefined
+    configId: string | undefined = undefined
+    parentChartConfigId: string | undefined = undefined
+    parentUrl: string | null = null
+    references: References | undefined = undefined
+
+    patchConfig: GrapherInterface = {}
+    parentConfig: GrapherInterface = {}
+    isInheritanceEnabled: boolean | undefined = true
+
+    editor: NarrativeChartEditor | undefined = undefined
+
+    constructor(admin: Admin, narrativeChartId: number, history: History) {
+        makeObservable(this, {
+            name: observable.ref,
+            configId: observable.ref,
+            parentUrl: observable.ref,
+            references: observable,
+            patchConfig: observable.ref,
+            parentConfig: observable.ref,
+            editor: observable.ref,
+        })
+        this.admin = admin
+        this.narrativeChartId = narrativeChartId
+        this.history = history
+    }
+
+    onNameChange(_value: string): void {
+        // the name is not editable once the narrative chart is created
+        return undefined
+    }
+
+    /** fetch the narrative chart's configs, then construct the editor */
+    async init(): Promise<void> {
+        const { admin, narrativeChartId } = this
+        const [data, refs] = await Promise.all([
+            admin.getJSON(
+                `/api/narrative-charts/${narrativeChartId}.config.json`
+            ),
+            admin.getJSON(
+                `/api/narrative-charts/${narrativeChartId}.references.json`
+            ),
+        ])
+        runInAction(() => {
+            this.name = data.name
+            this.configId = data.chartConfigId
+            this.patchConfig = data.configPatch
+            this.parentConfig = data.parentConfigFull
+            this.parentUrl = data.parentUrl
+            this.references = refs?.references
+            this.editor = new NarrativeChartEditor({ manager: this })
+        })
+    }
+}
+
+export type EmbeddedEditorHost =
+    | EmbeddedChartEditorHost
+    | EmbeddedNarrativeChartEditorHost

--- a/adminSiteClient/richEditor/chartEditing/EmbeddedChartEditorPanel.tsx
+++ b/adminSiteClient/richEditor/chartEditing/EmbeddedChartEditorPanel.tsx
@@ -1,0 +1,89 @@
+import { observer } from "mobx-react"
+import { Alert, Button, Space, Spin } from "antd"
+import { AbstractChartEditor } from "../../AbstractChartEditor.js"
+import { getFullReferencesCount } from "../../ChartEditor.js"
+import { ChartEditorEnvironment } from "../../ChartEditorEnvironment.js"
+import { ChartEditorSettingsPanel } from "../../ChartEditorSettingsPanel.js"
+import { ChartEditingSession } from "./ChartEditingContext.js"
+import { EmbeddedChartEditorHost } from "./EmbeddedChartEditorHosts.js"
+
+/**
+ * The right-rail "Chart editor" tab: the full chart editor form (its own
+ * tabs as a second level) bound to the chart of the session's canvas block,
+ * which renders the live preview in place.
+ */
+export const EmbeddedChartEditorPanel = observer(
+    function EmbeddedChartEditorPanel(props: {
+        session: ChartEditingSession
+        environment: ChartEditorEnvironment<AbstractChartEditor> | null
+        onClose: () => void
+    }): React.ReactElement {
+        const { session, environment } = props
+        const { host } = session
+        const editor = host.editor
+
+        const isParentChart = session.kind === "chart"
+        const fullEditorUrl = isParentChart
+            ? `/admin/charts/${(host as EmbeddedChartEditorHost).chartId}/edit`
+            : `/admin/narrative-charts/${
+                  (host as Exclude<typeof host, EmbeddedChartEditorHost>)
+                      .narrativeChartId
+              }/edit`
+
+        return (
+            <div className="chart-editor-embedded">
+                <div className="chart-editor-embedded__header">
+                    <strong className="chart-editor-embedded__title">
+                        {isParentChart
+                            ? (editor?.grapherState.title ?? session.identity)
+                            : session.identity}
+                    </strong>
+                    <Space size="small">
+                        <a
+                            href={fullEditorUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                        >
+                            Open in full editor
+                        </a>
+                        <Button size="small" onClick={props.onClose}>
+                            Close
+                        </Button>
+                    </Space>
+                </div>
+                {isParentChart && (
+                    <Alert
+                        type="warning"
+                        showIcon
+                        className="chart-editor-embedded__warning"
+                        title="You are editing the chart itself"
+                        description={`Saved changes appear on its grapher page and everywhere it is embedded${
+                            editor?.references
+                                ? ` (${getFullReferencesCount(editor.references)} references)`
+                                : ""
+                        }. To customize the chart only for this article, create a narrative chart instead.`}
+                    />
+                )}
+                {session.kind === "narrative-chart" && (
+                    <Alert
+                        type="info"
+                        showIcon
+                        className="chart-editor-embedded__warning"
+                        title="Narrative chart"
+                        description="Changes only affect this narrative chart, not its parent."
+                    />
+                )}
+                {editor && environment?.isReady ? (
+                    <ChartEditorSettingsPanel
+                        editor={editor}
+                        environment={environment}
+                    />
+                ) : (
+                    <div className="chart-editor-embedded__loading">
+                        <Spin /> Loading editor…
+                    </div>
+                )}
+            </div>
+        )
+    }
+)

--- a/adminSiteClient/richEditor/chartEditing/useChartEditingState.ts
+++ b/adminSiteClient/richEditor/chartEditing/useChartEditingState.ts
@@ -1,0 +1,259 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { observable, runInAction, type IObservableValue } from "mobx"
+import { Modal, message } from "antd"
+import type { Editor } from "@tiptap/core"
+import type { History } from "history"
+import { useQueryClient } from "@tanstack/react-query"
+import { AbstractChartEditor } from "../../AbstractChartEditor.js"
+import { ChartEditorEnvironment } from "../../ChartEditorEnvironment.js"
+import { Admin } from "../../Admin.js"
+import {
+    EmbeddedChartEditorHost,
+    EmbeddedNarrativeChartEditorHost,
+} from "./EmbeddedChartEditorHosts.js"
+import {
+    ChartEditingContextValue,
+    ChartEditingSession,
+    OpenChartSessionArgs,
+    OpenNarrativeChartSessionArgs,
+} from "./ChartEditingContext.js"
+
+function confirmDiscard(): Promise<boolean> {
+    return new Promise((resolve) => {
+        Modal.confirm({
+            title: "Discard unsaved chart changes?",
+            content:
+                "The chart you are editing has unsaved changes that will be lost.",
+            okText: "Discard",
+            okButtonProps: { danger: true },
+            onOk: () => resolve(true),
+            onCancel: () => resolve(false),
+        })
+    })
+}
+
+/**
+ * State for in-situ chart editing sessions: opening the embedded editor for
+ * a block's parent chart or narrative chart, keeping the target block's
+ * position mapped through document changes, guarding unsaved changes, and
+ * refreshing the canvas' config caches when a session ends.
+ *
+ * Also owns the (lazily created, page-lifetime) ChartEditorEnvironment that
+ * the embedded editor form needs — its dataset/variable database is heavy
+ * and fetched at most once per page.
+ */
+export function useChartEditingState(args: {
+    admin: Admin
+    tiptapEditor: Editor | null
+    history: History
+    /** called when a session opens/closes, to switch the rail tab */
+    onSessionOpened: () => void
+    onSessionClosed: () => void
+}): {
+    contextValue: ChartEditingContextValue
+    environment: ChartEditorEnvironment<AbstractChartEditor> | null
+} {
+    const { admin, tiptapEditor, history } = args
+    const queryClient = useQueryClient()
+    const [session, setSession] = useState<ChartEditingSession | null>(null)
+    const [isOpeningSession, setIsOpeningSession] = useState(false)
+
+    const sessionRef = useRef(session)
+    sessionRef.current = session
+
+    // The active host, held in a MobX box so the environment's reactions can
+    // track session changes (a plain ref would leave the second session's
+    // editor without its config: the editor→updateGrapher reaction would
+    // never re-fire).
+    const hostBoxRef = useRef<IObservableValue<
+        EmbeddedChartEditorHost | EmbeddedNarrativeChartEditorHost | null
+    > | null>(null)
+    hostBoxRef.current ??= observable.box(null, { deep: false })
+    const hostBox = hostBoxRef.current
+
+    const onSessionOpenedRef = useRef(args.onSessionOpened)
+    onSessionOpenedRef.current = args.onSessionOpened
+    const onSessionClosedRef = useRef(args.onSessionClosed)
+    onSessionClosedRef.current = args.onSessionClosed
+
+    // The environment (editor database, DoD details, validation) is shared by
+    // all sessions on this page. Created on first use, disposed on unmount.
+    const [environment, setEnvironment] =
+        useState<ChartEditorEnvironment<AbstractChartEditor> | null>(null)
+    const environmentRef = useRef(environment)
+    environmentRef.current = environment
+
+    const ensureEnvironment = useCallback((): void => {
+        if (environmentRef.current) return
+        const env = new ChartEditorEnvironment<AbstractChartEditor>({
+            manager: {
+                admin,
+                // the environment always follows the active session's editor
+                get editor(): AbstractChartEditor {
+                    return hostBox.get()?.editor as AbstractChartEditor
+                },
+            },
+        })
+        env.start()
+        environmentRef.current = env
+        setEnvironment(env)
+    }, [admin, hostBox])
+
+    useEffect(() => {
+        return () => {
+            environmentRef.current?.dispose()
+            sessionRef.current?.host.editor?.dispose()
+        }
+    }, [])
+
+    // Keep the target block's position mapped through document changes
+    useEffect(() => {
+        if (!tiptapEditor) return undefined
+        const onTransaction = ({
+            transaction,
+        }: {
+            transaction: { docChanged: boolean; mapping: any }
+        }): void => {
+            if (!transaction.docChanged) return
+            setSession((prev) => {
+                if (!prev || prev.blockPos === null) return prev
+                const result = transaction.mapping.mapResult(prev.blockPos)
+                const blockPos = result.deleted ? null : result.pos
+                if (blockPos === prev.blockPos) return prev
+                return { ...prev, blockPos }
+            })
+        }
+        tiptapEditor.on("transaction", onTransaction)
+        return () => {
+            tiptapEditor.off("transaction", onTransaction)
+        }
+    }, [tiptapEditor])
+
+    const invalidateChartCaches = useCallback(async (): Promise<void> => {
+        // refetch saved configs so the canvas shows what was saved
+        await Promise.all([
+            queryClient.invalidateQueries({
+                queryKey: ["richEditorGrapherConfig"],
+            }),
+            queryClient.invalidateQueries({
+                queryKey: ["richEditorGrapherConfigByUuid"],
+            }),
+            queryClient.invalidateQueries({
+                queryKey: ["richEditorNarrativeChart"],
+            }),
+        ])
+    }, [queryClient])
+
+    /** true when it's OK to proceed (no unsaved changes, or user discarded) */
+    const guardUnsavedChanges = useCallback(async (): Promise<boolean> => {
+        const current = sessionRef.current
+        if (!current?.host.editor?.isModified) return true
+        return confirmDiscard()
+    }, [])
+
+    const replaceSession = useCallback(
+        async (next: ChartEditingSession): Promise<void> => {
+            sessionRef.current?.host.editor?.dispose()
+            runInAction(() => hostBox.set(next.host))
+            setSession(next)
+            onSessionOpenedRef.current()
+        },
+        [hostBox]
+    )
+
+    const openChartSession = useCallback(
+        async (openArgs: OpenChartSessionArgs): Promise<void> => {
+            if (!(await guardUnsavedChanges())) return
+            setIsOpeningSession(true)
+            try {
+                ensureEnvironment()
+                const host = new EmbeddedChartEditorHost(
+                    admin,
+                    openArgs.chartId
+                )
+                await host.init()
+                await replaceSession({
+                    kind: "chart",
+                    blockPos: openArgs.blockPos,
+                    identity: openArgs.slug,
+                    host,
+                })
+            } catch (error) {
+                console.error(error)
+                void message.error("Couldn’t open the chart editor")
+            } finally {
+                setIsOpeningSession(false)
+            }
+        },
+        [admin, ensureEnvironment, guardUnsavedChanges, replaceSession]
+    )
+
+    const openNarrativeChartSession = useCallback(
+        async (openArgs: OpenNarrativeChartSessionArgs): Promise<void> => {
+            if (!(await guardUnsavedChanges())) return
+            setIsOpeningSession(true)
+            try {
+                ensureEnvironment()
+                const host = new EmbeddedNarrativeChartEditorHost(
+                    admin,
+                    openArgs.narrativeChartId,
+                    history
+                )
+                await host.init()
+                await replaceSession({
+                    kind: "narrative-chart",
+                    blockPos: openArgs.blockPos,
+                    identity: openArgs.name,
+                    host,
+                })
+            } catch (error) {
+                console.error(error)
+                void message.error("Couldn’t open the narrative chart editor")
+            } finally {
+                setIsOpeningSession(false)
+            }
+        },
+        [admin, ensureEnvironment, guardUnsavedChanges, history, replaceSession]
+    )
+
+    const closeSession = useCallback(async (): Promise<void> => {
+        if (!sessionRef.current) return
+        if (!(await guardUnsavedChanges())) return
+        sessionRef.current.host.editor?.dispose()
+        runInAction(() => hostBox.set(null))
+        setSession(null)
+        onSessionClosedRef.current()
+        await invalidateChartCaches()
+    }, [guardUnsavedChanges, hostBox, invalidateChartCaches])
+
+    // Warn before leaving the page with unsaved chart edits (the article body
+    // autosaves, but chart edits only persist via the editor's save button)
+    useEffect(() => {
+        const onBeforeUnload = (event: BeforeUnloadEvent): void => {
+            if (sessionRef.current?.host.editor?.isModified) {
+                event.preventDefault()
+            }
+        }
+        window.addEventListener("beforeunload", onBeforeUnload)
+        return () => window.removeEventListener("beforeunload", onBeforeUnload)
+    }, [])
+
+    const contextValue = useMemo<ChartEditingContextValue>(
+        () => ({
+            session,
+            isOpeningSession,
+            openChartSession,
+            openNarrativeChartSession,
+            closeSession,
+        }),
+        [
+            session,
+            isOpeningSession,
+            openChartSession,
+            openNarrativeChartSession,
+            closeSession,
+        ]
+    )
+
+    return { contextValue, environment }
+}

--- a/adminSiteClient/richEditor/chartEditing/useNarrativeChartInfo.ts
+++ b/adminSiteClient/richEditor/chartEditing/useNarrativeChartInfo.ts
@@ -1,0 +1,33 @@
+import { useContext } from "react"
+import { useQuery } from "@tanstack/react-query"
+import {
+    RichEditorNarrativeChartInfo,
+    RichEditorResolveReferencesResponse,
+} from "../../../adminShared/RichEditorTypes.js"
+import { AdminAppContext } from "../../AdminAppContext.js"
+
+/**
+ * Resolved info (incl. numeric id, parent slug, config id) for a narrative
+ * chart by name. Shared by the canvas NodeView and the block inspector;
+ * invalidated when an embedded editing session saves and closes.
+ */
+export function useNarrativeChartInfo(name: string): {
+    info: RichEditorNarrativeChartInfo | null | undefined
+    isLoading: boolean
+} {
+    const { admin } = useContext(AdminAppContext)
+    const infoQuery = useQuery({
+        queryKey: ["richEditorNarrativeChart", name],
+        queryFn: async () => {
+            const response = (await admin.requestJSON(
+                "/api/editor/resolveReferences",
+                { narrativeChartNames: [name] },
+                "POST"
+            )) as unknown as RichEditorResolveReferencesResponse
+            return response.narrativeCharts[name] ?? null
+        },
+        enabled: !!name,
+        staleTime: Infinity,
+    })
+    return { info: infoQuery.data, isLoading: infoQuery.isLoading }
+}

--- a/adminSiteClient/richEditor/grapherUrls.ts
+++ b/adminSiteClient/richEditor/grapherUrls.ts
@@ -1,0 +1,13 @@
+/** slug + query string of a grapher chart URL, or null for anything else */
+export function parseGrapherUrl(
+    url: string
+): { slug: string; queryStr: string } | null {
+    try {
+        const parsed = new URL(url)
+        const match = parsed.pathname.match(/\/grapher\/([^/]+)\/?$/)
+        if (!match) return null
+        return { slug: decodeURIComponent(match[1]), queryStr: parsed.search }
+    } catch {
+        return null
+    }
+}

--- a/adminSiteClient/richEditor/inspection.test.ts
+++ b/adminSiteClient/richEditor/inspection.test.ts
@@ -1,0 +1,83 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from "vitest"
+import { Editor } from "@tiptap/core"
+import { NodeSelection } from "@tiptap/pm/state"
+import { OwidEnrichedGdocBlock } from "@ourworldindata/types"
+import { getRichEditorBaseExtensions } from "./extensions.js"
+import { enrichedBlocksToPmDoc } from "./serialization/serialization.js"
+import { pmNodeNames } from "./serialization/pmJson.js"
+import { convertSelectedChartBlockToNarrativeChart } from "./inspection.js"
+
+const chartBlock: OwidEnrichedGdocBlock = {
+    type: "chart",
+    url: "https://ourworldindata.org/grapher/life-expectancy",
+    size: "narrow",
+    height: "700",
+    caption: [{ spanType: "span-simple-text", text: "A caption" }],
+    parseErrors: [],
+} as OwidEnrichedGdocBlock
+
+function makeEditorWithSelectedChart(): Editor {
+    const editor = new Editor({
+        extensions: getRichEditorBaseExtensions(),
+        content: enrichedBlocksToPmDoc([chartBlock]),
+    })
+    editor.commands.setNodeSelection(0)
+    return editor
+}
+
+describe("convertSelectedChartBlockToNarrativeChart", () => {
+    it("converts the selected chart block, preserving embed options", () => {
+        const editor = makeEditorWithSelectedChart()
+
+        const pos = convertSelectedChartBlockToNarrativeChart(
+            editor,
+            "my-narrative-chart"
+        )
+        expect(pos).toBe(0)
+
+        const node = editor.state.doc.nodeAt(0)
+        expect(node?.type.name).toBe(pmNodeNames.narrativeChart)
+        expect(node?.attrs.props).toEqual({
+            name: "my-narrative-chart",
+            size: "narrow",
+            height: "700",
+            caption: [{ spanType: "span-simple-text", text: "A caption" }],
+        })
+
+        // the block stays selected so the inspector remains open
+        const selection = editor.state.selection
+        expect(selection).toBeInstanceOf(NodeSelection)
+        expect(selection.from).toBe(0)
+
+        // the conversion is a normal transaction, so undo restores the chart
+        editor.commands.undo()
+        const restored = editor.state.doc.nodeAt(0)
+        expect(restored?.type.name).toBe(pmNodeNames.chart)
+        expect(restored?.attrs.props).toEqual({
+            url: "https://ourworldindata.org/grapher/life-expectancy",
+            size: "narrow",
+            height: "700",
+            caption: [{ spanType: "span-simple-text", text: "A caption" }],
+        })
+
+        editor.destroy()
+    })
+
+    it("does nothing when the selection is not a chart block", () => {
+        const editor = new Editor({
+            extensions: getRichEditorBaseExtensions(),
+            content: enrichedBlocksToPmDoc([
+                {
+                    type: "text",
+                    value: [{ spanType: "span-simple-text", text: "hi" }],
+                    parseErrors: [],
+                } as OwidEnrichedGdocBlock,
+            ]),
+        })
+        expect(
+            convertSelectedChartBlockToNarrativeChart(editor, "nope")
+        ).toBeNull()
+        editor.destroy()
+    })
+})

--- a/adminSiteClient/richEditor/inspection.test.ts
+++ b/adminSiteClient/richEditor/inspection.test.ts
@@ -26,7 +26,7 @@ function makeEditorWithSelectedChart(): Editor {
     return editor
 }
 
-describe("convertSelectedChartBlockToNarrativeChart", () => {
+describe(convertSelectedChartBlockToNarrativeChart, () => {
     it("converts the selected chart block, preserving embed options", () => {
         const editor = makeEditorWithSelectedChart()
 

--- a/adminSiteClient/richEditor/inspection.ts
+++ b/adminSiteClient/richEditor/inspection.ts
@@ -33,8 +33,18 @@ export interface InspectedBlock {
     props: Record<string, unknown>
     updateProps: (props: Record<string, unknown>) => void
     deleteBlock: () => void
+    /**
+     * Current ProseMirror position of the inspected block (re-read from the
+     * live selection), or null when the selection moved elsewhere
+     */
+    getPos: () => number | null
     /** Structural commands, set only for the selected table block */
     tableCommands?: InspectedTableCommands
+    /**
+     * Convert this block into a narrative-chart block referencing the given
+     * name; set only for chart blocks. Returns the block's position.
+     */
+    convertToNarrativeChart?: (name: string) => number | null
 }
 
 const nodeNameToPropsAtomBlockType = Object.fromEntries(
@@ -126,6 +136,16 @@ export function inspectedBlockFromSelection(
         editor.chain().focus().deleteSelection().run()
     }
 
+    const getPos = (): number | null => {
+        const current = editor.state.selection
+        if (
+            !(current instanceof NodeSelection) ||
+            current.node.type.name !== nodeType
+        )
+            return null
+        return current.from
+    }
+
     const propsAtomBlockType = nodeNameToPropsAtomBlockType[nodeType]
     if (propsAtomBlockType) {
         return {
@@ -138,6 +158,16 @@ export function inspectedBlockFromSelection(
                 props: newProps,
             })),
             deleteBlock,
+            getPos,
+            ...(nodeType === pmNodeNames.chart
+                ? {
+                      convertToNarrativeChart: (name: string) =>
+                          convertSelectedChartBlockToNarrativeChart(
+                              editor,
+                              name
+                          ),
+                  }
+                : {}),
         }
     }
 
@@ -152,6 +182,7 @@ export function inspectedBlockFromSelection(
                 (_attrs, newProps) => newProps
             ),
             deleteBlock,
+            getPos,
             ...(nodeType === pmNodeNames.tableBlock
                 ? { tableCommands: buildTableCommands(editor) }
                 : {}),
@@ -167,6 +198,7 @@ export function inspectedBlockFromSelection(
             props: (block ?? {}) as Record<string, unknown>,
             updateProps: () => undefined,
             deleteBlock,
+            getPos,
         }
     }
 
@@ -179,6 +211,7 @@ export function inspectedBlockFromSelection(
             props: {},
             updateProps: () => undefined,
             deleteBlock,
+            getPos,
         }
     }
 
@@ -295,6 +328,51 @@ export function replaceSelectedBlockWithCursor(editor: Editor): boolean {
         .insertContentAt(pos, { type: pmNodeNames.paragraph })
         .setTextSelection(pos + 1)
         .run()
+}
+
+/**
+ * Convert the currently selected `chart` block into a `narrative-chart`
+ * block referencing the given narrative chart, carrying over the embed
+ * options (size, height, caption). Legal because both nodes are leaf atoms
+ * with a single `props` attr. Returns the block's position, or null when
+ * the selection is not a chart block. Undoable like any other transaction
+ * (though undo does not delete the created narrative chart).
+ */
+export function convertSelectedChartBlockToNarrativeChart(
+    editor: Editor,
+    name: string
+): number | null {
+    const selection = editor.state.selection
+    if (
+        !(selection instanceof NodeSelection) ||
+        selection.node.type.name !== pmNodeNames.chart
+    )
+        return null
+    const pos = selection.from
+    const chartProps = (selection.node.attrs.props ?? {}) as {
+        size?: string
+        height?: string
+        caption?: unknown
+    }
+    const props: Record<string, unknown> = {
+        name,
+        size: chartProps.size ?? "wide",
+    }
+    if (chartProps.height !== undefined) props.height = chartProps.height
+    if (chartProps.caption !== undefined) props.caption = chartProps.caption
+    const applied = editor
+        .chain()
+        .command(({ tr, state }) => {
+            tr.setNodeMarkup(
+                pos,
+                state.schema.nodes[pmNodeNames.narrativeChart],
+                { props }
+            )
+            return true
+        })
+        .setNodeSelection(pos)
+        .run()
+    return applied ? pos : null
 }
 
 /**

--- a/adminSiteClient/richEditor/nodeViews/AtomBlockViews.tsx
+++ b/adminSiteClient/richEditor/nodeViews/AtomBlockViews.tsx
@@ -1,5 +1,4 @@
-import { useContext, useEffect, useRef, useState } from "react"
-import { useQuery } from "@tanstack/react-query"
+import { useEffect, useRef, useState } from "react"
 import { NodeViewProps, NodeViewWrapper } from "@tiptap/react"
 import {
     EnrichedBlockAllCharts,
@@ -12,9 +11,12 @@ import {
     Span,
 } from "@ourworldindata/types"
 import { spansToUnformattedPlainText } from "@ourworldindata/utils"
-import { RichEditorResolveReferencesResponse } from "../../../adminShared/RichEditorTypes.js"
-import { AdminAppContext } from "../../AdminAppContext.js"
+import { GRAPHER_DYNAMIC_CONFIG_URL } from "../../../settings/clientSettings.js"
+import { useEditingSessionGrapherState } from "../chartEditing/ChartEditingContext.js"
+import { useNarrativeChartInfo } from "../chartEditing/useNarrativeChartInfo.js"
+import { parseGrapherUrl } from "../grapherUrls.js"
 import { BlockFrame } from "./BlockFrame.js"
+import { LiveChartEmbed } from "./LiveChartEmbed.js"
 
 // NodeViews for the atom blocks whose `props` attr carries the enriched
 // block verbatim. They render a preview with a shared BlockFrame chrome:
@@ -29,14 +31,15 @@ function BlockChrome(props: {
     nodeViewProps: NodeViewProps
     blockType: string
     summary: string
+    narrow?: boolean
     children?: React.ReactNode
 }): React.ReactElement {
     const { nodeViewProps, blockType, summary, children } = props
     return (
         <NodeViewWrapper
             className={`rich-atom-block rich-atom-block--${blockType}${
-                nodeViewProps.selected ? " rich-block--selected" : ""
-            }`}
+                props.narrow ? " rich-atom-block--narrow" : ""
+            }${nodeViewProps.selected ? " rich-block--selected" : ""}`}
         >
             <BlockFrame
                 nodeViewProps={nodeViewProps}
@@ -51,6 +54,8 @@ function BlockChrome(props: {
 /** Renders its children only once the wrapper has scrolled near the viewport */
 function LazyVisible(props: {
     height: number
+    /** render immediately, e.g. while an editing session owns this block */
+    forceVisible?: boolean
     children: React.ReactNode
 }): React.ReactElement {
     const ref = useRef<HTMLDivElement | null>(null)
@@ -72,7 +77,7 @@ function LazyVisible(props: {
     }, [visible])
     return (
         <div ref={ref} style={{ minHeight: props.height }}>
-            {visible ? (
+            {visible || props.forceVisible ? (
                 props.children
             ) : (
                 <div
@@ -98,29 +103,61 @@ export function ChartBlockView(props: NodeViewProps): React.ReactElement {
         "type"
     >
     const url = chart.url ?? ""
+    const grapherUrl = parseGrapherUrl(url)
+    const height = Number(chart.height) || CHART_FRAME_HEIGHT
+
+    const liveGrapherState = useEditingSessionGrapherState({
+        getPos: props.getPos,
+        kind: "chart",
+        identity: grapherUrl?.slug ?? "",
+    })
+
+    let contents: React.ReactNode
+    if (grapherUrl) {
+        contents = (
+            <LazyVisible height={height} forceVisible={!!liveGrapherState}>
+                <LiveChartEmbed
+                    configUrl={`${GRAPHER_DYNAMIC_CONFIG_URL}/${grapherUrl.slug}.config.json${grapherUrl.queryStr}`}
+                    queryKey={[
+                        "richEditorGrapherConfig",
+                        grapherUrl.slug,
+                        grapherUrl.queryStr,
+                    ]}
+                    queryStr={grapherUrl.queryStr}
+                    height={height}
+                    liveGrapherState={liveGrapherState}
+                />
+            </LazyVisible>
+        )
+    } else if (url) {
+        // not a grapher chart (e.g. an explorer) — keep the iframe preview
+        contents = (
+            <LazyVisible height={height}>
+                <iframe
+                    className="rich-atom-block__chart-frame"
+                    src={url}
+                    title={url}
+                    loading="lazy"
+                    style={{ height }}
+                />
+            </LazyVisible>
+        )
+    } else {
+        contents = (
+            <div className="rich-atom-block__empty">
+                Select this block to pick a chart in the right rail
+            </div>
+        )
+    }
+
     return (
         <BlockChrome
             nodeViewProps={props}
             blockType="chart"
             summary={url.replace(/^https?:\/\/[^/]+/, "") || "no chart chosen"}
+            narrow={chart.size === "narrow"}
         >
-            {url ? (
-                <LazyVisible height={CHART_FRAME_HEIGHT}>
-                    <iframe
-                        className="rich-atom-block__chart-frame"
-                        src={url}
-                        title={url}
-                        loading="lazy"
-                        style={{
-                            height: Number(chart.height) || CHART_FRAME_HEIGHT,
-                        }}
-                    />
-                </LazyVisible>
-            ) : (
-                <div className="rich-atom-block__empty">
-                    Select this block to pick a chart in the right rail
-                </div>
-            )}
+            {contents}
             {chart.caption && (
                 <figcaption className="rich-atom-block__caption">
                     {captionText(chart.caption)}
@@ -133,57 +170,45 @@ export function ChartBlockView(props: NodeViewProps): React.ReactElement {
 export function NarrativeChartBlockView(
     props: NodeViewProps
 ): React.ReactElement {
-    const { admin } = useContext(AdminAppContext)
     const chart = getBlockProps(props) as unknown as Omit<
         EnrichedBlockNarrativeChart,
         "type"
     >
     const name = chart.name ?? ""
+    const height = Number(chart.height) || CHART_FRAME_HEIGHT
 
-    const infoQuery = useQuery({
-        queryKey: ["richEditorNarrativeChart", name],
-        queryFn: async () => {
-            const response = (await admin.requestJSON(
-                "/api/editor/resolveReferences",
-                { narrativeChartNames: [name] },
-                "POST"
-            )) as unknown as RichEditorResolveReferencesResponse
-            return response.narrativeCharts[name] ?? null
-        },
-        enabled: !!name,
-        staleTime: Infinity,
+    const { info, isLoading } = useNarrativeChartInfo(name)
+
+    const liveGrapherState = useEditingSessionGrapherState({
+        getPos: props.getPos,
+        kind: "narrative-chart",
+        identity: name,
     })
-    const info = infoQuery.data
-
-    let frameUrl: string | undefined
-    if (info) {
-        const params = new URLSearchParams(
-            info.queryParamsForParentChart as Record<string, string>
-        )
-        frameUrl = `https://ourworldindata.org/grapher/${info.parentChartSlug}?${params.toString()}`
-    }
 
     return (
         <BlockChrome
             nodeViewProps={props}
             blockType="narrative-chart"
             summary={info ? `${name} — ${info.title}` : name || "no chart"}
+            narrow={chart.size === "narrow"}
         >
-            {frameUrl ? (
-                <LazyVisible height={CHART_FRAME_HEIGHT}>
-                    <iframe
-                        className="rich-atom-block__chart-frame"
-                        src={frameUrl}
-                        title={name}
-                        loading="lazy"
-                        style={{
-                            height: Number(chart.height) || CHART_FRAME_HEIGHT,
-                        }}
+            {info ? (
+                <LazyVisible height={height} forceVisible={!!liveGrapherState}>
+                    <LiveChartEmbed
+                        // the narrative chart's own config already encodes
+                        // tab/selection, so no query string is applied
+                        configUrl={`${GRAPHER_DYNAMIC_CONFIG_URL}/by-uuid/${info.chartConfigId}.config.json`}
+                        queryKey={[
+                            "richEditorGrapherConfigByUuid",
+                            info.chartConfigId,
+                        ]}
+                        height={height}
+                        liveGrapherState={liveGrapherState}
                     />
                 </LazyVisible>
             ) : (
                 <div className="rich-atom-block__empty">
-                    {infoQuery.isLoading
+                    {isLoading
                         ? "Resolving narrative chart…"
                         : `Narrative chart "${name}" not found`}
                 </div>

--- a/adminSiteClient/richEditor/nodeViews/AtomBlockViews.tsx
+++ b/adminSiteClient/richEditor/nodeViews/AtomBlockViews.tsx
@@ -129,8 +129,8 @@ export function ChartBlockView(props: NodeViewProps): React.ReactElement {
                 />
             </LazyVisible>
         )
-    } else if (url) {
-        // not a grapher chart (e.g. an explorer) — keep the iframe preview
+    } else if (/^https?:\/\//i.test(url)) {
+        // a non-grapher absolute URL (e.g. an explorer) — iframe preview
         contents = (
             <LazyVisible height={height}>
                 <iframe
@@ -141,6 +141,14 @@ export function ChartBlockView(props: NodeViewProps): React.ReactElement {
                     style={{ height }}
                 />
             </LazyVisible>
+        )
+    } else if (url) {
+        // never iframe a non-absolute URL: it would resolve inside the admin
+        // and render an admin page into the block
+        contents = (
+            <div className="rich-atom-block__empty">
+                Not a valid chart URL — pick a chart in the right rail
+            </div>
         )
     } else {
         contents = (

--- a/adminSiteClient/richEditor/nodeViews/LiveChartEmbed.tsx
+++ b/adminSiteClient/richEditor/nodeViews/LiveChartEmbed.tsx
@@ -1,0 +1,123 @@
+import { useEffect, useMemo, useRef } from "react"
+import { useQuery } from "@tanstack/react-query"
+import {
+    FetchingGrapher,
+    Grapher,
+    GrapherState,
+    migrateGrapherConfigToLatestVersion,
+    useElementBounds,
+} from "@ourworldindata/grapher"
+import type { GrapherProgrammaticInterface } from "@ourworldindata/grapher"
+import {
+    ADMIN_BASE_URL,
+    BAKED_GRAPHER_URL,
+    CATALOG_URL,
+    DATA_API_URL,
+} from "../../../settings/clientSettings.js"
+
+export interface LiveChartEmbedProps {
+    /** URL to fetch the full grapher config from */
+    configUrl: string
+    /** react-query cache key for the config fetch */
+    queryKey: readonly (string | number)[]
+    /** query string (e.g. "?tab=map") applied on top of the config */
+    queryStr?: string
+    height: number
+    /**
+     * When set, an in-situ editing session owns this block: render the
+     * session's grapher state directly instead of fetching the saved config.
+     */
+    liveGrapherState?: GrapherState
+}
+
+/**
+ * A live in-page <Grapher> for the rich editor canvas (charts used to render
+ * as iframes here). Modeled on the slideshow editor's SlideGrapher: config is
+ * fetched client-side, data comes from the data API, and the chart fills the
+ * measured container bounds.
+ */
+export function LiveChartEmbed(props: LiveChartEmbedProps): React.ReactElement {
+    const containerRef = useRef<HTMLDivElement>(null)
+    const bounds = useElementBounds(containerRef)
+
+    const configQuery = useQuery({
+        queryKey: props.queryKey,
+        queryFn: async (): Promise<GrapherProgrammaticInterface> => {
+            const response = await fetch(props.configUrl)
+            if (!response.ok)
+                throw new Error(
+                    `Failed to fetch chart config (${response.status})`
+                )
+            const config = await response.json()
+            return migrateGrapherConfigToLatestVersion(config)
+        },
+        staleTime: Infinity,
+        enabled: !props.liveGrapherState,
+    })
+
+    const config = useMemo<GrapherProgrammaticInterface | undefined>(
+        () =>
+            configQuery.data
+                ? {
+                      ...configQuery.data,
+                      bakedGrapherURL: BAKED_GRAPHER_URL,
+                      adminBaseUrl: ADMIN_BASE_URL,
+                      isEmbeddedInAnOwidPage: true,
+                  }
+                : undefined,
+        [configQuery.data]
+    )
+
+    // While an editing session renders this chart, the canvas owns the
+    // grapher's bounds (the standalone editor's preview pane isn't there).
+    const liveGrapherState = props.liveGrapherState
+    useEffect(() => {
+        if (liveGrapherState && bounds) {
+            liveGrapherState.externalBounds = bounds
+        }
+    }, [liveGrapherState, bounds])
+
+    let contents: React.ReactNode
+    if (liveGrapherState) {
+        contents = <Grapher grapherState={liveGrapherState} />
+    } else if (config) {
+        contents = (
+            <FetchingGrapher
+                // remount when an invalidation refetched the config so the
+                // grapher state is rebuilt from the fresh config
+                key={configQuery.dataUpdatedAt}
+                config={config}
+                queryStr={props.queryStr}
+                dataApiUrl={DATA_API_URL}
+                catalogUrl={CATALOG_URL}
+                archiveContext={undefined}
+                externalBounds={bounds}
+            />
+        )
+    } else if (configQuery.isError) {
+        contents = (
+            <div className="rich-atom-block__empty">
+                Couldn’t load this chart’s config
+            </div>
+        )
+    } else {
+        contents = (
+            <div
+                className="rich-atom-block__placeholder"
+                style={{ height: props.height }}
+            >
+                Loading chart…
+            </div>
+        )
+    }
+
+    return (
+        <div
+            ref={containerRef}
+            className="rich-atom-block__grapher"
+            style={{ height: props.height }}
+        >
+            {contents}
+        </div>
+    )
+}

--- a/adminSiteClient/richEditor/useChartList.ts
+++ b/adminSiteClient/richEditor/useChartList.ts
@@ -1,0 +1,33 @@
+import { useContext } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { AdminAppContext } from "../AdminAppContext.js"
+
+export const GRAPHER_URL_PREFIX = "https://ourworldindata.org/grapher/"
+
+export interface ChartListItem {
+    id: number
+    title: string
+    slug: string
+    isPublished: boolean
+}
+
+export function useChartList(): ChartListItem[] {
+    const { admin } = useContext(AdminAppContext)
+    const chartsQuery = useQuery({
+        queryKey: ["richEditorChartList"],
+        // fail-soft: without the chart list the field still accepts pasted
+        // grapher URLs, so a failing list endpoint must not break the editor
+        queryFn: async () => {
+            const response = await admin.rawRequest(
+                "/api/charts.json",
+                undefined,
+                "GET"
+            )
+            if (!response.ok) return { charts: [] }
+            return (await response.json()) as { charts: ChartListItem[] }
+        },
+        staleTime: Infinity,
+        retry: false,
+    })
+    return chartsQuery.data?.charts ?? []
+}

--- a/adminSiteServer/apiRoutes/richEditor.ts
+++ b/adminSiteServer/apiRoutes/richEditor.ts
@@ -930,13 +930,24 @@ export async function resolveEditorReferences(
         narrativeChartNames = [],
     } = req.body as RichEditorResolveReferencesRequest
 
-    const [linkedCharts, images, linkedDocuments, narrativeCharts] =
+    const [linkedCharts, images, linkedDocuments, narrativeCharts, ncIdRows] =
         await Promise.all([
             loadLinkedChartsForSlugs(trx, grapherSlugs, explorerSlugs),
             filenames.length ? getImagesByFilenames(trx, filenames) : [],
             gdocIds.length ? getMinimalGdocPostsByIds(trx, gdocIds) : [],
             getNarrativeChartsInfo(trx, narrativeChartNames),
+            narrativeChartNames.length
+                ? db.knexRaw<{ id: number; name: string }>(
+                      trx,
+                      `SELECT id, name FROM narrative_charts WHERE name IN (?)`,
+                      [narrativeChartNames]
+                  )
+                : [],
         ])
+
+    const narrativeChartIdsByName = new Map(
+        ncIdRows.map((row) => [row.name, row.id])
+    )
 
     const imageMetadata: Record<string, ImageMetadata> = {}
     for (const image of images) {
@@ -954,6 +965,12 @@ export async function resolveEditorReferences(
         linkedCharts: _.keyBy(linkedCharts, "originalSlug"),
         imageMetadata,
         linkedDocuments: _.keyBy(linkedDocuments, "id"),
-        narrativeCharts: _.keyBy(narrativeCharts, "name"),
+        narrativeCharts: _.keyBy(
+            narrativeCharts.map((nc) => ({
+                ...nc,
+                id: narrativeChartIdsByName.get(nc.name) ?? 0,
+            })),
+            "name"
+        ),
     }
 }

--- a/adminSiteServer/tests/rich-editor.test.ts
+++ b/adminSiteServer/tests/rich-editor.test.ts
@@ -1,5 +1,7 @@
+import * as _ from "lodash-es"
 import { describe, expect, it } from "vitest"
 import {
+    NARRATIVE_CHART_PROPS_TO_OMIT,
     OwidGdocAuthoringMode,
     PostsGdocsCommentThreadsTableName,
     PostsGdocsDraftsTableName,
@@ -7,6 +9,7 @@ import {
     PostsGdocsTableName,
     type DbRawPostGdoc,
 } from "@ourworldindata/types"
+import { latestGrapherConfigSchema } from "@ourworldindata/grapher"
 import { getAdminTestEnv } from "./testEnv.js"
 
 const env = getAdminTestEnv()
@@ -510,6 +513,52 @@ describe("rich editor API", { timeout: 20000 }, () => {
             body: JSON.stringify({ narrativeChartNames: ["does-not-exist"] }),
         })
         expect(resolved.narrativeCharts).toEqual({})
+    })
+
+    it("resolves narrative charts with their id, slug and config id", async () => {
+        // Mirrors the rich editor's create-narrative-chart flow: create a
+        // parent chart, derive a narrative chart from its full config, then
+        // resolve it by name.
+        const chartResponse = await env.request({
+            method: "POST",
+            path: "/charts",
+            body: JSON.stringify({
+                $schema: latestGrapherConfigSchema,
+                slug: "parent-chart",
+                title: "Parent chart",
+                chartTypes: ["LineChart"],
+                isPublished: true,
+            }),
+        })
+        const parentChartId = chartResponse.chartId
+
+        const fullConfig = await env.fetchJson(
+            `/charts/${parentChartId}.config.json`
+        )
+        const created = await env.request({
+            method: "POST",
+            path: "/narrative-charts",
+            body: JSON.stringify({
+                type: "chart",
+                name: "parent-chart-nc",
+                parentChartId,
+                config: _.omit(fullConfig, NARRATIVE_CHART_PROPS_TO_OMIT),
+            }),
+        })
+        expect(created.narrativeChartId).toBeGreaterThan(0)
+
+        const resolved = await env.request({
+            method: "POST",
+            path: "/editor/resolveReferences",
+            body: JSON.stringify({
+                narrativeChartNames: ["parent-chart-nc", "does-not-exist"],
+            }),
+        })
+        const info = resolved.narrativeCharts["parent-chart-nc"]
+        expect(info.id).toBe(created.narrativeChartId)
+        expect(info.parentChartSlug).toBe("parent-chart")
+        expect(typeof info.chartConfigId).toBe("string")
+        expect(resolved.narrativeCharts["does-not-exist"]).toBeUndefined()
     })
 
     it("answers presence heartbeats", async () => {

--- a/db/tests/testHelpers.ts
+++ b/db/tests/testHelpers.ts
@@ -13,6 +13,7 @@ import {
     JobsTableName,
     MultiDimDataPagesTableName,
     MultiDimXChartConfigsTableName,
+    NarrativeChartsTableName,
     PostsGdocsCommentThreadsTableName,
     PostsGdocsCommentsTableName,
     PostsGdocsDraftsTableName,
@@ -30,6 +31,7 @@ export const TABLES_IN_USE = [
     ChartDimensionsTableName,
     ChartRevisionsTableName,
     ChartSlugRedirectsTableName, // Must come before ChartsTableName due to foreign key
+    NarrativeChartsTableName, // Must come before ChartsTableName due to foreign key
     MultiDimXChartConfigsTableName,
     MultiDimDataPagesTableName,
     ExplorerViewsTableName, // Must come before ExplorersTableName due to foreign key

--- a/rich-editing-technical-plan.md
+++ b/rich-editing-technical-plan.md
@@ -278,6 +278,17 @@ _Addendum 2 (2026-07-03)_: blockquote, callout and aside became React NodeViews 
 
 - Chart-editor engine extraction (`embedded` mode); "Customize this chart" → narrative chart creation + overlay editing (Stage B).
 
+### 10c. Status (2026-07-03): M3 built
+
+M3 shipped on `rich-editing-m3` (stacked on M2), going beyond Stage B per Daniel's call: **both parent charts and narrative charts are editable in-situ**, and the editor lives in the right rail rather than an overlay.
+
+- **Live in-canvas graphers everywhere**: chart and narrative-chart blocks render as real in-page `<Grapher>` components (via `FetchingGrapher`, configs fetched through the dynamic-config endpoints incl. `by-uuid` for narrative charts, react-query cached, block URL query params applied), replacing the M2 iframe workaround. IntersectionObserver lazy-mounting stays; non-grapher URLs (explorers) keep an iframe fallback. The site-CSS spike turned out unnecessary for this — grapher's own scoped styles coexist fine with the canvas.
+- **Editor engine extraction**: `ChartEditorEnvironment` (editor database, DoD details, validation computeds, config→grapher reactions) and `ChartEditorSettingsPanel` (tab bar + tab dispatch + save buttons) extracted from `ChartEditorView`, which is now a page shell — the four standalone editor pages are unchanged. An `embedded` manager flag disables URL `?tab=` sync; embedded save buttons hide Delete and the redundant "Save as narrative chart".
+- **Rail sessions**: selecting a chart block offers "Edit chart…" (loud this-changes-it-everywhere warning with reference count — Stage C pulled forward), "Create narrative chart…" (derives one from the parent via the existing POST, converts the block in place — undoable — and opens its editor), and full-editor link-outs; narrative-chart blocks get "Edit narrative chart…". A session opens a "Chart editor" rail tab (rail widens to fit the 550px-designed form) with the **full second-level tab set** (basic/data/text/customize/map/…/refs/export/debug). While a session is active the target block's NodeView renders the editor's live `grapherState`, so every form edit updates the chart in place at article proportions; the block's position is remapped through doc transactions (duplicate embeds of the same chart stay independent). Unsaved chart edits are guarded on session switch/close and page unload; closing invalidates the config caches so the canvas shows what was saved. The heavy editor database is fetched once per page, shared across sessions.
+- `resolveReferences` now returns narrative chart numeric ids (needed to open their editor); test-db cleanup learned about `narrative_charts`.
+
+Deviations/notes: slug→chart-id resolution uses the charts list (redirected slugs: button disabled, full editor as escape hatch); the export tab works embedded but has no static-preview pane; undoing a block conversion leaves the created narrative chart orphaned; comment marks and block drag are unaffected by live graphers. Verified: full browser flow (parent edit with live canvas update + discard guard; create-narrative-chart → convert → live edit → save → reopen), corpus still 1,173/1,173, unit (1,995) and db (85) suites green.
+
 **M4 — AI side panel** (separate detailed plan when we get there)
 
 - Command layer hardening, chat rail, Claude API proxy, suggestion/track-changes mode.


### PR DESCRIPTION
Stacked on #6687 (M2) → #6685 (M1) → #6684 (M0). Implements **Milestone 3 — In-situ chart editing** from [`rich-editing-technical-plan.md`](https://github.com/owid/owid-grapher/blob/rich-editing-m3/rich-editing-technical-plan.md) §7/§10 (status recorded in §10c). Goes beyond the planned Stage B: both **parent charts and narrative charts** are editable in-situ, and the editor lives in the right rail rather than an overlay.

## Live in-canvas graphers (iframes retired)

- `chart` and `narrative-chart` blocks render as real in-page **`<Grapher>` components** via `FetchingGrapher`: configs come from the dynamic-config endpoints (`/grapher/:slug.config.json` incl. multi-dim resolution, `by-uuid/:uuid.config.json` for narrative charts), cached in react-query so saves can invalidate them; block-URL query params (`?tab=map&country=…`) are applied. IntersectionObserver lazy-mounting stays; non-grapher URLs (explorers) keep an iframe fallback.
- `narrow`/`wide` block sizes now render at their real measures.

## Chart editor engine extraction (`embedded` mode)

- **`ChartEditorEnvironment`** (editor variable/dataset database, DoD details, validation error computeds, the config→grapher reactions) and **`ChartEditorSettingsPanel`** (tab bar + per-tab dispatch + save buttons) extracted from `ChartEditorView`, which is now a page shell (AdminLayout, `<Prompt>`, preview pane). The four standalone editor pages are **unchanged** and browser-verified (tabs + `?tab=` URL sync, save, preview bounds).
- An `embedded` flag on the editor manager disables URL tab sync; embedded save buttons hide **Delete** (would navigate away) and **Save as narrative chart** (replaced by the block-aware flow).

## In-situ editing sessions

- Selecting a **chart block** adds to its inspector: **Edit chart…** (confirm + persistent *"you are editing the chart itself — changes appear everywhere (N references)"* warning), **Create narrative chart…** (derives one from the parent via the existing create endpoint, converts the block in place — undoable — and opens its editor), and full-editor link-outs. **Narrative-chart blocks** get *Edit narrative chart…*.
- A session opens a widened **"Chart editor" rail tab** with the full second-level tab set (basic/data/text/customize/map/scatter/marimekko/revisions/refs/export/debug, as applicable per editor). While active, the target block's NodeView renders the editor's **live `grapherState`** — every form edit updates the chart in place at article proportions. The block's position is remapped through doc transactions, so duplicate embeds of the same chart stay independent.
- Unsaved chart edits are guarded on session switch, close and page unload; closing invalidates the config caches so the canvas refetches what was saved. The heavy editor database is fetched once per page and shared across sessions.
- `resolveReferences` now returns narrative chart numeric ids (needed to open their editor).

## Verification

- Playwright e2e against the dev DB covering the full flow — parent-chart session (full tabs, live in-canvas title editing, discard guard), create-narrative-chart (block conversion, live editing, save PUT, close → canvas refetch). It caught two real bugs that are fixed here: the environment's editor reaction tracked a plain ref so a *second* session never received its config (silently saving narrative charts with empty entity selections), and a stale inspector after block conversion (TipTap emits no `selectionUpdate` when the restored NodeSelection is `eq`).
- Corpus round-trip still **1,173/1,173 (100%)**; unit suite green (1,995 tests, incl. a new conversion-helper test); db suite green (85 tests, incl. a new create→resolve narrative chart test; test-db cleanup order learned about `narrative_charts`).

## Notes / deferred

- Redirected chart slugs can't be resolved to a chart id from the block URL (button disabled with a hint; full editor link-out as escape hatch).
- The export tab works embedded but has no static-preview pane (downloads fine).
- Undoing a block conversion restores the chart block but leaves the created narrative chart orphaned.
- Scoped-site-CSS spike turned out unnecessary for charts — grapher's own scoped styles coexist with the canvas; adopting `site/gdocs` components for other blocks remains open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)