### PR TITLE
⚡ Speed up and simplify legacyToOwidTableAndDimensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
         "testFormatAll": "yarn oxfmt --check",
         "testFormatChanged": "bash -c 'files=$((git diff --name-only --diff-filter=ACMRTUXB && git diff --name-only --cached --diff-filter=ACMRTUXB) | sort -u | grep -E \"\\.(tsx?|jsx?|ts|js|json|md|html|css|scss|yml)$\" | tr \"\\n\" \" \"); if [ -n \"$files\" ]; then yarn oxfmt --check $files; else echo \"No uncommitted files to check formatting\"; fi'",
         "test": "vitest",
+        "testBench": "vitest bench --run",
         "test:functions:e2e-r2": "vitest functions/test/grapher-config-r2.e2e.test.ts",
         "test:functions:e2e-search": "vitest functions/test/search.e2e.test.ts",
         "testBdd": "yarn bddgen && yarn playwright test",

--- a/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.bench.ts
+++ b/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.bench.ts
@@ -1,0 +1,310 @@
+// Benchmarks for fullJoinTables(), the multi-table join at the heart of
+// legacyToOwidTableAndDimensions(). Run with `yarn testBench`.
+//
+// The cases below mirror the shapes fullJoinTables() sees in production:
+// - year variables joined on year+entity (by far the most common case)
+// - sub-yearly (day/week/month) variables joined on day+entity
+// - a mix of both, where the day+entity index is the primary one and lookups
+//   into the year tables go through the year+entity and entity-only fallbacks
+// - variables with a targetTime, which are joined on entity only
+
+import * as _ from "lodash-es"
+import { bench, describe } from "vitest"
+import {
+    ColumnTypeNames,
+    OwidColumnDef,
+    OwidTableSlugs,
+    TimeInterval,
+} from "@ourworldindata/types"
+import { OwidTable } from "@ourworldindata/core-table"
+import {
+    EPOCH_DATE,
+    getYearFromISOStringAndDayOffset,
+    OwidVariableDataMetadataDimensions,
+} from "@ourworldindata/utils"
+import { buildVariableTable, fullJoinTables } from "./LegacyToOwidTable"
+
+const YEAR_INDEX = [OwidTableSlugs.Year, OwidTableSlugs.EntityId]
+const DAY_INDEX = [OwidTableSlugs.Day, OwidTableSlugs.EntityId]
+const ENTITY_INDEX = [OwidTableSlugs.EntityId]
+
+/**
+ * OwidTable computes its column store and columns lazily and memoizes them.
+ * Benchmarks reuse the same tables across iterations, so we touch everything
+ * once up front to measure the join itself rather than a one-off parse in the
+ * first iteration.
+ */
+const warmTable = (table: OwidTable): OwidTable => {
+    table.getColumns(table.columnSlugs).forEach((col) => col.values)
+    return table
+}
+
+const entityIdsRange = (count: number, offset = 0): number[] =>
+    _.range(offset + 1, offset + count + 1)
+
+/**
+ * Builds a variable table with one row per (entity, time) pair, going through
+ * the same buildVariableTable() the real code uses.
+ */
+const makeVariableTable = ({
+    variableId,
+    entityIds,
+    times,
+    timeInterval = TimeInterval.Year,
+}: {
+    variableId: number
+    entityIds: number[]
+    times: number[]
+    timeInterval?: TimeInterval
+}): OwidTable => {
+    const entities: number[] = []
+    const years: number[] = []
+    const values: number[] = []
+    for (const entityId of entityIds)
+        for (const time of times) {
+            entities.push(entityId)
+            years.push(time)
+            // deterministic, so runs are comparable
+            values.push((entityId * 31 + time * 7) % 1000)
+        }
+
+    const variable: OwidVariableDataMetadataDimensions = {
+        data: { entities, values, years },
+        metadata: {
+            id: variableId,
+            display: { timeInterval },
+            dimensions: {
+                years: { values: [] },
+                entities: {
+                    values: entityIds.map((id) => ({
+                        id,
+                        name: `Country ${id}`,
+                        code: `C${id.toString().padStart(3, "0")}`,
+                    })),
+                },
+            },
+        },
+    }
+
+    return warmTable(buildVariableTable(variable))
+}
+
+/**
+ * A variable with a targetTime, as produced for scatter/marimekko dimensions:
+ * filtered down to a single time and with the time column dropped, so it can
+ * only be joined on entity.
+ */
+const makeTargetTimeTable = ({
+    variableId,
+    entityIds,
+    times,
+    targetTime,
+}: {
+    variableId: number
+    entityIds: number[]
+    times: number[]
+    targetTime: number
+}): OwidTable => {
+    const table = makeVariableTable({ variableId, entityIds, times })
+    return warmTable(
+        table
+            .filterByTargetTimes([targetTime], 0)
+            .interpolateColumnWithTolerance(variableId.toString(), {
+                toleranceOverride: 0,
+            })
+            .dropColumns([OwidTableSlugs.Year])
+    )
+}
+
+/**
+ * Joins day tables together and derives a year column from the day column,
+ * mirroring what legacyToOwidTableAndDimensions() does before joining the
+ * result with the year based variables.
+ */
+const joinDaysAndFillYear = (dayTables: OwidTable[]): OwidTable => {
+    const joined = fullJoinTables(dayTables, DAY_INDEX)
+    const dayColumn = joined.getColumns([OwidTableSlugs.Day])[0]
+    const getYearMemoized = _.memoize((day: number) =>
+        getYearFromISOStringAndDayOffset(EPOCH_DATE, day)
+    )
+    const yearColumnDef: OwidColumnDef = {
+        slug: OwidTableSlugs.Year,
+        name: OwidTableSlugs.Year,
+        type: ColumnTypeNames.Year,
+        values: dayColumn.values.map((day) => getYearMemoized(day as number)),
+    }
+    return warmTable(joined.appendColumns([yearColumnDef]))
+}
+
+describe("fullJoinTables: year variables", () => {
+    const smallTables = _.range(0, 3).map((i) =>
+        makeVariableTable({
+            variableId: 100 + i,
+            entityIds: entityIdsRange(30),
+            times: _.range(2000, 2025),
+        })
+    )
+    // 6 variables × 200 entities × 60 years = 12k rows each
+    const mediumTables = _.range(0, 6).map((i) =>
+        makeVariableTable({
+            variableId: 200 + i,
+            entityIds: entityIdsRange(200),
+            times: _.range(1960, 2020),
+        })
+    )
+    // 12 variables × 250 entities × 120 years = 30k rows each
+    const largeTables = _.range(0, 12).map((i) =>
+        makeVariableTable({
+            variableId: 300 + i,
+            entityIds: entityIdsRange(250),
+            times: _.range(1900, 2020),
+        })
+    )
+    // Barely overlapping coverage: the union of all index values is far larger
+    // than any single table, so most lookups miss and end up as
+    // NoMatchingValueAfterJoin
+    const raggedTables = _.range(0, 6).map((i) =>
+        makeVariableTable({
+            variableId: 400 + i,
+            entityIds: entityIdsRange(120, i * 40),
+            times: _.range(1950 + i * 15, 1950 + i * 15 + 40),
+        })
+    )
+
+    bench("3 tables × 30 entities × 25 years", () => {
+        fullJoinTables(smallTables, YEAR_INDEX)
+    })
+
+    bench("6 tables × 200 entities × 60 years", () => {
+        fullJoinTables(mediumTables, YEAR_INDEX)
+    })
+
+    bench("12 tables × 250 entities × 120 years", () => {
+        fullJoinTables(largeTables, YEAR_INDEX)
+    })
+
+    bench("6 tables with barely overlapping entities and years", () => {
+        fullJoinTables(raggedTables, YEAR_INDEX)
+    })
+})
+
+describe("fullJoinTables: sub-yearly variables", () => {
+    // 3 variables × 60 entities × 2 years of daily data = 22k rows each
+    const dayTables = _.range(0, 3).map((i) =>
+        makeVariableTable({
+            variableId: 500 + i,
+            entityIds: entityIdsRange(60),
+            times: _.range(18000, 18000 + 365 * 2),
+            timeInterval: TimeInterval.Day,
+        })
+    )
+    // Daily, weekly and monthly variables all end up in the day column, but at
+    // different granularities, so their index values only partially overlap
+    const mixedIntervalTables = [
+        makeVariableTable({
+            variableId: 600,
+            entityIds: entityIdsRange(60),
+            times: _.range(18000, 18000 + 365 * 2),
+            timeInterval: TimeInterval.Day,
+        }),
+        makeVariableTable({
+            variableId: 601,
+            entityIds: entityIdsRange(60),
+            times: _.range(18000, 18000 + 365 * 2, 7),
+            timeInterval: TimeInterval.Week,
+        }),
+        makeVariableTable({
+            variableId: 602,
+            entityIds: entityIdsRange(60),
+            // a 32 day step never lands twice in the same month, so no two
+            // rows snap onto the same month start
+            times: _.range(18000, 18000 + 365 * 2, 32),
+            timeInterval: TimeInterval.Month,
+        }),
+    ]
+
+    bench("3 day tables × 60 entities × 730 days", () => {
+        fullJoinTables(dayTables, DAY_INDEX)
+    })
+
+    bench("day + week + month tables × 60 entities × 730 days", () => {
+        fullJoinTables(mixedIntervalTables, DAY_INDEX)
+    })
+})
+
+describe("fullJoinTables: mixed day and year variables", () => {
+    const entityIds = entityIdsRange(60)
+    const dayTimes = _.range(18000, 18000 + 365 * 2)
+    const joinedDays = joinDaysAndFillYear(
+        _.range(0, 2).map((i) =>
+            makeVariableTable({
+                variableId: 700 + i,
+                entityIds,
+                times: dayTimes,
+                timeInterval: TimeInterval.Day,
+            })
+        )
+    )
+    const yearTables = _.range(0, 3).map((i) =>
+        makeVariableTable({
+            variableId: 800 + i,
+            entityIds,
+            times: _.range(1960, 2025),
+        })
+    )
+    // A continents-style variable with data for a single year only: no lookup
+    // by day+entity or year+entity can hit, so every row falls through to the
+    // entity-only fallback
+    const singleYearTable = makeVariableTable({
+        variableId: 900,
+        entityIds,
+        times: [2015],
+    })
+    const fallbacks = [
+        [OwidTableSlugs.Year, OwidTableSlugs.EntityId],
+        [OwidTableSlugs.EntityId],
+    ]
+
+    bench("2 day tables + 3 year tables (year+entity fallback)", () => {
+        fullJoinTables([joinedDays, ...yearTables], DAY_INDEX, fallbacks)
+    })
+
+    bench("2 day tables + single-year table (entity-only fallback)", () => {
+        fullJoinTables([joinedDays, singleYearTable], DAY_INDEX, fallbacks)
+    })
+
+    bench("2 day tables + 3 year tables + single-year table", () => {
+        fullJoinTables(
+            [joinedDays, ...yearTables, singleYearTable],
+            DAY_INDEX,
+            fallbacks
+        )
+    })
+})
+
+describe("fullJoinTables: variables with a targetTime", () => {
+    const entityIds = entityIdsRange(200)
+    const times = _.range(1960, 2020)
+    const yearTables = _.range(0, 3).map((i) =>
+        makeVariableTable({ variableId: 1000 + i, entityIds, times })
+    )
+    const joinedYears = warmTable(fullJoinTables(yearTables, YEAR_INDEX))
+    const targetTimeTables = _.range(0, 2).map((i) =>
+        makeTargetTimeTable({
+            variableId: 1100 + i,
+            entityIds,
+            times,
+            targetTime: 2010,
+        })
+    )
+
+    bench("2 targetTime tables joined on entity only", () => {
+        fullJoinTables(targetTimeTables, ENTITY_INDEX)
+    })
+
+    bench("joined year table + 2 targetTime tables", () => {
+        fullJoinTables([joinedYears, ...targetTimeTables], YEAR_INDEX, [
+            ENTITY_INDEX,
+        ])
+    })
+})

