### PR TITLE
✨🤖 name the original time in the tolerance notice

### DIFF
--- a/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellTooltips.tsx
+++ b/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellTooltips.tsx
@@ -71,17 +71,28 @@ export class DumbbellTimeRangeTooltip extends React.Component<DumbbellTooltipPro
         if (isStartOriginal && isEndOriginal) return undefined
 
         const formatTime = (t: number) => formatColumn.formatTime(t)
-        const targetYear =
+        const targetTime =
             !isStartOriginal && !isEndOriginal
                 ? `${formatTime(startTime)} and ${formatTime(endTime)}`
                 : !isStartOriginal
                   ? formatTime(startTime)
                   : formatTime(endTime)
 
+        // The subtitle shows the original time of both values. Naming the
+        // original time here only helps if the subtitle mixes a target time with
+        // an original time, i.e. if only one of the two values was interpolated.
+        const originalTime =
+            !isStartOriginal && !isEndOriginal
+                ? undefined
+                : !isStartOriginal
+                  ? formatTime(target.start.time)
+                  : formatTime(target.end.time)
+
         return {
             icon: TooltipFooterIcon.Notice,
-            text: makeTooltipToleranceNotice(targetYear, {
+            text: makeTooltipToleranceNotice(targetTime, {
                 plural: !isStartOriginal && !isEndOriginal,
+                originalTime,
             }),
         }
     }

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapTooltip.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapTooltip.tsx
@@ -215,36 +215,41 @@ export class MapTooltip
     @computed private get toleranceNotice(): FooterItem | undefined {
         const { startDatum, startTime, endDatum, endTime } = this
 
-        const startValueIsInterpolated =
-            startDatum && startDatum?.originalTime !== startTime
-        const endValueIsInterpolated =
-            endDatum && endDatum?.originalTime !== endTime
+        const interpolated = excludeUndefined([
+            startDatum && startDatum.originalTime !== startTime
+                ? { target: startTime, original: startDatum.originalTime }
+                : undefined,
+            endDatum && endDatum.originalTime !== endTime
+                ? { target: endTime, original: endDatum.originalTime }
+                : undefined,
+        ])
 
-        const formattedStartTime = this.formatTime(this.startTime)
-        const formattedEndTime = this.formatTime(this.endTime)
+        if (interpolated.length === 0) return undefined
 
-        if (startValueIsInterpolated && endValueIsInterpolated)
-            return {
-                icon: TooltipFooterIcon.Notice,
-                text: makeTooltipToleranceNotice(
-                    `${formattedStartTime} and ${formattedEndTime}`,
-                    { plural: true }
-                ),
-            }
+        const formatTimes = (times: (Time | undefined)[]): string =>
+            excludeUndefined(times.map((time) => this.formatTime(time))).join(
+                " and "
+            )
 
-        if (endValueIsInterpolated && formattedEndTime)
-            return {
-                icon: TooltipFooterIcon.Notice,
-                text: makeTooltipToleranceNotice(formattedEndTime),
-            }
+        const targetTimes = formatTimes(interpolated.map((i) => i.target))
+        if (!targetTimes) return undefined
 
-        if (startValueIsInterpolated && formattedStartTime)
-            return {
-                icon: TooltipFooterIcon.Notice,
-                text: makeTooltipToleranceNotice(formattedStartTime),
-            }
+        // The subtitle shows the original time of each value. Naming the
+        // original time here only helps if the subtitle mixes a target time with
+        // an original time, i.e. if a value range is shown and only one of the
+        // two values was interpolated.
+        const originalTime =
+            this.shouldShowValueRange && interpolated.length === 1
+                ? this.formatTime(interpolated[0].original)
+                : undefined
 
-        return undefined
+        return {
+            icon: TooltipFooterIcon.Notice,
+            text: makeTooltipToleranceNotice(targetTimes, {
+                plural: interpolated.length > 1,
+                originalTime,
+            }),
+        }
     }
 
     @computed private get roundingNotice(): FooterItem | undefined {

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
@@ -781,26 +781,48 @@ export class SlopeChart
             ? `% change between ${formatColumn.formatTime(actualStartTime)} and ${formatColumn.formatTime(actualEndTime)}`
             : timeRange
 
-        const constructTargetYearForToleranceNotice = () => {
+        // The subtitle shows the original time of both values. Naming the
+        // original time here only helps if the subtitle mixes a target time with
+        // an original time, i.e. if only one of the two values was interpolated.
+        const constructTimesForToleranceNotice = ():
+            | { target: string; original?: string; plural: boolean }
+            | undefined => {
             const isStartValueOriginal = series.start.originalTime === startTime
             const isEndValueOriginal = series.end.originalTime === endTime
 
             if (!isStartValueOriginal && !isEndValueOriginal) {
-                return `${formatTime(startTime)} and ${formatTime(endTime)}`
+                return {
+                    target: `${formatTime(startTime)} and ${formatTime(endTime)}`,
+                    plural: true,
+                }
             } else if (!isStartValueOriginal) {
-                return formatTime(startTime)
+                return {
+                    target: formatTime(startTime),
+                    original: formatTime(actualStartTime),
+                    plural: false,
+                }
             } else if (!isEndValueOriginal) {
-                return formatTime(endTime)
+                return {
+                    target: formatTime(endTime),
+                    original: formatTime(actualEndTime),
+                    plural: false,
+                }
             } else {
                 return undefined
             }
         }
 
-        const targetYear = constructTargetYearForToleranceNotice()
-        const toleranceNotice = targetYear
+        const toleranceNoticeTimes = constructTimesForToleranceNotice()
+        const toleranceNotice = toleranceNoticeTimes
             ? {
                   icon: TooltipFooterIcon.Notice,
-                  text: makeTooltipToleranceNotice(targetYear),
+                  text: makeTooltipToleranceNotice(
+                      toleranceNoticeTimes.target,
+                      {
+                          plural: toleranceNoticeTimes.plural,
+                          originalTime: toleranceNoticeTimes.original,
+                      }
+                  ),
               }
             : undefined
         const roundingNotice = series.column.roundsToSignificantFigures
@@ -830,7 +852,7 @@ export class SlopeChart
                 title={title}
                 titleAnnotation={titleAnnotation}
                 subtitle={timeLabel}
-                subtitleFormat={targetYear ? "notice" : undefined}
+                subtitleFormat={toleranceNoticeTimes ? "notice" : undefined}
                 dissolve={fading}
                 footer={footer}
                 dismiss={() => (this.tooltipState.target = null)}

--- a/packages/@ourworldindata/grapher/src/tooltip/TooltipContents.tsx
+++ b/packages/@ourworldindata/grapher/src/tooltip/TooltipContents.tsx
@@ -315,11 +315,15 @@ export function SignificanceIcon({
 }
 
 export function makeTooltipToleranceNotice(
-    targetYear: string,
-    { plural }: { plural: boolean } = { plural: false }
+    targetTime: string,
+    {
+        plural = false,
+        originalTime,
+    }: { plural?: boolean; originalTime?: string } = {}
 ): string {
     const dataPoint = plural ? "data points" : "data point"
-    return `Data not available for ${targetYear}. Showing closest available ${dataPoint} instead`
+    const originalTimeNotice = originalTime ? ` (${originalTime})` : ""
+    return `Data not available for ${targetTime}. Showing closest available ${dataPoint}${originalTimeNotice} instead`
 }
 
 export function makeTooltipRoundingNotice(


### PR DESCRIPTION
> _Written by Anthropic Claude Opus 5 — @sophiamersmann at the wheel._

## Context

Tooltips already say when a value came from a different time than the one you asked for: _"Data not available for 2020. Showing closest available data point instead"_. That works when there's one time involved — but when a tooltip covers a time range and only one of the two values was interpolated, the subtitle ends up mixing a target time with an original time, and there's nothing to tell you which is which.

In that case the notice now names the original time, matching what the data table already does:

- _"Data not available for 2020. Showing closest available data point (2019) instead"_

Applies to the faceted map, slope chart and dumbbell time-range tooltips.

Deliberately left as is where a single parenthetical can't work: tooltips with one target time but several values that can each resolve to a different original time (stacked discrete bar, marimekko, dumbbell two-column, scatter), and the single-value map tooltip, whose subtitle is the original time already.

Also in here:

- The notice helper's parameters are renamed from `targetYear`/`closestYear` to `targetTime`/`originalTime`, since these aren't always years
- Fixes the slope chart saying the singular "data point" when both of its values were interpolated

## Screenshots

_(add before/after of a slope chart tooltip where only one endpoint was interpolated)_

## Testing guidance

- Open a slope chart whose start or end time is missing for some entities and hover an entity where only one of the two values fell back to another time — the subtitle should name that time in parentheses.
- Hover one where both values were interpolated — it should read "data points", plural, and no parenthetical.
- Facet a map tab by pulling the timeline handles apart and hover a country that only has data for one of the two times.
- Check the untouched cases still read sensibly: stacked discrete bar, marimekko, scatter, and a single-time map tooltip.
