### PR TITLE
Reword two SVG tester status labels

### DIFF
--- a/adminSiteClient/svgTesterHelpers.ts
+++ b/adminSiteClient/svgTesterHelpers.ts
@@ -10,8 +10,8 @@ export type SvgTesterDisplayStatus =
 
 export const DISPLAY_STATUS_LABELS: Record<SvgTesterDisplayStatus, string> = {
     "not-run": "Not run",
-    unreadable: "No result (file unreadable)",
-    running: "No result (killed or still running)",
+    unreadable: "Results file unreadable",
+    running: "Running (or killed mid-run)",
     error: "Error",
     differences: "Differences",
     ok: "No differences",


### PR DESCRIPTION
> _Written by Anthropic Claude Opus 5 — @sophiamersmann at the wheel._

Two of the status tags on `/admin/svgtester` led with "No result", which buries the useful half of what they say. They now state the fact directly, matching the wording owidbot uses for the same states in the PR comment:

| state | before | after |
| --- | --- | --- |
| `running` | No result (killed or still running) | Running (or killed mid-run) |
| `unreadable` | No result (file unreadable) | Results file unreadable |

Wording only — no change to columns, tag colours, or which states exist. The labels also appear on the suite page as the headline for a run that didn't report, where both read fine.