### PR TITLE
🚧🤖 test branch for the SVG tester exit-code change (do not merge)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # owid-grapher
 
+change
+
 The monorepo we use at [Our World in Data](https://ourworldindata.org) to create and publish embeddable, interactive visualizations like this one:
 
 [![A Grapher chart showing world-wide life expectancy at birth. Click for interactive.](https://ourworldindata.org/grapher/life-expectancy.svg)](https://ourworldindata.org/grapher/life-expectancy)

--- a/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
@@ -2512,7 +2512,8 @@ export class GrapherState
     }
 
     @computed get currentTitle(): string {
-        let text = this.displayTitle.trim()
+        let text =
+            (this.id === 64 ? "[test 2] " : "") + this.displayTitle.trim()
         if (text.length === 0) return text
 
         // Helper function to add an annotation fragment to the title;
@@ -2764,6 +2765,8 @@ export class GrapherState
     private set facetStrategy(facet: FacetStrategy) {
         this.selectedFacetStrategy = facet
     }
+
+    // test
 
     set baseFontSize(val: number) {
         this._baseFontSize = val

--- a/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
@@ -2512,8 +2512,7 @@ export class GrapherState
     }
 
     @computed get currentTitle(): string {
-        let text =
-            (this.id === 64 ? "[test 2] " : "") + this.displayTitle.trim()
+        let text = this.displayTitle.trim()
         if (text.length === 0) return text
 
         // Helper function to add an annotation fragment to the title;
@@ -2765,8 +2764,6 @@ export class GrapherState
     private set facetStrategy(facet: FacetStrategy) {
         this.selectedFacetStrategy = facet
     }
-
-    // test
 
     set baseFontSize(val: number) {
         this._baseFontSize = val

--- a/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
@@ -2512,7 +2512,8 @@ export class GrapherState
     }
 
     @computed get currentTitle(): string {
-        let text = (this.id === 64 ? "[test 3] " : "") + this.displayTitle.trim()
+        let text =
+            (this.id === 64 ? "[test 3] " : "") + this.displayTitle.trim()
         if (text.length === 0) return text
 
         // Helper function to add an annotation fragment to the title;

--- a/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
@@ -2512,7 +2512,7 @@ export class GrapherState
     }
 
     @computed get currentTitle(): string {
-        let text = this.displayTitle.trim()
+        let text = (this.id === 64 ? "[test 3] " : "") + this.displayTitle.trim()
         if (text.length === 0) return text
 
         // Helper function to add an annotation fragment to the title;


### PR DESCRIPTION
> _Written by Anthropic Claude Opus 5 — @sophiamersmann at the wheel._

**Test branch — not for merge.** Exists to exercise ops#svgtester-exit-semantics end to end on a real staging build.

`staging-script` resolves the ops branch whose name matches the grapher branch, so this branch's builds run the new `svg-tester.sh` instead of the one on ops `main`.

Contents: current master (with #6913 and #6914 merged) plus a deliberate `[test]` prefix on chart 64's title, so the tester is guaranteed to find differences.

## What we're checking

| | expected |
| --- | --- |
| with `staging-viz` | 🟡 soft-fail, `exit 24`, "SVG differences found (expected on a staging-viz PR)" |
| without the label | 🔴 red, `exit 1`, "SVG differences found" |
| this comment | owidbot reports the counts from `verify-results.json`, not from a log |
| the svgs branch | the references commit carries an updated `results.csv` alongside the SVGs |
| the Buildkite log | the tester's output appears inline, now that the `> verify-graphs.log` redirect is gone |

Delete the branch once the ops PR has landed.
