### PR TITLE
Test removeWordsIfNoResults on the pages index (staging experiment)

### DIFF
--- a/baker/algolia/configureAlgolia.ts
+++ b/baker/algolia/configureAlgolia.ts
@@ -83,6 +83,10 @@ export const configureAlgolia = async () => {
             customRanking: ["desc(score)", "desc(importance)"],
             attributesToSnippet: ["content:20"],
             attributeForDistinct: "slug",
+            // If a query still returns nothing, retry treating all words as optional
+            // rather than showing a blank page — same experiment as the charts index
+            // (#6676), now on the pages index (writing + data insights).
+            removeWordsIfNoResults: "allOptional",
             attributesForFaceting: [
                 "filterOnly(slug)",
                 "afterDistinct(type)",


### PR DESCRIPTION
**Staging-only experiment — not meant to merge as-is.**

Mirrors #6676 (charts index): adds `removeWordsIfNoResults: "allOptional"` to the **pages** index settings, so the staging site's writing + data-insights search can be spot-checked with the setting on.

The quantitative comparison runs in owid/analytics (`search_demand classify --surface writing|data-insights`) against the production index via query-time parameters; this staging deploy exists so reviewers can click through real search UI results.

Context: [Slack thread](https://owid.slack.com/archives/C0149NKLZAM/p1782919982324179) — charts got the setting approved; this evaluates whether the rationale extends to writing and data insights.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
