### PR TITLE
✨ Say which view an SVG tester error came from

### DIFF
--- a/adminSiteClient/SvgTesterSuitePage.scss
+++ b/adminSiteClient/SvgTesterSuitePage.scss
@@ -191,6 +191,13 @@ $svg-tester-error-frame: #dda4a0;
     font-weight: bold;
 }
 
+.SvgTesterErrors__query {
+    color: $gray-70;
+    font-size: 12px;
+    margin-left: 6px;
+    word-break: break-all;
+}
+
 .SvgTesterErrors__kind {
     color: $gray-70;
     font-size: 12px;

--- a/adminSiteClient/SvgTesterSuitePage.tsx
+++ b/adminSiteClient/SvgTesterSuitePage.tsx
@@ -447,25 +447,30 @@ function SvgTesterErrors({ errors }: { errors: SvgTesterVerifyErrorEntry[] }) {
             <ul className="SvgTesterErrors__list">
                 {errors.map((error, index) => (
                     <li
-                        key={`${error.viewId}-${index}`}
+                        key={`${anchorId(error.viewId, error.queryStr)}-${index}`}
                         className="SvgTesterErrors__item"
                     >
                         <div className="SvgTesterErrors__view">
                             <a
                                 className="SvgTesterErrors__slug"
-                                href={`/grapher/${error.viewId}`}
+                                href={`/grapher/${chartPath(error)}`}
                                 target="_blank"
                                 rel="noopener"
                                 title="Open this chart as this build renders it"
                             >
                                 {error.viewId}
                             </a>
+                            {error.queryStr && (
+                                <code className="SvgTesterErrors__query">
+                                    ?{error.queryStr}
+                                </code>
+                            )}
                             <span className="SvgTesterErrors__kind">
                                 {KIND_LABELS[error.kind]}
                             </span>
                             <a
                                 className="SvgTesterErrors__production"
-                                href={`${LIVE_URL}/grapher/${error.viewId}`}
+                                href={`${LIVE_URL}/grapher/${chartPath(error)}`}
                                 target="_blank"
                                 rel="noopener"
                             >
@@ -647,7 +652,7 @@ function svgUrl(
     return `/admin/api/svgtester/${suite}/${kind}/${encodeURIComponent(entry.svgFilename)}`
 }
 
-function chartPath(entry: SvgTesterVerifyDifferenceEntry): string {
+function chartPath(entry: { viewId: string; queryStr?: string }): string {
     return entry.queryStr ? `${entry.viewId}?${entry.queryStr}` : entry.viewId
 }
 

--- a/devTools/svgTester/utils.ts
+++ b/devTools/svgTester/utils.ts
@@ -77,6 +77,7 @@ interface VerifyResultDifference {
 interface VerifyResultError {
     kind: "error"
     viewId: string
+    queryStr?: string
     error: Error
 }
 
@@ -89,9 +90,17 @@ const resultOk = (): VerifyResult => ({
     kind: "ok",
 })
 
-export const resultError = (viewId: string, error: Error): VerifyResult => ({
+// `queryStr` identifies which view failed: a chart in the grapher-views suite
+// has up to 32 of them, and without it every one of its rows reads the same and
+// links to the same place.
+export const resultError = (
+    viewId: string,
+    error: Error,
+    queryStr?: string
+): VerifyResult => ({
     kind: "error",
     viewId,
+    queryStr: queryStr || undefined,
     error,
 })
 
@@ -887,7 +896,13 @@ export async function renderAndVerifySvg({
                 /* ignore ENOENT */
             })
         }
-        return Promise.resolve(resultError(referenceEntry.viewId, err as Error))
+        return Promise.resolve(
+            resultError(
+                referenceEntry.viewId,
+                err as Error,
+                referenceEntry.queryStr
+            )
+        )
     }
 }
 
@@ -933,6 +948,7 @@ export function summariseVerifyResults(
         .filter((result) => result.kind === "error")
         .map((result) => ({
             viewId: result.viewId,
+            queryStr: result.queryStr,
             kind: classifyVerifyError(result.error),
             // The stack stays on stderr for the CI log; this file is a status
             // report, not a crash dump.

--- a/devTools/svgTester/verify-graphs.ts
+++ b/devTools/svgTester/verify-graphs.ts
@@ -168,7 +168,11 @@ async function verifyGraphers(args: ReturnType<typeof parseArguments>) {
                                 console.warn(
                                     `Timed out after ${JOB_TIMEOUT_MS}ms: ${job.dir.viewId}`
                                 )
-                            return utils.resultError(job.dir.viewId, err)
+                            return utils.resultError(
+                                job.dir.viewId,
+                                err,
+                                job.queryStr
+                            )
                         })
                         .then((result: utils.VerifyResult) => {
                             settledResults[index] = result
@@ -195,7 +199,8 @@ async function verifyGraphers(args: ReturnType<typeof parseArguments>) {
                 settledResults[index] ??
                 utils.resultError(
                     job.dir.viewId,
-                    abortError ?? new Error("Job produced no result")
+                    abortError ?? new Error("Job produced no result"),
+                    job.queryStr
                 )
         )
 

--- a/packages/@ourworldindata/types/src/domainTypes/SvgTester.ts
+++ b/packages/@ourworldindata/types/src/domainTypes/SvgTester.ts
@@ -27,6 +27,7 @@ export interface SvgTesterVerifyDifferenceEntry {
 
 export interface SvgTesterVerifyErrorEntry {
     viewId: string
+    queryStr?: string
     kind: "timeout" | "render" | "stalled"
     message: string
 }


### PR DESCRIPTION
> _Written by Anthropic Claude Opus 5 — @sophiamersmann at the wheel._

A difference entry records the query string of the view it came from. An error entry never has.

In `grapher-views` a single chart has up to 32 views — measured against the current `owid-grapher-svgs` checkout, that suite has 82 view ids across 1,058 rows. A chart that fails across all of its views therefore produced up to 32 error rows carrying the same label, the same `/grapher/<viewId>` link and the same production link. For a timeout, even the message text is identical. There was no way to tell which view broke, or to open the one that did.

## What changed

`queryStr` is carried through `resultError` into the run summary, and the error list links to the specific view the same way the difference list already does:

- `SvgTesterVerifyErrorEntry` gains an optional `queryStr`, matching `SvgTesterVerifyDifferenceEntry`
- all three `resultError` call sites pass it — it was already in scope at each one
- error rows render the query string, link both anchors through the existing `chartPath` helper, and key off `anchorId`

`chartPath` widens from taking a difference entry to `{ viewId, queryStr }`, so both lists share it rather than growing a second copy.

## Notes

The field is optional, so an existing `verify-results.json` on disk renders exactly as it does today rather than breaking.

Stacked on #6934: two of the three `resultError` call sites predate it, but the third is inside a block that PR adds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)