### PR TITLE
🎉 Add the "Copy for social" button to announcement pages

### DIFF
--- a/site/gdocs/components/CopySocialButton.tsx
+++ b/site/gdocs/components/CopySocialButton.tsx
@@ -1,9 +1,16 @@
 import { useState } from "react"
+import cx from "clsx"
 import { copyToClipboard } from "@ourworldindata/utils"
 import { CookieKey } from "@ourworldindata/grapher"
 import { useIsClient } from "usehooks-ts"
 
-export function CopySocialButton({ text }: { text: string }) {
+export function CopySocialButton({
+    text,
+    className,
+}: {
+    text: string
+    className?: string
+}) {
     const isClient = useIsClient()
     const [label, setLabel] = useState("Copy for social")
 
@@ -23,7 +30,7 @@ export function CopySocialButton({ text }: { text: string }) {
     return (
         <a
             href="#"
-            className="data-insight-copy-link-button body-3-medium"
+            className={cx("body-3-medium", className)}
             onClick={(e) => {
                 e.preventDefault()
                 handleClick()

--- a/site/gdocs/pages/Announcement.scss
+++ b/site/gdocs/pages/Announcement.scss
@@ -8,3 +8,37 @@
     padding: 24px;
     margin: 48px 0;
 }
+
+.announcement-page-footer {
+    display: flex;
+    justify-content: flex-end;
+    border-top: solid $blue-20 1px;
+    padding-top: 24px;
+    margin-top: 24px;
+
+    // The button inside only renders for logged-in admins, so readers would
+    // otherwise see a stray divider at the bottom of the page.
+    &:empty {
+        display: none;
+    }
+}
+
+.announcement-page-copy-social-button {
+    @include light-blue-button;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 8px 24px;
+    height: 40px;
+    color: $blue-90;
+    background-color: $blue-20;
+    border-radius: 0;
+
+    &:hover {
+        background-color: $blue-10;
+    }
+
+    @include sm-only {
+        width: 100%;
+    }
+}

--- a/site/gdocs/pages/Announcement.tsx
+++ b/site/gdocs/pages/Announcement.tsx
@@ -1,7 +1,24 @@
-import { OwidGdocAnnouncementInterface } from "@ourworldindata/types"
+import {
+    AnnouncementLatestType,
+    LATEST_TYPE_LABELS,
+    OwidGdocAnnouncementInterface,
+} from "@ourworldindata/types"
+import { formatInlineList } from "@ourworldindata/utils"
+import { useContext } from "react"
 import * as React from "react"
 import { AnnouncementContent } from "../../latest/AnnouncementContent.js"
 import { deriveAnnouncementLatestType } from "../../latest/latestUtils.js"
+import { AttachmentsContext } from "../AttachmentsContext.js"
+import { CopySocialButton } from "../components/CopySocialButton.js"
+import { buildSocialText } from "../socialText.js"
+
+// Announcements posted on social media are data and topic updates; the other
+// kinds (website upgrades, general announcements) aren't, so they don't get
+// the button.
+const SOCIAL_LATEST_TYPES: readonly AnnouncementLatestType[] = [
+    "data-update",
+    "topic-update",
+]
 
 type AnnouncementProps = {
     className?: string
@@ -10,13 +27,27 @@ type AnnouncementProps = {
     "contentMd5" | "markdown" | "publicationContext" | "revisionId"
 >
 
+function buildAuthorsNote(
+    latestType: AnnouncementLatestType,
+    authors: string[]
+): string | undefined {
+    if (authors.length === 0) return undefined
+    const kicker = LATEST_TYPE_LABELS[latestType].toLowerCase()
+    return `This ${kicker} was led by ${formatInlineList(authors, "and")}.`
+}
+
 export const AnnouncementPage = ({
     content,
     publishedAt,
     slug,
     tags,
 }: AnnouncementProps): React.ReactElement => {
+    const { linkedDocuments } = useContext(AttachmentsContext)
     const latestType = deriveAnnouncementLatestType(content.kicker)
+    // CTA-only announcements have an empty body (enforced by
+    // GdocAnnouncement._validateSubclass), so there's nothing to copy.
+    const shouldShowCopySocialButton =
+        SOCIAL_LATEST_TYPES.includes(latestType) && content.body.length > 0
     return (
         <div className="announcement-page grid grid-cols-12-full-width">
             <div className="announcement-page-content span-cols-6 col-start-5 span-md-cols-8 col-md-start-4 span-sm-cols-14 col-sm-start-1">
@@ -32,6 +63,22 @@ export const AnnouncementPage = ({
                     cta={content.cta}
                     isStandalone
                 />
+                {shouldShowCopySocialButton && (
+                    <div className="announcement-page-footer">
+                        <CopySocialButton
+                            className="announcement-page-copy-social-button"
+                            text={buildSocialText({
+                                title: content.title,
+                                body: content.body,
+                                authorsNote: buildAuthorsNote(
+                                    latestType,
+                                    content.authors
+                                ),
+                                linkedDocuments,
+                            })}
+                        />
+                    </div>
+                )}
             </div>
         </div>
     )

--- a/site/gdocs/pages/DataInsight.tsx
+++ b/site/gdocs/pages/DataInsight.tsx
@@ -2,15 +2,10 @@ import cx from "clsx"
 import {
     LatestDataInsight,
     OwidGdocDataInsightInterface,
-    OwidEnrichedGdocBlock,
-    OwidGdocMinimalPostInterface,
     copyToClipboard,
     formatInlineList,
     MinimalTag,
-    Span,
 } from "@ourworldindata/utils"
-import { getLinkType, getUrlTarget } from "@ourworldindata/components"
-import { ContentGraphLinkType } from "@ourworldindata/types"
 import { useContext, useState } from "react"
 import * as React from "react"
 import {
@@ -26,7 +21,7 @@ import DataInsightDateline from "../components/DataInsightDateline.js"
 import LatestDataInsights from "../components/LatestDataInsights.js"
 import { AttachmentsContext } from "../AttachmentsContext.js"
 import { BAKED_BASE_URL } from "../../../settings/clientSettings.js"
-import { getLinkedDocumentUrl } from "../utils.js"
+import { buildSocialText } from "../socialText.js"
 import { CopySocialButton } from "../components/CopySocialButton.js"
 import { buildLatestPagePath } from "../../latest/latestUtils.js"
 
@@ -107,64 +102,9 @@ function CopyLinkButton(props: { slug: string }) {
     )
 }
 
-function spansToPlainText(spans: Span[]): string {
-    return spans
-        .map((span): string => {
-            if (span.spanType === "span-simple-text") return span.text
-            if (span.spanType === "span-newline") return "\n"
-            return spansToPlainText(span.children)
-        })
-        .join("")
-}
-
-function resolveCtaUrl(
-    rawUrl: string,
-    linkedDocuments: Record<string, OwidGdocMinimalPostInterface>
-): string {
-    if (getLinkType(rawUrl) !== ContentGraphLinkType.Gdoc) return rawUrl
-    const target = getUrlTarget(rawUrl)
-    const doc = linkedDocuments[target]
-    if (!doc) return rawUrl
-    return getLinkedDocumentUrl(doc, rawUrl)
-}
-
-function ensureTrailingPunctuation(text: string): string {
-    const trimmed = text.trimEnd()
-    return /[.!?…]["'”’)\]]*$/.test(trimmed) ? trimmed : `${trimmed}.`
-}
-
-function buildSocialText(
-    title: string,
-    body: OwidEnrichedGdocBlock[],
-    authors: string[],
-    linkedDocuments: Record<string, OwidGdocMinimalPostInterface>
-): string {
-    const paragraphs: string[] = []
-    let ctaText: string | undefined
-    let ctaUrl: string | undefined
-
-    for (const block of body) {
-        if (block.type === "text") {
-            paragraphs.push(spansToPlainText(block.value))
-        } else if (block.type === "cta") {
-            ctaText = block.text.replace(/[.:]+$/, "")
-            ctaUrl = resolveCtaUrl(block.url, linkedDocuments)
-        }
-    }
-
-    const parts = [ensureTrailingPunctuation(title), paragraphs.join("\n\n")]
-
-    if (authors.length > 0) {
-        parts.push(
-            `(This Data Insight was written by ${formatInlineList(authors, "and")}.)`
-        )
-    }
-
-    if (ctaText && ctaUrl) {
-        parts.push(`${ctaText}: ${ctaUrl}`)
-    }
-
-    return parts.join("\n\n")
+function buildAuthorsNote(authors: string[]): string | undefined {
+    if (authors.length === 0) return undefined
+    return `(This Data Insight was written by ${formatInlineList(authors, "and")}.)`
 }
 
 export const DataInsightBody = (
@@ -235,12 +175,15 @@ export const DataInsightBody = (
                     <RelatedTopicsList tags={props.tags ?? undefined} />
                     <CopyLinkButton slug={props.slug} />
                     <CopySocialButton
-                        text={buildSocialText(
-                            props.content.title,
-                            props.content.body,
-                            props.content.authors,
-                            linkedDocuments
-                        )}
+                        className="data-insight-copy-link-button"
+                        text={buildSocialText({
+                            title: props.content.title,
+                            body: props.content.body,
+                            authorsNote: buildAuthorsNote(
+                                props.content.authors
+                            ),
+                            linkedDocuments,
+                        })}
                     />
                 </div>
             </div>

--- a/site/gdocs/socialText.test.ts
+++ b/site/gdocs/socialText.test.ts
@@ -1,0 +1,81 @@
+import { expect, it, describe } from "vitest"
+import { OwidEnrichedGdocBlock } from "@ourworldindata/utils"
+import { buildSocialText } from "./socialText.js"
+
+function textBlock(text: string): OwidEnrichedGdocBlock {
+    return {
+        type: "text",
+        value: [{ spanType: "span-simple-text", text }],
+        parseErrors: [],
+    }
+}
+
+function ctaBlock(text: string, url: string): OwidEnrichedGdocBlock {
+    return { type: "cta", text, url, parseErrors: [] }
+}
+
+function build(
+    title: string,
+    body: OwidEnrichedGdocBlock[] = [],
+    authorsNote?: string
+): string {
+    return buildSocialText({
+        title,
+        body,
+        authorsNote,
+        linkedDocuments: {},
+    })
+}
+
+describe("buildSocialText", () => {
+    it("ends the title with a period when it has none", () => {
+        expect(build("Life expectancy has doubled")).toBe(
+            "Life expectancy has doubled."
+        )
+    })
+
+    it("leaves sentence-ending punctuation alone", () => {
+        expect(build("Is the world getting better?")).toBe(
+            "Is the world getting better?"
+        )
+        expect(build("It doubled since 1900.")).toBe("It doubled since 1900.")
+    })
+
+    it("looks past closing quotes and brackets", () => {
+        expect(build("“Is the world getting better?”")).toBe(
+            "“Is the world getting better?”"
+        )
+        expect(build("Emissions are falling (for now)")).toBe(
+            "Emissions are falling (for now)."
+        )
+    })
+
+    it("joins the title, paragraphs, authors note and cta", () => {
+        const text = build(
+            "Land use has changed",
+            [
+                textBlock("Cropland covers a tenth of the world."),
+                textBlock("Pasture covers a quarter."),
+                ctaBlock(
+                    "Explore the updated data:",
+                    "https://ourworldindata.org/land-use"
+                ),
+            ],
+            "This data update was led by Lucas Rodés-Guirao."
+        )
+        expect(text).toBe(
+            [
+                "Land use has changed.",
+                "Cropland covers a tenth of the world.\n\nPasture covers a quarter.",
+                "This data update was led by Lucas Rodés-Guirao.",
+                "Explore the updated data: https://ourworldindata.org/land-use",
+            ].join("\n\n")
+        )
+    })
+
+    it("omits the authors note when there is none", () => {
+        expect(build("A title", [textBlock("Some text.")])).toBe(
+            "A title.\n\nSome text."
+        )
+    })
+})

--- a/site/gdocs/socialText.test.ts
+++ b/site/gdocs/socialText.test.ts
@@ -27,7 +27,7 @@ function build(
     })
 }
 
-describe("buildSocialText", () => {
+describe(buildSocialText, () => {
     it("ends the title with a period when it has none", () => {
         expect(build("Life expectancy has doubled")).toBe(
             "Life expectancy has doubled."

--- a/site/gdocs/socialText.ts
+++ b/site/gdocs/socialText.ts
@@ -1,0 +1,74 @@
+import {
+    OwidEnrichedGdocBlock,
+    OwidGdocMinimalPostInterface,
+    Span,
+} from "@ourworldindata/utils"
+import { getLinkType, getUrlTarget } from "@ourworldindata/components"
+import { ContentGraphLinkType } from "@ourworldindata/types"
+import { getLinkedDocumentUrl } from "./utils.js"
+
+function spansToPlainText(spans: Span[]): string {
+    return spans
+        .map((span): string => {
+            if (span.spanType === "span-simple-text") return span.text
+            if (span.spanType === "span-newline") return "\n"
+            return spansToPlainText(span.children)
+        })
+        .join("")
+}
+
+function resolveCtaUrl(
+    rawUrl: string,
+    linkedDocuments: Record<string, OwidGdocMinimalPostInterface>
+): string {
+    if (getLinkType(rawUrl) !== ContentGraphLinkType.Gdoc) return rawUrl
+    const target = getUrlTarget(rawUrl)
+    const doc = linkedDocuments[target]
+    if (!doc) return rawUrl
+    return getLinkedDocumentUrl(doc, rawUrl)
+}
+
+function ensureTrailingPunctuation(text: string): string {
+    const trimmed = text.trimEnd()
+    return /[.!?…]["'”’)\]]*$/.test(trimmed) ? trimmed : `${trimmed}.`
+}
+
+/** Plain text for the admin-only "Copy for social" button, shared by data
+ * insights and announcements. The authors note is passed in because its
+ * wording differs per gdoc type. */
+export function buildSocialText({
+    title,
+    body,
+    authorsNote,
+    linkedDocuments,
+}: {
+    title: string
+    body: OwidEnrichedGdocBlock[]
+    authorsNote?: string
+    linkedDocuments: Record<string, OwidGdocMinimalPostInterface>
+}): string {
+    const paragraphs: string[] = []
+    let ctaText: string | undefined
+    let ctaUrl: string | undefined
+
+    for (const block of body) {
+        if (block.type === "text") {
+            paragraphs.push(spansToPlainText(block.value))
+        } else if (block.type === "cta") {
+            ctaText = block.text.replace(/[.:]+$/, "")
+            ctaUrl = resolveCtaUrl(block.url, linkedDocuments)
+        }
+    }
+
+    const parts = [ensureTrailingPunctuation(title), paragraphs.join("\n\n")]
+
+    if (authorsNote) {
+        parts.push(authorsNote)
+    }
+
+    if (ctaText && ctaUrl) {
+        parts.push(`${ctaText}: ${ctaUrl}`)
+    }
+
+    return parts.filter(Boolean).join("\n\n")
+}


### PR DESCRIPTION
> _Written by Anthropic Claude Opus 5 — @edomt at the wheel._

**Scope note for reviewers (including @codex): this is an internal helper for our own editors, not a reader-facing feature.** The button is only rendered for logged-in admins, and it just pre-fills a social post that a human edits before publishing. Please keep suggestions proportionate to that — correctness and reader-visible side effects matter, exhaustive text-formatting edge cases don't.

Stacked on #6890 — review that one first, this PR's diff is against it.

### What this does

Data and topic updates now get the same admin-only `Copy for social` button that data insights have, at the bottom of the standalone announcement page.

The copied text starts at the title and ends with the CTA, matching the data insight order:

```
How have humans reshaped the world's land over the last 12,000 years?

<body paragraphs>

This data update was led by Lucas Rodés-Guirao.

Explore the updated data in our interactive charts: https://ourworldindata.org/land-use
```

The authors note wording differs per gdoc type, so it's now passed in by each call site rather than baked into the builder — data insights keep `(This Data Insight was written by …)`, announcements get `This <kicker> was led by …`, with the kicker taken from `LATEST_TYPE_LABELS`.

### Where the button does and doesn't appear

| | Button? |
| --- | --- |
| Data update / topic update announcement | yes |
| Website upgrade / general announcement | no |
| CTA-only announcement (empty body by validation) | no |
| `/latest` feed hits | no — it's rendered by the standalone page, not by the shared `AnnouncementContent` |
| Logged-out readers | no — unchanged `isAdmin` cookie gate in `CopySocialButton` |

The footer wrapper collapses via `:empty` so readers don't see a stray divider where the button would be.

### Structure

`buildSocialText` and its helpers move out of `DataInsight.tsx` into `site/gdocs/socialText.ts`, which makes them unit-testable — `socialText.test.ts` covers the title punctuation cases and the part ordering. Empty parts are now filtered out, so an announcement whose body holds only a CTA block doesn't get a double blank line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)