### PR TITLE
✨🤖 (svg-tester-viewer) Show the SVG tester's query strings decoded

### DIFF
--- a/adminSiteClient/SvgTesterSuitePage.scss
+++ b/adminSiteClient/SvgTesterSuitePage.scss
@@ -121,6 +121,14 @@ $svg-tester-error-frame: #dda4a0;
     margin-left: 8px;
 }
 
+.SvgTesterQueryParams {
+    margin-left: 6px;
+}
+
+.SvgTesterErrors__item .SvgTesterQueryParams {
+    font-size: 12px;
+}
+
 .SvgTesterSuitePage__modes {
     border-bottom: 1px solid $gray-10;
     display: flex;
@@ -189,13 +197,6 @@ $svg-tester-error-frame: #dda4a0;
 
 .SvgTesterErrors__slug {
     font-weight: bold;
-}
-
-.SvgTesterErrors__query {
-    color: $gray-70;
-    font-size: 12px;
-    margin-left: 6px;
-    word-break: break-all;
 }
 
 .SvgTesterErrors__kind {

--- a/adminSiteClient/SvgTesterSuitePage.tsx
+++ b/adminSiteClient/SvgTesterSuitePage.tsx
@@ -337,7 +337,9 @@ function DifferenceCard({
                         #
                     </a>{" "}
                     <strong>{entry.viewId}</strong>
-                    {entry.queryStr && <code> ?{entry.queryStr}</code>}
+                    {entry.queryStr && (
+                        <SvgTesterQueryParams queryStr={entry.queryStr} />
+                    )}
                     {entry.chartType && (
                         <Tag className="SvgTesterSuitePage__chart-type">
                             {entry.chartType}
@@ -461,9 +463,9 @@ function SvgTesterErrors({ errors }: { errors: SvgTesterVerifyErrorEntry[] }) {
                                 {error.viewId}
                             </a>
                             {error.queryStr && (
-                                <code className="SvgTesterErrors__query">
-                                    ?{error.queryStr}
-                                </code>
+                                <SvgTesterQueryParams
+                                    queryStr={error.queryStr}
+                                />
                             )}
                             <span className="SvgTesterErrors__kind">
                                 {KIND_LABELS[error.kind]}
@@ -484,6 +486,18 @@ function SvgTesterErrors({ errors }: { errors: SvgTesterVerifyErrorEntry[] }) {
                 ))}
             </ul>
         </section>
+    )
+}
+
+function SvgTesterQueryParams({ queryStr }: { queryStr: string }) {
+    const decoded = [...new URLSearchParams(queryStr)]
+        .map(([key, value]) => `${key}=${value}`)
+        .join("&")
+
+    return (
+        <code className="SvgTesterQueryParams" title={queryStr}>
+            ?{decoded}
+        </code>
     )
 }
 


### PR DESCRIPTION
> _Written by Anthropic Claude Opus 5 — @sophiamersmann at the wheel._

The query string that labels each entry on an SVG tester suite page was
rendered raw. Since a `focus` param is resolved to a real series name before
the view is recorded, that string is full of percent-encoding:

```
?tab=line&time=earliest..latest&stackMode=relative&yScale=linear&facet=entity&focus=Deaths+from+air+pollution%2C+total
```

Round-tripping it through `URLSearchParams` decodes it for display, so the
same entry now reads `focus=Deaths from air pollution, total`. The raw
encoded string stays available in the `title` attribute.

The card header and the render-error list had duplicated the raw markup;
they now share one `SvgTesterQueryParams` component. Two knock-on changes
from that: the error list picks up the card header's default `code` colour
instead of its own grey, and it loses `word-break: break-all`, which was
breaking tokens mid-word. Decoded values wrap at their spaces instead.

This is display-only — `anchorId()` and `svgFilename` still use the raw
string, so no anchors or reference-SVG lookups change.

Stacked on #6940.