### PR TITLE
🐝 Enable hardlinks-global nmMode to dedupe node_modules across worktrees

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -10,6 +10,8 @@ logFilters:
   - code: YN0013
     level: discard
 
+nmMode: hardlinks-global
+
 nodeLinker: node-modules
 
 npmMinimalAgeGate: 72h


### PR DESCRIPTION
> _Written by Claude Fable 5 — @Marigold at the wheel._

## Why

Every `git worktree` on this repo does its own full `yarn install`. With Yarn's default `nmMode` (`classic`), that produces a fully independent copy of every installed package per worktree — confirmed directly: two separate worktrees installing the same package ended up with different inodes (`nlink=1` each). Across several parallel worktrees that's multiple GB of pure duplication of identical package versions.

## What

Set `nmMode: hardlinks-global` in `.yarnrc.yml`. This makes Yarn link package files from its global store into each worktree's `node_modules` instead of copying them.

Verified with a real test: two separate worktrees, each doing a fresh `yarn install` under this setting, ended up with the exact same inode for the same package file (`nlink=3` — one link per worktree plus the global store). The marginal disk cost of an additional worktree's `node_modules` drops to close to zero.

Safe because installed package files are never modified in place after install, so there's no risk of one worktree's install affecting another's.
