### PR TITLE
🔨 Pass VITE_PORT to the admin dev server in tmux targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ up: require create-if-missing.env tmp-downloads/owid_metadata.sql.gz node_module
 			set remain-on-exit on \; \
 		set-option -g default-shell $(SCRIPT_SHELL) \; \
 		new-window -n admin \
-			'ADMIN_SERVER_PORT=$(ADMIN_SERVER_PORT) devTools/docker/wait-for-mysql.sh && ADMIN_SERVER_PORT=$(ADMIN_SERVER_PORT) yarn startAdminDevServer' \; \
+			'ADMIN_SERVER_PORT=$(ADMIN_SERVER_PORT) devTools/docker/wait-for-mysql.sh && ADMIN_SERVER_PORT=$(ADMIN_SERVER_PORT) VITE_PORT=$(VITE_PORT) yarn startAdminDevServer' \; \
 			set remain-on-exit on \; \
 		new-window -n vite 'VITE_PORT=$(VITE_PORT) yarn run startSiteFront' \; \
 			set remain-on-exit on \; \
@@ -112,7 +112,7 @@ up.devcontainer: create-if-missing.env.devcontainer tmp-downloads/owid_metadata.
 	@mkdir -p logs
 	tmux new-session -s $(TMUX_SESSION_NAME) \
 		-n admin \
-			'ADMIN_SERVER_PORT=$(ADMIN_SERVER_PORT) devTools/docker/wait-for-mysql.sh && ADMIN_SERVER_PORT=$(ADMIN_SERVER_PORT) yarn startAdminDevServer' \; \
+			'ADMIN_SERVER_PORT=$(ADMIN_SERVER_PORT) devTools/docker/wait-for-mysql.sh && ADMIN_SERVER_PORT=$(ADMIN_SERVER_PORT) VITE_PORT=$(VITE_PORT) yarn startAdminDevServer' \; \
 			set remain-on-exit on \; \
 		new-window -n vite 'VITE_PORT=$(VITE_PORT) yarn run startSiteFront' \; \
 			set remain-on-exit on \; \
@@ -157,7 +157,7 @@ up.full: require create-if-missing.env.full tmp-downloads/owid_metadata.sql.gz n
 			set remain-on-exit on \; \
 		set-option -g default-shell $(SCRIPT_SHELL) \; \
 		new-window -n admin \
-			'ADMIN_SERVER_PORT=$(ADMIN_SERVER_PORT) devTools/docker/wait-for-mysql.sh && ADMIN_SERVER_PORT=$(ADMIN_SERVER_PORT) yarn startAdminDevServer' \; \
+			'ADMIN_SERVER_PORT=$(ADMIN_SERVER_PORT) devTools/docker/wait-for-mysql.sh && ADMIN_SERVER_PORT=$(ADMIN_SERVER_PORT) VITE_PORT=$(VITE_PORT) yarn startAdminDevServer' \; \
 			set remain-on-exit on \; \
 		new-window -n vite 'VITE_PORT=$(VITE_PORT) yarn run startSiteFront' \; \
 			set remain-on-exit on \; \


### PR DESCRIPTION
> _Written by Anthropic Claude Fable 5 — @sophiamersmann at the wheel._

When a tmux server is already running, `tmux new-session` gives new sessions the *server's* environment, not the exports of the `make` invocation that creates them. With two checkouts running side by side (on different ports via `.env`), the second checkout's admin server then inherits the first checkout's `VITE_PORT` — dotenv doesn't override variables that already exist — and renders its dev asset URLs against the wrong vite instance. The page loads fine but serves the other checkout's JavaScript, which is confusing to debug.

The Makefile already guards against this for `ADMIN_SERVER_PORT` by passing it explicitly on the tmux window's command line; this does the same for `VITE_PORT` in the `up`, `up.devcontainer`, and `up.full` targets. `up.headless` is unaffected (no tmux server in between).

🤖 Generated with [Claude Code](https://claude.com/claude-code)