### PR TITLE
Stable concept-based colors for world regions on categorical maps

### DIFF
--- a/packages/@ourworldindata/grapher/src/color/CustomSchemes.test.ts
+++ b/packages/@ourworldindata/grapher/src/color/CustomSchemes.test.ts
@@ -1,0 +1,70 @@
+import { expect, it, describe } from "vitest"
+import * as _ from "lodash-es"
+import { regions, checkIsAggregate } from "@ourworldindata/utils"
+import {
+    RegionMapColorMap,
+    OwidCategoricalMapScheme,
+    MapContinentColors,
+} from "./CustomSchemes"
+
+describe("RegionMapColorMap", () => {
+    it("colors the same region concept identically across sources", () => {
+        const subSaharanAfricas = [
+            RegionMapColorMap["Sub-Saharan Africa (WB)"],
+            RegionMapColorMap["Sub-Saharan Africa (UN SDG)"],
+            RegionMapColorMap["Sub-Saharan Africa (Pew)"],
+            RegionMapColorMap["Sub-Saharan Africa (WID)"],
+            RegionMapColorMap["Sub-Saharan Africa (ILO)"],
+            RegionMapColorMap["Sub Saharan Africa (Maddison)"],
+        ]
+        expect(subSaharanAfricas[0]).toBeTruthy()
+        expect(new Set(subSaharanAfricas).size).toEqual(1)
+
+        const europes = [
+            RegionMapColorMap["Europe"],
+            RegionMapColorMap["Europe (UN)"],
+            RegionMapColorMap["Europe (WHO)"],
+            RegionMapColorMap["Europe (WID)"],
+            RegionMapColorMap["Europe and Central Asia (WB)"],
+            RegionMapColorMap["Europe and Northern America (UN SDG)"],
+        ]
+        expect(europes[0]).toBeTruthy()
+        expect(new Set(europes).size).toEqual(1)
+    })
+
+    it("assigns distinct colors to sibling regions within each source", () => {
+        const aggregatesByProvider = _.groupBy(
+            regions
+                .filter(checkIsAggregate)
+                .filter((region) => region.definedBy),
+            (region) => region.definedBy
+        )
+        for (const [provider, aggregates] of Object.entries(
+            aggregatesByProvider
+        )) {
+            const pinnedColors = aggregates
+                .map((region) => RegionMapColorMap[region.name])
+                .filter((color) => color !== undefined)
+            expect(
+                new Set(pinnedColors).size,
+                `duplicate concept colors among sibling regions of ${provider}`
+            ).toEqual(pinnedColors.length)
+        }
+    })
+
+    it("keeps Arab States distinguishable from its ILO tier-2 siblings", () => {
+        // "Arab States (ILO)" appears in both ILO breakdowns, alongside
+        // "Northern Africa (ILO)" in the granular one
+        expect(RegionMapColorMap["Arab States (ILO)"]).toBeTruthy()
+        expect(RegionMapColorMap["Arab States (ILO)"]).not.toEqual(
+            RegionMapColorMap["Northern Africa (ILO)"]
+        )
+    })
+
+    it("is wired up as the categorical map scheme's name-keyed colors", () => {
+        expect(OwidCategoricalMapScheme.colorMap).toBe(RegionMapColorMap)
+        expect(MapContinentColors["Africa (WHO)"]).toEqual(
+            RegionMapColorMap["Africa (WHO)"]
+        )
+    })
+})

--- a/packages/@ourworldindata/grapher/src/color/CustomSchemes.test.ts
+++ b/packages/@ourworldindata/grapher/src/color/CustomSchemes.test.ts
@@ -7,7 +7,7 @@ import {
     MapContinentColors,
 } from "./CustomSchemes"
 
