### PR TITLE
Allow any block in the key insight asset column

### DIFF
--- a/bespoke/readme.md
+++ b/bespoke/readme.md
@@ -113,6 +113,8 @@ A key insight slide normally takes an image (`filename`), a grapher/explorer cha
 
 `asset` is mutually exclusive with `filename`, `url` and `narrativeChartName` — specify exactly one.
 
+The asset column holds one visual filling one slot, so it accepts `bespoke-component`, `chart`, `narrative-chart`, `image`, `static-viz`, `video` and `html`. Layout containers (`side-by-side`, `sticky-left`, `sticky-right`, …) are rejected with a parse error: their grid classes are written for the full 12-column page grid, and the asset column is 7 of those columns, so they would lay out wrong rather than fail. The list is `KEY_INSIGHT_ASSET_BLOCK_TYPES` in `db/model/Gdoc/rawToEnriched.ts`.
+
 Two things to know when authoring one of these:
 
 - **The `size` property has no effect inside a key insight.** The asset column already sets the width (7 of 12 columns on desktop, full width on mobile), and the component fills it.

--- a/bespoke/readme.md
+++ b/bespoke/readme.md
@@ -86,6 +86,40 @@ Use the `{.bespoke-component}` ArchieML block:
 | `size`    | No       | `wide`  | Layout width: `narrow`, `wide`, or `widest`                                                         |
 | `config`  | No       | `{}`    | Key-value pairs passed to the mount function. Values must be strings (no nesting).                  |
 
+### Embedding in a key insight
+
+A key insight slide normally takes an image (`filename`), a grapher/explorer chart (`url`) or a narrative chart (`narrativeChartName`). To put a bespoke component in the asset column instead, use the `[.+asset]` array, which accepts any block:
+
+```yaml
+{.key-insights}
+  heading: Key insights
+  [.insights]
+    title: Most children die from preventable causes
+    [.+asset]
+      {.bespoke-component}
+        bundle: causes-of-death
+        variant: treemap
+        {.config}
+          ageGroup: Children under 5
+        {}
+      {}
+    []
+    [.+content]
+      Text of the insight goes here.
+    []
+  []
+{}
+```
+
+`asset` is mutually exclusive with `filename`, `url` and `narrativeChartName` — specify exactly one.
+
+Two things to know when authoring one of these:
+
+- **The `size` property has no effect inside a key insight.** The asset column already sets the width (7 of 12 columns on desktop, full width on mobile), and the component fills it.
+- **Don't turn on URL syncing.** The key insights block writes the active slide to the `?insight=` query param; a component that also syncs its state to the URL will fight it.
+
+Note that every slide of a key insights block is in the DOM from page load, not just the active one — so a bespoke component in slide 3 mounts and fetches its data even if the reader never opens that slide.
+
 ## Sizing
 
 The **width** of your component is determined by the `size` property in the ArchieML block:

--- a/db/gdocTests.test.ts
+++ b/db/gdocTests.test.ts
@@ -10,7 +10,6 @@ import {
     RawBlockText,
     EnrichedBlockTopicPageIntro,
     EnrichedBlockSocials,
-    EnrichedBlockKeyInsights,
     SocialLinkType,
 } from "@ourworldindata/utils"
 import { spansToHtmlString } from "./model/Gdoc/gdocUtils.js"
@@ -24,8 +23,6 @@ import {
     parseSimpleText,
 } from "./model/Gdoc/rawToEnriched.js"
 import { gdocToArchie } from "./model/Gdoc/gdocToArchie.js"
-import { enrichedBlockToMarkdown } from "./model/Gdoc/enrichedToMarkdown.js"
-import { enrichedBlockToIndexableText } from "./model/Gdoc/enrichedToIndexableText.js"
 import { docs_v1 } from "@googleapis/docs"
 import { documentContainsMixedStraightAndCurlyQuotes } from "./model/Gdoc/gdocValidation.js"
 
@@ -575,83 +572,4 @@ level: 2
             )
         }
     )
