### PR TITLE
🎉🤖 (time-interval) calendar-aware ticks & labels for quarterly axes

### DIFF
--- a/packages/@ourworldindata/grapher/src/axis/Axis.test.ts
+++ b/packages/@ourworldindata/grapher/src/axis/Axis.test.ts
@@ -419,6 +419,32 @@ describe("for months", () => {
         expect(wide).toBeGreaterThanOrEqual(narrow) // wider fits at least as many
     })
 
+    it("labels every band value with its quarter on a discrete quarterly axis", () => {
+        const day = (date: string): number =>
+            convertDateToDaysSinceEpoch(dayjs.utc(date))
+        const bandValues = ["2020-01-01", "2020-04-01", "2020-07-01"].map(day)
+        const table = new OwidTable({ entityName: ["usa"], quarter: [0] }, [
+            { slug: "quarter", type: ColumnTypeNames.Quarter },
+        ])
+        const axis = new HorizontalAxis(
+            new AxisConfig({
+                scaleType: ScaleType.linear,
+                min: bandValues[0],
+                max: bandValues[bandValues.length - 1],
+                bandValues,
+            })
+        )
+        axis.formatColumn = table.get("quarter")
+        axis.range = [0, 800]
+
+        // one tick per band value, labeled with the column's quarter format
+        expect(axis.tickLabels.map((t) => t.formattedValue)).toEqual([
+            "Q1 2020",
+            "Q2 2020",
+            "Q3 2020",
+        ])
+    })
+
     it("falls back to overlap-hiding when no evenly-spaced option fits on a daily band axis", () => {
         const day = (date: string): number =>
             convertDateToDaysSinceEpoch(dayjs.utc(date))

--- a/packages/@ourworldindata/grapher/src/axis/Axis.ts
+++ b/packages/@ourworldindata/grapher/src/axis/Axis.ts
@@ -14,13 +14,13 @@ import {
     Tickmark,
     ValueRange,
     OwidVariableRoundingMode,
+    isSubYearly,
 } from "@ourworldindata/utils"
 import { ComparisonLineConfig } from "@ourworldindata/types"
 import { AxisConfig, AxisManager } from "./AxisConfig"
 import {
     buildTimeAxisTicks,
     getDiscreteTimeTickOptions,
-    isCalendarTickInterval,
     type CalendarTickInterval,
 } from "./timeAxisTicks.js"
 import { MarkdownTextWrap } from "@ourworldindata/components"
@@ -342,7 +342,7 @@ abstract class AbstractAxis {
         | undefined {
         const column = this.formatColumn
         if (this.config.ticks || !column?.isTimeColumn) return undefined
-        return isCalendarTickInterval(column.timeInterval)
+        return isSubYearly(column.timeInterval)
             ? column.timeInterval
             : undefined
     }

--- a/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.test.ts
+++ b/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.test.ts
@@ -8,6 +8,8 @@ import { TimeInterval } from "@ourworldindata/types"
 import {
     buildTimeAxisTicks,
     buildDiscreteTimeAxisTicks,
+    buildContinuousQuarterlyAxisTicks,
+    getDiscreteQuarterlyTickOptions,
     buildContinuousMonthlyAxisTicks,
     getDiscreteMonthlyTickOptions,
     buildContinuousWeeklyAxisTicks,
@@ -280,6 +282,125 @@ describe(buildContinuousDailyAxisTicks, () => {
             expect(value).toBeGreaterThanOrEqual(minDay)
             expect(value).toBeLessThanOrEqual(maxDay)
         }
+    })
+})
+
+describe(buildContinuousQuarterlyAxisTicks, () => {
+    // The grid tick values, as YYYY-MM-DD (or undefined for a degenerate span).
+    const gridDates = (
+        min: string,
+        max: string,
+        targetCount: number
+    ): string[] | undefined => {
+        const ticks = buildContinuousQuarterlyAxisTicks({
+            domain: [day(min), day(max)],
+            targetCount,
+        })
+        return ticks && asDates(ticks.map((tick) => tick.value))
+    }
+
+    it("steps by quarter (Jan/Apr/Jul/Oct) across a ~1.5-year span", () => {
+        expect(gridDates("2020-01-01", "2021-06-01", 6)).toEqual([
+            "2020-01-01",
+            "2020-04-01",
+            "2020-07-01",
+            "2020-10-01",
+            "2021-01-01",
+            "2021-04-01",
+        ])
+    })
+
+    it("never steps below a quarter, even for short spans", () => {
+        // The monthly ladder would pick a 1-month step here
+        expect(gridDates("2023-01-01", "2023-07-01", 6)).toEqual([
+            "2023-01-01",
+            "2023-04-01",
+            "2023-07-01",
+        ])
+    })
+
+    it("steps by half-years for ~3-year spans, keeping the year on each January", () => {
+        const ticks = buildContinuousQuarterlyAxisTicks({
+            domain: [day("2020-01-01"), day("2022-07-01")],
+            targetCount: 6,
+        })!
+        expect(ticks.map((t) => t.label)).toEqual([
+            "Jan 2020",
+            "Jul",
+            "Jan 2021",
+            "Jul",
+            "Jan 2022",
+            "Jul",
+        ])
+    })
+
+    it("labels multi-year spans with bare years", () => {
+        const ticks = buildContinuousQuarterlyAxisTicks({
+            domain: [day("2015-06-15"), day("2022-03-01")],
+            targetCount: 6,
+        })!
+        expect(ticks.map((t) => t.label)).toEqual([
+            "2016",
+            "2018",
+            "2020",
+            "2022",
+        ])
+    })
+
+    it("returns undefined for a degenerate (single-quarter) span", () => {
+        expect(gridDates("2020-05-03", "2020-05-28", 6)).toBeUndefined()
+    })
+})
+
+describe(getDiscreteQuarterlyTickOptions, () => {
+    const quarterStarts = (startYear: number, endYear: number): number[] => {
+        const values: number[] = []
+        for (let y = startYear; y <= endYear; y++)
+            for (const m of ["01", "04", "07", "10"])
+                values.push(day(`${y}-${m}-01`))
+        return values
+    }
+    const monthGaps = (ticks: { value: number }[]): number[] => {
+        const idx = ticks.map((t) => {
+            const d = convertDaysSinceEpochToDate(t.value)
+            return d.year() * 12 + d.month()
+        })
+        return idx.slice(1).map((m, i) => m - idx[i])
+    }
+
+    // All quarters of 2018-2023
+    const options = getDiscreteQuarterlyTickOptions({
+        bandValues: quarterStarts(2018, 2023),
+    })
+
+    it("orders options from finest to coarsest", () => {
+        const counts = options.map((option) => option.length)
+        expect(counts).toEqual([...counts].sort((a, b) => b - a))
+    })
+
+    it("includes an every-other-quarter option", () => {
+        const halfYearly = options.find((option) => monthGaps(option)[0] === 6)!
+        expect(halfYearly).toHaveLength(12)
+    })
+
+    it("includes a yearly option of first quarters only", () => {
+        const yearly = options.find((option) => monthGaps(option)[0] === 12)!
+        expect(yearly).toHaveLength(6)
+        for (const tick of yearly)
+            expect(convertDaysSinceEpochToDate(tick.value).month()).toBe(0)
+    })
+
+    it("offers only the every-value option for off-grid quarter starts", () => {
+        // A Feb/May/Aug/Nov cadence doesn't lie on the January-anchored grid
+        const bandValues = [
+            "2020-02-01",
+            "2020-05-01",
+            "2020-08-01",
+            "2020-11-01",
+        ].map(day)
+        const options = getDiscreteQuarterlyTickOptions({ bandValues })
+        expect(options).toHaveLength(1)
+        expect(options[0].map((t) => t.value)).toEqual(bandValues)
     })
 })
 
@@ -576,6 +697,12 @@ describe(getDiscreteTimeTickOptions, () => {
                 bandValues,
             })
         ).toEqual(getDiscreteMonthlyTickOptions({ bandValues }))
