### PR TITLE
🎉 Add migrant-demographics bespoke population pyramid

### DIFF
--- a/bespoke/projects/migrant-demographics/package.json
+++ b/bespoke/projects/migrant-demographics/package.json
@@ -1,0 +1,46 @@
+{
+    "name": "@owid/bespoke-migrant-demographics",
+    "private": true,
+    "type": "module",
+    "entrypoints": {
+        "js": "src/index.tsx",
+        "dev-only-global-css": "src/dev-only-global-css.css"
+    },
+    "scripts": {
+        "dev": "vite dev",
+        "build": "vite build",
+        "typecheck": "tsc"
+    },
+    "dependencies": {
+        "@fortawesome/fontawesome-svg-core": "^6.7.2",
+        "@fortawesome/free-solid-svg-icons": "^6.7.2",
+        "@fortawesome/react-fontawesome": "^0.2.2",
+        "@ourworldindata/components": "link:../../../packages/@ourworldindata/components",
+        "@ourworldindata/grapher": "link:../../../packages/@ourworldindata/grapher",
+        "@ourworldindata/types": "link:../../../packages/@ourworldindata/types",
+        "@ourworldindata/utils": "link:../../../packages/@ourworldindata/utils",
+        "@react-stately/flags": "^3.2.1",
+        "@rollup/plugin-swc": "^0.4.1",
+        "@tanstack/react-query": "^5.101.0",
+        "clsx": "^2.1.1",
+        "d3": "^7.9.0",
+        "normalize.css": "^8.0.1",
+        "nuqs": "^2.8.9",
+        "react": "^19.2.7",
+        "react-aria-components": "^1.18.0",
+        "react-dom": "^19.2.7",
+        "remeda": "^2.39.0",
+        "tippy.js": "^6.3.7",
+        "vite-plugin-css-position": "^2.0.9"
+    },
+    "devDependencies": {
+        "@types/d3": "^7.4.3",
+        "@types/react": "^19.2.17",
+        "@types/react-dom": "^19.2.3",
+        "@vitejs/plugin-react": "^6.0.2",
+        "sass": "^1.101.0",
+        "typescript": "^7.0.2",
+        "vite": "^8.0.16",
+        "vitest": "^4.1.8"
+    }
+}

--- a/bespoke/projects/migrant-demographics/src/base.scss
+++ b/bespoke/projects/migrant-demographics/src/base.scss
@@ -1,0 +1,6 @@
+@use "../../../../packages/@ourworldindata/components/src/styles/typography-constants"
+    as typography;
+
+:host {
+    font-family: typography.$sans-serif-font-stack;
+}

--- a/bespoke/projects/migrant-demographics/src/components/MigrantDemographicsCaptionedChart.tsx
+++ b/bespoke/projects/migrant-demographics/src/components/MigrantDemographicsCaptionedChart.tsx
@@ -1,0 +1,83 @@
+import { Frame } from "../../../../components/Frame/Frame.js"
+import { ChartHeader } from "../../../../components/ChartHeader/ChartHeader.js"
+import { ChartFooter } from "../../../../components/ChartFooter/ChartFooter.js"
+import { Spinner } from "../../../../components/Spinner/Spinner.js"
+
+import {
+    MetricMode,
+    NATIVE_BORN_COLOR,
+    PyramidData,
+} from "../helpers/constants.js"
+import {
+    formatCountWords,
+    formatEntityForSentence,
+    formatEntityForTitle,
+} from "../helpers/format.js"
+import { PopulationPyramid } from "./PopulationPyramid.js"
+
+export function MigrantDemographicsCaptionedChart({
+    data,
+    source,
+    note,
+    metric,
+    compare,
+    isLoading = false,
+}: {
+    data: PyramidData
+    source: string
+    note?: string
+    metric: MetricMode
+    compare: boolean
+    isLoading?: boolean
+}): React.ReactElement {
+    const entitySentence = formatEntityForSentence(data.entityName)
+    const entityTitle = formatEntityForTitle(data.entityName)
+
+    return (
+        <Frame className="migrant-demographics-captioned-chart">
+            <ChartHeader
+                className="migrant-demographics-header"
+                title={`Population pyramid of immigrants living in ${entityTitle}`}
+                subtitle={
+                    <>
+                        The age and sex profile of the{" "}
+                        {formatCountWords(data.totalMigrants)} living in{" "}
+                        {entitySentence} who were born elsewhere.
+                    </>
+                }
+            />
+
+            {compare && <NativeBornLegend />}
+
+            <div className="migrant-demographics-captioned-chart__chart-area">
+                {isLoading && <Spinner />}
+                <PopulationPyramid
+                    data={data}
+                    metric={metric}
+                    compare={compare}
+                />
+            </div>
+
+            <ChartFooter
+                className="migrant-demographics-footer"
+                source={source}
+                note={note}
+            />
+        </Frame>
+    )
+}
+
+function NativeBornLegend(): React.ReactElement {
+    return (
+        <div className="migrant-demographics-legend">
+            <span
+                className="migrant-demographics-legend__swatch"
+                style={{ backgroundColor: NATIVE_BORN_COLOR }}
+                aria-hidden
+            />
+            <span className="migrant-demographics-legend__label">
+                Native-born residents
+            </span>
+        </div>
+    )
+}

