### PR TITLE
📜 Add public-export review step to DB migration checklist

### DIFF
--- a/db/migration/CLAUDE.md
+++ b/db/migration/CLAUDE.md
@@ -5,8 +5,22 @@ When a new migration is added, make sure that:
 - If columns have been added/deleted, all necessary views were recreated that reference one of the modified columns
 - The DB type definitions in the /packages/@ourworldindata/types/src/dbTypes folder have been updated
 - The docs in ../docs/ have been updated
+- **The impact on the public data export has been reviewed** (see [below](#public-data-export-datasette--publicduckdb)) — adding, dropping, or renaming a table or column can leak private data into, or break, the public `public.duckdb` published on Datasette
 
-Additionally, make sure you tell the user to make sure that it may be necessary to adjust the code in:
+Additionally, make sure you tell the user that it may be necessary to adjust the code in:
 
 - the owid/etl repository and
 - the owid/analytics repository
+
+### Public data export (Datasette / `public.duckdb`)
+
+A sanitized, **published-content-only** copy of this database is exported nightly to the public as `public.duckdb` (browsable on [datasette-public.owid.io](https://datasette-public.owid.io) and available as an open download). What it exposes is an **explicit allowlist** defined in the **`owid/analytics`** repo (`analytics/duckdb/build.py` plus the reviewed snapshot `analytics/duckdb/public_schema.json`). The nightly analytics bake fails if the built schema drifts from that allowlist, so an unreviewed schema change will break the pipeline (e.g. [build #793](https://buildkite.com/our-world-in-data/analytics-full-bake-daily/builds/793): `SCHEMA DRIFT ... REMOVED COLUMN redirects.{code}`).
+
+We have previously leaked data we did not intend to publish, so treat this as a **required review step** whenever a migration adds, drops, or renames a table or column:
+
+- **New table or column** → decide whether it is safe to publish. **When in doubt, keep it out.** Never publish drafts / unpublished content, PII (emails, tokens), editor/reviewer ids, internal flags, or free-text editorial notes. Only field-level metadata that is already visible on published pages of ourworldindata.org should go public.
+- **Dropped or renamed column that was public** → this is a breaking change for downstream consumers of `public.duckdb` and must be announced.
+
+To action either case, run the **`fix-public-export-drift` skill** (in the `owid/analytics` repo). It walks through excluding a field or blessing it into the allowlist and regenerating `public_schema.json` — the committed diff to that file is the review record for widening the public surface.
+
+**If you are unsure whether a field is safe to publish, ask the analytics team (`#data-analytics` on Slack) before merging — do not publish by default.**

--- a/db/readme.md
+++ b/db/readme.md
@@ -39,6 +39,10 @@ Make sure you write a **down** migration in case there is any chance things can 
 
 You can find examples of older migrations here: https://github.com/owid/owid-grapher/tree/2dd7f0661ba6fe7fdfb1ad2a59b9ef7ed7a2ad9f/db/migration
 
+### After a schema change
+
+Adding, dropping, or renaming tables or columns has effects beyond this repo. Go through the [checklist in `db/migration/CLAUDE.md`](./migration/CLAUDE.md) before merging. In particular, review whether the change affects the **public data export** (`public.duckdb`, published openly on Datasette): unreviewed schema changes break the nightly analytics bake and can leak private data. When in doubt, keep it out and ask the analytics team (`#data-analytics`).
+
 ### Reverting a migration
 
 To revert the last migration on **your local development server**, use `yarn revertLastDbMigration`. Running that repeatedly will revert additional migrations. This is useful when working with migrations locally – when you make a change to an existing migration, you need to revert and re-run it.


### PR DESCRIPTION
## Context

MySQL schema changes flow downstream into the **public data export** (`public.duckdb`, published openly on Datasette + as an open download). That export is a published-content-only allowlist defined in `owid/analytics`, and the nightly analytics bake **fails** if a migration drifts the schema from the reviewed allowlist — e.g. [analytics-full-bake-daily #793](https://buildkite.com/our-world-in-data/analytics-full-bake-daily/builds/793) (`SCHEMA DRIFT ... REMOVED COLUMN redirects.{code}`). We have previously leaked data we did not intend to publish, so this needs to be an explicit review step, not something caught after the fact.

This adds that step to the migration checklist devs/agents follow:

- **`db/migration/CLAUDE.md`** — new "Public data export" review item + subsection: the publish/keep-private decision (default: keep it out — no drafts, PII, internal ids/flags, or editorial notes), a pointer to the `fix-public-export-drift` skill in `owid/analytics`, and to ping `#data-analytics` when unsure. Also notes the reverse case: dropping/renaming a previously-public column is a breaking change for downstream consumers.
- **`db/readme.md`** — short pointer to the checklist from the human-facing Migrations docs.

Docs-only change.

## Testing guidance

- Read the rendered [`db/migration/CLAUDE.md`](https://github.com/owid/owid-grapher/blob/list-tasks-mysql-db-updated/db/migration/CLAUDE.md) and [`db/readme.md`](https://github.com/owid/owid-grapher/blob/list-tasks-mysql-db-updated/db/readme.md); confirm the guidance and links read correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
