### PR TITLE
🎉 Internal commenting on charts and data pages

### DIFF
--- a/adminSiteClient/ChartEditorComments.tsx
+++ b/adminSiteClient/ChartEditorComments.tsx
@@ -1,0 +1,36 @@
+import { useState } from "react"
+import { Drawer } from "antd"
+import { CommentTarget } from "@ourworldindata/types"
+import { CommentsPanel } from "../site/comments/CommentsPanel.js"
+import { useCommentThreads } from "../site/comments/useComments.js"
+
+export function ChartEditorCommentsButton({
+    target,
+}: {
+    target: CommentTarget
+}): React.ReactElement {
+    const [isOpen, setIsOpen] = useState(false)
+    const { data } = useCommentThreads(target)
+    return (
+        <>
+            <button
+                type="button"
+                className="btn btn-secondary chart-editor-comments-button"
+                onClick={() => setIsOpen(true)}
+            >
+                Comments
+                {data && data.unresolvedCount > 0
+                    ? ` (${data.unresolvedCount})`
+                    : ""}
+            </button>
+            <Drawer
+                title="Comments"
+                placement="right"
+                open={isOpen}
+                onClose={() => setIsOpen(false)}
+            >
+                <CommentsPanel target={target} />
+            </Drawer>
+        </>
+    )
+}

--- a/adminSiteClient/ChartEditorPage.tsx
+++ b/adminSiteClient/ChartEditorPage.tsx
@@ -4,6 +4,7 @@ import { observable, computed, runInAction, action, makeObservable } from "mobx"
 import { getParentVariableIdFromChartConfig } from "@ourworldindata/utils"
 import {
     type AnalyticsGrapherViewWithRank,
+    CommentTargetType,
     GrapherInterface,
     ChartRedirect,
     MinimalTagWithIsTopic,
@@ -216,6 +217,19 @@ export class ChartEditorPage
     }
 
     override render(): React.ReactElement {
-        return <ChartEditorView manager={this} />
+        const { grapherId } = this.props
+        return (
+            <ChartEditorView
+                manager={this}
+                commentTarget={
+                    grapherId !== undefined
+                        ? {
+                              targetType: CommentTargetType.Chart,
+                              targetId: grapherId,
+                          }
+                        : undefined
+                }
+            />
+        )
     }
 }

