### PR TITLE
🐛🤖 tag a joined time column with the finest interval

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.test.ts
+++ b/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.test.ts
@@ -563,6 +563,19 @@ describe(legacyToOwidTableAndDimensions, () => {
             expect(table.timeColumn instanceof ColumnTypeMap.Year).toBeTruthy()
             expect(table.timeColumn instanceof ColumnTypeMap.Decade).toBeFalsy()
         })
+
+        it("falls back to 'day' when weeks and months are mixed, since neither grid contains the other", () => {
+            const weekly = makeVariable(6, TimeInterval.Week, [0, 7])
+            const table = buildTable([weekly, monthly])
+            expect(table.timeColumn instanceof ColumnTypeMap.Week).toBeFalsy()
+            expect(table.timeColumn instanceof ColumnTypeMap.Month).toBeFalsy()
+            // Every time stays addressable, so no two points share a label
+            const times = table.timeColumn.uniqValues as number[]
+            const labels = times.map((time) =>
+                table.timeColumn.formatValue(time)
+            )
+            expect(new Set(labels).size).toEqual(times.length)
+        })
     })
 
     describe("variables with mixed days & years", () => {

--- a/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.test.ts
+++ b/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.test.ts
@@ -505,6 +505,66 @@ describe(legacyToOwidTableAndDimensions, () => {
         })
     })
 
