### PR TITLE
✨ Show result counts in the search result type toggle

### DIFF
--- a/site/search/SearchResultTypeToggle.tsx
+++ b/site/search/SearchResultTypeToggle.tsx
@@ -1,6 +1,8 @@
 import { RadioButton } from "@ourworldindata/components"
 import { SearchResultType } from "@ourworldindata/types"
+import { commafyNumber } from "@ourworldindata/utils"
 import { useSearchContext } from "./SearchContext.js"
+import { useResultTypeCounts } from "./searchHooks.js"
 import {
     getEffectiveResultType,
     hasDatasetFilters,
@@ -19,6 +21,7 @@ export const SearchResultTypeToggle = () => {
         actions: { setResultType },
     } = useSearchContext()
     const { resultType, filters, query } = state
+    const counts = useResultTypeCounts()
 
     if (hasDatasetFilters(filters)) return null
 
@@ -41,15 +44,25 @@ export const SearchResultTypeToggle = () => {
             <legend className="search-result-type-toggle__legend">
                 Filter by type of content:
             </legend>
-            {optionsToShow.map((option) => (
-                <RadioButton
-                    key={option.value}
-                    checked={effectiveResultType === option.value}
-                    onChange={() => setResultType(option.value)}
-                    label={option.label}
-                    group="search-result-type"
-                />
-            ))}
+            {optionsToShow.map((option) => {
+                const count =
+                    option.value !== SearchResultType.ALL
+                        ? counts?.[option.value]
+                        : undefined
+                return (
+                    <RadioButton
+                        key={option.value}
+                        checked={effectiveResultType === option.value}
+                        onChange={() => setResultType(option.value)}
+                        label={
+                            count !== undefined
+                                ? `${option.label} (${commafyNumber(count)})`
+                                : option.label
+                        }
+                        group="search-result-type"
+                    />
+                )
+            })}
         </fieldset>
     )
 }

--- a/site/search/queries.ts
+++ b/site/search/queries.ts
@@ -14,6 +14,7 @@ import {
     PageChronologicalRecord,
     DataInsightHit,
     FlatArticleHit,
+    SearchResultType,
 } from "@ourworldindata/types"
 import { type SearchResponse } from "algoliasearch"
 import { type LiteClient } from "algoliasearch/lite"
@@ -63,6 +64,8 @@ export const searchQueryKeys = {
         [PAGES_INDEX, "topics", makeStateForKey(state)] as const,
     profiles: (state: SearchState) =>
         [PAGES_INDEX, "profiles", makeStateForKey(state)] as const,
+    resultTypeCounts: (state: SearchState, options: ResultTypeCountsOptions) =>
+        ["result-type-counts", makeStateForKey(state), options] as const,
 } as const
 
 export const latestPagesQueryKey = {
@@ -131,11 +134,7 @@ export async function queryDataTopics(
     }))
 }
 
