### PR TITLE
🎉 🤖 expose gdocs as ArchieML over the admin API for agent editing

### DIFF
--- a/adminSiteClient/gdocsValidation.ts
+++ b/adminSiteClient/gdocsValidation.ts
@@ -5,7 +5,7 @@ import {
     OwidGdocErrorMessageType,
     OwidGdocType,
     checkIsOwidGdocType,
-    traverseEnrichedBlock,
+    getParseFindings,
     OwidGdocErrorMessageProperty,
     OwidGdoc,
     checkIsGdocPost,
@@ -74,19 +74,9 @@ function validateBody(gdoc: OwidGdoc, errors: OwidGdocErrorMessage[]) {
     if (!gdoc.content.body) {
         errors.push(getMissingContentPropertyError("body"))
     } else {
-        for (const block of gdoc.content.body) {
-            traverseEnrichedBlock(block, (block) => {
-                errors.push(
-                    ...block.parseErrors.map((parseError) => ({
-                        message: parseError.message,
-                        type: parseError.isWarning
-                            ? OwidGdocErrorMessageType.Warning
-                            : OwidGdocErrorMessageType.Error,
-                        property: "body" as const,
-                    }))
-                )
-            })
-        }
+        // Findings the parser recorded while parsing, transcribed by the same
+        // shared function the agent-facing write gate uses
+        errors.push(...getParseFindings({ body: gdoc.content.body }))
     }
 }
 
@@ -94,32 +84,8 @@ function validateRefs(
     gdoc: OwidGdocPostInterface,
     errors: OwidGdocErrorMessage[]
 ) {
-    if (gdoc.content.refs) {
-        // Errors due to refs being unused / undefined / malformed
-        if (gdoc.content.refs.errors.length) {
-            errors.push(...gdoc.content.refs.errors)
-        }
-        // Errors due to the content of the refs having parse errors
-        if (gdoc.content.refs.definitions) {
-            Object.values(gdoc.content.refs.definitions).map((definition) => {
-                definition.content.map((block) => {
-                    traverseEnrichedBlock(block, (node) => {
-                        if (node.parseErrors.length) {
-                            for (const parseError of node.parseErrors) {
-                                errors.push({
-                                    message: `Parse error in "${definition.id}" ref content: ${parseError.message}`,
-                                    property: "refs",
-                                    type: parseError.isWarning
-                                        ? OwidGdocErrorMessageType.Warning
-                                        : OwidGdocErrorMessageType.Error,
-                                })
-                            }
-                        }
-                    })
-                })
-            })
-        }
-    }
+    // Unused/undefined/malformed refs, and parse errors inside ref contents
+    errors.push(...getParseFindings({ refs: gdoc.content.refs }))
 }
 
 // Kind of arbitrary, see https://github.com/owid/owid-grapher/issues/2983

--- a/adminSiteClient/gdocsValidation.ts
+++ b/adminSiteClient/gdocsValidation.ts
@@ -5,7 +5,7 @@ import {
     OwidGdocErrorMessageType,
     OwidGdocType,
     checkIsOwidGdocType,
-    traverseEnrichedBlock,
+    getParseFindings,
     OwidGdocErrorMessageProperty,
     OwidGdoc,
     checkIsGdocPost,
@@ -15,6 +15,7 @@ import {
     OwidGdocAuthorInterface,
     getFilenameExtension,
     OwidEnrichedGdocBlock,
+    traverseEnrichedBlock,
 } from "@ourworldindata/utils"
 
 // Hostnames that are only reachable by OWID staff (e.g. because they sit
@@ -130,17 +131,11 @@ function validateBody(gdoc: OwidGdoc, errors: OwidGdocErrorMessage[]) {
     if (!gdoc.content.body) {
         errors.push(getMissingContentPropertyError("body"))
     } else {
+        // Findings the parser recorded while parsing, transcribed by the same
+        // shared function the agent-facing write gate uses
+        errors.push(...getParseFindings({ body: gdoc.content.body }))
         for (const block of gdoc.content.body) {
             traverseEnrichedBlock(block, (block) => {
-                errors.push(
-                    ...block.parseErrors.map((parseError) => ({
-                        message: parseError.message,
-                        type: parseError.isWarning
-                            ? OwidGdocErrorMessageType.Warning
-                            : OwidGdocErrorMessageType.Error,
-                        property: "body" as const,
-                    }))
-                )
                 validateEmbedUrls(block, errors)
             })
         }
@@ -151,32 +146,8 @@ function validateRefs(
     gdoc: OwidGdocPostInterface,
     errors: OwidGdocErrorMessage[]
 ) {
-    if (gdoc.content.refs) {
-        // Errors due to refs being unused / undefined / malformed
-        if (gdoc.content.refs.errors.length) {
-            errors.push(...gdoc.content.refs.errors)
-        }
-        // Errors due to the content of the refs having parse errors
-        if (gdoc.content.refs.definitions) {
-            Object.values(gdoc.content.refs.definitions).map((definition) => {
-                definition.content.map((block) => {
-                    traverseEnrichedBlock(block, (node) => {
-                        if (node.parseErrors.length) {
-                            for (const parseError of node.parseErrors) {
-                                errors.push({
-                                    message: `Parse error in "${definition.id}" ref content: ${parseError.message}`,
-                                    property: "refs",
-                                    type: parseError.isWarning
-                                        ? OwidGdocErrorMessageType.Warning
-                                        : OwidGdocErrorMessageType.Error,
-                                })
-                            }
-                        }
-                    })
-                })
-            })
-        }
-    }
+    // Unused/undefined/malformed refs, and parse errors inside ref contents
+    errors.push(...getParseFindings({ refs: gdoc.content.refs }))
 }
 
 // Kind of arbitrary, see https://github.com/owid/owid-grapher/issues/2983

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -52,6 +52,12 @@ import {
     getResearchAndWritingOrphans,
 } from "./apiRoutes/gdocs.js"
 import {
+    getGdocArchie,
+    getGdocValidation,
+    putGdocArchie,
+    createGdocFromArchie,
+} from "./apiRoutes/gdocArchie.js"
+import {
     getImagesHandler,
     postImageHandler,
     putImageHandler,
@@ -400,6 +406,17 @@ getRouteWithROTransaction(
 putRouteWithRWTransaction(apiRouter, "/gdocs/:id", createOrUpdateGdoc)
 deleteRouteWithRWTransaction(apiRouter, "/gdocs/:id", deleteGdoc)
 postRouteWithRWTransaction(apiRouter, "/gdocs/:gdocId/setTags", setGdocTags)
+// ArchieML view of a gdoc: read/replace the doc content as text, create a new
+// doc from text. Used by author-facing agents; see apiRoutes/gdocArchie.ts.
+getRouteWithROTransaction(apiRouter, "/gdocs/:id/archie", getGdocArchie)
+// RW because loading with contentSource=gdocs can sync image metadata
+getRouteNonIdempotentWithRWTransaction(
+    apiRouter,
+    "/gdocs/:id/validation",
+    getGdocValidation
+)
+putRouteWithRWTransaction(apiRouter, "/gdocs/:id/archie", putGdocArchie)
+postRouteWithRWTransaction(apiRouter, "/gdocs", createGdocFromArchie)
 
 // Data insight routes
 getRouteWithROTransaction(

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -52,6 +52,12 @@ import {
     getResearchAndWritingOrphans,
 } from "./apiRoutes/gdocs.js"
 import {
+    getGdocArchie,
+    getGdocValidation,
+    putGdocArchie,
+    createGdocFromArchie,
+} from "./apiRoutes/gdocArchie.js"
+import {
     getImagesHandler,
     postImageHandler,
     putImageHandler,
@@ -406,6 +412,17 @@ getRouteWithROTransaction(
 putRouteWithRWTransaction(apiRouter, "/gdocs/:id", createOrUpdateGdoc)
 deleteRouteWithRWTransaction(apiRouter, "/gdocs/:id", deleteGdoc)
 postRouteWithRWTransaction(apiRouter, "/gdocs/:gdocId/setTags", setGdocTags)
+// ArchieML view of a gdoc: read/replace the doc content as text, create a new
+// doc from text. Used by author-facing agents; see apiRoutes/gdocArchie.ts.
+getRouteWithROTransaction(apiRouter, "/gdocs/:id/archie", getGdocArchie)
+// RW because loading with contentSource=gdocs can sync image metadata
+getRouteNonIdempotentWithRWTransaction(
+    apiRouter,
+    "/gdocs/:id/validation",
+    getGdocValidation
+)
+putRouteWithRWTransaction(apiRouter, "/gdocs/:id/archie", putGdocArchie)
+postRouteWithRWTransaction(apiRouter, "/gdocs", createGdocFromArchie)
 
 // Data insight routes
 getRouteWithROTransaction(

--- a/adminSiteServer/apiRoutes/gdocArchie.ts
+++ b/adminSiteServer/apiRoutes/gdocArchie.ts
@@ -1,0 +1,355 @@
+import { docs as googleDocs, type docs_v1 } from "@googleapis/docs"
+import {
+    GDOCS_BASE_URL,
+    GdocsContentSource,
+    JsonError,
+    OwidGdocErrorMessage,
+    OwidGdocErrorMessageType,
+} from "@ourworldindata/types"
+import * as db from "../../db/db.js"
+import { OwidGoogleAuth } from "../../db/OwidGoogleAuth.js"
+import {
+    archieMlTextToBatchUpdates,
+    createGdocAndInsertOwidGdocPostContent,
+    deleteGdocContent,
+    owidArticleToArchieMLStringGenerator,
+} from "../../db/model/Gdoc/archieToGdoc.js"
+import {
+    joinArchieMlSkipSegments,
+    splitArchieMlSkipSegments,
+    type ArchieMlSkipSegments,
+} from "../../db/model/Gdoc/archieMlSkipBlocks.js"
+import { archieToEnriched } from "../../db/model/Gdoc/archieToEnriched.js"
+import { gdocToArchie } from "../../db/model/Gdoc/gdocToArchie.js"
+import {
+    createOrLoadGdocById,
+    getAndLoadGdocById,
+    getGdocBaseObjectById,
+    updateGdocContentOnly,
+} from "../../db/model/Gdoc/GdocFactory.js"
+import {
+    compareArchieMlContent,
+    validateArchieMl,
+    type ArchieMlValidationResult,
+} from "../../db/model/Gdoc/validateArchieMl.js"
+import { GDOCS_AGENT_DRAFTS_FOLDER } from "../../settings/serverSettings.js"
+import { getErrors } from "../../adminSiteClient/gdocsValidation.js"
+import { Request } from "../authentication.js"
+import { HandlerResponse } from "../FunctionalRouter.js"
+
+interface ArchieMlGateFailure {
+    writable: false
+    errors: OwidGdocErrorMessage[]
+    warnings: OwidGdocErrorMessage[]
+}
+
+const previewUrl = (id: string): string => `/admin/gdocs/${id}/preview`
+
+// The doc's validation report, shaped like every doc-report response:
+// errors block publishing (mirrors the admin's publish gating), warnings
+// don't. Meaning is carried by the endpoint contract: this always describes
+// a stored doc, never the submitted text.
+function docReport(adminErrors: OwidGdocErrorMessage[]): {
+    publishable: boolean
+    errors: OwidGdocErrorMessage[]
+    warnings: OwidGdocErrorMessage[]
+} {
+    const errors = adminErrors.filter(
+        (e) => e.type === OwidGdocErrorMessageType.Error
+    )
+    return {
+        publishable: errors.length === 0,
+        errors,
+        warnings: adminErrors.filter(
+            (e) => e.type !== OwidGdocErrorMessageType.Error
+        ),
+    }
+}
+const docUrl = (id: string): string => `${GDOCS_BASE_URL}/document/d/${id}/edit`
+
+async function fetchGdocDocument(
+    client: docs_v1.Docs,
+    documentId: string
+): Promise<docs_v1.Schema$Document> {
+    try {
+        const { data } = await client.documents.get({
+            documentId,
+            suggestionsViewMode: "PREVIEW_WITHOUT_SUGGESTIONS",
+        })
+        return data
+    } catch {
+        throw new JsonError(
+            `Could not fetch gdoc "${documentId}" from Google. Check the id and make sure the document is shared with the OWID service account.`,
+            404
+        )
+    }
+}
+
+function getArchieMlFromBody(req: Request): string {
+    const archieMl = req.body?.archieMl
+    if (typeof archieMl !== "string" || !archieMl.trim())
+        throw new JsonError(
+            `The request body must contain a non-empty "archieMl" string`,
+            400
+        )
+    return archieMl
+}
+
+// Validate the ArchieML, treating mid-document :skip/:ignore directives as an
+// error: their hidden content has no stable anchor after canonicalization, so
+// a wholesale replace would silently destroy it. Leading/trailing blocks are
+// fine — the write path preserves those verbatim (see archieMlSkipBlocks.ts).
+function validateWithSkipSegments(archieMl: string): {
+    validation: ArchieMlValidationResult
+    segments: ArchieMlSkipSegments
+} {
+    const segments = splitArchieMlSkipSegments(archieMl)
+    const validation = validateArchieMl(archieMl)
+    if (segments.midDocumentDirectiveLines.length > 0) {
+        validation.errors.push({
+            property: "body",
+            type: OwidGdocErrorMessageType.Error,
+            message:
+                `:skip/:ignore directive in the middle of the document ` +
+                `(line ${segments.midDocumentDirectiveLines.join(", ")}). ` +
+                `Hidden content there cannot be preserved through a full ` +
+                `replace — move it to the very top or bottom of the ` +
+                `document, or make that change by hand.`,
+        })
+        validation.valid = false
+    }
+    return { validation, segments }
+}
+
+/**
+ * GET /gdocs/:id/archie
+ *
+ * Returns the canonical ArchieML view of a Google Doc — the same derived text
+ * the ingestion pipeline parses — for agents/tools that reason over or edit a
+ * doc as text. Unlike GET /gdocs/:id?contentSource=gdocs this is
+ * side-effect-free: no images are synced and nothing is persisted.
+ */
+export async function getGdocArchie(
+    req: Request,
+    res: HandlerResponse,
+    trx: db.KnexReadonlyTransaction
+) {
+    const id = req.params.id
+    const client = googleDocs({
+        version: "v1",
+        auth: OwidGoogleAuth.getGoogleReadonlyAuth(),
+    })
+    const document = await fetchGdocDocument(client, id)
+    const { text } = await gdocToArchie(document)
+    const dbRow = await getGdocBaseObjectById(trx, id, false)
+
+    res.set("Cache-Control", "no-store")
+    return {
+        archieMl: text,
+        revisionId: document.revisionId,
+        title: document.title,
+        registered: !!dbRow,
+        published: dbRow?.published ?? false,
+    }
+}
+
+/**
+ * GET /gdocs/:id/validation
+ *
+ * The validation report for a doc, as the admin computes it: the doc is
+ * fetched fresh from Google, loaded with its DB context (which runs
+ * GdocBase.validate — images, linked documents, …), and run through the same
+ * getErrors the admin UI uses. Nothing is persisted. Same { errors, warnings }
+ * shape and meaning as the write responses.
+ */
+export async function getGdocValidation(
+    req: Request,
+    _res: HandlerResponse,
+    trx: db.KnexReadWriteTransaction
+) {
+    const id = req.params.id
+    const dbRow = await getGdocBaseObjectById(trx, id, false)
+    if (!dbRow)
+        throw new JsonError(
+            `Gdoc "${id}" is not registered in the admin. Register it first (PUT /gdocs/:id with an empty body).`,
+            404
+        )
+    const gdoc = await getAndLoadGdocById(trx, id, GdocsContentSource.Gdocs)
+    return docReport(getErrors(gdoc))
+}
+
+/**
+ * PUT /gdocs/:id/archie
+ *
+ * Replaces the entire content of an (unpublished) Google Doc with the given
+ * ArchieML, after validating it against the real ingestion pipeline. Pass
+ * `?dryRun=true` to only run the validation. `expectedRevisionId` (from a
+ * prior GET) guards against overwriting concurrent author edits.
+ */
+export async function putGdocArchie(
+    req: Request,
+    res: HandlerResponse,
+    trx: db.KnexReadWriteTransaction
+) {
+    const id = req.params.id
+    const dryRun = req.query.dryRun === "true"
+    const archieMl = getArchieMlFromBody(req)
+
+    const { validation, segments } = validateWithSkipSegments(archieMl)
+    if (!validation.valid) {
+        res.status(400)
+        return {
+            writable: false,
+            errors: validation.errors,
+            warnings: validation.warnings,
+        } satisfies ArchieMlGateFailure
+    }
+    if (dryRun)
+        return { writable: true, errors: [], warnings: validation.warnings }
+
+    const dbRow = await getGdocBaseObjectById(trx, id, false)
+    if (!dbRow)
+        throw new JsonError(
+            `Gdoc "${id}" is not registered in the admin. Register it first (PUT /gdocs/:id with an empty body).`,
+            404
+        )
+    if (dbRow.published)
+        throw new JsonError(
+            `Gdoc "${id}" is published. Refusing to overwrite a published document — its Google Doc is shared with production.`,
+            403
+        )
+
+    const expectedRevisionId = req.body?.expectedRevisionId
+    if (typeof expectedRevisionId !== "string" || !expectedRevisionId)
+        throw new JsonError(
+            `The request body must contain "expectedRevisionId" (returned by GET /gdocs/:id/archie)`,
+            400
+        )
+
+    const client = googleDocs({
+        version: "v1",
+        auth: OwidGoogleAuth.getGoogleReadWriteAuth(),
+    })
+    const before = await fetchGdocDocument(client, id)
+    if (before.revisionId !== expectedRevisionId)
+        throw new JsonError(
+            `The document changed since it was read (revision ${before.revisionId}, expected ${expectedRevisionId}). Re-read it and re-apply your edit.`,
+            409
+        )
+
+    // Wholesale replace: wipe the body, then insert the new content with real
+    // Google Docs formatting. The written text is the canonical form of the
+    // parsed content, with any leading/trailing :skip//:ignore segments from
+    // the incoming text preserved verbatim around it (their content is
+    // invisible to the parse, so this is the only way it survives).
+    const canonicalArchieMl = [
+        ...owidArticleToArchieMLStringGenerator(validation.content!),
+    ].join("\n")
+    const textToWrite = joinArchieMlSkipSegments(segments, canonicalArchieMl)
+    await deleteGdocContent(client, id)
+    await client.documents.batchUpdate({
+        documentId: id,
+        requestBody: { requests: archieMlTextToBatchUpdates(textToWrite) },
+    })
+
+    // Read back and verify at the parse level: Google normalizes bytes
+    // (style-run splits, trailing newlines), so a byte comparison would cry
+    // wolf. What must survive is the *content*. A mismatch is reported, not
+    // rolled back — the doc history still has the previous revision.
+    const after = await fetchGdocDocument(client, id)
+    const { text: readBack } = await gdocToArchie(after)
+    let verification: { identical: boolean; differingBodyBlocks?: number[] }
+    try {
+        const comparison = compareArchieMlContent(
+            validation.content!,
+            archieToEnriched(readBack)
+        )
+        verification = comparison.identical
+            ? { identical: true }
+            : {
+                  identical: false,
+                  differingBodyBlocks: comparison.differingBodyBlocks,
+              }
+    } catch {
+        verification = { identical: false }
+    }
+
+    // Re-ingest into the DB so the admin preview reflects the change. The
+    // loaded gdoc carries the admin's contextual validation (loadState runs
+    // GdocBase.validate: broken image references, links to unpublished docs,
+    // missing excerpt, …) — report it the way the admin UI would. These are
+    // about the *saved* doc: informational, not a failure of the write.
+    const gdoc = await getAndLoadGdocById(trx, id, GdocsContentSource.Gdocs)
+    await updateGdocContentOnly(trx, id, gdoc)
+
+    return {
+        ok: true,
+        revisionId: after.revisionId,
+        previewUrl: previewUrl(id),
+        verification,
+        ...docReport(getErrors(gdoc)),
+    }
+}
+
+/**
+ * POST /gdocs
+ *
+ * Creates a new Google Doc from ArchieML, registers it in the admin, and
+ * returns its ids and URLs. Pass `?dryRun=true` to only run the validation.
+ * The doc is created inside `folderId` (default: GDOCS_AGENT_DRAFTS_FOLDER) —
+ * it must be a folder shared with authors, since a doc created outside a
+ * shared folder lands in the service account's private Drive.
+ */
+export async function createGdocFromArchie(
+    req: Request,
+    res: HandlerResponse,
+    trx: db.KnexReadWriteTransaction
+) {
+    const dryRun = req.query.dryRun === "true"
+    const archieMl = getArchieMlFromBody(req)
+
+    const { validation, segments } = validateWithSkipSegments(archieMl)
+    if (segments.prefix || segments.suffix) {
+        validation.errors.push({
+            property: "body",
+            type: OwidGdocErrorMessageType.Error,
+            message:
+                "A new document should not contain :skip/:ignore directives — remove them.",
+        })
+        validation.valid = false
+    }
+    if (!validation.valid) {
+        res.status(400)
+        return {
+            writable: false,
+            errors: validation.errors,
+            warnings: validation.warnings,
+        } satisfies ArchieMlGateFailure
+    }
+    if (dryRun)
+        return { writable: true, errors: [], warnings: validation.warnings }
+
+    const folderId = req.body?.folderId || GDOCS_AGENT_DRAFTS_FOLDER
+    if (typeof folderId !== "string" || !folderId)
+        throw new JsonError(
+            `No target Drive folder: pass "folderId" or configure GDOCS_AGENT_DRAFTS_FOLDER`,
+            400
+        )
+
+    const documentId = await createGdocAndInsertOwidGdocPostContent(
+        validation.content!,
+        null,
+        folderId
+    )
+    // Registers the doc and loads it with its DB context, which runs the
+    // admin's contextual validation — reported below like the admin UI would.
+    const created = await createOrLoadGdocById(trx, documentId)
+
+    res.status(201)
+    return {
+        id: documentId,
+        docUrl: docUrl(documentId),
+        previewUrl: previewUrl(documentId),
+        ...docReport(getErrors(created)),
+    }
+}

--- a/adminSiteServer/apiRoutes/gdocArchie.ts
+++ b/adminSiteServer/apiRoutes/gdocArchie.ts
@@ -254,14 +254,21 @@ export async function putGdocArchie(
 
     // Read back and verify at the parse level: Google normalizes bytes
     // (style-run splits, trailing newlines), so a byte comparison would cry
-    // wolf. What must survive is the *content*. A mismatch is reported, not
-    // rolled back — the doc history still has the previous revision.
+    // wolf. What must survive is the *content*. The expected side is the
+    // parse of the canonical text we wrote — not the submission parse, which
+    // may contain front-matter keys the gate already warned would be dropped.
+    // A mismatch is reported, not rolled back — the doc history still has
+    // the previous revision.
     const after = await fetchGdocDocument(client, id)
     const { text: readBack } = await gdocToArchie(after)
-    let verification: { identical: boolean; differingBodyBlocks?: number[] }
+    let verification: {
+        identical: boolean
+        differingBodyBlocks?: number[]
+        differingFrontMatterKeys?: string[]
+    }
     try {
         const comparison = compareArchieMlContent(
-            validation.content!,
+            archieToEnriched(canonicalArchieMl),
             archieToEnriched(readBack)
         )
         verification = comparison.identical
@@ -269,6 +276,7 @@ export async function putGdocArchie(
             : {
                   identical: false,
                   differingBodyBlocks: comparison.differingBodyBlocks,
+                  differingFrontMatterKeys: comparison.differingFrontMatterKeys,
               }
     } catch {
         verification = { identical: false }

--- a/adminSiteServer/test-files/gdoc-archie-api-test.json
+++ b/adminSiteServer/test-files/gdoc-archie-api-test.json
@@ -1,0 +1,637 @@
+{
+    "size": 0,
+    "data": {
+        "title": "Minimal test",
+        "body": {
+            "content": [
+                {
+                    "endIndex": 1,
+                    "sectionBreak": {
+                        "sectionStyle": {
+                            "columnSeparatorStyle": "NONE",
+                            "contentDirection": "LEFT_TO_RIGHT",
+                            "sectionType": "CONTINUOUS"
+                        }
+                    }
+                },
+                {
+                    "startIndex": 1,
+                    "endIndex": 22,
+                    "paragraph": {
+                        "elements": [
+                            {
+                                "startIndex": 1,
+                                "endIndex": 22,
+                                "textRun": {
+                                    "content": "Title: Basic article\n",
+                                    "textStyle": {}
+                                }
+                            }
+                        ],
+                        "paragraphStyle": {
+                            "namedStyleType": "NORMAL_TEXT",
+                            "direction": "LEFT_TO_RIGHT"
+                        }
+                    }
+                },
+                {
+                    "startIndex": 22,
+                    "endIndex": 69,
+                    "paragraph": {
+                        "elements": [
+                            {
+                                "startIndex": 22,
+                                "endIndex": 69,
+                                "textRun": {
+                                    "content": "Subtitle: This will be shown beneath the title\n",
+                                    "textStyle": {}
+                                }
+                            }
+                        ],
+                        "paragraphStyle": {
+                            "namedStyleType": "NORMAL_TEXT",
+                            "direction": "LEFT_TO_RIGHT"
+                        }
+                    }
+                },
+                {
+                    "startIndex": 69,
+                    "endIndex": 122,
+                    "paragraph": {
+                        "elements": [
+                            {
+                                "startIndex": 69,
+                                "endIndex": 122,
+                                "textRun": {
+                                    "content": "Excerpt: This will be shown on social media previews\n",
+                                    "textStyle": {}
+                                }
+                            }
+                        ],
+                        "paragraphStyle": {
+                            "namedStyleType": "NORMAL_TEXT",
+                            "direction": "LEFT_TO_RIGHT"
+                        }
+                    }
+                },
+                {
+                    "startIndex": 122,
+                    "endIndex": 149,
+                    "paragraph": {
+                        "elements": [
+                            {
+                                "startIndex": 122,
+                                "endIndex": 149,
+                                "textRun": {
+                                    "content": "authors: Our World In Data\n",
+                                    "textStyle": {}
+                                }
+                            }
+                        ],
+                        "paragraphStyle": {
+                            "namedStyleType": "NORMAL_TEXT",
+                            "direction": "LEFT_TO_RIGHT"
+                        }
+                    }
+                },
+                {
+                    "startIndex": 149,
+                    "endIndex": 175,
+                    "paragraph": {
+                        "elements": [
+                            {
+                                "startIndex": 149,
+                                "endIndex": 175,
+                                "textRun": {
+                                    "content": "dateline: January 1, 2023\n",
+                                    "textStyle": {}
+                                }
+                            }
+                        ],
+                        "paragraphStyle": {
+                            "namedStyleType": "NORMAL_TEXT",
+                            "direction": "LEFT_TO_RIGHT"
+                        }
+                    }
+                },
+                {
+                    "startIndex": 175,
+                    "endIndex": 190,
+                    "paragraph": {
+                        "elements": [
+                            {
+                                "startIndex": 175,
+                                "endIndex": 190,
+                                "textRun": {
+                                    "content": "type: article \n",
+                                    "textStyle": {}
+                                }
+                            }
+                        ],
+                        "paragraphStyle": {
+                            "namedStyleType": "NORMAL_TEXT",
+                            "direction": "LEFT_TO_RIGHT"
+                        }
+                    }
+                },
+                {
+                    "startIndex": 190,
+                    "endIndex": 191,
+                    "paragraph": {
+                        "elements": [
+                            {
+                                "startIndex": 190,
+                                "endIndex": 191,
+                                "textRun": {
+                                    "content": "\n",
+                                    "textStyle": {}
+                                }
+                            }
+                        ],
+                        "paragraphStyle": {
+                            "namedStyleType": "NORMAL_TEXT",
+                            "direction": "LEFT_TO_RIGHT"
+                        }
+                    }
+                },
+                {
+                    "startIndex": 191,
+                    "endIndex": 199,
+                    "paragraph": {
+                        "elements": [
+                            {
+                                "startIndex": 191,
+                                "endIndex": 199,
+                                "textRun": {
+                                    "content": "[+body]\n",
+                                    "textStyle": {}
+                                }
+                            }
+                        ],
+                        "paragraphStyle": {
+                            "namedStyleType": "NORMAL_TEXT",
+                            "direction": "LEFT_TO_RIGHT"
+                        }
+                    }
+                },
+                {
+                    "startIndex": 199,
+                    "endIndex": 222,
+                    "paragraph": {
+                        "elements": [
+                            {
+                                "startIndex": 199,
+                                "endIndex": 222,
+                                "textRun": {
+                                    "content": "This is a minimal test\n",
+                                    "textStyle": {}
+                                }
+                            }
+                        ],
+                        "paragraphStyle": {
+                            "namedStyleType": "NORMAL_TEXT",
+                            "direction": "LEFT_TO_RIGHT"
+                        }
+                    }
+                },
+                {
+                    "startIndex": 222,
+                    "endIndex": 225,
+                    "paragraph": {
+                        "elements": [
+                            {
+                                "startIndex": 222,
+                                "endIndex": 225,
+                                "textRun": {
+                                    "content": "[]\n",
+                                    "textStyle": {}
+                                }
+                            }
+                        ],
+                        "paragraphStyle": {
+                            "namedStyleType": "NORMAL_TEXT",
+                            "direction": "LEFT_TO_RIGHT"
+                        }
+                    }
+                }
+            ]
+        },
+        "documentStyle": {
+            "background": {
+                "color": {}
+            },
+            "pageNumberStart": 1,
+            "marginTop": {
+                "magnitude": 72,
+                "unit": "PT"
+            },
+            "marginBottom": {
+                "magnitude": 72,
+                "unit": "PT"
+            },
+            "marginRight": {
+                "magnitude": 72,
+                "unit": "PT"
+            },
+            "marginLeft": {
+                "magnitude": 72,
+                "unit": "PT"
+            },
+            "pageSize": {
+                "height": {
+                    "magnitude": 792,
+                    "unit": "PT"
+                },
+                "width": {
+                    "magnitude": 612,
+                    "unit": "PT"
+                }
+            },
+            "marginHeader": {
+                "magnitude": 36,
+                "unit": "PT"
+            },
+            "marginFooter": {
+                "magnitude": 36,
+                "unit": "PT"
+            },
+            "useCustomHeaderFooterMargins": true,
+            "documentFormat": {
+                "documentMode": "PAGELESS"
+            }
+        },
+        "namedStyles": {
+            "styles": [
+                {
+                    "namedStyleType": "NORMAL_TEXT",
+                    "textStyle": {
+                        "bold": false,
+                        "italic": false,
+                        "underline": false,
+                        "strikethrough": false,
+                        "smallCaps": false,
+                        "backgroundColor": {},
+                        "foregroundColor": {
+                            "color": {
+                                "rgbColor": {}
+                            }
+                        },
+                        "fontSize": {
+                            "magnitude": 11,
+                            "unit": "PT"
+                        },
+                        "weightedFontFamily": {
+                            "fontFamily": "Arial",
+                            "weight": 400
+                        },
+                        "baselineOffset": "NONE"
+                    },
+                    "paragraphStyle": {
+                        "namedStyleType": "NORMAL_TEXT",
+                        "alignment": "START",
+                        "lineSpacing": 115,
+                        "direction": "LEFT_TO_RIGHT",
+                        "spacingMode": "COLLAPSE_LISTS",
+                        "spaceAbove": {
+                            "unit": "PT"
+                        },
+                        "spaceBelow": {
+                            "unit": "PT"
+                        },
+                        "borderBetween": {
+                            "color": {},
+                            "width": {
+                                "unit": "PT"
+                            },
+                            "padding": {
+                                "unit": "PT"
+                            },
+                            "dashStyle": "SOLID"
+                        },
+                        "borderTop": {
+                            "color": {},
+                            "width": {
+                                "unit": "PT"
+                            },
+                            "padding": {
+                                "unit": "PT"
+                            },
+                            "dashStyle": "SOLID"
+                        },
+                        "borderBottom": {
+                            "color": {},
+                            "width": {
+                                "unit": "PT"
+                            },
+                            "padding": {
+                                "unit": "PT"
+                            },
+                            "dashStyle": "SOLID"
+                        },
+                        "borderLeft": {
+                            "color": {},
+                            "width": {
+                                "unit": "PT"
+                            },
+                            "padding": {
+                                "unit": "PT"
+                            },
+                            "dashStyle": "SOLID"
+                        },
+                        "borderRight": {
+                            "color": {},
+                            "width": {
+                                "unit": "PT"
+                            },
+                            "padding": {
+                                "unit": "PT"
+                            },
+                            "dashStyle": "SOLID"
+                        },
+                        "indentFirstLine": {
+                            "unit": "PT"
+                        },
+                        "indentStart": {
+                            "unit": "PT"
+                        },
+                        "indentEnd": {
+                            "unit": "PT"
+                        },
+                        "keepLinesTogether": false,
+                        "keepWithNext": false,
+                        "avoidWidowAndOrphan": true,
+                        "shading": {
+                            "backgroundColor": {}
+                        },
+                        "pageBreakBefore": false
+                    }
+                },
+                {
+                    "namedStyleType": "HEADING_1",
+                    "textStyle": {
+                        "fontSize": {
+                            "magnitude": 20,
+                            "unit": "PT"
+                        }
+                    },
+                    "paragraphStyle": {
+                        "namedStyleType": "NORMAL_TEXT",
+                        "direction": "LEFT_TO_RIGHT",
+                        "spaceAbove": {
+                            "magnitude": 20,
+                            "unit": "PT"
+                        },
+                        "spaceBelow": {
+                            "magnitude": 6,
+                            "unit": "PT"
+                        },
+                        "keepLinesTogether": true,
+                        "keepWithNext": true,
+                        "pageBreakBefore": false
+                    }
+                },
+                {
+                    "namedStyleType": "HEADING_2",
+                    "textStyle": {
+                        "bold": false,
+                        "fontSize": {
+                            "magnitude": 16,
+                            "unit": "PT"
+                        }
+                    },
+                    "paragraphStyle": {
+                        "namedStyleType": "NORMAL_TEXT",
+                        "direction": "LEFT_TO_RIGHT",
+                        "spaceAbove": {
+                            "magnitude": 18,
+                            "unit": "PT"
+                        },
+                        "spaceBelow": {
+                            "magnitude": 6,
+                            "unit": "PT"
+                        },
+                        "keepLinesTogether": true,
+                        "keepWithNext": true,
+                        "pageBreakBefore": false
+                    }
+                },
+                {
+                    "namedStyleType": "HEADING_3",
+                    "textStyle": {
+                        "bold": false,
+                        "foregroundColor": {
+                            "color": {
+                                "rgbColor": {
+                                    "red": 0.2627451,
+                                    "green": 0.2627451,
+                                    "blue": 0.2627451
+                                }
+                            }
+                        },
+                        "fontSize": {
+                            "magnitude": 14,
+                            "unit": "PT"
+                        }
+                    },
+                    "paragraphStyle": {
+                        "namedStyleType": "NORMAL_TEXT",
+                        "direction": "LEFT_TO_RIGHT",
+                        "spaceAbove": {
+                            "magnitude": 16,
+                            "unit": "PT"
+                        },
+                        "spaceBelow": {
+                            "magnitude": 4,
+                            "unit": "PT"
+                        },
+                        "keepLinesTogether": true,
+                        "keepWithNext": true,
+                        "pageBreakBefore": false
+                    }
+                },
+                {
+                    "namedStyleType": "HEADING_4",
+                    "textStyle": {
+                        "foregroundColor": {
+                            "color": {
+                                "rgbColor": {
+                                    "red": 0.4,
+                                    "green": 0.4,
+                                    "blue": 0.4
+                                }
+                            }
+                        },
+                        "fontSize": {
+                            "magnitude": 12,
+                            "unit": "PT"
+                        }
+                    },
+                    "paragraphStyle": {
+                        "namedStyleType": "NORMAL_TEXT",
+                        "direction": "LEFT_TO_RIGHT",
+                        "spaceAbove": {
+                            "magnitude": 14,
+                            "unit": "PT"
+                        },
+                        "spaceBelow": {
+                            "magnitude": 4,
+                            "unit": "PT"
+                        },
+                        "keepLinesTogether": true,
+                        "keepWithNext": true,
+                        "pageBreakBefore": false
+                    }
+                },
+                {
+                    "namedStyleType": "HEADING_5",
+                    "textStyle": {
+                        "foregroundColor": {
+                            "color": {
+                                "rgbColor": {
+                                    "red": 0.4,
+                                    "green": 0.4,
+                                    "blue": 0.4
+                                }
+                            }
+                        },
+                        "fontSize": {
+                            "magnitude": 11,
+                            "unit": "PT"
+                        }
+                    },
+                    "paragraphStyle": {
+                        "namedStyleType": "NORMAL_TEXT",
+                        "direction": "LEFT_TO_RIGHT",
+                        "spaceAbove": {
+                            "magnitude": 12,
+                            "unit": "PT"
+                        },
+                        "spaceBelow": {
+                            "magnitude": 4,
+                            "unit": "PT"
+                        },
+                        "keepLinesTogether": true,
+                        "keepWithNext": true,
+                        "pageBreakBefore": false
+                    }
+                },
+                {
+                    "namedStyleType": "HEADING_6",
+                    "textStyle": {
+                        "italic": true,
+                        "foregroundColor": {
+                            "color": {
+                                "rgbColor": {
+                                    "red": 0.4,
+                                    "green": 0.4,
+                                    "blue": 0.4
+                                }
+                            }
+                        },
+                        "fontSize": {
+                            "magnitude": 11,
+                            "unit": "PT"
+                        }
+                    },
+                    "paragraphStyle": {
+                        "namedStyleType": "NORMAL_TEXT",
+                        "direction": "LEFT_TO_RIGHT",
+                        "spaceAbove": {
+                            "magnitude": 12,
+                            "unit": "PT"
+                        },
+                        "spaceBelow": {
+                            "magnitude": 4,
+                            "unit": "PT"
+                        },
+                        "keepLinesTogether": true,
+                        "keepWithNext": true,
+                        "pageBreakBefore": false
+                    }
+                },
+                {
+                    "namedStyleType": "TITLE",
+                    "textStyle": {
+                        "fontSize": {
+                            "magnitude": 26,
+                            "unit": "PT"
+                        }
+                    },
+                    "paragraphStyle": {
+                        "namedStyleType": "NORMAL_TEXT",
+                        "direction": "LEFT_TO_RIGHT",
+                        "spaceAbove": {
+                            "unit": "PT"
+                        },
+                        "spaceBelow": {
+                            "magnitude": 3,
+                            "unit": "PT"
+                        },
+                        "keepLinesTogether": true,
+                        "keepWithNext": true,
+                        "pageBreakBefore": false
+                    }
+                },
+                {
+                    "namedStyleType": "SUBTITLE",
+                    "textStyle": {
+                        "italic": false,
+                        "foregroundColor": {
+                            "color": {
+                                "rgbColor": {
+                                    "red": 0.4,
+                                    "green": 0.4,
+                                    "blue": 0.4
+                                }
+                            }
+                        },
+                        "fontSize": {
+                            "magnitude": 15,
+                            "unit": "PT"
+                        },
+                        "weightedFontFamily": {
+                            "fontFamily": "Arial",
+                            "weight": 400
+                        }
+                    },
+                    "paragraphStyle": {
+                        "namedStyleType": "NORMAL_TEXT",
+                        "direction": "LEFT_TO_RIGHT",
+                        "spaceAbove": {
+                            "unit": "PT"
+                        },
+                        "spaceBelow": {
+                            "magnitude": 16,
+                            "unit": "PT"
+                        },
+                        "keepLinesTogether": true,
+                        "keepWithNext": true,
+                        "pageBreakBefore": false
+                    }
+                }
+            ]
+        },
+        "revisionId": "archie-test-revision-1",
+        "suggestionsViewMode": "PREVIEW_WITHOUT_SUGGESTIONS",
+        "documentId": "gdoc-archie-api-test"
+    },
+    "config": {
+        "url": "https://docs.googleapis.com/v1/documents/1TZOYb5VeZXdK65yQE5u9XHPtQJ9kxudmTnEAY3vcup0?suggestionsViewMode=PREVIEW_WITHOUT_SUGGESTIONS",
+        "method": "GET",
+        "apiVersion": "",
+        "userAgentDirectives": [
+            {
+                "product": "google-api-nodejs-client",
+                "version": "8.0.2-rc.0",
+                "comment": "gzip"
+            }
+        ],
+        "headers": {},
+        "params": {
+            "suggestionsViewMode": "PREVIEW_WITHOUT_SUGGESTIONS"
+        },
+        "retry": true,
+        "responseType": "unknown"
+    },
+    "headers": {}
+}

--- a/adminSiteServer/tests/gdoc-archie.test.ts
+++ b/adminSiteServer/tests/gdoc-archie.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect } from "vitest"
+import { PostsGdocsTableName } from "@ourworldindata/types"
+import { getAdminTestEnv } from "./testEnv.js"
+
+const env = getAdminTestEnv()
+
+// Google Docs API calls are mocked to read from
+// adminSiteServer/test-files/<documentId>.json (see setupDbTest.ts)
+const FIXTURE_DOC_ID = "gdoc-archie-api-test"
+const FIXTURE_REVISION_ID = "archie-test-revision-1"
+
+const VALID_ARCHIE = `title: Archie API test
+byline: Author
+type: article
+[+body]
+Hello world
+[]
+`
+
+const INVALID_ARCHIE = `title: Archie API test
+byline: Author
+type: article
+[+body]
+{.small-chart}
+url: https://ourworldindata.org/grapher/life-expectancy
+{}
+[]
+`
+
+// env.request()/fetchJson() assert status 200, so error paths use raw fetch
+async function rawRequest(
+    method: "GET" | "POST" | "PUT",
+    path: string,
+    body?: object
+): Promise<Response> {
+    return await fetch(env.baseUrl + path, {
+        method,
+        headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${env.apiKey}`,
+        },
+        body: body ? JSON.stringify(body) : undefined,
+    })
+}
+
+async function seedGdocRow(id: string, published: boolean): Promise<void> {
+    const row = {
+        id,
+        slug: id,
+        content: JSON.stringify({ title: "Archie API test", type: "article" }),
+        published: published ? 1 : 0,
+    }
+    await env.testKnex(PostsGdocsTableName).insert(row).onConflict("id").merge()
+}
+
+describe("gdoc ArchieML API", { timeout: 20000 }, () => {
+    it("GET /gdocs/:id/archie returns the ArchieML view of the doc", async () => {
+        const json = await env.fetchJson(`/gdocs/${FIXTURE_DOC_ID}/archie`)
+        expect(typeof json.archieMl).toBe("string")
+        expect(json.archieMl.length).toBeGreaterThan(0)
+        expect(json.revisionId).toBe(FIXTURE_REVISION_ID)
+        expect(json.registered).toBe(false)
+        expect(json.published).toBe(false)
+    })
+
+    it("PUT ?dryRun=true validates without writing", async () => {
+        const res = await rawRequest(
+            "PUT",
+            `/gdocs/${FIXTURE_DOC_ID}/archie?dryRun=true`,
+            { archieMl: VALID_ARCHIE }
+        )
+        expect(res.status).toBe(200)
+        const json = await res.json()
+        expect(json.writable).toBe(true)
+        expect(json.errors).toEqual([])
+        // dry run must not create or touch any DB row
+        const row = await env
+            .testKnex(PostsGdocsTableName)
+            .where({ id: FIXTURE_DOC_ID })
+            .first()
+        expect(row).toBeUndefined()
+    })
+
+    it("PUT rejects invalid ArchieML with 400 and structured errors", async () => {
+        const res = await rawRequest(
+            "PUT",
+            `/gdocs/${FIXTURE_DOC_ID}/archie?dryRun=true`,
+            { archieMl: INVALID_ARCHIE }
+        )
+        expect(res.status).toBe(400)
+        const json = await res.json()
+        expect(json.writable).toBe(false)
+        expect(json.errors.length).toBeGreaterThan(0)
+        expect(json.errors[0].message).toContain("failed to parse")
+    })
+
+    it("PUT accepts leading/trailing :skip blocks but rejects mid-document ones", async () => {
+        const edges = `:skip\npreview link\n:endskip\n${VALID_ARCHIE}:ignore\ngraveyard\n`
+        const okRes = await rawRequest(
+            "PUT",
+            `/gdocs/${FIXTURE_DOC_ID}/archie?dryRun=true`,
+            { archieMl: edges }
+        )
+        expect(okRes.status).toBe(200)
+        expect((await okRes.json()).writable).toBe(true)
+
+        const midDoc = VALID_ARCHIE.replace(
+            "Hello world",
+            "Hello world\n:skip\nhidden draft\n:endskip\nMore text"
+        )
+        const midRes = await rawRequest(
+            "PUT",
+            `/gdocs/${FIXTURE_DOC_ID}/archie?dryRun=true`,
+            { archieMl: midDoc }
+        )
+        expect(midRes.status).toBe(400)
+        const json = await midRes.json()
+        expect(json.writable).toBe(false)
+        expect(json.errors[0].message).toContain("middle of the document")
+    })
+
+    it("POST rejects any :skip/:ignore in a new doc", async () => {
+        const res = await rawRequest("POST", `/gdocs?dryRun=true`, {
+            archieMl: `:skip\nnote\n:endskip\n${VALID_ARCHIE}`,
+        })
+        expect(res.status).toBe(400)
+        const json = await res.json()
+        expect(json.errors[0].message).toContain("should not contain")
+    })
+
+    it("PUT rejects a missing archieMl body with 400", async () => {
+        const res = await rawRequest(
+            "PUT",
+            `/gdocs/${FIXTURE_DOC_ID}/archie`,
+            {}
+        )
+        expect(res.status).toBe(400)
+    })
+
+    it("PUT refuses a doc that is not registered in the admin with 404", async () => {
+        const res = await rawRequest(
+            "PUT",
+            `/gdocs/gdoc-archie-unregistered/archie`,
+            { archieMl: VALID_ARCHIE, expectedRevisionId: "whatever" }
+        )
+        expect(res.status).toBe(404)
+    })
+
+    it("GET /gdocs/:id/validation refuses an unregistered doc with 404", async () => {
+        const res = await rawRequest(
+            "GET",
+            `/gdocs/gdoc-archie-unregistered/validation`
+        )
+        expect(res.status).toBe(404)
+    })
+
+    it("PUT refuses a published doc with 403", async () => {
+        await seedGdocRow(FIXTURE_DOC_ID, true)
+        const res = await rawRequest("PUT", `/gdocs/${FIXTURE_DOC_ID}/archie`, {
+            archieMl: VALID_ARCHIE,
+            expectedRevisionId: FIXTURE_REVISION_ID,
+        })
+        expect(res.status).toBe(403)
+    })
+
+    it("PUT requires expectedRevisionId and rejects a stale one with 409", async () => {
+        await seedGdocRow(FIXTURE_DOC_ID, false)
+
+        const missing = await rawRequest(
+            "PUT",
+            `/gdocs/${FIXTURE_DOC_ID}/archie`,
+            { archieMl: VALID_ARCHIE }
+        )
+        expect(missing.status).toBe(400)
+
+        const stale = await rawRequest(
+            "PUT",
+            `/gdocs/${FIXTURE_DOC_ID}/archie`,
+            { archieMl: VALID_ARCHIE, expectedRevisionId: "stale-revision" }
+        )
+        expect(stale.status).toBe(409)
+    })
+
+    it("POST /gdocs ?dryRun=true validates creation input", async () => {
+        const ok = await rawRequest("POST", `/gdocs?dryRun=true`, {
+            archieMl: VALID_ARCHIE,
+        })
+        expect(ok.status).toBe(200)
+        expect((await ok.json()).writable).toBe(true)
+
+        const bad = await rawRequest("POST", `/gdocs?dryRun=true`, {
+            archieMl: INVALID_ARCHIE,
+        })
+        expect(bad.status).toBe(400)
+        expect((await bad.json()).writable).toBe(false)
+    })
+
+    it("POST /gdocs without a configured target folder returns 400", async () => {
+        // GDOCS_AGENT_DRAFTS_FOLDER is not set in the test environment
+        const res = await rawRequest("POST", `/gdocs`, {
+            archieMl: VALID_ARCHIE,
+        })
+        expect(res.status).toBe(400)
+        const json = await res.json()
+        expect(json.error.message).toContain("target Drive folder")
+    })
+})

--- a/adminSiteServer/tests/gdoc-archie.test.ts
+++ b/adminSiteServer/tests/gdoc-archie.test.ts
@@ -10,7 +10,7 @@ const FIXTURE_DOC_ID = "gdoc-archie-api-test"
 const FIXTURE_REVISION_ID = "archie-test-revision-1"
 
 const VALID_ARCHIE = `title: Archie API test
-byline: Author
+authors: Author
 type: article
 [+body]
 Hello world
@@ -18,7 +18,7 @@ Hello world
 `
 
 const INVALID_ARCHIE = `title: Archie API test
-byline: Author
+authors: Author
 type: article
 [+body]
 {.small-chart}
@@ -79,6 +79,23 @@ describe("gdoc ArchieML API", { timeout: 20000 }, () => {
             .where({ id: FIXTURE_DOC_ID })
             .first()
         expect(row).toBeUndefined()
+    })
+
+    it("PUT ?dryRun=true warns that invented front matter like slug is dropped", async () => {
+        const res = await rawRequest(
+            "PUT",
+            `/gdocs/${FIXTURE_DOC_ID}/archie?dryRun=true`,
+            { archieMl: `slug: my-new-slug\n${VALID_ARCHIE}` }
+        )
+        expect(res.status).toBe(200)
+        const json = await res.json()
+        expect(json.writable).toBe(true)
+        expect(json.warnings).toContainEqual(
+            expect.objectContaining({
+                property: "slug",
+                message: expect.stringContaining("managed in the admin"),
+            })
+        )
     })
 
     it("PUT rejects invalid ArchieML with 400 and structured errors", async () => {

--- a/db/gdocTests.test.ts
+++ b/db/gdocTests.test.ts
@@ -55,9 +55,8 @@ function getArchieMLDocWithContent(
 ): string {
     return `title: Writing OWID Articles With Google Docs
 subtitle: This article documents how to use and configure the various built in features of our template system
-byline: Matthew Conlen
+authors: Matthew Conlen
 dateline: June 30, 2022
-template: centered
 ${extraFrontmatter}
 [+body]
 ${content}
@@ -1235,7 +1234,7 @@ describe("refs source-form serializer", () => {
 describe(validateArchieMl, () => {
     const doc = (body: string, frontmatter: string = "type: article"): string =>
         `title: Test doc
-byline: Author
+authors: Author
 ${frontmatter}
 [+body]
 ${body}
@@ -1306,6 +1305,73 @@ ${body}
         )
         expect(result.valid).toBe(true)
         expect(result.warnings.length).toBeGreaterThan(0)
+    })
+
+    it("rejects unrecognized front-matter keys (e.g. a misspelled field)", () => {
+        // A typo of a real field would otherwise be silently dropped on
+        // write, losing the intended value — so an unknown key is an error.
+        const result = validateArchieMl(
+            doc("Hello", "type: article\nsutitle: Oops a typo")
+        )
+        expect(result.valid).toBe(false)
+        expect(result.errors).toContainEqual(
+            expect.objectContaining({
+                property: "sutitle",
+                message: expect.stringContaining("Unrecognized"),
+            })
+        )
+    })
+
+    it("points admin-managed keys like slug to the admin settings", () => {
+        const result = validateArchieMl(
+            doc("Hello", "type: article\nslug: my-slug")
+        )
+        expect(result.valid).toBe(true)
+        expect(result.warnings).toContainEqual(
+            expect.objectContaining({
+                property: "slug",
+                message: expect.stringContaining("admin"),
+            })
+        )
+    })
+
+    it("refuses front matter the write-back cannot serialize yet", () => {
+        const result = validateArchieMl(
+            doc(
+                "Hello",
+                "type: article\n[.faqs]\nid: what-is-this\n[.+content]\nAn answer.\n[]\n[]"
+            )
+        )
+        expect(result.valid).toBe(false)
+        expect(result.errors).toContainEqual(
+            expect.objectContaining({
+                property: "faqs",
+                message: expect.stringContaining("not yet supported"),
+            })
+        )
+    })
+
+    it("rejects the legacy byline key (new drafts must use authors)", () => {
+        // `byline` is a pre-2023 alias the parse still honours (so authorship
+        // is understood), but it is not a field new drafts should use — the
+        // write-back emits `authors`, so the stray `byline` key is rejected as
+        // unrecognized. The fix is to rename it to `authors`.
+        const result = validateArchieMl(`title: Test doc
+byline: Jane Doe (Editor)
+type: article
+[+body]
+Hello world.
+[]
+`)
+        expect(result.valid).toBe(false)
+        expect(result.errors).toContainEqual(
+            expect.objectContaining({
+                property: "byline",
+                message: expect.stringContaining("Unrecognized"),
+            })
+        )
+        // the parse still understood the authorship, it's just the wrong key
+        expect(result.content?.authorRoles).toEqual({ "Jane Doe": "Editor" })
     })
 })
 

--- a/db/gdocTests.test.ts
+++ b/db/gdocTests.test.ts
@@ -22,6 +22,14 @@ import { archieToEnriched } from "./model/Gdoc/archieToEnriched.js"
 import { OwidRawGdocBlockToArchieMLString } from "./model/Gdoc/rawToArchie.js"
 import { owidArticleToArchieMLStringGenerator } from "./model/Gdoc/archieToGdoc.js"
 import {
+    compareArchieMlContent,
+    validateArchieMl,
+} from "./model/Gdoc/validateArchieMl.js"
+import {
+    joinArchieMlSkipSegments,
+    splitArchieMlSkipSegments,
+} from "./model/Gdoc/archieMlSkipBlocks.js"
+import {
     getContentKeysForGdocType,
     OWID_GDOC_DATA_INSIGHT_CONTENT_KEYS,
     OWID_GDOC_POST_CONTENT_KEYS,
@@ -724,23 +732,22 @@ describe("document-level ArchieML round trip", () => {
     // back is a fixed point. The write-back canonicalizes formatting —
     // property order, key casing, whitespace — without losing content, so the
     // string comparison is against that canonical form rather than the
-    // handwritten input; content preservation is what the enriched-level
-    // comparison checks. Returns the first parse and its canonical write-back
+    // handwritten input; content preservation is checked by validateArchieMl,
+    // the same gate the admin API uses, so CI exercises exactly the code the
+    // endpoint runs. Returns the first parse and its canonical write-back
     // for fixture-specific assertions.
     function expectDocToRoundTrip(archieml: string): {
         first: OwidGdocPostContent
         canonicalArchieML: string
     } {
-        const first = archieToEnriched(archieml)
+        const result = validateArchieMl(archieml, { requireType: false })
+        expect(result.errors).toEqual([])
+        const first = result.content!
         const canonicalArchieML = enrichedToArchieML(first)
-        const second = archieToEnriched(canonicalArchieML)
-        expect(omitUndefinedValues(second.body)).toEqual(
-            omitUndefinedValues(first.body)
+        // The canonical form must itself be a fixed point at the string level.
+        expect(enrichedToArchieML(archieToEnriched(canonicalArchieML))).toEqual(
+            canonicalArchieML
         )
-        expect(omitUndefinedValues(second.refs?.definitions)).toEqual(
-            omitUndefinedValues(first.refs?.definitions)
-        )
-        expect(enrichedToArchieML(second)).toEqual(canonicalArchieML)
         return { first, canonicalArchieML }
     }
 
@@ -1222,5 +1229,154 @@ describe("refs source-form serializer", () => {
         expect(text).toContain("Citation.")
         expect(text).not.toContain("id: abc123hash")
         expect(text).not.toContain("inline body\n[]")
+    })
+})
+
+describe(validateArchieMl, () => {
+    const doc = (body: string, frontmatter: string = "type: article"): string =>
+        `title: Test doc
+byline: Author
+${frontmatter}
+[+body]
+${body}
+[]
+`
+
+    it("accepts a valid document", () => {
+        const result = validateArchieMl(doc("Hello world"))
+        expect(result.valid).toBe(true)
+        expect(result.errors).toEqual([])
+        expect(result.content?.body).toHaveLength(1)
+    })
+
+    it("reports an unknown block type as a parse failure", () => {
+        const result = validateArchieMl(doc("{.small-chart}\nurl: test\n{}"))
+        expect(result.valid).toBe(false)
+        expect(result.content).toBeUndefined()
+        expect(result.errors).toHaveLength(1)
+        expect(result.errors[0].message).toContain("failed to parse")
+    })
+
+    it("reports attribute-level parseErrors on known blocks", () => {
+        const result = validateArchieMl(doc("{.chart}\ncaption: hi\n{}"))
+        expect(result.valid).toBe(false)
+        expect(result.errors).toEqual([
+            expect.objectContaining({
+                property: "body",
+                message: "[chart] url property is missing",
+            }),
+        ])
+        // The parse itself succeeded, so the content is still returned
+        expect(result.content).toBeDefined()
+    })
+
+    it("requires a writable gdoc type by default", () => {
+        const missing = validateArchieMl(doc("Hello", ""))
+        expect(missing.valid).toBe(false)
+        expect(missing.errors).toEqual([
+            expect.objectContaining({ property: "type" }),
+        ])
+
+        const wrong = validateArchieMl(doc("Hello", "type: homepage"))
+        expect(wrong.valid).toBe(false)
+        expect(wrong.errors[0].message).toContain('"homepage"')
+
+        const dataInsight = validateArchieMl(doc("Hello", "type: data-insight"))
+        expect(dataInsight.valid).toBe(true)
+
+        const off = validateArchieMl(doc("Hello", ""), { requireType: false })
+        expect(off.valid).toBe(true)
+    })
+
+    it("tolerates empty text blocks dropped by canonicalization", () => {
+        // An inline tag left open across a paragraph break (as produced by
+        // some real gdocs) yields a text block with zero spans. The write-back
+        // emits nothing for it, so the re-parse legitimately drops it — the
+        // fixed-point check must not flag that as content loss.
+        const result = validateArchieMl(
+            doc("Some <i>italic text\n\n</i>\n\nNext paragraph")
+        )
+        expect(result.valid).toBe(true)
+        expect(result.errors).toEqual([])
+    })
+
+    it("passes documents with warnings but reports them", () => {
+        const result = validateArchieMl(
+            doc('Some <a href="https://owid.cloud/foo">link</a>')
+        )
+        expect(result.valid).toBe(true)
+        expect(result.warnings.length).toBeGreaterThan(0)
+    })
+})
+
+describe(splitArchieMlSkipSegments, () => {
+    const skipBlock = ":skip\nSome hidden preview link\n:endskip"
+
+    it("passes through documents without directives", () => {
+        const text = "title: t\n[+body]\nHello\n[]\n"
+        const s = splitArchieMlSkipSegments(text)
+        expect(s.prefix).toBe("")
+        expect(s.core).toBe(text)
+        expect(s.suffix).toBe("")
+        expect(s.midDocumentDirectiveLines).toEqual([])
+    })
+
+    it("captures a leading skip block as prefix", () => {
+        const text = `${skipBlock}\n\ntitle: t\n[+body]\nHello\n[]\n`
+        const s = splitArchieMlSkipSegments(text)
+        expect(s.prefix).toBe(skipBlock)
+        expect(s.core.startsWith("\ntitle: t")).toBe(true)
+        expect(s.midDocumentDirectiveLines).toEqual([])
+        expect(joinArchieMlSkipSegments(s, "CANON")).toBe(`${skipBlock}\nCANON`)
+    })
+
+    it("captures a trailing skip block and an :ignore tail as suffix", () => {
+        const text = `title: t\n[+body]\nHello\n[]\n\n${skipBlock}\n:ignore\ngraveyard text`
+        const s = splitArchieMlSkipSegments(text)
+        expect(s.prefix).toBe("")
+        expect(s.core).toContain("Hello")
+        expect(s.core).not.toContain(":skip")
+        expect(s.suffix).toContain(":skip")
+        expect(s.suffix).toContain(":ignore\ngraveyard text")
+        expect(s.midDocumentDirectiveLines).toEqual([])
+    })
+
+    it("treats an unterminated :skip as a suffix (it runs to EOF)", () => {
+        const text = `title: t\n[+body]\nHello\n[]\n:skip\ndraft stuff`
+        const s = splitArchieMlSkipSegments(text)
+        expect(s.core).not.toContain(":skip")
+        expect(s.suffix).toBe(":skip\ndraft stuff")
+        expect(s.midDocumentDirectiveLines).toEqual([])
+    })
+
+    it("flags mid-document skip blocks with their line numbers", () => {
+        const text = `title: t\n[+body]\nBefore\n${skipBlock}\nAfter\n[]\n`
+        const s = splitArchieMlSkipSegments(text)
+        expect(s.midDocumentDirectiveLines).toEqual([4, 6])
+        expect(s.prefix).toBe("")
+        expect(s.suffix).toBe("")
+    })
+})
+
+describe(compareArchieMlContent, () => {
+    const parse = (body: string): ReturnType<typeof archieToEnriched> =>
+        archieToEnriched(`title: t\ntype: article\n[+body]\n${body}\n[]\n`)
+
+    it("reports identical for equivalent content", () => {
+        const result = compareArchieMlContent(
+            parse("Hello <b>world</b>"),
+            parse("Hello <b>world</b>")
+        )
+        expect(result.identical).toBe(true)
+    })
+
+    it("pinpoints differing blocks", () => {
+        const result = compareArchieMlContent(
+            parse("Same\n\nDiffers here\n\nSame again"),
+            parse("Same\n\nDiffers HERE\n\nSame again")
+        )
+        expect(result.identical).toBe(false)
+        expect(result.differingBodyBlocks).toEqual([1])
+        expect(result.refsMatch).toBe(true)
     })
 })

--- a/db/model/Gdoc/archieMlSkipBlocks.ts
+++ b/db/model/Gdoc/archieMlSkipBlocks.ts
@@ -1,0 +1,101 @@
+// Handling of ArchieML's :skip/:endskip and :ignore directives for the
+// wholesale-replace write path.
+//
+// Content inside these directives is invisible to the enriched model (the
+// parser discards it), so a canonical write-back cannot re-emit it. Blocks at
+// the very start or very end of a document have stable anchors and can be
+// preserved verbatim around the canonicalized core; a :skip block in the
+// middle of the document has no stable anchor after canonicalization, so the
+// caller should refuse rather than silently destroy hidden content.
+
+const SKIP_START = /^[ \t\r]*:[ \t\r]*skip\b/i
+const SKIP_END = /^[ \t\r]*:[ \t\r]*endskip\b/i
+const IGNORE = /^[ \t\r]*:[ \t\r]*ignore\b/i
+const BLANK = /^[ \t\r]*$/
+
+export interface ArchieMlSkipSegments {
+    /** Leading :skip…:endskip block(s), verbatim (empty if none) */
+    prefix: string
+    /** The parseable middle of the document */
+    core: string
+    /**
+     * Trailing :skip…:endskip block(s), an :ignore (which by definition runs
+     * to the end of the document), or an unterminated :skip — verbatim.
+     */
+    suffix: string
+    /** 1-based line numbers of :skip/:endskip directives inside the core */
+    midDocumentDirectiveLines: number[]
+}
+
+export function splitArchieMlSkipSegments(text: string): ArchieMlSkipSegments {
+    const lines = text.split("\n")
+
+    // :ignore and an unterminated :skip both run to the end of the document,
+    // so the earliest of them starts the suffix.
+    let tailStart = lines.length
+    for (let i = 0; i < lines.length; i++) {
+        if (IGNORE.test(lines[i])) {
+            tailStart = i
+            break
+        }
+        if (
+            SKIP_START.test(lines[i]) &&
+            !lines.slice(i + 1).some((l) => SKIP_END.test(l))
+        ) {
+            tailStart = i
+            break
+        }
+    }
+
+    // Leading complete :skip…:endskip blocks (with any blank lines between)
+    let coreStart = 0
+    for (;;) {
+        let i = coreStart
+        while (i < tailStart && BLANK.test(lines[i])) i++
+        if (i >= tailStart || !SKIP_START.test(lines[i])) break
+        const end = lines.findIndex((l, j) => j > i && SKIP_END.test(l))
+        if (end === -1 || end >= tailStart) break
+        coreStart = end + 1
+    }
+
+    // Trailing complete :skip…:endskip blocks just before the tail
+    let coreEnd = tailStart // exclusive
+    for (;;) {
+        let i = coreEnd - 1
+        while (i >= coreStart && BLANK.test(lines[i])) i--
+        if (i < coreStart || !SKIP_END.test(lines[i])) break
+        let start = -1
+        for (let j = i - 1; j >= coreStart; j--) {
+            if (SKIP_START.test(lines[j])) {
+                start = j
+                break
+            }
+            if (SKIP_END.test(lines[j])) break
+        }
+        if (start === -1) break
+        coreEnd = start
+    }
+
+    const midDocumentDirectiveLines: number[] = []
+    for (let i = coreStart; i < coreEnd; i++) {
+        if (SKIP_START.test(lines[i]) || SKIP_END.test(lines[i]))
+            midDocumentDirectiveLines.push(i + 1)
+    }
+
+    return {
+        prefix: lines.slice(0, coreStart).join("\n"),
+        core: lines.slice(coreStart, coreEnd).join("\n"),
+        suffix: lines.slice(coreEnd).join("\n"),
+        midDocumentDirectiveLines,
+    }
+}
+
+/** Re-attach preserved skip segments around a canonicalized core. */
+export function joinArchieMlSkipSegments(
+    segments: Pick<ArchieMlSkipSegments, "prefix" | "suffix">,
+    canonicalCore: string
+): string {
+    return [segments.prefix, canonicalCore, segments.suffix]
+        .filter((s) => s.trim() !== "")
+        .join("\n")
+}

--- a/db/model/Gdoc/archieToGdoc.ts
+++ b/db/model/Gdoc/archieToGdoc.ts
@@ -271,7 +271,19 @@ function* lineToBatchUpdates(line: Line): Generator<docs_v1.Schema$Request> {
 export function articleToBatchUpdates(
     content: ArchieMlWritableContent
 ): docs_v1.Schema$Request[] {
-    const archieMlLines = [...owidArticleToArchieMLStringGenerator(content)]
+    return archieMlTextToBatchUpdates(
+        [...owidArticleToArchieMLStringGenerator(content)].join("\n")
+    )
+}
+
+// Converts ArchieML text into Google Docs batchUpdate requests with real
+// formatting (the inline HTML becomes styled text runs). Exposed separately
+// from articleToBatchUpdates so callers can write text that carries verbatim
+// segments (e.g. preserved :skip blocks) around the canonical form.
+export function archieMlTextToBatchUpdates(
+    text: string
+): docs_v1.Schema$Request[] {
+    const archieMlLines = text.split("\n")
 
     let isInsideHtmlBlock = false
 
@@ -365,13 +377,15 @@ async function createGdoc(
 
 export async function createGdocAndInsertOwidGdocPostContent(
     content: ArchieMlWritableContent,
-    existingGdocId: string | null
+    existingGdocId: string | null,
+    targetFolder: string = GDOCS_BACKPORTING_TARGET_FOLDER
 ): Promise<string> {
     const batchUpdates = articleToBatchUpdates(content)
 
-    const targetFolder = GDOCS_BACKPORTING_TARGET_FOLDER
-    if (targetFolder === undefined || targetFolder === "")
-        throw new Error("GDOCS_BACKPORTING_TARGET_FOLDER is not set")
+    if (!existingGdocId && !targetFolder)
+        throw new Error(
+            "No target Drive folder given for gdoc creation (GDOCS_BACKPORTING_TARGET_FOLDER is not set)"
+        )
     const auth = OwidGoogleAuth.getGoogleReadWriteAuth()
     const client = googleDocs({
         version: "v1",

--- a/db/model/Gdoc/archieToGdoc.ts
+++ b/db/model/Gdoc/archieToGdoc.ts
@@ -272,7 +272,19 @@ function* lineToBatchUpdates(line: Line): Generator<docs_v1.Schema$Request> {
 export function articleToBatchUpdates(
     content: ArchieMlWritableContent
 ): docs_v1.Schema$Request[] {
-    const archieMlLines = [...owidArticleToArchieMLStringGenerator(content)]
+    return archieMlTextToBatchUpdates(
+        [...owidArticleToArchieMLStringGenerator(content)].join("\n")
+    )
+}
+
+// Converts ArchieML text into Google Docs batchUpdate requests with real
+// formatting (the inline HTML becomes styled text runs). Exposed separately
+// from articleToBatchUpdates so callers can write text that carries verbatim
+// segments (e.g. preserved :skip blocks) around the canonical form.
+export function archieMlTextToBatchUpdates(
+    text: string
+): docs_v1.Schema$Request[] {
+    const archieMlLines = text.split("\n")
 
     let isInsideHtmlBlock = false
 
@@ -366,13 +378,15 @@ async function createGdoc(
 
 export async function createGdocAndInsertOwidGdocPostContent(
     content: ArchieMlWritableContent,
-    existingGdocId: string | null
+    existingGdocId: string | null,
+    targetFolder: string = GDOCS_BACKPORTING_TARGET_FOLDER
 ): Promise<string> {
     const batchUpdates = articleToBatchUpdates(content)
 
-    const targetFolder = GDOCS_BACKPORTING_TARGET_FOLDER
-    if (targetFolder === undefined || targetFolder === "")
-        throw new Error("GDOCS_BACKPORTING_TARGET_FOLDER is not set")
+    if (!existingGdocId && !targetFolder)
+        throw new Error(
+            "No target Drive folder given for gdoc creation (GDOCS_BACKPORTING_TARGET_FOLDER is not set)"
+        )
     const auth = OwidGoogleAuth.getGoogleReadWriteAuth()
     const client = googleDocs({
         version: "v1",

--- a/db/model/Gdoc/validateArchieMl.ts
+++ b/db/model/Gdoc/validateArchieMl.ts
@@ -1,0 +1,207 @@
+import * as _ from "lodash-es"
+import {
+    OwidGdocErrorMessage,
+    OwidGdocErrorMessageType,
+    OwidGdocPostContent,
+    OwidGdocType,
+} from "@ourworldindata/types"
+import { getParseFindings } from "@ourworldindata/utils"
+import { archieToEnriched } from "./archieToEnriched.js"
+import { owidArticleToArchieMLStringGenerator } from "./archieToGdoc.js"
+
+export interface ArchieMlValidationResult {
+    valid: boolean
+    errors: OwidGdocErrorMessage[]
+    warnings: OwidGdocErrorMessage[]
+    /** Present when the parse itself succeeded (even if block errors exist). */
+    content?: OwidGdocPostContent
+}
+
+/**
+ * Gdoc types whose content the ArchieML write-back layer
+ * (owidArticleToArchieMLStringGenerator) knows how to serialize.
+ */
+export const ARCHIE_WRITABLE_GDOC_TYPES: OwidGdocType[] = [
+    OwidGdocType.Article,
+    OwidGdocType.TopicPage,
+    OwidGdocType.LinearTopicPage,
+    OwidGdocType.Fragment,
+    OwidGdocType.DataInsight,
+]
+
+/** Strip undefined object properties on both sides of a deep comparison. */
+const normalizeForComparison = (value: unknown): unknown =>
+    JSON.parse(JSON.stringify(value ?? null))
+
+// The parse of a real gdoc can contain empty text blocks (e.g. from stray
+// formatting in the doc). They render as nothing, and the write-back emits
+// nothing for them, so the re-parse legitimately drops them. Strip them
+// before the fixed-point comparison so this canonicalization does not count
+// as content loss.
+const withoutEmptyTextBlocks = (
+    blocks: OwidGdocPostContent["body"]
+): OwidGdocPostContent["body"] =>
+    blocks?.filter((b) => !(b.type === "text" && b.value.length === 0))
+
+// Inline refs are keyed by a sha1 of their *raw* source bytes, which a
+// write-back can only reproduce canonically (e.g. a dod link re-emitted in
+// its short form, or blank paragraphs dropped). The content itself is still
+// compared in full at its footnote index, so the regenerated hash key is
+// noise — replace hash-shaped ids with a placeholder. Author-chosen ids
+// (ID-based refs) are kept and must survive the round trip.
+const CONTENT_HASH_ID = /^[0-9a-f]{40}$/
+
+const normalizeRefDefinitions = (
+    definitions:
+        | NonNullable<OwidGdocPostContent["refs"]>["definitions"]
+        | undefined
+): unknown =>
+    Object.values(definitions ?? {})
+        .map((ref) => ({
+            ...ref,
+            id: CONTENT_HASH_ID.test(ref.id) ? "<content-hash>" : ref.id,
+            content: withoutEmptyTextBlocks(ref.content),
+        }))
+        .sort((a, b) => a.index - b.index)
+
+export interface ArchieMlContentComparison {
+    identical: boolean
+    /** Indices (in the empty-block-stripped body) of blocks that differ */
+    differingBodyBlocks: number[]
+    refsMatch: boolean
+}
+
+/**
+ * Semantic equality of two parsed documents, with the tolerances a canonical
+ * round trip is allowed: empty text blocks are ignored and inline-ref content
+ * hashes are treated as opaque. Used both by the fixed-point check below and
+ * by the write endpoint's post-write read-back verification.
+ */
+export function compareArchieMlContent(
+    expected: OwidGdocPostContent,
+    actual: OwidGdocPostContent
+): ArchieMlContentComparison {
+    const a = withoutEmptyTextBlocks(expected.body) ?? []
+    const b = withoutEmptyTextBlocks(actual.body) ?? []
+    const differingBodyBlocks: number[] = []
+    for (let i = 0; i < Math.max(a.length, b.length); i++) {
+        if (
+            !_.isEqual(
+                normalizeForComparison(a[i]),
+                normalizeForComparison(b[i])
+            )
+        )
+            differingBodyBlocks.push(i)
+    }
+    const refsMatch = _.isEqual(
+        normalizeForComparison(
+            normalizeRefDefinitions(expected.refs?.definitions)
+        ),
+        normalizeForComparison(
+            normalizeRefDefinitions(actual.refs?.definitions)
+        )
+    )
+    return {
+        identical: differingBodyBlocks.length === 0 && refsMatch,
+        differingBodyBlocks,
+        refsMatch,
+    }
+}
+
+function collectParseErrors(
+    content: OwidGdocPostContent,
+    errors: OwidGdocErrorMessage[],
+    warnings: OwidGdocErrorMessage[]
+): void {
+    for (const finding of getParseFindings(content)) {
+        const target =
+            finding.type === OwidGdocErrorMessageType.Warning
+                ? warnings
+                : errors
+        target.push(finding)
+    }
+}
+
+/**
+ * Validate an ArchieML document against the real gdoc ingestion pipeline.
+ *
+ * Composes existing primitives into the single gate used by the admin API
+ * (and, via the round-trip tests, exercised on every CI run):
+ *   1. `archieToEnriched` — throws on unknown block types; a throw becomes a
+ *      single error.
+ *   2. Collect the non-fatal `parseErrors` attached to blocks (body and ref
+ *      contents), split into errors and warnings.
+ *   3. Fixed point: serialize the parsed content back to ArchieML and re-parse
+ *      it. ArchieML's `load()` never errors — a typo'd marker or unclosed tag
+ *      silently swallows content — so a mismatch here is the only signal that
+ *      content was dropped or mangled.
+ *   4. `content.type` must be a type the write-back layer knows how to
+ *      serialize (see ARCHIE_WRITABLE_GDOC_TYPES). Disable with
+ *      `requireType: false` (e.g. for fragments under test).
+ */
+export function validateArchieMl(
+    text: string,
+    { requireType = true }: { requireType?: boolean } = {}
+): ArchieMlValidationResult {
+    const errors: OwidGdocErrorMessage[] = []
+    const warnings: OwidGdocErrorMessage[] = []
+
+    let content: OwidGdocPostContent
+    try {
+        content = archieToEnriched(text)
+    } catch (error) {
+        errors.push({
+            property: "body",
+            type: OwidGdocErrorMessageType.Error,
+            message: `The document failed to parse: ${
+                error instanceof Error ? error.message : String(error)
+            }`,
+        })
+        return { valid: false, errors, warnings }
+    }
+
+    collectParseErrors(content, errors, warnings)
+
+    if (
+        requireType &&
+        (!content.type || !ARCHIE_WRITABLE_GDOC_TYPES.includes(content.type))
+    ) {
+        errors.push({
+            property: "type",
+            type: OwidGdocErrorMessageType.Error,
+            message: content.type
+                ? `Gdoc type "${content.type}" is not supported by the ArchieML write-back layer. Supported types: ${ARCHIE_WRITABLE_GDOC_TYPES.join(", ")}.`
+                : `The document is missing a "type" front-matter field. Supported types: ${ARCHIE_WRITABLE_GDOC_TYPES.join(", ")}.`,
+        })
+    }
+
+    // Fixed-point check: writing the parsed content back to ArchieML and
+    // re-parsing it must reproduce the same content.
+    try {
+        const canonicalArchieMl = [
+            ...owidArticleToArchieMLStringGenerator(content),
+        ].join("\n")
+        const reparsed = archieToEnriched(canonicalArchieMl)
+        if (!compareArchieMlContent(content, reparsed).identical) {
+            errors.push({
+                property: "body",
+                type: OwidGdocErrorMessageType.Error,
+                message:
+                    "The document does not round-trip cleanly: some content is " +
+                    "silently dropped or altered when it is written back to " +
+                    "ArchieML (e.g. an unclosed [.list] tag or a malformed " +
+                    "block marker). Compare your input against the parsed result.",
+            })
+        }
+    } catch (error) {
+        errors.push({
+            property: "body",
+            type: OwidGdocErrorMessageType.Error,
+            message: `The document parses, but its canonical write-back form does not: ${
+                error instanceof Error ? error.message : String(error)
+            }`,
+        })
+    }
+
+    return { valid: errors.length === 0, errors, warnings, content }
+}

--- a/db/model/Gdoc/validateArchieMl.ts
+++ b/db/model/Gdoc/validateArchieMl.ts
@@ -1,6 +1,10 @@
 import * as _ from "lodash-es"
 import {
+    getContentKeysForGdocType,
+    OWID_GDOC_BASE_ROW_KEYS,
+    OWID_GDOC_POST_CONTENT_KEYS,
     OwidGdocErrorMessage,
+    OwidGdocErrorMessageProperty,
     OwidGdocErrorMessageType,
     OwidGdocPostContent,
     OwidGdocType,
@@ -64,11 +68,16 @@ const normalizeRefDefinitions = (
         }))
         .sort((a, b) => a.index - b.index)
 
+const frontMatterKeys = (content: OwidGdocPostContent): string[] =>
+    Object.keys(content).filter((key) => key !== "body" && key !== "refs")
+
 export interface ArchieMlContentComparison {
     identical: boolean
     /** Indices (in the empty-block-stripped body) of blocks that differ */
     differingBodyBlocks: number[]
     refsMatch: boolean
+    /** Top-level keys (other than body/refs) that are dropped or altered */
+    differingFrontMatterKeys: string[]
 }
 
 /**
@@ -101,10 +110,104 @@ export function compareArchieMlContent(
             normalizeRefDefinitions(actual.refs?.definitions)
         )
     )
+    const expectedByKey = expected as unknown as Record<string, unknown>
+    const actualByKey = actual as unknown as Record<string, unknown>
+    const differingFrontMatterKeys = [
+        ...new Set([...frontMatterKeys(expected), ...frontMatterKeys(actual)]),
+    ].filter(
+        (key) =>
+            !_.isEqual(
+                normalizeForComparison(expectedByKey[key]),
+                normalizeForComparison(actualByKey[key])
+            )
+    )
     return {
-        identical: differingBodyBlocks.length === 0 && refsMatch,
+        identical:
+            differingBodyBlocks.length === 0 &&
+            refsMatch &&
+            differingFrontMatterKeys.length === 0,
         differingBodyBlocks,
         refsMatch,
+        differingFrontMatterKeys,
+    }
+}
+
+/**
+ * Classify front-matter keys that do not survive the write-back round trip,
+ * using the write-back fate classification declared next to the content
+ * interfaces (the single source of truth for what the write-back supports).
+ */
+function collectFrontMatterFindings(
+    differingFrontMatterKeys: string[],
+    type: OwidGdocType | undefined,
+    errors: OwidGdocErrorMessage[],
+    warnings: OwidGdocErrorMessage[]
+): void {
+    const keyFates: Record<string, string> =
+        (type && getContentKeysForGdocType(type)) || OWID_GDOC_POST_CONTENT_KEYS
+    for (const key of differingFrontMatterKeys) {
+        const property = key as OwidGdocErrorMessageProperty
+        switch (keyFates[key]) {
+            case "unsupported":
+                errors.push({
+                    property,
+                    type: OwidGdocErrorMessageType.Error,
+                    message:
+                        `The front-matter field "${key}" is not yet supported ` +
+                        `by the ArchieML write-back — writing this document ` +
+                        `would lose it. Edit this document in Google Docs ` +
+                        `directly instead.`,
+                })
+                break
+            case "derived":
+                warnings.push({
+                    property,
+                    type: OwidGdocErrorMessageType.Warning,
+                    message:
+                        `The front-matter field "${key}" is derived from other ` +
+                        `content and regenerated on every parse — the value in ` +
+                        `the document is ignored and removed by the write.`,
+                })
+                break
+            case "emitted":
+                errors.push({
+                    property,
+                    type: OwidGdocErrorMessageType.Error,
+                    message:
+                        `The front-matter field "${key}" does not survive the ` +
+                        `write-back round trip — its value would be altered or ` +
+                        `lost. Compare your input against the parsed result.`,
+                })
+                break
+            default:
+                if (OWID_GDOC_BASE_ROW_KEYS.includes(key)) {
+                    // Admin-managed row property (slug, tags, …): dropping it
+                    // from the document is correct, so this is only a warning.
+                    warnings.push({
+                        property,
+                        type: OwidGdocErrorMessageType.Warning,
+                        message:
+                            `"${key}" is not part of the document's content — ` +
+                            `it is managed in the admin and will be removed by ` +
+                            `the write. Relay requested changes to it to a ` +
+                            `human author instead of putting it in the document.`,
+                    })
+                } else {
+                    // A key the schema doesn't know — most often a misspelled
+                    // field (e.g. "sutitle"). Dropping it silently would lose
+                    // the author's intent, so refuse the write.
+                    errors.push({
+                        property,
+                        type: OwidGdocErrorMessageType.Error,
+                        message:
+                            `Unrecognized front-matter field "${key}" — it is ` +
+                            `not a known field${type ? ` for a ${type}` : ""} ` +
+                            `and would be dropped on write. If it is a ` +
+                            `misspelling of a real field, fix it; otherwise ` +
+                            `remove it.`,
+                    })
+                }
+        }
     }
 }
 
@@ -182,7 +285,11 @@ export function validateArchieMl(
             ...owidArticleToArchieMLStringGenerator(content),
         ].join("\n")
         const reparsed = archieToEnriched(canonicalArchieMl)
-        if (!compareArchieMlContent(content, reparsed).identical) {
+        const comparison = compareArchieMlContent(content, reparsed)
+        if (
+            comparison.differingBodyBlocks.length > 0 ||
+            !comparison.refsMatch
+        ) {
             errors.push({
                 property: "body",
                 type: OwidGdocErrorMessageType.Error,
@@ -193,6 +300,12 @@ export function validateArchieMl(
                     "block marker). Compare your input against the parsed result.",
             })
         }
+        collectFrontMatterFindings(
+            comparison.differingFrontMatterKeys,
+            content.type,
+            errors,
+            warnings
+        )
     } catch (error) {
         errors.push({
             property: "body",

--- a/docs/gdocs-agent-cms.md
+++ b/docs/gdocs-agent-cms.md
@@ -147,7 +147,13 @@ flowchart LR
 - **Silent content swallow**: ArchieML's `load()` never errors — a typo'd
   marker or unclosed `[.list]` silently drops content. `validateArchieMl`
   catches this with a fixed-point check (parse → write back → re-parse →
-  compare).
+  compare), across the body, refs, **and every top-level front-matter key**.
+- **Dropped front matter**: a front-matter key the write-back doesn't preserve
+  is caught by the same fixed-point check and classified — an authored field
+  the write-back can't yet serialize (`faqs`, `details`) is refused; an
+  admin-managed property (`slug`, `tags`, …) or an unrecognized key is warned
+  about. So an agent that invents a `slug:` line is told it's admin-managed,
+  rather than getting a silent no-op.
 - **Registry drift**: no failure at all — CI regenerates and auto-commits.
 
 ## CI self-heal
@@ -186,9 +192,13 @@ anything). No per-item taxonomy to decode.
 
 The gate, [`validateArchieMl`](../db/model/Gdoc/validateArchieMl.ts), composes
 the pipeline's own primitives: `archieToEnriched` (throws on unknown blocks) →
-collect `parseErrors` → fixed-point re-serialize check → require a post-shaped
-`type`. The round-trip test suite asserts through the same function, so CI
-exercises exactly the gate the endpoints run.
+collect `parseErrors` → fixed-point re-serialize check (body, refs, and
+front-matter keys) → require a post-shaped `type`. Dropped front-matter keys
+are classified against the write-back fate declared next to the content
+interfaces — one source of truth shared with the serializer — so "this field
+would be silently lost" becomes a precise, structured message. The round-trip
+test suite asserts through the same function, so CI exercises exactly the gate
+the endpoints run.
 
 Authors use this through the `gdoc-editor` skill in
 [owid-claude-plugins](https://github.com/owid/owid-claude-plugins) — no repo

--- a/docs/gdocs-agent-cms.md
+++ b/docs/gdocs-agent-cms.md
@@ -1,0 +1,256 @@
+# Agent-editable gdocs CMS — visual overview
+
+One idea across a stack of PRs: **the ArchieML component types are the single
+source of truth**, and once every layer derives from them, an agent can safely
+read, edit, and create gdocs on an author's behalf — with the server as the
+only gate.
+
+| PR / branch                                             | What it does                                                                                                                                                                                                                                                   |
+| ------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [#6543](https://github.com/owid/owid-grapher/pull/6543) | Generates a JSON registry of all components from the type definitions (JSDoc + `.md` sidecars). CI keeps it fresh.                                                                                                                                             |
+| [#6695](https://github.com/owid/owid-grapher/pull/6695) | Shows that registry in the admin at `/components` (and serves it at `/admin/api/components.json`).                                                                                                                                                             |
+| [#6544](https://github.com/owid/owid-grapher/pull/6544) | Makes the gdoc ⇄ ArchieML round trip faithful (underline, strikethrough, refs) and tests it.                                                                                                                                                                   |
+| this branch                                             | Exposes the round trip over HTTP: read/replace/create gdocs as ArchieML via the admin API, gated by `validateArchieMl`. A `gdoc-editor` skill in [owid-claude-plugins](https://github.com/owid/owid-claude-plugins) gives authors a repo-less Claude workflow. |
+
+## The big picture
+
+Content lives at **four levels**. Ingest walks down the ladder, write-back
+walks up, and the admin API exposes level ② (the text authors and agents work
+in) over HTTP. Colours = which PR owns the box.
+
+```mermaid
+flowchart LR
+    Author["👤 Author"] -->|writes| GDoc
+    Agent["🤖 Author's agent<br/>(no repo, no creds)"]
+    CI["⚙️ CI"] -->|"regenerate & auto-commit"| Gen
+
+    subgraph SPINE["Single source of truth"]
+        Types[["ArchieML component types<br/>JSDoc + .md sidecars"]]
+    end
+
+    subgraph BUILD["#6543 · registry"]
+        Gen["generator"] -->|emits| Reg[("registry JSON<br/>(committed)")]
+    end
+
+    subgraph GALLERY["#6695 · gallery"]
+        Page["/components admin page"]
+    end
+
+    subgraph API["this branch · admin API"]
+        Routes["GET · PUT /gdocs/:id/archie<br/>POST /gdocs<br/>gate: validateArchieMl"]
+    end
+
+    subgraph PIPE["#6544 · content round-trip"]
+        direction TB
+        GDoc["① Google Doc"]
+        Archie["② ArchieML text"]
+        Raw["③ raw blocks"]
+        Enr{{"④ enriched blocks"}}
+    end
+
+    DB[("MySQL")]
+    Site["site render"]
+
+    %% down = ingest
+    GDoc -->|gdocToArchie| Archie
+    Archie -->|archieml.load| Raw
+    Raw -->|rawToEnriched| Enr
+    %% up = write-back
+    Enr -->|enrichedToRaw| Raw
+    Raw -->|rawToArchie| Archie
+    Archie -->|archieToGdoc| GDoc
+
+    Agent <-->|"read / replace / create<br/>ArchieML over HTTP"| Routes
+    Routes <--> Archie
+    Types -.->|documents| Gen
+    Types -.->|"defines block shapes"| Enr
+    Reg --> Page
+    Reg -.->|"block reference for agents"| Routes
+    Enr --> DB
+    Enr --> Site
+
+    classDef spine fill:#f3e8ff,stroke:#7c3aed,color:#4c1d95;
+    classDef pr6543 fill:#dbeafe,stroke:#2563eb,color:#1e3a8a;
+    classDef pr6695 fill:#dcfce7,stroke:#16a34a,color:#14532d;
+    classDef pr6544 fill:#fef9c3,stroke:#ca8a04,color:#713f12;
+    classDef prapi fill:#ffe4e6,stroke:#e11d48,color:#881337;
+    class Types spine;
+    class Gen,Reg pr6543;
+    class Page pr6695;
+    class GDoc,Archie,Raw,Enr pr6544;
+    class Routes,Agent prapi;
+```
+
+Notes:
+
+- `archieToEnriched` is the public entry point for ②→④ (it runs `archieml.load`
+  then `rawToEnriched`, using `htmlToEnriched` for inline HTML). `archieToGdoc`
+  is the entry point for ④→① (it calls `enrichedToRaw` then `rawToArchie`
+  internally).
+- Enriched (④) is what gets stored, validated, and rendered.
+
+## When things go wrong
+
+Same picture, with the failure paths. Colour = severity.
+
+```mermaid
+flowchart LR
+    Author["👤 Author / agent"]
+
+    subgraph GUARD["Pre-flight (server-side)"]
+        DryRun["PUT/POST …?dryRun=true<br/>validateArchieMl"]
+    end
+
+    subgraph BUILD["#6543 · registry"]
+        Gen["generator<br/>(validates every example)"] --> Reg[("registry JSON")]
+    end
+
+    subgraph PIPE["ingest"]
+        Parse["archieToEnriched"]
+        Enr{{"④ enriched"}}
+    end
+
+    AdminVal["admin validation"]
+
+    Caught(["✓ structured errors returned,<br/>nothing written"]):::safe
+    Stale(["✗ red CI · registry stays stale<br/>(not blocking)"]):::gate
+    Abort(["✗ whole doc fails to ingest"]):::fail
+    Warn(["⚠ author warned, doc still ingests"]):::warn
+
+    Author -->|"validate before writing"| DryRun
+    Author -->|"or push a doc directly"| Parse
+    Reg -.->|"block reference (/admin/api/components.json)"| DryRun
+    Parse --> Enr
+    Enr --> AdminVal
+
+    DryRun -->|"① unknown block · ③ bad attribute<br/>· silent content swallow (fixed point)"| Caught
+    Gen -->|"② broken example in sidecar"| Stale
+    Parse -->|"① unknown block → throws"| Abort
+    AdminVal -->|"③ bad attribute"| Warn
+
+    classDef safe fill:#dcfce7,stroke:#16a34a,color:#14532d,stroke-width:2px;
+    classDef gate fill:#ffedd5,stroke:#ea580c,color:#7c2d12,stroke-width:2px;
+    classDef fail fill:#fee2e2,stroke:#dc2626,color:#7f1d1d,stroke-width:2px;
+    classDef warn fill:#fef9c3,stroke:#eab308,color:#713f12,stroke-width:2px;
+```
+
+- **① Unknown block** (`{.small-chart}`): the parser throws and the _whole doc_
+  fails. The dry-run endpoint returns the parser's error before anything is
+  written; the block reference at `/admin/api/components.json` lists every valid
+  block with docs and examples.
+- **② Broken example** in a `.md` sidecar: the generator writes nothing and CI
+  goes red. Not blocking — the committed registry just stays at its last good
+  state until the example is fixed.
+- **③ Bad attribute** on a known block: non-fatal `parseError`. The dry run
+  reports it as a structured error; if the doc ingests anyway (direct push),
+  the admin shows it to the author as a warning.
+- **Silent content swallow**: ArchieML's `load()` never errors — a typo'd
+  marker or unclosed `[.list]` silently drops content. `validateArchieMl`
+  catches this with a fixed-point check (parse → write back → re-parse →
+  compare).
+- **Registry drift**: no failure at all — CI regenerates and auto-commits.
+
+## CI self-heal
+
+The registry JSON is generated, never hand-edited. On every push/PR **targeting
+`master`**, the `regenerate-components-reference` job in
+[`format.yml`](../.github/workflows/format.yml) reruns the generator and
+auto-commits any diff. Broken examples make the job red and skip the commit, so
+the committed registry can go stale but never corrupt.
+
+**Stacked PRs:** only the bottom PR of a Graphite stack targets `master`, so
+upstack PRs get no self-heal (and no auto-format). If you change types or
+sidecars upstack, run `yarn generateComponentsReference` locally.
+
+## How an agent edits a gdoc
+
+A gdoc is not a text file: bold, links and refs are real Google formatting, not
+markup characters. You can't "paste ArchieML into a doc" — something must
+convert it, and the only converter (`articleToBatchUpdates`) takes **enriched**
+input. The admin API is built around that funnel, so faulty ArchieML can't
+reach the doc — there is no string-shaped door:
+
+| Route                                 | What it does                                                                                                                                                                                                                                                                               |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `GET /admin/api/gdocs/:id/archie`     | The doc as canonical ArchieML text + `revisionId`, `registered`, `published`. Side-effect-free (unlike `?contentSource=gdocs`, which syncs images and persists).                                                                                                                           |
+| `PUT /admin/api/gdocs/:id/archie`     | Wholesale-replace the doc content. Refuses published docs (403), unregistered docs (404), stale `expectedRevisionId` (409), and anything `validateArchieMl` rejects (400). `?dryRun=true` = validate only. After writing: read-back verification + re-ingest so the admin preview is warm. |
+| `POST /admin/api/gdocs`               | Create a doc from ArchieML in a shared Drive folder (`folderId` or `GDOCS_AGENT_DRAFTS_FOLDER`), register it in the admin. Same gate and `?dryRun=true`.                                                                                                                                   |
+| `GET /admin/api/gdocs/:id/validation` | The stored doc's complete validation report, exactly as the admin computes it (`getErrors`): `publishable`, `errors`, `warnings`.                                                                                                                                                          |
+
+Validation reporting follows one rule — **each response is about exactly one
+artifact, and the endpoint contract says which**. Dry runs and 400s judge
+_your submission_ (`writable` + why not); `GET …/validation` and the write
+success responses carry _the stored doc's_ complete report (`publishable` +
+the admin's errors/warnings — errors block publishing, warnings never block
+anything). No per-item taxonomy to decode.
+
+The gate, [`validateArchieMl`](../db/model/Gdoc/validateArchieMl.ts), composes
+the pipeline's own primitives: `archieToEnriched` (throws on unknown blocks) →
+collect `parseErrors` → fixed-point re-serialize check → require a post-shaped
+`type`. The round-trip test suite asserts through the same function, so CI
+exercises exactly the gate the endpoints run.
+
+Authors use this through the `gdoc-editor` skill in
+[owid-claude-plugins](https://github.com/owid/owid-claude-plugins) — no repo
+checkout, no Google credentials. On a tailnet machine, auth is automatic
+(Tailscale identity); otherwise a Bearer admin API key works. The skill's
+workflow: read (+ a `GET …/validation` baseline) → propose edits → dry run
+until `writable` → show the author a diff → apply with `expectedRevisionId` →
+report the saved doc's validation delta and the preview URL.
+
+## The two round-trip tests
+
+**A (vitest)** proves the converters are lossless for _every_ block type —
+without touching Google. **B (live script)** proves the Google boundary is
+lossless — for a small sample. Together they close the circle. Both A and the
+API endpoints run through `validateArchieMl`, so the tested gate and the
+production gate are the same function.
+
+```mermaid
+flowchart TB
+    subgraph A["🧪 A · vitest — db/gdocTests.test.ts<br/>no Google · every block type · runs on every PR"]
+        direction TB
+        A4["④ enriched"]
+        A3["③ raw"]
+        A2["② ArchieML string"]
+        A4b["④ enriched again"]
+        A4 -->|enrichedToRaw| A3 -->|rawToArchie| A2 -->|archieToEnriched| A4b
+        A4b -.->|"must equal"| A4
+    end
+
+    subgraph B["🌐 B · live — devTools/gdocs/test-roundtrip.ts<br/>real gdoc · curated sample · run by hand"]
+        direction TB
+        B4["④ enriched fixture"]
+        B2ref["② expected ArchieML"]
+        B1["① live Google Doc"]
+        B2out["② ArchieML read back"]
+        B4 -->|"string generator"| B2ref
+        B4 -->|batchUpdate| B1
+        B1 -->|gdocToArchie| B2out
+        B2out -.->|"must match"| B2ref
+    end
+
+    A -.-|"A covers ②⇄③⇄④ broadly"| NOTE(["B covers ④→①→② — the Google segment A can't reach"])
+    B -.- NOTE
+
+    classDef unit fill:#dbeafe,stroke:#2563eb,color:#1e3a8a;
+    classDef live fill:#fef9c3,stroke:#ca8a04,color:#713f12;
+    classDef gap fill:#f3e8ff,stroke:#7c3aed,color:#4c1d95;
+    class A4,A3,A2,A4b unit;
+    class B4,B2ref,B1,B2out live;
+    class NOTE gap;
+```
+
+|          | A · vitest                 | B · live                     |
+| -------- | -------------------------- | ---------------------------- |
+| Path     | ④→③→②→④, in-process        | ④→①→②, through a real doc    |
+| Coverage | every block example + refs | inline styles, heading, refs |
+| Cost     | milliseconds, every PR     | creds + live doc, manual     |
+
+B trusts A: its "expected" string comes from the same converters A already
+proved lossless, so any diff B finds points at the Google segment. The `PUT`
+endpoint runs B's read-back comparison on every real write, so each replaced
+doc self-verifies.
+
+Known gap: both loops start from machine-made content. Odd formatting in real
+human docs is only caught at ingest, by admin validation.

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -26,6 +26,9 @@ import {
     type OwidGdocAuthorInterface,
     type OwidGdoc,
     OwidGdocType,
+    type OwidGdocErrorMessage,
+    OwidGdocErrorMessageType,
+    type OwidGdocPostContent,
     type OwidGdocJSON,
     type Span,
     UserCountryInformation,
@@ -1847,6 +1850,47 @@ export function traverseEnrichedBlock(
             callback
         )
         .exhaustive()
+}
+
+/**
+ * Transcribes the findings the ArchieML parser recorded while parsing —
+ * `parseErrors` on blocks (body and ref contents) and `refs.errors` — into
+ * OwidGdocErrorMessages. This function performs NO judgments of its own:
+ * new validation rules belong in `getErrors`'s check functions (advisory,
+ * shown in the admin) or in `validateArchieMl` (blocks agent writes), not
+ * here. Shared by both so the admin and the write gate can never diverge on
+ * what the parser reported.
+ */
+export function getParseFindings(content: {
+    body?: OwidEnrichedGdocBlock[]
+    refs?: OwidGdocPostContent["refs"]
+}): OwidGdocErrorMessage[] {
+    const findings: OwidGdocErrorMessage[] = []
+    const transcribe = (
+        property: OwidGdocErrorMessage["property"],
+        blocks: OwidEnrichedGdocBlock[] | undefined
+    ): void => {
+        for (const block of blocks ?? []) {
+            traverseEnrichedBlock(block, (node) => {
+                for (const parseError of node.parseErrors ?? []) {
+                    findings.push({
+                        property,
+                        type: parseError.isWarning
+                            ? OwidGdocErrorMessageType.Warning
+                            : OwidGdocErrorMessageType.Error,
+                        message: `[${node.type}] ${parseError.message}`,
+                    })
+                }
+            })
+        }
+    }
+
+    transcribe("body", content.body)
+    for (const ref of Object.values(content.refs?.definitions ?? {})) {
+        transcribe("refs", ref.content)
+    }
+    findings.push(...(content.refs?.errors ?? []))
+    return findings
 }
 
 export function checkNodeIsSpan(node: NodeWithUrl): node is Span {

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -26,6 +26,9 @@ import {
     type OwidGdocAuthorInterface,
     type OwidGdoc,
     OwidGdocType,
+    type OwidGdocErrorMessage,
+    OwidGdocErrorMessageType,
+    type OwidGdocPostContent,
     type OwidGdocJSON,
     type Span,
     UserCountryInformation,
@@ -1923,6 +1926,47 @@ export function traverseEnrichedBlock(
             callback
         )
         .exhaustive()
+}
+
+/**
+ * Transcribes the findings the ArchieML parser recorded while parsing —
+ * `parseErrors` on blocks (body and ref contents) and `refs.errors` — into
+ * OwidGdocErrorMessages. This function performs NO judgments of its own:
+ * new validation rules belong in `getErrors`'s check functions (advisory,
+ * shown in the admin) or in `validateArchieMl` (blocks agent writes), not
+ * here. Shared by both so the admin and the write gate can never diverge on
+ * what the parser reported.
+ */
+export function getParseFindings(content: {
+    body?: OwidEnrichedGdocBlock[]
+    refs?: OwidGdocPostContent["refs"]
+}): OwidGdocErrorMessage[] {
+    const findings: OwidGdocErrorMessage[] = []
+    const transcribe = (
+        property: OwidGdocErrorMessage["property"],
+        blocks: OwidEnrichedGdocBlock[] | undefined
+    ): void => {
+        for (const block of blocks ?? []) {
+            traverseEnrichedBlock(block, (node) => {
+                for (const parseError of node.parseErrors ?? []) {
+                    findings.push({
+                        property,
+                        type: parseError.isWarning
+                            ? OwidGdocErrorMessageType.Warning
+                            : OwidGdocErrorMessageType.Error,
+                        message: `[${node.type}] ${parseError.message}`,
+                    })
+                }
+            })
+        }
+    }
+
+    transcribe("body", content.body)
+    for (const ref of Object.values(content.refs?.definitions ?? {})) {
+        transcribe("refs", ref.content)
+    }
+    findings.push(...(content.refs?.errors ?? []))
+    return findings
 }
 
 export function checkNodeIsSpan(node: NodeWithUrl): node is Span {

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -93,6 +93,7 @@ export {
     imemo,
     recursivelyMapArticleContent,
     traverseEnrichedBlock,
+    getParseFindings,
     checkNodeIsSpan,
     generateToc,
     extractLinksFromMarkdown,

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -91,6 +91,7 @@ export {
     imemo,
     recursivelyMapArticleContent,
     traverseEnrichedBlock,
+    getParseFindings,
     checkNodeIsSpan,
     generateToc,
     groupTocIntoSections,

--- a/settings/serverSettings.ts
+++ b/settings/serverSettings.ts
@@ -96,6 +96,13 @@ export const GDOCS_CLIENT_EMAIL: string = clientSettings.GDOCS_CLIENT_EMAIL
 export const GDOCS_CLIENT_ID: string = serverSettings.GDOCS_CLIENT_ID ?? ""
 export const GDOCS_BACKPORTING_TARGET_FOLDER: string =
     serverSettings.GDOCS_BACKPORTING_TARGET_FOLDER ?? ""
+// Default Drive folder for gdocs created through the admin API
+// (POST /gdocs). Must be shared with authors — a doc created outside a shared
+// folder lands in the service account's private Drive, invisible to humans.
+export const GDOCS_AGENT_DRAFTS_FOLDER: string =
+    serverSettings.GDOCS_AGENT_DRAFTS_FOLDER ??
+    serverSettings.GDOCS_BACKPORTING_TARGET_FOLDER ??
+    ""
 
 export const GDOCS_DONATE_FAQS_DOCUMENT_ID: string =
     serverSettings.GDOCS_DONATE_FAQS_DOCUMENT_ID ?? ""

--- a/settings/serverSettings.ts
+++ b/settings/serverSettings.ts
@@ -95,6 +95,13 @@ export const GDOCS_PRIVATE_KEY: string = (
 export const GDOCS_CLIENT_EMAIL: string = clientSettings.GDOCS_CLIENT_EMAIL
 export const GDOCS_BACKPORTING_TARGET_FOLDER: string =
     serverSettings.GDOCS_BACKPORTING_TARGET_FOLDER ?? ""
+// Default Drive folder for gdocs created through the admin API
+// (POST /gdocs). Must be shared with authors — a doc created outside a shared
+// folder lands in the service account's private Drive, invisible to humans.
+export const GDOCS_AGENT_DRAFTS_FOLDER: string =
+    serverSettings.GDOCS_AGENT_DRAFTS_FOLDER ??
+    serverSettings.GDOCS_BACKPORTING_TARGET_FOLDER ??
+    ""
 
 export const GDOCS_DONATE_FAQS_DOCUMENT_ID: string =
     serverSettings.GDOCS_DONATE_FAQS_DOCUMENT_ID ?? ""


### PR DESCRIPTION
## Context

Third PR of the **claude-cms** stack (on #6544, under #6716). Lets an author
point a Claude (or any HTTP client) at the admin server and read, edit,
validate, and create gdocs **as ArchieML text** — no repo checkout, no Google
credentials, no client-side parser. All validation and Google-Docs writing
happens server-side, so faulty ArchieML physically cannot reach a document.

The companion `gdoc-editor` skill (in
[owid-claude-plugins](https://github.com/owid/owid-claude-plugins)) gives
authors the workflow on top of these endpoints. Architecture overview lives in
[docs/gdocs-agent-cms.md](../blob/claude-cms-agent-api/docs/gdocs-agent-cms.md).

## What you can observe

Three routes under the existing admin auth (Tailscale identity or Bearer API
key — no new auth):

| Route | Behavior |
| --- | --- |
| `GET /admin/api/gdocs/:id/archie` | The doc as canonical ArchieML (the exact text the ingestion pipeline sees) + `revisionId`, `registered`, `published`. Side-effect-free. |
| `PUT /admin/api/gdocs/:id/archie` | Wholesale-replaces the doc's content with real Google formatting. `?dryRun=true` validates only. |
| `POST /admin/api/gdocs` | Creates a doc from ArchieML in a shared Drive folder and registers it in the admin. |

The write refuses, in order — each with a structured error:

1. **400** — invalid ArchieML: unknown blocks, attribute `parseErrors`,
   unsupported `type`, or content that would be *silently dropped* on
   write-back (fixed-point check; ArchieML's `load()` never errors on its own)
2. **400** — a `:skip`/`:ignore` directive in the *middle* of the doc (hidden
   content there can't survive a replace); leading/trailing skip blocks are
   **preserved verbatim** (e.g. the "Preview" link atop most docs)
3. **404** — doc not registered · **403** — doc published · **409** —
   `expectedRevisionId` stale (author edited since the read)

**Front-matter keys are checked too, and each dropped key is classified** so an
agent gets a precise signal instead of a silent loss:

- an authored field the write-back can't serialize yet (`faqs`, `details`) →
  **refused**
- an admin-managed property (`slug`, `tags`, `publishedAt`, …) → a **warning**
  telling the agent to relay the change to a human, not invent front matter
- any other unrecognized key (e.g. a misspelled field) → **rejected**, so a typo can't silently drop content

This directly answers the incident where an agent invented a `slug:` line and
the write "succeeded" while dropping it.

After a successful write the doc is **read back and verified at the parse
level**, re-ingested so the admin preview is immediately correct, and the
response returns the `previewUrl` plus the saved doc's full validation report.

**One reporting rule:** each response is about exactly one artifact and the
endpoint contract says which. Dry runs / 400s judge *your submission*
(`writable` + why); `GET …/validation` and write-success responses carry *the
stored doc's* report (`publishable` + the admin's own errors/warnings). No
per-item taxonomy to decode.

## Architecture

- **`validateArchieMl` is the single gate** — parse → collect `parseErrors` →
  fixed-point re-serialize check (body, refs, **and now every top-level
  front-matter key**) → writable-type check. The dropped-key classification
  resolves against the write-back fate consts from #6544, so the gate and the
  serializer share one source of truth. The round-trip tests assert *through
  this same function*, so CI runs exactly the gate the endpoints run.
- **`splitArchieMlSkipSegments`** separates leading/trailing skip segments
  (preserved verbatim around the canonical form) from the parseable core.
- **`compareArchieMlContent`** — semantic doc equality with the tolerances a
  canonical round trip is allowed. Shared by the gate and the post-write
  verification, which deliberately does *not* compare bytes (Google normalizes
  style runs on write).
- No new auth, no schema changes; one new setting
  (`GDOCS_AGENT_DRAFTS_FOLDER`, falls back to `GDOCS_BACKPORTING_TARGET_FOLDER`).

## Testing guidance

Unit + API tests cover the gate, the front-matter classification, skip
segmentation, and all refusal paths (`db/gdocTests.test.ts`,
`adminSiteServer/tests/gdoc-archie.test.ts` — `yarn test`, `make dbtest`).

Verified end-to-end against staging with real content, including the incident
replay: dry-running an edit that adds `slug:` returns `writable: true` with the
admin-managed warning; adding `[.faqs]` is refused; a `deprecation-notice`
round-trips cleanly.

```bash
HOST=http://staging-site-claude-cms-agent-api
curl -s $HOST/admin/api/gdocs/<docId>/archie                       # read
curl -s -X PUT "$HOST/admin/api/gdocs/<docId>/archie?dryRun=true" \
  -H "Content-Type: application/json" -d '{"archieMl": "..."}'    # validate
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