--- a/adminSiteClient/ChartEditorView.tsx
+++ b/adminSiteClient/ChartEditorView.tsx
@@ -20,6 +20,7 @@ import {
     getIndexableKeys,
 } from "@ourworldindata/utils"
 import {
+    CommentTarget,
     GrapherInterface,
     DimensionProperty,
     ORIGIN_URL_REGEX_PATTERNS,
@@ -57,6 +58,7 @@ import { EditorMarimekkoTab } from "./EditorMarimekkoTab.js"
 import { EditorExportTab } from "./EditorExportTab.js"
 import { runDetailsOnDemand } from "../site/detailsOnDemand.js"
 import { AbstractChartEditor } from "./AbstractChartEditor.js"
+import { ChartEditorCommentsButton } from "./ChartEditorComments.js"
 import {
     ErrorMessages,
     ErrorMessagesForDimensions,
@@ -114,6 +116,8 @@ export interface ChartEditorViewManager<Editor> {
 
 interface ChartEditorViewProps<Editor> {
     manager: ChartEditorViewManager<Editor>
+    /** When set, an internal comments drawer is available in the editor */
+    commentTarget?: CommentTarget
 }
 
 @observer
@@ -515,6 +519,11 @@ export class ChartEditorView<
                     )}
                 </div>
                 <div className="chart-editor-view">
+                    {this.props.commentTarget && (
+                        <ChartEditorCommentsButton
+                            target={this.props.commentTarget}
+                        />
+                    )}
                     {grapherState.id && (
                         <a
                             className="preview"

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -186,6 +186,12 @@ import {
     updateStaticViz,
     deleteStaticViz,
 } from "./apiRoutes/staticViz.js"
+import {
+    getComments,
+    createComment,
+    setCommentResolvedState,
+    deleteCommentById,
+} from "./apiRoutes/comments.js"
 
 const apiRouter = new FunctionalRouter()
 
@@ -463,6 +469,20 @@ deleteRouteWithRWTransaction(
     apiRouter,
     "/multi-dims/:id/redirects/:redirectId",
     handleDeleteMultiDimRedirect
+)
+
+// Internal comments on charts, variables and multi-dims
+getRouteWithROTransaction(apiRouter, "/comments.json", getComments)
+postRouteWithRWTransaction(apiRouter, "/comments", createComment)
+putRouteWithRWTransaction(
+    apiRouter,
+    "/comments/:commentId/resolved",
+    setCommentResolvedState
+)
+deleteRouteWithRWTransaction(
+    apiRouter,
+    "/comments/:commentId",
+    deleteCommentById
 )
 
 // Explorer routes

--- a/adminSiteServer/apiRoutes/comments.ts
+++ b/adminSiteServer/apiRoutes/comments.ts
@@ -1,0 +1,156 @@
+import {
+    CommentTargetType,
+    JsonError,
+    serializeCommentViewState,
+} from "@ourworldindata/types"
+import * as z from "zod"
+import * as db from "../../db/db.js"
+import {
+    commentTargetExists,
+    deleteComment,
+    getCommentById,
+    getCommentsForTarget,
+    insertComment,
+    setCommentResolved,
+} from "../../db/model/Comment.js"
+import { expectInt } from "../../serverUtils/serverUtil.js"
+import { Request } from "../authentication.js"
+import { HandlerResponse } from "../FunctionalRouter.js"
+
+const targetSchema = z.object({
+    targetType: z.enum(CommentTargetType),
+    targetId: z.coerce.number().int().positive(),
+})
+
+const getCommentsSchema = targetSchema.extend({
+    includeResolved: z
+        .enum(["true", "false"])
+        .optional()
+        .transform((value) => value === "true"),
+})
+
+const createRootCommentSchema = targetSchema.extend({
+    content: z.string().trim().min(1),
+    anchor: z.string().max(255).nullish(),
+    viewState: z.record(z.string(), z.string()).nullish(),
+})
+
+const createReplySchema = z.object({
+    parentId: z.number().int().positive(),
+    content: z.string().trim().min(1),
+})
+
+const setResolvedSchema = z.object({
+    resolved: z.boolean(),
+})
+
+function parseOrThrow<T extends z.ZodType>(
+    schema: T,
+    value: unknown
+): z.infer<T> {
+    const result = schema.safeParse(value)
+    if (!result.success) {
+        throw new JsonError(`Invalid request: ${result.error.message}`, 400)
+    }
+    return result.data
+}
+
+export async function getComments(
+    req: Request,
+    res: HandlerResponse,
+    trx: db.KnexReadonlyTransaction
+) {
+    const { targetType, targetId, includeResolved } = parseOrThrow(
+        getCommentsSchema,
+        req.query
+    )
+    const comments = await getCommentsForTarget(
+        trx,
+        { targetType, targetId },
+        { includeResolved }
+    )
+    return { comments, currentUserId: res.locals.user.id }
+}
+
+export async function createComment(
+    req: Request,
+    res: HandlerResponse,
+    trx: db.KnexReadWriteTransaction
+) {
+    // Replies only carry the parent reference and their content; the target is
+    // inherited from the root comment and anchor/viewState stay on the root.
+    if ("parentId" in req.body) {
+        const { parentId, content } = parseOrThrow(createReplySchema, req.body)
+        const parent = await getCommentById(trx, parentId)
+        if (!parent) throw new JsonError("Parent comment not found", 404)
+        if (parent.parentId !== null) {
+            throw new JsonError(
+                "Comments can only be nested one level deep; reply to the root comment of the thread instead",
+                400
+            )
+        }
+        const id = await insertComment(trx, {
+            targetType: parent.targetType,
+            targetId: parent.targetId,
+            parentId,
+            content,
+            userId: res.locals.user.id,
+        })
+        return { success: true, id }
+    }
+
+    const { targetType, targetId, content, anchor, viewState } = parseOrThrow(
+        createRootCommentSchema,
+        req.body
+    )
+    if (!(await commentTargetExists(trx, { targetType, targetId }))) {
+        throw new JsonError(
+            `No ${targetType} with id ${targetId} exists to comment on`,
+            404
+        )
+    }
+    const id = await insertComment(trx, {
+        targetType,
+        targetId,
+        anchor,
+        viewState: serializeCommentViewState(viewState ?? null),
+        content,
+        userId: res.locals.user.id,
+    })
+    return { success: true, id }
+}
+
+export async function setCommentResolvedState(
+    req: Request,
+    res: HandlerResponse,
+    trx: db.KnexReadWriteTransaction
+) {
+    const id = expectInt(req.params.commentId)
+    const { resolved } = parseOrThrow(setResolvedSchema, req.body)
+    const comment = await getCommentById(trx, id)
+    if (!comment) throw new JsonError("Comment not found", 404)
+    if (comment.parentId !== null) {
+        throw new JsonError(
+            "Only root comments of a thread can be resolved",
+            400
+        )
+    }
+    await setCommentResolved(trx, id, resolved ? res.locals.user.id : null)
+    return { success: true }
+}
+
+export async function deleteCommentById(
+    req: Request,
+    res: HandlerResponse,
+    trx: db.KnexReadWriteTransaction
+) {
+    const id = expectInt(req.params.commentId)
+    const comment = await getCommentById(trx, id)
+    if (!comment) throw new JsonError("Comment not found", 404)
+    const user = res.locals.user
+    if (comment.userId !== user.id && !user.isSuperuser) {
+        throw new JsonError("You can only delete your own comments", 403)
+    }
+    await deleteComment(trx, id)
+    return { success: true }
+}

--- a/adminSiteServer/tests/comments.test.ts
+++ b/adminSiteServer/tests/comments.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, beforeEach } from "vitest"
+import { getAdminTestEnv } from "./testEnv.js"
+import { CommentsTableName, CommentTargetType } from "@ourworldindata/types"
+import { latestGrapherConfigSchema } from "@ourworldindata/grapher"
+
+const env = getAdminTestEnv()
+
+describe("Comments API", { timeout: 15000 }, () => {
+    const testChartConfig = {
+        $schema: latestGrapherConfigSchema,
+        slug: "test-chart",
+        title: "Test chart",
+        chartTypes: ["LineChart"],
+    }
+
+    let chartId: number
+
+    beforeEach(async () => {
+        const response = await env.request({
+            method: "POST",
+            path: "/charts",
+            body: JSON.stringify(testChartConfig),
+        })
+        chartId = response.chartId
+    })
+
+    async function requestExpectingError(arg: {
+        method: "POST" | "PUT" | "DELETE"
+        path: string
+        body?: string
+        expectedStatus: number
+    }): Promise<void> {
+        const response = await fetch(env.baseUrl + arg.path, {
+            method: arg.method,
+            headers: {
+                "Content-Type": "application/json",
+                Authorization: `Bearer ${env.apiKey}`,
+            },
+            body: arg.body,
+        })
+        expect(response.status).toBe(arg.expectedStatus)
+    }
+
+    function createComment(body: Record<string, unknown>): Promise<any> {
+        return env.request({
+            method: "POST",
+            path: "/comments",
+            body: JSON.stringify(body),
+        })
+    }
+
+    function listComments(query = ""): Promise<any> {
+        return env.fetchJson(
+            `/comments.json?targetType=chart&targetId=${chartId}${query}`
+        )
+    }
+
+    it("creates and lists comments with author information", async () => {
+        const { id } = await createComment({
+            targetType: CommentTargetType.Chart,
+            targetId: chartId,
+            content: "The subtitle has a typo",
+            anchor: "subtitle",
+        })
+        expect(typeof id).toBe("number")
+
+        const { comments, currentUserId } = await listComments()
+        expect(comments).toHaveLength(1)
+        expect(comments[0]).toMatchObject({
+            id,
+            targetType: CommentTargetType.Chart,
+            targetId: chartId,
+            anchor: "subtitle",
+            viewState: null,
+            parentId: null,
+            content: "The subtitle has a typo",
+            authorFullName: "Admin",
+            resolvedAt: null,
+        })
+        expect(comments[0].userId).toBe(currentUserId)
+    })
+
+    it("rejects comments on targets that don't exist", async () => {
+        await requestExpectingError({
+            method: "POST",
+            path: "/comments",
+            body: JSON.stringify({
+                targetType: CommentTargetType.Chart,
+                targetId: 9999,
+                content: "Comment on a missing chart",
+            }),
+            expectedStatus: 404,
+        })
+        await requestExpectingError({
+            method: "POST",
+            path: "/comments",
+            body: JSON.stringify({
+                targetType: CommentTargetType.Variable,
+                targetId: chartId,
+                content: "Chart ids are not variable ids",
+            }),
+            expectedStatus: 404,
+        })
+    })
+
+    it("stores the multi-dim view state of a comment", async () => {
+        const viewState = { metric: "cases", frequency: "weekly" }
+        await createComment({
+            targetType: CommentTargetType.Chart,
+            targetId: chartId,
+            content: "This view looks off",
+            viewState,
+        })
+        const { comments } = await listComments()
+        expect(comments[0].viewState).toEqual(viewState)
+    })
+
+    it("supports one level of threaded replies", async () => {
+        const { id: rootId } = await createComment({
+            targetType: CommentTargetType.Chart,
+            targetId: chartId,
+            content: "Root comment",
+        })
+        const { id: replyId } = await createComment({
+            parentId: rootId,
+            content: "A reply",
+        })
+
+        const { comments } = await listComments()
+        expect(comments).toHaveLength(2)
+        const reply = comments.find((c: any) => c.id === replyId)
+        // The reply inherits the target from the root comment
+        expect(reply).toMatchObject({
+            parentId: rootId,
+            targetType: CommentTargetType.Chart,
+            targetId: chartId,
+            content: "A reply",
+        })
+
+        // Replying to a reply is not allowed
+        await requestExpectingError({
+            method: "POST",
+            path: "/comments",
+            body: JSON.stringify({
+                parentId: replyId,
+                content: "A nested reply",
+            }),
+            expectedStatus: 400,
+        })
+    })
+
+    it("resolves and reopens threads", async () => {
+        const { id: rootId } = await createComment({
+            targetType: CommentTargetType.Chart,
+            targetId: chartId,
+            content: "Root comment",
+        })
+        const { id: replyId } = await createComment({
+            parentId: rootId,
+            content: "A reply",
+        })
+
+        await env.request({
+            method: "PUT",
+            path: `/comments/${rootId}/resolved`,
+            body: JSON.stringify({ resolved: true }),
+        })
+
+        // Resolved threads (including their replies) are hidden by default...
+        const { comments: unresolvedOnly } = await listComments()
+        expect(unresolvedOnly).toHaveLength(0)
+
+        // ...but included on request, with resolution metadata
+        const { comments: all } = await listComments("&includeResolved=true")
+        expect(all).toHaveLength(2)
+        const root = all.find((c: any) => c.id === rootId)
+        expect(root.resolvedAt).not.toBeNull()
+        expect(root.resolvedByFullName).toBe("Admin")
+
+        await env.request({
+            method: "PUT",
+            path: `/comments/${rootId}/resolved`,
+            body: JSON.stringify({ resolved: false }),
+        })
+        const { comments: reopened } = await listComments()
+        expect(reopened).toHaveLength(2)
+
+        // Replies themselves cannot be resolved
+        await requestExpectingError({
+            method: "PUT",
+            path: `/comments/${replyId}/resolved`,
+            body: JSON.stringify({ resolved: true }),
+            expectedStatus: 400,
+        })
+    })
+
+    it("deletes a thread along with its replies", async () => {
+        const { id: rootId } = await createComment({
+            targetType: CommentTargetType.Chart,
+            targetId: chartId,
+            content: "Root comment",
+        })
+        await createComment({ parentId: rootId, content: "A reply" })
+        expect(await env.getCount(CommentsTableName)).toBe(2)
+
+        await env.request({
+            method: "DELETE",
+            path: `/comments/${rootId}`,
+        })
+        expect(await env.getCount(CommentsTableName)).toBe(0)
+    })
+})

--- a/db/docs/comments.yml
+++ b/db/docs/comments.yml
@@ -1,0 +1,36 @@
+metadata:
+  description: |
+    Internal comments that OWID staff attach to content in the admin, used to flag
+    and discuss data/metadata issues in context (e.g. a typo on a data page, a data
+    issue on an indicator, a broken multi-dim view). Comments target a chart, a
+    variable (data page) or a multi-dim data page, can optionally be anchored to a
+    specific metadata field and/or multi-dim view, support one level of threading
+    (replies), and have a resolve workflow similar to review comments on GitHub.
+  incoming_foreign_keys:
+    - table: comments
+      column: parentId
+fields:
+  id:
+    description: Unique identifier for the comment
+  targetType:
+    description: Type of entity the comment is attached to - 'chart', 'variable' or 'multiDim'
+  targetId:
+    description: ID of the target entity. References charts.id, variables.id or multi_dim_data_pages.id depending on targetType. No database foreign key is possible on a polymorphic column, so existence is validated by the admin API.
+  anchor:
+    description: Optional identifier of the part of the target the comment is anchored to, e.g. a data page metadata field like 'descriptionShort' or 'source'. NULL for comments on the target as a whole.
+  viewState:
+    description: 'For multi-dim targets, JSON object with the dimension choices identifying the view the comment was made on, e.g. {"metric": "cases"}. NULL otherwise.'
+  parentId:
+    description: For replies, the id of the root comment of the thread. NULL for root comments. Deleting a root comment cascades to its replies.
+  content:
+    description: The comment text
+  userId:
+    description: ID of the user who wrote the comment
+  resolvedAt:
+    description: Timestamp when the thread was resolved. Only set on root comments. NULL while unresolved.
+  resolvedByUserId:
+    description: ID of the user who resolved the thread. NULL while unresolved.
+  createdAt:
+    description: Timestamp when the comment was created
+  updatedAt:
+    description: Timestamp when the comment was last updated

--- a/db/docs/users.yml
+++ b/db/docs/users.yml
@@ -3,6 +3,10 @@ metadata:
   incoming_foreign_keys:
     - table: chart_revisions
       column: userId
+    - table: comments
+      column: userId
+    - table: comments
+      column: resolvedByUserId
     - table: charts
       column: lastEditedByUserId
     - table: charts

--- a/db/migration/1783608535493-CreateCommentsTable.ts
+++ b/db/migration/1783608535493-CreateCommentsTable.ts
@@ -1,0 +1,49 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class CreateCommentsTable1783608535493 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`-- sql
+            CREATE TABLE comments (
+                id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+
+                -- What the comment is attached to. targetId references charts.id,
+                -- variables.id or multi_dim_data_pages.id depending on targetType
+                -- (validated in the API, no FK possible on a polymorphic column).
+                targetType ENUM('chart', 'variable', 'multiDim') NOT NULL,
+                targetId INT NOT NULL,
+
+                -- Optional finer-grained anchor within the target, e.g. a metadata
+                -- field on a data page ("descriptionShort") and, for multi-dims,
+                -- the dimension choices of the view being commented on.
+                anchor VARCHAR(255) DEFAULT NULL,
+                viewState JSON DEFAULT NULL,
+
+                -- Replies set parentId to the root comment of their thread.
+                -- Resolution state lives on the root comment only.
+                parentId INT DEFAULT NULL,
+                content TEXT NOT NULL,
+
+                userId INT NOT NULL,
+                resolvedAt TIMESTAMP NULL DEFAULT NULL,
+                resolvedByUserId INT DEFAULT NULL,
+                createdAt TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updatedAt TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+                INDEX idx_comments_target (targetType, targetId),
+
+                CONSTRAINT fk_comments_parent FOREIGN KEY (parentId)
+                    REFERENCES comments (id) ON DELETE CASCADE,
+                CONSTRAINT fk_comments_user FOREIGN KEY (userId)
+                    REFERENCES users (id),
+                CONSTRAINT fk_comments_resolved_by_user FOREIGN KEY (resolvedByUserId)
+                    REFERENCES users (id) ON DELETE SET NULL
+            )
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`-- sql
+            DROP TABLE comments
+        `)
+    }
+}

--- a/db/model/Comment.ts
+++ b/db/model/Comment.ts
@@ -1,0 +1,134 @@
+import {
+    CommentTarget,
+    CommentTargetType,
+    CommentWithAuthor,
+    DbInsertComment,
+    DbRawComment,
+    JsonString,
+    parseCommentRow,
+} from "@ourworldindata/types"
+import * as db from "../db.js"
+
+const TABLE_BY_TARGET_TYPE: Record<CommentTargetType, string> = {
+    [CommentTargetType.Chart]: "charts",
+    [CommentTargetType.Variable]: "variables",
+    [CommentTargetType.MultiDim]: "multi_dim_data_pages",
+}
+
+export async function commentTargetExists(
+    knex: db.KnexReadonlyTransaction,
+    target: CommentTarget
+): Promise<boolean> {
+    const result = await db.knexRawFirst(
+        knex,
+        `SELECT 1 FROM ?? WHERE id = ?`,
+        [TABLE_BY_TARGET_TYPE[target.targetType], target.targetId]
+    )
+    return Boolean(result)
+}
+
+export async function getCommentsForTarget(
+    knex: db.KnexReadonlyTransaction,
+    target: CommentTarget,
+    { includeResolved = false }: { includeResolved?: boolean } = {}
+): Promise<CommentWithAuthor[]> {
+    // Replies never carry resolution state themselves, so when filtering out
+    // resolved threads we look at the root comment's resolvedAt for them.
+    const resolvedFilter = includeResolved
+        ? ""
+        : "AND COALESCE(root.resolvedAt, c.resolvedAt) IS NULL"
+    const rows = await db.knexRaw<
+        DbRawComment & {
+            authorFullName: string
+            resolvedByFullName: string | null
+        }
+    >(
+        knex,
+        `-- sql
+        SELECT
+            c.*,
+            author.fullName AS authorFullName,
+            resolver.fullName AS resolvedByFullName
+        FROM comments c
+        JOIN users author ON author.id = c.userId
+        LEFT JOIN users resolver ON resolver.id = c.resolvedByUserId
+        LEFT JOIN comments root ON root.id = c.parentId
+        WHERE c.targetType = ? AND c.targetId = ?
+        ${resolvedFilter}
+        ORDER BY c.createdAt ASC, c.id ASC`,
+        [target.targetType, target.targetId]
+    )
+    return rows.map((row) => ({
+        ...parseCommentRow(row),
+        authorFullName: row.authorFullName,
+        resolvedByFullName: row.resolvedByFullName,
+    }))
+}
+
+export async function getCommentById(
+    knex: db.KnexReadonlyTransaction,
+    id: number
+): Promise<DbRawComment | undefined> {
+    return await db.knexRawFirst<DbRawComment>(
+        knex,
+        `SELECT * FROM comments WHERE id = ?`,
+        [id]
+    )
+}
+
+export async function insertComment(
+    knex: db.KnexReadWriteTransaction,
+    comment: Pick<
+        DbInsertComment,
+        "targetType" | "targetId" | "content" | "userId"
+    > & {
+        anchor?: string | null
+        viewState?: JsonString | null
+        parentId?: number | null
+    }
+): Promise<number> {
+    const result = await db.knexRawInsert(
+        knex,
+        `-- sql
+        INSERT INTO comments
+            (targetType, targetId, anchor, viewState, parentId, content, userId)
+        VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        [
+            comment.targetType,
+            comment.targetId,
+            comment.anchor ?? null,
+            comment.viewState ?? null,
+            comment.parentId ?? null,
+            comment.content,
+            comment.userId,
+        ]
+    )
+    return result.insertId
+}
+
+export async function setCommentResolved(
+    knex: db.KnexReadWriteTransaction,
+    id: number,
+    resolvedByUserId: number | null
+): Promise<void> {
+    if (resolvedByUserId === null) {
+        await db.knexRaw(
+            knex,
+            `UPDATE comments SET resolvedAt = NULL, resolvedByUserId = NULL WHERE id = ?`,
+            [id]
+        )
+    } else {
+        await db.knexRaw(
+            knex,
+            `UPDATE comments SET resolvedAt = NOW(), resolvedByUserId = ? WHERE id = ?`,
+            [resolvedByUserId, id]
+        )
+    }
+}
+
+export async function deleteComment(
+    knex: db.KnexReadWriteTransaction,
+    id: number
+): Promise<void> {
+    await db.knexRaw(knex, `DELETE FROM comments WHERE id = ?`, [id])
+}

