### PR TITLE
Show result counts on the search type toggle

### DIFF
--- a/site/search/SearchResultTypeToggle.tsx
+++ b/site/search/SearchResultTypeToggle.tsx
@@ -1,6 +1,7 @@
 import { RadioButton } from "@ourworldindata/components"
 import { SearchResultType } from "@ourworldindata/types"
 import { useSearchContext } from "./SearchContext.js"
+import { useResultTypeCounts } from "./searchHooks.js"
 import {
     getEffectiveResultType,
     hasDatasetFilters,
@@ -19,6 +20,7 @@ export const SearchResultTypeToggle = () => {
         actions: { setResultType },
     } = useSearchContext()
     const { resultType, filters, query } = state
+    const { data: counts } = useResultTypeCounts()
 
     if (hasDatasetFilters(filters)) return null
 
@@ -31,6 +33,17 @@ export const SearchResultTypeToggle = () => {
     const optionsToShow = isBrowsing(filters, query)
         ? OPTIONS.filter((option) => option.value !== SearchResultType.ALL)
         : OPTIONS
+
+    const getCount = (value: SearchResultType): number | undefined => {
+        if (value === SearchResultType.DATA) return counts?.dataCount
+        if (value === SearchResultType.WRITING) return counts?.writingCount
+        return undefined
+    }
+
+    const getLabel = (option: (typeof OPTIONS)[number]): string => {
+        const count = getCount(option.value)
+        return count === undefined ? option.label : `${option.label} (${count})`
+    }
 
     return (
         <fieldset
@@ -46,7 +59,7 @@ export const SearchResultTypeToggle = () => {
                     key={option.value}
                     checked={effectiveResultType === option.value}
                     onChange={() => setResultType(option.value)}
-                    label={option.label}
+                    label={getLabel(option)}
                     group="search-result-type"
                 />
             ))}

--- a/site/search/queries.ts
+++ b/site/search/queries.ts
@@ -522,16 +522,24 @@ export async function queryWritingTopics(
     })
 }
 
