### PR TITLE
🎉🤖 Add the SVG tester report to the admin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ ifdef WRANGLER_PORT
 WRANGLER_PORT := $(strip $(WRANGLER_PORT))
 endif
 
-.PHONY: help up up.headless up.worktree setup.worktree require.worktree up.full down down.headless down.worktree refresh refresh.wp refresh.private refresh.full migrate svgtest svgtest.reset svgtest.grapher-views svgtest.mdims svgtest.thumbnails svgtest.md5s bdd bdd.ui check-not-prod
+.PHONY: help up up.headless up.worktree setup.worktree require.worktree up.full down down.headless down.worktree refresh refresh.wp refresh.private refresh.full migrate svgtest svgtest.reset svgtest.full svgtest.grapher-views svgtest.mdims svgtest.thumbnails svgtest.md5s bdd bdd.ui check-not-prod
 
 help:
 	@echo 'Available commands:'
@@ -59,9 +59,8 @@ help:
 	@echo '  make playwright-browsers    install Playwright browsers'
 	@echo '  make bdd                    (while up) start BDD test environment'
 	@echo '  make bdd.ui                 (while up) start BDD test environment with UI'
-	@echo '  make svgtest                generate an SVG test report for graphers'
-	@echo '  make svgtest.full           generate a full SVG test report'
-	@echo '  make svgtest.md5s           resync reference md5s in ../owid-grapher-svgs after references change'
+	@echo '  make svgtest                run the SVG tests for graphers'
+	@echo '  make svgtest.full           run the SVG tests for all suites'
 	@echo '  make local-bake             do a full local site bake'
 	@echo '  make archive                create an archived version of our charts'
 	@echo '  make wikipedia-archive      create a Wikipedia archive (strips GTM, rewrites archive URLs)'
@@ -410,93 +409,73 @@ svgtest.reset: ../owid-grapher-svgs
 	cd ../owid-grapher-svgs && git fetch && git checkout -f master && git reset --hard origin/master && git clean -fdx
 
 svgtest: svgtest.reset node_modules
-	@echo '==> Generating SVG test report for graphers'
+	@echo '==> Running the SVG tests for graphers'
 
-	@# generate a full new set of svgs, then report on any differences
+	@# generate a full new set of svgs and compare them against the references
 	yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/verify-graphs.ts || [ $$? -eq 2 ]
 
-	@if [ -n "$$(ls -A ../owid-grapher-svgs/graphers/differences 2>/dev/null)" ]; then \
-		yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/create-compare-view.ts graphers && \
-		open ../owid-grapher-svgs/graphers/differences.html; \
-	else \
+	@if [ -z "$$(ls -A ../owid-grapher-svgs/graphers/differences 2>/dev/null)" ]; then \
 		echo '==> No differences (graphers)'; \
 	fi
 
 svgtest.full: svgtest.reset node_modules
-	@echo '==> Generating full SVG test report'
+	@echo '==> Running all SVG test suites'
 
 	@# run test suite for stand-alone graphers
 	yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/verify-graphs.ts || [ $$? -eq 2 ]
 
-	@if [ -n "$$(ls -A ../owid-grapher-svgs/graphers/differences 2>/dev/null)" ]; then \
-		yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/create-compare-view.ts graphers; \
-	else \
+	@if [ -z "$$(ls -A ../owid-grapher-svgs/graphers/differences 2>/dev/null)" ]; then \
 		echo '==> No differences (graphers)'; \
 	fi
 
 	@# run test suite for grapher views
 	yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/verify-graphs.ts grapher-views || [ $$? -eq 2 ]
 
-	@if [ -n "$$(ls -A ../owid-grapher-svgs/grapher-views/differences 2>/dev/null)" ]; then \
-		yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/create-compare-view.ts grapher-views; \
-	else \
+	@if [ -z "$$(ls -A ../owid-grapher-svgs/grapher-views/differences 2>/dev/null)" ]; then \
 		echo '==> No differences (grapher-views)'; \
 	fi
 
 	@# run test suite for mdims
 	yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/verify-graphs.ts mdims || [ $$? -eq 2 ]
 
-	@if [ -n "$$(ls -A ../owid-grapher-svgs/mdims/differences 2>/dev/null)" ]; then \
-		yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/create-compare-view.ts mdims; \
-	else \
+	@if [ -z "$$(ls -A ../owid-grapher-svgs/mdims/differences 2>/dev/null)" ]; then \
 		echo '==> No differences (mdims)'; \
 	fi
 
 	@# run test suite for thumbnails
 	yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/verify-graphs.ts thumbnails || [ $$? -eq 2 ]
 
-	@if [ -n "$$(ls -A ../owid-grapher-svgs/thumbnails/differences 2>/dev/null)" ]; then \
-		yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/create-compare-view.ts thumbnails; \
-	else \
+	@if [ -z "$$(ls -A ../owid-grapher-svgs/thumbnails/differences 2>/dev/null)" ]; then \
 		echo '==> No differences (thumbnails)'; \
 	fi
 
 svgtest.grapher-views: svgtest.reset node_modules
-	@echo '==> Generating SVG test report for grapher-views'
+	@echo '==> Running the SVG tests for grapher-views'
 
-	@# run test suite for grapher-views, then report on any differences
+	@# run test suite for grapher-views
 	yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/verify-graphs.ts grapher-views || [ $$? -eq 2 ]
 
-	@if [ -n "$$(ls -A ../owid-grapher-svgs/grapher-views/differences 2>/dev/null)" ]; then \
-		yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/create-compare-view.ts grapher-views && \
-		open ../owid-grapher-svgs/grapher-views/differences.html; \
-	else \
+	@if [ -z "$$(ls -A ../owid-grapher-svgs/grapher-views/differences 2>/dev/null)" ]; then \
 		echo '==> No differences (grapher-views)'; \
 	fi
 
 svgtest.mdims: svgtest.reset node_modules
-	@echo '==> Generating SVG test report for mdims'
+	@echo '==> Running the SVG tests for mdims'
 
-	@# run test suite for mdims, then report on any differences
+	@# run test suite for mdims
 	yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/verify-graphs.ts mdims || [ $$? -eq 2 ]
 
-	@if [ -n "$$(ls -A ../owid-grapher-svgs/mdims/differences 2>/dev/null)" ]; then \
-		yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/create-compare-view.ts mdims && \
-		open ../owid-grapher-svgs/mdims/differences.html; \
-	else \
+	@if [ -z "$$(ls -A ../owid-grapher-svgs/mdims/differences 2>/dev/null)" ]; then \
 		echo '==> No differences (mdims)'; \
 	fi
 
 svgtest.thumbnails: svgtest.reset node_modules
-	@echo '==> Generating SVG test report for thumbnails'
+	@echo '==> Running the SVG tests for thumbnails'
 
-	@# run test suite for thumbnails, then report on any differences
+	@# run test suite for thumbnails
 	yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/verify-graphs.ts thumbnails || [ $$? -eq 2 ]
 
-	@if [ -n "$$(ls -A ../owid-grapher-svgs/thumbnails/differences 2>/dev/null)" ]; then \
-		yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/create-compare-view.ts thumbnails && \
-		open ../owid-grapher-svgs/thumbnails/differences.html; \
-	else \
+	@if [ -z "$$(ls -A ../owid-grapher-svgs/thumbnails/differences 2>/dev/null)" ]; then \
 		echo '==> No differences (thumbnails)'; \
 	fi
 

--- a/adminSiteClient/AdminApp.tsx
+++ b/adminSiteClient/AdminApp.tsx
@@ -56,6 +56,8 @@ import MultiDimRedirectsIndexPage from "./MultiDimRedirectsIndexPage.js"
 import { FeaturedMetricsPage } from "./FeaturedMetricsPage.js"
 import { DodsIndexPage } from "./DodsIndexPage.js"
 import { StaticVizIndexPage } from "./StaticVizIndexPage.js"
+import { SvgTesterIndexPage } from "./SvgTesterIndexPage.js"
+import { SvgTesterSuitePage } from "./SvgTesterSuitePage.js"
 import { StaticVizEditPage } from "./StaticVizEditPage.js"
 import { SlideshowsIndexPage } from "./slideshows/SlideshowsIndexPage.js"
 import { SlideshowEditorPage } from "./slideshows/SlideshowEditorPage.js"