--- a/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.bench.ts
+++ b/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.bench.ts
@@ -12,6 +12,8 @@ import * as _ from "lodash-es"
 import { bench, describe } from "vitest"
 import {
     ColumnTypeNames,
+    DimensionProperty,
+    OwidChartDimensionInterface,
     OwidColumnDef,
     OwidTableSlugs,
     TimeInterval,
@@ -20,9 +22,16 @@ import { OwidTable } from "@ourworldindata/core-table"
 import {
     EPOCH_DATE,
     getYearFromISOStringAndDayOffset,
+    MultipleOwidVariableDataDimensionsMap,
     OwidVariableDataMetadataDimensions,
 } from "@ourworldindata/utils"
-import { buildVariableTable, fullJoinTables } from "./LegacyToOwidTable"
+import {
+    buildVariableTable,
+    fullJoinTables,
+    JoinTable,
+    legacyToOwidTableAndDimensionsWithMandatorySlug,
+    owidTableToJoinTable,
+} from "./LegacyToOwidTable"
 
 const YEAR_INDEX = [OwidTableSlugs.Year, OwidTableSlugs.EntityId]
 const DAY_INDEX = [OwidTableSlugs.Day, OwidTableSlugs.EntityId]
@@ -42,21 +51,20 @@ const warmTable = (table: OwidTable): OwidTable => {
 const entityIdsRange = (count: number, offset = 0): number[] =>
     _.range(offset + 1, offset + count + 1)
 
-/**
- * Builds a variable table with one row per (entity, time) pair, going through
- * the same buildVariableTable() the real code uses.
- */
-const makeVariableTable = ({
-    variableId,
-    entityIds,
-    times,
-    timeInterval = TimeInterval.Year,
-}: {
+interface VariableOptions {
     variableId: number
     entityIds: number[]
     times: number[]
     timeInterval?: TimeInterval
-}): OwidTable => {
+}
+
+/** Builds a legacy variable with one row per (entity, time) pair */
+const makeVariable = ({
+    variableId,
+    entityIds,
+    times,
+    timeInterval = TimeInterval.Year,
+}: VariableOptions): OwidVariableDataMetadataDimensions => {
     const entities: number[] = []
     const years: number[] = []
     const values: number[] = []
@@ -68,7 +76,7 @@ const makeVariableTable = ({
             values.push((entityId * 31 + time * 7) % 1000)
         }
 
-    const variable: OwidVariableDataMetadataDimensions = {
+    return {
         data: { entities, values, years },
         metadata: {
             id: variableId,
@@ -85,9 +93,14 @@ const makeVariableTable = ({
             },
         },
     }
-
-    return warmTable(buildVariableTable(variable))
 }
+
+/**
+ * Builds a variable table with one row per (entity, time) pair, going through
+ * the same buildVariableTable() the real code uses.
+ */
+const makeVariableTable = (options: VariableOptions): JoinTable =>
+    owidTableToJoinTable(warmTable(buildVariableTable(makeVariable(options))))
 
 /**
  * A variable with a targetTime, as produced for scatter/marimekko dimensions:
@@ -104,15 +117,19 @@ const makeTargetTimeTable = ({
     entityIds: number[]
     times: number[]
     targetTime: number
-}): OwidTable => {
-    const table = makeVariableTable({ variableId, entityIds, times })
-    return warmTable(
-        table
-            .filterByTargetTimes([targetTime], 0)
-            .interpolateColumnWithTolerance(variableId.toString(), {
-                toleranceOverride: 0,
-            })
-            .dropColumns([OwidTableSlugs.Year])
+}): JoinTable => {
+    const table = warmTable(
+        buildVariableTable(makeVariable({ variableId, entityIds, times }))
+    )
+    return owidTableToJoinTable(
+        warmTable(
+            table
+                .filterByTargetTimes([targetTime], 0)
+                .interpolateColumnWithTolerance(variableId.toString(), {
+                    toleranceOverride: 0,
+                })
+                .dropColumns([OwidTableSlugs.Year])
+        )
     )
 }
 
@@ -121,9 +138,9 @@ const makeTargetTimeTable = ({
  * mirroring what legacyToOwidTableAndDimensions() does before joining the
  * result with the year based variables.
  */
-const joinDaysAndFillYear = (dayTables: OwidTable[]): OwidTable => {
+const joinDaysAndFillYear = (dayTables: JoinTable[]): JoinTable => {
     const joined = fullJoinTables(dayTables, DAY_INDEX)
-    const dayColumn = joined.getColumns([OwidTableSlugs.Day])[0]
+    const dayValues = joined.columnStore[OwidTableSlugs.Day]
     const getYearMemoized = _.memoize((day: number) =>
         getYearFromISOStringAndDayOffset(EPOCH_DATE, day)
     )
@@ -131,9 +148,17 @@ const joinDaysAndFillYear = (dayTables: OwidTable[]): OwidTable => {
         slug: OwidTableSlugs.Year,
         name: OwidTableSlugs.Year,
         type: ColumnTypeNames.Year,
-        values: dayColumn.values.map((day) => getYearMemoized(day as number)),
     }
-    return warmTable(joined.appendColumns([yearColumnDef]))
+    return {
+        columnStore: {
+            ...joined.columnStore,
+            [OwidTableSlugs.Year]: dayValues.map((day) =>
+                getYearMemoized(day as number)
+            ),
+        },
+        defs: [...joined.defs, yearColumnDef],
+        numRows: joined.numRows,
+    }
 }
 
 describe("fullJoinTables: year variables", () => {
@@ -288,7 +313,7 @@ describe("fullJoinTables: variables with a targetTime", () => {
     const yearTables = _.range(0, 3).map((i) =>
         makeVariableTable({ variableId: 1000 + i, entityIds, times })
     )
-    const joinedYears = warmTable(fullJoinTables(yearTables, YEAR_INDEX))
+    const joinedYears = fullJoinTables(yearTables, YEAR_INDEX)
     const targetTimeTables = _.range(0, 2).map((i) =>
         makeTargetTimeTable({
             variableId: 1100 + i,
@@ -306,5 +331,121 @@ describe("fullJoinTables: variables with a targetTime", () => {
         fullJoinTables([joinedYears, ...targetTimeTables], YEAR_INDEX, [
             ENTITY_INDEX,
         ])
+    })
+})
+
+describe("legacyToOwidTableAndDimensions: end to end", () => {
+    const yDimensions = (
+        variables: OwidVariableDataMetadataDimensions[],
+        targetYear?: number
+    ): OwidChartDimensionInterface[] =>
+        variables.map((variable) => ({
+            variableId: variable.metadata.id,
+            property: DimensionProperty.y,
+            targetYear,
+        }))
+    const varMap = (
+        variables: OwidVariableDataMetadataDimensions[]
+    ): MultipleOwidVariableDataDimensionsMap =>
+        new Map(variables.map((variable) => [variable.metadata.id, variable]))
+    const selectedEntityColors = { "Country 1": "#f00", "Country 2": "#0f0" }
+
+    const yearVariables = _.range(0, 6).map((i) =>
+        makeVariable({
+            variableId: 2000 + i,
+            entityIds: entityIdsRange(200),
+            times: _.range(1960, 2020),
+        })
+    )
+    const largeYearVariables = _.range(0, 12).map((i) =>
+        makeVariable({
+            variableId: 2100 + i,
+            entityIds: entityIdsRange(250),
+            times: _.range(1900, 2020),
+        })
+    )
+    const dayVariables = _.range(0, 2).map((i) =>
+        makeVariable({
+            variableId: 2200 + i,
+            entityIds: entityIdsRange(60),
+            times: _.range(18000, 18000 + 365 * 2),
+            timeInterval: TimeInterval.Day,
+        })
+    )
+    const mixedYearVariables = _.range(0, 3).map((i) =>
+        makeVariable({
+            variableId: 2210 + i,
+            entityIds: entityIdsRange(60),
+            times: _.range(1960, 2025),
+        })
+    )
+    // Monthly values arrive as representative days and get snapped to the
+    // month start when the table is built
+    const monthlyVariables = _.range(0, 3).map((i) =>
+        makeVariable({
+            variableId: 2300 + i,
+            entityIds: entityIdsRange(60),
+            times: _.range(18000 + i, 18000 + i + 365 * 4, 32),
+            timeInterval: TimeInterval.Month,
+        })
+    )
+    const scatterVariables = _.range(0, 2).map((i) =>
+        makeVariable({
+            variableId: 2400 + i,
+            entityIds: entityIdsRange(200),
+            times: _.range(1960, 2020),
+        })
+    )
+    const scatterTargetTimeVariables = _.range(0, 2).map((i) =>
+        makeVariable({
+            variableId: 2410 + i,
+            entityIds: entityIdsRange(200),
+            times: _.range(1960, 2020),
+        })
+    )
+
+    bench("6 year variables × 200 entities × 60 years", () => {
+        legacyToOwidTableAndDimensionsWithMandatorySlug(
+            varMap(yearVariables),
+            yDimensions(yearVariables),
+            selectedEntityColors
+        )
+    })
+
+    bench("12 year variables × 250 entities × 120 years", () => {
+        legacyToOwidTableAndDimensionsWithMandatorySlug(
+            varMap(largeYearVariables),
+            yDimensions(largeYearVariables),
+            selectedEntityColors
+        )
+    })
+
+    bench("2 day variables + 3 year variables", () => {
+        const variables = [...dayVariables, ...mixedYearVariables]
+        legacyToOwidTableAndDimensionsWithMandatorySlug(
+            varMap(variables),
+            yDimensions(variables),
+            selectedEntityColors
+        )
+    })
+
+    bench("3 monthly variables × 60 entities × 4 years", () => {
+        legacyToOwidTableAndDimensionsWithMandatorySlug(
+            varMap(monthlyVariables),
+            yDimensions(monthlyVariables),
+            selectedEntityColors
+        )
+    })
+
+    bench("scatter: 2 year variables + 2 targetTime variables", () => {
+        const variables = [...scatterVariables, ...scatterTargetTimeVariables]
+        legacyToOwidTableAndDimensionsWithMandatorySlug(
+            varMap(variables),
+            [
+                ...yDimensions(scatterVariables),
+                ...yDimensions(scatterTargetTimeVariables, 2010),
+            ],
+            selectedEntityColors
+        )
     })
 })

--- a/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.test.ts
+++ b/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.test.ts
@@ -1,6 +1,7 @@
 import { expect, it, describe } from "vitest"
 
 import {
+    ColumnTypeNames,
     GRAPHER_CHART_TYPES,
     OwidTableSlugs,
     StandardOwidColumnDefs,
@@ -14,6 +15,8 @@ import {
     OwidTable,
 } from "@ourworldindata/core-table"
 import {
+    buildVariableTable,
+    fullJoinTables,
     legacyToOwidTableAndDimensions,
     legacyToOwidTableAndDimensionsWithMandatorySlug,
 } from "./LegacyToOwidTable"
@@ -1003,5 +1006,139 @@ Papua New Guinea,PNG,1983,5.5,1983,`
             config.selectedEntityColors
         ).get("3512").def
         expect(columnDef.nonRedistributable).toEqual(true)
+    })
+})
+
+describe(fullJoinTables, () => {
+    // fullJoinTables uses fast numeric composite keys when all times and entity
+    // ids fit into 26 bits, and generic string keys otherwise. Both paths have
+    // to produce equivalent joins - we verify this by joining the same data
+    // twice, with entity ids shifted beyond 2^26 to force the string path.
+    const HUGE_ID_OFFSET = 2 ** 26
+
+    const makeTable = (
+        variableId: number,
+        rows: [entityId: number, time: number, value: number][],
+        timeInterval?: TimeInterval
+    ): OwidTable => {
+        const entityIds = [...new Set(rows.map((row) => row[0]))]
+        return buildVariableTable({
+            data: {
+                entities: rows.map((row) => row[0]),
+                years: rows.map((row) => row[1]),
+                values: rows.map((row) => row[2]),
+            },
+            metadata: {
+                id: variableId,
+                display: timeInterval ? { timeInterval } : undefined,
+                dimensions: {
+                    years: { values: [] },
+                    entities: {
+                        values: entityIds.map((id) => ({
+                            id,
+                            // identical names for both id ranges, so the
+                            // joined tables are comparable
+                            name: `Entity ${id % HUGE_ID_OFFSET}`,
+                        })),
+                    },
+                },
+            },
+        })
+    }
+
+    const expectEquivalentJoins = (
+        numericKeyed: OwidTable,
+        stringKeyed: OwidTable
+    ): void => {
+        expect(stringKeyed.columnSlugs).toEqual(numericKeyed.columnSlugs)
+        for (const slug of numericKeyed.columnSlugs) {
+            const numericValues =
+                numericKeyed.get(slug).valuesIncludingErrorValues
+            const stringValues =
+                stringKeyed.get(slug).valuesIncludingErrorValues
+            if (slug === OwidTableSlugs.EntityId)
+                expect(stringValues).toEqual(
+                    numericValues.map((id) => (id as number) + HUGE_ID_OFFSET)
+                )
+            else expect(stringValues).toEqual(numericValues)
+        }
+    }
+
+    it("joins by year+entity identically with numeric and string keys", () => {
+        const joinByYear = (offset: number): OwidTable =>
+            fullJoinTables(
+                [
+                    makeTable(2, [
+                        [offset + 1, 2000, 1],
+                        [offset + 1, 2001, 2],
+                        [offset + 2, 2001, 3],
+                    ]),
+                    // partial overlap, so the join has misses too
+                    makeTable(3, [
+                        [offset + 1, 2001, 10],
+                        [offset + 2, 2003, 11],
+                    ]),
+                ],
+                [OwidTableSlugs.Year, OwidTableSlugs.EntityId]
+            )
+
+        const numericKeyed = joinByYear(0)
+        expect(numericKeyed.get("2").valuesIncludingErrorValues).toEqual([
+            1,
+            2,
+            3,
+            ErrorValueTypes.NoMatchingValueAfterJoin,
+        ])
+        expect(numericKeyed.get("3").valuesIncludingErrorValues).toEqual([
+            ErrorValueTypes.NoMatchingValueAfterJoin,
+            10,
+            ErrorValueTypes.NoMatchingValueAfterJoin,
+            11,
+        ])
+        expectEquivalentJoins(numericKeyed, joinByYear(HUGE_ID_OFFSET))
+    })
+
+    it("joins days and years via fallbacks identically with numeric and string keys", () => {
+        const joinDaysAndYears = (offset: number): OwidTable => {
+            const dayTable = makeTable(
+                4,
+                [
+                    [offset + 1, 18992, 5],
+                    [offset + 1, 18993, 6],
+                    [offset + 2, 18992, 7],
+                ],
+                TimeInterval.Day
+            ).appendColumns([
+                {
+                    slug: OwidTableSlugs.Year,
+                    name: OwidTableSlugs.Year,
+                    type: ColumnTypeNames.Year,
+                    values: [2022, 2022, 2022],
+                },
+            ])
+            const yearTable = makeTable(5, [
+                [offset + 1, 2022, 100],
+                // only matched via the entity-only fallback
+                [offset + 2, 2015, 200],
+            ])
+            return fullJoinTables(
+                [dayTable, yearTable],
+                [OwidTableSlugs.Day, OwidTableSlugs.EntityId],
+                [
+                    [OwidTableSlugs.Year, OwidTableSlugs.EntityId],
+                    [OwidTableSlugs.EntityId],
+                ]
+            )
+        }
+
+        const numericKeyed = joinDaysAndYears(0)
+        expect(numericKeyed.get("4").valuesIncludingErrorValues).toEqual([
+            5, 6, 7,
+        ])
+        // entity 1 matches by year+entity, entity 2 by entity only
+        expect(numericKeyed.get("5").valuesIncludingErrorValues).toEqual([
+            100, 100, 200,
+        ])
+        expectEquivalentJoins(numericKeyed, joinDaysAndYears(HUGE_ID_OFFSET))
     })
 })

--- a/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.test.ts
+++ b/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.test.ts
@@ -1010,12 +1010,6 @@ Papua New Guinea,PNG,1983,5.5,1983,`
 })
 
 describe(fullJoinTables, () => {
-    // fullJoinTables uses fast numeric composite keys when all times and entity
-    // ids fit into 26 bits, and generic string keys otherwise. Both paths have
-    // to produce equivalent joins - we verify this by joining the same data
-    // twice, with entity ids shifted beyond 2^26 to force the string path.
-    const HUGE_ID_OFFSET = 2 ** 26
-
     const makeTable = (
         variableId: number,
         rows: [entityId: number, time: number, value: number][],
@@ -1036,9 +1030,7 @@ describe(fullJoinTables, () => {
                     entities: {
                         values: entityIds.map((id) => ({
                             id,
-                            // identical names for both id ranges, so the
-                            // joined tables are comparable
-                            name: `Entity ${id % HUGE_ID_OFFSET}`,
+                            name: `Entity ${id}`,
                         })),
                     },
                 },
@@ -1046,99 +1038,102 @@ describe(fullJoinTables, () => {
         })
     }
 
-    const expectEquivalentJoins = (
-        numericKeyed: OwidTable,
-        stringKeyed: OwidTable
-    ): void => {
-        expect(stringKeyed.columnSlugs).toEqual(numericKeyed.columnSlugs)
-        for (const slug of numericKeyed.columnSlugs) {
-            const numericValues =
-                numericKeyed.get(slug).valuesIncludingErrorValues
-            const stringValues =
-                stringKeyed.get(slug).valuesIncludingErrorValues
-            if (slug === OwidTableSlugs.EntityId)
-                expect(stringValues).toEqual(
-                    numericValues.map((id) => (id as number) + HUGE_ID_OFFSET)
-                )
-            else expect(stringValues).toEqual(numericValues)
-        }
-    }
+    it("joins by year+entity", () => {
+        const joined = fullJoinTables(
+            [
+                makeTable(2, [
+                    [1, 2000, 1],
+                    [1, 2001, 2],
+                    [2, 2001, 3],
+                ]),
+                // partial overlap, so the join has misses too
+                makeTable(3, [
+                    [1, 2001, 10],
+                    [2, 2003, 11],
+                ]),
+            ],
+            [OwidTableSlugs.Year, OwidTableSlugs.EntityId]
+        )
 
-    it("joins by year+entity identically with numeric and string keys", () => {
-        const joinByYear = (offset: number): OwidTable =>
-            fullJoinTables(
-                [
-                    makeTable(2, [
-                        [offset + 1, 2000, 1],
-                        [offset + 1, 2001, 2],
-                        [offset + 2, 2001, 3],
-                    ]),
-                    // partial overlap, so the join has misses too
-                    makeTable(3, [
-                        [offset + 1, 2001, 10],
-                        [offset + 2, 2003, 11],
-                    ]),
-                ],
-                [OwidTableSlugs.Year, OwidTableSlugs.EntityId]
-            )
-
-        const numericKeyed = joinByYear(0)
-        expect(numericKeyed.get("2").valuesIncludingErrorValues).toEqual([
+        expect(joined.get("2").valuesIncludingErrorValues).toEqual([
             1,
             2,
             3,
             ErrorValueTypes.NoMatchingValueAfterJoin,
         ])
-        expect(numericKeyed.get("3").valuesIncludingErrorValues).toEqual([
+        expect(joined.get("3").valuesIncludingErrorValues).toEqual([
             ErrorValueTypes.NoMatchingValueAfterJoin,
             10,
             ErrorValueTypes.NoMatchingValueAfterJoin,
             11,
         ])
-        expectEquivalentJoins(numericKeyed, joinByYear(HUGE_ID_OFFSET))
     })
 
-    it("joins days and years via fallbacks identically with numeric and string keys", () => {
-        const joinDaysAndYears = (offset: number): OwidTable => {
-            const dayTable = makeTable(
-                4,
-                [
-                    [offset + 1, 18992, 5],
-                    [offset + 1, 18993, 6],
-                    [offset + 2, 18992, 7],
-                ],
-                TimeInterval.Day
-            ).appendColumns([
-                {
-                    slug: OwidTableSlugs.Year,
-                    name: OwidTableSlugs.Year,
-                    type: ColumnTypeNames.Year,
-                    values: [2022, 2022, 2022],
-                },
-            ])
-            const yearTable = makeTable(5, [
-                [offset + 1, 2022, 100],
-                // only matched via the entity-only fallback
-                [offset + 2, 2015, 200],
-            ])
-            return fullJoinTables(
-                [dayTable, yearTable],
-                [OwidTableSlugs.Day, OwidTableSlugs.EntityId],
-                [
-                    [OwidTableSlugs.Year, OwidTableSlugs.EntityId],
-                    [OwidTableSlugs.EntityId],
-                ]
-            )
-        }
-
-        const numericKeyed = joinDaysAndYears(0)
-        expect(numericKeyed.get("4").valuesIncludingErrorValues).toEqual([
-            5, 6, 7,
+    it("joins days and years via fallbacks", () => {
+        const dayTable = makeTable(
+            4,
+            [
+                [1, 18992, 5],
+                [1, 18993, 6],
+                [2, 18992, 7],
+            ],
+            TimeInterval.Day
+        ).appendColumns([
+            {
+                slug: OwidTableSlugs.Year,
+                name: OwidTableSlugs.Year,
+                type: ColumnTypeNames.Year,
+                values: [2022, 2022, 2022],
+            },
         ])
+        const yearTable = makeTable(5, [
+            [1, 2022, 100],
+            // only matched via the entity-only fallback
+            [2, 2015, 200],
+        ])
+        const joined = fullJoinTables(
+            [dayTable, yearTable],
+            [OwidTableSlugs.Day, OwidTableSlugs.EntityId],
+            [
+                [OwidTableSlugs.Year, OwidTableSlugs.EntityId],
+                [OwidTableSlugs.EntityId],
+            ]
+        )
+
+        expect(joined.get("4").valuesIncludingErrorValues).toEqual([5, 6, 7])
         // entity 1 matches by year+entity, entity 2 by entity only
-        expect(numericKeyed.get("5").valuesIncludingErrorValues).toEqual([
+        expect(joined.get("5").valuesIncludingErrorValues).toEqual([
             100, 100, 200,
         ])
-        expectEquivalentJoins(numericKeyed, joinDaysAndYears(HUGE_ID_OFFSET))
+    })
+
+    it("throws when an entity id is too large for the composite key encoding", () => {
+        // entity ids have to be below 2^26 for the numeric composite join keys
+        const hugeId = 2 ** 26
+        const tables = [
+            makeTable(2, [[hugeId, 2000, 1]]),
+            makeTable(3, [[hugeId, 2001, 2]]),
+        ]
+        expect(() =>
+            fullJoinTables(tables, [
+                OwidTableSlugs.Year,
+                OwidTableSlugs.EntityId,
+            ])
+        ).toThrow("does not fit the composite key encoding")
+    })
+
+    it("throws when a time value is too large for the composite key encoding", () => {
+        // times have to be within ±2^26 for the numeric composite join keys
+        const hugeYear = 2 ** 26
+        const tables = [
+            makeTable(2, [[1, hugeYear, 1]]),
+            makeTable(3, [[1, 2001, 2]]),
+        ]
+        expect(() =>
+            fullJoinTables(tables, [
+                OwidTableSlugs.Year,
+                OwidTableSlugs.EntityId,
+            ])
+        ).toThrow("does not fit the composite key encoding")
     })
 })

--- a/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.test.ts
+++ b/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.test.ts
@@ -17,8 +17,10 @@ import {
 import {
     buildVariableTable,
     fullJoinTables,
+    JoinTable,
     legacyToOwidTableAndDimensions,
     legacyToOwidTableAndDimensionsWithMandatorySlug,
+    owidTableToJoinTable,
 } from "./LegacyToOwidTable"
 import {
     MultipleOwidVariableDataDimensionsMap,
@@ -1010,7 +1012,7 @@ Papua New Guinea,PNG,1983,5.5,1983,`
 })
 
 describe(fullJoinTables, () => {
-    const makeTable = (
+    const makeOwidTable = (
         variableId: number,
         rows: [entityId: number, time: number, value: number][],
         timeInterval?: TimeInterval
@@ -1037,6 +1039,8 @@ describe(fullJoinTables, () => {
             },
         })
     }
+    const makeTable = (...args: Parameters<typeof makeOwidTable>): JoinTable =>
+        owidTableToJoinTable(makeOwidTable(...args))
 
     it("joins by year+entity", () => {
         const joined = fullJoinTables(
@@ -1055,13 +1059,13 @@ describe(fullJoinTables, () => {
             [OwidTableSlugs.Year, OwidTableSlugs.EntityId]
         )
 
-        expect(joined.get("2").valuesIncludingErrorValues).toEqual([
+        expect(joined.columnStore["2"]).toEqual([
             1,
             2,
             3,
             ErrorValueTypes.NoMatchingValueAfterJoin,
         ])
-        expect(joined.get("3").valuesIncludingErrorValues).toEqual([
+        expect(joined.columnStore["3"]).toEqual([
             ErrorValueTypes.NoMatchingValueAfterJoin,
             10,
             ErrorValueTypes.NoMatchingValueAfterJoin,
@@ -1070,22 +1074,24 @@ describe(fullJoinTables, () => {
     })
 
     it("joins days and years via fallbacks", () => {
-        const dayTable = makeTable(
-            4,
-            [
-                [1, 18992, 5],
-                [1, 18993, 6],
-                [2, 18992, 7],
-            ],
-            TimeInterval.Day
-        ).appendColumns([
-            {
-                slug: OwidTableSlugs.Year,
-                name: OwidTableSlugs.Year,
-                type: ColumnTypeNames.Year,
-                values: [2022, 2022, 2022],
-            },
-        ])
+        const dayTable = owidTableToJoinTable(
+            makeOwidTable(
+                4,
+                [
+                    [1, 18992, 5],
+                    [1, 18993, 6],
+                    [2, 18992, 7],
+                ],
+                TimeInterval.Day
+            ).appendColumns([
+                {
+                    slug: OwidTableSlugs.Year,
+                    name: OwidTableSlugs.Year,
+                    type: ColumnTypeNames.Year,
+                    values: [2022, 2022, 2022],
+                },
+            ])
+        )
         const yearTable = makeTable(5, [
             [1, 2022, 100],
             // only matched via the entity-only fallback
@@ -1100,11 +1106,9 @@ describe(fullJoinTables, () => {
             ]
         )
 
-        expect(joined.get("4").valuesIncludingErrorValues).toEqual([5, 6, 7])
+        expect(joined.columnStore["4"]).toEqual([5, 6, 7])
         // entity 1 matches by year+entity, entity 2 by entity only
-        expect(joined.get("5").valuesIncludingErrorValues).toEqual([
-            100, 100, 200,
-        ])
+        expect(joined.columnStore["5"]).toEqual([100, 100, 200])
     })
 
     it("throws when an entity id is too large for the composite key encoding", () => {

--- a/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.ts
+++ b/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.ts
@@ -381,6 +381,143 @@ export const legacyToOwidTableAndDimensions = (
     return joinedVariablesTable
 }
 
+type RowIndexKey = number | string
+// Almost every index key matches exactly one row, so we store a bare row
+// number for that case and only allocate an array when a key actually has
+// several matching rows (this saves hundreds of thousands of tiny array
+// allocations when joining large tables)
+type RowIndexHits = number | number[]
+type RowIndex = Map<RowIndexKey, RowIndexHits>
+
+const firstHit = (hits: RowIndexHits): number =>
+    typeof hits === "number" ? hits : hits[0]
+const lastHit = (hits: RowIndexHits): number =>
+    typeof hits === "number" ? hits : hits[hits.length - 1]
+
+const addHitToRowIndex = (
+    index: RowIndex,
+    key: RowIndexKey,
+    row: number
+): void => {
+    const existing = index.get(key)
+    if (existing === undefined) index.set(key, row)
+    else if (typeof existing === "number") index.set(key, [existing, row])
+    else existing.push(row)
+}
+
+// Generic string keys ("2020 123") mean a number-to-string conversion, a
+// concatenation and string hashing for every row of every table - by far the
+// most expensive part of the join. Our index columns (year/day and entityId)
+// are always integers, so we can instead encode a [time, entityId] tuple as
+// the single number time * 2^26 + entityId, which is exact as long as
+// |time| < 2^26 (years and days since epoch are far below 67 million) and
+// 0 <= entityId < 2^26 (database ids). If any value doesn't fit we
+// transparently fall back to the generic string keys.
+// Note that this must be multiplication, not a bit shift: the composite key
+// uses up to 52 bits, but JS bitwise operators truncate to 32-bit integers.
+// Multiplication and addition are exact up to 2^53.
+const NUMERIC_KEY_BASE = 2 ** 26
+
+const tryBuildNumericRowIndexes = (
+    tables: OwidTable[],
+    columnSlugs: string[],
+    shouldIndexTable: boolean[]
+): RowIndex[] | undefined => {
+    if (columnSlugs.length !== 1 && columnSlugs.length !== 2) return undefined
+    const indexes: RowIndex[] = []
+    for (let tableIndex = 0; tableIndex < tables.length; tableIndex++) {
+        if (!shouldIndexTable[tableIndex]) {
+            indexes.push(new Map())
+            continue
+        }
+        const columnStore = tables[tableIndex].columnStore
+        const col0 = columnStore[columnSlugs[0]]
+        const col1 =
+            columnSlugs.length === 2 ? columnStore[columnSlugs[1]] : undefined
+        if (!col0 || (columnSlugs.length === 2 && !col1)) return undefined
+        const numRows = tables[tableIndex].numRows
+        const index: RowIndex = new Map()
+        for (let row = 0; row < numRows; row++) {
+            const v0 = col0[row]
+            if (typeof v0 !== "number" || !Number.isInteger(v0))
+                return undefined
+            let key = v0
+            if (col1) {
+                const v1 = col1[row]
+                if (
+                    typeof v1 !== "number" ||
+                    !Number.isInteger(v1) ||
+                    v1 < 0 ||
+                    v1 >= NUMERIC_KEY_BASE ||
+                    Math.abs(v0) >= NUMERIC_KEY_BASE
+                )
+                    return undefined
+                key = v0 * NUMERIC_KEY_BASE + v1
+            }
+            addHitToRowIndex(index, key, row)
+        }
+        indexes.push(index)
+    }
+    return indexes
+}
+
+// Same as CoreTable.rowIndex() but with the compact RowIndexHits encoding
+const buildStringRowIndex = (
+    table: OwidTable,
+    columnSlugs: string[]
+): RowIndex => {
+    const keyFn = makeKeyFn(table.columnStore, columnSlugs)
+    const index: RowIndex = new Map()
+    const numRows = table.numRows
+    for (let row = 0; row < numRows; row++)
+        addHitToRowIndex(index, keyFn(row), row)
+    return index
+}
+
+/**
+ * Builds one row index per table over the given columns, plus a key function
+ * that computes the matching lookup key from a row of the first table. Uses
+ * fast numeric composite keys when all values fit (see above) and the generic
+ * string keys of CoreTable.rowIndex() otherwise. The two key encodings are
+ * incompatible, so an index and its key function always have to come from the
+ * same call.
+ */
+const buildRowIndexesPerTable = (
+    tables: OwidTable[],
+    columnSlugs: string[],
+    shouldIndexTable?: boolean[]
+): {
+    indexPerTable: RowIndex[]
+    firstTableKeyFn: (rowIndex: number) => RowIndexKey
+} => {
+    const shouldIndex = shouldIndexTable ?? tables.map(() => true)
+    const numericIndexes = tryBuildNumericRowIndexes(
+        tables,
+        columnSlugs,
+        shouldIndex
+    )
+    if (numericIndexes) {
+        const columnStore = tables[0].columnStore
+        const col0 = columnStore[columnSlugs[0]]
+        const col1 =
+            columnSlugs.length === 2 ? columnStore[columnSlugs[1]] : undefined
+        return {
+            indexPerTable: numericIndexes,
+            firstTableKeyFn: col1
+                ? (rowIndex): number =>
+                      (col0[rowIndex] as number) * NUMERIC_KEY_BASE +
+                      (col1[rowIndex] as number)
+                : (rowIndex): number => col0[rowIndex] as number,
+        }
+    }
+    return {
+        indexPerTable: tables.map((table, i) =>
+            shouldIndex[i] ? buildStringRowIndex(table, columnSlugs) : new Map()
+        ),
+        firstTableKeyFn: makeKeyFn(tables[0].columnStore, columnSlugs),
+    }
+}
+
 // Exported for benchmarking (see LegacyToOwidTable.bench.ts), not meant to be
 // used outside of this module.
 export const fullJoinTables = (
@@ -391,8 +528,8 @@ export const fullJoinTables = (
     // This function merges a number of OwidTables together using a given list of columns
     // to be used as the merge key. The merge key columns are used to construct a full set
     // of index values from the various tables - all tables are enumerated, we create
-    // a merged string value from the index column values for each row and then we create
-    // a set from all these string values.
+    // a merged key value from the index column values for each row and then we create
+    // a set from all these key values.
     // Note that not every table has to have values for all columns - not even all the index
     // columns have to exist on all tables (the index columns have to exist on the first table though)!
     // The reason for this and how this can possibly work
@@ -411,32 +548,31 @@ export const fullJoinTables = (
     if (tables.length === 0) return new OwidTable()
     else if (tables.length === 1) return tables[0]
 
-    // Get all the index values per table and then figure out the full set of all stringified index values
-    const mainIndexPerTable: Map<string, number[]>[] = tables.map((table) =>
-        // When we get a mergeFallbackLookupColumn then it can happen that a table does not have all the
-        // columns of the main index. In this case, just return an empty map because that will lead all
-        // lookups by main index to fail and we'll try the fallback index
-        mergeFallbackLookupColumns &&
-        _.difference(indexColumnNames, table.columnSlugs).length > 0
-            ? new Map()
-            : table.rowIndex(indexColumnNames)
+    // Get all the index values per table and then figure out the full set of all index keys.
+    // When we get a mergeFallbackLookupColumn then it can happen that a table does not have
+    // all the columns of the main index. In this case, just use an empty map for that table
+    // because that will lead all lookups by main index to fail and we'll try the fallback index
+    const { indexPerTable: mainIndexPerTable } = buildRowIndexesPerTable(
+        tables,
+        indexColumnNames,
+        tables.map(
+            (table) =>
+                !mergeFallbackLookupColumns ||
+                _.difference(indexColumnNames, table.columnSlugs).length === 0
+        )
     )
 
-    // Construct all the fallback index lookup values for all tables. mergeFallbackLookupColumns is an
-    // array of array that is supposed to be treated as a sequence of tuples of column names
-    const fallbackIndexesPerTable = mergeFallbackLookupColumns?.map(
-        (fallbackColumns) =>
-            tables.map((table) => table.rowIndex(fallbackColumns))
-    )
-    // Key functions that turn a row of the first table into the lookup key for each
-    // fallback column tuple. When we look up values and don't find a match in the main
-    // index we use these as the fallback lookup keys. This is the case when we join year
-    // and day variables and then use day+entityId as the key but the year variables don't
+    // Construct all the fallback indexes for all tables. mergeFallbackLookupColumns is an
+    // array of arrays that is supposed to be treated as a sequence of tuples of column names.
+    // Each lookup comes with a key function that turns a row of the first table into the
+    // lookup key for its fallback column tuple. When we look up values and don't find a match
+    // in the main index we use these as the fallback lookup keys. This is the case when we join
+    // year and day variables and then use day+entityId as the key but the year variables don't
     // have those - so for the year variables we then check if there is a match using
     // year+entityId where the year to use comes from the first table that by convention
     // HAS TO contain a year column with the value to merge years on.
-    const fallbackKeyFnsForFirstTable = mergeFallbackLookupColumns?.map(
-        (columnSet) => makeKeyFn(tables[0].columnStore, columnSet)
+    const fallbackLookups = mergeFallbackLookupColumns?.map((columnSet) =>
+        buildRowIndexesPerTable(tables, columnSet)
     )
 
     // Figure out which column names are shared. Shared columns (the index columns but also in our
@@ -448,7 +584,7 @@ export const fullJoinTables = (
     const sharedColumnNames = intersection(
         ...tables.map((table) => table.columnSlugs)
     )
-    const allIndexValues = new Set<string>()
+    const allIndexValues = new Set<RowIndexKey>()
     for (const index of mainIndexPerTable)
         for (const key of index.keys()) allIndexValues.add(key)
     const numOutputRows = allIndexValues.size
@@ -488,48 +624,51 @@ export const fullJoinTables = (
 
     const numMultipleMatchesPerTable = new Array(tables.length).fill(0)
 
+    // Scratch array holding, for the current index value, each table's main index
+    // hits - filled once per output row so that we only pay for one lookup per table
+    const mainHitsPerTable: (RowIndexHits | undefined)[] = new Array(
+        tables.length
+    )
+
     // Now loop over all unique index values and for each assemble as full a row as we can manage by looking
     // up the values in the different source tables
     let outputRow = 0
     for (const index of allIndexValues.values()) {
-        // First we handle the shared columns. The first table might not have a value at
-        // the current index (e.g. a year that does not exist in the first table). We
-        // therefore have to keep looking in the other tables until we find a table that
-        // has the values. Because the index values were generated from the combined set
-        // of all index values we are guaranteed to find a value eventually before we
-        // exceed the length of the tables array
-        let sharedSourceTable = 0
-        let sharedHits = mainIndexPerTable[0].get(index)
-        while (sharedHits === undefined) {
-            sharedSourceTable++
-            sharedHits = mainIndexPerTable[sharedSourceTable].get(index)
+        // Look the current index value up in every table's main index. The first table
+        // that has a hit becomes the source for the shared columns. The first table might
+        // not have a value at the current index (e.g. a year that does not exist in the
+        // first table) but because the index values were generated from the combined set
+        // of all index values we are guaranteed to find one of the tables with a hit
+        let sharedSourceTable = -1
+        for (let i = 0; i < tables.length; i++) {
+            const hits = mainIndexPerTable[i].get(index)
+            mainHitsPerTable[i] = hits
+            if (sharedSourceTable === -1 && hits !== undefined)
+                sharedSourceTable = i
         }
+        const sharedRow = firstHit(mainHitsPerTable[sharedSourceTable]!)
         const sharedSourceValues = sharedSourceValuesPerTable[sharedSourceTable]
         for (let i = 0; i < sharedDefs.length; i++)
-            sharedDefs[i].values[outputRow] =
-                sharedSourceValues[i][sharedHits[0]]
+            sharedDefs[i].values[outputRow] = sharedSourceValues[i][sharedRow]
 
         // Figure out the fallback merge lookup keys from the first table (if the first
         // table has a row at the current index - otherwise there is nothing to derive
         // the fallback keys, e.g. the year, from)
-        const firstTableHits =
-            sharedSourceTable === 0
-                ? sharedHits
-                : mainIndexPerTable[0].get(index)
+        const firstTableHits = mainHitsPerTable[0]
         const fallbackKeys =
-            fallbackKeyFnsForFirstTable && firstTableHits
-                ? fallbackKeyFnsForFirstTable.map((keyFn) =>
-                      keyFn(firstTableHits[0])
+            fallbackLookups && firstTableHits !== undefined
+                ? fallbackLookups.map((lookup) =>
+                      lookup.firstTableKeyFn(firstHit(firstTableHits))
                   )
                 : undefined
         // Now add all the non-shared value columns. We loop over all tables and for each
         // resolve the source row for the current index value: first by looking up a match
-        // in the main index, mainIndexPerTable[i]. If we don't have a hit for this row in
-        // this table then we try the fallbackKeys in turn to see if we can merge based on
-        // these fallback indexes. If no option leads to a match we store
+        // in the main index. If we don't have a hit for this row in this table then we
+        // try the fallbackKeys in turn to see if we can merge based on these fallback
+        // indexes. If no option leads to a match we store
         // ErrorValueTypes.NoMatchingValueAfterJoin in the cells of this table's columns.
         for (let i = 0; i < tables.length; i++) {
-            const mainHits = mainIndexPerTable[i].get(index)
+            const mainHits = mainHitsPerTable[i]
             let sourceRow: number | undefined
             if (mainHits !== undefined) {
                 // This case should be rare but it can come up. The old algorithm ran into this often because it
@@ -539,18 +678,19 @@ export const fullJoinTables = (
                 // first we should usually be able to find a unique match. The error output (after the loop, so we
                 // log once per table instead of once per row) is here so that when something is weird in an edge
                 // case then this shows up as a debugging hint in the console.
-                if (mainHits.length > 1) numMultipleMatchesPerTable[i]++
-                sourceRow = mainHits[0]
-            } else if (fallbackKeys && fallbackIndexesPerTable) {
+                if (typeof mainHits !== "number")
+                    numMultipleMatchesPerTable[i]++
+                sourceRow = firstHit(mainHits)
+            } else if (fallbackKeys && fallbackLookups) {
                 // If the main index did not lead to a hit then we try the fallback indices in turn
                 for (
                     let fallback = 0;
                     fallback < fallbackKeys.length;
                     fallback++
                 ) {
-                    const fallbackHits = fallbackIndexesPerTable[fallback][
-                        i
-                    ].get(fallbackKeys[fallback])
+                    const fallbackHits = fallbackLookups[
+                        fallback
+                    ].indexPerTable[i].get(fallbackKeys[fallback])
                     if (fallbackHits !== undefined) {
                         // If any of the fallbacks led to a hit then we use this hit
                         // Note that we choose the last of the fallbackHits entries to look up the row in the columnstore here.
@@ -566,7 +706,7 @@ export const fullJoinTables = (
                         // this entity. This could in theory be pretty wrong as well but in practice it often means a very close match.
                         // The proper solution as mentioned above would be to never fall back to entity matches only and move
                         // the tolerance matching into this function as well instead.
-                        sourceRow = fallbackHits[fallbackHits.length - 1]
+                        sourceRow = lastHit(fallbackHits)
                         break
                     }
                 }

--- a/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.ts
+++ b/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.ts
@@ -18,7 +18,6 @@ import {
 import {
     OwidTable,
     ErrorValueTypes,
-    makeKeyFn,
     makeAnnotationsSlug,
 } from "@ourworldindata/core-table"
 import {
@@ -381,84 +380,79 @@ export const legacyToOwidTableAndDimensions = (
     return joinedVariablesTable
 }
 
-type JoinKey = number | string
-type JoinKeyFn = (rowIndex: number) => JoinKey
+type JoinKeyFn = (rowIndex: number) => number
 
-// Generic string keys ("2020 123") mean a number-to-string conversion, a
+// String join keys ("2020 123") would mean a number-to-string conversion, a
 // concatenation and string hashing for every row of every table - by far the
 // most expensive part of the join. Our index columns (year/day and entityId)
-// are always integers, so we can instead encode a [time, entityId] tuple as
-// the single number time * 2^26 + entityId, which is exact as long as
+// are always integers, so we instead encode a [time, entityId] tuple as the
+// single number time * 2^26 + entityId, which is exact as long as
 // |time| < 2^26 (years and days since epoch are far below 67 million) and
-// 0 <= entityId < 2^26 (database ids). If any value doesn't fit we
-// transparently fall back to the generic string keys.
+// 0 <= entityId < 2^26 (database ids). We validate this upfront and throw if
+// any value doesn't fit.
 // Note that this must be multiplication, not a bit shift: the composite key
 // uses up to 52 bits, but JS bitwise operators truncate to 32-bit integers.
 // Multiplication and addition are exact up to 2^53.
 const NUMERIC_KEY_BASE = 2 ** 26
 
-const canUseNumericKeys = (
-    tables: OwidTable[],
-    columnSlugs: string[],
-    tableNeedsKeys: boolean[]
-): boolean => {
-    if (columnSlugs.length !== 1 && columnSlugs.length !== 2) return false
-    for (let t = 0; t < tables.length; t++) {
-        if (!tableNeedsKeys[t]) continue
-        const columnStore = tables[t].columnStore
-        const col0 = columnStore[columnSlugs[0]]
-        const col1 =
-            columnSlugs.length === 2 ? columnStore[columnSlugs[1]] : undefined
-        if (!col0 || (columnSlugs.length === 2 && !col1)) return false
-        const numRows = tables[t].numRows
-        for (let row = 0; row < numRows; row++) {
-            const v0 = col0[row]
-            if (typeof v0 !== "number" || !Number.isInteger(v0)) return false
-            if (col1) {
-                const v1 = col1[row]
-                if (
-                    typeof v1 !== "number" ||
-                    !Number.isInteger(v1) ||
-                    v1 < 0 ||
-                    v1 >= NUMERIC_KEY_BASE ||
-                    Math.abs(v0) >= NUMERIC_KEY_BASE
-                )
-                    return false
-            }
-        }
-    }
-    return true
-}
-
 /**
- * Builds, for each table, a function that computes the join key for one of its
- * rows over the given columns. Uses the fast numeric composite keys when all
- * values fit (see above) and generic string keys otherwise. The two encodings
- * are incompatible, so key functions that are matched against each other
- * always have to come from the same call. Tables with `tableNeedsKeys` set to
- * false are skipped during validation and get a key function that must not be
- * called (they may lack the key columns entirely).
+ * Builds, for each table, a function that computes the numeric join key for
+ * one of its rows over the given columns: the column value itself for a single
+ * column, v0 * 2^26 + v1 for a pair (see above). Throws if any value doesn't
+ * fit the encoding. Tables with `tableNeedsKeys` set to false are skipped
+ * during validation and get a key function that must not be called (they may
+ * lack the key columns entirely).
  */
 const makeJoinKeyFns = (
     tables: OwidTable[],
     columnSlugs: string[],
     tableNeedsKeys: boolean[]
 ): JoinKeyFn[] => {
-    if (canUseNumericKeys(tables, columnSlugs, tableNeedsKeys))
-        return tables.map((table) => {
-            const columnStore = table.columnStore
-            const col0 = columnStore[columnSlugs[0]]
-            const col1 =
-                columnSlugs.length === 2
-                    ? columnStore[columnSlugs[1]]
-                    : undefined
-            return col1
-                ? (rowIndex): number =>
-                      (col0[rowIndex] as number) * NUMERIC_KEY_BASE +
-                      (col1[rowIndex] as number)
-                : (rowIndex): number => col0[rowIndex] as number
+    if (columnSlugs.length !== 1 && columnSlugs.length !== 2)
+        throw new Error(
+            `Cannot join on ${columnSlugs.length} columns, only 1 or 2 are supported`
+        )
+    for (let t = 0; t < tables.length; t++) {
+        if (!tableNeedsKeys[t]) continue
+        const columnStore = tables[t].columnStore
+        const numRows = tables[t].numRows
+        columnSlugs.forEach((slug, i) => {
+            const column = columnStore[slug]
+            if (!column)
+                throw new Error(
+                    `Join column '${slug}' is missing from a table (columns: ${tables[
+                        t
+                    ].columnSlugs.join(", ")})`
+                )
+            for (let row = 0; row < numRows; row++) {
+                const value = column[row]
+                if (typeof value !== "number" || !Number.isSafeInteger(value))
+                    throw new Error(
+                        `Join key value '${value}' in column '${slug}' is not an integer`
+                    )
+                if (
+                    columnSlugs.length === 2 &&
+                    (i === 0
+                        ? Math.abs(value) >= NUMERIC_KEY_BASE
+                        : value < 0 || value >= NUMERIC_KEY_BASE)
+                )
+                    throw new Error(
+                        `Join key value ${value} in column '${slug}' does not fit the composite key encoding`
+                    )
+            }
         })
-    return tables.map((table) => makeKeyFn(table.columnStore, columnSlugs))
+    }
+    return tables.map((table) => {
+        const columnStore = table.columnStore
+        const col0 = columnStore[columnSlugs[0]]
+        const col1 =
+            columnSlugs.length === 2 ? columnStore[columnSlugs[1]] : undefined
+        return col1
+            ? (rowIndex): number =>
+                  (col0[rowIndex] as number) * NUMERIC_KEY_BASE +
+                  (col1[rowIndex] as number)
+            : (rowIndex): number => col0[rowIndex] as number
+    })
 }
 
 // Exported for benchmarking (see LegacyToOwidTable.bench.ts), not meant to be
@@ -507,7 +501,7 @@ export const fullJoinTables = (
 
     // Pass 1: assign an output row to every distinct index key, in order of first
     // occurrence across the tables (this determines the row order of the joined table)
-    const outputRowByKey = new Map<JoinKey, number>()
+    const outputRowByKey = new Map<number, number>()
     for (let t = 0; t < tables.length; t++) {
         if (!tableHasMainIndexColumns[t]) continue
         const keyFn = mainKeyFns[t]
@@ -564,7 +558,7 @@ export const fullJoinTables = (
             firstTableKeyFn: keyFns[0],
             lastRowByKeyPerTable: tables.map((table, t) => {
                 const keyFn = keyFns[t]
-                const lastRowByKey = new Map<JoinKey, number>()
+                const lastRowByKey = new Map<number, number>()
                 const numRows = table.numRows
                 // Later rows overwrite earlier ones, so a lookup yields the LAST row with
                 // a given fallback key. In the usual case the fallback key should have

--- a/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.ts
+++ b/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.ts
@@ -4,6 +4,7 @@ import * as _ from "lodash-es"
 import {
     ColumnTypeNames,
     CoreColumnDef,
+    CoreColumnStore,
     StandardOwidColumnDefs,
     OwidTableSlugs,
     OwidColumnDef,
@@ -43,6 +44,47 @@ import { isContinentsVariableId } from "./GrapherConstants"
 import * as R from "remeda"
 import { getDimensionColumnSlug } from "../chart/ChartDimension.js"
 
+/**
+ * A lightweight table representation used while joining variables: just the
+ * column values and defs, without any of the OwidTable machinery. Building a
+ * real OwidTable for every variable would re-parse each non-skipParsing column
+ * (a per-cell String()/parseFloat round trip that allocates a new array per
+ * column); instead we construct the values with the right types directly and
+ * only build one OwidTable at the very end.
+ */
+export interface JoinTable {
+    columnStore: CoreColumnStore
+    defs: OwidColumnDef[]
+    numRows: number
+}
+
+export const owidTableToJoinTable = (table: OwidTable): JoinTable => ({
+    columnStore: table.columnStore,
+    defs: table.getColumns(table.columnSlugs).map((col) => col.def),
+    numRows: table.numRows,
+})
+
+export const joinTableToOwidTable = (joinTable: JoinTable): OwidTable =>
+    // Passing the values via the defs marks the columns as already typed, so
+    // the constructor doesn't re-parse them
+    new OwidTable(
+        [],
+        joinTable.defs.map((def) => ({
+            ...def,
+            values: joinTable.columnStore[def.slug],
+        }))
+    )
+
+/** Mirrors what StringColumn.parse() would do with a missing value */
+const toStringValueOrError = (
+    value: string | undefined | null
+): string | ErrorValue =>
+    value === undefined
+        ? ErrorValueTypes.UndefinedButShouldBeString
+        : value === null
+          ? ErrorValueTypes.NullButShouldBeString
+          : value
+
 export const legacyToOwidTableAndDimensionsWithMandatorySlug = (
     json: MultipleOwidVariableDataDimensionsMap,
     dimensions: OwidChartDimensionInterface[],
@@ -75,13 +117,13 @@ export const legacyToOwidTableAndDimensions = (
     const entityMeta = [...json.values()].flatMap(
         (value) => value.metadata.dimensions.entities.values
     )
-    const entityMetaById: OwidEntityKey = Object.fromEntries(
-        entityMeta.map((entity) => [entity.id.toString(), entity])
+    const entityMetaById = new Map(
+        entityMeta.map((entity) => [entity.id, entity])
     )
 
     // Base column defs, shared by all variable tables
 
-    const baseColumnDefs: Map<ColumnSlug, CoreColumnDef> = new Map()
+    const baseColumnDefs: Map<ColumnSlug, OwidColumnDef> = new Map()
     StandardOwidColumnDefs.forEach((def) => {
         baseColumnDefs.set(def.slug, def)
     })
@@ -90,9 +132,9 @@ export const legacyToOwidTableAndDimensions = (
     // multiple columns for a single variable.
     const dimensionColumns = _.uniqBy(dimensions, (dim) => dim.slug)
 
-    const variableTablesToJoinByYear: OwidTable[] = []
-    const variableTablesToJoinByDay: OwidTable[] = []
-    const variableTablesWithYearToJoinByEntityOnly: OwidTable[] = []
+    const variableTablesToJoinByYear: JoinTable[] = []
+    const variableTablesToJoinByDay: JoinTable[] = []
+    const variableTablesWithYearToJoinByEntityOnly: JoinTable[] = []
     for (const dimension of dimensionColumns) {
         const variable = json.get(dimension.variableId)
 
@@ -142,14 +184,17 @@ export const legacyToOwidTableAndDimensions = (
         )
         const entityIds = variable.data.entities ?? []
         const entityNames = entityIds.map(
-            // if entityMetaById[id] does not exist, then we don't have entity
-            // from variable metadata in MySQL. This can happen because we take
-            // data from S3 and metadata from MySQL. After we unify it, it should
-            // no longer be a problem
-            (id) => entityMetaById[id]?.name ?? id.toString()
+            // if entityMetaById.get(id) does not exist, then we don't have
+            // entity from variable metadata in MySQL. This can happen because
+            // we take data from S3 and metadata from MySQL. After we unify it,
+            // it should no longer be a problem
+            (id) => entityMetaById.get(id)?.name ?? id.toString()
         )
-        // see comment above about entityMetaById[id]
-        const entityCodes = entityIds.map((id) => entityMetaById[id]?.code)
+        // see comment above about entityMetaById.get(id). Codes can be missing
+        // and are stored as ErrorValues then, just like column parsing would
+        const entityCodes = entityIds.map((id) =>
+            toStringValueOrError(entityMetaById.get(id)?.code)
+        )
 
         // If there is a conversionFactor, apply it.
         let values = variable.data.values || []
@@ -168,7 +213,7 @@ export const legacyToOwidTableAndDimensions = (
                 valueColumnDef.type = ColumnTypeNames.Numeric
         }
 
-        const columnStore: { [key: string]: any[] } = {
+        const columnStore: CoreColumnStore = {
             [OwidTableSlugs.EntityId]: entityIds,
             [OwidTableSlugs.EntityCode]: entityCodes,
             [OwidTableSlugs.EntityName]: entityNames,
@@ -177,17 +222,21 @@ export const legacyToOwidTableAndDimensions = (
         }
 
         if (annotationColumnDef) {
+            // Missing annotations are stored as ErrorValues, just like column
+            // parsing would
             columnStore[annotationColumnDef.slug] = entityNames.map(
-                (entityName) => annotationMap!.get(entityName)
+                (entityName) =>
+                    toStringValueOrError(annotationMap!.get(entityName))
             )
             columnDefs.set(annotationColumnDef.slug, annotationColumnDef)
         }
         // Build the tables
 
-        let variableTable = new OwidTable(
+        const variableTable: JoinTable = {
             columnStore,
-            Array.from(columnDefs.values())
-        )
+            defs: Array.from(columnDefs.values()),
+            numRows: entityIds.length,
+        }
 
         // If there is a targetTime set on the dimension, we need to perform the join on the
         // entities columns only, excluding any time columns.
@@ -195,7 +244,9 @@ export const legacyToOwidTableAndDimensions = (
         // column which can be used to recover the time.
         const targetTime = dimension?.targetYear
         if (_.isNumber(targetTime)) {
-            variableTable = variableTable
+            // These transforms need a real OwidTable, so we build one just for
+            // this variable
+            const owidTable = joinTableToOwidTable(variableTable)
                 // interpolateColumnWithTolerance() won't handle injecting times beyond the current
                 // allTimes. So if targetYear is 2018, and we have data up to 2017, the
                 // interpolation won't add the 2018 rows (unless we apply the interpolation after
@@ -213,7 +264,9 @@ export const legacyToOwidTableAndDimensions = (
             // We keep variables that have a targetTime set in a special bucket and will join them
             // on entity only (disregarding the year since we already filtered all other years out for
             // those variables)
-            variableTablesWithYearToJoinByEntityOnly.push(variableTable)
+            variableTablesWithYearToJoinByEntityOnly.push(
+                owidTableToJoinTable(owidTable)
+            )
         } else if (isSubYearly(getTimeInterval(variable.metadata.display)))
             variableTablesToJoinByDay.push(variableTable)
         else variableTablesToJoinByYear.push(variableTable)
@@ -250,31 +303,36 @@ export const legacyToOwidTableAndDimensions = (
         OwidTableSlugs.EntityId,
     ])
 
-    let joinedVariablesTable: OwidTable
+    let joinedVariablesTable: JoinTable
     // If we have both day and year based variables we need to do some special logic as described above
     if (
         variableTablesToJoinByYear.length > 0 &&
         variableTablesToJoinByDay.length > 0
     ) {
         // Derive the year from the day column and add it to the joined days table
-        const daysColumn = variablesJoinedByDay.getColumns([
-            OwidTableSlugs.Day,
-        ])[0]
+        const daysValues = variablesJoinedByDay.columnStore[OwidTableSlugs.Day]
         const getYearFromISOStringMemoized = _.memoize((dayValue: number) =>
             getYearFromISOStringAndDayOffset(EPOCH_DATE, dayValue)
         )
-        const yearsForDaysValues = daysColumn.values.map((dayValue) =>
+        const yearsForDaysValues = daysValues.map((dayValue) =>
             getYearFromISOStringMemoized(dayValue as number)
         )
 
-        const newYearColumn = {
-            ...daysColumn,
-            slug: OwidTableSlugs.Year,
-            name: OwidTableSlugs.Year,
-            values: yearsForDaysValues,
-        } as OwidColumnDef
-        const variablesJoinedByDayWithYearFilled =
-            variablesJoinedByDay.appendColumns([newYearColumn])
+        const variablesJoinedByDayWithYearFilled: JoinTable = {
+            columnStore: {
+                ...variablesJoinedByDay.columnStore,
+                [OwidTableSlugs.Year]: yearsForDaysValues,
+            },
+            defs: [
+                ...variablesJoinedByDay.defs,
+                {
+                    slug: OwidTableSlugs.Year,
+                    name: OwidTableSlugs.Year,
+                    type: ColumnTypeNames.Year,
+                },
+            ],
+            numRows: variablesJoinedByDay.numRows,
+        }
 
         // Now join the already merged days table with all the years. It is important
         // to not join the years together into one table already before so that each
@@ -339,11 +397,26 @@ export const legacyToOwidTableAndDimensions = (
     // Inject a common "time" column that is used as the main time column for the table
     // e.g. for the timeline.
     for (const dayOrYearSlug of [OwidTableSlugs.Day, OwidTableSlugs.Year]) {
-        if (joinedVariablesTable.columnSlugs.includes(dayOrYearSlug)) {
-            joinedVariablesTable = joinedVariablesTable.duplicateColumn(
-                dayOrYearSlug,
-                { slug: OwidTableSlugs.Time, name: OwidTableSlugs.Time }
-            )
+        const sourceDef = joinedVariablesTable.defs.find(
+            (def) => def.slug === dayOrYearSlug
+        )
+        if (sourceDef) {
+            joinedVariablesTable = {
+                columnStore: {
+                    ...joinedVariablesTable.columnStore,
+                    [OwidTableSlugs.Time]:
+                        joinedVariablesTable.columnStore[dayOrYearSlug].slice(),
+                },
+                defs: [
+                    ...joinedVariablesTable.defs,
+                    {
+                        ...sourceDef,
+                        slug: OwidTableSlugs.Time,
+                        name: OwidTableSlugs.Time,
+                    },
+                ],
+                numRows: joinedVariablesTable.numRows,
+            }
             // Do not inject multiple columns, terminate after one is successful
             break
         }
@@ -363,21 +436,29 @@ export const legacyToOwidTableAndDimensions = (
                 : ErrorValueTypes.UndefinedButShouldBeString
         }
 
-        const values =
-            joinedVariablesTable.entityNameColumn.valuesIncludingErrorValues.map(
-                (entityName) => valueFn(entityName as EntityName)
-            )
+        const entityNames =
+            joinedVariablesTable.columnStore[OwidTableSlugs.EntityName] ?? []
+        const values = entityNames.map((entityName) =>
+            valueFn(entityName as EntityName)
+        )
 
-        joinedVariablesTable = joinedVariablesTable.appendColumns([
-            {
-                slug: entityColorColumnSlug,
-                name: entityColorColumnSlug,
-                type: ColumnTypeNames.Color,
-                values: values,
+        joinedVariablesTable = {
+            columnStore: {
+                ...joinedVariablesTable.columnStore,
+                [entityColorColumnSlug]: values,
             },
-        ])
+            defs: [
+                ...joinedVariablesTable.defs,
+                {
+                    slug: entityColorColumnSlug,
+                    name: entityColorColumnSlug,
+                    type: ColumnTypeNames.Color,
+                },
+            ],
+            numRows: joinedVariablesTable.numRows,
+        }
     }
-    return joinedVariablesTable
+    return joinTableToOwidTable(joinedVariablesTable)
 }
 
 type JoinKeyFn = (rowIndex: number) => number
@@ -404,7 +485,7 @@ const NUMERIC_KEY_BASE = 2 ** 26
  * lack the key columns entirely).
  */
 const makeJoinKeyFns = (
-    tables: OwidTable[],
+    tables: JoinTable[],
     columnSlugs: string[],
     tableNeedsKeys: boolean[]
 ): JoinKeyFn[] => {
@@ -422,7 +503,9 @@ const makeJoinKeyFns = (
                 throw new Error(
                     `Join column '${slug}' is missing from a table (columns: ${tables[
                         t
-                    ].columnSlugs.join(", ")})`
+                    ].defs
+                        .map((def) => def.slug)
+                        .join(", ")})`
                 )
             for (let row = 0; row < numRows; row++) {
                 const value = column[row]
@@ -455,14 +538,14 @@ const makeJoinKeyFns = (
     })
 }
 
-// Exported for benchmarking (see LegacyToOwidTable.bench.ts), not meant to be
-// used outside of this module.
+// Exported for benchmarking and testing (see LegacyToOwidTable.bench.ts), not
+// meant to be used outside of this module.
 export const fullJoinTables = (
-    tables: OwidTable[],
+    tables: JoinTable[],
     indexColumnNames: OwidTableSlugs[],
     mergeFallbackLookupColumns?: OwidTableSlugs[][]
-): OwidTable => {
-    // This function merges a number of OwidTables together using a given list of columns
+): JoinTable => {
+    // This function merges a number of tables together using a given list of columns
     // to be used as the merge key. The merge key columns are used to construct a full set
     // of index values from the various tables - all tables are enumerated, we create
     // a merged key value from the index column values for each row and then we create
@@ -482,16 +565,20 @@ export const fullJoinTables = (
     // matching the day from the population variable (year+entity lookup) but for variables that don't
     // have overlapping years (e.g. continents that only has 2015 as the single year) we want to fall back
     // to merging by entity alone as a last resort
-    if (tables.length === 0) return new OwidTable()
+    if (tables.length === 0) return { columnStore: {}, defs: [], numRows: 0 }
     else if (tables.length === 1) return tables[0]
+
+    const columnSlugsPerTable = tables.map((table) =>
+        table.defs.map((def) => def.slug)
+    )
 
     // When we get a mergeFallbackLookupColumn then it can happen that a table does not
     // have all the columns of the main index. Those tables get no main index keys at all,
     // so all main lookups miss for them and we go through the fallback indexes instead
-    const tableHasMainIndexColumns = tables.map(
-        (table) =>
+    const tableHasMainIndexColumns = columnSlugsPerTable.map(
+        (columnSlugs) =>
             !mergeFallbackLookupColumns ||
-            _.difference(indexColumnNames, table.columnSlugs).length === 0
+            _.difference(indexColumnNames, columnSlugs).length === 0
     )
     const mainKeyFns = makeJoinKeyFns(
         tables,
@@ -589,30 +676,30 @@ export const fullJoinTables = (
     // as we don't make sure that the values are equal for the same index values (we only assume that
     // this is true) - but this is how we have handled it in the past and it works with the setup we
     // have.
-    const sharedColumnNames = intersection(
-        ...tables.map((table) => table.columnSlugs)
-    )
+    const sharedColumnNames = intersection(...columnSlugsPerTable)
 
     // Now identify for each table which columns should be copied (i.e. all non-index columns).
-    const columnsToAddPerTable = tables.map((table) =>
-        _.difference(table.columnSlugs, sharedColumnNames)
+    const columnsToAddPerTable = columnSlugsPerTable.map((columnSlugs) =>
+        _.difference(columnSlugs, sharedColumnNames)
     )
     // Prepare the output column defs with preallocated value arrays (we know the number
     // of output rows already - one per unique index value). For each def we also keep a
     // reference to the column store array it is copied from so that we don't have to
     // re-resolve it for every cell.
     const makeOutputDefs = (
-        table: OwidTable,
+        table: JoinTable,
         columnNames: string[]
-    ): { def: OwidColumnDef; values: any[]; sourceValues: any[] }[] =>
-        table.getColumns(columnNames).map((col) => {
+    ): { def: OwidColumnDef; values: any[]; sourceValues: any[] }[] => {
+        const defsBySlug = new Map(table.defs.map((def) => [def.slug, def]))
+        return columnNames.map((slug) => {
             const values = new Array(numOutputRows)
             return {
-                def: { ...col.def, values },
+                def: { ...defsBySlug.get(slug)! },
                 values,
-                sourceValues: table.columnStore[col.slug],
+                sourceValues: table.columnStore[slug],
             }
         })
+    }
     // The shared columns end up only once in the output. We preferentially get their
     // values from the first table but because the first table is not guaranteed to
     // contain all index values we'll try the other tables in turn if the given row
@@ -689,17 +776,21 @@ export const fullJoinTables = (
     numMultipleMatchesPerTable.forEach((count, i) => {
         if (count > 0)
             console.error(
-                `Found ${count} duplicate rows for the join index in table ${
-                    tables[i].tableSlug ??
-                    `#${i} (columns ${tables[i].columnSlugs.join(", ")})`
-                }`
+                `Found ${count} duplicate rows for the join index in table #${i} (columns ${columnSlugsPerTable[
+                    i
+                ].join(", ")})`
             )
     })
 
-    return new OwidTable(
-        [],
-        [...sharedDefs, ...ownDefsPerTable.flat()].map((entry) => entry.def)
-    )
+    const outputEntries = [...sharedDefs, ...ownDefsPerTable.flat()]
+    const columnStore: CoreColumnStore = {}
+    for (const entry of outputEntries)
+        columnStore[entry.def.slug] = entry.values
+    return {
+        columnStore,
+        defs: outputEntries.map((entry) => entry.def),
+        numRows: numOutputRows,
+    }
 }
 
 const variableTypeToColumnType = (type: OwidVariableType): ColumnTypeNames => {
@@ -879,9 +970,14 @@ const timeColumnValuesFromOwidVariable = (
 
     // Snap sub-yearly values (except plain days) to the start of their period,
     // so variables that pick different representative days for the same period
-    // still align
-    if (isSubYearly(interval) && interval !== TimeInterval.Day)
-        times = times.map((time) => snapToIntervalStart(time, interval))
+    // still align. Memoized because the snapping goes through dayjs and the
+    // same times come up once per entity
+    if (isSubYearly(interval) && interval !== TimeInterval.Day) {
+        const snapMemoized = _.memoize((time: number) =>
+            snapToIntervalStart(time, interval)
+        )
+        times = times.map(snapMemoized)
+    }
 
     return times
 }

--- a/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.ts
+++ b/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.ts
@@ -381,7 +381,9 @@ export const legacyToOwidTableAndDimensions = (
     return joinedVariablesTable
 }
 
-const fullJoinTables = (
+// Exported for benchmarking (see LegacyToOwidTable.bench.ts), not meant to be
+// used outside of this module.
+export const fullJoinTables = (
     tables: OwidTable[],
     indexColumnNames: OwidTableSlugs[],
     mergeFallbackLookupColumns?: OwidTableSlugs[][]

--- a/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.ts
+++ b/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.ts
@@ -381,29 +381,8 @@ export const legacyToOwidTableAndDimensions = (
     return joinedVariablesTable
 }
 
-type RowIndexKey = number | string
-// Almost every index key matches exactly one row, so we store a bare row
-// number for that case and only allocate an array when a key actually has
-// several matching rows (this saves hundreds of thousands of tiny array
-// allocations when joining large tables)
-type RowIndexHits = number | number[]
-type RowIndex = Map<RowIndexKey, RowIndexHits>
-
-const firstHit = (hits: RowIndexHits): number =>
-    typeof hits === "number" ? hits : hits[0]
-const lastHit = (hits: RowIndexHits): number =>
-    typeof hits === "number" ? hits : hits[hits.length - 1]
-
-const addHitToRowIndex = (
-    index: RowIndex,
-    key: RowIndexKey,
-    row: number
-): void => {
-    const existing = index.get(key)
-    if (existing === undefined) index.set(key, row)
-    else if (typeof existing === "number") index.set(key, [existing, row])
-    else existing.push(row)
-}
+type JoinKey = number | string
+type JoinKeyFn = (rowIndex: number) => JoinKey
 
 // Generic string keys ("2020 123") mean a number-to-string conversion, a
 // concatenation and string hashing for every row of every table - by far the
@@ -418,30 +397,23 @@ const addHitToRowIndex = (
 // Multiplication and addition are exact up to 2^53.
 const NUMERIC_KEY_BASE = 2 ** 26
 
-const tryBuildNumericRowIndexes = (
+const canUseNumericKeys = (
     tables: OwidTable[],
     columnSlugs: string[],
-    shouldIndexTable: boolean[]
-): RowIndex[] | undefined => {
-    if (columnSlugs.length !== 1 && columnSlugs.length !== 2) return undefined
-    const indexes: RowIndex[] = []
-    for (let tableIndex = 0; tableIndex < tables.length; tableIndex++) {
-        if (!shouldIndexTable[tableIndex]) {
-            indexes.push(new Map())
-            continue
-        }
-        const columnStore = tables[tableIndex].columnStore
+    tableNeedsKeys: boolean[]
+): boolean => {
+    if (columnSlugs.length !== 1 && columnSlugs.length !== 2) return false
+    for (let t = 0; t < tables.length; t++) {
+        if (!tableNeedsKeys[t]) continue
+        const columnStore = tables[t].columnStore
         const col0 = columnStore[columnSlugs[0]]
         const col1 =
             columnSlugs.length === 2 ? columnStore[columnSlugs[1]] : undefined
-        if (!col0 || (columnSlugs.length === 2 && !col1)) return undefined
-        const numRows = tables[tableIndex].numRows
-        const index: RowIndex = new Map()
+        if (!col0 || (columnSlugs.length === 2 && !col1)) return false
+        const numRows = tables[t].numRows
         for (let row = 0; row < numRows; row++) {
             const v0 = col0[row]
-            if (typeof v0 !== "number" || !Number.isInteger(v0))
-                return undefined
-            let key = v0
+            if (typeof v0 !== "number" || !Number.isInteger(v0)) return false
             if (col1) {
                 const v1 = col1[row]
                 if (
@@ -451,71 +423,42 @@ const tryBuildNumericRowIndexes = (
                     v1 >= NUMERIC_KEY_BASE ||
                     Math.abs(v0) >= NUMERIC_KEY_BASE
                 )
-                    return undefined
-                key = v0 * NUMERIC_KEY_BASE + v1
+                    return false
             }
-            addHitToRowIndex(index, key, row)
         }
-        indexes.push(index)
     }
-    return indexes
-}
-
-// Same as CoreTable.rowIndex() but with the compact RowIndexHits encoding
-const buildStringRowIndex = (
-    table: OwidTable,
-    columnSlugs: string[]
-): RowIndex => {
-    const keyFn = makeKeyFn(table.columnStore, columnSlugs)
-    const index: RowIndex = new Map()
-    const numRows = table.numRows
-    for (let row = 0; row < numRows; row++)
-        addHitToRowIndex(index, keyFn(row), row)
-    return index
+    return true
 }
 
 /**
- * Builds one row index per table over the given columns, plus a key function
- * that computes the matching lookup key from a row of the first table. Uses
- * fast numeric composite keys when all values fit (see above) and the generic
- * string keys of CoreTable.rowIndex() otherwise. The two key encodings are
- * incompatible, so an index and its key function always have to come from the
- * same call.
+ * Builds, for each table, a function that computes the join key for one of its
+ * rows over the given columns. Uses the fast numeric composite keys when all
+ * values fit (see above) and generic string keys otherwise. The two encodings
+ * are incompatible, so key functions that are matched against each other
+ * always have to come from the same call. Tables with `tableNeedsKeys` set to
+ * false are skipped during validation and get a key function that must not be
+ * called (they may lack the key columns entirely).
  */
-const buildRowIndexesPerTable = (
+const makeJoinKeyFns = (
     tables: OwidTable[],
     columnSlugs: string[],
-    shouldIndexTable?: boolean[]
-): {
-    indexPerTable: RowIndex[]
-    firstTableKeyFn: (rowIndex: number) => RowIndexKey
-} => {
-    const shouldIndex = shouldIndexTable ?? tables.map(() => true)
-    const numericIndexes = tryBuildNumericRowIndexes(
-        tables,
-        columnSlugs,
-        shouldIndex
-    )
-    if (numericIndexes) {
-        const columnStore = tables[0].columnStore
-        const col0 = columnStore[columnSlugs[0]]
-        const col1 =
-            columnSlugs.length === 2 ? columnStore[columnSlugs[1]] : undefined
-        return {
-            indexPerTable: numericIndexes,
-            firstTableKeyFn: col1
+    tableNeedsKeys: boolean[]
+): JoinKeyFn[] => {
+    if (canUseNumericKeys(tables, columnSlugs, tableNeedsKeys))
+        return tables.map((table) => {
+            const columnStore = table.columnStore
+            const col0 = columnStore[columnSlugs[0]]
+            const col1 =
+                columnSlugs.length === 2
+                    ? columnStore[columnSlugs[1]]
+                    : undefined
+            return col1
                 ? (rowIndex): number =>
                       (col0[rowIndex] as number) * NUMERIC_KEY_BASE +
                       (col1[rowIndex] as number)
-                : (rowIndex): number => col0[rowIndex] as number,
-        }
-    }
-    return {
-        indexPerTable: tables.map((table, i) =>
-            shouldIndex[i] ? buildStringRowIndex(table, columnSlugs) : new Map()
-        ),
-        firstTableKeyFn: makeKeyFn(tables[0].columnStore, columnSlugs),
-    }
+                : (rowIndex): number => col0[rowIndex] as number
+        })
+    return tables.map((table) => makeKeyFn(table.columnStore, columnSlugs))
 }
 
 // Exported for benchmarking (see LegacyToOwidTable.bench.ts), not meant to be
@@ -548,32 +491,103 @@ export const fullJoinTables = (
     if (tables.length === 0) return new OwidTable()
     else if (tables.length === 1) return tables[0]
 
-    // Get all the index values per table and then figure out the full set of all index keys.
-    // When we get a mergeFallbackLookupColumn then it can happen that a table does not have
-    // all the columns of the main index. In this case, just use an empty map for that table
-    // because that will lead all lookups by main index to fail and we'll try the fallback index
-    const { indexPerTable: mainIndexPerTable } = buildRowIndexesPerTable(
+    // When we get a mergeFallbackLookupColumn then it can happen that a table does not
+    // have all the columns of the main index. Those tables get no main index keys at all,
+    // so all main lookups miss for them and we go through the fallback indexes instead
+    const tableHasMainIndexColumns = tables.map(
+        (table) =>
+            !mergeFallbackLookupColumns ||
+            _.difference(indexColumnNames, table.columnSlugs).length === 0
+    )
+    const mainKeyFns = makeJoinKeyFns(
         tables,
         indexColumnNames,
-        tables.map(
-            (table) =>
-                !mergeFallbackLookupColumns ||
-                _.difference(indexColumnNames, table.columnSlugs).length === 0
-        )
+        tableHasMainIndexColumns
     )
+
+    // Pass 1: assign an output row to every distinct index key, in order of first
+    // occurrence across the tables (this determines the row order of the joined table)
+    const outputRowByKey = new Map<JoinKey, number>()
+    for (let t = 0; t < tables.length; t++) {
+        if (!tableHasMainIndexColumns[t]) continue
+        const keyFn = mainKeyFns[t]
+        const numRows = tables[t].numRows
+        for (let row = 0; row < numRows; row++) {
+            const key = keyFn(row)
+            if (!outputRowByKey.has(key))
+                outputRowByKey.set(key, outputRowByKey.size)
+        }
+    }
+    const numOutputRows = outputRowByKey.size
+
+    // Pass 2: for each table, resolve which of its rows (if any) belongs to each
+    // output row. After this the actual row assembly is just array reads - no more
+    // hashing. -1 means the table has no row for that output row. Note that these
+    // arrays hold row indices into the source tables (not the up-to-52-bit join
+    // keys), so int32 is plenty.
+    const mainSourceRowPerTable = tables.map(() =>
+        new Int32Array(numOutputRows).fill(-1)
+    )
+    const numMultipleMatchesPerTable = new Array(tables.length).fill(0)
+    for (let t = 0; t < tables.length; t++) {
+        if (!tableHasMainIndexColumns[t]) continue
+        const keyFn = mainKeyFns[t]
+        const sourceRow = mainSourceRowPerTable[t]
+        const numRows = tables[t].numRows
+        for (let row = 0; row < numRows; row++) {
+            const outputRow = outputRowByKey.get(keyFn(row))!
+            if (sourceRow[outputRow] === -1) sourceRow[outputRow] = row
+            // Several rows of one table mapping to the same index key should be rare
+            // but can come up. We keep the first row and log (once per table, after
+            // the join) as a debugging hint in the console for weird edge cases.
+            else numMultipleMatchesPerTable[t]++
+        }
+    }
 
     // Construct all the fallback indexes for all tables. mergeFallbackLookupColumns is an
     // array of arrays that is supposed to be treated as a sequence of tuples of column names.
-    // Each lookup comes with a key function that turns a row of the first table into the
-    // lookup key for its fallback column tuple. When we look up values and don't find a match
-    // in the main index we use these as the fallback lookup keys. This is the case when we join
-    // year and day variables and then use day+entityId as the key but the year variables don't
-    // have those - so for the year variables we then check if there is a match using
-    // year+entityId where the year to use comes from the first table that by convention
-    // HAS TO contain a year column with the value to merge years on.
-    const fallbackLookups = mergeFallbackLookupColumns?.map((columnSet) =>
-        buildRowIndexesPerTable(tables, columnSet)
-    )
+    // Each lookup maps a table's fallback keys to rows, and comes with a key function that
+    // turns a row of the first table into the lookup key for its fallback column tuple.
+    // When we look up values and don't find a match in the main index we use these as the
+    // fallback lookup keys. This is the case when we join year and day variables and then
+    // use day+entityId as the key but the year variables don't have those - so for the year
+    // variables we then check if there is a match using year+entityId where the year to use
+    // comes from the first table that by convention HAS TO contain a year column with the
+    // value to merge years on.
+    const fallbackLookups = mergeFallbackLookupColumns?.map((columnSet) => {
+        const keyFns = makeJoinKeyFns(
+            tables,
+            columnSet,
+            tables.map(() => true)
+        )
+        return {
+            firstTableKeyFn: keyFns[0],
+            lastRowByKeyPerTable: tables.map((table, t) => {
+                const keyFn = keyFns[t]
+                const lastRowByKey = new Map<JoinKey, number>()
+                const numRows = table.numRows
+                // Later rows overwrite earlier ones, so a lookup yields the LAST row with
+                // a given fallback key. In the usual case the fallback key should have
+                // enough information to match just one row (e.g. year+entity). But for
+                // cases when we join day and year variables we have as the ultimate
+                // fallback a match by entity only and an entity like Germany of course has
+                // many rows in e.g. the population variable. If this join here were
+                // properly time and tolerance aware then we could avoid matching on entity
+                // alone as the ultimate fallback but for now this function is not that
+                // clever. We could thus choose any of the matching rows. Pre July 2022 the
+                // code always chose the first one, which is often the first year that the
+                // variable has data for for the given entity. This is not great, e.g. when
+                // using a covid date based variable and joining it to population or
+                // similar. Using the last row could in theory be pretty wrong as well but
+                // in practice it often means a very close match. The proper solution as
+                // mentioned above would be to never fall back to entity matches only and
+                // move the tolerance matching into this function as well instead.
+                for (let row = 0; row < numRows; row++)
+                    lastRowByKey.set(keyFn(row), row)
+                return lastRowByKey
+            }),
+        }
+    })
 
     // Figure out which column names are shared. Shared columns (the index columns but also in our
     // data model stuff like entityCode and entityName that we usually have in addition to entityId)
@@ -584,10 +598,6 @@ export const fullJoinTables = (
     const sharedColumnNames = intersection(
         ...tables.map((table) => table.columnSlugs)
     )
-    const allIndexValues = new Set<RowIndexKey>()
-    for (const index of mainIndexPerTable)
-        for (const key of index.keys()) allIndexValues.add(key)
-    const numOutputRows = allIndexValues.size
 
     // Now identify for each table which columns should be copied (i.e. all non-index columns).
     const columnsToAddPerTable = tables.map((table) =>
@@ -622,96 +632,55 @@ export const fullJoinTables = (
         ([table, columnNames]) => makeOutputDefs(table, columnNames)
     )
 
-    const numMultipleMatchesPerTable = new Array(tables.length).fill(0)
-
-    // Scratch array holding, for the current index value, each table's main index
-    // hits - filled once per output row so that we only pay for one lookup per table
-    const mainHitsPerTable: (RowIndexHits | undefined)[] = new Array(
-        tables.length
-    )
-
-    // Now loop over all unique index values and for each assemble as full a row as we can manage by looking
-    // up the values in the different source tables
-    let outputRow = 0
-    for (const index of allIndexValues.values()) {
-        // Look the current index value up in every table's main index. The first table
-        // that has a hit becomes the source for the shared columns. The first table might
-        // not have a value at the current index (e.g. a year that does not exist in the
-        // first table) but because the index values were generated from the combined set
-        // of all index values we are guaranteed to find one of the tables with a hit
-        let sharedSourceTable = -1
-        for (let i = 0; i < tables.length; i++) {
-            const hits = mainIndexPerTable[i].get(index)
-            mainHitsPerTable[i] = hits
-            if (sharedSourceTable === -1 && hits !== undefined)
-                sharedSourceTable = i
-        }
-        const sharedRow = firstHit(mainHitsPerTable[sharedSourceTable]!)
+    // Now assemble the output rows. All main index information is in the
+    // mainSourceRowPerTable arrays already, so this loop is hashing-free except
+    // for fallback lookups.
+    for (let outputRow = 0; outputRow < numOutputRows; outputRow++) {
+        // The first table with a row for this output row becomes the source for the
+        // shared columns. The first table might not have one (e.g. a year that does not
+        // exist in the first table) but because the output rows were generated from the
+        // combined keys of all tables we are guaranteed to find a table with a row
+        let sharedSourceTable = 0
+        while (mainSourceRowPerTable[sharedSourceTable][outputRow] === -1)
+            sharedSourceTable++
+        const sharedRow = mainSourceRowPerTable[sharedSourceTable][outputRow]
         const sharedSourceValues = sharedSourceValuesPerTable[sharedSourceTable]
         for (let i = 0; i < sharedDefs.length; i++)
             sharedDefs[i].values[outputRow] = sharedSourceValues[i][sharedRow]
 
         // Figure out the fallback merge lookup keys from the first table (if the first
-        // table has a row at the current index - otherwise there is nothing to derive
+        // table has a row for this output row - otherwise there is nothing to derive
         // the fallback keys, e.g. the year, from)
-        const firstTableHits = mainHitsPerTable[0]
+        const firstTableRow = mainSourceRowPerTable[0][outputRow]
         const fallbackKeys =
-            fallbackLookups && firstTableHits !== undefined
+            fallbackLookups && firstTableRow !== -1
                 ? fallbackLookups.map((lookup) =>
-                      lookup.firstTableKeyFn(firstHit(firstTableHits))
+                      lookup.firstTableKeyFn(firstTableRow)
                   )
                 : undefined
-        // Now add all the non-shared value columns. We loop over all tables and for each
-        // resolve the source row for the current index value: first by looking up a match
-        // in the main index. If we don't have a hit for this row in this table then we
-        // try the fallbackKeys in turn to see if we can merge based on these fallback
-        // indexes. If no option leads to a match we store
-        // ErrorValueTypes.NoMatchingValueAfterJoin in the cells of this table's columns.
+        // Now add all the non-shared value columns. We loop over all tables and for
+        // each resolve the source row for this output row: from the main index if it
+        // had a match, otherwise by trying the fallbackKeys in turn. If no option
+        // leads to a match we store ErrorValueTypes.NoMatchingValueAfterJoin in the
+        // cells of this table's columns.
         for (let i = 0; i < tables.length; i++) {
-            const mainHits = mainHitsPerTable[i]
-            let sourceRow: number | undefined
-            if (mainHits !== undefined) {
-                // This case should be rare but it can come up. The old algorithm ran into this often because it
-                // joined a lot more stuff on entity only and then when you look up by entity into a table that has
-                // several years you end up with multiple matches. The old algorithm used to just pick one value.
-                // We still do this ultimately but because we try to match even day and year variables by year+entity
-                // first we should usually be able to find a unique match. The error output (after the loop, so we
-                // log once per table instead of once per row) is here so that when something is weird in an edge
-                // case then this shows up as a debugging hint in the console.
-                if (typeof mainHits !== "number")
-                    numMultipleMatchesPerTable[i]++
-                sourceRow = firstHit(mainHits)
-            } else if (fallbackKeys && fallbackLookups) {
-                // If the main index did not lead to a hit then we try the fallback indices in turn
+            let sourceRow: number = mainSourceRowPerTable[i][outputRow]
+            if (sourceRow === -1 && fallbackKeys && fallbackLookups) {
                 for (
                     let fallback = 0;
                     fallback < fallbackKeys.length;
                     fallback++
                 ) {
-                    const fallbackHits = fallbackLookups[
+                    const fallbackRow = fallbackLookups[
                         fallback
-                    ].indexPerTable[i].get(fallbackKeys[fallback])
-                    if (fallbackHits !== undefined) {
-                        // If any of the fallbacks led to a hit then we use this hit
-                        // Note that we choose the last of the fallbackHits entries to look up the row in the columnstore here.
-                        // In the usual case the fallback index should still have enough information to match just one row (e.g.
-                        // year+entity). But for cases when we join day and year variables we have as the ultimate fallback a match
-                        // by entity only and this can then of course result in many hits when looking up an entity like Germany
-                        // in e.g. the population variable. If this join here were properly time and tolerance aware then we could
-                        // avoid matching on entity alone as the ultimate fallback but for now this function is not that clever.
-                        // For the cases when we do get multiple hits for an index we could thus choose any data point. Pre July 2022
-                        // the old code always chose the first datapoint, which is often the first year that the variable has data for
-                        // for the given entity. This is not great, e.g. when using a covid date based variable and joining it to
-                        // population or similar. What we do here now is to use the last row that this variable has data for for
-                        // this entity. This could in theory be pretty wrong as well but in practice it often means a very close match.
-                        // The proper solution as mentioned above would be to never fall back to entity matches only and move
-                        // the tolerance matching into this function as well instead.
-                        sourceRow = lastHit(fallbackHits)
+                    ].lastRowByKeyPerTable[i].get(fallbackKeys[fallback])
+                    if (fallbackRow !== undefined) {
+                        sourceRow = fallbackRow
                         break
                     }
                 }
             }
-            if (sourceRow !== undefined)
+            if (sourceRow !== -1)
                 for (const ownDef of ownDefsPerTable[i])
                     ownDef.values[outputRow] = ownDef.sourceValues[sourceRow]
             else
@@ -721,13 +690,12 @@ export const fullJoinTables = (
                     ownDef.values[outputRow] =
                         ErrorValueTypes.NoMatchingValueAfterJoin
         }
-        outputRow++
     }
 
     numMultipleMatchesPerTable.forEach((count, i) => {
         if (count > 0)
             console.error(
-                `Found more than one matching row for ${count} index values in table ${
+                `Found ${count} duplicate rows for the join index in table ${
                     tables[i].tableSlug ??
                     `#${i} (columns ${tables[i].columnSlugs.join(", ")})`
                 }`

--- a/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.ts
+++ b/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.ts
@@ -412,7 +412,7 @@ export const fullJoinTables = (
     else if (tables.length === 1) return tables[0]
 
     // Get all the index values per table and then figure out the full set of all stringified index values
-    const indexValuesPerTable: Map<string, number[]>[] = tables.map((table) =>
+    const mainIndexPerTable: Map<string, number[]>[] = tables.map((table) =>
         // When we get a mergeFallbackLookupColumn then it can happen that a table does not have all the
         // columns of the main index. In this case, just return an empty map because that will lead all
         // lookups by main index to fail and we'll try the fallback index
@@ -424,11 +424,20 @@ export const fullJoinTables = (
 
     // Construct all the fallback index lookup values for all tables. mergeFallbackLookupColumns is an
     // array of array that is supposed to be treated as a sequence of tuples of column names
-    const mergeFallbackLookupValuesPerTable = mergeFallbackLookupColumns
-        ? mergeFallbackLookupColumns.map((fallbackColumns) =>
-              tables.map((table) => table.rowIndex(fallbackColumns))
-          )
-        : undefined
+    const fallbackIndexesPerTable = mergeFallbackLookupColumns?.map(
+        (fallbackColumns) =>
+            tables.map((table) => table.rowIndex(fallbackColumns))
+    )
+    // Key functions that turn a row of the first table into the lookup key for each
+    // fallback column tuple. When we look up values and don't find a match in the main
+    // index we use these as the fallback lookup keys. This is the case when we join year
+    // and day variables and then use day+entityId as the key but the year variables don't
+    // have those - so for the year variables we then check if there is a match using
+    // year+entityId where the year to use comes from the first table that by convention
+    // HAS TO contain a year column with the value to merge years on.
+    const fallbackKeyFnsForFirstTable = mergeFallbackLookupColumns?.map(
+        (columnSet) => makeKeyFn(tables[0].columnStore, columnSet)
+    )
 
     // Figure out which column names are shared. Shared columns (the index columns but also in our
     // data model stuff like entityCode and entityName that we usually have in addition to entityId)
@@ -439,147 +448,155 @@ export const fullJoinTables = (
     const sharedColumnNames = intersection(
         ...tables.map((table) => table.columnSlugs)
     )
-    const allIndexValuesArray = indexValuesPerTable.flatMap((index) => [
-        ...index.keys(),
-    ])
-    const allIndexValues = new Set(allIndexValuesArray)
+    const allIndexValues = new Set<string>()
+    for (const index of mainIndexPerTable)
+        for (const key of index.keys()) allIndexValues.add(key)
+    const numOutputRows = allIndexValues.size
 
     // Now identify for each table which columns should be copied (i.e. all non-index columns).
     const columnsToAddPerTable = tables.map((table) =>
         _.difference(table.columnSlugs, sharedColumnNames)
     )
-    // Prepare a special entry for the Table + column names tuple that we will zip and
-    // map in the next step. This special entry is the first table and contains only the
-    // unique columns (index + other tables that are shared among all tables).
-    // We will preferentially get the unique values from the first table but because
-    // the first table is not guaranteed to contain all index values we'll later on
-    // try other tables for these shared columns if the given row index does
-    // not exist in the first table
-    const firstTableDuplicateForIndices: [
-        OwidTable | undefined,
-        string[] | undefined,
-    ] = [tables[0], sharedColumnNames]
-    const defsToAddPerTable = [firstTableDuplicateForIndices]
-        .concat(R.zip(tables, columnsToAddPerTable))
-        .map(
-            (tableAndColumns) =>
-                tableAndColumns[0]!
-                    .getColumns(tableAndColumns[1]!)
-                    .map((col) => {
-                        const def = { ...col.def }
-                        def.values = []
-                        return def
-                    }) as OwidColumnDef[]
-        )
+    // Prepare the output column defs with preallocated value arrays (we know the number
+    // of output rows already - one per unique index value). For each def we also keep a
+    // reference to the column store array it is copied from so that we don't have to
+    // re-resolve it for every cell.
+    const makeOutputDefs = (
+        table: OwidTable,
+        columnNames: string[]
+    ): { def: OwidColumnDef; values: any[]; sourceValues: any[] }[] =>
+        table.getColumns(columnNames).map((col) => {
+            const values = new Array(numOutputRows)
+            return {
+                def: { ...col.def, values },
+                values,
+                sourceValues: table.columnStore[col.slug],
+            }
+        })
+    // The shared columns end up only once in the output. We preferentially get their
+    // values from the first table but because the first table is not guaranteed to
+    // contain all index values we'll try the other tables in turn if the given row
+    // index does not exist in the first table. For this we need each table's column
+    // store array per shared column.
+    const sharedDefs = makeOutputDefs(tables[0], sharedColumnNames)
+    const sharedSourceValuesPerTable = tables.map((table) =>
+        sharedColumnNames.map((slug) => table.columnStore[slug])
+    )
+    const ownDefsPerTable = R.zip(tables, columnsToAddPerTable).map(
+        ([table, columnNames]) => makeOutputDefs(table, columnNames)
+    )
+
+    const numMultipleMatchesPerTable = new Array(tables.length).fill(0)
+
     // Now loop over all unique index values and for each assemble as full a row as we can manage by looking
     // up the values in the different source tables
+    let outputRow = 0
     for (const index of allIndexValues.values()) {
-        // First we handle the unique/index columns (defsToAddPerTable[0])
-        for (const def of defsToAddPerTable[0]) {
-            // The index columns are special - the first table might not have a value for each of the index columns
-            // at the current index (e.g. a year that does not exist in the first table). We therefore have to keep
-            // looking in the other tables until we find a table that has the values. Because the index values were
-            // generated from the combined set of all index values we are guaranteed to find a value eventually before
-            // we exceed the length of the tables array
-            let tableIndex = 0
-            let indexHits = indexValuesPerTable[tableIndex].get(index)
-            while (indexHits === undefined) {
-                tableIndex++
-                indexHits = indexValuesPerTable[tableIndex].get(index)
-            }
-            def.values?.push(
-                tables[tableIndex].columnStore[def.slug][indexHits[0]]
-            )
+        // First we handle the shared columns. The first table might not have a value at
+        // the current index (e.g. a year that does not exist in the first table). We
+        // therefore have to keep looking in the other tables until we find a table that
+        // has the values. Because the index values were generated from the combined set
+        // of all index values we are guaranteed to find a value eventually before we
+        // exceed the length of the tables array
+        let sharedSourceTable = 0
+        let sharedHits = mainIndexPerTable[0].get(index)
+        while (sharedHits === undefined) {
+            sharedSourceTable++
+            sharedHits = mainIndexPerTable[sharedSourceTable].get(index)
         }
-        // Now figure out the fallback merge lookup index value from the first table.
-        // This is the fallback index we use when looking up values and we don't find a value in the normal index.
-        // This is the case when we join year and day variables and then use day+entityid as the key but the year
-        // variables don't have those - so for the year variables we then check if there is a match using year+entityId
-        // where the year to use comes from the first table that by convention HAS TO contain a year column with the
-        // value to merge years on.
-        const indexHits = indexValuesPerTable[0].get(index)
-        const fallbackMergeIndices =
-            mergeFallbackLookupColumns && indexHits
-                ? mergeFallbackLookupColumns.map((columnSet) =>
-                      makeKeyFn(tables[0].columnStore, columnSet)(indexHits[0])
+        const sharedSourceValues = sharedSourceValuesPerTable[sharedSourceTable]
+        for (let i = 0; i < sharedDefs.length; i++)
+            sharedDefs[i].values[outputRow] =
+                sharedSourceValues[i][sharedHits[0]]
+
+        // Figure out the fallback merge lookup keys from the first table (if the first
+        // table has a row at the current index - otherwise there is nothing to derive
+        // the fallback keys, e.g. the year, from)
+        const firstTableHits =
+            sharedSourceTable === 0
+                ? sharedHits
+                : mainIndexPerTable[0].get(index)
+        const fallbackKeys =
+            fallbackKeyFnsForFirstTable && firstTableHits
+                ? fallbackKeyFnsForFirstTable.map((keyFn) =>
+                      keyFn(firstTableHits[0])
                   )
                 : undefined
-        // now add all the nonindex value columns. We now loop over all tables and for each non-shared column
-        // we look up the value for the current row. We find the value for the current row by first trying to
-        // look up a match based on the shared index values, indexValuesPerTable[i]. If we don't have a hit
-        // for this row in this table then we try the fallbackMergeIndices in turn to see if we can merge
-        // based on these fallback indexes. If no option leads to a match we store ErrorValueTypes.NoMatchingValueAfterJoin
-        // in the cell.
-
-        // note that defsToAddPerTable has one more element than tables (the one duplicate of the
-        // first table that we added in the beginning that we use as the primary source for the shared columns)
+        // Now add all the non-shared value columns. We loop over all tables and for each
+        // resolve the source row for the current index value: first by looking up a match
+        // in the main index, mainIndexPerTable[i]. If we don't have a hit for this row in
+        // this table then we try the fallbackKeys in turn to see if we can merge based on
+        // these fallback indexes. If no option leads to a match we store
+        // ErrorValueTypes.NoMatchingValueAfterJoin in the cells of this table's columns.
         for (let i = 0; i < tables.length; i++) {
-            let indexHits = indexValuesPerTable[i].get(index)
-
-            if (indexHits !== undefined && indexHits.length > 1)
+            const mainHits = mainIndexPerTable[i].get(index)
+            let sourceRow: number | undefined
+            if (mainHits !== undefined) {
                 // This case should be rare but it can come up. The old algorithm ran into this often because it
                 // joined a lot more stuff on entity only and then when you look up by entity into a table that has
                 // several years you end up with multiple matches. The old algorithm used to just pick one value.
                 // We still do this ultimately but because we try to match even day and year variables by year+entity
-                // first we should usually be able to find a unique match. The error output is here so that when
-                // something is weird in an edge case then this shows up as a debugging hint in the console.
-                console.error(
-                    `Found more than one matching row in table ${tables[i].tableSlug}`
-                )
-            for (const def of defsToAddPerTable[i + 1]) {
-                // If the main index led to a hit then we just copy the value into the new row from the source table
-                if (indexHits !== undefined)
-                    def.values?.push(
-                        tables[i].columnStore[def.slug][indexHits[0]]
-                    )
-                else {
-                    // If the main index did not lead to a hit then we try the fallback indices in turn
-                    indexHits = undefined
-                    for (
-                        let fallbackIndex = 0;
-                        fallbackMergeIndices &&
-                        mergeFallbackLookupValuesPerTable &&
-                        indexHits === undefined &&
-                        fallbackIndex < fallbackMergeIndices.length;
-                        fallbackIndex++
-                    ) {
-                        indexHits = mergeFallbackLookupValuesPerTable[
-                            fallbackIndex
-                        ][i].get(fallbackMergeIndices[fallbackIndex])
-                    }
-                    if (indexHits !== undefined)
+                // first we should usually be able to find a unique match. The error output (after the loop, so we
+                // log once per table instead of once per row) is here so that when something is weird in an edge
+                // case then this shows up as a debugging hint in the console.
+                if (mainHits.length > 1) numMultipleMatchesPerTable[i]++
+                sourceRow = mainHits[0]
+            } else if (fallbackKeys && fallbackIndexesPerTable) {
+                // If the main index did not lead to a hit then we try the fallback indices in turn
+                for (
+                    let fallback = 0;
+                    fallback < fallbackKeys.length;
+                    fallback++
+                ) {
+                    const fallbackHits = fallbackIndexesPerTable[fallback][
+                        i
+                    ].get(fallbackKeys[fallback])
+                    if (fallbackHits !== undefined) {
                         // If any of the fallbacks led to a hit then we use this hit
-                        // Note that we choose the last of the indexHits entries to look up the row in the columnstore here.
+                        // Note that we choose the last of the fallbackHits entries to look up the row in the columnstore here.
                         // In the usual case the fallback index should still have enough information to match just one row (e.g.
                         // year+entity). But for cases when we join day and year variables we have as the ultimate fallback a match
-                        // by entity only and this can then of course result in many indexHits when looking up an entity like Germany
+                        // by entity only and this can then of course result in many hits when looking up an entity like Germany
                         // in e.g. the population variable. If this join here were properly time and tolerance aware then we could
-                        // avoid matching on entity alone as the ultimate fallback but for  now this function is not that clever.
+                        // avoid matching on entity alone as the ultimate fallback but for now this function is not that clever.
                         // For the cases when we do get multiple hits for an index we could thus choose any data point. Pre July 2022
                         // the old code always chose the first datapoint, which is often the first year that the variable has data for
                         // for the given entity. This is not great, e.g. when using a covid date based variable and joining it to
-                        // population or similar. What we do here now is to use indexHits.length - 1 as the index, i.e. the last
-                        // row that this variable has data for for this entity. This could in theory be pretty wrong as well but in
-                        // practice it often means a very close match.
+                        // population or similar. What we do here now is to use the last row that this variable has data for for
+                        // this entity. This could in theory be pretty wrong as well but in practice it often means a very close match.
                         // The proper solution as mentioned above would be to never fall back to entity matches only and move
                         // the tolerance matching into this function as well instead.
-                        def.values?.push(
-                            tables[i].columnStore[def.slug][
-                                indexHits[indexHits.length - 1]
-                            ]
-                        )
-                    // If none of the fallback values worked either we write ErrorValueTypes.NoMatchingValueAfterJoin into the cell
-                    else
-                        def.values?.push(
-                            ErrorValueTypes.NoMatchingValueAfterJoin
-                        )
+                        sourceRow = fallbackHits[fallbackHits.length - 1]
+                        break
+                    }
                 }
             }
+            if (sourceRow !== undefined)
+                for (const ownDef of ownDefsPerTable[i])
+                    ownDef.values[outputRow] = ownDef.sourceValues[sourceRow]
+            else
+                // If neither the main index nor the fallbacks led to a hit we write
+                // ErrorValueTypes.NoMatchingValueAfterJoin into the cells
+                for (const ownDef of ownDefsPerTable[i])
+                    ownDef.values[outputRow] =
+                        ErrorValueTypes.NoMatchingValueAfterJoin
         }
+        outputRow++
     }
+
+    numMultipleMatchesPerTable.forEach((count, i) => {
+        if (count > 0)
+            console.error(
+                `Found more than one matching row for ${count} index values in table ${
+                    tables[i].tableSlug ??
+                    `#${i} (columns ${tables[i].columnSlugs.join(", ")})`
+                }`
+            )
+    })
+
     return new OwidTable(
         [],
-        defsToAddPerTable.flatMap((defs) => defs)
+        [...sharedDefs, ...ownDefsPerTable.flat()].map((entry) => entry.def)
     )
 }
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,5 +15,15 @@ export default defineConfig({
         ],
         pool: "threads",
         setupFiles: ["devTools/vitest-setup.ts"],
+        benchmark: {
+            // benchmarks have their own include/exclude, so the compiled .bench.js
+            // files in dist/ would get picked up without this
+            exclude: [
+                ...configDefaults.exclude,
+                "itsJustJavascript/**",
+                "**/dist/**",
+                "bespoke/**",
+            ],
+        },
     },
 })


### PR DESCRIPTION
> _Written by Anthropic Claude Fable 5 — @marcelgerber at the wheel._

`legacyToOwidTableAndDimensions()` — the function that merges all of a chart's variables into its input table — was both slow and hard to follow. This PR adds benchmarks and then reworks it in several rounds, making the whole thing **~2–7× faster** depending on the chart shape, somewhat simpler, and fixing a subtle bug along the way.

## Benchmarks

New `LegacyToOwidTable.bench.ts` (run with `yarn testBench`) with two suites:
- `fullJoinTables`: the multi-table join in isolation — plain year joins (small → 12 tables × 30k rows), sub-yearly variables (day/week/month), mixed day+year joins exercising the fallback cascade, and targetTime variables joined on entity only
- `legacyToOwidTableAndDimensions` end to end, from legacy variable JSON to the finished `OwidTable`

End to end:

| case | before | after |
| --- | --- | --- |
| 6 year variables × 200 entities × 60 years | 15.4 ms | 9.5 ms |
| 12 year variables × 250 × 120 | 81 ms | 52 ms |
| 2 day + 3 year variables | 47 ms | 38 ms |
| 3 monthly variables × 60 entities × 4 years | 12.6 ms | 1.7 ms |
| scatter: 2 year + 2 targetTime variables | 11.7 ms | 8.0 ms |

The join in isolation is ~2–3.5× faster than before (e.g. 12 tables × 30k rows: 101 ms → 34 ms).

## What changed

**The join** (`fullJoinTables`):
- **Numeric composite join keys**: instead of string keys (`"2020 123"` — number→string conversion, concatenation and string hashing per row), a `[time, entityId]` tuple is encoded as `time * 2^26 + entityId` (exact in float64 up to 2^53). Values that don't fit throw with a descriptive error — real ids/times are ~3 orders of magnitude below the limit.
- **Two-pass structure**: pass 1 assigns every distinct key an output row (preserving the previous row order); pass 2 records each table's source row per output row in an `Int32Array` (`-1` = no match). Row assembly is then pure array reads — each input row is hashed at most twice in total, instead of ~3× plus per-key hits-array allocations.
- **Fallback indexes** (day+year joins, targetTime) are plain `Map<key, lastRow>` — overwrite-on-insert gives the documented last-match-wins semantics for free.

**Around the join** (`legacyToOwidTableAndDimensions`):
- Variables are joined as lightweight `{columnStore, defs, numRows}` objects instead of constructing an `OwidTable` per variable. Root `OwidTable`s re-parse every non-`skipParsing` column — a per-cell `String()`/`parseFloat` round trip that allocates a new array per column. The one thing parsing did for our data (missing codes/annotations → `ErrorValue`s) is now done explicitly.
- Only one `OwidTable` is built at the very end, with values passed via the defs so nothing re-parses. The `time` and `entityColor` columns are plain array appends instead of `duplicateColumn`/`appendColumns` table transforms. (The targetTime path still builds a real `OwidTable` for its filter/interpolate transforms.)
- The dayjs-based `snapToIntervalStart` is memoized per distinct time — the same times come up once per entity, so this is the 7.5× on monthly variables.

**Bug fix**: on a multi-hit fallback (e.g. entity-only match into a multi-year table), the first copied column of a table used the *last* matching row while its remaining columns used the *first*, so one output row could mix values from different source rows. Source rows are now resolved once per (row, table).

**Debug output**: the per-row `console.error` on duplicate matches (thousands of logs per join on month/quarter data) is now a single per-table summary.

## Verification

- `make svgtest`: byte-identical SVGs across the full reference suite after every round
- Full unit suite passes, incl. new tests for the join, the encoding limits (throws on too-large entity ids / times), and the ErrorValue conversion
- typecheck, lint, format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