--- a/bespoke/projects/migrant-demographics/src/components/MigrantDemographicsChart.tsx
+++ b/bespoke/projects/migrant-demographics/src/components/MigrantDemographicsChart.tsx
@@ -1,0 +1,149 @@
+import { useMemo } from "react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { NuqsAdapter } from "nuqs/adapters/react"
+import {
+    parseAsBoolean,
+    parseAsInteger,
+    parseAsString,
+    parseAsStringLiteral,
+} from "nuqs"
+import * as R from "remeda"
+
+import { Time } from "@ourworldindata/types"
+
+import { useUrlState } from "../../../../hooks/useUrlState.js"
+import { Spinner } from "../../../../components/Spinner/Spinner.js"
+
+import { MetricMode, MigrantDemographicsConfig } from "../helpers/constants.js"
+import { useMigrantDataset } from "../helpers/dataFetching.js"
+import { MigrantDemographicsCaptionedChart } from "./MigrantDemographicsCaptionedChart.js"
+import { MigrantDemographicsControls } from "./MigrantDemographicsControls.js"
+
+const DEFAULT_ENTITY = "United States of America"
+const DEFAULT_METRIC: MetricMode = "number"
+
+// Sentinel meaning "the latest available year"; the concrete default isn't
+// known until the data has loaded.
+const LATEST_YEAR = -1
+
+const queryClient = new QueryClient()
+
+export function MigrantDemographicsChartWithProviders(props: {
+    container?: HTMLDivElement
+    config?: MigrantDemographicsConfig
+}): React.ReactElement {
+    return (
+        <NuqsAdapter>
+            <QueryClientProvider client={queryClient}>
+                <MigrantDemographicsChart config={props.config} />
+            </QueryClientProvider>
+        </NuqsAdapter>
+    )
+}
+
+function MigrantDemographicsChart({
+    config,
+}: {
+    config?: MigrantDemographicsConfig
+}): React.ReactElement {
+    const urlSync = config?.urlSync ?? false
+
+    const [entityName, setEntityName] = useUrlState({
+        key: "migrantEntity",
+        parser: parseAsString,
+        defaultValue: config?.entity ?? DEFAULT_ENTITY,
+        enabled: urlSync,
+    })
+    const [year, setYear] = useUrlState<Time>({
+        key: "migrantYear",
+        parser: parseAsInteger,
+        defaultValue: config?.year ?? LATEST_YEAR,
+        enabled: urlSync,
+    })
+    const [metric, setMetric] = useUrlState<MetricMode>({
+        key: "migrantMetric",
+        parser: parseAsStringLiteral(["number", "share"]),
+        defaultValue: config?.metric ?? DEFAULT_METRIC,
+        enabled: urlSync,
+    })
+    const [compare, setCompare] = useUrlState<boolean>({
+        key: "migrantCompare",
+        parser: parseAsBoolean,
+        defaultValue: config?.compare ?? false,
+        enabled: urlSync,
+    })
+
+    const { dataset, status } = useMigrantDataset()
+
+    const entityNames = useMemo(
+        () => dataset?.entities.map((entity) => entity.name) ?? [],
+        [dataset]
+    )
+
+    // Clamp the (possibly URL- or config-provided) selections to what's
+    // available in the data.
+    const activeEntityName =
+        dataset && !dataset.hasEntity(entityName) ? DEFAULT_ENTITY : entityName
+    const activeYear = dataset ? resolveYear(year, dataset.years) : year
+
+    const pyramidData = useMemo(
+        () => dataset?.getPyramidData(activeEntityName, activeYear),
+        [dataset, activeEntityName, activeYear]
+    )
+
+    if (status === "error") return <MigrantDemographicsError />
+    if (status === "pending" || !dataset) return <MigrantDemographicsSkeleton />
+    if (!pyramidData) return <MigrantDemographicsError />
+
+    return (
+        <div className="migrant-demographics-chart">
+            {!config?.hideControls && (
+                <MigrantDemographicsControls
+                    entityNames={entityNames}
+                    entityName={activeEntityName}
+                    years={dataset.years}
+                    year={activeYear}
+                    metric={metric}
+                    compare={compare}
+                    setEntityName={setEntityName}
+                    setYear={setYear}
+                    setMetric={setMetric}
+                    setCompare={setCompare}
+                />
+            )}
+            <MigrantDemographicsCaptionedChart
+                data={pyramidData}
+                source={dataset.source}
+                metric={metric}
+                compare={compare}
+            />
+        </div>
+    )
+}
+
+function resolveYear(year: Time, years: Time[]): Time {
+    if (years.length === 0) return year
+    if (year === LATEST_YEAR) return years[years.length - 1]
+    // Snap to the nearest available year within range.
+    const clamped = R.clamp(year, {
+        min: years[0],
+        max: years[years.length - 1],
+    })
+    return R.firstBy(years, (y) => Math.abs(y - clamped)) ?? clamped
+}
+
+function MigrantDemographicsError(): React.ReactElement {
+    return (
+        <div className="migrant-demographics-error">
+            The migrant demographics visualization can’t be loaded.
+        </div>
+    )
+}
+
+function MigrantDemographicsSkeleton(): React.ReactElement {
+    return (
+        <div className="migrant-demographics-skeleton">
+            <Spinner />
+        </div>
+    )
+}

--- a/bespoke/projects/migrant-demographics/src/components/MigrantDemographicsControls.tsx
+++ b/bespoke/projects/migrant-demographics/src/components/MigrantDemographicsControls.tsx
@@ -1,0 +1,113 @@
+import { useMemo } from "react"
+
+import { faCheck } from "@fortawesome/free-solid-svg-icons"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import { Time } from "@ourworldindata/types"
+
+import { Frame } from "../../../../components/Frame/Frame.js"
+import { EntityDropdown } from "../../../../components/EntityDropdown/EntityDropdown.js"
+import { TimeSlider } from "../../../../components/TimeSlider/TimeSlider.js"
+import { Switcher } from "../../../../components/Switcher/Switcher.js"
+
+import { MetricMode } from "../helpers/constants.js"
+
+export function MigrantDemographicsControls({
+    entityNames,
+    entityName,
+    years,
+    year,
+    metric,
+    compare,
+    setEntityName,
+    setYear,
+    setMetric,
+    setCompare,
+}: {
+    entityNames: string[]
+    entityName: string
+    years: Time[]
+    year: Time
+    metric: MetricMode
+    compare: boolean
+    setEntityName: (entityName: string) => void
+    setYear: (year: Time) => void
+    setMetric: (metric: MetricMode) => void
+    setCompare: (compare: boolean) => void
+}): React.ReactElement {
+    const entityOptions = useMemo(
+        () =>
+            entityNames.map((name) => ({
+                value: name,
+                label: name,
+            })),
+        [entityNames]
+    )
+
+    return (
+        <Frame className="migrant-demographics-controls">
+            <div className="migrant-demographics-controls__row">
+                <div className="migrant-demographics-controls__field">
+                    <label className="migrant-demographics-controls__label">
+                        Country or region
+                    </label>
+                    <EntityDropdown
+                        label="Country or region"
+                        availableEntities={entityOptions}
+                        selectedEntityName={entityName}
+                        onChange={setEntityName}
+                        placeholder="Select a country or region..."
+                        aria-label="Select a country or region"
+                    />
+                </div>
+                <div className="migrant-demographics-controls__field migrant-demographics-controls__field--year">
+                    <label className="migrant-demographics-controls__label">
+                        Year: <strong>{year}</strong>
+                    </label>
+                    <TimeSlider
+                        className="migrant-demographics-time-slider"
+                        times={years}
+                        selectedTime={year}
+                        onChange={setYear}
+                    />
+                </div>
+            </div>
+
+            <div className="migrant-demographics-controls__row migrant-demographics-controls__row--toggles">
+                {!compare && (
+                    <div className="migrant-demographics-controls__field migrant-demographics-controls__field--metric">
+                        <label className="migrant-demographics-controls__label">
+                            Show
+                        </label>
+                        <Switcher<MetricMode>
+                            className="migrant-demographics-metric-switcher"
+                            ariaLabel="Show absolute numbers or shares"
+                            selectedKey={metric}
+                            onChange={setMetric}
+                            items={[
+                                { key: "number", element: "Number" },
+                                { key: "share", element: "Share" },
+                            ]}
+                        />
+                    </div>
+                )}
+                <label className="migrant-demographics-checkbox">
+                    <input
+                        type="checkbox"
+                        className="migrant-demographics-checkbox__input"
+                        checked={compare}
+                        onChange={(event) => setCompare(event.target.checked)}
+                    />
+                    <span
+                        className="migrant-demographics-checkbox__box"
+                        aria-hidden
+                    >
+                        <FontAwesomeIcon icon={faCheck} />
+                    </span>
+                    <span className="migrant-demographics-checkbox__label">
+                        Compare with native-born
+                    </span>
+                </label>
+            </div>
+        </Frame>
+    )
+}

