### PR TITLE
🔨🤖 give the SVG tester distinct exit codes for differences and failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ ifdef WRANGLER_PORT
 WRANGLER_PORT := $(strip $(WRANGLER_PORT))
 endif
 
-.PHONY: help up up.headless up.worktree setup.worktree require.worktree up.full down down.headless down.worktree refresh refresh.wp refresh.private refresh.full migrate svgtest svgtest.reset svgtest.graphers svgtest.grapher-views svgtest.mdims svgtest.thumbnails bdd bdd.ui check-not-prod
+.PHONY: help up up.headless up.worktree setup.worktree require.worktree up.full down down.headless down.worktree refresh refresh.wp refresh.private refresh.full migrate svgtest svgtest.reset svgtest.grapher-views svgtest.mdims svgtest.thumbnails bdd bdd.ui check-not-prod
 
 help:
 	@echo 'Available commands:'
@@ -411,49 +411,93 @@ svgtest.reset: ../owid-grapher-svgs
 svgtest: svgtest.reset node_modules
 	@echo '==> Generating SVG test report for graphers'
 
-	@# generate a full new set of svgs and create an HTML report if there are differences
-	yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/verify-graphs.ts \
-		|| (yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/create-compare-view.ts && open ../owid-grapher-svgs/graphers/differences.html)
+	@# generate a full new set of svgs, then report on any differences
+	yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/verify-graphs.ts || [ $$? -eq 2 ]
+
+	@if [ -n "$$(ls -A ../owid-grapher-svgs/graphers/differences 2>/dev/null)" ]; then \
+		yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/create-compare-view.ts graphers && \
+		open ../owid-grapher-svgs/graphers/differences.html; \
+	else \
+		echo '==> No differences (graphers)'; \
+	fi
 
 svgtest.full: svgtest.reset node_modules
 	@echo '==> Generating full SVG test report'
 
 	@# run test suite for stand-alone graphers
-	yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/verify-graphs.ts \
-		|| yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/create-compare-view.ts
+	yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/verify-graphs.ts || [ $$? -eq 2 ]
+
+	@if [ -n "$$(ls -A ../owid-grapher-svgs/graphers/differences 2>/dev/null)" ]; then \
+		yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/create-compare-view.ts graphers; \
+	else \
+		echo '==> No differences (graphers)'; \
+	fi
 
 	@# run test suite for grapher views
-	yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/verify-graphs.ts grapher-views \
-		|| yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/create-compare-view.ts grapher-views
+	yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/verify-graphs.ts grapher-views || [ $$? -eq 2 ]
+
+	@if [ -n "$$(ls -A ../owid-grapher-svgs/grapher-views/differences 2>/dev/null)" ]; then \
+		yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/create-compare-view.ts grapher-views; \
+	else \
+		echo '==> No differences (grapher-views)'; \
+	fi
 
 	@# run test suite for mdims
-	yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/verify-graphs.ts mdims \
-		|| yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/create-compare-view.ts mdims
+	yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/verify-graphs.ts mdims || [ $$? -eq 2 ]
+
+	@if [ -n "$$(ls -A ../owid-grapher-svgs/mdims/differences 2>/dev/null)" ]; then \
+		yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/create-compare-view.ts mdims; \
+	else \
+		echo '==> No differences (mdims)'; \
+	fi
 
 	@# run test suite for thumbnails
-	yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/verify-graphs.ts thumbnails \
-		|| yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/create-compare-view.ts thumbnails
+	yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/verify-graphs.ts thumbnails || [ $$? -eq 2 ]
+
+	@if [ -n "$$(ls -A ../owid-grapher-svgs/thumbnails/differences 2>/dev/null)" ]; then \
+		yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/create-compare-view.ts thumbnails; \
+	else \
+		echo '==> No differences (thumbnails)'; \
+	fi
 
 svgtest.grapher-views: svgtest.reset node_modules
 	@echo '==> Generating SVG test report for grapher-views'
 
-	@# run test suite for grapher-views and create an HTML report if there are differences
-	yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/verify-graphs.ts grapher-views \
-		|| (yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/create-compare-view.ts grapher-views && open ../owid-grapher-svgs/grapher-views/differences.html)
+	@# run test suite for grapher-views, then report on any differences
+	yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/verify-graphs.ts grapher-views || [ $$? -eq 2 ]
+
+	@if [ -n "$$(ls -A ../owid-grapher-svgs/grapher-views/differences 2>/dev/null)" ]; then \
+		yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/create-compare-view.ts grapher-views && \
+		open ../owid-grapher-svgs/grapher-views/differences.html; \
+	else \
+		echo '==> No differences (grapher-views)'; \
+	fi
 
 svgtest.mdims: svgtest.reset node_modules
 	@echo '==> Generating SVG test report for mdims'
 
