### PR TITLE
🐛🤖 (svg-tester) keep the reference md5 index in sync with the references

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ ifdef WRANGLER_PORT
 WRANGLER_PORT := $(strip $(WRANGLER_PORT))
 endif
 
-.PHONY: help up up.headless up.worktree setup.worktree require.worktree up.full down down.headless down.worktree refresh refresh.wp refresh.private refresh.full migrate svgtest svgtest.reset svgtest.grapher-views svgtest.mdims svgtest.thumbnails bdd bdd.ui check-not-prod
+.PHONY: help up up.headless up.worktree setup.worktree require.worktree up.full down down.headless down.worktree refresh refresh.wp refresh.private refresh.full migrate svgtest svgtest.reset svgtest.grapher-views svgtest.mdims svgtest.thumbnails svgtest.md5s bdd bdd.ui check-not-prod
 
 help:
 	@echo 'Available commands:'
@@ -61,6 +61,7 @@ help:
 	@echo '  make bdd.ui                 (while up) start BDD test environment with UI'
 	@echo '  make svgtest                generate an SVG test report for graphers'
 	@echo '  make svgtest.full           generate a full SVG test report'
+	@echo '  make svgtest.md5s           resync reference md5s in ../owid-grapher-svgs after references change'
 	@echo '  make local-bake             do a full local site bake'
 	@echo '  make archive                create an archived version of our charts'
 	@echo '  make wikipedia-archive      create a Wikipedia archive (strips GTM, rewrites archive URLs)'
@@ -498,6 +499,14 @@ svgtest.thumbnails: svgtest.reset node_modules
 	else \
 		echo '==> No differences (thumbnails)'; \
 	fi
+
+svgtest.md5s: ../owid-grapher-svgs node_modules
+	@echo '==> Recomputing reference md5s in ../owid-grapher-svgs'
+
+	yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/update-reference-md5s.ts graphers
+	yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/update-reference-md5s.ts grapher-views
+	yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/update-reference-md5s.ts mdims
+	yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/update-reference-md5s.ts thumbnails
 
 node_modules: package.json yarn.lock yarn.config.cjs
 	@echo '==> Installing packages'

--- a/devTools/svgTester/update-reference-md5s.ts
+++ b/devTools/svgTester/update-reference-md5s.ts
@@ -1,0 +1,97 @@
+#! /usr/bin/env node
+
+import yargs from "yargs"
+import { hideBin } from "yargs/helpers"
+import fs from "fs-extra"
+import path from "path"
+
+import * as utils from "./utils.js"
+import { hashMd5 } from "../../serverUtils/hash.js"
+
+/**
+ * Bring the md5 column of a suite's references/results.csv back in sync with the
+ * .svg files next to it.
+ */
+async function main(args: ReturnType<typeof parseArguments>): Promise<void> {
+    const testSuite = args.testSuite as utils.TestSuite
+    const referencesDir = path.join(
+        utils.SVG_REPO_PATH,
+        testSuite,
+        "references"
+    )
+
+    if (!fs.existsSync(referencesDir))
+        throw `Reference directory does not exist ${referencesDir}`
+
+    const svgRecords = await utils.parseReferenceCsv(referencesDir)
+
+    let updated = 0
+    const missing: string[] = []
+
+    for (const record of svgRecords) {
+        const svgPath = path.join(referencesDir, record.svgFilename)
+        if (!fs.existsSync(svgPath)) {
+            missing.push(record.svgFilename)
+            continue
+        }
+
+        // utf-8 to match how the file was written and how the md5 was computed
+        // in the first place (renderSvg hashes the same string it writes out).
+        const md5 = hashMd5(await fs.readFile(svgPath, "utf-8"))
+        if (md5 !== record.md5) {
+            utils.logIfVerbose(
+                args.verbose,
+                `${record.viewId}: ${record.md5} -> ${md5}`
+            )
+            record.md5 = md5
+            updated += 1
+        }
+    }
+
+    if (missing.length) {
+        console.warn(
+            `${missing.length} reference SVGs in results.csv do not exist on disk, left untouched`
+        )
+        for (const svgFilename of missing) {
+            utils.logIfVerbose(args.verbose, `  missing: ${svgFilename}`)
+        }
+    }
+
+    if (updated === 0) {
+        console.log(`${testSuite}: all ${svgRecords.length} md5s already match`)
+        return
+    }
+
+    await utils.writeReferenceCsv(referencesDir, svgRecords)
+    console.log(
+        `${testSuite}: updated ${updated} of ${svgRecords.length} md5s in results.csv`
+    )
+}
+
+function parseArguments() {
+    return yargs(hideBin(process.argv))
+        .usage(
+            "Recompute the md5 column in a test suite's references/results.csv from the reference SVGs on disk"
+        )
+        .command("$0 [testSuite]", false)
+        .positional("testSuite", {
+            type: "string",
+            description: utils.TEST_SUITE_DESCRIPTION,
+            default: "graphers",
+            choices: utils.TEST_SUITES,
+        })
+        .options({
+            verbose: {
+                type: "boolean",
+                description: "Verbose mode",
+                default: false,
+            },
+        })
+        .help()
+        .alias("help", "h")
+        .version(false)
+        .parseSync()
+}
+
+const argv = parseArguments()
+void main(argv)


