### PR TITLE
Surface tag graph placement in admin tag editors

### DIFF
--- a/adminSiteClient/ChartEditor.ts
+++ b/adminSiteClient/ChartEditor.ts
@@ -25,6 +25,7 @@ import {
     References,
 } from "./AbstractChartEditor.js"
 import { Admin } from "./Admin.js"
+import { MinimalTagWithMetadata } from "./TagGraphMetadata.js"
 
 export interface Log {
     userId: number
@@ -69,7 +70,7 @@ export interface ChartEditorManager extends AbstractChartEditorManager {
     redirects: ChartRedirect[]
     views?: AnalyticsGrapherViewWithRank
     tags?: DbChartTagJoin[]
-    availableTags?: DbChartTagJoin[]
+    availableTags?: MinimalTagWithMetadata[]
     forceDatapage?: boolean
 }
 

--- a/adminSiteClient/ChartEditorPage.tsx
+++ b/adminSiteClient/ChartEditorPage.tsx
@@ -6,7 +6,7 @@ import {
     type AnalyticsGrapherViewWithRank,
     GrapherInterface,
     ChartRedirect,
-    MinimalTagWithIsTopic,
+    MinimalTagWithMetadata,
     DbChartTagJoin,
 } from "@ourworldindata/types"
 import { Admin } from "./Admin.js"
@@ -57,7 +57,7 @@ export class ChartEditorPage
     redirects: ChartRedirect[] = []
     views: AnalyticsGrapherViewWithRank | undefined = undefined
     tags: DbChartTagJoin[] | undefined = undefined
-    availableTags: MinimalTagWithIsTopic[] | undefined = undefined
+    availableTags: MinimalTagWithMetadata[] | undefined = undefined
     forceDatapage: boolean | undefined = undefined
     variableIdsByCatalogPath: Record<string, number | null> | undefined =
         undefined

--- a/adminSiteClient/ChartList.tsx
+++ b/adminSiteClient/ChartList.tsx
@@ -18,6 +18,10 @@ import {
     SortOrder,
 } from "@ourworldindata/types"
 import { ChartRow } from "./ChartRow.js"
+import {
+    getTagGraphRolesById,
+    MinimalTagWithMetadata,
+} from "./TagGraphMetadata.js"
 import { References } from "./AbstractChartEditor.js"
 import {
     SearchWord,
@@ -79,7 +83,7 @@ export class ChartList extends React.Component<ChartListProps> {
     searchInput: string | undefined = undefined
     maxVisibleCharts = 50
     sortConfig: SortConfig | undefined = undefined
-    availableTags: DbChartTagJoin[] = []
+    availableTags: MinimalTagWithMetadata[] | undefined = undefined
 
     constructor(props: ChartListProps) {
         super(props)
@@ -225,6 +229,7 @@ export class ChartList extends React.Component<ChartListProps> {
             searchInput,
         } = this
         const { availableTags } = this
+        const tagGraphRolesById = getTagGraphRolesById(availableTags ?? [])
 
         const highlight = highlightFunctionForSearchWords(this.searchWords)
         const hasMoreCharts = this.chartsFiltered.length > this.maxVisibleCharts
@@ -338,16 +343,20 @@ export class ChartList extends React.Component<ChartListProps> {
                         </tr>
                     </thead>
                     <tbody>
-                        {chartsToShow.map((chart) => (
-                            <ChartRow
-                                chart={chart}
-                                key={chart.id}
-                                availableTags={availableTags}
-                                searchHighlight={highlight}
-                                onDelete={this.onDeleteChart}
-                                showInheritanceColumn={showInheritanceColumn}
-                            />
-                        ))}
+                        {availableTags &&
+                            chartsToShow.map((chart) => (
+                                <ChartRow
+                                    chart={chart}
+                                    key={chart.id}
+                                    availableTags={availableTags}
+                                    tagGraphRolesById={tagGraphRolesById}
+                                    searchHighlight={highlight}
+                                    onDelete={this.onDeleteChart}
+                                    showInheritanceColumn={
+                                        showInheritanceColumn
+                                    }
+                                />
+                            ))}
                     </tbody>
                 </table>
                 {hasMoreCharts && (

--- a/adminSiteClient/ChartRow.tsx
+++ b/adminSiteClient/ChartRow.tsx
@@ -19,11 +19,16 @@ import {
     excludeUndefined,
 } from "@ourworldindata/utils"
 import { Dropdown } from "antd"
+import {
+    getTagGraphRolesById,
+    MinimalTagWithMetadata,
+} from "./TagGraphMetadata.js"
 
 interface ChartRowProps {
     chart: ChartListItem
     searchHighlight?: (text: string) => string | React.ReactElement
-    availableTags: DbChartTagJoin[]
+    availableTags: MinimalTagWithMetadata[]
+    tagGraphRolesById: ReturnType<typeof getTagGraphRolesById>
     onDelete: (chart: ChartListItem) => void
     showInheritanceColumn?: boolean
 }
@@ -55,8 +60,13 @@ export class ChartRow extends React.Component<ChartRowProps> {
     }
 
     override render() {
-        const { chart, searchHighlight, availableTags, showInheritanceColumn } =
-            this.props
+        const {
+            chart,
+            searchHighlight,
+            availableTags,
+            tagGraphRolesById,
+            showInheritanceColumn,
+        } = this.props
 
         const highlight = searchHighlight || lodash.identity
 
@@ -123,6 +133,7 @@ export class ChartRow extends React.Component<ChartRowProps> {
                     <EditableTags
                         tags={chart.tags}
                         suggestions={availableTags}
+                        tagGraphRolesById={tagGraphRolesById}
                         onSave={this.onSaveTags}
                         hasKeyChartSupport
                         hasSuggestionsSupport

--- a/adminSiteClient/CreateDataInsightModal.tsx
+++ b/adminSiteClient/CreateDataInsightModal.tsx
@@ -40,7 +40,7 @@ import { ApiNarrativeChartOverview } from "../adminShared/AdminTypes"
 import {
     downloadImage,
     MinimalTag,
-    MinimalTagWithIsTopic,
+    MinimalTagWithMetadata,
     RequiredBy,
 } from "@ourworldindata/utils"
 import { match } from "ts-pattern"
@@ -442,7 +442,7 @@ export function CreateDataInsightModal(props: {
         if (!hasTopicTagsField) return
 
         const fetchTags = () =>
-            admin.getJSON<{ tags: MinimalTagWithIsTopic[] }>("/api/tags.json")
+            admin.getJSON<{ tags: MinimalTagWithMetadata[] }>("/api/tags.json")
 
         void fetchTags().then((result) =>
             setAllTopicTags(result.tags.filter((tag) => tag.isTopic))

--- a/adminSiteClient/DataInsightIndexPage.tsx
+++ b/adminSiteClient/DataInsightIndexPage.tsx
@@ -47,7 +47,7 @@ import {
     GrapherChartOrMapType,
     OwidGdocDataInsightIndexItem,
     MinimalTag,
-    MinimalTagWithIsTopic,
+    MinimalTagWithMetadata,
 } from "@ourworldindata/types"
 import { copyToClipboard, dayjs, RequiredBy } from "@ourworldindata/utils"
 import {
@@ -63,6 +63,7 @@ import {
 import { ReuploadImageForDataInsightModal } from "./ReuploadImageForDataInsightModal.js"
 import { CreateDataInsightModal } from "./CreateDataInsightModal.js"
 import { EditableTags } from "./EditableTags.js"
+import { getTagGraphRolesById } from "./TagGraphMetadata.js"
 
 type NarrativeDataInsightIndexItem = RequiredBy<
     OwidGdocDataInsightIndexItem,
@@ -95,7 +96,8 @@ const plusIcon = <FontAwesomeIcon icon={faPlus} size="sm" />
 const NotificationContext = createContext(null)
 
 function createColumns(ctx: {
-    availableTopicTags: MinimalTag[]
+    availableTopicTags: MinimalTagWithMetadata[]
+    tagGraphRolesById: ReturnType<typeof getTagGraphRolesById>
     updateTags: (gdocId: string, tags: MinimalTag[]) => Promise<void>
     highlightFn: (
         text: string | null | undefined
@@ -180,6 +182,7 @@ function createColumns(ctx: {
                         ctx.updateTags(dataInsight.id, tags as MinimalTag[])
                     }
                     suggestions={ctx.availableTopicTags}
+                    tagGraphRolesById={ctx.tagGraphRolesById}
                 />
             ),
         },
@@ -293,8 +296,16 @@ export function DataInsightIndexPage() {
     const [dataInsights, setDataInsights, refreshDataInsights] =
         useDataInsights(admin)
 
-    const [availableTopicTags, setAvailableTopicTags] = useState<MinimalTag[]>(
-        []
+    const [availableTags, setAvailableTags] = useState<
+        MinimalTagWithMetadata[] | undefined
+    >(undefined)
+    const availableTopicTags = useMemo(
+        () => availableTags?.filter((tag) => tag.isTopic),
+        [availableTags]
+    )
+    const tagGraphRolesById = useMemo(
+        () => getTagGraphRolesById(availableTags ?? []),
+        [availableTags]
     )
 
     const [searchValue, setSearchValue] = useState("")
@@ -466,13 +477,22 @@ export function DataInsightIndexPage() {
             dataInsight: DataInsightIndexItemThatCanBeUploaded
         ) => setDataInsightForImageUpload(dataInsight)
 
+        if (!availableTags || !availableTopicTags) return []
+
         return createColumns({
             availableTopicTags,
+            tagGraphRolesById,
             updateTags,
             highlightFn,
             triggerImageUploadFlow,
         })
-    }, [searchWords, availableTopicTags, updateTags])
+    }, [
+        searchWords,
+        availableTags,
+        availableTopicTags,
+        tagGraphRolesById,
+        updateTags,
+    ])
 
     const updateDataInsightPreview = (
         dataInsightId: string,
@@ -522,11 +542,9 @@ export function DataInsightIndexPage() {
 
     useEffect(() => {
         const fetchTags = () =>
-            admin.getJSON<{ tags: MinimalTagWithIsTopic[] }>("/api/tags.json")
+            admin.getJSON<{ tags: MinimalTagWithMetadata[] }>("/api/tags.json")
 
-        void fetchTags().then((result) =>
-            setAvailableTopicTags(result.tags.filter((tag) => tag.isTopic))
-        )
+        void fetchTags().then((result) => setAvailableTags(result.tags))
     }, [admin])
 
     return (
@@ -552,10 +570,12 @@ export function DataInsightIndexPage() {
                             <Select
                                 value={topicTagFilter}
                                 placeholder="Select a topic tag..."
-                                options={availableTopicTags.map((tag) => ({
-                                    value: tag.name,
-                                    label: tag.name,
-                                }))}
+                                options={(availableTopicTags ?? []).map(
+                                    (tag) => ({
+                                        value: tag.name,
+                                        label: tag.name,
+                                    })
+                                )}
                                 onChange={(tag: string) =>
                                     setTopicTagFilter(tag)
                                 }

--- a/adminSiteClient/DatasetEditPage.tsx
+++ b/adminSiteClient/DatasetEditPage.tsx
@@ -10,6 +10,7 @@ import { AdminLayout } from "./AdminLayout.js"
 import { Link } from "./Link.js"
 import { BindString, Toggle, FieldsRow, Timeago, TextField } from "./Forms.js"
 import { EditableTags } from "./EditableTags.js"
+import { MinimalTagWithMetadata } from "./TagGraphMetadata.js"
 import { ChartList, ChartListItem } from "./ChartList.js"
 import { OriginList } from "./OriginList.js"
 import { SourceList } from "./SourceList.js"
@@ -82,7 +83,7 @@ interface DatasetPageData {
     metadataEditedByUserId: number
     metadataEditedByUserName: string
 
-    availableTags: { id: number; name: string }[]
+    availableTags: MinimalTagWithMetadata[]
     tags: { id: number; name: string }[]
     variables: VariableListItem[]
     charts: ChartListItem[]
@@ -363,10 +364,7 @@ class MultiDimList extends Component<MultiDimListProps> {
 
 interface DatasetTagEditorProps {
     newDataset: DatasetEditable
-    availableTags: {
-        id: number
-        name: string
-    }[]
+    availableTags: MinimalTagWithMetadata[]
 }
 
 @observer

--- a/adminSiteClient/DatasetList.tsx
+++ b/adminSiteClient/DatasetList.tsx
@@ -8,6 +8,10 @@ import { Link } from "./Link.js"
 import { AdminAppContext, AdminAppContextType } from "./AdminAppContext.js"
 import { Timeago } from "./Forms.js"
 import { EditableTags } from "./EditableTags.js"
+import {
+    getTagGraphRolesById,
+    MinimalTagWithMetadata,
+} from "./TagGraphMetadata.js"
 
 export interface DatasetListItem {
     id: number
@@ -28,7 +32,8 @@ export interface DatasetListItem {
 
 interface DatasetRowProps {
     dataset: DatasetListItem
-    availableTags: DbChartTagJoin[]
+    availableTags: MinimalTagWithMetadata[]
+    tagGraphRolesById: ReturnType<typeof getTagGraphRolesById>
     searchHighlight?: (text: string) => string | React.ReactElement
 }
 
@@ -59,7 +64,8 @@ class DatasetRow extends React.Component<DatasetRowProps> {
     }
 
     override render() {
-        const { dataset, searchHighlight, availableTags } = this.props
+        const { dataset, searchHighlight, availableTags, tagGraphRolesById } =
+            this.props
 
         const highlight = searchHighlight || lodash.identity
 
@@ -94,6 +100,7 @@ class DatasetRow extends React.Component<DatasetRowProps> {
                     <EditableTags
                         tags={dataset.tags}
                         suggestions={availableTags}
+                        tagGraphRolesById={tagGraphRolesById}
                         onSave={this.onSaveTags}
                         disabled={dataset.namespace !== "owid"}
                     />
@@ -113,7 +120,7 @@ export class DatasetList extends React.Component<DatasetListProps> {
     static override contextType = AdminAppContext
     declare context: AdminAppContextType
 
-    availableTags: DbChartTagJoin[] = []
+    availableTags: MinimalTagWithMetadata[] | undefined = undefined
 
     constructor(props: DatasetListProps) {
         super(props)
@@ -133,7 +140,8 @@ export class DatasetList extends React.Component<DatasetListProps> {
     }
 
     override render() {
-        const { props } = this
+        const { props, availableTags } = this
+        const tagGraphRolesById = getTagGraphRolesById(availableTags ?? [])
         return (
             <table className="table table-bordered">
                 <thead>
@@ -149,14 +157,16 @@ export class DatasetList extends React.Component<DatasetListProps> {
                     </tr>
                 </thead>
                 <tbody>
-                    {props.datasets.map((dataset) => (
-                        <DatasetRow
-                            dataset={dataset}
-                            availableTags={this.availableTags}
-                            key={dataset.id}
-                            searchHighlight={props.searchHighlight}
-                        />
-                    ))}
+                    {availableTags &&
+                        props.datasets.map((dataset) => (
+                            <DatasetRow
+                                dataset={dataset}
+                                availableTags={availableTags}
+                                tagGraphRolesById={tagGraphRolesById}
+                                key={dataset.id}
+                                searchHighlight={props.searchHighlight}
+                            />
+                        ))}
                 </tbody>
             </table>
         )

--- a/adminSiteClient/EditTags.tsx
+++ b/adminSiteClient/EditTags.tsx
@@ -1,16 +1,22 @@
 import { createRef, Component } from "react"
 import { action, makeObservable } from "mobx"
 import { observer } from "mobx-react"
-import { DbChartTagJoin } from "@ourworldindata/utils"
+import { DbChartTagJoin, TagGraphRole } from "@ourworldindata/utils"
 import {
     ReactTags,
     ReactTagsAPI,
     Tag as TagAutocomplete,
 } from "react-tag-autocomplete"
+import cx from "clsx"
+import {
+    getTagGraphRolesById,
+    MinimalTagWithMetadata,
+} from "./TagGraphMetadata.js"
+import { TagGraphMarker } from "./TagGraphMarker.js"
 
 interface EditTagsProps {
     tags: DbChartTagJoin[]
-    suggestions: DbChartTagJoin[]
+    suggestions: MinimalTagWithMetadata[]
     onDelete: (index: number) => void
     onAdd: (tag: DbChartTagJoin) => void
     onSave: () => void
@@ -42,7 +48,10 @@ export class EditTags extends Component<EditTagsProps> {
     }
 
     onAdd = (tag: TagAutocomplete) => {
-        this.props.onAdd(convertAutocompleteTotag(tag))
+        const suggestion = this.props.suggestions.find(
+            ({ id }) => id === tag.value
+        )
+        if (suggestion) this.props.onAdd(suggestion)
     }
 
     override componentDidMount() {
@@ -58,6 +67,7 @@ export class EditTags extends Component<EditTagsProps> {
 
     override render() {
         const { tags, suggestions } = this.props
+        const tagGraphRolesById = getTagGraphRolesById(suggestions)
         return (
             <div className="EditTags" onClick={this.onClick}>
                 <ReactTags
@@ -66,6 +76,67 @@ export class EditTags extends Component<EditTagsProps> {
                     activateFirstOption
                     onAdd={this.onAdd}
                     onDelete={this.props.onDelete}
+                    renderOption={({
+                        children,
+                        classNames,
+                        option,
+                        ...optionProps
+                    }) => {
+                        const tagGraphRole = getTagGraphRole(
+                            option.value,
+                            tagGraphRolesById
+                        )
+                        return (
+                            <div
+                                {...optionProps}
+                                className={cx(classNames.option, {
+                                    [classNames.optionIsActive]: option.active,
+                                    "react-tags__listbox-option--area":
+                                        tagGraphRole === "area",
+                                    "react-tags__listbox-option--orphan":
+                                        tagGraphRole === "orphan",
+                                })}
+                            >
+                                {tagGraphRole !== "descendant" &&
+                                    tagGraphRole && (
+                                        <TagGraphMarker
+                                            variant={tagGraphRole}
+                                            className="react-tags__graph-marker"
+                                        />
+                                    )}
+                                {children}
+                            </div>
+                        )
+                    }}
+                    renderTag={({ classNames, tag, ...tagProps }) => {
+                        const tagGraphRole = getTagGraphRole(
+                            tag.value,
+                            tagGraphRolesById
+                        )
+                        return (
+                            <button
+                                {...tagProps}
+                                type="button"
+                                className={cx(classNames.tag, {
+                                    "react-tags__tag--area":
+                                        tagGraphRole === "area",
+                                    "react-tags__tag--orphan":
+                                        tagGraphRole === "orphan",
+                                })}
+                            >
+                                <span className={classNames.tagName}>
+                                    {tagGraphRole !== "descendant" &&
+                                        tagGraphRole && (
+                                            <TagGraphMarker
+                                                variant={tagGraphRole}
+                                                className="react-tags__graph-marker"
+                                            />
+                                        )}
+                                    {tag.label}
+                                </span>
+                            </button>
+                        )
+                    }}
                     ref={this.reactTagsApi}
                 />
             </div>
@@ -77,7 +148,10 @@ const convertTagToAutocomplete = (t: DbChartTagJoin) => ({
     value: t.id,
     label: t.name,
 })
-const convertAutocompleteTotag = (t: TagAutocomplete) => ({
-    id: t.value as number,
-    name: t.label,
-})
+
+function getTagGraphRole(
+    value: TagAutocomplete["value"],
+    rolesById: ReturnType<typeof getTagGraphRolesById>
+): TagGraphRole | undefined {
+    return typeof value === "number" ? rolesById.get(value) : undefined
+}

--- a/adminSiteClient/EditableTags.tsx
+++ b/adminSiteClient/EditableTags.tsx
@@ -6,9 +6,15 @@ import {
     KeyChartLevel,
     TaggableType,
     DbChartTagJoin,
+    TagGraphRole,
 } from "@ourworldindata/utils"
 import { TagBadge } from "./TagBadge.js"
 import { EditTags } from "./EditTags.js"
+import {
+    getTagGraphRoleById,
+    getTagGraphRolesById,
+    MinimalTagWithMetadata,
+} from "./TagGraphMetadata.js"
 import { AdminAppContext, AdminAppContextType } from "./AdminAppContext.js"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faEdit, faWandMagicSparkles } from "@fortawesome/free-solid-svg-icons"
@@ -20,7 +26,8 @@ interface TaggableItem {
 
 interface EditableTagsProps {
     tags: DbChartTagJoin[]
-    suggestions: DbChartTagJoin[]
+    suggestions: MinimalTagWithMetadata[]
+    tagGraphRolesById?: ReadonlyMap<number, TagGraphRole>
     onSave: (tags: DbChartTagJoin[]) => void
     disabled?: boolean
     hasKeyChartSupport?: boolean
@@ -134,13 +141,9 @@ export class EditableTags extends React.Component<EditableTagsProps> {
     }
 
     override render() {
-        const { disabled, hasKeyChartSupport, hasSuggestionsSupport } =
-            this.props
-        const { tags } = this
-
-        return (
-            <div className="EditableTags">
-                {this.isEditing ? (
+        if (this.isEditing) {
+            return (
+                <div className="EditableTags">
                     <EditTags
                         tags={this.tags}
                         onAdd={this.onAddTag}
@@ -148,54 +151,67 @@ export class EditableTags extends React.Component<EditableTagsProps> {
                         onSave={this.onToggleEdit}
                         suggestions={this.props.suggestions}
                     />
-                ) : (
-                    <div>
-                        {tags.map((t, i) => (
-                            <TagBadge
-                                onToggleKey={
-                                    hasKeyChartSupport &&
-                                    filterUncategorizedTag(t) &&
-                                    filterUnlistedTag(t)
-                                        ? () => this.onToggleKey(i)
-                                        : undefined
-                                }
-                                onApprove={
-                                    hasSuggestionsSupport &&
-                                    filterUncategorizedTag(t)
-                                        ? () => this.onApprove(i)
-                                        : undefined
-                                }
-                                key={t.id}
-                                tag={t}
-                            />
-                        ))}
-                        {!disabled && (
-                            <>
-                                {hasSuggestionsSupport && (
-                                    <button
-                                        className="btn btn-link EditableTags__action"
-                                        onClick={this.onSuggest}
-                                    >
-                                        <FontAwesomeIcon
-                                            icon={faWandMagicSparkles}
-                                        />
-                                        Suggest
-                                    </button>
-                                )}
+                </div>
+            )
+        }
+
+        const { disabled, hasKeyChartSupport, hasSuggestionsSupport } =
+            this.props
+        const tagGraphRolesById =
+            this.props.tagGraphRolesById ??
+            getTagGraphRolesById(this.props.suggestions)
+        return (
+            <div className="EditableTags">
+                <div>
+                    {this.tags.map((tag, index) => (
+                        <TagBadge
+                            onToggleKey={
+                                hasKeyChartSupport &&
+                                filterUncategorizedTag(tag) &&
+                                filterUnlistedTag(tag)
+                                    ? () => this.onToggleKey(index)
+                                    : undefined
+                            }
+                            onApprove={
+                                hasSuggestionsSupport &&
+                                filterUncategorizedTag(tag)
+                                    ? () => this.onApprove(index)
+                                    : undefined
+                            }
+                            key={tag.id}
+                            tag={tag}
+                            tagGraphRole={getTagGraphRoleById(
+                                tagGraphRolesById,
+                                tag.id
+                            )}
+                        />
+                    ))}
+                    {!disabled && (
+                        <>
+                            {hasSuggestionsSupport && (
                                 <button
                                     className="btn btn-link EditableTags__action"
-                                    onClick={(e) => {
-                                        this.onToggleEdit()
-                                        e.stopPropagation()
-                                    }}
+                                    onClick={this.onSuggest}
                                 >
-                                    <FontAwesomeIcon icon={faEdit} />
-                                    Edit
+                                    <FontAwesomeIcon
+                                        icon={faWandMagicSparkles}
+                                    />
+                                    Suggest
                                 </button>
-                            </>
-                        )}
-                    </div>
-                )}
+                            )}
+                            <button
+                                className="btn btn-link EditableTags__action"
+                                onClick={(event) => {
+                                    this.onToggleEdit()
+                                    event.stopPropagation()
+                                }}
+                            >
+                                <FontAwesomeIcon icon={faEdit} />
+                                Edit tags
+                            </button>
+                        </>
+                    )}
+                </div>
             </div>
         )
     }

--- a/adminSiteClient/EditorBasicTab.tsx
+++ b/adminSiteClient/EditorBasicTab.tsx
@@ -56,6 +56,7 @@ import {
     isIndicatorChartEditorInstance,
 } from "./IndicatorChartEditor.js"
 import { EditableTags } from "./EditableTags.js"
+import { MinimalTagWithMetadata } from "./TagGraphMetadata.js"
 import {
     GDP_PER_CAPITA_CATALOG_PATH,
     POPULATION_CATALOG_PATH,
@@ -534,7 +535,7 @@ class VariablesSection<
 const TagsSection = (props: {
     chartId: number | undefined
     tags: DbChartTagJoin[] | undefined
-    availableTags: DbChartTagJoin[] | undefined
+    availableTags: MinimalTagWithMetadata[] | undefined
     onSaveTags: (tags: DbChartTagJoin[]) => void
 }) => {
     const { chartId, tags, availableTags } = props

--- a/adminSiteClient/ExplorerTagsPage.tsx
+++ b/adminSiteClient/ExplorerTagsPage.tsx
@@ -11,6 +11,10 @@ import {
     ExplorerProgram,
 } from "@ourworldindata/explorer"
 import { EditableTags } from "./EditableTags.js"
+import {
+    getTagGraphRolesById,
+    MinimalTagWithMetadata,
+} from "./TagGraphMetadata.js"
 import cx from "clsx"
 
 type ExplorerWithTags = {
@@ -24,7 +28,7 @@ export class ExplorerTagsPage extends Component {
     declare context: AdminAppContextType
     explorersWithTags: ExplorerWithTags[] = []
     explorers: ExplorerProgram[] = []
-    tags: DbChartTagJoin[] = []
+    tags: MinimalTagWithMetadata[] = []
     newExplorerSlug = ""
     newExplorerTags: DbChartTagJoin[] = []
 
@@ -45,6 +49,10 @@ export class ExplorerTagsPage extends Component {
     }
 
     // Don't show explorers that already have tags
+    @computed get tagGraphRolesById(): ReturnType<typeof getTagGraphRolesById> {
+        return getTagGraphRolesById(this.tags)
+    }
+
     @computed get filteredExplorers() {
         return this.explorers.filter((explorer) => {
             return !this.explorersWithTags.some((e) => e.slug === explorer.slug)
@@ -103,6 +111,9 @@ export class ExplorerTagsPage extends Component {
                                             <EditableTags
                                                 tags={explorer.tags}
                                                 suggestions={this.tags}
+                                                tagGraphRolesById={
+                                                    this.tagGraphRolesById
+                                                }
                                                 onSave={(tags) => {
                                                     void this.saveTags(
                                                         explorer.slug,
@@ -161,6 +172,9 @@ export class ExplorerTagsPage extends Component {
                                         key={this.explorersWithTags.length}
                                         tags={[]}
                                         suggestions={this.tags}
+                                        tagGraphRolesById={
+                                            this.tagGraphRolesById
+                                        }
                                         onSave={(tags) => {
                                             this.newExplorerTags = tags
                                         }}
@@ -189,7 +203,7 @@ export class ExplorerTagsPage extends Component {
 
     async getData() {
         const [{ tags }, explorersWithTags, explorers] = await Promise.all([
-            this.context.admin.getJSON<{ tags: DbChartTagJoin[] }>(
+            this.context.admin.getJSON<{ tags: MinimalTagWithMetadata[] }>(
                 "/api/tags.json"
             ),
             this.context.admin.getJSON<{ explorers: ExplorerWithTags[] }>(

--- a/adminSiteClient/GdocsIndexPage.scss
+++ b/adminSiteClient/GdocsIndexPage.scss
@@ -22,6 +22,15 @@
     margin-right: 8px;
 }
 
+.gdoc-index-item__tagging-warning {
+    display: inline-block;
+    padding: 8px 10px;
+    margin-bottom: 8px;
+    color: #754500;
+    font-size: 0.85rem;
+    background-color: #fff8e1;
+}
+
 .gdoc-index-item__title {
     display: inline;
 }

--- a/adminSiteClient/GdocsIndexPage.tsx
+++ b/adminSiteClient/GdocsIndexPage.tsx
@@ -15,13 +15,14 @@ import {
     faUserPen,
     faBullhorn,
     faFileLines,
+    faTriangleExclamation,
 } from "@fortawesome/free-solid-svg-icons"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import {
-    DbChartTagJoin,
     OwidGdocType,
     checkIsGdocPost,
     OwidGdocIndexItem,
+    MinimalTagWithMetadata,
 } from "@ourworldindata/utils"
 import {
     buildSearchWordsFromSearchString,
@@ -36,6 +37,7 @@ import { GdocsStoreContext } from "./GdocsStoreContext.js"
 import { computed, observable, makeObservable } from "mobx"
 import { BAKED_BASE_URL } from "../settings/clientSettings.js"
 import { GdocsEditLink } from "./GdocsEditLink.js"
+import { getTagGraphRolesById } from "./TagGraphMetadata.js"
 
 const iconGdocTypeMap = {
     [OwidGdocType.Fragment]: <FontAwesomeIcon icon={faPuzzlePiece} />,
@@ -146,6 +148,49 @@ type GdocsSearchFilters = Record<OwidGdocType, boolean> & {
     publishStatus: GdocPublishStatus
 }
 
+function canTagGdoc(gdoc: OwidGdocIndexItem): boolean {
+    return (
+        !!gdoc.type &&
+        ![
+            OwidGdocType.AboutPage,
+            OwidGdocType.Author,
+            OwidGdocType.Fragment,
+            OwidGdocType.Homepage,
+        ].includes(gdoc.type)
+    )
+}
+
+function TagWarning({
+    gdoc,
+    orphanTagIds,
+}: {
+    gdoc: OwidGdocIndexItem
+    orphanTagIds?: ReadonlySet<number>
+}): React.ReactElement | null {
+    let warning
+    if (!gdoc.tags?.length) {
+        warning =
+            "This document has no tags. " +
+            "Without any topic tags, this document will not be filterable in the search or latest page."
+    } else if (
+        orphanTagIds &&
+        gdoc.tags.every((tag) => orphanTagIds.has(tag.id))
+    ) {
+        warning =
+            "This document has only orphan tags. " +
+            "Without any topic tags, this document will not be filterable in the search or latest page."
+    }
+
+    if (!warning) return null
+
+    return (
+        <span className="gdoc-index-item__tagging-warning">
+            <FontAwesomeIcon icon={faTriangleExclamation} />{" "}
+            <span>{warning}</span>
+        </span>
+    )
+}
+
 @observer
 export class GdocsIndexPage extends React.Component<RouteComponentProps> {
     static override contextType = GdocsStoreContext
@@ -187,8 +232,13 @@ export class GdocsIndexPage extends React.Component<RouteComponentProps> {
     }
 
     @computed
-    get tags(): DbChartTagJoin[] {
+    get tags(): MinimalTagWithMetadata[] {
         return this.context?.availableTags || []
+    }
+
+    @computed
+    get tagGraphRolesById(): ReturnType<typeof getTagGraphRolesById> {
+        return getTagGraphRolesById(this.tags)
     }
 
     @computed get allGdocsToShow(): OwidGdocIndexItem[] {
@@ -346,25 +396,31 @@ export class GdocsIndexPage extends React.Component<RouteComponentProps> {
                                 <p className="gdoc-index-item__byline">
                                     {gdoc.authors?.join(", ")}
                                 </p>
-                                <span className="gdoc-index-item__tags">
-                                    {gdoc.type &&
-                                    ![
-                                        OwidGdocType.Fragment,
-                                        OwidGdocType.AboutPage,
-                                    ].includes(gdoc.type) &&
-                                    gdoc.tags ? (
-                                        <EditableTags
-                                            tags={gdoc.tags}
-                                            onSave={(tags) =>
-                                                this.context?.updateTags(
-                                                    gdoc,
-                                                    tags as any
-                                                )
-                                            }
-                                            suggestions={this.tags}
-                                        />
+                                <div className="gdoc-index-item__tags">
+                                    {canTagGdoc(gdoc) ? (
+                                        <>
+                                            <TagWarning
+                                                gdoc={gdoc}
+                                                orphanTagIds={
+                                                    this.context?.orphanTagIds
+                                                }
+                                            />
+                                            <EditableTags
+                                                tags={gdoc.tags ?? []}
+                                                onSave={(tags) =>
+                                                    this.context?.updateTags(
+                                                        gdoc,
+                                                        tags as any
+                                                    )
+                                                }
+                                                suggestions={this.tags}
+                                                tagGraphRolesById={
+                                                    this.tagGraphRolesById
+                                                }
+                                            />
+                                        </>
                                     ) : null}
-                                </span>
+                                </div>
                             </div>
                             <div className="gdoc-index-item__publish-status">
                                 {gdoc.published

--- a/adminSiteClient/GdocsStore.tsx
+++ b/adminSiteClient/GdocsStore.tsx
@@ -1,11 +1,11 @@
-import { action, observable, makeObservable } from "mobx"
+import { action, computed, observable, makeObservable } from "mobx"
 import {
     getOwidGdocFromJSON,
     OwidGdocJSON,
-    DbChartTagJoin,
     OwidGdoc,
     DbPlainTag,
     OwidGdocIndexItem,
+    MinimalTagWithMetadata,
 } from "@ourworldindata/utils"
 import { Admin } from "./Admin.js"
 import {
@@ -22,7 +22,7 @@ import {
  */
 export class GdocsStore {
     gdocs: OwidGdocIndexItem[] = []
-    availableTags: DbChartTagJoin[] = []
+    availableTags: MinimalTagWithMetadata[] = []
     admin: Admin
 
     constructor(admin: Admin) {
@@ -31,6 +31,14 @@ export class GdocsStore {
             availableTags: observable,
         })
         this.admin = admin
+    }
+
+    @computed get orphanTagIds(): Set<number> {
+        return new Set(
+            this.availableTags
+                .filter((tag) => tag.tagGraphRole === "orphan")
+                .map((tag) => tag.id)
+        )
     }
 
     @action
@@ -81,10 +89,10 @@ export class GdocsStore {
 
     @action
     async fetchTags() {
-        const json = await this.admin.getJSON<{ tags: DbChartTagJoin[] }>(
-            "/api/tags.json"
-        )
-        this.availableTags = json.tags
+        const { tags } = await this.admin.getJSON<{
+            tags: MinimalTagWithMetadata[]
+        }>("/api/tags.json")
+        this.availableTags = tags
     }
 
     @action

--- a/adminSiteClient/TagBadge.tsx
+++ b/adminSiteClient/TagBadge.tsx
@@ -1,6 +1,10 @@
 import * as React from "react"
 import { observer } from "mobx-react"
-import { KeyChartLevel, DbChartTagJoin } from "@ourworldindata/utils"
+import {
+    KeyChartLevel,
+    DbChartTagJoin,
+    TagGraphRole,
+} from "@ourworldindata/utils"
 
 import { Link } from "./Link.js"
 import Tippy from "@tippyjs/react"
@@ -8,12 +12,14 @@ import { TagBucketSortingIcon } from "./TagBucketSortingIcon.js"
 import cx from "clsx"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faClock } from "@fortawesome/free-solid-svg-icons"
+import { TagGraphMarker } from "./TagGraphMarker.js"
 
 interface TagBadgeProps {
     tag: DbChartTagJoin
     onToggleKey?: () => void
     onApprove?: () => void
     searchHighlight?: (text: string) => string | React.ReactElement
+    tagGraphRole: TagGraphRole
 }
 
 function levelToDesc(level?: KeyChartLevel): string {
@@ -34,6 +40,7 @@ export const TagBadge = observer(function TagBadge({
     searchHighlight,
     onToggleKey,
     onApprove,
+    tagGraphRole,
 }: TagBadgeProps) {
     const isPending = !tag.isApproved && onApprove
     const keyChartLevelDesc =
@@ -47,9 +54,17 @@ export const TagBadge = observer(function TagBadge({
         <span
             className={cx("TagBadge", {
                 "TagBadge--is-pending": isPending,
+                "TagBadge--is-area": tagGraphRole === "area",
+                "TagBadge--is-orphan": tagGraphRole === "orphan",
             })}
         >
             <Link className="TagBadge__name" to={`/tags/${tag.id}`}>
+                {tagGraphRole !== "descendant" && tagGraphRole && (
+                    <TagGraphMarker
+                        variant={tagGraphRole}
+                        className="TagBadge__graph-icon"
+                    />
+                )}
                 {searchHighlight ? searchHighlight(tag.name) : tag.name}
             </Link>
             {isPending ? (

--- a/adminSiteClient/TagEditPage.tsx
+++ b/adminSiteClient/TagEditPage.tsx
@@ -2,12 +2,12 @@ import { Component } from "react"
 import { observer } from "mobx-react"
 import { observable, computed, runInAction, makeObservable } from "mobx"
 import { Prompt, Redirect } from "react-router-dom"
-import { DbChartTagJoin } from "@ourworldindata/utils"
 import { AdminLayout } from "./AdminLayout.js"
 import { BindString, Timeago, Toggle } from "./Forms.js"
 import { DatasetList, DatasetListItem } from "./DatasetList.js"
 import { ChartList, ChartListItem } from "./ChartList.js"
 import { TagBadge } from "./TagBadge.js"
+import { MinimalTagWithMetadata } from "./TagGraphMetadata.js"
 import { AdminAppContext, AdminAppContextType } from "./AdminAppContext.js"
 import { AutoComplete } from "antd"
 
@@ -18,7 +18,7 @@ interface TagPageData {
     updatedAt: string
     datasets: DatasetListItem[]
     charts: ChartListItem[]
-    children: DbChartTagJoin[]
+    children: MinimalTagWithMetadata[]
     slug: string | null
     searchableInAlgolia: boolean
 }
@@ -232,7 +232,11 @@ class TagEditor extends Component<{
                     <section>
                         <h3>Subcategories</h3>
                         {tag.children.map((c) => (
-                            <TagBadge tag={c} key={c.id} />
+                            <TagBadge
+                                tag={c}
+                                key={c.id}
+                                tagGraphRole={c.tagGraphRole}
+                            />
                         ))}
                     </section>
                 )}

--- a/adminSiteClient/TagGraphMarker.tsx
+++ b/adminSiteClient/TagGraphMarker.tsx
@@ -1,0 +1,25 @@
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import { faCompass, faLinkSlash } from "@fortawesome/free-solid-svg-icons"
+import { ReactElement } from "react"
+
+export function TagGraphMarker({
+    variant,
+    className,
+}: {
+    variant: "area" | "orphan"
+    className: string
+}): ReactElement {
+    const isArea = variant === "area"
+    return (
+        <span
+            className={className}
+            title={
+                isArea
+                    ? "Top-level area used in site navigation"
+                    : "Orphan tag that is not part of the tag graph"
+            }
+        >
+            <FontAwesomeIcon icon={isArea ? faCompass : faLinkSlash} />
+        </span>
+    )
+}

--- a/adminSiteClient/TagGraphMetadata.ts
+++ b/adminSiteClient/TagGraphMetadata.ts
@@ -1,0 +1,18 @@
+import { MinimalTagWithMetadata, TagGraphRole } from "@ourworldindata/types"
+
+export type { MinimalTagWithMetadata } from "@ourworldindata/types"
+
+export function getTagGraphRolesById(
+    tags: readonly MinimalTagWithMetadata[]
+): ReadonlyMap<number, TagGraphRole> {
+    return new Map(tags.map((tag) => [tag.id, tag.tagGraphRole]))
+}
+
+export function getTagGraphRoleById(
+    rolesById: ReadonlyMap<number, TagGraphRole>,
+    tagId: number
+): TagGraphRole {
+    const role = rolesById.get(tagId)
+    if (!role) throw new Error(`Tag graph role not found for tag ${tagId}`)
+    return role
+}

--- a/adminSiteClient/TagGraphPage.tsx
+++ b/adminSiteClient/TagGraphPage.tsx
@@ -11,7 +11,7 @@ import {
 import * as lodash from "lodash-es"
 import { AdminLayout } from "./AdminLayout.js"
 import {
-    MinimalTagWithIsTopic,
+    MinimalTagWithMetadata,
     TagGraphNode,
     TagGraphRoot,
     createTagGraph,
@@ -89,7 +89,7 @@ function DraggableDroppable(props: {
 }
 
 interface AddChildFormProps {
-    tags: MinimalTagWithIsTopic[]
+    tags: MinimalTagWithMetadata[]
     label: string
     setChild: (parentId: number, childId: number) => void
     parentId: number
@@ -173,8 +173,8 @@ interface TagGraphNodeContainerProps {
     setWeight: (parentId: number, childId: number, weight: number) => void
     setChild: (parentId: number, childId: number) => void
     removeNode: (parentId: number, childId: number) => void
-    tags: MinimalTagWithIsTopic[]
-    parentsById: Record<string, MinimalTagWithIsTopic[]>
+    tags: MinimalTagWithMetadata[]
+    parentsById: Record<string, MinimalTagWithMetadata[]>
     disableDroppable?: boolean
 }
 
@@ -218,6 +218,8 @@ class TagGraphNodeContainer extends React.Component<TagGraphNodeContainerProps> 
 
     override render() {
         const { id, name, path, children, weight, isTopic } = this.props.node
+        const tag = this.props.tags.find((tag) => tag.id === id)
+        if (!tag) throw new Error(`Tag graph node ${id} not found`)
         const serializedPath = path.join("-")
         return (
             // IDs can't start with a number, so we prefix with "node-"
@@ -228,7 +230,7 @@ class TagGraphNodeContainer extends React.Component<TagGraphNodeContainerProps> 
                 className="tag-box"
                 disableDroppable={this.props.disableDroppable}
             >
-                <TagBadge tag={{ id, name }} />
+                <TagBadge tag={{ id, name }} tagGraphRole={tag.tagGraphRole} />
                 {isTopic ? (
                     <span
                         className="tag-box__is-topic"
@@ -339,16 +341,16 @@ export class TagGraphPage extends React.Component {
     flatTagGraph: FlatTagGraph = {}
     rootId: number | null = null
     addTagParentId: number | undefined = undefined
-    tags: MinimalTagWithIsTopic[] = []
+    tags: MinimalTagWithMetadata[] = []
 
     @computed get tagGraph(): TagGraphRoot | null {
         if (!this.rootId) return null
         return createTagGraph(this.flatTagGraph, this.rootId)
     }
 
-    @computed get parentsById(): Record<string, MinimalTagWithIsTopic[]> {
+    @computed get parentsById(): Record<string, MinimalTagWithMetadata[]> {
         if (!this.tagGraph) return {}
-        const parentsById: Record<string, MinimalTagWithIsTopic[]> = {}
+        const parentsById: Record<string, MinimalTagWithMetadata[]> = {}
         for (const [parentId, children] of Object.entries(this.flatTagGraph)) {
             for (const child of children) {
                 const parent = this.tags.find(
@@ -369,7 +371,7 @@ export class TagGraphPage extends React.Component {
     @computed get nonAreaTags() {
         if (!this.rootId) return []
         const areaTags = this.flatTagGraph[this.rootId]
-        const areaTagIds = areaTags?.map((tag) => tag.childId) || []
+        const areaTagIds = areaTags?.map((tag) => tag.childId) ?? []
         return this.tags.filter((tag) => !areaTagIds.includes(tag.id))
     }
 
@@ -569,7 +571,7 @@ export class TagGraphPage extends React.Component {
         >("/api/flatTagGraph.json")
 
         const tags = await this.context.admin
-            .getJSON<{ tags: MinimalTagWithIsTopic[] }>("/api/tags.json")
+            .getJSON<{ tags: MinimalTagWithMetadata[] }>("/api/tags.json")
             .then((data) => data.tags)
 
         runInAction(() => {

--- a/adminSiteClient/TagsIndexPage.tsx
+++ b/adminSiteClient/TagsIndexPage.tsx
@@ -3,7 +3,7 @@ import { Component } from "react"
 import { AdminLayout } from "./AdminLayout.js"
 import { AdminAppContext, AdminAppContextType } from "./AdminAppContext.js"
 import { observable, runInAction, makeObservable } from "mobx"
-import { DbPlainTag } from "@ourworldindata/types"
+import { MinimalTagWithMetadata } from "@ourworldindata/types"
 import { TagBadge } from "./TagBadge.js"
 import { Link } from "react-router-dom"
 import { Button, Modal } from "antd"
@@ -13,7 +13,7 @@ export class TagsIndexPage extends Component {
     static override contextType = AdminAppContext
     declare context: AdminAppContextType
 
-    tags: DbPlainTag[] = []
+    tags: MinimalTagWithMetadata[] = []
     newTagName = ""
     newTagSlug = ""
     isAddingTag = false
@@ -35,9 +35,9 @@ export class TagsIndexPage extends Component {
     }
 
     async getData() {
-        const result = await this.context.admin.getJSON<{ tags: DbPlainTag[] }>(
-            "/api/tags.json"
-        )
+        const result = await this.context.admin.getJSON<{
+            tags: MinimalTagWithMetadata[]
+        }>("/api/tags.json")
         runInAction(() => {
             this.tags = result.tags
         })
@@ -87,7 +87,7 @@ export class TagsIndexPage extends Component {
 
     override render() {
         return (
-            <AdminLayout title="Categories">
+            <AdminLayout title="Tags">
                 <main className="TagsIndexPage">
                     {this.addTagModal()}
                     <header className="TagsIndexPage__header">
@@ -107,10 +107,8 @@ export class TagsIndexPage extends Component {
                     {this.tags.map((tag) => (
                         <TagBadge
                             key={tag.id}
-                            tag={{
-                                id: tag.id,
-                                name: tag.name,
-                            }}
+                            tag={tag}
+                            tagGraphRole={tag.tagGraphRole}
                         />
                     ))}
                 </main>

--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -1105,6 +1105,27 @@ main:not(.ChartEditorPage):not(.GdocsEditPage):not(.MultiDimDetailPage) {
     border-color: #eb8038;
 }
 
+.TagBadge--is-area {
+    background-color: #e8f1ff;
+}
+
+.TagBadge--is-orphan {
+    background-color: #fff4df;
+}
+
+.TagBadge--is-area .TagBadge__name {
+    color: #1d5c96;
+}
+
+.TagBadge--is-orphan .TagBadge__name {
+    color: #8a5100;
+}
+
+.TagBadge__graph-icon {
+    display: inline-block;
+    margin-right: 4px;
+}
+
 .TagBadge__name {
     color: #333;
 }

--- a/adminSiteClient/styles/react-tag-autocomplete.scss
+++ b/adminSiteClient/styles/react-tag-autocomplete.scss
@@ -172,3 +172,35 @@
     background-color: transparent;
     font-weight: bold;
 }
+
+.react-tags__tag--area {
+    color: #174f83;
+    background-color: #dceaff;
+}
+
+.react-tags__listbox-option--area {
+    color: #174f83;
+    background-color: #eef5ff;
+}
+
+.react-tags__listbox-option--area.is-active {
+    background-color: #dceaff;
+}
+
+.react-tags__tag--orphan {
+    color: #754500;
+    background-color: #ffedc7;
+}
+
+.react-tags__listbox-option--orphan {
+    color: #754500;
+    background-color: #fff7e8;
+}
+
+.react-tags__listbox-option--orphan.is-active {
+    background-color: #ffedc7;
+}
+
+.react-tags__graph-marker {
+    margin-right: 4px;
+}

--- a/adminSiteServer/apiRoutes/datasets.ts
+++ b/adminSiteServer/apiRoutes/datasets.ts
@@ -351,16 +351,7 @@ export async function getDataset(
     )
     dataset.tags = tags
 
-    const availableTags = await db.knexRaw<{
-        id: number
-        name: string
-    }>(
-        trx,
-        `-- sql
-        SELECT t.id, t.name
-        FROM tags t
-        `
-    )
+    const availableTags = await db.getMinimalTagsWithMetadata(trx)
     dataset.availableTags = availableTags
 
     // Fetch explorers that use variables or charts from this dataset

--- a/adminSiteServer/apiRoutes/tags.ts
+++ b/adminSiteServer/apiRoutes/tags.ts
@@ -150,7 +150,19 @@ export async function getTagById(
     `,
         [tag.id]
     )
-    tag.children = children
+    const tagGraphRolesById = new Map(
+        (await db.getMinimalTagsWithMetadata(trx)).map((tag) => [
+            tag.id,
+            tag.tagGraphRole,
+        ])
+    )
+    tag.children = children.map((child) => {
+        const tagGraphRole = tagGraphRolesById.get(child.id)
+        if (!tagGraphRole) {
+            throw new Error(`Tag graph role not found for tag ${child.id}`)
+        }
+        return { ...child, tagGraphRole }
+    })
 
     return { tag }
 }
@@ -249,7 +261,7 @@ export async function getAllTags(
     _res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
 ) {
-    return { tags: await db.getMinimalTagsWithIsTopic(trx) }
+    return { tags: await db.getMinimalTagsWithMetadata(trx) }
 }
 
 export async function deleteTag(

--- a/adminSiteServer/tests/tags.test.ts
+++ b/adminSiteServer/tests/tags.test.ts
@@ -76,50 +76,71 @@ describe("Tag graph and breadcrumbs", { timeout: 15000 }, () => {
     })
 
     it("should be able to see all the tags", async () => {
+        await env.testKnex(TagsTableName).insert([
+            { id: 7, name: "Orphan parent" },
+            { id: 8, name: "Orphan child" },
+        ])
+        await env
+            .testKnex(TagGraphTableName)
+            .insert({ parentId: 7, childId: 8 })
         const tags = await env.fetchJson("/tags.json")
         expect(tags).toEqual({
             tags: [
                 {
                     id: 6,
-                    isTopic: 0,
+                    tagGraphRole: "descendant",
+                    isTopic: false,
                     name: "Climate & Air",
                     slug: null,
-                    isSearchable: 0,
+                    isSearchable: false,
                 },
                 {
                     id: 5,
-                    isTopic: 1,
+                    tagGraphRole: "descendant",
+                    isTopic: true,
                     name: "CO2 & Greenhouse Gas Emissions",
                     slug: "co2-and-greenhouse-gas-emissions",
-                    isSearchable: 1,
+                    isSearchable: true,
                 },
                 {
                     id: 3,
-                    isTopic: 1,
+                    tagGraphRole: "descendant",
+                    isTopic: true,
                     name: "Energy",
                     slug: "energy",
-                    isSearchable: 1,
+                    isSearchable: true,
                 },
                 {
                     id: 2,
-                    isTopic: 0,
+                    tagGraphRole: "area",
+                    isTopic: false,
                     name: "Energy and Environment",
                     slug: null,
-                    isSearchable: 0,
+                    isSearchable: false,
                 },
                 {
                     id: 4,
-                    isTopic: 1,
+                    tagGraphRole: "descendant",
+                    isTopic: true,
                     name: "Nuclear Energy",
                     slug: "nuclear-energy",
-                    isSearchable: 1,
+                    isSearchable: true,
                 },
                 {
-                    id: 1,
-                    isTopic: 0,
-                    name: "tag-graph-root",
+                    id: 8,
+                    tagGraphRole: "orphan",
+                    isTopic: false,
+                    name: "Orphan child",
                     slug: null,
-                    isSearchable: 0,
+                    isSearchable: false,
+                },
+                {
+                    id: 7,
+                    tagGraphRole: "orphan",
+                    isTopic: false,
+                    name: "Orphan parent",
+                    slug: null,
+                    isSearchable: false,
                 },
             ],
         })

--- a/db/db.ts
+++ b/db/db.ts
@@ -23,7 +23,7 @@ import {
     TagGraphRootName,
     FlatTagGraph,
     FlatTagGraphNode,
-    MinimalTagWithIsTopic,
+    MinimalTagWithMetadata,
     DbPlainPostGdocLink,
     ContentGraphLinkType,
     OwidGdoc,
@@ -809,20 +809,55 @@ export async function updateTagGraph(
     }
 }
 
-export function getMinimalTagsWithIsTopic(
+type RawMinimalTagWithMetadata = Omit<
+    MinimalTagWithMetadata,
+    "isTopic" | "isSearchable"
+> & {
+    isTopic: 0 | 1
+    isSearchable: 0 | 1
+}
+
+export function getMinimalTagsWithMetadata(
     knex: KnexReadonlyTransaction
-): Promise<MinimalTagWithIsTopic[]> {
-    return knexRaw<MinimalTagWithIsTopic>(
+): Promise<MinimalTagWithMetadata[]> {
+    return knexRaw<RawMinimalTagWithMetadata>(
         knex,
         `-- sql
+        WITH RECURSIVE tags_in_graph AS (
+            SELECT id
+            FROM tags
+            WHERE name = '${TagGraphRootName}'
+
+            UNION DISTINCT
+
+            SELECT tg.childId
+            FROM tag_graph tg
+            JOIN tags_in_graph parent ON tg.parentId = parent.id
+        )
         SELECT t.id,
         t.name,
         t.slug,
+        CASE
+            WHEN EXISTS (
+                SELECT 1
+                FROM tag_graph tg
+                JOIN tags root ON tg.parentId = root.id
+                WHERE tg.childId = t.id
+                    AND root.name = '${TagGraphRootName}'
+            ) THEN 'area'
+            WHEN NOT EXISTS (
+                SELECT 1
+                FROM tags_in_graph
+                WHERE tags_in_graph.id = t.id
+            ) THEN 'orphan'
+            ELSE 'descendant'
+        END AS tagGraphRole,
         t.slug IS NOT NULL AND MAX(IF(pg.type IN (:types), TRUE, FALSE)) AS isTopic,
         (t.slug IS NOT NULL AND MAX(IF(pg.type IN (:types), TRUE, FALSE))) OR t.searchableInAlgolia AS isSearchable
         FROM tags t
         LEFT JOIN posts_gdocs_x_tags gt ON t.id = gt.tagId
         LEFT JOIN posts_gdocs pg ON gt.gdocId = pg.id
+        WHERE t.name != '${TagGraphRootName}'
         GROUP BY t.id, t.name
         ORDER BY t.name ASC
     `,
@@ -833,6 +868,12 @@ export function getMinimalTagsWithIsTopic(
                 OwidGdocType.Article,
             ],
         }
+    ).then((tags) =>
+        tags.map((tag) => ({
+            ...tag,
+            isTopic: Boolean(tag.isTopic),
+            isSearchable: Boolean(tag.isSearchable),
+        }))
     )
 }
 

--- a/packages/@ourworldindata/types/src/dbTypes/Tags.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/Tags.ts
@@ -15,8 +15,11 @@ export type DbPlainTag = Required<DbInsertTag>
 // For now, this is all the metadata we need for tags in the frontend
 export type MinimalTag = Pick<DbPlainTag, "id" | "name" | "slug">
 
+export type TagGraphRole = "area" | "descendant" | "orphan"
+
 // Used in the tag graph
-export type MinimalTagWithIsTopic = MinimalTag & {
+export type MinimalTagWithMetadata = MinimalTag & {
+    tagGraphRole: TagGraphRole
     isTopic: boolean
     isSearchable: boolean
 }

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -679,8 +679,9 @@ export {
 export {
     type DbInsertTag,
     type DbPlainTag,
-    type MinimalTagWithIsTopic,
+    type MinimalTagWithMetadata,
     type MinimalTag,
+    type TagGraphRole,
     TagsTableName,
 } from "./dbTypes/Tags.js"
 export {


### PR DESCRIPTION
Highlight area and orphan tags across admin tagging interfaces, warn about untagged gdocs, and exclude the tag graph root from suggestions.

## Context

This came up when I was investigating how would current items from the latest feed end up in the new email notifications and I discovered some had missing/orphan tags.

## Screenshots

Examples of the UI changes:

<img width="702" height="120" alt="image" src="https://github.com/user-attachments/assets/c8970109-00ec-4475-8078-0f683d26add1" />

<img width="1258" height="293" alt="image" src="https://github.com/user-attachments/assets/e000dc0a-e48b-417f-90ca-c86ed8a39705" />

<img width="626" height="173" alt="image" src="https://github.com/user-attachments/assets/af295b1a-8a2a-4d35-8e77-51225d6b1810" />

## Testing guidance

Check that it looks sensible and none of the usage of tags in the admin is broken.