### PR TITLE
Add devTools/callAdminApi.ts CLI for scripting the admin API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,11 @@ When creating a git branch, use a short descriptive name without any prefix (in 
 
 When creating new skills in `.claude/skills/`, always include `metadata: { internal: true }` in the SKILL.md frontmatter unless explicitly asked for the skill to be public. This prevents external skill indexes from crawling and listing our internal skills.
 
+## Testing on staging
+
+- `yarn tsx devTools/callAdminApi.ts get <chartId> --branch <branch>` / `set <chartId> '<jsonPatch>' --branch <branch>` / `unset <chartId> <field> --branch <branch>`: inspect or change a chart's config on any `staging-site-<branch>` (or `--host` for local/prod) without the browser.
+- Auth is `ADMIN_API_KEY` in `.env` — one shared key works against **every** staging server (not per-branch), since `admin_api_keys` ships in the private data dump every staging build restores from (see `db/exportMetadataTables.ts`). It's the same key etl already uses; no need to mint a new one.
+
 ## Team
 
 Everything you post to GitHub or Slack goes out under a **human's identity**. Any text you author and post that a reader could take for the human's own words **must** carry the attribution line below. This is mandatory — not a judgment call about whether the comment is "worth it."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ When creating new skills in `.claude/skills/`, always include `metadata: { inter
 
 - `yarn tsx devTools/callAdminApi.ts get <chartId> --branch <branch>` / `set <chartId> '<jsonPatch>' --branch <branch>` / `unset <chartId> <field> --branch <branch>`: inspect or change a chart's config on any `staging-site-<branch>` (or `--host` for local/prod) without the browser.
 - Auth is `ADMIN_API_KEY` in `.env` — one shared key works against **every** staging server (not per-branch), since `admin_api_keys` ships in the private data dump every staging build restores from (see `db/exportMetadataTables.ts`). It's the same key etl already uses; no need to mint a new one.
-- For UI/CSS changes (not just chart-config edits), don't wait for the full static-site rebake (~10-13 min) — `http://staging-site-<branch>/admin/charts/<id>/edit` (or `/preview`) reflects a pushed code change within ~1-3 min, since the admin client bundle deploys faster than the full site bake.
+- Don't wait for the static-site rebake (~10-13 min) to check or share a chart — `http://staging-site-<branch>/admin/charts/<id>/preview` reflects both chart-config edits and pushed code changes within ~1-3 min. Default to this link (not the public `/grapher/<slug>` page) whenever pointing someone at a chart on staging.
 
 ## Team
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,7 @@ When creating new skills in `.claude/skills/`, always include `metadata: { inter
 
 - `yarn tsx devTools/callAdminApi.ts get <chartId> --branch <branch>` / `set <chartId> '<jsonPatch>' --branch <branch>` / `unset <chartId> <field> --branch <branch>`: inspect or change a chart's config on any `staging-site-<branch>` (or `--host` for local/prod) without the browser.
 - Auth is `ADMIN_API_KEY` in `.env` — one shared key works against **every** staging server (not per-branch), since `admin_api_keys` ships in the private data dump every staging build restores from (see `db/exportMetadataTables.ts`). It's the same key etl already uses; no need to mint a new one.
+- For UI/CSS changes (not just chart-config edits), don't wait for the full static-site rebake (~10-13 min) — `http://staging-site-<branch>/admin/charts/<id>/edit` (or `/preview`) reflects a pushed code change within ~1-3 min, since the admin client bundle deploys faster than the full site bake.
 
 ## Team
 

--- a/devTools/callAdminApi.ts
+++ b/devTools/callAdminApi.ts
@@ -68,6 +68,11 @@ async function putChartConfig(
 }
 
 async function main() {
+    // Fail fast with a clean message instead of a stack trace buried under
+    // yargs' usage output, which is what a lazy check inside a command
+    // handler would otherwise produce.
+    getApiKey()
+
     await yargs(hideBin(process.argv))
         .option("branch", {
             type: "string",
@@ -89,10 +94,7 @@ async function main() {
                 }),
             async (argv) => {
                 const baseUrl = resolveBaseUrl(argv)
-                const config = await getChartConfig(
-                    baseUrl,
-                    argv.chartId as number
-                )
+                const config = await getChartConfig(baseUrl, argv.chartId)
                 console.log(JSON.stringify(config, null, 2))
             }
         )
@@ -112,8 +114,8 @@ async function main() {
                     }),
             async (argv) => {
                 const baseUrl = resolveBaseUrl(argv)
-                const chartId = argv.chartId as number
-                const patch = JSON.parse(argv.patchJson as string)
+                const { chartId } = argv
+                const patch = JSON.parse(argv.patchJson)
                 const current = await getChartConfig(baseUrl, chartId)
                 const merged = { ...current, ...patch }
                 await putChartConfig(baseUrl, chartId, merged)
@@ -137,9 +139,9 @@ async function main() {
                     }),
             async (argv) => {
                 const baseUrl = resolveBaseUrl(argv)
-                const chartId = argv.chartId as number
+                const { chartId } = argv
                 const current = await getChartConfig(baseUrl, chartId)
-                delete current[argv.field as string]
+                delete current[argv.field]
                 await putChartConfig(baseUrl, chartId, current)
                 console.log("Saved. New config:")
                 console.log(JSON.stringify(current, null, 2))
@@ -151,6 +153,6 @@ async function main() {
 }
 
 void main().catch((error) => {
-    console.error("Encountered an error:", error)
+    console.error(error instanceof Error ? error.message : error)
     process.exit(-1)
 })

--- a/devTools/callAdminApi.ts
+++ b/devTools/callAdminApi.ts
@@ -69,18 +69,21 @@ async function putChartConfig(
         },
         body: JSON.stringify(config),
     })
