### PR TITLE
🐛 Restore "Related research & writing" on old-design data pages

### DIFF
--- a/site/DataPageV2Content.tsx
+++ b/site/DataPageV2Content.tsx
@@ -255,6 +255,12 @@ export const DataPageV2Content = ({
                     {!useNewDatapageDesign && (
                         <>
                             <div className="col-start-2 span-cols-12">
+                                {relatedResearch &&
+                                    relatedResearch.length > 0 && (
+                                        <DataPageResearchAndWriting
+                                            relatedResearch={relatedResearch}
+                                        />
+                                    )}
                                 {datapageData.allCharts &&
                                 datapageData.allCharts.length > 0 ? (
                                     <div


### PR DESCRIPTION
## Problem

#6579 (the datapage redesign experiment) moved `DataPageResearchAndWriting` inside the `useNewDatapageDesign` branch of `DataPageV2Content`. Since it shipped on 2026-07-01, **every data page outside the 10-page `data-page-metadata-v1` experiment has been baked without its "Related research and writing" section** (check e.g. [/grapher/child-mortality](https://ourworldindata.org/grapher/child-mortality)).

The removal is unmistakable in analytics: R&W link clicks on a fixed set of 10 old-design data pages went from **149 in June to 1 in July** (~0.46 clicks per 100 page views → 0), while other article-link clicks on the same pages stayed stable — so this is the component disappearing, not a tracking change.

## Fix

Render `DataPageResearchAndWriting` in the `!useNewDatapageDesign` branch, in its original pre-#6579 position (top of the all-charts/metadata column). The new-design rendering is untouched.

Pages will pick the section back up as they're rebaked.

## Testing

- `yarn typecheck` passes.
- The JSX restored is identical to the pre-#6579 markup (same wrapper div, same guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)