### PR TITLE
✨🤖 compare two time points with "vs." instead of a range

### DIFF
--- a/packages/@ourworldindata/core-table/src/CoreTableColumns.test.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTableColumns.test.ts
@@ -47,6 +47,14 @@ describe(ColumnTypeNames.Quarter, () => {
             col.formatTimeRange(day("2025-02-15"), day("2026-11-20"))
         ).toEqual("Jan 2025 to Dec 2026")
     })
+
+    it("formats a comparison as the two quarters themselves", () => {
+        const day = (iso: string): number =>
+            convertDateToDaysSinceEpoch(dayjs.utc(iso))
+        expect(
+            col.formatTimeComparison(day("2025-02-15"), day("2026-11-20"))
+        ).toEqual("Q1 2025 vs. Q4 2026")
+    })
 })
 
 describe(ColumnTypeNames.Decade, () => {
@@ -113,6 +121,14 @@ describe(ColumnTypeNames.Week, () => {
         expect(
             col.formatTimeRange(day("2026-06-03"), day("2026-07-08"))
         ).toEqual("Jun 1, 2026 to Jul 12, 2026")
+    })
+
+    it("formats a comparison as the two weeks themselves", () => {
+        const day = (iso: string): number =>
+            convertDateToDaysSinceEpoch(dayjs.utc(iso))
+        expect(
+            col.formatTimeComparison(day("2026-06-03"), day("2026-07-08"))
+        ).toEqual("Week of Jun 1, 2026 vs. Week of Jul 6, 2026")
     })
 
     it("formats the short timeline label as the plain week-start date", () => {

--- a/packages/@ourworldindata/core-table/src/CoreTableColumns.ts
+++ b/packages/@ourworldindata/core-table/src/CoreTableColumns.ts
@@ -156,6 +156,11 @@ export abstract class AbstractCoreColumn<
         return `${this.formatTime(startTime)} to ${this.formatTime(endTime)}`
     }
 
+    /** Formats a start/end time pair as a comparison of two time points */
+    formatTimeComparison(startTime: number, endTime: number): string {
+        return `${this.formatTime(startTime)} vs. ${this.formatTime(endTime)}`
+    }
+
     @imemo get roundingMode(): OwidVariableRoundingMode {
         return (
             this.display?.roundingMode ?? OwidVariableRoundingMode.decimalPlaces

--- a/packages/@ourworldindata/grapher/src/core/GrapherState.test.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.test.ts
@@ -565,6 +565,80 @@ describe("title", () => {
         expect(grapher.mainTitle).toContain("Change in")
     })
 
+    it("compares the two times of a faceted map, rather than giving a range", () => {
+        const table = SynthesizeGDPTable(
+            { entityCount: 2, timeRange: [2000, 2010] },
+            1
+        )
+        const grapher = new GrapherState({
+            table,
+            ySlugs: SampleColumnSlugs.GDP,
+            tab: GRAPHER_TAB_CONFIG_OPTIONS.map,
+            hasMapTab: true,
+        })
+
+        // A single time is shown as-is
+        grapher.timelineHandleTimeBounds = [2005, 2005]
+        expect(grapher.titleAnnotation).toEqual("2005")
+
+        // Two times facet the map into two snapshots
+        grapher.timelineHandleTimeBounds = [2001, 2005]
+        expect(grapher.isFaceted).toBe(true)
+        expect(grapher.titleAnnotation).toEqual("2001 vs. 2005")
+    })
+
+    it("compares the two times of a dumbbell chart, rather than giving a range", () => {
+        const table = SynthesizeGDPTable(
+            { entityCount: 2, timeRange: [2000, 2010] },
+            1
+        )
+        const grapher = new GrapherState({
+            table,
+            ySlugs: SampleColumnSlugs.GDP,
+            chartTypes: [GRAPHER_CHART_TYPES.Dumbbell],
+            selectedEntityNames: [...table.availableEntityNames],
+        })
+        grapher.timelineHandleTimeBounds = [2001, 2005]
+
+        expect(grapher.titleAnnotation).toEqual("2001 vs. 2005")
+    })
+
+    it("compares the two times of a slope chart, rather than giving a range", () => {
+        const table = SynthesizeGDPTable(
+            { entityCount: 2, timeRange: [2000, 2010] },
+            1
+        )
+        const grapher = new GrapherState({
+            table,
+            ySlugs: SampleColumnSlugs.GDP,
+            chartTypes: [GRAPHER_CHART_TYPES.SlopeChart],
+            selectedEntityNames: [...table.availableEntityNames],
+        })
+        grapher.timelineHandleTimeBounds = [2001, 2005]
+
+        expect(grapher.titleAnnotation).toEqual("2001 vs. 2005")
+    })
+
+    it("gives a range for a relative slope chart, which shows a change over a period", () => {
+        const table = SynthesizeGDPTable(
+            { entityCount: 2, timeRange: [2000, 2010] },
+            1
+        )
+        const grapher = new GrapherState({
+            table,
+            ySlugs: SampleColumnSlugs.GDP,
+            chartTypes: [GRAPHER_CHART_TYPES.SlopeChart],
+            selectedEntityNames: [...table.availableEntityNames],
+            stackMode: StackMode.relative,
+        })
+        grapher.timelineHandleTimeBounds = [2001, 2005]
+
+        // The two halves of the copy belong together: "Change in …" reads as a
+        // period, so the annotation stays a range
+        expect(grapher.mainTitle).toContain("Change in")
+        expect(grapher.titleAnnotation).toEqual("2001 to 2005")
+    })
+
     it("has no annotation when annotation fields are hidden", () => {
         const table = SynthesizeGDPTable(
             { entityCount: 2, timeRange: [2000, 2010] },

--- a/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
@@ -2729,13 +2729,25 @@ export class GrapherState
         )
     }
 
+    @computed private get comparesTwoTimePoints(): boolean {
+        // Faceted maps show one map per timeline handle
+        if (this.isOnMapTab) return this.isFaceted
+
+        // Dumbbell charts compare two time points if not single-time
+        if (this.isOnDumbbellTab) return true
+
+        // Relative slope charts show the change over a period ("Change in X,
+        // 1990 to 2020"), not two snapshots side by side
+        return this.isOnSlopeChartTab && !this.isRelativeMode
+    }
+
     @computed private get timeTitleSuffix(): string | undefined {
         const { startTime, endTime, xOverrideTime } = this
 
         const timeColumn = this.table.timeColumn
-        if (timeColumn.isMissing) return undefined // Do not show year until data is loaded
 
-        const formatTime = (time: Time): string => timeColumn.formatTime(time)
+        // Do not show year until data is loaded
+        if (timeColumn.isMissing) return undefined
 
         // Add 'Time vs. Time' suffix for scatter plots with time override
         if (
@@ -2743,19 +2755,17 @@ export class GrapherState
             endTime !== undefined &&
             xOverrideTime !== undefined
         ) {
-            const times = _.sortBy([endTime, xOverrideTime])
-            return times.map((time) => formatTime(time)).join(" vs. ")
+            const [start, end] = _.sortBy([endTime, xOverrideTime])
+            return timeColumn.formatTimeComparison(start, end)
         }
 
         if (startTime === undefined || endTime === undefined) return undefined
 
-        if (startTime === endTime) return formatTime(startTime)
+        if (startTime === endTime) return timeColumn.formatTime(startTime)
 
-        // Dumbbell charts compare two points, so use "vs." instead of a range
-        if (this.isOnDumbbellTab)
-            return `${formatTime(startTime)} vs. ${formatTime(endTime)}`
-
-        return timeColumn.formatTimeRange(startTime, endTime)
+        return this.comparesTwoTimePoints
+            ? timeColumn.formatTimeComparison(startTime, endTime)
+            : timeColumn.formatTimeRange(startTime, endTime)
     }
 
     @computed get sourcesLine(): string {

--- a/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellTooltips.tsx
+++ b/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellTooltips.tsx
@@ -54,10 +54,10 @@ export class DumbbellTimeRangeTooltip extends React.Component<DumbbellTooltipPro
         const originalStartTime = target?.start.time ?? startTime
         const originalEndTime = target?.end.time ?? endTime
 
-        const formattedStartTime = formatColumn.formatTime(originalStartTime)
-        const formattedEndTime = formatColumn.formatTime(originalEndTime)
-
-        return `${formattedStartTime} to ${formattedEndTime}`
+        return formatColumn.formatTimeComparison(
+            originalStartTime,
+            originalEndTime
+        )
     }
 
     @computed private get toleranceNotice(): FooterItem | undefined {

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapTooltip.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapTooltip.tsx
@@ -199,14 +199,22 @@ export class MapTooltip
 
     @computed private get tooltipSubtitle(): string | undefined {
         const { startDatum, endDatum, startTime, endTime } = this
+        const { timeColumn } = this.entityTable
 
         const originalStartTime = startDatum?.originalTime ?? startTime
         const originalEndTime = endDatum?.originalTime ?? endTime
 
         if (this.shouldShowValueRange) {
-            return [originalStartTime, originalEndTime]
-                .map((time) => this.formatTime(time))
-                .join(" to ")
+            if (
+                originalStartTime === undefined ||
+                originalEndTime === undefined
+            )
+                return undefined
+
+            return timeColumn.formatTimeComparison(
+                originalStartTime,
+                originalEndTime
+            )
         }
 
         return this.formatTime(originalEndTime)

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotTooltip.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotTooltip.tsx
@@ -81,7 +81,7 @@ export class ScatterPlotTooltip extends React.Component<ScatterPlotTooltipProps>
             return makeToleranceNotice({
                 startTime,
                 endTime,
-                formatTime: (time) => yColumn.formatTime(time),
+                column: yColumn,
             })
         }
 
@@ -106,7 +106,7 @@ export class ScatterPlotTooltip extends React.Component<ScatterPlotTooltipProps>
         return makeToleranceNotice({
             startTime,
             endTime,
-            formatTime: (time) => yColumn.formatTime(time),
+            column: yColumn,
         })
     }
 
@@ -156,8 +156,14 @@ export class ScatterPlotTooltip extends React.Component<ScatterPlotTooltipProps>
         const { manager, yColumn, xColumn } = this.chartState
         const { startTime, endTime, isRelativeMode } = manager
 
+        const isComparison = hasSameVariableWithTimeOverride(
+            xColumn,
+            yColumn,
+            this.points
+        )
+
         let times: Time[]
-        if (hasSameVariableWithTimeOverride(xColumn, yColumn, this.points)) {
+        if (isComparison) {
             times = _.sortBy([this.points[0].time.x, this.points[0].time.y])
         } else if (this.chartState.isTimeScatter) {
             times = _.uniq(excludeNullish(this.values.map((v) => v.time.y)))
@@ -165,9 +171,9 @@ export class ScatterPlotTooltip extends React.Component<ScatterPlotTooltipProps>
             times = _.uniq(excludeNullish([startTime, endTime]))
         }
 
-        const timeRange = times.map((t) => yColumn.formatTime(t)).join(" to ")
+        const timeLabel = formatTimes(times, yColumn, { isComparison })
 
-        return timeRange + (isRelativeMode ? " (avg. annual change)" : "")
+        return timeLabel + (isRelativeMode ? " (avg. annual change)" : "")
     }
 
     override render(): React.ReactElement | null {
@@ -412,18 +418,33 @@ function hasTimeMismatch({
     return startTimesDiffer || endTimesDiffer
 }
 
+function formatTimes(
+    times: Time[],
+    column: CoreColumn,
+    { isComparison = false }: { isComparison?: boolean } = {}
+): string {
+    if (times.length === 0) return ""
+    if (times.length === 1) return column.formatTime(times[0])
+
+    const [startTime, endTime] = times
+    return isComparison
+        ? column.formatTimeComparison(startTime, endTime)
+        : column.formatTimeRange(startTime, endTime)
+}
+
 function makeToleranceNotice({
     startTime,
     endTime,
-    formatTime,
+    column,
 }: {
     startTime?: Time
     endTime?: Time
-    formatTime: (time: Time) => string
+    column: CoreColumn
 }): FooterItem {
-    const targetNotice = _.uniq(excludeNullish([startTime, endTime]))
-        .map((t) => formatTime(t))
-        .join(" to ")
+    const targetNotice = formatTimes(
+        _.uniq(excludeNullish([startTime, endTime])),
+        column
+    )
 
     return {
         icon: TooltipFooterIcon.Notice,

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotTooltip.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotTooltip.tsx
@@ -11,6 +11,7 @@ import {
     RequiredBy,
 } from "@ourworldindata/utils"
 import { ColumnTypeMap, CoreColumn } from "@ourworldindata/core-table"
+import { OwidColumnDef } from "@ourworldindata/types"
 import {
     Tooltip,
     TooltipState,
@@ -385,9 +386,13 @@ function hasSameVariableWithTimeOverride(
     // Check if there is exactly one point
     if (points.length !== 1) return false
 
-    // Check if both axes use the same dataset/variable
-    const isSameDataset = xColumn.def.datasetId === yColumn.def.datasetId
-    if (!isSameDataset) return false
+    // Check if both axes use the same variable
+    const xDef = xColumn.def as OwidColumnDef
+    const yDef = yColumn.def as OwidColumnDef
+    const isSameVariable =
+        xDef.owidVariableId !== undefined &&
+        xDef.owidVariableId === yDef.owidVariableId
+    if (!isSameVariable) return false
 
     // Check if the point has different time points for x and y
     const point = points[0]

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
@@ -776,10 +776,9 @@ export class SlopeChart
 
         const actualStartTime = series.start.originalTime
         const actualEndTime = series.end.originalTime
-        const timeRange = `${formatTime(actualStartTime)} to ${formatTime(actualEndTime)}`
         const timeLabel = isRelativeMode
             ? `% change between ${formatColumn.formatTime(actualStartTime)} and ${formatColumn.formatTime(actualEndTime)}`
-            : timeRange
+            : formatColumn.formatTimeComparison(actualStartTime, actualEndTime)
 
         const constructTargetYearForToleranceNotice = () => {
             const isStartValueOriginal = series.start.originalTime === startTime


### PR DESCRIPTION
> _Written by Claude Sonnet 5 — @sophiamersmann at the wheel._

## Context

Chart titles annotate the time period shown, e.g. "GDP, 1990 to 2020". But some chart types don't show a period — they show two snapshots side by side and let you compare them: a faceted map plots 1990 and 2020 as separate panels, a dumbbell chart draws two dots, a slope chart draws two endpoints. For those, "1990 to 2020" reads as a span even though nothing in between is actually shown.

This adds `formatTimeComparison()` next to the existing `formatTimeRange()` on `CoreColumn`, and uses it for:

- the chart title's time annotation, for faceted maps, dumbbell charts, and slope charts (outside relative mode, where "Change in X, 1990 to 2020" already reads as a period, not a comparison)
- the matching tooltips (map, scatter with a time override, dumbbell, slope), so hovering agrees with the title

Relative slope charts, connected/time scatters, and everything else that genuinely shows a range keep "to".

## Screenshots

_(add before/after of a faceted map title and tooltip)_

## Testing guidance

- Facet a map (pull the timeline handles apart on the map tab) — the title and tooltip should read "1990 vs. 2020"
- Open a dumbbell or slope chart with the handles apart — same wording; switch a slope chart to relative mode and it should go back to "1990 to 2020"
- Open a scatter plot comparing the same variable across two times (x vs. y) — title and tooltip should read "1990 vs. 2020"
- Check line, stacked, and non-time-override scatter charts are unaffected

## Note for reviewer

Not yet reflected in `owid-grapher-svgs`. Running `make svgtest.full` will show diffs on faceted maps, the `tab=slope` grapher-views, and a handful of slope-default thumbnails/mdims — all just the time-annotation wording.
