### PR TITLE
🔨🤖 (chart-titles) add TextWrapGroup, replacing MarkdownTextWrap.fromFragments

### DIFF
--- a/bespoke/projects/causes-of-death/src/components/CausesOfDeathTreemapTileLabels.tsx
+++ b/bespoke/projects/causes-of-death/src/components/CausesOfDeathTreemapTileLabels.tsx
@@ -5,6 +5,7 @@ import { formatCount, formatShare } from "../helpers/CausesOfDeathHelpers.js"
 import { useCausesOfDeathChartContext } from "../helpers/CausesOfDeathContext.js"
 import { TreeNode } from "../helpers/CausesOfDeathConstants.js"
 import { MarkdownTextWrap } from "@ourworldindata/components/src/MarkdownTextWrap/MarkdownTextWrap.js"
+import { TextWrapGroup } from "@ourworldindata/components/src/MarkdownTextWrap/TextWrapGroup.js"
 import { MarkdownTextWrapSvg } from "@ourworldindata/components/src/MarkdownTextWrap/MarkdownTextWrapComponents.js"
 
 type LabelKey = "title" | "percentage" | "description" | "perYear" | "perDay"
@@ -97,11 +98,17 @@ export function CausesOfDeathTreemapTileLabels({
     const lineHeight = 1.1
 
     const makeLabelWrapForFontSize = (fontSize: number) =>
-        MarkdownTextWrap.fromFragments({
-            main: { text: formattedPercentage, bold: true },
-            secondary: { text: labelText },
-            newLine: isLargestTile ? "continue-line" : "avoid-wrap",
-            textWrapProps: { maxWidth: availableWidth, fontSize, lineHeight },
+        new TextWrapGroup({
+            fragments: [
+                { text: formattedPercentage, fontWeight: 700 },
+                {
+                    text: labelText,
+                    newLine: isLargestTile ? "continue-line" : "avoid-wrap",
+                },
+            ],
+            maxWidth: availableWidth,
+            fontSize,
+            lineHeight,
         })
 
     const fontSize = calculateOptimalFontSize({
@@ -217,7 +224,7 @@ function createTextBounds({
     padding,
 }: {
     contentBounds: Bounds
-    textWrap: PartialLabelKeyRecord<MarkdownTextWrap>
+    textWrap: PartialLabelKeyRecord<MarkdownTextWrap | TextWrapGroup>
     padding: number
 }): PartialLabelKeyRecord<Bounds> {
     const titleBounds = new Bounds(
@@ -313,7 +320,7 @@ function calculateOptimalFontSize({
     availableHeight,
     minFontSize,
 }: {
-    makeTextWrap: (fontSize: number) => MarkdownTextWrap
+    makeTextWrap: (fontSize: number) => TextWrapGroup
     initialFontSize: number
     availableWidth: number
     availableHeight: number

--- a/packages/@ourworldindata/components/src/MarkdownTextWrap/AbstractTokenTextWrap.tsx
+++ b/packages/@ourworldindata/components/src/MarkdownTextWrap/AbstractTokenTextWrap.tsx
@@ -5,6 +5,7 @@ import {
     imemo,
     FontFamily,
     VerticalAlign,
+    type RequiredBy,
 } from "@ourworldindata/utils"
 import * as R from "remeda"
 import {
@@ -33,19 +34,59 @@ export interface TokenTextWrapOptions {
     detailsOrderedByReference: string[]
 }
 
+export type TokenTextWrapProps = {
+    fontSize: number
+    maxWidth?: number
+    lineHeight?: number
+    fontWeight?: number
+    fontFamily?: FontFamily
+    verticalAlign?: VerticalAlign
+    style?: CSSProperties
+    detailsOrderedByReference?: string[]
+}
+
 /**
  * Base class for text wraps that lay out a stream of IR tokens.
  *
- * Subclasses only provide the token stream (via the abstract `text`, `tokens`
- * and `options` getters); this class implements everything downstream of it:
+ * Subclasses only provide the token stream (via the abstract `text` and
+ * `tokens` getters); this class implements everything downstream of it:
  * - line-splitting against `maxWidth` (`htmlLines`, `svgLines`)
  * - metrics (`width`, `height`, `lineCount`, per-line heights and gaps)
  *
  * Known subclasses: `MarkdownTextWrap` (tokens parsed from a markdown string)
  * and `TextWrapGroup` (tokens assembled from multiple fragments).
  */
-export abstract class AbstractTokenTextWrap implements ITextWrap {
-    protected abstract get options(): TokenTextWrapOptions
+export abstract class AbstractTokenTextWrap<
+    Props extends TokenTextWrapProps = TokenTextWrapProps,
+> implements ITextWrap {
+    private static readonly defaultOptions = {
+        maxWidth: Infinity,
+        lineHeight: 1.1,
+        verticalAlign: VerticalAlign.bottom,
+        detailsOrderedByReference: [] as string[],
+    } as const satisfies Partial<TokenTextWrapProps>
+
+    private readonly initialProps: Props
+    constructor(props: Props) {
+        this.initialProps = props
+    }
+
+    @imemo get props(): RequiredBy<
+        Props,
+        keyof typeof AbstractTokenTextWrap.defaultOptions
+    > {
+        return {
+            ...AbstractTokenTextWrap.defaultOptions,
+            ...this.initialProps,
+        }
+    }
+
+    protected get options(): TokenTextWrapOptions {
+        // The cast is safe since the defaults guarantee that all required
+        // options are set, but TS can't verify this for a generic Props
+        return this.props as TokenTextWrapOptions
+    }
+
     abstract get text(): string
     abstract get tokens(): IRToken[]
 

--- a/packages/@ourworldindata/components/src/MarkdownTextWrap/AbstractTokenTextWrap.tsx
+++ b/packages/@ourworldindata/components/src/MarkdownTextWrap/AbstractTokenTextWrap.tsx
@@ -6,9 +6,11 @@ import {
     FontFamily,
     VerticalAlign,
 } from "@ourworldindata/utils"
-import { match } from "ts-pattern"
 import * as R from "remeda"
-import { type ITextWrap } from "../TextWrap/TextWrap.js"
+import {
+    getTextPositionForSvgRendering,
+    type ITextWrap,
+} from "../TextWrap/TextWrap.js"
 import {
     appendReferenceNumbers,
     getLineFontSize,
@@ -157,25 +159,6 @@ export abstract class AbstractTokenTextWrap implements ITextWrap {
     }
 
     getPositionForSvgRendering(x: number, y: number): [number, number] {
-        const { fontSize, lineHeight, height, verticalAlign } = this
-
-        // Magic number set through experimentation.
-        // The HTML and SVG renderers need to position lines identically.
-        // This number was tweaked until the overlaid HTML and SVG outputs
-        // overlap.
-        const HEIGHT_CORRECTION_FACTOR = 0.74
-
-        const textHeight = fontSize * HEIGHT_CORRECTION_FACTOR
-        const containerHeight = lineHeight * fontSize
-        const correctedY =
-            y + (containerHeight - (containerHeight - textHeight) / 2)
-
-        const renderY = match(verticalAlign)
-            .with(VerticalAlign.top, () => correctedY - height)
-            .with(VerticalAlign.middle, () => correctedY - height / 2)
-            .with(VerticalAlign.bottom, () => correctedY)
-            .exhaustive()
-
-        return [x, renderY]
+        return getTextPositionForSvgRendering(this, x, y)
     }
 }

--- a/packages/@ourworldindata/components/src/MarkdownTextWrap/AbstractTokenTextWrap.tsx
+++ b/packages/@ourworldindata/components/src/MarkdownTextWrap/AbstractTokenTextWrap.tsx
@@ -1,0 +1,181 @@
+import * as _ from "lodash-es"
+import { CSSProperties } from "react"
+import {
+    cssFontFamily,
+    imemo,
+    FontFamily,
+    VerticalAlign,
+} from "@ourworldindata/utils"
+import { match } from "ts-pattern"
+import * as R from "remeda"
+import { type ITextWrap } from "../TextWrap/TextWrap.js"
+import {
+    appendReferenceNumbers,
+    getLineFontSize,
+    getLineGap,
+    lineToPlaintext,
+    recursiveMergeTextTokens,
+    splitIntoLines,
+    type IRFontParams,
+    type IRToken,
+} from "./IRTokens.js"
+
+export interface TokenTextWrapOptions {
+    maxWidth: number
+    lineHeight: number
+    fontSize: number
+    fontWeight?: number
+    fontFamily?: FontFamily
+    verticalAlign: VerticalAlign
+    style?: CSSProperties
+    detailsOrderedByReference: string[]
+}
+
+/**
+ * Base class for text wraps that lay out a stream of IR tokens.
+ *
+ * Subclasses only provide the token stream (via the abstract `text`, `tokens`
+ * and `options` getters); this class implements everything downstream of it:
+ * - line-splitting against `maxWidth` (`htmlLines`, `svgLines`)
+ * - metrics (`width`, `height`, `lineCount`, per-line heights and gaps)
+ *
+ * Known subclasses: `MarkdownTextWrap` (tokens parsed from a markdown string)
+ * and `TextWrapGroup` (tokens assembled from multiple fragments).
+ */
+export abstract class AbstractTokenTextWrap implements ITextWrap {
+    protected abstract get options(): TokenTextWrapOptions
+    abstract get text(): string
+    abstract get tokens(): IRToken[]
+
+    @imemo get maxWidth(): number {
+        return this.options.maxWidth
+    }
+
+    @imemo get lineHeight(): number {
+        return this.options.lineHeight
+    }
+
+    @imemo get fontSize(): number {
+        return this.options.fontSize
+    }
+
+    @imemo get fontWeight(): number | undefined {
+        return this.options.fontWeight
+    }
+
+    @imemo get fontFamily(): FontFamily | undefined {
+        return this.options.fontFamily
+    }
+
+    @imemo get verticalAlign(): VerticalAlign {
+        return this.options.verticalAlign
+    }
+
+    @imemo get detailsOrderedByReference(): string[] {
+        return this.options.detailsOrderedByReference
+    }
+
+    @imemo get fontParams(): IRFontParams {
+        return {
+            fontFamily: this.fontFamily,
+            fontSize: this.fontSize,
+            fontWeight: this.fontWeight,
+        }
+    }
+
+    @imemo get plaintext(): string {
+        return this.htmlLines.map(lineToPlaintext).join("\n")
+    }
+
+    @imemo get htmlLines(): IRToken[][] {
+        const lines = splitIntoLines(this.tokens, this.maxWidth)
+        return lines.map((line) =>
+            recursiveMergeTextTokens(line, this.fontParams)
+        )
+    }
+
+    @imemo get svgLines(): IRToken[][] {
+        return splitIntoLines(this.tokens, this.maxWidth)
+    }
+
+    @imemo get svgLinesWithDodReferenceNumbers(): IRToken[][] {
+        const tokensWithReferenceNumbers = appendReferenceNumbers(
+            this.tokens,
+            this.detailsOrderedByReference
+        )
+        return splitIntoLines(tokensWithReferenceNumbers, this.maxWidth)
+    }
+
+    @imemo get width(): number {
+        const { htmlLines } = this
+        const lineLengths = htmlLines.map((tokens) =>
+            _.sumBy(tokens, (token) => token.width)
+        )
+        return _.max(lineLengths) ?? 0
+    }
+
+    @imemo get singleLineHeight(): number {
+        return this.fontSize * this.lineHeight
+    }
+
+    @imemo get lastLineWidth(): number {
+        return _.sumBy(R.last(this.htmlLines), (token) => token.width) ?? 0
+    }
+
+    @imemo get lineCount(): number {
+        return this.htmlLines.length
+    }
+
+    getLineHeight(line: IRToken[]): number {
+        return (getLineFontSize(line) ?? this.fontSize) * this.lineHeight
+    }
+
+    /** Per-line line heights */
+    @imemo get lineHeights(): number[] {
+        return this.htmlLines.map((line) => this.getLineHeight(line))
+    }
+
+    /** Extra vertical space above each line */
+    @imemo get lineGaps(): number[] {
+        return this.htmlLines.map((line) => getLineGap(line))
+    }
+
+    @imemo get height(): number {
+        return _.sum(this.lineHeights) + _.sum(this.lineGaps)
+    }
+
+    @imemo get style(): CSSProperties {
+        return {
+            fontSize: this.fontSize,
+            fontWeight: this.fontWeight,
+            fontFamily: this.fontFamily
+                ? cssFontFamily(this.fontFamily)
+                : undefined,
+            ...this.options.style,
+            lineHeight: this.lineHeight,
+        }
+    }
+
+    getPositionForSvgRendering(x: number, y: number): [number, number] {
+        const { fontSize, lineHeight, height, verticalAlign } = this
+
+        // Magic number set through experimentation.
+        // The HTML and SVG renderers need to position lines identically.
+        // This number was tweaked until the overlaid HTML and SVG outputs
+        // overlap.
+        const HEIGHT_CORRECTION_FACTOR = 0.74
+
+        const textHeight = fontSize * HEIGHT_CORRECTION_FACTOR
+        const containerHeight = lineHeight * fontSize
+        const correctedY =
+            y + (containerHeight - (containerHeight - textHeight) / 2)
+
+        const renderY = match(verticalAlign)
+            .with(VerticalAlign.top, () => correctedY - height)
+            .with(VerticalAlign.middle, () => correctedY - height / 2)
+            .with(VerticalAlign.bottom, () => correctedY)
+            .exhaustive()
+
+        return [x, renderY]
+    }
+}

--- a/packages/@ourworldindata/components/src/MarkdownTextWrap/IRTokens.tsx
+++ b/packages/@ourworldindata/components/src/MarkdownTextWrap/IRTokens.tsx
@@ -590,6 +590,32 @@ export function getLineGap(tokens: IRToken[]): number {
     )
 }
 
+/**
+ * Horizontal extents of all details-on-demand tokens on a line, relative to
+ * the line's start. Recurses into container elements (fragments, bold, ...)
+ * since DoDs may be arbitrarily nested, but not into the DoDs themselves.
+ */
+export function getDodUnderlineSegments(
+    tokens: IRToken[],
+    startOffset: number = 0
+): { x: number; width: number }[] {
+    const segments: { x: number; width: number }[] = []
+    let offset = startOffset
+    for (const token of tokens) {
+        if (token instanceof IRDetailOnDemand) {
+            segments.push({ x: offset, width: token.width })
+        } else if (token instanceof IRElement) {
+            // a fragment's children start after its inline gap
+            const inlineGap = token instanceof IRFragment ? token.inlineGap : 0
+            segments.push(
+                ...getDodUnderlineSegments(token.children, offset + inlineGap)
+            )
+        }
+        offset += token.width
+    }
+    return segments
+}
+
 // useful for debugging
 export function lineToPlaintext(tokens: IRToken[]): string {
     return tokens.map((t) => t.toPlaintext()).join("")

--- a/packages/@ourworldindata/components/src/MarkdownTextWrap/IRTokens.tsx
+++ b/packages/@ourworldindata/components/src/MarkdownTextWrap/IRTokens.tsx
@@ -1,0 +1,726 @@
+import * as _ from "lodash-es"
+import * as React from "react"
+import {
+    cssFontFamily,
+    excludeUndefined,
+    imemo,
+    Bounds,
+    FontFamily,
+} from "@ourworldindata/utils"
+import * as R from "remeda"
+
+const SUPERSCRIPT_NUMERALS = {
+    "0": "\u2070",
+    "1": "\u00b9",
+    "2": "\u00b2",
+    "3": "\u00b3",
+    "4": "\u2074",
+    "5": "\u2075",
+    "6": "\u2076",
+    "7": "\u2077",
+    "8": "\u2078",
+    "9": "\u2079",
+}
+
+export interface IRFontParams {
+    fontSize?: number
+    fontWeight?: number
+    fontFamily?: FontFamily
+    isItalic?: boolean
+}
+
+export interface IRBreakpoint {
+    tokenIndex: number
+    tokenStartOffset: number
+    breakOffset: number
+}
+
+export interface IRToken {
+    width: number
+    fontParams?: IRFontParams
+    getBreakpointBefore(targetWidth: number): IRBreakpoint | undefined
+    toHTML(key?: React.Key): React.ReactElement | undefined
+    toSVG(key?: React.Key): React.ReactElement | undefined
+    toPlaintext(): string | undefined
+}
+
+export class IRText implements IRToken {
+    constructor(
+        public text: string,
+        public fontParams?: IRFontParams
+    ) {}
+    @imemo get width(): number {
+        return Bounds.forText(this.text, this.fontParams).width
+    }
+    @imemo get height(): number {
+        return this.fontParams?.fontSize || 13
+    }
+    getBreakpointBefore(): undefined {
+        return undefined
+    }
+    toHTML(key?: React.Key): React.ReactElement {
+        return <span key={key}>{this.text}</span>
+    }
+    toSVG(key?: React.Key): React.ReactElement {
+        return <React.Fragment key={key}>{this.text}</React.Fragment>
+    }
+    toPlaintext(): string {
+        return this.text
+    }
+}
+
+export class IRWhitespace implements IRToken {
+    constructor(public fontParams?: IRFontParams) {}
+    @imemo get width(): number {
+        return Bounds.forText(" ", this.fontParams).width
+    }
+    getBreakpointBefore(): IRBreakpoint {
+        // Have to give it some `breakOffset` because we designate locations
+        // to split based on it, and `0` leads to being exactly in between tokens.
+        return { tokenIndex: 0, tokenStartOffset: 0, breakOffset: 0.0001 }
+    }
+    toHTML(key?: React.Key): React.ReactElement {
+        return <span key={key}> </span>
+    }
+    toSVG(key?: React.Key): React.ReactElement {
+        return <React.Fragment key={key}> </React.Fragment>
+    }
+    toPlaintext(): string {
+        return " "
+    }
+}
+
+export class IRLineBreak implements IRToken {
+    get width(): number {
+        return 0
+    }
+    getBreakpointBefore(): undefined {
+        return undefined
+    }
+    toHTML(key?: React.Key): React.ReactElement {
+        return <br key={key} />
+    }
+    toSVG(): undefined {
+        // We have to deal with this special case in
+        // whatever procedure does text reflow.
+        return undefined
+    }
+    toPlaintext(): string {
+        return "\n"
+    }
+}
+
+export abstract class IRElement implements IRToken {
+    constructor(
+        public children: IRToken[],
+        public fontParams?: IRFontParams
+    ) {}
+
+    @imemo get width(): number {
+        return getLineWidth(this.children)
+    }
+
+    getBreakpointBefore(targetWidth: number): IRBreakpoint | undefined {
+        return getBreakpointBefore(this.children, targetWidth)
+    }
+
+    splitBefore(maxWidth: number): {
+        before: IRToken | undefined
+        after: IRToken | undefined
+    } {
+        const { before, after } = splitLineAtBreakpoint(this.children, maxWidth)
+        return {
+            // do not create tokens without children
+            before: before.length ? this.getClone(before) : undefined,
+            after: after.length ? this.getContinuationClone(after) : undefined,
+        }
+    }
+
+    splitOnLineBreaks(): IRToken[][] {
+        const lines = splitAllOnNewline(this.children)
+        if (lines.length > 1) {
+            return lines.map((tokens, index) =>
+                // Do not create a clone without children.
+                // There aren't any children in a line when the first or last
+                // token is a newline.
+                tokens.length
+                    ? [
+                          index === 0
+                              ? this.getClone(tokens)
+                              : this.getContinuationClone(tokens),
+                      ]
+                    : []
+            )
+        }
+        // Do not create copies of element
+        // if there are no newlines inside.
+        return [[this]]
+    }
+
+    abstract getClone(children: IRToken[]): IRElement
+
+    /**
+     * Clone holding the part of this element that continues on a new line
+     * after a wrap or line break. Same as `getClone` except that elements
+     * carrying gaps relative to the preceding content drop them here.
+     */
+    getContinuationClone(children: IRToken[]): IRElement {
+        return this.getClone(children)
+    }
+    abstract toHTML(key?: React.Key): React.ReactElement
+    abstract toSVG(key?: React.Key): React.ReactElement
+
+    toPlaintext(): string {
+        return lineToPlaintext(this.children)
+    }
+}
+
+export class IRBold extends IRElement {
+    getClone(children: IRToken[]): IRBold {
+        return new IRBold(children, this.fontParams)
+    }
+    toHTML(key?: React.Key): React.ReactElement {
+        return (
+            <strong key={key}>
+                {this.children.map((child, i) => child.toHTML(i))}
+            </strong>
+        )
+    }
+    toSVG(key?: React.Key): React.ReactElement {
+        return (
+            <tspan key={key} style={{ fontWeight: 700 }}>
+                {this.children.map((child, i) => child.toSVG(i))}
+            </tspan>
+        )
+    }
+}
+
+export class IRSpan extends IRElement {
+    getClone(children: IRToken[]): IRSpan {
+        return new IRSpan(children, this.fontParams)
+    }
+    toHTML(key?: React.Key): React.ReactElement {
+        return (
+            <span key={key}>
+                {this.children.map((child, i) => child.toHTML(i))}
+            </span>
+        )
+    }
+    toSVG(key?: React.Key): React.ReactElement {
+        return (
+            <tspan key={key}>
+                {this.children.map((child, i) => child.toSVG(i))}
+            </tspan>
+        )
+    }
+}
+
+export interface IRFragmentStyle {
+    fontSize?: number
+    fontFamily?: FontFamily
+    fontWeight?: number
+    color?: string
+}
+
+/** Wraps the tokens of a single TextWrapGroup fragment */
+export class IRFragment extends IRElement {
+    constructor(
+        public fragmentIndex: number,
+        children: IRToken[],
+        public styleDelta: IRFragmentStyle = {},
+        fontParams?: IRFontParams,
+        /** Horizontal space before the fragment on its line */
+        public inlineGap: number = 0,
+        /**
+         * Vertical space between the preceding line and the fragment's
+         * first line. It can't be rendered by an inline element; it is
+         * applied per line instead
+         */
+        public lineGap: number = 0
+    ) {
+        super(children, fontParams)
+    }
+    @imemo override get width(): number {
+        return this.inlineGap + getLineWidth(this.children)
+    }
+    /**
+     * The inherited implementation operates on the children alone, but this
+     * fragment's width includes the inline gap, so breakpoints need to be
+     * shifted by the gap. The gap itself is a break opportunity (like the
+     * whitespace it replaces): if no internal breakpoint fits, the line may
+     * break right before the fragment.
+     */
+    override getBreakpointBefore(
+        targetWidth: number
+    ): IRBreakpoint | undefined {
+        if (!this.inlineGap) return super.getBreakpointBefore(targetWidth)
+        const internal = super.getBreakpointBefore(targetWidth - this.inlineGap)
+        if (internal && internal.breakOffset + this.inlineGap <= targetWidth)
+            return {
+                ...internal,
+                breakOffset: internal.breakOffset + this.inlineGap,
+            }
+        return { tokenIndex: 0, tokenStartOffset: 0, breakOffset: 0.0001 }
+    }
+    override splitBefore(maxWidth: number): {
+        before: IRToken | undefined
+        after: IRToken | undefined
+    } {
+        if (!this.inlineGap) return super.splitBefore(maxWidth)
+        // A break width within the gap moves the whole fragment to the next
+        // line, where it continues without the gap
+        if (maxWidth <= this.inlineGap)
+            return {
+                before: undefined,
+                after: this.getContinuationClone(this.children),
+            }
+        const { before, after } = splitLineAtBreakpoint(
+            this.children,
+            maxWidth - this.inlineGap
+        )
+        return {
+            before: before.length ? this.getClone(before) : undefined,
+            after: after.length ? this.getContinuationClone(after) : undefined,
+        }
+    }
+    getClone(children: IRToken[]): IRFragment {
+        return new IRFragment(
+            this.fragmentIndex,
+            children,
+            this.styleDelta,
+            this.fontParams,
+            this.inlineGap,
+            this.lineGap
+        )
+    }
+    override getContinuationClone(children: IRToken[]): IRFragment {
+        // The gaps space the fragment from the preceding content, so they
+        // don't carry over to continuation lines when the fragment wraps
+        return new IRFragment(
+            this.fragmentIndex,
+            children,
+            this.styleDelta,
+            this.fontParams
+        )
+    }
+    toHTML(key?: React.Key): React.ReactElement {
+        const children = this.children.map((child, i) => child.toHTML(i))
+        if (_.isEmpty(this.styleDelta) && !this.inlineGap)
+            return <React.Fragment key={key}>{children}</React.Fragment>
+        const { fontSize, fontFamily, fontWeight, color } = this.styleDelta
+        return (
+            <span
+                key={key}
+                style={{
+                    display: "inline-block",
+                    marginLeft: this.inlineGap || undefined,
+                    fontSize,
+                    fontWeight,
+                    fontFamily: fontFamily
+                        ? cssFontFamily(fontFamily)
+                        : undefined,
+                    color,
+                }}
+            >
+                {children}
+            </span>
+        )
+    }
+    toSVG(key?: React.Key): React.ReactElement {
+        const children = this.children.map((child, i) => child.toSVG(i))
+        if (_.isEmpty(this.styleDelta) && !this.inlineGap)
+            return <React.Fragment key={key}>{children}</React.Fragment>
+        const { fontSize, fontFamily, fontWeight, color } = this.styleDelta
+        return (
+            <tspan
+                key={key}
+                dx={this.inlineGap || undefined}
+                style={{
+                    fontSize,
+                    fontWeight,
+                    fontFamily: fontFamily
+                        ? cssFontFamily(fontFamily)
+                        : undefined,
+                    fill: color,
+                }}
+            >
+                {children}
+            </tspan>
+        )
+    }
+}
+
+export class IRSuperscript implements IRToken {
+    constructor(
+        public text: string,
+        public fontParams?: IRFontParams
+    ) {}
+    @imemo get width(): number {
+        return Bounds.forText(this.text, { fontSize: this.height / 2 }).width
+    }
+    @imemo get height(): number {
+        return this.fontParams?.fontSize || 16
+    }
+    getBreakpointBefore(): undefined {
+        return undefined
+    }
+    toHTML(key?: React.Key): React.ReactElement {
+        return <sup key={key}>{this.text}</sup>
+    }
+    toSVG(key?: React.Key): React.ReactElement {
+        // replace numerals with literals, for everything else let the font-feature handle it
+        const style = { fontFeatureSettings: '"sups"' }
+        const text = this.text.replace(/./g, (c) =>
+            _.get(SUPERSCRIPT_NUMERALS, c, c)
+        )
+        return (
+            <React.Fragment key={key}>
+                <tspan style={style}>{text}</tspan>
+            </React.Fragment>
+        )
+    }
+    toPlaintext(): string {
+        return this.text
+    }
+}
+
+export class IRItalic extends IRElement {
+    getClone(children: IRToken[]): IRItalic {
+        return new IRItalic(children, this.fontParams)
+    }
+    toHTML(key?: React.Key): React.ReactElement {
+        return (
+            <em key={key}>
+                {this.children.map((child, i) => child.toHTML(i))}
+            </em>
+        )
+    }
+    toSVG(key?: React.Key): React.ReactElement {
+        return (
+            <tspan key={key} style={{ fontStyle: "italic" }}>
+                {this.children.map((child, i) => child.toSVG(i))}
+            </tspan>
+        )
+    }
+}
+
+export class IRLink extends IRElement {
+    constructor(
+        public href: string,
+        children: IRToken[],
+        fontParams?: IRFontParams
+    ) {
+        super(children, fontParams)
+    }
+    getClone(children: IRToken[]): IRLink {
+        return new IRLink(this.href, children, this.fontParams)
+    }
+    toHTML(key?: React.Key): React.ReactElement {
+        return (
+            <a key={key} href={this.href}>
+                {this.children.map((child, i) => child.toHTML(i))}
+            </a>
+        )
+    }
+    toSVG(key?: React.Key): React.ReactElement {
+        return (
+            <a
+                key={key}
+                href={this.href}
+                style={{ textDecoration: "underline" }}
+            >
+                {this.children.map((child, i) => child.toSVG(i))}
+            </a>
+        )
+    }
+}
+
+export class IRDetailOnDemand extends IRElement {
+    constructor(
+        public term: string,
+        children: IRToken[],
+        fontParams?: IRFontParams
+    ) {
+        super(children, fontParams)
+    }
+    getClone(children: IRToken[]): IRDetailOnDemand {
+        return new IRDetailOnDemand(this.term, children, this.fontParams)
+    }
+    toHTML(key?: React.Key): React.ReactElement {
+        return (
+            <span
+                key={key}
+                className="dod-span"
+                data-id={this.term}
+                tabIndex={0}
+            >
+                {this.children.map((child, i) => child.toHTML(i))}
+            </span>
+        )
+    }
+    toSVG(key?: React.Key): React.ReactElement {
+        return (
+            <tspan key={key} className="dod-span" data-id={this.term}>
+                {this.children.map((child, i) => child.toSVG(i))}
+            </tspan>
+        )
+    }
+}
+
+function splitAllOnNewline(tokens: IRToken[]): IRToken[][] {
+    if (!tokens.length) return []
+    let currentLine: IRToken[] = []
+    const lines: IRToken[][] = [currentLine]
+    const unproccessed: IRToken[] = [...tokens]
+    while (unproccessed.length > 0) {
+        const token = unproccessed.shift()!
+        if (token instanceof IRElement) {
+            const [firstLine, ...otherLines] = token.splitOnLineBreaks()
+            if (firstLine) currentLine.push(...firstLine)
+            if (otherLines.length) {
+                lines.push(...otherLines)
+                currentLine = R.last(lines)!
+            }
+        } else if (token instanceof IRLineBreak) {
+            currentLine = []
+            lines.push(currentLine)
+        } else {
+            currentLine.push(token)
+        }
+    }
+    return lines
+}
+
+export function splitLineAtBreakpoint(
+    tokens: IRToken[],
+    breakWidth: number
+): { before: IRToken[]; after: IRToken[] } {
+    let i = 0
+    let offset = 0
+    // finding the token where the split should be
+    // NOTE: the token may not be splittable, which is why we need an exact
+    // `breakWidth` provided, not the line width.
+    while (i < tokens.length - 1 && offset + tokens[i].width < breakWidth) {
+        offset += tokens[i].width
+        i++
+    }
+    const token = tokens[i]
+    if (token instanceof IRElement) {
+        const { before, after } = token.splitBefore(breakWidth - offset)
+        return {
+            before: excludeUndefined([...tokens.slice(0, i), before]),
+            after: excludeUndefined([after, ...tokens.slice(i + 1)]),
+        }
+    } else {
+        return { before: tokens.slice(0, i), after: trimLeft(tokens.slice(i)) }
+    }
+}
+
+function trimLeft(tokens: IRToken[]): IRToken[] {
+    let i = 0
+    while (i < tokens.length && tokens[i] instanceof IRWhitespace) {
+        i++
+    }
+    return tokens.slice(i)
+}
+
+// Even though it says "before", it may return a breakpoint after, because
+// there is no earlier breakpoint in the line.
+export function getBreakpointBefore(
+    tokens: IRToken[],
+    maxWidth: number
+): IRBreakpoint | undefined {
+    let tokenStartOffset = 0
+    let prevBreakpoint: IRBreakpoint | undefined = undefined
+    for (let index = 0; index < tokens.length; index++) {
+        const token = tokens[index]
+        const candidate = token.getBreakpointBefore(maxWidth - tokenStartOffset)
+        if (candidate !== undefined) {
+            if (
+                prevBreakpoint &&
+                candidate.breakOffset + tokenStartOffset > maxWidth
+            ) {
+                break
+            }
+            prevBreakpoint = {
+                tokenStartOffset,
+                tokenIndex: index,
+                breakOffset: candidate.breakOffset + tokenStartOffset,
+            }
+        }
+        tokenStartOffset += token.width
+    }
+    return prevBreakpoint
+}
+
+export function getLineWidth(tokens: IRToken[]): number {
+    return _.sum(tokens.map((token) => token.width))
+}
+
+/**
+ * The largest font size of any token on the line, or `undefined` if none of
+ * the tokens specifies a font size.
+ */
+export function getLineFontSize(tokens: IRToken[]): number | undefined {
+    const tokenFontSize = (token: IRToken): number => {
+        const ownFontSize = token.fontParams?.fontSize ?? 0
+        const childrenFontSize =
+            token instanceof IRElement
+                ? (_.max(token.children.map(tokenFontSize)) ?? 0)
+                : 0
+        return Math.max(ownFontSize, childrenFontSize)
+    }
+    const maxFontSize = _.max(tokens.map(tokenFontSize)) ?? 0
+    return maxFontSize > 0 ? maxFontSize : undefined
+}
+
+/**
+ * Extra vertical space (in px) above the line: the largest line gap of any
+ * fragment on the line. Fragments carry a line gap when they were placed on
+ * a new line with an explicit gap; it is rendered as a line margin (HTML)
+ * or an extra baseline offset (SVG).
+ */
+export function getLineGap(tokens: IRToken[]): number {
+    return (
+        _.max(
+            tokens.map((token) =>
+                token instanceof IRFragment ? token.lineGap : 0
+            )
+        ) ?? 0
+    )
+}
+
+// useful for debugging
+export function lineToPlaintext(tokens: IRToken[]): string {
+    return tokens.map((t) => t.toPlaintext()).join("")
+}
+
+export const isTextToken = (token: IRToken): token is IRText | IRWhitespace =>
+    token instanceof IRText || token instanceof IRWhitespace
+
+/**
+ * Merges adjacent text tokens, because the way we render text in React is otherwise
+ * not very compatible with Google Translate, breaking our site in weird ways when
+ * translated.
+ * This is to be run _just before_ rendering to HTML, because it loses some
+ * information and is not easily reversible.
+ * See also https://github.com/owid/owid-grapher/issues/1785
+ */
+export const recursiveMergeTextTokens = (
+    tokens: IRToken[],
+    fontParams?: IRFontParams
+): IRToken[] => {
+    if (tokens.length === 0) return []
+
+    // merge adjacent text tokens into one
+    const mergedTextTokens: IRToken[] = tokens.reduce((acc, token) => {
+        if (isTextToken(token)) {
+            const l = R.last(acc)
+            if (l && isTextToken(l)) {
+                // replace last value in acc with merged text token
+                acc.pop()
+                return [
+                    ...acc,
+                    new IRText(
+                        l.toPlaintext() + token.toPlaintext(),
+                        fontParams
+                    ),
+                ]
+            }
+        }
+        return [...acc, token]
+    }, [] as IRToken[])
+
+    // recursively enter non-text tokens, and merge their children;
+    // elements that carry their own fontParams (e.g. IRFragment) pass those
+    // down so merged text keeps the correct measurement params
+    return mergedTextTokens.map((token) => {
+        if (token instanceof IRElement) {
+            return token.getClone(
+                recursiveMergeTextTokens(
+                    token.children,
+                    token.fontParams ?? fontParams
+                )
+            )
+        }
+        return token
+    })
+}
+
+export function splitIntoLines(
+    tokens: IRToken[],
+    maxWidth: number
+): IRToken[][] {
+    const processedLines: IRToken[][] = []
+    const unprocessedLines: IRToken[][] = splitAllOnNewline(tokens)
+    while (unprocessedLines.length) {
+        const currentLine = unprocessedLines.shift()!
+        if (getLineWidth(currentLine) <= maxWidth) {
+            processedLines.push(currentLine)
+        } else {
+            const breakpoint = getBreakpointBefore(currentLine, maxWidth)
+            if (!breakpoint) {
+                processedLines.push(currentLine)
+            } else {
+                const { before, after } = splitLineAtBreakpoint(
+                    currentLine,
+                    breakpoint.breakOffset
+                )
+                processedLines.push(before)
+                unprocessedLines.unshift(after)
+            }
+        }
+    }
+    return processedLines
+}
+
+/**
+ * Tokenizes plain text without any markdown parsing, so that literal markdown
+ * characters (e.g. `*`, `_`, `[`) are preserved verbatim. Newlines become
+ * hard line breaks.
+ */
+export function convertPlaintextToIRTokens(
+    text: string,
+    fontParams?: IRFontParams
+): IRToken[] {
+    const lines = text.split("\n")
+    return lines.flatMap((line, lineIndex) => {
+        const words = line.split(/\s+/).filter((word) => word.length > 0)
+        const tokens: IRToken[] = words.flatMap((word, wordIndex) =>
+            wordIndex < words.length - 1
+                ? [new IRText(word, fontParams), new IRWhitespace(fontParams)]
+                : [new IRText(word, fontParams)]
+        )
+        return lineIndex < lines.length - 1
+            ? [...tokens, new IRLineBreak()]
+            : tokens
+    })
+}
+
+export function appendReferenceNumbers(
+    tokens: IRToken[],
+    references: string[]
+): IRToken[] {
+    function traverse(token: IRToken, callback: (token: IRToken) => any): any {
+        if (token instanceof IRElement) {
+            token.children.flatMap((child) => traverse(child, callback))
+        }
+        return callback(token)
+    }
+
+    const appendedTokens: IRToken[] = _.cloneDeep(tokens).flatMap((token) =>
+        traverse(token, (token: IRToken) => {
+            if (token instanceof IRDetailOnDemand) {
+                const referenceIndex =
+                    references.findIndex((term) => term === token.term) + 1
+                if (referenceIndex === 0) return token
+                token.children.push(
+                    new IRSuperscript(String(referenceIndex), token.fontParams)
+                )
+            }
+            return token
+        })
+    )
+
+    return appendedTokens
+}

--- a/packages/@ourworldindata/components/src/MarkdownTextWrap/MarkdownTextWrap.test.ts
+++ b/packages/@ourworldindata/components/src/MarkdownTextWrap/MarkdownTextWrap.test.ts
@@ -3,13 +3,16 @@ import { expect, it, describe } from "vitest"
 import { cssFontFamily, FontFamily, VerticalAlign } from "@ourworldindata/utils"
 import {
     IRText,
+    getDodUnderlineSegments,
     getLineWidth,
     lineToPlaintext,
     recursiveMergeTextTokens,
-    IRWhitespace,
     IRBold,
-    IRLink,
+    IRDetailOnDemand,
     IRLineBreak,
+    IRLink,
+    IRWhitespace,
+    type IRToken,
 } from "./IRTokens.js"
 import { MarkdownTextWrap } from "./MarkdownTextWrap.js"
 
@@ -209,6 +212,47 @@ describe(MarkdownTextWrap, () => {
                 ]),
                 new IRText("fourfive"),
             ])
+        })
+    })
+
+    describe(getDodUnderlineSegments, () => {
+        const makeLine = (text: string): IRToken[] =>
+            new MarkdownTextWrap({ text, fontSize: 14 }).svgLines[0]
+
+        it("should find a top-level DoD", () => {
+            const line = makeLine("before [term](#dod:term) after")
+            const dodIndex = line.findIndex(
+                (token) => token instanceof IRDetailOnDemand
+            )
+
+            expect(getDodUnderlineSegments(line)).toEqual([
+                {
+                    x: getLineWidth(line.slice(0, dodIndex)),
+                    width: line[dodIndex].width,
+                },
+            ])
+        })
+
+        it("should find a DoD nested inside bold", () => {
+            const line = makeLine("**an [important](#dod:important) term**")
+            const bold = line[0] as IRBold
+            const dodIndex = bold.children.findIndex(
+                (token) => token instanceof IRDetailOnDemand
+            )
+
+            expect(line).toEqual([expect.any(IRBold)])
+            expect(getDodUnderlineSegments(line)).toEqual([
+                {
+                    x: getLineWidth(bold.children.slice(0, dodIndex)),
+                    width: bold.children[dodIndex].width,
+                },
+            ])
+        })
+
+        it("should find no segments in a line without DoDs", () => {
+            const line = makeLine("just **plain** text")
+
+            expect(getDodUnderlineSegments(line)).toEqual([])
         })
     })
 })

--- a/packages/@ourworldindata/components/src/MarkdownTextWrap/MarkdownTextWrap.test.ts
+++ b/packages/@ourworldindata/components/src/MarkdownTextWrap/MarkdownTextWrap.test.ts
@@ -1,9 +1,8 @@
 import { expect, it, describe } from "vitest"
 
-import { FontFamily, VerticalAlign } from "@ourworldindata/utils"
+import { cssFontFamily, FontFamily, VerticalAlign } from "@ourworldindata/utils"
 import {
     IRText,
-    MarkdownTextWrap,
     getLineWidth,
     lineToPlaintext,
     recursiveMergeTextTokens,
@@ -11,7 +10,8 @@ import {
     IRBold,
     IRLink,
     IRLineBreak,
-} from "./MarkdownTextWrap.js"
+} from "./IRTokens.js"
+import { MarkdownTextWrap } from "./MarkdownTextWrap.js"
 
 describe(MarkdownTextWrap, () => {
     it("heavier fontWeight should be wider than plain IRText", () => {
@@ -53,7 +53,7 @@ describe(MarkdownTextWrap, () => {
         })
 
         expect(element.style).toMatchObject({
-            fontFamily: FontFamily.Lato,
+            fontFamily: cssFontFamily(FontFamily.Lato),
             fontWeight: 800,
             fontSize: 14,
         })
@@ -210,89 +210,5 @@ describe(MarkdownTextWrap, () => {
                 new IRText("fourfive"),
             ])
         })
-    })
-})
-
-describe("fromFragments", () => {
-    const fontSize = 14
-
-    it("should place fragments in-line by default", () => {
-        const textWrap = MarkdownTextWrap.fromFragments({
-            main: { text: "Lower middle-income countries" },
-            secondary: { text: "30 million" },
-            textWrapProps: {
-                maxWidth: 500,
-                fontSize,
-            },
-        })
-        expect(textWrap.svgLines.length).toEqual(1)
-        expect(textWrap.htmlLines.length).toEqual(1)
-    })
-
-    it("should place the secondary text in a new line if requested", () => {
-        const textWrap = MarkdownTextWrap.fromFragments({
-            main: { text: "Lower middle-income countries" },
-            secondary: { text: "30 million" },
-            newLine: "always",
-            textWrapProps: {
-                maxWidth: 1000,
-                fontSize,
-            },
-        })
-        expect(textWrap.svgLines.length).toEqual(2)
-        expect(textWrap.htmlLines.length).toEqual(2)
-    })
-
-    it("should place the secondary text in a new line if line breaks should be avoided", () => {
-        const textWrap = MarkdownTextWrap.fromFragments({
-            main: { text: "Lower middle-income countries" },
-            secondary: { text: "30 million" },
-            newLine: "avoid-wrap",
-            textWrapProps: {
-                maxWidth: 250,
-                fontSize,
-            },
-        })
-        expect(textWrap.svgLines.length).toEqual(2)
-        expect(textWrap.htmlLines.length).toEqual(2)
-    })
-
-    it("should place the secondary text in the same line if possible", () => {
-        const textWrap = MarkdownTextWrap.fromFragments({
-            main: { text: "Lower middle-income countries" },
-            secondary: { text: "30 million" },
-            newLine: "avoid-wrap",
-            textWrapProps: {
-                maxWidth: 1000,
-                fontSize,
-            },
-        })
-        expect(textWrap.svgLines.length).toEqual(1)
-        expect(textWrap.htmlLines.length).toEqual(1)
-    })
-
-    it("should use all available space when one fragment exceeds the given max width", () => {
-        const textWrap = MarkdownTextWrap.fromFragments({
-            main: { text: "Long-word-that-can't-be-broken-up more words" },
-            secondary: { text: "30 million" },
-            textWrapProps: {
-                maxWidth: 150,
-                fontSize,
-            },
-        })
-        expect(textWrap.width).toBeGreaterThan(150)
-    })
-
-    it("should place very long words in a separate line", () => {
-        const textWrap = MarkdownTextWrap.fromFragments({
-            main: { text: "30 million" },
-            secondary: { text: "Long-word-that-can't-be-broken-up" },
-            textWrapProps: {
-                maxWidth: 150,
-                fontSize,
-            },
-        })
-        expect(textWrap.svgLines.length).toEqual(2)
-        expect(textWrap.htmlLines.length).toEqual(2)
     })
 })

--- a/packages/@ourworldindata/components/src/MarkdownTextWrap/MarkdownTextWrap.tsx
+++ b/packages/@ourworldindata/components/src/MarkdownTextWrap/MarkdownTextWrap.tsx
@@ -1,11 +1,4 @@
-import { CSSProperties } from "react"
-import {
-    imemo,
-    Bounds,
-    FontFamily,
-    VerticalAlign,
-    type RequiredBy,
-} from "@ourworldindata/utils"
+import { imemo, Bounds } from "@ourworldindata/utils"
 import { type ITextWrap } from "../TextWrap/TextWrap.js"
 import { fromMarkdown } from "mdast-util-from-markdown"
 import type { Root, RootContent } from "mdast"
@@ -25,47 +18,12 @@ import {
 } from "./IRTokens.js"
 import {
     AbstractTokenTextWrap,
-    type TokenTextWrapOptions,
+    type TokenTextWrapProps,
 } from "./AbstractTokenTextWrap.js"
 
-type MarkdownTextWrapOptions = {
-    maxWidth?: number
-    fontFamily?: FontFamily
-    fontSize: number
-    fontWeight?: number
-    lineHeight?: number
-    verticalAlign?: VerticalAlign
-    style?: CSSProperties
-    detailsOrderedByReference?: string[]
-}
+type MarkdownTextWrapProps = { text: string } & TokenTextWrapProps
 
-type MarkdownTextWrapProps = { text: string } & MarkdownTextWrapOptions
-
-export class MarkdownTextWrap extends AbstractTokenTextWrap {
-    private static readonly defaultOptions = {
-        maxWidth: Infinity,
-        lineHeight: 1.1,
-        verticalAlign: VerticalAlign.bottom,
-        detailsOrderedByReference: [] as string[],
-    } as const satisfies Partial<MarkdownTextWrapProps>
-
-    private readonly initialProps: MarkdownTextWrapProps
-    constructor(props: MarkdownTextWrapProps) {
-        super()
-        this.initialProps = props
-    }
-
-    @imemo get props(): RequiredBy<
-        MarkdownTextWrapProps,
-        keyof typeof MarkdownTextWrap.defaultOptions
-    > {
-        return { ...MarkdownTextWrap.defaultOptions, ...this.initialProps }
-    }
-
-    protected get options(): TokenTextWrapOptions {
-        return this.props
-    }
-
+export class MarkdownTextWrap extends AbstractTokenTextWrap<MarkdownTextWrapProps> {
     @imemo get text(): string {
         return normalizeMarkdownNewlines(this.props.text)
     }

--- a/packages/@ourworldindata/components/src/MarkdownTextWrap/MarkdownTextWrap.tsx
+++ b/packages/@ourworldindata/components/src/MarkdownTextWrap/MarkdownTextWrap.tsx
@@ -1,8 +1,5 @@
-import * as _ from "lodash-es"
 import { CSSProperties } from "react"
-import * as React from "react"
 import {
-    excludeUndefined,
     imemo,
     Bounds,
     FontFamily,
@@ -15,489 +12,21 @@ import type { Root, RootContent } from "mdast"
 import { match } from "ts-pattern"
 import { urlRegex } from "../markdown/remarkPlainLinks.js"
 import * as R from "remeda"
-
-const SUPERSCRIPT_NUMERALS = {
-    "0": "\u2070",
-    "1": "\u00b9",
-    "2": "\u00b2",
-    "3": "\u00b3",
-    "4": "\u2074",
-    "5": "\u2075",
-    "6": "\u2076",
-    "7": "\u2077",
-    "8": "\u2078",
-    "9": "\u2079",
-}
-
-export interface IRFontParams {
-    fontSize?: number
-    fontWeight?: number
-    fontFamily?: FontFamily
-    isItalic?: boolean
-}
-
-export interface IRBreakpoint {
-    tokenIndex: number
-    tokenStartOffset: number
-    breakOffset: number
-}
-
-export interface IRToken {
-    width: number
-    getBreakpointBefore(targetWidth: number): IRBreakpoint | undefined
-    toHTML(key?: React.Key): React.ReactElement | undefined
-    toSVG(key?: React.Key): React.ReactElement | undefined
-    toPlaintext(): string | undefined
-}
-
-export class IRText implements IRToken {
-    constructor(
-        public text: string,
-        public fontParams?: IRFontParams
-    ) {}
-    @imemo get width(): number {
-        return Bounds.forText(this.text, this.fontParams).width
-    }
-    @imemo get height(): number {
-        return this.fontParams?.fontSize || 13
-    }
-    getBreakpointBefore(): undefined {
-        return undefined
-    }
-    toHTML(key?: React.Key): React.ReactElement {
-        return <span key={key}>{this.text}</span>
-    }
-    toSVG(key?: React.Key): React.ReactElement {
-        return <React.Fragment key={key}>{this.text}</React.Fragment>
-    }
-    toPlaintext(): string {
-        return this.text
-    }
-}
-
-export class IRWhitespace implements IRToken {
-    constructor(public fontParams?: IRFontParams) {}
-    @imemo get width(): number {
-        return Bounds.forText(" ", this.fontParams).width
-    }
-    getBreakpointBefore(): IRBreakpoint {
-        // Have to give it some `breakOffset` because we designate locations
-        // to split based on it, and `0` leads to being exactly in between tokens.
-        return { tokenIndex: 0, tokenStartOffset: 0, breakOffset: 0.0001 }
-    }
-    toHTML(key?: React.Key): React.ReactElement {
-        return <span key={key}> </span>
-    }
-    toSVG(key?: React.Key): React.ReactElement {
-        return <React.Fragment key={key}> </React.Fragment>
-    }
-    toPlaintext(): string {
-        return " "
-    }
-}
-
-export class IRLineBreak implements IRToken {
-    get width(): number {
-        return 0
-    }
-    getBreakpointBefore(): undefined {
-        return undefined
-    }
-    toHTML(key?: React.Key): React.ReactElement {
-        return <br key={key} />
-    }
-    toSVG(): undefined {
-        // We have to deal with this special case in
-        // whatever procedure does text reflow.
-        return undefined
-    }
-    toPlaintext(): string {
-        return "\n"
-    }
-}
-
-export abstract class IRElement implements IRToken {
-    constructor(
-        public children: IRToken[],
-        public fontParams?: IRFontParams
-    ) {}
-
-    @imemo get width(): number {
-        return getLineWidth(this.children)
-    }
-
-    getBreakpointBefore(targetWidth: number): IRBreakpoint | undefined {
-        return getBreakpointBefore(this.children, targetWidth)
-    }
-
-    splitBefore(maxWidth: number): {
-        before: IRToken | undefined
-        after: IRToken | undefined
-    } {
-        const { before, after } = splitLineAtBreakpoint(this.children, maxWidth)
-        return {
-            // do not create tokens without children
-            before: before.length ? this.getClone(before) : undefined,
-            after: after.length ? this.getClone(after) : undefined,
-        }
-    }
-
-    splitOnLineBreaks(): IRToken[][] {
-        const lines = splitAllOnNewline(this.children)
-        if (lines.length > 1) {
-            return lines.map((tokens) =>
-                // Do not create a clone without children.
-                // There aren't any children in a line when the first or last
-                // token is a newline.
-                tokens.length ? [this.getClone(tokens)] : []
-            )
-        }
-        // Do not create copies of element
-        // if there are no newlines inside.
-        return [[this]]
-    }
-
-    abstract getClone(children: IRToken[]): IRElement
-    abstract toHTML(key?: React.Key): React.ReactElement
-    abstract toSVG(key?: React.Key): React.ReactElement
-
-    toPlaintext(): string {
-        return lineToPlaintext(this.children)
-    }
-}
-
-export class IRBold extends IRElement {
-    getClone(children: IRToken[]): IRBold {
-        return new IRBold(children, this.fontParams)
-    }
-    toHTML(key?: React.Key): React.ReactElement {
-        return (
-            <strong key={key}>
-                {this.children.map((child, i) => child.toHTML(i))}
-            </strong>
-        )
-    }
-    toSVG(key?: React.Key): React.ReactElement {
-        return (
-            <tspan key={key} style={{ fontWeight: 700 }}>
-                {this.children.map((child, i) => child.toSVG(i))}
-            </tspan>
-        )
-    }
-}
-
-export class IRSpan extends IRElement {
-    getClone(children: IRToken[]): IRSpan {
-        return new IRSpan(children, this.fontParams)
-    }
-    toHTML(key?: React.Key): React.ReactElement {
-        return (
-            <span key={key}>
-                {this.children.map((child, i) => child.toHTML(i))}
-            </span>
-        )
-    }
-    toSVG(key?: React.Key): React.ReactElement {
-        return (
-            <tspan key={key}>
-                {this.children.map((child, i) => child.toSVG(i))}
-            </tspan>
-        )
-    }
-}
-
-export class IRSuperscript implements IRToken {
-    constructor(
-        public text: string,
-        public fontParams?: IRFontParams
-    ) {}
-    @imemo get width(): number {
-        return Bounds.forText(this.text, { fontSize: this.height / 2 }).width
-    }
-    @imemo get height(): number {
-        return this.fontParams?.fontSize || 16
-    }
-    getBreakpointBefore(): undefined {
-        return undefined
-    }
-    toHTML(key?: React.Key): React.ReactElement {
-        return <sup key={key}>{this.text}</sup>
-    }
-    toSVG(key?: React.Key): React.ReactElement {
-        // replace numerals with literals, for everything else let the font-feature handle it
-        const style = { fontFeatureSettings: '"sups"' }
-        const text = this.text.replace(/./g, (c) =>
-            _.get(SUPERSCRIPT_NUMERALS, c, c)
-        )
-        return (
-            <React.Fragment key={key}>
-                <tspan style={style}>{text}</tspan>
-            </React.Fragment>
-        )
-    }
-    toPlaintext(): string {
-        return this.text
-    }
-}
-
-export class IRItalic extends IRElement {
-    getClone(children: IRToken[]): IRItalic {
-        return new IRItalic(children, this.fontParams)
-    }
-    toHTML(key?: React.Key): React.ReactElement {
-        return (
-            <em key={key}>
-                {this.children.map((child, i) => child.toHTML(i))}
-            </em>
-        )
-    }
-    toSVG(key?: React.Key): React.ReactElement {
-        return (
-            <tspan key={key} style={{ fontStyle: "italic" }}>
-                {this.children.map((child, i) => child.toSVG(i))}
-            </tspan>
-        )
-    }
-}
-
-export class IRLink extends IRElement {
-    constructor(
-        public href: string,
-        children: IRToken[],
-        fontParams?: IRFontParams
-    ) {
-        super(children, fontParams)
-    }
-    getClone(children: IRToken[]): IRLink {
-        return new IRLink(this.href, children, this.fontParams)
-    }
-    toHTML(key?: React.Key): React.ReactElement {
-        return (
-            <a key={key} href={this.href}>
-                {this.children.map((child, i) => child.toHTML(i))}
-            </a>
-        )
-    }
-    toSVG(key?: React.Key): React.ReactElement {
-        return (
-            <a
-                key={key}
-                href={this.href}
-                style={{ textDecoration: "underline" }}
-            >
-                {this.children.map((child, i) => child.toSVG(i))}
-            </a>
-        )
-    }
-}
-
-export class IRDetailOnDemand extends IRElement {
-    constructor(
-        public term: string,
-        children: IRToken[],
-        fontParams?: IRFontParams
-    ) {
-        super(children, fontParams)
-    }
-    getClone(children: IRToken[]): IRDetailOnDemand {
-        return new IRDetailOnDemand(this.term, children, this.fontParams)
-    }
-    toHTML(key?: React.Key): React.ReactElement {
-        return (
-            <span
-                key={key}
-                className="dod-span"
-                data-id={this.term}
-                tabIndex={0}
-            >
-                {this.children.map((child, i) => child.toHTML(i))}
-            </span>
-        )
-    }
-    toSVG(key?: React.Key): React.ReactElement {
-        return (
-            <tspan key={key} className="dod-span" data-id={this.term}>
-                {this.children.map((child, i) => child.toSVG(i))}
-            </tspan>
-        )
-    }
-}
-
-function splitAllOnNewline(tokens: IRToken[]): IRToken[][] {
-    if (!tokens.length) return []
-    let currentLine: IRToken[] = []
-    const lines: IRToken[][] = [currentLine]
-    const unproccessed: IRToken[] = [...tokens]
-    while (unproccessed.length > 0) {
-        const token = unproccessed.shift()!
-        if (token instanceof IRElement) {
-            const [firstLine, ...otherLines] = token.splitOnLineBreaks()
-            if (firstLine) currentLine.push(...firstLine)
-            if (otherLines.length) {
-                lines.push(...otherLines)
-                currentLine = R.last(lines)!
-            }
-        } else if (token instanceof IRLineBreak) {
-            currentLine = []
-            lines.push(currentLine)
-        } else {
-            currentLine.push(token)
-        }
-    }
-    return lines
-}
-
-export function splitLineAtBreakpoint(
-    tokens: IRToken[],
-    breakWidth: number
-): { before: IRToken[]; after: IRToken[] } {
-    let i = 0
-    let offset = 0
-    // finding the token where the split should be
-    // NOTE: the token may not be splittable, which is why we need an exact
-    // `breakWidth` provided, not the line width.
-    while (i < tokens.length - 1 && offset + tokens[i].width < breakWidth) {
-        offset += tokens[i].width
-        i++
-    }
-    const token = tokens[i]
-    if (token instanceof IRElement) {
-        const { before, after } = token.splitBefore(breakWidth - offset)
-        return {
-            before: excludeUndefined([...tokens.slice(0, i), before]),
-            after: excludeUndefined([after, ...tokens.slice(i + 1)]),
-        }
-    } else {
-        return { before: tokens.slice(0, i), after: trimLeft(tokens.slice(i)) }
-    }
-}
-
-function trimLeft(tokens: IRToken[]): IRToken[] {
-    let i = 0
-    while (i < tokens.length && tokens[i] instanceof IRWhitespace) {
-        i++
-    }
-    return tokens.slice(i)
-}
-
-// Even though it says "before", it may return a breakpoint after, because
-// there is no earlier breakpoint in the line.
-export function getBreakpointBefore(
-    tokens: IRToken[],
-    maxWidth: number
-): IRBreakpoint | undefined {
-    let tokenStartOffset = 0
-    let prevBreakpoint: IRBreakpoint | undefined = undefined
-    for (let index = 0; index < tokens.length; index++) {
-        const token = tokens[index]
-        const candidate = token.getBreakpointBefore(maxWidth - tokenStartOffset)
-        if (candidate !== undefined) {
-            if (
-                prevBreakpoint &&
-                candidate.breakOffset + tokenStartOffset > maxWidth
-            ) {
-                break
-            }
-            prevBreakpoint = {
-                tokenStartOffset,
-                tokenIndex: index,
-                breakOffset: candidate.breakOffset + tokenStartOffset,
-            }
-        }
-        tokenStartOffset += token.width
-    }
-    return prevBreakpoint
-}
-
-export function getLineWidth(tokens: IRToken[]): number {
-    return _.sum(tokens.map((token) => token.width))
-}
-
-// useful for debugging
-export function lineToPlaintext(tokens: IRToken[]): string {
-    return tokens.map((t) => t.toPlaintext()).join("")
-}
-
-export const isTextToken = (token: IRToken): token is IRText | IRWhitespace =>
-    token instanceof IRText || token instanceof IRWhitespace
-
-/**
- * Merges adjacent text tokens, because the way we render text in React is otherwise
- * not very compatible with Google Translate, breaking our site in weird ways when
- * translated.
- * This is to be run _just before_ rendering to HTML, because it loses some
- * information and is not easily reversible.
- * See also https://github.com/owid/owid-grapher/issues/1785
- */
-export const recursiveMergeTextTokens = (
-    tokens: IRToken[],
-    fontParams?: IRFontParams
-): IRToken[] => {
-    if (tokens.length === 0) return []
-
-    // merge adjacent text tokens into one
-    const mergedTextTokens: IRToken[] = tokens.reduce((acc, token) => {
-        if (isTextToken(token)) {
-            const l = R.last(acc)
-            if (l && isTextToken(l)) {
-                // replace last value in acc with merged text token
-                acc.pop()
-                return [
-                    ...acc,
-                    new IRText(
-                        l.toPlaintext() + token.toPlaintext(),
-                        fontParams
-                    ),
-                ]
-            }
-        }
-        return [...acc, token]
-    }, [] as IRToken[])
-
-    // recursively enter non-text tokens, and merge their children
-    return mergedTextTokens.map((token) => {
-        if (token instanceof IRElement) {
-            return token.getClone(
-                recursiveMergeTextTokens(token.children, fontParams)
-            )
-        }
-        return token
-    })
-}
-
-export function splitIntoLines(
-    tokens: IRToken[],
-    maxWidth: number
-): IRToken[][] {
-    const processedLines: IRToken[][] = []
-    const unprocessedLines: IRToken[][] = splitAllOnNewline(tokens)
-    while (unprocessedLines.length) {
-        const currentLine = unprocessedLines.shift()!
-        if (getLineWidth(currentLine) <= maxWidth) {
-            processedLines.push(currentLine)
-        } else {
-            const breakpoint = getBreakpointBefore(currentLine, maxWidth)
-            if (!breakpoint) {
-                processedLines.push(currentLine)
-            } else {
-                const { before, after } = splitLineAtBreakpoint(
-                    currentLine,
-                    breakpoint.breakOffset
-                )
-                processedLines.push(before)
-                unprocessedLines.unshift(after)
-            }
-        }
-    }
-    return processedLines
-}
-
-export const sumTextWrapHeights = (
-    elements: ITextWrap[],
-    spacer: number = 0
-): number =>
-    _.sum(elements.map((element) => element.height)) +
-    (elements.length - 1) * spacer
+import {
+    IRBold,
+    IRDetailOnDemand,
+    IRItalic,
+    IRLineBreak,
+    IRLink,
+    IRText,
+    IRWhitespace,
+    type IRFontParams,
+    type IRToken,
+} from "./IRTokens.js"
+import {
+    AbstractTokenTextWrap,
+    type TokenTextWrapOptions,
+} from "./AbstractTokenTextWrap.js"
 
 type MarkdownTextWrapOptions = {
     maxWidth?: number
@@ -512,9 +41,7 @@ type MarkdownTextWrapOptions = {
 
 type MarkdownTextWrapProps = { text: string } & MarkdownTextWrapOptions
 
-type TextFragment = { text: string; bold?: boolean }
-
-export class MarkdownTextWrap implements ITextWrap {
+export class MarkdownTextWrap extends AbstractTokenTextWrap {
     private static readonly defaultOptions = {
         maxWidth: Infinity,
         lineHeight: 1.1,
@@ -524,6 +51,7 @@ export class MarkdownTextWrap implements ITextWrap {
 
     private readonly initialProps: MarkdownTextWrapProps
     constructor(props: MarkdownTextWrapProps) {
+        super()
         this.initialProps = props
     }
 
@@ -534,201 +62,43 @@ export class MarkdownTextWrap implements ITextWrap {
         return { ...MarkdownTextWrap.defaultOptions, ...this.initialProps }
     }
 
-    static fromFragments({
-        main,
-        secondary,
-        newLine = "continue-line",
-        textWrapProps,
-    }: {
-        main: TextFragment
-        secondary: TextFragment
-        newLine?: "continue-line" | "always" | "avoid-wrap"
-        textWrapProps: Omit<MarkdownTextWrapOptions, "fontWeight">
-    }) {
-        const mainMarkdownText = maybeBoldMarkdownText(main)
-        const secondaryMarkdownText = maybeBoldMarkdownText(secondary)
-
-        const combinedTextContinued = [
-            mainMarkdownText,
-            secondaryMarkdownText,
-        ].join(" ")
-        const combinedTextNewLine = [
-            mainMarkdownText,
-            secondaryMarkdownText,
-        ].join("\n")
-
-        if (newLine === "always") {
-            return new MarkdownTextWrap({
-                text: combinedTextNewLine,
-                ...textWrapProps,
-            })
-        }
-
-        if (newLine === "continue-line") {
-            return new MarkdownTextWrap({
-                text: combinedTextContinued,
-                ...textWrapProps,
-            })
-        }
-
-        // If newLine is set to 'avoid-wrap', we first try to fit the secondary
-        // text on the same line as the main text. If it doesn't fit, we place
-        // it on a new line.
-        const mainTextWrap = new MarkdownTextWrap({ ...main, ...textWrapProps })
-        const secondaryTextFitsOnSameLine = canAppendTextToLastLine({
-            existingTextWrap: mainTextWrap,
-            textToAppend: secondaryMarkdownText,
-        })
-
-        if (secondaryTextFitsOnSameLine) {
-            return new MarkdownTextWrap({
-                text: combinedTextContinued,
-                ...textWrapProps,
-            })
-        } else {
-            return new MarkdownTextWrap({
-                text: combinedTextNewLine,
-                ...textWrapProps,
-            })
-        }
+    protected get options(): TokenTextWrapOptions {
+        return this.props
     }
 
-    @imemo get maxWidth(): number {
-        return this.props.maxWidth
-    }
-    @imemo get lineHeight(): number {
-        return this.props.lineHeight
-    }
-    @imemo get fontSize(): number {
-        return this.props.fontSize
-    }
-    @imemo get fontWeight(): number | undefined {
-        return this.props.fontWeight
-    }
-    @imemo get fontFamily(): FontFamily | undefined {
-        return this.props.fontFamily
-    }
-    @imemo get verticalAlign(): VerticalAlign {
-        return this.props.verticalAlign
-    }
-    @imemo get fontParams(): IRFontParams {
-        return {
-            fontFamily: this.props.fontFamily,
-            fontSize: this.props.fontSize,
-            fontWeight: this.props.fontWeight,
-        }
-    }
     @imemo get text(): string {
-        // NOTE: ❗Here we deviate from the normal markdown spec. We replace \n with <SPACE><SPACE>\n to make sure that single \n are treated as
-        // actual line breaks but only if none of the other markdown line break rules apply.
-        // This is a bit different to how markdown usually works but we have a substantial
-        // amount of legacy charts that use newlines in this way and it seems that it is
-        // better to support this simple case than to do a data migration of many chart subtitles.
-        const baseText = this.props.text
-        // This replace is a bit funky - we want to make sure that single \n are treated as
-        // actual line breaks but only if none of the other markdown line break rules apply.
-        // These are:
-        // - \n\n is always a new paragraph
-        // - Two spaces before \n is a line break (this rule is not entirely checked as we only check for a single space)
-        // - A backslash before \n is a line break
-        // The code below normalizes all cases to <SPACE><SPACE>\n which will lead to them surviving the markdown parsing
-        let text = baseText.trim()
-        text = text.replaceAll("\n\n", "@@LINEBREAK@@")
-        text = text.replaceAll("\\\n", "@@LINEBREAK@@")
-        text = text.replaceAll("  \n", "@@LINEBREAK@@")
-        text = text.replaceAll("\n", "  \n")
-        text = text.replaceAll("@@LINEBREAK@@", "  \n")
-        return text
-    }
-    @imemo get detailsOrderedByReference(): string[] {
-        return this.props.detailsOrderedByReference
+        return normalizeMarkdownNewlines(this.props.text)
     }
 
-    @imemo get plaintext(): string {
-        return this.htmlLines.map(lineToPlaintext).join("\n")
+    @imemo get tokens(): IRToken[] {
+        return convertMarkdownToIRTokens(this.text, this.fontParams)
     }
+}
 
-    @imemo get tokensFromMarkdown(): IRToken[] {
-        const tokens = convertMarkdownToIRTokens(this.text, this.fontParams)
-        return tokens
-    }
-
-    @imemo get htmlLines(): IRToken[][] {
-        const tokens = this.tokensFromMarkdown
-        const lines = splitIntoLines(tokens, this.maxWidth)
-        return lines.map((line) =>
-            recursiveMergeTextTokens(line, this.fontParams)
-        )
-    }
-
-    @imemo get svgLines(): IRToken[][] {
-        const tokens = this.tokensFromMarkdown
-        const lines = splitIntoLines(tokens, this.maxWidth)
-        return lines
-    }
-
-    @imemo get svgLinesWithDodReferenceNumbers(): IRToken[][] {
-        const references = this.detailsOrderedByReference
-        const tokens = this.tokensFromMarkdown
-        const tokensWithReferenceNumbers = appendReferenceNumbers(
-            tokens,
-            references
-        )
-        return splitIntoLines(tokensWithReferenceNumbers, this.maxWidth)
-    }
-
-    @imemo get width(): number {
-        const { htmlLines } = this
-        const lineLengths = htmlLines.map((tokens) =>
-            _.sumBy(tokens, (token) => token.width)
-        )
-        return _.max(lineLengths) ?? 0
-    }
-
-    @imemo get singleLineHeight(): number {
-        return this.fontSize * this.lineHeight
-    }
-
-    @imemo get lastLineWidth(): number {
-        return _.sumBy(R.last(this.htmlLines), (token) => token.width) ?? 0
-    }
-
-    @imemo get height(): number {
-        const { htmlLines } = this
-        if (htmlLines.length === 0) return 0
-        return htmlLines.length * this.singleLineHeight
-    }
-
-    @imemo get style(): any {
-        return {
-            ...this.fontParams,
-            ...this.props.style,
-            lineHeight: this.lineHeight,
-        }
-    }
-
-    getPositionForSvgRendering(x: number, y: number): [number, number] {
-        const { fontSize, lineHeight, height, verticalAlign } = this
-
-        // Magic number set through experimentation.
-        // The HTML and SVG renderers need to position lines identically.
-        // This number was tweaked until the overlaid HTML and SVG outputs
-        // overlap.
-        const HEIGHT_CORRECTION_FACTOR = 0.74
-
-        const textHeight = fontSize * HEIGHT_CORRECTION_FACTOR
-        const containerHeight = lineHeight * fontSize
-        const correctedY =
-            y + (containerHeight - (containerHeight - textHeight) / 2)
-
-        const renderY = match(verticalAlign)
-            .with(VerticalAlign.top, () => correctedY - height)
-            .with(VerticalAlign.middle, () => correctedY - height / 2)
-            .with(VerticalAlign.bottom, () => correctedY)
-            .exhaustive()
-
-        return [x, renderY]
-    }
+/**
+ * Normalizes newline variants into markdown hard line breaks.
+ *
+ * NOTE: ❗Here we deviate from the normal markdown spec. We replace \n with <SPACE><SPACE>\n to make sure that single \n are treated as
+ * actual line breaks but only if none of the other markdown line break rules apply.
+ * This is a bit different to how markdown usually works but we have a substantial
+ * amount of legacy charts that use newlines in this way and it seems that it is
+ * better to support this simple case than to do a data migration of many chart subtitles.
+ */
+export function normalizeMarkdownNewlines(baseText: string): string {
+    // This replace is a bit funky - we want to make sure that single \n are treated as
+    // actual line breaks but only if none of the other markdown line break rules apply.
+    // These are:
+    // - \n\n is always a new paragraph
+    // - Two spaces before \n is a line break (this rule is not entirely checked as we only check for a single space)
+    // - A backslash before \n is a line break
+    // The code below normalizes all cases to <SPACE><SPACE>\n which will lead to them surviving the markdown parsing
+    let text = baseText.trim()
+    text = text.replaceAll("\n\n", "@@LINEBREAK@@")
+    text = text.replaceAll("\\\n", "@@LINEBREAK@@")
+    text = text.replaceAll("  \n", "@@LINEBREAK@@")
+    text = text.replaceAll("\n", "  \n")
+    text = text.replaceAll("@@LINEBREAK@@", "  \n")
+    return text
 }
 
 export function convertMarkdownToIRTokens(
@@ -1043,34 +413,14 @@ function convertMarkdownNodeToIRTokens(
     return converted
 }
 
-function appendReferenceNumbers(
-    tokens: IRToken[],
-    references: string[]
-): IRToken[] {
-    function traverse(token: IRToken, callback: (token: IRToken) => any): any {
-        if (token instanceof IRElement) {
-            token.children.flatMap((child) => traverse(child, callback))
-        }
-        return callback(token)
-    }
-
-    const appendedTokens: IRToken[] = _.cloneDeep(tokens).flatMap((token) =>
-        traverse(token, (token: IRToken) => {
-            if (token instanceof IRDetailOnDemand) {
-                const referenceIndex =
-                    references.findIndex((term) => term === token.term) + 1
-                if (referenceIndex === 0) return token
-                token.children.push(
-                    new IRSuperscript(String(referenceIndex), token.fontParams)
-                )
-            }
-            return token
-        })
-    )
-
-    return appendedTokens
+export function toPlaintext(markdown: string): string {
+    return new MarkdownTextWrap({
+        text: markdown,
+        fontSize: 10, // doesn't matter, but is a mandatory field
+    }).plaintext
 }
 
+/** Checks whether a piece of text fits on the last line of an existing text wrap */
 export function canAppendTextToLastLine({
     existingTextWrap,
     textToAppend,
@@ -1086,7 +436,7 @@ export function canAppendTextToLastLine({
 
     const spaceWidth = Bounds.forText(" ", { fontSize }).width
     const availableWidthInLastLine =
-        maxWidth - lastLineWidth - spaceWidth - reservedWidth - 10 // 10px wiggle room
+        maxWidth - lastLineWidth - spaceWidth - reservedWidth
 
     if (availableWidthInLastLine <= 0) return false
 
@@ -1099,21 +449,4 @@ export function canAppendTextToLastLine({
     })
 
     return secondaryTextWrap.svgLines.length === 1
-}
-
-function maybeBoldMarkdownText({
-    text,
-    bold,
-}: {
-    text: string
-    bold?: boolean
-}): string {
-    return bold ? `**${text}**` : text
-}
-
-export function toPlaintext(markdown: string): string {
-    return new MarkdownTextWrap({
-        text: markdown,
-        fontSize: 10, // doesn't matter, but is a mandatory field
-    }).plaintext
 }

--- a/packages/@ourworldindata/components/src/MarkdownTextWrap/MarkdownTextWrapComponents.tsx
+++ b/packages/@ourworldindata/components/src/MarkdownTextWrap/MarkdownTextWrapComponents.tsx
@@ -2,9 +2,9 @@ import * as _ from "lodash-es"
 import * as React from "react"
 import { DetailsMarker } from "@ourworldindata/types"
 import {
+    getDodUnderlineSegments,
     getLineFontSize,
     getLineGap,
-    IRDetailOnDemand,
     IRToken,
 } from "./IRTokens.js"
 import { AbstractTokenTextWrap } from "./AbstractTokenTextWrap.js"
@@ -118,26 +118,23 @@ export function MarkdownTextWrapSvg({
             {detailsMarker === "underline" &&
                 lines.map((line, lineIndex) => {
                     const lineY = (getLineY(lineIndex) + 2).toFixed(1)
-                    let currWidth = 0
-                    return line.map((token) => {
-                        const underline =
-                            token instanceof IRDetailOnDemand ? (
-                                <line
-                                    className="dod-underline"
-                                    x1={x + currWidth}
-                                    y1={lineY}
-                                    x2={x + currWidth + token.width}
-                                    y2={lineY}
-                                    stroke="currentColor"
-                                    strokeWidth={1}
-                                    strokeDasharray={1}
-                                    // important for rotated text
-                                    transform={svgTextProps?.transform}
-                                />
-                            ) : null
-                        currWidth += token.width
-                        return underline
-                    })
+                    return getDodUnderlineSegments(line).map(
+                        (segment, segmentIndex) => (
+                            <line
+                                key={`${lineIndex}-${segmentIndex}`}
+                                className="dod-underline"
+                                x1={x + segment.x}
+                                y1={lineY}
+                                x2={x + segment.x + segment.width}
+                                y2={lineY}
+                                stroke="currentColor"
+                                strokeWidth={1}
+                                strokeDasharray={1}
+                                // important for rotated text
+                                transform={svgTextProps?.transform}
+                            />
+                        )
+                    )
                 })}
         </g>
     )

--- a/packages/@ourworldindata/components/src/MarkdownTextWrap/MarkdownTextWrapComponents.tsx
+++ b/packages/@ourworldindata/components/src/MarkdownTextWrap/MarkdownTextWrapComponents.tsx
@@ -1,18 +1,27 @@
+import * as _ from "lodash-es"
 import * as React from "react"
 import { DetailsMarker } from "@ourworldindata/types"
 import {
-    MarkdownTextWrap,
+    getLineFontSize,
+    getLineGap,
     IRDetailOnDemand,
     IRToken,
-} from "./MarkdownTextWrap.js"
+} from "./IRTokens.js"
+import { AbstractTokenTextWrap } from "./AbstractTokenTextWrap.js"
+import { omitUndefinedValues } from "@ourworldindata/utils"
 
 function MarkdownTextWrapLine({
     line,
+    style,
 }: {
     line: IRToken[]
+    style?: React.CSSProperties
 }): React.ReactElement {
     return (
-        <span className="markdown-text-wrap__line">
+        <span
+            className="markdown-text-wrap__line"
+            style={omitUndefinedValues(style)}
+        >
             {line.length ? line.map((token, i) => token.toHTML(i)) : <br />}
         </span>
     )
@@ -21,7 +30,7 @@ function MarkdownTextWrapLine({
 export function MarkdownTextWrapHtml({
     textWrap,
 }: {
-    textWrap: MarkdownTextWrap
+    textWrap: AbstractTokenTextWrap
 }): React.ReactElement | null {
     const { htmlLines } = textWrap
     if (htmlLines.length === 0) return null
@@ -31,10 +40,23 @@ export function MarkdownTextWrapHtml({
                 const plaintextLine = line
                     .map((token) => token.toPlaintext())
                     .join("")
+
+                const lineFontSize = getLineFontSize(line) ?? textWrap.fontSize
+                const lineGap = getLineGap(line)
+
+                const style = {
+                    fontSize:
+                        lineFontSize !== textWrap.fontSize
+                            ? lineFontSize
+                            : undefined,
+                    marginTop: lineGap > 0 ? lineGap : undefined,
+                }
+
                 return (
                     <MarkdownTextWrapLine
                         key={`${plaintextLine}-${i}`}
                         line={line}
+                        style={style}
                     />
                 )
             })}
@@ -50,13 +72,12 @@ export function MarkdownTextWrapSvg({
     id,
     ...svgTextProps
 }: {
-    textWrap: MarkdownTextWrap
+    textWrap: AbstractTokenTextWrap
     x: number
     y: number
     detailsMarker?: DetailsMarker
     id?: string
 } & React.SVGProps<SVGTextElement>): React.ReactElement {
-    const { fontSize, lineHeight } = textWrap
     const lines =
         detailsMarker === "superscript"
             ? textWrap.svgLinesWithDodReferenceNumbers
@@ -65,8 +86,13 @@ export function MarkdownTextWrapSvg({
 
     const [, yOffset] = textWrap.getPositionForSvgRendering(x, y)
 
-    const getLineY = (lineIndex: number) =>
-        yOffset + lineHeight * fontSize * lineIndex
+    // The first line's baseline is given by yOffset; every subsequent line
+    // advances the baseline by its own line height plus its line gap
+    const lineHeights = lines.map(
+        (line) => textWrap.getLineHeight(line) + getLineGap(line)
+    )
+    const getLineY = (lineIndex: number): number =>
+        yOffset + _.sum(lineHeights.slice(1, lineIndex + 1))
 
     return (
         <g id={id} className="markdown-text-wrap">

--- a/packages/@ourworldindata/components/src/MarkdownTextWrap/TextWrapGroup.test.ts
+++ b/packages/@ourworldindata/components/src/MarkdownTextWrap/TextWrapGroup.test.ts
@@ -1,0 +1,594 @@
+import { expect, it, describe } from "vitest"
+
+import * as React from "react"
+import {
+    lineToPlaintext,
+    IRFragment,
+    IRDetailOnDemand,
+    IRSuperscript,
+    type IRToken,
+} from "./IRTokens.js"
+import { TextWrapGroup } from "./TextWrapGroup.js"
+
+const linesWithFragment = (wrap: TextWrapGroup, index: number): IRToken[][] =>
+    wrap.svgLines.filter((line) =>
+        line.some(
+            (token) =>
+                token instanceof IRFragment && token.fragmentIndex === index
+        )
+    )
+
+/**
+ * How each fragment was placed relative to the preceding content, derived
+ * from the rendered lines: a fragment was placed on a new line iff its
+ * first occurrence is the first token of its line.
+ */
+const fragmentPlacements = (
+    wrap: TextWrapGroup
+): ("first" | "inline" | "new-line")[] =>
+    wrap.fragments.map((_, index) => {
+        if (index === 0) return "first"
+        const firstToken = linesWithFragment(wrap, index)[0][0]
+        return firstToken instanceof IRFragment &&
+            firstToken.fragmentIndex === index
+            ? "new-line"
+            : "inline"
+    })
+
+describe(TextWrapGroup, () => {
+    const fontSize = 14
+
+    it("should place fragments in one line if they fit", () => {
+        const textWrap = new TextWrapGroup({
+            fragments: [
+                { text: "Lower middle-income countries" },
+                { text: "30 million" },
+            ],
+            maxWidth: 500,
+            fontSize,
+        })
+        expect(textWrap.svgLines.length).toEqual(1)
+        expect(textWrap.htmlLines.length).toEqual(1)
+        expect(fragmentPlacements(textWrap)).toEqual(["first", "inline"])
+    })
+
+    it("should place a fragment in a new line if requested", () => {
+        const textWrap = new TextWrapGroup({
+            fragments: [
+                { text: "Lower middle-income countries" },
+                { text: "30 million", newLine: "always" },
+            ],
+            maxWidth: 1000,
+            fontSize,
+        })
+        expect(textWrap.svgLines.length).toEqual(2)
+        expect(textWrap.htmlLines.length).toEqual(2)
+        expect(fragmentPlacements(textWrap)).toEqual(["first", "new-line"])
+    })
+
+    it("should let a continue-line fragment wrap freely instead of moving it to a new line", () => {
+        const makeGroup = (
+            newLine: "continue-line" | "avoid-wrap"
+        ): TextWrapGroup =>
+            new TextWrapGroup({
+                fragments: [
+                    { text: "25%" },
+                    { text: "died from cardiovascular diseases", newLine },
+                ],
+                maxWidth: 150,
+                fontSize,
+            })
+        // with avoid-wrap, the fragment moves to a new line as a whole,
+        // where it wraps internally since it exceeds a full line
+        const avoided = makeGroup("avoid-wrap")
+        expect(avoided.svgLines.length).toEqual(3)
+        expect(fragmentPlacements(avoided)).toEqual(["first", "new-line"])
+        expect(avoided.fragmentLineCounts).toEqual([1, 2])
+        // with continue-line, the fragment continues on the first line
+        const continued = makeGroup("continue-line")
+        expect(continued.svgLines.length).toEqual(2)
+        expect(lineToPlaintext(continued.svgLines[0])).toEqual("25% died from")
+    })
+
+    it("should wrap a continue-line fragment to the next line if the current line is full", () => {
+        const firstFragmentWidth = new TextWrapGroup({
+            fragments: [{ text: "Lower middle-income countries" }],
+            fontSize,
+        }).width
+        const textWrap = new TextWrapGroup({
+            fragments: [
+                { text: "Lower middle-income countries" },
+                {
+                    text: "cardiovascular",
+                    newLine: "continue-line",
+                    newLineGap: 10,
+                },
+            ],
+            // no room for the second fragment on the first line
+            maxWidth: firstFragmentWidth + 5,
+            fontSize,
+        })
+        expect(textWrap.svgLines.map(lineToPlaintext)).toEqual([
+            "Lower middle-income countries",
+            "cardiovascular",
+        ])
+        // the new-line gap doesn't apply: the fragment flowed onto a new
+        // line through wrapping, it wasn't placed there
+        expect(textWrap.lineGaps).toEqual([0, 0])
+    })
+
+    it("should break before a continue-line fragment with an inline gap", () => {
+        const makeGroup = (inlineGap?: number): TextWrapGroup =>
+            new TextWrapGroup({
+                fragments: [
+                    { text: "Lower middle-income countries" },
+                    {
+                        text: "cardiovascular",
+                        newLine: "continue-line",
+                        inlineGap,
+                    },
+                ],
+                maxWidth: 200,
+                fontSize,
+            })
+        // the gap provides the same break opportunity as a space: both
+        // versions break between the fragments
+        const expectedLines = [
+            "Lower middle-income countries",
+            "cardiovascular",
+        ]
+        expect(makeGroup().svgLines.map(lineToPlaintext)).toEqual(expectedLines)
+        expect(makeGroup(4).svgLines.map(lineToPlaintext)).toEqual(
+            expectedLines
+        )
+        // the gap is dropped when the fragment starts the new line
+        const fragment = makeGroup(4).svgLines.at(-1)![0] as IRFragment
+        expect(fragment.inlineGap).toEqual(0)
+    })
+
+    it("should move a fragment to a new line as a whole if it doesn't fit", () => {
+        const textWrap = new TextWrapGroup({
+            fragments: [
+                { text: "Lower middle-income countries" },
+                { text: "30 million" },
+            ],
+            maxWidth: 250,
+            fontSize,
+        })
+        expect(textWrap.svgLines.length).toEqual(2)
+        expect(textWrap.htmlLines.length).toEqual(2)
+        expect(fragmentPlacements(textWrap)).toEqual(["first", "new-line"])
+    })
+
+    it("should use all available space when one fragment exceeds the given max width", () => {
+        const textWrap = new TextWrapGroup({
+            fragments: [
+                { text: "Long-word-that-can't-be-broken-up more words" },
+                { text: "30 million" },
+            ],
+            maxWidth: 150,
+            fontSize,
+        })
+        expect(textWrap.width).toBeGreaterThan(150)
+    })
+
+    it("should place very long words in a separate line", () => {
+        const textWrap = new TextWrapGroup({
+            fragments: [
+                { text: "30 million" },
+                { text: "Long-word-that-can't-be-broken-up" },
+            ],
+            maxWidth: 150,
+            fontSize,
+        })
+        expect(textWrap.svgLines.length).toEqual(2)
+        expect(textWrap.htmlLines.length).toEqual(2)
+    })
+
+    it("should drop fragments with empty text", () => {
+        const textWrap = new TextWrapGroup({
+            fragments: [{ text: "Some text" }, { text: "  " }],
+            fontSize,
+        })
+        expect(textWrap.fragments).toHaveLength(1)
+        expect(fragmentPlacements(textWrap)).toEqual(["first"])
+        expect(textWrap.plaintext).toEqual("Some text")
+    })
+
+    it("should handle a group with no non-empty fragments", () => {
+        const textWrap = new TextWrapGroup({
+            fragments: [{ text: "  " }],
+            fontSize,
+        })
+        expect(textWrap.fragments).toEqual([])
+        expect(textWrap.svgLines).toEqual([])
+        expect(textWrap.htmlLines).toEqual([])
+        expect(textWrap.plaintext).toEqual("")
+        expect(textWrap.width).toEqual(0)
+        expect(textWrap.height).toEqual(0)
+    })
+
+    it("should ignore placement options on the first fragment", () => {
+        const textWrap = new TextWrapGroup({
+            fragments: [
+                { text: "Some text", newLine: "always", newLineGap: 10 },
+            ],
+            fontSize,
+            lineHeight: 1,
+        })
+        expect(textWrap.svgLines.length).toEqual(1)
+        expect(textWrap.lineGaps).toEqual([0])
+        expect(textWrap.height).toEqual(fontSize)
+    })
+
+    it("should treat the first non-empty fragment as the first fragment", () => {
+        const textWrap = new TextWrapGroup({
+            fragments: [
+                { text: " " },
+                { text: "Some text", newLine: "always", newLineGap: 10 },
+            ],
+            fontSize,
+            lineHeight: 1,
+        })
+        expect(textWrap.svgLines.length).toEqual(1)
+        expect(textWrap.lineGaps).toEqual([0])
+        expect(textWrap.plaintext).toEqual("Some text")
+    })
+
+    it("should honor hard line breaks within fragments", () => {
+        const makeGroup = (markdown: boolean): TextWrapGroup =>
+            new TextWrapGroup({
+                fragments: [
+                    { text: "first line\nsecond line", markdown },
+                    { text: "annotation" },
+                ],
+                fontSize,
+            })
+        for (const textWrap of [makeGroup(false), makeGroup(true)]) {
+            expect(textWrap.svgLines.map(lineToPlaintext)).toEqual([
+                "first line",
+                "second line annotation",
+            ])
+        }
+    })
+
+    it("should not parse markdown in plain-text fragments", () => {
+        const textWrap = new TextWrapGroup({
+            fragments: [{ text: "A **literal** asterisk" }],
+            fontSize,
+        })
+        expect(textWrap.plaintext).toEqual("A **literal** asterisk")
+    })
+
+    it("should parse markdown in markdown fragments", () => {
+        const textWrap = new TextWrapGroup({
+            fragments: [{ text: "A **bold** word", markdown: true }],
+            fontSize,
+        })
+        expect(textWrap.plaintext).toEqual("A bold word")
+    })
+
+    it("should measure fragments at their own font size", () => {
+        const makeGroup = (annotationFontSize: number): TextWrapGroup =>
+            new TextWrapGroup({
+                fragments: [
+                    { text: "Some text" },
+                    { text: "annotation", fontSize: annotationFontSize },
+                ],
+                fontSize: 20,
+            })
+        const small = makeGroup(10)
+        const large = makeGroup(20)
+        expect(small.width).toBeLessThan(large.width)
+        expect(small.lastLineWidth).toBeLessThan(large.lastLineWidth)
+    })
+
+    it("should measure fragments at their own font weight", () => {
+        const measure = (props: {
+            fontWeight?: number
+            groupFontWeight?: number
+        }): number =>
+            new TextWrapGroup({
+                fragments: [
+                    { text: "Some text", fontWeight: props.fontWeight },
+                ],
+                fontSize,
+                fontWeight: props.groupFontWeight,
+            }).width
+        // bold text measures wider than regular text
+        expect(measure({ fontWeight: 700 })).toBeGreaterThan(measure({}))
+        // fragments fall back to the group-level font weight
+        expect(measure({ groupFontWeight: 700 })).toEqual(
+            measure({ fontWeight: 700 })
+        )
+    })
+
+    it("should measure the fit against the last line of a wrapped fragment", () => {
+        const makeGroup = (secondText: string): TextWrapGroup =>
+            new TextWrapGroup({
+                fragments: [
+                    { text: "Lower middle-income countries" },
+                    { text: secondText },
+                ],
+                maxWidth: 100,
+                fontSize,
+            })
+        // the first fragment wraps; a short second fragment still fits
+        // inline on its last line
+        const withShortFragment = makeGroup("30")
+        expect(withShortFragment.fragmentLineCounts).toEqual([3, 1])
+        expect(fragmentPlacements(withShortFragment)).toEqual([
+            "first",
+            "inline",
+        ])
+        // a longer second fragment moves to a new line
+        const withLongFragment = makeGroup("30 million")
+        expect(withLongFragment.fragmentLineCounts).toEqual([3, 1])
+        expect(fragmentPlacements(withLongFragment)).toEqual([
+            "first",
+            "new-line",
+        ])
+    })
+
+    it("should use tighter line heights for lines with smaller fragments", () => {
+        const textWrap = new TextWrapGroup({
+            fragments: [
+                { text: "Lower middle-income countries" },
+                { text: "30 million", fontSize: 7, newLine: "always" },
+            ],
+            fontSize,
+            lineHeight: 1,
+        })
+        expect(fragmentPlacements(textWrap)).toEqual(["first", "new-line"])
+        expect(textWrap.lineHeights).toEqual([fontSize, 7])
+        expect(textWrap.height).toEqual(fontSize + 7)
+    })
+
+    it("should apply the line gap only when the fragment starts a new line", () => {
+        const makeGroup = (
+            newLine: "always" | "avoid-wrap",
+            maxWidth = Infinity
+        ): TextWrapGroup =>
+            new TextWrapGroup({
+                fragments: [
+                    { text: "Lower middle-income countries" },
+                    {
+                        text: "30 million",
+                        fontSize: 7,
+                        newLineGap: 10,
+                        newLine,
+                    },
+                ],
+                maxWidth,
+                fontSize,
+                lineHeight: 1,
+            })
+        // on its own line, the gap is added above the fragment's line
+        const withNewLine = makeGroup("always")
+        expect(withNewLine.lineGaps).toEqual([0, 10])
+        expect(withNewLine.height).toEqual(fontSize + 10 + 7)
+        // inline, the gap is ignored
+        const inline = makeGroup("avoid-wrap")
+        expect(inline.lineGaps).toEqual([0])
+        expect(inline.height).toEqual(fontSize)
+        // an avoid-wrap fragment that is moved to a new line gets the gap
+        const bumped = makeGroup("avoid-wrap", 220)
+        expect(fragmentPlacements(bumped)).toEqual(["first", "new-line"])
+        expect(bumped.lineGaps).toEqual([0, 10])
+    })
+
+    it("should apply the line gap only once when the fragment wraps", () => {
+        const textWrap = new TextWrapGroup({
+            fragments: [
+                { text: "Long-run estimates of interpersonal trust" },
+                {
+                    text: "an annotation that is long enough to wrap across several lines",
+                    fontSize: 7,
+                    newLineGap: 10,
+                    newLine: "always",
+                },
+            ],
+            maxWidth: 100,
+            fontSize,
+            lineHeight: 1,
+        })
+        const annotationLineCount = textWrap.fragmentLineCounts[1]
+        expect(annotationLineCount).toBeGreaterThan(1)
+        // the gap precedes the fragment's first line only
+        expect(textWrap.lineGaps.filter((gap) => gap > 0)).toEqual([10])
+    })
+
+    it("should use an explicit gap between fragments if given", () => {
+        const makeGroup = (inlineGap: number): TextWrapGroup =>
+            new TextWrapGroup({
+                fragments: [
+                    { text: "Some text" },
+                    { text: "annotation", inlineGap },
+                ],
+                fontSize,
+            })
+        const withSmallGap = makeGroup(4)
+        const withLargeGap = makeGroup(24)
+        expect(withLargeGap.width - withSmallGap.width).toEqual(20)
+        expect(withLargeGap.lastLineWidth - withSmallGap.lastLineWidth).toEqual(
+            20
+        )
+
+        // the total width is the sum of the fragment widths plus the gap
+        const measureText = (text: string): number =>
+            new TextWrapGroup({ fragments: [{ text }], fontSize }).width
+        expect(withSmallGap.width).toEqual(
+            measureText("Some text") + 4 + measureText("annotation")
+        )
+
+        // no separate whitespace token; the gap is baked into the fragment
+        const line = withSmallGap.svgLines[0]
+        expect(line).toHaveLength(2)
+        const fragment = line[1] as IRFragment
+        expect(fragment.inlineGap).toEqual(4)
+
+        const svg = fragment.toSVG() as React.ReactElement<{ dx?: number }>
+        expect(svg.type).toEqual("tspan")
+        expect(svg.props.dx).toEqual(4)
+
+        const html = fragment.toHTML() as React.ReactElement<{
+            style: React.CSSProperties
+        }>
+        expect(html.type).toEqual("span")
+        expect(html.props.style.marginLeft).toEqual(4)
+        // atomic inline, so that a link underline doesn't continue
+        // across the fragment
+        expect(html.props.style.display).toEqual("inline-block")
+    })
+
+    it("should account for the inline gap when deciding if a fragment fits", () => {
+        const makeGroup = (inlineGap: number): TextWrapGroup =>
+            new TextWrapGroup({
+                fragments: [
+                    { text: "Lower middle-income countries" },
+                    { text: "30 million", inlineGap },
+                ],
+                maxWidth: 300,
+                fontSize,
+            })
+        // with a small gap the fragment fits inline; a large gap pushes it
+        // to a new line even though the text alone would fit
+        expect(fragmentPlacements(makeGroup(4))).toEqual(["first", "inline"])
+        expect(fragmentPlacements(makeGroup(100))).toEqual([
+            "first",
+            "new-line",
+        ])
+    })
+
+    it("should ignore the gap when the fragment starts a new line", () => {
+        const textWrap = new TextWrapGroup({
+            fragments: [
+                { text: "Lower middle-income countries" },
+                { text: "30 million", inlineGap: 6 },
+            ],
+            maxWidth: 250,
+            fontSize,
+        })
+        expect(fragmentPlacements(textWrap)).toEqual(["first", "new-line"])
+        const fragment = textWrap.svgLines.at(-1)![0] as IRFragment
+        expect(fragment.inlineGap).toEqual(0)
+    })
+
+    it("should render no wrapper element for fragments that match the group style", () => {
+        const textWrap = new TextWrapGroup({
+            fragments: [
+                { text: "plain text" },
+                // explicitly given, but identical to the group style
+                { text: "same style", fontSize, fontWeight: 400 },
+            ],
+            fontSize,
+            fontWeight: 400,
+        })
+        const fragments = textWrap.svgLines[0].filter(
+            (token) => token instanceof IRFragment
+        )
+        expect(fragments).toHaveLength(2)
+        for (const fragment of fragments) {
+            expect(fragment.toSVG().type).toEqual(React.Fragment)
+            expect(fragment.toHTML().type).toEqual(React.Fragment)
+        }
+    })
+
+    it("should render a styled wrapper for fragments that differ from the group style", () => {
+        const textWrap = new TextWrapGroup({
+            fragments: [
+                { text: "main" },
+                {
+                    text: "annotation",
+                    fontSize: 10,
+                    fontWeight: 700,
+                    color: "#767676",
+                },
+            ],
+            fontSize,
+        })
+        const fragment = textWrap.svgLines[0].at(-1) as IRFragment
+
+        const svg = fragment.toSVG() as React.ReactElement<{
+            style: React.CSSProperties
+        }>
+        expect(svg.type).toEqual("tspan")
+        expect(svg.props.style).toMatchObject({
+            fontSize: 10,
+            fontWeight: 700,
+            fill: "#767676",
+        })
+
+        const html = fragment.toHTML() as React.ReactElement<{
+            style: React.CSSProperties
+        }>
+        expect(html.type).toEqual("span")
+        expect(html.props.style).toMatchObject({
+            // atomic inline, so that a link underline doesn't extend into
+            // the fragment (relevant when it's placed on its own line)
+            display: "inline-block",
+            fontSize: 10,
+            fontWeight: 700,
+            color: "#767676",
+        })
+    })
+
+    it("should append superscript reference numbers to details on demand", () => {
+        const textWrap = new TextWrapGroup({
+            fragments: [{ text: "A [dod](#dod:example) term", markdown: true }],
+            fontSize,
+            detailsOrderedByReference: ["example"],
+        })
+        const fragment = textWrap
+            .svgLinesWithDodReferenceNumbers[0][0] as IRFragment
+        const dod = fragment.children.find(
+            (token) => token instanceof IRDetailOnDemand
+        ) as IRDetailOnDemand
+        expect(dod).toBeInstanceOf(IRDetailOnDemand)
+        expect(dod.children.at(-1)).toBeInstanceOf(IRSuperscript)
+    })
+
+    it("should place a longer sequence of fragments with mixed modes", () => {
+        const textWrap = new TextWrapGroup({
+            fragments: [
+                { text: "Energy use" },
+                { text: "(kilowatt-hours per person)", newLine: "always" },
+                { text: "annotation" },
+            ],
+            maxWidth: 300,
+            fontSize,
+        })
+        expect(fragmentPlacements(textWrap)).toEqual([
+            "first",
+            "new-line",
+            "inline",
+        ])
+        expect(textWrap.svgLines.map(lineToPlaintext)).toEqual([
+            "Energy use",
+            "(kilowatt-hours per person) annotation",
+        ])
+    })
+
+    it("should lay out axis-style labels (bold main label plus unit)", () => {
+        const textWrap = new TextWrapGroup({
+            fragments: [
+                { text: "Energy use", fontWeight: 700, markdown: true },
+                { text: "(kilowatt-hours per person)", markdown: true },
+            ],
+            maxWidth: 300,
+            fontSize,
+            lineHeight: 1,
+        })
+        expect(textWrap.plaintext).toEqual(
+            "Energy use (kilowatt-hours per person)"
+        )
+        expect(textWrap.svgLines.length).toEqual(1)
+
+        const mainFragment = textWrap.svgLines[0][0] as IRFragment
+        const svg = mainFragment.toSVG() as React.ReactElement<{
+            style: React.CSSProperties
+        }>
+        expect(svg.type).toEqual("tspan")
+        expect(svg.props.style).toMatchObject({ fontWeight: 700 })
+    })
+})

--- a/packages/@ourworldindata/components/src/MarkdownTextWrap/TextWrapGroup.test.ts
+++ b/packages/@ourworldindata/components/src/MarkdownTextWrap/TextWrapGroup.test.ts
@@ -2,6 +2,8 @@ import { expect, it, describe } from "vitest"
 
 import * as React from "react"
 import {
+    getDodUnderlineSegments,
+    getLineWidth,
     lineToPlaintext,
     IRFragment,
     IRDetailOnDemand,
@@ -546,6 +548,60 @@ describe(TextWrapGroup, () => {
         ) as IRDetailOnDemand
         expect(dod).toBeInstanceOf(IRDetailOnDemand)
         expect(dod.children.at(-1)).toBeInstanceOf(IRSuperscript)
+    })
+
+    it("should find underline segments for DoDs nested inside fragments", () => {
+        const textWrap = new TextWrapGroup({
+            fragments: [
+                {
+                    text: "Deaths from [malaria](#dod:malaria)",
+                    fontWeight: 700,
+                    markdown: true,
+                },
+                { text: "(per 100,000 people)" },
+            ],
+            maxWidth: 1000,
+            fontSize,
+        })
+        const line = textWrap.svgLines[0]
+        const fragment = line[0] as IRFragment
+        const dodIndex = fragment.children.findIndex(
+            (token) => token instanceof IRDetailOnDemand
+        )
+
+        expect(getDodUnderlineSegments(line)).toEqual([
+            {
+                x: getLineWidth(fragment.children.slice(0, dodIndex)),
+                width: fragment.children[dodIndex].width,
+            },
+        ])
+    })
+
+    it("should offset underline segments by a fragment's inline gap", () => {
+        const inlineGap = 10
+        const textWrap = new TextWrapGroup({
+            fragments: [
+                { text: "Deaths" },
+                {
+                    text: "[malaria](#dod:malaria)",
+                    markdown: true,
+                    newLine: "continue-line",
+                    inlineGap,
+                },
+            ],
+            maxWidth: 1000,
+            fontSize,
+        })
+        const line = textWrap.svgLines[0]
+        const dodFragment = line.at(-1) as IRFragment
+
+        expect(dodFragment.inlineGap).toEqual(inlineGap)
+        expect(getDodUnderlineSegments(line)).toEqual([
+            {
+                x: getLineWidth(line.slice(0, -1)) + inlineGap,
+                width: dodFragment.width - inlineGap,
+            },
+        ])
     })
 
     it("should place a longer sequence of fragments with mixed modes", () => {

--- a/packages/@ourworldindata/components/src/MarkdownTextWrap/TextWrapGroup.tsx
+++ b/packages/@ourworldindata/components/src/MarkdownTextWrap/TextWrapGroup.tsx
@@ -1,0 +1,251 @@
+import { CSSProperties } from "react"
+import * as R from "remeda"
+import {
+    Bounds,
+    FontFamily,
+    imemo,
+    omitUndefinedValues,
+    VerticalAlign,
+    type RequiredBy,
+} from "@ourworldindata/utils"
+import {
+    convertPlaintextToIRTokens,
+    getLineWidth,
+    IRFontParams,
+    IRFragment,
+    IRFragmentStyle,
+    IRLineBreak,
+    IRToken,
+    IRWhitespace,
+    splitIntoLines,
+} from "./IRTokens.js"
+import {
+    AbstractTokenTextWrap,
+    TokenTextWrapOptions,
+} from "./AbstractTokenTextWrap.js"
+import {
+    convertMarkdownToIRTokens,
+    normalizeMarkdownNewlines,
+} from "./MarkdownTextWrap.js"
+
+/**
+ * A single fragment of a TextWrapGroup. The inherited style props act as
+ * overrides that fall back to the group-level style when not given.
+ */
+export interface TextWrapFragment extends IRFragmentStyle {
+    text: string
+
+    /** Parse the text as markdown (including details on demand) */
+    markdown?: boolean
+
+    /**
+     * Placement relative to the preceding content:
+     * - "avoid-wrap" places the fragment on the current line if it fits there
+     *    in its entirety and on a new line otherwise
+     * - "continue-line" continues on the current line unconditionally and lets
+     *    the fragment wrap freely
+     * - "always" always starts a new line
+     */
+    newLine?: "avoid-wrap" | "continue-line" | "always"
+
+    /**
+     * Horizontal gap between the preceding content and this fragment.
+     * Only applies when the fragment is placed inline (continues a line)
+     */
+    inlineGap?: number
+
+    /**
+     * Vertical gap between the preceding line and this fragment.
+     * Only applies when the fragment is placed on a new line
+     */
+    newLineGap?: number
+}
+
+type TextWrapGroupProps = {
+    fragments: TextWrapFragment[]
+    fontSize: number
+    maxWidth?: number
+    lineHeight?: number
+    fontWeight?: number
+    fontFamily?: FontFamily
+    verticalAlign?: VerticalAlign
+    style?: CSSProperties
+    detailsOrderedByReference?: string[]
+}
+
+/**
+ * Wraps a sequence of text fragments, each with its own font style, into
+ * lines. A fragment is treated as an unbreakable unit where possible: with
+ * the default "avoid-wrap" placement it continues on the current line only
+ * if it fits there in its entirety, and otherwise starts a new line, where
+ * it may wrap internally if it is longer than a full line.
+ */
+export class TextWrapGroup extends AbstractTokenTextWrap {
+    private static readonly defaultOptions = {
+        maxWidth: Infinity,
+        lineHeight: 1.1,
+        verticalAlign: VerticalAlign.bottom,
+        detailsOrderedByReference: [] as string[],
+    } as const satisfies Partial<TextWrapGroupProps>
+
+    private readonly initialProps: TextWrapGroupProps
+    constructor(props: TextWrapGroupProps) {
+        super()
+        this.initialProps = props
+    }
+
+    @imemo get props(): RequiredBy<
+        TextWrapGroupProps,
+        keyof typeof TextWrapGroup.defaultOptions
+    > {
+        return { ...TextWrapGroup.defaultOptions, ...this.initialProps }
+    }
+
+    protected get options(): TokenTextWrapOptions {
+        return this.props
+    }
+
+    @imemo get fragments(): TextWrapFragment[] {
+        return this.props.fragments.filter(
+            (fragment) => fragment.text.trim().length > 0
+        )
+    }
+
+    @imemo get text(): string {
+        return this.fragments.map((fragment) => fragment.text).join(" ")
+    }
+
+    private getFragmentFontParams(fragment: TextWrapFragment): IRFontParams {
+        return {
+            fontFamily: fragment.fontFamily ?? this.fontFamily,
+            fontSize: fragment.fontSize ?? this.fontSize,
+            fontWeight: fragment.fontWeight ?? this.fontWeight,
+        }
+    }
+
+    /** Style props in which the fragment differs from the group-level style */
+    private getFragmentStyleDelta(fragment: TextWrapFragment): IRFragmentStyle {
+        return omitUndefinedValues({
+            fontSize:
+                fragment.fontSize !== this.fontSize
+                    ? fragment.fontSize
+                    : undefined,
+            fontFamily:
+                fragment.fontFamily !== this.fontFamily
+                    ? fragment.fontFamily
+                    : undefined,
+            fontWeight:
+                fragment.fontWeight !== this.fontWeight
+                    ? fragment.fontWeight
+                    : undefined,
+            color: fragment.color,
+        })
+    }
+
+    private makeFragmentElement(
+        fragment: TextWrapFragment,
+        index: number
+    ): IRFragment {
+        const fontParams = this.getFragmentFontParams(fragment)
+        const children = fragment.markdown
+            ? convertMarkdownToIRTokens(
+                  normalizeMarkdownNewlines(fragment.text),
+                  fontParams
+              )
+            : convertPlaintextToIRTokens(fragment.text, fontParams)
+        return new IRFragment(
+            index,
+            children,
+            this.getFragmentStyleDelta(fragment),
+            fontParams
+        )
+    }
+
+    /** The number of lines each fragment spans */
+    @imemo get fragmentLineCounts(): number[] {
+        return this.fragments.map(
+            (_, index) =>
+                this.svgLines.filter((line) =>
+                    line.some(
+                        (token) =>
+                            token instanceof IRFragment &&
+                            token.fragmentIndex === index
+                    )
+                ).length
+        )
+    }
+
+    @imemo get tokens(): IRToken[] {
+        const tokens: IRToken[] = []
+        this.fragments.forEach((fragment, index) => {
+            const element = this.makeFragmentElement(fragment, index)
+
+            const elementWithGap = (gaps: {
+                inlineGap?: number
+                lineGap?: number
+            }): IRFragment =>
+                new IRFragment(
+                    index,
+                    element.children,
+                    element.styleDelta,
+                    element.fontParams,
+                    gaps.inlineGap,
+                    gaps.lineGap
+                )
+
+            const pushOnNewLine = (): void => {
+                tokens.push(
+                    new IRLineBreak(),
+                    fragment.newLineGap
+                        ? elementWithGap({ lineGap: fragment.newLineGap })
+                        : element
+                )
+            }
+
+            const pushOnCurrentLine = (): void => {
+                if (fragment.inlineGap !== undefined) {
+                    tokens.push(
+                        elementWithGap({ inlineGap: fragment.inlineGap })
+                    )
+                } else {
+                    tokens.push(new IRWhitespace(this.fontParams), element)
+                }
+            }
+
+            if (index === 0) {
+                tokens.push(element)
+                return
+            }
+
+            const newLine = fragment.newLine ?? "avoid-wrap"
+            if (newLine === "always") {
+                pushOnNewLine()
+                return
+            }
+            if (newLine === "continue-line") {
+                pushOnCurrentLine()
+                return
+            }
+
+            // "avoid-wrap": place the fragment on the current line only if it
+            // fits there in its entirety, otherwise start a new line
+            const lines = splitIntoLines(tokens, this.maxWidth)
+            const lastLineWidth = getLineWidth(R.last(lines) ?? [])
+            const spaceWidth = Bounds.forText(" ", {
+                fontSize: this.fontSize,
+            }).width
+            const gapWidth = fragment.inlineGap ?? spaceWidth
+            const availableWidth = this.maxWidth - lastLineWidth - gapWidth
+            const fitsOnCurrentLine =
+                availableWidth > 0 &&
+                splitIntoLines([element], availableWidth).length === 1
+            if (fitsOnCurrentLine) {
+                pushOnCurrentLine()
+            } else {
+                pushOnNewLine()
+            }
+        })
+
+        return tokens
+    }
+}

--- a/packages/@ourworldindata/components/src/MarkdownTextWrap/TextWrapGroup.tsx
+++ b/packages/@ourworldindata/components/src/MarkdownTextWrap/TextWrapGroup.tsx
@@ -1,13 +1,5 @@
-import { CSSProperties } from "react"
 import * as R from "remeda"
-import {
-    Bounds,
-    FontFamily,
-    imemo,
-    omitUndefinedValues,
-    VerticalAlign,
-    type RequiredBy,
-} from "@ourworldindata/utils"
+import { Bounds, imemo, omitUndefinedValues } from "@ourworldindata/utils"
 import {
     convertPlaintextToIRTokens,
     getLineWidth,
@@ -21,7 +13,7 @@ import {
 } from "./IRTokens.js"
 import {
     AbstractTokenTextWrap,
-    TokenTextWrapOptions,
+    type TokenTextWrapProps,
 } from "./AbstractTokenTextWrap.js"
 import {
     convertMarkdownToIRTokens,
@@ -63,15 +55,7 @@ export interface TextWrapFragment extends IRFragmentStyle {
 
 type TextWrapGroupProps = {
     fragments: TextWrapFragment[]
-    fontSize: number
-    maxWidth?: number
-    lineHeight?: number
-    fontWeight?: number
-    fontFamily?: FontFamily
-    verticalAlign?: VerticalAlign
-    style?: CSSProperties
-    detailsOrderedByReference?: string[]
-}
+} & TokenTextWrapProps
 
 /**
  * Wraps a sequence of text fragments, each with its own font style, into
@@ -80,31 +64,7 @@ type TextWrapGroupProps = {
  * if it fits there in its entirety, and otherwise starts a new line, where
  * it may wrap internally if it is longer than a full line.
  */
-export class TextWrapGroup extends AbstractTokenTextWrap {
-    private static readonly defaultOptions = {
-        maxWidth: Infinity,
-        lineHeight: 1.1,
-        verticalAlign: VerticalAlign.bottom,
-        detailsOrderedByReference: [] as string[],
-    } as const satisfies Partial<TextWrapGroupProps>
-
-    private readonly initialProps: TextWrapGroupProps
-    constructor(props: TextWrapGroupProps) {
-        super()
-        this.initialProps = props
-    }
-
-    @imemo get props(): RequiredBy<
-        TextWrapGroupProps,
-        keyof typeof TextWrapGroup.defaultOptions
-    > {
-        return { ...TextWrapGroup.defaultOptions, ...this.initialProps }
-    }
-
-    protected get options(): TokenTextWrapOptions {
-        return this.props
-    }
-
+export class TextWrapGroup extends AbstractTokenTextWrap<TextWrapGroupProps> {
     @imemo get fragments(): TextWrapFragment[] {
         return this.props.fragments.filter(
             (fragment) => fragment.text.trim().length > 0

--- a/packages/@ourworldindata/components/src/TextWrap/TextWrap.ts
+++ b/packages/@ourworldindata/components/src/TextWrap/TextWrap.ts
@@ -107,6 +107,13 @@ export interface ITextWrap {
     getPositionForSvgRendering(x: number, y: number): [number, number]
 }
 
+export const sumTextWrapHeights = (
+    elements: ITextWrap[],
+    spacer: number = 0
+): number =>
+    _.sum(elements.map((element) => element.height)) +
+    (elements.length - 1) * spacer
+
 export class TextWrap implements ITextWrap {
     private static readonly defaultOptions = {
         maxWidth: Infinity,

--- a/packages/@ourworldindata/components/src/TextWrap/TextWrap.ts
+++ b/packages/@ourworldindata/components/src/TextWrap/TextWrap.ts
@@ -103,8 +103,40 @@ export interface ITextWrap {
     readonly fontWeight: number | undefined
     readonly fontFamily: FontFamily | undefined
     readonly lineHeight: number
+    readonly verticalAlign: VerticalAlign
     readonly text: string
     getPositionForSvgRendering(x: number, y: number): [number, number]
+}
+
+/**
+ * The SVG position of the first line's baseline for a text wrap anchored
+ * at (x, y), such that the HTML and SVG renderers position lines identically.
+ */
+export function getTextPositionForSvgRendering(
+    textWrap: ITextWrap,
+    x: number,
+    y: number
+): [number, number] {
+    const { fontSize, lineHeight, height, verticalAlign } = textWrap
+
+    // Magic number set through experimentation.
+    // The HTML and SVG renderers need to position lines identically.
+    // This number was tweaked until the overlaid HTML and SVG outputs
+    // overlap.
+    const HEIGHT_CORRECTION_FACTOR = 0.74
+
+    const textHeight = fontSize * HEIGHT_CORRECTION_FACTOR
+    const containerHeight = lineHeight * fontSize
+    const correctedY =
+        y + (containerHeight - (containerHeight - textHeight) / 2)
+
+    const renderY = match(verticalAlign)
+        .with(VerticalAlign.top, () => correctedY - height)
+        .with(VerticalAlign.middle, () => correctedY - height / 2)
+        .with(VerticalAlign.bottom, () => correctedY)
+        .exhaustive()
+
+    return [x, renderY]
 }
 
 export const sumTextWrapHeights = (
@@ -307,26 +339,6 @@ export class TextWrap implements ITextWrap {
     }
 
     getPositionForSvgRendering(x: number, y: number): [number, number] {
-        const { lines, fontSize, lineHeight, height, verticalAlign } = this
-
-        // Magic number set through experimentation.
-        // The HTML and SVG renderers need to position lines identically.
-        // This number was tweaked until the overlaid HTML and SVG outputs
-        // overlap.
-        const HEIGHT_CORRECTION_FACTOR = 0.74
-
-        const textHeight = _.max(lines.map((line) => line.height)) ?? 0
-        const correctedTextHeight = textHeight * HEIGHT_CORRECTION_FACTOR
-        const containerHeight = lineHeight * fontSize
-        const correctedY =
-            y + (containerHeight - (containerHeight - correctedTextHeight) / 2)
-
-        const renderY = match(verticalAlign)
-            .with(VerticalAlign.top, () => correctedY - height)
-            .with(VerticalAlign.middle, () => correctedY - height / 2)
-            .with(VerticalAlign.bottom, () => correctedY)
-            .exhaustive()
-
-        return [x, renderY]
+        return getTextPositionForSvgRendering(this, x, y)
     }
 }

--- a/packages/@ourworldindata/components/src/detailsOnDemand.scss
+++ b/packages/@ourworldindata/components/src/detailsOnDemand.scss
@@ -41,6 +41,12 @@
     }
 }
 
+// In SVG, a dotted underline is drawn manually, so suppress the css underline
+// to avoid rendering two overlapping dotted lines
+tspan.dod-span {
+    text-decoration: none;
+}
+
 // Stops text from getting pushed out of the way when a tooltip appears on Chrome
 [data-tippy-root] {
     display: inline;

--- a/packages/@ourworldindata/components/src/index.ts
+++ b/packages/@ourworldindata/components/src/index.ts
@@ -2,15 +2,21 @@ export {
     type ITextWrap,
     TextWrap,
     shortenWithEllipsis,
+    sumTextWrapHeights,
 } from "./TextWrap/TextWrap.js"
 export { TextWrapSvg, TextWrapHtml } from "./TextWrap/TextWrapComponents.js"
 
+export { IRFragment } from "./MarkdownTextWrap/IRTokens.js"
+export { AbstractTokenTextWrap } from "./MarkdownTextWrap/AbstractTokenTextWrap.js"
 export {
     MarkdownTextWrap,
-    sumTextWrapHeights,
     toPlaintext,
     canAppendTextToLastLine,
 } from "./MarkdownTextWrap/MarkdownTextWrap.js"
+export {
+    TextWrapGroup,
+    type TextWrapFragment,
+} from "./MarkdownTextWrap/TextWrapGroup.js"
 export {
     MarkdownTextWrapSvg,
     MarkdownTextWrapHtml,

--- a/packages/@ourworldindata/grapher/src/axis/Axis.ts
+++ b/packages/@ourworldindata/grapher/src/axis/Axis.ts
@@ -23,7 +23,7 @@ import {
     getDiscreteTimeTickOptions,
     type CalendarTickInterval,
 } from "./timeAxisTicks.js"
-import { MarkdownTextWrap } from "@ourworldindata/components"
+import { MarkdownTextWrap, TextWrapGroup } from "@ourworldindata/components"
 import { CoreColumn } from "@ourworldindata/core-table"
 import {
     DEFAULT_GRAPHER_BOUNDS,
@@ -159,12 +159,12 @@ abstract class AbstractAxis {
         return this._scaleType ?? this.config.scaleType ?? ScaleType.linear
     }
 
-    @computed get isLogScale(): boolean {
-        return this.scaleType === ScaleType.log
-    }
-
     set scaleType(value: ScaleType) {
         this._scaleType = value
+    }
+
+    @computed get isLogScale(): boolean {
+        return this.scaleType === ScaleType.log
     }
 
     @computed get label(): string {
@@ -623,7 +623,10 @@ abstract class AbstractAxis {
         return Math.floor(GRAPHER_FONT_SCALE_12 * this.fontSize)
     }
 
-    @computed get labelTextWrap(): MarkdownTextWrap | undefined {
+    @computed get labelTextWrap():
+        | MarkdownTextWrap
+        | TextWrapGroup
+        | undefined {
         if (!this.label) return
 
         const textWrapProps = {
@@ -639,26 +642,28 @@ abstract class AbstractAxis {
             displayUnit: this.formatColumn?.displayUnit,
         })
 
+        const mainLabelFragment = {
+            text: axisLabel.mainLabel,
+            fontWeight: 700,
+            markdown: true,
+        }
+
         const logScaleNotice = "plotted on a logarithmic axis"
 
         if (axisLabel.unit) {
             const secondaryText = this.isLogScale
                 ? `(${axisLabel.unit}; ${logScaleNotice})`
                 : `(${axisLabel.unit})`
-            return MarkdownTextWrap.fromFragments({
-                main: { text: axisLabel.mainLabel, bold: true },
-                secondary: { text: secondaryText },
-                newLine: "avoid-wrap",
-                textWrapProps,
+            return new TextWrapGroup({
+                fragments: [mainLabelFragment, { text: secondaryText }],
+                ...textWrapProps,
             })
         }
 
         if (this.isLogScale) {
-            return MarkdownTextWrap.fromFragments({
-                main: { text: axisLabel.mainLabel, bold: true },
-                secondary: { text: `(${logScaleNotice})` },
-                newLine: "avoid-wrap",
-                textWrapProps,
+            return new TextWrapGroup({
+                fragments: [mainLabelFragment, { text: `(${logScaleNotice})` }],
+                ...textWrapProps,
             })
         }
 

--- a/packages/@ourworldindata/grapher/src/header/Header.tsx
+++ b/packages/@ourworldindata/grapher/src/header/Header.tsx
@@ -280,7 +280,7 @@ abstract class AbstractHeader<
     }
 
     private renderSubtitle(): React.ReactElement {
-        const style = {
+        const style: React.CSSProperties = {
             ...this.subtitle.style,
             marginTop: this.subtitleMarginTop,
             width: this.useFullWidthForSubtitle ? "100%" : undefined,

--- a/packages/@ourworldindata/utils/src/Bounds.ts
+++ b/packages/@ourworldindata/utils/src/Bounds.ts
@@ -1,6 +1,7 @@
 import * as _ from "lodash-es"
 import { PointVector } from "./PointVector.js"
-import { getPixelWidth, FontFamily } from "./stringWidth.js"
+import { getPixelWidth } from "./stringWidth.js"
+import { FontFamily } from "./fonts.js"
 import {
     Box,
     GridParameters,
@@ -21,8 +22,6 @@ export interface GridBounds {
     cellEdges: Set<Position>
     bounds: Bounds
 }
-
-export { FontFamily }
 
 export class Bounds {
     static fromProps(props: Box): Bounds {

--- a/packages/@ourworldindata/utils/src/fonts.ts
+++ b/packages/@ourworldindata/utils/src/fonts.ts
@@ -1,0 +1,22 @@
+import { match } from "ts-pattern"
+
+export enum FontFamily {
+    Lato = "Lato",
+    PlayfairDisplay = "PlayfairDisplay",
+}
+
+/** Maps a FontFamily enum value to a CSS font stack */
+export function cssFontFamily(fontFamily: FontFamily): string {
+    return match(fontFamily)
+        .with(
+            FontFamily.Lato,
+            () =>
+                "Lato, 'Helvetica Neue', Helvetica, Arial, 'Liberation Sans', sans-serif"
+        )
+        .with(
+            FontFamily.PlayfairDisplay,
+            () =>
+                "'Playfair Display', Georgia, 'Times New Roman', 'Liberation Serif', serif"
+        )
+        .exhaustive()
+}

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -265,9 +265,10 @@ export {
     type PadObject,
     type GridBounds,
     type SplitBoundsPadding,
-    FontFamily,
     Bounds,
 } from "./Bounds.js"
+
+export { FontFamily, cssFontFamily } from "./fonts.js"
 
 export {
     type Persistable,

--- a/packages/@ourworldindata/utils/src/stringWidth.test.ts
+++ b/packages/@ourworldindata/utils/src/stringWidth.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 
-import { getPixelWidth, FontFamily } from "./stringWidth.js"
+import { getPixelWidth } from "./stringWidth.js"
+import { FontFamily } from "./fonts.js"
 
 describe(getPixelWidth, () => {
     it("calculates width for basic ASCII text", () => {

--- a/packages/@ourworldindata/utils/src/stringWidth.ts
+++ b/packages/@ourworldindata/utils/src/stringWidth.ts
@@ -1,3 +1,5 @@
+import { FontFamily } from "./fonts.js"
+
 /**
  * This file contains hardcoded character widths for our two main fonts (Lato and
  * Playfair Display). It can be used to roughly estimate the width of a string in
@@ -11,11 +13,6 @@
 // We have pixel width data for all ASCII characters, plus the following:
 // ₀₁₂₃₄₅₆₇₈₉⁰¹²³⁴⁵⁶⁷⁸⁹
 // ‑–—…‘’“”°→≤≥£ºµ‰
-
-export enum FontFamily {
-    Lato = "Lato",
-    PlayfairDisplay = "PlayfairDisplay",
-}
 
 // Variant indices: 0=regular, 1=bold, 2=italic, 3=bold+italic
 // Pre-flattened maps: widthsMap[font][variant][char] -> width in pixels


### PR DESCRIPTION
## Context

Groundwork for rendering the entity/time suffix of chart titles in a smaller, muted style (see the next PR in the stack). That requires laying out pieces of text with different font styles as one wrapped unit — something we couldn't do well before.

This PR introduces **`TextWrapGroup`**: a text wrap that takes a list of text fragments, each with its own font style (family, size, weight, color), and wraps them together into lines. By default, a fragment is kept intact where possible: it continues on the current line only if it fits there in its entirety, and otherwise moves to a new line as a whole (where it may wrap internally if it's longer than a full line).

It generalizes and replaces `MarkdownTextWrap.fromFragments`, which could only distinguish fragments by boldness. Under the hood it reuses the existing `MarkdownTextWrap` machinery, so markdown, details-on-demand, and HTML/SVG rendering all work per fragment.

## New classes

- **`TextWrapGroup`** — the new public API. Takes a group-level style plus a list of `TextWrapFragment`s (text + optional style overrides + placement: `avoid-wrap` / `continue-line` / `always`, and optional inline/new-line gaps). Each fragment is converted to IR tokens (markdown-parsed or plaintext) and the merged token stream is laid out as one unit.
- **`AbstractTokenTextWrap`** — base class extracted from `MarkdownTextWrap`, now shared by both. Subclasses only supply the IR token stream; the base class implements everything downstream: line-splitting against `maxWidth`, metrics (width/height/line count), and HTML/SVG rendering incl. baseline math. `MarkdownTextWrap` itself is unchanged in behavior — it's the same pipeline, just with the token source made pluggable.
- **`IRFragment`** — a new IR element token that represents one fragment in the merged stream. It carries the fragment's style *delta* relative to the group (rendering no wrapper element at all when a fragment matches the group style, which keeps existing SVG output byte-identical) and knows about the gap preceding it, so line-breaking treats the gap as a break opportunity just like whitespace.
