### PR TITLE
Content-hash the site bundle's filenames

### DIFF
--- a/.bundlemonrc.json
+++ b/.bundlemonrc.json
@@ -1,14 +1,17 @@
 {
     "baseDir": "./dist/assets",
     "defaultCompression": "brotli",
+    "pathLabels": {
+        "hash": "[a-zA-Z0-9_-]+"
+    },
     "files": [
         {
-            "path": "owid.mjs",
+            "path": "owid.<hash>.mjs",
             "maxSize": "800kB",
             "maxPercentIncrease": 2
         },
         {
-            "path": "owid.css",
+            "path": "owid.<hash>.css",
             "maxSize": "61kB"
         }
     ],

--- a/site/viteUtils.test.ts
+++ b/site/viteUtils.test.ts
@@ -71,4 +71,42 @@ describe(createTagsForManifestEntry, () => {
             '<script type="module" src="BASE/assets/owid.mjs" data-attach-owid-error-handler="true"></script>',
         ])
     })
+
+    // The site bundle's filenames carry a content hash, and nothing outside the
+    // manifest knows what it is: pages have to pick the hashed filenames up from
+    // the manifest entry, keyed by the (unhashed) entry point source path.
+    it("uses the hashed filenames from the manifest", () => {
+        const hashedManifest = {
+            "site/owid.entry.css": {
+                file: "assets/owid.DEg8Xc_1.css",
+                src: "site/owid.entry.css",
+            },
+            "site/owid.entry.ts": {
+                css: ["assets/owid.DEg8Xc_1.css"],
+                file: "assets/owid.B7uK2p-9.mjs",
+                isEntry: true,
+                src: "site/owid.entry.ts",
+            },
+        }
+
+        const assets = createTagsForManifestEntry(
+            hashedManifest,
+            "site/owid.entry.ts",
+            "BASE/"
+        )
+
+        const render = (asset: (typeof assets.forHeader)[number]) =>
+            ReactDOMServer.renderToStaticMarkup(asset)
+
+        expect(assets.forHeader.map(render)).toEqual(
+            expect.arrayContaining([
+                '<link rel="preload" href="BASE/assets/owid.DEg8Xc_1.css" as="style"/>',
+                '<link rel="stylesheet" href="BASE/assets/owid.DEg8Xc_1.css"/>',
+                '<link rel="modulepreload" href="BASE/assets/owid.B7uK2p-9.mjs"/>',
+            ])
+        )
+        expect(assets.forFooter.map(render)).toEqual([
+            '<script type="module" src="BASE/assets/owid.B7uK2p-9.mjs" data-attach-owid-error-handler="true"></script>',
+        ])
+    })
 })

--- a/site/viteUtils.tsx
+++ b/site/viteUtils.tsx
@@ -183,7 +183,14 @@ export const viteAssetsForAdmin = () => viteAssets(ViteEntryPoint.Admin)
 export const viteAssetsForSite = ({
     staticAssetMap,
 }: { staticAssetMap?: AssetMap } = {}) =>
