### PR TITLE
🔨🤖 svgTester: remove the explorers test suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ ifdef WRANGLER_PORT
 WRANGLER_PORT := $(strip $(WRANGLER_PORT))
 endif
 
-.PHONY: help up up.headless up.worktree setup.worktree require.worktree up.full down down.headless down.worktree refresh refresh.wp refresh.private refresh.full migrate svgtest svgtest.reset svgtest.graphers svgtest.grapher-views svgtest.mdims svgtest.explorers svgtest.thumbnails bdd bdd.ui check-not-prod
+.PHONY: help up up.headless up.worktree setup.worktree require.worktree up.full down down.headless down.worktree refresh refresh.wp refresh.private refresh.full migrate svgtest svgtest.reset svgtest.graphers svgtest.grapher-views svgtest.mdims svgtest.thumbnails bdd bdd.ui check-not-prod
 
 help:
 	@echo 'Available commands:'
@@ -61,7 +61,6 @@ help:
 	@echo '  make bdd.ui                 (while up) start BDD test environment with UI'
 	@echo '  make svgtest                generate an SVG test report for graphers'
 	@echo '  make svgtest.full           generate a full SVG test report'
-	@echo '  make svgtest.explorers      generate an SVG test report for explorers only'
 	@echo '  make local-bake             do a full local site bake'
 	@echo '  make archive                create an archived version of our charts'
 	@echo '  make wikipedia-archive      create a Wikipedia archive (strips GTM, rewrites archive URLs)'
@@ -431,10 +430,6 @@ svgtest.full: svgtest.reset node_modules
 	yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/verify-graphs.ts mdims \
 		|| yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/create-compare-view.ts mdims
 
-	@# run test suite for explorers
-	yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/verify-graphs.ts explorers --manifest top.manifest.json \
-		|| yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/create-compare-view.ts explorers
-
 	@# run test suite for thumbnails
 	yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/verify-graphs.ts thumbnails \
 		|| yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/create-compare-view.ts thumbnails
@@ -452,13 +447,6 @@ svgtest.mdims: svgtest.reset node_modules
 	@# run test suite for mdims and create an HTML report if there are differences
 	yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/verify-graphs.ts mdims \
 		|| (yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/create-compare-view.ts mdims && open ../owid-grapher-svgs/mdims/differences.html)
-
-svgtest.explorers: svgtest.reset node_modules
-	@echo '==> Generating SVG test report for explorers'
-
-	@# run test suite for explorers and create an HTML report if there are differences
-	yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/verify-graphs.ts explorers \
-		|| (yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/create-compare-view.ts explorers && open ../owid-grapher-svgs/explorers/differences.html)
 
 svgtest.thumbnails: svgtest.reset node_modules
 	@echo '==> Generating SVG test report for thumbnails'

