### PR TITLE
🐛🤖 fix missing chart titles in PNG exports

### DIFF
--- a/packages/@ourworldindata/components/src/MarkdownTextWrap/IRTokens.tsx
+++ b/packages/@ourworldindata/components/src/MarkdownTextWrap/IRTokens.tsx
@@ -4,6 +4,7 @@ import {
     cssFontFamily,
     excludeUndefined,
     imemo,
+    omitUndefinedValues,
     Bounds,
     FontFamily,
 } from "@ourworldindata/utils"
@@ -326,23 +327,25 @@ export class IRFragment extends IRElement {
             </span>
         )
     }
+    /** The fragment's style overrides, as SVG-flavoured CSS */
+    @imemo get svgStyle(): React.CSSProperties {
+        const { fontSize, fontFamily, fontWeight, color } = this.styleDelta
+        return omitUndefinedValues({
+            fontSize,
+            fontWeight,
+            fontFamily: fontFamily ? cssFontFamily(fontFamily) : undefined,
+            fill: color,
+        })
+    }
     toSVG(key?: React.Key): React.ReactElement {
         const children = this.children.map((child, i) => child.toSVG(i))
         if (_.isEmpty(this.styleDelta) && !this.inlineGap)
             return <React.Fragment key={key}>{children}</React.Fragment>
-        const { fontSize, fontFamily, fontWeight, color } = this.styleDelta
         return (
             <tspan
                 key={key}
                 dx={this.inlineGap || undefined}
-                style={{
-                    fontSize,
-                    fontWeight,
-                    fontFamily: fontFamily
-                        ? cssFontFamily(fontFamily)
-                        : undefined,
-                    fill: color,
-                }}
+                style={this.svgStyle}
             >
                 {children}
             </tspan>

--- a/packages/@ourworldindata/components/src/MarkdownTextWrap/MarkdownTextWrapComponents.test.tsx
+++ b/packages/@ourworldindata/components/src/MarkdownTextWrap/MarkdownTextWrapComponents.test.tsx
@@ -1,0 +1,65 @@
+import { expect, it, describe } from "vitest"
+
+import * as React from "react"
+import ReactDOMServer from "react-dom/server"
+import { FontFamily } from "@ourworldindata/utils"
+import { MarkdownTextWrapSvg } from "./MarkdownTextWrapComponents.js"
+import { MarkdownTextWrap } from "./MarkdownTextWrap.js"
+import { TextWrapGroup } from "./TextWrapGroup.js"
+
+const renderSvg = (element: React.ReactElement): string =>
+    ReactDOMServer.renderToStaticMarkup(element)
+
+const textElements = (svg: string): string[] =>
+    svg.match(/<text\b[^>]*>.*?<\/text>/g) ?? []
+
+describe(MarkdownTextWrapSvg, () => {
+    it("renders one <text> element per line, without tspans", () => {
+        const textWrap = new MarkdownTextWrap({
+            text: "one two three four",
+            fontSize: 10,
+            maxWidth: 40,
+        })
+        expect(textWrap.svgLines.length).toBeGreaterThan(1)
+
+        const svg = renderSvg(
+            <MarkdownTextWrapSvg textWrap={textWrap} x={16} y={16} />
+        )
+        expect(textElements(svg)).toHaveLength(textWrap.svgLines.length)
+        expect(svg).not.toContain("<tspan")
+    })
+
+    // resvg drops a <text> element that mixes font families when the text
+    // contains certain glyph pairs, which silently dropped chart titles
+    it("gives a fragment that switches the font family its own <text>", () => {
+        const textWrap = new TextWrapGroup({
+            fragments: [
+                { text: "Estimated number of malaria cases" },
+                {
+                    text: "World, 2000 to 2024",
+                    fontFamily: FontFamily.Lato,
+                    inlineGap: 6,
+                },
+            ],
+            fontFamily: FontFamily.PlayfairDisplay,
+            fontSize: 25,
+            maxWidth: 1000,
+        })
+        expect(textWrap.svgLines).toHaveLength(1)
+
+        const svg = renderSvg(
+            <MarkdownTextWrapSvg textWrap={textWrap} x={16} y={16} />
+        )
+        const [title, annotation] = textElements(svg)
+        expect(textElements(svg)).toHaveLength(2)
+        expect(title).toContain("Playfair Display")
+        expect(title).not.toContain("Lato")
+        expect(annotation).toContain("Lato")
+        expect(annotation).not.toContain("Playfair Display")
+
+        // The annotation starts after the title text plus the inline gap,
+        // since a <text> element can't offset itself with dx
+        const titleWidth = textWrap.svgLines[0][0].width
+        expect(annotation).toContain(`x="${(16 + titleWidth + 6).toFixed(1)}"`)
+    })
+})

--- a/packages/@ourworldindata/components/src/MarkdownTextWrap/MarkdownTextWrapComponents.tsx
+++ b/packages/@ourworldindata/components/src/MarkdownTextWrap/MarkdownTextWrapComponents.tsx
@@ -5,6 +5,7 @@ import {
     getDodUnderlineSegments,
     getLineFontSize,
     getLineGap,
+    IRFragment,
     IRToken,
 } from "./IRTokens.js"
 import { AbstractTokenTextWrap } from "./AbstractTokenTextWrap.js"
@@ -94,26 +95,29 @@ export function MarkdownTextWrapSvg({
     const getLineY = (lineIndex: number): number =>
         yOffset + _.sum(lineHeights.slice(1, lineIndex + 1))
 
+    const textRuns = lines.flatMap((line, lineIndex) =>
+        splitLineIntoTextRuns(line, x, getLineY(lineIndex))
+    )
+
     return (
         <g id={id} className="markdown-text-wrap">
-            <text
-                x={x.toFixed(1)}
-                y={yOffset.toFixed(1)}
-                style={textWrap.style}
-                {...svgTextProps}
-            >
-                {lines.map((line, lineIndex) => (
-                    <tspan
-                        key={lineIndex}
-                        x={x}
-                        y={getLineY(lineIndex).toFixed(1)}
-                    >
-                        {line.map((token, tokenIndex) =>
-                            token.toSVG(tokenIndex)
-                        )}
-                    </tspan>
-                ))}
-            </text>
+            {textRuns.map((run, runIndex) => (
+                <text
+                    key={runIndex}
+                    x={run.x.toFixed(1)}
+                    y={run.y.toFixed(1)}
+                    style={
+                        run.style
+                            ? { ...textWrap.style, ...run.style }
+                            : textWrap.style
+                    }
+                    {...svgTextProps}
+                >
+                    {run.tokens.map((token, tokenIndex) =>
+                        token.toSVG(tokenIndex)
+                    )}
+                </text>
+            ))}
             {/* SVG doesn't support dotted underlines, so we draw them manually */}
             {detailsMarker === "underline" &&
                 lines.map((line, lineIndex) => {
@@ -138,4 +142,50 @@ export function MarkdownTextWrapSvg({
                 })}
         </g>
     )
+}
+
+interface SvgTextRun {
+    tokens: IRToken[]
+    x: number
+    y: number
+    /** Style overrides on top of the text wrap's own style */
+    style?: React.CSSProperties
+}
+
+/**
+ * Splits a line into the `<text>` elements it renders as. A line is one
+ * element, except that fragments switching the font family get one of their
+ * own: resvg — which rasterises chart PNGs at the edge — silently drops a
+ * whole `<text>` element that mixes font families when the text contains
+ * certain glyph pairs (`ti`, `tt`, `tf` and `ft` in Playfair Display).
+ */
+function splitLineIntoTextRuns(
+    line: IRToken[],
+    x: number,
+    y: number
+): SvgTextRun[] {
+    const runs: SvgTextRun[] = []
+    let currentRun: SvgTextRun | undefined
+    let offset = 0
+    for (const token of line) {
+        if (token instanceof IRFragment && token.styleDelta.fontFamily) {
+            runs.push({
+                tokens: token.children,
+                // A <text> element has no dx, so the fragment's inline gap
+                // is folded into its x position
+                x: x + offset + token.inlineGap,
+                y,
+                style: token.svgStyle,
+            })
+            currentRun = undefined
+        } else {
+            if (!currentRun) {
+                currentRun = { tokens: [], x: x + offset, y }
+                runs.push(currentRun)
+            }
+            currentRun.tokens.push(token)
+        }
+        offset += token.width
+    }
+    return runs
 }


### PR DESCRIPTION
> _Written by Anthropic Claude Opus 5 — @sophiamersmann at the wheel._


On production, the `.png` version of a chart renders without its title, while the `.svg` version is fine — e.g. [estimated-number-of-malaria-cases.png](https://ourworldindata.org/grapher/estimated-number-of-malaria-cases.png) vs [.svg](https://ourworldindata.org/grapher/estimated-number-of-malaria-cases.svg).

The cause is a bug in resvg (`@resvg/resvg-wasm`, which rasterises PNGs in the Cloudflare function): it silently drops a whole `<text>` element that mixes font families when the text contains one of the glyph pairs `ti`, `tt`, `tf` or `ft` in Playfair Display. This is [linebender/resvg#614](https://github.com/linebender/resvg/issues/614), fixed upstream in resvg 0.41.0 — but `@resvg/resvg-wasm` still compiles resvg 0.34, so no published version has the fix (details below). The title annotation puts a Lato fragment inside a Playfair `<text>`, so any title containing one of those pairs lost its title entirely — 1,969 of 4,444 published charts.

The fix is to stop mixing font families in a single `<text>`: each line is now rendered as its own `<text>` element without `<tspan>`s, and a fragment that switches the font family gets a `<text>` element of its own.

Example: [prod](https://ourworldindata.org/grapher/estimated-number-of-malaria-cases.png?nocache) / [staging](http://staging-site-svg-text-per-line/grapher/estimated-number-of-malaria-cases.png?nocache)

<details><summary>Details</summary>

### Root cause

Both `.png` and `.svg` come from the same `generateStaticSvg` output; only the rasterisation differs (`functions/_common/grapherRenderer.ts`). Rendering the live production `.svg` through resvg 2.6.2 with the bundled font buffers reproduces the missing title exactly, and `Resvg.toString()` shows usvg discarding the `<text>` node before rasterising (empty tree, 0 paths) rather than failing to draw it.

Bisecting the production title markup:

| variant | result |
|---|---|
| production title as-is | blank |
| title text truncated to `"Est"` (no `ti`) | ok |
| Playfair swapped for Lato | ok |
| title without the annotation fragment | ok |
| Lato outer + Lato nested | ok |

Brute-forcing all lowercase pairs against the bundled Playfair Display gives exactly four failures: `ti`, `tt`, `tf`, `ft`. Neither font size, weight, `dx`, x-offset, nor the pair's position matters, and the pair may sit in either span or straddle the boundary. Loading only the Playfair buffer (so both spans resolve to one face) makes the identical SVG render fine — the trigger needs two font faces in one `<text>` plus one of those pairs.

### Why those glyph pairs

This is [linebender/resvg#614](https://github.com/linebender/resvg/issues/614) (closed 2024-03-31). usvg's `process_chunk` shapes the **whole** string once per font involved, then maps glyphs back to their spans by byte index. When one font's shaping produces a different number of glyph clusters than another's, that mapping breaks and the text node is dropped — which is exactly the two conditions measured above: two font faces in one `<text>`, plus a pair whose shaping collapses clusters.

> An earlier version of this description claimed the trigger was *not* ligature-related, reasoning from the fact that Playfair's `liga`/`calt`/`rlig` lookups contain no `t` pairs. That was wrong: the issue is about cluster counts differing between the two fonts, not about a `ti` ligature existing in Playfair.

### Upstream status

Fixed in [resvg 0.41.0](https://github.com/linebender/resvg/blob/main/CHANGELOG.md) (2024-04-03): *"Missing text when a `text` element uses multiple fonts and one of them produces ligatures."*

We can't simply pin a fixed version, because the npm version and the resvg version are decoupled: [resvg-js pins `resvg = "0.34.0"`](https://github.com/yisibl/resvg-js/blob/main/Cargo.toml) in its Cargo.toml and compiles it into the shipped `.wasm`. All eight published builds from 2.6.2 through 2.7.0-alpha.2 (Jan 2026) produce byte-identical blank output and embed the same `rustybuzz-0.7.0` / `fontdb-0.14.1` / `tiny-skia-0.10.0`. `resolutions`/`overrides` can't reach it either — the engine is compiled machine code inside the binary, not an npm dependency.

Swapping the renderer was evaluated as an alternative to this PR:

| option | resvg | result |
|---|---|---|
| `@resvg/resvg-wasm` 2.6.2 → 2.7.0-alpha.2 | 0.34 | title dropped |
| `@cf-wasm/resvg` 0.4.0 | 0.34 | dropped (byte-identical repackage) |
| `svg2png-wasm` 1.4.1 | ~0.40 | dropped |
| `resvg-wasm` 0.5.0 | 0.47 | renders — but single-maintainer, ~2.7k downloads/month, no docs, types not exposed |
| `@resvg/resvg-js` (native) | 0.34 | same bug, so a Node service wouldn't help |
| sharp / librsvg | — | renders correctly, but librsvg has never been ported to wasm |
| wasm-vips | — | [cannot run on Workers](https://github.com/kleisauke/wasm-vips/issues/2) (Emscripten pthreads need shared memory) |

For reference, upgrading the engine would be low-risk when we choose to do it: resvg 0.34 vs 0.48 is pixel-identical on `life-expectancy` and `co-emissions-per-capita?tab=map` (0.000% differing pixels), with differences on `malaria` and `population-density` confined to the restored title. Getting there means either accepting that hobby package or compiling resvg to wasm ourselves — separate infrastructure work, not a blocker for this fix.

Workarounds tested:

| approach | works |
|---|---|
| bump `@resvg/resvg-wasm` (all 8 published versions) | no, all still broken |
| `font-variant-ligatures: none` | no, resvg ignores it |
| `font-feature-settings: 'liga' 0, 'calt' 0` | no, resvg ignores it |
| flat sibling `<tspan>` in the same `<text>` | no |
| separate `<text>` elements | yes |

### Changes

- `MarkdownTextWrapComponents.tsx` — `MarkdownTextWrapSvg` renders one `<text>` per line with no `<tspan>` wrapper. New `splitLineIntoTextRuns` helper splits a line at fragments that switch the font family, folding the fragment's `inlineGap` into its `x` (a `<text>` element has no `dx`).
- `IRTokens.tsx` — new `IRFragment.svgStyle` getter, so the same style object can go on either a `tspan` or a standalone `<text>`; `toSVG` reuses it.
- `MarkdownTextWrapComponents.test.tsx` — new: asserts one `<text>` per line with no tspans, and that a family-switching fragment gets its own `<text>` at the expected `x`.

`fontFamily` is only ever set on a fragment by the header title annotation (`Header.tsx`); axis-label fragments don't set it, so nothing else changes shape beyond losing the `<tspan>` wrapper.

`textAnchor` semantics are preserved: the horizontal axis label uses `textAnchor="middle"` and every line already carried the same `x`, so one `<text x=… text-anchor="middle">` per line is equivalent to one `<tspan x=…>` per line. A family-switching fragment combined with a non-start anchor would be mispositioned, but that combination does not occur.

### Verification

- Rendered the real title through `MarkdownTextWrapSvg` → resvg with the production font buffers: title renders. Also checked a wrapped title (annotation drops to its own line with `newLineGap` applied) and a plain multi-line subtitle.
- `yarn test run`: 2264 pass. Two failures in `GrapherState.test.ts` (`currentSubtitle`) are pre-existing and unrelated — that property does not exist anywhere in the grapher source, and the same two errors appear in `yarn typecheck` on an untouched tree.
- Lint and format clean.
- Staging rasterises PNGs through the same Cloudflare function as production (the same request against `staging-site-master` returns a byte-identical broken PNG), so this is testable on the branch's staging server.

</details>
