### PR TITLE
✨ Drop per-chart entries from the SVG tester suite list

### DIFF
--- a/adminSiteClient/SvgTesterIndexPage.tsx
+++ b/adminSiteClient/SvgTesterIndexPage.tsx
@@ -2,7 +2,7 @@ import { useContext } from "react"
 import { Spin, Table, TableColumnsType, Tag, Tooltip, Typography } from "antd"
 import { useQuery } from "@tanstack/react-query"
 import { Link } from "react-router-dom"
-import { SvgTesterSuiteStatus } from "@ourworldindata/types"
+import { SvgTesterSuiteOverview } from "@ourworldindata/types"
 import { ENV } from "../settings/clientSettings.js"
 import { AdminLayout } from "./AdminLayout.js"
 import { AdminAppContext } from "./AdminAppContext.js"
@@ -32,7 +32,7 @@ export function SvgTesterIndexPage() {
     const { data, isLoading } = useQuery({
         queryKey: ["svgtester-suites"],
         queryFn: () =>
-            admin.getJSON<{ suites: SvgTesterSuiteStatus[] }>(
+            admin.getJSON<{ suites: SvgTesterSuiteOverview[] }>(
                 "/api/svgtester/suites.json"
             ),
         refetchOnWindowFocus: true,
@@ -64,7 +64,7 @@ export function SvgTesterIndexPage() {
     )
 }
 
-const columns: TableColumnsType<SvgTesterSuiteStatus> = [
+const columns: TableColumnsType<SvgTesterSuiteOverview> = [
     {
         title: "Suite",
         dataIndex: "suite",
@@ -158,7 +158,7 @@ const columns: TableColumnsType<SvgTesterSuiteStatus> = [
     },
 ]
 
-function StatusTag({ status }: { status: SvgTesterSuiteStatus }) {
+function StatusTag({ status }: { status: SvgTesterSuiteOverview }) {
     const display = displayStatus(status)
     return (
         <span className="SvgTesterIndexPage__status">

--- a/adminSiteClient/SvgTesterSuitePage.tsx
+++ b/adminSiteClient/SvgTesterSuitePage.tsx
@@ -16,6 +16,7 @@ import { Link, useHistory, useLocation, useParams } from "react-router-dom"
 import * as _ from "lodash-es"
 import {
     SvgTesterDirectory,
+    SvgTesterSuiteOverview,
     SvgTesterSuiteStatus,
     SvgTesterVerifyDifferenceEntry,
     SvgTesterVerifyErrorEntry,
@@ -244,7 +245,7 @@ function SuiteSwitcher({ currentSuite }: { currentSuite: string | undefined }) {
     const { data } = useQuery({
         queryKey: ["svgtester-suites"],
         queryFn: () =>
-            admin.getJSON<{ suites: SvgTesterSuiteStatus[] }>(
+            admin.getJSON<{ suites: SvgTesterSuiteOverview[] }>(
                 "/api/svgtester/suites.json"
             ),
     })

--- a/adminSiteClient/svgTesterHelpers.ts
+++ b/adminSiteClient/svgTesterHelpers.ts
@@ -1,4 +1,4 @@
-import { SvgTesterSuiteStatus } from "@ourworldindata/types"
+import { SvgTesterSuiteOverview } from "@ourworldindata/types"
 
 export type SvgTesterDisplayStatus =
     | "not-run"
@@ -18,7 +18,7 @@ export const DISPLAY_STATUS_LABELS: Record<SvgTesterDisplayStatus, string> = {
 }
 
 export function displayStatus(
-    status: SvgTesterSuiteStatus
+    status: SvgTesterSuiteOverview
 ): SvgTesterDisplayStatus {
     if (status.isUnreadable) return "unreadable"
     if (!status.results) return "not-run"
@@ -29,13 +29,13 @@ export function displayStatus(
 }
 
 /** True only when the run actually finished and reported */
-export function hasReportedResult(status: SvgTesterSuiteStatus): boolean {
+export function hasReportedResult(status: SvgTesterSuiteOverview): boolean {
     const display = displayStatus(status)
     return display === "ok" || display === "differences" || display === "error"
 }
 
 /** True when the suite page has something to show: differences or render errors */
-export function hasFindings(status: SvgTesterSuiteStatus): boolean {
+export function hasFindings(status: SvgTesterSuiteOverview): boolean {
     const counts = status.results?.counts
     if (!counts) return false
     return counts.differences > 0 || counts.errors > 0

--- a/adminSiteServer/apiRoutes/svgTester.ts
+++ b/adminSiteServer/apiRoutes/svgTester.ts
@@ -8,8 +8,10 @@ import {
     SVG_TESTER_DIRECTORIES,
     SvgTesterDirectory,
     SvgTesterSuite,
+    SvgTesterSuiteOverview,
     SvgTesterSuiteStatus,
     SVG_TESTER_VERIFY_RESULTS_FILENAME,
+    SvgTesterVerifyRunOverview,
     SvgTesterVerifyRunSummary,
 } from "@ourworldindata/types"
 import { SVG_TESTER_REPO_PATH } from "../../settings/serverSettings.js"
@@ -81,8 +83,16 @@ async function readResults(suite: SvgTesterSuite): Promise<{
     }
 }
 
+function toOverview(
+    results: SvgTesterVerifyRunSummary | null
+): SvgTesterVerifyRunOverview | null {
+    if (!results) return null
+    const { differences: _differences, errors: _errors, ...overview } = results
+    return overview
+}
+
 export async function getSvgTesterSuites(): Promise<{
-    suites: SvgTesterSuiteStatus[]
+    suites: SvgTesterSuiteOverview[]
 }> {
     const grapherHead = await headCommit()
 
@@ -99,7 +109,7 @@ export async function getSvgTesterSuites(): Promise<{
             )
             return {
                 suite,
-                results,
+                results: toOverview(results),
                 grapherCommitSubject,
                 isStale,
                 isUnreadable,

--- a/packages/@ourworldindata/types/src/domainTypes/SvgTester.ts
+++ b/packages/@ourworldindata/types/src/domainTypes/SvgTester.ts
@@ -48,14 +48,25 @@ export interface SvgTesterVerifyRunSummary {
     errors: SvgTesterVerifyErrorEntry[]
 }
 
-export interface SvgTesterSuiteStatus {
+/** A run summary without its per-chart entries */
+export type SvgTesterVerifyRunOverview = Omit<
+    SvgTesterVerifyRunSummary,
+    "differences" | "errors"
+>
+
+/** What the suite list needs: headline numbers, no per-chart entries */
+export interface SvgTesterSuiteOverview {
     suite: SvgTesterSuite
     /** Null when the suite has never run */
-    results: SvgTesterVerifyRunSummary | null
+    results: SvgTesterVerifyRunOverview | null
     /** Subject line of `results.grapherCommit`, null when it isn't in local history */
     grapherCommitSubject: string | null
     /** True when the results describe a different grapher commit than the one checked out */
     isStale: boolean
     /** True when the file exists but could not be parsed (killed mid-write). */
     isUnreadable: boolean
+}
+
+export interface SvgTesterSuiteStatus extends SvgTesterSuiteOverview {
+    results: SvgTesterVerifyRunSummary | null
 }


### PR DESCRIPTION
> _Written by Anthropic Claude Opus 5 — @sophiamersmann at the wheel._

`/api/svgtester/suites.json` returned each suite's full run summary, including one entry per difference and per error. The suite list renders none of that — it only ever reads `counts`, `status`, `startedAt`, `durationMs` and `grapherCommit`.

Measured against the current `owid-grapher-svgs` checkout:

| Suite | Before | After |
| --- | --- | --- |
| graphers | 792.6 KB | 0.3 KB |
| grapher-views | 300.4 KB | 0.3 KB |
| mdims | 213.9 KB | 0.3 KB |
| thumbnails | 0.3 KB | 0.3 KB |

That is 1.3 MB per response, and the query sets `refetchOnWindowFocus: true`, so it is paid again on every tab switch back to the page.

## What changed

`getSvgTesterSuites` now strips `differences` and `errors` before returning. The projection is a rest-destructure rather than an explicit field list, so a field added to the summary later can't be silently dropped from the list.

Typing it needed a new `SvgTesterSuiteOverview`, with `SvgTesterSuiteStatus extends` it and narrowing `results` back to the full summary. That direction matters: a full status stays assignable to an overview, so `displayStatus` / `hasReportedResult` / `hasFindings` retype once and keep working for both the list and a single suite's page.

A suite's own page is untouched and still fetches its entries in full.

## Notes

Independent of #6934 — no overlapping lines, and it applies to master on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)