### PR TITLE
Fix staging Serve admin auth through nginx

### DIFF
--- a/adminSiteServer/authentication.test.ts
+++ b/adminSiteServer/authentication.test.ts
@@ -1,8 +1,17 @@
 import { describe, expect, it } from "vitest"
-import { getTrustedTailscaleUserLogin, isLoopbackIp } from "./authentication.js"
+import {
+    getClientIp,
+    getTrustedTailscaleUserLogin,
+    isLoopbackIp,
+} from "./authentication.js"
 
-const mockRequest = (headers: Record<string, string | undefined>) => ({
+const mockRequest = (
+    headers: Record<string, string | undefined>,
+    remoteAddress = "127.0.0.1"
+) => ({
+    headers,
     get: (header: string) => headers[header.toLowerCase()],
+    socket: { remoteAddress },
 })
 
 describe("Tailscale auth helpers", () => {
@@ -11,19 +20,18 @@ describe("Tailscale auth helpers", () => {
             "tailscale-user-login": "danyx23@github",
         })
 
-        expect(getTrustedTailscaleUserLogin(req as any, "127.0.0.1")).toBe(
-            "danyx23@github"
-        )
+        expect(getTrustedTailscaleUserLogin(req as any)).toBe("danyx23@github")
     })
 
     it("ignores spoofed Tailscale identity headers on non-localhost requests", () => {
-        const req = mockRequest({
-            "tailscale-user-login": "danyx23@github",
-        })
+        const req = mockRequest(
+            {
+                "tailscale-user-login": "danyx23@github",
+            },
+            "100.125.52.18"
+        )
 
-        expect(
-            getTrustedTailscaleUserLogin(req as any, "100.125.52.18")
-        ).toBeUndefined()
+        expect(getTrustedTailscaleUserLogin(req as any)).toBeUndefined()
     })
 
     it("recognizes loopback IP variants", () => {
@@ -31,5 +39,14 @@ describe("Tailscale auth helpers", () => {
         expect(isLoopbackIp("::1")).toBe(true)
         expect(isLoopbackIp("localhost")).toBe(true)
         expect(isLoopbackIp("100.125.52.18")).toBe(false)
+        expect(isLoopbackIp(undefined)).toBe(false)
+    })
+
+    it("uses the original client IP from X-Forwarded-For", () => {
+        const req = mockRequest({
+            "x-forwarded-for": "100.125.52.18, 127.0.0.1",
+        })
+
+        expect(getClientIp(req as any)).toBe("100.125.52.18")
     })
 })

--- a/adminSiteServer/authentication.ts
+++ b/adminSiteServer/authentication.ts
@@ -180,12 +180,8 @@ export async function tailscaleAuthMiddleware(
         return next()
     }
 
-    const tailscaleUserLogin = getTrustedTailscaleUserLogin(req, clientIp)
-    const ipToUserMap = tailscaleUserLogin
-        ? undefined
-        : await getTailscaleIpToUserMap()
-
-    const loginName = tailscaleUserLogin ?? ipToUserMap?.[clientIp]
+    const ipToUserMap = await getTailscaleIpToUserMap()
+    const loginName = ipToUserMap[clientIp] ?? getTrustedTailscaleUserLogin(req)
 
     if (!loginName) {
         return next()
@@ -274,26 +270,27 @@ async function getDevAdminUser(): Promise<DbPlainUser | undefined> {
 }
 
 export function getTrustedTailscaleUserLogin(
-    req: express.Request,
-    clientIp: string
+    req: express.Request
 ): string | undefined {
     // Tailscale Serve forwards authenticated tailnet requests with identity
     // headers, but the backend connection reaches nginx/admin over localhost.
-    // Only trust the header on that localhost path; direct HTTP access should
-    // continue to authenticate via the Tailscale source IP from X-Forwarded-For.
-    if (!isLoopbackIp(clientIp)) return undefined
+    // Direct staging HTTP auth should usually authenticate via the Tailscale
+    // source IP from X-Forwarded-For before this header fallback is used.
+    if (!isLoopbackIp(req.socket.remoteAddress)) return undefined
 
     const login = req.get(TAILSCALE_USER_LOGIN_HEADER)?.trim()
     return login || undefined
 }
 
-export function isLoopbackIp(ip: string): boolean {
+export function isLoopbackIp(ip: string | undefined): boolean {
     return ip === "127.0.0.1" || ip === "::1" || ip === "localhost"
 }
 
-function getClientIp(req: express.Request): string | undefined {
+export function getClientIp(req: express.Request): string | undefined {
     let ip =
-        (req.headers["x-forwarded-for"] as string) ||
+        (req.headers["x-forwarded-for"] as string | undefined)
+            ?.split(",")[0]
+            ?.trim() ||
         req.socket.remoteAddress ||
         req.ip
     if (ip?.startsWith("::ffff:")) {


### PR DESCRIPTION
## Summary
- parse the original client IP from the first `X-Forwarded-For` entry before doing Tailscale IP auth
- trust `Tailscale-User-Login` based on the actual socket being localhost, not the forwarded client IP
- add regression coverage for multi-hop `X-Forwarded-For` from Tailscale Serve -> nginx -> admin

## Testing
- `yarn test adminSiteServer/authentication.test.ts --run`
- `yarn fixFormatChanged`
- `yarn testLintChanged`