### PR TITLE
🔨🤖 prefix svg tester logs with the view being rendered

### DIFF
--- a/devTools/svgTester/utils.ts
+++ b/devTools/svgTester/utils.ts
@@ -452,6 +452,18 @@ function resolveFocusPlaceholderInQueryString(
     }
 }
 
+// Grapher internals log warnings (e.g. about ambiguous table joins) without any
+// hint of which chart triggered them, so tag every log line with the view being
+// rendered. Safe because a workerpool worker only ever renders one view at a time.
+let currentViewId: string | undefined
+for (const method of ["log", "warn", "error"] as const) {
+    const original = console[method].bind(console)
+    console[method] = (...args: unknown[]): void =>
+        currentViewId
+            ? original(`${currentViewId}:`, ...args)
+            : original(...args)
+}
+
 export async function renderSvg({
     dir,
     queryStr,
@@ -461,6 +473,7 @@ export async function renderSvg({
     queryStr?: string
     variant?: "default" | "thumbnail"
 }): Promise<[string, SvgRecord, string]> {
+    currentViewId = dir.viewId
     const configAndData = await loadGrapherConfigAndData(dir.configPath)
 
     // Graphers sometimes need to generate ids (incrementing numbers). For this
@@ -702,6 +715,7 @@ export async function renderAndVerifySvg({
     variant = "default",
     rmOnError,
 }: RenderJobDescription): Promise<VerifyResult> {
+    currentViewId = referenceEntry?.viewId
     try {
         if (!dir) throw "Dir was not defined"
         if (!referenceEntry) throw "ReferenceEntry was not defined"
@@ -732,7 +746,7 @@ export async function renderAndVerifySvg({
         }
         return Promise.resolve(validationResult)
     } catch (err) {
-        console.error(`${referenceEntry.viewId}: render failed`, err)
+        console.error("render failed", err)
         if (rmOnError) {
             const outPath = path.join(outDir, referenceEntry.svgFilename)
             await fs.unlink(outPath).catch(() => {


### PR DESCRIPTION
> _Written by Claude Opus 5 — @sophiamersmann at the wheel._

Warnings logged from grapher internals during an svg test run — most often
`Found more than one matching row in table undefined` from the variable-join
code — gave no indication of which chart produced them. Now every log line from
a worker is tagged with the view id being rendered, e.g.
`seawater-ph: Found more than one matching row in table undefined`.

Note that these warnings are emitted once per ambiguous joined row, so a single
chart can produce dozens of identical lines. That noise is unchanged here; only
the attribution is new.

<details><summary>Details</summary>

- `devTools/svgTester/utils.ts`: wraps `console.log/warn/error` once at module
  load with a prefix taken from a module-level `currentViewId`, set at the top of
  `renderSvg` (and of `renderAndVerifySvg`, so failures that happen before
  rendering starts get the right slug rather than the previous job's).
- No save/restore around each render: each workerpool worker runs one job at a
  time, so a module-level tag is sufficient. In the parent process
  `currentViewId` stays `undefined` and progress logging is unaffected.
- Dropped the now-redundant slug from the `render failed` message, which would
  otherwise be printed twice.

</details>