-	@# run test suite for mdims and create an HTML report if there are differences
-	yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/verify-graphs.ts mdims \
-		|| (yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/create-compare-view.ts mdims && open ../owid-grapher-svgs/mdims/differences.html)
+	@# run test suite for mdims, then report on any differences
+	yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/verify-graphs.ts mdims || [ $$? -eq 2 ]
+
+	@if [ -n "$$(ls -A ../owid-grapher-svgs/mdims/differences 2>/dev/null)" ]; then \
+		yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/create-compare-view.ts mdims && \
+		open ../owid-grapher-svgs/mdims/differences.html; \
+	else \
+		echo '==> No differences (mdims)'; \
+	fi
 
 svgtest.thumbnails: svgtest.reset node_modules
 	@echo '==> Generating SVG test report for thumbnails'
 
-	@# run test suite for thumbnails and create an HTML report if there are differences
-	yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/verify-graphs.ts thumbnails \
-		|| (yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/create-compare-view.ts thumbnails && open ../owid-grapher-svgs/thumbnails/differences.html)
+	@# run test suite for thumbnails, then report on any differences
+	yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/verify-graphs.ts thumbnails || [ $$? -eq 2 ]
+
+	@if [ -n "$$(ls -A ../owid-grapher-svgs/thumbnails/differences 2>/dev/null)" ]; then \
+		yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/create-compare-view.ts thumbnails && \
+		open ../owid-grapher-svgs/thumbnails/differences.html; \
+	else \
+		echo '==> No differences (thumbnails)'; \
+	fi
 
 node_modules: package.json yarn.lock yarn.config.cjs
 	@echo '==> Installing packages'

--- a/devTools/svgTester/readme.md
+++ b/devTools/svgTester/readme.md
@@ -82,7 +82,8 @@ Use `verify-graphs.ts` to check SVG outputs against the reference export. The sc
 - Processes the SVG to remove non-deterministic elements
 - Compares the MD5 hash with the reference
 - If there's a difference, saves the new SVG to the differences directory and reports it
-- Returns a non-zero exit code if any differences are found
+- Writes `verify-results.json` recording the outcome: status, counts, which views differed and which errored
+- Returns a non-zero exit code only if the tester itself malfunctioned (a render crashed, a reference was missing, a job timed out). Differences are the expected output and exit 0 — read `verify-results.json` to find out how many there were
 
 The script works with test suites stored in the directory structure:
 
@@ -162,4 +163,4 @@ This should be done periodically (e.g., monthly) or when significant data/config
 
 ## Notes
 
-For all tools use the verbose flag if you want to see what the tool is doing, otherwise there is no output to stdout except for failing graph ids in the verify-graphs script for easy bash collection of failing graphs.
+For all tools use the verbose flag if you want to see what the tool is doing. Otherwise `verify-graphs.ts` prints one affected view id per line to stdout, so failing ids can be collected with a shell pipeline, and counts to stderr. That output is for humans and pipelines only — anything that needs to act on the result should read `verify-results.json` instead.

--- a/devTools/svgTester/utils.ts
+++ b/devTools/svgTester/utils.ts
@@ -166,10 +166,8 @@ export function logIfVerbose(verbose: boolean, message: string, param?: any) {
 function findFirstDiffIndex(a: string, b: string): number {
     let i = 0
     while (i < a.length && i < b.length && a[i] === b[i]) i++
-    if (a.length === b.length && a.length === i) {
-        console.warn("No difference found even though hash was different!")
-        i = -1
-    }
+    // No difference found even though hash was different
+    if (a.length === b.length && a.length === i) i = -1
     return i
 }
 
@@ -840,6 +838,13 @@ function classifyVerifyError(error: Error): VerifyErrorEntry["kind"] {
     return error?.name === "TimeoutError" ? "timeout" : "render"
 }
 
+// Several failure paths in here `throw` a plain string rather than an Error, and
+// errors crossing a worker boundary are structured clones, so `.message` is not
+// something we can count on.
+function verifyErrorMessage(error: Error): string {
+    return String(error?.message ?? error)
+}
+
 export function summariseVerifyResults(
     validationResults: VerifyResult[],
     options: {
@@ -866,7 +871,7 @@ export function summariseVerifyResults(
             kind: classifyVerifyError(result.error),
             // The stack stays on stderr for the CI log; this file is a status
             // report, not a crash dump.
-            message: String(result.error?.message ?? result.error),
+            message: verifyErrorMessage(result.error),
         }))
 
     // An errored suite is reported as errored even if it also found differences:
@@ -975,12 +980,21 @@ function resolveCommit(cwd?: string): string | null {
     }
 }
 