+        expect(
+            getDiscreteTimeTickOptions({
+                interval: TimeInterval.Quarter,
+                bandValues,
+            })
+        ).toEqual(getDiscreteQuarterlyTickOptions({ bandValues }))
         expect(
             getDiscreteTimeTickOptions({
                 interval: TimeInterval.Week,

--- a/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.test.ts
+++ b/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.test.ts
@@ -6,7 +6,6 @@ import {
 } from "@ourworldindata/utils"
 import { TimeInterval } from "@ourworldindata/types"
 import {
-    buildTimeAxisTicks,
     buildDiscreteTimeAxisTicks,
     buildContinuousQuarterlyAxisTicks,
     getDiscreteQuarterlyTickOptions,
@@ -568,19 +567,6 @@ describe(buildDiscreteTimeAxisTicks, () => {
             bandValues: ["2020-01-01", "2020-04-01"].map(day),
         })
         for (const tick of ticks) expect(tick.label).toBeUndefined()
-    })
-})
-
-describe(buildTimeAxisTicks, () => {
-    it("returns undefined for intervals without special handling", () => {
-        const bandValues = ["2020-01-01", "2021-01-01"].map(day)
-        const ticks = buildTimeAxisTicks({
-            interval: TimeInterval.Year,
-            domain: [bandValues[0], bandValues[1]],
-            targetCount: 6,
-            bandValues,
-        })
-        expect(ticks).toBeUndefined()
     })
 })
 

