### PR TITLE
✅ Add vitest benchmarks for hot grapher render paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
         "testFormatAll": "yarn oxfmt --check",
         "testFormatChanged": "bash -c 'files=$((git diff --name-only --diff-filter=ACMRTUXB && git diff --name-only --cached --diff-filter=ACMRTUXB) | sort -u | grep -E \"\\.(tsx?|jsx?|ts|js|json|md|html|css|scss|yml)$\" | tr \"\\n\" \" \"); if [ -n \"$files\" ]; then yarn oxfmt --check $files; else echo \"No uncommitted files to check formatting\"; fi'",
         "test": "vitest",
+        "bench": "vitest bench --run",
         "test:functions:e2e-r2": "vitest functions/test/grapher-config-r2.e2e.test.ts",
         "test:functions:e2e-search": "vitest functions/test/search.e2e.test.ts",
         "testBdd": "yarn bddgen && yarn playwright test",

--- a/packages/@ourworldindata/components/src/TextWrap/TextWrap.bench.ts
+++ b/packages/@ourworldindata/components/src/TextWrap/TextWrap.bench.ts
@@ -1,0 +1,54 @@
+import { bench, describe } from "vitest"
+import { Bounds } from "@ourworldindata/utils"
+import { TextWrap, shortenWithEllipsis } from "./TextWrap.js"
+
+// Text measurement is one of the most frequently called operations in a render:
+// every axis tick, legend entry, label and title is measured (and often
+// wrapped or truncated) to lay it out. Each individual call is cheap, but they
+// happen thousands of times per chart, so the per-call cost matters.
+
+/** Reference a value so it isn't flagged as an unused expression. */
+function keep(value: unknown): void {
+    if (value === undefined) throw new Error("expected a value")
+}
+
+const shortLabel = "Life expectancy"
+const longTitle =
+    "Share of the population living in extreme poverty, by world region, 1990 to 2019"
+const paragraph =
+    "Our World in Data presents the empirical evidence on global living " +
+    "conditions across many dimensions such as health, poverty, education, " +
+    "and the environment, drawing on data from research institutions and " +
+    "statistical agencies around the world."
+
+describe("Bounds.forText (measurement kernel)", () => {
+    bench("short label", () => {
+        Bounds.forText(shortLabel, { fontSize: 12 })
+    })
+
+    bench("long title", () => {
+        Bounds.forText(longTitle, { fontSize: 16 })
+    })
+})
+
+describe("TextWrap.lines (word wrapping)", () => {
+    // TextWrap memoizes its computed getters, so build a fresh instance per
+    // iteration and then read `lines` to trigger the wrapping.
+    bench("wrap a title to 320px", () => {
+        keep(
+            new TextWrap({ text: longTitle, maxWidth: 320, fontSize: 16 }).lines
+        )
+    })
+
+    bench("wrap a paragraph to 400px", () => {
+        keep(
+            new TextWrap({ text: paragraph, maxWidth: 400, fontSize: 14 }).lines
+        )
+    })
+})
+
+describe("shortenWithEllipsis (binary-search truncation)", () => {
+    bench("truncate a title to 200px", () => {
+        shortenWithEllipsis(longTitle, 200, { fontSize: 16 })
+    })
+})

