### PR TITLE
Misc improvements to the SVG tester pages in the admin

### DIFF
--- a/adminSiteClient/SvgTesterIndexPage.tsx
+++ b/adminSiteClient/SvgTesterIndexPage.tsx
@@ -161,7 +161,7 @@ const columns: TableColumnsType<SvgTesterSuiteStatus> = [
 function StatusTag({ status }: { status: SvgTesterSuiteStatus }) {
     const display = displayStatus(status)
     return (
-        <>
+        <span className="SvgTesterIndexPage__status">
             <Tag color={DISPLAY_STATUS_COLORS[display]}>
                 {DISPLAY_STATUS_LABELS[display]}
             </Tag>
@@ -170,6 +170,6 @@ function StatusTag({ status }: { status: SvgTesterSuiteStatus }) {
                     <Tag color="warning">Stale</Tag>
                 </Tooltip>
             )}
-        </>
+        </span>
     )
 }

--- a/adminSiteClient/SvgTesterIndexPage.tsx
+++ b/adminSiteClient/SvgTesterIndexPage.tsx
@@ -110,12 +110,17 @@ const columns: TableColumnsType<SvgTesterSuiteStatus> = [
     },
     {
         title: "Ran",
-        render: (_, status) =>
-            hasReportedResult(status) ? (
-                <Timeago time={status.results!.startedAt} />
-            ) : (
-                "–"
-            ),
+        render: (_, status) => {
+            const startedAt = status.results?.startedAt
+            if (!startedAt) return "–"
+            if (!hasReportedResult(status))
+                return (
+                    <>
+                        started <Timeago time={startedAt} />
+                    </>
+                )
+            return <Timeago time={startedAt} />
+        },
     },
     {
         title: "Took",

--- a/adminSiteClient/SvgTesterIndexPage.tsx
+++ b/adminSiteClient/SvgTesterIndexPage.tsx
@@ -12,6 +12,7 @@ import {
     displayStatus,
     formatDuration,
     hasFindings,
+    hasReportedResult,
     SvgTesterDisplayStatus,
 } from "./svgTesterHelpers.js"
 
@@ -171,10 +172,4 @@ function StatusTag({ status }: { status: SvgTesterSuiteStatus }) {
             )}
         </>
     )
-}
-
-/** True only when the run actually finished and reported */
-function hasReportedResult(status: SvgTesterSuiteStatus): boolean {
-    const display = displayStatus(status)
-    return display === "ok" || display === "differences" || display === "error"
 }

--- a/adminSiteClient/SvgTesterIndexPage.tsx
+++ b/adminSiteClient/SvgTesterIndexPage.tsx
@@ -130,16 +130,23 @@ const columns: TableColumnsType<SvgTesterSuiteStatus> = [
         render: (_, status) => {
             const commit = status.results?.grapherCommit
             if (!commit) return "–"
-            const short = <code title={commit}>{commit.slice(0, 7)}</code>
-            if (ENV === "development") return short
+            const short = <code>{commit.slice(0, 7)}</code>
+            const link =
+                ENV === "development" ? (
+                    short
+                ) : (
+                    <a
+                        href={`https://github.com/owid/owid-grapher/commit/${commit}`}
+                        target="_blank"
+                        rel="noopener"
+                    >
+                        {short}
+                    </a>
+                )
             return (
-                <a
-                    href={`https://github.com/owid/owid-grapher/commit/${commit}`}
-                    target="_blank"
-                    rel="noopener"
-                >
-                    {short}
-                </a>
+                <Tooltip title={status.grapherCommitSubject ?? commit}>
+                    {link}
+                </Tooltip>
             )
         },
     },

--- a/adminSiteClient/SvgTesterSuitePage.scss
+++ b/adminSiteClient/SvgTesterSuitePage.scss
@@ -5,6 +5,10 @@ $svg-tester-current-frame: #94c2a0;
 $svg-tester-error: #b3261e;
 $svg-tester-error-frame: #dda4a0;
 
