### PR TITLE
Add opt-in map option to hide the tooltip tolerance notice

### DIFF
--- a/adminSiteClient/EditorMapTab.tsx
+++ b/adminSiteClient/EditorMapTab.tsx
@@ -182,6 +182,12 @@ class TooltipSection extends Component<{ mapConfig: MapConfig }> {
             : undefined
     }
 
+    @action.bound onHideToleranceNotice(hideToleranceNotice: boolean) {
+        this.props.mapConfig.hideToleranceNotice = hideToleranceNotice
+            ? true
+            : undefined
+    }
+
     override render() {
         const { mapConfig } = this.props
         return (
@@ -192,6 +198,13 @@ class TooltipSection extends Component<{ mapConfig: MapConfig }> {
                     }
                     value={!!mapConfig.tooltipUseCustomLabels}
                     onValue={this.onTooltipUseCustomLabels}
+                />
+                <Toggle
+                    label={
+                        "Hide the notice shown when a value comes from a nearby year (tolerance)"
+                    }
+                    value={!!mapConfig.hideToleranceNotice}
+                    onValue={this.onHideToleranceNotice}
                 />
             </Section>
         )

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapConfig.ts
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapConfig.ts
@@ -46,6 +46,10 @@ class MapConfigDefaults {
     colorScale = new ColorScaleConfig()
     // Show the label from colorSchemeLabels in the tooltip instead of the numeric value
     tooltipUseCustomLabels: boolean | undefined = undefined
+    // Suppress the tooltip notice shown when a value comes from a nearby year
+    // (via tolerance) rather than the selected year. Useful on maps where the
+    // selected time is really a per-entity attribute rather than a time series.
+    hideToleranceNotice: boolean | undefined = undefined
 
     constructor() {
         makeObservable(this, {
@@ -59,6 +63,7 @@ class MapConfigDefaults {
             globe: observable,
             colorScale: observable,
             tooltipUseCustomLabels: observable,
+            hideToleranceNotice: observable,
         })
     }
 }

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapTooltip.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapTooltip.tsx
@@ -212,7 +212,16 @@ export class MapTooltip
         return this.formatTime(originalEndTime)
     }
 
+    @computed private get hideToleranceNotice(): boolean {
+        return !!this.props.manager.mapConfig?.hideToleranceNotice
+    }
+
     @computed private get toleranceNotice(): FooterItem | undefined {
+        // On some maps the selected time is really a per-entity attribute rather
+        // than a time series, so the tolerance notice is misleading and can be
+        // suppressed via the map config.
+        if (this.hideToleranceNotice) return undefined
+
         const { startDatum, startTime, endDatum, endTime } = this
 
         const startValueIsInterpolated =

--- a/packages/@ourworldindata/grapher/src/schema/defaultGrapherConfig.ts
+++ b/packages/@ourworldindata/grapher/src/schema/defaultGrapherConfig.ts
@@ -64,6 +64,7 @@ export const defaultGrapherConfig = {
         },
         toleranceStrategy: "closest",
         tooltipUseCustomLabels: false,
+        hideToleranceNotice: false,
         time: "latest",
         selectedEntityNames: [],
     },

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.010.yaml
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.010.yaml
@@ -348,6 +348,14 @@ properties:
         type: boolean
         default: false
         description: Show the label from colorSchemeLabels in the tooltip instead of the numeric value
+      hideToleranceNotice:
+        type: boolean
+        default: false
+        description: |
+          Hide the tooltip notice that is shown when a value comes from a nearby year (via tolerance) rather than
+          the selected year. Useful on maps where the selected time is really a per-entity attribute (e.g. each country
+          plotted at its own target year) rather than a time series, where the notice would otherwise appear for most
+          countries even though their values are valid.
       time:
         description: Select a specific time to be displayed. If startTime is given, this acts as the end time.
         default: "latest"

--- a/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
+++ b/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
@@ -614,6 +614,7 @@ export interface MapConfigInterface {
     globe?: GlobeConfig
     colorScale?: Partial<ColorScaleConfigInterface>
     tooltipUseCustomLabels?: boolean
+    hideToleranceNotice?: boolean
     selectedEntityNames?: EntityName[]
 }
 


### PR DESCRIPTION
> _Written by Claude Code — @pabloarosado at the wheel._

**Draft / for discussion** — opening this so we can decide whether it's worthwhile before polishing.

## What this does

Adds an opt-in map config boolean, **`map.hideToleranceNotice`** (defaults to `false`), that suppresses the map tooltip's tolerance notice:

> Data not available for {year}. Showing closest available data point instead

When the flag is off (the default), behavior is unchanged. When a chart author enables it via the new checkbox in the map editor's **Tooltip** section, the notice is hidden.

## Why

On some maps the time dimension isn't really a time series — it's a per-entity *attribute*. For example, a map where each country is plotted at its own target year. In that case the map defaults its selected time to the latest year present, so most countries render the "Data not available for {year}, showing closest" notice even though their value is perfectly valid for that country. The notice is confusing there. This opt-in checkbox lets a chart author suppress it for those maps, without affecting any map that doesn't set the flag.

## How it's wired

Mirrors the existing `map.tooltipUseCustomLabels` field end-to-end. The notice is produced by the `toleranceNotice` getter in `MapTooltip`, which returns `undefined` when the flag is set (so both the tooltip footer and the `subtitleFormat` "notice" styling that key off it behave). The flag is read from `manager.mapConfig`, which is already reachable inside `MapTooltip`.

Because this is an additive optional field, no schema version bump or DB migration is needed (per the schema README, non-breaking additions just edit the YAML). `defaultGrapherConfig.ts` was regenerated from the schema.

## Files changed

- `packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts` — add `hideToleranceNotice?: boolean` to `MapConfigInterface`
- `packages/@ourworldindata/grapher/src/mapCharts/MapConfig.ts` — add the observable field + default
- `packages/@ourworldindata/grapher/src/schema/grapher-schema.010.yaml` — add the schema property
- `packages/@ourworldindata/grapher/src/schema/defaultGrapherConfig.ts` — regenerated default (`hideToleranceNotice: false`)
- `packages/@ourworldindata/grapher/src/mapCharts/MapTooltip.tsx` — gate `toleranceNotice` on the flag
- `adminSiteClient/EditorMapTab.tsx` — add the admin checkbox in the Tooltip section

## Verification

- Typecheck (`tsc -b`) passes.
- Lint (`oxlint`) and format (`oxfmt`) pass on the touched files.
- `MapTooltip`, `MapConfig`, schema migration, and grapher-config-utils unit tests pass.