--- a/bespoke/projects/migrant-demographics/src/components/PopulationPyramid.tsx
+++ b/bespoke/projects/migrant-demographics/src/components/PopulationPyramid.tsx
@@ -1,0 +1,429 @@
+import { useMemo, useState } from "react"
+import { scaleLinear } from "d3"
+
+import { useContainerWidth } from "../../../../hooks/useContainerWidth.js"
+
+import {
+    AXIS_LABEL_COLOR,
+    AgeBandRow,
+    FEMALE_COLOR,
+    GRID_LINE_COLOR,
+    MALE_COLOR,
+    MetricMode,
+    NATIVE_BORN_COLOR,
+    PyramidData,
+} from "../helpers/constants.js"
+import {
+    formatCountShort,
+    formatPercent,
+    formatShareShort,
+} from "../helpers/format.js"
+
+export interface PopulationPyramidProps {
+    data: PyramidData
+    metric: MetricMode
+    compare: boolean
+}
+
+/** The value that determines a bar's length, given the current metric. */
+interface RowValues {
+    ageBand: string
+    men: number
+    women: number
+    nativeMen: number
+    nativeWomen: number
+}
+
+const MIN_ROW_HEIGHT = 16
+const MAX_ROW_HEIGHT = 28
+
+export function PopulationPyramid(
+    props: PopulationPyramidProps
+): React.ReactElement {
+    const { ref, width } = useContainerWidth()
+    return (
+        <div ref={ref} className="population-pyramid">
+            {width > 0 && <PopulationPyramidSvg {...props} width={width} />}
+        </div>
+    )
+}
+
+function PopulationPyramidSvg({
+    data,
+    metric,
+    compare,
+    width,
+}: PopulationPyramidProps & { width: number }): React.ReactElement {
+    // Comparing migrants with the native-born only makes sense as shares,
+    // since the two populations differ by an order of magnitude.
+    const effectiveMetric: MetricMode = compare ? "share" : metric
+
+    const isNarrow = width < 480
+    const centerWidth = Math.round(clamp(width * 0.14, 52, 84))
+    const rowHeight = clamp(
+        Math.round((width * 0.55) / data.rows.length),
+        MIN_ROW_HEIGHT,
+        MAX_ROW_HEIGHT
+    )
+    const barHeight = Math.round(rowHeight * 0.72)
+
+    const fontSize = {
+        panelHeader: isNarrow ? 12 : 14,
+        ageBand: isNarrow ? 11 : 13,
+        tick: isNarrow ? 10 : 12,
+        axisTitle: isNarrow ? 11 : 13,
+        value: isNarrow ? 10 : 12,
+    }
+
+    const margin = {
+        top: fontSize.panelHeader + 18,
+        bottom: fontSize.tick + fontSize.axisTitle + 26,
+    }
+
+    const panelWidth = (width - centerWidth) / 2
+    const rightStart = panelWidth + centerWidth
+    const chartHeight = data.rows.length * rowHeight
+    const height = margin.top + chartHeight + margin.bottom
+    const chartBottom = margin.top + chartHeight
+
+    // Convert raw counts to the plotted value (absolute or share of the
+    // respective population).
+    const rowValues: RowValues[] = useMemo(() => {
+        const toShare = (value: number, total: number): number =>
+            total > 0 ? (value / total) * 100 : 0
+        return data.rows.map((row: AgeBandRow) => {
+            if (effectiveMetric === "share") {
+                return {
+                    ageBand: row.ageBand,
+                    men: toShare(row.men, data.totalMigrants),
+                    women: toShare(row.women, data.totalMigrants),
+                    nativeMen: toShare(row.nativeMen, data.totalNativeBorn),
+                    nativeWomen: toShare(row.nativeWomen, data.totalNativeBorn),
+                }
+            }
+            return {
+                ageBand: row.ageBand,
+                men: row.men,
+                women: row.women,
+                nativeMen: row.nativeMen,
+                nativeWomen: row.nativeWomen,
+            }
+        })
+    }, [data, effectiveMetric])
+
+    const maxValue = useMemo(() => {
+        let max = 0
+        for (const row of rowValues) {
+            max = Math.max(max, row.men, row.women)
+            if (compare) max = Math.max(max, row.nativeMen, row.nativeWomen)
+        }
+        return max || 1
+    }, [rowValues, compare])
+
+    // Length of a bar (0 at the centre, growing outward).
+    const lengthScale = useMemo(
+        () => scaleLinear().domain([0, maxValue]).range([0, panelWidth]),
+        [maxValue, panelWidth]
+    )
+
+    const ticks = useMemo(
+        () => lengthScale.ticks(isNarrow ? 4 : 5),
+        [lengthScale, isNarrow]
+    )
+
+    const formatTick = (value: number): string =>
+        effectiveMetric === "share"
+            ? formatShareShort(value)
+            : formatCountShort(value)
+
+    const [hoveredBand, setHoveredBand] = useState<string | null>(null)
+
+    // Row i (0-4) sits at the bottom; 75+ at the top.
+    const rowY = (index: number): number =>
+        margin.top + (data.rows.length - 1 - index) * rowHeight
+
+    const menPercent = formatPercent(
+        data.totalMigrants > 0 ? data.totalMen / data.totalMigrants : 0
+    )
+    const womenPercent = formatPercent(
+        data.totalMigrants > 0 ? data.totalWomen / data.totalMigrants : 0
+    )
+
+    const centerX = panelWidth + centerWidth / 2
+
+    return (
+        <svg
+            className="population-pyramid__svg"
+            viewBox={`0 0 ${width} ${height}`}
+            width={width}
+            height={height}
+            role="img"
+            aria-label="Population pyramid"
+        >
+            {/* Panel headers */}
+            <text
+                x={panelWidth / 2}
+                y={margin.top - 8}
+                textAnchor="middle"
+                className="population-pyramid__panel-header"
+                fontSize={fontSize.panelHeader}
+            >
+                Men ({menPercent})
+            </text>
+            <text
+                x={rightStart + panelWidth / 2}
+                y={margin.top - 8}
+                textAnchor="middle"
+                className="population-pyramid__panel-header"
+                fontSize={fontSize.panelHeader}
+            >
+                Women ({womenPercent})
+            </text>
+
+            {/* Gridlines + tick labels */}
+            {ticks.map((tick) => {
+                const len = lengthScale(tick)
+                return (
+                    <g key={tick} className="population-pyramid__grid">
+                        <line
+                            x1={panelWidth - len}
+                            y1={margin.top}
+                            x2={panelWidth - len}
+                            y2={chartBottom}
+                            stroke={GRID_LINE_COLOR}
+                        />
+                        <line
+                            x1={rightStart + len}
+                            y1={margin.top}
+                            x2={rightStart + len}
+                            y2={chartBottom}
+                            stroke={GRID_LINE_COLOR}
+                        />
+                        <text
+                            x={panelWidth - len}
+                            y={chartBottom + fontSize.tick + 6}
+                            textAnchor="middle"
+                            fill={AXIS_LABEL_COLOR}
+                            fontSize={fontSize.tick}
+                        >
+                            {formatTick(tick)}
+                        </text>
+                        <text
+                            x={rightStart + len}
+                            y={chartBottom + fontSize.tick + 6}
+                            textAnchor="middle"
+                            fill={AXIS_LABEL_COLOR}
+                            fontSize={fontSize.tick}
+                        >
+                            {formatTick(tick)}
+                        </text>
+                    </g>
+                )
+            })}
+
+            {/* Bars */}
+            {rowValues.map((row, index) => {
+                const y = rowY(index) + (rowHeight - barHeight) / 2
+                const menLen = lengthScale(row.men)
+                const womenLen = lengthScale(row.women)
+                const dimmed =
+                    hoveredBand !== null && hoveredBand !== row.ageBand
+                const opacity = dimmed ? 0.35 : 1
+                return (
+                    <g key={row.ageBand}>
+                        <rect
+                            x={panelWidth - menLen}
+                            y={y}
+                            width={menLen}
+                            height={barHeight}
+                            fill={MALE_COLOR}
+                            opacity={opacity}
+                            shapeRendering="crispEdges"
+                        />
+                        <rect
+                            x={rightStart}
+                            y={y}
+                            width={womenLen}
+                            height={barHeight}
+                            fill={FEMALE_COLOR}
+                            opacity={opacity}
+                            shapeRendering="crispEdges"
+                        />
+                    </g>
+                )
+            })}
+
+            {/* Native-born comparison outline */}
+            {compare && (
+                <>
+                    <StepOutline
+                        rows={rowValues}
+                        pick={(row) => row.nativeMen}
+                        lengthScale={lengthScale}
+                        rowY={rowY}
+                        rowHeight={rowHeight}
+                        baseX={panelWidth}
+                        direction={-1}
+                    />
+                    <StepOutline
+                        rows={rowValues}
+                        pick={(row) => row.nativeWomen}
+                        lengthScale={lengthScale}
+                        rowY={rowY}
+                        rowHeight={rowHeight}
+                        baseX={rightStart}
+                        direction={1}
+                    />
+                </>
+            )}
+
+            {/* Age-band labels in the centre column */}
+            {data.rows.map((row, index) => (
+                <text
+                    key={row.ageBand}
+                    x={centerX}
+                    y={rowY(index) + rowHeight / 2}
+                    textAnchor="middle"
+                    dominantBaseline="central"
+                    className="population-pyramid__age-label"
+                    fontSize={fontSize.ageBand}
+                >
+                    {row.ageBand}
+                </text>
+            ))}
+
+            {/* Hovered-row value labels */}
+            {hoveredBand !== null &&
+                (() => {
+                    const index = rowValues.findIndex(
+                        (row) => row.ageBand === hoveredBand
+                    )
+                    if (index === -1) return null
+                    const row = rowValues[index]
+                    const y = rowY(index) + rowHeight / 2
+                    const menLen = lengthScale(row.men)
+                    const womenLen = lengthScale(row.women)
+                    const format = (value: number): string =>
+                        effectiveMetric === "share"
+                            ? `${value.toFixed(1)}%`
+                            : formatCountShort(value)
+                    return (
+                        <>
+                            <text
+                                x={panelWidth - menLen - 5}
+                                y={y}
+                                textAnchor="end"
+                                dominantBaseline="central"
+                                className="population-pyramid__value-label"
+                                fontSize={fontSize.value}
+                                fill={MALE_COLOR}
+                            >
+                                {format(row.men)}
+                            </text>
+                            <text
+                                x={rightStart + womenLen + 5}
+                                y={y}
+                                textAnchor="start"
+                                dominantBaseline="central"
+                                className="population-pyramid__value-label"
+                                fontSize={fontSize.value}
+                                fill={FEMALE_COLOR}
+                            >
+                                {format(row.women)}
+                            </text>
+                        </>
+                    )
+                })()}
+
+            {/* Axis title */}
+            <text
+                x={centerX}
+                y={height - 6}
+                textAnchor="middle"
+                className="population-pyramid__axis-title"
+                fontSize={fontSize.axisTitle}
+            >
+                {effectiveMetric === "share"
+                    ? "Share of each population"
+                    : "Number of immigrants"}
+            </text>
+
+            {/* Hover hit areas spanning the full width of each row */}
+            {data.rows.map((row, index) => (
+                <rect
+                    key={row.ageBand}
+                    x={0}
+                    y={rowY(index)}
+                    width={width}
+                    height={rowHeight}
+                    fill="transparent"
+                    onMouseEnter={() => setHoveredBand(row.ageBand)}
+                    onMouseLeave={() => setHoveredBand(null)}
+                />
+            ))}
+        </svg>
+    )
+}
+
+/**
+ * A stepped outline hugging the outer edge of the bars for one panel, used to
+ * overlay the native-born profile. `direction` is -1 for the left (men) panel
+ * and +1 for the right (women) panel.
+ */
+function StepOutline({
+    rows,
+    pick,
+    lengthScale,
+    rowY,
+    rowHeight,
+    baseX,
+    direction,
+}: {
+    rows: RowValues[]
+    pick: (row: RowValues) => number
+    lengthScale: (value: number) => number
+    rowY: (index: number) => number
+    rowHeight: number
+    baseX: number
+    direction: 1 | -1
+}): React.ReactElement {
+    const points: Array<[number, number]> = []
+    // Walk from the top row (last index) down to the bottom row (index 0).
+    const orderedIndices = rows.map((_, i) => i).reverse()
+
+    // Start on the centre axis at the very top.
+    const firstIndex = orderedIndices[0]
+    points.push([baseX, rowY(firstIndex)])
+
+    for (const index of orderedIndices) {
+        const len = lengthScale(pick(rows[index]))
+        const x = baseX + direction * len
+        const top = rowY(index)
+        const bottom = top + rowHeight
+        points.push([x, top])
+        points.push([x, bottom])
+    }
+
+    // Return to the centre axis at the very bottom.
+    const lastIndex = orderedIndices[orderedIndices.length - 1]
+    points.push([baseX, rowY(lastIndex) + rowHeight])
+
+    const d = points
+        .map(([x, y], i) => `${i === 0 ? "M" : "L"}${x},${y}`)
+        .join(" ")
+
+    return (
+        <path
+            d={d}
+            fill="none"
+            stroke={NATIVE_BORN_COLOR}
+            strokeWidth={1.5}
+            strokeLinejoin="round"
+            className="population-pyramid__native-outline"
+        />
+    )
+}
+
+function clamp(value: number, min: number, max: number): number {
+    return Math.max(min, Math.min(max, value))
+}

