### PR TITLE
Show the Wikipedia SVG export option to all users

### DIFF
--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
@@ -359,10 +359,6 @@ export class DownloadModalVisTab extends React.Component<DownloadModalProps> {
         return !_.isEmpty(this.manager.detailsOrderedByReference)
     }
 
-    @computed private get showExportControls(): boolean {
-        return this.hasDetails || !!this.manager.showAdminControls
-    }
-
     @computed private get showInteractiveEmbedTip(): boolean {
         return !!(this.manager.isOnArchivalPage || this.manager.hasArchivedPage)
     }
@@ -499,44 +495,37 @@ export class DownloadModalVisTab extends React.Component<DownloadModalProps> {
                                 disabled={isRegenerating}
                             />
                         </div>
-                        {this.showExportControls && (
-                            <>
-                                {this.hasDetails && (
-                                    <Checkbox
-                                        checked={this.shouldIncludeDetails}
-                                        label="Include terminology definitions at bottom of chart"
-                                        onChange={(): void => {
-                                            this.reset()
-                                            this.toggleIncludeDetails()
-                                            this.export()
-                                        }}
-                                    />
-                                )}
-                                {this.manager.showAdminControls && (
-                                    <Checkbox
-                                        checked={this.isExportingSquare}
-                                        label="Square format"
-                                        onChange={action((): void => {
-                                            this.reset()
-                                            this.toggleExportFormat()
-                                            this.export()
-                                        })}
-                                    />
-                                )}
-                                {this.manager.showAdminControls && (
-                                    <Checkbox
-                                        checked={this.isWikimediaExport}
-                                        label="Optimize SVG for Wikipedia upload"
-                                        onChange={action((): void => {
-                                            this.reset()
-                                            this.toggleExportForUseOnWikimedia()
-
-                                            this.export()
-                                        })}
-                                    />
-                                )}
-                            </>
+                        {this.hasDetails && (
+                            <Checkbox
+                                checked={this.shouldIncludeDetails}
+                                label="Include terminology definitions at bottom of chart"
+                                onChange={(): void => {
+                                    this.reset()
+                                    this.toggleIncludeDetails()
+                                    this.export()
+                                }}
+                            />
                         )}
+                        {this.manager.showAdminControls && (
+                            <Checkbox
+                                checked={this.isExportingSquare}
+                                label="Square format"
+                                onChange={action((): void => {
+                                    this.reset()
+                                    this.toggleExportFormat()
+                                    this.export()
+                                })}
+                            />
+                        )}
+                        <Checkbox
+                            checked={this.isWikimediaExport}
+                            label="Optimize SVG for Wikipedia upload"
+                            onChange={action((): void => {
+                                this.reset()
+                                this.toggleExportForUseOnWikimedia()
+                                this.export()
+                            })}
+                        />
                     </div>
                 ) : (
                     <Callout


### PR DESCRIPTION
> _Written by Anthropic Claude Fable 5 — @marcelgerber at the wheel._

The "Optimize SVG for Wikipedia upload" checkbox in the download modal (added in #5004) was only visible to admins, on localhost, and on staging. That gating was inherited from the "For use in social media" checkbox the feature was modelled on — it was never a deliberate decision (see #4536, where a checkbox in the download modal was requested without any staff-only caveat). Since the feature exists for external Wikipedia editors, they should actually get to see it: this PR removes the `showAdminControls` gate so the checkbox shows for everyone.

<details><summary>Details</summary>

- The checkbox was behind two gates: its own `showAdminControls` conditional, and the outer `showExportControls` wrapper (`hasDetails || showAdminControls`) around the whole checkbox block. Removing only the inner one would have been a no-op for logged-out visitors on charts without details, so both are removed.
- With the Wikipedia checkbox now unconditional, the `showExportControls` getter had no remaining callers and is deleted.
- The other two checkboxes keep their gates: "Include terminology definitions" still requires `hasDetails`, "Square format" stays behind `showAdminControls`.
- Verified with `yarn typecheck`, `yarn testLintChanged`, `yarn testFormatChanged`.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)