### PR TITLE
✨🤖 left-align multi-line categorical map legends

### DIFF
--- a/packages/@ourworldindata/grapher/src/facet/FacetMap.tsx
+++ b/packages/@ourworldindata/grapher/src/facet/FacetMap.tsx
@@ -365,7 +365,7 @@ export class FacetMap
     }
 
     @computed get legendX(): number {
-        return this.bounds.x
+        return this.bounds.x + (this.bounds.width - this.legendMaxWidth) / 2
     }
 
     @computed get numericLegendY(): number {
@@ -391,11 +391,19 @@ export class FacetMap
     }
 
     @computed get legendMaxWidth(): number {
-        return this.bounds.width * MAP_LEGEND_MAX_WIDTH_RATIO
+        // Numeric tick labels are centered on bin boundaries and thus stick out
+        // past the legend's edges, so they need some padding left and right
+        return this.hasNumericLegend
+            ? this.bounds.width * MAP_LEGEND_MAX_WIDTH_RATIO
+            : this.bounds.width
     }
 
     @computed get legendAlign(): HorizontalAlign {
-        return HorizontalAlign.center
+        if (this.hasNumericLegend) return HorizontalAlign.center
+        // Centered categorical legends are hard to read across multiple lines
+        return (this.categoryLegend?.numLines ?? 0) > 1
+            ? HorizontalAlign.left
+            : HorizontalAlign.center
     }
 
     @computed get hoverColors(): Color[] | undefined {
@@ -439,10 +447,14 @@ export class FacetMap
             : undefined
     }
 
+    @computed private get hasNumericLegend(): boolean {
+        return this.numericLegendData.length > 1
+    }
+
     @computed private get numericLegend():
         | HorizontalNumericColorLegend
         | undefined {
-        return this.numericLegendData.length > 1
+        return this.hasNumericLegend
             ? new HorizontalNumericColorLegend({ manager: this })
             : undefined
     }

--- a/packages/@ourworldindata/grapher/src/legend/HorizontalColorLegends.tsx
+++ b/packages/@ourworldindata/grapher/src/legend/HorizontalColorLegends.tsx
@@ -806,20 +806,16 @@ export class HorizontalCategoricalColorLegend extends HorizontalColorLegend {
         return lines
     }
 
