### PR TITLE
✨🤖 (time-interval) always use the compact week format ("W3 2023")

### DIFF
--- a/packages/@ourworldindata/core-table/src/CoreTableColumns.test.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTableColumns.test.ts
@@ -75,21 +75,15 @@ describe(ColumnTypeNames.Week, () => {
     it("formats days-since-epoch as weeks", () => {
         // day 0 = EPOCH_DATE = 2020-01-21, a Tuesday in ISO week 4 of 2020,
         // which starts on Monday 2020-01-20
-        expect(col.formatValue(0)).toEqual("Jan 20–26, 2020")
-        expect(col.formatTimeShort(0)).toEqual("W4 2020")
+        expect(col.formatValue(0)).toEqual("W4 2020")
         expect(col.formatForCsv(0)).toEqual("2020-W04")
     })
 
-    it("formats weeks across month and year boundaries", () => {
-        // day 6 = 2020-01-27, a Monday; the week ends in February
-        expect(col.formatValue(6)).toEqual("Jan 27 – Feb 2, 2020")
-        // day -22 = Monday 2019-12-30, ISO week 1 of 2020: the range shows
-        // both years, the compact format the ISO week year
-        expect(col.formatValue(-22)).toEqual("Dec 30, 2019 – Jan 5, 2020")
-        expect(col.formatTimeShort(-22)).toEqual("W1 2020")
+    it("formats weeks across year boundaries with the ISO week year", () => {
+        // day -22 = Monday 2019-12-30, ISO week 1 of 2020
+        expect(col.formatValue(-22)).toEqual("W1 2020")
         // day -20 = 2020-01-01 falls into the same week starting in 2019
-        expect(col.formatValue(-20)).toEqual("Dec 30, 2019 – Jan 5, 2020")
-        expect(col.formatTimeShort(-20)).toEqual("W1 2020")
+        expect(col.formatValue(-20)).toEqual("W1 2020")
     })
 })
 

--- a/packages/@ourworldindata/core-table/src/CoreTableColumns.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTableColumns.ts
@@ -145,11 +145,6 @@ export abstract class AbstractCoreColumn<
         return this.originalTimeColumn.formatValue(time)
     }
 
-    // For space-constrained contexts like the timeline slider
-    formatTimeShort(time: number): string {
-        return this.originalTimeColumn.formatValueShort(time)
-    }
-
     @imemo get roundingMode(): OwidVariableRoundingMode {
         return (
             this.display?.roundingMode ?? OwidVariableRoundingMode.decimalPlaces
@@ -930,10 +925,6 @@ export abstract class TimeColumn<
         return this.formatValue(time)
     }
 
-    override formatTimeShort(time: number): string {
-        return this.formatValueShort(time)
-    }
-
     override parse(val: unknown): number | ErrorValue {
         return parseInt(String(val))
     }
@@ -971,19 +962,10 @@ const memoFormatMonth = _.memoize(
 const memoFormatMonthCsv = _.memoize(
     (value: number): string => formatDay(value, { format: "YYYY-MM" }) // "2023-01"
 )
-// The week as a Monday–Sunday date range. Snaps to the ISO-week Monday
-// so indicators that pick a different representative day for the same
-// week still show the same label
+// The ISO week number and week-year. Because the ISO week is the same for
+// every day of the week, indicators that pick a different representative
+// day for the same week still show the same label
 const memoFormatWeek = _.memoize((value: number): string => {
-    const monday = convertDaysSinceEpochToDate(value).startOf("isoWeek")
-    const sunday = monday.add(6, "days")
-    if (monday.year() !== sunday.year())
-        return `${monday.format("MMM D, YYYY")} – ${sunday.format("MMM D, YYYY")}` // "Dec 30, 2019 – Jan 5, 2020"
-    return monday.month() === sunday.month()
-        ? `${monday.format("MMM D")}–${sunday.format("D, YYYY")}` // "Jan 16–22, 2023"
-        : `${monday.format("MMM D")} – ${sunday.format("MMM D, YYYY")}` // "Jan 30 – Feb 5, 2023"
-})
-const memoFormatWeekShort = _.memoize((value: number): string => {
     const date = convertDaysSinceEpochToDate(value)
     return `W${date.isoWeek()} ${date.isoWeekYear()}` // "W3 2023"
 })
@@ -1071,11 +1053,7 @@ class WeekColumn<
     }
 
     override formatValue(value: number): string {
-        return memoFormatWeek(value) // "Jan 16–22, 2023"
-    }
-
-    override formatTimeShort(time: number): string {
-        return memoFormatWeekShort(time) // "W3 2023"
+        return memoFormatWeek(value) // "W3 2023"
     }
 
     override formatForCsv(value: number): string {

--- a/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
@@ -2715,9 +2715,7 @@ export class GrapherState
         const timeColumn = this.table.timeColumn
         if (timeColumn.isMissing) return undefined // Do not show year until data is loaded
 
-        // Use the compact time format in the title
-        const formatTime = (time: Time): string =>
-            timeColumn.formatTimeShort(time)
+        const formatTime = (time: Time): string => timeColumn.formatTime(time)
 
         // Add 'Time vs. Time' suffix for scatter plots with time override
         if (

--- a/packages/@ourworldindata/grapher/src/timeline/TimelineComponent.tsx
+++ b/packages/@ourworldindata/grapher/src/timeline/TimelineComponent.tsx
@@ -416,11 +416,9 @@ export class TimelineComponent extends React.Component<TimelineComponentProps> {
     }
 
     private formatTime(time: number): string {
-        const { timeColumn, isSemiNarrow } = this.manager
+        const { timeColumn } = this.manager
         if (!timeColumn) return time.toString()
-        return isSemiNarrow
-            ? timeColumn.formatTimeShort(time)
-            : timeColumn.formatTime(time)
+        return timeColumn.formatTime(time)
     }
 
     @action.bound private togglePlay(): void {

--- a/packages/@ourworldindata/grapher/src/timeline/TimelineController.ts
+++ b/packages/@ourworldindata/grapher/src/timeline/TimelineController.ts
@@ -23,7 +23,6 @@ export enum TimelineDragTarget {
 
 export interface TimelineManager {
     disablePlay?: boolean
-    isSemiNarrow?: boolean
     timeColumn?: TimeColumn
     isTimelineAnimationPlaying?: boolean
     isTimelineAnimationActive?: boolean


### PR DESCRIPTION
> _Written by Anthropic Claude Fable 5 — @sophiamersmann at the wheel._

Week columns had two formats: a long Monday–Sunday date range ("Jan 16–22, 2023") used in most places, and a compact ISO-week format ("W3 2023") for space-constrained contexts (chart title time suffix, semi-narrow timeline). For simplicity, switch to the compact format everywhere.

I want to bring back human-readable formatting, but for now let's keep it simple.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- GitButler Footer Boundary Top -->
---
This is **part 9 of 9 in a stack** made with GitButler:
- <kbd>&nbsp;9&nbsp;</kbd> #6810 👈 
- <kbd>&nbsp;8&nbsp;</kbd> #6752 
- <kbd>&nbsp;7&nbsp;</kbd> #6733 
- <kbd>&nbsp;6&nbsp;</kbd> #6723 
- <kbd>&nbsp;5&nbsp;</kbd> #6722 
- <kbd>&nbsp;4&nbsp;</kbd> #6721 
- <kbd>&nbsp;3&nbsp;</kbd> #6699 
- <kbd>&nbsp;2&nbsp;</kbd> #6696 
- <kbd>&nbsp;1&nbsp;</kbd> #6700 
<!-- GitButler Footer Boundary Bottom -->