--- a/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.ts
+++ b/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.ts
@@ -54,29 +54,28 @@ const WEEK_STEPS = [
     14, // 2 weeks
 ] as const
 
-// A fixed Monday (in days since epoch) that anchors weekly grids
-const MONDAY_REFERENCE = snapToIntervalStart(0, TimeInterval.Week)
-
 export type CalendarTickInterval = Exclude<
     TimeInterval,
     TimeInterval.Year | TimeInterval.Decade
 >
+
+/** A time value plus derived calendar fields for evenly spaced ticks */
+interface CalendarValue {
+    value: number
+    monthIndex: number
+    isFirstOfMonth: boolean
+    isFirstWeekOfMonth: boolean
+}
+
+/** Maps a value to its index on a grid, or `undefined` when it is off-grid */
+type GetGridIndex = (value: CalendarValue) => number | undefined
 
 /** A tickmark for a day-since-epoch `value`, labeled with the given dayjs format. */
 function makeDayTick(value: number, format: string): Tickmark {
     return { value, priority: 2, label: formatDay(value, { format }) }
 }
 
-/** A band value with its calendar coordinates */
-interface CalendarValue {
-    value: number
-    /** The calendar month, as a linear count of months */
-    monthIndex: number
-    isFirstOfMonth: boolean
-    /** Whether the value falls within the first seven days of its month */
-    isFirstWeekOfMonth: boolean
-}
-
+/** Converts a day-since-epoch value to CalendarValue metadata. */
 function toCalendarValue(value: number): CalendarValue {
     const date = convertDaysSinceEpochToDate(value)
     return {
@@ -89,30 +88,34 @@ function toCalendarValue(value: number): CalendarValue {
 
 /**
  * The reference day that anchors a day grid with the given step: a Monday for
- * weekly steps (so ticks land on week starts), the epoch otherwise (so grids
- * are stable when panning).
+ * weekly steps (so ticks land on week starts), the epoch otherwise.
  */
 function dayGridReference(step: number): number {
-    return step % 7 === 0 ? MONDAY_REFERENCE : 0
+    return step % 7 === 0 ? snapToIntervalStart(0, TimeInterval.Week) : 0
 }
 
 /**
- * The position of a value on the day grid with the given step;
- * an integer only for values that lie on the grid.
+ * The index of a value on the day grid with the given step,
+ * or `undefined` when the value is off-grid.
  */
-function dayGridPosition({ value }: CalendarValue, step: number): number {
-    return (value - dayGridReference(step)) / step
+function dayGridPosition(
+    { value }: CalendarValue,
+    step: number
+): number | undefined {
+    const index = (value - dayGridReference(step)) / step
+    return Number.isInteger(index) ? index : undefined
 }
 
 /**
- * The position of a value on the January-anchored month grid with the given
- * step; an integer only for values that lie on the grid.
+ * The index of a value on the January-anchored month grid with the given
+ * step, or `undefined` when the value is off-grid.
  */
 function monthGridPosition(
     { monthIndex }: CalendarValue,
     step: number
-): number {
-    return monthIndex / step
+): number | undefined {
+    const index = monthIndex / step
+    return Number.isInteger(index) ? index : undefined
 }
 
 /**
@@ -183,7 +186,7 @@ function buildContinuousMonthGridTicks({
         .diff(minDate.startOf("month"), "month")
     if (spanMonths <= 0) return undefined
 
-    // Pick the smallest step that keeps the tick count at or below the target.
+    // Pick the smallest step that keeps the tick count at or below the target
     const step =
         steps.find((s) => spanMonths / s <= targetCount) ??
         steps[steps.length - 1]
@@ -201,19 +204,18 @@ function buildContinuousMonthGridTicks({
     const monthsFromAnchor = (date: dayjs.Dayjs): number =>
         date.startOf("month").diff(anchor, "month")
 
-    // The first and last indices that stay within the domain: round the
-    // start up and the end down so both ticks land inside the domain.
-    const firstStep = Math.ceil(monthsFromAnchor(minDate) / step)
-    const lastStep = Math.floor(monthsFromAnchor(maxDate) / step)
+    // The first and last grid indices that stay within the domain
+    const firstGridIndex = Math.ceil(monthsFromAnchor(minDate) / step)
+    const lastGridIndex = Math.floor(monthsFromAnchor(maxDate) / step)
 
-    const grid = _.range(firstStep, lastStep + 1)
+    const grid = _.range(firstGridIndex, lastGridIndex + 1)
         .map((k) => convertDateToDaysSinceEpoch(anchor.add(k * step, "month")))
         // The first index is rounded from the domain's start month, so a
         // mid-month domain start can produce a tick just before it - drop those
         .filter((value) => value >= domain[0] && value <= domain[1])
     if (!grid.length) return undefined
 
-    // When every tick is a January, drop the redundant month and label only the year.
+    // When every tick is a January, drop the redundant month and label only the year
     const isJanuary = (value: number): boolean =>
         convertDaysSinceEpochToDate(value).month() === 0
     if (grid.every(isJanuary))
@@ -246,9 +248,8 @@ export function buildContinuousMonthlyAxisTicks({
 }
 
 /**
- * A calendar-nice quarter grid (quarter starts: Jan/Apr/Jul/Oct 1, labeled
- * with month names), sized to `targetCount`. Uses the month grid restricted
- * to quarter-sized steps, so quarterly axes never show sub-quarter ticks.
+ * A calendar-nice quarter grid (labeled with month names), sized to
+ * `targetCount`.
  */
 export function buildContinuousQuarterlyAxisTicks({
     domain,
@@ -281,8 +282,7 @@ function buildContinuousDayGridTicks({
     const spanDays = domain[1] - domain[0]
     if (spanDays <= 0) return undefined
 
-    // The first and last grid indices that stay within the domain: round the
-    // start up and the end down so both ticks land inside the domain.
+    // The first and last grid indices that stay within the domain
     const gridIndexRange = (step: number): [number, number] => {
         const reference = dayGridReference(step)
         return [
@@ -295,13 +295,9 @@ function buildContinuousDayGridTicks({
         return last - first + 1
     }
 
-    // Pick the smallest step that keeps the tick count at or below the
-    // target; if even the coarsest step produces too many ticks, fall
-    // through to the monthly (and yearly) grid. The span/step estimate can
-    // count one tick more than actually lands in the domain, so also accept
-    // a step by its in-domain count — otherwise a 29-day domain with a
-    // target of two would skip the fitting biweekly grid and fall through
-    // to a single monthly tick.
+    // Pick the smallest step whose exact in-domain tick count fits the target;
+    // if even the coarsest step is too dense, fall through to the monthly
+    // (and yearly) grid.
     let step = steps.find(
         (s) =>
             spanDays / s <= targetCount || inDomainTickCount(s) <= targetCount
@@ -312,16 +308,15 @@ function buildContinuousDayGridTicks({
             targetCount,
         })
         if (monthlyTicks) return monthlyTicks
+
         // A span within a single calendar month has no monthly grid to
-        // continue on; keep the coarsest step rather than dropping calendar
-        // ticks entirely, which would hand the axis to generic d3 ticks that
-        // can sit between grid points (e.g. sub-week ticks on a weekly axis)
+        // continue on; fallback to the coarsest step in that case
         step = steps[steps.length - 1]
     }
 
     const reference = dayGridReference(step)
-    const [firstStep, lastStep] = gridIndexRange(step)
-    const grid = _.range(firstStep, lastStep + 1).map(
+    const [firstGridIndex, lastGridIndex] = gridIndexRange(step)
+    const grid = _.range(firstGridIndex, lastGridIndex + 1).map(
         (k) => reference + k * step
     )
     if (!grid.length) return undefined
@@ -373,20 +368,15 @@ export function buildContinuousWeeklyAxisTicks({
 }
 
 /**
- * One tick per domain value. The ticks carry no label: each value is labeled
- * independently, so the axis falls back to the column's own time format,
- * which is never abbreviated (e.g. "Jan 2023" for months, "Jan 5, 2023"
- * for days).
+ * One tick per domain value. The ticks carry no label, so the axis falls back
+ * to the column's own time format.
  */
 export function buildDiscreteTimeAxisTicks({
     bandValues,
 }: {
     bandValues: number[]
 }): Tickmark[] {
-    return _.sortBy(_.uniq(bandValues)).map((value) => ({
-        value,
-        priority: 2,
-    }))
+    return _.sortBy(_.uniq(bandValues)).map((value) => ({ value, priority: 2 }))
 }
 
 /**
@@ -419,43 +409,38 @@ export function getDiscreteTimeTickOptions({
 }
 
 /**
- * Maps a value to its position on a grid; an integer for values on the grid,
- * a non-integer (or NaN) otherwise.
- */
-type GridPosition = (value: CalendarValue) => number
-
-/**
  * One label set per grid, starting with a set that labels every value. A grid's
  * set is only offered when its values sit on consecutive grid points, so
- * every offered set is evenly spaced. Skips sets that don't thin the previous
- * one. Single-value sets aren't offered: when no multi-label set fits, the
- * axis falls back to greedy labeling, which labels as many bands as fit
- * instead of a lone calendar-anchored one (often the first or last band).
- * The grids are expected to be ordered from finest to coarsest.
+ * every offered set is evenly spaced. The indexers are expected to be ordered
+ * from finest to coarsest.
  */
 function buildTickOptionsFromGrids(
     bandValues: number[],
-    grids: GridPosition[]
+    getGridIndexers: GetGridIndex[]
 ): Tickmark[][] {
     const calendarValues = _.sortBy(_.uniq(bandValues)).map(toCalendarValue)
+
     const makeTier = (values: CalendarValue[]): Tickmark[] =>
         values.map(({ value }) => ({ value, priority: 2 }))
 
-    // The finest option labels every value, evenly spaced or not
+    // The finest option labels every value
     const tiers: Tickmark[][] = [makeTier(calendarValues)]
     if (calendarValues.length <= 1) return tiers
 
-    for (const gridPosition of grids) {
+    for (const getGridIndex of getGridIndexers) {
         const valuesOnGrid = calendarValues
-            .map((value) => ({ value, position: gridPosition(value) }))
-            .filter(({ position }) => Number.isInteger(position))
+            .map((value) => ({ value, index: getGridIndex(value) }))
+            .filter(
+                (entry): entry is { value: CalendarValue; index: number } =>
+                    entry.index !== undefined
+            )
+
+        // Require at least two values
         if (valuesOnGrid.length < 2) continue
 
-        // Only offer evenly-spaced sets: the values must sit on consecutive
-        // grid points, otherwise the labels would have ragged gaps
+        // Only offer evenly-spaced sets
         const isEvenlySpaced = valuesOnGrid.every(
-            ({ position }, i) =>
-                i === 0 || position - valuesOnGrid[i - 1].position === 1
+            ({ index }, i) => i === 0 || index - valuesOnGrid[i - 1].index === 1
         )
         if (!isEvenlySpaced) continue
 
@@ -466,6 +451,8 @@ function buildTickOptionsFromGrids(
 
         tiers.push(makeTier(valuesOnGrid.map(({ value }) => value)))
 
+        // Two labels are the smallest useful tier, and later (coarser)
+        // grids cannot produce a strictly smaller tier
         if (valuesOnGrid.length === 2) break
     }
 
@@ -516,7 +503,9 @@ export function getDiscreteWeeklyTickOptions({
         ),
         ...MONTH_STEPS.map(
             (step) => (value: CalendarValue) =>
-                value.isFirstWeekOfMonth ? monthGridPosition(value, step) : NaN
+                value.isFirstWeekOfMonth
+                    ? monthGridPosition(value, step)
+                    : undefined
         ),
     ])
 }
@@ -537,7 +526,9 @@ export function getDiscreteDailyTickOptions({
         ),
         ...MONTH_STEPS.map(
             (step) => (value: CalendarValue) =>
-                value.isFirstOfMonth ? monthGridPosition(value, step) : NaN
+                value.isFirstOfMonth
+                    ? monthGridPosition(value, step)
+                    : undefined
         ),
     ])
 }

--- a/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.ts
+++ b/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.ts
@@ -57,24 +57,10 @@ const WEEK_STEPS = [
 // A fixed Monday (in days since epoch) that anchors weekly grids
 const MONDAY_REFERENCE = snapToIntervalStart(0, TimeInterval.Week)
 
-// Time intervals with calendar-aware axis ticks; all other intervals
-// fall back to the generic d3 ticks
-const CALENDAR_TICK_INTERVALS = [
-    TimeInterval.Quarter,
-    TimeInterval.Month,
-    TimeInterval.Week,
-    TimeInterval.Day,
-] as const
-
-export type CalendarTickInterval = (typeof CALENDAR_TICK_INTERVALS)[number]
-
-export function isCalendarTickInterval(
-    interval: TimeInterval
-): interval is CalendarTickInterval {
-    return (CALENDAR_TICK_INTERVALS as readonly TimeInterval[]).includes(
-        interval
-    )
-}
+export type CalendarTickInterval = Exclude<
+    TimeInterval,
+    TimeInterval.Year | TimeInterval.Decade
+>
 
 /** A tickmark for a day-since-epoch `value`, labeled with the given dayjs format. */
 function makeDayTick(value: number, format: string): Tickmark {
@@ -144,23 +130,19 @@ function labelGridWithYearOnChange(
     })
 }
 
-/**
- * Calendar-aware ticks for a time axis, or `undefined` if the interval has no
- * special handling (the caller then falls back to the generic d3 ticks).
- */
+/** Calendar-aware ticks for a time axis */
 export function buildTimeAxisTicks({
     interval,
     domain,
     targetCount,
     bandValues,
 }: {
-    interval: TimeInterval
+    interval: CalendarTickInterval
     domain: [number, number]
     targetCount: number
     bandValues?: number[]
 }): Tickmark[] | undefined {
-    if (!isCalendarTickInterval(interval)) return undefined
-
+    // Discrete time axes place one tick per provided band value
     if (bandValues?.length) return buildDiscreteTimeAxisTicks({ bandValues })
 
     return match(interval)

--- a/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.ts
+++ b/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.ts
@@ -25,6 +25,20 @@ const MONTH_STEPS = [
     1200, // 100 years
 ] as const
 
+// Calendar-nice step sizes in months for quarterly axes,
+// so they never show sub-quarter ticks
+const QUARTER_STEPS = [
+    3, // 1 quarter
+    6, // 2 quarters
+    12, // 1 year
+    24, // 2 years
+    60, // 5 years
+    120, // 10 years
+    300, // 25 years
+    600, // 50 years
+    1200, // 100 years
+] as const
+
 // Calendar-nice step sizes in days
 const DAY_STEPS = [
     1, // 1 day
@@ -46,6 +60,7 @@ const MONDAY_REFERENCE = snapToIntervalStart(0, TimeInterval.Week)
 // Time intervals with calendar-aware axis ticks; all other intervals
 // fall back to the generic d3 ticks
 const CALENDAR_TICK_INTERVALS = [
+    TimeInterval.Quarter,
     TimeInterval.Month,
     TimeInterval.Week,
     TimeInterval.Day,
@@ -149,6 +164,9 @@ export function buildTimeAxisTicks({
     if (bandValues?.length) return buildDiscreteTimeAxisTicks({ bandValues })
 
     return match(interval)
+        .with(TimeInterval.Quarter, () =>
+            buildContinuousQuarterlyAxisTicks({ domain, targetCount })
+        )
         .with(TimeInterval.Month, () =>
             buildContinuousMonthlyAxisTicks({ domain, targetCount })
         )
@@ -162,15 +180,18 @@ export function buildTimeAxisTicks({
 }
 
 /**
- * An evenly-spaced, January-anchored month grid, sized to `targetCount`,
- * with redundant year/month parts dropped from the labels.
+ * An evenly-spaced, January-anchored month grid stepped by one of the given
+ * step sizes, sized to `targetCount`, with redundant year/month parts
+ * dropped from the labels.
  */
-export function buildContinuousMonthlyAxisTicks({
+function buildContinuousMonthGridTicks({
     domain,
     targetCount,
+    steps,
 }: {
     domain: [number, number]
     targetCount: number
+    steps: readonly number[]
 }): Tickmark[] | undefined {
     const minDate = convertDaysSinceEpochToDate(domain[0])
     const maxDate = convertDaysSinceEpochToDate(domain[1])
@@ -182,8 +203,8 @@ export function buildContinuousMonthlyAxisTicks({
 
     // Pick the smallest step that keeps the tick count at or below the target.
     const step =
-        MONTH_STEPS.find((s) => spanMonths / s <= targetCount) ??
-        MONTH_STEPS[MONTH_STEPS.length - 1]
+        steps.find((s) => spanMonths / s <= targetCount) ??
+        steps[steps.length - 1]
 
     // Start from January of a "nice" anchor year. For year-based steps
     // (12+ months), round the year down to the nearest multiple of the step in
@@ -221,6 +242,43 @@ export function buildContinuousMonthlyAxisTicks({
     return labelGridWithYearOnChange(grid, {
         format: "MMM",
         formatWithYear: "MMM YYYY",
+    })
+}
+
+/**
+ * An evenly-spaced, January-anchored month grid, sized to `targetCount`,
+ * with redundant year/month parts dropped from the labels.
+ */
+export function buildContinuousMonthlyAxisTicks({
+    domain,
+    targetCount,
+}: {
+    domain: [number, number]
+    targetCount: number
+}): Tickmark[] | undefined {
+    return buildContinuousMonthGridTicks({
+        domain,
+        targetCount,
+        steps: MONTH_STEPS,
+    })
+}
+
+/**
+ * A calendar-nice quarter grid (quarter starts: Jan/Apr/Jul/Oct 1, labeled
+ * with month names), sized to `targetCount`. Uses the month grid restricted
+ * to quarter-sized steps, so quarterly axes never show sub-quarter ticks.
+ */
+export function buildContinuousQuarterlyAxisTicks({
+    domain,
+    targetCount,
+}: {
+    domain: [number, number]
+    targetCount: number
+}): Tickmark[] | undefined {
+    return buildContinuousMonthGridTicks({
+        domain,
+        targetCount,
+        steps: QUARTER_STEPS,
     })
 }
 
@@ -363,6 +421,9 @@ export function getDiscreteTimeTickOptions({
     bandValues: number[]
 }): Tickmark[][] {
     return match(interval)
+        .with(TimeInterval.Quarter, () =>
+            getDiscreteQuarterlyTickOptions({ bandValues })
+        )
         .with(TimeInterval.Month, () =>
             getDiscreteMonthlyTickOptions({ bandValues })
         )
@@ -438,6 +499,20 @@ export function getDiscreteMonthlyTickOptions({
     return buildTickOptionsFromGrids(
         bandValues,
         MONTH_STEPS.map(
+            (step) => (value: CalendarValue) => monthGridPosition(value, step)
+        )
+    )
+}
+
+/** See getDiscreteTimeTickOptions; steps every quarter, half-year, year, … */
+export function getDiscreteQuarterlyTickOptions({
+    bandValues,
+}: {
+    bandValues: number[]
+}): Tickmark[][] {
+    return buildTickOptionsFromGrids(
+        bandValues,
+        QUARTER_STEPS.map(
             (step) => (value: CalendarValue) => monthGridPosition(value, step)
         )
     )

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -252,7 +252,9 @@ const SUB_YEARLY_INTERVALS = new Set<TimeInterval>([
  * Whether the interval is finer than a year and therefore encoded as
  * days-since-epoch (day/week/month/quarter)
  */
-export function isSubYearly(interval: TimeInterval): boolean {
+export function isSubYearly(
+    interval: TimeInterval
+): interval is Exclude<TimeInterval, TimeInterval.Year | TimeInterval.Decade> {
     return SUB_YEARLY_INTERVALS.has(interval)
 }
 


### PR DESCRIPTION
Extends the calendar tick system to quarter-interval columns.
Quarter values are month-grid values (quarter-start 1sts), so both
sides reduce to the month machinery with the step ladder restricted
to quarter multiples (via a shared month-grid builder parameterized
by step ladder, so quarterly axes never show sub-quarter ticks).
Continuous axes label quarter starts with month names; discrete
(band) axes thin from every value to half-yearly and first-quarter
tiers, labeled by QuarterColumn ("Q1 2023").

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

<!-- GitButler Footer Boundary Top -->
---
This is **part 6 of 9 in a stack** made with GitButler:
- <kbd>&nbsp;9&nbsp;</kbd> #6810 
- <kbd>&nbsp;8&nbsp;</kbd> #6752 
- <kbd>&nbsp;7&nbsp;</kbd> #6733 
- <kbd>&nbsp;6&nbsp;</kbd> #6723 👈 
- <kbd>&nbsp;5&nbsp;</kbd> #6722 
- <kbd>&nbsp;4&nbsp;</kbd> #6721 
- <kbd>&nbsp;3&nbsp;</kbd> #6699 
- <kbd>&nbsp;2&nbsp;</kbd> #6696 
- <kbd>&nbsp;1&nbsp;</kbd> #6700 
<!-- GitButler Footer Boundary Bottom -->