### PR TITLE
🐛🤖 fix stitched historical/projected values on the map

### DIFF
--- a/packages/@ourworldindata/grapher/src/chart/ChartUtils.tsx
+++ b/packages/@ourworldindata/grapher/src/chart/ChartUtils.tsx
@@ -43,6 +43,7 @@ import {
     CoreColumn,
     ErrorValueTypes,
     isNotErrorValueOrEmptyCell,
+    makeOriginalTimeSlugFromColumnSlug,
     OwidTable,
 } from "@ourworldindata/core-table"
 import { GRAPHER_BACKGROUND } from "../color/ColorConstants"
@@ -249,7 +250,9 @@ export function combineHistoricalAndProjectionColumns(
     const transformFn = (
         row: Record<ColumnSlug, { value: CoreValueType; time: Time }>,
         time: Time
-    ): { isProjection: boolean; value: PrimitiveType } | undefined => {
+    ):
+        | { isProjection: boolean; value: PrimitiveType; originalTime: Time }
+        | undefined => {
         // It's possible to have both a historical and a projected value
         // for a given year. In that case, we prefer the historical value.
 
@@ -264,12 +267,21 @@ export function combineHistoricalAndProjectionColumns(
             // If tolerance was applied to the historical column, we need to
             // make sure the interpolated historical value doesn't get picked
             // over the actual projected value
-            historicalTimeDiff <= projectionTimeDiff
+            (!isNotErrorValueOrEmptyCell(projected.value) ||
+                historicalTimeDiff <= projectionTimeDiff)
         )
-            return { value: historical.value, isProjection: false }
+            return {
+                value: historical.value,
+                isProjection: false,
+                originalTime: historical.time,
+            }
 
         if (isNotErrorValueOrEmptyCell(projected.value)) {
-            return { value: projected.value, isProjection: true }
+            return {
+                value: projected.value,
+                isProjection: true,
+                originalTime: projected.time,
+            }
         }
 
         return undefined
@@ -281,6 +293,23 @@ export function combineHistoricalAndProjectionColumns(
         { ...table.get(projectedSlug).def, slug: combinedSlug },
         (row, time) =>
             transformFn(row, time)?.value ??
+            ErrorValueTypes.MissingValuePlaceholder
+    )
+
+    // Keep the time each combined value actually comes from
+    table = table.combineColumns(
+        [projectedSlug, historicalSlug],
+        {
+            ...table.get(combinedSlug).originalTimeColumn.def,
+            slug: makeOriginalTimeSlugFromColumnSlug(combinedSlug),
+            display: { includeInTable: false },
+            derivedFrom: {
+                columnSlug: combinedSlug,
+                relationship: "originalTime",
+            },
+        },
+        (row, time) =>
+            transformFn(row, time)?.originalTime ??
             ErrorValueTypes.MissingValuePlaceholder
     )
 

--- a/packages/@ourworldindata/grapher/src/chart/ToleranceNotice.ts
+++ b/packages/@ourworldindata/grapher/src/chart/ToleranceNotice.ts
@@ -132,7 +132,7 @@ export function formatToleranceNotice({
 }
 
 /** The largest tolerance configured on any of the given columns */
-function getMaxConfiguredTolerance(columns: CoreColumn[]): number {
+export function getMaxConfiguredTolerance(columns: CoreColumn[]): number {
     return Math.max(0, ...columns.map((column) => column.tolerance))
 }
 

--- a/packages/@ourworldindata/grapher/src/core/GrapherState.test.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.test.ts
@@ -797,6 +797,90 @@ describe("toleranceNotice", () => {
         )
     })
 
+    describe("a historical and projected map", () => {
+        const NOTICE =
+            "Where data for 2004 is unavailable, the value from the closest year between 2001 and 2003 is shown instead."
+
+        const makeProjectedGrapher = ({
+            extraRows = [],
+            historicalTolerance = 3,
+            projectedTolerance = 3,
+        }: {
+            extraRows?: (string | number)[][]
+            historicalTolerance?: number
+            projectedTolerance?: number
+        } = {}): GrapherState =>
+            new GrapherState({
+                table: new OwidTable(
+                    [
+                        ["entityName", "year", "pop", "pop_projected"],
+                        ["France", 1990, 10, ""],
+                        ["France", 2002, 100, ""],
+                        ["France", 2004, "", 400],
+                        // Germany's closest projected value is from 2003, a
+                        // year short of the 2004 the map is showing
+                        ["Germany", 2002, 150, ""],
+                        ["Germany", 2003, "", 350],
+                        ...extraRows,
+                    ],
+                    [
+                        {
+                            slug: "pop",
+                            type: ColumnTypeNames.Numeric,
+                            tolerance: historicalTolerance,
+                            display: { name: "Population" },
+                        },
+                        {
+                            slug: "pop_projected",
+                            type: ColumnTypeNames.Numeric,
+                            tolerance: projectedTolerance,
+                            display: { name: "Population", isProjection: true },
+                        },
+                        { slug: "year", type: ColumnTypeNames.Year },
+                    ]
+                ),
+                dimensions: ["pop", "pop_projected"].map((slug, i) => ({
+                    slug,
+                    property: DimensionProperty.y,
+                    variableId: 100 + i,
+                })),
+                tab: GRAPHER_TAB_CONFIG_OPTIONS.map,
+                hasMapTab: true,
+                map: { columnSlug: "pop_projected" },
+            })
+
+        it("explains the tolerance", () => {
+            expect(makeProjectedGrapher().toleranceNotice).toEqual(NOTICE)
+        })
+
+        it("is absent when no value was filled in from another time", () => {
+            expect(
+                makeProjectedGrapher({
+                    extraRows: [["Germany", 2004, "", 450]],
+                }).toleranceNotice
+            ).toBeUndefined()
+        })
+
+        it("gives the tolerance of whichever column the value came from", () => {
+            // Italy is historical-only, so only the historical tolerance can
+            // carry its 2002 value to the 2004 the map is showing
+            const italy: (string | number)[][] = [["Italy", 2002, 200, ""]]
+            expect(
+                makeProjectedGrapher({
+                    extraRows: italy,
+                    projectedTolerance: 0,
+                }).toleranceNotice
+            ).toEqual(NOTICE)
+            expect(
+                makeProjectedGrapher({
+                    extraRows: italy,
+                    historicalTolerance: 0,
+                    projectedTolerance: 0,
+                }).toleranceNotice
+            ).toBeUndefined()
+        })
+    })
+
     describe("only when tolerance is actually applied", () => {
         // Every country has data for every year
         const completeTable = (): OwidTable =>

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapChart.test.ts
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapChart.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest"
 
+import { ColumnTypeNames } from "@ourworldindata/types"
 import {
+    OwidTable,
     SampleColumnSlugs,
     SynthesizeGDPTable,
     SynthesizeProjectedPopulationTable,
@@ -154,5 +156,175 @@ describe("not applicable entities", () => {
         expect(chartState.colorScale.inapplicableLabel).toEqual(
             "Selected country"
         )
+    })
+})
+
+it("keeps the source time of combined values that tolerance was applied to", () => {
+    // France has a projected value for the target time; Germany's closest
+    // projected value is from 2003; Italy only has historical data, from 2002
+    const table = new OwidTable(
+        [
+            ["entityName", "year", "population", "projected_population"],
+            ["France", 2002, 100, ""],
+            ["France", 2003, "", 300],
+            ["France", 2004, "", 400],
+            ["Germany", 2002, 150, ""],
+            ["Germany", 2003, "", 350],
+            ["Italy", 2002, 200, ""],
+        ],
+        [
+            {
+                slug: "population",
+                type: ColumnTypeNames.Numeric,
+                tolerance: 3,
+            },
+            {
+                slug: "projected_population",
+                type: ColumnTypeNames.Numeric,
+                tolerance: 3,
+                display: { isProjection: true },
+            },
+            { slug: "year", type: ColumnTypeNames.Year },
+        ]
+    )
+
+    const combinedSlug = "projected_population-population"
+    const manager: MapChartManager = {
+        table,
+        mapColumnSlug: "projected_population",
+        targetTime: 2004,
+        projectionColumnInfoBySlug: new Map([
+            [
+                "projected_population",
+                {
+                    projectedSlug: "projected_population",
+                    historicalSlug: "population",
+                    combinedSlug,
+                    slugForIsProjectionColumn: `${combinedSlug}-isProjection`,
+                },
+            ],
+        ]),
+    }
+
+    const chartState = new MapChartState({ manager })
+    expect(chartState.series).toEqual([
+        expect.objectContaining({
+            seriesName: "France",
+            time: 2004,
+            value: 400,
+            isProjection: true,
+        }),
+        expect.objectContaining({
+            seriesName: "Germany",
+            time: 2003,
+            value: 350,
+            isProjection: true,
+        }),
+        expect.objectContaining({
+            seriesName: "Italy",
+            time: 2002,
+            value: 200,
+            isProjection: false,
+        }),
+    ])
+})
+
+it("doesn't apply tolerance a second time to a plain map column", () => {
+    // Spain's only value is from 2000, which a tolerance of 3 carries as far as
+    // 2003, so it must not appear on a map showing 2006 — reaching that far
+    // would mean applying the tolerance a second time
+    const table = new OwidTable(
+        [
+            ["entityName", "year", "population"],
+            ["France", 2000, 100],
+            ["France", 2003, 150],
+            ["France", 2006, 200],
+            ["Spain", 2000, 300],
+        ],
+        [
+            {
+                slug: "population",
+                type: ColumnTypeNames.Numeric,
+                tolerance: 3,
+            },
+            { slug: "year", type: ColumnTypeNames.Year },
+        ]
+    )
+
+    const chartState = new MapChartState({
+        manager: { table, mapColumnSlug: "population", targetTime: 2006 },
+    })
+
+    // Spain is not included because its value is too far away from the target time
+    expect(chartState.series.map((series) => series.seriesName)).toEqual([
+        "France",
+    ])
+})
+
+describe("doesn't apply tolerance a second time across the stitch", () => {
+    // Spain's only value is historical, from 2000. A tolerance of 3 carries it
+    // as far as 2003, so it must not appear on a map showing 2006 — reaching
+    // that far would mean applying the tolerance twice
+    const makeChartState = (mapConfig?: MapConfig): MapChartState => {
+        const table = new OwidTable(
+            [
+                ["entityName", "year", "population", "projected_population"],
+                ["France", 2000, 100, ""],
+                ["France", 2003, 150, ""],
+                ["France", 2006, "", 200],
+                ["Spain", 2000, 300, ""],
+            ],
+            [
+                {
+                    slug: "population",
+                    type: ColumnTypeNames.Numeric,
+                    tolerance: 3,
+                },
+                {
+                    slug: "projected_population",
+                    type: ColumnTypeNames.Numeric,
+                    tolerance: 3,
+                    display: { isProjection: true },
+                },
+                { slug: "year", type: ColumnTypeNames.Year },
+            ]
+        )
+
+        const combinedSlug = "projected_population-population"
+        return new MapChartState({
+            manager: {
+                table,
+                mapColumnSlug: "projected_population",
+                targetTime: 2006,
+                mapConfig,
+                projectionColumnInfoBySlug: new Map([
+                    [
+                        "projected_population",
+                        {
+                            projectedSlug: "projected_population",
+                            historicalSlug: "population",
+                            combinedSlug,
+                            slugForIsProjectionColumn: `${combinedSlug}-isProjection`,
+                        },
+                    ],
+                ]),
+            },
+        })
+    }
+
+    it("when the tolerance comes from the columns", () => {
+        // Spain is not included because its value is too far away from the target time
+        expect(
+            makeChartState().series.map((series) => series.seriesName)
+        ).toEqual(["France"])
+    })
+
+    it("when the tolerance comes from the map config", () => {
+        // Spain is not included because its value is too far away from the target time
+        expect(
+            makeChartState(new MapConfig({ timeTolerance: 3 })).series.map(
+                (series) => series.seriesName
+            )
+        ).toEqual(["France"])
     })
 })

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapChartState.ts
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapChartState.ts
@@ -38,7 +38,10 @@ import { getCountriesByRegion, isOnTheMap } from "./MapHelpers"
 import { MapSelectionArray } from "../selection/MapSelectionArray"
 import { ColorScale, ColorScaleManager } from "../color/ColorScale"
 import { ColorScaleConfig } from "../color/ColorScaleConfig"
-import { makeToleranceNotice } from "../chart/ToleranceNotice.js"
+import {
+    getMaxConfiguredTolerance,
+    makeToleranceNotice,
+} from "../chart/ToleranceNotice.js"
 
 export type MapFormatValueForTooltip = (
     d: PrimitiveType,
@@ -241,11 +244,10 @@ export class MapChartState implements ChartState, ColorScaleManager {
 
         // A target time is set for faceted maps
         if (this.manager.targetTime !== undefined) {
-            table = table.filterByTargetTimes(
-                [this.manager.targetTime],
-                this.mapConfig.timeTolerance ??
-                    table.get(this.mapColumnSlug).tolerance
-            )
+            // No tolerance here: the map column was interpolated above, so
+            // don't apply tolerance again, otherwise the tolerance window
+            // will be twice as wide
+            table = table.filterByTargetTimes([this.manager.targetTime])
         }
 
         return table
@@ -343,6 +345,17 @@ export class MapChartState implements ChartState, ColorScaleManager {
         return this.manager.targetTime ?? this.manager.endTime
     }
 
+    /** The columns the map's values are drawn from, before any stitching */
+    @computed private get sourceColumns(): CoreColumn[] {
+        const { mapColumnInfo } = this
+        const { table } = this.manager
+        return mapColumnInfo.type === "historical+projected"
+            ? [mapColumnInfo.historicalSlug, mapColumnInfo.projectedSlug].map(
+                  (slug) => table.get(slug)
+              )
+            : [table.get(mapColumnInfo.slug)]
+    }
+
     @computed private get toleranceStrategy(): ToleranceStrategy | undefined {
         return (
             this.mapConfig.toleranceStrategy ?? this.mapColumn.toleranceStrategy
@@ -355,7 +368,9 @@ export class MapChartState implements ChartState, ColorScaleManager {
             // Only the countries the map currently shows are relevant
             transformedTable: this.transformedTableForActiveRegion,
             columns: [this.mapColumn],
-            timeTolerance: this.mapConfig.timeTolerance,
+            timeTolerance:
+                this.mapConfig.timeTolerance ??
+                getMaxConfiguredTolerance(this.sourceColumns),
             toleranceStrategy: this.toleranceStrategy,
         })
     }
@@ -371,17 +386,14 @@ export class MapChartState implements ChartState, ColorScaleManager {
             : undefined
     }
 
-    private checkIsProjection(
-        entityName: EntityName,
-        originalTime: Time
-    ): boolean {
+    private checkIsProjection(entityName: EntityName, time: Time): boolean {
         return match(this.mapColumnInfo.type)
             .with("historical", () => false)
             .with("projected", () => true)
             .with("historical+projected", () =>
-                this.columnIsProjection?.valueByEntityNameAndOriginalTime
-                    .get(entityName)
-                    ?.get(originalTime)
+                this.columnIsProjection?.valueByTimeAndEntityName
+                    .get(time)
+                    ?.get(entityName)
             )
             .exhaustive()
     }
@@ -397,13 +409,10 @@ export class MapChartState implements ChartState, ColorScaleManager {
 
         return mapColumn.owidRows
             .map((row) => {
-                const { entityName, value, originalTime } = row
+                const { entityName, time, value, originalTime } = row
                 const color =
                     this.colorScale.getColor(value) || this.noDataColor
-                const isProjection = this.checkIsProjection(
-                    entityName,
-                    originalTime
-                )
+                const isProjection = this.checkIsProjection(entityName, time)
                 return {
                     seriesName: entityName,
                     time: originalTime,


### PR DESCRIPTION
> _Written by Anthropic Claude Opus 5 — @sophiamersmann at the wheel._

Indicators that stitch a projection onto its historical stem are merged into one column by `combineHistoricalAndProjectionColumns`. Four things were wrong with that column and with how the map reads it:

- **The combined column didn't record where its values came from.** Without a `<slug>-originalTime` column, `getOriginalTimeColumnSlug` falls back to the table's time column, so every value looked like an exact match for the target time even when tolerance had pulled it in from another year. The map's tolerance notice was therefore suppressed entirely, the map tooltip claimed the target year in its subtitle, and discrete bar charts annotated bars with the target year instead of the year each bar is from.
- **A tolerance-filled historical value was discarded when the projection had no value at all**, so the entity dropped off the map as "no data" rather than showing its historical value.
- **The notice stated the wrong tolerance.** The combined column's def is copied from the projection, so its own tolerance says nothing about what the historical stem allows — it now comes from the two columns the values actually come from. `share-of-women-aged-1549-who-are-married-or-in-a-union` is this shape today: historical tolerance 5, projection none.
- **The faceted map spent its tolerance twice.** Both columns are interpolated before being stitched, so the target time already carries a value wherever one is in reach; re-filtering with a tolerance could only pull in the *other* facet's row.

Two things worth knowing before reviewing:

**No published chart shows any of these bugs today.** Every projection map chart with a tolerance configured has data dense enough that tolerance never fires, and the charts with sparse enough data have no tolerance — the two sets don't intersect. I verified this by running `GrapherState` over the real indicator data for all seven candidate configs across every year on their timelines. So there's no broken chart to go and look at; the repro recipe below adds a tolerance to make it visible.

**The facet filter change isn't limited to stitched columns.** It applies to every map column, though it is inert for unstitched ones: `transformTableForSingleMapColumn` drops error rows *before* interpolating, and `complete()` then recreates a row at every time, so the row at the target time always survives and wins at distance 0. Only the stitched path drops error rows *after* combining, which is what opened the hole. Still the part most worth a second opinion, and the reason `svg-tester` deserves a look.

<details><summary>Details</summary>

### Changes

- **`ChartUtils.tsx`** — `combineHistoricalAndProjectionColumns` now adds a `<combinedSlug>-originalTime` column recording which source column's time each combined value came from. The historical-vs-projected choice also treats "the projection has no value here" as a case where the historical value wins: previously a missing projected value kept the row's own table time, giving it a time difference of 0 and beating a tolerance-filled historical value.
- **`MapChartState.ts`** — `toleranceNotice` takes its tolerance from `sourceColumns` (the historical and projected columns) rather than the combined column; `transformedTable`'s target-time filter no longer passes a tolerance; `checkIsProjection` keys on the row's own time via `valueByTimeAndEntityName` (the shape `EntitySelector` already used for that column) instead of on the original time.
- **`ToleranceNotice.ts`** — `getMaxConfiguredTolerance` exported so the map can ask the source columns.

The is-projection column deliberately does *not* get its own originalTime column: it would be a byte-for-byte duplicate of the combined column's, since both are built from the same `transformFn` over the same rows. Audited every reader — `MapChart.tsx:371` (`.values.every`), `MapTooltip.tsx:192` (`.owidRows[0].value`), `DiscreteBarChartState.ts:312` (`.valuesIncludingErrorValues`) are positional, and `EntitySelector.tsx:472` uses `valueByTimeAndEntityName`, whose keys come from the table's time column (`CoreTableColumns.ts:464-466`), not the originalTime column.

### Reproducing it

`urban-agglomerations-more-than-1-million` (chart 2803) is the closest chart — UN WUP data, 5-yearly, with a handful of countries starting late. It needs a tolerance added, which the chart editor can do live without saving.

*Source time and the dropped historical value*: editor → Map tab → Tolerance `5`; view the map at **1975**. Before, Lesotho, Malawi, Mauritania, Namibia, Oman, Rwanda and the United Arab Emirates were grey "no data" and there was no tolerance note (161 countries coloured). After, all seven are coloured from their 1980 value, their tooltips say 1980, and the note reads *"Where data for 1975 is unavailable, the value from the closest year between 1970 and 1980 is shown instead."* (168 countries). At **2020** instead, Eswatini's value comes from 2015 and Vanuatu's from 2025 — a projection shown on a 2020 map, which previously read as "2020".

*Double-spent tolerance*: same chart, but set Tolerance `5` on both dimension cards in the Data tab and leave the map tolerance empty (a map tolerance overrides both applications, so it masks the difference). Then `?tab=map&time=2015..2020` for two side-by-side maps and look at **Vanuatu on the 2015 map**. Its first data point is 2025. Before, it was coloured there — 2025 → 2020 by interpolation, 2020 → 2015 by the facet filter, ten years of reach from a tolerance of five. After, it is correctly grey.

### Tests

- `MapChart.test.ts` — source time and projection flag across the exact-projection, tolerance-projection and interpolated-historical paths; the double-spend pinned from both configuration sources (column tolerance and `map.timeTolerance`).
- `GrapherState.test.ts` — the tolerance notice end to end for a stitched map, including the case where only the historical column's tolerance can carry a value.

Verified by mutation that each test earns its place: removing the combined originalTime column fails *"explains the tolerance"*, *"gives the tolerance of whichever column the value came from"* and *"keeps the source time of combined values…"*; dropping `sourceColumns` fails only the second; reverting the facet filter fails only the two double-spend cases.

Two gaps left deliberately. The plain-column double-spend test passes with and without the fix — for the structural reason above, it can't be made to discriminate without a table the pipeline cannot produce, so it stands as a guard rather than a regression test. And no test drives a genuinely faceted table through `FacetMap`'s wiring, so the facet *leak* itself (as opposed to the general "don't reach past the target time" invariant) is only demonstrated empirically.

</details>
