### PR TITLE
Fix map brackets becoming stuck on hover & improve map bracket highlighting on mobile

### DIFF
--- a/packages/@ourworldindata/grapher/src/legend/HorizontalColorLegends.test.ts
+++ b/packages/@ourworldindata/grapher/src/legend/HorizontalColorLegends.test.ts
@@ -109,6 +109,7 @@ describe(HorizontalNumericColorLegend, () => {
         })
         const onLegendMouseOver = vi.fn()
         const onLegendMouseLeave = vi.fn()
+        const onLegendTouchSelect = vi.fn()
 
         const { container } = render(
             React.createElement(
@@ -119,6 +120,7 @@ describe(HorizontalNumericColorLegend, () => {
                         numericLegendData: [bin],
                         onLegendMouseOver,
                         onLegendMouseLeave,
+                        onLegendTouchSelect,
                     },
                 })
             )
@@ -127,11 +129,21 @@ describe(HorizontalNumericColorLegend, () => {
 
         expect(swatch).not.toBeNull()
 
-        fireEvent.pointerEnter(swatch!)
-        fireEvent.pointerLeave(swatch!)
+        fireEvent.pointerEnter(swatch!, { pointerType: "touch" })
+
+        expect(onLegendMouseOver).not.toHaveBeenCalled()
+
+        fireEvent.pointerEnter(swatch!, { pointerType: "mouse" })
+        fireEvent.pointerLeave(swatch!, { pointerType: "mouse" })
+        fireEvent.pointerUp(swatch!, { pointerType: "mouse" })
 
         expect(onLegendMouseOver).toHaveBeenCalledWith(bin)
         expect(onLegendMouseLeave).toHaveBeenCalledOnce()
+        expect(onLegendTouchSelect).not.toHaveBeenCalled()
+
+        fireEvent.pointerUp(swatch!, { pointerType: "touch" })
+
+        expect(onLegendTouchSelect).toHaveBeenCalledWith(bin)
     })
 
     it("renders highlighted bins as non-interactive overlays", () => {

--- a/packages/@ourworldindata/grapher/src/legend/HorizontalColorLegends.test.ts
+++ b/packages/@ourworldindata/grapher/src/legend/HorizontalColorLegends.test.ts
@@ -1,4 +1,10 @@
-import { expect, it, describe } from "vitest"
+/**
+ * @vitest-environment happy-dom
+ */
+
+import * as React from "react"
+import { fireEvent, render } from "@testing-library/react"
+import { expect, it, describe, vi } from "vitest"
 
 import { CategoricalBin, NumericBin } from "../color/ColorScaleBin"
 import {
@@ -87,6 +93,44 @@ describe(HorizontalNumericColorLegend, () => {
         expect(marginBetween(bins[1], bins[2])).toEqual(margin)
         expect(marginBetween(bins[2], bins[3])).toEqual(0)
         expect(marginBetween(bins[3], bins[4])).toEqual(margin)
+    })
+
+    it("clears legend hover when the pointer leaves a bin", () => {
+        const bin = new NumericBin({
+            isFirst: true,
+            isOpenLeft: false,
+            isOpenRight: false,
+            min: 0,
+            max: 1,
+            displayMin: "0",
+            displayMax: "1",
+            color: "#fff",
+        })
+        const onLegendMouseOver = vi.fn()
+        const onLegendMouseLeave = vi.fn()
+
+        const { container } = render(
+            React.createElement(
+                "svg",
+                undefined,
+                React.createElement(HorizontalNumericColorLegend, {
+                    manager: {
+                        numericLegendData: [bin],
+                        onLegendMouseOver,
+                        onLegendMouseLeave,
+                    },
+                })
+            )
+        )
+        const swatch = container.querySelector("#swatches > *")
+
+        expect(swatch).not.toBeNull()
+
+        fireEvent.pointerEnter(swatch!)
+        fireEvent.pointerLeave(swatch!)
+
+        expect(onLegendMouseOver).toHaveBeenCalledWith(bin)
+        expect(onLegendMouseLeave).toHaveBeenCalledOnce()
     })
 })
 

--- a/packages/@ourworldindata/grapher/src/legend/HorizontalColorLegends.test.ts
+++ b/packages/@ourworldindata/grapher/src/legend/HorizontalColorLegends.test.ts
@@ -12,6 +12,7 @@ import {
     HorizontalNumericColorLegend,
     PositionedBin,
 } from "./HorizontalColorLegends"
+import { Emphasis } from "../interaction/Emphasis"
 
 describe(HorizontalNumericColorLegend, () => {
     it("can create one", () => {
@@ -131,6 +132,54 @@ describe(HorizontalNumericColorLegend, () => {
 
         expect(onLegendMouseOver).toHaveBeenCalledWith(bin)
         expect(onLegendMouseLeave).toHaveBeenCalledOnce()
+    })
+
+    it("renders highlighted bins as non-interactive overlays", () => {
+        const highlightedBin = new NumericBin({
+            isFirst: true,
+            isOpenLeft: false,
+            isOpenRight: false,
+            min: 0,
+            max: 1,
+            displayMin: "0",
+            displayMax: "1",
+            color: "#fff",
+        })
+        const otherBin = new NumericBin({
+            isFirst: false,
+            isOpenLeft: false,
+            isOpenRight: false,
+            min: 1,
+            max: 2,
+            displayMin: "1",
+            displayMax: "2",
+            color: "#000",
+        })
+
+        const { container } = render(
+            React.createElement(
+                "svg",
+                undefined,
+                React.createElement(HorizontalNumericColorLegend, {
+                    manager: {
+                        numericLegendData: [highlightedBin, otherBin],
+                        resolveLegendBinEmphasis: (bin) =>
+                            bin === highlightedBin
+                                ? Emphasis.Highlighted
+                                : Emphasis.Default,
+                    },
+                })
+            )
+        )
+
+        const swatches = container.querySelector("#swatches")!
+        const [firstBin, , highlightOverlay] = Array.from(swatches.children)
+
+        expect(swatches.children).toHaveLength(3)
+        expect(highlightOverlay.getAttribute("x")).toBe(
+            firstBin.getAttribute("x")
+        )
+        expect(highlightOverlay.getAttribute("pointer-events")).toBe("none")
     })
 })
 

--- a/packages/@ourworldindata/grapher/src/legend/HorizontalColorLegends.test.ts
+++ b/packages/@ourworldindata/grapher/src/legend/HorizontalColorLegends.test.ts
@@ -3,8 +3,8 @@
  */
 
 import * as React from "react"
-import { fireEvent, render } from "@testing-library/react"
-import { expect, it, describe, vi } from "vitest"
+import { render } from "@testing-library/react"
+import { expect, it, describe } from "vitest"
 
 import { CategoricalBin, NumericBin } from "../color/ColorScaleBin"
 import {
@@ -94,81 +94,6 @@ describe(HorizontalNumericColorLegend, () => {
         expect(marginBetween(bins[1], bins[2])).toEqual(margin)
         expect(marginBetween(bins[2], bins[3])).toEqual(0)
         expect(marginBetween(bins[3], bins[4])).toEqual(margin)
-    })
-
-    it("clears legend hover when the pointer leaves a bin", () => {
-        const bin = new NumericBin({
-            isFirst: true,
-            isOpenLeft: false,
-            isOpenRight: false,
-            min: 0,
-            max: 1,
-            displayMin: "0",
-            displayMax: "1",
-            color: "#fff",
-        })
-        const onLegendMouseOver = vi.fn()
-        const onLegendMouseLeave = vi.fn()
-        const onLegendTouchSelect = vi.fn()
-
-        const { container } = render(
-            React.createElement(
-                "svg",
-                undefined,
-                React.createElement(HorizontalNumericColorLegend, {
-                    manager: {
-                        numericLegendData: [bin],
-                        onLegendMouseOver,
-                        onLegendMouseLeave,
-                        onLegendTouchSelect,
-                    },
-                })
-            )
-        )
-        const swatch = container.querySelector("#swatches > *")
-        const hitArea = container.querySelector("#swatch-hit-areas > rect")
-
-        expect(swatch).not.toBeNull()
-        expect(hitArea).not.toBeNull()
-        expect(Number(hitArea!.getAttribute("y"))).toBeLessThan(
-            Number(swatch!.getAttribute("y"))
-        )
-        expect(
-            Number(hitArea!.getAttribute("y")) +
-                Number(hitArea!.getAttribute("height"))
-        ).toBe(Number(swatch!.getAttribute("y")))
-
-        fireEvent.pointerEnter(hitArea!, { pointerType: "mouse" })
-        fireEvent.pointerLeave(hitArea!, { pointerType: "mouse" })
-        fireEvent.pointerUp(hitArea!, { pointerType: "mouse" })
-
-        expect(onLegendMouseOver).not.toHaveBeenCalled()
-        expect(onLegendMouseLeave).not.toHaveBeenCalled()
-        expect(onLegendTouchSelect).not.toHaveBeenCalled()
-
-        fireEvent.pointerEnter(swatch!, { pointerType: "mouse" })
-        fireEvent.pointerLeave(swatch!, { pointerType: "mouse" })
-        fireEvent.pointerUp(swatch!, { pointerType: "mouse" })
-
-        expect(onLegendMouseOver).toHaveBeenCalledWith(bin)
-        expect(onLegendMouseLeave).toHaveBeenCalledOnce()
-        expect(onLegendTouchSelect).not.toHaveBeenCalled()
-
-        fireEvent.pointerEnter(hitArea!, { pointerType: "touch" })
-
-        expect(onLegendMouseOver).toHaveBeenCalledOnce()
-
-        fireEvent.pointerUp(hitArea!, { pointerType: "touch" })
-
-        expect(onLegendTouchSelect).toHaveBeenCalledWith(bin)
-
-        fireEvent.pointerEnter(swatch!, { pointerType: "touch" })
-
-        expect(onLegendMouseOver).toHaveBeenCalledOnce()
-
-        fireEvent.pointerUp(swatch!, { pointerType: "touch" })
-
-        expect(onLegendTouchSelect).toHaveBeenCalledTimes(2)
     })
 
     it("renders highlighted bins as non-interactive overlays", () => {

--- a/packages/@ourworldindata/grapher/src/legend/HorizontalColorLegends.test.ts
+++ b/packages/@ourworldindata/grapher/src/legend/HorizontalColorLegends.test.ts
@@ -126,12 +126,25 @@ describe(HorizontalNumericColorLegend, () => {
             )
         )
         const swatch = container.querySelector("#swatches > *")
+        const hitArea = container.querySelector("#swatch-hit-areas > rect")
 
         expect(swatch).not.toBeNull()
+        expect(hitArea).not.toBeNull()
+        expect(Number(hitArea!.getAttribute("y"))).toBeLessThan(
+            Number(swatch!.getAttribute("y"))
+        )
+        expect(
+            Number(hitArea!.getAttribute("y")) +
+                Number(hitArea!.getAttribute("height"))
+        ).toBe(Number(swatch!.getAttribute("y")))
 
-        fireEvent.pointerEnter(swatch!, { pointerType: "touch" })
+        fireEvent.pointerEnter(hitArea!, { pointerType: "mouse" })
+        fireEvent.pointerLeave(hitArea!, { pointerType: "mouse" })
+        fireEvent.pointerUp(hitArea!, { pointerType: "mouse" })
 
         expect(onLegendMouseOver).not.toHaveBeenCalled()
+        expect(onLegendMouseLeave).not.toHaveBeenCalled()
+        expect(onLegendTouchSelect).not.toHaveBeenCalled()
 
         fireEvent.pointerEnter(swatch!, { pointerType: "mouse" })
         fireEvent.pointerLeave(swatch!, { pointerType: "mouse" })
@@ -141,9 +154,21 @@ describe(HorizontalNumericColorLegend, () => {
         expect(onLegendMouseLeave).toHaveBeenCalledOnce()
         expect(onLegendTouchSelect).not.toHaveBeenCalled()
 
-        fireEvent.pointerUp(swatch!, { pointerType: "touch" })
+        fireEvent.pointerEnter(hitArea!, { pointerType: "touch" })
+
+        expect(onLegendMouseOver).toHaveBeenCalledOnce()
+
+        fireEvent.pointerUp(hitArea!, { pointerType: "touch" })
 
         expect(onLegendTouchSelect).toHaveBeenCalledWith(bin)
+
+        fireEvent.pointerEnter(swatch!, { pointerType: "touch" })
+
+        expect(onLegendMouseOver).toHaveBeenCalledOnce()
+
+        fireEvent.pointerUp(swatch!, { pointerType: "touch" })
+
+        expect(onLegendTouchSelect).toHaveBeenCalledTimes(2)
     })
 
     it("renders highlighted bins as non-interactive overlays", () => {

--- a/packages/@ourworldindata/grapher/src/legend/HorizontalColorLegends.tsx
+++ b/packages/@ourworldindata/grapher/src/legend/HorizontalColorLegends.tsx
@@ -106,6 +106,10 @@ const CATEGORICAL_BIN_MIN_WIDTH = 20
 const SPACE_BETWEEN_CATEGORICAL_BINS = 7
 const MINIMUM_LABEL_DISTANCE = 5
 
+const stopPointerDownPropagation = (event: React.PointerEvent): void => {
+    event.stopPropagation()
+}
+
 export abstract class HorizontalColorLegend extends React.Component<{
     manager: HorizontalColorLegendManager
 }> {
@@ -576,6 +580,7 @@ export class HorizontalNumericColorLegend extends HorizontalColorLegend {
                 ref={this.base}
                 id={makeFigmaId("numeric-color-legend")}
                 className="numericColorLegend"
+                onPointerDown={stopPointerDownPropagation}
             >
                 <g id={makeFigmaId("lines")}>
                     {numericLabels.map((label, index) => {
@@ -989,6 +994,7 @@ export class HorizontalCategoricalColorLegend extends HorizontalColorLegend {
             <g
                 id={makeFigmaId("categorical-color-legend")}
                 className="categoricalColorLegend"
+                onPointerDown={stopPointerDownPropagation}
             >
                 {this.renderSwatches()}
                 {this.renderLabels()}

--- a/packages/@ourworldindata/grapher/src/legend/HorizontalColorLegends.tsx
+++ b/packages/@ourworldindata/grapher/src/legend/HorizontalColorLegends.tsx
@@ -494,6 +494,52 @@ export class HorizontalNumericColorLegend extends HorizontalColorLegend {
 
         const bottomY = this.numericLegendY + height
 
+        const renderBin = (
+            positionedBin: PositionedBin,
+            index: number,
+            isHighlightOverlay = false
+        ): React.ReactElement => {
+            const bin = positionedBin.bin
+            const style = this.getMarkerStyleConfig(bin)
+            const fill = bin.patternRef ? `url(#${bin.patternRef})` : style.fill
+
+            return (
+                <NumericBinRect
+                    key={isHighlightOverlay ? `highlight-${index}` : index}
+                    x={positionedBin.x}
+                    y={bottomY - numericBinSize}
+                    width={positionedBin.width}
+                    height={numericBinSize}
+                    fill={fill}
+                    stroke={style.stroke}
+                    strokeWidth={style.strokeWidth}
+                    opacity={style.opacity}
+                    isOpenLeft={
+                        bin instanceof NumericBin ? bin.props.isOpenLeft : false
+                    }
+                    isOpenRight={
+                        bin instanceof NumericBin
+                            ? bin.props.isOpenRight
+                            : false
+                    }
+                    pointerEvents={isHighlightOverlay ? "none" : undefined}
+                    onPointerEnter={
+                        isHighlightOverlay
+                            ? undefined
+                            : (): void => {
+                                  this.manager.onLegendMouseEnter?.(bin)
+                                  this.manager.onLegendMouseOver?.(bin)
+                              }
+                    }
+                    onPointerLeave={
+                        isHighlightOverlay
+                            ? undefined
+                            : (): void => this.manager.onLegendMouseLeave?.()
+                    }
+                />
+            )
+        }
+
         const textColor =
             this.legendStyleConfig?.text?.default?.color ?? DEFAULT_TEXT_COLOR
 
@@ -531,48 +577,24 @@ export class HorizontalNumericColorLegend extends HorizontalColorLegend {
                     })}
                 </g>
                 <g id={makeFigmaId("swatches")}>
-                    {_.sortBy(
-                        positionedBins.map((positionedBin, index) => {
-                            const bin = positionedBin.bin
-                            const style = this.getMarkerStyleConfig(bin)
-
-                            const fill = bin.patternRef
-                                ? `url(#${bin.patternRef})`
-                                : style.fill
-
-                            return (
-                                <NumericBinRect
-                                    key={index}
-                                    x={positionedBin.x}
-                                    y={bottomY - numericBinSize}
-                                    width={positionedBin.width}
-                                    height={numericBinSize}
-                                    fill={fill}
-                                    stroke={style.stroke}
-                                    strokeWidth={style.strokeWidth}
-                                    opacity={style.opacity}
-                                    isOpenLeft={
-                                        bin instanceof NumericBin
-                                            ? bin.props.isOpenLeft
-                                            : false
-                                    }
-                                    isOpenRight={
-                                        bin instanceof NumericBin
-                                            ? bin.props.isOpenRight
-                                            : false
-                                    }
-                                    onPointerEnter={() => {
-                                        this.manager.onLegendMouseEnter?.(bin)
-                                        this.manager.onLegendMouseOver?.(bin)
-                                    }}
-                                    onPointerLeave={() =>
-                                        this.manager.onLegendMouseLeave?.()
-                                    }
-                                />
-                            )
-                        }),
-                        (rect) => rect.props["strokeWidth"]
+                    {positionedBins.map((positionedBin, index) =>
+                        renderBin(positionedBin, index)
                     )}
+                    {/*
+                        Render highlighted bins last so their stroke is painted above adjacent bins.
+                        Note that this renders the highlighted bin twice, once in its normal place and once in the highlight layer here.
+
+                        Another option to solve the cosmetic stroke issue would be to sort their bins by their emphasis state, but that has caused issues with React event handlers becoming detached from the elements and `pointerleave` events not firing.
+                    */}
+                    {positionedBins
+                        .filter(
+                            (positionedBin) =>
+                                this.getBinState(positionedBin.bin) ===
+                                Emphasis.Highlighted
+                        )
+                        .map((positionedBin, index) =>
+                            renderBin(positionedBin, index, true)
+                        )}
                 </g>
                 <g id={makeFigmaId("labels")}>
                     {numericLabels.map((label, index) => {

--- a/packages/@ourworldindata/grapher/src/legend/HorizontalColorLegends.tsx
+++ b/packages/@ourworldindata/grapher/src/legend/HorizontalColorLegends.tsx
@@ -87,6 +87,7 @@ export interface HorizontalColorLegendManager {
     onLegendMouseEnter?: (d: ColorScaleBin) => void
     onLegendMouseLeave?: () => void
     onLegendMouseOver?: (d: ColorScaleBin) => void
+    onLegendTouchSelect?: (d: ColorScaleBin) => void
     onLegendClick?: (d: ColorScaleBin) => void
     isStatic?: boolean
     resolveLegendBinEmphasis?: (bin: ColorScaleBin) => Emphasis
@@ -526,7 +527,13 @@ export class HorizontalNumericColorLegend extends HorizontalColorLegend {
                     onPointerEnter={
                         isHighlightOverlay
                             ? undefined
-                            : (): void => {
+                            : (event): void => {
+                                  if (
+                                      event.pointerType === "touch" &&
+                                      this.manager.onLegendTouchSelect
+                                  )
+                                      return
+
                                   this.manager.onLegendMouseEnter?.(bin)
                                   this.manager.onLegendMouseOver?.(bin)
                               }
@@ -534,7 +541,23 @@ export class HorizontalNumericColorLegend extends HorizontalColorLegend {
                     onPointerLeave={
                         isHighlightOverlay
                             ? undefined
-                            : (): void => this.manager.onLegendMouseLeave?.()
+                            : (event): void => {
+                                  if (
+                                      event.pointerType === "touch" &&
+                                      this.manager.onLegendTouchSelect
+                                  )
+                                      return
+
+                                  this.manager.onLegendMouseLeave?.()
+                              }
+                    }
+                    onPointerUp={
+                        isHighlightOverlay
+                            ? undefined
+                            : (event): void => {
+                                  if (event.pointerType === "touch")
+                                      this.manager.onLegendTouchSelect?.(bin)
+                              }
                     }
                 />
             )
@@ -885,11 +908,27 @@ export class HorizontalCategoricalColorLegend extends HorizontalColorLegend {
         return (
             <g>
                 {marks.map((mark, index) => {
-                    const pointerEnter = () =>
-                        manager.onLegendMouseEnter?.(mark.bin)
-                    const pointerOver = () =>
-                        manager.onLegendMouseOver?.(mark.bin)
-                    const pointerLeave = () => manager.onLegendMouseLeave?.()
+                    const isTouchSelection = (
+                        event: React.PointerEvent
+                    ): boolean =>
+                        event.pointerType === "touch" &&
+                        !!manager.onLegendTouchSelect
+                    const pointerEnter = (event: React.PointerEvent): void => {
+                        if (!isTouchSelection(event))
+                            manager.onLegendMouseEnter?.(mark.bin)
+                    }
+                    const pointerOver = (event: React.PointerEvent): void => {
+                        if (!isTouchSelection(event))
+                            manager.onLegendMouseOver?.(mark.bin)
+                    }
+                    const pointerLeave = (event: React.PointerEvent): void => {
+                        if (!isTouchSelection(event))
+                            manager.onLegendMouseLeave?.()
+                    }
+                    const pointerUp = (event: React.PointerEvent): void => {
+                        if (event.pointerType === "touch")
+                            manager.onLegendTouchSelect?.(mark.bin)
+                    }
                     const click = () => manager.onLegendClick?.(mark.bin)
 
                     return (
@@ -898,6 +937,7 @@ export class HorizontalCategoricalColorLegend extends HorizontalColorLegend {
                             onPointerEnter={pointerEnter}
                             onPointerOver={pointerOver}
                             onPointerLeave={pointerLeave}
+                            onPointerUp={pointerUp}
                             onClick={click}
                             style={{ cursor: manager.legendCursor }}
                         >

--- a/packages/@ourworldindata/grapher/src/legend/HorizontalColorLegends.tsx
+++ b/packages/@ourworldindata/grapher/src/legend/HorizontalColorLegends.tsx
@@ -525,7 +525,6 @@ export class HorizontalNumericColorLegend extends HorizontalColorLegend {
 
         const renderBin = (
             positionedBin: PositionedBin,
-            index: number,
             isHighlightOverlay = false
         ): React.ReactElement => {
             const bin = positionedBin.bin
@@ -534,12 +533,16 @@ export class HorizontalNumericColorLegend extends HorizontalColorLegend {
 
             return (
                 <NumericBinRect
-                    key={isHighlightOverlay ? `highlight-${index}` : index}
+                    key={
+                        isHighlightOverlay
+                            ? `highlight-${positionedBin.x}`
+                            : positionedBin.x
+                    }
                     x={positionedBin.x}
                     y={bottomY - numericBinSize}
                     width={positionedBin.width}
                     height={numericBinSize}
-                    fill={fill}
+                    fill={isHighlightOverlay ? "none" : fill}
                     stroke={style.stroke}
                     strokeWidth={style.strokeWidth}
                     opacity={style.opacity}
@@ -602,8 +605,8 @@ export class HorizontalNumericColorLegend extends HorizontalColorLegend {
                     })}
                 </g>
                 <g id={makeFigmaId("swatches")}>
-                    {positionedBins.map((positionedBin, index) =>
-                        renderBin(positionedBin, index)
+                    {positionedBins.map((positionedBin) =>
+                        renderBin(positionedBin)
                     )}
                     {/*
                         Render highlighted bins last so their stroke is painted above adjacent bins.
@@ -617,9 +620,7 @@ export class HorizontalNumericColorLegend extends HorizontalColorLegend {
                                 this.getBinState(positionedBin.bin) ===
                                 Emphasis.Highlighted
                         )
-                        .map((positionedBin, index) =>
-                            renderBin(positionedBin, index, true)
-                        )}
+                        .map((positionedBin) => renderBin(positionedBin, true))}
                 </g>
                 <g id={makeFigmaId("labels")}>
                     {numericLabels.map((label, index) => {
@@ -644,7 +645,7 @@ export class HorizontalNumericColorLegend extends HorizontalColorLegend {
                 {this.manager.onLegendTouchSelect && (
                     // Add invisible hit areas above each swatch for touch interaction.
                     // They are the height of the legend labels, and only handle touch events.
-                    <g id={makeFigmaId("swatch-hit-areas")}>
+                    <g id={makeFigmaId("swatch-hit-areas")} aria-hidden="true">
                         {positionedBins.map((positionedBin, index) => (
                             <rect
                                 key={index}

--- a/packages/@ourworldindata/grapher/src/legend/HorizontalColorLegends.tsx
+++ b/packages/@ourworldindata/grapher/src/legend/HorizontalColorLegends.tsx
@@ -561,11 +561,11 @@ export class HorizontalNumericColorLegend extends HorizontalColorLegend {
                                             ? bin.props.isOpenRight
                                             : false
                                     }
-                                    onMouseEnter={() => {
+                                    onPointerEnter={() => {
                                         this.manager.onLegendMouseEnter?.(bin)
                                         this.manager.onLegendMouseOver?.(bin)
                                     }}
-                                    onMouseLeave={() =>
+                                    onPointerLeave={() =>
                                         this.manager.onLegendMouseLeave?.()
                                     }
                                 />
@@ -863,28 +863,19 @@ export class HorizontalCategoricalColorLegend extends HorizontalColorLegend {
         return (
             <g>
                 {marks.map((mark, index) => {
-                    const mouseEnter = (): void =>
-                        manager.onLegendMouseEnter
-                            ? manager.onLegendMouseEnter(mark.bin)
-                            : undefined
-                    const mouseOver = (): void =>
-                        manager.onLegendMouseOver
-                            ? manager.onLegendMouseOver(mark.bin)
-                            : undefined
-                    const mouseLeave = (): void =>
-                        manager.onLegendMouseLeave
-                            ? manager.onLegendMouseLeave()
-                            : undefined
-                    const click = manager.onLegendClick
-                        ? (): void => manager.onLegendClick?.(mark.bin)
-                        : undefined
+                    const pointerEnter = () =>
+                        manager.onLegendMouseEnter?.(mark.bin)
+                    const pointerOver = () =>
+                        manager.onLegendMouseOver?.(mark.bin)
+                    const pointerLeave = () => manager.onLegendMouseLeave?.()
+                    const click = () => manager.onLegendClick?.(mark.bin)
 
                     return (
                         <g
                             key={`${mark.label}-${index}`}
-                            onMouseEnter={mouseEnter}
-                            onMouseOver={mouseOver}
-                            onMouseLeave={mouseLeave}
+                            onPointerEnter={pointerEnter}
+                            onPointerOver={pointerOver}
+                            onPointerLeave={pointerLeave}
                             onClick={click}
                             style={{ cursor: manager.legendCursor }}
                         >

--- a/packages/@ourworldindata/grapher/src/legend/HorizontalColorLegends.tsx
+++ b/packages/@ourworldindata/grapher/src/legend/HorizontalColorLegends.tsx
@@ -495,6 +495,34 @@ export class HorizontalNumericColorLegend extends HorizontalColorLegend {
 
         const bottomY = this.numericLegendY + height
 
+        const onPointerEnter =
+            (bin: ColorScaleBin) =>
+            (event: React.PointerEvent): void => {
+                if (
+                    event.pointerType === "touch" &&
+                    this.manager.onLegendTouchSelect
+                )
+                    return
+
+                this.manager.onLegendMouseEnter?.(bin)
+                this.manager.onLegendMouseOver?.(bin)
+            }
+        const onPointerLeave = (event: React.PointerEvent): void => {
+            if (
+                event.pointerType === "touch" &&
+                this.manager.onLegendTouchSelect
+            )
+                return
+
+            this.manager.onLegendMouseLeave?.()
+        }
+        const onPointerUp =
+            (bin: ColorScaleBin) =>
+            (event: React.PointerEvent): void => {
+                if (event.pointerType === "touch")
+                    this.manager.onLegendTouchSelect?.(bin)
+            }
+
         const renderBin = (
             positionedBin: PositionedBin,
             index: number,
@@ -525,39 +553,13 @@ export class HorizontalNumericColorLegend extends HorizontalColorLegend {
                     }
                     pointerEvents={isHighlightOverlay ? "none" : undefined}
                     onPointerEnter={
-                        isHighlightOverlay
-                            ? undefined
-                            : (event): void => {
-                                  if (
-                                      event.pointerType === "touch" &&
-                                      this.manager.onLegendTouchSelect
-                                  )
-                                      return
-
-                                  this.manager.onLegendMouseEnter?.(bin)
-                                  this.manager.onLegendMouseOver?.(bin)
-                              }
+                        isHighlightOverlay ? undefined : onPointerEnter(bin)
                     }
                     onPointerLeave={
-                        isHighlightOverlay
-                            ? undefined
-                            : (event): void => {
-                                  if (
-                                      event.pointerType === "touch" &&
-                                      this.manager.onLegendTouchSelect
-                                  )
-                                      return
-
-                                  this.manager.onLegendMouseLeave?.()
-                              }
+                        isHighlightOverlay ? undefined : onPointerLeave
                     }
                     onPointerUp={
-                        isHighlightOverlay
-                            ? undefined
-                            : (event): void => {
-                                  if (event.pointerType === "touch")
-                                      this.manager.onLegendTouchSelect?.(bin)
-                              }
+                        isHighlightOverlay ? undefined : onPointerUp(bin)
                     }
                 />
             )
@@ -639,6 +641,24 @@ export class HorizontalNumericColorLegend extends HorizontalColorLegend {
                         )
                     })}
                 </g>
+                {this.manager.onLegendTouchSelect && (
+                    // Add invisible hit areas above each swatch for touch interaction.
+                    // They are the height of the legend labels, and only handle touch events.
+                    <g id={makeFigmaId("swatch-hit-areas")}>
+                        {positionedBins.map((positionedBin, index) => (
+                            <rect
+                                key={index}
+                                x={positionedBin.x}
+                                y={this.numericLegendY}
+                                width={positionedBin.width}
+                                height={Math.max(0, height - numericBinSize)}
+                                fill="transparent"
+                                pointerEvents="all"
+                                onPointerUp={onPointerUp(positionedBin.bin)}
+                            />
+                        ))}
+                    </g>
+                )}
                 {this.legendTitle && (
                     <TextWrapSvg
                         textWrap={this.legendTitle}

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapChart.test.ts
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapChart.test.ts
@@ -49,9 +49,7 @@ it("pins a map bracket selected by touch until the next touch", () => {
 
     expect(chart.hoverBracket).toBe(firstBracket)
 
-    chart.onDocumentPointerDown({
-        pointerType: "touch",
-    } as globalThis.PointerEvent)
+    chart.onDocumentPointerDown()
 
     expect(chart.hoverBracket).toBeUndefined()
 

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapChart.test.ts
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapChart.test.ts
@@ -6,6 +6,7 @@ import {
     SynthesizeProjectedPopulationTable,
 } from "@ourworldindata/core-table"
 import { MapChartManager } from "./MapChartConstants"
+import { MapChart } from "./MapChart"
 import { MapChartState } from "./MapChartState"
 
 const table = SynthesizeGDPTable({
@@ -31,6 +32,32 @@ it("filters out non-map entities from colorScaleColumn", () => {
     expect(chartState.colorScaleColumn.uniqEntityNames).toEqual(
         expect.arrayContaining(["France", "Germany"])
     )
+})
+
+it("pins a map bracket selected by touch until the next touch", () => {
+    const chartState = new MapChartState({ manager })
+    const chart = new MapChart({ chartState })
+    const [firstBracket, secondBracket] = chartState.colorScale.legendBins
+
+    expect(firstBracket).toBeDefined()
+    expect(secondBracket).toBeDefined()
+
+    chart.onLegendMouseOver(firstBracket)
+    chart.onLegendTouchSelect(firstBracket)
+    chart.onLegendMouseLeave()
+    chart.onLegendMouseOver(secondBracket)
+
+    expect(chart.hoverBracket).toBe(firstBracket)
+
+    chart.onDocumentPointerDown({
+        pointerType: "touch",
+    } as globalThis.PointerEvent)
+
+    expect(chart.hoverBracket).toBeUndefined()
+
+    chart.onLegendMouseOver(secondBracket)
+
+    expect(chart.hoverBracket).toBe(secondBracket)
 })
 
 it("combines projected data with its historical counterpart", () => {

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
@@ -100,7 +100,11 @@ export class MapChart
      * Hovering a map bracket highlights all countries within that bracket on the map.
      */
     hoverBracket: MapBracket | undefined = undefined
-    private isLegendBracketPinned = false
+    /**
+     * For touch events, we "pin" the hover bracket into an active state until the user taps outside of the legend.
+     * This is to create a better touch device experience.
+     */
+    private isHoverBracketPinnedBecauseOfTouchEvent = false
 
     tooltipState = new TooltipState<{
         featureId: string
@@ -202,18 +206,18 @@ export class MapChart
     }
 
     @action.bound onLegendMouseOver(bracket: MapBracket): void {
-        if (this.isLegendBracketPinned) return
+        if (this.isHoverBracketPinnedBecauseOfTouchEvent) return
         this.hoverBracket = bracket
     }
 
     @action.bound onLegendMouseLeave(): void {
-        if (this.isLegendBracketPinned) return
+        if (this.isHoverBracketPinnedBecauseOfTouchEvent) return
         this.hoverBracket = undefined
     }
 
     @action.bound onLegendTouchSelect(bracket: MapBracket): void {
         this.hoverBracket = bracket
-        this.isLegendBracketPinned = true
+        this.isHoverBracketPinnedBecauseOfTouchEvent = true
     }
 
     @computed get mapConfig(): MapConfig {
@@ -237,11 +241,9 @@ export class MapChart
         }
     }
 
-    @action.bound onDocumentPointerDown(e: globalThis.PointerEvent): void {
-        if (e.pointerType !== "touch") return
-
+    @action.bound onDocumentPointerDown(): void {
         this.hoverBracket = undefined
-        this.isLegendBracketPinned = false
+        this.isHoverBracketPinnedBecauseOfTouchEvent = false
     }
 
     @computed get externalLegend(): HorizontalColorLegendManager | undefined {

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
@@ -245,9 +245,10 @@ export class MapChart
     // This only applies to when the hover bracket is currently pinned because of a touch event.
     // But it doesn't check that the pointer event here is a touch event, because otherwise we would
     // get into weird states with hybrid devices that have both touch and mouse input.
+    //
+    // Note that the legend itself stops propagation of pointer events, so this event handler will
+    // only be called when the user taps outside of the legend.
     @action.bound onDocumentPointerDown(): void {
-        if (!this.isHoverBracketPinnedBecauseOfTouchEvent) return
-
         this.hoverBracket = undefined
         this.isHoverBracketPinnedBecauseOfTouchEvent = false
     }

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
@@ -242,9 +242,9 @@ export class MapChart
     }
 
     // Clear the pinned hover bracket when the user taps outside of the legend.
-    // This only applies to when the hover bracket is pinned because of a touch event-
-    // But it doesn't check that the pointer event here is a touch event, because otherwise we would get into weird states
-    // with hybrid devices that have both touch and mouse input.
+    // This only applies to when the hover bracket is currently pinned because of a touch event.
+    // But it doesn't check that the pointer event here is a touch event, because otherwise we would
+    // get into weird states with hybrid devices that have both touch and mouse input.
     @action.bound onDocumentPointerDown(): void {
         if (!this.isHoverBracketPinnedBecauseOfTouchEvent) return
 

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
@@ -241,7 +241,13 @@ export class MapChart
         }
     }
 
+    // Clear the pinned hover bracket when the user taps outside of the legend.
+    // This only applies to when the hover bracket is pinned because of a touch event-
+    // But it doesn't check that the pointer event here is a touch event, because otherwise we would get into weird states
+    // with hybrid devices that have both touch and mouse input.
     @action.bound onDocumentPointerDown(): void {
+        if (!this.isHoverBracketPinnedBecauseOfTouchEvent) return
+
         this.hoverBracket = undefined
         this.isHoverBracketPinnedBecauseOfTouchEvent = false
     }

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
@@ -100,6 +100,7 @@ export class MapChart
      * Hovering a map bracket highlights all countries within that bracket on the map.
      */
     hoverBracket: MapBracket | undefined = undefined
+    private isLegendBracketPinned = false
 
     tooltipState = new TooltipState<{
         featureId: string
@@ -190,6 +191,7 @@ export class MapChart
         this.onMapMouseLeave()
         this.onLegendMouseLeave()
         document.removeEventListener("keydown", this.onDocumentKeyDown)
+        document.removeEventListener("pointerdown", this.onDocumentPointerDown)
     }
 
     @action.bound onLegendMouseEnter(bracket: MapBracket): void {
@@ -200,11 +202,18 @@ export class MapChart
     }
 
     @action.bound onLegendMouseOver(bracket: MapBracket): void {
+        if (this.isLegendBracketPinned) return
         this.hoverBracket = bracket
     }
 
     @action.bound onLegendMouseLeave(): void {
+        if (this.isLegendBracketPinned) return
         this.hoverBracket = undefined
+    }
+
+    @action.bound onLegendTouchSelect(bracket: MapBracket): void {
+        this.hoverBracket = bracket
+        this.isLegendBracketPinned = true
     }
 
     @computed get mapConfig(): MapConfig {
@@ -226,6 +235,13 @@ export class MapChart
             this.globeController.resetGlobe()
             this.mapConfig.region = MapRegionName.World
         }
+    }
+
+    @action.bound onDocumentPointerDown(e: globalThis.PointerEvent): void {
+        if (e.pointerType !== "touch") return
+
+        this.hoverBracket = undefined
+        this.isLegendBracketPinned = false
     }
 
     @computed get externalLegend(): HorizontalColorLegendManager | undefined {
@@ -250,6 +266,7 @@ export class MapChart
         exposeInstanceOnWindow(this)
 
         document.addEventListener("keydown", this.onDocumentKeyDown)
+        document.addEventListener("pointerdown", this.onDocumentPointerDown)
     }
 
     @computed private get legendData(): ColorScaleBin[] {


### PR DESCRIPTION
> _Written by OpenAI GPT-5 — @marcelgerber at the wheel._

Fixes #6396.

Fixes the long-standing issue that map brackets regularly became stuck-active after hovering them.

The problem here was that React would re-create the DOM elements because they got resorted after becoming highlighted; and then `mouseleave` wouldn't necessarily fire on the new DOM element, because they were not necessarily marked as `mouseenter`-ed after the DOM reshuffle.

This also improves the interaction pattern on mobile: A tap on a bracket marks the map bracket as highlighted, and it stays highlighted until the user taps anywhere else.
Touch targets are now also vertically larger, covering the space around the map bracket labels, too.

## Open questions

- [x] What should the mobile on-hover behavior be?