-})
-
-describe("key insight assets", () => {
-    const parseInsightWithAsset = (
-        assetBlock: string
-    ): EnrichedBlockKeyInsights => {
-        const raw = load(`[.+body]
-{.key-insights}
-heading: Key insights
-[.insights]
-title: An insight
-[.+asset]
-${assetBlock}
-[]
-[.+content]
-Some text.
-[]
-[]
-{}
-[]`)
-        return parseRawBlocksToEnrichedBlocks(
-            raw.body[0] as OwidRawGdocBlock
-        ) as EnrichedBlockKeyInsights
-    }
-
-    it("accepts a bespoke component as an asset", () => {
-        const block = parseInsightWithAsset(`{.bespoke-component}
-bundle: causes-of-death
-variant: treemap
-{.config}
-ageGroup: Children under 5
-{}
-{}`)
-
-        expect(block.parseErrors).toEqual([])
-        const asset = block.insights[0].asset
-        expect(asset).toHaveLength(1)
-        expect(asset![0]).toMatchObject({
-            type: "bespoke-component",
-            bundle: "causes-of-death",
-            variant: "treemap",
-            config: { ageGroup: "Children under 5" },
-        })
-    })
-
-    it("rejects layout containers, which would silently lay out wrong", () => {
-        const block = parseInsightWithAsset(`{.side-by-side}
-[.left]
-[]
-[.right]
-[]
-{}`)
-
-        expect(block.insights[0].asset).toBeUndefined()
-        expect(block.parseErrors[0].message).toContain(
-            `Key insight asset can't be a "side-by-side" block`
-        )
-    })
-
-    it("indexes text authored on an asset block", () => {
-        const block = parseInsightWithAsset(`{.image}
-filename: causes-of-death.png
-alt: A treemap of the causes of death worldwide
-{}`)
-
-        expect(block.parseErrors).toEqual([])
-        const indexed = enrichedBlockToIndexableText(block)
-        expect(indexed).toContain("A treemap of the causes of death worldwide")
-    })
-
-    it("does not leak 'undefined' into markdown for assets dropped from it", () => {
-        const block = parseInsightWithAsset(`{.bespoke-component}
-bundle: causes-of-death
-variant: treemap
-{}`)
-
-        const markdown = enrichedBlockToMarkdown(block, true)
-        expect(markdown).not.toContain("undefined")
-    })
 })

--- a/db/gdocTests.test.ts
+++ b/db/gdocTests.test.ts
@@ -25,6 +25,7 @@ import {
 } from "./model/Gdoc/rawToEnriched.js"
 import { gdocToArchie } from "./model/Gdoc/gdocToArchie.js"
 import { enrichedBlockToMarkdown } from "./model/Gdoc/enrichedToMarkdown.js"
+import { enrichedBlockToIndexableText } from "./model/Gdoc/enrichedToIndexableText.js"
 import { docs_v1 } from "@googleapis/docs"
 import { documentContainsMixedStraightAndCurlyQuotes } from "./model/Gdoc/gdocValidation.js"
 
@@ -631,6 +632,17 @@ ageGroup: Children under 5
         expect(block.parseErrors[0].message).toContain(
             `Key insight asset can't be a "side-by-side" block`
         )
+    })
+
+    it("indexes text authored on an asset block", () => {
+        const block = parseInsightWithAsset(`{.image}
+filename: causes-of-death.png
+alt: A treemap of the causes of death worldwide
+{}`)
+
+        expect(block.parseErrors).toEqual([])
+        const indexed = enrichedBlockToIndexableText(block)
+        expect(indexed).toContain("A treemap of the causes of death worldwide")
     })
 
     it("does not leak 'undefined' into markdown for assets dropped from it", () => {

--- a/db/gdocTests.test.ts
+++ b/db/gdocTests.test.ts
@@ -10,6 +10,7 @@ import {
     RawBlockText,
     EnrichedBlockTopicPageIntro,
     EnrichedBlockSocials,
+    EnrichedBlockKeyInsights,
     SocialLinkType,
 } from "@ourworldindata/utils"
 import { spansToHtmlString } from "./model/Gdoc/gdocUtils.js"
@@ -23,6 +24,7 @@ import {
     parseSimpleText,
 } from "./model/Gdoc/rawToEnriched.js"
 import { gdocToArchie } from "./model/Gdoc/gdocToArchie.js"
+import { enrichedBlockToMarkdown } from "./model/Gdoc/enrichedToMarkdown.js"
 import { docs_v1 } from "@googleapis/docs"
 import { documentContainsMixedStraightAndCurlyQuotes } from "./model/Gdoc/gdocValidation.js"
 
@@ -572,4 +574,72 @@ level: 2
             )
         }
     )
+})
+
+describe("key insight assets", () => {
+    const parseInsightWithAsset = (
+        assetBlock: string
+    ): EnrichedBlockKeyInsights => {
+        const raw = load(`[.+body]
+{.key-insights}
+heading: Key insights
+[.insights]
+title: An insight
+[.+asset]
+${assetBlock}
+[]
+[.+content]
+Some text.
+[]
+[]
+{}
+[]`)
+        return parseRawBlocksToEnrichedBlocks(
+            raw.body[0] as OwidRawGdocBlock
+        ) as EnrichedBlockKeyInsights
+    }
+
+    it("accepts a bespoke component as an asset", () => {
+        const block = parseInsightWithAsset(`{.bespoke-component}
+bundle: causes-of-death
+variant: treemap
+{.config}
+ageGroup: Children under 5
+{}
+{}`)
+
+        expect(block.parseErrors).toEqual([])
+        const asset = block.insights[0].asset
+        expect(asset).toHaveLength(1)
+        expect(asset![0]).toMatchObject({
+            type: "bespoke-component",
+            bundle: "causes-of-death",
+            variant: "treemap",
+            config: { ageGroup: "Children under 5" },
+        })
+    })
+
+    it("rejects layout containers, which would silently lay out wrong", () => {
+        const block = parseInsightWithAsset(`{.side-by-side}
+[.left]
+[]
+[.right]
+[]
+{}`)
+
+        expect(block.insights[0].asset).toBeUndefined()
+        expect(block.parseErrors[0].message).toContain(
+            `Key insight asset can't be a "side-by-side" block`
+        )
+    })
+
+    it("does not leak 'undefined' into markdown for assets dropped from it", () => {
+        const block = parseInsightWithAsset(`{.bespoke-component}
+bundle: causes-of-death
+variant: treemap
+{}`)
+
+        const markdown = enrichedBlockToMarkdown(block, true)
+        expect(markdown).not.toContain("undefined")
+    })
 })