-export function displayVerifyResultsAndGetExitCode(
+export const EXIT_CODE_DIFFERENCES = 2
+export const EXIT_CODE_ERROR = 1
+
+export function verifyExitCode(summary: VerifyRunSummary): number {
+    if (summary.counts.errors > 0) return EXIT_CODE_ERROR
+    if (summary.counts.differences > 0) return EXIT_CODE_DIFFERENCES
+    return 0
+}
+
+// Human-facing output. The machine-readable version of all this is
+// verify-results.json.
+export function reportVerifyResults(
     validationResults: VerifyResult[],
     verbose: boolean
-): number {
-    let returnCode: number
-
+): void {
     const errorResults = validationResults.filter(
         (result) => result.kind === "error"
     )
@@ -994,33 +1008,32 @@ export function displayVerifyResultsAndGetExitCode(
             verbose,
             `There were no differences in all graphs processed`
         )
-        returnCode = 0
-    } else {
-        if (errorResults.length) {
-            console.warn(
-                `${errorResults.length} graphs threw errors: ${errorResults
-                    .map((err) => err.viewId)
-                    .join()}`
-            )
-            for (const result of errorResults) {
-                console.log(result.viewId?.toString(), result.error) // write to stdout one grapher id per file for easy piping to other processes
-            }
-        }
-        if (differenceResults.length) {
-            console.warn(
-                `${
-                    differenceResults.length
-                } graphs had differences: ${differenceResults
-                    .map((err) => err.difference.viewId)
-                    .join()}`
-            )
-            for (const result of differenceResults) {
-                console.log("", result.difference.viewId) // write to stdout one grapher id per file for easy piping to other processes
-            }
-        }
-        returnCode = errorResults.length + differenceResults.length
+        return
     }
-    return returnCode
+
+    if (errorResults.length) {
+        console.warn(
+            `${errorResults.length} graphs threw errors: ${errorResults
+                .map((err) => err.viewId)
+                .join()}`
+        )
+        for (const result of errorResults) {
+            console.log(`${result.viewId}: ${verifyErrorMessage(result.error)}`)
+        }
+    }
+
+    if (differenceResults.length) {
+        console.warn(
+            `${
+                differenceResults.length
+            } graphs had differences: ${differenceResults
+                .map((err) => err.difference.viewId)
+                .join()}`
+        )
+        for (const result of differenceResults) {
+            console.log(result.difference.viewId)
+        }
+    }
 }
 
 export function readLinesFromFile(filename: string): string[] {

--- a/devTools/svgTester/utils.ts
+++ b/devTools/svgTester/utils.ts
@@ -1012,24 +1012,14 @@ export function reportVerifyResults(
     }
 
     if (errorResults.length) {
-        console.warn(
-            `${errorResults.length} graphs threw errors: ${errorResults
-                .map((err) => err.viewId)
-                .join()}`
-        )
+        console.warn(`${errorResults.length} graphs threw errors`)
         for (const result of errorResults) {
             console.log(`${result.viewId}: ${verifyErrorMessage(result.error)}`)
         }
     }
 
     if (differenceResults.length) {
-        console.warn(
-            `${
-                differenceResults.length
-            } graphs had differences: ${differenceResults
-                .map((err) => err.difference.viewId)
-                .join()}`
-        )
+        console.warn(`${differenceResults.length} graphs had differences`)
         for (const result of differenceResults) {
             console.log(result.difference.viewId)
         }

--- a/devTools/svgTester/verify-graphs.ts
+++ b/devTools/svgTester/verify-graphs.ts
@@ -154,22 +154,18 @@ async function verifyGraphers(args: ReturnType<typeof parseArguments>) {
 
         utils.logIfVerbose(verbose, "Verifications completed")
 
-        await utils.writeVerifyResults(
-            testSuiteDir,
-            utils.summariseVerifyResults(validationResults, {
-                suite: testSuite,
-                startedAt,
-                durationMs: Date.now() - startedAt.getTime(),
-            })
-        )
+        const summary = utils.summariseVerifyResults(validationResults, {
+            suite: testSuite,
+            startedAt,
+            durationMs: Date.now() - startedAt.getTime(),
+        })
+        await utils.writeVerifyResults(testSuiteDir, summary)
 
-        const exitCode = utils.displayVerifyResultsAndGetExitCode(
-            validationResults,
-            verbose
-        )
+        utils.reportVerifyResults(validationResults, verbose)
+
         // This call to exit is necessary for some unknown reason to make sure that the process terminates. It
         // was not required before introducing the multiprocessing library.
-        process.exit(exitCode)
+        process.exit(utils.verifyExitCode(summary))
     } catch (error) {
         console.error("Encountered an error: ", error)
         // Record the failure too, so that "the suite never got to run" is
@@ -190,7 +186,7 @@ async function verifyGraphers(args: ReturnType<typeof parseArguments>) {
             })
         // This call to exit is necessary for some unknown reason to make sure that the process terminates. It
         // was not required before introducing the multiprocessing library.
-        process.exit(-1)
+        process.exit(1)
     }
 }
 


