### PR TITLE
🐝 Upgrade MySQL to 8.4 LTS (dev + staging)

### DIFF
--- a/docker-compose.dbtests.yml
+++ b/docker-compose.dbtests.yml
@@ -3,7 +3,7 @@
 services:
   # Stock mysql database. Root password is hardcoded for now
   db:
-    image: mysql:8
+    image: mysql:8.4
     command: --log-bin-trust-function-creators=ON
     restart: always
     volumes:
@@ -15,9 +15,9 @@ services:
       MYSQL_ROOT_PASSWORD: weeniest-stretch-contaminate-gnarl
       MYSQL_ROOT_HOST: "%"
 
-  # mysql:8 container for running the DB creation scripts
+  # mysql:8.4 container for running the DB creation scripts
   db-load-data:
-    image: mysql:8
+    image: mysql:8.4
     command: "/app/create-test-db.sh"
     volumes:
       - ./devTools/docker:/app

--- a/docker-compose.devcontainer.yml
+++ b/docker-compose.devcontainer.yml
@@ -44,7 +44,7 @@ services:
 
   # Stock mysql database. Used for grapher database. Root password is hardcoded for now
   db:
-    image: mysql:8
+    image: mysql:8.4
     restart: always
     volumes:
       - mysql_data:/var/lib/mysql
@@ -59,7 +59,7 @@ services:
   # These init scripts check if the grapher database and users are missing, if so they create them
   # and pull the data to have a working dev environment.
   db-load-data:
-    image: mysql:8
+    image: mysql:8.4
     command: "/app/grapher-only-mysql-init.sh"
     volumes:
       - ./devTools/docker:/app

--- a/docker-compose.grapher.yml
+++ b/docker-compose.grapher.yml
@@ -29,7 +29,7 @@
 services:
   # Stock mysql database. Root password is hardcoded for now
   db:
-    image: mysql:8
+    image: mysql:8.4
     restart: always
     volumes:
       - ./devTools/docker/my.cnf:/etc/my.cnf:ro
@@ -42,11 +42,11 @@ services:
       MYSQL_ROOT_PASSWORD: weeniest-stretch-contaminate-gnarl
       MYSQL_ROOT_HOST: "%"
 
-  # mysql:8 container for running the DB init scripts
+  # mysql:8.4 container for running the DB init scripts
   # These init scripts check if the grapher database and users are missing, if so they create them
   # and pull the data to have a working dev environment.
   db-load-data:
-    image: mysql:8
+    image: mysql:8.4
     command: "/app/grapher-mysql-init.sh"
     volumes:
       - ./devTools/docker:/app


### PR DESCRIPTION
Pins the dev database to `mysql:8.4`.

The `mysql:8` tag **already resolves to 8.4.11** — Docker Hub moved it when 8.4 became the newest 8.x line. So freshly pulled dev environments have silently been running 8.4 while production runs 8.0.46, and which one you get depends on when you last pulled. This pins it explicitly so the version stops drifting in either direction.

It also matches where the servers are going: MySQL 8.0 left extended support on 30 Apr 2026 and 8.0.46 was its final upstream release. The fleet side is owid/ops#600.

Nothing else changes. `mysql2` already speaks `caching_sha2_password`, and the DB init scripts create users with a bare `IDENTIFIED BY`, so they inherit the server default rather than the auth plugin 8.4 no longer loads.

## How to test it

```
docker compose -f docker-compose.grapher.yml down
docker compose -f docker-compose.grapher.yml up
make dbtest
```

8.4 upgrades an existing 8.0 datadir in place on first start. If that fails, drop the volume and `make refresh.atomic` — a 3 GB download and nothing else lost.

Verified locally: `docker compose -f docker-compose.dbtests.yml up --abort-on-container-exit --exit-code-from db-load-data` brings up **8.4.11** and `db-load-data` exits **0**, which covers database creation, user creation and the migrations mount.

`staging-site-upgrade-mysql` is running 8.4.11 for this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