--- a/db/model/Gdoc/enrichedToIndexableText.ts
+++ b/db/model/Gdoc/enrichedToIndexableText.ts
@@ -283,6 +283,10 @@ export function enrichedBlockToIndexableText(
                     joinBlocksAsSentences([
                         insight.title,
                         enrichedBlocksToIndexableText(insight.content, options),
+                        // Asset blocks carry authored text of their own - an
+                        // image's alt text, a chart or video caption - which is
+                        // visible on the page and so belongs in the index.
+                        enrichedBlocksToIndexableText(insight.asset, options),
                     ])
                 )
                 return (

--- a/db/model/Gdoc/enrichedToMarkdown.ts
+++ b/db/model/Gdoc/enrichedToMarkdown.ts
@@ -464,7 +464,13 @@ ${items}
                               { name: insight.narrativeChartName },
                               exportComponents
                           )
-                        : undefined
+                        : insight.asset
+                          ? enrichedBlocksToMarkdown(
+                                insight.asset,
+                                exportComponents,
+                                options
+                            )
+                          : undefined
                 const content =
                     enrichedBlocksToMarkdown(
                         insight.content,

--- a/db/model/Gdoc/enrichedToMarkdown.ts
+++ b/db/model/Gdoc/enrichedToMarkdown.ts
@@ -478,10 +478,6 @@ ${items}
                         options
                     ) ?? ""
 
-                // Coalesce: blocks that are dropped from Markdown (a
-                // bespoke-component, say) leave `imageOrChart` undefined, which
-                // would otherwise interpolate as the literal string "undefined"
-                // into the Markdown we persist for querying and search.
                 const text = `### ${insight.title}
 ${content}
 ${imageOrChart ?? ""}`

--- a/db/model/Gdoc/enrichedToMarkdown.ts
+++ b/db/model/Gdoc/enrichedToMarkdown.ts
@@ -478,9 +478,13 @@ ${items}
                         options
                     ) ?? ""
 
