### PR TITLE
🎉🤖 Add sidebar-toc-h1-only flag to hide h2s from sidebar TOC

### DIFF
--- a/adminSiteClient/gdocsDeploy.ts
+++ b/adminSiteClient/gdocsDeploy.ts
@@ -78,6 +78,7 @@ export const checkIsLightningUpdate = (
         "cover-image": true,
         "hide-citation": true,
         "sidebar-toc": true,
+        "sidebar-toc-h1-only": true,
         "heading-variant": true,
         "hide-subscribe-banner": true,
         body: true,
@@ -174,6 +175,7 @@ export const checkIsLightningUpdate = (
         body: false,
         refs: false,
         "sidebar-toc": true,
+        "sidebar-toc-h1-only": true,
         toc: true,
         instantiatedEntity: false, // NA, derived field
     }

--- a/db/model/Gdoc/archieToGdoc.ts
+++ b/db/model/Gdoc/archieToGdoc.ts
@@ -30,6 +30,7 @@ function* owidArticleToArchieMLStringGenerator(
         yield "[]"
     }
     yield* propertyToArchieMLString("sidebar-toc", article)
+    yield* propertyToArchieMLString("sidebar-toc-h1-only", article)
     yield* propertyToArchieMLString("heading-variant", article)
     yield* propertyToArchieMLString("hide-subscribe-banner", article)
     // TODO: inline refs

--- a/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
@@ -311,6 +311,7 @@ export interface OwidGdocProfileContent {
     excerpt?: string
     "featured-image"?: string
     "sidebar-toc"?: boolean
+    "sidebar-toc-h1-only"?: boolean
     toc?: TocHeadingWithSupertitle[]
     body: OwidEnrichedGdocBlock[]
     refs?: { definitions: RefDictionary; errors: OwidGdocErrorMessage[] }
@@ -529,6 +530,7 @@ export interface OwidGdocPostContent {
     "atom-title"?: string
     "atom-excerpt"?: string
     "sidebar-toc"?: boolean
+    "sidebar-toc-h1-only"?: boolean
     "heading-variant"?: "heavy" | "light"
     "hide-subscribe-banner"?: boolean
     "cover-color"?:

--- a/site/gdocs/pages/GdocPost.tsx
+++ b/site/gdocs/pages/GdocPost.tsx
@@ -77,6 +77,10 @@ export function GdocPost({
     )
     const citationText = `${shortPageCitation} Published online at OurWorldinData.org. Retrieved from: '${citationUrl}' [Online Resource]${archivalPhrase ? ` ${archivalPhrase}` : ""}`
     const hasSidebarToc = content["sidebar-toc"]
+    const sidebarHeadings =
+        content.toc && content["sidebar-toc-h1-only"]
+            ? content.toc.filter((heading) => !heading.isSubheading)
+            : content.toc
     const headingVariant = content["heading-variant"] ?? "light"
     const shouldHideSubscribeBanner =
         content["hide-subscribe-banner"] || postType === OwidGdocType.TopicPage
@@ -114,9 +118,9 @@ export function GdocPost({
             {isDeprecated && content["deprecation-notice"] && (
                 <DeprecationNotice blocks={content["deprecation-notice"]} />
             )}
-            {hasSidebarToc && content.toc ? (
+            {hasSidebarToc && sidebarHeadings ? (
                 <SidebarTableOfContents
-                    headings={content.toc}
+                    headings={sidebarHeadings}
                     tagName={tags?.[0]?.name}
                 />
             ) : null}

--- a/site/gdocs/pages/Profile.tsx
+++ b/site/gdocs/pages/Profile.tsx
@@ -26,6 +26,10 @@ type ProfileProps = Omit<
 
 export function Profile({ content, publishedAt, slug, tags }: ProfileProps) {
     const hasSidebarToc = content["sidebar-toc"]
+    const sidebarHeadings =
+        content.toc && content["sidebar-toc-h1-only"]
+            ? content.toc.filter((heading) => !heading.isSubheading)
+            : content.toc
     const instantiatedEntity = content.instantiatedEntity
 
     const shortPageCitation = getShortPageCitation(
@@ -91,9 +95,9 @@ export function Profile({ content, publishedAt, slug, tags }: ProfileProps) {
                     </a>
                 </div>
             </header>
-            {hasSidebarToc && content.toc ? (
+            {hasSidebarToc && sidebarHeadings ? (
                 <SidebarTableOfContents
-                    headings={content.toc}
+                    headings={sidebarHeadings}
                     tagName={tags?.[0]?.name}
                 />
             ) : null}


### PR DESCRIPTION
## What

Adds a document-level ArchieML boolean `sidebar-toc-h1-only`. When an author sets it (alongside `sidebar-toc: true`), the sidebar table of contents shows only the h1 section headings — the nested h2 subheadings are dropped. Absent/false keeps today's behavior.

## How

The h2s are filtered out of `content.toc` at the render sites (`GdocPost.tsx`, `Profile.tsx`) before the headings reach `SidebarTableOfContents`. Because that component derives both the rendered sections **and** the scroll-spy's observed ids from the same headings array, the scroll-spy stays consistent: while reading a former h2 region the active row stays on the enclosing h1, and `activeId` can never point at a row that isn't shown. `generateToc` is unchanged, and `LTPTableOfContents` already ignores subheadings.

Also wired through the two exhaustive deploy config maps and the ArchieML serializer so the setting round-trips.

Design doc: `docs/superpowers/specs/2026-07-09-sidebar-toc-h1-only-design.md`

## Testing

Typecheck, lint, and format pass. Manual check: on a topic/profile page with the sidebar enabled, set `sidebar-toc-h1-only: true` and confirm only h1 rows show with no nested h2s; unset and confirm h2s reappear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)