### PR TITLE
🔨🤖 report progress while a suite runs

### DIFF
--- a/devTools/svgTester/utils.ts
+++ b/devTools/svgTester/utils.ts
@@ -980,6 +980,40 @@ function resolveCommit(cwd?: string): string | null {
     }
 }
 
+/** How often the run reports progress */
+const PROGRESS_INTERVAL_MS = 30 * 1000
+
+/** Periodic progress while a suite runs. */
+export function startVerifyProgress(
+    suite: string, // TODO: Use type
+    total: number,
+    pool: { stats: () => { busyWorkers: number } }
+): { recordResult: (result: VerifyResult) => void; stop: () => void } {
+    const startedAt = Date.now()
+    const counts = { done: 0, ok: 0, differences: 0, errors: 0 }
+
+    const timer = setInterval(() => {
+        const elapsed = Math.round((Date.now() - startedAt) / 1000)
+        console.log(
+            `${suite}: ${counts.done}/${total} done ` +
+                `(${counts.ok} ok, ${counts.differences} differ, ${counts.errors} errored) · ` +
+                `${pool.stats().busyWorkers} in flight · ${elapsed}s elapsed`
+        )
+    }, PROGRESS_INTERVAL_MS)
+    // Never hold the process open on our account
+    timer.unref?.()
+
+    return {
+        recordResult: (result: VerifyResult) => {
+            counts.done += 1
+            if (result.kind === "ok") counts.ok += 1
+            else if (result.kind === "difference") counts.differences += 1
+            else counts.errors += 1
+        },
+        stop: () => clearInterval(timer),
+    }
+}
+
 export const EXIT_CODE_DIFFERENCES = 2
 export const EXIT_CODE_ERROR = 1
 

--- a/devTools/svgTester/verify-graphs.ts
+++ b/devTools/svgTester/verify-graphs.ts
@@ -102,7 +102,6 @@ async function verifyGraphers(args: ReturnType<typeof parseArguments>) {
                 }
             })
 
-        // if verbose, log how many SVGs we're going to process
         const jobCount = verifyJobs.length
         if (jobCount === 0) {
             utils.logIfVerbose(verbose, "No matching configs found")
@@ -117,12 +116,9 @@ async function verifyGraphers(args: ReturnType<typeof parseArguments>) {
                 })
             )
             process.exit(0)
-        } else {
-            utils.logIfVerbose(
-                verbose,
-                `Verifying ${jobCount} SVG${jobCount > 1 ? "s" : ""}...`
-            )
         }
+
+        console.log(`Verifying ${jobCount} SVG${jobCount > 1 ? "s" : ""}...`)
 
         const pool = workerpool.pool(__dirname + "/worker.ts", {
             minWorkers: 2,
@@ -132,21 +128,36 @@ async function verifyGraphers(args: ReturnType<typeof parseArguments>) {
             },
         })
 
+        const progress = utils.startVerifyProgress(testSuite, jobCount, pool)
+
         // Parallelize the CPU heavy verification using the workerpool library
         // This call will then in parallel take the descriptions of the verifyJobs,
         // load the config and data and intialize a grapher, create the default svg output and check if it's md5 hash is the same as the one in
         // the reference csv file (from the referenceDataByChartKey lookup above). The entire parallel operation returns a promise containing an array
         // of result values.
-        const validationResults: utils.VerifyResult[] = await Promise.all(
-            verifyJobs.map((job) =>
-                pool
-                    .exec("renderAndVerifySvg", [job])
-                    .timeout(JOB_TIMEOUT_MS)
-                    .catch((err: Error) =>
-                        utils.resultError(job.dir.viewId, err)
-                    )
+        let validationResults: utils.VerifyResult[]
+        try {
+            validationResults = await Promise.all(
+                verifyJobs.map((job) =>
+                    pool
+                        .exec("renderAndVerifySvg", [job])
+                        .timeout(JOB_TIMEOUT_MS)
+                        .catch((err: Error) => {
+                            if (err?.name === "TimeoutError")
+                                console.warn(
+                                    `Timed out after ${JOB_TIMEOUT_MS}ms: ${job.dir.viewId}`
+                                )
+                            return utils.resultError(job.dir.viewId, err)
+                        })
+                        .then((result: utils.VerifyResult) => {
+                            progress.recordResult(result)
+                            return result
+                        })
+                )
             )
-        )
+        } finally {
+            progress.stop()
+        }
 
         if (validationResults.length !== verifyJobs.length)
             // This is a sanity check that should never trigger


### PR DESCRIPTION
A suite that stalls and a suite that is merely slow produce identical
output today: nothing at all until the final summary. A thumbnails run on a
staging container recently sat for 52 minutes and printed not one line
before the step timeout killed it, which left no way to tell whether it was
stuck, crawling, or enumerating the wrong number of charts.

Three changes, all output only.

A progress line every 30s: charts done out of total, split by outcome, how
many are in flight, and elapsed. It ticks on a timer rather than every N
charts on purpose — the case worth seeing is the one where nothing
completes, and since the workers are separate threads this still fires
while every one of them is wedged. A completed count that stops moving
beside a full in-flight count is the whole diagnosis. A per-chart counter
would have printed nothing.

Timeouts now say so when they happen. A render that throws already reports
itself from inside the worker, but a workerpool timeout rejects in the
parent and was folded silently into an error result — so the one failure
capable of stalling a whole suite was also the only one that printed
nothing.

The job count is no longer behind --verbose. Without it a log cannot
distinguish a suite that enumerated the views it should from one that
enumerated thousands.