-export async function queryCharts(
-    liteSearchClient: LiteClient,
-    state: SearchState,
-    page: number = 0
-) {
+function buildChartsBaseParams(state: SearchState) {
     const countryFacetFilters = formatCountryFacetFilters(
         getFilterNamesOfType(state.filters, FilterType.COUNTRY),
         state.requireAllCountries
@@ -170,12 +169,22 @@ export async function queryCharts(
         ...fmFacetFilter,
     ]
 
+    return {
+        indexName: CHARTS_INDEX,
+        query: state.query,
+        facetFilters,
+    }
+}
+
+export async function queryCharts(
+    liteSearchClient: LiteClient,
+    state: SearchState,
+    page: number = 0
+) {
     const searchParams = [
         {
-            indexName: CHARTS_INDEX,
+            ...buildChartsBaseParams(state),
             attributesToRetrieve: DATA_CATALOG_ATTRIBUTES,
-            query: state.query,
-            facetFilters,
             highlightPreTag: "<mark>",
             highlightPostTag: "</mark>",
             hitsPerPage: 9,
@@ -186,12 +195,7 @@ export async function queryCharts(
     return searchSingleForHits<SearchChartHit>(liteSearchClient, searchParams)
 }
 
-export async function queryDataInsights(
-    liteSearchClient: LiteClient,
-    state: SearchState,
-    page: number = 0,
-    hitsPerPage: number = 4
-) {
+function buildDataInsightsBaseParams(state: SearchState) {
     const selectedCountryNames = getFilterNamesOfType(
         state.filters,
         FilterType.COUNTRY
@@ -208,20 +212,31 @@ export async function queryDataInsights(
         .filter(Boolean)
         .join(" ")
 
+    return {
+        indexName: PAGES_INDEX,
+        query,
+        filters: `type:${OwidGdocType.DataInsight}`,
+        facetFilters: formatTopicFacetFilters(selectedTopics),
+        // Do not search through the content of data insights in case there
+        // is a country filter present. This is to avoid returning data
+        // insights that might mention a country, but are not *about* that
+        // country (e.g. "Unlike Germany...").
+        ...(hasCountry && {
+            // a subset of searchableAttributes on the Pages index
+            restrictSearchableAttributes: ["title", "tags", "authors"],
+        }),
+    }
+}
+
+export async function queryDataInsights(
+    liteSearchClient: LiteClient,
+    state: SearchState,
+    page: number = 0,
+    hitsPerPage: number = 4
+) {
     const searchParams = [
         {
-            indexName: PAGES_INDEX,
-            query,
-            filters: `type:${OwidGdocType.DataInsight}`,
-            facetFilters: formatTopicFacetFilters(selectedTopics),
-            // Do not search through the content of data insights in case there
-            // is a country filter present. This is to avoid returning data
-            // insights that might mention a country, but are not *about* that
-            // country (e.g. "Unlike Germany...").
-            ...(hasCountry && {
-                // a subset of searchableAttributes on the Pages index
-                restrictSearchableAttributes: ["title", "tags", "authors"],
-            }),
+            ...buildDataInsightsBaseParams(state),
             attributesToRetrieve: [
                 "title",
                 "thumbnailUrl",
@@ -239,19 +254,13 @@ export async function queryDataInsights(
     return searchSingleForHits<DataInsightHit>(liteSearchClient, searchParams)
 }
 
-export async function queryArticles(
-    liteSearchClient: LiteClient,
-    state: SearchState,
-    offset: number = 0,
-    length: number
-) {
+function buildArticlesBaseParams(state: SearchState) {
     const selectedCountryNames = getFilterNamesOfType(
         state.filters,
         FilterType.COUNTRY
     )
     const hasCountry = selectedCountryNames.size > 0
     const selectedTopics = getFilterNamesOfType(state.filters, FilterType.TOPIC)
-    const isFilterOnly = state.query.trim() === ""
     // Using the selected countries as query search terms until articles
     // are tagged with countries.
     const query = [
@@ -262,20 +271,33 @@ export async function queryArticles(
         .filter(Boolean)
         .join(" ")
 
+    return {
+        indexName: PAGES_INDEX,
+        query,
+        filters: `type:${OwidGdocType.Article} OR type:${OwidGdocType.AboutPage}`,
+        facetFilters: formatTopicFacetFilters(selectedTopics),
+        // Do not search through the content of articles in case there is a
+        // country filter present. This is to avoid returning articles that
+        // might mention a country, but are not *about* that country (e.g.
+        // "Unlike Germany...").
+        ...(hasCountry && {
+            // a subset of searchableAttributes on the Pages index
+            restrictSearchableAttributes: ["title", "tags", "authors"],
+        }),
+    }
+}
+
+export async function queryArticles(
+    liteSearchClient: LiteClient,
+    state: SearchState,
+    offset: number = 0,
+    length: number
+) {
+    const isFilterOnly = state.query.trim() === ""
+
     const searchParams = [
         {
-            indexName: PAGES_INDEX,
-            query,
-            filters: `type:${OwidGdocType.Article} OR type:${OwidGdocType.AboutPage}`,
-            facetFilters: formatTopicFacetFilters(selectedTopics),
-            // Do not search through the content of articles in case there is a
-            // country filter present. This is to avoid returning articles that
-            // might mention a country, but are not *about* that country (e.g.
-            // "Unlike Germany...").
-            ...(hasCountry && {
-                // a subset of searchableAttributes on the Pages index
-                restrictSearchableAttributes: ["title", "tags", "authors"],
-            }),
+            ...buildArticlesBaseParams(state),
             attributesToRetrieve: [
                 "title",
                 "thumbnailUrl",
@@ -295,20 +317,26 @@ export async function queryArticles(
     return searchSingleForHits<FlatArticleHit>(liteSearchClient, searchParams)
 }
 
+function buildTopicPagesBaseParams(state: SearchState) {
+    const selectedTopics = getFilterNamesOfType(state.filters, FilterType.TOPIC)
+
+    return {
+        indexName: PAGES_INDEX,
+        query: state.query,
+        filters: `type:${OwidGdocType.TopicPage} OR type:${OwidGdocType.LinearTopicPage}`,
+        facetFilters: formatTopicFacetFilters(selectedTopics),
+    }
+}
+
 export async function queryTopicPages(
     liteSearchClient: LiteClient,
     state: SearchState,
     offset: number = 0,
     length: number
 ) {
-    const selectedTopics = getFilterNamesOfType(state.filters, FilterType.TOPIC)
-
     const searchParams = [
         {
-            indexName: PAGES_INDEX,
-            query: state.query,
-            filters: `type:${OwidGdocType.TopicPage} OR type:${OwidGdocType.LinearTopicPage}`,
-            facetFilters: formatTopicFacetFilters(selectedTopics),
+            ...buildTopicPagesBaseParams(state),
             attributesToRetrieve: [
                 "title",
                 "type",
@@ -326,12 +354,7 @@ export async function queryTopicPages(
     return searchSingleForHits<TopicPageHit>(liteSearchClient, searchParams)
 }
 
-export async function queryProfiles(
-    liteSearchClient: LiteClient,
-    state: SearchState,
-    offset: number = 0,
-    length: number
-) {
+function buildProfilesBaseParams(state: SearchState) {
     const selectedCountryNames = getFilterNamesOfType(
         state.filters,
         FilterType.COUNTRY
@@ -346,12 +369,23 @@ export async function queryProfiles(
         ...formatTopicFacetFilters(selectedTopics),
     ]
 
+    return {
+        indexName: PAGES_INDEX,
+        query: state.query,
+        filters: `type:${OwidGdocType.Profile}`,
+        facetFilters,
+    }
+}
+
+export async function queryProfiles(
+    liteSearchClient: LiteClient,
+    state: SearchState,
+    offset: number = 0,
+    length: number
+) {
     const searchParams = [
         {
-            indexName: PAGES_INDEX,
-            query: state.query,
-            filters: `type:${OwidGdocType.Profile}`,
-            facetFilters,
+            ...buildProfilesBaseParams(state),
             attributesToRetrieve: [
                 "title",
                 "thumbnailUrl",
@@ -368,6 +402,63 @@ export async function queryProfiles(
     ]
 
     return searchSingleForHits<ProfileHit>(liteSearchClient, searchParams)
+}
+
+export interface ResultTypeCountsOptions {
+    /** Whether the Writing tab would show topic pages for the current state */
+    includeTopicPages: boolean
+    /** Whether the Writing tab would show profiles for the current state */
+    includeProfiles: boolean
+}
+
+export type ResultTypeCounts = Record<
+    SearchResultType.DATA | SearchResultType.WRITING,
+    number
+>
+
+// Count-only queries: we only read `nbHits`, so no hits, highlighting or
+// Algolia analytics are needed.
+const COUNT_ONLY_PARAMS = {
+    hitsPerPage: 0,
+    attributesToRetrieve: [],
+    attributesToHighlight: [],
+    analytics: false,
+}
+
+/**
+ * Fetches the total number of results behind the "Data" and "Writing" options
+ * of the result type toggle, in a single batched Algolia request. Reuses the
+ * same search parameters as the individual result sections so the counts match
+ * what each tab actually shows.
+ */
+export async function queryResultTypeCounts(
+    liteSearchClient: LiteClient,
+    state: SearchState,
+    options: ResultTypeCountsOptions
+): Promise<ResultTypeCounts> {
+    const writingParams = [
+        buildArticlesBaseParams(state),
+        buildDataInsightsBaseParams(state),
+        ...(options.includeTopicPages
+            ? [buildTopicPagesBaseParams(state)]
+            : []),
+        ...(options.includeProfiles ? [buildProfilesBaseParams(state)] : []),
+    ]
+
+    const searchParams = [buildChartsBaseParams(state), ...writingParams].map(
+        (params) => ({ ...params, ...COUNT_ONLY_PARAMS })
+    )
+
+    const response = await liteSearchClient.searchForHits(searchParams)
+    const [chartsResult, ...writingResults] = response.results
+
+    return {
+        [SearchResultType.DATA]: chartsResult.nbHits ?? 0,
+        [SearchResultType.WRITING]: R.sumBy(
+            writingResults,
+            (result) => result.nbHits ?? 0
+        ),
+    }
 }
 
 export interface LatestPagesResult {

--- a/site/search/searchHooks.ts
+++ b/site/search/searchHooks.ts
@@ -1,10 +1,16 @@
-import { FilterType, SearchState } from "@ourworldindata/types"
+import { FilterType, SearchState, SearchTopicType } from "@ourworldindata/types"
 import {
     getFilterNamesOfType,
     getSelectedTopic,
     getPaginationOffsetAndLength,
     getNbPaginatedItemsRequested,
+    isBrowsing,
 } from "./searchUtils.js"
+import {
+    queryResultTypeCounts,
+    ResultTypeCountsOptions,
+    searchQueryKeys,
+} from "./queries.js"
 import { DEFAULT_SEARCH_STATE } from "./searchState.js"
 import { useSearchContext } from "./SearchContext.js"
 import { fetchJson, flattenNonTopicNodes } from "@ourworldindata/utils"
@@ -211,6 +217,39 @@ export function useInfiniteSearch<THit>({
         hits,
         totalResults,
     }
+}
+
+/**
+ * Fetches the total number of results behind the "Data" and "Writing" options
+ * of the result type toggle. Mirrors the template logic in
+ * SearchTemplatesWriting: topic pages and profiles only count towards the
+ * Writing total when the corresponding template would show them.
+ *
+ * Returns undefined while loading, on error, or when browsing (no query and
+ * no filters), where whole-catalog counts wouldn't be meaningful.
+ */
+export function useResultTypeCounts() {
+    const { state, liteSearchClient, templateConfig } = useSearchContext()
+    const { topicType, hasCountry, hasQuery } = templateConfig
+
+    const options: ResultTypeCountsOptions = {
+        // The Writing template hides topic pages when filtering by country
+        // without a topic or query (see SearchTemplatesWriting).
+        includeTopicPages: !(topicType === null && hasCountry && !hasQuery),
+        // Profiles are only shown when a country is selected and the selected
+        // topic is not an area (see SearchTemplatesWriting).
+        includeProfiles: hasCountry && topicType !== SearchTopicType.Area,
+    }
+
+    const { data } = useQuery({
+        queryKey: searchQueryKeys.resultTypeCounts(state, options),
+        queryFn: () => queryResultTypeCounts(liteSearchClient, state, options),
+        enabled:
+            !templateConfig.hasDatasetFilters &&
+            !isBrowsing(state.filters, state.query),
+    })
+
+    return data
 }
 
 export function useTopicTagGraph({ isPreviewing }: { isPreviewing: boolean }) {


### PR DESCRIPTION
## Context

The "Filter by type of content: All / Data / Writing" toggle on /search didn't tell users how many results are behind each option. This PR adds result counts to the Data and Writing options — e.g. "Data (123)" / "Writing (45)" — so users can see at a glance where the hits are before switching tabs.

How it works:

- A new `queryResultTypeCounts` in `site/search/queries.ts` issues a single batched, count-only Algolia request (`hitsPerPage: 0`, no highlighting, `analytics: false` so the extra queries don't pollute Algolia analytics). "Data" is the charts-index total; "Writing" sums articles/about pages, data insights, topic pages, and profiles from the pages index.
- To keep the counts consistent with what each tab actually renders, the search-parameter building of the existing per-section queries (charts, articles, data insights, topic pages, profiles) is extracted into shared `build*BaseParams` helpers that both the result queries and the count query reuse. The individual section queries are behaviorally unchanged.
- A new `useResultTypeCounts` hook mirrors the template logic from `SearchTemplatesWriting`: topic pages are excluded from the Writing count when filtering by country without a topic or query, and profiles are only included when a country is selected and the selected topic isn't an area.
- Counts are not requested while browsing (no query and no filters — whole-catalog totals aren't meaningful there) or when dataset filters hide the toggle. While loading (or on error) the labels gracefully fall back to plain "Data" / "Writing". Counts are formatted with `commafyNumber`, matching the section headers.

## Screenshots / Videos / Diagrams

No layout changes — the counts are appended to the existing radio button labels, e.g. "Data (1,234)".

## Testing guidance

1. Go to /search and search for something, e.g. "energy".
2. The toggle should read "All / Data (n) / Writing (m)", with n matching the chart results total and m matching the sum of the Research & Writing and Data Insights section totals.
3. Add a country filter (e.g. Germany) and verify the counts update and still match the section totals on the Writing tab (including Country Profiles).
4. Add a topic filter and verify the same.
5. Clear the query and all filters (browse mode): the toggle should show plain "Data / Writing" without counts.
6. Apply a dataset filter (e.g. from a producer link): the toggle stays hidden as before.

## Checklist

### Before merging

- [ ] Changes to HTML were checked for accessibility concerns


---
_Generated by [Claude Code](https://claude.ai/code/session_01AzpoNoPXWcrqhemYQ7m3BM)_