--- a/bespoke/projects/migrant-demographics/src/demo.scss
+++ b/bespoke/projects/migrant-demographics/src/demo.scss
@@ -1,0 +1,12 @@
+// Styles needed outside the Shadow DOM for portaled react-aria overlays
+// (dropdown menus, popovers). These are imported on the demo page for
+// testing purposes. On the real site, these styles are already available
+// globally.
+
+@import "../../../../packages/@ourworldindata/components/src/styles/colors.scss";
+@import "../../../../packages/@ourworldindata/components/src/styles/variables.scss";
+@import "../../../../packages/@ourworldindata/components/src/styles/typography-constants";
+@import "../../../../packages/@ourworldindata/components/src/styles/typography.scss";
+@import "../../../../packages/@ourworldindata/grapher/src/core/variables.scss";
+@import "../../../../packages/@ourworldindata/grapher/src/core/typography.scss";
+@import "../../../../packages/@ourworldindata/grapher/src/controls/Dropdown.scss";

--- a/bespoke/projects/migrant-demographics/src/dev-only-global-css.css
+++ b/bespoke/projects/migrant-demographics/src/dev-only-global-css.css
@@ -1,0 +1,7 @@
+/*
+// Styles for portaled react-aria overlays (e.g. dropdown menus) that render
+// outside the Shadow DOM. On the real site these are available globally;
+// importing them here ensures they're present on the demo page too.
+*/
+
+@import "demo.scss";

--- a/bespoke/projects/migrant-demographics/src/grapher.scss
+++ b/bespoke/projects/migrant-demographics/src/grapher.scss
@@ -1,0 +1,12 @@
+@import "../../../../packages/@ourworldindata/components/src/styles/colors.scss";
+@import "../../../../packages/@ourworldindata/components/src/styles/variables.scss";
+@import "../../../../packages/@ourworldindata/components/src/styles/typography-constants.scss";
+@import "../../../../packages/@ourworldindata/components/src/styles/typography.scss";
+@import "../../../../packages/@ourworldindata/components/src/styles/util.scss";
+@import "../../../../packages/@ourworldindata/components/src/styles/mixins.scss";
+
+@import "../../../../packages/@ourworldindata/grapher/src/core/typography.scss";
+@import "../../../../packages/@ourworldindata/grapher/src/core/variables.scss";
+
+@import "../../../../packages/@ourworldindata/grapher/src/controls/Dropdown.scss";
+@import "../../../../packages/@ourworldindata/grapher/src/tooltip/Tooltip.scss";

