### PR TITLE
Fix datapage descriptionKey paragraph spacing

### DIFF
--- a/site/AboutThisData.scss
+++ b/site/AboutThisData.scss
@@ -37,6 +37,20 @@
     }
 }
 
+.key-info__key-description {
+    p {
+        margin: 8px 0;
+
+        &:first-of-type {
+            margin-top: 0;
+        }
+
+        &:last-of-type {
+            margin-bottom: 0;
+        }
+    }
+}
+
 .key-info__expandable-descriptions {
     p {
         margin: 8px 0;


### PR DESCRIPTION
> _Written by Claude Fable 5 — @Marigold at the wheel._

Fixes #6819.

`descriptionKey` is now a free-form markdown string, so it can render as several sibling `<p>` elements. `.key-info__content p { margin: 0; }` zeroes every paragraph's margin — that rule dates back to when each key fact was its own bullet, and was meant to reset the paragraph a markdown list item wraps its text in. It also catches the new top-level paragraphs though, so consecutive paragraphs in a `descriptionKey` render back-to-back with no visible gap, reading as one dense block instead of separate paragraphs.

This adds a more specific `.key-info__key-description p` rule (8px margin, collapsing to 0 for the first/last paragraph) so it wins over the existing reset for this component specifically — matching the pattern already used by the neighboring `.key-info__expandable-descriptions` (FAQ / additional info) section.

## How to test it

Most existing `descriptionKey` values are short bullet lists without consecutive paragraphs, so the bug doesn't show up on every indicator. A real example with plain multi-paragraph prose (no bullets):

- http://staging-site-datapage-descriptionkey-para/grapher/dietary-compositions-by-commodity-group — scroll to "What you should know about this indicator"; the paragraphs should now have visible spacing between them.

Already verified locally: rendered a synthetic 3-paragraph `descriptionKey` through the real page and confirmed computed `margin` on the `<p>` elements goes from `0px`/`0px` (paragraphs touching) to `8px` between paragraphs and `0px` at the first/last (matches the FAQ section's existing spacing convention). No visual regression on bullet-list `descriptionKey` values (e.g. [school-closures-covid](http://staging-site-datapage-descriptionkey-para/grapher/school-closures-covid)), since those don't have consecutive top-level paragraphs.
