### PR TITLE
✨ show an origin's snapshot description in addition to its description

### DIFF
--- a/packages/@ourworldindata/utils/src/metadataHelpers.ts
+++ b/packages/@ourworldindata/utils/src/metadataHelpers.ts
@@ -144,9 +144,15 @@ const prepareOriginForDisplay = (origin: OwidOrigin): DisplaySource => {
         label += " – " + origin.title
     }
 
+    const descriptions = [origin.description, origin.descriptionSnapshot]
+        .filter((text): text is string => !!text)
+        .map((text) => text.trim())
+    const description =
+        descriptions.length > 0 ? descriptions.join("\n\n") : undefined
+
     return {
         label,
-        description: origin.description,
+        description,
         retrievedOn: origin.dateAccessed,
         retrievedFrom: origin.urlMain,
         citation: origin.citationFull,


### PR DESCRIPTION
> _Written by Anthropic Claude Opus 5 — @sophiamersmann at the wheel._

Resolves https://github.com/owid/owid-grapher/issues/6447

Origins carry two descriptions: `description` (about the dataset as a whole) and `description_snapshot` (about the specific file we downloaded from it). We only ever rendered the first one, so snapshot-level notes were dropped, and origins without a dataset description showed nothing at all.

This shows both, joined by a blank line, wherever sources are displayed — the sources modal, data pages and mdim pages. This replaces #6523, which only handled the missing-`description` case.

No backend change is needed: `descriptionSnapshot` is already part of the variable metadata JSON.

## Examples

**Only `description_snapshot` is set** — previously nothing was shown, now the snapshot description is:

| Chart | Origin | Shown text (new) |
| --- | --- | --- |
| [banning-of-chick-culling](https://ourworldindata.org/grapher/banning-of-chick-culling) ([staging](http://staging-site-show-snapshot-description/grapher/banning-of-chick-culling)) | Various sources — Chick culling laws | "Male baby chicks are commonly killed in laying hens hatcheries all around the world…" |
| [data-centers-share-electricity-demand](https://ourworldindata.org/grapher/data-centers-share-electricity-demand) ([staging](http://staging-site-show-snapshot-description/grapher/data-centers-share-electricity-demand)) | International Energy Agency — Energy and AI | "This dataset contains world and regional data on energy consumption and infrastructure related to artificial intelligence…" |

**Both are set** — previously only the dataset description was shown, now the snapshot description follows it as a second paragraph:

[annual-area-burnt-by-wildfires](https://ourworldindata.org/grapher/annual-area-burnt-by-wildfires) ([staging](http://staging-site-show-snapshot-description/grapher/annual-area-burnt-by-wildfires)), origin "Global Wildfire Information System — Seasonal wildfire trends":

> The dataset provides a weekly comprehensive overview of fire activity and its environmental impact, incorporating data from the Global Wildfire Information System (GWIS) and satellite imagery from MODIS and VIIRS…
>
> **This dataset covers all years from 2003 up to and including the current year.** ← newly shown

**Only `description` is set, or neither** — unchanged.

## Notes

Across all origins, 1,113 have both descriptions and 145 have only a snapshot description; the two fields are never identical, so this can't produce a duplicated paragraph.

The 145 origins that previously had no description at all move from the static rendering to an expandable toggle on data pages, since they now have something to expand.

Appending the snapshot description means it carries no label saying where it came from. If that reads poorly, the alternative is to give it its own labelled block in `IndicatorSources` — happy to switch.

`title_snapshot` is likewise never displayed (1,683 origins have one that differs from `title`). Left out of this PR: the source label doubles as the deduplication key for sources, so changing it has a wider blast radius.