### PR TITLE
Exclude topic update announcements from homepage

### DIFF
--- a/db/db.ts
+++ b/db/db.ts
@@ -417,6 +417,11 @@ export const getHomepageAnnouncements = (
         AND pg.publishedAt <= NOW()
         AND pg.type = '${OwidGdocType.Announcement}'
         AND pg.publicationContext = 'listed'
+        -- Topic updates are surfaced as topic pages in the homepage's featured
+        -- work column, so listing them here too would show them twice.
+        -- COALESCE because a kicker-less announcement has a JSON NULL here,
+        -- which would otherwise make the comparison NULL and drop the row.
+        AND COALESCE(pg.content ->> '$.kicker', '') != 'topic-update'
         ORDER BY pg.publishedAt DESC
         LIMIT 3
         `


### PR DESCRIPTION
## Context

[Slack](https://owid.slack.com/archives/C0AE1N6GNQY/p1785137591267509?thread_ts=1784845354.999179&cid=C0AE1N6GNQY)

## Testing guidance

1. Note the content of "Updates and announcements" on the homepage
2. Publish an announcement with kicker `topic-update` and publication context `listed`
3. The announcement should be absent from "Updates and announcements" on the homepage
4. `/latest` should list the announcement once indexed