### PR TITLE
📜🤖 Harden cloud-sandbox agent guidance in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@
 - yarn test run --reporter dot: run unit tests. Uses vitest, can take one or more test filenames to only run a subset.
 - make migrate: apply migrations
 - make dbtest: run database and api tests
-- make up.headless: start the dev environment (MySQL via docker, admin server on :3030, vite on :8090) without tmux, servers run in the background with logs in logs/. Use this when you need the running site or database and no dev environment is up yet — e.g. in cloud sandboxes. Stop it with make down.headless. Never run it on a developer machine where a dev environment may already be running (check with pgrep -f adminSiteServer first) — it kills existing dev servers.
+- make up.headless: start the dev environment (MySQL via docker, admin server on :3030, vite on :8090) without tmux, servers run in the background with logs in logs/. Use this when you need the running site or database and no dev environment is up yet — e.g. in cloud sandboxes. The environment is ready when the output prints `Dev environment is up` — wait for that exact line; don't grep for vite/admin startup patterns, they never appear in this output. Stop it with make down.headless. Never run it on a developer machine where a dev environment may already be running (check with pgrep -f adminSiteServer first) — it kills existing dev servers.
 
 When you want to create a git commit, refer to docs/agent-guidelines/commit-messages.md for instructions.
 
@@ -29,13 +29,14 @@ When creating new skills in `.claude/skills/`, always include `metadata: { inter
 
 Notes for sessions running in a Claude Code cloud sandbox (`CLAUDE_CODE_REMOTE=true`):
 
+- The sandbox pre-creates a session branch named `claude/<slug>-<random-suffix>`, which violates the branch-naming rules above. Rename it before the first push: `git branch -m <short-descriptive-name>`.
 - Use `make up.headless` when you need the running site or database. If the sandbox snapshot has a pre-imported native MySQL (the usual case), it starts within a few minutes. Only the docker fallback is slow: a cold run downloads the DB dump and imports it (10-20 minutes) and can outlive a command timeout — run it in the background, and if it gets killed anyway, just re-run it: every step is idempotent and resumes where it left off.
 - The snapshot's database can be up to a week older than the code. After `make up.headless`, run `make migrate` to apply any migrations merged since — it's idempotent and takes seconds. If pages still 500 on missing tables/columns, `make refresh` re-imports a fresh dump (10-20 minutes).
 - `ALGOLIA_ID` and `ALGOLIA_SEARCH_KEY` are provided as environment variables (public, search-only credentials), so local site search works. Never scrape API keys out of deployed JS bundles.
 - Chart thumbnails on site pages are served by a Cloudflare function that doesn't run locally. `GRAPHER_DYNAMIC_THUMBNAIL_URL` and `EXPLORER_DYNAMIC_THUMBNAIL_URL` are usually provided as environment variables pointing at the production ones; if they're absent and thumbnails are missing, set them in `.env` to `https://ourworldindata.org/grapher` and `https://ourworldindata.org/explorers`.
 - To screenshot a locally served page, use `node devTools/screenshot/screenshotPage.mjs <url> <out.png>`. The sandbox routes outbound HTTPS through an egress proxy that resets Chromium's TLS handshake; the script works around this by routing external requests through Playwright's Node-side request context.
 - Staging servers are on Tailscale and unreachable from the sandbox, and local ports cannot be exposed to the user. Verify changes with typecheck, unit tests, and the local dev environment (plus screenshots).
-- After pushing a branch, tell the user where to review the change on the branch's staging server, deep-linked to the affected page — e.g. `http://staging-site-<branch>/search?q=malaria` (branch name with slashes turned into hyphens, truncated to 28 characters). Mention that the staging server takes a while to build after a push, especially the first one.
+- After pushing a branch, tell the user where to review the change on the branch's staging server, deep-linked to the affected page — e.g. `http://staging-site-<name>/search?q=malaria`. Don't derive the staging name by hand; compute it with `node -e 'const b=process.argv[1].replace(/[/._]/g,"-");console.log(("staging-site-"+b.slice(0,28)).replace(/-+$/,""))' "$(git branch --show-current)"`. Mention that the staging server takes a while to build after a push, especially the first one.
 
 # Codebase overview
 


### PR DESCRIPTION
## Context

Follow-up to #6738 based on the first real claude.ai/code cloud-sandbox session that used `make up.headless` (the one that produced #6742). The session succeeded, but three agent-guidance gaps in CLAUDE.md cost time or produced wrong output:

1. **No documented readiness signal for `make up.headless`.** The agent grepped its log for vite/admin startup patterns (`vite.*ready`, `listening`, …) that never appear in the recipe's output, so its watcher never fired and it fell back to a blind 270-second sleep — roughly 5 wasted minutes after the environment was already up. CLAUDE.md now names the exact ready line: `Dev environment is up`.

2. **The platform-created `claude/...` branch bypasses our branch-naming rules.** claude.ai/code creates the session branch (prefix + random suffix) before the agent runs, so the existing "no `claude/` prefix" instruction — which only covers branches the agent creates itself — never applied. The sandbox section now says to rename the branch (`git branch -m`) before the first push.

3. **Staging-server names were hand-truncated instead of computed.** The agent produced two different wrong names in one session (`...type-toggle-cou`, 29 chars, and `...type-tog`, 22 chars); the correct name is the 28-char truncation `staging-site-claude-search-type-toggle-co` (verified live: it's the one that responds). The prose rule is replaced with a `node -e` one-liner that mirrors the logic in `devTools/db-ai-helpers/query.ts`.

## Testing guidance

- The one-liner reproduces the live staging name for the #6742 session branch: `node -e '...' "claude/search-type-toggle-counts-t2j5od"` → `staging-site-claude-search-type-toggle-co` (HTTP 200 over Tailscale).
- Docs-only change otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
