### PR TITLE
🐛 (grapher) hide the slope chart's log notice when time labels are hidden

### DIFF
--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
@@ -1005,6 +1005,10 @@ export class SlopeChart
     private renderLogNotice(): React.ReactElement | null {
         if (!this.chartState.isLogScale) return null
 
+        // The notice is rendered in line with the time labels, so if those
+        // are hidden (e.g. for inner facets), hide the notice as well
+        if (this.xAxis.config.hideTickLabels) return null
+
         const fontSize = GRAPHER_FONT_SCALE_11 * this.fontSize
 
         const longText = "plotted on a logarithmic axis"


### PR DESCRIPTION
> _Written by Anthropic Claude Fable 5 — @sophiamersmann at the wheel._

When a slope chart is faceted, inner facets may hide their x-axis time labels (`FacetChart` passes `hideAxis`, which slope charts reinterpret as `hideTickLabels`). The "plotted on a logarithmic axis" notice is rendered in line with those labels, so it looked stranded on facets without time labels.

The notice now checks the same `hideTickLabels` flag as the time labels and disappears exactly when they do — including the shared-x-axis facet case, where only the bottom-row facets keep their labels (and now their notices).

🤖 Generated with [Claude Code](https://claude.com/claude-code)