### PR TITLE
Rewrite bare "ai" query to "artificial intelligence" in app code

### DIFF
--- a/baker/algolia/configureAlgolia.ts
+++ b/baker/algolia/configureAlgolia.ts
@@ -1,5 +1,5 @@
 import { algoliasearch, SearchClient } from "algoliasearch"
-import type { SynonymHit, IndexSettings } from "@algolia/client-search"
+import type { SynonymHit, IndexSettings, Rule } from "@algolia/client-search"
 import {
     ALGOLIA_ID,
     TOPICS_CONTENT_GRAPH,
@@ -212,6 +212,30 @@ export const configureAlgolia = async () => {
             indexName,
             synonymHit: algoliaSynonyms,
             replaceExistingSynonyms: true,
+        })
+    }
+
+    // "ai" is short enough that Algolia's default prefix search matches it
+    // against any word starting with "ai" (aid, air, aids, aviation...).
+    // Those prefix matches all tie on relevance, so ranking falls back to
+    // raw popularity and buries the actual AI content (see #6771). A
+    // synonym doesn't help here - it only adds more tied matches. Rewriting
+    // the query to the unambiguous "artificial intelligence" restores
+    // exact-match ranking. `anchoring: "is"` limits this to the bare query
+    // "ai", so longer queries that merely contain the word are unaffected.
+    const rules: Rule[] = [
+        {
+            objectID: "ai-query-replacement",
+            conditions: [{ pattern: "ai", anchoring: "is" }],
+            consequence: { params: { query: "artificial intelligence" } },
+        },
+    ]
+
+    for (const indexName of [pagesIndexName, explorerViewsAndChartsIndexName]) {
+        await client.saveRules({
+            indexName,
+            rules,
+            forwardToReplicas: true,
         })
     }
 

--- a/baker/algolia/configureAlgolia.ts
+++ b/baker/algolia/configureAlgolia.ts
@@ -1,5 +1,5 @@
 import { algoliasearch, SearchClient } from "algoliasearch"
-import type { SynonymHit, IndexSettings, Rule } from "@algolia/client-search"
+import type { SynonymHit, IndexSettings } from "@algolia/client-search"
 import {
     ALGOLIA_ID,
     TOPICS_CONTENT_GRAPH,
@@ -212,30 +212,6 @@ export const configureAlgolia = async () => {
             indexName,
             synonymHit: algoliaSynonyms,
             replaceExistingSynonyms: true,
-        })
-    }
-
-    // "ai" is short enough that Algolia's default prefix search matches it
-    // against any word starting with "ai" (aid, air, aids, aviation...).
-    // Those prefix matches all tie on relevance, so ranking falls back to
-    // raw popularity and buries the actual AI content (see #6771). A
-    // synonym doesn't help here - it only adds more tied matches. Rewriting
-    // the query to the unambiguous "artificial intelligence" restores
-    // exact-match ranking. `anchoring: "is"` limits this to the bare query
-    // "ai", so longer queries that merely contain the word are unaffected.
-    const rules: Rule[] = [
-        {
-            objectID: "ai-query-replacement",
-            conditions: [{ pattern: "ai", anchoring: "is" }],
-            consequence: { params: { query: "artificial intelligence" } },
-        },
-    ]
-
-    for (const indexName of [pagesIndexName, explorerViewsAndChartsIndexName]) {
-        await client.saveRules({
-            indexName,
-            rules,
-            forwardToReplicas: true,
         })
     }
 