--- a/packages/@ourworldindata/core-table/src/CoreTableUtils.bench.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTableUtils.bench.ts
@@ -1,0 +1,113 @@
+import { bench, describe } from "vitest"
+import { CoreValueType, Time } from "@ourworldindata/types"
+import {
+    ErrorValueTypes,
+    linearInterpolation,
+    toleranceInterpolation,
+    computeRollingAverage,
+} from "./index.js"
+
+// These are the innermost numeric kernels of the table transform pipeline.
+// Grapher runs them once per entity group whenever a chart applies tolerance,
+// linear interpolation or a rolling-average smoothing, so they sit directly on
+// the hot path between "data loaded" and "chart drawn". We feed them synthetic
+// single-entity time series so the benchmark measures the loop itself, free of
+// table-construction overhead.
+
+interface SparseSeries {
+    values: CoreValueType[]
+    times: Time[]
+    validIndices: number[]
+}
+
+/**
+ * Build a single-entity time series of `length` points where roughly every
+ * `gapEvery`-th point carries a value and the rest are gaps to be filled in.
+ * Deterministic (no randomness) so numbers are comparable across runs.
+ */
+function makeSparseSeries(length: number, gapEvery: number): SparseSeries {
+    const values: CoreValueType[] = []
+    const times: Time[] = []
+    const validIndices: number[] = []
+    for (let i = 0; i < length; i++) {
+        times.push(1900 + i)
+        if (i % gapEvery === 0) {
+            values.push(100 + Math.sin(i / 7) * 50)
+            validIndices.push(i)
+        } else {
+            values.push(ErrorValueTypes.MissingValuePlaceholder)
+        }
+    }
+    return { values, times, validIndices }
+}
+
+/** A dense numeric array for rolling-average smoothing. */
+function makeDenseValues(length: number): number[] {
+    const values: number[] = []
+    for (let i = 0; i < length; i++)
+        values.push(1000 + Math.sin(i / 5) * 200 + i)
+    return values
+}
+
+const small = makeSparseSeries(120, 4) // ~1 variable, 120 years, gaps every 4th
+const large = makeSparseSeries(2000, 4) // long daily-ish series with many gaps
+
+describe(linearInterpolation, () => {
+    // The kernels mutate their input in place, so each iteration works on a
+    // fresh copy — otherwise the second run would only measure the fully-filled
+    // short-circuit. slice() is a cheap native copy relative to the loop.
+    const context = { extrapolateAtStart: true, extrapolateAtEnd: true }
+
+    bench("120 points, gaps every 4th", () => {
+        linearInterpolation(
+            small.values.slice(),
+            small.times,
+            [...small.validIndices],
+            context
+        )
+    })
+
+    bench("2000 points, gaps every 4th", () => {
+        linearInterpolation(
+            large.values.slice(),
+            large.times,
+            [...large.validIndices],
+            context
+        )
+    })
+})
+
+describe(toleranceInterpolation, () => {
+    const context = { timeToleranceForwards: 5, timeToleranceBackwards: 5 }
+
+    bench("120 points, tolerance 5", () => {
+        toleranceInterpolation(
+            small.values.slice(),
+            small.times.slice(),
+            [...small.validIndices],
+            context
+        )
+    })
+
+    bench("2000 points, tolerance 5", () => {
+        toleranceInterpolation(
+            large.values.slice(),
+            large.times.slice(),
+            [...large.validIndices],
+            context
+        )
+    })
+})
+
+describe(computeRollingAverage, () => {
+    const smallDense = makeDenseValues(120)
+    const largeDense = makeDenseValues(2000)
+
+    bench("120 points, window 7", () => {
+        computeRollingAverage(smallDense, 7)
+    })
+
+    bench("2000 points, window 30", () => {
+        computeRollingAverage(largeDense, 30)
+    })
+})

