### PR TITLE
✨ baked latest page skeletons

### DIFF
--- a/site/LatestPage.tsx
+++ b/site/LatestPage.tsx
@@ -7,6 +7,7 @@ import {
     serializeJSONForInlineScript,
 } from "@ourworldindata/utils"
 import { Html } from "./Html.js"
+import { LatestPageSkeleton } from "./latest/LatestPageSkeleton.js"
 
 declare global {
     interface Window {
@@ -41,7 +42,9 @@ export const LatestPage = (props: {
                     id="latest-page-root"
                     className="latest-page grid grid-cols-12-full-width"
                 >
-                    {/* Latest UI is rendered client-side only */}
+                    {/* Baked placeholder only — the real Latest UI is
+                        client-side rendered into this element, replacing it */}
+                    <LatestPageSkeleton topicTagGraph={topicTagGraph} />
                 </main>
                 <SiteFooter context={SiteFooterContext.latestPage} />
             </body>

--- a/site/latest/LatestPageHeader.tsx
+++ b/site/latest/LatestPageHeader.tsx
@@ -1,0 +1,10 @@
+export const LatestPageHeader = () => (
+    <header className="latest-page-header span-cols-14 grid grid-cols-12-full-width">
+        <h1 className="display-2-semibold span-cols-8 col-start-2 col-md-start-2 span-md-cols-10 col-sm-start-2 span-sm-cols-12">
+            Latest
+        </h1>
+        <p className="latest-page__header-subtitle body-1-regular span-cols-8 col-start-2 col-md-start-2 span-md-cols-10 col-sm-start-2 span-sm-cols-12">
+            Our latest articles, data updates, and announcements
+        </p>
+    </header>
+)

--- a/site/latest/LatestPageSkeleton.tsx
+++ b/site/latest/LatestPageSkeleton.tsx
@@ -1,0 +1,71 @@
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import { faCaretDown, faFilter } from "@fortawesome/free-solid-svg-icons"
+import { TagGraphRoot } from "@ourworldindata/types"
+import { LatestPageHeader } from "./LatestPageHeader.js"
+import { LatestSearchSkeleton } from "./LatestSearchSkeleton.js"
+import {
+    LATEST_FACETS_CONTAINER_CLASSES,
+    LATEST_FILTERS_DIVIDER_CLASSES,
+} from "./latestUtils.js"
+
+/**
+ * Static stand-in for the /latest UI, baked into the page HTML so the layout
+ * doesn't jump while the client-side app loads. React replaces it wholesale
+ * when it mounts into #latest-page-root (createRoot, not hydration), so it
+ * only needs to look like LatestSearch's initial loading render — the facets
+ * are inert copies, not the react-aria/scroll-menu components.
+ */
+export const LatestPageSkeleton = ({
+    topicTagGraph,
+}: {
+    topicTagGraph: TagGraphRoot
+}) => {
+    const areas = topicTagGraph.children.map((child) => child.name)
+
+    return (
+        <>
+            <LatestPageHeader />
+            <div className={LATEST_FACETS_CONTAINER_CLASSES}>
+                <div className="latest-topic-facets" aria-hidden="true">
+                    <div className="latest-topic-facets__filters">
+                        <div className="latest-topic-facets__topic-pills">
+                            <div className="latest-topic-facets-skeleton__pill-row">
+                                <div
+                                    className="latest-topic-facets__topic-pill"
+                                    data-selected="true"
+                                >
+                                    All
+                                </div>
+                                {areas.map((area) => (
+                                    <div
+                                        key={area}
+                                        className="latest-topic-facets__topic-pill"
+                                    >
+                                        {area}
+                                    </div>
+                                ))}
+                            </div>
+                        </div>
+                        <div className="latest-topic-facets__content-type-dropdown">
+                            <div className="latest-topic-facets__content-type-trigger">
+                                <FontAwesomeIcon
+                                    icon={faFilter}
+                                    className="latest-topic-facets__content-type-trigger-icon"
+                                />
+                                <span className="latest-topic-facets__content-type-trigger-label">
+                                    Filter by type
+                                </span>
+                                <FontAwesomeIcon
+                                    icon={faCaretDown}
+                                    className="latest-topic-facets__content-type-trigger-chevron"
+                                />
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <hr className={LATEST_FILTERS_DIVIDER_CLASSES} />
+            <LatestSearchSkeleton />
+        </>
+    )
+}

--- a/site/latest/LatestSearch.tsx
+++ b/site/latest/LatestSearch.tsx
@@ -10,6 +10,11 @@ import { LiteClient } from "algoliasearch/lite"
 import { useTagGraphTopics } from "../search/searchHooks.js"
 import { useInfiniteLatestPages, useLatestAnalytics } from "./latestHooks.js"
 import { LatestTopicFacets } from "./LatestTopicFacets.js"
+import { LatestPageHeader } from "./LatestPageHeader.js"
+import {
+    LATEST_FACETS_CONTAINER_CLASSES,
+    LATEST_FILTERS_DIVIDER_CLASSES,
+} from "./latestUtils.js"
 import {
     searchParamsToState,
     stateToSearchParams,
@@ -136,15 +141,8 @@ export const LatestSearch = ({
 
     return (
         <LatestContext.Provider value={{ analytics }}>
-            <header className="latest-page-header span-cols-14 grid grid-cols-12-full-width">
-                <h1 className="display-2-semibold span-cols-8 col-start-2 col-md-start-2 span-md-cols-10 col-sm-start-2 span-sm-cols-12">
-                    Latest
-                </h1>
-                <p className="latest-page__header-subtitle body-1-regular span-cols-8 col-start-2 col-md-start-2 span-md-cols-10 col-sm-start-2 span-sm-cols-12">
-                    Our latest articles, data updates, and announcements
-                </p>
-            </header>
-            <div className="latest-search__facets-container span-cols-12 col-start-2 span-md-cols-12 col-md-start-2 span-sm-cols-14 col-sm-start-1">
+            <LatestPageHeader />
+            <div className={LATEST_FACETS_CONTAINER_CLASSES}>
                 <LatestTopicFacets
                     topics={allAreas}
                     selectedTopics={topics}
@@ -155,7 +153,7 @@ export const LatestSearch = ({
                     disabledTopics={disabledTopics}
                 />
             </div>
-            <hr className="latest-search__filters-divider span-cols-12 col-start-2 span-md-cols-12 col-md-start-2 span-sm-cols-14 col-sm-start-1" />
+            <hr className={LATEST_FILTERS_DIVIDER_CLASSES} />
             {isLoading ? (
                 <LatestSearchSkeleton />
             ) : hits.length === 0 ? (

--- a/site/latest/LatestSearchSkeleton.scss
+++ b/site/latest/LatestSearchSkeleton.scss
@@ -1,3 +1,12 @@
+// Layout for the inert pill copies in the baked LatestPageSkeleton — the live
+// UI gets this from react-horizontal-scrolling-menu's inline styles instead.
+.latest-topic-facets-skeleton__pill-row {
+    display: flex;
+    gap: 8px;
+    overflow: hidden;
+    pointer-events: none;
+}
+
 .latest-hit-skeleton {
     margin-bottom: 48px;
 

--- a/site/latest/latestUtils.ts
+++ b/site/latest/latestUtils.ts
@@ -70,6 +70,15 @@ export const latestTypeLabelPlural = (type: LatestType): string =>
 export const LATEST_HIT_GRID_CLASSES =
     "span-cols-8 col-start-2 span-md-cols-12 col-md-start-2 span-sm-cols-14 col-sm-start-1"
 
+/** Grid positioning for the facets row and the divider beneath it — shared
+ * between the live UI (LatestSearch) and the baked skeleton
+ * (LatestPageSkeleton) so the two layouts can't drift apart. */
+export const LATEST_FACETS_CONTAINER_CLASSES =
+    "latest-search__facets-container span-cols-12 col-start-2 span-md-cols-12 col-md-start-2 span-sm-cols-14 col-sm-start-1"
+
+export const LATEST_FILTERS_DIVIDER_CLASSES =
+    "latest-search__filters-divider span-cols-12 col-start-2 span-md-cols-12 col-md-start-2 span-sm-cols-14 col-sm-start-1"
+
 /** Stable id for the announcement content heading, used by parent wrappers
  * (the feed's <article>) for aria-labelledby. */
 export const announcementContentTitleId = (slug: string) =>


### PR DESCRIPTION
The latest page has a large content jump currently because we have no placeholders in the raw HTML. This PR changes that.

**Before**
https://github.com/user-attachments/assets/6957a25b-b423-421f-858d-fef6e22b26cd




**After**
https://github.com/user-attachments/assets/7c390e64-4511-4014-8b3e-cad964634c27

