### PR TITLE
✨🤖 (time-interval) label quarterly ranges and timeline with month names

### DIFF
--- a/packages/@ourworldindata/core-table/src/CoreTableColumns.test.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTableColumns.test.ts
@@ -30,6 +30,23 @@ describe(ColumnTypeNames.Quarter, () => {
         expect(col.formatValue(400)).toEqual("Q1 2021")
         expect(col.formatForCsv(400)).toEqual("2021-Q1")
     })
+
+    it("formats the short timeline label as the quarter's start month", () => {
+        // day 0 = 2020-01-21 (Q1 2020) → start month Jan 2020
+        expect(col.formatTimeShort(0)).toEqual("Jan 2020")
+        // day 200 = 2020-08-08 (Q3 2020) → start month Jul 2020
+        expect(col.formatTimeShort(200)).toEqual("Jul 2020")
+    })
+
+    it("formats a range from start-quarter start month to end-quarter end month", () => {
+        const day = (iso: string): number =>
+            convertDateToDaysSinceEpoch(dayjs.utc(iso))
+        // 2025-02-15 → Q1 2025 (starts Jan)
+        // 2026-11-20 → Q4 2026 (ends Dec)
+        expect(
+            col.formatTimeRange(day("2025-02-15"), day("2026-11-20"))
+        ).toEqual("Jan 2025 to Dec 2026")
+    })
 })
 
 describe(ColumnTypeNames.Decade, () => {

--- a/packages/@ourworldindata/core-table/src/CoreTableColumns.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTableColumns.ts
@@ -1146,6 +1146,21 @@ class QuarterColumn<
         return memoFormatQuarterCsv(value) // "2023-Q1"
     }
 
+    // The quarter's start month, e.g. "Jan 2026"
+    override formatTimeShort(time: number): string {
+        return convertDaysSinceEpochToDate(time)
+            .startOf("quarter")
+            .format("MMM YYYY")
+    }
+
+    // The span from the first month of the start quarter to the last month of
+    // the end quarter, e.g. "Jan 2025 to Dec 2026"
+    override formatTimeRange(startTime: number, endTime: number): string {
+        const start = convertDaysSinceEpochToDate(startTime).startOf("quarter")
+        const end = convertDaysSinceEpochToDate(endTime).endOf("quarter")
+        return `${start.format("MMM YYYY")} to ${end.format("MMM YYYY")}`
+    }
+
     // The first of the epoch's quarter, used as the anchor for counting quarters.
     private static readonly epochQuarterStart = dayjs
         .utc(EPOCH_DATE)

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.test.tsx
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.test.tsx
@@ -101,6 +101,13 @@ describe("when you select a range of years", () => {
         const cell = container.querySelector("tbody .cell-deltaRatio")
         expect(cell?.textContent).toBe("-4%")
     })
+
+    it("labels the sparkline column with the time range", () => {
+        const headers = [
+            ...container.querySelectorAll("thead th.subdimension"),
+        ].map((header) => header.textContent)
+        expect(headers).toContain("1950 to 2019")
+    })
 })
 
 describe("when the table doesn't have data for all rows", () => {

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
@@ -369,11 +369,11 @@ export class DataTable extends React.Component<DataTableProps> {
     ): string {
         const col = dimension.coreTableColumn
 
-        if (column.key === SparklineKey.sparkline) {
-            const minTime = col.formatTime(this.timelineMinTime!)
-            const maxTime = col.formatTime(this.timelineMaxTime!)
-            return `${minTime}–${maxTime}`
-        }
+        if (column.key === SparklineKey.sparkline)
+            return col.formatTimeRange(
+                this.timelineMinTime!,
+                this.timelineMaxTime!
+            )
 
         return isDeltaColumn(column.key)
             ? columnNameByType[column.key]


### PR DESCRIPTION
> _Written by Anthropic Claude Opus 5 — @sophiamersmann at the wheel._

A single quarter keeps its `Q1 2026` label everywhere it appears (chart title, tooltips, discrete axis), but ranges and the timeline spell out plain month labels instead of chaining quarter labels together:

- **Range title**: `Jan 2025 to Dec 2026` — the first month of the start quarter to the last month of the end quarter.
- **Timeline** handles, hover and extent: the quarter's start month, e.g. `Jan 2026`.

CSV export and the continuous axis are unchanged. This reuses the generic `formatTimeShort` / `formatTimeRange` hooks added for weekly labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)