### PR TITLE
perf(axis): avoid placing ticks just to compute axis height

### DIFF
--- a/packages/@ourworldindata/grapher/src/axis/Axis.test.ts
+++ b/packages/@ourworldindata/grapher/src/axis/Axis.test.ts
@@ -8,6 +8,7 @@ import {
     ColumnTypeNames,
 } from "@ourworldindata/types"
 import {
+    CoreColumn,
     OwidTable,
     SynthesizeFruitTable,
     SynthesizeGDPTable,
@@ -332,6 +333,138 @@ describe("manual ticks", () => {
             defaultAxis.tickLabels.map((label) => label.value)
         ).not.toContain(99)
     })
+})
+
+describe("axis height", () => {
+    const day = (date: string): number =>
+        convertDateToDaysSinceEpoch(dayjs.utc(date))
+
+    const timeColumn = (type: ColumnTypeNames, slug: string): CoreColumn =>
+        new OwidTable({ entityName: ["usa"], [slug]: [0] }, [
+            { slug, type },
+        ]).get(slug)
+
+    /**
+     * The height given by `HorizontalAxis.height` should match the height of the placed tick labels plus padding and label offset in all cases, or `minSize` if that is larger.
+     */
+    const heightFromPlacedTickLabels = (axis: HorizontalAxis): number => {
+        if (axis.hideAxis) return 0
+        const maxTickHeight = axis.tickLabels.length
+            ? Math.max(...axis.tickLabels.map((tick) => tick.height))
+            : undefined
+        const paddedTickHeight = maxTickHeight
+            ? maxTickHeight + axis.tickPadding
+            : 0
+        return Math.max(
+            paddedTickHeight + axis.labelOffset,
+            axis.config.minSize ?? 0
+        )
+    }
+
+    const cases: [string, () => HorizontalAxis][] = [
+        [
+            "a plain linear axis",
+            () => new AxisConfig({ min: 0, max: 100 }).toHorizontalAxis(),
+        ],
+        [
+            "a fractional domain, which has no whole-number start tick",
+            () => new AxisConfig({ min: 0.3, max: 0.9 }).toHorizontalAxis(),
+        ],
+        [
+            "a log axis",
+            () =>
+                new AxisConfig({
+                    min: 1,
+                    max: 10000,
+                    scaleType: ScaleType.log,
+                }).toHorizontalAxis(),
+        ],
+        [
+            "a degenerate domain, as used before any data has loaded",
+            () => new AxisConfig({}).toHorizontalAxis(),
+        ],
+        [
+            "an axis with a label",
+            () =>
+                new AxisConfig({
+                    min: 0,
+                    max: 100,
+                    label: "A rather long axis label that has to wrap",
+                }).toHorizontalAxis(),
+        ],
+        [
+            "a hidden axis with a minSize",
+            () =>
+                new AxisConfig({
+                    min: 0,
+                    max: 100,
+                    minSize: 200,
+                    hideAxis: true,
+                }).toHorizontalAxis(),
+        ],
+        [
+            "an axis with author-supplied ticks, all outside the domain",
+            () =>
+                new AxisConfig({
+                    min: 0.5,
+                    max: 10.5,
+                    ticks: [{ value: 1000, priority: 1 }],
+                }).toHorizontalAxis(),
+        ],
+        [
+            "a continuous monthly time axis",
+            () => {
+                const axis = new AxisConfig({
+                    min: day("2020-01-01"),
+                    max: day("2022-12-01"),
+                }).toHorizontalAxis()
+                axis.formatColumn = timeColumn(ColumnTypeNames.Month, "month")
+                return axis
+            },
+        ],
+        [
+            "a monthly time axis too short to span a month",
+            () => {
+                const axis = new AxisConfig({
+                    min: day("2020-01-01"),
+                    max: day("2020-01-08"),
+                }).toHorizontalAxis()
+                axis.formatColumn = timeColumn(ColumnTypeNames.Month, "month")
+                return axis
+            },
+        ],
+        [
+            "a discrete monthly band axis",
+            () => {
+                const bandValues = ["2020-01-01", "2020-04-01"].map(day)
+                const axis = new AxisConfig({
+                    min: bandValues[0],
+                    max: bandValues[1],
+                    bandValues,
+                }).toHorizontalAxis()
+                axis.formatColumn = timeColumn(ColumnTypeNames.Month, "month")
+                return axis
+            },
+        ],
+        [
+            "a discrete band axis with no bands, as used when there's no data",
+            () => {
+                const axis = new AxisConfig({
+                    bandValues: [],
+                }).toHorizontalAxis()
+                axis.formatColumn = timeColumn(ColumnTypeNames.Month, "month")
+                return axis
+            },
+        ],
+    ]
+
+    for (const [description, makeAxis] of cases) {
+        it(`matches the placed tick labels for ${description}`, () => {
+            const axis = makeAxis()
+            axis.range = [0, 800]
+            expect(axis.height).toEqual(heightFromPlacedTickLabels(axis))
+        })
+    }
 })
 
 describe("calendar-aware time ticks", () => {

--- a/packages/@ourworldindata/grapher/src/axis/Axis.test.ts
+++ b/packages/@ourworldindata/grapher/src/axis/Axis.test.ts
@@ -1,4 +1,4 @@
-import { expect, it, describe } from "vitest"
+import { expect, it, describe, vi } from "vitest"
 import * as R from "remeda"
 
 import { HorizontalAxis } from "../axis/Axis"
@@ -462,7 +462,15 @@ describe("axis height", () => {
         it(`matches the placed tick labels for ${description}`, () => {
             const axis = makeAxis()
             axis.range = [0, 800]
-            expect(axis.height).toEqual(heightFromPlacedTickLabels(axis))
+
+            // ...and gets there without placing a single label, which is the
+            // whole point of computing the height separately
+            const placeTickLabel = vi.spyOn(axis, "placeTickLabel")
+            const { height } = axis
+            expect(placeTickLabel).not.toHaveBeenCalled()
+            placeTickLabel.mockRestore()
+
+            expect(height).toEqual(heightFromPlacedTickLabels(axis))
         })
     }
 })

--- a/packages/@ourworldindata/grapher/src/axis/Axis.ts
+++ b/packages/@ourworldindata/grapher/src/axis/Axis.ts
@@ -712,8 +712,9 @@ export class HorizontalAxis extends AbstractAxis {
 
         if (hideAxis) return 0
 
-        const maxTickHeight = _.max(this.tickLabels.map((tick) => tick.height))
-        const paddedTickHeight = maxTickHeight ? maxTickHeight + tickPadding : 0
+        const paddedTickHeight = this.hasTickLabels
+            ? this.tickFontSize + tickPadding
+            : 0
 
         return Math.max(paddedTickHeight + labelOffset, minSize)
     }
@@ -757,6 +758,24 @@ export class HorizontalAxis extends AbstractAxis {
             (t): number => t.priority,
         ])
         return _.sortedUniqBy(sortedTicks, (t) => t.value)
