### PR TITLE
🔨🤖 (svg-tester) store variable data once

### DIFF
--- a/devTools/svgTester/dump-data.ts
+++ b/devTools/svgTester/dump-data.ts
@@ -162,10 +162,7 @@ async function main(args: ReturnType<typeof parseArguments>) {
                 const slugs = charts.map((chart) => chart.id)
 
                 // Write manifest file
-                const manifest: utils.GrapherViewsManifest = {
-                    slugs,
-                    dataDir: "../graphers/data",
-                }
+                const manifest: utils.GrapherViewsManifest = { slugs }
                 const manifestPath = path.join(
                     testSuiteDir,
                     "top.manifest.json"
@@ -198,10 +195,7 @@ async function main(args: ReturnType<typeof parseArguments>) {
                 const slugs = charts.map((chart) => chart.id)
 
                 // Write manifest file
-                const manifest: utils.GrapherViewsManifest = {
-                    slugs,
-                    dataDir: "../graphers/data",
-                }
+                const manifest: utils.GrapherViewsManifest = { slugs }
                 const manifestPath = path.join(
                     testSuiteDir,
                     "top.manifest.json"

--- a/devTools/svgTester/readme.md
+++ b/devTools/svgTester/readme.md
@@ -23,11 +23,14 @@ Use `dump-data.ts` to dump configuration and data files. It needs a running grap
 
 #### Graphers
 
-For every public and published grapher (~4,500 at the time of writing), it creates one subdirectory with the grapher slug as the directory name containing:
+For every public and published grapher (~4,500 at the time of writing), it creates one subdirectory with the grapher slug as the directory name containing a single `config.json`, the grapher's JSON configuration.
 
-- `config.json` - The grapher's JSON configuration
-- `{variableId}.data.json` - Data file for each variable used in the grapher
-- `{variableId}.metadata.json` - Metadata file for each variable used in the grapher
+The data itself goes into `{SVG_TESTER_REPO_PATH}/variables/`, shared by every test suite:
+
+- `{variableId}.data.json` - Data file for the variable
+- `{variableId}.metadata.json` - Metadata file for the variable
+
+**Careful with partial refreshes:** because the directory is shared, dumping a single suite rewrites variable files that the other suites also read, which can shift their reference SVGs even though you never touched them. `refresh.sh` dumps all four suites, so the normal path is safe; if you dump one suite by hand and see diffs somewhere unexpected, re-run the full refresh.
 
 #### Grapher-views
 
@@ -66,7 +69,8 @@ Use `export-graphs.ts` to generate reference SVG exports. The script uses parall
 The script works with test suites stored in the directory structure:
 
 ```
-{SVG_TESTER_REPO_PATH}/{testSuite}/data/       # Input data (from dump-data.ts)
+{SVG_TESTER_REPO_PATH}/variables/              # Variable data, shared by all suites
+{SVG_TESTER_REPO_PATH}/{testSuite}/data/       # Chart configs (from dump-data.ts)
 {SVG_TESTER_REPO_PATH}/{testSuite}/references/ # Output SVG references
 ```
 
@@ -89,7 +93,8 @@ Use `verify-graphs.ts` to check SVG outputs against the reference export. The sc
 The script works with test suites stored in the directory structure:
 
 ```
-{SVG_TESTER_REPO_PATH}/{testSuite}/data/        # Input data (from dump-data.ts)
+{SVG_TESTER_REPO_PATH}/variables/               # Variable data, shared by all suites
+{SVG_TESTER_REPO_PATH}/{testSuite}/data/        # Chart configs (from dump-data.ts)
 {SVG_TESTER_REPO_PATH}/{testSuite}/references/  # Reference SVGs (from export-graphs.ts)
 {SVG_TESTER_REPO_PATH}/{testSuite}/differences/ # Output differences (if any)
 ```

--- a/devTools/svgTester/refresh.sh
+++ b/devTools/svgTester/refresh.sh
@@ -49,6 +49,9 @@ main() {
         && git clean -fdx \
         && cd -
 
+    echo "=> Clearing shared variable data"
+    rm -rf $SVGS_REPO/variables
+
     refresh graphers
     refresh grapher-views
     refresh mdims

--- a/devTools/svgTester/utils.ts
+++ b/devTools/svgTester/utils.ts
@@ -53,6 +53,9 @@ export const TEST_SUITE_DESCRIPTION =
 const CONFIG_FILENAME = "config.json"
 const RESULTS_FILENAME = "results.csv"
 
+// Variable data is shared by every suite
+export const VARIABLES_DIR = path.join(SVG_TESTER_REPO_PATH, "variables")
+
 // Reading one config.json per chart is ~4,500 tiny reads for the graphers suite.
 // Doing them serially costs half a second before a single svg is rendered; any
 // concurrency at all removes that, so this is kept low enough not to sit on a
@@ -361,18 +364,39 @@ async function writeToFile(data: unknown, filename: string) {
     await fs.writeFile(filename, json)
 }
 
+// Charts are dumped concurrently and share variables, so the same id is asked
+// for many times over. Keyed by the in-flight promise rather than by "does the
+// file exist yet" so two concurrent charts can't both start writing it.
+const variableWrites = new Map<number, Promise<void>>()
+
 async function writeVariableDataAndMetadataFiles(
-    variableIds: number[],
-    outDir: string
+    variableIds: number[]
 ): Promise<void> {
-    const writeVariablePromises = variableIds.map(async (variableId) => {
-        const dataPath = path.join(outDir, `${variableId}.data.json`)
-        const metadataPath = path.join(outDir, `${variableId}.metadata.json`)
+    await fs.ensureDir(VARIABLES_DIR)
 
-        const variableData = await getVariableData(variableId)
+    const writeVariablePromises = variableIds.map((variableId) => {
+        const inFlight = variableWrites.get(variableId)
+        if (inFlight) return inFlight
 
-        await writeToFile(variableData.data, dataPath)
-        await writeToFile(variableData.metadata, metadataPath)
+        const write = (async () => {
+            const variableData = await getVariableData(variableId)
+            await writeToFile(
+                variableData.data,
+                path.join(VARIABLES_DIR, `${variableId}.data.json`)
+            )
+            await writeToFile(
+                variableData.metadata,
+                path.join(VARIABLES_DIR, `${variableId}.metadata.json`)
+            )
+        })().catch((error) => {
+            // Don't let one transient failure poison every other chart that
+            // uses this variable - the next one to ask for it retries.
+            variableWrites.delete(variableId)
+            throw error
+        })
+
+        variableWrites.set(variableId, write)
+        return write
     })
 
     await Promise.allSettled(writeVariablePromises)
@@ -398,7 +422,7 @@ export async function saveGrapherSchemaAndData(
 
     await Promise.allSettled([
         promise1,
-        writeVariableDataAndMetadataFiles(variableIds, dataDir),
+        writeVariableDataAndMetadataFiles(variableIds),
     ])
 }
 
@@ -598,14 +622,13 @@ async function loadGrapherConfigAndData(
     const rawConfig = (await fs.readJson(configPath)) as GrapherInterface
     const config = migrateGrapherConfigToLatestVersion(rawConfig) // ensure the config is migrated to the latest schema version
 
-    // TODO: this bakes the same commonly used variables over and over again - deduplicate
-    // this on the variable level and bake those separately into a different directory.
-    // Tried an in-process per-worker-thread cache here; measured no difference (see PR
-    // description) because data loading isn't the bottleneck, so leaving this as-is.
     const variableIds = config.dimensions?.map((d) => d.variableId) ?? []
     const loadDataPromises = variableIds.map(async (variableId) => {
-        const dataPath = path.join(inputDir, `${variableId}.data.json`)
-        const metadataPath = path.join(inputDir, `${variableId}.metadata.json`)
+        const dataPath = path.join(VARIABLES_DIR, `${variableId}.data.json`)
+        const metadataPath = path.join(
+            VARIABLES_DIR,
+            `${variableId}.metadata.json`
+        )
         const dataFileSize = await stat(dataPath).then((stats) => stats.size)
         const data = (await fs.readJson(dataPath)) as OwidVariableMixedData
         const metadata = (await fs.readJson(
@@ -974,7 +997,16 @@ export function logVerifySummary(summary: SvgTesterVerifyRunSummary): void {
 
 export interface GrapherViewsManifest {
     slugs: string[]
-    dataDir: string // Relative path to the data directory (e.g., "../graphers/data")
+}
+
+// grapher-views and thumbnails have no data/ of their own - they re-test charts
+// the graphers suite already dumped.
+function dataDirForSuite(testSuite: SvgTesterSuite): string {
+    const suiteOwningTheData =
+        testSuite === "grapher-views" || testSuite === "thumbnails"
+            ? "graphers"
+            : testSuite
+    return path.join(SVG_TESTER_REPO_PATH, suiteOwningTheData, "data")
 }
 
 // Load manifest from a specific path
@@ -1002,10 +1034,10 @@ export async function loadManifestViewIds(
     manifestName?: string
 }> {
     const testSuiteDir = path.join(SVG_TESTER_REPO_PATH, testSuite)
-    const defaultDataDir = path.join(testSuiteDir, "data")
+    const dataDir = dataDirForSuite(testSuite)
 
-    // For grapher-views and thumbnails, load the manifest to resolve dataDir
-    // (these suites don't have their own data/ directory)
+    // grapher-views and thumbnails are defined by their manifest: without one
+    // they would fall back to every chart in the graphers suite.
     if (testSuite === "grapher-views" || testSuite === "thumbnails") {
         const defaultManifestName = "top.manifest.json"
         const manifestName = options.manifestName ?? defaultManifestName
@@ -1013,8 +1045,6 @@ export async function loadManifestViewIds(
         const manifest = await loadManifestFromPath(manifestPath)
 
         if (manifest) {
-            const dataDir = path.join(testSuiteDir, manifest.dataDir)
-
             // viewIds are explicitly provided
             if (options.targetViewIds) return { viewIds: null, dataDir }
 
@@ -1030,7 +1060,7 @@ export async function loadManifestViewIds(
 
     // For other test suites, skip manifest if viewIds are explicitly provided
     if (options.targetViewIds) {
-        return { viewIds: null, dataDir: defaultDataDir }
+        return { viewIds: null, dataDir }
     }
 
     // For other test suites, only load manifest if explicitly provided
@@ -1039,7 +1069,6 @@ export async function loadManifestViewIds(
         const manifest = await loadManifestFromPath(manifestPath)
 
         if (manifest) {
-            const dataDir = path.join(testSuiteDir, manifest.dataDir)
             return {
                 viewIds: manifest.slugs,
                 dataDir,
@@ -1050,6 +1079,6 @@ export async function loadManifestViewIds(
         }
     }
 
-    // Default: no manifest, use default data directory
-    return { viewIds: null, dataDir: defaultDataDir }
+    // Default: no manifest, every chart in the suite's data directory
+    return { viewIds: null, dataDir }
 }


### PR DESCRIPTION
> _Written by Anthropic Claude Opus 5 — @sophiamersmann at the wheel._

Every chart in the svgs repo dumped its own copy of each variable's data and metadata, so the repo carried 4.26 GB where 2.27 GB of distinct files does — one variable backs hundreds of charts. `900801.data.json` alone existed 682 times.

The copies are byte-identical, and structurally so: `getVariableData(variableId)` takes a variable id and no chart context, so one id can only produce one payload. Verified anyway, by md5-comparing every copy of 300 randomly sampled duplicated filenames — zero mismatches.

Variables now live in a single repo-root `variables/` directory shared by every suite; chart directories keep only `config.json`.

| | files | working tree |
|---|---|---|
| graphers | 22,836 | 4.04 GB |
| mdims | 4,136 | 0.22 GB |
| after | **18,472** | **2.27 GB** |

### What this does and doesn't buy

It does **not** reduce the bytes read per run — a chart still loads its variables, and `900801.data.json` is still read 682 times. What halves is the *distinct* working set, so the page cache can hold it. Locally that gap is worth ~6s per graphers run (54s cold vs ~48s warm), and the staging containers have less RAM and slower storage than a laptop.

It also saves almost nothing in `.git` — git already stores identical blobs once. The win is disk and page cache on every staging container.

### Also in here

Drops the manifest's `dataDir` field. It was a constant (`"../graphers/data"`, written identically in both branches of `dump-data.ts`) pointing grapher-views and thumbnails at the graphers suite — something `loadManifestViewIds` already branches on two lines earlier. Existing manifests keep working since the extra key is simply ignored, and the next refresh rewrites them without it.

`refresh.sh` now clears `variables/` once in `main()` rather than per suite, which also prunes variables no chart references any more.

### Verification

Rendered every SVG in all four suites before and after the move and compared md5s: **6,461 outputs, byte-identical**.

### Careful

- **This needs a `refresh.sh` run to lay the svgs repo out accordingly.** Until then the tester cannot find its data, so don't merge it ahead of that.
- Because the directory is shared, dumping a *single* suite by hand rewrites variable files the other suites also read, which can shift their reference SVGs. `refresh.sh` dumps all four, so the normal path is safe. Noted in the readme.