### PR TITLE
🎉🤖 (site) iframe embed mode for bespoke visualizations

### DIFF
--- a/adminSiteClient/GdocsPreviewPage.tsx
+++ b/adminSiteClient/GdocsPreviewPage.tsx
@@ -58,6 +58,7 @@ import {
     BAKED_BASE_URL,
     PUBLISHED_AT_FORMAT,
 } from "../settings/clientSettings.js"
+import { DISABLE_IFRAME_EMBED_PARAM } from "../site/SiteConstants.js"
 import { RouteComponentProps } from "react-router-dom"
 import * as R from "remeda"
 
@@ -116,6 +117,9 @@ export const GdocsPreviewPage = ({ match, history }: GdocsMatchProps) => {
                 ? selectedEntity
                 : undefined,
         acceptSuggestions: acceptSuggestions ? "true" : "false",
+        // The preview frames the article, which would otherwise trigger the
+        // iframe embed mode on embeddable pages and hide everything but the viz
+        [DISABLE_IFRAME_EMBED_PARAM]: "true",
     })
 
     const fetchGdoc = useCallback(

--- a/bespoke/readme.md
+++ b/bespoke/readme.md
@@ -128,16 +128,37 @@ For a good embed, the project should also support `urlSync: true`, which syncs t
 
 ### Embed snippet
 
-Give the iframe a flexible width and a fixed aspect ratio, and point it at the article URL (optionally with state params):
+Give the iframe a flexible width and point it at the article URL (optionally with state params):
 
 ```html
 <iframe
     src="https://ourworldindata.org/where-do-migrants-live?migrationCountry=France"
-    style="width: 100%; aspect-ratio: 16 / 10; border: 0;"
+    style="width: 100%; border: 0;"
+    height="600"
     allow="web-share; clipboard-write"
     loading="lazy"
 ></iframe>
 ```
+
+### Sizing the iframe to fit
+
+An iframe can't size itself to its content, so in iframe mode the embedded page reports the visualization's rendered height to the parent window via `postMessage` (an `owid-bespoke-embed-height` message, sent on load and whenever the height changes). Embedding sites that want the iframe to fit exactly — no scrollbar, no whitespace — add a small listener:
+
+```html
+<script>
+    window.addEventListener("message", (event) => {
+        if (event.origin !== "https://ourworldindata.org") return
+        if (event.data?.type !== "owid-bespoke-embed-height") return
+        for (const iframe of document.querySelectorAll("iframe")) {
+            if (iframe.contentWindow === event.source) {
+                iframe.height = event.data.height
+            }
+        }
+    })
+</script>
+```
+
+Without the listener, the iframe keeps its static `height` (or aspect ratio) and scrolls if the content is taller.
 
 ## Shadow DOM considerations
 

--- a/bespoke/readme.md
+++ b/bespoke/readme.md
@@ -99,6 +99,46 @@ Ideally, your component adapts fluidly to any width given by its container. But 
 There is currently no mechanism for specifying dimensions ahead of time to prevent layout shifts. Components are rendered at whatever size the container provides once they load, and there will be a layout shift.
 We might add a way to specify dimensions for the loading state in the future.
 
+## Embeds on external sites
+
+External sites can embed a bespoke visualization by iframing the article page that hosts it. When such a page is loaded inside an iframe, all site chrome (header, footer, cookie notice) and article content is hidden and only the visualization is shown.
+
+### Opting in
+
+Set `iframeEmbed: true` in the block's `{.config}`:
+
+```yaml
+{.bespoke-component}
+  bundle: causes-of-death
+  variant: treemap
+  {.config}
+    urlSync: true
+    iframeEmbed: true
+  {}
+{}
+```
+
+The flag is consumed entirely by the site layer ([site/gdocs/OwidGdocPage.tsx](../site/gdocs/OwidGdocPage.tsx)) — projects never see it and don't need to parse it.
+
+**One embeddable block per article**: iframe mode only kicks in when an article has _exactly one_ top-level block with `iframeEmbed: true`.
+
+### URL state (`urlSync`)
+
+For a good embed, the project should also support `urlSync: true`, which syncs the viz state (selected country, year, …) to query parameters. That way an embed can pin a specific view via the iframe URL, e.g. `?migrationCountry=France`. Implement it with the shared [`useUrlState`](hooks/useUrlState.ts) hook and prefix the parameter keys with the project name (`causesOfDeathRegion`, `migrationCountry`, …) so multiple projects on the same page can't collide.
+
+### Embed snippet
+
+Give the iframe a flexible width and a fixed aspect ratio, and point it at the article URL (optionally with state params):
+
+```html
+<iframe
+    src="https://ourworldindata.org/where-do-migrants-live?migrationCountry=France"
+    style="width: 100%; aspect-ratio: 16 / 10; border: 0;"
+    allow="web-share; clipboard-write"
+    loading="lazy"
+></iframe>
+```
+
 ## Shadow DOM considerations
 
 Components run inside a Shadow DOM, which provides full CSS encapsulation but comes with trade-offs:

--- a/bespoke/readme.md
+++ b/bespoke/readme.md
@@ -122,6 +122,8 @@ The flag is consumed entirely by the site layer ([site/gdocs/OwidGdocPage.tsx](.
 
 **One embeddable block per article**: iframe mode only kicks in when an article has _exactly one_ top-level block with `iframeEmbed: true`.
 
+Iframe mode can be suppressed with a `?disableIframeEmbed` query param — the admin's article preview (which frames articles too) uses this so editors still see the full article.
+
 ### URL state (`urlSync`)
 
 For a good embed, the project should also support `urlSync: true`, which syncs the viz state (selected country, year, …) to query parameters. That way an embed can pin a specific view via the iframe URL, e.g. `?migrationCountry=France`. Implement it with the shared [`useUrlState`](hooks/useUrlState.ts) hook and prefix the parameter keys with the project name (`causesOfDeathRegion`, `migrationCountry`, …) so multiple projects on the same page can't collide.

--- a/site/IframeDetector.tsx
+++ b/site/IframeDetector.tsx
@@ -1,9 +1,10 @@
 import { GRAPHER_IS_IN_IFRAME_CLASS } from "@ourworldindata/grapher"
+import { DISABLE_IFRAME_EMBED_PARAM } from "./SiteConstants.js"
 
 export const IFrameDetector = () => (
     <script
         dangerouslySetInnerHTML={{
-            __html: `if (window != window.top) document.documentElement.classList.add('${GRAPHER_IS_IN_IFRAME_CLASS}')`,
+            __html: `if (window != window.top && !new URLSearchParams(window.location.search).has('${DISABLE_IFRAME_EMBED_PARAM}')) document.documentElement.classList.add('${GRAPHER_IS_IN_IFRAME_CLASS}')`,
         }}
     />
 )

--- a/site/SiteConstants.ts
+++ b/site/SiteConstants.ts
@@ -31,6 +31,8 @@ export const DATA_INSIGHT_ATOM_FEED_PROPS = {
     href: `https://ourworldindata.org/${DATA_INSIGHTS_ATOM_FEED_NAME}`,
 }
 
+export const DISABLE_IFRAME_EMBED_PARAM = "disableIframeEmbed"
+
 export const DEFAULT_TOMBSTONE_REASON =
     "Our World in Data is designed to be an evergreen publication. This " +
     "means that when a page cannot be updated due to outdated data or " +

--- a/site/gdocs/OwidGdocPage.tsx
+++ b/site/gdocs/OwidGdocPage.tsx
@@ -1,5 +1,6 @@
 import * as _ from "lodash-es"
 import { Head } from "../Head.js"
+import { IFrameDetector } from "../IframeDetector.js"
 import { SiteHeader } from "../SiteHeader.js"
 import { SiteFooter } from "../SiteFooter.js"
 import { CitationMeta } from "../CitationMeta.js"
@@ -22,6 +23,7 @@ import { match, P } from "ts-pattern"
 import {
     ARCHIVED_THUMBNAIL_FILENAME,
     ArchiveContext,
+    OwidEnrichedGdocBlock,
     OwidGdocDataInsightInterface,
     OwidGdocPostInterface,
     OwidGdocProfileInterface,
@@ -123,6 +125,25 @@ function isJsonLdArticlePredicate(
     )
 }
 
+function isIframeEmbeddableBespokeBlock(block: OwidEnrichedGdocBlock): boolean {
+    return (
+        block.type === "bespoke-component" &&
+        block.config.iframeEmbed === "true"
+    )
+}
+
+/**
+ * A page qualifies for bespoke iframe embedding if it has exactly one
+ * top-level bespoke component with `iframeEmbed: true` in its config.
+ * When such a page is loaded inside an iframe, all site chrome and article
+ * content is hidden and only the flagged bespoke component is shown.
+ */
+function checkIsBespokeIframeEmbedPage(gdoc: OwidGdocUnionType): boolean {
+    const body = "body" in gdoc.content ? gdoc.content.body : undefined
+    if (!body) return false
+    return body.filter(isIframeEmbeddableBespokeBlock).length === 1
+}
+
 function getAtomFeedProps(gdoc: OwidGdocUnionType): {
     title: string
     href: string
@@ -170,6 +191,7 @@ export default function OwidGdocPage({
     const isDataInsight = checkIsDataInsight(gdoc)
     const isAuthor = checkIsAuthor(gdoc)
     const isJsonLdArticle = isJsonLdArticlePredicate(gdoc)
+    const isBespokeIframeEmbedPage = checkIsBespokeIframeEmbedPage(gdoc)
 
     let imageUrl
     if (
@@ -231,6 +253,7 @@ export default function OwidGdocPage({
                         imageUrl={imageUrl}
                     />
                 )}
+                {isBespokeIframeEmbedPage && <IFrameDetector />}
                 <script
                     dangerouslySetInnerHTML={{
                         __html: `window._OWID_GDOC_PROPS = ${JSON.stringify(
@@ -239,7 +262,13 @@ export default function OwidGdocPage({
                     }}
                 ></script>
             </Head>
-            <body>
+            <body
+                className={
+                    isBespokeIframeEmbedPage
+                        ? "GdocBespokeIframeEmbedPage"
+                        : undefined
+                }
+            >
                 <SiteHeader
                     isOnHomepage={gdoc.content.type === OwidGdocType.Homepage}
                     archiveInfo={isOnArchivalPage ? archiveContext : undefined}

--- a/site/gdocs/components/BespokeComponent.scss
+++ b/site/gdocs/components/BespokeComponent.scss
@@ -1,5 +1,23 @@
 @use "sass:color";
 
+html.IsInIframe body.GdocBespokeIframeEmbedPage {
+    @include hide-site-chrome;
+
+    // Drop the article grid so the embed spans the full iframe width
+    .centered-article-container {
+        display: block;
+
+        > * {
+            display: none;
+        }
+
+        > [data-bespoke-iframe-embed="true"] {
+            display: block;
+            margin: 0;
+        }
+    }
+}
+
 .bespoke-component__error {
     padding: 16px;
     background-color: color.scale($vermillion, $lightness: +90%);

--- a/site/gdocs/components/BespokeComponent.tsx
+++ b/site/gdocs/components/BespokeComponent.tsx
@@ -47,10 +47,33 @@ export function BespokeComponent({
     className?: string
     block: EnrichedBlockBespokeComponent
 }) {
+    const wrapperRef = useRef<HTMLDivElement>(null)
     const containerRef = useRef<HTMLDivElement>(null)
     const disposeRef = useRef<(() => void) | null>(null)
     const [isLoading, setIsLoading] = useState(true)
     const [error, setError] = useState<string | null>(null)
+
+    // When shown inside an iframe on an external site, report the rendered
+    // height to the parent window so the embedding page can size the iframe
+    // to fit (see "Embeds on external sites" in bespoke/readme.md).
+    useEffect(() => {
+        if (block.config.iframeEmbed !== "true") return
+        if (window === window.parent) return
+        const wrapper = wrapperRef.current
+        if (!wrapper) return
+
+        const observer = new ResizeObserver(() => {
+            window.parent.postMessage(
+                {
+                    type: "owid-bespoke-embed-height",
+                    height: wrapper.offsetHeight,
+                },
+                "*"
+            )
+        })
+        observer.observe(wrapper)
+        return () => observer.disconnect()
+    }, [block.config])
 
     const definition = useMemo(
         () => BESPOKE_COMPONENT_REGISTRY[block.bundle],
@@ -149,6 +172,7 @@ export function BespokeComponent({
 
     return (
         <div
+            ref={wrapperRef}
             className={className}
             data-bespoke-iframe-embed={iframeEmbedAttribute}
         >

--- a/site/gdocs/components/BespokeComponent.tsx
+++ b/site/gdocs/components/BespokeComponent.tsx
@@ -133,28 +133,27 @@ export function BespokeComponent({
         cssUrl,
     ])
 
+    const iframeEmbedAttribute =
+        block.config.iframeEmbed === "true" ? "true" : undefined
+
     if (error) {
-        return <BespokeError className={className} message={error} />
+        return (
+            <div
+                className={cx(className, "bespoke-component__error")}
+                data-bespoke-iframe-embed={iframeEmbedAttribute}
+            >
+                {error}
+            </div>
+        )
     }
 
     return (
-        <div className={className}>
+        <div
+            className={className}
+            data-bespoke-iframe-embed={iframeEmbedAttribute}
+        >
             {isLoading && <LoadingIndicator />}
             <div ref={containerRef}></div>
-        </div>
-    )
-}
-
-function BespokeError({
-    className,
-    message,
-}: {
-    className?: string
-    message: string
-}) {
-    return (
-        <div className={cx(className, "bespoke-component__error")}>
-            {message}
         </div>
     )
 }


### PR DESCRIPTION
Let external sites embed a bespoke visualization by iframing its article page. This isn't advertised yet for any of our existing bespoke components.

Setting `iframeEmbed: true` on a bespoke component enables the behavior:

```yaml
{.bespoke-component}
  bundle: causes-of-death
  variant: treemap
  {.config}
    urlSync: true
    iframeEmbed: true
  {}
{}
```

One limitation of iframes is that they can't automatically resize to fit their content. To work around this, the embedded page reports the visualization's rendered height to the parent window via `postMessage`. It sends an `owid-bespoke-embed-height` message on load and whenever the height changes.

Embedding sites that want the iframe to fit its content need to add a listener like this:

```html
<script>
    window.addEventListener("message", (event) => {
        if (event.origin !== "https://ourworldindata.org") return
        if (event.data?.type !== "owid-bespoke-embed-height") return
        for (const iframe of document.querySelectorAll("iframe")) {
            if (iframe.contentWindow === event.source) {
                iframe.height = event.data.height
            }
        }
    })
</script>
```

Grapher charts don't need this because they set the height to 100vw and then the rest flows from there. However, that's not how bespoke data viz are implemented, and it would be quite a bit of work to rewrite them.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #6732 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #6731
<!-- GitButler Footer Boundary Bottom -->