### PR TITLE
✨ End the title with a period in "Copy for social" text

### DIFF
--- a/site/gdocs/pages/DataInsight.tsx
+++ b/site/gdocs/pages/DataInsight.tsx
@@ -130,7 +130,7 @@ function resolveCtaUrl(
 
 function ensureTrailingPunctuation(text: string): string {
     const trimmed = text.trimEnd()
-    return /[.!?…]$/.test(trimmed) ? trimmed : `${trimmed}.`
+    return /[.!?…]["'”’)\]]*$/.test(trimmed) ? trimmed : `${trimmed}.`
 }
 
 function buildSocialText(

--- a/site/gdocs/pages/DataInsight.tsx
+++ b/site/gdocs/pages/DataInsight.tsx
@@ -128,6 +128,11 @@ function resolveCtaUrl(
     return getLinkedDocumentUrl(doc, rawUrl)
 }
 
+function ensureTrailingPunctuation(text: string): string {
+    const trimmed = text.trimEnd()
+    return /[.!?…]$/.test(trimmed) ? trimmed : `${trimmed}.`
+}
+
 function buildSocialText(
     title: string,
     body: OwidEnrichedGdocBlock[],
@@ -147,7 +152,7 @@ function buildSocialText(
         }
     }
 
-    const parts = [title, paragraphs.join("\n\n")]
+    const parts = [ensureTrailingPunctuation(title), paragraphs.join("\n\n")]
 
     if (authors.length > 0) {
         parts.push(


### PR DESCRIPTION
> _Written by Anthropic Claude Opus 5 — @edomt at the wheel._

The `Copy for social` button on data insight pages builds a text block that starts with the DI's title. Titles are written without a final period, but social posts read better with one, so it was being added by hand after every copy.

The title now gets a period appended unless it already ends in sentence punctuation (`.`, `!`, `?`, `…`):

| Title | Copied text starts with |
| --- | --- |
| `Life expectancy has doubled` | `Life expectancy has doubled.` |
| `Is the world getting better?` | `Is the world getting better?` |
| `Emissions are falling (for now)` | `Emissions are falling (for now).` |

Only the title is affected — body paragraphs, the authors line, and the CTA are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)