### PR TITLE
Align dumbbell time-range legend labels with value labels

### DIFF
--- a/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChart.tsx
+++ b/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChart.tsx
@@ -50,7 +50,6 @@ import {
     DumbbellValueLabel,
     TOP_LEGEND_BOTTOM_PADDING,
     LegendLabel,
-    PlacedDumbbellHead,
     MIN_LEGEND_LABEL_GAP,
 } from "./DumbbellChartConstants"
 import { DumbbellChartState } from "./DumbbellChartState"
@@ -62,6 +61,7 @@ import {
     AxisLayout,
     calculateAxisLayout,
     computePercentChange,
+    toLeftRight,
 } from "./DumbbellChartHelpers"
 import { AnimatedRows } from "../animation/AnimatedRows"
 import { roundFontSize, textWidth } from "../chart/ChartUtils.js"
@@ -503,14 +503,18 @@ export class DumbbellChart
 
         if (!topSeries) return undefined
 
-        const resolveTextAnchor = ({
-            head,
-            otherHead,
-        }: {
-            head: PlacedDumbbellHead
-            otherHead: PlacedDumbbellHead
-        }): HorizontalAlign =>
-            head.x <= otherHead.x ? HorizontalAlign.right : HorizontalAlign.left
+        // Order the heads like the value labels do (including the tie-break
+        // for equal endpoints) so legend and value labels stay in sync.
+        // Labels are anchored on their inner edges: the label over the left
+        // head is right-aligned, the one over the right head is left-aligned
+        const { left: leftHead } = toLeftRight(topSeries.start, topSeries.end)
+        const startIsLeft = leftHead === topSeries.start
+        const startAnchor = startIsLeft
+            ? HorizontalAlign.right
+            : HorizontalAlign.left
+        const endAnchor = startIsLeft
+            ? HorizontalAlign.left
+            : HorizontalAlign.right
 
         const offset = (textAnchor: HorizontalAlign): number =>
             match(this.chartState.mode)
@@ -534,15 +538,6 @@ export class DumbbellChart
                         : -magnitude
                 })
                 .exhaustive()
-
-        const startAnchor = resolveTextAnchor({
-            head: topSeries.start,
-            otherHead: topSeries.end,
-        })
-        const endAnchor = resolveTextAnchor({
-            head: topSeries.end,
-            otherHead: topSeries.start,
-        })
 
         return [
             {

--- a/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChart.tsx
+++ b/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChart.tsx
@@ -411,12 +411,10 @@ export class DumbbellChart
                         start: {
                             text: formatColumn.formatTime(startTime),
                             color: GRAPHER_LIGHT_TEXT,
-                            textAnchor: "center",
                         } satisfies LegendLabel,
                         end: {
                             text: formatColumn.formatTime(endTime),
                             color: GRAPHER_LIGHT_TEXT,
-                            textAnchor: "center",
                         } satisfies LegendLabel,
                     }
                 })
@@ -429,12 +427,10 @@ export class DumbbellChart
                         start: {
                             text: startColumn.nonEmptyDisplayName,
                             color: darkenColorForText(columnColors.start),
-                            textAnchor: "outward",
                         } satisfies LegendLabel,
                         end: {
                             text: endColumn.nonEmptyDisplayName,
                             color: darkenColorForText(columnColors.end),
-                            textAnchor: "outward",
                         } satisfies LegendLabel,
                     }
                 })
@@ -491,49 +487,59 @@ export class DumbbellChart
 
         const sortedSeries = _.sortBy(this.placedSeries, (series) => series.y)
 