--- a/bespoke/projects/migrant-demographics/src/helpers/constants.ts
+++ b/bespoke/projects/migrant-demographics/src/helpers/constants.ts
@@ -1,0 +1,83 @@
+import { EntityName, Time } from "@ourworldindata/types"
+
+/** Colors for the two sexes, matching OWID's population charts. */
+export const MALE_COLOR = "#4C6EE0"
+export const FEMALE_COLOR = "#B13267"
+
+/** The stepped outline drawn for the native-born comparison. */
+export const NATIVE_BORN_COLOR = "#1d3d63"
+
+export const GRID_LINE_COLOR = "#e7e7e7"
+export const AXIS_LABEL_COLOR = "#858585"
+
+export type MetricMode = "number" | "share"
+
+/** Per-year data for one entity, one array entry per age band. */
+export interface YearData {
+    /** Migrant stock — men */
+    m: number[]
+    /** Migrant stock — women */
+    f: number[]
+    /** Total resident population — men */
+    pm: number[]
+    /** Total resident population — women */
+    pf: number[]
+}
+
+export interface MigrantEntityJson {
+    code: number
+    name: EntityName
+    isAggregate: boolean
+    data: Record<string, YearData>
+}
+
+export interface MigrantMetaJson {
+    title: string
+    source: string
+    unit: string
+    note: string
+}
+
+export interface MigrantDataJson {
+    meta: MigrantMetaJson
+    ageBands: string[]
+    years: number[]
+    entities: MigrantEntityJson[]
+}
+
+export interface MigrantDemographicsConfig {
+    entity?: string
+    year?: number
+    metric?: MetricMode
+    compare?: boolean
+    hideControls?: boolean
+    urlSync?: boolean
+}
+
+/** A single row of the pyramid: one age band, both sexes. */
+export interface AgeBandRow {
+    ageBand: string
+    /** Migrant men in this band */
+    men: number
+    /** Migrant women in this band */
+    women: number
+    /** Native-born men in this band */
+    nativeMen: number
+    /** Native-born women in this band */
+    nativeWomen: number
+}
+
+/** Everything the pyramid needs to render for one entity/year selection. */
+export interface PyramidData {
+    entityName: EntityName
+    year: Time
+    ageBands: string[]
+    rows: AgeBandRow[]
+    /** Total migrant stock (both sexes) */
+    totalMigrants: number
+    /** Total native-born residents (both sexes) */
+    totalNativeBorn: number
+    /** Total migrant men / women (for the header percentages) */
+    totalMen: number
+    totalWomen: number
+}

--- a/bespoke/projects/migrant-demographics/src/helpers/dataFetching.ts
+++ b/bespoke/projects/migrant-demographics/src/helpers/dataFetching.ts
@@ -1,0 +1,97 @@
+import { QueryStatus, useQuery } from "@tanstack/react-query"
+import { fetchJson } from "@ourworldindata/utils"
+import { EntityName, Time } from "@ourworldindata/types"
+
+import {
+    AgeBandRow,
+    MigrantDataJson,
+    MigrantEntityJson,
+    PyramidData,
+} from "./constants.js"
+
+const DATA_URL =
+    "https://owid-public.owid.io/bespoke/migrant-demographics/migrant-demographics.json"
+
+/**
+ * Thin wrapper around the raw JSON providing convenient lookups. The whole
+ * dataset is a single (~800 KB) file, so we fetch it once and derive
+ * everything from it in memory.
+ */
+export class MigrantDataset {
+    readonly meta: MigrantDataJson["meta"]
+    readonly ageBands: string[]
+    readonly years: Time[]
+    readonly entities: MigrantEntityJson[]
+
+    private readonly entityByName: Map<EntityName, MigrantEntityJson>
+
+    constructor(json: MigrantDataJson) {
+        this.meta = json.meta
+        this.ageBands = json.ageBands
+        this.years = json.years
+        this.entities = json.entities
+        this.entityByName = new Map(
+            json.entities.map((entity) => [entity.name, entity])
+        )
+    }
+
+    get source(): string {
+        return this.meta.source
+    }
+
+    hasEntity(entityName: EntityName): boolean {
+        return this.entityByName.has(entityName)
+    }
+
+    /** Compute everything the pyramid needs for one entity/year selection. */
+    getPyramidData(
+        entityName: EntityName,
+        year: Time
+    ): PyramidData | undefined {
+        const entity = this.entityByName.get(entityName)
+        const yearData = entity?.data[String(year)]
+        if (!entity || !yearData) return undefined
+
+        const rows: AgeBandRow[] = this.ageBands.map((ageBand, i) => {
+            const men = yearData.m[i] ?? 0
+            const women = yearData.f[i] ?? 0
+            // Native-born = total resident population − migrants.
+            const nativeMen = Math.max(0, (yearData.pm[i] ?? 0) - men)
+            const nativeWomen = Math.max(0, (yearData.pf[i] ?? 0) - women)
+            return { ageBand, men, women, nativeMen, nativeWomen }
+        })
+
+        const sum = (pick: (row: AgeBandRow) => number): number =>
+            rows.reduce((acc, row) => acc + pick(row), 0)
+
+        const totalMen = sum((row) => row.men)
+        const totalWomen = sum((row) => row.women)
+        const totalNativeMen = sum((row) => row.nativeMen)
+        const totalNativeWomen = sum((row) => row.nativeWomen)
+
+        return {
+            entityName: entity.name,
+            year,
+            ageBands: this.ageBands,
+            rows,
+            totalMigrants: totalMen + totalWomen,
+            totalNativeBorn: totalNativeMen + totalNativeWomen,
+            totalMen,
+            totalWomen,
+        }
+    }
+}
+
+export function useMigrantDataset(): {
+    dataset?: MigrantDataset
+    status: QueryStatus
+} {
+    const result = useQuery({
+        queryKey: ["migrant-demographics"],
+        queryFn: () => fetchJson<MigrantDataJson>(DATA_URL),
+        staleTime: Infinity,
+    })
+
+    const dataset = result.data ? new MigrantDataset(result.data) : undefined
+    return { dataset, status: result.status }
+}

--- a/bespoke/projects/migrant-demographics/src/helpers/format.ts
+++ b/bespoke/projects/migrant-demographics/src/helpers/format.ts
@@ -1,0 +1,81 @@
+import { EntityName } from "@ourworldindata/types"
+
+/**
+ * Some entity names read awkwardly in a sentence ("... living in United States
+ * of America"). Map the most common ones to a natural phrase; everything else
+ * falls back to the raw name.
+ */
+const ENTITY_SENTENCE_OVERRIDES: Record<string, string> = {
+    "United States of America": "the United States",
+    "United Kingdom": "the United Kingdom",
+    "United Arab Emirates": "the United Arab Emirates",
+    Netherlands: "the Netherlands",
+    Philippines: "the Philippines",
+    "Czech Republic": "the Czech Republic",
+    "Democratic Republic of Congo": "the Democratic Republic of Congo",
+    "Russian Federation": "the Russian Federation",
+    WORLD: "the world",
+    AFRICA: "Africa",
+    ASIA: "Asia",
+    EUROPE: "Europe",
+    OCEANIA: "Oceania",
+    "NORTHERN AMERICA": "Northern America",
+    "LATIN AMERICA AND THE CARIBBEAN": "Latin America and the Caribbean",
+}
+
+export function formatEntityForSentence(entityName: EntityName): string {
+    return ENTITY_SENTENCE_OVERRIDES[entityName] ?? entityName
+}
+
+/** Title-cased display name, since some source names are all-caps. */
+export function formatEntityForTitle(entityName: EntityName): string {
+    return formatEntityForSentence(entityName)
+}
+
+/**
+ * Human-readable count for the subtitle, e.g. 50_632_836 → "51 million".
+ */
+export function formatCountWords(value: number): string {
+    if (value >= 1_000_000) {
+        const millions = value / 1_000_000
+        const rounded =
+            millions >= 10 ? Math.round(millions) : roundTo(millions, 1)
+        return `${formatNumber(rounded)} million`
+    }
+    if (value >= 1_000) {
+        return `${formatNumber(Math.round(value / 1_000))} thousand`
+    }
+    return formatNumber(Math.round(value))
+}
+
+/**
+ * Abbreviated axis-tick label, e.g. 500_000 → "500k", 2_500_000 → "2.5M".
+ */
+export function formatCountShort(value: number): string {
+    if (value === 0) return "0"
+    const abs = Math.abs(value)
+    if (abs >= 1_000_000) {
+        return `${(value / 1_000_000).toFixed(1)}M`
+    }
+    if (abs >= 1_000) {
+        return `${Math.round(value / 1_000)}k`
+    }
+    return formatNumber(Math.round(value))
+}
+
+export function formatShareShort(value: number): string {
+    return `${roundTo(value, 0)}%`
+}
+
+export function formatPercent(fraction: number): string {
+    return `${Math.round(fraction * 100)}%`
+}
+
+function roundTo(value: number, decimals: number): number {
+    const factor = Math.pow(10, decimals)
+    return Math.round(value * factor) / factor
+}
+
+function formatNumber(value: number): string {
+    return value.toLocaleString("en-US")
+}