+.AdminLayout > main.SvgTesterSuitePage {
+    height: auto;
+}
+
 .SvgTesterSuitePage__nav {
     align-items: baseline;
     display: flex;
@@ -38,9 +42,13 @@ $svg-tester-error-frame: #dda4a0;
 }
 
 .SvgTesterSuitePage__summary {
+    background: $white;
     border-bottom: 1px solid $gray-20;
     margin-bottom: 16px;
-    padding-bottom: 12px;
+    padding: 12px 0;
+    position: sticky;
+    top: 0;
+    z-index: 1;
 }
 
 .SvgTesterSuitePage__headline {

--- a/adminSiteClient/SvgTesterSuitePage.scss
+++ b/adminSiteClient/SvgTesterSuitePage.scss
@@ -76,6 +76,11 @@ $svg-tester-error-frame: #dda4a0;
     border-radius: 2px;
     margin-bottom: 20px;
     padding: 12px;
+
+    &:target {
+        border-color: $blue-40;
+        box-shadow: 0 0 0 3px $blue-10;
+    }
 }
 
 .SvgTesterSuitePage__card-header {
@@ -88,6 +93,17 @@ $svg-tester-error-frame: #dda4a0;
 .SvgTesterSuitePage__identity {
     min-width: 0;
     overflow-wrap: anywhere;
+}
+
+.SvgTesterSuitePage__anchor {
+    color: $gray-60;
+    font-weight: bold;
+    text-decoration: none;
+
+    &:hover {
+        color: $gray-100;
+        text-decoration: none;
+    }
 }
 
 .SvgTesterSuitePage__chart-type {

--- a/adminSiteClient/SvgTesterSuitePage.scss
+++ b/adminSiteClient/SvgTesterSuitePage.scss
@@ -10,10 +10,6 @@ $svg-tester-error-frame: #dda4a0;
 }
 
 .SvgTesterSuitePage__nav {
-    align-items: baseline;
-    display: flex;
-    gap: 16px;
-    justify-content: space-between;
     margin-bottom: 16px;
 }
 
@@ -49,6 +45,13 @@ $svg-tester-error-frame: #dda4a0;
     position: sticky;
     top: 0;
     z-index: 1;
+}
+
+.SvgTesterSuitePage__headline-row {
+    align-items: baseline;
+    display: flex;
+    gap: 16px;
+    justify-content: space-between;
 }
 
 .SvgTesterSuitePage__headline {

--- a/adminSiteClient/SvgTesterSuitePage.scss
+++ b/adminSiteClient/SvgTesterSuitePage.scss
@@ -62,7 +62,7 @@ $svg-tester-error-frame: #dda4a0;
     color: $svg-tester-error;
 }
 
-.SvgTesterSuitePage__stale {
+.SvgTesterSuitePage__commit {
     border-bottom: 1px dotted $gray-60;
     cursor: help;
 }

--- a/adminSiteClient/SvgTesterSuitePage.tsx
+++ b/adminSiteClient/SvgTesterSuitePage.tsx
@@ -1,5 +1,14 @@
 import { useContext, useEffect, useMemo, useState } from "react"
-import { Alert, Select, Space, Spin, Tag, Tooltip, Typography } from "antd"
+import {
+    Alert,
+    FloatButton,
+    Select,
+    Space,
+    Spin,
+    Tag,
+    Tooltip,
+    Typography,
+} from "antd"
 import ReactDiffViewer, { DiffMethod } from "react-diff-viewer-continued"
 import cx from "clsx"
 import { useQuery } from "@tanstack/react-query"
@@ -216,6 +225,8 @@ export function SvgTesterSuitePage() {
                         </>
                     )}
                 </Spin>
+
+                <FloatButton.BackTop duration={1} />
             </main>
         </AdminLayout>
     )

--- a/adminSiteClient/SvgTesterSuitePage.tsx
+++ b/adminSiteClient/SvgTesterSuitePage.tsx
@@ -1,9 +1,9 @@
-import { useContext, useMemo, useState } from "react"
+import { useContext, useEffect, useMemo, useState } from "react"
 import { Alert, Select, Space, Spin, Tag, Tooltip, Typography } from "antd"
 import ReactDiffViewer, { DiffMethod } from "react-diff-viewer-continued"
 import cx from "clsx"
 import { useQuery } from "@tanstack/react-query"