### PR DESCRIPTION
> _Written by Anthropic Claude Opus 5 — @sophiamersmann at the wheel._

Stacked on #6913 — review that one first; this branch's diff is the last commit only.

## The bug

`references/results.csv` indexes each reference SVG by md5, and `verifySvg` uses it as a fast path: equal hash means no difference, skip reading the file.

But `commit_differences` in ops' `svg-tester.sh` copies newly rendered SVGs over `references/` and commits them, without ever rewriting the CSV:

```bash
cp $1/differences/*.svg $1/references   # updates the files
git add $1/references                    # commits them
                                         # never touches results.csv
```

So after every master run the index describes the *previous* references. Measured on the current master of `owid-grapher-svgs`, nine days after the last refresh:

| suite | stale md5s | of |
| --- | --- | --- |
| graphers | **1,924** | 4,460 |
| mdims | 274 | 810 |
| thumbnails | 34 | 135 |
| grapher-views | 29 | 1,058 |

43% of the graphers suite. Roughly tracks how often each suite runs on master — graphers on every build, the others only behind the label.

Each stale entry costs a file read and a full text comparison on every run, where the hash would have exited early. It's also what produced the `No difference found even though hash was different!` line for thousands of charts (silenced in #6913 — that was the symptom, this is the cause).

Not a correctness problem: the comparison falls through to comparing content, which is authoritative. Purely wasted work and noise.

## The fix

`update-reference-md5s.ts` recomputes the column from the files on disk, reusing the existing `parseReferenceCsv` / `writeReferenceCsv` helpers so the format round-trips exactly.

Three deliberate choices:

- **Rehashes everything** rather than tracking what changed, so one run repairs any amount of drift however it arose, and re-running is a no-op.
- **Renders nothing** — the file on disk is what the reference *is*; this only re-derives the index from it.
- **Missing reference files are reported and left in the CSV**, not dropped. A vanished reference is someone's bug, not something to tidy away by quietly shrinking the index.

`make svgtest.md5s` runs it over all four suites. It deliberately does *not* depend on `svgtest.reset`: resyncing an index shouldn't move you onto master or discard local work in the sibling repo.

## Verified

```
$ make svgtest.md5s
graphers: updated 1924 of 4460 md5s in results.csv
grapher-views: updated 29 of 1058 md5s in results.csv
mdims: updated 274 of 810 md5s in results.csv
thumbnails: updated 34 of 135 md5s in results.csv

$ make svgtest.md5s        # idempotent
graphers: all 4460 md5s already match
...
```

Independently confirmed with a Python md5 pass afterwards (0 stale of 4,460), and by diffing the CSV before and after: only the `md5` column changed, row set identical.

## Follow-ups

- **The index still drifts after this.** `commit_differences` needs to call the script before `git add`, so it stops re-accumulating. That's an ops change and belongs with the `svg-tester.sh` rewrite that removes `soft_fail`.
- **A one-off repair for the existing 1,924.** Running this on master in `owid-grapher-svgs` and committing the four CSVs retires today's drift without waiting for the next monthly refresh.
- Worth noting what this bargain is: a derived cache kept in sync by remembering to update it. The rehash-everything design makes any single run self-correcting, but it goes stale again the moment another path writes references without calling it.