--- a/bespoke/projects/migrant-demographics/src/index.scss
+++ b/bespoke/projects/migrant-demographics/src/index.scss
@@ -1,0 +1,19 @@
+@import "normalize.css";
+
+@import "@fortawesome/fontawesome-svg-core/styles.css";
+
+@import "tippy.js/dist/tippy.css";
+@import "tippy.js/themes/light.css";
+
+@import "./grapher.scss";
+@import "./base.scss";
+
+@import "./styles.scss";
+
+// Shared components
+@import "../../../components/Frame/Frame.scss";
+@import "../../../components/ChartHeader/ChartHeader.scss";
+@import "../../../components/ChartFooter/ChartFooter.scss";
+@import "../../../components/TimeSlider/TimeSlider.scss";
+@import "../../../components/Switcher/Switcher.scss";
+@import "../../../components/Spinner/Spinner.scss";

--- a/bespoke/projects/migrant-demographics/src/index.tsx
+++ b/bespoke/projects/migrant-demographics/src/index.tsx
@@ -1,0 +1,60 @@
+import { createRoot } from "react-dom/client"
+import { enableShadowDOM } from "@react-stately/flags"
+
+import type {
+    BespokeComponentMountFn,
+    BespokeComponentVariantsList,
+} from "owid-bespoke-types"
+import StylesTarget from "vite-plugin-css-position/react"
+
+import { MigrantDemographicsChartWithProviders } from "./components/MigrantDemographicsChart.js"
+import { MetricMode, MigrantDemographicsConfig } from "./helpers/constants.js"
+
+import "./index.scss"
+
+// Enable react-aria's internal Shadow DOM handling paths.
+// Must be called before any react-aria components render.
+enableShadowDOM()
+
+export const VARIANTS = [
+    {
+        name: "pyramid",
+        component: MigrantDemographicsChartWithProviders,
+        demoConfig: {},
+        demoSize: "wide",
+    },
+] satisfies BespokeComponentVariantsList
+
+export const mount: BespokeComponentMountFn = (
+    container: HTMLDivElement,
+    opts: { variant?: string; config?: Record<string, string> }
+) => {
+    const variant = VARIANTS.find((v) => v.name === opts.variant)
+    if (!variant) {
+        container.textContent = `Unknown variant: "${opts.variant}"`
+        return
+    }
+
+    const rawConfig = opts.config ?? {}
+    const config: MigrantDemographicsConfig = {
+        entity: rawConfig.entity,
+        year: rawConfig.year ? parseInt(rawConfig.year, 10) : undefined,
+        metric: parseMetric(rawConfig.metric),
+        compare: rawConfig.compare === "true",
+        hideControls: rawConfig.hideControls === "true",
+        urlSync: rawConfig.urlSync === "true",
+    }
+
+    const root = createRoot(container)
+    root.render(
+        <>
+            <StylesTarget />
+            <variant.component container={container} config={config} />
+        </>
+    )
+    return () => root.unmount()
+}
+
+function parseMetric(value: string | undefined): MetricMode | undefined {
+    return value === "number" || value === "share" ? value : undefined
+}

--- a/bespoke/projects/migrant-demographics/src/styles.scss
+++ b/bespoke/projects/migrant-demographics/src/styles.scss
@@ -1,0 +1,238 @@
+.migrant-demographics-chart {
+    color: $dark-text;
+    font-family: $sans-serif-font-stack;
+}
+
+// ------- Controls -------
+
+.migrant-demographics-controls {
+    .migrant-demographics-controls__row {
+        display: flex;
+        column-gap: 24px;
+        row-gap: 16px;
+        align-items: flex-end;
+
+        @include sm-only {
+            flex-direction: column;
+            align-items: stretch;
+            row-gap: 12px;
+        }
+    }
+
+    .migrant-demographics-controls__row + .migrant-demographics-controls__row {
+        margin-top: 16px;
+    }
+
+    .migrant-demographics-controls__row--toggles {
+        align-items: flex-end;
+
+        @include sm-only {
+            align-items: stretch;
+        }
+    }
+
+    .migrant-demographics-controls__field {
+        display: flex;
+        flex-direction: column;
+        row-gap: 6px;
+        flex: 1 1 0;
+        min-width: 0;
+    }
+
+    .migrant-demographics-controls__field--year {
+        flex: 1 1 0;
+    }
+
+    .migrant-demographics-controls__field--metric {
+        flex: 0 0 auto;
+    }
+
+    .migrant-demographics-controls__label {
+        font-size: 11px;
+        font-weight: 700;
+        letter-spacing: 0.1em;
+        color: $light-text;
+        text-transform: uppercase;
+
+        strong {
+            color: $dark-text;
+        }
+    }
+}
+
+.migrant-demographics-time-slider {
+    width: 100%;
+}
+
+.migrant-demographics-metric-switcher {
+    width: fit-content;
+}
+
+// ------- Compare checkbox -------
+
+.migrant-demographics-checkbox {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    cursor: pointer;
+    height: 30px;
+    user-select: none;
+
+    // Visually hidden but still accessible and focusable.
+    .migrant-demographics-checkbox__input {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        margin: 0;
+        padding: 0;
+        opacity: 0;
+        pointer-events: none;
+    }
+
+    .migrant-demographics-checkbox__box {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 18px;
+        height: 18px;
+        border-radius: 3px;
+        box-shadow: inset 0 0 0 1px $gray-50;
+        background: white;
+        color: white;
+        font-size: 11px;
+
+        svg {
+            opacity: 0;
+        }
+    }
+
+    .migrant-demographics-checkbox__input:checked
+        + .migrant-demographics-checkbox__box {
+        background: $active-text;
+        box-shadow: inset 0 0 0 1px $active-text;
+
+        svg {
+            opacity: 1;
+        }
+    }
+
+    .migrant-demographics-checkbox__input:focus-visible
+        + .migrant-demographics-checkbox__box {
+        outline: 2px solid $blue-40;
+        outline-offset: 1px;
+    }
+
+    .migrant-demographics-checkbox__label {
+        font-size: 11px;
+        font-weight: 700;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        color: $light-text;
+    }
+}
+
+// ------- Captioned chart -------
+
+.migrant-demographics-captioned-chart {
+    .migrant-demographics-captioned-chart__chart-area {
+        position: relative;
+        margin-top: 8px;
+    }
+}
+
+.migrant-demographics-header {
+    &.chart-header .chart-header__title {
+        @include sm-only {
+            font-size: 1.25rem;
+        }
+    }
+
+    &.chart-header .chart-header__subtitle {
+        @include sm-only {
+            font-size: 0.9375rem;
+        }
+    }
+}
+
+.migrant-demographics-footer {
+    font-size: 0.875rem;
+
+    @include sm-only {
+        font-size: 0.75rem;
+    }
+}
+
+.migrant-demographics-legend {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: 4px;
+    font-size: 0.8125rem;
+    color: $dark-text;
+
+    .migrant-demographics-legend__swatch {
+        width: 20px;
+        height: 3px;
+        flex-shrink: 0;
+    }
+
+    .migrant-demographics-legend__label {
+        font-weight: 700;
+    }
+}
+
+// ------- Pyramid -------
+
+.population-pyramid {
+    width: 100%;
+}
+
+.population-pyramid__svg {
+    display: block;
+    width: 100%;
+    height: auto;
+
+    .population-pyramid__panel-header {
+        fill: $dark-text;
+        font-weight: 700;
+    }
+
+    .population-pyramid__age-label {
+        fill: $dark-text;
+        font-weight: 700;
+    }
+
+    .population-pyramid__axis-title {
+        fill: $dark-text;
+        font-weight: 700;
+    }
+
+    .population-pyramid__value-label {
+        font-weight: 700;
+    }
+
+    .population-pyramid__native-outline {
+        pointer-events: none;
+    }
+}
+
+// ------- Loading / error -------
+
+.migrant-demographics-skeleton {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 600px;
+    border: 1px solid $frame-color;
+
+    .spinner {
+        color: $gray-60;
+    }
+}
+
+.migrant-demographics-error {
+    padding: 24px;
+    color: $light-text;
+}

