### PR TITLE
✨🤖 (time-interval) label weekly time as readable dates, not ISO week numbers

### DIFF
--- a/packages/@ourworldindata/core-table/src/CoreTableColumns.test.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTableColumns.test.ts
@@ -73,18 +73,36 @@ describe(ColumnTypeNames.Day, () => {
 describe(ColumnTypeNames.Week, () => {
     const col = new ColumnTypeMap.Week(new OwidTable(), { slug: "test" })
 
-    it("formats days-since-epoch as weeks", () => {
-        // day 0 = EPOCH_DATE = 2020-01-21, a Tuesday in ISO week 4 of 2020,
-        // which starts on Monday 2020-01-20
-        expect(col.formatValue(0)).toEqual("W4 2020")
+    it("formats a week as 'Week of <week-start Monday>'", () => {
+        // day 0 = EPOCH_DATE = 2020-01-21, a Tuesday in the ISO week
+        // that starts on Monday 2020-01-20
+        expect(col.formatValue(0)).toEqual("Week of Jan 20, 2020")
+        // CSV keeps the machine-readable ISO week
         expect(col.formatForCsv(0)).toEqual("2020-W04")
     })
 
-    it("formats weeks across year boundaries with the ISO week year", () => {
-        // day -22 = Monday 2019-12-30, ISO week 1 of 2020
-        expect(col.formatValue(-22)).toEqual("W1 2020")
-        // day -20 = 2020-01-01 falls into the same week starting in 2019
-        expect(col.formatValue(-20)).toEqual("W1 2020")
+    it("anchors 'Week of' on the Monday across a year boundary", () => {
+        // day -22 = Monday 2019-12-30 (ISO week 1 of 2020)
+        expect(col.formatValue(-22)).toEqual("Week of Dec 30, 2019")
+        // day -20 = 2020-01-01 falls into the same week
+        expect(col.formatValue(-20)).toEqual("Week of Dec 30, 2019")
+    })
+
+    it("formats a range as start-week Monday to end-week Sunday", () => {
+        const day = (iso: string): number =>
+            convertDateToDaysSinceEpoch(dayjs.utc(iso))
+        // 2026-06-03 (Wed) → week starts Mon 2026-06-01
+        // 2026-07-08 (Wed) → week ends Sun 2026-07-12
+        expect(
+            col.formatTimeRange(day("2026-06-03"), day("2026-07-08"))
+        ).toEqual("Jun 1, 2026 to Jul 12, 2026")
+    })
+
+    it("formats the short timeline label as the plain week-start date", () => {
+        const day = (iso: string): number =>
+            convertDateToDaysSinceEpoch(dayjs.utc(iso))
+        // 2026-06-03 (Wed) → week starts Mon 2026-06-01, no "Week of" prefix
+        expect(col.formatTimeShort(day("2026-06-03"))).toEqual("Jun 1, 2026")
     })
 })
 

--- a/packages/@ourworldindata/core-table/src/CoreTableColumns.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTableColumns.ts
@@ -147,6 +147,15 @@ export abstract class AbstractCoreColumn<
         return this.originalTimeColumn.formatValue(time)
     }
 
+    formatTimeShort(time: number): string {
+        return this.formatTime(time)
+    }
+
+    /** Formats a start/end time pair */
+    formatTimeRange(startTime: number, endTime: number): string {
+        return `${this.formatTime(startTime)} to ${this.formatTime(endTime)}`
+    }
+
     @imemo get roundingMode(): OwidVariableRoundingMode {
         return (
             this.display?.roundingMode ?? OwidVariableRoundingMode.decimalPlaces
@@ -973,12 +982,9 @@ const memoFormatMonth = _.memoize(
 const memoFormatMonthCsv = _.memoize(
     (value: number): string => formatDay(value, { format: "YYYY-MM" }) // "2023-01"
 )
-// The ISO week number and week-year. Because the ISO week is the same for
-// every day of the week, indicators that pick a different representative
-// day for the same week still show the same label
 const memoFormatWeek = _.memoize((value: number): string => {
-    const date = convertDaysSinceEpochToDate(value)
-    return `W${date.isoWeek()} ${date.isoWeekYear()}` // "W3 2023"
+    const monday = convertDaysSinceEpochToDate(value).startOf("isoWeek")
+    return `Week of ${monday.format("MMM D, YYYY")}` // "Week of Jan 20, 2020"
 })
 const memoFormatWeekCsv = _.memoize((value: number): string => {
     const date = convertDaysSinceEpochToDate(value)
@@ -1097,11 +1103,25 @@ class WeekColumn<
     }
 
     override formatValue(value: number): string {
-        return memoFormatWeek(value) // "W3 2023"
+        return memoFormatWeek(value) // "Week of Jan 20, 2020"
     }
 
     override formatForCsv(value: number): string {
         return memoFormatWeekCsv(value) // "2023-W03"
+    }
+
+    // The plain week-start date (ISO-week Monday), e.g. "Jun 1, 2026"
+    override formatTimeShort(time: number): string {
+        const monday = convertDaysSinceEpochToDate(time).startOf("isoWeek")
+        return monday.format("MMM D, YYYY")
+    }
+
+    // The span from the first day of the start week (ISO-week Monday) to the
+    // last day of the end week (Sunday), e.g. "Jun 1, 2026 to Jul 12, 2026".
+    override formatTimeRange(startTime: number, endTime: number): string {
+        const start = convertDaysSinceEpochToDate(startTime).startOf("isoWeek")
+        const end = convertDaysSinceEpochToDate(endTime).endOf("isoWeek")
+        return `${start.format("MMM D, YYYY")} to ${end.format("MMM D, YYYY")}`
     }
 }
 

--- a/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
@@ -2729,15 +2729,13 @@ export class GrapherState
 
         if (startTime === undefined || endTime === undefined) return undefined
 
-        // Dumbbell charts compare two points, so use "vs" instead of "to"
-        const separator = this.isOnDumbbellTab ? " vs. " : " to "
+        if (startTime === endTime) return formatTime(startTime)
 
-        const time =
-            startTime === endTime
-                ? formatTime(startTime)
-                : formatTime(startTime) + separator + formatTime(endTime)
+        // Dumbbell charts compare two points, so use "vs." instead of a range
+        if (this.isOnDumbbellTab)
+            return `${formatTime(startTime)} vs. ${formatTime(endTime)}`
 
-        return time
+        return timeColumn.formatTimeRange(startTime, endTime)
     }
 
     @computed get sourcesLine(): string {

--- a/packages/@ourworldindata/grapher/src/timeline/TimelineComponent.tsx
+++ b/packages/@ourworldindata/grapher/src/timeline/TimelineComponent.tsx
@@ -430,7 +430,7 @@ export class TimelineComponent extends React.Component<TimelineComponentProps> {
     private formatTime(time: number): string {
         const { timeColumn } = this.manager
         if (!timeColumn) return time.toString()
-        return timeColumn.formatTime(time)
+        return timeColumn.formatTimeShort(time)
     }
 
     @action.bound private togglePlay(): void {


### PR DESCRIPTION
> _Written by Claude Opus 4.8 — @sophiamersmann at the wheel._

I did some more thinking about how to represent weeks in Grapher and landed on the following:

- I think I prefer ‘Week of Jun 12, 2026’ over ‘6-12 Jun 2026’ because, although the latter is often a bit shorter, it (i) isn't immediately obvious that it represents a week, (ii) is a bit confusing because it's written as a time range, and (iii) gets unwieldy for weeks that cross month or year boundaries.
- For single-time charts, the title now says ‘Week of …’. For time range charts, however, ‘Week of Jun 12, 2021 to Week of Jul 2, 2026’ feels too verbose, so instead we display the range as plain dates, e.g. ‘Jun 12, 2021 to Jul 8, 2026’, where the second date is the last day of the final week (Sunday).
- The timeline also uses plain dates. There's a slight discrepancy with the title because the end label on the timeline shows the first day of the week rather than the last.
- In tooltips, we use the long label (‘Week of …’), and discrete axis ticks use the same format. It's quite space-consuming, but I think that's the least confusing option.

CSV export (`2026-W23`) and the continuous time axis (already week-start dates) are unchanged.