-    const json = await res.json()
-    if (!res.ok || json.success === false)
-        throw new Error(`PUT failed: ${res.status} ${JSON.stringify(json)}`)
+    // Read as text before parsing: error responses (e.g. a 502 from a proxy)
+    // aren't always JSON, and the raw body is the best error message we have.
+    const body = await res.text()
+    if (!res.ok) throw new Error(`PUT failed: ${res.status} ${body}`)
+    const json = JSON.parse(body) as { success?: boolean }
+    if (json.success === false) throw new Error(`PUT failed: ${body}`)
 }
 
 async function main() {
-    // Fail fast with a clean message instead of a stack trace buried under
-    // yargs' usage output, which is what a lazy check inside a command
-    // handler would otherwise produce.
-    getApiKey()
-
     await yargs(hideBin(process.argv))
+        // Fail fast with a clean message instead of a stack trace buried
+        // under yargs' usage output, which is what a lazy check inside a
+        // command handler would otherwise produce. As middleware it doesn't
+        // run for --help, so usage stays viewable without a key.
+        .middleware(() => void getApiKey())
         .option("branch", {
             type: "string",
             describe:

--- a/devTools/callAdminApi.ts
+++ b/devTools/callAdminApi.ts
@@ -1,0 +1,156 @@
+// Small CLI for calling any owid-grapher admin API (local dev, staging, or
+// production) from the command line, e.g. for manually testing a chart
+// config change on a staging server without going through the browser.
+//
+// Auth: reads ADMIN_API_KEY from .env. The same key works against every
+// staging server, since `admin_api_keys` ships in the private data dump that
+// every staging build restores from (see db/exportMetadataTables.ts).
+//
+// Examples:
+//   yarn tsx devTools/callAdminApi.ts get 123 --branch archiving-charts
+//   yarn tsx devTools/callAdminApi.ts set 123 '{"deprecationNotice":"test"}' --branch archiving-charts
+//   yarn tsx devTools/callAdminApi.ts get 123 --host http://localhost:3030/admin/api
+
+import "../settings/loadDotenv.js"
+import yargs from "yargs"
+import { hideBin } from "yargs/helpers"
+
+interface HostArgs {
+    branch?: string
+    host?: string
+}
+
+function resolveBaseUrl(args: HostArgs): string {
+    if (args.host) return args.host.replace(/\/$/, "")
+    if (args.branch)
+        return `http://staging-site-${args.branch}.tail6e23.ts.net/admin/api`
+    return "http://localhost:3030/admin/api"
+}
+
+function getApiKey(): string {
+    const key = process.env.ADMIN_API_KEY
+    if (!key)
+        throw new Error(
+            "ADMIN_API_KEY is not set. Add it to .env (see devTools/createAdminApiKey.ts to mint one, " +
+                "or reuse the shared key already used by etl)."
+        )
+    return key
+}
+
+async function getChartConfig(
+    baseUrl: string,
+    chartId: number
+): Promise<Record<string, unknown>> {
+    const res = await fetch(`${baseUrl}/charts/${chartId}.config.json`, {
+        headers: { Authorization: `Bearer ${getApiKey()}` },
+    })
+    if (!res.ok)
+        throw new Error(`GET failed: ${res.status} ${await res.text()}`)
+    return res.json()
+}
+
+async function putChartConfig(
+    baseUrl: string,
+    chartId: number,
+    config: Record<string, unknown>
+): Promise<void> {
+    const res = await fetch(`${baseUrl}/charts/${chartId}`, {
+        method: "PUT",
+        headers: {
+            Authorization: `Bearer ${getApiKey()}`,
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify(config),
+    })
+    const json = await res.json()
+    if (!res.ok || json.success === false)
+        throw new Error(`PUT failed: ${res.status} ${JSON.stringify(json)}`)
+}
+
+async function main() {
+    await yargs(hideBin(process.argv))
+        .option("branch", {
+            type: "string",
+            describe:
+                "Staging branch name, e.g. archiving-charts (resolves to staging-site-<branch>)",
+        })
+        .option("host", {
+            type: "string",
+            describe:
+                "Override base URL, e.g. http://localhost:3030/admin/api. Takes precedence over --branch.",
+        })
+        .command(
+            "get <chartId>",
+            "Fetch a chart's full config as JSON",
+            (y) =>
+                y.positional("chartId", {
+                    type: "number",
+                    demandOption: true,
+                }),
+            async (argv) => {
+                const baseUrl = resolveBaseUrl(argv)
+                const config = await getChartConfig(
+                    baseUrl,
+                    argv.chartId as number
+                )
+                console.log(JSON.stringify(config, null, 2))
+            }
+        )
+        .command(
+            "set <chartId> <patchJson>",
+            "Shallow-merge a JSON object into a chart's config and save it",
+            (y) =>
+                y
+                    .positional("chartId", {
+                        type: "number",
+                        demandOption: true,
+                    })
+                    .positional("patchJson", {
+                        type: "string",
+                        demandOption: true,
+                        describe: "JSON object to merge into the config",
+                    }),
+            async (argv) => {
+                const baseUrl = resolveBaseUrl(argv)
+                const chartId = argv.chartId as number
+                const patch = JSON.parse(argv.patchJson as string)
+                const current = await getChartConfig(baseUrl, chartId)
+                const merged = { ...current, ...patch }
+                await putChartConfig(baseUrl, chartId, merged)
+                console.log("Saved. New config:")
+                console.log(JSON.stringify(merged, null, 2))
+            }
+        )
+        .command(
+            "unset <chartId> <field>",
+            "Remove a top-level field from a chart's config and save it",
+            (y) =>
+                y
+                    .positional("chartId", {
+                        type: "number",
+                        demandOption: true,
+                    })
+                    .positional("field", {
+                        type: "string",
+                        demandOption: true,
+                        describe: "Top-level config key to remove",
+                    }),
+            async (argv) => {
+                const baseUrl = resolveBaseUrl(argv)
+                const chartId = argv.chartId as number
+                const current = await getChartConfig(baseUrl, chartId)
+                delete current[argv.field as string]
+                await putChartConfig(baseUrl, chartId, current)
+                console.log("Saved. New config:")
+                console.log(JSON.stringify(current, null, 2))
+            }
+        )
+        .demandCommand(1)
+        .strict()
+        .help().argv
+}
+
+void main().catch((error) => {
+    console.error("Encountered an error:", error)
+    process.exit(-1)
+})

--- a/devTools/callAdminApi.ts
+++ b/devTools/callAdminApi.ts
@@ -10,10 +10,15 @@
 //   yarn tsx devTools/callAdminApi.ts get 123 --branch archiving-charts
 //   yarn tsx devTools/callAdminApi.ts set 123 '{"deprecationNotice":"test"}' --branch archiving-charts
 //   yarn tsx devTools/callAdminApi.ts get 123 --host http://localhost:3030/admin/api
+//
+// set/unset attribute writes to the ADMIN_API_KEY's own owner (e.g. the etl
+// service account) unless you pass --userId <id>, which requires that owner
+// to be a superuser.
 
 import "../settings/loadDotenv.js"
 import yargs from "yargs"
 import { hideBin } from "yargs/helpers"
+import { getContainerName } from "./stagingHostname.js"
 
 interface HostArgs {
     branch?: string
@@ -23,7 +28,7 @@ interface HostArgs {
 function resolveBaseUrl(args: HostArgs): string {
     if (args.host) return args.host.replace(/\/$/, "")
     if (args.branch)
-        return `http://staging-site-${args.branch}.tail6e23.ts.net/admin/api`
+        return `http://${getContainerName(args.branch)}.tail6e23.ts.net/admin/api`
     return "http://localhost:3030/admin/api"
 }
 
@@ -52,13 +57,15 @@ async function getChartConfig(
 async function putChartConfig(
     baseUrl: string,
     chartId: number,
-    config: Record<string, unknown>
+    config: Record<string, unknown>,
+    userId: number | undefined
 ): Promise<void> {
     const res = await fetch(`${baseUrl}/charts/${chartId}`, {
         method: "PUT",
         headers: {
             Authorization: `Bearer ${getApiKey()}`,
             "Content-Type": "application/json",
+            ...(userId !== undefined && { "x-act-as-user": String(userId) }),
         },
         body: JSON.stringify(config),
     })
@@ -83,6 +90,12 @@ async function main() {
             type: "string",
             describe:
                 "Override base URL, e.g. http://localhost:3030/admin/api. Takes precedence over --branch.",
+        })
+        .option("userId", {
+            type: "number",
+            describe:
+                "Attribute set/unset writes to this user id instead of ADMIN_API_KEY's own owner " +
+                "(sends x-act-as-user; the key's user must be a superuser).",
         })
         .command(
             "get <chartId>",
@@ -118,7 +131,7 @@ async function main() {
                 const patch = JSON.parse(argv.patchJson)
                 const current = await getChartConfig(baseUrl, chartId)
                 const merged = { ...current, ...patch }
-                await putChartConfig(baseUrl, chartId, merged)
+                await putChartConfig(baseUrl, chartId, merged, argv.userId)
                 console.log("Saved. New config:")
                 console.log(JSON.stringify(merged, null, 2))
             }
@@ -142,7 +155,7 @@ async function main() {
                 const { chartId } = argv
                 const current = await getChartConfig(baseUrl, chartId)
                 delete current[argv.field]
-                await putChartConfig(baseUrl, chartId, current)
+                await putChartConfig(baseUrl, chartId, current, argv.userId)
                 console.log("Saved. New config:")
                 console.log(JSON.stringify(current, null, 2))
             }

--- a/devTools/db-ai-helpers/query.ts
+++ b/devTools/db-ai-helpers/query.ts
@@ -6,23 +6,7 @@ import { dataSource } from "../../db/dataSource.js"
 import yargs from "yargs"
 import { hideBin } from "yargs/helpers"
 
-function normalizeBranch(branchName: string): string {
-    return branchName.replace(/[/._]/g, "-")
-}
-
-function getContainerName(branchName: string): string {
-    let normalized = normalizeBranch(branchName)
-
-    // Strip staging-site- prefix to add it back later
-    normalized = normalized.replace(/^staging-site-/, "")
-
-    // Truncate to 28 characters (Cloudflare's limit)
-    const limit = 28
-    const containerName = `staging-site-${normalized.slice(0, limit)}`
-
-    // Remove trailing hyphens
-    return containerName.replace(/-+$/, "")
-}
+import { getContainerName } from "../stagingHostname.js"
 
 function getCurrentBranch(): string {
     return execSync("git rev-parse --abbrev-ref HEAD", {

--- a/devTools/stagingHostname.ts
+++ b/devTools/stagingHostname.ts
@@ -1,0 +1,22 @@
+// This function is duplicated in these places, make sure to change all of them:
+//     https://github.com/owid/ops/blob/main/templates/lxc-manager/prune_staging_containers.py
+//     https://github.com/owid/ops/blob/main/templates/lxc-manager/shared
+//     https://github.com/owid/etl/blob/master/etl/config.py
+
+export function normalizeBranch(branchName: string): string {
+    return branchName.replace(/[/._]/g, "-")
+}
+
+export function getContainerName(branchName: string): string {
+    let normalized = normalizeBranch(branchName)
+
+    // Strip staging-site- prefix to add it back later
+    normalized = normalized.replace(/^staging-site-/, "")
+
+    // Truncate to 28 characters (Cloudflare's limit)
+    const limit = 28
+    const containerName = `staging-site-${normalized.slice(0, limit)}`
+
+    // Remove trailing hyphens
+    return containerName.replace(/-+$/, "")
+}


### PR DESCRIPTION
> _Written by Claude Sonnet 5 and Claude Fable 5 — @Marigold at the wheel._

## Summary

Split out of [#6808](https://github.com/owid/owid-grapher/pull/6808) — general-purpose tooling that isn't specific to that PR's feature.

Adds `devTools/callAdminApi.ts`, a small CLI for getting/setting/unsetting fields on a chart config against any admin API (local, staging, or production) via `ADMIN_API_KEY`:

```
yarn tsx devTools/callAdminApi.ts get <chartId> --branch <branch>
yarn tsx devTools/callAdminApi.ts set <chartId> '<jsonPatch>' --branch <branch>
yarn tsx devTools/callAdminApi.ts unset <chartId> <field> --branch <branch>
```

The same `ADMIN_API_KEY` works against **every** staging server (not per-branch), since `admin_api_keys` ships in the private data dump every staging build restores from (see `db/exportMetadataTables.ts`) — no need to mint a new key per branch. It's the same key etl already uses.

Also documents this, plus two related staging-workflow notes, in `CLAUDE.md`:
- the CLI itself and the shared-key auth
- `/admin/charts/<id>/preview` reflects both chart-config edits and pushed code changes within ~1-3 min, much faster than the full static-site rebake (~10-13 min) — default to that link over the public `/grapher/<slug>` page when showing someone a chart on staging

## Review follow-ups

- `024ff8d` (Codex review): branch names are normalized the same way staging hostnames are generated (shared `devTools/stagingHostname.ts`, extracted from `query.ts`), and `--userId` sends `x-act-as-user` so writes can be attributed to the actual editor instead of the shared key's owner (superuser-only, pre-existing server support).
- `b74f3f8`: PUT errors now surface the raw response body instead of an opaque JSON parse error when the server returns non-JSON (e.g. a 502), and `--help` works without `ADMIN_API_KEY` set (real commands still fail fast with a clean message).

## How to test it

Against this PR's own staging server (chart 64 is life expectancy):

```
yarn tsx devTools/callAdminApi.ts get 64 --branch admin-api-cli
yarn tsx devTools/callAdminApi.ts set 64 '{"subtitle":"testing callAdminApi"}' --branch admin-api-cli
yarn tsx devTools/callAdminApi.ts unset 64 subtitle --branch admin-api-cli
```

The `set` should be visible at http://staging-site-admin-api-cli/admin/charts/64/preview within ~1-3 min (remember to `unset` after).

Already verified, so the above is mostly for feel: live `get` against `staging-site-admin-api-cli` returns the config; `--help` works without a key and real commands without a key fail with a clean one-line message; used throughout [#6808](https://github.com/owid/owid-grapher/pull/6808)'s review to set/inspect/clear a real chart's config on staging; format/lint/typecheck clean.