--- a/bespoke/projects/migrant-demographics/src/vite-env.d.ts
+++ b/bespoke/projects/migrant-demographics/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/bespoke/projects/migrant-demographics/tsconfig.json
+++ b/bespoke/projects/migrant-demographics/tsconfig.json
@@ -1,0 +1,31 @@
+{
+    "compilerOptions": {
+        "target": "ES2020",
+        "module": "ESNext",
+        "moduleResolution": "bundler",
+        "jsx": "react-jsx",
+        "strict": true,
+        "noUnusedLocals": true,
+        "esModuleInterop": true,
+        "skipLibCheck": true,
+        "noEmit": true,
+        "paths": {
+            "owid-bespoke-types": ["../../shared/bespokeComponentTypes.ts"]
+        },
+        "lib": [
+            "dom",
+            "dom.iterable",
+            "es2020",
+            "es2021",
+            "es2022.array", // Array `at`
+            "es2022.error", // Error `cause`
+            "es2022.object", // Object `hasOwn`
+            "es2023.array", // Array `findLast`, `findLastIndex`, `toReversed`, `toSorted`, etc.
+            "es2024.collection", // `Map.groupBy`
+            "es2024.object", // `Object.groupBy`
+            "es2025.collection", // Set `union`, `intersection`, `difference` etc.
+            "es2025.iterator" // Iterator helpers: `map`, `filter`, `reduce`, `some`, `every`, `find`, etc.
+        ]
+    },
+    "include": ["src"]
+}

