### PR TITLE
Add deprecation notice banner to chart config

### DIFF
--- a/adminSiteClient/EditorTextTab.tsx
+++ b/adminSiteClient/EditorTextTab.tsx
@@ -507,6 +507,17 @@ export class EditorTextTab<
                         </Button>
                     )}
                 </Section>
+                <Section name="Deprecation">
+                    <BindString
+                        label="Deprecation notice"
+                        field="deprecationNotice"
+                        store={grapherState}
+                        textarea
+                        softCharacterLimit={280}
+                        placeholder="e.g. This chart is no longer updated because … See [our updated charts](https://ourworldindata.org/...) instead."
+                        helpText="Shown as a banner on the chart, including embeds. Supports markdown links. Point readers to a successor chart if one exists. Leave empty for charts that are still maintained."
+                    />
+                </Section>
                 <Section name="Misc">
                     <BindString
                         label="Internal author notes"

--- a/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.scss
+++ b/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.scss
@@ -1,5 +1,6 @@
 // keep in sync with constant values in CaptionedChart.tsx
 $controlRowHeight: 32px; // keep in sync with CONTROLS_ROW_HEIGHT
+$deprecationNoticePadding: 8px; // keep in sync with DEPRECATION_NOTICE_PADDING
 
 .CaptionedChart {
     width: 100%;
@@ -21,6 +22,33 @@ $controlRowHeight: 32px; // keep in sync with CONTROLS_ROW_HEIGHT
 
     .controls {
         width: 100%;
+    }
+}
+
+.DeprecationNotice {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+    padding: $deprecationNoticePadding;
+    background-color: $amber-10;
+    border-left: 4px solid $amber;
+    color: $dark-text;
+
+    svg {
+        flex-shrink: 0;
+        margin-top: 3px;
+        color: $amber;
+    }
+
+    a {
+        font-weight: 700;
+        text-decoration-line: underline;
+        text-underline-offset: auto;
+        color: inherit;
+
+        &:hover {
+            text-decoration-line: none;
+        }
     }
 }
 

--- a/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.scss
+++ b/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.scss
@@ -24,38 +24,38 @@ $controlRowHeight: 32px; // keep in sync with CONTROLS_ROW_HEIGHT
     }
 }
 
