### PR TITLE
🎉🤖 (time-interval) calendar-aware ticks & labels for weekly axes

### DIFF
--- a/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.test.ts
+++ b/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.test.ts
@@ -327,6 +327,16 @@ describe(buildContinuousWeeklyAxisTicks, () => {
         ])
     })
 
+    it("keeps the biweekly grid for same-month spans where no step meets the target", () => {
+        // No monthly grid exists within a single calendar month, so the
+        // coarsest week step wins over falling back to generic d3 ticks
+        expect(gridDates("2020-03-01", "2020-03-31", 2)).toEqual([
+            "2020-03-02",
+            "2020-03-16",
+            "2020-03-30",
+        ])
+    })
+
     it("continues on the monthly grid for multi-month spans", () => {
         const domain: [number, number] = [day("2020-01-06"), day("2020-07-06")]
         const ticks = buildContinuousWeeklyAxisTicks({ domain, targetCount: 6 })

--- a/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.test.ts
+++ b/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.test.ts
@@ -10,6 +10,8 @@ import {
     buildDiscreteTimeAxisTicks,
     buildContinuousMonthlyAxisTicks,
     getDiscreteMonthlyTickOptions,
+    buildContinuousWeeklyAxisTicks,
+    getDiscreteWeeklyTickOptions,
     buildContinuousDailyAxisTicks,
     getDiscreteDailyTickOptions,
     getDiscreteTimeTickOptions,
@@ -281,6 +283,138 @@ describe(buildContinuousDailyAxisTicks, () => {
     })
 })
 
+describe(buildContinuousWeeklyAxisTicks, () => {
+    // The grid tick values, as YYYY-MM-DD (or undefined for a degenerate span).
+    const gridDates = (
+        min: string,
+        max: string,
+        targetCount: number
+    ): string[] | undefined => {
+        const ticks = buildContinuousWeeklyAxisTicks({
+            domain: [day(min), day(max)],
+            targetCount,
+        })
+        return ticks && asDates(ticks.map((tick) => tick.value))
+    }
+
+    it("steps weekly on Mondays for short spans", () => {
+        expect(gridDates("2020-03-02", "2020-04-06", 6)).toEqual([
+            "2020-03-02",
+            "2020-03-09",
+            "2020-03-16",
+            "2020-03-23",
+            "2020-03-30",
+            "2020-04-06",
+        ])
+    })
+
+    it("never steps below a week, even for tiny spans", () => {
+        // The daily ladder would pick a 2-day step here
+        expect(gridDates("2020-03-02", "2020-03-09", 6)).toEqual([
+            "2020-03-02",
+            "2020-03-09",
+        ])
+    })
+
+    it("steps biweekly on Mondays for ~2-3 month spans", () => {
+        expect(gridDates("2020-03-02", "2020-05-11", 6)).toEqual([
+            "2020-03-02",
+            "2020-03-16",
+            "2020-03-30",
+            "2020-04-13",
+            "2020-04-27",
+            "2020-05-11",
+        ])
+    })
+
+    it("continues on the monthly grid for multi-month spans", () => {
+        const domain: [number, number] = [day("2020-01-06"), day("2020-07-06")]
+        const ticks = buildContinuousWeeklyAxisTicks({ domain, targetCount: 6 })
+        expect(ticks).toEqual(
+            buildContinuousMonthlyAxisTicks({ domain, targetCount: 6 })
+        )
+    })
+
+    it("labels multi-year spans with bare years", () => {
+        const ticks = buildContinuousWeeklyAxisTicks({
+            domain: [day("2015-06-15"), day("2022-03-07")],
+            targetCount: 6,
+        })!
+        expect(ticks.map((t) => t.label)).toEqual([
+            "2016",
+            "2018",
+            "2020",
+            "2022",
+        ])
+    })
+
+    it("shows the year on the first tick and wherever the year changes", () => {
+        const ticks = buildContinuousWeeklyAxisTicks({
+            domain: [day("2020-12-14"), day("2021-01-25")],
+            targetCount: 6,
+        })!
+        expect(ticks.map((t) => t.label)).toEqual([
+            "Dec 14, 2020",
+            "Dec 21",
+            "Dec 28",
+            "Jan 4, 2021",
+            "Jan 11",
+            "Jan 18",
+            "Jan 25",
+        ])
+    })
+
+    it("returns undefined for a degenerate (single-week) span", () => {
+        expect(gridDates("2020-03-02", "2020-03-02", 6)).toBeUndefined()
+    })
+})
+
+describe(getDiscreteWeeklyTickOptions, () => {
+    // `count` consecutive Mondays, starting from a Monday
+    const weeklyValues = (firstMonday: string, count: number): number[] => {
+        const first = day(firstMonday)
+        return Array.from({ length: count }, (_, week) => first + 7 * week)
+    }
+    const dayGaps = (ticks: { value: number }[]): number[] =>
+        ticks.slice(1).map((t, i) => t.value - ticks[i].value)
+
+    // All Mondays of 2020 (Jan 6 through Dec 28)
+    const options = getDiscreteWeeklyTickOptions({
+        bandValues: weeklyValues("2020-01-06", 52),
+    })
+
+    it("orders options from finest to coarsest", () => {
+        const counts = options.map((option) => option.length)
+        expect(counts).toEqual([...counts].sort((a, b) => b - a))
+    })
+
+    it("includes a biweekly option on Mondays", () => {
+        const biweekly = options.find((option) => dayGaps(option)[0] === 14)!
+        expect(biweekly).toHaveLength(26)
+        for (const tick of biweekly)
+            expect(convertDaysSinceEpochToDate(tick.value).day()).toBe(1)
+    })
+
+    it("puts monthly and coarser options on each month's first week", () => {
+        const monthly = options.filter((option) => dayGaps(option)[0] > 14)
+        expect(monthly.length).toBeGreaterThan(0)
+        for (const option of monthly)
+            for (const tick of option) {
+                const date = convertDaysSinceEpochToDate(tick.value)
+                expect(date.day()).toBe(1) // still a week value (a Monday)
+                expect(date.date()).toBeLessThanOrEqual(7) // in the first week
+            }
+    })
+
+    it("offers only the every-value option for weeks on irregular dates", () => {
+        // Not Mondays, and none in a month's first week
+        const bandValues = ["2020-03-10", "2020-03-18", "2020-03-25"].map(day)
+        const options = getDiscreteWeeklyTickOptions({ bandValues })
+        expect(options).toHaveLength(1)
+        expect(options[0].map((t) => t.value)).toEqual(bandValues)
+    })
+})
+
 describe(buildDiscreteTimeAxisTicks, () => {
     it("returns one tick per value, sorted and deduplicated", () => {
         const ticks = buildDiscreteTimeAxisTicks({
@@ -432,6 +566,12 @@ describe(getDiscreteTimeTickOptions, () => {
                 bandValues,
             })
         ).toEqual(getDiscreteMonthlyTickOptions({ bandValues }))
+        expect(
+            getDiscreteTimeTickOptions({
+                interval: TimeInterval.Week,
+                bandValues,
+            })
+        ).toEqual(getDiscreteWeeklyTickOptions({ bandValues }))
         expect(
             getDiscreteTimeTickOptions({
                 interval: TimeInterval.Day,

--- a/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.ts
+++ b/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.ts
@@ -262,12 +262,22 @@ function buildContinuousDayGridTicks({
     // a step by its in-domain count — otherwise a 29-day domain with a
     // target of two would skip the fitting biweekly grid and fall through
     // to a single monthly tick.
-    const step = steps.find(
+    let step = steps.find(
         (s) =>
             spanDays / s <= targetCount || inDomainTickCount(s) <= targetCount
     )
-    if (step === undefined)
-        return buildContinuousMonthlyAxisTicks({ domain, targetCount })
+    if (step === undefined) {
+        const monthlyTicks = buildContinuousMonthlyAxisTicks({
+            domain,
+            targetCount,
+        })
+        if (monthlyTicks) return monthlyTicks
+        // A span within a single calendar month has no monthly grid to
+        // continue on; keep the coarsest step rather than dropping calendar
+        // ticks entirely, which would hand the axis to generic d3 ticks that
+        // can sit between grid points (e.g. sub-week ticks on a weekly axis)
+        step = steps[steps.length - 1]
+    }
 
     const reference = dayGridReference(step)
     const [firstStep, lastStep] = gridIndexRange(step)

--- a/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.ts
+++ b/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.ts
@@ -33,12 +33,23 @@ const DAY_STEPS = [
     14, // 2 weeks
 ] as const
 
+// Calendar-nice step sizes in days for weekly axes,
+// so they never show sub-week ticks
+const WEEK_STEPS = [
+    7, // 1 week
+    14, // 2 weeks
+] as const
+
 // A fixed Monday (in days since epoch) that anchors weekly grids
 const MONDAY_REFERENCE = snapToIntervalStart(0, TimeInterval.Week)
 
 // Time intervals with calendar-aware axis ticks; all other intervals
 // fall back to the generic d3 ticks
-const CALENDAR_TICK_INTERVALS = [TimeInterval.Month, TimeInterval.Day] as const
+const CALENDAR_TICK_INTERVALS = [
+    TimeInterval.Month,
+    TimeInterval.Week,
+    TimeInterval.Day,
+] as const
 
 export type CalendarTickInterval = (typeof CALENDAR_TICK_INTERVALS)[number]
 
@@ -61,6 +72,8 @@ interface CalendarValue {
     /** The calendar month, as a linear count of months */
     monthIndex: number
     isFirstOfMonth: boolean
+    /** Whether the value falls within the first seven days of its month */
+    isFirstWeekOfMonth: boolean
 }
 
 function toCalendarValue(value: number): CalendarValue {
@@ -69,6 +82,7 @@ function toCalendarValue(value: number): CalendarValue {
         value,
         monthIndex: date.year() * 12 + date.month(),
         isFirstOfMonth: date.date() === 1,
+        isFirstWeekOfMonth: date.date() <= 7,
     }
 }
 
@@ -137,6 +151,9 @@ export function buildTimeAxisTicks({
     return match(interval)
         .with(TimeInterval.Month, () =>
             buildContinuousMonthlyAxisTicks({ domain, targetCount })
+        )
+        .with(TimeInterval.Week, () =>
+            buildContinuousWeeklyAxisTicks({ domain, targetCount })
         )
         .with(TimeInterval.Day, () =>
             buildContinuousDailyAxisTicks({ domain, targetCount })
@@ -208,16 +225,18 @@ export function buildContinuousMonthlyAxisTicks({
 }
 
 /**
- * A calendar-nice day grid (every day, every other day, weekly or biweekly
- * on Mondays), sized to `targetCount`, with redundant year parts dropped from
- * the labels. Spans too long for day-sized steps continue on the monthly grid.
+ * A calendar-nice day grid stepped by one of the given step sizes, sized to
+ * `targetCount`, with redundant year parts dropped from the labels. Spans
+ * too long for the coarsest step continue on the monthly grid.
  */
-export function buildContinuousDailyAxisTicks({
+function buildContinuousDayGridTicks({
     domain,
     targetCount,
+    steps,
 }: {
     domain: [number, number]
     targetCount: number
+    steps: readonly number[]
 }): Tickmark[] | undefined {
     const spanDays = domain[1] - domain[0]
     if (spanDays <= 0) return undefined
@@ -237,13 +256,13 @@ export function buildContinuousDailyAxisTicks({
     }
 
     // Pick the smallest step that keeps the tick count at or below the
-    // target; if even the coarsest day step produces too many ticks, fall
+    // target; if even the coarsest step produces too many ticks, fall
     // through to the monthly (and yearly) grid. The span/step estimate can
     // count one tick more than actually lands in the domain, so also accept
     // a step by its in-domain count — otherwise a 29-day domain with a
     // target of two would skip the fitting biweekly grid and fall through
     // to a single monthly tick.
-    const step = DAY_STEPS.find(
+    const step = steps.find(
         (s) =>
             spanDays / s <= targetCount || inDomainTickCount(s) <= targetCount
     )
@@ -262,6 +281,44 @@ export function buildContinuousDailyAxisTicks({
     return labelGridWithYearOnChange(grid, {
         format: "MMM D",
         formatWithYear: "MMM D, YYYY",
+    })
+}
+
+/**
+ * A calendar-nice day grid (every day, every other day, weekly or biweekly
+ * on Mondays), sized to `targetCount`, with redundant year parts dropped from
+ * the labels. Spans too long for day-sized steps continue on the monthly grid.
+ */
+export function buildContinuousDailyAxisTicks({
+    domain,
+    targetCount,
+}: {
+    domain: [number, number]
+    targetCount: number
+}): Tickmark[] | undefined {
+    return buildContinuousDayGridTicks({
+        domain,
+        targetCount,
+        steps: DAY_STEPS,
+    })
+}
+
+/**
+ * A calendar-nice week grid (weekly or biweekly on Mondays, labeled with the
+ * week-start dates), sized to `targetCount`. Spans too long for week-sized
+ * steps continue on the monthly grid.
+ */
+export function buildContinuousWeeklyAxisTicks({
+    domain,
+    targetCount,
+}: {
+    domain: [number, number]
+    targetCount: number
+}): Tickmark[] | undefined {
+    return buildContinuousDayGridTicks({
+        domain,
+        targetCount,
+        steps: WEEK_STEPS,
     })
 }
 
@@ -298,6 +355,9 @@ export function getDiscreteTimeTickOptions({
     return match(interval)
         .with(TimeInterval.Month, () =>
             getDiscreteMonthlyTickOptions({ bandValues })
+        )
+        .with(TimeInterval.Week, () =>
+            getDiscreteWeeklyTickOptions({ bandValues })
         )
         .with(TimeInterval.Day, () =>
             getDiscreteDailyTickOptions({ bandValues })
@@ -371,6 +431,27 @@ export function getDiscreteMonthlyTickOptions({
             (step) => (value: CalendarValue) => monthGridPosition(value, step)
         )
     )
+}
+
+/**
+ * See getDiscreteTimeTickOptions; steps weekly and biweekly (on Mondays),
+ * then continues on the monthly grid restricted to each month's first week,
+ * so ticks stay on actual week values.
+ */
+export function getDiscreteWeeklyTickOptions({
+    bandValues,
+}: {
+    bandValues: number[]
+}): Tickmark[][] {
+    return buildTickOptionsFromGrids(bandValues, [
+        ...WEEK_STEPS.map(
+            (step) => (value: CalendarValue) => dayGridPosition(value, step)
+        ),
+        ...MONTH_STEPS.map(
+            (step) => (value: CalendarValue) =>
+                value.isFirstWeekOfMonth ? monthGridPosition(value, step) : NaN
+        ),
+    ])
 }
 
 /**


### PR DESCRIPTION
Extends the calendar tick system to week-interval columns: continuous
weekly axes step weekly/biweekly on Mondays, labeled with week-start
dates, then continue on the monthly/yearly grid (via a shared day-grid
builder parameterized by step ladder, so weekly axes never show
sub-week ticks). Discrete (band) weekly axes thin from every value to
biweekly Mondays, then to first-week-of-month/quarter/year tiers that
stay on actual week values; labels come from WeekColumn ("W2 2020").

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

<!-- GitButler Footer Boundary Top -->
---
This is **part 5 of 9 in a stack** made with GitButler:
- <kbd>&nbsp;9&nbsp;</kbd> #6810 
- <kbd>&nbsp;8&nbsp;</kbd> #6752 
- <kbd>&nbsp;7&nbsp;</kbd> #6733 
- <kbd>&nbsp;6&nbsp;</kbd> #6723 
- <kbd>&nbsp;5&nbsp;</kbd> #6722 👈 
- <kbd>&nbsp;4&nbsp;</kbd> #6721 
- <kbd>&nbsp;3&nbsp;</kbd> #6699 
- <kbd>&nbsp;2&nbsp;</kbd> #6696 
- <kbd>&nbsp;1&nbsp;</kbd> #6700 
<!-- GitButler Footer Boundary Bottom -->