### PR TITLE
🎉 (grapher) shorten the entity name before dropping it

### DIFF
--- a/packages/@ourworldindata/grapher/src/controls/Controls.scss
+++ b/packages/@ourworldindata/grapher/src/controls/Controls.scss
@@ -108,8 +108,34 @@ nav.controlsRow .controls {
 }
 
 @container grapher (max-width:675px) {
-    // hide the entity name in the Edit/Select/Switch button
-    nav.controlsRow .chart-controls .entity-selection-menu button.menu-toggle {
+    // default entity type: shorten the entity name in the Edit/Select/Change
+    // button ("Edit countries and regions" -> "Edit countries")
+    nav.controlsRow
+        .chart-controls
+        .entity-selection-menu--shortenable
+        button.menu-toggle {
+        label span .entity-suffix {
+            display: none;
+        }
+    }
+
+    // custom entity types can't be shortened; hide the entity name entirely
+    nav.controlsRow
+        .chart-controls
+        .entity-selection-menu:not(.entity-selection-menu--shortenable)
+        button.menu-toggle {
+        label span {
+            display: none;
+        }
+    }
+}
+
+// now also drop the shortened entity name ("Edit countries" -> "Edit")
+@container grapher (max-width:350px) {
+    nav.controlsRow
+        .chart-controls
+        .entity-selection-menu--shortenable
+        button.menu-toggle {
         label span {
             display: none;
         }
@@ -117,7 +143,7 @@ nav.controlsRow .controls {
 }
 
 @container grapher (max-width:725px) {
-    // hide the entity name in the Edit/Select/Switch button
+    // hide the entity name in the Edit/Select/Change button
     nav.controlsRow .map-controls .entity-selection-menu button.menu-toggle {
         label span {
             display: none;

--- a/packages/@ourworldindata/grapher/src/controls/EntitySelectionToggle.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/EntitySelectionToggle.tsx
@@ -5,6 +5,10 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faEye, faRightLeft, faPen } from "@fortawesome/free-solid-svg-icons"
 import classnames from "clsx"
 import { GrapherWindowType } from "@ourworldindata/types"
+import {
+    DEFAULT_GRAPHER_ENTITY_TYPE,
+    DEFAULT_GRAPHER_ENTITY_TYPE_PLURAL,
+} from "../core/GrapherConstants"
 
 export interface EntitySelectionManager {
     canHighlightEntities?: boolean
@@ -24,6 +28,11 @@ interface EntitySelectionLabel {
     icon: React.ReactElement
     action: string
     entity: string
+    /**
+     * Optional tail of the entity name that is dropped before
+     * the entity name collapses entirely
+     */
+    entitySuffix?: string
 }
 
 @observer
@@ -86,21 +95,21 @@ export class EntitySelectionToggle extends React.Component<{
         if (canHighlightEntities)
             return {
                 action: "Select",
-                entity: entityTypePlural,
+                ...splitDefaultEntityLabel(entityTypePlural),
                 icon: <FontAwesomeIcon icon={faEye} />,
             }
 
         if (canChangeEntity)
             return {
                 action: "Change",
-                entity: entityType,
+                ...splitDefaultEntityLabel(entityType),
                 icon: <FontAwesomeIcon icon={faRightLeft} />,
             }
 
         if (canAddEntities)
             return {
                 action: "Edit",
-                entity: entityTypePlural,
+                ...splitDefaultEntityLabel(entityTypePlural),
                 icon: <FontAwesomeIcon icon={faPen} />,
             }
 
@@ -112,7 +121,11 @@ export class EntitySelectionToggle extends React.Component<{
         const { isEntitySelectorModalOrDrawerOpen: active } = this.props.manager
 
         return showToggle && label ? (
-            <div className="entity-selection-menu">
+            <div
+                className={classnames("entity-selection-menu", {
+                    "entity-selection-menu--shortenable": !!label.entitySuffix,
+                })}
+            >
                 <button
                     className={classnames("menu-toggle", { active })}
                     onClick={action((e): void => {
@@ -122,14 +135,36 @@ export class EntitySelectionToggle extends React.Component<{
                     })}
                     type="button"
                     data-track-note="chart_add_entity"
-                    aria-label={`${label.action} ${label.entity}`}
+                    aria-label={`${label.action} ${label.entity}${label.entitySuffix ?? ""}`}
                 >
                     {label.icon}
                     <label className="label">
-                        {label.action} <span>{label.entity}</span>
+                        {label.action}{" "}
+                        <span>
+                            {label.entity}
+                            {label.entitySuffix && (
+                                <span className="entity-suffix">
+                                    {label.entitySuffix}
+                                </span>
+                            )}
+                        </span>
                     </label>
                 </button>
             </div>
         ) : null
     }
+}
+
+/**
+ * Splits the default entity type into a base and a droppable suffix
+ * ("countries and regions" -> "countries" + " and regions")
+ */
+function splitDefaultEntityLabel(
+    entity: string
+): Pick<EntitySelectionLabel, "entity" | "entitySuffix"> {
+    if (entity === DEFAULT_GRAPHER_ENTITY_TYPE_PLURAL)
+        return { entity: "countries", entitySuffix: " and regions" }
+    if (entity === DEFAULT_GRAPHER_ENTITY_TYPE)
+        return { entity: "country", entitySuffix: " or region" }
+    return { entity }
 }


### PR DESCRIPTION
> _Written by Anthropic Claude Fable 5 — @sophiamersmann at the wheel._

Fixes #6399

## What this does

When the controls row gets narrow, the entity-selection button currently jumps straight from "Edit countries and regions" to a bare "Edit". This adds an intermediate rung for the default entity type: the name is shortened before it is dropped entirely (#6399).

The label ladder on the chart tab is now (container width):

| width | button label |
| --- | --- |
| > 675px | Edit countries and regions |
| 350–675px | Edit countries |
| ≤ 350px | Edit |

The final collapse deliberately sits below the 500px rung where the content switchers lose their tab labels — that frees up enough space for the shortened name to stay around quite a bit longer. The singular case gets the same treatment ("Change country or region" → "Change country").

## Implementation

- `EntitySelectionToggle` splits the default entity type into a base and a suffix (`"countries"` + `" and regions"`), renders the suffix in its own span, and marks the menu with an `entity-selection-menu--shortenable` class. The `aria-label` always carries the full phrase.
- `Controls.scss` hides only the suffix at the existing 675px breakpoint for shortenable menus and drops the whole name at a new 350px breakpoint. Custom entity types can't be shortened predictably, so they keep the previous behavior (full name → bare action at 675px), as does the map tab (already-short "Select countries", 725px).

🤖 Generated with [Claude Code](https://claude.com/claude-code)