### PR TITLE
Support multi-dim links in explorer tiles

### DIFF
--- a/db/model/Gdoc/GdocBase.ts
+++ b/db/model/Gdoc/GdocBase.ts
@@ -1285,7 +1285,7 @@ export class GdocBase implements OwidGdocBaseInterface {
                     ) {
                         linkErrors.push({
                             property: "content",
-                            message: `Grapher chart with slug "${link.target}" does not exist or is not published`,
+                            message: `Chart or multi-dim data page with slug "${link.target}" does not exist or is not published`,
                             type: OwidGdocErrorMessageType.Error,
                         })
                     } else if (
@@ -1319,7 +1319,7 @@ export class GdocBase implements OwidGdocBaseInterface {
                     ) {
                         linkErrors.push({
                             property: "content",
-                            message: `Explorer chart with slug "${link.target}" does not exist or is not published`,
+                            message: `Explorer with slug "${link.target}" does not exist or is not published`,
                             type: OwidGdocErrorMessageType.Error,
                         })
                     }

--- a/db/model/Gdoc/GdocBase.ts
+++ b/db/model/Gdoc/GdocBase.ts
@@ -1288,6 +1288,16 @@ export class GdocBase implements OwidGdocBaseInterface {
                             message: `Grapher chart with slug "${link.target}" does not exist or is not published`,
                             type: OwidGdocErrorMessageType.Error,
                         })
+                    } else if (
+                        link.componentType === "explorer-tiles" &&
+                        !grapherRedirect &&
+                        chartIdsBySlug[link.target]
+                    ) {
+                        linkErrors.push({
+                            property: "content",
+                            message: `Explorer tiles can only link to explorers or multi-dim data pages, but "${link.target}" is a regular grapher chart`,
+                            type: OwidGdocErrorMessageType.Error,
+                        })
                     }
                 })
                 .with({ linkType: ContentGraphLinkType.Explorer }, async () => {
@@ -1630,7 +1640,7 @@ export function makeMultiDimLinkedChart(
         title,
         dimensionSlugs: config.dimensions.map((d) => d.slug),
         resolvedUrl,
-        tags: [],
+        tags: config.topicTags ?? [],
         archivedPageVersion,
     }
 }

--- a/db/model/Gdoc/rawToEnriched.ts
+++ b/db/model/Gdoc/rawToEnriched.ts
@@ -2859,9 +2859,13 @@ function parseExplorerTiles(
     const parsedExplorerUrls: { url: string }[] = []
     for (const explorer of raw.value.explorers) {
         const url = extractUrl(explorer.url)
-        if (getLinkType(url) !== "explorer") {
+        // Multi-dim data pages live under /grapher/, so grapher-type URLs are
+        // accepted here; GdocBase link validation checks that they actually
+        // point to a multi-dim and not a regular chart
+        const linkType = getLinkType(url)
+        if (linkType !== "explorer" && linkType !== "grapher") {
             return createError({
-                message: `Explorer tiles contains a non-explorer URL: ${url}`,
+                message: `Explorer tiles can only link to explorers or multi-dim data pages, but got: ${url}`,
             })
         }
         parsedExplorerUrls.push({ url })

--- a/site/gdocs/components/ExplorerTiles.tsx
+++ b/site/gdocs/components/ExplorerTiles.tsx
@@ -1,4 +1,7 @@
-import { EnrichedBlockExplorerTiles } from "@ourworldindata/types"
+import {
+    ChartConfigType,
+    EnrichedBlockExplorerTiles,
+} from "@ourworldindata/types"
 import { Button } from "@ourworldindata/components"
 import { useLinkedChart } from "../utils.js"
 import { useDocumentContext } from "../DocumentContext.js"
@@ -11,6 +14,18 @@ function ExplorerTile({ url }: { url: string }) {
         return <p>{errorMessage}</p>
     }
     if (!linkedChart) {
+        return null
+    }
+    // Grapher URLs are only valid here if they resolve to a multi-dim data page
+    if (linkedChart.configType === ChartConfigType.Grapher) {
+        if (isPreviewing) {
+            return (
+                <p>
+                    Explorer tiles can only link to explorers or multi-dim data
+                    pages, but {url} is a regular grapher chart
+                </p>
+            )
+        }
         return null
     }
     const icon = linkedChart.tags[0] ? (

--- a/site/gdocs/utils.ts
+++ b/site/gdocs/utils.ts
@@ -227,7 +227,10 @@ export const useLinkedChart = (
     const linkedChart = linkedCharts?.[urlTarget]
     if (!linkedChart) {
         return {
-            errorMessage: `${linkType} chart with slug ${urlTarget} not found`,
+            errorMessage:
+                linkType === "explorer"
+                    ? `Explorer with slug "${urlTarget}" not found`
+                    : `Chart or multi-dim data page with slug "${urlTarget}" not found`,
         }
     }
 


### PR DESCRIPTION
> _Written by Claude Fable 5 — @marcelgerber at the wheel._

`explorer-tiles` blocks in gdocs only accepted `/explorers/` URLs. Since multi-dim data pages are the successors to explorers but live under `/grapher/`, this PR makes the block work with mdim links too: they parse, validate (with a gdoc error if a `/grapher/` URL turns out to be a regular chart rather than an mdim), and render as tiles — including the topic icon, which mdim linked charts never got before.

One point for discussion: mdim tiles keep the red "Data Explorer" suffix after the title, consistent with how explorers that redirect to mdims already render in these tiles. Happy to change that if we want different text for mdims.

<details><summary>Details</summary>

- **Parsing** (`db/model/Gdoc/rawToEnriched.ts`): `parseExplorerTiles` now accepts grapher-type URLs alongside explorer ones. Whether a `/grapher/` URL is actually an mdim requires DB access, so that check happens at validation time instead.
- **Validation** (`db/model/Gdoc/GdocBase.ts`): explorer-tiles links that resolve to a *regular* grapher chart (a chart-slug hit with no mdim redirect, mirroring the linked-chart resolution order in `loadLinkedChartsForSlugs`) produce a gdoc error in the admin.
- **Rendering** (`site/gdocs/components/ExplorerTiles.tsx`): mdim `LinkedChart`s render as tiles; plain-grapher links are hidden in production and show the error while previewing.
- `makeMultiDimLinkedChart` now populates `tags` from the mdim config's `topicTags` — it previously always set `tags: []`, so mdim tiles would never show the topic icon.
- Mdim links resolve through the existing attachments layer (`makeMultiDimLinkedChart`); explorer→mdim redirects already exercised that path in this component, so direct `/grapher/` links were the only missing piece.
- Testing: `yarn typecheck`, `yarn testLintChanged`, `yarn testFormatChanged` pass; gdoc round-trip tests (`db/gdocTests.test.ts`, 81 tests) pass.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
