### PR TITLE
🚧🤖 debug: hard-code referenceEntity for china-imports variable

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
@@ -810,6 +810,15 @@ export class GrapherState
     @action.bound updateFromObject(obj?: GrapherProgrammaticInterface): void {
         if (!obj) return
 
+        // TODO: debug only, remove before committing.
+        // Drop the custom color and label for the "China" reference entity
+        // that are left over from the sentinel-value hack in the
+        // china-imports chart
+        if (obj.id === 8832) {
+            delete obj.map?.colorScale?.customCategoryColors?.["China"]
+            delete obj.map?.colorScale?.customCategoryLabels?.["China"]
+        }
+
         updatePersistables(this, obj)
 
         this.bindUrlToWindow = obj.bindUrlToWindow ?? false

--- a/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.ts
+++ b/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.ts
@@ -687,7 +687,7 @@ const columnDefFromOwidVariable = (
     // TODO: debug only, remove before committing
     const display =
         variable.id === 1104804
-            ? { ...variable.display, notApplicableEntities: ["China"] }
+            ? { ...variable.display, inapplicableEntities: ["China"] }
             : variable.display
 
     const isContinent = isContinentsVariableId(variable.id)

--- a/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.ts
+++ b/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.ts
@@ -170,12 +170,24 @@ export const legacyToOwidTableAndDimensions = (
                 valueColumnDef.type = ColumnTypeNames.Numeric
         }
 
+        // TODO: debug only, remove before committing.
+        // Drop the categorical "China" values carried by the china-imports
+        // variable — in the real setup, the reference entity has no values
+        const debugValues: unknown[] =
+            dimension.variableId === 1104804
+                ? values.map((value, index) =>
+                      entityNames[index] === "China"
+                          ? ErrorValueTypes.MissingValuePlaceholder
+                          : value
+                  )
+                : values
+
         const columnStore: { [key: string]: any[] } = {
             [OwidTableSlugs.EntityId]: entityIds,
             [OwidTableSlugs.EntityCode]: entityCodes,
             [OwidTableSlugs.EntityName]: entityNames,
             [timeColumnDef.slug]: times,
-            [valueColumnDef.slug]: values,
+            [valueColumnDef.slug]: debugValues,
         }
 
         if (annotationColumnDef) {
@@ -664,7 +676,6 @@ const columnDefFromOwidVariable = (
         descriptionFromProducer,
         source,
         origins,
-        display,
         timespan,
         nonRedistributable,
         presentation,
@@ -672,6 +683,12 @@ const columnDefFromOwidVariable = (
         updatePeriodDays,
         shortName,
     } = variable
+
+    // TODO: debug only, remove before committing
+    const display =
+        variable.id === 1104804
+            ? { ...variable.display, notApplicableEntities: ["China"] }
+            : variable.display
 
     const isContinent = isContinentsVariableId(variable.id)
     const name = variable.name


### PR DESCRIPTION
> _Written by Anthropic Claude Fable 5 — @sophiamersmann at the wheel._

Temporary debugging aid on top of the `display.referenceEntity` PR: hard-codes `referenceEntity: "China"` for the china-imports variable and drops its categorical China values, simulating the intended setup where the reference entity itself carries no values. Not meant to be merged.

Example: http://staging-site-reference-entity-debug/grapher/china-imports-as-share-of-gdp

🤖 Generated with [Claude Code](https://claude.com/claude-code)