### PR TITLE
Skip mdim side-by-side compensation when its controls are hidden

### DIFF
--- a/site/gdocs/components/ArticleBlock.tsx
+++ b/site/gdocs/components/ArticleBlock.tsx
@@ -649,11 +649,17 @@ function ArticleBlockInternal({
             </div>
         ))
         .with({ type: "side-by-side" }, (block) => {
-            // Use the chart info detected at the top level
+            // Use the chart info detected at the top level. The compensation
+            // offsets the multi-dim's controls row, which is only rendered
+            // when the embed's controls are visible (no hideControls=true).
+            const controlsHidden = (url: string | undefined): boolean =>
+                Url.fromURL(url ?? "").queryParams.hideControls === "true"
             const leftIsMdim =
-                leftLinkedChart?.configType === ChartConfigType.MultiDim
+                leftLinkedChart?.configType === ChartConfigType.MultiDim &&
+                !controlsHidden(leftIsChart ? leftBlock.url : undefined)
             const rightIsMdim =
-                rightLinkedChart?.configType === ChartConfigType.MultiDim
+                rightLinkedChart?.configType === ChartConfigType.MultiDim &&
+                !controlsHidden(rightIsChart ? rightBlock.url : undefined)
 
             // Check if both are charts and one is mdim and the other isn't
             const shouldApplyCompensation =

--- a/site/gdocs/components/ArticleBlock.tsx
+++ b/site/gdocs/components/ArticleBlock.tsx
@@ -663,7 +663,9 @@ function ArticleBlockInternal({
 
             // Check if both are charts and one is mdim and the other isn't
             const shouldApplyCompensation =
-                leftIsChart && rightIsChart && leftIsMdimWithControls !== rightIsMdimWithControls
+                leftIsChart &&
+                rightIsChart &&
+                leftIsMdimWithControls !== rightIsMdimWithControls
 
             return (
                 <div className={getLayout("side-by-side", containerType)}>
@@ -672,7 +674,8 @@ function ArticleBlockInternal({
                             "grid grid-cols-6 span-cols-6 span-sm-cols-12",
                             {
                                 "mdim-compensation":
-                                    shouldApplyCompensation && !leftIsMdimWithControls,
+                                    shouldApplyCompensation &&
+                                    !leftIsMdimWithControls,
                             }
                         )}
                     >
@@ -689,7 +692,8 @@ function ArticleBlockInternal({
                             "grid grid-cols-6 span-cols-6 span-sm-cols-12",
                             {
                                 "mdim-compensation":
-                                    shouldApplyCompensation && !rightIsMdimWithControls,
+                                    shouldApplyCompensation &&
+                                    !rightIsMdimWithControls,
                             }
                         )}
                     >

--- a/site/gdocs/components/ArticleBlock.tsx
+++ b/site/gdocs/components/ArticleBlock.tsx
@@ -654,16 +654,16 @@ function ArticleBlockInternal({
             // when the embed's controls are visible (no hideControls=true).
             const controlsHidden = (url: string | undefined): boolean =>
                 Url.fromURL(url ?? "").queryParams.hideControls === "true"
-            const leftIsMdim =
+            const leftIsMdimWithControls =
                 leftLinkedChart?.configType === ChartConfigType.MultiDim &&
                 !controlsHidden(leftIsChart ? leftBlock.url : undefined)
-            const rightIsMdim =
+            const rightIsMdimWithControls =
                 rightLinkedChart?.configType === ChartConfigType.MultiDim &&
                 !controlsHidden(rightIsChart ? rightBlock.url : undefined)
 
             // Check if both are charts and one is mdim and the other isn't
             const shouldApplyCompensation =
-                leftIsChart && rightIsChart && leftIsMdim !== rightIsMdim
+                leftIsChart && rightIsChart && leftIsMdimWithControls !== rightIsMdimWithControls
 
             return (
                 <div className={getLayout("side-by-side", containerType)}>
@@ -672,7 +672,7 @@ function ArticleBlockInternal({
                             "grid grid-cols-6 span-cols-6 span-sm-cols-12",
                             {
                                 "mdim-compensation":
-                                    shouldApplyCompensation && !leftIsMdim,
+                                    shouldApplyCompensation && !leftIsMdimWithControls,
                             }
                         )}
                     >
@@ -689,7 +689,7 @@ function ArticleBlockInternal({
                             "grid grid-cols-6 span-cols-6 span-sm-cols-12",
                             {
                                 "mdim-compensation":
-                                    shouldApplyCompensation && !rightIsMdim,
+                                    shouldApplyCompensation && !rightIsMdimWithControls,
                             }
                         )}
                     >


### PR DESCRIPTION
## Human summary

Fix misalignment when embedding an MDIM with hidden controls side by side with a normal grapher chart.
See one example [in prod](https://admin.owid.io/admin/gdocs/1IyKQx8mXhCvbSaRwFzhxQLci0Sx3P93swsSuBnwVT2w/preview) | [in this PR](http://staging-site-mdim-compensation-hidden-con/admin/gdocs/1IyKQx8mXhCvbSaRwFzhxQLci0Sx3P93swsSuBnwVT2w/preview).

<img height="200" alt="Screenshot 2026-08-07 at 16 16 58" src="https://github.com/user-attachments/assets/e2537918-45ce-4c46-bd4f-018fd37feeb4" />

<img height="200" alt="Screenshot 2026-08-07 at 16 17 05" src="https://github.com/user-attachments/assets/b2c87010-e111-4c48-b5aa-a855e48806d7" />

Related to https://github.com/owid/owid-grapher/pull/6930/

---
> _Written by Claude Fable 5 — @pabloarosado at the wheel._

## Problem

A side-by-side block with a multi-dim on one side applies `.mdim-compensation` (`margin-top: 74px`) to the other side, to align it with the multi-dim's controls row. The check only asks whether the side *is* a multi-dim — not whether its controls are visible. An embed with `hideControls=true` renders no controls row, so the other side gets pushed down 74px against nothing (visible on /cleanest-air-lessons, where a multi-dim embed sits beside an explorer embed).

## Fix

Treat a multi-dim with `hideControls=true` like a plain chart when deciding compensation. One conditional in `ArticleBlock.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