+                // Coalesce: blocks that are dropped from Markdown (a
+                // bespoke-component, say) leave `imageOrChart` undefined, which
+                // would otherwise interpolate as the literal string "undefined"
+                // into the Markdown we persist for querying and search.
                 const text = `### ${insight.title}
 ${content}
-${imageOrChart}`
+${imageOrChart ?? ""}`
                 return text
             })
             const allInsights = insightTexts.join("\n\n")

--- a/db/model/Gdoc/enrichedToRaw.ts
+++ b/db/model/Gdoc/enrichedToRaw.ts
@@ -576,6 +576,9 @@ export function enrichedBlockToRawBlock(
                         filename: insight.filename,
                         url: insight.url,
                         narrativeChartName: insight.narrativeChartName,
+                        asset: insight.asset?.map((asset) =>
+                            enrichedBlockToRawBlock(asset)
+                        ),
                         content: insight.content?.map((content) =>
                             enrichedBlockToRawBlock(content)
                         ),

--- a/db/model/Gdoc/exampleEnrichedBlocks.ts
+++ b/db/model/Gdoc/exampleEnrichedBlocks.ts
@@ -650,6 +650,32 @@ export const enrichedBlockExamples: Record<
                     },
                 ],
             },
+            {
+                title: "Key insight number 4",
+                type: "key-insight-slide",
+                asset: [
+                    {
+                        type: "bespoke-component",
+                        bundle: "causes-of-death",
+                        variant: "treemap",
+                        size: BlockSize.Wide,
+                        config: { region: "World" },
+                        parseErrors: [],
+                    },
+                ],
+                content: [
+                    {
+                        type: "text",
+                        parseErrors: [],
+                        value: [
+                            {
+                                spanType: "span-simple-text",
+                                text: "I am the first paragraph of the fourth insight.",
+                            },
+                        ],
+                    },
+                ],
+            },
         ],
         parseErrors: [],
     },

--- a/db/model/Gdoc/extractGdocComponentInfo.ts
+++ b/db/model/Gdoc/extractGdocComponentInfo.ts
@@ -30,6 +30,13 @@ function iterateKeyInsights<T extends EnrichedBlockKeyInsights>(
     const items: ChildIterationInfo[] = []
     for (let i = 0; i < parent.insights.length; i++) {
         const slide = parent.insights[i]
+        for (let j = 0; j < (slide.asset?.length ?? 0); j++) {
+            items.push({
+                child: slide.asset![j],
+                parentPath: `${parentPath}`,
+                path: `${parentPath}.insights[${i}].asset[${j}]`,
+            })
+        }
         for (let j = 0; j < slide.content.length; j++) {
             items.push({
                 child: slide.content[j],

--- a/db/model/Gdoc/rawToArchie.ts
+++ b/db/model/Gdoc/rawToArchie.ts
@@ -727,6 +727,13 @@ function* rawKeyInsightsToArchieMLString(
             yield* propertyToArchieMLString("filename", insight)
             yield* propertyToArchieMLString("url", insight)
             yield* propertyToArchieMLString("narrativeChartName", insight)
+            if (insight.asset) {
+                yield "[.+asset]"
+                for (const asset of insight.asset) {
+                    yield* OwidRawGdocBlockToArchieMLStringGenerator(asset)
+                }
+                yield "[]"
+            }
             if (insight.content) {
                 yield "[.+content]"
                 for (const content of insight.content) {

--- a/db/model/Gdoc/rawToEnriched.ts
+++ b/db/model/Gdoc/rawToEnriched.ts
@@ -2410,12 +2410,6 @@ function parseExpander(raw: RawBlockExpander): EnrichedBlockExpander {
     }
 }
 
-// Blocks allowed in a key insight's asset column. It holds one visual filling
-// one slot, so layout containers (side-by-side, sticky-left/right, gray-section)
-// are deliberately excluded: their grid classes are written for the full
-// 12-column page grid, and the asset column is 7 of those columns, so they
-// would silently lay out wrong rather than fail. Extend this list when a new
-// block type genuinely works standing alone in the column.
 const KEY_INSIGHT_ASSET_BLOCK_TYPES = new Set([
     "bespoke-component",
     "chart",

--- a/db/model/Gdoc/rawToEnriched.ts
+++ b/db/model/Gdoc/rawToEnriched.ts
@@ -2439,25 +2439,28 @@ function parseKeyInsights(raw: RawBlockKeyInsights): EnrichedBlockKeyInsights {
         if (!rawInsight.title) {
             parseErrors.push({ message: "Key insight is missing a title" })
         }
+        const hasAsset = !!rawInsight.asset?.length
         if (
             !rawInsight.url &&
             !rawInsight.filename &&
-            !rawInsight.narrativeChartName
+            !rawInsight.narrativeChartName &&
+            !hasAsset
         ) {
             parseErrors.push({
                 message:
-                    "Key insight is missing a url, filename or narrativeChartName. One of these two fields must be specified.",
+                    "Key insight is missing a url, filename, narrativeChartName or asset. One of these fields must be specified.",
             })
         }
         const hasMoreThanOneResourceField =
             Number(!!rawInsight.url) +
                 Number(!!rawInsight.filename) +
-                Number(!!rawInsight.narrativeChartName) >
+                Number(!!rawInsight.narrativeChartName) +
+                Number(hasAsset) >
             1
         if (hasMoreThanOneResourceField) {
             parseErrors.push({
                 message:
-                    "Key insight has more than just one of the fields url, filename, narrativeChartName. Only one of these fields can be specified.",
+                    "Key insight has more than just one of the fields url, filename, narrativeChartName, asset. Only one of these fields can be specified.",
             })
         }
         const url = Url.fromURL(extractUrl(rawInsight.url))
@@ -2468,6 +2471,11 @@ function parseKeyInsights(raw: RawBlockKeyInsights): EnrichedBlockKeyInsights {
                         "Key insight has url that isn't an explorer or grapher",
                 })
             }
+        }
+        const enrichedAsset: OwidEnrichedGdocBlock[] = []
+        for (const rawAsset of _.compact(rawInsight.asset)) {
+            const enrichedBlock = parseRawBlocksToEnrichedBlocks(rawAsset)
+            if (enrichedBlock) enrichedAsset.push(enrichedBlock)
         }
         const enrichedContent: OwidEnrichedGdocBlock[] = []
         if (!rawInsight.content) {
@@ -2494,6 +2502,9 @@ function parseKeyInsights(raw: RawBlockKeyInsights): EnrichedBlockKeyInsights {
             if (rawInsight.narrativeChartName) {
                 enrichedInsight.narrativeChartName =
                     rawInsight.narrativeChartName
+            }
+            if (enrichedAsset.length) {
+                enrichedInsight.asset = enrichedAsset
             }
             enrichedInsights.push(enrichedInsight)
         }

--- a/db/model/Gdoc/rawToEnriched.ts
+++ b/db/model/Gdoc/rawToEnriched.ts
@@ -2410,6 +2410,22 @@ function parseExpander(raw: RawBlockExpander): EnrichedBlockExpander {
     }
 }
 
+// Blocks allowed in a key insight's asset column. It holds one visual filling
+// one slot, so layout containers (side-by-side, sticky-left/right, gray-section)
+// are deliberately excluded: their grid classes are written for the full
+// 12-column page grid, and the asset column is 7 of those columns, so they
+// would silently lay out wrong rather than fail. Extend this list when a new
+// block type genuinely works standing alone in the column.
+const KEY_INSIGHT_ASSET_BLOCK_TYPES = new Set([
+    "bespoke-component",
+    "chart",
+    "narrative-chart",
+    "image",
+    "static-viz",
+    "video",
+    "html",
+])
+
 function parseKeyInsights(raw: RawBlockKeyInsights): EnrichedBlockKeyInsights {
     const createError = (error: ParseError): EnrichedBlockKeyInsights => ({
         type: "key-insights",
@@ -2475,7 +2491,16 @@ function parseKeyInsights(raw: RawBlockKeyInsights): EnrichedBlockKeyInsights {
         const enrichedAsset: OwidEnrichedGdocBlock[] = []
         for (const rawAsset of _.compact(rawInsight.asset)) {
             const enrichedBlock = parseRawBlocksToEnrichedBlocks(rawAsset)
-            if (enrichedBlock) enrichedAsset.push(enrichedBlock)
+            if (!enrichedBlock) continue
+            if (!KEY_INSIGHT_ASSET_BLOCK_TYPES.has(enrichedBlock.type)) {
+                parseErrors.push({
+                    message: `Key insight asset can't be a "${enrichedBlock.type}" block. Supported asset blocks are: ${[
+                        ...KEY_INSIGHT_ASSET_BLOCK_TYPES,
+                    ].join(", ")}.`,
+                })
+                continue
+            }
+            enrichedAsset.push(enrichedBlock)
         }
         const enrichedContent: OwidEnrichedGdocBlock[] = []
         if (!rawInsight.content) {

--- a/packages/@ourworldindata/types/src/gdocTypes/archieMLComponents/KeyInsights.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/archieMLComponents/KeyInsights.ts
@@ -9,6 +9,12 @@ export type RawBlockKeyInsightsSlide = {
     filename?: string
     url?: string
     narrativeChartName?: string
+    /**
+     * Generic escape hatch for the asset column: an arbitrary block (a bespoke
+     * component, for example) rendered instead of the image/chart shorthands
+     * above. Authored as `[.+asset]` in ArchieML.
+     */
+    asset?: OwidRawGdocBlock[]
     content?: OwidRawGdocBlock[]
 }
 
@@ -26,6 +32,7 @@ export type EnrichedBlockKeyInsightsSlide = {
     filename?: string
     url?: string
     narrativeChartName?: string
+    asset?: OwidEnrichedGdocBlock[]
     content: OwidEnrichedGdocBlock[]
 }
 

--- a/packages/@ourworldindata/types/src/gdocTypes/raycastSnippets.json
+++ b/packages/@ourworldindata/types/src/gdocTypes/raycastSnippets.json
@@ -106,7 +106,7 @@
     },
     {
         "name": "key-insights",
-        "text": "{.key-insights}\nheading: \n[.insights]\ntitle: \nfilename: \n[.+content]\n\n\n[]\ntitle: \nurl: \n[.+content]\n\n\n[]\ntitle: \nnarrativeChartName: \n[.+content]\n\n\n[]\n[]\n{}",
+        "text": "{.key-insights}\nheading: \n[.insights]\ntitle: \nfilename: \n[.+content]\n\n\n[]\ntitle: \nurl: \n[.+content]\n\n\n[]\ntitle: \nnarrativeChartName: \n[.+content]\n\n\n[]\ntitle: \n[.+asset]\n{.bespoke-component}\nbundle: \nvariant: \nsize: \n{.config}\nregion: \n{}\n{}\n[]\n[.+content]\n\n[]\n[]\n{}",
         "keyword": "+key-insights"
     },
     {

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -1597,6 +1597,7 @@ export function recursivelyMapArticleContent(
     } else if (node.type === "key-insights") {
         node.insights.forEach((insight) => {
             callback(insight)
+            insight.asset?.forEach(callback)
             insight.content.forEach(callback)
         })
     }
@@ -1666,11 +1667,14 @@ export function traverseEnrichedBlock(
         })
         .with({ type: "key-insights" }, (keyInsights) => {
             callback(keyInsights)
-            keyInsights.insights.forEach((insight) =>
+            keyInsights.insights.forEach((insight) => {
+                insight.asset?.forEach((node) =>
+                    traverseEnrichedBlock(node, callback, spanCallback)
+                )
                 insight.content.forEach((node) =>
                     traverseEnrichedBlock(node, callback, spanCallback)
                 )
-            )
+            })
         })
         .with({ type: "expander" }, (expander) => {
             callback(expander)

--- a/site/gdocs/components/Image.tsx
+++ b/site/gdocs/components/Image.tsx
@@ -58,6 +58,7 @@ const containerSizes: Record<ImageParentContainer, string> = {
     ["data-insight"]: "100%",
     ["full-width"]: "100vw",
     ["key-insight"]: gridSpan5,
+    ["key-insight-asset"]: gridSpan7,
     ["about-page"]: gridSpan8,
     ["author-byline"]: "48px",
     ["author-header"]: gridSpan2,

--- a/site/gdocs/components/KeyInsights.scss
+++ b/site/gdocs/components/KeyInsights.scss
@@ -168,3 +168,14 @@ $slide-content-height: $grapher-height;
         @include body-2-regular;
     }
 }
+
+// The asset column supplies its own vertical spacing (`.key-insight__asset-container`
+// in Image.scss), so blocks rendered into it must not add theirs on top. The
+// container is a grid item, i.e. a block formatting context root, so a child's
+// margins can't collapse into it and would stack instead: a bespoke component,
+// which carries `margin: 32px 0 48px 0`, would sit 32px lower than the image it
+// replaces.
+.key-insight__asset-container > [class*="article-block__"] {
+    margin-top: 0;
+    margin-bottom: 0;
+}

--- a/site/gdocs/components/KeyInsights.scss
+++ b/site/gdocs/components/KeyInsights.scss
@@ -170,11 +170,7 @@ $slide-content-height: $grapher-height;
 }
 
 // The asset column supplies its own vertical spacing (`.key-insight__asset-container`
-// in Image.scss), so blocks rendered into it must not add theirs on top. The
-// container is a grid item, i.e. a block formatting context root, so a child's
-// margins can't collapse into it and would stack instead: a bespoke component,
-// which carries `margin: 32px 0 48px 0`, would sit 32px lower than the image it
-// replaces.
+// in Image.scss), so blocks rendered into it must not add theirs on top.
 .key-insight__asset-container > [class*="article-block__"] {
     margin-top: 0;
     margin-bottom: 0;

--- a/site/gdocs/components/KeyInsights.test.tsx
+++ b/site/gdocs/components/KeyInsights.test.tsx
@@ -10,6 +10,7 @@ import {
     getWindowUrl,
     slugify,
 } from "@ourworldindata/utils"
+import { BlockSize } from "@ourworldindata/types"
 import { fireEvent, render, screen } from "@testing-library/react"
 import "@testing-library/jest-dom/vitest"
 
@@ -97,4 +98,38 @@ it("updates the URL", () => {
     expect(getWindowUrl().queryStr).toEqual(
         `?${KEY_INSIGHTS_INSIGHT_PARAM}=${slugifiedTitle}`
     )
+})
+
+it("renders an asset block in the asset column", () => {
+    const keyInsights: EnrichedBlockKeyInsights = {
+        type: "key-insights",
+        heading: "Key insights",
+        parseErrors: [],
+        insights: [
+            {
+                type: "key-insight-slide",
+                title: "Key insight with a bespoke asset",
+                asset: [
+                    {
+                        type: "bespoke-component",
+                        // Deliberately not in the registry, so the component
+                        // renders its error state synchronously rather than
+                        // trying to fetch a bundle.
+                        bundle: "not-a-real-bundle",
+                        size: BlockSize.Wide,
+                        config: {},
+                        parseErrors: [],
+                    },
+                ],
+                content: [],
+            },
+        ],
+    }
+    renderKeyInsights(keyInsights)
+
+    const assetContainer = document
+        .querySelector(".key-insight__asset-container")
+        ?.querySelector(".bespoke-component__error")
+    expect(assetContainer).toBeInTheDocument()
+    expect(assetContainer).toHaveTextContent("not-a-real-bundle")
 })

--- a/site/gdocs/components/KeyInsights.test.tsx
+++ b/site/gdocs/components/KeyInsights.test.tsx
@@ -112,9 +112,6 @@ it("renders an asset block in the asset column", () => {
                 asset: [
                     {
                         type: "bespoke-component",
-                        // Deliberately not in the registry, so the component
-                        // renders its error state synchronously rather than
-                        // trying to fetch a bundle.
                         bundle: "not-a-real-bundle",
                         size: BlockSize.Wide,
                         config: {},

--- a/site/gdocs/components/KeyInsights.tsx
+++ b/site/gdocs/components/KeyInsights.tsx
@@ -11,7 +11,7 @@ import {
     slugify,
     KEY_INSIGHTS_ID,
 } from "@ourworldindata/utils"
-import { BlockSize } from "@ourworldindata/types"
+import { BlockSize, OwidEnrichedGdocBlock } from "@ourworldindata/types"
 
 import { ArticleBlocks } from "./ArticleBlocks.js"
 import Image from "./Image.js"
@@ -290,11 +290,21 @@ export const KeyInsights = ({
         filename,
         url,
         narrativeChartName,
+        asset,
     }: {
         filename?: string
         url?: string
         narrativeChartName?: string
+        asset?: OwidEnrichedGdocBlock[]
     }): React.ReactElement | null {
+        if (asset?.length) {
+            return (
+                <ArticleBlocks
+                    blocks={asset}
+                    containerType="key-insight-asset"
+                />
+            )
+        }
         if (filename) {
             return (
                 <Image
@@ -359,6 +369,7 @@ export const KeyInsights = ({
                                     filename,
                                     url,
                                     narrativeChartName,
+                                    asset,
                                 },
                                 idx
                             ) => {
@@ -397,6 +408,7 @@ export const KeyInsights = ({
                                                     filename,
                                                     url,
                                                     narrativeChartName,
+                                                    asset,
                                                 })}
                                             </div>
                                         </div>

--- a/site/gdocs/components/layout.ts
+++ b/site/gdocs/components/layout.ts
@@ -11,6 +11,7 @@ export type Container =
     | "side-by-side"
     | "datapage"
     | "key-insight"
+    | "key-insight-asset"
     | "about-page"
     | "author-header"
     | "data-insight"
@@ -161,6 +162,11 @@ const layouts: { [key in Container]: Layouts} = {
     ["key-insight"]: {
         ["default"]: "col-start-1 span-cols-5 col-md-start-1 span-md-cols-12",
         ["prominent-link"]: "grid grid-cols-6 span-cols-6 span-md-cols-12 grid-md-cols-12",
+    },
+    ["key-insight-asset"]: {
+        // The asset column is already sized by its wrapper, so blocks inside it
+        // just fill the width they're given - no grid placement of their own.
+        ["default"]: "",
     },
     ["latest-announcement"]: {
         ["default"]: "span-cols-8 span-sm-cols-6",

--- a/site/gdocs/components/layout.ts
+++ b/site/gdocs/components/layout.ts
@@ -166,6 +166,8 @@ const layouts: { [key in Container]: Layouts} = {
     ["key-insight-asset"]: {
         // The asset column is already sized by its wrapper, so blocks inside it
         // just fill the width they're given - no grid placement of their own.
+        // Safe because KEY_INSIGHT_ASSET_BLOCK_TYPES in rawToEnriched.ts rejects
+        // layout containers, which would need the page grid this omits.
         ["default"]: "",
     },
     ["latest-announcement"]: {

--- a/site/gdocs/components/layout.ts
+++ b/site/gdocs/components/layout.ts
@@ -164,10 +164,6 @@ const layouts: { [key in Container]: Layouts} = {
         ["prominent-link"]: "grid grid-cols-6 span-cols-6 span-md-cols-12 grid-md-cols-12",
     },
     ["key-insight-asset"]: {
-        // The asset column is already sized by its wrapper, so blocks inside it
-        // just fill the width they're given - no grid placement of their own.
-        // Safe because KEY_INSIGHT_ASSET_BLOCK_TYPES in rawToEnriched.ts rejects
-        // layout containers, which would need the page grid this omits.
         ["default"]: "",
     },
     ["latest-announcement"]: {


### PR DESCRIPTION
> _Written by Claude Opus 5 — @paarriagadap at the wheel._

## What

A key insight slide can currently show one of three things in its asset column: an image (`filename`), a grapher/explorer chart (`url`), or a narrative chart (`narrativeChartName`). This adds a fourth, generic option — an `[.+asset]` array that accepts any block.

The motivating case is putting bespoke viz into key insights, to replace static images on topic pages like [Causes of death](https://ourworldindata.org/causes-of-death?insight=millions-of-young-children-die-from-preventable-causes-each-year#key-insights) and [Child mortality](https://ourworldindata.org/child-mortality?insight=most-children-die-from-preventable-causes#key-insights), both of which are the `causes-of-death` treemap with different config.

Rather than bolt on a fourth mutually-exclusive `bespokeBundle` field, the generic array means key insights doesn't need to know bespoke components exist, and the *next* asset type needs no changes here either.

## Authoring

```
{.key-insights}
  heading: Key insights
  [.insights]
    title: Most children die from preventable causes
    [.+asset]
      {.bespoke-component}
        bundle: causes-of-death
        variant: treemap
        {.config}
          ageGroup: Children under 5
        {}
      {}
    []
    [.+content]
      Text of the insight goes here.
    []
  []
{}
```

`asset` is mutually exclusive with `filename` / `url` / `narrativeChartName` — exactly one must be specified.

## What "any block" means

Any block that works standing alone in one slot: `bespoke-component`, `chart`, `narrative-chart`, `image`, `static-viz`, `video`, `html`. Layout containers (`side-by-side`, `sticky-left`, `sticky-right`, …) are rejected at parse time with an error naming the type — their grid classes are written for the full 12-column page grid, and the asset column is 7 of those columns, so they would lay out wrong rather than fail. The list is `KEY_INSIGHT_ASSET_BLOCK_TYPES` in `rawToEnriched.ts`; extend it when a block type genuinely works there.

## How it renders

The asset blocks go through `ArticleBlocks` under a new `key-insight-asset` container type, which applies **no** grid placement of its own: `.key-insight__asset-container` already sizes the column (7 of 12 on desktop, full width on mobile), so blocks just fill the width they're given.

The column also owns the vertical spacing. Blocks rendered into it get their vertical margins zeroed, because the container is a grid item — a block formatting context root — so a child's margins stack instead of collapsing into it. Without that, a bespoke component (`margin: 32px 0 48px 0`) sat 32px lower than the image it replaced.

A side effect of the no-grid-placement rule is that `size:` on a bespoke component has no effect inside a key insight. That's documented in `bespoke/readme.md`.

## Two things worth knowing (documented in the readme, not enforced in code)

- **Don't turn on a component's URL syncing inside a key insight.** The key insights block writes the active slide to `?insight=`; a component that also syncs state to the URL will fight it.
- **Every slide is in the DOM from page load**, so a bespoke component in slide 3 mounts and fetches its data even if the reader never opens that slide. Same as charts today; worth revisiting if we end up with several per page.

One thing that happened to already be handled: inactive slides use `height: 0; overflow: hidden; visibility: hidden` rather than `display: none` (added in #6410 for grapher charts), so a bespoke component in an inactive slide still measures a real width and doesn't lay out broken.

## Changes

| Area | Files |
|---|---|
| Types | `archieMLComponents/KeyInsights.ts` |
| Parse + round-trip | `rawToEnriched.ts`, `enrichedToRaw.ts`, `rawToArchie.ts`, `enrichedToMarkdown.ts` |
| Search indexing | `enrichedToIndexableText.ts` |
| Traversal (link + image extraction, admin component info) | `Util.ts`, `extractGdocComponentInfo.ts` |
| Render | `KeyInsights.tsx`, `KeyInsights.scss`, `layout.ts`, `Image.tsx` |
| Docs + snippets | `bespoke/readme.md`, `exampleEnrichedBlocks.ts`, `raycastSnippets.json` (regenerated) |

Two of those are easy to miss and both matter:

- **Traversal.** `extractFilenamesFromBlock` and gdoc link extraction both run through `traverseEnrichedBlock`, so descending into `asset` is what makes an `{.image}` or `{.chart}` in the asset column register its image / link like it would anywhere else.
- **Indexing.** Every asset type except `bespoke-component` and `html` carries authored on-page text — an image's alt text, a chart / narrative-chart / static-viz / video caption — so `insight.asset` goes through `enrichedBlocksToIndexableText` alongside `insight.content`, otherwise that text never reaches Algolia.

Also: blocks that markdown drops (a `bespoke-component`) leave the asset conversion undefined, which was interpolating the literal string `undefined` into the markdown `GdocBase.updateMarkdown()` persists for querying and search. Coalesced at the interpolation site, which also covers the pre-existing path where a malformed insight has none of the four fields.

## Testing

- `db/gdocTests.test.ts` — the enriched → raw → ArchieML → parse → enriched round-trip now covers a key insight with a bespoke-component asset, including its nested `{.config}` two levels down inside `[.insights]` → `[.+asset]`. That nesting was the part most likely to break, and it round-trips clean.
- `db/gdocTests.test.ts` — a `key insight assets` block covering the accepted bespoke-component case, the rejected layout container, markdown with no `undefined` leak, and alt text reaching the index. Each of the three fix tests was verified to fail with its fix reverted.
- `site/gdocs/components/KeyInsights.test.tsx` — an asset block renders inside `.key-insight__asset-container`.
- `yarn typecheck`, `yarn testLintChanged`, `yarn checkRaycastSnippets` clean; full `vitest run` green apart from `functions/test/grapher-config-r2.e2e.test.ts`, which hook-times-out under full-suite parallel load and passes on its own both with and without this branch.

## Seeing it

The changes are live on the branch's staging server, on a copy of the Causes of death doc where the key-insight edits are Google Docs **suggestions** — so nothing can reach production from them, since the normal ingestion path fetches with `PREVIEW_WITHOUT_SUGGESTIONS`.

- **Admin preview** (turn the **Preview suggestions** switch on — the asset blocks are invisible without it): http://staging-site-key-insight-asset-block/admin/gdocs/1srs-VlnCNd1lMZBiuzNRUBsT41wWnGWddFRMiZ0jNaE/preview
- **Direct link, suggestions already applied**, nothing to toggle: http://staging-site-key-insight-asset-block/gdocs/1srs-VlnCNd1lMZBiuzNRUBsT41wWnGWddFRMiZ0jNaE/preview?acceptSuggestions=true

Note that `?acceptSuggestions=true` only works on the second URL. The admin page holds that flag in component state initialised to `false` and never reads it from the URL, so on the first link the switch is the only way.

Two insights use the new field there, one configured `ageGroup: All ages` and one `ageGroup: Children under 5`, both with `hideControls: true`. The served markup confirms the container does its job — inside a key insight the block gets `article-block__bespoke-component--wide` and no grid classes, while the same bundle in a `gray-section` further down the same document still gets its full `col-start-4 span-cols-8 …` placement.

## Not in this PR

- **No content changes.** Nothing on the topic pages is touched — this only makes the embedding possible.
- **Three of the five candidate insights aren't served by the `causes-of-death` bundle as it stands**, for reasons that are about data and viz choice rather than this plumbing. Cardiovascular already works without any change (Heart diseases is the largest tile at 31.9%), though the bundle labels it "Heart diseases" rather than "Cardiovascular diseases". War and peace would need a way to highlight a sub-1% tile (Conflict and terrorism is 0.26%). Terrorism can't be served at all: GBD has no terrorism-only cause, only the combined "Conflict and terrorism".