### PR DESCRIPTION
> _Written by Anthropic Claude Opus 5 — @sophiamersmann at the wheel._

Follows #6911, which moved the counts into `verify-results.json`. This makes the exit code mean something precise.

## Why

`verify-graphs.ts` returned `differences + errors` as its exit code, and POSIX masks exit status to 8 bits. A run with exactly **256** problems exited 0 — the Buildkite step went green, and owidbot dropped the report link (it only emits one when the status is ❌). 512 and 768 did the same. Across ~4,500 charts, a sweeping layout change lands in that range routinely.

## Three fixed codes

| exit | meaning |
| --- | --- |
| 0 | no differences |
| 2 | differences found |
| 1 | the tester itself malfunctioned — a render crashed, a reference was missing, a job timed out |

The count lives in `verify-results.json`, so nothing is lost by not encoding it in the exit status, and the code is derived from that same summary rather than recounted.

**Separating 2 from 1 is what lets the caller decide policy.** Whether "N charts changed" should fail a build depends on whether the change was expected — the companion ops change keys that off the `staging-viz` label:

| branch | label | outcome | step |
| --- | --- | --- | --- |
| PR | none | differences | 🔴 |
| PR | `staging-viz` | differences | 🟢 |
| PR | either | clean | 🟢 |
| PR | either | malfunction | 🔴 |
| master | — | differences | 🟢 (master absorbs them as the new references) |
| master | — | malfunction | 🔴 |

Previously both outcomes arrived as one non-zero number and ops reconstructed the distinction with `exit 24` plus a `soft_fail`.

## Also in here

**`reportVerifyResults`** replaces `displayVerifyResultsAndGetExitCode` — printing is all it does now. Errors print as `viewId: message` rather than the whole `Error`, whose stack ran to many lines per failure and inflated the line count owidbot used to parse. Several paths in the tester `throw` plain strings rather than `Error`s, so the message goes through the same fallback the summariser uses; the first version of this printed `life-expectancy: undefined`.

**The Makefile changes are required, not incidental.** The five `svgtest` targets used to build their report only when verify exited non-zero (`… || (create-compare-view.ts … && open …)`). They now gate the report on the differences directory, and tolerate exit 2 explicitly:

```make
yarn tsx … verify-graphs.ts || [ $$? -eq 2 ]
```

so a difference continues to the report while a genuine failure still aborts the target. Also drops `svgtest.graphers` from `.PHONY` — it is not a target and never has been.

The `catch` block exits `1` rather than `-1`, which the shell reports as 255.

**`readme.md`** — two claims were false: "returns a non-zero exit code if any differences are found", and the stdout contract. Both now point at `verify-results.json` as the machine-readable output.

## Verified

Against the real svgs checkout, all three codes:

| Case | Exit |
| --- | --- |
| clean run | **0** |
| reference genuinely differing | **2** |
| reference file missing | **1**, `life-expectancy: Reference SVG does not exist …` |

Plus both branches of the new Makefile guard with the real command (`==> No differences (graphers)` when empty; `create-compare-view.ts` runs and writes a 16 KB report when not), and the exit-code tolerance itself: `2 → 0`, `1 → 1`, `0 → 0`.

`yarn typecheck`, lint and format clean; unit tests green.

## Merge order

The ops change that applies the label policy must land **after** this: it reads exit 2, which doesn't exist until this merges. In the window between, differences produce a non-zero exit that ops still treats with the old `exit 24` path — the pre-existing behaviour, unchanged.

## Not verified

- **`make svgtest` end to end.** Each piece is verified — reset, verify, guard, report — but never in one run; that needs the full reset plus a 4,460-chart render.
- **The other four targets** (`svgtest.full`, `.grapher-views`, `.mdims`, `.thumbnails`) are textually identical blocks with the suite substituted, checked only via `make -n`.
