### PR TITLE
🔨🤖 (time-interval) drop yearIsDay, bump config schema to v011

### DIFF
--- a/adminSiteClient/GrapherConfigGridEditor.tsx
+++ b/adminSiteClient/GrapherConfigGridEditor.tsx
@@ -44,6 +44,7 @@ import {
     Grapher,
     GrapherProgrammaticInterface,
     GrapherState,
+    latestGrapherConfigSchema,
     loadCatalogData,
     MapChartState,
 } from "@ourworldindata/grapher"
@@ -1106,9 +1107,9 @@ export class GrapherConfigGridEditor extends React.Component<GrapherConfigGridEd
     }
 
     async getFieldDefinitions() {
-        const json = await fetch(
-            "https://files.ourworldindata.org/schemas/grapher-schema.010.json"
-        ).then((response) => response.json())
+        const json = await fetch(latestGrapherConfigSchema!).then((response) =>
+            response.json()
+        )
         const fieldDescriptions = extractFieldDescriptionsFromSchema(json)
         runInAction(() => {
             // Now that we have the field Definitions we can initialize everything, including

--- a/adminSiteClient/VariableEditPage.tsx
+++ b/adminSiteClient/VariableEditPage.tsx
@@ -244,14 +244,6 @@ class VariableEditor extends Component<{
                                     value={variable.display?.timeInterval}
                                 />
                                 <ReadOnlyField
-                                    label="Treat year column as day series (deprecated)"
-                                    value={
-                                        variable.display?.yearIsDay
-                                            ? "Yes"
-                                            : "No"
-                                    }
-                                />
-                                <ReadOnlyField
                                     label="Zero Day as YYYY-MM-DD"
                                     value={variable.display?.zeroDay}
                                 />

--- a/adminSiteServer/testPageRouter.tsx
+++ b/adminSiteServer/testPageRouter.tsx
@@ -221,13 +221,9 @@ async function propsFromQueryParams(
             `
             (
                 SELECT COUNT(DISTINCT CASE
-                    WHEN variables.display->>"$.timeInterval" IN ("day", "week", "month", "quarter")
-                        THEN "day"
-                    WHEN variables.display->>"$.timeInterval" IN ("year", "decade")
+                    WHEN COALESCE(variables.display->>"$.timeInterval", "year") IN ("year", "decade")
                         THEN "year"
-                    WHEN variables.display->>"$.yearIsDay" = "true"
-                        THEN "day"
-                    ELSE "year"
+                    ELSE "day"
                 END) as timeTypeCount
                 FROM variables
                 JOIN chart_dimensions ON chart_dimensions.variableId = variables.id

--- a/db/migration/1783933313714-BumpGrapherSchemaToV11.ts
+++ b/db/migration/1783933313714-BumpGrapherSchemaToV11.ts
@@ -1,0 +1,28 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+const V010 = "https://files.ourworldindata.org/schemas/grapher-schema.010.json"
+const V011 = "https://files.ourworldindata.org/schemas/grapher-schema.011.json"
+
+const configColumns = [
+    { table: "chart_configs", column: "patch" },
+    { table: "chart_configs", column: "full" },
+    { table: "chart_revisions", column: "config" },
+]
+
+export class BumpGrapherSchemaToV111783933313714 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        for (const { table, column } of configColumns) {
+            await queryRunner.query(`-- sql
+                UPDATE ${table}
+                SET ${column} = JSON_SET(${column}, '$.$schema', '${V011}')`)
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        for (const { table, column } of configColumns) {
+            await queryRunner.query(`-- sql
+                UPDATE ${table}
+                SET ${column} = JSON_SET(${column}, '$.$schema', '${V010}')`)
+        }
+    }
+}

--- a/docs/chart-api.openapi.yaml
+++ b/docs/chart-api.openapi.yaml
@@ -354,7 +354,7 @@ paths:
       description: |-
         Returns the raw configuration for the grapher chart.
 
-        The config follows the [Grapher JSON schema](https://files.ourworldindata.org/schemas/grapher-schema.010.json).
+        The config follows the [Grapher JSON schema](https://files.ourworldindata.org/schemas/grapher-schema.011.json).
       operationId: getChartConfig
       tags:
         - Metadata
@@ -369,7 +369,7 @@ paths:
               schema:
                 type: object
                 description: |-
-                  Grapher chart configuration object. See the [Grapher JSON schema](https://files.ourworldindata.org/schemas/grapher-schema.010.json) for the full specification.
+                  Grapher chart configuration object. See the [Grapher JSON schema](https://files.ourworldindata.org/schemas/grapher-schema.011.json) for the full specification.
               examples:
                 life-expectancy:
                   summary: Life expectancy config
@@ -379,7 +379,7 @@ paths:
                     id: 64
                     slug: life-expectancy
                     title: Life expectancy
-                    $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json
+                    $schema: https://files.ourworldindata.org/schemas/grapher-schema.011.json
                     version: 62
                     hasMapTab: true
                     originUrl: /life-expectancy

--- a/packages/@ourworldindata/grapher/src/core/GrapherState.test.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.test.ts
@@ -13,6 +13,7 @@ import {
     GRAPHER_TAB_NAMES,
     OwidChartDimensionInterface,
     GRAPHER_TAB_QUERY_PARAMS,
+    TimeInterval,
 } from "@ourworldindata/types"
 import {
     TimeBoundValue,
@@ -297,7 +298,10 @@ const getGrapher = (): GrapherState => {
                 },
                 metadata: {
                     id: 142609,
-                    display: { zeroDay: "2020-01-21", yearIsDay: true },
+                    display: {
+                        zeroDay: "2020-01-21",
+                        timeInterval: TimeInterval.Day,
+                    },
                     dimensions: {
                         entities: {
                             values: [

--- a/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.test.ts
+++ b/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.test.ts
@@ -409,23 +409,6 @@ describe(legacyToOwidTableAndDimensions, () => {
             ).toBeTruthy()
         })
 
-        it("still treats legacy yearIsDay: true as daily", () => {
-            const table = buildTable({ yearIsDay: true })
-            expect(
-                table.get(OwidTableSlugs.Time) instanceof ColumnTypeMap.Day
-            ).toBeTruthy()
-        })
-
-        it("lets timeInterval win over a conflicting yearIsDay flag", () => {
-            const table = buildTable({
-                timeInterval: TimeInterval.Day,
-                yearIsDay: false,
-            })
-            expect(
-                table.get(OwidTableSlugs.Time) instanceof ColumnTypeMap.Day
-            ).toBeTruthy()
-        })
-
         it("routes sub-yearly intervals to the day bucket with their own column type", () => {
             const cases = [
                 [TimeInterval.Week, ColumnTypeMap.Week],

--- a/packages/@ourworldindata/grapher/src/schema/defaultGrapherConfig.ts
+++ b/packages/@ourworldindata/grapher/src/schema/defaultGrapherConfig.ts
@@ -4,7 +4,7 @@
 
 import { GrapherInterface } from "@ourworldindata/types"
 
-export const latestSchemaVersion = "010" as const
+export const latestSchemaVersion = "011" as const
 export const outdatedSchemaVersions = [
     "001",
     "002",
@@ -15,10 +15,11 @@ export const outdatedSchemaVersions = [
     "007",
     "008",
     "009",
+    "010",
 ] as const
 
 export const defaultGrapherConfig = {
-    $schema: "https://files.ourworldindata.org/schemas/grapher-schema.010.json",
+    $schema: "https://files.ourworldindata.org/schemas/grapher-schema.011.json",
     license: "cc-by",
     selectedEntityNames: [],
     focusedSeriesNames: [],

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.011.yaml
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.011.yaml
@@ -1,5 +1,5 @@
 $schema: "http://json-schema.org/draft-07/schema#"
-$id: "https://files.ourworldindata.org/schemas/grapher-schema.010.json"
+$id: "https://files.ourworldindata.org/schemas/grapher-schema.011.json"
 # If you update the required keys, make sure that the mergeGrapherConfigs and
 # diffGrapherConfigs functions both reflect this change
 required:
@@ -14,12 +14,12 @@ properties:
     type: string
     description: Url of the concrete schema version to use to validate this document
     format: uri
-    default: "https://files.ourworldindata.org/schemas/grapher-schema.010.json"
+    default: "https://files.ourworldindata.org/schemas/grapher-schema.011.json"
     # We restrict the $schema field to a single value since we expect all
     # configs in our database to be valid against the latest schema.
     # If we ever need to validate configs against multiple schema versions,
     # we can remove this constraint.
-    const: "https://files.ourworldindata.org/schemas/grapher-schema.010.json"
+    const: "https://files.ourworldindata.org/schemas/grapher-schema.011.json"
   id:
     type: integer
     description: Internal database id
@@ -145,10 +145,6 @@ properties:
                 - quarter
                 - year
                 - decade
-            yearIsDay:
-              type: boolean
-              default: false
-              description: "(Deprecated, use timeInterval instead) Switch to indicate if the number in the year column represents a day (since zeroDay) or not i.e. a year"
             color:
               type: string
               description: Default color for this time series

--- a/packages/@ourworldindata/grapher/src/schema/migrations/migrate.test.ts
+++ b/packages/@ourworldindata/grapher/src/schema/migrations/migrate.test.ts
@@ -2,7 +2,11 @@ import { expect, it, vi } from "vitest"
 
 import { defaultGrapherConfig } from "../defaultGrapherConfig"
 import { migrateGrapherConfigToLatestVersion } from "./migrate"
-import { migrateFrom006To007, migrateFrom007To008 } from "./migrations"
+import {
+    migrateFrom006To007,
+    migrateFrom007To008,
+    migrateFrom010To011,
+} from "./migrations"
 import { AnyConfigWithValidSchema } from "./helpers"
 import * as _ from "lodash-es"
 
@@ -132,4 +136,31 @@ it("migrates version 007 to 008 correctly", () => {
         "map.colorScale.customNumericValues",
         [0, 1, 2, 3]
     )
+})
+
+it("migrates version 010 to 011 correctly", () => {
+    const config: AnyConfigWithValidSchema = {
+        $schema:
+            "https://files.ourworldindata.org/schemas/grapher-schema.010.json",
+        dimensions: [
+            { property: "y", variableId: 1, display: { yearIsDay: true } },
+            { property: "y", variableId: 2, display: { yearIsDay: false } },
+            { property: "y", variableId: 3, display: { unit: "%" } },
+        ],
+    }
+
+    const migrated = migrateFrom010To011(config)
+
+    // check that the $schema field is updated
+    expect(migrated).toHaveProperty(
+        "$schema",
+        "https://files.ourworldindata.org/schemas/grapher-schema.011.json"
+    )
+
+    // yearIsDay: true becomes timeInterval: "day"
+    expect(migrated.dimensions[0].display).toEqual({ timeInterval: "day" })
+    // yearIsDay: false is just dropped (year is the default)
+    expect(migrated.dimensions[1].display).toEqual({})
+    // dimensions without yearIsDay are untouched
+    expect(migrated.dimensions[2].display).toEqual({ unit: "%" })
 })

--- a/packages/@ourworldindata/grapher/src/schema/migrations/migrations.ts
+++ b/packages/@ourworldindata/grapher/src/schema/migrations/migrations.ts
@@ -151,6 +151,24 @@ export const migrateFrom009To010 = (config: AnyConfigWithValidSchema) => {
     return config
 }
 
+export const migrateFrom010To011 = (config: AnyConfigWithValidSchema) => {
+    // Drop the deprecated yearIsDay flag in favor of timeInterval
+    for (const dimension of config.dimensions ?? []) {
+        const display = dimension.display
+        if (!display) continue
+        if (
+            display.yearIsDay === true &&
+            (display.timeInterval === undefined ||
+                display.timeInterval === null)
+        )
+            display.timeInterval = "day"
+        delete display.yearIsDay
+    }
+
+    config.$schema = createSchemaForVersion("011")
+    return config
+}
+
 export const runMigration = (
     config: AnyConfigWithValidSchema
 ): AnyConfigWithValidSchema => {
@@ -166,5 +184,6 @@ export const runMigration = (
         .with("007", () => migrateFrom007To008(config))
         .with("008", () => migrateFrom008To009(config))
         .with("009", () => migrateFrom009To010(config))
+        .with("010", () => migrateFrom010To011(config))
         .exhaustive()
 }

--- a/packages/@ourworldindata/types/src/OwidVariableDisplayConfigInterface.ts
+++ b/packages/@ourworldindata/types/src/OwidVariableDisplayConfigInterface.ts
@@ -16,8 +16,6 @@ export interface OwidVariableDisplayConfigInterface {
     numSignificantFigures?: number
     tolerance?: number
     timeInterval?: TimeInterval
-    /** Deprecated: Use `timeInterval: "day"` instead. */
-    yearIsDay?: boolean
     zeroDay?: string
     entityAnnotationsMap?: string
     includeInTable?: boolean

--- a/packages/@ourworldindata/utils/src/OwidVariable.ts
+++ b/packages/@ourworldindata/utils/src/OwidVariable.ts
@@ -25,7 +25,6 @@ class OwidVariableDisplayConfigDefaults {
     numSignificantFigures: number | undefined = undefined
     tolerance: number | undefined = undefined
     timeInterval: TimeInterval | undefined = undefined
-    yearIsDay: boolean | undefined = undefined
     zeroDay: string | undefined = undefined
     entityAnnotationsMap: string | undefined = undefined
     includeInTable: boolean | undefined = true
@@ -45,7 +44,6 @@ class OwidVariableDisplayConfigDefaults {
             numSignificantFigures: observable,
             tolerance: observable,
             timeInterval: observable,
-            yearIsDay: observable,
             zeroDay: observable,
             entityAnnotationsMap: observable,
             includeInTable: observable,

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -242,16 +242,13 @@ export function formatDay(
 }
 
 /**
- * Resolves the time interval of an indicator from its display config, falling
- * back to the deprecated `yearIsDay` flag when `timeInterval` is not set.
+ * Resolves the time interval of an indicator from its display config,
+ * defaulting to `year` when not set.
  */
 export function getTimeInterval(
     display?: OwidVariableDisplayConfigInterface
 ): TimeInterval {
-    return (
-        display?.timeInterval ??
-        (display?.yearIsDay ? TimeInterval.Day : TimeInterval.Year)
-    )
+    return display?.timeInterval ?? TimeInterval.Year
 }
 
 const SUB_YEARLY_INTERVALS = new Set<TimeInterval>([


### PR DESCRIPTION
After the ETL has been migrated, we can drop `yearIsDay`.

<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 6 in a stack** made with GitButler:
- <kbd>&nbsp;6&nbsp;</kbd> #6752 
- <kbd>&nbsp;5&nbsp;</kbd> #6843 
- <kbd>&nbsp;4&nbsp;</kbd> #6823 
- <kbd>&nbsp;3&nbsp;</kbd> #6733 👈 
- <kbd>&nbsp;2&nbsp;</kbd> #6696 
- <kbd>&nbsp;1&nbsp;</kbd> #6700 
<!-- GitButler Footer Boundary Bottom -->