### PR TITLE
Replace LatestDataInsights carousel with CSS scroll-snap

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,8 +109,6 @@
         "d3": "^7.9.0",
         "dayjs": "^1.11.21",
         "dotenv": "^17.4.2",
-        "embla-carousel-class-names": "^8.6.0",
-        "embla-carousel-react": "^8.6.0",
         "entities": "^7.0.1",
         "express": "^5.2.1",
         "figma-api": "^2.2.0-beta",

--- a/site/gdocs/components/LatestDataInsights.scss
+++ b/site/gdocs/components/LatestDataInsights.scss
@@ -94,14 +94,14 @@ html:not(.js-enabled) .latest-data-insights__card,
     box-shadow: 0 4px 24px 0 rgba(0, 0, 0, 0.08);
 }
 
-.latest-data-insights__card--see-all {
-    @include sm-up {
-        display: none;
-    }
-}
-
 .latest-data-insights__card__see-all {
     padding: 257px 0;
+}
+
+@include sm-up {
+    .latest-data-insights__card--see-all, .latest-data-insights__dot--see-all {
+        display: none;
+    }
 }
 
 // Sizing flex child picture elements is finnicky on Safari.
@@ -259,11 +259,5 @@ html:not(.js-enabled) .latest-data-insights__card,
         background-color: $blue-70;
         width: 12px;
         height: 12px;
-    }
-}
-
-.latest-data-insights__dot--see-all {
-    @include sm-up {
-        display: none;
     }
 }

--- a/site/gdocs/components/LatestDataInsights.scss
+++ b/site/gdocs/components/LatestDataInsights.scss
@@ -7,32 +7,37 @@
     }
 }
 
-.latest-data-insights__viewport {
-    overflow: hidden;
-    // Let box-shadow of the focused card overflow the container. It would
-    // happen by default with the initial value of `overflow`, which is
-    // `visible`, but we need it to be `hidden` for the carousel. We exclude
-    // the right side to keep the content clipped correctly.
-    padding: 24px 0 24px 24px;
-    margin: -24px 0 -24px -24px;
-}
-
-html:not(.js-enabled) .latest-data-insights__viewport {
-    overflow: auto;
-}
-
 .latest-data-insights__card-container {
     display: flex;
     gap: var(--grid-gap);
-    scrollbar-width: thin;
     list-style: none;
-    margin: 0;
-    padding: 0;
+    overflow-x: auto;
+    scroll-snap-type: x mandatory;
+    // Let box-shadow of the focused card overflow the container: pad the
+    // scroller and pull it back out with negative margins. We exclude the
+    // right side to keep the content clipped correctly, and offset the snap
+    // positions by the extra left padding.
+    padding: 24px 0 24px 24px;
+    margin: -24px 0 -24px -24px;
+    scroll-padding-left: 24px;
+    scrollbar-width: thin;
+}
+
+html.js-enabled .latest-data-insights__card-container {
+    // Hide the scrollbar; the carousel is controlled via the arrow buttons
+    // (desktop) and swiping (mobile). Without JS there are no buttons, so we
+    // keep a thin scrollbar as a scroll affordance.
+    scrollbar-width: none;
+
+    &::-webkit-scrollbar {
+        display: none;
+    }
 }
 
 .latest-data-insights__card {
     flex: 0 0 845px;
     height: 322px;
+    scroll-snap-align: start;
     transition:
         opacity 0.2s ease-in-out,
         box-shadow 0.2s ease-in-out;
@@ -46,7 +51,7 @@ html:not(.js-enabled) .latest-data-insights__viewport {
 }
 
 html:not(.js-enabled) .latest-data-insights__card,
-.latest-data-insights__card.is-snapped {
+.latest-data-insights__card--snapped {
     opacity: 1;
 }
 
@@ -83,9 +88,14 @@ html:not(.js-enabled) .latest-data-insights__card,
     }
 }
 
