### PR TITLE
🎉🤖 (time-interval) calendar-aware ticks & labels for sub-yearly time axes

### DIFF
--- a/packages/@ourworldindata/grapher/src/axis/Axis.test.ts
+++ b/packages/@ourworldindata/grapher/src/axis/Axis.test.ts
@@ -2,13 +2,23 @@ import { expect, it, describe } from "vitest"
 import * as R from "remeda"
 
 import { HorizontalAxis } from "../axis/Axis"
-import { ScaleType, AxisConfigInterface } from "@ourworldindata/types"
 import {
+    ScaleType,
+    AxisConfigInterface,
+    ColumnTypeNames,
+} from "@ourworldindata/types"
+import {
+    OwidTable,
     SynthesizeFruitTable,
     SynthesizeGDPTable,
 } from "@ourworldindata/core-table"
 import { AxisConfig } from "./AxisConfig"
-import { AxisAlign } from "@ourworldindata/utils"
+import {
+    AxisAlign,
+    dayjs,
+    convertDateToDaysSinceEpoch,
+    convertDaysSinceEpochToDate,
+} from "@ourworldindata/utils"
 
 it("can create an axis", () => {
     const axisConfig = new AxisConfig({
@@ -276,5 +286,251 @@ describe("manual ticks", () => {
         expect(
             defaultAxis.tickLabels.map((label) => label.value)
         ).not.toContain(99)
+    })
+})
+
+describe("for months", () => {
+    function makeMonthlyTimeAxis(
+        min: string,
+        max: string,
+        maxTicks?: number
+    ): HorizontalAxis {
+        const day = (date: string): number =>
+            convertDateToDaysSinceEpoch(dayjs.utc(date))
+        const table = new OwidTable({ entityName: ["usa"], month: [0] }, [
+            { slug: "month", type: ColumnTypeNames.Month },
+        ])
+        const axis = new HorizontalAxis(
+            new AxisConfig({
+                scaleType: ScaleType.linear,
+                min: day(min),
+                max: day(max),
+                ...(maxTicks !== undefined ? { maxTicks } : {}),
+            })
+        )
+        axis.formatColumn = table.get("month")
+        axis.hideFractionalTicks = true
+        axis.range = [0, 800]
+        return axis
+    }
+
+    it("places monthly time-axis ticks on first-of-month, January-anchored boundaries", () => {
+        const day = (date: string): number =>
+            convertDateToDaysSinceEpoch(dayjs.utc(date))
+        const axis = makeMonthlyTimeAxis("2020-01-01", "2022-12-01")
+
+        const values = axis.getTickValues().map((tick) => tick.value)
+
+        // every tick lands on the first of a month...
+        for (const value of values)
+            expect(convertDaysSinceEpochToDate(value).date()).toBe(1)
+        // ...and year boundaries are always on the grid regardless of the step
+        expect(values).toContain(day("2021-01-01"))
+        expect(values).toContain(day("2022-01-01"))
+    })
+
+    it("drops repeated years on a sub-year monthly axis, keeping months and Januaries", () => {
+        const labels = makeMonthlyTimeAxis(
+            "2020-03-01",
+            "2022-11-01",
+            8
+        ).tickLabels.map((tick) => tick.formattedValue)
+
+        // no bare year: every label is a month, optionally with a year
+        for (const label of labels)
+            expect(label).toMatch(/^[A-Z][a-z]{2}( \d{4})?$/)
+        // the year rides along on each January
+        expect(labels).toContain("Jan 2021")
+        expect(labels).toContain("Jan 2022")
+        // ...but not on the intervening months
+        expect(labels).toContain("Jul")
+    })
+
+    it("labels a yearly-cadence monthly axis with bare years only", () => {
+        const labels = makeMonthlyTimeAxis(
+            "2000-01-01",
+            "2020-01-01",
+            6
+        ).tickLabels.map((tick) => tick.formattedValue)
+
+        expect(labels.length).toBeGreaterThan(1)
+        for (const label of labels) expect(label).toMatch(/^\d{4}$/)
+    })
+
+    it("keeps per-value labels when a monthly axis has author-supplied ticks", () => {
+        // Custom ticks (as stacked bars / slope / sparkline set) get thinned by
+        // overlap-hiding after labeling, so the year-suppression is skipped and every
+        // label keeps its year — even same-year ticks.
+        const day = (date: string): number =>
+            convertDateToDaysSinceEpoch(dayjs.utc(date))
+        const table = new OwidTable({ entityName: ["usa"], month: [0] }, [
+            { slug: "month", type: ColumnTypeNames.Month },
+        ])
+        const axis = new HorizontalAxis(
+            new AxisConfig({
+                scaleType: ScaleType.linear,
+                min: day("2020-01-01"),
+                max: day("2020-11-01"),
+                ticks: [
+                    { value: day("2020-01-01"), priority: 2 },
+                    { value: day("2020-06-01"), priority: 2 },
+                    { value: day("2020-11-01"), priority: 2 },
+                ],
+            })
+        )
+        axis.formatColumn = table.get("month")
+        axis.range = [0, 800]
+
+        const labels = axis.tickLabels.map((tick) => tick.formattedValue)
+        expect(labels).toEqual(["Jan 2020", "Jun 2020", "Nov 2020"])
+    })
+
+    it("labels every bar with month + year on a discrete monthly axis", () => {
+        const day = (date: string): number =>
+            convertDateToDaysSinceEpoch(dayjs.utc(date))
+        const bandValues = ["2020-01-01", "2020-04-01", "2020-07-01"].map(day)
+        const table = new OwidTable({ entityName: ["usa"], month: [0] }, [
+            { slug: "month", type: ColumnTypeNames.Month },
+        ])
+        const axis = new HorizontalAxis(
+            new AxisConfig({
+                scaleType: ScaleType.linear,
+                min: bandValues[0],
+                max: bandValues[bandValues.length - 1],
+                bandValues,
+            })
+        )
+        axis.formatColumn = table.get("month")
+        axis.range = [0, 800]
+
+        // one tick per bar, each keeping its full month + year
+        expect(axis.getTickValues().map((t) => t.label)).toEqual([
+            "Jan 2020",
+            "Apr 2020",
+            "Jul 2020",
+        ])
+    })
+
+    it("thins a discrete monthly axis to a uniform cadence (no ragged gaps)", () => {
+        const monthlyDomain = (
+            startYear: number,
+            endYear: number
+        ): number[] => {
+            const values: number[] = []
+            for (let y = startYear; y <= endYear; y++)
+                for (let m = 1; m <= 12; m++)
+                    values.push(
+                        convertDateToDaysSinceEpoch(
+                            dayjs.utc(`${y}-${String(m).padStart(2, "0")}-01`)
+                        )
+                    )
+            return values
+        }
+        const monthIndex = (value: number): number => {
+            const d = convertDaysSinceEpochToDate(value)
+            return d.year() * 12 + d.month()
+        }
+        const table = new OwidTable({ entityName: ["usa"], month: [0] }, [
+            { slug: "month", type: ColumnTypeNames.Month },
+        ])
+
+        const bandValues = monthlyDomain(2016, 2023)
+        const tickCountAt = (width: number): number => {
+            const axis = new HorizontalAxis(
+                new AxisConfig({
+                    scaleType: ScaleType.linear,
+                    min: bandValues[0],
+                    max: bandValues[bandValues.length - 1],
+                    bandValues,
+                })
+            )
+            axis.formatColumn = table.get("month")
+            axis.range = [0, width]
+
+            const months = axis.tickLabels
+                .map((label) => monthIndex(label.value))
+                .sort((a, b) => a - b)
+            const gaps = months.slice(1).map((m, i) => m - months[i])
+            // every gap identical → a single uniform tier, never ragged (0 gaps
+            // when only one tick survives)
+            expect(new Set(gaps).size).toBeLessThanOrEqual(1)
+            return months.length
+        }
+
+        const narrow = tickCountAt(120)
+        const wide = tickCountAt(2000)
+        expect(wide).toBeGreaterThan(1) // a wide axis shows a real cadence
+        expect(wide).toBeGreaterThanOrEqual(narrow) // wider fits at least as many
+    })
+
+    it("keeps monthly ticks aligned when min/max are not month boundaries", () => {
+        const day = (date: string): number =>
+            convertDateToDaysSinceEpoch(dayjs.utc(date))
+        const min = day("2020-01-15")
+        const max = day("2022-12-20")
+
+        const axis = makeMonthlyTimeAxis("2020-01-15", "2022-12-20")
+        const values = axis.getTickValues().map((tick) => tick.value)
+
+        expect(values.length).toBeGreaterThan(0)
+        for (const value of values)
+            expect(convertDaysSinceEpochToDate(value).date()).toBe(1)
+        // at least one generated tick falls in the actual requested range
+        expect(values.some((value) => value >= min && value <= max)).toBe(true)
+    })
+
+    it("keeps January boundaries on the grid across sparse and dense cadences", () => {
+        const day = (date: string): number =>
+            convertDateToDaysSinceEpoch(dayjs.utc(date))
+
+        const sparse = makeMonthlyTimeAxis("2020-01-01", "2022-12-01", 4)
+            .getTickValues()
+            .map((tick) => tick.value)
+        const dense = makeMonthlyTimeAxis("2020-01-01", "2022-12-01", 20)
+            .getTickValues()
+            .map((tick) => tick.value)
+
+        for (const values of [sparse, dense]) {
+            expect(values).toContain(day("2021-01-01"))
+            expect(values).toContain(day("2022-01-01"))
+        }
+    })
+
+    it("uses sensible month labels when maxTicks is very low", () => {
+        const labels = makeMonthlyTimeAxis(
+            "2020-01-01",
+            "2022-12-01",
+            1
+        ).tickLabels.map((tick) => tick.formattedValue)
+
+        expect(labels.length).toBeGreaterThanOrEqual(1)
+        for (const label of labels)
+            expect(label).toMatch(/^(\d{4}|[A-Z][a-z]{2}( \d{4})?)$/)
+    })
+
+    it("does not invent missing months on an irregular discrete monthly domain", () => {
+        const day = (date: string): number =>
+            convertDateToDaysSinceEpoch(dayjs.utc(date))
+        const bandValues = [
+            day("2020-01-01"),
+            day("2020-03-01"),
+            day("2020-10-01"),
+        ]
+        const table = new OwidTable({ entityName: ["usa"], month: [0] }, [
+            { slug: "month", type: ColumnTypeNames.Month },
+        ])
+        const axis = new HorizontalAxis(
+            new AxisConfig({
+                scaleType: ScaleType.linear,
+                min: bandValues[0],
+                max: bandValues[bandValues.length - 1],
+                bandValues,
+            })
+        )
+        axis.formatColumn = table.get("month")
+        axis.range = [0, 800]
+
+        const values = axis.getTickValues().map((tick) => tick.value)
+        expect(values).toEqual(bandValues)
     })
 })

--- a/packages/@ourworldindata/grapher/src/axis/Axis.test.ts
+++ b/packages/@ourworldindata/grapher/src/axis/Axis.test.ts
@@ -463,6 +463,32 @@ describe("for months", () => {
         expect(wide).toBeGreaterThanOrEqual(narrow) // wider fits at least as many
     })
 
+    it("labels every band value with its quarter on a discrete quarterly axis", () => {
+        const day = (date: string): number =>
+            convertDateToDaysSinceEpoch(dayjs.utc(date))
+        const bandValues = ["2020-01-01", "2020-04-01", "2020-07-01"].map(day)
+        const table = new OwidTable({ entityName: ["usa"], quarter: [0] }, [
+            { slug: "quarter", type: ColumnTypeNames.Quarter },
+        ])
+        const axis = new HorizontalAxis(
+            new AxisConfig({
+                scaleType: ScaleType.linear,
+                min: bandValues[0],
+                max: bandValues[bandValues.length - 1],
+                bandValues,
+            })
+        )
+        axis.formatColumn = table.get("quarter")
+        axis.range = [0, 800]
+
+        // one tick per band value, labeled with the column's quarter format
+        expect(axis.tickLabels.map((t) => t.formattedValue)).toEqual([
+            "Q1 2020",
+            "Q2 2020",
+            "Q3 2020",
+        ])
+    })
+
     it("falls back to overlap-hiding when no evenly-spaced option fits on a daily band axis", () => {
         const day = (date: string): number =>
             convertDateToDaysSinceEpoch(dayjs.utc(date))

--- a/packages/@ourworldindata/grapher/src/axis/Axis.test.ts
+++ b/packages/@ourworldindata/grapher/src/axis/Axis.test.ts
@@ -385,7 +385,7 @@ describe("for months", () => {
         expect(labels).toEqual(["Jan 2020", "Jun 2020", "Nov 2020"])
     })
 
-    it("labels every bar with month + year on a discrete monthly axis", () => {
+    it("labels every band value with month + year on a discrete monthly axis", () => {
         const day = (date: string): number =>
             convertDateToDaysSinceEpoch(dayjs.utc(date))
         const bandValues = ["2020-01-01", "2020-04-01", "2020-07-01"].map(day)
@@ -403,8 +403,8 @@ describe("for months", () => {
         axis.formatColumn = table.get("month")
         axis.range = [0, 800]
 
-        // one tick per bar, each keeping its full month + year
-        expect(axis.getTickValues().map((t) => t.label)).toEqual([
+        // one tick per band value, labeled with the column's full month + year format
+        expect(axis.tickLabels.map((t) => t.formattedValue)).toEqual([
             "Jan 2020",
             "Apr 2020",
             "Jul 2020",
@@ -461,6 +461,42 @@ describe("for months", () => {
         const wide = tickCountAt(2000)
         expect(wide).toBeGreaterThan(1) // a wide axis shows a real cadence
         expect(wide).toBeGreaterThanOrEqual(narrow) // wider fits at least as many
+    })
+
+    it("falls back to overlap-hiding when no evenly-spaced option fits on a daily band axis", () => {
+        const day = (date: string): number =>
+            convertDateToDaysSinceEpoch(dayjs.utc(date))
+        // Irregular dates — no Mondays, no first-of-month — so the only
+        // evenly-spaced labeling option is labeling every value
+        const bandValues = [
+            "2020-03-03",
+            "2020-03-06",
+            "2020-03-07",
+            "2020-03-12",
+            "2020-03-13",
+            "2020-03-17",
+            "2020-03-20",
+            "2020-03-26",
+        ].map(day)
+        const table = new OwidTable({ entityName: ["usa"], day: [0] }, [
+            { slug: "day", type: ColumnTypeNames.Day },
+        ])
+        const axis = new HorizontalAxis(
+            new AxisConfig({
+                scaleType: ScaleType.linear,
+                min: bandValues[0],
+                max: bandValues[bandValues.length - 1],
+                bandValues,
+            })
+        )
+        axis.formatColumn = table.get("day")
+        axis.range = [0, 120] // far too narrow to label every value
+
+        // labeling every value does not fit, so the axis greedily
+        // drops overlapping labels instead of rendering them all
+        const labels = axis.tickLabels
+        expect(labels.length).toBeGreaterThan(0)
+        expect(labels.length).toBeLessThan(bandValues.length)
     })
 
     it("keeps monthly ticks aligned when min/max are not month boundaries", () => {

--- a/packages/@ourworldindata/grapher/src/axis/Axis.test.ts
+++ b/packages/@ourworldindata/grapher/src/axis/Axis.test.ts
@@ -332,7 +332,7 @@ describe("for months", () => {
     it("drops repeated years on a sub-year monthly axis, keeping months and Januaries", () => {
         const labels = makeMonthlyTimeAxis(
             "2020-03-01",
-            "2022-11-01",
+            "2021-11-01",
             8
         ).tickLabels.map((tick) => tick.formattedValue)
 
@@ -341,9 +341,22 @@ describe("for months", () => {
             expect(label).toMatch(/^[A-Z][a-z]{2}( \d{4})?$/)
         // the year rides along on each January
         expect(labels).toContain("Jan 2021")
-        expect(labels).toContain("Jan 2022")
         // ...but not on the intervening months
         expect(labels).toContain("Jul")
+    })
+
+    it("keeps the year on every tick of a half-yearly axis", () => {
+        // At a 6-month step, half the ticks are Januaries carrying the year
+        // anyway, so all ticks get it for consistency
+        const labels = makeMonthlyTimeAxis(
+            "2020-03-01",
+            "2022-11-01",
+            8
+        ).tickLabels.map((tick) => tick.formattedValue)
+
+        for (const label of labels)
+            expect(label).toMatch(/^[A-Z][a-z]{2} \d{4}$/)
+        expect(labels).toContain("Jul 2021")
     })
 
     it("labels a yearly-cadence monthly axis with bare years only", () => {

--- a/packages/@ourworldindata/grapher/src/axis/Axis.test.ts
+++ b/packages/@ourworldindata/grapher/src/axis/Axis.test.ts
@@ -18,7 +18,52 @@ import {
     dayjs,
     convertDateToDaysSinceEpoch,
     convertDaysSinceEpochToDate,
+    Tickmark,
 } from "@ourworldindata/utils"
+
+// Day-since-epoch for a "YYYY-MM-DD" date
+const day = (date: string): number =>
+    convertDateToDaysSinceEpoch(dayjs.utc(date))
+
+/** A horizontal time axis over a column of the given time type */
+function makeTimeAxis({
+    columnType = ColumnTypeNames.Month,
+    min,
+    max,
+    maxTicks,
+    ticks,
+    bandValues,
+    range = [0, 800],
+    hideFractionalTicks = false,
+}: {
+    columnType?: ColumnTypeNames
+    min?: number
+    max?: number
+    maxTicks?: number
+    ticks?: Tickmark[]
+    bandValues?: number[]
+    range?: [number, number]
+    hideFractionalTicks?: boolean
+}): HorizontalAxis {
+    const slug = "timeValue"
+    const table = new OwidTable({ entityName: ["usa"], [slug]: [0] }, [
+        { slug, type: columnType },
+    ])
+    const axis = new HorizontalAxis(
+        new AxisConfig({
+            scaleType: ScaleType.linear,
+            min: min ?? bandValues?.[0],
+            max: max ?? (bandValues ? R.last(bandValues) : undefined),
+            maxTicks,
+            ticks,
+            bandValues,
+        })
+    )
+    axis.formatColumn = table.get(slug)
+    axis.hideFractionalTicks = hideFractionalTicks
+    axis.range = range
+    return axis
+}
 
 it("can create an axis", () => {
     const axisConfig = new AxisConfig({
@@ -289,35 +334,13 @@ describe("manual ticks", () => {
     })
 })
 
-describe("for months", () => {
-    function makeMonthlyTimeAxis(
-        min: string,
-        max: string,
-        maxTicks?: number
-    ): HorizontalAxis {
-        const day = (date: string): number =>
-            convertDateToDaysSinceEpoch(dayjs.utc(date))
-        const table = new OwidTable({ entityName: ["usa"], month: [0] }, [
-            { slug: "month", type: ColumnTypeNames.Month },
-        ])
-        const axis = new HorizontalAxis(
-            new AxisConfig({
-                scaleType: ScaleType.linear,
-                min: day(min),
-                max: day(max),
-                ...(maxTicks !== undefined ? { maxTicks } : {}),
-            })
-        )
-        axis.formatColumn = table.get("month")
-        axis.hideFractionalTicks = true
-        axis.range = [0, 800]
-        return axis
-    }
-
+describe("calendar-aware time ticks", () => {
     it("places monthly time-axis ticks on first-of-month, January-anchored boundaries", () => {
-        const day = (date: string): number =>
-            convertDateToDaysSinceEpoch(dayjs.utc(date))
-        const axis = makeMonthlyTimeAxis("2020-01-01", "2022-12-01")
+        const axis = makeTimeAxis({
+            min: day("2020-01-01"),
+            max: day("2022-12-01"),
+            hideFractionalTicks: true,
+        })
 
         const values = axis.getTickValues().map((tick) => tick.value)
 
@@ -330,11 +353,12 @@ describe("for months", () => {
     })
 
     it("drops repeated years on a sub-year monthly axis, keeping months and Januaries", () => {
-        const labels = makeMonthlyTimeAxis(
-            "2020-03-01",
-            "2021-11-01",
-            8
-        ).tickLabels.map((tick) => tick.formattedValue)
+        const labels = makeTimeAxis({
+            min: day("2020-03-01"),
+            max: day("2021-11-01"),
+            maxTicks: 8,
+            hideFractionalTicks: true,
+        }).tickLabels.map((tick) => tick.formattedValue)
 
         // no bare year: every label is a month, optionally with a year
         for (const label of labels)
@@ -348,11 +372,12 @@ describe("for months", () => {
     it("keeps the year on every tick of a half-yearly axis", () => {
         // At a 6-month step, half the ticks are Januaries carrying the year
         // anyway, so all ticks get it for consistency
-        const labels = makeMonthlyTimeAxis(
-            "2020-03-01",
-            "2022-11-01",
-            8
-        ).tickLabels.map((tick) => tick.formattedValue)
+        const labels = makeTimeAxis({
+            min: day("2020-03-01"),
+            max: day("2022-11-01"),
+            maxTicks: 8,
+            hideFractionalTicks: true,
+        }).tickLabels.map((tick) => tick.formattedValue)
 
         for (const label of labels)
             expect(label).toMatch(/^[A-Z][a-z]{2} \d{4}$/)
@@ -360,11 +385,12 @@ describe("for months", () => {
     })
 
     it("labels a yearly-cadence monthly axis with bare years only", () => {
-        const labels = makeMonthlyTimeAxis(
-            "2000-01-01",
-            "2020-01-01",
-            6
-        ).tickLabels.map((tick) => tick.formattedValue)
+        const labels = makeTimeAxis({
+            min: day("2000-01-01"),
+            max: day("2020-01-01"),
+            maxTicks: 6,
+            hideFractionalTicks: true,
+        }).tickLabels.map((tick) => tick.formattedValue)
 
         expect(labels.length).toBeGreaterThan(1)
         for (const label of labels) expect(label).toMatch(/^\d{4}$/)
@@ -374,47 +400,23 @@ describe("for months", () => {
         // Custom ticks (as stacked bars / slope / sparkline set) get thinned by
         // overlap-hiding after labeling, so the year-suppression is skipped and every
         // label keeps its year — even same-year ticks.
-        const day = (date: string): number =>
-            convertDateToDaysSinceEpoch(dayjs.utc(date))
-        const table = new OwidTable({ entityName: ["usa"], month: [0] }, [
-            { slug: "month", type: ColumnTypeNames.Month },
-        ])
-        const axis = new HorizontalAxis(
-            new AxisConfig({
-                scaleType: ScaleType.linear,
-                min: day("2020-01-01"),
-                max: day("2020-11-01"),
-                ticks: [
-                    { value: day("2020-01-01"), priority: 2 },
-                    { value: day("2020-06-01"), priority: 2 },
-                    { value: day("2020-11-01"), priority: 2 },
-                ],
-            })
-        )
-        axis.formatColumn = table.get("month")
-        axis.range = [0, 800]
+        const axis = makeTimeAxis({
+            min: day("2020-01-01"),
+            max: day("2020-11-01"),
+            ticks: [
+                { value: day("2020-01-01"), priority: 2 },
+                { value: day("2020-06-01"), priority: 2 },
+                { value: day("2020-11-01"), priority: 2 },
+            ],
+        })
 
         const labels = axis.tickLabels.map((tick) => tick.formattedValue)
         expect(labels).toEqual(["Jan 2020", "Jun 2020", "Nov 2020"])
     })
 
     it("labels every band value with month + year on a discrete monthly axis", () => {
-        const day = (date: string): number =>
-            convertDateToDaysSinceEpoch(dayjs.utc(date))
         const bandValues = ["2020-01-01", "2020-04-01", "2020-07-01"].map(day)
-        const table = new OwidTable({ entityName: ["usa"], month: [0] }, [
-            { slug: "month", type: ColumnTypeNames.Month },
-        ])
-        const axis = new HorizontalAxis(
-            new AxisConfig({
-                scaleType: ScaleType.linear,
-                min: bandValues[0],
-                max: bandValues[bandValues.length - 1],
-                bandValues,
-            })
-        )
-        axis.formatColumn = table.get("month")
-        axis.range = [0, 800]
+        const axis = makeTimeAxis({ bandValues })
 
         // one tick per band value, labeled with the column's full month + year format
         expect(axis.tickLabels.map((t) => t.formattedValue)).toEqual([
@@ -432,33 +434,17 @@ describe("for months", () => {
             const values: number[] = []
             for (let y = startYear; y <= endYear; y++)
                 for (let m = 1; m <= 12; m++)
-                    values.push(
-                        convertDateToDaysSinceEpoch(
-                            dayjs.utc(`${y}-${String(m).padStart(2, "0")}-01`)
-                        )
-                    )
+                    values.push(day(`${y}-${String(m).padStart(2, "0")}-01`))
             return values
         }
         const monthIndex = (value: number): number => {
             const d = convertDaysSinceEpochToDate(value)
             return d.year() * 12 + d.month()
         }
-        const table = new OwidTable({ entityName: ["usa"], month: [0] }, [
-            { slug: "month", type: ColumnTypeNames.Month },
-        ])
 
         const bandValues = monthlyDomain(2016, 2023)
         const tickCountAt = (width: number): number => {
-            const axis = new HorizontalAxis(
-                new AxisConfig({
-                    scaleType: ScaleType.linear,
-                    min: bandValues[0],
-                    max: bandValues[bandValues.length - 1],
-                    bandValues,
-                })
-            )
-            axis.formatColumn = table.get("month")
-            axis.range = [0, width]
+            const axis = makeTimeAxis({ bandValues, range: [0, width] })
 
             const months = axis.tickLabels
                 .map((label) => monthIndex(label.value))
@@ -477,22 +463,11 @@ describe("for months", () => {
     })
 
     it("labels every band value with its quarter on a discrete quarterly axis", () => {
-        const day = (date: string): number =>
-            convertDateToDaysSinceEpoch(dayjs.utc(date))
         const bandValues = ["2020-01-01", "2020-04-01", "2020-07-01"].map(day)
-        const table = new OwidTable({ entityName: ["usa"], quarter: [0] }, [
-            { slug: "quarter", type: ColumnTypeNames.Quarter },
-        ])
-        const axis = new HorizontalAxis(
-            new AxisConfig({
-                scaleType: ScaleType.linear,
-                min: bandValues[0],
-                max: bandValues[bandValues.length - 1],
-                bandValues,
-            })
-        )
-        axis.formatColumn = table.get("quarter")
-        axis.range = [0, 800]
+        const axis = makeTimeAxis({
+            columnType: ColumnTypeNames.Quarter,
+            bandValues,
+        })
 
         // one tick per band value, labeled with the column's quarter format
         expect(axis.tickLabels.map((t) => t.formattedValue)).toEqual([
@@ -503,8 +478,6 @@ describe("for months", () => {
     })
 
     it("falls back to overlap-hiding when no evenly-spaced option fits on a daily band axis", () => {
-        const day = (date: string): number =>
-            convertDateToDaysSinceEpoch(dayjs.utc(date))
         // Irregular dates — no Mondays, no first-of-month — so the only
         // evenly-spaced labeling option is labeling every value
         const bandValues = [
@@ -517,19 +490,11 @@ describe("for months", () => {
             "2020-03-20",
             "2020-03-26",
         ].map(day)
-        const table = new OwidTable({ entityName: ["usa"], day: [0] }, [
-            { slug: "day", type: ColumnTypeNames.Day },
-        ])
-        const axis = new HorizontalAxis(
-            new AxisConfig({
-                scaleType: ScaleType.linear,
-                min: bandValues[0],
-                max: bandValues[bandValues.length - 1],
-                bandValues,
-            })
-        )
-        axis.formatColumn = table.get("day")
-        axis.range = [0, 120] // far too narrow to label every value
+        const axis = makeTimeAxis({
+            columnType: ColumnTypeNames.Day,
+            bandValues,
+            range: [0, 120], // far too narrow to label every value
+        })
 
         // labeling every value does not fit, so the axis greedily
         // drops overlapping labels instead of rendering them all
@@ -539,12 +504,10 @@ describe("for months", () => {
     })
 
     it("keeps monthly ticks aligned when min/max are not month boundaries", () => {
-        const day = (date: string): number =>
-            convertDateToDaysSinceEpoch(dayjs.utc(date))
         const min = day("2020-01-15")
         const max = day("2022-12-20")
 
-        const axis = makeMonthlyTimeAxis("2020-01-15", "2022-12-20")
+        const axis = makeTimeAxis({ min, max, hideFractionalTicks: true })
         const values = axis.getTickValues().map((tick) => tick.value)
 
         expect(values.length).toBeGreaterThan(0)
@@ -555,28 +518,29 @@ describe("for months", () => {
     })
 
     it("keeps January boundaries on the grid across sparse and dense cadences", () => {
-        const day = (date: string): number =>
-            convertDateToDaysSinceEpoch(dayjs.utc(date))
+        const tickValuesAt = (maxTicks: number): number[] =>
+            makeTimeAxis({
+                min: day("2020-01-01"),
+                max: day("2022-12-01"),
+                maxTicks,
+                hideFractionalTicks: true,
+            })
+                .getTickValues()
+                .map((tick) => tick.value)
 
-        const sparse = makeMonthlyTimeAxis("2020-01-01", "2022-12-01", 4)
-            .getTickValues()
-            .map((tick) => tick.value)
-        const dense = makeMonthlyTimeAxis("2020-01-01", "2022-12-01", 20)
-            .getTickValues()
-            .map((tick) => tick.value)
-
-        for (const values of [sparse, dense]) {
+        for (const values of [tickValuesAt(4), tickValuesAt(20)]) {
             expect(values).toContain(day("2021-01-01"))
             expect(values).toContain(day("2022-01-01"))
         }
     })
 
     it("uses sensible month labels when maxTicks is very low", () => {
-        const labels = makeMonthlyTimeAxis(
-            "2020-01-01",
-            "2022-12-01",
-            1
-        ).tickLabels.map((tick) => tick.formattedValue)
+        const labels = makeTimeAxis({
+            min: day("2020-01-01"),
+            max: day("2022-12-01"),
+            maxTicks: 1,
+            hideFractionalTicks: true,
+        }).tickLabels.map((tick) => tick.formattedValue)
 
         expect(labels.length).toBeGreaterThanOrEqual(1)
         for (const label of labels)
@@ -584,26 +548,12 @@ describe("for months", () => {
     })
 
     it("does not invent missing months on an irregular discrete monthly domain", () => {
-        const day = (date: string): number =>
-            convertDateToDaysSinceEpoch(dayjs.utc(date))
         const bandValues = [
             day("2020-01-01"),
             day("2020-03-01"),
             day("2020-10-01"),
         ]
-        const table = new OwidTable({ entityName: ["usa"], month: [0] }, [
-            { slug: "month", type: ColumnTypeNames.Month },
-        ])
-        const axis = new HorizontalAxis(
-            new AxisConfig({
-                scaleType: ScaleType.linear,
-                min: bandValues[0],
-                max: bandValues[bandValues.length - 1],
-                bandValues,
-            })
-        )
-        axis.formatColumn = table.get("month")
-        axis.range = [0, 800]
+        const axis = makeTimeAxis({ bandValues })
 
         const values = axis.getTickValues().map((tick) => tick.value)
         expect(values).toEqual(bandValues)

--- a/packages/@ourworldindata/grapher/src/axis/Axis.ts
+++ b/packages/@ourworldindata/grapher/src/axis/Axis.ts
@@ -14,13 +14,13 @@ import {
     Tickmark,
     ValueRange,
     OwidVariableRoundingMode,
+    isSubYearly,
 } from "@ourworldindata/utils"
 import { ComparisonLineConfig } from "@ourworldindata/types"
 import { AxisConfig, AxisManager } from "./AxisConfig"
 import {
     buildTimeAxisTicks,
     getDiscreteTimeTickOptions,
-    isCalendarTickInterval,
     type CalendarTickInterval,
 } from "./timeAxisTicks.js"
 import { MarkdownTextWrap } from "@ourworldindata/components"
@@ -342,7 +342,7 @@ abstract class AbstractAxis {
         | undefined {
         const column = this.formatColumn
         if (this.config.ticks || !column?.isTimeColumn) return undefined
-        return isCalendarTickInterval(column.timeInterval)
+        return isSubYearly(column.timeInterval)
             ? column.timeInterval
             : undefined
     }

--- a/packages/@ourworldindata/grapher/src/axis/Axis.ts
+++ b/packages/@ourworldindata/grapher/src/axis/Axis.ts
@@ -19,7 +19,9 @@ import { ComparisonLineConfig } from "@ourworldindata/types"
 import { AxisConfig, AxisManager } from "./AxisConfig"
 import {
     buildTimeAxisTicks,
-    getDiscreteMonthlyTickOptions,
+    getDiscreteTimeTickOptions,
+    isCalendarTickInterval,
+    type CalendarTickInterval,
 } from "./timeAxisTicks.js"
 import { MarkdownTextWrap } from "@ourworldindata/components"
 import { CoreColumn } from "@ourworldindata/core-table"
@@ -330,15 +332,30 @@ abstract class AbstractAxis {
     }
 
     /**
+     * The time interval for which this axis shows calendar-aware ticks, or
+     * `undefined` if the axis uses the generic tick pipeline instead (because
+     * ticks are author-supplied, the column isn't a time column, or its
+     * interval has no calendar-aware handling).
+     */
+    @computed protected get calendarTickInterval():
+        | CalendarTickInterval
+        | undefined {
+        const column = this.formatColumn
+        if (this.config.ticks || !column?.isTimeColumn) return undefined
+        return isCalendarTickInterval(column.timeInterval)
+            ? column.timeInterval
+            : undefined
+    }
+
+    /**
      * Calendar-aware ticks (values + labels) for time axes that support them;
      * `undefined` otherwise, so the axis falls through to the generic pipeline.
      */
     @computed protected get timeAxisTicks(): Tickmark[] | undefined {
-        if (this.config.ticks || !this.formatColumn?.isTimeColumn)
-            return undefined
+        if (this.calendarTickInterval === undefined) return undefined
 
         return buildTimeAxisTicks({
-            interval: this.formatColumn.timeInterval,
+            interval: this.calendarTickInterval,
             domain: this.domain,
             targetCount: this.totalTicksTarget,
             bandValues: this.config.bandValues,
@@ -741,19 +758,21 @@ export class HorizontalAxis extends AbstractAxis {
 
     @computed get tickLabels(): TickLabelPlacement[] {
         // A discrete (band) time axis shows a single evenly-spaced labeling:
-        // the finest one that fits (every month, then quarter, year, 2 years, …)
-        if (this.timeAxisTicks && this.config.bandValues) {
-            const options = getDiscreteMonthlyTickOptions({
-                bandValues: this.config.bandValues ?? [],
+        // the finest one that fits (every day, then week, month, quarter, year, …)
+        const interval = this.calendarTickInterval
+        if (interval !== undefined && this.config.bandValues) {
+            const options = getDiscreteTimeTickOptions({
+                interval,
+                bandValues: this.config.bandValues,
             })
-            let placedTickLabels: TickLabelPlacement[] = []
             for (const option of options) {
-                placedTickLabels = option.map((tick) =>
+                const placedTickLabels = option.map((tick) =>
                     this.placeTickLabel(tick.value, tick.label)
                 )
-                if (labelsFit(placedTickLabels, { padding: 3 })) break
+                if (labelsFit(placedTickLabels, { padding: 3 }))
+                    return placedTickLabels
             }
-            return placedTickLabels
+            // If no evenly-spaced option fits, fall through to the greedy labeling below
         }
 
         // Otherwise: place all ticks greedily drop individual overlaps.

--- a/packages/@ourworldindata/grapher/src/axis/Axis.ts
+++ b/packages/@ourworldindata/grapher/src/axis/Axis.ts
@@ -50,6 +50,9 @@ type Scale = ScaleLinear<number, number> | ScaleLogarithmic<number, number>
 
 const OUTER_PADDING = 4
 
+// An axis never shows more labels than this
+const MAX_TICK_LABEL_COUNT = 50
+
 const doIntersect = (bounds: Bounds, bounds2: Bounds): boolean => {
     return bounds.intersects(bounds2)
 }
@@ -766,6 +769,9 @@ export class HorizontalAxis extends AbstractAxis {
                 bandValues: this.config.bandValues,
             })
             for (const option of options) {
+                // Denser options can't fit, so don't bother measuring them
+                if (option.length > MAX_TICK_LABEL_COUNT) continue
+
                 const placedTickLabels = option.map((tick) =>
                     this.placeTickLabel(tick.value, tick.label)
                 )
@@ -775,7 +781,7 @@ export class HorizontalAxis extends AbstractAxis {
             // If no evenly-spaced option fits, fall through to the greedy labeling below
         }
 
-        // Otherwise: place all ticks greedily drop individual overlaps.
+        // Otherwise: place all ticks greedily, then drop individual overlaps.
         const placedTickLabels = _.sortBy(
             this.baseTicks,
             (tick) => tick.priority
@@ -1044,22 +1050,25 @@ export class DualAxis {
     }
 }
 
-/** Whether no two labels overlap, keeping at least `padding` of space between them. */
+/**
+ * Whether no two labels overlap, keeping at least `padding` of space between them.
+ *
+ * Expects `tickLabels` in the order they appear on the axis, so that it suffices
+ * to compare neighbours.
+ */
 function labelsFit(
     tickLabels: TickLabelPlacement[],
     { padding = 0 }: { padding?: number } = {}
 ): boolean {
-    for (let i = 0; i < tickLabels.length; i++) {
-        for (let j = i + 1; j < tickLabels.length; j++) {
-            if (
-                doIntersect(
-                    // Expand bounds so that labels aren't too close together
-                    boundsFromLabelPlacement(tickLabels[i]).expand(padding),
-                    boundsFromLabelPlacement(tickLabels[j]).expand(padding)
-                )
+    for (let i = 0; i < tickLabels.length - 1; i++) {
+        if (
+            doIntersect(
+                // Expand bounds so that labels aren't too close together
+                boundsFromLabelPlacement(tickLabels[i]).expand(padding),
+                boundsFromLabelPlacement(tickLabels[i + 1]).expand(padding)
             )
-                return false
-        }
+        )
+            return false
     }
     return true
 }

--- a/packages/@ourworldindata/grapher/src/axis/Axis.ts
+++ b/packages/@ourworldindata/grapher/src/axis/Axis.ts
@@ -17,6 +17,10 @@ import {
 } from "@ourworldindata/utils"
 import { ComparisonLineConfig } from "@ourworldindata/types"
 import { AxisConfig, AxisManager } from "./AxisConfig"
+import {
+    buildTimeAxisTicks,
+    getDiscreteMonthlyTickOptions,
+} from "./timeAxisTicks.js"
 import { MarkdownTextWrap } from "@ourworldindata/components"
 import { CoreColumn } from "@ourworldindata/core-table"
 import {
@@ -228,13 +232,13 @@ abstract class AbstractAxis {
 
     /**
      * Maximum width a single value can take up on the axis.
-     * Not meaningful if no domain values are given.
+     * Not meaningful if no band values are given.
      */
     @computed get bandWidth(): number | undefined {
-        const { domainValues } = this.config
-        if (!domainValues) return undefined
+        const { bandValues } = this.config
+        if (!bandValues) return undefined
         return AbstractAxis.calculateBandWidth({
-            values: domainValues,
+            values: bandValues,
             scale: this.d3_scale,
         })
     }
@@ -281,10 +285,10 @@ abstract class AbstractAxis {
             this.niceTicks = undefined
         }
 
-        if (this.config.domainValues) {
+        if (this.config.bandValues) {
             // compute bandwidth and adjust the scale
             const bandWidth = AbstractAxis.calculateBandWidth({
-                values: this.config.domainValues,
+                values: this.config.bandValues,
                 scale,
             })
             const offset = bandWidth / 2 + OUTER_PADDING
@@ -325,15 +329,41 @@ abstract class AbstractAxis {
         )
     }
 
+    /**
+     * Calendar-aware ticks (values + labels) for time axes that support them;
+     * `undefined` otherwise, so the axis falls through to the generic pipeline.
+     */
+    @computed protected get timeAxisTicks(): Tickmark[] | undefined {
+        if (this.config.ticks || !this.formatColumn?.isTimeColumn)
+            return undefined
+
+        return buildTimeAxisTicks({
+            interval: this.formatColumn.timeInterval,
+            domain: this.domain,
+            targetCount: this.totalTicksTarget,
+            bandValues: this.config.bandValues,
+        })
+    }
+
+    /** One labelled tick per discrete band */
+    @computed private get bandTicks(): Tickmark[] | undefined {
+        const { bandValues } = this.config
+        if (!bandValues) return undefined
+        return bandValues.map((value) => ({ value, priority: 2 }))
+    }
+
     getTickValues(): Tickmark[] {
-        const { d3_scale } = this
+        const { d3_scale, timeAxisTicks } = this
+
+        if (timeAxisTicks) return timeAxisTicks
 
         let ticks: Tickmark[]
 
-        if (this.config.ticks) {
+        const manualTicks = this.config.ticks ?? this.bandTicks
+        if (manualTicks) {
             // If custom ticks are supplied, use them without any transformations or additions.
             const [minValue, maxValue] = d3_scale.domain()
-            const processedTicks = this.config.ticks
+            const processedTicks = manualTicks
                 // replace ±Infinity with minimum/maximum
                 .map((tick) => {
                     if (tick.value === -Infinity)
@@ -673,6 +703,8 @@ export class HorizontalAxis extends AbstractAxis {
     }
 
     protected override get baseTicks(): Tickmark[] {
+        if (this.timeAxisTicks) return this.timeAxisTicks
+
         let ticks = this.getTickValues().filter(
             (tick): boolean => !tick.gridLineOnly
         )
@@ -708,19 +740,32 @@ export class HorizontalAxis extends AbstractAxis {
     }
 
     @computed get tickLabels(): TickLabelPlacement[] {
-        // Get ticks with coordinates, sorted by priority
-        const tickLabels = _.sortBy(
+        // A discrete (band) time axis shows a single evenly-spaced labeling:
+        // the finest one that fits (every month, then quarter, year, 2 years, …)
+        if (this.timeAxisTicks && this.config.bandValues) {
+            const options = getDiscreteMonthlyTickOptions({
+                bandValues: this.config.bandValues ?? [],
+            })
+            let placedTickLabels: TickLabelPlacement[] = []
+            for (const option of options) {
+                placedTickLabels = option.map((tick) =>
+                    this.placeTickLabel(tick.value, tick.label)
+                )
+                if (labelsFit(placedTickLabels, { padding: 3 })) break
+            }
+            return placedTickLabels
+        }
+
+        // Otherwise: place all ticks greedily drop individual overlaps.
+        const placedTickLabels = _.sortBy(
             this.baseTicks,
             (tick) => tick.priority
-        ).map((tick) => this.placeTickLabel(tick.value))
-        const visibleTickLabels = hideOverlappingTickLabels(tickLabels, {
-            padding: 3,
-        })
-        return visibleTickLabels
+        ).map((tick) => this.placeTickLabel(tick.value, tick.label))
+        return hideOverlappingTickLabels(placedTickLabels, { padding: 3 })
     }
 
-    placeTickLabel(value: number): TickLabelPlacement {
-        const formattedValue = this.formatTick(value)
+    placeTickLabel(value: number, label?: string): TickLabelPlacement {
+        const formattedValue = label ?? this.formatTick(value)
         const { width, height } = Bounds.forText(formattedValue, {
             fontSize: this.tickFontSize,
         })
@@ -980,6 +1025,30 @@ export class DualAxis {
     }
 }
 
+/** Whether no two labels overlap, keeping at least `padding` of space between them. */
+function labelsFit(
+    tickLabels: TickLabelPlacement[],
+    { padding = 0 }: { padding?: number } = {}
+): boolean {
+    for (let i = 0; i < tickLabels.length; i++) {
+        for (let j = i + 1; j < tickLabels.length; j++) {
+            if (
+                doIntersect(
+                    // Expand bounds so that labels aren't too close together
+                    boundsFromLabelPlacement(tickLabels[i]).expand(padding),
+                    boundsFromLabelPlacement(tickLabels[j]).expand(padding)
+                )
+            )
+                return false
+        }
+    }
+    return true
+}
+
+/**
+ * Drops each label that overlaps an earlier (higher-priority) one, returning the
+ * survivors. `padding` is the minimum space kept between them.
+ */
 function hideOverlappingTickLabels(
     tickLabels: TickLabelPlacement[],
     { padding = 0 }: { padding?: number } = {}
@@ -991,7 +1060,7 @@ function hideOverlappingTickLabels(
             if (t1 === t2 || t1.isHidden || t2.isHidden) continue
             if (
                 doIntersect(
-                    // Expand bounds so that labels aren't too close together.
+                    // Expand bounds so that labels aren't too close together
                     boundsFromLabelPlacement(t1).expand(padding),
                     boundsFromLabelPlacement(t2).expand(padding)
                 )

--- a/packages/@ourworldindata/grapher/src/axis/AxisConfig.ts
+++ b/packages/@ourworldindata/grapher/src/axis/AxisConfig.ts
@@ -45,7 +45,7 @@ class AxisConfigDefaults implements AxisConfigInterface {
     ticks: Tickmark[] | undefined = undefined
     singleValueAxisPointAlign: AxisAlign | undefined = undefined
     label: string | undefined = undefined
-    domainValues: number[] | undefined = undefined
+    bandValues: number[] | undefined = undefined
     shouldOffsetTickLabelAtStart: boolean | undefined = undefined
     shouldOffsetTickLabelAtEnd: boolean | undefined = undefined
 
@@ -70,7 +70,7 @@ class AxisConfigDefaults implements AxisConfigInterface {
             ticks: observable.ref,
             singleValueAxisPointAlign: observable.ref,
             label: observable.ref,
-            domainValues: observable.ref,
+            bandValues: observable.ref,
             shouldOffsetTickLabelAtStart: observable.ref,
             shouldOffsetTickLabelAtEnd: observable.ref,
         })
@@ -131,7 +131,7 @@ export class AxisConfig
             facetDomain: this.facetDomain,
             ticks: this.ticks,
             singleValueAxisPointAlign: this.singleValueAxisPointAlign,
-            domainValues: this.domainValues,
+            bandValues: this.bandValues,
         }) as AxisConfigInterface
 
         deleteRuntimeAndUnchangedProps(obj, new AxisConfigDefaults())

--- a/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.test.ts
+++ b/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.test.ts
@@ -214,6 +214,15 @@ describe(buildContinuousDailyAxisTicks, () => {
         ])
     })
 
+    it("keeps a day step whose in-domain ticks meet a target the raw span/step estimate exceeds", () => {
+        // 29 days / 14 is just over the target of 2, but only two biweekly
+        // Mondays land in the domain — prefer them over a single monthly tick
+        expect(gridDates("2020-03-04", "2020-04-02", 2)).toEqual([
+            "2020-03-16",
+            "2020-03-30",
+        ])
+    })
+
     it("continues on the monthly grid for multi-month spans", () => {
         const domain: [number, number] = [day("2020-01-01"), day("2020-07-01")]
         const ticks = buildContinuousDailyAxisTicks({ domain, targetCount: 6 })

--- a/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.test.ts
+++ b/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.test.ts
@@ -155,6 +155,16 @@ describe(buildContinuousMonthlyAxisTicks, () => {
             "Oct",
         ])
     })
+
+    it("keeps the year on every tick when at least half would carry it anyway", () => {
+        // Two of the three ticks (the first and the January) carry the year,
+        // so a lone year-less "Apr" would just look inconsistent
+        expect(labels("2020-09-15", "2021-05-01", 3)).toEqual([
+            "Oct 2020",
+            "Jan 2021",
+            "Apr 2021",
+        ])
+    })
 })
 
 describe(buildContinuousDailyAxisTicks, () => {
@@ -318,18 +328,20 @@ describe(buildContinuousQuarterlyAxisTicks, () => {
         ])
     })
 
-    it("steps by half-years for ~3-year spans, keeping the year on each January", () => {
+    it("steps by half-years for ~3-year spans, keeping the year on every tick", () => {
+        // Half the ticks are Januaries that carry the year anyway, so the
+        // alternation "Jan 2020 · Jul · Jan 2021" would just look inconsistent
         const ticks = buildContinuousQuarterlyAxisTicks({
             domain: [day("2020-01-01"), day("2022-07-01")],
             targetCount: 6,
         })!
         expect(ticks.map((t) => t.label)).toEqual([
             "Jan 2020",
-            "Jul",
+            "Jul 2020",
             "Jan 2021",
-            "Jul",
+            "Jul 2021",
             "Jan 2022",
-            "Jul",
+            "Jul 2022",
         ])
     })
 

--- a/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.test.ts
+++ b/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.test.ts
@@ -327,6 +327,16 @@ describe(buildContinuousWeeklyAxisTicks, () => {
         ])
     })
 
+    it("keeps the biweekly grid for same-month spans where no step meets the target", () => {
+        // No monthly grid exists within a single calendar month, so the
+        // coarsest week step wins over falling back to generic d3 ticks
+        expect(gridDates("2020-03-01", "2020-03-31", 2)).toEqual([
+            "2020-03-02",
+            "2020-03-16",
+            "2020-03-30",
+        ])
+    })
+
     it("continues on the monthly grid for multi-month spans", () => {
         const domain: [number, number] = [day("2020-01-06"), day("2020-07-06")]
         const ticks = buildContinuousWeeklyAxisTicks({ domain, targetCount: 6 })

--- a/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.test.ts
+++ b/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.test.ts
@@ -8,6 +8,8 @@ import { TimeInterval } from "@ourworldindata/types"
 import {
     buildTimeAxisTicks,
     buildDiscreteTimeAxisTicks,
+    buildContinuousQuarterlyAxisTicks,
+    getDiscreteQuarterlyTickOptions,
     buildContinuousMonthlyAxisTicks,
     getDiscreteMonthlyTickOptions,
     buildContinuousWeeklyAxisTicks,
@@ -280,6 +282,125 @@ describe(buildContinuousDailyAxisTicks, () => {
             expect(value).toBeGreaterThanOrEqual(minDay)
             expect(value).toBeLessThanOrEqual(maxDay)
         }
+    })
+})
+
+describe(buildContinuousQuarterlyAxisTicks, () => {
+    // The grid tick values, as YYYY-MM-DD (or undefined for a degenerate span).
+    const gridDates = (
+        min: string,
+        max: string,
+        targetCount: number
+    ): string[] | undefined => {
+        const ticks = buildContinuousQuarterlyAxisTicks({
+            domain: [day(min), day(max)],
+            targetCount,
+        })
+        return ticks && asDates(ticks.map((tick) => tick.value))
+    }
+
+    it("steps by quarter (Jan/Apr/Jul/Oct) across a ~1.5-year span", () => {
+        expect(gridDates("2020-01-01", "2021-06-01", 6)).toEqual([
+            "2020-01-01",
+            "2020-04-01",
+            "2020-07-01",
+            "2020-10-01",
+            "2021-01-01",
+            "2021-04-01",
+        ])
+    })
+
+    it("never steps below a quarter, even for short spans", () => {
+        // The monthly ladder would pick a 1-month step here
+        expect(gridDates("2023-01-01", "2023-07-01", 6)).toEqual([
+            "2023-01-01",
+            "2023-04-01",
+            "2023-07-01",
+        ])
+    })
+
+    it("steps by half-years for ~3-year spans, keeping the year on each January", () => {
+        const ticks = buildContinuousQuarterlyAxisTicks({
+            domain: [day("2020-01-01"), day("2022-07-01")],
+            targetCount: 6,
+        })!
+        expect(ticks.map((t) => t.label)).toEqual([
+            "Jan 2020",
+            "Jul",
+            "Jan 2021",
+            "Jul",
+            "Jan 2022",
+            "Jul",
+        ])
+    })
+
+    it("labels multi-year spans with bare years", () => {
+        const ticks = buildContinuousQuarterlyAxisTicks({
+            domain: [day("2015-06-15"), day("2022-03-01")],
+            targetCount: 6,
+        })!
+        expect(ticks.map((t) => t.label)).toEqual([
+            "2016",
+            "2018",
+            "2020",
+            "2022",
+        ])
+    })
+
+    it("returns undefined for a degenerate (single-quarter) span", () => {
+        expect(gridDates("2020-05-03", "2020-05-28", 6)).toBeUndefined()
+    })
+})
+
+describe(getDiscreteQuarterlyTickOptions, () => {
+    const quarterStarts = (startYear: number, endYear: number): number[] => {
+        const values: number[] = []
+        for (let y = startYear; y <= endYear; y++)
+            for (const m of ["01", "04", "07", "10"])
+                values.push(day(`${y}-${m}-01`))
+        return values
+    }
+    const monthGaps = (ticks: { value: number }[]): number[] => {
+        const idx = ticks.map((t) => {
+            const d = convertDaysSinceEpochToDate(t.value)
+            return d.year() * 12 + d.month()
+        })
+        return idx.slice(1).map((m, i) => m - idx[i])
+    }
+
+    // All quarters of 2018-2023
+    const options = getDiscreteQuarterlyTickOptions({
+        bandValues: quarterStarts(2018, 2023),
+    })
+
+    it("orders options from finest to coarsest", () => {
+        const counts = options.map((option) => option.length)
+        expect(counts).toEqual([...counts].sort((a, b) => b - a))
+    })
+
+    it("includes an every-other-quarter option", () => {
+        const halfYearly = options.find((option) => monthGaps(option)[0] === 6)!
+        expect(halfYearly).toHaveLength(12)
+    })
+
+    it("includes a yearly option of first quarters only", () => {
+        const yearly = options.find((option) => monthGaps(option)[0] === 12)!
+        expect(yearly).toHaveLength(6)
+        for (const tick of yearly)
+            expect(convertDaysSinceEpochToDate(tick.value).month()).toBe(0)
+    })
+
+    it("offers only the every-value option for off-grid quarter starts", () => {
+        // A Feb/May/Aug/Nov cadence doesn't lie on the January-anchored grid
+        const bandValues = [
+            "2020-02-01",
+            "2020-05-01",
+            "2020-08-01",
+            "2020-11-01",
+        ].map(day)
+        const options = getDiscreteQuarterlyTickOptions({ bandValues })
+        expect(options).toHaveLength(1)
+        expect(options[0].map((t) => t.value)).toEqual(bandValues)
     })
 })
 
@@ -576,6 +697,12 @@ describe(getDiscreteTimeTickOptions, () => {
                 bandValues,
             })
         ).toEqual(getDiscreteMonthlyTickOptions({ bandValues }))
+        expect(
+            getDiscreteTimeTickOptions({
+                interval: TimeInterval.Quarter,
+                bandValues,
+            })
+        ).toEqual(getDiscreteQuarterlyTickOptions({ bandValues }))
         expect(
             getDiscreteTimeTickOptions({
                 interval: TimeInterval.Week,

--- a/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.test.ts
+++ b/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.test.ts
@@ -4,10 +4,15 @@ import {
     convertDaysSinceEpochToDate,
     convertDateToDaysSinceEpoch,
 } from "@ourworldindata/utils"
+import { TimeInterval } from "@ourworldindata/types"
 import {
-    buildDiscreteMonthlyAxisTicks,
+    buildTimeAxisTicks,
+    buildDiscreteTimeAxisTicks,
     buildContinuousMonthlyAxisTicks,
     getDiscreteMonthlyTickOptions,
+    buildContinuousDailyAxisTicks,
+    getDiscreteDailyTickOptions,
+    getDiscreteTimeTickOptions,
 } from "./timeAxisTicks"
 
 // Day-since-epoch for a "YYYY-MM-DD" date
@@ -81,6 +86,16 @@ describe(buildContinuousMonthlyAxisTicks, () => {
         expect(gridDates("2020-05-03", "2020-05-28", 6)).toBeUndefined()
     })
 
+    it("drops grid ticks before a mid-month domain start", () => {
+        // The 2-month grid is anchored to January, but the domain only
+        // starts on Jan 5, so the Jan 1 tick is dropped
+        expect(gridDates("2020-01-05", "2020-08-20", 6)).toEqual([
+            "2020-03-01",
+            "2020-05-01",
+            "2020-07-01",
+        ])
+    })
+
     it("only produces first-of-month ticks within the domain", () => {
         const minDay = day("2015-07-15")
         const maxDay = day("2019-02-20")
@@ -139,24 +154,270 @@ describe(buildContinuousMonthlyAxisTicks, () => {
     })
 })
 
-describe(buildDiscreteMonthlyAxisTicks, () => {
-    it("labels every bar with month + year (the year is never dropped)", () => {
-        const ticks = buildDiscreteMonthlyAxisTicks({
+describe(buildContinuousDailyAxisTicks, () => {
+    // The grid tick values, as YYYY-MM-DD (or undefined for a degenerate span).
+    const gridDates = (
+        min: string,
+        max: string,
+        targetCount: number
+    ): string[] | undefined => {
+        const ticks = buildContinuousDailyAxisTicks({
+            domain: [day(min), day(max)],
+            targetCount,
+        })
+        return ticks && asDates(ticks.map((tick) => tick.value))
+    }
+
+    it("steps every day for short spans", () => {
+        expect(gridDates("2020-03-01", "2020-03-05", 6)).toEqual([
+            "2020-03-01",
+            "2020-03-02",
+            "2020-03-03",
+            "2020-03-04",
+            "2020-03-05",
+        ])
+    })
+
+    it("steps every other day on a grid that is stable when panning", () => {
+        const grid = [
+            "2020-03-01",
+            "2020-03-03",
+            "2020-03-05",
+            "2020-03-07",
+            "2020-03-09",
+        ]
+        expect(gridDates("2020-03-01", "2020-03-10", 6)).toEqual(grid)
+        // A domain start one day earlier keeps the same grid
+        expect(gridDates("2020-02-29", "2020-03-09", 6)).toEqual(grid)
+    })
+
+    it("steps weekly on Mondays", () => {
+        const dates = gridDates("2020-03-01", "2020-04-05", 6)!
+        expect(dates).toEqual([
+            "2020-03-02",
+            "2020-03-09",
+            "2020-03-16",
+            "2020-03-23",
+            "2020-03-30",
+        ])
+        for (const date of dates) expect(dayjs.utc(date).day()).toBe(1)
+    })
+
+    it("steps biweekly on Mondays for ~2-3 month spans", () => {
+        expect(gridDates("2020-03-01", "2020-05-15", 6)).toEqual([
+            "2020-03-02",
+            "2020-03-16",
+            "2020-03-30",
+            "2020-04-13",
+            "2020-04-27",
+            "2020-05-11",
+        ])
+    })
+
+    it("continues on the monthly grid for multi-month spans", () => {
+        const domain: [number, number] = [day("2020-01-01"), day("2020-07-01")]
+        const ticks = buildContinuousDailyAxisTicks({ domain, targetCount: 6 })
+        expect(ticks).toEqual(
+            buildContinuousMonthlyAxisTicks({ domain, targetCount: 6 })
+        )
+        expect(asDates(ticks!.map((t) => t.value))).toEqual([
+            "2020-01-01",
+            "2020-02-01",
+            "2020-03-01",
+            "2020-04-01",
+            "2020-05-01",
+            "2020-06-01",
+            "2020-07-01",
+        ])
+    })
+
+    it("labels multi-year spans with bare years", () => {
+        const ticks = buildContinuousDailyAxisTicks({
+            domain: [day("2015-06-15"), day("2022-03-01")],
+            targetCount: 6,
+        })!
+        expect(ticks.map((t) => t.label)).toEqual([
+            "2016",
+            "2018",
+            "2020",
+            "2022",
+        ])
+    })
+
+    it("shows the year on the first tick and wherever the year changes", () => {
+        const ticks = buildContinuousDailyAxisTicks({
+            domain: [day("2020-12-20"), day("2021-01-20")],
+            targetCount: 6,
+        })!
+        expect(ticks.map((t) => t.label)).toEqual([
+            "Dec 21, 2020",
+            "Dec 28",
+            "Jan 4, 2021",
+            "Jan 11",
+            "Jan 18",
+        ])
+    })
+
+    it("only produces ticks within the domain", () => {
+        const minDay = day("2020-03-04")
+        const maxDay = day("2020-04-02")
+        const ticks = buildContinuousDailyAxisTicks({
+            domain: [minDay, maxDay],
+            targetCount: 6,
+        })!
+        for (const { value } of ticks) {
+            expect(value).toBeGreaterThanOrEqual(minDay)
+            expect(value).toBeLessThanOrEqual(maxDay)
+        }
+    })
+})
+
+describe(buildDiscreteTimeAxisTicks, () => {
+    it("returns one tick per value, sorted and deduplicated", () => {
+        const ticks = buildDiscreteTimeAxisTicks({
             bandValues: [
-                "2020-01-01",
-                "2020-04-01",
-                "2020-07-01",
-                "2021-01-01",
-                "2021-04-01",
+                "2020-03-03",
+                "2020-03-01",
+                "2020-03-02",
+                "2020-03-01",
             ].map(day),
         })
-        expect(ticks.map((t) => t.label)).toEqual([
-            "Jan 2020",
-            "Apr 2020",
-            "Jul 2020",
-            "Jan 2021",
-            "Apr 2021",
+        expect(asDates(ticks.map((t) => t.value))).toEqual([
+            "2020-03-01",
+            "2020-03-02",
+            "2020-03-03",
         ])
+    })
+
+    it("leaves ticks unlabeled so the axis uses the column's own time format", () => {
+        const ticks = buildDiscreteTimeAxisTicks({
+            bandValues: ["2020-01-01", "2020-04-01"].map(day),
+        })
+        for (const tick of ticks) expect(tick.label).toBeUndefined()
+    })
+})
+
+describe(buildTimeAxisTicks, () => {
+    it("returns undefined for intervals without special handling", () => {
+        const bandValues = ["2020-01-01", "2021-01-01"].map(day)
+        const ticks = buildTimeAxisTicks({
+            interval: TimeInterval.Year,
+            domain: [bandValues[0], bandValues[1]],
+            targetCount: 6,
+            bandValues,
+        })
+        expect(ticks).toBeUndefined()
+    })
+})
+
+describe(getDiscreteDailyTickOptions, () => {
+    const dailyBars = (start: string, end: string): number[] => {
+        const values: number[] = []
+        for (let d = day(start); d <= day(end); d++) values.push(d)
+        return values
+    }
+    const dayGaps = (ticks: { value: number }[]): number[] =>
+        ticks.slice(1).map((t, i) => t.value - ticks[i].value)
+
+    const options = getDiscreteDailyTickOptions({
+        bandValues: dailyBars("2020-01-01", "2020-06-30"),
+    })
+
+    it("orders options from finest to coarsest", () => {
+        const counts = options.map((option) => option.length)
+        expect(counts).toEqual([...counts].sort((a, b) => b - a))
+    })
+
+    it("makes the day and week options a single uniform spacing", () => {
+        for (const option of options) {
+            const gaps = new Set(dayGaps(option))
+            // day/week tiers are uniform; monthly tiers step by
+            // calendar months, so their gaps vary by a few days
+            if ([...gaps].every((gap) => gap < 28))
+                expect(gaps.size).toBeLessThanOrEqual(1)
+        }
+    })
+
+    it("puts weekly and biweekly options on Mondays", () => {
+        const weekly = options.find((option) => dayGaps(option)[0] === 7)!
+        const biweekly = options.find((option) => dayGaps(option)[0] === 14)!
+        for (const tick of [...weekly, ...biweekly])
+            expect(convertDaysSinceEpochToDate(tick.value).day()).toBe(1)
+    })
+
+    it("puts monthly and coarser options on the first of the month", () => {
+        const monthly = options.filter((option) => dayGaps(option)[0] >= 28)
+        expect(monthly.length).toBeGreaterThan(0)
+        for (const option of monthly)
+            for (const tick of option)
+                expect(convertDaysSinceEpochToDate(tick.value).date()).toBe(1)
+    })
+
+    it("includes a quarterly option on first-of-month values", () => {
+        const quarterly = options.find((option) => option.length === 2)
+        expect(asDates(quarterly!.map((t) => t.value))).toEqual([
+            "2020-01-01",
+            "2020-04-01",
+        ])
+    })
+
+    it("never offers a ragged subset of irregular values", () => {
+        // Band values on irregular dates. The every-2nd-day grid *contains* four of
+        // them — Mar 7, 11, 17 and 21 — but with ragged gaps (4, 6 and 4
+        // days), because the values in between sit on odd days. Labeling that
+        // subset would look deliberate, so it must not be offered. With no
+        // Mondays or first-of-months either, the only option left is
+        // labeling every value.
+        const bandValues = [
+            "2020-03-06",
+            "2020-03-07",
+            "2020-03-10",
+            "2020-03-11",
+            "2020-03-17",
+            "2020-03-18",
+            "2020-03-21",
+        ].map(day)
+        const options = getDiscreteDailyTickOptions({ bandValues })
+        expect(options).toHaveLength(1)
+        expect(options[0].map((t) => t.value)).toEqual(bandValues)
+    })
+
+    it("thins weekly values to consecutive biweekly Mondays, never a ragged parity subset", () => {
+        // Band values on every Monday: the biweekly option must take every other
+        // Monday, and no option may have uneven gaps
+        const mondays = [
+            "2020-03-02",
+            "2020-03-09",
+            "2020-03-16",
+            "2020-03-23",
+            "2020-03-30",
+            "2020-04-06",
+            "2020-04-13",
+        ].map(day)
+        const options = getDiscreteDailyTickOptions({ bandValues: mondays })
+        for (const option of options)
+            expect(new Set(dayGaps(option)).size).toBeLessThanOrEqual(1)
+        const biweekly = options.find((option) => dayGaps(option)[0] === 14)
+        expect(biweekly!).toHaveLength(4)
+    })
+})
+
+describe(getDiscreteTimeTickOptions, () => {
+    const bandValues = ["2020-01-01", "2020-02-01", "2020-03-01"].map(day)
+
+    it("dispatches by time interval", () => {
+        expect(
+            getDiscreteTimeTickOptions({
+                interval: TimeInterval.Month,
+                bandValues,
+            })
+        ).toEqual(getDiscreteMonthlyTickOptions({ bandValues }))
+        expect(
+            getDiscreteTimeTickOptions({
+                interval: TimeInterval.Day,
+                bandValues,
+            })
+        ).toEqual(getDiscreteDailyTickOptions({ bandValues }))
     })
 })
 
@@ -191,16 +452,16 @@ describe(getDiscreteMonthlyTickOptions, () => {
         const twoYearOption = options.find(
             (option) => monthGaps(option)[0] === 24 // 2 years
         )
-        expect(twoYearOption?.map((t) => t.label)).toEqual([
-            "Jan 2010",
-            "Jan 2012",
-            "Jan 2014",
-            "Jan 2016",
-            "Jan 2018",
-            "Jan 2020",
-            "Jan 2022",
-            "Jan 2024",
-            "Jan 2026",
+        expect(asDates(twoYearOption!.map((t) => t.value))).toEqual([
+            "2010-01-01",
+            "2012-01-01",
+            "2014-01-01",
+            "2016-01-01",
+            "2018-01-01",
+            "2020-01-01",
+            "2022-01-01",
+            "2024-01-01",
+            "2026-01-01",
         ])
     })
 

--- a/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.test.ts
+++ b/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.test.ts
@@ -6,7 +6,6 @@ import {
 } from "@ourworldindata/utils"
 import { TimeInterval } from "@ourworldindata/types"
 import {
-    buildTimeAxisTicks,
     buildDiscreteTimeAxisTicks,
     buildContinuousQuarterlyAxisTicks,
     getDiscreteQuarterlyTickOptions,
@@ -568,19 +567,6 @@ describe(buildDiscreteTimeAxisTicks, () => {
             bandValues: ["2020-01-01", "2020-04-01"].map(day),
         })
         for (const tick of ticks) expect(tick.label).toBeUndefined()
-    })
-})
-
-describe(buildTimeAxisTicks, () => {
-    it("returns undefined for intervals without special handling", () => {
-        const bandValues = ["2020-01-01", "2021-01-01"].map(day)
-        const ticks = buildTimeAxisTicks({
-            interval: TimeInterval.Year,
-            domain: [bandValues[0], bandValues[1]],
-            targetCount: 6,
-            bandValues,
-        })
-        expect(ticks).toBeUndefined()
     })
 })
 

--- a/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.test.ts
+++ b/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.test.ts
@@ -10,6 +10,8 @@ import {
     buildDiscreteTimeAxisTicks,
     buildContinuousMonthlyAxisTicks,
     getDiscreteMonthlyTickOptions,
+    buildContinuousWeeklyAxisTicks,
+    getDiscreteWeeklyTickOptions,
     buildContinuousDailyAxisTicks,
     getDiscreteDailyTickOptions,
     getDiscreteTimeTickOptions,
@@ -281,6 +283,138 @@ describe(buildContinuousDailyAxisTicks, () => {
     })
 })
 
+describe(buildContinuousWeeklyAxisTicks, () => {
+    // The grid tick values, as YYYY-MM-DD (or undefined for a degenerate span).
+    const gridDates = (
+        min: string,
+        max: string,
+        targetCount: number
+    ): string[] | undefined => {
+        const ticks = buildContinuousWeeklyAxisTicks({
+            domain: [day(min), day(max)],
+            targetCount,
+        })
+        return ticks && asDates(ticks.map((tick) => tick.value))
+    }
+
+    it("steps weekly on Mondays for short spans", () => {
+        expect(gridDates("2020-03-02", "2020-04-06", 6)).toEqual([
+            "2020-03-02",
+            "2020-03-09",
+            "2020-03-16",
+            "2020-03-23",
+            "2020-03-30",
+            "2020-04-06",
+        ])
+    })
+
+    it("never steps below a week, even for tiny spans", () => {
+        // The daily ladder would pick a 2-day step here
+        expect(gridDates("2020-03-02", "2020-03-09", 6)).toEqual([
+            "2020-03-02",
+            "2020-03-09",
+        ])
+    })
+
+    it("steps biweekly on Mondays for ~2-3 month spans", () => {
+        expect(gridDates("2020-03-02", "2020-05-11", 6)).toEqual([
+            "2020-03-02",
+            "2020-03-16",
+            "2020-03-30",
+            "2020-04-13",
+            "2020-04-27",
+            "2020-05-11",
+        ])
+    })
+
+    it("continues on the monthly grid for multi-month spans", () => {
+        const domain: [number, number] = [day("2020-01-06"), day("2020-07-06")]
+        const ticks = buildContinuousWeeklyAxisTicks({ domain, targetCount: 6 })
+        expect(ticks).toEqual(
+            buildContinuousMonthlyAxisTicks({ domain, targetCount: 6 })
+        )
+    })
+
+    it("labels multi-year spans with bare years", () => {
+        const ticks = buildContinuousWeeklyAxisTicks({
+            domain: [day("2015-06-15"), day("2022-03-07")],
+            targetCount: 6,
+        })!
+        expect(ticks.map((t) => t.label)).toEqual([
+            "2016",
+            "2018",
+            "2020",
+            "2022",
+        ])
+    })
+
+    it("shows the year on the first tick and wherever the year changes", () => {
+        const ticks = buildContinuousWeeklyAxisTicks({
+            domain: [day("2020-12-14"), day("2021-01-25")],
+            targetCount: 6,
+        })!
+        expect(ticks.map((t) => t.label)).toEqual([
+            "Dec 14, 2020",
+            "Dec 21",
+            "Dec 28",
+            "Jan 4, 2021",
+            "Jan 11",
+            "Jan 18",
+            "Jan 25",
+        ])
+    })
+
+    it("returns undefined for a degenerate (single-week) span", () => {
+        expect(gridDates("2020-03-02", "2020-03-02", 6)).toBeUndefined()
+    })
+})
+
+describe(getDiscreteWeeklyTickOptions, () => {
+    // `count` consecutive Mondays, starting from a Monday
+    const weeklyValues = (firstMonday: string, count: number): number[] => {
+        const first = day(firstMonday)
+        return Array.from({ length: count }, (_, week) => first + 7 * week)
+    }
+    const dayGaps = (ticks: { value: number }[]): number[] =>
+        ticks.slice(1).map((t, i) => t.value - ticks[i].value)
+
+    // All Mondays of 2020 (Jan 6 through Dec 28)
+    const options = getDiscreteWeeklyTickOptions({
+        bandValues: weeklyValues("2020-01-06", 52),
+    })
+
+    it("orders options from finest to coarsest", () => {
+        const counts = options.map((option) => option.length)
+        expect(counts).toEqual([...counts].sort((a, b) => b - a))
+    })
+
+    it("includes a biweekly option on Mondays", () => {
+        const biweekly = options.find((option) => dayGaps(option)[0] === 14)!
+        expect(biweekly).toHaveLength(26)
+        for (const tick of biweekly)
+            expect(convertDaysSinceEpochToDate(tick.value).day()).toBe(1)
+    })
+
+    it("puts monthly and coarser options on each month's first week", () => {
+        const monthly = options.filter((option) => dayGaps(option)[0] > 14)
+        expect(monthly.length).toBeGreaterThan(0)
+        for (const option of monthly)
+            for (const tick of option) {
+                const date = convertDaysSinceEpochToDate(tick.value)
+                expect(date.day()).toBe(1) // still a week value (a Monday)
+                expect(date.date()).toBeLessThanOrEqual(7) // in the first week
+            }
+    })
+
+    it("offers only the every-value option for weeks on irregular dates", () => {
+        // Not Mondays, and none in a month's first week
+        const bandValues = ["2020-03-10", "2020-03-18", "2020-03-25"].map(day)
+        const options = getDiscreteWeeklyTickOptions({ bandValues })
+        expect(options).toHaveLength(1)
+        expect(options[0].map((t) => t.value)).toEqual(bandValues)
+    })
+})
+
 describe(buildDiscreteTimeAxisTicks, () => {
     it("returns one tick per value, sorted and deduplicated", () => {
         const ticks = buildDiscreteTimeAxisTicks({
@@ -432,6 +566,12 @@ describe(getDiscreteTimeTickOptions, () => {
                 bandValues,
             })
         ).toEqual(getDiscreteMonthlyTickOptions({ bandValues }))
+        expect(
+            getDiscreteTimeTickOptions({
+                interval: TimeInterval.Week,
+                bandValues,
+            })
+        ).toEqual(getDiscreteWeeklyTickOptions({ bandValues }))
         expect(
             getDiscreteTimeTickOptions({
                 interval: TimeInterval.Day,

--- a/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.test.ts
+++ b/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.test.ts
@@ -370,6 +370,17 @@ describe(getDiscreteDailyTickOptions, () => {
         ])
     })
 
+    it("never offers a single-label option", () => {
+        // Jul 1 is the range's only first-of-month and used to be offered as
+        // a lone calendar-anchored tick on the last band; instead, the axis
+        // should fall back to greedy labeling when no multi-label option fits
+        const options = getDiscreteDailyTickOptions({
+            bandValues: dailyBars("2025-06-07", "2025-07-01"),
+        })
+        for (const option of options)
+            expect(option.length).toBeGreaterThanOrEqual(2)
+    })
+
     it("never offers a ragged subset of irregular values", () => {
         // Band values on irregular dates. The every-2nd-day grid *contains* four of
         // them — Mar 7, 11, 17 and 21 — but with ragged gaps (4, 6 and 4

--- a/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.test.ts
+++ b/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.test.ts
@@ -1,0 +1,214 @@
+import { expect, it, describe } from "vitest"
+import {
+    dayjs,
+    convertDaysSinceEpochToDate,
+    convertDateToDaysSinceEpoch,
+} from "@ourworldindata/utils"
+import {
+    buildDiscreteMonthlyAxisTicks,
+    buildContinuousMonthlyAxisTicks,
+    getDiscreteMonthlyTickOptions,
+} from "./timeAxisTicks"
+
+// Day-since-epoch for a "YYYY-MM-DD" date
+const day = (date: string): number =>
+    convertDateToDaysSinceEpoch(dayjs.utc(date))
+
+const asDates = (ticks: number[]): string[] =>
+    ticks.map((t) => convertDaysSinceEpochToDate(t).format("YYYY-MM-DD"))
+
+describe(buildContinuousMonthlyAxisTicks, () => {
+    // The grid tick values, as YYYY-MM-DD (or undefined for a degenerate span).
+    const gridDates = (
+        min: string,
+        max: string,
+        targetCount: number
+    ): string[] | undefined => {
+        const ticks = buildContinuousMonthlyAxisTicks({
+            domain: [day(min), day(max)],
+            targetCount,
+        })
+        return ticks && asDates(ticks.map((tick) => tick.value))
+    }
+
+    it("steps every month for short spans", () => {
+        expect(gridDates("2020-01-01", "2020-03-01", 6)).toEqual([
+            "2020-01-01",
+            "2020-02-01",
+            "2020-03-01",
+        ])
+    })
+
+    it("steps every other month, anchored to January", () => {
+        expect(gridDates("2020-01-01", "2020-09-01", 6)).toEqual([
+            "2020-01-01",
+            "2020-03-01",
+            "2020-05-01",
+            "2020-07-01",
+            "2020-09-01",
+        ])
+    })
+
+    it("steps by quarter (Jan/Apr/Jul/Oct) across a ~1.5-year span", () => {
+        expect(gridDates("2020-01-01", "2021-06-01", 6)).toEqual([
+            "2020-01-01",
+            "2020-04-01",
+            "2020-07-01",
+            "2020-10-01",
+            "2021-01-01",
+            "2021-04-01",
+        ])
+    })
+
+    it("steps by whole years for multi-year spans", () => {
+        expect(gridDates("2018-03-01", "2021-11-01", 4)).toEqual([
+            "2019-01-01",
+            "2020-01-01",
+            "2021-01-01",
+        ])
+    })
+
+    it("snaps to a 5-year grid for long spans", () => {
+        expect(gridDates("2007-06-01", "2022-06-01", 6)).toEqual([
+            "2010-01-01",
+            "2015-01-01",
+            "2020-01-01",
+        ])
+    })
+
+    it("returns undefined for a degenerate (single-month) span", () => {
+        expect(gridDates("2020-05-01", "2020-05-01", 6)).toBeUndefined()
+        expect(gridDates("2020-05-03", "2020-05-28", 6)).toBeUndefined()
+    })
+
+    it("only produces first-of-month ticks within the domain", () => {
+        const minDay = day("2015-07-15")
+        const maxDay = day("2019-02-20")
+        const ticks = buildContinuousMonthlyAxisTicks({
+            domain: [minDay, maxDay],
+            targetCount: 6,
+        })!
+        for (const { value } of ticks) {
+            expect(value).toBeGreaterThanOrEqual(minDay)
+            expect(value).toBeLessThanOrEqual(maxDay)
+            expect(convertDaysSinceEpochToDate(value).date()).toBe(1)
+        }
+    })
+
+    // The tick labels (grid values are covered above).
+    const labels = (min: string, max: string, targetCount: number): string[] =>
+        buildContinuousMonthlyAxisTicks({
+            domain: [day(min), day(max)],
+            targetCount,
+        })!.map((tick) => tick.label!)
+
+    it("gives every tick priority 2", () => {
+        const ticks = buildContinuousMonthlyAxisTicks({
+            domain: [day("2020-01-01"), day("2022-01-01")],
+            targetCount: 3,
+        })!
+        expect(ticks.map((t) => t.priority)).toEqual([2, 2, 2])
+    })
+
+    it("labels a yearly-cadence grid with bare years", () => {
+        expect(labels("2020-01-01", "2023-01-01", 4)).toEqual([
+            "2020",
+            "2021",
+            "2022",
+            "2023",
+        ])
+    })
+
+    it("shows the year on the first tick and each January, month-only otherwise", () => {
+        expect(labels("2020-01-01", "2021-06-01", 6)).toEqual([
+            "Jan 2020",
+            "Apr",
+            "Jul",
+            "Oct",
+            "Jan 2021",
+            "Apr",
+        ])
+    })
+
+    it("shows the year only on the first tick when the grid has no January", () => {
+        expect(labels("2020-02-01", "2020-11-01", 4)).toEqual([
+            "Apr 2020",
+            "Jul",
+            "Oct",
+        ])
+    })
+})
+
+describe(buildDiscreteMonthlyAxisTicks, () => {
+    it("labels every bar with month + year (the year is never dropped)", () => {
+        const ticks = buildDiscreteMonthlyAxisTicks({
+            bandValues: [
+                "2020-01-01",
+                "2020-04-01",
+                "2020-07-01",
+                "2021-01-01",
+                "2021-04-01",
+            ].map(day),
+        })
+        expect(ticks.map((t) => t.label)).toEqual([
+            "Jan 2020",
+            "Apr 2020",
+            "Jul 2020",
+            "Jan 2021",
+            "Apr 2021",
+        ])
+    })
+})
+
+describe(getDiscreteMonthlyTickOptions, () => {
+    const monthlyBars = (startYear: number, endYear: number): number[] => {
+        const values: number[] = []
+        for (let y = startYear; y <= endYear; y++)
+            for (let m = 1; m <= 12; m++)
+                values.push(day(`${y}-${String(m).padStart(2, "0")}-01`))
+        return values
+    }
+    const monthGaps = (ticks: { value: number }[]): number[] => {
+        const idx = ticks.map((t) => {
+            const d = convertDaysSinceEpochToDate(t.value)
+            return d.year() * 12 + d.month()
+        })
+        return idx.slice(1).map((m, i) => m - idx[i])
+    }
+
+    it("makes every option a single uniform spacing", () => {
+        const options = getDiscreteMonthlyTickOptions({
+            bandValues: monthlyBars(2010, 2026),
+        })
+        for (const option of options)
+            expect(new Set(monthGaps(option)).size).toBeLessThanOrEqual(1)
+    })
+
+    it("gives an every-2-year option of even years only (never 2015/2025)", () => {
+        const options = getDiscreteMonthlyTickOptions({
+            bandValues: monthlyBars(2010, 2026),
+        })
+        const twoYearOption = options.find(
+            (option) => monthGaps(option)[0] === 24 // 2 years
+        )
+        expect(twoYearOption?.map((t) => t.label)).toEqual([
+            "Jan 2010",
+            "Jan 2012",
+            "Jan 2014",
+            "Jan 2016",
+            "Jan 2018",
+            "Jan 2020",
+            "Jan 2022",
+            "Jan 2024",
+            "Jan 2026",
+        ])
+    })
+
+    it("orders options from finest to coarsest", () => {
+        const options = getDiscreteMonthlyTickOptions({
+            bandValues: monthlyBars(2010, 2026),
+        })
+        const counts = options.map((option) => option.length)
+        expect(counts).toEqual([...counts].sort((a, b) => b - a))
+    })
+})

--- a/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.test.ts
+++ b/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.test.ts
@@ -89,6 +89,20 @@ describe(buildContinuousMonthlyAxisTicks, () => {
         expect(gridDates("2020-05-03", "2020-05-28", 6)).toBeUndefined()
     })
 
+    it("keeps a month step whose in-domain ticks meet a target the raw span/step estimate exceeds", () => {
+        // 77 months / 12 is just over the target of 6, but the mid-month
+        // domain start clips off the anchor January, so exactly six yearly
+        // ticks land in the domain — prefer them over three 2-yearly ticks
+        expect(gridDates("2020-01-09", "2026-06-28", 6)).toEqual([
+            "2021-01-01",
+            "2022-01-01",
+            "2023-01-01",
+            "2024-01-01",
+            "2025-01-01",
+            "2026-01-01",
+        ])
+    })
+
     it("drops grid ticks before a mid-month domain start", () => {
         // The 2-month grid is anchored to January, but the domain only
         // starts on Jan 5, so the Jan 1 tick is dropped

--- a/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.ts
+++ b/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.ts
@@ -127,10 +127,19 @@ function labelGridWithYearOnChange(
     { format, formatWithYear }: { format: string; formatWithYear: string }
 ): Tickmark[] {
     const years = grid.map((value) => convertDaysSinceEpochToDate(value).year())
-    return grid.map((value, i) => {
-        const isNewYear = i === 0 || years[i] !== years[i - 1]
-        return makeDayTick(value, isNewYear ? formatWithYear : format)
-    })
+    const isNewYear = (i: number): boolean =>
+        i === 0 || years[i] !== years[i - 1]
+
+    // When at least half the ticks carry the year anyway, an alternation of
+    // wide and narrow labels (e.g. "Jan 2020 · Jul · Jan 2021") saves no
+    // meaningful space and just looks inconsistent, so all ticks get the year
+    const newYearCount = grid.filter((_, i) => isNewYear(i)).length
+    if (newYearCount >= grid.length / 2)
+        return grid.map((value) => makeDayTick(value, formatWithYear))
+
+    return grid.map((value, i) =>
+        makeDayTick(value, isNewYear(i) ? formatWithYear : format)
+    )
 }
 
 /** Calendar-aware ticks for a time axis */

--- a/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.ts
+++ b/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.ts
@@ -195,33 +195,48 @@ function buildContinuousMonthGridTicks({
         .diff(minDate.startOf("month"), "month")
     if (spanMonths <= 0) return undefined
 
-    // Pick the smallest step that keeps the tick count at or below the target
-    const step =
-        steps.find((s) => spanMonths / s <= targetCount) ??
-        steps[steps.length - 1]
+    const gridForStep = (step: number): number[] => {
+        // Start from January of a "nice" anchor year. For year-based steps
+        // (12+ months), round the year down to the nearest multiple of the
+        // step in years, e.g. step=5y and min year=2023 -> anchor year=2020.
+        let anchorYear = minDate.year()
+        if (step >= 12) {
+            const yearsStep = step / 12
+            anchorYear = Math.floor(anchorYear / yearsStep) * yearsStep
+        }
 
-    // Start from January of a "nice" anchor year. For year-based steps
-    // (12+ months), round the year down to the nearest multiple of the step in
-    // years, e.g. step=5y and min year=2023 -> anchor year=2020.
-    let anchorYear = minDate.year()
-    if (step >= 12) {
-        const yearsStep = step / 12
-        anchorYear = Math.floor(anchorYear / yearsStep) * yearsStep
+        const anchor = dayjs.utc(`${anchorYear}-01-01`)
+        const monthsFromAnchor = (date: dayjs.Dayjs): number =>
+            date.startOf("month").diff(anchor, "month")
+
+        // The first and last grid indices that stay within the domain
+        const firstGridIndex = Math.ceil(monthsFromAnchor(minDate) / step)
+        const lastGridIndex = Math.floor(monthsFromAnchor(maxDate) / step)
+
+        return (
+            _.range(firstGridIndex, lastGridIndex + 1)
+                .map((k) =>
+                    convertDateToDaysSinceEpoch(anchor.add(k * step, "month"))
+                )
+                // The first index is rounded from the domain's start month, so
+                // a mid-month domain start can produce a tick just before it -
+                // drop those
+                .filter((value) => value >= domain[0] && value <= domain[1])
+        )
     }
 
-    const anchor = dayjs.utc(`${anchorYear}-01-01`)
-    const monthsFromAnchor = (date: dayjs.Dayjs): number =>
-        date.startOf("month").diff(anchor, "month")
+    // Pick the smallest step that keeps the tick count at or below the
+    // target. The span/step estimate can count a tick the domain clips off
+    // (e.g. a mid-month January start drops the anchor tick), so also accept
+    // a step whose exact in-domain tick count fits.
+    const step =
+        steps.find(
+            (s) =>
+                spanMonths / s <= targetCount ||
+                gridForStep(s).length <= targetCount
+        ) ?? steps[steps.length - 1]
 
-    // The first and last grid indices that stay within the domain
-    const firstGridIndex = Math.ceil(monthsFromAnchor(minDate) / step)
-    const lastGridIndex = Math.floor(monthsFromAnchor(maxDate) / step)
-
-    const grid = _.range(firstGridIndex, lastGridIndex + 1)
-        .map((k) => convertDateToDaysSinceEpoch(anchor.add(k * step, "month")))
-        // The first index is rounded from the domain's start month, so a
-        // mid-month domain start can produce a tick just before it - drop those
-        .filter((value) => value >= domain[0] && value <= domain[1])
+    const grid = gridForStep(step)
     if (!grid.length) return undefined
 
     // When every tick is a January, drop the redundant month and label only the year

--- a/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.ts
+++ b/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.ts
@@ -262,12 +262,22 @@ function buildContinuousDayGridTicks({
     // a step by its in-domain count — otherwise a 29-day domain with a
     // target of two would skip the fitting biweekly grid and fall through
     // to a single monthly tick.
-    const step = steps.find(
+    let step = steps.find(
         (s) =>
             spanDays / s <= targetCount || inDomainTickCount(s) <= targetCount
     )
-    if (step === undefined)
-        return buildContinuousMonthlyAxisTicks({ domain, targetCount })
+    if (step === undefined) {
+        const monthlyTicks = buildContinuousMonthlyAxisTicks({
+            domain,
+            targetCount,
+        })
+        if (monthlyTicks) return monthlyTicks
+        // A span within a single calendar month has no monthly grid to
+        // continue on; keep the coarsest step rather than dropping calendar
+        // ticks entirely, which would hand the axis to generic d3 ticks that
+        // can sit between grid points (e.g. sub-week ticks on a weekly axis)
+        step = steps[steps.length - 1]
+    }
 
     const reference = dayGridReference(step)
     const [firstStep, lastStep] = gridIndexRange(step)

--- a/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.ts
+++ b/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.ts
@@ -54,29 +54,28 @@ const WEEK_STEPS = [
     14, // 2 weeks
 ] as const
 
-// A fixed Monday (in days since epoch) that anchors weekly grids
-const MONDAY_REFERENCE = snapToIntervalStart(0, TimeInterval.Week)
-
 export type CalendarTickInterval = Exclude<
     TimeInterval,
     TimeInterval.Year | TimeInterval.Decade
 >
+
+/** A time value plus derived calendar fields for evenly spaced ticks */
+interface CalendarValue {
+    value: number
+    monthIndex: number
+    isFirstOfMonth: boolean
+    isFirstWeekOfMonth: boolean
+}
+
+/** Maps a value to its index on a grid, or `undefined` when it is off-grid */
+type GetGridIndex = (value: CalendarValue) => number | undefined
 
 /** A tickmark for a day-since-epoch `value`, labeled with the given dayjs format. */
 function makeDayTick(value: number, format: string): Tickmark {
     return { value, priority: 2, label: formatDay(value, { format }) }
 }
 
-/** A band value with its calendar coordinates */
-interface CalendarValue {
-    value: number
-    /** The calendar month, as a linear count of months */
-    monthIndex: number
-    isFirstOfMonth: boolean
-    /** Whether the value falls within the first seven days of its month */
-    isFirstWeekOfMonth: boolean
-}
-
+/** Converts a day-since-epoch value to CalendarValue metadata. */
 function toCalendarValue(value: number): CalendarValue {
     const date = convertDaysSinceEpochToDate(value)
     return {
@@ -89,30 +88,34 @@ function toCalendarValue(value: number): CalendarValue {
 
 /**
  * The reference day that anchors a day grid with the given step: a Monday for
- * weekly steps (so ticks land on week starts), the epoch otherwise (so grids
- * are stable when panning).
+ * weekly steps (so ticks land on week starts), the epoch otherwise.
  */
 function dayGridReference(step: number): number {
-    return step % 7 === 0 ? MONDAY_REFERENCE : 0
+    return step % 7 === 0 ? snapToIntervalStart(0, TimeInterval.Week) : 0
 }
 
 /**
- * The position of a value on the day grid with the given step;
- * an integer only for values that lie on the grid.
+ * The index of a value on the day grid with the given step,
+ * or `undefined` when the value is off-grid.
  */
-function dayGridPosition({ value }: CalendarValue, step: number): number {
-    return (value - dayGridReference(step)) / step
+function dayGridPosition(
+    { value }: CalendarValue,
+    step: number
+): number | undefined {
+    const index = (value - dayGridReference(step)) / step
+    return Number.isInteger(index) ? index : undefined
 }
 
 /**
- * The position of a value on the January-anchored month grid with the given
- * step; an integer only for values that lie on the grid.
+ * The index of a value on the January-anchored month grid with the given
+ * step, or `undefined` when the value is off-grid.
  */
 function monthGridPosition(
     { monthIndex }: CalendarValue,
     step: number
-): number {
-    return monthIndex / step
+): number | undefined {
+    const index = monthIndex / step
+    return Number.isInteger(index) ? index : undefined
 }
 
 /**
@@ -183,7 +186,7 @@ function buildContinuousMonthGridTicks({
         .diff(minDate.startOf("month"), "month")
     if (spanMonths <= 0) return undefined
 
-    // Pick the smallest step that keeps the tick count at or below the target.
+    // Pick the smallest step that keeps the tick count at or below the target
     const step =
         steps.find((s) => spanMonths / s <= targetCount) ??
         steps[steps.length - 1]
@@ -201,19 +204,18 @@ function buildContinuousMonthGridTicks({
     const monthsFromAnchor = (date: dayjs.Dayjs): number =>
         date.startOf("month").diff(anchor, "month")
 
-    // The first and last indices that stay within the domain: round the
-    // start up and the end down so both ticks land inside the domain.
-    const firstStep = Math.ceil(monthsFromAnchor(minDate) / step)
-    const lastStep = Math.floor(monthsFromAnchor(maxDate) / step)
+    // The first and last grid indices that stay within the domain
+    const firstGridIndex = Math.ceil(monthsFromAnchor(minDate) / step)
+    const lastGridIndex = Math.floor(monthsFromAnchor(maxDate) / step)
 
-    const grid = _.range(firstStep, lastStep + 1)
+    const grid = _.range(firstGridIndex, lastGridIndex + 1)
         .map((k) => convertDateToDaysSinceEpoch(anchor.add(k * step, "month")))
         // The first index is rounded from the domain's start month, so a
         // mid-month domain start can produce a tick just before it - drop those
         .filter((value) => value >= domain[0] && value <= domain[1])
     if (!grid.length) return undefined
 
-    // When every tick is a January, drop the redundant month and label only the year.
+    // When every tick is a January, drop the redundant month and label only the year
     const isJanuary = (value: number): boolean =>
         convertDaysSinceEpochToDate(value).month() === 0
     if (grid.every(isJanuary))
@@ -246,9 +248,8 @@ export function buildContinuousMonthlyAxisTicks({
 }
 
 /**
- * A calendar-nice quarter grid (quarter starts: Jan/Apr/Jul/Oct 1, labeled
- * with month names), sized to `targetCount`. Uses the month grid restricted
- * to quarter-sized steps, so quarterly axes never show sub-quarter ticks.
+ * A calendar-nice quarter grid (labeled with month names), sized to
+ * `targetCount`.
  */
 export function buildContinuousQuarterlyAxisTicks({
     domain,
@@ -281,8 +282,7 @@ function buildContinuousDayGridTicks({
     const spanDays = domain[1] - domain[0]
     if (spanDays <= 0) return undefined
 
-    // The first and last grid indices that stay within the domain: round the
-    // start up and the end down so both ticks land inside the domain.
+    // The first and last grid indices that stay within the domain
     const gridIndexRange = (step: number): [number, number] => {
         const reference = dayGridReference(step)
         return [
@@ -295,13 +295,9 @@ function buildContinuousDayGridTicks({
         return last - first + 1
     }
 
-    // Pick the smallest step that keeps the tick count at or below the
-    // target; if even the coarsest step produces too many ticks, fall
-    // through to the monthly (and yearly) grid. The span/step estimate can
-    // count one tick more than actually lands in the domain, so also accept
-    // a step by its in-domain count — otherwise a 29-day domain with a
-    // target of two would skip the fitting biweekly grid and fall through
-    // to a single monthly tick.
+    // Pick the smallest step whose exact in-domain tick count fits the target;
+    // if even the coarsest step is too dense, fall through to the monthly
+    // (and yearly) grid.
     let step = steps.find(
         (s) =>
             spanDays / s <= targetCount || inDomainTickCount(s) <= targetCount
@@ -312,16 +308,15 @@ function buildContinuousDayGridTicks({
             targetCount,
         })
         if (monthlyTicks) return monthlyTicks
+
         // A span within a single calendar month has no monthly grid to
-        // continue on; keep the coarsest step rather than dropping calendar
-        // ticks entirely, which would hand the axis to generic d3 ticks that
-        // can sit between grid points (e.g. sub-week ticks on a weekly axis)
+        // continue on; fallback to the coarsest step in that case
         step = steps[steps.length - 1]
     }
 
     const reference = dayGridReference(step)
-    const [firstStep, lastStep] = gridIndexRange(step)
-    const grid = _.range(firstStep, lastStep + 1).map(
+    const [firstGridIndex, lastGridIndex] = gridIndexRange(step)
+    const grid = _.range(firstGridIndex, lastGridIndex + 1).map(
         (k) => reference + k * step
     )
     if (!grid.length) return undefined
@@ -373,20 +368,15 @@ export function buildContinuousWeeklyAxisTicks({
 }
 
 /**
- * One tick per domain value. The ticks carry no label: each value is labeled
- * independently, so the axis falls back to the column's own time format,
- * which is never abbreviated (e.g. "Jan 2023" for months, "Jan 5, 2023"
- * for days).
+ * One tick per domain value. The ticks carry no label, so the axis falls back
+ * to the column's own time format.
  */
 export function buildDiscreteTimeAxisTicks({
     bandValues,
 }: {
     bandValues: number[]
 }): Tickmark[] {
-    return _.sortBy(_.uniq(bandValues)).map((value) => ({
-        value,
-        priority: 2,
-    }))
+    return _.sortBy(_.uniq(bandValues)).map((value) => ({ value, priority: 2 }))
 }
 
 /**
@@ -419,43 +409,38 @@ export function getDiscreteTimeTickOptions({
 }
 
 /**
- * Maps a value to its position on a grid; an integer for values on the grid,
- * a non-integer (or NaN) otherwise.
- */
-type GridPosition = (value: CalendarValue) => number
-
-/**
  * One label set per grid, starting with a set that labels every value. A grid's
  * set is only offered when its values sit on consecutive grid points, so
- * every offered set is evenly spaced. Skips sets that don't thin the previous
- * one. Single-value sets aren't offered: when no multi-label set fits, the
- * axis falls back to greedy labeling, which labels as many bands as fit
- * instead of a lone calendar-anchored one (often the first or last band).
- * The grids are expected to be ordered from finest to coarsest.
+ * every offered set is evenly spaced. The indexers are expected to be ordered
+ * from finest to coarsest.
  */
 function buildTickOptionsFromGrids(
     bandValues: number[],
-    grids: GridPosition[]
+    getGridIndexers: GetGridIndex[]
 ): Tickmark[][] {
     const calendarValues = _.sortBy(_.uniq(bandValues)).map(toCalendarValue)
+
     const makeTier = (values: CalendarValue[]): Tickmark[] =>
         values.map(({ value }) => ({ value, priority: 2 }))
 
-    // The finest option labels every value, evenly spaced or not
+    // The finest option labels every value
     const tiers: Tickmark[][] = [makeTier(calendarValues)]
     if (calendarValues.length <= 1) return tiers
 
-    for (const gridPosition of grids) {
+    for (const getGridIndex of getGridIndexers) {
         const valuesOnGrid = calendarValues
-            .map((value) => ({ value, position: gridPosition(value) }))
-            .filter(({ position }) => Number.isInteger(position))
+            .map((value) => ({ value, index: getGridIndex(value) }))
+            .filter(
+                (entry): entry is { value: CalendarValue; index: number } =>
+                    entry.index !== undefined
+            )
+
+        // Require at least two values
         if (valuesOnGrid.length < 2) continue
 
-        // Only offer evenly-spaced sets: the values must sit on consecutive
-        // grid points, otherwise the labels would have ragged gaps
+        // Only offer evenly-spaced sets
         const isEvenlySpaced = valuesOnGrid.every(
-            ({ position }, i) =>
-                i === 0 || position - valuesOnGrid[i - 1].position === 1
+            ({ index }, i) => i === 0 || index - valuesOnGrid[i - 1].index === 1
         )
         if (!isEvenlySpaced) continue
 
@@ -466,6 +451,8 @@ function buildTickOptionsFromGrids(
 
         tiers.push(makeTier(valuesOnGrid.map(({ value }) => value)))
 
+        // Two labels are the smallest useful tier, and later (coarser)
+        // grids cannot produce a strictly smaller tier
         if (valuesOnGrid.length === 2) break
     }
 
@@ -516,7 +503,9 @@ export function getDiscreteWeeklyTickOptions({
         ),
         ...MONTH_STEPS.map(
             (step) => (value: CalendarValue) =>
-                value.isFirstWeekOfMonth ? monthGridPosition(value, step) : NaN
+                value.isFirstWeekOfMonth
+                    ? monthGridPosition(value, step)
+                    : undefined
         ),
     ])
 }
@@ -537,7 +526,9 @@ export function getDiscreteDailyTickOptions({
         ),
         ...MONTH_STEPS.map(
             (step) => (value: CalendarValue) =>
-                value.isFirstOfMonth ? monthGridPosition(value, step) : NaN
+                value.isFirstOfMonth
+                    ? monthGridPosition(value, step)
+                    : undefined
         ),
     ])
 }

--- a/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.ts
+++ b/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.ts
@@ -142,6 +142,29 @@ function labelGridWithYearOnChange(
     )
 }
 
+/**
+ * The grid of the smallest step that keeps the tick count at or below the
+ * target, or `undefined` when even the coarsest step produces too many ticks.
+ */
+function findGridForTarget({
+    steps,
+    targetCount,
+    span,
+    gridForStep,
+}: {
+    steps: readonly number[]
+    targetCount: number
+    span: number
+    gridForStep: (step: number) => number[]
+}): number[] | undefined {
+    for (const step of steps) {
+        const grid = gridForStep(step)
+        if (span / step <= targetCount || grid.length <= targetCount)
+            return grid
+    }
+    return undefined
+}
+
 /** Calendar-aware ticks for a time axis */
 export function buildTimeAxisTicks({
     interval,
@@ -225,18 +248,15 @@ function buildContinuousMonthGridTicks({
         )
     }
 
-    // Pick the smallest step that keeps the tick count at or below the
-    // target. The span/step estimate can count a tick the domain clips off
-    // (e.g. a mid-month January start drops the anchor tick), so also accept
-    // a step whose exact in-domain tick count fits.
-    const step =
-        steps.find(
-            (s) =>
-                spanMonths / s <= targetCount ||
-                gridForStep(s).length <= targetCount
-        ) ?? steps[steps.length - 1]
-
-    const grid = gridForStep(step)
+    const grid =
+        findGridForTarget({
+            steps,
+            targetCount,
+            span: spanMonths,
+            gridForStep,
+        }) ??
+        // Even the coarsest step produces too many ticks; use it anyway
+        gridForStep(steps[steps.length - 1])
     if (!grid.length) return undefined
 
     // When every tick is a January, drop the redundant month and label only the year
@@ -306,27 +326,25 @@ function buildContinuousDayGridTicks({
     const spanDays = domain[1] - domain[0]
     if (spanDays <= 0) return undefined
 
-    // The first and last grid indices that stay within the domain
-    const gridIndexRange = (step: number): [number, number] => {
+    const gridForStep = (step: number): number[] => {
         const reference = dayGridReference(step)
-        return [
-            Math.ceil((domain[0] - reference) / step),
-            Math.floor((domain[1] - reference) / step),
-        ]
-    }
-    const inDomainTickCount = (step: number): number => {
-        const [first, last] = gridIndexRange(step)
-        return last - first + 1
+        // The first and last grid indices that stay within the domain
+        const firstGridIndex = Math.ceil((domain[0] - reference) / step)
+        const lastGridIndex = Math.floor((domain[1] - reference) / step)
+        return _.range(firstGridIndex, lastGridIndex + 1).map(
+            (k) => reference + k * step
+        )
     }
 
-    // Pick the smallest step whose exact in-domain tick count fits the target;
-    // if even the coarsest step is too dense, fall through to the monthly
-    // (and yearly) grid.
-    let step = steps.find(
-        (s) =>
-            spanDays / s <= targetCount || inDomainTickCount(s) <= targetCount
-    )
-    if (step === undefined) {
+    // If even the coarsest step is too dense, fall through to the monthly
+    // (and yearly) grid
+    let grid = findGridForTarget({
+        steps,
+        targetCount,
+        span: spanDays,
+        gridForStep,
+    })
+    if (grid === undefined) {
         const monthlyTicks = buildContinuousMonthlyAxisTicks({
             domain,
             targetCount,
@@ -335,14 +353,8 @@ function buildContinuousDayGridTicks({
 
         // A span within a single calendar month has no monthly grid to
         // continue on; fallback to the coarsest step in that case
-        step = steps[steps.length - 1]
+        grid = gridForStep(steps[steps.length - 1])
     }
-
-    const reference = dayGridReference(step)
-    const [firstGridIndex, lastGridIndex] = gridIndexRange(step)
-    const grid = _.range(firstGridIndex, lastGridIndex + 1).map(
-        (k) => reference + k * step
-    )
     if (!grid.length) return undefined
 
     // Label the day and month, keeping the year on the first tick

--- a/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.ts
+++ b/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.ts
@@ -5,6 +5,7 @@ import {
     Tickmark,
     convertDaysSinceEpochToDate,
     convertDateToDaysSinceEpoch,
+    snapToIntervalStart,
 } from "@ourworldindata/utils"
 import { TimeInterval } from "@ourworldindata/types"
 import { match } from "ts-pattern"
@@ -24,9 +25,94 @@ const MONTH_STEPS = [
     1200, // 100 years
 ] as const
 
+// Calendar-nice step sizes in days
+const DAY_STEPS = [
+    1, // 1 day
+    2, // 2 days
+    7, // 1 week
+    14, // 2 weeks
+] as const
+
+// A fixed Monday (in days since epoch) that anchors weekly grids
+const MONDAY_REFERENCE = snapToIntervalStart(0, TimeInterval.Week)
+
+// Time intervals with calendar-aware axis ticks; all other intervals
+// fall back to the generic d3 ticks
+const CALENDAR_TICK_INTERVALS = [TimeInterval.Month, TimeInterval.Day] as const
+
+export type CalendarTickInterval = (typeof CALENDAR_TICK_INTERVALS)[number]
+
+export function isCalendarTickInterval(
+    interval: TimeInterval
+): interval is CalendarTickInterval {
+    return (CALENDAR_TICK_INTERVALS as readonly TimeInterval[]).includes(
+        interval
+    )
+}
+
 /** A tickmark for a day-since-epoch `value`, labeled with the given dayjs format. */
 function makeDayTick(value: number, format: string): Tickmark {
     return { value, priority: 2, label: formatDay(value, { format }) }
+}
+
+/** A band value with its calendar coordinates */
+interface CalendarValue {
+    value: number
+    /** The calendar month, as a linear count of months */
+    monthIndex: number
+    isFirstOfMonth: boolean
+}
+
+function toCalendarValue(value: number): CalendarValue {
+    const date = convertDaysSinceEpochToDate(value)
+    return {
+        value,
+        monthIndex: date.year() * 12 + date.month(),
+        isFirstOfMonth: date.date() === 1,
+    }
+}
+
+/**
+ * The reference day that anchors a day grid with the given step: a Monday for
+ * weekly steps (so ticks land on week starts), the epoch otherwise (so grids
+ * are stable when panning).
+ */
+function dayGridReference(step: number): number {
+    return step % 7 === 0 ? MONDAY_REFERENCE : 0
+}
+
+/**
+ * The position of a value on the day grid with the given step;
+ * an integer only for values that lie on the grid.
+ */
+function dayGridPosition({ value }: CalendarValue, step: number): number {
+    return (value - dayGridReference(step)) / step
+}
+
+/**
+ * The position of a value on the January-anchored month grid with the given
+ * step; an integer only for values that lie on the grid.
+ */
+function monthGridPosition(
+    { monthIndex }: CalendarValue,
+    step: number
+): number {
+    return monthIndex / step
+}
+
+/**
+ * Labels each grid value with `format`, switching to `formatWithYear` on the
+ * first tick and wherever the year changes.
+ */
+function labelGridWithYearOnChange(
+    grid: number[],
+    { format, formatWithYear }: { format: string; formatWithYear: string }
+): Tickmark[] {
+    const years = grid.map((value) => convertDaysSinceEpochToDate(value).year())
+    return grid.map((value, i) => {
+        const isNewYear = i === 0 || years[i] !== years[i - 1]
+        return makeDayTick(value, isNewYear ? formatWithYear : format)
+    })
 }
 
 /**
@@ -44,13 +130,18 @@ export function buildTimeAxisTicks({
     targetCount: number
     bandValues?: number[]
 }): Tickmark[] | undefined {
+    if (!isCalendarTickInterval(interval)) return undefined
+
+    if (bandValues?.length) return buildDiscreteTimeAxisTicks({ bandValues })
+
     return match(interval)
         .with(TimeInterval.Month, () =>
-            bandValues?.length
-                ? buildDiscreteMonthlyAxisTicks({ bandValues })
-                : buildContinuousMonthlyAxisTicks({ domain, targetCount })
+            buildContinuousMonthlyAxisTicks({ domain, targetCount })
         )
-        .otherwise(() => undefined)
+        .with(TimeInterval.Day, () =>
+            buildContinuousDailyAxisTicks({ domain, targetCount })
+        )
+        .exhaustive()
 }
 
 /**
@@ -95,9 +186,12 @@ export function buildContinuousMonthlyAxisTicks({
     const firstStep = Math.ceil(monthsFromAnchor(minDate) / step)
     const lastStep = Math.floor(monthsFromAnchor(maxDate) / step)
 
-    const grid = _.range(firstStep, lastStep + 1).map((k) =>
-        convertDateToDaysSinceEpoch(anchor.add(k * step, "month"))
-    )
+    const grid = _.range(firstStep, lastStep + 1)
+        .map((k) => convertDateToDaysSinceEpoch(anchor.add(k * step, "month")))
+        // The first index is rounded from the domain's start month, so a
+        // mid-month domain start can produce a tick just before it - drop those
+        .filter((value) => value >= domain[0] && value <= domain[1])
+    if (!grid.length) return undefined
 
     // When every tick is a January, drop the redundant month and label only the year.
     const isJanuary = (value: number): boolean =>
@@ -107,53 +201,177 @@ export function buildContinuousMonthlyAxisTicks({
 
     // Otherwise label the month only, keeping the year on the first tick
     // and each January (i.e. wherever the year changes)
-    const years = grid.map((value) => convertDaysSinceEpochToDate(value).year())
-    return grid.map((value, i) => {
-        const isNewYear = i === 0 || years[i] !== years[i - 1]
-        return makeDayTick(value, isNewYear ? "MMM YYYY" : "MMM")
+    return labelGridWithYearOnChange(grid, {
+        format: "MMM",
+        formatWithYear: "MMM YYYY",
     })
 }
 
-/** One tick per domain value, each labeled with its full month and year */
-export function buildDiscreteMonthlyAxisTicks({
+/**
+ * A calendar-nice day grid (every day, every other day, weekly or biweekly
+ * on Mondays), sized to `targetCount`, with redundant year parts dropped from
+ * the labels. Spans too long for day-sized steps continue on the monthly grid.
+ */
+export function buildContinuousDailyAxisTicks({
+    domain,
+    targetCount,
+}: {
+    domain: [number, number]
+    targetCount: number
+}): Tickmark[] | undefined {
+    const spanDays = domain[1] - domain[0]
+    if (spanDays <= 0) return undefined
+
+    // Pick the smallest step that keeps the tick count at or below the
+    // target; if even the coarsest day step produces too many ticks,
+    // fall through to the monthly (and yearly) grid.
+    const step = DAY_STEPS.find((s) => spanDays / s <= targetCount)
+    if (step === undefined)
+        return buildContinuousMonthlyAxisTicks({ domain, targetCount })
+
+    const reference = dayGridReference(step)
+
+    // The first and last indices that stay within the domain: round the
+    // start up and the end down so both ticks land inside the domain.
+    const firstStep = Math.ceil((domain[0] - reference) / step)
+    const lastStep = Math.floor((domain[1] - reference) / step)
+
+    const grid = _.range(firstStep, lastStep + 1).map(
+        (k) => reference + k * step
+    )
+    if (!grid.length) return undefined
+
+    // Label the day and month, keeping the year on the first tick
+    // and wherever the year changes
+    return labelGridWithYearOnChange(grid, {
+        format: "MMM D",
+        formatWithYear: "MMM D, YYYY",
+    })
+}
+
+/**
+ * One tick per domain value. The ticks carry no label: each value is labeled
+ * independently, so the axis falls back to the column's own time format,
+ * which is never abbreviated (e.g. "Jan 2023" for months, "Jan 5, 2023"
+ * for days).
+ */
+export function buildDiscreteTimeAxisTicks({
     bandValues,
 }: {
     bandValues: number[]
 }): Tickmark[] {
-    return _.sortBy(_.uniq(bandValues)).map((value) =>
-        makeDayTick(value, "MMM YYYY")
-    )
+    return _.sortBy(_.uniq(bandValues)).map((value) => ({
+        value,
+        priority: 2,
+    }))
 }
 
 /**
- * The label sets a discrete monthly axis can pick from, ordered from finest to
- * coarsest — each a single evenly-spaced set (every month, quarter, year, 2
- * years, …). The axis shows the finest that fits; using one spacing per set
+ * The label sets a discrete time axis can pick from, ordered from finest to
+ * coarsest — each a single evenly-spaced set (every day, week, month, quarter,
+ * year, …). The axis shows the finest that fits; using one spacing per set
  * ensures the gaps remain uniform.
  */
+export function getDiscreteTimeTickOptions({
+    interval,
+    bandValues,
+}: {
+    interval: CalendarTickInterval
+    bandValues: number[]
+}): Tickmark[][] {
+    return match(interval)
+        .with(TimeInterval.Month, () =>
+            getDiscreteMonthlyTickOptions({ bandValues })
+        )
+        .with(TimeInterval.Day, () =>
+            getDiscreteDailyTickOptions({ bandValues })
+        )
+        .exhaustive()
+}
+
+/**
+ * Maps a value to its position on a grid; an integer for values on the grid,
+ * a non-integer (or NaN) otherwise.
+ */
+type GridPosition = (value: CalendarValue) => number
+
+/**
+ * One label set per grid, starting with a set that labels every value. A grid's
+ * set is only offered when its values sit on consecutive grid points, so
+ * every offered set is evenly spaced. Skips sets that don't thin the previous
+ * one and stops once a set holds a single value (nothing coarser can add).
+ * The grids are expected to be ordered from finest to coarsest.
+ */
+function buildTickOptionsFromGrids(
+    bandValues: number[],
+    grids: GridPosition[]
+): Tickmark[][] {
+    const calendarValues = _.sortBy(_.uniq(bandValues)).map(toCalendarValue)
+    const makeTier = (values: CalendarValue[]): Tickmark[] =>
+        values.map(({ value }) => ({ value, priority: 2 }))
+
+    // The finest option labels every value, evenly spaced or not
+    const tiers: Tickmark[][] = [makeTier(calendarValues)]
+    if (calendarValues.length <= 1) return tiers
+
+    for (const gridPosition of grids) {
+        const valuesOnGrid = calendarValues
+            .map((value) => ({ value, position: gridPosition(value) }))
+            .filter(({ position }) => Number.isInteger(position))
+        if (!valuesOnGrid.length) continue
+
+        // Only offer evenly-spaced sets: the values must sit on consecutive
+        // grid points, otherwise the labels would have ragged gaps
+        const isEvenlySpaced = valuesOnGrid.every(
+            ({ position }, i) =>
+                i === 0 || position - valuesOnGrid[i - 1].position === 1
+        )
+        if (!isEvenlySpaced) continue
+
+        // The axis shows the first set whose labels fit, so a set with as
+        // many labels as the previous one can't fit where that one didn't —
+        // only offer strictly smaller sets
+        if (valuesOnGrid.length === tiers[tiers.length - 1].length) continue
+
+        tiers.push(makeTier(valuesOnGrid.map(({ value }) => value)))
+
+        if (valuesOnGrid.length === 1) break
+    }
+
+    return tiers
+}
+
+/** See getDiscreteTimeTickOptions; steps every month, quarter, year, … */
 export function getDiscreteMonthlyTickOptions({
     bandValues,
 }: {
     bandValues: number[]
 }): Tickmark[][] {
-    const sortedValues = _.sortBy(_.uniq(bandValues))
-
-    const monthIndex = (value: number): number => {
-        const date = convertDaysSinceEpochToDate(value)
-        return date.year() * 12 + date.month()
-    }
-
-    const tiers: Tickmark[][] = []
-    for (const step of MONTH_STEPS) {
-        const valuesOnGrid = sortedValues.filter(
-            (value) => monthIndex(value) % step === 0
+    return buildTickOptionsFromGrids(
+        bandValues,
+        MONTH_STEPS.map(
+            (step) => (value: CalendarValue) => monthGridPosition(value, step)
         )
-        if (!valuesOnGrid.length) continue
+    )
+}
 
-        tiers.push(valuesOnGrid.map((value) => makeDayTick(value, "MMM YYYY")))
-
-        if (valuesOnGrid.length === 1) break // nothing coarser can add
-    }
-
-    return tiers
+/**
+ * See getDiscreteTimeTickOptions; steps every day, every other day,
+ * weekly and biweekly (on Mondays), then continues on the monthly grid
+ * restricted to first-of-month values.
+ */
+export function getDiscreteDailyTickOptions({
+    bandValues,
+}: {
+    bandValues: number[]
+}): Tickmark[][] {
+    return buildTickOptionsFromGrids(bandValues, [
+        ...DAY_STEPS.map(
+            (step) => (value: CalendarValue) => dayGridPosition(value, step)
+        ),
+        ...MONTH_STEPS.map(
+            (step) => (value: CalendarValue) =>
+                value.isFirstOfMonth ? monthGridPosition(value, step) : NaN
+        ),
+    ])
 }

--- a/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.ts
+++ b/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.ts
@@ -33,12 +33,23 @@ const DAY_STEPS = [
     14, // 2 weeks
 ] as const
 
+// Calendar-nice step sizes in days for weekly axes,
+// so they never show sub-week ticks
+const WEEK_STEPS = [
+    7, // 1 week
+    14, // 2 weeks
+] as const
+
 // A fixed Monday (in days since epoch) that anchors weekly grids
 const MONDAY_REFERENCE = snapToIntervalStart(0, TimeInterval.Week)
 
 // Time intervals with calendar-aware axis ticks; all other intervals
 // fall back to the generic d3 ticks
-const CALENDAR_TICK_INTERVALS = [TimeInterval.Month, TimeInterval.Day] as const
+const CALENDAR_TICK_INTERVALS = [
+    TimeInterval.Month,
+    TimeInterval.Week,
+    TimeInterval.Day,
+] as const
 
 export type CalendarTickInterval = (typeof CALENDAR_TICK_INTERVALS)[number]
 
@@ -61,6 +72,8 @@ interface CalendarValue {
     /** The calendar month, as a linear count of months */
     monthIndex: number
     isFirstOfMonth: boolean
+    /** Whether the value falls within the first seven days of its month */
+    isFirstWeekOfMonth: boolean
 }
 
 function toCalendarValue(value: number): CalendarValue {
@@ -69,6 +82,7 @@ function toCalendarValue(value: number): CalendarValue {
         value,
         monthIndex: date.year() * 12 + date.month(),
         isFirstOfMonth: date.date() === 1,
+        isFirstWeekOfMonth: date.date() <= 7,
     }
 }
 
@@ -137,6 +151,9 @@ export function buildTimeAxisTicks({
     return match(interval)
         .with(TimeInterval.Month, () =>
             buildContinuousMonthlyAxisTicks({ domain, targetCount })
+        )
+        .with(TimeInterval.Week, () =>
+            buildContinuousWeeklyAxisTicks({ domain, targetCount })
         )
         .with(TimeInterval.Day, () =>
             buildContinuousDailyAxisTicks({ domain, targetCount })
@@ -208,16 +225,18 @@ export function buildContinuousMonthlyAxisTicks({
 }
 
 /**
- * A calendar-nice day grid (every day, every other day, weekly or biweekly
- * on Mondays), sized to `targetCount`, with redundant year parts dropped from
- * the labels. Spans too long for day-sized steps continue on the monthly grid.
+ * A calendar-nice day grid stepped by one of the given step sizes, sized to
+ * `targetCount`, with redundant year parts dropped from the labels. Spans
+ * too long for the coarsest step continue on the monthly grid.
  */
-export function buildContinuousDailyAxisTicks({
+function buildContinuousDayGridTicks({
     domain,
     targetCount,
+    steps,
 }: {
     domain: [number, number]
     targetCount: number
+    steps: readonly number[]
 }): Tickmark[] | undefined {
     const spanDays = domain[1] - domain[0]
     if (spanDays <= 0) return undefined
@@ -237,13 +256,13 @@ export function buildContinuousDailyAxisTicks({
     }
 
     // Pick the smallest step that keeps the tick count at or below the
-    // target; if even the coarsest day step produces too many ticks, fall
+    // target; if even the coarsest step produces too many ticks, fall
     // through to the monthly (and yearly) grid. The span/step estimate can
     // count one tick more than actually lands in the domain, so also accept
     // a step by its in-domain count — otherwise a 29-day domain with a
     // target of two would skip the fitting biweekly grid and fall through
     // to a single monthly tick.
-    const step = DAY_STEPS.find(
+    const step = steps.find(
         (s) =>
             spanDays / s <= targetCount || inDomainTickCount(s) <= targetCount
     )
@@ -262,6 +281,44 @@ export function buildContinuousDailyAxisTicks({
     return labelGridWithYearOnChange(grid, {
         format: "MMM D",
         formatWithYear: "MMM D, YYYY",
+    })
+}
+
+/**
+ * A calendar-nice day grid (every day, every other day, weekly or biweekly
+ * on Mondays), sized to `targetCount`, with redundant year parts dropped from
+ * the labels. Spans too long for day-sized steps continue on the monthly grid.
+ */
+export function buildContinuousDailyAxisTicks({
+    domain,
+    targetCount,
+}: {
+    domain: [number, number]
+    targetCount: number
+}): Tickmark[] | undefined {
+    return buildContinuousDayGridTicks({
+        domain,
+        targetCount,
+        steps: DAY_STEPS,
+    })
+}
+
+/**
+ * A calendar-nice week grid (weekly or biweekly on Mondays, labeled with the
+ * week-start dates), sized to `targetCount`. Spans too long for week-sized
+ * steps continue on the monthly grid.
+ */
+export function buildContinuousWeeklyAxisTicks({
+    domain,
+    targetCount,
+}: {
+    domain: [number, number]
+    targetCount: number
+}): Tickmark[] | undefined {
+    return buildContinuousDayGridTicks({
+        domain,
+        targetCount,
+        steps: WEEK_STEPS,
     })
 }
 
@@ -298,6 +355,9 @@ export function getDiscreteTimeTickOptions({
     return match(interval)
         .with(TimeInterval.Month, () =>
             getDiscreteMonthlyTickOptions({ bandValues })
+        )
+        .with(TimeInterval.Week, () =>
+            getDiscreteWeeklyTickOptions({ bandValues })
         )
         .with(TimeInterval.Day, () =>
             getDiscreteDailyTickOptions({ bandValues })
@@ -371,6 +431,27 @@ export function getDiscreteMonthlyTickOptions({
             (step) => (value: CalendarValue) => monthGridPosition(value, step)
         )
     )
+}
+
+/**
+ * See getDiscreteTimeTickOptions; steps weekly and biweekly (on Mondays),
+ * then continues on the monthly grid restricted to each month's first week,
+ * so ticks stay on actual week values.
+ */
+export function getDiscreteWeeklyTickOptions({
+    bandValues,
+}: {
+    bandValues: number[]
+}): Tickmark[][] {
+    return buildTickOptionsFromGrids(bandValues, [
+        ...WEEK_STEPS.map(
+            (step) => (value: CalendarValue) => dayGridPosition(value, step)
+        ),
+        ...MONTH_STEPS.map(
+            (step) => (value: CalendarValue) =>
+                value.isFirstWeekOfMonth ? monthGridPosition(value, step) : NaN
+        ),
+    ])
 }
 
 /**

--- a/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.ts
+++ b/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.ts
@@ -315,7 +315,9 @@ type GridPosition = (value: CalendarValue) => number
  * One label set per grid, starting with a set that labels every value. A grid's
  * set is only offered when its values sit on consecutive grid points, so
  * every offered set is evenly spaced. Skips sets that don't thin the previous
- * one and stops once a set holds a single value (nothing coarser can add).
+ * one. Single-value sets aren't offered: when no multi-label set fits, the
+ * axis falls back to greedy labeling, which labels as many bands as fit
+ * instead of a lone calendar-anchored one (often the first or last band).
  * The grids are expected to be ordered from finest to coarsest.
  */
 function buildTickOptionsFromGrids(
@@ -334,7 +336,7 @@ function buildTickOptionsFromGrids(
         const valuesOnGrid = calendarValues
             .map((value) => ({ value, position: gridPosition(value) }))
             .filter(({ position }) => Number.isInteger(position))
-        if (!valuesOnGrid.length) continue
+        if (valuesOnGrid.length < 2) continue
 
         // Only offer evenly-spaced sets: the values must sit on consecutive
         // grid points, otherwise the labels would have ragged gaps
@@ -351,7 +353,7 @@ function buildTickOptionsFromGrids(
 
         tiers.push(makeTier(valuesOnGrid.map(({ value }) => value)))
 
-        if (valuesOnGrid.length === 1) break
+        if (valuesOnGrid.length === 2) break
     }
 
     return tiers

--- a/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.ts
+++ b/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.ts
@@ -222,20 +222,36 @@ export function buildContinuousDailyAxisTicks({
     const spanDays = domain[1] - domain[0]
     if (spanDays <= 0) return undefined
 
+    // The first and last grid indices that stay within the domain: round the
+    // start up and the end down so both ticks land inside the domain.
+    const gridIndexRange = (step: number): [number, number] => {
+        const reference = dayGridReference(step)
+        return [
+            Math.ceil((domain[0] - reference) / step),
+            Math.floor((domain[1] - reference) / step),
+        ]
+    }
+    const inDomainTickCount = (step: number): number => {
+        const [first, last] = gridIndexRange(step)
+        return last - first + 1
+    }
+
     // Pick the smallest step that keeps the tick count at or below the
-    // target; if even the coarsest day step produces too many ticks,
-    // fall through to the monthly (and yearly) grid.
-    const step = DAY_STEPS.find((s) => spanDays / s <= targetCount)
+    // target; if even the coarsest day step produces too many ticks, fall
+    // through to the monthly (and yearly) grid. The span/step estimate can
+    // count one tick more than actually lands in the domain, so also accept
+    // a step by its in-domain count — otherwise a 29-day domain with a
+    // target of two would skip the fitting biweekly grid and fall through
+    // to a single monthly tick.
+    const step = DAY_STEPS.find(
+        (s) =>
+            spanDays / s <= targetCount || inDomainTickCount(s) <= targetCount
+    )
     if (step === undefined)
         return buildContinuousMonthlyAxisTicks({ domain, targetCount })
 
     const reference = dayGridReference(step)
-
-    // The first and last indices that stay within the domain: round the
-    // start up and the end down so both ticks land inside the domain.
-    const firstStep = Math.ceil((domain[0] - reference) / step)
-    const lastStep = Math.floor((domain[1] - reference) / step)
-
+    const [firstStep, lastStep] = gridIndexRange(step)
     const grid = _.range(firstStep, lastStep + 1).map(
         (k) => reference + k * step
     )

--- a/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.ts
+++ b/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.ts
@@ -1,0 +1,159 @@
+import * as _ from "lodash-es"
+import {
+    dayjs,
+    formatDay,
+    Tickmark,
+    convertDaysSinceEpochToDate,
+    convertDateToDaysSinceEpoch,
+} from "@ourworldindata/utils"
+import { TimeInterval } from "@ourworldindata/types"
+import { match } from "ts-pattern"
+
+// Calendar-nice step sizes in months
+const MONTH_STEPS = [
+    1, // 1 month
+    2, // 2 months
+    3, // 3 months
+    6, // 6 months
+    12, // 1 year
+    24, // 2 years
+    60, // 5 years
+    120, // 10 years
+    300, // 25 years
+    600, // 50 years
+    1200, // 100 years
+] as const
+
+/** A tickmark for a day-since-epoch `value`, labeled with the given dayjs format. */
+function makeDayTick(value: number, format: string): Tickmark {
+    return { value, priority: 2, label: formatDay(value, { format }) }
+}
+
+/**
+ * Calendar-aware ticks for a time axis, or `undefined` if the interval has no
+ * special handling (the caller then falls back to the generic d3 ticks).
+ */
+export function buildTimeAxisTicks({
+    interval,
+    domain,
+    targetCount,
+    bandValues,
+}: {
+    interval: TimeInterval
+    domain: [number, number]
+    targetCount: number
+    bandValues?: number[]
+}): Tickmark[] | undefined {
+    return match(interval)
+        .with(TimeInterval.Month, () =>
+            bandValues?.length
+                ? buildDiscreteMonthlyAxisTicks({ bandValues })
+                : buildContinuousMonthlyAxisTicks({ domain, targetCount })
+        )
+        .otherwise(() => undefined)
+}
+
+/**
+ * An evenly-spaced, January-anchored month grid, sized to `targetCount`,
+ * with redundant year/month parts dropped from the labels.
+ */
+export function buildContinuousMonthlyAxisTicks({
+    domain,
+    targetCount,
+}: {
+    domain: [number, number]
+    targetCount: number
+}): Tickmark[] | undefined {
+    const minDate = convertDaysSinceEpochToDate(domain[0])
+    const maxDate = convertDaysSinceEpochToDate(domain[1])
+
+    const spanMonths = maxDate
+        .startOf("month")
+        .diff(minDate.startOf("month"), "month")
+    if (spanMonths <= 0) return undefined
+
+    // Pick the smallest step that keeps the tick count at or below the target.
+    const step =
+        MONTH_STEPS.find((s) => spanMonths / s <= targetCount) ??
+        MONTH_STEPS[MONTH_STEPS.length - 1]
+
+    // Start from January of a "nice" anchor year. For year-based steps
+    // (12+ months), round the year down to the nearest multiple of the step in
+    // years, e.g. step=5y and min year=2023 -> anchor year=2020.
+    let anchorYear = minDate.year()
+    if (step >= 12) {
+        const yearsStep = step / 12
+        anchorYear = Math.floor(anchorYear / yearsStep) * yearsStep
+    }
+
+    const anchor = dayjs.utc(`${anchorYear}-01-01`)
+    const monthsFromAnchor = (date: dayjs.Dayjs): number =>
+        date.startOf("month").diff(anchor, "month")
+
+    // The first and last indices that stay within the domain: round the
+    // start up and the end down so both ticks land inside the domain.
+    const firstStep = Math.ceil(monthsFromAnchor(minDate) / step)
+    const lastStep = Math.floor(monthsFromAnchor(maxDate) / step)
+
+    const grid = _.range(firstStep, lastStep + 1).map((k) =>
+        convertDateToDaysSinceEpoch(anchor.add(k * step, "month"))
+    )
+
+    // When every tick is a January, drop the redundant month and label only the year.
+    const isJanuary = (value: number): boolean =>
+        convertDaysSinceEpochToDate(value).month() === 0
+    if (grid.every(isJanuary))
+        return grid.map((value) => makeDayTick(value, "YYYY"))
+
+    // Otherwise label the month only, keeping the year on the first tick
+    // and each January (i.e. wherever the year changes)
+    const years = grid.map((value) => convertDaysSinceEpochToDate(value).year())
+    return grid.map((value, i) => {
+        const isNewYear = i === 0 || years[i] !== years[i - 1]
+        return makeDayTick(value, isNewYear ? "MMM YYYY" : "MMM")
+    })
+}
+
+/** One tick per domain value, each labeled with its full month and year */
+export function buildDiscreteMonthlyAxisTicks({
+    bandValues,
+}: {
+    bandValues: number[]
+}): Tickmark[] {
+    return _.sortBy(_.uniq(bandValues)).map((value) =>
+        makeDayTick(value, "MMM YYYY")
+    )
+}
+
+/**
+ * The label sets a discrete monthly axis can pick from, ordered from finest to
+ * coarsest — each a single evenly-spaced set (every month, quarter, year, 2
+ * years, …). The axis shows the finest that fits; using one spacing per set
+ * ensures the gaps remain uniform.
+ */
+export function getDiscreteMonthlyTickOptions({
+    bandValues,
+}: {
+    bandValues: number[]
+}): Tickmark[][] {
+    const sortedValues = _.sortBy(_.uniq(bandValues))
+
+    const monthIndex = (value: number): number => {
+        const date = convertDaysSinceEpochToDate(value)
+        return date.year() * 12 + date.month()
+    }
+
+    const tiers: Tickmark[][] = []
+    for (const step of MONTH_STEPS) {
+        const valuesOnGrid = sortedValues.filter(
+            (value) => monthIndex(value) % step === 0
+        )
+        if (!valuesOnGrid.length) continue
+
+        tiers.push(valuesOnGrid.map((value) => makeDayTick(value, "MMM YYYY")))
+
+        if (valuesOnGrid.length === 1) break // nothing coarser can add
+    }
+
+    return tiers
+}

--- a/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.ts
+++ b/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.ts
@@ -57,24 +57,10 @@ const WEEK_STEPS = [
 // A fixed Monday (in days since epoch) that anchors weekly grids
 const MONDAY_REFERENCE = snapToIntervalStart(0, TimeInterval.Week)
 
-// Time intervals with calendar-aware axis ticks; all other intervals
-// fall back to the generic d3 ticks
-const CALENDAR_TICK_INTERVALS = [
-    TimeInterval.Quarter,
-    TimeInterval.Month,
-    TimeInterval.Week,
-    TimeInterval.Day,
-] as const
-
-export type CalendarTickInterval = (typeof CALENDAR_TICK_INTERVALS)[number]
-
-export function isCalendarTickInterval(
-    interval: TimeInterval
-): interval is CalendarTickInterval {
-    return (CALENDAR_TICK_INTERVALS as readonly TimeInterval[]).includes(
-        interval
-    )
-}
+export type CalendarTickInterval = Exclude<
+    TimeInterval,
+    TimeInterval.Year | TimeInterval.Decade
+>
 
 /** A tickmark for a day-since-epoch `value`, labeled with the given dayjs format. */
 function makeDayTick(value: number, format: string): Tickmark {
@@ -144,23 +130,19 @@ function labelGridWithYearOnChange(
     })
 }
 
-/**
- * Calendar-aware ticks for a time axis, or `undefined` if the interval has no
- * special handling (the caller then falls back to the generic d3 ticks).
- */
+/** Calendar-aware ticks for a time axis */
 export function buildTimeAxisTicks({
     interval,
     domain,
     targetCount,
     bandValues,
 }: {
-    interval: TimeInterval
+    interval: CalendarTickInterval
     domain: [number, number]
     targetCount: number
     bandValues?: number[]
 }): Tickmark[] | undefined {
-    if (!isCalendarTickInterval(interval)) return undefined
-
+    // Discrete time axes place one tick per provided band value
     if (bandValues?.length) return buildDiscreteTimeAxisTicks({ bandValues })
 
     return match(interval)

--- a/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.ts
+++ b/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.ts
@@ -25,6 +25,20 @@ const MONTH_STEPS = [
     1200, // 100 years
 ] as const
 
+// Calendar-nice step sizes in months for quarterly axes,
+// so they never show sub-quarter ticks
+const QUARTER_STEPS = [
+    3, // 1 quarter
+    6, // 2 quarters
+    12, // 1 year
+    24, // 2 years
+    60, // 5 years
+    120, // 10 years
+    300, // 25 years
+    600, // 50 years
+    1200, // 100 years
+] as const
+
 // Calendar-nice step sizes in days
 const DAY_STEPS = [
     1, // 1 day
@@ -46,6 +60,7 @@ const MONDAY_REFERENCE = snapToIntervalStart(0, TimeInterval.Week)
 // Time intervals with calendar-aware axis ticks; all other intervals
 // fall back to the generic d3 ticks
 const CALENDAR_TICK_INTERVALS = [
+    TimeInterval.Quarter,
     TimeInterval.Month,
     TimeInterval.Week,
     TimeInterval.Day,
@@ -149,6 +164,9 @@ export function buildTimeAxisTicks({
     if (bandValues?.length) return buildDiscreteTimeAxisTicks({ bandValues })
 
     return match(interval)
+        .with(TimeInterval.Quarter, () =>
+            buildContinuousQuarterlyAxisTicks({ domain, targetCount })
+        )
         .with(TimeInterval.Month, () =>
             buildContinuousMonthlyAxisTicks({ domain, targetCount })
         )
@@ -162,15 +180,18 @@ export function buildTimeAxisTicks({
 }
 
 /**
- * An evenly-spaced, January-anchored month grid, sized to `targetCount`,
- * with redundant year/month parts dropped from the labels.
+ * An evenly-spaced, January-anchored month grid stepped by one of the given
+ * step sizes, sized to `targetCount`, with redundant year/month parts
+ * dropped from the labels.
  */
-export function buildContinuousMonthlyAxisTicks({
+function buildContinuousMonthGridTicks({
     domain,
     targetCount,
+    steps,
 }: {
     domain: [number, number]
     targetCount: number
+    steps: readonly number[]
 }): Tickmark[] | undefined {
     const minDate = convertDaysSinceEpochToDate(domain[0])
     const maxDate = convertDaysSinceEpochToDate(domain[1])
@@ -182,8 +203,8 @@ export function buildContinuousMonthlyAxisTicks({
 
     // Pick the smallest step that keeps the tick count at or below the target.
     const step =
-        MONTH_STEPS.find((s) => spanMonths / s <= targetCount) ??
-        MONTH_STEPS[MONTH_STEPS.length - 1]
+        steps.find((s) => spanMonths / s <= targetCount) ??
+        steps[steps.length - 1]
 
     // Start from January of a "nice" anchor year. For year-based steps
     // (12+ months), round the year down to the nearest multiple of the step in
@@ -221,6 +242,43 @@ export function buildContinuousMonthlyAxisTicks({
     return labelGridWithYearOnChange(grid, {
         format: "MMM",
         formatWithYear: "MMM YYYY",
+    })
+}
+
+/**
+ * An evenly-spaced, January-anchored month grid, sized to `targetCount`,
+ * with redundant year/month parts dropped from the labels.
+ */
+export function buildContinuousMonthlyAxisTicks({
+    domain,
+    targetCount,
+}: {
+    domain: [number, number]
+    targetCount: number
+}): Tickmark[] | undefined {
+    return buildContinuousMonthGridTicks({
+        domain,
+        targetCount,
+        steps: MONTH_STEPS,
+    })
+}
+
+/**
+ * A calendar-nice quarter grid (quarter starts: Jan/Apr/Jul/Oct 1, labeled
+ * with month names), sized to `targetCount`. Uses the month grid restricted
+ * to quarter-sized steps, so quarterly axes never show sub-quarter ticks.
+ */
+export function buildContinuousQuarterlyAxisTicks({
+    domain,
+    targetCount,
+}: {
+    domain: [number, number]
+    targetCount: number
+}): Tickmark[] | undefined {
+    return buildContinuousMonthGridTicks({
+        domain,
+        targetCount,
+        steps: QUARTER_STEPS,
     })
 }
 
@@ -363,6 +421,9 @@ export function getDiscreteTimeTickOptions({
     bandValues: number[]
 }): Tickmark[][] {
     return match(interval)
+        .with(TimeInterval.Quarter, () =>
+            getDiscreteQuarterlyTickOptions({ bandValues })
+        )
         .with(TimeInterval.Month, () =>
             getDiscreteMonthlyTickOptions({ bandValues })
         )
@@ -438,6 +499,20 @@ export function getDiscreteMonthlyTickOptions({
     return buildTickOptionsFromGrids(
         bandValues,
         MONTH_STEPS.map(
+            (step) => (value: CalendarValue) => monthGridPosition(value, step)
+        )
+    )
+}
+
+/** See getDiscreteTimeTickOptions; steps every quarter, half-year, year, … */
+export function getDiscreteQuarterlyTickOptions({
+    bandValues,
+}: {
+    bandValues: number[]
+}): Tickmark[][] {
+    return buildTickOptionsFromGrids(
+        bandValues,
+        QUARTER_STEPS.map(
             (step) => (value: CalendarValue) => monthGridPosition(value, step)
         )
     )

--- a/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.ts
+++ b/packages/@ourworldindata/grapher/src/axis/timeAxisTicks.ts
@@ -6,6 +6,7 @@ import {
     convertDaysSinceEpochToDate,
     convertDateToDaysSinceEpoch,
     snapToIntervalStart,
+    sortNumeric,
 } from "@ourworldindata/utils"
 import { TimeInterval } from "@ourworldindata/types"
 import { match } from "ts-pattern"
@@ -86,12 +87,15 @@ function toCalendarValue(value: number): CalendarValue {
     }
 }
 
+// The Monday that anchors weekly day grids
+const WEEK_GRID_REFERENCE = snapToIntervalStart(0, TimeInterval.Week)
+
 /**
  * The reference day that anchors a day grid with the given step: a Monday for
  * weekly steps (so ticks land on week starts), the epoch otherwise.
  */
 function dayGridReference(step: number): number {
-    return step % 7 === 0 ? snapToIntervalStart(0, TimeInterval.Week) : 0
+    return step % 7 === 0 ? WEEK_GRID_REFERENCE : 0
 }
 
 /**
@@ -412,7 +416,10 @@ export function buildDiscreteTimeAxisTicks({
 }: {
     bandValues: number[]
 }): Tickmark[] {
-    return _.sortBy(_.uniq(bandValues)).map((value) => ({ value, priority: 2 }))
+    return sortNumeric(_.uniq(bandValues)).map((value) => ({
+        value,
+        priority: 2,
+    }))
 }
 
 /**
@@ -454,7 +461,7 @@ function buildTickOptionsFromGrids(
     bandValues: number[],
     getGridIndexers: GetGridIndex[]
 ): Tickmark[][] {
-    const calendarValues = _.sortBy(_.uniq(bandValues)).map(toCalendarValue)
+    const calendarValues = sortNumeric(_.uniq(bandValues)).map(toCalendarValue)
 
     const makeTier = (values: CalendarValue[]): Tickmark[] =>
         values.map(({ value }) => ({ value, priority: 2 }))

--- a/packages/@ourworldindata/grapher/src/facet/FacetChart.tsx
+++ b/packages/@ourworldindata/grapher/src/facet/FacetChart.tsx
@@ -544,11 +544,11 @@ export class FacetChart
                 config.min = _.min(domains.map((d) => d[0]))
                 config.max = _.max(domains.map((d) => d[1]))
 
-                // Find domain values across all facets
-                const domainValues = _.uniq(
-                    axes.flatMap((axis) => axis.config.domainValues ?? [])
+                // Find band values across all facets
+                const bandValues = _.uniq(
+                    axes.flatMap((axis) => axis.config.bandValues ?? [])
                 )
-                if (domainValues.length > 0) config.domainValues = domainValues
+                if (bandValues.length > 0) config.bandValues = bandValues
 
                 // Find ticks across all facets
                 const ticks = _.uniq(

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedUtils.ts
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedUtils.ts
@@ -143,11 +143,7 @@ export function resolveCollision(
 export function getXAxisConfigDefaultsForStackedBar(
     chartState: StackedBarChartState
 ): AxisConfigInterface {
-    return {
-        hideGridlines: true,
-        domainValues: chartState.xValues,
-        ticks: chartState.xValues.map((value) => ({ value, priority: 2 })),
-    }
+    return { hideGridlines: true, bandValues: chartState.xValues }
 }
 
 function placeStackedAreaPoint(

--- a/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
+++ b/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
@@ -263,6 +263,7 @@ export interface Tickmark {
     faint?: boolean
     gridLineOnly?: boolean
     solid?: boolean // mostly for labelling domain start (e.g. 0)
+    label?: string
 }
 export interface TickFormattingOptions {
     roundingMode?: OwidVariableRoundingMode
@@ -353,11 +354,15 @@ export interface AxisConfigInterface {
     singleValueAxisPointAlign?: AxisAlign
 
     /**
-     * If given, think of the axis scale as a band scale, where each domain value
-     * occupies a fixed width. The axis is padded on both sides to reserve space
-     * for the outermost values.
+     * If given, treat the axis as a band scale: each value occupies a fixed
+     * width and the axis is padded on both sides to reserve space for the
+     * outermost values.
+     *
+     * These values also become the default tick positions (one tick per band),
+     * unless `ticks` is set explicitly or a calendar-aware tick layout applies
+     * (e.g. monthly time axes).
      */
-    domainValues?: number[]
+    bandValues?: number[]
 
     /**
      * Whether to offset the leftmost tick label so it doesn't overflow the axis start.

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -262,7 +262,9 @@ const SUB_YEARLY_INTERVALS = new Set<TimeInterval>([
  * Whether the interval is finer than a year and therefore encoded as
  * days-since-epoch (day/week/month/quarter)
  */
-export function isSubYearly(interval: TimeInterval): boolean {
+export function isSubYearly(
+    interval: TimeInterval
+): interval is Exclude<TimeInterval, TimeInterval.Year | TimeInterval.Decade> {
     return SUB_YEARLY_INTERVALS.has(interval)
 }
 


### PR DESCRIPTION
> _Written by Anthropic Claude Fable 5 — @sophiamersmann at the wheel._

Generate calendar-nice ticks and labels for time axes of month, day, week and quarter interval columns, instead of the generic d3 ticks.

- **Continuous axes** step along calendar-anchored grids: a January-anchored month grid (1/2/3/6/12/… month steps, restricted to quarter multiples for quarterly axes) and a day grid (1/2 days, weekly/biweekly on Mondays; week multiples only for weekly axes). For yearly ticks, the start and end ticks have the highest priority and are always shown.     This does not apply to sub-yearly axes, where the start and end ticks are only rendered when they coincide with a time grid value.
- **Discrete (band) axes** (stacked bars) place one tick per bar and thin the labels to the finest evenly-spaced calendar tier that fits (every value → biweekly → first-of-month/quarter/year, per interval), labeled by the column's own time format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)