### PR TITLE
🔨🤖 (chart-configs) replace chart_configs.patch + full with a single config column

### DIFF
--- a/adminSiteClient/CreateNarrativeChartEditorPage.tsx
+++ b/adminSiteClient/CreateNarrativeChartEditorPage.tsx
@@ -88,7 +88,7 @@ class CreateNarrativeChartEditorPageInternal
         const chartConfig = await this.context.admin.getJSON(
             `/api/chart-configs/${this.props.chartConfigId}.config.json`
         )
-        this.parentConfig = chartConfig.full
+        this.parentConfig = chartConfig
     }
 
     @computed get admin(): Admin {

--- a/adminSiteServer/apiRoutes/bulkUpdates.ts
+++ b/adminSiteServer/apiRoutes/bulkUpdates.ts
@@ -34,7 +34,7 @@ export async function getChartBulkUpdate(
     trx: db.KnexReadonlyTransaction
 ): Promise<BulkGrapherConfigResponse<BulkChartEditResponseRow>> {
     const context: OperationContext = {
-        grapherConfigFieldName: "chart_configs.full",
+        grapherConfigFieldName: "chart_configs.config",
         whitelistedColumnNamesAndTypes:
             chartBulkUpdateAllowedColumnNamesAndTypes,
     }
@@ -55,7 +55,7 @@ export async function getChartBulkUpdate(
         `-- sql
                 SELECT
                     charts.id as id,
-                    chart_configs.full as config,
+                    chart_configs.config as config,
                     charts.createdAt as createdAt,
                     charts.updatedAt as updatedAt,
                     charts.lastEditedAt as lastEditedAt,
@@ -98,11 +98,11 @@ export async function updateBulkChartConfigs(
     const chartIds = new Set(patchesList.map((patch) => patch.id))
 
     const configsAndIds = await db.knexRaw<
-        Pick<DbPlainChart, "id"> & { config: DbRawChartConfig["full"] }
+        Pick<DbPlainChart, "id"> & { config: DbRawChartConfig["config"] }
     >(
         trx,
         `-- sql
-            SELECT c.id, cc.full as config
+            SELECT c.id, cc.config as config
             FROM charts c
             JOIN chart_configs cc ON cc.id = c.configId
             WHERE c.id IN (?)
@@ -163,7 +163,7 @@ export async function getVariableAnnotations(
             SELECT
                 variables.id as id,
                 variables.name as name,
-                chart_configs.patch as config,
+                chart_configs.config as config,
                 d.name as datasetname,
                 namespaces.name as namespacename,
                 variables.createdAt as createdAt,
@@ -172,7 +172,7 @@ export async function getVariableAnnotations(
             FROM variables
             LEFT JOIN active_datasets as d on variables.datasetId = d.id
             LEFT JOIN namespaces on d.namespace = namespaces.name
-            LEFT JOIN chart_configs on variables.grapherConfigIdAdmin = chart_configs.id
+            LEFT JOIN chart_configs on variables.patchConfigIdAdmin = chart_configs.id
             WHERE ${whereClause}
             ORDER BY variables.id DESC
             LIMIT 50
@@ -191,7 +191,7 @@ export async function getVariableAnnotations(
             FROM variables
             LEFT JOIN active_datasets as d on variables.datasetId = d.id
             LEFT JOIN namespaces on d.namespace = namespaces.name
-            LEFT JOIN chart_configs on variables.grapherConfigIdAdmin = chart_configs.id
+            LEFT JOIN chart_configs on variables.patchConfigIdAdmin = chart_configs.id
             WHERE ${whereClause}
         `
     )
@@ -208,14 +208,14 @@ export async function updateVariableAnnotations(
 
     const configsAndIds = await db.knexRaw<
         Pick<DbRawVariable, "id"> & {
-            grapherConfigAdmin: DbRawChartConfig["patch"]
+            grapherConfigAdmin: DbRawChartConfig["config"]
         }
     >(
         trx,
         `-- sql
-          SELECT v.id, cc.patch AS grapherConfigAdmin
+          SELECT v.id, cc.config AS grapherConfigAdmin
           FROM variables v
-          LEFT JOIN chart_configs cc ON v.grapherConfigIdAdmin = cc.id
+          LEFT JOIN chart_configs cc ON v.patchConfigIdAdmin = cc.id
           WHERE v.id IN (?)`,
         [variableIds.values().toArray()]
     )

--- a/adminSiteServer/apiRoutes/chartConfigs.ts
+++ b/adminSiteServer/apiRoutes/chartConfigs.ts
@@ -2,7 +2,7 @@ import { Request } from "express"
 import { HandlerResponse } from "../FunctionalRouter.js"
 import { JsonError } from "@ourworldindata/utils"
 import * as db from "../../db/db.js"
-import { getChartConfigById } from "../../db/model/ChartConfigs.js"
+import { getChartConfigByUUID } from "../../db/model/ChartConfigs.js"
 
 export async function getChartConfig(
     req: Request,
@@ -10,7 +10,7 @@ export async function getChartConfig(
     trx: db.KnexReadonlyTransaction
 ) {
     const { chartConfigId } = req.params
-    const config = await getChartConfigById(trx, chartConfigId)
+    const config = await getChartConfigByUUID(trx, chartConfigId)
     if (config) return config
     throw new JsonError(`No chart config found for id ${chartConfigId}`, 404)
 }

--- a/adminSiteServer/apiRoutes/charts.ts
+++ b/adminSiteServer/apiRoutes/charts.ts
@@ -8,8 +8,6 @@ import {
     DbPlainChart,
     R2GrapherConfigDirectory,
     DbInsertChartRevision,
-    DbRawChartConfig,
-    ChartConfigsTableName,
     DbChartTagJoin,
     ContentGraphLinkType,
     StaticVizTableName,
@@ -45,7 +43,6 @@ import {
     getWordpressPostReferencesByChartId,
     getGdocsPostReferencesByChartId,
 } from "../../db/model/Post.js"
-import { UpdatedChartInheritanceRecord } from "../../db/model/Variable.js"
 import { enqueueExplorerRefreshJobsForDependencies } from "../../db/model/Explorer.js"
 import { expectInt } from "../../serverUtils/serverUtil.js"
 import {
@@ -54,10 +51,7 @@ import {
     retrieveChartConfigFromDbAndSaveToR2,
     updateChartConfigPairInDbAndR2,
 } from "../chartConfigHelpers.js"
-import {
-    deleteGrapherConfigFromR2,
-    saveGrapherConfigToR2ByUUID,
-} from "../../serverUtils/r2/chartConfigR2Helpers.js"
+import { deleteGrapherConfigFromR2 } from "../../serverUtils/r2/chartConfigR2Helpers.js"
 import { triggerStaticBuild } from "../../baker/GrapherBakingUtils.js"
 import * as db from "../../db/db.js"
 import { getLogsByChartId } from "../getLogsByChartId.js"
@@ -566,23 +560,6 @@ export const saveGrapher = async (
     return {
         chartId,
         savedPatch: patchConfig,
-    }
-}
-
-export async function updateGrapherConfigsInR2(
-    knex: db.KnexReadonlyTransaction,
-    updatedCharts: UpdatedChartInheritanceRecord[],
-    updatedMultiDimViews: { chartConfigId: string; isPublished: boolean }[]
-) {
-    const idsToUpdate = [
-        ...updatedCharts.filter(({ isPublished }) => isPublished),
-        ...updatedMultiDimViews,
-    ].map(({ chartConfigId }) => chartConfigId)
-    const builder = knex<DbRawChartConfig>(ChartConfigsTableName)
-        .select("id", "config", "configMd5")
-        .whereIn("id", idsToUpdate)
-    for await (const { id, config, configMd5 } of builder.stream()) {
-        await saveGrapherConfigToR2ByUUID(id, config, configMd5)
     }
 }
 

--- a/adminSiteServer/apiRoutes/charts.ts
+++ b/adminSiteServer/apiRoutes/charts.ts
@@ -4,7 +4,6 @@ import {
     GrapherInterface,
     JsonError,
     DbPlainUser,
-    Base64String,
     serializeChartConfig,
     DbPlainChart,
     R2GrapherConfigDirectory,
@@ -23,7 +22,6 @@ import {
     parseIntOrUndefined,
     omitUndefinedValues,
 } from "@ourworldindata/utils"
-import { v7 as uuidv7 } from "uuid"
 import {
     References,
     StaticVizReference,
@@ -51,12 +49,13 @@ import { UpdatedChartInheritanceRecord } from "../../db/model/Variable.js"
 import { enqueueExplorerRefreshJobsForDependencies } from "../../db/model/Explorer.js"
 import { expectInt } from "../../serverUtils/serverUtil.js"
 import {
+    deleteChartConfigPairFromDbAndR2,
+    insertChartConfigPair,
     retrieveChartConfigFromDbAndSaveToR2,
-    updateChartConfigInDbAndR2,
+    updateChartConfigPairInDbAndR2,
 } from "../chartConfigHelpers.js"
 import {
     deleteGrapherConfigFromR2,
-    deleteGrapherConfigFromR2ByUUID,
     saveGrapherConfigToR2ByUUID,
 } from "../../serverUtils/r2/chartConfigR2Helpers.js"
 import { triggerStaticBuild } from "../../baker/GrapherBakingUtils.js"
@@ -94,7 +93,7 @@ export const getReferencesByChartId = async (
     const narrativeChartsPromise = db.knexRaw<NarrativeChartMinimalInformation>(
         knex,
         `-- sql
-        SELECT nc.id, nc.name, cc.full ->> "$.title" AS title
+        SELECT nc.id, nc.name, cc.config ->> "$.title" AS title
         FROM narrative_charts nc
         JOIN chart_configs cc ON cc.id = nc.chartConfigId
         WHERE nc.parentChartId = ?`,
@@ -248,7 +247,7 @@ const saveNewChart = async (
         shouldInherit?: boolean
     }
 ): Promise<{
-    chartConfigId: Base64String
+    chartConfigId: string
     patchConfig: GrapherInterface
     fullConfig: GrapherInterface
 }> => {
@@ -263,23 +262,12 @@ const saveNewChart = async (
 
     const now = new Date()
 
-    // insert patch & full configs into the chart_configs table
-    // We can't quite use `saveNewChartConfigInDbAndR2` here, because
-    // we need to update the chart id in the config after inserting it.
-    const chartConfigId = uuidv7() as Base64String
-    await db.knexRaw(
+    // Insert without publishing to R2 yet, because we need to update the chart
+    // id in the config after inserting it.
+    const { chartConfigId, patchConfigId } = await insertChartConfigPair(
         knex,
-        `-- sql
-            INSERT INTO chart_configs (id, patch, full, createdAt, updatedAt)
-            VALUES (?, ?, ?, ?, ?)
-        `,
-        [
-            chartConfigId,
-            serializeChartConfig(patchConfig),
-            serializeChartConfig(fullConfig),
-            now,
-            now,
-        ]
+        { config: fullConfig, patchConfig },
+        now
     )
 
     // add a new chart to the charts table
@@ -288,6 +276,7 @@ const saveNewChart = async (
         `-- sql
             INSERT INTO charts (
                 configId,
+                patchConfigId,
                 isInheritanceEnabled,
                 forceDatapage,
                 createdAt,
@@ -295,26 +284,33 @@ const saveNewChart = async (
                 lastEditedAt,
                 lastEditedByUserId
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
         `,
-        [chartConfigId, shouldInherit, forceDatapage, now, now, now, user.id]
+        [
+            chartConfigId,
+            patchConfigId,
+            shouldInherit,
+            forceDatapage,
+            now,
+            now,
+            now,
+            user.id,
+        ]
     )
 
-    // The chart config itself has an id field that should store the id of the chart - update the chart now so this is true
+    // The chart config itself has an id field that should store the id of the
+    // chart - update the chart now so this is true
     const chartId = result.insertId
     patchConfig.id = chartId
     fullConfig.id = chartId
     await db.knexRaw(
         knex,
         `-- sql
-            UPDATE chart_configs cc
-            JOIN charts c ON c.configId = cc.id
-            SET
-                cc.patch=JSON_SET(cc.patch, '$.id', ?),
-                cc.full=JSON_SET(cc.full, '$.id', ?)
-            WHERE c.id = ?
+            UPDATE chart_configs
+            SET config = JSON_SET(config, '$.id', ?)
+            WHERE id IN (?, ?)
         `,
-        [chartId, chartId, chartId]
+        [chartId, chartConfigId, patchConfigId]
     )
 
     await retrieveChartConfigFromDbAndSaveToR2(knex, chartConfigId)
@@ -355,20 +351,24 @@ const updateExistingChart = async (
     const patchConfig = diffGrapherConfigs(config, parent?.config ?? {})
     const fullConfig = mergeGrapherConfigs(parent?.config ?? {}, patchConfig)
 
-    const chartConfigIdRow = await db.knexRawFirst<
-        Pick<DbPlainChart, "configId">
-    >(knex, `SELECT configId FROM charts WHERE id = ?`, [chartId])
+    const chartRow = await db.knexRawFirst<
+        Pick<DbPlainChart, "configId" | "patchConfigId">
+    >(knex, `SELECT configId, patchConfigId FROM charts WHERE id = ?`, [
+        chartId,
+    ])
 
-    if (!chartConfigIdRow)
-        throw new JsonError(`No chart config found for id ${chartId}`, 404)
+    if (!chartRow) throw new JsonError(`No chart found for id ${chartId}`, 404)
 
     const now = new Date()
 
-    const { chartConfigId } = await updateChartConfigInDbAndR2(
+    const { chartConfigId } = await updateChartConfigPairInDbAndR2(
         knex,
-        chartConfigIdRow.configId,
-        patchConfig,
-        fullConfig,
+        {
+            configId: chartRow.configId,
+            patchConfigId: chartRow.patchConfigId,
+            config: fullConfig,
+            patchConfig,
+        },
         now
     )
 
@@ -579,10 +579,10 @@ export async function updateGrapherConfigsInR2(
         ...updatedMultiDimViews,
     ].map(({ chartConfigId }) => chartConfigId)
     const builder = knex<DbRawChartConfig>(ChartConfigsTableName)
-        .select("id", "full", "fullMd5")
+        .select("id", "config", "configMd5")
         .whereIn("id", idsToUpdate)
-    for await (const { id, full, fullMd5 } of builder.stream()) {
-        await saveGrapherConfigToR2ByUUID(id, full, fullMd5)
+    for await (const { id, config, configMd5 } of builder.stream()) {
+        await saveGrapherConfigToR2ByUUID(id, config, configMd5)
     }
 }
 
@@ -599,7 +599,7 @@ export async function getChartsJson(
             FROM charts
             JOIN chart_configs ON chart_configs.id = charts.configId
             JOIN users lastEditedByUser ON lastEditedByUser.id = charts.lastEditedByUserId
-            LEFT JOIN analytics_grapher_views agv ON (agv.grapher_slug = chart_configs.slug AND chart_configs.full ->> '$.isPublished' = "true")
+            LEFT JOIN analytics_grapher_views agv ON (agv.grapher_slug = chart_configs.slug AND chart_configs.config ->> '$.isPublished' = "true")
             LEFT JOIN users publishedByUser ON publishedByUser.id = charts.publishedByUserId
             LEFT JOIN chart_references_view crv ON crv.chartId = charts.id
             ORDER BY charts.lastEditedAt DESC LIMIT ?
@@ -730,7 +730,7 @@ export async function getChartViewsJson(
             FROM analytics_grapher_views v
             JOIN chart_configs cc
                 ON cc.slug = v.grapher_slug
-                AND cc.full ->> "$.isPublished" = "true"
+                AND cc.config ->> "$.isPublished" = "true"
             JOIN charts c ON c.configId = cc.id
         ) ranked ON ranked.grapher_slug = v.grapher_slug
         WHERE v.grapher_slug = ?`,
@@ -871,32 +871,27 @@ export async function deleteChart(
         chart.id,
     ])
 
-    const row = await db.knexRawFirst<Pick<DbPlainChart, "configId">>(
-        trx,
-        `SELECT configId FROM charts WHERE id = ?`,
-        [chart.id]
-    )
-    if (!row || !row.configId)
+    const chartRow = await db.knexRawFirst<
+        Pick<DbPlainChart, "configId" | "patchConfigId">
+    >(trx, `SELECT configId, patchConfigId FROM charts WHERE id = ?`, [
+        chart.id,
+    ])
+    if (!chartRow)
         throw new JsonError(`No chart config found for id ${chart.id}`, 404)
-    if (row) {
-        await db.knexRaw(trx, `DELETE FROM charts WHERE id=?`, [chart.id])
-        await db.knexRaw(trx, `DELETE FROM chart_configs WHERE id=?`, [
-            row.configId,
-        ])
-    }
 
-    if (chart.isPublished)
+    await db.knexRaw(trx, `DELETE FROM charts WHERE id=?`, [chart.id])
+    await deleteChartConfigPairFromDbAndR2(trx, chartRow)
+
+    if (chart.isPublished) {
         await triggerStaticBuild(
             res.locals.user,
             `Deleting chart ${chart.slug}`
         )
-
-    await deleteGrapherConfigFromR2ByUUID(row.configId)
-    if (chart.isPublished)
         await deleteGrapherConfigFromR2(
             R2GrapherConfigDirectory.publishedGrapherBySlug,
             `${chart.slug}.json`
         )
+    }
 
     return { success: true }
 }

--- a/adminSiteServer/apiRoutes/dataInsights.ts
+++ b/adminSiteServer/apiRoutes/dataInsights.ts
@@ -44,7 +44,7 @@ type DataInsightRow = Pick<
         gdocId: DbRawPostGdoc["id"]
         narrativeChartId?: DbPlainNarrativeChart["id"]
         narrativeChartConfigId?: DbPlainNarrativeChart["chartConfigId"]
-        chartConfig?: DbRawChartConfig["full"]
+        chartConfig?: DbRawChartConfig["config"]
         imageId?: DbRawImage["id"]
         tags?: MinimalTag[]
     }
@@ -106,10 +106,10 @@ async function getAllDataInsightIndexItemsOrderedByUpdatedAt(
 
         -- only consider published stand-alone charts since we join by slug which is only unique for published charts
         WITH published_charts AS (
-            SELECT cc.id, cc.slug, cc.full
+            SELECT cc.id, cc.slug, cc.config
             FROM chart_configs cc
             JOIN charts c ON c.configId = cc.id
-            WHERE cc.full ->> '$.isPublished' = 'true'
+            WHERE cc.config ->> '$.isPublished' = 'true'
         )
 
         SELECT
@@ -126,7 +126,7 @@ async function getAllDataInsightIndexItemsOrderedByUpdatedAt(
             nc.chartConfigId AS narrativeChartConfigId,
 
             -- chart config (prefer narrative charts over grapher URLs)
-            COALESCE(cc_narrativeChart.full, cc_grapherUrl.full) AS chartConfig,
+            COALESCE(cc_narrativeChart.config, cc_grapherUrl.config) AS chartConfig,
 
             -- image fields
             i.id AS imageId,

--- a/adminSiteServer/apiRoutes/datasets.ts
+++ b/adminSiteServer/apiRoutes/datasets.ts
@@ -164,7 +164,7 @@ export async function getDataset(
                     cd.variableId,
                     cd.chartId,
                     cc.slug,
-                    cc.full->>'$.title' AS title
+                    cc.config->>'$.title' AS title
                 FROM chart_dimensions cd
                 JOIN charts c ON c.id = cd.chartId
                 JOIN chart_configs cc ON cc.id = c.configId
@@ -194,7 +194,7 @@ export async function getDataset(
                 JOIN chart_configs cc ON cc.id = mdxcc.chartConfigId
                 JOIN multi_dim_data_pages mdp ON mdp.id = mdxcc.multiDimId
                 JOIN JSON_TABLE(
-                    cc.full,
+                    cc.config,
                     '$.dimensions[*]' COLUMNS (variableId INT PATH '$.variableId')
                 ) jt ON jt.variableId IS NOT NULL
                 WHERE jt.variableId IN (?)
@@ -327,7 +327,7 @@ export async function getDataset(
             JOIN variables AS v ON cd.variableId = v.id
             JOIN users lastEditedByUser ON lastEditedByUser.id = charts.lastEditedByUserId
             LEFT JOIN users publishedByUser ON publishedByUser.id = charts.publishedByUserId
-            LEFT JOIN analytics_grapher_views agv ON (agv.grapher_slug = chart_configs.slug AND chart_configs.full ->> '$.isPublished' = "true")
+            LEFT JOIN analytics_grapher_views agv ON (agv.grapher_slug = chart_configs.slug AND chart_configs.config ->> '$.isPublished' = "true")
             LEFT JOIN chart_references_view crv ON crv.chartId = charts.id
             WHERE v.datasetId = ?
             GROUP BY charts.id, agv.views_365d, crv.narrativeChartsCount, crv.referencesCount
@@ -554,10 +554,10 @@ export async function republishCharts(
             trx,
             `-- sql
                 UPDATE chart_configs cc
-                JOIN charts c ON c.configId = cc.id
+                JOIN charts c
+                    ON cc.id IN (c.configId, c.patchConfigId)
                 SET
-                    cc.patch = JSON_SET(cc.patch, "$.version", cc.patch->"$.version" + 1),
-                    cc.full = JSON_SET(cc.full, "$.version", cc.full->"$.version" + 1),
+                    cc.config = JSON_SET(cc.config, "$.version", cc.config->"$.version" + 1),
                     cc.updatedAt = ?,
                     c.updatedAt = ?
                 WHERE c.id IN (

--- a/adminSiteServer/apiRoutes/narrativeCharts.ts
+++ b/adminSiteServer/apiRoutes/narrativeCharts.ts
@@ -31,10 +31,10 @@ import {
 } from "../../adminShared/AdminTypes.js"
 import { expectInt } from "../../serverUtils/serverUtil.js"
 import {
-    saveNewChartConfigInDbAndR2,
-    updateChartConfigInDbAndR2,
+    deleteChartConfigPairFromDbAndR2,
+    saveNewChartConfigPairInDbAndR2,
+    updateChartConfigPairInDbAndR2,
 } from "../chartConfigHelpers.js"
-import { deleteGrapherConfigFromR2ByUUID } from "../../serverUtils/r2/chartConfigR2Helpers.js"
 
 import {
     isKebabCase,
@@ -46,7 +46,7 @@ import { Request } from "../authentication.js"
 import { HandlerResponse } from "../FunctionalRouter.js"
 import { getPublishedLinksTo } from "../../db/model/Link.js"
 import { triggerStaticBuild } from "../../baker/GrapherBakingUtils.js"
-import { getChartConfigById as _getChartConfigById } from "../../db/model/ChartConfigs.js"
+import { getChartConfigByUUID } from "../../db/model/ChartConfigs.js"
 import { narrativeChartExists } from "../../db/model/NarrativeChart.js"
 import { getMultiDimDataPageById } from "../../db/model/MultiDimDataPage.js"
 
@@ -98,16 +98,13 @@ function makeParentUrl(
     return null
 }
 
-async function getChartConfigById(
+async function expectChartConfigByUUID(
     trx: db.KnexReadonlyTransaction,
-    chartConfigId: string
+    id: string
 ) {
-    const chartConfig = await _getChartConfigById(trx, chartConfigId)
+    const chartConfig = await getChartConfigByUUID(trx, id)
     if (!chartConfig) {
-        throw new JsonError(
-            `No chart config found for id ${chartConfigId}`,
-            404
-        )
+        throw new JsonError(`No chart config found for id ${id}`, 404)
     }
     return chartConfig
 }
@@ -117,7 +114,7 @@ async function getChartConfigByMultiDimXChartConfigId(
     multiDimXChartConfigId: number
 ) {
     const row = await trx<DbInsertChartConfig>(ChartConfigsTableName)
-        .select("full")
+        .select("config")
         .join(
             MultiDimXChartConfigsTableName,
             `${ChartConfigsTableName}.id`,
@@ -131,7 +128,7 @@ async function getChartConfigByMultiDimXChartConfigId(
             404
         )
     }
-    return parseChartConfig(row.full)
+    return parseChartConfig(row.config)
 }
 
 async function getViewDimensions(
@@ -198,14 +195,14 @@ export async function getNarrativeCharts(
             nc.updatedAt,
             u.fullName as lastEditedByUser,
             nc.chartConfigId,
-            cc.full ->> "$.title" as title,
+            cc.config ->> "$.title" as title,
             nc.parentChartId,
             nc.parentMultiDimXChartConfigId,
             nc.queryParamsForParentChart,
             CASE
-                WHEN nc.parentChartId IS NOT NULL THEN pcc1.full ->> "$.title"
+                WHEN nc.parentChartId IS NOT NULL THEN pcc1.config ->> "$.title"
                 ELSE COALESCE(
-                    pcc2.full ->> "$.title",
+                    pcc2.config ->> "$.title",
                     mddp.config ->> "$.title.title",
                     ''
                 )
@@ -290,15 +287,16 @@ export async function getNarrativeChartById(
             nc.updatedAt,
             u.fullName as lastEditedByUser,
             nc.chartConfigId,
-            cc.full as configFull,
-            cc.patch as configPatch,
+            cc.config as configFull,
+            cc_patch.config as configPatch,
             nc.parentChartId,
             nc.parentMultiDimXChartConfigId as parentChartConfigId,
-            pcc.full as parentConfigFull,
+            pcc.config as parentConfigFull,
             mddp.catalogPath as parentCatalogPath,
             nc.queryParamsForParentChart
         FROM narrative_charts nc
         JOIN chart_configs cc ON nc.chartConfigId = cc.id
+        JOIN chart_configs cc_patch ON nc.patchConfigId = cc_patch.id
         LEFT JOIN charts pc ON nc.parentChartId = pc.id
         LEFT JOIN multi_dim_x_chart_configs mdxcc ON nc.parentMultiDimXChartConfigId = mdxcc.id
         LEFT JOIN multi_dim_data_pages mddp ON mdxcc.multiDimId = mddp.id
@@ -352,12 +350,11 @@ async function createNarrativeChartFromChart(
             parentConfig,
             config
         )
-    const { chartConfigId } = await saveNewChartConfigInDbAndR2(
-        trx,
-        undefined,
-        patchConfig,
-        fullConfig
-    )
+    const { chartConfigId, patchConfigId } =
+        await saveNewChartConfigPairInDbAndR2(trx, {
+            config: fullConfig,
+            patchConfig,
+        })
     const [narrativeChartId] = await trx<DbInsertNarrativeChart>(
         NarrativeChartsTableName
     ).insert({
@@ -365,6 +362,7 @@ async function createNarrativeChartFromChart(
         parentChartId,
         lastEditedByUserId: userId,
         chartConfigId,
+        patchConfigId,
         queryParamsForParentChart: JSON.stringify(queryParams),
     })
     return { narrativeChartId, success: true }
@@ -380,10 +378,13 @@ async function createNarrativeChartFromMultiDimView(
     | { narrativeChartId: number; success: boolean }
     | { success: false; errorMsg: string }
 > {
-    const parentChartConfig = await getChartConfigById(trx, parentChartConfigId)
+    const parentChartConfig = await expectChartConfigByUUID(
+        trx,
+        parentChartConfigId
+    )
     const { patchConfig, fullConfig, queryParams } =
         await createPatchConfigAndQueryParamsForNarrativeChart(
-            parentChartConfig.full,
+            parentChartConfig,
             config
         )
     const multiDimXChartConfig = await trx<DbPlainMultiDimXChartConfig>(
@@ -399,12 +400,11 @@ async function createNarrativeChartFromMultiDimView(
         )
     }
     const viewDimensions = await getViewDimensions(trx, multiDimXChartConfig.id)
-    const { chartConfigId } = await saveNewChartConfigInDbAndR2(
-        trx,
-        undefined,
-        patchConfig,
-        fullConfig
-    )
+    const { chartConfigId, patchConfigId } =
+        await saveNewChartConfigPairInDbAndR2(trx, {
+            config: fullConfig,
+            patchConfig,
+        })
     const [narrativeChartId] = await trx<DbInsertNarrativeChart>(
         NarrativeChartsTableName
     ).insert({
@@ -412,6 +412,7 @@ async function createNarrativeChartFromMultiDimView(
         lastEditedByUserId: userId,
         parentMultiDimXChartConfigId: multiDimXChartConfig.id,
         chartConfigId,
+        patchConfigId,
         queryParamsForParentChart: JSON.stringify({
             ...queryParams,
             ...viewDimensions,
@@ -497,6 +498,7 @@ export async function updateNarrativeChart(
             "parentChartId",
             "parentMultiDimXChartConfigId",
             "chartConfigId",
+            "patchConfigId",
             "name"
         )
         .where({ id })
@@ -538,12 +540,12 @@ export async function updateNarrativeChart(
         )
     }
 
-    await updateChartConfigInDbAndR2(
-        trx,
-        existingRow.chartConfigId,
+    await updateChartConfigPairInDbAndR2(trx, {
+        configId: existingRow.chartConfigId,
+        patchConfigId: existingRow.patchConfigId,
+        config: fullConfig,
         patchConfig,
-        fullConfig
-    )
+    })
 
     await trx
         .table(NarrativeChartsTableName)
@@ -579,19 +581,17 @@ export async function deleteNarrativeChart(
 ) {
     const id = expectInt(req.params.id)
 
-    const {
-        name,
-        chartConfigId,
-    }: { name: string | undefined; chartConfigId: string | undefined } =
-        await trx(NarrativeChartsTableName)
-            .select("name", "chartConfigId")
-            .where({ id })
-            .first()
-            .then((row) => row ?? {})
+    const narrativeChart = await trx<DbPlainNarrativeChart>(
+        NarrativeChartsTableName
+    )
+        .select("name", "chartConfigId", "patchConfigId")
+        .where({ id })
+        .first()
 
-    if (!chartConfigId || !name) {
+    if (!narrativeChart) {
         throw new JsonError(`No narrative chart found for id ${id}`, 404)
     }
+    const { name, chartConfigId, patchConfigId } = narrativeChart
 
     const references = await getPublishedLinksTo(
         trx,
@@ -609,10 +609,10 @@ export async function deleteNarrativeChart(
     }
 
     await trx.table(NarrativeChartsTableName).where({ id }).delete()
-
-    await deleteGrapherConfigFromR2ByUUID(chartConfigId)
-
-    await trx.table(ChartConfigsTableName).where({ id: chartConfigId }).delete()
+    await deleteChartConfigPairFromDbAndR2(trx, {
+        configId: chartConfigId,
+        patchConfigId,
+    })
 
     return { success: true }
 }

--- a/adminSiteServer/apiRoutes/tags.ts
+++ b/adminSiteServer/apiRoutes/tags.ts
@@ -128,7 +128,7 @@ export async function getTagById(
                 LEFT JOIN chart_tags ct ON ct.chartId=charts.id
                 JOIN users lastEditedByUser ON lastEditedByUser.id = charts.lastEditedByUserId
                 LEFT JOIN users publishedByUser ON publishedByUser.id = charts.publishedByUserId
-                LEFT JOIN analytics_grapher_views agv ON (agv.grapher_slug = chart_configs.slug AND chart_configs.full ->> '$.isPublished' = "true")
+                LEFT JOIN analytics_grapher_views agv ON (agv.grapher_slug = chart_configs.slug AND chart_configs.config ->> '$.isPublished' = "true")
                 LEFT JOIN chart_references_view crv ON crv.chartId = charts.id
                 WHERE ct.tagId ${tagId === UNCATEGORIZED_TAG_ID ? "IS NULL" : "= ?"}
                 GROUP BY charts.id, agv.views_365d, crv.narrativeChartsCount, crv.referencesCount

--- a/adminSiteServer/apiRoutes/variables.ts
+++ b/adminSiteServer/apiRoutes/variables.ts
@@ -13,6 +13,8 @@ import {
     GrapherInterface,
     OwidVariableWithSource,
     parseChartConfig,
+    ChartConfigsTableName,
+    R2GrapherConfigDirectory,
 } from "@ourworldindata/types"
 import {
     fetchS3DataValuesByPath,
@@ -42,7 +44,10 @@ import {
 } from "../../db/model/Chart.js"
 import { expectInt } from "../../serverUtils/serverUtil.js"
 import { triggerStaticBuild } from "../../baker/GrapherBakingUtils.js"
-import { updateGrapherConfigsInR2 } from "./charts.js"
+import {
+    saveGrapherConfigToR2,
+    saveGrapherConfigToR2ByUUID,
+} from "../../serverUtils/r2/chartConfigR2Helpers.js"
 import { Request } from "../authentication.js"
 import { HandlerResponse } from "../FunctionalRouter.js"
 
@@ -589,4 +594,32 @@ export async function getVariablesVariableIdChartsJson(
         isInheritanceEnabled: chart.isInheritanceEnabled,
         isPublished: chart.isPublished,
     }))
+}
+
+async function updateGrapherConfigsInR2(
+    knex: db.KnexReadonlyTransaction,
+    updatedCharts: { chartConfigId: string; isPublished: boolean }[],
+    updatedMultiDimViews: { chartConfigId: string; isPublished: boolean }[]
+): Promise<void> {
+    const publishedChartConfigIds = new Set(
+        updatedCharts
+            .filter(({ isPublished }) => isPublished)
+            .map(({ chartConfigId }) => chartConfigId)
+    )
+    const idsToUpdate = [...updatedCharts, ...updatedMultiDimViews]
+        .filter(({ isPublished }) => isPublished)
+        .map(({ chartConfigId }) => chartConfigId)
+    const builder = knex<DbRawChartConfig>(ChartConfigsTableName)
+        .select("id", "slug", "config", "configMd5")
+        .whereIn("id", idsToUpdate)
+    for await (const { id, slug, config, configMd5 } of builder.stream()) {
+        await saveGrapherConfigToR2ByUUID(id, config, configMd5)
+        if (publishedChartConfigIds.has(id) && slug)
+            await saveGrapherConfigToR2(
+                config,
+                R2GrapherConfigDirectory.publishedGrapherBySlug,
+                `${slug}.json`,
+                configMd5
+            )
+    }
 }

--- a/adminSiteServer/apiRoutes/variables.ts
+++ b/adminSiteServer/apiRoutes/variables.ts
@@ -20,6 +20,7 @@ import {
     getAllChartsForIndicator,
     getLatestVariableIdsByCatalogPath,
     getGrapherConfigsForVariable,
+    mergeVariableChartConfigs,
     getMergedGrapherConfigForVariable,
     searchVariables,
     updateAllChartsThatInheritFromIndicator,
@@ -39,7 +40,6 @@ import {
     oldChartFieldList,
     assignTagsForCharts,
 } from "../../db/model/Chart.js"
-import { updateExistingFullConfig } from "../../db/model/ChartConfigs.js"
 import { expectInt } from "../../serverUtils/serverUtil.js"
 import { triggerStaticBuild } from "../../baker/GrapherBakingUtils.js"
 import { updateGrapherConfigsInR2 } from "./charts.js"
@@ -215,7 +215,7 @@ export async function getVariablesGrapherConfigETLPatchConfigJson(
     if (!variable) {
         throw new JsonError(`Variable with id ${variableId} not found`, 500)
     }
-    return variable.etl?.patchConfig ?? {}
+    return variable.etl?.config ?? {}
 }
 
 export async function getVariablesGrapherConfigAdminPatchConfigJson(
@@ -228,7 +228,7 @@ export async function getVariablesGrapherConfigAdminPatchConfigJson(
     if (!variable) {
         throw new JsonError(`Variable with id ${variableId} not found`, 500)
     }
-    return variable.admin?.patchConfig ?? {}
+    return variable.admin?.config ?? {}
 }
 
 export async function getVariablesMergedGrapherConfigJson(
@@ -262,17 +262,17 @@ export async function getVariablesVariableIdJson(
     const rawCharts = await db.knexRaw<
         OldChartFieldList & {
             isInheritanceEnabled: DbPlainChart["isInheritanceEnabled"]
-            config: DbRawChartConfig["full"]
+            config: DbRawChartConfig["config"]
         }
     >(
         trx,
         `-- sql
-                SELECT ${oldChartFieldList}, charts.isInheritanceEnabled, chart_configs.full AS config
+                SELECT ${oldChartFieldList}, charts.isInheritanceEnabled, chart_configs.config AS config
                 FROM charts
                 JOIN chart_configs ON chart_configs.id = charts.configId
                 JOIN users lastEditedByUser ON lastEditedByUser.id = charts.lastEditedByUserId
                 LEFT JOIN users publishedByUser ON publishedByUser.id = charts.publishedByUserId
-                LEFT JOIN analytics_grapher_views agv ON (agv.grapher_slug = chart_configs.slug AND chart_configs.full ->> '$.isPublished' = "true")
+                LEFT JOIN analytics_grapher_views agv ON (agv.grapher_slug = chart_configs.slug AND chart_configs.config ->> '$.isPublished' = "true")
                 LEFT JOIN chart_references_view crv ON crv.chartId = charts.id
                 JOIN chart_dimensions cd ON cd.chartId = charts.id
                 WHERE cd.variableId = ?
@@ -296,11 +296,12 @@ export async function getVariablesVariableIdJson(
         trx,
         variableId
     )
-    const grapherConfigETL = variableWithConfigs?.etl?.patchConfig
-    const grapherConfigAdmin = variableWithConfigs?.admin?.patchConfig
-    const mergedGrapherConfig =
-        variableWithConfigs?.admin?.fullConfig ??
-        variableWithConfigs?.etl?.fullConfig
+    const grapherConfigETL = variableWithConfigs?.etl?.config
+    const grapherConfigAdmin = variableWithConfigs?.admin?.config
+    const mergedGrapherConfig = mergeVariableChartConfigs({
+        etl: grapherConfigETL,
+        admin: grapherConfigAdmin,
+    })
 
     // add the variable's display field to the merged grapher config
     if (mergedGrapherConfig) {
@@ -402,7 +403,7 @@ export async function deleteVariablesVariableIdGrapherConfigETL(
         trx,
         `-- sql
                 UPDATE variables
-                SET grapherConfigIdETL = NULL
+                SET patchConfigIdETL = NULL
                 WHERE id = ?
             `,
         [variableId]
@@ -418,17 +419,8 @@ export async function deleteVariablesVariableIdGrapherConfigETL(
         [variable.etl.configId]
     )
 
-    // update admin config if there is one
-    if (variable.admin) {
-        await updateExistingFullConfig(trx, {
-            configId: variable.admin.configId,
-            config: variable.admin.patchConfig,
-            updatedAt: now,
-        })
-    }
-
     const updates = {
-        patchConfigAdmin: variable.admin?.patchConfig,
+        patchConfigAdmin: variable.admin?.config,
         updatedAt: now,
     }
     const updatedCharts = await updateAllChartsThatInheritFromIndicator(
@@ -531,7 +523,7 @@ export async function deleteVariablesVariableIdGrapherConfigAdmin(
         trx,
         `-- sql
                 UPDATE variables
-                SET grapherConfigIdAdmin = NULL
+                SET patchConfigIdAdmin = NULL
                 WHERE id = ?
             `,
         [variableId]
@@ -548,7 +540,7 @@ export async function deleteVariablesVariableIdGrapherConfigAdmin(
     )
 
     const updates = {
-        patchConfigETL: variable.etl?.patchConfig,
+        patchConfigETL: variable.etl?.config,
         updatedAt: now,
     }
     const updatedCharts = await updateAllChartsThatInheritFromIndicator(

--- a/adminSiteServer/chartConfigHelpers.ts
+++ b/adminSiteServer/chartConfigHelpers.ts
@@ -1,17 +1,29 @@
 import {
     ChartConfigsTableName,
-    DbInsertChartConfig,
     DbRawChartConfig,
     GrapherInterface,
     R2GrapherConfigDirectory,
-    serializeChartConfig,
 } from "@ourworldindata/types"
-import { v7 as uuidv7 } from "uuid"
 import * as db from "../db/db.js"
 import {
+    insertChartConfig,
+    updateChartConfig,
+} from "../db/model/ChartConfigs.js"
+import {
+    deleteGrapherConfigFromR2ByUUID,
     saveGrapherConfigToR2,
     saveGrapherConfigToR2ByUUID,
 } from "../serverUtils/r2/chartConfigR2Helpers.js"
+
+export interface ChartConfigPair {
+    config: GrapherInterface
+    patchConfig: GrapherInterface
+}
+
+interface ChartConfigPairIds {
+    configId: string
+    patchConfigId: string
+}
 
 /**
  * One particular detail of of MySQL's JSON support is that MySQL _normalizes_ JSON when storing it.
@@ -30,16 +42,17 @@ export const retrieveChartConfigFromDbAndSaveToR2 = async (
     chartConfigId: string,
     r2Path?: { directory: R2GrapherConfigDirectory; filename: string }
 ) => {
-    // We need to get the full config and the md5 hash from the database instead of
+    // We need to get the config and the md5 hash from the database instead of
     // computing our own md5 hash because MySQL normalizes JSON and our
     // client computed md5 would be different from the ones computed by and stored in R2
-    const fullConfigMd5: Pick<DbRawChartConfig, "full" | "fullMd5"> =
-        await knex(ChartConfigsTableName)
-            .select("full", "fullMd5")
-            .where({ id: chartConfigId })
-            .first()
+    const row: Pick<DbRawChartConfig, "config" | "configMd5"> = await knex(
+        ChartConfigsTableName
+    )
+        .select("config", "configMd5")
+        .where({ id: chartConfigId })
+        .first()
 
-    if (!fullConfigMd5)
+    if (!row)
         throw new Error(
             `Chart config not found in the database! id=${chartConfigId}`
         )
@@ -47,59 +60,84 @@ export const retrieveChartConfigFromDbAndSaveToR2 = async (
     if (!r2Path) {
         await saveGrapherConfigToR2ByUUID(
             chartConfigId,
-            fullConfigMd5.full,
-            fullConfigMd5.fullMd5
+            row.config,
+            row.configMd5
         )
     } else {
         await saveGrapherConfigToR2(
-            fullConfigMd5.full,
+            row.config,
             r2Path.directory,
             r2Path.filename,
-            fullConfigMd5.fullMd5
+            row.configMd5
         )
     }
 
     return {
         chartConfigId,
-        fullConfig: fullConfigMd5.full,
-        fullConfigMd5: fullConfigMd5.fullMd5,
+        config: row.config,
+        configMd5: row.configMd5,
     }
 }
 
 export const updateChartConfigInDbAndR2 = async (
     knex: db.KnexReadWriteTransaction,
-    chartConfigId: string,
-    patchConfig: GrapherInterface,
-    fullConfig: GrapherInterface,
+    configId: string,
+    config: GrapherInterface,
     updatedAt: Date = new Date()
 ) => {
-    await knex<DbInsertChartConfig>(ChartConfigsTableName)
-        .update({
-            patch: serializeChartConfig(patchConfig),
-            full: serializeChartConfig(fullConfig),
-            updatedAt, // It's not updated automatically in the DB.
-        })
-        .where({ id: chartConfigId })
-
-    return retrieveChartConfigFromDbAndSaveToR2(knex, chartConfigId)
+    await updateChartConfig(knex, { configId, config, updatedAt })
+    return retrieveChartConfigFromDbAndSaveToR2(knex, configId)
 }
 
-export const saveNewChartConfigInDbAndR2 = async (
+/** Inserts a chart config pair without publishing */
+export const insertChartConfigPair = async (
     knex: db.KnexReadWriteTransaction,
-    chartConfigId: string | undefined,
-    patchConfig: GrapherInterface,
-    fullConfig: GrapherInterface,
+    { config, patchConfig }: ChartConfigPair,
     now: Date = new Date()
-) => {
-    chartConfigId ??= uuidv7()
-
-    await knex<DbInsertChartConfig>(ChartConfigsTableName).insert({
-        id: chartConfigId,
-        patch: serializeChartConfig(patchConfig),
-        full: serializeChartConfig(fullConfig),
+): Promise<{ chartConfigId: string; patchConfigId: string }> => {
+    const chartConfigId = await insertChartConfig(knex, {
+        config,
         createdAt: now,
         updatedAt: now,
     })
+    const patchConfigId = await insertChartConfig(knex, {
+        config: patchConfig,
+        createdAt: now,
+        updatedAt: now,
+    })
+    return { chartConfigId, patchConfigId }
+}
 
-    return retrieveChartConfigFromDbAndSaveToR2(knex, chartConfigId)
+export const saveNewChartConfigPairInDbAndR2 = async (
+    knex: db.KnexReadWriteTransaction,
+    pair: ChartConfigPair,
+    now: Date = new Date()
+) => {
+    const ids = await insertChartConfigPair(knex, pair, now)
+    await retrieveChartConfigFromDbAndSaveToR2(knex, ids.chartConfigId)
+    return ids
+}
+
+export const updateChartConfigPairInDbAndR2 = async (
+    knex: db.KnexReadWriteTransaction,
+    pair: ChartConfigPair & ChartConfigPairIds,
+    now: Date = new Date()
+) => {
+    await updateChartConfig(knex, {
+        configId: pair.patchConfigId,
+        config: pair.patchConfig,
+        updatedAt: now,
+    })
+    return updateChartConfigInDbAndR2(knex, pair.configId, pair.config, now)
+}
+
+export const deleteChartConfigPairFromDbAndR2 = async (
+    knex: db.KnexReadWriteTransaction,
+    pair: ChartConfigPairIds
+) => {
+    await knex(ChartConfigsTableName)
+        .whereIn("id", [pair.configId, pair.patchConfigId])
+        .delete()
+    // Only the resolved config was published
+    await deleteGrapherConfigFromR2ByUUID(pair.configId)
 }

--- a/adminSiteServer/mockSiteRouter.ts
+++ b/adminSiteServer/mockSiteRouter.ts
@@ -30,13 +30,12 @@ import {
 import { expectInt, renderToHtmlPage } from "../serverUtils/serverUtil.js"
 import { makeSitemap } from "../baker/sitemap.js"
 import { getChartConfigBySlug } from "../db/model/Chart.js"
+import { getChartConfigByUUID } from "../db/model/ChartConfigs.js"
 import { ExplorerAdminServer } from "../explorerAdminServer/ExplorerAdminServer.js"
 import { getVariableData, getVariableMetadata } from "../db/model/Variable.js"
 import { MultiEmbedderTestPage } from "../site/multiembedder/MultiEmbedderTestPage.js"
 import {
-    DbRawChartConfig,
     JsonError,
-    parseChartConfig,
     TombstonePageData,
     gdocUrlRegex,
     OwidGdocMinimalPostInterface,
@@ -225,13 +224,8 @@ getPlainRouteWithROTransaction(
     mockSiteRouter,
     "/grapher/by-uuid/:uuid.config.json",
     async (req, res, trx) => {
-        const chartRow = await db.knexRawFirst<Pick<DbRawChartConfig, "full">>(
-            trx,
-            "SELECT full FROM chart_configs WHERE id = ?",
-            [req.params.uuid]
-        )
-        if (!chartRow) throw new JsonError("No such chart", 404)
-        const config = parseChartConfig(chartRow.full)
+        const config = await getChartConfigByUUID(trx, req.params.uuid)
+        if (!config) throw new JsonError("No such chart", 404)
         res.json(config)
     }
 )
@@ -261,13 +255,9 @@ getPlainRouteWithROTransaction(
                 multiDim.config,
                 searchParams
             )
-            const configRow = await db.knexRawFirst<
-                Pick<DbRawChartConfig, "full">
-            >(trx, "SELECT full FROM chart_configs WHERE id = ?", [
-                view.fullConfigId,
-            ])
-            if (configRow) {
-                res.json(parseChartConfig(configRow.full))
+            const config = await getChartConfigByUUID(trx, view.fullConfigId)
+            if (config) {
+                res.json(config)
                 return
             }
         }

--- a/adminSiteServer/multiDim.ts
+++ b/adminSiteServer/multiDim.ts
@@ -21,7 +21,7 @@ import {
     MultiDimDataPagesTableName,
     MultiDimXChartConfigsTableName,
     MultiDimViewDimensionsTableName,
-    parseChartConfigsRow,
+    parseChartConfig,
     R2GrapherConfigDirectory,
     View,
 } from "@ourworldindata/types"
@@ -43,8 +43,9 @@ import {
     saveMultiDimConfigToR2,
 } from "../serverUtils/r2/chartConfigR2Helpers.js"
 import {
-    saveNewChartConfigInDbAndR2,
+    saveNewChartConfigPairInDbAndR2,
     updateChartConfigInDbAndR2,
+    updateChartConfigPairInDbAndR2,
 } from "./chartConfigHelpers.js"
 
 function catalogPathFromIndicatorEntry(
@@ -164,13 +165,21 @@ async function getViewIdToChartConfigIdMap(
     const rows = await db.knexRaw<DbPlainMultiDimXChartConfig>(
         knex,
         `-- sql
-        SELECT viewId, chartConfigId
+        SELECT viewId, chartConfigId, patchConfigId
         FROM multi_dim_x_chart_configs mdxcc
         JOIN multi_dim_data_pages mddp ON mddp.id = mdxcc.multiDimId
         WHERE mddp.catalogPath = ?`,
         [catalogPath]
     )
-    return new Map(rows.map((row) => [row.viewId, row.chartConfigId]))
+    return new Map(
+        rows.map((row) => [
+            row.viewId,
+            {
+                chartConfigId: row.chartConfigId,
+                patchConfigId: row.patchConfigId,
+            },
+        ])
+    )
 }
 
 async function retrieveMultiDimConfigFromDbAndSaveToR2(
@@ -220,15 +229,26 @@ async function upsertMultiDimConfig(
 
 async function cleanUpOrphanedChartConfigs(
     knex: db.KnexReadWriteTransaction,
-    orphanedChartConfigIds: string[]
+    orphanedViews: { chartConfigId: string; patchConfigId: string }[]
 ) {
+    const chartConfigIds = orphanedViews.map((view) => view.chartConfigId)
+
     await knex<DbPlainMultiDimXChartConfig>(MultiDimXChartConfigsTableName)
-        .whereIn("chartConfigId", orphanedChartConfigIds)
+        .whereIn("chartConfigId", chartConfigIds)
         .delete()
+
     await knex<DbRawChartConfig>(ChartConfigsTableName)
-        .whereIn("id", orphanedChartConfigIds)
+        .whereIn(
+            "id",
+            orphanedViews.flatMap((view) => [
+                view.chartConfigId,
+                view.patchConfigId,
+            ])
+        )
         .delete()
-    for (const id of orphanedChartConfigIds) {
+
+    // Only the resolved config was published
+    for (const id of chartConfigIds) {
         await deleteGrapherConfigFromR2ByUUID(id)
     }
 }
@@ -262,6 +282,7 @@ export async function upsertMultiDim(
 
     const enrichedViews = await Promise.all(
         config.views.map(async (view) => {
+            const viewId = dimensionsToViewId(view.dimensions)
             const variableId = view.indicators.y[0].id
             let viewGrapherConfig: GrapherInterface = {}
             if (view.config) {
@@ -299,69 +320,104 @@ export async function upsertMultiDim(
                 variableConfigs.get(variableId) ?? {},
                 patchGrapherConfig
             )
-            const existingChartConfigId = existingViewIdsToChartConfigIds.get(
-                dimensionsToViewId(view.dimensions)
-            )
-            let chartConfigId
-            if (existingChartConfigId) {
-                chartConfigId = existingChartConfigId
-                await updateChartConfigInDbAndR2(
-                    knex,
-                    chartConfigId,
-                    patchGrapherConfig,
-                    fullGrapherConfig
-                )
+            const existing = existingViewIdsToChartConfigIds.get(viewId)
+            let chartConfigId: string
+            let patchConfigId: string
+            if (existing) {
+                chartConfigId = existing.chartConfigId
+                patchConfigId = existing.patchConfigId
+                await updateChartConfigPairInDbAndR2(knex, {
+                    configId: chartConfigId,
+                    patchConfigId,
+                    config: fullGrapherConfig,
+                    patchConfig: patchGrapherConfig,
+                })
                 reusedChartConfigIds.add(chartConfigId)
                 console.debug(`Chart config updated id=${chartConfigId}`)
             } else {
-                const result = await saveNewChartConfigInDbAndR2(
-                    knex,
-                    undefined,
-                    patchGrapherConfig,
-                    fullGrapherConfig
-                )
-                chartConfigId = result.chartConfigId
+                const ids = await saveNewChartConfigPairInDbAndR2(knex, {
+                    config: fullGrapherConfig,
+                    patchConfig: patchGrapherConfig,
+                })
+                chartConfigId = ids.chartConfigId
+                patchConfigId = ids.patchConfigId
                 await knex(MultiDimViewDimensionsTableName).insert({
                     chartConfigId,
                     dimensions: JSON.stringify(view.dimensions),
                 })
                 console.debug(`Chart config created id=${chartConfigId}`)
             }
-            return { ...view, fullConfigId: chartConfigId }
+            return {
+                viewId,
+                patchConfigId,
+                view: { ...view, fullConfigId: chartConfigId },
+            }
         })
     )
 
-    const orphanedChartConfigIds = existingViewIdsToChartConfigIds
+    const orphanedViews = existingViewIdsToChartConfigIds
         .values()
-        .filter((id) => !reusedChartConfigIds.has(id))
+        .filter((ids) => !reusedChartConfigIds.has(ids.chartConfigId))
         .toArray()
-    await cleanUpOrphanedChartConfigs(knex, orphanedChartConfigIds)
+    await cleanUpOrphanedChartConfigs(knex, orphanedViews)
 
-    const enrichedConfig = { ...config, views: enrichedViews }
+    const enrichedConfig = {
+        ...config,
+        views: enrichedViews.map(({ view }) => view),
+    }
     const multiDimId = await upsertMultiDimConfig(
         knex,
         catalogPath,
         enrichedConfig
     )
-    for (const view of enrichedConfig.views) {
+    for (const { viewId, patchConfigId, view } of enrichedViews) {
         await upsertMultiDimXChartConfigs(knex, {
             multiDimId,
-            viewId: dimensionsToViewId(view.dimensions),
+            viewId,
             variableId: view.indicators.y[0].id,
             chartConfigId: view.fullConfigId,
+            patchConfigId,
         })
     }
     return multiDimId
 }
 
-async function getChartConfigsByIds(
+/** Both configs of the given views, keyed by the view's resolved id */
+async function getViewChartConfigs(
     knex: db.KnexReadonlyTransaction,
-    ids: string[]
+    chartConfigIds: string[]
 ) {
-    const rows = await knex<DbRawChartConfig>(ChartConfigsTableName)
-        .select("id", "patch", "full")
-        .whereIn("id", ids)
-    return new Map(rows.map((row) => [row.id, parseChartConfigsRow(row)]))
+    const rows = await db.knexRaw<{
+        chartConfigId: string
+        patchConfigId: string | null
+        config: DbRawChartConfig["config"]
+        patchConfig: DbRawChartConfig["config"] | null
+    }>(
+        knex,
+        `-- sql
+        SELECT
+            cc.id AS chartConfigId,
+            mdxcc.patchConfigId,
+            cc.config,
+            cc_patch.config AS patchConfig
+        FROM chart_configs cc
+        LEFT JOIN multi_dim_x_chart_configs mdxcc ON mdxcc.chartConfigId = cc.id
+        LEFT JOIN chart_configs cc_patch ON cc_patch.id = mdxcc.patchConfigId
+        WHERE cc.id IN (?)`,
+        [chartConfigIds]
+    )
+    return new Map(
+        rows.map((row) => [
+            row.chartConfigId,
+            {
+                patchConfigId: row.patchConfigId,
+                config: parseChartConfig(row.config),
+                patchConfig: row.patchConfig
+                    ? parseChartConfig(row.patchConfig)
+                    : undefined,
+            },
+        ])
+    )
 }
 
 export async function setMultiDimPublished(
@@ -369,7 +425,7 @@ export async function setMultiDimPublished(
     multiDim: DbEnrichedMultiDimDataPage,
     published: boolean
 ) {
-    const chartConfigs = await getChartConfigsByIds(
+    const viewConfigs = await getViewChartConfigs(
         knex,
         multiDim.config.views.map((view) => view.fullConfigId)
     )
@@ -377,17 +433,27 @@ export async function setMultiDimPublished(
     await Promise.all(
         multiDim.config.views.map(async (view) => {
             const { fullConfigId: chartConfigId } = view
-            const chartConfig = chartConfigs.get(chartConfigId)
-            if (!chartConfig) {
+            const viewConfig = viewConfigs.get(chartConfigId)
+            if (!viewConfig) {
                 throw new JsonError(
                     `Chart config not found id=${chartConfigId}`,
                     404
                 )
             }
-            const { patch, full } = chartConfig
-            patch.isPublished = published
-            full.isPublished = published
-            await updateChartConfigInDbAndR2(knex, chartConfigId, patch, full)
+            const { config, patchConfig, patchConfigId } = viewConfig
+
+            config.isPublished = published
+            if (patchConfigId && patchConfig) {
+                patchConfig.isPublished = published
+                await updateChartConfigPairInDbAndR2(knex, {
+                    configId: chartConfigId,
+                    patchConfigId,
+                    config,
+                    patchConfig,
+                })
+            } else {
+                await updateChartConfigInDbAndR2(knex, chartConfigId, config)
+            }
         })
     )
 

--- a/adminSiteServer/testPageRouter.tsx
+++ b/adminSiteServer/testPageRouter.tsx
@@ -164,7 +164,7 @@ async function propsFromQueryParams(
 
     if (params.type) {
         if (params.type === GRAPHER_MAP_TYPE) {
-            query = query.andWhereRaw(`cc.full->>"$.hasMapTab" = "true"`)
+            query = query.andWhereRaw(`cc.config->>"$.hasMapTab" = "true"`)
             tab ||= GRAPHER_TAB_CONFIG_OPTIONS.map
         } else {
             query = query.andWhereRaw(`cc.chartType = :type`, {
@@ -176,33 +176,35 @@ async function propsFromQueryParams(
 
     if (params.logLinear) {
         query = query.andWhereRaw(
-            `cc.full->>'$.yAxis.canChangeScaleType' = "true" OR cc.full->>'$.xAxis.canChangeScaleType'  = "true"`
+            `cc.config->>'$.yAxis.canChangeScaleType' = "true" OR cc.config->>'$.xAxis.canChangeScaleType'  = "true"`
         )
         tab = GRAPHER_TAB_CONFIG_OPTIONS.chart
     }
 
     if (params.comparisonLines) {
         query = query.andWhereRaw(
-            `cc.full->'$.comparisonLines[0].yEquals' != ''`
+            `cc.config->'$.comparisonLines[0].yEquals' != ''`
         )
         tab = GRAPHER_TAB_CONFIG_OPTIONS.chart
     }
 
     if (params.stackMode) {
-        query = query.andWhereRaw(`cc.full->'$.stackMode' = :stackMode`, {
+        query = query.andWhereRaw(`cc.config->'$.stackMode' = :stackMode`, {
             stackMode: params.stackMode,
         })
         tab = GRAPHER_TAB_CONFIG_OPTIONS.chart
     }
 
     if (params.relativeToggle) {
-        query = query.andWhereRaw(`cc.full->>'$.hideRelativeToggle' = "false"`)
+        query = query.andWhereRaw(
+            `cc.config->>'$.hideRelativeToggle' = "false"`
+        )
         tab = GRAPHER_TAB_CONFIG_OPTIONS.chart
     }
 
     if (params.chartTypeSwitcher) {
         query = query.andWhereRaw(
-            `COALESCE(json_length(cc.full->'$.chartTypes'), 2) > 1`
+            `COALESCE(json_length(cc.config->'$.chartTypes'), 2) > 1`
         )
     }
 
@@ -211,7 +213,7 @@ async function propsFromQueryParams(
         // have a visible categorial legend, and can leave out some that have one.
         // But in practice it seems to work reasonably well.
         query = query.andWhereRaw(
-            `json_length(cc.full->'$.map.colorScale.customCategoryColors') > 1`
+            `json_length(cc.config->'$.map.colorScale.customCategoryColors') > 1`
         )
         tab = GRAPHER_TAB_CONFIG_OPTIONS.map
     }
@@ -235,7 +237,7 @@ async function propsFromQueryParams(
 
     if (params.faceted) {
         query = query.andWhereRaw(
-            `cc.full->>'$.selectedFacetStrategy' != 'none'`
+            `cc.config->>'$.selectedFacetStrategy' != 'none'`
         )
         tab = GRAPHER_TAB_CONFIG_OPTIONS.chart
     }
@@ -244,13 +246,13 @@ async function propsFromQueryParams(
         const mode = params.addCountryMode
         if (mode === EntitySelectionMode.MultipleEntities) {
             query = query.andWhereRaw(
-                `cc.full->'$.addCountryMode' IS NULL OR cc.full->'$.addCountryMode' = :mode`,
+                `cc.config->'$.addCountryMode' IS NULL OR cc.config->'$.addCountryMode' = :mode`,
                 {
                     mode: EntitySelectionMode.MultipleEntities,
                 }
             )
         } else {
-            query = query.andWhereRaw(`cc.full->'$.addCountryMode' = :mode`, {
+            query = query.andWhereRaw(`cc.config->'$.addCountryMode' = :mode`, {
                 mode,
             })
         }
@@ -261,7 +263,7 @@ async function propsFromQueryParams(
     }
 
     if (tab === GRAPHER_TAB_CONFIG_OPTIONS.map) {
-        query = query.andWhereRaw(`cc.full->>"$.hasMapTab" = "true"`)
+        query = query.andWhereRaw(`cc.config->>"$.hasMapTab" = "true"`)
     } else if (tab === GRAPHER_TAB_CONFIG_OPTIONS.chart) {
         query = query.andWhereRaw(`cc.chartType IS NOT NULL`)
     }
@@ -491,11 +493,11 @@ getPlainRouteWithROTransaction(
     async (req, res, trx) => {
         const id = req.params.id
         const chartRaw = await db.knexRawFirst<
-            Pick<DbPlainChart, "id"> & { config: DbRawChartConfig["full"] }
+            Pick<DbPlainChart, "id"> & { config: DbRawChartConfig["config"] }
         >(
             trx,
             `-- sql
-                select ca.id, cc.full as config
+                select ca.id, cc.config as config
                 from charts ca
                 join chart_configs cc
                 on ca.configId = cc.id
@@ -680,10 +682,10 @@ getPlainRouteWithROTransaction(
     testPageRouter,
     "/previews",
     async (req, res, trx) => {
-        const rows = await db.knexRaw<{ config: DbRawChartConfig["full"] }>(
+        const rows = await db.knexRaw<{ config: DbRawChartConfig["config"] }>(
             trx,
             `-- sql
-                SELECT cc.full as config
+                SELECT cc.config as config
                 FROM charts ca
                 JOIN chart_configs cc
                 ON ca.configId = cc.id
@@ -700,10 +702,10 @@ getPlainRouteWithROTransaction(
     testPageRouter,
     "/embedVariants",
     async (req, res, trx) => {
-        const rows = await db.knexRaw<{ config: DbRawChartConfig["full"] }>(
+        const rows = await db.knexRaw<{ config: DbRawChartConfig["config"] }>(
             trx,
             `-- sql
-                SELECT cc.full as config
+                SELECT cc.config as config
                 FROM charts ca
                 JOIN chart_configs cc
                 ON ca.configId = cc.id

--- a/adminSiteServer/tests/charts.test.ts
+++ b/adminSiteServer/tests/charts.test.ts
@@ -44,7 +44,8 @@ describe("Charts API", { timeout: 15000 }, () => {
         const chartCountAfter = await env.getCount(ChartsTableName)
         expect(chartCountAfter).toBe(1)
         const chartConfigsCountAfter = await env.getCount(ChartConfigsTableName)
-        expect(chartConfigsCountAfter).toBe(1)
+        // one for the full config and one for the patch config
+        expect(chartConfigsCountAfter).toBe(2)
 
         const parentConfig = (
             await env.fetchJson(`/charts/${chartId}.parent.json`)
@@ -193,11 +194,7 @@ describe("Indicator-level chart configs", { timeout: 15000 }, () => {
 
         // get inserted configs from the database
         const row = await env.testKnex(ChartConfigsTableName).first()
-        const patchConfigETL = JSON.parse(row.patch)
-        const fullConfigETL = JSON.parse(row.full)
-
-        // for ETL configs, patch and full configs should be the same
-        expect(patchConfigETL).toEqual(fullConfigETL)
+        const patchConfigETL = JSON.parse(row.config)
 
         // check that the dimensions field were added to the config
         const processedTestVariableConfigETL = {
@@ -220,7 +217,7 @@ describe("Indicator-level chart configs", { timeout: 15000 }, () => {
 
         // since no admin-authored config exists, the merged config should be
         // the same as the ETL config
-        expect(mergedGrapherConfig).toEqual(fullConfigETL)
+        expect(mergedGrapherConfig).toEqual(patchConfigETL)
 
         // add an admin-authored config for the variable
         await env.request({
@@ -272,7 +269,7 @@ describe("Indicator-level chart configs", { timeout: 15000 }, () => {
             .testKnex(ChartConfigsTableName)
             .where("id", multiDimView1.chartConfigId)
             .first()
-        expect(JSON.parse(fullViewConfig1.full)).toEqual(
+        expect(JSON.parse(fullViewConfig1.config)).toEqual(
             expectedMergedViewConfig
         )
 
@@ -293,7 +290,7 @@ describe("Indicator-level chart configs", { timeout: 15000 }, () => {
             .testKnex(ChartConfigsTableName)
             .where("id", multiDimView1.chartConfigId)
             .first()
-        expect(JSON.parse(fullViewConfig1Updated.full)).toEqual(
+        expect(JSON.parse(fullViewConfig1Updated.config)).toEqual(
             expectedMergedViewConfigUpdated
         )
 
@@ -304,7 +301,9 @@ describe("Indicator-level chart configs", { timeout: 15000 }, () => {
             .testKnex(ChartConfigsTableName)
             .whereIn("id", [
                 multiDimView1.chartConfigId,
+                multiDimView1.patchConfigId,
                 multiDimView2.chartConfigId,
+                multiDimView2.patchConfigId,
             ])
             .delete()
 
@@ -317,7 +316,7 @@ describe("Indicator-level chart configs", { timeout: 15000 }, () => {
         mergedGrapherConfig = await env.fetchJson(
             `/variables/mergedGrapherConfig/${variableId}.json`
         )
-        expect(mergedGrapherConfig).toEqual(fullConfigETL)
+        expect(mergedGrapherConfig).toEqual(patchConfigETL)
 
         // delete the ETL-authored grapher config we just added
         await env.request({
@@ -510,7 +509,7 @@ describe("Indicator-level chart configs", { timeout: 15000 }, () => {
 
         // get the ETL config from the database
         const row = await env.testKnex(ChartConfigsTableName).first()
-        const fullConfigETL = JSON.parse(row.full)
+        const fullConfigETL = JSON.parse(row.config)
 
         // check the parent of the chart
         const parent = await env.fetchJson(`/charts/${chartId}.parent.json`)
@@ -621,16 +620,23 @@ describe("Indicator-level chart configs", { timeout: 15000 }, () => {
         })
         const chartId = response.chartId
 
-        // helper functions to get the updatedAt timestamp of the chart and its config
-        const chartUpdatedAt = async (): Promise<Date> =>
-            (await env.testKnex(ChartsTableName).first()).updatedAt
-        const configUpdatedAt = async (): Promise<Date> =>
-            (await env.testKnex(ChartConfigsTableName).first()).updatedAt
+        // the chart and both of its config rows share one updatedAt
+        const expectTimestampsInSync = async (): Promise<Date> => {
+            const chart = await env
+                .testKnex(ChartsTableName)
+                .where({ id: chartId })
+                .first()
+            const configs = await env
+                .testKnex(ChartConfigsTableName)
+                .whereIn("id", [chart.configId, chart.patchConfigId])
+            expect(configs.length).toBe(2)
+            expect(chart.updatedAt).not.toBeNull()
+            for (const config of configs)
+                expect(config.updatedAt).toEqual(chart.updatedAt)
+            return chart.updatedAt
+        }
 
-        // verify that both updatedAt timestamps are initialized on create
-        expect(await chartUpdatedAt()).not.toBeNull()
-        expect(await configUpdatedAt()).not.toBeNull()
-        expect(await chartUpdatedAt()).toEqual(await configUpdatedAt())
+        const updatedAtOnCreate = await expectTimestampsInSync()
 
         // update the chart
         await env.request({
@@ -642,12 +648,10 @@ describe("Indicator-level chart configs", { timeout: 15000 }, () => {
             }),
         })
 
-        // verify that the updatedAt timestamps are the same
-        const chartAfterUpdate = await chartUpdatedAt()
-        const configAfterUpdate = await configUpdatedAt()
-        expect(chartAfterUpdate).not.toBeNull()
-        expect(configAfterUpdate).not.toBeNull()
-        expect(chartAfterUpdate).toEqual(configAfterUpdate)
+        const updatedAtOnUpdate = await expectTimestampsInSync()
+        expect(updatedAtOnUpdate.getTime()).toBeGreaterThanOrEqual(
+            updatedAtOnCreate.getTime()
+        )
     })
 
     it("should bump the config version of a dataset's charts on republish", async () => {

--- a/adminSiteServer/tests/explorer-views.test.ts
+++ b/adminSiteServer/tests/explorer-views.test.ts
@@ -379,8 +379,9 @@ graphers
         }
 
         const finalChartConfigsCount = await getChartConfigsCount()
-        // Should only have the original 2 test charts left (explorer view configs are deleted)
-        expect(finalChartConfigsCount).toBe(2)
+        // Should only have the original 2 test charts left (explorer view configs
+        // are deleted). Each chart keeps two configs: the full config and the patch config.
+        expect(finalChartConfigsCount).toBe(4)
     })
 
     it("should handle error cases gracefully", async () => {

--- a/adminSiteServer/tests/multi-dim-views.test.ts
+++ b/adminSiteServer/tests/multi-dim-views.test.ts
@@ -4,6 +4,7 @@ import {
     ChartConfigsTableName,
     GrapherInterface,
     IndicatorsBeforePreProcessing,
+    MultiDimDataPagesTableName,
     MultiDimViewDimensionsTableName,
     MultiDimXChartConfigsTableName,
     View,
@@ -76,7 +77,19 @@ describe("Multi-dim views", { timeout: 20000 }, () => {
             .testKnex(ChartConfigsTableName)
             .where({ id: chartConfigId })
             .first()
-        return JSON.parse(row.full)
+        return JSON.parse(row.config)
+    }
+
+    async function publishMultiDim(): Promise<void> {
+        const multiDim = await env
+            .testKnex(MultiDimDataPagesTableName)
+            .where({ catalogPath })
+            .first()
+        await env.request({
+            method: "PATCH",
+            path: `/multi-dims/${multiDim.id}`,
+            body: JSON.stringify({ published: true, slug: "energy-use" }),
+        })
     }
 
     beforeEach(async () => {
@@ -87,7 +100,8 @@ describe("Multi-dim views", { timeout: 20000 }, () => {
         await upsertMultiDim([totalView, perCapitaView])
 
         expect(await env.getCount(MultiDimXChartConfigsTableName)).toBe(2)
-        expect(await env.getCount(ChartConfigsTableName)).toBe(2)
+        // two config rows per view: the resolved one and its authored layer
+        expect(await env.getCount(ChartConfigsTableName)).toBe(4)
         expect(await env.getCount(MultiDimViewDimensionsTableName)).toBe(2)
 
         const viewConfigIds = await getViewConfigIds()
@@ -111,7 +125,8 @@ describe("Multi-dim views", { timeout: 20000 }, () => {
         expect(Object.keys(after)).toEqual(["metric=total"])
         // The surviving view keeps its config id, which is a public identity
         expect(after["metric=total"]).toBe(before["metric=total"])
-        expect(await env.getCount(ChartConfigsTableName)).toBe(1)
+        // both of the removed view's config rows are gone
+        expect(await env.getCount(ChartConfigsTableName)).toBe(2)
 
         // multi_dim_view_dimensions is an append-only log for analytics: its row
         // for the removed view deliberately outlives the config it names, so a
@@ -149,5 +164,29 @@ describe("Multi-dim views", { timeout: 20000 }, () => {
 
         // Propagation updates the rows in place rather than replacing them
         expect(await getViewConfigIds()).toEqual(viewConfigIds)
+    })
+
+    it("keeps views published when the indicator's config changes", async () => {
+        await upsertMultiDim([totalView, perCapitaView])
+        const viewConfigIds = await getViewConfigIds()
+
+        await publishMultiDim()
+
+        for (const chartConfigId of Object.values(viewConfigIds)) {
+            expect((await getConfig(chartConfigId)).isPublished).toBe(true)
+        }
+
+        await env.request({
+            method: "PUT",
+            path: `/variables/${variableId}/grapherConfigETL`,
+            body: JSON.stringify({
+                $schema: latestGrapherConfigSchema,
+                note: "Indicator note",
+            }),
+        })
+
+        const config = await getConfig(viewConfigIds["metric=total"])
+        expect(config.isPublished).toBe(true)
+        expect(config.note).toBe("Indicator note")
     })
 })

--- a/adminSiteServer/tests/narrative-charts.test.ts
+++ b/adminSiteServer/tests/narrative-charts.test.ts
@@ -92,7 +92,8 @@ describe("Narrative charts API", { timeout: 20000 }, () => {
         const narrativeChartId = await createNarrativeChart(chartId)
 
         expect(await env.getCount(NarrativeChartsTableName)).toBe(1)
-        expect(await env.getCount(ChartConfigsTableName)).toBe(2)
+        // two config rows each for the parent chart and the narrative chart
+        expect(await env.getCount(ChartConfigsTableName)).toBe(4)
 
         const narrativeChart = await getNarrativeChart(narrativeChartId)
         expect(narrativeChart.parentType).toBe("chart")
@@ -186,7 +187,7 @@ describe("Narrative charts API", { timeout: 20000 }, () => {
         const after = await getNarrativeChart(narrativeChartId)
         expect(after.chartConfigId).toBe(before.chartConfigId)
         expect(after.configFull.title).toBe("Updated title")
-        expect(await env.getCount(ChartConfigsTableName)).toBe(2)
+        expect(await env.getCount(ChartConfigsTableName)).toBe(4)
     })
 
     it("does not re-merge a narrative chart when its parent chart changes", async () => {
@@ -212,7 +213,7 @@ describe("Narrative charts API", { timeout: 20000 }, () => {
     it("deletes a narrative chart and its configs", async () => {
         const { chartId } = await createParentChart()
         const narrativeChartId = await createNarrativeChart(chartId)
-        expect(await env.getCount(ChartConfigsTableName)).toBe(2)
+        expect(await env.getCount(ChartConfigsTableName)).toBe(4)
 
         await env.request({
             method: "DELETE",
@@ -220,7 +221,7 @@ describe("Narrative charts API", { timeout: 20000 }, () => {
         })
 
         expect(await env.getCount(NarrativeChartsTableName)).toBe(0)
-        // Only the parent chart's config is left
-        expect(await env.getCount(ChartConfigsTableName)).toBe(1)
+        // Only the parent chart's two config rows are left
+        expect(await env.getCount(ChartConfigsTableName)).toBe(2)
     })
 })

--- a/adminSiteServer/tests/testEnv.ts
+++ b/adminSiteServer/tests/testEnv.ts
@@ -25,7 +25,7 @@ export interface TestEnv {
     // Helpers
     fetchJson(path: string): Promise<any>
     request(arg: {
-        method: "POST" | "PUT" | "DELETE"
+        method: "POST" | "PUT" | "PATCH" | "DELETE"
         path: string
         body?: string
     }): Promise<any>
@@ -146,7 +146,7 @@ export function getAdminTestEnv(): TestEnv {
     }
 
     async function request(arg: {
-        method: "POST" | "PUT" | "DELETE"
+        method: "POST" | "PUT" | "PATCH" | "DELETE"
         path: string
         body?: string
     }): Promise<any> {

--- a/baker/GrapherBaker.tsx
+++ b/baker/GrapherBaker.tsx
@@ -473,7 +473,7 @@ export const bakeAllChangedGrapherPagesAndDeleteRemovedGraphers = async (
 ) => {
     const chartsToBake = await knexRaw<
         Pick<DbPlainChart, "id"> & {
-            config: DbRawChartConfig["full"]
+            config: DbRawChartConfig["config"]
             slug: string
         }
     >(
@@ -481,11 +481,11 @@ export const bakeAllChangedGrapherPagesAndDeleteRemovedGraphers = async (
         `-- sql
         SELECT
             c.id,
-            cc.full as config,
+            cc.config as config,
             cc.slug
         FROM charts c
         JOIN chart_configs cc ON c.configId = cc.id
-        WHERE JSON_EXTRACT(cc.full, "$.isPublished")=true
+        WHERE JSON_EXTRACT(cc.config, "$.isPublished")=true
         ORDER BY cc.slug ASC`
     )
 

--- a/baker/GrapherImageBaker.tsx
+++ b/baker/GrapherImageBaker.tsx
@@ -56,14 +56,14 @@ export async function getPublishedGraphersBySlug(
 
     // Select all graphers that are published
     const sql = `-- sql
-        SELECT c.id, cc.full as config
+        SELECT c.id, cc.config as config
         FROM charts c
         JOIN chart_configs cc ON c.configId = cc.id
-        WHERE cc.full ->> "$.isPublished" = 'true'
+        WHERE cc.config ->> "$.isPublished" = 'true'
     `
 
     const query = db.knexRaw<
-        Pick<DbPlainChart, "id"> & { config: DbRawChartConfig["full"] }
+        Pick<DbPlainChart, "id"> & { config: DbRawChartConfig["config"] }
     >(knex, sql)
     for (const row of await query) {
         const grapher = JSON.parse(row.config)

--- a/baker/MultiDimBaker.tsx
+++ b/baker/MultiDimBaker.tsx
@@ -43,7 +43,7 @@ import {
 import { MultiDimArchivalManifest } from "../serverUtils/archivalUtils.js"
 import { getLatestArchivedMultiDimPageVersions } from "../db/model/ArchivedMultiDimVersion.js"
 import { getDatapageDataV2 } from "../site/dataPage.js"
-import { getChartConfigByUuid } from "../db/model/ChartConfigs.js"
+import { getChartConfigByUUID } from "../db/model/ChartConfigs.js"
 
 const getLatestMultiDimArchivedVersionsIfEnabled = async (
     knex: db.KnexReadonlyTransaction,
@@ -143,7 +143,7 @@ export async function renderMultiDimDataPageFromConfig({
             getVariableMetadata(initialViewVariableId, {
                 noCache: isPreviewing,
             }),
-            getChartConfigByUuid(knex, initialView.fullConfigId),
+            getChartConfigByUUID(knex, initialView.fullConfigId),
         ])
         if (!fullGrapherConfig) {
             throw new Error(

--- a/baker/SiteBaker.tsx
+++ b/baker/SiteBaker.tsx
@@ -875,17 +875,17 @@ export class SiteBaker {
                 `-- sql
                 SELECT
                     cc.slug,
-                    cc.full ->> '$.subtitle' as subtitle,
-                    cc.full ->> '$.note' as note
+                    cc.config ->> '$.subtitle' as subtitle,
+                    cc.config ->> '$.note' as note
                 FROM
                     charts c
                 JOIN
                     chart_configs cc ON c.configId = cc.id
                 WHERE
-                    JSON_EXTRACT(cc.full, "$.isPublished") = true
+                    JSON_EXTRACT(cc.config, "$.isPublished") = true
                 AND (
-                    JSON_EXTRACT(cc.full, "$.subtitle") LIKE "%#dod:%"
-                    OR JSON_EXTRACT(cc.full, "$.note") LIKE "%#dod:%"
+                    JSON_EXTRACT(cc.config, "$.subtitle") LIKE "%#dod:%"
+                    OR JSON_EXTRACT(cc.config, "$.note") LIKE "%#dod:%"
                 )
                 ORDER BY
                     cc.slug ASC

--- a/baker/algolia/utils/charts.ts
+++ b/baker/algolia/utils/charts.ts
@@ -116,13 +116,13 @@ async function getRawChartsRecords(
         WITH indexable_charts AS (
             SELECT c.id,
                    cc.slug,
-                   cc.full                                 AS config,
-                   JSON_LENGTH(cc.full ->> "$.dimensions") AS numDimensions,
+                   cc.config                                 AS config,
+                   JSON_LENGTH(cc.config ->> "$.dimensions") AS numDimensions,
                    c.publishedAt,
                    c.updatedAt
             FROM charts c
                      LEFT JOIN chart_configs cc ON c.configId = cc.id
-            WHERE cc.full ->> "$.isPublished" = 'true'
+            WHERE cc.config ->> "$.isPublished" = 'true'
             -- NOT tagged "Unlisted"
             AND NOT EXISTS (
                 SELECT 1 FROM chart_tags ct_unlisted

--- a/baker/algolia/utils/explorerViews.ts
+++ b/baker/algolia/utils/explorerViews.ts
@@ -401,8 +401,8 @@ const fetchGrapherInfo = async (
     return await trx
         .select(
             trx.raw("charts.id as id"),
-            trx.raw("chart_configs.full->>'$.title' as title"),
-            trx.raw("chart_configs.full->>'$.subtitle' as subtitle"),
+            trx.raw("chart_configs.config->>'$.title' as title"),
+            trx.raw("chart_configs.config->>'$.subtitle' as subtitle"),
             "ddc.datasetNamespaces",
             "ddc.datasetVersions",
             "ddc.datasetProducts",
@@ -416,7 +416,7 @@ const fetchGrapherInfo = async (
             "ddc.chartId"
         )
         .whereIn("charts.id", grapherIds)
-        .andWhereRaw("chart_configs.full->>'$.isPublished' = 'true'")
+        .andWhereRaw("chart_configs.config->>'$.isPublished' = 'true'")
         .then((rows) => _.keyBy(rows, "id"))
 }
 

--- a/baker/algolia/utils/mdimViews.ts
+++ b/baker/algolia/utils/mdimViews.ts
@@ -48,9 +48,9 @@ async function getChartConfigsByIds(
     ids: string[]
 ) {
     const rows = await knex<DbRawChartConfig>(ChartConfigsTableName)
-        .select("id", "full")
+        .select("id", "config")
         .whereIn("id", ids)
-    return new Map(rows.map((row) => [row.id, parseChartConfig(row.full)]))
+    return new Map(rows.map((row) => [row.id, parseChartConfig(row.config)]))
 }
 
 async function getDatasetDimensionsByVariableIds(

--- a/baker/archival/ArchivalBaker.ts
+++ b/baker/archival/ArchivalBaker.ts
@@ -327,7 +327,7 @@ const bakeChartConfig = async (
 ) => {
     // Fetch the grapher config from the database
     const chartConfigRow = await knex<DbRawChartConfig>(ChartConfigsTableName)
-        .select("full")
+        .select("config")
         .where("id", chartConfigId)
         .first()
 
@@ -335,7 +335,7 @@ const bakeChartConfig = async (
         throw new Error(`Chart config not found with id: ${chartConfigId}`)
     }
 
-    const configStringified = chartConfigRow.full
+    const configStringified = chartConfigRow.config
 
     const apiPath = "grapher/by-uuid"
     const configFilename = path.join(
@@ -551,7 +551,7 @@ export const archiveNarrativeCharts = async (
     }
 
     const narrativeChartRows = await knex("narrative_charts as nc")
-        .select("nc.id", "nc.name", "cc.full as config")
+        .select("nc.id", "nc.name", "cc.config as config")
         .join("chart_configs as cc", "nc.chartConfigId", "cc.id")
         .whereIn("nc.name", uniqueNarrativeChartNames)
         .then((rows: NarrativeChartRow[]) =>

--- a/baker/siteRenderers.tsx
+++ b/baker/siteRenderers.tsx
@@ -30,7 +30,6 @@ import {
     OwidGdocType,
     OwidGdoc,
     TombstonePageData,
-    mergeGrapherConfigs,
     flattenNonTopicNodes,
 } from "@ourworldindata/utils"
 import {
@@ -83,6 +82,7 @@ import {
     getMinimalGdocBaseObjects,
 } from "../db/model/Gdoc/GdocFactory.js"
 import { transformExplorerProgramToResolveCatalogPaths } from "../db/model/ExplorerCatalogResolver.js"
+import { mergeVariableChartConfigs } from "../db/model/Variable.js"
 import {
     Attachments,
     AttachmentsContext,
@@ -577,11 +577,11 @@ export const renderExplorerPage = async (
     let grapherConfigRows: ChartRow[] = []
     if (requiredGrapherIds.length)
         grapherConfigRows = await knexRaw<
-            Pick<DbPlainChart, "id"> & { config: DbRawChartConfig["full"] }
+            Pick<DbPlainChart, "id"> & { config: DbRawChartConfig["config"] }
         >(
             knex,
             `-- sql
-                SELECT c.id, cc.full as config
+                SELECT c.id, cc.config as config
                 FROM charts c
                 JOIN chart_configs cc ON c.configId=cc.id
                 WHERE c.id IN (?)
@@ -600,11 +600,11 @@ export const renderExplorerPage = async (
             `-- sql
                 SELECT
                     v.id,
-                    cc_etl.patch AS grapherConfigETL,
-                    cc_admin.patch AS grapherConfigAdmin
+                    cc_etl.config AS grapherConfigETL,
+                    cc_admin.config AS grapherConfigAdmin
                 FROM variables v
-                    LEFT JOIN chart_configs cc_admin ON cc_admin.id=v.grapherConfigIdAdmin
-                    LEFT JOIN chart_configs cc_etl ON cc_etl.id=v.grapherConfigIdETL
+                    LEFT JOIN chart_configs cc_admin ON cc_admin.id=v.patchConfigIdAdmin
+                    LEFT JOIN chart_configs cc_etl ON cc_etl.id=v.patchConfigIdETL
                 WHERE v.id IN (?)
             `,
             [requiredVariableIds]
@@ -634,19 +634,21 @@ export const renderExplorerPage = async (
     const partialGrapherConfigs = partialGrapherConfigRows
         .filter((row) => row.grapherConfigAdmin || row.grapherConfigETL)
         .map((row) => {
-            const adminConfig = row.grapherConfigAdmin
-                ? parseGrapherConfigFromRow({
-                      id: row.id,
-                      config: row.grapherConfigAdmin,
-                  })
-                : {}
-            const etlConfig = row.grapherConfigETL
-                ? parseGrapherConfigFromRow({
-                      id: row.id,
-                      config: row.grapherConfigETL,
-                  })
-                : {}
-            const mergedConfig = mergeGrapherConfigs(etlConfig, adminConfig)
+            const mergedConfig =
+                mergeVariableChartConfigs({
+                    etl: row.grapherConfigETL
+                        ? parseGrapherConfigFromRow({
+                              id: row.id,
+                              config: row.grapherConfigETL,
+                          })
+                        : undefined,
+                    admin: row.grapherConfigAdmin
+                        ? parseGrapherConfigFromRow({
+                              id: row.id,
+                              config: row.grapherConfigAdmin,
+                          })
+                        : undefined,
+                }) ?? {}
             // explorers set their own dimensions, so we don't need to include them here
             const mergedConfigWithoutDimensions = _.omit(
                 mergedConfig,

--- a/baker/sitemap.ts
+++ b/baker/sitemap.ts
@@ -114,7 +114,7 @@ export const makeSitemap = async (
             FROM charts c
             JOIN chart_configs cc ON cc.id = c.configId
             WHERE
-                cc.full->"$.isPublished" = true
+                cc.config->"$.isPublished" = true
         `
     )
 

--- a/baker/updateChartEntities.ts
+++ b/baker/updateChartEntities.ts
@@ -51,7 +51,7 @@ const preFetchCommonVariables = async (
             FROM chart_dimensions cd
             JOIN charts c ON cd.chartId = c.id
             JOIN chart_configs cc ON c.configId = cc.id
-            WHERE cc.full ->> "$.isPublished" = "true"
+            WHERE cc.config ->> "$.isPublished" = "true"
             GROUP BY variableId
             ORDER BY COUNT(variableId) DESC
             LIMIT ??
@@ -141,14 +141,14 @@ export const obtainAvailableEntitiesForGraphers = async (
     const entityNameToIdMap = await mapEntityNamesToEntityIds(trx)
 
     const allPublishedGraphers = await db.knexRaw<
-        Pick<DbPlainChart, "id"> & { config: DbRawChartConfig["full"] }
+        Pick<DbPlainChart, "id"> & { config: DbRawChartConfig["config"] }
     >(
         trx,
         `-- sql
-            SELECT c.id, cc.full as config
+            SELECT c.id, cc.config as config
             FROM charts c
             JOIN chart_configs cc ON c.configId = cc.id
-            WHERE cc.full ->> "$.isPublished" = 'true'
+            WHERE cc.config ->> "$.isPublished" = 'true'
             ${chartIds?.length ? `AND c.id IN (${chartIds.join(",")})` : ""}
         `
     )

--- a/db/db.ts
+++ b/db/db.ts
@@ -366,7 +366,7 @@ export const getTotalNumberOfCharts = (
             SELECT COUNT(*) AS count
             FROM charts c
             JOIN chart_configs cc ON c.configId = cc.id
-            WHERE cc.full ->> "$.isPublished" = "true"
+            WHERE cc.config ->> "$.isPublished" = "true"
         `
     ).then((res) => res?.count ?? 0)
 }
@@ -1443,7 +1443,7 @@ export async function validateChartSlug(
             FROM ${ChartConfigsTableName} cc
             JOIN ${ChartsTableName} c ON c.configId = cc.id
             WHERE cc.slug = ?
-            AND cc.full->>"$.isPublished" = "true"`,
+            AND cc.config->>"$.isPublished" = "true"`,
             [slug]
         ).then((rows) => rows[0])
 

--- a/db/docs/chart_configs.yml
+++ b/db/docs/chart_configs.yml
@@ -2,46 +2,46 @@ metadata:
   description: |
     This table stores all grapher chart configs, i.e. the actual json configuration that Grapher uses to create charts. It is the only place in our database where actual grapher config JSON blobs are stored.
 
+    Every row holds exactly one config, in the `config` column. What a row *means* is decided by the foreign key that points at it, not by anything on the row: a `configId`/`chartConfigId` names the config that renders, a `patchConfigId` names an authored layer that gets merged into one. Nothing on the row itself distinguishes them, so **always reach a config through its owner** — a query that starts `FROM chart_configs` (matching on `slug`, say) will match both a chart's rendered config and its patch.
+
     Here are some kinds of entities in our DB that reference rows in this table:
-    - Standalone charts, shown on our website at https://ourworldindata.org/grapher/SLUG, stored in the charts table
-    - Multi-dim charts, shown also at https://ourworldindata.org/grapher/SLUG, stored in the multi_dim_x_chart_configs table
-    - Narrative charts, shown only as embedded views in articles and that are based on parent standalone charts, stored in the narrative_charts table
-    - Indicator level charts, used in the inheritance mechanism in standalone charts and multi-dim charts, stored in the variables table
+    - Standalone charts, shown on our website at https://ourworldindata.org/grapher/SLUG, stored in the charts table (configId = rendered, patchConfigId = editor-authored layer)
+    - Multi-dim charts, shown also at https://ourworldindata.org/grapher/SLUG, stored in the multi_dim_x_chart_configs table (chartConfigId = rendered view, patchConfigId = YAML-authored layer)
+    - Narrative charts, shown only as embedded views in articles and that are based on parent standalone charts, stored in the narrative_charts table (chartConfigId = rendered, patchConfigId = editor-authored layer)
+    - Explorer views, stored in the explorer_views table (chartConfigId only — the config is generated whole, there is no authored layer)
+    - Indicator level charts, used in the inheritance mechanism in standalone charts and multi-dim charts, stored in the variables table (patchConfigIdETL and patchConfigIdAdmin — both authored layers; the effective indicator config is merged in code by mergeVariableChartConfigs in db/model/Variable.ts and is not stored anywhere)
+    - multi_dim_redirects.viewConfigId, which uses a config id purely as an identifier for an mdim view and never reads the JSON
 
-    Charts have an inheritance mechanism where, for example, standalone charts can inherit from the main variable that is used in that chart.
+    Charts have an inheritance mechanism where, for example, standalone charts can inherit from the main variable that is used in that chart. The rendered config is the merge of all authored layers up the chain, and it is stored, so most queries want the row named by `configId`/`chartConfigId` and can ignore the patch rows entirely.
 
-    This inheritance is reflected in this table in the patch and full columns. The patch column stores only the configuration changes that currently it performs. The full one is the merged configuration from all the upstream dependencies plus the current patch. When querying details of chart configs, prefer to use the full column.
-
-    The actual chart config is a complex JSON object. See the column description for patch and full below for the schema url and the most important fields.
+    The actual chart config is a complex JSON object. See the column description for config below for the schema url and the most important fields.
   incoming_foreign_keys:
     - table: charts
       column: configId
+    - table: charts
+      column: patchConfigId
     - table: explorer_views
       column: chartConfigId
+    - table: multi_dim_redirects
+      column: viewConfigId
     - table: multi_dim_x_chart_configs
       column: chartConfigId
+    - table: multi_dim_x_chart_configs
+      column: patchConfigId
     - table: narrative_charts
       column: chartConfigId
+    - table: narrative_charts
+      column: patchConfigId
     - table: variables
-      column: grapherConfigIdAdmin
+      column: patchConfigIdAdmin
     - table: variables
-      column: grapherConfigIdETL
+      column: patchConfigIdETL
 fields:
   id:
     description: Unique identifier for the chart configuration
-  patch:
+  config:
     description: |
-      Incremental configuration JSON that contains only the changes from the inherited or base configuration. Stored as a JSON column, so can be queried with the ->> operator.
-
-      The full schema is available at 'https://files.ourworldindata.org/schemas/grapher-schema.latest.json'. For querying chart contents, the most important fields are:
-          - title
-          - subtitle
-          - chartTypes: array of string enums with valid values: ScatterPlot, StackedArea, DiscreteBar, StackedDiscreteBar, SlopeChart, StackedBar, Marimekko. Indicates which of these chart tabs are enabled for the chart.
-          - hasMapTab: Whether the map tab is enabled
-          - isPublished: whether the chart is published, if it is a standalone chart (i.e. a chart referenced from the charts table)
-  full:
-    description: |
-      Complete merged configuration JSON that combines inherited configuration with local patches. This is the final configuration used for rendering. Stored as a JSON column, so can be queried with the ->> operator.
+      The chart configuration JSON. Stored as a JSON column, so can be queried with the ->> operator. Depending on which foreign key points at this row, it is either the configuration used for rendering or an authored layer that is merged into one.
 
       The full schema is available at 'https://files.ourworldindata.org/schemas/grapher-schema.latest.json'. For querying chart contents, the most important fields are:
           - title
@@ -50,12 +50,12 @@ fields:
           - hasMapTab: Whether the map tab is enabled
           - isPublished: whether the chart is published, if it is a standalone chart (i.e. a chart referenced from the charts table)
   slug:
-    description: URL-friendly identifier for the chart, used in URLs like /grapher/[slug]
+    description: URL-friendly identifier for the chart, used in URLs like /grapher/[slug]. This column is a GENERATED STORED column, no need to update it in insert/update calls. Not unique — a standalone chart's patch row carries the same slug as its rendered row, so filter by slug only after joining through an owner.
   chartType:
-    description: Type of chart visualization (e.g., LineChart, BarChart, ScatterPlot, WorldMap). This only indicates the main chart - prefer to query the chartTypes field and the hasMapTab field in the full config instead. This column is a GENERATED STORED column, no need to update it in insert/update calls
+    description: Type of chart visualization (e.g., LineChart, BarChart, ScatterPlot, WorldMap). This only indicates the main chart - prefer to query the chartTypes field and the hasMapTab field in the config instead. This column is a GENERATED STORED column, no need to update it in insert/update calls
   createdAt:
     description: Timestamp when the configuration was created
   updatedAt:
-    description: Timestamp when the configuration was last updated
-  fullMd5:
-    description: MD5 hash of the full configuration JSON used for change detection and caching
+    description: Timestamp when the configuration was last updated. When an owner writes its config, its rendered row and its patch row are written together and share the same timestamp. Indicator propagation is the exception — it rewrites only the rendered row, because the authored layer doesn't change.
+  configMd5:
+    description: MD5 hash of the config JSON used for change detection and caching. This column is a GENERATED STORED column, no need to update it in insert/update calls

--- a/db/docs/chart_revisions.yml
+++ b/db/docs/chart_revisions.yml
@@ -2,7 +2,7 @@ metadata:
   description: |
     Historical chart revision tracking for version control purposes of standalone charts (those published at https://ourworldindata.org/grapher/SLUG).
 
-    This table stores snapshots of chart configurations over time when editing them in the admin, enabling rollback functionality and change history tracking. Each revision captures the full chart configuration at a specific point in time.
+    This table stores snapshots of chart configurations over time when editing them in the admin, enabling rollback functionality and change history tracking. Each revision captures the config as authored in the editor (the chart's patch, not the merged config that gets rendered) at a specific point in time.
 
     This table is only used in the admin UI to got back to previous versions.
 fields:
@@ -14,7 +14,7 @@ fields:
     description: Foreign key to users table. The user who created this revision.
   config:
     description: |
-      JSON configuration of the chart at the time of this revision
+      The chart config as authored in the editor at the time of this revision (chart_configs.config of the row named by charts.patchConfigId, not the merged config). It is only ever rendered as a diff against the neighbouring revisions, never restored programmatically.
 
       The full schema is available at 'https://files.ourworldindata.org/schemas/grapher-schema.latest.json'. For querying chart contents, the most important fields are:
           - title

--- a/db/docs/charts.yml
+++ b/db/docs/charts.yml
@@ -25,9 +25,11 @@ fields:
   id:
     description: Unique identifier for the chart
   configId:
-    description: Foreign key to chart_configs table. Charts store their configuration separately to enable inheritance and efficient updates. The chart_configs table contains the actual config, the slug of the chart etc., so in many queries, these two tables have to be joined.
+    description: Foreign key to chart_configs table, pointing at the config that is actually rendered (the merge of the indicator layers and this chart's patch). The chart_configs table contains the actual config, the slug of the chart etc., so in many queries, these two tables have to be joined. This is the pointer you want unless you specifically need what a user authored.
+  patchConfigId:
+    description: Foreign key to chart_configs table, pointing at the layer authored in the chart editor, i.e. the changes made on top of the inherited indicator config. Equals the rendered config when inheritance is disabled.
   isInheritanceEnabled:
-    description: When true, chart inherits configuration from parent variable's grapherConfigIdAdmin or grapherConfigIdETL. This allows variables to define default chart settings that are automatically applied to all inheriting charts.
+    description: When true, chart inherits configuration from parent variable's patchConfigIdAdmin or patchConfigIdETL. This allows variables to define default chart settings that are automatically applied to all inheriting charts.
   forceDatapage:
     description: When true, force rendering this chart as a data page using metadata from the first Y indicator.
   createdAt:

--- a/db/docs/explorer_views.yml
+++ b/db/docs/explorer_views.yml
@@ -20,8 +20,7 @@ fields:
       This represents the state of the explorer's controls that would produce this specific chart configuration.
   chartConfigId:
     description: |
-      Foreign key reference to chart_configs.id. Points to the complete grapher configuration JSON that should be used when this combination of explorer parameters is selected.
-      This allows explorer views to leverage the existing chart configuration infrastructure.
+      Foreign key reference to chart_configs.id. Points to the complete grapher configuration JSON that should be used when this combination of explorer parameters is selected. This allows explorer views to leverage the existing chart configuration infrastructure.
       NULL when configuration extraction failed (error will be populated instead).
   error:
     description: |

--- a/db/docs/multi_dim_x_chart_configs.yml
+++ b/db/docs/multi_dim_x_chart_configs.yml
@@ -15,7 +15,9 @@ fields:
   variableId:
     description: Foreign key to variables table for the variable being visualized
   chartConfigId:
-    description: Foreign key to chart_configs table for the chart configuration
+    description: Foreign key to chart_configs table for the config that is rendered for this view (the merge of the indicator config and the view's patch)
+  patchConfigId:
+    description: Foreign key to chart_configs table for the view config as authored in the mdim YAML (the mdim-wide config composed with this view's own config). Read whenever the view has to be re-merged, e.g. after an indicator config change.
   createdAt:
     description: Timestamp when the configuration was created
   updatedAt:

--- a/db/docs/narrative_charts.yml
+++ b/db/docs/narrative_charts.yml
@@ -6,7 +6,9 @@ fields:
   name:
     description: Descriptive name of the narrative chart for editorial reference
   chartConfigId:
-    description: Foreign key to chart_configs table for the narrative-specific configuration
+    description: Foreign key to chart_configs table for the config that is rendered for this narrative chart, i.e. the parent chart or mdim view config merged with the narrative patch at save time (it is not refreshed when the parent changes)
+  patchConfigId:
+    description: Foreign key to chart_configs table for the layer authored in the narrative chart editor, i.e. the changes made on top of the parent chart or mdim view.
   parentChartId:
     description: Foreign key to standalone chart for the base chart this narrative view is derived from
   parentMultiDimXChartConfigId:

--- a/db/docs/variables.yml
+++ b/db/docs/variables.yml
@@ -1,6 +1,6 @@
 metadata:
   description: |
-    Variables represent individual indicators or metrics (e.g., 'GDP per capita', 'Life expectancy'). Variables are the fundamental data units that get visualized in charts. They support a dual configuration system where both the ETL python codebase and the typescript admin client UI can define default chart configurations that charts can inherit. The ETL controls grapherConfigIdETL for this purpose, the grapher admin controls grapherConfigIdAdmin.
+    Variables represent individual indicators or metrics (e.g., 'GDP per capita', 'Life expectancy'). Variables are the fundamental data units that get visualized in charts. They support a dual configuration system where both the ETL python codebase and the typescript admin client UI can define default chart configurations that charts can inherit. The ETL controls patchConfigIdETL for this purpose, the grapher admin controls patchConfigIdAdmin. Both are authored layers; the effective indicator config is merged in code (mergeVariableChartConfigs in db/model/Variable.ts) and is not stored in the database.
   incoming_foreign_keys:
     - table: chart_dimensions
       column: variableId
@@ -81,9 +81,9 @@ fields:
     description: Variable type (e.g., 'ordinal', 'continuous')
   sort:
     description: JSON configuration for how the variable should be sorted
-  grapherConfigIdAdmin:
-    description: Foreign key to chart_configs table. Admin-authored default chart configuration that charts can inherit from.
-  grapherConfigIdETL:
+  patchConfigIdAdmin:
+    description: Foreign key to chart_configs table. Admin-authored layer on top of the ETL config, holding only the changes made in the admin. Charts inherit the merge of the two, which is computed in code rather than stored.
+  patchConfigIdETL:
     description: Foreign key to chart_configs table. ETL-authored default chart configuration that charts can inherit from.
   dataChecksum:
     description: Checksum of the variable's data values, used for change detection

--- a/db/migration/1786450384438-AddPatchConfigIdPointers.ts
+++ b/db/migration/1786450384438-AddPatchConfigIdPointers.ts
@@ -1,0 +1,72 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+/**
+ * Give charts, mdim views and narrative charts a pointer to the chart_configs
+ * row holding their authored (patch) config, alongside the existing pointer to
+ * their resolved one.
+ *
+ * Nullable, because nothing populates patchConfigId on insert yet.
+ */
+export class AddPatchConfigIdPointers1786450384438 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`-- sql
+            ALTER TABLE charts
+            ADD COLUMN patchConfigId char(36) NULL AFTER configId,
+            ADD UNIQUE INDEX patchConfigId (patchConfigId),
+            ADD CONSTRAINT fk_charts_patch_config_id FOREIGN KEY (patchConfigId)
+                REFERENCES chart_configs (id) ON DELETE RESTRICT ON UPDATE RESTRICT
+        `)
+
+        await queryRunner.query(`-- sql
+            ALTER TABLE multi_dim_x_chart_configs
+            ADD COLUMN patchConfigId char(36) NULL AFTER chartConfigId,
+            ADD UNIQUE INDEX patchConfigId (patchConfigId),
+            ADD CONSTRAINT fk_multi_dim_x_chart_configs_patch_config_id
+                FOREIGN KEY (patchConfigId)
+                REFERENCES chart_configs (id) ON DELETE RESTRICT ON UPDATE RESTRICT
+        `)
+
+        await queryRunner.query(`-- sql
+            ALTER TABLE narrative_charts
+            ADD COLUMN patchConfigId char(36) NULL AFTER chartConfigId,
+            ADD UNIQUE INDEX patchConfigId (patchConfigId),
+            ADD CONSTRAINT fk_narrative_charts_patch_config_id
+                FOREIGN KEY (patchConfigId)
+                REFERENCES chart_configs (id) ON DELETE RESTRICT ON UPDATE RESTRICT
+        `)
+
+        // Drive-by change: narrative_charts is the only table whose pointer
+        // to the final config isn't unique
+        await queryRunner.query(`-- sql
+            ALTER TABLE narrative_charts
+            DROP INDEX chartConfigId,
+            ADD UNIQUE INDEX chartConfigId (chartConfigId)
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`-- sql
+            ALTER TABLE narrative_charts
+            DROP INDEX chartConfigId,
+            ADD INDEX chartConfigId (chartConfigId)
+        `)
+
+        await queryRunner.query(`-- sql
+            ALTER TABLE narrative_charts
+            DROP FOREIGN KEY fk_narrative_charts_patch_config_id,
+            DROP COLUMN patchConfigId
+        `)
+
+        await queryRunner.query(`-- sql
+            ALTER TABLE multi_dim_x_chart_configs
+            DROP FOREIGN KEY fk_multi_dim_x_chart_configs_patch_config_id,
+            DROP COLUMN patchConfigId
+        `)
+
+        await queryRunner.query(`-- sql
+            ALTER TABLE charts
+            DROP FOREIGN KEY fk_charts_patch_config_id,
+            DROP COLUMN patchConfigId
+        `)
+    }
+}

--- a/db/migration/1786450392136-BackfillPatchConfigRows.ts
+++ b/db/migration/1786450392136-BackfillPatchConfigRows.ts
@@ -1,0 +1,114 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+import { v7 as uuidv7 } from "uuid"
+
+// The three owners whose authored config layer moves into a chart_configs row
+// of its own. `resolvedPointer` is the column naming the owner's merged config,
+// whose `patch` column we are copying out.
+const OWNERS = [
+    {
+        table: "charts",
+        resolvedPointer: "configId",
+        tmpTable: "tmpPatchConfigIdxChart",
+    },
+    {
+        table: "multi_dim_x_chart_configs",
+        resolvedPointer: "chartConfigId",
+        tmpTable: "tmpPatchConfigIdxMultiDimView",
+    },
+    {
+        table: "narrative_charts",
+        resolvedPointer: "chartConfigId",
+        tmpTable: "tmpPatchConfigIdxNarrativeChart",
+    },
+] as const
+
+export class BackfillPatchConfigRows1786450392136 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        for (const { table, resolvedPointer, tmpTable } of OWNERS) {
+            const owners: { id: number }[] = await queryRunner.query(`-- sql
+                SELECT id FROM ${table}
+            `)
+            if (owners.length === 0) continue
+
+            // Create a temporary table to hold the mapping of owner id → new
+            // patch config id. The new ids are UUIDv7, which is not available
+            // in MySQL, so we mint them here
+            await queryRunner.query(`-- sql
+                CREATE TABLE ${tmpTable} (
+                    uuid char(36) NOT NULL PRIMARY KEY,
+                    ownerId INT NOT NULL
+                )
+            `)
+            await queryRunner.query(
+                `-- sql
+                    INSERT INTO ${tmpTable} (uuid, ownerId) VALUES ?
+                `,
+                [owners.map((owner) => [uuidv7(), owner.id])]
+            )
+
+            // Copy each owner's authored config into a row of its own. The
+            // timestamps come from the source row so chart-sync's comparisons
+            // don't read these as changes.
+            await queryRunner.query(`-- sql
+                INSERT INTO chart_configs (id, patch, full, createdAt, updatedAt)
+                SELECT tmp.uuid, cc.patch, cc.patch, cc.createdAt, cc.updatedAt
+                FROM ${tmpTable} tmp
+                JOIN ${table} o ON o.id = tmp.ownerId
+                JOIN chart_configs cc ON cc.id = o.${resolvedPointer}
+            `)
+
+            // Point each owner at the row just created for it
+            await queryRunner.query(`-- sql
+                UPDATE ${table} o
+                JOIN ${tmpTable} tmp ON tmp.ownerId = o.id
+                SET o.patchConfigId = tmp.uuid
+            `)
+
+            // Drop the temporary table
+            await queryRunner.query(`-- sql
+                DROP TABLE ${tmpTable}
+            `)
+        }
+
+        // Every owner now points at a row of its own, so require the pointer
+        for (const { table } of OWNERS) {
+            await queryRunner.query(`-- sql
+                ALTER TABLE ${table}
+                MODIFY COLUMN patchConfigId char(36) NOT NULL
+            `)
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        for (const { table } of OWNERS) {
+            await queryRunner.query(`-- sql
+                ALTER TABLE ${table}
+                MODIFY COLUMN patchConfigId char(36) NULL
+            `)
+        }
+
+        for (const { table, tmpTable } of OWNERS) {
+            await queryRunner.query(`-- sql
+                CREATE TABLE ${tmpTable} (uuid char(36) NOT NULL PRIMARY KEY)
+            `)
+
+            await queryRunner.query(`-- sql
+                INSERT INTO ${tmpTable} (uuid)
+                SELECT patchConfigId FROM ${table} WHERE patchConfigId IS NOT NULL
+            `)
+
+            await queryRunner.query(`-- sql
+                UPDATE ${table} SET patchConfigId = NULL
+            `)
+
+            await queryRunner.query(`-- sql
+                DELETE cc FROM chart_configs cc
+                JOIN ${tmpTable} tmp ON tmp.uuid = cc.id
+            `)
+
+            await queryRunner.query(`-- sql
+                DROP TABLE ${tmpTable}
+            `)
+        }
+    }
+}

--- a/db/migration/1786454321825-ReplaceChartConfigPatchAndFullWithConfig.ts
+++ b/db/migration/1786454321825-ReplaceChartConfigPatchAndFullWithConfig.ts
@@ -1,0 +1,142 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+// Owners that keep their authored config in a chart_configs row of their own
+const OWNERS = [
+    { table: "charts", resolvedPointer: "configId" },
+    { table: "multi_dim_x_chart_configs", resolvedPointer: "chartConfigId" },
+    { table: "narrative_charts", resolvedPointer: "chartConfigId" },
+] as const
+
+// Unchanged except for dropping the `patch` reference, which was dead anyway
+const CHARTS_X_PARENTS_VIEW = `-- sql
+    ALTER VIEW charts_x_parents AS (
+      WITH y_dimensions AS (
+        SELECT * FROM chart_dimensions WHERE property = 'y'
+      ),
+      single_y_indicator_charts AS (
+        SELECT
+          c.id as chartId,
+          -- should only be one
+          max(yd.variableId) as variableId
+        FROM charts c
+          JOIN chart_configs cc ON cc.id = c.configId
+          JOIN y_dimensions yd ON c.id = yd.chartId
+        WHERE
+          -- scatter plots can't inherit settings
+          -- NULL chartType means no chart tab (chartTypes=[]), which should be included
+          (cc.chartType != 'ScatterPlot' OR cc.chartType IS NULL)
+        GROUP BY c.id
+        HAVING
+          -- restrict to single y-variable charts
+          COUNT(distinct yd.variableId) = 1
+      )
+      SELECT variableId, chartId FROM single_y_indicator_charts ORDER BY variableId
+    )
+`
+
+/** Replace chart_configs.patch + full with a single `config` column */
+export class ReplaceChartConfigPatchAndFullWithConfig1786454321825 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        // Drop the `patch` config reference from the charts_x_parents view
+        // (it was a dead reference anyway)
+        await queryRunner.query(CHARTS_X_PARENTS_VIEW)
+
+        // For admin-authored indicator config, `patch` holds the authored config,
+        // `full` is merged with the ETL layer. We want to keep the authored config
+        // in the new `config` column, so copy it over. No need to do this for
+        // the ETL layer, since patch and full are identical there.
+        await queryRunner.query(`-- sql
+            UPDATE chart_configs cc
+            JOIN variables v ON v.grapherConfigIdAdmin = cc.id
+            SET cc.full = cc.patch
+        `)
+
+        // Drop the patch column and all three generated columns that depend on `full`
+        // Dropping `slug` also drops `idx_chart_configs_slug`
+        await queryRunner.query(`-- sql
+            ALTER TABLE chart_configs
+            DROP COLUMN slug,
+            DROP COLUMN chartType,
+            DROP COLUMN fullMd5,
+            DROP COLUMN patch
+        `)
+
+        // Rename `full` to `config`
+        await queryRunner.query(`-- sql
+            ALTER TABLE chart_configs RENAME COLUMN \`full\` TO config
+        `)
+
+        // Add back the three generated columns, now over `config`, and the index on slug
+        await queryRunner.query(`-- sql
+            ALTER TABLE chart_configs
+            ADD COLUMN slug varchar(255)
+                GENERATED ALWAYS AS (json_unquote(json_extract(config, '$.slug'))) STORED
+                AFTER config,
+            ADD COLUMN chartType varchar(255)
+                GENERATED ALWAYS AS ((case
+                    when (json_unquote(json_extract(config, '$.chartTypes')) is null)
+                    then 'LineChart'
+                    else json_unquote(json_extract(config, '$.chartTypes[0]'))
+                end)) STORED
+                AFTER slug,
+            ADD COLUMN configMd5 char(24)
+                GENERATED ALWAYS AS (to_base64(unhex(md5(config)))) STORED NOT NULL,
+            ADD INDEX idx_chart_configs_slug (slug)
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        // Nullable to begin with, since it is filled in two passes.
+        await queryRunner.query(`-- sql
+            ALTER TABLE chart_configs ADD COLUMN patch json NULL AFTER id
+        `)
+
+        // For owners that keep an authored config, patch comes back from the row
+        // holding it.
+        for (const { table, resolvedPointer } of OWNERS) {
+            await queryRunner.query(`-- sql
+                UPDATE chart_configs resolved
+                JOIN ${table} o ON o.${resolvedPointer} = resolved.id
+                JOIN chart_configs patch ON patch.id = o.patchConfigId
+                SET resolved.patch = patch.config
+            `)
+        }
+
+        // Everything else — indicator configs, explorer views, and the authored
+        // rows themselves — held patch identical to full.
+        await queryRunner.query(`-- sql
+            UPDATE chart_configs SET patch = config WHERE patch IS NULL
+        `)
+        await queryRunner.query(`-- sql
+            ALTER TABLE chart_configs MODIFY COLUMN patch json NOT NULL
+        `)
+
+        await queryRunner.query(`-- sql
+            ALTER TABLE chart_configs
+            DROP COLUMN slug,
+            DROP COLUMN chartType,
+            DROP COLUMN configMd5
+        `)
+
+        await queryRunner.query(`-- sql
+            ALTER TABLE chart_configs RENAME COLUMN config TO \`full\`
+        `)
+
+        await queryRunner.query(`-- sql
+            ALTER TABLE chart_configs
+            ADD COLUMN slug varchar(255)
+                GENERATED ALWAYS AS (json_unquote(json_extract(\`full\`, '$.slug'))) STORED
+                AFTER \`full\`,
+            ADD COLUMN chartType varchar(255)
+                GENERATED ALWAYS AS ((case
+                    when (json_unquote(json_extract(\`full\`, '$.chartTypes')) is null)
+                    then 'LineChart'
+                    else json_unquote(json_extract(\`full\`, '$.chartTypes[0]'))
+                end)) STORED
+                AFTER slug,
+            ADD COLUMN fullMd5 char(24)
+                GENERATED ALWAYS AS (to_base64(unhex(md5(\`full\`)))) STORED NOT NULL,
+            ADD INDEX idx_chart_configs_slug (slug)
+        `)
+    }
+}

--- a/db/migration/1786455779158-RenameChartConfigForeignKeys.ts
+++ b/db/migration/1786455779158-RenameChartConfigForeignKeys.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+/** `variables.grapherConfigId{ETL,Admin}` become `patchConfigId{ETL,Admin}` */
+export class RenameChartConfigForeignKeys1786455779158 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`-- sql
+            ALTER TABLE variables
+            RENAME COLUMN grapherConfigIdETL TO patchConfigIdETL,
+            RENAME COLUMN grapherConfigIdAdmin TO patchConfigIdAdmin,
+            RENAME INDEX grapherConfigIdETL TO patchConfigIdETL,
+            RENAME INDEX grapherConfigIdAdmin TO patchConfigIdAdmin
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`-- sql
+            ALTER TABLE variables
+            RENAME COLUMN patchConfigIdETL TO grapherConfigIdETL,
+            RENAME COLUMN patchConfigIdAdmin TO grapherConfigIdAdmin,
+            RENAME INDEX patchConfigIdETL TO grapherConfigIdETL,
+            RENAME INDEX patchConfigIdAdmin TO grapherConfigIdAdmin
+        `)
+    }
+}

--- a/db/model/Chart.ts
+++ b/db/model/Chart.ts
@@ -3,6 +3,7 @@ import * as db from "../db.js"
 import {
     getDataForMultipleVariables,
     getGrapherConfigsForVariable,
+    mergeVariableChartConfigs,
 } from "./Variable.js"
 import {
     JsonError,
@@ -44,7 +45,7 @@ export async function mapSlugsToIds(
                     SELECT c.id, cc.slug
                     FROM charts c
                     JOIN chart_configs cc ON cc.id = c.configId
-                    WHERE cc.full ->> "$.isPublished" = "true"
+                    WHERE cc.config ->> "$.isPublished" = "true"
                 `
             ),
         ])
@@ -82,16 +83,16 @@ export async function mapSlugsToConfigs(
         }>(
             knex,
             `-- sql
-                SELECT csr.slug AS slug, cc.full AS config, c.id AS id
+                SELECT csr.slug AS slug, cc.config AS config, c.id AS id
                 FROM chart_slug_redirects csr
                 JOIN charts c ON csr.chart_id = c.id
                 JOIN chart_configs cc ON cc.id = c.configId
-                WHERE cc.full ->> "$.isPublished" = "true"
+                WHERE cc.config ->> "$.isPublished" = "true"
                 UNION
-                SELECT cc.slug, cc.full AS config, c.id AS id
+                SELECT cc.slug, cc.config AS config, c.id AS id
                 FROM charts c
                 JOIN chart_configs cc ON cc.id = c.configId
-                WHERE cc.full ->> "$.isPublished" = "true"
+                WHERE cc.config ->> "$.isPublished" = "true"
             `
         )
         .then((results) =>
@@ -105,13 +106,15 @@ export async function mapSlugsToConfigs(
 export async function getEnrichedChartBySlug(
     knex: db.KnexReadonlyTransaction,
     slug: string
-): Promise<(DbPlainChart & { config: DbEnrichedChartConfig["full"] }) | null> {
+): Promise<
+    (DbPlainChart & { config: DbEnrichedChartConfig["config"] }) | null
+> {
     let chart = await db.knexRawFirst<
-        DbPlainChart & { config: DbRawChartConfig["full"] }
+        DbPlainChart & { config: DbRawChartConfig["config"] }
     >(
         knex,
         `-- sql
-            SELECT c.*, cc.full as config
+            SELECT c.*, cc.config as config
             FROM charts c
             JOIN chart_configs cc ON c.configId = cc.id
             WHERE cc.slug = ?
@@ -121,12 +124,12 @@ export async function getEnrichedChartBySlug(
 
     if (!chart) {
         chart = await db.knexRawFirst<
-            DbPlainChart & { config: DbRawChartConfig["full"] }
+            DbPlainChart & { config: DbRawChartConfig["config"] }
         >(
             knex,
             `-- sql
                 SELECT
-                    c.*, cc.full as config
+                    c.*, cc.config as config
                 FROM
                     chart_slug_redirects csr
                     JOIN charts c ON csr.chart_id = c.id
@@ -148,13 +151,13 @@ export async function getEnrichedChartBySlug(
 export async function getRawChartById(
     knex: db.KnexReadonlyTransaction,
     id: number
-): Promise<(DbPlainChart & { config: DbRawChartConfig["full"] }) | null> {
+): Promise<(DbPlainChart & { config: DbRawChartConfig["config"] }) | null> {
     const chart = await db.knexRawFirst<
-        DbPlainChart & { config: DbRawChartConfig["full"] }
+        DbPlainChart & { config: DbRawChartConfig["config"] }
     >(
         knex,
         `-- sql
-            SELECT c.*, cc.full AS config
+            SELECT c.*, cc.config AS config
             FROM charts c
             JOIN chart_configs cc ON c.configId = cc.id
             WHERE id = ?
@@ -168,13 +171,13 @@ export async function getRawChartById(
 export async function getRawChartsByIds(
     knex: db.KnexReadonlyTransaction,
     ids: number[]
-): Promise<(DbPlainChart & { config: DbRawChartConfig["full"] })[]> {
+): Promise<(DbPlainChart & { config: DbRawChartConfig["config"] })[]> {
     const charts = await db.knexRaw<
-        DbPlainChart & { config: DbRawChartConfig["full"] }
+        DbPlainChart & { config: DbRawChartConfig["config"] }
     >(
         knex,
         `-- sql
-            SELECT c.*, cc.full AS config
+            SELECT c.*, cc.config AS config
             FROM charts c
             JOIN chart_configs cc ON c.configId = cc.id
             WHERE c.id IN (?)
@@ -188,24 +191,26 @@ export async function getPatchConfigByChartId(
     knex: db.KnexReadonlyTransaction,
     id: number
 ): Promise<GrapherInterface | undefined> {
-    const chart = await db.knexRawFirst<Pick<DbRawChartConfig, "patch">>(
+    const chart = await db.knexRawFirst<Pick<DbRawChartConfig, "config">>(
         knex,
         `-- sql
-            SELECT patch
+            SELECT cc.config
             FROM chart_configs cc
-            JOIN charts c ON c.configId = cc.id
+            JOIN charts c ON c.patchConfigId = cc.id
             WHERE c.id = ?
         `,
         [id]
     )
     if (!chart) return undefined
-    return parseChartConfig(chart.patch)
+    return parseChartConfig(chart.config)
 }
 
 export async function getEnrichedChartById(
     knex: db.KnexReadonlyTransaction,
     id: number
-): Promise<(DbPlainChart & { config: DbEnrichedChartConfig["full"] }) | null> {
+): Promise<
+    (DbPlainChart & { config: DbEnrichedChartConfig["config"] }) | null
+> {
     const rawChart = await getRawChartById(knex, id)
     if (!rawChart) return null
     return { ...rawChart, config: parseChartConfig(rawChart.config) }
@@ -214,7 +219,7 @@ export async function getEnrichedChartById(
 export async function getEnrichedChartsByIds(
     knex: db.KnexReadonlyTransaction,
     ids: number[]
-): Promise<(DbPlainChart & { config: DbEnrichedChartConfig["full"] })[]> {
+): Promise<(DbPlainChart & { config: DbEnrichedChartConfig["config"] })[]> {
     const charts = await getRawChartsByIds(knex, ids)
     return charts.map((rawChart) => ({
         ...rawChart,
@@ -245,18 +250,18 @@ export const getChartConfigById = async (
     grapherId: number
 ): Promise<
     | (Pick<DbPlainChart, "id" | "forceDatapage"> & {
-          config: DbEnrichedChartConfig["full"]
+          config: DbEnrichedChartConfig["config"]
       })
     | undefined
 > => {
     const grapher = await db.knexRawFirst<
         Pick<DbPlainChart, "id" | "forceDatapage"> & {
-            config: DbRawChartConfig["full"]
+            config: DbRawChartConfig["config"]
         }
     >(
         knex,
         `-- sql
-            SELECT c.id, c.forceDatapage, cc.full as config
+            SELECT c.id, c.forceDatapage, cc.config as config
             FROM charts c
             JOIN chart_configs cc ON c.configId = cc.id
             WHERE c.id=?
@@ -278,17 +283,17 @@ export async function getChartConfigBySlug(
     slug: string
 ): Promise<
     Pick<DbPlainChart, "id"> & {
-        config: DbEnrichedChartConfig["full"]
+        config: DbEnrichedChartConfig["config"]
     }
 > {
     const row = await db.knexRawFirst<
         Pick<DbPlainChart, "id" | "forceDatapage"> & {
-            config: DbRawChartConfig["full"]
+            config: DbRawChartConfig["config"]
         }
     >(
         knex,
         `-- sql
-            SELECT c.id, cc.full as config
+            SELECT c.id, cc.config as config
             FROM charts c
             JOIN chart_configs cc ON c.configId = cc.id
             WHERE cc.slug = ?`,
@@ -357,11 +362,12 @@ export async function getParentByChartId(
     const parentVariableId = await getParentVariableIdByChartId(trx, chartId)
     if (!parentVariableId) return {}
     const variable = await getGrapherConfigsForVariable(trx, parentVariableId)
-    const parentConfig =
-        variable?.admin?.fullConfig ?? variable?.etl?.fullConfig
     return {
         variableId: parentVariableId,
-        config: parentConfig,
+        config: mergeVariableChartConfigs({
+            etl: variable?.etl?.config,
+            admin: variable?.admin?.config,
+        }),
     }
 }
 
@@ -375,11 +381,12 @@ export async function getParentByChartConfig(
     const parentVariableId = getParentVariableIdFromChartConfig(config)
     if (!parentVariableId) return {}
     const variable = await getGrapherConfigsForVariable(trx, parentVariableId)
-    const parentConfig =
-        variable?.admin?.fullConfig ?? variable?.etl?.fullConfig
     return {
         variableId: parentVariableId,
-        config: parentConfig,
+        config: mergeVariableChartConfigs({
+            etl: variable?.etl?.config,
+            admin: variable?.admin?.config,
+        }),
     }
 }
 
@@ -468,7 +475,7 @@ export async function getGptTopicSuggestions(
     const chartConfigOnly = await db.knexRawFirst<{ config: string }>(
         knex,
         `-- sql
-            SELECT cc.full as config
+            SELECT cc.config as config
             FROM chart_configs cc
             JOIN charts c ON c.configId = cc.id
             WHERE c.id = ?
@@ -559,15 +566,15 @@ export interface OldChartFieldList {
 
 export const oldChartFieldList = `
         charts.id,
-        chart_configs.full->>"$.title" AS title,
-        chart_configs.full->>"$.slug" AS slug,
+        chart_configs.config->>"$.title" AS title,
+        chart_configs.config->>"$.slug" AS slug,
         chart_configs.chartType AS type,
-        chart_configs.full->>"$.internalNotes" AS internalNotes,
-        chart_configs.full->>"$.variantName" AS variantName,
-        chart_configs.full->>"$.tab" AS tab,
+        chart_configs.config->>"$.internalNotes" AS internalNotes,
+        chart_configs.config->>"$.variantName" AS variantName,
+        chart_configs.config->>"$.tab" AS tab,
         chart_configs.chartType IS NOT NULL AS hasChartTab,
-        JSON_EXTRACT(chart_configs.full, "$.hasMapTab") = true AS hasMapTab,
-        JSON_EXTRACT(chart_configs.full, "$.isPublished") = true AS isPublished,
+        JSON_EXTRACT(chart_configs.config, "$.hasMapTab") = true AS hasMapTab,
+        JSON_EXTRACT(chart_configs.config, "$.isPublished") = true AS isPublished,
         charts.lastEditedAt,
         charts.lastEditedByUserId,
         lastEditedByUser.fullName AS lastEditedBy,
@@ -606,7 +613,7 @@ export const getMostViewedGrapherIdsByChartType = async (
             JOIN charts c ON c.configId = cc.id
             WHERE a.url LIKE "https://ourworldindata.org/grapher/%"
                 AND cc.chartType = ?
-                AND cc.full ->> "$.isPublished" = "true"
+                AND cc.config ->> "$.isPublished" = "true"
             ORDER BY a.views_365d DESC
             LIMIT ?
         `,
@@ -641,15 +648,15 @@ export const getRelatedChartsForVariable = async (
             SELECT
                 charts.id AS chartId,
                 chart_configs.slug,
-                chart_configs.full->>"$.title" AS title,
-                chart_configs.full->>"$.variantName" AS variantName,
+                chart_configs.config->>"$.title" AS title,
+                chart_configs.config->>"$.variantName" AS variantName,
                 MAX(chart_tags.keyChartLevel) as keyChartLevel
             FROM charts
             JOIN chart_configs ON charts.configId=chart_configs.id
             INNER JOIN chart_tags ON charts.id=chart_tags.chartId
             INNER JOIN chart_dimensions ON charts.id=chart_dimensions.chartId
             WHERE chart_dimensions.variableId = ${variableId}
-            AND chart_configs.full->>"$.isPublished" = "true"
+            AND chart_configs.config->>"$.isPublished" = "true"
             ${filterUnlistedClause}
             ${excludeChartIds}
             GROUP BY charts.id
@@ -671,8 +678,8 @@ export const getRelatedChartsForChart = async (
             SELECT
                 charts.id AS chartId,
                 chart_configs.slug,
-                chart_configs.full->>"$.title" AS title,
-                chart_configs.full->>"$.variantName" AS variantName
+                chart_configs.config->>"$.title" AS title,
+                chart_configs.config->>"$.variantName" AS variantName
             FROM ${RelatedChartsTableName} rc
             JOIN charts ON charts.id = rc.relatedChartId
             JOIN chart_configs ON charts.configId = chart_configs.id
@@ -680,7 +687,7 @@ export const getRelatedChartsForChart = async (
                 AND rc.relatedChartId != rc.chartId
                 AND rc.reviewer = 'production'
                 AND rc.label = 'good'
-                AND chart_configs.full->>"$.isPublished" = "true"
+                AND chart_configs.config->>"$.isPublished" = "true"
                 AND NOT EXISTS (
                     SELECT 1 FROM chart_tags ct
                     JOIN tags t ON ct.tagId = t.id
@@ -722,7 +729,7 @@ export async function getAllPublishedChartSlugs(
             SELECT cc.slug
             FROM charts c
             JOIN chart_configs cc ON c.configId = cc.id
-            WHERE cc.full->>"$.isPublished" = "true"
+            WHERE cc.config->>"$.isPublished" = "true"
         `
     )
     return rows.map((row) => row.slug)

--- a/db/model/ChartConfigs.ts
+++ b/db/model/ChartConfigs.ts
@@ -1,45 +1,60 @@
 import {
     ChartConfigsTableName,
-    DbEnrichedChartConfig,
     DbInsertChartConfig,
     DbRawChartConfig,
     GrapherInterface,
     parseChartConfig,
-    parseChartConfigsRow,
     serializeChartConfig,
 } from "@ourworldindata/types"
 
+import { v7 as uuidv7 } from "uuid"
+
 import * as db from "../db.js"
 
-export async function getChartConfigById(
+export async function getChartConfigByUUID(
     knex: db.KnexReadonlyTransaction,
     id: string
-): Promise<DbEnrichedChartConfig | undefined> {
-    const chartConfig = await knex<DbRawChartConfig>(ChartConfigsTableName)
-        .where("id", id)
-        .first()
-    return chartConfig ? parseChartConfigsRow(chartConfig) : undefined
+): Promise<GrapherInterface | undefined> {
+    const row = await db.knexRawFirst<Pick<DbRawChartConfig, "config">>(
+        knex,
+        `SELECT config FROM chart_configs WHERE id = ?`,
+        [id]
+    )
+    return row ? parseChartConfig(row.config) : undefined
 }
 
+/** Returns the id of the new row, which it mints. */
 export async function insertChartConfig(
     knex: db.KnexReadWriteTransaction,
-    config: DbInsertChartConfig
+    {
+        config,
+        createdAt,
+        updatedAt,
+    }: {
+        config: GrapherInterface
+        createdAt?: Date
+        updatedAt?: Date
+    }
 ): Promise<string> {
-    await knex(ChartConfigsTableName).insert(config)
-    return config.id
+    const id = uuidv7()
+    await knex<DbInsertChartConfig>(ChartConfigsTableName).insert({
+        id,
+        config: serializeChartConfig(config),
+        createdAt,
+        updatedAt,
+    })
+    return id
 }
 
-export async function updateExistingConfigPair(
+export async function updateChartConfig(
     knex: db.KnexReadWriteTransaction,
     {
         configId,
-        patchConfig,
-        fullConfig,
+        config,
         updatedAt,
     }: {
         configId: DbInsertChartConfig["id"]
-        patchConfig: GrapherInterface
-        fullConfig: GrapherInterface
+        config: GrapherInterface
         updatedAt: Date
     }
 ): Promise<void> {
@@ -48,74 +63,10 @@ export async function updateExistingConfigPair(
         `-- sql
             UPDATE chart_configs
             SET
-                patch = ?,
-                full = ?,
+                config = ?,
                 updatedAt = ?
             WHERE id = ?
         `,
-        [
-            serializeChartConfig(patchConfig),
-            serializeChartConfig(fullConfig),
-            updatedAt,
-            configId,
-        ]
+        [serializeChartConfig(config), updatedAt, configId]
     )
-}
-
-type ConfigId = DbInsertChartConfig["id"]
-interface UpdateFields {
-    config: GrapherInterface
-    updatedAt: Date
-}
-
-export async function updateExistingPatchConfig(
-    knex: db.KnexReadWriteTransaction,
-    params: UpdateFields & { configId: ConfigId }
-): Promise<void> {
-    await updateExistingConfig(knex, { ...params, column: "patch" })
-}
-
-export async function updateExistingFullConfig(
-    knex: db.KnexReadWriteTransaction,
-    params: UpdateFields & { configId: ConfigId }
-): Promise<void> {
-    await updateExistingConfig(knex, { ...params, column: "full" })
-}
-
-async function updateExistingConfig(
-    knex: db.KnexReadWriteTransaction,
-    {
-        column,
-        configId,
-        config,
-        updatedAt,
-    }: UpdateFields & {
-        configId: ConfigId
-        column: "patch" | "full"
-    }
-): Promise<void> {
-    await db.knexRaw(
-        knex,
-        `-- sql
-            UPDATE chart_configs
-            SET
-                ?? = ?,
-                updatedAt = ?
-            WHERE id = ?
-        `,
-        [column, serializeChartConfig(config), updatedAt, configId]
-    )
-}
-
-export async function getChartConfigByUuid(
-    knex: db.KnexReadonlyTransaction,
-    uuid: string
-): Promise<GrapherInterface | undefined> {
-    const row = await db.knexRawFirst<Pick<DbRawChartConfig, "full">>(
-        knex,
-        `SELECT full FROM chart_configs WHERE id = ?`,
-        [uuid]
-    )
-    if (!row) return undefined
-    return parseChartConfig(row.full)
 }

--- a/db/model/Dod.ts
+++ b/db/model/Dod.ts
@@ -153,11 +153,11 @@ export async function getDodsUsage(
     const chartsUsagePromise = knexRaw<{ slug: string; config: string }>(
         knex,
         `-- sql
-        SELECT cc.slug, cc.full AS config
+        SELECT cc.slug, cc.config AS config
         FROM ${ChartConfigsTableName} cc
         JOIN ${ChartsTableName} c ON c.configId = cc.id
-        WHERE cc.full LIKE "%#dod:%"
-        AND cc.full->>"$.isPublished" = "true"`
+        WHERE cc.config LIKE "%#dod:%"
+        AND cc.config->>"$.isPublished" = "true"`
     ).then((rows) =>
         rows.reduce(
             (acc, cur) => {

--- a/db/model/ExplorerViews.ts
+++ b/db/model/ExplorerViews.ts
@@ -2,8 +2,6 @@ import { KnexReadWriteTransaction, knexRaw } from "../db.js"
 import {
     DbInsertExplorerView,
     DbRawExplorerView,
-    serializeChartConfig,
-    DbInsertChartConfig,
     parseChartConfig,
     GrapherInterface,
     DbPlainChart,
@@ -16,10 +14,10 @@ import {
     ExplorerProps,
 } from "@ourworldindata/explorer"
 import { transformExplorerProgramToResolveCatalogPaths } from "./ExplorerCatalogResolver.js"
-import { insertChartConfig, updateExistingConfigPair } from "./ChartConfigs.js"
-import { v7 as uuidv7 } from "uuid"
+import { insertChartConfig, updateChartConfig } from "./ChartConfigs.js"
+import { mergeVariableChartConfigs } from "./Variable.js"
 import * as _ from "lodash-es"
-import { mergeGrapherConfigs, dimensionsToViewId } from "@ourworldindata/utils"
+import { dimensionsToViewId } from "@ourworldindata/utils"
 import { logErrorAndMaybeCaptureInSentry } from "../../serverUtils/errorLog.js"
 import {
     ADMIN_BASE_URL,
@@ -64,11 +62,11 @@ async function fetchExplorerDataForViews(
     let grapherConfigRows: ChartRow[] = []
     if (requiredGrapherIds.length)
         grapherConfigRows = await knexRaw<
-            Pick<DbPlainChart, "id"> & { config: DbRawChartConfig["full"] }
+            Pick<DbPlainChart, "id"> & { config: DbRawChartConfig["config"] }
         >(
             knex,
             `-- sql
-                SELECT c.id, cc.full as config
+                SELECT c.id, cc.config as config
                 FROM charts c
                 JOIN chart_configs cc ON c.configId=cc.id
                 WHERE c.id IN (?)
@@ -87,11 +85,11 @@ async function fetchExplorerDataForViews(
             `-- sql
                 SELECT
                     v.id,
-                    cc_etl.patch AS grapherConfigETL,
-                    cc_admin.patch AS grapherConfigAdmin
+                    cc_etl.config AS grapherConfigETL,
+                    cc_admin.config AS grapherConfigAdmin
                 FROM variables v
-                    LEFT JOIN chart_configs cc_admin ON cc_admin.id=v.grapherConfigIdAdmin
-                    LEFT JOIN chart_configs cc_etl ON cc_etl.id=v.grapherConfigIdETL
+                    LEFT JOIN chart_configs cc_admin ON cc_admin.id=v.patchConfigIdAdmin
+                    LEFT JOIN chart_configs cc_etl ON cc_etl.id=v.patchConfigIdETL
                 WHERE v.id IN (?)
             `,
             [requiredVariableIds]
@@ -120,19 +118,21 @@ async function fetchExplorerDataForViews(
     const partialGrapherConfigs = partialGrapherConfigRows
         .filter((row) => row.grapherConfigAdmin || row.grapherConfigETL)
         .map((row) => {
-            const adminConfig = row.grapherConfigAdmin
-                ? parseGrapherConfigFromRow({
-                      id: row.id,
-                      config: row.grapherConfigAdmin,
-                  })
-                : {}
-            const etlConfig = row.grapherConfigETL
-                ? parseGrapherConfigFromRow({
-                      id: row.id,
-                      config: row.grapherConfigETL,
-                  })
-                : {}
-            const mergedConfig = mergeGrapherConfigs(etlConfig, adminConfig)
+            const mergedConfig =
+                mergeVariableChartConfigs({
+                    etl: row.grapherConfigETL
+                        ? parseGrapherConfigFromRow({
+                              id: row.id,
+                              config: row.grapherConfigETL,
+                          })
+                        : undefined,
+                    admin: row.grapherConfigAdmin
+                        ? parseGrapherConfigFromRow({
+                              id: row.id,
+                              config: row.grapherConfigAdmin,
+                          })
+                        : undefined,
+                }) ?? {}
             // explorers set their own dimensions, so we don't need to include them here
             const mergedConfigWithoutDimensions = {
                 ...mergedConfig,
@@ -280,11 +280,17 @@ export async function refreshExplorerViewsForSlug(
         DbRawExplorerView,
         "id" | "viewId" | "chartConfigId" | "error"
     > & {
-        full: string | null
+        config: string | null
     }
 
     const existingViews: ExistingView[] = await knex
-        .select("ev.id", "ev.viewId", "ev.chartConfigId", "ev.error", "cc.full")
+        .select(
+            "ev.id",
+            "ev.viewId",
+            "ev.chartConfigId",
+            "ev.error",
+            "cc.config"
+        )
         .from("explorer_views as ev")
         .leftJoin("chart_configs as cc", "ev.chartConfigId", "cc.id")
         .where("ev.explorerSlug", slug)
@@ -342,12 +348,12 @@ export async function refreshExplorerViewsForSlug(
             } else if (
                 !existingView.error &&
                 !generatedView.error &&
-                existingView.full &&
+                existingView.config &&
                 generatedView.config
             ) {
                 // Both have successful configs, compare them
                 try {
-                    const existingConfig = parseChartConfig(existingView.full)
+                    const existingConfig = parseChartConfig(existingView.config)
                     configsEqual = _.isEqual(
                         existingConfig,
                         generatedView.config
@@ -425,10 +431,9 @@ export async function refreshExplorerViewsForSlug(
             }
         } else if (generated.config && existing.chartConfigId) {
             // Update existing chart config
-            await updateExistingConfigPair(knex, {
+            await updateChartConfig(knex, {
                 configId: existing.chartConfigId,
-                patchConfig: generated.config,
-                fullConfig: generated.config,
+                config: generated.config,
                 updatedAt: new Date(),
             })
 
@@ -440,13 +445,9 @@ export async function refreshExplorerViewsForSlug(
                 .update({ error: null })
         } else if (generated.config && !existing.chartConfigId) {
             // Create new chart config for previously failed view
-            const chartConfigId = uuidv7()
-            const chartConfig: DbInsertChartConfig = {
-                id: chartConfigId,
-                patch: serializeChartConfig(generated.config),
-                full: serializeChartConfig(generated.config),
-            }
-            await insertChartConfig(knex, chartConfig)
+            const chartConfigId = await insertChartConfig(knex, {
+                config: generated.config,
+            })
 
             await knex(ExplorerViewDimensionsTableName).insert({
                 chartConfigId,
@@ -472,13 +473,9 @@ export async function refreshExplorerViewsForSlug(
                 explorerViewsToInsert.push(insertView)
             } else if (newView.config) {
                 // Create chart config first
-                const chartConfigId = uuidv7()
-                const chartConfig: DbInsertChartConfig = {
-                    id: chartConfigId,
-                    patch: serializeChartConfig(newView.config),
-                    full: serializeChartConfig(newView.config),
-                }
-                await insertChartConfig(knex, chartConfig)
+                const chartConfigId = await insertChartConfig(knex, {
+                    config: newView.config,
+                })
 
                 await knex(ExplorerViewDimensionsTableName).insert({
                     chartConfigId,

--- a/db/model/Gdoc/GdocPost.ts
+++ b/db/model/Gdoc/GdocPost.ts
@@ -182,14 +182,14 @@ export class GdocPost extends GdocBase implements OwidGdocPostInterface {
                 SELECT DISTINCT
                     charts.id AS chartId,
                     chart_configs.slug,
-                    chart_configs.full->>"$.title" AS title,
-                    chart_configs.full->>"$.variantName" AS variantName,
+                    chart_configs.config->>"$.title" AS title,
+                    chart_configs.config->>"$.variantName" AS variantName,
                     chart_tags.keyChartLevel
                 FROM charts
                 JOIN chart_configs ON charts.configId=chart_configs.id
                 INNER JOIN chart_tags ON charts.id=chart_tags.chartId
                 WHERE chart_tags.tagId IN (?)
-                    AND chart_configs.full->>"$.isPublished" = "true"
+                    AND chart_configs.config->>"$.isPublished" = "true"
                 ORDER BY title ASC
             `,
             [this.tags.map((tag) => tag.id)]

--- a/db/model/Gdoc/dataCallouts.ts
+++ b/db/model/Gdoc/dataCallouts.ts
@@ -41,7 +41,7 @@ import { getMergedGrapherConfigForVariable } from "../Variable.js"
 import { getExplorerBySlug } from "../Explorer.js"
 import { transformExplorerProgramToResolveCatalogPaths } from "../ExplorerCatalogResolver.js"
 import { getMultiDimDataPageBySlug } from "../MultiDimDataPage.js"
-import { getChartConfigByUuid } from "../ChartConfigs.js"
+import { getChartConfigByUUID } from "../ChartConfigs.js"
 
 /**
  * Extract all data-callout blocks from an array of enriched blocks.
@@ -115,7 +115,7 @@ export async function prepareCalloutTableForUrl(
             multiDimPage.config,
             searchParams
         )
-        config = await getChartConfigByUuid(knex, view.fullConfigId)
+        config = await getChartConfigByUUID(knex, view.fullConfigId)
         if (!config) return undefined
     }
 

--- a/db/model/NarrativeChart.ts
+++ b/db/model/NarrativeChart.ts
@@ -42,7 +42,7 @@ export const getNarrativeChartsInfo = async (
     const rows: RawRow[] = await knex("narrative_charts as nc")
         .select(
             "nc.name",
-            knex.raw('cc.full ->> "$.title" as title'),
+            knex.raw('cc.config ->> "$.title" as title'),
             "nc.chartConfigId",
             knex.raw("COALESCE(pcc.slug, mddp.slug) as parentChartSlug"),
             "nc.queryParamsForParentChart",

--- a/db/model/Post.ts
+++ b/db/model/Post.ts
@@ -100,15 +100,15 @@ export const getPostRelatedCharts = async (
         `-- sql
         SELECT DISTINCT
             chart_configs.slug,
-            chart_configs.full->>"$.title" AS title,
-            chart_configs.full->>"$.variantName" AS variantName,
+            chart_configs.config->>"$.title" AS title,
+            chart_configs.config->>"$.variantName" AS variantName,
             chart_tags.keyChartLevel
         FROM charts
         JOIN chart_configs ON charts.configId=chart_configs.id
         INNER JOIN chart_tags ON charts.id=chart_tags.chartId
         INNER JOIN post_tags ON chart_tags.tagId=post_tags.tag_id
         WHERE post_tags.post_id=${postId}
-        AND chart_configs.full->>"$.isPublished" = "true"
+        AND chart_configs.config->>"$.isPublished" = "true"
         ORDER BY title ASC
     `
     )

--- a/db/model/Variable.ts
+++ b/db/model/Variable.ts
@@ -13,7 +13,6 @@ import {
     getVariableMetadataRoute,
 } from "@ourworldindata/grapher"
 import pl from "nodejs-polars"
-import { v7 as uuidv7 } from "uuid"
 import { DATA_API_URL } from "../../settings/serverSettings.js"
 import { escape } from "mysql2"
 import {
@@ -40,21 +39,28 @@ import {
     normalizeDescriptionKey,
 } from "@ourworldindata/types"
 import { knexRaw, knexRawFirst } from "../db.js"
-import {
-    updateExistingConfigPair,
-    updateExistingFullConfig,
-} from "./ChartConfigs.js"
+import { insertChartConfig, updateChartConfig } from "./ChartConfigs.js"
 
-interface ChartConfigPair {
+interface VariableChartConfig {
     configId: DbEnrichedChartConfig["id"]
-    patchConfig: DbEnrichedChartConfig["patch"]
-    fullConfig: DbEnrichedChartConfig["full"]
+    config: DbEnrichedChartConfig["config"]
 }
 
 interface VariableWithGrapherConfigs {
     variableId: DbEnrichedVariable["id"]
-    admin?: ChartConfigPair
-    etl?: ChartConfigPair
+    admin?: VariableChartConfig
+    etl?: VariableChartConfig
+}
+
+export function mergeVariableChartConfigs({
+    etl,
+    admin,
+}: {
+    etl?: GrapherInterface
+    admin?: GrapherInterface
+}): GrapherInterface | undefined {
+    if (!etl && !admin) return undefined
+    return mergeGrapherConfigs(etl ?? {}, admin ?? {})
 }
 
 export async function getGrapherConfigsForVariable(
@@ -64,27 +70,23 @@ export async function getGrapherConfigsForVariable(
     const variable = await knexRawFirst<
         Pick<
             DbRawVariable,
-            "id" | "grapherConfigIdAdmin" | "grapherConfigIdETL"
+            "id" | "patchConfigIdAdmin" | "patchConfigIdETL"
         > & {
-            patchConfigAdmin?: DbRawChartConfig["patch"]
-            patchConfigETL?: DbRawChartConfig["patch"]
-            fullConfigAdmin?: DbRawChartConfig["full"]
-            fullConfigETL?: DbRawChartConfig["full"]
+            configAdmin?: DbRawChartConfig["config"]
+            configETL?: DbRawChartConfig["config"]
         }
     >(
         knex,
         `-- sql
             SELECT
                 v.id,
-                v.grapherConfigIdAdmin,
-                v.grapherConfigIdETL,
-                cc_admin.patch AS patchConfigAdmin,
-                cc_admin.full AS fullConfigAdmin,
-                cc_etl.patch AS patchConfigETL,
-                cc_etl.full AS fullConfigETL
+                v.patchConfigIdAdmin,
+                v.patchConfigIdETL,
+                cc_admin.config AS configAdmin,
+                cc_etl.config AS configETL
             FROM variables v
-            LEFT JOIN chart_configs cc_admin ON v.grapherConfigIdAdmin = cc_admin.id
-            LEFT JOIN chart_configs cc_etl ON v.grapherConfigIdETL = cc_etl.id
+            LEFT JOIN chart_configs cc_admin ON v.patchConfigIdAdmin = cc_admin.id
+            LEFT JOIN chart_configs cc_etl ON v.patchConfigIdETL = cc_etl.id
             WHERE v.id = ?
         `,
         [variableId]
@@ -96,19 +98,17 @@ export async function getGrapherConfigsForVariable(
         config: string | undefined
     ): GrapherInterface => (config ? parseChartConfig(config) : {})
 
-    const admin = variable.grapherConfigIdAdmin
+    const admin = variable.patchConfigIdAdmin
         ? {
-              configId: variable.grapherConfigIdAdmin,
-              patchConfig: maybeParseChartConfig(variable.patchConfigAdmin),
-              fullConfig: maybeParseChartConfig(variable.fullConfigAdmin),
+              configId: variable.patchConfigIdAdmin,
+              config: maybeParseChartConfig(variable.configAdmin),
           }
         : undefined
 
-    const etl = variable.grapherConfigIdETL
+    const etl = variable.patchConfigIdETL
         ? {
-              configId: variable.grapherConfigIdETL,
-              patchConfig: maybeParseChartConfig(variable.patchConfigETL),
-              fullConfig: maybeParseChartConfig(variable.fullConfigETL),
+              configId: variable.patchConfigIdETL,
+              config: maybeParseChartConfig(variable.configETL),
           }
         : undefined
 
@@ -124,7 +124,11 @@ export async function getMergedGrapherConfigForVariable(
     variableId: number
 ): Promise<GrapherInterface | undefined> {
     const variable = await getGrapherConfigsForVariable(knex, variableId)
-    return variable?.admin?.fullConfig ?? variable?.etl?.fullConfig
+    if (!variable) return undefined
+    return mergeVariableChartConfigs({
+        etl: variable.etl?.config,
+        admin: variable.admin?.config,
+    })
 }
 
 export async function getMergedGrapherConfigsForVariables(
@@ -140,8 +144,10 @@ export async function getMergedGrapherConfigsForVariables(
     const configs = new Map<number, GrapherInterface>()
     for (const variable of variables) {
         if (variable) {
-            const config =
-                variable.admin?.fullConfig ?? variable.etl?.fullConfig
+            const config = mergeVariableChartConfigs({
+                etl: variable.etl?.config,
+                admin: variable.admin?.config,
+            })
             if (config) {
                 configs.set(variable.variableId, config)
             }
@@ -151,41 +157,26 @@ export async function getMergedGrapherConfigsForVariables(
 }
 
 export async function insertNewGrapherConfigForVariable(
-    knex: db.KnexReadonlyTransaction,
+    knex: db.KnexReadWriteTransaction,
     {
         type,
         variableId,
-        patchConfig,
-        fullConfig,
+        config,
         now,
     }: {
         type: "admin" | "etl"
         variableId: number
-        patchConfig: GrapherInterface
-        fullConfig: GrapherInterface
+        config: GrapherInterface
         now: Date
     }
 ): Promise<void> {
-    // insert chart configs into the database
-    const configId = uuidv7()
-    await db.knexRaw(
-        knex,
-        `-- sql
-            INSERT INTO chart_configs (id, patch, full, createdAt, updatedAt)
-            VALUES (?, ?, ?, ?, ?)
-        `,
-        [
-            configId,
-            JSON.stringify(patchConfig),
-            JSON.stringify(fullConfig),
-            now,
-            now,
-        ]
-    )
+    const configId = await insertChartConfig(knex, {
+        config,
+        createdAt: now,
+        updatedAt: now,
+    })
 
-    // make a reference to the config from the variables table
-    const column =
-        type === "admin" ? "grapherConfigIdAdmin" : "grapherConfigIdETL"
+    const column = type === "admin" ? "patchConfigIdAdmin" : "patchConfigIdETL"
     await db.knexRaw(
         knex,
         `-- sql
@@ -241,7 +232,7 @@ async function findAllChartsThatInheritFromIndicator(
     const charts = await db.knexRaw<{
         chartId: DbPlainChart["id"]
         chartConfigId: DbRawChartConfig["id"]
-        patchConfig: DbRawChartConfig["patch"]
+        patchConfig: DbRawChartConfig["config"]
         isPublished: boolean
     }>(
         trx,
@@ -249,10 +240,11 @@ async function findAllChartsThatInheritFromIndicator(
             SELECT
                 c.id as chartId,
                 cc.id as chartConfigId,
-                cc.patch as patchConfig,
-                cc.full ->> "$.isPublished" as isPublished
+                cc_patch.config as patchConfig,
+                cc.config ->> "$.isPublished" = "true" as isPublished
             FROM charts c
                 JOIN chart_configs cc ON cc.id = c.configId
+                JOIN chart_configs cc_patch ON cc_patch.id = c.patchConfigId
                 JOIN charts_x_parents cxp ON c.id = cxp.chartId
             WHERE
                 c.isInheritanceEnabled IS TRUE
@@ -264,7 +256,7 @@ async function findAllChartsThatInheritFromIndicator(
         chartId: chart.chartId,
         chartConfigId: chart.chartConfigId,
         patchConfig: parseChartConfig(chart.patchConfig),
-        isPublished: chart.isPublished,
+        isPublished: Boolean(chart.isPublished),
     }))
 }
 
@@ -298,7 +290,7 @@ export async function updateAllChartsThatInheritFromIndicator(
                 UPDATE chart_configs cc
                 JOIN charts c ON c.configId = cc.id
                 SET
-                    cc.full = ?,
+                    cc.config = ?,
                     cc.updatedAt = ?,
                     c.updatedAt = ?
                 WHERE cc.id = ?
@@ -328,18 +320,18 @@ async function findAllMultiDimViewsThatInheritFromIndicator(
 > {
     const charts = await db.knexRaw<{
         chartConfigId: DbPlainMultiDimXChartConfig["chartConfigId"]
-        patchConfig: DbRawChartConfig["patch"]
+        patchConfig: DbRawChartConfig["config"]
         isPublished: boolean
     }>(
         trx,
         `-- sql
             SELECT
                 mdxcc.chartConfigId as chartConfigId,
-                cc.patch as patchConfig,
+                cc.config as patchConfig,
                 md.published as isPublished
             FROM multi_dim_data_pages md
                 JOIN multi_dim_x_chart_configs mdxcc ON mdxcc.multiDimId = md.id
-                JOIN chart_configs cc ON cc.id = mdxcc.chartConfigId
+                JOIN chart_configs cc ON cc.id = mdxcc.patchConfigId
             WHERE mdxcc.variableId = ?
         `,
         [variableId]
@@ -385,7 +377,7 @@ export async function updateAllMultiDimViewsThatInheritFromIndicator(
             `-- sql
                 UPDATE chart_configs
                 SET
-                    full = ?,
+                    config = ?,
                     updatedAt = ?
                 WHERE id = ?
             `,
@@ -419,38 +411,23 @@ export async function updateGrapherConfigETLOfVariable(
     const now = new Date()
 
     if (variable.etl) {
-        await updateExistingConfigPair(trx, {
+        await updateChartConfig(trx, {
             configId: variable.etl.configId,
-            patchConfig: configETL,
-            fullConfig: configETL,
+            config: configETL,
             updatedAt: now,
         })
     } else {
         await insertNewGrapherConfigForVariable(trx, {
             type: "etl",
             variableId,
-            patchConfig: configETL,
-            fullConfig: configETL,
+            config: configETL,
             now,
-        })
-    }
-
-    // update admin-authored full config it is exists
-    if (variable.admin) {
-        const fullConfig = mergeGrapherConfigs(
-            configETL,
-            variable.admin.patchConfig
-        )
-        await updateExistingFullConfig(trx, {
-            configId: variable.admin.configId,
-            config: fullConfig,
-            updatedAt: now,
         })
     }
 
     const updates = {
         patchConfigETL: configETL,
-        patchConfigAdmin: variable.admin?.patchConfig,
+        patchConfigAdmin: variable.admin?.config,
         updatedAt: now,
     }
     const updatedCharts = await updateAllChartsThatInheritFromIndicator(
@@ -490,12 +467,7 @@ export async function updateGrapherConfigAdminOfVariable(
 
     const patchConfigAdmin = diffGrapherConfigs(
         validConfig,
-        variable.etl?.fullConfig ?? {}
-    )
-
-    const fullConfigAdmin = mergeGrapherConfigs(
-        variable.etl?.patchConfig ?? {},
-        patchConfigAdmin
+        variable.etl?.config ?? {}
     )
 
     // Set the updatedAt manually instead of letting the DB do it so it is the
@@ -504,24 +476,22 @@ export async function updateGrapherConfigAdminOfVariable(
     const now = new Date()
 
     if (variable.admin) {
-        await updateExistingConfigPair(trx, {
+        await updateChartConfig(trx, {
             configId: variable.admin.configId,
-            patchConfig: patchConfigAdmin,
-            fullConfig: fullConfigAdmin,
+            config: patchConfigAdmin,
             updatedAt: now,
         })
     } else {
         await insertNewGrapherConfigForVariable(trx, {
             type: "admin",
             variableId,
-            patchConfig: patchConfigAdmin,
-            fullConfig: fullConfigAdmin,
+            config: patchConfigAdmin,
             now,
         })
     }
 
     const updates = {
-        patchConfigETL: variable.etl?.patchConfig ?? {},
+        patchConfigETL: variable.etl?.config ?? {},
         patchConfigAdmin: patchConfigAdmin,
         updatedAt: now,
     }
@@ -558,7 +528,7 @@ export async function getAllChartsForIndicator(
 > {
     const charts = await db.knexRaw<{
         chartId: DbPlainChart["id"]
-        config: DbRawChartConfig["full"]
+        config: DbRawChartConfig["config"]
         isPublished: boolean
         isChild: boolean
         isInheritanceEnabled: DbPlainChart["isInheritanceEnabled"]
@@ -567,8 +537,8 @@ export async function getAllChartsForIndicator(
         `-- sql
         SELECT
             c.id AS chartId,
-            cc.full AS config,
-            cc.full ->> '$.isPublished' = "true" AS isPublished,
+            cc.config AS config,
+            cc.config ->> '$.isPublished' = "true" AS isPublished,
             cxp.variableId = ? AS isChild,
             c.isInheritanceEnabled
         FROM charts c

--- a/db/model/archival/archivalDb.ts
+++ b/db/model/archival/archivalDb.ts
@@ -78,13 +78,13 @@ export const getGrapherChecksumsFromDb = async (
         SELECT
             c.id AS chartId,
             cc.slug AS chartSlug,
-            cc.fullMd5 AS chartConfigMd5,
+            cc.configMd5 AS chartConfigMd5,
             JSON_OBJECTAGG(v.id, JSON_OBJECT("metadataChecksum", v.metadataChecksum, "dataChecksum", v.dataChecksum)) AS indicators
         FROM charts c
         JOIN chart_configs cc on c.configId = cc.id
         JOIN chart_dimensions cd on cd.chartId = c.id
         JOIN variables v on cd.variableId = v.id
-        WHERE cc.full ->> "$.isPublished" = "true"
+        WHERE cc.config ->> "$.isPublished" = "true"
         ${slugs ? `AND cc.slug IN (${slugs.map(() => "?").join(",")})` : ""}
         GROUP BY c.id
         ORDER BY c.id
@@ -232,7 +232,7 @@ export const getMultiDimChecksumsFromDb = async (
         SELECT
             mdxcc.multiDimId,
             mdxcc.chartConfigId,
-            cc.fullMd5 AS chartConfigMd5
+            cc.configMd5 AS chartConfigMd5
         FROM multi_dim_x_chart_configs mdxcc
         JOIN chart_configs cc ON mdxcc.chartConfigId = cc.id
         WHERE mdxcc.multiDimId IN (${multiDimPages.map(() => "?").join(",")})`,
@@ -361,8 +361,8 @@ export const getExplorerChecksumsFromDb = async (
         SELECT
             ev.explorerSlug,
             ev.chartConfigId,
-            cc.fullMd5 AS chartConfigMd5,
-            cc.full AS chartConfigFull
+            cc.configMd5 AS chartConfigMd5,
+            cc.config AS chartConfigFull
         FROM explorer_views ev
         JOIN chart_configs cc ON ev.chartConfigId = cc.id
         WHERE ev.chartConfigId IS NOT NULL
@@ -489,9 +489,9 @@ export const getNarrativeChartChecksumsFromDb = async (
         .select(
             "nc.id",
             "nc.name",
-            "cc.fullMd5 as chartConfigMd5",
+            "cc.configMd5 as chartConfigMd5",
             "nc.queryParamsForParentChartMd5",
-            "cc.full as config"
+            "cc.config as config"
         )
         .join("chart_configs as cc", "nc.chartConfigId", "cc.id")
 

--- a/db/tests/testHelpers.ts
+++ b/db/tests/testHelpers.ts
@@ -70,32 +70,32 @@ export async function insertTestChartConfig(
     config: GrapherInterface = {},
     id: string = uuidv7()
 ): Promise<string> {
-    const serializedConfig = JSON.stringify(config)
-    const row: DbInsertChartConfig = {
-        id,
-        patch: serializedConfig,
-        full: serializedConfig,
-    }
+    const row: DbInsertChartConfig = { id, config: JSON.stringify(config) }
     await knexInstance(ChartConfigsTableName).insert(row)
     return id
 }
 
-/** Inserts a chart_configs row together with the charts row that owns it. */
+/**
+ * Inserts the resolved and patch chart_configs rows together with the charts
+ * row that owns them.
+ */
 export async function insertTestChart(
     knexInstance: Knex<any, unknown[]>,
     {
         config,
         lastEditedByUserId,
     }: { config?: GrapherInterface; lastEditedByUserId: number }
-): Promise<{ chartId: number; configId: string }> {
+): Promise<{ chartId: number; configId: string; patchConfigId: string }> {
     const configId = await insertTestChartConfig(knexInstance, config)
+    const patchConfigId = await insertTestChartConfig(knexInstance, config)
     const row: DbInsertChart = {
         configId,
+        patchConfigId,
         lastEditedAt: new Date(),
         lastEditedByUserId,
     }
     const [chartId] = await knexInstance(ChartsTableName).insert(row)
-    return { chartId, configId }
+    return { chartId, configId, patchConfigId }
 }
 
 export function sleep(time: number, value: unknown): Promise<any> {

--- a/devTools/refreshExplorerViews.ts
+++ b/devTools/refreshExplorerViews.ts
@@ -154,7 +154,7 @@ async function prepareGrapherConfigsForExplorerViews(
 
                 // Batch fetch chart configs for R2 sync
                 const chartConfigs = await knex("chart_configs")
-                    .select("id", "full", "fullMd5")
+                    .select("id", "config", "configMd5")
                     .whereIn("id", chartConfigIdsToSync)
 
                 // Sync to R2 in parallel with limited concurrency using pMap
@@ -164,8 +164,8 @@ async function prepareGrapherConfigsForExplorerViews(
                         try {
                             await saveGrapherConfigToR2ByUUID(
                                 config.id,
-                                config.full,
-                                config.fullMd5
+                                config.config,
+                                config.configMd5
                             )
                         } catch (error) {
                             void logErrorAndMaybeCaptureInSentry(

--- a/devTools/svgTester/dump-data.ts
+++ b/devTools/svgTester/dump-data.ts
@@ -89,11 +89,11 @@ async function getAllPublishedMultiDimViews(
 
     // Fetch all chart configs
     const rows = await trx<DbRawChartConfig>(ChartConfigsTableName)
-        .select("id", "full")
+        .select("id", "config")
         .whereIn("id", [...chartConfigIds])
 
     const chartConfigsById = new Map(
-        rows.map((row) => [row.id, parseChartConfig(row.full)])
+        rows.map((row) => [row.id, parseChartConfig(row.config)])
     )
 
     // Create a config for each view with slug + viewId as the ID

--- a/devTools/syncGraphersToR2/syncGraphersToR2.ts
+++ b/devTools/syncGraphersToR2/syncGraphersToR2.ts
@@ -28,7 +28,7 @@ import { bytesToBase64, hexToBytes } from "../../serverUtils/serverUtil.js"
 import { HexString, R2GrapherConfigDirectory } from "@ourworldindata/types"
 import * as R from "remeda"
 
-type HashAndId = Pick<DbRawChartConfig, "fullMd5" | "id">
+type HashAndId = Pick<DbRawChartConfig, "configMd5" | "id">
 
 /** S3 list operations return at most 1000 items at a time. If there are
     more results, the NextContinueationToken is set and you have to perform
@@ -94,7 +94,7 @@ async function syncWithR2(
                 // in list of files to upsert then we don't need to upsert it
                 // so we delete it from that map
                 if (
-                    hashesOfFilesToToUpsert.get(object.Key)?.fullMd5 ===
+                    hashesOfFilesToToUpsert.get(object.Key)?.configMd5 ===
                     md5Base64
                 ) {
                     hashesOfFilesToToUpsert.delete(object.Key)
@@ -153,31 +153,31 @@ async function syncWithR2(
 
     // Chunk the inserts so that we don't need to keep all the full configs in memory
     for (const batch of R.chunk([...hashesOfFilesToToUpsert.entries()], 1000)) {
-        // Get the full configs for the batch
-        const fullConfigs = await knexRaw<
-            Pick<DbRawChartConfig, "id" | "full">
-        >(trx, `select id, full from chart_configs where id in (?)`, [
-            batch.map((entry) => entry[1].id),
-        ])
-        const fullConfigMap = new Map<string, string>(
-            fullConfigs.map(({ id, full }) => [id, full])
+        // Get the configs for the batch
+        const configs = await knexRaw<Pick<DbRawChartConfig, "id" | "config">>(
+            trx,
+            `select id, config from chart_configs where id in (?)`,
+            [batch.map((entry) => entry[1].id)]
+        )
+        const configMap = new Map<string, string>(
+            configs.map(({ id, config }) => [id, config])
         )
 
-        // Upload the full configs to R2 in parallel
+        // Upload the configs to R2 in parallel
         const uploadPromises = batch.map(async ([key, val]) => {
             const id = val.id
-            const fullMd5 = val.fullMd5
-            const full = fullConfigMap.get(id)
-            if (full === undefined) {
+            const configMd5 = val.configMd5
+            const config = configMap.get(id)
+            if (config === undefined) {
                 return Promise.reject(
-                    new Error(`Full config not found for id ${id}`)
+                    new Error(`Config not found for id ${id}`)
                 )
             }
             const putObjectCommandInput: PutObjectCommandInput = {
                 Bucket: GRAPHER_CONFIG_R2_BUCKET,
                 Key: key,
-                Body: full,
-                ContentMD5: fullMd5,
+                Body: config,
+                ContentMD5: configMd5,
                 ContentType: "application/json",
             }
             if (!dryRun)
@@ -244,14 +244,14 @@ async function main(parsedArgs: parseArgs.ParsedArgs, dryRun: boolean) {
         console.log("Syncing published charts")
         // Sync charts published by slug
         const slugsAndHashesFromDb = await knexRaw<
-            Pick<DbRawChartConfig, "slug" | "fullMd5" | "id">
+            Pick<DbRawChartConfig, "slug" | "configMd5" | "id">
         >(
             trx,
-            `select cc.slug, cc.fullMd5, cc.id
+            `select cc.slug, cc.configMd5, cc.id
              from chart_configs cc
              join charts c on c.configId = cc.id
              where cc.slug is not null
-             and cc.full ->> '$.isPublished' = "true"`
+             and cc.config ->> '$.isPublished' = "true"`
         )
         console.log(`Found ${slugsAndHashesFromDb.length} published charts`)
 
@@ -259,7 +259,7 @@ async function main(parsedArgs: parseArgs.ParsedArgs, dryRun: boolean) {
             hashesOfFilesToToUpsertBySlug.set(
                 `${pathPrefixBySlug}/${row.slug}.json`,
                 {
-                    fullMd5: row.fullMd5,
+                    configMd5: row.configMd5,
                     id: row.id,
                 }
             )
@@ -277,8 +277,8 @@ async function main(parsedArgs: parseArgs.ParsedArgs, dryRun: boolean) {
 
         // Sync charts by UUID
         const slugsAndHashesFromDbByUuid = await knexRaw<
-            Pick<DbRawChartConfig, "fullMd5" | "id">
-        >(trx, `select fullMd5, id from chart_configs`)
+            Pick<DbRawChartConfig, "configMd5" | "id">
+        >(trx, `select configMd5, id from chart_configs`)
 
         console.log(`Found ${slugsAndHashesFromDbByUuid.length} charts by UUID`)
 
@@ -286,7 +286,7 @@ async function main(parsedArgs: parseArgs.ParsedArgs, dryRun: boolean) {
             hashesOfFilesToToUpsertByUuid.set(
                 `${pathPrefixByUuid}/${row.id}.json`,
                 {
-                    fullMd5: row.fullMd5,
+                    configMd5: row.configMd5,
                     id: row.id,
                 }
             )

--- a/devTools/syncGraphersToR2/syncGraphersToR2.ts
+++ b/devTools/syncGraphersToR2/syncGraphersToR2.ts
@@ -278,9 +278,22 @@ async function main(parsedArgs: parseArgs.ParsedArgs, dryRun: boolean) {
         // Sync charts by UUID
         const slugsAndHashesFromDbByUuid = await knexRaw<
             Pick<DbRawChartConfig, "configMd5" | "id">
-        >(trx, `select configMd5, id from chart_configs`)
+        >(
+            trx,
+            `-- sql
+             select cc.configMd5, cc.id
+             from chart_configs cc
+             where cc.id in (
+                 select configId from charts
+                 union select chartConfigId from multi_dim_x_chart_configs
+                 union select chartConfigId from narrative_charts
+                 union select chartConfigId from explorer_views
+             )`
+        )
 
-        console.log(`Found ${slugsAndHashesFromDbByUuid.length} charts by UUID`)
+        console.log(
+            `Found ${slugsAndHashesFromDbByUuid.length} configs by UUID`
+        )
 
         slugsAndHashesFromDbByUuid.forEach((row) => {
             hashesOfFilesToToUpsertByUuid.set(

--- a/jobQueue/explorerJobProcessor.ts
+++ b/jobQueue/explorerJobProcessor.ts
@@ -163,7 +163,7 @@ export async function processExplorerViewsJob(
             // Fetch chart configs (simple read, no transaction needed)
             const chartConfigs = await knexReadonlyTransaction(async (knex) => {
                 return await knex("chart_configs")
-                    .select("id", "full", "fullMd5")
+                    .select("id", "config", "configMd5")
                     .whereIn("id", refreshResult.updatedChartConfigIds)
             })
 
@@ -172,8 +172,8 @@ export async function processExplorerViewsJob(
                 async (config) => {
                     await saveGrapherConfigToR2ByUUID(
                         config.id,
-                        config.full,
-                        config.fullMd5
+                        config.config,
+                        config.configMd5
                     )
                 },
                 { concurrency: CONCURRENCY }

--- a/packages/@ourworldindata/types/src/dbTypes/ChartConfigs.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/ChartConfigs.ts
@@ -7,19 +7,19 @@ import {
 export const ChartConfigsTableName = "chart_configs"
 export interface DbInsertChartConfig {
     id: string
-    patch: JsonString
-    full: JsonString
-    fullMd5?: Base64String
-    slug?: string | null
-    chartType?: GrapherChartType | null
+    config: JsonString
     createdAt?: Date
     updatedAt?: Date
 }
-export type DbRawChartConfig = Required<DbInsertChartConfig>
 
-export type DbEnrichedChartConfig = Omit<DbRawChartConfig, "patch" | "full"> & {
-    patch: GrapherInterface
-    full: GrapherInterface
+export type DbRawChartConfig = Required<DbInsertChartConfig> & {
+    slug: string | null
+    chartType: GrapherChartType | null
+    configMd5: Base64String
+}
+
+export type DbEnrichedChartConfig = Omit<DbRawChartConfig, "config"> & {
+    config: GrapherInterface
 }
 
 export function parseChartConfig(config: JsonString): GrapherInterface {
@@ -28,29 +28,4 @@ export function parseChartConfig(config: JsonString): GrapherInterface {
 
 export function serializeChartConfig(config: GrapherInterface): JsonString {
     return JSON.stringify(config)
-}
-
-export function parseChartConfigsRow<
-    T extends Pick<DbRawChartConfig, "patch" | "full">,
->(
-    row: T
-): Omit<T, "patch" | "full"> & {
-    patch: GrapherInterface
-    full: GrapherInterface
-} {
-    return {
-        ...row,
-        patch: parseChartConfig(row.patch),
-        full: parseChartConfig(row.full),
-    }
-}
-
-export function serializeChartsRow(
-    row: DbEnrichedChartConfig
-): DbRawChartConfig {
-    return {
-        ...row,
-        patch: serializeChartConfig(row.patch),
-        full: serializeChartConfig(row.full),
-    }
 }

--- a/packages/@ourworldindata/types/src/dbTypes/Charts.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/Charts.ts
@@ -1,6 +1,7 @@
 export const ChartsTableName = "charts"
 export interface DbInsertChart {
     configId: string
+    patchConfigId: string
     createdAt?: Date
     forceDatapage?: boolean
     id?: number

--- a/packages/@ourworldindata/types/src/dbTypes/MultiDimXChartConfigs.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/MultiDimXChartConfigs.ts
@@ -5,6 +5,7 @@ export type DbInsertMultiDimXChartConfig = {
     viewId: string
     variableId: number
     chartConfigId: string
+    patchConfigId: string
     createdAt?: Date
     updatedAt?: Date
 }

--- a/packages/@ourworldindata/types/src/dbTypes/NarrativeCharts.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/NarrativeCharts.ts
@@ -6,6 +6,7 @@ export interface DbInsertNarrativeChart {
     id?: number
     name: string
     chartConfigId: string
+    patchConfigId: string
     parentChartId?: number | null
     parentMultiDimXChartConfigId?: number | null
     queryParamsForParentChart: JsonString

--- a/packages/@ourworldindata/types/src/dbTypes/Variables.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/Variables.ts
@@ -19,8 +19,8 @@ export interface DbInsertVariable {
     descriptionShort?: string | null
     dimensions?: JsonString | null
     display: JsonString
-    grapherConfigIdAdmin?: string | null
-    grapherConfigIdETL?: string | null
+    patchConfigIdAdmin?: string | null
+    patchConfigIdETL?: string | null
     id?: number
     license?: JsonString | null
     licenses?: JsonString | null

--- a/packages/@ourworldindata/types/src/domainTypes/Archive.ts
+++ b/packages/@ourworldindata/types/src/domainTypes/Archive.ts
@@ -84,7 +84,7 @@ export interface MultiDimChecksumsObjectWithHash {
 export interface ExplorerChecksums {
     explorerConfigMd5: string
     chartConfigs: {
-        [id: string]: string // chartId -> chart_configs.fullMd5 of explorer view configs
+        [id: string]: string // chartId -> chart_configs.configMd5 of explorer view configs
     }
     indicators: IndicatorChecksums
 }

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -407,7 +407,6 @@ export {
     type DbInsertChartConfig,
     type DbRawChartConfig,
     type DbEnrichedChartConfig,
-    parseChartConfigsRow,
     parseChartConfig,
     serializeChartConfig,
     ChartConfigsTableName,


### PR DESCRIPTION
> _Written by Anthropic Claude Opus 5 — @sophiamersmann at the wheel._

Replaces `chart_configs.patch` + `chart_configs.full` with a single `config` column. A `chart_configs` row now holds one config, and which layer it is follows from the pointer that names it: `charts.configId` for the final config, and the new `charts.patchConfigId` for the patch layer. Same goes for mdim views and narrative charts. `variables.grapherConfigId{ETL,Admin}` are renamed to `patchConfigId{ETL,Admin}` for consistency.

**Tables that gained a patch row**

* Standalone charts: `charts.configId` points to the final config, and the new `charts.patchConfigId` points to what used to be the `patch` config.
* Mdim views: same split, with `multi_dim_x_chart_configs.chartConfigId` for the final config and the new `patchConfigId` for the YAML-authored layer.
* Narrative charts: same again, where `narrative_charts.chartConfigId` is the final config and the new `patchConfigId` points to the patch config.

**Indicator layers**

Indicator layers drop the full config and reconstruct it in code.

* ETL-authored indicator configs: `variables.grapherConfigIdETL` becomes `patchConfigIdETL`, a rename only. The row's patch and full configs were identical.
* Admin-authored indicator configs: `variables.grapherConfigIdAdmin` becomes `patchConfigIdAdmin`. The full config is dropped, and `patchConfigIdAdmin` points to the `patch` config. The final config (etl+admin) is constructed in code.

**Untouched**

* Explorer views: unchanged, since `patch` and `full` were identical.
* Mdim redirects: unchanged, since `patch` and `full` were identical.

## The migration

- Add a new column `patchConfigId` to `charts`, `multi_dim_x_chart_configs`, and `narrative_charts`
- Copy each owner's `patch` config into a row of its own and point the owner at it, keeping the source row's timestamps so chart-sync doesn't read it as a change
- Take `charts_x_parents` off `patch` (the reference to `patch` was dead anyway)
- Run `SET full = patch` on the admin indicator rows, so `config` keeps the patch rather than the merged etl+admin config
- Drop `patch` alongside the three generated columns (`slug`, `chartType`, `fullMd5`)
- Rename `full` to `config`, then put the generated columns and the slug index back
- Rename the `variables` pointers to `patchConfigId{ETL,Admin}`

## Worth a reviewer's attention

Annotated in code comments as well.

* **Behaviour change: the R2 sync script only uploads configs that are served.** It used to upload every `chart_configs.full` config (including indicator configs, which are never read but make up the vast majority, ~200.000). This reduces the configs in the PR from ~250.000 to ~25.000. Drafts are uploaded too, and explorer views as well because `refreshExplorerViews.ts` writes them there too.
* **Behaviour change: `GET /admin/api/chart-configs/:id.config.json` returns the config, not the whole row.**
* **Bug fix: an indicator config change triggered a static build even when nothing published had changed.** A query didn't check `isPublished` correctly, so drafts counted as published.
* **Bug fix: the by-slug config in R2 went stale.** An indicator config propagating into a published chart rewrote only `config/by-uuid/`, not `config/by-slug-published/<slug>.json`, so the latter stayed stale until the next sweep.

## Sibling PRs

- ETL: https://github.com/owid/etl/pull/6667
- Analytics: https://github.com/owid/analytics/pull/1003
- Automation: https://github.com/owid/automation/pull/18