### PR TITLE
🐛 Stop a wedged worker hanging the whole SVG tester suite

### DIFF
--- a/adminSiteClient/SvgTesterSuitePage.tsx
+++ b/adminSiteClient/SvgTesterSuitePage.tsx
@@ -98,6 +98,13 @@ export function SvgTesterSuitePage() {
         [differences, chartType]
     )
 
+    // Charts an aborted run never reached are not evidence of anything, so they
+    // stay out of the denominator
+    const checked = results
+        ? results.counts.total -
+          results.errors.filter((error) => error.kind === "stalled").length
+        : 0
+
     const status = data ? displayStatus(data) : undefined
 
     const isReported = data ? hasReportedResult(data) : false
@@ -126,9 +133,8 @@ export function SvgTesterSuitePage() {
                                             <strong>
                                                 {results.counts.differences.toLocaleString()}
                                             </strong>{" "}
-                                            of{" "}
-                                            {results.counts.total.toLocaleString()}{" "}
-                                            charts rendered differently
+                                            of {checked.toLocaleString()} charts
+                                            rendered differently
                                         </>
                                     ) : (
                                         status && DISPLAY_STATUS_LABELS[status]

--- a/adminSiteClient/SvgTesterSuitePage.tsx
+++ b/adminSiteClient/SvgTesterSuitePage.tsx
@@ -47,6 +47,7 @@ const VIEW_MODE_OPTIONS: { label: string; value: ViewMode }[] = [
 const KIND_LABELS: Record<SvgTesterVerifyErrorEntry["kind"], string> = {
     timeout: "Timed out",
     render: "Failed to render",
+    stalled: "Never ran",
 }
 
 /** Skip the diff when this much of the file changed */
@@ -438,8 +439,11 @@ function SvgTesterErrors({ errors }: { errors: SvgTesterVerifyErrorEntry[] }) {
                 not render
             </h2>
             <ul className="SvgTesterErrors__list">
-                {errors.map((error) => (
-                    <li key={error.viewId} className="SvgTesterErrors__item">
+                {errors.map((error, index) => (
+                    <li
+                        key={`${error.viewId}-${index}`}
+                        className="SvgTesterErrors__item"
+                    >
                         <div className="SvgTesterErrors__view">
                             <a
                                 className="SvgTesterErrors__slug"

--- a/devTools/svgTester/export-graphs.ts
+++ b/devTools/svgTester/export-graphs.ts
@@ -10,6 +10,7 @@ import type { Pool } from "workerpool"
 
 import { SVG_TESTER_REPO_PATH } from "../../settings/serverSettings.js"
 import * as utils from "./utils.js"
+import { registerExitHandler } from "../../db/cleanup.js"
 import {
     ALL_GRAPHER_CHART_TYPES,
     SVG_TESTER_SUITES,
@@ -115,11 +116,20 @@ async function exportGraphers(args: ReturnType<typeof parseArguments>) {
             // so the catch can shut the pool down.
             const activePool = utils.createSvgTesterPool()
             pool = activePool
+            // Ctrl-C and a cancelled Buildkite step both kill this process
+            // without reaching the shutdown below, and child workers - unlike
+            // the threads they replaced - outlive their parent.
+            registerExitHandler(() => utils.shutDownPool(activePool))
 
-            // Parallelize the CPU heavy rendering jobs
+            // Parallelize the CPU heavy rendering jobs. Time-boxed like the
+            // verify side: a worker parked in oxfmt's native formatter never
+            // settles, and refresh.sh runs this with no `timeout` wrapper at
+            // all, so without this the export just hangs forever.
             svgRecords = await Promise.all(
                 jobDescriptions.map((job) =>
-                    activePool.exec("renderSvgAndSave", [job])
+                    activePool
+                        .exec("renderSvgAndSave", [job])
+                        .timeout(utils.JOB_TIMEOUT_MS)
                 )
             )
         } else {

--- a/devTools/svgTester/export-graphs.ts
+++ b/devTools/svgTester/export-graphs.ts
@@ -6,11 +6,10 @@ import fs from "fs-extra"
 import yargs from "yargs"
 import { hideBin } from "yargs/helpers"
 import path from "path"
-import workerpool from "workerpool"
+import type { Pool } from "workerpool"
 
 import { SVG_TESTER_REPO_PATH } from "../../settings/serverSettings.js"
 import * as utils from "./utils.js"
-import { MAX_WORKERS } from "./utils.js"
 import {
     ALL_GRAPHER_CHART_TYPES,
     SVG_TESTER_SUITES,
@@ -18,6 +17,9 @@ import {
 } from "@ourworldindata/types"
 
 async function exportGraphers(args: ReturnType<typeof parseArguments>) {
+    // Declared out here so the catch below can shut it down too: that path is a
+    // crash, which is precisely when orphaned workers are easiest to leave behind.
+    let pool: Pool | undefined
     try {
         // Test suite
         const testSuite = args.testSuite as SvgTesterSuite
@@ -108,42 +110,40 @@ async function exportGraphers(args: ReturnType<typeof parseArguments>) {
 
         let svgRecords: utils.SvgRecord[] = []
         if (!isolate) {
-            const pool = workerpool.pool(__dirname + "/worker.ts", {
-                minWorkers: 2,
-                maxWorkers: MAX_WORKERS,
-                workerThreadOpts: {
-                    execArgv: ["--require", "tsx"],
-                },
-            })
+            // `activePool` is what the closure below uses: narrowing does
+            // not survive a captured `let`, and the outer binding only exists
+            // so the catch can shut the pool down.
+            const activePool = utils.createSvgTesterPool()
+            pool = activePool
 
             // Parallelize the CPU heavy rendering jobs
             svgRecords = await Promise.all(
                 jobDescriptions.map((job) =>
-                    pool.exec("renderSvgAndSave", [job])
+                    activePool.exec("renderSvgAndSave", [job])
                 )
             )
         } else {
             let i = 1
             for (const job of jobDescriptions) {
-                const pool = workerpool.pool(__dirname + "/worker.ts", {
-                    maxWorkers: 1,
-                    workerThreadOpts: {
-                        execArgv: ["--require", "tsx"],
-                    },
-                })
+                pool = utils.createSvgTesterPool(1)
                 const svgRecord = await pool.exec("renderSvgAndSave", [job])
-                pool.terminate()
+                // Awaited, unlike before: a pool per job means an un-awaited
+                // teardown would leave a process behind on every iteration.
+                await utils.shutDownPool(pool)
+                pool = undefined
                 svgRecords.push(svgRecord)
                 console.log(i++, "/", jobCount)
             }
         }
 
         await utils.writeReferenceCsv(outDir, svgRecords)
+        if (pool) await utils.shutDownPool(pool)
         // This call to exit is necessary for some unknown reason to make sure that the process terminates. It
         // was not required before introducing the multiprocessing library.
         process.exit(0)
     } catch (error) {
         console.error("Encountered an error: ", error)
+        if (pool) await utils.shutDownPool(pool)
         // This call to exit is necessary for some unknown reason to make sure that the process terminates. It
         // was not required before introducing the multiprocessing library.
         process.exit(-1)

--- a/devTools/svgTester/readme.md
+++ b/devTools/svgTester/readme.md
@@ -83,7 +83,14 @@ Use `verify-graphs.ts` to check SVG outputs against the reference export. The sc
 - Compares the MD5 hash with the reference
 - If there's a difference, saves the new SVG to the differences directory and reports it
 - Writes `verify-results.json` recording the outcome: status, counts, which views differed and which errored
-- Returns a non-zero exit code only if the tester itself malfunctioned (a render crashed, a reference was missing, a job timed out). Differences are the expected output and exit 0 — read `verify-results.json` to find out how many there were
+- Returns an exit code saying what kind of outcome it was:
+
+| Code | Meaning                                                                                                                                                                   |
+| ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 0    | Every chart matched its reference                                                                                                                                         |
+| 1    | At least one chart failed to render (a crash, a missing reference, a job timeout)                                                                                         |
+| 2    | Charts rendered differently — the expected outcome of a rendering change, not a failure. The Makefile targets treat it as a pass; read `verify-results.json` for the list |
+| 3    | The suite gave up part-way because the worker pool went sick, so most charts were never checked. Worth retrying: unlike 1, it says nothing about the charts               |
 
 The script works with test suites stored in the directory structure:
 

--- a/devTools/svgTester/utils.ts
+++ b/devTools/svgTester/utils.ts
@@ -21,6 +21,7 @@ import {
 } from "@ourworldindata/utils"
 import fs, { stat } from "fs-extra"
 import path from "path"
+import workerpool from "workerpool"
 import stream from "stream"
 import { execFileSync } from "child_process"
 import {
@@ -98,8 +99,19 @@ export const resultError = (viewId: string, error: Error): VerifyResult => ({
 // safety margin so one stuck render can't hang the entire run indefinitely.
 export const JOB_TIMEOUT_MS = 2 * 60 * 1000
 
-// Each worker is a separate Node worker_thread with its own V8 isolate/heap -
-// heap is not shared, so peak memory scales close to linearly with worker count
+// Total silence for this long means the pool has stopped dispatching
+// altogether - see the comment on createSvgTesterPool for how that happens -
+// and no per-job guard can see it, because the jobs left are all still queued
+// and a queued job hasn't armed its timer yet.
+export const STALL_TIMEOUT_MS = 2 * JOB_TIMEOUT_MS
+
+/** Raised when a suite gives up part-way rather than running to the end */
+export class SuiteAbortedError extends Error {
+    override name = "SuiteAbortedError"
+}
+
+// Each worker is a separate Node process with its own V8 isolate/heap - heap is
+// not shared, so peak memory scales close to linearly with worker count
 // regardless of how much of that concurrency is actually used. Swept 4/6/8/12 on
 // a 300-chart sample under two different host-contention levels (see the
 // verify-graphs PR description for both full tables) - 6 came out as the sweet
@@ -107,6 +119,61 @@ export const JOB_TIMEOUT_MS = 2 * 60 * 1000
 // wall-clock, not just a cheaper-but-slower tradeoff. Override via
 // SVG_TESTER_MAX_WORKERS on memory-constrained hosts.
 export const MAX_WORKERS = Number(process.env.SVG_TESTER_MAX_WORKERS) || 6
+
+// A worker that wedges fails every job handed to it, so an unbroken run of
+// timeouts means the pool is sick rather than the charts being slow. Bail
+// rather than spend JOB_TIMEOUT_MS on each job that is left. Only timeouts
+// count: a change that breaks a whole chart type legitimately errors many
+// charts in a row, and the run should report all of them.
+export const MAX_CONSECUTIVE_TIMEOUTS = 3 * MAX_WORKERS
+
+/**
+ * Workers are separate processes rather than worker_threads.
+ *
+ * Rendering calls into native addons (oxfmt formats every SVG), and a thread
+ * parked inside a N-API call cannot be reclaimed: `Worker.terminate()` only
+ * unwinds JS, so workerpool can neither kill nor replace it and the pool stops
+ * dispatching for good. A child process is killable, so the per-job timeout can
+ * actually recover the pool. Costs a slower worker start than a thread; the
+ * heap was never shared between workers anyway.
+ */
+export function createSvgTesterPool(
+    maxWorkers: number = MAX_WORKERS
+): workerpool.Pool {
+    return workerpool.pool(path.join(__dirname, "worker.ts"), {
+        minWorkers: Math.min(2, maxWorkers),
+        maxWorkers,
+        workerType: "process",
+        forkOpts: {
+            execArgv: ["--require", "tsx"],
+            // A render error travels home inside the result rather than as a
+            // rejection, and `fork`'s default JSON serialization flattens an
+            // Error to `{}` - name, message and stack all gone. Structured
+            // clone keeps them, which is what worker_threads gave us for free.
+            serialization: "advanced",
+        },
+    })
+}
+
+/** How long to wait for workers to die before leaving without them */
+const POOL_TERMINATE_TIMEOUT_MS = 10 * 1000
+
+/**
+ * Must be awaited before any `process.exit()` that follows a pool.
+ *
+ * `process.exit()` took worker threads with it; it does not take child
+ * processes, and an orphaned worker is reparented to pid 1 and runs on after
+ * the build that started it. Nothing on the staging boxes reaps those.
+ */
+export async function shutDownPool(pool: workerpool.Pool): Promise<void> {
+    // Force, because a wedged worker is exactly the case this has to handle,
+    // and time-boxed, because we are on our way out either way.
+    await pool
+        .terminate(true, POOL_TERMINATE_TIMEOUT_MS)
+        .catch((error: unknown) =>
+            console.error("Could not shut the worker pool down: ", error)
+        )
+}
 
 const resultDifference = (difference: SvgDifference): VerifyResult => ({
     kind: "difference",
@@ -813,12 +880,15 @@ export async function renderAndVerifySvg({
     }
 }
 
-// A `.timeout()` breach and a render crash both arrive through the same `.catch`
-// in verify-graphs.ts, so the only thing distinguishing them is the error name
-// workerpool gives a timeout. Errors crossing a worker boundary are structured
-// clones rather than real Error instances, hence the defensive access.
+// A `.timeout()` breach, a job the suite gave up on and a render crash all
+// arrive through the same `.catch` in verify-graphs.ts, so the only thing
+// distinguishing them is the error name workerpool gives a timeout (and the one
+// SuiteAbortedError gives itself). Errors crossing a worker boundary are
+// structured clones rather than real Error instances, hence the defensive access.
 function classifyVerifyError(error: Error): SvgTesterVerifyErrorEntry["kind"] {
-    return error?.name === "TimeoutError" ? "timeout" : "render"
+    if (error?.name === "TimeoutError") return "timeout"
+    if (error?.name === "SuiteAbortedError") return "stalled"
+    return "render"
 }
 
 // Several failure paths in here `throw` a plain string rather than an Error, and
@@ -995,14 +1065,86 @@ export function startVerifyProgress(
     }
 }
 
+/**
+ * Watches a run for the two ways a sick worker pool wastes the rest of a suite:
+ * going silent altogether (STALL_TIMEOUT_MS) and timing out job after job
+ * (MAX_CONSECUTIVE_TIMEOUTS). `aborted` resolves when either happens, so the
+ * caller can stop waiting on jobs that are never going to be worth waiting for.
+ */
+export function startRunGuard(
+    options: {
+        stallTimeoutMs?: number
+        maxConsecutiveTimeouts?: number
+    } = {}
+): {
+    recordResult: (result: VerifyResult) => void
+    aborted: Promise<SuiteAbortedError>
+    stop: () => void
+} {
+    const stallTimeoutMs = options.stallTimeoutMs ?? STALL_TIMEOUT_MS
+    const maxConsecutiveTimeouts =
+        options.maxConsecutiveTimeouts ?? MAX_CONSECUTIVE_TIMEOUTS
+
+    let lastResultAt = Date.now()
+    let consecutiveTimeouts = 0
+    let timer: NodeJS.Timeout | undefined
+    let abort: (error: SuiteAbortedError) => void
+
+    const aborted = new Promise<SuiteAbortedError>((resolve) => {
+        abort = resolve
+        // Deliberately not unref'd, unlike the progress timer: this timer is the
+        // only thing left holding the loop open in exactly the case it exists to
+        // report, and an empty event loop exits 0 - a stalled suite would go out
+        // green. `stop()` is what lets the process end.
+        timer = setInterval(() => {
+            const idleMs = Date.now() - lastResultAt
+            if (idleMs >= stallTimeoutMs)
+                resolve(
+                    new SuiteAbortedError(
+                        `No verify job reported back for ${Math.round(idleMs / 1000)}s - the worker pool is wedged`
+                    )
+                )
+        }, STALL_CHECK_INTERVAL_MS)
+    })
+
+    return {
+        recordResult: (result: VerifyResult) => {
+            lastResultAt = Date.now()
+            const isTimeout =
+                result.kind === "error" &&
+                classifyVerifyError(result.error) === "timeout"
+            consecutiveTimeouts = isTimeout ? consecutiveTimeouts + 1 : 0
+            if (consecutiveTimeouts >= maxConsecutiveTimeouts)
+                abort(
+                    new SuiteAbortedError(
+                        `${consecutiveTimeouts} verify jobs timed out in a row - the worker pool is wedged`
+                    )
+                )
+        },
+        aborted,
+        stop: () => clearInterval(timer),
+    }
+}
+
+/** How often the run guard checks for silence; well below STALL_TIMEOUT_MS */
+const STALL_CHECK_INTERVAL_MS = 10 * 1000
+
 const EXIT_CODE_DIFFERENCES = 2
 const EXIT_CODE_ERROR = 1
+// Distinct from a plain error so CI can retry a suite the pool killed rather
+// than one that genuinely found broken charts - see svg-tester.sh in owid/ops.
+const EXIT_CODE_ABORTED = 3
 
 export function verifyExitCode(summary: SvgTesterVerifyRunSummary): number {
+    if (summary.errors.some((error) => error.kind === "stalled"))
+        return EXIT_CODE_ABORTED
     if (summary.counts.errors > 0) return EXIT_CODE_ERROR
     if (summary.counts.differences > 0) return EXIT_CODE_DIFFERENCES
     return 0
 }
+
+/** Cap on how many errored views the console report names one by one */
+const MAX_ERRORS_LOGGED = 20
 
 // Human-facing output. The machine-readable version of all this is
 // verify-results.json.
@@ -1028,9 +1170,13 @@ export function reportVerifyResults(
 
     if (errorResults.length) {
         console.warn(`${errorResults.length} graphs threw errors`)
-        for (const result of errorResults) {
+        // A stalled run errors every job it never reached, which is hundreds of
+        // identical lines; the full list is in verify-results.json either way.
+        for (const result of errorResults.slice(0, MAX_ERRORS_LOGGED)) {
             console.log(`${result.viewId}: ${verifyErrorMessage(result.error)}`)
         }
+        const remaining = errorResults.length - MAX_ERRORS_LOGGED
+        if (remaining > 0) console.log(`... and ${remaining} more`)
     }
 
     if (differenceResults.length) {

--- a/devTools/svgTester/utils.ts
+++ b/devTools/svgTester/utils.ts
@@ -136,6 +136,9 @@ export const MAX_CONSECUTIVE_TIMEOUTS = 3 * MAX_WORKERS
  * dispatching for good. A child process is killable, so the per-job timeout can
  * actually recover the pool. Costs a slower worker start than a thread; the
  * heap was never shared between workers anyway.
+ *
+ * Killable only because worker.ts drops the SIGTERM handler it would otherwise
+ * inherit from this module - see the comment there.
  */
 export function createSvgTesterPool(
     maxWorkers: number = MAX_WORKERS
@@ -148,8 +151,12 @@ export function createSvgTesterPool(
             execArgv: ["--require", "tsx"],
             // A render error travels home inside the result rather than as a
             // rejection, and `fork`'s default JSON serialization flattens an
-            // Error to `{}` - name, message and stack all gone. Structured
-            // clone keeps them, which is what worker_threads gave us for free.
+            // Error to `{}` - message and stack gone. Structured clone keeps
+            // both, which is what worker_threads gave us for free. It does not
+            // keep a custom `name` though: anything outside the handful of
+            // built-in error types arrives as "Error", so classifyVerifyError
+            // works only because every name it matches is minted in this
+            // process rather than in a worker.
             serialization: "advanced",
         },
     })
@@ -168,10 +175,14 @@ const POOL_TERMINATE_TIMEOUT_MS = 10 * 1000
 export async function shutDownPool(pool: workerpool.Pool): Promise<void> {
     // Force, because a wedged worker is exactly the case this has to handle,
     // and time-boxed, because we are on our way out either way.
-    await pool
-        .terminate(true, POOL_TERMINATE_TIMEOUT_MS)
-        .catch((error: unknown) =>
-            console.error("Could not shut the worker pool down: ", error)
+    await pool.terminate(true, POOL_TERMINATE_TIMEOUT_MS)
+    // `terminate` resolves either way - workerpool folds a worker that failed
+    // to die back into a resolved promise - so counting what is left is the
+    // only way to notice one that outlived the deadline.
+    const stranded = pool.stats().totalWorkers
+    if (stranded > 0)
+        console.error(
+            `${stranded} worker process(es) survived ${POOL_TERMINATE_TIMEOUT_MS}ms of shutdown and are being left behind`
         )
 }
 
@@ -988,8 +999,8 @@ export async function writeVerifyRunStarted(
 }
 
 // For failures that happen before or around the run itself (missing directories,
-// an unreadable reference CSV, the job-count sanity check) rather than for a
-// single chart. Without this, such a run leaves no results file at all and is
+// an unreadable reference CSV) rather than for a single chart. Without this,
+// such a run leaves no results file at all and is
 // indistinguishable from a suite that was never started.
 export async function writeVerifyRunFailure(
     testSuiteDir: string,
@@ -1135,9 +1146,15 @@ const EXIT_CODE_ERROR = 1
 // than one that genuinely found broken charts - see svg-tester.sh in owid/ops.
 const EXIT_CODE_ABORTED = 3
 
-export function verifyExitCode(summary: SvgTesterVerifyRunSummary): number {
-    if (summary.errors.some((error) => error.kind === "stalled"))
-        return EXIT_CODE_ABORTED
+// `aborted` comes from the caller rather than being read back out of the
+// results: when the run guard trips on the last outstanding job, every job has
+// a result already, no entry is left to be marked "stalled", and an aborted run
+// would report as a plain error - the one case CI most needs to retry.
+export function verifyExitCode(
+    summary: SvgTesterVerifyRunSummary,
+    aborted: boolean
+): number {
+    if (aborted) return EXIT_CODE_ABORTED
     if (summary.counts.errors > 0) return EXIT_CODE_ERROR
     if (summary.counts.differences > 0) return EXIT_CODE_DIFFERENCES
     return 0
@@ -1171,11 +1188,19 @@ export function reportVerifyResults(
     if (errorResults.length) {
         console.warn(`${errorResults.length} graphs threw errors`)
         // A stalled run errors every job it never reached, which is hundreds of
-        // identical lines; the full list is in verify-results.json either way.
-        for (const result of errorResults.slice(0, MAX_ERRORS_LOGGED)) {
+        // identical lines worth capping. Genuine failures are all named, however
+        // many there are: the CI log is the only place a reader sees them, since
+        // verify-results.json is gitignored and not a Buildkite artifact.
+        const hasStalled = errorResults.some(
+            (result) => classifyVerifyError(result.error) === "stalled"
+        )
+        const logged = hasStalled
+            ? errorResults.slice(0, MAX_ERRORS_LOGGED)
+            : errorResults
+        for (const result of logged) {
             console.log(`${result.viewId}: ${verifyErrorMessage(result.error)}`)
         }
-        const remaining = errorResults.length - MAX_ERRORS_LOGGED
+        const remaining = errorResults.length - logged.length
         if (remaining > 0) console.log(`... and ${remaining} more`)
     }
 

--- a/devTools/svgTester/verify-graphs.ts
+++ b/devTools/svgTester/verify-graphs.ts
@@ -11,6 +11,7 @@ import { SVG_TESTER_REPO_PATH } from "../../settings/serverSettings.js"
 import * as utils from "./utils.js"
 import { JOB_TIMEOUT_MS } from "./utils.js"
 import { grapherSlugToExportFileKey } from "../../baker/GrapherBakingUtils.js"
+import { registerExitHandler } from "../../db/cleanup.js"
 import type { Pool } from "workerpool"
 import {
     ALL_GRAPHER_CHART_TYPES,
@@ -133,6 +134,10 @@ async function verifyGraphers(args: ReturnType<typeof parseArguments>) {
         // catch can shut the pool down.
         const activePool = utils.createSvgTesterPool()
         pool = activePool
+        // Ctrl-C and a cancelled Buildkite step both kill this process without
+        // reaching the shutdown below, and child workers - unlike the threads
+        // they replaced - outlive their parent.
+        registerExitHandler(() => utils.shutDownPool(activePool))
 
         const progress = utils.startVerifyProgress(
             testSuite,
@@ -144,10 +149,10 @@ async function verifyGraphers(args: ReturnType<typeof parseArguments>) {
         // Parallelize the CPU heavy verification using the workerpool library
         // This call will then in parallel take the descriptions of the verifyJobs,
         // load the config and data and intialize a grapher, create the default svg output and check if it's md5 hash is the same as the one in
-        // the reference csv file (from the referenceDataByChartKey lookup above). The entire parallel operation returns a promise containing an array
-        // of result values.
+        // the reference csv file (from the referenceDataByChartKey lookup above).
         // Results land in this array as they settle rather than only at the end,
-        // so a stalled run can still report everything that did finish.
+        // so a stalled run can still report everything that did finish - the
+        // race below resolves as soon as the guard gives up, without them.
         const settledResults: (utils.VerifyResult | undefined)[] = new Array(
             jobCount
         )
@@ -208,7 +213,7 @@ async function verifyGraphers(args: ReturnType<typeof parseArguments>) {
         await utils.shutDownPool(activePool)
         // This call to exit is necessary for some unknown reason to make sure that the process terminates. It
         // was not required before introducing the multiprocessing library.
-        process.exit(utils.verifyExitCode(summary))
+        process.exit(utils.verifyExitCode(summary, !!abortError))
     } catch (error) {
         console.error("Encountered an error: ", error)
         // Record the failure too, so that "the suite never got to run" is

--- a/devTools/svgTester/verify-graphs.ts
+++ b/devTools/svgTester/verify-graphs.ts
@@ -4,14 +4,14 @@ import yargs from "yargs"
 import { hideBin } from "yargs/helpers"
 import fs from "fs-extra"
 import path from "path"
-import workerpool from "workerpool"
 import * as _ from "lodash-es"
 import { match } from "ts-pattern"
 
 import { SVG_TESTER_REPO_PATH } from "../../settings/serverSettings.js"
 import * as utils from "./utils.js"
-import { JOB_TIMEOUT_MS, MAX_WORKERS } from "./utils.js"
+import { JOB_TIMEOUT_MS } from "./utils.js"
 import { grapherSlugToExportFileKey } from "../../baker/GrapherBakingUtils.js"
+import type { Pool } from "workerpool"
 import {
     ALL_GRAPHER_CHART_TYPES,
     SVG_TESTER_SUITES,
@@ -19,6 +19,9 @@ import {
 } from "@ourworldindata/types"
 
 async function verifyGraphers(args: ReturnType<typeof parseArguments>) {
+    // Declared out here so the catch below can shut it down too: that path is a
+    // crash, which is precisely when orphaned workers are easiest to leave behind.
+    let pool: Pool | undefined
     try {
         // Test suite
         const testSuite = args.testSuite as SvgTesterSuite
@@ -125,26 +128,34 @@ async function verifyGraphers(args: ReturnType<typeof parseArguments>) {
 
         console.log(`Verifying ${jobCount} SVG${jobCount > 1 ? "s" : ""}...`)
 
-        const pool = workerpool.pool(__dirname + "/worker.ts", {
-            minWorkers: 2,
-            maxWorkers: MAX_WORKERS,
-            workerThreadOpts: {
-                execArgv: ["--require", "tsx"],
-            },
-        })
+        // `activePool` is what the closures below use: narrowing does not
+        // survive a captured `let`, and the outer binding only exists so the
+        // catch can shut the pool down.
+        const activePool = utils.createSvgTesterPool()
+        pool = activePool
 
-        const progress = utils.startVerifyProgress(testSuite, jobCount, pool)
+        const progress = utils.startVerifyProgress(
+            testSuite,
+            jobCount,
+            activePool
+        )
+        const guard = utils.startRunGuard()
 
         // Parallelize the CPU heavy verification using the workerpool library
         // This call will then in parallel take the descriptions of the verifyJobs,
         // load the config and data and intialize a grapher, create the default svg output and check if it's md5 hash is the same as the one in
         // the reference csv file (from the referenceDataByChartKey lookup above). The entire parallel operation returns a promise containing an array
         // of result values.
-        let validationResults: utils.VerifyResult[]
+        // Results land in this array as they settle rather than only at the end,
+        // so a stalled run can still report everything that did finish.
+        const settledResults: (utils.VerifyResult | undefined)[] = new Array(
+            jobCount
+        )
+        let abortError: utils.SuiteAbortedError | undefined
         try {
-            validationResults = await Promise.all(
-                verifyJobs.map((job) =>
-                    pool
+            const allSettled = Promise.all(
+                verifyJobs.map((job, index) =>
+                    activePool
                         .exec("renderAndVerifySvg", [job])
                         .timeout(JOB_TIMEOUT_MS)
                         .catch((err: Error) => {
@@ -155,18 +166,33 @@ async function verifyGraphers(args: ReturnType<typeof parseArguments>) {
                             return utils.resultError(job.dir.viewId, err)
                         })
                         .then((result: utils.VerifyResult) => {
+                            settledResults[index] = result
                             progress.recordResult(result)
+                            guard.recordResult(result)
                             return result
                         })
                 )
             )
+            abortError = await Promise.race([
+                allSettled.then(() => undefined),
+                guard.aborted,
+            ])
         } finally {
             progress.stop()
+            guard.stop()
         }
 
-        if (validationResults.length !== verifyJobs.length)
-            // This is a sanity check that should never trigger
-            throw `Ran ${verifyJobs.length} verify jobs but only got ${validationResults.length} results!`
+        // Jobs the sick pool never got to are errored rather than dropped, so
+        // the totals still add up to the number of jobs the suite set out to run.
+        if (abortError) console.error(`Giving up: ${abortError.message}`)
+        const validationResults = verifyJobs.map(
+            (job, index) =>
+                settledResults[index] ??
+                utils.resultError(
+                    job.dir.viewId,
+                    abortError ?? new Error("Job produced no result")
+                )
+        )
 
         utils.logIfVerbose(verbose, "Verifications completed")
 
@@ -179,6 +205,7 @@ async function verifyGraphers(args: ReturnType<typeof parseArguments>) {
 
         utils.reportVerifyResults(validationResults, verbose)
 
+        await utils.shutDownPool(activePool)
         // This call to exit is necessary for some unknown reason to make sure that the process terminates. It
         // was not required before introducing the multiprocessing library.
         process.exit(utils.verifyExitCode(summary))
@@ -200,6 +227,7 @@ async function verifyGraphers(args: ReturnType<typeof parseArguments>) {
                     writeError
                 )
             })
+        if (pool) await utils.shutDownPool(pool)
         // This call to exit is necessary for some unknown reason to make sure that the process terminates. It
         // was not required before introducing the multiprocessing library.
         process.exit(1)

--- a/devTools/svgTester/worker.ts
+++ b/devTools/svgTester/worker.ts
@@ -5,6 +5,18 @@ import workerpool from "workerpool"
 
 import * as utils from "./utils.js"
 
+// utils.js reaches db/cleanup.ts (via db/model/Variable.js), which registers
+// SIGINT and SIGTERM handlers at import time. A JS signal handler suppresses
+// Node's default kill-on-signal and queues the exit onto the event loop
+// instead - and a worker wedged inside oxfmt's native formatter, the whole
+// reason these are processes rather than threads, never drains that loop. So
+// workerpool's `worker.kill()` (a bare SIGTERM) would leave it alive and the
+// pool could never recover. Dropping the handlers restores the default
+// disposition; the worker renders from dumped files and never opens the
+// database, so it has nothing to clean up.
+process.removeAllListeners("SIGINT")
+process.removeAllListeners("SIGTERM")
+
 // create a worker and register public functions
 workerpool.worker({
     renderAndVerifySvg: utils.renderAndVerifySvg,

--- a/packages/@ourworldindata/types/src/domainTypes/SvgTester.ts
+++ b/packages/@ourworldindata/types/src/domainTypes/SvgTester.ts
@@ -27,7 +27,7 @@ export interface SvgTesterVerifyDifferenceEntry {
 
 export interface SvgTesterVerifyErrorEntry {
     viewId: string
-    kind: "timeout" | "render"
+    kind: "timeout" | "render" | "stalled"
     message: string
 }
 


### PR DESCRIPTION
> _Written by Anthropic Claude Opus 5 — @sophiamersmann at the wheel._

## The problem

On a staging run the `thumbnails` suite stopped dead at `13/135 done · 6 in flight` and stayed there. It wasn't slow — it was deadlocked, and it would have sat there until the 7200 s wall-clock wrapper in `svg-tester.sh` killed it two hours later.

The other three suites in the same build finished normally: graphers 4460/4460 in 569 s, grapher-views 1058/1058 in 327 s, mdims 810/810 in 92 s — zero errors between them.

## What we found

Inspecting the live process on the staging container:

- all six workerpool worker threads parked in `futex_wait_queue` at 0 % CPU;
- ~4 s of CPU each, byte-identical across two samples 20 minutes apart — they had done literally nothing in between;
- the host was idle (`/proc/pressure/cpu some avg10=8 %`, io ≈ 0, nothing in uninterruptible sleep), so not CPU starvation;
- the same six threads alive since process start, meaning workerpool's terminate-on-timeout had not managed to replace a single one.

A `gdb` backtrace named the culprit:

```
#0  syscall()                                    ← futex wait, forever
#1 #2 #3  @oxfmt/binding-linux-x64-gnu/oxfmt.linux-x64-gnu.node
#4  v8impl::FunctionCallbackWrapper::Invoke      ← JS entering a N-API call
#5+ JS frames
```

The workers are deadlocked inside **oxfmt's native binding**. `prepareSvgForComparison` calls `format()` on every SVG, so every job goes through it.

That location is what turns one stuck render into a dead suite. A thread blocked inside a N-API call cannot be unwound — `Worker.terminate()` only terminates JS — so workerpool can neither kill nor replace the worker. With all six wedged the pool stops dispatching, and the remaining 122 jobs stayed queued. A queued job hasn't armed its timer yet, so nothing timed out again either: no progress, no errors, no output, for two hours.

It's a race rather than a property of any chart. The same `format()` call succeeded 6328 times in the other three suites of that very build; a 6 × 60 concurrent stress test on that same box was clean; the thumbnails suite ran green 8/8 locally; and the charts that timed out in CI render in 100–200 ms locally.

This looks like an upstream **oxc** bug — oxfmt 0.61.0, `format()` on an HTML filename (which routes through the JS-callback path), called concurrently from several `worker_threads`. Worth reporting there with that stack. **This PR does not fix that bug. It makes the tester survive it.**

## What this changes

1. **Workers are child processes, not worker threads** (`createSvgTesterPool`, now shared by `verify-graphs.ts` and `export-graphs.ts` instead of three copies of the pool options). A wedged process is killable, so the per-job timeout can actually recover the pool.
2. **The pool is shut down before every `process.exit()`** (`shutDownPool`, forced and time-boxed). `process.exit()` took worker *threads* with it; it does not take child processes, which get reparented to pid 1. This covers the crash path too, hence the pool handle living outside the `try`.
3. **IPC uses structured clone** (`serialization: "advanced"`). Load-bearing, see below.
4. **A run guard stops a sick pool from burning the rest of the suite** (`startRunGuard`): it gives up after `3 × MAX_WORKERS` consecutive timeouts, or after two job-timeouts of total silence. The jobs never reached are recorded as errors of a new kind, `stalled`, so the counts still add up to the number of jobs the suite set out to run.
5. **A suite that gave up exits 3**, distinct from an ordinary failure, so CI can tell "the pool went sick" from "the charts are broken". owid/ops#598 retries once on that code before calling the tester broken.
6. **Admin viewer**: a label for the new `stalled` kind, and error list items are no longer keyed by `viewId` alone — one chart can error on several tabs, which duplicates React keys.
7. **The console error list is capped at 20 entries** with a "… and N more" tail. A stalled run errors every job it never reached; the complete list is in `verify-results.json` regardless.

## Why processes, and why guards on top

Only the killability of a process is demonstrated. Tested directly — two workers wedged inside an uninterruptible native call, four ordinary jobs queued behind them:

```
thread : HUNG        — job0=TimeoutError job1=TimeoutError
process: all settled — job0=TimeoutError job1=TimeoutError job2=2 job3=4 job4=6 job5=8
```

The thread pool reproduces the production failure exactly; the process pool reclaims both workers and drains the queue.

Separate processes may also remove the race itself, since they don't share oxfmt's process-global native state — but that is a hypothesis, not something this PR establishes. The guards exist because of that uncertainty: if the deadlock turns out to be per-process, every worker wedges in turn and the suite grinds out 135 × 120 s of timeouts instead of hanging. The circuit breaker counts **only timeouts** for the same reason — a change that breaks a whole chart type legitimately errors many charts in a row, and the run should report all of them.

## Performance

Processes pay a slower worker start, so this was measured rather than assumed. Median wall clock, deterministic suites:

| suite | worker_threads | processes |
|---|---|---|
| thumbnails, 135 jobs | 9.2 s | 8.9 s |
| mdims, 810 jobs | 18.7 s | 18.5 s |
| graphers, 4460 jobs | 127.6 s | 115.9 s |

Faster, not slower, and plausibly for a real reason: Node's libuv threadpool is process-global, so all six worker threads were sharing four I/O threads for a workload that reads a config plus data files per job. Separate processes each get their own. The 135-job suite is the worst case for amortising startup and it didn't regress.

Caveat: measured on an idle 14-core machine, not on a staging container sharing a host with other builds.

## Two details worth a reviewer's eye

- **`serialization: "advanced"` is not cosmetic.** A render error travels home inside the result rather than as a rejection, and `fork`'s default JSON serialization flattens an `Error` to `{}` — measured `name=undefined message=undefined`. Without it every render-error message in `verify-results.json` would have silently gone blank.
- **The guard's timer is deliberately not `unref`'d.** An empty event loop exits 0, so an unref'd watchdog would let a stalled suite go out **green** — the exact opposite of the point.