-import { Link, useParams } from "react-router-dom"
+import { Link, useHistory, useLocation, useParams } from "react-router-dom"
 import * as _ from "lodash-es"
 import {
     SvgTesterDirectory,
@@ -41,10 +41,23 @@ const KIND_LABELS: Record<SvgTesterVerifyErrorEntry["kind"], string> = {
 /** Skip the diff when this much of the file changed */
 const MAX_CHANGED_RATIO = 0.25
 
+const CHART_TYPE_PARAM = "chartType"
+
 export function SvgTesterSuitePage() {
     const { admin } = useContext(AdminAppContext)
     const { suite } = useParams<{ suite: string }>()
-    const [chartType, setChartType] = useState<string>("all")
+    const location = useLocation()
+    const history = useHistory()
+
+    const chartType =
+        new URLSearchParams(location.search).get(CHART_TYPE_PARAM) ?? "all"
+
+    const setChartType = (value: string): void => {
+        const params = new URLSearchParams(location.search)
+        if (value === "all") params.delete(CHART_TYPE_PARAM)
+        else params.set(CHART_TYPE_PARAM, value)
+        history.replace({ search: params.toString(), hash: "" })
+    }
 
     const { data, isLoading } = useQuery({
         queryKey: ["svgtester-results", suite],
@@ -74,6 +87,13 @@ export function SvgTesterSuitePage() {
     )
 
     const status = data ? displayStatus(data) : undefined
+
+    // The browser jumps to the fragment before the cards it names exist: they
+    // only render once the results have loaded.
+    useEffect(() => {
+        if (!location.hash) return
+        document.getElementById(location.hash.slice(1))?.scrollIntoView()
+    }, [location.hash, results])
 
     return (
         <AdminLayout title={`SVG tester: ${suite}`}>
@@ -172,7 +192,7 @@ export function SvgTesterSuitePage() {
 
                             {visible.map((entry) => (
                                 <DifferenceCard
-                                    key={differenceKey(entry)}
+                                    key={anchorId(entry.viewId, entry.queryStr)}
                                     suite={suite}
                                     entry={entry}
                                 />
@@ -233,6 +253,7 @@ function DifferenceCard({
     const [mode, setMode] = useState<ViewMode>("side-by-side")
     const beforeUrl = svgUrl(suite, "references", entry)
     const afterUrl = svgUrl(suite, "differences", entry)
+    const anchor = anchorId(entry.viewId, entry.queryStr)
 
     // A thumbnail is a 300x160 rendering of a chart; the live chart is the full
     // one, so there is nothing for an interactive view to compare against.
@@ -242,10 +263,17 @@ function DifferenceCard({
             : VIEW_MODE_OPTIONS
 
     return (
-        <section className="SvgTesterSuitePage__card">
+        <section className="SvgTesterSuitePage__card" id={anchor}>
             <header className="SvgTesterSuitePage__card-header">
                 <span className="SvgTesterSuitePage__identity">
-                    <strong aria-hidden="true">#</strong>{" "}
+                    <a
+                        className="SvgTesterSuitePage__anchor"
+                        href={`#${anchor}`}
+                        aria-label={`Link to ${entry.viewId}`}
+                        title="Link to this chart"
+                    >
+                        #
+                    </a>{" "}
                     <strong>{entry.viewId}</strong>
                     {entry.queryStr && <code> ?{entry.queryStr}</code>}
                     {entry.chartType && (
@@ -564,7 +592,7 @@ async function fetchText(url: string): Promise<string> {
     return response.text()
 }
 
-/** Stable identifier for a difference, unique within a suite. */
-function differenceKey(entry: SvgTesterVerifyDifferenceEntry): string {
-    return entry.queryStr ? `${entry.viewId}?${entry.queryStr}` : entry.viewId
+function anchorId(viewId: string, queryStr?: string): string {
+    const id = queryStr ? `${viewId}--${queryStr}` : viewId
+    return id.replaceAll(/[^\w-]+/g, "-")
 }

--- a/adminSiteClient/SvgTesterSuitePage.tsx
+++ b/adminSiteClient/SvgTesterSuitePage.tsx
@@ -112,69 +112,74 @@ export function SvgTesterSuitePage() {
             <main className="SvgTesterSuitePage">
                 <div className="SvgTesterSuitePage__nav">
                     <Link to="/svgtester">← All suites</Link>
-                    <SuiteSwitcher currentSuite={suite} />
                 </div>
 
                 <Spin spinning={isLoading}>
-                    {results && (
+                    {data && (
                         <div className="SvgTesterSuitePage__summary">
-                            <div className="SvgTesterSuitePage__headline">
-                                {isReported ? (
-                                    <>
-                                        <strong>
-                                            {results.counts.differences.toLocaleString()}
-                                        </strong>{" "}
-                                        of{" "}
-                                        {results.counts.total.toLocaleString()}{" "}
-                                        charts rendered differently
-                                    </>
-                                ) : (
-                                    status && DISPLAY_STATUS_LABELS[status]
-                                )}
+                            <div className="SvgTesterSuitePage__headline-row">
+                                <div className="SvgTesterSuitePage__headline">
+                                    {results && isReported ? (
+                                        <>
+                                            <strong>
+                                                {results.counts.differences.toLocaleString()}
+                                            </strong>{" "}
+                                            of{" "}
+                                            {results.counts.total.toLocaleString()}{" "}
+                                            charts rendered differently
+                                        </>
+                                    ) : (
+                                        status && DISPLAY_STATUS_LABELS[status]
+                                    )}
+                                </div>
+                                <SuiteSwitcher currentSuite={suite} />
                             </div>
-                            <div className="SvgTesterSuitePage__meta">
-                                {suite} ·{" "}
-                                {isReported ? (
-                                    <>
-                                        ran <Timeago time={results.startedAt} />{" "}
-                                        in {formatDuration(results.durationMs)}
-                                    </>
-                                ) : (
-                                    <>
-                                        started{" "}
-                                        <Timeago time={results.startedAt} />
-                                    </>
-                                )}
-                                {results.counts.errors > 0 && (
-                                    <>
-                                        {" · "}
-                                        <span className="SvgTesterSuitePage__errors">
-                                            {results.counts.errors.toLocaleString()}{" "}
-                                            failed to render
-                                        </span>
-                                    </>
-                                )}
-                                {results.grapherCommit && (
-                                    <>
-                                        {" · "}
-                                        <CommitLabel
-                                            commit={results.grapherCommit}
-                                            subject={data?.grapherCommitSubject}
-                                            isStale={data?.isStale}
-                                        />
-                                    </>
-                                )}
-                            </div>
+                            {results && (
+                                <div className="SvgTesterSuitePage__meta">
+                                    {suite} ·{" "}
+                                    {isReported ? (
+                                        <>
+                                            ran{" "}
+                                            <Timeago time={results.startedAt} />{" "}
+                                            in{" "}
+                                            {formatDuration(results.durationMs)}
+                                        </>
+                                    ) : (
+                                        <>
+                                            started{" "}
+                                            <Timeago time={results.startedAt} />
+                                        </>
+                                    )}
+                                    {results.counts.errors > 0 && (
+                                        <>
+                                            {" · "}
+                                            <span className="SvgTesterSuitePage__errors">
+                                                {results.counts.errors.toLocaleString()}{" "}
+                                                failed to render
+                                            </span>
+                                        </>
+                                    )}
+                                    {results.grapherCommit && (
+                                        <>
+                                            {" · "}
+                                            <CommitLabel
+                                                commit={results.grapherCommit}
+                                                subject={
+                                                    data.grapherCommitSubject
+                                                }
+                                                isStale={data.isStale}
+                                            />
+                                        </>
+                                    )}
+                                </div>
+                            )}
                         </div>
                     )}
 
                     {results && <SvgTesterErrors errors={results.errors} />}
 
-                    {/* The headline already carries the status of a run that
-                        never reported; this is for the ones with no results
-                        file at all, and for runs that found nothing. */}
                     {status &&
-                        (isReported || !results) &&
+                        isReported &&
                         !differences.length &&
                         !results?.errors.length && (
                             <Alert

--- a/adminSiteClient/SvgTesterSuitePage.tsx
+++ b/adminSiteClient/SvgTesterSuitePage.tsx
@@ -19,6 +19,7 @@ import {
     DISPLAY_STATUS_LABELS,
     formatDuration,
     hasFindings,
+    hasReportedResult,
 } from "./svgTesterHelpers.js"
 
 const LIVE_URL = "https://ourworldindata.org"
@@ -88,6 +89,8 @@ export function SvgTesterSuitePage() {
 
     const status = data ? displayStatus(data) : undefined
 
+    const isReported = data ? hasReportedResult(data) : false
+
     // The browser jumps to the fragment before the cards it names exist: they
     // only render once the results have loaded.
     useEffect(() => {
@@ -107,16 +110,32 @@ export function SvgTesterSuitePage() {
                     {results && (
                         <div className="SvgTesterSuitePage__summary">
                             <div className="SvgTesterSuitePage__headline">
-                                <strong>
-                                    {results.counts.differences.toLocaleString()}
-                                </strong>{" "}
-                                of {results.counts.total.toLocaleString()}{" "}
-                                charts rendered differently
+                                {isReported ? (
+                                    <>
+                                        <strong>
+                                            {results.counts.differences.toLocaleString()}
+                                        </strong>{" "}
+                                        of{" "}
+                                        {results.counts.total.toLocaleString()}{" "}
+                                        charts rendered differently
+                                    </>
+                                ) : (
+                                    status && DISPLAY_STATUS_LABELS[status]
+                                )}
                             </div>
                             <div className="SvgTesterSuitePage__meta">
-                                {suite} · ran{" "}
-                                <Timeago time={results.startedAt} /> in{" "}
-                                {formatDuration(results.durationMs)}
+                                {suite} ·{" "}
+                                {isReported ? (
+                                    <>
+                                        ran <Timeago time={results.startedAt} />{" "}
+                                        in {formatDuration(results.durationMs)}
+                                    </>
+                                ) : (
+                                    <>
+                                        started{" "}
+                                        <Timeago time={results.startedAt} />
+                                    </>
+                                )}
                                 {results.counts.errors > 0 && (
                                     <>
                                         {" · "}
@@ -142,7 +161,11 @@ export function SvgTesterSuitePage() {
 
                     {results && <SvgTesterErrors errors={results.errors} />}
 
+                    {/* The headline already carries the status of a run that
+                        never reported; this is for the ones with no results
+                        file at all, and for runs that found nothing. */}
                     {status &&
+                        (isReported || !results) &&
                         !differences.length &&
                         !results?.errors.length && (
                             <Alert

--- a/adminSiteClient/SvgTesterSuitePage.tsx
+++ b/adminSiteClient/SvgTesterSuitePage.tsx
@@ -647,6 +647,6 @@ async function fetchText(url: string): Promise<string> {
 }
 
 function anchorId(viewId: string, queryStr?: string): string {
-    const id = queryStr ? `${viewId}--${queryStr}` : viewId
-    return id.replaceAll(/[^\w-]+/g, "-")
+    const id = queryStr ? `${viewId}?${queryStr}` : viewId
+    return encodeURIComponent(id)
 }

--- a/adminSiteClient/SvgTesterSuitePage.tsx
+++ b/adminSiteClient/SvgTesterSuitePage.tsx
@@ -126,21 +126,14 @@ export function SvgTesterSuitePage() {
                                         </span>
                                     </>
                                 )}
-                                {data?.isStale && (
+                                {results.grapherCommit && (
                                     <>
                                         {" · "}
-                                        <Tooltip title="These results describe a different grapher commit than the one checked out here. Re-run the suite to be sure they still describe your working tree.">
-                                            <span className="SvgTesterSuitePage__stale">
-                                                from commit{" "}
-                                                <code>
-                                                    {results.grapherCommit?.slice(
-                                                        0,
-                                                        7
-                                                    )}
-                                                </code>
-                                                , not the one checked out
-                                            </span>
-                                        </Tooltip>
+                                        <CommitLabel
+                                            commit={results.grapherCommit}
+                                            subject={data?.grapherCommitSubject}
+                                            isStale={data?.isStale}
+                                        />
                                     </>
                                 )}
                             </div>
@@ -240,6 +233,28 @@ function SuiteSwitcher({ currentSuite }: { currentSuite: string | undefined }) {
                 </Link>
             ))}
         </nav>
+    )
+}
+
+function CommitLabel({
+    commit,
+    subject,
+    isStale,
+}: {
+    commit: string
+    subject: string | null | undefined
+    isStale: boolean | undefined
+}) {
+    return (
+        <>
+            commit{" "}
+            <Tooltip title={subject ?? commit}>
+                <code className="SvgTesterSuitePage__commit">
+                    {commit.slice(0, 7)}
+                </code>
+            </Tooltip>
+            {isStale && " (stale)"}
+        </>
     )
 }
 

--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -1918,3 +1918,8 @@ main:not(.ChartEditorPage):not(.GdocsEditPage):not(.MultiDimDetailPage) {
     margin-bottom: 16px;
     color: $gray-70;
 }
+
+.SvgTesterIndexPage__status {
+    display: inline-flex;
+    gap: 8px;
+}

--- a/adminSiteClient/svgTesterHelpers.ts
+++ b/adminSiteClient/svgTesterHelpers.ts
@@ -28,6 +28,12 @@ export function displayStatus(
     return "ok"
 }
 
+/** True only when the run actually finished and reported */
+export function hasReportedResult(status: SvgTesterSuiteStatus): boolean {
+    const display = displayStatus(status)
+    return display === "ok" || display === "differences" || display === "error"
+}
+
 /** True when the suite page has something to show: differences or render errors */
 export function hasFindings(status: SvgTesterSuiteStatus): boolean {
     const counts = status.results?.counts

--- a/adminSiteServer/apiRoutes/svgTester.ts
+++ b/adminSiteServer/apiRoutes/svgTester.ts
@@ -40,6 +40,23 @@ async function headCommit(cwd?: string): Promise<string | null> {
     }
 }
 
+/** Subject line of a commit, or null when it isn't in this checkout's history */
+async function commitSubject(commit: string | null): Promise<string | null> {
+    // The sha comes out of a file on disk, so don't hand git anything shaped
+    // like an option or a revision range.
+    if (!commit || !/^[0-9a-f]{7,40}$/i.test(commit)) return null
+    try {
+        const { stdout } = await execFileAsync(
+            "git",
+            ["log", "-1", "--format=%s", commit, "--"],
+            { encoding: "utf-8" }
+        )
+        return stdout.trim() || null
+    } catch {
+        return null
+    }
+}
+
 async function readResults(suite: SvgTesterSuite): Promise<{
     results: SvgTesterVerifyRunSummary | null
     isUnreadable: boolean
@@ -77,7 +94,16 @@ export async function getSvgTesterSuites(): Promise<{
                 grapherHead &&
                 results.grapherCommit !== grapherHead
             )
-            return { suite, results, isStale, isUnreadable }
+            const grapherCommitSubject = await commitSubject(
+                results?.grapherCommit ?? null
+            )
+            return {
+                suite,
+                results,
+                grapherCommitSubject,
+                isStale,
+                isUnreadable,
+            }
         })
     )
 
@@ -98,7 +124,11 @@ export async function getSvgTesterResults(
         results.grapherCommit !== grapherHead
     )
 
-    return { suite, results, isStale, isUnreadable }
+    const grapherCommitSubject = await commitSubject(
+        results?.grapherCommit ?? null
+    )
+
+    return { suite, results, grapherCommitSubject, isStale, isUnreadable }
 }
 
 /** Serve one SVG out of the svgs checkout */

--- a/packages/@ourworldindata/types/src/domainTypes/SvgTester.ts
+++ b/packages/@ourworldindata/types/src/domainTypes/SvgTester.ts
@@ -52,6 +52,8 @@ export interface SvgTesterSuiteStatus {
     suite: SvgTesterSuite
     /** Null when the suite has never run */
     results: SvgTesterVerifyRunSummary | null
+    /** Subject line of `results.grapherCommit`, null when it isn't in local history */
+    grapherCommitSubject: string | null
     /** True when the results describe a different grapher commit than the one checked out */
     isStale: boolean
     /** True when the file exists but could not be parsed (killed mid-write). */


### PR DESCRIPTION
> _Written by Anthropic Claude Opus 5 — @sophiamersmann at the wheel._

A batch of small usability fixes to the SVG tester pages in the admin.

**Knowing what you're looking at**

- Each difference card on the suite page gets an anchor, so you can link someone to one chart instead of to the whole report.
- The grapher commit a run describes is now on the suite page always, not only when it's stale, and its subject line is the tooltip on the sha on both pages. The subject is resolved server-side from local git history at read time rather than recorded in `verify-results.json`, so existing results files get it without a re-run.
- A run that was killed or is still in flight writes zeroed placeholder counts and a zero duration. Those were rendered as though they were results — "0 of 0 charts rendered differently" on the suite page, and dashes in every column of the index table. Both now show the run's status and when it started.

**Getting around a long report**

- The summary block and the suite switcher stay stuck to the top while you scroll, and there's a back-to-top button, since a report can run to hundreds of cards. This needs the page to opt out of `AdminLayout`'s one-viewport height, or a sticky child comes unstuck after a screenful.
- Spacing between the status tags on the index table, which antd 6 no longer provides.