### PR TITLE
Show result counts on the search type toggle

### DIFF
--- a/site/search/SearchResultTypeToggle.scss
+++ b/site/search/SearchResultTypeToggle.scss
@@ -13,6 +13,10 @@
         }
     }
 
+    .search-result-type-toggle__count {
+        color: $blue-40;
+    }
+
     @include sm-only {
         margin-left: 0;
         margin-bottom: 24px;

--- a/site/search/SearchResultTypeToggle.tsx
+++ b/site/search/SearchResultTypeToggle.tsx
@@ -1,6 +1,8 @@
+import { commafyNumber } from "@ourworldindata/utils"
 import { RadioButton } from "@ourworldindata/components"
 import { SearchResultType } from "@ourworldindata/types"
 import { useSearchContext } from "./SearchContext.js"
+import { useResultTypeCounts } from "./searchHooks.js"
 import {
     getEffectiveResultType,
     hasDatasetFilters,
@@ -20,7 +22,10 @@ export const SearchResultTypeToggle = () => {
     } = useSearchContext()
     const { resultType, filters, query } = state
 
-    if (hasDatasetFilters(filters)) return null
+    const showToggle = !hasDatasetFilters(filters)
+    const { data: counts } = useResultTypeCounts({ enabled: showToggle })
+
+    if (!showToggle) return null
 
     const effectiveResultType = getEffectiveResultType(
         filters,
@@ -32,6 +37,13 @@ export const SearchResultTypeToggle = () => {
         ? OPTIONS.filter((option) => option.value !== SearchResultType.ALL)
         : OPTIONS
 
+    const countForOption = (value: SearchResultType): number | undefined => {
+        if (!counts) return undefined
+        if (value === SearchResultType.DATA) return counts.dataCount
+        if (value === SearchResultType.WRITING) return counts.writingCount
+        return undefined
+    }
+
     return (
         <fieldset
             className="search-result-type-toggle"
@@ -41,15 +53,29 @@ export const SearchResultTypeToggle = () => {
             <legend className="search-result-type-toggle__legend">
                 Filter by type of content:
             </legend>
-            {optionsToShow.map((option) => (
-                <RadioButton
-                    key={option.value}
-                    checked={effectiveResultType === option.value}
-                    onChange={() => setResultType(option.value)}
-                    label={option.label}
-                    group="search-result-type"
-                />
-            ))}
+            {optionsToShow.map((option) => {
+                const count = countForOption(option.value)
+                return (
+                    <RadioButton
+                        key={option.value}
+                        checked={effectiveResultType === option.value}
+                        onChange={() => setResultType(option.value)}
+                        label={
+                            count === undefined ? (
+                                option.label
+                            ) : (
+                                <>
+                                    {option.label}{" "}
+                                    <span className="search-result-type-toggle__count">
+                                        ({commafyNumber(count)})
+                                    </span>
+                                </>
+                            )
+                        }
+                        group="search-result-type"
+                    />
+                )
+            })}
         </fieldset>
     )
 }

--- a/site/search/queries.ts
+++ b/site/search/queries.ts
@@ -63,6 +63,8 @@ export const searchQueryKeys = {
         [PAGES_INDEX, "topics", makeStateForKey(state)] as const,
     profiles: (state: SearchState) =>
         [PAGES_INDEX, "profiles", makeStateForKey(state)] as const,
+    resultTypeCounts: (state: SearchState) =>
+        ["result-type-counts", makeStateForKey(state)] as const,
 } as const
 
 export const latestPagesQueryKey = {
@@ -368,6 +370,126 @@ export async function queryProfiles(
     ]
 
     return searchSingleForHits<ProfileHit>(liteSearchClient, searchParams)
+}
+
+export interface ResultTypeCounts {
+    dataCount: number
+    writingCount: number
+}
+
+// Issues one batched `searchForHits` call (single network round-trip) to get
+// the total number of matching results behind the "Data" and "Writing"
+// result-type options, so the toggle can show e.g. "Data (123)". Each
+// sub-query mirrors the facet filters of its corresponding content query
+// (queryCharts, queryDataInsights, queryArticles, queryTopicPages,
+// queryProfiles) but requests zero hits since only `nbHits` is needed.
+export async function queryResultTypeCounts(
+    liteSearchClient: LiteClient,
+    state: SearchState
+): Promise<ResultTypeCounts> {
+    const selectedCountryNames = getFilterNamesOfType(
+        state.filters,
+        FilterType.COUNTRY
+    )
+    const hasCountry = selectedCountryNames.size > 0
+    const selectedTopics = getFilterNamesOfType(state.filters, FilterType.TOPIC)
+    const countryFacetFilters = formatCountryFacetFilters(
+        selectedCountryNames,
+        state.requireAllCountries
+    )
+    const topicFacetFilters = formatTopicFacetFilters(selectedTopics)
+
+    const chartsFacetFilters = [
+        ...countryFacetFilters,
+        ...topicFacetFilters,
+        ...formatDisjunctiveFacetFilters(
+            getFilterNamesOfType(state.filters, FilterType.DATASET_PRODUCT),
+            "datasetProducts"
+        ),
+        ...formatDisjunctiveFacetFilters(
+            getFilterNamesOfType(state.filters, FilterType.DATASET_NAMESPACE),
+            "datasetNamespaces"
+        ),
+        ...formatDisjunctiveFacetFilters(
+            getFilterNamesOfType(state.filters, FilterType.DATASET_VERSION),
+            "datasetVersions"
+        ),
+        ...formatDisjunctiveFacetFilters(
+            getFilterNamesOfType(state.filters, FilterType.DATASET_PRODUCER),
+            "datasetProducers"
+        ),
+        ...formatFeaturedMetricFacetFilter(state.query),
+    ]
+
+    // Data insights and articles aren't tagged with countries directly, so
+    // selected countries are folded into the text query as exact phrases
+    // (mirrors queryDataInsights/queryArticles).
+    const textQueryWithCountries = [
+        state.query,
+        ...selectedCountryNames.keys().map((c) => `"${c}"`),
+    ]
+        .filter(Boolean)
+        .join(" ")
+    const restrictSearchableAttributes = hasCountry
+        ? { restrictSearchableAttributes: ["title", "tags", "authors"] }
+        : {}
+
+    const searchParams = [
+        // Data: charts
+        {
+            indexName: CHARTS_INDEX,
+            query: state.query,
+            facetFilters: chartsFacetFilters,
+            hitsPerPage: 0,
+        },
+        // Writing: data insights
+        {
+            indexName: PAGES_INDEX,
+            query: textQueryWithCountries,
+            filters: `type:${OwidGdocType.DataInsight}`,
+            facetFilters: topicFacetFilters,
+            ...restrictSearchableAttributes,
+            hitsPerPage: 0,
+        },
+        // Writing: articles
+        {
+            indexName: PAGES_INDEX,
+            query: textQueryWithCountries,
+            filters: `type:${OwidGdocType.Article} OR type:${OwidGdocType.AboutPage}`,
+            facetFilters: topicFacetFilters,
+            ...restrictSearchableAttributes,
+            hitsPerPage: 0,
+        },
+        // Writing: topic pages
+        {
+            indexName: PAGES_INDEX,
+            query: state.query,
+            filters: `type:${OwidGdocType.TopicPage} OR type:${OwidGdocType.LinearTopicPage}`,
+            facetFilters: topicFacetFilters,
+            hitsPerPage: 0,
+        },
+        // Writing: profiles
+        {
+            indexName: PAGES_INDEX,
+            query: state.query,
+            filters: `type:${OwidGdocType.Profile}`,
+            facetFilters: [...countryFacetFilters, ...topicFacetFilters],
+            hitsPerPage: 0,
+        },
+    ]
+
+    const response = await liteSearchClient.searchForHits<unknown>(searchParams)
+    const [charts, dataInsights, articles, topicPages, profiles] =
+        response.results
+
+    return {
+        dataCount: charts.nbHits ?? 0,
+        writingCount:
+            (dataInsights.nbHits ?? 0) +
+            (articles.nbHits ?? 0) +
+            (topicPages.nbHits ?? 0) +
+            (profiles.nbHits ?? 0),
+    }
 }
 
 export interface LatestPagesResult {

--- a/site/search/searchHooks.ts
+++ b/site/search/searchHooks.ts
@@ -6,6 +6,7 @@ import {
     getNbPaginatedItemsRequested,
 } from "./searchUtils.js"
 import { DEFAULT_SEARCH_STATE } from "./searchState.js"
+import { searchQueryKeys, queryResultTypeCounts } from "./queries.js"
 import { useSearchContext } from "./SearchContext.js"
 import { fetchJson, flattenNonTopicNodes } from "@ourworldindata/utils"
 import { useInfiniteQuery, useQuery } from "@tanstack/react-query"
@@ -211,6 +212,19 @@ export function useInfiniteSearch<THit>({
         hits,
         totalResults,
     }
+}
+
+/**
+ * Total result counts for the "Data" and "Writing" result-type options,
+ * used to annotate the SearchResultTypeToggle (e.g. "Data (123)").
+ */
+export function useResultTypeCounts({ enabled = true }: { enabled?: boolean }) {
+    const { state, liteSearchClient } = useSearchContext()
+    return useQuery({
+        queryKey: searchQueryKeys.resultTypeCounts(state),
+        queryFn: () => queryResultTypeCounts(liteSearchClient, state),
+        enabled,
+    })
 }
 
 export function useTopicTagGraph({ isPreviewing }: { isPreviewing: boolean }) {


### PR DESCRIPTION
## Context

On `/search`, the "Filter by type of content: All / Data / Writing" toggle didn't show how many results were behind each option. This adds counts to the Data and Writing options (e.g. "Data (123)") so users can see at a glance where the hits are before switching tabs.

Implementation: a single batched Algolia `searchForHits` call (`queryResultTypeCounts` in `site/search/queries.ts`) requests `hitsPerPage: 0` against the charts index and each of the pages-index content types (data insights, articles, topic pages, profiles), mirroring the facet filters of the existing content queries. The result is exposed via a new `useResultTypeCounts` hook and rendered in `SearchResultTypeToggle`.

## Screenshots / Videos / Diagrams

Toggle with an active query (`?q=malaria`): shows "Data (30)" / "Writing (40)", matching the "(30 results)" / "(34 results)" + "(6 results)" headers shown on each tab.

Toggle while browsing (no query, no filters): shows "Data (11,836)" / "Writing (1,029)".

## Testing guidance

- [ ] Visit `/search?q=<query>` and confirm the Data/Writing counts match the result headers shown on each tab
- [ ] Visit `/search` with no query (browsing mode) and confirm counts still render
- [ ] Select a country or topic filter and confirm counts update accordingly
- [ ] Confirm no counts are shown when a dataset filter is active (toggle is hidden entirely in that case, unchanged from before)

**Reminder to annotate the PR diff with design notes, alternatives you considered, and any other helpful context.**

## Checklist

### Before merging

- [x] Changes to CSS/HTML were checked on Desktop (verified locally via screenshots); mobile breakpoints not separately checked


---
_Generated by [Claude Code](https://claude.ai/code/session_015rbAXureDS4Khbr1fysfwc)_