### PR TITLE
fix: stabilize crowded line chart legends on hover

### DIFF
--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChart.test.ts
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChart.test.ts
@@ -1,4 +1,4 @@
-import { expect, it, describe } from "vitest"
+import { expect, it, describe, vi } from "vitest"
 
 import {
     SampleColumnSlugs,
@@ -9,6 +9,7 @@ import {
     OwidTable,
     ErrorValueTypes,
 } from "@ourworldindata/core-table"
+import { Bounds } from "@ourworldindata/utils"
 import { ChartManager } from "../chart/ChartManager"
 import {
     ColumnTypeNames,
@@ -21,6 +22,7 @@ import { LineChartManager } from "./LineChartConstants"
 import { OWID_NO_DATA_GRAY } from "../color/ColorConstants"
 import { LineChart } from "./LineChart"
 import { LineChartState } from "./LineChartState"
+import { Emphasis } from "../interaction/Emphasis"
 
 it("can create a new chart", () => {
     const table = SynthesizeGDPTable({ timeRange: [2000, 2010] })
@@ -286,6 +288,77 @@ it("reverses order of plotted series to plot the first one over the others", () 
 
     expect(chart.placedSeries).toHaveLength(2)
     expect(chart.placedSeries[0].seriesName).toEqual("pop")
+})
+
+it("keeps a crowded vertical legend stable while hovering a label", () => {
+    vi.useFakeTimers()
+    vi.stubGlobal("window", { setTimeout })
+
+    try {
+        const entityNames = Array.from(
+            { length: 20 },
+            (_, index) => `Entity ${index + 1}`
+        )
+        const table = new OwidTable({
+            entityName: entityNames.flatMap((name) => [name, name]),
+            year: entityNames.flatMap(() => [2000, 2001]),
+            gdp: entityNames.flatMap((_, index) => [index, index + 1]),
+        })
+        const manager: LineChartManager = {
+            table,
+            yColumnSlugs: ["gdp"],
+            selection: entityNames,
+            showSeriesLabels: true,
+        }
+        const chartState = new LineChartState({ manager })
+        const chart = new LineChart({
+            chartState,
+            bounds: new Bounds(0, 0, 640, 180),
+        })
+        const getLegendLayout = (): {
+            seriesName: string
+            bounds: Bounds
+        }[] =>
+            chart["verticalLabelsState"].placedSeries.map((series) => ({
+                seriesName: series.seriesName,
+                bounds: series.bounds,
+            }))
+
+        const initialLayout = getLegendLayout()
+        expect(initialLayout.length).toBeLessThan(entityNames.length)
+        const hoveredSeriesName = initialLayout[1].seriesName
+
+        chart["onVerticalLabelMouseEnter"](hoveredSeriesName)
+
+        expect(getLegendLayout()).toEqual(initialLayout)
+        expect(
+            chart["verticalLabelsState"].renderSeries.find(
+                (series) => series.seriesName === hoveredSeriesName
+            )?.emphasis
+        ).toBe(Emphasis.Highlighted)
+
+        chart["onVerticalLabelMouseLeave"]()
+        vi.advanceTimersByTime(200)
+
+        expect(getLegendLayout()).toEqual(initialLayout)
+        expect(
+            chart["verticalLabelsState"].renderSeries.find(
+                (series) => series.seriesName === hoveredSeriesName
+            )?.emphasis
+        ).toBe(Emphasis.Default)
+
+        chart["onVerticalLabelMouseEnter"]("Missing series")
+
+        expect(getLegendLayout()).toEqual(initialLayout)
+        expect(
+            chart["verticalLabelsState"].renderSeries.every(
+                (series) => series.emphasis === Emphasis.Muted
+            )
+        ).toBe(true)
+    } finally {
+        vi.unstubAllGlobals()
+        vi.useRealTimers()
+    }
 })
 
 describe("externalLegendBins", () => {

--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChart.tsx
@@ -338,6 +338,8 @@ export class LineChart
             fontWeight: this.fontWeight,
             verticalAlign: VerticalAlign.top,
             showRegionTooltip: !this.isStatic,
+            prioritizeHighlightedSeries:
+                this.hoveredLabelSeriesName === undefined,
         })
     }
 

--- a/packages/@ourworldindata/grapher/src/verticalLabels/VerticalLabels.test.ts
+++ b/packages/@ourworldindata/grapher/src/verticalLabels/VerticalLabels.test.ts
@@ -108,6 +108,62 @@ describe("dropping labels", () => {
         expect(stateWithFocus.visibleSeriesNames).toEqual(["Mexico"])
     })
 
+    it("can disable highlighted-series priority", () => {
+        const seriesWithHighlight = series.map((s) => ({
+            ...s,
+            emphasis:
+                s.seriesName === "Mexico"
+                    ? Emphasis.Highlighted
+                    : Emphasis.Muted,
+        }))
+        const yRange: [number, number] = [0, 50]
+        const options = {
+            yAxis: () => makeAxis({ yRange }),
+            prioritizeHighlightedSeries: false,
+        }
+
+        const state = new VerticalLabelsState(series, options)
+        const stateWithHighlight = new VerticalLabelsState(
+            seriesWithHighlight,
+            options
+        )
+        const importantStateWithHighlight = new VerticalLabelsState(
+            seriesWithHighlight,
+            {
+                ...options,
+                seriesNamesSortedByImportance: ["Canada", "Mexico"],
+            }
+        )
+        const importantStateWithDefaultPriority = new VerticalLabelsState(
+            seriesWithHighlight,
+            {
+                yAxis: options.yAxis,
+                seriesNamesSortedByImportance: ["Canada", "Mexico"],
+            }
+        )
+        const uncrowdedStateWithHighlight = new VerticalLabelsState(
+            seriesWithHighlight,
+            {
+                ...options,
+                yAxis: () => makeAxis({ yRange: [0, 100] }),
+            }
+        )
+
+        expect(stateWithHighlight.visibleSeriesNames).toEqual(
+            state.visibleSeriesNames
+        )
+        expect(importantStateWithHighlight.visibleSeriesNames).toEqual([
+            "Canada",
+        ])
+        expect(importantStateWithDefaultPriority.visibleSeriesNames).toEqual([
+            "Mexico",
+        ])
+        expect(uncrowdedStateWithHighlight.visibleSeriesNames).toEqual([
+            "Canada",
+            "Mexico",
+        ])
+    })
+
     it("uses all available space", () => {
         const series = makeSeries([
             { seriesName: "Canada", yValue: 5 },

--- a/packages/@ourworldindata/grapher/src/verticalLabels/VerticalLabelsFilterAlgorithms.ts
+++ b/packages/@ourworldindata/grapher/src/verticalLabels/VerticalLabelsFilterAlgorithms.ts
@@ -18,8 +18,9 @@ import { Emphasis } from "../interaction/Emphasis.js"
  */
 export function findImportantSeriesThatFitIntoTheAvailableSpace(
     seriesSortedByImportance: PlacedLabelSeries[],
-    availableHeight: number
-) {
+    availableHeight: number,
+    prioritizeHighlightedSeries = true
+): PlacedLabelSeries[] {
     let context: VerticalLabelsFilterAlgorithmContext = {
         candidates: new Set(seriesSortedByImportance),
         availableHeight,
@@ -27,10 +28,13 @@ export function findImportantSeriesThatFitIntoTheAvailableSpace(
         keepSeriesHeight: 0,
     }
 
-    const [highlightedCandidates, nonHighlightedCandidates] = _.partition(
-        seriesSortedByImportance,
-        (series) => series.emphasis === Emphasis.Highlighted
-    )
+    const [highlightedCandidates, nonHighlightedCandidates] =
+        prioritizeHighlightedSeries
+            ? _.partition(
+                  seriesSortedByImportance,
+                  (series) => series.emphasis === Emphasis.Highlighted
+              )
+            : [[], seriesSortedByImportance]
 
     const importanceScore = new Map(
         seriesSortedByImportance.map((series, index) => [
@@ -73,7 +77,8 @@ export function findImportantSeriesThatFitIntoTheAvailableSpace(
  */
 export function findSeriesThatFitIntoTheAvailableSpace(
     series: PlacedLabelSeries[],
-    availableHeight: number
+    availableHeight: number,
+    prioritizeHighlightedSeries = true
 ): PlacedLabelSeries[] {
     let context: VerticalLabelsFilterAlgorithmContext = {
         candidates: new Set(series),
@@ -82,10 +87,13 @@ export function findSeriesThatFitIntoTheAvailableSpace(
         keepSeriesHeight: 0,
     }
 
-    const [highlightedCandidates, nonHighlightedCandidates] = _.partition(
-        series,
-        (series) => series.emphasis === Emphasis.Highlighted
-    )
+    const [highlightedCandidates, nonHighlightedCandidates] =
+        prioritizeHighlightedSeries
+            ? _.partition(
+                  series,
+                  (series) => series.emphasis === Emphasis.Highlighted
+              )
+            : [[], series]
 
     // highlighted series have priority
     context = pickAsManyAsPossibleWithRetry({

--- a/packages/@ourworldindata/grapher/src/verticalLabels/VerticalLabelsState.ts
+++ b/packages/@ourworldindata/grapher/src/verticalLabels/VerticalLabelsState.ts
@@ -39,6 +39,7 @@ export interface VerticalLabelsStateOptions {
     textAnchor?: "start" | "end"
     showRegionTooltip?: boolean
     seriesNamesSortedByImportance?: SeriesName[]
+    prioritizeHighlightedSeries?: boolean
 }
 
 /**
@@ -56,6 +57,7 @@ export class VerticalLabelsState {
         verticalAlign: VerticalAlign.middle,
         textAnchor: "start",
         showRegionTooltip: true,
+        prioritizeHighlightedSeries: true,
     } as const satisfies Partial<VerticalLabelsStateOptions>
 
     constructor(series: LabelSeries[], options: VerticalLabelsStateOptions) {
@@ -313,6 +315,7 @@ export class VerticalLabelsState {
 
     @computed get visiblePlacedSeries(): PlacedLabelSeries[] {
         const { initialPlacedSeries, seriesSortedByImportance, legendY } = this
+        const { prioritizeHighlightedSeries } = this.options
         const availableHeight = Math.abs(legendY[1] - legendY[0])
         const totalHeight = this.computeHeight(initialPlacedSeries)
 
@@ -323,14 +326,16 @@ export class VerticalLabelsState {
         if (seriesSortedByImportance) {
             return findImportantSeriesThatFitIntoTheAvailableSpace(
                 seriesSortedByImportance,
-                availableHeight
+                availableHeight,
+                prioritizeHighlightedSeries
             )
         }
 
         // otherwise use the default filtering
         return findSeriesThatFitIntoTheAvailableSpace(
             initialPlacedSeries,
-            availableHeight
+            availableHeight,
+            prioritizeHighlightedSeries
         )
     }
 


### PR DESCRIPTION
## Context

Links to issues, Figma, Slack, and a technical introduction to the work.

## Screenshots / Videos / Diagrams

Add if relevant, i.e. might not be necessary when there are no UI changes.

## Testing guidance

- [ ] Does the change work in the archive?
- [ ] Does the staging experience have sign-off from product stakeholders?
- A crowded line chart filters its many labels, then hovering one of the visible labels highlights the corresponding series without changing the visible label order or placed coordinates; leaving the label restores normal emphasis with the same layout. - Highlighted-series prioritization remains enabled by default for other `VerticalLabelsState` consumers, while the opt-out produces the same filtered subset as the equivalent unhighlighted input; legends where every label fits remain unchanged. - Empty highlighted subsets, a hovered name absent from the current series, and labels too tall to fit continue through the existing retry/filter behavior without duplicate labels, an over-height result, or an exception.

## Checklist

(delete all that do not apply)

### Before merging

- [ ] Google Analytics events were adapted to fit the changes in this PR
- [ ] Changes to CSS/HTML were checked on Desktop and Mobile Safari at all three breakpoints
- [ ] Changes to HTML were checked for accessibility concerns

If DB migrations exists:

- [ ] If columns have been added/deleted, all necessary views were recreated and ETL and Analytics team members have been informed of the incoming changes
- [ ] The DB type definitions have been updated
- [ ] The DB types in the ETL have been updated

### After merging

- [ ] If a table was touched that is synced to R2, the sync script to update R2 has been run

Fixes #6276
