### PR TITLE
✨ Improve no-data message layout and rename it

### DIFF
--- a/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/barCharts/DiscreteBarChart.tsx
@@ -19,7 +19,7 @@ import {
     FontSettings,
     GRAPHER_FONT_SCALE_12,
 } from "../core/GrapherConstants"
-import { NoDataModal } from "../noDataModal/NoDataModal"
+import { NoDataMessage } from "../noDataMessage/NoDataMessage"
 import { HorizontalAxisZeroLine } from "../axis/AxisViews"
 import { AxisConfig, AxisManager } from "../axis/AxisConfig"
 import { ChartInterface } from "../chart/ChartInterface"
@@ -558,7 +558,7 @@ export class DiscreteBarChart
     override render(): React.ReactElement {
         if (this.chartState.errorInfo.reason)
             return (
-                <NoDataModal
+                <NoDataMessage
                     manager={this.manager}
                     bounds={this.bounds}
                     message={this.chartState.errorInfo.reason}

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
@@ -37,7 +37,7 @@ import {
 } from "../core/GrapherConstants"
 import * as R from "remeda"
 import { isEntityRegionGroupKey } from "../core/RegionGroups"
-import { NoDataModal } from "../noDataModal/NoDataModal"
+import { NoDataMessage } from "../noDataMessage/NoDataMessage"
 import {
     DataTableColumnKey,
     DisplayDataTableDimension,
@@ -617,14 +617,14 @@ export class DataTable extends React.Component<DataTableProps> {
         ) : null
     }
 
-    private renderNoDataModal(): React.ReactElement {
+    private renderNoDataMessage(): React.ReactElement {
         return (
             <svg
                 width={this.bounds.width}
                 height={this.bounds.height}
                 style={SVG_STYLE_PROPS}
             >
-                <NoDataModal
+                <NoDataMessage
                     manager={this.manager}
                     bounds={this.bounds}
                     message={`No ${this.entityType} matches this query`}
@@ -636,7 +636,8 @@ export class DataTable extends React.Component<DataTableProps> {
     }
 
     override render(): React.ReactElement | null {
-        if (this.sortedDisplayRows.length === 0) return this.renderNoDataModal()
+        if (this.sortedDisplayRows.length === 0)
+            return this.renderNoDataMessage()
 
         return (
             <div className="DataTable">

--- a/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChart.tsx
+++ b/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChart.tsx
@@ -29,7 +29,7 @@ import {
     enrichSeriesWithLabels,
     computeCenteredLabelYPositions,
 } from "../rowSeriesLabels/RowSeriesLabelHelpers.js"
-import { NoDataModal } from "../noDataModal/NoDataModal"
+import { NoDataMessage } from "../noDataMessage/NoDataMessage"
 import {
     HorizontalAxisComponent,
     HorizontalAxisGridLines,
@@ -756,7 +756,7 @@ export class DumbbellChart
     override render(): React.ReactElement {
         if (this.chartState.errorInfo.reason)
             return (
-                <NoDataModal
+                <NoDataMessage
                     manager={this.manager}
                     bounds={this.bounds}
                     message={this.chartState.errorInfo.reason}

--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
@@ -19,7 +19,7 @@ import { VerticalLabels } from "../verticalLabels/VerticalLabels"
 import { VerticalLabelsState } from "../verticalLabels/VerticalLabelsState"
 import { TooltipState } from "../tooltip/Tooltip"
 import { LineChartTooltip } from "./LineChartTooltip"
-import { NoDataModal } from "../noDataModal/NoDataModal"
+import { NoDataMessage } from "../noDataMessage/NoDataMessage"
 import { SeriesName, VerticalAlign, Time } from "@ourworldindata/types"
 import {
     BASE_FONT_SIZE,
@@ -506,15 +506,15 @@ export class LineChart
     }
 
     override render(): React.ReactElement {
-        const { manager, dualAxis } = this
+        const { manager } = this
 
         if (this.chartState.errorInfo.reason)
             return (
                 <g>
                     {this.renderDualAxis()}
-                    <NoDataModal
+                    <NoDataMessage
                         manager={manager}
-                        bounds={dualAxis.innerBounds}
+                        bounds={this.bounds}
                         message={this.chartState.errorInfo.reason}
                     />
                 </g>

--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChartThumbnail.tsx
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChartThumbnail.tsx
@@ -36,7 +36,7 @@ import { InitialAnchoredLabelSeries } from "../anchoredLabels/AnchoredLabelsType
 import { AnchoredLabelsState } from "../anchoredLabels/AnchoredLabelsState"
 import { AnchoredLabels } from "../anchoredLabels/AnchoredLabels"
 import { darkenColorForLine } from "../color/ColorUtils.js"
-import { NoDataModal } from "../noDataModal/NoDataModal"
+import { NoDataMessage } from "../noDataMessage/NoDataMessage"
 
 const DOT_RADIUS = 4
 const SPACE_BETWEEN_DOT_AND_LABEL = 4
@@ -494,9 +494,9 @@ export class LineChartThumbnail
     override render(): React.ReactElement {
         if (this.chartState.errorInfo.reason)
             return (
-                <NoDataModal
+                <NoDataMessage
                     manager={this.manager}
-                    bounds={this.props.bounds}
+                    bounds={this.bounds}
                     message={this.chartState.errorInfo.reason}
                 />
             )

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
@@ -57,7 +57,7 @@ import {
     MapRegionName,
 } from "@ourworldindata/types"
 import { ClipPath, makeClipPath } from "../chart/ChartUtils"
-import { NoDataModal } from "../noDataModal/NoDataModal"
+import { NoDataMessage } from "../noDataMessage/NoDataMessage"
 import { Component, createRef, PointerEvent } from "react"
 import { ChoroplethMap } from "./ChoroplethMap"
 import { ChoroplethGlobe } from "./ChoroplethGlobe"
@@ -675,7 +675,7 @@ export class MapChart
     override render(): React.ReactElement {
         if (this.chartState.errorInfo.reason)
             return (
-                <NoDataModal
+                <NoDataMessage
                     manager={this.manager}
                     bounds={this.props.bounds}
                     message={this.chartState.errorInfo.reason}

--- a/packages/@ourworldindata/grapher/src/noDataMessage/NoDataMessage.tsx
+++ b/packages/@ourworldindata/grapher/src/noDataMessage/NoDataMessage.tsx
@@ -2,17 +2,18 @@ import * as React from "react"
 import { computed, makeObservable } from "mobx"
 import { observer } from "mobx-react"
 import a from "indefinite"
-import { Bounds, VerticalAlign, dyFromAlign } from "@ourworldindata/utils"
+import { Bounds, VerticalAlign } from "@ourworldindata/utils"
 import {
     BASE_FONT_SIZE,
     DEFAULT_GRAPHER_BOUNDS,
     DEFAULT_GRAPHER_ENTITY_TYPE,
     DEFAULT_GRAPHER_ENTITY_TYPE_PLURAL,
+    GRAPHER_FONT_SCALE_14,
 } from "../core/GrapherConstants"
-import { Halo } from "@ourworldindata/components"
+import { Halo, TextWrap, TextWrapSvg } from "@ourworldindata/components"
 import { GRAPHER_DARK_TEXT, GRAPHER_LIGHT_TEXT } from "../color/ColorConstants"
 
-export interface NoDataModalManager {
+export interface NoDataMessageManager {
     canChangeEntity?: boolean
     canAddEntities?: boolean
     entityType?: string
@@ -21,17 +22,17 @@ export interface NoDataModalManager {
     isStatic?: boolean
 }
 
-interface NoDataModalProps {
+interface NoDataMessageProps {
     bounds?: Bounds
     message?: string
     helpText?: string
     hideTextOutline?: boolean
-    manager: NoDataModalManager
+    manager: NoDataMessageManager
 }
 
 @observer
-export class NoDataModal extends React.Component<NoDataModalProps> {
-    constructor(props: NoDataModalProps) {
+export class NoDataMessage extends React.Component<NoDataMessageProps> {
+    constructor(props: NoDataMessageProps) {
         super(props)
         makeObservable(this)
     }
@@ -40,17 +41,17 @@ export class NoDataModal extends React.Component<NoDataModalProps> {
         return this.props.bounds ?? DEFAULT_GRAPHER_BOUNDS
     }
 
-    @computed private get manager(): NoDataModalManager {
+    @computed private get manager(): NoDataMessageManager {
         return this.props.manager
     }
 
     @computed private get fontSize(): number {
-        // font sizes bigger than the base font size are too large for the no data text
-        return Math.min(this.manager.fontSize ?? BASE_FONT_SIZE, BASE_FONT_SIZE)
+        const baseFontSize = this.manager.fontSize ?? BASE_FONT_SIZE
+        return Math.floor(GRAPHER_FONT_SCALE_14 * baseFontSize)
     }
 
     override render(): React.ReactElement {
-        const { bounds } = this
+        const { bounds, fontSize } = this
         const { message } = this.props
         const {
             entityType = DEFAULT_GRAPHER_ENTITY_TYPE,
@@ -68,9 +69,33 @@ export class NoDataModal extends React.Component<NoDataModalProps> {
         const helpText = this.props.helpText ?? defaultHelpText
 
         const center = bounds.centerPos
-        const padding = 0.75 * this.fontSize
         const showHelpText = !isStatic && !!helpText
-        const helpTextFontSize = 0.9 * this.fontSize
+        const helpTextFontSize = Math.floor(0.9 * fontSize)
+
+        const maxWidth = bounds.width - 2 * fontSize
+        const messageWrap = new TextWrap({
+            text: message || "No available data",
+            maxWidth: bounds.width,
+            fontSize,
+            fontWeight: 500,
+            verticalAlign: VerticalAlign.middle,
+        })
+        const helpWrap = showHelpText
+            ? new TextWrap({
+                  text: helpText,
+                  maxWidth,
+                  fontSize: helpTextFontSize,
+                  verticalAlign: VerticalAlign.middle,
+              })
+            : undefined
+
+        // Vertically center the message + help text block as a whole.
+        const gap = helpWrap ? 0.5 * fontSize : 0
+        const totalHeight = messageWrap.height + gap + (helpWrap?.height ?? 0)
+        const top = center.y - totalHeight / 2
+        const messageY = top + messageWrap.height / 2
+        const helpY =
+            top + messageWrap.height + gap + (helpWrap?.height ?? 0) / 2
 
         return (
             <g className="no-data">
@@ -78,42 +103,31 @@ export class NoDataModal extends React.Component<NoDataModalProps> {
 
                 <Halo
                     id="no-data-message"
-                    fontSize={this.fontSize}
+                    fontSize={fontSize}
                     show={!this.props.hideTextOutline}
                 >
-                    <text
+                    <TextWrapSvg
+                        textWrap={messageWrap}
                         x={center.x}
-                        y={center.y}
-                        dy={
-                            showHelpText
-                                ? -padding / 2
-                                : dyFromAlign(VerticalAlign.middle)
-                        }
+                        y={messageY}
                         textAnchor="middle"
-                        fontSize={this.fontSize}
-                        fontWeight={500}
                         fill={GRAPHER_DARK_TEXT}
-                    >
-                        {message || "No available data"}
-                    </text>
+                    />
                 </Halo>
 
-                {showHelpText && (
+                {helpWrap && (
                     <Halo
                         id="no-data-help"
                         fontSize={helpTextFontSize}
                         show={!this.props.hideTextOutline}
                     >
-                        <text
+                        <TextWrapSvg
+                            textWrap={helpWrap}
                             x={center.x}
-                            y={center.y + padding / 2}
+                            y={helpY}
                             textAnchor="middle"
-                            dy={dyFromAlign(VerticalAlign.bottom)}
-                            fontSize={helpTextFontSize}
                             fill={GRAPHER_LIGHT_TEXT}
-                        >
-                            {helpText}
-                        </text>
+                        />
                     </Halo>
                 )}
             </g>

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.test.ts
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.test.ts
@@ -963,7 +963,7 @@ describe("correct bubble sizes", () => {
         const chart = new ScatterPlotChart({ chartState })
 
         const scatterPoints = new ScatterPointsWithLabels({
-            noDataModalManager: manager,
+            noDataMessageManager: manager,
             isConnected: chartState["isConnected"],
             hideConnectedScatterLines: chart["hideConnectedScatterLines"],
             seriesArray: chart["series"],
@@ -1028,7 +1028,7 @@ describe("correct bubble sizes", () => {
         const chart = new ScatterPlotChart({ chartState })
 
         const scatterPoints = new ScatterPointsWithLabels({
-            noDataModalManager: manager,
+            noDataMessageManager: manager,
             isConnected: chartState["isConnected"],
             hideConnectedScatterLines: chart["hideConnectedScatterLines"],
             seriesArray: chart["series"],

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.tsx
@@ -18,7 +18,7 @@ import {
     guid,
 } from "@ourworldindata/utils"
 import { observer } from "mobx-react"
-import { NoDataModal } from "../noDataModal/NoDataModal"
+import { NoDataMessage } from "../noDataMessage/NoDataMessage"
 import {
     BASE_FONT_SIZE,
     DEFAULT_GRAPHER_BOUNDS,
@@ -489,7 +489,7 @@ export class ScatterPlotChart
     @computed private get points(): React.ReactElement {
         return (
             <ScatterPointsWithLabels
-                noDataModalManager={this.manager}
+                noDataMessageManager={this.manager}
                 isConnected={this.chartState.isConnected}
                 hideConnectedScatterLines={this.hideConnectedScatterLines}
                 seriesArray={this.series}
@@ -725,7 +725,7 @@ export class ScatterPlotChart
     override render(): React.ReactElement {
         if (this.chartState.errorInfo.reason)
             return (
-                <NoDataModal
+                <NoDataMessage
                     manager={this.manager}
                     bounds={this.bounds}
                     message={this.chartState.errorInfo.reason}

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChartConstants.ts
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChartConstants.ts
@@ -3,7 +3,7 @@ import { Quadtree } from "d3-quadtree"
 import { OwidTable } from "@ourworldindata/core-table"
 import { DualAxis } from "../axis/Axis"
 import { ChartManager } from "../chart/ChartManager"
-import { NoDataModalManager } from "../noDataModal/NoDataModal"
+import { NoDataMessageManager } from "../noDataMessage/NoDataMessage"
 import { ColorScale } from "../color/ColorScale"
 import {
     ScatterPointLabelStrategy,
@@ -139,7 +139,7 @@ export interface ScatterPointsWithLabelsProps {
     onClick?: () => void
     isConnected: boolean
     hideConnectedScatterLines: boolean
-    noDataModalManager: NoDataModalManager
+    noDataMessageManager: NoDataMessageManager
     hideScatterLabels?: boolean
     hideEntityLabels?: boolean
     quadtree?: Quadtree<ScatterPointQuadtreeNode>

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChartThumbnail.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChartThumbnail.tsx
@@ -17,7 +17,7 @@ import { ScatterPlotManager } from "./ScatterPlotChartConstants"
 import { toSizeRange } from "./ScatterUtils"
 import { DualAxisComponent } from "../axis/AxisViews"
 import { ScatterPointsWithLabels } from "./ScatterPointsWithLabels"
-import { NoDataModal } from "../noDataModal/NoDataModal"
+import { NoDataMessage } from "../noDataMessage/NoDataMessage"
 
 @observer
 export class ScatterPlotChartThumbnail
@@ -94,7 +94,7 @@ export class ScatterPlotChartThumbnail
     override render(): React.ReactElement {
         if (this.chartState.errorInfo.reason)
             return (
-                <NoDataModal
+                <NoDataMessage
                     manager={this.manager}
                     bounds={this.props.bounds}
                     message={this.chartState.errorInfo.reason}
@@ -109,7 +109,7 @@ export class ScatterPlotChartThumbnail
                     showEndpointsOnly={true}
                 />
                 <ScatterPointsWithLabels
-                    noDataModalManager={this.manager}
+                    noDataMessageManager={this.manager}
                     isConnected={this.chartState.isConnected}
                     hideConnectedScatterLines={
                         !!this.manager.hideConnectedScatterLines

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPointsWithLabels.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPointsWithLabels.tsx
@@ -2,7 +2,7 @@ import * as _ from "lodash-es"
 import * as R from "remeda"
 
 import { ScaleLinear } from "d3-scale"
-import { NoDataModal } from "../noDataModal/NoDataModal"
+import { NoDataMessage } from "../noDataMessage/NoDataMessage"
 import { SortOrder } from "@ourworldindata/types"
 import {
     Bounds,
@@ -626,8 +626,8 @@ export class ScatterPointsWithLabels extends React.Component<ScatterPointsWithLa
 
         if (_.isEmpty(renderSeries))
             return (
-                <NoDataModal
-                    manager={this.props.noDataModalManager}
+                <NoDataMessage
+                    manager={this.props.noDataMessageManager}
                     bounds={bounds}
                 />
             )

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
@@ -15,7 +15,7 @@ import {
 } from "@ourworldindata/utils"
 import { observable, computed, action, makeObservable } from "mobx"
 import { observer } from "mobx-react"
-import { NoDataModal } from "../noDataModal/NoDataModal"
+import { NoDataMessage } from "../noDataMessage/NoDataMessage"
 import {
     BASE_FONT_SIZE,
     DEFAULT_GRAPHER_BOUNDS,
@@ -1118,7 +1118,7 @@ export class SlopeChart
     override render() {
         if (this.chartState.errorInfo.reason)
             return (
-                <NoDataModal
+                <NoDataMessage
                     manager={this.manager}
                     bounds={this.props.bounds}
                     message={this.chartState.errorInfo.reason}

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChartThumbnail.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChartThumbnail.tsx
@@ -32,7 +32,7 @@ import { SlopeChartXAxis } from "./SlopeChartXAxis"
 import { InitialAnchoredLabelSeries } from "../anchoredLabels/AnchoredLabelsTypes.js"
 import { AnchoredLabelsState } from "../anchoredLabels/AnchoredLabelsState"
 import { AnchoredLabels } from "../anchoredLabels/AnchoredLabels"
-import { NoDataModal } from "../noDataModal/NoDataModal"
+import { NoDataMessage } from "../noDataMessage/NoDataMessage"
 
 const DOT_RADIUS = 3.5
 const SPACE_BETWEEN_DOT_AND_LABEL = 4
@@ -438,7 +438,7 @@ export class SlopeChartThumbnail
     override render(): React.ReactElement {
         if (this.chartState.errorInfo.reason)
             return (
-                <NoDataModal
+                <NoDataMessage
                     manager={this.manager}
                     bounds={this.props.bounds}
                     message={this.chartState.errorInfo.reason}

--- a/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChart.tsx
@@ -22,7 +22,7 @@ import {
     GRAPHER_FONT_SCALE_12,
 } from "../core/GrapherConstants"
 import { DualAxisComponent } from "../axis/AxisViews"
-import { NoDataModal } from "../noDataModal/NoDataModal"
+import { NoDataMessage } from "../noDataMessage/NoDataMessage"
 import { AxisConfig, AxisManager } from "../axis/AxisConfig"
 import { ChartInterface } from "../chart/ChartInterface"
 import {
@@ -428,7 +428,7 @@ export class MarimekkoChart
     override render(): React.ReactElement {
         if (this.chartState.errorInfo.reason)
             return (
-                <NoDataModal
+                <NoDataMessage
                     manager={this.manager}
                     bounds={this.bounds}
                     message={this.chartState.errorInfo.reason}

--- a/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChartThumbnail.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChartThumbnail.tsx
@@ -18,7 +18,7 @@ import { MarimekkoBars } from "./MarimekkoBars"
 import { DualAxisComponent } from "../axis/AxisViews"
 import { toPlacedMarimekkoItems } from "./MarimekkoChartHelpers"
 import { MarimekkoInternalLabels } from "./MarimekkoInternalLabels"
-import { NoDataModal } from "../noDataModal/NoDataModal"
+import { NoDataMessage } from "../noDataMessage/NoDataMessage"
 
 const LABEL_PADDING = 4
 
@@ -134,7 +134,7 @@ export class MarimekkoChartThumbnail
     override render(): React.ReactElement {
         if (this.chartState.errorInfo.reason)
             return (
-                <NoDataModal
+                <NoDataMessage
                     manager={this.manager}
                     bounds={this.props.bounds}
                     message={this.chartState.errorInfo.reason}

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
@@ -20,7 +20,7 @@ import { DualAxisComponent } from "../axis/AxisViews"
 import { DualAxis, HorizontalAxis, VerticalAxis } from "../axis/Axis"
 import { VerticalLabels } from "../verticalLabels/VerticalLabels"
 import { VerticalLabelsState } from "../verticalLabels/VerticalLabelsState"
-import { NoDataModal } from "../noDataModal/NoDataModal"
+import { NoDataMessage } from "../noDataMessage/NoDataMessage"
 import { TooltipFooterIcon } from "../tooltip/TooltipProps.js"
 import {
     Tooltip,
@@ -628,9 +628,9 @@ export class StackedAreaChart
             return (
                 <g>
                     {this.renderAxis()}
-                    <NoDataModal
+                    <NoDataMessage
                         manager={this.manager}
-                        bounds={this.dualAxis.bounds}
+                        bounds={this.bounds}
                         message={this.chartState.errorInfo.reason}
                     />
                 </g>

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChartThumbnail.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChartThumbnail.tsx
@@ -28,7 +28,7 @@ import { InitialAnchoredLabelSeries } from "../anchoredLabels/AnchoredLabelsType
 import { AnchoredLabelsState } from "../anchoredLabels/AnchoredLabelsState"
 import { AnchoredLabels } from "../anchoredLabels/AnchoredLabels"
 import { resolveCollision, toPlacedStackedAreaSeries } from "./StackedUtils"
-import { NoDataModal } from "../noDataModal/NoDataModal"
+import { NoDataMessage } from "../noDataMessage/NoDataMessage"
 import { resolveEmphasis } from "../interaction/Emphasis.js"
 
 const LEGEND_PADDING = 4
@@ -233,7 +233,7 @@ export class StackedAreaChartThumbnail
     override render(): React.ReactElement {
         if (this.chartState.errorInfo.reason)
             return (
-                <NoDataModal
+                <NoDataMessage
                     manager={this.manager}
                     bounds={this.props.bounds}
                     message={this.chartState.errorInfo.reason}

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChart.tsx
@@ -12,7 +12,7 @@ import {
     exposeInstanceOnWindow,
 } from "@ourworldindata/utils"
 import { DualAxisComponent } from "../axis/AxisViews"
-import { NoDataModal } from "../noDataModal/NoDataModal"
+import { NoDataMessage } from "../noDataMessage/NoDataMessage"
 import {
     VerticalColorLegend,
     VerticalColorLegendManager,
@@ -543,15 +543,15 @@ export class StackedBarChart
     }
 
     override render(): React.ReactElement {
-        const { dualAxis, bounds } = this
+        const { bounds } = this
 
         if (this.chartState.errorInfo.reason)
             return (
                 <g width={bounds.width} height={bounds.height}>
                     {this.renderAxis()}
-                    <NoDataModal
+                    <NoDataMessage
                         manager={this.manager}
-                        bounds={dualAxis.innerBounds}
+                        bounds={bounds}
                         message={this.chartState.errorInfo.reason}
                     />
                 </g>

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChartThumbnail.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChartThumbnail.tsx
@@ -32,7 +32,7 @@ import { StackedBars } from "./StackedBars"
 import { InitialAnchoredLabelSeries } from "../anchoredLabels/AnchoredLabelsTypes.js"
 import { AnchoredLabelsState } from "../anchoredLabels/AnchoredLabelsState"
 import { AnchoredLabels } from "../anchoredLabels/AnchoredLabels"
-import { NoDataModal } from "../noDataModal/NoDataModal"
+import { NoDataMessage } from "../noDataMessage/NoDataMessage"
 import { resolveEmphasis } from "../interaction/Emphasis.js"
 
 const LEGEND_PADDING = 4
@@ -239,7 +239,7 @@ export class StackedBarChartThumbnail
     override render(): React.ReactElement {
         if (this.chartState.errorInfo.reason)
             return (
-                <NoDataModal
+                <NoDataMessage
                     manager={this.manager}
                     bounds={this.props.bounds}
                     message={this.chartState.errorInfo.reason}

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBarChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBarChart.tsx
@@ -29,7 +29,7 @@ import {
     HorizontalAxisZeroLine,
 } from "../axis/AxisViews"
 import { AxisConfig } from "../axis/AxisConfig"
-import { NoDataModal } from "../noDataModal/NoDataModal"
+import { NoDataMessage } from "../noDataMessage/NoDataMessage"
 import { ChartInterface } from "../chart/ChartInterface"
 import { ChartManager } from "../chart/ChartManager"
 import { OwidTable, CoreColumn } from "@ourworldindata/core-table"
@@ -601,7 +601,7 @@ export class StackedDiscreteBarChart
     override render(): React.ReactElement {
         if (this.chartState.errorInfo.reason)
             return (
-                <NoDataModal
+                <NoDataMessage
                     manager={this.manager}
                     bounds={this.bounds}
                     message={this.chartState.errorInfo.reason}


### PR DESCRIPTION
## What

Reworks the grapher no-data/error overlay (formerly `NoDataModal`, now `NoDataMessage`) and makes its bounds handling consistent across all chart types.

- Wrap the message into a compact, centered block instead of letting it stretch across the full width of the container — the old full-width layout looked bad in facets.
- Scale the font size the same way axis ticks are scaled off the base font size, so it shrinks appropriately in small facets.
- Rename `NoDataModal` → `NoDataMessage`: it's an inline SVG overlay, not a modal, and it renders any error/status message, not only "no data".
- Pass the **full chart bounds** consistently across all chart types, so the semi-transparent overlay masks the whole chart and the message is centered within it. Some charts (StackedArea, StackedBar, LineChart thumbnail) previously passed the inner plot area, which meant the overlay and text centering behaved differently per chart type.

## Examples

- http://staging-site-no-data-message/grapher/foreign-aid-given-to-donor-countries-share?tab=stacked-area
- http://staging-site-no-data-message/grapher/5-year-survival-rate-of-cancers-among-female-patients-in-england?tab=line&country=~Uterine+cancer

🤖 Generated with [Claude Code](https://claude.com/claude-code)