-.latest-data-insights__card.is-snapped
-    .latest-data-insights__card__data-insight {
+.latest-data-insights__card--snapped .latest-data-insights__card__data-insight {
     box-shadow: 0 4px 24px 0 rgba(0, 0, 0, 0.08);
+}
+
+.latest-data-insights__card--see-all {
+    @include sm-up {
+        display: none;
+    }
 }
 
 .latest-data-insights__card__see-all {

--- a/site/gdocs/components/LatestDataInsights.scss
+++ b/site/gdocs/components/LatestDataInsights.scss
@@ -248,15 +248,8 @@ html:not(.js-enabled) .latest-data-insights__card,
 
 .latest-data-insights__dot {
     background-color: $blue-30;
-    display: inline-flex;
-    text-decoration: none;
-    border: 0;
-    padding: 0;
-    margin: 0;
     width: 8px;
     height: 8px;
-    align-items: center;
-    justify-content: center;
     border-radius: 50%;
     transition: all 0.2s ease-in-out;
 
@@ -264,5 +257,11 @@ html:not(.js-enabled) .latest-data-insights__card,
         background-color: $blue-70;
         width: 12px;
         height: 12px;
+    }
+}
+
+.latest-data-insights__dot--see-all {
+    @include sm-up {
+        display: none;
     }
 }

--- a/site/gdocs/components/LatestDataInsights.scss
+++ b/site/gdocs/components/LatestDataInsights.scss
@@ -99,7 +99,8 @@ html:not(.js-enabled) .latest-data-insights__card,
 }
 
 @include sm-up {
-    .latest-data-insights__card--see-all, .latest-data-insights__dot--see-all {
+    .latest-data-insights__card--see-all,
+    .latest-data-insights__dot--see-all {
         display: none;
     }
 }

--- a/site/gdocs/components/LatestDataInsights.scss
+++ b/site/gdocs/components/LatestDataInsights.scss
@@ -38,6 +38,8 @@ html.js-enabled .latest-data-insights__card-container {
     flex: 0 0 845px;
     height: 322px;
     scroll-snap-align: start;
+    // A flick advances at most one card instead of flying past several.
+    scroll-snap-stop: always;
     transition:
         opacity 0.2s ease-in-out,
         box-shadow 0.2s ease-in-out;

--- a/site/gdocs/components/LatestDataInsights.tsx
+++ b/site/gdocs/components/LatestDataInsights.tsx
@@ -146,7 +146,8 @@ export default function LatestDataInsights({
                     text=""
                 />
             )}
-            <div className="latest-data-insights__dots">
+            {/* Without JS the dots would never update as the user scrolls. */}
+            <div className="latest-data-insights__dots js--hide-if-js-disabled">
                 {/* The extra dot belongs to the "See all" card; it's hidden
                     along with its card on larger screens (see CSS). */}
                 {Array.from({ length: dataInsights.length + 1 }, (_, index) => (

--- a/site/gdocs/components/LatestDataInsights.tsx
+++ b/site/gdocs/components/LatestDataInsights.tsx
@@ -68,6 +68,14 @@ export default function LatestDataInsights({
         }
     }, [updateSelectedIndex])
 
+    // Since snapping is mandatory, the scroller always rests on a snap
+    // position, so the selected index tells us whether there's room to
+    // scroll. dataInsights.length - 1 is the last card reachable by the
+    // buttons: the "See all" card beyond it only exists on small screens,
+    // where the buttons are hidden.
+    const canScrollPrev = selectedIndex > 0
+    const canScrollNext = selectedIndex < dataInsights.length - 1
+
     const scrollToCard = (index: number): void => {
         const scroller = scrollerRef.current
         if (!scroller) return
@@ -117,7 +125,7 @@ export default function LatestDataInsights({
                     />
                 </li>
             </ul>
-            {selectedIndex > 0 && (
+            {canScrollPrev && (
                 <Button
                     ariaLabel="Scroll to the previous data insight card"
                     className="latest-data-insights__control-button latest-data-insights__control-button--prev js--hide-if-js-disabled"
@@ -127,7 +135,7 @@ export default function LatestDataInsights({
                     text=""
                 />
             )}
-            {selectedIndex < dataInsights.length - 1 && (
+            {canScrollNext && (
                 <Button
                     ariaLabel="Scroll to the next data insight card"
                     className="latest-data-insights__control-button latest-data-insights__control-button--next js--hide-if-js-disabled"

--- a/site/gdocs/components/LatestDataInsights.tsx
+++ b/site/gdocs/components/LatestDataInsights.tsx
@@ -1,5 +1,4 @@
-import { memo, useState, useCallback, useEffect, useMemo } from "react"
-import { useMediaQuery } from "usehooks-ts"
+import { memo, useState, useCallback, useEffect, useMemo, useRef } from "react"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import {
     faArrowRight,
@@ -7,9 +6,6 @@ import {
     faChevronLeft,
 } from "@fortawesome/free-solid-svg-icons"
 import cx from "clsx"
-import useEmblaCarousel from "embla-carousel-react"
-import ClassNames from "embla-carousel-class-names"
-import type { EmblaCarouselType } from "embla-carousel"
 
 import { Button } from "@ourworldindata/components"
 import {
@@ -18,7 +14,6 @@ import {
     OwidEnrichedGdocBlock,
     LatestDataInsight,
 } from "@ourworldindata/utils"
-import { SMALL_BREAKPOINT_MEDIA_QUERY } from "../../SiteConstants.js"
 import { buildLatestPagePath } from "../../latest/latestUtils.js"
 import Image from "./Image.js"
 import { ArticleBlocks } from "./ArticleBlocks.js"
@@ -43,65 +38,102 @@ export default function LatestDataInsights({
             }),
         [latestDataInsights]
     )
-    const isSmallScreen = useMediaQuery(SMALL_BREAKPOINT_MEDIA_QUERY)
-    const [emblaRef, emblaApi] = useEmblaCarousel({ align: "start" }, [
-        ClassNames(),
-    ])
-    const { selectedIndex, scrollSnaps } = useDotButton(emblaApi)
+    const scrollerRef = useRef<HTMLUListElement>(null)
+    const [selectedIndex, setSelectedIndex] = useState(0)
+    const [snapCount, setSnapCount] = useState(0)
     const [canScrollPrev, setCanScrollPrev] = useState(false)
     const [canScrollNext, setCanScrollNext] = useState(false)
 
-    const onSelect = useCallback((emblaApi: EmblaCarouselType) => {
-        setCanScrollPrev(emblaApi.canScrollPrev())
-        setCanScrollNext(emblaApi.canScrollNext())
+    const updateScrollState = useCallback(() => {
+        const scroller = scrollerRef.current
+        if (!scroller) return
+        const cards = getVisibleCards(scroller)
+        if (cards.length === 0) return
+        const maxScroll = scroller.scrollWidth - scroller.clientWidth
+        const scrollLeft = scroller.scrollLeft
+        setCanScrollPrev(scrollLeft > 1)
+        setCanScrollNext(scrollLeft < maxScroll - 1)
+        setSnapCount(cards.length)
+        setSelectedIndex(
+            scrollLeft >= maxScroll - 1
+                ? cards.length - 1
+                : findNearestCardIndex(cards, scrollLeft)
+        )
     }, [])
 
     useEffect(() => {
-        if (!emblaApi) return
-        onSelect(emblaApi)
-        emblaApi.on("reInit", onSelect).on("select", onSelect)
+        const scroller = scrollerRef.current
+        if (!scroller) return
+        updateScrollState()
+        scroller.addEventListener("scroll", updateScrollState, {
+            passive: true,
+        })
+        window.addEventListener("resize", updateScrollState)
         return () => {
-            emblaApi.off("reInit", onSelect).off("select", onSelect)
+            scroller.removeEventListener("scroll", updateScrollState)
+            window.removeEventListener("resize", updateScrollState)
         }
-    }, [emblaApi, onSelect])
+    }, [updateScrollState])
 
-    const scrollPrev = useCallback(() => {
-        if (emblaApi) emblaApi.scrollPrev()
-    }, [emblaApi])
+    const scrollToCard = useCallback((index: number) => {
+        const scroller = scrollerRef.current
+        if (!scroller) return
+        const cards = getVisibleCards(scroller)
+        const card = cards[index]
+        if (!card) return
+        scroller.scrollTo({
+            left: card.offsetLeft - cards[0].offsetLeft,
+            behavior: "smooth",
+        })
+    }, [])
 
-    const scrollNext = useCallback(() => {
-        if (emblaApi) emblaApi.scrollNext()
-    }, [emblaApi])
+    const scrollPrev = useCallback(
+        () => scrollToCard(selectedIndex - 1),
+        [scrollToCard, selectedIndex]
+    )
+
+    const scrollNext = useCallback(
+        () => scrollToCard(selectedIndex + 1),
+        [scrollToCard, selectedIndex]
+    )
 
     return (
         <div className={cx("latest-data-insights", className)}>
-            <div className="latest-data-insights__viewport" ref={emblaRef}>
-                <ul className="latest-data-insights__card-container">
-                    {dataInsights.map((dataInsight, index) => (
-                        <DataInsightCard
-                            key={dataInsight.id}
-                            index={index}
-                            title={dataInsight.content.title}
-                            authors={dataInsight.content.authors}
-                            body={dataInsight.content.body}
-                            publishedAt={dataInsight.publishedAt}
-                            href={`/data-insights/${dataInsight.slug}`}
-                        />
-                    ))}
-                    {isSmallScreen && (
-                        // Normal way to hide the last slide would be a CSS media
-                        // query with `display: none`, but that breaks Embla.
-                        <li className="latest-data-insights__card">
-                            <Button
-                                className="latest-data-insights__card__see-all body-3-medium"
-                                href={buildLatestPagePath("data-insight")}
-                                text="See all our Data Insights"
-                                theme="outline-vermillion"
-                            />
-                        </li>
+            <ul
+                className="latest-data-insights__card-container"
+                ref={scrollerRef}
+            >
+                {dataInsights.map((dataInsight, index) => (
+                    <DataInsightCard
+                        key={dataInsight.id}
+                        index={index}
+                        isSnapped={index === selectedIndex}
+                        title={dataInsight.content.title}
+                        authors={dataInsight.content.authors}
+                        body={dataInsight.content.body}
+                        publishedAt={dataInsight.publishedAt}
+                        href={`/data-insights/${dataInsight.slug}`}
+                    />
+                ))}
+                {/* Only shown on small screens (see CSS). */}
+                <li
+                    className={cx(
+                        "latest-data-insights__card",
+                        "latest-data-insights__card--see-all",
+                        {
+                            "latest-data-insights__card--snapped":
+                                dataInsights.length === selectedIndex,
+                        }
                     )}
-                </ul>
-            </div>
+                >
+                    <Button
+                        className="latest-data-insights__card__see-all body-3-medium"
+                        href={buildLatestPagePath("data-insight")}
+                        text="See all our Data Insights"
+                        theme="outline-vermillion"
+                    />
+                </li>
+            </ul>
             {canScrollPrev && (
                 <Button
                     ariaLabel="Scroll to the previous data insight card"
@@ -123,7 +155,7 @@ export default function LatestDataInsights({
                 />
             )}
             <div className="latest-data-insights__dots">
-                {scrollSnaps.map((_, index) => (
+                {Array.from({ length: snapCount }, (_, index) => (
                     <div
                         key={index}
                         className={cx("latest-data-insights__dot", {
@@ -137,8 +169,33 @@ export default function LatestDataInsights({
     )
 }
 
+function getVisibleCards(scroller: HTMLElement): HTMLElement[] {
+    return Array.from(scroller.children).filter(
+        (card): card is HTMLElement =>
+            card instanceof HTMLElement && card.offsetWidth > 0
+    )
+}
+
+function findNearestCardIndex(
+    cards: HTMLElement[],
+    scrollLeft: number
+): number {
+    const origin = cards[0].offsetLeft
+    let nearestIndex = 0
+    let nearestDistance = Infinity
+    cards.forEach((card, index) => {
+        const distance = Math.abs(card.offsetLeft - origin - scrollLeft)
+        if (distance < nearestDistance) {
+            nearestDistance = distance
+            nearestIndex = index
+        }
+    })
+    return nearestIndex
+}
+
 const DataInsightCard = memo(function DataInsightCard({
     index,
+    isSnapped,
     title,
     authors,
     body,
@@ -146,6 +203,7 @@ const DataInsightCard = memo(function DataInsightCard({
     href,
 }: {
     index: number
+    isSnapped: boolean
     title: string
     authors: string[]
     body: OwidEnrichedGdocBlock[]
@@ -159,7 +217,11 @@ const DataInsightCard = memo(function DataInsightCard({
         | undefined
     const otherBlocks = body.filter((_, index) => index !== firstImageIndex)
     return (
-        <li className="latest-data-insights__card">
+        <li
+            className={cx("latest-data-insights__card", {
+                "latest-data-insights__card--snapped": isSnapped,
+            })}
+        >
             <a
                 className="latest-data-insights__card__data-insight"
                 href={href}
@@ -214,50 +276,3 @@ const DataInsightCard = memo(function DataInsightCard({
         </li>
     )
 })
-
-function useDotButton(emblaApi: EmblaCarouselType | undefined): {
-    selectedIndex: number
-    scrollSnaps: number[]
-    onDotButtonClick: (index: number) => void
-} {
-    const [selectedIndex, setSelectedIndex] = useState(0)
-    const [scrollSnaps, setScrollSnaps] = useState<number[]>([])
-
-    const onDotButtonClick = useCallback(
-        (index: number) => {
-            if (!emblaApi) return
-            emblaApi.scrollTo(index)
-        },
-        [emblaApi]
-    )
-
-    const onInit = useCallback((emblaApi: EmblaCarouselType) => {
-        setScrollSnaps(emblaApi.scrollSnapList())
-    }, [])
-
-    const onSelect = useCallback((emblaApi: EmblaCarouselType) => {
-        setSelectedIndex(emblaApi.selectedScrollSnap())
-    }, [])
-
-    useEffect(() => {
-        if (!emblaApi) return
-        onInit(emblaApi)
-        onSelect(emblaApi)
-        emblaApi
-            .on("reInit", onInit)
-            .on("reInit", onSelect)
-            .on("select", onSelect)
-        return () => {
-            emblaApi
-                .off("reInit", onInit)
-                .off("reInit", onSelect)
-                .off("select", onSelect)
-        }
-    }, [emblaApi, onInit, onSelect])
-
-    return {
-        selectedIndex,
-        scrollSnaps,
-        onDotButtonClick,
-    }
-}

--- a/site/gdocs/components/LatestDataInsights.tsx
+++ b/site/gdocs/components/LatestDataInsights.tsx
@@ -6,6 +6,7 @@ import {
     faChevronLeft,
 } from "@fortawesome/free-solid-svg-icons"
 import cx from "clsx"
+import * as R from "remeda"
 
 import { Button } from "@ourworldindata/components"
 import {
@@ -176,16 +177,11 @@ function findNearestCardIndex(
     scrollLeft: number
 ): number {
     const origin = cards[0].offsetLeft
-    let nearestIndex = 0
-    let nearestDistance = Infinity
-    cards.forEach((card, index) => {
-        const distance = Math.abs(card.offsetLeft - origin - scrollLeft)
-        if (distance < nearestDistance) {
-            nearestDistance = distance
-            nearestIndex = index
-        }
-    })
-    return nearestIndex
+    const nearest = R.firstBy(
+        cards.map((card, index) => ({ card, index })),
+        ({ card }) => Math.abs(card.offsetLeft - origin - scrollLeft)
+    )
+    return nearest?.index ?? 0
 }
 
 const DataInsightCard = memo(function DataInsightCard({

--- a/site/gdocs/components/LatestDataInsights.tsx
+++ b/site/gdocs/components/LatestDataInsights.tsx
@@ -40,42 +40,35 @@ export default function LatestDataInsights({
     )
     const scrollerRef = useRef<HTMLUListElement>(null)
     const [selectedIndex, setSelectedIndex] = useState(0)
-    const [snapCount, setSnapCount] = useState(0)
-    const [canScrollPrev, setCanScrollPrev] = useState(false)
-    const [canScrollNext, setCanScrollNext] = useState(false)
 
-    const updateScrollState = useCallback(() => {
+    const updateSelectedIndex = useCallback(() => {
         const scroller = scrollerRef.current
         if (!scroller) return
         const cards = getVisibleCards(scroller)
-        if (cards.length === 0) return
         const maxScroll = scroller.scrollWidth - scroller.clientWidth
-        const scrollLeft = scroller.scrollLeft
-        setCanScrollPrev(scrollLeft > 1)
-        setCanScrollNext(scrollLeft < maxScroll - 1)
-        setSnapCount(cards.length)
-        setSelectedIndex(
-            scrollLeft >= maxScroll - 1
-                ? cards.length - 1
-                : findNearestCardIndex(cards, scrollLeft)
-        )
+        if (cards.length === 0 || maxScroll <= 0) setSelectedIndex(0)
+        else if (scroller.scrollLeft >= maxScroll - 1)
+            // At the very end of the scroller the last card counts as
+            // selected even though it can't reach its snap position.
+            setSelectedIndex(cards.length - 1)
+        else setSelectedIndex(findNearestCardIndex(cards, scroller.scrollLeft))
     }, [])
 
     useEffect(() => {
         const scroller = scrollerRef.current
         if (!scroller) return
-        updateScrollState()
-        scroller.addEventListener("scroll", updateScrollState, {
+        updateSelectedIndex()
+        scroller.addEventListener("scroll", updateSelectedIndex, {
             passive: true,
         })
-        window.addEventListener("resize", updateScrollState)
+        window.addEventListener("resize", updateSelectedIndex)
         return () => {
-            scroller.removeEventListener("scroll", updateScrollState)
-            window.removeEventListener("resize", updateScrollState)
+            scroller.removeEventListener("scroll", updateSelectedIndex)
+            window.removeEventListener("resize", updateSelectedIndex)
         }
-    }, [updateScrollState])
+    }, [updateSelectedIndex])
 
-    const scrollToCard = useCallback((index: number) => {
+    const scrollToCard = (index: number): void => {
         const scroller = scrollerRef.current
         if (!scroller) return
         const cards = getVisibleCards(scroller)
@@ -85,17 +78,7 @@ export default function LatestDataInsights({
             left: card.offsetLeft - cards[0].offsetLeft,
             behavior: "smooth",
         })
-    }, [])
-
-    const scrollPrev = useCallback(
-        () => scrollToCard(selectedIndex - 1),
-        [scrollToCard, selectedIndex]
-    )
-
-    const scrollNext = useCallback(
-        () => scrollToCard(selectedIndex + 1),
-        [scrollToCard, selectedIndex]
-    )
+    }
 
     return (
         <div className={cx("latest-data-insights", className)}>
@@ -134,31 +117,35 @@ export default function LatestDataInsights({
                     />
                 </li>
             </ul>
-            {canScrollPrev && (
+            {selectedIndex > 0 && (
                 <Button
                     ariaLabel="Scroll to the previous data insight card"
-                    className="latest-data-insights__control-button latest-data-insights__control-button--prev"
+                    className="latest-data-insights__control-button latest-data-insights__control-button--prev js--hide-if-js-disabled"
                     theme="solid-blue"
-                    onClick={scrollPrev}
+                    onClick={() => scrollToCard(selectedIndex - 1)}
                     icon={faChevronLeft}
                     text=""
                 />
             )}
-            {canScrollNext && (
+            {selectedIndex < dataInsights.length - 1 && (
                 <Button
                     ariaLabel="Scroll to the next data insight card"
-                    className="latest-data-insights__control-button latest-data-insights__control-button--next"
+                    className="latest-data-insights__control-button latest-data-insights__control-button--next js--hide-if-js-disabled"
                     theme="solid-blue"
-                    onClick={scrollNext}
+                    onClick={() => scrollToCard(selectedIndex + 1)}
                     icon={faChevronRight}
                     text=""
                 />
             )}
             <div className="latest-data-insights__dots">
-                {Array.from({ length: snapCount }, (_, index) => (
+                {/* The extra dot belongs to the "See all" card; it's hidden
+                    along with its card on larger screens (see CSS). */}
+                {Array.from({ length: dataInsights.length + 1 }, (_, index) => (
                     <div
                         key={index}
                         className={cx("latest-data-insights__dot", {
+                            "latest-data-insights__dot--see-all":
+                                index === dataInsights.length,
                             "latest-data-insights__dot--selected":
                                 index === selectedIndex,
                         })}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8106,43 +8106,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"embla-carousel-class-names@npm:^8.6.0":
-  version: 8.6.0
-  resolution: "embla-carousel-class-names@npm:8.6.0"
-  peerDependencies:
-    embla-carousel: 8.6.0
-  checksum: 10/5f52fb9f7c84adbeb5039edbd90f84eb00663318a1e2d1fc24eb05a676ac426b5f22509a7658cc739f98bf87a5fba201c1980af653d9412a967325ed482c58da
-  languageName: node
-  linkType: hard
-
-"embla-carousel-react@npm:^8.6.0":
-  version: 8.6.0
-  resolution: "embla-carousel-react@npm:8.6.0"
-  dependencies:
-    embla-carousel: "npm:8.6.0"
-    embla-carousel-reactive-utils: "npm:8.6.0"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.1 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
-  checksum: 10/8a6338f28844f07e29df03fb09bf7e157e0aecb423b0ca7d9b9a65e4537acce4a140c94f177957518e44d5483993c1c40273b913cde7e543d0b68955efda8ffc
-  languageName: node
-  linkType: hard
-
-"embla-carousel-reactive-utils@npm:8.6.0":
-  version: 8.6.0
-  resolution: "embla-carousel-reactive-utils@npm:8.6.0"
-  peerDependencies:
-    embla-carousel: 8.6.0
-  checksum: 10/48b31931572b32b49705e6125d4f10c240fca0ee8a078867fc91f7c889f6adee95f7fd0b0fdf5dfef6d83d497115759f3f3ca2e8320e331efa0de1c9e6fb4638
-  languageName: node
-  linkType: hard
-
-"embla-carousel@npm:8.6.0":
-  version: 8.6.0
-  resolution: "embla-carousel@npm:8.6.0"
-  checksum: 10/6c1c4268160ce2a150c80f0c84edd4c42b47567f8ef25f56fb21819a4094cfa885614cb0837d180e8da8159ff79a077e0a2e1e679ed2c500ff52697d3ec94b78
-  languageName: node
-  linkType: hard
-
 "emoji-regex@npm:^10.3.0":
   version: 10.3.0
   resolution: "emoji-regex@npm:10.3.0"
@@ -9239,8 +9202,6 @@ __metadata:
     d3: "npm:^7.9.0"
     dayjs: "npm:^1.11.21"
     dotenv: "npm:^17.4.2"
-    embla-carousel-class-names: "npm:^8.6.0"
-    embla-carousel-react: "npm:^8.6.0"
     entities: "npm:^7.0.1"
     eslint: "npm:^10.0.3"
     eslint-plugin-import-x: "npm:^4.16.2"


### PR DESCRIPTION
This replaces Embla Carousel with [native CSS scroll snap](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Scroll_snap).

CSS scroll snap is supported in all our supported browsers by now.

Behavioral changes compared to Embla:
- The carousal (almost) fully works even without JS.
  - The only things that don't work are the left/right buttons and the dots at the bottom - they are hidden in this case.
  - Instead, we show a thin scrollbar in this case.
- On desktop, scrolling with a mouse drag doesn't work any more (including the overscroll behavior on the left).
- On desktop, you can also scroll with a horizontal scroll wheel, and using the arrow keys while the scroll container is keyboard-focused.

Other than that, both work very similarly (on desktop and mobile), and there are no visual differences at all.
Also, it uses pretty much the same amount of code as before, just with two fewer dependencies.

I've tested this a good bunch on both desktop and mobile, and also in older Safari versions (macOS & iOS) on Browserstack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
