### PR TITLE
🔨 add BAKED_BASE_URL to CF env

### DIFF
--- a/functions/_common/env.ts
+++ b/functions/_common/env.ts
@@ -1,6 +1,7 @@
 export interface Env {
     ASSETS: Fetcher
     url: URL
+    BAKED_BASE_URL?: string
     GRAPHER_CONFIG_R2_BUCKET?: R2Bucket
     GRAPHER_CONFIG_R2_BUCKET_FALLBACK?: R2Bucket
     GRAPHER_CONFIG_R2_BUCKET_PATH?: string

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -88,6 +88,7 @@
             ],
             "vars": {
                 "ENV": "production",
+                "BAKED_BASE_URL": "https://ourworldindata.org",
                 "MAILGUN_DOMAIN": "mg.ourworldindata.org",
                 "SLACK_ERROR_CHANNEL_ID": "C5JJW19PS",
                 "GRAPHER_CONFIG_R2_BUCKET_FALLBACK_PATH": "",


### PR DESCRIPTION
Adds `BAKED_BASE_URL` to CF Pages Functions env variables.

Doesn't set a value in the `preview` `vars` block in `wrangler.jsonc` because those are dynamic.