### PR TITLE
De-duplicate identical categorical map legend entries

### DIFF
--- a/packages/@ourworldindata/grapher/src/color/ColorScaleBin.test.ts
+++ b/packages/@ourworldindata/grapher/src/color/ColorScaleBin.test.ts
@@ -242,6 +242,28 @@ describe(mergeCategoricalBinsByLabelAndColor, () => {
         ).toHaveLength(2)
     })
 
+    it("does not merge bins that differ in pattern", () => {
+        // A patterned bin (e.g. the hatched no-data bin) must not merge into a
+        // solid category that happens to share its label and color, since they
+        // render differently and the patterned bin has distinct hover behavior.
+        const bins = [
+            new CategoricalBin({
+                index: 0,
+                value: "a",
+                label: "Same label",
+                color: "green",
+            }),
+            new CategoricalBin({
+                index: 1,
+                value: "b",
+                label: "Same label",
+                color: "green",
+                patternRef: "hatch",
+            }),
+        ]
+        expect(mergeCategoricalBinsByLabelAndColor(bins)).toHaveLength(2)
+    })
+
     it("leaves a single-member group's original bin untouched", () => {
         const bin = new CategoricalBin({
             index: 0,

--- a/packages/@ourworldindata/grapher/src/color/ColorScaleBin.test.ts
+++ b/packages/@ourworldindata/grapher/src/color/ColorScaleBin.test.ts
@@ -2,6 +2,7 @@ import { expect, it, describe } from "vitest"
 
 import {
     CategoricalBin,
+    dedupeRepeatedBins,
     mergeCategoricalBinsByLabelAndColor,
     NumericBin,
 } from "./ColorScaleBin"
@@ -103,7 +104,12 @@ describe(NumericBin, () => {
 
 describe(CategoricalBin, () => {
     it("contains only its own value by default", () => {
-        const bin = makeCategoricalBin(0, "Committed", "Committed", "green")
+        const bin = new CategoricalBin({
+            index: 0,
+            value: "Committed",
+            label: "Committed",
+            color: "green",
+        })
         expect(bin.contains("Committed")).toBe(true)
         expect(bin.contains("Pledged")).toBe(false)
         expect(bin.values).toEqual(["Committed"])
@@ -115,7 +121,7 @@ describe(CategoricalBin, () => {
             value: "In law",
             label: "Committed",
             color: "green",
-            values: ["In law", "In policy document"],
+            additionalValues: ["In policy document"],
         })
         expect(bin.contains("In law")).toBe(true)
         expect(bin.contains("In policy document")).toBe(true)
@@ -126,9 +132,30 @@ describe(CategoricalBin, () => {
 describe(mergeCategoricalBinsByLabelAndColor, () => {
     it("collapses bins with identical label and color into one entry", () => {
         const bins = [
-            makeCategoricalBin(0, "In law", "Committed", "green"),
-            makeCategoricalBin(1, "In policy document", "Committed", "green"),
-            makeCategoricalBin(2, "Pledged", "Pledged", "orange"),
+            new CategoricalBin({
+                index: 0,
+                value: "In law",
+                label: "Committed",
+                color: "green",
+            }),
+            new CategoricalBin({
+                index: 1,
+                value: "In policy document",
+                label: "Committed",
+                color: "green",
+            }),
+            new CategoricalBin({
+                index: 3,
+                value: "Pledged",
+                label: "Pledged",
+                color: "orange",
+            }),
+            new CategoricalBin({
+                index: 2,
+                value: "Announced",
+                label: "Committed",
+                color: "green",
+            }),
         ]
 
         const merged = mergeCategoricalBinsByLabelAndColor(bins)
@@ -136,29 +163,79 @@ describe(mergeCategoricalBinsByLabelAndColor, () => {
         expect(merged).toHaveLength(2)
         expect(merged.map((bin) => bin.text)).toEqual(["Committed", "Pledged"])
 
-        // The merged bin matches both underlying values, so hovering it still
-        // highlights every country in either category.
-        const [committed] = merged
-        expect(committed.values).toEqual(["In law", "In policy document"])
+        const committed = merged[0]
+        expect(committed.values).toEqual([
+            "In law",
+            "In policy document",
+            "Announced",
+        ])
         expect(committed.contains("In law")).toBe(true)
         expect(committed.contains("In policy document")).toBe(true)
+        expect(committed.contains("Announced")).toBe(true)
         // It keeps the first member's index, so `equals`-based hover matching
         // still resolves back to this one bin.
         expect(committed.equals(bins[0])).toBe(true)
     })
 
+    it("keeps a merged bin at the position of its first appearance", () => {
+        const bins = [
+            new CategoricalBin({
+                index: 0,
+                value: "In law",
+                label: "Committed",
+                color: "green",
+            }),
+            new CategoricalBin({
+                index: 1,
+                value: "Pledged",
+                label: "Pledged",
+                color: "orange",
+            }),
+            new CategoricalBin({
+                index: 2,
+                value: "In policy document",
+                label: "Committed",
+                color: "green",
+            }),
+        ]
+
+        const merged = mergeCategoricalBinsByLabelAndColor(bins)
+
+        expect(merged.map((bin) => bin.text)).toEqual(["Committed", "Pledged"])
+    })
+
     it("does not merge bins that differ in label or color", () => {
         const differentLabel = [
-            makeCategoricalBin(0, "a", "Label A", "green"),
-            makeCategoricalBin(1, "b", "Label B", "green"),
+            new CategoricalBin({
+                index: 0,
+                value: "a",
+                label: "Label A",
+                color: "green",
+            }),
+            new CategoricalBin({
+                index: 1,
+                value: "b",
+                label: "Label B",
+                color: "green",
+            }),
         ]
         expect(
             mergeCategoricalBinsByLabelAndColor(differentLabel)
         ).toHaveLength(2)
 
         const differentColor = [
-            makeCategoricalBin(0, "a", "Same label", "green"),
-            makeCategoricalBin(1, "b", "Same label", "orange"),
+            new CategoricalBin({
+                index: 0,
+                value: "a",
+                label: "Same label",
+                color: "green",
+            }),
+            new CategoricalBin({
+                index: 1,
+                value: "b",
+                label: "Same label",
+                color: "orange",
+            }),
         ]
         expect(
             mergeCategoricalBinsByLabelAndColor(differentColor)
@@ -166,18 +243,52 @@ describe(mergeCategoricalBinsByLabelAndColor, () => {
     })
 
     it("leaves a single-member group's original bin untouched", () => {
-        const bin = makeCategoricalBin(0, "only", "Only", "green")
+        const bin = new CategoricalBin({
+            index: 0,
+            value: "only",
+            label: "Only",
+            color: "green",
+        })
         const [merged] = mergeCategoricalBinsByLabelAndColor([bin])
         expect(merged).toBe(bin)
-        expect(merged.props.values).toBeUndefined()
+        expect(merged.props.additionalValues).toBeUndefined()
     })
 })
 
-function makeCategoricalBin(
-    index: number,
-    value: string,
-    label: string,
-    color: string
-): CategoricalBin {
-    return new CategoricalBin({ index, value, label, color })
-}
+describe(dedupeRepeatedBins, () => {
+    it("drops categorical bins repeating an earlier bin's text", () => {
+        // The same categories coming from two facets, with differing indexes
+        const bins = [
+            new CategoricalBin({
+                index: 0,
+                value: "Asia",
+                label: "Asia",
+                color: "red",
+            }),
+            new CategoricalBin({
+                index: 1,
+                value: "Europe",
+                label: "Europe",
+                color: "blue",
+            }),
+            new CategoricalBin({
+                index: 1,
+                value: "Asia",
+                label: "Asia",
+                color: "red",
+            }),
+            new CategoricalBin({
+                index: 0,
+                value: "Europe",
+                label: "Europe",
+                color: "blue",
+            }),
+        ]
+
+        const deduped = dedupeRepeatedBins(bins)
+
+        expect(deduped).toHaveLength(2)
+        expect(deduped[0]).toBe(bins[0])
+        expect(deduped[1]).toBe(bins[1])
+    })
+})

--- a/packages/@ourworldindata/grapher/src/color/ColorScaleBin.test.ts
+++ b/packages/@ourworldindata/grapher/src/color/ColorScaleBin.test.ts
@@ -1,6 +1,10 @@
 import { expect, it, describe } from "vitest"
 
-import { CategoricalBin, NumericBin } from "./ColorScaleBin"
+import {
+    CategoricalBin,
+    mergeCategoricalBinsByLabelAndColor,
+    NumericBin,
+} from "./ColorScaleBin"
 
 it("can create a bin", () => {
     const bin = new CategoricalBin({
@@ -96,3 +100,84 @@ describe(NumericBin, () => {
         })
     })
 })
+
+describe(CategoricalBin, () => {
+    it("contains only its own value by default", () => {
+        const bin = makeCategoricalBin(0, "Committed", "Committed", "green")
+        expect(bin.contains("Committed")).toBe(true)
+        expect(bin.contains("Pledged")).toBe(false)
+        expect(bin.values).toEqual(["Committed"])
+    })
+
+    it("contains all of its values when merged", () => {
+        const bin = new CategoricalBin({
+            index: 0,
+            value: "In law",
+            label: "Committed",
+            color: "green",
+            values: ["In law", "In policy document"],
+        })
+        expect(bin.contains("In law")).toBe(true)
+        expect(bin.contains("In policy document")).toBe(true)
+        expect(bin.contains("Pledged")).toBe(false)
+    })
+})
+
+describe(mergeCategoricalBinsByLabelAndColor, () => {
+    it("collapses bins with identical label and color into one entry", () => {
+        const bins = [
+            makeCategoricalBin(0, "In law", "Committed", "green"),
+            makeCategoricalBin(1, "In policy document", "Committed", "green"),
+            makeCategoricalBin(2, "Pledged", "Pledged", "orange"),
+        ]
+
+        const merged = mergeCategoricalBinsByLabelAndColor(bins)
+
+        expect(merged).toHaveLength(2)
+        expect(merged.map((bin) => bin.text)).toEqual(["Committed", "Pledged"])
+
+        // The merged bin matches both underlying values, so hovering it still
+        // highlights every country in either category.
+        const [committed] = merged
+        expect(committed.values).toEqual(["In law", "In policy document"])
+        expect(committed.contains("In law")).toBe(true)
+        expect(committed.contains("In policy document")).toBe(true)
+        // It keeps the first member's index, so `equals`-based hover matching
+        // still resolves back to this one bin.
+        expect(committed.equals(bins[0])).toBe(true)
+    })
+
+    it("does not merge bins that differ in label or color", () => {
+        const differentLabel = [
+            makeCategoricalBin(0, "a", "Label A", "green"),
+            makeCategoricalBin(1, "b", "Label B", "green"),
+        ]
+        expect(
+            mergeCategoricalBinsByLabelAndColor(differentLabel)
+        ).toHaveLength(2)
+
+        const differentColor = [
+            makeCategoricalBin(0, "a", "Same label", "green"),
+            makeCategoricalBin(1, "b", "Same label", "orange"),
+        ]
+        expect(
+            mergeCategoricalBinsByLabelAndColor(differentColor)
+        ).toHaveLength(2)
+    })
+
+    it("leaves a single-member group's original bin untouched", () => {
+        const bin = makeCategoricalBin(0, "only", "Only", "green")
+        const [merged] = mergeCategoricalBinsByLabelAndColor([bin])
+        expect(merged).toBe(bin)
+        expect(merged.props.values).toBeUndefined()
+    })
+})
+
+function makeCategoricalBin(
+    index: number,
+    value: string,
+    label: string,
+    color: string
+): CategoricalBin {
+    return new CategoricalBin({ index, value, label, color })
+}

--- a/packages/@ourworldindata/grapher/src/color/ColorScaleBin.ts
+++ b/packages/@ourworldindata/grapher/src/color/ColorScaleBin.ts
@@ -22,6 +22,10 @@ interface CategoricalBinProps extends BinProps {
     value: string
     label: string
     isHidden?: boolean
+    // Additional values that this bin matches, on top of `value`. Set only for
+    // merged legend bins (see `mergeCategoricalBinsByLabelAndColor`); when
+    // omitted the bin matches its single `value`, as before.
+    values?: string[]
 }
 
 abstract class AbstractColorScaleBin<T extends BinProps> {
@@ -107,6 +111,12 @@ export class CategoricalBin extends AbstractColorScaleBin<CategoricalBinProps> {
         return this.props.label || this.props.value
     }
 
+    /** All values this bin matches. A single-value bin matches just `value`;
+     * a merged bin also matches the values it absorbed. */
+    get values(): string[] {
+        return this.props.values ?? [this.props.value]
+    }
+
     contains(
         value: CoreValueType | undefined,
         { isProjection = false } = {}
@@ -116,7 +126,7 @@ export class CategoricalBin extends AbstractColorScaleBin<CategoricalBinProps> {
             (value !== undefined &&
                 isProjection &&
                 this.props.value === PROJECTED_DATA_LABEL) ||
-            (value !== undefined && value === this.props.value)
+            (value !== undefined && this.values.some((v) => v === value))
         )
     }
 
@@ -126,6 +136,45 @@ export class CategoricalBin extends AbstractColorScaleBin<CategoricalBinProps> {
             this.props.index === other.props.index
         )
     }
+}
+
+/**
+ * Merge categorical bins that share the same displayed label *and* color into a
+ * single bin, preserving the order of first appearance. This avoids showing
+ * multiple visually indistinguishable swatches in a legend when several
+ * categories are given the same custom label and color.
+ *
+ * The merged bin keeps the first bin's props (index, color, label, pattern) and
+ * additionally matches all the values of the bins it absorbs, so hovering it
+ * still highlights every entity in any of the merged categories, and hovering
+ * such an entity still resolves back to this one bin. Bins that differ in label
+ * or color are left untouched (and single-member groups keep their original
+ * object, so the default case is unchanged).
+ */
+export function mergeCategoricalBinsByLabelAndColor(
+    bins: CategoricalBin[]
+): CategoricalBin[] {
+    const binsByKey = new Map<string, CategoricalBin>()
+    const orderedKeys: string[] = []
+    for (const bin of bins) {
+        // Key on the displayed label and color together; JSON.stringify
+        // keeps the two fields unambiguously separated.
+        const key = JSON.stringify([bin.text, bin.color])
+        const existing = binsByKey.get(key)
+        if (existing) {
+            binsByKey.set(
+                key,
+                new CategoricalBin({
+                    ...existing.props,
+                    values: [...existing.values, ...bin.values],
+                })
+            )
+        } else {
+            binsByKey.set(key, bin)
+            orderedKeys.push(key)
+        }
+    }
+    return orderedKeys.map((key) => binsByKey.get(key)!)
 }
 
 export function isCategoricalBin(bin: ColorScaleBin): bin is CategoricalBin {

--- a/packages/@ourworldindata/grapher/src/color/ColorScaleBin.ts
+++ b/packages/@ourworldindata/grapher/src/color/ColorScaleBin.ts
@@ -1,3 +1,4 @@
+import * as _ from "lodash-es"
 import { Color, CoreValueType } from "@ourworldindata/types"
 import { NO_DATA_LABEL, PROJECTED_DATA_LABEL } from "./ColorScale"
 
@@ -22,10 +23,9 @@ interface CategoricalBinProps extends BinProps {
     value: string
     label: string
     isHidden?: boolean
-    // Additional values that this bin matches, on top of `value`. Set only for
-    // merged legend bins (see `mergeCategoricalBinsByLabelAndColor`); when
-    // omitted the bin matches its single `value`, as before.
-    values?: string[]
+    // Values this bin matches in addition to `value`. Set only for merged
+    // legend bins (see `mergeCategoricalBinsByLabelAndColor`).
+    additionalValues?: string[]
 }
 
 abstract class AbstractColorScaleBin<T extends BinProps> {
@@ -111,10 +111,9 @@ export class CategoricalBin extends AbstractColorScaleBin<CategoricalBinProps> {
         return this.props.label || this.props.value
     }
 
-    /** All values this bin matches. A single-value bin matches just `value`;
-     * a merged bin also matches the values it absorbed. */
+    /** All values this bin matches: `value` plus any values absorbed by merging */
     get values(): string[] {
-        return this.props.values ?? [this.props.value]
+        return [this.props.value, ...(this.props.additionalValues ?? [])]
     }
 
     contains(
@@ -147,18 +146,17 @@ export class CategoricalBin extends AbstractColorScaleBin<CategoricalBinProps> {
  * The merged bin keeps the first bin's props (index, color, label, pattern) and
  * additionally matches all the values of the bins it absorbs, so hovering it
  * still highlights every entity in any of the merged categories, and hovering
- * such an entity still resolves back to this one bin. Bins that differ in label
- * or color are left untouched (and single-member groups keep their original
- * object, so the default case is unchanged).
+ * such an entity still resolves back to this one bin.
+ *
+ * Unlike `dedupeRepeatedBins`, which drops repeated copies of the same bin,
+ * this merges distinct categories.
  */
 export function mergeCategoricalBinsByLabelAndColor(
     bins: CategoricalBin[]
 ): CategoricalBin[] {
     const binsByKey = new Map<string, CategoricalBin>()
-    const orderedKeys: string[] = []
     for (const bin of bins) {
-        // Key on the displayed label and color together; JSON.stringify
-        // keeps the two fields unambiguously separated.
+        // Key on the displayed label and color together
         const key = JSON.stringify([bin.text, bin.color])
         const existing = binsByKey.get(key)
         if (existing) {
@@ -166,15 +164,36 @@ export function mergeCategoricalBinsByLabelAndColor(
                 key,
                 new CategoricalBin({
                     ...existing.props,
-                    values: [...existing.values, ...bin.values],
+                    additionalValues: [
+                        ...(existing.props.additionalValues ?? []),
+                        ...bin.values,
+                    ],
                 })
             )
         } else {
             binsByKey.set(key, bin)
-            orderedKeys.push(key)
         }
     }
-    return orderedKeys.map((key) => binsByKey.get(key)!)
+    return [...binsByKey.values()]
+}
+
+/**
+ * Drop repeated occurrences of the same bin, e.g. the same category appearing
+ * once per facet, keeping the first occurrence unchanged.
+ */
+export function dedupeRepeatedBins<Bin extends ColorScaleBin>(
+    bins: Bin[]
+): Bin[] {
+    return _.uniqWith(bins, (binA, binB): boolean => {
+        // For categorical bins, the `.equals()` method isn't good enough,
+        // because it only compares `.index`, which in this case can be
+        // identical even when the bins are not, because they are coming
+        // from different charts (facets).
+        if (binA instanceof CategoricalBin) {
+            return binA.text === binB.text
+        }
+        return binA.equals(binB)
+    })
 }
 
 export function isCategoricalBin(bin: ColorScaleBin): bin is CategoricalBin {

--- a/packages/@ourworldindata/grapher/src/color/ColorScaleBin.ts
+++ b/packages/@ourworldindata/grapher/src/color/ColorScaleBin.ts
@@ -138,10 +138,10 @@ export class CategoricalBin extends AbstractColorScaleBin<CategoricalBinProps> {
 }
 
 /**
- * Merge categorical bins that share the same displayed label *and* color into a
- * single bin, preserving the order of first appearance. This avoids showing
- * multiple visually indistinguishable swatches in a legend when several
- * categories are given the same custom label and color.
+ * Merge categorical bins that share the same displayed label, color *and*
+ * pattern into a single bin, preserving the order of first appearance. This
+ * avoids showing multiple visually indistinguishable swatches in a legend when
+ * several categories are given the same custom label and color.
  *
  * The merged bin keeps the first bin's props (index, color, label, pattern) and
  * additionally matches all the values of the bins it absorbs, so hovering it
@@ -156,8 +156,11 @@ export function mergeCategoricalBinsByLabelAndColor(
 ): CategoricalBin[] {
     const binsByKey = new Map<string, CategoricalBin>()
     for (const bin of bins) {
-        // Key on the displayed label and color together
-        const key = JSON.stringify([bin.text, bin.color])
+        // Key on the displayed label, color and pattern together, so a patterned
+        // bin (e.g. the hatched no-data bin) is never merged into a solid
+        // category that happens to share its label and color. JSON.stringify
+        // keeps the fields unambiguously separated.
+        const key = JSON.stringify([bin.text, bin.color, bin.patternRef])
         const existing = binsByKey.get(key)
         if (existing) {
             binsByKey.set(

--- a/packages/@ourworldindata/grapher/src/facet/FacetChart.tsx
+++ b/packages/@ourworldindata/grapher/src/facet/FacetChart.tsx
@@ -59,6 +59,7 @@ import {
 import {
     CategoricalBin,
     ColorScaleBin,
+    dedupeRepeatedBins,
     NumericBin,
 } from "../color/ColorScaleBin"
 import { FocusArray } from "../focus/FocusArray"
@@ -776,19 +777,6 @@ export class FacetChart
         return undefined
     }
 
-    private getUniqBins<Bin extends ColorScaleBin>(bins: Bin[]): Bin[] {
-        return _.uniqWith(bins, (binA, binB): boolean => {
-            // For categorical bins, the `.equals()` method isn't good enough,
-            // because it only compares `.index`, which in this case can be
-            // identical even when the bins are not, because they are coming
-            // from different charts (facets).
-            if (binA instanceof CategoricalBin) {
-                return binA.text === binB.text
-            }
-            return binA.equals(binB)
-        })
-    }
-
     // legend props
 
     @computed get legendX(): number {
@@ -857,7 +845,7 @@ export class FacetChart
                 ...(legend.categoricalLegendData ?? []),
             ]
         )
-        const uniqBins = this.getUniqBins(allBins)
+        const uniqBins = dedupeRepeatedBins(allBins)
         const sortedBins = _.sortBy(
             uniqBins,
             (bin) => bin instanceof CategoricalBin
@@ -875,7 +863,7 @@ export class FacetChart
             ])
             .filter((bin) => bin instanceof CategoricalBin)
 
-        const uniqBins = this.getUniqBins(allBins).map(
+        const uniqBins = dedupeRepeatedBins(allBins).map(
             // Remap index to ensure it's unique (the above procedure can lead to duplicates)
             (bin, index) => new CategoricalBin({ ...bin.props, index })
         )

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
@@ -419,10 +419,7 @@ export class MapChart
         }
 
         // Collapse bins that would render identical swatches (same label and
-        // color) into one, so the legend doesn't show visual duplicates. The
-        // merged bin still matches all its underlying values, so hovering it
-        // highlights every country in any of the merged categories. Countries
-        // are still colored from the original, un-merged `colorScale.legendBins`.
+        // color) into one, so the legend doesn't show visual duplicates
         return mergeCategoricalBinsByLabelAndColor(categoricalLegendData)
     }
 

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
@@ -47,6 +47,7 @@ import {
     isNoDataBin,
     isNumericBin,
     isProjectedDataBin,
+    mergeCategoricalBinsByLabelAndColor,
     NumericBin,
 } from "../color/ColorScaleBin"
 import { LegendStyleConfig } from "../legend/LegendStyleConfig"
@@ -417,7 +418,12 @@ export class MapChart
             })
         }
 
-        return categoricalLegendData
+        // Collapse bins that would render identical swatches (same label and
+        // color) into one, so the legend doesn't show visual duplicates. The
+        // merged bin still matches all its underlying values, so hovering it
+        // highlights every country in any of the merged categories. Countries
+        // are still colored from the original, un-merged `colorScale.legendBins`.
+        return mergeCategoricalBinsByLabelAndColor(categoricalLegendData)
     }
 
     @computed private get hasCategoricalLegendData(): boolean {


### PR DESCRIPTION
> _Written by Claude Code — @pabloarosado at the wheel._

## What

On categorical world map charts, the legend renders one swatch per distinct category value. When several category values are assigned the **same label** and the **same color** (via `map.customCategoryLabels` / `map.customCategoryColors`), the legend shows multiple identical-looking swatches, i.e. visual duplicates.

This change collapses categorical legend bins that share the same displayed label **and** color into a single swatch, while preserving all interactive behavior.

## How

- `CategoricalBin` gains an optional `values` prop plus a `values` getter (defaulting to `[value]`). `contains(...)` now matches any of the bin's values instead of just its single `value`. The single-value path is byte-for-byte equivalent to before.
- A small pure helper, `mergeCategoricalBinsByLabelAndColor(bins)`, groups bins by `(label, color)`, preserves first-appearance order, and emits one merged bin per group. A merged bin keeps the first member's props (index, color, label, pattern) and gains the union of member values. Single-member groups keep their original object untouched.
- `MapChart.categoricalLegendData` applies this helper as its final step. Because a merged bin still `contains` all its underlying values, hovering the merged swatch highlights every country in any of the merged categories, and hovering a country still resolves back to the correct single swatch. Country fill colors are unchanged: they are still assigned from the un-merged `colorScale.legendBins`.
- `equals` is left as-is (index-based): a merged bin keeps a unique index, and all hover-matching comparisons happen within the same merged legend list, so it continues to resolve correctly.

## Backwards compatibility

The merge fires **only** when both the label and the color are already identical, so no existing chart can change in appearance except by collapsing swatches that already render as visual duplicates. Charts with distinct labels or colors are completely unaffected, and the default single-value code path is unchanged.

A scan of **all 1,632 published chart configurations** that use `map.customCategoryLabels` found **none** that map two different values to the same label. So no currently published chart changes appearance under this change; it only enables future charts that intentionally group categories under a shared label (e.g. a status map where a per-country year is embedded in the value but the legend should show the status alone).

## Tests

Extended `ColorScaleBin.test.ts`:
- bins with identical label + color collapse to a single legend entry;
- a merged bin's `contains` matches all member values, and it still `equals` its first member (so hover matching resolves to it);
- bins differing in label **or** color are not merged;
- a single-member group keeps its original bin object (no `values` set).
