### PR TITLE
Give multi-dim gdoc embeds with visible controls the explorer-wide layout

### DIFF
--- a/site/gdocs/components/ArticleBlock.tsx
+++ b/site/gdocs/components/ArticleBlock.tsx
@@ -214,10 +214,14 @@ function ArticleBlockInternal({
         .with({ type: "chart" }, (block) => {
             const resolvedUrl = linkedChart?.resolvedUrl ?? block.url
             const { isExplorer, queryParams } = Url.fromURL(resolvedUrl)
+            const isMultiDim =
+                linkedChart?.configType === ChartConfigType.MultiDim
             const areControlsHidden = queryParams.hideControls === "true"
             const size = block.size ?? BlockSize.Wide
+            // Multi-dims with visible controls render the same full-frame UI
+            // as explorers, so they get the same wide layout.
             const layoutSubtype =
-                isExplorer && !areControlsHidden
+                (isExplorer || isMultiDim) && !areControlsHidden
                     ? `explorer--${size}`
                     : `chart--${size}`
             return (


### PR DESCRIPTION
> _Written by Claude Fable 5 — @pabloarosado at the wheel._

## Problem

A gdoc `{.chart}` block already renders a multi-dim URL with visible controls in the same full frame as an explorer (dropdowns included), but the grid layout only special-cases explorers: multi-dims fall through to the centered `chart--wide` slot (`col-start-4 span-cols-8`) instead of the full-width `explorer--wide` slot (`col-start-2 span-cols-12`). The embed shows up centered and misaligned with the section heading — visible on the /energy topic page now that its explorer embed is being replaced with the energy-mix multi-dim.

## Fix

When picking the layout subtype, treat a multi-dim with visible controls like an explorer (`linkedChart.configType === ChartConfigType.MultiDim`). One conditional in `ArticleBlock.tsx`; no style changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
