### PR TITLE
🔨🤖 (chart-configs) derive the mdim view config layer instead of storing it

### DIFF
--- a/adminSiteServer/chartConfigHelpers.ts
+++ b/adminSiteServer/chartConfigHelpers.ts
@@ -89,7 +89,20 @@ export const updateChartConfigInDbAndR2 = async (
     return retrieveChartConfigFromDbAndSaveToR2(knex, configId)
 }
 
-/** Inserts a chart config pair without publishing */
+export const saveNewChartConfigInDbAndR2 = async (
+    knex: db.KnexReadWriteTransaction,
+    config: GrapherInterface,
+    now: Date = new Date()
+) => {
+    const chartConfigId = await insertChartConfig(knex, {
+        config,
+        createdAt: now,
+        updatedAt: now,
+    })
+    return retrieveChartConfigFromDbAndSaveToR2(knex, chartConfigId)
+}
+
+/** Inserts a chart config pair without uploading it to R2 */
 export const insertChartConfigPair = async (
     knex: db.KnexReadWriteTransaction,
     { config, patchConfig }: ChartConfigPair,

--- a/adminSiteServer/multiDim.ts
+++ b/adminSiteServer/multiDim.ts
@@ -1,10 +1,6 @@
 import * as _ from "lodash-es"
 
 import {
-    defaultGrapherConfig,
-    migrateGrapherConfigToLatestVersionAndFailOnError,
-} from "@ourworldindata/grapher"
-import {
     ChartConfigsTableName,
     DbEnrichedMultiDimDataPage,
     DbPlainMultiDimDataPage,
@@ -25,13 +21,13 @@ import {
     R2GrapherConfigDirectory,
     View,
 } from "@ourworldindata/types"
-import {
-    mergeGrapherConfigs,
-    MultiDimDataPageConfig,
-    dimensionsToViewId,
-} from "@ourworldindata/utils"
+import { mergeGrapherConfigs, dimensionsToViewId } from "@ourworldindata/utils"
+import * as Sentry from "@sentry/node"
 import * as db from "../db/db.js"
-import { upsertMultiDimDataPage } from "../db/model/MultiDimDataPage.js"
+import {
+    buildMdimViewPatchConfig,
+    upsertMultiDimDataPage,
+} from "../db/model/MultiDimDataPage.js"
 import { upsertMultiDimXChartConfigs } from "../db/model/MultiDimXChartConfigs.js"
 import {
     getIndicatorChartConfigs,
@@ -43,9 +39,8 @@ import {
     saveMultiDimConfigToR2,
 } from "../serverUtils/r2/chartConfigR2Helpers.js"
 import {
-    saveNewChartConfigPairInDbAndR2,
+    saveNewChartConfigInDbAndR2,
     updateChartConfigInDbAndR2,
-    updateChartConfigPairInDbAndR2,
 } from "./chartConfigHelpers.js"
 
 function catalogPathFromIndicatorEntry(
@@ -161,25 +156,17 @@ async function resolveMultiDimDataPageCatalogPathsToIndicatorIds(
 async function getViewIdToChartConfigIdMap(
     knex: db.KnexReadonlyTransaction,
     catalogPath: string
-) {
+): Promise<Map<string, string>> {
     const rows = await db.knexRaw<DbPlainMultiDimXChartConfig>(
         knex,
         `-- sql
-        SELECT viewId, chartConfigId, patchConfigId
+        SELECT viewId, chartConfigId
         FROM multi_dim_x_chart_configs mdxcc
         JOIN multi_dim_data_pages mddp ON mddp.id = mdxcc.multiDimId
         WHERE mddp.catalogPath = ?`,
         [catalogPath]
     )
-    return new Map(
-        rows.map((row) => [
-            row.viewId,
-            {
-                chartConfigId: row.chartConfigId,
-                patchConfigId: row.patchConfigId,
-            },
-        ])
-    )
+    return new Map(rows.map((row) => [row.viewId, row.chartConfigId]))
 }
 
 async function retrieveMultiDimConfigFromDbAndSaveToR2(
@@ -229,26 +216,16 @@ async function upsertMultiDimConfig(
 
 async function cleanUpOrphanedChartConfigs(
     knex: db.KnexReadWriteTransaction,
-    orphanedViews: { chartConfigId: string; patchConfigId: string }[]
+    orphanedChartConfigIds: string[]
 ) {
-    const chartConfigIds = orphanedViews.map((view) => view.chartConfigId)
-
     await knex<DbPlainMultiDimXChartConfig>(MultiDimXChartConfigsTableName)
-        .whereIn("chartConfigId", chartConfigIds)
+        .whereIn("chartConfigId", orphanedChartConfigIds)
         .delete()
 
     await knex<DbRawChartConfig>(ChartConfigsTableName)
-        .whereIn(
-            "id",
-            orphanedViews.flatMap((view) => [
-                view.chartConfigId,
-                view.patchConfigId,
-            ])
-        )
+        .whereIn("id", orphanedChartConfigIds)
         .delete()
-
-    // Only the resolved config was published
-    for (const id of chartConfigIds) {
+    for (const id of orphanedChartConfigIds) {
         await deleteGrapherConfigFromR2ByUUID(id)
     }
 }
@@ -262,6 +239,7 @@ export async function upsertMultiDim(
         knex,
         rawConfig
     )
+    reportViewConfigsWithoutSchema(catalogPath, config)
     const variableConfigs = await getIndicatorChartConfigs(
         knex,
         _.uniq(config.views.map((view) => view.indicators.y[0].id))
@@ -272,152 +250,108 @@ export async function upsertMultiDim(
         .select("published")
         .where({ catalogPath })
         .first()
-    const existingIsPublished = existingMultiDim?.published
+    const existingIsPublished = existingMultiDim
+        ? Boolean(existingMultiDim.published)
+        : undefined
     const existingViewIdsToChartConfigIds = await getViewIdToChartConfigIdMap(
         knex,
         catalogPath
     )
     const reusedChartConfigIds = new Set<string>()
-    const { grapherConfigSchema } = config
 
     const enrichedViews = await Promise.all(
         config.views.map(async (view) => {
-            const viewId = dimensionsToViewId(view.dimensions)
             const variableId = view.indicators.y[0].id
-            let viewGrapherConfig: GrapherInterface = {}
-            if (view.config) {
-                viewGrapherConfig = grapherConfigSchema
-                    ? { $schema: grapherConfigSchema, ...view.config }
-                    : view.config
-                if ("$schema" in viewGrapherConfig) {
-                    viewGrapherConfig =
-                        migrateGrapherConfigToLatestVersionAndFailOnError(
-                            viewGrapherConfig
-                        )
-                }
-            }
-            // Main config for each view. The collection-wide default selection
-            // applies only to views that don't define their own; a view-level
-            // selectedEntityNames sets that view's initial selection, while a
-            // reader's own selection still carries across views as before.
-            // https://github.com/owid/owid-grapher/issues/4928
-            const mainGrapherConfig: GrapherInterface = {
-                $schema: defaultGrapherConfig.$schema,
-                dimensions: MultiDimDataPageConfig.viewToDimensionsConfig(view),
-            }
-            if (viewGrapherConfig.selectedEntityNames === undefined) {
-                mainGrapherConfig.selectedEntityNames =
-                    config.defaultSelection ?? []
-            }
-            const patchGrapherConfig = mergeGrapherConfigs(
-                viewGrapherConfig,
-                mainGrapherConfig
+            const patchGrapherConfig = buildMdimViewPatchConfig(
+                config,
+                view,
+                existingIsPublished
             )
-            if (existingIsPublished !== undefined) {
-                patchGrapherConfig.isPublished = Boolean(existingIsPublished)
-            }
             const fullGrapherConfig = mergeGrapherConfigs(
                 variableConfigs.get(variableId) ?? {},
                 patchGrapherConfig
             )
-            const existing = existingViewIdsToChartConfigIds.get(viewId)
-            let chartConfigId: string
-            let patchConfigId: string
-            if (existing) {
-                chartConfigId = existing.chartConfigId
-                patchConfigId = existing.patchConfigId
-                await updateChartConfigPairInDbAndR2(knex, {
-                    configId: chartConfigId,
-                    patchConfigId,
-                    config: fullGrapherConfig,
-                    patchConfig: patchGrapherConfig,
-                })
+            const existingChartConfigId = existingViewIdsToChartConfigIds.get(
+                dimensionsToViewId(view.dimensions)
+            )
+            let chartConfigId
+            if (existingChartConfigId) {
+                chartConfigId = existingChartConfigId
+                await updateChartConfigInDbAndR2(
+                    knex,
+                    chartConfigId,
+                    fullGrapherConfig
+                )
                 reusedChartConfigIds.add(chartConfigId)
                 console.debug(`Chart config updated id=${chartConfigId}`)
             } else {
-                const ids = await saveNewChartConfigPairInDbAndR2(knex, {
-                    config: fullGrapherConfig,
-                    patchConfig: patchGrapherConfig,
-                })
-                chartConfigId = ids.chartConfigId
-                patchConfigId = ids.patchConfigId
+                const result = await saveNewChartConfigInDbAndR2(
+                    knex,
+                    fullGrapherConfig
+                )
+                chartConfigId = result.chartConfigId
                 await knex(MultiDimViewDimensionsTableName).insert({
                     chartConfigId,
                     dimensions: JSON.stringify(view.dimensions),
                 })
                 console.debug(`Chart config created id=${chartConfigId}`)
             }
-            return {
-                viewId,
-                patchConfigId,
-                view: { ...view, fullConfigId: chartConfigId },
-            }
+            return { ...view, fullConfigId: chartConfigId }
         })
     )
 
-    const orphanedViews = existingViewIdsToChartConfigIds
+    const orphanedChartConfigIds = existingViewIdsToChartConfigIds
         .values()
-        .filter((ids) => !reusedChartConfigIds.has(ids.chartConfigId))
+        .filter((chartConfigId) => !reusedChartConfigIds.has(chartConfigId))
         .toArray()
-    await cleanUpOrphanedChartConfigs(knex, orphanedViews)
+    await cleanUpOrphanedChartConfigs(knex, orphanedChartConfigIds)
 
-    const enrichedConfig = {
-        ...config,
-        views: enrichedViews.map(({ view }) => view),
-    }
+    const enrichedConfig = { ...config, views: enrichedViews }
     const multiDimId = await upsertMultiDimConfig(
         knex,
         catalogPath,
         enrichedConfig
     )
-    for (const { viewId, patchConfigId, view } of enrichedViews) {
+    for (const view of enrichedConfig.views) {
         await upsertMultiDimXChartConfigs(knex, {
             multiDimId,
-            viewId,
+            viewId: dimensionsToViewId(view.dimensions),
             variableId: view.indicators.y[0].id,
             chartConfigId: view.fullConfigId,
-            patchConfigId,
         })
     }
     return multiDimId
 }
 
-/** Both configs of the given views, keyed by the view's resolved id */
+/** Warns if any view config does not declare a schema version */
+function reportViewConfigsWithoutSchema(
+    catalogPath: string,
+    config: MultiDimDataPageConfigPreProcessed
+): void {
+    if (config.grapherConfigSchema) return
+    const viewIds = config.views
+        .filter((view) => view.config && !view.config.$schema)
+        .map((view) => dimensionsToViewId(view.dimensions))
+    if (viewIds.length === 0) return
+
+    console.warn(
+        `${catalogPath}: ${viewIds.length} view config(s) without a schema version, assumed latest`
+    )
+    // Static message, so that all affected pages group into one Sentry issue
+    Sentry.captureMessage(
+        "Multi-dim view configs without a schema version, assumed latest",
+        { level: "warning", extra: { catalogPath, viewIds } }
+    )
+}
+
 async function getViewChartConfigs(
     knex: db.KnexReadonlyTransaction,
-    chartConfigIds: string[]
-) {
-    const rows = await db.knexRaw<{
-        chartConfigId: string
-        patchConfigId: string | null
-        config: DbRawChartConfig["config"]
-        patchConfig: DbRawChartConfig["config"] | null
-    }>(
-        knex,
-        `-- sql
-        SELECT
-            cc.id AS chartConfigId,
-            mdxcc.patchConfigId,
-            cc.config,
-            cc_patch.config AS patchConfig
-        FROM chart_configs cc
-        LEFT JOIN multi_dim_x_chart_configs mdxcc ON mdxcc.chartConfigId = cc.id
-        LEFT JOIN chart_configs cc_patch ON cc_patch.id = mdxcc.patchConfigId
-        WHERE cc.id IN (?)`,
-        [chartConfigIds]
-    )
-    return new Map(
-        rows.map((row) => [
-            row.chartConfigId,
-            {
-                patchConfigId: row.patchConfigId,
-                config: parseChartConfig(row.config),
-                patchConfig: row.patchConfig
-                    ? parseChartConfig(row.patchConfig)
-                    : undefined,
-            },
-        ])
-    )
+    ids: string[]
+): Promise<Map<string, GrapherInterface>> {
+    const rows = await knex<DbRawChartConfig>(ChartConfigsTableName)
+        .select("id", "config")
+        .whereIn("id", ids)
+    return new Map(rows.map((row) => [row.id, parseChartConfig(row.config)]))
 }
 
 export async function setMultiDimPublished(
@@ -433,27 +367,15 @@ export async function setMultiDimPublished(
     await Promise.all(
         multiDim.config.views.map(async (view) => {
             const { fullConfigId: chartConfigId } = view
-            const viewConfig = viewConfigs.get(chartConfigId)
-            if (!viewConfig) {
+            const config = viewConfigs.get(chartConfigId)
+            if (!config) {
                 throw new JsonError(
                     `Chart config not found id=${chartConfigId}`,
                     404
                 )
             }
-            const { config, patchConfig, patchConfigId } = viewConfig
-
             config.isPublished = published
-            if (patchConfigId && patchConfig) {
-                patchConfig.isPublished = published
-                await updateChartConfigPairInDbAndR2(knex, {
-                    configId: chartConfigId,
-                    patchConfigId,
-                    config,
-                    patchConfig,
-                })
-            } else {
-                await updateChartConfigInDbAndR2(knex, chartConfigId, config)
-            }
+            await updateChartConfigInDbAndR2(knex, chartConfigId, config)
         })
     )
 

--- a/adminSiteServer/multiDim.ts
+++ b/adminSiteServer/multiDim.ts
@@ -22,7 +22,6 @@ import {
     View,
 } from "@ourworldindata/types"
 import { mergeGrapherConfigs, dimensionsToViewId } from "@ourworldindata/utils"
-import * as Sentry from "@sentry/node"
 import * as db from "../db/db.js"
 import {
     buildMdimViewPatchConfig,
@@ -239,7 +238,7 @@ export async function upsertMultiDim(
         knex,
         rawConfig
     )
-    reportViewConfigsWithoutSchema(catalogPath, config)
+    validateViewConfigSchemas(config)
     const variableConfigs = await getIndicatorChartConfigs(
         knex,
         _.uniq(config.views.map((view) => view.indicators.y[0].id))
@@ -323,9 +322,8 @@ export async function upsertMultiDim(
     return multiDimId
 }
 
-/** Warns if any view config does not declare a schema version */
-function reportViewConfigsWithoutSchema(
-    catalogPath: string,
+/** Throws if any view config does not declare a schema version */
+function validateViewConfigSchemas(
     config: MultiDimDataPageConfigPreProcessed
 ): void {
     if (config.grapherConfigSchema) return
@@ -334,13 +332,12 @@ function reportViewConfigsWithoutSchema(
         .map((view) => dimensionsToViewId(view.dimensions))
     if (viewIds.length === 0) return
 
-    console.warn(
-        `${catalogPath}: ${viewIds.length} view config(s) without a schema version, assumed latest`
-    )
-    // Static message, so that all affected pages group into one Sentry issue
-    Sentry.captureMessage(
-        "Multi-dim view configs without a schema version, assumed latest",
-        { level: "warning", extra: { catalogPath, viewIds } }
+    // Pages can have thousands of views, so only name the first few
+    const sample = viewIds.slice(0, 5).join(", ")
+    const more = viewIds.length > 5 ? `, and ${viewIds.length - 5} more` : ""
+    throw new JsonError(
+        `${viewIds.length} view config(s) declare no schema version (${sample}${more}). ` +
+            `Set $schema on each view config, or grapherConfigSchema on the multi-dim config.`
     )
 }
 

--- a/adminSiteServer/tests/charts.test.ts
+++ b/adminSiteServer/tests/charts.test.ts
@@ -260,6 +260,7 @@ describe("Indicator-level chart configs", { timeout: 15000 }, () => {
         const expectedMergedViewConfigUpdated = {
             ...expectedMergedViewConfig,
             subtitle: "Newly updated subtitle",
+            isPublished: false,
         }
         const fullViewConfig1Updated = await env
             .testKnex(ChartConfigsTableName)
@@ -276,9 +277,7 @@ describe("Indicator-level chart configs", { timeout: 15000 }, () => {
             .testKnex(ChartConfigsTableName)
             .whereIn("id", [
                 multiDimView1.chartConfigId,
-                multiDimView1.patchConfigId,
                 multiDimView2.chartConfigId,
-                multiDimView2.patchConfigId,
             ])
             .delete()
 

--- a/adminSiteServer/tests/multi-dim-views.test.ts
+++ b/adminSiteServer/tests/multi-dim-views.test.ts
@@ -100,8 +100,7 @@ describe("Multi-dim views", { timeout: 20000 }, () => {
         await upsertMultiDim([totalView, perCapitaView])
 
         expect(await env.getCount(MultiDimXChartConfigsTableName)).toBe(2)
-        // two config rows per view: the resolved one and its authored layer
-        expect(await env.getCount(ChartConfigsTableName)).toBe(4)
+        expect(await env.getCount(ChartConfigsTableName)).toBe(2)
         expect(await env.getCount(MultiDimViewDimensionsTableName)).toBe(2)
 
         const viewConfigIds = await getViewConfigIds()
@@ -115,6 +114,26 @@ describe("Multi-dim views", { timeout: 20000 }, () => {
         expect(config.dimensions).toEqual([{ property: "y", variableId }])
     })
 
+    it("migrates view configs to the latest schema version", async () => {
+        const outdatedView = {
+            ...totalView,
+            config: {
+                $schema:
+                    "https://files.ourworldindata.org/schemas/grapher-schema.005.json",
+                ...totalView.config,
+                // hideLegend was renamed to hideSeriesLabels in version 010
+                hideLegend: true,
+            } as GrapherInterface,
+        }
+        await upsertMultiDim([outdatedView])
+
+        const viewConfigIds = await getViewConfigIds()
+        const config = await getConfig(viewConfigIds["metric=total"])
+        expect(config.$schema).toBe(latestGrapherConfigSchema)
+        expect(config.hideSeriesLabels).toBe(true)
+        expect(config).not.toHaveProperty("hideLegend")
+    })
+
     it("drops the config row of a removed view and keeps the rest", async () => {
         await upsertMultiDim([totalView, perCapitaView])
         const before = await getViewConfigIds()
@@ -125,8 +144,7 @@ describe("Multi-dim views", { timeout: 20000 }, () => {
         expect(Object.keys(after)).toEqual(["metric=total"])
         // The surviving view keeps its config id, which is a public identity
         expect(after["metric=total"]).toBe(before["metric=total"])
-        // both of the removed view's config rows are gone
-        expect(await env.getCount(ChartConfigsTableName)).toBe(2)
+        expect(await env.getCount(ChartConfigsTableName)).toBe(1)
 
         // multi_dim_view_dimensions is an append-only log for analytics: its row
         // for the removed view deliberately outlives the config it names, so a

--- a/adminSiteServer/tests/multi-dim-views.test.ts
+++ b/adminSiteServer/tests/multi-dim-views.test.ts
@@ -134,6 +134,25 @@ describe("Multi-dim views", { timeout: 20000 }, () => {
         expect(config).not.toHaveProperty("hideLegend")
     })
 
+    it("rejects a view config that declares no schema version", async () => {
+        const { grapherConfigSchema: _omitted, ...configWithoutSchema } =
+            multiDimConfig([totalView]) as { grapherConfigSchema: string }
+        const response = await fetch(
+            `${env.baseUrl}/multi-dims/${encodeURIComponent(catalogPath)}`,
+            {
+                method: "PUT",
+                headers: {
+                    "Content-Type": "application/json",
+                    Authorization: `Bearer ${env.apiKey}`,
+                },
+                body: JSON.stringify({ config: configWithoutSchema }),
+            }
+        )
+
+        expect(response.status).toBe(400)
+        expect(await env.getCount(MultiDimDataPagesTableName)).toBe(0)
+    })
+
     it("drops the config row of a removed view and keeps the rest", async () => {
         await upsertMultiDim([totalView, perCapitaView])
         const before = await getViewConfigIds()

--- a/db/docs/chart_configs.yml
+++ b/db/docs/chart_configs.yml
@@ -6,7 +6,7 @@ metadata:
 
     Here are some kinds of entities in our DB that reference rows in this table:
     - Standalone charts, shown on our website at https://ourworldindata.org/grapher/SLUG, stored in the charts table (configId = rendered, patchConfigId = editor-authored layer)
-    - Multi-dim charts, shown also at https://ourworldindata.org/grapher/SLUG, stored in the multi_dim_x_chart_configs table (chartConfigId = rendered view, patchConfigId = YAML-authored layer)
+    - Multi-dim charts, shown also at https://ourworldindata.org/grapher/SLUG, stored in the multi_dim_x_chart_configs table (chartConfigId only — the authored layer is derived from multi_dim_data_pages.config, not stored)
     - Narrative charts, shown only as embedded views in articles and that are based on parent standalone charts, stored in the narrative_charts table (chartConfigId = rendered, patchConfigId = editor-authored layer)
     - Explorer views, stored in the explorer_views table (chartConfigId only — the config is generated whole, there is no authored layer)
     - Indicator level charts, used in the inheritance mechanism in standalone charts and multi-dim charts, stored in the variables table (patchConfigIdETL — a single authored layer, used as stored)
@@ -26,8 +26,6 @@ metadata:
       column: viewConfigId
     - table: multi_dim_x_chart_configs
       column: chartConfigId
-    - table: multi_dim_x_chart_configs
-      column: patchConfigId
     - table: narrative_charts
       column: chartConfigId
     - table: narrative_charts
@@ -54,6 +52,6 @@ fields:
   createdAt:
     description: Timestamp when the configuration was created
   updatedAt:
-    description: Timestamp when the configuration was last updated. When an owner writes its config, its rendered row and its patch row are written together and share the same timestamp. Indicator propagation is the exception — it rewrites only the rendered row, because the authored layer doesn't change.
+    description: Timestamp when the configuration was last updated
   configMd5:
     description: MD5 hash of the config JSON used for change detection and caching. This column is a GENERATED STORED column, no need to update it in insert/update calls

--- a/db/docs/multi_dim_x_chart_configs.yml
+++ b/db/docs/multi_dim_x_chart_configs.yml
@@ -15,9 +15,10 @@ fields:
   variableId:
     description: Foreign key to variables table for the variable being visualized
   chartConfigId:
-    description: Foreign key to chart_configs table for the config that is rendered for this view (the merge of the indicator config and the view's patch)
-  patchConfigId:
-    description: Foreign key to chart_configs table for the view config as authored in the mdim YAML (the mdim-wide config composed with this view's own config). Read whenever the view has to be re-merged, e.g. after an indicator config change.
+    description: |
+      Foreign key to chart_configs table for the config that is rendered for this
+      view: the y indicator's config merged with the view's layer derived from the
+      multi dim config.
   createdAt:
     description: Timestamp when the configuration was created
   updatedAt:

--- a/db/migration/1786695964018-DropMultiDimViewPatchConfigId.ts
+++ b/db/migration/1786695964018-DropMultiDimViewPatchConfigId.ts
@@ -1,0 +1,39 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class DropMultiDimViewPatchConfigId1786695964018 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const orphans = await queryRunner.query(`-- sql
+            SELECT patchConfigId AS id FROM multi_dim_x_chart_configs
+        `)
+
+        // MySQL can reject dropping a column and its foreign key in one ALTER
+        await queryRunner.query(`-- sql
+            ALTER TABLE multi_dim_x_chart_configs
+            DROP FOREIGN KEY fk_multi_dim_x_chart_configs_patch_config_id
+        `)
+        await queryRunner.query(`-- sql
+            ALTER TABLE multi_dim_x_chart_configs DROP COLUMN patchConfigId
+        `)
+
+        if (orphans.length > 0) {
+            await queryRunner.query(
+                `DELETE FROM chart_configs WHERE id IN (?)`,
+                [orphans.map((row: { id: string }) => row.id)]
+            )
+        }
+    }
+
+    // Restores the column, not the data
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`-- sql
+            ALTER TABLE multi_dim_x_chart_configs
+            ADD COLUMN patchConfigId CHAR(36)
+                CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_as_cs NULL
+                AFTER chartConfigId,
+            ADD UNIQUE KEY patchConfigId (patchConfigId),
+            ADD CONSTRAINT fk_multi_dim_x_chart_configs_patch_config_id
+                FOREIGN KEY (patchConfigId) REFERENCES chart_configs (id)
+                ON DELETE RESTRICT ON UPDATE RESTRICT
+        `)
+    }
+}

--- a/db/model/MultiDimDataPage.ts
+++ b/db/model/MultiDimDataPage.ts
@@ -9,10 +9,68 @@ import {
     DbPlainMultiDimDataPage,
     DbEnrichedMultiDimDataPage,
     ContentGraphLinkType,
+    GrapherInterface,
+    IndicatorsAfterPreProcessing,
     JsonString,
     MultiDimDataPageConfigEnriched,
+    View,
 } from "@ourworldindata/types"
+import {
+    defaultGrapherConfig,
+    migrateGrapherConfigToLatestVersionAndFailOnError,
+} from "@ourworldindata/grapher"
+import {
+    mergeGrapherConfigs,
+    MultiDimDataPageConfig,
+} from "@ourworldindata/utils"
 import { buildQueryStrFromConfig } from "./MultiDimRedirects.js"
+
+/**
+ * The config layer an mdim view's authors: the view's own config
+ * with the dimensions and default entities merged over it
+ */
+export function buildMdimViewPatchConfig(
+    config: Pick<
+        MultiDimDataPageConfigEnriched,
+        "defaultSelection" | "grapherConfigSchema"
+    >,
+    view: View<IndicatorsAfterPreProcessing>,
+    published?: boolean
+): GrapherInterface {
+    let viewGrapherConfig: GrapherInterface = {}
+
+    // Migrate the view's config to the latest schema version if it has a $schema
+    if (view.config) {
+        viewGrapherConfig = config.grapherConfigSchema
+            ? { $schema: config.grapherConfigSchema, ...view.config }
+            : view.config
+        if ("$schema" in viewGrapherConfig) {
+            viewGrapherConfig =
+                migrateGrapherConfigToLatestVersionAndFailOnError(
+                    viewGrapherConfig
+                )
+        }
+    }
+
+    const mainGrapherConfig: GrapherInterface = {
+        $schema: defaultGrapherConfig.$schema,
+        dimensions: MultiDimDataPageConfig.viewToDimensionsConfig(view),
+    }
+
+    // If the view doesn't define a selection, use the mdim's default selection
+    if (viewGrapherConfig.selectedEntityNames === undefined) {
+        mainGrapherConfig.selectedEntityNames = config.defaultSelection ?? []
+    }
+
+    const patchConfig = mergeGrapherConfigs(
+        viewGrapherConfig,
+        mainGrapherConfig
+    )
+
+    if (published !== undefined) patchConfig.isPublished = published
+
+    return patchConfig
+}
 
 /**
  * Returns zero if none of the inserted columns differs from the existing ones,

--- a/db/model/Variable.ts
+++ b/db/model/Variable.ts
@@ -32,6 +32,7 @@ import {
     DbEnrichedVariable,
     DbPlainChart,
     DbPlainMultiDimXChartConfig,
+    MultiDimXChartConfigsTableName,
     Distribution,
     DatasetOwners,
     DbPlainDataset,
@@ -39,6 +40,10 @@ import {
 } from "@ourworldindata/types"
 import { knexRaw, knexRawFirst } from "../db.js"
 import { insertChartConfig, updateChartConfig } from "./ChartConfigs.js"
+import {
+    buildMdimViewPatchConfig,
+    getMultiDimDataPageById,
+} from "./MultiDimDataPage.js"
 
 interface IndicatorChartConfigRecord {
     variableId: DbEnrichedVariable["id"]
@@ -260,28 +265,33 @@ async function findAllMultiDimViewsThatInheritFromIndicator(
         isPublished: boolean
     }[]
 > {
-    const charts = await db.knexRaw<{
-        chartConfigId: DbPlainMultiDimXChartConfig["chartConfigId"]
-        patchConfig: DbRawChartConfig["config"]
-        isPublished: boolean
-    }>(
-        trx,
-        `-- sql
-            SELECT
-                mdxcc.chartConfigId as chartConfigId,
-                cc.config as patchConfig,
-                md.published as isPublished
-            FROM multi_dim_data_pages md
-                JOIN multi_dim_x_chart_configs mdxcc ON mdxcc.multiDimId = md.id
-                JOIN chart_configs cc ON cc.id = mdxcc.patchConfigId
-            WHERE mdxcc.variableId = ?
-        `,
-        [variableId]
+    const rows = await trx<DbPlainMultiDimXChartConfig>(
+        MultiDimXChartConfigsTableName
     )
-    return charts.map((chart) => ({
-        ...chart,
-        patchConfig: parseChartConfig(chart.patchConfig),
-    }))
+        .select("multiDimId", "chartConfigId")
+        .where({ variableId })
+    const multiDimIds = _.uniq(rows.map((row) => row.multiDimId))
+    const chartConfigIds = new Set(rows.map((row) => row.chartConfigId))
+
+    const inheritingViews = []
+    for (const multiDimId of multiDimIds) {
+        const multiDim = await getMultiDimDataPageById(trx, multiDimId)
+        if (!multiDim) continue
+        const isPublished = Boolean(multiDim.published)
+        for (const view of multiDim.config.views) {
+            if (!chartConfigIds.has(view.fullConfigId)) continue
+            inheritingViews.push({
+                chartConfigId: view.fullConfigId,
+                isPublished,
+                patchConfig: buildMdimViewPatchConfig(
+                    multiDim.config,
+                    view,
+                    isPublished
+                ),
+            })
+        }
+    }
+    return inheritingViews
 }
 
 export async function updateAllMultiDimViewsThatInheritFromIndicator(
@@ -306,17 +316,11 @@ export async function updateAllMultiDimViewsThatInheritFromIndicator(
             patchConfigETL ?? {},
             view.patchConfig
         )
-        await db.knexRaw(
-            trx,
-            `-- sql
-                UPDATE chart_configs
-                SET
-                    config = ?,
-                    updatedAt = ?
-                WHERE id = ?
-            `,
-            [JSON.stringify(fullConfig), updatedAt, view.chartConfigId]
-        )
+        await updateChartConfig(trx, {
+            configId: view.chartConfigId,
+            config: fullConfig,
+            updatedAt,
+        })
     }
 
     // let the caller know if any views were updated

--- a/packages/@ourworldindata/types/src/dbTypes/MultiDimXChartConfigs.ts
+++ b/packages/@ourworldindata/types/src/dbTypes/MultiDimXChartConfigs.ts
@@ -5,7 +5,6 @@ export type DbInsertMultiDimXChartConfig = {
     viewId: string
     variableId: number
     chartConfigId: string
-    patchConfigId: string
     createdAt?: Date
     updatedAt?: Date
 }


### PR DESCRIPTION
> _Written by Anthropic Claude Opus 5 — @sophiamersmann at the wheel._

Drops `multi_dim_x_chart_configs.patchConfigId` and the `chart_configs` row it pointed at. A view's authored layer is now rebuilt from `multi_dim_data_pages.config` by `buildMdimViewPatchConfig`, which is shared by `upsertMultiDim` and the indicator-propagation path.

**Worth a reviewer's attention**

- Updating an indicator config, plus all the mdim views that inherit from it, is now slower
- View configs with no schema version are now reported to Sentry, once per upsert (right now about half of the mdim view configs declare no `$schema`). We could also turn this into a hard error if we'd prefer