### PR TITLE
🎉🤖 explain time tolerance in the chart's note

### DIFF
--- a/packages/@ourworldindata/components/src/index.ts
+++ b/packages/@ourworldindata/components/src/index.ts
@@ -6,7 +6,6 @@ export {
 } from "./TextWrap/TextWrap.js"
 export { TextWrapSvg, TextWrapHtml } from "./TextWrap/TextWrapComponents.js"
 
-export { IRFragment } from "./MarkdownTextWrap/IRTokens.js"
 export { AbstractTokenTextWrap } from "./MarkdownTextWrap/AbstractTokenTextWrap.js"
 export {
     MarkdownTextWrap,

--- a/packages/@ourworldindata/core-table/src/OwidTable.ts
+++ b/packages/@ourworldindata/core-table/src/OwidTable.ts
@@ -16,6 +16,7 @@ import {
 } from "@ourworldindata/utils"
 import {
     Time,
+    TimeRange,
     TransformType,
     CoreColumnStore,
     Color,
@@ -109,7 +110,7 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
     }
 
     /** The first and last time in the table, undefined if it has no times */
-    @imemo get timeRange(): [Time, Time] | undefined {
+    @imemo get timeRange(): TimeRange | undefined {
         const { minTime, maxTime } = this
         if (minTime === undefined || maxTime === undefined) return undefined
         return [minTime, maxTime]

--- a/packages/@ourworldindata/core-table/src/OwidTable.ts
+++ b/packages/@ourworldindata/core-table/src/OwidTable.ts
@@ -100,12 +100,19 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
         return this.entityIdColumn.slug
     }
 
-    @imemo get minTime(): Time {
-        return _.min(this.allTimes) as Time
+    @imemo get minTime(): Time | undefined {
+        return _.min(this.allTimes)
     }
 
-    @imemo get maxTime(): number | undefined {
+    @imemo get maxTime(): Time | undefined {
         return _.max(this.allTimes)
+    }
+
+    /** The first and last time in the table, undefined if it has no times */
+    @imemo get timeRange(): [Time, Time] | undefined {
+        const { minTime, maxTime } = this
+        if (minTime === undefined || maxTime === undefined) return undefined
+        return [minTime, maxTime]
     }
 
     @imemo private get allTimes(): Time[] {
@@ -207,16 +214,20 @@ export class OwidTable extends CoreTable<OwidRow, OwidColumnDef> {
     filterByTimeRange(start: TimeBound, end: TimeBound): this {
         if (this.isBlank) return this
 
-        // We may want to do this time adjustment in Grapher instead of here.
-        const adjustedStart = start === Infinity ? this.maxTime! : start
-        const adjustedEnd = end === -Infinity ? this.minTime : end
-        // todo: we should set a time column onload so we don't have to worry about it again.
+        // Nothing to filter by if the table has no times
+        if (!this.timeRange) return this
+        const [minTime, maxTime] = this.timeRange
+
+        // We may want to do this time adjustment in Grapher instead of here
+        const adjustedStart = start === Infinity ? maxTime : start
+        const adjustedEnd = end === -Infinity ? minTime : end
+        // TODO: we should set a time column onload so we don't have to worry about it again
         const timeColumnSlug = this.timeColumn?.slug || OwidTableSlugs.Time
 
         const description = `Keep only rows with Time between ${adjustedStart} - ${adjustedEnd}`
 
         // perf: if the time range is greater than the table's time range, we can skip the filter
-        if (adjustedStart <= this.minTime && adjustedEnd >= this.maxTime!)
+        if (adjustedStart <= minTime && adjustedEnd >= maxTime)
             return this.noopTransform(description).sortedByTime
 
         return this.columnFilter(

--- a/packages/@ourworldindata/grapher/src/chart/ChartInterface.ts
+++ b/packages/@ourworldindata/grapher/src/chart/ChartInterface.ts
@@ -65,6 +65,12 @@ export interface ChartState {
 
     /** Sort keys this chart type supports */
     availableSortKeys?: SortBy[]
+
+    /**
+     * Explains that some of the values aren't from the time the chart is
+     * labelled with, because tolerance was applied
+     */
+    toleranceNotice?: string
 }
 
 /** Interface implemented by all chart component classes */

--- a/packages/@ourworldindata/grapher/src/chart/ToleranceNotice.test.ts
+++ b/packages/@ourworldindata/grapher/src/chart/ToleranceNotice.test.ts
@@ -1,6 +1,6 @@
 import { expect, it, describe } from "vitest"
 import { CoreColumn, OwidTable } from "@ourworldindata/core-table"
-import { ColumnTypeNames } from "@ourworldindata/types"
+import { ColumnTypeNames, ToleranceStrategy } from "@ourworldindata/types"
 import { makeToleranceNotice } from "./ToleranceNotice"
 
 const timeColumnOfType = (
@@ -73,6 +73,43 @@ describe(makeToleranceNotice, () => {
         )
     })
 
+    it("only looks back when the tolerance strategy is backwards", () => {
+        expect(
+            makeToleranceNotice({
+                timeColumn: yearColumn([2000]),
+                timeTolerance: 3,
+                timeRange: [1990, 2010],
+                toleranceStrategy: ToleranceStrategy.backwards,
+            })
+        ).toEqual(
+            "Where data for 2000 is unavailable, the value from the closest year back to 1997 is shown instead."
+        )
+    })
+
+    it("only looks ahead when the tolerance strategy is forwards", () => {
+        expect(
+            makeToleranceNotice({
+                timeColumn: yearColumn([2000]),
+                timeTolerance: 3,
+                timeRange: [1990, 2010],
+                toleranceStrategy: ToleranceStrategy.forwards,
+            })
+        ).toEqual(
+            "Where data for 2000 is unavailable, the value from the closest year up to 2003 is shown instead."
+        )
+    })
+
+    it("is absent when a one-directional window has no years to reach", () => {
+        expect(
+            makeToleranceNotice({
+                timeColumn: yearColumn([1990]),
+                timeTolerance: 3,
+                timeRange: [1990, 2010],
+                toleranceStrategy: ToleranceStrategy.backwards,
+            })
+        ).toBeUndefined()
+    })
+
     it("names the one year a value can come from where the window leaves just the one", () => {
         expect(
             makeToleranceNotice({
@@ -93,7 +130,7 @@ describe(makeToleranceNotice, () => {
                 timeRange: [1990, 2002],
             })
         ).toEqual(
-            "Where data is unavailable, the closest value within 3 years is shown instead."
+            "Where data is unavailable, the closest available value within 3 years is shown instead."
         )
     })
 
@@ -105,7 +142,7 @@ describe(makeToleranceNotice, () => {
                 timeRange: [0, 730],
             })
         ).toEqual(
-            "Where data is unavailable, the closest value within 90 days is shown instead."
+            "Where data is unavailable, the closest available value within 90 days is shown instead."
         )
     })
 
@@ -118,6 +155,19 @@ describe(makeToleranceNotice, () => {
             })
         ).toEqual(
             "Where data is unavailable, the closest available value is shown instead."
+        )
+    })
+
+    it("names the direction of a one-directional tolerance in the plainer sentence", () => {
+        expect(
+            makeToleranceNotice({
+                timeColumn: yearColumn([2000, 2010]),
+                timeTolerance: 3,
+                timeRange: [1990, 2010],
+                toleranceStrategy: ToleranceStrategy.backwards,
+            })
+        ).toEqual(
+            "Where data is unavailable, the closest earlier value within 3 years is shown instead."
         )
     })
 

--- a/packages/@ourworldindata/grapher/src/chart/ToleranceNotice.test.ts
+++ b/packages/@ourworldindata/grapher/src/chart/ToleranceNotice.test.ts
@@ -149,12 +149,24 @@ describe(makeToleranceNotice, () => {
     it("drops the window when the tolerance spans the whole chart", () => {
         expect(
             makeToleranceNotice({
-                timeColumn: yearColumn([2000]),
+                timeColumn: yearColumn([1990, 2002]),
                 timeTolerance: 9999,
                 timeRange: [1990, 2002],
             })
         ).toEqual(
             "Where data is unavailable, the closest available value is shown instead."
+        )
+    })
+
+    it("names the years even where the tolerance covers all of them", () => {
+        expect(
+            makeToleranceNotice({
+                timeColumn: yearColumn([2022]),
+                timeTolerance: 3,
+                timeRange: [2019, 2022],
+            })
+        ).toEqual(
+            "Where data for 2022 is unavailable, the value from the closest year back to 2019 is shown instead."
         )
     })
 

--- a/packages/@ourworldindata/grapher/src/chart/ToleranceNotice.test.ts
+++ b/packages/@ourworldindata/grapher/src/chart/ToleranceNotice.test.ts
@@ -57,7 +57,7 @@ describe(makeToleranceNotice, () => {
                 timeRange: [1990, 2010],
             })
         ).toEqual(
-            "Where data for 2010 is unavailable, the value from the closest year back to 2007 is shown instead."
+            "Where data for 2010 is unavailable, the value from the closest year between 2007 and 2009 is shown instead."
         )
     })
 
@@ -69,7 +69,7 @@ describe(makeToleranceNotice, () => {
                 timeRange: [1990, 2010],
             })
         ).toEqual(
-            "Where data for 1990 is unavailable, the value from the closest year up to 1993 is shown instead."
+            "Where data for 1990 is unavailable, the value from the closest year between 1991 and 1993 is shown instead."
         )
     })
 
@@ -82,7 +82,7 @@ describe(makeToleranceNotice, () => {
                 toleranceStrategy: ToleranceStrategy.backwards,
             })
         ).toEqual(
-            "Where data for 2000 is unavailable, the value from the closest year back to 1997 is shown instead."
+            "Where data for 2000 is unavailable, the value from the closest year between 1997 and 1999 is shown instead."
         )
     })
 
@@ -95,7 +95,7 @@ describe(makeToleranceNotice, () => {
                 toleranceStrategy: ToleranceStrategy.forwards,
             })
         ).toEqual(
-            "Where data for 2000 is unavailable, the value from the closest year up to 2003 is shown instead."
+            "Where data for 2000 is unavailable, the value from the closest year between 2001 and 2003 is shown instead."
         )
     })
 
@@ -166,7 +166,7 @@ describe(makeToleranceNotice, () => {
                 timeRange: [2019, 2022],
             })
         ).toEqual(
-            "Where data for 2022 is unavailable, the value from the closest year back to 2019 is shown instead."
+            "Where data for 2022 is unavailable, the value from the closest year between 2019 and 2021 is shown instead."
         )
     })
 

