### PR TITLE
✨🤖 (time-interval) calendar-aware ticks & labels for daily axes

### DIFF
--- a/packages/@ourworldindata/grapher/src/axis/Axis.test.ts
+++ b/packages/@ourworldindata/grapher/src/axis/Axis.test.ts
@@ -341,7 +341,7 @@ describe("for months", () => {
         expect(labels).toEqual(["Jan 2020", "Jun 2020", "Nov 2020"])
     })
 
-    it("labels every bar with month + year on a discrete monthly axis", () => {
+    it("labels every band value with month + year on a discrete monthly axis", () => {
         const day = (date: string): number =>
             convertDateToDaysSinceEpoch(dayjs.utc(date))
         const bandValues = ["2020-01-01", "2020-04-01", "2020-07-01"].map(day)
@@ -359,8 +359,8 @@ describe("for months", () => {
         axis.formatColumn = table.get("month")
         axis.range = [0, 800]
 
-        // one tick per bar, each keeping its full month + year
-        expect(axis.getTickValues().map((t) => t.label)).toEqual([
+        // one tick per band value, labeled with the column's full month + year format
+        expect(axis.tickLabels.map((t) => t.formattedValue)).toEqual([
             "Jan 2020",
             "Apr 2020",
             "Jul 2020",
@@ -417,6 +417,42 @@ describe("for months", () => {
         const wide = tickCountAt(2000)
         expect(wide).toBeGreaterThan(1) // a wide axis shows a real cadence
         expect(wide).toBeGreaterThanOrEqual(narrow) // wider fits at least as many
+    })
+
+    it("falls back to overlap-hiding when no evenly-spaced option fits on a daily band axis", () => {
+        const day = (date: string): number =>
+            convertDateToDaysSinceEpoch(dayjs.utc(date))
+        // Irregular dates — no Mondays, no first-of-month — so the only
+        // evenly-spaced labeling option is labeling every value
+        const bandValues = [
+            "2020-03-03",
+            "2020-03-06",
+            "2020-03-07",
+            "2020-03-12",
+            "2020-03-13",
+            "2020-03-17",
+            "2020-03-20",
+            "2020-03-26",
+        ].map(day)
+        const table = new OwidTable({ entityName: ["usa"], day: [0] }, [
+            { slug: "day", type: ColumnTypeNames.Day },
+        ])
+        const axis = new HorizontalAxis(
+            new AxisConfig({
+                scaleType: ScaleType.linear,
+                min: bandValues[0],
+                max: bandValues[bandValues.length - 1],
+                bandValues,
+            })
+        )
+        axis.formatColumn = table.get("day")
+        axis.range = [0, 120] // far too narrow to label every value
+
+        // labeling every value does not fit, so the axis greedily
+        // drops overlapping labels instead of rendering them all
+        const labels = axis.tickLabels
+        expect(labels.length).toBeGreaterThan(0)
+        expect(labels.length).toBeLessThan(bandValues.length)
     })
 
     it("keeps monthly ticks aligned when min/max are not month boundaries", () => {

--- a/packages/@ourworldindata/grapher/src/axis/Axis.ts
+++ b/packages/@ourworldindata/grapher/src/axis/Axis.ts
@@ -19,7 +19,9 @@ import { ComparisonLineConfig } from "@ourworldindata/types"
 import { AxisConfig, AxisManager } from "./AxisConfig"
 import {
     buildTimeAxisTicks,
-    getDiscreteMonthlyTickOptions,
+    getDiscreteTimeTickOptions,
+    isCalendarTickInterval,
+    type CalendarTickInterval,
 } from "./timeAxisTicks.js"
 import { MarkdownTextWrap } from "@ourworldindata/components"
 import { CoreColumn } from "@ourworldindata/core-table"
@@ -330,15 +332,30 @@ abstract class AbstractAxis {
     }
 
     /**
+     * The time interval for which this axis shows calendar-aware ticks, or
+     * `undefined` if the axis uses the generic tick pipeline instead (because
+     * ticks are author-supplied, the column isn't a time column, or its
+     * interval has no calendar-aware handling).
+     */
+    @computed protected get calendarTickInterval():
+        | CalendarTickInterval
+        | undefined {
+        const column = this.formatColumn
+        if (this.config.ticks || !column?.isTimeColumn) return undefined
+        return isCalendarTickInterval(column.timeInterval)
+            ? column.timeInterval
+            : undefined
+    }
+
+    /**
      * Calendar-aware ticks (values + labels) for time axes that support them;
      * `undefined` otherwise, so the axis falls through to the generic pipeline.
      */
     @computed protected get timeAxisTicks(): Tickmark[] | undefined {
-        if (this.config.ticks || !this.formatColumn?.isTimeColumn)
-            return undefined
+        if (this.calendarTickInterval === undefined) return undefined
 
         return buildTimeAxisTicks({
-            interval: this.formatColumn.timeInterval,
+            interval: this.calendarTickInterval,
             domain: this.domain,
             targetCount: this.totalTicksTarget,
             bandValues: this.config.bandValues,
@@ -723,19 +740,21 @@ export class HorizontalAxis extends AbstractAxis {
 
     @computed get tickLabels(): TickLabelPlacement[] {
         // A discrete (band) time axis shows a single evenly-spaced labeling:
-        // the finest one that fits (every month, then quarter, year, 2 years, …)
-        if (this.timeAxisTicks && this.config.bandValues) {
-            const options = getDiscreteMonthlyTickOptions({
-                bandValues: this.config.bandValues ?? [],
+        // the finest one that fits (every day, then week, month, quarter, year, …)
+        const interval = this.calendarTickInterval
+        if (interval !== undefined && this.config.bandValues) {
+            const options = getDiscreteTimeTickOptions({
+                interval,
+                bandValues: this.config.bandValues,
             })
-            let placedTickLabels: TickLabelPlacement[] = []
             for (const option of options) {
-                placedTickLabels = option.map((tick) =>
+                const placedTickLabels = option.map((tick) =>
                     this.placeTickLabel(tick.value, tick.label)
                 )
-                if (labelsFit(placedTickLabels, { padding: 3 })) break
+                if (labelsFit(placedTickLabels, { padding: 3 }))
+                    return placedTickLabels
             }
-            return placedTickLabels
+            // If no evenly-spaced option fits, fall through to the greedy labeling below
         }
 
         // Otherwise: place all ticks greedily drop individual overlaps.

--- a/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.test.ts
+++ b/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.test.ts
@@ -214,6 +214,15 @@ describe(buildContinuousDailyAxisTicks, () => {
         ])
     })
 
+    it("keeps a day step whose in-domain ticks meet a target the raw span/step estimate exceeds", () => {
+        // 29 days / 14 is just over the target of 2, but only two biweekly
+        // Mondays land in the domain — prefer them over a single monthly tick
+        expect(gridDates("2020-03-04", "2020-04-02", 2)).toEqual([
+            "2020-03-16",
+            "2020-03-30",
+        ])
+    })
+
     it("continues on the monthly grid for multi-month spans", () => {
         const domain: [number, number] = [day("2020-01-01"), day("2020-07-01")]
         const ticks = buildContinuousDailyAxisTicks({ domain, targetCount: 6 })

--- a/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.test.ts
+++ b/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.test.ts
@@ -4,10 +4,15 @@ import {
     convertDaysSinceEpochToDate,
     convertDateToDaysSinceEpoch,
 } from "@ourworldindata/utils"
+import { TimeInterval } from "@ourworldindata/types"
 import {
-    buildDiscreteMonthlyAxisTicks,
+    buildTimeAxisTicks,
+    buildDiscreteTimeAxisTicks,
     buildContinuousMonthlyAxisTicks,
     getDiscreteMonthlyTickOptions,
+    buildContinuousDailyAxisTicks,
+    getDiscreteDailyTickOptions,
+    getDiscreteTimeTickOptions,
 } from "./timeAxisTicks"
 
 // Day-since-epoch for a "YYYY-MM-DD" date
@@ -81,6 +86,16 @@ describe(buildContinuousMonthlyAxisTicks, () => {
         expect(gridDates("2020-05-03", "2020-05-28", 6)).toBeUndefined()
     })
 
+    it("drops grid ticks before a mid-month domain start", () => {
+        // The 2-month grid is anchored to January, but the domain only
+        // starts on Jan 5, so the Jan 1 tick is dropped
+        expect(gridDates("2020-01-05", "2020-08-20", 6)).toEqual([
+            "2020-03-01",
+            "2020-05-01",
+            "2020-07-01",
+        ])
+    })
+
     it("only produces first-of-month ticks within the domain", () => {
         const minDay = day("2015-07-15")
         const maxDay = day("2019-02-20")
@@ -139,24 +154,270 @@ describe(buildContinuousMonthlyAxisTicks, () => {
     })
 })
 
-describe(buildDiscreteMonthlyAxisTicks, () => {
-    it("labels every bar with month + year (the year is never dropped)", () => {
-        const ticks = buildDiscreteMonthlyAxisTicks({
+describe(buildContinuousDailyAxisTicks, () => {
+    // The grid tick values, as YYYY-MM-DD (or undefined for a degenerate span).
+    const gridDates = (
+        min: string,
+        max: string,
+        targetCount: number
+    ): string[] | undefined => {
+        const ticks = buildContinuousDailyAxisTicks({
+            domain: [day(min), day(max)],
+            targetCount,
+        })
+        return ticks && asDates(ticks.map((tick) => tick.value))
+    }
+
+    it("steps every day for short spans", () => {
+        expect(gridDates("2020-03-01", "2020-03-05", 6)).toEqual([
+            "2020-03-01",
+            "2020-03-02",
+            "2020-03-03",
+            "2020-03-04",
+            "2020-03-05",
+        ])
+    })
+
+    it("steps every other day on a grid that is stable when panning", () => {
+        const grid = [
+            "2020-03-01",
+            "2020-03-03",
+            "2020-03-05",
+            "2020-03-07",
+            "2020-03-09",
+        ]
+        expect(gridDates("2020-03-01", "2020-03-10", 6)).toEqual(grid)
+        // A domain start one day earlier keeps the same grid
+        expect(gridDates("2020-02-29", "2020-03-09", 6)).toEqual(grid)
+    })
+
+    it("steps weekly on Mondays", () => {
+        const dates = gridDates("2020-03-01", "2020-04-05", 6)!
+        expect(dates).toEqual([
+            "2020-03-02",
+            "2020-03-09",
+            "2020-03-16",
+            "2020-03-23",
+            "2020-03-30",
+        ])
+        for (const date of dates) expect(dayjs.utc(date).day()).toBe(1)
+    })
+
+    it("steps biweekly on Mondays for ~2-3 month spans", () => {
+        expect(gridDates("2020-03-01", "2020-05-15", 6)).toEqual([
+            "2020-03-02",
+            "2020-03-16",
+            "2020-03-30",
+            "2020-04-13",
+            "2020-04-27",
+            "2020-05-11",
+        ])
+    })
+
+    it("continues on the monthly grid for multi-month spans", () => {
+        const domain: [number, number] = [day("2020-01-01"), day("2020-07-01")]
+        const ticks = buildContinuousDailyAxisTicks({ domain, targetCount: 6 })
+        expect(ticks).toEqual(
+            buildContinuousMonthlyAxisTicks({ domain, targetCount: 6 })
+        )
+        expect(asDates(ticks!.map((t) => t.value))).toEqual([
+            "2020-01-01",
+            "2020-02-01",
+            "2020-03-01",
+            "2020-04-01",
+            "2020-05-01",
+            "2020-06-01",
+            "2020-07-01",
+        ])
+    })
+
+    it("labels multi-year spans with bare years", () => {
+        const ticks = buildContinuousDailyAxisTicks({
+            domain: [day("2015-06-15"), day("2022-03-01")],
+            targetCount: 6,
+        })!
+        expect(ticks.map((t) => t.label)).toEqual([
+            "2016",
+            "2018",
+            "2020",
+            "2022",
+        ])
+    })
+
+    it("shows the year on the first tick and wherever the year changes", () => {
+        const ticks = buildContinuousDailyAxisTicks({
+            domain: [day("2020-12-20"), day("2021-01-20")],
+            targetCount: 6,
+        })!
+        expect(ticks.map((t) => t.label)).toEqual([
+            "Dec 21, 2020",
+            "Dec 28",
+            "Jan 4, 2021",
+            "Jan 11",
+            "Jan 18",
+        ])
+    })
+
+    it("only produces ticks within the domain", () => {
+        const minDay = day("2020-03-04")
+        const maxDay = day("2020-04-02")
+        const ticks = buildContinuousDailyAxisTicks({
+            domain: [minDay, maxDay],
+            targetCount: 6,
+        })!
+        for (const { value } of ticks) {
+            expect(value).toBeGreaterThanOrEqual(minDay)
+            expect(value).toBeLessThanOrEqual(maxDay)
+        }
+    })
+})
+
+describe(buildDiscreteTimeAxisTicks, () => {
+    it("returns one tick per value, sorted and deduplicated", () => {
+        const ticks = buildDiscreteTimeAxisTicks({
             bandValues: [
-                "2020-01-01",
-                "2020-04-01",
-                "2020-07-01",
-                "2021-01-01",
-                "2021-04-01",
+                "2020-03-03",
+                "2020-03-01",
+                "2020-03-02",
+                "2020-03-01",
             ].map(day),
         })
-        expect(ticks.map((t) => t.label)).toEqual([
-            "Jan 2020",
-            "Apr 2020",
-            "Jul 2020",
-            "Jan 2021",
-            "Apr 2021",
+        expect(asDates(ticks.map((t) => t.value))).toEqual([
+            "2020-03-01",
+            "2020-03-02",
+            "2020-03-03",
         ])
+    })
+
+    it("leaves ticks unlabeled so the axis uses the column's own time format", () => {
+        const ticks = buildDiscreteTimeAxisTicks({
+            bandValues: ["2020-01-01", "2020-04-01"].map(day),
+        })
+        for (const tick of ticks) expect(tick.label).toBeUndefined()
+    })
+})
+
+describe(buildTimeAxisTicks, () => {
+    it("returns undefined for intervals without special handling", () => {
+        const bandValues = ["2020-01-01", "2021-01-01"].map(day)
+        const ticks = buildTimeAxisTicks({
+            interval: TimeInterval.Year,
+            domain: [bandValues[0], bandValues[1]],
+            targetCount: 6,
+            bandValues,
+        })
+        expect(ticks).toBeUndefined()
+    })
+})
+
+describe(getDiscreteDailyTickOptions, () => {
+    const dailyBars = (start: string, end: string): number[] => {
+        const values: number[] = []
+        for (let d = day(start); d <= day(end); d++) values.push(d)
+        return values
+    }
+    const dayGaps = (ticks: { value: number }[]): number[] =>
+        ticks.slice(1).map((t, i) => t.value - ticks[i].value)
+
+    const options = getDiscreteDailyTickOptions({
+        bandValues: dailyBars("2020-01-01", "2020-06-30"),
+    })
+
+    it("orders options from finest to coarsest", () => {
+        const counts = options.map((option) => option.length)
+        expect(counts).toEqual([...counts].sort((a, b) => b - a))
+    })
+
+    it("makes the day and week options a single uniform spacing", () => {
+        for (const option of options) {
+            const gaps = new Set(dayGaps(option))
+            // day/week tiers are uniform; monthly tiers step by
+            // calendar months, so their gaps vary by a few days
+            if ([...gaps].every((gap) => gap < 28))
+                expect(gaps.size).toBeLessThanOrEqual(1)
+        }
+    })
+
+    it("puts weekly and biweekly options on Mondays", () => {
+        const weekly = options.find((option) => dayGaps(option)[0] === 7)!
+        const biweekly = options.find((option) => dayGaps(option)[0] === 14)!
+        for (const tick of [...weekly, ...biweekly])
+            expect(convertDaysSinceEpochToDate(tick.value).day()).toBe(1)
+    })
+
+    it("puts monthly and coarser options on the first of the month", () => {
+        const monthly = options.filter((option) => dayGaps(option)[0] >= 28)
+        expect(monthly.length).toBeGreaterThan(0)
+        for (const option of monthly)
+            for (const tick of option)
+                expect(convertDaysSinceEpochToDate(tick.value).date()).toBe(1)
+    })
+
+    it("includes a quarterly option on first-of-month values", () => {
+        const quarterly = options.find((option) => option.length === 2)
+        expect(asDates(quarterly!.map((t) => t.value))).toEqual([
+            "2020-01-01",
+            "2020-04-01",
+        ])
+    })
+
+    it("never offers a ragged subset of irregular values", () => {
+        // Band values on irregular dates. The every-2nd-day grid *contains* four of
+        // them — Mar 7, 11, 17 and 21 — but with ragged gaps (4, 6 and 4
+        // days), because the values in between sit on odd days. Labeling that
+        // subset would look deliberate, so it must not be offered. With no
+        // Mondays or first-of-months either, the only option left is
+        // labeling every value.
+        const bandValues = [
+            "2020-03-06",
+            "2020-03-07",
+            "2020-03-10",
+            "2020-03-11",
+            "2020-03-17",
+            "2020-03-18",
+            "2020-03-21",
+        ].map(day)
+        const options = getDiscreteDailyTickOptions({ bandValues })
+        expect(options).toHaveLength(1)
+        expect(options[0].map((t) => t.value)).toEqual(bandValues)
+    })
+
+    it("thins weekly values to consecutive biweekly Mondays, never a ragged parity subset", () => {
+        // Band values on every Monday: the biweekly option must take every other
+        // Monday, and no option may have uneven gaps
+        const mondays = [
+            "2020-03-02",
+            "2020-03-09",
+            "2020-03-16",
+            "2020-03-23",
+            "2020-03-30",
+            "2020-04-06",
+            "2020-04-13",
+        ].map(day)
+        const options = getDiscreteDailyTickOptions({ bandValues: mondays })
+        for (const option of options)
+            expect(new Set(dayGaps(option)).size).toBeLessThanOrEqual(1)
+        const biweekly = options.find((option) => dayGaps(option)[0] === 14)
+        expect(biweekly!).toHaveLength(4)
+    })
+})
+
+describe(getDiscreteTimeTickOptions, () => {
+    const bandValues = ["2020-01-01", "2020-02-01", "2020-03-01"].map(day)
+
+    it("dispatches by time interval", () => {
+        expect(
+            getDiscreteTimeTickOptions({
+                interval: TimeInterval.Month,
+                bandValues,
+            })
+        ).toEqual(getDiscreteMonthlyTickOptions({ bandValues }))
+        expect(
+            getDiscreteTimeTickOptions({
+                interval: TimeInterval.Day,
+                bandValues,
+            })
+        ).toEqual(getDiscreteDailyTickOptions({ bandValues }))
     })
 })
 
@@ -191,16 +452,16 @@ describe(getDiscreteMonthlyTickOptions, () => {
         const twoYearOption = options.find(
             (option) => monthGaps(option)[0] === 24 // 2 years
         )
-        expect(twoYearOption?.map((t) => t.label)).toEqual([
-            "Jan 2010",
-            "Jan 2012",
-            "Jan 2014",
-            "Jan 2016",
-            "Jan 2018",
-            "Jan 2020",
-            "Jan 2022",
-            "Jan 2024",
-            "Jan 2026",
+        expect(asDates(twoYearOption!.map((t) => t.value))).toEqual([
+            "2010-01-01",
+            "2012-01-01",
+            "2014-01-01",
+            "2016-01-01",
+            "2018-01-01",
+            "2020-01-01",
+            "2022-01-01",
+            "2024-01-01",
+            "2026-01-01",
         ])
     })
 

--- a/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.test.ts
+++ b/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.test.ts
@@ -370,6 +370,17 @@ describe(getDiscreteDailyTickOptions, () => {
         ])
     })
 
+    it("never offers a single-label option", () => {
+        // Jul 1 is the range's only first-of-month and used to be offered as
+        // a lone calendar-anchored tick on the last band; instead, the axis
+        // should fall back to greedy labeling when no multi-label option fits
+        const options = getDiscreteDailyTickOptions({
+            bandValues: dailyBars("2025-06-07", "2025-07-01"),
+        })
+        for (const option of options)
+            expect(option.length).toBeGreaterThanOrEqual(2)
+    })
+
     it("never offers a ragged subset of irregular values", () => {
         // Band values on irregular dates. The every-2nd-day grid *contains* four of
         // them — Mar 7, 11, 17 and 21 — but with ragged gaps (4, 6 and 4

--- a/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.ts
+++ b/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.ts
@@ -5,6 +5,7 @@ import {
     Tickmark,
     convertDaysSinceEpochToDate,
     convertDateToDaysSinceEpoch,
+    snapToIntervalStart,
 } from "@ourworldindata/utils"
 import { TimeInterval } from "@ourworldindata/types"
 import { match } from "ts-pattern"
@@ -24,9 +25,94 @@ const MONTH_STEPS = [
     1200, // 100 years
 ] as const
 
+// Calendar-nice step sizes in days
+const DAY_STEPS = [
+    1, // 1 day
+    2, // 2 days
+    7, // 1 week
+    14, // 2 weeks
+] as const
+
+// A fixed Monday (in days since epoch) that anchors weekly grids
+const MONDAY_REFERENCE = snapToIntervalStart(0, TimeInterval.Week)
+
+// Time intervals with calendar-aware axis ticks; all other intervals
+// fall back to the generic d3 ticks
+const CALENDAR_TICK_INTERVALS = [TimeInterval.Month, TimeInterval.Day] as const
+
+export type CalendarTickInterval = (typeof CALENDAR_TICK_INTERVALS)[number]
+
+export function isCalendarTickInterval(
+    interval: TimeInterval
+): interval is CalendarTickInterval {
+    return (CALENDAR_TICK_INTERVALS as readonly TimeInterval[]).includes(
+        interval
+    )
+}
+
 /** A tickmark for a day-since-epoch `value`, labeled with the given dayjs format. */
 function makeDayTick(value: number, format: string): Tickmark {
     return { value, priority: 2, label: formatDay(value, { format }) }
+}
+
+/** A band value with its calendar coordinates */
+interface CalendarValue {
+    value: number
+    /** The calendar month, as a linear count of months */
+    monthIndex: number
+    isFirstOfMonth: boolean
+}
+
+function toCalendarValue(value: number): CalendarValue {
+    const date = convertDaysSinceEpochToDate(value)
+    return {
+        value,
+        monthIndex: date.year() * 12 + date.month(),
+        isFirstOfMonth: date.date() === 1,
+    }
+}
+
+/**
+ * The reference day that anchors a day grid with the given step: a Monday for
+ * weekly steps (so ticks land on week starts), the epoch otherwise (so grids
+ * are stable when panning).
+ */
+function dayGridReference(step: number): number {
+    return step % 7 === 0 ? MONDAY_REFERENCE : 0
+}
+
+/**
+ * The position of a value on the day grid with the given step;
+ * an integer only for values that lie on the grid.
+ */
+function dayGridPosition({ value }: CalendarValue, step: number): number {
+    return (value - dayGridReference(step)) / step
+}
+
+/**
+ * The position of a value on the January-anchored month grid with the given
+ * step; an integer only for values that lie on the grid.
+ */
+function monthGridPosition(
+    { monthIndex }: CalendarValue,
+    step: number
+): number {
+    return monthIndex / step
+}
+
+/**
+ * Labels each grid value with `format`, switching to `formatWithYear` on the
+ * first tick and wherever the year changes.
+ */
+function labelGridWithYearOnChange(
+    grid: number[],
+    { format, formatWithYear }: { format: string; formatWithYear: string }
+): Tickmark[] {
+    const years = grid.map((value) => convertDaysSinceEpochToDate(value).year())
+    return grid.map((value, i) => {
+        const isNewYear = i === 0 || years[i] !== years[i - 1]
+        return makeDayTick(value, isNewYear ? formatWithYear : format)
+    })
 }
 
 /**
@@ -44,13 +130,18 @@ export function buildTimeAxisTicks({
     targetCount: number
     bandValues?: number[]
 }): Tickmark[] | undefined {
+    if (!isCalendarTickInterval(interval)) return undefined
+
+    if (bandValues?.length) return buildDiscreteTimeAxisTicks({ bandValues })
+
     return match(interval)
         .with(TimeInterval.Month, () =>
-            bandValues?.length
-                ? buildDiscreteMonthlyAxisTicks({ bandValues })
-                : buildContinuousMonthlyAxisTicks({ domain, targetCount })
+            buildContinuousMonthlyAxisTicks({ domain, targetCount })
         )
-        .otherwise(() => undefined)
+        .with(TimeInterval.Day, () =>
+            buildContinuousDailyAxisTicks({ domain, targetCount })
+        )
+        .exhaustive()
 }
 
 /**
@@ -95,9 +186,12 @@ export function buildContinuousMonthlyAxisTicks({
     const firstStep = Math.ceil(monthsFromAnchor(minDate) / step)
     const lastStep = Math.floor(monthsFromAnchor(maxDate) / step)
 
-    const grid = _.range(firstStep, lastStep + 1).map((k) =>
-        convertDateToDaysSinceEpoch(anchor.add(k * step, "month"))
-    )
+    const grid = _.range(firstStep, lastStep + 1)
+        .map((k) => convertDateToDaysSinceEpoch(anchor.add(k * step, "month")))
+        // The first index is rounded from the domain's start month, so a
+        // mid-month domain start can produce a tick just before it - drop those
+        .filter((value) => value >= domain[0] && value <= domain[1])
+    if (!grid.length) return undefined
 
     // When every tick is a January, drop the redundant month and label only the year.
     const isJanuary = (value: number): boolean =>
@@ -107,53 +201,177 @@ export function buildContinuousMonthlyAxisTicks({
 
     // Otherwise label the month only, keeping the year on the first tick
     // and each January (i.e. wherever the year changes)
-    const years = grid.map((value) => convertDaysSinceEpochToDate(value).year())
-    return grid.map((value, i) => {
-        const isNewYear = i === 0 || years[i] !== years[i - 1]
-        return makeDayTick(value, isNewYear ? "MMM YYYY" : "MMM")
+    return labelGridWithYearOnChange(grid, {
+        format: "MMM",
+        formatWithYear: "MMM YYYY",
     })
 }
 
-/** One tick per domain value, each labeled with its full month and year */
-export function buildDiscreteMonthlyAxisTicks({
+/**
+ * A calendar-nice day grid (every day, every other day, weekly or biweekly
+ * on Mondays), sized to `targetCount`, with redundant year parts dropped from
+ * the labels. Spans too long for day-sized steps continue on the monthly grid.
+ */
+export function buildContinuousDailyAxisTicks({
+    domain,
+    targetCount,
+}: {
+    domain: [number, number]
+    targetCount: number
+}): Tickmark[] | undefined {
+    const spanDays = domain[1] - domain[0]
+    if (spanDays <= 0) return undefined
+
+    // Pick the smallest step that keeps the tick count at or below the
+    // target; if even the coarsest day step produces too many ticks,
+    // fall through to the monthly (and yearly) grid.
+    const step = DAY_STEPS.find((s) => spanDays / s <= targetCount)
+    if (step === undefined)
+        return buildContinuousMonthlyAxisTicks({ domain, targetCount })
+
+    const reference = dayGridReference(step)
+
+    // The first and last indices that stay within the domain: round the
+    // start up and the end down so both ticks land inside the domain.
+    const firstStep = Math.ceil((domain[0] - reference) / step)
+    const lastStep = Math.floor((domain[1] - reference) / step)
+
+    const grid = _.range(firstStep, lastStep + 1).map(
+        (k) => reference + k * step
+    )
+    if (!grid.length) return undefined
+
+    // Label the day and month, keeping the year on the first tick
+    // and wherever the year changes
+    return labelGridWithYearOnChange(grid, {
+        format: "MMM D",
+        formatWithYear: "MMM D, YYYY",
+    })
+}
+
+/**
+ * One tick per domain value. The ticks carry no label: each value is labeled
+ * independently, so the axis falls back to the column's own time format,
+ * which is never abbreviated (e.g. "Jan 2023" for months, "Jan 5, 2023"
+ * for days).
+ */
+export function buildDiscreteTimeAxisTicks({
     bandValues,
 }: {
     bandValues: number[]
 }): Tickmark[] {
-    return _.sortBy(_.uniq(bandValues)).map((value) =>
-        makeDayTick(value, "MMM YYYY")
-    )
+    return _.sortBy(_.uniq(bandValues)).map((value) => ({
+        value,
+        priority: 2,
+    }))
 }
 
 /**
- * The label sets a discrete monthly axis can pick from, ordered from finest to
- * coarsest — each a single evenly-spaced set (every month, quarter, year, 2
- * years, …). The axis shows the finest that fits; using one spacing per set
+ * The label sets a discrete time axis can pick from, ordered from finest to
+ * coarsest — each a single evenly-spaced set (every day, week, month, quarter,
+ * year, …). The axis shows the finest that fits; using one spacing per set
  * ensures the gaps remain uniform.
  */
+export function getDiscreteTimeTickOptions({
+    interval,
+    bandValues,
+}: {
+    interval: CalendarTickInterval
+    bandValues: number[]
+}): Tickmark[][] {
+    return match(interval)
+        .with(TimeInterval.Month, () =>
+            getDiscreteMonthlyTickOptions({ bandValues })
+        )
+        .with(TimeInterval.Day, () =>
+            getDiscreteDailyTickOptions({ bandValues })
+        )
+        .exhaustive()
+}
+
+/**
+ * Maps a value to its position on a grid; an integer for values on the grid,
+ * a non-integer (or NaN) otherwise.
+ */
+type GridPosition = (value: CalendarValue) => number
+
+/**
+ * One label set per grid, starting with a set that labels every value. A grid's
+ * set is only offered when its values sit on consecutive grid points, so
+ * every offered set is evenly spaced. Skips sets that don't thin the previous
+ * one and stops once a set holds a single value (nothing coarser can add).
+ * The grids are expected to be ordered from finest to coarsest.
+ */
+function buildTickOptionsFromGrids(
+    bandValues: number[],
+    grids: GridPosition[]
+): Tickmark[][] {
+    const calendarValues = _.sortBy(_.uniq(bandValues)).map(toCalendarValue)
+    const makeTier = (values: CalendarValue[]): Tickmark[] =>
+        values.map(({ value }) => ({ value, priority: 2 }))
+
+    // The finest option labels every value, evenly spaced or not
+    const tiers: Tickmark[][] = [makeTier(calendarValues)]
+    if (calendarValues.length <= 1) return tiers
+
+    for (const gridPosition of grids) {
+        const valuesOnGrid = calendarValues
+            .map((value) => ({ value, position: gridPosition(value) }))
+            .filter(({ position }) => Number.isInteger(position))
+        if (!valuesOnGrid.length) continue
+
+        // Only offer evenly-spaced sets: the values must sit on consecutive
+        // grid points, otherwise the labels would have ragged gaps
+        const isEvenlySpaced = valuesOnGrid.every(
+            ({ position }, i) =>
+                i === 0 || position - valuesOnGrid[i - 1].position === 1
+        )
+        if (!isEvenlySpaced) continue
+
+        // The axis shows the first set whose labels fit, so a set with as
+        // many labels as the previous one can't fit where that one didn't —
+        // only offer strictly smaller sets
+        if (valuesOnGrid.length === tiers[tiers.length - 1].length) continue
+
+        tiers.push(makeTier(valuesOnGrid.map(({ value }) => value)))
+
+        if (valuesOnGrid.length === 1) break
+    }
+
+    return tiers
+}
+
+/** See getDiscreteTimeTickOptions; steps every month, quarter, year, … */
 export function getDiscreteMonthlyTickOptions({
     bandValues,
 }: {
     bandValues: number[]
 }): Tickmark[][] {
-    const sortedValues = _.sortBy(_.uniq(bandValues))
-
-    const monthIndex = (value: number): number => {
-        const date = convertDaysSinceEpochToDate(value)
-        return date.year() * 12 + date.month()
-    }
-
-    const tiers: Tickmark[][] = []
-    for (const step of MONTH_STEPS) {
-        const valuesOnGrid = sortedValues.filter(
-            (value) => monthIndex(value) % step === 0
+    return buildTickOptionsFromGrids(
+        bandValues,
+        MONTH_STEPS.map(
+            (step) => (value: CalendarValue) => monthGridPosition(value, step)
         )
-        if (!valuesOnGrid.length) continue
+    )
+}
 
-        tiers.push(valuesOnGrid.map((value) => makeDayTick(value, "MMM YYYY")))
-
-        if (valuesOnGrid.length === 1) break // nothing coarser can add
-    }
-
-    return tiers
+/**
+ * See getDiscreteTimeTickOptions; steps every day, every other day,
+ * weekly and biweekly (on Mondays), then continues on the monthly grid
+ * restricted to first-of-month values.
+ */
+export function getDiscreteDailyTickOptions({
+    bandValues,
+}: {
+    bandValues: number[]
+}): Tickmark[][] {
+    return buildTickOptionsFromGrids(bandValues, [
+        ...DAY_STEPS.map(
+            (step) => (value: CalendarValue) => dayGridPosition(value, step)
+        ),
+        ...MONTH_STEPS.map(
+            (step) => (value: CalendarValue) =>
+                value.isFirstOfMonth ? monthGridPosition(value, step) : NaN
+        ),
+    ])
 }

--- a/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.ts
+++ b/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.ts
@@ -315,7 +315,9 @@ type GridPosition = (value: CalendarValue) => number
  * One label set per grid, starting with a set that labels every value. A grid's
  * set is only offered when its values sit on consecutive grid points, so
  * every offered set is evenly spaced. Skips sets that don't thin the previous
- * one and stops once a set holds a single value (nothing coarser can add).
+ * one. Single-value sets aren't offered: when no multi-label set fits, the
+ * axis falls back to greedy labeling, which labels as many bands as fit
+ * instead of a lone calendar-anchored one (often the first or last band).
  * The grids are expected to be ordered from finest to coarsest.
  */
 function buildTickOptionsFromGrids(
@@ -334,7 +336,7 @@ function buildTickOptionsFromGrids(
         const valuesOnGrid = calendarValues
             .map((value) => ({ value, position: gridPosition(value) }))
             .filter(({ position }) => Number.isInteger(position))
-        if (!valuesOnGrid.length) continue
+        if (valuesOnGrid.length < 2) continue
 
         // Only offer evenly-spaced sets: the values must sit on consecutive
         // grid points, otherwise the labels would have ragged gaps
@@ -351,7 +353,7 @@ function buildTickOptionsFromGrids(
 
         tiers.push(makeTier(valuesOnGrid.map(({ value }) => value)))
 
-        if (valuesOnGrid.length === 1) break
+        if (valuesOnGrid.length === 2) break
     }
 
     return tiers

--- a/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.ts
+++ b/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.ts
@@ -222,20 +222,36 @@ export function buildContinuousDailyAxisTicks({
     const spanDays = domain[1] - domain[0]
     if (spanDays <= 0) return undefined
 
+    // The first and last grid indices that stay within the domain: round the
+    // start up and the end down so both ticks land inside the domain.
+    const gridIndexRange = (step: number): [number, number] => {
+        const reference = dayGridReference(step)
+        return [
+            Math.ceil((domain[0] - reference) / step),
+            Math.floor((domain[1] - reference) / step),
+        ]
+    }
+    const inDomainTickCount = (step: number): number => {
+        const [first, last] = gridIndexRange(step)
+        return last - first + 1
+    }
+
     // Pick the smallest step that keeps the tick count at or below the
-    // target; if even the coarsest day step produces too many ticks,
-    // fall through to the monthly (and yearly) grid.
-    const step = DAY_STEPS.find((s) => spanDays / s <= targetCount)
+    // target; if even the coarsest day step produces too many ticks, fall
+    // through to the monthly (and yearly) grid. The span/step estimate can
+    // count one tick more than actually lands in the domain, so also accept
+    // a step by its in-domain count — otherwise a 29-day domain with a
+    // target of two would skip the fitting biweekly grid and fall through
+    // to a single monthly tick.
+    const step = DAY_STEPS.find(
+        (s) =>
+            spanDays / s <= targetCount || inDomainTickCount(s) <= targetCount
+    )
     if (step === undefined)
         return buildContinuousMonthlyAxisTicks({ domain, targetCount })
 
     const reference = dayGridReference(step)
-
-    // The first and last indices that stay within the domain: round the
-    // start up and the end down so both ticks land inside the domain.
-    const firstStep = Math.ceil((domain[0] - reference) / step)
-    const lastStep = Math.floor((domain[1] - reference) / step)
-
+    const [firstStep, lastStep] = gridIndexRange(step)
     const grid = _.range(firstStep, lastStep + 1).map(
         (k) => reference + k * step
     )


### PR DESCRIPTION
Extends the monthly tick ladder downward: daily axes step every
day, 2 days, weekly/biweekly on Mondays, then continue on the
existing monthly/yearly grid for longer spans. Discrete (band)
time axes pick the finest evenly-spaced label set that fits; their
ticks carry no label and fall back to the column's own time format
so formatting is defined in one place. The intervals with
calendar-aware ticks are typed (CalendarTickInterval) and narrowed
once in Axis.calendarTickInterval. Also drops monthly grid ticks
that fall before a mid-month domain start, reachable now that
daily domains delegate to the monthly grid.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

<!-- GitButler Footer Boundary Top -->
---
This is **part 4 of 9 in a stack** made with GitButler:
- <kbd>&nbsp;9&nbsp;</kbd> #6810 
- <kbd>&nbsp;8&nbsp;</kbd> #6752 
- <kbd>&nbsp;7&nbsp;</kbd> #6733 
- <kbd>&nbsp;6&nbsp;</kbd> #6723 
- <kbd>&nbsp;5&nbsp;</kbd> #6722 
- <kbd>&nbsp;4&nbsp;</kbd> #6721 👈 
- <kbd>&nbsp;3&nbsp;</kbd> #6699 
- <kbd>&nbsp;2&nbsp;</kbd> #6696 
- <kbd>&nbsp;1&nbsp;</kbd> #6700 
<!-- GitButler Footer Boundary Bottom -->