### PR TITLE
Preserve selectedEntityNames when switching to Marimekko/Scatter

### DIFF
--- a/adminSiteClient/EditorBasicTab.test.tsx
+++ b/adminSiteClient/EditorBasicTab.test.tsx
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest"
+import { GRAPHER_CHART_TYPES } from "@ourworldindata/types"
+import { GrapherState } from "@ourworldindata/grapher"
+import { DimensionSlotView } from "./EditorBasicTab.js"
+
+describe("DimensionSlotView#updateDefaultSelection", () => {
+    it("keeps an existing entity selection when switching to Marimekko", async () => {
+        const grapherState = new GrapherState({
+            chartTypes: [GRAPHER_CHART_TYPES.LineChart],
+            selectedEntityNames: ["France", "Germany"],
+        })
+
+        const view = new DimensionSlotView({
+            slot: {} as any,
+            editor: { grapherState } as any,
+            database: {} as any,
+            errorMessagesForDimensions: {} as any,
+        })
+
+        // Mirrors checking the "Marimekko" chart type checkbox in the
+        // admin, which replaces the chart's chartTypes list.
+        grapherState.chartTypes = [GRAPHER_CHART_TYPES.Marimekko]
+
+        await (view as any).updateDefaultSelection()
+
+        expect(grapherState.selection.selectedEntityNames).toEqual([
+            "France",
+            "Germany",
+        ])
+    })
+})

--- a/adminSiteClient/EditorBasicTab.tsx
+++ b/adminSiteClient/EditorBasicTab.tsx
@@ -83,7 +83,7 @@ interface DimensionSlotViewProps<Editor> {
 }
 
 @observer
