### PR TITLE
🎉🤖 show the slope chart tooltip when a label is hovered

### DIFF
--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx
@@ -667,7 +667,9 @@ export class SlopeChart
         return this.leftLabelsMaxLevel >= 4 && !!this.manager.showSeriesLabels
     }
 
-    private updateTooltipPosition(event: SVGMouseOrTouchEvent): void {
+    @action.bound private updateTooltipPosition(
+        event: SVGMouseOrTouchEvent
+    ): void {
         const ref = this.manager.base?.current
         if (ref) this.tooltipState.position = getRelativeMouse(ref, event)
     }
@@ -700,22 +702,29 @@ export class SlopeChart
             const toleranceSq = tolerance * tolerance
 
             if (closestSlope && distanceSq < toleranceSq) {
-                this.onSlopeMouseOver(closestSlope)
+                this.setHoveredSeries(closestSlope)
             } else {
-                this.onSlopeMouseLeave()
+                this.clearHoveredSeries()
             }
         })
     }
 
     private hoverTimer?: number
-    @action.bound onVerticalLabelMouseEnter(seriesName: SeriesName): void {
+    @action.bound private setHoveredSeries(series: SlopeChartSeries): void {
         this.chartState.focusArray.clear()
         clearTimeout(this.hoverTimer)
-        this.hoveredSeriesName = seriesName
+        this.hoveredSeriesName = series.seriesName
+        this.tooltipState.target = { series }
+    }
+
+    @action.bound onVerticalLabelMouseEnter(seriesName: SeriesName): void {
+        const series = this.series.find((s) => s.seriesName === seriesName)
+        if (series) this.setHoveredSeries(series)
     }
 
     @action.bound private clearHoveredSeries(): void {
         this.hoveredSeriesName = undefined
+        this.tooltipState.target = null
     }
 
     @action.bound private debouncedClearHoveredSeries(): void {
@@ -732,17 +741,6 @@ export class SlopeChart
         this.debouncedClearHoveredSeries()
     }
 
-    @action.bound onSlopeMouseOver(series: SlopeChartSeries): void {
-        this.chartState.focusArray.clear()
-        this.hoveredSeriesName = series.seriesName
-        this.tooltipState.target = { series }
-    }
-
-    @action.bound onSlopeMouseLeave(): void {
-        this.clearHoveredSeries()
-        this.tooltipState.target = null
-    }
-
     mouseFrame?: number
     @action.bound onMouseMove(event: SVGMouseOrTouchEvent): void {
         this.updateTooltipPosition(event)
@@ -752,7 +750,7 @@ export class SlopeChart
     @action.bound onMouseLeave(): void {
         if (this.mouseFrame !== undefined) cancelAnimationFrame(this.mouseFrame)
 
-        this.onSlopeMouseLeave()
+        this.clearHoveredSeries()
     }
 
     @computed private get renderUid(): number {
@@ -1138,14 +1136,19 @@ export class SlopeChart
 
     private renderInteractive(): React.ReactElement {
         return (
-            <>
+            <g
+                onMouseMove={this.updateTooltipPosition}
+                onTouchStart={this.updateTooltipPosition}
+                onTouchMove={this.updateTooltipPosition}
+            >
+                <rect {...this.bounds.toProps()} fillOpacity={0} />
                 {this.renderYAxis()}
                 {this.renderXAxis()}
                 {this.renderInteractiveSlopes()}
                 {this.renderVerticalLabels()}
                 {this.renderNoDataSection()}
                 {this.tooltip}
-            </>
+            </g>
         )
     }
 


### PR DESCRIPTION
> _Written by Anthropic Claude Opus 5 — @sophiamersmann at the wheel._

In slope charts, the tooltip only showed up when a slope was hovered. Now hovering one of the labels (left or right) shows the same tooltip for that series.

To place the tooltip next to the cursor when it's outside the slope area, mouse position is now tracked across the whole chart area — the same approach the line chart uses. Slope hit-detection stays scoped to the slope area, so it can't interfere with a label hover.

This also fixes a pre-existing glitch: moving from a label onto a slope left a pending label-leave timer that cleared the hover state 200ms later.

Not covered: tapping a label on touch devices — the label interaction overlays in `VerticalLabels` have no touch handlers, so this is hover-only for now.

<details><summary>Details</summary>

All changes are in `packages/@ourworldindata/grapher/src/slopeCharts/SlopeChart.tsx`.

- `setHoveredSeries(series)` is the single entry point for both hover sources (slope hit-detection and `onVerticalLabelMouseEnter`): it clears the focus array, cancels the pending hover timer, sets `hoveredSeriesName`, and sets `tooltipState.target`.
- `clearHoveredSeries()` now also nulls `tooltipState.target`. That made `onSlopeMouseOver` and `onSlopeMouseLeave` redundant wrappers, so they were removed and their call sites (`detectHoveredSlope`, `onMouseLeave`) call `setHoveredSeries` / `clearHoveredSeries` directly.
- `onVerticalLabelMouseEnter` looks the series up by name; label leave keeps going through the existing debounced clear, so the 200ms anti-flicker window now covers the tooltip too when skimming across stacked labels.
- `renderInteractive` wraps its content in a `<g>` with `onMouseMove` / `onTouchStart` / `onTouchMove` bound to `updateTooltipPosition` (now `@action.bound`) plus a full-`bounds` transparent `<rect>` so moves over labels and whitespace are picked up. This mirrors `LineChart.renderInteractive`. The slope-area `<g>` keeps its own handlers, so `detectHoveredSlope` still only runs inside the `startX…endX` band and can't clear a hover set by a label.
- Tooltip placement near the right-hand labels needs no special casing: `TooltipCard` already flips and clamps to the container bounds.

Test plan: `yarn typecheck` clean (apart from two pre-existing `currentSubtitle` errors in `GrapherState.test.ts`), lint/format clean, `SlopeChart.test.ts` passes. `SlopeChart.test.ts` is state-level only, so the hover behaviour itself needs a manual check; the static render path is untouched.

</details>