### PR TITLE
🎉 Add newsletter archive tiles to /latest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -466,6 +466,10 @@ index-scheduled: node_modules
 	@echo '==> Indexing scheduled (newly-live) gdocs into the pages-chronological Algolia index'
 	yarn tsx --tsconfig tsconfig.tsx.json baker/algolia/indexScheduledPagesChronologicalToAlgolia.js
 
+sync-newsletters: node_modules
+	@echo '==> Syncing sent Mailchimp campaigns into the newsletters table'
+	yarn tsx --tsconfig tsconfig.tsx.json baker/syncNewslettersFromMailchimp.js
+
 delete-algolia-index: node_modules
 	@echo '==> Deleting Algolia index'
 	yarn tsx --tsconfig tsconfig.tsx.json baker/algolia/deleteAlgoliaIndex.js

--- a/adminSiteServer/mockSiteRouter.ts
+++ b/adminSiteServer/mockSiteRouter.ts
@@ -335,8 +335,10 @@ mockSiteRouter.get("/thank-you", async (req, res) =>
     res.send(await renderThankYouPage())
 )
 
-mockSiteRouter.get("/subscribe", async (req, res) =>
-    res.send(await renderSubscribePage())
+getPlainRouteWithROTransaction(
+    mockSiteRouter,
+    "/subscribe",
+    async (_, res, trx) => res.send(await renderSubscribePage(trx))
 )
 
 getPlainRouteWithROTransaction(

--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -822,7 +822,7 @@ export class SiteBaker {
         )
         await this.stageWrite(
             `${this.bakedSiteDir}/subscribe.html`,
-            await renderSubscribePage()
+            await renderSubscribePage(knex)
         )
         await this.stageWrite(
             `${this.bakedSiteDir}/collection/custom.html`,

--- a/baker/siteRenderers.tsx
+++ b/baker/siteRenderers.tsx
@@ -546,15 +546,14 @@ export const renderExplorerIndexPage = async (
 export const renderSubscribePage = async (
     knex: KnexReadonlyTransaction
 ): Promise<string> => {
-    const [latestBrief, latestDataInsight] = await Promise.all([
-        getLatestNewsletterByType(knex, "owid-brief"),
-        getLatestNewsletterByType(knex, "data-insight"),
-    ])
+    const latestDataInsight = await getLatestNewsletterByType(
+        knex,
+        "data-insight"
+    )
     return renderToHtmlPage(
         <SubscribePage
             baseUrl={BAKED_BASE_URL}
             newsletterExampleUrls={{
-                briefUrl: latestBrief?.url,
                 dataInsightsUrl: latestDataInsight?.url,
             }}
         />

--- a/baker/siteRenderers.tsx
+++ b/baker/siteRenderers.tsx
@@ -84,6 +84,10 @@ import {
 } from "../db/model/Gdoc/GdocFactory.js"
 import { transformExplorerProgramToResolveCatalogPaths } from "../db/model/ExplorerCatalogResolver.js"
 import {
+    getLatestFeedNewsletters,
+    getLatestNewsletterByType,
+} from "../db/model/Newsletter.js"
+import {
     Attachments,
     AttachmentsContext,
 } from "../site/gdocs/AttachmentsContext.js"
@@ -221,10 +225,12 @@ export const renderThankYouPage = async () => {
 export const renderLatestPage = async (knex: KnexReadonlyTransaction) => {
     const topicTagGraph = await generateTopicTagGraph(knex)
     const flattenedTopicTagGraph = flattenNonTopicNodes(topicTagGraph)
+    const newsletters = await getLatestFeedNewsletters(knex)
     return renderToHtmlPage(
         <LatestPage
             baseUrl={BAKED_BASE_URL}
             topicTagGraph={flattenedTopicTagGraph}
+            newsletters={newsletters}
         />
     )
 }
@@ -537,8 +543,22 @@ export const renderExplorerIndexPage = async (
     )
 }
 
-export const renderSubscribePage = async (): Promise<string> => {
-    return renderToHtmlPage(<SubscribePage baseUrl={BAKED_BASE_URL} />)
+export const renderSubscribePage = async (
+    knex: KnexReadonlyTransaction
+): Promise<string> => {
+    const [latestBrief, latestDataInsight] = await Promise.all([
+        getLatestNewsletterByType(knex, "owid-brief"),
+        getLatestNewsletterByType(knex, "data-insight"),
+    ])
+    return renderToHtmlPage(
+        <SubscribePage
+            baseUrl={BAKED_BASE_URL}
+            newsletterExampleUrls={{
+                briefUrl: latestBrief?.url,
+                dataInsightsUrl: latestDataInsight?.url,
+            }}
+        />
+    )
 }
 
 interface ExplorerRenderOpts {

--- a/baker/syncNewslettersFromMailchimp.ts
+++ b/baker/syncNewslettersFromMailchimp.ts
@@ -9,7 +9,11 @@ import {
     MAILCHIMP_API_SERVER,
 } from "../settings/serverSettings.js"
 import { DbInsertNewsletter, NewsletterType } from "@ourworldindata/types"
-import { upsertNewsletters } from "../db/model/Newsletter.js"
+import {
+    getBriefNewsletterIdsMissingImage,
+    setNewsletterImageUrl,
+    upsertNewsletters,
+} from "../db/model/Newsletter.js"
 
 /**
  * Syncs sent Mailchimp campaigns into the `newsletters` DB table, from which
@@ -41,6 +45,19 @@ const INTEREST_ID_TO_TYPE: Record<string, NewsletterType> = {
 
 const PAGE_SIZE = 1000
 
+// The Brief's template chrome (header banner etc.) is rendered as full-width
+// images; edition-specific content images are narrower (inset by the content
+// block padding). Used to pick the first *content* image of an edition as
+// its /latest tile image.
+const TEMPLATE_IMAGE_MIN_WIDTH = 600
+
+function mailchimpAuthHeader(): string {
+    const auth = Buffer.from(`anystring:${MAILCHIMP_API_KEY}`).toString(
+        "base64"
+    )
+    return `Basic ${auth}`
+}
+
 interface MailchimpCampaign {
     id: string
     send_time?: string
@@ -65,9 +82,6 @@ interface MailchimpCampaignsResponse {
 }
 
 async function fetchAllSentCampaigns(): Promise<MailchimpCampaign[]> {
-    const auth = Buffer.from(`anystring:${MAILCHIMP_API_KEY}`).toString(
-        "base64"
-    )
     const fields = [
         "total_items",
         "campaigns.id",
@@ -83,7 +97,7 @@ async function fetchAllSentCampaigns(): Promise<MailchimpCampaign[]> {
     while (true) {
         const url = `https://${MAILCHIMP_API_SERVER}.api.mailchimp.com/3.0/campaigns?status=sent&count=${PAGE_SIZE}&offset=${offset}&fields=${fields}`
         const response = await fetch(url, {
-            headers: { Authorization: `Basic ${auth}` },
+            headers: { Authorization: mailchimpAuthHeader() },
         })
         if (!response.ok) {
             throw new Error(
@@ -136,6 +150,62 @@ function campaignToNewsletter(
     }
 }
 
+/**
+ * Extract the first edition-specific content image from a campaign's HTML,
+ * or "" if none qualifies. Template chrome (the Brief's header banner) is
+ * skipped via the full-width heuristic — see TEMPLATE_IMAGE_MIN_WIDTH.
+ *
+ * The returned URL points at Mailchimp's public CDN (mcusercontent.com) and
+ * is hotlinked as-is on /latest tiles. If we ever want to drop that external
+ * dependency, this is the place to re-upload to Cloudflare Images instead.
+ */
+async function fetchFirstContentImage(campaignId: string): Promise<string> {
+    const url = `https://${MAILCHIMP_API_SERVER}.api.mailchimp.com/3.0/campaigns/${campaignId}/content?fields=html`
+    const response = await fetch(url, {
+        headers: { Authorization: mailchimpAuthHeader() },
+    })
+    if (!response.ok) {
+        throw new Error(
+            `Mailchimp content request for campaign ${campaignId} failed: ${response.status} ${response.statusText}`
+        )
+    }
+    const { html } = (await response.json()) as { html?: string }
+    if (!html) return ""
+
+    for (const tag of html.match(/<img[^>]*>/g) ?? []) {
+        const src = tag.match(/src="([^"]+)"/)?.[1]
+        if (!src || !src.startsWith("https://")) continue
+        const width = parseInt(tag.match(/width="(\d+)"/)?.[1] ?? "", 10)
+        if (width >= TEMPLATE_IMAGE_MIN_WIDTH) continue
+        return src
+    }
+    return ""
+}
+
+/** Fill in tile images for OWID Brief newsletters that haven't been checked
+ * yet. One content request per campaign, so the backfill is a one-off burst
+ * and steady-state runs only fetch newly synced editions. */
+async function syncNewsletterImages(): Promise<void> {
+    const missingIds = await db.knexReadonlyTransaction(
+        getBriefNewsletterIdsMissingImage,
+        db.TransactionCloseMode.KeepOpen
+    )
+    if (!missingIds.length) return
+
+    let found = 0
+    for (const mailchimpId of missingIds) {
+        const imageUrl = await fetchFirstContentImage(mailchimpId)
+        if (imageUrl) found++
+        await db.knexReadWriteTransaction(
+            (trx) => setNewsletterImageUrl(trx, mailchimpId, imageUrl),
+            db.TransactionCloseMode.KeepOpen
+        )
+    }
+    console.log(
+        `Checked ${missingIds.length} newsletters for tile images, found ${found}`
+    )
+}
+
 const syncNewslettersFromMailchimp = async (): Promise<void> => {
     if (!MAILCHIMP_API_KEY) {
         console.error("MAILCHIMP_API_KEY is not set. Exiting.")
@@ -149,7 +219,7 @@ const syncNewslettersFromMailchimp = async (): Promise<void> => {
 
     await db.knexReadWriteTransaction(
         (trx) => upsertNewsletters(trx, newsletters),
-        db.TransactionCloseMode.Close
+        db.TransactionCloseMode.KeepOpen
     )
 
     const counts = newsletters.reduce<Record<string, number>>((acc, n) => {
@@ -160,6 +230,10 @@ const syncNewslettersFromMailchimp = async (): Promise<void> => {
         `Synced ${newsletters.length} newsletters from ${campaigns.length} sent campaigns:`,
         counts
     )
+
+    await syncNewsletterImages()
+
+    await db.closeTypeOrmAndKnexConnections()
     process.exit(0)
 }
 

--- a/baker/syncNewslettersFromMailchimp.ts
+++ b/baker/syncNewslettersFromMailchimp.ts
@@ -1,0 +1,171 @@
+// This should be imported as early as possible so the global error handler is
+// set up before any errors are thrown.
+import "../serverUtils/instrument.js"
+
+import * as Sentry from "@sentry/node"
+import * as db from "../db/db.js"
+import {
+    MAILCHIMP_API_KEY,
+    MAILCHIMP_API_SERVER,
+} from "../settings/serverSettings.js"
+import { DbInsertNewsletter, NewsletterType } from "@ourworldindata/types"
+import { upsertNewsletters } from "../db/model/Newsletter.js"
+
+/**
+ * Syncs sent Mailchimp campaigns into the `newsletters` DB table, from which
+ * the baker feeds the /latest newsletter tiles and the /subscribe example
+ * links. Intended to be run on a schedule (e.g. a Buildkite cron); each run
+ * pages through the full campaign history and upserts, so it's idempotent
+ * and self-heals gaps.
+ *
+ * Newsletters deliberately stay out of Algolia (and thus out of /search and
+ * the atom feeds, which Mailchimp itself consumes to send newsletters).
+ *
+ * Note: Mailchimp API keys expire one year after creation. When the key
+ * expires this script exits with an error (caught by Sentry) — generate a
+ * new key in Mailchimp and update MAILCHIMP_API_KEY in the server settings.
+ */
+
+// The main OWID audience. Campaigns sent to other lists are test sends
+// (e.g. "[PREFLIGHT] …") and are skipped.
+const MAILCHIMP_LIST_ID = "2e166c1fc1"
+
+// Audience interest-group ids ("Newsletter" groups) that identify which
+// newsletter a campaign was sent to. Stable machine ids — unlike subject
+// lines, which have changed over the years ("Biweekly Digest" → "The OWID
+// Brief") and would misclassify most of the history.
+const INTEREST_ID_TO_TYPE: Record<string, NewsletterType> = {
+    "7aa5a63b3f": "owid-brief",
+    "7f9fa4b5c4": "data-insight",
+}
+
+const PAGE_SIZE = 1000
+
+interface MailchimpCampaign {
+    id: string
+    send_time?: string
+    long_archive_url?: string
+    settings?: {
+        subject_line?: string
+    }
+    recipients?: {
+        list_id?: string
+        segment_opts?: {
+            conditions?: {
+                condition_type?: string
+                value?: string[]
+            }[]
+        }
+    }
+}
+
+interface MailchimpCampaignsResponse {
+    campaigns: MailchimpCampaign[]
+    total_items: number
+}
+
+async function fetchAllSentCampaigns(): Promise<MailchimpCampaign[]> {
+    const auth = Buffer.from(`anystring:${MAILCHIMP_API_KEY}`).toString(
+        "base64"
+    )
+    const fields = [
+        "total_items",
+        "campaigns.id",
+        "campaigns.send_time",
+        "campaigns.long_archive_url",
+        "campaigns.settings.subject_line",
+        "campaigns.recipients.list_id",
+        "campaigns.recipients.segment_opts.conditions",
+    ].join(",")
+
+    const campaigns: MailchimpCampaign[] = []
+    let offset = 0
+    while (true) {
+        const url = `https://${MAILCHIMP_API_SERVER}.api.mailchimp.com/3.0/campaigns?status=sent&count=${PAGE_SIZE}&offset=${offset}&fields=${fields}`
+        const response = await fetch(url, {
+            headers: { Authorization: `Basic ${auth}` },
+        })
+        if (!response.ok) {
+            throw new Error(
+                `Mailchimp campaigns request failed: ${response.status} ${response.statusText}`
+            )
+        }
+        const data = (await response.json()) as MailchimpCampaignsResponse
+        campaigns.push(...data.campaigns)
+        offset += PAGE_SIZE
+        if (offset >= data.total_items) break
+    }
+    return campaigns
+}
+
+function deriveNewsletterType(
+    campaign: MailchimpCampaign
+): NewsletterType | undefined {
+    const conditions = campaign.recipients?.segment_opts?.conditions ?? []
+    for (const condition of conditions) {
+        if (condition.condition_type !== "Interests") continue
+        for (const interestId of condition.value ?? []) {
+            const type = INTEREST_ID_TO_TYPE[interestId]
+            if (type) return type
+        }
+    }
+    return undefined
+}
+
+function campaignToNewsletter(
+    campaign: MailchimpCampaign
+): DbInsertNewsletter | undefined {
+    if (campaign.recipients?.list_id !== MAILCHIMP_LIST_ID) return undefined
+
+    const type = deriveNewsletterType(campaign)
+    if (!type) return undefined
+
+    const title = campaign.settings?.subject_line
+    const url = campaign.long_archive_url
+    const sendTime = campaign.send_time
+    // A handful of historical campaigns lack a subject line (one-off
+    // experiments) — skip them, they'd make empty tiles.
+    if (!title || !url || !sendTime) return undefined
+
+    return {
+        mailchimpId: campaign.id,
+        type,
+        title,
+        url,
+        publishedAt: new Date(sendTime),
+    }
+}
+
+const syncNewslettersFromMailchimp = async (): Promise<void> => {
+    if (!MAILCHIMP_API_KEY) {
+        console.error("MAILCHIMP_API_KEY is not set. Exiting.")
+        process.exit(1)
+    }
+
+    const campaigns = await fetchAllSentCampaigns()
+    const newsletters = campaigns
+        .map(campaignToNewsletter)
+        .filter((n) => n !== undefined)
+
+    await db.knexReadWriteTransaction(
+        (trx) => upsertNewsletters(trx, newsletters),
+        db.TransactionCloseMode.Close
+    )
+
+    const counts = newsletters.reduce<Record<string, number>>((acc, n) => {
+        acc[n.type] = (acc[n.type] ?? 0) + 1
+        return acc
+    }, {})
+    console.log(
+        `Synced ${newsletters.length} newsletters from ${campaigns.length} sent campaigns:`,
+        counts
+    )
+    process.exit(0)
+}
+
+syncNewslettersFromMailchimp().catch(async (e) => {
+    console.error("Error in syncNewslettersFromMailchimp:", e)
+    Sentry.captureException(e)
+    await Sentry.close()
+    process.exit(1)
+})

--- a/db/docs/newsletters.yml
+++ b/db/docs/newsletters.yml
@@ -1,12 +1,12 @@
 metadata:
-  description: Archive of newsletters sent via Mailchimp ("The OWID Brief" and Data Insight emails). Synced from the Mailchimp Marketing API by baker/syncNewslettersFromMailchimp.ts. OWID Brief newsletters are indexed into the pages-chronological Algolia index so each appears as a tile on /latest linking out to its Mailchimp archive page; the most recent newsletter of each type feeds the "see example" links on the baked /subscribe page.
+  description: Archive of newsletters sent via Mailchimp ("The OWID Brief" and Data Insight emails). Synced from the Mailchimp Marketing API by baker/syncNewslettersFromMailchimp.ts. OWID Brief newsletters are injected into latest.html at bake time so each appears as a tile on /latest linking out to its Mailchimp archive page (deliberately not via Algolia, to keep newsletters out of /search and the atom feeds); the most recent newsletter of each type feeds the "see example" links on the baked /subscribe page.
 fields:
   id:
     description: Unique identifier for the newsletter
   mailchimpId:
     description: Mailchimp campaign id as returned by the Marketing API (unique constraint)
   type:
-    description: Campaign type derived from the subject line prefix — "owid-brief" ("The OWID Brief:" prefix) or "data-insight" ("Data Insight:" prefix)
+    description: Campaign type — "owid-brief" or "data-insight" — derived from the Mailchimp audience interest-group id the campaign was sent to (stable across historical subject line renames like "Biweekly Digest" → "The OWID Brief")
   title:
     description: Subject line of the newsletter campaign
   url:

--- a/db/docs/newsletters.yml
+++ b/db/docs/newsletters.yml
@@ -1,0 +1,19 @@
+metadata:
+  description: Archive of newsletters sent via Mailchimp ("The OWID Brief" and Data Insight emails). Synced from the Mailchimp Marketing API by baker/syncNewslettersFromMailchimp.ts. OWID Brief newsletters are indexed into the pages-chronological Algolia index so each appears as a tile on /latest linking out to its Mailchimp archive page; the most recent newsletter of each type feeds the "see example" links on the baked /subscribe page.
+fields:
+  id:
+    description: Unique identifier for the newsletter
+  mailchimpId:
+    description: Mailchimp campaign id as returned by the Marketing API (unique constraint)
+  type:
+    description: Campaign type derived from the subject line prefix — "owid-brief" ("The OWID Brief:" prefix) or "data-insight" ("Data Insight:" prefix)
+  title:
+    description: Subject line of the newsletter campaign
+  url:
+    description: Public Mailchimp campaign-archive URL for reading the newsletter in the browser
+  publishedAt:
+    description: When the campaign was sent, from the Marketing API's send_time
+  createdAt:
+    description: Timestamp when the record was synced into this table
+  updatedAt:
+    description: Timestamp when the record was last updated by the sync

--- a/db/docs/newsletters.yml
+++ b/db/docs/newsletters.yml
@@ -11,6 +11,8 @@ fields:
     description: Subject line of the newsletter campaign
   url:
     description: Public Mailchimp campaign-archive URL for reading the newsletter in the browser
+  imageUrl:
+    description: First content image of the campaign, hotlinked from Mailchimp's CDN (mcusercontent.com) and shown on the /latest tile. NULL means not yet checked; empty string means checked but no suitable image found. Re-upload to Cloudflare Images if we ever want to drop the Mailchimp CDN dependency.
   publishedAt:
     description: When the campaign was sent, from the Marketing API's send_time
   createdAt:

--- a/db/exportMetadataTables.ts
+++ b/db/exportMetadataTables.ts
@@ -53,6 +53,7 @@ export const PUBLIC_DATA_TABLES = [
     "multi_dim_x_chart_configs",
     "namespaces",
     "narrative_charts",
+    "newsletters",
     "origins_variables",
     "origins",
     "post_tags",

--- a/db/migration/1784702942916-CreateNewslettersTable.ts
+++ b/db/migration/1784702942916-CreateNewslettersTable.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class CreateNewslettersTable1784702942916 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`-- sql
+            CREATE TABLE newsletters (
+                id INT AUTO_INCREMENT PRIMARY KEY,
+                mailchimpId VARCHAR(64) NOT NULL UNIQUE,
+                type VARCHAR(32) NOT NULL,
+                title VARCHAR(512) NOT NULL,
+                url VARCHAR(1024) NOT NULL,
+                publishedAt DATETIME NOT NULL,
+                createdAt DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updatedAt DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                INDEX idx_newsletters_type_publishedAt (type, publishedAt)
+            )
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP TABLE newsletters`)
+    }
+}

--- a/db/migration/1784732249361-AddNewsletterImageUrl.ts
+++ b/db/migration/1784732249361-AddNewsletterImageUrl.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class AddNewsletterImageUrl1784732249361 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `ALTER TABLE newsletters ADD COLUMN imageUrl VARCHAR(1024) NULL`
+        )
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE newsletters DROP COLUMN imageUrl`)
+    }
+}

--- a/db/model/Newsletter.ts
+++ b/db/model/Newsletter.ts
@@ -12,10 +12,35 @@ export async function upsertNewsletters(
     newsletters: DbInsertNewsletter[]
 ): Promise<void> {
     if (!newsletters.length) return
+    // imageUrl is deliberately not merged: it's filled in by a separate
+    // sync pass and must not be clobbered on re-upserts.
     await knex<DbPlainNewsletter>(NewslettersTableName)
         .insert(newsletters)
         .onConflict("mailchimpId")
         .merge(["type", "title", "url", "publishedAt"])
+}
+
+/** Mailchimp ids of OWID Brief newsletters whose campaign content hasn't
+ * been checked for a tile image yet (imageUrl NULL; "" means checked but
+ * none found). */
+export async function getBriefNewsletterIdsMissingImage(
+    knex: db.KnexReadonlyTransaction
+): Promise<string[]> {
+    const rows = await knex<DbPlainNewsletter>(NewslettersTableName)
+        .select("mailchimpId")
+        .where({ type: "owid-brief" })
+        .whereNull("imageUrl")
+    return rows.map((row) => row.mailchimpId)
+}
+
+export async function setNewsletterImageUrl(
+    knex: db.KnexReadWriteTransaction,
+    mailchimpId: string,
+    imageUrl: string
+): Promise<void> {
+    await knex<DbPlainNewsletter>(NewslettersTableName)
+        .where({ mailchimpId })
+        .update({ imageUrl })
 }
 
 export async function getNewslettersByType(
@@ -45,6 +70,8 @@ export async function getLatestFeedNewsletters(
         title: row.title,
         url: row.url,
         date: row.publishedAt.toISOString(),
+        // "" means "checked, no suitable image" — treat like NULL here.
+        ...(row.imageUrl ? { imageUrl: row.imageUrl } : {}),
     }))
 }
 

--- a/db/model/Newsletter.ts
+++ b/db/model/Newsletter.ts
@@ -1,0 +1,59 @@
+import {
+    DbInsertNewsletter,
+    DbPlainNewsletter,
+    LatestNewsletter,
+    NewsletterType,
+    NewslettersTableName,
+} from "@ourworldindata/types"
+import * as db from "../db"
+
+export async function upsertNewsletters(
+    knex: db.KnexReadWriteTransaction,
+    newsletters: DbInsertNewsletter[]
+): Promise<void> {
+    if (!newsletters.length) return
+    await knex<DbPlainNewsletter>(NewslettersTableName)
+        .insert(newsletters)
+        .onConflict("mailchimpId")
+        .merge(["type", "title", "url", "publishedAt"])
+}
+
+export async function getNewslettersByType(
+    knex: db.KnexReadonlyTransaction,
+    type: NewsletterType
+): Promise<DbPlainNewsletter[]> {
+    return knex<DbPlainNewsletter>(NewslettersTableName)
+        .where({ type })
+        .orderBy("publishedAt", "desc")
+}
+
+/**
+ * Newsletters shown as tiles on /latest, newest first. Only Brief-era
+ * campaigns (subject starting with "The OWID Brief") qualify: the same
+ * audience previously received "Biweekly Digest" emails, many with bare,
+ * repetitive subject lines that would make poor tiles.
+ */
+export async function getLatestFeedNewsletters(
+    knex: db.KnexReadonlyTransaction
+): Promise<LatestNewsletter[]> {
+    const rows = await knex<DbPlainNewsletter>(NewslettersTableName)
+        .where({ type: "owid-brief" })
+        .andWhere("title", "like", "The OWID Brief%")
+        .orderBy("publishedAt", "desc")
+    return rows.map((row) => ({
+        mailchimpId: row.mailchimpId,
+        title: row.title,
+        url: row.url,
+        date: row.publishedAt.toISOString(),
+    }))
+}
+
+export async function getLatestNewsletterByType(
+    knex: db.KnexReadonlyTransaction,
+    type: NewsletterType
+): Promise<DbPlainNewsletter | undefined> {
+    return knex<DbPlainNewsletter>(NewslettersTableName)
+        .where({ type })
+        .orderBy("publishedAt", "desc")
+        .first()
+}

--- a/packages/@ourworldindata/types/src/dbTypes/Newsletters.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/Newsletters.ts
@@ -1,14 +1,14 @@
 export const NewslettersTableName = "newsletters"
 
 /** The Mailchimp campaign types we sync from the Mailchimp Marketing API,
- * distinguished by their subject line prefix ("The OWID Brief: …" vs
- * "Data Insight: …"). Only "owid-brief" newsletters are indexed for /latest;
- * both types feed the "see example" links on /subscribe. */
+ * distinguished by the audience interest group they were sent to (see
+ * baker/syncNewslettersFromMailchimp.ts). Only "owid-brief" newsletters are
+ * shown on /latest; both types feed the "see example" links on /subscribe. */
 export const NEWSLETTER_TYPES = ["owid-brief", "data-insight"] as const
 export type NewsletterType = (typeof NEWSLETTER_TYPES)[number]
 
 export type DbInsertNewsletter = {
-    /** Mailchimp campaign id, extracted from the archive URL's `id` param */
+    /** Mailchimp campaign id as returned by the Marketing API */
     mailchimpId: string
     type: NewsletterType
     title: string

--- a/packages/@ourworldindata/types/src/dbTypes/Newsletters.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/Newsletters.ts
@@ -14,6 +14,13 @@ export type DbInsertNewsletter = {
     title: string
     /** Public Mailchimp campaign-archive URL the /latest tile links out to */
     url: string
+    /**
+     * First content image of the campaign, hotlinked from Mailchimp's CDN
+     * (mcusercontent.com). NULL = not yet checked; "" = checked, no suitable
+     * image found. If we ever want to stop depending on Mailchimp's CDN,
+     * the sync should re-upload these to Cloudflare Images instead.
+     */
+    imageUrl?: string | null
     publishedAt: Date
     createdAt?: Date
     updatedAt?: Date

--- a/packages/@ourworldindata/types/src/dbTypes/Newsletters.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/Newsletters.ts
@@ -1,0 +1,24 @@
+export const NewslettersTableName = "newsletters"
+
+/** The Mailchimp campaign types we sync from the Mailchimp Marketing API,
+ * distinguished by their subject line prefix ("The OWID Brief: …" vs
+ * "Data Insight: …"). Only "owid-brief" newsletters are indexed for /latest;
+ * both types feed the "see example" links on /subscribe. */
+export const NEWSLETTER_TYPES = ["owid-brief", "data-insight"] as const
+export type NewsletterType = (typeof NEWSLETTER_TYPES)[number]
+
+export type DbInsertNewsletter = {
+    /** Mailchimp campaign id, extracted from the archive URL's `id` param */
+    mailchimpId: string
+    type: NewsletterType
+    title: string
+    /** Public Mailchimp campaign-archive URL the /latest tile links out to */
+    url: string
+    publishedAt: Date
+    createdAt?: Date
+    updatedAt?: Date
+}
+
+export type DbPlainNewsletter = Required<DbInsertNewsletter> & {
+    id: number
+}

--- a/packages/@ourworldindata/types/src/domainTypes/Latest.ts
+++ b/packages/@ourworldindata/types/src/domainTypes/Latest.ts
@@ -66,14 +66,14 @@ export interface LatestNewsletter {
 export const NEWSLETTERS_WINDOW_PROP = "_OWID_NEWSLETTERS"
 
 /**
- * Archive URLs of the most recent edition of each newsletter, shown as the
- * "see example" links on /subscribe. Baked into the page (and read back on
+ * Archive URL of the most recent Data Insights edition, shown as the
+ * "see example" link on /subscribe. Baked into the page (and read back on
  * hydration via window._OWID_NEWSLETTER_EXAMPLES so server and client render
- * identically). Fields are optional so the page still renders from an empty
- * newsletters table; the form falls back to static example links.
+ * identically). Optional so the page still renders from an empty newsletters
+ * table; the form falls back to a static example link. The OWID Brief link
+ * needs no baked data — it points to /latest?type=newsletter.
  */
 export interface NewsletterExampleUrls {
-    briefUrl?: string
     dataInsightsUrl?: string
 }
 

--- a/packages/@ourworldindata/types/src/domainTypes/Latest.ts
+++ b/packages/@ourworldindata/types/src/domainTypes/Latest.ts
@@ -11,13 +11,16 @@ import * as z from "zod/mini"
 /* Latest filter state */
 
 /**
- * The flat content-category dimension used by /latest. For articles and
- * data insights this mirrors the gdoc type; for announcements it reflects
+ * The flat content-category dimension of gdoc-backed content. For articles
+ * and data insights this mirrors the gdoc type; for announcements it reflects
  * the (slugified) kicker. Absent for gdoc types that are indexed but not
  * shown on /latest (topic pages, linear topic pages).
  *
- * Ordered as displayed in the /latest "Filter by type" dropdown so callers
- * can iterate this tuple directly to render the dropdown.
+ * Deliberately excludes "newsletter": the dynamic /atom.xml?type= Cloudflare
+ * Function validates its `type` param against this constant, and newsletters
+ * must never appear in our feeds — Mailchimp consumes those feeds to send
+ * newsletters in the first place. Use LATEST_PAGE_TYPE_VALUES for the
+ * /latest page UI instead.
  */
 export const LATEST_TYPE_VALUES = [
     "data-insight",
@@ -27,7 +30,52 @@ export const LATEST_TYPE_VALUES = [
     "website-upgrade",
     "announcement",
 ] as const
-export type LatestType = (typeof LATEST_TYPE_VALUES)[number]
+
+/**
+ * All type values filterable on the /latest page: the gdoc-backed
+ * LATEST_TYPE_VALUES plus newsletters (synced from the Mailchimp campaign
+ * archive — see the `newsletters` DB table).
+ *
+ * Ordered as displayed in the /latest "Filter by type" dropdown so callers
+ * can iterate this tuple directly to render the dropdown.
+ */
+export const LATEST_PAGE_TYPE_VALUES = [
+    ...LATEST_TYPE_VALUES,
+    "newsletter",
+] as const
+export type LatestType = (typeof LATEST_PAGE_TYPE_VALUES)[number]
+
+/**
+ * A newsletter shown as a tile on /latest, linking out to its Mailchimp
+ * campaign-archive page. Newsletters deliberately live outside the
+ * pages-chronological Algolia index (and therefore outside /search and the
+ * atom feeds, which Mailchimp itself consumes): the baker injects them into
+ * latest.html as `window._OWID_NEWSLETTERS` and the /latest SPA weaves them
+ * into the feed client-side. Synced from the Mailchimp Marketing API into the
+ * `newsletters` DB table by baker/syncNewslettersFromMailchimp.ts.
+ */
+export interface LatestNewsletter {
+    mailchimpId: string
+    title: string
+    /** External Mailchimp campaign-archive URL the tile links out to */
+    url: string
+    /** ISO timestamp of when the campaign was sent */
+    date: string
+}
+
+export const NEWSLETTERS_WINDOW_PROP = "_OWID_NEWSLETTERS"
+
+/**
+ * Archive URLs of the most recent edition of each newsletter, shown as the
+ * "see example" links on /subscribe. Baked into the page (and read back on
+ * hydration via window._OWID_NEWSLETTER_EXAMPLES so server and client render
+ * identically). Fields are optional so the page still renders from an empty
+ * newsletters table; the form falls back to static example links.
+ */
+export interface NewsletterExampleUrls {
+    briefUrl?: string
+    dataInsightsUrl?: string
+}
 
 // Subset of LATEST_TYPE_VALUES that announcement gdocs can map to via their
 // (slugified) kicker. Validated upstream in GdocAnnouncement._validateSubclass
@@ -40,8 +88,8 @@ export const ANNOUNCEMENT_LATEST_TYPES = [
 ] as const satisfies readonly LatestType[]
 export type AnnouncementLatestType = (typeof ANNOUNCEMENT_LATEST_TYPES)[number]
 
-/** Singular display labels for a LatestType. Iterate LATEST_TYPE_VALUES to
- * get the dropdown display order; append "s" for the plural form used as
+/** Singular display labels for a LatestType. Iterate LATEST_PAGE_TYPE_VALUES
+ * to get the dropdown display order; append "s" for the plural form used as
  * the dropdown label. Used wherever a per-item kicker is rendered
  * (announcement page, homepage announcement card, /latest hit metadata). */
 export const LATEST_TYPE_LABELS: Record<LatestType, string> = {
@@ -51,6 +99,7 @@ export const LATEST_TYPE_LABELS: Record<LatestType, string> = {
     "topic-update": "Topic update",
     "website-upgrade": "Website upgrade",
     announcement: "Announcement",
+    newsletter: "Newsletter",
 }
 
 export const LATEST_PATH = "/latest"

--- a/packages/@ourworldindata/types/src/domainTypes/Latest.ts
+++ b/packages/@ourworldindata/types/src/domainTypes/Latest.ts
@@ -61,6 +61,9 @@ export interface LatestNewsletter {
     url: string
     /** ISO timestamp of when the campaign was sent */
     date: string
+    /** First content image of the edition, hotlinked from Mailchimp's CDN
+     * (mcusercontent.com) — see the `newsletters` table docs. */
+    imageUrl?: string
 }
 
 export const NEWSLETTERS_WINDOW_PROP = "_OWID_NEWSLETTERS"

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -510,6 +510,13 @@ export {
     JobsTableName,
 } from "./dbTypes/Jobs.js"
 export {
+    type DbInsertNewsletter,
+    type DbPlainNewsletter,
+    NEWSLETTER_TYPES,
+    type NewsletterType,
+    NewslettersTableName,
+} from "./dbTypes/Newsletters.js"
+export {
     type DbRawImage,
     type DbEnrichedImage,
     type DbEnrichedImageWithUserId,

--- a/settings/serverSettings.ts
+++ b/settings/serverSettings.ts
@@ -72,6 +72,13 @@ export const ALGOLIA_SECRET_KEY: string =
 export const ALGOLIA_INDEXING: boolean =
     serverSettings.ALGOLIA_INDEXING === "true"
 
+// Mailchimp Marketing API credentials, used by
+// baker/syncNewslettersFromMailchimp.ts to sync sent campaigns into the
+// newsletters table. Note: Mailchimp API keys expire one year after creation.
+export const MAILCHIMP_API_KEY: string = serverSettings.MAILCHIMP_API_KEY ?? ""
+export const MAILCHIMP_API_SERVER: string =
+    serverSettings.MAILCHIMP_API_SERVER ?? "us8"
+
 export const UNCATEGORIZED_TAG_ID: number =
     parseIntOrUndefined(serverSettings.UNCATEGORIZED_TAG_ID) ?? 375
 

--- a/site/LatestPage.tsx
+++ b/site/LatestPage.tsx
@@ -1,7 +1,11 @@
 import { Head } from "./Head.js"
 import { SiteHeader } from "./SiteHeader.js"
 import { SiteFooter } from "./SiteFooter.js"
-import { SiteFooterContext, TagGraphRoot } from "@ourworldindata/utils"
+import {
+    serializeJSONForHTML,
+    SiteFooterContext,
+    TagGraphRoot,
+} from "@ourworldindata/utils"
 import { LatestNewsletter } from "@ourworldindata/types"
 import { Html } from "./Html.js"
 
@@ -30,7 +34,7 @@ export const LatestPage = (props: {
             >
                 <script
                     dangerouslySetInnerHTML={{
-                        __html: `window._OWID_TOPIC_TAG_GRAPH = ${JSON.stringify(topicTagGraph)}\nwindow._OWID_NEWSLETTERS = ${JSON.stringify(newsletters)}`,
+                        __html: `window._OWID_TOPIC_TAG_GRAPH = ${JSON.stringify(topicTagGraph)}\nwindow._OWID_NEWSLETTERS = ${serializeJSONForHTML(newsletters)}`,
                     }}
                 ></script>
             </Head>

--- a/site/LatestPage.tsx
+++ b/site/LatestPage.tsx
@@ -2,19 +2,22 @@ import { Head } from "./Head.js"
 import { SiteHeader } from "./SiteHeader.js"
 import { SiteFooter } from "./SiteFooter.js"
 import { SiteFooterContext, TagGraphRoot } from "@ourworldindata/utils"
+import { LatestNewsletter } from "@ourworldindata/types"
 import { Html } from "./Html.js"
 
 declare global {
     interface Window {
         _OWID_TOPIC_TAG_GRAPH: TagGraphRoot
+        _OWID_NEWSLETTERS: LatestNewsletter[]
     }
 }
 
 export const LatestPage = (props: {
     baseUrl: string
     topicTagGraph: TagGraphRoot
+    newsletters: LatestNewsletter[]
 }) => {
-    const { baseUrl, topicTagGraph } = props
+    const { baseUrl, topicTagGraph, newsletters } = props
 
     return (
         <Html>
@@ -27,7 +30,7 @@ export const LatestPage = (props: {
             >
                 <script
                     dangerouslySetInnerHTML={{
-                        __html: `window._OWID_TOPIC_TAG_GRAPH = ${JSON.stringify(topicTagGraph)}`,
+                        __html: `window._OWID_TOPIC_TAG_GRAPH = ${JSON.stringify(topicTagGraph)}\nwindow._OWID_NEWSLETTERS = ${JSON.stringify(newsletters)}`,
                     }}
                 ></script>
             </Head>

--- a/site/NewsletterSubscription.tsx
+++ b/site/NewsletterSubscription.tsx
@@ -6,6 +6,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { SiteAnalytics } from "./SiteAnalytics.js"
 import { TextInput } from "@ourworldindata/components"
 import { NewsletterExampleUrls } from "@ourworldindata/types"
+import { buildLatestPagePath } from "./latest/latestUtils.js"
 import { NewsletterSubscriptionContext } from "./newsletter.js"
 import { NewsletterIcon } from "./gdocs/components/NewsletterIcon.js"
 
@@ -83,11 +84,10 @@ export const NewsletterSubscriptionHeader = ({
     )
 }
 
-// Static fallbacks for the "see example" links, used in render contexts that
+// Static fallback for the "see example" link, used in render contexts that
 // have no access to the newsletters table (e.g. the floating subscribe
-// dialog). The baked /subscribe page passes the latest editions instead.
+// dialog). The baked /subscribe page passes the latest edition instead.
 const DEFAULT_EXAMPLE_URLS: NewsletterExampleUrls = {
-    briefUrl: "https://mailchi.mp/ourworldindata/owid-brief-2025-11-14",
     dataInsightsUrl:
         "https://us8.campaign-archive.com/?u=18058af086319ba6afad752ec&id=fdf16136e1",
 }
@@ -165,12 +165,10 @@ export const NewsletterSubscriptionForm = ({
                 </label>
                 <a
                     className="newsletter-subscription-form__example-link note-12-medium"
-                    data-track-note="subscribe_example_owid_brief"
-                    href={
-                        exampleUrls?.briefUrl ?? DEFAULT_EXAMPLE_URLS.briefUrl
-                    }
+                    data-track-note="subscribe_recent_owid_briefs"
+                    href={buildLatestPagePath("newsletter")}
                 >
-                    See example OWID Brief newsletter
+                    See recent OWID Brief newsletters
                 </a>
             </div>
             <img

--- a/site/NewsletterSubscription.tsx
+++ b/site/NewsletterSubscription.tsx
@@ -165,6 +165,7 @@ export const NewsletterSubscriptionForm = ({
                 </label>
                 <a
                     className="newsletter-subscription-form__example-link note-12-medium"
+                    data-track-note="subscribe_example_owid_brief"
                     href={
                         exampleUrls?.briefUrl ?? DEFAULT_EXAMPLE_URLS.briefUrl
                     }
@@ -202,6 +203,7 @@ export const NewsletterSubscriptionForm = ({
                 </label>
                 <a
                     className="newsletter-subscription-form__example-link note-12-medium"
+                    data-track-note="subscribe_example_data_insights"
                     href={
                         exampleUrls?.dataInsightsUrl ??
                         DEFAULT_EXAMPLE_URLS.dataInsightsUrl

--- a/site/NewsletterSubscription.tsx
+++ b/site/NewsletterSubscription.tsx
@@ -5,6 +5,7 @@ import { faTimes, faEnvelopeOpenText } from "@fortawesome/free-solid-svg-icons"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { SiteAnalytics } from "./SiteAnalytics.js"
 import { TextInput } from "@ourworldindata/components"
+import { NewsletterExampleUrls } from "@ourworldindata/types"
 import { NewsletterSubscriptionContext } from "./newsletter.js"
 import { NewsletterIcon } from "./gdocs/components/NewsletterIcon.js"
 
@@ -82,12 +83,23 @@ export const NewsletterSubscriptionHeader = ({
     )
 }
 
+// Static fallbacks for the "see example" links, used in render contexts that
+// have no access to the newsletters table (e.g. the floating subscribe
+// dialog). The baked /subscribe page passes the latest editions instead.
+const DEFAULT_EXAMPLE_URLS: NewsletterExampleUrls = {
+    briefUrl: "https://mailchi.mp/ourworldindata/owid-brief-2025-11-14",
+    dataInsightsUrl:
+        "https://us8.campaign-archive.com/?u=18058af086319ba6afad752ec&id=fdf16136e1",
+}
+
 export const NewsletterSubscriptionForm = ({
     context,
     className = "",
+    exampleUrls,
 }: {
     context: NewsletterSubscriptionContext
     className?: string
+    exampleUrls?: NewsletterExampleUrls
 }) => {
     const DATA_INSIGHTS = "16"
     const BIWEEKLY = "2"
@@ -153,7 +165,9 @@ export const NewsletterSubscriptionForm = ({
                 </label>
                 <a
                     className="newsletter-subscription-form__example-link note-12-medium"
-                    href="https://mailchi.mp/ourworldindata/owid-brief-2025-11-14"
+                    href={
+                        exampleUrls?.briefUrl ?? DEFAULT_EXAMPLE_URLS.briefUrl
+                    }
                 >
                     See example OWID Brief newsletter
                 </a>
@@ -188,7 +202,10 @@ export const NewsletterSubscriptionForm = ({
                 </label>
                 <a
                     className="newsletter-subscription-form__example-link note-12-medium"
-                    href="https://us8.campaign-archive.com/?u=18058af086319ba6afad752ec&id=fdf16136e1"
+                    href={
+                        exampleUrls?.dataInsightsUrl ??
+                        DEFAULT_EXAMPLE_URLS.dataInsightsUrl
+                    }
                 >
                     See example Data Insights newsletter
                 </a>

--- a/site/SiteAnalytics.ts
+++ b/site/SiteAnalytics.ts
@@ -10,6 +10,7 @@ import {
     type DataInsightHit,
     type StackedArticleHit,
     FilterType,
+    type LatestNewsletter,
     type LatestState,
     type LatestPageChronologicalRecord,
     type UserSurveyExperimentArm,
@@ -62,6 +63,16 @@ export class SiteAnalytics extends GrapherAnalytics {
             eventAction: "filter",
             latestTopics: state.topics.join("~") || undefined,
             latestType: state.latestType ?? undefined,
+        })
+    }
+
+    logLatestNewsletterClick(newsletter: LatestNewsletter, position: number) {
+        this.logToGA({
+            event: EventCategory.SiteLatestResultClick,
+            eventAction: "click",
+            eventTarget: `newsletter-${newsletter.mailchimpId}`,
+            latestPosition: position,
+            latestType: "newsletter",
         })
     }
 

--- a/site/SubscribePage.tsx
+++ b/site/SubscribePage.tsx
@@ -3,6 +3,7 @@ import { Html } from "./Html.js"
 import { SiteHeader } from "./SiteHeader.js"
 import { SiteFooter } from "./SiteFooter.js"
 import {
+    NewsletterExampleUrls,
     SiteFooterContext,
     SUBSCRIBE_PAGE_FORM_CONTAINER_ID,
 } from "@ourworldindata/types"
@@ -11,11 +12,24 @@ import { NewsletterSubscriptionContext } from "./newsletter.js"
 import { OwidSocials } from "./OwidSocials.js"
 import { BAKED_BASE_URL } from "../settings/clientSettings.js"
 
-export interface SubscribePageProps {
-    baseUrl: string
+declare global {
+    interface Window {
+        _OWID_NEWSLETTER_EXAMPLES?: NewsletterExampleUrls
+    }
 }
 
-export const SubscribePage = ({ baseUrl }: SubscribePageProps) => {
+export interface SubscribePageProps {
+    baseUrl: string
+    /** Latest edition of each newsletter, for the "see example" links. Also
+     * injected as window._OWID_NEWSLETTER_EXAMPLES so client-side hydration
+     * renders the same URLs as the bake. */
+    newsletterExampleUrls: NewsletterExampleUrls
+}
+
+export const SubscribePage = ({
+    baseUrl,
+    newsletterExampleUrls,
+}: SubscribePageProps) => {
     return (
         <Html>
             <Head
@@ -24,7 +38,13 @@ export const SubscribePage = ({ baseUrl }: SubscribePageProps) => {
                 pageDesc="Stay up to date with our latest research and data insights by subscribing to our newsletter."
                 baseUrl={baseUrl}
                 imageUrl={`${BAKED_BASE_URL}/images/biweekly-newsletter.webp`}
-            />
+            >
+                <script
+                    dangerouslySetInnerHTML={{
+                        __html: `window._OWID_NEWSLETTER_EXAMPLES = ${JSON.stringify(newsletterExampleUrls)}`,
+                    }}
+                ></script>
+            </Head>
             <body>
                 <SiteHeader />
                 <main className="subscribe-page grid grid-cols-12-full-width">
@@ -37,6 +57,7 @@ export const SubscribePage = ({ baseUrl }: SubscribePageProps) => {
                                 context={
                                     NewsletterSubscriptionContext.SubscribePage
                                 }
+                                exampleUrls={newsletterExampleUrls}
                             />
                         </div>
                         <OwidSocials

--- a/site/SubscribePage.tsx
+++ b/site/SubscribePage.tsx
@@ -7,6 +7,7 @@ import {
     SiteFooterContext,
     SUBSCRIBE_PAGE_FORM_CONTAINER_ID,
 } from "@ourworldindata/types"
+import { serializeJSONForHTML } from "@ourworldindata/utils"
 import { NewsletterSubscriptionForm } from "./NewsletterSubscription.js"
 import { NewsletterSubscriptionContext } from "./newsletter.js"
 import { OwidSocials } from "./OwidSocials.js"
@@ -41,7 +42,7 @@ export const SubscribePage = ({
             >
                 <script
                     dangerouslySetInnerHTML={{
-                        __html: `window._OWID_NEWSLETTER_EXAMPLES = ${JSON.stringify(newsletterExampleUrls)}`,
+                        __html: `window._OWID_NEWSLETTER_EXAMPLES = ${serializeJSONForHTML(newsletterExampleUrls)}`,
                     }}
                 ></script>
             </Head>

--- a/site/latest/LatestHitMetadata.tsx
+++ b/site/latest/LatestHitMetadata.tsx
@@ -6,6 +6,7 @@ import {
     faBook,
     faBookmark,
     faChartLine,
+    faEnvelope,
     faLightbulb,
     faNewspaper,
 } from "@fortawesome/free-solid-svg-icons"
@@ -21,6 +22,7 @@ const LATEST_TYPE_ICONS: Record<LatestType, IconDefinition> = {
     "topic-update": faBookmark,
     "website-upgrade": faArrowPointer,
     announcement: faNewspaper,
+    newsletter: faEnvelope,
 }
 
 /**

--- a/site/latest/LatestNewsletterHit.scss
+++ b/site/latest/LatestNewsletterHit.scss
@@ -51,6 +51,12 @@
     margin-left: 8px;
 }
 
+.latest-newsletter-hit__byline {
+    @include body-3-medium-italic;
+    color: $blue-50;
+    margin: 0 0 4px;
+}
+
 .latest-newsletter-hit__description {
     @include body-3-medium;
     color: $blue-60;

--- a/site/latest/LatestNewsletterHit.scss
+++ b/site/latest/LatestNewsletterHit.scss
@@ -21,6 +21,28 @@
     flex-shrink: 0;
 }
 
+// With a featured image the card mirrors the article card's proportions:
+// thumbnail on the left, content beside it.
+.latest-newsletter-hit__card--with-image {
+    align-items: flex-start;
+
+    @include sm-only {
+        flex-direction: column;
+    }
+}
+
+.latest-newsletter-hit__image {
+    flex-shrink: 0;
+    width: 188px;
+    max-width: 100%;
+    height: auto;
+    display: block;
+
+    @include sm-only {
+        width: 100%;
+    }
+}
+
 .latest-newsletter-hit__title {
     @include h3-bold;
     margin: 0 0 4px;

--- a/site/latest/LatestNewsletterHit.scss
+++ b/site/latest/LatestNewsletterHit.scss
@@ -31,15 +31,11 @@
     }
 }
 
-// Substack-style uniform thumbnail: a fixed 1200:630 box showing the top
-// section of the image, so tiles stay the same size regardless of each
-// edition's chart proportions.
 .latest-newsletter-hit__image {
     flex-shrink: 0;
     width: 188px;
-    aspect-ratio: 1200 / 630;
-    object-fit: cover;
-    object-position: top;
+    max-width: 100%;
+    height: auto;
     display: block;
 
     @include sm-only {

--- a/site/latest/LatestNewsletterHit.scss
+++ b/site/latest/LatestNewsletterHit.scss
@@ -31,11 +31,15 @@
     }
 }
 
+// Substack-style uniform thumbnail: a fixed 1200:630 box showing the top
+// section of the image, so tiles stay the same size regardless of each
+// edition's chart proportions.
 .latest-newsletter-hit__image {
     flex-shrink: 0;
     width: 188px;
-    max-width: 100%;
-    height: auto;
+    aspect-ratio: 1200 / 630;
+    object-fit: cover;
+    object-position: top;
     display: block;
 
     @include sm-only {

--- a/site/latest/LatestNewsletterHit.scss
+++ b/site/latest/LatestNewsletterHit.scss
@@ -1,0 +1,58 @@
+.latest-newsletter-hit {
+    position: relative;
+    @include sm-only {
+        margin-left: 16px;
+        margin-right: 16px;
+    }
+}
+
+.latest-newsletter-hit__card {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    padding: 16px;
+    // Outlined rather than filled ($blue-10) like the other cards, so
+    // newsletter tiles read as a distinct kind of item in the feed.
+    border: 1px solid $blue-20;
+    color: $blue-90;
+}
+
+.latest-newsletter-hit__icon {
+    flex-shrink: 0;
+}
+
+.latest-newsletter-hit__title {
+    @include h3-bold;
+    margin: 0 0 4px;
+}
+
+.latest-newsletter-hit__title-link {
+    color: inherit;
+    text-decoration: none;
+
+    // Stretched link: covers the whole card so clicking anywhere opens the
+    // newsletter (mirrors the article card's behavior).
+    &::after {
+        content: "";
+        position: absolute;
+        inset: 0;
+        z-index: 1;
+    }
+}
+
+.latest-newsletter-hit:hover .latest-newsletter-hit__title-link {
+    text-decoration: underline;
+    text-underline-offset: 4px;
+}
+
+.latest-newsletter-hit__external-icon {
+    width: 12px;
+    height: 12px;
+    margin-left: 8px;
+}
+
+.latest-newsletter-hit__description {
+    @include body-3-medium;
+    color: $blue-60;
+    margin: 0;
+}

--- a/site/latest/LatestNewsletterHit.tsx
+++ b/site/latest/LatestNewsletterHit.tsx
@@ -1,0 +1,62 @@
+import { LatestNewsletter } from "@ourworldindata/types"
+import cx from "clsx"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import { faArrowUpRightFromSquare } from "@fortawesome/free-solid-svg-icons"
+import { NewsletterIcon } from "../gdocs/components/NewsletterIcon.js"
+import { LatestHitMetadata } from "./LatestHitMetadata.js"
+import { LATEST_HIT_GRID_CLASSES } from "./latestUtils.js"
+import { useLatestContext } from "./LatestContext.js"
+
+/**
+ * Newsletter tile for the /latest feed. Unlike the other hit types this
+ * links out to the Mailchimp campaign-archive page (in a new tab) rather
+ * than to a page on our site.
+ */
+export const LatestNewsletterHit = ({
+    hit,
+    position,
+}: {
+    hit: LatestNewsletter
+    position: number
+}) => {
+    const { analytics } = useLatestContext()
+    const titleId = `latest-hit-newsletter-${hit.mailchimpId}-title`
+    return (
+        <article
+            id={`newsletter-${hit.mailchimpId}`}
+            aria-labelledby={titleId}
+            className={cx("latest-newsletter-hit", LATEST_HIT_GRID_CLASSES)}
+        >
+            <LatestHitMetadata latestType="newsletter" publishedAt={hit.date} />
+            <div className="latest-newsletter-hit__card">
+                <NewsletterIcon className="latest-newsletter-hit__icon" />
+                <div className="latest-newsletter-hit__content">
+                    <h2 id={titleId} className="latest-newsletter-hit__title">
+                        <a
+                            href={hit.url}
+                            target="_blank"
+                            rel="noopener"
+                            className="latest-newsletter-hit__title-link"
+                            onClick={() =>
+                                analytics.logLatestNewsletterClick(
+                                    hit,
+                                    position
+                                )
+                            }
+                        >
+                            {hit.title}
+                            <FontAwesomeIcon
+                                icon={faArrowUpRightFromSquare}
+                                className="latest-newsletter-hit__external-icon"
+                            />
+                        </a>
+                    </h2>
+                    <p className="latest-newsletter-hit__description">
+                        Our email digest of new charts, articles, and data —
+                        read this edition in your browser.
+                    </p>
+                </div>
+            </div>
+        </article>
+    )
+}

--- a/site/latest/LatestNewsletterHit.tsx
+++ b/site/latest/LatestNewsletterHit.tsx
@@ -52,8 +52,8 @@ export const LatestNewsletterHit = ({
                         </a>
                     </h2>
                     <p className="latest-newsletter-hit__description">
-                        Our email digest of new charts, articles, and data —
-                        read this edition in your browser.
+                        A twice-monthly digest of our latest work plus curated
+                        highlights from across Our World in Data.
                     </p>
                 </div>
             </div>

--- a/site/latest/LatestNewsletterHit.tsx
+++ b/site/latest/LatestNewsletterHit.tsx
@@ -32,8 +32,23 @@ export const LatestNewsletterHit = ({
             className={cx("latest-newsletter-hit", LATEST_HIT_GRID_CLASSES)}
         >
             <LatestHitMetadata latestType="newsletter" publishedAt={hit.date} />
-            <div className="latest-newsletter-hit__card">
-                <NewsletterIcon className="latest-newsletter-hit__icon" />
+            <div
+                className={cx("latest-newsletter-hit__card", {
+                    "latest-newsletter-hit__card--with-image": hit.imageUrl,
+                })}
+            >
+                {hit.imageUrl ? (
+                    // Hotlinked from Mailchimp's CDN — see LatestNewsletter.
+                    <img
+                        className="latest-newsletter-hit__image"
+                        src={hit.imageUrl}
+                        alt=""
+                        loading="lazy"
+                        decoding="async"
+                    />
+                ) : (
+                    <NewsletterIcon className="latest-newsletter-hit__icon" />
+                )}
                 <div className="latest-newsletter-hit__content">
                     <h2 id={titleId} className="latest-newsletter-hit__title">
                         <a

--- a/site/latest/LatestNewsletterHit.tsx
+++ b/site/latest/LatestNewsletterHit.tsx
@@ -7,6 +7,10 @@ import { LatestHitMetadata } from "./LatestHitMetadata.js"
 import { LATEST_HIT_GRID_CLASSES } from "./latestUtils.js"
 import { useLatestContext } from "./LatestContext.js"
 
+// The OWID Brief has a single standing author; the Mailchimp API doesn't
+// expose authorship, so it's not part of the synced newsletter data.
+const NEWSLETTER_AUTHOR = "Charlie Giattino"
+
 /**
  * Newsletter tile for the /latest feed. Unlike the other hit types this
  * links out to the Mailchimp campaign-archive page (in a new tab) rather
@@ -51,6 +55,9 @@ export const LatestNewsletterHit = ({
                             />
                         </a>
                     </h2>
+                    <p className="latest-newsletter-hit__byline">
+                        {NEWSLETTER_AUTHOR}
+                    </p>
                     <p className="latest-newsletter-hit__description">
                         A twice-monthly digest of our latest work plus curated
                         highlights from across Our World in Data.

--- a/site/latest/LatestSearch.tsx
+++ b/site/latest/LatestSearch.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useMemo, useRef, useState } from "react"
 import { useSearchParams } from "react-router-dom-v5-compat"
 import {
-    LATEST_TYPE_VALUES,
+    LATEST_PAGE_TYPE_VALUES,
+    LatestNewsletter,
     LatestState,
     LatestType,
     TagGraphRoot,
@@ -16,6 +17,8 @@ import {
     urlNeedsSanitization,
 } from "./latestState.js"
 import { LatestHit } from "./LatestHit.js"
+import { LatestNewsletterHit } from "./LatestNewsletterHit.js"
+import { LatestFeedItem, weaveNewslettersIntoFeed } from "./latestUtils.js"
 import { LatestSearchSkeleton } from "./LatestSearchSkeleton.js"
 import { LatestContext } from "./LatestContext.js"
 import { SiteAnalytics } from "../SiteAnalytics.js"
@@ -29,9 +32,14 @@ const analytics = new SiteAnalytics()
 
 export const LatestSearch = ({
     topicTagGraph,
+    newsletters,
     liteSearchClient,
 }: {
     topicTagGraph: TagGraphRoot
+    /** Injected at bake time (window._OWID_NEWSLETTERS), sorted by date
+     * descending. Newsletters live outside the Algolia index and are woven
+     * into the feed client-side. */
+    newsletters: LatestNewsletter[]
     liteSearchClient: LiteClient
 }) => {
     const [searchParams, setSearchParams] = useSearchParams()
@@ -93,12 +101,39 @@ export const LatestSearch = ({
     // topic selection. Never disable the currently active type.
     const disabledTypes = useMemo(() => {
         const disabled = new Set<LatestType>()
-        for (const value of LATEST_TYPE_VALUES) {
+        for (const value of LATEST_PAGE_TYPE_VALUES) {
             if (value === latestType) continue
+            if (value === "newsletter") {
+                // Newsletters live outside Algolia and carry no topic tags,
+                // so they're only available when no topic is selected.
+                if (topics.length > 0 || newsletters.length === 0)
+                    disabled.add(value)
+                continue
+            }
             if ((latestTypeFacetCounts[value] ?? 0) === 0) disabled.add(value)
         }
         return disabled
-    }, [latestType, latestTypeFacetCounts])
+    }, [latestType, latestTypeFacetCounts, topics.length, newsletters.length])
+
+    // Weave bake-time newsletters into the Algolia-backed record stream.
+    const feedItems: LatestFeedItem[] = useMemo(() => {
+        // Newsletters have no topic tags, so any topic selection excludes
+        // them; likewise any non-newsletter type filter.
+        const includeNewsletters = topics.length === 0
+        if (latestType === "newsletter")
+            return includeNewsletters
+                ? newsletters.map((newsletter) => ({
+                      kind: "newsletter" as const,
+                      newsletter,
+                  }))
+                : []
+        const recordItems = hits.map((record) => ({
+            kind: "record" as const,
+            record,
+        }))
+        if (!includeNewsletters || latestType) return recordItems
+        return weaveNewslettersIntoFeed(hits, newsletters, hasNextPage ?? false)
+    }, [hits, newsletters, topics.length, latestType, hasNextPage])
 
     // Disable topics that would yield 0 results given the current filters.
     // Never disable a topic that is already selected (so the user can deselect
@@ -113,6 +148,23 @@ export const LatestSearch = ({
         }
         return disabled
     }, [allAreas, tagFacetCounts, topics])
+
+    const renderFeedItem = (item: LatestFeedItem, position: number) =>
+        item.kind === "newsletter" ? (
+            <LatestNewsletterHit
+                key={`newsletter-${item.newsletter.mailchimpId}`}
+                hit={item.newsletter}
+                position={position}
+            />
+        ) : (
+            <LatestHit
+                key={item.record.objectID}
+                hit={item.record}
+                selectedTopic={topics[0]}
+                position={position}
+                shouldAutoExpand={item.record.slug === autoExpandedSlug}
+            />
+        )
 
     // After the first data load, scroll to the URL hash anchor (e.g.
     // /latest#some-slug) so that links from the homepage land on the
@@ -158,7 +210,7 @@ export const LatestSearch = ({
             <hr className="latest-search__filters-divider span-cols-12 col-start-2 span-md-cols-12 col-md-start-2 span-sm-cols-14 col-sm-start-1" />
             {isLoading ? (
                 <LatestSearchSkeleton />
-            ) : hits.length === 0 ? (
+            ) : feedItems.length === 0 ? (
                 <SearchNoResults
                     subtitle={
                         <p className="body-3-medium">
@@ -175,15 +227,9 @@ export const LatestSearch = ({
                 />
             ) : (
                 <>
-                    {hits.slice(0, 2).map((hit, i) => (
-                        <LatestHit
-                            key={hit.objectID}
-                            hit={hit}
-                            selectedTopic={topics[0]}
-                            position={i + 1}
-                            shouldAutoExpand={hit.slug === autoExpandedSlug}
-                        />
-                    ))}
+                    {feedItems
+                        .slice(0, 2)
+                        .map((item, i) => renderFeedItem(item, i + 1))}
                     {/* Always render the signup block — with 0 or 1 hits it
                         falls below whatever cards exist, which is the
                         intended layout. */}
@@ -191,15 +237,9 @@ export const LatestSearch = ({
                         className="latest-page__newsletter-signup col-start-11 span-cols-3 col-lg-start-10 span-lg-cols-4 span-md-cols-14 col-md-start-1"
                         context={NewsletterSubscriptionContext.Latest}
                     />
-                    {hits.slice(2).map((hit, i) => (
-                        <LatestHit
-                            key={hit.objectID}
-                            hit={hit}
-                            selectedTopic={topics[0]}
-                            position={i + 3}
-                            shouldAutoExpand={hit.slug === autoExpandedSlug}
-                        />
-                    ))}
+                    {feedItems
+                        .slice(2)
+                        .map((item, i) => renderFeedItem(item, i + 3))}
                     {hasNextPage && (
                         <SearchHorizontalDivider
                             className="span-cols-8 col-start-2 span-md-cols-12 col-md-start-2 span-sm-cols-14 col-sm-start-1"

--- a/site/latest/LatestSearchWrapper.tsx
+++ b/site/latest/LatestSearchWrapper.tsx
@@ -1,12 +1,14 @@
-import { TagGraphRoot } from "@ourworldindata/types"
+import { LatestNewsletter, TagGraphRoot } from "@ourworldindata/types"
 import { LatestSearch } from "./LatestSearch.js"
 import { getLiteSearchClient } from "../search/searchClients.js"
 import { SiteQueryClientProvider } from "../SiteQueryClientProvider.js"
 
 export const LatestSearchWrapper = ({
     topicTagGraph,
+    newsletters,
 }: {
     topicTagGraph: TagGraphRoot
+    newsletters: LatestNewsletter[]
 }) => {
     const liteSearchClient = getLiteSearchClient()
 
@@ -14,6 +16,7 @@ export const LatestSearchWrapper = ({
         <SiteQueryClientProvider>
             <LatestSearch
                 topicTagGraph={topicTagGraph}
+                newsletters={newsletters}
                 liteSearchClient={liteSearchClient}
             />
         </SiteQueryClientProvider>

--- a/site/latest/LatestTopicFacets.tsx
+++ b/site/latest/LatestTopicFacets.tsx
@@ -18,7 +18,7 @@ import {
     ToggleButtonGroup,
     type Key,
 } from "react-aria-components"
-import { LATEST_TYPE_VALUES, LatestType } from "@ourworldindata/types"
+import { LATEST_PAGE_TYPE_VALUES, LatestType } from "@ourworldindata/types"
 import { latestTypeLabelPlural } from "./latestUtils.js"
 
 /**
@@ -244,7 +244,7 @@ export const LatestTopicFacets = ({
                                 label="All"
                                 ariaLabel="All types"
                             />
-                            {LATEST_TYPE_VALUES.map((value) => (
+                            {LATEST_PAGE_TYPE_VALUES.map((value) => (
                                 <ContentTypeListBoxItem
                                     key={value}
                                     id={value}

--- a/site/latest/latestUtils.test.ts
+++ b/site/latest/latestUtils.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest"
-import { deriveAnnouncementLatestType } from "./latestUtils.js"
+import {
+    LatestNewsletter,
+    PageChronologicalRecord,
+} from "@ourworldindata/types"
+import {
+    deriveAnnouncementLatestType,
+    weaveNewslettersIntoFeed,
+} from "./latestUtils.js"
 
 describe(deriveAnnouncementLatestType, () => {
     it.each(["data-update", "website-upgrade", "announcement"])(
@@ -24,4 +31,72 @@ describe(deriveAnnouncementLatestType, () => {
             expect(deriveAnnouncementLatestType(kicker)).toBe("announcement")
         }
     )
+})
+
+describe(weaveNewslettersIntoFeed, () => {
+    const record = (date: string) =>
+        ({ date }) as unknown as PageChronologicalRecord
+    const newsletter = (date: string) => ({ date }) as LatestNewsletter
+
+    const dates = (items: ReturnType<typeof weaveNewslettersIntoFeed>) =>
+        items.map((item) =>
+            item.kind === "newsletter"
+                ? `n:${item.newsletter.date}`
+                : `r:${item.record.date}`
+        )
+
+    it("interleaves newsletters into records by date descending", () => {
+        const items = weaveNewslettersIntoFeed(
+            [record("2026-07-20"), record("2026-07-10"), record("2026-07-01")],
+            [newsletter("2026-07-17"), newsletter("2026-07-03")],
+            false
+        )
+        expect(dates(items)).toEqual([
+            "r:2026-07-20",
+            "n:2026-07-17",
+            "r:2026-07-10",
+            "n:2026-07-03",
+            "r:2026-07-01",
+        ])
+    })
+
+    it("holds back newsletters older than the loaded range while more pages remain", () => {
+        const items = weaveNewslettersIntoFeed(
+            [record("2026-07-20"), record("2026-07-10")],
+            [newsletter("2026-07-17"), newsletter("2026-07-03")],
+            true
+        )
+        expect(dates(items)).toEqual([
+            "r:2026-07-20",
+            "n:2026-07-17",
+            "r:2026-07-10",
+        ])
+    })
+
+    it("appends remaining newsletters once the last page is loaded", () => {
+        const items = weaveNewslettersIntoFeed(
+            [record("2026-07-20")],
+            [newsletter("2026-07-17"), newsletter("2026-07-03")],
+            false
+        )
+        expect(dates(items)).toEqual([
+            "r:2026-07-20",
+            "n:2026-07-17",
+            "n:2026-07-03",
+        ])
+    })
+
+    it("returns records unchanged when there are no newsletters", () => {
+        const items = weaveNewslettersIntoFeed([record("2026-07-20")], [], true)
+        expect(dates(items)).toEqual(["r:2026-07-20"])
+    })
+
+    it("returns all newsletters when there are no records", () => {
+        const items = weaveNewslettersIntoFeed(
+            [],
+            [newsletter("2026-07-17")],
+            false
+        )
+        expect(dates(items)).toEqual(["n:2026-07-17"])
+    })
 })

--- a/site/latest/latestUtils.ts
+++ b/site/latest/latestUtils.ts
@@ -1,10 +1,11 @@
 import {
     ANNOUNCEMENT_LATEST_TYPES,
     AnnouncementLatestType,
+    LATEST_PAGE_TYPE_VALUES,
     LATEST_PATH,
     LATEST_TYPE_LABELS,
-    LATEST_TYPE_VALUES,
     LatestFeedGdoc,
+    LatestNewsletter,
     LatestType,
     LatestUrlParam,
     PageChronologicalRecord,
@@ -20,7 +21,7 @@ export function buildLatestPagePath(type?: LatestType): string {
 /** Decode the URL query `?type=` param back to a LatestType or null. */
 export function decodeLatestType(param: string | null): LatestType | null {
     if (!param) return null
-    return (LATEST_TYPE_VALUES as readonly string[]).includes(param)
+    return (LATEST_PAGE_TYPE_VALUES as readonly string[]).includes(param)
         ? (param as LatestType)
         : null
 }
@@ -65,6 +66,58 @@ export function deriveLatestType(gdoc: LatestFeedGdoc): LatestType {
  * /latest's "Filter by type" filter ("Articles", "Data Insights", …). */
 export const latestTypeLabelPlural = (type: LatestType): string =>
     `${LATEST_TYPE_LABELS[type]}s`
+
+/**
+ * A single item in the /latest feed: either an Algolia-backed chronological
+ * record or a newsletter injected into the page at bake time (newsletters
+ * deliberately live outside the Algolia index — see LatestNewsletter).
+ */
+export type LatestFeedItem =
+    | { kind: "record"; record: PageChronologicalRecord }
+    | { kind: "newsletter"; newsletter: LatestNewsletter }
+
+/**
+ * Merge newsletters into the date-sorted record stream, preserving reverse
+ * chronological order. Both inputs must be sorted by date descending.
+ *
+ * While more record pages remain to be fetched (`hasMoreRecords`), only
+ * newsletters that fall within the already-loaded date range are woven in —
+ * older ones join as later pages load, so items never appear out of order or
+ * jump around.
+ */
+export function weaveNewslettersIntoFeed(
+    records: PageChronologicalRecord[],
+    newsletters: LatestNewsletter[],
+    hasMoreRecords: boolean
+): LatestFeedItem[] {
+    const oldestLoadedDate = records[records.length - 1]?.date
+    const eligible =
+        hasMoreRecords && oldestLoadedDate
+            ? newsletters.filter((n) => n.date >= oldestLoadedDate)
+            : newsletters
+
+    const items: LatestFeedItem[] = []
+    let newsletterIndex = 0
+    for (const record of records) {
+        while (
+            newsletterIndex < eligible.length &&
+            eligible[newsletterIndex].date >= record.date
+        ) {
+            items.push({
+                kind: "newsletter",
+                newsletter: eligible[newsletterIndex++],
+            })
+        }
+        items.push({ kind: "record", record })
+    }
+    while (newsletterIndex < eligible.length) {
+        items.push({
+            kind: "newsletter",
+            newsletter: eligible[newsletterIndex++],
+        })
+    }
+    return items
+}
 
 /** Grid positioning applied to the root of every hit card. */
 export const LATEST_HIT_GRID_CLASSES =

--- a/site/owid.scss
+++ b/site/owid.scss
@@ -54,6 +54,7 @@
 @import "./latest/LatestArticleHit.scss";
 @import "./latest/LatestDataInsightHit.scss";
 @import "./latest/LatestAnnouncementHit.scss";
+@import "./latest/LatestNewsletterHit.scss";
 @import "./latest/AnnouncementContent.scss";
 @import "./latest/LatestSearchSkeleton.scss";
 @import "./latest/ExpandableText.scss";

--- a/site/runSiteFooterScripts.tsx
+++ b/site/runSiteFooterScripts.tsx
@@ -71,6 +71,8 @@ function hydrateSubscribePage() {
             newsletterContainer,
             <NewsletterSubscriptionForm
                 context={NewsletterSubscriptionContext.SubscribePage}
+                // Baked into the page so hydration matches the server render.
+                exampleUrls={window._OWID_NEWSLETTER_EXAMPLES}
             />
         )
     }
@@ -87,10 +89,14 @@ function hydrateSlideshowPage() {
 function runLatestPage() {
     const root = document.getElementById("latest-page-root")
     const topicTagGraph = window._OWID_TOPIC_TAG_GRAPH
+    const newsletters = window._OWID_NEWSLETTERS ?? []
     if (root) {
         createRoot(root).render(
             <BrowserRouter>
-                <LatestSearchWrapper topicTagGraph={topicTagGraph} />
+                <LatestSearchWrapper
+                    topicTagGraph={topicTagGraph}
+                    newsletters={newsletters}
+                />
             </BrowserRouter>
         )
     }


### PR DESCRIPTION
> _Written by Anthropic Claude Fable 5 — @edomt at the wheel._

## Summary

Brings our newsletter archive to https://ourworldindata.org/latest: each edition of The OWID Brief shows as a tile in the feed, in chronological order, linking out to its Mailchimp campaign-archive page.

- **New `newsletters` table**, synced from the Mailchimp Marketing API by `baker/syncNewslettersFromMailchimp.ts` (`make sync-newsletters`). Campaigns are classified by their audience interest-group ids — robust across the historical "Biweekly Digest" → "The OWID Brief" rename — and test sends to other lists are excluded. Requires `MAILCHIMP_API_KEY` / `MAILCHIMP_API_SERVER` in server settings; note Mailchimp API keys expire after one year (the sync fails loudly to Sentry when that happens).
- **Newsletters stay out of Algolia entirely.** The baker injects Brief editions into `latest.html` as `window._OWID_NEWSLETTERS`, and the /latest SPA weaves them into the Algolia-backed record stream client-side, by date. This keeps them out of /search and the atom feeds by construction — important because Mailchimp consumes those feeds to send newsletters — and leaves `functions/atom.xml.ts` and the indexers untouched.
- **New outlined newsletter card** (envelope icon, "Newsletter" kicker) that opens the archive page in a new tab, plus a "Newsletters" option in the /latest type filter. Only campaigns titled "The OWID Brief: …" become tiles; older Biweekly Digest editions are synced to the DB but not shown.
- **/subscribe "see example" links** now point to the latest edition of each newsletter, resolved at bake time and passed to hydration via `window._OWID_NEWSLETTER_EXAMPLES` (static fallbacks remain for client-only contexts like the floating subscribe dialog).

## ⚠️ Known tradeoff: tile images are hotlinked from Mailchimp's CDN

Each tile's featured image is the first edition-specific content image of the campaign, served **directly from Mailchimp's CDN (`mcusercontent.com`)** — a deliberate shortcut to ship the visual improvement cheaply. This adds an external dependency to /latest: if Mailchimp ever changes or expires those URLs, tiles lose their images (they degrade gracefully to the envelope icon). **For a clean version, refactor the sync to re-upload these images to Cloudflare Images** — the place to do it is `fetchFirstContentImage` in `baker/syncNewslettersFromMailchimp.ts`, and the `newsletters.imageUrl` column docs flag it too.

## Deployment notes

- `make migrate` creates the `newsletters` table.
- `make sync-newsletters` needs a schedule (e.g. Buildkite cron, like `index-scheduled`) plus the Mailchimp credentials in prod/staging settings. Note: staging servers regenerate `.env` from the ops template on every push, so `MAILCHIMP_API_KEY` must be added to that template (manual appends get wiped).

## Testing

- Full typecheck, oxlint, and formatting pass; 25 unit tests pass including new coverage for the feed-weaving logic.
- Verified end-to-end on `staging-site-newsletter-archive`: the sync imported 480 newsletters from 1,110 sent campaigns (109 OWID Briefs, 371 Data Insights), and after a bake:
  - [/latest](http://staging-site-newsletter-archive/latest) shows the 18 Brief-era editions (subjects starting "The OWID Brief") as tiles woven into the feed in date order;
  - [/latest?type=newsletter](http://staging-site-newsletter-archive/latest?type=newsletter) shows the same 18 tiles on their own via the new type filter;
  - [/subscribe](http://staging-site-newsletter-archive/subscribe) links to the latest edition of each newsletter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



