### PR TITLE
🚧 Prototype: /featured-viz dashboard for bespoke visualizations

### DIFF
--- a/adminSiteServer/mockSiteRouter.ts
+++ b/adminSiteServer/mockSiteRouter.ts
@@ -13,6 +13,7 @@ import {
     renderExplorerPage,
     makeAtomFeedNoTopicPages,
     renderDynamicCollectionPage,
+    renderFeaturedVizPage,
     renderTopChartsCollectionPage,
     renderThankYouPage,
     makeDataInsightsAtomFeed,
@@ -219,6 +220,10 @@ getPlainRouteWithROTransaction(
 
 mockSiteRouter.get("/collection/custom", async (_, res) => {
     return res.send(renderDynamicCollectionPage())
+})
+
+mockSiteRouter.get("/featured-viz", async (_, res) => {
+    return res.send(renderFeaturedVizPage())
 })
 
 getPlainRouteWithROTransaction(

--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -20,6 +20,7 @@ import {
     renderGdoc,
     makeAtomFeedNoTopicPages,
     renderDynamicCollectionPage,
+    renderFeaturedVizPage,
     renderTopChartsCollectionPage,
     renderThankYouPage,
     makeDataInsightsAtomFeed,
@@ -827,6 +828,10 @@ export class SiteBaker {
         await this.stageWrite(
             `${this.bakedSiteDir}/collection/custom.html`,
             renderDynamicCollectionPage()
+        )
+        await this.stageWrite(
+            `${this.bakedSiteDir}/featured-viz.html`,
+            renderFeaturedVizPage()
         )
         await this.stageWrite(
             `${this.bakedSiteDir}/collection/top-charts.html`,

--- a/baker/siteRenderers.tsx
+++ b/baker/siteRenderers.tsx
@@ -7,6 +7,7 @@ import { StaticCollectionPage } from "../site/collections/StaticCollectionPage.j
 import NotFoundPage from "../site/NotFoundPage.js"
 import { DonatePage } from "../site/DonatePage.js"
 import { ExplorerIndexPage } from "../site/ExplorerIndexPage.js"
+import { FeaturedVizPage } from "../site/featuredViz/FeaturedVizPage.js"
 import { SubscribePage } from "../site/SubscribePage.js"
 import { ThankYouPage } from "../site/ThankYouPage.js"
 import TombstonePage from "../site/TombstonePage.js"
@@ -135,6 +136,10 @@ export async function renderTopChartsCollectionPage(
 
 export function renderDynamicCollectionPage() {
     return renderToHtmlPage(<DynamicCollectionPage baseUrl={BAKED_BASE_URL} />)
+}
+
+export function renderFeaturedVizPage() {
+    return renderToHtmlPage(<FeaturedVizPage baseUrl={BAKED_BASE_URL} />)
 }
 
 export const renderGdocsPageBySlug = async (

--- a/bespoke/projects/income-plots/package.json
+++ b/bespoke/projects/income-plots/package.json
@@ -1,0 +1,46 @@
+{
+    "name": "@owid/bespoke-income-plots",
+    "private": true,
+    "type": "module",
+    "entrypoints": {
+        "js": "src/index.tsx"
+    },
+    "scripts": {
+        "dev": "vite dev",
+        "build": "vite build",
+        "typecheck": "tsgo"
+    },
+    "dependencies": {
+        "@floating-ui/react": "^0.27.16",
+        "@fortawesome/fontawesome-svg-core": "^6.7.2",
+        "@fortawesome/free-solid-svg-icons": "^6.7.2",
+        "@fortawesome/react-fontawesome": "^0.2.2",
+        "@ourworldindata/components": "link:../../../packages/@ourworldindata/components",
+        "@ourworldindata/types": "link:../../../packages/@ourworldindata/types",
+        "@ourworldindata/utils": "link:../../../packages/@ourworldindata/utils",
+        "@react-stately/flags": "^3.2.0",
+        "classnames": "^2.5.1",
+        "d3": "^7.9.0",
+        "fast-kde": "^0.2.2",
+        "jotai": "^2.20.0",
+        "jotai-effect": "^2.3.1",
+        "react": "^19.2.4",
+        "react-aria": "^3.48.0",
+        "react-aria-components": "^1.17.0",
+        "react-dom": "^19.2.4",
+        "remeda": "^2.32.0",
+        "usehooks-ts": "^3.1.1",
+        "vite-plugin-css-position": "^2.0.9"
+    },
+    "devDependencies": {
+        "@rollup/plugin-swc": "^0.4.0",
+        "@swc/core": "^1.15.33",
+        "@types/d3": "^7.4.3",
+        "@types/react": "^19.2.14",
+        "@types/react-dom": "^19.2.3",
+        "@typescript/native-preview": "^7.0.0-dev.20260408.1",
+        "@vitejs/plugin-react": "^6.0.0",
+        "sass": "^1.87.0",
+        "vite": "^8.0.5"
+    }
+}

--- a/bespoke/projects/income-plots/src/ShadowRootContext.tsx
+++ b/bespoke/projects/income-plots/src/ShadowRootContext.tsx
@@ -1,0 +1,5 @@
+import { createContext, useContext } from "react"
+
+export const ShadowRootContext = createContext<HTMLElement | null>(null)
+
+export const useShadowRoot = () => useContext(ShadowRootContext)

--- a/bespoke/projects/income-plots/src/components/App.tsx
+++ b/bespoke/projects/income-plots/src/components/App.tsx
@@ -1,0 +1,158 @@
+import {
+    Suspense,
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+} from "react"
+import { IncomePlot } from "./IncomePlot.tsx"
+import {
+    IncomePlotControlsRowBottom,
+    IncomePlotControlsRowTop,
+} from "./IncomePlotControlsRow.tsx"
+import { IncomePlotDrawer } from "./IncomePlotDrawer.tsx"
+import { Provider, useAtom, useAtomValue, useSetAtom } from "jotai"
+import {
+    atomCurrentTab,
+    atomCurrentYear,
+    atomEffectIncludeLocalCountryInSelection,
+    atomisNarrow,
+} from "../store.ts"
+import { useResizeObserver, useWindowSize } from "usehooks-ts"
+import { UNSAFE_PortalProvider } from "react-aria"
+import { useShadowRoot } from "../ShadowRootContext.tsx"
+import { Frame } from "../../../../components/Frame/Frame.js"
+import { ChartHeader } from "../../../../components/ChartHeader/ChartHeader.js"
+import { ChartFooter } from "../../../../components/ChartFooter/ChartFooter.js"
+import { LoadingIndicator } from "@ourworldindata/components"
+import {
+    getIncomePlotTitle,
+    INCOME_PLOT_SOURCE,
+    INCOME_PLOT_SUBTITLE,
+} from "../utils/incomePlotMetadata.ts"
+
+export const App = ({
+    tab,
+    isolateState = false,
+}: {
+    tab?: "global" | "countries"
+    isolateState?: boolean
+}) => {
+    if (isolateState) {
+        return (
+            <Provider>
+                <AppInner tab={tab} />
+            </Provider>
+        )
+    }
+    return <AppInner tab={tab} />
+}
+
+const AppInner = ({ tab }: { tab?: "global" | "countries" }) => {
+    const shadowRoot = useShadowRoot()
+    useAtom(atomEffectIncludeLocalCountryInSelection) // include local country in selection once the local country is detected
+
+    const setCurrentTab = useSetAtom(atomCurrentTab)
+    useEffect(() => {
+        if (tab === "global" || tab === "countries") {
+            setCurrentTab(tab)
+        }
+    }, [tab, setCurrentTab])
+
+    const currentYear = useAtomValue(atomCurrentYear)
+    const containerRef = useRef<HTMLDivElement>(null)
+    const bottomControlsRef = useRef<HTMLDivElement>(null)
+    const { width = 0 } = useResizeObserver({
+        ref: containerRef as React.RefObject<HTMLDivElement>,
+    })
+    const { height: bottomControlsHeight = 0 } = useResizeObserver({
+        ref: bottomControlsRef as React.RefObject<HTMLDivElement>,
+    })
+
+    const setisNarrow = useSetAtom(atomisNarrow)
+
+    const isNarrow = useMemo(() => !!(width && width < 720), [width])
+    useEffect(() => {
+        setisNarrow(isNarrow)
+    }, [isNarrow, setisNarrow])
+
+    const { height: windowHeight, width: windowWidth } = useWindowSize()
+    const isPortrait = windowHeight >= windowWidth
+
+    const aspectRatio = isNarrow && isPortrait ? 1.1 : 5 / 3
+    const plotHeight = useMemo(() => {
+        const targetChartAreaHeight = width / aspectRatio
+        const controlsHeight = isNarrow ? 0 : bottomControlsHeight
+        return Math.max(targetChartAreaHeight - controlsHeight, 1)
+    }, [aspectRatio, bottomControlsHeight, isNarrow, width])
+
+    const [drawerOpen, setDrawerOpen] = useState(false)
+    const closeDrawer = useCallback(() => setDrawerOpen(false), [])
+
+    return (
+        <UNSAFE_PortalProvider
+            getContainer={shadowRoot ? () => shadowRoot : undefined}
+        >
+            <Frame className="income-plot-captioned-chart">
+                <ChartHeader
+                    className="income-plot-header"
+                    title={getIncomePlotTitle(currentYear)}
+                    subtitle={INCOME_PLOT_SUBTITLE}
+                />
+                <div ref={containerRef}>
+                    <IncomePlotControlsRowTop
+                        isNarrow={isNarrow}
+                        onOpenSettings={() => setDrawerOpen(true)}
+                    />
+                    <div
+                        className="income-plot-captioned-chart__chart-area"
+                        style={{
+                            aspectRatio: aspectRatio,
+                        }}
+                    >
+                        <Suspense
+                            fallback={
+                                <div
+                                    className="income-plot-loading"
+                                    style={{ height: plotHeight }}
+                                >
+                                    <LoadingIndicator
+                                        title="Loading income distributions"
+                                        color="#5b5b5b"
+                                    />
+                                </div>
+                            }
+                        >
+                            <IncomePlot
+                                key={currentYear}
+                                height={plotHeight}
+                                width={width}
+                                isNarrow={isNarrow}
+                                tab={tab}
+                            />
+                        </Suspense>
+                        {!isNarrow && (
+                            <div
+                                ref={bottomControlsRef}
+                                className="income-plot-captioned-chart__bottom-controls"
+                            >
+                                <IncomePlotControlsRowBottom />
+                            </div>
+                        )}
+                    </div>
+                    {isNarrow && (
+                        <IncomePlotDrawer
+                            isOpen={drawerOpen}
+                            onClose={closeDrawer}
+                        />
+                    )}
+                </div>
+                <ChartFooter
+                    className="income-plot-footer"
+                    source={INCOME_PLOT_SOURCE}
+                />
+            </Frame>
+        </UNSAFE_PortalProvider>
+    )
+}

--- a/bespoke/projects/income-plots/src/components/IncomePlot.tsx
+++ b/bespoke/projects/income-plots/src/components/IncomePlot.tsx
@@ -1,0 +1,1074 @@
+import {
+    MouseEvent,
+    PointerEvent,
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+} from "react"
+import { useAtom, useAtomValue, useSetAtom } from "jotai"
+import * as d3 from "d3"
+import { formatCurrency, getLabelDirection } from "../utils/incomePlotUtils.ts"
+import {
+    atomCombinedFactor,
+    atomCountriesOrRegionsMode,
+    atomCountryRegionMap,
+    atomCurrentCurrency,
+    atomCurrentTab,
+    atomCustomPovertyLine,
+    atomCustomPovertyLineFormatted,
+    atomHoveredEntity,
+    atomHoveredEntityType,
+    atomHoveredX,
+    atomKdeDataForYear,
+    atomKdeXValues,
+    atomIsInSingleCountryMode,
+    atomSelectedCountryNames,
+    atomShowCustomPovertyLine,
+    atomEntityColorMap,
+    atomLegendPlacement,
+    atomRawDataForYear,
+} from "../store.ts"
+import {
+    INT_POVERTY_LINE,
+    StackedSeriesPoint,
+} from "../utils/incomePlotConstants.ts"
+import * as R from "remeda"
+import { IncomePlotTooltip } from "./IncomePlotTooltip.tsx"
+import { IncomePlotLegend } from "./IncomePlotLegend.tsx"
+
+const style = {
+    fontFamily:
+        'Lato, "Helvetica Neue", Helvetica, Arial, "Liberation Sans", sans-serif',
+    fontSize: "13px",
+    maxWidth: "100%",
+    display: "block",
+}
+
+const LABEL_FONT_SIZES = [13, 12, 11, 10, 9] as const
+const CHAR_WIDTH_RATIO = 0.4 // approximate char width as fraction of font size
+
+export interface IncomePlotProps {
+    height: number
+    width: number
+    isNarrow?: boolean
+    tab?: "global" | "countries"
+}
+
+interface IncomePlotClipPathProps {
+    xScale: d3.ScaleLogarithmic<number, number> | null
+}
+
+const IncomePlotClipPath = ({ xScale }: IncomePlotClipPathProps) => {
+    const povertyLine = useAtomValue(atomCustomPovertyLine)
+    const hoveredX = useAtomValue(atomHoveredX)
+    const hoverRightThresholdPlaced = useMemo(() => {
+        const threshold = povertyLine ?? hoveredX
+        if (!xScale || threshold === null) return null
+        return xScale(threshold)
+    }, [povertyLine, hoveredX, xScale])
+    return (
+        <defs>
+            <clipPath id="highlight-clip">
+                <rect
+                    x="0"
+                    y="0"
+                    width={hoverRightThresholdPlaced ?? "100%"}
+                    height={"100%"}
+                />
+            </clipPath>
+        </defs>
+    )
+}
+
+interface IncomePlotAreasProps {
+    xScale: d3.ScaleLogarithmic<number, number> | null
+    height: number
+}
+
+const IncomePlotAreasStacked = ({ xScale, height }: IncomePlotAreasProps) => {
+    const ref = useRef<SVGGElement>(null)
+
+    const points = useAtomValue(atomKdeDataForYear)
+    const xValues = useAtomValue(atomKdeXValues)
+    const countryRegionMap = useAtomValue(atomCountryRegionMap)
+    const countriesOrRegionsMode = useAtomValue(atomCountriesOrRegionsMode)
+    const selectedCountryNames: string[] = [] // Country selection is disabled for stacked mode for now
+    const [hoveredEntity, setHoveredEntity] = useAtom(atomHoveredEntity)
+    const hoveredEntityType = useAtomValue(atomHoveredEntityType)
+    const entityColors = useAtomValue(atomEntityColorMap)
+
+    // Prepare Data for Stack
+    const stackedSeries = useMemo(() => {
+        // 1. Group by X and pivot
+        // Create a map for quick lookup: x -> { country: y }
+        const dataMap = new Map<number, { [key: string]: number }>()
+        points.forEach((d) => {
+            if (!dataMap.has(d.x)) dataMap.set(d.x, {})
+            const xMap = dataMap.get(d.x)!
+            xMap[d.country] = d.yScaledByPop
+        })
+
+        const countries = Array.from(countryRegionMap.keys())
+
+        const stackedDataInput = xValues.map((x) => {
+            const row: any = { x }
+            const xValuesMap = dataMap.get(x) || {}
+            countries.forEach((country) => {
+                row[country] = xValuesMap[country] || 0
+            })
+            return row
+        })
+
+        // 2. Stack
+        const stack = d3.stack().keys(countries)
+
+        const stackedSeries = stack(stackedDataInput)
+
+        stackedSeries.forEach((s) => {
+            const series = s as unknown as StackedSeriesPoint
+            series.country = series.key
+            series.region = countryRegionMap.get(series.key)!
+            series.color = entityColors.get(series.region)!
+        })
+
+        return stackedSeries as unknown as StackedSeriesPoint[]
+    }, [points, countryRegionMap, xValues, entityColors])
+
+    const yMax = useMemo(() => {
+        return d3.max(stackedSeries, (series) => d3.max(series, (d) => d[1]))!
+    }, [stackedSeries])
+
+    const yScale = useMemo(() => {
+        if (!xScale) return null
+        return d3
+            .scaleLinear()
+            .domain([0, yMax])
+            .range([height - 30, 30])
+    }, [height, xScale, yMax])
+
+    // Area Generator
+    const area = useMemo(() => {
+        if (!xScale || !yScale) return null
+        return d3
+            .area<any>()
+            .x((d) => xScale(d.data.x))
+            .y0((d) => yScale(d[0]))
+            .y1((d) => yScale(d[1]))
+    }, [xScale, yScale])
+
+    const regionStackedData = useMemo(() => {
+        // Re-stack the already stacked data by regions.
+        // We need to compute this even when we are in country mode, so that we have this data available for `regionLabels` below.
+        const grouped = R.groupBy(stackedSeries, (d) => d.region)
+        return Object.values(grouped).map((dataForRegion) => {
+            const first = R.first(dataForRegion)
+            const last = R.last(dataForRegion)
+
+            const combined = R.zip(first, last).map(([f, l]) => {
+                const arr = [f[0], l[1]] as d3.SeriesPoint<{ x: number }>
+                arr.data = f.data
+                return arr
+            }) as StackedSeriesPoint
+
+            combined.key = first.region
+            combined.region = first.region
+            combined.color = first.color
+
+            return combined
+        })
+    }, [stackedSeries])
+
+    const stackedData = useMemo(
+        () =>
+            countriesOrRegionsMode === "countries"
+                ? stackedSeries
+                : regionStackedData,
+        [countriesOrRegionsMode, stackedSeries, regionStackedData]
+    )
+
+    const seriesWithAreas = useMemo(() => {
+        if (!area) return []
+        return stackedData.map((series) => ({
+            ...series,
+            area: area(series),
+        }))
+    }, [area, stackedData])
+
+    /**
+     * Marcel here: The following code is for placing region labels inside the areas. It was implemented by Claude Code and I don't fully understand it. Be careful!
+     */
+
+    // Place region name labels inside each stacked area.
+    //
+    // We find the best label position using a weighted "pole of inaccessibility":
+    // 1. Build the boundary polygon of each region area in pixel space
+    // 2. Scale x-coordinates by 1/aspectRatio (where aspectRatio = text width /
+    //    text height). In this compressed space, finding the largest inscribed
+    //    circle is equivalent to finding the largest inscribed oval with the
+    //    text's aspect ratio in the original space.
+    // 3. Build a Delaunay triangulation of the scaled boundary points for fast
+    //    nearest-neighbor lookups
+    // 4. Test a grid of candidate points; for each, query the Delaunay to get
+    //    the distance to the nearest boundary in scaled space
+    // 5. The candidate with the maximum distance is the center of the largest
+    //    inscribed text-shaped rectangle
+    //
+    // The bestDist in scaled space directly determines the max font size:
+    // in original space it corresponds to half-height = bestDist and
+    // half-width = bestDist * textAspect. Since text at font size f needs
+    // half-height f/2, the max font is 2 * bestDist (with a comfort margin).
+    const regionLabels = useMemo(() => {
+        if (!xScale || !yScale) return []
+
+        // Convert each series' data coordinates to pixel space once up front
+        const seriesPixelData = regionStackedData.map((series) => {
+            return series.map((point) => ({
+                x: xScale(point.data.x),
+                top: yScale(point[1]), // upper edge (smaller y = higher on screen)
+                bot: yScale(point[0]), // lower edge
+            }))
+        })
+
+        return regionStackedData.map((series, seriesIdx) => {
+            const n = series.length
+            const pxData = seriesPixelData[seriesIdx]
+            const regionName = series.region ?? series.key
+
+            // The text's aspect ratio (width/height) determines how we weight
+            // horizontal vs vertical distances. This ratio is font-size-
+            // independent since both dimensions scale linearly with font size.
+            const textAspect = regionName.length * CHAR_WIDTH_RATIO
+            // Compressing x by this factor transforms the problem so that
+            // Euclidean distance in the scaled space corresponds to how well
+            // a text-shaped rectangle fits in the original space.
+            const xShrink = 1 / textAspect
+
+            // Build the boundary polygon in scaled space: trace the top edge
+            // left-to-right, then the bottom edge right-to-left.
+            // We subdivide each edge segment so that vertex spacing in
+            // scaled space is at most MAX_SEG_LEN px. This ensures that
+            // "nearest vertex" closely approximates "nearest edge".
+            const MAX_SEG_LEN = 4
+            const boundaryPoints: number[] = []
+
+            const addSubdividedEdge = (
+                points: typeof pxData,
+                getY: (p: (typeof pxData)[0]) => number
+            ) => {
+                for (let i = 0; i < points.length - 1; i++) {
+                    const x0 = points[i].x * xShrink
+                    const y0 = getY(points[i])
+                    const x1 = points[i + 1].x * xShrink
+                    const y1 = getY(points[i + 1])
+                    const segLen = Math.hypot(x1 - x0, y1 - y0)
+                    const subdivisions = Math.max(
+                        1,
+                        Math.ceil(segLen / MAX_SEG_LEN)
+                    )
+                    for (let s = 0; s < subdivisions; s++) {
+                        const t = s / subdivisions
+                        boundaryPoints.push(
+                            x0 + t * (x1 - x0),
+                            y0 + t * (y1 - y0)
+                        )
+                    }
+                }
+                // Add the last point
+                const last = points[points.length - 1]
+                boundaryPoints.push(last.x * xShrink, getY(last))
+            }
+
+            // Top edge left-to-right
+            addSubdividedEdge(pxData, (p) => p.top)
+            // Bottom edge right-to-left
+            addSubdividedEdge([...pxData].reverse(), (p) => p.bot)
+
+            const scaledCoords = new Float64Array(boundaryPoints)
+
+            // Build Delaunay on the scaled boundary so that nearest-neighbor
+            // queries reflect the text's aspect ratio
+            const delaunay = new d3.Delaunay(scaledCoords)
+
+            // Search an 50×40 grid of candidate points inside the region.
+            // For each candidate, find the weighted distance to the nearest
+            // boundary point and keep track of the maximum.
+            let bestPoint: [number, number] | null = null
+            let bestDistSq = 0 // squared distance (avoids sqrt in inner loop)
+
+            const GRID_X = 50
+            const GRID_Y = 40
+
+            for (let gx = 1; gx < GRID_X; gx++) {
+                // Interpolate between data points to get the x position and
+                // the top/bottom edges of the region at this grid column
+                const t = gx / GRID_X
+                const idx = t * (n - 1)
+                const i0 = Math.floor(idx)
+                const i1 = Math.min(i0 + 1, n - 1)
+                const frac = idx - i0
+
+                const topPx =
+                    pxData[i0].top * (1 - frac) + pxData[i1].top * frac
+                const botPx =
+                    pxData[i0].bot * (1 - frac) + pxData[i1].bot * frac
+                const px = pxData[i0].x * (1 - frac) + pxData[i1].x * frac
+
+                // Skip very thin slices of the region
+                const height = botPx - topPx
+                if (height <= 10) continue
+
+                // Query the Delaunay in scaled x-space
+                const scaledPx = px * xShrink
+
+                for (let gy = 1; gy < GRID_Y; gy++) {
+                    const py = topPx + (gy / GRID_Y) * height
+
+                    // Find nearest boundary point in scaled space
+                    const nearestIdx = delaunay.find(scaledPx, py)
+                    const dx = scaledPx - scaledCoords[nearestIdx * 2]
+                    const dy = py - scaledCoords[nearestIdx * 2 + 1]
+                    const distSq = dx * dx + dy * dy
+
+                    if (distSq > bestDistSq) {
+                        bestDistSq = distSq
+                        bestPoint = [px, py]
+                    }
+                }
+            }
+
+            // bestDist (in scaled space) is the radius of the largest
+            // inscribed circle. The max font size that fits is 2 * bestDist,
+            // reduced by a comfort margin (0.65) to ensure breathing room.
+            const bestDist = Math.sqrt(bestDistSq)
+            const maxFont = bestDist * 2 * 0.65
+            const chosenFontSize = LABEL_FONT_SIZES.find((f) => f <= maxFont)
+
+            return {
+                region: regionName,
+                point: bestPoint,
+                fontSize: chosenFontSize,
+                color: series.color,
+            }
+        })
+    }, [regionStackedData, xScale, yScale])
+
+    const onMouseLeave = useCallback(
+        (entity: string) => {
+            // Only set to null if it hasn't been changed in the meantime
+            setHoveredEntity((current) => (current === entity ? null : current))
+        },
+        [setHoveredEntity]
+    )
+
+    return (
+        <g className="plot-series-stacked" ref={ref}>
+            {seriesWithAreas.map((series) => {
+                if (!series.area) return null
+                const isHighlighted =
+                    hoveredEntityType === null
+                        ? undefined
+                        : series[hoveredEntityType] === hoveredEntity
+
+                const isSelected =
+                    series.country &&
+                    selectedCountryNames.includes(series.country)
+                        ? true
+                        : undefined
+
+                const entityName =
+                    countriesOrRegionsMode === "countries"
+                        ? series.country
+                        : series.region
+
+                return (
+                    <g
+                        key={entityName}
+                        className="income-plot-series"
+                        data-country={series.country}
+                        data-region={series.region}
+                        data-selected={isSelected}
+                        data-highlighted={isHighlighted}
+                        onMouseEnter={() =>
+                            entityName && setHoveredEntity(entityName)
+                        }
+                        onMouseLeave={() =>
+                            entityName && onMouseLeave(entityName)
+                        }
+                    >
+                        <path
+                            className="area-bg"
+                            fill={series.color}
+                            d={series.area}
+                            strokeWidth={0.1}
+                            stroke="white"
+                        />
+                        <path
+                            className="area-fg"
+                            fill={series.color}
+                            d={series.area}
+                            clipPath="url(#highlight-clip)"
+                            style={{ pointerEvents: "none" }}
+                            strokeWidth={0.15}
+                            strokeOpacity={0.5}
+                            stroke="white"
+                        />
+                    </g>
+                )
+            })}
+            {regionLabels.map((label) => {
+                if (!label.point || !label.fontSize) return null
+                return (
+                    <text
+                        key={label.region}
+                        className="region-label"
+                        x={label.point[0]}
+                        y={label.point[1]}
+                        fontSize={label.fontSize}
+                    >
+                        {label.region}
+                    </text>
+                )
+            })}
+        </g>
+    )
+}
+
+const sanitizeId = (name: string) => name.replace(/[^a-zA-Z0-9-_]/g, "")
+
+const IncomePlotAreasUnstacked = ({ xScale, height }: IncomePlotAreasProps) => {
+    const ref = useRef<SVGGElement>(null)
+
+    const points = useAtomValue(atomKdeDataForYear)
+    const rawData = useAtomValue(atomRawDataForYear)
+    const countryRegionMap = useAtomValue(atomCountryRegionMap)
+    const countriesOrRegionsMode = useAtomValue(atomCountriesOrRegionsMode)
+    const selectedCountryNames = useAtomValue(atomSelectedCountryNames)
+    const [hoveredEntity, setHoveredEntity] = useAtom(atomHoveredEntity)
+    const hoveredEntityType = useAtomValue(atomHoveredEntityType)
+    const entityColors = useAtomValue(atomEntityColorMap)
+
+    const countryLimits = useMemo(() => {
+        const limits = new Map<
+            string,
+            { lowerCutoff: number; upperCutoff: number }
+        >()
+        rawData.forEach((record) => {
+            const avgs = record.avgs
+            const len = avgs.length
+            const percentileIndex = 10 // 1 percentile
+            if (len > 0) {
+                const lowerCutoff = avgs[percentileIndex - 1]
+                const upperCutoff = avgs[1000 - percentileIndex - 1]
+                limits.set(record.country, { lowerCutoff, upperCutoff })
+            }
+        })
+        return limits
+    }, [rawData])
+
+    // Prepare Data for Stack
+    const filteredData = useMemo(() => {
+        return points.filter((d) => {
+            if (!selectedCountryNames.includes(d.country)) return false
+            const limits = countryLimits.get(d.country)
+            if (!limits) return true
+            return d.x >= limits.lowerCutoff && d.x <= limits.upperCutoff
+        })
+    }, [points, selectedCountryNames, countryLimits])
+
+    const yMax = useMemo(
+        () => d3.max(filteredData, (d) => d.y) || 0,
+        [filteredData]
+    )
+
+    const groupedData = useMemo(() => {
+        return d3.group(filteredData, (d) => d.country)
+    }, [filteredData])
+
+    const yScale = useMemo(() => {
+        if (!xScale) return null
+        return d3
+            .scaleLinear()
+            .domain([0, yMax])
+            .range([height - 30, 30])
+    }, [xScale, yMax, height])
+
+    // Area Generator
+    const area = useMemo(() => {
+        if (!xScale || !yScale) return null
+        return d3
+            .area<any>()
+            .x((d) => xScale(d.x))
+            .y0(yScale(0))
+            .y1((d) => yScale(d.y))
+    }, [xScale, yScale])
+
+    // Line Generator
+    const line = useMemo(() => {
+        if (!xScale || !yScale) return null
+        return d3
+            .line<any>()
+            .x((d) => xScale(d.x))
+            .y((d) => yScale(d.y))
+    }, [xScale, yScale])
+
+    const seriesWithAreas = useMemo(() => {
+        if (!area || !line) return []
+        return Array.from(groupedData).map(([country, points]) => {
+            const region = countryRegionMap.get(country) ?? ""
+            const limits = countryLimits.get(country)
+            return {
+                country,
+                region,
+                color: entityColors.get(country),
+                area: area(points),
+                line: line(points),
+                lowerCutoff: limits?.lowerCutoff,
+                upperCutoff: limits?.upperCutoff,
+            }
+        })
+    }, [area, line, groupedData, countryRegionMap, entityColors, countryLimits])
+
+    const onMouseLeave = useCallback(
+        (entity: string) => {
+            // Only set to null if it hasn't been changed in the meantime
+            setHoveredEntity((current) => (current === entity ? null : current))
+        },
+        [setHoveredEntity]
+    )
+
+    return (
+        <g className="plot-series-unstacked" ref={ref}>
+            <defs>
+                {seriesWithAreas.map((series) => {
+                    if (
+                        !xScale ||
+                        series.lowerCutoff === undefined ||
+                        series.upperCutoff === undefined
+                    )
+                        return null
+                    const x1 = xScale(series.lowerCutoff)
+                    const x2 = xScale(series.upperCutoff)
+                    const totalWidth = x2 - x1
+                    if (totalWidth <= 0) return null
+
+                    const cleanCountry = sanitizeId(series.country)
+                    const maskId = `fade-mask-${cleanCountry}`
+                    const gradId = `fade-grad-${cleanCountry}`
+
+                    return (
+                        <g key={series.country}>
+                            <linearGradient
+                                id={gradId}
+                                gradientUnits="userSpaceOnUse"
+                                x1={x1}
+                                x2={x2}
+                                y1={0}
+                                y2={0}
+                            >
+                                <stop
+                                    offset="0%"
+                                    stopColor="white"
+                                    stopOpacity={0}
+                                />
+                                <stop
+                                    offset="4%"
+                                    stopColor="white"
+                                    stopOpacity={1}
+                                />
+                                <stop
+                                    offset="96%"
+                                    stopColor="white"
+                                    stopOpacity={1}
+                                />
+                                <stop
+                                    offset="100%"
+                                    stopColor="white"
+                                    stopOpacity={0}
+                                />
+                            </linearGradient>
+                            <mask id={maskId}>
+                                <rect
+                                    x="0"
+                                    y="0"
+                                    width="100%"
+                                    height="100%"
+                                    fill={`url(#${gradId})`}
+                                />
+                            </mask>
+                        </g>
+                    )
+                })}
+            </defs>
+            {seriesWithAreas.map((series) => {
+                if (!series.area || !series.line) return null
+                const isHighlighted =
+                    hoveredEntityType === null
+                        ? undefined
+                        : series[hoveredEntityType] === hoveredEntity
+
+                const entityName =
+                    countriesOrRegionsMode === "countries"
+                        ? series.country
+                        : series.region
+
+                const cleanCountry = sanitizeId(series.country)
+                const maskId = `fade-mask-${cleanCountry}`
+
+                return (
+                    <g
+                        key={entityName}
+                        className="income-plot-series"
+                        data-country={series.country}
+                        data-region={series.region}
+                        data-highlighted={isHighlighted}
+                        onMouseEnter={() =>
+                            entityName && setHoveredEntity(entityName)
+                        }
+                        onMouseLeave={() =>
+                            entityName && onMouseLeave(entityName)
+                        }
+                        mask={`url(#${maskId})`}
+                    >
+                        <path
+                            className="area-bg"
+                            fill={series.color}
+                            d={series.area}
+                        />
+                        <path
+                            className="line-bg"
+                            fill="none"
+                            d={series.line}
+                            strokeWidth={1}
+                            strokeOpacity={0.6}
+                            stroke={series.color}
+                        />
+                        <path
+                            className="area-fg"
+                            fill={series.color}
+                            d={series.area}
+                            clipPath="url(#highlight-clip)"
+                            style={{ pointerEvents: "none" }}
+                        />
+                        <path
+                            className="line-fg"
+                            fill="none"
+                            d={series.line}
+                            clipPath="url(#highlight-clip)"
+                            style={{ pointerEvents: "none" }}
+                            strokeWidth={1}
+                            stroke={series.color}
+                        />
+                    </g>
+                )
+            })}
+        </g>
+    )
+}
+
+interface IncomePlotXAxisProps {
+    xScale: d3.ScaleLogarithmic<number, number> | null
+    height: number
+    marginBottom: number
+    marginTop: number
+    isNarrow?: boolean
+}
+
+const IncomePlotXAxis = ({
+    xScale,
+    height,
+    marginBottom,
+    marginTop,
+    isNarrow,
+}: IncomePlotXAxisProps) => {
+    const xAxisRef = useRef<SVGGElement>(null)
+
+    const currentCurrency = useAtomValue(atomCurrentCurrency)
+    const combinedFactor = useAtomValue(atomCombinedFactor)
+
+    useEffect(() => {
+        if (!xAxisRef.current || !xScale) return
+
+        const g = d3.select(xAxisRef.current)
+        const tickMarkPoints = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+        const tickMarkPointsToDisplay = isNarrow ? [1, 3] : [1, 2, 3, 5]
+
+        const [min, max] = xScale.domain()
+
+        // Mapping from tick value to whether the label should be shown on the axis
+        const xTicks: Map<number, boolean> = new Map()
+        for (
+            let power = Math.floor(Math.log10(min * combinedFactor));
+            Math.pow(10, power) <= max * combinedFactor;
+            power++
+        ) {
+            const base = Math.pow(10, power)
+            tickMarkPoints.forEach((multiplier) => {
+                const val = (base * multiplier) / combinedFactor
+                if (val >= min && val <= max)
+                    xTicks.set(
+                        val,
+                        tickMarkPointsToDisplay.includes(multiplier)
+                    )
+            })
+        }
+
+        const xAxis = d3
+            .axisBottom(xScale)
+            .tickValues(Array.from(xTicks.keys()))
+            .tickFormat((d) => {
+                const shouldShowLabel = xTicks.get(d as number) ?? false
+                if (!shouldShowLabel) return ""
+                return formatCurrency(
+                    (d as number) * combinedFactor,
+                    currentCurrency,
+                    { formatShort: true }
+                )
+            })
+            .tickSizeOuter(0)
+
+        g.call(xAxis)
+
+        g.select(".domain").remove()
+
+        // Add grid lines for ticks that have labels
+        g.selectAll<SVGGElement, number>(".tick")
+            .filter((d) => xTicks.get(d) === true)
+            .select("line")
+            .clone()
+            .attr("y2", -(height - marginBottom - marginTop))
+            .attr("stroke-opacity", 0.1)
+
+        return () => void g.selectAll("*").remove()
+    }, [
+        xScale,
+        height,
+        marginBottom,
+        marginTop,
+        currentCurrency,
+        combinedFactor,
+        isNarrow,
+    ])
+
+    return (
+        <g
+            className="x-axis"
+            ref={xAxisRef}
+            transform={`translate(0,${height - marginBottom})`}
+        />
+    )
+}
+
+interface IncomePlotIntPovertyLineProps {
+    xScale: d3.ScaleLogarithmic<number, number> | null
+    marginTop: number
+    height: number
+    marginBottom: number
+}
+
+const IncomePlotIntPovertyLine = ({
+    xScale,
+    marginTop,
+    height,
+    marginBottom,
+}: IncomePlotIntPovertyLineProps) => {
+    const combinedFactor = useAtomValue(atomCombinedFactor)
+    const currentCurrency = useAtomValue(atomCurrentCurrency)
+    const legendPlacement = useAtomValue(atomLegendPlacement)
+
+    if (!xScale) return null
+
+    const povertyLine = INT_POVERTY_LINE
+    const x = xScale(povertyLine)
+    const labelDirection = getLabelDirection(povertyLine, legendPlacement)
+    const labelX = labelDirection === "right" ? x + 5 : x - 9
+
+    const povertyLineText = `International poverty line: ${formatCurrency(
+        povertyLine * combinedFactor,
+        currentCurrency
+    )}`
+
+    return (
+        <g className="poverty-line" style={{ pointerEvents: "none" }}>
+            <line
+                x1={x}
+                x2={x}
+                y1={marginTop}
+                y2={height - marginBottom}
+                stroke="#a9a9a9"
+                strokeWidth={1}
+                strokeOpacity={0.8}
+                strokeDasharray="3,4"
+            />
+            <text
+                fill="#a9a9a9"
+                transform={`translate(${labelX}, ${marginTop + 2}) rotate(90)`}
+                textAnchor="start"
+                fontSize={10}
+            >
+                {povertyLineText}
+            </text>
+        </g>
+    )
+}
+
+interface IncomePlotCustomPovertyLineProps {
+    xScale: d3.ScaleLogarithmic<number, number> | null
+    marginTop: number
+    height: number
+    marginBottom: number
+}
+
+const IncomePlotCustomPovertyLine = ({
+    xScale,
+    marginTop,
+    height,
+    marginBottom,
+}: IncomePlotCustomPovertyLineProps) => {
+    const povertyLine = useAtomValue(atomCustomPovertyLine)
+    const povertyLineFormatted = useAtomValue(atomCustomPovertyLineFormatted)
+    const legendPlacement = useAtomValue(atomLegendPlacement)
+
+    if (!xScale || povertyLine === null || povertyLineFormatted === null)
+        return null
+
+    const x = xScale(povertyLine)
+    const labelDirection = getLabelDirection(povertyLine, legendPlacement)
+    const labelX = labelDirection === "right" ? x + 5 : x - 5
+    const textAnchor = labelDirection === "right" ? "start" : "end"
+
+    return (
+        <g className="poverty-line" style={{ pointerEvents: "none" }}>
+            <line
+                x1={x}
+                x2={x}
+                y1={marginTop}
+                y2={height - marginBottom}
+                stroke="#d73027"
+                strokeWidth={2}
+                strokeDasharray="5,5"
+            />
+            <text
+                x={labelX}
+                y={marginTop + 10}
+                fill="#d73027"
+                fontWeight="bold"
+                textAnchor={textAnchor}
+            >
+                Poverty line: {povertyLineFormatted}
+            </text>
+        </g>
+    )
+}
+
+interface IncomePlotPointerProps {
+    xScale: d3.ScaleLogarithmic<number, number> | null
+    marginTop: number
+    height: number
+    marginBottom: number
+}
+
+const IncomePlotPointer = ({
+    xScale,
+    marginTop,
+    height,
+    marginBottom,
+}: IncomePlotPointerProps) => {
+    const hoveredX = useAtomValue(atomHoveredX)
+    const povertyLine = useAtomValue(atomCustomPovertyLine)
+    const combinedFactor = useAtomValue(atomCombinedFactor)
+    const currentCurrency = useAtomValue(atomCurrentCurrency)
+
+    if (!xScale || hoveredX === null || povertyLine !== null) return null
+    return (
+        <g className="pointer" style={{ pointerEvents: "none" }}>
+            <line
+                x1={xScale(hoveredX)}
+                x2={xScale(hoveredX)}
+                y1={marginTop}
+                y2={height - marginBottom}
+                stroke="red"
+                strokeOpacity={0.15}
+                style={{ pointerEvents: "none" }}
+            />
+            <text
+                x={xScale(hoveredX)}
+                y={height - marginBottom + 9}
+                dy="0.71em"
+                fill="red"
+                stroke="white"
+                strokeWidth={3}
+                paintOrder="stroke"
+            >
+                {formatCurrency(hoveredX * combinedFactor, currentCurrency)}
+            </text>
+        </g>
+    )
+}
+
+export function IncomePlot({
+    height,
+    isNarrow = false,
+    width,
+    tab,
+}: IncomePlotProps) {
+    const svgRef = useRef<SVGSVGElement>(null)
+
+    const setCurrentTab = useSetAtom(atomCurrentTab)
+    useEffect(() => {
+        if (tab === "global" || tab === "countries") {
+            setCurrentTab(tab)
+        }
+    }, [tab, setCurrentTab])
+
+    const setPovertyLine = useSetAtom(atomCustomPovertyLine)
+    const setShowPovertyLine = useSetAtom(atomShowCustomPovertyLine)
+    const xValues = useAtomValue(atomKdeXValues)
+    const setHoveredEntity = useSetAtom(atomHoveredEntity)
+    const setHoveredX = useSetAtom(atomHoveredX)
+    const isSingleCountryMode = useAtomValue(atomIsInSingleCountryMode)
+    const legendPlacement = useAtomValue(atomLegendPlacement)
+    const selectedCountryNames = useAtomValue(atomSelectedCountryNames)
+
+    // Margins
+    const marginTop = 10
+    const marginRight = 20
+    const marginBottom = 30
+    const marginLeft = 20
+
+    const plotWidth = Math.min(width, 1000)
+    const plotHeight = height
+
+    const xScale = useMemo(() => {
+        const xMin = R.first(xValues)
+        const xMax = R.last(xValues)
+        const xDomain = [xMin, xMax]
+
+        const xScale = d3
+            .scaleLog()
+            .domain(xDomain)
+            .range([marginLeft, plotWidth - marginRight])
+        return xScale
+    }, [xValues, plotWidth])
+
+    const onPointerMove = useCallback(
+        (event: PointerEvent) => {
+            if (!xScale || !svgRef.current) return
+
+            // Don't show tooltip or hover line for touch events
+            if (event.pointerType === "touch") return
+
+            const [mx] = d3.pointer(event, svgRef.current)
+            const xVal = xScale.invert(mx)
+            setHoveredX(xVal)
+        },
+        [xScale, setHoveredX]
+    )
+
+    const onPointerLeave = useCallback(() => {
+        setHoveredEntity(null)
+        setHoveredX(null)
+    }, [setHoveredEntity, setHoveredX])
+
+    const onClick = useCallback(
+        (event: MouseEvent) => {
+            if (!xScale || !svgRef.current) return
+            const [mx] = d3.pointer(event, svgRef.current)
+            const xVal = xScale.invert(mx)
+
+            setPovertyLine(xVal)
+            setShowPovertyLine((showPovertyLine) => !showPovertyLine)
+        },
+        [xScale, setPovertyLine, setShowPovertyLine]
+    )
+
+    return (
+        <>
+            <div
+                className="income-plot-chart"
+                style={{
+                    position: "relative",
+                    maxWidth: "100%",
+                    display: "flow-root",
+                }}
+            >
+                {!isNarrow &&
+                    !(
+                        isSingleCountryMode && selectedCountryNames.length === 0
+                    ) && (
+                        <IncomePlotLegend
+                            isNarrow={false}
+                            position={legendPlacement}
+                        />
+                    )}
+                {isSingleCountryMode && selectedCountryNames.length === 0 ? (
+                    <div
+                        className="income-plot-empty-state"
+                        style={{ height: plotHeight - 12 }}
+                    >
+                        <div className="income-plot-empty-state__content">
+                            <p className="income-plot-empty-state__message">
+                                Please select one or more countries using the
+                                dropdown above to display their income
+                                distributions.
+                            </p>
+                        </div>
+                    </div>
+                ) : (
+                    <>
+                        <svg
+                            ref={svgRef}
+                            className="income-plot-chart-svg"
+                            width={plotWidth}
+                            viewBox={`0 0 ${plotWidth} ${plotHeight}`}
+                            style={style}
+                            onPointerMove={onPointerMove}
+                            onPointerLeave={onPointerLeave}
+                            onClick={onClick}
+                        >
+                            <IncomePlotClipPath xScale={xScale} />
+                            <IncomePlotXAxis
+                                xScale={xScale}
+                                height={plotHeight}
+                                marginBottom={marginBottom}
+                                marginTop={marginTop}
+                                isNarrow={isNarrow}
+                            />
+                            {isSingleCountryMode ? (
+                                <IncomePlotAreasUnstacked
+                                    xScale={xScale}
+                                    height={plotHeight}
+                                />
+                            ) : (
+                                <IncomePlotAreasStacked
+                                    xScale={xScale}
+                                    height={plotHeight}
+                                />
+                            )}
+                            <IncomePlotIntPovertyLine
+                                xScale={xScale}
+                                marginTop={marginTop}
+                                height={plotHeight}
+                                marginBottom={marginBottom}
+                            />
+                            <IncomePlotCustomPovertyLine
+                                xScale={xScale}
+                                marginTop={marginTop}
+                                height={plotHeight}
+                                marginBottom={marginBottom}
+                            />
+                            <IncomePlotPointer
+                                xScale={xScale}
+                                marginTop={marginTop}
+                                height={plotHeight}
+                                marginBottom={marginBottom}
+                            />
+                        </svg>
+                        <IncomePlotTooltip />
+                    </>
+                )}
+            </div>
+            {isNarrow && <IncomePlotLegend isNarrow={true} />}
+        </>
+    )
+}

--- a/bespoke/projects/income-plots/src/components/IncomePlotControlsRow.tsx
+++ b/bespoke/projects/income-plots/src/components/IncomePlotControlsRow.tsx
@@ -1,0 +1,460 @@
+import { useAtom, useAtomValue } from "jotai"
+import {
+    atomCountriesOrRegionsMode,
+    atomCurrentCurrency,
+    atomCurrentTab,
+    atomCurrentYear,
+    atomSelectedCountryNames,
+    atomTimeInterval,
+    loadableIntDollarConversions,
+    loadableLocalCurrencyConversion,
+} from "../store.ts"
+import {
+    INT_DOLLAR_CONVERSION_KEY_INFO,
+    SUGGESTED_CURRENCY_COUNTRY_CODES,
+} from "../utils/incomePlotConstants.ts"
+import * as R from "remeda"
+import { IncomePlotCountrySelector } from "./IncomePlotCountrySelector.tsx"
+import { LabeledSwitch } from "./LabeledSwitch.tsx"
+import cx from "classnames"
+
+import * as React from "react"
+import { useMemo, useState } from "react"
+import {
+    Tabs as AriaTabs,
+    TabList,
+    Tab,
+    Select,
+    Button,
+    Popover,
+    ListBox,
+    ListBoxItem,
+    SelectValue,
+    ListBoxSection,
+    Header,
+    Autocomplete,
+    SelectStateContext,
+    ListStateContext,
+    useFilter,
+    SearchField,
+    Input,
+} from "react-aria-components"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import {
+    faGlobe,
+    faFlag,
+    faGear,
+    faChevronDown,
+    faSearch,
+    faX,
+} from "@fortawesome/free-solid-svg-icons"
+import type {
+    IntDollarConversionEntry,
+    IntDollarConversionKeyInfo,
+} from "../types.ts"
+
+export interface TabItem<TabKey extends string = string> {
+    key: TabKey
+    element: React.ReactElement
+}
+
+export const Tabs = <TabKey extends string = string>({
+    items,
+    selectedKey,
+    onChange,
+    className,
+    variant = "default",
+}: {
+    items: TabItem<TabKey>[]
+    selectedKey: TabKey
+    onChange: (key: TabKey) => void
+    className?: string
+    variant?: "default" | "slim" | "stretch" | "scroll"
+}) => {
+    return (
+        <AriaTabs
+            selectedKey={selectedKey}
+            onSelectionChange={(key) => {
+                if (typeof key === "string") onChange(key as TabKey)
+            }}
+        >
+            <TabList
+                className={cx("Tabs", "Tabs--variant-" + variant, className)}
+            >
+                {items.map((item) => (
+                    <Tab
+                        key={item.key}
+                        id={item.key}
+                        className={cx("Tabs__Tab")}
+                    >
+                        {item.element}
+                    </Tab>
+                ))}
+            </TabList>
+        </AriaTabs>
+    )
+}
+
+export const IncomePlotControlsRowTop = ({
+    isNarrow = false,
+    onOpenSettings,
+}: {
+    isNarrow?: boolean
+    onOpenSettings?: () => void
+}) => {
+    const [currentTab, setCurrentTab] = useAtom(atomCurrentTab)
+    const [countriesOrRegionsMode, nextCountriesOrRegionsMode] = useAtom(
+        atomCountriesOrRegionsMode
+    )
+    const selectedCountryNames = useAtomValue(atomSelectedCountryNames)
+
+    const isGlobal = currentTab === "global"
+    const isCountries = currentTab === "countries"
+
+    return (
+        <div className="income-plot-controls-top" style={{ marginBottom: 10 }}>
+            <Tabs
+                variant="slim"
+                items={[
+                    {
+                        key: "global",
+                        element: (
+                            <span>
+                                <FontAwesomeIcon icon={faGlobe} />
+                                Global
+                            </span>
+                        ),
+                    },
+                    {
+                        key: "countries",
+                        element: (
+                            <span>
+                                <FontAwesomeIcon icon={faFlag} />
+                                Selected countries (
+                                {selectedCountryNames.length})
+                            </span>
+                        ),
+                    },
+                ]}
+                selectedKey={currentTab}
+                onChange={setCurrentTab}
+            />
+            {isNarrow && onOpenSettings && (
+                <button
+                    className="income-plot-drawer-trigger"
+                    onClick={onOpenSettings}
+                    aria-label="Open settings"
+                >
+                    <FontAwesomeIcon icon={faGear} />
+                </button>
+            )}
+            {isGlobal && !isNarrow && (
+                <LabeledSwitch
+                    value={countriesOrRegionsMode === "countries"}
+                    onToggle={() => nextCountriesOrRegionsMode()}
+                    leftLabel="Show regions"
+                    rightLabel="Show countries"
+                />
+            )}
+            {isCountries && !isNarrow && <IncomePlotCountrySelector />}
+        </div>
+    )
+}
+
+export const IncomePlotControlsRowBottom = () => {
+    const [timeInterval, nextTimeInterval] = useAtom(atomTimeInterval)
+    const currentYear = useAtomValue(atomCurrentYear)
+    const [currentCurrency, setCurrency] = useAtom(atomCurrentCurrency)
+    const conversionsLoadable = useAtomValue(loadableIntDollarConversions)
+    const localConversionLoadable = useAtomValue(
+        loadableLocalCurrencyConversion
+    )
+
+    const { contains } = useFilter({ sensitivity: "base" })
+    const [currencySearchValue, setCurrencySearchValue] = useState("")
+
+    const conversions =
+        conversionsLoadable.state === "hasData"
+            ? conversionsLoadable.data
+            : undefined
+    const isLoadingConversions = conversionsLoadable.state === "loading"
+    const hasConversionError =
+        conversionsLoadable.state === "hasError" ||
+        (conversionsLoadable.state === "hasData" &&
+            conversionsLoadable.data === undefined)
+    const localConversion =
+        localConversionLoadable.state === "hasData"
+            ? localConversionLoadable.data
+            : null
+
+    const suggestedConversionOptions = useMemo(() => {
+        if (!conversions) return []
+
+        const conversionsByCountryCode = new Map(
+            conversions.map((conversion) => [
+                conversion.country_code,
+                conversion,
+            ])
+        )
+        const localConversionCountryCode = localConversion?.country_code
+        const suggestedOptions = SUGGESTED_CURRENCY_COUNTRY_CODES.flatMap(
+            (countryCode) => {
+                if (countryCode === localConversionCountryCode) return []
+
+                const conversion = conversionsByCountryCode.get(countryCode)
+                return conversion ? [conversion] : []
+            }
+        )
+        const sortedSuggestedOptions = R.sortBy(
+            suggestedOptions,
+            R.prop("country")
+        )
+
+        return localConversion
+            ? [localConversion, ...sortedSuggestedOptions]
+            : sortedSuggestedOptions
+    }, [conversions, localConversion])
+
+    // Build sorted options list, excluding options already shown as suggested
+    const conversionOptions = useMemo(() => {
+        if (!conversions) return []
+        const suggestedCountryCodes = new Set(
+            suggestedConversionOptions.map((c) => c.country_code)
+        )
+        const sorted = R.sortBy(conversions, R.prop("country"))
+        return sorted.filter((c) => !suggestedCountryCodes.has(c.country_code))
+    }, [conversions, suggestedConversionOptions])
+
+    const selectedKey =
+        currentCurrency.currency_code === "INTD"
+            ? "INTD"
+            : (currentCurrency.country_code ?? "INTD")
+
+    const handleSelectionChange = (key: React.Key | null) => {
+        if (key === null) return
+
+        const keyStr = String(key)
+        if (keyStr === "INTD") {
+            setCurrency(INT_DOLLAR_CONVERSION_KEY_INFO)
+            setCurrencySearchValue("")
+            return
+        }
+        const entry = conversions?.find((c) => c.country_code === keyStr)
+        if (entry) {
+            const info: IntDollarConversionKeyInfo = {
+                currency_code: entry.currency_code,
+                currency_name: entry.currency_name,
+                conversion_factor: entry.conversion_factor,
+                country: entry.country,
+                country_code: entry.country_code,
+            }
+            setCurrency(info)
+            setCurrencySearchValue("")
+        }
+    }
+
+    const handleCurrencySearchSubmit = (
+        focusedKey: React.Key | null
+    ): boolean => {
+        if (focusedKey === null) return false
+
+        handleSelectionChange(focusedKey)
+        return true
+    }
+
+    const selectedLabel =
+        currentCurrency.currency_code === "INTD"
+            ? "International-$"
+            : `${currentCurrency.currency_name} (${currentCurrency.country})`
+
+    return (
+        <div className="income-plot-controls-bottom">
+            <button onClick={() => nextTimeInterval()} className="control-pill">
+                {R.toTitleCase(timeInterval)}
+            </button>
+            <span className="control-text">
+                income or consumption in {currentYear} in
+            </span>
+            <Select
+                className="currency-select"
+                value={selectedKey}
+                onChange={handleSelectionChange}
+                onOpenChange={(isOpen) => {
+                    if (!isOpen) setCurrencySearchValue("")
+                }}
+                aria-label="Currency"
+            >
+                <Button className="control-pill currency-select__trigger">
+                    <SelectValue>{selectedLabel}</SelectValue>
+                    <FontAwesomeIcon
+                        icon={faChevronDown}
+                        className="currency-select__chevron"
+                    />
+                </Button>
+                <Popover
+                    className="currency-select__popover"
+                    placement="top start"
+                    offset={4}
+                >
+                    <Autocomplete
+                        filter={contains}
+                        inputValue={currencySearchValue}
+                        onInputChange={setCurrencySearchValue}
+                        disableAutoFocusFirst={false}
+                    >
+                        <CurrencySearchField
+                            onSubmit={handleCurrencySearchSubmit}
+                        />
+                        <ListBox
+                            className="currency-select__listbox"
+                            onAction={handleSelectionChange}
+                            renderEmptyState={() => (
+                                <div className="currency-select__empty">
+                                    No countries or currencies match your
+                                    search.
+                                </div>
+                            )}
+                        >
+                            <ListBoxItem
+                                id="INTD"
+                                textValue="International Dollar INTD International-$"
+                                className="currency-select__item"
+                            >
+                                <b>International dollar</b>
+                            </ListBoxItem>
+                            {suggestedConversionOptions.length > 0 && (
+                                <ListBoxSection>
+                                    <Header className="currency-select__section-header">
+                                        Suggested
+                                    </Header>
+                                    {suggestedConversionOptions.map((c) => (
+                                        <ListBoxItem
+                                            key={c.country_code}
+                                            id={c.country_code}
+                                            textValue={getCurrencySearchText(c)}
+                                            className="currency-select__item"
+                                        >
+                                            <CurrencyOption
+                                                country={c.country}
+                                                currencyName={c.currency_name}
+                                                currencyCode={c.currency_code}
+                                            />
+                                        </ListBoxItem>
+                                    ))}
+                                </ListBoxSection>
+                            )}
+                            {isLoadingConversions && (
+                                <ListBoxItem
+                                    id="loading-currencies"
+                                    isDisabled
+                                    className="currency-select__item currency-select__item--status"
+                                >
+                                    Loading local currencies...
+                                </ListBoxItem>
+                            )}
+                            {hasConversionError && (
+                                <ListBoxItem
+                                    id="currency-error"
+                                    isDisabled
+                                    className="currency-select__item currency-select__item--status"
+                                >
+                                    Could not load local currencies.
+                                </ListBoxItem>
+                            )}
+                            {conversionOptions.length > 0 && (
+                                <ListBoxSection>
+                                    <Header className="currency-select__section-header">
+                                        All countries
+                                    </Header>
+                                    {conversionOptions.map((c) => (
+                                        <ListBoxItem
+                                            key={c.country_code}
+                                            id={c.country_code}
+                                            textValue={getCurrencySearchText(c)}
+                                            className="currency-select__item"
+                                        >
+                                            <CurrencyOption
+                                                country={c.country}
+                                                currencyName={c.currency_name}
+                                                currencyCode={c.currency_code}
+                                            />
+                                        </ListBoxItem>
+                                    ))}
+                                </ListBoxSection>
+                            )}
+                        </ListBox>
+                    </Autocomplete>
+                </Popover>
+            </Select>
+        </div>
+    )
+}
+
+const getCurrencySearchText = (entry: IntDollarConversionEntry): string => {
+    return [
+        entry.country,
+        entry.country_code,
+        entry.currency_name,
+        entry.currency_code,
+    ].join(" ")
+}
+
+const CurrencySearchField = ({
+    onSubmit,
+}: {
+    onSubmit: (focusedKey: React.Key | null) => boolean
+}): React.ReactElement => {
+    const selectState = React.useContext(SelectStateContext)
+    const listState = React.useContext(ListStateContext)
+
+    return (
+        <SearchField
+            aria-label="Search countries and currencies"
+            autoFocus
+            className="currency-select__search"
+            onSubmit={() => {
+                const didSelect = onSubmit(
+                    listState?.selectionManager.focusedKey ?? null
+                )
+                if (didSelect) selectState?.close()
+            }}
+        >
+            <FontAwesomeIcon
+                icon={faSearch}
+                className="currency-select__search-icon"
+            />
+            <Input
+                placeholder="Search country or currency"
+                className="react-aria-Input inset"
+            />
+            <Button className="clear-button">
+                <FontAwesomeIcon
+                    icon={faX}
+                    className="currency-select__clear-icon"
+                />
+            </Button>
+        </SearchField>
+    )
+}
+
+const CurrencyOption = ({
+    country,
+    currencyName,
+    currencyCode,
+}: {
+    country: string
+    currencyName: string
+    currencyCode: string
+}): React.ReactElement => {
+    return (
+        <span className="currency-select__option">
+            <span className="currency-select__option-country">{country}</span>
+            <span className="currency-select__option-currency">
+                {currencyName}
+                <span className="currency-select__option-code">
+                    {currencyCode}
+                </span>
+            </span>
+        </span>
+    )
+}

--- a/bespoke/projects/income-plots/src/components/IncomePlotCountrySelector.tsx
+++ b/bespoke/projects/income-plots/src/components/IncomePlotCountrySelector.tsx
@@ -1,0 +1,323 @@
+import { useAtom, useAtomValue } from "jotai"
+import {
+    atomAvailableCountryNames,
+    atomSelectedCountryNames,
+    atomRawDataForYear,
+    atomCurrentCurrency,
+    atomCombinedFactor,
+    atomTimeInterval,
+} from "../store.ts"
+import { Suspense, useMemo, useState } from "react"
+import {
+    Button,
+    Dialog,
+    DialogTrigger,
+    Input,
+    ListBox,
+    ListBoxItem,
+    Popover,
+    SearchField,
+    type Selection,
+} from "react-aria-components"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import {
+    faMagnifyingGlass,
+    faChevronDown,
+    faXmark,
+    faCheck,
+    faArrowUp,
+    faArrowDown,
+    faSort,
+} from "@fortawesome/free-solid-svg-icons"
+import * as React from "react"
+import { formatCurrency, getTimeIntervalStr } from "../utils/incomePlotUtils.ts"
+
+const IncomePlotCountrySelectorInner = (): React.ReactElement => {
+    const availableCountryNames = useAtomValue(atomAvailableCountryNames)
+    const [selectedCountryNames, setSelectedCountryNames] = useAtom(
+        atomSelectedCountryNames
+    )
+    const [searchQuery, setSearchQuery] = useState("")
+
+    type SortKey = "name" | "median"
+    type SortDirection = "asc" | "desc"
+    const [sortBy, setSortBy] = useState<SortKey>("name")
+    const [sortDirection, setSortDirection] = useState<SortDirection>("asc")
+
+    const rawDataForYear = useAtomValue(atomRawDataForYear)
+    const currency = useAtomValue(atomCurrentCurrency)
+    const combinedFactor = useAtomValue(atomCombinedFactor)
+    const timeInterval = useAtomValue(atomTimeInterval)
+
+    const countryMedianMap = useMemo((): Map<string, string> => {
+        const map = new Map<string, string>()
+        for (const record of rawDataForYear) {
+            const rawMedian = record.avgs[499]
+            if (typeof rawMedian === "number" && !isNaN(rawMedian)) {
+                const formatted = formatCurrency(
+                    rawMedian * combinedFactor,
+                    currency,
+                    { formatShort: true }
+                )
+                const period = getTimeIntervalStr(timeInterval)
+                map.set(record.country, `${formatted}/${period}`)
+            }
+        }
+        return map
+    }, [rawDataForYear, currency, combinedFactor, timeInterval])
+
+    const countryNumericMedianMap = useMemo((): Map<string, number> => {
+        const map = new Map<string, number>()
+        for (const record of rawDataForYear) {
+            const rawMedian = record.avgs[499]
+            if (typeof rawMedian === "number" && !isNaN(rawMedian)) {
+                map.set(record.country, rawMedian)
+            }
+        }
+        return map
+    }, [rawDataForYear])
+
+    const filteredCountries = useMemo((): string[] => {
+        return availableCountryNames.filter((country) =>
+            country.toLowerCase().includes(searchQuery.toLowerCase())
+        )
+    }, [availableCountryNames, searchQuery])
+
+    const sortedCountries = useMemo((): string[] => {
+        const list = [...filteredCountries]
+        list.sort((a, b) => {
+            if (sortBy === "name") {
+                const cmp = a.localeCompare(b, undefined, {
+                    sensitivity: "base",
+                })
+                return sortDirection === "asc" ? cmp : -cmp
+            } else {
+                const valA = countryNumericMedianMap.get(a)
+                const valB = countryNumericMedianMap.get(b)
+
+                // Handle missing values (always at the end)
+                if (valA === undefined && valB === undefined) return 0
+                if (valA === undefined) return 1
+                if (valB === undefined) return -1
+
+                const cmp = valA - valB
+                return sortDirection === "asc" ? cmp : -cmp
+            }
+        })
+        return list
+    }, [filteredCountries, sortBy, sortDirection, countryNumericMedianMap])
+
+    const selectedKeys = useMemo(
+        (): Selection => new Set(selectedCountryNames),
+        [selectedCountryNames]
+    )
+
+    const handleSort = (key: SortKey): void => {
+        if (sortBy === key) {
+            setSortDirection(sortDirection === "asc" ? "desc" : "asc")
+        } else {
+            setSortBy(key)
+            setSortDirection("asc")
+        }
+    }
+
+    const handleSortKeyDown = (
+        e: React.KeyboardEvent<HTMLSpanElement>,
+        key: SortKey
+    ): void => {
+        if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault()
+            handleSort(key)
+        }
+    }
+
+    const handleSelectionChange = (keys: Selection): void => {
+        if (keys !== "all") {
+            const newSelected = Array.from(keys) as string[]
+            setSelectedCountryNames(newSelected)
+        }
+    }
+
+    const handleClearAll = (): void => {
+        setSelectedCountryNames([])
+    }
+
+    const triggerLabel =
+        selectedCountryNames.length > 0
+            ? selectedCountryNames.length === 1
+                ? "1 country selected"
+                : `${selectedCountryNames.length} countries selected`
+            : "Search and select countries"
+
+    return (
+        <DialogTrigger>
+            <Button className="search-country-selector-button">
+                <FontAwesomeIcon
+                    icon={faMagnifyingGlass}
+                    className="search-country-selector__search-icon"
+                />
+                <span className="search-country-selector-label">
+                    {triggerLabel}
+                </span>
+                <FontAwesomeIcon
+                    icon={faChevronDown}
+                    className="search-country-selector__chevron"
+                />
+            </Button>
+            <Popover
+                className="search-country-selector-list-container"
+                placement="bottom start"
+                onOpenChange={(isOpen: boolean): void => {
+                    if (!isOpen) setSearchQuery("")
+                }}
+            >
+                <Dialog className="search-country-selector-dialog">
+                    <SearchField
+                        aria-label="Search countries"
+                        className="search-country-selector-search"
+                        value={searchQuery}
+                        onChange={setSearchQuery}
+                        autoFocus
+                    >
+                        <FontAwesomeIcon
+                            icon={faMagnifyingGlass}
+                            className="search-country-selector-search__icon"
+                        />
+                        <Input
+                            placeholder="Search..."
+                            className="react-aria-Input search-country-selector-search__input"
+                        />
+                        {searchQuery && (
+                            <Button
+                                className="clear-button search-country-selector-search__clear"
+                                onClick={(): void => setSearchQuery("")}
+                            >
+                                <FontAwesomeIcon icon={faXmark} />
+                            </Button>
+                        )}
+                    </SearchField>
+
+                    <div className="search-country-selector-clear-container">
+                        <button
+                            onClick={handleClearAll}
+                            className="search-country-selector-clear-all"
+                            disabled={selectedCountryNames.length === 0}
+                        >
+                            Clear all
+                        </button>
+                    </div>
+
+                    <div className="search-country-selector-header-row">
+                        <span
+                            className="search-country-selector-header-col--left"
+                            role="button"
+                            tabIndex={0}
+                            title="Sort by Country"
+                            onClick={(): void => handleSort("name")}
+                            onKeyDown={(e): void =>
+                                handleSortKeyDown(e, "name")
+                            }
+                        >
+                            Country
+                            <FontAwesomeIcon
+                                icon={
+                                    sortBy === "name"
+                                        ? sortDirection === "asc"
+                                            ? faArrowUp
+                                            : faArrowDown
+                                        : faSort
+                                }
+                                className={`search-country-selector-header__icon ${
+                                    sortBy !== "name"
+                                        ? "search-country-selector-header__icon--inactive"
+                                        : ""
+                                }`}
+                            />
+                        </span>
+                        <span
+                            className="search-country-selector-header-col--right"
+                            role="button"
+                            tabIndex={0}
+                            title="Sort by Median"
+                            onClick={(): void => handleSort("median")}
+                            onKeyDown={(e): void =>
+                                handleSortKeyDown(e, "median")
+                            }
+                        >
+                            Median
+                            <FontAwesomeIcon
+                                icon={
+                                    sortBy === "median"
+                                        ? sortDirection === "asc"
+                                            ? faArrowUp
+                                            : faArrowDown
+                                        : faSort
+                                }
+                                className={`search-country-selector-header__icon ${
+                                    sortBy !== "median"
+                                        ? "search-country-selector-header__icon--inactive"
+                                        : ""
+                                }`}
+                            />
+                        </span>
+                    </div>
+
+                    <ListBox
+                        aria-label="Countries"
+                        selectionMode="multiple"
+                        className="search-country-selector-list"
+                        selectedKeys={selectedKeys}
+                        onSelectionChange={handleSelectionChange}
+                    >
+                        {sortedCountries.map((country) => (
+                            <ListBoxItem
+                                key={country}
+                                id={country}
+                                textValue={country}
+                                className="search-country-selector-list__item"
+                            >
+                                {({ isSelected }): React.ReactElement => (
+                                    <>
+                                        <div className="checkbox-container">
+                                            <div
+                                                className={`search-country-selector-checkbox ${
+                                                    isSelected ? "checked" : ""
+                                                }`}
+                                            >
+                                                {isSelected && (
+                                                    <FontAwesomeIcon
+                                                        icon={faCheck}
+                                                        style={{
+                                                            fontSize: "10px",
+                                                            color: "white",
+                                                        }}
+                                                    />
+                                                )}
+                                            </div>
+                                        </div>
+                                        <span className="country-name">
+                                            {country}
+                                        </span>
+                                        {countryMedianMap.has(country) && (
+                                            <span className="country-median">
+                                                {countryMedianMap.get(country)}
+                                            </span>
+                                        )}
+                                    </>
+                                )}
+                            </ListBoxItem>
+                        ))}
+                    </ListBox>
+                </Dialog>
+            </Popover>
+        </DialogTrigger>
+    )
+}
+
+export const IncomePlotCountrySelector = (): React.ReactElement => {
+    return (
+        <Suspense fallback={<div>Loading countries...</div>}>
+            <IncomePlotCountrySelectorInner />
+        </Suspense>
+    )
+}

--- a/bespoke/projects/income-plots/src/components/IncomePlotDrawer.tsx
+++ b/bespoke/projects/income-plots/src/components/IncomePlotDrawer.tsx
@@ -1,0 +1,218 @@
+import { useAtom, useAtomValue } from "jotai"
+import {
+    atomTimeInterval,
+    atomCurrentCurrency,
+    atomCountriesOrRegionsMode,
+    atomCurrentTab,
+    atomAvailableCountryNames,
+    atomSelectedCountryNames,
+    loadableLocalCurrencyConversion,
+} from "../store.ts"
+import {
+    INT_DOLLAR_CONVERSION_KEY_INFO,
+    TIME_INTERVALS,
+    TimeInterval,
+} from "../utils/incomePlotConstants.ts"
+import { Suspense, useMemo, useState } from "react"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+
+import { faMagnifyingGlass, faXmark } from "@fortawesome/free-solid-svg-icons"
+
+interface IncomePlotDrawerProps {
+    isOpen: boolean
+    onClose: () => void
+}
+
+const TIME_INTERVAL_LABELS: Record<TimeInterval, string> = {
+    daily: "Daily",
+    monthly: "Monthly",
+    yearly: "Yearly",
+}
+
+const MODE_OPTIONS = [
+    { value: "regions" as const, label: "Show regions" },
+    { value: "countries" as const, label: "Show countries" },
+]
+
+function DrawerCountrySelectorInner() {
+    const availableCountryNames = useAtomValue(atomAvailableCountryNames)
+    const [selectedCountryNames, setSelectedCountryNames] = useAtom(
+        atomSelectedCountryNames
+    )
+    const [searchQuery, setSearchQuery] = useState("")
+
+    const selectedSet = useMemo(
+        () => new Set(selectedCountryNames),
+        [selectedCountryNames]
+    )
+
+    const filteredCountries = useMemo(() => {
+        if (!searchQuery) return availableCountryNames
+        const query = searchQuery.toLowerCase()
+        return availableCountryNames.filter((c) =>
+            c.toLowerCase().includes(query)
+        )
+    }, [availableCountryNames, searchQuery])
+
+    const handleToggleCountry = (countryName: string) => {
+        if (selectedSet.has(countryName)) {
+            setSelectedCountryNames(
+                selectedCountryNames.filter((c) => c !== countryName)
+            )
+        } else {
+            setSelectedCountryNames([...selectedCountryNames, countryName])
+        }
+    }
+
+    return (
+        <div className="drawer-country-selector">
+            <div className="drawer-country-selector__search">
+                <FontAwesomeIcon
+                    icon={faMagnifyingGlass}
+                    className="drawer-country-selector__search-icon"
+                />
+                <input
+                    value={searchQuery}
+                    onChange={(e) => setSearchQuery(e.target.value)}
+                    placeholder="Search and select countries"
+                    className="drawer-country-selector__search-input"
+                />
+            </div>
+            <div className="drawer-country-selector__list">
+                {filteredCountries.map((country) => (
+                    <label
+                        key={country}
+                        className="drawer-country-selector__item"
+                    >
+                        <input
+                            type="checkbox"
+                            checked={selectedSet.has(country)}
+                            onChange={() => handleToggleCountry(country)}
+                            className="drawer-country-selector__checkbox"
+                        />
+                        <span className="drawer-country-selector__country-name">
+                            {country}
+                        </span>
+                    </label>
+                ))}
+            </div>
+        </div>
+    )
+}
+
+function DrawerCountrySelector() {
+    return (
+        <Suspense>
+            <DrawerCountrySelectorInner />
+        </Suspense>
+    )
+}
+
+export function IncomePlotDrawer({ isOpen, onClose }: IncomePlotDrawerProps) {
+    const [timeInterval, setTimeInterval] = useAtom(atomTimeInterval)
+    const [currency, setCurrency] = useAtom(atomCurrentCurrency)
+    const [mode, setMode] = useAtom(atomCountriesOrRegionsMode)
+    const currentTab = useAtomValue(atomCurrentTab)
+    const localConversionLoadable = useAtomValue(
+        loadableLocalCurrencyConversion
+    )
+    const localConversion =
+        localConversionLoadable.state === "hasData"
+            ? localConversionLoadable.data
+            : null
+
+    return (
+        <>
+            <div
+                className={`income-plot-drawer-backdrop${isOpen ? " income-plot-drawer-backdrop--open" : ""}`}
+                onClick={onClose}
+            />
+            <div
+                className={`income-plot-drawer${isOpen ? " income-plot-drawer--open" : ""}`}
+            >
+                <div className="income-plot-drawer__header">
+                    <span className="income-plot-drawer__title">Settings</span>
+                    <button
+                        className="income-plot-drawer__close"
+                        onClick={onClose}
+                        aria-label="Close settings"
+                    >
+                        <FontAwesomeIcon icon={faXmark} />
+                    </button>
+                </div>
+
+                <div className="income-plot-drawer__sections">
+                    <div className="income-plot-drawer__section">
+                        <div className="income-plot-drawer__section-label">
+                            Time interval
+                        </div>
+                        <div className="income-plot-drawer__button-group">
+                            {TIME_INTERVALS.map((interval) => (
+                                <button
+                                    key={interval}
+                                    className={`income-plot-drawer__button${timeInterval === interval ? " income-plot-drawer__button--active" : ""}`}
+                                    onClick={() => setTimeInterval(interval)}
+                                >
+                                    {TIME_INTERVAL_LABELS[interval]}
+                                </button>
+                            ))}
+                        </div>
+                    </div>
+
+                    <div className="income-plot-drawer__divider" />
+
+                    <div className="income-plot-drawer__section">
+                        <div className="income-plot-drawer__section-label">
+                            Currency
+                        </div>
+                        <div className="income-plot-drawer__button-group">
+                            <button
+                                className={`income-plot-drawer__button${currency.currency_code === "INTD" ? " income-plot-drawer__button--active" : ""}`}
+                                onClick={() =>
+                                    setCurrency(INT_DOLLAR_CONVERSION_KEY_INFO)
+                                }
+                            >
+                                International-$
+                            </button>
+                            <button
+                                className={`income-plot-drawer__button${currency.currency_code !== "INTD" ? " income-plot-drawer__button--active" : ""}`}
+                                onClick={() =>
+                                    localConversion &&
+                                    setCurrency(localConversion)
+                                }
+                                disabled={!localConversion}
+                            >
+                                {localConversion
+                                    ? `${localConversion.currency_name} (${localConversion.country})`
+                                    : "Local currency"}
+                            </button>
+                        </div>
+                    </div>
+
+                    <div className="income-plot-drawer__divider" />
+
+                    {currentTab === "global" && (
+                        <div className="income-plot-drawer__section">
+                            <div className="income-plot-drawer__section-label">
+                                Chart options
+                            </div>
+                            <div className="income-plot-drawer__button-group">
+                                {MODE_OPTIONS.map((opt) => (
+                                    <button
+                                        key={opt.value}
+                                        className={`income-plot-drawer__button${mode === opt.value ? " income-plot-drawer__button--active" : ""}`}
+                                        onClick={() => setMode(opt.value)}
+                                    >
+                                        {opt.label}
+                                    </button>
+                                ))}
+                            </div>
+                        </div>
+                    )}
+
+                    {currentTab === "countries" && <DrawerCountrySelector />}
+                </div>
+            </div>
+        </>
+    )
+}

--- a/bespoke/projects/income-plots/src/components/IncomePlotLegend.tsx
+++ b/bespoke/projects/income-plots/src/components/IncomePlotLegend.tsx
@@ -1,0 +1,127 @@
+import { useAtom, useAtomValue } from "jotai"
+import {
+    atomCombinedFactor,
+    atomCurrentCurrency,
+    atomHoveredEntity,
+    atomLegendEntries,
+    atomPovertyLineForLegend,
+    atomRawDataForYear,
+    atomTimeInterval,
+} from "../store.ts"
+import * as R from "remeda"
+import cx from "classnames"
+import { useMemo } from "react"
+import {
+    computePercentageBelowLine,
+    formatCurrency,
+    getTimeIntervalStr,
+    roundPercentage,
+} from "../utils/incomePlotUtils.ts"
+import { WORLD_ENTITY_NAME } from "../utils/incomePlotConstants.ts"
+
+export type IncomePlotLegendPosition = "left" | "right"
+
+export const IncomePlotLegend = ({
+    isNarrow = false,
+    position = "right",
+}: {
+    isNarrow?: boolean
+    position?: IncomePlotLegendPosition
+}) => {
+    const entries = useAtomValue(atomLegendEntries)
+    const [hoveredEntity, setHoveredEntity] = useAtom(atomHoveredEntity)
+    const povertyLine = useAtomValue(atomPovertyLineForLegend)
+    const currency = useAtomValue(atomCurrentCurrency)
+    const combinedFactor = useAtomValue(atomCombinedFactor)
+    const povertyLineFormatted =
+        povertyLine !== null
+            ? formatCurrency(povertyLine * combinedFactor, currency)
+            : null
+    const rawDataForYear = useAtomValue(atomRawDataForYear)
+    const timeInterval = useAtomValue(atomTimeInterval)
+
+    const percentageBelowLineMap = useMemo(() => {
+        if (povertyLine === null) return null
+
+        return computePercentageBelowLine(
+            rawDataForYear,
+            povertyLine,
+            new Set(entries.map((e) => e.name))
+        )
+    }, [entries, povertyLine, rawDataForYear])
+
+    const entriesSorted = useMemo(() => {
+        if (!percentageBelowLineMap)
+            return entries.filter((e) => e.name !== WORLD_ENTITY_NAME)
+
+        // Sort by the percentage below the poverty line, descending, so the bar chart looks nice
+        return R.sortBy(entries, [
+            (entry) => {
+                const percentage = percentageBelowLineMap.get(entry.name)
+                return percentage !== undefined ? percentage : Infinity
+            },
+            "desc",
+        ])
+    }, [entries, percentageBelowLineMap])
+
+    return (
+        <div
+            className={cx("income-plot-legend", {
+                "income-plot-legend--mobile": isNarrow,
+                [`income-plot-legend--${position}`]: !isNarrow,
+            })}
+        >
+            {percentageBelowLineMap && povertyLineFormatted && (
+                <div className="legend-poverty-line-header">
+                    Share of population that lives on less than{" "}
+                    {povertyLineFormatted} a {getTimeIntervalStr(timeInterval)}
+                </div>
+            )}
+            <div className="legend-entries-container">
+                {entriesSorted.map((entry) => {
+                    const isHovered = entry.name === hoveredEntity
+                    const percentageBelow = percentageBelowLineMap?.get(
+                        entry.name
+                    )
+
+                    return (
+                        <div
+                            className={cx("legend-entry", {
+                                "legend-entry--hovered": isHovered,
+                                "legend-entry--has-percentages":
+                                    percentageBelow !== undefined,
+                                "--legend-entry--is-world":
+                                    entry.name === WORLD_ENTITY_NAME,
+                            })}
+                            id={`legend-entry-${R.toKebabCase(entry.name)}`}
+                            key={entry.name}
+                            onMouseEnter={() => setHoveredEntity(entry.name)}
+                            onMouseLeave={() => setHoveredEntity(null)}
+                            style={
+                                {
+                                    "--legend-entry-color": entry.color,
+                                    "--legend-entry-percentage-value":
+                                        percentageBelow !== undefined
+                                            ? R.round(percentageBelow, 1)
+                                            : "",
+                                } as React.CSSProperties
+                            }
+                        >
+                            <div className="legend-entry-percentage-container">
+                                {percentageBelow !== undefined && (
+                                    <span className="legend-entry-percentage-label">
+                                        {roundPercentage(percentageBelow)}%
+                                    </span>
+                                )}
+                                <div className="legend-entry-swatch"></div>
+                            </div>
+                            <span className="legend-entry-label">
+                                {entry.name}
+                            </span>
+                        </div>
+                    )
+                })}
+            </div>
+        </div>
+    )
+}

--- a/bespoke/projects/income-plots/src/components/IncomePlotTooltip.tsx
+++ b/bespoke/projects/income-plots/src/components/IncomePlotTooltip.tsx
@@ -1,0 +1,128 @@
+import {
+    FloatingPortal,
+    arrow,
+    autoUpdate,
+    flip,
+    offset,
+    shift,
+    useClientPoint,
+    useFloating,
+    useHover,
+    useInteractions,
+} from "@floating-ui/react"
+import { useAtomValue } from "jotai"
+import { useRef } from "react"
+import { useShadowRoot } from "../ShadowRootContext.tsx"
+import {
+    atomCombinedFactor,
+    atomCurrentCurrency,
+    atomCustomPovertyLine,
+    atomHoveredEntity,
+    atomHoveredX,
+    atomLegendPlacement,
+    atomRawDataForYear,
+    atomTimeInterval,
+    atomTooltipIsOpen,
+} from "../store.ts"
+import {
+    computePercentageBelowLine,
+    formatCurrency,
+    getLabelDirection,
+    getTimeIntervalStr,
+    roundPercentage,
+} from "../utils/incomePlotUtils.ts"
+import { WORLD_ENTITY_NAME } from "../utils/incomePlotConstants.ts"
+
+export const IncomePlotTooltip = () => {
+    const arrowRef = useRef(null)
+    const shadowRoot = useShadowRoot()
+
+    const isOpen = useAtomValue(atomTooltipIsOpen)
+    const hoveredEntity = useAtomValue(atomHoveredEntity)
+    const hoveredX = useAtomValue(atomHoveredX)
+    const povertyLine = useAtomValue(atomCustomPovertyLine)
+    const rawDataForYear = useAtomValue(atomRawDataForYear)
+    const currency = useAtomValue(atomCurrentCurrency)
+    const combinedFactor = useAtomValue(atomCombinedFactor)
+    const timeInterval = useAtomValue(atomTimeInterval)
+
+    const lineForDisplay = povertyLine ?? hoveredX
+
+    const legendPlacement = useAtomValue(atomLegendPlacement)
+
+    const tooltipPlacement = getLabelDirection(hoveredX ?? 0, legendPlacement)
+
+    const { refs, floatingStyles, context } = useFloating({
+        open: isOpen,
+        middleware: [offset(10), flip(), shift(), arrow({ element: arrowRef })],
+        placement: tooltipPlacement,
+        whileElementsMounted: autoUpdate,
+    })
+
+    const hover = useHover(context, { move: false })
+    const clientPoint = useClientPoint(context)
+    const { getFloatingProps } = useInteractions([hover, clientPoint])
+
+    if (!lineForDisplay) return null
+
+    const entityForPercentage = hoveredEntity ?? WORLD_ENTITY_NAME
+    let percentageForEntity: number | undefined = undefined
+    if (entityForPercentage) {
+        const percentageMap = computePercentageBelowLine(
+            rawDataForYear,
+            lineForDisplay,
+            new Set([entityForPercentage])
+        )
+        percentageForEntity = percentageMap.get(entityForPercentage)
+    }
+
+    return (
+        <>
+            {isOpen && (
+                <FloatingPortal root={shadowRoot}>
+                    <div
+                        className="income-plot-tooltip"
+                        ref={refs.setFloating}
+                        style={floatingStyles}
+                        {...getFloatingProps()}
+                    >
+                        {entityForPercentage && (
+                            <>
+                                {entityForPercentage !== WORLD_ENTITY_NAME && (
+                                    <div className="tooltip--entityName">
+                                        {entityForPercentage}
+                                    </div>
+                                )}
+                                <div className="tooltip--percentage">
+                                    {percentageForEntity !== undefined && (
+                                        <>
+                                            {roundPercentage(
+                                                percentageForEntity
+                                            )}
+                                            % of the{" "}
+                                            {entityForPercentage ===
+                                            WORLD_ENTITY_NAME
+                                                ? "world"
+                                                : "country's"}{" "}
+                                            population lives on less than{" "}
+                                            {formatCurrency(
+                                                lineForDisplay * combinedFactor,
+                                                currency
+                                            )}
+                                            /{getTimeIntervalStr(timeInterval)}
+                                        </>
+                                    )}
+                                </div>
+                            </>
+                        )}
+                        <div className="tooltip--set-pov-line">
+                            {povertyLine !== null
+                                ? "Click to unset custom poverty line"
+                                : "Click to set a custom poverty line"}
+                        </div>
+                    </div>
+                </FloatingPortal>
+            )}
+        </>
+    )
+}

--- a/bespoke/projects/income-plots/src/components/LabeledSwitch.tsx
+++ b/bespoke/projects/income-plots/src/components/LabeledSwitch.tsx
@@ -1,0 +1,49 @@
+import cx from "classnames"
+
+export const LabeledSwitch = ({
+    value,
+    onToggle,
+    leftLabel,
+    rightLabel,
+}: {
+    value?: boolean
+    onToggle: () => void
+    leftLabel?: string
+    rightLabel?: string
+}) => {
+    return (
+        <div className="labeled-switch">
+            {leftLabel && (
+                <span
+                    className={cx("labeled-switch__label", {
+                        "labeled-switch__label--active": !value,
+                    })}
+                    onClick={onToggle}
+                >
+                    {leftLabel}
+                </span>
+            )}
+            <label className="labeled-switch__toggle">
+                <input
+                    type="checkbox"
+                    checked={value}
+                    onChange={onToggle}
+                    className="labeled-switch__input"
+                />
+                <div className="labeled-switch__track">
+                    <div className="labeled-switch__thumb" />
+                </div>
+            </label>
+            {rightLabel && (
+                <span
+                    className={cx("labeled-switch__label", {
+                        "labeled-switch__label--active": value,
+                    })}
+                    onClick={onToggle}
+                >
+                    {rightLabel}
+                </span>
+            )}
+        </div>
+    )
+}

--- a/bespoke/projects/income-plots/src/controls.scss
+++ b/bespoke/projects/income-plots/src/controls.scss
@@ -1,0 +1,789 @@
+@import "../../../../packages/@ourworldindata/components/src/styles/colors.scss";
+@import "../../../../packages/@ourworldindata/components/src/styles/variables.scss";
+@import "../../../../packages/@ourworldindata/components/src/styles/typography-constants.scss";
+@import "../../../../packages/@ourworldindata/components/src/styles/typography.scss";
+@import "../../../../packages/@ourworldindata/grapher/src/core/typography.scss";
+
+$dark-text: $gray-80;
+$light-text: $gray-70;
+$active-text: $blue-90;
+
+.income-plot-controls-top {
+    height: 30px;
+    display: flex;
+    align-items: center;
+    gap: 24px;
+    font-family:
+        "Lato", "Helvetica Neue", Helvetica, Arial, "Liberation Sans",
+        sans-serif;
+    font-size: 14px;
+    color: #333;
+}
+
+.labeled-switch {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+
+    &__label {
+        cursor: pointer;
+        color: #555;
+        user-select: none;
+
+        &--active {
+            color: #333;
+            font-weight: 700;
+        }
+    }
+
+    &__toggle {
+        display: inline-flex;
+        align-items: center;
+        cursor: pointer;
+    }
+
+    &__input {
+        position: absolute;
+        opacity: 0;
+        pointer-events: none;
+    }
+
+    &__track {
+        width: 29px;
+        height: 16px;
+        background: $gray-30;
+        border-radius: 8px;
+        position: relative;
+        transition: background 200ms;
+        top: 1px; // small adjustment
+    }
+
+    &__thumb {
+        width: 10px;
+        height: 10px;
+        background: $gray-70;
+        border-radius: 5px;
+        position: absolute;
+        top: 3px;
+        left: 3px;
+        transition: transform 333ms;
+    }
+
+    &__toggle:hover &__thumb {
+        background: $gray-80;
+    }
+
+    &__input:checked + &__track {
+        background: $blue-20;
+
+        .labeled-switch__thumb {
+            background: $blue-50;
+            transform: translateX(13px);
+        }
+    }
+
+    &__toggle:hover &__input:checked + &__track .labeled-switch__thumb {
+        background: darken($blue-50, 13%);
+    }
+
+    &__input:focus-visible + &__track {
+        outline: 2px solid $blue-50;
+    }
+}
+
+.search-country-selector-button {
+    display: flex;
+    align-items: center;
+    background: white;
+    border: 1px solid #ccc;
+    border-radius: 3px;
+    padding: 6px 10px;
+    cursor: pointer;
+    width: 260px;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+    outline: none;
+    text-align: left;
+    font-family: inherit;
+    font-size: 14px;
+}
+
+.search-country-selector-button[data-hovered] {
+    border-color: #aaa;
+    background: #fafafa;
+}
+
+.search-country-selector-button[data-focused] {
+    border-color: $blue-50;
+    box-shadow: 0 0 0 1px $blue-50;
+}
+
+.search-country-selector-label {
+    flex: 1;
+    color: #333;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.search-country-selector__chevron {
+    font-size: 10px;
+    opacity: 0.6;
+    margin-left: 8px;
+}
+
+.search-country-selector__search-icon {
+    color: #666;
+    margin-right: 8px;
+    font-size: 14px;
+}
+
+.search-country-selector-list-container {
+    background: white;
+    border: 1px solid #e6e7e8;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
+    border-radius: 4px;
+    width: 260px;
+    max-height: 400px;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    outline: none;
+    z-index: 1000;
+}
+
+.search-country-selector-dialog {
+    outline: none;
+    display: flex;
+    flex-direction: column;
+    max-height: 100%;
+}
+
+.search-country-selector-search {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 16px;
+    border-bottom: 1px solid #f0f0f0;
+}
+
+.search-country-selector-search__icon {
+    color: #999;
+    font-size: 12px;
+    flex-shrink: 0;
+}
+
+.search-country-selector-search__input {
+    border: none;
+    background: transparent;
+    font-size: 14px;
+    font-family: inherit;
+    color: #333;
+    outline: none;
+    padding: 0;
+    flex: 1;
+    min-width: 0;
+}
+
+.search-country-selector-search__input::placeholder {
+    color: #888;
+}
+
+.search-country-selector-search__clear {
+    background: none;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    color: #999;
+    display: flex;
+    align-items: center;
+}
+
+.search-country-selector-search__clear:hover {
+    color: #333;
+}
+
+.search-country-selector-header-row {
+    display: flex;
+    align-items: center;
+    padding: 6px 16px;
+    background-color: $gray-5;
+    border-bottom: 1px solid $gray-20;
+    font-size: 11px;
+    font-weight: 700;
+    color: $gray-60;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.search-country-selector-header-col--left {
+    flex: 1;
+    padding-left: 30px;
+    cursor: pointer;
+    user-select: none;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    outline: none;
+}
+
+.search-country-selector-header-col--left:hover,
+.search-country-selector-header-col--left:focus-visible {
+    color: $gray-90;
+}
+
+.search-country-selector-header-col--right {
+    flex-shrink: 0;
+    cursor: pointer;
+    user-select: none;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    outline: none;
+}
+
+.search-country-selector-header-col--right:hover,
+.search-country-selector-header-col--right:focus-visible {
+    color: $gray-90;
+}
+
+.search-country-selector-header__icon {
+    font-size: 10px;
+    color: $gray-50;
+    margin-left: 4px;
+}
+
+.search-country-selector-header__icon--inactive {
+    color: $gray-30;
+    transition: color 0.15s ease;
+}
+
+.search-country-selector-header-col--left:hover
+    .search-country-selector-header__icon--inactive,
+.search-country-selector-header-col--right:hover
+    .search-country-selector-header__icon--inactive {
+    color: $gray-50;
+}
+
+.search-country-selector-list {
+    outline: none;
+    padding: 0;
+    margin: 0;
+    list-style: none;
+    max-height: 400px;
+    overflow-y: auto;
+}
+
+.search-country-selector-list__item {
+    display: flex;
+    align-items: center;
+    padding: 10px 16px;
+    cursor: pointer;
+    font-size: 14px;
+    color: #333;
+    border-bottom: 1px solid #f0f0f0;
+    outline: none;
+}
+
+.search-country-selector-list__item:last-child {
+    border-bottom: none;
+}
+
+.search-country-selector-clear-container {
+    padding: 8px 16px;
+    border-bottom: 1px solid #f0f0f0;
+    display: flex;
+    justify-content: flex-end;
+}
+
+.search-country-selector-clear-all {
+    background: none;
+    border: none;
+    color: #666;
+    font-size: 12px;
+    cursor: pointer;
+    padding: 0;
+    text-decoration: underline;
+}
+
+.search-country-selector-clear-all:hover:not(:disabled) {
+    color: #333;
+}
+
+.search-country-selector-clear-all:disabled {
+    color: $gray-30;
+    cursor: default;
+    text-decoration: none;
+}
+
+.search-country-selector-list__item:hover,
+.search-country-selector-list__item[data-focused] {
+    background-color: #f9f9f9;
+}
+
+.checkbox-container {
+    display: flex;
+    align-items: center;
+    margin-right: 12px;
+}
+
+.search-country-selector-checkbox {
+    width: 18px;
+    height: 18px;
+    border: 1px solid #ccc;
+    border-radius: 3px;
+    background-color: white;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.search-country-selector-checkbox.checked {
+    background-color: #607d8b; /* Sleek slate blue color */
+    border-color: #607d8b;
+}
+
+.search-country-selector-list__item[data-focused]
+    .search-country-selector-checkbox,
+.search-country-selector-list__item:hover .search-country-selector-checkbox {
+    border-color: #607d8b;
+}
+
+.country-name {
+    flex: 1;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.country-median {
+    color: $gray-60;
+    font-size: 12px;
+    margin-left: 12px;
+    white-space: nowrap;
+    flex-shrink: 0;
+    font-variant-numeric: tabular-nums;
+}
+
+.income-plot-controls-bottom {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    margin-bottom: 10px;
+    font-family:
+        "Lato", "Helvetica Neue", Helvetica, Arial, "Liberation Sans",
+        sans-serif;
+    font-size: 14px;
+    color: #333;
+}
+
+.control-pill {
+    background: $blue-5;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    padding: 4px 14px;
+    font-size: 14px;
+    color: $blue-90;
+    cursor: pointer;
+    font-family:
+        "Lato", "Helvetica Neue", Helvetica, Arial, "Liberation Sans",
+        sans-serif;
+    transition: background-color 0.15s ease;
+
+    &:hover {
+        background: #e8e8e8;
+    }
+
+    &:active {
+        background: #ddd;
+    }
+}
+
+.control-text {
+    color: #555;
+    font-size: 14px;
+}
+
+.currency-select {
+    position: relative;
+    display: inline-block;
+}
+
+.currency-select__trigger {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.currency-select__chevron {
+    font-size: 10px;
+    opacity: 0.6;
+}
+
+.currency-select__popover {
+    position: absolute;
+    z-index: 100;
+    background: white;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    min-width: 320px;
+    display: flex;
+    flex-direction: column;
+    max-height: 350px;
+}
+
+.currency-select__search {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px;
+    border-bottom: 1px solid #eee;
+
+    .react-aria-Input {
+        border: none;
+        background: transparent;
+        font-size: 13px;
+        font-family: inherit;
+        color: #333;
+        outline: none;
+        padding: 0;
+        flex: 1;
+        min-width: 0;
+
+        &::placeholder {
+            color: #999;
+        }
+    }
+
+    .clear-button {
+        background: none;
+        border: none;
+        padding: 0;
+        cursor: pointer;
+        color: #999;
+        display: flex;
+        align-items: center;
+
+        &:hover {
+            color: #333;
+        }
+    }
+}
+
+.currency-select__search-icon {
+    color: #999;
+    font-size: 12px;
+    flex-shrink: 0;
+}
+
+.currency-select__clear-icon {
+    font-size: 10px;
+}
+
+.currency-select__listbox {
+    outline: none;
+    padding: 4px 0;
+    overflow-y: auto;
+    max-height: 600px;
+}
+
+.currency-select__listbox .react-aria-ListBoxSection {
+    margin-top: 8px;
+}
+
+.currency-select__section-header {
+    padding: 4px 12px;
+    font-size: 11px;
+    font-weight: 700;
+    color: #999;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.currency-select__item {
+    padding: 7px 12px;
+    font-size: 13px;
+    cursor: pointer;
+    outline: none;
+
+    &[data-focused] {
+        background: $blue-5;
+    }
+
+    &[data-selected] {
+        font-weight: 700;
+        color: $blue-90;
+    }
+
+    &[data-disabled] {
+        color: #777;
+        cursor: default;
+    }
+}
+
+.currency-select__item--status {
+    padding: 10px 12px;
+    font-style: italic;
+}
+
+.currency-select__item--hint {
+    padding: 8px 12px 10px;
+    color: #777;
+    font-style: italic;
+}
+
+.currency-select__empty {
+    padding: 14px 12px;
+    color: #777;
+    font-size: 13px;
+    font-style: italic;
+}
+
+.currency-select__option {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 16px;
+}
+
+.currency-select__option-country {
+    color: #333;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.currency-select__option-currency {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 6px;
+    color: #666;
+    flex-shrink: 0;
+    font-size: 12px;
+}
+
+.currency-select__option-code {
+    color: #999;
+    font-variant-numeric: tabular-nums;
+}
+
+$controlRowHeight: 28px;
+
+// Mixins for slim tab styling, shared with ContentSwitchers.scss
+@mixin slim-tab-item {
+    $visual-gap: 1px;
+
+    position: relative;
+    display: block;
+    color: $light-text;
+    font-size: var(--tabs-font-size, 13px);
+    font-weight: 500;
+    height: $controlRowHeight - 2 * $visual-gap;
+    line-height: $controlRowHeight - 2 * $visual-gap;
+    border-radius: $visual-gap;
+    cursor: pointer;
+    letter-spacing: 0.01em;
+    white-space: nowrap;
+    user-select: none;
+    text-align: center;
+
+    &[data-hovered] {
+        background-color: $gray-10;
+    }
+}
+@mixin slim-tab-separator {
+    &::before {
+        content: "";
+        display: block;
+        width: 1px;
+        height: calc(100% - 12px);
+        position: absolute;
+        top: 6px;
+        background-color: $gray-20;
+        left: -0.5px;
+    }
+}
+
+.Tabs {
+    position: relative;
+
+    &::-webkit-scrollbar {
+        display: none;
+    }
+
+    // Variant: default
+    &.Tabs--variant-default,
+    &.Tabs--variant-scroll {
+        margin: 16px 0;
+        display: flex;
+
+        .Tabs__Tab {
+            @include grapher_label-2-medium;
+            flex-shrink: 0;
+            display: inline-block;
+            margin: 0 8px 8px 0;
+            padding: 8px;
+            border: 1px solid $blue-10;
+            background: #fff;
+            color: $dark-text;
+            white-space: normal;
+            cursor: pointer;
+            text-wrap: balance;
+
+            &[data-hovered] {
+                background-color: $gray-10;
+                border-color: $gray-10;
+            }
+
+            &[data-selected] {
+                background: $accent-pale-blue;
+                border-color: $accent-pale-blue;
+                color: $blue-90;
+            }
+        }
+    }
+
+    // Variant: horizontal scroll
+    &.Tabs--variant-scroll {
+        overflow-x: auto;
+        white-space: nowrap;
+        -webkit-overflow-scrolling: touch;
+        scrollbar-width: none;
+
+        $fade-out-width: 40px;
+        padding-right: $fade-out-width;
+        mask-image: linear-gradient(
+            to right,
+            black calc(100% - #{$fade-out-width}),
+            transparent 100%
+        );
+        -webkit-mask-image: linear-gradient(
+            to right,
+            black calc(100% - #{$fade-out-width}),
+            transparent 100%
+        );
+    }
+
+    // Variant: slim
+    &.Tabs--variant-slim {
+        --tab-padding: 10px;
+
+        $light-stroke: $gray-20;
+        $active-fill: $blue-20;
+
+        $border-radius: 4px;
+        $visual-gap: 1px;
+
+        display: flex;
+        height: $controlRowHeight;
+        margin: 0;
+        padding: $visual-gap;
+        // using a box-shadow instead of a border fixes a bug
+        // where the tab items weren't centered when zoomed in or out
+        box-shadow: inset 0 0 0 1px $light-stroke;
+        border-radius: $border-radius;
+
+        gap: 1px;
+        padding-left: $visual-gap * 2;
+        padding-right: $visual-gap * 2;
+
+        .Tabs__Tab {
+            @include slim-tab-item;
+            transform: translateY($visual-gap);
+            padding: 0 var(--tab-padding);
+            text-overflow: ellipsis;
+            overflow: hidden;
+            transition:
+                background-color 0.15s ease,
+                color 0.15s ease;
+
+            &[data-selected] {
+                color: $active-text;
+                font-weight: 700;
+                background-color: $active-fill;
+            }
+        }
+
+        // separators between tabs
+        .Tabs__Tab + .Tabs__Tab {
+            @include slim-tab-separator;
+        }
+
+        // hide separators when a tab is hovered over or when a tab is active
+        .Tabs__Tab[data-selected]::before,
+        .Tabs__Tab[data-hovered]::before,
+        .Tabs__Tab[data-selected] + .Tabs__Tab::before,
+        .Tabs__Tab[data-hovered] + .Tabs__Tab::before {
+            display: none;
+        }
+    }
+
+    // Variant: stretch
+    &.Tabs--variant-stretch {
+        display: flex;
+        gap: 8px;
+
+        $hover-fill: $gray-10;
+        $active-fill: $accent-pale-blue;
+
+        .Tabs__Tab {
+            flex-grow: 1;
+            flex-shrink: 1;
+
+            @include grapher_label-2-medium;
+            display: inline-block;
+            padding: 8px;
+            border: 1px solid $blue-10;
+            background: #fff;
+            color: $dark-text;
+            cursor: pointer;
+            text-wrap: balance;
+
+            &[data-hovered] {
+                background-color: $hover-fill;
+                border-color: $hover-fill;
+            }
+
+            &[data-selected] {
+                background: $active-fill;
+                border-color: $active-fill;
+                color: $blue-90;
+            }
+        }
+    }
+
+    svg {
+        margin-right: 4px;
+    }
+}
+
+.income-plot-empty-state {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    border: 1px solid $gray-20;
+    border-radius: 2px;
+    background-color: $gray-5;
+    padding: 24px;
+    box-sizing: border-box;
+    margin-bottom: 12px;
+}
+
+.income-plot-empty-state__content {
+    max-width: 320px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    gap: 12px;
+}
+
+.income-plot-empty-state__message {
+    font-size: 14px;
+    color: $gray-70;
+    line-height: 1.5;
+    margin: 0;
+    font-family: inherit;
+}

--- a/bespoke/projects/income-plots/src/fast-kde.d.ts
+++ b/bespoke/projects/income-plots/src/fast-kde.d.ts
@@ -1,0 +1,68 @@
+declare module "fast-kde" {
+    export interface Density1dOptions<T = any> {
+        adjust?: number
+        pad?: number
+        bins?: number
+        x?: (d: T) => number
+        weight?: (d: T) => number
+        bandwidth?: number
+        extent?: [number, number]
+    }
+
+    export interface Density1dEstimator {
+        [Symbol.iterator](): Generator<{ x: number; y: number }>
+        points(x?: string, y?: string): Generator<{ [key: string]: number }>
+        grid(): Float64Array
+        extent(): [number, number]
+        bandwidth(value?: number): number | Density1dEstimator
+    }
+
+    export function density1d<T = any>(
+        data: T[],
+        options?: Density1dOptions<T>
+    ): Density1dEstimator
+
+    export interface Density2dOptions<T = any> {
+        adjust?: number
+        pad?: number
+        bins?: [number, number] | number
+        x?: (d: T) => number
+        y?: (d: T) => number
+        weight?: (d: T) => number
+        bandwidth?: [number, number] | number
+        extent?: [[number, number], [number, number]] | [number, number]
+    }
+
+    export interface Density2dEstimator {
+        [Symbol.iterator](): Generator<{ x: number; y: number; z: number }>
+        points(
+            x?: string,
+            y?: string,
+            z?: string
+        ): Generator<{ [key: string]: number }>
+        grid(): Float64Array
+        extent(): [[number, number], [number, number]]
+        heatmap(options?: {
+            color?: (t: number) => string | { r: number; g: number; b: number }
+            clamp?: [number, number]
+            canvas?: HTMLCanvasElement
+            maxColors?: number
+        }): HTMLCanvasElement
+        bandwidth(
+            value?: [number, number] | number
+        ): [number, number] | Density2dEstimator
+    }
+
+    export function density2d<T = any>(
+        data: T[],
+        options?: Density2dOptions<T>
+    ): Density2dEstimator
+
+    export function nrd<T = any>(data: T[], accessor?: (d: T) => number): number
+
+    export function opacityMap(
+        r: number,
+        g: number,
+        b: number
+    ): (opacity: number) => { r: number; g: number; b: number; opacity: number }
+}

--- a/bespoke/projects/income-plots/src/grapher.scss
+++ b/bespoke/projects/income-plots/src/grapher.scss
@@ -1,0 +1,12 @@
+@import "../../../../packages/@ourworldindata/components/src/styles/colors.scss";
+@import "../../../../packages/@ourworldindata/components/src/styles/variables.scss";
+@import "../../../../packages/@ourworldindata/components/src/styles/typography-constants.scss";
+@import "../../../../packages/@ourworldindata/components/src/styles/typography.scss";
+@import "../../../../packages/@ourworldindata/components/src/styles/util.scss";
+@import "../../../../packages/@ourworldindata/components/src/styles/mixins.scss";
+
+@import "../../../../packages/@ourworldindata/grapher/src/core/typography.scss";
+@import "../../../../packages/@ourworldindata/grapher/src/core/variables.scss";
+
+@import "../../../../packages/@ourworldindata/grapher/src/controls/Dropdown.scss";
+@import "../../../../packages/@ourworldindata/grapher/src/tooltip/Tooltip.scss";

--- a/bespoke/projects/income-plots/src/index.tsx
+++ b/bespoke/projects/income-plots/src/index.tsx
@@ -1,0 +1,52 @@
+import { createRoot } from "react-dom/client"
+import { enableShadowDOM } from "@react-stately/flags"
+import StylesTarget from "vite-plugin-css-position/react"
+
+import type {
+    BespokeComponentMountFn,
+    BespokeComponentVariantsList,
+} from "owid-bespoke-types"
+
+import { App } from "./components/App.tsx"
+import { ShadowRootContext } from "./ShadowRootContext.tsx"
+import "./main.scss"
+
+type IncomePlotVariantName = "distribution" | "upside-down"
+
+export const VARIANTS = [
+    { name: "distribution", demoConfig: {} },
+    {
+        name: "distribution",
+        demoConfig: { tab: "countries", isolateState: "true" },
+    },
+] satisfies BespokeComponentVariantsList<IncomePlotVariantName>
+
+enableShadowDOM()
+
+export const mount: BespokeComponentMountFn = (
+    container: HTMLDivElement,
+    opts: { variant?: string; config?: Record<string, string> }
+) => {
+    const variantName = opts.variant ?? "distribution"
+    const variant = VARIANTS.find((entry) => entry.name === variantName)
+
+    if (!variant) {
+        container.textContent = `Unknown variant: "${variantName}"`
+        return
+    }
+
+    const initialTab = opts.config?.tab as "global" | "countries" | undefined
+    const isolateState = opts.config?.isolateState === "true"
+
+    const root = createRoot(container)
+    root.render(
+        <ShadowRootContext.Provider value={container}>
+            <StylesTarget />
+            <App tab={initialTab} isolateState={isolateState} />
+        </ShadowRootContext.Provider>
+    )
+
+    return () => {
+        root.unmount()
+    }
+}

--- a/bespoke/projects/income-plots/src/main.scss
+++ b/bespoke/projects/income-plots/src/main.scss
@@ -1,0 +1,11 @@
+@import "tippy.js/dist/tippy.css";
+@import "tippy.js/themes/light.css";
+
+@import "./grapher.scss";
+
+@import "./controls";
+@import "../../../components/Frame/Frame.scss";
+@import "../../../components/ChartHeader/ChartHeader.scss";
+@import "../../../components/ChartFooter/ChartFooter.scss";
+@import "../../../../packages/@ourworldindata/components/src/loadingIndicator/LoadingIndicator.scss";
+@import "./styles.css";

--- a/bespoke/projects/income-plots/src/store.ts
+++ b/bespoke/projects/income-plots/src/store.ts
@@ -1,0 +1,365 @@
+import { atom, type Atom } from "jotai"
+import { unwrap } from "jotai/utils"
+import { atomEffect } from "jotai-effect"
+import {
+    DETECT_COUNTRY_URL,
+    INCOME_DISTRIBUTION_URL,
+    INT_DOLLAR_CONVERSIONS_URL,
+    INT_DOLLAR_CONVERSION_KEY_INFO,
+    POVERTY_DATA_YEAR,
+    TIME_INTERVAL_FACTORS,
+    TIME_INTERVALS,
+    WORLD_ENTITY_NAME,
+    type TimeInterval,
+} from "./utils/incomePlotConstants.ts"
+import type {
+    IntDollarConversions,
+    DetectCountryResponse,
+    IntDollarConversionKeyInfo,
+    IncomeDistributionDataFile,
+    IncomeDistributionCountryData,
+} from "./types.ts"
+import {
+    assignColors,
+    formatCurrency,
+    kdeLog,
+    REGION_COLORS,
+} from "./utils/incomePlotUtils.ts"
+import * as R from "remeda"
+
+type LoadableState<Value> =
+    | { state: "loading" }
+    | { state: "hasData"; data: Value }
+    | { state: "hasError"; error: unknown }
+
+const loadableAtom = <Value>(anAtom: Atom<Value>) => {
+    const loading = Symbol("loading")
+    const unwrappedAtom = unwrap(anAtom, () => loading)
+    return atom((get): LoadableState<Awaited<Value>> => {
+        try {
+            const data = get(unwrappedAtom)
+            if (data === loading) return { state: "loading" }
+            return { state: "hasData", data: data as Awaited<Value> }
+        } catch (error) {
+            return { state: "hasError", error }
+        }
+    })
+}
+
+export const atomisNarrow = atom(false)
+
+const atomCustomPovertyLineInternal = atom(3)
+export const atomShowCustomPovertyLine = atom(false)
+export const atomCustomPovertyLine = atom(
+    (get) => {
+        const show = get(atomShowCustomPovertyLine)
+        if (!show) return null
+        return get(atomCustomPovertyLineInternal)
+    },
+    (get, set, newValue: number) => {
+        set(atomCustomPovertyLineInternal, newValue)
+    }
+)
+export const atomPovertyLineForLegend = atom((get) => {
+    const line = get(atomCustomPovertyLine)
+    const isNarrow = get(atomisNarrow)
+    if (line === null && isNarrow) return 3
+    return line
+})
+export const atomCustomPovertyLineFormatted = atom((get) => {
+    const line = get(atomCustomPovertyLine)
+    if (line === null) return null
+    const currency = get(atomCurrentCurrency)
+    const combinedFactor = get(atomCombinedFactor)
+    return formatCurrency(line * combinedFactor, currency)
+})
+
+// Basic atoms related to data-display controls
+export const atomCurrentYear = atom<number>(POVERTY_DATA_YEAR)
+
+const atomTimeIntervalIdx = atom(0)
+export const atomTimeInterval = atom(
+    (get) => {
+        const idx = get(atomTimeIntervalIdx)
+        return TIME_INTERVALS[idx]
+    },
+    // Set a specific time interval, or advance to the next one if none given
+    (get, set, newValue?: TimeInterval) => {
+        if (newValue !== undefined) {
+            const idx = TIME_INTERVALS.indexOf(newValue)
+            if (idx !== -1) set(atomTimeIntervalIdx, idx)
+        } else {
+            const idx = get(atomTimeIntervalIdx)
+            set(atomTimeIntervalIdx, (idx + 1) % TIME_INTERVALS.length)
+        }
+    }
+)
+
+export const atomTimeIntervalFactor = atom((get) => {
+    const idx = get(atomTimeIntervalIdx)
+    return TIME_INTERVAL_FACTORS[idx]
+})
+
+const atomCountriesOrRegionsModeInternal = atom<"countries" | "regions">(
+    "countries"
+)
+export const atomCountriesOrRegionsMode = atom(
+    (get) => {
+        const isSingleCountryMode = get(atomIsInSingleCountryMode)
+        if (isSingleCountryMode) return "countries"
+        return get(atomCountriesOrRegionsModeInternal)
+    },
+    (get, set, newValue?: "countries" | "regions") => {
+        if (newValue !== undefined) {
+            set(atomCountriesOrRegionsModeInternal, newValue)
+        } else {
+            set(atomCountriesOrRegionsModeInternal, (current) =>
+                current === "countries" ? "regions" : "countries"
+            )
+        }
+    }
+)
+
+// Data
+
+export const atomRawDataForYear = atom<
+    Promise<IncomeDistributionCountryData[]>
+>(async (get, { signal }) => {
+    const year = get(atomCurrentYear)
+    const url = INCOME_DISTRIBUTION_URL.replace("<YEAR>", year.toString())
+    const res = await fetch(url, { signal })
+    if (!res.ok) throw new Error(`Failed to fetch income data: ${res.status}`)
+    const rawData = (await res.json()) as IncomeDistributionDataFile
+    const rawDataForYear = Object.values(rawData.data)
+    const sortedDataForYear = R.sortBy(
+        rawDataForYear,
+        [R.prop("region"), "desc"],
+        [R.prop("totalPopulation"), "desc"]
+    )
+    return sortedDataForYear
+})
+
+export const atomCountryRegionMap = atom(async (get) => {
+    const rawData = await get(atomRawDataForYear)
+
+    return new Map(rawData.map((d) => [d.country, d.region]))
+})
+
+export const atomKdeDataForYear = atom(async (get) => {
+    const rawData = await get(atomRawDataForYear)
+    const kdeData = rawData.flatMap((record) => {
+        const common = {
+            country: record.country,
+            region: record.region,
+            pop: record.totalPopulation,
+        }
+        const kdeRes = kdeLog(record.avgs.map(Math.log2))
+        return kdeRes.map((kde) => ({
+            ...common,
+            ...kde,
+            yScaledByPop: kde.y * common.pop,
+        }))
+    })
+
+    return kdeData
+})
+
+export const atomKdeXValues = atom<Promise<[number, ...number[]]>>(
+    async (get) => {
+        const kdeData = await get(atomKdeDataForYear)
+        return Array.from(new Set(kdeData.map((d) => d.x))) as [
+            number,
+            ...number[],
+        ]
+    }
+)
+
+export const atomKdeDataForYearGroupedByRegion = atom(async (get) => {
+    const kdeData = await get(atomKdeDataForYear)
+
+    const transformed = R.mapValues(
+        R.groupBy(kdeData, (d) => `${d.region}-${d.x}`),
+        (kdes) => {
+            const first = kdes[0]
+            return {
+                ...first,
+                country: null,
+                pop: R.sumBy(kdes, (d) => d.pop),
+                y: R.sumBy(kdes, (d) => d.y),
+            }
+        }
+    )
+    return Object.values(transformed)
+})
+
+// Currency conversion data (incl. country detection)
+export const atomIntDollarConversions = atom(async () => {
+    try {
+        const res = await fetch(INT_DOLLAR_CONVERSIONS_URL)
+        const data = (await res.json()) as IntDollarConversions
+        return data.filter((c) => c.currency_code)
+    } catch {
+        return undefined
+    }
+})
+
+export const atomDetectedCountry = atom(async () => {
+    try {
+        const res = await fetch(DETECT_COUNTRY_URL)
+        return (await res.json()) as DetectCountryResponse
+    } catch {
+        return undefined
+    }
+})
+
+export const atomLocalCurrencyConversion = atom(async (get) => {
+    const conversions = await get(atomIntDollarConversions)
+    const detectedCountry = await get(atomDetectedCountry)
+    const countryCode = detectedCountry?.country?.code
+    if (!countryCode) return null
+
+    const conversion = conversions?.find((c) => c.country_code === countryCode)
+    if (!conversion) return null
+
+    return conversion
+})
+
+// Legend
+export const atomLegendEntries = atom((get) => {
+    const currentEntities = get(atomCurrentEntitiesSorted)
+    const entityColors = get(atomEntityColorMap)
+    const hasPovertyLine = get(atomPovertyLineForLegend) !== null
+    const map = currentEntities.map((entity) => {
+        const colorEntry = entityColors.get(entity)
+        return {
+            name: entity,
+            color: colorEntry,
+        }
+    })
+    if (hasPovertyLine)
+        map.push({
+            name: WORLD_ENTITY_NAME,
+            color: entityColors.get(WORLD_ENTITY_NAME),
+        })
+    return map
+})
+
+export const atomLegendPlacement = atom((get) => {
+    const povertyLine = get(atomCustomPovertyLine)
+    if (povertyLine !== null && povertyLine > 20) return "left"
+    return "right"
+})
+
+// Hover state of the chart
+export const atomHoveredEntity = atom<string | null>(null)
+export const atomHoveredEntityType = atom((get) => {
+    const hoveredEntity = get(atomHoveredEntity)
+    if (!hoveredEntity) return null
+
+    const regionNames = Object.keys(REGION_COLORS)
+    const entry = regionNames.includes(hoveredEntity)
+    if (entry) return "region"
+    return "country"
+})
+export const atomHoveredX = atom<number | null>(null)
+
+// Currency
+export const atomCurrentCurrency = atom<IntDollarConversionKeyInfo>(
+    INT_DOLLAR_CONVERSION_KEY_INFO
+)
+
+export const atomCurrentCurrencyFactor = atom((get) => {
+    const currency = get(atomCurrentCurrency)
+    return currency.conversion_factor
+})
+
+export const atomCombinedFactor = atom((get) => {
+    const timeIntervalFactor = get(atomTimeIntervalFactor)
+    const currencyFactor = get(atomCurrentCurrencyFactor)
+    return timeIntervalFactor * currencyFactor
+})
+
+export const atomTooltipIsOpen = atom((get) => {
+    const hoveredX = get(atomHoveredX)
+    return hoveredX !== null
+})
+
+const atomCountrySelection = atom<string[]>([
+    "China",
+    "United States",
+    "India",
+    "Nigeria",
+])
+export const atomSelectedCountryNames = atom(
+    (get) => {
+        return get(atomCountrySelection)
+    },
+    (get, set, newValue: string[]) => {
+        set(atomCountrySelection, newValue)
+    }
+)
+
+export const atomAvailableCountryNames = atom(async (get) => {
+    const rawData = await get(atomRawDataForYear)
+    return rawData.map((d) => d.country).toSorted()
+})
+
+export const atomCurrentTab = atom<"global" | "countries">("global")
+
+export const atomIsInSingleCountryMode = atom((get) => {
+    return get(atomCurrentTab) === "countries"
+})
+
+export const atomCurrentEntitiesSorted = atom((get) => {
+    const isSingleCountryMode = get(atomIsInSingleCountryMode)
+    const selectedCountryNames = get(atomSelectedCountryNames)
+
+    if (isSingleCountryMode) {
+        return selectedCountryNames.toSorted()
+    } else {
+        return Object.keys(REGION_COLORS)
+    }
+})
+
+export const atomEntityColorMap = atom((get) => {
+    const currentEntities = get(atomCurrentEntitiesSorted)
+    return assignColors(currentEntities)
+})
+
+export const loadableIntDollarConversions = loadableAtom(
+    atomIntDollarConversions
+)
+export const loadableLocalCurrencyConversion = loadableAtom(
+    atomLocalCurrencyConversion
+)
+export const loadableDetectedCountry = loadableAtom(atomDetectedCountry)
+export const loadableAvailableCountries = loadableAtom(
+    atomAvailableCountryNames
+)
+
+const atomHasLocalCountryBeenIncludedInSelection = atom(false)
+export const atomEffectIncludeLocalCountryInSelection = atomEffect(
+    (get, set) => {
+        const hasLocalCountryBeenIncluded = get(
+            atomHasLocalCountryBeenIncludedInSelection
+        )
+        if (hasLocalCountryBeenIncluded) return
+
+        const detectedCountry = get(loadableDetectedCountry)
+        const availableCountries = get(loadableAvailableCountries)
+        const selectedCountries = get(atomSelectedCountryNames)
+
+        if (
+            detectedCountry.state !== "hasData" ||
+            availableCountries.state !== "hasData"
+        )
+            return
+        const countryName = detectedCountry.data?.country?.name
+        if (!countryName) return
+        if (!availableCountries.data.includes(countryName)) return
+        if (selectedCountries.includes(countryName)) return
+
+        set(atomCountrySelection, [countryName, ...selectedCountries])
+        set(atomHasLocalCountryBeenIncludedInSelection, true)
+    }
+)

--- a/bespoke/projects/income-plots/src/styles.css
+++ b/bespoke/projects/income-plots/src/styles.css
@@ -1,0 +1,517 @@
+:root,
+:host {
+    --gray-20: #e7e7e7;
+    --gray-60: #a1a1a1;
+    --gray-80: #5b5b5b;
+    --gray-100: #2d2d2d;
+    --blue-20: #dbe5f0;
+    --legend-swatch-size: 12px;
+}
+
+* {
+    font-family:
+        Lato, "Helvetica Neue", Helvetica, Arial, "Liberation Sans", sans-serif;
+}
+
+.svg-inline--fa {
+    box-sizing: content-box;
+    display: var(--fa-display, inline-block);
+    height: 1em;
+    overflow: visible;
+    vertical-align: -0.125em;
+    width: var(--fa-width, 1.25em);
+}
+
+.income-plot-captioned-chart {
+    .income-plot-captioned-chart__chart-area {
+        position: relative;
+    }
+}
+
+.income-plot-loading {
+    position: relative;
+    min-height: 180px;
+}
+
+/**
+ * This here is super annoying. We need `shape-rendering: crispEdges` to be set in Chrome in order
+ * to avoid pixelated edges, but in Firefox it _causes_ pixelated edges and we don't want to set it.
+ * So we use a Firefox-specific media query to unset it afterwards. Ugh.
+ */
+.income-plot-chart-svg path {
+    shape-rendering: crispEdges;
+
+    /* This media query only works in Firefox, and so it's used to apply a style only for Firefox. */
+    @media screen and (min--moz-device-pixel-ratio: 0) {
+        shape-rendering: unset;
+    }
+}
+
+.income-plot-chart-svg {
+    .tick {
+        color: var(--gray-100);
+    }
+}
+
+.income-plot-legend {
+    position: absolute;
+    top: 12px;
+    width: max-content;
+    z-index: 100;
+    background: white;
+
+    padding: 16px;
+    border: 1px solid var(--blue-20);
+
+    &.income-plot-legend--left {
+        left: 12px;
+    }
+
+    &.income-plot-legend--right {
+        right: 12px;
+    }
+
+    .legend-poverty-line-header {
+        font-size: 13px;
+        color: black;
+        margin-bottom: 12px;
+    }
+
+    .legend-entries-container {
+        font-size: 12px;
+
+        display: grid;
+        grid-template-columns: max-content 170px;
+        column-gap: 5px;
+
+        color: var(--gray-100);
+
+        cursor: default;
+    }
+
+    .legend-entry {
+        /* We could be using row-gap in the grid, but then there's space between legend items for mouse events, which makes for an odd mouse interaction. So we use padding instead. */
+        padding-top: 1px;
+        padding-bottom: 1px;
+        display: grid;
+        grid-column: 1 / -1;
+        grid-template-columns: subgrid;
+        align-items: center;
+
+        color: color-mix(
+            in oklab,
+            var(--legend-entry-color),
+            var(--gray-100) 30%
+        );
+
+        &.legend-entry--has-percentages {
+            .legend-entry-label {
+                text-overflow: ellipsis;
+                overflow: hidden;
+                white-space: nowrap;
+            }
+        }
+
+        &.--legend-entry--is-world {
+            font-weight: bold;
+        }
+    }
+
+    /* If there's at least one hovered legend entry, dim all non-highlighted ones */
+    &:has(.legend-entry--hovered) {
+        .legend-entry:not(.legend-entry--hovered) {
+            opacity: 0.5;
+        }
+    }
+
+    .legend-entry-percentage-container {
+        justify-self: end;
+        display: flex;
+        align-items: center;
+        gap: 5px;
+        color: var(--gray-80);
+    }
+
+    .legend-entry-swatch {
+        display: inline-block;
+        background-color: var(--legend-entry-color);
+        height: var(--legend-swatch-size);
+        width: var(--legend-swatch-size);
+        justify-self: end;
+
+        .legend-entry--has-percentages & {
+            width: calc(var(--legend-entry-percentage-value, 0) * 1px);
+        }
+    }
+
+    &.income-plot-legend--mobile {
+        position: static;
+        width: auto;
+        border: none;
+        padding: 8px 0;
+        user-select: none;
+
+        .legend-entries-container {
+            grid-template-columns: 1fr 2fr;
+        }
+
+        .legend-entry-percentage-container {
+            justify-self: end;
+            width: 100%;
+            justify-content: flex-end;
+        }
+
+        .legend-entry-swatch {
+            .legend-entry--has-percentages & {
+                /* 40px we need to subtract to make space for the percentage text */
+                width: calc(
+                    var(--legend-entry-percentage-value, 0) * (100% - 40px) /
+                        100
+                );
+            }
+        }
+    }
+}
+
+.income-plot-captioned-chart {
+    color: var(--gray-80);
+}
+
+.income-plot-chart {
+    .plot-series-stacked {
+        .income-plot-series .area-bg {
+            fill-opacity: 0.3;
+        }
+        .income-plot-series .area-fg {
+            fill-opacity: 0.8;
+        }
+    }
+
+    .plot-series-unstacked {
+        .income-plot-series .area-bg {
+            fill-opacity: 0.15;
+        }
+        .income-plot-series .area-fg {
+            fill-opacity: 0.3;
+        }
+    }
+
+    &:has(.income-plot-series[data-selected]) {
+        .income-plot-series {
+            opacity: 0.5;
+        }
+        .income-plot-series[data-selected="true"] {
+            opacity: 1;
+            path {
+                stroke-width: 0.3px;
+            }
+        }
+    }
+
+    .region-label {
+        fill: rgba(0, 0, 0, 0.9);
+        stroke: rgba(255, 255, 255, 0.8);
+        stroke-width: 3px;
+        paint-order: stroke;
+        pointer-events: none;
+        text-anchor: middle;
+        dominant-baseline: central;
+    }
+
+    &:has(.income-plot-series[data-highlighted]) {
+        .income-plot-series {
+            opacity: 0.35;
+        }
+        .income-plot-series[data-highlighted="true"] {
+            opacity: 1;
+        }
+
+        .plot-series-unstacked {
+            .income-plot-series[data-highlighted="true"] .area-bg {
+                fill-opacity: 0.3;
+            }
+            .income-plot-series[data-highlighted="true"] .area-fg {
+                fill-opacity: 0.5;
+            }
+            .income-plot-series[data-highlighted="true"] .line-fg {
+                stroke-opacity: 1;
+            }
+        }
+    }
+}
+
+.income-plot-tooltip {
+    z-index: 101;
+    border: 1px solid var(--gray-20);
+    border-radius: 4px;
+    background: white;
+    padding: 12px;
+    max-width: 200px;
+    font-size: 14px;
+    pointer-events: none;
+    box-shadow: 0px 4px 40px 0px #00000026;
+
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+
+    .tooltip--entityName {
+        color: var(--gray-100);
+    }
+
+    .tooltip--percentage {
+        color: var(--gray-100);
+        font-weight: bold;
+    }
+
+    .tooltip--set-pov-line {
+        font-size: 0.9em;
+        color: var(--gray-80);
+        font-style: italic;
+    }
+}
+
+/* Drawer (mobile settings panel) */
+
+.income-plot-drawer-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.3);
+    z-index: 200;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.25s ease;
+
+    &.income-plot-drawer-backdrop--open {
+        opacity: 1;
+        pointer-events: auto;
+    }
+}
+
+.income-plot-drawer {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    z-index: 201;
+    background: white;
+    border-radius: 4px 4px 0 0;
+    padding: 16px;
+    transform: translateY(100%);
+    transition:
+        transform 0.3s ease,
+        box-shadow 0.3s ease;
+
+    max-height: 80svh;
+    display: flex;
+    flex-direction: column;
+
+    &.income-plot-drawer--open {
+        transform: translateY(0);
+        box-shadow:
+            0px -7px 16px 0px rgba(0, 0, 0, 0.06),
+            0px -29px 29px 0px rgba(0, 0, 0, 0.05),
+            0px -66px 39px 0px rgba(0, 0, 0, 0.03);
+    }
+}
+
+.income-plot-drawer__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 16px;
+}
+
+.income-plot-drawer__title {
+    font-size: 12px;
+    font-weight: 900;
+    text-transform: uppercase;
+    letter-spacing: 1.2px;
+    color: var(--gray-60);
+}
+
+.income-plot-drawer__close {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 40px;
+    border-radius: 9999px;
+    border: 1px solid var(--gray-20);
+    background: none;
+    cursor: pointer;
+    color: var(--gray-80);
+
+    &:hover {
+        background: #f5f5f5;
+    }
+}
+
+.income-plot-drawer__sections {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    flex: 1;
+    min-height: 0;
+}
+
+.income-plot-drawer__section-label {
+    font-size: 14px;
+    font-weight: 700;
+    color: var(--gray-80);
+    margin-bottom: 8px;
+}
+
+.income-plot-drawer__button-group {
+    display: flex;
+    gap: 8px;
+
+    > * {
+        flex: 1;
+    }
+}
+
+.income-plot-drawer__button {
+    height: 40px;
+    padding: 0 16px;
+    border-radius: 4px;
+    border: 1px solid var(--gray-20);
+    background: none;
+    cursor: pointer;
+    font-size: 13px;
+    font-weight: 500;
+    letter-spacing: 0.13px;
+    color: #858585;
+    white-space: nowrap;
+
+    &.income-plot-drawer__button--active {
+        background: var(--blue-20);
+        border-color: var(--blue-20);
+        color: #1d3d63;
+    }
+}
+
+.income-plot-drawer__divider {
+    height: 1px;
+    flex-shrink: 0;
+    background: var(--gray-20);
+}
+
+/* Drawer country selector */
+
+.drawer-country-selector {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+    flex: 1;
+    min-height: 0;
+}
+
+.drawer-country-selector__search {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    height: 40px;
+    flex-shrink: 0;
+    padding-left: 8px;
+    padding-right: 16px;
+    border: 1px solid var(--gray-20);
+    border-radius: 4px;
+    background: white;
+}
+
+.drawer-country-selector__search-icon {
+    color: #858585;
+    font-size: 12px;
+    width: 16px;
+    flex-shrink: 0;
+}
+
+.drawer-country-selector__search-input {
+    border: none;
+    outline: none;
+    flex: 1;
+    font-size: 14px;
+    background: transparent;
+    color: var(--gray-80);
+
+    &::placeholder {
+        color: #a1a1a1;
+    }
+}
+
+.drawer-country-selector__list {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+}
+
+.drawer-country-selector__item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 8px 8px 16px;
+    border-bottom: 1px solid #f2f2f2;
+    cursor: pointer;
+}
+
+.drawer-country-selector__checkbox {
+    appearance: none;
+    -webkit-appearance: none;
+    width: 16px;
+    height: 16px;
+    border: 1px solid #dadada;
+    border-radius: 2px;
+    background: white;
+    cursor: pointer;
+    position: relative;
+    margin: 0;
+    flex-shrink: 0;
+
+    &:checked {
+        background: #98a9bd;
+        border-color: #98a9bd;
+
+        &::after {
+            content: "";
+            position: absolute;
+            left: 4px;
+            top: 1px;
+            width: 5px;
+            height: 9px;
+            border: solid white;
+            border-width: 0 1.5px 1.5px 0;
+            transform: rotate(45deg);
+        }
+    }
+}
+
+.drawer-country-selector__country-name {
+    font-size: 13px;
+    letter-spacing: 0.13px;
+    color: var(--gray-80);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.income-plot-drawer-trigger {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin: 8px auto 0;
+    padding: 8px 16px;
+    border-radius: 4px;
+    border: 1px solid var(--gray-20);
+    background: none;
+    cursor: pointer;
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--gray-80);
+
+    &:hover {
+        background: #f5f5f5;
+    }
+}

--- a/bespoke/projects/income-plots/src/types.ts
+++ b/bespoke/projects/income-plots/src/types.ts
@@ -1,0 +1,44 @@
+export interface IncomeDistributionCountryData {
+    avgs: number[]
+    country: string
+    region: string
+    totalPopulation: number
+}
+
+export interface IncomeDistributionDataFile {
+    year: number
+    data: Record<string, IncomeDistributionCountryData>
+}
+
+export interface IntDollarConversionEntry {
+    country: string
+    country_code: string
+    ppp_year: number
+    ppp_factor: number
+    ppp_source: "pip" | "wdi"
+    cpi_factor: number
+    conversion_factor: number
+    conversion_factor_year: number
+    currency_code: string
+    currency_name: string
+}
+
+export type IntDollarConversions = IntDollarConversionEntry[]
+
+export interface IntDollarConversionKeyInfo {
+    currency_code: string
+    currency_name: string
+    conversion_factor: number
+    country?: string
+    country_code?: string
+}
+
+export interface DetectCountryResponse {
+    country?: {
+        code?: string
+        name?: string
+        short_code?: string
+        slug?: string
+        regions?: string[]
+    }
+}

--- a/bespoke/projects/income-plots/src/utils/incomePlotConstants.ts
+++ b/bespoke/projects/income-plots/src/utils/incomePlotConstants.ts
@@ -1,0 +1,59 @@
+import { SeriesPoint } from "d3-shape"
+import { IntDollarConversionKeyInfo } from "../types"
+
+export const INT_POVERTY_LINE = 3.0
+
+export const WORLD_ENTITY_NAME = "World"
+
+export const POVERTY_DATA_YEAR = 2026 as const
+
+export const TIME_INTERVALS = ["daily", "monthly", "yearly"] as const
+export type TimeInterval = (typeof TIME_INTERVALS)[number]
+
+export const TIME_INTERVAL_FACTORS = [1, 365 / 12, 365] as const
+
+export const INT_DOLLAR_CONVERSIONS_URL =
+    "https://catalog.ourworldindata.org/external/owid_grapher/latest/int_dollar_conversions/int_dollar_conversions.json"
+
+export const INCOME_DISTRIBUTION_URL =
+    "https://owid-public.owid.io/data/poverty-inequality/income-distribution.<YEAR>.json"
+
+export const DETECT_COUNTRY_URL = "https://detect-country.owid.io/"
+
+export const INT_DOLLAR_CONVERSION_KEY_INFO: IntDollarConversionKeyInfo = {
+    currency_code: "INTD",
+    currency_name: "International Dollar",
+    conversion_factor: 1,
+}
+
+export const SUGGESTED_CURRENCY_COUNTRY_CODES = [
+    "BRA",
+    "CHN",
+    "DEU",
+    "ESP",
+    "FRA",
+    "GBR",
+    "IDN",
+    "IND",
+    "JPN",
+    "RUS",
+    "USA",
+] as const
+
+export interface LegendEntry {
+    name: string
+    color: string
+}
+
+export type LegendEntries = LegendEntry[]
+
+export const KDE_BANDWIDTH = 0.1
+export const KDE_EXTENT = [0.25, 1000].map(Math.log2) as [number, number]
+export const KDE_NUM_BINS = 200
+
+export interface StackedSeriesPoint extends Array<SeriesPoint<{ x: number }>> {
+    key: string
+    country?: string
+    region: string
+    color: string
+}

--- a/bespoke/projects/income-plots/src/utils/incomePlotMetadata.ts
+++ b/bespoke/projects/income-plots/src/utils/incomePlotMetadata.ts
@@ -1,0 +1,8 @@
+export const getIncomePlotTitle = (year: number): string =>
+    `Global income distribution in ${year}`
+
+export const INCOME_PLOT_SUBTITLE =
+    "Income or consumption per person, adjusted for price differences between countries and inflation."
+
+export const INCOME_PLOT_SOURCE =
+    "World Bank Poverty and Inequality Platform (2026)"

--- a/bespoke/projects/income-plots/src/utils/incomePlotUtils.ts
+++ b/bespoke/projects/income-plots/src/utils/incomePlotUtils.ts
@@ -1,0 +1,228 @@
+import { roundSigFig } from "@ourworldindata/utils"
+import * as fastKde from "fast-kde"
+import {
+    KDE_BANDWIDTH,
+    KDE_EXTENT,
+    KDE_NUM_BINS,
+    TimeInterval,
+    WORLD_ENTITY_NAME,
+} from "./incomePlotConstants.ts"
+import * as R from "remeda"
+import {
+    IntDollarConversionKeyInfo,
+    type IncomeDistributionCountryData,
+} from "../types.ts"
+
+export type HorizontalDirection = "left" | "right"
+
+export function getLabelDirection(
+    x: number,
+    legendPlacement: HorizontalDirection
+): HorizontalDirection {
+    if (x < 3) return "right"
+    if (x > 50) return "left"
+
+    return legendPlacement === "left" ? "right" : "left"
+}
+
+const currencyFormatterCache = new Map<string, Intl.NumberFormat>()
+
+export function formatCurrency(
+    num: number,
+    currency: IntDollarConversionKeyInfo,
+    { formatShort }: { formatShort?: boolean } = {}
+) {
+    const currencyCode = currency.currency_code
+    if (currencyCode === "INTD") {
+        if (num >= 10_000_000) return "$" + Math.round(num / 1_000_000) + "M"
+        if (num >= 1_000_000) return "$" + roundSigFig(num / 1_000_000, 2) + "M"
+        if (num >= 10_000) return "$" + Math.round(num / 1_000) + "k"
+        if (num >= 1_000) return "$" + roundSigFig(num / 1_000, 2) + "k"
+        if (num >= 10) return "$" + roundSigFig(num, 2)
+        if (num >= 1) {
+            if (formatShort && Math.round(num) === num)
+                return "$" + Math.round(num)
+            return "$" + (Math.round(num * 10) / 10).toFixed(2)
+        } else return "$" + R.round(num, 1).toFixed(2)
+    }
+
+    let formatter = currencyFormatterCache.get(currencyCode)
+    if (!formatter) {
+        formatter = new Intl.NumberFormat("en-US", {
+            style: "currency",
+            currency: currencyCode,
+            trailingZeroDisplay: "stripIfInteger",
+            notation: "engineering",
+            maximumSignificantDigits: 2,
+        })
+        currencyFormatterCache.set(currencyCode, formatter)
+    }
+    return formatter
+        .format(num)
+        .replace(/(\d\d)0?E-3$/, "0.$1")
+        .replace(/E0$/, "")
+        .replace(/E3$/, "k")
+        .replace(/E6$/, "M")
+        .replace(/E9$/, "B")
+}
+
+export function kdeLog(pointsLog2: number[]) {
+    const k = fastKde.density1d(pointsLog2, {
+        bandwidth: KDE_BANDWIDTH,
+        extent: KDE_EXTENT,
+        bins: KDE_NUM_BINS,
+    })
+    return [...k.points()].map((p) => ({
+        ...p,
+        x: Math.pow(2, p.x),
+    })) as Array<{ x: number; y: number }>
+}
+
+// copied from CustomSchemes.ts
+const OwidDistinctColors = {
+    Purple: "#6d3e91",
+    DarkOrange: "#c05917",
+    LightTeal: "#58ac8c",
+    Blue: "#286bbb",
+    Maroon: "#883039",
+    Camel: "#bc8e5a",
+    MidnightBlue: "#00295b",
+    DustyCoral: "#c15065",
+    DarkOliveGreen: "#18470f",
+    DarkCopper: "#9a5129",
+    Peach: "#e56e5a",
+    Mauve: "#a2559c",
+    Turquoise: "#38aaba",
+    OliveGreen: "#578145",
+    Cherry: "#970046",
+    Teal: "#00847e",
+    RustyOrange: "#b13507",
+    Denim: "#4c6a9c",
+    Fuchsia: "#cf0a66",
+    TealishGreen: "#00875e",
+    Copper: "#b16214",
+    DarkMauve: "#8c4569",
+    Lime: "#3b8e1d",
+    Coral: "#d73c50",
+} as const
+
+export const WORLD_COLOR = OwidDistinctColors.Purple
+
+const COLOR_ROTATION = [
+    OwidDistinctColors.Turquoise,
+    OwidDistinctColors.Denim,
+    OwidDistinctColors.DustyCoral,
+    OwidDistinctColors.Camel,
+    OwidDistinctColors.Peach,
+    OwidDistinctColors.TealishGreen,
+    OwidDistinctColors.Mauve,
+]
+
+export const REGION_COLORS = {
+    "East Asia and Pacific": OwidDistinctColors.Turquoise,
+    "Europe and Central Asia": OwidDistinctColors.Denim,
+    "Latin America and Caribbean": OwidDistinctColors.DustyCoral,
+    "Middle East, North Africa, Afghanistan and Pakistan":
+        OwidDistinctColors.Camel,
+    "North America": OwidDistinctColors.Peach,
+    "South Asia": OwidDistinctColors.TealishGreen,
+    "Sub-Saharan Africa": OwidDistinctColors.Mauve,
+}
+
+export const REGION_NAMES = Object.keys(REGION_COLORS)
+const REGION_NAME_SET = new Set(REGION_NAMES)
+
+export const assignColors = (arr: string[]) => {
+    const map = new Map<string, string>(
+        arr.map((entity, index) => [
+            entity,
+            COLOR_ROTATION[index % COLOR_ROTATION.length],
+        ])
+    )
+    map.set(WORLD_ENTITY_NAME, WORLD_COLOR)
+    return map
+}
+
+export const computePercentageBelowLine = (
+    rawData: IncomeDistributionCountryData[],
+    line: number,
+    countriesOrRegions: Set<string>
+) => {
+    const requestedCountries = new Set<string>()
+    const requestedRegions = new Set<string>()
+    const requestedWorld = countriesOrRegions.has(WORLD_ENTITY_NAME)
+
+    for (const entity of countriesOrRegions) {
+        if (entity === WORLD_ENTITY_NAME) continue
+        if (REGION_NAME_SET.has(entity)) requestedRegions.add(entity)
+        else requestedCountries.add(entity)
+    }
+
+    const totalsByEntity: Record<
+        string,
+        { totalPop: number; populationBelowLine: number }
+    > = {}
+    const addContribution = (
+        entity: string,
+        pop: number,
+        populationBelowLine: number
+    ) => {
+        const record = (totalsByEntity[entity] ??= {
+            totalPop: 0,
+            populationBelowLine: 0,
+        })
+
+        record.totalPop += pop
+        record.populationBelowLine += populationBelowLine
+    }
+
+    for (const record of rawData) {
+        const pop = record.totalPopulation
+        const matchesWorld = requestedWorld
+        const matchesRegion = requestedRegions.has(record.region)
+        const matchesCountry = requestedCountries.has(record.country)
+
+        if (!matchesWorld && !matchesRegion && !matchesCountry) continue
+
+        // SortedIndex finds the highest point that is lower than the set line, and so we can compute the number of people living below the line, in order to then compute the percentage of people living below the line for each entity and region (totalPopulationBelowLine / totalPopulation).
+        const index = R.sortedIndex(record.avgs, line)
+        const populationBelowLine = (index / 10) * pop
+
+        if (matchesWorld) {
+            addContribution(WORLD_ENTITY_NAME, pop, populationBelowLine)
+        }
+        if (matchesRegion) {
+            addContribution(record.region, pop, populationBelowLine)
+        }
+        if (matchesCountry) {
+            addContribution(record.country, pop, populationBelowLine)
+        }
+    }
+
+    return new Map(
+        [...countriesOrRegions].map((entity) => {
+            const totals = totalsByEntity[entity]
+            const percentageBelowLine = totals
+                ? totals.populationBelowLine / totals.totalPop
+                : NaN
+            return [entity, percentageBelowLine]
+        })
+    )
+}
+
+export const getTimeIntervalStr = (interval: TimeInterval) => {
+    switch (interval) {
+        case "yearly":
+            return "year"
+        case "monthly":
+            return "month"
+        case "daily":
+            return "day"
+    }
+}
+
+export const roundPercentage = (num: number) => {
+    if (num <= 1) return "<1"
+    if (num >= 99) return ">99"
+    else return Math.round(num)
+}

--- a/bespoke/projects/income-plots/src/vite-env.d.ts
+++ b/bespoke/projects/income-plots/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/bespoke/projects/income-plots/tsconfig.json
+++ b/bespoke/projects/income-plots/tsconfig.json
@@ -1,0 +1,32 @@
+{
+    "compilerOptions": {
+        "target": "ES2020",
+        "module": "ESNext",
+        "moduleResolution": "bundler",
+        "allowImportingTsExtensions": true,
+        "jsx": "react-jsx",
+        "strict": true,
+        "esModuleInterop": true,
+        "skipLibCheck": true,
+        "noEmit": true,
+        "paths": {
+            "owid-bespoke-types": ["../../shared/bespokeComponentTypes.ts"]
+        },
+        "lib": [
+            "dom",
+            "dom.iterable",
+            "es2020",
+            "es2021",
+            "es2022.array", // Array `at`
+            "es2022.error", // Error `cause`
+            "es2022.object", // Object `hasOwn`
+            "es2023.array", // Array `findLast`, `findLastIndex`, `toReversed`, `toSorted`, etc.
+            "es2023.intl", // Intl.NumberFormat `trailingZeroDisplay`
+            "es2024.collection", // `Map.groupBy`
+            "es2024.object", // `Object.groupBy`
+            "es2025.collection", // Set `union`, `intersection`, `difference` etc.
+            "es2025.iterator" // Iterator helpers: `map`, `filter`, `reduce`, `some`, `every`, `find`, etc.
+        ]
+    },
+    "include": ["src"]
+}

--- a/bespoke/projects/income-plots/vite.config.ts
+++ b/bespoke/projects/income-plots/vite.config.ts
@@ -1,0 +1,61 @@
+import { defineConfig, withFilter } from "vite"
+import pluginReact from "@vitejs/plugin-react"
+import { viteCssPosition } from "vite-plugin-css-position"
+import pluginSwc from "@rollup/plugin-swc"
+
+import { entrypoints } from "./package.json"
+
+export default defineConfig({
+    plugins: [
+        withFilter(
+            // Use swc to transform decorators, since rolldown/oxc doesn't support modern decorators yet. We could remove this once they do - see https://github.com/oxc-project/oxc/issues/9170.
+            pluginSwc({
+                swc: {
+                    jsc: {
+                        parser: {
+                            syntax: "typescript",
+                            decorators: true,
+                        },
+                        transform: {
+                            decoratorVersion: "2023-11",
+                            useDefineForClassFields: true,
+                        },
+
+                        // This setting we need to override from @rollup/plugin-swc's default, otherwise it will not put optional properties on classes (e.g. `class A { optionalProp?: string }`), thereby breaking mobx decorators
+                        loose: false,
+                        target: "esnext",
+                    },
+                },
+            }),
+            // Only run this transform if the file contains a decorator.
+            { transform: { code: /[^"]@/, id: /.*\.(ts|tsx)$/ } }
+        ),
+        pluginReact(),
+        // This plugin allows us to Vite-inject styles directly into the Shadow DOM, and still use HMR in development.
+        // Use <StylesTarget /> in the React tree to specify where the styles should be injected.
+        viteCssPosition({
+            enableDev: true,
+        }),
+    ],
+    resolve: {
+        // The linked @ourworldindata/* packages resolve React relative
+        // to their real paths, which would load a second copy of React
+        // and break hooks. This forces all React imports to resolve to
+        // the single copy in this project's node_modules.
+        dedupe: ["react", "react-dom", "@react-stately/flags"],
+    },
+    build: {
+        lib: {
+            entry: entrypoints.js,
+            formats: ["es"],
+            fileName: "index",
+        },
+        sourcemap: true,
+        outDir: "dist",
+    },
+    define: {
+        "process.env.NODE_ENV": JSON.stringify(
+            process.env.NODE_ENV || "development"
+        ),
+    },
+})

--- a/bespoke/yarn.lock
+++ b/bespoke/yarn.lock
@@ -15,6 +15,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@emnapi/core@npm:1.11.1":
+  version: 1.11.1
+  resolution: "@emnapi/core@npm:1.11.1"
+  dependencies:
+    "@emnapi/wasi-threads": "npm:1.2.2"
+    tslib: "npm:^2.4.0"
+  checksum: 10/9aba37e0c11a75ef8372fd0a9c6e5396f4e8c1ebdd6fee737414787610a9dc1cd9bf188f525153561ca9363896e1135dd240f1ce28f3470dba3ad7e683e6db1a
+  languageName: node
+  linkType: hard
+
 "@emnapi/runtime@npm:1.10.0":
   version: 1.10.0
   resolution: "@emnapi/runtime@npm:1.10.0"
@@ -24,12 +34,82 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@emnapi/runtime@npm:1.11.1":
+  version: 1.11.1
+  resolution: "@emnapi/runtime@npm:1.11.1"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10/8f7c622a49314df4d07952110e108e83b0fe129a8ddb9ef1e0ae372d754616169d5b0dd47a0d354a0fea2612abe42cedb582d15916936d1320c6c468acc804cc
+  languageName: node
+  linkType: hard
+
 "@emnapi/wasi-threads@npm:1.2.1":
   version: 1.2.1
   resolution: "@emnapi/wasi-threads@npm:1.2.1"
   dependencies:
     tslib: "npm:^2.4.0"
   checksum: 10/57cd4292be81c05d26aa886d68a9e4c449ff666e8503fed6463dfc6b64a4e4213f03c152d53296b7cda32840271e38cd33347332070658f01befeb9bf4e59f36
+  languageName: node
+  linkType: hard
+
+"@emnapi/wasi-threads@npm:1.2.2":
+  version: 1.2.2
+  resolution: "@emnapi/wasi-threads@npm:1.2.2"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10/297fb6b1d89744bd0b41d5fec32bade05dc8dcf1f70eba86527226609fb3f6ad3fa96b3b2377b7449709715b3bd1569654c9def1dbbc85fb6b9cb0cff5bc5ebf
+  languageName: node
+  linkType: hard
+
+"@floating-ui/core@npm:^1.8.0":
+  version: 1.8.0
+  resolution: "@floating-ui/core@npm:1.8.0"
+  dependencies:
+    "@floating-ui/utils": "npm:^0.2.12"
+  checksum: 10/762cd5677fd4e82597db2efdd8f1e81d248eac5615d8be755e1bbb5f12a14c56a6bccd735676374d4914db7ccb3f09ec405ec7433e8c48a5521f5d66dc8dd5d6
+  languageName: node
+  linkType: hard
+
+"@floating-ui/dom@npm:^1.8.0":
+  version: 1.8.0
+  resolution: "@floating-ui/dom@npm:1.8.0"
+  dependencies:
+    "@floating-ui/core": "npm:^1.8.0"
+    "@floating-ui/utils": "npm:^0.2.12"
+  checksum: 10/2e7d75fb702875a62795dd8529569f27eff53167768d75476056d6bf824a1ba608177a8877ed9d728eadb5787b4bd07b043fb2c3125b7ad2505a398680b323c0
+  languageName: node
+  linkType: hard
+
+"@floating-ui/react-dom@npm:^2.1.9":
+  version: 2.1.9
+  resolution: "@floating-ui/react-dom@npm:2.1.9"
+  dependencies:
+    "@floating-ui/dom": "npm:^1.8.0"
+  peerDependencies:
+    react: ">=16.8.0"
+    react-dom: ">=16.8.0"
+  checksum: 10/d775609760291d0f1477a9e23fc3508a35bcda1f36601d74bd3e94b817841b266914fa9964697963cb1ac09b451e51283a2ce25f0c3719d0aca761e327bdee43
+  languageName: node
+  linkType: hard
+
+"@floating-ui/react@npm:^0.27.16":
+  version: 0.27.20
+  resolution: "@floating-ui/react@npm:0.27.20"
+  dependencies:
+    "@floating-ui/react-dom": "npm:^2.1.9"
+    "@floating-ui/utils": "npm:^0.2.12"
+    tabbable: "npm:^6.0.0"
+  peerDependencies:
+    react: ">=17.0.0"
+    react-dom: ">=17.0.0"
+  checksum: 10/1102efe7e3317d88c537517a66a4a9f7c981d3191dea4edc993f0e2be21335892a43f7b8e6852e91e1d6d817a1b03962e751fbca4dffd4afe7d69cef85441180
+  languageName: node
+  linkType: hard
+
+"@floating-ui/utils@npm:^0.2.12":
+  version: 0.2.12
+  resolution: "@floating-ui/utils@npm:0.2.12"
+  checksum: 10/ec4e176fb22d33d75df752c5acf82dcaacae40ed2d09c1a5015cb4081318fff20260db216678e952344b95f90c6b43214762b69eba7c51556ecd82c35a795cff
   languageName: node
   linkType: hard
 
@@ -125,6 +205,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@napi-rs/wasm-runtime@npm:^1.1.6":
+  version: 1.1.6
+  resolution: "@napi-rs/wasm-runtime@npm:1.1.6"
+  dependencies:
+    "@tybys/wasm-util": "npm:^0.10.3"
+  peerDependencies:
+    "@emnapi/core": ^1.7.1
+    "@emnapi/runtime": ^1.7.1
+  checksum: 10/3e43425df17547d9d58ab69cce8e6cef38a062eccec4d2def5fc9e10e81cd19ae228b3ab9be4b149b57078d33913687511312d2414089877759b7db1f43625ba
+  languageName: node
+  linkType: hard
+
 "@ourworldindata/components@link:../../../packages/@ourworldindata/components::locator=%40owid%2Fbespoke-causes-of-death%40workspace%3Aprojects%2Fcauses-of-death":
   version: 0.0.0-use.local
   resolution: "@ourworldindata/components@link:../../../packages/@ourworldindata/components::locator=%40owid%2Fbespoke-causes-of-death%40workspace%3Aprojects%2Fcauses-of-death"
@@ -146,6 +238,12 @@ __metadata:
 "@ourworldindata/components@link:../../../packages/@ourworldindata/components::locator=%40owid%2Fbespoke-food-trade%40workspace%3Aprojects%2Ffood-trade":
   version: 0.0.0-use.local
   resolution: "@ourworldindata/components@link:../../../packages/@ourworldindata/components::locator=%40owid%2Fbespoke-food-trade%40workspace%3Aprojects%2Ffood-trade"
+  languageName: node
+  linkType: soft
+
+"@ourworldindata/components@link:../../../packages/@ourworldindata/components::locator=%40owid%2Fbespoke-income-plots%40workspace%3Aprojects%2Fincome-plots":
+  version: 0.0.0-use.local
+  resolution: "@ourworldindata/components@link:../../../packages/@ourworldindata/components::locator=%40owid%2Fbespoke-income-plots%40workspace%3Aprojects%2Fincome-plots"
   languageName: node
   linkType: soft
 
@@ -227,6 +325,12 @@ __metadata:
   languageName: node
   linkType: soft
 
+"@ourworldindata/types@link:../../../packages/@ourworldindata/types::locator=%40owid%2Fbespoke-income-plots%40workspace%3Aprojects%2Fincome-plots":
+  version: 0.0.0-use.local
+  resolution: "@ourworldindata/types@link:../../../packages/@ourworldindata/types::locator=%40owid%2Fbespoke-income-plots%40workspace%3Aprojects%2Fincome-plots"
+  languageName: node
+  linkType: soft
+
 "@ourworldindata/types@link:../../../packages/@ourworldindata/types::locator=%40owid%2Fbespoke-migration%40workspace%3Aprojects%2Fmigration":
   version: 0.0.0-use.local
   resolution: "@ourworldindata/types@link:../../../packages/@ourworldindata/types::locator=%40owid%2Fbespoke-migration%40workspace%3Aprojects%2Fmigration"
@@ -260,6 +364,12 @@ __metadata:
 "@ourworldindata/utils@link:../../../packages/@ourworldindata/utils::locator=%40owid%2Fbespoke-food-trade%40workspace%3Aprojects%2Ffood-trade":
   version: 0.0.0-use.local
   resolution: "@ourworldindata/utils@link:../../../packages/@ourworldindata/utils::locator=%40owid%2Fbespoke-food-trade%40workspace%3Aprojects%2Ffood-trade"
+  languageName: node
+  linkType: soft
+
+"@ourworldindata/utils@link:../../../packages/@ourworldindata/utils::locator=%40owid%2Fbespoke-income-plots%40workspace%3Aprojects%2Fincome-plots":
+  version: 0.0.0-use.local
+  resolution: "@ourworldindata/utils@link:../../../packages/@ourworldindata/utils::locator=%40owid%2Fbespoke-income-plots%40workspace%3Aprojects%2Fincome-plots"
   languageName: node
   linkType: soft
 
@@ -466,6 +576,42 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@owid/bespoke-income-plots@workspace:projects/income-plots":
+  version: 0.0.0-use.local
+  resolution: "@owid/bespoke-income-plots@workspace:projects/income-plots"
+  dependencies:
+    "@floating-ui/react": "npm:^0.27.16"
+    "@fortawesome/fontawesome-svg-core": "npm:^6.7.2"
+    "@fortawesome/free-solid-svg-icons": "npm:^6.7.2"
+    "@fortawesome/react-fontawesome": "npm:^0.2.2"
+    "@ourworldindata/components": "link:../../../packages/@ourworldindata/components"
+    "@ourworldindata/types": "link:../../../packages/@ourworldindata/types"
+    "@ourworldindata/utils": "link:../../../packages/@ourworldindata/utils"
+    "@react-stately/flags": "npm:^3.2.0"
+    "@rollup/plugin-swc": "npm:^0.4.0"
+    "@swc/core": "npm:^1.15.33"
+    "@types/d3": "npm:^7.4.3"
+    "@types/react": "npm:^19.2.14"
+    "@types/react-dom": "npm:^19.2.3"
+    "@typescript/native-preview": "npm:^7.0.0-dev.20260408.1"
+    "@vitejs/plugin-react": "npm:^6.0.0"
+    classnames: "npm:^2.5.1"
+    d3: "npm:^7.9.0"
+    fast-kde: "npm:^0.2.2"
+    jotai: "npm:^2.20.0"
+    jotai-effect: "npm:^2.3.1"
+    react: "npm:^19.2.4"
+    react-aria: "npm:^3.48.0"
+    react-aria-components: "npm:^1.17.0"
+    react-dom: "npm:^19.2.4"
+    remeda: "npm:^2.32.0"
+    sass: "npm:^1.87.0"
+    usehooks-ts: "npm:^3.1.1"
+    vite: "npm:^8.0.5"
+    vite-plugin-css-position: "npm:^2.0.9"
+  languageName: unknown
+  linkType: soft
+
 "@owid/bespoke-migration@workspace:projects/migration":
   version: 0.0.0-use.local
   resolution: "@owid/bespoke-migration@workspace:projects/migration"
@@ -514,6 +660,13 @@ __metadata:
   version: 0.133.0
   resolution: "@oxc-project/types@npm:0.133.0"
   checksum: 10/de44f653a9e0c0267309122f1f184120c6869af4382218a6bf4a320c5150743eb00b5e8641b04917666281995ed0fe6381561922a48a28082a75bb122acf3ac6
+  languageName: node
+  linkType: hard
+
+"@oxc-project/types@npm:=0.139.0":
+  version: 0.139.0
+  resolution: "@oxc-project/types@npm:0.139.0"
+  checksum: 10/7f5e958bf700c1777737f0b27fe2a207fd9ff6494e2ec7529d20d7b1d2c668f7687182d490e72d59a58dd9c176f7cacc3938e824b3e664e4d6e5ce4e0ff44872
   languageName: node
   linkType: hard
 
@@ -668,7 +821,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-stately/flags@npm:^3.2.1":
+"@react-stately/flags@npm:^3.2.0, @react-stately/flags@npm:^3.2.1":
   version: 3.2.1
   resolution: "@react-stately/flags@npm:3.2.1"
   dependencies:
@@ -690,9 +843,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-types/shared@npm:^3.36.0":
+  version: 3.36.0
+  resolution: "@react-types/shared@npm:3.36.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/07807eb7e8878abea313206861f81ba91a183d3d8e7eda67a0add23aec4c104018b0d23810ca99f4e647e95cd03dc26796ce1824368d106d66024503542b66ec
+  languageName: node
+  linkType: hard
+
 "@rolldown/binding-android-arm64@npm:1.0.3":
   version: 1.0.3
   resolution: "@rolldown/binding-android-arm64@npm:1.0.3"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-android-arm64@npm:1.1.5":
+  version: 1.1.5
+  resolution: "@rolldown/binding-android-arm64@npm:1.1.5"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
@@ -704,9 +873,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/binding-darwin-arm64@npm:1.1.5":
+  version: 1.1.5
+  resolution: "@rolldown/binding-darwin-arm64@npm:1.1.5"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@rolldown/binding-darwin-x64@npm:1.0.3":
   version: 1.0.3
   resolution: "@rolldown/binding-darwin-x64@npm:1.0.3"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-darwin-x64@npm:1.1.5":
+  version: 1.1.5
+  resolution: "@rolldown/binding-darwin-x64@npm:1.1.5"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
@@ -718,9 +901,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/binding-freebsd-x64@npm:1.1.5":
+  version: 1.1.5
+  resolution: "@rolldown/binding-freebsd-x64@npm:1.1.5"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@rolldown/binding-linux-arm-gnueabihf@npm:1.0.3":
   version: 1.0.3
   resolution: "@rolldown/binding-linux-arm-gnueabihf@npm:1.0.3"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-arm-gnueabihf@npm:1.1.5":
+  version: 1.1.5
+  resolution: "@rolldown/binding-linux-arm-gnueabihf@npm:1.1.5"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
@@ -732,9 +929,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/binding-linux-arm64-gnu@npm:1.1.5":
+  version: 1.1.5
+  resolution: "@rolldown/binding-linux-arm64-gnu@npm:1.1.5"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@rolldown/binding-linux-arm64-musl@npm:1.0.3":
   version: 1.0.3
   resolution: "@rolldown/binding-linux-arm64-musl@npm:1.0.3"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-arm64-musl@npm:1.1.5":
+  version: 1.1.5
+  resolution: "@rolldown/binding-linux-arm64-musl@npm:1.1.5"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
@@ -746,9 +957,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/binding-linux-ppc64-gnu@npm:1.1.5":
+  version: 1.1.5
+  resolution: "@rolldown/binding-linux-ppc64-gnu@npm:1.1.5"
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@rolldown/binding-linux-s390x-gnu@npm:1.0.3":
   version: 1.0.3
   resolution: "@rolldown/binding-linux-s390x-gnu@npm:1.0.3"
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-s390x-gnu@npm:1.1.5":
+  version: 1.1.5
+  resolution: "@rolldown/binding-linux-s390x-gnu@npm:1.1.5"
   conditions: os=linux & cpu=s390x & libc=glibc
   languageName: node
   linkType: hard
@@ -760,6 +985,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/binding-linux-x64-gnu@npm:1.1.5":
+  version: 1.1.5
+  resolution: "@rolldown/binding-linux-x64-gnu@npm:1.1.5"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@rolldown/binding-linux-x64-musl@npm:1.0.3":
   version: 1.0.3
   resolution: "@rolldown/binding-linux-x64-musl@npm:1.0.3"
@@ -767,9 +999,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/binding-linux-x64-musl@npm:1.1.5":
+  version: 1.1.5
+  resolution: "@rolldown/binding-linux-x64-musl@npm:1.1.5"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
 "@rolldown/binding-openharmony-arm64@npm:1.0.3":
   version: 1.0.3
   resolution: "@rolldown/binding-openharmony-arm64@npm:1.0.3"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-openharmony-arm64@npm:1.1.5":
+  version: 1.1.5
+  resolution: "@rolldown/binding-openharmony-arm64@npm:1.1.5"
   conditions: os=openharmony & cpu=arm64
   languageName: node
   linkType: hard
@@ -785,9 +1031,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/binding-wasm32-wasi@npm:1.1.5":
+  version: 1.1.5
+  resolution: "@rolldown/binding-wasm32-wasi@npm:1.1.5"
+  dependencies:
+    "@emnapi/core": "npm:1.11.1"
+    "@emnapi/runtime": "npm:1.11.1"
+    "@napi-rs/wasm-runtime": "npm:^1.1.6"
+  conditions: cpu=wasm32
+  languageName: node
+  linkType: hard
+
 "@rolldown/binding-win32-arm64-msvc@npm:1.0.3":
   version: 1.0.3
   resolution: "@rolldown/binding-win32-arm64-msvc@npm:1.0.3"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-win32-arm64-msvc@npm:1.1.5":
+  version: 1.1.5
+  resolution: "@rolldown/binding-win32-arm64-msvc@npm:1.1.5"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
@@ -799,14 +1063,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/pluginutils@npm:^1.0.0":
+"@rolldown/binding-win32-x64-msvc@npm:1.1.5":
+  version: 1.1.5
+  resolution: "@rolldown/binding-win32-x64-msvc@npm:1.1.5"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rolldown/pluginutils@npm:^1.0.0, @rolldown/pluginutils@npm:^1.0.1":
   version: 1.0.1
   resolution: "@rolldown/pluginutils@npm:1.0.1"
   checksum: 10/4e95cf9ce23d75e5aa03ea0249cd86f7d1e21f83fbf6f8520e4edd8a251ba1b82c4ba9bc13cd24b6c4661daec6225b06e6d35c64c604e731b230b2a49af47d05
   languageName: node
   linkType: hard
 
-"@rollup/plugin-swc@npm:^0.4.1":
+"@rollup/plugin-swc@npm:^0.4.0, @rollup/plugin-swc@npm:^0.4.1":
   version: 0.4.1
   resolution: "@rollup/plugin-swc@npm:0.4.1"
   dependencies:
@@ -859,9 +1130,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@swc/core-darwin-arm64@npm:1.15.46":
+  version: 1.15.46
+  resolution: "@swc/core-darwin-arm64@npm:1.15.46"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@swc/core-darwin-x64@npm:1.15.41":
   version: 1.15.41
   resolution: "@swc/core-darwin-x64@npm:1.15.41"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@swc/core-darwin-x64@npm:1.15.46":
+  version: 1.15.46
+  resolution: "@swc/core-darwin-x64@npm:1.15.46"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
@@ -873,9 +1158,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@swc/core-linux-arm-gnueabihf@npm:1.15.46":
+  version: 1.15.46
+  resolution: "@swc/core-linux-arm-gnueabihf@npm:1.15.46"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
 "@swc/core-linux-arm64-gnu@npm:1.15.41":
   version: 1.15.41
   resolution: "@swc/core-linux-arm64-gnu@npm:1.15.41"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@swc/core-linux-arm64-gnu@npm:1.15.46":
+  version: 1.15.46
+  resolution: "@swc/core-linux-arm64-gnu@npm:1.15.46"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
@@ -887,9 +1186,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@swc/core-linux-arm64-musl@npm:1.15.46":
+  version: 1.15.46
+  resolution: "@swc/core-linux-arm64-musl@npm:1.15.46"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
 "@swc/core-linux-ppc64-gnu@npm:1.15.41":
   version: 1.15.41
   resolution: "@swc/core-linux-ppc64-gnu@npm:1.15.41"
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@swc/core-linux-ppc64-gnu@npm:1.15.46":
+  version: 1.15.46
+  resolution: "@swc/core-linux-ppc64-gnu@npm:1.15.46"
   conditions: os=linux & cpu=ppc64 & libc=glibc
   languageName: node
   linkType: hard
@@ -901,9 +1214,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@swc/core-linux-s390x-gnu@npm:1.15.46":
+  version: 1.15.46
+  resolution: "@swc/core-linux-s390x-gnu@npm:1.15.46"
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@swc/core-linux-x64-gnu@npm:1.15.41":
   version: 1.15.41
   resolution: "@swc/core-linux-x64-gnu@npm:1.15.41"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@swc/core-linux-x64-gnu@npm:1.15.46":
+  version: 1.15.46
+  resolution: "@swc/core-linux-x64-gnu@npm:1.15.46"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
@@ -915,9 +1242,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@swc/core-linux-x64-musl@npm:1.15.46":
+  version: 1.15.46
+  resolution: "@swc/core-linux-x64-musl@npm:1.15.46"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
 "@swc/core-win32-arm64-msvc@npm:1.15.41":
   version: 1.15.41
   resolution: "@swc/core-win32-arm64-msvc@npm:1.15.41"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@swc/core-win32-arm64-msvc@npm:1.15.46":
+  version: 1.15.46
+  resolution: "@swc/core-win32-arm64-msvc@npm:1.15.46"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
@@ -929,10 +1270,76 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@swc/core-win32-ia32-msvc@npm:1.15.46":
+  version: 1.15.46
+  resolution: "@swc/core-win32-ia32-msvc@npm:1.15.46"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
 "@swc/core-win32-x64-msvc@npm:1.15.41":
   version: 1.15.41
   resolution: "@swc/core-win32-x64-msvc@npm:1.15.41"
   conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@swc/core-win32-x64-msvc@npm:1.15.46":
+  version: 1.15.46
+  resolution: "@swc/core-win32-x64-msvc@npm:1.15.46"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@swc/core@npm:^1.15.33":
+  version: 1.15.46
+  resolution: "@swc/core@npm:1.15.46"
+  dependencies:
+    "@swc/core-darwin-arm64": "npm:1.15.46"
+    "@swc/core-darwin-x64": "npm:1.15.46"
+    "@swc/core-linux-arm-gnueabihf": "npm:1.15.46"
+    "@swc/core-linux-arm64-gnu": "npm:1.15.46"
+    "@swc/core-linux-arm64-musl": "npm:1.15.46"
+    "@swc/core-linux-ppc64-gnu": "npm:1.15.46"
+    "@swc/core-linux-s390x-gnu": "npm:1.15.46"
+    "@swc/core-linux-x64-gnu": "npm:1.15.46"
+    "@swc/core-linux-x64-musl": "npm:1.15.46"
+    "@swc/core-win32-arm64-msvc": "npm:1.15.46"
+    "@swc/core-win32-ia32-msvc": "npm:1.15.46"
+    "@swc/core-win32-x64-msvc": "npm:1.15.46"
+    "@swc/counter": "npm:^0.1.3"
+    "@swc/types": "npm:^0.1.27"
+  peerDependencies:
+    "@swc/helpers": ">=0.5.17"
+  dependenciesMeta:
+    "@swc/core-darwin-arm64":
+      optional: true
+    "@swc/core-darwin-x64":
+      optional: true
+    "@swc/core-linux-arm-gnueabihf":
+      optional: true
+    "@swc/core-linux-arm64-gnu":
+      optional: true
+    "@swc/core-linux-arm64-musl":
+      optional: true
+    "@swc/core-linux-ppc64-gnu":
+      optional: true
+    "@swc/core-linux-s390x-gnu":
+      optional: true
+    "@swc/core-linux-x64-gnu":
+      optional: true
+    "@swc/core-linux-x64-musl":
+      optional: true
+    "@swc/core-win32-arm64-msvc":
+      optional: true
+    "@swc/core-win32-ia32-msvc":
+      optional: true
+    "@swc/core-win32-x64-msvc":
+      optional: true
+  peerDependenciesMeta:
+    "@swc/helpers":
+      optional: true
+  checksum: 10/7345ee1a99729f0082bfe7988bada60c8390bc8642cb06d33514773a0ab1b6a350d0213538058daedbf964871e1056426971c7c1993c8da5d50c52b86c4b6371
   languageName: node
   linkType: hard
 
@@ -1013,6 +1420,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@swc/types@npm:^0.1.27":
+  version: 0.1.27
+  resolution: "@swc/types@npm:0.1.27"
+  dependencies:
+    "@swc/counter": "npm:^0.1.3"
+  checksum: 10/96b8161fbb3a151741c0b286a5886609219accc45c67b7cf946376c352d76e6c0fb11554d3e1daee3e55fe82156e8237b82245cda8e706f580d1c03272cfa29a
+  languageName: node
+  linkType: hard
+
 "@tanstack/query-core@npm:5.101.0":
   version: 5.101.0
   resolution: "@tanstack/query-core@npm:5.101.0"
@@ -1037,6 +1453,15 @@ __metadata:
   dependencies:
     tslib: "npm:^2.4.0"
   checksum: 10/d12f1dafe12d7a573c406b35ffef0038042b9cc9fbcc74d657267eb635499b956276afc05eebdbd81bea582e1c4c921421a1dd7243a93daaa8c8216b19395c23
+  languageName: node
+  linkType: hard
+
+"@tybys/wasm-util@npm:^0.10.3":
+  version: 0.10.3
+  resolution: "@tybys/wasm-util@npm:0.10.3"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10/6cf39f7a2926b1c8bc6fe3f9f03318a33dd6dae81bdbd059983f9c6ee22d10a827f12564d648c05a2d4926e03c86cbe2799fb20609ee65e9efc39603039b4765
   languageName: node
   linkType: hard
 
@@ -1462,12 +1887,93 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react@npm:^19.2.17":
+"@types/react@npm:^19.2.14, @types/react@npm:^19.2.17":
   version: 19.2.17
   resolution: "@types/react@npm:19.2.17"
   dependencies:
     csstype: "npm:^3.2.2"
   checksum: 10/8debb092bd0bb9c99176a31824c7587c27c775a6526b60060e7b9e8dc2af53aee2ffadc7a1e3845953792437db5699d34a9054e198c9d4e54a74728ff47c6725
+  languageName: node
+  linkType: hard
+
+"@typescript/native-preview-darwin-arm64@npm:7.0.0-dev.20260707.2":
+  version: 7.0.0-dev.20260707.2
+  resolution: "@typescript/native-preview-darwin-arm64@npm:7.0.0-dev.20260707.2"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@typescript/native-preview-darwin-x64@npm:7.0.0-dev.20260707.2":
+  version: 7.0.0-dev.20260707.2
+  resolution: "@typescript/native-preview-darwin-x64@npm:7.0.0-dev.20260707.2"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@typescript/native-preview-linux-arm64@npm:7.0.0-dev.20260707.2":
+  version: 7.0.0-dev.20260707.2
+  resolution: "@typescript/native-preview-linux-arm64@npm:7.0.0-dev.20260707.2"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@typescript/native-preview-linux-arm@npm:7.0.0-dev.20260707.2":
+  version: 7.0.0-dev.20260707.2
+  resolution: "@typescript/native-preview-linux-arm@npm:7.0.0-dev.20260707.2"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@typescript/native-preview-linux-x64@npm:7.0.0-dev.20260707.2":
+  version: 7.0.0-dev.20260707.2
+  resolution: "@typescript/native-preview-linux-x64@npm:7.0.0-dev.20260707.2"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@typescript/native-preview-win32-arm64@npm:7.0.0-dev.20260707.2":
+  version: 7.0.0-dev.20260707.2
+  resolution: "@typescript/native-preview-win32-arm64@npm:7.0.0-dev.20260707.2"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@typescript/native-preview-win32-x64@npm:7.0.0-dev.20260707.2":
+  version: 7.0.0-dev.20260707.2
+  resolution: "@typescript/native-preview-win32-x64@npm:7.0.0-dev.20260707.2"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@typescript/native-preview@npm:^7.0.0-dev.20260408.1":
+  version: 7.0.0-dev.20260707.2
+  resolution: "@typescript/native-preview@npm:7.0.0-dev.20260707.2"
+  dependencies:
+    "@typescript/native-preview-darwin-arm64": "npm:7.0.0-dev.20260707.2"
+    "@typescript/native-preview-darwin-x64": "npm:7.0.0-dev.20260707.2"
+    "@typescript/native-preview-linux-arm": "npm:7.0.0-dev.20260707.2"
+    "@typescript/native-preview-linux-arm64": "npm:7.0.0-dev.20260707.2"
+    "@typescript/native-preview-linux-x64": "npm:7.0.0-dev.20260707.2"
+    "@typescript/native-preview-win32-arm64": "npm:7.0.0-dev.20260707.2"
+    "@typescript/native-preview-win32-x64": "npm:7.0.0-dev.20260707.2"
+  dependenciesMeta:
+    "@typescript/native-preview-darwin-arm64":
+      optional: true
+    "@typescript/native-preview-darwin-x64":
+      optional: true
+    "@typescript/native-preview-linux-arm":
+      optional: true
+    "@typescript/native-preview-linux-arm64":
+      optional: true
+    "@typescript/native-preview-linux-x64":
+      optional: true
+    "@typescript/native-preview-win32-arm64":
+      optional: true
+    "@typescript/native-preview-win32-x64":
+      optional: true
+  bin:
+    tsgo: bin/tsgo
+  checksum: 10/c0fa2e0326b205e5542bd063e85e34622d11db6c364f43d898e4f7473cc73dc40244b7616252f28d5e9ace71126bd09cc7c9eb3e26788fe20daa30091f77afcb
   languageName: node
   linkType: hard
 
@@ -1781,6 +2287,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vitejs/plugin-react@npm:^6.0.0":
+  version: 6.0.4
+  resolution: "@vitejs/plugin-react@npm:6.0.4"
+  dependencies:
+    "@rolldown/pluginutils": "npm:^1.0.1"
+  peerDependencies:
+    "@rolldown/plugin-babel": ^0.1.7 || ^0.2.0
+    babel-plugin-react-compiler: ^1.0.0
+    vite: ^8.0.0
+  peerDependenciesMeta:
+    "@rolldown/plugin-babel":
+      optional: true
+    babel-plugin-react-compiler:
+      optional: true
+  checksum: 10/f8995d3c543d6e554f7c71003f7d849529a148f3d0182a23fa3073a698847bf6618369b46799da785935086289721c612d666613da554b33a540108a0f6e249e
+  languageName: node
+  linkType: hard
+
 "@vitejs/plugin-react@npm:^6.0.2":
   version: 6.0.2
   resolution: "@vitejs/plugin-react@npm:6.0.2"
@@ -1941,7 +2465,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"classnames@npm:^2.3.1":
+"classnames@npm:^2.3.1, classnames@npm:^2.5.1":
   version: 2.5.1
   resolution: "classnames@npm:2.5.1"
   checksum: 10/58eb394e8817021b153bb6e7d782cfb667e4ab390cb2e9dac2fc7c6b979d1cc2b2a733093955fc5c94aa79ef5c8c89f11ab77780894509be6afbb91dddd79d15
@@ -2039,7 +2563,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"d3-color@npm:1 - 3, d3-color@npm:3, d3-color@npm:3.1.0":
+"d3-color@npm:1 - 3, d3-color@npm:3, d3-color@npm:3.1.0, d3-color@npm:^3.1.0":
   version: 3.1.0
   resolution: "d3-color@npm:3.1.0"
   checksum: 10/536ba05bfd9f4fcd6fa289b5974f5c846b21d186875684637e22bf6855e6aba93e24a2eb3712985c6af3f502fbbfa03708edb72f58142f626241a8a17258e545
@@ -2430,6 +2954,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fast-kde@npm:^0.2.2":
+  version: 0.2.2
+  resolution: "fast-kde@npm:0.2.2"
+  dependencies:
+    d3-color: "npm:^3.1.0"
+  checksum: 10/8310d60a076a2be2b117955bdcfdae5a1711adc926f9384404a1c513adc1e65803ffb1e43a7585cb6adff38d07a2c49bb39cf675257c5bf0d521dc11ae7d93a3
+  languageName: node
+  linkType: hard
+
 "fdir@npm:^6.5.0":
   version: 6.5.0
   resolution: "fdir@npm:6.5.0"
@@ -2518,6 +3051,36 @@ __metadata:
   version: 4.0.0
   resolution: "isexe@npm:4.0.0"
   checksum: 10/2ead327ef596042ef9c9ec5f236b316acfaedb87f4bb61b3c3d574fb2e9c8a04b67305e04733bde52c24d9622fdebd3270aadb632adfbf9cadef88fe30f479e5
+  languageName: node
+  linkType: hard
+
+"jotai-effect@npm:^2.3.1":
+  version: 2.4.1
+  resolution: "jotai-effect@npm:2.4.1"
+  peerDependencies:
+    jotai: ">=2.20.0 || >=3.0.0-alpha.0"
+  checksum: 10/55007beeddbf3b1dc82906bb75e654751309d91bbce9d75919108558dbdb6c566f5c186008e8769e3ab47977dd2a10be636858e5ac3a00f57e01c01d1ac46437
+  languageName: node
+  linkType: hard
+
+"jotai@npm:^2.20.0":
+  version: 2.20.2
+  resolution: "jotai@npm:2.20.2"
+  peerDependencies:
+    "@babel/core": ">=7.0.0"
+    "@babel/template": ">=7.0.0"
+    "@types/react": ">=17.0.0"
+    react: ">=17.0.0"
+  peerDependenciesMeta:
+    "@babel/core":
+      optional: true
+    "@babel/template":
+      optional: true
+    "@types/react":
+      optional: true
+    react:
+      optional: true
+  checksum: 10/110a4b6fa7ceb61b10400adfb13be5fe343ec477c883393ba5d7420b70c8b1d7eb1920eaa6f89a9fafd9faca3a06a15900542e28780a91b73403bd7fb5476099
   languageName: node
   linkType: hard
 
@@ -2676,6 +3239,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash.debounce@npm:^4.0.8":
+  version: 4.0.8
+  resolution: "lodash.debounce@npm:4.0.8"
+  checksum: 10/cd0b2819786e6e80cb9f5cda26b1a8fc073daaf04e48d4cb462fa4663ec9adb3a5387aa22d7129e48eed1afa05b482e2a6b79bfc99b86886364449500cbb00fd
+  languageName: node
+  linkType: hard
+
 "loose-envify@npm:^1.4.0":
   version: 1.4.0
   resolution: "loose-envify@npm:1.4.0"
@@ -2725,6 +3295,15 @@ __metadata:
   bin:
     nanoid: bin/nanoid.cjs
   checksum: 10/6eec280694e2088d18fb802b1e3bfc4578e27b665b7ecfbe36c7356612fea2f814277056e671e2a1529dff551588a652efdc0bfa39f8a3185bc2247be311872e
+  languageName: node
+  linkType: hard
+
+"nanoid@npm:^3.3.16":
+  version: 3.3.16
+  resolution: "nanoid@npm:3.3.16"
+  bin:
+    nanoid: bin/nanoid.cjs
+  checksum: 10/8004af92b5541af1dbd23b69845b5026f777d5b7ef07163cea1837aae86e052ced8b383cecbf8a4f1b5e77ae207df96dc45e16b9e0fa3c4b761d085f1e42851b
   languageName: node
   linkType: hard
 
@@ -2837,6 +3416,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"picomatch@npm:^4.0.5":
+  version: 4.0.5
+  resolution: "picomatch@npm:4.0.5"
+  checksum: 10/8bad770af9dcdb7f94ad1a893adcbe08a97d75a18872f8fed37161d3124217471c402b3929f051532f795f4ff2e53dcebb1644df4c1a5f3a9c476fef3b9f8c51
+  languageName: node
+  linkType: hard
+
 "postcss@npm:^8.5.15":
   version: 8.5.15
   resolution: "postcss@npm:8.5.15"
@@ -2845,6 +3431,17 @@ __metadata:
     picocolors: "npm:^1.1.1"
     source-map-js: "npm:^1.2.1"
   checksum: 10/d02ad19eb1e0fa53a1229ee6d53807eb88f903f2b9a8cac66993367f3ac7dd3b97238c783a54ccbf4145f82f6ca9a5cbd58f089846285d759c8a3259fbea8318
+  languageName: node
+  linkType: hard
+
+"postcss@npm:^8.5.17":
+  version: 8.5.23
+  resolution: "postcss@npm:8.5.23"
+  dependencies:
+    nanoid: "npm:^3.3.16"
+    picocolors: "npm:^1.1.1"
+    source-map-js: "npm:^1.2.1"
+  checksum: 10/8387f421216696bf62a13e5a270e9fefdafc81e196903c0f8d7653f8bab315367cc2261b3c22cf197e492cb075f31bdfc07fd9c3be1cb165ff3cabe14c5a039a
   languageName: node
   linkType: hard
 
@@ -2863,6 +3460,23 @@ __metadata:
     object-assign: "npm:^4.1.1"
     react-is: "npm:^16.13.1"
   checksum: 10/7d959caec002bc964c86cdc461ec93108b27337dabe6192fb97d69e16a0c799a03462713868b40749bfc1caf5f57ef80ac3e4ffad3effa636ee667582a75e2c0
+  languageName: node
+  linkType: hard
+
+"react-aria-components@npm:^1.17.0":
+  version: 1.19.0
+  resolution: "react-aria-components@npm:1.19.0"
+  dependencies:
+    "@internationalized/date": "npm:^3.12.2"
+    "@react-types/shared": "npm:^3.36.0"
+    "@swc/helpers": "npm:^0.5.0"
+    client-only: "npm:^0.0.1"
+    react-aria: "npm:3.50.0"
+    react-stately: "npm:3.48.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/60ea4bb611b621a78c4f0a9da4141b65679ffadef0990c32a6da16c769cd77b9e0efa5f4c87d0aac5693ca995a05e2c1a24b309b8a9c2f9704bcb91e3fd5f8c8
   languageName: node
   linkType: hard
 
@@ -2903,6 +3517,37 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-aria@npm:3.50.0, react-aria@npm:^3.48.0":
+  version: 3.50.0
+  resolution: "react-aria@npm:3.50.0"
+  dependencies:
+    "@internationalized/date": "npm:^3.12.2"
+    "@internationalized/number": "npm:^3.6.7"
+    "@internationalized/string": "npm:^3.2.9"
+    "@react-types/shared": "npm:^3.36.0"
+    "@swc/helpers": "npm:^0.5.0"
+    aria-hidden: "npm:^1.2.3"
+    clsx: "npm:^2.0.0"
+    react-stately: "npm:3.48.0"
+    use-sync-external-store: "npm:^1.6.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/6209fee37a1b92f5866f4ce90f34a7e6d793d7aab5195a6897d5f28d39fb4bdb7d6f67214c249666b4f67b4361a7319205a36e542994ea03b61da1ff04a020aa
+  languageName: node
+  linkType: hard
+
+"react-dom@npm:^19.2.4":
+  version: 19.2.8
+  resolution: "react-dom@npm:19.2.8"
+  dependencies:
+    scheduler: "npm:^0.27.0"
+  peerDependencies:
+    react: ^19.2.8
+  checksum: 10/fb45d500a8615a36d71a821213a3d4bfe32a70aa1d04ce17d8791dd10c4ef0281e7fdd46694e1112f0f2dcf58df89d12043a13228be9788458aa82f4885a9cdc
+  languageName: node
+  linkType: hard
+
 "react-dom@npm:^19.2.7":
   version: 19.2.7
   resolution: "react-dom@npm:19.2.7"
@@ -2934,6 +3579,29 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
   checksum: 10/be1d9a04b4c914abbddf0b99c0bfcab86eaf5d4ee5ce609d8798f9a53ae2e75778aad40ea3d13e5914c23a67311874b7754d90e02c2c0044768e5bbc1a7d8586
+  languageName: node
+  linkType: hard
+
+"react-stately@npm:3.48.0":
+  version: 3.48.0
+  resolution: "react-stately@npm:3.48.0"
+  dependencies:
+    "@internationalized/date": "npm:^3.12.2"
+    "@internationalized/number": "npm:^3.6.7"
+    "@internationalized/string": "npm:^3.2.9"
+    "@react-types/shared": "npm:^3.36.0"
+    "@swc/helpers": "npm:^0.5.0"
+    use-sync-external-store: "npm:^1.6.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/7400375b1c3a3909c5b02cd3d350ed0c46cd9c68600bb29cdccc179de825f170a5bae3bf11c927276e9fb2a293138f55c697d7ba0d14890bec828eeaedc75a7e
+  languageName: node
+  linkType: hard
+
+"react@npm:^19.2.4":
+  version: 19.2.8
+  resolution: "react@npm:19.2.8"
+  checksum: 10/a3c697798035e295ca9e51591d3a8700824535cb8c070fac1f8abbe69717ceb99108cbc4ba7b31a606806f336b1eba705705f63b9d39ace198fe51e8990ac843
   languageName: node
   linkType: hard
 
@@ -2971,7 +3639,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"remeda@npm:^2.39.0":
+"remeda@npm:^2.32.0, remeda@npm:^2.39.0":
   version: 2.39.0
   resolution: "remeda@npm:2.39.0"
   checksum: 10/5b0dc3aaf291a4b35c694bd1cd6584c1aeab90de31da47797c5e83f1cda2553a33cf557fe199d9a06c29814f608b808722ad82a51245e99f85df1b633f792258
@@ -3043,6 +3711,64 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rolldown@npm:~1.1.5":
+  version: 1.1.5
+  resolution: "rolldown@npm:1.1.5"
+  dependencies:
+    "@oxc-project/types": "npm:=0.139.0"
+    "@rolldown/binding-android-arm64": "npm:1.1.5"
+    "@rolldown/binding-darwin-arm64": "npm:1.1.5"
+    "@rolldown/binding-darwin-x64": "npm:1.1.5"
+    "@rolldown/binding-freebsd-x64": "npm:1.1.5"
+    "@rolldown/binding-linux-arm-gnueabihf": "npm:1.1.5"
+    "@rolldown/binding-linux-arm64-gnu": "npm:1.1.5"
+    "@rolldown/binding-linux-arm64-musl": "npm:1.1.5"
+    "@rolldown/binding-linux-ppc64-gnu": "npm:1.1.5"
+    "@rolldown/binding-linux-s390x-gnu": "npm:1.1.5"
+    "@rolldown/binding-linux-x64-gnu": "npm:1.1.5"
+    "@rolldown/binding-linux-x64-musl": "npm:1.1.5"
+    "@rolldown/binding-openharmony-arm64": "npm:1.1.5"
+    "@rolldown/binding-wasm32-wasi": "npm:1.1.5"
+    "@rolldown/binding-win32-arm64-msvc": "npm:1.1.5"
+    "@rolldown/binding-win32-x64-msvc": "npm:1.1.5"
+    "@rolldown/pluginutils": "npm:^1.0.0"
+  dependenciesMeta:
+    "@rolldown/binding-android-arm64":
+      optional: true
+    "@rolldown/binding-darwin-arm64":
+      optional: true
+    "@rolldown/binding-darwin-x64":
+      optional: true
+    "@rolldown/binding-freebsd-x64":
+      optional: true
+    "@rolldown/binding-linux-arm-gnueabihf":
+      optional: true
+    "@rolldown/binding-linux-arm64-gnu":
+      optional: true
+    "@rolldown/binding-linux-arm64-musl":
+      optional: true
+    "@rolldown/binding-linux-ppc64-gnu":
+      optional: true
+    "@rolldown/binding-linux-s390x-gnu":
+      optional: true
+    "@rolldown/binding-linux-x64-gnu":
+      optional: true
+    "@rolldown/binding-linux-x64-musl":
+      optional: true
+    "@rolldown/binding-openharmony-arm64":
+      optional: true
+    "@rolldown/binding-wasm32-wasi":
+      optional: true
+    "@rolldown/binding-win32-arm64-msvc":
+      optional: true
+    "@rolldown/binding-win32-x64-msvc":
+      optional: true
+  bin:
+    rolldown: ./bin/cli.mjs
+  checksum: 10/a2c90a68751591fe6e05952d3dc5c92e8cef18511568af43912fc95ebd2c1a1ee9650df9c998a6a66a2f5aa5e02853b66bbc255ab38ef62f86fa8af925a669f9
+  languageName: node
+  linkType: hard
+
 "root-workspace-0b6124@workspace:.":
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
@@ -3082,6 +3808,23 @@ __metadata:
   bin:
     sass: sass.js
   checksum: 10/d38ac48a0ca08bd37fdcdc3409aebde1da2bd3e8e9f9c3bff783720e6e9d4488f75e86c706c8bf01af6c2d5decdf31ecfb81b287627b81f191baf2f60037aa68
+  languageName: node
+  linkType: hard
+
+"sass@npm:^1.87.0":
+  version: 1.102.0
+  resolution: "sass@npm:1.102.0"
+  dependencies:
+    "@parcel/watcher": "npm:^2.4.1"
+    chokidar: "npm:^5.0.0"
+    immutable: "npm:^5.1.5"
+    source-map-js: "npm:>=0.6.2 <2.0.0"
+  dependenciesMeta:
+    "@parcel/watcher":
+      optional: true
+  bin:
+    sass: sass.js
+  checksum: 10/c69c254db64274778cc2a7f00a0fd92c0c53b9c3d25e0e8e7cf8c18788ff998c1e51e1e16198a62f58513c8c406ecc2bb61c4f29f05a0f7109c2f26700161137
   languageName: node
   linkType: hard
 
@@ -3133,6 +3876,13 @@ __metadata:
   version: 4.1.0
   resolution: "std-env@npm:4.1.0"
   checksum: 10/008146cdb834010383138d356e0dd3e3b0ac127a8229f711b8c518bb22940813cc0dcd654fc76b17f0b18179f56089f8b8e52bd6a7ffa0041a966581e7a44dbe
+  languageName: node
+  linkType: hard
+
+"tabbable@npm:^6.0.0":
+  version: 6.5.0
+  resolution: "tabbable@npm:6.5.0"
+  checksum: 10/c3b37430dd1a9f1c3a413b46d0598e3af55588959d4c386eeb1910a82632ac45cb6ed237902353e38e2a956326286773621cf5b8dca6d82c76da441918f8c718
   languageName: node
   linkType: hard
 
@@ -3361,6 +4111,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"usehooks-ts@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "usehooks-ts@npm:3.1.1"
+  dependencies:
+    lodash.debounce: "npm:^4.0.8"
+  peerDependencies:
+    react: ^16.8.0  || ^17 || ^18 || ^19 || ^19.0.0-rc
+  checksum: 10/4f5d6beab003d76f90c6a9b8b0cd5b61f24528fa3dbbf1a6d9c0a509cb80914074af911a92dab0bc07873f14f714771306f5271e1e8f09b94add1722da37debb
+  languageName: node
+  linkType: hard
+
 "vite-plugin-css-injected-by-js@npm:^3.5.2":
   version: 3.5.2
   resolution: "vite-plugin-css-injected-by-js@npm:3.5.2"
@@ -3444,6 +4205,63 @@ __metadata:
   bin:
     vite: bin/vite.js
   checksum: 10/a5d91d26f6110672a292a06ca161af9a58279fe9d27106c8c0afb725a942b0b47091c440c3b1e7ebc8e0fe901f64ac6a2ffee3cdae2f899339686dbecd0c0266
+  languageName: node
+  linkType: hard
+
+"vite@npm:^8.0.5":
+  version: 8.1.5
+  resolution: "vite@npm:8.1.5"
+  dependencies:
+    fsevents: "npm:~2.3.3"
+    lightningcss: "npm:^1.32.0"
+    picomatch: "npm:^4.0.5"
+    postcss: "npm:^8.5.17"
+    rolldown: "npm:~1.1.5"
+    tinyglobby: "npm:^0.2.17"
+  peerDependencies:
+    "@types/node": ^20.19.0 || >=22.12.0
+    "@vitejs/devtools": ^0.3.0
+    esbuild: ^0.27.0 || ^0.28.0
+    jiti: ">=1.21.0"
+    less: ^4.0.0
+    sass: ^1.70.0
+    sass-embedded: ^1.70.0
+    stylus: ">=0.54.8"
+    sugarss: ^5.0.0
+    terser: ^5.16.0
+    tsx: ^4.8.1
+    yaml: ^2.4.2
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+    "@vitejs/devtools":
+      optional: true
+    esbuild:
+      optional: true
+    jiti:
+      optional: true
+    less:
+      optional: true
+    sass:
+      optional: true
+    sass-embedded:
+      optional: true
+    stylus:
+      optional: true
+    sugarss:
+      optional: true
+    terser:
+      optional: true
+    tsx:
+      optional: true
+    yaml:
+      optional: true
+  bin:
+    vite: bin/vite.js
+  checksum: 10/7278baa0723097a181566a46050f8218bb2c57c559cb68494709b6eb9a9eb332bfbc8fb3638857300eeaedbae37343e131e323da9ebda157e5f9ccfc48eefe02
   languageName: node
   linkType: hard
 

--- a/packages/@ourworldindata/types/src/domainTypes/Various.ts
+++ b/packages/@ourworldindata/types/src/domainTypes/Various.ts
@@ -40,6 +40,7 @@ export enum SiteFooterContext {
     searchPage = "search-page",
     subscribePage = "subscribe-page",
     slideshowPage = "slideshow-page",
+    featuredVizPage = "featured-viz-page",
 }
 
 export interface GitCommit {

--- a/site/SiteResources.tsx
+++ b/site/SiteResources.tsx
@@ -10,6 +10,9 @@ export const SiteResources = () => {
                 <a href="/explorers">Data Explorers</a>
             </li>
             <li>
+                <a href="/featured-viz">Featured Visualizations</a>
+            </li>
+            <li>
                 <a href="/sdgs">SDG Tracker</a>
             </li>
             <li>

--- a/site/bespokeComponentRegistry.ts
+++ b/site/bespokeComponentRegistry.ts
@@ -29,4 +29,7 @@ export const BESPOKE_COMPONENT_REGISTRY: Record<
     migration: {
         scriptUrl: "/migration/index.js",
     },
+    "income-plots": {
+        scriptUrl: "/income-plots/index.js",
+    },
 }

--- a/site/featuredViz/FeaturedVizDashboard.tsx
+++ b/site/featuredViz/FeaturedVizDashboard.tsx
@@ -6,10 +6,7 @@ import {
     faUpRightFromSquare,
 } from "@fortawesome/free-solid-svg-icons"
 import { BespokeComponent } from "../gdocs/components/BespokeComponent.js"
-import {
-    FEATURED_VIZ_ITEMS,
-    FeaturedVizItem,
-} from "./featuredVizContent.js"
+import { FEATURED_VIZ_ITEMS, FeaturedVizItem } from "./featuredVizContent.js"
 
 export const FEATURED_VIZ_PAGE_ROOT_ID = "featured-viz-page-root"
 
@@ -108,10 +105,10 @@ export const FeaturedVizDashboard = () => {
                     <h1 className="h1-semibold">Featured visualizations</h1>
                     <p className="featured-viz-page__subtitle subtitle-1">
                         Some questions need more than a standard chart. These
-                        interactive visualizations were custom-built by our
-                        team to let you explore the data behind big global
-                        questions — every one of them is live on this page, so
-                        dive in and play.
+                        interactive visualizations were custom-built by our team
+                        to let you explore the data behind big global questions
+                        — every one of them is live on this page, so dive in and
+                        play.
                     </p>
                     <nav
                         className="featured-viz-page__jump-nav"

--- a/site/featuredViz/FeaturedVizDashboard.tsx
+++ b/site/featuredViz/FeaturedVizDashboard.tsx
@@ -1,0 +1,138 @@
+import cx from "clsx"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import {
+    faArrowRight,
+    faFlask,
+    faUpRightFromSquare,
+} from "@fortawesome/free-solid-svg-icons"
+import { BespokeComponent } from "../gdocs/components/BespokeComponent.js"
+import {
+    FEATURED_VIZ_ITEMS,
+    FeaturedVizItem,
+} from "./featuredVizContent.js"
+
+export const FEATURED_VIZ_PAGE_ROOT_ID = "featured-viz-page-root"
+
+const EMBED_LAYOUT_CLASSES: Record<string, string> = {
+    narrow: "col-start-5 span-cols-6 col-md-start-3 span-md-cols-10 span-sm-cols-12 col-sm-start-2",
+    wide: "col-start-4 span-cols-8 col-md-start-3 span-md-cols-10 span-sm-cols-12 col-sm-start-2",
+    widest: "span-cols-12 col-start-2",
+}
+
+const formatAuthors = (authors: string[]): string => {
+    if (authors.length <= 1) return authors.join("")
+    return `${authors.slice(0, -1).join(", ")} and ${authors[authors.length - 1]}`
+}
+
+const FeaturedVizSection = ({ item }: { item: FeaturedVizItem }) => {
+    return (
+        <section
+            id={item.id}
+            className="featured-viz-page__section grid grid-cols-12-full-width"
+        >
+            <div className="featured-viz-page__section-header grid grid-cols-12 span-cols-12 col-start-2">
+                <div className="featured-viz-page__section-intro span-cols-7 span-md-cols-12">
+                    <span className="featured-viz-page__eyebrow overline-black-caps">
+                        {item.eyebrow}
+                    </span>
+                    <h2 className="h2-bold">
+                        {item.title}
+                        {item.draftPreviewUrl && (
+                            <span className="featured-viz-page__draft-badge">
+                                <FontAwesomeIcon icon={faFlask} />
+                                Work in progress
+                            </span>
+                        )}
+                    </h2>
+                    <p className="body-2-regular">{item.description}</p>
+                </div>
+                <div className="featured-viz-page__section-highlights span-cols-4 col-start-9 span-md-cols-12 col-md-start-1">
+                    <h3 className="overline-black-caps">Things to try</h3>
+                    <ul>
+                        {item.highlights.map((highlight) => (
+                            <li key={highlight.text}>
+                                <FontAwesomeIcon icon={highlight.icon} />
+                                <span>{highlight.text}</span>
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            </div>
+            <div
+                className={cx(
+                    "featured-viz-page__embed",
+                    EMBED_LAYOUT_CLASSES[item.block.size] ??
+                        EMBED_LAYOUT_CLASSES.widest
+                )}
+            >
+                <BespokeComponent block={item.block} />
+            </div>
+            <div className="featured-viz-page__section-footer span-cols-12 col-start-2">
+                <span className="featured-viz-page__authors body-3-medium">
+                    By {formatAuthors(item.authors)}
+                </span>
+                {item.articleUrl && (
+                    <a
+                        className="featured-viz-page__article-link body-3-medium"
+                        href={item.articleUrl}
+                        data-track-note="featured_viz_article_link"
+                    >
+                        Read the article
+                        <FontAwesomeIcon icon={faArrowRight} />
+                    </a>
+                )}
+                {item.draftPreviewUrl && (
+                    <a
+                        className="featured-viz-page__article-link body-3-medium"
+                        href={item.draftPreviewUrl}
+                        data-track-note="featured_viz_draft_link"
+                    >
+                        Preview the draft article (staging)
+                        <FontAwesomeIcon icon={faUpRightFromSquare} />
+                    </a>
+                )}
+            </div>
+        </section>
+    )
+}
+
+export const FeaturedVizDashboard = () => {
+    return (
+        <div className="featured-viz-page">
+            <header className="featured-viz-page__header grid grid-cols-12-full-width">
+                <div className="featured-viz-page__header-content span-cols-12 col-start-2">
+                    <div className="featured-viz-page__prototype-notice body-3-medium">
+                        <FontAwesomeIcon icon={faFlask} />
+                        Prototype — an internal preview, not a published page
+                    </div>
+                    <h1 className="h1-semibold">Featured visualizations</h1>
+                    <p className="featured-viz-page__subtitle subtitle-1">
+                        Some questions need more than a standard chart. These
+                        interactive visualizations were custom-built by our
+                        team to let you explore the data behind big global
+                        questions — every one of them is live on this page, so
+                        dive in and play.
+                    </p>
+                    <nav
+                        className="featured-viz-page__jump-nav"
+                        aria-label="Featured visualizations on this page"
+                    >
+                        <span className="overline-black-caps">
+                            On this page
+                        </span>
+                        <ul>
+                            {FEATURED_VIZ_ITEMS.map((item) => (
+                                <li key={item.id}>
+                                    <a href={`#${item.id}`}>{item.eyebrow}</a>
+                                </li>
+                            ))}
+                        </ul>
+                    </nav>
+                </div>
+            </header>
+            {FEATURED_VIZ_ITEMS.map((item) => (
+                <FeaturedVizSection item={item} key={item.id} />
+            ))}
+        </div>
+    )
+}

--- a/site/featuredViz/FeaturedVizPage.scss
+++ b/site/featuredViz/FeaturedVizPage.scss
@@ -1,0 +1,197 @@
+.featured-viz-page__header {
+    background-color: $blue-5;
+    border-bottom: 1px solid $blue-20;
+    padding: 32px 0 40px;
+}
+
+.featured-viz-page__prototype-notice {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 4px 12px;
+    margin-bottom: 16px;
+    border-radius: 24px;
+    background-color: $amber-10;
+    border: 1px solid $amber;
+    color: $blue-90;
+
+    svg {
+        color: $blue-60;
+    }
+}
+
+.featured-viz-page__header h1 {
+    margin: 0 0 8px;
+    color: $blue-90;
+}
+
+.featured-viz-page__subtitle {
+    margin: 0;
+    max-width: 48rem;
+    color: $blue-70;
+}
+
+.featured-viz-page__jump-nav {
+    margin-top: 24px;
+
+    .overline-black-caps {
+        display: block;
+        margin-bottom: 8px;
+        color: $blue-50;
+    }
+
+    ul {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+    }
+
+    a {
+        display: inline-block;
+        padding: 6px 16px;
+        border: 1px solid $blue-20;
+        border-radius: 24px;
+        background-color: $white;
+        color: $blue-90;
+        font-size: 0.875rem;
+        font-weight: 500;
+        text-decoration: none;
+
+        &:hover {
+            background-color: $blue-90;
+            border-color: $blue-90;
+            color: $white;
+        }
+    }
+}
+
+.featured-viz-page__section {
+    padding: 48px 0 40px;
+    scroll-margin-top: 16px;
+}
+
+.featured-viz-page__section + .featured-viz-page__section {
+    border-top: 1px solid $blue-20;
+}
+
+.featured-viz-page__eyebrow {
+    display: block;
+    margin-bottom: 8px;
+    color: $vermillion;
+}
+
+.featured-viz-page__section-intro h2 {
+    margin: 0 0 16px;
+    color: $blue-90;
+}
+
+.featured-viz-page__draft-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    vertical-align: middle;
+    margin-left: 12px;
+    padding: 4px 12px;
+    border-radius: 24px;
+    background-color: $amber-10;
+    border: 1px solid $amber;
+    color: $blue-90;
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    white-space: nowrap;
+
+    svg {
+        color: $blue-60;
+    }
+}
+
+.featured-viz-page__section-intro p {
+    margin: 0;
+    color: $blue-70;
+}
+
+.featured-viz-page__section-highlights {
+    .overline-black-caps {
+        display: block;
+        margin-bottom: 12px;
+        color: $blue-50;
+    }
+
+    ul {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+    }
+
+    li {
+        display: flex;
+        align-items: baseline;
+        gap: 12px;
+        padding: 8px 0;
+        color: $blue-90;
+        font-size: 0.875rem;
+        line-height: 1.4;
+    }
+
+    li + li {
+        border-top: 1px solid $gray-10;
+    }
+
+    svg {
+        flex-shrink: 0;
+        width: 14px;
+        color: $vermillion;
+    }
+
+    @include md-down {
+        margin-top: 24px;
+    }
+}
+
+.featured-viz-page__embed {
+    margin-top: 32px;
+    padding: 24px;
+    border: 1px solid $gray-20;
+    border-radius: 2px;
+    background-color: $white;
+    // Reserve space so the page doesn't jump around while the
+    // visualizations load in.
+    min-height: 480px;
+
+    @include sm-only {
+        padding: 8px;
+    }
+
+    .loading-indicator {
+        min-height: 432px;
+    }
+}
+
+.featured-viz-page__section-footer {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 8px 24px;
+    margin-top: 16px;
+}
+
+.featured-viz-page__authors {
+    color: $blue-50;
+}
+
+.featured-viz-page__article-link {
+    @include owid-link-90;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+
+    svg {
+        font-size: 0.75em;
+    }
+}

--- a/site/featuredViz/FeaturedVizPage.tsx
+++ b/site/featuredViz/FeaturedVizPage.tsx
@@ -1,0 +1,30 @@
+import { Head } from "../Head.js"
+import { Html } from "../Html.js"
+import { SiteHeader } from "../SiteHeader.js"
+import { SiteFooter } from "../SiteFooter.js"
+import { SiteFooterContext } from "@ourworldindata/types"
+import {
+    FEATURED_VIZ_PAGE_ROOT_ID,
+    FeaturedVizDashboard,
+} from "./FeaturedVizDashboard.js"
+
+export const FeaturedVizPage = ({ baseUrl }: { baseUrl: string }) => {
+    return (
+        <Html>
+            <Head
+                canonicalUrl={`${baseUrl}/featured-viz`}
+                pageTitle="Featured visualizations"
+                pageDesc="Custom-built interactive visualizations from the Our World in Data team."
+                baseUrl={baseUrl}
+                noindex
+            />
+            <body>
+                <SiteHeader />
+                <main id={FEATURED_VIZ_PAGE_ROOT_ID}>
+                    <FeaturedVizDashboard />
+                </main>
+                <SiteFooter context={SiteFooterContext.featuredVizPage} />
+            </body>
+        </Html>
+    )
+}

--- a/site/featuredViz/featuredVizContent.tsx
+++ b/site/featuredViz/featuredVizContent.tsx
@@ -1,0 +1,203 @@
+import { BlockSize, EnrichedBlockBespokeComponent } from "@ourworldindata/types"
+import { IconDefinition } from "@fortawesome/fontawesome-svg-core"
+import {
+    faMagnifyingGlass,
+    faRightLeft,
+    faArrowPointer,
+    faSliders,
+    faClockRotateLeft,
+    faLocationDot,
+    faLayerGroup,
+    faCoins,
+    faWheatAwn,
+    faChartLine,
+    faPersonWalkingArrowRight,
+} from "@fortawesome/free-solid-svg-icons"
+
+export interface FeaturedVizHighlight {
+    icon: IconDefinition
+    text: string
+}
+
+export interface FeaturedVizItem {
+    id: string
+    eyebrow: string
+    title: string
+    description: string
+    highlights: FeaturedVizHighlight[]
+    authors: string[]
+    /** Link to the published article, if there is one */
+    articleUrl?: string
+    /** For unpublished drafts: where to preview the work in progress */
+    draftPreviewUrl?: string
+    block: EnrichedBlockBespokeComponent
+}
+
+const makeBlock = (
+    bundle: string,
+    variant: string,
+    size: BlockSize,
+    config: Record<string, string> = {}
+): EnrichedBlockBespokeComponent => ({
+    type: "bespoke-component",
+    bundle,
+    variant,
+    size,
+    config,
+    parseErrors: [],
+})
+
+export const FEATURED_VIZ_ITEMS: FeaturedVizItem[] = [
+    {
+        id: "migration",
+        eyebrow: "Migration",
+        title: "Where do migrants live, and where were they born?",
+        description:
+            "Every country's migration story has two sides: the people who moved there, and the people who left. This flow diagram connects where the world's international migrants were born to where they live today, so you can see both sides at once.",
+        highlights: [
+            {
+                icon: faMagnifyingGlass,
+                text: "Search for any country to focus the diagram on its migrants",
+            },
+            {
+                icon: faPersonWalkingArrowRight,
+                text: "Switch the view between where people moved to and where they were born",
+            },
+            {
+                icon: faArrowPointer,
+                text: "Hover over any flow to see how many people it represents",
+            },
+        ],
+        authors: [
+            "Hannah Ritchie",
+            "Sophia Mersmann",
+            "Tuna Acisu",
+            "Marwa Boukarim",
+        ],
+        articleUrl: "/where-do-migrants-live-and-where-were-they-born",
+        block: makeBlock("migration", "sankey", BlockSize.Wide, {
+            country: "Malaysia",
+        }),
+    },
+    {
+        id: "causes-of-death",
+        eyebrow: "Global health",
+        title: "What do people die from in different countries?",
+        description:
+            "An interactive treemap of causes of death, where every rectangle is sized by its share of deaths. Compare the whole world with individual countries and income groups, and see how the picture has shifted over more than four decades.",
+        highlights: [
+            {
+                icon: faLayerGroup,
+                text: "Switch between the world, regions, income groups, and individual countries",
+            },
+            {
+                icon: faSliders,
+                text: "Break the data down by age group and sex",
+            },
+            {
+                icon: faClockRotateLeft,
+                text: "Scrub through the decades with the time slider",
+            },
+            {
+                icon: faArrowPointer,
+                text: "Hover over any cause to see the number of deaths and its share",
+            },
+        ],
+        authors: ["Hannah Ritchie", "Sophia Mersmann", "Fiona Spooner"],
+        articleUrl: "/what-do-people-die-from-in-different-countries",
+        block: makeBlock("causes-of-death", "treemap", BlockSize.Wide),
+    },
+    {
+        id: "food-trade",
+        eyebrow: "Food & agriculture",
+        title: "How does food get traded around the world?",
+        description:
+            "Much of the food we eat was grown somewhere else. This flow diagram follows food from the countries that export it to the countries that import it — for the world as a whole, for a single product, or for one country's entire food trade.",
+        highlights: [
+            {
+                icon: faWheatAwn,
+                text: "Pick a product — soybeans, coffee, wheat — and see who exports and imports it",
+            },
+            {
+                icon: faRightLeft,
+                text: "Focus on one country and flip between its exports and its imports",
+            },
+            {
+                icon: faArrowPointer,
+                text: "Hover over a flow to see how much food it carries",
+            },
+        ],
+        authors: [
+            "Hannah Ritchie",
+            "Sophia Mersmann",
+            "Pablo Rosado",
+            "Marwa Boukarim",
+        ],
+        articleUrl: "/how-does-food-get-traded-around-the-world",
+        block: makeBlock("food-trade", "sankey", BlockSize.Wide),
+    },
+    {
+        id: "population-simulation",
+        eyebrow: "Population & demography",
+        title: "How will populations change in the 21st century?",
+        description:
+            "A population simulator built on the same approach as the UN's projections. Set the fertility rate, life expectancy, and migration yourself, and watch how a country's population — and its age structure — responds over the rest of the century.",
+        highlights: [
+            {
+                icon: faLocationDot,
+                text: "Starts with the country you're in — or pick any other",
+            },
+            {
+                icon: faSliders,
+                text: "Drag the fertility, life expectancy, and migration sliders to build your own scenario",
+            },
+            {
+                icon: faChartLine,
+                text: "Compare your scenario against the UN's projections as it unfolds",
+            },
+        ],
+        authors: ["Sophia Mersmann", "Daniel Bachler", "Hannah Ritchie"],
+        articleUrl: "/population-simulation-tool",
+        block: makeBlock("demography", "simulation", BlockSize.Widest, {
+            region: "userLocation",
+        }),
+    },
+    {
+        id: "global-inequality",
+        eyebrow: "Economic inequality",
+        title: "Visualizing global inequality",
+        description:
+            "Every country's income distribution, stacked into one global picture based on the World Bank's global income data. It makes visible the large inequalities that exist both within and between countries — at the same time.",
+        highlights: [
+            {
+                icon: faLayerGroup,
+                text: "Switch between the global picture and country-by-country comparisons",
+            },
+            {
+                icon: faMagnifyingGlass,
+                text: "Add your own country and see how its income distribution compares",
+            },
+            {
+                icon: faArrowPointer,
+                text: "Click anywhere in the plot to see the share of people below that income",
+            },
+            {
+                icon: faCoins,
+                text: "View incomes in international dollars or your local currency",
+            },
+        ],
+        authors: [
+            "Joe Hasell",
+            "Marcel Gerber",
+            "Pablo Arriagada",
+            "Bertha Rohenkohl",
+            "Marwa Boukarim",
+        ],
+        draftPreviewUrl:
+            "http://staging-site-staging-server-bespoke/admin/gdocs/1AjxhGRu0vXIdIILbYAGniU0Wu-0lmQTUYMbEWRZaqA8/preview",
+        block: makeBlock("income-plots", "distribution", BlockSize.Widest, {
+            tab: "global",
+            isolateState: "true",
+        }),
+    },
+]

--- a/site/gdocs/pages/Homepage.tsx
+++ b/site/gdocs/pages/Homepage.tsx
@@ -1,75 +1,30 @@
 import * as React from "react"
 import { ArticleBlocks } from "../components/ArticleBlocks.js"
 import { OwidGdocHomepageContent } from "@ourworldindata/types"
-import { getAllChildrenOfArea } from "@ourworldindata/utils"
-import { AttachmentsContext } from "../AttachmentsContext.js"
+import { HomepageTopicAreas } from "./HomepageTopicAreas.js"
 
 export interface HomepageProps {
     content: OwidGdocHomepageContent
 }
 
-const AllTopicsSection = () => {
-    const { homepageMetadata } = React.useContext(AttachmentsContext)
-    if (!homepageMetadata) return null
-    const { tagGraph } = homepageMetadata
-    if (!tagGraph) return null
-
-    // We have to flatten the areas because we can't nest <ul> elements and have them render correctly
-    // Filter to only include topics (tags with slugs) - searchable non-topic tags shouldn't appear here
-    const flattenedAreas = tagGraph.children.map((area) => ({
-        ...area,
-        children: getAllChildrenOfArea(area).filter((topic) => topic.isTopic),
-    }))
-
-    return (
-        <section
-            id="all-topics"
-            className="grid grid-cols-12-full-width span-cols-14 homepage-topics-section"
-        >
-            <h2 className="h2-bold span-cols-12 col-start-2">All our topics</h2>
-            <p className="body-2-regular span-cols-12 col-start-2">
-                All our data, research, and writing — topic by topic.
-            </p>
-            {flattenedAreas.map((area) => (
-                <section
-                    key={area.name}
-                    className="homepage-topic span-cols-12 col-start-2"
-                >
-                    <h2 className="homepage-topic__topic-name h3-bold">
-                        {area.name}
-                    </h2>
-                    <ul className="homepage-topic__topic-list display-3-regular">
-                        {area.children.map(({ slug, name }) =>
-                            slug ? (
-                                <li
-                                    className="homepage-topic__topic-entry"
-                                    key={`topic-entry-${slug}`}
-                                >
-                                    <a href={`/${slug}`}>{name}</a>
-                                </li>
-                            ) : (
-                                <li
-                                    className="homepage-topic__subtopic"
-                                    key={`subarea-${name}`}
-                                >
-                                    {name}:
-                                </li>
-                            )
-                        )}
-                    </ul>
-                </section>
-            ))}
-        </section>
-    )
-}
+// Prototype: the "Explore the data" (key-indicator-collection) and "Data
+// explorers" (explorer-tiles) sections are replaced by the per-area sections
+// rendered by HomepageTopicAreas below.
+const HIDDEN_HOMEPAGE_BLOCK_TYPES = new Set([
+    "key-indicator-collection",
+    "explorer-tiles",
+])
 
 export const Homepage = (props: HomepageProps): React.ReactElement => {
     const { content } = props
+    const blocks = content.body.filter(
+        (block) => !HIDDEN_HOMEPAGE_BLOCK_TYPES.has(block.type)
+    )
 
     return (
         <div className="grid grid-cols-12-full-width">
-            <ArticleBlocks blocks={content.body} />
-            <AllTopicsSection />
+            <ArticleBlocks blocks={blocks} />
+            <HomepageTopicAreas />
         </div>
     )
 }

--- a/site/gdocs/pages/HomepageTopicAreas.scss
+++ b/site/gdocs/pages/HomepageTopicAreas.scss
@@ -1,0 +1,198 @@
+.homepage-topic-areas {
+    margin-top: 24px;
+}
+
+.homepage-topic-areas__header {
+    text-align: center;
+    margin-bottom: 8px;
+
+    h2 {
+        margin: 0 0 8px;
+        color: $blue-90;
+    }
+
+    p {
+        margin: 0 auto;
+        max-width: 48rem;
+        color: $blue-70;
+    }
+}
+
+.homepage-topic-area {
+    padding: 32px 0 40px;
+    border-top: 1px solid $blue-20;
+    margin-top: 24px;
+}
+
+.homepage-topic-area__name {
+    margin: 0 0 8px;
+    color: $blue-90;
+}
+
+.homepage-topic-area__embed {
+    margin: 16px 0 0;
+    padding: 16px 16px 8px;
+    border: 1px solid $gray-20;
+    border-radius: 2px;
+    background-color: $white;
+    // Reserve space so the page doesn't jump around while the
+    // visualizations load in.
+    min-height: 480px;
+
+    @include sm-only {
+        padding: 8px;
+    }
+
+    .loading-indicator {
+        min-height: 432px;
+    }
+}
+
+.homepage-topic-area__embed-caption {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    justify-content: flex-end;
+    gap: 8px 16px;
+    padding: 8px 0;
+    color: $blue-50;
+
+    a {
+        @include owid-link-90;
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+
+        svg {
+            font-size: 0.75em;
+        }
+    }
+}
+
+.homepage-topic-area__draft-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 2px 10px;
+    border-radius: 24px;
+    background-color: $amber-10;
+    border: 1px solid $amber;
+    color: $blue-90;
+    font-size: 0.6875rem;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    white-space: nowrap;
+
+    svg {
+        color: $blue-60;
+    }
+}
+
+.homepage-topic-area__links {
+    margin-top: 24px;
+
+    .overline-black-caps {
+        display: block;
+        margin-bottom: 8px;
+        color: $blue-50;
+    }
+}
+
+.homepage-topic-area__featured-list {
+    list-style: none;
+    margin: 0 0 24px;
+    padding: 0;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: var(--grid-gap, 24px);
+}
+
+.homepage-topic-area__featured-card {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    height: 100%;
+    padding: 16px;
+    border: 1px solid $blue-20;
+    background-color: $white;
+    color: $blue-90;
+    text-decoration: none;
+    transition: box-shadow 150ms;
+
+    &:hover {
+        box-shadow: 0 0 12px 0 rgba(49, 37, 2, 0.1);
+
+        .homepage-topic-area__featured-title {
+            text-decoration: underline;
+        }
+    }
+}
+
+.homepage-topic-area__featured-type {
+    font-size: 0.6875rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: $vermillion;
+}
+
+.homepage-topic-area__featured-title {
+    font-size: 0.9375rem;
+    font-weight: 500;
+    line-height: 1.35;
+
+    svg {
+        font-size: 0.75em;
+        margin-left: 6px;
+    }
+}
+
+.homepage-topic-area__topics ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.homepage-topic-area__topics a {
+    display: inline-block;
+    padding: 4px 14px;
+    border: 1px solid $blue-20;
+    border-radius: 24px;
+    background-color: $blue-5;
+    color: $blue-90;
+    font-size: 0.875rem;
+    font-weight: 500;
+    text-decoration: none;
+
+    &:hover {
+        background-color: $blue-90;
+        border-color: $blue-90;
+        color: $white;
+    }
+}
+
+.homepage-topic-area__topics-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 4px 14px;
+    border: none;
+    border-radius: 24px;
+    background: none;
+    color: $vermillion;
+    font-size: 0.875rem;
+    font-weight: 700;
+    cursor: pointer;
+
+    &:hover {
+        text-decoration: underline;
+    }
+
+    svg {
+        font-size: 0.75em;
+    }
+}

--- a/site/gdocs/pages/HomepageTopicAreas.tsx
+++ b/site/gdocs/pages/HomepageTopicAreas.tsx
@@ -1,0 +1,195 @@
+import * as React from "react"
+import cx from "clsx"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import {
+    faArrowRight,
+    faChevronDown,
+    faChevronUp,
+    faFlask,
+} from "@fortawesome/free-solid-svg-icons"
+import { TagGraphNode } from "@ourworldindata/types"
+import { getAllChildrenOfArea } from "@ourworldindata/utils"
+import { AttachmentsContext } from "../AttachmentsContext.js"
+import { BespokeComponent } from "../components/BespokeComponent.js"
+import {
+    HOMEPAGE_AREA_CONTENT,
+    HomepageFeaturedLink,
+} from "./homepageTopicAreasContent.js"
+
+const NUM_TOPICS_SHOWN_COLLAPSED = 6
+
+const EMBED_LAYOUT_CLASSES: Record<string, string> = {
+    narrow: "col-start-5 span-cols-6 col-md-start-3 span-md-cols-10 span-sm-cols-12 col-sm-start-2",
+    wide: "col-start-4 span-cols-8 col-md-start-3 span-md-cols-10 span-sm-cols-12 col-sm-start-2",
+    widest: "span-cols-12 col-start-2",
+}
+
+const FEATURED_LINK_TYPE_LABELS: Record<
+    HomepageFeaturedLink["type"],
+    string
+> = {
+    article: "Article",
+    explorer: "Data Explorer",
+    chart: "Interactive Chart",
+}
+
+const makeAreaId = (name: string): string =>
+    name
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-|-$/g, "")
+
+const TopicsList = ({
+    areaName,
+    topics,
+}: {
+    areaName: string
+    topics: TagGraphNode[]
+}) => {
+    const [isExpanded, setIsExpanded] = React.useState(false)
+    const visibleTopics = isExpanded
+        ? topics
+        : topics.slice(0, NUM_TOPICS_SHOWN_COLLAPSED)
+    const numHidden = topics.length - NUM_TOPICS_SHOWN_COLLAPSED
+
+    return (
+        <div className="homepage-topic-area__topics">
+            <h3 className="overline-black-caps">Topics</h3>
+            <ul>
+                {visibleTopics.map((topic) => (
+                    <li key={topic.slug}>
+                        <a
+                            href={`/${topic.slug}`}
+                            data-track-note="homepage_topic_area_topic"
+                        >
+                            {topic.name}
+                        </a>
+                    </li>
+                ))}
+                {numHidden > 0 && (
+                    <li>
+                        <button
+                            type="button"
+                            className="homepage-topic-area__topics-toggle"
+                            aria-expanded={isExpanded}
+                            onClick={() => setIsExpanded(!isExpanded)}
+                        >
+                            {isExpanded ? (
+                                <>
+                                    Show fewer topics
+                                    <FontAwesomeIcon icon={faChevronUp} />
+                                </>
+                            ) : (
+                                <>
+                                    See all {topics.length} topics in{" "}
+                                    {areaName.toLowerCase()}
+                                    <FontAwesomeIcon icon={faChevronDown} />
+                                </>
+                            )}
+                        </button>
+                    </li>
+                )}
+            </ul>
+        </div>
+    )
+}
+
+const FeaturedLinks = ({ links }: { links: HomepageFeaturedLink[] }) => {
+    if (!links.length) return null
+    return (
+        <div className="homepage-topic-area__featured">
+            <h3 className="overline-black-caps">Featured</h3>
+            <ul className="homepage-topic-area__featured-list">
+                {links.map((link) => (
+                    <li key={link.href}>
+                        <a
+                            className="homepage-topic-area__featured-card"
+                            href={link.href}
+                            data-track-note="homepage_topic_area_featured"
+                        >
+                            <span className="homepage-topic-area__featured-type">
+                                {FEATURED_LINK_TYPE_LABELS[link.type]}
+                            </span>
+                            <span className="homepage-topic-area__featured-title">
+                                {link.title}
+                                <FontAwesomeIcon icon={faArrowRight} />
+                            </span>
+                        </a>
+                    </li>
+                ))}
+            </ul>
+        </div>
+    )
+}
+
+const TopicAreaSection = ({ area }: { area: TagGraphNode }) => {
+    const content = HOMEPAGE_AREA_CONTENT[area.name]
+    const topics = getAllChildrenOfArea(area).filter(
+        (topic) => topic.isTopic && topic.slug
+    )
+    const embed = content?.embed
+
+    return (
+        <section
+            id={makeAreaId(area.name)}
+            className="homepage-topic-area grid grid-cols-12-full-width span-cols-14"
+        >
+            <h2 className="homepage-topic-area__name h2-bold span-cols-12 col-start-2">
+                {area.name}
+            </h2>
+            {embed && (
+                <figure
+                    className={cx(
+                        "homepage-topic-area__embed",
+                        EMBED_LAYOUT_CLASSES[embed.block.size] ??
+                            EMBED_LAYOUT_CLASSES.widest
+                    )}
+                >
+                    <BespokeComponent block={embed.block} />
+                    <figcaption className="homepage-topic-area__embed-caption body-3-medium">
+                        {embed.isDraft && (
+                            <span className="homepage-topic-area__draft-badge">
+                                <FontAwesomeIcon icon={faFlask} />
+                                Work in progress
+                            </span>
+                        )}
+                        <a href={embed.sourceHref}>
+                            From: {embed.sourceTitle}
+                            <FontAwesomeIcon icon={faArrowRight} />
+                        </a>
+                    </figcaption>
+                </figure>
+            )}
+            <div className="homepage-topic-area__links span-cols-12 col-start-2">
+                {content && <FeaturedLinks links={content.featured} />}
+                <TopicsList areaName={area.name} topics={topics} />
+            </div>
+        </section>
+    )
+}
+
+export const HomepageTopicAreas = () => {
+    const { homepageMetadata } = React.useContext(AttachmentsContext)
+    const tagGraph = homepageMetadata?.tagGraph
+    if (!tagGraph) return null
+
+    return (
+        // The footer links to #all-topics — keep that anchor working
+        <section
+            id="all-topics"
+            className="homepage-topic-areas grid grid-cols-12-full-width span-cols-14"
+        >
+            <header className="homepage-topic-areas__header span-cols-12 col-start-2">
+                <h2 className="h1-semibold">Explore our world, area by area</h2>
+                <p className="subtitle-1">
+                    All our data, research, and writing, organized by the big
+                    areas of work — with some of our interactive
+                    visualizations to explore along the way.
+                </p>
+            </header>
+            {tagGraph.children.map((area) => (
+                <TopicAreaSection area={area} key={area.name} />
+            ))}
+        </section>
+    )
+}

--- a/site/gdocs/pages/HomepageTopicAreas.tsx
+++ b/site/gdocs/pages/HomepageTopicAreas.tsx
@@ -24,14 +24,12 @@ const EMBED_LAYOUT_CLASSES: Record<string, string> = {
     widest: "span-cols-12 col-start-2",
 }
 
-const FEATURED_LINK_TYPE_LABELS: Record<
-    HomepageFeaturedLink["type"],
-    string
-> = {
-    article: "Article",
-    explorer: "Data Explorer",
-    chart: "Interactive Chart",
-}
+const FEATURED_LINK_TYPE_LABELS: Record<HomepageFeaturedLink["type"], string> =
+    {
+        article: "Article",
+        explorer: "Data Explorer",
+        chart: "Interactive Chart",
+    }
 
 const makeAreaId = (name: string): string =>
     name
@@ -183,8 +181,8 @@ export const HomepageTopicAreas = () => {
                 <h2 className="h1-semibold">Explore our world, area by area</h2>
                 <p className="subtitle-1">
                     All our data, research, and writing, organized by the big
-                    areas of work — with some of our interactive
-                    visualizations to explore along the way.
+                    areas of work — with some of our interactive visualizations
+                    to explore along the way.
                 </p>
             </header>
             {tagGraph.children.map((area) => (

--- a/site/gdocs/pages/homepageTopicAreasContent.ts
+++ b/site/gdocs/pages/homepageTopicAreasContent.ts
@@ -1,0 +1,261 @@
+import { BlockSize, EnrichedBlockBespokeComponent } from "@ourworldindata/types"
+
+export type HomepageFeaturedLinkType = "article" | "explorer" | "chart"
+
+export interface HomepageFeaturedLink {
+    title: string
+    href: string
+    type: HomepageFeaturedLinkType
+}
+
+export interface HomepageAreaEmbed {
+    block: EnrichedBlockBespokeComponent
+    /** The article the embedded viz comes from */
+    sourceTitle: string
+    sourceHref: string
+    isDraft?: boolean
+}
+
+export interface HomepageAreaContent {
+    embed?: HomepageAreaEmbed
+    featured: HomepageFeaturedLink[]
+}
+
+const makeBlock = (
+    bundle: string,
+    variant: string,
+    size: BlockSize,
+    config: Record<string, string> = {}
+): EnrichedBlockBespokeComponent => ({
+    type: "bespoke-component",
+    bundle,
+    variant,
+    size,
+    config,
+    parseErrors: [],
+})
+
+/**
+ * Prototype content for the homepage topic-area sections, keyed by the area's
+ * name in the topic tag graph.
+ */
+export const HOMEPAGE_AREA_CONTENT: Record<string, HomepageAreaContent> = {
+    "Population and Demographic Change": {
+        embed: {
+            block: makeBlock("demography", "simulation", BlockSize.Widest, {
+                region: "userLocation",
+            }),
+            sourceTitle:
+                "Population tool: How will populations across the world change in the 21st century?",
+            sourceHref: "/population-simulation-tool",
+        },
+        featured: [
+            {
+                title: "Two centuries of rapid global population growth will come to an end",
+                href: "/world-population-growth-past-future",
+                type: "article",
+            },
+            {
+                title: "Population & Demography Data Explorer",
+                href: "/explorers/population-and-demography",
+                type: "explorer",
+            },
+        ],
+    },
+    Health: {
+        embed: {
+            block: makeBlock("causes-of-death", "treemap", BlockSize.Wide),
+            sourceTitle: "What do people die from in different countries?",
+            sourceHref: "/what-do-people-die-from-in-different-countries",
+        },
+        featured: [
+            {
+                title: "Why do women live longer than men?",
+                href: "/why-do-women-live-longer-than-men",
+                type: "article",
+            },
+            {
+                title: "Life expectancy",
+                href: "/grapher/life-expectancy",
+                type: "chart",
+            },
+            {
+                title: "Child mortality rate",
+                href: "/grapher/child-mortality-igme",
+                type: "chart",
+            },
+        ],
+    },
+    "Energy and Environment": {
+        featured: [
+            {
+                title: "Who has contributed most to global CO₂ emissions?",
+                href: "/contributed-most-global-co2",
+                type: "article",
+            },
+            {
+                title: "CO₂ emissions per capita",
+                href: "/grapher/co-emissions-per-capita",
+                type: "chart",
+            },
+            {
+                title: "Energy Data Explorer",
+                href: "/explorers/energy",
+                type: "explorer",
+            },
+            {
+                title: "Climate Change Impacts Data Explorer",
+                href: "/explorers/climate-change",
+                type: "explorer",
+            },
+        ],
+    },
+    "Food and Agriculture": {
+        embed: {
+            block: makeBlock("food-trade", "sankey", BlockSize.Wide),
+            sourceTitle: "How does food get traded around the world?",
+            sourceHref: "/how-does-food-get-traded-around-the-world",
+        },
+        featured: [
+            {
+                title: "The world has passed ‘peak agricultural land’",
+                href: "/peak-agriculture-land",
+                type: "article",
+            },
+            {
+                title: "Global Food Data Explorer",
+                href: "/explorers/global-food",
+                type: "explorer",
+            },
+            {
+                title: "Daily supply of calories per person",
+                href: "/grapher/daily-per-capita-caloric-supply",
+                type: "chart",
+            },
+        ],
+    },
+    "Poverty and Economic Development": {
+        embed: {
+            block: makeBlock("income-plots", "distribution", BlockSize.Widest, {
+                tab: "global",
+                isolateState: "true",
+            }),
+            sourceTitle: "Visualizing global inequality",
+            sourceHref:
+                "http://staging-site-staging-server-bespoke/admin/gdocs/1AjxhGRu0vXIdIILbYAGniU0Wu-0lmQTUYMbEWRZaqA8/preview",
+            isDraft: true,
+        },
+        featured: [
+            {
+                title: "Poverty Data Explorer",
+                href: "/explorers/poverty-explorer",
+                type: "explorer",
+            },
+            {
+                title: "Share of population living in extreme poverty",
+                href: "/grapher/share-of-population-in-extreme-poverty",
+                type: "chart",
+            },
+            {
+                title: "GDP per capita",
+                href: "/grapher/gdp-per-capita-worldbank",
+                type: "chart",
+            },
+        ],
+    },
+    "Education and Knowledge": {
+        featured: [
+            {
+                title: "Millions of children learn only very little. How can the world provide a better education to the next generation?",
+                href: "/better-learning",
+                type: "article",
+            },
+            {
+                title: "Average years of schooling",
+                href: "/grapher/mean-years-of-schooling-long-run",
+                type: "chart",
+            },
+            {
+                title: "Literate and illiterate world population",
+                href: "/grapher/literate-and-illiterate-world-population",
+                type: "chart",
+            },
+        ],
+    },
+    "Innovation and Technological Change": {
+        featured: [
+            {
+                title: "The brief history of artificial intelligence: the world has changed fast — what might be next?",
+                href: "/brief-history-of-ai",
+                type: "article",
+            },
+            {
+                title: "Computation used to train notable AI systems",
+                href: "/grapher/computation-used-to-train-notable-artificial-intelligence-systems",
+                type: "chart",
+            },
+            {
+                title: "Moore’s law: transistors per microprocessor",
+                href: "/grapher/transistors-per-microprocessor",
+                type: "chart",
+            },
+        ],
+    },
+    "Living Conditions, Community and Wellbeing": {
+        featured: [
+            {
+                title: "Self-reported life satisfaction",
+                href: "/grapher/happiness-cantril-ladder",
+                type: "chart",
+            },
+            {
+                title: "Who Americans spend their time with, by age",
+                href: "/grapher/time-spent-with-relationships-by-age-us",
+                type: "chart",
+            },
+            {
+                title: "Water, Sanitation and Hygiene Data Explorer",
+                href: "/explorers/water-and-sanitation",
+                type: "explorer",
+            },
+        ],
+    },
+    "Human Rights and Democracy": {
+        featured: [
+            {
+                title: "People around the world have gained democratic rights, but some have many more rights than others",
+                href: "/democratic-world",
+                type: "article",
+            },
+            {
+                title: "Democracy Data Explorer",
+                href: "/explorers/democracy",
+                type: "explorer",
+            },
+            {
+                title: "Age of electoral democracy",
+                href: "/grapher/age-of-electoral-democracy",
+                type: "chart",
+            },
+        ],
+    },
+    "Violence and War": {
+        featured: [
+            {
+                title: "War in Ukraine",
+                href: "/ukraine-war",
+                type: "article",
+            },
+            {
+                title: "Conflict Data Explorer",
+                href: "/explorers/conflict-data",
+                type: "explorer",
+            },
+            {
+                title: "Deaths in armed conflicts",
+                href: "/grapher/deaths-in-armed-conflicts",
+                type: "chart",
+            },
+        ],
+    },
+}

--- a/site/owid.scss
+++ b/site/owid.scss
@@ -199,6 +199,7 @@
 
 @import "./gdocs/pages/DataInsight.scss";
 @import "./gdocs/pages/Homepage.scss";
+@import "./gdocs/pages/HomepageTopicAreas.scss";
 @import "./gdocs/pages/Author.scss";
 @import "./gdocs/pages/AboutPage.scss";
 @import "./gdocs/pages/Announcement.scss";

--- a/site/owid.scss
+++ b/site/owid.scss
@@ -46,6 +46,7 @@
 @import "css/noscript.scss";
 @import "./NewsletterSignupBlock.scss";
 @import "./ExplorerIndexPage.scss";
+@import "./featuredViz/FeaturedVizPage.scss";
 @import "./SubscribePage.scss";
 @import "./LatestPage.scss";
 @import "./latest/LatestSearch.scss";

--- a/site/runSiteFooterScripts.tsx
+++ b/site/runSiteFooterScripts.tsx
@@ -48,6 +48,10 @@ import {
     SlideshowPresentation,
     _OWID_SLIDESHOW_PROPS,
 } from "./slideshows/SlideshowPresentation.js"
+import {
+    FEATURED_VIZ_PAGE_ROOT_ID,
+    FeaturedVizDashboard,
+} from "./featuredViz/FeaturedVizDashboard.js"
 
 function runSearchPage() {
     const root = document.getElementById("search-page-root")
@@ -73,6 +77,13 @@ function hydrateSubscribePage() {
                 context={NewsletterSubscriptionContext.SubscribePage}
             />
         )
+    }
+}
+
+function hydrateFeaturedVizPage() {
+    const root = document.getElementById(FEATURED_VIZ_PAGE_ROOT_ID)
+    if (root) {
+        hydrateRoot(root, <FeaturedVizDashboard />)
     }
 }
 
@@ -382,6 +393,12 @@ export const runSiteFooterScripts = async (
             runSiteTools()
             runCookiePreferencesManager()
             void runDetailsOnDemand()
+            break
+        case SiteFooterContext.featuredVizPage:
+            hydrateFeaturedVizPage()
+            runSiteNavigation({ hideDonationFlag, isPreviewing })
+            runSiteTools()
+            runCookiePreferencesManager()
             break
         case SiteFooterContext.dynamicCollectionPage:
             // Don't break, run default case too


### PR DESCRIPTION
> _Written by Anthropic Claude Fable 5 — @JoeHasell at the wheel._

## Context

**Illustrative prototype, not intended to ship** — this draft PR exists mainly so the branch gets a staging server to share.

Adds a prototype page at `/featured-viz` that acts as a dashboard for all our bespoke viz projects. Each project is embedded **live and fully interactive** on the page (via the same Shadow-DOM embed mechanism articles use), with a topic eyebrow, a short description, a "Things to try" panel highlighting each tool's interactivity, authors, and a link to the published article. The page header carries a "Prototype — internal preview" pill, a jump-nav to each section, and the page is `noindex`.

Featured:

- Where do migrants live, and where were they born? (`migration`)
- What do people die from in different countries? (`causes-of-death`)
- How does food get traded around the world? (`food-trade`)
- Population simulation tool (`demography`)
- Visualizing global inequality (`income-plots` — unpublished draft, badged "Work in progress"; the project is ported over from the `staging-server-bespoke` branch and registered so it can be featured)

Implementation:

- `FeaturedVizPage` baked as a special page, plus a `mockSiteRouter` route for local dev; hydrated client-side via a new `SiteFooterContext.featuredVizPage`
- Embed variants/configs mirror what the published articles use
- "Featured Visualizations" added to the Resources dropdown in the site navigation (desktop + mobile)

## Screenshots / Videos / Diagrams

Verified locally against production bespoke builds at desktop (1440px) and mobile (390px) widths — all five visualizations render and are interactive.

## Testing guidance

- Open `/featured-viz` on the staging server and play with each embedded viz
- Check the "Featured Visualizations" entry in the Resources dropdown (desktop and mobile menu)

## Checklist

Skipped — illustrative prototype for internal review, not planned for merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014feceh5pmNUwS2kdnR4Ddz

---
_Generated by [Claude Code](https://claude.ai/code/session_014feceh5pmNUwS2kdnR4Ddz)_