-class DimensionSlotView<
+export class DimensionSlotView<
     Editor extends AbstractChartEditor,
 > extends React.Component<DimensionSlotViewProps<Editor>> {
     disposers: IReactionDisposer[] = []
@@ -237,8 +237,9 @@ class DimensionSlotView<
 
         if (grapherState.isScatter || grapherState.isMarimekko) {
             // Chart types that display all entities shouldn't select
-            // any entity by default
-            selection.clearSelection()
+            // any entity by default, but an existing selection (e.g. one
+            // that was authored) should be left untouched
+            return
         } else if (
             nonProjectedYColumns.length > 1 &&
             !grapherState.hasStackedArea &&

--- a/packages/@ourworldindata/grapher/src/core/GrapherState.test.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.test.ts
@@ -663,26 +663,81 @@ describe("urls", () => {
         expect(grapher.isTimelineAnimationPlaying).toBe(false)
     })
 
-    it("keeps an authored entity selection when switching to Marimekko in the editor", () => {
+    it("keeps an authored entity selection when switching to Marimekko", () => {
+        const grapher = new GrapherState({
+            chartTypes: [
+                GRAPHER_CHART_TYPES.LineChart,
+                GRAPHER_CHART_TYPES.Marimekko,
+            ],
+            selectedEntityNames: ["World"],
+        })
+
+        const previousTab = grapher.activeTab
+        grapher.setTab(GRAPHER_TAB_NAMES.Marimekko)
+        grapher.onTabChange(previousTab, GRAPHER_TAB_NAMES.Marimekko)
+
+        expect(grapher.selection.selectedEntityNames).toEqual(["World"])
+    })
+
+    // A scatter plot moves unselected entities into a faded background
+    // layer, so a selection authored for a sibling tab (e.g. a line chart)
+    // is cleared when switching to the scatter tab
+    const makeScatterGrapher = (): GrapherState => {
+        const table = SynthesizeGDPTable({
+            entityCount: 5,
+            timeRange: [2000, 2001],
+        })
+        return new GrapherState({
+            table,
+            chartTypes: [
+                GRAPHER_CHART_TYPES.LineChart,
+                GRAPHER_CHART_TYPES.ScatterPlot,
+            ],
+            selectedEntityNames: table.availableEntityNames.slice(0, 2),
+            dimensions: [
+                {
+                    slug: SampleColumnSlugs.GDP,
+                    property: DimensionProperty.y,
+                    variableId: SampleColumnSlugs.GDP as any,
+                },
+                {
+                    slug: SampleColumnSlugs.Population,
+                    property: DimensionProperty.x,
+                    variableId: SampleColumnSlugs.Population as any,
+                },
+            ],
+        })
+    }
+
+    it("clears an authored entity selection when switching to a scatter plot", () => {
+        const grapher = makeScatterGrapher()
+        expect(grapher.selection.hasSelection).toBe(true)
+
+        const previousTab = grapher.activeTab
+        grapher.setTab(GRAPHER_TAB_NAMES.ScatterPlot)
+        grapher.onTabChange(previousTab, GRAPHER_TAB_NAMES.ScatterPlot)
+
+        expect(grapher.selection.selectedEntityNames).toEqual([])
+    })
+
+    it("keeps an authored entity selection when switching to a scatter plot in the editor", () => {
         // `isEditor` is read from `window.isEditor` at construction time,
         // mirroring how the admin chart editor marks itself. This test file
         // runs in a plain (non-jsdom) environment, so `window` doesn't
         // otherwise exist here.
         ;(globalThis as any).window = { isEditor: true }
         try {
-            const grapher = new GrapherState({
-                chartTypes: [
-                    GRAPHER_CHART_TYPES.LineChart,
-                    GRAPHER_CHART_TYPES.Marimekko,
-                ],
-                selectedEntityNames: ["World"],
-            })
+            const grapher = makeScatterGrapher()
+            const selectedEntityNames = grapher.selection.selectedEntityNames
+            expect(selectedEntityNames).toHaveLength(2)
 
             const previousTab = grapher.activeTab
-            grapher.setTab(GRAPHER_TAB_NAMES.Marimekko)
-            grapher.onTabChange(previousTab, GRAPHER_TAB_NAMES.Marimekko)
+            grapher.setTab(GRAPHER_TAB_NAMES.ScatterPlot)
+            grapher.onTabChange(previousTab, GRAPHER_TAB_NAMES.ScatterPlot)
 
-            expect(grapher.selection.selectedEntityNames).toEqual(["World"])
+            expect(grapher.selection.selectedEntityNames).toEqual(
+                selectedEntityNames
+            )
         } finally {
             delete (globalThis as any).window
         }

--- a/packages/@ourworldindata/grapher/src/core/GrapherState.test.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.test.ts
@@ -670,19 +670,42 @@ describe("urls", () => {
         // otherwise exist here.
         ;(globalThis as any).window = { isEditor: true }
         try {
+            const table = SynthesizeGDPTable({
+                entityCount: 3,
+                timeRange: [2000, 2010],
+            })
+            const selectedEntityNames = table.availableEntityNames.slice(0, 2)
             const grapher = new GrapherState({
+                table,
                 chartTypes: [
                     GRAPHER_CHART_TYPES.LineChart,
                     GRAPHER_CHART_TYPES.Marimekko,
                 ],
-                selectedEntityNames: ["World"],
+                selectedEntityNames,
+                dimensions: [
+                    {
+                        slug: SampleColumnSlugs.GDP,
+                        property: DimensionProperty.y,
+                        variableId: SampleColumnSlugs.GDP as any,
+                    },
+                ],
             })
 
             const previousTab = grapher.activeTab
             grapher.setTab(GRAPHER_TAB_NAMES.Marimekko)
             grapher.onTabChange(previousTab, GRAPHER_TAB_NAMES.Marimekko)
 
-            expect(grapher.selection.selectedEntityNames).toEqual(["World"])
+            expect(grapher.selection.selectedEntityNames).toEqual(
+                selectedEntityNames
+            )
+
+            // The time handles should also be left untouched in the editor
+            // (outside the editor, switching to a single-time chart type
+            // like Marimekko moves both handles to the same time)
+            expect(grapher.timelineHandleTimeBounds).toEqual([
+                -Infinity,
+                Infinity,
+            ])
         } finally {
             delete (globalThis as any).window
         }

--- a/packages/@ourworldindata/grapher/src/core/GrapherState.test.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.test.ts
@@ -663,81 +663,26 @@ describe("urls", () => {
         expect(grapher.isTimelineAnimationPlaying).toBe(false)
     })
 
-    it("keeps an authored entity selection when switching to Marimekko", () => {
-        const grapher = new GrapherState({
-            chartTypes: [
-                GRAPHER_CHART_TYPES.LineChart,
-                GRAPHER_CHART_TYPES.Marimekko,
-            ],
-            selectedEntityNames: ["World"],
-        })
-
-        const previousTab = grapher.activeTab
-        grapher.setTab(GRAPHER_TAB_NAMES.Marimekko)
-        grapher.onTabChange(previousTab, GRAPHER_TAB_NAMES.Marimekko)
-
-        expect(grapher.selection.selectedEntityNames).toEqual(["World"])
-    })
-
-    // A scatter plot moves unselected entities into a faded background
-    // layer, so a selection authored for a sibling tab (e.g. a line chart)
-    // is cleared when switching to the scatter tab
-    const makeScatterGrapher = (): GrapherState => {
-        const table = SynthesizeGDPTable({
-            entityCount: 5,
-            timeRange: [2000, 2001],
-        })
-        return new GrapherState({
-            table,
-            chartTypes: [
-                GRAPHER_CHART_TYPES.LineChart,
-                GRAPHER_CHART_TYPES.ScatterPlot,
-            ],
-            selectedEntityNames: table.availableEntityNames.slice(0, 2),
-            dimensions: [
-                {
-                    slug: SampleColumnSlugs.GDP,
-                    property: DimensionProperty.y,
-                    variableId: SampleColumnSlugs.GDP as any,
-                },
-                {
-                    slug: SampleColumnSlugs.Population,
-                    property: DimensionProperty.x,
-                    variableId: SampleColumnSlugs.Population as any,
-                },
-            ],
-        })
-    }
-
-    it("clears an authored entity selection when switching to a scatter plot", () => {
-        const grapher = makeScatterGrapher()
-        expect(grapher.selection.hasSelection).toBe(true)
-
-        const previousTab = grapher.activeTab
-        grapher.setTab(GRAPHER_TAB_NAMES.ScatterPlot)
-        grapher.onTabChange(previousTab, GRAPHER_TAB_NAMES.ScatterPlot)
-
-        expect(grapher.selection.selectedEntityNames).toEqual([])
-    })
-
-    it("keeps an authored entity selection when switching to a scatter plot in the editor", () => {
+    it("keeps an authored entity selection when switching to Marimekko in the editor", () => {
         // `isEditor` is read from `window.isEditor` at construction time,
         // mirroring how the admin chart editor marks itself. This test file
         // runs in a plain (non-jsdom) environment, so `window` doesn't
         // otherwise exist here.
         ;(globalThis as any).window = { isEditor: true }
         try {
-            const grapher = makeScatterGrapher()
-            const selectedEntityNames = grapher.selection.selectedEntityNames
-            expect(selectedEntityNames).toHaveLength(2)
+            const grapher = new GrapherState({
+                chartTypes: [
+                    GRAPHER_CHART_TYPES.LineChart,
+                    GRAPHER_CHART_TYPES.Marimekko,
+                ],
+                selectedEntityNames: ["World"],
+            })
 
             const previousTab = grapher.activeTab
-            grapher.setTab(GRAPHER_TAB_NAMES.ScatterPlot)
-            grapher.onTabChange(previousTab, GRAPHER_TAB_NAMES.ScatterPlot)
+            grapher.setTab(GRAPHER_TAB_NAMES.Marimekko)
+            grapher.onTabChange(previousTab, GRAPHER_TAB_NAMES.Marimekko)
 
-            expect(grapher.selection.selectedEntityNames).toEqual(
-                selectedEntityNames
-            )
+            expect(grapher.selection.selectedEntityNames).toEqual(["World"])
         } finally {
             delete (globalThis as any).window
         }

--- a/packages/@ourworldindata/grapher/src/core/GrapherState.test.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.test.ts
@@ -662,6 +662,31 @@ describe("urls", () => {
         expect(grapher.disablePlay).toBe(true)
         expect(grapher.isTimelineAnimationPlaying).toBe(false)
     })
+
+    it("keeps an authored entity selection when switching to Marimekko in the editor", () => {
+        // `isEditor` is read from `window.isEditor` at construction time,
+        // mirroring how the admin chart editor marks itself. This test file
+        // runs in a plain (non-jsdom) environment, so `window` doesn't
+        // otherwise exist here.
+        ;(globalThis as any).window = { isEditor: true }
+        try {
+            const grapher = new GrapherState({
+                chartTypes: [
+                    GRAPHER_CHART_TYPES.LineChart,
+                    GRAPHER_CHART_TYPES.Marimekko,
+                ],
+                selectedEntityNames: ["World"],
+            })
+
+            const previousTab = grapher.activeTab
+            grapher.setTab(GRAPHER_TAB_NAMES.Marimekko)
+            grapher.onTabChange(previousTab, GRAPHER_TAB_NAMES.Marimekko)
+
+            expect(grapher.selection.selectedEntityNames).toEqual(["World"])
+        } finally {
+            delete (globalThis as any).window
+        }
+    })
 })
 
 describe("time domain tests", () => {

--- a/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
@@ -2017,19 +2017,17 @@ export class GrapherState
         const isChartTypeThatShowsAllEntities =
             this.isChartTypeThatShowsAllEntities(tab)
 
-        // On a scatter plot, a selection moves all other entities into a
-        // faded background layer, so a selection authored for another tab
-        // (e.g. a line chart) would visually filter the scatter. We therefore
-        // clear the selection unless the user has explicitly changed it.
-        // This intentionally does NOT apply to:
-        // - Marimekko charts, where a selection only bolds and prioritises
-        //   entity labels and hides nothing, and where most published charts
-        //   share their selection with sibling tabs like a line chart
-        // - the editor, which persists the live selection on save, so this
-        //   temporary display adjustment would permanently wipe an authored
-        //   selection (see #6794)
+        // If the chart show all entities (e.g. scatter plot or Marimekko chart),
+        // then we typically prefer no selection unless the user has explicitly
+        // made changes to the default selection.
+        // In the editor, this clearing is skipped: it's meant to be a
+        // temporary, display-only adjustment that gets restored when
+        // switching back to a tab that shows a subset of entities, but the
+        // editor can persist the live selection as-is when saving, which
+        // would otherwise wipe out an authored selection just by previewing
+        // a different chart type.
         if (
-            tab === GRAPHER_TAB_NAMES.ScatterPlot &&
+            isChartTypeThatShowsAllEntities &&
             !this.areSelectedEntitiesDifferentThanAuthors &&
             !this.isEditor
         ) {

--- a/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
@@ -2019,17 +2019,10 @@ export class GrapherState
 
         // If the chart show all entities (e.g. scatter plot or Marimekko chart),
         // then we typically prefer no selection unless the user has explicitly
-        // made changes to the default selection.
-        // In the editor, this clearing is skipped: it's meant to be a
-        // temporary, display-only adjustment that gets restored when
-        // switching back to a tab that shows a subset of entities, but the
-        // editor can persist the live selection as-is when saving, which
-        // would otherwise wipe out an authored selection just by previewing
-        // a different chart type.
+        // made changes to the default selection
         if (
             isChartTypeThatShowsAllEntities &&
-            !this.areSelectedEntitiesDifferentThanAuthors &&
-            !this.isEditor
+            !this.areSelectedEntitiesDifferentThanAuthors
         ) {
             this.selection.clearSelection()
         }
@@ -2048,8 +2041,14 @@ export class GrapherState
                 "adjustStateForTab has been called before grapher has loaded its data, this is probably a mistake"
             )
 
-        this.ensureEntitySelectionIsSensibleForTab(tab)
-        this.ensureTimeHandlesAreSensibleForTab(tab)
+        // Skip in the editor: these adjustments mutate the entity selection
+        // and time handles as a side effect of switching tabs, and the editor
+        // persists the live state on save, which would silently alter the
+        // authored config (see #6794)
+        if (!this.isEditor) {
+            this.ensureEntitySelectionIsSensibleForTab(tab)
+            this.ensureTimeHandlesAreSensibleForTab(tab)
+        }
 
         // Stop animation when switching to a tab where playback is disabled
         if (this.disablePlay && this.isTimelineAnimationActive) {

--- a/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
@@ -2019,10 +2019,17 @@ export class GrapherState
 
         // If the chart show all entities (e.g. scatter plot or Marimekko chart),
         // then we typically prefer no selection unless the user has explicitly
-        // made changes to the default selection
+        // made changes to the default selection.
+        // In the editor, this clearing is skipped: it's meant to be a
+        // temporary, display-only adjustment that gets restored when
+        // switching back to a tab that shows a subset of entities, but the
+        // editor can persist the live selection as-is when saving, which
+        // would otherwise wipe out an authored selection just by previewing
+        // a different chart type.
         if (
             isChartTypeThatShowsAllEntities &&
-            !this.areSelectedEntitiesDifferentThanAuthors
+            !this.areSelectedEntitiesDifferentThanAuthors &&
+            !this.isEditor
         ) {
             this.selection.clearSelection()
         }

--- a/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
@@ -2017,17 +2017,19 @@ export class GrapherState
         const isChartTypeThatShowsAllEntities =
             this.isChartTypeThatShowsAllEntities(tab)
 
-        // If the chart show all entities (e.g. scatter plot or Marimekko chart),
-        // then we typically prefer no selection unless the user has explicitly
-        // made changes to the default selection.
-        // In the editor, this clearing is skipped: it's meant to be a
-        // temporary, display-only adjustment that gets restored when
-        // switching back to a tab that shows a subset of entities, but the
-        // editor can persist the live selection as-is when saving, which
-        // would otherwise wipe out an authored selection just by previewing
-        // a different chart type.
+        // On a scatter plot, a selection moves all other entities into a
+        // faded background layer, so a selection authored for another tab
+        // (e.g. a line chart) would visually filter the scatter. We therefore
+        // clear the selection unless the user has explicitly changed it.
+        // This intentionally does NOT apply to:
+        // - Marimekko charts, where a selection only bolds and prioritises
+        //   entity labels and hides nothing, and where most published charts
+        //   share their selection with sibling tabs like a line chart
+        // - the editor, which persists the live selection on save, so this
+        //   temporary display adjustment would permanently wipe an authored
+        //   selection (see #6794)
         if (
-            isChartTypeThatShowsAllEntities &&
+            tab === GRAPHER_TAB_NAMES.ScatterPlot &&
             !this.areSelectedEntitiesDifferentThanAuthors &&
             !this.isEditor
         ) {


### PR DESCRIPTION
## Summary
There were two independent places in the admin that could permanently clear `selectedEntityNames` when a chart's active chart type became Scatter or Marimekko:

- `DimensionSlotView.updateDefaultSelection()` (admin-only) unconditionally called `selection.clearSelection()` whenever the chart type was Scatter or Marimekko, even if a selection (e.g. an authored `selectedEntityNames`) already existed. Every other chart-type branch in that method only sets default entities when the selection is empty; Scatter/Marimekko were the only ones actively wiping out an existing selection. Fixed by making that branch a no-op instead (new charts still get no auto-picked default selection, matching the original intent from #965).
- `GrapherState.ensureEntitySelectionIsSensibleForTab()` clears the selection whenever it still matches the authored config and the new tab is a "shows all entities" type (Scatter/Marimekko). On the live site this is a temporary display adjustment that gets restored when switching back to a normal tab. But the chart editor persists the live selection as-is on save, so simply previewing Marimekko/Scatter via the chart-type tab switcher and clicking "Update chart" silently wiped `selectedEntityNames` — this is the exact repro in #6794. Fixed by skipping the clearing when `grapherState.isEditor` is true.

**Viewer-facing behavior is unchanged**: on the live site, switching to a Marimekko/scatter tab still clears the selection unless the user has customized it — per review, that's intentional (these chart types work better without entities highlighted by default). An earlier commit on this branch that changed this for Marimekko was reverted.

Fixes #6794.

## Test plan
- [x] Added a failing-then-passing test (`adminSiteClient/EditorBasicTab.test.tsx`) reproducing the first bug: switching `chartTypes` to Marimekko previously cleared `selectedEntityNames`.
- [x] Added a failing-then-passing test (`GrapherState.test.ts`) reproducing the second bug: switching the active tab to Marimekko in the editor previously cleared `selectedEntityNames`.
- [x] `yarn test run --reporter dot packages/@ourworldindata/grapher/ adminSiteClient/` — all tests pass.
- [x] `yarn testFormatChanged` / `yarn testLintChanged` clean on changed files.
- [x] Manually reproduced against chart 639 locally (`make up.headless`): enabled Marimekko, switched to it via the chart-type tab switcher, clicked "Update chart", and confirmed via a direct DB query that `selectedEntityNames` was preserved (`["World"]`) after save.
- [x] Verified viewer-facing pages in a browser locally: scatter tab switches still clear an authored-matching selection (`air-pollution-vs-gdp-per-capita`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