+    }
+
+    /**
+     * Whether the axis shows any tick labels. Mirrors the branches of
+     * `tickLabels` without placing them, so callers that only need to know
+     * whether there are labels don't pay for the layout.
+     */
+    @computed private get hasTickLabels(): boolean {
+        // A discrete time axis labels its band values and nothing else
+        if (this.calendarTickInterval !== undefined && this.config.bandValues)
+            return this.config.bandValues.length > 0
+
+        // Otherwise there is at least one tick whenever the domain is usable:
+        // `baseTicks` always keeps the domain start when it's a whole
+        // number. A degenerate (no-data) domain is neither, and falls through to computing `baseTicks`.
+        if (this.domain[0] % 1 === 0) return true
+
+        return this.baseTicks.length > 0
     }
 
     @computed get tickLabels(): TickLabelPlacement[] {

--- a/packages/@ourworldindata/grapher/src/axis/Axis.ts
+++ b/packages/@ourworldindata/grapher/src/axis/Axis.ts
@@ -763,16 +763,26 @@ export class HorizontalAxis extends AbstractAxis {
     /**
      * Whether the axis shows any tick labels. Mirrors the branches of
      * `tickLabels` without placing them, so callers that only need to know
-     * whether there are labels don't pay for the layout.
+     * whether there are labels don't pay for the layout computation.
      */
     @computed private get hasTickLabels(): boolean {
-        // A discrete time axis labels its band values and nothing else
-        if (this.calendarTickInterval !== undefined && this.config.bandValues)
-            return this.config.bandValues.length > 0
+        // A calendar-aware time axis picks its ticks before the generic
+        // pipeline below gets a say
+        if (this.calendarTickInterval !== undefined) {
+            // A discrete axis labels its band values and nothing else: each
+            // labeling option it chooses from labels at least one band, and if
+            // none of them fit it falls back to one label per band
+            if (this.config.bandValues) return this.config.bandValues.length > 0
 
-        // Otherwise there is at least one tick whenever the domain is usable:
-        // `baseTicks` always keeps the domain start when it's a whole
-        // number. A degenerate (no-data) domain is neither, and falls through to computing `baseTicks`.
+            // A continuous axis usually has labels, either because it is labelled
+            // via the calendar ticks code path, or because that code path returns
+            // `undefined` and then we fall back to the same `baseTicks` logic
+            // that otherwise runs, and we then know that `domain[0]` is a whole
+            // number and thus there is at least this one tick.
+        }
+
+        // The generic pipeline keeps the domain start whenever it's a whole
+        // number, so any such domain has at least one tick.
         if (this.domain[0] % 1 === 0) return true
 
         return this.baseTicks.length > 0


### PR DESCRIPTION
> _Written by Claude Opus 5 — @marcelgerber at the wheel._

A change on top of #6823. There are code paths that build a `HorizontalAxis` _just_ to learn its size, and until now those ran the full tick label layout.

`HorizontalAxis.height` no longer places tick labels: `Bounds.forText` derives a label's height from the font size alone, so `max(tick label heights)` is always `tickFontSize` when there is at least one label. All `height` needed was _whether any exist_ — now answered by `hasTickLabels`, which also short-circuits before `baseTicks` on the common path.

On chart `h5n1-flu-reported-cases`, `tickLabels` runs **2× instead of 5×** for the initial render (~17 ms of ~25 ms saved; dev build, one chart).

<details>
<summary>Things to watch</summary>

- **`hasTickLabels` re-states the emptiness rules of the tick pipeline** — the fragile part. It relies on `baseTicks` prepending the domain start when `domain[0] % 1 === 0`, and on the calendar builders returning `undefined` rather than `[]` (`baseTicks` returns `timeAxisTicks` _before_ the prepend, so a builder returning `[]` would make the short-circuit claim a tick that isn't there). Both are pinned by tests, not comments.
- **`height` assumes `Bounds.forText` height is font-size-only.** True today; multi-line or text-dependent tick labels would silently break it.
- Preserved on purpose: `bandValues: []` still gives 0 height, and the degenerate `[Infinity, -Infinity]` pre-data domain falls through to `baseTicks`.
- Untouched: `DualAxis` still clones to measure, and `verticalAxisSize` still places labels on a throwaway clone (`VerticalAxis.width` genuinely needs label _widths_). The remaining 2 calls are one layout pass each, since the chart lays out twice on load.
</details>

<details>
<summary>Where the 5 calls came from</summary>

Traced in the browser with a call log, stack traces and a MobX `spy`:

| # | axis instance | range | entered via |
| - | ------------- | ----- | ----------- |
| 1 | clone A | `[0, 805]` | `DualAxis.horizontalAxisSize` → `axis.size` → `get height` |
| 2 | clone B | `[36, 821]` | `DualAxis.horizontalAxis` → `HorizontalAxisComponent.render` |
| 3 | clone A again | `[0, 805]` | MobX re-validating a stale computed |
| 4 | clone C | `[0, 805]` | `horizontalAxisSize` → `get height` |
| 5 | clone D | `[35, 821]` | `HorizontalAxisComponent.render` |

Three separate multipliers:

1. **Two clones per layout pass.** `DualAxis` needs the axis height to compute `innerBounds`, but the axis it's handed has no range yet, so it clones one with `range = [0, bounds.width]` purely to measure, then clones another with the final range to render. Separate instances, so nothing is memoised across them.
2. **Two layout passes.** `baseFontSize` is set imperatively from measured bounds in `Grapher.componentDidMount`/`componentDidUpdate`. On a datapage the chart first measures 1277px wide → font 18, the layout settles to 959px, and the next `componentDidUpdate` corrects to 16. `baseFontSize` is the root of the whole font graph, so everything re-runs.
3. **One wasted revalidation** (#3). Because the measurement clone is created _inside_ a computed, MobX keeps its computed graph in the dependency tree and re-validates it before re-running `horizontalAxisSize`, which then discards it and builds a fresh clone anyway.

This PR removes 1, 3 and 4 — the calls that only ever fed `height`.

</details>

<details>
<summary>Verification</summary>

- New `describe("axis height")` over 11 axis configurations (linear, fractional domain, log, degenerate, labelled, hidden + `minSize`, out-of-domain author ticks, continuous monthly, sub-month monthly, discrete band, empty band), each asserting `height` matches the old placed-tick-labels formula.
- Mutation-tested: forcing `hasTickLabels` true breaks the degenerate-domain and out-of-domain-ticks cases; forcing the band branch true breaks the empty-band case.
- Before/after on the live chart: identical tick label coordinates and bars.

</details>