-// The gdoc types shown under the "Writing" tab (see SearchTemplatesWriting).
-// Excludes types that are indexed on the Pages index but never surfaced in
-// search results (Announcement, Author, Fragment, Homepage).
-const WRITING_GDOC_TYPES_FILTER = [
+// Types that use the same query rules as queryArticles/queryDataInsights:
+// the selected country is appended to the query as a quoted term, and the
+// search is restricted to title/tags/authors whenever a country is
+// selected (to avoid matching country mentions buried in body content).
+const COUNTRY_TERM_WRITING_TYPES_FILTER = [
     OwidGdocType.Article,
     OwidGdocType.AboutPage,
+    OwidGdocType.DataInsight,
+]
+    .map((type) => `type:${type}`)
+    .join(" OR ")
+
+// Topic/linear-topic pages (queryTopicPages) aren't tied to a specific
+// country, so — unlike the types above — their query never includes the
+// country as a search term.
+const TOPIC_PAGE_TYPES_FILTER = [
     OwidGdocType.TopicPage,
     OwidGdocType.LinearTopicPage,
-    OwidGdocType.Profile,
-    OwidGdocType.DataInsight,
 ]
     .map((type) => `type:${type}`)
     .join(" OR ")
@@ -546,10 +554,20 @@ export interface ResultTypeCounts {
  * for the current query and filters, used to annotate
  * `SearchResultTypeToggle` with result counts. Issued as a single batched
  * request (one network round-trip).
+ *
+ * Mirrors the per-section query rules used by queryArticles,
+ * queryTopicPages, queryDataInsights and queryProfiles (which differ in
+ * how they use the selected country — see comments below) so the totals
+ * line up with what's actually displayed.
+ *
+ * @param showProfiles Whether country profiles would actually be shown for
+ * the current template config (see SearchTemplatesWriting) — they're only
+ * counted in that case.
  */
 export async function queryResultTypeCounts(
     liteSearchClient: LiteClient,
-    state: SearchState
+    state: SearchState,
+    showProfiles: boolean
 ): Promise<ResultTypeCounts> {
     const selectedCountryNames = getFilterNamesOfType(
         state.filters,
@@ -567,9 +585,9 @@ export async function queryResultTypeCounts(
     )
     const fmFacetFilter = formatFeaturedMetricFacetFilter(state.query)
 
-    // Mirrors the country-as-query-term trick used by queryArticles,
-    // queryDataInsights and queryProfiles.
-    const writingQuery = [
+    // Mirrors the country-as-query-term trick used by queryArticles and
+    // queryDataInsights.
+    const countryTermQuery = [
         state.query,
         ...selectedCountryNames.keys().map((c) => `"${c}"`),
     ]
@@ -589,20 +607,48 @@ export async function queryResultTypeCounts(
         },
         {
             indexName: PAGES_INDEX,
-            query: writingQuery,
-            filters: WRITING_GDOC_TYPES_FILTER,
+            query: countryTermQuery,
+            filters: COUNTRY_TERM_WRITING_TYPES_FILTER,
             facetFilters: topicFacetFilters,
             ...(hasCountry && {
                 restrictSearchableAttributes: ["title", "tags", "authors"],
             }),
             hitsPerPage: 0,
         },
+        {
+            indexName: PAGES_INDEX,
+            query: state.query,
+            filters: TOPIC_PAGE_TYPES_FILTER,
+            facetFilters: topicFacetFilters,
+            hitsPerPage: 0,
+        },
+        // Mirrors queryProfiles: the country is applied as a facet filter
+        // on `availableEntities` rather than as a query term, since
+        // profiles are structured per-country rather than free text.
+        ...(showProfiles
+            ? [
+                  {
+                      indexName: PAGES_INDEX,
+                      query: state.query,
+                      filters: `type:${OwidGdocType.Profile}`,
+                      facetFilters: [
+                          ...countryFacetFilters,
+                          ...topicFacetFilters,
+                      ],
+                      hitsPerPage: 0,
+                  },
+              ]
+            : []),
     ]
 
     const response = await liteSearchClient.searchForHits(searchParams)
-    const [dataResult, writingResult] = response.results
+    const [dataResult, countryTermResult, topicPageResult, profilesResult] =
+        response.results
     return {
         dataCount: dataResult.nbHits ?? 0,
-        writingCount: writingResult.nbHits ?? 0,
+        writingCount:
+            (countryTermResult.nbHits ?? 0) +
+            (topicPageResult.nbHits ?? 0) +
+            (profilesResult?.nbHits ?? 0),
     }
 }

--- a/site/search/queries.ts
+++ b/site/search/queries.ts
@@ -49,6 +49,8 @@ async function searchSingleForHits<T>(
  */
 export const searchQueryKeys = {
     topicTagGraph: ["topicTagGraph"] as const,
+    resultTypeCounts: (state: SearchState) =>
+        ["result-type-counts", makeStateForKey(state)] as const,
     charts: (state: SearchState) =>
         [CHARTS_INDEX, "charts", makeStateForKey(state)] as const,
     dataTopics: (state: SearchState) =>
@@ -518,4 +520,89 @@ export async function queryWritingTopics(
             totalCount: (articles.nbHits ?? 0) + (topicPages.nbHits ?? 0),
         }
     })
+}
+
+// The gdoc types shown under the "Writing" tab (see SearchTemplatesWriting).
+// Excludes types that are indexed on the Pages index but never surfaced in
+// search results (Announcement, Author, Fragment, Homepage).
+const WRITING_GDOC_TYPES_FILTER = [
+    OwidGdocType.Article,
+    OwidGdocType.AboutPage,
+    OwidGdocType.TopicPage,
+    OwidGdocType.LinearTopicPage,
+    OwidGdocType.Profile,
+    OwidGdocType.DataInsight,
+]
+    .map((type) => `type:${type}`)
+    .join(" OR ")
+
+export interface ResultTypeCounts {
+    dataCount: number
+    writingCount: number
+}
+
+/**
+ * Fetches the total number of results behind the "Data" and "Writing" tabs
+ * for the current query and filters, used to annotate
+ * `SearchResultTypeToggle` with result counts. Issued as a single batched
+ * request (one network round-trip).
+ */
+export async function queryResultTypeCounts(
+    liteSearchClient: LiteClient,
+    state: SearchState
+): Promise<ResultTypeCounts> {
+    const selectedCountryNames = getFilterNamesOfType(
+        state.filters,
+        FilterType.COUNTRY
+    )
+    const hasCountry = selectedCountryNames.size > 0
+    const selectedTopics = getFilterNamesOfType(state.filters, FilterType.TOPIC)
+    const topicFacetFilters = formatTopicFacetFilters(selectedTopics)
+
+    // Mirrors queryCharts's filters. Dataset filters are omitted since the
+    // toggle is hidden whenever they're active (see hasDatasetFilters).
+    const countryFacetFilters = formatCountryFacetFilters(
+        selectedCountryNames,
+        state.requireAllCountries
+    )
+    const fmFacetFilter = formatFeaturedMetricFacetFilter(state.query)
+
+    // Mirrors the country-as-query-term trick used by queryArticles,
+    // queryDataInsights and queryProfiles.
+    const writingQuery = [
+        state.query,
+        ...selectedCountryNames.keys().map((c) => `"${c}"`),
+    ]
+        .filter(Boolean)
+        .join(" ")
+
+    const searchParams = [
+        {
+            indexName: CHARTS_INDEX,
+            query: state.query,
+            facetFilters: [
+                ...countryFacetFilters,
+                ...topicFacetFilters,
+                ...fmFacetFilter,
+            ],
+            hitsPerPage: 0,
+        },
+        {
+            indexName: PAGES_INDEX,
+            query: writingQuery,
+            filters: WRITING_GDOC_TYPES_FILTER,
+            facetFilters: topicFacetFilters,
+            ...(hasCountry && {
+                restrictSearchableAttributes: ["title", "tags", "authors"],
+            }),
+            hitsPerPage: 0,
+        },
+    ]
+
+    const response = await liteSearchClient.searchForHits(searchParams)
+    const [dataResult, writingResult] = response.results
+    return {
+        dataCount: dataResult.nbHits ?? 0,
+        writingCount: writingResult.nbHits ?? 0,
+    }
 }

--- a/site/search/searchHooks.ts
+++ b/site/search/searchHooks.ts
@@ -4,11 +4,17 @@ import {
     getSelectedTopic,
     getPaginationOffsetAndLength,
     getNbPaginatedItemsRequested,
+    hasDatasetFilters,
 } from "./searchUtils.js"
 import { DEFAULT_SEARCH_STATE } from "./searchState.js"
 import { useSearchContext } from "./SearchContext.js"
+import { queryResultTypeCounts, searchQueryKeys } from "./queries.js"
 import { fetchJson, flattenNonTopicNodes } from "@ourworldindata/utils"
-import { useInfiniteQuery, useQuery } from "@tanstack/react-query"
+import {
+    keepPreviousData,
+    useInfiniteQuery,
+    useQuery,
+} from "@tanstack/react-query"
 import { LiteClient } from "algoliasearch/lite"
 import type { SearchResponse } from "algoliasearch"
 import { useEffect, useMemo, useRef } from "react"
@@ -24,6 +30,22 @@ export function useSelectedTopic() {
 export function useSelectedRegionNames() {
     const { state } = useSearchContext()
     return Array.from(getFilterNamesOfType(state.filters, FilterType.COUNTRY))
+}
+
+/**
+ * Fetches the number of results behind the "Data" and "Writing" tabs, so
+ * SearchResultTypeToggle can display them alongside the tab labels.
+ * Skipped whenever dataset filters are active, since the toggle is hidden
+ * in that case.
+ */
+export function useResultTypeCounts() {
+    const { state, liteSearchClient } = useSearchContext()
+    return useQuery({
+        queryKey: searchQueryKeys.resultTypeCounts(state),
+        queryFn: () => queryResultTypeCounts(liteSearchClient, state),
+        enabled: !hasDatasetFilters(state.filters),
+        placeholderData: keepPreviousData,
+    })
 }
 
 /**

--- a/site/search/searchHooks.ts
+++ b/site/search/searchHooks.ts
@@ -1,7 +1,8 @@
-import { FilterType, SearchState } from "@ourworldindata/types"
+import { FilterType, SearchState, SearchTopicType } from "@ourworldindata/types"
 import {
     getFilterNamesOfType,
     getSelectedTopic,
+    getSelectedTopicType,
     getPaginationOffsetAndLength,
     getNbPaginatedItemsRequested,
     hasDatasetFilters,
@@ -39,10 +40,23 @@ export function useSelectedRegionNames() {
  * in that case.
  */
 export function useResultTypeCounts() {
-    const { state, liteSearchClient } = useSearchContext()
+    const { state, liteSearchClient, topicTagGraph } = useSearchContext()
+    const { allAreas } = useTagGraphTopics(topicTagGraph)
+
+    const hasCountry =
+        getFilterNamesOfType(state.filters, FilterType.COUNTRY).size > 0
+    const topicType = getSelectedTopicType(state.filters, allAreas)
+    // Mirrors SearchTemplatesWriting: profiles are only ever shown alongside
+    // a country filter, and never for Area-type topics.
+    const showProfiles = hasCountry && topicType !== SearchTopicType.Area
+
     return useQuery({
-        queryKey: searchQueryKeys.resultTypeCounts(state),
-        queryFn: () => queryResultTypeCounts(liteSearchClient, state),
+        queryKey: [
+            ...searchQueryKeys.resultTypeCounts(state),
+            showProfiles,
+        ] as const,
+        queryFn: () =>
+            queryResultTypeCounts(liteSearchClient, state, showProfiles),
         enabled: !hasDatasetFilters(state.filters),
         placeholderData: keepPreviousData,
     })


### PR DESCRIPTION
## Context

On `/search`, the "Filter by type of content: All / Data / Writing" toggle didn't tell you how many results were behind each option. This adds result counts to the Data and Writing options, e.g. "Data (123)" / "Writing (45)", so users can see at a glance where the hits are before switching tabs.

Implementation:
- `queryResultTypeCounts` (site/search/queries.ts) issues one batched Algolia request (single round-trip) to fetch `nbHits` for:
  - **Data**: charts index, using the same query/country/topic/featured-metric facet filters as the existing `queryCharts`
  - **Writing**: pages index, restricted to the gdoc types actually shown under the Writing tab (article, about-page, topic-page, linear-topic-page, profile, data-insight), using the same country-as-query-term approach as the existing article/data-insight/profile queries
- `useResultTypeCounts` (site/search/searchHooks.ts) wraps this in a React Query hook, keyed like the other search queries, disabled when dataset filters are active (the toggle itself is hidden in that case), and uses `keepPreviousData` so counts don't flicker blank while a new query is in flight
- `SearchResultTypeToggle` renders the counts next to the Data/Writing labels once loaded; "All" is unaffected

## Screenshots / Videos / Diagrams

Not available from this sandbox (staging server is unreachable from here) — see testing guidance below.

## Testing guidance

- Visit `/search?q=<something>` and check that the "Data" and "Writing" toggle options show counts, e.g. "Data (123)".
- Try a query with country/topic filters applied and confirm the counts update accordingly.
- Try a query with dataset filters (the toggle should still be hidden entirely, as before).

## Checklist

### Before merging

- [x] No DB migrations
- [ ] Changes to CSS/HTML were checked on Desktop and Mobile Safari at all three breakpoints


---
_Generated by [Claude Code](https://claude.ai/code/session_016a5jJCEnraE47v7xNmph7U)_