### PR TITLE
enhance(archive): speed up archive runs on staging servers

### DIFF
--- a/baker/archival/archiveChangedPages.ts
+++ b/baker/archival/archiveChangedPages.ts
@@ -34,6 +34,7 @@ import {
     ArchivalTimestamp,
     OwidChartDimensionInterface,
     AssetMap,
+    excludeNullish,
 } from "@ourworldindata/utils"
 import { insertArchivedChartVersions } from "../../db/model/ArchivedChartVersion.js"
 import { insertArchivedExplorerVersions } from "../../db/model/ArchivedExplorerVersion.js"
@@ -263,7 +264,12 @@ const getGraphersToArchive = async (
             opts.chartIds.join(", ")
         )
 
-        const allChecksums = await getGrapherChecksumsFromDb(trx)
+        const charts = await getEnrichedChartsByIds(trx, opts.chartIds)
+        const slugs = excludeNullish(
+            charts.map((chart) => chart.config.slug).filter((slug) => slug)
+        )
+
+        const allChecksums = await getGrapherChecksumsFromDb(trx, slugs)
         const graphersToArchive = allChecksums.filter((checksum) =>
             opts.chartIds?.includes(checksum.chartId)
         )

--- a/baker/archival/archiveChangedPages.ts
+++ b/baker/archival/archiveChangedPages.ts
@@ -199,7 +199,7 @@ const getPostsToArchive = async (
 
     if ((postSlugs && postSlugs.length > 0) || force) {
         const { postChecksums: allChecksums, imagesByPostId: allImages } =
-            await getPostChecksumsFromDb(trx)
+            await getPostChecksumsFromDb(trx, postSlugs)
 
         let postsToArchive = allChecksums
         if (postSlugs && postSlugs.length > 0) {

--- a/baker/archival/createWikipediaArchive.ts
+++ b/baker/archival/createWikipediaArchive.ts
@@ -3,6 +3,7 @@ import fs from "fs-extra"
 import yargs from "yargs"
 import { hideBin } from "yargs/helpers"
 import pMap from "p-map"
+import * as R from "remeda"
 import { ARCHIVE_BASE_URL } from "../../settings/clientSettings.js"
 import { WIKIPEDIA_ARCHIVE_BASE_URL } from "../../settings/serverSettings.js"
 
@@ -104,8 +105,9 @@ async function createWikipediaArchive(opts: {
     if (dryRun) console.log("(dry run — no files will be written)")
 
     const files = await walkDir(inputDir)
-    const htmlFiles = files.filter((f) => f.endsWith(".html"))
-    const otherFiles = files.filter((f) => !f.endsWith(".html"))
+    const [htmlFiles, otherFiles] = R.partition(files, (f) =>
+        f.endsWith(".html")
+    )
 
     console.log(
         `Found ${files.length} files (${htmlFiles.length} HTML, ${otherFiles.length} other)`

--- a/db/model/Gdoc/GdocProfile.ts
+++ b/db/model/Gdoc/GdocProfile.ts
@@ -18,7 +18,7 @@ import {
 import * as db from "../../db.js"
 import { GdocBase } from "./GdocBase.js"
 import { loadAndClearLinkedCallouts } from "./dataCallouts.js"
-import { PreparedCalloutTable } from "@ourworldindata/grapher"
+import type { PreparedCalloutTable } from "@ourworldindata/grapher"
 
 const GENERIC_PROFILE_SCOPES = new Set<OwidGdocProfileScope>([
     "countries",

--- a/db/model/Gdoc/dataCallouts.ts
+++ b/db/model/Gdoc/dataCallouts.ts
@@ -1,10 +1,10 @@
 import {
     fetchInputTableForConfig,
     getEntityNamesParam,
-    GrapherProgrammaticInterface,
+    type GrapherProgrammaticInterface,
     prepareCalloutTable,
     constructGrapherValuesJsonFromTable,
-    PreparedCalloutTable,
+    type PreparedCalloutTable,
 } from "@ourworldindata/grapher"
 import { OwidTable } from "@ourworldindata/core-table"
 import {

--- a/db/model/archival/archivalDb.ts
+++ b/db/model/archival/archivalDb.ts
@@ -854,17 +854,22 @@ function collectVariableIdsFromIndicators(
 }
 
 export async function getPostChecksumsFromDb(
-    knex: db.KnexReadonlyTransaction
+    knex: db.KnexReadonlyTransaction,
+    postSlugs?: string[]
 ): Promise<{
     postChecksums: PostChecksumsObjectWithHash[]
     imagesByPostId: Record<string, ArchivalImage[]>
 }> {
     // Phase 1: Fetch all posts and their linked content
-    const posts = await knex<DbRawPostGdoc>(PostsGdocsTableName)
+    let postsQuery = knex<DbRawPostGdoc>(PostsGdocsTableName)
         .select("id", "slug", "contentMd5")
         .where("published", true)
         .where("publishedAt", "<=", knex.fn.now())
         .where("type", OwidGdocType.Article)
+    if (postSlugs?.length) {
+        postsQuery = postsQuery.whereIn("slug", postSlugs)
+    }
+    const posts = await postsQuery
 
     if (posts.length === 0) return { postChecksums: [], imagesByPostId: {} }
 

--- a/packages/@ourworldindata/grapher/src/core/PeerCountrySelection.ts
+++ b/packages/@ourworldindata/grapher/src/core/PeerCountrySelection.ts
@@ -21,7 +21,7 @@ import {
 import { CoreColumn } from "@ourworldindata/core-table"
 import { WORLD_ENTITY_NAME } from "./GrapherConstants.js"
 import { match } from "ts-pattern"
-import { GrapherState } from "./GrapherState.js"
+import type { GrapherState } from "./GrapherState.js"
 
 interface SelectDefaultEntitiesAsPeersParams {
     defaultSelection: EntityName[]


### PR DESCRIPTION
Speeds up the staging server archive runs considerably, mostly by filtering the diffing down to just the requested slugs or IDs (especially useful for `posts`!).