--- a/packages/@ourworldindata/grapher/src/chart/ToleranceNotice.test.ts
+++ b/packages/@ourworldindata/grapher/src/chart/ToleranceNotice.test.ts
@@ -1,0 +1,107 @@
+import { expect, it, describe } from "vitest"
+import { CoreColumn, OwidTable } from "@ourworldindata/core-table"
+import { ColumnTypeNames } from "@ourworldindata/types"
+import { makeToleranceNotice } from "./ToleranceNotice"
+
+const timeColumnOfType = (
+    slug: string,
+    type: ColumnTypeNames,
+    times: number[] = [0, 1]
+): CoreColumn =>
+    new OwidTable(
+        [
+            ["entityName", slug, "gdp"],
+            ...times.map((time) => ["France", time, 100]),
+        ],
+        [
+            { slug: "gdp", type: ColumnTypeNames.Numeric },
+            { slug, type },
+        ]
+    ).timeColumn
+
+const yearColumn = (times?: number[]): CoreColumn =>
+    timeColumnOfType("year", ColumnTypeNames.Year, times)
+const monthColumn = (times?: number[]): CoreColumn =>
+    timeColumnOfType("month", ColumnTypeNames.Month, times)
+
+describe(makeToleranceNotice, () => {
+    it("names the years a value can come from", () => {
+        expect(
+            makeToleranceNotice({
+                timeColumn: yearColumn([2000]),
+                timeTolerance: 3,
+                timeRange: [1990, 2010],
+            })
+        ).toEqual(
+            "Where data for 2000 is unavailable, the value from the closest year between 1997 and 2003 is shown instead."
+        )
+    })
+
+    it("clips the window to the years the data covers", () => {
+        expect(
+            makeToleranceNotice({
+                timeColumn: yearColumn([2010]),
+                timeTolerance: 3,
+                timeRange: [1990, 2010],
+            })
+        ).toEqual(
+            "Where data for 2010 is unavailable, the value from the closest year between 2007 and 2010 is shown instead."
+        )
+    })
+
+    it("states the tolerance as a window when the chart covers several times", () => {
+        expect(
+            makeToleranceNotice({
+                timeColumn: yearColumn(),
+                timeTolerance: 3,
+                timeRange: [1990, 2002],
+            })
+        ).toEqual(
+            "Where data is unavailable, the closest value within 3 years is shown instead."
+        )
+    })
+
+    it("states the tolerance of a monthly indicator as a window of days", () => {
+        expect(
+            makeToleranceNotice({
+                timeColumn: monthColumn([100]),
+                timeTolerance: 90,
+                timeRange: [0, 730],
+            })
+        ).toEqual(
+            "Where data is unavailable, the closest value within 90 days is shown instead."
+        )
+    })
+
+    it("drops the window when the tolerance spans the whole chart", () => {
+        expect(
+            makeToleranceNotice({
+                timeColumn: yearColumn([2000]),
+                timeTolerance: 9999,
+                timeRange: [1990, 2002],
+            })
+        ).toEqual(
+            "Where data is unavailable, the closest available value is shown instead."
+        )
+    })
+
+    it("is absent when no tolerance is configured", () => {
+        expect(
+            makeToleranceNotice({
+                timeColumn: yearColumn([2000]),
+                timeTolerance: 0,
+                timeRange: [1990, 2002],
+            })
+        ).toBeUndefined()
+    })
+
+    it("is absent when the chart covers a single point in time", () => {
+        expect(
+            makeToleranceNotice({
+                timeColumn: yearColumn([2000]),
+                timeTolerance: 5,
+                timeRange: [2000, 2000],
+            })
+        ).toBeUndefined()
+    })
+})

--- a/packages/@ourworldindata/grapher/src/chart/ToleranceNotice.test.ts
+++ b/packages/@ourworldindata/grapher/src/chart/ToleranceNotice.test.ts
@@ -40,12 +40,48 @@ describe(makeToleranceNotice, () => {
     it("clips the window to the years the data covers", () => {
         expect(
             makeToleranceNotice({
+                timeColumn: yearColumn([2009]),
+                timeTolerance: 3,
+                timeRange: [1990, 2010],
+            })
+        ).toEqual(
+            "Where data for 2009 is unavailable, the value from the closest year between 2006 and 2010 is shown instead."
+        )
+    })
+
+    it("only looks back when the chart shows the last year of the data", () => {
+        expect(
+            makeToleranceNotice({
                 timeColumn: yearColumn([2010]),
                 timeTolerance: 3,
                 timeRange: [1990, 2010],
             })
         ).toEqual(
-            "Where data for 2010 is unavailable, the value from the closest year between 2007 and 2010 is shown instead."
+            "Where data for 2010 is unavailable, the value from the closest year back to 2007 is shown instead."
+        )
+    })
+
+    it("only looks ahead when the chart shows the first year of the data", () => {
+        expect(
+            makeToleranceNotice({
+                timeColumn: yearColumn([1990]),
+                timeTolerance: 3,
+                timeRange: [1990, 2010],
+            })
+        ).toEqual(
+            "Where data for 1990 is unavailable, the value from the closest year up to 1993 is shown instead."
+        )
+    })
+
+    it("names the one year a value can come from where the window leaves just the one", () => {
+        expect(
+            makeToleranceNotice({
+                timeColumn: yearColumn([2010]),
+                timeTolerance: 1,
+                timeRange: [1990, 2010],
+            })
+        ).toEqual(
+            "Where data for 2010 is unavailable, the value from 2009 is shown instead."
         )
     })
 

--- a/packages/@ourworldindata/grapher/src/chart/ToleranceNotice.test.ts
+++ b/packages/@ourworldindata/grapher/src/chart/ToleranceNotice.test.ts
@@ -130,7 +130,7 @@ describe(formatToleranceNotice, () => {
                 timeRange: [1990, 2002],
             })
         ).toEqual(
-            "Where data is unavailable, the closest available value within 3 years is shown instead."
+            "Where data is unavailable, the closest value within 3 years is shown instead."
         )
     })
 
@@ -142,7 +142,7 @@ describe(formatToleranceNotice, () => {
                 timeRange: [0, 730],
             })
         ).toEqual(
-            "Where data is unavailable, the closest available value within 90 days is shown instead."
+            "Where data is unavailable, the closest value within 90 days is shown instead."
         )
     })
 
@@ -154,7 +154,7 @@ describe(formatToleranceNotice, () => {
                 timeRange: [1990, 2002],
             })
         ).toEqual(
-            "Where data is unavailable, the closest available value is shown instead."
+            "Where data is unavailable, the closest value is shown instead."
         )
     })
 

--- a/packages/@ourworldindata/grapher/src/chart/ToleranceNotice.test.ts
+++ b/packages/@ourworldindata/grapher/src/chart/ToleranceNotice.test.ts
@@ -1,7 +1,7 @@
 import { expect, it, describe } from "vitest"
 import { CoreColumn, OwidTable } from "@ourworldindata/core-table"
 import { ColumnTypeNames, ToleranceStrategy } from "@ourworldindata/types"
