### PR TITLE
Let /api/search?type=pages filter by any gdoc type via pageTypes

### DIFF
--- a/docs/search-api.openapi.yaml
+++ b/docs/search-api.openapi.yaml
@@ -8,7 +8,7 @@ info:
     This API allows you to search through:
 
     - **Charts**: Interactive data visualizations with country-specific filtering
-    - **Pages**: Articles, research papers, and informational pages
+    - **Pages**: Articles, data insights, and other content pages (filter by type via `pageTypes`)
 
     !!! tip "Semantic Search"
 
@@ -111,6 +111,18 @@ paths:
             type: boolean
             default: false
           example: false
+
+        # Pages-specific parameters
+        - name: pageTypes
+          in: query
+          description: |
+            Comma-separated list of page content types to search. Only applicable
+            when `type=pages`. Defaults to `article,about-page` when omitted.
+          required: false
+          schema:
+            type: string
+            default: "article,about-page"
+          example: "data-insight"
 
       responses:
         "200":
@@ -387,7 +399,15 @@ components:
           type: string
           enum:
             - article
+            - topic-page
+            - fragment
+            - linear-topic-page
+            - data-insight
+            - homepage
             - about-page
+            - author
+            - announcement
+            - profile
           description: Type of page content
           example: "article"
         thumbnailUrl:

--- a/functions/api/search/index.test.ts
+++ b/functions/api/search/index.test.ts
@@ -151,6 +151,78 @@ describe("Search API endpoint", () => {
         })
     })
 