-        // Find the top-most series that has a visible change
-        const topSeries =
-            sortedSeries.find((s) => s.start.x !== s.end.x) ?? sortedSeries[0]
+        const topSeries = match(this.chartState.mode)
+            // In time-range mode, anchor to the top-most series so the
+            // legend labels align with its value labels
+            .with(DumbbellMode.TimeRange, () => sortedSeries[0])
+            // In two-column mode, anchor to the top-most series that has a
+            // visible change
+            .with(
+                DumbbellMode.TwoColumn,
+                () =>
+                    sortedSeries.find((s) => s.start.x !== s.end.x) ??
+                    sortedSeries[0]
+            )
+            .exhaustive()
 
         if (!topSeries) return undefined
 
         const resolveTextAnchor = ({
-            label,
             head,
             otherHead,
         }: {
-            label: LegendLabel
             head: PlacedDumbbellHead
             otherHead: PlacedDumbbellHead
         }): HorizontalAlign =>
-            match(label.textAnchor)
-                .with("center", () => HorizontalAlign.center)
-                .with("outward", () =>
-                    head.x <= otherHead.x
-                        ? HorizontalAlign.right
-                        : HorizontalAlign.left
-                )
-                .exhaustive()
+            head.x <= otherHead.x ? HorizontalAlign.right : HorizontalAlign.left
 
-        // Shift outward-anchored labels inward by a bit
-        const offsetMagnitude = Math.min(
-            20,
-            Math.floor(Math.abs(topSeries.end.x - topSeries.start.x) / 4)
-        )
-        const inwardOffset = (textAnchor: HorizontalAlign): number =>
-            match(textAnchor)
-                .with(HorizontalAlign.right, () => offsetMagnitude)
-                .with(HorizontalAlign.left, () => -offsetMagnitude)
-                .with(HorizontalAlign.center, () => 0)
+        const offset = (textAnchor: HorizontalAlign): number =>
+            match(this.chartState.mode)
+                // In time-range mode, shift labels outward by the same gap
+                // as the value labels so both align perfectly
+                .with(DumbbellMode.TimeRange, () =>
+                    textAnchor === HorizontalAlign.right
+                        ? -VALUE_LABEL_DOT_GAP
+                        : VALUE_LABEL_DOT_GAP
+                )
+                // In two-column mode, shift labels inward by a bit
+                .with(DumbbellMode.TwoColumn, () => {
+                    const magnitude = Math.min(
+                        20,
+                        Math.floor(
+                            Math.abs(topSeries.end.x - topSeries.start.x) / 4
+                        )
+                    )
+                    return textAnchor === HorizontalAlign.right
+                        ? magnitude
+                        : -magnitude
+                })
                 .exhaustive()
 
         const startAnchor = resolveTextAnchor({
-            label: legendLabels.start,
             head: topSeries.start,
             otherHead: topSeries.end,
         })
         const endAnchor = resolveTextAnchor({
-            label: legendLabels.end,
             head: topSeries.end,
             otherHead: topSeries.start,
         })
@@ -541,13 +547,13 @@ export class DumbbellChart
         return [
             {
                 text: legendLabels.start.text,
-                x: topSeries.start.x + inwardOffset(startAnchor),
+                x: topSeries.start.x + offset(startAnchor),
                 color: legendLabels.start.color,
                 textAnchor: startAnchor,
             },
             {
                 text: legendLabels.end.text,
-                x: topSeries.end.x + inwardOffset(endAnchor),
+                x: topSeries.end.x + offset(endAnchor),
                 color: legendLabels.end.color,
                 textAnchor: endAnchor,
             },

--- a/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChartConstants.ts
+++ b/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChartConstants.ts
@@ -133,7 +133,6 @@ export const DUMBBELL_STYLE: Record<Emphasis, DumbbellStyle> = {
 export interface LegendLabel {
     text: string
     color: string
-    textAnchor: "center" | "outward"
 }
 
 export const DUMBBELL_SORT_KEYS = [


### PR DESCRIPTION
In time-range mode, the inline legend's year labels were centered over the top dumbbell's dots. They are now anchored on their inner edges (right-aligned over the left dot, left-aligned over the right dot) and shifted outward by the value-label gap, so they align exactly with the value labels of the top-most dumbbell. The legend also now anchors to the actual top-most row (zero-gap rows no longer need to be skipped with outward anchoring).

Two-column mode keeps its inward nudge, so column label placement is unchanged. The now-constant `textAnchor` field is removed from `LegendLabel`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)