--- a/devTools/svgTester/create-compare-view.ts
+++ b/devTools/svgTester/create-compare-view.ts
@@ -21,13 +21,8 @@ async function main(args: ReturnType<typeof parseArguments>) {
 
     const compareUrl = args.compareUrl
 
-    const isExplorer = testSuite === "explorers"
-    const compareChartUrl = isExplorer
-        ? compareUrl + "/explorers"
-        : compareUrl + "/grapher"
-    const liveChartUrl = isExplorer
-        ? LIVE_URL + "/explorers"
-        : LIVE_URL + "/grapher"
+    const compareChartUrl = compareUrl + "/grapher"
+    const liveChartUrl = LIVE_URL + "/grapher"
 
     if (!fs.existsSync(workingDir))
         throw `Working directory does not exist ${workingDir}`

--- a/devTools/svgTester/dump-data.ts
+++ b/devTools/svgTester/dump-data.ts
@@ -2,7 +2,6 @@
 
 import path from "path"
 import { match } from "ts-pattern"
-import * as _ from "lodash-es"
 import {
     TransactionCloseMode,
     knexReadonlyTransaction,
@@ -13,13 +12,11 @@ import { getMostViewedGrapherIdsByChartType } from "../../db/model/Chart.js"
 import { getAllPublishedMultiDimDataPages } from "../../db/model/MultiDimDataPage.js"
 import {
     ALL_GRAPHER_CHART_TYPES,
-    ExplorerType,
     GrapherInterface,
     ChartConfigsTableName,
     DbRawChartConfig,
 } from "@ourworldindata/types"
 import { parseChartConfig, queryParamsToStr } from "@ourworldindata/utils"
-import { ExplorerProgram } from "@ourworldindata/explorer"
 
 import fs from "fs-extra"
 
@@ -27,13 +24,7 @@ import yargs from "yargs"
 import { hideBin } from "yargs/helpers"
 import * as utils from "./utils.js"
 import pMap from "p-map"
-import { ExplorerAdminServer } from "../../explorerAdminServer/ExplorerAdminServer.js"
-import {
-    getAnalyticsPageviewsByUrlObj,
-    assertAnalyticsPageviewsPopulated,
-} from "../../db/model/Pageview.js"
-import { transformExplorerProgramToResolveCatalogPaths } from "../../db/model/ExplorerCatalogResolver.js"
-import { ExplorerViewManifest } from "./utils.js"
+import { assertAnalyticsPageviewsPopulated } from "../../db/model/Pageview.js"
 
 interface ChartInfo {
     id: string
@@ -135,266 +126,6 @@ async function saveGrapherSchemaAndData(
     console.log(`Successfully exported ${charts.length} charts`)
 }
 
-function allocateViewCount({
-    totalViews,
-    pageviews,
-    totalPageviews,
-    targetTotalViews,
-    minViews = 10,
-    maxViews = 100,
-}: {
-    totalViews: number
-    pageviews: number
-    totalPageviews: number
-    targetTotalViews: number
-    minViews?: number
-    maxViews?: number
-}): number {
-    // Allocate based on popularity
-    const pageviewRatio = totalPageviews > 0 ? pageviews / totalPageviews : 0
-    const allocated = Math.floor(targetTotalViews * pageviewRatio)
-
-    // Apply constraints
-    return _.clamp(Math.min(allocated, totalViews), minViews, maxViews)
-}
-
-function selectViewsToTest(
-    allChoices: Array<Record<string, string>>,
-    targetCount: number
-): Array<{ index: number; choiceParams: Record<string, string> }> {
-    if (targetCount >= allChoices.length) {
-        // Test all views
-        return allChoices.map((params, index) => ({
-            index,
-            choiceParams: params,
-        }))
-    }
-
-    // Always include first view (default)
-    const selected = [{ index: 0, choiceParams: allChoices[0] }]
-
-    // Random sample for remaining
-    const remaining = targetCount - 1
-    const availableIndices = _.range(1, allChoices.length)
-
-    const sampledIndices = _.sampleSize(availableIndices, remaining)
-
-    for (const index of sampledIndices) {
-        selected.push({ index, choiceParams: allChoices[index] })
-    }
-
-    return _.sortBy(selected, "index")
-}
-
-async function writeManifestFile({
-    totalViews,
-    selectedViews,
-    explorerDir,
-    manifestFilename = "top.manifest.json",
-}: {
-    totalViews: number
-    selectedViews: Array<{
-        index: number
-        choiceParams: Record<string, string>
-    }>
-    explorerDir: string
-    manifestFilename?: string
-}): Promise<void> {
-    const manifest: ExplorerViewManifest = {
-        totalViews,
-        selectedViews: selectedViews.length,
-        viewsToTest: selectedViews.map((v) => v.choiceParams),
-    }
-
-    const manifestPath = path.join(explorerDir, manifestFilename)
-    await fs.writeFile(manifestPath, JSON.stringify(manifest, null, 2))
-}
-
-async function dumpExplorerWithData({
-    knex,
-    explorerProgram,
-    outDir,
-    pageviews,
-    totalPageviews,
-    targetTotalViews,
-}: {
-    knex: KnexReadonlyTransaction
-    explorerProgram: ExplorerProgram
-    outDir: string
-    pageviews: number
-    totalPageviews: number
-    targetTotalViews: number
-}) {
-    const explorerSlug = explorerProgram.slug
-    const explorerType = utils.getExplorerType(explorerProgram)
-
-    // Skip grapher based explorers (already tested via the graphers suite)
-    if (explorerType === ExplorerType.Grapher) return
-
-    console.log(`Exporting explorer: ${explorerSlug} (${explorerType})`)
-
-    // Create output directory for this explorer
-    const explorerDir = path.join(outDir, explorerSlug)
-    if (!fs.existsSync(explorerDir))
-        fs.mkdirSync(explorerDir, { recursive: true })
-
-    // Save the explorer config
-    const tsvPath = path.join(explorerDir, "config.tsv")
-    await fs.writeFile(tsvPath, explorerProgram.toString())
-
-    // Determine which views to test
-    if (pageviews > 0) {
-        const allChoices =
-            explorerProgram.decisionMatrix.allDecisionsAsQueryParams()
-        const totalViews = allChoices.length
-
-        const numViewsToTest = allocateViewCount({
-            totalViews,
-            pageviews,
-            totalPageviews,
-            targetTotalViews,
-        })
-        const selectedViews = selectViewsToTest(allChoices, numViewsToTest)
-
-        console.log(
-            `  Sampling ${selectedViews.length}/${totalViews} views (${Math.round((selectedViews.length / totalViews) * 100)}%)`
-        )
-
-        // Write manifest json file
-        await writeManifestFile({ totalViews, selectedViews, explorerDir })
-    }
-
-    await match(explorerType)
-        .with(ExplorerType.Indicator, async () => {
-            const { requiredVariableIds, allVariableIds } =
-                explorerProgram.decisionMatrix
-
-            if (allVariableIds.length > 0) {
-                await utils.writeVariableDataAndMetadataFiles(
-                    allVariableIds,
-                    explorerDir
-                )
-            }
-
-            if (requiredVariableIds.length > 0)
-                await utils.savePartialGrapherConfigs(
-                    requiredVariableIds,
-                    explorerDir,
-                    knex
-                )
-        })
-        .with(ExplorerType.Csv, async () => {
-            const tableSlugs = explorerProgram.tableSlugs
-            const urlReplacements = new Map<string, string>()
-
-            for (const tableSlug of tableSlugs) {
-                const tableDef = explorerProgram.getTableDef(tableSlug)
-                if (!tableDef || tableDef.inlineData || !tableDef.url) continue
-
-                const tableName = tableSlug || "default"
-
-                try {
-                    const response = await fetch(tableDef.url)
-                    if (!response.ok) {
-                        throw new Error(
-                            `Failed to fetch ${tableDef.url}: ${response.status} ${response.statusText}`
-                        )
-                    }
-                    const csvContent = await response.text()
-                    const csvPath = path.join(explorerDir, `${tableName}.csv`)
-                    await fs.writeFile(csvPath, csvContent)
-
-                    // Track the URL replacement for updating TSV
-                    urlReplacements.set(tableDef.url, `file://${csvPath}`)
-                } catch (error) {
-                    console.error(
-                        `Error fetching table ${tableName}:`,
-                        error instanceof Error ? error.message : error
-                    )
-                }
-            }
-
-            // Replace remote URLs with local file paths in the TSV
-            if (urlReplacements.size > 0) {
-                let modifiedTsvContent = explorerProgram.toString()
-                for (const [originalUrl, localPath] of urlReplacements) {
-                    modifiedTsvContent = modifiedTsvContent.replaceAll(
-                        originalUrl,
-                        localPath
-                    )
-                }
-                await fs.writeFile(tsvPath, modifiedTsvContent)
-            }
-        })
-        .exhaustive()
-}
-
-async function saveExplorerConfigAndData(
-    knex: KnexReadonlyTransaction,
-    explorers: ExplorerProgram[],
-    outDir: string,
-    {
-        pageviewsByUrl,
-        targetTotalViews,
-    }: {
-        pageviewsByUrl: { [url: string]: { views_365d: number } }
-        targetTotalViews: number
-    }
-): Promise<void> {
-    console.log(`Exporting ${explorers.length} explorers...`)
-
-    // Calculate total pageviews for all explorers
-    const explorerPageviewsBySlug = new Map(
-        explorers.map((explorer) => {
-            const url = `/explorers/${explorer.slug}`
-            return [explorer.slug, pageviewsByUrl[url]?.views_365d ?? 0]
-        })
-    )
-
-    const totalPageviews = _.sum(
-        explorers.map(
-            (explorer) => explorerPageviewsBySlug.get(explorer.slug) ?? 0
-        )
-    )
-    const totalPageviewsExcludingCovid =
-        totalPageviews - (explorerPageviewsBySlug.get("covid") ?? 0)
-
-    for (const explorer of explorers) {
-        const pageviews = explorerPageviewsBySlug.get(explorer.slug) ?? 0
-
-        // For COVID, always test all views
-        // For others, use the allocation calculation (excluding COVID pageviews)
-        const totalPageviews =
-            explorer.slug === "covid"
-                ? pageviews // Use COVID's own pageviews so it gets 100% allocation
-                : totalPageviewsExcludingCovid
-
-        await dumpExplorerWithData({
-            explorerProgram: explorer,
-            outDir,
-            knex,
-            pageviews,
-            totalPageviews,
-            targetTotalViews,
-        })
-    }
-
-    // Count total views across all explorers by reading manifests
-    let totalViewsAcrossAllExplorers = 0
-    for (const explorer of explorers) {
-        const explorerDir = path.join(outDir, explorer.slug)
-        const manifestPath = path.join(explorerDir, "top.manifest.json")
-        if (await fs.pathExists(manifestPath)) {
-            const manifest: ExplorerViewManifest =
-                await fs.readJson(manifestPath)
-            totalViewsAcrossAllExplorers += manifest.selectedViews
-        }
-    }
-
-    console.log(`Successfully exported ${explorers.length} explorers`)
-    console.log(`Total explorer views to test: ${totalViewsAcrossAllExplorers}`)
-}
-
 async function main(args: ReturnType<typeof parseArguments>) {
     try {
         const testSuite = args.testSuite as utils.TestSuite
@@ -493,49 +224,6 @@ async function main(args: ReturnType<typeof parseArguments>) {
                     concurrency,
                 })
             })
-            .with("explorers", async () => {
-                await knexReadonlyTransaction(
-                    assertAnalyticsPageviewsPopulated,
-                    TransactionCloseMode.Close
-                )
-                const explorerAdminServer = new ExplorerAdminServer()
-                const targetTotalViews = args.targetViews
-
-                await knexReadonlyTransaction(async (trx) => {
-                    // Fetch pageview data for all explorers
-                    const pageviewsByUrl =
-                        await getAnalyticsPageviewsByUrlObj(trx)
-
-                    const rawExplorers =
-                        await explorerAdminServer.getAllPublishedExplorers(trx)
-
-                    // Ignore explorers that are Grapher ID based
-                    // (they are covered by the grapher tests)
-                    const explorersToExport = rawExplorers.filter(
-                        (explorer) => {
-                            const type = utils.getExplorerType(explorer)
-                            return type !== ExplorerType.Grapher
-                        }
-                    )
-
-                    // Resolve catalog paths in explorer programs
-                    const explorers = await Promise.all(
-                        explorersToExport.map(async (explorer) => {
-                            const result =
-                                await transformExplorerProgramToResolveCatalogPaths(
-                                    explorer,
-                                    trx
-                                )
-                            return result.program
-                        })
-                    )
-
-                    await saveExplorerConfigAndData(trx, explorers, outDir, {
-                        pageviewsByUrl,
-                        targetTotalViews,
-                    })
-                }, TransactionCloseMode.Close)
-            })
             .exhaustive()
     } catch (error) {
         console.error("Encountered an error: ", error)
@@ -561,12 +249,6 @@ function parseArguments() {
                 type: "number",
                 description: "Number of charts to export in parallel.",
                 default: 32,
-            },
-            targetViews: {
-                type: "number",
-                description:
-                    "Target total number of explorer views to test (for explorers test suite). Views are allocated proportionally based on pageviews.",
-                default: 1500,
             },
         })
         .help()