--- a/db/tests/testHelpers.ts
+++ b/db/tests/testHelpers.ts
@@ -4,6 +4,7 @@ import {
     ChartRevisionsTableName,
     ChartSlugRedirectsTableName,
     ChartsTableName,
+    CommentsTableName,
     DatasetsTableName,
     AdminApiKeysTableName,
     ExplorerChartsTableName,
@@ -23,6 +24,7 @@ import type { Knex } from "knex"
 
 // the order is important here since we drop rows from the tables in this order
 export const TABLES_IN_USE = [
+    CommentsTableName, // Must come before ChartsTableName and UsersTableName due to foreign keys
     ChartDimensionsTableName,
     ChartRevisionsTableName,
     ChartSlugRedirectsTableName, // Must come before ChartsTableName due to foreign key

--- a/packages/@ourworldindata/types/src/dbTypes/Comments.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/Comments.ts
@@ -1,0 +1,68 @@
+import { JsonString } from "../domainTypes/Various.js"
+
+export const CommentsTableName = "comments"
+
+export enum CommentTargetType {
+    Chart = "chart",
+    Variable = "variable",
+    MultiDim = "multiDim",
+}
+
+/** Identifies the entity a comment (thread) is attached to */
+export interface CommentTarget {
+    targetType: CommentTargetType
+    targetId: number
+}
+
+/**
+ * Dimension choices identifying the multi-dim view a comment was made on,
+ * e.g. { metric: "cases", frequency: "weekly" }
+ */
+export type CommentViewState = Record<string, string>
+
+export interface DbInsertComment {
+    id?: number
+    targetType: CommentTargetType
+    targetId: number
+    anchor?: string | null
+    viewState?: JsonString | null
+    parentId?: number | null
+    content: string
+    userId: number
+    resolvedAt?: Date | null
+    resolvedByUserId?: number | null
+    createdAt?: Date
+    updatedAt?: Date
+}
+
+export type DbRawComment = Required<DbInsertComment>
+
+export type DbEnrichedComment = Omit<DbRawComment, "viewState"> & {
+    viewState: CommentViewState | null
+}
+
+export function parseCommentViewState(
+    viewState: JsonString | null
+): CommentViewState | null {
+    return viewState ? JSON.parse(viewState) : null
+}
+
+export function serializeCommentViewState(
+    viewState: CommentViewState | null
+): JsonString | null {
+    return viewState ? JSON.stringify(viewState) : null
+}
+
+export function parseCommentRow(row: DbRawComment): DbEnrichedComment {
+    return { ...row, viewState: parseCommentViewState(row.viewState) }
+}
+
+export function serializeCommentRow(row: DbEnrichedComment): DbRawComment {
+    return { ...row, viewState: serializeCommentViewState(row.viewState) }
+}
+
+/** A comment joined with author information, as returned by the admin API */
+export type CommentWithAuthor = DbEnrichedComment & {
+    authorFullName: string
+    resolvedByFullName: string | null
+}

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -453,6 +453,20 @@ export {
     type DbPlainChartXEntity,
 } from "./dbTypes/ChartsXEntities.js"
 export {
+    CommentsTableName,
+    CommentTargetType,
+    type CommentTarget,
+    type CommentViewState,
+    type DbInsertComment,
+    type DbRawComment,
+    type DbEnrichedComment,
+    type CommentWithAuthor,
+    parseCommentViewState,
+    serializeCommentViewState,
+    parseCommentRow,
+    serializeCommentRow,
+} from "./dbTypes/Comments.js"
+export {
     type DbPlainDatapage,
     DatapagesTableName,
 } from "./dbTypes/Datapages.js"

--- a/site/AboutThisData.tsx
+++ b/site/AboutThisData.tsx
@@ -11,6 +11,7 @@ import {
 } from "@ourworldindata/components"
 import { DataPageDataV2 } from "@ourworldindata/types"
 import KeyDataTable from "./KeyDataTable.js"
+import { commentAnchorAttrs } from "./comments/commentAnchors.js"
 import { getAttributionUnshortened } from "./datapageUtils.js"
 
 export default function AboutThisData({
@@ -46,7 +47,10 @@ export default function AboutThisData({
                     <div className="col-start-1 span-cols-8 span-lg-cols-7 span-sm-cols-12">
                         <div className="key-info__content">
                             {hasDescriptionKey && (
-                                <div className="key-info__key-description">
+                                <div
+                                    className="key-info__key-description"
+                                    {...commentAnchorAttrs("descriptionKey")}
+                                >
                                     {datapageData.descriptionKey.length ===
                                     1 ? (
                                         <SimpleMarkdownText

--- a/site/KeyDataTable.tsx
+++ b/site/KeyDataTable.tsx
@@ -9,6 +9,7 @@ import {
     makeLinks,
     SimpleMarkdownText,
 } from "@ourworldindata/components"
+import { commentAnchorAttrs } from "./comments/commentAnchors.js"
 
 export default function KeyDataTable({
     datapageData,
@@ -31,7 +32,10 @@ export default function KeyDataTable({
     return (
         <div className="key-data-block grid grid-cols-4 grid-sm-cols-12">
             {datapageData.descriptionShort && (
-                <div className="key-data span-cols-4 span-sm-cols-12">
+                <div
+                    className="key-data span-cols-4 span-sm-cols-12"
+                    {...commentAnchorAttrs("descriptionShort")}
+                >
                     <div className="key-data-description-short__title">
                         {datapageData.title.title}
                     </div>
@@ -53,37 +57,55 @@ export default function KeyDataTable({
                 </div>
             )}
             {source && (
-                <div className="key-data span-cols-4 span-sm-cols-12">
+                <div
+                    className="key-data span-cols-4 span-sm-cols-12"
+                    {...commentAnchorAttrs("source")}
+                >
                     <div className="key-data__title">Source</div>
                     <div>{source}</div>
                 </div>
             )}
             {lastUpdated && (
-                <div className="key-data span-cols-2 span-sm-cols-6">
+                <div
+                    className="key-data span-cols-2 span-sm-cols-6"
+                    {...commentAnchorAttrs("lastUpdated")}
+                >
                     <div className="key-data__title">Last updated</div>
                     <div>{lastUpdated}</div>
                 </div>
             )}
             {nextUpdate && (
-                <div className="key-data span-cols-2 span-sm-cols-6">
+                <div
+                    className="key-data span-cols-2 span-sm-cols-6"
+                    {...commentAnchorAttrs("nextUpdate")}
+                >
                     <div className="key-data__title">Next expected update</div>
                     <div>{nextUpdate}</div>
                 </div>
             )}
             {dateRange && (
-                <div className="key-data span-cols-2 span-sm-cols-6">
+                <div
+                    className="key-data span-cols-2 span-sm-cols-6"
+                    {...commentAnchorAttrs("dateRange")}
+                >
                     <div className="key-data__title">Date range</div>
                     <div>{dateRange}</div>
                 </div>
             )}
             {unit && (
-                <div className="key-data span-cols-2 span-sm-cols-6">
+                <div
+                    className="key-data span-cols-2 span-sm-cols-6"
+                    {...commentAnchorAttrs("unit")}
+                >
                     <div className="key-data__title">Unit</div>
                     <div>{unit}</div>
                 </div>
             )}
             {unitConversionFactor && (
-                <div className="key-data span-cols-2 span-sm-cols-6">
+                <div
+                    className="key-data span-cols-2 span-sm-cols-6"
+                    {...commentAnchorAttrs("unitConversionFactor")}
+                >
                     <div className="key-data__title">
                         Unit conversion factor
                     </div>
@@ -91,7 +113,10 @@ export default function KeyDataTable({
                 </div>
             )}
             {links && (
-                <div className="key-data span-cols-2 span-sm-cols-6">
+                <div
+                    className="key-data span-cols-2 span-sm-cols-6"
+                    {...commentAnchorAttrs("links")}
+                >
                     <div className="key-data__title">Links</div>
                     <div className="key-data__content--hide-overflow">
                         {links}

--- a/site/MetadataSection.tsx
+++ b/site/MetadataSection.tsx
@@ -25,6 +25,7 @@ import {
 } from "@ourworldindata/utils"
 import { ArticleBlocks } from "./gdocs/components/ArticleBlocks.js"
 import { ChartLicenseNotice } from "./ChartLicenseNotice.js"
+import { commentAnchorAttrs } from "./comments/commentAnchors.js"
 
 export default function MetadataSection({
     attributionShort,
@@ -87,7 +88,10 @@ export default function MetadataSection({
         <div className="MetadataSection span-cols-14 grid grid-cols-12-full-width">
             <div className="col-start-2 span-cols-12">
                 {!!faqEntries?.faqs.length && (
-                    <div className="section-wrapper section-wrapper__faqs grid">
+                    <div
+                        className="section-wrapper section-wrapper__faqs grid"
+                        {...commentAnchorAttrs("faqs")}
+                    >
                         <h2
                             className="metadata-section__title span-cols-2 span-lg-cols-3 col-md-start-2 span-md-cols-10 col-sm-start-1 span-sm-cols-12"
                             id="faqs"
@@ -102,7 +106,10 @@ export default function MetadataSection({
                         </div>
                     </div>
                 )}
-                <div className="section-wrapper grid">
+                <div
+                    className="section-wrapper grid"
+                    {...commentAnchorAttrs("sourcesAndProcessing")}
+                >
                     <h2
                         className="data-sources-processing__title span-cols-2 span-lg-cols-3 col-md-start-2 span-md-cols-10 col-sm-start-1 span-sm-cols-12"
                         id={DATAPAGE_SOURCES_AND_PROCESSING_SECTION_ID}

--- a/site/comments/CommentComposer.tsx
+++ b/site/comments/CommentComposer.tsx
@@ -1,0 +1,61 @@
+import { useState } from "react"
+
+export function CommentComposer({
+    onSubmit,
+    placeholder = "Add a comment...",
+    submitLabel = "Comment",
+    autoFocus,
+}: {
+    onSubmit: (content: string) => Promise<unknown>
+    placeholder?: string
+    submitLabel?: string
+    autoFocus?: boolean
+}): React.ReactElement {
+    const [content, setContent] = useState("")
+    const [isSubmitting, setIsSubmitting] = useState(false)
+
+    const submit = async (): Promise<void> => {
+        const trimmed = content.trim()
+        if (!trimmed || isSubmitting) return
+        setIsSubmitting(true)
+        try {
+            await onSubmit(trimmed)
+            setContent("")
+        } finally {
+            setIsSubmitting(false)
+        }
+    }
+
+    return (
+        <form
+            className="comment-composer"
+            onSubmit={(event) => {
+                event.preventDefault()
+                void submit()
+            }}
+        >
+            <textarea
+                className="comment-composer__input"
+                value={content}
+                onChange={(event) => setContent(event.target.value)}
+                onKeyDown={(event) => {
+                    if (event.key === "Enter" && (event.metaKey || event.ctrlKey))
+                        void submit()
+                }}
+                placeholder={placeholder}
+                rows={3}
+                disabled={isSubmitting}
+                autoFocus={autoFocus}
+            />
+            <div className="comment-composer__actions">
+                <button
+                    type="submit"
+                    className="comment-composer__submit"
+                    disabled={!content.trim() || isSubmitting}
+                >
+                    {isSubmitting ? "Saving..." : submitLabel}
+                </button>
+            </div>
+        </form>
+    )
+}

--- a/site/comments/CommentComposer.tsx
+++ b/site/comments/CommentComposer.tsx
@@ -39,7 +39,10 @@ export function CommentComposer({
                 value={content}
                 onChange={(event) => setContent(event.target.value)}
                 onKeyDown={(event) => {
-                    if (event.key === "Enter" && (event.metaKey || event.ctrlKey))
+                    if (
+                        event.key === "Enter" &&
+                        (event.metaKey || event.ctrlKey)
+                    )
                         void submit()
                 }}
                 placeholder={placeholder}

--- a/site/comments/CommentThread.tsx
+++ b/site/comments/CommentThread.tsx
@@ -1,0 +1,127 @@
+import { useState } from "react"
+import cx from "classnames"
+import { CommentWithAuthor } from "@ourworldindata/types"
+import { dayjs } from "@ourworldindata/utils"
+import { CommentComposer } from "./CommentComposer.js"
+import { CommentThreadData } from "./useComments.js"
+
+function CommentItem({
+    comment,
+    canDelete,
+    onDelete,
+}: {
+    comment: CommentWithAuthor
+    canDelete: boolean
+    onDelete: () => void
+}): React.ReactElement {
+    const createdAt = dayjs(comment.createdAt)
+    return (
+        <div className="comment-item">
+            <div className="comment-item__header">
+                <span className="comment-item__author">
+                    {comment.authorFullName}
+                </span>
+                <time
+                    className="comment-item__time"
+                    title={createdAt.format()}
+                >
+                    {createdAt.fromNow()}
+                </time>
+            </div>
+            <div className="comment-item__content">{comment.content}</div>
+            {canDelete && (
+                <button
+                    type="button"
+                    className="comment-item__delete"
+                    onClick={onDelete}
+                >
+                    Delete
+                </button>
+            )}
+        </div>
+    )
+}
+
+export function CommentThread({
+    thread,
+    currentUserId,
+    anchorLabel,
+    onReply,
+    onSetResolved,
+    onDeleteComment,
+}: {
+    thread: CommentThreadData
+    currentUserId: number
+    anchorLabel?: string
+    onReply: (content: string) => Promise<unknown>
+    onSetResolved: (resolved: boolean) => void
+    onDeleteComment: (id: number) => void
+}): React.ReactElement {
+    const [isReplying, setIsReplying] = useState(false)
+    const { root, replies } = thread
+    const isResolved = root.resolvedAt !== null
+
+    const deleteComment = (comment: CommentWithAuthor) => {
+        if (window.confirm("Delete this comment?")) onDeleteComment(comment.id)
+    }
+
+    return (
+        <div
+            className={cx("comment-thread", {
+                "comment-thread--resolved": isResolved,
+            })}
+        >
+            {anchorLabel && (
+                <div className="comment-thread__anchor">on: {anchorLabel}</div>
+            )}
+            <CommentItem
+                comment={root}
+                canDelete={root.userId === currentUserId}
+                onDelete={() => deleteComment(root)}
+            />
+            {replies.map((reply) => (
+                <div key={reply.id} className="comment-thread__reply">
+                    <CommentItem
+                        comment={reply}
+                        canDelete={reply.userId === currentUserId}
+                        onDelete={() => deleteComment(reply)}
+                    />
+                </div>
+            ))}
+            {isResolved && root.resolvedByFullName && (
+                <div className="comment-thread__resolved-by">
+                    Resolved by {root.resolvedByFullName}
+                </div>
+            )}
+            <div className="comment-thread__actions">
+                {!isResolved && (
+                    <button
+                        type="button"
+                        className="comment-thread__action"
+                        onClick={() => setIsReplying(!isReplying)}
+                    >
+                        Reply
+                    </button>
+                )}
+                <button
+                    type="button"
+                    className="comment-thread__action"
+                    onClick={() => onSetResolved(!isResolved)}
+                >
+                    {isResolved ? "Reopen" : "Resolve"}
+                </button>
+            </div>
+            {isReplying && (
+                <CommentComposer
+                    placeholder="Reply..."
+                    submitLabel="Reply"
+                    autoFocus
+                    onSubmit={async (content) => {
+                        await onReply(content)
+                        setIsReplying(false)
+                    }}
+                />
+            )}
+        </div>
+    )
+}

--- a/site/comments/CommentThread.tsx
+++ b/site/comments/CommentThread.tsx
@@ -21,10 +21,7 @@ function CommentItem({
                 <span className="comment-item__author">
                     {comment.authorFullName}
                 </span>
-                <time
-                    className="comment-item__time"
-                    title={createdAt.format()}
-                >
+                <time className="comment-item__time" title={createdAt.format()}>
                     {createdAt.fromNow()}
                 </time>
             </div>

--- a/site/comments/Comments.scss
+++ b/site/comments/Comments.scss
@@ -1,0 +1,296 @@
+/* Styles for the internal commenting UI. Loaded via CommentsPanel.tsx, so
+   they ship with the admin bundle and the lazily loaded preview overlay chunk,
+   but never with the public site styles. */
+
+.comments-panel {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    height: 100%;
+    font-size: 13px;
+    color: #333;
+}
+
+.comments-panel__composer {
+    padding-bottom: 12px;
+    border-bottom: 1px solid #e7e7e7;
+}
+
+.comments-panel__active-anchor {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-bottom: 8px;
+    padding: 4px 8px;
+    background: #eef3f7;
+    border-radius: 4px;
+}
+
+.comments-panel__clear-anchor {
+    margin-left: auto;
+    border: none;
+    background: none;
+    cursor: pointer;
+    font-size: 15px;
+    line-height: 1;
+    color: #666;
+}
+
+.comments-panel__clear-anchor:hover {
+    color: #333;
+}
+
+.comments-panel__show-resolved {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin: 10px 0;
+    cursor: pointer;
+}
+
+.comments-panel__threads {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+}
+
+.comments-panel__message {
+    padding: 20px 0;
+    text-align: center;
+    color: #888;
+}
+
+.comments-panel__message--error {
+    color: #c0392b;
+}
+
+.comment-composer__input {
+    width: 100%;
+    padding: 8px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    font-family: inherit;
+    font-size: 13px;
+    resize: vertical;
+    box-sizing: border-box;
+
+    &:focus {
+        outline: none;
+        border-color: #002147;
+    }
+}
+
+.comment-composer__actions {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 6px;
+}
+
+.comment-composer__submit {
+    padding: 5px 14px;
+    border: none;
+    border-radius: 4px;
+    background: #002147;
+    color: #fff;
+    font-size: 13px;
+    cursor: pointer;
+
+    &:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+    }
+}
+
+.comment-thread {
+    padding: 10px 12px;
+    border: 1px solid #e7e7e7;
+    border-radius: 6px;
+    margin-bottom: 10px;
+    background: #fff;
+}
+
+.comment-thread--resolved {
+    opacity: 0.65;
+    background: #f7f7f7;
+}
+
+.comment-thread__anchor {
+    margin-bottom: 6px;
+    font-size: 11px;
+    font-style: italic;
+    color: #777;
+}
+
+.comment-thread__reply {
+    margin-top: 8px;
+    padding-left: 12px;
+    border-left: 2px solid #e7e7e7;
+}
+
+.comment-thread__resolved-by {
+    margin-top: 6px;
+    font-size: 11px;
+    color: #2e7d32;
+}
+
+.comment-thread__actions {
+    display: flex;
+    gap: 12px;
+    margin-top: 8px;
+}
+
+.comment-thread__action {
+    border: none;
+    background: none;
+    padding: 0;
+    font-size: 12px;
+    color: #0d68a8;
+    cursor: pointer;
+
+    &:hover {
+        text-decoration: underline;
+    }
+}
+
+.comment-item__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 8px;
+}
+
+.comment-item__author {
+    font-weight: 600;
+}
+
+.comment-item__time {
+    font-size: 11px;
+    color: #999;
+}
+
+.comment-item__content {
+    margin-top: 3px;
+    line-height: 1.4;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+.comment-item__delete {
+    border: none;
+    background: none;
+    padding: 0;
+    margin-top: 4px;
+    font-size: 11px;
+    color: #c0392b;
+    cursor: pointer;
+
+    &:hover {
+        text-decoration: underline;
+    }
+}
+
+/* Comments button in the chart editor */
+
+.chart-editor-comments-button {
+    align-self: flex-start;
+    margin-bottom: 12px;
+}
+
+/* Preview overlay (floating button + panel on data page previews) */
+
+.comments-overlay__toggle {
+    position: fixed;
+    right: 20px;
+    bottom: 20px;
+    z-index: 100;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 18px;
+    border: none;
+    border-radius: 20px;
+    background: #002147;
+    color: #fff;
+    font-size: 14px;
+    cursor: pointer;
+    box-shadow: 0 3px 10px rgba(0, 0, 0, 0.25);
+}
+
+.comments-overlay__toggle--open {
+    background: #1d3d63;
+}
+
+.comments-overlay__count {
+    padding: 1px 7px;
+    border-radius: 10px;
+    background: #d73c50;
+    font-size: 12px;
+}
+
+.comments-overlay__panel {
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 99;
+    display: flex;
+    flex-direction: column;
+    width: 360px;
+    padding: 16px;
+    background: #fff;
+    border-left: 1px solid #ddd;
+    box-shadow: -3px 0 12px rgba(0, 0, 0, 0.12);
+}
+
+.comments-overlay__panel-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 12px;
+
+    h3 {
+        margin: 0;
+        font-size: 16px;
+    }
+}
+
+.comments-overlay__close {
+    border: none;
+    background: none;
+    font-size: 20px;
+    line-height: 1;
+    color: #666;
+    cursor: pointer;
+
+    &:hover {
+        color: #333;
+    }
+}
+
+/* While the overlay panel is open, anchored fields become click targets */
+
+.comments-anchor-mode [data-comment-anchor] {
+    cursor: pointer;
+
+    &:hover {
+        outline: 2px solid rgba(0, 33, 71, 0.4);
+        outline-offset: 3px;
+        border-radius: 2px;
+    }
+}
+
+.comments-anchor-badge {
+    position: absolute;
+    z-index: 98;
+    min-width: 20px;
+    height: 20px;
+    padding: 0 6px;
+    border: none;
+    border-radius: 10px;
+    background: #d73c50;
+    color: #fff;
+    font-size: 11px;
+    font-weight: 600;
+    cursor: pointer;
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.25);
+}

--- a/site/comments/CommentsPanel.tsx
+++ b/site/comments/CommentsPanel.tsx
@@ -1,0 +1,129 @@
+import { useState } from "react"
+import { CommentTarget, CommentViewState } from "@ourworldindata/types"
+import { CommentComposer } from "./CommentComposer.js"
+import { CommentThread } from "./CommentThread.js"
+import {
+    useCommentThreads,
+    useCreateComment,
+    useDeleteComment,
+    useSetThreadResolved,
+} from "./useComments.js"
+import "./Comments.scss"
+
+/**
+ * The one comments UI, shared by every host: the chart editor renders it
+ * inside a drawer, the data page preview overlay renders it in a floating
+ * panel. Hosts only decide where it lives and which anchors exist.
+ */
+export function CommentsPanel({
+    target,
+    anchorLabels,
+    activeAnchor,
+    onActiveAnchorChange,
+    newCommentViewState,
+}: {
+    target: CommentTarget
+    /** Labels for the anchors comments can be attached to in this host */
+    anchorLabels?: Record<string, string>
+    /** When set, the list is filtered to and new comments anchored to this field */
+    activeAnchor?: string | null
+    onActiveAnchorChange?: (anchor: string | null) => void
+    /** For multi-dim hosts: the view new comments should be attached to */
+    newCommentViewState?: CommentViewState | null
+}): React.ReactElement {
+    const [includeResolved, setIncludeResolved] = useState(false)
+    const { data, isLoading, error } = useCommentThreads(target, {
+        includeResolved,
+    })
+    const createComment = useCreateComment(target)
+    const setResolved = useSetThreadResolved(target)
+    const deleteComment = useDeleteComment(target)
+
+    const threads = activeAnchor
+        ? data?.threads.filter((thread) => thread.root.anchor === activeAnchor)
+        : data?.threads
+
+    return (
+        <div className="comments-panel">
+            <div className="comments-panel__composer">
+                {activeAnchor && (
+                    <div className="comments-panel__active-anchor">
+                        Commenting on:{" "}
+                        <strong>
+                            {anchorLabels?.[activeAnchor] ?? activeAnchor}
+                        </strong>
+                        <button
+                            type="button"
+                            className="comments-panel__clear-anchor"
+                            title="Comment on the page as a whole instead"
+                            onClick={() => onActiveAnchorChange?.(null)}
+                        >
+                            &times;
+                        </button>
+                    </div>
+                )}
+                <CommentComposer
+                    onSubmit={(content) =>
+                        createComment.mutateAsync({
+                            content,
+                            anchor: activeAnchor ?? null,
+                            viewState: newCommentViewState ?? null,
+                        })
+                    }
+                />
+            </div>
+            <label className="comments-panel__show-resolved">
+                <input
+                    type="checkbox"
+                    checked={includeResolved}
+                    onChange={(event) =>
+                        setIncludeResolved(event.target.checked)
+                    }
+                />{" "}
+                Show resolved
+            </label>
+            <div className="comments-panel__threads">
+                {isLoading ? (
+                    <div className="comments-panel__message">Loading...</div>
+                ) : error ? (
+                    <div className="comments-panel__message comments-panel__message--error">
+                        Failed to load comments: {error.message}
+                    </div>
+                ) : !threads?.length ? (
+                    <div className="comments-panel__message">
+                        No comments yet
+                    </div>
+                ) : (
+                    threads.map((thread) => (
+                        <CommentThread
+                            key={thread.root.id}
+                            thread={thread}
+                            currentUserId={data!.currentUserId}
+                            anchorLabel={
+                                thread.root.anchor
+                                    ? (anchorLabels?.[thread.root.anchor] ??
+                                      thread.root.anchor)
+                                    : undefined
+                            }
+                            onReply={(content) =>
+                                createComment.mutateAsync({
+                                    content,
+                                    parentId: thread.root.id,
+                                })
+                            }
+                            onSetResolved={(resolved) =>
+                                setResolved.mutate({
+                                    id: thread.root.id,
+                                    resolved,
+                                })
+                            }
+                            onDeleteComment={(id) =>
+                                deleteComment.mutate({ id })
+                            }
+                        />
+                    ))
+                )}
+            </div>
+        </div>
+    )
+}

--- a/site/comments/DataPageCommentsOverlay.tsx
+++ b/site/comments/DataPageCommentsOverlay.tsx
@@ -1,0 +1,188 @@
+import { useEffect, useMemo, useState } from "react"
+import { createRoot } from "react-dom/client"
+import { createPortal } from "react-dom"
+import cx from "classnames"
+import { CommentTarget, CommentTargetType } from "@ourworldindata/types"
+import {
+    COMMENT_ANCHOR_ATTRIBUTE,
+    DATA_PAGE_COMMENT_ANCHORS,
+} from "./commentAnchors.js"
+import { CommentsPanel } from "./CommentsPanel.js"
+import { CommentThreadData, useCommentThreads } from "./useComments.js"
+import { SiteQueryClientProvider } from "../SiteQueryClientProvider.js"
+
+const ANCHOR_MODE_BODY_CLASS = "comments-anchor-mode"
+
+/**
+ * Small count badges rendered next to each anchored element that has
+ * unresolved comments. They live in a portal and are positioned with document
+ * coordinates, so the page's own (React-managed) DOM is never touched.
+ */
+function AnchorBadges({
+    threads,
+    onSelect,
+}: {
+    threads: CommentThreadData[]
+    onSelect: (anchor: string) => void
+}): React.ReactElement | null {
+    const [badges, setBadges] = useState<
+        { anchor: string; count: number; top: number; left: number }[]
+    >([])
+
+    const countsByAnchor = useMemo(() => {
+        const counts = new Map<string, number>()
+        for (const thread of threads) {
+            if (!thread.root.anchor || thread.root.resolvedAt) continue
+            counts.set(
+                thread.root.anchor,
+                (counts.get(thread.root.anchor) ?? 0) + 1
+            )
+        }
+        return counts
+    }, [threads])
+
+    useEffect(() => {
+        const computePositions = (): void => {
+            const positioned = []
+            for (const [anchor, count] of countsByAnchor) {
+                const element = document.querySelector(
+                    `[${COMMENT_ANCHOR_ATTRIBUTE}="${anchor}"]`
+                )
+                if (!element) continue
+                const rect = element.getBoundingClientRect()
+                positioned.push({
+                    anchor,
+                    count,
+                    top: rect.top + window.scrollY,
+                    left: rect.right + window.scrollX + 8,
+                })
+            }
+            setBadges(positioned)
+        }
+        computePositions()
+        window.addEventListener("resize", computePositions)
+        return () => window.removeEventListener("resize", computePositions)
+    }, [countsByAnchor])
+
+    if (!badges.length) return null
+    return createPortal(
+        <>
+            {badges.map((badge) => (
+                <button
+                    key={badge.anchor}
+                    type="button"
+                    className="comments-anchor-badge"
+                    style={{ top: badge.top, left: badge.left }}
+                    title="Show comments on this field"
+                    onClick={() => onSelect(badge.anchor)}
+                >
+                    {badge.count}
+                </button>
+            ))}
+        </>,
+        document.body
+    )
+}
+
+export function DataPageCommentsOverlay({
+    variableId,
+}: {
+    variableId: number
+}): React.ReactElement {
+    const [isOpen, setIsOpen] = useState(false)
+    const [activeAnchor, setActiveAnchor] = useState<string | null>(null)
+    const target: CommentTarget = useMemo(
+        () => ({
+            targetType: CommentTargetType.Variable,
+            targetId: variableId,
+        }),
+        [variableId]
+    )
+    const { data } = useCommentThreads(target)
+
+    // While the panel is open, anchored elements become clickable to direct
+    // new comments at them (visual affordance via the body class in SCSS).
+    useEffect(() => {
+        if (!isOpen) return undefined
+        document.body.classList.add(ANCHOR_MODE_BODY_CLASS)
+        const onClick = (event: MouseEvent): void => {
+            const anchorElement = (event.target as Element).closest?.(
+                `[${COMMENT_ANCHOR_ATTRIBUTE}]`
+            )
+            if (!anchorElement) return
+            event.preventDefault()
+            event.stopPropagation()
+            setActiveAnchor(
+                anchorElement.getAttribute(COMMENT_ANCHOR_ATTRIBUTE)
+            )
+        }
+        document.addEventListener("click", onClick, true)
+        return () => {
+            document.body.classList.remove(ANCHOR_MODE_BODY_CLASS)
+            document.removeEventListener("click", onClick, true)
+        }
+    }, [isOpen])
+
+    return (
+        <>
+            <button
+                type="button"
+                className={cx("comments-overlay__toggle", {
+                    "comments-overlay__toggle--open": isOpen,
+                })}
+                onClick={() => setIsOpen(!isOpen)}
+            >
+                Comments
+                {data && data.unresolvedCount > 0 && (
+                    <span className="comments-overlay__count">
+                        {data.unresolvedCount}
+                    </span>
+                )}
+            </button>
+            {isOpen && (
+                <div className="comments-overlay__panel">
+                    <div className="comments-overlay__panel-header">
+                        <h3>Comments</h3>
+                        <button
+                            type="button"
+                            className="comments-overlay__close"
+                            title="Close"
+                            onClick={() => setIsOpen(false)}
+                        >
+                            &times;
+                        </button>
+                    </div>
+                    <CommentsPanel
+                        target={target}
+                        anchorLabels={DATA_PAGE_COMMENT_ANCHORS}
+                        activeAnchor={activeAnchor}
+                        onActiveAnchorChange={setActiveAnchor}
+                    />
+                </div>
+            )}
+            {isOpen && data && (
+                <AnchorBadges
+                    threads={data.threads}
+                    onSelect={setActiveAnchor}
+                />
+            )}
+        </>
+    )
+}
+
+/**
+ * Mounts the overlay on an admin data page preview. Loaded via dynamic import
+ * from runSiteFooterScripts so none of this code (or react-query) ends up in
+ * the public site chunk.
+ */
+export function mountDataPageCommentsOverlay(): void {
+    const variableId = window._OWID_GRAPHER_CONFIG?.dimensions?.[0]?.variableId
+    if (!variableId) return
+    const container = document.createElement("div")
+    document.body.appendChild(container)
+    createRoot(container).render(
+        <SiteQueryClientProvider>
+            <DataPageCommentsOverlay variableId={variableId} />
+        </SiteQueryClientProvider>
+    )
+}

--- a/site/comments/commentAnchors.ts
+++ b/site/comments/commentAnchors.ts
@@ -1,0 +1,29 @@
+export const COMMENT_ANCHOR_ATTRIBUTE = "data-comment-anchor"
+
+/**
+ * The parts of a data page staff can anchor comments to. Keys are stored in
+ * the comments table (comments.anchor), so treat renames as data migrations.
+ * Site components declare where an anchor lives by spreading
+ * commentAnchorAttrs() on the element that renders the field.
+ */
+export const DATA_PAGE_COMMENT_ANCHORS = {
+    descriptionShort: "Title and short description",
+    source: "Source",
+    lastUpdated: "Last updated",
+    nextUpdate: "Next expected update",
+    dateRange: "Date range",
+    unit: "Unit",
+    unitConversionFactor: "Unit conversion factor",
+    links: "Links",
+    descriptionKey: "What you should know about this data",
+    sourcesAndProcessing: "Sources and processing",
+    faqs: "FAQs",
+} as const
+
+export type DataPageCommentAnchor = keyof typeof DATA_PAGE_COMMENT_ANCHORS
+
+export function commentAnchorAttrs(anchor: DataPageCommentAnchor): {
+    [COMMENT_ANCHOR_ATTRIBUTE]: string
+} {
+    return { [COMMENT_ANCHOR_ATTRIBUTE]: anchor }
+}

--- a/site/comments/useComments.ts
+++ b/site/comments/useComments.ts
@@ -1,0 +1,135 @@
+import {
+    useMutation,
+    useQuery,
+    useQueryClient,
+    UseMutationResult,
+    UseQueryResult,
+} from "@tanstack/react-query"
+import {
+    CommentTarget,
+    CommentViewState,
+    CommentWithAuthor,
+} from "@ourworldindata/types"
+
+// Both the admin SPA and the admin-served preview pages are same-origin with
+// the admin API, so relative paths work in every host of this hook.
+const COMMENTS_API_PATH = "/admin/api/comments"
+
+export interface CommentThreadData {
+    root: CommentWithAuthor
+    replies: CommentWithAuthor[]
+}
+
+export interface CommentThreadsData {
+    threads: CommentThreadData[]
+    unresolvedCount: number
+    currentUserId: number
+}
+
+async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
+    const response = await fetch(url, {
+        headers: { "Content-Type": "application/json" },
+        ...init,
+    })
+    const json = await response.json().catch(() => undefined)
+    if (!response.ok) {
+        throw new Error(json?.error?.message ?? response.statusText)
+    }
+    return json
+}
+
+function groupIntoThreads(comments: CommentWithAuthor[]): CommentThreadData[] {
+    const roots = comments.filter((comment) => comment.parentId === null)
+    // Roots newest-first, replies in chronological order (as returned)
+    return roots
+        .map((root) => ({
+            root,
+            replies: comments.filter(
+                (comment) => comment.parentId === root.id
+            ),
+        }))
+        .reverse()
+}
+
+function commentsQueryKey(target: CommentTarget): (string | number)[] {
+    return ["comments", target.targetType, target.targetId]
+}
+
+export function useCommentThreads(
+    target: CommentTarget,
+    { includeResolved = false }: { includeResolved?: boolean } = {}
+): UseQueryResult<CommentThreadsData> {
+    return useQuery({
+        queryKey: [...commentsQueryKey(target), { includeResolved }],
+        queryFn: () =>
+            fetchJson<{
+                comments: CommentWithAuthor[]
+                currentUserId: number
+            }>(
+                `${COMMENTS_API_PATH}.json?targetType=${target.targetType}` +
+                    `&targetId=${target.targetId}` +
+                    `&includeResolved=${includeResolved}`
+            ),
+        select: ({ comments, currentUserId }) => {
+            const threads = groupIntoThreads(comments)
+            return {
+                threads,
+                unresolvedCount: threads.filter(
+                    (thread) => !thread.root.resolvedAt
+                ).length,
+                currentUserId,
+            }
+        },
+    })
+}
+
+function useInvalidateComments(target: CommentTarget): () => Promise<void> {
+    const queryClient = useQueryClient()
+    return () =>
+        queryClient.invalidateQueries({ queryKey: commentsQueryKey(target) })
+}
+
+export type CreateCommentInput =
+    | { content: string; anchor?: string | null; viewState?: CommentViewState | null }
+    | { content: string; parentId: number }
+
+export function useCreateComment(
+    target: CommentTarget
+): UseMutationResult<unknown, Error, CreateCommentInput> {
+    const invalidate = useInvalidateComments(target)
+    return useMutation({
+        mutationFn: (input: CreateCommentInput) =>
+            fetchJson(COMMENTS_API_PATH, {
+                method: "POST",
+                body: JSON.stringify(
+                    "parentId" in input ? input : { ...target, ...input }
+                ),
+            }),
+        onSuccess: invalidate,
+    })
+}
+
+export function useSetThreadResolved(
+    target: CommentTarget
+): UseMutationResult<unknown, Error, { id: number; resolved: boolean }> {
+    const invalidate = useInvalidateComments(target)
+    return useMutation({
+        mutationFn: ({ id, resolved }) =>
+            fetchJson(`${COMMENTS_API_PATH}/${id}/resolved`, {
+                method: "PUT",
+                body: JSON.stringify({ resolved }),
+            }),
+        onSuccess: invalidate,
+    })
+}
+
+export function useDeleteComment(
+    target: CommentTarget
+): UseMutationResult<unknown, Error, { id: number }> {
+    const invalidate = useInvalidateComments(target)
+    return useMutation({
+        mutationFn: ({ id }) =>
+            fetchJson(`${COMMENTS_API_PATH}/${id}`, { method: "DELETE" }),
+        onSuccess: invalidate,
+    })
+}

--- a/site/comments/useComments.ts
+++ b/site/comments/useComments.ts
@@ -44,9 +44,7 @@ function groupIntoThreads(comments: CommentWithAuthor[]): CommentThreadData[] {
     return roots
         .map((root) => ({
             root,
-            replies: comments.filter(
-                (comment) => comment.parentId === root.id
-            ),
+            replies: comments.filter((comment) => comment.parentId === root.id),
         }))
         .reverse()
 }
@@ -90,7 +88,11 @@ function useInvalidateComments(target: CommentTarget): () => Promise<void> {
 }
 
 export type CreateCommentInput =
-    | { content: string; anchor?: string | null; viewState?: CommentViewState | null }
+    | {
+          content: string
+          anchor?: string | null
+          viewState?: CommentViewState | null
+      }
     | { content: string; parentId: number }
 
 export function useCreateComment(

--- a/site/runSiteFooterScripts.tsx
+++ b/site/runSiteFooterScripts.tsx
@@ -96,6 +96,14 @@ function runLatestPage() {
     }
 }
 
+// Loaded lazily so the internal commenting UI (and its dependencies) never
+// ends up in the site chunks that public visitors download.
+function mountPreviewCommentsOverlay() {
+    void import("./comments/DataPageCommentsOverlay.js").then((module) =>
+        module.mountDataPageCommentsOverlay()
+    )
+}
+
 function hydrateDataPageV2Content({
     isPreviewing,
 }: { isPreviewing?: boolean } = {}) {
@@ -335,6 +343,7 @@ export const runSiteFooterScripts = async (
     switch (context) {
         case SiteFooterContext.dataPageV2:
             hydrateDataPageV2Content({ isPreviewing })
+            if (isPreviewing) mountPreviewCommentsOverlay()
             runAllGraphersLoadedListener()
             runSiteNavigation({ hideDonationFlag, isPreviewing })
             runSiteTools()


### PR DESCRIPTION
## Context

Clean rebuild of the internal-commenting prototype from #6051 (do-not-merge POC, now closed). Background: [discovery deck](https://docs.google.com/presentation/d/1B9648KSRLT07o2V7PeZ-jJulS-KGffRNttbRw8_aLkU/edit?usp=sharing).

Lets staff flag and discuss data/metadata issues in context — anchored to a chart, an indicator/data page, or (schema-ready) a specific multi-dim view and field — with threaded replies and a resolve/reopen workflow, instead of routing every typo through Slack.

Main differences to the POC implementation:

- **One shared comments UI** (`site/comments/`, react-query) used by both hosts, instead of five duplicated copies of the same components.
- **No injected JS strings.** The data page preview overlay is a typed React component loaded as a lazy Vite chunk, gated on the existing `isPreviewing` flag. Public visitors never download any comment code, styles, or data; the API (reads included) sits behind admin auth at `/admin/api/comments*`.
- **Declarative field anchoring** via `data-comment-anchor` attributes rendered by the data page components themselves (single typed registry), instead of brittle CSS selectors.
- **Cleaner schema**: numeric polymorphic `targetId` with API-side existence validation, one level of threading via `parentId` (cascade delete), resolution state on thread roots, `viewState` JSON for multi-dim views. Covered by DB tests (`adminSiteServer/tests/comments.test.ts`).

Deliberately out of scope for this PR: mounting the overlay on multi-dim previews (schema/API/UI already support it), surfacing comments on live production pages for logged-in staff, bot participants (owidbot fixes, ETL inspector), and notifications.

## Testing guidance

On the staging server (`http://staging-site-internal-comments`, migrations run on deploy):

1. Open any data page preview, e.g. `/admin/datapage-preview/<variableId>`. Click the floating **Comments** button (bottom right). With the panel open, hover a field like *Source* or *What you should know* — click it to anchor a comment to that field. Post, reply, resolve, reopen, delete. Count badges appear next to fields with open threads.
2. Open a saved chart in the editor (`/admin/charts/<chartId>/edit`) and use the **Comments** button above the preview link — same panel in a drawer.
3. Verify isolation: on a baked/public page there is no comments button, and `curl http://staging-site-internal-comments/admin/api/comments.json?...` without auth returns a redirect/401.

- [ ] Does the staging experience have sign-off from product stakeholders?

## Checklist

### Before merging

If DB migrations exists:

- [ ] If columns have been added/deleted, all necessary views were recreated and ETL and Analytics team members have been informed of the incoming changes (new table only — no views affected; ETL/Analytics untouched)
- [x] The DB type definitions have been updated
- [ ] The DB types in the ETL have been updated (n/a — table not used by ETL yet)
- [x] Update the documentation in db/docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)