### PR TITLE
Disable InnoDB redo log during atomic staging DB refresh imports

### DIFF
--- a/devTools/docker/atomic-grapher-data.sh
+++ b/devTools/docker/atomic-grapher-data.sh
@@ -47,8 +47,22 @@ _mysql() {
     fi
 }
 
+# This loads hundreds of thousands of rows in one go, which can outpace InnoDB's
+# redo log checkpointer (especially with the small default innodb_redo_log_capacity)
+# and stall every other connection on the instance. Disabling redo logging for the
+# duration is safe here: $2 is always a throwaway database (NEW_DB, or
+# GRAPHER_DB_NAME on first-time setup before it holds anything) that gets dropped
+# and retried on failure, never the live, already-swapped-in database.
 import_db() {
+    _mysql -e "ALTER INSTANCE DISABLE INNODB REDO_LOG;"
+    # Run with errexit off so a failing import doesn't abort the script here and
+    # skip the re-enable below, leaving the instance without crash-recoverable logging.
+    set +o errexit
     cat $1 | gunzip | sed s/.\*DEFINER\=\`.\*// | grep -vF GLOBAL.GTID_PURGED | _mysql $2
+    local status=$?
+    set -o errexit
+    _mysql -e "ALTER INSTANCE ENABLE INNODB REDO_LOG;"
+    return $status
 }
 
 # Import the private sidecar dump into the replacement DB *before* the atomic

--- a/devTools/docker/atomic-grapher-data.sh
+++ b/devTools/docker/atomic-grapher-data.sh
@@ -55,12 +55,15 @@ _mysql() {
 # and retried on failure, never the live, already-swapped-in database.
 import_db() {
     _mysql -e "ALTER INSTANCE DISABLE INNODB REDO_LOG;"
-    # Run with errexit off so a failing import doesn't abort the script here and
-    # skip the re-enable below, leaving the instance without crash-recoverable logging.
+    # Covers both a failing import (errexit off below so we reach the re-enable)
+    # and the import being killed outright (CI timeout, operator abort): the trap
+    # fires on that exit/signal too, so redo logging never stays off instance-wide.
+    trap '_mysql -e "ALTER INSTANCE ENABLE INNODB REDO_LOG;" 2>/dev/null || true' EXIT INT TERM
     set +o errexit
     cat $1 | gunzip | sed s/.\*DEFINER\=\`.\*// | grep -vF GLOBAL.GTID_PURGED | _mysql $2
     local status=$?
     set -o errexit
+    trap - EXIT INT TERM
     _mysql -e "ALTER INSTANCE ENABLE INNODB REDO_LOG;"
     return $status
 }


### PR DESCRIPTION
## Summary
- `staging-site-master` was stuck on a week-old commit (Jul 7) despite 46 commits landing on `master` since — root cause traced back to MySQL, not Buildkite.
- `atomic-grapher-data.sh`'s bulk import (700k+ rows from `owid_metadata.sql.gz` into a throwaway temp DB) outpaces InnoDB's redo log checkpointer under the default 100MB `innodb_redo_log_capacity`, stalling every other MySQL client on the instance for ~1-2 minutes per refresh.
- On `staging-site-master` this cascaded into `deploy-queue` connection drops ("Connection lost: The server closed the connection" / `ECONNREFUSED`), which prevented any deploy from ever completing.
- Fix: wrap `import_db` in `ALTER INSTANCE DISABLE/ENABLE INNODB REDO_LOG`. Safe here because `import_db`'s target is always a disposable database (`NEW_DB`, or `GRAPHER_DB_NAME` pre-swap on first-time setup) that gets dropped and retried on failure — never the live, already-swapped-in database.

## Test plan
- [x] Verified `owid`'s MySQL user already has the `INNODB_REDO_LOG_ENABLE` dynamic privilege on `staging-site-master` (no grant needed)
- [x] Ran the full atomic refresh (`DATA_FOLDER=tmp-downloads`, real ~700k-row dump) against `staging-site-master` with the fix applied
- [x] Confirmed zero "unable to reserve space in redo log" / "waiting for a new redo log file" warnings in mysql's error log during the ~2.5 min import (previously recurred every run)
- [x] Confirmed no new `deploy-queue` connection errors during the test window
- [x] Confirmed MySQL healthy and swapped-in data queryable after (`SELECT COUNT(*) FROM owid.variables` → 774469 rows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)