-    @computed private get contentWidth(): number {
-        return _.max(this.markLines.map((l) => l.totalWidth)) as number
-    }
-
-    @computed private get containerWidth(): number {
-        return this.width ?? this.contentWidth
+    @computed get numLines(): number {
+        return this.markLines.length
     }
 
     @computed private get marks(): CategoricalMark[] {
         const lines = this.markLines
         const align = this.legendAlign
-        const width = this.containerWidth
+        const width = this.width
 
-        // Center each line
+        // Align each line
         lines.forEach((line) => {
             // TODO abstract this
             const xShift =

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
@@ -512,8 +512,11 @@ export class MapChart
     }
 
     @computed get legendMaxWidth(): number {
-        // it seems nice to have just a little bit of extra padding left and right
-        return this.bounds.width * MAP_LEGEND_MAX_WIDTH_RATIO
+        // Numeric tick labels are centered on bin boundaries and thus stick out
+        // past the legend's edges, so they need some padding left and right
+        return this.hasNumericLegend
+            ? this.bounds.width * MAP_LEGEND_MAX_WIDTH_RATIO
+            : this.bounds.width
     }
 
     @computed get legendX(): number {
@@ -540,10 +543,14 @@ export class MapChart
             : undefined
     }
 
+    @computed private get hasNumericLegend(): boolean {
+        return !!this.manager.showLegend && this.numericLegendData.length > 1
+    }
+
     @computed private get numericLegend():
         | HorizontalNumericColorLegend
         | undefined {
-        return this.manager.showLegend && this.numericLegendData.length > 1
+        return this.hasNumericLegend
             ? new HorizontalNumericColorLegend({ manager: this })
             : undefined
     }
@@ -559,7 +566,11 @@ export class MapChart
     }
 
     @computed get legendAlign(): HorizontalAlign {
-        return HorizontalAlign.center
+        if (this.hasNumericLegend) return HorizontalAlign.center
+        // Centered categorical legends are hard to read across multiple lines
+        return (this.categoryLegend?.numLines ?? 0) > 1
+            ? HorizontalAlign.left
+            : HorizontalAlign.center
     }
 
     @computed get numericLegendY(): number {


### PR DESCRIPTION

> _Written by Anthropic Claude Opus 5 — @sophiamersmann at the wheel._

Resolves #3988. Second run at #4324, which was reverted in #4440.

That PR dropped the 5% horizontal padding around *every* map legend, which pushed the outermost numeric tick labels outside the frame on narrow screens — the regression that got it reverted. The padding can't be keyed off alignment (alignment → line count → available width → alignment is circular), but it can be keyed off whether a numeric legend is present, which is the better condition anyway: numeric tick labels are centred on bin boundaries and stick out past the legend's edges, categorical marks never do.

So categorical-only legends now get the full width and left-align when they wrap; anything with a numeric legend keeps its padding and stays centred. Single-line categorical legends are visually unchanged.

Also fixes a pre-existing quirk in faceted maps, where `legendX` sat at `bounds.x` while the legend box was only 95% wide, so the "centred" legend was shifted left by half the padding. **This moves faceted numeric map legends right by ~2.5% of the chart width.**

⚠️ Expect a large SVG-tester diff: every categorical-only map legend now wraps at 100% instead of 95% of the available width, so line breaks shift even where alignment doesn't change. #4324 produced 88 diffs. I haven't run the suite.

<details><summary>Details</summary>

### Changes

- **`mapCharts/MapChart.tsx`** — extracted `hasNumericLegend` (the predicate `numericLegend` already used inline), then keyed both `legendMaxWidth` and `legendAlign` off it. `legendX` needs no change: with the full width it collapses to `bounds.x`, which equals `CaptionedChart`'s `innerBounds.x` — the title/subtitle left edge — so the legend lines up with the text.
- **`facet/FacetMap.tsx`** — same two getters, plus `legendX` now centres the box (`bounds.x + (bounds.width - legendMaxWidth) / 2`).
- **`legend/HorizontalColorLegends.tsx`** — re-added `numLines` (removed by the revert). Deleted the dead `contentWidth`/`containerWidth` pair: `containerWidth` was `this.width ?? this.contentWidth`, but `width` is `legendWidth ?? legendMaxWidth ?? 200` and so never `undefined`, meaning the fallback never fired.

### No MobX cycle

`legendAlign → categoryLegend.numLines → markLines → width → legendMaxWidth → hasNumericLegend → numericLegendData`, which reads colour-scale bins only, no geometry. `marks` reads `legendAlign`, but `numLines` doesn't read `marks`.

### Why not left-align all categorical legends

`FacetChart.legendAlign` does exactly `numeric ? center : left`, and stacked-discrete-bar and dumbbell categorical legends are left-aligned unconditionally — so there's precedent for the simpler rule. #3988 rejected it: a single-line legend left-aligned against a centred map looks off, and the agreement in the issue was to try multi-line-only first.

### Overflow check

Categorical marks can't overflow their box the way numeric labels do: `markLines` only places a mark when `xOffset + markWidth <= width`, and `markWidth` includes the trailing `markPadding`, so a line's text ends at or before `width - markPadding`. The one exception — a single mark wider than the whole legend — already existed and is now *less* likely, since the box grew from 95% to 100%.

### Tests

`yarn test`, `yarn typecheck`, lint and format all clean. No new unit tests — the behaviour is layout, so the SVG tester is the meaningful check. `make svgtest` not run locally.

</details>