+// Custom muted-amber palette from the "2a" option of the Claude Design
+// mockup (not in colors.scss — deliberately softer than $amber/$amber-10,
+// chosen so the notice reads as a warning without the brand amber's punch)
+$deprecation-notice-bg: #fbf6e8;
+$deprecation-notice-border: #f0e2b8;
+$deprecation-notice-icon: #a3861f;
+$deprecation-notice-heading: #5c4a10;
+$deprecation-notice-text: #6b5a1f;
+
 // keep in sync with constant values in CaptionedChart.tsx
 .DeprecationNotice__box {
     display: flex;
     align-items: flex-start;
-    border-radius: 8px;
-    background: $blue-5;
-    border: 1px solid $blue-20;
+    border-radius: 6px;
+    background: $deprecation-notice-bg;
+    border: 1px solid $deprecation-notice-border;
+
+    svg {
+        flex-shrink: 0;
+        margin-top: 3px;
+        font-size: 13px;
+        color: $deprecation-notice-icon;
+    }
 
     strong {
         font-weight: 600;
-        color: $blue-95;
-    }
-}
-
-.DeprecationNotice__icon {
-    flex: 0 0 auto;
-    margin-top: 1px;
-    border-radius: 6px;
-    background: $blue-20;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-
-    svg {
-        font-size: 14px;
-        color: $blue-60;
+        color: $deprecation-notice-heading;
     }
 }
 
 .DeprecationNotice__text {
-    padding-top: 2px;
-    color: $blue-60;
+    color: $deprecation-notice-text;
 
     a {
         color: $vermillion;

--- a/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.scss
+++ b/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.scss
@@ -1,6 +1,5 @@
 // keep in sync with constant values in CaptionedChart.tsx
 $controlRowHeight: 32px; // keep in sync with CONTROLS_ROW_HEIGHT
-$deprecationNoticePadding: 8px; // keep in sync with DEPRECATION_NOTICE_PADDING
 
 .CaptionedChart {
     width: 100%;
@@ -25,29 +24,30 @@ $deprecationNoticePadding: 8px; // keep in sync with DEPRECATION_NOTICE_PADDING
     }
 }
 
-// Matches the "this article is outdated" notice used in gdoc articles
-// (site/gdocs/components/centered-article.scss's .deprecation-notice):
-// pale-yellow flat box, no border accent, vermillion icon, 4px radius.
-.DeprecationNotice {
+// Styled in the vocabulary of grapher's own chrome (hairline stroke,
+// 4px radius, muted grey text and icon — like the tab controls below it)
+// rather than as a colored callout box, which would compete with the
+// chart itself for attention. The bold markdown lead-in and the archive
+// icon carry the message.
+.DeprecationNotice__box {
     display: flex;
     align-items: flex-start;
-    gap: 8px;
-    padding: $deprecationNoticePadding;
-    background-color: #fff5d8;
+    gap: 8px; // keep in sync with DEPRECATION_NOTICE_ICON_WIDTH
     border-radius: 4px;
+    box-shadow: inset 0 0 0 1px $gray-20;
     color: $dark-text;
 
     svg {
         flex-shrink: 0;
-        margin-top: 3px;
-        color: $vermillion;
+        font-size: 13px; // keep in sync with DEPRECATION_NOTICE_ICON_WIDTH
+        margin-top: 2px;
+        color: $gray-60;
     }
 
     a {
-        font-weight: 700;
+        color: inherit;
         text-decoration-line: underline;
         text-underline-offset: auto;
-        color: inherit;
 
         &:hover {
             text-decoration-line: none;

--- a/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.scss
+++ b/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.scss
@@ -25,19 +25,22 @@ $deprecationNoticePadding: 8px; // keep in sync with DEPRECATION_NOTICE_PADDING
     }
 }
 
+// Matches the "this article is outdated" notice used in gdoc articles
+// (site/gdocs/components/centered-article.scss's .deprecation-notice):
+// pale-yellow flat box, no border accent, vermillion icon, 4px radius.
 .DeprecationNotice {
     display: flex;
     align-items: flex-start;
     gap: 8px;
     padding: $deprecationNoticePadding;
-    background-color: $amber-10;
-    border-left: 4px solid $amber;
+    background-color: #fff5d8;
+    border-radius: 4px;
     color: $dark-text;
 
     svg {
         flex-shrink: 0;
         margin-top: 3px;
-        color: $amber;
+        color: $vermillion;
     }
 
     a {

--- a/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.scss
+++ b/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.scss
@@ -24,32 +24,46 @@ $controlRowHeight: 32px; // keep in sync with CONTROLS_ROW_HEIGHT
     }
 }
 
-// Styled in the vocabulary of grapher's own chrome (hairline stroke,
-// 4px radius, muted grey text and icon — like the tab controls below it)
-// rather than as a colored callout box, which would compete with the
-// chart itself for attention. The bold markdown lead-in and the archive
-// icon carry the message.
+// keep in sync with constant values in CaptionedChart.tsx
 .DeprecationNotice__box {
     display: flex;
     align-items: flex-start;
-    gap: 8px; // keep in sync with DEPRECATION_NOTICE_ICON_WIDTH
-    border-radius: 4px;
-    box-shadow: inset 0 0 0 1px $gray-20;
-    color: $dark-text;
+    border-radius: 8px;
+    background: $blue-5;
+    border: 1px solid $blue-20;
+
+    strong {
+        font-weight: 600;
+        color: $blue-95;
+    }
+}
+
+.DeprecationNotice__icon {
+    flex: 0 0 auto;
+    margin-top: 1px;
+    border-radius: 6px;
+    background: $blue-20;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 
     svg {
-        flex-shrink: 0;
-        font-size: 13px; // keep in sync with DEPRECATION_NOTICE_ICON_WIDTH
-        margin-top: 2px;
-        color: $gray-60;
+        font-size: 14px;
+        color: $blue-60;
     }
+}
+
+.DeprecationNotice__text {
+    padding-top: 2px;
+    color: $blue-60;
 
     a {
-        color: inherit;
+        color: $vermillion;
         text-decoration-line: underline;
         text-underline-offset: auto;
 
         &:hover {
+            color: $accent-vermillion;
             text-decoration-line: none;
         }
     }

--- a/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
@@ -284,6 +284,21 @@ export class CaptionedChart extends AbstractCaptionedChart {
         )
     }
 
+    // Markdown links render as plain <a href>, with no way to pass per-link
+    // target/rel props. Inside an iframe embed, opening the successor link
+    // in the iframe itself would be a poor escape hatch, so intercept clicks
+    // there and open in a new tab instead (same as the hand-authored links
+    // in Header/Footer already do for isInIFrame).
+    private readonly onDeprecationNoticeClick = (
+        event: React.MouseEvent<HTMLDivElement>
+    ): void => {
+        if (!this.manager.isInIFrame) return
+        const anchor = (event.target as HTMLElement).closest("a")
+        if (!anchor) return
+        event.preventDefault()
+        window.open(anchor.href, "_blank", "noopener")
+    }
+
     private renderDeprecationNotice(): React.ReactElement {
         return (
             <div
@@ -300,6 +315,7 @@ export class CaptionedChart extends AbstractCaptionedChart {
                         padding: `${DEPRECATION_NOTICE_PADDING_VERTICAL}px ${DEPRECATION_NOTICE_PADDING_HORIZONTAL}px`,
                         gap: DEPRECATION_NOTICE_GAP,
                     }}
+                    onClick={this.onDeprecationNoticeClick}
                 >
                     <FontAwesomeIcon icon={faBoxArchive} />
                     <div

--- a/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
@@ -111,8 +111,11 @@ interface CaptionedChartProps {
 export const CONTROLS_ROW_HEIGHT = 32
 
 // keep in sync with sass variables in CaptionedChart.scss
-const DEPRECATION_NOTICE_PADDING = 8
+const DEPRECATION_NOTICE_PADDING_VERTICAL = 8
+const DEPRECATION_NOTICE_PADDING_HORIZONTAL = 12
+const DEPRECATION_NOTICE_ICON_WIDTH = 21 // 13px icon + 8px gap
 const DEPRECATION_NOTICE_FONT_SIZE = 13
+const DEPRECATION_NOTICE_LINE_HEIGHT = 1.3846 // grapher_body-3-regular
 
 abstract class AbstractCaptionedChart extends React.Component<CaptionedChartProps> {
     protected framePaddingHorizontal = GRAPHER_FRAME_PADDING_HORIZONTAL
@@ -200,9 +203,12 @@ export class CaptionedChart extends AbstractCaptionedChart {
         if (!this.showDeprecationNotice) return undefined
         return new MarkdownTextWrap({
             text: this.manager.deprecationNotice!,
-            maxWidth: this.maxWidth - 2 * DEPRECATION_NOTICE_PADDING - 20,
+            maxWidth:
+                this.maxWidth -
+                2 * DEPRECATION_NOTICE_PADDING_HORIZONTAL -
+                DEPRECATION_NOTICE_ICON_WIDTH,
             fontSize: DEPRECATION_NOTICE_FONT_SIZE,
-            lineHeight: 1.25,
+            lineHeight: DEPRECATION_NOTICE_LINE_HEIGHT,
             detailsOrderedByReference: this.manager.detailsOrderedByReference,
         })
     }
@@ -211,7 +217,7 @@ export class CaptionedChart extends AbstractCaptionedChart {
         if (!this.deprecationNoticeTextWrap) return 0
         return (
             this.deprecationNoticeTextWrap.height +
-            2 * DEPRECATION_NOTICE_PADDING
+            2 * DEPRECATION_NOTICE_PADDING_VERTICAL
         )
     }
 
@@ -282,15 +288,22 @@ export class CaptionedChart extends AbstractCaptionedChart {
                 className="DeprecationNotice"
                 style={{
                     width: this.bounds.width,
-                    padding: `${DEPRECATION_NOTICE_PADDING}px ${this.framePaddingHorizontal}px`,
+                    padding: `0 ${this.framePaddingHorizontal}px`,
                 }}
                 data-track-note="chart_deprecation_notice"
             >
-                <FontAwesomeIcon icon={faBoxArchive} />
-                <div style={this.deprecationNoticeTextWrap!.style}>
-                    <MarkdownTextWrapHtml
-                        textWrap={this.deprecationNoticeTextWrap!}
-                    />
+                <div
+                    className="DeprecationNotice__box"
+                    style={{
+                        padding: `${DEPRECATION_NOTICE_PADDING_VERTICAL}px ${DEPRECATION_NOTICE_PADDING_HORIZONTAL}px`,
+                    }}
+                >
+                    <FontAwesomeIcon icon={faBoxArchive} />
+                    <div style={this.deprecationNoticeTextWrap!.style}>
+                        <MarkdownTextWrapHtml
+                            textWrap={this.deprecationNoticeTextWrap!}
+                        />
+                    </div>
                 </div>
             </div>
         )

--- a/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
@@ -111,11 +111,12 @@ interface CaptionedChartProps {
 export const CONTROLS_ROW_HEIGHT = 32
 
 // keep in sync with sass variables in CaptionedChart.scss
-const DEPRECATION_NOTICE_PADDING_VERTICAL = 8
-const DEPRECATION_NOTICE_PADDING_HORIZONTAL = 12
-const DEPRECATION_NOTICE_ICON_WIDTH = 21 // 13px icon + 8px gap
-const DEPRECATION_NOTICE_FONT_SIZE = 13
-const DEPRECATION_NOTICE_LINE_HEIGHT = 1.3846 // grapher_body-3-regular
+const DEPRECATION_NOTICE_PADDING_VERTICAL = 16
+const DEPRECATION_NOTICE_PADDING_HORIZONTAL = 20
+const DEPRECATION_NOTICE_GAP = 14
+const DEPRECATION_NOTICE_ICON_BADGE_SIZE = 32
+const DEPRECATION_NOTICE_FONT_SIZE = 15
+const DEPRECATION_NOTICE_LINE_HEIGHT = 1.5
 
 abstract class AbstractCaptionedChart extends React.Component<CaptionedChartProps> {
     protected framePaddingHorizontal = GRAPHER_FRAME_PADDING_HORIZONTAL
@@ -206,7 +207,8 @@ export class CaptionedChart extends AbstractCaptionedChart {
             maxWidth:
                 this.maxWidth -
                 2 * DEPRECATION_NOTICE_PADDING_HORIZONTAL -
-                DEPRECATION_NOTICE_ICON_WIDTH,
+                DEPRECATION_NOTICE_ICON_BADGE_SIZE -
+                DEPRECATION_NOTICE_GAP,
             fontSize: DEPRECATION_NOTICE_FONT_SIZE,
             lineHeight: DEPRECATION_NOTICE_LINE_HEIGHT,
             detailsOrderedByReference: this.manager.detailsOrderedByReference,
@@ -216,14 +218,17 @@ export class CaptionedChart extends AbstractCaptionedChart {
     @computed private get deprecationNoticeHeight(): number {
         if (!this.deprecationNoticeTextWrap) return 0
         return (
-            this.deprecationNoticeTextWrap.height +
+            Math.max(
+                DEPRECATION_NOTICE_ICON_BADGE_SIZE,
+                this.deprecationNoticeTextWrap.height
+            ) +
             2 * DEPRECATION_NOTICE_PADDING_VERTICAL
         )
     }
 
     @computed private get deprecationNoticeHeightWithPadding(): number {
         if (!this.showDeprecationNotice) return 0
-        return this.deprecationNoticeHeight + this.verticalPaddingSmall
+        return this.deprecationNoticeHeight + this.verticalPadding
     }
 
     @computed private get showControlsRow(): boolean {
@@ -296,10 +301,22 @@ export class CaptionedChart extends AbstractCaptionedChart {
                     className="DeprecationNotice__box"
                     style={{
                         padding: `${DEPRECATION_NOTICE_PADDING_VERTICAL}px ${DEPRECATION_NOTICE_PADDING_HORIZONTAL}px`,
+                        gap: DEPRECATION_NOTICE_GAP,
                     }}
                 >
-                    <FontAwesomeIcon icon={faBoxArchive} />
-                    <div style={this.deprecationNoticeTextWrap!.style}>
+                    <div
+                        className="DeprecationNotice__icon"
+                        style={{
+                            width: DEPRECATION_NOTICE_ICON_BADGE_SIZE,
+                            height: DEPRECATION_NOTICE_ICON_BADGE_SIZE,
+                        }}
+                    >
+                        <FontAwesomeIcon icon={faBoxArchive} />
+                    </div>
+                    <div
+                        className="DeprecationNotice__text"
+                        style={this.deprecationNoticeTextWrap!.style}
+                    >
                         <MarkdownTextWrapHtml
                             textWrap={this.deprecationNoticeTextWrap!}
                         />
@@ -417,7 +434,7 @@ export class CaptionedChart extends AbstractCaptionedChart {
                 {/* #2 [Deprecation notice] */}
                 {this.showDeprecationNotice && this.renderDeprecationNotice()}
                 {this.showDeprecationNotice && (
-                    <VerticalSpace height={this.verticalPaddingSmall} />
+                    <VerticalSpace height={this.verticalPadding} />
                 )}
 
                 {this.manager.isReady ? (

--- a/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
@@ -111,11 +111,11 @@ interface CaptionedChartProps {
 export const CONTROLS_ROW_HEIGHT = 32
 
 // keep in sync with sass variables in CaptionedChart.scss
-const DEPRECATION_NOTICE_PADDING_VERTICAL = 16
-const DEPRECATION_NOTICE_PADDING_HORIZONTAL = 20
-const DEPRECATION_NOTICE_GAP = 14
-const DEPRECATION_NOTICE_ICON_BADGE_SIZE = 32
-const DEPRECATION_NOTICE_FONT_SIZE = 15
+const DEPRECATION_NOTICE_PADDING_VERTICAL = 12
+const DEPRECATION_NOTICE_PADDING_HORIZONTAL = 16
+const DEPRECATION_NOTICE_GAP = 10
+const DEPRECATION_NOTICE_ICON_WIDTH = 16
+const DEPRECATION_NOTICE_FONT_SIZE = 14
 const DEPRECATION_NOTICE_LINE_HEIGHT = 1.5
 
 abstract class AbstractCaptionedChart extends React.Component<CaptionedChartProps> {
@@ -207,7 +207,7 @@ export class CaptionedChart extends AbstractCaptionedChart {
             maxWidth:
                 this.maxWidth -
                 2 * DEPRECATION_NOTICE_PADDING_HORIZONTAL -
-                DEPRECATION_NOTICE_ICON_BADGE_SIZE -
+                DEPRECATION_NOTICE_ICON_WIDTH -
                 DEPRECATION_NOTICE_GAP,
             fontSize: DEPRECATION_NOTICE_FONT_SIZE,
             lineHeight: DEPRECATION_NOTICE_LINE_HEIGHT,
@@ -218,10 +218,7 @@ export class CaptionedChart extends AbstractCaptionedChart {
     @computed private get deprecationNoticeHeight(): number {
         if (!this.deprecationNoticeTextWrap) return 0
         return (
-            Math.max(
-                DEPRECATION_NOTICE_ICON_BADGE_SIZE,
-                this.deprecationNoticeTextWrap.height
-            ) +
+            this.deprecationNoticeTextWrap.height +
             2 * DEPRECATION_NOTICE_PADDING_VERTICAL
         )
     }
@@ -304,15 +301,7 @@ export class CaptionedChart extends AbstractCaptionedChart {
                         gap: DEPRECATION_NOTICE_GAP,
                     }}
                 >
-                    <div
-                        className="DeprecationNotice__icon"
-                        style={{
-                            width: DEPRECATION_NOTICE_ICON_BADGE_SIZE,
-                            height: DEPRECATION_NOTICE_ICON_BADGE_SIZE,
-                        }}
-                    >
-                        <FontAwesomeIcon icon={faBoxArchive} />
-                    </div>
+                    <FontAwesomeIcon icon={faBoxArchive} />
                     <div
                         className="DeprecationNotice__text"
                         style={this.deprecationNoticeTextWrap!.style}

--- a/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
@@ -25,7 +25,7 @@ import { MapChartManager } from "../mapCharts/MapChartConstants"
 import { ChartManager } from "../chart/ChartManager"
 import {
     faExternalLinkAlt,
-    faTriangleExclamation,
+    faBoxArchive,
 } from "@fortawesome/free-solid-svg-icons"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { FooterManager } from "../footer/FooterManager"
@@ -286,7 +286,7 @@ export class CaptionedChart extends AbstractCaptionedChart {
                 }}
                 data-track-note="chart_deprecation_notice"
             >
-                <FontAwesomeIcon icon={faTriangleExclamation} />
+                <FontAwesomeIcon icon={faBoxArchive} />
                 <div style={this.deprecationNoticeTextWrap!.style}>
                     <MarkdownTextWrapHtml
                         textWrap={this.deprecationNoticeTextWrap!}

--- a/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
@@ -9,6 +9,7 @@ import {
 } from "@ourworldindata/utils"
 import {
     MarkdownTextWrap,
+    MarkdownTextWrapHtml,
     MarkdownTextWrapSvg,
     LoadingIndicator,
 } from "@ourworldindata/components"
@@ -22,7 +23,10 @@ import {
 } from "../core/GrapherConstants"
 import { MapChartManager } from "../mapCharts/MapChartConstants"
 import { ChartManager } from "../chart/ChartManager"
-import { faExternalLinkAlt } from "@fortawesome/free-solid-svg-icons"
+import {
+    faExternalLinkAlt,
+    faTriangleExclamation,
+} from "@fortawesome/free-solid-svg-icons"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { FooterManager } from "../footer/FooterManager"
 import { HeaderManager } from "../header/HeaderManager"
@@ -93,6 +97,10 @@ export interface CaptionedChartManager
     // related question
     relatedQuestions?: RelatedQuestionsConfig[]
     showRelatedQuestion?: boolean
+
+    // deprecation notice
+    deprecationNotice?: string
+    showDeprecationNotice?: boolean
 }
 
 interface CaptionedChartProps {
@@ -101,6 +109,10 @@ interface CaptionedChartProps {
 
 // keep in sync with sass variables in CaptionedChart.scss
 export const CONTROLS_ROW_HEIGHT = 32
+
+// keep in sync with sass variables in CaptionedChart.scss
+const DEPRECATION_NOTICE_PADDING = 8
+const DEPRECATION_NOTICE_FONT_SIZE = 13
 
 abstract class AbstractCaptionedChart extends React.Component<CaptionedChartProps> {
     protected framePaddingHorizontal = GRAPHER_FRAME_PADDING_HORIZONTAL
@@ -178,6 +190,36 @@ export class CaptionedChart extends AbstractCaptionedChart {
         return this.manager.isMedium ? 24 : 28
     }
 
+    @computed private get showDeprecationNotice(): boolean {
+        return !!this.manager.showDeprecationNotice
+    }
+
+    @computed private get deprecationNoticeTextWrap():
+        | MarkdownTextWrap
+        | undefined {
+        if (!this.showDeprecationNotice) return undefined
+        return new MarkdownTextWrap({
+            text: this.manager.deprecationNotice!,
+            maxWidth: this.maxWidth - 2 * DEPRECATION_NOTICE_PADDING - 20,
+            fontSize: DEPRECATION_NOTICE_FONT_SIZE,
+            lineHeight: 1.25,
+            detailsOrderedByReference: this.manager.detailsOrderedByReference,
+        })
+    }
+
+    @computed private get deprecationNoticeHeight(): number {
+        if (!this.deprecationNoticeTextWrap) return 0
+        return (
+            this.deprecationNoticeTextWrap.height +
+            2 * DEPRECATION_NOTICE_PADDING
+        )
+    }
+
+    @computed private get deprecationNoticeHeightWithPadding(): number {
+        if (!this.showDeprecationNotice) return 0
+        return this.deprecationNoticeHeight + this.verticalPaddingSmall
+    }
+
     @computed private get showControlsRow(): boolean {
         if (this.manager.hideControlsRow) return false
         return ControlsRow.shouldShow(this.manager)
@@ -230,6 +272,26 @@ export class CaptionedChart extends AbstractCaptionedChart {
                     {relatedQuestions![0].text}
                 </a>
                 <FontAwesomeIcon icon={faExternalLinkAlt} />
+            </div>
+        )
+    }
+
+    private renderDeprecationNotice(): React.ReactElement {
+        return (
+            <div
+                className="DeprecationNotice"
+                style={{
+                    width: this.bounds.width,
+                    padding: `${DEPRECATION_NOTICE_PADDING}px ${this.framePaddingHorizontal}px`,
+                }}
+                data-track-note="chart_deprecation_notice"
+            >
+                <FontAwesomeIcon icon={faTriangleExclamation} />
+                <div style={this.deprecationNoticeTextWrap!.style}>
+                    <MarkdownTextWrapHtml
+                        textWrap={this.deprecationNoticeTextWrap!}
+                    />
+                </div>
             </div>
         )
     }
@@ -292,6 +354,7 @@ export class CaptionedChart extends AbstractCaptionedChart {
             this.bounds.height -
                 2 * this.framePaddingVertical -
                 this.headerHeightWithPadding -
+                this.deprecationNoticeHeightWithPadding -
                 this.controlsRowHeightWithPadding -
                 this.timelineHeightWithPadding -
                 this.footerHeightWithPadding -
@@ -312,14 +375,16 @@ export class CaptionedChart extends AbstractCaptionedChart {
         // A CaptionedChart looks like this (components in [brackets] are optional):
         //    #1 Header
         //            ---- vertical space
-        //    #2 [Controls]
+        //    #2 [Deprecation notice]
         //            ---- vertical space (small)
-        //    #3 Chart/Map/Table
+        //    #3 [Controls]
         //            ---- vertical space (small)
-        //    #4 [Timeline]
+        //    #4 Chart/Map/Table
+        //            ---- vertical space (small)
+        //    #5 [Timeline]
         //            ---- vertical space
-        //    #5 Footer
-        //    #6 [Related question]
+        //    #6 Footer
+        //    #7 [Related question]
         return (
             <div
                 className="CaptionedChart"
@@ -336,35 +401,41 @@ export class CaptionedChart extends AbstractCaptionedChart {
                     </>
                 )}
 
+                {/* #2 [Deprecation notice] */}
+                {this.showDeprecationNotice && this.renderDeprecationNotice()}
+                {this.showDeprecationNotice && (
+                    <VerticalSpace height={this.verticalPaddingSmall} />
+                )}
+
                 {this.manager.isReady ? (
                     <>
-                        {/* #2 [Controls] */}
+                        {/* #3 [Controls] */}
                         {this.showControlsRow && this.renderControlsRow()}
                         {this.showControlsRow && (
                             <VerticalSpace height={this.verticalPaddingSmall} />
                         )}
 
-                        {/* #3 Chart/Map/Table */}
+                        {/* #4 Chart/Map/Table */}
                         <ChartAreaContent
                             manager={this.manager}
                             bounds={this.boundsForChartArea}
                             padWidth={GRAPHER_FRAME_PADDING_HORIZONTAL}
                         />
 
-                        {/* #4 [Timeline] */}
+                        {/* #5 [Timeline] */}
                         {this.manager.hasTimeline && (
                             <VerticalSpace height={this.verticalPaddingSmall} />
                         )}
                         {this.manager.hasTimeline && this.renderTimeline()}
 
-                        {/* #5 Footer */}
+                        {/* #6 Footer */}
                         <VerticalSpace height={this.verticalPadding} />
                         <Footer
                             manager={this.manager}
                             maxWidth={this.maxWidth}
                         />
 
-                        {/* #6 [Related question] */}
+                        {/* #7 [Related question] */}
                         {this.showRelatedQuestion &&
                             this.renderRelatedQuestion()}
                     </>

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -100,6 +100,7 @@ export interface GrapherProgrammaticInterface extends GrapherInterface {
     hideShareButton?: boolean
     hideExploreTheDataButton?: boolean
     hideRelatedQuestion?: boolean
+    hideDeprecationNotice?: boolean
     enableMapSelection?: boolean
 
     enableKeyboardShortcuts?: boolean

--- a/packages/@ourworldindata/grapher/src/core/GrapherState.test.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.test.ts
@@ -102,6 +102,51 @@ describe("toObject", () => {
             chartTypes: ["LineChart", "SlopeChart"],
         })
     })
+
+    it("round-trips deprecationNotice", () => {
+        const grapher = new GrapherState({
+            deprecationNotice:
+                "**No longer updated.** See [successor](/grapher/foo).",
+        })
+        expect(grapher.toObject()).toEqual({
+            $schema: latestGrapherConfigSchema,
+            deprecationNotice:
+                "**No longer updated.** See [successor](/grapher/foo).",
+        })
+    })
+
+    it("an empty Grapher does not serialise deprecationNotice", () => {
+        expect(new GrapherState({}).toObject().deprecationNotice).toBe(
+            undefined
+        )
+    })
+})
+
+describe("showDeprecationNotice", () => {
+    it("is false when deprecationNotice is unset", () => {
+        expect(new GrapherState({}).showDeprecationNotice).toBe(false)
+    })
+
+    it("is false when deprecationNotice is blank", () => {
+        expect(
+            new GrapherState({ deprecationNotice: "   " }).showDeprecationNotice
+        ).toBe(false)
+    })
+
+    it("is true when deprecationNotice is set", () => {
+        expect(
+            new GrapherState({ deprecationNotice: "No longer updated." })
+                .showDeprecationNotice
+        ).toBe(true)
+    })
+
+    it("is false when hideDeprecationNotice is set", () => {
+        const grapher = new GrapherState({
+            deprecationNotice: "No longer updated.",
+        })
+        grapher.hideDeprecationNotice = true
+        expect(grapher.showDeprecationNotice).toBe(false)
+    })
 })
 
 describe("hideFullScreenButton", () => {

--- a/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
@@ -472,6 +472,9 @@ export class GrapherState
     /** Links to related questions */
     relatedQuestions: RelatedQuestionsConfig[] | undefined = undefined
 
+    /** Markdown notice shown as a banner when the chart is no longer maintained */
+    deprecationNotice: string | undefined = undefined
+
     //
     // Internal state not persisted in the config
     //
@@ -588,6 +591,7 @@ export class GrapherState
     hideExploreTheDataButton = true
     hideControlsRow = false
     hideRelatedQuestion = false
+    hideDeprecationNotice = false
     canHideExternalControlsInEmbed: boolean = false
     recommendedIframeEmbedHeight?: number
     hideExternalControlsInEmbedUrl: boolean =
@@ -702,6 +706,8 @@ export class GrapherState
             includedEntityNames: observable,
             comparisonLines: observable,
             relatedQuestions: observable,
+            deprecationNotice: observable.ref,
+            hideDeprecationNotice: observable,
             dataTableConfig: observable,
             highlightedTimesInLineChart: observable.ref,
             hideFacetControl: observable.ref,
@@ -3704,6 +3710,14 @@ export class GrapherState
             !!this.relatedQuestions &&
             !!this.hasRelatedQuestion &&
             !!this.isRelatedQuestionTargetDifferentFromCurrentPage
+        )
+    }
+
+    @computed get showDeprecationNotice(): boolean {
+        return (
+            !this.hideDeprecationNotice &&
+            !!this.deprecationNotice?.trim() &&
+            this.variant !== GrapherVariant.Thumbnail
         )
     }
 

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.010.yaml
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.010.yaml
@@ -61,6 +61,12 @@ properties:
   note:
     type: string
     description: Note displayed in the footer of the chart
+  deprecationNotice:
+    type: string
+    description: |
+      Markdown text displayed as a prominent banner on the chart when it is no
+      longer updated. Should explain why and link to a successor chart where
+      one exists.
   internalNotes:
     type: string
     description: Additional text used internally to differentiate charts with the same title

--- a/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
+++ b/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
@@ -630,6 +630,8 @@ export interface GrapherInterface extends SortConfig {
     subtitle?: string
     sourceDesc?: string
     note?: string
+    /** Markdown notice shown as a banner on the chart when it is no longer maintained. Supports links to a successor chart. */
+    deprecationNotice?: string
     hideAnnotationFieldsInTitle?: AnnotationFieldsInTitle
     minTime?: TimeBound | TimeBoundValueStr
     maxTime?: TimeBound | TimeBoundValueStr
@@ -780,6 +782,7 @@ export const grapherKeysToSerialize = [
     "subtitle",
     "sourceDesc",
     "note",
+    "deprecationNotice",
     "hideAnnotationFieldsInTitle",
     "minTime",
     "maxTime",


### PR DESCRIPTION
> _Written by Claude Sonnet 5 — @Marigold at the wheel._

## Summary

Adds an optional `deprecationNotice` field to the chart config, rendered as a banner on the chart when a chart is no longer maintained (e.g. because the underlying source changed methodology or was discontinued). The banner:

- shows on grapher pages, data pages, and iframe embeds (it's part of the chart frame, not a page wrapper), so it travels wherever the chart is cited or embedded
- supports markdown, so editors can link to a successor chart
- is picked up automatically by the archival baker on future archived versions, since configs are snapshotted verbatim

Editable in the chart editor under a new "Deprecation" section (next to "Related").

Addresses [owid/owid-grapher#6711](https://github.com/owid/owid-grapher/issues/6711) — the near-term driver is ~60 popular energy charts being frozen as the Statistical Review of World Energy switches from the substitution method to Total Energy Supply.

Not included in this PR (left as follow-ups):
- Redirecting a deleted chart's slug to its latest archived version
- Showing the notice in static SVG/PNG exports and thumbnails (interactive-only for now, confirmed both in code and by inspecting an actual downloaded PNG)

## How to review

A real deprecation notice is currently set on [global-energy-substitution](https://ourworldindata.org/grapher/global-energy-substitution) (one of the ~62 charts this feature exists for — see [owid/etl#6393](https://github.com/owid/etl/pull/6393) for the underlying methodology migration) on the `archiving-charts` staging server:
- **See it**: http://staging-site-archiving-charts/admin/charts/4432/preview
- **Edit it in the admin**: http://staging-site-archiving-charts/admin/charts/4432/edit (Text tab → "Deprecation" section)

## Test plan

- [x] `yarn test run --reporter dot GrapherState` — round-trip serialization and banner-visibility tests pass
- [x] `yarn testLintChanged` / `yarn testFormatChanged` clean
- [x] Set a notice on a real chart on staging (`staging-site-archiving-charts`) via the admin editor UI, and confirmed the banner renders correctly below the header, doesn't clip the chart area (`scrollHeight === clientHeight`), and wraps properly at a 375px mobile width; the markdown link resolves correctly.

Also uses `devTools/callAdminApi.ts`, split out into its own PR ([#6822](https://github.com/owid/owid-grapher/pull/6822)) since it's general-purpose tooling, not specific to this feature.

