### PR TITLE
🚧 for testing (don't merge)

### DIFF
--- a/packages/@ourworldindata/grapher/src/lineCharts/LineChartThumbnail.tsx
+++ b/packages/@ourworldindata/grapher/src/lineCharts/LineChartThumbnail.tsx
@@ -745,7 +745,7 @@ export class LineChartThumbnail
                     <VerticalAxisZeroLine
                         axis={this.dualAxis.verticalAxis}
                         bounds={this.dualAxis.innerBounds}
-                        strokeWidth={0.5}
+                        strokeWidth={1}
                     />
                 ) : (
                     // The domain line is the baseline at the bottom of the plot.
@@ -754,7 +754,7 @@ export class LineChartThumbnail
                     <VerticalAxisDomainLine
                         verticalAxis={this.dualAxis.verticalAxis}
                         bounds={this.dualAxis.innerBounds}
-                        strokeWidth={0.5}
+                        strokeWidth={1}
                     />
                 )}
                 {!this.dualAxis.horizontalAxis.hideAxis && (

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
@@ -85,7 +85,7 @@ type SVGMouseOrTouchEvent =
     | React.MouseEvent<SVGGElement>
     | React.TouchEvent<SVGGElement>
 
-const DOT_RADIUS = 3.5
+const DOT_RADIUS = 5
 
 const TIME_LABEL_PADDING = 4
 const VERTICAL_LABELS_PADDING = 4


### PR DESCRIPTION
Delete `create-compare-view.ts` (799 lines) and the generated-HTML path with it. The admin serves the diff browser at `/admin/svgtester`, reading `verify-results.json` and the rendered SVGs off the checkout on disk, so there is no report left to generate.

The script already has no callers: the `svgtest*` Makefile targets stopped invoking it when the viewer landed in #6923, and `create_report` in `svg-tester.sh` goes in owid/ops#597.

**The `diff` dependency goes too.** It had no other importer in the repo. The viewer's `react-diff-viewer-continued` declares `diff: ^9.0.0` as a regular dependency (not a peer), so it stays resolvable — the lockfile change is just the one descriptor line off the root workspace.

## Ordering

Stacked on `svgtester-viewer` (#6923), which has to land first — that PR is what removed the Makefile call sites and repointed the readme.

**owid/ops#597 must also merge before this.** Ops changes apply to every open PR the moment they land, so if this merged first, `create_report` would still be calling a script that no longer exists: the call fails, `tester_broke=1`, and the SVG tester step goes red on every open PR that has rebased onto the deletion. The reverse order is harmless — ops just stops invoking code that is still there.

## Testing

`yarn typecheck` passes. Nothing to lint or format-check: the change is one deletion plus two dependency-manifest lines.

Checked before deleting that the three `utils.ts` symbols the script used — `SvgRecord`, `TEST_SUITE_DESCRIPTION`, `parseReferenceCsv` — all still have other consumers in `verify-graphs.ts`, `export-graphs.ts`, `dump-data.ts` and `update-reference-md5s.ts`, so nothing is left stranded behind it.

Part of the SVG tester redesign — item 20a of `docs/svg-tester-redesign-plan.md`.

<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #6927 👈 
- <kbd>&nbsp;2&nbsp;</kbd> #6929
- <kbd>&nbsp;1&nbsp;</kbd> #6923
<!-- GitButler Footer Boundary Bottom -->