### PR TITLE
Show 3 significant figures in demography population values

### DIFF
--- a/bespoke/projects/demography/src/helpers/utils.ts
+++ b/bespoke/projects/demography/src/helpers/utils.ts
@@ -59,7 +59,7 @@ export function formatPopulationValueShort(value: number): string {
 export function formatPopulationValueLong(value: number): string {
     return formatValue(value, {
         roundingMode: OwidVariableRoundingMode.significantFigures,
-        numSignificantFigures: 2,
+        numSignificantFigures: 3,
         numberAbbreviation: "long",
     })
 }


### PR DESCRIPTION
> _Written by Anthropic Claude Opus 5 — @edomt at the wheel._

Two significant figures is too coarse for population values, and the problem gets worse the bigger the country. For the US, every projected total between 415 and 425 million collapses into "420 million", so the tooltip and the chart's endpoint labels hide differences of several million people — enough that changing an assumption can visibly move the line without changing the number next to it. This bumps `formatPopulationValueLong` to 3 significant figures.

The helper is shared, so this also affects the endpoint labels on the population chart ("420 million" → "422 million") and the age-zone legend in the standalone population pyramid variant. `formatPopulationValueShort` (pyramid bar labels, where space is tight) is left at 2.

<details><summary>Details</summary>

- Single-line change in `bespoke/projects/demography/src/helpers/utils.ts`: `numSignificantFigures: 2` → `3` in `formatPopulationValueLong`.
- Call sites affected:
    - `PopulationChart.tsx:707,727,740,747` — tooltip rows (historical, "UN projection", "Your projection").
    - `PopulationChart.tsx:585,600` — the benchmark/forecast endpoint labels drawn on the chart.
    - `AgeZoneLegend.tsx:259,488,494` — total population, per-zone values, and the overflow annotation.
- Not changed: `formatPopulationDifference` (`PopulationChart.tsx:49`), the "(-130M)" figure in the tooltip and the difference label, still 2 sigfigs; and `formatPopulationValueShort`, used for pyramid bar labels.
- Worth a look when reviewing: `AgeZoneLegend` fits its per-zone value into the segment width and falls back to the short form, then hides it, when it doesn't fit (`AgeZoneLegend.tsx:493-505`). An extra digit makes that fallback slightly more likely on narrow segments.
- No tests cover these formatters. `yarn typecheck` and `yarn testLintChanged` are clean — typecheck reports pre-existing `functions/_common/grapherRenderer.ts` errors (missing `resvg-wasm`) that also occur on an unmodified tree.

</details>