### PR TITLE
Forward Cloudflare's verified-bot category to GA4

### DIFF
--- a/docs/google-tag-manager.md
+++ b/docs/google-tag-manager.md
@@ -41,6 +41,8 @@ additional consent check requiring `analytics_storage`. Decide that per
 parameter when wiring it up in the GTM UI — the dataLayer push itself can't
 express it. For `asn`/`as_org` we chose not to gate:
 [PR #6791](https://github.com/owid/owid-grapher/pull/6791#discussion_r3751166526).
+`verified_bot_category` describes the client software rather than the visitor's
+network, so the question doesn't arise for it at all.
 
 Quick console checks on any page with GTM:
 

--- a/functions/_common/asnDataLayer.test.ts
+++ b/functions/_common/asnDataLayer.test.ts
@@ -37,6 +37,26 @@ describe(buildDataLayerScript, () => {
         ).toContain(`{"as_org":"Cloudflare"}`)
     })
 
+    it("includes verified_bot_category when Cloudflare flagged a verified bot", () => {
+        expect(
+            buildDataLayerScript({
+                asn: 15169,
+                asOrganization: "Google LLC",
+                verifiedBotCategory: "Search Engine Crawler",
+            })
+        ).toContain(`"verified_bot_category":"Search Engine Crawler"`)
+    })
+
+    it("omits verified_bot_category for non-bot traffic", () => {
+        // Absent means "not a verified bot", so the key must not be sent empty
+        expect(buildDataLayerScript({ asn: 680 })).not.toContain(
+            "verified_bot_category"
+        )
+        expect(
+            buildDataLayerScript({ asn: 680, verifiedBotCategory: "" })
+        ).not.toContain("verified_bot_category")
+    })
+
     it("returns undefined when cf info is absent (e.g. local dev)", () => {
         expect(buildDataLayerScript(undefined)).toBeUndefined()
         expect(buildDataLayerScript({})).toBeUndefined()

--- a/functions/_common/asnDataLayer.ts
+++ b/functions/_common/asnDataLayer.ts
@@ -14,24 +14,44 @@ import { Env } from "./env.js"
 // for impact evaluation (universities, governments, NGOs) that rarely respond
 // to surveys. Not PII.
 //
-// Param names (`asn`, `as_org`) match the sampled server-side
-// `cf_function_invocation` events in analytics.ts so they can be analyzed
-// together downstream.
+// `verified_bot_category` rides along for a different reason: GA4's web events
+// carry no user-agent string at all, so on this channel there is no way to tell
+// a crawler that renders our JS from a human — `as_org` can't do it, because
+// e.g. "Google LLC" covers Googlebot, Google Cloud and Googlers alike. This is
+// Cloudflare's authoritative Verified Bots label ("Search Engine Crawler",
+// "AI Assistant", "AI Crawler", …), and it's the only bot signal this channel
+// gets. Absent means "not a verified bot" — the key is omitted rather than sent
+// empty, so it costs nothing on the ~92% of requests that aren't bots.
+//
+// Param names (`asn`, `as_org`, `verified_bot_category`) match the sampled
+// server-side `cf_function_invocation` events in analytics.ts so they can be
+// analyzed together downstream.
+
+type AsnDataLayerCfProperties = Partial<
+    Pick<IncomingRequestCfProperties, "asn" | "asOrganization">
+> & {
+    // Not in this @cloudflare/workers-types version yet, so it reaches us via
+    // the cf index signature as `unknown` (same as in analytics.ts); String()
+    // below keeps it type-safe without a cast.
+    verifiedBotCategory?: unknown
+}
 
 export function buildDataLayerScript(
-    cf:
-        | Partial<Pick<IncomingRequestCfProperties, "asn" | "asOrganization">>
-        | undefined
+    cf: AsnDataLayerCfProperties | undefined
 ): string | undefined {
     if (!cf) return undefined
-    if (!cf.asn && !cf.asOrganization) return undefined
+    const verifiedBotCategory = String(cf.verifiedBotCategory ?? "")
     const params = {
         ...(cf.asn ? { asn: cf.asn } : {}),
         // GA4 param values must be 100 characters or less
         ...(cf.asOrganization
             ? { as_org: cf.asOrganization.slice(0, 100) }
             : {}),
+        ...(verifiedBotCategory
+            ? { verified_bot_category: verifiedBotCategory.slice(0, 100) }
+            : {}),
     }
+    if (Object.keys(params).length === 0) return undefined
     const json = escapeJSONStringForInlineScript(JSON.stringify(params))
     return `<script>window.dataLayer=window.dataLayer||[];window.dataLayer.push(${json});</script>`
 }

--- a/functions/_common/asnDataLayer.ts
+++ b/functions/_common/asnDataLayer.ts
@@ -23,6 +23,18 @@ import { Env } from "./env.js"
 // gets. Absent means "not a verified bot" — the key is omitted rather than sent
 // empty, so it costs nothing on the ~92% of requests that aren't bots.
 //
+// Treat the values as free-form strings, not an enum: Cloudflare replaced this
+// taxonomy on 2026-07-01 with behaviour-based categories (Search, Agent,
+// Training, …) and the names we get today are explicitly the backwards-
+// compatible legacy set, so they can change without a deploy on our side.
+// https://developers.cloudflare.com/bots/concepts/bot/verified-bots/
+//
+// Deliberately NOT sending the sibling `botManagement.verifiedBot` boolean: it
+// is always false on our plan, including on requests Cloudflare did give a
+// category, so it would contradict this field. The category is the field that
+// works for us (`cf.verified_bot_category` in Cloudflare's rules language —
+// note it hangs off `cf`, not off `cf.botManagement`).
+//
 // Param names (`asn`, `as_org`, `verified_bot_category`) match the sampled
 // server-side `cf_function_invocation` events in analytics.ts so they can be
 // analyzed together downstream.


### PR DESCRIPTION
#: 👨 Summary

`asn` and `as_org` is flowing to GA4. While we're at it, we can as well add `verifiedBotCategory` by Cloudflare. I'll add it to GTM and GA4 in the same way.

---------------------------

#6791 started forwarding the visitor's network (`asn`, `as_org`) into the GTM dataLayer so GA4 events carry it. This adds a third field from the same `request.cf` object: Cloudflare's Verified Bots category. Behaviour change is one extra key in the existing inline push, and only on requests Cloudflare has identified as a verified bot.

_Skim — one function and its tests. The part worth a moment is the guard change described below._

## How it works

GA4's web events carry **no user-agent string at all**, which is why `bot_classified_traffic` in the analytics repo only classifies the server-side `cf_function_invocation` channel — its UA-based logic has nothing to work with on web events. So on the channel #6791 opened up, `as_org` is the only bot-ish signal available, and it can't do the job: "Google LLC" (ASN 15169) covers Googlebot, Google Cloud tenants and Google employees browsing charts, indistinguishably. `verifiedBotCategory` is Cloudflare's authoritative label for that population — `Search Engine Crawler`, `AI Assistant`, `AI Crawler`, `Page Preview`, … — and it's the only bot signal this channel can get.

Two things follow from how it's sent:

- **The key is omitted, not sent empty**, matching what the review on #6791 settled for `asn`/`as_org`. So absent means "not a verified bot", and the ~92% of page requests that are ordinary traffic pay zero extra bytes. This is also why the param name matches the server-side one in `analytics.ts` — the two channels stay analysable together.
- **The early-return guard changed shape.** It used to be `if (!cf.asn && !cf.asOrganization) return undefined`, which would have discarded a push carrying only a bot category. It's now "build the params, return undefined if none of them are set", so each field is independent. Same behaviour for every input the old guard accepted.

`verifiedBotCategory` isn't in our `@cloudflare/workers-types` version yet, so it arrives through the `cf` index signature as `unknown`. `analytics.ts` handles that with `String(... ?? "")` and this does the same, rather than casting.

## Verified

- Tests assert the two behaviours that matter: the key appears with the category when Cloudflare set one, and is absent both when the field is missing and when it's an empty string.
- **Not verified end-to-end, and can't be from this repo:** the param reaches GA4 only once a Data Layer Variable plus a GA4 parameter mapping are added in the GTM UI, and it only shows up in GA4 reports/Explore once registered as a custom dimension there. Until then this changes the page source and nothing else. There's also no observable surface on a staging bake — staging is baked without a GTM container ID, and requests reaching the box over Tailscale don't carry a `request.cf` at all, so no push is generated.

## Decisions worth a second look

Each event-scoped custom dimension consumes one of GA4's 50 slots, so this is only worth merging if the dimension actually gets registered and used to segment. We have a cautionary precedent in the sibling code: `bot_score` is wired end-to-end and has been a permanent `-1` sentinel since day one, because it needs Enterprise Bot Management rather than the Super Bot Fight Mode we're on — it's documented as inert in `analytics.ts`. Registration is planned here, which is the assumption this PR rests on.

<details><summary>Details</summary>

**Sizing the population.** Server-side `cf_function_invocation` events, page-ish paths (static assets and data files excluded), 7 days to 2026-08-12, from the 1% GA4 sample:

| `verified_bot_category` | share of page requests |
| --- | --- |
| (absent) | 92.3% |
| Search Engine Crawler | 2.6% |
| AI Assistant | 2.2% |
| AI Crawler | 1.0% |
| Page Preview | 0.7% |
| AI Search | 0.3% |
| Search Engine Optimization | 0.3% |
| Feed Fetcher / Security / Monitoring / Webhooks | 0.6% |

So ~7.7% of page requests are verified bots and roughly half of that is AI assistants, crawlers and AI search — the segment we currently can't see at all in the web-event stream.

**The ambiguity this resolves, concretely.** Client-side events since the #6791 rollout, top two networks by volume:

| network | events | distinct `user_pseudo_id` |
| --- | --- | --- |
| Google LLC (15169) | 758 | 55 |
| Comcast (7922) | 178 | 7 |

Google's ASN shows ~8× more distinct client identities than a large consumer ISP, almost all desktop Chrome, and on the server-side channel that same ASN is 54% `Search Engine Crawler`. That pattern is consistent with a rendering crawler executing our GTM, but `as_org` alone cannot confirm it — which is the question this field answers.

**Rollout state of #6791 for reference:** client-side `asn` coverage reached 92–100% of `page_view` events within about an hour of that deploy and holds there across every page family (`/grapher/*`, articles, `/explorers/*`, `/search*`, homepage). The residual few percent is the browser-cached-HTML case documented in `asnDataLayer.ts`.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