--- a/devTools/svgTester/export-graphs.ts
+++ b/devTools/svgTester/export-graphs.ts
@@ -145,59 +145,6 @@ async function exportGraphers(args: ReturnType<typeof parseArguments>) {
     }
 }
 
-async function exportExplorers(args: ReturnType<typeof parseArguments>) {
-    const testSuite = args.testSuite as utils.TestSuite
-    const verbose = args.verbose
-
-    // Input and output directories
-    const dataDir = path.join(utils.SVG_REPO_PATH, testSuite, "data")
-    const outDir = path.join(utils.SVG_REPO_PATH, testSuite, "references")
-
-    if (!fs.existsSync(dataDir))
-        throw `Input directory does not exist ${dataDir}`
-    if (!fs.existsSync(outDir)) fs.mkdirSync(outDir, { recursive: true })
-
-    // Collect all explorer directories
-    const explorerJobs: { dir: string; outDir: string }[] = []
-    const dir = await fs.opendir(dataDir)
-    for await (const entry of dir) {
-        if (!entry.isDirectory()) continue
-
-        const explorerDataDir = path.join(dataDir, entry.name)
-        explorerJobs.push({ dir: explorerDataDir, outDir })
-    }
-
-    const jobCount = explorerJobs.length
-    if (jobCount === 0) {
-        utils.logIfVerbose(verbose, "No explorer directories found")
-        process.exit(0)
-    } else {
-        utils.logIfVerbose(
-            verbose,
-            `Exporting ${jobCount} explorer${jobCount > 1 ? "s" : ""}...`
-        )
-    }
-
-    const pool = workerpool.pool(__dirname + "/worker.ts", {
-        minWorkers: 2,
-        maxWorkers: MAX_WORKERS,
-        workerThreadOpts: {
-            execArgv: ["--require", "tsx"],
-        },
-    })
-
-    const allSvgRecordsArrays: utils.SvgRecord[][] = await Promise.all(
-        explorerJobs.map((job) =>
-            pool.exec("renderExplorerViewsToSVGsAndSave", [job])
-        )
-    )
-
-    await pool.terminate()
-
-    const allSvgRecords = allSvgRecordsArrays.flat()
-    await utils.writeReferenceCsv(outDir, allSvgRecords)
-}
-
 async function main(args: ReturnType<typeof parseArguments>) {
     const testSuite = args.testSuite as utils.TestSuite
 
@@ -206,7 +153,6 @@ async function main(args: ReturnType<typeof parseArguments>) {
         .with("grapher-views", () => exportGraphers(args))
         .with("mdims", () => exportGraphers(args))
         .with("thumbnails", () => exportGraphers(args))
-        .with("explorers", () => exportExplorers(args))
         .exhaustive()
 }
 

--- a/devTools/svgTester/readme.md
+++ b/devTools/svgTester/readme.md
@@ -1,6 +1,6 @@
 # SVG Tester
 
-This folder contains a set of tools to check the default svg output of all (or a subset of) graphers, mdims and explorers. The intended use is to easily check if a change you made to the grapher leads to any of the svg outputs to change (i.e. it tests all graphers svg output plus mdim and explorer views against a reference export). This is not perfect as it doesn't include any interaction but it's a nice sanity check to see if a change broke something.
+This folder contains a set of tools to check the default svg output of all (or a subset of) graphers and mdims. The intended use is to easily check if a change you made to the grapher leads to any of the svg outputs to change (i.e. it tests all graphers svg output plus mdim views against a reference export). This is not perfect as it doesn't include any interaction but it's a nice sanity check to see if a change broke something.
 
 ## Overview
 
@@ -13,7 +13,6 @@ The SVG tester supports multiple test suites:
 - **graphers**: Standalone grapher charts
 - **grapher-views**: All possible chart configurations for each grapher (different tabs, etc.)
 - **mdims**: Multi-dimensional data pages with multiple views
-- **explorers**: Interactive data explorers. Both indicator-based and CSV-based (FromColumnSlugs) explorers are tested. Grapher ID-based explorers are skipped since they're already covered by the grapher tests.
 - **thumbnails**: Thumbnail versions of the most viewed graphers. For each chart, all available tabs are tested.
 
 ## Make a reference set of SVGs
@@ -44,21 +43,6 @@ For published multi-dimensional data pages, creates subdirectories named `{slug}
 yarn tsx devTools/svgTester/dump-data.ts mdims
 ```
 
-#### Explorers
-
-For every published explorer, creates one subdirectory named after the explorer slug in the `explorers` test suite directory containing:
-
-- `config.tsv` - The explorer's TSV configuration with URLs replaced by local file paths
-- For **indicator-based explorers**: `{variableId}.data.json`, `{variableId}.metadata.json`, and `{variableId}.config.json` files for each variable referenced in the explorer
-- For **CSV-based explorers**: CSV files are downloaded and saved as `{tableSlug}.csv`
-
-The script automatically resolves catalog paths to indicator IDs and replaces remote URLs in the explorer tsv config with local file paths to the dumped data.
-
-```bash
-# Dump all published explorer configs and data
-yarn tsx devTools/svgTester/dump-data.ts explorers
-```
-
 **Note on compression:** We use uncompressed files because gzipped files have legacy headers that indicate the OS they were generated on, leading to mass git diffs when dumps are made on different systems.
 
 #### Thumbnails
@@ -69,10 +53,10 @@ For the most-viewed graphers, creates a manifest file listing which charts to te
 
 ### 2. Generate reference SVGs
 
-Use `export-graphs.ts` to generate reference SVG exports. The script uses parallel processing (workerpools) for efficient handling of large numbers of charts and explorers. For each item, it:
+Use `export-graphs.ts` to generate reference SVG exports. The script uses parallel processing (workerpools) for efficient handling of large numbers of charts. For each item, it:
 
 - Loads the config and data
-- Initializes a grapher or explorer instance
+- Initializes a grapher instance
 - Generates SVG output
 - Processes the SVG to remove non-deterministic elements
 - Calculates an MD5 checksum
@@ -93,7 +77,7 @@ This script does NOT require database access - it uses the dumped data files fro
 Use `verify-graphs.ts` to check SVG outputs against the reference export. The script uses parallel processing (workerpools) for efficient verification. For each item, it:
 
 - Loads the config and data
-- Initializes a grapher or explorer instance
+- Initializes a grapher instance
 - Generates SVG output
 - Processes the SVG to remove non-deterministic elements
 - Compares the MD5 hash with the reference
@@ -135,7 +119,7 @@ make svgtest.full
 This command:
 
 1. Resets `../owid-grapher-svgs` to `origin/master`
-2. Runs `export-graphs.ts` for all test suites (graphers, grapher-views, mdims, explorers, thumbnails)
+2. Runs `export-graphs.ts` for all test suites (graphers, grapher-views, mdims, thumbnails)
 3. Generates HTML comparison reports for each test suite
 
 ## Refreshing Reference Data
@@ -153,7 +137,7 @@ make refresh.full    # Refresh the database and analytics from production
 The `refresh.sh` script will:
 
 1. Reset `../owid-grapher-svgs` to `origin/master`
-2. For each test suite (graphers, grapher-views, mdims, explorers):
+2. For each test suite (graphers, grapher-views, mdims, thumbnails):
     - Dump configs and data using `dump-data.ts`
     - Commit the configs and data
     - Generate reference SVGs using `export-graphs.ts`

--- a/devTools/svgTester/refresh.sh
+++ b/devTools/svgTester/refresh.sh
@@ -52,7 +52,6 @@ main() {
     refresh graphers
     refresh grapher-views
     refresh mdims
-    refresh explorers
     refresh thumbnails
 }
 

--- a/devTools/svgTester/utils.ts
+++ b/devTools/svgTester/utils.ts
@@ -1,25 +1,18 @@
 import {
-    ExplorerType,
     GRAPHER_CHART_TYPES,
     GrapherChartType,
     GrapherTabName,
     GrapherInterface,
-    OwidChartDimensionInterface,
-    parseChartConfig,
     GrapherVariant,
     GRAPHER_TAB_NAMES,
     GrapherChartOrMapType,
 } from "@ourworldindata/types"
 import {
     Bounds,
-    mergeGrapherConfigs,
     MultipleOwidVariableDataDimensionsMap,
     OwidVariableMixedData,
     OwidVariableWithSourceAndDimension,
-    queryParamsToStr,
     TESTING_ONLY_disable_guid,
-    PromiseCache,
-    CoreTableInputOption,
 } from "@ourworldindata/utils"
 import fs, { stat } from "fs-extra"
 import path from "path"
@@ -36,11 +29,8 @@ import { getHeapStatistics } from "v8"
 import { queryStringsByChartType } from "./chart-configurations.js"
 import * as d3 from "d3-dsv"
 import {
-    DEFAULT_GRAPHER_HEIGHT,
-    DEFAULT_GRAPHER_WIDTH,
     GrapherProgrammaticInterface,
     legacyToOwidTableAndDimensions,
-    legacyToOwidTableAndDimensionsWithMandatorySlug,
     migrateGrapherConfigToLatestVersion,
     GrapherState,
     GRAPHER_THUMBNAIL_WIDTH,
@@ -52,15 +42,6 @@ import oxfmtConfig from "../../.oxfmtrc.json"
 import { hashMd5 } from "../../serverUtils/hash.js"
 import * as R from "remeda"
 import ReactDOMServer from "react-dom/server"
-import {
-    Explorer,
-    ExplorerChartCreationMode,
-    ExplorerChoiceParams,
-    ExplorerProgram,
-    ExplorerProps,
-    GrapherGrammar,
-} from "@ourworldindata/explorer"
-import { knexRaw, KnexReadonlyTransaction } from "../../db/db.js"
 
 export const SVG_REPO_PATH = "../owid-grapher-svgs"
 
@@ -68,13 +49,12 @@ export const TEST_SUITES = [
     "graphers",
     "grapher-views",
     "mdims",
-    "explorers",
     "thumbnails",
 ] as const
 export type TestSuite = (typeof TEST_SUITES)[number]
 
 export const TEST_SUITE_DESCRIPTION =
-    "Test suite to run: 'graphers' for default Grapher views, 'grapher-views' for all views of a subset of Graphers. 'mdims' for all multi-dim views. 'explorers' for all Explorer views. 'thumbnails' for thumbnail versions (300x160) of all published graphers."
+    "Test suite to run: 'graphers' for default Grapher views, 'grapher-views' for all views of a subset of Graphers. 'mdims' for all multi-dim views. 'thumbnails' for thumbnail versions (300x160) of all published graphers."
 
 const CONFIG_FILENAME = "config.json"
 const RESULTS_FILENAME = "results.csv"
@@ -130,27 +110,6 @@ export const JOB_TIMEOUT_MS = 2 * 60 * 1000
 // wall-clock, not just a cheaper-but-slower tradeoff. Override via
 // SVG_TESTER_MAX_WORKERS on memory-constrained hosts.
 export const MAX_WORKERS = Number(process.env.SVG_TESTER_MAX_WORKERS) || 6
-
-// Rejects if the given promise doesn't settle within `timeoutMs`. Used to bound
-// a single render so one stuck view can't hang a whole worker job.
-async function withTimeout<T>(
-    promise: Promise<T>,
-    timeoutMs: number,
-    label: string
-): Promise<T> {
-    let timer: ReturnType<typeof setTimeout> | undefined
-    const timeout = new Promise<never>((_resolve, reject) => {
-        timer = setTimeout(
-            () => reject(new Error(`Timed out after ${timeoutMs}ms: ${label}`)),
-            timeoutMs
-        )
-    })
-    try {
-        return await Promise.race([promise, timeout])
-    } finally {
-        if (timer) clearTimeout(timer)
-    }
-}
 
 const resultDifference = (difference: SvgDifference): VerifyResult => ({
     kind: "difference",
@@ -881,132 +840,9 @@ export function readLinesFromFile(filename: string): string[] {
     return content.split("\n")
 }
 
-export function getExplorerType(
-    explorerProgram: ExplorerProgram
-): ExplorerType {
-    const decisionMatrix = explorerProgram.decisionMatrix
-
-    // It's an indicator-based explorer if any row refers to yVariableIds
-    const yVariableIdsColumn = decisionMatrix.table.get(
-        GrapherGrammar.yVariableIds.keyword
-    )
-    if (yVariableIdsColumn.numValues > 0) return ExplorerType.Indicator
-
-    // If all rows refer to grapher IDs, it's a grapher-based explorer
-    const grapherIdsColumn = decisionMatrix.table.get(
-        GrapherGrammar.grapherId.keyword
-    )
-    if (grapherIdsColumn.numValues === decisionMatrix.numRows)
-        return ExplorerType.Grapher
-
-    // Otherwise, it's a CSV-based explorer
-    return ExplorerType.Csv
-}
-
-const loadInputTableForConfig = async (
-    dir: string,
-    args: {
-        dimensions?: OwidChartDimensionInterface[]
-        selectedEntityColors?: {
-            [entityName: string]: string | undefined
-        }
-    }
-) => {
-    if (!args.dimensions || args.dimensions.length === 0) return undefined
-
-    // Load variable data from disk for the requested dimensions
-    const variableIds = args.dimensions.map((d) => d.variableId)
-    const variableDataMap = new Map()
-
-    for (const variableId of variableIds) {
-        const dataPath = path.join(dir, `${variableId}.data.json`)
-        const metadataPath = path.join(dir, `${variableId}.metadata.json`)
-
-        if (!(await fs.pathExists(dataPath))) {
-            console.warn(
-                `Missing data file for variable ${variableId} (${dir})`
-            )
-            continue
-        }
-
-        const data = await fs.readJson(dataPath)
-        const metadata = await fs.readJson(metadataPath)
-        variableDataMap.set(variableId, { data, metadata })
-    }
-
-    // Convert to OwidTable
-    const inputTable = legacyToOwidTableAndDimensionsWithMandatorySlug(
-        variableDataMap,
-        args.dimensions,
-        args.selectedEntityColors
-    )
-
-    return inputTable
-}
-
-async function loadPartialGrapherConfigs(
-    dir: string
-): Promise<GrapherProgrammaticInterface[]> {
-    const partialGrapherConfigs: GrapherProgrammaticInterface[] = []
-
-    // Read all .config.json files in the directory
-    const files = await fs.readdir(dir)
-    const configFiles = files.filter((file) => file.endsWith(".config.json"))
-
-    for (const configFile of configFiles) {
-        const variableId = parseInt(configFile.replace(".config.json", ""))
-        if (isNaN(variableId)) continue
-
-        const configPath = path.join(dir, configFile)
-        const config = await fs.readJson(configPath)
-        partialGrapherConfigs.push(config)
-    }
-
-    return partialGrapherConfigs
-}
-
-// Patch ExplorerProgram's static tableDataLoader to support file:// URLs
-// This allows us to load CSV files from disk during testing without
-// modifying global fetch or requiring network access
-function patchExplorerTableLoader(): void {
-    ;(ExplorerProgram as any).tableDataLoader = new PromiseCache(
-        async (url: string): Promise<CoreTableInputOption> => {
-            if (url.startsWith("file://")) {
-                const filePath = url.replace("file://", "")
-                const content = await fs.readFile(filePath, "utf-8")
-                return content
-            }
-
-            const response = await fetch(url)
-            if (!response.ok) throw new Error(response.statusText)
-            const tableInput: CoreTableInputOption = url.endsWith(".json")
-                ? await response.json()
-                : await response.text()
-            return tableInput
-        }
-    )
-}
-
-export interface ExplorerViewManifest {
-    totalViews: number
-    selectedViews: number
-    viewsToTest: ExplorerChoiceParams[]
-}
-
 export interface GrapherViewsManifest {
     slugs: string[]
     dataDir: string // Relative path to the data directory (e.g., "../graphers/data")
-}
-
-async function loadViewsManifest(
-    explorerDir: string,
-    filename: string
-): Promise<ExplorerViewManifest | null> {
-    const manifestPath = path.join(explorerDir, filename)
-    if (!(await fs.pathExists(manifestPath))) {
-        return null
-    }
-    return await fs.readJson(manifestPath)
 }
 
 // Load manifest from a specific path
@@ -1096,361 +932,4 @@ export async function loadManifestViewIds(
 
     // Default: no manifest, use default data directory
     return { viewIds: null, dataDir: defaultDataDir }
-}
-
-async function getChoicesToTest(
-    explorerDir: string,
-    explorerProgram: ExplorerProgram,
-    manifestFilename?: string
-): Promise<Array<Record<string, string>>> {
-    // Use manifest to select which views to test
-    if (manifestFilename) {
-        const manifest = await loadViewsManifest(explorerDir, manifestFilename)
-        if (manifest) return manifest.viewsToTest
-    }
-
-    // No manifest - generate all possible choices
-    return explorerProgram.decisionMatrix.allDecisionsAsQueryParams()
-}
-
-export async function renderExplorerViewsToSVGsAndSave({
-    dir,
-    outDir,
-}: {
-    dir: string
-    outDir: string
-}): Promise<SvgRecord[]> {
-    // Set up file-aware table loader for local CSV files
-    patchExplorerTableLoader()
-
-    const configPath = path.join(dir, "config.tsv")
-    const tsvContent = await fs.readFile(configPath, "utf-8")
-
-    const explorerSlug = path.basename(dir)
-    const explorerProgram = new ExplorerProgram(explorerSlug, tsvContent)
-    const explorerType = getExplorerType(explorerProgram)
-
-    // Skip Grapher explorers
-    if (explorerType === ExplorerType.Grapher) return []
-
-    const width = DEFAULT_GRAPHER_WIDTH
-    const height = DEFAULT_GRAPHER_HEIGHT
-    const bounds = new Bounds(0, 0, width, height)
-
-    // Load partial grapher configs
-    const partialGrapherConfigs = await loadPartialGrapherConfigs(dir)
-
-    const explorerProps: ExplorerProps = {
-        slug: explorerSlug,
-        program: tsvContent,
-        isEmbeddedInAnOwidPage: true,
-        adminBaseUrl: "https://ourworldindata.org",
-        bakedBaseUrl: "https://ourworldindata.org",
-        bakedGrapherUrl: "https://ourworldindata.org/grapher",
-        dataApiUrl: "https://api.ourworldindata.org/v1/indicators", // Unused
-        catalogUrl: "https://catalog.ourworldindata.org", // Unused
-        partialGrapherConfigs,
-        bounds,
-        staticBounds: bounds,
-        loadInputTableForConfig: (args) => loadInputTableForConfig(dir, args),
-    }
-
-    const choicesToTest = await getChoicesToTest(dir, explorerProgram)
-
-    const svgRecords: SvgRecord[] = []
-
-    for (const choiceParams of choicesToTest) {
-        // Reset GUID for each view to ensure deterministic output
-        TESTING_ONLY_disable_guid()
-
-        // Create a fresh Explorer instance for each view
-        const explorer = new Explorer(explorerProps)
-
-        const oldRow = explorer.explorerProgram.currentlySelectedGrapherRow || 0
-
-        // Set the explorer to this specific choice combination
-        explorer.explorerProgram.decisionMatrix.setValuesFromChoiceParams(
-            choiceParams
-        )
-
-        // Skip if this is a grapher id based row
-        if (
-            explorer.explorerProgram.chartCreationMode ===
-            ExplorerChartCreationMode.FromGrapherId
-        )
-            continue
-
-        // Update the explorer
-        await explorer.reactToUserChangingSelection(oldRow)
-
-        // Generate SVG for this view
-        const svg = await explorer.grapherState.generateStaticSvg(
-            ReactDOMServer.renderToStaticMarkup
-        )
-        const preparedSvg = await prepareSvgForComparison(svg)
-
-        const queryStr = queryParamsToStr(choiceParams).replace("?", "")
-        const viewId = `${explorerSlug}?${queryStr}`
-
-        const outFilename = buildSvgOutFilename(
-            {
-                slug: explorerSlug,
-                version: 0, // Explorers don't have versions
-                width,
-                height,
-                queryStr,
-            },
-            { shouldHashQueryStr: true }
-        )
-
-        await fs.writeFile(path.join(outDir, outFilename), preparedSvg)
-
-        svgRecords.push({
-            viewId,
-            chartType: explorer.grapherState.activeTab,
-            md5: hashMd5(preparedSvg),
-            svgFilename: outFilename,
-        })
-    }
-
-    return svgRecords
-}
-
-export async function renderAndVerifyExplorerViews({
-    explorerDir,
-    explorerSlug,
-    referencesDir,
-    differencesDir,
-    verbose,
-    rmOnError,
-    manifest,
-}: {
-    explorerDir: string
-    explorerSlug: string
-    referencesDir: string
-    differencesDir: string
-    verbose: boolean
-    rmOnError: boolean
-    manifest?: string
-}): Promise<VerifyResult[]> {
-    // Set up file-aware table loader for local CSV files
-    patchExplorerTableLoader()
-
-    // Load reference CSV
-    const referenceData = await parseReferenceCsv(referencesDir)
-    const referenceDataByViewId = new Map(
-        referenceData.map((record) => [record.viewId, record])
-    )
-
-    // Load explorer config
-    const configPath = path.join(explorerDir, "config.tsv")
-    const tsvContent = await fs.readFile(configPath, "utf-8")
-    const explorerProgram = new ExplorerProgram(explorerSlug, tsvContent)
-    const explorerType = getExplorerType(explorerProgram)
-
-    // Skip Grapher explorers
-    if (explorerType === ExplorerType.Grapher) return []
-
-    const width = DEFAULT_GRAPHER_WIDTH
-    const height = DEFAULT_GRAPHER_HEIGHT
-    const bounds = new Bounds(0, 0, width, height)
-
-    // Load partial grapher configs
-    const partialGrapherConfigs = await loadPartialGrapherConfigs(explorerDir)
-
-    // Set up explorer props
-    const explorerProps: ExplorerProps = {
-        slug: explorerSlug,
-        program: tsvContent,
-        isEmbeddedInAnOwidPage: true,
-        adminBaseUrl: "https://ourworldindata.org",
-        bakedBaseUrl: "https://ourworldindata.org",
-        bakedGrapherUrl: "https://ourworldindata.org/grapher",
-        dataApiUrl: "https://api.ourworldindata.org/v1/indicators", // Unused
-        catalogUrl: "https://catalog.ourworldindata.org", // Unused
-        partialGrapherConfigs,
-        bounds,
-        staticBounds: bounds,
-        loadInputTableForConfig: (args) =>
-            loadInputTableForConfig(explorerDir, args),
-    }
-
-    const choicesToTest = await getChoicesToTest(
-        explorerDir,
-        explorerProgram,
-        manifest
-    )
-
-    const results: VerifyResult[] = []
-
-    // Process all views for this explorer sequentially
-    for (const choiceParams of choicesToTest) {
-        const queryStr = queryParamsToStr(choiceParams).replace("?", "")
-        const viewId = `${explorerSlug}?${queryStr}`
-
-        const referenceEntry = referenceDataByViewId.get(viewId)
-        if (!referenceEntry) {
-            console.warn(`No reference found for ${viewId}`)
-            continue
-        }
-
-        try {
-            logIfVerbose(verbose, `Verifying explorer view ${viewId}`)
-
-            // Reset GUID for deterministic output
-            TESTING_ONLY_disable_guid()
-
-            // Create a fresh Explorer instance for this view, reusing shared config
-            const explorer = new Explorer(explorerProps)
-
-            const oldRow =
-                explorer.explorerProgram.currentlySelectedGrapherRow || 0
-
-            // Set the explorer to this specific choice combination
-            explorer.explorerProgram.decisionMatrix.setValuesFromChoiceParams(
-                choiceParams
-            )
-
-            // Skip if this is a grapher id based row
-            if (
-                explorer.explorerProgram.chartCreationMode ===
-                ExplorerChartCreationMode.FromGrapherId
-            ) {
-                results.push({ kind: "ok" })
-                continue
-            }
-
-            // Bound each view's render+verify so one stuck view can't hang the
-            // whole worker job. Scoping the timeout here (rather than around the
-            // entire multi-view worker call) means large explorers with many
-            // views aren't misreported as timeouts just for taking a while in
-            // aggregate.
-            const validationResult = await withTimeout(
-                (async (): Promise<VerifyResult> => {
-                    // Update the explorer
-                    await explorer.reactToUserChangingSelection(oldRow)
-
-                    // Generate SVG for this view
-                    const svg = await explorer.grapherState.generateStaticSvg(
-                        ReactDOMServer.renderToStaticMarkup
-                    )
-
-                    const outFilename = buildSvgOutFilename(
-                        {
-                            slug: explorerSlug,
-                            version: 0, // Explorers don't have versions
-                            width,
-                            height,
-                            queryStr,
-                        },
-                        { shouldHashQueryStr: true }
-                    )
-
-                    const preparedSvg = await prepareSvgForComparison(svg)
-                    const svgRecord: SvgRecord = {
-                        viewId,
-                        chartType: explorer.grapherState.activeTab,
-                        md5: hashMd5(preparedSvg),
-                        svgFilename: outFilename,
-                    }
-
-                    // Verify against reference
-                    const result = await verifySvg(
-                        preparedSvg,
-                        svgRecord,
-                        referenceEntry,
-                        referencesDir,
-                        verbose
-                    )
-
-                    // If there was a difference, write the SVG
-                    if (result.kind === "difference") {
-                        if (verbose) logDifferencesToConsole(svgRecord, result)
-                        const pathFragments = path.parse(svgRecord.svgFilename)
-                        const outputPath = path.join(
-                            differencesDir,
-                            pathFragments.name + pathFragments.ext
-                        )
-                        await fs.writeFile(outputPath, preparedSvg)
-                    }
-
-                    return result
-                })(),
-                JOB_TIMEOUT_MS,
-                viewId
-            )
-
-            results.push(validationResult)
-        } catch (err) {
-            console.error(`Threw error for ${viewId}:`, err)
-            if (rmOnError) {
-                const outPath = path.join(
-                    differencesDir,
-                    referenceEntry.svgFilename
-                )
-                await fs.unlink(outPath).catch(() => {
-                    /* ignore ENOENT */
-                })
-            }
-            results.push(resultError(viewId, err as Error))
-        }
-    }
-
-    return results
-}
-
-export async function savePartialGrapherConfigs(
-    variableIds: number[],
-    outDir: string,
-    knex: KnexReadonlyTransaction
-): Promise<void> {
-    // Fetch partial grapher configs for each variable
-    type ChartRow = {
-        id: number
-        grapherConfigAdmin: string | null
-        grapherConfigETL: string | null
-    }
-    const partialGrapherConfigRows: ChartRow[] = await knexRaw(
-        knex,
-        `-- sql
-        SELECT
-            v.id,
-            cc_etl.patch AS grapherConfigETL,
-            cc_admin.patch AS grapherConfigAdmin
-        FROM variables v
-            LEFT JOIN chart_configs cc_admin ON cc_admin.id=v.grapherConfigIdAdmin
-            LEFT JOIN chart_configs cc_etl ON cc_etl.id=v.grapherConfigIdETL
-        WHERE v.id IN (?)`,
-        [variableIds]
-    )
-
-    const parseRow = (
-        row: ChartRow
-    ): { variableId: number; config: GrapherInterface } => {
-        const adminConfig: GrapherProgrammaticInterface = row.grapherConfigAdmin
-            ? parseChartConfig(row.grapherConfigAdmin)
-            : {}
-        const etlConfig: GrapherProgrammaticInterface = row.grapherConfigETL
-            ? parseChartConfig(row.grapherConfigETL)
-            : {}
-
-        const mergedConfig = mergeGrapherConfigs(etlConfig, adminConfig)
-
-        // Set the variable id as the config id
-        mergedConfig.id = row.id
-
-        // Explorers set their own dimensions, so we don't need to include them here
-        delete mergedConfig.dimensions
-
-        return { variableId: row.id, config: mergedConfig }
-    }
-
-    const partialGrapherConfigs = partialGrapherConfigRows
-        .filter((row) => row.grapherConfigAdmin || row.grapherConfigETL)
-        .map((row) => parseRow(row))
-
-    for (const { variableId, config } of partialGrapherConfigs) {
-        const configPath = path.join(outDir, `${variableId}.config.json`)
-        await fs.writeFile(configPath, JSON.stringify(config, null, 2))
-    }
 }

--- a/devTools/svgTester/verify-graphs.ts
+++ b/devTools/svgTester/verify-graphs.ts
@@ -13,107 +13,6 @@ import { JOB_TIMEOUT_MS, MAX_WORKERS } from "./utils.js"
 import { grapherSlugToExportFileKey } from "../../baker/GrapherBakingUtils.js"
 import { ALL_GRAPHER_CHART_TYPES } from "@ourworldindata/types"
 
-async function verifyExplorers(args: ReturnType<typeof parseArguments>) {
-    const testSuite = args.testSuite as utils.TestSuite
-    const verbose = args.verbose
-    const manifest = args.manifest
-
-    // Input and output directories
-    const dataDir = path.join(utils.SVG_REPO_PATH, testSuite, "data")
-    const referencesDir = path.join(
-        utils.SVG_REPO_PATH,
-        testSuite,
-        "references"
-    )
-    const differencesDir = path.join(
-        utils.SVG_REPO_PATH,
-        testSuite,
-        "differences"
-    )
-
-    if (!fs.existsSync(dataDir))
-        throw `Input directory does not exist ${dataDir}`
-    if (!fs.existsSync(referencesDir))
-        throw `Reference directory does not exist ${referencesDir}`
-    if (!fs.existsSync(differencesDir))
-        fs.mkdirSync(differencesDir, { recursive: true })
-
-    // Collect all explorer directories
-    const explorerJobs: {
-        explorerDir: string
-        explorerSlug: string
-        referencesDir: string
-        differencesDir: string
-        verbose: boolean
-        rmOnError: boolean
-        manifest?: string
-    }[] = []
-
-    const dir = await fs.opendir(dataDir)
-    for await (const entry of dir) {
-        if (!entry.isDirectory()) continue
-
-        const explorerDir = path.join(dataDir, entry.name)
-        const explorerSlug = entry.name
-
-        explorerJobs.push({
-            explorerDir,
-            explorerSlug,
-            referencesDir,
-            differencesDir,
-            manifest,
-            verbose: args.verbose,
-            rmOnError: args.rmOnError,
-        })
-    }
-
-    const jobCount = explorerJobs.length
-    if (jobCount === 0) {
-        utils.logIfVerbose(verbose, "No explorer directories found")
-        process.exit(0)
-    } else {
-        utils.logIfVerbose(
-            verbose,
-            `Verifying ${jobCount} explorer${jobCount > 1 ? "s" : ""}...`
-        )
-    }
-
-    const pool = workerpool.pool(__dirname + "/worker.ts", {
-        minWorkers: 2,
-        maxWorkers: MAX_WORKERS,
-        workerThreadOpts: {
-            execArgv: ["--require", "tsx"],
-        },
-    })
-
-    const validationResultsArrays: utils.VerifyResult[][] = await Promise.all(
-        explorerJobs.map((job) =>
-            // The per-view timeout lives inside renderAndVerifyExplorerViews,
-            // so we deliberately don't wrap this whole (multi-view) call in
-            // .timeout() — a large explorer with many views could legitimately
-            // exceed the per-view budget in aggregate.
-            pool
-                .exec("renderAndVerifyExplorerViews", [job])
-                .catch((err: Error) => [
-                    utils.resultError(job.explorerSlug, err),
-                ])
-        )
-    )
-
-    await pool.terminate()
-
-    // Flatten the array of arrays
-    const validationResults = validationResultsArrays.flat()
-
-    utils.logIfVerbose(verbose, "Verifications completed")
-
-    const exitCode = utils.displayVerifyResultsAndGetExitCode(
-        validationResults,
-        verbose
-    )
-    process.exit(exitCode)
-}
-
 async function verifyGraphers(args: ReturnType<typeof parseArguments>) {
     try {
         // Test suite
@@ -262,7 +161,6 @@ async function main(args: ReturnType<typeof parseArguments>) {
         .with("grapher-views", () => verifyGraphers(args))
         .with("mdims", () => verifyGraphers(args))
         .with("thumbnails", () => verifyGraphers(args))
-        .with("explorers", () => verifyExplorers(args))
         .exhaustive()
 }
 

--- a/devTools/svgTester/worker.ts
+++ b/devTools/svgTester/worker.ts
@@ -9,6 +9,4 @@ import * as utils from "./utils.js"
 workerpool.worker({
     renderAndVerifySvg: utils.renderAndVerifySvg,
     renderSvgAndSave: utils.renderSvgAndSave,
-    renderExplorerViewsToSVGsAndSave: utils.renderExplorerViewsToSVGsAndSave,
-    renderAndVerifyExplorerViews: utils.renderAndVerifyExplorerViews,
 })


### PR DESCRIPTION
> _Written by Anthropic Claude Opus 5 — @sophiamersmann at the wheel._

Explorers are being removed from the codebase, so the SVG tester's explorers suite goes now rather than being carried through the planned tester rewrite. This is the owid-grapher half of that removal.

## ⚠️ Merge order

**Requires https://github.com/owid/ops/pull/594 to land first.** That PR stops `svg-tester.sh` from invoking the suite. If this merges first, yargs rejects the `explorers` positional argument, the suite exits non-zero, and because `set +e` is active at that point `exit_code_explorers` propagates — turning the SVG tester step red on every open PR.

Since `staging-script` resolves the ops branch whose name matches the grapher branch, this branch's staging build already picks up the matching ops branch, so both halves get exercised together before either merges.

## Why this suite was the awkward one

It was the only suite with a second render path. One `pool.exec("renderAndVerifyExplorerViews", …)` handled an *entire* explorer — many views rendered sequentially — so workerpool's job-level `.timeout()` couldn't distinguish a wedged view from a legitimately large explorer. That's why it carried its own inner per-view `withTimeout`, and why the explorer branch deliberately didn't chain `.timeout()` on its exec.

The remaining suites are one render per job (`verifyJobs` is built from the flattened `chartViewsToGenerate`, including the expanded `grapher-views` and `thumbnails` cases), so they stay bounded by `.timeout(JOB_TIMEOUT_MS)` at `verify-graphs.ts:128`. `withTimeout` had exactly one call site, inside `renderAndVerifyExplorerViews`, so it goes too — nothing regresses.

## What's removed

- **`utils.ts`** — `renderExplorerViewsToSVGsAndSave`, `renderAndVerifyExplorerViews`, and the helpers they were the sole callers of: `getExplorerType`, `loadInputTableForConfig`, `loadPartialGrapherConfigs`, `patchExplorerTableLoader`, `loadViewsManifest`, `ExplorerViewManifest`, `getChoicesToTest`, `savePartialGrapherConfigs`, `withTimeout`. Plus `explorers` from `TEST_SUITES` and the orphaned imports.
- **`dump-data.ts`** — `dumpExplorerWithData`, `saveExplorerConfigAndData`, `writeManifestFile`, and `allocateViewCount` / `selectViewsToTest` (called only from inside `dumpExplorerWithData`); the `.with("explorers", …)` match arm; the `targetViews` option.
- **`verify-graphs.ts`** / **`export-graphs.ts`** / **`worker.ts`** — `verifyExplorers`, `exportExplorers`, their match arms, the two explorer worker exports.
- **`create-compare-view.ts`** — the `isExplorer` URL branching.
- **`Makefile`** — the `svgtest.explorers` target, its `.PHONY` and help entries, and the explorers block in `svgtest.full`.
- **`refresh.sh`** / **`readme.md`** — the explorers suite and its documentation.

Also drops the tester's dependencies on `@ourworldindata/explorer`, `explorerAdminServer` and `db/model/ExplorerCatalogResolver` — the latter two were imported without being declared in `devTools/svgTester/tsconfig.json`.

## Verification

- `yarn typecheck`, `yarn testLintChanged`, `yarn testFormatChanged` all clean. `noUnusedLocals` did the heavy lifting for finding orphaned symbols — worth deleting the functions first and letting `tsc` enumerate the rest rather than tracing callers by hand.
- `yarn test run` green (155 files, 2212 tests).
- `bash -n devTools/svgTester/refresh.sh` OK.
- Negative check: `verify-graphs.ts explorers` now exits with `Invalid values: Argument: testSuite, Given: "explorers", Choices: "graphers", "grapher-views", "mdims", "thumbnails"`.
- I did **not** run `make svgtest`, since it force-resets `../owid-grapher-svgs` to `origin/master`. Worth one run before merge on a machine where that's safe.

## Follow-ups, not in this PR

- **`../owid-grapher-svgs/explorers/` still exists** (3.1 GB of the checkout). Removing it is a separate step, folded into the next reference refresh so the remaining suites get regenerated at the same time. Note that removes it from new `--depth=1` container clones but doesn't shrink the pack, since those blobs stay reachable from history.
- **`apps/owidbot/grapher.py` in owid/etl** still lists explorers; until that's dropped it reports `_skipped_`, which is accurate.
- **`export-graphs.ts` has no per-job timeout at all** (`pool.exec("renderSvgAndSave", …)` is unwrapped at `:117` and `:129`). Pre-existing, unrelated to this change, and it only bites during a refresh — but it's inconsistent with the verify path and worth a one-liner sometime.