### PR TITLE
Drop oxfmt from the SVG tester's output path

### DIFF
--- a/adminSiteClient/SvgTesterSuitePage.tsx
+++ b/adminSiteClient/SvgTesterSuitePage.tsx
@@ -49,9 +49,6 @@ const KIND_LABELS: Record<SvgTesterVerifyErrorEntry["kind"], string> = {
     render: "Failed to render",
 }
 
-/** Skip the diff when this much of the file changed */
-const MAX_CHANGED_RATIO = 0.25
-
 const CHART_TYPE_PARAM = "chartType"
 
 export function SvgTesterSuitePage() {
@@ -414,11 +411,7 @@ function DifferenceCard({
                 <SvgTesterOverlay beforeUrl={beforeUrl} afterUrl={afterUrl} />
             )}
             {mode === "diff" && (
-                <SvgTesterDiff
-                    beforeUrl={beforeUrl}
-                    afterUrl={afterUrl}
-                    changedRatio={entry.changedRatio}
-                />
+                <SvgTesterDiff beforeUrl={beforeUrl} afterUrl={afterUrl} />
             )}
             {mode === "interactive" && (
                 <SvgTesterInteractive chartPath={chartPath(entry)} />
@@ -543,15 +536,10 @@ function SvgTesterOverlay({
 function SvgTesterDiff({
     beforeUrl,
     afterUrl,
-    changedRatio,
 }: {
     beforeUrl: string
     afterUrl: string
-    changedRatio: number | undefined
 }) {
-    const knownTooLarge =
-        changedRatio !== undefined && changedRatio > MAX_CHANGED_RATIO
-
     // Only runs when the diff tab is opened, so the SVG text is not fetched for
     // every entry in a large report just to render its images.
     const { data, isLoading, error } = useQuery({
@@ -564,10 +552,7 @@ function SvgTesterDiff({
             return { before, after }
         },
         staleTime: Infinity,
-        enabled: !knownTooLarge,
     })
-
-    if (knownTooLarge) return <DiffSkipped ratio={changedRatio} />
 
     if (isLoading) return <Spin />
     if (error || !data)
@@ -590,17 +575,6 @@ function SvgTesterDiff({
             showDiffOnly={true}
             extraLinesSurroundingDiff={3}
             styles={{ contentText: { wordBreak: "break-all" } }}
-        />
-    )
-}
-
-function DiffSkipped({ ratio }: { ratio: number }) {
-    return (
-        <Alert
-            type="info"
-            showIcon
-            title="Too different to diff"
-            description={`About ${Math.round(ratio * 100)}% of this chart's markup changed. A line-by-line diff of two renderings that different takes many seconds to compute and is not readable — compare them side by side instead.`}
         />
     )
 }

--- a/devTools/svgTester/utils.ts
+++ b/devTools/svgTester/utils.ts
@@ -133,7 +133,6 @@ interface SvgDifference {
     queryStr?: string
     chartType: GrapherTabName | undefined
     svgFilename: string
-    changedRatio: number
     startIndex: number
     referenceSvgFragment: string
     newSvgFragment: string
@@ -154,31 +153,6 @@ export function logIfVerbose(verbose: boolean, message: string, param?: any) {
     if (verbose)
         if (param) console.log(message, param)
         else console.log(message)
-}
-
-/**
- * Share of lines on one side with no counterpart on the other, 0–1.
- *
- * O(n) and about a millisecond on a typical chart, so it is affordable for
- * every difference in a run. A real edit distance is not: on the largest
- * reference (16k lines), diffing two renderings that differ everywhere takes
- * over 15 seconds.
- */
-function estimateChangedRatio(before: string, after: string): number {
-    const beforeLines = before.split("\n")
-    const afterLines = after.split("\n")
-    const counts = new Map<string, number>()
-    for (const line of beforeLines)
-        counts.set(line, (counts.get(line) ?? 0) + 1)
-    let shared = 0
-    for (const line of afterLines) {
-        const remaining = counts.get(line)
-        if (remaining) {
-            counts.set(line, remaining - 1)
-            shared++
-        }
-    }
-    return 1 - shared / Math.max(beforeLines.length, afterLines.length)
 }
 
 function findFirstDiffIndex(a: string, b: string): number {
@@ -231,10 +205,6 @@ async function verifySvg(
         queryStr: newSvgRecord.resolvedQueryStr ?? newSvgRecord.queryStr,
         chartType: newSvgRecord.chartType,
         svgFilename: newSvgRecord.svgFilename,
-        changedRatio: estimateChangedRatio(
-            preparedReferenceSvg,
-            preparedNewSvg
-        ),
         startIndex: firstDiffIndex,
         referenceSvgFragment: preparedReferenceSvg.substring(
             firstDiffIndex - 20,
@@ -824,7 +794,6 @@ export function summariseVerifyResults(
             queryStr: difference.queryStr || undefined,
             chartType: difference.chartType,
             svgFilename: difference.svgFilename,
-            changedRatio: difference.changedRatio,
         }))
 
     const errors = validationResults

--- a/devTools/svgTester/utils.ts
+++ b/devTools/svgTester/utils.ts
@@ -43,8 +43,6 @@ import {
     GRAPHER_THUMBNAIL_HEIGHT,
     mapGrapherTabNameToQueryParam,
 } from "@ourworldindata/grapher"
-import { format, type FormatConfig } from "oxfmt"
-import oxfmtConfig from "../../.oxfmtrc.json"
 import { hashMd5 } from "../../serverUtils/hash.js"
 import { SVG_TESTER_REPO_PATH } from "../../settings/serverSettings.js"
 import * as R from "remeda"
@@ -205,40 +203,24 @@ async function verifySvg(
         return resultOk()
     }
 
-    // The stored reference .svg file is already in oxfmt-formatted canonical
-    // form - that's what wrote it in the first place (renderSvgAndSave /
-    // commit_differences), and formatting is idempotent (verified: reformatting
-    // an already-formatted reference file is a no-op). So compare the
-    // freshly-formatted new svg directly against the file's bytes first,
-    // without paying for a reformat on every single chart.
+    // The stored reference .svg file is the output of prepareSvgForComparison,
+    // same as `preparedNewSvg` - that's what wrote it in the first place
+    // (renderSvgAndSave / commit_differences) - so the two compare byte for
+    // byte.
     //
     // Note results.csv's md5 column can go stale independently of the .svg
     // file itself (commit_differences in svg-tester.sh updates the file but
     // never the CSV), which is why the fast-path check above frequently
     // misses even when there's no real difference - don't rely on md5 for
     // anything beyond that optimistic early-exit.
-    const referenceSvgRaw = await loadReferenceSvg(
+    const preparedReferenceSvg = await loadReferenceSvg(
         referenceSvgsPath,
         referenceSvgRecord
     )
-    let preparedReferenceSvg = referenceSvgRaw
-    let firstDiffIndex = findFirstDiffIndex(preparedNewSvg, referenceSvgRaw)
-
-    if (firstDiffIndex !== -1) {
-        // Only reached if the direct comparison found a difference. The
-        // reference file is normally already canonical (see above), but if
-        // it was written by an older oxfmt version/config than what's
-        // running now, a fresh render can look "different" purely from
-        // formatting drift rather than an actual content change. Reformat
-        // and re-compare before concluding it's a real difference - this
-        // only costs an extra format() call on charts that didn't match on
-        // the first (cheap) try.
-        preparedReferenceSvg = await prepareSvgForComparison(referenceSvgRaw)
-        firstDiffIndex = findFirstDiffIndex(
-            preparedNewSvg,
-            preparedReferenceSvg
-        )
-    }
+    const firstDiffIndex = findFirstDiffIndex(
+        preparedNewSvg,
+        preparedReferenceSvg
+    )
 
     if (firstDiffIndex === -1) {
         return resultOk()
@@ -573,11 +555,9 @@ export async function renderSvg({
     )
     const durationTotal = Date.now() - timeStart
 
-    // Formatting the SVG (to strip non-deterministic fragments before hashing)
-    // is the expensive part of this function. Compute it once here and hand it
-    // back to callers instead of letting them redundantly reformat the same
-    // raw svg again for comparison/output purposes.
-    const preparedSvg = await prepareSvgForComparison(svg)
+    // What gets hashed, written out and compared - callers take it from here
+    // rather than re-deriving it from the raw svg.
+    const preparedSvg = prepareSvgForComparison(svg)
 
     const svgRecord: SvgRecord = {
         viewId: dir.viewId,
@@ -601,17 +581,16 @@ export async function renderSvg({
 const replaceRegexes = [/id="react-select-\d+-.+"/g]
 /** Some fragments of the svgs are non-deterministic. This function is used to
     delete all such fragments */
-async function prepareSvgForComparison(svg: string): Promise<string> {
+function prepareSvgForComparison(svg: string): string {
     let current = svg
     for (const replaceRegex of replaceRegexes) {
         current = current.replace(replaceRegex, "")
     }
-    return await formatSvg(current)
-}
-
-async function formatSvg(svg: string): Promise<string> {
-    const result = await format("input.html", svg, oxfmtConfig as FormatConfig)
-    return result.code
+    // React renders the whole svg onto a single line, and the line diff in the
+    // admin needs lines to work with, so break it up one tag per line. `><`
+    // only ever occurs at a tag boundary because React escapes `>` in text and
+    // in attributes.
+    return current.replaceAll("><", ">\n<")
 }
 
 export interface RenderSvgAndSaveJobDescription {

--- a/packages/@ourworldindata/types/src/domainTypes/SvgTester.ts
+++ b/packages/@ourworldindata/types/src/domainTypes/SvgTester.ts
@@ -22,7 +22,6 @@ export interface SvgTesterVerifyDifferenceEntry {
     queryStr?: string
     chartType?: string
     svgFilename: string
-    changedRatio?: number
 }
 
 export interface SvgTesterVerifyErrorEntry {


### PR DESCRIPTION
> _Written by Claude Opus 5 — @sophiamersmann at the wheel._

## Context

The SVG tester ran every rendered SVG through oxfmt before hashing and writing it. That cost ~25ms per chart, grew the reference files by a third, and kept wedging CI inside oxfmt's native formatter.

The formatting existed for exactly one reason: the admin's line diff needs lines to work with, and React renders the whole SVG onto a single line. A plain tag split (`><` → `>\n<`) gives that for ~0ms and produces a third as many lines. Client-side diff cost scales with line count, so the worst case across all references drops from 15.8s to 0.5s.

With the diff that cheap, `changedRatio` goes too. It existed only to recognise an unreadable full-rewrite diff before fetching anything — at 0.5s the guard costs more than it saves.

## ⚠️ Every reference SVG changes

The on-disk format of the references changes, so `verify-graphs.ts` reports a difference for every view until they are regenerated.

- This PR needs the **`staging-viz`** label, so the SVG tester step soft-fails rather than blocking (`svg-tester.sh` turns exit code 2 into a soft failure only for labelled PRs).
- On merge to `master` the tester commits the newly rendered SVGs as the new references itself, and resyncs `results.csv`'s md5 column at the same time.

## Testing guidance

1. `make svgtest` — expect a difference for every view, for the reason above.
2. Open `/admin/svgtester/graphers` and click into a few differences: the line diff should render effectively instantly, where the largest references used to take ~15s.
3. Confirm the reference SVGs are about a third smaller and one tag per line.