### PR TITLE
🔨🤖 (svg-tester) flatten chart configs into one directory

### DIFF
--- a/devTools/svgTester/dump-data.ts
+++ b/devTools/svgTester/dump-data.ts
@@ -133,7 +133,7 @@ async function main(args: ReturnType<typeof parseArguments>) {
     try {
         const testSuite = args.testSuite as SvgTesterSuite
         const testSuiteDir = path.join(SVG_TESTER_REPO_PATH, testSuite)
-        const outDir = path.join(testSuiteDir, "data")
+        const outDir = path.join(testSuiteDir, "configs")
         const concurrency = args.concurrency
 
         if (!fs.existsSync(outDir)) fs.mkdirSync(outDir, { recursive: true })

--- a/devTools/svgTester/export-graphs.ts
+++ b/devTools/svgTester/export-graphs.ts
@@ -30,10 +30,10 @@ async function exportGraphers(args: ReturnType<typeof parseArguments>) {
         const targetChartTypes = args.chartTypes
         const randomCount = args.random
 
-        // Load manifest and determine data directory
+        // Load manifest and determine configs directory
         const {
             viewIds: manifestViewIds,
-            dataDir,
+            configsDir,
             manifestName,
         } = await utils.loadManifestViewIds(testSuite, {
             targetViewIds,
@@ -49,20 +49,23 @@ async function exportGraphers(args: ReturnType<typeof parseArguments>) {
         // Other options
         const isolate = args.isolate
 
-        if (!fs.existsSync(dataDir))
-            throw `Input directory does not exist ${dataDir}`
+        if (!fs.existsSync(configsDir))
+            throw `Configs directory does not exist ${configsDir}`
         if (!fs.existsSync(outDir)) fs.mkdirSync(outDir, { recursive: true })
 
         const startedAt = Date.now()
 
-        const chartIdsToProcess = await utils.selectChartIdsToProcess(dataDir, {
-            viewIds: targetViewIds ?? manifestViewIds ?? undefined,
-            chartTypes: targetChartTypes,
-            randomCount,
-        })
+        const chartIdsToProcess = await utils.selectChartIdsToProcess(
+            configsDir,
+            {
+                viewIds: targetViewIds ?? manifestViewIds ?? undefined,
+                chartTypes: targetChartTypes,
+                randomCount,
+            }
+        )
 
         const chartViewsToGenerate = await utils.findChartViewsToGenerate(
-            dataDir,
+            configsDir,
             chartIdsToProcess,
             {
                 queryStr: grapherQueryString,
@@ -77,7 +80,7 @@ async function exportGraphers(args: ReturnType<typeof parseArguments>) {
             chartViewsToGenerate.map((chart: utils.ChartWithQueryStr) => ({
                 dir: {
                     viewId: chart.viewId,
-                    pathToProcess: path.join(dataDir, chart.viewId),
+                    configPath: utils.configPathFor(configsDir, chart.viewId),
                 },
                 queryStr: chart.queryStr,
                 outDir,

--- a/devTools/svgTester/readme.md
+++ b/devTools/svgTester/readme.md
@@ -23,7 +23,7 @@ Use `dump-data.ts` to dump configuration and data files. It needs a running grap
 
 #### Graphers
 
-For every public and published grapher (~4,500 at the time of writing), it creates one subdirectory with the grapher slug as the directory name containing a single `config.json`, the grapher's JSON configuration.
+For every public and published grapher (~4,500 at the time of writing), it writes one config file per chart, `{SVG_TESTER_REPO_PATH}/graphers/configs/{slug}.json`.
 
 The data itself goes into `{SVG_TESTER_REPO_PATH}/variables/`, shared by every test suite:
 
@@ -40,7 +40,7 @@ For the most-viewed graphers (subset of all charts), creates a manifest file lis
 
 #### Multi-dimensional views
 
-For published multi-dimensional data pages, creates subdirectories named `{slug}?{queryStr}` containing config and data for each view:
+For published multi-dimensional data pages, writes one config per view, named `{slug}?{queryStr}.json`. Those names carry the view's query string, so they are long (152 bytes at most today, against a 255-byte limit) and contain `?` and `&`, which means they need quoting in the shell and cannot be checked out on Windows:
 
 ```bash
 yarn tsx devTools/svgTester/dump-data.ts mdims
@@ -70,7 +70,7 @@ The script works with test suites stored in the directory structure:
 
 ```
 {SVG_TESTER_REPO_PATH}/variables/              # Variable data, shared by all suites
-{SVG_TESTER_REPO_PATH}/{testSuite}/data/       # Chart configs (from dump-data.ts)
+{SVG_TESTER_REPO_PATH}/{testSuite}/configs/    # Chart configs (from dump-data.ts)
 {SVG_TESTER_REPO_PATH}/{testSuite}/references/ # Output SVG references
 ```
 
@@ -94,7 +94,7 @@ The script works with test suites stored in the directory structure:
 
 ```
 {SVG_TESTER_REPO_PATH}/variables/               # Variable data, shared by all suites
-{SVG_TESTER_REPO_PATH}/{testSuite}/data/        # Chart configs (from dump-data.ts)
+{SVG_TESTER_REPO_PATH}/{testSuite}/configs/     # Chart configs (from dump-data.ts)
 {SVG_TESTER_REPO_PATH}/{testSuite}/references/  # Reference SVGs (from export-graphs.ts)
 {SVG_TESTER_REPO_PATH}/{testSuite}/differences/ # Output differences (if any)
 ```

--- a/devTools/svgTester/refresh.sh
+++ b/devTools/svgTester/refresh.sh
@@ -18,7 +18,7 @@ refresh() {
     local path=$SVGS_REPO/$testSuite
 
     echo "=> Dumping configs and data ($testSuite)"
-    rm -rf $path/data
+    rm -rf $path/data $path/configs
     yarn tsx --tsconfig tsconfig.tsx.json devTools/svgTester/dump-data.ts \
         $testSuite
 

--- a/devTools/svgTester/utils.ts
+++ b/devTools/svgTester/utils.ts
@@ -50,8 +50,12 @@ import pMap from "p-map"
 export const TEST_SUITE_DESCRIPTION =
     "Test suite to run: 'graphers' for default Grapher views, 'grapher-views' for all views of a subset of Graphers. 'mdims' for all multi-dim views. 'thumbnails' for thumbnail versions (300x160) of all published graphers."
 
-const CONFIG_FILENAME = "config.json"
+const CONFIG_EXTENSION = ".json"
 const RESULTS_FILENAME = "results.csv"
+
+export function configPathFor(configsDir: string, viewId: string): string {
+    return path.join(configsDir, `${viewId}${CONFIG_EXTENSION}`)
+}
 
 // Variable data is shared by every suite
 export const VARIABLES_DIR = path.join(SVG_TESTER_REPO_PATH, "variables")
@@ -149,7 +153,7 @@ interface SvgDifference {
 
 interface JobDirectory {
     viewId: string
-    pathToProcess: string
+    configPath: string
 }
 
 interface JobConfigAndData {
@@ -201,14 +205,14 @@ async function verifySvg(
 }
 
 export async function selectChartIdsToProcess(
-    inDir: string,
+    configsDir: string,
     options: {
         viewIds?: string[]
         chartTypes?: GrapherChartType[]
         randomCount?: number
     }
 ): Promise<string[]> {
-    let validViewIds = await findValidViewIds(inDir, options)
+    let validViewIds = await findValidViewIds(configsDir, options)
 
     if (options.randomCount !== undefined) {
         validViewIds = R.sample(validViewIds, options.randomCount)
@@ -241,7 +245,7 @@ function getAvailableTabsFromConfig(
 }
 
 export async function findChartViewsToGenerate(
-    inDir: string,
+    configsDir: string,
     viewIds: string[],
     options: {
         queryStr?: string
@@ -253,7 +257,9 @@ export async function findChartViewsToGenerate(
     const chartsPerView = await pMap(
         viewIds,
         async (viewId): Promise<ChartWithQueryStr[]> => {
-            const grapherConfig = await parseGrapherConfig(viewId, { inDir })
+            const grapherConfig = await parseGrapherConfig(viewId, {
+                configsDir,
+            })
 
             const chartType =
                 grapherConfig.chartTypes?.[0] ?? GRAPHER_CHART_TYPES.LineChart
@@ -287,7 +293,7 @@ export async function findChartViewsToGenerate(
 }
 
 async function findValidViewIds(
-    inDir: string,
+    configsDir: string,
     {
         viewIds = [],
         chartTypes = [],
@@ -298,62 +304,52 @@ async function findValidViewIds(
 ): Promise<string[]> {
     const validChartIds: string[] = []
 
-    // If nothing is specified, scan all directories in the inDir folder
-    if (viewIds.length === 0 && chartTypes.length === 0) {
-        const dir = await fs.opendir(inDir)
-        for await (const entry of dir) {
-            if (entry.isDirectory()) {
-                const viewId = entry.name
-                validChartIds.push(viewId)
-            }
-        }
-        return validChartIds
-    }
+    // If nothing is specified, take every config in the folder
+    if (viewIds.length === 0 && chartTypes.length === 0)
+        return listViewIds(configsDir)
 
-    // If grapher ids were given check which ones exist in inDir and filter to those
+    // If grapher ids were given check which ones exist and filter to those
     // -> if by doing so we drop some, warn the user
     if (viewIds.length > 0) {
         const validatedChartIds = viewIds.filter((viewId) =>
-            fs.existsSync(path.join(inDir, viewId))
+            fs.existsSync(configPathFor(configsDir, viewId))
         )
         validChartIds.push(...validatedChartIds)
         if (validChartIds.length < viewIds.length) {
             const invalidChartIds = _.difference(viewIds, validatedChartIds)
             console.warn(
-                `${viewIds.length} view ids were given but only ${validChartIds.length} existed as directories. Missing ids: ${invalidChartIds}`
+                `${viewIds.length} view ids were given but only ${validChartIds.length} had a config. Missing ids: ${invalidChartIds}`
             )
         }
     }
 
-    // If chart types are given, scan all directories and add those that match a given chart type
+    // If chart types are given, read every config and keep the ones that match
     if (chartTypes.length > 0) {
-        const dir = await fs.opendir(inDir)
-        for await (const entry of dir) {
-            if (entry.isDirectory()) {
-                const viewId = entry.name
-                const grapherConfig = await parseGrapherConfig(viewId, {
-                    inDir,
-                })
-                const chartType =
-                    grapherConfig.chartTypes?.[0] ??
-                    GRAPHER_CHART_TYPES.LineChart
-                if (chartTypes.includes(chartType)) {
-                    validChartIds.push(viewId)
-                }
-            }
+        for (const viewId of await listViewIds(configsDir)) {
+            const grapherConfig = await parseGrapherConfig(viewId, {
+                configsDir,
+            })
+            const chartType =
+                grapherConfig.chartTypes?.[0] ?? GRAPHER_CHART_TYPES.LineChart
+            if (chartTypes.includes(chartType)) validChartIds.push(viewId)
         }
     }
 
     return validChartIds
 }
 
+async function listViewIds(configsDir: string): Promise<string[]> {
+    const filenames = await fs.readdir(configsDir)
+    return filenames
+        .filter((filename) => filename.endsWith(CONFIG_EXTENSION))
+        .map((filename) => filename.slice(0, -CONFIG_EXTENSION.length))
+}
+
 async function parseGrapherConfig(
-    chartId: string,
-    { inDir }: { inDir: string }
+    viewId: string,
+    { configsDir }: { configsDir: string }
 ): Promise<GrapherInterface> {
-    const grapherConfigPath = path.join(inDir, chartId, "config.json")
-    const grapherConfig = await fs.readJson(grapherConfigPath)
-    return grapherConfig
+    return fs.readJson(configPathFor(configsDir, viewId))
 }
 
 // Not fs.writeJson: that appends a final newline, which would rewrite every
@@ -412,10 +408,11 @@ export async function saveGrapherSchemaAndData(
 ): Promise<void> {
     const config = jobDescription.config
     const outDir = jobDescription.outDir
-    const dataDir = path.join(outDir, jobDescription.id ?? "")
-    if (!fs.existsSync(dataDir)) fs.mkdirSync(dataDir)
-    const configPath = path.join(dataDir, CONFIG_FILENAME)
-    const promise1 = writeToFile(config, configPath)
+    await fs.ensureDir(outDir)
+    const promise1 = writeToFile(
+        config,
+        configPathFor(outDir, jobDescription.id)
+    )
 
     const grapher = initGrapherForSvgExport(config)
     const variableIds = grapher.grapherState.dimensions.map((d) => d.variableId)
@@ -464,7 +461,7 @@ export async function renderSvg({
     queryStr?: string
     variant?: "default" | "thumbnail"
 }): Promise<[string, SvgRecord, string]> {
-    const configAndData = await loadGrapherConfigAndData(dir.pathToProcess)
+    const configAndData = await loadGrapherConfigAndData(dir.configPath)
 
     // Graphers sometimes need to generate ids (incrementing numbers). For this
     // they keep a stateful variable in clientutils. To minimize differences
@@ -613,12 +610,10 @@ async function loadReferenceSvg(
 }
 
 async function loadGrapherConfigAndData(
-    inputDir: string
+    configPath: string
 ): Promise<JobConfigAndData> {
-    if (!fs.existsSync(inputDir))
-        throw `Input directory does not exist ${inputDir}`
+    if (!fs.existsSync(configPath)) throw `Config does not exist ${configPath}`
 
-    const configPath = path.join(inputDir, CONFIG_FILENAME)
     const rawConfig = (await fs.readJson(configPath)) as GrapherInterface
     const config = migrateGrapherConfigToLatestVersion(rawConfig) // ensure the config is migrated to the latest schema version
 
@@ -1001,12 +996,12 @@ export interface GrapherViewsManifest {
 
 // grapher-views and thumbnails have no data/ of their own - they re-test charts
 // the graphers suite already dumped.
-function dataDirForSuite(testSuite: SvgTesterSuite): string {
-    const suiteOwningTheData =
+function configsDirForSuite(testSuite: SvgTesterSuite): string {
+    const suiteOwningTheConfigs =
         testSuite === "grapher-views" || testSuite === "thumbnails"
             ? "graphers"
             : testSuite
-    return path.join(SVG_TESTER_REPO_PATH, suiteOwningTheData, "data")
+    return path.join(SVG_TESTER_REPO_PATH, suiteOwningTheConfigs, "configs")
 }
 
 // Load manifest from a specific path
@@ -1021,7 +1016,7 @@ async function loadManifestFromPath(
 }
 
 // Load manifest with appropriate defaults for test suites that require it
-// Returns the manifest view IDs and the data directory to use
+// Returns the manifest view IDs and the configs directory to use
 export async function loadManifestViewIds(
     testSuite: SvgTesterSuite,
     options: {
@@ -1030,11 +1025,11 @@ export async function loadManifestViewIds(
     }
 ): Promise<{
     viewIds: string[] | null
-    dataDir: string
+    configsDir: string
     manifestName?: string
 }> {
     const testSuiteDir = path.join(SVG_TESTER_REPO_PATH, testSuite)
-    const dataDir = dataDirForSuite(testSuite)
+    const configsDir = configsDirForSuite(testSuite)
 
     // grapher-views and thumbnails are defined by their manifest: without one
     // they would fall back to every chart in the graphers suite.
@@ -1046,9 +1041,9 @@ export async function loadManifestViewIds(
 
         if (manifest) {
             // viewIds are explicitly provided
-            if (options.targetViewIds) return { viewIds: null, dataDir }
+            if (options.targetViewIds) return { viewIds: null, configsDir }
 
-            return { viewIds: manifest.slugs, dataDir, manifestName }
+            return { viewIds: manifest.slugs, configsDir, manifestName }
         } else {
             throw new Error(
                 `No manifest found at ${manifestPath}. For ${testSuite}, you must either:\n` +
@@ -1060,7 +1055,7 @@ export async function loadManifestViewIds(
 
     // For other test suites, skip manifest if viewIds are explicitly provided
     if (options.targetViewIds) {
-        return { viewIds: null, dataDir }
+        return { viewIds: null, configsDir }
     }
 
     // For other test suites, only load manifest if explicitly provided
@@ -1071,7 +1066,7 @@ export async function loadManifestViewIds(
         if (manifest) {
             return {
                 viewIds: manifest.slugs,
-                dataDir,
+                configsDir,
                 manifestName: options.manifestName,
             }
         } else {
@@ -1079,6 +1074,6 @@ export async function loadManifestViewIds(
         }
     }
 
-    // Default: no manifest, every chart in the suite's data directory
-    return { viewIds: null, dataDir }
+    // Default: no manifest, every chart in the suite's configs directory
+    return { viewIds: null, configsDir }
 }

--- a/devTools/svgTester/verify-graphs.ts
+++ b/devTools/svgTester/verify-graphs.ts
@@ -32,10 +32,10 @@ async function verifyGraphers(args: ReturnType<typeof parseArguments>) {
         const targetChartTypes = args.chartTypes
         const randomCount = args.random
 
-        // Load manifest and determine data directory
+        // Load manifest and determine configs directory
         const {
             viewIds: manifestViewIds,
-            dataDir,
+            configsDir,
             manifestName,
         } = await utils.loadManifestViewIds(testSuite, {
             targetViewIds,
@@ -51,8 +51,8 @@ async function verifyGraphers(args: ReturnType<typeof parseArguments>) {
         // Other options
         const rmOnError = args.rmOnError
 
-        if (!fs.existsSync(dataDir))
-            throw `Input directory does not exist ${dataDir}`
+        if (!fs.existsSync(configsDir))
+            throw `Configs directory does not exist ${configsDir}`
         if (!fs.existsSync(referencesDir))
             throw `Reference directory does not exist ${referencesDir}`
         if (!fs.existsSync(differencesDir)) fs.mkdirSync(differencesDir)
@@ -63,14 +63,17 @@ async function verifyGraphers(args: ReturnType<typeof parseArguments>) {
         const startedAt = new Date()
         await utils.writeVerifyRunStarted(testSuiteDir, testSuite, startedAt)
 
-        const chartIdsToProcess = await utils.selectChartIdsToProcess(dataDir, {
-            viewIds: targetViewIds ?? manifestViewIds ?? undefined,
-            chartTypes: targetChartTypes,
-            randomCount,
-        })
+        const chartIdsToProcess = await utils.selectChartIdsToProcess(
+            configsDir,
+            {
+                viewIds: targetViewIds ?? manifestViewIds ?? undefined,
+                chartTypes: targetChartTypes,
+                randomCount,
+            }
+        )
 
         const chartViewsToGenerate = await utils.findChartViewsToGenerate(
-            dataDir,
+            configsDir,
             chartIdsToProcess,
             {
                 queryStr: grapherQueryString,
@@ -94,9 +97,9 @@ async function verifyGraphers(args: ReturnType<typeof parseArguments>) {
                 const { viewId, queryStr } = chart
                 const key = grapherSlugToExportFileKey(viewId, queryStr)
                 const referenceEntry = referenceDataByChartKey.get(key)!
-                const pathToProcess = path.join(dataDir, viewId)
+                const configPath = utils.configPathFor(configsDir, viewId)
                 return {
-                    dir: { viewId: chart.viewId, pathToProcess },
+                    dir: { viewId: chart.viewId, configPath },
                     referenceEntry,
                     referenceDir: referencesDir,
                     outDir: differencesDir,


### PR DESCRIPTION
> _Written by Anthropic Claude Opus 5 — @sophiamersmann at the wheel._

Stacked on #6955.

Once variable data moves out of the chart directories, every one of them holds a lone `config.json` — 5,270 directories wrapping a single file each. Configs now live in `{suite}/configs/{viewId}.json`.

```
before   {suite}/data/{viewId}/config.json      5,270 directories, one file each
after    {suite}/configs/{viewId}.json          2 directories, 5,270 files
```

`data/` is renamed to `configs/` because it no longer holds any data, and the `dataDir` variable follows suit — that rename is most of the diff's line count.

### Why

There's no byte win here; after the de-dup all the config data is 21 MB. The gains are 5,270 fewer inodes and directory entries for `git status`, `git clean -fdx` and checkout to walk, and simpler code: `findValidViewIds` loses both of its `opendir`/`isDirectory` scans for a file listing, `JobDirectory` carries a file path rather than a directory, and `loadGrapherConfigAndData` takes the config path directly.

On its own this wouldn't justify another forced refresh of the svgs repo. It's here because the repo is being re-laid-out for the parent PR anyway, so it rides along for free.

### Long filenames

mdim view ids carry their query string, so these filenames are long and contain `?` and `&`:

```
graphers: 4,460 ids, longest 151 bytes -> 156 with .json
mdims:      811 ids, longest 147 bytes -> 152 with .json
limit:    255 bytes per path component
```

Both were already true of the directory names they replace, so the marginal cost is the 5 bytes of `.json` against ~100 bytes of headroom, and the total path gets shorter. Also checked: no case-insensitive collisions (matters on APFS), no non-ASCII, no id already ending in `.json`.

The headroom will erode as multi-dims gain dimensions. If it ever runs out, `buildSvgOutFilename` already has `shouldHashQueryStr` and the reference SVGs are named that way for the same reason — but that would make configs unreadable in a directory listing, so not pre-emptively.

`?` is illegal in Windows filenames, so the svgs repo can't be checked out there. Also already true today. Noted in the readme.

### Verification

Reshaped the svgs repo locally and ran all four suites against references generated from the old layout:

```
graphers:      4460 verified · 4456 ok · 4 differ
grapher-views: 1058 verified · all match
mdims:          810 verified · all match
thumbnails:     135 verified · all match
```

The four are all `WorldMap` charts and come from unrelated in-flight map work in the same working tree, not from the layout.

### Careful

Needs the same `refresh.sh` run as the parent PR — don't merge either ahead of it.