-describe("RegionMapColorMap", () => {
+describe("region concept colors", () => {
     it("colors the same region concept identically across sources", () => {
         const subSaharanAfricas = [
             RegionMapColorMap["Sub-Saharan Africa (WB)"],

--- a/packages/@ourworldindata/grapher/src/color/CustomSchemes.ts
+++ b/packages/@ourworldindata/grapher/src/color/CustomSchemes.ts
@@ -1,5 +1,5 @@
 import * as _ from "lodash-es"
-import { lazy } from "@ourworldindata/utils"
+import { lazy, regions } from "@ourworldindata/utils"
 import {
     Color,
     ColorSchemeInterface,
@@ -358,6 +358,140 @@ export const OwidMapColors: Record<string, Color> = {
     Tomato: "#D94C3F",
 } as const
 
+// One canonical map color per world-region *concept*. Region definitions differ
+// between sources (WB, UN, WHO, Pew, Maddison, WID, ILO, ...), but most of their
+// regions correspond to a shared set of concepts — coloring by concept makes the
+// same part of the world look the same across charts, no matter whose definition
+// a chart uses. The hues are draft picks from the categorical map palette; the
+// invariant to preserve when revising them is that sibling regions within one
+// source stay distinguishable (see CustomSchemes.test.ts).
+export const RegionConceptMapColors = {
+    africa: OwidMapColors.LightPurple,
+    northernAfrica: OwidMapColors.LightSand,
+    middleEastNorthAfrica: OwidMapColors.Sand,
+    europe: OwidMapColors.MutedDenim,
+    easternEurope: OwidMapColors.Lavendar,
+    westernEurope: OwidMapColors.LightDenim,
+    asia: OwidMapColors.MutedTeal,
+    centralAsia: OwidMapColors.LightTeal,
+    eastAsia: OwidMapColors.LightGreen,
+    southeastAsia: OwidMapColors.LeafGreen,
+    southAsia: OwidMapColors.Olive,
+    latinAmerica: OwidMapColors.MutedCherry,
+    northernAmerica: OwidMapColors.LightOrange,
+    americas: OwidMapColors.SoftOrange,
+    southAmerica: OwidMapColors.Tomato,
+    oceania: OwidMapColors.SkyTurquoise,
+    australiaNewZealand: OwidMapColors.Mustard,
+    // Same as americas — they never appear on the same map, and this keeps
+    // Antarctica's long-standing map color
+    antarctica: OwidMapColors.SoftOrange,
+} as const
+
+// Which concept each region name corresponds to, keyed by the name with any
+// " (PROVIDER)" suffix stripped, so that "Sub-Saharan Africa (WB)" and
+// "Sub-Saharan Africa (UN SDG)" both resolve via "Sub-Saharan Africa".
+// Names not listed here (e.g. Melanesia, or the UN M49 subdivisions of Africa)
+// keep the positional palette fallback.
+const regionNameToConcept: Record<string, keyof typeof RegionConceptMapColors> =
+    {
+        // Continents
+        Africa: "africa",
+        Antarctica: "antarctica",
+        Asia: "asia",
+        Europe: "europe",
+        "North America": "northernAmerica",
+        Oceania: "oceania",
+        "South America": "southAmerica",
+
+        // Africa
+        "Northern Africa": "northernAfrica",
+        "Sub-Saharan Africa": "africa",
+        "Sub Saharan Africa": "africa", // Maddison spelling
+
+        // Middle East & North Africa
+        "Arab States": "middleEastNorthAfrica",
+        "Eastern Mediterranean": "middleEastNorthAfrica",
+        "Middle East": "middleEastNorthAfrica",
+        "Middle East and North Africa": "middleEastNorthAfrica",
+        "Middle East-North Africa": "middleEastNorthAfrica",
+        "Middle East, North Africa, Afghanistan and Pakistan":
+            "middleEastNorthAfrica",
+        "Northern Africa and Western Asia": "middleEastNorthAfrica",
+        "Western Asia": "middleEastNorthAfrica",
+
+        // Europe
+        "Eastern Europe": "easternEurope",
+        "Europe and Central Asia": "europe",
+        "Europe and Northern America": "europe",
+        "Northern, Southern and Western Europe": "europe",
+        "Western Europe": "westernEurope",
+
+        // Asia & Pacific
+        "Asia and the Pacific": "asia",
+        "Asia Pacific": "asia",
+        "Asia-Pacific": "asia",
+        "Central and Southern Asia": "southAsia",
+        "Central and Western Asia": "centralAsia",
+        "Central Asia": "centralAsia",
+        "East Asia": "eastAsia",
+        "East Asia and Pacific": "asia",
+        "Eastern and South-Eastern Asia": "eastAsia",
+        "Eastern Asia": "eastAsia",
+        Eurasia: "centralAsia",
+        "Russia and Central Asia": "centralAsia",
+        "South and South East Asia": "southAsia",
+        "South and South-East Asia": "southAsia",
+        "South Asia": "southAsia",
+        "South-East Asia": "southeastAsia",
+        "South-eastern Asia": "southeastAsia",
+        "South-Eastern Asia and the Pacific": "southeastAsia",
+        "Southern Asia": "southAsia",
+
+        // Americas
+        Americas: "americas",
+        "Central and South America": "latinAmerica",
+        "Latin America": "latinAmerica",
+        "Latin America and Caribbean": "latinAmerica",
+        "Latin America and the Caribbean": "latinAmerica",
+        "Latin America-Caribbean": "latinAmerica",
+        "Northern America": "northernAmerica",
+        "Western offshoots": "northernAmerica", // Maddison: US, Canada, Australia, NZ
+
+        // Oceania
+        "Australia and New Zealand": "australiaNewZealand",
+        "Western Pacific": "oceania",
+    }
+
+const REGION_PROVIDER_SUFFIX = /\s*\([^)]*\)$/
+
+function buildRegionMapColorMap(): Record<string, Color> {
+    const colorMap: Record<string, Color> = {}
+    for (const region of regions) {
+        if (
+            region.regionType !== "continent" &&
+            region.regionType !== "aggregate"
+        )
+            continue
+        const baseName = region.name.replace(REGION_PROVIDER_SUFFIX, "")
+        const concept = regionNameToConcept[baseName]
+        if (concept) colorMap[region.name] = RegionConceptMapColors[concept]
+    }
+    // Income groups keep their dedicated colors
+    colorMap["High-income countries"] = IncomeGroupColors.HighIncome
+    colorMap["Upper-middle-income countries"] =
+        IncomeGroupColors.UpperMiddleIncome
+    colorMap["Lower-middle-income countries"] =
+        IncomeGroupColors.LowerMiddleIncome
+    colorMap["Low-income countries"] = IncomeGroupColors.LowIncome
+    return colorMap
+}
+
+// name → map color for every continent and provider-defined region whose concept
+// is known, generated from the regions catalog — a region added there picks up
+// its concept color without any change in this file.
+export const RegionMapColorMap: Record<string, Color> = buildRegionMapColorMap()
+
 export const ContinentColors = {
     // World
     World: OwidDistinctColors.DarkOliveGreen,
@@ -429,34 +563,33 @@ export const ContinentColors = {
     "Oceania (UN SDG)": OwidDistinctColors.Turquoise,
     "Sub-Saharan Africa (UN SDG)": OwidDistinctColors.DarkMauve,
 
-    // Maddison Project Database regions — pinned to the exact colors their map chart renders
-    // (the default categorical palette CategoricalMapPalette10, in legend/display order).
-    // Defined here (not only in MapContinentColors) so the admin "Continents" picker offers
-    // the same colors, letting a Maddison-region chart be colored to match the map. They flow
-    // into MapContinentColors via its spread, so the region hover matches too.
-    "Western offshoots (Maddison)": OwidMapColors.MutedDenim,
-    "Western Europe (Maddison)": OwidMapColors.SoftOrange,
-    "Eastern Europe (Maddison)": OwidMapColors.MutedTeal,
-    "Latin America (Maddison)": OwidMapColors.SoftPurple,
-    "East Asia (Maddison)": OwidMapColors.Sand,
-    "South and South East Asia (Maddison)": OwidMapColors.MutedCherry,
-    "Middle East and North Africa (Maddison)": OwidMapColors.LeafGreen,
-    "Sub Saharan Africa (Maddison)": OwidMapColors.SkyTurquoise,
+    // Maddison Project Database regions — pinned to the same concept colors their maps
+    // render (see RegionMapColorMap above), so the admin "Continents" picker offers
+    // matching colors, letting a Maddison-region chart be colored to match the map.
+    "Western offshoots (Maddison)": RegionConceptMapColors.northernAmerica,
+    "Western Europe (Maddison)": RegionConceptMapColors.westernEurope,
+    "Eastern Europe (Maddison)": RegionConceptMapColors.easternEurope,
+    "Latin America (Maddison)": RegionConceptMapColors.latinAmerica,
+    "East Asia (Maddison)": RegionConceptMapColors.eastAsia,
+    "South and South East Asia (Maddison)": RegionConceptMapColors.southAsia,
+    "Middle East and North Africa (Maddison)":
+        RegionConceptMapColors.middleEastNorthAfrica,
+    "Sub Saharan Africa (Maddison)": RegionConceptMapColors.africa,
 
     // WID regions — same idea (see Maddison note above).
-    "North America (WID)": OwidMapColors.MutedDenim,
-    "Latin America (WID)": OwidMapColors.SoftOrange,
-    "Europe (WID)": OwidMapColors.MutedTeal,
-    "Russia and Central Asia (WID)": OwidMapColors.SoftPurple,
-    "Middle East and North Africa (WID)": OwidMapColors.Sand,
-    "Sub-Saharan Africa (WID)": OwidMapColors.MutedCherry,
-    "East Asia (WID)": OwidMapColors.LeafGreen,
-    "South and South-East Asia (WID)": OwidMapColors.SkyTurquoise,
-    "Oceania (WID)": OwidMapColors.Lavendar,
+    "North America (WID)": RegionConceptMapColors.northernAmerica,
+    "Latin America (WID)": RegionConceptMapColors.latinAmerica,
+    "Europe (WID)": RegionConceptMapColors.europe,
+    "Russia and Central Asia (WID)": RegionConceptMapColors.centralAsia,
+    "Middle East and North Africa (WID)":
+        RegionConceptMapColors.middleEastNorthAfrica,
+    "Sub-Saharan Africa (WID)": RegionConceptMapColors.africa,
+    "East Asia (WID)": RegionConceptMapColors.eastAsia,
+    "South and South-East Asia (WID)": RegionConceptMapColors.southAsia,
+    "Oceania (WID)": RegionConceptMapColors.oceania,
 
-    // ILO regions are intentionally NOT pinned: "Arab States (ILO)" is shared by both ILO
-    // tiers and sits at a different palette position in each, so one name-keyed color can't
-    // match both charts without a clash. ILO stays on the position-based palette fallback.
+    // ILO, IEA and UN M49 regions are not pinned here; on maps they are covered by
+    // RegionMapColorMap via the "OWID Categorical Map" scheme and MapContinentColors.
 
     // Income groups
     "High-income countries": IncomeGroupColors.HighIncome,
@@ -781,6 +914,9 @@ export const OwidCategoricalMapScheme = {
     singleColorScale: false,
     isDistinct: true,
     colorSets: [CategoricalMapPalette10, CategoricalMapPalette17],
+    // Known region names get their stable concept color; all other values fall
+    // back to the positional palettes above
+    colorMap: RegionMapColorMap,
 }
 CustomColorSchemes.push(OwidCategoricalMapScheme)
 
@@ -811,53 +947,9 @@ export const MapContinentColors = {
     WesternEurope: OwidMapColors.LightDenim,
     AustralasiaAndOceania: OwidMapColors.Mustard,
 
-    // World Bank regions
-    "East Asia and Pacific (WB)": OwidMapColors.SkyTurquoise,
-    "Europe and Central Asia (WB)": OwidMapColors.MutedDenim,
-    "Middle East, North Africa, Afghanistan and Pakistan (WB)":
-        OwidMapColors.Sand,
-    "North America (WB)": OwidMapColors.SoftOrange,
-    "South Asia (WB)": OwidMapColors.Olive,
-    "Sub-Saharan Africa (WB)": OwidMapColors.LightPurple,
-    "Latin America and Caribbean (WB)": OwidMapColors.MutedCherry,
-
-    // UN regions
-    "Asia (UN)": OwidMapColors.MutedTeal,
-    "Africa (UN)": OwidMapColors.LightPurple,
-    "Europe (UN)": OwidMapColors.MutedDenim,
-    "Oceania (UN)": OwidMapColors.SkyTurquoise,
-    "Northern America (UN)": OwidMapColors.LightOrange,
-    "Latin America and the Caribbean (UN)": OwidMapColors.MutedCherry,
-
-    // WHO regions
-    "Africa (WHO)": OwidMapColors.LightPurple,
-    "Europe (WHO)": OwidMapColors.MutedDenim,
-    "Americas (WHO)": OwidMapColors.SoftOrange,
-    "South-East Asia (WHO)": OwidMapColors.LeafGreen,
-    "Western Pacific (WHO)": OwidMapColors.SkyTurquoise,
-    "Eastern Mediterranean (WHO)": OwidMapColors.Sand,
-
-    // Pew Research Center regions
-    "Europe (Pew)": OwidMapColors.MutedDenim,
-    "Asia-Pacific (Pew)": OwidMapColors.MutedTeal,
-    "North America (Pew)": OwidMapColors.SoftOrange,
-    "Sub-Saharan Africa (Pew)": OwidMapColors.LightPurple,
-    "Latin America-Caribbean (Pew)": OwidMapColors.MutedCherry,
-    "Middle East-North Africa (Pew)": OwidMapColors.Sand,
-
-    // UN SDG regions
-    "Australia and New Zealand (UN SDG)": OwidMapColors.MutedTeal,
-    "Central and Southern Asia (UN SDG)": OwidMapColors.Olive,
-    "Eastern and South-Eastern Asia (UN SDG)": OwidMapColors.SoftOrange,
-    "Europe and Northern America (UN SDG)": OwidMapColors.MutedDenim,
-    "Latin America and the Caribbean (UN SDG)": OwidMapColors.MutedCherry,
-    "Northern Africa and Western Asia (UN SDG)": OwidMapColors.Sand,
-    "Oceania (UN SDG)": OwidMapColors.SkyTurquoise,
-    "Sub-Saharan Africa (UN SDG)": OwidMapColors.LightPurple,
-
-    // Maddison/WID provider regions are inherited from the ContinentColors spread above
-    // (pinned to their map-chart colors there); ILO is intentionally left unpinned. See the
-    // ContinentColors block for the full explanation.
+    // Provider-defined regions (WB, UN, WHO, Pew, UN SDG, Maddison, WID, ILO, ...)
+    // get their concept color, consistent across sources
+    ...RegionMapColorMap,
 } as const
 
 export const DefaultColorScheme = OwidDistinctColorScheme


### PR DESCRIPTION
## Context

Slack discussion: https://owid.slack.com/archives/C04VBQ00HQR/p1784291286011359 — region maps from non-OWID sources (WID, Maddison, ILO, …) got arbitrary positional colors from the `OWID Categorical Map` palette, while manually curated charts (UN, WHO, Pew) matched our region color language by hand. The hardcoded pins that existed had also drifted: the same part of the world was colored differently depending on the source (e.g. Sub-Saharan Africa was DarkMauve in `ContinentColors`' WB/Pew/UN SDG pins, LightPurple in `MapContinentColors`, and MutedCherry for WID).

This PR is a draft of a stable, low-friction solution:

- **`RegionConceptMapColors`**: one canonical map color per world-region *concept* (africa, europe, MENA, eastAsia, latinAmerica, …), drawn from the categorical map palette. Concepts were chosen to keep already-consistent charts (UN, WHO) pixel-identical.
- **`RegionMapColorMap`**: generated from the regions catalog by stripping the `" (PROVIDER)"` suffix and looking up the concept — so a region added to the catalog picks up its color with no code change here, and all sources (WB, UN, WHO, Pew, UN SDG, Maddison, WID, ILO, UN M49, IEA) are covered uniformly.
- The map is attached as the name-keyed `colorMap` of the **`OWID Categorical Map` scheme**: known region names get their stable concept color, all other values keep the positional palette fallback. Existing charts using this scheme (e.g. WID 9176, Maddison 7784, ILO 9177) become cross-source consistent with no editor action. Per-chart `customCategoryColors` still override, so hand-curated charts are unaffected.
- `MapContinentColors`' hand-maintained provider pins are replaced by the generated map, and the Maddison/WID pins in `ContinentColors` (previously frozen to accidental positional chart colors) now reference the same concept colors. ILO is now pinned too: `Arab States (ILO)` gets one color across both ILO breakdowns, distinct from `Northern Africa (ILO)`.

Notes for review:

- The exact hues are draft picks pending design review — the concept table is ~20 lines and easy to revise; tests enforce that sibling regions within one source stay distinguishable.
- A few granular regions (Melanesia/Micronesia/Polynesia, Northern/Southern Europe, UN M49 Africa subdivisions, Caribbean/Central America) have no concept yet and keep the positional fallback.
- This covers the map story; the `Continents` (line/scatter) scheme is unchanged apart from the Maddison/WID re-pins. A follow-up could move the concept assignment into the ETL regions dataset to make it fully data-driven.

## Screenshots / Videos / Diagrams

Compare on staging (`staging-site-improve-color-scale-for-cont`) once built: charts 9176 (WID), 7784 (Maddison), 9177 (ILO) and https://ourworldindata.org/world-region-map-definitions.

## Testing guidance

- Run `yarn test run packages/@ourworldindata/grapher/src/color/CustomSchemes.test.ts` — asserts same concept ⇒ same color across sources, and sibling distinctness within every provider.
- On staging, open the maps of charts 9176 / 7784 / 9177 and check that the same world regions are colored consistently across them (and against the manually curated UN/WHO/Pew charts).
- Check a categorical map with non-region values still gets the positional palette as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)