@@ -233,6 +235,20 @@ export class AdminApp extends React.Component<{
                                 <Route
                                     path="/files"
                                     component={FilesIndexPage}
+                                />
+                                <Route
+                                    exact
+                                    path="/svgtester"
+                                    component={SvgTesterIndexPage}
+                                />
+                                <Route
+                                    exact
+                                    path="/svgtester/:suite"
+                                    render={({ match }) => (
+                                        <SvgTesterSuitePage
+                                            key={match.params.suite}
+                                        />
+                                    )}
                                 />
                                 <Route
                                     exact

--- a/adminSiteClient/AdminSidebar.tsx
+++ b/adminSiteClient/AdminSidebar.tsx
@@ -26,6 +26,7 @@ import {
     faMonument,
     faDisplay,
     faLinkSlash,
+    faCodeCompare,
 } from "@fortawesome/free-solid-svg-icons"
 
 import { ETL_WIZARD_URL } from "../settings/clientSettings.js"
@@ -178,16 +179,22 @@ export const AdminSidebar = (): React.ReactElement => (
                     Redirects
                 </Link>
             </li>
-            <li>
-                <Link to="/test">
-                    <FontAwesomeIcon icon={faEye} fixedWidth /> Test
-                </Link>
-            </li>
             <li className="header">UTILITIES</li>
             <li>
                 <Link to="/deploys">
                     <FontAwesomeIcon icon={faSatelliteDish} fixedWidth /> Deploy
                     status
+                </Link>
+            </li>
+            <li>
+                <Link to="/svgtester">
+                    <FontAwesomeIcon icon={faCodeCompare} fixedWidth /> SVG
+                    tester
+                </Link>
+            </li>
+            <li>
+                <Link to="/test">
+                    <FontAwesomeIcon icon={faEye} fixedWidth /> Chart previews
                 </Link>
             </li>
             <li>

--- a/adminSiteClient/SvgTesterIndexPage.tsx
+++ b/adminSiteClient/SvgTesterIndexPage.tsx
@@ -1,0 +1,168 @@
+import { useContext } from "react"
+import { Spin, Table, TableColumnsType, Tag, Tooltip, Typography } from "antd"
+import { useQuery } from "@tanstack/react-query"
+import { Link } from "react-router-dom"
+import { SvgTesterSuiteStatus } from "@ourworldindata/types"
+import { ENV } from "../settings/clientSettings.js"
+import { AdminLayout } from "./AdminLayout.js"
+import { AdminAppContext } from "./AdminAppContext.js"
+import { Timeago } from "./Forms.js"
+import {
+    DISPLAY_STATUS_LABELS,
+    displayStatus,
+    formatDuration,
+    hasFindings,
+    SvgTesterDisplayStatus,
+} from "./svgTesterHelpers.js"
+
+/** antd Tag colours */
+const DISPLAY_STATUS_COLORS: Record<SvgTesterDisplayStatus, string> = {
+    "not-run": "default",
+    unreadable: "warning",
+    running: "warning",
+    error: "error",
+    differences: "processing",
+    ok: "success",
+}
+
+export function SvgTesterIndexPage() {
+    const { admin } = useContext(AdminAppContext)
+
+    const { data, isLoading } = useQuery({
+        queryKey: ["svgtester-suites"],
+        queryFn: () =>
+            admin.getJSON<{ suites: SvgTesterSuiteStatus[] }>(
+                "/api/svgtester/suites.json"
+            ),
+        refetchOnWindowFocus: true,
+    })
+
+    const suites = data?.suites ?? []
+
+    return (
+        <AdminLayout title="SVG tester">
+            <main className="SvgTesterIndexPage">
+                <p className="SvgTesterIndexPage__intro">
+                    Results of the last SVG tester run in this server&apos;s{" "}
+                    <code>owid-grapher-svgs</code> checkout. Run a suite with{" "}
+                    <code>make svgtest</code> locally, or let the{" "}
+                    <code>SVG tester</code> Buildkite step write them on a
+                    staging container.
+                </p>
+                <Spin spinning={isLoading}>
+                    <Table
+                        size="small"
+                        columns={columns}
+                        dataSource={suites}
+                        rowKey={(status) => status.suite}
+                        pagination={false}
+                    />
+                </Spin>
+            </main>
+        </AdminLayout>
+    )
+}
+
+const columns: TableColumnsType<SvgTesterSuiteStatus> = [
+    {
+        title: "Suite",
+        dataIndex: "suite",
+        render: (suite: string, status) =>
+            hasFindings(status) ? (
+                <Link to={`/svgtester/${suite}`}>{suite}</Link>
+            ) : (
+                suite
+            ),
+    },
+    {
+        title: "Status",
+        render: (_, status) => <StatusTag status={status} />,
+    },
+    {
+        title: "Differences",
+        align: "right",
+        render: (_, status) =>
+            hasReportedResult(status)
+                ? status.results!.counts.differences.toLocaleString()
+                : "–",
+    },
+    {
+        title: "Errors",
+        align: "right",
+        render: (_, status) => {
+            if (!hasReportedResult(status)) return "–"
+            const errors = status.results!.counts.errors
+            if (!errors) return 0
+            return (
+                <Typography.Text type="danger">
+                    {errors.toLocaleString()}
+                </Typography.Text>
+            )
+        },
+    },
+    {
+        title: "Charts",
+        align: "right",
+        render: (_, status) =>
+            hasReportedResult(status)
+                ? status.results!.counts.total.toLocaleString()
+                : "–",
+    },
+    {
+        title: "Ran",
+        render: (_, status) =>
+            hasReportedResult(status) ? (
+                <Timeago time={status.results!.startedAt} />
+            ) : (
+                "–"
+            ),
+    },
+    {
+        title: "Took",
+        align: "right",
+        render: (_, status) =>
+            hasReportedResult(status)
+                ? formatDuration(status.results!.durationMs)
+                : "–",
+    },
+    {
+        title: "Grapher commit",
+        render: (_, status) => {
+            const commit = status.results?.grapherCommit
+            if (!commit) return "–"
+            const short = <code title={commit}>{commit.slice(0, 7)}</code>
+            if (ENV === "development") return short
+            return (
+                <a
+                    href={`https://github.com/owid/owid-grapher/commit/${commit}`}
+                    target="_blank"
+                    rel="noopener"
+                >
+                    {short}
+                </a>
+            )
+        },
+    },
+]
+
+function StatusTag({ status }: { status: SvgTesterSuiteStatus }) {
+    const display = displayStatus(status)
+    return (
+        <>
+            <Tag color={DISPLAY_STATUS_COLORS[display]}>
+                {DISPLAY_STATUS_LABELS[display]}
+            </Tag>
+            {status.isStale && (
+                <Tooltip title="These results describe a different grapher commit than the one checked out here. They are shown anyway, but re-run the suite to be sure.">
+                    <Tag color="warning">Stale</Tag>
+                </Tooltip>
+            )}
+        </>
+    )
+}
+
+/** True only when the run actually finished and reported */
+function hasReportedResult(status: SvgTesterSuiteStatus): boolean {
+    const display = displayStatus(status)
+    return display === "ok" || display === "differences" || display === "error"
+}

--- a/adminSiteClient/SvgTesterSuitePage.scss
+++ b/adminSiteClient/SvgTesterSuitePage.scss
@@ -1,0 +1,357 @@
+$svg-tester-reference: #b3261e;
+$svg-tester-reference-frame: #dda4a0;
+$svg-tester-current: #146c2e;
+$svg-tester-current-frame: #94c2a0;
+$svg-tester-error: #b3261e;
+$svg-tester-error-frame: #dda4a0;
+
+.SvgTesterSuitePage__nav {
+    align-items: baseline;
+    display: flex;
+    gap: 16px;
+    justify-content: space-between;
+    margin-bottom: 16px;
+}
+
+.SvgTesterSuitePage__suites {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+}
+
+.SvgTesterSuitePage__suite {
+    border-bottom: 2px solid transparent;
+    color: $gray-70;
+    font-size: 13px;
+    padding-bottom: 2px;
+    text-decoration: none;
+
+    &:hover {
+        color: $gray-100;
+        text-decoration: none;
+    }
+
+    &.is-active {
+        border-bottom-color: $gray-100;
+        color: $gray-100;
+    }
+}
+
+.SvgTesterSuitePage__summary {
+    border-bottom: 1px solid $gray-20;
+    margin-bottom: 16px;
+    padding-bottom: 12px;
+}
+
+.SvgTesterSuitePage__headline {
+    color: $gray-100;
+    font-size: 18px;
+
+    strong {
+        font-size: 22px;
+    }
+}
+
+.SvgTesterSuitePage__meta {
+    color: $gray-70;
+    font-size: 13px;
+    margin-top: 4px;
+}
+
+.SvgTesterSuitePage__errors {
+    color: $svg-tester-error;
+}
+
+.SvgTesterSuitePage__stale {
+    border-bottom: 1px dotted $gray-60;
+    cursor: help;
+}
+
+.SvgTesterSuitePage__controls {
+    margin-bottom: 20px;
+}
+
+.SvgTesterSuitePage__card {
+    border: 1px solid $gray-20;
+    border-radius: 2px;
+    margin-bottom: 20px;
+    padding: 12px;
+}
+
+.SvgTesterSuitePage__card-header {
+    align-items: baseline;
+    display: flex;
+    gap: 16px;
+    justify-content: space-between;
+}
+
+.SvgTesterSuitePage__identity {
+    min-width: 0;
+    overflow-wrap: anywhere;
+}
+
+.SvgTesterSuitePage__chart-type {
+    margin-left: 8px;
+}
+
+.SvgTesterSuitePage__modes {
+    border-bottom: 1px solid $gray-10;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+    margin-bottom: 16px;
+    margin-top: 8px;
+    padding-bottom: 12px;
+}
+
+.SvgTesterSuitePage__mode {
+    background: none;
+    border: 0;
+    border-bottom: 2px solid transparent;
+    color: $gray-70;
+    cursor: pointer;
+    font-size: 13px;
+    padding: 0 0 4px;
+
+    &:hover {
+        color: $gray-100;
+    }
+
+    &:focus-visible {
+        outline: 2px solid $gray-60;
+        outline-offset: 2px;
+    }
+
+    &.is-active {
+        border-bottom-color: $gray-100;
+        color: $gray-100;
+    }
+}
+
+.SvgTesterSuitePage__links {
+    color: $gray-70;
+    font-size: 13px;
+    white-space: nowrap;
+}
+
+.SvgTesterErrors {
+    border: 1px solid $svg-tester-error-frame;
+    border-radius: 2px;
+    margin-bottom: 20px;
+    padding: 12px;
+}
+
+.SvgTesterErrors__heading {
+    color: $svg-tester-error;
+    font-size: 14px;
+    font-weight: bold;
+    margin: 0 0 8px;
+}
+
+.SvgTesterErrors__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.SvgTesterErrors__item + .SvgTesterErrors__item {
+    border-top: 1px solid $gray-10;
+    margin-top: 8px;
+    padding-top: 8px;
+}
+
+.SvgTesterErrors__slug {
+    font-weight: bold;
+}
+
+.SvgTesterErrors__kind {
+    color: $gray-70;
+    font-size: 12px;
+    margin-left: 8px;
+}
+
+.SvgTesterErrors__production {
+    font-size: 12px;
+    margin-left: 8px;
+}
+
+.SvgTesterErrors__message {
+    color: $gray-90;
+    font-size: 12px;
+    margin: 4px 0 0;
+    max-height: 8em;
+    overflow: auto;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+// Difference blend: the base rendering, then the current one subtracted from
+// it, so identical pixels cancel out and only changes survive.
+//
+// The blend leaves "unchanged" as black, which makes a page of near-identical
+// charts a wall of black. Inverting the composited result flips that: unchanged
+// is white, changes are dark. The filter has to sit on the parent so it applies
+// after the two images have blended, not to either one of them.
+.SvgTesterOverlay {
+    // Same frame as the other views. Outside the filter, or it would invert.
+    border: 1px solid $gray-10;
+    line-height: 0;
+    max-width: 100%;
+    width: fit-content;
+}
+
+.SvgTesterOverlay__stack {
+    background: #000;
+    filter: invert(1);
+    position: relative;
+}
+
+.SvgTesterOverlay img {
+    display: block;
+    max-width: 100%;
+}
+
+.SvgTesterOverlay__difference {
+    left: 0;
+    mix-blend-mode: difference;
+    position: absolute;
+    top: 0;
+}
+
+.SvgTesterSuitePage__side-by-side {
+    display: grid;
+    gap: 16px;
+    grid-template-columns: repeat(2, minmax(0, max-content));
+    justify-content: start;
+}
+
+.SvgTesterSuitePage__pane {
+    margin: 0;
+}
+
+.SvgTesterSuitePage__pane figcaption,
+.SvgTesterInteractive__pane figcaption {
+    font-size: 11px;
+    font-weight: bold;
+    letter-spacing: 0.06em;
+    margin-bottom: 8px;
+    text-transform: uppercase;
+}
+
+.SvgTesterSuitePage__pane a {
+    display: block;
+}
+
+.SvgTesterSuitePage__pane img {
+    border: 2px solid transparent;
+    display: block;
+    max-width: 100%;
+}
+
+.SvgTesterSuitePage__pane--before figcaption {
+    color: $svg-tester-reference;
+}
+
+.SvgTesterSuitePage__pane--before img {
+    border-color: $svg-tester-reference-frame;
+}
+
+.SvgTesterSuitePage__pane--after figcaption {
+    color: $svg-tester-current;
+}
+
+.SvgTesterSuitePage__pane--after img {
+    border-color: $svg-tester-current-frame;
+}
+
+.SvgTesterInteractive {
+    display: grid;
+    gap: 16px;
+    grid-template-columns: 1fr 1fr;
+}
+
+.SvgTesterInteractive__pane {
+    margin: 0;
+}
+
+.SvgTesterInteractive__pane figcaption {
+    color: $gray-70;
+}
+
+.SvgTesterInteractive iframe {
+    border: 1px solid $gray-10;
+    display: block;
+    height: 600px;
+    width: 100%;
+}
+
+// Shrink-wrap the image: the divider and the drag area are positioned as a
+// percentage of this box, while clip-path is a percentage of the image, so the
+// two only line up if the box is exactly the image's width.
+.SvgTesterSlider {
+    max-width: 100%;
+    width: fit-content;
+}
+
+.SvgTesterSlider__images {
+    border: 1px solid $gray-10;
+    cursor: ew-resize;
+    line-height: 0;
+    position: relative;
+}
+
+.SvgTesterSlider__images img {
+    display: block;
+    max-width: 100%;
+}
+
+.SvgTesterSlider__after {
+    clip-path: inset(0 0 0 var(--position));
+    left: 0;
+    position: absolute;
+    top: 0;
+}
+
+// The range input covers the whole chart and is invisible
+.SvgTesterSlider__range {
+    appearance: none;
+    background: transparent;
+    cursor: ew-resize;
+    height: 100%;
+    left: 0;
+    margin: 0;
+    opacity: 0;
+    position: absolute;
+    top: 0;
+    width: 100%;
+    z-index: 2;
+}
+
+.SvgTesterSlider__range::-webkit-slider-thumb {
+    appearance: none;
+    height: 100%;
+    width: 2px;
+}
+
+.SvgTesterSlider__range::-moz-range-thumb {
+    border: 0;
+    height: 100%;
+    width: 2px;
+}
+
+.SvgTesterSlider__handle {
+    background: $gray-80;
+    bottom: 0;
+    left: var(--position);
+    pointer-events: none;
+    position: absolute;
+    top: 0;
+    width: 2px;
+    z-index: 3;
+}
+
+// The input is invisible, so its focus ring has to show up on the divider.
+.SvgTesterSlider__range:focus-visible ~ .SvgTesterSlider__handle {
+    box-shadow: 0 0 0 2px rgba(91, 91, 91, 0.35);
+    width: 4px;
+}

--- a/adminSiteClient/SvgTesterSuitePage.tsx
+++ b/adminSiteClient/SvgTesterSuitePage.tsx
@@ -1,0 +1,570 @@
+import { useContext, useMemo, useState } from "react"
+import { Alert, Select, Space, Spin, Tag, Tooltip, Typography } from "antd"
+import ReactDiffViewer, { DiffMethod } from "react-diff-viewer-continued"
+import cx from "clsx"
+import { useQuery } from "@tanstack/react-query"
+import { Link, useParams } from "react-router-dom"
+import * as _ from "lodash-es"
+import {
+    SvgTesterDirectory,
+    SvgTesterSuiteStatus,
+    SvgTesterVerifyDifferenceEntry,
+    SvgTesterVerifyErrorEntry,
+} from "@ourworldindata/types"
+import { AdminLayout } from "./AdminLayout.js"
+import { AdminAppContext } from "./AdminAppContext.js"
+import { Timeago } from "./Forms.js"
+import {
+    displayStatus,
+    DISPLAY_STATUS_LABELS,
+    formatDuration,
+    hasFindings,
+} from "./svgTesterHelpers.js"
+
+const LIVE_URL = "https://ourworldindata.org"
+
+type ViewMode = "side-by-side" | "swipe" | "overlay" | "diff" | "interactive"
+
+const VIEW_MODE_OPTIONS: { label: string; value: ViewMode }[] = [
+    { label: "Side by side", value: "side-by-side" },
+    { label: "Swipe", value: "swipe" },
+    { label: "Overlay", value: "overlay" },
+    { label: "Diff", value: "diff" },
+    { label: "Interactive", value: "interactive" },
+]
+
+const KIND_LABELS: Record<SvgTesterVerifyErrorEntry["kind"], string> = {
+    timeout: "Timed out",
+    render: "Failed to render",
+}
+
+/** Skip the diff when this much of the file changed */
+const MAX_CHANGED_RATIO = 0.25
+
+export function SvgTesterSuitePage() {
+    const { admin } = useContext(AdminAppContext)
+    const { suite } = useParams<{ suite: string }>()
+    const [chartType, setChartType] = useState<string>("all")
+
+    const { data, isLoading } = useQuery({
+        queryKey: ["svgtester-results", suite],
+        queryFn: () =>
+            admin.getJSON<SvgTesterSuiteStatus>(
+                `/api/svgtester/${suite}/results.json`
+            ),
+        refetchOnWindowFocus: true,
+    })
+
+    const results = data?.results
+    const differences = useMemo(() => results?.differences ?? [], [results])
+
+    const chartTypeCounts = useMemo(
+        () => _.countBy(differences, (entry) => entry.chartType ?? "Unknown"),
+        [differences]
+    )
+
+    const visible = useMemo(
+        () =>
+            chartType === "all"
+                ? differences
+                : differences.filter(
+                      (entry) => (entry.chartType ?? "Unknown") === chartType
+                  ),
+        [differences, chartType]
+    )
+
+    const status = data ? displayStatus(data) : undefined
+
+    return (
+        <AdminLayout title={`SVG tester: ${suite}`}>
+            <main className="SvgTesterSuitePage">
+                <div className="SvgTesterSuitePage__nav">
+                    <Link to="/svgtester">← All suites</Link>
+                    <SuiteSwitcher currentSuite={suite} />
+                </div>
+
+                <Spin spinning={isLoading}>
+                    {results && (
+                        <div className="SvgTesterSuitePage__summary">
+                            <div className="SvgTesterSuitePage__headline">
+                                <strong>
+                                    {results.counts.differences.toLocaleString()}
+                                </strong>{" "}
+                                of {results.counts.total.toLocaleString()}{" "}
+                                charts rendered differently
+                            </div>
+                            <div className="SvgTesterSuitePage__meta">
+                                {suite} · ran{" "}
+                                <Timeago time={results.startedAt} /> in{" "}
+                                {formatDuration(results.durationMs)}
+                                {results.counts.errors > 0 && (
+                                    <>
+                                        {" · "}
+                                        <span className="SvgTesterSuitePage__errors">
+                                            {results.counts.errors.toLocaleString()}{" "}
+                                            failed to render
+                                        </span>
+                                    </>
+                                )}
+                                {data?.isStale && (
+                                    <>
+                                        {" · "}
+                                        <Tooltip title="These results describe a different grapher commit than the one checked out here. Re-run the suite to be sure they still describe your working tree.">
+                                            <span className="SvgTesterSuitePage__stale">
+                                                from commit{" "}
+                                                <code>
+                                                    {results.grapherCommit?.slice(
+                                                        0,
+                                                        7
+                                                    )}
+                                                </code>
+                                                , not the one checked out
+                                            </span>
+                                        </Tooltip>
+                                    </>
+                                )}
+                            </div>
+                        </div>
+                    )}
+
+                    {results && <SvgTesterErrors errors={results.errors} />}
+
+                    {status &&
+                        !differences.length &&
+                        !results?.errors.length && (
+                            <Alert
+                                type="info"
+                                showIcon
+                                title={DISPLAY_STATUS_LABELS[status]}
+                                description="There is nothing to compare for this suite."
+                            />
+                        )}
+
+                    {!!differences.length && (
+                        <>
+                            <div className="SvgTesterSuitePage__controls">
+                                <Space size="middle" wrap>
+                                    <Select
+                                        value={chartType}
+                                        onChange={setChartType}
+                                        style={{ minWidth: 220 }}
+                                        options={[
+                                            {
+                                                value: "all",
+                                                label: `All chart types (${differences.length.toLocaleString()})`,
+                                            },
+                                            ..._.sortBy(
+                                                Object.entries(chartTypeCounts),
+                                                ([, count]) => -count
+                                            ).map(([type, count]) => ({
+                                                value: type,
+                                                label: `${type} (${count.toLocaleString()})`,
+                                            })),
+                                        ]}
+                                    />
+                                    <Typography.Text type="secondary">
+                                        Showing{" "}
+                                        {visible.length.toLocaleString()} of{" "}
+                                        {differences.length.toLocaleString()}
+                                    </Typography.Text>
+                                </Space>
+                            </div>
+
+                            {visible.map((entry) => (
+                                <DifferenceCard
+                                    key={differenceKey(entry)}
+                                    suite={suite}
+                                    entry={entry}
+                                />
+                            ))}
+                        </>
+                    )}
+                </Spin>
+            </main>
+        </AdminLayout>
+    )
+}
+
+/** Jump between the suites that have something to look at */
+function SuiteSwitcher({ currentSuite }: { currentSuite: string | undefined }) {
+    const { admin } = useContext(AdminAppContext)
+
+    const { data } = useQuery({
+        queryKey: ["svgtester-suites"],
+        queryFn: () =>
+            admin.getJSON<{ suites: SvgTesterSuiteStatus[] }>(
+                "/api/svgtester/suites.json"
+            ),
+    })
+
+    // The current suite stays listed even without findings, so the switcher
+    // doesn't lose the page you are on.
+    const suites = (data?.suites ?? []).filter(
+        (status) => hasFindings(status) || status.suite === currentSuite
+    )
+
+    if (suites.length < 2) return null
+
+    return (
+        <nav className="SvgTesterSuitePage__suites" aria-label="Test suites">
+            {suites.map(({ suite }) => (
+                <Link
+                    key={suite}
+                    to={`/svgtester/${suite}`}
+                    className={cx("SvgTesterSuitePage__suite", {
+                        "is-active": suite === currentSuite,
+                    })}
+                    aria-current={suite === currentSuite ? "page" : undefined}
+                >
+                    {suite}
+                </Link>
+            ))}
+        </nav>
+    )
+}
+
+function DifferenceCard({
+    suite,
+    entry,
+}: {
+    suite: string
+    entry: SvgTesterVerifyDifferenceEntry
+}) {
+    const [mode, setMode] = useState<ViewMode>("side-by-side")
+    const beforeUrl = svgUrl(suite, "references", entry)
+    const afterUrl = svgUrl(suite, "differences", entry)
+
+    // A thumbnail is a 300x160 rendering of a chart; the live chart is the full
+    // one, so there is nothing for an interactive view to compare against.
+    const viewModes =
+        suite === "thumbnails"
+            ? VIEW_MODE_OPTIONS.filter((o) => o.value !== "interactive")
+            : VIEW_MODE_OPTIONS
+
+    return (
+        <section className="SvgTesterSuitePage__card">
+            <header className="SvgTesterSuitePage__card-header">
+                <span className="SvgTesterSuitePage__identity">
+                    <strong aria-hidden="true">#</strong>{" "}
+                    <strong>{entry.viewId}</strong>
+                    {entry.queryStr && <code> ?{entry.queryStr}</code>}
+                    {entry.chartType && (
+                        <Tag className="SvgTesterSuitePage__chart-type">
+                            {entry.chartType}
+                        </Tag>
+                    )}
+                </span>
+                <span className="SvgTesterSuitePage__links">
+                    Open chart:{" "}
+                    <a
+                        href={`${LIVE_URL}/grapher/${chartPath(entry)}`}
+                        target="_blank"
+                        rel="noopener"
+                    >
+                        production
+                    </a>{" "}
+                    ·{" "}
+                    <a
+                        href={`/grapher/${chartPath(entry)}`}
+                        target="_blank"
+                        rel="noopener"
+                    >
+                        this build
+                    </a>
+                </span>
+            </header>
+
+            <div
+                className="SvgTesterSuitePage__modes"
+                role="group"
+                aria-label="Comparison view"
+            >
+                {viewModes.map((option) => (
+                    <button
+                        key={option.value}
+                        type="button"
+                        className={cx("SvgTesterSuitePage__mode", {
+                            "is-active": mode === option.value,
+                        })}
+                        aria-pressed={mode === option.value}
+                        onClick={() => setMode(option.value)}
+                    >
+                        {option.label}
+                    </button>
+                ))}
+            </div>
+
+            {mode === "side-by-side" && (
+                <div className="SvgTesterSuitePage__side-by-side">
+                    <figure className="SvgTesterSuitePage__pane SvgTesterSuitePage__pane--before">
+                        <figcaption>Reference</figcaption>
+                        <a
+                            href={`${LIVE_URL}/grapher/${chartPath(entry)}`}
+                            target="_blank"
+                            rel="noopener"
+                            title="Open this chart on ourworldindata.org"
+                        >
+                            <img
+                                src={beforeUrl}
+                                alt="Reference"
+                                loading="lazy"
+                            />
+                        </a>
+                    </figure>
+                    <figure className="SvgTesterSuitePage__pane SvgTesterSuitePage__pane--after">
+                        <figcaption>Current</figcaption>
+                        <a
+                            href={`/grapher/${chartPath(entry)}`}
+                            target="_blank"
+                            rel="noopener"
+                            title="Open this chart as this build renders it"
+                        >
+                            <img src={afterUrl} alt="Current" loading="lazy" />
+                        </a>
+                    </figure>
+                </div>
+            )}
+            {mode === "swipe" && (
+                <SvgTesterSlider beforeUrl={beforeUrl} afterUrl={afterUrl} />
+            )}
+            {mode === "overlay" && (
+                <SvgTesterOverlay beforeUrl={beforeUrl} afterUrl={afterUrl} />
+            )}
+            {mode === "diff" && (
+                <SvgTesterDiff
+                    beforeUrl={beforeUrl}
+                    afterUrl={afterUrl}
+                    changedRatio={entry.changedRatio}
+                />
+            )}
+            {mode === "interactive" && (
+                <SvgTesterInteractive chartPath={chartPath(entry)} />
+            )}
+        </section>
+    )
+}
+
+/** Charts that did not render at all */
+function SvgTesterErrors({ errors }: { errors: SvgTesterVerifyErrorEntry[] }) {
+    if (!errors.length) return null
+
+    return (
+        <section className="SvgTesterErrors">
+            <h2 className="SvgTesterErrors__heading">
+                {errors.length} {errors.length === 1 ? "chart" : "charts"} did
+                not render
+            </h2>
+            <ul className="SvgTesterErrors__list">
+                {errors.map((error) => (
+                    <li key={error.viewId} className="SvgTesterErrors__item">
+                        <div className="SvgTesterErrors__view">
+                            <a
+                                className="SvgTesterErrors__slug"
+                                href={`/grapher/${error.viewId}`}
+                                target="_blank"
+                                rel="noopener"
+                                title="Open this chart as this build renders it"
+                            >
+                                {error.viewId}
+                            </a>
+                            <span className="SvgTesterErrors__kind">
+                                {KIND_LABELS[error.kind]}
+                            </span>
+                            <a
+                                className="SvgTesterErrors__production"
+                                href={`${LIVE_URL}/grapher/${error.viewId}`}
+                                target="_blank"
+                                rel="noopener"
+                            >
+                                production
+                            </a>
+                        </div>
+                        <pre className="SvgTesterErrors__message">
+                            {error.message}
+                        </pre>
+                    </li>
+                ))}
+            </ul>
+        </section>
+    )
+}
+
+/** Before/after swipe comparison */
+function SvgTesterSlider({
+    beforeUrl,
+    afterUrl,
+}: {
+    beforeUrl: string
+    afterUrl: string
+}) {
+    const [position, setPosition] = useState(50)
+
+    return (
+        <div
+            className="SvgTesterSlider"
+            style={{ "--position": `${position}%` } as React.CSSProperties}
+        >
+            <div className="SvgTesterSlider__images">
+                <img src={beforeUrl} alt="Reference" loading="lazy" />
+                <img
+                    className="SvgTesterSlider__after"
+                    src={afterUrl}
+                    alt="Current"
+                    loading="lazy"
+                />
+                <input
+                    className="SvgTesterSlider__range"
+                    type="range"
+                    min={0}
+                    max={100}
+                    value={position}
+                    aria-label="Reveal more of the current rendering"
+                    onChange={(e) => setPosition(e.target.valueAsNumber)}
+                />
+                {/* Decorative: the input above it takes the pointer events. */}
+                <div className="SvgTesterSlider__handle" aria-hidden="true" />
+            </div>
+        </div>
+    )
+}
+
+/**
+ * The two renderings stacked with a difference blend: identical pixels cancel
+ * out and only changes survive
+ */
+function SvgTesterOverlay({
+    beforeUrl,
+    afterUrl,
+}: {
+    beforeUrl: string
+    afterUrl: string
+}) {
+    return (
+        // The frame is on the outer element and the inversion on the inner one:
+        // a filter applies to everything it contains, so a border inside it
+        // would come out inverted too.
+        <div className="SvgTesterOverlay">
+            <div className="SvgTesterOverlay__stack">
+                <img src={beforeUrl} alt="Reference" loading="lazy" />
+                <img
+                    className="SvgTesterOverlay__difference"
+                    src={afterUrl}
+                    alt="Current, blended against the reference"
+                    loading="lazy"
+                />
+            </div>
+        </div>
+    )
+}
+
+function SvgTesterDiff({
+    beforeUrl,
+    afterUrl,
+    changedRatio,
+}: {
+    beforeUrl: string
+    afterUrl: string
+    changedRatio: number | undefined
+}) {
+    const knownTooLarge =
+        changedRatio !== undefined && changedRatio > MAX_CHANGED_RATIO
+
+    // Only runs when the diff tab is opened, so the SVG text is not fetched for
+    // every entry in a large report just to render its images.
+    const { data, isLoading, error } = useQuery({
+        queryKey: ["svgtester-diff", beforeUrl, afterUrl],
+        queryFn: async () => {
+            const [before, after] = await Promise.all([
+                fetchText(beforeUrl),
+                fetchText(afterUrl),
+            ])
+            return { before, after }
+        },
+        staleTime: Infinity,
+        enabled: !knownTooLarge,
+    })
+
+    if (knownTooLarge) return <DiffSkipped ratio={changedRatio} />
+
+    if (isLoading) return <Spin />
+    if (error || !data)
+        return (
+            <Alert
+                type="error"
+                showIcon
+                title="Could not load the SVGs to diff"
+                description={String(error)}
+            />
+        )
+
+    return (
+        <ReactDiffViewer
+            oldValue={data.before}
+            newValue={data.after}
+            // LINES, not the WORDS mode: word-granularity over a thousand lines of SVG markup is too slow
+            compareMethod={DiffMethod.LINES}
+            splitView={true}
+            showDiffOnly={true}
+            extraLinesSurroundingDiff={3}
+            styles={{ contentText: { wordBreak: "break-all" } }}
+        />
+    )
+}
+
+function DiffSkipped({ ratio }: { ratio: number }) {
+    return (
+        <Alert
+            type="info"
+            showIcon
+            title="Too different to diff"
+            description={`About ${Math.round(ratio * 100)}% of this chart's markup changed. A line-by-line diff of two renderings that different takes many seconds to compute and is not readable — compare them side by side instead.`}
+        />
+    )
+}
+
+/** The two interactive charts as iframes, side by side */
+function SvgTesterInteractive({ chartPath }: { chartPath: string }) {
+    return (
+        <div className="SvgTesterInteractive">
+            <figure className="SvgTesterInteractive__pane">
+                <figcaption>Production</figcaption>
+                <iframe
+                    src={`${LIVE_URL}/grapher/${chartPath}`}
+                    title="This chart on ourworldindata.org"
+                    loading="lazy"
+                />
+            </figure>
+            <figure className="SvgTesterInteractive__pane">
+                <figcaption>This build</figcaption>
+                <iframe
+                    src={`/grapher/${chartPath}`}
+                    title="This chart as this build renders it"
+                    loading="lazy"
+                />
+            </figure>
+        </div>
+    )
+}
+
+function svgUrl(
+    suite: string,
+    kind: SvgTesterDirectory,
+    entry: SvgTesterVerifyDifferenceEntry
+): string {
+    return `/admin/api/svgtester/${suite}/${kind}/${encodeURIComponent(entry.svgFilename)}`
+}
+
+function chartPath(entry: SvgTesterVerifyDifferenceEntry): string {
+    return entry.queryStr ? `${entry.viewId}?${entry.queryStr}` : entry.viewId
+}
+
+async function fetchText(url: string): Promise<string> {
+    const response = await fetch(url)
+    if (!response.ok) throw new Error(`${response.status} fetching ${url}`)
+    return response.text()
+}
+
+/** Stable identifier for a difference, unique within a suite. */
+function differenceKey(entry: SvgTesterVerifyDifferenceEntry): string {
+    return entry.queryStr ? `${entry.viewId}?${entry.queryStr}` : entry.viewId
+}

--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -37,6 +37,7 @@
 @import "./slideshows/SlideshowAdmin.scss";
 // Slide content styles reused for slideshow preview
 @import "../site/slideshows/SlideContent.scss";
+@import "./SvgTesterSuitePage.scss";
 
 html {
     font-size: 14px;
@@ -1910,4 +1911,10 @@ main:not(.ChartEditorPage):not(.GdocsEditPage):not(.MultiDimDetailPage) {
         top: 1px;
         margin-right: 6px;
     }
+}
+
+.SvgTesterIndexPage__intro {
+    max-width: 720px;
+    margin-bottom: 16px;
+    color: $gray-70;
 }

--- a/adminSiteClient/svgTesterHelpers.ts
+++ b/adminSiteClient/svgTesterHelpers.ts
@@ -1,0 +1,43 @@
+import { SvgTesterSuiteStatus } from "@ourworldindata/types"
+
+export type SvgTesterDisplayStatus =
+    | "not-run"
+    | "unreadable"
+    | "running"
+    | "error"
+    | "differences"
+    | "ok"
+
+export const DISPLAY_STATUS_LABELS: Record<SvgTesterDisplayStatus, string> = {
+    "not-run": "Not run",
+    unreadable: "No result (file unreadable)",
+    running: "No result (killed or still running)",
+    error: "Error",
+    differences: "Differences",
+    ok: "No differences",
+}
+
+export function displayStatus(
+    status: SvgTesterSuiteStatus
+): SvgTesterDisplayStatus {
+    if (status.isUnreadable) return "unreadable"
+    if (!status.results) return "not-run"
+    if (status.results.status === "running") return "running"
+    if (status.results.status === "error") return "error"
+    if (status.results.status === "differences") return "differences"
+    return "ok"
+}
+
+/** True when the suite page has something to show: differences or render errors */
+export function hasFindings(status: SvgTesterSuiteStatus): boolean {
+    const counts = status.results?.counts
+    if (!counts) return false
+    return counts.differences > 0 || counts.errors > 0
+}
+
+export function formatDuration(durationMs: number): string {
+    if (durationMs < 1000) return `${durationMs} ms`
+    const seconds = durationMs / 1000
+    if (seconds < 90) return `${seconds.toFixed(0)} s`
+    return `${(seconds / 60).toFixed(1)} min`
+}

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -164,6 +164,11 @@ import {
     refreshDataInsights,
 } from "./apiRoutes/dataInsights.js"
 import { getFigmaImageUrl } from "./apiRoutes/figma.js"
+import {
+    getSvgTesterResults,
+    getSvgTesterSuites,
+    getSvgTesterSvg,
+} from "./apiRoutes/svgTester.js"
 import { sendMessageToSlack } from "./apiRoutes/slack.js"
 import {
     createFeaturedMetric,
@@ -683,6 +688,11 @@ getRouteWithROTransaction(apiRouter, "/figma/image", getFigmaImageUrl)
 
 // Slack routes
 postRouteWithRWTransaction(apiRouter, "/slack/sendMessage", sendMessageToSlack)
+
+// SVG tester
+apiRouter.get("/svgtester/suites.json", getSvgTesterSuites)
+apiRouter.get("/svgtester/:suite/results.json", getSvgTesterResults)
+apiRouter.router.get("/svgtester/:suite/:kind/:filename", getSvgTesterSvg)
 
 // Deploy helpers
 apiRouter.get("/deploys.json", async () => ({

--- a/adminSiteServer/apiRoutes/svgTester.test.ts
+++ b/adminSiteServer/apiRoutes/svgTester.test.ts
@@ -1,0 +1,61 @@
+import { expect, it, describe } from "vitest"
+import path from "path"
+import { resolveSvgPath } from "./svgTester.js"
+import { SVG_TESTER_REPO_PATH } from "../../settings/serverSettings.js"
+
+const graphersReferences = path.resolve(
+    SVG_TESTER_REPO_PATH,
+    "graphers",
+    "references"
+)
+
+describe(resolveSvgPath, () => {
+    it("resolves a plain svg filename inside the suite directory", () => {
+        expect(
+            resolveSvgPath("graphers", "references", "life-expectancy_v42.svg")
+        ).toBe(path.join(graphersReferences, "life-expectancy_v42.svg"))
+    })
+
+    it("resolves an mdim filename, which carries a query string", () => {
+        const filename = "academic-performance?sex=both&subject=reading_v0.svg"
+        expect(resolveSvgPath("mdims", "references", filename)).toBe(
+            path.resolve(SVG_TESTER_REPO_PATH, "mdims", "references", filename)
+        )
+    })
+
+    it("accepts both svg directories", () => {
+        for (const kind of ["references", "differences"]) {
+            expect(resolveSvgPath("graphers", kind, "a.svg")).not.toBeNull()
+        }
+    })
+
+    it("rejects a directory that is not one of the two svg directories", () => {
+        // `data/` is 3.8 GB of dumped inputs and must stay unreachable
+        expect(resolveSvgPath("graphers", "data", "a.svg")).toBeNull()
+        expect(resolveSvgPath("graphers", ".git", "a.svg")).toBeNull()
+    })
+
+    it("rejects an unknown suite", () => {
+        expect(resolveSvgPath("explorers", "references", "a.svg")).toBeNull()
+        expect(resolveSvgPath("..", "references", "a.svg")).toBeNull()
+    })
+
+    it("rejects traversal and anything that is not a bare svg basename", () => {
+        const filenames = [
+            "../../.git/config",
+            "../references/a.svg",
+            "sub/dir/a.svg",
+            ".git",
+            ".hidden.svg",
+            "a.svg.json",
+            "a.png",
+            "",
+        ]
+        for (const filename of filenames) {
+            expect(
+                resolveSvgPath("graphers", "references", filename),
+                filename
+            ).toBeNull()
+        }
+    })
+})

--- a/adminSiteServer/apiRoutes/svgTester.ts
+++ b/adminSiteServer/apiRoutes/svgTester.ts
@@ -1,0 +1,144 @@
+import fs from "fs-extra"
+import path from "path"
+import { execFile } from "child_process"
+import { promisify } from "util"
+import { Request, Response } from "express"
+import {
+    SVG_TESTER_SUITES,
+    SVG_TESTER_DIRECTORIES,
+    SvgTesterDirectory,
+    SvgTesterSuite,
+    SvgTesterSuiteStatus,
+    SVG_TESTER_VERIFY_RESULTS_FILENAME,
+    SvgTesterVerifyRunSummary,
+} from "@ourworldindata/types"
+import { SVG_TESTER_REPO_PATH } from "../../settings/serverSettings.js"
+
+const execFileAsync = promisify(execFile)
+
+function suiteDir(suite: SvgTesterSuite): string {
+    return path.join(SVG_TESTER_REPO_PATH, suite)
+}
+
+function parseSuite(value: string): SvgTesterSuite | undefined {
+    return SVG_TESTER_SUITES.find((suite) => suite === value)
+}
+
+function parseKind(value: string): SvgTesterDirectory | undefined {
+    return SVG_TESTER_DIRECTORIES.find((kind) => kind === value)
+}
+
+async function headCommit(cwd?: string): Promise<string | null> {
+    try {
+        const { stdout } = await execFileAsync("git", ["rev-parse", "HEAD"], {
+            cwd,
+            encoding: "utf-8",
+        })
+        return stdout.trim()
+    } catch {
+        return null
+    }
+}
+
+async function readResults(suite: SvgTesterSuite): Promise<{
+    results: SvgTesterVerifyRunSummary | null
+    isUnreadable: boolean
+}> {
+    const file = path.join(suiteDir(suite), SVG_TESTER_VERIFY_RESULTS_FILENAME)
+    let raw: string
+    try {
+        raw = await fs.readFile(file, "utf-8")
+    } catch {
+        // No file at all: this suite was never run on this machine.
+        return { results: null, isUnreadable: false }
+    }
+    try {
+        return {
+            results: JSON.parse(raw) as SvgTesterVerifyRunSummary,
+            isUnreadable: false,
+        }
+    } catch {
+        // The writer can be killed mid-write, so a truncated file is plausible
+        // and is its own state rather than "absent".
+        return { results: null, isUnreadable: true }
+    }
+}
+
+export async function getSvgTesterSuites(): Promise<{
+    suites: SvgTesterSuiteStatus[]
+}> {
+    const grapherHead = await headCommit()
+
+    const suites = await Promise.all(
+        SVG_TESTER_SUITES.map(async (suite) => {
+            const { results, isUnreadable } = await readResults(suite)
+            const isStale = Boolean(
+                results?.grapherCommit &&
+                grapherHead &&
+                results.grapherCommit !== grapherHead
+            )
+            return { suite, results, isStale, isUnreadable }
+        })
+    )
+
+    return { suites }
+}
+
+export async function getSvgTesterResults(
+    req: Request
+): Promise<SvgTesterSuiteStatus> {
+    const suite = parseSuite(req.params.suite)
+    if (!suite) throw new Error(`Unknown test suite: ${req.params.suite}`)
+
+    const { results, isUnreadable } = await readResults(suite)
+    const grapherHead = await headCommit()
+    const isStale = Boolean(
+        results?.grapherCommit &&
+        grapherHead &&
+        results.grapherCommit !== grapherHead
+    )
+
+    return { suite, results, isStale, isUnreadable }
+}
+
+/** Serve one SVG out of the svgs checkout */
+export function resolveSvgPath(
+    suite: string,
+    kind: string,
+    filename: string
+): string | null {
+    const parsedSuite = parseSuite(suite)
+    const parsedKind = parseKind(kind)
+
+    const isSafeBasename =
+        filename.endsWith(".svg") &&
+        !filename.startsWith(".") &&
+        !/[/\\]/.test(filename)
+
+    if (!parsedSuite || !parsedKind || !isSafeBasename) return null
+
+    const dir = path.resolve(suiteDir(parsedSuite), parsedKind)
+    const file = path.resolve(dir, filename)
+
+    return file.startsWith(dir + path.sep) ? file : null
+}
+
+export async function getSvgTesterSvg(
+    req: Request,
+    res: Response
+): Promise<void> {
+    const file = resolveSvgPath(
+        req.params.suite,
+        req.params.kind,
+        req.params.filename
+    )
+
+    if (!file || !(await fs.pathExists(file))) {
+        res.status(404).end()
+        return
+    }
+
+    res.type("image/svg+xml")
+    res.setHeader("Cache-Control", "no-cache")
+    res.sendFile(file)
+}

--- a/devTools/svgTester/create-compare-view.ts
+++ b/devTools/svgTester/create-compare-view.ts
@@ -4,6 +4,8 @@ import yargs from "yargs"
 import { hideBin } from "yargs/helpers"
 import fs from "fs-extra"
 import path from "path"
+import { SVG_TESTER_SUITES, type SvgTesterSuite } from "@ourworldindata/types"
+import { SVG_TESTER_REPO_PATH } from "../../settings/serverSettings.js"
 import * as utils from "./utils.js"
 import * as _ from "lodash-es"
 import * as Diff from "diff"
@@ -16,8 +18,8 @@ const DIFFERENCES_DIR_NAME = "differences"
 const HTML_OUTPUT_FILENAME = "differences.html"
 
 async function main(args: ReturnType<typeof parseArguments>) {
-    const testSuite = args.testSuite as utils.TestSuite
-    const workingDir = path.join(utils.SVG_REPO_PATH, testSuite)
+    const testSuite = args.testSuite as SvgTesterSuite
+    const workingDir = path.join(SVG_TESTER_REPO_PATH, testSuite)
 
     const compareUrl = args.compareUrl
 
@@ -95,7 +97,7 @@ function parseArguments() {
             type: "string",
             description: utils.TEST_SUITE_DESCRIPTION,
             default: "graphers",
-            choices: utils.TEST_SUITES,
+            choices: SVG_TESTER_SUITES,
         })
         .parserConfiguration({ "camel-case-expansion": true })
         .options({

--- a/devTools/svgTester/dump-data.ts
+++ b/devTools/svgTester/dump-data.ts
@@ -7,6 +7,7 @@ import {
     knexReadonlyTransaction,
     type KnexReadonlyTransaction,
 } from "../../db/db.js"
+import { SVG_TESTER_REPO_PATH } from "../../settings/serverSettings.js"
 import { getPublishedGraphersBySlug } from "../../baker/GrapherImageBaker.js"
 import { getMostViewedGrapherIdsByChartType } from "../../db/model/Chart.js"
 import { getAllPublishedMultiDimDataPages } from "../../db/model/MultiDimDataPage.js"
@@ -15,6 +16,8 @@ import {
     GrapherInterface,
     ChartConfigsTableName,
     DbRawChartConfig,
+    SVG_TESTER_SUITES,
+    type SvgTesterSuite,
 } from "@ourworldindata/types"
 import { parseChartConfig, queryParamsToStr } from "@ourworldindata/utils"
 
@@ -128,8 +131,8 @@ async function saveGrapherSchemaAndData(
 
 async function main(args: ReturnType<typeof parseArguments>) {
     try {
-        const testSuite = args.testSuite as utils.TestSuite
-        const testSuiteDir = path.join(utils.SVG_REPO_PATH, testSuite)
+        const testSuite = args.testSuite as SvgTesterSuite
+        const testSuiteDir = path.join(SVG_TESTER_REPO_PATH, testSuite)
         const outDir = path.join(testSuiteDir, "data")
         const concurrency = args.concurrency
 
@@ -241,7 +244,7 @@ function parseArguments() {
             type: "string",
             description: utils.TEST_SUITE_DESCRIPTION,
             default: "graphers",
-            choices: utils.TEST_SUITES,
+            choices: SVG_TESTER_SUITES,
         })
         .parserConfiguration({ "camel-case-expansion": true })
         .options({

--- a/devTools/svgTester/export-graphs.ts
+++ b/devTools/svgTester/export-graphs.ts
@@ -8,17 +8,22 @@ import { hideBin } from "yargs/helpers"
 import path from "path"
 import workerpool from "workerpool"
 
+import { SVG_TESTER_REPO_PATH } from "../../settings/serverSettings.js"
 import * as utils from "./utils.js"
 import { MAX_WORKERS } from "./utils.js"
-import { ALL_GRAPHER_CHART_TYPES } from "@ourworldindata/types"
+import {
+    ALL_GRAPHER_CHART_TYPES,
+    SVG_TESTER_SUITES,
+    type SvgTesterSuite,
+} from "@ourworldindata/types"
 
 async function exportGraphers(args: ReturnType<typeof parseArguments>) {
     try {
         // Test suite
-        const testSuite = args.testSuite as utils.TestSuite
+        const testSuite = args.testSuite as SvgTesterSuite
 
         // Input and output directories
-        const testSuiteDir = path.join(utils.SVG_REPO_PATH, testSuite)
+        const testSuiteDir = path.join(SVG_TESTER_REPO_PATH, testSuite)
         const outDir = path.join(testSuiteDir, "references")
 
         // Charts to process
@@ -146,7 +151,7 @@ async function exportGraphers(args: ReturnType<typeof parseArguments>) {
 }
 
 async function main(args: ReturnType<typeof parseArguments>) {
-    const testSuite = args.testSuite as utils.TestSuite
+    const testSuite = args.testSuite as SvgTesterSuite
 
     await match(testSuite)
         .with("graphers", () => exportGraphers(args))
@@ -164,7 +169,7 @@ function parseArguments() {
             type: "string",
             description: utils.TEST_SUITE_DESCRIPTION,
             default: "graphers",
-            choices: utils.TEST_SUITES,
+            choices: SVG_TESTER_SUITES,
         })
         .parserConfiguration({ "camel-case-expansion": true })
         .options({

--- a/devTools/svgTester/readme.md
+++ b/devTools/svgTester/readme.md
@@ -109,9 +109,9 @@ This command:
 
 1. Resets `../owid-grapher-svgs` to `origin/master`
 2. Runs `verify-graphs.ts` against the reference SVGs
-3. If there are differences, generates an HTML comparison report using `create-compare-view.ts`
+3. Lists any differences it found; inspect them at `/admin/svgtester/graphers` in the admin
 
-### Generate full test report with all test suites
+### Run all test suites
 
 ```bash
 make svgtest.full
@@ -121,7 +121,7 @@ This command:
 
 1. Resets `../owid-grapher-svgs` to `origin/master`
 2. Runs `export-graphs.ts` for all test suites (graphers, grapher-views, mdims, thumbnails)
-3. Generates HTML comparison reports for each test suite
+3. Lists any differences it found; inspect them at `/admin/svgtester/<suite>` in the admin
 
 ## Refreshing Reference Data
 

--- a/devTools/svgTester/update-reference-md5s.ts
+++ b/devTools/svgTester/update-reference-md5s.ts
@@ -5,6 +5,8 @@ import { hideBin } from "yargs/helpers"
 import fs from "fs-extra"
 import path from "path"
 
+import { SVG_TESTER_SUITES, type SvgTesterSuite } from "@ourworldindata/types"
+import { SVG_TESTER_REPO_PATH } from "../../settings/serverSettings.js"
 import * as utils from "./utils.js"
 import { hashMd5 } from "../../serverUtils/hash.js"
 
@@ -13,9 +15,9 @@ import { hashMd5 } from "../../serverUtils/hash.js"
  * .svg files next to it.
  */
 async function main(args: ReturnType<typeof parseArguments>): Promise<void> {
-    const testSuite = args.testSuite as utils.TestSuite
+    const testSuite = args.testSuite as SvgTesterSuite
     const referencesDir = path.join(
-        utils.SVG_REPO_PATH,
+        SVG_TESTER_REPO_PATH,
         testSuite,
         "references"
     )
@@ -78,7 +80,7 @@ function parseArguments() {
             type: "string",
             description: utils.TEST_SUITE_DESCRIPTION,
             default: "graphers",
-            choices: utils.TEST_SUITES,
+            choices: SVG_TESTER_SUITES,
         })
         .options({
             verbose: {

--- a/devTools/svgTester/utils.ts
+++ b/devTools/svgTester/utils.ts
@@ -6,6 +6,11 @@ import {
     GrapherVariant,
     GRAPHER_TAB_NAMES,
     GrapherChartOrMapType,
+    type SvgTesterSuite,
+    SVG_TESTER_VERIFY_RESULTS_FILENAME,
+    type SvgTesterVerifyRunStatus,
+    type SvgTesterVerifyErrorEntry,
+    type SvgTesterVerifyRunSummary,
 } from "@ourworldindata/types"
 import {
     Bounds,
@@ -41,26 +46,15 @@ import {
 import { format, type FormatConfig } from "oxfmt"
 import oxfmtConfig from "../../.oxfmtrc.json"
 import { hashMd5 } from "../../serverUtils/hash.js"
+import { SVG_TESTER_REPO_PATH } from "../../settings/serverSettings.js"
 import * as R from "remeda"
 import ReactDOMServer from "react-dom/server"
-
-export const SVG_REPO_PATH = "../owid-grapher-svgs"
-
-export const TEST_SUITES = [
-    "graphers",
-    "grapher-views",
-    "mdims",
-    "thumbnails",
-] as const
-export type TestSuite = (typeof TEST_SUITES)[number]
 
 export const TEST_SUITE_DESCRIPTION =
     "Test suite to run: 'graphers' for default Grapher views, 'grapher-views' for all views of a subset of Graphers. 'mdims' for all multi-dim views. 'thumbnails' for thumbnail versions (300x160) of all published graphers."
 
 const CONFIG_FILENAME = "config.json"
 const RESULTS_FILENAME = "results.csv"
-
-export const VERIFY_RESULTS_FILENAME = "verify-results.json"
 
 export const finished = util.promisify(stream.finished) // (A)
 
@@ -141,6 +135,7 @@ export interface SvgDifference {
     queryStr?: string
     chartType: GrapherTabName | undefined
     svgFilename: string
+    changedRatio: number
     startIndex: number
     referenceSvgFragment: string
     newSvgFragment: string
@@ -161,6 +156,31 @@ export function logIfVerbose(verbose: boolean, message: string, param?: any) {
     if (verbose)
         if (param) console.log(message, param)
         else console.log(message)
+}
+
+/**
+ * Share of lines on one side with no counterpart on the other, 0–1.
+ *
+ * O(n) and about a millisecond on a typical chart, so it is affordable for
+ * every difference in a run. A real edit distance is not: on the largest
+ * reference (16k lines), diffing two renderings that differ everywhere takes
+ * over 15 seconds.
+ */
+export function estimateChangedRatio(before: string, after: string): number {
+    const beforeLines = before.split("\n")
+    const afterLines = after.split("\n")
+    const counts = new Map<string, number>()
+    for (const line of beforeLines)
+        counts.set(line, (counts.get(line) ?? 0) + 1)
+    let shared = 0
+    for (const line of afterLines) {
+        const remaining = counts.get(line)
+        if (remaining) {
+            counts.set(line, remaining - 1)
+            shared++
+        }
+    }
+    return 1 - shared / Math.max(beforeLines.length, afterLines.length)
 }
 
 function findFirstDiffIndex(a: string, b: string): number {
@@ -229,6 +249,10 @@ export async function verifySvg(
         queryStr: newSvgRecord.resolvedQueryStr ?? newSvgRecord.queryStr,
         chartType: newSvgRecord.chartType,
         svgFilename: newSvgRecord.svgFilename,
+        changedRatio: estimateChangedRatio(
+            preparedReferenceSvg,
+            preparedNewSvg
+        ),
         startIndex: firstDiffIndex,
         referenceSvgFragment: preparedReferenceSvg.substring(
             firstDiffIndex - 20,
@@ -794,47 +818,11 @@ export async function renderAndVerifySvg({
     }
 }
 
-// "running" is written before the first render and overwritten when the run
-// finishes. A file left in that state means the process died before it could
-// report - killed by the `timeout` wrapper or Buildkite cancelling the step, say -
-// which is otherwise indistinguishable from a suite that was never selected.
-export type VerifyRunStatus = "running" | "ok" | "differences" | "error"
-
-export interface VerifyDifferenceEntry {
-    viewId: string
-    queryStr?: string
-    chartType?: string
-    svgFilename: string
-}
-
-export interface VerifyErrorEntry {
-    viewId: string
-    kind: "timeout" | "render"
-    message: string
-}
-
-export interface VerifyRunSummary {
-    suite: TestSuite
-    status: VerifyRunStatus
-    startedAt: string
-    durationMs: number
-    grapherCommit: string | null
-    svgsCommit: string | null
-    counts: {
-        total: number
-        ok: number
-        differences: number
-        errors: number
-    }
-    differences: VerifyDifferenceEntry[]
-    errors: VerifyErrorEntry[]
-}
-
 // A `.timeout()` breach and a render crash both arrive through the same `.catch`
 // in verify-graphs.ts, so the only thing distinguishing them is the error name
 // workerpool gives a timeout. Errors crossing a worker boundary are structured
 // clones rather than real Error instances, hence the defensive access.
-function classifyVerifyError(error: Error): VerifyErrorEntry["kind"] {
+function classifyVerifyError(error: Error): SvgTesterVerifyErrorEntry["kind"] {
     return error?.name === "TimeoutError" ? "timeout" : "render"
 }
 
@@ -848,11 +836,11 @@ function verifyErrorMessage(error: Error): string {
 export function summariseVerifyResults(
     validationResults: VerifyResult[],
     options: {
-        suite: TestSuite
+        suite: SvgTesterSuite
         startedAt: Date
         durationMs: number
     }
-): VerifyRunSummary {
+): SvgTesterVerifyRunSummary {
     const differences = validationResults
         .filter((result) => result.kind === "difference")
         .map(({ difference }) => ({
@@ -862,6 +850,7 @@ export function summariseVerifyResults(
             queryStr: difference.queryStr || undefined,
             chartType: difference.chartType,
             svgFilename: difference.svgFilename,
+            changedRatio: difference.changedRatio,
         }))
 
     const errors = validationResults
@@ -876,7 +865,7 @@ export function summariseVerifyResults(
 
     // An errored suite is reported as errored even if it also found differences:
     // we can't claim to know what changed when part of the run didn't complete.
-    const status: VerifyRunStatus = errors.length
+    const status: SvgTesterVerifyRunStatus = errors.length
         ? "error"
         : differences.length
           ? "differences"
@@ -888,7 +877,7 @@ export function summariseVerifyResults(
         startedAt: options.startedAt.toISOString(),
         durationMs: options.durationMs,
         grapherCommit: resolveCommit(),
-        svgsCommit: resolveCommit(SVG_REPO_PATH),
+        svgsCommit: resolveCommit(SVG_TESTER_REPO_PATH),
         counts: {
             total: validationResults.length,
             ok: validationResults.length - differences.length - errors.length,
@@ -905,9 +894,9 @@ export function summariseVerifyResults(
 // explicit paths only.
 export async function writeVerifyResults(
     testSuiteDir: string,
-    summary: VerifyRunSummary
+    summary: SvgTesterVerifyRunSummary
 ): Promise<void> {
-    const outPath = path.join(testSuiteDir, VERIFY_RESULTS_FILENAME)
+    const outPath = path.join(testSuiteDir, SVG_TESTER_VERIFY_RESULTS_FILENAME)
     await fs.writeFile(outPath, JSON.stringify(summary, null, 2) + "\n")
 }
 
@@ -920,7 +909,7 @@ export async function writeVerifyResults(
 // The counts are zeroed placeholders and mean nothing until the run finishes.
 export async function writeVerifyRunStarted(
     testSuiteDir: string,
-    suite: TestSuite,
+    suite: SvgTesterSuite,
     startedAt: Date
 ): Promise<void> {
     await writeVerifyResults(testSuiteDir, {
@@ -929,7 +918,7 @@ export async function writeVerifyRunStarted(
         startedAt: startedAt.toISOString(),
         durationMs: 0,
         grapherCommit: resolveCommit(),
-        svgsCommit: resolveCommit(SVG_REPO_PATH),
+        svgsCommit: resolveCommit(SVG_TESTER_REPO_PATH),
         counts: { total: 0, ok: 0, differences: 0, errors: 0 },
         differences: [],
         errors: [],
@@ -942,7 +931,7 @@ export async function writeVerifyRunStarted(
 // indistinguishable from a suite that was never started.
 export async function writeVerifyRunFailure(
     testSuiteDir: string,
-    suite: TestSuite,
+    suite: SvgTesterSuite,
     error: unknown
 ): Promise<void> {
     const startedAt = new Date()
@@ -952,7 +941,7 @@ export async function writeVerifyRunFailure(
         startedAt: startedAt.toISOString(),
         durationMs: 0,
         grapherCommit: resolveCommit(),
-        svgsCommit: resolveCommit(SVG_REPO_PATH),
+        svgsCommit: resolveCommit(SVG_TESTER_REPO_PATH),
         counts: { total: 0, ok: 0, differences: 0, errors: 1 },
         differences: [],
         errors: [
@@ -985,7 +974,7 @@ const PROGRESS_INTERVAL_MS = 30 * 1000
 
 /** Periodic progress while a suite runs. */
 export function startVerifyProgress(
-    suite: string, // TODO: Use type
+    suite: SvgTesterSuite,
     total: number,
     pool: { stats: () => { busyWorkers: number } }
 ): { recordResult: (result: VerifyResult) => void; stop: () => void } {
@@ -1017,7 +1006,7 @@ export function startVerifyProgress(
 export const EXIT_CODE_DIFFERENCES = 2
 export const EXIT_CODE_ERROR = 1
 
-export function verifyExitCode(summary: VerifyRunSummary): number {
+export function verifyExitCode(summary: SvgTesterVerifyRunSummary): number {
     if (summary.counts.errors > 0) return EXIT_CODE_ERROR
     if (summary.counts.differences > 0) return EXIT_CODE_DIFFERENCES
     return 0
@@ -1084,7 +1073,7 @@ export async function loadManifestFromPath(
 // Load manifest with appropriate defaults for test suites that require it
 // Returns the manifest view IDs and the data directory to use
 export async function loadManifestViewIds(
-    testSuite: TestSuite,
+    testSuite: SvgTesterSuite,
     options: {
         targetViewIds?: string[]
         manifestName?: string
@@ -1093,7 +1082,7 @@ export async function loadManifestViewIds(
 ): Promise<{ viewIds: string[] | null; dataDir: string }> {
     const { verbose = false } = options
 
-    const testSuiteDir = path.join(SVG_REPO_PATH, testSuite)
+    const testSuiteDir = path.join(SVG_TESTER_REPO_PATH, testSuite)
     const defaultDataDir = path.join(testSuiteDir, "data")
 
     // For grapher-views and thumbnails, load the manifest to resolve dataDir

--- a/devTools/svgTester/verify-graphs.ts
+++ b/devTools/svgTester/verify-graphs.ts
@@ -8,18 +8,23 @@ import workerpool from "workerpool"
 import * as _ from "lodash-es"
 import { match } from "ts-pattern"
 
+import { SVG_TESTER_REPO_PATH } from "../../settings/serverSettings.js"
 import * as utils from "./utils.js"
 import { JOB_TIMEOUT_MS, MAX_WORKERS } from "./utils.js"
 import { grapherSlugToExportFileKey } from "../../baker/GrapherBakingUtils.js"
-import { ALL_GRAPHER_CHART_TYPES } from "@ourworldindata/types"
+import {
+    ALL_GRAPHER_CHART_TYPES,
+    SVG_TESTER_SUITES,
+    type SvgTesterSuite,
+} from "@ourworldindata/types"
 
 async function verifyGraphers(args: ReturnType<typeof parseArguments>) {
     try {
         // Test suite
-        const testSuite = args.testSuite as utils.TestSuite
+        const testSuite = args.testSuite as SvgTesterSuite
 
         // Input and output directories
-        const testSuiteDir = path.join(utils.SVG_REPO_PATH, testSuite)
+        const testSuiteDir = path.join(SVG_TESTER_REPO_PATH, testSuite)
         const referencesDir = path.join(testSuiteDir, "references")
         const differencesDir = path.join(testSuiteDir, "differences")
 
@@ -185,8 +190,8 @@ async function verifyGraphers(args: ReturnType<typeof parseArguments>) {
         // nothing useful left to do but exit.
         await utils
             .writeVerifyRunFailure(
-                path.join(utils.SVG_REPO_PATH, args.testSuite),
-                args.testSuite as utils.TestSuite,
+                path.join(SVG_TESTER_REPO_PATH, args.testSuite),
+                args.testSuite as SvgTesterSuite,
                 error
             )
             .catch((writeError) => {
@@ -202,7 +207,7 @@ async function verifyGraphers(args: ReturnType<typeof parseArguments>) {
 }
 
 async function main(args: ReturnType<typeof parseArguments>) {
-    const testSuite = args.testSuite as utils.TestSuite
+    const testSuite = args.testSuite as SvgTesterSuite
 
     await match(testSuite)
         .with("graphers", () => verifyGraphers(args))
@@ -222,7 +227,7 @@ function parseArguments() {
             type: "string",
             description: utils.TEST_SUITE_DESCRIPTION,
             default: "graphers",
-            choices: utils.TEST_SUITES,
+            choices: SVG_TESTER_SUITES,
         })
         .parserConfiguration({ "camel-case-expansion": true })
         .options({

--- a/packages/@ourworldindata/types/src/domainTypes/SvgTester.ts
+++ b/packages/@ourworldindata/types/src/domainTypes/SvgTester.ts
@@ -1,0 +1,59 @@
+export const SVG_TESTER_SUITES = [
+    "graphers",
+    "grapher-views",
+    "mdims",
+    "thumbnails",
+] as const
+export type SvgTesterSuite = (typeof SVG_TESTER_SUITES)[number]
+
+export const SVG_TESTER_DIRECTORIES = ["references", "differences"] as const
+export type SvgTesterDirectory = (typeof SVG_TESTER_DIRECTORIES)[number]
+
+export const SVG_TESTER_VERIFY_RESULTS_FILENAME = "verify-results.json"
+
+export type SvgTesterVerifyRunStatus =
+    | "running"
+    | "ok"
+    | "differences"
+    | "error"
+
+export interface SvgTesterVerifyDifferenceEntry {
+    viewId: string
+    queryStr?: string
+    chartType?: string
+    svgFilename: string
+    changedRatio?: number
+}
+
+export interface SvgTesterVerifyErrorEntry {
+    viewId: string
+    kind: "timeout" | "render"
+    message: string
+}
+
+export interface SvgTesterVerifyRunSummary {
+    suite: SvgTesterSuite
+    status: SvgTesterVerifyRunStatus
+    startedAt: string
+    durationMs: number
+    grapherCommit: string | null
+    svgsCommit: string | null
+    counts: {
+        total: number
+        ok: number
+        differences: number
+        errors: number
+    }
+    differences: SvgTesterVerifyDifferenceEntry[]
+    errors: SvgTesterVerifyErrorEntry[]
+}
+
+export interface SvgTesterSuiteStatus {
+    suite: SvgTesterSuite
+    /** Null when the suite has never run */
+    results: SvgTesterVerifyRunSummary | null
+    /** True when the results describe a different grapher commit than the one checked out */
+    isStale: boolean
+    /** True when the file exists but could not be parsed (killed mid-write). */
+    isUnreadable: boolean
+}

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -870,3 +870,4 @@ export {
 export * from "./analyticsTypes/analyticsTypes.js"
 export * from "./domainTypes/Latest.js"
 export * from "./domainTypes/Search.js"
+export * from "./domainTypes/SvgTester.js"

--- a/settings/serverSettings.ts
+++ b/settings/serverSettings.ts
@@ -172,3 +172,6 @@ export const SEARCH_EVAL_URL: string =
     "https://pub-ec761fe0df554b02bc605610f3296000.r2.dev"
 
 export const FIGMA_API_KEY: string = process.env.FIGMA_API_KEY ?? ""
+
+export const SVG_TESTER_REPO_PATH: string =
+    serverSettings.SVG_TESTER_REPO_PATH ?? "../owid-grapher-svgs"


### PR DESCRIPTION
> _Written by Anthropic Claude Opus 5 — @sophiamersmann at the wheel._

Stage 1 of Phase 3 of the [SVG tester redesign](https://github.com/owid/owid-grapher/blob/master/docs/svg-tester-redesign-plan.md). `/admin/svgtester` replaces the generated `differences.html`: a suite index, and per suite every chart that rendered differently. A local run and a staging run are now read through the same page, instead of a file opened off disk and a githack link in a PR comment.

Nothing is removed yet — `create-compare-view.ts` still runs and owidbot still links to it. That goes in Stage 2, once this has been used in anger.

### Five ways to look at a difference

Chosen per chart, because which one answers the question depends on the chart.

| view | question it answers |
| --- | --- |
| Side by side | what do the two renderings look like? |
| Swipe | where did it move? (drag the divider) |
| Overlay | which pixels changed at all? |
| Diff | what changed in the markup? |
| Interactive | does the chart still work? |

**Overlay** stacks the two renderings with `mix-blend-mode: difference` and inverts the result, so unchanged reads as white and only changes show. One CSS property, no canvas, no image library. On the China import map it showed that whole countries had changed colour — which reading the two charts side by side did not make obvious.

**Interactive** embeds both charts live, production against this build. It answers a different question from the others and the difference matters: the tester compares SVGs rendered from the frozen dump in `owid-grapher-svgs`, so both sides share inputs and any difference is down to code. These render from live data and can differ for reasons the tester deliberately controls for.

### Charts that failed to render are now listed

With their kind and message, above the differences, each linking to the chart on this build where it broke. They were counted but never shown, which is backwards — a chart that changed might be fine, one that would not render is not.

### Where the contract lives

`adminSiteServer` must not depend on `devTools/`, and it already depends on `adminSiteClient`, so neither the tester nor the admin could own the shape of `verify-results.json`. Both depend on `@ourworldindata/types`, so it moved there — suites, rendering directories, results filename, run status, difference and error entries, run summary, and the suite status the API returns.

`verify-results.json` also gains `changedRatio`. The tester is the only place that measurement is cheap: it holds both renderings already, so an O(n) estimate costs about a millisecond, where a reader would have to fetch two ~127 KB files per chart. The diff view uses it to recognise an unreadable diff before fetching anything.

### The API

Three read-only routes serving the local `owid-grapher-svgs` checkout. Naming each reachable directory in an explicit route rather than mounting one means the suite's 3.8 GB of dumped inputs and the repo's `.git` are unreachable by construction. `resolveSvgPath` validates on top of that and is unit-tested, since traversal is the part worth locking down.

### `make svgtest` now opens the page

Which means it needs the admin server where before it needed nothing. Accepted deliberately: the alternative is keeping a second, local-only report, which is the duplication this work exists to remove. The target prints the URL rather than opening a browser at nothing when the server is down.

### Libraries

The old report loaded `img-comparison-slider` and `diff2html` from unpkg; neither came back. The text diff uses `react-diff-viewer-continued`, already a dependency and already how `GdocsDiff` and the chart editor show diffs. The swipe control is hand-rolled — a native range input stretched invisibly across the chart, so press-to-jump, drag-to-scrub, arrow keys and a focus target all come for free.

### Testing

Verified at three levels: the handlers directly, real HTTP against a running admin, and every view in a browser against a real `make svgtest` run. A genuine render failure was driven end to end by corrupting one chart's dumped data, which confirmed the `render` error kind, the `status: error` precedence over differences, and the errors list.

Not exercised: the `timeout` error kind, which needs a render exceeding 120 s.

owid-grapher#6917 was the throwaway branch used for the earlier ops-side testing and is closed. A test branch is stacked on top of this PR so the page has real differences to show on staging.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #6927
- <kbd>&nbsp;2&nbsp;</kbd> #6929
- <kbd>&nbsp;1&nbsp;</kbd> #6923 👈 
<!-- GitButler Footer Boundary Bottom -->