--- a/packages/@ourworldindata/core-table/src/OwidTable.bench.ts
+++ b/packages/@ourworldindata/core-table/src/OwidTable.bench.ts
@@ -1,0 +1,114 @@
+import { bench, describe } from "vitest"
+import {
+    ColumnTypeNames,
+    OwidColumnDef,
+    OwidTableSlugs,
+} from "@ourworldindata/types"
+import { OwidTable } from "./OwidTable.js"
+import {
+    SampleColumnSlugs,
+    SynthesizeGDPTable,
+} from "./OwidTableSynthesizers.js"
+
+// Table-level transforms are what a chart's `transformTable()` chains together
+// on every render. They walk the whole column store, so their cost scales with
+// entity count × time range. We build tables once and measure the individual
+// transforms; the synthesizer uses a fixed seed so the data is identical run
+// to run.
+
+const SEED = 1
+
+/** Reference a value so it isn't flagged as an unused expression (and assert the materialization actually produced data). */
+function keep(value: unknown): void {
+    if (value === undefined) throw new Error("expected a value")
+}
+
+const dataColumnDefs: OwidColumnDef[] = [
+    { slug: SampleColumnSlugs.Population, type: ColumnTypeNames.Population },
+    { slug: SampleColumnSlugs.GDP, type: ColumnTypeNames.Currency },
+    { slug: SampleColumnSlugs.LifeExpectancy, type: ColumnTypeNames.Age },
+]
+
+/**
+ * Build a plain CSV string (~entityCount × timeSpan rows, 3 numeric columns)
+ * the way an ingested dataset arrives, so we can measure the parse-and-type
+ * path in isolation from data generation.
+ */
+function makeCsv(entityCount: number, timeSpan: number): string {
+    const header = [
+        OwidTableSlugs.EntityName,
+        OwidTableSlugs.EntityCode,
+        OwidTableSlugs.EntityId,
+        OwidTableSlugs.Year,
+        SampleColumnSlugs.Population,
+        SampleColumnSlugs.GDP,
+        SampleColumnSlugs.LifeExpectancy,
+    ].join(",")
+
+    const lines: string[] = [header]
+    for (let e = 0; e < entityCount; e++) {
+        const name = `Country ${e}`
+        const code = `C${e}`
+        for (let t = 0; t < timeSpan; t++) {
+            const year = 1900 + t
+            const pop = Math.round(1e7 + Math.sin(e + t) * 1e6)
+            const gdp = Math.round(1e9 + Math.cos(e + t) * 1e8)
+            const life = (60 + ((e + t) % 30)).toFixed(2)
+            lines.push(`${name},${code},${e},${year},${pop},${gdp},${life}`)
+        }
+    }
+    return lines.join("\n")
+}
+
+describe("OwidTable construction (CSV parse + type coercion)", () => {
+    const smallCsv = makeCsv(50, 60) // 3k rows
+    const largeCsv = makeCsv(200, 120) // 24k rows
+
+    // The column store is computed lazily on first access, so we read a column's
+    // values to force the parse we want to measure.
+    bench("parse 3k rows", () => {
+        const table = new OwidTable(smallCsv, dataColumnDefs)
+        keep(table.get(SampleColumnSlugs.GDP).values)
+    })
+
+    bench("parse 24k rows", () => {
+        const table = new OwidTable(largeCsv, dataColumnDefs)
+        keep(table.get(SampleColumnSlugs.GDP).values)
+    })
+})
+
+describe("filterByEntityNames", () => {
+    const table = SynthesizeGDPTable(
+        { entityCount: 200, timeRange: [1900, 2020] },
+        SEED
+    )
+    // Materialize the base table once so we measure the filter, not the parse.
+    keep(table.get(SampleColumnSlugs.GDP).values)
+    const half = table.availableEntityNames.slice(
+        0,
+        Math.floor(table.availableEntityNames.length / 2)
+    )
+
+    bench("keep half of 200 entities", () => {
+        const filtered = table.filterByEntityNames(half)
+        keep(filtered.numRows)
+    })
+})
+
+describe("interpolateColumnWithTolerance", () => {
+    // Punch holes in the data so tolerance interpolation actually has gaps to
+    // fill (complete grid → sort → interpolate is the expensive branch).
+    const table = SynthesizeGDPTable(
+        { entityCount: 100, timeRange: [1900, 2000] },
+        SEED
+    ).replaceRandomCells(4000, [SampleColumnSlugs.Population], SEED)
+    keep(table.get(SampleColumnSlugs.Population).values)
+
+    bench("tolerance 10 over 100 entities × 100 years", () => {
+        const interpolated = table.interpolateColumnWithTolerance(
+            SampleColumnSlugs.Population,
+            { toleranceOverride: 10 }
+        )
+        keep(interpolated.get(SampleColumnSlugs.Population).values)
+    })
+})

--- a/packages/@ourworldindata/grapher/src/color/BinningStrategies.bench.ts
+++ b/packages/@ourworldindata/grapher/src/color/BinningStrategies.bench.ts
@@ -1,0 +1,54 @@
+import { bench, describe } from "vitest"
+import {
+    BinningStrategyConfig,
+    runBinningStrategy,
+} from "./BinningStrategies.js"
+
+// Choropleth maps and scatter color legends call `runBinningStrategy` to derive
+// the numeric bin thresholds from the full set of values in the color column.
+// It sorts and de-duplicates the values, computes quantiles and (for midpoint
+// modes) makes several extra passes over the array, so its cost grows with the
+// number of distinct data points.
+
+/** A deterministic, ascending-sorted distribution spanning negative → positive. */
+function makeSortedValues(count: number): number[] {
+    const values: number[] = []
+    for (let i = 0; i < count; i++) {
+        // A skewed spread from roughly -200 to +2000
+        values.push(Math.round((Math.sin(i) + 1) ** 3 * 250 - 200))
+    }
+    return values.sort((a, b) => a - b)
+}
+
+const values = makeSortedValues(10000)
+
+describe(runBinningStrategy, () => {
+    // runBinningStrategy mutates the config it receives (fills in midpoint /
+    // midpointMode defaults), so we hand it a fresh config object each iteration
+    // while reusing the shared sorted values array.
+    bench("auto, 10k values", () => {
+        const conf: BinningStrategyConfig = {
+            strategy: "auto",
+            sortedValues: values,
+        }
+        runBinningStrategy(conf)
+    })
+
+    bench("equalSizeBins-normal, 10k values", () => {
+        const conf: BinningStrategyConfig = {
+            strategy: "equalSizeBins-normal",
+            sortedValues: values,
+        }
+        runBinningStrategy(conf)
+    })
+
+    bench("symmetric midpoint at 0, 10k values", () => {
+        const conf: BinningStrategyConfig = {
+            strategy: "auto",
+            sortedValues: values,
+            midpoint: 0,
+            midpointMode: "symmetric",
+        }
+        runBinningStrategy(conf)
+    })
+})

