### PR TITLE
🐛 Fix staging deploy-queue Buildkite 422 on branch builds

### DIFF
--- a/baker/BuildkiteTrigger.ts
+++ b/baker/BuildkiteTrigger.ts
@@ -50,6 +50,13 @@ export class BuildkiteTrigger {
             branch: this.branch,
             message: message,
             env: { ...env, BUILDKITE_DEPLOY_CONTENT_SLACK_CHANNEL },
+            // Staging deploys trigger this build for a specific branch via the API.
+            // Without this flag, the build is rejected with 422 "Branches have been
+            // disabled for this pipeline" whenever the target pipeline has the "Build
+            // branches" trigger turned off (the automated-staging pipelines are
+            // PR-triggered, so it is off). We deliberately want this branch build, so
+            // bypass the pipeline's branch trigger/filter rules.
+            ignore_pipeline_branch_filters: true,
         }
 
         const response = await fetch(url, {
@@ -64,7 +71,14 @@ export class BuildkiteTrigger {
             return resp.number
         } else {
             const errorText = await response.text()
-            throw new Error(`Error: ${response.status}\n${errorText}`)
+            const explanation = errorText.includes(
+                "Branches have been disabled"
+            )
+                ? " — likely cause: this branch no longer exists on GitHub (e.g. its PR was merged/closed) or the pipeline's branch filter is misconfigured in Buildkite"
+                : ""
+            throw new Error(
+                `Error triggering Buildkite build on pipeline "${this.pipelineSlug}" for branch "${this.branch}": ${response.status}\n${errorText}${explanation}`
+            )
         }
     }
 


### PR DESCRIPTION
## Problem

Staging servers built with the `staging-bake` PR label configure the deploy queue to trigger a Buildkite build for their own branch via the REST API (`BUILDKITE_DEPLOY_CONTENT_PIPELINE_SLUG=grapher-automated-staging-environment`, `BUILDKITE_BRANCH=<branch>`). Those automated-staging pipelines are **PR-triggered** — "Build branches" is turned off — so an API build targeting a *branch* is rejected with:

```
422 {"message":"Branches have been disabled for this pipeline"}
```

The deploy queue retries the failed deploy indefinitely, so one leftover staging server generated **17,587 identical Sentry events** (ADMIN-N4).

## Fix

- **`BuildkiteTrigger`** — send `ignore_pipeline_branch_filters: true` in the create-build payload. This is a deliberate, API-initiated branch build, so it should bypass the pipeline's branch trigger/filter rules. Verified against the live pipeline: the exact payload returns `422` without the flag and `201` with it.
- **`BuildkiteTrigger`** — the thrown error now includes the pipeline slug, branch name, and a plain-English explanation, so this is self-diagnosing next time instead of a bare `Error: 422`.

## Testing

Reproduced the 422 and confirmed the flag flips it to 201 by replaying the exact deploy-queue payload against `grapher-automated-staging-environment` via the Buildkite REST API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
