### PR TITLE
🎉🤖 record each verify run's outcome in verify-results.json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -406,7 +406,7 @@ unittest: node_modules
 
 svgtest.reset: ../owid-grapher-svgs
 	@echo '==> Resetting owid-grapher-svgs repo to a clean state'
-	cd ../owid-grapher-svgs && git fetch && git checkout -f master && git reset --hard origin/master && git clean -fd
+	cd ../owid-grapher-svgs && git fetch && git checkout -f master && git reset --hard origin/master && git clean -fdx
 
 svgtest: svgtest.reset node_modules
 	@echo '==> Generating SVG test report for graphers'

--- a/devTools/svgTester/utils.ts
+++ b/devTools/svgTester/utils.ts
@@ -17,6 +17,7 @@ import {
 import fs, { stat } from "fs-extra"
 import path from "path"
 import stream from "stream"
+import { execFileSync } from "child_process"
 import {
     buildSvgOutFilename,
     initGrapherForSvgExport,
@@ -58,6 +59,8 @@ export const TEST_SUITE_DESCRIPTION =
 
 const CONFIG_FILENAME = "config.json"
 const RESULTS_FILENAME = "results.csv"
+
+export const VERIFY_RESULTS_FILENAME = "verify-results.json"
 
 export const finished = util.promisify(stream.finished) // (A)
 
@@ -135,6 +138,9 @@ export type SvgRecord = {
 
 export interface SvgDifference {
     viewId: string
+    queryStr?: string
+    chartType: GrapherTabName | undefined
+    svgFilename: string
     startIndex: number
     referenceSvgFragment: string
     newSvgFragment: string
@@ -222,6 +228,9 @@ export async function verifySvg(
     logIfVerbose(verbose, `${newSvgRecord.viewId} had differences`)
     return resultDifference({
         viewId: newSvgRecord.viewId,
+        queryStr: newSvgRecord.resolvedQueryStr ?? newSvgRecord.queryStr,
+        chartType: newSvgRecord.chartType,
+        svgFilename: newSvgRecord.svgFilename,
         startIndex: firstDiffIndex,
         referenceSvgFragment: preparedReferenceSvg.substring(
             firstDiffIndex - 20,
@@ -626,7 +635,7 @@ export async function loadReferenceSvg(
         referenceSvgRecord.svgFilename
     )
     if (!fs.existsSync(referenceFilename))
-        throw `Input directory does not exist ${referenceFilename}`
+        throw `Reference SVG does not exist ${referenceFilename}`
     const svg = await fs.readFile(referenceFilename, "utf-8")
     return svg
 }
@@ -784,6 +793,185 @@ export async function renderAndVerifySvg({
             })
         }
         return Promise.resolve(resultError(referenceEntry.viewId, err as Error))
+    }
+}
+
+// "running" is written before the first render and overwritten when the run
+// finishes. A file left in that state means the process died before it could
+// report - killed by the `timeout` wrapper or Buildkite cancelling the step, say -
+// which is otherwise indistinguishable from a suite that was never selected.
+export type VerifyRunStatus = "running" | "ok" | "differences" | "error"
+
+export interface VerifyDifferenceEntry {
+    viewId: string
+    queryStr?: string
+    chartType?: string
+    svgFilename: string
+}
+
+export interface VerifyErrorEntry {
+    viewId: string
+    kind: "timeout" | "render"
+    message: string
+}
+
+export interface VerifyRunSummary {
+    suite: TestSuite
+    status: VerifyRunStatus
+    startedAt: string
+    durationMs: number
+    grapherCommit: string | null
+    svgsCommit: string | null
+    counts: {
+        total: number
+        ok: number
+        differences: number
+        errors: number
+    }
+    differences: VerifyDifferenceEntry[]
+    errors: VerifyErrorEntry[]
+}
+
+// A `.timeout()` breach and a render crash both arrive through the same `.catch`
+// in verify-graphs.ts, so the only thing distinguishing them is the error name
+// workerpool gives a timeout. Errors crossing a worker boundary are structured
+// clones rather than real Error instances, hence the defensive access.
+function classifyVerifyError(error: Error): VerifyErrorEntry["kind"] {
+    return error?.name === "TimeoutError" ? "timeout" : "render"
+}
+
+export function summariseVerifyResults(
+    validationResults: VerifyResult[],
+    options: {
+        suite: TestSuite
+        startedAt: Date
+        durationMs: number
+    }
+): VerifyRunSummary {
+    const differences = validationResults
+        .filter((result) => result.kind === "difference")
+        .map(({ difference }) => ({
+            viewId: difference.viewId,
+            // The default view has an empty query string; omit rather than
+            // recording `""`.
+            queryStr: difference.queryStr || undefined,
+            chartType: difference.chartType,
+            svgFilename: difference.svgFilename,
+        }))
+
+    const errors = validationResults
+        .filter((result) => result.kind === "error")
+        .map((result) => ({
+            viewId: result.viewId,
+            kind: classifyVerifyError(result.error),
+            // The stack stays on stderr for the CI log; this file is a status
+            // report, not a crash dump.
+            message: String(result.error?.message ?? result.error),
+        }))
+
+    // An errored suite is reported as errored even if it also found differences:
+    // we can't claim to know what changed when part of the run didn't complete.
+    const status: VerifyRunStatus = errors.length
+        ? "error"
+        : differences.length
+          ? "differences"
+          : "ok"
+
+    return {
+        suite: options.suite,
+        status,
+        startedAt: options.startedAt.toISOString(),
+        durationMs: options.durationMs,
+        grapherCommit: resolveCommit(),
+        svgsCommit: resolveCommit(SVG_REPO_PATH),
+        counts: {
+            total: validationResults.length,
+            ok: validationResults.length - differences.length - errors.length,
+            differences: differences.length,
+            errors: errors.length,
+        },
+        differences,
+        errors,
+    }
+}
+
+// Written next to verify-graphs.log so both live with the suite they describe.
+// Nothing commits it: create_report/commit_differences in svg-tester.sh add
+// explicit paths only.
+export async function writeVerifyResults(
+    testSuiteDir: string,
+    summary: VerifyRunSummary
+): Promise<void> {
+    const outPath = path.join(testSuiteDir, VERIFY_RESULTS_FILENAME)
+    await fs.writeFile(outPath, JSON.stringify(summary, null, 2) + "\n")
+}
+
+// Written before the first render so that the file's existence proves the suite
+// started. If the process is killed before it can overwrite this - the `timeout`
+// wrapper in svg-tester.sh, a cancelled Buildkite step, kill_stale_runs - the
+// leftover "running" status is what tells the reader it died mid-run. Deliberately
+// not a signal handler: `timeout` signals `yarn`, not the node process underneath
+// it, and nothing can catch the SIGKILL that follows --kill-after anyway.
+// The counts are zeroed placeholders and mean nothing until the run finishes.
+export async function writeVerifyRunStarted(
+    testSuiteDir: string,
+    suite: TestSuite,
+    startedAt: Date
+): Promise<void> {
+    await writeVerifyResults(testSuiteDir, {
+        suite,
+        status: "running",
+        startedAt: startedAt.toISOString(),
+        durationMs: 0,
+        grapherCommit: resolveCommit(),
+        svgsCommit: resolveCommit(SVG_REPO_PATH),
+        counts: { total: 0, ok: 0, differences: 0, errors: 0 },
+        differences: [],
+        errors: [],
+    })
+}
+
+// For failures that happen before or around the run itself (missing directories,
+// an unreadable reference CSV, the job-count sanity check) rather than for a
+// single chart. Without this, such a run leaves no results file at all and is
+// indistinguishable from a suite that was never started.
+export async function writeVerifyRunFailure(
+    testSuiteDir: string,
+    suite: TestSuite,
+    error: unknown
+): Promise<void> {
+    const startedAt = new Date()
+    await writeVerifyResults(testSuiteDir, {
+        suite,
+        status: "error",
+        startedAt: startedAt.toISOString(),
+        durationMs: 0,
+        grapherCommit: resolveCommit(),
+        svgsCommit: resolveCommit(SVG_REPO_PATH),
+        counts: { total: 0, ok: 0, differences: 0, errors: 1 },
+        differences: [],
+        errors: [
+            {
+                viewId: "",
+                kind: "render",
+                message: String(error instanceof Error ? error.message : error),
+            },
+        ],
+    })
+}
+
+// Best-effort: in CI the commit is handed to us, locally we ask git, and if
+// neither works the field is null rather than the run failing over provenance.
+function resolveCommit(cwd?: string): string | null {
+    if (!cwd && process.env.BUILDKITE_COMMIT)
+        return process.env.BUILDKITE_COMMIT
+    try {
+        return execFileSync("git", ["rev-parse", "HEAD"], {
+            cwd,
+            encoding: "utf-8",
+        }).trim()
+    } catch {
+        return null
     }
 }
 

--- a/devTools/svgTester/verify-graphs.ts
+++ b/devTools/svgTester/verify-graphs.ts
@@ -49,8 +49,14 @@ async function verifyGraphers(args: ReturnType<typeof parseArguments>) {
         if (!fs.existsSync(dataDir))
             throw `Input directory does not exist ${dataDir}`
         if (!fs.existsSync(referencesDir))
-            throw `Reference directory does not exist ${dataDir}`
+            throw `Reference directory does not exist ${referencesDir}`
         if (!fs.existsSync(differencesDir)) fs.mkdirSync(differencesDir)
+
+        // Claim the results file up front: from here on its absence means the
+        // suite never started, and a lingering "running" status means it was
+        // killed before it could report.
+        const startedAt = new Date()
+        await utils.writeVerifyRunStarted(testSuiteDir, testSuite, startedAt)
 
         const chartIdsToProcess = await utils.selectChartIdsToProcess(dataDir, {
             viewIds: targetViewIds ?? manifestViewIds ?? undefined,
@@ -100,6 +106,16 @@ async function verifyGraphers(args: ReturnType<typeof parseArguments>) {
         const jobCount = verifyJobs.length
         if (jobCount === 0) {
             utils.logIfVerbose(verbose, "No matching configs found")
+            // Nothing to do is a legitimate outcome, but it still has to
+            // overwrite the "running" placeholder written above.
+            await utils.writeVerifyResults(
+                testSuiteDir,
+                utils.summariseVerifyResults([], {
+                    suite: testSuite,
+                    startedAt,
+                    durationMs: Date.now() - startedAt.getTime(),
+                })
+            )
             process.exit(0)
         } else {
             utils.logIfVerbose(
@@ -138,6 +154,15 @@ async function verifyGraphers(args: ReturnType<typeof parseArguments>) {
 
         utils.logIfVerbose(verbose, "Verifications completed")
 
+        await utils.writeVerifyResults(
+            testSuiteDir,
+            utils.summariseVerifyResults(validationResults, {
+                suite: testSuite,
+                startedAt,
+                durationMs: Date.now() - startedAt.getTime(),
+            })
+        )
+
         const exitCode = utils.displayVerifyResultsAndGetExitCode(
             validationResults,
             verbose
@@ -147,6 +172,22 @@ async function verifyGraphers(args: ReturnType<typeof parseArguments>) {
         process.exit(exitCode)
     } catch (error) {
         console.error("Encountered an error: ", error)
+        // Record the failure too, so that "the suite never got to run" is
+        // distinguishable from "the suite ran and found nothing" by whoever
+        // reads the results file. Best-effort: if even this write fails there's
+        // nothing useful left to do but exit.
+        await utils
+            .writeVerifyRunFailure(
+                path.join(utils.SVG_REPO_PATH, args.testSuite),
+                args.testSuite as utils.TestSuite,
+                error
+            )
+            .catch((writeError) => {
+                console.error(
+                    "Could not write the results file either: ",
+                    writeError
+                )
+            })
         // This call to exit is necessary for some unknown reason to make sure that the process terminates. It
         // was not required before introducing the multiprocessing library.
         process.exit(-1)


### PR DESCRIPTION
> _Written by Anthropic Claude Opus 5 — @sophiamersmann at the wheel._

First step of the SVG tester rewrite's status contract. Purely additive: nothing reads the new file yet, and stdout and the exit code are unchanged, so this can't affect any current behaviour.

## Why

The SVG tester reports its outcome only as stdout lines plus an exit code, and both are lossy:

- **The exit code is a count, and POSIX masks it to 8 bits.** `displayVerifyResultsAndGetExitCode` returns `errorResults.length + differenceResults.length`, passed straight to `process.exit`. A run with exactly **256** problems exits 0 — the Buildkite step goes green and owidbot drops the report link (it only emits one when the status is ❌). 512 and 768 too. With ~4,500 charts in the graphers suite, a sweeping layout change lands in that range routinely.
- **Error output inflates the difference count.** owidbot counts differences as `len(f.readlines())` over `verify-graphs.log`, but that function prints one line per difference *and* dumps whole `Error` objects (stack traces included) for failures. The count is only correct when nothing errored.
- **A killed run leaves nothing at all**, so "the graphers suite was killed after 55 minutes" is indistinguishable from "this suite wasn't selected".

## What this adds

One file per suite at `{SVG_REPO_PATH}/{suite}/verify-results.json`, next to `verify-graphs.log`:

```json
{
  "suite": "graphers",
  "status": "differences",
  "startedAt": "2026-08-05T14:51:16.040Z",
  "durationMs": 1731,
  "grapherCommit": "e179adb87f…",
  "svgsCommit": "6f34881cee…",
  "counts": { "total": 2, "ok": 1, "differences": 1, "errors": 0 },
  "differences": [
    { "viewId": "life-expectancy", "chartType": "LineChart",
      "svgFilename": "life-expectancy_v64_850x600.svg" }
  ],
  "errors": []
}
```

Named `verify-results.json`, not `results.json`, so it doesn't read as a sibling of `references/results.csv` (the md5 index), which it has nothing to do with.

**The file is claimed up front with `status: "running"`** and overwritten when the run finishes. That makes three cases distinguishable: no file (the suite never ran), `running` (it started and was killed before it could report — the `timeout --signal=TERM --kill-after=60` wrapper in `svg-tester.sh`, a cancelled Buildkite step, or `kill_stale_runs` reaping a superseded build), and a real terminal status.

Deliberately *not* a signal handler: `timeout` signals `yarn`, not the node process beneath it, so a `SIGTERM` hook may never fire — and nothing can catch the `SIGKILL` that follows `--kill-after` anyway. Writing up front is immune to both.

Errors distinguish `kind: "timeout"` from `"render"` via workerpool's `TimeoutError`; today a `.timeout(JOB_TIMEOUT_MS)` breach and a render crash arrive through the same `.catch` and are indistinguishable.

## Also in here

- `SvgDifference` gains `queryStr`, `chartType` and `svgFilename` — the fields the summary needs, taken from the `SvgRecord` already in scope in `verifySvg`.
- Two error messages corrected, since they now surface *in* the status file: a missing `references/` directory reported the **data** directory's path, and a missing reference **file** said "Input directory does not exist".

## Verified

Six cases against the real graphers suite:

| Case | Result |
| --- | --- |
| Two charts, no differences | `ok`, counts 2/2/0/0 |
| Reference genuinely mismatching | `differences` with a populated `differences[]` |
| Reference SVG missing for one chart | `error`, `kind: "render"`, alongside `ok: 1` |
| `references/` directory missing | `error`, written from the `catch` block |
| SIGTERM then SIGKILL 20 s into a full run | file left at `status: "running"` |
| `--viewIds no-such-chart-slug` | `ok` with `total: 0` — placeholder correctly overwritten |

`yarn typecheck`, `yarn testLintChanged`, `yarn testFormatChanged` all clean.

## Notes for the reviewer

- **The file should be gitignored in `owid-grapher-svgs`** (already done). CI never commits it — `create_report`/`commit_differences` add explicit paths — but `refresh.sh` runs `git add --all` twice per suite, which would otherwise commit a stale results file into a reference-data commit.
- **No `schemaVersion`.** Nothing consumes the format yet, so versioning it would be speculative; worth revisiting only if a future viewer ever breaks on an old run.
- **`grapherCommit` is not meaningful on a dev machine using GitButler**, where `git rev-parse HEAD` returns the synthetic workspace commit. In CI it's `BUILDKITE_COMMIT`, which is what Phase 3 will key R2 objects on.

Next: owidbot reads this file and the log parsing goes away; then the exit code becomes 0-for-differences / non-zero-only-for-malfunction, which also requires restructuring the `svgtest` Makefile targets, since they currently generate their HTML report only when verify exits non-zero.