--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChartState.bench.ts
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChartState.bench.ts
@@ -1,0 +1,62 @@
+import { bench, describe } from "vitest"
+import {
+    SampleColumnSlugs,
+    SynthesizeGDPTable,
+} from "@ourworldindata/core-table"
+import { LineChartState } from "./LineChartState.js"
+import { LineChartManager } from "./LineChartConstants.js"
+
+// End-to-end chart-state pipeline for the line chart: filter/clean the input
+// table (`transformTable`) and turn it into the logical `series` (one line per
+// entity × y-column, each with a point per year). This is the work that runs
+// between "config + data" and "ready to lay out and draw", and it is redone
+// whenever the selection or the underlying table changes.
+//
+// The state memoizes its computed getters, so every benchmark constructs a
+// *fresh* state per iteration — otherwise we'd measure a cached value. The
+// input table is built once (fixed seed) and its column store is materialized
+// up front so we don't fold parse cost into the transform measurement.
+
+const SEED = 1
+
+/** Reference a value so it isn't flagged as an unused expression (and assert the materialization actually produced data). */
+function keep(value: unknown): void {
+    if (value === undefined) throw new Error("expected a value")
+}
+
+function makeManager(entityCount: number): LineChartManager {
+    const table = SynthesizeGDPTable(
+        { entityCount, timeRange: [1900, 2020] },
+        SEED
+    )
+    keep(table.get(SampleColumnSlugs.GDP).values) // materialize the base table
+    return {
+        table,
+        yColumnSlugs: [SampleColumnSlugs.GDP],
+        selection: table.availableEntityNames,
+    }
+}
+
+describe("LineChartState.transformTable", () => {
+    const manager = makeManager(200)
+
+    bench("200 entities × 120 years", () => {
+        const state = new LineChartState({ manager })
+        keep(state.transformedTable.get(SampleColumnSlugs.GDP).values)
+    })
+})
+
+describe("LineChartState.series", () => {
+    const smallManager = makeManager(50)
+    const largeManager = makeManager(200)
+
+    bench("50 entities", () => {
+        const state = new LineChartState({ manager: smallManager })
+        keep(state.series)
+    })
+
+    bench("200 entities", () => {
+        const state = new LineChartState({ manager: largeManager })
+        keep(state.series)
+    })
+})

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChartState.bench.ts
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChartState.bench.ts
@@ -1,0 +1,62 @@
+import { bench, describe } from "vitest"
+import {
+    SampleColumnSlugs,
+    SynthesizeGDPTable,
+} from "@ourworldindata/core-table"
+import { ScatterPlotChartState } from "./ScatterPlotChartState.js"
+import { ScatterPlotManager } from "./ScatterPlotChartConstants.js"
+
+// The scatter plot has the heaviest table-transform pipeline of the common
+// chart types: `transformTable` chains dropping/filtering with a
+// closest-time-match interpolation between the X and Y columns, then
+// `allPoints` builds a rich point object per row (reading x, y, size, color and
+// their original-time columns) and `series` groups those points by entity.
+//
+// State getters are memoized, so each benchmark builds a fresh state per
+// iteration. The input table is materialized once up front.
+
+const SEED = 1
+
+/** Reference a value so it isn't flagged as an unused expression (and assert the materialization actually produced data). */
+function keep(value: unknown): void {
+    if (value === undefined) throw new Error("expected a value")
+}
+
+function makeManager(entityCount: number): ScatterPlotManager {
+    const table = SynthesizeGDPTable(
+        { entityCount, timeRange: [1950, 2020] },
+        SEED
+    )
+    keep(table.get(SampleColumnSlugs.GDP).values) // materialize the base table
+    return {
+        table,
+        xColumnSlug: SampleColumnSlugs.GDP,
+        yColumnSlug: SampleColumnSlugs.LifeExpectancy,
+        sizeColumnSlug: SampleColumnSlugs.Population,
+        selection: table.availableEntityNames,
+    }
+}
+
+describe("ScatterPlotChartState.allPoints", () => {
+    const smallManager = makeManager(50)
+    const largeManager = makeManager(200)
+
+    bench("50 entities × 70 years", () => {
+        const state = new ScatterPlotChartState({ manager: smallManager })
+        keep(state.allPoints)
+    })
+
+    bench("200 entities × 70 years", () => {
+        const state = new ScatterPlotChartState({ manager: largeManager })
+        keep(state.allPoints)
+    })
+})
+
+describe("ScatterPlotChartState.series", () => {
+    const manager = makeManager(200)
+
+    bench("200 entities × 70 years", () => {
+        const state = new ScatterPlotChartState({ manager })
+        keep(state.series)
+    })
+})

