### PR TITLE
🐝 add workflow to publish grapher package to GitHub Packages

### DIFF
--- a/.github/workflows/grapher-publish-github.yml
+++ b/.github/workflows/grapher-publish-github.yml
@@ -1,0 +1,85 @@
+name: Publish grapher to GitHub Packages
+
+# Manually-triggered publish of the grapher package to GitHub's npm registry
+# (npm.pkg.github.com) — useful for testing the real install flow from any
+# branch before the package is published to npm proper.
+#
+# GitHub Packages requires an npm package's scope to match the GitHub account
+# that owns it, and the workflow's GITHUB_TOKEN can only publish into this
+# repo's owner namespace. Since no `ourworldindata` account exists on GitHub,
+# the package is published as `@owid/grapher`. The rename happens inside the
+# packed artifact: `yarn pack` applies publishConfig (which plain
+# `npm publish` would not), and name/version are then rewritten in the
+# extracted tarball so the repo's own workspace setup is never touched.
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (defaults to 0.0.0-preview.<run number>)"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+
+defaults:
+  run:
+    working-directory: packages/@ourworldindata/grapher
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup-node-yarn-deps
+
+      - name: Build package
+        run: yarn build
+
+      - name: Test package
+        run: yarn testPackage
+
+      - name: Pack with publishConfig applied
+        run: |
+          yarn pack --out "$RUNNER_TEMP/grapher.tgz"
+          tar -xzf "$RUNNER_TEMP/grapher.tgz" -C "$RUNNER_TEMP"
+
+      - name: Publish to GitHub Packages
+        working-directory: ${{ runner.temp }}/package
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          RUN_NUMBER: ${{ github.run_number }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${INPUT_VERSION:-0.0.0-preview.$RUN_NUMBER}"
+          npm pkg set name="@owid/grapher" version="$VERSION"
+
+          # Prereleases get the `preview` dist-tag so they never shadow a
+          # proper release under `latest`.
+          case "$VERSION" in
+            *-*) TAG="preview" ;;
+            *) TAG="latest" ;;
+          esac
+
+          echo "//npm.pkg.github.com/:_authToken=\${NODE_AUTH_TOKEN}" > .npmrc
+          npm publish --registry=https://npm.pkg.github.com --tag "$TAG"
+
+          {
+            echo "Published \`@owid/grapher@$VERSION\` (dist-tag \`$TAG\`) to GitHub Packages."
+            echo ""
+            echo "Install it with a \`.npmrc\` of:"
+            echo ""
+            echo '```'
+            echo "@owid:registry=https://npm.pkg.github.com"
+            echo "//npm.pkg.github.com/:_authToken=<a PAT with read:packages>"
+            echo '```'
+            echo ""
+            echo "and then \`npm install @owid/grapher@$VERSION\`."
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
> _Written by Anthropic Claude Fable 5 — @marcelgerber at the wheel._

Adds a manually-triggered (`workflow_dispatch`) workflow that builds the grapher package, runs its smoke tests, and publishes it as `@owid/grapher` to GitHub's npm registry — useful for testing the real install flow with preview versions (`0.0.0-preview.<run number>`, `preview` dist-tag) before the package exists on npm proper.

This is the workflow file from #6918's `npm-grapher` branch, landed separately: GitHub only registers `workflow_dispatch` workflows once they exist on the default branch, so it can't be run at all while it only lives on a feature branch. With this merged, it can be dispatched against any branch (including `npm-grapher` itself before it merges) — the build/test/pack steps all run on the dispatched ref, so master needs nothing beyond the workflow file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)