### PR TITLE
✨🤖 Say which SVG tester view failed, and show query strings decoded

### DIFF
--- a/adminSiteClient/SvgTesterSuitePage.scss
+++ b/adminSiteClient/SvgTesterSuitePage.scss
@@ -121,6 +121,14 @@ $svg-tester-error-frame: #dda4a0;
     margin-left: 8px;
 }
 
+.SvgTesterQueryParams {
+    margin-left: 6px;
+}
+
+.SvgTesterErrors__item .SvgTesterQueryParams {
+    font-size: 12px;
+}
+
 .SvgTesterSuitePage__modes {
     border-bottom: 1px solid $gray-10;
     display: flex;
@@ -155,7 +163,7 @@ $svg-tester-error-frame: #dda4a0;
     }
 }
 
-.SvgTesterSuitePage__links {
+.SvgTesterChartLinks {
     color: $gray-70;
     font-size: 13px;
     white-space: nowrap;
@@ -187,17 +195,20 @@ $svg-tester-error-frame: #dda4a0;
     padding-top: 8px;
 }
 
-.SvgTesterErrors__slug {
-    font-weight: bold;
+.SvgTesterErrors__view {
+    align-items: baseline;
+    display: flex;
+    gap: 16px;
+    justify-content: space-between;
+}
+
+.SvgTesterErrors__identity {
+    min-width: 0;
+    overflow-wrap: anywhere;
 }
 
 .SvgTesterErrors__kind {
     color: $gray-70;
-    font-size: 12px;
-    margin-left: 8px;
-}
-
-.SvgTesterErrors__production {
     font-size: 12px;
     margin-left: 8px;
 }

--- a/adminSiteClient/SvgTesterSuitePage.tsx
+++ b/adminSiteClient/SvgTesterSuitePage.tsx
@@ -125,6 +125,15 @@ export function SvgTesterSuitePage() {
                                             of{" "}
                                             {results.counts.total.toLocaleString()}{" "}
                                             charts rendered differently
+                                            {results.counts.errors > 0 && (
+                                                <span className="SvgTesterSuitePage__errors">
+                                                    {", "}
+                                                    <strong>
+                                                        {results.counts.errors.toLocaleString()}
+                                                    </strong>{" "}
+                                                    failed to render
+                                                </span>
+                                            )}
                                         </>
                                     ) : (
                                         status && DISPLAY_STATUS_LABELS[status]
@@ -146,15 +155,6 @@ export function SvgTesterSuitePage() {
                                         <>
                                             started{" "}
                                             <Timeago time={results.startedAt} />
-                                        </>
-                                    )}
-                                    {results.counts.errors > 0 && (
-                                        <>
-                                            {" · "}
-                                            <span className="SvgTesterSuitePage__errors">
-                                                {results.counts.errors.toLocaleString()}{" "}
-                                                failed to render
-                                            </span>
                                         </>
                                     )}
                                     {results.grapherCommit && (
@@ -327,31 +327,16 @@ function DifferenceCard({
                         #
                     </a>{" "}
                     <strong>{entry.viewId}</strong>
-                    {entry.queryStr && <code> ?{entry.queryStr}</code>}
+                    {entry.queryStr && (
+                        <SvgTesterQueryParams queryStr={entry.queryStr} />
+                    )}
                     {entry.chartType && (
                         <Tag className="SvgTesterSuitePage__chart-type">
                             {entry.chartType}
                         </Tag>
                     )}
                 </span>
-                <span className="SvgTesterSuitePage__links">
-                    Open chart:{" "}
-                    <a
-                        href={`${LIVE_URL}/grapher/${chartPath(entry)}`}
-                        target="_blank"
-                        rel="noopener"
-                    >
-                        production
-                    </a>{" "}
-                    ·{" "}
-                    <a
-                        href={`/grapher/${chartPath(entry)}`}
-                        target="_blank"
-                        rel="noopener"
-                    >
-                        this build
-                    </a>
-                </span>
+                <SvgTesterChartLinks entry={entry} />
             </header>
 
             <div
@@ -432,28 +417,23 @@ function SvgTesterErrors({ errors }: { errors: SvgTesterVerifyErrorEntry[] }) {
             </h2>
             <ul className="SvgTesterErrors__list">
                 {errors.map((error) => (
-                    <li key={error.viewId} className="SvgTesterErrors__item">
+                    <li
+                        key={anchorId(error.viewId, error.queryStr)}
+                        className="SvgTesterErrors__item"
+                    >
                         <div className="SvgTesterErrors__view">
-                            <a
-                                className="SvgTesterErrors__slug"
-                                href={`/grapher/${error.viewId}`}
-                                target="_blank"
-                                rel="noopener"
-                                title="Open this chart as this build renders it"
-                            >
-                                {error.viewId}
-                            </a>
-                            <span className="SvgTesterErrors__kind">
-                                {KIND_LABELS[error.kind]}
+                            <span className="SvgTesterErrors__identity">
+                                <strong>{error.viewId}</strong>
+                                {error.queryStr && (
+                                    <SvgTesterQueryParams
+                                        queryStr={error.queryStr}
+                                    />
+                                )}
+                                <span className="SvgTesterErrors__kind">
+                                    {KIND_LABELS[error.kind]}
+                                </span>
                             </span>
-                            <a
-                                className="SvgTesterErrors__production"
-                                href={`${LIVE_URL}/grapher/${error.viewId}`}
-                                target="_blank"
-                                rel="noopener"
-                            >
-                                production
-                            </a>
+                            <SvgTesterChartLinks entry={error} />
                         </div>
                         <pre className="SvgTesterErrors__message">
                             {error.message}
@@ -462,6 +442,43 @@ function SvgTesterErrors({ errors }: { errors: SvgTesterVerifyErrorEntry[] }) {
                 ))}
             </ul>
         </section>
+    )
+}
+
+function SvgTesterChartLinks({
+    entry,
+}: {
+    entry: { viewId: string; queryStr?: string }
+}) {
+    const path = chartPath(entry)
+
+    return (
+        <span className="SvgTesterChartLinks">
+            Open chart:{" "}
+            <a
+                href={`${LIVE_URL}/grapher/${path}`}
+                target="_blank"
+                rel="noopener"
+            >
+                production
+            </a>{" "}
+            ·{" "}
+            <a href={`/grapher/${path}`} target="_blank" rel="noopener">
+                this build
+            </a>
+        </span>
+    )
+}
+
+function SvgTesterQueryParams({ queryStr }: { queryStr: string }) {
+    const decoded = [...new URLSearchParams(queryStr)]
+        .map(([key, value]) => `${key}=${value}`)
+        .join("&")
+
+    return (
+        <code className="SvgTesterQueryParams" title={queryStr}>
+            ?{decoded}
+        </code>
     )
 }
 
@@ -611,7 +628,7 @@ function svgUrl(
     return `/admin/api/svgtester/${suite}/${kind}/${encodeURIComponent(entry.svgFilename)}`
 }
 
-function chartPath(entry: SvgTesterVerifyDifferenceEntry): string {
+function chartPath(entry: { viewId: string; queryStr?: string }): string {
     return entry.queryStr ? `${entry.viewId}?${entry.queryStr}` : entry.viewId
 }
 

--- a/devTools/svgTester/utils.ts
+++ b/devTools/svgTester/utils.ts
@@ -714,7 +714,7 @@ export async function renderAndVerifySvg({
             resultError(
                 referenceEntry.viewId,
                 err as Error,
-                referenceEntry.queryStr
+                referenceEntry.resolvedQueryStr || referenceEntry.queryStr
             )
         )
     }

--- a/devTools/svgTester/utils.ts
+++ b/devTools/svgTester/utils.ts
@@ -70,6 +70,7 @@ interface VerifyResultDifference {
 interface VerifyResultError {
     kind: "error"
     viewId: string
+    queryStr?: string
     error: Error
 }
 
@@ -82,9 +83,14 @@ const resultOk = (): VerifyResult => ({
     kind: "ok",
 })
 
-export const resultError = (viewId: string, error: Error): VerifyResult => ({
+export const resultError = (
+    viewId: string,
+    error: Error,
+    queryStr?: string
+): VerifyResult => ({
     kind: "error",
     viewId,
+    queryStr: queryStr || undefined,
     error,
 })
 
@@ -704,7 +710,13 @@ export async function renderAndVerifySvg({
                 /* ignore ENOENT */
             })
         }
-        return Promise.resolve(resultError(referenceEntry.viewId, err as Error))
+        return Promise.resolve(
+            resultError(
+                referenceEntry.viewId,
+                err as Error,
+                referenceEntry.queryStr
+            )
+        )
     }
 }
 
@@ -746,6 +758,7 @@ export function summariseVerifyResults(
         .filter((result) => result.kind === "error")
         .map((result) => ({
             viewId: result.viewId,
+            queryStr: result.queryStr,
             kind: classifyVerifyError(result.error),
             // The stack stays on stderr for the CI log; this file is a status
             // report, not a crash dump.

--- a/devTools/svgTester/verify-graphs.ts
+++ b/devTools/svgTester/verify-graphs.ts
@@ -161,7 +161,11 @@ async function verifyGraphers(args: ReturnType<typeof parseArguments>) {
                                     `${job.dir.viewId}: worker failed`,
                                     err
                                 )
-                            return utils.resultError(job.dir.viewId, err)
+                            return utils.resultError(
+                                job.dir.viewId,
+                                err,
+                                job.queryStr
+                            )
                         })
                         .then((result: utils.VerifyResult) => {
                             progress.recordResult(result)

--- a/devTools/svgTester/verify-graphs.ts
+++ b/devTools/svgTester/verify-graphs.ts
@@ -164,7 +164,8 @@ async function verifyGraphers(args: ReturnType<typeof parseArguments>) {
                             return utils.resultError(
                                 job.dir.viewId,
                                 err,
-                                job.queryStr
+                                job.referenceEntry.resolvedQueryStr ||
+                                    job.queryStr
                             )
                         })
                         .then((result: utils.VerifyResult) => {

--- a/packages/@ourworldindata/types/src/domainTypes/SvgTester.ts
+++ b/packages/@ourworldindata/types/src/domainTypes/SvgTester.ts
@@ -26,6 +26,7 @@ export interface SvgTesterVerifyDifferenceEntry {
 
 export interface SvgTesterVerifyErrorEntry {
     viewId: string
+    queryStr?: string
     kind: "timeout" | "render"
     message: string
 }


### PR DESCRIPTION
> _Written by Anthropic Claude Opus 5 — @sophiamersmann at the wheel._

Replaces #6940 and #6943, which were stacked on a PR that is no longer going in. Same changes, rebased onto `master`, plus two follow-ups noted at the end.

A difference entry records the query string of the view it came from. An error entry never did.

In `grapher-views` a single chart has up to 32 views — measured against the current `owid-grapher-svgs` checkout, that suite has 82 view ids across 1,058 rows. A chart that fails across all of its views therefore produced up to 32 error rows carrying the same label, the same `/grapher/<viewId>` link and the same production link. For a timeout, even the message text is identical. There was no way to tell which view broke, or to open the one that did.

## Which view failed

`queryStr` is carried through `resultError` into the run summary, and the error list links to the specific view the same way the difference list already does:

- `SvgTesterVerifyErrorEntry` gains an optional `queryStr`, matching `SvgTesterVerifyDifferenceEntry`
- both `resultError` call sites pass it — it was already in scope at each one
- error rows render the query string, link through the existing `chartPath` helper, and key off `anchorId`

`chartPath` widens from taking a difference entry to `{ viewId, queryStr }`, so both lists share it rather than growing a second copy.

## Decoded query strings

The query string labelling each entry was rendered raw. Since a `focus` param is resolved to a real series name before the view is recorded, that string is full of percent-encoding:

```
?tab=line&time=earliest..latest&stackMode=relative&yScale=linear&facet=entity&focus=Deaths+from+air+pollution%2C+total
```

Round-tripping it through `URLSearchParams` decodes it for display, so the same entry now reads `focus=Deaths from air pollution, total`. The raw encoded string stays available in the `title` attribute.

This is display-only — `anchorId()` and `svgFilename` still use the raw string, so no anchors or reference-SVG lookups change.

## Shared markup

The card header and the error row had duplicated the query-string markup and the chart links. They now share `SvgTesterQueryParams` and `SvgTesterChartLinks`. Knock-on effects:

- the error list picks up the card header's default `code` colour instead of its own grey, and loses `word-break: break-all`, which was breaking tokens mid-word — decoded values wrap at their spaces instead
- the error row's chart links move to the right under the card's `Open chart:` prefix, so the viewId stops being a link (it duplicated `this build`)

## Two follow-ups beyond the closed PRs

- render failures are now part of the page headline (`4 of 1,057 charts rendered differently, 5 failed to render`) rather than a smaller note in the meta line below it, where they were easy to miss. Removed from the meta line so the count isn't stated twice.
- the error row's layout matches the difference card's header, per the point above.

## Notes

The field is optional, so an existing `verify-results.json` on disk renders exactly as it does today rather than breaking.

Verified against a hand-written `verify-results.json`, since reproducing a real 32-view failure means waiting for one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)