+    describe("pageTypes parameter", () => {
+        it("passes a single pageTypes value through to searchPages", async () => {
+            const mockSearchPages = vi
+                .spyOn(searchApi, "searchPages")
+                .mockResolvedValue({
+                    query: "malaria",
+                    results: [],
+                    nbHits: 0,
+                    offset: 0,
+                    length: 20,
+                })
+
+            const request = new Request(
+                "http://localhost/api/search?q=malaria&type=pages&pageTypes=data-insight"
+            )
+            await onRequestGet({ request, env: mockEnv } as any)
+
+            expect(mockSearchPages).toHaveBeenCalledWith(
+                expect.anything(),
+                "malaria",
+                0,
+                20,
+                ["data-insight"],
+                "http://localhost"
+            )
+        })
+
+        it("parses and trims a comma-separated pageTypes list", async () => {
+            const mockSearchPages = vi
+                .spyOn(searchApi, "searchPages")
+                .mockResolvedValue({
+                    query: "malaria",
+                    results: [],
+                    nbHits: 0,
+                    offset: 0,
+                    length: 20,
+                })
+
+            const request = new Request(
+                "http://localhost/api/search?q=malaria&type=pages&pageTypes=article,%20about-page"
+            )
+            await onRequestGet({ request, env: mockEnv } as any)
+
+            expect(mockSearchPages).toHaveBeenCalledWith(
+                expect.anything(),
+                "malaria",
+                0,
+                20,
+                ["article", "about-page"],
+                "http://localhost"
+            )
+        })
+
+        it("rejects an unknown pageTypes value without calling searchPages", async () => {
+            const mockSearchPages = vi.spyOn(searchApi, "searchPages")
+
+            const request = new Request(
+                "http://localhost/api/search?q=malaria&type=pages&pageTypes=bogus-type"
+            )
+            const response = await onRequestGet({
+                request,
+                env: mockEnv,
+            } as any)
+
+            expect(response.status).toBe(400)
+            const body = await response.json()
+            assert(typeof body === "object" && body !== null && "error" in body)
+            expect(body.error).toContain("bogus-type")
+            expect(mockSearchPages).not.toHaveBeenCalled()
+        })
+    })
+
     describe("pagination validation", () => {
         it("rejects negative page", async () => {
             const request = new Request(

--- a/functions/api/search/index.ts
+++ b/functions/api/search/index.ts
@@ -7,13 +7,22 @@ import {
     SearchState,
     SearchValidationError,
 } from "./searchApi.js"
-import { FilterType, Filter, SearchUrlParam } from "@ourworldindata/types"
+import {
+    FilterType,
+    Filter,
+    SearchUrlParam,
+    ALL_GDOC_TYPES,
+} from "@ourworldindata/types"
 
 const DEFAULT_HITS_PER_PAGE = 20
 const MAX_HITS_PER_PAGE = 100
 const MAX_PAGE = 1000
 
 type SearchType = "charts" | "pages"
+
+// gdoc content types the `pageTypes` param (type=pages only) may request, as
+// a Set for O(1) membership checks.
+const VALID_PAGE_TYPES = new Set<string>(ALL_GDOC_TYPES)
 
 const hasSearchEnvVars = (env: Env): boolean => {
     return !!env.ALGOLIA_ID && !!env.ALGOLIA_SEARCH_KEY
@@ -59,6 +68,29 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
         const requireAllCountries =
             url.searchParams.get(SearchUrlParam.REQUIRE_ALL_COUNTRIES) ===
             "true"
+
+        // Which gdoc content types to include (only applies when
+        // type=pages, e.g. "data-insight" or "article,about-page"). Omitted
+        // -> searchPages()'s own default (article + about-page), so existing
+        // callers see no change. Validated upfront against the full gdoc
+        // type enum (a static, compile-time list — unlike topics, which are
+        // dynamic data and so are validated lazily against a live lookup).
+        const pageTypesParam = url.searchParams.get("pageTypes")
+        let pageTypes: string[] | undefined
+        if (pageTypesParam) {
+            pageTypes = pageTypesParam
+                .split(",")
+                .map((t) => t.trim())
+                .filter(Boolean)
+            const invalidTypes = pageTypes.filter(
+                (t) => !VALID_PAGE_TYPES.has(t)
+            )
+            if (invalidTypes.length > 0) {
+                throw new SearchValidationError(
+                    `Invalid pageTypes value(s): "${invalidTypes.join('", "')}". Valid types: ${Array.from(VALID_PAGE_TYPES).join(", ")}`
+                )
+            }
+        }
 
         // Parse pagination parameters
         const page = parseInt(url.searchParams.get("page") || "0")
@@ -150,7 +182,7 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
                       query,
                       page * hitsPerPage, // Convert page to offset
                       hitsPerPage,
-                      undefined, // Use default page types
+                      pageTypes, // undefined -> searchPages()'s own default
                       baseUrl
                   )
                 : await searchCharts(

--- a/functions/api/search/searchApi.integration.test.ts
+++ b/functions/api/search/searchApi.integration.test.ts
@@ -322,6 +322,22 @@ describe("searchPages with real Algolia", () => {
         })
     })
 
+    it("builds type-specific URLs for non-article page types", async () => {
+        // data-insights bake to /data-insights/<slug> (see
+        // getPrefixedGdocPath), different from the bare /<slug> used by
+        // article/about-page.
+        const diResult = await searchPages(algoliaConfig, "co2", 0, 5, [
+            "data-insight",
+        ])
+        expect(diResult.results.length).toBeGreaterThan(0)
+        diResult.results.forEach((page) => {
+            expect(page.type).toBe("data-insight")
+            expect(page.url).toBe(
+                `https://ourworldindata.org/data-insights/${page.slug}`
+            )
+        })
+    })
+
     it("removes internal Algolia fields from results", async () => {
         const result = await searchPages(algoliaConfig, "population", 0, 1)
 

--- a/functions/api/search/searchApi.ts
+++ b/functions/api/search/searchApi.ts
@@ -4,7 +4,9 @@ import {
     Filter,
     ChartRecordType,
     SearchChartHit,
+    OwidGdocType,
 } from "@ourworldindata/types"
+import { getCanonicalUrl } from "@ourworldindata/components"
 import { getIndexName, AlgoliaConfig } from "./algoliaClient.js"
 
 /**
@@ -393,8 +395,16 @@ export async function searchPages(
             ...cleanHit
         } = hit as any
 
-        // Construct URL based on slug
-        const url = `${baseUrl}/${cleanHit.slug}`
+        // Construct URL based on slug + type: different gdoc types bake to
+        // different path prefixes (e.g. data-insights -> /data-insights/,
+        // profiles -> /profile/) — getCanonicalUrl/getPrefixedGdocPath is the
+        // single source of truth the baker itself uses, so newly-exposed
+        // pageTypes (beyond the original article/about-page) resolve to
+        // working links instead of a bare `${baseUrl}/${slug}` guess.
+        const url = getCanonicalUrl(baseUrl, {
+            slug: cleanHit.slug,
+            content: { type: cleanHit.type as OwidGdocType },
+        })
 
         return {
             ...cleanHit,


### PR DESCRIPTION
## Summary

- `searchPages()` (`functions/api/search/searchApi.ts`) already accepts an arbitrary `pageTypes: string[]` and builds a generic `type:X OR type:Y` Algolia filter from it — but the HTTP handler (`functions/api/search/index.ts`) always called it with a hardcoded `undefined`, silently locking every `type=pages` request to `article`/`about-page` only.
- Adds a `pageTypes` query param: comma-separated gdoc type names (e.g. `pageTypes=data-insight`), validated upfront against the full `OwidGdocType` enum (400 + no-Sentry `SearchValidationError` on an unknown value, mirroring the existing `type` param validation).
- Omitting `pageTypes` keeps today's default (`article,about-page`) — no behavior change for existing callers.
- This lets consumers of the public API (e.g. the analytics repo's search evaluator, the MCP server) reach data-insights and other content types through this same endpoint, instead of needing separate direct-Algolia access.
- Updated `docs/search-api.openapi.yaml` (new param, full `PageResult.type` enum).

## Test plan

- [x] `yarn test run functions/api/search/` — 45/45 pass, including the existing `searchApi.integration.test.ts` case that already exercises `searchPages(..., ["about-page"])` against real Algolia
- [x] Added unit tests: single `pageTypes` value passed through, comma-separated list parsed/trimmed, unknown value rejected with 400 and `searchPages` never called
- [x] `yarn typecheck` clean
- [x] `yarn testLintChanged` / `yarn fixFormatChanged` clean
- [ ] Manually verify against staging: `.../api/search?type=pages&pageTypes=data-insight&q=malaria`

🤖 Generated with [Claude Code](https://claude.com/claude-code)