### PR TITLE
🚧🤖 [test] prefix on every chart title, for exercising ops#597

### DIFF
--- a/bespoke/readme.md
+++ b/bespoke/readme.md
@@ -124,6 +124,8 @@ export default defineConfig({
 })
 ```
 
+change
+
 Then render `<StylesTarget />` in your component tree:
 
 ```tsx

--- a/packages/@ourworldindata/grapher/src/header/Header.tsx
+++ b/packages/@ourworldindata/grapher/src/header/Header.tsx
@@ -73,7 +73,10 @@ abstract class AbstractHeader<
     }
 
     @computed protected get titleText(): string {
-        return this.manager.mainTitle?.trim() ?? ""
+        const title = this.manager.mainTitle?.trim() ?? ""
+        // TEMPORARY: forces every chart to render differently so the SVG
+        // tester reports diffs. Do not merge.
+        return title ? `[test] ${title}` : title
     }
 
     @computed protected get titleAnnotationText(): string {


### PR DESCRIPTION
🚧 Do not merge — throwaway test branch

> _Written by Claude Opus 5 — @sophiamersmann at the wheel._

Prefixes every chart title with `[test]` so every chart renders differently and
the SVG tester reports differences in every suite.

This exists only to exercise https://github.com/owid/ops/pull/597 on a staging
container: the branch name matches that PR's head ref, so this branch's builds
pick up the changed `svg-tester.sh`. What we're checking is that a branch build
makes zero commits and zero pushes to `owid-grapher-svgs` between the last suite
and the end of the step, while the report link in the owidbot comment still
resolves.

Delete once that's confirmed.