### PR TITLE
Consistent logging for the SVG tester, and dead code around it

### DIFF
--- a/devTools/svgTester/export-graphs.ts
+++ b/devTools/svgTester/export-graphs.ts
@@ -31,12 +31,14 @@ async function exportGraphers(args: ReturnType<typeof parseArguments>) {
         const randomCount = args.random
 
         // Load manifest and determine data directory
-        const { viewIds: manifestViewIds, dataDir } =
-            await utils.loadManifestViewIds(testSuite, {
-                targetViewIds,
-                manifestName: args.manifest,
-                verbose: args.verbose,
-            })
+        const {
+            viewIds: manifestViewIds,
+            dataDir,
+            manifestName,
+        } = await utils.loadManifestViewIds(testSuite, {
+            targetViewIds,
+            manifestName: args.manifest,
+        })
 
         // Chart configurations to test
         const grapherQueryString = args.queryStr
@@ -46,23 +48,12 @@ async function exportGraphers(args: ReturnType<typeof parseArguments>) {
 
         // Other options
         const isolate = args.isolate
-        const verbose = args.verbose
-
-        if (isolate) {
-            utils.logIfVerbose(
-                verbose,
-                "Running in 'isolate' mode. This will be slower, but heap usage readouts will be accurate."
-            )
-        } else {
-            utils.logIfVerbose(
-                verbose,
-                "Not running in 'isolate'. Reported heap usage readouts will be inaccurate. Run in --isolate mode (way slower!) for accurate heap usage readouts."
-            )
-        }
 
         if (!fs.existsSync(dataDir))
             throw `Input directory does not exist ${dataDir}`
         if (!fs.existsSync(outDir)) fs.mkdirSync(outDir, { recursive: true })
+
+        const startedAt = Date.now()
 
         const chartIdsToProcess = await utils.selectChartIdsToProcess(dataDir, {
             viewIds: targetViewIds ?? manifestViewIds ?? undefined,
@@ -93,17 +84,13 @@ async function exportGraphers(args: ReturnType<typeof parseArguments>) {
                 variant,
             }))
 
-        // if verbose, log how many SVGs we're going to generate
         const jobCount = jobDescriptions.length
         if (jobCount === 0) {
-            utils.logIfVerbose(verbose, "No matching configs found")
+            console.log(`${testSuite}: nothing to do, no configs matched`)
             process.exit(0)
-        } else {
-            utils.logIfVerbose(
-                verbose,
-                `Generating ${jobCount} SVG${jobCount > 1 ? "s" : ""}...`
-            )
         }
+
+        utils.logRunStart(testSuite, "exporting", jobCount, manifestName)
 
         let svgRecords: utils.SvgRecord[] = []
         if (!isolate) {
@@ -115,37 +102,63 @@ async function exportGraphers(args: ReturnType<typeof parseArguments>) {
                 },
             })
 
+            const progress = utils.startProgress(testSuite, jobCount, pool)
+
             // Parallelize the CPU heavy rendering jobs
-            svgRecords = await Promise.all(
-                jobDescriptions.map((job) =>
-                    pool.exec("renderSvgAndSave", [job])
+            try {
+                svgRecords = await Promise.all(
+                    jobDescriptions.map((job) =>
+                        pool
+                            .exec("renderSvgAndSave", [job])
+                            .then((svgRecord: utils.SvgRecord) => {
+                                progress.recordResult()
+                                return svgRecord
+                            })
+                    )
                 )
-            )
+            } finally {
+                progress.stop()
+            }
         } else {
-            let i = 1
-            for (const job of jobDescriptions) {
-                const pool = workerpool.pool(__dirname + "/worker.ts", {
-                    maxWorkers: 1,
-                    workerThreadOpts: {
-                        execArgv: ["--require", "tsx"],
-                    },
-                })
-                const svgRecord = await pool.exec("renderSvgAndSave", [job])
-                pool.terminate()
-                svgRecords.push(svgRecord)
-                console.log(i++, "/", jobCount)
+            console.log(
+                `${testSuite}: isolate mode, one chart per process - slower, but heap readouts are accurate`
+            )
+            // A fresh single-worker pool per chart, so one is busy by construction
+            const progress = utils.startProgress(testSuite, jobCount, {
+                stats: () => ({ busyWorkers: 1 }),
+            })
+            try {
+                for (const job of jobDescriptions) {
+                    const pool = workerpool.pool(__dirname + "/worker.ts", {
+                        maxWorkers: 1,
+                        workerThreadOpts: {
+                            execArgv: ["--require", "tsx"],
+                        },
+                    })
+                    const svgRecord = await pool.exec("renderSvgAndSave", [job])
+                    pool.terminate()
+                    svgRecords.push(svgRecord)
+                    progress.recordResult()
+                }
+            } finally {
+                progress.stop()
             }
         }
 
         await utils.writeReferenceCsv(outDir, svgRecords)
+        utils.logExportSummary(
+            testSuite,
+            svgRecords.length,
+            Date.now() - startedAt
+        )
         // This call to exit is necessary for some unknown reason to make sure that the process terminates. It
         // was not required before introducing the multiprocessing library.
         process.exit(0)
     } catch (error) {
-        console.error("Encountered an error: ", error)
+        console.error(`${args.testSuite}: export failed`, error)
         // This call to exit is necessary for some unknown reason to make sure that the process terminates. It
         // was not required before introducing the multiprocessing library.
-        process.exit(-1)
+        process.exit(1)
     }
 }
 
@@ -206,11 +219,6 @@ function parseArguments() {
                 type: "boolean",
                 description:
                     "Run each export in a separate process. This yields accurate heap usage measurements, but is slower.",
-                default: false,
-            },
-            verbose: {
-                type: "boolean",
-                description: "Verbose mode",
                 default: false,
             },
         })