--- a/packages/@ourworldindata/grapher/src/verticalLabels/VerticalLabelsState.bench.ts
+++ b/packages/@ourworldindata/grapher/src/verticalLabels/VerticalLabelsState.bench.ts
@@ -1,0 +1,61 @@
+import { bench, describe } from "vitest"
+import { AxisConfig } from "../axis/AxisConfig.js"
+import { VerticalLabelsState } from "./VerticalLabelsState.js"
+import { VerticalAxis } from "../axis/Axis.js"
+import { LabelSeries } from "./VerticalLabelsTypes.js"
+
+// The right-hand-side series labels on a line chart (country names next to each
+// line end) have to be measured, filtered to what fits, and then nudged apart
+// so they don't overlap. The de-collision step re-stacks overlapping groups in
+// a loop, so it gets expensive when many labels crowd a short axis — exactly
+// the case this benchmark sets up.
+
+/** Reference a value so it isn't flagged as an unused expression. */
+function keep(value: unknown): void {
+    if (value === undefined) throw new Error("expected a value")
+}
+
+function makeAxis(yRange: [number, number]): VerticalAxis {
+    const yAxis = new AxisConfig({ min: 0, max: 100 }).toVerticalAxis()
+    yAxis.range = yRange
+    return yAxis
+}
+
+/**
+ * Build `count` labels whose values cluster in the lower half of the domain, so
+ * a large share of them collide and have to be repositioned.
+ */
+function makeSeries(count: number): LabelSeries[] {
+    const series: LabelSeries[] = []
+    for (let i = 0; i < count; i++) {
+        series.push({
+            seriesName: `Country ${i}`,
+            label: `Country ${i}`,
+            color: "#4c6a9c",
+            // Cluster values so labels overlap heavily
+            yValue: (i % 40) + Math.sin(i) * 3,
+        })
+    }
+    return series
+}
+
+describe("VerticalLabelsState.placedSeries", () => {
+    const fewSeries = makeSeries(20)
+    const manySeries = makeSeries(80)
+
+    bench("20 labels on a 400px axis", () => {
+        const state = new VerticalLabelsState(fewSeries, {
+            yAxis: () => makeAxis([400, 0]),
+            maxWidth: 150,
+        })
+        keep(state.placedSeries)
+    })
+
+    bench("80 crowded labels on a 400px axis", () => {
+        const state = new VerticalLabelsState(manySeries, {
+            yAxis: () => makeAxis([400, 0]),
+            maxWidth: 150,
+        })
+        keep(state.placedSeries)
+    })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,6 +13,17 @@ export default defineConfig({
             "adminSiteServer/tests/**",
             "bespoke/**",
         ],
+        // Benchmarks (*.bench.ts, run with `yarn bench`) live next to the code
+        // they measure. Exclude compiled output so we don't run each bench twice
+        // (once from src, once from the tsc-emitted dist copy).
+        benchmark: {
+            exclude: [
+                ...configDefaults.exclude,
+                "itsJustJavascript/**",
+                "**/dist/**",
+                "bespoke/**",
+            ],
+        },
         pool: "threads",
         setupFiles: ["devTools/vitest-setup.ts"],
     },


### PR DESCRIPTION
> _Written by Anthropic Claude Opus 5 — @marcelgerber at the wheel._

## Context

We have a number of time-sensitive code paths in the grapher rendering pipeline — table transformations, series construction, placement/labeling, text measurement — but no way to measure them or catch regressions. This adds `vitest bench` benchmarks for a representative set of them.

There is no existing benchmark infrastructure in the repo, so this also adds the plumbing:

- **`yarn bench`** → `vitest bench --run`
- **`benchmark.exclude` in `vitest.config.ts`** — `tsc -b` emits `*.bench.js` into each package's `dist/`, so without this every benchmark runs twice (once from `src`, once from the compiled copy). Mirrors the existing `test.exclude` entries.

Benchmarks live next to the code they measure, as `*.bench.ts`.

### What's covered

Picked to span the four categories where the cost actually lives, rather than to be exhaustive:

| Area | File | Measures |
| --- | --- | --- |
| Transform kernels | `core-table/src/CoreTableUtils.bench.ts` | `toleranceInterpolation`, `linearInterpolation`, `computeRollingAverage` — the innermost per-entity-group numeric loops |
| Table ops | `core-table/src/OwidTable.bench.ts` | CSV parse + type coercion (`new OwidTable`), `filterByEntityNames`, `interpolateColumnWithTolerance` |
| Line chart pipeline | `grapher/src/lineCharts/LineChartState.bench.ts` | `transformTable`, `series` |
| Scatter pipeline | `grapher/src/scatterCharts/ScatterPlotChartState.bench.ts` | `allPoints`, `series` — the heaviest transform chain, incl. closest-time matching between X and Y |
| Color / binning | `grapher/src/color/BinningStrategies.bench.ts` | `runBinningStrategy` (auto, equal-size, symmetric midpoint) |
| Placement / labeling | `grapher/src/verticalLabels/VerticalLabelsState.bench.ts` | `placedSeries` — end-label collision resolution on a crowded axis |
| Text measurement | `components/src/TextWrap/TextWrap.bench.ts` | `Bounds.forText`, `TextWrap.lines`, `shortenWithEllipsis` |

### Notes on how the benchmarks are written

Two things that are easy to get wrong and are worth knowing if you add more:

- **Memoization has to be defeated.** Chart state getters are MobX `@computed` / `@imemo`, so a benchmark that reuses one state instance measures a cache hit after the first iteration. Every chart-state bench constructs a **fresh state per iteration**, and the input table is materialized once up front so table-parse cost isn't folded into the transform measurement.
- **Inputs are deterministic.** They use the fixed-seed `Synthesize*Table` generators (or seedless `Math.sin`-based generators), so results are comparable run to run rather than varying with random data.

The interpolation kernels mutate their input in place, so those benches copy the arrays per iteration; the copy is cheap relative to the loop being measured.

Most benchmarks run at two input sizes (e.g. 50 vs 200 entities) so scaling behaviour is visible, not just a single number.

### Scope / limitations

These are micro and component-level benchmarks of isolated functions — they are **not** end-to-end render or paint timings. They're intended for catching regressions in these specific kernels. Nothing is wired into CI; `yarn bench` is manual for now.

Not covered, but plausible follow-ups: axis tick generation (`Axis.getTickValues`), stacked-chart `stackSeries` / `withMissingValuesAsZeroes`, and scatter label collision avoidance (`hideCollidingLabelsByPriority`, which is O(n²)).

## Screenshots / Videos / Diagrams

Not applicable — no production code changed, so there is nothing to see in the UI.

## Testing guidance

```bash
yarn bench                                                  # whole suite
yarn vitest bench --run packages/@ourworldindata/core-table/src/OwidTable.bench.ts   # one file
```

Expect 15 benchmark groups across 7 files, all passing. Sanity checks worth doing:

1. Each file reports **once** — if you see the same group listed twice with a `dist/` path, the `benchmark.exclude` change isn't taking effect.
2. Larger input sizes should be meaningfully slower than smaller ones within a group (the summary line prints the ratio). A group where both sizes are identical would suggest the work is being memoized or optimized away rather than measured.

Verified locally: `yarn bench` (all pass), `yarn typecheck`, `yarn testLintChanged`, `yarn testFormatChanged`.

- [ ] ~Does the change work in the archive?~ n/a — test-only change, nothing baked or served
- [ ] ~Does the staging experience have sign-off from product stakeholders?~ n/a — no user-facing change

## Checklist

No production code, CSS/HTML, analytics, or DB migrations are touched by this PR, so the before/after-merge items don't apply.

---
_Generated by [Claude Code](https://claude.ai/code/session_019jcEmkEAoc5i8uMBSDrsRF)_