### PR TITLE
🎉 🤖 (grapher) shorten entity label before dropping it

### DIFF
--- a/packages/@ourworldindata/grapher/src/controls/EntitySelectionToggle.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/EntitySelectionToggle.tsx
@@ -4,7 +4,12 @@ import { observer } from "mobx-react"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faEye, faRightLeft, faPen } from "@fortawesome/free-solid-svg-icons"
 import classnames from "clsx"
+import { match } from "ts-pattern"
 import { GrapherWindowType } from "@ourworldindata/types"
+import {
+    DEFAULT_GRAPHER_ENTITY_TYPE,
+    DEFAULT_GRAPHER_ENTITY_TYPE_PLURAL,
+} from "../core/GrapherConstants"
 import { measureButtonWidth } from "./controlsRow/ControlsRowConstants"
 
 export interface EntitySelectionManager {
@@ -27,9 +32,16 @@ interface EntitySelectionLabel {
     entity: string
 }
 
+/**
+ * How verbose the button label is: the full entity name
+ * ("Edit countries and regions"), a shortened one ("Edit countries"),
+ * or the action alone ("Edit").
+ */
+export type EntityLabelMode = "full" | "short" | "action-only"
+
 interface EntitySelectionToggleProps {
     manager: EntitySelectionManager
-    showEntityLabel?: boolean
+    entityLabelMode?: EntityLabelMode
 }
 
 @observer
@@ -68,15 +80,14 @@ export class EntitySelectionToggle extends React.Component<EntitySelectionToggle
     static estimateWidth(
         manager: EntitySelectionManager,
         {
-            showEntityLabel,
+            entityLabelMode,
         }: Required<Omit<EntitySelectionToggleProps, "manager">>
     ): number {
         if (!EntitySelectionToggle.shouldShow(manager)) return 0
         const label = getEntitySelectionLabel(manager)
         if (!label) return 0
-        const text = showEntityLabel
-            ? `${label.action} ${label.entity}`
-            : label.action
+        const entityName = getEntityName(label, entityLabelMode)
+        const text = entityName ? `${label.action} ${entityName}` : label.action
         return measureButtonWidth(text)
     }
 
@@ -90,8 +101,12 @@ export class EntitySelectionToggle extends React.Component<EntitySelectionToggle
 
     override render(): React.ReactElement | null {
         const { shouldShow, label } = this
-        const { showEntityLabel = true } = this.props
+        const { entityLabelMode = "full" } = this.props
         const { isEntitySelectorModalOrDrawerOpen: active } = this.props.manager
+
+        const entityName = label
+            ? getEntityName(label, entityLabelMode)
+            : undefined
 
         return shouldShow && label ? (
             <div className="entity-selection-menu">
@@ -108,9 +123,9 @@ export class EntitySelectionToggle extends React.Component<EntitySelectionToggle
                 >
                     {label.icon}
                     <label className="label">
-                        {showEntityLabel ? (
+                        {entityName ? (
                             <>
-                                {label.action} <span>{label.entity}</span>
+                                {label.action} <span>{entityName}</span>
                             </>
                         ) : (
                             label.action
@@ -163,4 +178,26 @@ function getEntitySelectionLabel(
         }
 
     return null
+}
+
+/** The entity name rendered next to the action, undefined if action-only */
+function getEntityName(
+    label: EntitySelectionLabel,
+    mode: EntityLabelMode
+): string | undefined {
+    return match(mode)
+        .with("full", () => label.entity)
+        .with("short", () => getShortEntityName(label.entity))
+        .with("action-only", () => undefined)
+        .exhaustive()
+}
+
+// Only the default entity types have a short version
+const SHORT_ENTITY_NAMES: Record<string, string> = {
+    [DEFAULT_GRAPHER_ENTITY_TYPE]: "country",
+    [DEFAULT_GRAPHER_ENTITY_TYPE_PLURAL]: "countries",
+}
+
+function getShortEntityName(entity: string): string {
+    return SHORT_ENTITY_NAMES[entity] ?? entity
 }

--- a/packages/@ourworldindata/grapher/src/controls/controlsRow/ControlsRow.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/controlsRow/ControlsRow.tsx
@@ -101,7 +101,7 @@ export class ControlsRow extends Component<ControlsRowProps> {
             <div className="controls chart-controls">
                 <EntitySelectionToggle
                     manager={this.manager}
-                    showEntityLabel={this.layout.showEntityLabel}
+                    entityLabelMode={this.layout.entityLabelMode}
                 />
                 <SettingsMenu
                     manager={this.manager}
@@ -143,7 +143,7 @@ export class ControlsRow extends Component<ControlsRowProps> {
                 <MapRegionDropdown manager={this.manager} />
                 <EntitySelectionToggle
                     manager={this.manager}
-                    showEntityLabel={this.layout.showEntityLabel}
+                    entityLabelMode={this.layout.entityLabelMode}
                 />
             </>
         )

--- a/packages/@ourworldindata/grapher/src/controls/controlsRow/ControlsRowLayout.ts
+++ b/packages/@ourworldindata/grapher/src/controls/controlsRow/ControlsRowLayout.ts
@@ -1,6 +1,9 @@
 import * as _ from "lodash-es"
 import { ContentSwitchers } from "../ContentSwitchers"
-import { EntitySelectionToggle } from "../EntitySelectionToggle"
+import {
+    EntitySelectionToggle,
+    EntityLabelMode,
+} from "../EntitySelectionToggle"
 import { SettingsMenu } from "../SettingsMenu"
 import { MapResetButton } from "../MapResetButton"
 import { MapZoomToSelectionButton } from "../MapZoomToSelectionButton"
@@ -18,7 +21,7 @@ import { CONTROLS_GAP, CONTROLS_ROW_GAP } from "./ControlsRowConstants"
 export interface ControlsRowLayout {
     tabPadding: number
     showTabLabels: boolean
-    showEntityLabel: boolean
+    entityLabelMode: EntityLabelMode
     showSettingsLabel: boolean
 }
 
@@ -26,17 +29,19 @@ export interface ControlsRowLayout {
 // prettier-ignore
 export const CONTROLS_ROW_LAYOUT_LADDER: ControlsRowLayout[] = [
     // Show all labels
-    { tabPadding: 16, showTabLabels: true, showEntityLabel: true, showSettingsLabel: true },
+    { tabPadding: 16, showTabLabels: true, entityLabelMode: "full", showSettingsLabel: true },
     // Reduce tab padding
-    { tabPadding: 12, showTabLabels: true, showEntityLabel: true, showSettingsLabel: true },
+    { tabPadding: 12, showTabLabels: true, entityLabelMode: "full", showSettingsLabel: true },
     // Hide settings label
-    { tabPadding: 12, showTabLabels: true, showEntityLabel: true, showSettingsLabel: false },
-    // Hide entity label
-    { tabPadding: 12, showTabLabels: true, showEntityLabel: false, showSettingsLabel: false },
+    { tabPadding: 12, showTabLabels: true, entityLabelMode: "full", showSettingsLabel: false },
+    // Shorten entity name ("Edit countries" for "Edit countries and regions")
+    { tabPadding: 12, showTabLabels: true, entityLabelMode: "short", showSettingsLabel: false },
     // Hide tab labels
-    { tabPadding: 12, showTabLabels: false, showEntityLabel: false, showSettingsLabel: false },
+    { tabPadding: 12, showTabLabels: false, entityLabelMode: "short", showSettingsLabel: false },
+    // Hide entity name ("Edit")
+    { tabPadding: 12, showTabLabels: false, entityLabelMode: "action-only", showSettingsLabel: false },
     // Reduce tab padding further
-    { tabPadding: 8, showTabLabels: false, showEntityLabel: false, showSettingsLabel: false },
+    { tabPadding: 8, showTabLabels: false, entityLabelMode: "action-only", showSettingsLabel: false },
 ]
 
 // Bounds.forText only approximates text widths, so leave a bit of headroom
@@ -56,7 +61,7 @@ function measureChartControlsWidth(
 ): number {
     return sumControlWidths([
         EntitySelectionToggle.estimateWidth(manager, {
-            showEntityLabel: layout.showEntityLabel,
+            entityLabelMode: layout.entityLabelMode,
         }),
         SettingsMenu.estimateWidth(manager, {
             showLabel: layout.showSettingsLabel,
@@ -88,7 +93,7 @@ function measureMapControlsWidth(
         MapResetButton.estimateWidth(manager, "resetView"),
         MapRegionDropdown.estimateWidth(manager),
         EntitySelectionToggle.estimateWidth(manager, {
-            showEntityLabel: layout.showEntityLabel,
+            entityLabelMode: layout.entityLabelMode,
         }),
     ])
 }


### PR DESCRIPTION
> _Written by Anthropic Claude Fable 5 — @sophiamersmann at the wheel._

Fixes #6399.

Builds on the content-aware controls row layout: instead of jumping straight from "Edit countries and regions" to a bare "Edit", the layout ladder gets a new "short" rung in between. The entity label prop becomes a three-state `entityLabelMode: "full" | "short" | "action-only"`.

- Only the default entity types have a short version ("countries and regions" → "countries", "country or region" → "country"). Custom entity types are unpredictable to shorten automatically, so they keep their full name and the rung falls through at no cost.
- The "hide tab labels" rung moves above "hide entity name". The tab icons are self-explanatory, and without this reorder phones (~330–540px frame width) don't fit the short label next to labeled tabs and land on the bare "Edit" the issue was filed about. With it, phones get icon-only tabs + "Edit countries".

The resulting ladder, most to least verbose: tab padding 16 → 12px, settings label dropped, entity name shortened, tab labels dropped, entity name dropped, tab padding 12 → 8px.

A side effect of the reorder: the map tab's already-short "Select countries" also survives one rung longer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #6814 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #6813
<!-- GitButler Footer Boundary Bottom -->