### PR TITLE
📜 CLAUDE.md: two-part PR description format

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,7 @@ The Our World in Data monorepo: the Grapher charting library, the chart/data adm
 ### Git
 
 - When you want to create a commit, follow `docs/agent-guidelines/commit-messages.md` — it covers the pre-commit checks and the gitmoji + 🤖 message format.
+- PR descriptions are two-part. First, a **concise** human-facing part: what changed and why, important considerations and pitfalls, and anything that needs discussion — a few sentences or bullets, no padding. Then a `<details><summary>Details</summary>` block for everything only useful to an agent picking the work back up or to automated code review: implementation notes, file-by-file breakdowns, edge cases handled, test plans. If a detail doesn't change what a human reviewer does, it goes in the details block or gets cut.
 - Branch names: short and descriptive, no prefix (in particular no `claude/` prefix and no random suffix). Every branch gets a staging server named `staging-site-<branch>` with slashes turned into hyphens and the name truncated to 28 characters, so long or prefixed branch names produce unusable staging names.
 
 ## Architecture


### PR DESCRIPTION
> _Written by Anthropic Claude Fable 5 — @marcelgerber at the wheel._

Agent-written PR descriptions have been too long. This adds a rule to CLAUDE.md: a concise human-facing part (what changed and why, pitfalls, things to discuss), with everything only useful to agents or automated review hidden in a `<details>` block.

<details><summary>Details</summary>

- Single bullet added to the Git section of `CLAUDE.md`, right after the commit-message line.
- Includes a placement test: if a detail doesn't change what a human reviewer does, it goes in the details block or gets cut.

</details>