### PR TITLE
🐛🤖 (chart-configs) always reach chart configs through their owner table

### DIFF
--- a/db/db.ts
+++ b/db/db.ts
@@ -40,6 +40,7 @@ import {
     TagGraphRoot,
     FeaturedMetricByParentTagNameDictionary,
     ChartConfigsTableName,
+    ChartsTableName,
     FeaturedMetricsTableName,
     TagsTableName,
     PostsGdocsXTagsTableName,
@@ -1438,10 +1439,11 @@ export async function validateChartSlug(
         const grapher = await knexRaw(
             trx,
             `-- sql
-            SELECT id
-            FROM ${ChartConfigsTableName}
-            WHERE slug = ?
-            AND full->>"$.isPublished" = "true"`,
+            SELECT c.id
+            FROM ${ChartConfigsTableName} cc
+            JOIN ${ChartsTableName} c ON c.configId = cc.id
+            WHERE cc.slug = ?
+            AND cc.full->>"$.isPublished" = "true"`,
             [slug]
         ).then((rows) => rows[0])
 

--- a/db/model/Dod.ts
+++ b/db/model/Dod.ts
@@ -7,6 +7,7 @@ import {
     ContentGraphLinkType,
     ExplorersTableName,
     ChartConfigsTableName,
+    ChartsTableName,
     VariablesTableName,
     DodsTableName,
     DodUsageRecord,
@@ -152,10 +153,11 @@ export async function getDodsUsage(
     const chartsUsagePromise = knexRaw<{ slug: string; config: string }>(
         knex,
         `-- sql
-        SELECT slug, full AS config
-        FROM ${ChartConfigsTableName}
-        WHERE full LIKE "%#dod:%"
-        AND full->>"$.isPublished" = "true"`
+        SELECT cc.slug, cc.full AS config
+        FROM ${ChartConfigsTableName} cc
+        JOIN ${ChartsTableName} c ON c.configId = cc.id
+        WHERE cc.full LIKE "%#dod:%"
+        AND cc.full->>"$.isPublished" = "true"`
     ).then((rows) =>
         rows.reduce(
             (acc, cur) => {

--- a/db/model/StaticViz.ts
+++ b/db/model/StaticViz.ts
@@ -45,7 +45,10 @@ const BASE_STATIC_VIZ_QUERY = `-- sql
         ${StaticVizTableName} sv
     LEFT JOIN ${UsersTableName} u ON sv.createdBy = u.id
     LEFT JOIN ${UsersTableName} u2 ON sv.updatedBy = u2.id
-    LEFT JOIN charts c ON c.configId IN (SELECT id FROM chart_configs WHERE slug = sv.grapherSlug)
+    LEFT JOIN (
+        charts c
+        JOIN chart_configs cc ON cc.id = c.configId
+    ) ON cc.slug = sv.grapherSlug
     INNER JOIN
         ${ImagesTableName} desktopImage ON sv.imageId = desktopImage.id
     LEFT JOIN

--- a/devTools/syncGraphersToR2/syncGraphersToR2.ts
+++ b/devTools/syncGraphersToR2/syncGraphersToR2.ts
@@ -247,10 +247,11 @@ async function main(parsedArgs: parseArgs.ParsedArgs, dryRun: boolean) {
             Pick<DbRawChartConfig, "slug" | "fullMd5" | "id">
         >(
             trx,
-            `select slug, fullMd5, id
-             from chart_configs
-             where slug is not null
-             and full ->> '$.isPublished' = "true"`
+            `select cc.slug, cc.fullMd5, cc.id
+             from chart_configs cc
+             join charts c on c.configId = cc.id
+             where cc.slug is not null
+             and cc.full ->> '$.isPublished' = "true"`
         )
         console.log(`Found ${slugsAndHashesFromDb.length} published charts`)
 


### PR DESCRIPTION
> _Written by Anthropic Claude Opus 5 — @sophiamersmann at the wheel._

Some preliminary work for the planned `chart_configs` refactor (`patch` + `full` → a single `config` column), which will add patch-config rows to the table and therefore allow multiple rows to share a slug. As a result, every by-slug query should go through the config’s owner table (e.g. `charts`) to guarantee slug uniqueness.