--- a/bespoke/projects/migrant-demographics/vite.config.ts
+++ b/bespoke/projects/migrant-demographics/vite.config.ts
@@ -1,0 +1,69 @@
+import { defineConfig, withFilter } from "vite"
+import pluginReact from "@vitejs/plugin-react"
+import { viteCssPosition } from "vite-plugin-css-position"
+import pluginSwc from "@rollup/plugin-swc"
+
+import { entrypoints } from "./package.json"
+
+export default defineConfig({
+    plugins: [
+        withFilter(
+            // Use swc to transform decorators, since rolldown/oxc doesn't support modern decorators yet. We could remove this once they do - see https://github.com/oxc-project/oxc/issues/9170.
+            pluginSwc({
+                swc: {
+                    jsc: {
+                        parser: {
+                            syntax: "typescript",
+                            decorators: true,
+                        },
+                        transform: {
+                            decoratorVersion: "2023-11",
+                            useDefineForClassFields: true,
+                        },
+
+                        // This setting we need to override from @rollup/plugin-swc's default, otherwise it will not put optional properties on classes (e.g. `class A { optionalProp?: string }`), thereby breaking mobx decorators
+                        loose: false,
+                        target: "esnext",
+                    },
+                },
+            }),
+            // Only run this transform if the file contains a decorator.
+            { transform: { code: /[^"]@/, id: /.*\.(ts|tsx)$/ } }
+        ),
+        pluginReact(),
+        // This plugin allows us to Vite-inject styles directly into the Shadow DOM, and still use HMR in development.
+        // Use <StylesTarget /> in the React tree to specify where the styles should be injected.
+        viteCssPosition({
+            enableDev: true,
+        }),
+    ],
+    resolve: {
+        // The linked @ourworldindata/* packages and the shared
+        // bespoke/{components,hooks} workspaces resolve their dependencies
+        // relative to their real paths, which would load a second copy of
+        // React (breaking hooks) or @tanstack/react-query (breaking the
+        // QueryClient context, since each copy has its own React context).
+        // This forces these to resolve to a single copy in this project's
+        // node_modules.
+        dedupe: [
+            "react",
+            "react-dom",
+            "@react-stately/flags",
+            "@tanstack/react-query",
+        ],
+    },
+    build: {
+        lib: {
+            entry: entrypoints.js,
+            formats: ["es"],
+            fileName: "index",
+        },
+        sourcemap: true,
+        outDir: "dist",
+    },
+    define: {
+        "process.env.NODE_ENV": JSON.stringify(
+            process.env.NODE_ENV || "development"
+        ),
+    },
+})

--- a/bespoke/yarn.lock
+++ b/bespoke/yarn.lock
@@ -149,6 +149,12 @@ __metadata:
   languageName: node
   linkType: soft
 
+"@ourworldindata/components@link:../../../packages/@ourworldindata/components::locator=%40owid%2Fbespoke-migrant-demographics%40workspace%3Aprojects%2Fmigrant-demographics":
+  version: 0.0.0-use.local
+  resolution: "@ourworldindata/components@link:../../../packages/@ourworldindata/components::locator=%40owid%2Fbespoke-migrant-demographics%40workspace%3Aprojects%2Fmigrant-demographics"
+  languageName: node
+  linkType: soft
+
 "@ourworldindata/components@link:../../../packages/@ourworldindata/components::locator=%40owid%2Fbespoke-migration%40workspace%3Aprojects%2Fmigration":
   version: 0.0.0-use.local
   resolution: "@ourworldindata/components@link:../../../packages/@ourworldindata/components::locator=%40owid%2Fbespoke-migration%40workspace%3Aprojects%2Fmigration"
@@ -197,6 +203,12 @@ __metadata:
   languageName: node
   linkType: soft
 
+"@ourworldindata/grapher@link:../../../packages/@ourworldindata/grapher::locator=%40owid%2Fbespoke-migrant-demographics%40workspace%3Aprojects%2Fmigrant-demographics":
+  version: 0.0.0-use.local
+  resolution: "@ourworldindata/grapher@link:../../../packages/@ourworldindata/grapher::locator=%40owid%2Fbespoke-migrant-demographics%40workspace%3Aprojects%2Fmigrant-demographics"
+  languageName: node
+  linkType: soft
+
 "@ourworldindata/grapher@link:../../../packages/@ourworldindata/grapher::locator=%40owid%2Fbespoke-migration%40workspace%3Aprojects%2Fmigration":
   version: 0.0.0-use.local
   resolution: "@ourworldindata/grapher@link:../../../packages/@ourworldindata/grapher::locator=%40owid%2Fbespoke-migration%40workspace%3Aprojects%2Fmigration"
@@ -224,6 +236,12 @@ __metadata:
 "@ourworldindata/types@link:../../../packages/@ourworldindata/types::locator=%40owid%2Fbespoke-food-trade%40workspace%3Aprojects%2Ffood-trade":
   version: 0.0.0-use.local
   resolution: "@ourworldindata/types@link:../../../packages/@ourworldindata/types::locator=%40owid%2Fbespoke-food-trade%40workspace%3Aprojects%2Ffood-trade"
+  languageName: node
+  linkType: soft
+
+"@ourworldindata/types@link:../../../packages/@ourworldindata/types::locator=%40owid%2Fbespoke-migrant-demographics%40workspace%3Aprojects%2Fmigrant-demographics":
+  version: 0.0.0-use.local
+  resolution: "@ourworldindata/types@link:../../../packages/@ourworldindata/types::locator=%40owid%2Fbespoke-migrant-demographics%40workspace%3Aprojects%2Fmigrant-demographics"
   languageName: node
   linkType: soft
 
@@ -260,6 +278,12 @@ __metadata:
 "@ourworldindata/utils@link:../../../packages/@ourworldindata/utils::locator=%40owid%2Fbespoke-food-trade%40workspace%3Aprojects%2Ffood-trade":
   version: 0.0.0-use.local
   resolution: "@ourworldindata/utils@link:../../../packages/@ourworldindata/utils::locator=%40owid%2Fbespoke-food-trade%40workspace%3Aprojects%2Ffood-trade"
+  languageName: node
+  linkType: soft
+
+"@ourworldindata/utils@link:../../../packages/@ourworldindata/utils::locator=%40owid%2Fbespoke-migrant-demographics%40workspace%3Aprojects%2Fmigrant-demographics":
+  version: 0.0.0-use.local
+  resolution: "@ourworldindata/utils@link:../../../packages/@ourworldindata/utils::locator=%40owid%2Fbespoke-migrant-demographics%40workspace%3Aprojects%2Fmigrant-demographics"
   languageName: node
   linkType: soft
 
@@ -463,6 +487,41 @@ __metadata:
     nuqs: "npm:^2.8.9"
     react: "npm:^19.2.7"
     typescript: "npm:^7.0.2"
+  languageName: unknown
+  linkType: soft
+
+"@owid/bespoke-migrant-demographics@workspace:projects/migrant-demographics":
+  version: 0.0.0-use.local
+  resolution: "@owid/bespoke-migrant-demographics@workspace:projects/migrant-demographics"
+  dependencies:
+    "@fortawesome/fontawesome-svg-core": "npm:^6.7.2"
+    "@fortawesome/free-solid-svg-icons": "npm:^6.7.2"
+    "@fortawesome/react-fontawesome": "npm:^0.2.2"
+    "@ourworldindata/components": "link:../../../packages/@ourworldindata/components"
+    "@ourworldindata/grapher": "link:../../../packages/@ourworldindata/grapher"
+    "@ourworldindata/types": "link:../../../packages/@ourworldindata/types"
+    "@ourworldindata/utils": "link:../../../packages/@ourworldindata/utils"
+    "@react-stately/flags": "npm:^3.2.1"
+    "@rollup/plugin-swc": "npm:^0.4.1"
+    "@tanstack/react-query": "npm:^5.101.0"
+    "@types/d3": "npm:^7.4.3"
+    "@types/react": "npm:^19.2.17"
+    "@types/react-dom": "npm:^19.2.3"
+    "@vitejs/plugin-react": "npm:^6.0.2"
+    clsx: "npm:^2.1.1"
+    d3: "npm:^7.9.0"
+    normalize.css: "npm:^8.0.1"
+    nuqs: "npm:^2.8.9"
+    react: "npm:^19.2.7"
+    react-aria-components: "npm:^1.18.0"
+    react-dom: "npm:^19.2.7"
+    remeda: "npm:^2.39.0"
+    sass: "npm:^1.101.0"
+    tippy.js: "npm:^6.3.7"
+    typescript: "npm:^7.0.2"
+    vite: "npm:^8.0.16"
+    vite-plugin-css-position: "npm:^2.0.9"
+    vitest: "npm:^4.1.8"
   languageName: unknown
   linkType: soft
 

--- a/site/bespokeComponentRegistry.ts
+++ b/site/bespokeComponentRegistry.ts
@@ -29,4 +29,7 @@ export const BESPOKE_COMPONENT_REGISTRY: Record<
     migration: {
         scriptUrl: "/migration/index.js",
     },
+    "migrant-demographics": {
+        scriptUrl: "/migrant-demographics/index.js",
+    },
 }


### PR DESCRIPTION
> _Written by Anthropic Claude Opus 4.8 — @sophiamersmann at the wheel._

(created without a skill for testing)

<img width="857" height="858" alt="Screenshot 2026-07-24 at 13 31 01" src="https://github.com/user-attachments/assets/96e8898a-da4d-4c85-bc37-83dedf9757f0" />


## Context

A new bespoke viz (`bespoke/projects/migrant-demographics/`) that renders an age/sex **population pyramid** of the international migrant stock, styled after Grapher. It reads the single `migrant-demographics.json` dataset (UN DESA, International Migrant Stock 2020) and lets the reader compare the migrant profile with that of the native-born population.

The controls and captioned-chart layout follow the causes-of-death treemap: header/footer/frame and the dropdown/slider/switcher come from the shared `bespoke/components` library.

## How it works

- **Data**: the whole dataset is a single ~800 KB file, fetched once via react-query and wrapped in a `MigrantDataset` class. Native-born is derived as `total resident − migrants`.
- **Number mode**: absolute counts, both halves sharing one symmetric axis.
- **Share mode**: each population (migrants vs native-born) is normalized to its own total, so the two shapes are comparable regardless of absolute size.
- **Compare with native-born**: forces Share mode, hides the Number/Share toggle, and draws the native-born profile as a stepped outline over the migrant bars.
- Registered the bundle in `site/bespokeComponentRegistry.ts`.

## Screenshots / Videos / Diagrams

Best viewed on the staging server (see testing guidance). The component has three states — **Number** (absolute counts), **Share** (each population normalized to its own total), and **Compare with native-born** (Share mode with the native-born profile overlaid as a stepped outline).

## Testing guidance

Once the staging build finishes, open the demo on `staging-site-migrant-demographics` and:

1. Confirm the default view (United States, 2020, Number) shows ~51 million with a 48% / 52% men/women split.
2. Switch between **Number** and **Share** and drag the **year** slider (1990–2020).
3. Change the **country or region** and check the title/subtitle update.
4. Toggle **Compare with native-born** — the Number/Share toggle should disappear, the axis switch to shares, and the stepped native-born outline appear.

Locally: `yarn startBespokeDevServer`, then `http://localhost:8089/migrant-demographics/demo`.

- [ ] Does the change work in the archive?
- [ ] Does the staging experience have sign-off from product stakeholders?

## Checklist

### Before merging

- [ ] Changes to CSS/HTML were checked on Desktop and Mobile Safari at all three breakpoints
- [ ] Changes to HTML were checked for accessibility concerns

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UeHtt3ismZ81tbG5bx86dq