-    viteAssets(ViteEntryPoint.Site, { prodAssetMap: staticAssetMap })
+    // Archival pages load the archive bundle, so they have to be resolved
+    // through the archive build's manifest: `staticAssetMap` is keyed by the
+    // filenames in dist/assets-archive (see ASSET_FILES in ArchivalBaker), and
+    // the site build's filenames now carry a content hash, so the two no longer
+    // coincide the way they used to.
+    viteAssets(IS_ARCHIVE ? ViteEntryPoint.Archive : ViteEntryPoint.Site, {
+        prodAssetMap: staticAssetMap,
+    })
 
 export const generateEmbedSnippet = () => {
     // Make sure we're using an absolute URL here, since we don't know in what context the embed snippet is used.

--- a/vite.config-common.mts
+++ b/vite.config-common.mts
@@ -15,6 +15,23 @@ export const defineViteConfigForEntrypoint = (entrypoint: ViteEntryPoint) => {
     const isBundlemon = process.env.BUNDLEMON === "true"
     const vitePort = parseInt(process.env.VITE_PORT || "8090", 10)
 
+    // The site bundle is content-addressed: the filename changes whenever the
+    // bytes do, so a page can never silently load an older stylesheet or script
+    // than the HTML was built against (it 404s instead), and a given URL can be
+    // cached indefinitely. The filenames are resolved through .vite/manifest.json
+    // at render time (site/viteUtils.tsx), so nothing references them literally.
+    //
+    // The archive bundle has to keep stable names: the archival baker hashes
+    // those files itself on the way into the archive directory, and looks them
+    // up by name to do it (ASSET_FILES in baker/archival/ArchivalBaker.ts).
+    // The admin bundle is out of scope — it's served from dist/assets-admin by
+    // the admin server itself (adminSiteServer/appClass.tsx), so it is never
+    // stale in the way a baked asset can be.
+    const useHashedFileNames = entrypoint === ViteEntryPoint.Site
+    const outNameTemplate = useHashedFileNames
+        ? `${entrypointInfo.outName}.[hash]`
+        : entrypointInfo.outName
+
     return defineConfig({
         publicDir: false, // don't copy public folder to dist
         css: {
@@ -69,8 +86,8 @@ export const defineViteConfigForEntrypoint = (entrypoint: ViteEntryPoint) => {
                     [entrypointInfo.outName]: entrypointInfo.entryPointFile,
                 },
                 output: {
-                    assetFileNames: `${entrypointInfo.outName}.css`,
-                    entryFileNames: `${entrypointInfo.outName}.mjs`,
+                    assetFileNames: `${outNameTemplate}.css`,
+                    entryFileNames: `${outNameTemplate}.mjs`,
                 },
             },
         },


### PR DESCRIPTION
> _Written by Anthropic Claude Opus 5 — @Marigold at the wheel._

## Context

`dist/assets/owid.css` and `owid.mjs` were pinned to stable filenames, which makes a baked asset and its replacement indistinguishable. The bake refreshes them in one blunt step — `rm -rf bakedSite/assets && cp -r dist/assets bakedSite/assets` (`baker/SiteBaker.tsx:1106`) — and the staging script runs archive creation *before* the site bake, so a crash in the archive skips the copy entirely. The old files then stay in place and every request still succeeds with a `200`.

That is not hypothetical. On `chart-rows-text-left-chart-right` this week, builds [#31831](https://buildkite.com/our-world-in-data/grapher-automated-staging-environment/builds/31831) and [#31834](https://buildkite.com/our-world-in-data/grapher-automated-staging-environment/builds/31834) served the previous build's stylesheet for over an hour while looking exactly like successful deploys. A designer reported a pushed CSS change as missing, was told the preview just hadn't rebuilt, and establishing what was actually deployed took byte-comparing `/assets/owid.css` against a known-good build. (The root cause of those failures was separate — a stale branch — but the *stale asset* was what made it undiagnosable from the outside.)

## What this does

Emit `owid.[hash].css` / `owid.[hash].mjs` for the site entrypoint, so the filename is a claim about the contents:

- HTML built against one bundle can only ever load that bundle.
- A missed copy step is a **404**, not silently old CSS.
- A given URL's contents can never change, so it becomes cacheable indefinitely (see follow-ups).

Nothing referenced those names literally: they are resolved through `.vite/manifest.json`, keyed by the entry point's *source* path, so page rendering needed no changes at all.

Two adjustments fall out of it:

- **Archival pages now resolve assets through the archive build's manifest.** They previously went through the *site* manifest and remapped the result via `staticAssetMap`, which is keyed by the filenames in `dist/assets-archive` — that only worked because both builds happened to emit `owid.mjs`. The archive bundle deliberately keeps stable names, because `bakeAssets` in `ArchivalBaker` hashes it separately and looks the files up by name.
- **BundleMon** tracks the two files via its `<hash>` placeholder so size history still lines up across builds.

The admin bundle is out of scope — it's served from `dist/assets-admin` by the admin server itself, so it can't go stale the way a baked asset can.

## How to test it

The mechanism is visible without a bake:

```
yarn buildViteSite
ls dist/assets/            # owid.<hash>.mjs, owid.<hash>.css
cat dist/assets/.vite/manifest.json
```

To confirm rendering picks the hashed names up (`VITE_PREVIEW=true` forces production asset resolution in a dev checkout):

```
echo 'import R from "react-dom/server"; import {viteAssetsForSite} from "./site/viteUtils.js"
const a = viteAssetsForSite(); [...a.forHeader, ...a.forFooter].forEach(t => console.log(R.renderToStaticMarkup(t)))' > /tmp/check.tsx
VITE_PREVIEW=true yarn tsx --tsconfig tsconfig.tsx.json /tmp/check.tsx
```

Expected — hashed URLs throughout:

```
<link rel="modulepreload" href="/assets/owid.B5shjRlm.mjs"/>
<link rel="preload" href="/assets/owid.oGZIKCXe.css" as="style"/>
<link rel="stylesheet" href="/assets/owid.oGZIKCXe.css"/>
<script type="module" src="/assets/owid.B5shjRlm.mjs" data-attach-owid-error-handler="true"></script>
```

On this branch's staging server, the thing to check is a **normal baked page and an archival page**: view source and confirm the stylesheet/script URLs are hashed and resolve (no 404s in the network tab), and that an archival page still loads its own bundle.

Already verified locally: `yarn buildViteSite` emits hashed names and a matching manifest; the rendered tags above; `sourceMappingURL` in the bundle correctly points at the hashed `.map`; `yarn buildViteArchive` still emits plain `owid.css` / `owid.mjs` / `owid.mjs.map` as `ASSET_FILES` expects; typecheck clean; `site/viteUtils.test.ts` (with a new hashed-manifest case) and `createWikipediaArchive.test.ts` pass; lint and format clean.

Genuinely unverified and worth a reviewer's eye: **BundleMon in CI** (the `<hash>` placeholder and the `pathLabels` regex are only exercised there), and the **archival bake end to end**, which I couldn't run locally.

## Trade-off to be aware of

This converts "silently stale" into "loudly broken", and that cuts both ways: old hashed files disappear on the next bake, so HTML cached from before a deploy can reference an asset that no longer exists. Exposure is small in practice — `public/_headers` sets `Cache-Control: no-cache` for `/*`, so both browsers and the CDN revalidate HTML — but it is a real change in failure mode, and the usual mitigation if it ever bites is retaining the previous build's assets.

## Follow-ups, deliberately not in this PR

- `/assets/*` inherits `Cache-Control: no-cache` and can now be cached immutably — a real reader-facing performance win. It has to exclude `embedCharts.js`, whose URL third-party sites load directly and which stays unhashed on purpose.
- The preview's `/assets` should be served from `dist/assets` rather than the baked copy, so a design review never waits on a bake at all. That's an nginx change in the ops repo, and it's the half of this that actually removes ~10 minutes from each round trip. **Until it lands, hashing alone means a failed bake shows up as an unstyled preview rather than a stale one** — louder, but worth knowing before this merges.