-import { makeToleranceNotice } from "./ToleranceNotice"
+import { formatToleranceNotice } from "./ToleranceNotice"
 
 const timeColumnOfType = (
     slug: string,
@@ -24,10 +24,10 @@ const yearColumn = (times?: number[]): CoreColumn =>
 const monthColumn = (times?: number[]): CoreColumn =>
     timeColumnOfType("month", ColumnTypeNames.Month, times)
 
-describe(makeToleranceNotice, () => {
+describe(formatToleranceNotice, () => {
     it("names the years a value can come from", () => {
         expect(
-            makeToleranceNotice({
+            formatToleranceNotice({
                 timeColumn: yearColumn([2000]),
                 timeTolerance: 3,
                 timeRange: [1990, 2010],
@@ -39,7 +39,7 @@ describe(makeToleranceNotice, () => {
 
     it("clips the window to the years the data covers", () => {
         expect(
-            makeToleranceNotice({
+            formatToleranceNotice({
                 timeColumn: yearColumn([2009]),
                 timeTolerance: 3,
                 timeRange: [1990, 2010],
@@ -51,7 +51,7 @@ describe(makeToleranceNotice, () => {
 
     it("only looks back when the chart shows the last year of the data", () => {
         expect(
-            makeToleranceNotice({
+            formatToleranceNotice({
                 timeColumn: yearColumn([2010]),
                 timeTolerance: 3,
                 timeRange: [1990, 2010],
@@ -63,7 +63,7 @@ describe(makeToleranceNotice, () => {
 
     it("only looks ahead when the chart shows the first year of the data", () => {
         expect(
-            makeToleranceNotice({
+            formatToleranceNotice({
                 timeColumn: yearColumn([1990]),
                 timeTolerance: 3,
                 timeRange: [1990, 2010],
@@ -75,7 +75,7 @@ describe(makeToleranceNotice, () => {
 
     it("only looks back when the tolerance strategy is backwards", () => {
         expect(
-            makeToleranceNotice({
+            formatToleranceNotice({
                 timeColumn: yearColumn([2000]),
                 timeTolerance: 3,
                 timeRange: [1990, 2010],
@@ -88,7 +88,7 @@ describe(makeToleranceNotice, () => {
 
     it("only looks ahead when the tolerance strategy is forwards", () => {
         expect(
-            makeToleranceNotice({
+            formatToleranceNotice({
                 timeColumn: yearColumn([2000]),
                 timeTolerance: 3,
                 timeRange: [1990, 2010],
@@ -101,7 +101,7 @@ describe(makeToleranceNotice, () => {
 
     it("is absent when a one-directional window has no years to reach", () => {
         expect(
-            makeToleranceNotice({
+            formatToleranceNotice({
                 timeColumn: yearColumn([1990]),
                 timeTolerance: 3,
                 timeRange: [1990, 2010],
@@ -112,7 +112,7 @@ describe(makeToleranceNotice, () => {
 
     it("names the one year a value can come from where the window leaves just the one", () => {
         expect(
-            makeToleranceNotice({
+            formatToleranceNotice({
                 timeColumn: yearColumn([2010]),
                 timeTolerance: 1,
                 timeRange: [1990, 2010],
@@ -124,7 +124,7 @@ describe(makeToleranceNotice, () => {
 
     it("states the tolerance as a window when the chart covers several times", () => {
         expect(
-            makeToleranceNotice({
+            formatToleranceNotice({
                 timeColumn: yearColumn(),
                 timeTolerance: 3,
                 timeRange: [1990, 2002],
@@ -136,7 +136,7 @@ describe(makeToleranceNotice, () => {
 
     it("states the tolerance of a monthly indicator as a window of days", () => {
         expect(
-            makeToleranceNotice({
+            formatToleranceNotice({
                 timeColumn: monthColumn([100]),
                 timeTolerance: 90,
                 timeRange: [0, 730],
@@ -148,7 +148,7 @@ describe(makeToleranceNotice, () => {
 
     it("drops the window when the tolerance spans the whole chart", () => {
         expect(
-            makeToleranceNotice({
+            formatToleranceNotice({
                 timeColumn: yearColumn([1990, 2002]),
                 timeTolerance: 9999,
                 timeRange: [1990, 2002],
@@ -160,7 +160,7 @@ describe(makeToleranceNotice, () => {
 
     it("names the years even where the tolerance covers all of them", () => {
         expect(
-            makeToleranceNotice({
+            formatToleranceNotice({
                 timeColumn: yearColumn([2022]),
                 timeTolerance: 3,
                 timeRange: [2019, 2022],
@@ -172,7 +172,7 @@ describe(makeToleranceNotice, () => {
 
     it("names the direction of a one-directional tolerance in the plainer sentence", () => {
         expect(
-            makeToleranceNotice({
+            formatToleranceNotice({
                 timeColumn: yearColumn([2000, 2010]),
                 timeTolerance: 3,
                 timeRange: [1990, 2010],
@@ -185,7 +185,7 @@ describe(makeToleranceNotice, () => {
 
     it("is absent when no tolerance is configured", () => {
         expect(
-            makeToleranceNotice({
+            formatToleranceNotice({
                 timeColumn: yearColumn([2000]),
                 timeTolerance: 0,
                 timeRange: [1990, 2002],
@@ -195,7 +195,7 @@ describe(makeToleranceNotice, () => {
 
     it("is absent when the chart covers a single point in time", () => {
         expect(
-            makeToleranceNotice({
+            formatToleranceNotice({
                 timeColumn: yearColumn([2000]),
                 timeTolerance: 5,
                 timeRange: [2000, 2000],

--- a/packages/@ourworldindata/grapher/src/chart/ToleranceNotice.ts
+++ b/packages/@ourworldindata/grapher/src/chart/ToleranceNotice.ts
@@ -7,12 +7,47 @@ import {
     ColumnSlug,
     Time,
     TimeInterval,
+    TimeRange,
     ToleranceStrategy,
 } from "@ourworldindata/types"
 import { isSubYearly } from "@ourworldindata/utils"
 
-/** The sentence explaining the chart's tolerance, if it has one worth stating */
+/**
+ * The notice a chart should show, if it has a tolerance worth stating and any
+ * value it plots is actually filled in from another time.
+ */
 export function makeToleranceNotice({
+    inputTable,
+    transformedTable,
+    columns,
+    timeTolerance,
+    toleranceStrategy,
+}: {
+    inputTable: OwidTable
+    transformedTable: OwidTable
+    columns: CoreColumn[]
+    timeTolerance?: number
+    toleranceStrategy?: ToleranceStrategy
+}): string | undefined {
+    const tolerance =
+        timeTolerance ??
+        Math.max(0, ...columns.map((column) => column.tolerance))
+    if (!tolerance) return undefined
+
+    const notice = formatToleranceNotice({
+        timeColumn: transformedTable.timeColumn,
+        timeRange: inputTable.timeRange,
+        timeTolerance: tolerance,
+        toleranceStrategy,
+    })
+    // Skip the scan below when there's no notice for it to caption
+    if (!notice) return undefined
+
+    const slugs = columns.map((column) => column.slug)
+    return hasToleranceApplied(transformedTable, slugs) ? notice : undefined
+}
+
+export function formatToleranceNotice({
     timeColumn,
     timeTolerance,
     timeRange,
@@ -20,7 +55,7 @@ export function makeToleranceNotice({
 }: {
     timeColumn: CoreColumn
     timeTolerance: number
-    timeRange: [Time, Time] | undefined
+    timeRange: TimeRange | undefined
     toleranceStrategy?: ToleranceStrategy
 }): string | undefined {
     if (!timeTolerance || timeColumn.isMissing) return undefined
@@ -51,12 +86,21 @@ export function makeToleranceNotice({
             toleranceStrategy === ToleranceStrategy.backwards
                 ? targetTime
                 : Math.min(targetTime + timeTolerance, lastTime)
+
+        // The target year has no data, so a window ending on it stops a year short
+        const start = from === targetTime ? from + 1 : from
+        const end = to === targetTime ? to - 1 : to
+
         // A one-directional window at the edge of the data reaches nothing
-        if (from === targetTime && to === targetTime) return undefined
+        if (start > end) return undefined
 
-        const window = formatToleranceWindow(timeColumn, targetTime, [from, to])
+        const format = (time: Time): string => timeColumn.formatTime(time)
+        const window =
+            start === end
+                ? format(start)
+                : `the closest year between ${format(start)} and ${format(end)}`
 
-        return `Where data for ${timeColumn.formatTime(targetTime)} is unavailable, the value from ${window} is shown instead.`
+        return `Where data for ${format(targetTime)} is unavailable, the value from ${window} is shown instead.`
     } else {
         // "closest", plus the direction where the tolerance only looks one way
         const closest =
@@ -84,9 +128,9 @@ export function makeToleranceNotice({
 
 /**
  * Whether any value in the given columns is filled in from a different time
- * than the one it's shown for. Typically called with a `tranformedTable`.
+ * than the one it's shown for. Typically called with a `transformedTable`.
  */
-export function hasToleranceApplied(
+function hasToleranceApplied(
     table: OwidTable,
     columnSlugs: ColumnSlug[]
 ): boolean {
@@ -108,31 +152,6 @@ export function hasToleranceApplied(
 
         return false
     })
-}
-
-/** The largest tolerance configured on any of the given columns */
-export function getMaxConfiguredTolerance(columns: CoreColumn[]): number {
-    return Math.max(0, ...columns.map((column) => column.tolerance))
-}
-
-/** The years a value shown for `targetTime` can come from, in words */
-function formatToleranceWindow(
-    timeColumn: CoreColumn,
-    targetTime: Time,
-    [from, to]: [Time, Time]
-): string {
-    const format = (time: Time): string => timeColumn.formatTime(time)
-
-    // The target year has no data, so a window ending on it starts (or stops)
-    // at the year next to it. That's the one-sided case, which is the norm:
-    // charts default to the latest year of their data.
-    const start = from === targetTime ? from + 1 : from
-    const end = to === targetTime ? to - 1 : to
-
-    // Name the year itself where the window leaves just the one
-    if (start === end) return format(start)
-
-    return `the closest year between ${format(start)} and ${format(end)}`
 }
 
 /** The tolerance in words, e.g. "3 years" or "a year" */

--- a/packages/@ourworldindata/grapher/src/chart/ToleranceNotice.ts
+++ b/packages/@ourworldindata/grapher/src/chart/ToleranceNotice.ts
@@ -39,22 +39,7 @@ export function makeToleranceNotice({
     // Tolerance can't be applied if the chart only has a single time
     if (firstTime === lastTime) return undefined
 
-    // "closest", plus the direction where the tolerance only looks one way
-    const closest =
-        toleranceStrategy === ToleranceStrategy.backwards
-            ? "closest earlier"
-            : toleranceStrategy === ToleranceStrategy.forwards
-              ? "closest later"
-              : "closest available"
-
-    // A tolerance that spans the whole chart isn't a window, it just means
-    // "whenever there is data". Indicators configured that way use a sentinel
-    // like 9999, which would otherwise read as "within 9999 years".
-    const isUnbounded = timeTolerance >= lastTime - firstTime
-    if (isUnbounded)
-        return `Where data is unavailable, the ${closest} value is shown instead.`
-
-    // Detailed notice for a chart that plots a single year,
+    // Detailed notice for a chart with yearly data that plots a single year,
     // all other cases (time range plotted, sub-yearly data) use a simpler notice
     if (targetTime !== undefined && !isSubYearly(timeColumn.timeInterval)) {
         // A one-directional strategy reaches to one side of the time shown only
@@ -73,6 +58,21 @@ export function makeToleranceNotice({
 
         return `Where data for ${timeColumn.formatTime(targetTime)} is unavailable, the value from ${window} is shown instead.`
     } else {
+        // "closest", plus the direction where the tolerance only looks one way
+        const closest =
+            toleranceStrategy === ToleranceStrategy.backwards
+                ? "closest earlier"
+                : toleranceStrategy === ToleranceStrategy.forwards
+                  ? "closest later"
+                  : "closest available"
+
+        // A tolerance that spans the whole chart isn't a window, it just means
+        // "whenever there is data". Indicators configured that way use a sentinel
+        // like 9999, which would otherwise read as "within 9999 days"
+        const isUnbounded = timeTolerance >= lastTime - firstTime
+        if (isUnbounded)
+            return `Where data is unavailable, the ${closest} value is shown instead.`
+
         const tolerance = formatTimeTolerance(
             timeTolerance,
             timeColumn.timeInterval

--- a/packages/@ourworldindata/grapher/src/chart/ToleranceNotice.ts
+++ b/packages/@ourworldindata/grapher/src/chart/ToleranceNotice.ts
@@ -44,7 +44,9 @@ export function makeToleranceNotice({
     if (targetTime !== undefined && !isSubYearly(timeColumn.timeInterval)) {
         const from = Math.max(targetTime - timeTolerance, firstTime)
         const to = Math.min(targetTime + timeTolerance, lastTime)
-        return `Where data for ${timeColumn.formatTime(targetTime)} is unavailable, the value from the closest year between ${timeColumn.formatTime(from)} and ${timeColumn.formatTime(to)} is shown instead.`
+        const window = formatToleranceWindow(timeColumn, targetTime, [from, to])
+
+        return `Where data for ${timeColumn.formatTime(targetTime)} is unavailable, the value from ${window} is shown instead.`
     } else {
         const tolerance = formatTimeTolerance(
             timeTolerance,
@@ -86,6 +88,30 @@ export function hasToleranceApplied(
 /** The largest tolerance configured on any of the given columns */
 export function getMaxConfiguredTolerance(columns: CoreColumn[]): number {
     return Math.max(0, ...columns.map((column) => column.tolerance))
+}
+
+/** The years a value shown for `targetTime` can come from, in words */
+function formatToleranceWindow(
+    timeColumn: CoreColumn,
+    targetTime: Time,
+    [from, to]: [Time, Time]
+): string {
+    const format = (time: Time): string => timeColumn.formatTime(time)
+
+    if (from < targetTime && to > targetTime)
+        return `the closest year between ${format(from)} and ${format(to)}`
+
+    // The window is one-sided when the chart shows the first or last year of
+    // its data, which is the norm: charts default to the latest year
+    const isLookingAhead = to > targetTime
+    const bound = isLookingAhead ? to : from
+
+    // Name the year itself where the window leaves just the one
+    if (Math.abs(bound - targetTime) === 1) return format(bound)
+
+    return isLookingAhead
+        ? `the closest year up to ${format(to)}`
+        : `the closest year back to ${format(from)}`
 }
 
 /** The tolerance in words, e.g. "3 years" or "a year" */

--- a/packages/@ourworldindata/grapher/src/chart/ToleranceNotice.ts
+++ b/packages/@ourworldindata/grapher/src/chart/ToleranceNotice.ts
@@ -134,9 +134,10 @@ function formatToleranceWindow(
     // Name the year itself where the window leaves just the one
     if (Math.abs(bound - targetTime) === 1) return format(bound)
 
+    // The target year has no data, so the window starts at the year next to it
     return isLookingAhead
-        ? `the closest year up to ${format(to)}`
-        : `the closest year back to ${format(from)}`
+        ? `the closest year between ${format(targetTime + 1)} and ${format(to)}`
+        : `the closest year between ${format(from)} and ${format(targetTime - 1)}`
 }
 
 /** The tolerance in words, e.g. "3 years" or "a year" */

--- a/packages/@ourworldindata/grapher/src/chart/ToleranceNotice.ts
+++ b/packages/@ourworldindata/grapher/src/chart/ToleranceNotice.ts
@@ -3,7 +3,12 @@ import {
     getOriginalTimeColumnSlug,
     OwidTable,
 } from "@ourworldindata/core-table"
-import { ColumnSlug, Time, TimeInterval } from "@ourworldindata/types"
+import {
+    ColumnSlug,
+    Time,
+    TimeInterval,
+    ToleranceStrategy,
+} from "@ourworldindata/types"
 import { isSubYearly } from "@ourworldindata/utils"
 
 /** The sentence explaining the chart's tolerance, if it has one worth stating */
@@ -11,10 +16,12 @@ export function makeToleranceNotice({
     timeColumn,
     timeTolerance,
     timeRange,
+    toleranceStrategy = ToleranceStrategy.closest,
 }: {
     timeColumn: CoreColumn
     timeTolerance: number
     timeRange: [Time, Time] | undefined
+    toleranceStrategy?: ToleranceStrategy
 }): string | undefined {
     if (!timeTolerance || timeColumn.isMissing) return undefined
 
@@ -32,18 +39,36 @@ export function makeToleranceNotice({
     // Tolerance can't be applied if the chart only has a single time
     if (firstTime === lastTime) return undefined
 
+    // "closest", plus the direction where the tolerance only looks one way
+    const closest =
+        toleranceStrategy === ToleranceStrategy.backwards
+            ? "closest earlier"
+            : toleranceStrategy === ToleranceStrategy.forwards
+              ? "closest later"
+              : "closest available"
+
     // A tolerance that spans the whole chart isn't a window, it just means
     // "whenever there is data". Indicators configured that way use a sentinel
     // like 9999, which would otherwise read as "within 9999 years".
     const isUnbounded = timeTolerance >= lastTime - firstTime
     if (isUnbounded)
-        return "Where data is unavailable, the closest available value is shown instead."
+        return `Where data is unavailable, the ${closest} value is shown instead.`
 
     // Detailed notice for a chart that plots a single year,
     // all other cases (time range plotted, sub-yearly data) use a simpler notice
     if (targetTime !== undefined && !isSubYearly(timeColumn.timeInterval)) {
-        const from = Math.max(targetTime - timeTolerance, firstTime)
-        const to = Math.min(targetTime + timeTolerance, lastTime)
+        // A one-directional strategy reaches to one side of the time shown only
+        const from =
+            toleranceStrategy === ToleranceStrategy.forwards
+                ? targetTime
+                : Math.max(targetTime - timeTolerance, firstTime)
+        const to =
+            toleranceStrategy === ToleranceStrategy.backwards
+                ? targetTime
+                : Math.min(targetTime + timeTolerance, lastTime)
+        // A one-directional window at the edge of the data reaches nothing
+        if (from === targetTime && to === targetTime) return undefined
+
         const window = formatToleranceWindow(timeColumn, targetTime, [from, to])
 
         return `Where data for ${timeColumn.formatTime(targetTime)} is unavailable, the value from ${window} is shown instead.`
@@ -53,7 +78,7 @@ export function makeToleranceNotice({
             timeColumn.timeInterval
         )
 
-        return `Where data is unavailable, the closest value within ${tolerance} is shown instead.`
+        return `Where data is unavailable, the ${closest} value within ${tolerance} is shown instead.`
     }
 }
 

--- a/packages/@ourworldindata/grapher/src/chart/ToleranceNotice.ts
+++ b/packages/@ourworldindata/grapher/src/chart/ToleranceNotice.ts
@@ -1,0 +1,100 @@
+import {
+    CoreColumn,
+    getOriginalTimeColumnSlug,
+    OwidTable,
+} from "@ourworldindata/core-table"
+import { ColumnSlug, Time, TimeInterval } from "@ourworldindata/types"
+import { isSubYearly } from "@ourworldindata/utils"
+
+/** The sentence explaining the chart's tolerance, if it has one worth stating */
+export function makeToleranceNotice({
+    timeColumn,
+    timeTolerance,
+    timeRange,
+}: {
+    timeColumn: CoreColumn
+    timeTolerance: number
+    timeRange: [Time, Time] | undefined
+}): string | undefined {
+    if (!timeTolerance || timeColumn.isMissing) return undefined
+
+    // Without times there's nothing tolerance could have substituted
+    if (!timeRange) return undefined
+
+    // No target time for charts that plot a time range
+    const targetTime =
+        timeColumn.uniqTimesAsc.length === 1
+            ? timeColumn.uniqTimesAsc[0]
+            : undefined
+
+    const [firstTime, lastTime] = timeRange
+
+    // Tolerance can't be applied if the chart only has a single time
+    if (firstTime === lastTime) return undefined
+
+    // A tolerance that spans the whole chart isn't a window, it just means
+    // "whenever there is data". Indicators configured that way use a sentinel
+    // like 9999, which would otherwise read as "within 9999 years".
+    const isUnbounded = timeTolerance >= lastTime - firstTime
+    if (isUnbounded)
+        return "Where data is unavailable, the closest available value is shown instead."
+
+    // Detailed notice for a chart that plots a single year,
+    // all other cases (time range plotted, sub-yearly data) use a simpler notice
+    if (targetTime !== undefined && !isSubYearly(timeColumn.timeInterval)) {
+        const from = Math.max(targetTime - timeTolerance, firstTime)
+        const to = Math.min(targetTime + timeTolerance, lastTime)
+        return `Where data for ${timeColumn.formatTime(targetTime)} is unavailable, the value from the closest year between ${timeColumn.formatTime(from)} and ${timeColumn.formatTime(to)} is shown instead.`
+    } else {
+        const tolerance = formatTimeTolerance(
+            timeTolerance,
+            timeColumn.timeInterval
+        )
+
+        return `Where data is unavailable, the closest value within ${tolerance} is shown instead.`
+    }
+}
+
+/**
+ * Whether any value in the given columns is filled in from a different time
+ * than the one it's shown for. Typically called with a `tranformedTable`.
+ */
+export function hasToleranceApplied(
+    table: OwidTable,
+    columnSlugs: ColumnSlug[]
+): boolean {
+    const { timeColumn } = table
+    if (timeColumn.isMissing) return false
+
+    const times = timeColumn.valuesIncludingErrorValues
+
+    return columnSlugs.some((slug) => {
+        const originalTimeSlug = getOriginalTimeColumnSlug(table, slug)
+        if (!table.has(slug) || !table.has(originalTimeSlug)) return false
+
+        const originalTimes =
+            table.get(originalTimeSlug).valuesIncludingErrorValues
+
+        for (let i = 0; i < times.length; i++) {
+            if (times[i] !== originalTimes[i]) return true
+        }
+
+        return false
+    })
+}
+
+/** The largest tolerance configured on any of the given columns */
+export function getMaxConfiguredTolerance(columns: CoreColumn[]): number {
+    return Math.max(0, ...columns.map((column) => column.tolerance))
+}
+
+/** The tolerance in words, e.g. "3 years" or "a year" */
+function formatTimeTolerance(
+    tolerance: number,
+    timeInterval: TimeInterval
+): string {
+    // Sub-yearly times are stored as days, so their tolerance is in days
+    const unit = isSubYearly(timeInterval) ? "day" : "year"
+
+    return tolerance === 1 ? `a ${unit}` : `${tolerance} ${unit}s`
+}

--- a/packages/@ourworldindata/grapher/src/chart/ToleranceNotice.ts
+++ b/packages/@ourworldindata/grapher/src/chart/ToleranceNotice.ts
@@ -113,7 +113,7 @@ export function formatToleranceNotice({
                 ? "closest earlier"
                 : toleranceStrategy === ToleranceStrategy.forwards
                   ? "closest later"
-                  : "closest available"
+                  : "closest"
 
         // A tolerance that spans the whole chart isn't a window, it just means
         // "whenever there is data". Indicators configured that way use a sentinel

--- a/packages/@ourworldindata/grapher/src/chart/ToleranceNotice.ts
+++ b/packages/@ourworldindata/grapher/src/chart/ToleranceNotice.ts
@@ -4,7 +4,6 @@ import {
     OwidTable,
 } from "@ourworldindata/core-table"
 import {
-    ColumnSlug,
     Time,
     TimeInterval,
     TimeRange,
@@ -29,22 +28,28 @@ export function makeToleranceNotice({
     timeTolerance?: number
     toleranceStrategy?: ToleranceStrategy
 }): string | undefined {
-    const tolerance =
-        timeTolerance ??
-        Math.max(0, ...columns.map((column) => column.tolerance))
-    if (!tolerance) return undefined
+    const configuredTolerance =
+        timeTolerance ?? getMaxConfiguredTolerance(columns)
+    if (!configuredTolerance) return undefined
 
-    const notice = formatToleranceNotice({
+    const appliedColumns = columnsWithToleranceApplied(
+        transformedTable,
+        columns
+    )
+    if (!appliedColumns.length) return undefined
+
+    // Only take into account the tolerance configured on the columns
+    // that actually had a value filled in from another time
+    const appliedTolerance = getMaxConfiguredTolerance(appliedColumns)
+    const statedTolerance =
+        timeTolerance ?? (appliedTolerance || configuredTolerance)
+
+    return formatToleranceNotice({
         timeColumn: transformedTable.timeColumn,
         timeRange: inputTable.timeRange,
-        timeTolerance: tolerance,
+        timeTolerance: statedTolerance,
         toleranceStrategy,
     })
-    // Skip the scan below when there's no notice for it to caption
-    if (!notice) return undefined
-
-    const slugs = columns.map((column) => column.slug)
-    return hasToleranceApplied(transformedTable, slugs) ? notice : undefined
 }
 
 export function formatToleranceNotice({
@@ -126,20 +131,26 @@ export function formatToleranceNotice({
     }
 }
 
+/** The largest tolerance configured on any of the given columns */
+function getMaxConfiguredTolerance(columns: CoreColumn[]): number {
+    return Math.max(0, ...columns.map((column) => column.tolerance))
+}
+
 /**
- * Whether any value in the given columns is filled in from a different time
- * than the one it's shown for. Typically called with a `transformedTable`.
+ * Of the given columns, those with a value that is filled in from a different
+ * time than the one it's shown for. Typically called with a `transformedTable`.
  */
-function hasToleranceApplied(
+function columnsWithToleranceApplied(
     table: OwidTable,
-    columnSlugs: ColumnSlug[]
-): boolean {
+    columns: CoreColumn[]
+): CoreColumn[] {
     const { timeColumn } = table
-    if (timeColumn.isMissing) return false
+    if (timeColumn.isMissing) return []
 
     const times = timeColumn.valuesIncludingErrorValues
 
-    return columnSlugs.some((slug) => {
+    return columns.filter((column) => {
+        const { slug } = column
         const originalTimeSlug = getOriginalTimeColumnSlug(table, slug)
         if (!table.has(slug) || !table.has(originalTimeSlug)) return false
 

--- a/packages/@ourworldindata/grapher/src/chart/ToleranceNotice.ts
+++ b/packages/@ourworldindata/grapher/src/chart/ToleranceNotice.ts
@@ -123,21 +123,16 @@ function formatToleranceWindow(
 ): string {
     const format = (time: Time): string => timeColumn.formatTime(time)
 
-    if (from < targetTime && to > targetTime)
-        return `the closest year between ${format(from)} and ${format(to)}`
-
-    // The window is one-sided when the chart shows the first or last year of
-    // its data, which is the norm: charts default to the latest year
-    const isLookingAhead = to > targetTime
-    const bound = isLookingAhead ? to : from
+    // The target year has no data, so a window ending on it starts (or stops)
+    // at the year next to it. That's the one-sided case, which is the norm:
+    // charts default to the latest year of their data.
+    const start = from === targetTime ? from + 1 : from
+    const end = to === targetTime ? to - 1 : to
 
     // Name the year itself where the window leaves just the one
-    if (Math.abs(bound - targetTime) === 1) return format(bound)
+    if (start === end) return format(start)
 
-    // The target year has no data, so the window starts at the year next to it
-    return isLookingAhead
-        ? `the closest year between ${format(targetTime + 1)} and ${format(to)}`
-        : `the closest year between ${format(from)} and ${format(targetTime - 1)}`
+    return `the closest year between ${format(start)} and ${format(end)}`
 }
 
 /** The tolerance in words, e.g. "3 years" or "a year" */

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -727,6 +727,15 @@ export class Grapher extends React.Component<GrapherProps> {
         )
     }
 
+    private freezeToleranceNoticeWhileTimelineMoves(): void {
+        this.grapherState.disposers.push(
+            reaction(
+                () => this.grapherState.isTimelineInteractionActive,
+                this.grapherState.setToleranceNoticeFrozen
+            )
+        )
+    }
+
     private clearFocusMode(): void {
         // Make it easy to exit focus mode by clearing it when the selection
         // or view changes. This is disabled in the admin to avoid clearing
@@ -760,6 +769,7 @@ export class Grapher extends React.Component<GrapherProps> {
         this.bindKeyboardShortcuts()
 
         this.clearFocusMode()
+        this.freezeToleranceNoticeWhileTimelineMoves()
     }
 
     private _shortcutsBound = false

--- a/packages/@ourworldindata/grapher/src/core/GrapherState.test.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.test.ts
@@ -700,7 +700,7 @@ describe("toleranceNotice", () => {
     it("explains the tolerance on the map tab", () => {
         const grapher = makeGrapherWithTolerance()
         expect(grapher.toleranceNotice).toEqual(
-            "Where data for 2002 is unavailable, the value from the closest year between 1999 and 2002 is shown instead."
+            "Where data for 2002 is unavailable, the value from the closest year back to 1999 is shown instead."
         )
     })
 
@@ -839,7 +839,7 @@ describe("toleranceNotice", () => {
 
     describe("appending to the authored note", () => {
         const NOTICE =
-            "Where data for 2002 is unavailable, the value from the closest year between 1999 and 2002 is shown instead."
+            "Where data for 2002 is unavailable, the value from the closest year back to 1999 is shown instead."
 
         it("separates the notice from a note ending in a period", () => {
             const grapher = makeGrapherWithTolerance({

--- a/packages/@ourworldindata/grapher/src/core/GrapherState.test.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.test.ts
@@ -700,7 +700,7 @@ describe("toleranceNotice", () => {
     it("explains the tolerance on the map tab", () => {
         const grapher = makeGrapherWithTolerance()
         expect(grapher.toleranceNotice).toEqual(
-            "Where data for 2002 is unavailable, the value from the closest year back to 1999 is shown instead."
+            "Where data for 2002 is unavailable, the value from the closest year between 1999 and 2001 is shown instead."
         )
     })
 
@@ -839,7 +839,7 @@ describe("toleranceNotice", () => {
 
     describe("appending to the authored note", () => {
         const NOTICE =
-            "Where data for 2002 is unavailable, the value from the closest year back to 1999 is shown instead."
+            "Where data for 2002 is unavailable, the value from the closest year between 1999 and 2001 is shown instead."
 
         it("separates the notice from a note ending in a period", () => {
             const grapher = makeGrapherWithTolerance({

--- a/packages/@ourworldindata/grapher/src/core/GrapherState.test.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.test.ts
@@ -35,6 +35,7 @@ import {
 import { legacyToCurrentGrapherQueryParams } from "./GrapherUrlMigrations"
 import { setSelectedEntityNamesParam } from "./EntityUrlBuilder"
 import { MapConfig } from "../mapCharts/MapConfig"
+import { TimelineDragTarget } from "../timeline/TimelineController"
 import { SelectionArray } from "../selection/SelectionArray"
 import { latestGrapherConfigSchema } from "./GrapherConstants.js"
 import { legacyToOwidTableAndDimensionsWithMandatorySlug } from "./LegacyToOwidTable.js"
@@ -659,6 +660,215 @@ describe("title", () => {
 
         expect(grapher.titleAnnotation).toBeUndefined()
         expect(grapher.fullTitle).toEqual(grapher.mainTitle)
+    })
+})
+
+describe("toleranceNotice", () => {
+    // Germany lacks data for 2002 and Italy for 2000
+    const makeTable = (extraRows: (string | number)[][] = []): OwidTable =>
+        new OwidTable(
+            [
+                ["entityName", "year", "gdp"],
+                ["France", 1990, 50],
+                ["France", 2000, 100],
+                ["France", 2001, 200],
+                ["France", 2002, 300],
+                ["Germany", 2000, 400],
+                ["Germany", 2001, 500],
+                ["Italy", 2001, 600],
+                ["Italy", 2002, 700],
+                ...extraRows,
+            ],
+            [
+                { slug: "gdp", type: ColumnTypeNames.Numeric, tolerance: 1 },
+                { slug: "year", type: ColumnTypeNames.Year },
+            ]
+        )
+
+    const makeGrapherWithTolerance = (
+        props?: Partial<GrapherProgrammaticInterface>
+    ): GrapherState =>
+        new GrapherState({
+            table: makeTable(),
+            ySlugs: "gdp",
+            tab: GRAPHER_TAB_CONFIG_OPTIONS.map,
+            hasMapTab: true,
+            map: { timeTolerance: 3 },
+            ...props,
+        })
+
+    it("explains the tolerance on the map tab", () => {
+        const grapher = makeGrapherWithTolerance()
+        expect(grapher.toleranceNotice).toEqual(
+            "Where data for 2002 is unavailable, the value from the closest year between 1999 and 2002 is shown instead."
+        )
+    })
+
+    it("only explains the tolerance when necessary", () => {
+        const grapher = makeGrapherWithTolerance()
+        const noteAt = (year: number): string | undefined => {
+            grapher.timelineHandleTimeBounds = [year, year]
+            return grapher.toleranceNotice
+        }
+        // Italy has no 2000 value and Germany no 2002 one, but 2001 is the one
+        // year every country has data for
+        expect(noteAt(2000)).toBeDefined()
+        expect(noteAt(2001)).toBeUndefined()
+        expect(noteAt(2002)).toBeDefined()
+    })
+
+    describe("frozen while the timeline is in motion", () => {
+        const drag = (grapher: GrapherState): void => {
+            grapher.timelineDragTarget = TimelineDragTarget.End
+            grapher.setToleranceNoticeFrozen(true)
+        }
+        const release = (grapher: GrapherState): void => {
+            grapher.timelineDragTarget = undefined
+            grapher.setToleranceNoticeFrozen(false)
+        }
+        const goTo = (grapher: GrapherState, year: number): void => {
+            grapher.timelineHandleTimeBounds = [year, year]
+        }
+
+        it("keeps a notice that was up when the drag started", () => {
+            const grapher = makeGrapherWithTolerance()
+            goTo(grapher, 2000) // tolerance applies here
+            drag(grapher)
+            goTo(grapher, 2001) // but not here
+            expect(grapher.toleranceNotice).toBeDefined()
+            release(grapher)
+            expect(grapher.toleranceNotice).toBeUndefined()
+        })
+
+        it("keeps a notice that was down when the drag started", () => {
+            const grapher = makeGrapherWithTolerance()
+            goTo(grapher, 2001)
+            drag(grapher)
+            goTo(grapher, 2000)
+            expect(grapher.toleranceNotice).toBeUndefined()
+            release(grapher)
+            expect(grapher.toleranceNotice).toBeDefined()
+        })
+
+        it("freezes nothing when the timeline is idle", () => {
+            const grapher = makeGrapherWithTolerance()
+            goTo(grapher, 2000)
+            grapher.setToleranceNoticeFrozen(true)
+            goTo(grapher, 2001)
+            expect(grapher.toleranceNotice).toBeUndefined()
+        })
+    })
+
+    describe("only when tolerance is actually applied", () => {
+        // Every country has data for every year
+        const completeTable = (): OwidTable =>
+            new OwidTable(
+                [
+                    ["entityName", "year", "gdp"],
+                    ["France", 1990, 50],
+                    ["France", 2000, 100],
+                    ["France", 2002, 300],
+                    ["Germany", 1990, 60],
+                    ["Germany", 2000, 400],
+                    ["Germany", 2002, 600],
+                ],
+                [
+                    {
+                        slug: "gdp",
+                        type: ColumnTypeNames.Numeric,
+                        tolerance: 3,
+                    },
+                    { slug: "year", type: ColumnTypeNames.Year },
+                ]
+            )
+
+        it("is absent on a chart tab whose data has no gaps", () => {
+            const grapher = new GrapherState({
+                table: completeTable(),
+                ySlugs: "gdp",
+                chartTypes: [GRAPHER_CHART_TYPES.SlopeChart],
+                selectedEntityNames: ["France", "Germany"],
+            })
+            expect(grapher.toleranceNotice).toBeUndefined()
+        })
+
+        // A gap only counts if the entity carrying it is on screen
+        const gapInSpainTable = (): OwidTable =>
+            new OwidTable(
+                [
+                    ["entityName", "year", "gdp"],
+                    ["France", 2000, 100],
+                    ["France", 2001, 200],
+                    ["France", 2002, 300],
+                    ["Germany", 2000, 400],
+                    ["Germany", 2001, 500],
+                    ["Germany", 2002, 600],
+                    ["Spain", 2000, 700],
+                    ["Spain", 2001, 800],
+                    // Spain has no 2002 value, which is the slope's end point
+                ],
+                [
+                    {
+                        slug: "gdp",
+                        type: ColumnTypeNames.Numeric,
+                        tolerance: 3,
+                    },
+                    { slug: "year", type: ColumnTypeNames.Year },
+                ]
+            )
+
+        const makeSlopeGrapher = (
+            selectedEntityNames: string[]
+        ): GrapherState =>
+            new GrapherState({
+                table: gapInSpainTable(),
+                ySlugs: "gdp",
+                chartTypes: [GRAPHER_CHART_TYPES.SlopeChart],
+                selectedEntityNames,
+            })
+
+        it("ignores a gap in an entity that isn't selected", () => {
+            expect(
+                makeSlopeGrapher(["France", "Germany"]).toleranceNotice
+            ).toBeUndefined()
+            expect(
+                makeSlopeGrapher(["France", "Germany", "Spain"]).toleranceNotice
+            ).toBeDefined()
+        })
+    })
+
+    describe("appending to the authored note", () => {
+        const NOTICE =
+            "Where data for 2002 is unavailable, the value from the closest year between 1999 and 2002 is shown instead."
+
+        it("separates the notice from a note ending in a period", () => {
+            const grapher = makeGrapherWithTolerance({
+                note: "Values are adjusted.",
+            })
+            expect(grapher.effectiveNote).toEqual(
+                `Values are adjusted. ${NOTICE}`
+            )
+        })
+
+        it("terminates a note that ends without punctuation", () => {
+            const grapher = makeGrapherWithTolerance({
+                note: "Values are adjusted",
+            })
+            expect(grapher.effectiveNote).toEqual(
+                `Values are adjusted. ${NOTICE}`
+            )
+        })
+
+        it("keeps a note's own end punctuation", () => {
+            const grapher = makeGrapherWithTolerance({
+                note: "Is this adjusted?",
+            })
+            expect(grapher.effectiveNote).toEqual(`Is this adjusted? ${NOTICE}`)
+        })
+
+        it("stands alone when there is no authored note", () => {
+            expect(makeGrapherWithTolerance().effectiveNote).toEqual(NOTICE)
+        })
     })
 })
 

--- a/packages/@ourworldindata/grapher/src/core/GrapherState.test.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.test.ts
@@ -759,6 +759,44 @@ describe("toleranceNotice", () => {
         })
     })
 
+    it("is only as wide as the columns that were substituted", () => {
+        const grapher = new GrapherState({
+            table: new OwidTable(
+                [
+                    ["entityName", "year", "gdp", "pop"],
+                    ["France", 1990, 10, 1],
+                    ["France", 2001, 200, 20],
+                    // Only gdp is missing its 2002 value
+                    ["France", 2002, "", 30],
+                    ["Germany", 1990, 20, 2],
+                    ["Germany", 2001, 300, 30],
+                    ["Germany", 2002, 400, 40],
+                ],
+                [
+                    {
+                        slug: "gdp",
+                        type: ColumnTypeNames.Numeric,
+                        tolerance: 3,
+                    },
+                    {
+                        slug: "pop",
+                        type: ColumnTypeNames.Numeric,
+                        tolerance: 10,
+                    },
+                    { slug: "year", type: ColumnTypeNames.Year },
+                ]
+            ),
+            ySlugs: "gdp pop",
+            chartTypes: [GRAPHER_CHART_TYPES.SlopeChart],
+            selectedEntityNames: ["France", "Germany"],
+        })
+
+        // gdp's 3 years, not pop's 10, which isn't currently applied
+        expect(grapher.toleranceNotice).toEqual(
+            "Where data is unavailable, the closest available value within 3 years is shown instead."
+        )
+    })
+
     describe("only when tolerance is actually applied", () => {
         // Every country has data for every year
         const completeTable = (): OwidTable =>

--- a/packages/@ourworldindata/grapher/src/core/GrapherState.test.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.test.ts
@@ -793,7 +793,7 @@ describe("toleranceNotice", () => {
 
         // gdp's 3 years, not pop's 10, which isn't currently applied
         expect(grapher.toleranceNotice).toEqual(
-            "Where data is unavailable, the closest available value within 3 years is shown instead."
+            "Where data is unavailable, the closest value within 3 years is shown instead."
         )
     })
 

--- a/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
@@ -574,6 +574,9 @@ export class GrapherState
     areHandlesOnSameTimeBeforeAnimation: boolean | undefined = undefined
     /** Which timeline element is currently being dragged */
     timelineDragTarget: TimelineDragTarget | undefined = undefined
+    /** The tolerance notice as of the start of a timeline interaction */
+    frozenToleranceNotice: { notice: string | undefined } | undefined =
+        undefined
 
     // Display flags
     hasTableTab = true
@@ -732,6 +735,7 @@ export class GrapherState
             animationStartTime: observable.ref,
             areHandlesOnSameTimeBeforeAnimation: observable.ref,
             timelineDragTarget: observable.ref,
+            frozenToleranceNotice: observable.ref,
             isEntitySelectorModalOrDrawerOpen: observable.ref,
             activeModal: observable.ref,
             activeDownloadModalTab: observable.ref,
@@ -2471,6 +2475,50 @@ export class GrapherState
         const yColumns = this.yColumnsFromDimensions
         if (yColumns.length === 1) return yColumns[0].def.descriptionShort ?? ""
         return ""
+    }
+
+    /**
+     * Explains that some of the values on screen aren't from the time the
+     * chart is labelled with, because tolerance was applied.
+     */
+    @computed get toleranceNotice(): string | undefined {
+        // No need to show a notice on the table tab because the table
+        // shows the original time for each value
+        if (!this.isReady || !this.isOnChartOrMapTab) return undefined
+
+        // Freeze the notice during timeline interactions so it doesn't change
+        // while the user is dragging or playing an animation
+        if (this.frozenToleranceNotice && this.isTimelineInteractionActive)
+            return this.frozenToleranceNotice.notice
+
+        return this.chartState.toleranceNotice
+    }
+
+    /** Whether the timeline is being dragged or is playing an animation */
+    @computed get isTimelineInteractionActive(): boolean {
+        return !!this.timelineDragTarget || this.isTimelineAnimationPlaying
+    }
+
+    @action.bound setToleranceNoticeFrozen(isFrozen: boolean): void {
+        this.frozenToleranceNotice = isFrozen
+            ? { notice: this.toleranceNotice }
+            : undefined
+    }
+
+    /**
+     * Effective note resolved from the authored note, with the tolerance
+     * notice appended when tolerance was applied to something on screen
+     */
+    @computed get effectiveNote(): string | undefined {
+        const { note, toleranceNotice } = this
+        if (!toleranceNotice) return note
+
+        const authoredNote = note?.trim()
+        if (!authoredNote) return toleranceNotice
+
+        // Run the two together as sentences
+        const separator = /[.!?]$/.test(authoredNote) ? " " : ". "
+        return `${authoredNote}${separator}${toleranceNotice}`
     }
 
     @computed get shouldAddEntitySuffixToTitle(): boolean {

--- a/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChartState.ts
+++ b/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChartState.ts
@@ -14,11 +14,7 @@ import {
 import { OwidTable, CoreColumn } from "@ourworldindata/core-table"
 import { domainExtent } from "@ourworldindata/utils"
 import { ChartState } from "../chart/ChartInterface"
-import {
-    getMaxConfiguredTolerance,
-    hasToleranceApplied,
-    makeToleranceNotice,
-} from "../chart/ToleranceNotice"
+import { makeToleranceNotice } from "../chart/ToleranceNotice"
 import {
     DEFAULT_DUMBBELL_TREND_COLOR_MAP,
     DUMBBELL_SORT_KEYS,
@@ -359,27 +355,12 @@ export class DumbbellChartState implements ChartState {
         ])
     }
 
-    /** The notice itself, regardless of whether it currently applies */
-    @computed private get toleranceNoticeIfApplied(): string | undefined {
-        return makeToleranceNotice({
-            timeColumn: this.transformedTable.timeColumn,
-            timeRange: this.inputTable.timeRange,
-            timeTolerance: getMaxConfiguredTolerance(this.yColumns),
-        })
-    }
-
-    /** Whether any value shown right now is filled in from another time */
-    @computed private get isToleranceApplied(): boolean {
-        // Skip the scan below when there's no notice for it to caption
-        if (!this.toleranceNoticeIfApplied) return false
-
-        return hasToleranceApplied(this.transformedTable, this.yColumnSlugs)
-    }
-
     @computed get toleranceNotice(): string | undefined {
-        return this.isToleranceApplied
-            ? this.toleranceNoticeIfApplied
-            : undefined
+        return makeToleranceNotice({
+            inputTable: this.inputTable,
+            transformedTable: this.transformedTable,
+            columns: this.yColumns,
+        })
     }
 
     @computed get yDomainDefault(): [number, number] {

--- a/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChartState.ts
+++ b/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChartState.ts
@@ -15,6 +15,11 @@ import { OwidTable, CoreColumn } from "@ourworldindata/core-table"
 import { domainExtent } from "@ourworldindata/utils"
 import { ChartState } from "../chart/ChartInterface"
 import {
+    getMaxConfiguredTolerance,
+    hasToleranceApplied,
+    makeToleranceNotice,
+} from "../chart/ToleranceNotice"
+import {
     DEFAULT_DUMBBELL_TREND_COLOR_MAP,
     DUMBBELL_SORT_KEYS,
     DumbbellChartManager,
@@ -352,6 +357,29 @@ export class DumbbellChartState implements ChartState {
             series.start.value,
             series.end.value,
         ])
+    }
+
+    /** The notice itself, regardless of whether it currently applies */
+    @computed private get toleranceNoticeIfApplied(): string | undefined {
+        return makeToleranceNotice({
+            timeColumn: this.transformedTable.timeColumn,
+            timeRange: this.inputTable.timeRange,
+            timeTolerance: getMaxConfiguredTolerance(this.yColumns),
+        })
+    }
+
+    /** Whether any value shown right now is filled in from another time */
+    @computed private get isToleranceApplied(): boolean {
+        // Skip the scan below when there's no notice for it to caption
+        if (!this.toleranceNoticeIfApplied) return false
+
+        return hasToleranceApplied(this.transformedTable, this.yColumnSlugs)
+    }
+
+    @computed get toleranceNotice(): string | undefined {
+        return this.isToleranceApplied
+            ? this.toleranceNoticeIfApplied
+            : undefined
     }
 
     @computed get yDomainDefault(): [number, number] {

--- a/packages/@ourworldindata/grapher/src/footer/Footer.tsx
+++ b/packages/@ourworldindata/grapher/src/footer/Footer.tsx
@@ -136,11 +136,13 @@ abstract class AbstractFooter<
     }
 
     @computed protected get noteText(): string {
-        return this.manager.note ? `Note: ${this.manager.note}` : ""
+        const note = this.manager.effectiveNote
+        return note ? `Note: ${note}` : ""
     }
 
     @computed protected get markdownNoteText(): string {
-        return this.manager.note ? `**Note:** ${this.manager.note}` : ""
+        const note = this.manager.effectiveNote
+        return note ? `**Note:** ${note}` : ""
     }
 
     @computed protected get license(): LicenseOption {

--- a/packages/@ourworldindata/grapher/src/footer/FooterManager.ts
+++ b/packages/@ourworldindata/grapher/src/footer/FooterManager.ts
@@ -5,7 +5,7 @@ import { GrapherModal } from "../core/GrapherConstants"
 
 export interface FooterManager extends TooltipManager, ActionButtonsManager {
     sourcesLine?: string
-    note?: string
+    effectiveNote?: string
     hasOWIDLogo?: boolean
     license?: LicenseOption
     originUrlWithProtocol?: string

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapChartState.ts
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapChartState.ts
@@ -23,6 +23,7 @@ import {
     PrimitiveType,
     TickFormattingOptions,
     Time,
+    ToleranceStrategy,
 } from "@ourworldindata/types"
 import {
     anyToString,
@@ -340,12 +341,19 @@ export class MapChartState implements ChartState, ColorScaleManager {
         return this.mapConfig.timeTolerance ?? this.mapColumn.tolerance
     }
 
+    @computed private get toleranceStrategy(): ToleranceStrategy | undefined {
+        return (
+            this.mapConfig.toleranceStrategy ?? this.mapColumn.toleranceStrategy
+        )
+    }
+
     /** The notice itself, regardless of whether it currently applies */
     @computed private get toleranceNoticeIfApplied(): string | undefined {
         return makeToleranceNotice({
             timeColumn: this.transformedTable.timeColumn,
             timeRange: this.inputTable.timeRange,
             timeTolerance: this.timeTolerance,
+            toleranceStrategy: this.toleranceStrategy,
         })
     }
 

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapChartState.ts
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapChartState.ts
@@ -38,10 +38,7 @@ import { getCountriesByRegion, isOnTheMap } from "./MapHelpers"
 import { MapSelectionArray } from "../selection/MapSelectionArray"
 import { ColorScale, ColorScaleManager } from "../color/ColorScale"
 import { ColorScaleConfig } from "../color/ColorScaleConfig"
-import {
-    hasToleranceApplied,
-    makeToleranceNotice,
-} from "../chart/ToleranceNotice.js"
+import { makeToleranceNotice } from "../chart/ToleranceNotice.js"
 
 export type MapFormatValueForTooltip = (
     d: PrimitiveType,
@@ -337,40 +334,21 @@ export class MapChartState implements ChartState, ColorScaleManager {
         return this.manager.targetTime ?? this.manager.endTime
     }
 
-    @computed private get timeTolerance(): number {
-        return this.mapConfig.timeTolerance ?? this.mapColumn.tolerance
-    }
-
     @computed private get toleranceStrategy(): ToleranceStrategy | undefined {
         return (
             this.mapConfig.toleranceStrategy ?? this.mapColumn.toleranceStrategy
         )
     }
 
-    /** The notice itself, regardless of whether it currently applies */
-    @computed private get toleranceNoticeIfApplied(): string | undefined {
+    @computed get toleranceNotice(): string | undefined {
         return makeToleranceNotice({
-            timeColumn: this.transformedTable.timeColumn,
-            timeRange: this.inputTable.timeRange,
-            timeTolerance: this.timeTolerance,
+            inputTable: this.inputTable,
+            // Only the countries the map currently shows are relevant
+            transformedTable: this.transformedTableForActiveRegion,
+            columns: [this.mapColumn],
+            timeTolerance: this.mapConfig.timeTolerance,
             toleranceStrategy: this.toleranceStrategy,
         })
-    }
-
-    /** Whether any value shown right now is filled in from another time */
-    @computed private get isToleranceApplied(): boolean {
-        // Skip the scan below when there's no notice for it to caption
-        if (!this.toleranceNoticeIfApplied) return false
-
-        return hasToleranceApplied(this.transformedTableForActiveRegion, [
-            this.mapColumnSlug,
-        ])
-    }
-
-    @computed get toleranceNotice(): string | undefined {
-        return this.isToleranceApplied
-            ? this.toleranceNoticeIfApplied
-            : undefined
     }
 
     @computed get columnIsProjection(): CoreColumn | undefined {

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapChartState.ts
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapChartState.ts
@@ -37,6 +37,10 @@ import { getCountriesByRegion, isOnTheMap } from "./MapHelpers"
 import { MapSelectionArray } from "../selection/MapSelectionArray"
 import { ColorScale, ColorScaleManager } from "../color/ColorScale"
 import { ColorScaleConfig } from "../color/ColorScaleConfig"
+import {
+    hasToleranceApplied,
+    makeToleranceNotice,
+} from "../chart/ToleranceNotice.js"
 
 export type MapFormatValueForTooltip = (
     d: PrimitiveType,
@@ -249,6 +253,21 @@ export class MapChartState implements ChartState, ColorScaleManager {
         return table
     }
 
+    /**
+     * The transformed table narrowed to the countries the map draws, which is
+     * only the active continent when zoomed into one in 2D
+     */
+    @computed private get transformedTableForActiveRegion(): OwidTable {
+        if (!this.mapConfig.is2dContinentActive()) return this.transformedTable
+
+        const countries = getCountriesByRegion(
+            MAP_REGION_LABELS[this.mapConfig.region]
+        )
+        if (!countries) return this.transformedTable
+
+        return this.transformedTable.filterByEntityNames([...countries])
+    }
+
     @computed get selectionArray(): MapSelectionArray {
         return this.mapConfig.selection
     }
@@ -315,6 +334,35 @@ export class MapChartState implements ChartState, ColorScaleManager {
 
     @computed get targetTime(): number | undefined {
         return this.manager.targetTime ?? this.manager.endTime
+    }
+
+    @computed private get timeTolerance(): number {
+        return this.mapConfig.timeTolerance ?? this.mapColumn.tolerance
+    }
+
+    /** The notice itself, regardless of whether it currently applies */
+    @computed private get toleranceNoticeIfApplied(): string | undefined {
+        return makeToleranceNotice({
+            timeColumn: this.transformedTable.timeColumn,
+            timeRange: this.inputTable.timeRange,
+            timeTolerance: this.timeTolerance,
+        })
+    }
+
+    /** Whether any value shown right now is filled in from another time */
+    @computed private get isToleranceApplied(): boolean {
+        // Skip the scan below when there's no notice for it to caption
+        if (!this.toleranceNoticeIfApplied) return false
+
+        return hasToleranceApplied(this.transformedTableForActiveRegion, [
+            this.mapColumnSlug,
+        ])
+    }
+
+    @computed get toleranceNotice(): string | undefined {
+        return this.isToleranceApplied
+            ? this.toleranceNoticeIfApplied
+            : undefined
     }
 
     @computed get columnIsProjection(): CoreColumn | undefined {

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChartState.ts
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChartState.ts
@@ -35,11 +35,7 @@ import {
     intersection,
     lowerCaseFirstLetterUnlessAbbreviation,
 } from "@ourworldindata/utils"
-import {
-    getMaxConfiguredTolerance,
-    hasToleranceApplied,
-    makeToleranceNotice,
-} from "../chart/ToleranceNotice.js"
+import { makeToleranceNotice } from "../chart/ToleranceNotice.js"
 import { ColorScaleConfig } from "../color/ColorScaleConfig"
 import { OWID_NO_DATA_GRAY } from "../color/ColorConstants"
 import { AxisConfig } from "../axis/AxisConfig"
@@ -448,34 +444,16 @@ export class ScatterPlotChartState implements ChartState, ColorScaleManager {
             : [this.xColumn, this.yColumn]
     }
 
-    /** The notice itself, regardless of whether it currently applies */
-    @computed private get toleranceNoticeIfApplied(): string | undefined {
+    @computed get toleranceNotice(): string | undefined {
         // Time scatters plot time itself on the x axis, so there's no target
         // time a value could be missing for
         if (this.isTimeScatter) return undefined
 
         return makeToleranceNotice({
-            timeColumn: this.transformedTable.timeColumn,
-            timeRange: this.inputTable.timeRange,
-            timeTolerance: getMaxConfiguredTolerance(this.toleranceColumns),
+            inputTable: this.inputTable,
+            transformedTable: this.transformedTable,
+            columns: this.toleranceColumns,
         })
-    }
-
-    /** Whether any value shown right now is filled in from another time */
-    @computed private get isToleranceApplied(): boolean {
-        // Skip the scan below when there's no notice for it to caption
-        if (!this.toleranceNoticeIfApplied) return false
-
-        return hasToleranceApplied(
-            this.transformedTable,
-            this.toleranceColumns.map((column) => column.slug)
-        )
-    }
-
-    @computed get toleranceNotice(): string | undefined {
-        return this.isToleranceApplied
-            ? this.toleranceNoticeIfApplied
-            : undefined
     }
 
     @computed private get selectedPoints(): SeriesPoint[] {

--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChartState.ts
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChartState.ts
@@ -35,6 +35,11 @@ import {
     intersection,
     lowerCaseFirstLetterUnlessAbbreviation,
 } from "@ourworldindata/utils"
+import {
+    getMaxConfiguredTolerance,
+    hasToleranceApplied,
+    makeToleranceNotice,
+} from "../chart/ToleranceNotice.js"
 import { ColorScaleConfig } from "../color/ColorScaleConfig"
 import { OWID_NO_DATA_GRAY } from "../color/ColorConstants"
 import { AxisConfig } from "../axis/AxisConfig"
@@ -430,6 +435,47 @@ export class ScatterPlotChartState implements ChartState, ColorScaleManager {
 
     @computed get allPoints(): SeriesPoint[] {
         return this.series.flatMap((series) => series.points)
+    }
+
+    /**
+     * The columns whose values can miss the time the chart is labelled with.
+     * When the x column is pinned to a time of its own, it's meant to come
+     * from a different time, so that isn't a tolerance caveat.
+     */
+    @computed private get toleranceColumns(): CoreColumn[] {
+        return this.xOverrideTime !== undefined
+            ? [this.yColumn]
+            : [this.xColumn, this.yColumn]
+    }
+
+    /** The notice itself, regardless of whether it currently applies */
+    @computed private get toleranceNoticeIfApplied(): string | undefined {
+        // Time scatters plot time itself on the x axis, so there's no target
+        // time a value could be missing for
+        if (this.isTimeScatter) return undefined
+
+        return makeToleranceNotice({
+            timeColumn: this.transformedTable.timeColumn,
+            timeRange: this.inputTable.timeRange,
+            timeTolerance: getMaxConfiguredTolerance(this.toleranceColumns),
+        })
+    }
+
+    /** Whether any value shown right now is filled in from another time */
+    @computed private get isToleranceApplied(): boolean {
+        // Skip the scan below when there's no notice for it to caption
+        if (!this.toleranceNoticeIfApplied) return false
+
+        return hasToleranceApplied(
+            this.transformedTable,
+            this.toleranceColumns.map((column) => column.slug)
+        )
+    }
+
+    @computed get toleranceNotice(): string | undefined {
+        return this.isToleranceApplied
+            ? this.toleranceNoticeIfApplied
+            : undefined
     }
 
     @computed private get selectedPoints(): SeriesPoint[] {

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChartState.ts
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChartState.ts
@@ -41,11 +41,7 @@ import {
 import { domainExtent } from "@ourworldindata/utils"
 import { AxisConfig } from "../axis/AxisConfig"
 import { HorizontalAxis, VerticalAxis } from "../axis/Axis"
-import {
-    getMaxConfiguredTolerance,
-    hasToleranceApplied,
-    makeToleranceNotice,
-} from "../chart/ToleranceNotice"
+import { makeToleranceNotice } from "../chart/ToleranceNotice"
 
 export class SlopeChartState implements ChartState {
     manager: SlopeChartManager
@@ -341,27 +337,12 @@ export class SlopeChartState implements ChartState {
         ])
     }
 
-    /** The notice itself, regardless of whether it currently applies */
-    @computed private get toleranceNoticeIfApplied(): string | undefined {
-        return makeToleranceNotice({
-            timeColumn: this.transformedTable.timeColumn,
-            timeRange: this.inputTable.timeRange,
-            timeTolerance: getMaxConfiguredTolerance(this.yColumns),
-        })
-    }
-
-    /** Whether any value shown right now is filled in from another time */
-    @computed private get isToleranceApplied(): boolean {
-        // Skip the scan below when there's no notice for it to caption
-        if (!this.toleranceNoticeIfApplied) return false
-
-        return hasToleranceApplied(this.transformedTable, this.yColumnSlugs)
-    }
-
     @computed get toleranceNotice(): string | undefined {
-        return this.isToleranceApplied
-            ? this.toleranceNoticeIfApplied
-            : undefined
+        return makeToleranceNotice({
+            inputTable: this.inputTable,
+            transformedTable: this.transformedTable,
+            columns: this.yColumns,
+        })
     }
 
     @computed get xDomain(): [number, number] {

--- a/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChartState.ts
+++ b/packages/@ourworldindata/grapher/src/slopeCharts/SlopeChartState.ts
@@ -41,6 +41,11 @@ import {
 import { domainExtent } from "@ourworldindata/utils"
 import { AxisConfig } from "../axis/AxisConfig"
 import { HorizontalAxis, VerticalAxis } from "../axis/Axis"
+import {
+    getMaxConfiguredTolerance,
+    hasToleranceApplied,
+    makeToleranceNotice,
+} from "../chart/ToleranceNotice"
 
 export class SlopeChartState implements ChartState {
     manager: SlopeChartManager
@@ -334,6 +339,29 @@ export class SlopeChartState implements ChartState {
             series.start.value,
             series.end.value,
         ])
+    }
+
+    /** The notice itself, regardless of whether it currently applies */
+    @computed private get toleranceNoticeIfApplied(): string | undefined {
+        return makeToleranceNotice({
+            timeColumn: this.transformedTable.timeColumn,
+            timeRange: this.inputTable.timeRange,
+            timeTolerance: getMaxConfiguredTolerance(this.yColumns),
+        })
+    }
+
+    /** Whether any value shown right now is filled in from another time */
+    @computed private get isToleranceApplied(): boolean {
+        // Skip the scan below when there's no notice for it to caption
+        if (!this.toleranceNoticeIfApplied) return false
+
+        return hasToleranceApplied(this.transformedTable, this.yColumnSlugs)
+    }
+
+    @computed get toleranceNotice(): string | undefined {
+        return this.isToleranceApplied
+            ? this.toleranceNoticeIfApplied
+            : undefined
     }
 
     @computed get xDomain(): [number, number] {

--- a/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChartState.ts
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChartState.ts
@@ -41,6 +41,11 @@ import { SelectionArray } from "../selection/SelectionArray"
 import { FocusArray } from "../focus/FocusArray"
 import { AxisConfig } from "../axis/AxisConfig.js"
 import { HorizontalAxis, VerticalAxis } from "../axis/Axis.js"
+import {
+    getMaxConfiguredTolerance,
+    hasToleranceApplied,
+    makeToleranceNotice,
+} from "../chart/ToleranceNotice.js"
 
 export class MarimekkoChartState implements ChartState, ColorScaleManager {
     manager: MarimekkoChartManager
@@ -151,6 +156,36 @@ export class MarimekkoChartState implements ChartState, ColorScaleManager {
 
     @computed get colorColumnSlug(): string | undefined {
         return this.manager.colorColumnSlug
+    }
+
+    @computed private get toleranceColumns(): CoreColumn[] {
+        return excludeUndefined([...this.yColumns, this.xColumn])
+    }
+
+    /** The notice itself, regardless of whether it currently applies */
+    @computed private get toleranceNoticeIfApplied(): string | undefined {
+        return makeToleranceNotice({
+            timeColumn: this.transformedTable.timeColumn,
+            timeRange: this.inputTable.timeRange,
+            timeTolerance: getMaxConfiguredTolerance(this.toleranceColumns),
+        })
+    }
+
+    /** Whether any value shown right now is filled in from another time */
+    @computed private get isToleranceApplied(): boolean {
+        // Skip the scan below when there's no notice for it to caption
+        if (!this.toleranceNoticeIfApplied) return false
+
+        return hasToleranceApplied(
+            this.transformedTable,
+            excludeUndefined([...this.yColumnSlugs, this.xColumnSlug])
+        )
+    }
+
+    @computed get toleranceNotice(): string | undefined {
+        return this.isToleranceApplied
+            ? this.toleranceNoticeIfApplied
+            : undefined
     }
 
     @computed get colorColumn(): CoreColumn {

--- a/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChartState.ts
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/MarimekkoChartState.ts
@@ -41,11 +41,7 @@ import { SelectionArray } from "../selection/SelectionArray"
 import { FocusArray } from "../focus/FocusArray"
 import { AxisConfig } from "../axis/AxisConfig.js"
 import { HorizontalAxis, VerticalAxis } from "../axis/Axis.js"
-import {
-    getMaxConfiguredTolerance,
-    hasToleranceApplied,
-    makeToleranceNotice,
-} from "../chart/ToleranceNotice.js"
+import { makeToleranceNotice } from "../chart/ToleranceNotice.js"
 
 export class MarimekkoChartState implements ChartState, ColorScaleManager {
     manager: MarimekkoChartManager
@@ -158,34 +154,12 @@ export class MarimekkoChartState implements ChartState, ColorScaleManager {
         return this.manager.colorColumnSlug
     }
 
-    @computed private get toleranceColumns(): CoreColumn[] {
-        return excludeUndefined([...this.yColumns, this.xColumn])
-    }
-
-    /** The notice itself, regardless of whether it currently applies */
-    @computed private get toleranceNoticeIfApplied(): string | undefined {
-        return makeToleranceNotice({
-            timeColumn: this.transformedTable.timeColumn,
-            timeRange: this.inputTable.timeRange,
-            timeTolerance: getMaxConfiguredTolerance(this.toleranceColumns),
-        })
-    }
-
-    /** Whether any value shown right now is filled in from another time */
-    @computed private get isToleranceApplied(): boolean {
-        // Skip the scan below when there's no notice for it to caption
-        if (!this.toleranceNoticeIfApplied) return false
-
-        return hasToleranceApplied(
-            this.transformedTable,
-            excludeUndefined([...this.yColumnSlugs, this.xColumnSlug])
-        )
-    }
-
     @computed get toleranceNotice(): string | undefined {
-        return this.isToleranceApplied
-            ? this.toleranceNoticeIfApplied
-            : undefined
+        return makeToleranceNotice({
+            inputTable: this.inputTable,
+            transformedTable: this.transformedTable,
+            columns: excludeUndefined([...this.yColumns, this.xColumn]),
+        })
     }
 
     @computed get colorColumn(): CoreColumn {

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBarChartState.ts
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBarChartState.ts
@@ -38,11 +38,7 @@ import { ColorScheme } from "../color/ColorScheme"
 import { ColorSchemes } from "../color/ColorSchemes"
 import { excludeUndefined } from "@ourworldindata/utils"
 import { FocusArray } from "../focus/FocusArray"
-import {
-    getMaxConfiguredTolerance,
-    hasToleranceApplied,
-    makeToleranceNotice,
-} from "../chart/ToleranceNotice"
+import { makeToleranceNotice } from "../chart/ToleranceNotice"
 
 export class StackedDiscreteBarChartState implements ChartState {
     manager: StackedDiscreteBarChartManager
@@ -153,27 +149,12 @@ export class StackedDiscreteBarChartState implements ChartState {
         return this.transformedTable.getColumns(this.yColumnSlugs)
     }
 
-    /** The notice itself, regardless of whether it currently applies */
-    @computed private get toleranceNoticeIfApplied(): string | undefined {
-        return makeToleranceNotice({
-            timeColumn: this.transformedTable.timeColumn,
-            timeRange: this.inputTable.timeRange,
-            timeTolerance: getMaxConfiguredTolerance(this.yColumns),
-        })
-    }
-
-    /** Whether any value shown right now is filled in from another time */
-    @computed private get isToleranceApplied(): boolean {
-        // Skip the scan below when there's no notice for it to caption
-        if (!this.toleranceNoticeIfApplied) return false
-
-        return hasToleranceApplied(this.transformedTable, this.yColumnSlugs)
-    }
-
     @computed get toleranceNotice(): string | undefined {
-        return this.isToleranceApplied
-            ? this.toleranceNoticeIfApplied
-            : undefined
+        return makeToleranceNotice({
+            inputTable: this.inputTable,
+            transformedTable: this.transformedTable,
+            columns: this.yColumns,
+        })
     }
 
     @computed get formatColumn(): CoreColumn {

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBarChartState.ts
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedDiscreteBarChartState.ts
@@ -38,6 +38,11 @@ import { ColorScheme } from "../color/ColorScheme"
 import { ColorSchemes } from "../color/ColorSchemes"
 import { excludeUndefined } from "@ourworldindata/utils"
 import { FocusArray } from "../focus/FocusArray"
+import {
+    getMaxConfiguredTolerance,
+    hasToleranceApplied,
+    makeToleranceNotice,
+} from "../chart/ToleranceNotice"
 
 export class StackedDiscreteBarChartState implements ChartState {
     manager: StackedDiscreteBarChartManager
@@ -146,6 +151,29 @@ export class StackedDiscreteBarChartState implements ChartState {
 
     @computed get yColumns(): CoreColumn[] {
         return this.transformedTable.getColumns(this.yColumnSlugs)
+    }
+
+    /** The notice itself, regardless of whether it currently applies */
+    @computed private get toleranceNoticeIfApplied(): string | undefined {
+        return makeToleranceNotice({
+            timeColumn: this.transformedTable.timeColumn,
+            timeRange: this.inputTable.timeRange,
+            timeTolerance: getMaxConfiguredTolerance(this.yColumns),
+        })
+    }
+
+    /** Whether any value shown right now is filled in from another time */
+    @computed private get isToleranceApplied(): boolean {
+        // Skip the scan below when there's no notice for it to caption
+        if (!this.toleranceNoticeIfApplied) return false
+
+        return hasToleranceApplied(this.transformedTable, this.yColumnSlugs)
+    }
+
+    @computed get toleranceNotice(): string | undefined {
+        return this.isToleranceApplied
+            ? this.toleranceNoticeIfApplied
+            : undefined
     }
 
     @computed get formatColumn(): CoreColumn {


### PR DESCRIPTION
> _Written by Claude Opus 5 — @sophiamersmann at the wheel._

Supersedes #6743 

Joe & Este found the info icon too subtle. The tolerance notice should be on screen and is appended to Grapher’s note in this PR.

The tolerance note is only shown when it applies to the currently active view, i.e. at least one of the currently plotted entities has a tolerance value for the currently selected year.

The main problem with this approach is that the note appears and disappears as you drag the time slider. This causes layout jumps that also affect the time slider itself, so the drag target can jump away underneath you.

What I tried to get rid of the layout shift:

* I tried moving the note above the slider (below the subtitle, in one of the chart corners, below or above the chart), but it all looked weird. The note is the best place for it.
* I tried reserving space for the tolerance notice even when it isn’t shown for the selected year, but that introduced weird whitespace that looked buggy and also unnecessarily ate into the available space for the chart.
* I also tried simply always showing the note, but that’s inaccurate in some cases even when carefully worded. We don’t want to talk about tolerance when it isn’t relevant for the current view.

So, in the end, I landed on this solution to make the layout shift less bad: the note is frozen during a timeline drag. While you’re dragging, the notice can be momentarily stale (it holds whatever was true when you grabbed the handle) and updates on release. The same applies when the timeline is animated.

Wording

When a single year is plotted:

> Where data for 2009 is unavailable, the value from the closest year between 2006 and 2010 is shown instead.

When two time points are plotted:

> Where data is unavailable, the closest value within 3 years is shown instead.

<details><summary>Details</summary>

### Shape

New `packages/@ourworldindata/grapher/src/chart/ToleranceNotice.ts` holds `makeToleranceNotice({ inputTable, transformedTable, columns, timeTolerance, toleranceStrategy })`, which is what each chart state calls, over three helpers:

- `formatToleranceNotice({ timeColumn, timeTolerance, timeRange, toleranceStrategy })` — builds the sentence. `timeColumn` is the time column of the table the chart draws; `timeRange` is the first and last time in its unfiltered data, so the window doesn't collapse as the timeline moves.
- `columnsWithToleranceApplied(table, columns)` — of the given columns, those with a value that sits at a different time from the one it's shown for, by comparing the column's values against its `originalTime` column.
- `getMaxConfiguredTolerance(columns)` — the widest tolerance across the columns a chart matches values over, taken over the columns that were substituted rather than all of them.

The sentence is chosen in this order:

1. No tolerance, no time column, or no times at all → no notice.
2. The data covers a single time → no notice; tolerance can't substitute anything.
3. The tolerance spans the whole dataset → "…the closest value is shown instead", because indicators configured that way use a sentinel like `9999`, which would otherwise read as "within 9999 years".
4. The chart plots exactly one time and the data is yearly → the detailed sentence, with the window clipped to the data's first and last year and to the direction the tolerance reaches. A one-directional window at the edge of the data reaches nothing, so that case gets no notice either.
5. Otherwise → "…the closest value within 3 years is shown instead".

Each opting-in `*ChartState` exposes `toleranceNotice` (added to `ChartInterface`), which names only what is chart-specific:

```ts
@computed get toleranceNotice(): string | undefined {
    return makeToleranceNotice({
        inputTable: this.inputTable,
        transformedTable: this.transformedTable,
        columns: this.yColumns,
    })
}
```

`makeToleranceNotice` returns early when none of those columns has a tolerance configured, so those charts never pay for the row scan.

`GrapherState` merges it into the authored note as `effectiveNote`, which `Footer` now reads instead of `note`. The two are run together as sentences, terminating the authored note if the author didn't, so the notice doesn't read as part of it.

### The year comes from the times the chart plots

There is no per-chart-type "am I a single-year chart" flag: `formatToleranceNotice` reads `timeColumn.uniqTimesAsc` off the table the chart draws. One time means the chart is labelled with that year; a slope, time-range dumbbell or faceted map holds two, and a connected scatter more. This keeps the notice correct by construction — a chart type that changes what it plots (as the dumbbell did in #6961) carries the notice along with it.

### Direction

The window is stated as a range that excludes the year on screen, since that year having no data is the premise: "between 2006 and 2010" where it reaches both ways, "between 2007 and 2009" where it only reaches back, and — where it leaves a single year — "2009". That last case also catches a wide tolerance clipped by a short dataset (data 2022–2023, tolerance 3 → "the value from 2022").

`ToleranceStrategy` (`closest` | `backwards` | `forwards`) is resolved by `MapChartState` the same way `interpolateColumnWithTolerance` resolves it — `mapConfig.toleranceStrategy ?? mapColumn.toleranceStrategy` — and clamps one side of the window to the target year. The map is the only caller that passes one, since nothing populates the column-level strategy today; the parameter defaults to `closest`. The plainer sentences carry the direction as an adjective instead: "the closest earlier value within 3 years", "the closest later value".

### "On screen" is decided by the table

`columnsWithToleranceApplied` is called with a table already narrowed to what's visible. Chart types whose transform filters to the selected entities get that for free; the map narrows to the active continent itself via `transformedTableForActiveRegion` when zoomed in 2D. There's no separate entity-list parameter — the table is the single source of truth for what counts.

### Freezing during timeline interaction

`GrapherState.frozenToleranceNotice` stores the notice as of the start of an interaction. It's boxed (`{ notice: string | undefined }`) so that freezing an *absent* notice is distinguishable from not freezing at all — otherwise a notice that wasn't showing when the drag started would appear mid-drag, which is what the freeze exists to prevent. A reaction in `Grapher` drives it from `isTimelineInteractionActive`.

### Performance

`columnsWithToleranceApplied` reads the raw column store and moves on to the next column at the first deviation. Two nicer-reading versions were benchmarked and rejected: `column.owidRows` (~3x slower warm, 40–140x cold, since it materializes an object per row) and `times.some()` (~3x slower, one call per row). Worst case is a chart with a tolerance where nothing was substituted, which visits every row: ~0.05 ms on a 28k-row table.

### `OwidTable` changes

- New `timeRange` getter: `[Time, Time]`, or `undefined` if the table has no times.
- `minTime` and `maxTime` are now both `Time | undefined`. `minTime` previously cast its `undefined` away with `as Time` while `maxTime` didn't — the runtime behaviour is unchanged, but the `?? 0` / `?? 1900` / `?? 2000` fallbacks already in `DumbbellChartState`, `SlopeChartState` and `ScatterPlotChart` are now backed by the type instead of contradicting it.
- `filterByTimeRange` goes through `timeRange`, which drops the two `this.maxTime!` assertions it used to need.

### Also in this PR

Removes an unused `IRFragment` export from `@ourworldindata/components`. Leftover from an earlier approach to this feature; the class is only used inside its own package.

### Tests

`ToleranceNotice.test.ts` covers the sentence's branches directly: the detailed sentence and its clipping, the backwards-only and forwards-only windows (both from sitting at the edge of the data and from a one-directional strategy), the single-year window, a one-directional window with nothing to reach, the plainer sentence with and without a direction, a monthly indicator's tolerance stated in days, the unbounded sentinel, and the absent cases.

`GrapherState.test.ts` covers the integration on a map: the exact sentence, appearing and disappearing as the timeline moves between years with and without gaps, the freeze during a drag, gaps in unselected entities being ignored (via a slope chart), a gapless chart tab staying silent, and the four `effectiveNote` composition rules.

Not covered, if a reviewer wants more: the notice being wired up in each individual chart state (only the map and slope are exercised end to end), a faceted map falling back to the plainer sentence, and the scatter's relative-mode case described above.

</details>


