### PR TITLE
✨ 🤖 (grapher) content-aware controls row layout

### DIFF
--- a/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.scss
+++ b/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.scss
@@ -17,7 +17,7 @@ $controlRowHeight: 32px; // keep in sync with CONTROLS_ROW_HEIGHT
     width: 100%;
     display: flex;
     justify-content: space-between;
-    gap: 16px;
+    gap: var(--controls-row-gap, 16px);
 
     .controls {
         width: 100%;

--- a/packages/@ourworldindata/grapher/src/chart/ChartUtils.tsx
+++ b/packages/@ourworldindata/grapher/src/chart/ChartUtils.tsx
@@ -377,8 +377,15 @@ export function sortByConfig<T>(
     return sortOrder === SortOrder.desc ? sortedRows.toReversed() : sortedRows
 }
 
-export function textWidth(text: string, fontSettings: FontSettings): number {
-    return Bounds.forText(text, fontSettings).width
+export function textWidth(
+    text: string,
+    fontSettings: Omit<FontSettings, "lineHeight">
+): number {
+    const { fontSize, letterSpacing = 0 } = fontSettings
+    return (
+        Bounds.forText(text, fontSettings).width +
+        text.length * letterSpacing * fontSize
+    )
 }
 
 export function roundFontSize(fontSize: number): number {

--- a/packages/@ourworldindata/grapher/src/controls/ContentSwitchers.scss
+++ b/packages/@ourworldindata/grapher/src/controls/ContentSwitchers.scss
@@ -46,16 +46,15 @@ $active-icon: $blue-50;
 
     .Tabs.ContentSwitchers .Tabs__Tab,
     .ContentSwitchers__OverflowMenuItem {
-        $icon-padding: 6px;
-
         .ContentSwitchers__TabContent {
             display: flex;
             height: 100%;
             align-items: center;
-            gap: $icon-padding;
+            gap: var(--tab-icon-gap, 6px);
         }
 
         svg {
+            width: var(--tab-icon-width, 13px);
             color: $gray-60;
         }
 
@@ -79,6 +78,12 @@ $active-icon: $blue-50;
 
     .Tabs.ContentSwitchers {
         box-shadow: none; // Moved to the container
+        padding: var(--tabs-frame-padding, 2px);
+
+        .Tabs__Tab {
+            font-weight: var(--tab-font-weight, 500);
+            letter-spacing: var(--label-letter-spacing, 0.01em);
+        }
     }
 
     // The overflow menu button is styled as a slim variant tab
@@ -91,7 +96,10 @@ $active-icon: $blue-50;
         @include slim-tab-item;
         @include slim-tab-separator;
 
-        padding: 0 8px;
+        padding: 0 var(--overflow-button-padding, 8px);
+        font-weight: var(--tab-font-weight, 500);
+        letter-spacing: var(--label-letter-spacing, 0.01em);
+
         margin: $visual-gap;
         margin-left: -$visual-gap;
 
@@ -112,5 +120,16 @@ $active-icon: $blue-50;
     &:has(.Tabs__Tab:last-child[data-selected])
         > .ContentSwitchers__OverflowMenuButton::before {
         display: none;
+    }
+}
+
+.Tabs.ContentSwitchers.ContentSwitchers--icons-only {
+    .Tabs__Tab .label {
+        display: none;
+    }
+
+    // Center the icon now that it's the only content in the tab
+    .Tabs__Tab .ContentSwitchers__TabContent {
+        justify-content: center;
     }
 }

--- a/packages/@ourworldindata/grapher/src/controls/ContentSwitchers.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/ContentSwitchers.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { useCallback } from "react"
+import { useCallback, type CSSProperties } from "react"
 import { action, computed } from "mobx"
 import cx from "clsx"
 import { observer } from "mobx-react"
@@ -15,6 +15,15 @@ import {
     Popover,
 } from "react-aria-components"
 import { GrapherTabIcon } from "@ourworldindata/components"
+import {
+    OVERFLOW_BUTTON_PADDING,
+    TAB_CONTENT_CSS_VARIABLES,
+    TAB_FONT,
+    TAB_ICON_GAP,
+    TAB_ICON_WIDTH,
+    TABS_FRAME_PADDING,
+} from "./controlsRow/ControlsRowConstants"
+import { textWidth } from "../chart/ChartUtils"
 
 export interface ContentSwitchersManager {
     availableTabs?: GrapherTabName[]
@@ -27,16 +36,44 @@ export interface ContentSwitchersManager {
 const MAX_VISIBLE_TABS = 4
 const MAX_VISIBLE_TABS_BEFORE_OVERFLOW = 3
 
-function shouldShowContentSwitchers(manager: ContentSwitchersManager): boolean {
-    return (manager.availableTabs ?? []).length > 1
+interface ContentSwitchersProps {
+    manager: ContentSwitchersManager
+    showTabLabels?: boolean
+    tabPadding?: number
 }
 
 @observer
-export class ContentSwitchers extends React.Component<{
-    manager: ContentSwitchersManager
-}> {
+export class ContentSwitchers extends React.Component<ContentSwitchersProps> {
     static shouldShow(manager: ContentSwitchersManager): boolean {
-        return shouldShowContentSwitchers(manager)
+        const availableTabs = manager.availableTabs ?? []
+        return availableTabs.length > 1
+    }
+
+    static estimateWidth(
+        manager: ContentSwitchersManager,
+        layout: Required<Omit<ContentSwitchersProps, "manager">>
+    ): number {
+        if (!ContentSwitchers.shouldShow(manager)) return 0
+
+        const availableTabs = manager.availableTabs ?? []
+        const activeTab = manager.activeTab ?? availableTabs[0]
+        const visibleTabs = getVisibleTabs(availableTabs, activeTab)
+        const hiddenTabCount = availableTabs.length - visibleTabs.length
+
+        let width = 2 * TABS_FRAME_PADDING
+        for (const tab of visibleTabs) {
+            width += 2 * layout.tabPadding + TAB_ICON_WIDTH
+            if (layout.showTabLabels)
+                width +=
+                    TAB_ICON_GAP +
+                    textWidth(makeLabelForGrapherTab(tab), TAB_FONT)
+        }
+        if (hiddenTabCount > 0)
+            width +=
+                2 * OVERFLOW_BUTTON_PADDING +
+                textWidth(`+${hiddenTabCount}`, TAB_FONT)
+
+        return width
     }
 
     @computed private get manager(): ContentSwitchersManager {
@@ -48,29 +85,11 @@ export class ContentSwitchers extends React.Component<{
     }
 
     @computed private get shouldShow(): boolean {
-        return shouldShowContentSwitchers(this.manager)
+        return ContentSwitchers.shouldShow(this.manager)
     }
 
     @computed private get visibleTabs(): GrapherTabName[] {
-        const { activeTab, availableTabs } = this
-
-        // If there are four or fewer tabs, show all of them
-        if (availableTabs.length <= MAX_VISIBLE_TABS) {
-            return availableTabs
-        }
-
-        // Otherwise, only show the first 3 tabs
-        const visibleTabs = availableTabs.slice(
-            0,
-            MAX_VISIBLE_TABS_BEFORE_OVERFLOW
-        )
-
-        // If the active tab is not visible, replace the last visible tab with it
-        if (!visibleTabs.includes(activeTab)) {
-            visibleTabs[visibleTabs.length - 1] = activeTab
-        }
-
-        return visibleTabs
+        return getVisibleTabs(this.availableTabs, this.activeTab)
     }
 
     @computed private get hiddenTabs(): GrapherTabName[] {
@@ -105,11 +124,18 @@ export class ContentSwitchers extends React.Component<{
     override render(): React.ReactElement | null {
         if (!this.shouldShow) return null
 
+        const { showTabLabels = true, tabPadding = 16 } = this.props
+
         return (
             <div className="ContentSwitchers__Container">
                 <Tabs
                     variant="slim"
-                    className="ContentSwitchers"
+                    className={cx("ContentSwitchers", {
+                        "ContentSwitchers--icons-only": !showTabLabels,
+                    })}
+                    style={
+                        { "--tab-padding": `${tabPadding}px` } as CSSProperties
+                    }
                     items={this.tabItems}
                     selectedKey={this.activeTab}
                     onChange={this.setTab}
@@ -150,6 +176,7 @@ function OverflowMenu({
             <Popover
                 className="ContentSwitchers__OverflowMenu"
                 placement="bottom"
+                style={TAB_CONTENT_CSS_VARIABLES}
             >
                 <Menu
                     className="ContentSwitchers__OverflowMenuList"
@@ -177,4 +204,24 @@ function TabContent({ tab }: { tab: GrapherTabName }): React.ReactElement {
             <span className="label">{makeLabelForGrapherTab(tab)}</span>
         </span>
     )
+}
+
+function getVisibleTabs(
+    availableTabs: GrapherTabName[],
+    activeTab: GrapherTabName
+): GrapherTabName[] {
+    // If there are four or fewer tabs, show all of them
+    if (availableTabs.length <= MAX_VISIBLE_TABS) {
+        return availableTabs
+    }
+
+    // Otherwise, only show the first 3 tabs
+    const visibleTabs = availableTabs.slice(0, MAX_VISIBLE_TABS_BEFORE_OVERFLOW)
+
+    // If the active tab is not visible, replace the last visible tab with it
+    if (!visibleTabs.includes(activeTab)) {
+        visibleTabs[visibleTabs.length - 1] = activeTab
+    }
+
+    return visibleTabs
 }

--- a/packages/@ourworldindata/grapher/src/controls/Controls.scss
+++ b/packages/@ourworldindata/grapher/src/controls/Controls.scss
@@ -9,8 +9,6 @@ $selected-fill: #c7ced7;
 
 $active-switch: $blue-50;
 
-$medium: 400;
-$bold: 700;
 $lato: $sans-serif-font-stack;
 
 $indent: 15px;
@@ -20,17 +18,20 @@ $control-row-height: 32px;
 nav.controlsRow .controls {
     display: flex;
     justify-content: flex-end;
-    gap: 8px;
+    gap: var(--controls-gap, 8px);
 
     button.menu-toggle {
-        font: $medium 13px/16px $lato;
-        letter-spacing: 0.01em;
+        font-family: $lato;
+        font-size: var(--button-font-size, 13px);
+        font-weight: var(--button-font-weight, 400);
+        line-height: 16px;
+        letter-spacing: var(--label-letter-spacing, 0.01em);
         display: flex;
         align-items: center;
-        border: 1px solid $light-stroke;
+        border: var(--button-border-width, 1px) solid $light-stroke;
         border-radius: 4px;
         height: $control-row-height;
-        padding: 7px;
+        padding: var(--button-padding, 7px);
         color: $dark-text;
         white-space: nowrap;
 
@@ -43,109 +44,27 @@ nav.controlsRow .controls {
         &:active {
             color: $active-text;
             background: $active-fill;
-            border: 1px solid $active-fill;
+            border: var(--button-border-width, 1px) solid $active-fill;
         }
 
         svg {
+            width: var(--button-icon-width, 13px);
             height: 12px;
-            margin-right: 5px;
+            margin-right: var(--button-icon-margin, 5px);
             vertical-align: bottom;
         }
 
         label:hover {
             cursor: pointer;
         }
-    }
-}
 
-//
-// Make buttons narrower by omitting their text labels as the viewport gets narrower
-// use the .GrapherComponentSemiNarrow if necessary but allow container queries to
-// collapse labels in two steps on browsers that support them
-//
-// TODO: the measurement and label-hiding logic will have to move to js anyway once the
-//       number of chart buttons becomes variable and the settings button can be replaced
-//       by a single control widget ‘promoted’ from within the drawer
-//
-@at-root {
-    // collapse both the settings and entity selector labels down at the semi-narrow breakpoint
-    .GrapherComponentSemiNarrow {
-        nav.controlsRow .settings-menu button.menu-toggle {
+        &.icon-only {
             min-height: $control-row-height;
+
             svg {
-                margin: 0 2px;
-            }
-            .label {
-                display: none;
+                margin: 0 var(--icon-only-button-icon-margin, 2px);
             }
         }
-        nav.controlsRow .entity-selection-menu button.menu-toggle {
-            label span {
-                display: none;
-            }
-        }
-    }
-}
-
-@container grapher (max-width:575px) {
-    // collapse the Settings toggle down to just an icon on small screens
-    nav.controlsRow .settings-menu button.menu-toggle {
-        min-height: $control-row-height;
-        svg {
-            margin: 0 2px;
-        }
-        .label {
-            display: none;
-        }
-    }
-
-    // undo the .GrapherComponentSemiNarrow hiding until next container query
-    nav.controlsRow .entity-selection-menu button.menu-toggle {
-        label span {
-            display: inline;
-        }
-    }
-}
-
-@container grapher (max-width:675px) {
-    // hide the entity name in the Edit/Select/Switch button
-    nav.controlsRow .chart-controls .entity-selection-menu button.menu-toggle {
-        label span {
-            display: none;
-        }
-    }
-}
-
-@container grapher (max-width:725px) {
-    // hide the entity name in the Edit/Select/Switch button
-    nav.controlsRow .map-controls .entity-selection-menu button.menu-toggle {
-        label span {
-            display: none;
-        }
-    }
-}
-
-@container grapher (max-width:500px) {
-    // hide labels on smaller screens
-    .ContentSwitchers .Tabs__Tab .label {
-        display: none;
-    }
-
-    // center the icon now that it's the only content in the tab
-    .ContentSwitchers .Tabs__Tab .ContentSwitchers__TabContent {
-        justify-content: center;
-    }
-}
-
-// reduce the horizontal padding of a content switcher tab based on grapher's size
-@container grapher (max-width:725px) {
-    .ContentSwitchers .Tabs__Tab {
-        --tab-padding: 12px;
-    }
-}
-@container grapher (max-width:335px) {
-    .ContentSwitchers .Tabs__Tab {
-        --tab-padding: 8px;
     }
 }
 

--- a/packages/@ourworldindata/grapher/src/controls/DataTableFilterDropdown.scss
+++ b/packages/@ourworldindata/grapher/src/controls/DataTableFilterDropdown.scss
@@ -1,5 +1,5 @@
 .data-table-filter-dropdown {
-    width: 194px;
+    width: var(--data-table-filter-dropdown-width, 194px);
 }
 
 .data-table-filter-dropdown-menu {

--- a/packages/@ourworldindata/grapher/src/controls/DataTableFilterDropdown.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/DataTableFilterDropdown.tsx
@@ -8,6 +8,7 @@ import { OwidTable } from "@ourworldindata/core-table"
 import { SelectionArray } from "../selection/SelectionArray"
 import { makeSelectionArray } from "../chart/ChartUtils"
 import { RegionGroup, regionGroupLabels } from "../core/RegionGroups"
+import { DATA_TABLE_FILTER_DROPDOWN_WIDTH } from "./controlsRow/ControlsRowConstants"
 
 export interface DataTableFilterDropdownManager {
     dataTableConfig: DataTableConfig
@@ -39,6 +40,12 @@ export class DataTableFilterDropdown extends React.Component<{
     static shouldShow(manager: DataTableFilterDropdownManager): boolean {
         const menu = new DataTableFilterDropdown({ manager })
         return menu.shouldShow
+    }
+
+    static estimateWidth(manager: DataTableFilterDropdownManager): number {
+        return DataTableFilterDropdown.shouldShow(manager)
+            ? DATA_TABLE_FILTER_DROPDOWN_WIDTH
+            : 0
     }
 
     @computed private get manager(): DataTableFilterDropdownManager {

--- a/packages/@ourworldindata/grapher/src/controls/DataTableSearchField.scss
+++ b/packages/@ourworldindata/grapher/src/controls/DataTableSearchField.scss
@@ -1,3 +1,3 @@
 .data-table-search-field {
-    flex: 0 1 208px;
+    flex: 0 1 var(--data-table-search-field-width, 208px);
 }

--- a/packages/@ourworldindata/grapher/src/controls/DataTableSearchField.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/DataTableSearchField.tsx
@@ -7,6 +7,7 @@ import { SearchField } from "./SearchField"
 import { DEFAULT_GRAPHER_ENTITY_TYPE } from "../core/GrapherConstants"
 import { isAnyRegionDataProviderKey } from "../core/RegionGroups"
 import { match } from "ts-pattern"
+import { DATA_TABLE_SEARCH_FIELD_WIDTH } from "./controlsRow/ControlsRowConstants"
 
 export interface DataTableSearchFieldManager {
     dataTableConfig: DataTableConfig
@@ -24,8 +25,13 @@ export class DataTableSearchField extends React.Component<{
     }
 
     static shouldShow(manager: DataTableSearchFieldManager): boolean {
-        const menu = new DataTableSearchField({ manager })
-        return menu.shouldShow
+        return !!manager.isOnTableTab
+    }
+
+    static estimateWidth(manager: DataTableSearchFieldManager): number {
+        return DataTableSearchField.shouldShow(manager)
+            ? DATA_TABLE_SEARCH_FIELD_WIDTH
+            : 0
     }
 
     @computed private get manager(): DataTableSearchFieldManager {
@@ -37,7 +43,7 @@ export class DataTableSearchField extends React.Component<{
     }
 
     @computed private get shouldShow(): boolean {
-        return !!this.manager.isOnTableTab
+        return DataTableSearchField.shouldShow(this.manager)
     }
 
     @computed private get entityType(): string {

--- a/packages/@ourworldindata/grapher/src/controls/EntitySelectionToggle.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/EntitySelectionToggle.tsx
@@ -5,6 +5,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faEye, faRightLeft, faPen } from "@fortawesome/free-solid-svg-icons"
 import classnames from "clsx"
 import { GrapherWindowType } from "@ourworldindata/types"
+import { measureButtonWidth } from "./controlsRow/ControlsRowConstants"
 
 export interface EntitySelectionManager {
     canHighlightEntities?: boolean
@@ -26,28 +27,26 @@ interface EntitySelectionLabel {
     entity: string
 }
 
-@observer
-export class EntitySelectionToggle extends React.Component<{
+interface EntitySelectionToggleProps {
     manager: EntitySelectionManager
-}> {
-    constructor(props: { manager: EntitySelectionManager }) {
+    showEntityLabel?: boolean
+}
+
+@observer
+export class EntitySelectionToggle extends React.Component<EntitySelectionToggleProps> {
+    constructor(props: EntitySelectionToggleProps) {
         super(props)
         makeObservable(this)
     }
 
     static shouldShow(manager: EntitySelectionManager): boolean {
-        const toggle = new EntitySelectionToggle({ manager })
-        return toggle.showToggle
-    }
-
-    @computed get showToggle(): boolean {
         const {
             isOnChartTab,
             isOnMapTab,
             hideEntityControls,
             shouldShowEntitySelectorAs,
             canChangeAddOrHighlightEntities,
-        } = this.props.manager
+        } = manager
 
         if (hideEntityControls) return false
 
@@ -62,56 +61,39 @@ export class EntitySelectionToggle extends React.Component<{
             isOnChartTab &&
             canChangeAddOrHighlightEntities &&
             (shouldShowModal || shouldShowDrawer) &&
-            this.label
+            getEntitySelectionLabel(manager)
         )
     }
 
+    static estimateWidth(
+        manager: EntitySelectionManager,
+        {
+            showEntityLabel,
+        }: Required<Omit<EntitySelectionToggleProps, "manager">>
+    ): number {
+        if (!EntitySelectionToggle.shouldShow(manager)) return 0
+        const label = getEntitySelectionLabel(manager)
+        if (!label) return 0
+        const text = showEntityLabel
+            ? `${label.action} ${label.entity}`
+            : label.action
+        return measureButtonWidth(text)
+    }
+
+    @computed private get shouldShow(): boolean {
+        return EntitySelectionToggle.shouldShow(this.props.manager)
+    }
+
     @computed get label(): EntitySelectionLabel | null {
-        const {
-            entityType = "",
-            entityTypePlural = "",
-            canHighlightEntities,
-            canChangeEntity,
-            canAddEntities,
-            isOnMapTab,
-        } = this.props.manager
-
-        if (isOnMapTab)
-            return {
-                action: "Select",
-                entity: "countries",
-                icon: <FontAwesomeIcon icon={faPen} />,
-            }
-
-        if (canHighlightEntities)
-            return {
-                action: "Select",
-                entity: entityTypePlural,
-                icon: <FontAwesomeIcon icon={faEye} />,
-            }
-
-        if (canChangeEntity)
-            return {
-                action: "Change",
-                entity: entityType,
-                icon: <FontAwesomeIcon icon={faRightLeft} />,
-            }
-
-        if (canAddEntities)
-            return {
-                action: "Edit",
-                entity: entityTypePlural,
-                icon: <FontAwesomeIcon icon={faPen} />,
-            }
-
-        return null
+        return getEntitySelectionLabel(this.props.manager)
     }
 
     override render(): React.ReactElement | null {
-        const { showToggle, label } = this
+        const { shouldShow, label } = this
+        const { showEntityLabel = true } = this.props
         const { isEntitySelectorModalOrDrawerOpen: active } = this.props.manager
 
-        return showToggle && label ? (
+        return shouldShow && label ? (
             <div className="entity-selection-menu">
                 <button
                     className={classnames("menu-toggle", { active })}
@@ -126,10 +108,59 @@ export class EntitySelectionToggle extends React.Component<{
                 >
                     {label.icon}
                     <label className="label">
-                        {label.action} <span>{label.entity}</span>
+                        {showEntityLabel ? (
+                            <>
+                                {label.action} <span>{label.entity}</span>
+                            </>
+                        ) : (
+                            label.action
+                        )}
                     </label>
                 </button>
             </div>
         ) : null
     }
+}
+
+function getEntitySelectionLabel(
+    manager: EntitySelectionManager
+): EntitySelectionLabel | null {
+    const {
+        entityType = "",
+        entityTypePlural = "",
+        canHighlightEntities,
+        canChangeEntity,
+        canAddEntities,
+        isOnMapTab,
+    } = manager
+
+    if (isOnMapTab)
+        return {
+            action: "Select",
+            entity: "countries",
+            icon: <FontAwesomeIcon icon={faPen} />,
+        }
+
+    if (canHighlightEntities)
+        return {
+            action: "Select",
+            entity: entityTypePlural,
+            icon: <FontAwesomeIcon icon={faEye} />,
+        }
+
+    if (canChangeEntity)
+        return {
+            action: "Change",
+            entity: entityType,
+            icon: <FontAwesomeIcon icon={faRightLeft} />,
+        }
+
+    if (canAddEntities)
+        return {
+            action: "Edit",
+            entity: entityTypePlural,
+            icon: <FontAwesomeIcon icon={faPen} />,
+        }
+
+    return null
 }

--- a/packages/@ourworldindata/grapher/src/controls/MapRegionDropdown.scss
+++ b/packages/@ourworldindata/grapher/src/controls/MapRegionDropdown.scss
@@ -1,3 +1,3 @@
 .map-region-dropdown {
-    flex: 0 1 155px;
+    flex: 0 1 var(--map-region-dropdown-width, 155px);
 }

--- a/packages/@ourworldindata/grapher/src/controls/MapRegionDropdown.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/MapRegionDropdown.tsx
@@ -6,6 +6,7 @@ import { MapRegionName } from "@ourworldindata/types"
 import { Dropdown } from "./Dropdown"
 import { MAP_REGION_LABELS } from "../mapCharts/MapChartConstants"
 import { GlobeController } from "../mapCharts/GlobeController"
+import { MAP_REGION_DROPDOWN_WIDTH } from "./controlsRow/ControlsRowConstants"
 
 export interface MapRegionDropdownManager {
     mapConfig?: MapConfig
@@ -30,8 +31,22 @@ export class MapRegionDropdown extends React.Component<{
     }
 
     static shouldShow(manager: MapRegionDropdownManager): boolean {
-        const menu = new MapRegionDropdown({ manager })
-        return menu.showMenu
+        const { isOnMapTab, isFaceted } = manager
+        const mapConfig = manager.mapConfig ?? new MapConfig()
+
+        return !!(
+            isOnMapTab &&
+            // Hide the dropdown when the globe is active
+            !mapConfig.globe.isActive &&
+            // Hide the dropdown when the map is not faceted unless a 2d continent is active
+            !(mapConfig.region === MapRegionName.World && !isFaceted)
+        )
+    }
+
+    static estimateWidth(manager: MapRegionDropdownManager): number {
+        return MapRegionDropdown.shouldShow(manager)
+            ? MAP_REGION_DROPDOWN_WIDTH
+            : 0
     }
 
     @computed private get manager(): MapRegionDropdownManager {
@@ -42,16 +57,8 @@ export class MapRegionDropdown extends React.Component<{
         return this.manager.mapConfig ?? new MapConfig()
     }
 
-    @computed private get showMenu(): boolean {
-        const { isOnMapTab, isFaceted, mapConfig } = this.manager
-
-        return !!(
-            isOnMapTab &&
-            // Hide the dropdown when the globe is active
-            !mapConfig?.globe.isActive &&
-            // Hide the dropdown when the map is not faceted unless a 2d continent is active
-            !(this.mapConfig.region === MapRegionName.World && !isFaceted)
-        )
+    @computed private get shouldShow(): boolean {
+        return MapRegionDropdown.shouldShow(this.manager)
     }
 
     @action.bound onChange(selected: MapRegionDropdownOption | null): void {
@@ -89,7 +96,7 @@ export class MapRegionDropdown extends React.Component<{
     }
 
     override render(): React.ReactElement | null {
-        if (!this.showMenu) return null
+        if (!this.shouldShow) return null
 
         return (
             <Dropdown

--- a/packages/@ourworldindata/grapher/src/controls/MapResetButton.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/MapResetButton.tsx
@@ -11,6 +11,7 @@ import { GlobeController } from "../mapCharts/GlobeController"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faRotateLeft } from "@fortawesome/free-solid-svg-icons"
 import { match } from "ts-pattern"
+import { measureButtonWidth } from "./controlsRow/ControlsRowConstants"
 
 interface MapResetButtonProps {
     manager: MapResetButtonManager
@@ -28,10 +29,7 @@ export interface MapResetButtonManager {
 }
 
 @observer
-export class MapResetButton extends React.Component<{
-    manager: MapResetButtonManager
-    action: "resetView" | "resetZoom"
-}> {
+export class MapResetButton extends React.Component<MapResetButtonProps> {
     constructor(props: MapResetButtonProps) {
         super(props)
         makeObservable(this)
@@ -39,18 +37,13 @@ export class MapResetButton extends React.Component<{
 
     static shouldShow(
         manager: MapResetButtonManager,
-        action: "resetView" | "resetZoom"
+        action: MapResetButtonProps["action"]
     ): boolean {
-        const menu = new MapResetButton({ manager, action })
-        return menu.showMenu
-    }
-
-    @computed private get showMenu(): boolean {
-        const { mapConfig } = this
-        const { isOnMapTab, isFaceted, shouldShowEntitySelectorAs } =
-            this.props.manager
+        const { isOnMapTab, isFaceted, shouldShowEntitySelectorAs } = manager
 
         if (!isOnMapTab) return false
+
+        const mapConfig = manager.mapConfig ?? new MapConfig()
 
         const shouldShowPanel =
             shouldShowEntitySelectorAs === GrapherWindowType.panel
@@ -61,10 +54,22 @@ export class MapResetButton extends React.Component<{
         const shouldShowResetZoomButton =
             mapConfig.globe.isActive && !shouldShowResetViewButton
 
-        return match(this.props.action)
+        return match(action)
             .with("resetView", () => shouldShowResetViewButton)
             .with("resetZoom", () => shouldShowResetZoomButton)
             .exhaustive()
+    }
+
+    static estimateWidth(
+        manager: MapResetButtonManager,
+        action: MapResetButtonProps["action"]
+    ): number {
+        if (!MapResetButton.shouldShow(manager, action)) return 0
+        return measureButtonWidth(makeResetButtonLabel(action))
+    }
+
+    @computed private get shouldShow(): boolean {
+        return MapResetButton.shouldShow(this.props.manager, this.props.action)
     }
 
     @computed private get manager(): MapResetButtonManager {
@@ -76,10 +81,7 @@ export class MapResetButton extends React.Component<{
     }
 
     @computed private get label(): string {
-        return match(this.props.action)
-            .with("resetView", () => "Reset view")
-            .with("resetZoom", () => "Reset zoom")
-            .exhaustive()
+        return makeResetButtonLabel(this.props.action)
     }
 
     @computed private get trackNote(): string {
@@ -100,7 +102,7 @@ export class MapResetButton extends React.Component<{
     }
 
     override render(): React.ReactElement | null {
-        return this.showMenu ? (
+        return this.shouldShow ? (
             <button
                 type="button"
                 data-track-note={this.trackNote}
@@ -112,4 +114,11 @@ export class MapResetButton extends React.Component<{
             </button>
         ) : null
     }
+}
+
+function makeResetButtonLabel(action: MapResetButtonProps["action"]): string {
+    return match(action)
+        .with("resetView", () => "Reset view")
+        .with("resetZoom", () => "Reset zoom")
+        .exhaustive()
 }

--- a/packages/@ourworldindata/grapher/src/controls/MapZoomDropdown.scss
+++ b/packages/@ourworldindata/grapher/src/controls/MapZoomDropdown.scss
@@ -1,5 +1,5 @@
 .map-zoom-dropdown {
-    flex: 0 1 202px;
+    flex: 0 1 var(--map-zoom-dropdown-width, 202px);
 }
 
 .map-zoom-dropdown-local-icon {

--- a/packages/@ourworldindata/grapher/src/controls/MapZoomDropdown.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/MapZoomDropdown.tsx
@@ -27,6 +27,7 @@ import {
 import { MAP_REGION_LABELS } from "../mapCharts/MapChartConstants"
 import { match } from "ts-pattern"
 import * as R from "remeda"
+import { MAP_ZOOM_DROPDOWN_WIDTH } from "./controlsRow/ControlsRowConstants"
 
 export interface MapZoomDropdownManager {
     mapConfig?: MapConfig
@@ -69,18 +70,20 @@ export class MapZoomDropdown extends React.Component<{
     }
 
     static shouldShow(manager: MapZoomDropdownManager): boolean {
-        const menu = new MapZoomDropdown({ manager })
-        return menu.showMenu
-    }
-
-    @computed private get showMenu(): boolean {
-        const { isMapSelectionEnabled, isOnMapTab, mapConfig } =
-            this.props.manager
+        const { isMapSelectionEnabled, isOnMapTab, mapConfig } = manager
         return !!(
             isOnMapTab &&
             !isMapSelectionEnabled &&
             !mapConfig?.globe.isActive
         )
+    }
+
+    static estimateWidth(manager: MapZoomDropdownManager): number {
+        return MapZoomDropdown.shouldShow(manager) ? MAP_ZOOM_DROPDOWN_WIDTH : 0
+    }
+
+    @computed private get shouldShow(): boolean {
+        return MapZoomDropdown.shouldShow(this.props.manager)
     }
 
     @computed private get manager(): MapZoomDropdownManager {
@@ -237,7 +240,7 @@ export class MapZoomDropdown extends React.Component<{
     }
 
     override render(): React.ReactElement | null {
-        return this.showMenu ? (
+        return this.shouldShow ? (
             <div className="map-zoom-dropdown">
                 <Dropdown
                     options={

--- a/packages/@ourworldindata/grapher/src/controls/MapZoomToSelectionButton.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/MapZoomToSelectionButton.tsx
@@ -4,6 +4,12 @@ import { observer } from "mobx-react"
 import { MapConfig } from "../mapCharts/MapConfig"
 import { GlobeController } from "../mapCharts/GlobeController"
 import { MapRegionName } from "@ourworldindata/types"
+import {
+    measureButtonWidth,
+    ZOOM_TO_SELECTION_ICON_WIDTH,
+} from "./controlsRow/ControlsRowConstants"
+
+const ZOOM_TO_SELECTION_LABEL = "Zoom to selection"
 
 export interface MapZoomToSelectionButtonManager {
     mapConfig?: MapConfig
@@ -25,21 +31,28 @@ export class MapZoomToSelectionButton extends React.Component<MapZoomToSelection
     }
 
     static shouldShow(manager: MapZoomToSelectionButtonManager): boolean {
-        const menu = new MapZoomToSelectionButton({ manager })
-        return menu.showMenu
-    }
-
-    @computed private get showMenu(): boolean {
-        const { isOnMapTab, mapConfig, isMapSelectionEnabled } =
-            this.props.manager
+        const { isOnMapTab, mapConfig, isFaceted, isMapSelectionEnabled } =
+            manager
         return !!(
             isOnMapTab &&
             mapConfig?.selection.hasSelection &&
             mapConfig?.region === MapRegionName.World &&
             !mapConfig?.globe.isActive &&
-            !this.manager.isFaceted &&
+            !isFaceted &&
             isMapSelectionEnabled
         )
+    }
+
+    static estimateWidth(manager: MapZoomToSelectionButtonManager): number {
+        if (!MapZoomToSelectionButton.shouldShow(manager)) return 0
+        return measureButtonWidth(
+            ZOOM_TO_SELECTION_LABEL,
+            ZOOM_TO_SELECTION_ICON_WIDTH
+        )
+    }
+
+    @computed private get shouldShow(): boolean {
+        return MapZoomToSelectionButton.shouldShow(this.props.manager)
     }
 
     @computed private get manager(): MapZoomToSelectionButtonManager {
@@ -53,15 +66,15 @@ export class MapZoomToSelectionButton extends React.Component<MapZoomToSelection
     }
 
     override render(): React.ReactElement | null {
-        return this.showMenu ? (
+        return this.shouldShow ? (
             <button
                 onClick={this.onClick}
                 type="button"
                 data-track-note="map_zoom_to_selection"
                 className="menu-toggle"
             >
-                <GlobeIcon size={16} />
-                <span className="label">Zoom to selection</span>
+                <GlobeIcon size={ZOOM_TO_SELECTION_ICON_WIDTH} />
+                <span className="label">{ZOOM_TO_SELECTION_LABEL}</span>
             </button>
         ) : null
     }
@@ -70,8 +83,8 @@ export class MapZoomToSelectionButton extends React.Component<MapZoomToSelection
 function GlobeIcon({ size }: { size: number }): React.ReactElement {
     return (
         <svg
-            width="16"
-            height="16"
+            width={size}
+            height={size}
             viewBox="0 0 16 16"
             fill="none"
             style={{ width: size, height: size }}

--- a/packages/@ourworldindata/grapher/src/controls/SettingsMenu.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/SettingsMenu.tsx
@@ -40,6 +40,9 @@ import {
 } from "./settings/NoDataAreaToggle"
 import { GRAPHER_SETTINGS_CLASS } from "../core/GrapherConstants"
 import { LONG_CHART_TYPE_LABEL } from "../chart/ChartTabs"
+import { measureButtonWidth } from "./controlsRow/ControlsRowConstants"
+
+const SETTINGS_LABEL = "Settings"
 
 const {
     LineChart,
@@ -87,6 +90,7 @@ interface SettingsMenuProps {
     manager: SettingsMenuManager
     popoverMaxWidth?: number
     popoverMaxHeight?: number
+    showLabel?: boolean
 }
 
 @observer
@@ -102,6 +106,14 @@ export class SettingsMenu extends React.Component<SettingsMenuProps> {
     static shouldShow(manager: SettingsMenuManager): boolean {
         const test = new SettingsMenu({ manager })
         return test.showSettingsMenuToggle
+    }
+
+    static estimateWidth(
+        manager: SettingsMenuManager,
+        { showLabel }: Required<Pick<SettingsMenuProps, "showLabel">>
+    ): number {
+        if (!SettingsMenu.shouldShow(manager)) return 0
+        return measureButtonWidth(showLabel ? SETTINGS_LABEL : undefined)
     }
 
     @computed get chartType(): GrapherChartType {
@@ -316,6 +328,7 @@ export class SettingsMenu extends React.Component<SettingsMenuProps> {
 
     private renderSettingsButtonAndPopup(): React.ReactElement {
         const { active } = this
+        const { showLabel = true } = this.props
 
         return (
             <div className="settings-menu">
@@ -324,12 +337,17 @@ export class SettingsMenu extends React.Component<SettingsMenuProps> {
                     onOpenChange={this.toggleVisibility}
                 >
                     <Button
-                        className={classnames("menu-toggle", { active })}
+                        className={classnames("menu-toggle", {
+                            active,
+                            "icon-only": !showLabel,
+                        })}
                         data-track-note="chart_settings_menu_toggle"
                         aria-label="Chart settings"
                     >
                         <FontAwesomeIcon icon={faGear} />
-                        <span className="label">Settings</span>
+                        {showLabel && (
+                            <span className="label">{SETTINGS_LABEL}</span>
+                        )}
                     </Button>
                     <Popover
                         className={GRAPHER_SETTINGS_CLASS}

--- a/packages/@ourworldindata/grapher/src/controls/controlsRow/ControlsRow.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/controlsRow/ControlsRow.tsx
@@ -14,7 +14,12 @@ import {
     MapRegionDropdownManager,
 } from "../MapRegionDropdown"
 import { SettingsMenu, SettingsMenuManager } from "../SettingsMenu"
-import { GRAPHER_FRAME_PADDING_HORIZONTAL } from "../../core/GrapherConstants"
+import {
+    DEFAULT_GRAPHER_BOUNDS,
+    GRAPHER_FRAME_PADDING_HORIZONTAL,
+} from "../../core/GrapherConstants"
+import { chooseControlsRowLayout, ControlsRowLayout } from "./ControlsRowLayout"
+import { CONTROLS_ROW_CSS_VARIABLES } from "./ControlsRowConstants"
 import { MapResetButton, MapResetButtonManager } from "../MapResetButton"
 import {
     DataTableFilterDropdown,
@@ -62,44 +67,53 @@ export class ControlsRow extends Component<ControlsRowProps> {
     }
 
     static shouldShow(manager: ControlsRowManager): boolean {
-        const test = new ControlsRow({ manager })
-        return test.showControlsRow
+        return (
+            ContentSwitchers.shouldShow(manager) ||
+            SettingsMenu.shouldShow(manager) ||
+            EntitySelectionToggle.shouldShow(manager) ||
+            // Map controls
+            MapRegionDropdown.shouldShow(manager) ||
+            MapZoomDropdown.shouldShow(manager) ||
+            MapZoomToSelectionButton.shouldShow(manager) ||
+            MapResetButton.shouldShow(manager, "resetZoom") ||
+            MapResetButton.shouldShow(manager, "resetView") ||
+            // Table controls
+            DataTableFilterDropdown.shouldShow(manager) ||
+            DataTableSearchField.shouldShow(manager)
+        )
     }
 
     @computed private get manager(): ControlsRowManager {
         return this.props.manager
     }
 
-    @computed private get showControlsRow(): boolean {
-        return (
-            ContentSwitchers.shouldShow(this.manager) ||
-            SettingsMenu.shouldShow(this.manager) ||
-            EntitySelectionToggle.shouldShow(this.manager) ||
-            // Map controls
-            MapRegionDropdown.shouldShow(this.manager) ||
-            MapZoomDropdown.shouldShow(this.manager) ||
-            MapZoomToSelectionButton.shouldShow(this.manager) ||
-            MapResetButton.shouldShow(this.manager, "resetZoom") ||
-            MapResetButton.shouldShow(this.manager, "resetView") ||
-            // Table controls
-            DataTableFilterDropdown.shouldShow(this.manager) ||
-            DataTableSearchField.shouldShow(this.manager)
-        )
+    @computed private get maxWidth(): number {
+        return this.props.maxWidth ?? DEFAULT_GRAPHER_BOUNDS.width
     }
 
+    @computed private get layout(): ControlsRowLayout {
+        return chooseControlsRowLayout(this.manager, this.maxWidth)
+    }
+
+    // mirrored by measureChartControlsWidth in ControlsRowLayout.ts
     private renderChartControls(): React.ReactElement {
         return (
             <div className="controls chart-controls">
-                <EntitySelectionToggle manager={this.manager} />
+                <EntitySelectionToggle
+                    manager={this.manager}
+                    showEntityLabel={this.layout.showEntityLabel}
+                />
                 <SettingsMenu
                     manager={this.manager}
                     popoverMaxWidth={this.props.popoverMaxWidth}
                     popoverMaxHeight={this.props.popoverMaxHeight}
+                    showLabel={this.layout.showSettingsLabel}
                 />
             </div>
         )
     }
 
+    // mirrored by measureTableControlsWidth in ControlsRowLayout.ts
     private renderTableControls(): React.ReactElement {
         return (
             <div className="controls table-controls">
@@ -109,6 +123,7 @@ export class ControlsRow extends Component<ControlsRowProps> {
         )
     }
 
+    // mirrored by measureMapControlsWidth in ControlsRowLayout.ts
     private renderMapControls(): React.ReactElement {
         return (
             <div className="controls map-controls">
@@ -126,7 +141,10 @@ export class ControlsRow extends Component<ControlsRowProps> {
                 <MapZoomToSelectionButton manager={this.manager} />
                 <MapResetButton manager={this.manager} action="resetView" />
                 <MapRegionDropdown manager={this.manager} />
-                <EntitySelectionToggle manager={this.manager} />
+                <EntitySelectionToggle
+                    manager={this.manager}
+                    showEntityLabel={this.layout.showEntityLabel}
+                />
             </>
         )
     }
@@ -151,10 +169,17 @@ export class ControlsRow extends Component<ControlsRowProps> {
         return (
             <nav
                 className="controlsRow"
-                style={{ padding: `0 ${this.framePaddingHorizontal}px` }}
+                style={{
+                    padding: `0 ${this.framePaddingHorizontal}px`,
+                    ...CONTROLS_ROW_CSS_VARIABLES,
+                }}
             >
                 <div>
-                    <ContentSwitchers manager={this.manager} />
+                    <ContentSwitchers
+                        manager={this.manager}
+                        showTabLabels={this.layout.showTabLabels}
+                        tabPadding={this.layout.tabPadding}
+                    />
                 </div>
                 <div className="controls">
                     {this.manager.isOnMapTab

--- a/packages/@ourworldindata/grapher/src/controls/controlsRow/ControlsRowConstants.ts
+++ b/packages/@ourworldindata/grapher/src/controls/controlsRow/ControlsRowConstants.ts
@@ -1,0 +1,113 @@
+import type { CSSProperties } from "react"
+import type { FontSettings } from "../../core/GrapherConstants"
+import { textWidth } from "../../chart/ChartUtils"
+
+/**
+ * Sizing constants and measurement primitives for the controls row.
+ *
+ * The constants are the single source of truth: the controls' estimateWidth
+ * statics use them to estimate how much space the row's content needs, and
+ * ControlsRow injects them as CSS custom properties that the stylesheets
+ * read, so the rendered sizes can't drift away from the estimated ones.
+ */
+
+// Buttons (button.menu-toggle, styled in Controls.scss)
+const BUTTON_FONT_SIZE = 13
+const BUTTON_FONT_WEIGHT = 400
+const BUTTON_PADDING = 7
+const BUTTON_BORDER_WIDTH = 1
+const BUTTON_ICON_WIDTH = 13
+const BUTTON_ICON_MARGIN = 5
+const ICON_ONLY_BUTTON_ICON_MARGIN = 2
+// The GlobeIcon in MapZoomToSelectionButton.tsx, sized via its `size` prop
+export const ZOOM_TO_SELECTION_ICON_WIDTH = 16
+
+// Applies to both button and tab labels
+const LABEL_LETTER_SPACING_EM = 0.01
+
+// Gap between the buttons in nav.controlsRow .controls (Controls.scss)
+export const CONTROLS_GAP = 8
+// Flex gap between the content switchers and the controls (CaptionedChart.scss)
+export const CONTROLS_ROW_GAP = 16
+
+// Slim tabs (Tabs.scss and ContentSwitchers.scss)
+export const TABS_FRAME_PADDING = 2
+const TAB_FONT_SIZE = 13
+const TAB_FONT_WEIGHT = 500
+export const TAB_ICON_WIDTH = 13
+export const TAB_ICON_GAP = 6
+export const OVERFLOW_BUTTON_PADDING = 8
+
+// Dropdowns, honored as their flex-basis (or width) in the respective .scss files
+export const MAP_REGION_DROPDOWN_WIDTH = 155
+export const MAP_ZOOM_DROPDOWN_WIDTH = 202
+export const DATA_TABLE_FILTER_DROPDOWN_WIDTH = 194
+export const DATA_TABLE_SEARCH_FIELD_WIDTH = 208
+
+/**
+ * Injected on controlsRow so the stylesheets render exactly the sizes
+ * that ControlsRowLayout.ts assumes.
+ */
+export const CONTROLS_ROW_CSS_VARIABLES = {
+    "--button-font-size": `${BUTTON_FONT_SIZE}px`,
+    "--button-font-weight": `${BUTTON_FONT_WEIGHT}`,
+    "--button-padding": `${BUTTON_PADDING}px`,
+    "--button-border-width": `${BUTTON_BORDER_WIDTH}px`,
+    "--button-icon-width": `${BUTTON_ICON_WIDTH}px`,
+    "--button-icon-margin": `${BUTTON_ICON_MARGIN}px`,
+    "--icon-only-button-icon-margin": `${ICON_ONLY_BUTTON_ICON_MARGIN}px`,
+    "--label-letter-spacing": `${LABEL_LETTER_SPACING_EM}em`,
+    "--controls-gap": `${CONTROLS_GAP}px`,
+    "--controls-row-gap": `${CONTROLS_ROW_GAP}px`,
+    "--tabs-frame-padding": `${TABS_FRAME_PADDING}px`,
+    "--tabs-font-size": `${TAB_FONT_SIZE}px`,
+    "--tab-font-weight": `${TAB_FONT_WEIGHT}`,
+    "--tab-icon-width": `${TAB_ICON_WIDTH}px`,
+    "--tab-icon-gap": `${TAB_ICON_GAP}px`,
+    "--overflow-button-padding": `${OVERFLOW_BUTTON_PADDING}px`,
+    "--map-region-dropdown-width": `${MAP_REGION_DROPDOWN_WIDTH}px`,
+    "--map-zoom-dropdown-width": `${MAP_ZOOM_DROPDOWN_WIDTH}px`,
+    "--data-table-filter-dropdown-width": `${DATA_TABLE_FILTER_DROPDOWN_WIDTH}px`,
+    "--data-table-search-field-width": `${DATA_TABLE_SEARCH_FIELD_WIDTH}px`,
+} as CSSProperties
+
+/**
+ * The tabs' overflow menu renders into a portal outside of controlsRow,
+ * so the tab content variables need to be injected on the popover separately.
+ */
+export const TAB_CONTENT_CSS_VARIABLES = {
+    "--tab-icon-width": `${TAB_ICON_WIDTH}px`,
+    "--tab-icon-gap": `${TAB_ICON_GAP}px`,
+} as CSSProperties
+
+type MeasuredFontSettings = Pick<
+    FontSettings,
+    "fontSize" | "fontWeight" | "letterSpacing"
+>
+
+const BUTTON_FONT: MeasuredFontSettings = {
+    fontSize: BUTTON_FONT_SIZE,
+    fontWeight: BUTTON_FONT_WEIGHT,
+    letterSpacing: LABEL_LETTER_SPACING_EM,
+}
+export const TAB_FONT: MeasuredFontSettings = {
+    fontSize: TAB_FONT_SIZE,
+    fontWeight: TAB_FONT_WEIGHT,
+    letterSpacing: LABEL_LETTER_SPACING_EM,
+}
+
+/** Width of a button.menu-toggle. Icon-only if no label is given. */
+export function measureButtonWidth(
+    label: string | undefined,
+    iconWidth: number = BUTTON_ICON_WIDTH
+): number {
+    const frameWidth = 2 * (BUTTON_PADDING + BUTTON_BORDER_WIDTH)
+    if (label === undefined)
+        return frameWidth + 2 * ICON_ONLY_BUTTON_ICON_MARGIN + iconWidth
+    return (
+        frameWidth +
+        iconWidth +
+        BUTTON_ICON_MARGIN +
+        textWidth(label, BUTTON_FONT)
+    )
+}

--- a/packages/@ourworldindata/grapher/src/controls/controlsRow/ControlsRowLayout.ts
+++ b/packages/@ourworldindata/grapher/src/controls/controlsRow/ControlsRowLayout.ts
@@ -1,0 +1,144 @@
+import * as _ from "lodash-es"
+import { ContentSwitchers } from "../ContentSwitchers"
+import { EntitySelectionToggle } from "../EntitySelectionToggle"
+import { SettingsMenu } from "../SettingsMenu"
+import { MapResetButton } from "../MapResetButton"
+import { MapZoomToSelectionButton } from "../MapZoomToSelectionButton"
+import { MapRegionDropdown } from "../MapRegionDropdown"
+import { MapZoomDropdown } from "../MapZoomDropdown"
+import { DataTableFilterDropdown } from "../DataTableFilterDropdown"
+import { DataTableSearchField } from "../DataTableSearchField"
+import type { ControlsRowManager } from "./ControlsRow"
+import { CONTROLS_GAP, CONTROLS_ROW_GAP } from "./ControlsRowConstants"
+
+/**
+ * The layout policy of the controls row: which labels and paddings are
+ * dropped or reduced when the row runs out of horizontal space.
+ */
+export interface ControlsRowLayout {
+    tabPadding: number
+    showTabLabels: boolean
+    showEntityLabel: boolean
+    showSettingsLabel: boolean
+}
+
+// Ordered from most to least verbose
+// prettier-ignore
+export const CONTROLS_ROW_LAYOUT_LADDER: ControlsRowLayout[] = [
+    // Show all labels
+    { tabPadding: 16, showTabLabels: true, showEntityLabel: true, showSettingsLabel: true },
+    // Reduce tab padding
+    { tabPadding: 12, showTabLabels: true, showEntityLabel: true, showSettingsLabel: true },
+    // Hide settings label
+    { tabPadding: 12, showTabLabels: true, showEntityLabel: true, showSettingsLabel: false },
+    // Hide entity label
+    { tabPadding: 12, showTabLabels: true, showEntityLabel: false, showSettingsLabel: false },
+    // Hide tab labels
+    { tabPadding: 12, showTabLabels: false, showEntityLabel: false, showSettingsLabel: false },
+    // Reduce tab padding further
+    { tabPadding: 8, showTabLabels: false, showEntityLabel: false, showSettingsLabel: false },
+]
+
+// Bounds.forText only approximates text widths, so leave a bit of headroom
+const SAFETY_MARGIN = 8
+
+/** Total width of the given controls, including the gaps between them */
+function sumControlWidths(widths: number[]): number {
+    const visibleWidths = widths.filter((width) => width > 0)
+    const totalGaps = Math.max(0, visibleWidths.length - 1) * CONTROLS_GAP
+    return _.sum(visibleWidths) + totalGaps
+}
+
+// mirrors ControlsRow.renderChartControls
+function measureChartControlsWidth(
+    manager: ControlsRowManager,
+    layout: ControlsRowLayout
+): number {
+    return sumControlWidths([
+        EntitySelectionToggle.estimateWidth(manager, {
+            showEntityLabel: layout.showEntityLabel,
+        }),
+        SettingsMenu.estimateWidth(manager, {
+            showLabel: layout.showSettingsLabel,
+        }),
+    ])
+}
+
+// mirrors ControlsRow.renderMapControls
+function measureMapControlsWidth(
+    manager: ControlsRowManager,
+    layout: ControlsRowLayout
+): number {
+    if (!manager.isMapSelectionEnabled) {
+        // mirrors ControlsRow.renderMapControlsForMobile
+        const resetZoomWidth = MapResetButton.estimateWidth(
+            manager,
+            "resetZoom"
+        )
+        if (resetZoomWidth > 0) return resetZoomWidth
+        return manager.isFaceted
+            ? MapRegionDropdown.estimateWidth(manager)
+            : MapZoomDropdown.estimateWidth(manager)
+    }
+
+    // mirrors ControlsRow.renderMapControlsForDesktop
+    return sumControlWidths([
+        MapResetButton.estimateWidth(manager, "resetZoom"),
+        MapZoomToSelectionButton.estimateWidth(manager),
+        MapResetButton.estimateWidth(manager, "resetView"),
+        MapRegionDropdown.estimateWidth(manager),
+        EntitySelectionToggle.estimateWidth(manager, {
+            showEntityLabel: layout.showEntityLabel,
+        }),
+    ])
+}
+
+// mirrors ControlsRow.renderTableControls
+function measureTableControlsWidth(manager: ControlsRowManager): number {
+    return sumControlWidths([
+        DataTableFilterDropdown.estimateWidth(manager),
+        DataTableSearchField.estimateWidth(manager),
+    ])
+}
+
+function measureControlsWidth(
+    manager: ControlsRowManager,
+    layout: ControlsRowLayout
+): number {
+    if (manager.isOnMapTab) return measureMapControlsWidth(manager, layout)
+    if (manager.isOnTableTab) return measureTableControlsWidth(manager)
+    return measureChartControlsWidth(manager, layout)
+}
+
+/** Estimated width of the controls row's content in the given layout */
+export function measureControlsRowWidth(
+    manager: ControlsRowManager,
+    layout: ControlsRowLayout
+): number {
+    const tabsWidth = ContentSwitchers.estimateWidth(manager, {
+        showTabLabels: layout.showTabLabels,
+        tabPadding: layout.tabPadding,
+    })
+    const controlsWidth = measureControlsWidth(manager, layout)
+    if (tabsWidth === 0) return controlsWidth
+    if (controlsWidth === 0) return tabsWidth
+    return tabsWidth + CONTROLS_ROW_GAP + controlsWidth
+}
+
+/**
+ * Pick the most verbose layout of the controls row that fits into the given
+ * width. If none fits, the least verbose one is returned.
+ */
+export function chooseControlsRowLayout(
+    manager: ControlsRowManager,
+    maxWidth: number
+): ControlsRowLayout {
+    for (const layout of CONTROLS_ROW_LAYOUT_LADDER) {
+        if (
+            measureControlsRowWidth(manager, layout) + SAFETY_MARGIN <=
+            maxWidth
+        )
+            return layout
+    }
+    return CONTROLS_ROW_LAYOUT_LADDER[CONTROLS_ROW_LAYOUT_LADDER.length - 1]
+}

--- a/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherConstants.ts
@@ -178,4 +178,5 @@ export interface FontSettings {
     fontSize: number
     fontWeight: number
     lineHeight: number
+    letterSpacing?: number // in em, e.g. 0.01 for CSS `letter-spacing: 0.01em`
 }

--- a/packages/@ourworldindata/grapher/src/tabs/Tabs.tsx
+++ b/packages/@ourworldindata/grapher/src/tabs/Tabs.tsx
@@ -18,12 +18,14 @@ export const Tabs = <TabKey extends string = string>({
     selectedKey,
     onChange,
     className,
+    style,
     variant = "default",
 }: {
     items: TabItem<TabKey>[]
     selectedKey: TabKey
     onChange: (key: TabKey) => void
     className?: string
+    style?: React.CSSProperties
     variant?: "default" | "slim" | "stretch" | "scroll"
 }) => {
     return (
@@ -35,6 +37,7 @@ export const Tabs = <TabKey extends string = string>({
         >
             <TabList
                 className={cx("Tabs", "Tabs--variant-" + variant, className)}
+                style={style}
             >
                 {items.map((item) => (
                     <Tab


### PR DESCRIPTION
> _Written by Anthropic Claude Fable 5 — @sophiamersmann at the wheel._

Replaces the controls row's five hardcoded container-query breakpoints (335, 500, 575, 675, 725px) plus the JS-driven `.GrapherComponentSemiNarrow` label rules with content-aware width estimation in JS. The row now renders the most verbose layout that provably fits, at any width and for any chart configuration.

Why: the old thresholds were hand-tuned for the default labels only, so anything off the default path could silently overflow the row — custom `entityType` / `entityTypePlural` strings, the map tab's state-dependent button set, or any newly added control. Kicked off by #6399, which made it clear the label collapsing needs to be content-aware, not breakpoint-based.

How it works:

- Each control estimates its own width in a `static estimateWidth(...)` co-located with its `shouldShow` and render, so measure-inputs equal render-inputs by construction (precedent: `ActionButtons` does the same for the footer).
- `ControlsRowLayout.ts` composes the estimates per tab and walks a ladder of layouts from most to least verbose (full labels → reduced tab padding → settings label dropped → entity label dropped → tab labels dropped), picking the first rung that fits the width budget.
- `ControlsRowConstants.ts` is the single source of truth for sizing: the constants are injected as CSS custom properties on `nav.controlsRow`, and the stylesheets consume them via `var(...)`, so rendered and estimated sizes stay in sync. The `var()` fallback values are manual duplicates kept in sync by hand.
- Text is measured with `textWidth` (extended to honor an optional `FontSettings.letterSpacing`), with a small safety margin for the character-table approximation.

Intended behavior shift: labels now collapse when they actually stop fitting, which is later than the old conservative breakpoints — e.g. the default chart keeps its full entity label down to ~540px frame width instead of 675px.

Also: `shouldShow` statics no longer instantiate throwaway components.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #6814
- <kbd>&nbsp;1&nbsp;</kbd> #6813 👈 
<!-- GitButler Footer Boundary Bottom -->