--- a/devTools/svgTester/export-graphs.ts
+++ b/devTools/svgTester/export-graphs.ts
@@ -1,7 +1,6 @@
 #! /usr/bin/env node
 
 import * as _ from "lodash-es"
-import { match } from "ts-pattern"
 import fs from "fs-extra"
 import yargs from "yargs"
 import { hideBin } from "yargs/helpers"
@@ -150,17 +149,6 @@ async function exportGraphers(args: ReturnType<typeof parseArguments>) {
     }
 }
 
-async function main(args: ReturnType<typeof parseArguments>) {
-    const testSuite = args.testSuite as SvgTesterSuite
-
-    await match(testSuite)
-        .with("graphers", () => exportGraphers(args))
-        .with("grapher-views", () => exportGraphers(args))
-        .with("mdims", () => exportGraphers(args))
-        .with("thumbnails", () => exportGraphers(args))
-        .exhaustive()
-}
-
 function parseArguments() {
     return yargs(hideBin(process.argv))
         .usage("Export Grapher SVG renderings and a summary CSV file")
@@ -232,5 +220,4 @@ function parseArguments() {
         .parseSync()
 }
 
-const argv = parseArguments()
-void main(argv)
+void exportGraphers(parseArguments())

--- a/devTools/svgTester/readme.md
+++ b/devTools/svgTester/readme.md
@@ -66,8 +66,8 @@ Use `export-graphs.ts` to generate reference SVG exports. The script uses parall
 The script works with test suites stored in the directory structure:
 
 ```
-{SVG_REPO_PATH}/{testSuite}/data/       # Input data (from dump-data.ts)
-{SVG_REPO_PATH}/{testSuite}/references/ # Output SVG references
+{SVG_TESTER_REPO_PATH}/{testSuite}/data/       # Input data (from dump-data.ts)
+{SVG_TESTER_REPO_PATH}/{testSuite}/references/ # Output SVG references
 ```
 
 This script does NOT require database access - it uses the dumped data files from `dump-data.ts`.
@@ -81,16 +81,17 @@ Use `verify-graphs.ts` to check SVG outputs against the reference export. The sc
 - Generates SVG output
 - Processes the SVG to remove non-deterministic elements
 - Compares the MD5 hash with the reference
-- If there's a difference, saves the new SVG to the differences directory and reports it
+- If there's a difference, saves the new SVG to the differences directory
 - Writes `verify-results.json` recording the outcome: status, counts, which views differed and which errored
-- Returns a non-zero exit code only if the tester itself malfunctioned (a render crashed, a reference was missing, a job timed out). Differences are the expected output and exit 0 — read `verify-results.json` to find out how many there were
+- Logs counts only — which views differed is in `verify-results.json`, the `differences/` directory, and the admin report at `/admin/svgtester/<suite>`
+- Exits 0 when everything matched, 2 when it found differences, and 1 if the tester itself malfunctioned (a render crashed, a reference was missing, a job timed out)
 
 The script works with test suites stored in the directory structure:
 
 ```
-{SVG_REPO_PATH}/{testSuite}/data/        # Input data (from dump-data.ts)
-{SVG_REPO_PATH}/{testSuite}/references/  # Reference SVGs (from export-graphs.ts)
-{SVG_REPO_PATH}/{testSuite}/differences/ # Output differences (if any)
+{SVG_TESTER_REPO_PATH}/{testSuite}/data/        # Input data (from dump-data.ts)
+{SVG_TESTER_REPO_PATH}/{testSuite}/references/  # Reference SVGs (from export-graphs.ts)
+{SVG_TESTER_REPO_PATH}/{testSuite}/differences/ # Output differences (if any)
 ```
 
 This script does NOT require database access - it uses the dumped data files from `dump-data.ts`.
@@ -109,7 +110,7 @@ This command:
 
 1. Resets `../owid-grapher-svgs` to `origin/master`
 2. Runs `verify-graphs.ts` against the reference SVGs
-3. Lists any differences it found; inspect them at `/admin/svgtester/graphers` in the admin
+3. Reports how many views differed; inspect them at `/admin/svgtester/graphers` in the admin
 
 ### Run all test suites
 
@@ -120,8 +121,21 @@ make svgtest.full
 This command:
 
 1. Resets `../owid-grapher-svgs` to `origin/master`
-2. Runs `export-graphs.ts` for all test suites (graphers, grapher-views, mdims, thumbnails)
-3. Lists any differences it found; inspect them at `/admin/svgtester/<suite>` in the admin
+2. Runs `verify-graphs.ts` for all test suites (graphers, grapher-views, mdims, thumbnails)
+3. Reports how many views differed per suite; inspect them at `/admin/svgtester/<suite>` in the admin
+
+### Resync the reference md5 index
+
+```bash
+make svgtest.md5s
+```
+
+`references/results.csv` indexes each reference SVG by md5, and verify uses it as a
+fast path: equal hash means no difference, skip reading the file. If reference SVGs
+are ever replaced without the CSV being rewritten, the index describes the previous
+references and the fast path stops working. This recomputes the column from the
+files on disk for all four suites; re-running it is a no-op. CI does this
+automatically whenever it commits new references.
 
 ## Refreshing Reference Data
 

--- a/devTools/svgTester/readme.md
+++ b/devTools/svgTester/readme.md
@@ -160,7 +160,3 @@ git commit -m "chore: update reference data"
 ```
 
 This should be done periodically (e.g., monthly) or when significant data/config changes occur.
-
-## Notes
-
-For all tools use the verbose flag if you want to see what the tool is doing. Otherwise `verify-graphs.ts` prints one affected view id per line to stdout, so failing ids can be collected with a shell pipeline, and counts to stderr. That output is for humans and pipelines only — anything that needs to act on the result should read `verify-results.json` instead.

--- a/devTools/svgTester/update-reference-md5s.ts
+++ b/devTools/svgTester/update-reference-md5s.ts
@@ -41,23 +41,15 @@ async function main(args: ReturnType<typeof parseArguments>): Promise<void> {
         // in the first place (renderSvg hashes the same string it writes out).
         const md5 = hashMd5(await fs.readFile(svgPath, "utf-8"))
         if (md5 !== record.md5) {
-            utils.logIfVerbose(
-                args.verbose,
-                `${record.viewId}: ${record.md5} -> ${md5}`
-            )
             record.md5 = md5
             updated += 1
         }
     }
 
-    if (missing.length) {
+    if (missing.length)
         console.warn(
-            `${missing.length} reference SVGs in results.csv do not exist on disk, left untouched`
+            `${testSuite}: ${missing.length} reference svgs in results.csv do not exist on disk, left untouched`
         )
-        for (const svgFilename of missing) {
-            utils.logIfVerbose(args.verbose, `  missing: ${svgFilename}`)
-        }
-    }
 
     if (updated === 0) {
         console.log(`${testSuite}: all ${svgRecords.length} md5s already match`)
@@ -65,8 +57,9 @@ async function main(args: ReturnType<typeof parseArguments>): Promise<void> {
     }
 
     await utils.writeReferenceCsv(referencesDir, svgRecords)
+    // Which rows changed is in `git diff results.csv`, no need to list them here
     console.log(
-        `${testSuite}: updated ${updated} of ${svgRecords.length} md5s in results.csv`
+        `${testSuite}: ${updated} of ${svgRecords.length} md5s updated in results.csv`
     )
 }
 
@@ -81,13 +74,6 @@ function parseArguments() {
             description: utils.TEST_SUITE_DESCRIPTION,
             default: "graphers",
             choices: SVG_TESTER_SUITES,
-        })
-        .options({
-            verbose: {
-                type: "boolean",
-                description: "Verbose mode",
-                default: false,
-            },
         })
         .help()
         .alias("help", "h")

--- a/devTools/svgTester/utils.ts
+++ b/devTools/svgTester/utils.ts
@@ -21,7 +21,6 @@ import {
 } from "@ourworldindata/utils"
 import fs, { stat } from "fs-extra"
 import path from "path"
-import stream from "stream"
 import { execFileSync } from "child_process"
 import {
     buildSvgOutFilename,
@@ -30,7 +29,6 @@ import {
 import { getVariableData } from "../../db/model/Variable.js"
 
 import * as _ from "lodash-es"
-import util from "util"
 import { getHeapStatistics } from "v8"
 import { queryStringsByChartType } from "./chart-configurations.js"
 import * as d3 from "d3-dsv"
@@ -53,8 +51,6 @@ export const TEST_SUITE_DESCRIPTION =
 
 const CONFIG_FILENAME = "config.json"
 const RESULTS_FILENAME = "results.csv"
-
-export const finished = util.promisify(stream.finished) // (A)
 
 export interface ChartWithQueryStr {
     viewId: string
@@ -146,10 +142,8 @@ interface JobConfigAndData {
     totalDataFileSize: number
 }
 
-export function logIfVerbose(verbose: boolean, message: string, param?: any) {
-    if (verbose)
-        if (param) console.log(message, param)
-        else console.log(message)
+export function logIfVerbose(verbose: boolean, message: string) {
+    if (verbose) console.log(message)
 }
 
 async function verifySvg(
@@ -343,11 +337,6 @@ async function parseGrapherConfig(
     return grapherConfig
 }
 
-async function writeToFile(data: unknown, filename: string) {
-    const json = JSON.stringify(data, null, 2)
-    await fs.writeFile(filename, json)
-}
-
 async function writeVariableDataAndMetadataFiles(
     variableIds: number[],
     outDir: string
@@ -358,8 +347,8 @@ async function writeVariableDataAndMetadataFiles(
 
         const variableData = await getVariableData(variableId)
 
-        await writeToFile(variableData.data, dataPath)
-        await writeToFile(variableData.metadata, metadataPath)
+        await fs.writeJson(dataPath, variableData.data, { spaces: 2 })
+        await fs.writeJson(metadataPath, variableData.metadata, { spaces: 2 })
     })
 
     await Promise.allSettled(writeVariablePromises)
@@ -378,7 +367,7 @@ export async function saveGrapherSchemaAndData(
     const dataDir = path.join(outDir, jobDescription.id ?? "")
     if (!fs.existsSync(dataDir)) fs.mkdirSync(dataDir)
     const configPath = path.join(dataDir, CONFIG_FILENAME)
-    const promise1 = writeToFile(config, configPath)
+    const promise1 = fs.writeJson(configPath, config, { spaces: 2 })
 
     const grapher = initGrapherForSvgExport(config)
     const variableIds = grapher.grapherState.dimensions.map((d) => d.variableId)
@@ -557,11 +546,6 @@ export async function renderSvgAndSave(
     return Promise.resolve(svgRecord)
 }
 
-async function readJsonFile(filename: string): Promise<unknown> {
-    const content = await fs.readJson(filename)
-    return content
-}
-
 async function loadReferenceSvg(
     referenceDir: string,
     referenceSvgRecord: SvgRecord
@@ -587,7 +571,7 @@ async function loadGrapherConfigAndData(
         throw `Input directory does not exist ${inputDir}`
 
     const configPath = path.join(inputDir, CONFIG_FILENAME)
-    const rawConfig = (await readJsonFile(configPath)) as GrapherInterface
+    const rawConfig = (await fs.readJson(configPath)) as GrapherInterface
     const config = migrateGrapherConfigToLatestVersion(rawConfig) // ensure the config is migrated to the latest schema version
 
     // TODO: this bakes the same commonly used variables over and over again - deduplicate
@@ -599,8 +583,8 @@ async function loadGrapherConfigAndData(
         const dataPath = path.join(inputDir, `${variableId}.data.json`)
         const metadataPath = path.join(inputDir, `${variableId}.metadata.json`)
         const dataFileSize = await stat(dataPath).then((stats) => stats.size)
-        const data = (await readJsonFile(dataPath)) as OwidVariableMixedData
-        const metadata = (await readJsonFile(
+        const data = (await fs.readJson(dataPath)) as OwidVariableMixedData
+        const metadata = (await fs.readJson(
             metadataPath
         )) as OwidVariableWithSourceAndDimension
         return { data, metadata, dataFileSize }

--- a/devTools/svgTester/utils.ts
+++ b/devTools/svgTester/utils.ts
@@ -142,19 +142,19 @@ interface JobConfigAndData {
     totalDataFileSize: number
 }
 
-export function logIfVerbose(verbose: boolean, message: string) {
-    if (verbose) console.log(message)
+/** Seconds under a minute, whole minutes above it. */
+function formatDuration(ms: number): string {
+    const seconds = Math.round(ms / 1000)
+    if (seconds < 60) return `${seconds}s`
+    return `${Math.round(seconds / 60)}m`
 }
 
 async function verifySvg(
     preparedNewSvg: string,
     newSvgRecord: SvgRecord,
     referenceSvgRecord: SvgRecord,
-    referenceSvgsPath: string,
-    verbose: boolean
+    referenceSvgsPath: string
 ): Promise<VerifyResult> {
-    logIfVerbose(verbose, `verifying ${newSvgRecord.viewId}`)
-
     if (newSvgRecord.md5 === referenceSvgRecord.md5) {
         // if the md5 hash is unchanged then there is no difference
         return resultOk()
@@ -176,7 +176,6 @@ async function verifySvg(
         )
         return resultOk()
     }
-    logIfVerbose(verbose, `${newSvgRecord.viewId} had differences`)
     return resultDifference({
         viewId: newSvgRecord.viewId,
         queryStr: newSvgRecord.resolvedQueryStr ?? newSvgRecord.queryStr,
@@ -648,7 +647,6 @@ export interface RenderJobDescription {
     outDir: string
     queryStr?: string
     variant?: "default" | "thumbnail"
-    verbose: boolean
     rmOnError?: boolean
 }
 
@@ -659,7 +657,6 @@ export async function renderAndVerifySvg({
     outDir,
     queryStr,
     variant = "default",
-    verbose,
     rmOnError,
 }: RenderJobDescription): Promise<VerifyResult> {
     try {
@@ -678,8 +675,7 @@ export async function renderAndVerifySvg({
             preparedSvg,
             svgRecord,
             referenceEntry,
-            referenceDir,
-            verbose
+            referenceDir
         )
         // Differing svgs get written out so the admin report can diff them
         // against the reference
@@ -693,7 +689,7 @@ export async function renderAndVerifySvg({
         }
         return Promise.resolve(validationResult)
     } catch (err) {
-        console.error(`Threw error for ${referenceEntry.viewId}:`, err)
+        console.error(`${referenceEntry.viewId}: render failed`, err)
         if (rmOnError) {
             const outPath = path.join(outDir, referenceEntry.svgFilename)
             await fs.unlink(outPath).catch(() => {
@@ -854,29 +850,41 @@ function resolveCommit(cwd?: string): string | null {
 /** How often the run reports progress */
 const PROGRESS_INTERVAL_MS = 30 * 1000
 
-/** Periodic progress while a suite runs. */
-export function startVerifyProgress(
+/**
+ * Periodic progress while a suite runs, shared by verify and export. Verify
+ * passes each result so the line can break the tally down by outcome; export
+ * has no outcomes to report and just counts jobs off.
+ */
+export function startProgress(
     suite: SvgTesterSuite,
     total: number,
-    pool: { stats: () => { busyWorkers: number } }
-): { recordResult: (result: VerifyResult) => void; stop: () => void } {
+    pool: { stats: () => { busyWorkers: number } },
+    options: { withOutcomes?: boolean } = {}
+): { recordResult: (result?: VerifyResult) => void; stop: () => void } {
     const startedAt = Date.now()
     const counts = { done: 0, ok: 0, differences: 0, errors: 0 }
 
     const timer = setInterval(() => {
-        const elapsed = Math.round((Date.now() - startedAt) / 1000)
-        console.log(
-            `${suite}: ${counts.done}/${total} done ` +
-                `(${counts.ok} ok, ${counts.differences} differ, ${counts.errors} errored) · ` +
-                `${pool.stats().busyWorkers} in flight · ${elapsed}s elapsed`
+        const parts = [`${counts.done}/${total}`]
+        if (options.withOutcomes)
+            parts.push(
+                `${counts.ok} ok`,
+                `${counts.differences} differ`,
+                `${counts.errors} errored`
+            )
+        parts.push(
+            `${pool.stats().busyWorkers} busy`,
+            formatDuration(Date.now() - startedAt)
         )
+        console.log(`${suite}: ${parts.join(" · ")}`)
     }, PROGRESS_INTERVAL_MS)
     // Never hold the process open on our account
     timer.unref?.()
 
     return {
-        recordResult: (result: VerifyResult) => {
+        recordResult: (result?: VerifyResult) => {
             counts.done += 1
+            if (!result) return
             if (result.kind === "ok") counts.ok += 1
             else if (result.kind === "difference") counts.differences += 1
             else counts.errors += 1
@@ -894,41 +902,42 @@ export function verifyExitCode(summary: SvgTesterVerifyRunSummary): number {
     return 0
 }
 
-// Human-facing output. The machine-readable version of all this is
-// verify-results.json.
-export function reportVerifyResults(
-    validationResults: VerifyResult[],
-    verbose: boolean
+/** Opening line for both scripts: what is about to run, and over how many views. */
+export function logRunStart(
+    suite: SvgTesterSuite,
+    verb: string,
+    count: number,
+    manifestName?: string
 ): void {
-    const errorResults = validationResults.filter(
-        (result) => result.kind === "error"
-    )
+    const parts = [`${verb} ${count} svg${count === 1 ? "" : "s"}`]
+    if (manifestName) parts.push(`manifest ${manifestName}`)
+    console.log(`${suite}: ${parts.join(" · ")}`)
+}
 
-    const differenceResults = validationResults.filter(
-        (result) => result.kind === "difference"
-    )
+export function logExportSummary(
+    suite: SvgTesterSuite,
+    count: number,
+    durationMs: number
+): void {
+    console.log(`${suite}: ${count} exported in ${formatDuration(durationMs)}`)
+}
 
-    if (errorResults.length === 0 && differenceResults.length === 0) {
-        logIfVerbose(
-            verbose,
-            `There were no differences in all graphs processed`
-        )
-        return
+/**
+ * The run's closing line. Which views differed is not repeated here - the admin
+ * report, verify-results.json and the differences/ directory all have it, in
+ * more useful form than a list of slugs.
+ */
+export function logVerifySummary(summary: SvgTesterVerifyRunSummary): void {
+    const { suite, counts } = summary
+    const parts = [
+        `${counts.total} verified in ${formatDuration(summary.durationMs)}`,
+    ]
+    if (counts.differences === 0 && counts.errors === 0) parts.push("all match")
+    else {
+        if (counts.differences) parts.push(`${counts.differences} differ`)
+        if (counts.errors) parts.push(`${counts.errors} errored`)
     }
-
-    if (errorResults.length) {
-        console.warn(`${errorResults.length} graphs threw errors`)
-        for (const result of errorResults) {
-            console.log(`${result.viewId}: ${verifyErrorMessage(result.error)}`)
-        }
-    }
-
-    if (differenceResults.length) {
-        console.warn(`${differenceResults.length} graphs had differences`)
-        for (const result of differenceResults) {
-            console.log(result.difference.viewId)
-        }
-    }
+    console.log(`${suite}: ${parts.join(" · ")}`)
 }
 
 export interface GrapherViewsManifest {
@@ -954,11 +963,12 @@ export async function loadManifestViewIds(
     options: {
         targetViewIds?: string[]
         manifestName?: string
-        verbose?: boolean
     }
-): Promise<{ viewIds: string[] | null; dataDir: string }> {
-    const { verbose = false } = options
-
+): Promise<{
+    viewIds: string[] | null
+    dataDir: string
+    manifestName?: string
+}> {
     const testSuiteDir = path.join(SVG_TESTER_REPO_PATH, testSuite)
     const defaultDataDir = path.join(testSuiteDir, "data")
 
@@ -974,21 +984,9 @@ export async function loadManifestViewIds(
             const dataDir = path.join(testSuiteDir, manifest.dataDir)
 
             // viewIds are explicitly provided
-            if (options.targetViewIds) {
-                logIfVerbose(
-                    verbose,
-                    `Using data directory: ${manifest.dataDir}`
-                )
-                return { viewIds: null, dataDir }
-            }
+            if (options.targetViewIds) return { viewIds: null, dataDir }
 
-            logIfVerbose(
-                verbose,
-                `Read ${manifest.slugs.length} chart slugs from manifest: ${manifestName}`
-            )
-            logIfVerbose(verbose, `Using data directory: ${manifest.dataDir}`)
-
-            return { viewIds: manifest.slugs, dataDir }
+            return { viewIds: manifest.slugs, dataDir, manifestName }
         } else {
             throw new Error(
                 `No manifest found at ${manifestPath}. For ${testSuite}, you must either:\n` +
@@ -1010,12 +1008,11 @@ export async function loadManifestViewIds(
 
         if (manifest) {
             const dataDir = path.join(testSuiteDir, manifest.dataDir)
-            logIfVerbose(
-                verbose,
-                `Read ${manifest.slugs.length} chart slugs from manifest: ${options.manifestName}`
-            )
-            logIfVerbose(verbose, `Using data directory: ${manifest.dataDir}`)
-            return { viewIds: manifest.slugs, dataDir }
+            return {
+                viewIds: manifest.slugs,
+                dataDir,
+                manifestName: options.manifestName,
+            }
         } else {
             console.warn(`Warning: Manifest not found at ${manifestPath}`)
         }

--- a/devTools/svgTester/utils.ts
+++ b/devTools/svgTester/utils.ts
@@ -133,9 +133,6 @@ interface SvgDifference {
     queryStr?: string
     chartType: GrapherTabName | undefined
     svgFilename: string
-    startIndex: number
-    referenceSvgFragment: string
-    newSvgFragment: string
 }
 
 interface JobDirectory {
@@ -153,14 +150,6 @@ export function logIfVerbose(verbose: boolean, message: string, param?: any) {
     if (verbose)
         if (param) console.log(message, param)
         else console.log(message)
-}
-
-function findFirstDiffIndex(a: string, b: string): number {
-    let i = 0
-    while (i < a.length && i < b.length && a[i] === b[i]) i++
-    // No difference found even though hash was different
-    if (a.length === b.length && a.length === i) i = -1
-    return i
 }
 
 async function verifySvg(
@@ -185,12 +174,8 @@ async function verifySvg(
         referenceSvgsPath,
         referenceSvgRecord
     )
-    const firstDiffIndex = findFirstDiffIndex(
-        preparedNewSvg,
-        preparedReferenceSvg
-    )
 
-    if (firstDiffIndex === -1) {
+    if (preparedNewSvg === preparedReferenceSvg) {
         // Same bytes, different md5 - results.csv has drifted from the references
         console.warn(
             `${newSvgRecord.viewId}: md5 differs but the svg is identical, run 'make svgtest.md5s'`
@@ -203,15 +188,6 @@ async function verifySvg(
         queryStr: newSvgRecord.resolvedQueryStr ?? newSvgRecord.queryStr,
         chartType: newSvgRecord.chartType,
         svgFilename: newSvgRecord.svgFilename,
-        startIndex: firstDiffIndex,
-        referenceSvgFragment: preparedReferenceSvg.substring(
-            firstDiffIndex - 20,
-            firstDiffIndex + 20
-        ),
-        newSvgFragment: preparedNewSvg.substring(
-            firstDiffIndex - 20,
-            firstDiffIndex + 20
-        ),
     })
 }
 
@@ -638,17 +614,6 @@ async function loadGrapherConfigAndData(
     return { config, variableData, totalDataFileSize }
 }
 
-function logDifferencesToConsole(
-    svgRecord: SvgRecord,
-    validationResult: VerifyResultDifference
-): void {
-    console.warn(
-        `Svg was different for ${svgRecord.viewId}. The difference starts at character ${validationResult.difference.startIndex}.
-Reference: ${validationResult.difference.referenceSvgFragment}
-Current  : ${validationResult.difference.newSvgFragment}`
-    )
-}
-
 export async function parseReferenceCsv(
     referenceDir: string
 ): Promise<SvgRecord[]> {
@@ -732,20 +697,15 @@ export async function renderAndVerifySvg({
             referenceDir,
             verbose
         )
-        // verifySvg returns a Result type - if it is success we don't care any further
-        // but if there was an error then we write the svg and a message to stderr
-        switch (validationResult.kind) {
-            case "difference": {
-                if (verbose)
-                    logDifferencesToConsole(svgRecord, validationResult)
-                const pathFragments = path.parse(svgRecord.svgFilename)
-                const outputPath = path.join(
-                    outDir,
-                    pathFragments.name + pathFragments.ext
-                )
-                await fs.writeFile(outputPath, preparedSvg)
-                break
-            }
+        // Differing svgs get written out so the admin report can diff them
+        // against the reference
+        if (validationResult.kind === "difference") {
+            const pathFragments = path.parse(svgRecord.svgFilename)
+            const outputPath = path.join(
+                outDir,
+                pathFragments.name + pathFragments.ext
+            )
+            await fs.writeFile(outputPath, preparedSvg)
         }
         return Promise.resolve(validationResult)
     } catch (err) {

--- a/devTools/svgTester/utils.ts
+++ b/devTools/svgTester/utils.ts
@@ -336,6 +336,14 @@ async function parseGrapherConfig(
     return grapherConfig
 }
 
+// Not fs.writeJson: that appends a final newline, which would rewrite every
+// dumped file in the svgs repo on the next refresh and shift totalDataFileSize
+// for every chart.
+async function writeToFile(data: unknown, filename: string) {
+    const json = JSON.stringify(data, null, 2)
+    await fs.writeFile(filename, json)
+}
+
 async function writeVariableDataAndMetadataFiles(
     variableIds: number[],
     outDir: string
@@ -346,8 +354,8 @@ async function writeVariableDataAndMetadataFiles(
 
         const variableData = await getVariableData(variableId)
 
-        await fs.writeJson(dataPath, variableData.data, { spaces: 2 })
-        await fs.writeJson(metadataPath, variableData.metadata, { spaces: 2 })
+        await writeToFile(variableData.data, dataPath)
+        await writeToFile(variableData.metadata, metadataPath)
     })
 
     await Promise.allSettled(writeVariablePromises)
@@ -366,7 +374,7 @@ export async function saveGrapherSchemaAndData(
     const dataDir = path.join(outDir, jobDescription.id ?? "")
     if (!fs.existsSync(dataDir)) fs.mkdirSync(dataDir)
     const configPath = path.join(dataDir, CONFIG_FILENAME)
-    const promise1 = fs.writeJson(configPath, config, { spaces: 2 })
+    const promise1 = writeToFile(config, configPath)
 
     const grapher = initGrapherForSvgExport(config)
     const variableIds = grapher.grapherState.dimensions.map((d) => d.variableId)

--- a/devTools/svgTester/utils.ts
+++ b/devTools/svgTester/utils.ts
@@ -181,12 +181,6 @@ async function verifySvg(
     // same as `preparedNewSvg` - that's what wrote it in the first place
     // (renderSvgAndSave / commit_differences) - so the two compare byte for
     // byte.
-    //
-    // Note results.csv's md5 column can go stale independently of the .svg
-    // file itself (commit_differences in svg-tester.sh updates the file but
-    // never the CSV), which is why the fast-path check above frequently
-    // misses even when there's no real difference - don't rely on md5 for
-    // anything beyond that optimistic early-exit.
     const preparedReferenceSvg = await loadReferenceSvg(
         referenceSvgsPath,
         referenceSvgRecord
@@ -197,6 +191,10 @@ async function verifySvg(
     )
 
     if (firstDiffIndex === -1) {
+        // Same bytes, different md5 - results.csv has drifted from the references
+        console.warn(
+            `${newSvgRecord.viewId}: md5 differs but the svg is identical, run 'make svgtest.md5s'`
+        )
         return resultOk()
     }
     logIfVerbose(verbose, `${newSvgRecord.viewId} had differences`)

--- a/devTools/svgTester/verify-graphs.ts
+++ b/devTools/svgTester/verify-graphs.ts
@@ -149,9 +149,17 @@ async function verifyGraphers(args: ReturnType<typeof parseArguments>) {
                         .exec("renderAndVerifySvg", [job])
                         .timeout(JOB_TIMEOUT_MS)
                         .catch((err: Error) => {
+                            // Only pool-level rejections reach here - a job that
+                            // throws is caught inside renderAndVerifySvg, which
+                            // logs it and resolves. So nothing else reports these.
                             if (err?.name === "TimeoutError")
                                 console.warn(
                                     `${job.dir.viewId}: timed out after ${JOB_TIMEOUT_MS}ms`
+                                )
+                            else
+                                console.error(
+                                    `${job.dir.viewId}: worker failed`,
+                                    err
                                 )
                             return utils.resultError(job.dir.viewId, err)
                         })

--- a/devTools/svgTester/verify-graphs.ts
+++ b/devTools/svgTester/verify-graphs.ts
@@ -33,12 +33,14 @@ async function verifyGraphers(args: ReturnType<typeof parseArguments>) {
         const randomCount = args.random
 
         // Load manifest and determine data directory
-        const { viewIds: manifestViewIds, dataDir } =
-            await utils.loadManifestViewIds(testSuite, {
-                targetViewIds,
-                manifestName: args.manifest,
-                verbose: args.verbose,
-            })
+        const {
+            viewIds: manifestViewIds,
+            dataDir,
+            manifestName,
+        } = await utils.loadManifestViewIds(testSuite, {
+            targetViewIds,
+            manifestName: args.manifest,
+        })
 
         // Chart configurations to test
         const grapherQueryString = args.queryStr
@@ -48,7 +50,6 @@ async function verifyGraphers(args: ReturnType<typeof parseArguments>) {
 
         // Other options
         const rmOnError = args.rmOnError
-        const verbose = args.verbose
 
         if (!fs.existsSync(dataDir))
             throw `Input directory does not exist ${dataDir}`
@@ -101,14 +102,13 @@ async function verifyGraphers(args: ReturnType<typeof parseArguments>) {
                     outDir: differencesDir,
                     queryStr,
                     variant,
-                    verbose,
                     rmOnError,
                 }
             })
 
         const jobCount = verifyJobs.length
         if (jobCount === 0) {
-            utils.logIfVerbose(verbose, "No matching configs found")
+            console.log(`${testSuite}: nothing to do, no configs matched`)
             // Nothing to do is a legitimate outcome, but it still has to
             // overwrite the "running" placeholder written above.
             await utils.writeVerifyResults(
@@ -122,7 +122,7 @@ async function verifyGraphers(args: ReturnType<typeof parseArguments>) {
             process.exit(0)
         }
 
-        console.log(`Verifying ${jobCount} SVG${jobCount > 1 ? "s" : ""}...`)
+        utils.logRunStart(testSuite, "verifying", jobCount, manifestName)
 
         const pool = workerpool.pool(__dirname + "/worker.ts", {
             minWorkers: 2,
@@ -132,7 +132,9 @@ async function verifyGraphers(args: ReturnType<typeof parseArguments>) {
             },
         })
 
-        const progress = utils.startVerifyProgress(testSuite, jobCount, pool)
+        const progress = utils.startProgress(testSuite, jobCount, pool, {
+            withOutcomes: true,
+        })
 
         // Parallelize the CPU heavy verification using the workerpool library
         // This call will then in parallel take the descriptions of the verifyJobs,
@@ -149,7 +151,7 @@ async function verifyGraphers(args: ReturnType<typeof parseArguments>) {
                         .catch((err: Error) => {
                             if (err?.name === "TimeoutError")
                                 console.warn(
-                                    `Timed out after ${JOB_TIMEOUT_MS}ms: ${job.dir.viewId}`
+                                    `${job.dir.viewId}: timed out after ${JOB_TIMEOUT_MS}ms`
                                 )
                             return utils.resultError(job.dir.viewId, err)
                         })
@@ -167,8 +169,6 @@ async function verifyGraphers(args: ReturnType<typeof parseArguments>) {
             // This is a sanity check that should never trigger
             throw `Ran ${verifyJobs.length} verify jobs but only got ${validationResults.length} results!`
 
-        utils.logIfVerbose(verbose, "Verifications completed")
-
         const summary = utils.summariseVerifyResults(validationResults, {
             suite: testSuite,
             startedAt,
@@ -176,13 +176,13 @@ async function verifyGraphers(args: ReturnType<typeof parseArguments>) {
         })
         await utils.writeVerifyResults(testSuiteDir, summary)
 
-        utils.reportVerifyResults(validationResults, verbose)
+        utils.logVerifySummary(summary)
 
         // This call to exit is necessary for some unknown reason to make sure that the process terminates. It
         // was not required before introducing the multiprocessing library.
         process.exit(utils.verifyExitCode(summary))
     } catch (error) {
-        console.error("Encountered an error: ", error)
+        console.error(`${args.testSuite}: verify failed`, error)
         // Record the failure too, so that "the suite never got to run" is
         // distinguishable from "the suite ran and found nothing" by whoever
         // reads the results file. Best-effort: if even this write fails there's
@@ -195,7 +195,7 @@ async function verifyGraphers(args: ReturnType<typeof parseArguments>) {
             )
             .catch((writeError) => {
                 console.error(
-                    "Could not write the results file either: ",
+                    `${args.testSuite}: could not write the results file either`,
                     writeError
                 )
             })
@@ -264,11 +264,6 @@ function parseArguments() {
                 type: "boolean",
                 description:
                     "Remove output files where we encounter errors, so errors are apparent in diffs",
-                default: false,
-            },
-            verbose: {
-                type: "boolean",
-                description: "Verbose mode",
                 default: false,
             },
         })

--- a/devTools/svgTester/verify-graphs.ts
+++ b/devTools/svgTester/verify-graphs.ts
@@ -6,7 +6,6 @@ import fs from "fs-extra"
 import path from "path"
 import workerpool from "workerpool"
 import * as _ from "lodash-es"
-import { match } from "ts-pattern"
 
 import { SVG_TESTER_REPO_PATH } from "../../settings/serverSettings.js"
 import * as utils from "./utils.js"
@@ -206,17 +205,6 @@ async function verifyGraphers(args: ReturnType<typeof parseArguments>) {
     }
 }
 
-async function main(args: ReturnType<typeof parseArguments>) {
-    const testSuite = args.testSuite as SvgTesterSuite
-
-    await match(testSuite)
-        .with("graphers", () => verifyGraphers(args))
-        .with("grapher-views", () => verifyGraphers(args))
-        .with("mdims", () => verifyGraphers(args))
-        .with("thumbnails", () => verifyGraphers(args))
-        .exhaustive()
-}
-
 function parseArguments() {
     return yargs(hideBin(process.argv))
         .usage(
@@ -290,5 +278,4 @@ function parseArguments() {
         .parseSync()
 }
 
-const argv = parseArguments()
-void main(argv)
+void verifyGraphers(parseArguments())


### PR DESCRIPTION
> _Written by Claude Opus 5 — @sophiamersmann at the wheel._

## Context

Stacked on #6946 — this PR targets `svgtester-drop-oxfmt`, so review that one first.

**`export-graphs.ts` and `verify-graphs.ts` now log the same three things and nothing else:** an opening line naming what is about to run, a progress line every 30 seconds, and a closing line with the outcome — suite-prefixed, on stdout.

```
graphers: verifying 4460 svgs
graphers: 1200/4460 · 1200 ok · 0 differ · 0 errored · 6 busy · 30s
graphers: 4460 verified in 18m · all match
```

stderr carries only what needs attention: a chart that failed to render (with its full stack, which `verify-results.json` deliberately does not keep), a timeout, a stale manifest.

Export gains the progress reporter verify already had. It previously printed **nothing at all** for a run of thousands of charts, while `--isolate` — the mode you almost never take — printed a counter per chart. Its fatal exit code is now 1 rather than -1, matching the 0/1/2 that `svg-tester.sh` switches on.

**`--verbose` is gone** from export, verify and `update-reference-md5s`. Nothing passed it: not the Makefile, not `refresh.sh`, not ops' `svg-tester.sh`. Of the eight messages behind it, four belonged in the default output and four were noise — a line per chart announcing it was about to be verified, a second line per chart repeating the end summary, `Verifications completed`, and a lecture about heap accuracy in the mode you did not ask for. That deletes `logIfVerbose` and takes `verbose` out of `RenderJobDescription`, where it was being cloned into every worker job.

Which views differed is no longer printed. The admin report, `verify-results.json` and the `differences/` directory all record it, in more useful form than a list of slugs.

## Also here

- **A stale comment claimed `results.csv`'s md5 column drifts from the references**, making verify's fast path miss "frequently". That was true when written; ops' `commit_differences` now resyncs the CSV. Measured on `origin/master` of `owid-grapher-svgs`: 0 of 6,463 rows across all four suites mismatch, where 43% of the graphers suite did before. The byte comparison stays — it is what detects a real difference — but the "identical bytes, different md5" branch now warns instead of passing silently.
- **`startIndex` and two 20-character SVG fragments** were only ever read by a `--verbose` console line; `summariseVerifyResults` never put them in `verify-results.json`. With them gone, `findFirstDiffIndex` reduces to a `===`.
- **Dead code:** a promisified `stream.finished` with no reference anywhere, `logIfVerbose`'s never-passed `any` parameter, a four-branch `ts-pattern` match in each entry point where every branch called the same function, and `writeToFile`/`readJsonFile` reimplementing `fs.writeJson`/`fs.readJson`.
- **Readme corrections**, three of which predate this branch: the exit codes were inverted (it said differences exit 0, where they exit 2 — which is what the Makefile and `svg-tester.sh` both switch on), `svgtest.full` was documented as running `export-graphs.ts` rather than `verify-graphs.ts`, and `SVG_REPO_PATH` is not a setting. Also documents `make svgtest.md5s`, the only script the readme never mentioned.

## Testing guidance

1. `make svgtest` — expect the three-line output above. Differences are expected while this is stacked on #6946, until the references are regenerated.
2. `yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/verify-graphs.ts graphers -c <some-slug>` — confirm the start and closing lines, and that `--verbose` is no longer accepted.
3. `export-graphs.ts` writes into `references/` and rewrites `results.csv` with only the rows it rendered, so point `SVG_TESTER_REPO_PATH` at a scratch copy when testing it on a subset rather than the real sibling repo.
4. Both entry points and `update-reference-md5s.ts` were smoke-tested this way; `tsc`, oxlint `--deny-warnings` and oxfmt are clean.