--- a/site/search/queries.ts
+++ b/site/search/queries.ts
@@ -27,6 +27,7 @@ import {
     PAGES_CHRONOLOGICAL_INDEX,
     DATA_CATALOG_ATTRIBUTES,
     formatDisjunctiveFacetFilters,
+    resolveSearchQuery,
 } from "./searchUtils.js"
 import {
     buildChartsFacetFilters,
@@ -111,7 +112,7 @@ export async function queryDataTopics(
         return {
             indexName: CHARTS_INDEX,
             attributesToRetrieve: DATA_CATALOG_ATTRIBUTES,
-            query: state.query,
+            query: resolveSearchQuery(state.query),
             facetFilters: facetFilters,
             highlightPreTag: "<mark>",
             highlightPostTag: "</mark>",
@@ -160,7 +161,7 @@ export async function queryCharts(
     const searchParams = {
         indexName: CHARTS_INDEX,
         attributesToRetrieve: DATA_CATALOG_ATTRIBUTES,
-        query: state.query,
+        query: resolveSearchQuery(state.query),
         facetFilters,
         highlightPreTag: "<mark>",
         highlightPostTag: "</mark>",
@@ -189,7 +190,7 @@ export async function queryDataInsights(
     // Using the selected countries as query search terms until data insights
     // are tagged with countries.
     const query = [
-        state.query,
+        resolveSearchQuery(state.query),
         // Use advanced syntax to search for countries as exact phrases
         ...selectedCountryNames.keys().map((c) => `"${c}"`),
     ]
@@ -238,7 +239,7 @@ export async function queryArticles(
     // Using the selected countries as query search terms until articles
     // are tagged with countries.
     const query = [
-        state.query,
+        resolveSearchQuery(state.query),
         // Use advanced syntax to search for countries as exact phrases
         ...selectedCountryNames.keys().map((c) => `"${c}"`),
     ]
@@ -289,7 +290,7 @@ export async function queryTopicPages(
 
     const searchParams = {
         indexName: PAGES_INDEX,
-        query: state.query,
+        query: resolveSearchQuery(state.query),
         filters: `type:${OwidGdocType.TopicPage} OR type:${OwidGdocType.LinearTopicPage}`,
         facetFilters: formatTopicFacetFilters(selectedTopics),
         attributesToRetrieve: [
@@ -330,7 +331,7 @@ export async function queryProfiles(
 
     const searchParams = {
         indexName: PAGES_INDEX,
-        query: state.query,
+        query: resolveSearchQuery(state.query),
         filters: `type:${OwidGdocType.Profile}`,
         facetFilters,
         attributesToRetrieve: [

--- a/site/search/searchUtils.test.ts
+++ b/site/search/searchUtils.test.ts
@@ -8,6 +8,7 @@ import {
     createTopicFilter,
     extractFiltersFromQuery,
     createCountryFilter,
+    resolveSearchQuery,
 } from "./searchUtils"
 
 import { FilterType, SynonymMap } from "@ourworldindata/types"
@@ -737,6 +738,28 @@ describe("Fuzzy search in search autocomplete", () => {
             expect(result.suggestions[0].type).toBe(FilterType.QUERY)
             expect(result.unmatchedQuery).toBe("nonexistenttopic")
         })
+    })
+})
+
+describe(resolveSearchQuery, () => {
+    it("rewrites the bare query 'ai' to 'artificial intelligence'", () => {
+        expect(resolveSearchQuery("ai")).toEqual("artificial intelligence")
+    })
+
+    it("is case-insensitive and trims whitespace", () => {
+        expect(resolveSearchQuery("AI")).toEqual("artificial intelligence")
+        expect(resolveSearchQuery("  ai  ")).toEqual("artificial intelligence")
+    })
+
+    it("leaves longer queries containing 'ai' unchanged", () => {
+        expect(resolveSearchQuery("chatgpt and ai regulation")).toEqual(
+            "chatgpt and ai regulation"
+        )
+        expect(resolveSearchQuery("air pollution")).toEqual("air pollution")
+    })
+
+    it("leaves unrelated queries unchanged", () => {
+        expect(resolveSearchQuery("population")).toEqual("population")
     })
 })
 

--- a/site/search/searchUtils.tsx
+++ b/site/search/searchUtils.tsx
@@ -413,6 +413,24 @@ export function getSelectableTopics(
     return new Set()
 }
 
+// Algolia's prefix search treats short queries like "ai" as matching any
+// word starting with those letters (aid, air, aids, aviation...). All of
+// those prefix matches tie on relevance, so ranking falls back to raw
+// popularity and buries the actual AI content (see #6771). A synonym
+// doesn't fix this - it only adds more tied matches. Rewriting the query to
+// the unambiguous "artificial intelligence" restores exact-match ranking.
+// Our Algolia plan doesn't support Query Rules (which would do this
+// server-side), so the rewrite happens here instead. Scoped to the exact
+// (trimmed, case-insensitive) query so longer queries that merely contain
+// "ai" are unaffected.
+const SHORT_QUERY_REWRITES: Record<string, string> = {
+    ai: "artificial intelligence",
+}
+
+export function resolveSearchQuery(query: string): string {
+    return SHORT_QUERY_REWRITES[query.trim().toLowerCase()] ?? query
+}
+
 export function serializeSet(set: Set<string>) {
     return set.size ? [...set].join("~") : undefined
 }


### PR DESCRIPTION
> _Written by Claude Sonnet 5 — @Marigold at the wheel._

## Summary

Searching "ai" on-site returns mostly irrelevant results (see #6771) — Algolia's default prefix search matches "ai" against any word starting with those letters (aid, air, aids, aviation...), all of which tie on relevance, so ranking falls back to raw chart/page popularity and buries the actual AI content. This isn't a niche query — it's ~340 searches/month on its own, part of ~1,100 searches/month containing "ai" as a word (~0.5% of all on-site search volume).

The existing "ai" ↔ "artificial intelligence" synonym (`site/search/synonymUtils.ts`) doesn't fix this — synonyms only add more documents to the tied match pool, they don't restore the exact-match ranking signal.

This rewrites the literal query "ai" to "artificial intelligence" in application code (`site/search/searchUtils.tsx`, applied at every Algolia query-building call site in `site/search/queries.ts`), which restores exact-match ranking. It's scoped to the exact (trimmed, case-insensitive) query, so longer queries that merely contain the word "ai" are untouched.

An earlier version of this PR did the rewrite via an Algolia [query rule](https://www.algolia.com/doc/guides/managing-results/rules/rules-overview/) instead, configured in `baker/algolia/configureAlgolia.ts` alongside our synonyms. That's the more idiomatic place for this kind of thing, but our Algolia plan doesn't support Query Rules — `saveRules` returned `402 Rules quota exceeded`, and the index dashboard has no Rules tab at all. Hence the app-level rewrite instead.

This is deliberately scoped to just "ai". A broader pass over other short/ambiguous queries (`gnp`, `gii`, `imr`, `ev`, `lcoe`, `pbi`, `std`, `mmr`, ...) turned up several with real search volume and similarly bad results, but each needs its own case-by-case judgment call about what the acronym could reasonably mean beyond whatever happens to be in our index today — e.g. "gii" reads at least as naturally as "Global Innovation Index" as it does "Gender Inequality Index" (the only one we have content for), and rewriting it site-wide risks being confidently wrong for a real chunk of searchers. Rather than bulk-adding a list of guesses, this PR ships only the one case that's unambiguous. The general short-query ranking gap described in #6771 (`un`, `eu`, `co`, etc., which don't have a safe single-meaning fix) is still open.

## Test plan

- [x] Verified live against the prod indices that `"artificial intelligence"` as a literal query ranks cleanly (all hits relevant) while `"ai"` does not, confirming the rewrite approach works
- [x] Added unit tests for `resolveSearchQuery` covering the rewrite, case/whitespace handling, and that longer queries containing "ai" are left alone
- [x] Confirmed on the `staging-algolia`-labelled staging index that `/search?q=ai` now surfaces AI content first — verified both via a live browser session on `staging-site-ai-query-rule` (network capture shows the outgoing Algolia call carries `"query":"artificial intelligence"`, and `/search?q=ai` renders AI charts top-of-list) and via a volume-weighted LLM-judged A/B over every on-site query containing "ai" from the last 30 days (analytics repo's `search_demand` tool): 0% relevant → 100% relevant for the exact query "ai", no regressions across the rest of the "ai" query set. The fix also correctly extends to compound queries like `china ai` — country-entity extraction strips "china" into a filter chip, and the residual free-text query ("ai") gets rewritten the same way.

## Follow-up

Worth rerunning the search-demand comparison above after #6715 (closest-matches / `removeWordsIfNoResults` fallback) merges — it changes Algolia's zero-result fallback behavior, which likely shifts the numbers for the many *multi-word* `ai ___` queries (`ai patents`, `ai adoption`, `spending on ai`, ...) that this PR doesn't touch and that currently return zero results despite relevant OWID content existing for several of them.

To rerun: see [owid/analytics#948](https://github.com/owid/analytics/pull/948), which adds the tooling this verification used. From the `analytics` repo:

```bash
uv run python -m experiments.search_demand classify \
  --source filtered --query-contains "ai" \
  --engine-a "algolia://explorer-views-and-charts" --engine-a-name "Production" \
  --engine-a-ui "https://ourworldindata.org/search?q=" \
  --engine-b "rewrite+algolia://explorer-views-and-charts" --engine-b-name "with rewrite" \
  --engine-b-ui "https://ourworldindata.org/search?q=" \
  --output-dir ai/search_demand_ai_query
```

This produces `ai/search_demand_ai_query/search_demand_report_filtered.html`, a volume-weighted, LLM-judged before/after comparison across every on-site query containing "ai" (bucket shares are coverage of total search demand, not 100%, since it's filtered to "ai"-containing queries). `--engine-b` reproduces owid-grapher's app-level query rewrite (`resolveSearchQuery`) against the same prod Algolia index `--engine-a` uses — since the rewrite runs in browser JS with no HTTP endpoint to hit directly, this is the only way to A/B it against real demand data without staging deploys or dev-Algolia-app index drift.
