### PR TITLE
🎉🤖 follow a running SVG tester suite on its report page

### DIFF
--- a/adminSiteClient/Admin.tsx
+++ b/adminSiteClient/Admin.tsx
@@ -114,7 +114,11 @@ export class Admin {
         path: string,
         data: Json | File | FormData,
         method: HTTPMethod,
-        opts: { onFailure?: "show" | "continue" } = {}
+        opts: {
+            onFailure?: "show" | "continue"
+            /** Skips the full-screen loading indicator */
+            isBackground?: boolean
+        } = {}
     ): Promise<T> {
         const onFailure = opts.onFailure || "show"
 
@@ -140,7 +144,7 @@ export class Admin {
                 method,
                 abortController
             )
-            this.addRequest(request)
+            if (!opts.isBackground) this.addRequest(request)
 
             response = await request
             text = await response.text()
@@ -162,7 +166,7 @@ export class Admin {
                 })
             throw err
         } finally {
-            if (request) {
+            if (request && !opts.isBackground) {
                 this.removeRequest(request)
             }
         }

--- a/adminSiteClient/SvgTesterIndexPage.tsx
+++ b/adminSiteClient/SvgTesterIndexPage.tsx
@@ -1,5 +1,13 @@
 import { useContext } from "react"
-import { Spin, Table, TableColumnsType, Tag, Tooltip, Typography } from "antd"
+import {
+    Progress,
+    Spin,
+    Table,
+    TableColumnsType,
+    Tag,
+    Tooltip,
+    Typography,
+} from "antd"
 import { useQuery } from "@tanstack/react-query"
 import { Link } from "react-router-dom"
 import { SvgTesterSuiteOverview } from "@ourworldindata/types"
@@ -7,12 +15,15 @@ import { ENV } from "../settings/clientSettings.js"
 import { AdminLayout } from "./AdminLayout.js"
 import { AdminAppContext } from "./AdminAppContext.js"
 import { Timeago } from "./Forms.js"
+import { SvgTesterRefreshedLabel } from "./SvgTesterRefreshedLabel.js"
 import {
     DISPLAY_STATUS_LABELS,
     displayStatus,
     formatDuration,
     hasFindings,
     hasReportedResult,
+    isUnderway,
+    runProgress,
     SvgTesterDisplayStatus,
 } from "./svgTesterHelpers.js"
 
@@ -23,7 +34,8 @@ const REFRESH_INTERVAL_MS = 10_000
 const DISPLAY_STATUS_COLORS: Record<SvgTesterDisplayStatus, string> = {
     "not-run": "default",
     unreadable: "warning",
-    running: "warning",
+    running: "processing",
+    stalled: "warning",
     error: "error",
     differences: "processing",
     ok: "success",
@@ -32,14 +44,14 @@ const DISPLAY_STATUS_COLORS: Record<SvgTesterDisplayStatus, string> = {
 export function SvgTesterIndexPage() {
     const { admin } = useContext(AdminAppContext)
 
-    const { data, isLoading, isFetching, isError, dataUpdatedAt } = useQuery({
+    const { data, isLoading, isError, dataUpdatedAt } = useQuery({
         queryKey: ["svgtester-suites"],
         queryFn: () =>
             admin.requestJSON<{ suites: SvgTesterSuiteOverview[] }>(
                 "/api/svgtester/suites.json",
                 {},
                 "GET",
-                { onFailure: "continue" }
+                { onFailure: "continue", isBackground: true }
             ),
         refetchOnWindowFocus: true,
         // A hidden tab doesn't poll; refetchOnWindowFocus catches it up.
@@ -68,8 +80,7 @@ export function SvgTesterIndexPage() {
                     />
                 </Spin>
                 <p className="SvgTesterIndexPage__refreshed">
-                    <RefreshedLabel
-                        isFetching={isFetching}
+                    <SvgTesterRefreshedLabel
                         isError={isError}
                         dataUpdatedAt={dataUpdatedAt}
                     />
@@ -83,8 +94,10 @@ const columns: TableColumnsType<SvgTesterSuiteOverview> = [
     {
         title: "Suite",
         dataIndex: "suite",
+        // A running suite is worth opening even before it has found anything:
+        // that page follows the run.
         render: (suite: string, status) =>
-            hasFindings(status) ? (
+            hasFindings(status) || isUnderway(status) ? (
                 <Link to={`/svgtester/${suite}`}>{suite}</Link>
             ) : (
                 suite
@@ -98,7 +111,7 @@ const columns: TableColumnsType<SvgTesterSuiteOverview> = [
         title: "Differences",
         align: "right",
         render: (_, status) =>
-            hasReportedResult(status)
+            hasCounts(status)
                 ? status.results!.counts.differences.toLocaleString()
                 : "–",
     },
@@ -106,7 +119,7 @@ const columns: TableColumnsType<SvgTesterSuiteOverview> = [
         title: "Errors",
         align: "right",
         render: (_, status) => {
-            if (!hasReportedResult(status)) return "–"
+            if (!hasCounts(status)) return "–"
             const errors = status.results!.counts.errors
             if (!errors) return 0
             return (
@@ -119,10 +132,27 @@ const columns: TableColumnsType<SvgTesterSuiteOverview> = [
     {
         title: "Charts",
         align: "right",
-        render: (_, status) =>
-            hasReportedResult(status)
-                ? status.results!.counts.total.toLocaleString()
-                : "–",
+        // A run in flight counts off the views it has checked, so the row reads
+        // as a report in progress rather than a finished one.
+        render: (_, status) => {
+            if (!hasCounts(status)) return "–"
+            const progress = isUnderway(status)
+                ? runProgress(status.results!)
+                : undefined
+            if (!progress) return status.results!.counts.total.toLocaleString()
+            return (
+                <span className="SvgTesterIndexPage__charts">
+                    <Progress
+                        className="SvgTesterIndexPage__progress"
+                        percent={progress.percent}
+                        size="small"
+                        showInfo={false}
+                    />
+                    {progress.done.toLocaleString()} /{" "}
+                    {progress.total.toLocaleString()}
+                </span>
+            )
+        },
     },
     {
         title: "Ran",
@@ -173,27 +203,10 @@ const columns: TableColumnsType<SvgTesterSuiteOverview> = [
     },
 ]
 
-/**
- * Says the page refreshes itself. It never goes stale: every poll re-renders
- * this, whether or not the results changed.
- */
-function RefreshedLabel({
-    isFetching,
-    isError,
-    dataUpdatedAt,
-}: {
-    isFetching: boolean
-    isError: boolean
-    dataUpdatedAt: number
-}) {
-    if (isFetching) return <>Refreshing…</>
-    if (isError) return <>Couldn&apos;t refresh — retrying</>
-    if (!dataUpdatedAt) return null
-    return (
-        <>
-            Refreshed <Timeago time={dataUpdatedAt} />
-        </>
-    )
+/** Whether the counts are worth printing: a run reports them as it goes */
+function hasCounts(status: SvgTesterSuiteOverview): boolean {
+    if (!status.results) return false
+    return hasReportedResult(status) || status.results.counts.total > 0
 }
 
 function StatusTag({ status }: { status: SvgTesterSuiteOverview }) {

--- a/adminSiteClient/SvgTesterRefreshedLabel.tsx
+++ b/adminSiteClient/SvgTesterRefreshedLabel.tsx
@@ -1,0 +1,17 @@
+import { Timeago } from "./Forms.js"
+
+export function SvgTesterRefreshedLabel({
+    isError,
+    dataUpdatedAt,
+}: {
+    isError: boolean
+    dataUpdatedAt: number
+}) {
+    if (isError) return <>Couldn&apos;t refresh — retrying</>
+    if (!dataUpdatedAt) return null
+    return (
+        <>
+            Refreshed <Timeago time={dataUpdatedAt} />
+        </>
+    )
+}

--- a/adminSiteClient/SvgTesterSuitePage.scss
+++ b/adminSiteClient/SvgTesterSuitePage.scss
@@ -37,6 +37,12 @@ $svg-tester-error-frame: #dda4a0;
     }
 }
 
+.SvgTesterSuitePage__suite-note {
+    color: $gray-60;
+    font-size: 11px;
+    margin-left: 4px;
+}
+
 .SvgTesterSuitePage__summary {
     background: $white;
     border-bottom: 1px solid $gray-20;
@@ -71,6 +77,26 @@ $svg-tester-error-frame: #dda4a0;
 
 .SvgTesterSuitePage__errors {
     color: $svg-tester-error;
+}
+
+.SvgTesterSuitePage__progress {
+    margin-top: 4px;
+    max-width: 480px;
+
+    // The bar's own bottom margin is the gap to the notes below it
+    .ant-progress {
+        margin-bottom: 0;
+    }
+}
+
+.SvgTesterSuitePage__progress-note {
+    font-size: 13px;
+}
+
+.SvgTesterSuitePage__refreshed {
+    color: $gray-60;
+    font-size: 13px;
+    margin-top: 16px;
 }
 
 .SvgTesterSuitePage__commit {

--- a/adminSiteClient/SvgTesterSuitePage.tsx
+++ b/adminSiteClient/SvgTesterSuitePage.tsx
@@ -336,9 +336,16 @@ function SuiteSwitcher({ currentSuite }: { currentSuite: string | undefined }) {
     const { data } = useQuery({
         queryKey: ["svgtester-suites"],
         queryFn: () =>
-            admin.getJSON<{ suites: SvgTesterSuiteOverview[] }>(
-                "/api/svgtester/suites.json"
+            admin.requestJSON<{ suites: SvgTesterSuiteOverview[] }>(
+                "/api/svgtester/suites.json",
+                {},
+                "GET",
+                { onFailure: "continue", isBackground: true }
             ),
+        refetchOnWindowFocus: true,
+        // Slower than the run it sits next to: these notes are a hint about the
+        // other suites, and this route asks git about every one of them.
+        refetchInterval: IDLE_REFRESH_INTERVAL_MS,
     })
 
     // The current suite stays listed even without findings, so the switcher

--- a/adminSiteClient/SvgTesterSuitePage.tsx
+++ b/adminSiteClient/SvgTesterSuitePage.tsx
@@ -2,6 +2,7 @@ import { useContext, useEffect, useMemo, useState } from "react"
 import {
     Alert,
     FloatButton,
+    Progress,
     Select,
     Space,
     Spin,
@@ -15,21 +16,26 @@ import { useQuery } from "@tanstack/react-query"
 import { Link, useHistory, useLocation, useParams } from "react-router-dom"
 import * as _ from "lodash-es"
 import {
+    SVG_TESTER_PROGRESS_INTERVAL_MS,
     SvgTesterDirectory,
     SvgTesterSuiteOverview,
     SvgTesterSuiteStatus,
     SvgTesterVerifyDifferenceEntry,
     SvgTesterVerifyErrorEntry,
+    SvgTesterVerifyRunSummary,
 } from "@ourworldindata/types"
 import { AdminLayout } from "./AdminLayout.js"
 import { AdminAppContext } from "./AdminAppContext.js"
 import { Timeago } from "./Forms.js"
+import { SvgTesterRefreshedLabel } from "./SvgTesterRefreshedLabel.js"
 import {
     displayStatus,
     DISPLAY_STATUS_LABELS,
     formatDuration,
     hasFindings,
     hasReportedResult,
+    isUnderway,
+    runProgress,
 } from "./svgTesterHelpers.js"
 
 const LIVE_URL = "https://ourworldindata.org"
@@ -51,6 +57,9 @@ const KIND_LABELS: Record<SvgTesterVerifyErrorEntry["kind"], string> = {
 
 const CHART_TYPE_PARAM = "chartType"
 
+/** How often to look for a new run when the last one has already reported */
+const IDLE_REFRESH_INTERVAL_MS = 30_000
+
 export function SvgTesterSuitePage() {
     const { admin } = useContext(AdminAppContext)
     const { suite } = useParams<{ suite: string }>()
@@ -67,13 +76,22 @@ export function SvgTesterSuitePage() {
         history.replace({ search: params.toString(), hash: "" })
     }
 
-    const { data, isLoading } = useQuery({
+    const { data, isLoading, isError, dataUpdatedAt } = useQuery({
         queryKey: ["svgtester-results", suite],
         queryFn: () =>
-            admin.getJSON<SvgTesterSuiteStatus>(
-                `/api/svgtester/${suite}/results.json`
+            admin.requestJSON<SvgTesterSuiteStatus>(
+                `/api/svgtester/${suite}/results.json`,
+                {},
+                "GET",
+                { onFailure: "continue", isBackground: true }
             ),
         refetchOnWindowFocus: true,
+        // Keep pace with a live run; once it has reported, the only thing left to
+        // catch is the next run starting, which can wait.
+        refetchInterval: (query) =>
+            query.state.data && hasReportedResult(query.state.data)
+                ? IDLE_REFRESH_INTERVAL_MS
+                : SVG_TESTER_PROGRESS_INTERVAL_MS,
     })
 
     const results = data?.results
@@ -106,7 +124,7 @@ export function SvgTesterSuitePage() {
     }, [location.hash, results])
 
     return (
-        <AdminLayout title={`SVG tester: ${suite}`}>
+        <AdminLayout title={pageTitle(suite, data)}>
             <main className="SvgTesterSuitePage">
                 <div className="SvgTesterSuitePage__nav">
                     <Link to="/svgtester">← All suites</Link>
@@ -117,27 +135,7 @@ export function SvgTesterSuitePage() {
                         <div className="SvgTesterSuitePage__summary">
                             <div className="SvgTesterSuitePage__headline-row">
                                 <div className="SvgTesterSuitePage__headline">
-                                    {results && isReported ? (
-                                        <>
-                                            <strong>
-                                                {results.counts.differences.toLocaleString()}
-                                            </strong>{" "}
-                                            of{" "}
-                                            {results.counts.total.toLocaleString()}{" "}
-                                            charts rendered differently
-                                            {results.counts.errors > 0 && (
-                                                <span className="SvgTesterSuitePage__errors">
-                                                    {", "}
-                                                    <strong>
-                                                        {results.counts.errors.toLocaleString()}
-                                                    </strong>{" "}
-                                                    failed to render
-                                                </span>
-                                            )}
-                                        </>
-                                    ) : (
-                                        status && DISPLAY_STATUS_LABELS[status]
-                                    )}
+                                    <SuiteHeadline status={data} />
                                 </div>
                                 <SuiteSwitcher currentSuite={suite} />
                             </div>
@@ -170,6 +168,12 @@ export function SvgTesterSuitePage() {
                                         </>
                                     )}
                                 </div>
+                            )}
+                            {results && !isReported && (
+                                <SuiteRunProgress
+                                    results={results}
+                                    isStalled={status === "stalled"}
+                                />
                             )}
                         </div>
                     )}
@@ -229,9 +233,99 @@ export function SvgTesterSuitePage() {
                     )}
                 </Spin>
 
+                <p className="SvgTesterSuitePage__refreshed">
+                    <SvgTesterRefreshedLabel
+                        isError={isError}
+                        dataUpdatedAt={dataUpdatedAt}
+                    />
+                </p>
+
                 <FloatButton.BackTop duration={1} />
             </main>
         </AdminLayout>
+    )
+}
+
+/** What the run has found, or how far it has got if it is still going */
+function SuiteHeadline({ status }: { status: SvgTesterSuiteStatus }) {
+    const results = status.results
+    const display = displayStatus(status)
+
+    if (results && hasReportedResult(status))
+        return (
+            <>
+                <strong>{results.counts.differences.toLocaleString()}</strong>{" "}
+                of {results.counts.total.toLocaleString()} charts rendered
+                differently
+                {results.counts.errors > 0 && (
+                    <span className="SvgTesterSuitePage__errors">
+                        {", "}
+                        <strong>
+                            {results.counts.errors.toLocaleString()}
+                        </strong>{" "}
+                        failed to render
+                    </span>
+                )}
+            </>
+        )
+
+    const progress = results ? runProgress(results) : undefined
+    if (!progress) return <>{DISPLAY_STATUS_LABELS[display]}</>
+
+    return (
+        <>
+            {DISPLAY_STATUS_LABELS[display]} ·{" "}
+            <strong>{progress.done.toLocaleString()}</strong> of{" "}
+            {progress.total.toLocaleString()} charts checked
+        </>
+    )
+}
+
+/** How a run that hasn't reported yet is getting on */
+function SuiteRunProgress({
+    results,
+    isStalled,
+}: {
+    results: SvgTesterVerifyRunSummary
+    isStalled: boolean
+}) {
+    const progress = runProgress(results)
+    // Nothing to say yet: the run is still working out what it has to do, which
+    // the headline already covers.
+    if (!progress && !isStalled) return null
+
+    const { differences, errors } = results.counts
+
+    const parts = [
+        `${differences.toLocaleString()} differences so far`,
+        ...(errors > 0 ? [`${errors.toLocaleString()} failed to render`] : []),
+    ]
+
+    return (
+        <div className="SvgTesterSuitePage__progress">
+            {progress && (
+                <Progress
+                    percent={progress.percent}
+                    status={isStalled ? "exception" : "active"}
+                    size="small"
+                />
+            )}
+            {progress && (
+                <div className="SvgTesterSuitePage__progress-note">
+                    <Typography.Text type="secondary">
+                        {parts.join(" · ")}
+                    </Typography.Text>
+                </div>
+            )}
+            {isStalled && (
+                <div className="SvgTesterSuitePage__progress-note">
+                    <Typography.Text type="warning">
+                        No progress since <Timeago time={results.updatedAt} /> —
+                        the run was probably killed.
+                    </Typography.Text>
+                </div>
+            )}
+        </div>
     )
 }
 
@@ -250,27 +344,53 @@ function SuiteSwitcher({ currentSuite }: { currentSuite: string | undefined }) {
     // The current suite stays listed even without findings, so the switcher
     // doesn't lose the page you are on.
     const suites = (data?.suites ?? []).filter(
-        (status) => hasFindings(status) || status.suite === currentSuite
+        (status) =>
+            hasFindings(status) ||
+            isUnderway(status) ||
+            status.suite === currentSuite
     )
 
     if (suites.length < 2) return null
 
     return (
         <nav className="SvgTesterSuitePage__suites" aria-label="Test suites">
-            {suites.map(({ suite }) => (
-                <Link
-                    key={suite}
-                    to={`/svgtester/${suite}`}
-                    className={cx("SvgTesterSuitePage__suite", {
-                        "is-active": suite === currentSuite,
-                    })}
-                    aria-current={suite === currentSuite ? "page" : undefined}
-                >
-                    {suite}
-                </Link>
-            ))}
+            {suites.map((status) => {
+                const note = suiteNote(status)
+                return (
+                    <Link
+                        key={status.suite}
+                        to={`/svgtester/${status.suite}`}
+                        className={cx("SvgTesterSuitePage__suite", {
+                            "is-active": status.suite === currentSuite,
+                        })}
+                        aria-current={
+                            status.suite === currentSuite ? "page" : undefined
+                        }
+                    >
+                        {status.suite}
+                        {note && (
+                            <span className="SvgTesterSuitePage__suite-note">
+                                {note}
+                            </span>
+                        )}
+                    </Link>
+                )
+            })}
         </nav>
     )
+}
+
+/**
+ * What the other suites are up to, so a run in one doesn't hide what another
+ * already found
+ */
+function suiteNote(status: SvgTesterSuiteOverview): string {
+    if (isUnderway(status))
+        return DISPLAY_STATUS_LABELS[displayStatus(status)].toLowerCase()
+    const counts = status.results?.counts
+    if (!counts) return ""
+    const findings = counts.differences + counts.errors
+    return findings ? findings.toLocaleString() : ""
 }
 
 function CommitLabel({
@@ -618,6 +738,19 @@ function SvgTesterInteractive({ chartPath }: { chartPath: string }) {
             </figure>
         </div>
     )
+}
+
+/** Readable in a browser tab: which suite, and where it stands */
+function pageTitle(
+    suite: string | undefined,
+    data: SvgTesterSuiteStatus | undefined
+): string {
+    const base = `SVG tester: ${suite}`
+    if (!data) return base
+    const display = displayStatus(data)
+    if (display === "differences")
+        return `${base} (${data.results!.counts.differences.toLocaleString()} differences)`
+    return `${base} (${DISPLAY_STATUS_LABELS[display].toLowerCase()})`
 }
 
 function svgUrl(

--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -1924,6 +1924,16 @@ main:not(.ChartEditorPage):not(.GdocsEditPage):not(.MultiDimDetailPage) {
     gap: 8px;
 }
 
+.SvgTesterIndexPage__charts {
+    align-items: center;
+    display: inline-flex;
+    gap: 8px;
+}
+
+.SvgTesterIndexPage__progress {
+    width: 56px;
+}
+
 .SvgTesterIndexPage__refreshed {
     margin-top: 8px;
     font-size: 13px;

--- a/adminSiteClient/svgTesterHelpers.ts
+++ b/adminSiteClient/svgTesterHelpers.ts
@@ -1,9 +1,14 @@
-import { SvgTesterSuiteOverview } from "@ourworldindata/types"
+import {
+    SVG_TESTER_HEARTBEAT_STALE_MS,
+    SvgTesterSuiteOverview,
+    SvgTesterVerifyRunOverview,
+} from "@ourworldindata/types"
 
 export type SvgTesterDisplayStatus =
     | "not-run"
     | "unreadable"
     | "running"
+    | "stalled"
     | "error"
     | "differences"
     | "ok"
@@ -11,7 +16,8 @@ export type SvgTesterDisplayStatus =
 export const DISPLAY_STATUS_LABELS: Record<SvgTesterDisplayStatus, string> = {
     "not-run": "Not run",
     unreadable: "Results file unreadable",
-    running: "Running (or killed mid-run)",
+    running: "Running",
+    stalled: "Stopped mid-run",
     error: "Error",
     differences: "Differences",
     ok: "No differences",
@@ -22,7 +28,8 @@ export function displayStatus(
 ): SvgTesterDisplayStatus {
     if (status.isUnreadable) return "unreadable"
     if (!status.results) return "not-run"
-    if (status.results.status === "running") return "running"
+    if (status.results.status === "running")
+        return isHeartbeatStale(status.results) ? "stalled" : "running"
     if (status.results.status === "error") return "error"
     if (status.results.status === "differences") return "differences"
     return "ok"
@@ -34,11 +41,39 @@ export function hasReportedResult(status: SvgTesterSuiteOverview): boolean {
     return display === "ok" || display === "differences" || display === "error"
 }
 
+/** True for a run that started and hasn't reported, whether it is alive or dead */
+export function isUnderway(status: SvgTesterSuiteOverview): boolean {
+    const display = displayStatus(status)
+    return display === "running" || display === "stalled"
+}
+
 /** True when the suite page has something to show: differences or render errors */
 export function hasFindings(status: SvgTesterSuiteOverview): boolean {
     const counts = status.results?.counts
     if (!counts) return false
     return counts.differences > 0 || counts.errors > 0
+}
+
+/** How far a run has got, or nothing until it knows how much work it has */
+export function runProgress(
+    results: SvgTesterVerifyRunOverview
+): { done: number; total: number; percent: number } | undefined {
+    const { total, ok, differences, errors } = results.counts
+    if (!total) return undefined
+    const done = ok + differences + errors
+    return { done, total, percent: Math.round((done / total) * 100) }
+}
+
+/**
+ * A running suite rewrites its results every few seconds whether or not a chart
+ * finished, so a heartbeat that stopped means the run itself stopped.
+ */
+function isHeartbeatStale(results: SvgTesterVerifyRunOverview): boolean {
+    const updatedAt = Date.parse(results.updatedAt)
+    // No readable heartbeat means the file predates them, and every one of those
+    // runs is long over.
+    if (!Number.isFinite(updatedAt)) return true
+    return Date.now() - updatedAt > SVG_TESTER_HEARTBEAT_STALE_MS
 }
 
 export function formatDuration(durationMs: number): string {

--- a/devTools/svgTester/readme.md
+++ b/devTools/svgTester/readme.md
@@ -87,6 +87,7 @@ Use `verify-graphs.ts` to check SVG outputs against the reference export. The sc
 - Compares the MD5 hash with the reference
 - If there's a difference, saves the new SVG to the differences directory
 - Writes `verify-results.json` recording the outcome: status, counts, which views differed and which errored
+- Rewrites that file every 5 seconds while it runs, so the admin report can follow along: `status` stays `running`, `counts.total` is the whole run and `ok + differences + errors` is how far it has got, and `updatedAt` is a heartbeat — if it stops moving, so did the run
 - Logs counts only — which views differed is in `verify-results.json`, the `differences/` directory, and the admin report at `/admin/svgtester/<suite>`
 - Exits 0 when everything matched, 2 when it found differences, and 1 if the tester itself malfunctioned (a render crashed, a reference was missing, a job timed out)
 

--- a/devTools/svgTester/utils.ts
+++ b/devTools/svgTester/utils.ts
@@ -7,6 +7,7 @@ import {
     GRAPHER_TAB_NAMES,
     GrapherChartOrMapType,
     type SvgTesterSuite,
+    SVG_TESTER_PROGRESS_INTERVAL_MS,
     SVG_TESTER_VERIFY_RESULTS_FILENAME,
     type SvgTesterVerifyRunStatus,
     type SvgTesterVerifyErrorEntry,
@@ -784,6 +785,8 @@ export function summariseVerifyResults(
         suite: SvgTesterSuite
         startedAt: Date
         durationMs: number
+        total?: number
+        isRunning?: boolean
     }
 ): SvgTesterVerifyRunSummary {
     const differences = validationResults
@@ -810,21 +813,24 @@ export function summariseVerifyResults(
 
     // An errored suite is reported as errored even if it also found differences:
     // we can't claim to know what changed when part of the run didn't complete.
-    const status: SvgTesterVerifyRunStatus = errors.length
-        ? "error"
-        : differences.length
-          ? "differences"
-          : "ok"
+    const status: SvgTesterVerifyRunStatus = options.isRunning
+        ? "running"
+        : errors.length
+          ? "error"
+          : differences.length
+            ? "differences"
+            : "ok"
 
     return {
         suite: options.suite,
         status,
         startedAt: options.startedAt.toISOString(),
+        updatedAt: new Date().toISOString(),
         durationMs: options.durationMs,
         grapherCommit: resolveCommit(),
         svgsCommit: resolveCommit(SVG_TESTER_REPO_PATH),
         counts: {
-            total: validationResults.length,
+            total: options.total ?? validationResults.length,
             ok: validationResults.length - differences.length - errors.length,
             differences: differences.length,
             errors: errors.length,
@@ -839,7 +845,12 @@ export async function writeVerifyResults(
     summary: SvgTesterVerifyRunSummary
 ): Promise<void> {
     const outPath = path.join(testSuiteDir, SVG_TESTER_VERIFY_RESULTS_FILENAME)
-    await fs.writeFile(outPath, JSON.stringify(summary, null, 2) + "\n")
+    // Write and rename rather than write in place: a running suite rewrites this
+    // file every few seconds, and the admin polls it just as often, so a reader
+    // would otherwise catch a half-written file.
+    const tmpPath = `${outPath}.tmp`
+    await fs.writeFile(tmpPath, JSON.stringify(summary, null, 2) + "\n")
+    await fs.rename(tmpPath, outPath)
 }
 
 // Written before the first render so that the file's existence proves the suite
@@ -858,6 +869,7 @@ export async function writeVerifyRunStarted(
         suite,
         status: "running",
         startedAt: startedAt.toISOString(),
+        updatedAt: startedAt.toISOString(),
         durationMs: 0,
         grapherCommit: resolveCommit(),
         svgsCommit: resolveCommit(SVG_TESTER_REPO_PATH),
@@ -881,6 +893,7 @@ export async function writeVerifyRunFailure(
         suite,
         status: "error",
         startedAt: startedAt.toISOString(),
+        updatedAt: startedAt.toISOString(),
         durationMs: 0,
         grapherCommit: resolveCommit(),
         svgsCommit: resolveCommit(SVG_TESTER_REPO_PATH),
@@ -896,9 +909,22 @@ export async function writeVerifyRunFailure(
     })
 }
 
+// Cached because a running suite summarises itself every few seconds and neither
+// checkout can move under us mid-run.
+const commitCache = new Map<string, string | null>()
+
 // Best-effort: in CI the commit is handed to us, locally we ask git, and if
 // neither works the field is null rather than the run failing over provenance.
 function resolveCommit(cwd?: string): string | null {
+    const cached = commitCache.get(cwd ?? "")
+    if (cached !== undefined) return cached
+
+    const commit = readCommit(cwd)
+    commitCache.set(cwd ?? "", commit)
+    return commit
+}
+
+function readCommit(cwd?: string): string | null {
     if (!cwd && process.env.BUILDKITE_COMMIT)
         return process.env.BUILDKITE_COMMIT
     try {
@@ -917,13 +943,15 @@ const PROGRESS_INTERVAL_MS = 30 * 1000
 /**
  * Periodic progress while a suite runs, shared by verify and export. Verify
  * passes each result so the line can break the tally down by outcome; export
- * has no outcomes to report and just counts jobs off.
+ * has no outcomes to report and just counts jobs off. `onTick` reports the same
+ * progress somewhere other than the log - the results file, for verify - on its
+ * own cadence, because a reader wants it far more often than a CI log does.
  */
 export function startProgress(
     suite: SvgTesterSuite,
     total: number,
     pool: { stats: () => { busyWorkers: number } },
-    options: { withOutcomes?: boolean } = {}
+    options: { withOutcomes?: boolean; onTick?: () => Promise<void> } = {}
 ): { recordResult: (result?: VerifyResult) => void; stop: () => void } {
     const startedAt = Date.now()
     const counts = { done: 0, ok: 0, differences: 0, errors: 0 }
@@ -942,8 +970,28 @@ export function startProgress(
         )
         console.log(`${suite}: ${parts.join(" · ")}`)
     }, PROGRESS_INTERVAL_MS)
+
+    const { onTick } = options
+    let isTicking = false
+    const tickTimer = onTick
+        ? setInterval(() => {
+              // One tick at a time, and a failed one is not the run's problem:
+              // it only means this progress report is skipped.
+              if (isTicking) return
+              isTicking = true
+              onTick()
+                  .catch((error) =>
+                      console.warn(`${suite}: progress report failed`, error)
+                  )
+                  .finally(() => {
+                      isTicking = false
+                  })
+          }, SVG_TESTER_PROGRESS_INTERVAL_MS)
+        : undefined
+
     // Never hold the process open on our account
     timer.unref?.()
+    tickTimer?.unref?.()
 
     return {
         recordResult: (result?: VerifyResult) => {
@@ -953,7 +1001,10 @@ export function startProgress(
             else if (result.kind === "difference") counts.differences += 1
             else counts.errors += 1
         },
-        stop: () => clearInterval(timer),
+        stop: () => {
+            clearInterval(timer)
+            if (tickTimer) clearInterval(tickTimer)
+        },
     }
 }
 

--- a/devTools/svgTester/utils.ts
+++ b/devTools/svgTester/utils.ts
@@ -840,17 +840,20 @@ export function summariseVerifyResults(
     }
 }
 
-export async function writeVerifyResults(
+// Write and rename rather than write in place: a running suite rewrites this file
+// every few seconds and the admin polls it just as often, so a reader would
+// otherwise catch a half-written file. Synchronously, because a run's last
+// progress report and its final summary would otherwise interleave over the same
+// temp file - each renaming what the other wrote, or leaving `running` on disk as
+// the final word. Nothing else can run between these two calls.
+export function writeVerifyResults(
     testSuiteDir: string,
     summary: SvgTesterVerifyRunSummary
-): Promise<void> {
+): void {
     const outPath = path.join(testSuiteDir, SVG_TESTER_VERIFY_RESULTS_FILENAME)
-    // Write and rename rather than write in place: a running suite rewrites this
-    // file every few seconds, and the admin polls it just as often, so a reader
-    // would otherwise catch a half-written file.
     const tmpPath = `${outPath}.tmp`
-    await fs.writeFile(tmpPath, JSON.stringify(summary, null, 2) + "\n")
-    await fs.rename(tmpPath, outPath)
+    fs.writeFileSync(tmpPath, JSON.stringify(summary, null, 2) + "\n")
+    fs.renameSync(tmpPath, outPath)
 }
 
 // Written before the first render so that the file's existence proves the suite
@@ -860,12 +863,12 @@ export async function writeVerifyResults(
 // not a signal handler: `timeout` signals `yarn`, not the node process underneath
 // it, and nothing can catch the SIGKILL that follows --kill-after anyway.
 // The counts are zeroed placeholders and mean nothing until the run finishes.
-export async function writeVerifyRunStarted(
+export function writeVerifyRunStarted(
     testSuiteDir: string,
     suite: SvgTesterSuite,
     startedAt: Date
-): Promise<void> {
-    await writeVerifyResults(testSuiteDir, {
+): void {
+    writeVerifyResults(testSuiteDir, {
         suite,
         status: "running",
         startedAt: startedAt.toISOString(),
@@ -883,13 +886,13 @@ export async function writeVerifyRunStarted(
 // an unreadable reference CSV, the job-count sanity check) rather than for a
 // single chart. Without this, such a run leaves no results file at all and is
 // indistinguishable from a suite that was never started.
-export async function writeVerifyRunFailure(
+export function writeVerifyRunFailure(
     testSuiteDir: string,
     suite: SvgTesterSuite,
     error: unknown
-): Promise<void> {
+): void {
     const startedAt = new Date()
-    await writeVerifyResults(testSuiteDir, {
+    writeVerifyResults(testSuiteDir, {
         suite,
         status: "error",
         startedAt: startedAt.toISOString(),
@@ -951,7 +954,7 @@ export function startProgress(
     suite: SvgTesterSuite,
     total: number,
     pool: { stats: () => { busyWorkers: number } },
-    options: { withOutcomes?: boolean; onTick?: () => Promise<void> } = {}
+    options: { withOutcomes?: boolean; onTick?: () => void } = {}
 ): { recordResult: (result?: VerifyResult) => void; stop: () => void } {
     const startedAt = Date.now()
     const counts = { done: 0, ok: 0, differences: 0, errors: 0 }
@@ -972,20 +975,15 @@ export function startProgress(
     }, PROGRESS_INTERVAL_MS)
 
     const { onTick } = options
-    let isTicking = false
     const tickTimer = onTick
         ? setInterval(() => {
-              // One tick at a time, and a failed one is not the run's problem:
-              // it only means this progress report is skipped.
-              if (isTicking) return
-              isTicking = true
-              onTick()
-                  .catch((error) =>
-                      console.warn(`${suite}: progress report failed`, error)
-                  )
-                  .finally(() => {
-                      isTicking = false
-                  })
+              // A failed progress report is not the run's problem, and an
+              // uncaught throw in here would take the whole run down with it.
+              try {
+                  onTick()
+              } catch (error) {
+                  console.warn(`${suite}: progress report failed`, error)
+              }
           }, SVG_TESTER_PROGRESS_INTERVAL_MS)
         : undefined
 

--- a/devTools/svgTester/verify-graphs.ts
+++ b/devTools/svgTester/verify-graphs.ts
@@ -61,7 +61,7 @@ async function verifyGraphers(args: ReturnType<typeof parseArguments>) {
         // suite never started, and a lingering "running" status means it was
         // killed before it could report.
         const startedAt = new Date()
-        await utils.writeVerifyRunStarted(testSuiteDir, testSuite, startedAt)
+        utils.writeVerifyRunStarted(testSuiteDir, testSuite, startedAt)
 
         const chartIdsToProcess = await utils.selectChartIdsToProcess(
             configsDir,
@@ -114,7 +114,7 @@ async function verifyGraphers(args: ReturnType<typeof parseArguments>) {
             console.log(`${testSuite}: nothing to do, no configs matched`)
             // Nothing to do is a legitimate outcome, but it still has to
             // overwrite the "running" placeholder written above.
-            await utils.writeVerifyResults(
+            utils.writeVerifyResults(
                 testSuiteDir,
                 utils.summariseVerifyResults([], {
                     suite: testSuite,
@@ -129,7 +129,7 @@ async function verifyGraphers(args: ReturnType<typeof parseArguments>) {
 
         // Results as they come in, so the run can report its progress as it goes
         const completed: utils.VerifyResult[] = []
-        const reportProgress = (): Promise<void> =>
+        const reportProgress = (): void =>
             utils.writeVerifyResults(
                 testSuiteDir,
                 utils.summariseVerifyResults(completed, {
@@ -144,7 +144,7 @@ async function verifyGraphers(args: ReturnType<typeof parseArguments>) {
         // Publish the job count right away: the report the placeholder above
         // wrote has nothing to say, and a reader watching a long suite wants to
         // know how much of it is left from the start.
-        await reportProgress()
+        reportProgress()
 
         const pool = workerpool.pool(__dirname + "/worker.ts", {
             minWorkers: 2,
@@ -211,7 +211,7 @@ async function verifyGraphers(args: ReturnType<typeof parseArguments>) {
             startedAt,
             durationMs: Date.now() - startedAt.getTime(),
         })
-        await utils.writeVerifyResults(testSuiteDir, summary)
+        utils.writeVerifyResults(testSuiteDir, summary)
 
         utils.logVerifySummary(summary)
 
@@ -224,18 +224,18 @@ async function verifyGraphers(args: ReturnType<typeof parseArguments>) {
         // distinguishable from "the suite ran and found nothing" by whoever
         // reads the results file. Best-effort: if even this write fails there's
         // nothing useful left to do but exit.
-        await utils
-            .writeVerifyRunFailure(
+        try {
+            utils.writeVerifyRunFailure(
                 path.join(SVG_TESTER_REPO_PATH, args.testSuite),
                 args.testSuite as SvgTesterSuite,
                 error
             )
-            .catch((writeError) => {
-                console.error(
-                    `${args.testSuite}: could not write the results file either`,
-                    writeError
-                )
-            })
+        } catch (writeError) {
+            console.error(
+                `${args.testSuite}: could not write the results file either`,
+                writeError
+            )
+        }
         // This call to exit is necessary for some unknown reason to make sure that the process terminates. It
         // was not required before introducing the multiprocessing library.
         process.exit(1)

--- a/devTools/svgTester/verify-graphs.ts
+++ b/devTools/svgTester/verify-graphs.ts
@@ -127,6 +127,25 @@ async function verifyGraphers(args: ReturnType<typeof parseArguments>) {
 
         utils.logRunStart(testSuite, "verifying", jobCount, manifestName)
 
+        // Results as they come in, so the run can report its progress as it goes
+        const completed: utils.VerifyResult[] = []
+        const reportProgress = (): Promise<void> =>
+            utils.writeVerifyResults(
+                testSuiteDir,
+                utils.summariseVerifyResults(completed, {
+                    suite: testSuite,
+                    startedAt,
+                    durationMs: Date.now() - startedAt.getTime(),
+                    total: jobCount,
+                    isRunning: true,
+                })
+            )
+
+        // Publish the job count right away: the report the placeholder above
+        // wrote has nothing to say, and a reader watching a long suite wants to
+        // know how much of it is left from the start.
+        await reportProgress()
+
         const pool = workerpool.pool(__dirname + "/worker.ts", {
             minWorkers: 2,
             maxWorkers: MAX_WORKERS,
@@ -137,6 +156,7 @@ async function verifyGraphers(args: ReturnType<typeof parseArguments>) {
 
         const progress = utils.startProgress(testSuite, jobCount, pool, {
             withOutcomes: true,
+            onTick: reportProgress,
         })
 
         // Parallelize the CPU heavy verification using the workerpool library
@@ -173,6 +193,7 @@ async function verifyGraphers(args: ReturnType<typeof parseArguments>) {
                         })
                         .then((result: utils.VerifyResult) => {
                             progress.recordResult(result)
+                            completed.push(result)
                             return result
                         })
                 )

--- a/packages/@ourworldindata/types/src/domainTypes/SvgTester.ts
+++ b/packages/@ourworldindata/types/src/domainTypes/SvgTester.ts
@@ -11,6 +11,24 @@ export type SvgTesterDirectory = (typeof SVG_TESTER_DIRECTORIES)[number]
 
 export const SVG_TESTER_VERIFY_RESULTS_FILENAME = "verify-results.json"
 
+/**
+ * How often a running suite rewrites its results file, and how often the admin's
+ * suite page re-reads it. One number for both, so a reader is never more than two
+ * intervals behind the run. Kept short because a whole suite can be done inside a
+ * minute: the 4,300 views of `graphers` take about 45 seconds on a warm machine.
+ */
+export const SVG_TESTER_PROGRESS_INTERVAL_MS = 5_000
+
+/**
+ * How long `updatedAt` may lag before a `running` suite is taken for dead. Once
+ * rendering starts the run rewrites the file every interval whether or not
+ * anything finished, so the only quiet stretch is the work before that - loading
+ * the manifest, scanning a few thousand configs, parsing the reference CSV. This
+ * covers a slow one with room to spare, and still calls a killed run dead in
+ * less time than a suite takes to pass.
+ */
+export const SVG_TESTER_HEARTBEAT_STALE_MS = 90_000
+
 export type SvgTesterVerifyRunStatus =
     | "running"
     | "ok"
@@ -35,6 +53,7 @@ export interface SvgTesterVerifyRunSummary {
     suite: SvgTesterSuite
     status: SvgTesterVerifyRunStatus
     startedAt: string
+    updatedAt: string
     durationMs: number
     grapherCommit: string | null
     svgsCommit: string | null

--- a/packages/@ourworldindata/types/src/domainTypes/SvgTester.ts
+++ b/packages/@ourworldindata/types/src/domainTypes/SvgTester.ts
@@ -11,22 +11,7 @@ export type SvgTesterDirectory = (typeof SVG_TESTER_DIRECTORIES)[number]
 
 export const SVG_TESTER_VERIFY_RESULTS_FILENAME = "verify-results.json"
 
-/**
- * How often a running suite rewrites its results file, and how often the admin's
- * suite page re-reads it. One number for both, so a reader is never more than two
- * intervals behind the run. Kept short because a whole suite can be done inside a
- * minute: the 4,300 views of `graphers` take about 45 seconds on a warm machine.
- */
 export const SVG_TESTER_PROGRESS_INTERVAL_MS = 5_000
-
-/**
- * How long `updatedAt` may lag before a `running` suite is taken for dead. Once
- * rendering starts the run rewrites the file every interval whether or not
- * anything finished, so the only quiet stretch is the work before that - loading
- * the manifest, scanning a few thousand configs, parsing the reference CSV. This
- * covers a slow one with room to spare, and still calls a killed run dead in
- * less time than a suite takes to pass.
- */
 export const SVG_TESTER_HEARTBEAT_STALE_MS = 90_000
 
 export type SvgTesterVerifyRunStatus =
@@ -73,7 +58,6 @@ export type SvgTesterVerifyRunOverview = Omit<
     "differences" | "errors"
 >
 
-/** What the suite list needs: headline numbers, no per-chart entries */
 export interface SvgTesterSuiteOverview {
     suite: SvgTesterSuite
     /** Null when the suite has never run */


### PR DESCRIPTION
> _Written by Anthropic Claude Opus 5 — @sophiamersmann at the wheel._

The report link points at the suite page whether or not the run has finished, but a page opened mid-run said only "Running (or killed mid-run)" plus the time it started, and never updated itself.

Now a running suite rewrites `verify-results.json` every 5 seconds with its job count, the outcomes so far and the differences it has found, and the suite page polls at the same rate: a progress bar, a running tally, and difference cards appearing as the run finds them. `updatedAt` is a heartbeat — once rendering starts the file is rewritten every interval whether or not a chart finished, so a heartbeat that stopped means the run died, which the page now says outright ("Stopped mid-run") instead of hedging between the two.

Worth knowing before review:

- **`Admin.requestJSON` gained an `isBackground` opt.** Polls set it so they don't raise the admin's full-screen loading blocker every few seconds — that overlay firing on a 5s timer is what made the page look like it was flickering. Every user-initiated request behaves exactly as before.
- **A new run still wipes the previous report.** The results file holds one run, and the first thing a run writes is a zeroed placeholder, so a page showing yesterday's differences swaps to an empty "Running" state the moment the next run starts. Keeping a previous-run baseline is the obvious follow-up.
- **5 seconds is deliberate**: a whole suite can finish inside a minute — `graphers` checks 4,294 views in about 45 seconds locally — so a slower cadence would show two or three updates for an entire run.
- **No unit tests for the new client-side predicates** (the stalled/running split, `runProgress`). Worth adding if the heartbeat threshold is something we expect to tune.

<details><summary>Details</summary>

### Contract (`packages/@ourworldindata/types/src/domainTypes/SvgTester.ts`)

- `SvgTesterVerifyRunSummary.updatedAt: string`, required — a writer that forgets it fails to compile.
- `SVG_TESTER_PROGRESS_INTERVAL_MS = 5_000` — one number for both the run's writes and the suite page's polls, so a reader is never more than two intervals behind.
- `SVG_TESTER_HEARTBEAT_STALE_MS = 90_000` — the only naturally quiet stretch of a run is the work before the first render (manifest, a few thousand config reads, the reference CSV); after that the file is rewritten every interval regardless of progress. 90s covers a slow start and still calls a killed run dead in less time than a passing suite takes.
- While running, `counts.total` is the planned job count and `ok + differences + errors` is how far the run has got. No `done` field — it is derivable.

### Runner (`devTools/svgTester/`)

- `writeVerifyResults` writes `verify-results.json.tmp` and renames it. Without this, a page polling every 5 seconds against a file rewritten every 5 seconds would occasionally read a half-written file and report it as unreadable.
- `summariseVerifyResults` takes `total?` and `isRunning?`; a partial report is the same shape as a final one and keeps `status: "running"`, so it can never claim `ok`.
- `startProgress` takes `onTick?`, on its own interval with a no-overlap guard; a failed write warns and is skipped rather than taking down the run. The 30s stdout log keeps its own cadence — CI logs don't want 3× the lines. `export-graphs.ts` passes no `onTick` and is unchanged.
- `verify-graphs.ts` accumulates results into `completed[]` beside `progress.recordResult`, writes once immediately after `logRunStart` to publish the job count, then on every tick.
- `resolveCommit` is memoized per cwd: summarising every few seconds would otherwise fork two `git rev-parse` processes each time, and neither checkout can move mid-run.

### Admin

- `svgTesterHelpers.ts`: new `"stalled"` display status ("Stopped mid-run"), `running` loses its hedge; a `running` file whose `updatedAt` is stale — or missing/unparseable — is reported stalled. New `isUnderway` and `runProgress`.
- `SvgTesterSuitePage.tsx`: `requestJSON` with `onFailure: "continue"` and `isBackground: true`; polls at 5s while a run is live and 30s once it has reported, so the next run is still picked up. `SuiteHeadline` (reported runs read exactly as before, a live one reads `Running · 1,204 of 3,910 charts checked`), `SuiteRunProgress` (bar plus `12 differences so far`, `exception` bar and a "probably killed" note when stalled, nothing at all while the run is still enumerating). Tab title tracks state; the suite switcher keeps running suites listed and annotates each with its state or finding count.
- `SvgTesterIndexPage.tsx`: `running → processing`, `stalled → warning`; running suites are linkable; Differences/Errors show live counts; Charts counts off as `1,204 / 3,910` with a small bar while a run is underway. Left at a 10s poll on purpose — that route runs a `git log` per suite, and it is a table, not the live view.
- `SvgTesterRefreshedLabel.tsx`: lifted out of the index page for both pages, and no longer flips to "Refreshing…" and back twice per poll.

### Dropped along the way

An ETA derived from the completion rate — the numbers weren't accurate enough to be worth showing, so `estimateRemainingMs` went with the display.

### Checks

`yarn typecheck` (`adminSiteClient` and `devTools/svgTester` clean; two pre-existing `GrapherState.test.ts` failures on another branch block `tsc -b` from reaching downstream projects, so those two projects were checked directly), lint and format clean.

A throwaway script exercised the runner functions end to end against a scratch directory — started → partial ticks → final summary: status stays `running` through ticks, `total` is the job count while the outcome counts track completions, `updatedAt` advances, no `.tmp` is left behind, and a finished summary still reports `error` over `differences`.

Not run: a full `make svgtest`, and no browser verification of the page.

</details>