### PR TITLE
Improve favicon setup

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -26,3 +26,11 @@
     Access-Control-Allow-Origin: *
     ! Cache-Control
     Cache-Control: public, max-age=31536000
+
+/favicon.ico
+    ! Cache-Control
+    Cache-Control: public, max-age=604800
+
+/apple-touch-icon.png
+    ! Cache-Control
+    Cache-Control: public, max-age=604800

--- a/site/Head.tsx
+++ b/site/Head.tsx
@@ -97,11 +97,8 @@ export const Head = (props: {
                     data-archival-date={props.archiveContext.archivalDate}
                 />
             )}
-            <link
-                rel="apple-touch-icon"
-                sizes="180x180"
-                href="/apple-touch-icon.png"
-            />
+            <link rel="icon" href="/favicon.ico" />
+            <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
             <link
                 rel="preload"
                 href="/fonts/LatoLatin-Regular.woff2"


### PR DESCRIPTION
- Cache the icons for a week
- Add explicit <link> tag for other HTML consumers than browsers
- Remove unnecessary Apple icon size

https://evilmartians.com/chronicles/how-to-favicon-in-2021-six-files-that-fit-most-needs
