### PR TITLE
🐛🤖 give dumbbell charts only the times they plot

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
@@ -1034,10 +1034,16 @@ export class GrapherState
             return table.filterByTargetTimes(targetTimes)
         }
 
-        if (this.isOnDiscreteBarTab || this.isOnMarimekkoTab)
+        if (
+            this.isOnDiscreteBarTab ||
+            this.isOnMarimekkoTab ||
+            this.checkIsTwoColumnDumbbell(this.activeTab)
+        )
             return table.filterByTargetTimes([endTime])
 
-        if (this.isOnSlopeChartTab)
+        // Any dumbbell reaching this point plots a single indicator, and so
+        // compares it across the two times the timeline handles sit on
+        if (this.isOnSlopeChartTab || this.isOnDumbbellTab)
             return table.filterByTargetTimes([startTime, endTime])
 
         return table.filterByTimeRange(startTime, endTime)
@@ -1932,6 +1938,19 @@ export class GrapherState
         })
     }
 
+    /**
+     * Dumbbell charts plotting two indicators compare them at a single time,
+     * whereas those plotting one indicator compare it across two times
+     */
+    private readonly checkIsTwoColumnDumbbell = (
+        tabName: GrapherTabName
+    ): boolean => {
+        return (
+            tabName === GRAPHER_TAB_NAMES.Dumbbell &&
+            this.yColumnSlugs.length >= 2
+        )
+    }
+
     private readonly checkOnlySingleTimeSelectionPossible = (
         tabName: GrapherTabName
     ): boolean => {
@@ -1939,9 +1958,7 @@ export class GrapherState
             tabName === GRAPHER_TAB_NAMES.DiscreteBar ||
             tabName === GRAPHER_TAB_NAMES.StackedDiscreteBar ||
             tabName === GRAPHER_TAB_NAMES.Marimekko ||
-            // Dumbbell charts plotting two indicators use a single time
-            (tabName === GRAPHER_TAB_NAMES.Dumbbell &&
-                this.yColumnSlugs.length >= 2)
+            this.checkIsTwoColumnDumbbell(tabName)
         )
     }
 
@@ -1965,9 +1982,8 @@ export class GrapherState
         return (
             tabName === GRAPHER_TAB_NAMES.LineChart ||
             tabName === GRAPHER_TAB_NAMES.SlopeChart ||
-            // Dumbbell charts plotting a single indicator use a time range
             (tabName === GRAPHER_TAB_NAMES.Dumbbell &&
-                this.yColumnSlugs.length < 2)
+                !this.checkIsTwoColumnDumbbell(tabName))
         )
     }
 


### PR DESCRIPTION
> _Written by Claude Opus 5 — @sophiamersmann at the wheel._

A dumbbell draws two endpoints per entity, but its transformed table kept every row in between: `tableAfterAllTransformsAndFilters` special-cases the map, discrete bar, Marimekko and slope, and dumbbells fell through to `filterByTimeRange`. So anything reading that table as "what the chart shows" saw years the chart never draws.

Dumbbells now filter to their target times like the chart types they resemble — both handles when plotting one indicator across two times, the end time alone when comparing two indicators at one time.

The rule telling those two modes apart already existed twice, in `checkOnlySingleTimeSelectionPossible` and `checkOnlyTimeRangeSelectionPossible`; it now lives once, in `checkIsTwoColumnDumbbell`.

**Worth checking on staging:** this narrows what dumbbell charts see, so it can change rendering beyond the case that motivated it. `filterByTargetTimes` defaults to a tolerance of 0, so an entity without a row exactly on a handle time now drops out where it previously survived, and `sortConfig` reads the same table, so bar order could shift. `make svgtest` hasn't been run — worth doing before this leaves draft.

<details><summary>Details</summary>

### Why it matters beyond tidiness

Found while reviewing the tolerance notice stacked on top of this (#6959). That feature asks "was a value on screen filled in from another time?" by comparing each value's time against its original time across the transformed table. For every other opted-in chart type the table already holds exactly what's drawn, so the question is well posed. For dumbbells it wasn't: a chart whose two endpoints are both exact but which has a tolerance-filled year in between would claim a substitution the reader can't find. Codex flagged the same thing on #6959 (P2).

The alternative was to leave the table alone and derive the check from the rendered series instead — `isToleranceDistanceValid` (`ChartUtils.tsx:441`) already computes `originalTime !== time` on exactly the endpoint rows. That's a smaller change but it makes the chart state carry a second, parallel notion of "on screen". Fixing the table keeps one definition, which is why this is its own PR at the bottom of the stack rather than a patch inside the notice work.

### The mode rule

`DumbbellChartState.mode` is `yColumnSlugs.length > 1 ? TwoColumn : TimeRange`. `GrapherState` can compute the same thing without touching `chartState`: the chart state's `yColumnSlugs` resolves through `autoDetectYColumnSlugs(manager)` back to `GrapherState.yColumnSlugs`, so there's no cycle. The two existing call sites were already relying on that fact, spelled out inline.

### Tests

The regression test lives one branch up, in #6959, since it asserts the tolerance notice — the observable symptom. It's a time-range dumbbell with exact endpoints and a gap at an intervening year, expecting no notice; it fails if the change in this PR is reverted.

</details>
