### PR TITLE
🐛 Show an error notice when search fails instead of "no results"

### DIFF
--- a/site/latest/LatestSearch.scss
+++ b/site/latest/LatestSearch.scss
@@ -30,8 +30,8 @@
     }
 }
 
-// Override SearchNoResults — it's display:none by default for multi-query search
-.latest-page .search-no-results {
+// Override SearchEmptyState — it's display:none by default for multi-query search
+.latest-page .search-empty-state {
     display: block;
 }
 

--- a/site/latest/LatestSearch.tsx
+++ b/site/latest/LatestSearch.tsx
@@ -22,6 +22,7 @@ import { SiteAnalytics } from "../SiteAnalytics.js"
 import { NewsletterSignupBlock } from "../NewsletterSignupBlock.js"
 import { SearchHorizontalDivider } from "../search/SearchHorizontalDivider.js"
 import { SearchNoResults } from "../search/SearchNoResults.js"
+import { SearchError } from "../search/SearchError.js"
 import { NewsletterSubscriptionContext } from "../newsletter.js"
 import { PoweredBy } from "react-instantsearch"
 
@@ -83,6 +84,7 @@ export const LatestSearch = ({
         hasNextPage,
         isFetchingNextPage,
         isLoading,
+        isError,
     } = useInfiniteLatestPages({
         topics,
         latestType,
@@ -158,6 +160,8 @@ export const LatestSearch = ({
             <hr className="latest-search__filters-divider span-cols-12 col-start-2 span-md-cols-12 col-md-start-2 span-sm-cols-14 col-sm-start-1" />
             {isLoading ? (
                 <LatestSearchSkeleton />
+            ) : isError ? (
+                <SearchError />
             ) : hits.length === 0 ? (
                 <SearchNoResults
                     subtitle={

--- a/site/latest/LatestSearch.tsx
+++ b/site/latest/LatestSearch.tsx
@@ -85,11 +85,20 @@ export const LatestSearch = ({
         isFetchingNextPage,
         isLoading,
         isError,
+        isPlaceholderData,
     } = useInfiniteLatestPages({
         topics,
         latestType,
         liteSearchClient,
     })
+
+    // Only replace the feed with the error notice when the failure left us
+    // with nothing worth showing. A failed "load more" or background refetch
+    // sets isError while the already-loaded cards are still in `data`, and
+    // those stay useful; placeholder hits, on the other hand, belong to the
+    // previous filter selection, so showing them under the current filters
+    // would be wrong.
+    const hasNothingToShow = isError && (hits.length === 0 || isPlaceholderData)
 
     // Disable type options that would yield 0 results given the current
     // topic selection. Never disable the currently active type.
@@ -160,7 +169,7 @@ export const LatestSearch = ({
             <hr className="latest-search__filters-divider span-cols-12 col-start-2 span-md-cols-12 col-md-start-2 span-sm-cols-14 col-sm-start-1" />
             {isLoading ? (
                 <LatestSearchSkeleton />
-            ) : isError ? (
+            ) : hasNothingToShow ? (
                 <SearchError heading="We couldn’t load the latest updates." />
             ) : hits.length === 0 ? (
                 <SearchNoResults

--- a/site/latest/LatestSearch.tsx
+++ b/site/latest/LatestSearch.tsx
@@ -161,7 +161,7 @@ export const LatestSearch = ({
             {isLoading ? (
                 <LatestSearchSkeleton />
             ) : isError ? (
-                <SearchError />
+                <SearchError heading="We couldn’t load the latest updates." />
             ) : hits.length === 0 ? (
                 <SearchNoResults
                     subtitle={

--- a/site/owid.scss
+++ b/site/owid.scss
@@ -88,7 +88,7 @@
 @import "./search/SearchStackedArticleHit.scss";
 @import "./search/SearchTopicPageHit.scss";
 @import "./search/SearchResultHeader.scss";
-@import "./search/SearchNoResults.scss";
+@import "./search/SearchEmptyState.scss";
 @import "./search/SearchClosestMatchesNotice.scss";
 @import "./search/SearchDetectedFilters.scss";
 @import "./search/skeletons.scss";

--- a/site/search/Search.test.tsx
+++ b/site/search/Search.test.tsx
@@ -68,14 +68,14 @@ describe("Search empty states", () => {
         expect(
             await screen.findByText(/no results for this query/i)
         ).toBeTruthy()
-        expect(screen.queryByText(/temporarily unavailable/i)).toBeNull()
+        expect(screen.queryByText(/isn’t working right now/i)).toBeNull()
     })
 
     it("shows an error notice, not the no-results notice, when the search fails", async () => {
         renderSearch(failingClient)
 
         expect(
-            await screen.findByText(/search is temporarily unavailable/i)
+            await screen.findByText(/search isn’t working right now/i)
         ).toBeTruthy()
         expect(screen.queryByText(/no results for this query/i)).toBeNull()
     })

--- a/site/search/Search.test.tsx
+++ b/site/search/Search.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import { expect, it, describe } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { MemoryRouter } from "react-router-dom-v5-compat"
+import type { LiteClient } from "algoliasearch/lite"
+import { TagGraphRootName, type TagGraphRoot } from "@ourworldindata/types"
+import { Search } from "./Search.js"
+
+const topicTagGraph: TagGraphRoot = {
+    children: [],
+    id: 0,
+    isTopic: false,
+    isSearchable: false,
+    name: TagGraphRootName,
+    path: [0],
+    slug: null,
+    weight: 0,
+}
+
+// Every search query ultimately goes through `searchForHits` (see
+// searchClosestMatches.ts in @ourworldindata/utils), so stubbing it is enough
+// to simulate Algolia being up-but-empty or failing outright.
+function makeSearchClient(
+    searchForHits: (requests: unknown[]) => Promise<unknown>
+): LiteClient {
+    return { searchForHits } as unknown as LiteClient
+}
+
+const emptyResultsClient = makeSearchClient((requests) =>
+    Promise.resolve({
+        results: requests.map(() => ({
+            hits: [],
+            nbHits: 0,
+            nbPages: 0,
+            page: 0,
+        })),
+    })
+)
+
+const failingClient = makeSearchClient(() =>
+    Promise.reject(new Error("This operation cannot be processed"))
+)
+
+function renderSearch(liteSearchClient: LiteClient) {
+    const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+    })
+    render(
+        <MemoryRouter initialEntries={["/search?q=gdp"]}>
+            <QueryClientProvider client={queryClient}>
+                <Search
+                    topicTagGraph={topicTagGraph}
+                    liteSearchClient={liteSearchClient}
+                />
+            </QueryClientProvider>
+        </MemoryRouter>
+    )
+}
+
+describe("Search empty states", () => {
+    it("shows the no-results notice when the search succeeds without hits", async () => {
+        renderSearch(emptyResultsClient)
+
+        expect(
+            await screen.findByText(/no results for this query/i)
+        ).toBeTruthy()
+        expect(screen.queryByText(/temporarily unavailable/i)).toBeNull()
+    })
+
+    it("shows an error notice, not the no-results notice, when the search fails", async () => {
+        renderSearch(failingClient)
+
+        expect(
+            await screen.findByText(/search is temporarily unavailable/i)
+        ).toBeTruthy()
+        expect(screen.queryByText(/no results for this query/i)).toBeNull()
+    })
+})

--- a/site/search/Search.test.tsx
+++ b/site/search/Search.test.tsx
@@ -3,12 +3,13 @@
  */
 
 import { expect, it, describe } from "vitest"
-import { render, screen } from "@testing-library/react"
+import { fireEvent, render, screen } from "@testing-library/react"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { MemoryRouter } from "react-router-dom-v5-compat"
 import type { LiteClient } from "algoliasearch/lite"
 import { TagGraphRootName, type TagGraphRoot } from "@ourworldindata/types"
 import { Search } from "./Search.js"
+import { CHARTS_INDEX } from "./searchUtils.js"
 
 const topicTagGraph: TagGraphRoot = {
     children: [],
@@ -30,7 +31,7 @@ function makeSearchClient(
     return { searchForHits } as unknown as LiteClient
 }
 
-const emptyResultsClient = makeSearchClient((requests) =>
+const emptyResults = (requests: unknown[]) =>
     Promise.resolve({
         results: requests.map(() => ({
             hits: [],
@@ -39,18 +40,34 @@ const emptyResultsClient = makeSearchClient((requests) =>
             page: 0,
         })),
     })
-)
+
+const emptyResultsClient = makeSearchClient(emptyResults)
 
 const failingClient = makeSearchClient(() =>
     Promise.reject(new Error("This operation cannot be processed"))
 )
 
-function renderSearch(liteSearchClient: LiteClient) {
+// Fails only the charts index, so the Data template errors while the Writing
+// template searches successfully.
+const chartsOnlyFailingClient = makeSearchClient((requests) => {
+    const failsChartsIndex = requests.some(
+        (request) =>
+            (request as { indexName?: string }).indexName === CHARTS_INDEX
+    )
+    if (failsChartsIndex)
+        return Promise.reject(new Error("This operation cannot be processed"))
+    return emptyResults(requests)
+})
+
+function renderSearch(
+    liteSearchClient: LiteClient,
+    searchParams: string = "?q=gdp"
+) {
     const queryClient = new QueryClient({
         defaultOptions: { queries: { retry: false } },
     })
     render(
-        <MemoryRouter initialEntries={["/search?q=gdp"]}>
+        <MemoryRouter initialEntries={[`/search${searchParams}`]}>
             <QueryClientProvider client={queryClient}>
                 <Search
                     topicTagGraph={topicTagGraph}
@@ -78,5 +95,23 @@ describe("Search empty states", () => {
             await screen.findByText(/search isn’t working right now/i)
         ).toBeTruthy()
         expect(screen.queryByText(/no results for this query/i)).toBeNull()
+    })
+
+    it("drops the error notice once the failed query is no longer rendered", async () => {
+        // The charts query keeps its cache entry (and its error) after the
+        // toggle switches to Writing, because `resultType` is not part of the
+        // query key — only the observer check keeps the notice from sticking.
+        renderSearch(chartsOnlyFailingClient, "?q=gdp&resultType=data")
+
+        expect(
+            await screen.findByText(/search isn’t working right now/i)
+        ).toBeTruthy()
+
+        fireEvent.click(screen.getByLabelText("Writing"))
+
+        expect(
+            await screen.findByText(/no results for this query/i)
+        ).toBeTruthy()
+        expect(screen.queryByText(/isn’t working right now/i)).toBeNull()
     })
 })

--- a/site/search/Search.tsx
+++ b/site/search/Search.tsx
@@ -17,7 +17,11 @@ import {
     hasDatasetFilters,
     isBrowsing,
 } from "./searchUtils.js"
-import { useTagGraphTopics, useSearchAnalytics } from "./searchHooks.js"
+import {
+    useTagGraphTopics,
+    useSearchAnalytics,
+    useHasSearchError,
+} from "./searchHooks.js"
 import { stateToSearchParams, useSearchParamsState } from "./searchState.js"
 
 // Components
@@ -29,6 +33,7 @@ import { SearchTemplatesAll } from "./SearchTemplatesAll.js"
 import { SearchTemplatesData } from "./SearchTemplatesData.js"
 import { SearchTemplatesWriting } from "./SearchTemplatesWriting.js"
 import { SearchNoResults } from "./SearchNoResults.js"
+import { SearchError } from "./SearchError.js"
 import { SearchDetectedFilters } from "./SearchDetectedFilters.js"
 import { buildSynonymMap } from "./synonymUtils.js"
 import { SiteAnalytics } from "../SiteAnalytics.js"
@@ -67,6 +72,7 @@ export const Search = ({
     useSearchAnalytics(state, analytics)
 
     const isFetching = useIsFetching()
+    const hasSearchError = useHasSearchError(state)
 
     // Autofocus only on the first mount if the user is browsing.
     const [shouldAutoFocus, setShouldAutoFocus] = useState(() =>
@@ -128,7 +134,8 @@ export const Search = ({
                 <SearchResultTypeToggle />
             </div>
             <div className="search-template-results col-start-2 span-cols-12">
-                {!isFetching && <SearchNoResults />}
+                {!isFetching &&
+                    (hasSearchError ? <SearchError /> : <SearchNoResults />)}
                 {match(templateConfig.resultType)
                     .with(SearchResultType.ALL, () => <SearchTemplatesAll />)
                     .with(SearchResultType.DATA, () => <SearchTemplatesData />)

--- a/site/search/SearchEmptyState.scss
+++ b/site/search/SearchEmptyState.scss
@@ -1,4 +1,4 @@
-.search-no-results {
+.search-empty-state {
     display: none;
     text-align: center;
     margin-top: min(100px, 15vh);
@@ -10,7 +10,7 @@
     p {
         color: $blue-60;
     }
-    .search-no-results__icon {
+    .search-empty-state__icon {
         background-color: $blue-10;
         color: $blue-50;
         font-size: 20px;
@@ -19,6 +19,6 @@
     }
 }
 
-.search-no-results:only-child {
+.search-empty-state:only-child {
     display: block;
 }

--- a/site/search/SearchEmptyState.tsx
+++ b/site/search/SearchEmptyState.tsx
@@ -1,0 +1,33 @@
+import React from "react"
+import type { IconDefinition } from "@fortawesome/fontawesome-svg-core"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+
+/**
+ * Shared layout for the states where a search page has nothing to show: no
+ * results for the query (`SearchNoResults`) and a failed search
+ * (`SearchError`).
+ *
+ * On /search this is hidden unless it is the only child of the results
+ * container (see SearchEmptyState.scss), so it never shows up next to result
+ * sections that did return hits.
+ */
+export const SearchEmptyState = ({
+    icon,
+    heading,
+    subtitle,
+}: {
+    icon: IconDefinition
+    heading: string
+    subtitle: React.ReactNode
+}) => {
+    return (
+        <div className="search-empty-state span-cols-12 col-start-2">
+            <FontAwesomeIcon
+                className="search-empty-state__icon"
+                icon={icon}
+            />
+            <h2 className="body-1-regular">{heading}</h2>
+            {subtitle}
+        </div>
+    )
+}

--- a/site/search/SearchEmptyState.tsx
+++ b/site/search/SearchEmptyState.tsx
@@ -22,10 +22,7 @@ export const SearchEmptyState = ({
 }) => {
     return (
         <div className="search-empty-state span-cols-12 col-start-2">
-            <FontAwesomeIcon
-                className="search-empty-state__icon"
-                icon={icon}
-            />
+            <FontAwesomeIcon className="search-empty-state__icon" icon={icon} />
             <h2 className="body-1-regular">{heading}</h2>
             {subtitle}
         </div>

--- a/site/search/SearchError.tsx
+++ b/site/search/SearchError.tsx
@@ -1,0 +1,23 @@
+import { faTriangleExclamation } from "@fortawesome/free-solid-svg-icons"
+import { SearchEmptyState } from "./SearchEmptyState.js"
+
+/**
+ * Shown when the search backend failed, in place of the "no results" notice.
+ * The distinction matters: telling readers there are no results for their
+ * query when we couldn't search at all sends them away believing we have
+ * nothing on the topic.
+ */
+export const SearchError = () => {
+    return (
+        <SearchEmptyState
+            icon={faTriangleExclamation}
+            heading="Search is temporarily unavailable."
+            subtitle={
+                <p className="body-3-medium">
+                    Something went wrong on our end. Please try again in a few
+                    minutes.
+                </p>
+            }
+        />
+    )
+}

--- a/site/search/SearchError.tsx
+++ b/site/search/SearchError.tsx
@@ -5,17 +5,23 @@ import { SearchEmptyState } from "./SearchEmptyState.js"
  * Shown when the search backend failed, in place of the "no results" notice.
  * The distinction matters: telling readers there are no results for their
  * query when we couldn't search at all sends them away believing we have
- * nothing on the topic.
+ * nothing on the topic — hence the reassurance that the content is still
+ * there, and no promise about when search will be back.
  */
-export const SearchError = () => {
+export const SearchError = ({
+    heading = "Search isn’t working right now.",
+}: {
+    heading?: string
+} = {}) => {
     return (
         <SearchEmptyState
             icon={faTriangleExclamation}
-            heading="Search is temporarily unavailable."
+            heading={heading}
             subtitle={
                 <p className="body-3-medium">
-                    Something went wrong on our end. Please try again in a few
-                    minutes.
+                    This is a problem on our end. Our charts and articles are
+                    all still there — you can browse them by topic from the site
+                    menu.
                 </p>
             }
         />

--- a/site/search/SearchNoResults.tsx
+++ b/site/search/SearchNoResults.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { faSearch } from "@fortawesome/free-solid-svg-icons"
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import { SearchEmptyState } from "./SearchEmptyState.js"
 
 export const SearchNoResults = ({
     heading = "There are no results for this query.",
@@ -14,13 +14,10 @@ export const SearchNoResults = ({
     subtitle?: React.ReactNode
 } = {}) => {
     return (
-        <div className="search-no-results span-cols-12 col-start-2">
-            <FontAwesomeIcon
-                className="search-no-results__icon"
-                icon={faSearch}
-            />
-            <h2 className="body-1-regular">{heading}</h2>
-            {subtitle}
-        </div>
+        <SearchEmptyState
+            icon={faSearch}
+            heading={heading}
+            subtitle={subtitle}
+        />
     )
 }

--- a/site/search/searchHooks.ts
+++ b/site/search/searchHooks.ts
@@ -7,11 +7,22 @@ import {
 } from "./searchUtils.js"
 import { DEFAULT_SEARCH_STATE } from "./searchState.js"
 import { useSearchContext } from "./SearchContext.js"
+import { searchQueryKeys } from "./queries.js"
 import { fetchJson, flattenNonTopicNodes } from "@ourworldindata/utils"
-import { useInfiniteQuery, useQuery } from "@tanstack/react-query"
+import {
+    useInfiniteQuery,
+    useQuery,
+    useQueryClient,
+} from "@tanstack/react-query"
 import { LiteClient } from "algoliasearch/lite"
 import type { SearchResponse } from "algoliasearch"
-import { useEffect, useMemo, useRef } from "react"
+import {
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useSyncExternalStore,
+} from "react"
 import type { TagGraphNode, TagGraphRoot } from "@ourworldindata/types"
 import { SiteAnalytics } from "../SiteAnalytics.js"
 import * as R from "remeda"
@@ -225,6 +236,46 @@ export function useInfiniteSearch<THit>({
         totalResults,
         isClosestMatches,
     }
+}
+
+/**
+ * True when any of the Algolia queries for the current search state failed
+ * (e.g. Algolia is down or blocking us). Every results component renders
+ * nothing when its query fails, so without this the page falls back to the
+ * "no results for this query" notice, which misrepresents an outage as an
+ * empty index — see `SearchError`.
+ *
+ * Scoped to the current state's query keys on purpose: the query cache is
+ * shared site-wide and keeps failed queries from earlier searches around
+ * until they are garbage collected.
+ */
+export function useHasSearchError(state: SearchState): boolean {
+    const queryCache = useQueryClient().getQueryCache()
+
+    const getSnapshot = () =>
+        [
+            searchQueryKeys.charts(state),
+            searchQueryKeys.dataTopics(state),
+            searchQueryKeys.dataInsights(state),
+            searchQueryKeys.articles(state),
+            searchQueryKeys.topicPages(state),
+            searchQueryKeys.writingTopics(state),
+            searchQueryKeys.profiles(state),
+        ].some(
+            (queryKey) =>
+                queryCache.find({ queryKey, exact: true })?.state.status ===
+                "error"
+        )
+
+    return useSyncExternalStore(
+        useCallback(
+            (onStoreChange) => queryCache.subscribe(onStoreChange),
+            [queryCache]
+        ),
+        getSnapshot,
+        // No query has run during server rendering
+        () => false
+    )
 }
 
 export function useTopicTagGraph({ isPreviewing }: { isPreviewing: boolean }) {

--- a/site/search/searchHooks.ts
+++ b/site/search/searchHooks.ts
@@ -245,9 +245,13 @@ export function useInfiniteSearch<THit>({
  * "no results for this query" notice, which misrepresents an outage as an
  * empty index — see `SearchError`.
  *
- * Scoped to the current state's query keys on purpose: the query cache is
- * shared site-wide and keeps failed queries from earlier searches around
- * until they are garbage collected.
+ * The query cache is shared site-wide and holds on to failed queries until
+ * they are garbage collected, so this only counts failures that are both
+ * keyed to the current search state and still observed by a mounted
+ * component. Without the observer check, a charts query that failed under
+ * the Data toggle would keep the notice up after a switch to Writing, whose
+ * template doesn't render charts at all — `resultType` is deliberately not
+ * part of the query keys.
  */
 export function useHasSearchError(state: SearchState): boolean {
     const queryCache = useQueryClient().getQueryCache()
@@ -261,11 +265,12 @@ export function useHasSearchError(state: SearchState): boolean {
             searchQueryKeys.topicPages(state),
             searchQueryKeys.writingTopics(state),
             searchQueryKeys.profiles(state),
-        ].some(
-            (queryKey) =>
-                queryCache.find({ queryKey, exact: true })?.state.status ===
-                "error"
-        )
+        ].some((queryKey) => {
+            const query = queryCache.find({ queryKey, exact: true })
+            return (
+                query?.state.status === "error" && query.getObserversCount() > 0
+            )
+        })
 
     return useSyncExternalStore(
         useCallback(


### PR DESCRIPTION
> _Written by Anthropic Claude Opus 5 — @Marigold at the wheel._

When the search backend fails, every results section on `/search` renders nothing, so the page falls back to "There are no results for this query." During today's Algolia outage that meant readers searching for `gdp` were told we have nothing on GDP, publicly included. This adds a distinct notice for failed searches, on `/search` and `/latest`: _"Search isn't working right now. This is a problem on our end. Our charts and articles are all still there — you can browse them by topic from the site menu."_ It deliberately makes no promise about when search returns, since the cause is usually not ours to fix on a schedule.

_Skim — one new hook, one component split, no change to any working search path._

**[Before / after screenshots](https://claude.ai/code/artifact/a67bd6c1-dbf3-40cd-97fa-b7e029bc2e51)** — `/search?q=gdp` captured live with the Algolia requests blocked, production on the left and this branch on the right.

## How it works

`useHasSearchError(state)` watches the React Query cache (`useSyncExternalStore` over `queryCache.subscribe`, the same pattern as the library's own `useIsFetching`) and reports whether any of the current search state's Algolia queries ended in `error`. `Search.tsx` then renders `SearchError` instead of `SearchNoResults`.

Three decisions worth knowing:

- **Cache introspection rather than per-section error states.** Each results component already returns `null` when its query fails, so the alternative was making all six of them report upward, or showing six error boxes. Reading the cache keeps the change in one place.
- **Scoped to the current state's query keys and to queries a mounted component still observes.** The cache is shared site-wide, so an unscoped check would flip on a failed chart-hit data fetch. The observer check covers what the keys can't: `resultType` is deliberately not part of them, so a charts query that failed under the Data toggle would otherwise keep the notice up after a switch to Writing, whose template renders no charts at all.
- **The error notice reuses the no-results `:only-child` CSS trick** (`SearchEmptyState`), so it appears only when nothing else rendered. If the charts query fails but writing results come back, the reader sees the writing results and no error — same degradation as today, minus the false claim.

The markup that was inside `SearchNoResults` moved into `SearchEmptyState`, and `SearchNoResults.scss` was renamed to match (styling only — which of the two notices renders is decided in `Search.tsx`). `SearchNoResults` keeps its existing props and call sites. `/latest` passes its own heading, since "Search isn't working" reads oddly on a feed page, and only swaps in the notice when the failure left nothing usable: an infinite query keeps its loaded pages when a "load more" fails, and those cards stay worth showing — while placeholder hits don't, because `keepPreviousData` means they belong to the previous filter selection.

Not covered: the autocomplete dropdown, which shows an empty list on failure — silent, but not misleading in the same way.

## Verified

- Seen in a browser, not just asserted: the screenshots linked above are captures of this branch on staging and of production, both with the Algolia requests aborted.
- `site/search/Search.test.tsx` renders `<Search>` against a stubbed `LiteClient` and separates three cases — a search that succeeds with zero hits still says "no results"; a rejecting client shows the error notice and not "no results"; and after the toggle moves from Data to Writing, the cached charts failure no longer produces a notice. I checked that each of the last two fails without the code it covers, so neither passes vacuously.
- Not verified: `/latest`, which has no component test. Its two states are the same component, but the "keep the loaded cards when load-more fails" condition is only reasoned from the query-state types, not exercised.

## How to test it

https://staging-site-search-error-message.owid.io/search?q=gdp — search works again, so to see the failure state open DevTools → Network → block request URL `*algolia*`, then reload. The notice appears after roughly seven seconds, once React Query has worked through its three retries.
