### PR TITLE
🔨 Standardize Cloudflare Email error handling

### DIFF
--- a/functions/_common/emailNotifications.ts
+++ b/functions/_common/emailNotifications.ts
@@ -322,8 +322,8 @@ const JSON_HEADERS = {
     "Content-Type": "application/json",
 }
 
-/** Preflight handler, re-exported by every JSON endpoint. */
-export const onRequestOptions: PagesFunction = async () => {
+/** Preflight handler; every JSON endpoint exports it as `onRequestOptions`. */
+export const handleOptionsRequest: PagesFunction = async () => {
     return new Response(null, { headers: CORS_HEADERS, status: 200 })
 }
 

--- a/functions/_common/emailNotifications.ts
+++ b/functions/_common/emailNotifications.ts
@@ -1,9 +1,11 @@
+import * as Sentry from "@sentry/cloudflare"
 import {
     EMAIL_NOTIFICATIONS_CONTENT_TYPE_LABELS,
     EMAIL_NOTIFICATIONS_FREQUENCY_LABELS,
     EMAIL_NOTIFICATIONS_FROM_ADDRESS,
     EmailNotificationsPreferences,
 } from "@ourworldindata/types"
+import { JsonError } from "@ourworldindata/utils"
 import { Env } from "./env.js"
 
 interface PostmarkEmail {
@@ -284,6 +286,73 @@ export function makeHtmlResponse(html: string, status = 200): Response {
         headers: { "Content-Type": "text/html; charset=utf-8" },
         status,
     })
+}
+
+/**
+ * What every email-notifications endpoint answers with when something fails
+ * unexpectedly. The detail goes to Sentry: errors raised by D1, Mailchimp and
+ * Postmark quote query fragments, internal identifiers and account state.
+ */
+export const GENERIC_ERROR_MESSAGE =
+    "Something went wrong. Please try again later."
+
+/**
+ * Expected client-caused failures (validation, rate limiting) carry messages
+ * we authored ourselves, so they are safe to show the user — and reporting
+ * them to Sentry would let any abuse burst flood it with events.
+ */
+function isExpectedClientError(error: unknown): error is JsonError {
+    return error instanceof JsonError && error.status < 500
+}
+
+// --- Shared endpoint plumbing ---
+
+const CORS_HEADERS = {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+    // Content-Type must be explicitly allowed for requests to be sent with a
+    // Content-Type of "application/json", because "application/json" is not a
+    // CORS-safelisted value for it.
+    // - https://developer.mozilla.org/en-US/docs/Glossary/CORS-safelisted_request_header
+    "Access-Control-Allow-Headers": "Content-Type",
+}
+
+const JSON_HEADERS = {
+    ...CORS_HEADERS,
+    "Content-Type": "application/json",
+}
+
+/** Preflight handler, re-exported by every JSON endpoint. */
+export const onRequestOptions: PagesFunction = async () => {
+    return new Response(null, { headers: CORS_HEADERS, status: 200 })
+}
+
+export function makeJsonResponse(body: object, status: number): Response {
+    return new Response(JSON.stringify(body), {
+        headers: JSON_HEADERS,
+        status,
+    })
+}
+
+/** Catch-block handler for JSON endpoints: report to Sentry, answer generically. */
+export function handleJsonError(error: unknown): Response {
+    if (isExpectedClientError(error)) {
+        return makeJsonResponse({ error: error.message }, error.status)
+    }
+    Sentry.captureException(error)
+    return makeJsonResponse(
+        { error: GENERIC_ERROR_MESSAGE },
+        error instanceof JsonError ? error.status : 500
+    )
+}
+
+/** Catch-block handler for HTML endpoints: report to Sentry, answer generically. */
+export function handleHtmlError(error: unknown, message: string): Response {
+    if (!isExpectedClientError(error)) Sentry.captureException(error)
+    return makeHtmlResponse(
+        renderMessagePage({ title: "Something went wrong", message }),
+        500
+    )
 }
 
 /**

--- a/functions/api/email-notifications/brief-status.ts
+++ b/functions/api/email-notifications/brief-status.ts
@@ -1,23 +1,12 @@
 import * as Sentry from "@sentry/cloudflare"
-import { EmailNotificationsBriefStatusResponse } from "@ourworldindata/utils"
 import { Env } from "../../_common/env.js"
-import { lookupEmailToken } from "../../_common/emailNotifications.js"
+import {
+    lookupEmailToken,
+    makeJsonResponse,
+} from "../../_common/emailNotifications.js"
 import { getOwidBriefStatus } from "../../_common/mailchimp.js"
 
-const CORS_HEADERS = {
-    "Access-Control-Allow-Origin": "*",
-    "Access-Control-Allow-Methods": "GET, OPTIONS",
-    "Access-Control-Allow-Headers": "Content-Type",
-}
-
-const JSON_HEADERS = {
-    ...CORS_HEADERS,
-    "Content-Type": "application/json",
-}
-
-export const onRequestOptions: PagesFunction = async () => {
-    return new Response(null, { headers: CORS_HEADERS, status: 200 })
-}
+export { onRequestOptions } from "../../_common/emailNotifications.js"
 
 /**
  * Whether the magic-link token's user is subscribed to the OWID Brief in
@@ -30,11 +19,11 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
     try {
         const db = env.EMAIL_NOTIFICATIONS_DB
         const token = new URL(request.url).searchParams.get("token")
-        if (!token || !db) return jsonResponse({ error: "invalid" }, 404)
+        if (!token || !db) return makeJsonResponse({ error: "invalid" }, 404)
 
         const lookup = await lookupEmailToken(db, token)
         if (lookup.state !== "valid") {
-            return jsonResponse(
+            return makeJsonResponse(
                 { error: lookup.state },
                 lookup.state === "expired" ? 410 : 404
             )
@@ -44,25 +33,15 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
             .prepare(`SELECT email FROM users WHERE id = ?1`)
             .bind(lookup.row.user_id)
             .first<{ email: string }>()
-        if (!user) return jsonResponse({ error: "invalid" }, 404)
+        if (!user) return makeJsonResponse({ error: "invalid" }, 404)
 
         const subscribedToOwidBrief = await getOwidBriefStatus(env, user.email)
         if (subscribedToOwidBrief === null) {
-            return jsonResponse({ error: "unavailable" }, 503)
+            return makeJsonResponse({ error: "unavailable" }, 503)
         }
-        return jsonResponse({ subscribedToOwidBrief }, 200)
+        return makeJsonResponse({ subscribedToOwidBrief }, 200)
     } catch (error) {
         Sentry.captureException(error)
-        return jsonResponse({ error: "unavailable" }, 503)
+        return makeJsonResponse({ error: "unavailable" }, 503)
     }
-}
-
-function jsonResponse(
-    response: EmailNotificationsBriefStatusResponse,
-    status: number
-): Response {
-    return new Response(JSON.stringify(response), {
-        headers: JSON_HEADERS,
-        status,
-    })
 }

--- a/functions/api/email-notifications/brief-status.ts
+++ b/functions/api/email-notifications/brief-status.ts
@@ -1,12 +1,13 @@
 import * as Sentry from "@sentry/cloudflare"
 import { Env } from "../../_common/env.js"
 import {
+    handleOptionsRequest,
     lookupEmailToken,
     makeJsonResponse,
 } from "../../_common/emailNotifications.js"
 import { getOwidBriefStatus } from "../../_common/mailchimp.js"
 
-export { onRequestOptions } from "../../_common/emailNotifications.js"
+export const onRequestOptions = handleOptionsRequest
 
 /**
  * Whether the magic-link token's user is subscribed to the OWID Brief in

--- a/functions/api/email-notifications/preferences.ts
+++ b/functions/api/email-notifications/preferences.ts
@@ -3,32 +3,19 @@ import * as z from "zod/mini"
 import {
     EmailNotificationsPreferences,
     EmailNotificationsPreferencesResponse,
-    EmailNotificationsSubscribeResponse,
     EmailNotificationsUpdatePreferencesRequestTypeObject,
     JsonError,
-    stringifyUnknownError,
 } from "@ourworldindata/utils"
 import { Env } from "../../_common/env.js"
 import {
     EmailTokenLookup,
+    handleJsonError,
     lookupEmailToken,
+    makeJsonResponse,
 } from "../../_common/emailNotifications.js"
 import { upsertOwidBriefSubscription } from "../../_common/mailchimp.js"
 
-const CORS_HEADERS = {
-    "Access-Control-Allow-Origin": "*",
-    "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
-    "Access-Control-Allow-Headers": "Content-Type",
-}
-
-const JSON_HEADERS = {
-    ...CORS_HEADERS,
-    "Content-Type": "application/json",
-}
-
-export const onRequestOptions: PagesFunction = async () => {
-    return new Response(null, { headers: CORS_HEADERS, status: 200 })
-}
+export { onRequestOptions } from "../../_common/emailNotifications.js"
 
 /**
  * Data source of the magic-link preferences page: resolves a magic-link token
@@ -76,13 +63,9 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
                       } as EmailNotificationsPreferences)
                     : null,
         }
-        return new Response(JSON.stringify(response), {
-            headers: JSON_HEADERS,
-            status: 200,
-        })
+        return makeJsonResponse(response, 200)
     } catch (error) {
-        Sentry.captureException(error)
-        return errorResponse(error)
+        return handleJsonError(error)
     }
 }
 
@@ -180,36 +163,16 @@ export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
             }
         }
 
-        const response: EmailNotificationsSubscribeResponse = { ok: true }
-        return new Response(JSON.stringify(response), {
-            headers: JSON_HEADERS,
-            status: 200,
-        })
+        return makeJsonResponse({ ok: true }, 200)
     } catch (error) {
-        if (!(error instanceof JsonError) || error.status >= 500) {
-            Sentry.captureException(error)
-        }
-        return errorResponse(error)
+        return handleJsonError(error)
     }
 }
 
 function tokenErrorResponse(
     lookup: EmailTokenLookup | { state: "invalid" }
 ): Response {
-    const response: EmailNotificationsPreferencesResponse =
-        lookup.state === "expired" ? { error: "expired" } : { error: "invalid" }
-    return new Response(JSON.stringify(response), {
-        headers: JSON_HEADERS,
-        status: lookup.state === "expired" ? 410 : 404,
-    })
-}
-
-function errorResponse(error: unknown): Response {
-    const response: EmailNotificationsPreferencesResponse = {
-        error: stringifyUnknownError(error) ?? "Unknown error",
-    }
-    return new Response(JSON.stringify(response), {
-        headers: JSON_HEADERS,
-        status: error instanceof JsonError ? error.status : 500,
-    })
+    return lookup.state === "expired"
+        ? makeJsonResponse({ error: "expired" }, 410)
+        : makeJsonResponse({ error: "invalid" }, 404)
 }

--- a/functions/api/email-notifications/preferences.ts
+++ b/functions/api/email-notifications/preferences.ts
@@ -10,12 +10,13 @@ import { Env } from "../../_common/env.js"
 import {
     EmailTokenLookup,
     handleJsonError,
+    handleOptionsRequest,
     lookupEmailToken,
     makeJsonResponse,
 } from "../../_common/emailNotifications.js"
 import { upsertOwidBriefSubscription } from "../../_common/mailchimp.js"
 
-export { onRequestOptions } from "../../_common/emailNotifications.js"
+export const onRequestOptions = handleOptionsRequest
 
 /**
  * Data source of the magic-link preferences page: resolves a magic-link token

--- a/functions/api/email-notifications/request-link.ts
+++ b/functions/api/email-notifications/request-link.ts
@@ -1,38 +1,25 @@
-import * as Sentry from "@sentry/cloudflare"
 import * as z from "zod/mini"
 import {
     EMAIL_NOTIFICATIONS_MAGIC_LINK_TTL_MS,
     EmailNotificationsRequestLinkRequestTypeObject,
-    EmailNotificationsSubscribeResponse,
     JsonError,
-    stringifyUnknownError,
 } from "@ourworldindata/utils"
 import { Env } from "../../_common/env.js"
 import {
     createEmailToken,
     escapeHtml,
+    handleHtmlError,
+    handleJsonError,
     makeHtmlResponse,
+    makeJsonResponse,
     renderActionPage,
     renderMessagePage,
     sendMagicLinkEmail,
 } from "../../_common/emailNotifications.js"
 
+export { onRequestOptions } from "../../_common/emailNotifications.js"
+
 const REQUEST_LINK_PATH = "/api/email-notifications/request-link"
-
-const CORS_HEADERS = {
-    "Access-Control-Allow-Origin": "*",
-    "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
-    "Access-Control-Allow-Headers": "Content-Type",
-}
-
-const JSON_HEADERS = {
-    ...CORS_HEADERS,
-    "Content-Type": "application/json",
-}
-
-export const onRequestOptions: PagesFunction = async () => {
-    return new Response(null, { headers: CORS_HEADERS, status: 200 })
-}
 
 /**
  * "Email me a link" page target from the notification email footers, with a
@@ -65,14 +52,9 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
             })
         )
     } catch (error) {
-        Sentry.captureException(error)
-        return makeHtmlResponse(
-            renderMessagePage({
-                title: "Something went wrong",
-                message:
-                    "We couldn't process your request. Please try again later.",
-            }),
-            500
+        return handleHtmlError(
+            error,
+            "We couldn't process your request. Please try again later."
         )
     }
 }
@@ -144,13 +126,7 @@ export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
             })
         }
 
-        if (isJson) {
-            const response: EmailNotificationsSubscribeResponse = { ok: true }
-            return new Response(JSON.stringify(response), {
-                headers: JSON_HEADERS,
-                status: 200,
-            })
-        }
+        if (isJson) return makeJsonResponse({ ok: true }, 200)
         return makeHtmlResponse(
             renderMessagePage({
                 title: "Check your inbox",
@@ -159,24 +135,10 @@ export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
             })
         )
     } catch (error) {
-        if (!(error instanceof JsonError) || error.status >= 500) {
-            Sentry.captureException(error)
-        }
-        if (isJson) {
-            const response: EmailNotificationsSubscribeResponse = {
-                error: stringifyUnknownError(error) ?? "Unknown error",
-            }
-            return new Response(JSON.stringify(response), {
-                headers: JSON_HEADERS,
-                status: error instanceof JsonError ? error.status : 500,
-            })
-        }
-        return makeHtmlResponse(
-            renderMessagePage({
-                title: "Something went wrong",
-                message: "We couldn't send the link. Please try again later.",
-            }),
-            500
+        if (isJson) return handleJsonError(error)
+        return handleHtmlError(
+            error,
+            "We couldn't send the link. Please try again later."
         )
     }
 }

--- a/functions/api/email-notifications/request-link.ts
+++ b/functions/api/email-notifications/request-link.ts
@@ -10,6 +10,7 @@ import {
     escapeHtml,
     handleHtmlError,
     handleJsonError,
+    handleOptionsRequest,
     makeHtmlResponse,
     makeJsonResponse,
     renderActionPage,
@@ -17,7 +18,7 @@ import {
     sendMagicLinkEmail,
 } from "../../_common/emailNotifications.js"
 
-export { onRequestOptions } from "../../_common/emailNotifications.js"
+export const onRequestOptions = handleOptionsRequest
 
 const REQUEST_LINK_PATH = "/api/email-notifications/request-link"
 

--- a/functions/api/email-notifications/subscribe.ts
+++ b/functions/api/email-notifications/subscribe.ts
@@ -9,12 +9,13 @@ import {
 import { Env } from "../../_common/env.js"
 import {
     handleJsonError,
+    handleOptionsRequest,
     makeJsonResponse,
     sendWelcomeEmail,
 } from "../../_common/emailNotifications.js"
 import { upsertOwidBriefSubscription } from "../../_common/mailchimp.js"
 
-export { onRequestOptions } from "../../_common/emailNotifications.js"
+export const onRequestOptions = handleOptionsRequest
 
 export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
     try {

--- a/functions/api/email-notifications/subscribe.ts
+++ b/functions/api/email-notifications/subscribe.ts
@@ -1,41 +1,20 @@
-import * as Sentry from "@sentry/cloudflare"
 import * as z from "zod/mini"
 import {
     EmailNotificationsPreferences,
     EmailNotificationsPreferencesTypeObject,
     EmailNotificationsSubscribeRequestTypeObject,
-    EmailNotificationsSubscribeResponse,
     JsonError,
     mergeEmailNotificationsPreferences,
-    stringifyUnknownError,
 } from "@ourworldindata/utils"
 import { Env } from "../../_common/env.js"
-import { sendWelcomeEmail } from "../../_common/emailNotifications.js"
+import {
+    handleJsonError,
+    makeJsonResponse,
+    sendWelcomeEmail,
+} from "../../_common/emailNotifications.js"
 import { upsertOwidBriefSubscription } from "../../_common/mailchimp.js"
 
-const CORS_HEADERS = {
-    "Access-Control-Allow-Origin": "*",
-    "Access-Control-Allow-Methods": "POST, OPTIONS",
-    // The Content-Type header is required to allow requests to be sent with a
-    // Content-Type of "application/json". This is because "application/json"
-    // is not an allowed value for Content-Type to be considered a
-    // CORS-safelisted header.
-    // - https://developer.mozilla.org/en-US/docs/Glossary/CORS-safelisted_request_header
-    "Access-Control-Allow-Headers": "Content-Type",
-}
-
-const DEFAULT_HEADERS = {
-    ...CORS_HEADERS,
-    "Content-Type": "application/json",
-}
-
-// This function is called when the request is a preflight request ("OPTIONS").
-export const onRequestOptions: PagesFunction = async () => {
-    return new Response(null, {
-        headers: CORS_HEADERS,
-        status: 200,
-    })
-}
+export { onRequestOptions } from "../../_common/emailNotifications.js"
 
 export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
     try {
@@ -109,34 +88,16 @@ export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
 
         if (data.subscribeToOwidBrief) {
             // The OWID Brief newsletter stays in Mailchimp; Mailchimp runs
-            // its own double opt-in for new list members.
-            try {
-                await upsertOwidBriefSubscription(env, email, true)
-            } catch (error) {
-                Sentry.captureException(error)
-                throw new JsonError(
-                    "Failed to subscribe to the OWID Brief newsletter. Please try again later.",
-                    500
-                )
-            }
+            // its own double opt-in for new list members. A failure here
+            // propagates as-is: the outer handler reports it to Sentry and
+            // answers generically, so wrapping it would only duplicate the
+            // Sentry event.
+            await upsertOwidBriefSubscription(env, email, true)
         }
 
-        const response: EmailNotificationsSubscribeResponse = { ok: true }
-        return new Response(JSON.stringify(response), {
-            headers: DEFAULT_HEADERS,
-            status: 200,
-        })
+        return makeJsonResponse({ ok: true }, 200)
     } catch (error) {
-        if (!(error instanceof JsonError) || error.status >= 500) {
-            Sentry.captureException(error)
-        }
-        const response: EmailNotificationsSubscribeResponse = {
-            error: stringifyUnknownError(error) ?? "Unknown error",
-        }
-        return new Response(JSON.stringify(response), {
-            headers: DEFAULT_HEADERS,
-            status: error instanceof JsonError ? error.status : 500,
-        })
+        return handleJsonError(error)
     }
 }
 

--- a/functions/api/email-notifications/unsubscribe.ts
+++ b/functions/api/email-notifications/unsubscribe.ts
@@ -1,7 +1,7 @@
-import * as Sentry from "@sentry/cloudflare"
 import { Env } from "../../_common/env.js"
 import {
     escapeHtml,
+    handleHtmlError,
     makeHtmlResponse,
     renderActionPage,
     renderMessagePage,
@@ -43,8 +43,10 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
             })
         )
     } catch (error) {
-        Sentry.captureException(error)
-        return errorResponse()
+        return handleHtmlError(
+            error,
+            "We couldn't unsubscribe you. Please try again later."
+        )
     }
 }
 
@@ -75,8 +77,10 @@ export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
             })
         )
     } catch (error) {
-        Sentry.captureException(error)
-        return errorResponse()
+        return handleHtmlError(
+            error,
+            "We couldn't unsubscribe you. Please try again later."
+        )
     }
 }
 
@@ -97,15 +101,5 @@ function invalidLinkResponse(): Response {
                 "This unsubscribe link is not valid. Please use the link from one of our emails.",
         }),
         404
-    )
-}
-
-function errorResponse(): Response {
-    return makeHtmlResponse(
-        renderMessagePage({
-            title: "Something went wrong",
-            message: "We couldn't unsubscribe you. Please try again later.",
-        }),
-        500
     )
 }


### PR DESCRIPTION
Cleans up the duplication between different handlers and ensures private infra information doesn't leak to the client

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>