### PR TITLE
✨🤖 (chart-titles) render entity/time in chart titles as a muted annotation

### DIFF
--- a/adminSiteClient/ChartEditor.ts
+++ b/adminSiteClient/ChartEditor.ts
@@ -175,7 +175,7 @@ export class ChartEditor extends AbstractChartEditor<ChartEditorManager> {
 
         // Chart title and slug may be autocalculated from data, in which case they won't be in props
         // But the server will need to know what we calculated in order to do its job
-        if (!patchConfig.title) patchConfig.title = grapherState.displayTitle
+        if (!patchConfig.title) patchConfig.title = grapherState.effectiveTitle
 
         // Only auto-generate slug when publishing. Drafts can have empty slugs to avoid
         // unnecessary slug collisions.

--- a/adminSiteClient/ChartEditorView.tsx
+++ b/adminSiteClient/ChartEditorView.tsx
@@ -186,7 +186,7 @@ export class ChartEditorView<
     get currentDetailReferences(): DetailReferences {
         const { grapherState } = this.manager.editor
         return {
-            subtitle: extractDetailsFromSyntax(grapherState.currentSubtitle),
+            subtitle: extractDetailsFromSyntax(grapherState.effectiveSubtitle),
             note: extractDetailsFromSyntax(grapherState.note ?? ""),
             axisLabelX: extractDetailsFromSyntax(
                 grapherState.xAxisConfig.label ?? ""

--- a/adminSiteClient/EditorExportTab.tsx
+++ b/adminSiteClient/EditorExportTab.tsx
@@ -32,10 +32,10 @@ type ExportSettings = Required<
 
 type OriginalGrapher = Pick<
     GrapherState,
-    | "currentTitle"
+    | "fullTitle"
     | "shouldAddEntitySuffixToTitle"
     | "shouldAddTimeSuffixToTitle"
-    | "currentSubtitle"
+    | "effectiveSubtitle"
     | "note"
     | "originUrl"
     | "shouldIncludeDetailsInStaticExport"
@@ -155,12 +155,12 @@ export class EditorExportTab<
     // a deep clone of Grapher would be simpler and cleaner, but takes too long
     private grabRelevantPropertiesFromGrapher(): OriginalGrapher {
         return {
-            currentTitle: this.grapherState.currentTitle,
+            fullTitle: this.grapherState.fullTitle,
             shouldAddEntitySuffixToTitle:
                 this.grapherState.shouldAddEntitySuffixToTitle,
             shouldAddTimeSuffixToTitle:
                 this.grapherState.shouldAddTimeSuffixToTitle,
-            currentSubtitle: this.grapherState.currentSubtitle,
+            effectiveSubtitle: this.grapherState.effectiveSubtitle,
             note: this.grapherState.note,
             originUrl: this.grapherState.originUrl,
             shouldIncludeDetailsInStaticExport:
@@ -251,7 +251,7 @@ export class EditorExportTab<
         return (
             <div className="EditorExportTab">
                 <Section name="Displayed elements">
-                    {this.originalGrapher.currentTitle && (
+                    {this.originalGrapher.fullTitle && (
                         <Toggle
                             label="Title"
                             value={!this.settings.hideTitle}
@@ -260,7 +260,7 @@ export class EditorExportTab<
                             })}
                         />
                     )}
-                    {this.originalGrapher.currentTitle &&
+                    {this.originalGrapher.fullTitle &&
                         this.originalGrapher.shouldAddEntitySuffixToTitle && (
                             <Toggle
                                 label="Title suffix: automatic entity"
@@ -276,7 +276,7 @@ export class EditorExportTab<
                                 )}
                             />
                         )}
-                    {this.originalGrapher.currentTitle &&
+                    {this.originalGrapher.fullTitle &&
                         this.originalGrapher.shouldAddTimeSuffixToTitle && (
                             <Toggle
                                 label="Title suffix: automatic time"
@@ -291,7 +291,7 @@ export class EditorExportTab<
                                 )}
                             />
                         )}
-                    {this.originalGrapher.currentSubtitle && (
+                    {this.originalGrapher.effectiveSubtitle && (
                         <Toggle
                             label="Subtitle"
                             value={!this.settings.hideSubtitle}

--- a/adminSiteClient/EditorTextTab.tsx
+++ b/adminSiteClient/EditorTextTab.tsx
@@ -220,7 +220,7 @@ export class EditorTextTab<
                 <Section name="Header">
                     <BindAutoStringExt
                         label="Title"
-                        readFn={(grapherState) => grapherState.displayTitle}
+                        readFn={(grapherState) => grapherState.effectiveTitle}
                         writeFn={(grapherState, newVal) =>
                             (grapherState.title = newVal)
                         }
@@ -283,7 +283,9 @@ export class EditorTextTab<
                     )}
                     <BindAutoStringExt
                         label="Subtitle"
-                        readFn={(grapherState) => grapherState.currentSubtitle}
+                        readFn={(grapherState) =>
+                            grapherState.effectiveSubtitle
+                        }
                         writeFn={(grapherState, newVal) =>
                             (grapherState.subtitle = newVal)
                         }

--- a/adminSiteClient/Forms.tsx
+++ b/adminSiteClient/Forms.tsx
@@ -984,7 +984,7 @@ export class BindAutoString<
     ```tsx
     <BindAutoStringExt
         label={"Subtitle"}
-        readFn={(g) => g.currentSubtitle}
+        readFn={(g) => g.effectiveSubtitle}
         writeFn={(g, newVal) => (g.subtitle = newVal)}
         isAuto={grapher.subtitle === undefined}
         store={grapher}

--- a/adminSiteClient/SaveButtons.tsx
+++ b/adminSiteClient/SaveButtons.tsx
@@ -347,10 +347,10 @@ class SaveButtonsForNarrativeChart extends Component<
                         narrativeChart={{
                             name: editor.manager.name!,
                             configId: editor.manager.configId!,
-                            title: grapherState.currentTitle,
+                            title: grapherState.fullTitle,
                         }}
                         initialValues={{
-                            title: grapherState.currentTitle,
+                            title: grapherState.fullTitle,
                             imageFilename: editor.manager.name
                                 ? `${editor.manager.name}.png`
                                 : undefined,

--- a/adminSiteClient/slideshows/chartRendering/SlideExplorer.tsx
+++ b/adminSiteClient/slideshows/chartRendering/SlideExplorer.tsx
@@ -112,8 +112,8 @@ export function SlideExplorer(props: {
                 (isReady) => {
                     if (!isReady) return
                     onChartReadyRef.current?.({
-                        title: explorer.grapherState.currentTitle,
-                        subtitle: explorer.grapherState.currentSubtitle,
+                        title: explorer.grapherState.fullTitle,
+                        subtitle: explorer.grapherState.effectiveSubtitle,
                     })
                     const config = getSlideshowGrapherConfig({
                         interactiveCharts:

--- a/adminSiteClient/slideshows/chartRendering/SlideGrapher.tsx
+++ b/adminSiteClient/slideshows/chartRendering/SlideGrapher.tsx
@@ -98,8 +98,8 @@ export function SlideGrapher(props: SlideGrapherProps): React.ReactElement {
             () => state.isReady,
             () => {
                 onChartReadyRef.current?.({
-                    title: state.currentTitle,
-                    subtitle: state.currentSubtitle,
+                    title: state.fullTitle,
+                    subtitle: state.effectiveSubtitle,
                 })
 
                 innerDispose = reaction(

--- a/db/model/ExplorerViews.ts
+++ b/db/model/ExplorerViews.ts
@@ -207,7 +207,7 @@ async function iterateExplorerViews(
             // the important properties with the fallback defaults here
             config.title = config.title ?? explorer.grapherState.defaultTitle
             config.subtitle =
-                config.subtitle ?? explorer.grapherState.currentSubtitle
+                config.subtitle ?? explorer.grapherState.effectiveSubtitle
 
             if (!config) {
                 throw new Error(

--- a/functions/_common/downloadFunctions.ts
+++ b/functions/_common/downloadFunctions.ts
@@ -96,7 +96,7 @@ export async function fetchZipForGrapher(
     // Use the slugified display title as filename for multi-dims
     let filename = identifier.id
     if (effectiveIdentifierType === "multi-dim-slug") {
-        filename = slugify(grapher.grapherState.displayTitle)
+        filename = slugify(grapher.grapherState.effectiveTitle)
     }
 
     const zipContent: UncompressedFile[] = [

--- a/functions/_common/explorerHandlers.ts
+++ b/functions/_common/explorerHandlers.ts
@@ -224,7 +224,7 @@ export async function fetchZipForExplorerView(
         const csv = assembleCsv(grapherState, searchParams)
         console.log("Fetched the parts, creating zip file")
 
-        const filename = slugify(grapherState.displayTitle)
+        const filename = slugify(grapherState.effectiveTitle)
 
         const zipContent: UncompressedFile[] = [
             {

--- a/functions/_common/readmeTools.ts
+++ b/functions/_common/readmeTools.ts
@@ -295,9 +295,9 @@ export function constructReadme(
 
     if (isSingleColumn) {
         const toleranceExplanation = `\nThe data file includes an additional column suffixed with (Original Year) or (Original Day). This column appears when we use "tolerance" to display data for time points where exact data is unavailable. For example, if a country does not have data for one or more years, we use tolerance to fill the gaps using the closest available data points. These suffix columns show you which year (or day) the value really came from, allowing you to see when the data was actually measured.`
-        readme = `# ${grapherState.displayTitle} - Data package
+        readme = `# ${grapherState.effectiveTitle} - Data package
 
-This data package contains the data that powers the chart ["${grapherState.displayTitle}"](${urlWithFilters}) on the Our World in Data website. It was downloaded on ${downloadDate}.
+This data package contains the data that powers the chart ["${grapherState.effectiveTitle}"](${urlWithFilters}) on the Our World in Data website. It was downloaded on ${downloadDate}.
 ${[...activeFilterSettings(searchParams, multiDimAvailableDimensions)].join("\n")}
 ## CSV Structure
 
@@ -325,9 +325,9 @@ ${sources.join("\n")}
     `
     } else {
         const toleranceExplanation = `\nThe data file includes additional columns suffixed with (Original Year) or (Original Day). These appear when we use "tolerance" to display data for time points where exact data is unavailable. For example, if a country does not have data for one or more years, we use tolerance to fill the gaps using the closest available data points. These suffix columns show you which year (or day) the value really came from, allowing you to see when the data was actually measured.`
-        readme = `# ${grapherState.displayTitle} - Data package
+        readme = `# ${grapherState.effectiveTitle} - Data package
 
-This data package contains the data that powers the chart ["${grapherState.displayTitle}"](${urlWithFilters}) on the Our World in Data website.
+This data package contains the data that powers the chart ["${grapherState.effectiveTitle}"](${urlWithFilters}) on the Our World in Data website.
 
 ## CSV Structure
 

--- a/packages/@ourworldindata/components/src/MarkdownTextWrap/AbstractTokenTextWrap.tsx
+++ b/packages/@ourworldindata/components/src/MarkdownTextWrap/AbstractTokenTextWrap.tsx
@@ -166,7 +166,7 @@ export abstract class AbstractTokenTextWrap<
     }
 
     @imemo get lineCount(): number {
-        return this.htmlLines.length
+        return this.svgLines.length
     }
 
     getLineHeight(line: IRToken[]): number {

--- a/packages/@ourworldindata/grapher/src/controls/ShareMenu.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/ShareMenu.tsx
@@ -22,7 +22,7 @@ import { GrapherRasterizeFn } from "../captionedChart/StaticChartRasterizer.js"
 
 export interface ShareMenuManager {
     slug?: string
-    currentTitle?: string
+    fullTitle?: string
     canonicalUrl?: string
     editUrl?: string
     createNarrativeChartUrl?: string
@@ -42,13 +42,13 @@ interface ShareMenuState {
     copiedPng: boolean
 }
 
-type ShareApiManager = Pick<ShareMenuManager, "canonicalUrl" | "currentTitle">
+type ShareApiManager = Pick<ShareMenuManager, "canonicalUrl" | "fullTitle">
 
 const getShareData = (manager: ShareApiManager): ShareData | undefined => {
     if (!manager.canonicalUrl) return undefined
 
     return {
-        title: manager.currentTitle ?? "",
+        title: manager.fullTitle ?? "",
         url: manager.canonicalUrl,
     }
 }
@@ -116,7 +116,7 @@ export class ShareMenu extends React.Component<ShareMenuProps, ShareMenuState> {
     }
 
     @computed get title(): string {
-        return this.manager.currentTitle ?? ""
+        return this.manager.fullTitle ?? ""
     }
 
     @computed get showShareMenu(): boolean {

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -686,7 +686,7 @@ export class Grapher extends React.Component<GrapherProps> {
             () => (this.debounceMode ? debouncedPushParams() : pushParams())
         )
 
-        autorun(() => (document.title = this.grapherState.currentTitle))
+        autorun(() => (document.title = this.grapherState.fullTitle))
     }
 
     @action.bound private setUpWindowResizeEventHandler(): void {

--- a/packages/@ourworldindata/grapher/src/core/GrapherState.test.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.test.ts
@@ -14,6 +14,7 @@ import {
     OwidChartDimensionInterface,
     GRAPHER_TAB_QUERY_PARAMS,
     TimeInterval,
+    StackMode,
 } from "@ourworldindata/types"
 import {
     TimeBoundValue,
@@ -387,7 +388,7 @@ it("can serialize scaleType if it changes", () => {
     expect(grapher.changedParams.xScale).toEqual(ScaleType.log)
 })
 
-describe("currentTitle", () => {
+describe("title", () => {
     it("shows the year of the selected data in the title", () => {
         const table = SynthesizeGDPTable(
             { entityCount: 2, timeRange: [2000, 2010] },
@@ -406,21 +407,21 @@ describe("currentTitle", () => {
         })
 
         grapher.timelineHandleTimeBounds = [2001, 2005]
-        expect(grapher.currentTitle).toContain("2001")
-        expect(grapher.currentTitle).toContain("2005")
-        expect(grapher.currentTitle).not.toContain("Infinity")
+        expect(grapher.fullTitle).toContain("2001")
+        expect(grapher.fullTitle).toContain("2005")
+        expect(grapher.fullTitle).not.toContain("Infinity")
 
         grapher.timelineHandleTimeBounds = [1900, 2020]
-        expect(grapher.currentTitle).toContain("2000")
-        expect(grapher.currentTitle).toContain("2009")
+        expect(grapher.fullTitle).toContain("2000")
+        expect(grapher.fullTitle).toContain("2009")
 
         grapher.timelineHandleTimeBounds = [-Infinity, Infinity]
-        expect(grapher.currentTitle).toContain("2000")
-        expect(grapher.currentTitle).toContain("2009")
+        expect(grapher.fullTitle).toContain("2000")
+        expect(grapher.fullTitle).toContain("2009")
 
         grapher.timelineHandleTimeBounds = [Infinity, Infinity]
-        expect(grapher.currentTitle).not.toContain("2000")
-        expect(grapher.currentTitle).toContain("2009")
+        expect(grapher.fullTitle).not.toContain("2000")
+        expect(grapher.fullTitle).toContain("2009")
     })
 
     it("can generate a title when all you have is a table and ySlug", () => {
@@ -433,7 +434,157 @@ describe("currentTitle", () => {
             ySlugs: "GDP",
         })
 
-        expect(grapher.currentTitle).toContain("GDP")
+        expect(grapher.fullTitle).toContain("GDP")
+    })
+
+    it("splits the title into a base and a time annotation", () => {
+        const table = SynthesizeGDPTable(
+            { entityCount: 2, timeRange: [2000, 2010] },
+            1
+        )
+        const grapher = new GrapherState({
+            table,
+            selectedEntityNames: [...table.availableEntityNames],
+            dimensions: [
+                {
+                    slug: SampleColumnSlugs.GDP,
+                    property: DimensionProperty.y,
+                    variableId: 1,
+                },
+            ],
+        })
+        grapher.timelineHandleTimeBounds = [2001, 2005]
+
+        expect(grapher.titleAnnotation).toContain("2001")
+        expect(grapher.titleAnnotation).toContain("2005")
+        expect(grapher.mainTitle).not.toContain("2001")
+        expect(grapher.fullTitle).toEqual(
+            `${grapher.mainTitle}, ${grapher.titleAnnotation}`
+        )
+    })
+
+    it("includes a single selected entity in the annotation", () => {
+        const table = SynthesizeGDPTable(
+            { entityCount: 2, timeRange: [2000, 2010] },
+            1
+        )
+        const entityName = table.availableEntityNames[0]
+        const grapher = new GrapherState({
+            table,
+            selectedEntityNames: [entityName],
+            ySlugs: `${SampleColumnSlugs.GDP} ${SampleColumnSlugs.Population}`,
+        })
+
+        expect(grapher.titleAnnotation).toContain(entityName)
+        expect(grapher.mainTitle).not.toContain(entityName)
+        expect(grapher.fullTitle).toEqual(
+            `${grapher.mainTitle}, ${grapher.titleAnnotation}`
+        )
+    })
+
+    it("combines entity and time in the annotation, entity first", () => {
+        const table = SynthesizeGDPTable(
+            { entityCount: 2, timeRange: [2000, 2010] },
+            1
+        )
+        const entityName = table.availableEntityNames[0]
+        const grapher = new GrapherState({
+            table,
+            selectedEntityNames: [entityName],
+            ySlugs: `${SampleColumnSlugs.GDP} ${SampleColumnSlugs.Population}`,
+        })
+        grapher.timelineHandleTimeBounds = [2001, 2005]
+
+        expect(grapher.titleAnnotation).toEqual(`${entityName}, 2001 to 2005`)
+        expect(grapher.fullTitle).toEqual(
+            `${grapher.mainTitle}, ${entityName}, 2001 to 2005`
+        )
+    })
+
+    it("can hide the entity annotation while keeping the time annotation", () => {
+        const table = SynthesizeGDPTable(
+            { entityCount: 2, timeRange: [2000, 2010] },
+            1
+        )
+        const entityName = table.availableEntityNames[0]
+        const grapher = new GrapherState({
+            table,
+            hideAnnotationFieldsInTitle: { entity: true },
+            addCountryMode: EntitySelectionMode.Disabled,
+            selectedEntityNames: [entityName],
+            ySlugs: `${SampleColumnSlugs.GDP} ${SampleColumnSlugs.Population}`,
+        })
+        grapher.timelineHandleTimeBounds = [2001, 2005]
+
+        expect(grapher.titleAnnotation).not.toContain(entityName)
+        expect(grapher.titleAnnotation).toEqual("2001 to 2005")
+    })
+
+    it("appends the annotation without a comma if the title ends with a question mark", () => {
+        const table = SynthesizeGDPTable(
+            { entityCount: 2, timeRange: [2000, 2010] },
+            1
+        )
+        const grapher = new GrapherState({
+            table,
+            title: "How rich are people?",
+            selectedEntityNames: [...table.availableEntityNames],
+            dimensions: [
+                {
+                    slug: SampleColumnSlugs.GDP,
+                    property: DimensionProperty.y,
+                    variableId: 1,
+                },
+            ],
+        })
+
+        expect(grapher.titleAnnotation).toBeDefined()
+        expect(grapher.fullTitle).toEqual(
+            `How rich are people? ${grapher.titleAnnotation}`
+        )
+    })
+
+    it("keeps the 'Change in' prefix in the title base", () => {
+        const table = SynthesizeGDPTable(
+            { entityCount: 2, timeRange: [2000, 2010] },
+            1
+        )
+        const grapher = new GrapherState({
+            table,
+            stackMode: StackMode.relative,
+            selectedEntityNames: [...table.availableEntityNames],
+            dimensions: [
+                {
+                    slug: SampleColumnSlugs.GDP,
+                    property: DimensionProperty.y,
+                    variableId: 1,
+                },
+            ],
+        })
+
+        expect(grapher.mainTitle).toContain("Change in")
+    })
+
+    it("has no annotation when annotation fields are hidden", () => {
+        const table = SynthesizeGDPTable(
+            { entityCount: 2, timeRange: [2000, 2010] },
+            1
+        )
+        const grapher = new GrapherState({
+            table,
+            hideAnnotationFieldsInTitle: { entity: true, time: true },
+            selectedEntityNames: [...table.availableEntityNames],
+            dimensions: [
+                {
+                    slug: SampleColumnSlugs.GDP,
+                    property: DimensionProperty.y,
+                    variableId: 1,
+                },
+            ],
+        })
+
+        expect(grapher.titleAnnotation).toBeUndefined()
+        expect(grapher.fullTitle).toEqual(grapher.mainTitle)
     })
 })
 

--- a/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
@@ -2261,7 +2261,7 @@ export class GrapherState
     }
 
     @computed get defaultSlug(): string {
-        return slugify(this.displayTitle)
+        return slugify(this.effectiveTitle)
     }
 
     @computed get displaySlug(): string {
@@ -2274,7 +2274,7 @@ export class GrapherState
 
         // Extract details from supporting text
         const subtitleDetails = !this.hideSubtitle
-            ? extractDetailsFromSyntax(this.currentSubtitle)
+            ? extractDetailsFromSyntax(this.effectiveSubtitle)
             : []
         const noteDetails = !this.hideNote
             ? extractDetailsFromSyntax(this.note ?? "")
@@ -2439,7 +2439,8 @@ export class GrapherState
         return this.validChartTypes.length > 1
     }
 
-    @computed get currentSubtitle(): string {
+    /** Effective subtitle resolved from authored subtitle or fallback description */
+    @computed get effectiveSubtitle(): string {
         const subtitle = this.subtitle
         if (subtitle !== undefined) return subtitle
         const yColumns = this.yColumnsFromDimensions
@@ -2511,19 +2512,21 @@ export class GrapherState
         )
     }
 
-    @computed get currentTitle(): string {
-        let text = this.displayTitle.trim()
-        if (text.length === 0) return text
+    /** Effective title resolved from authored title or default title derived from metadata */
+    @computed get effectiveTitle(): string {
+        if (this.title) return this.title
+        if (this.isReady) return this.defaultTitle
+        return ""
+    }
 
-        // Helper function to add an annotation fragment to the title;
-        // only adds a comma if the text does not end with a question mark
-        const appendAnnotationField = (
-            text: string,
-            annotation: string
-        ): string => {
-            const separator = text.endsWith("?") ? "" : ","
-            return `${text}${separator} ${annotation}`
-        }
+    /**
+     * The main line of the chart title, without the entity/time annotation,
+     * but including the "Change in" prefix and the x-indicator label where
+     * applicable.
+     */
+    @computed get mainTitle(): string {
+        let text = this.effectiveTitle.trim()
+        if (text.length === 0) return text
 
         // Add the x-axis label to the title for secondary scatter plots
         if (this.shouldAddXIndicatorLabelToTitle) {
@@ -2534,19 +2537,36 @@ export class GrapherState
             if (xAxisLabel) text += ` vs. ${xAxisLabel}`
         }
 
-        if (this.shouldAddEntitySuffixToTitle) {
-            const selectedEntityNames = this.selection.selectedEntityNames
-            const entityStr = selectedEntityNames[0]
-            if (entityStr?.length) text = appendAnnotationField(text, entityStr)
-        }
-
         if (this.shouldAddChangeInPrefixToTitle)
             text = "Change in " + lowerCaseFirstLetterUnlessAbbreviation(text)
 
-        if (this.shouldAddTimeSuffixToTitle && this.timeTitleSuffix)
-            text = appendAnnotationField(text, this.timeTitleSuffix)
-
         return text.trim()
+    }
+
+    /** The entity/time annotation of the chart title, e.g. "World, 2020" */
+    @computed get titleAnnotation(): string | undefined {
+        if (!this.mainTitle) return undefined
+
+        const parts: string[] = []
+
+        if (this.shouldAddEntitySuffixToTitle) {
+            const entityStr = this.selection.selectedEntityNames[0]
+            if (entityStr?.length) parts.push(entityStr)
+        }
+
+        if (this.shouldAddTimeSuffixToTitle && this.timeTitleSuffix)
+            parts.push(this.timeTitleSuffix)
+
+        return parts.length > 0 ? parts.join(", ") : undefined
+    }
+
+    /** The complete chart title: the main title plus the entity/time annotation */
+    @computed get fullTitle(): string {
+        if (!this.mainTitle || !this.titleAnnotation) return this.mainTitle
+
+        // Only add a comma if the title does not end with a question mark
+        const separator = this.mainTitle.endsWith("?") ? " " : ", "
+        return `${this.mainTitle}${separator}${this.titleAnnotation}`
     }
 
     /**
@@ -2824,12 +2844,6 @@ export class GrapherState
         return yColumns
             .map((col) => col.titlePublicOrDisplayName.title)
             .join(", ")
-    }
-
-    @computed get displayTitle(): string {
-        if (this.title) return this.title
-        if (this.isReady) return this.defaultTitle
-        return ""
     }
 
     @computed get isLineChart(): boolean {

--- a/packages/@ourworldindata/grapher/src/header/Header.scss
+++ b/packages/@ourworldindata/grapher/src/header/Header.scss
@@ -16,6 +16,10 @@
         font-family: $serif-font-stack;
         color: $gray-100;
         margin: 0;
+
+        a .markdown-text-wrap__line {
+            width: fit-content;
+        }
     }
 
     // subtitle

--- a/packages/@ourworldindata/grapher/src/header/Header.test.tsx
+++ b/packages/@ourworldindata/grapher/src/header/Header.test.tsx
@@ -1,0 +1,85 @@
+import { expect, describe, it } from "vitest"
+import { TextWrapGroup } from "@ourworldindata/components"
+import { Header } from "./Header"
+import { HeaderManager } from "./HeaderManager"
+
+const TITLE_ANNOTATION = "United Kingdom, 1990 to 2023"
+
+// A default-sized header starts out with a 25px title and shrinks it by no
+// more than 15% in 0.5px steps, i.e. down to 21.5px, to make the title fit
+const INITIAL_FONT_SIZE = 25
+const SMALLEST_FONT_SIZE = 21.5
+
+function makeTitle(
+    mainTitle: string,
+    maxWidth: number,
+    manager: HeaderManager = {}
+): TextWrapGroup {
+    const header = new Header({
+        maxWidth,
+        manager: {
+            mainTitle,
+            titleAnnotation: TITLE_ANNOTATION,
+            hideLogo: true,
+            ...manager,
+        },
+    })
+    return header.title
+}
+
+describe("title", () => {
+    it("keeps the initial font size if the title fits on a single line", () => {
+        const title = makeTitle("Historical trade openness in Europe", 760)
+        expect(title.fontSize).toEqual(INITIAL_FONT_SIZE)
+        expect(title.lineCount).toEqual(1)
+    })
+
+    it("shrinks the title as little as possible to fit it on a single line", () => {
+        // The title and its annotation need two lines at 24px, but fit on one
+        // at 23.5px
+        const title = makeTitle("Lung cancer death rates", 540)
+        expect(title.fontSize).toEqual(23.5)
+        expect(title.lineCount).toEqual(1)
+    })
+
+    it("keeps the main title on one line and moves the annotation to its own line", () => {
+        // The main title alone doesn't fit on one line until 23px
+        const title = makeTitle("Average height of men by decade of birth", 460)
+        expect(title.fontSize).toEqual(23)
+        expect(title.lineCount).toEqual(2)
+        expect(title.fragmentLineCounts).toEqual([1, 1])
+    })
+
+    it("shrinks the title as little as possible to reduce the number of lines", () => {
+        // The title spans four lines down to 23px, and three from 22.5px
+        const title = makeTitle(
+            "Share of the population with no formal education with projections",
+            380
+        )
+        expect(title.fontSize).toEqual(22.5)
+        expect(title.lineCount).toEqual(3)
+        expect(title.fragmentLineCounts).toEqual([2, 1])
+    })
+
+    it("uses the smallest font size if shrinking doesn't save a line", () => {
+        // This title spans three lines at every font size we're willing to use
+        const title = makeTitle("Historical trade openness in Europe", 300)
+        expect(title.fontSize).toEqual(SMALLEST_FONT_SIZE)
+        expect(title.lineCount).toEqual(3)
+    })
+
+    it("keeps font sizes on 0.5px steps for a custom base font size", () => {
+        // A base font size of 16.67 scales the title up to 26.05px
+        const manager: HeaderManager = {
+            useBaseFontSize: true,
+            fontSize: 16.67,
+        }
+        expect(
+            makeTitle("Historical trade openness in Europe", 760, manager)
+                .fontSize
+        ).toEqual(26)
+        expect(
+            makeTitle("Lung cancer death rates", 540, manager).fontSize
+        ).toEqual(23.5)
+    })
+})

--- a/packages/@ourworldindata/grapher/src/header/Header.tsx
+++ b/packages/@ourworldindata/grapher/src/header/Header.tsx
@@ -116,13 +116,6 @@ abstract class AbstractHeader<
         return this.manager.isSmall ? 1.1 : 1.2
     }
 
-    // The annotation is sized relative to the title. Smaller charts use a
-    // larger scale factor to keep the annotation legible
-    @computed private get titleAnnotationFontScale(): number {
-        if (this.manager.isMedium) return 0.8
-        return 0.72 // per design
-    }
-
     @computed private get initialTitleFontSize(): number {
         return this.manager.isStaticAndSmall
             ? 25
@@ -137,9 +130,7 @@ abstract class AbstractHeader<
 
     @computed private get titleAnnotationFontSize(): number {
         return _.clamp(
-            roundFontSize(
-                this.titleAnnotationFontScale * this.initialTitleFontSize
-            ),
+            roundFontSize(0.72 * this.initialTitleFontSize),
             this.subtitleFontSize, // Never smaller than the subtitle
             18
         )

--- a/packages/@ourworldindata/grapher/src/header/Header.tsx
+++ b/packages/@ourworldindata/grapher/src/header/Header.tsx
@@ -116,6 +116,35 @@ abstract class AbstractHeader<
         return this.manager.isSmall ? 1.1 : 1.2
     }
 
+    // The annotation is sized relative to the title. Smaller charts use a
+    // larger scale factor to keep the annotation legible
+    @computed private get titleAnnotationFontScale(): number {
+        if (this.manager.isMedium) return 0.8
+        return 0.72 // per design
+    }
+
+    @computed private get initialTitleFontSize(): number {
+        return this.manager.isStaticAndSmall
+            ? 25
+            : this.useBaseFontSize
+              ? (25 / BASE_FONT_SIZE) * this.baseFontSize
+              : this.manager.isNarrow
+                ? 18
+                : this.manager.isMedium
+                  ? 20
+                  : 25
+    }
+
+    @computed private get titleAnnotationFontSize(): number {
+        return _.clamp(
+            roundFontSize(
+                this.titleAnnotationFontScale * this.initialTitleFontSize
+            ),
+            this.subtitleFontSize, // Never smaller than the subtitle
+            18
+        )
+    }
+
     @computed get title(): TextWrapGroup {
         const logoPadding = this.manager.isNarrow
             ? 12
@@ -132,11 +161,9 @@ abstract class AbstractHeader<
                 text: this.titleAnnotationText,
                 fontFamily: FontFamily.Lato,
                 fontWeight: 700,
-                fontSize: _.clamp(
-                    roundFontSize(0.75 * fontSize),
-                    this.subtitleFontSize,
-                    18
-                ),
+                // Make sure the annotation is never bigger than the title,
+                // (relevant if the title has been downsized to fit)
+                fontSize: Math.min(this.titleAnnotationFontSize, fontSize),
                 color: GRAPHER_LIGHT_TEXT,
                 inlineGap: Math.min(6, Math.round(0.4 * fontSize)),
                 newLineGap: this.verticalPadding,
@@ -153,25 +180,17 @@ abstract class AbstractHeader<
             })
         }
 
-        const initialFontSize = this.manager.isStaticAndSmall
-            ? 25
-            : this.useBaseFontSize
-              ? (25 / BASE_FONT_SIZE) * this.baseFontSize
-              : this.manager.isNarrow
-                ? 18
-                : this.manager.isMedium
-                  ? 20
-                  : 25
+        const { initialTitleFontSize } = this
 
-        const title = makeTitle(Math.round(initialFontSize))
+        const title = makeTitle(Math.round(initialTitleFontSize))
 
         // If the title is already a single line, no need to decrease font size
         if (title.lineCount <= 1) return title
 
         // Decrease the initial font size by no more than 15% using 0.5px steps
         const potentialFontSizes = _.range(
-            initialFontSize,
-            initialFontSize * 0.85,
+            initialTitleFontSize,
+            initialTitleFontSize * 0.85,
             -0.5
         )
 

--- a/packages/@ourworldindata/grapher/src/header/Header.tsx
+++ b/packages/@ourworldindata/grapher/src/header/Header.tsx
@@ -10,9 +10,8 @@ import {
     MarkdownTextWrap,
     MarkdownTextWrapHtml,
     MarkdownTextWrapSvg,
-    TextWrap,
-    TextWrapSvg,
-    TextWrapHtml,
+    TextWrapGroup,
+    type TextWrapFragment,
 } from "@ourworldindata/components"
 import { computed, makeObservable } from "mobx"
 import { observer } from "mobx-react"
@@ -26,7 +25,12 @@ import {
     GRAPHER_FRAME_PADDING_VERTICAL,
     GRAPHER_HEADER_CLASS,
 } from "../core/GrapherConstants"
-import { GRAPHER_DARK_TEXT, GRAY_100 } from "../color/ColorConstants"
+import {
+    GRAPHER_DARK_TEXT,
+    GRAPHER_LIGHT_TEXT,
+    GRAY_100,
+} from "../color/ColorConstants"
+import { roundFontSize } from "../chart/ChartUtils.js"
 
 interface HeaderProps {
     manager: HeaderManager
@@ -68,11 +72,19 @@ abstract class AbstractHeader<
     }
 
     @computed protected get titleText(): string {
-        return this.manager.currentTitle?.trim() ?? ""
+        return this.manager.mainTitle?.trim() ?? ""
+    }
+
+    @computed protected get titleAnnotationText(): string {
+        return this.manager.titleAnnotation?.trim() ?? ""
+    }
+
+    @computed protected get titleAriaLabel(): string | undefined {
+        return this.manager.fullTitle?.trim() || undefined
     }
 
     @computed private get subtitleText(): string {
-        return this.manager.currentSubtitle?.trim() ?? ""
+        return this.manager.effectiveSubtitle?.trim() ?? ""
     }
 
     @computed get logo(): Logo | undefined {
@@ -104,22 +116,42 @@ abstract class AbstractHeader<
         return this.manager.isSmall ? 1.1 : 1.2
     }
 
-    @computed get title(): TextWrap {
+    @computed get title(): TextWrapGroup {
         const logoPadding = this.manager.isNarrow
             ? 12
             : this.manager.isSmall
               ? 16
               : 24
 
-        const makeTitle = (fontSize: number): TextWrap =>
-            new TextWrap({
+        const makeTitle = (fontSize: number): TextWrapGroup => {
+            const mainFragment: TextWrapFragment = {
                 text: this.titleText,
+            }
+
+            const annotationFragment: TextWrapFragment = {
+                text: this.titleAnnotationText,
+                fontFamily: FontFamily.Lato,
+                fontWeight: 700,
+                fontSize: _.clamp(
+                    roundFontSize(0.75 * fontSize),
+                    this.subtitleFontSize,
+                    18
+                ),
+                color: GRAPHER_LIGHT_TEXT,
+                inlineGap: Math.min(6, Math.round(0.4 * fontSize)),
+                newLineGap: this.verticalPadding,
+                newLine: "avoid-wrap",
+            }
+
+            return new TextWrapGroup({
+                fragments: [mainFragment, annotationFragment],
                 maxWidth: this.maxWidth - this.logoWidth - logoPadding,
                 fontFamily: FontFamily.PlayfairDisplay,
                 fontWeight: this.titleFontWeight,
                 lineHeight: this.titleLineHeight,
                 fontSize,
             })
+        }
 
         const initialFontSize = this.manager.isStaticAndSmall
             ? 25
@@ -131,28 +163,50 @@ abstract class AbstractHeader<
                   ? 20
                   : 25
 
-        let title = makeTitle(Math.round(initialFontSize))
+        const title = makeTitle(Math.round(initialFontSize))
 
-        // if the title is already a single line, no need to decrease font size
-        if (title.lines.length <= 1) return title
+        // If the title is already a single line, no need to decrease font size
+        if (title.lineCount <= 1) return title
 
-        const originalLineCount = title.lines.length
-        // decrease the initial font size by no more than 15% using 0.5px steps
+        // Decrease the initial font size by no more than 15% using 0.5px steps
         const potentialFontSizes = _.range(
             initialFontSize,
             initialFontSize * 0.85,
             -0.5
         )
-        // try to fit the title into a single line if possible-- but not if it would make the text too small
-        for (const fontSize of potentialFontSizes) {
-            title = makeTitle(fontSize)
-            const currentLineCount = title.lines.length
-            if (currentLineCount <= 1 || currentLineCount < originalLineCount)
-                break
-        }
-        // return the title at the new font size: either it now fits into a single line, or
-        // its size has been reduced so the multi-line title doesn't take up quite that much space
-        return title
+
+        const candidates = potentialFontSizes.map(makeTitle)
+
+        // Try to fit the title (including the annotation) into a single
+        // line if possible
+        const fitsFullTitleInOneLine = (candidate: TextWrapGroup): boolean =>
+            candidate.lineCount <= 1
+        const singleLineTitle = candidates.find(fitsFullTitleInOneLine)
+        if (singleLineTitle) return singleLineTitle
+
+        // Try to fit the main title text alone into a single line,
+        // with the annotation on its own line
+        const fitsMainTextInOneLine = (candidate: TextWrapGroup): boolean =>
+            candidate.fragmentLineCounts[0] === 1
+        if (fitsMainTextInOneLine(title)) return title
+        const singleLineMainText = candidates.find(fitsMainTextInOneLine)
+        if (singleLineMainText) return singleLineMainText
+
+        // Otherwise, return the title at a reduced font size: either it now
+        // spans fewer lines, or the multi-line title at least doesn't take
+        // up quite that much space
+        const hasFewerLinesThanTitle = (candidate: TextWrapGroup): boolean =>
+            candidate.lineCount < title.lineCount
+        const candidateWithFewerLines = candidates.find(hasFewerLinesThanTitle)
+        if (candidateWithFewerLines) return candidateWithFewerLines
+
+        // If none of the candidates have fewer lines than the original title,
+        // return the last candidate (the one with the smallest font size)
+        return candidates.at(-1)!
+    }
+
+    @computed private get titleStyle(): React.CSSProperties {
+        return { ...this.title.style, overflowY: "visible" }
     }
 
     @computed get useFullWidthForSubtitle(): boolean {
@@ -235,16 +289,16 @@ abstract class AbstractHeader<
     private renderTitle(): React.ReactElement {
         const { manager } = this
 
-        // avoid linking to a grapher/data page when we're already on it
+        // Avoid linking to a grapher/data page when we're already on it
         if (manager.isOnCanonicalUrl && !this.manager.isInIFrame) {
             return (
-                <h1 style={this.title.htmlStyle}>
-                    <TextWrapHtml textWrap={this.title} />
+                <h1 style={this.titleStyle} aria-label={this.titleAriaLabel}>
+                    <MarkdownTextWrapHtml textWrap={this.title} />
                 </h1>
             )
         }
 
-        // on smaller screens, make the whole width of the header clickable
+        // On smaller screens, make the whole width of the header clickable
         if (manager.isMedium) {
             return (
                 <a
@@ -255,25 +309,29 @@ abstract class AbstractHeader<
                         rel: "noopener",
                     })}
                 >
-                    <h1 style={this.title.htmlStyle}>
-                        <TextWrapHtml textWrap={this.title} />
+                    <h1
+                        style={this.titleStyle}
+                        aria-label={this.titleAriaLabel}
+                    >
+                        <MarkdownTextWrapHtml textWrap={this.title} />
                     </h1>
                 </a>
             )
         }
 
-        // on larger screens, only make the title text itself clickable
+        // On larger screens, only make the title text itself clickable
         return (
-            <h1 style={this.title.htmlStyle}>
+            <h1 style={this.titleStyle}>
                 <a
                     href={manager.canonicalUrl}
                     data-track-note="chart_click_title"
+                    aria-label={this.titleAriaLabel}
                     {...(manager.isInIFrame && {
                         target: "_blank",
                         rel: "noopener",
                     })}
                 >
-                    <TextWrapHtml textWrap={this.title} />
+                    <MarkdownTextWrapHtml textWrap={this.title} />
                 </a>
             </h1>
         )
@@ -373,7 +431,7 @@ export class StaticHeader extends AbstractHeader<StaticHeaderProps> {
                             rel: "noopener",
                         })}
                     >
-                        <TextWrapSvg
+                        <MarkdownTextWrapSvg
                             textWrap={title}
                             x={x}
                             y={y}

--- a/packages/@ourworldindata/grapher/src/header/Header.tsx
+++ b/packages/@ourworldindata/grapher/src/header/Header.tsx
@@ -1,4 +1,5 @@
 import * as _ from "lodash-es"
+import * as R from "remeda"
 import * as React from "react"
 import {
     LogoOption,
@@ -171,35 +172,56 @@ abstract class AbstractHeader<
             })
         }
 
-        const { initialTitleFontSize } = this
+        // Decrease the initial font size by no more than 15% using 0.5px steps
+        const initialFontSize = roundFontSize(this.initialTitleFontSize)
+        const potentialFontSizes = _.range(
+            initialFontSize,
+            initialFontSize * 0.85,
+            -0.5
+        )
 
-        const title = makeTitle(Math.round(initialTitleFontSize))
+        // Laying out a title is expensive, so candidates are only created
+        // when they're actually needed
+        const candidates: (TextWrapGroup | undefined)[] = []
+        const candidateAt = (index: number): TextWrapGroup =>
+            (candidates[index] ??= makeTitle(potentialFontSizes[index]))
+
+        // The first candidate is the title at its initial font size
+        const title = candidateAt(0)
 
         // If the title is already a single line, no need to decrease font size
         if (title.lineCount <= 1) return title
 
-        // Decrease the initial font size by no more than 15% using 0.5px steps
-        const potentialFontSizes = _.range(
-            initialTitleFontSize,
-            initialTitleFontSize * 0.85,
-            -0.5
-        )
-
-        const candidates = potentialFontSizes.map(makeTitle)
+        // Use binary search to find the largest font size that satisfies
+        // the given condition, or undefined if none do
+        const findLargestFontSizeThatFits = (
+            fits: (candidate: TextWrapGroup) => boolean
+        ): TextWrapGroup | undefined => {
+            const index = R.sortedIndexWith(
+                potentialFontSizes,
+                (_fontSize, index) => !fits(candidateAt(index))
+            )
+            // Nothing fits if the check fails for every candidate
+            if (index === potentialFontSizes.length) return undefined
+            return candidateAt(index)
+        }
 
         // Try to fit the title (including the annotation) into a single
         // line if possible
         const fitsFullTitleInOneLine = (candidate: TextWrapGroup): boolean =>
             candidate.lineCount <= 1
-        const singleLineTitle = candidates.find(fitsFullTitleInOneLine)
+        const singleLineTitle = findLargestFontSizeThatFits(
+            fitsFullTitleInOneLine
+        )
         if (singleLineTitle) return singleLineTitle
 
         // Try to fit the main title text alone into a single line,
         // with the annotation on its own line
         const fitsMainTextInOneLine = (candidate: TextWrapGroup): boolean =>
             candidate.fragmentLineCounts[0] === 1
-        if (fitsMainTextInOneLine(title)) return title
-        const singleLineMainText = candidates.find(fitsMainTextInOneLine)
+        const singleLineMainText = findLargestFontSizeThatFits(
+            fitsMainTextInOneLine
+        )
         if (singleLineMainText) return singleLineMainText
 
         // Otherwise, return the title at a reduced font size: either it now
@@ -207,12 +229,14 @@ abstract class AbstractHeader<
         // up quite that much space
         const hasFewerLinesThanTitle = (candidate: TextWrapGroup): boolean =>
             candidate.lineCount < title.lineCount
-        const candidateWithFewerLines = candidates.find(hasFewerLinesThanTitle)
+        const candidateWithFewerLines = findLargestFontSizeThatFits(
+            hasFewerLinesThanTitle
+        )
         if (candidateWithFewerLines) return candidateWithFewerLines
 
         // If none of the candidates have fewer lines than the original title,
-        // return the last candidate (the one with the smallest font size)
-        return candidates.at(-1)!
+        // return the candidate with the smallest font size
+        return candidateAt(potentialFontSizes.length - 1)
     }
 
     @computed private get titleStyle(): React.CSSProperties {

--- a/packages/@ourworldindata/grapher/src/header/HeaderManager.ts
+++ b/packages/@ourworldindata/grapher/src/header/HeaderManager.ts
@@ -2,8 +2,10 @@ import { Bounds } from "@ourworldindata/utils"
 import { DetailsMarker } from "@ourworldindata/types"
 
 export interface HeaderManager {
-    currentTitle?: string
-    currentSubtitle?: string
+    mainTitle?: string
+    titleAnnotation?: string
+    fullTitle?: string
+    effectiveSubtitle?: string
     hideLogo?: boolean
     shouldLinkToOwid?: boolean
     logo?: string

--- a/site/multiDim/MultiDimDataPageContent.tsx
+++ b/site/multiDim/MultiDimDataPageContent.tsx
@@ -359,7 +359,7 @@ export function DataPageContent({
     }, [grapherChangedParams, settings, setSearchParams])
 
     const grapherCurrentTitle = useMobxStateToReactState(
-        useCallback(() => grapherStateRef.current?.currentTitle, []),
+        useCallback(() => grapherStateRef.current?.fullTitle, []),
         !!grapherStateRef.current
     )
 


### PR DESCRIPTION
Grapher often appends an entity/time annotation to chart titles — e.g. 'Life expectancy, World, 2020'. So far this annotation was rendered as part of the title itself. This PR renders the annotation as a visually distinct, de-emphasized part of the title (smaller and gray).

As part of this work, the title is split into these parts:

- `effectiveTitle` — the resolved title, either configured by the author or derived from metadata
- `mainTitle` — the title without the annotation
- `titleAnnotation` — the entity/time part, e.g. "World, 2020"
- `fullTitle` — both combined into one string, used wherever plain text is needed

Since this replaces the old `currentTitle`/`displayTitle`, I thought it also made sense to update names of subtitle-related variables:

- `effectiveSubtitle` — the resolved subtitle, either configured by the author or derived from metadata (used to be `currentSubtitle`)