+    describe("variables with mixed intervals in the same bucket", () => {
+        const makeVariable = (
+            id: number,
+            interval: TimeInterval,
+            years: number[]
+        ): OwidVariableDataMetadataDimensions => ({
+            data: {
+                entities: years.map(() => 1),
+                values: years.map((_, index) => index),
+                years,
+            },
+            metadata: {
+                id,
+                display: { timeInterval: interval },
+                dimensions: {
+                    entities: {
+                        values: [{ name: "World", code: "OWID_WRL", id: 1 }],
+                    },
+                    years: { values: years.map((year) => ({ id: year })) },
+                },
+            },
+        })
+
+        const buildTable = (
+            variables: OwidVariableDataMetadataDimensions[]
+        ): OwidTable =>
+            legacyToOwidTableAndDimensionsWithMandatorySlug(
+                new Map(variables.map((v) => [v.metadata.id, v])),
+                variables.map((v) => ({
+                    variableId: v.metadata.id,
+                    property: DimensionProperty.y,
+                })),
+                {}
+            )
+
+        // day 0 is EPOCH_DATE (2020-01-21), so day -6 is 2020-01-15 (snapped to
+        // Jan 1) and day 25 is 2020-02-15 (snapped to Feb 1)
+        const daily = makeVariable(2, TimeInterval.Day, [0, 1, 2])
+        const monthly = makeVariable(3, TimeInterval.Month, [-6, 25])
+
+        it("labels the joined time column with the finest interval, whatever the dimension order", () => {
+            for (const variables of [
+                [daily, monthly],
+                [monthly, daily],
+            ]) {
+                const timeColumn = buildTable(variables).timeColumn
+                expect(timeColumn instanceof ColumnTypeMap.Day).toBeTruthy()
+                expect(timeColumn instanceof ColumnTypeMap.Month).toBeFalsy()
+            }
+        })
+
+        it("labels the joined time column with 'year' when years and decades are mixed", () => {
+            const annual = makeVariable(4, TimeInterval.Year, [2020, 2021])
+            const decadal = makeVariable(5, TimeInterval.Decade, [2020])
+            const table = buildTable([decadal, annual])
+            expect(table.timeColumn instanceof ColumnTypeMap.Year).toBeTruthy()
+            expect(table.timeColumn instanceof ColumnTypeMap.Decade).toBeFalsy()
+        })
+    })
+
     describe("variables with mixed days & years", () => {
         const legacyVariableConfig: MultipleOwidVariableDataDimensionsMap =
             new Map([

--- a/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.ts
+++ b/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.ts
@@ -37,7 +37,7 @@ import {
     OwidVariableType,
     getTimeInterval,
     isSubYearly,
-    findFinestTimeInterval,
+    findFinestCommonTimeInterval,
     snapToIntervalStart,
     dayjs,
 } from "@ourworldindata/utils"
@@ -597,8 +597,8 @@ const fullJoinTables = (
 }
 
 /**
- * Relabels the joined time column with the finest interval among the variable
- * tables that were joined into it
+ * Relabels the joined time column with the finest interval that can represent
+ * every joined variable table's times (each of their time columns knows its own)
  */
 const withFinestTimeColumnInterval = (
     joinedTable: OwidTable,
@@ -610,7 +610,7 @@ const withFinestTimeColumnInterval = (
     )
     if (new Set(intervals).size < 2) return joinedTable
     const timeColumnDef =
-        TIME_COLUMN_DEF_BY_INTERVAL[findFinestTimeInterval(intervals)]
+        TIME_COLUMN_DEF_BY_INTERVAL[findFinestCommonTimeInterval(intervals)]
     return joinedTable.updateDefs((def) =>
         def.slug === slug ? { ...def, ...timeColumnDef } : def
     )

--- a/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.ts
+++ b/packages/@ourworldindata/grapher/src/core/LegacyToOwidTable.ts
@@ -37,6 +37,7 @@ import {
     OwidVariableType,
     getTimeInterval,
     isSubYearly,
+    findFinestTimeInterval,
     snapToIntervalStart,
     dayjs,
 } from "@ourworldindata/utils"
@@ -337,6 +338,20 @@ export const legacyToOwidTableAndDimensions = (
             )
     }
 
+    // A bucket can hold several intervals (e.g. a daily and a monthly indicator
+    // both live in the day bucket), but the joined table has a single time
+    // column, which should be tagged with the finest of them
+    joinedVariablesTable = withFinestTimeColumnInterval(
+        joinedVariablesTable,
+        variableTablesToJoinByDay,
+        OwidTableSlugs.Day
+    )
+    joinedVariablesTable = withFinestTimeColumnInterval(
+        joinedVariablesTable,
+        variableTablesToJoinByYear,
+        OwidTableSlugs.Year
+    )
+
     // Inject a common "time" column that is used as the main time column for the table
     // e.g. for the timeline.
     for (const dayOrYearSlug of [OwidTableSlugs.Day, OwidTableSlugs.Year]) {
@@ -578,6 +593,26 @@ const fullJoinTables = (
     return new OwidTable(
         [],
         defsToAddPerTable.flatMap((defs) => defs)
+    )
+}
+
+/**
+ * Relabels the joined time column with the finest interval among the variable
+ * tables that were joined into it
+ */
+const withFinestTimeColumnInterval = (
+    joinedTable: OwidTable,
+    variableTables: OwidTable[],
+    slug: OwidTableSlugs.Day | OwidTableSlugs.Year
+): OwidTable => {
+    const intervals = variableTables.map(
+        (table) => table.get(slug).timeInterval
+    )
+    if (new Set(intervals).size < 2) return joinedTable
+    const timeColumnDef =
+        TIME_COLUMN_DEF_BY_INTERVAL[findFinestTimeInterval(intervals)]
+    return joinedTable.updateDefs((def) =>
+        def.slug === slug ? { ...def, ...timeColumnDef } : def
     )
 }
 

--- a/packages/@ourworldindata/types/src/OwidVariableDisplayConfigInterface.ts
+++ b/packages/@ourworldindata/types/src/OwidVariableDisplayConfigInterface.ts
@@ -49,6 +49,23 @@ export enum TimeInterval {
     Decade = "decade",
 }
 
+/** Sub-yearly intervals, finest first */
+export const SUB_YEARLY_TIME_INTERVALS = [
+    TimeInterval.Day,
+    TimeInterval.Week,
+    TimeInterval.Month,
+    TimeInterval.Quarter,
+] as const
+
+/** All time intervals, finest first */
+export const TIME_INTERVALS = [
+    ...SUB_YEARLY_TIME_INTERVALS,
+    TimeInterval.Year,
+    TimeInterval.Decade,
+] as const
+
+export type SubYearlyTimeInterval = (typeof SUB_YEARLY_TIME_INTERVALS)[number]
+
 export interface OwidChartDimensionInterface {
     property: DimensionProperty
     targetYear?: Time

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -323,6 +323,9 @@ export {
     type OwidVariableDataTableConfigInterface,
     OwidVariableRoundingMode,
     TimeInterval,
+    SUB_YEARLY_TIME_INTERVALS,
+    TIME_INTERVALS,
+    type SubYearlyTimeInterval,
     type OwidChartDimensionInterface,
     type OwidChartDimensionInterfaceWithMandatorySlug,
 } from "./OwidVariableDisplayConfigInterface.js"

--- a/packages/@ourworldindata/utils/src/Util.test.ts
+++ b/packages/@ourworldindata/utils/src/Util.test.ts
@@ -37,6 +37,7 @@ import {
     stripOuterParentheses,
     groupTocIntoSections,
     snapToIntervalStart,
+    findFinestTimeInterval,
     diffDatesInDays,
     convertDateToDaysSinceEpoch,
     toStartOfDayUtc,
@@ -697,6 +698,7 @@ describe(withUniformSpacing, () => {
         expect(withUniformSpacing([7, 12, 17])).toEqual([7, 12, 17])
     })
 })
+
 describe(snapToIntervalStart, () => {
     const day = (iso: string): number =>
         diffDatesInDays(dayjs.utc(iso), epochDate())
@@ -734,6 +736,20 @@ describe(snapToIntervalStart, () => {
         ).toEqual(day("2021-03-15"))
         expect(snapToIntervalStart(2021, TimeInterval.Year)).toEqual(2021)
         expect(snapToIntervalStart(2025, TimeInterval.Decade)).toEqual(2025)
+    })
+})
+
+describe(findFinestTimeInterval, () => {
+    it("picks the finest of the given intervals", () => {
+        expect(
+            findFinestTimeInterval([TimeInterval.Month, TimeInterval.Day])
+        ).toEqual(TimeInterval.Day)
+        expect(
+            findFinestTimeInterval([TimeInterval.Decade, TimeInterval.Year])
+        ).toEqual(TimeInterval.Year)
+        expect(
+            findFinestTimeInterval([TimeInterval.Quarter, TimeInterval.Week])
+        ).toEqual(TimeInterval.Week)
     })
 })
 

--- a/packages/@ourworldindata/utils/src/Util.test.ts
+++ b/packages/@ourworldindata/utils/src/Util.test.ts
@@ -37,7 +37,7 @@ import {
     stripOuterParentheses,
     groupTocIntoSections,
     snapToIntervalStart,
-    findFinestTimeInterval,
+    findFinestCommonTimeInterval,
     diffDatesInDays,
     convertDateToDaysSinceEpoch,
     toStartOfDayUtc,
@@ -739,17 +739,41 @@ describe(snapToIntervalStart, () => {
     })
 })
 
-describe(findFinestTimeInterval, () => {
+describe(findFinestCommonTimeInterval, () => {
     it("picks the finest of the given intervals", () => {
         expect(
-            findFinestTimeInterval([TimeInterval.Month, TimeInterval.Day])
+            findFinestCommonTimeInterval([TimeInterval.Month, TimeInterval.Day])
         ).toEqual(TimeInterval.Day)
         expect(
-            findFinestTimeInterval([TimeInterval.Decade, TimeInterval.Year])
+            findFinestCommonTimeInterval([
+                TimeInterval.Decade,
+                TimeInterval.Year,
+            ])
         ).toEqual(TimeInterval.Year)
+        // Quarter starts are month starts, so months represent both
         expect(
-            findFinestTimeInterval([TimeInterval.Quarter, TimeInterval.Week])
-        ).toEqual(TimeInterval.Week)
+            findFinestCommonTimeInterval([
+                TimeInterval.Quarter,
+                TimeInterval.Month,
+            ])
+        ).toEqual(TimeInterval.Month)
+    })
+
+    it("falls back to days when weeks are mixed with longer periods", () => {
+        // ISO-week Mondays and month/quarter starts are different grids, so
+        // neither can represent the other's times
+        expect(
+            findFinestCommonTimeInterval([
+                TimeInterval.Quarter,
+                TimeInterval.Week,
+            ])
+        ).toEqual(TimeInterval.Day)
+        expect(
+            findFinestCommonTimeInterval([
+                TimeInterval.Week,
+                TimeInterval.Month,
+            ])
+        ).toEqual(TimeInterval.Day)
     })
 })
 

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -54,7 +54,10 @@ import {
     RESEARCH_AND_WRITING_DEFAULT_HEADING,
     CHRONOLOGICAL_INDEX_TYPES,
     LATEST_FEED_TYPES,
+    SUB_YEARLY_TIME_INTERVALS,
+    TIME_INTERVALS,
     TimeInterval,
+    type SubYearlyTimeInterval,
     type OwidVariableDisplayConfigInterface,
 } from "@ourworldindata/types"
 import { Point, PointVector } from "./PointVector.js"
@@ -251,28 +254,31 @@ export function getTimeInterval(
     return display?.timeInterval ?? TimeInterval.Year
 }
 
-const SUB_YEARLY_INTERVALS = new Set<TimeInterval>([
-    TimeInterval.Day,
-    TimeInterval.Week,
-    TimeInterval.Month,
-    TimeInterval.Quarter,
-])
-
 /**
  * Whether the interval is finer than a year and therefore encoded as
  * days-since-epoch (day/week/month/quarter)
  */
 export function isSubYearly(
     interval: TimeInterval
-): interval is Exclude<TimeInterval, TimeInterval.Year | TimeInterval.Decade> {
-    return SUB_YEARLY_INTERVALS.has(interval)
+): interval is SubYearlyTimeInterval {
+    return SUB_YEARLY_TIME_INTERVALS.some((subYearly) => subYearly === interval)
+}
+
+/** The finest of the given intervals, e.g. `day` for day + month */
+export function findFinestTimeInterval(
+    intervals: TimeInterval[]
+): TimeInterval {
+    return (
+        TIME_INTERVALS.find((interval) => intervals.includes(interval)) ??
+        TimeInterval.Year
+    )
 }
 
 /**
  * Snap a time to the start of its interval, so indicators that pick different
  * representative days for the same period still align: month → first of the
  * month, quarter → first of the quarter, week → the ISO-week Monday. Day and
- * year are their own start and are returned unchanged.
+ * year are returned unchanged.
  */
 export function snapToIntervalStart(
     time: number,

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -264,14 +264,26 @@ export function isSubYearly(
     return SUB_YEARLY_TIME_INTERVALS.some((subYearly) => subYearly === interval)
 }
 
-/** The finest of the given intervals, e.g. `day` for day + month */
-export function findFinestTimeInterval(
+/**
+ * The finest interval that can represent every one of the given intervals'
+ * times, e.g. `day` for day + month. Weeks start on ISO Mondays and
+ * months/quarters on period starts, so those grids don't nest: a mix of them
+ * falls back to `day`, the grid that contains every other.
+ */
+export function findFinestCommonTimeInterval(
     intervals: TimeInterval[]
 ): TimeInterval {
-    return (
+    const finest =
         TIME_INTERVALS.find((interval) => intervals.includes(interval)) ??
         TimeInterval.Year
-    )
+    const mixesWeeksWithLongerPeriods =
+        finest === TimeInterval.Week &&
+        intervals.some(
+            (interval) =>
+                interval === TimeInterval.Month ||
+                interval === TimeInterval.Quarter
+        )
+    return mixesWeeksWithLongerPeriods ? TimeInterval.Day : finest
 }
 
 /**

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -132,6 +132,7 @@ export {
     epochDate,
     getTimeInterval,
     isSubYearly,
+    findFinestTimeInterval,
     snapToIntervalStart,
     logPerf,
     sleep,

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -132,7 +132,7 @@ export {
     epochDate,
     getTimeInterval,
     isSubYearly,
-    findFinestTimeInterval,
+    findFinestCommonTimeInterval,
     snapToIntervalStart,
     logPerf,
     sleep,


### PR DESCRIPTION
> _Written by Anthropic Claude Opus 5 — @sophiamersmann at the wheel._

When a chart mixes indicators whose intervals share a time bucket — a daily and a monthly indicator are both day-encoded, so both land in the `day` bucket — the joined table still has a single time column. `fullJoinTables` copies shared column defs from its first table, so that column was tagged with the interval of whichever dimension happened to come **first** in the chart config. That interval then drives axis ticks, timeline granularity and every time label on the chart.

This tags it with the **finest** interval in the bucket instead: that's the granularity of the union of times, and the only one at which the timeline can reach every data point. Same rule for the `year` bucket (year + decade).

Nothing renders differently today — no chart currently has two distinct intervals in one bucket.

What's still left to address for mixed-interval charts:
- Charts have a single time column, i.e. currently all times are formatted by that column (i.e. monthly data is formatted using daily format).
- Coarse points sit at their interval start, so they're shifted relative to a finer series on the same chart — WHO's month-end values are drawn ~30 days left of where the source dates them, while the daily line stays put.
- Stacked charts fill the gaps wrongly: stacked bar renders a monthly series as zero between its points, stacked area interpolates it onto daily granularity, and uniform spacing is computed from the single time column.

<details>
<summary>Details</summary>

### Implementation

`withFinestTimeColumnInterval(joinedTable, variableTables, slug)` in `LegacyToOwidTable.ts` reads each joined variable table's own time column interval (`table.get(slug).timeInterval`, which each `TimeColumn` subclass overrides with its own), and if more than one distinct interval is present, relabels the joined table's `day`/`year` column def with `TIME_COLUMN_DEF_BY_INTERVAL[finestTimeInterval(intervals)]`. It runs after all joins and before the `time` column is duplicated off `day`/`year`, so the canonical time column inherits the corrected tag.

Deriving the intervals from the bucket lists rather than tracking them alongside the join loop keeps them from drifting out of sync with the tables.

Supporting moves:

- `SUB_YEARLY_TIME_INTERVALS` and `TIME_INTERVALS` (both finest-first) now live in `types` next to the `TimeInterval` enum, with `SubYearlyTimeInterval` derived from the former — so `isSubYearly`'s guard type can no longer drift from the array it checks.
- `finestTimeInterval()` added to `utils`, alongside `isSubYearly` / `getTimeInterval` / `snapToIntervalStart`.

### Tests

`LegacyToOwidTable.test.ts` gains a "variables with mixed intervals in the same bucket" block: the finest interval wins in **both** dimension orders (daily + monthly), and year + decade resolves to `Year`. Both fail without the fix (the joined column stays `Month` / `Decade`). `Util.test.ts` covers `finestTimeInterval` directly.

`yarn typecheck`, `yarn testLintChanged`, `yarn testFormatChanged` clean. Unit suite passes. `make svgtest` not run: no chart in the DB has two distinct intervals in one bucket, so no reference output can move.

## Fixed examples

Measured by building each chart's input table from live indicator data, with the intervals the data's own cadence implies (daily confirmed COVID-19 deaths, weekly Economist estimates, monthly WHO estimates). "Distinct labels" is how many different strings the chart's times render as; "date-input reachable" is how many of them the timeline's date input can address, since it snaps typed dates to the tagged interval's start.

### `excess-deaths-cumulative-economist-who` — daily + weekly + monthly

Dimension order puts the three monthly WHO series first, then weekly Economist, then daily COVID deaths.

- **Was:** time column tagged `month`. All 2,391 distinct times collapsed to **80 distinct labels** — every daily point within a month rendered identically, e.g. the point for Jan 28, 2023 read `Jan 2023`. The axis drew monthly ticks over daily data, and only **79 of 2,391** times were reachable from the date input, so the daily series was effectively unaddressable.
- **Now:** tagged `day`. 2,391 distinct labels, all reachable; that same point reads `Jan 28, 2023`.

### `excess-deaths-cumulative-economist-single-entity` — daily + weekly

Weekly Economist central estimate is the first dimension, daily COVID deaths the second.

- **Was:** tagged `week`. 2,390 times → **342 labels**; the point for Jan 29, 2023 read `Week of Jan 23, 2023`, and only those 342 week-Mondays were reachable from the date input.
- **Now:** tagged `day`. 2,390 labels, all reachable, reading `Jan 29, 2023`.

### `excess-deaths-daily-economist-single-entity` — daily + weekly

Same shape, weekly first.

- **Was:** tagged `week`. 2,386 times → **342 labels**; the point for Feb 1, 2023 read `Week of Jan 30, 2023`.
- **Now:** tagged `day`. 2,386 labels, reading `Feb 1, 2023`.

### `excess-deaths-cumulative-who` — daily + monthly, and already correct

Daily COVID deaths is the first dimension here, so the joined column was already tagged `day` and this chart is **unchanged** by the fix. Worth including: it's the same mix of intervals as the first example and rendered fine purely because of dimension order — which is what made the bug easy to miss.

### How the example numbers were produced

A throwaway script fetched `.data.json` + `.metadata.json` for each chart's indicators from the public API, inferred each one's interval from its median gap in days, injected it as `display.timeInterval`, built the table through `legacyToOwidTableAndDimensionsWithMandatorySlug` with the real dimension order from `chart_dimensions`, and reported the joined time column's type, distinct times, distinct labels and date-input-reachable count. Run once with the fix and once with `withFinestTimeColumnInterval` short-circuited.

### Not addressed here

- **Per-series time labels.** With the column tagged `day`, a monthly series' times still render as `Jan 1, 2021` rather than `January 2021`, because `CoreColumn.formatTime` goes through `originalTimeColumn` — either the `-originalTime` column (whose def is spread from the table's time column) or the table's time column itself. Each value column does keep its own interval on `display`, so this is fixable in `originalTimeColumn`; deliberately left out of this PR.
- **Within-interval placement.** `snapToIntervalStart` moves coarse points to their interval start, which is invisible on a single-interval chart but shifts them left relative to a daily series on a mixed one (WHO's month-end dates move to the 1st, ~30 days). Alignment across coarse indicators is the reason snapping exists, so changing this is a design decision, not a bug fix.
- **Coarse series at an arbitrary selected time.** Tolerance is measured in days, so a monthly indicator needs `tolerance >= 31` to show up on a day it has no value for. Pre-existing and orthogonal to the join.
- **Stacked charts.** `StackedUtils.withMissingValuesAsZeroes` sets `value: 0` at every position a series lacks, so a monthly series stacked against daily data is zero between its points on a stacked bar chart (`shouldRunLinearInterpolation = false`); stacked area interpolates it linearly to daily granularity instead. `getUniformlySpacedTimes` also runs off the single time column, so a coarse series gets fine-grained spacing.
- **Downloads.** Fixing per-series labels in `CoreColumn.originalTimeColumn` would not reach CSV: `OwidTable.toCsv` formats each cell with its own column's `formatForCsv`, which for time is the single joined column, so a monthly indicator still exports `2021-01-01` rather than `2021-01`. `Axis.calendarTickInterval` reads the same single interval.
- **Day + year mixing**, the other half of #5794: the entity-only fallback in `fullJoinTables` still fabricates values there. Untouched.

</details>
