### PR TITLE
✨ improve user-facing grapher loading message

### DIFF
--- a/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
+++ b/packages/@ourworldindata/grapher/src/captionedChart/CaptionedChart.tsx
@@ -58,7 +58,6 @@ export interface CaptionedChartManager
         ControlsRowManager {
     bakedGrapherURL?: string
     isReady?: boolean
-    whatAreWeWaitingFor?: string
 
     // bounds
     captionedChartBounds?: Bounds
@@ -235,12 +234,7 @@ export class CaptionedChart extends AbstractCaptionedChart {
     }
 
     private renderLoadingIndicator(): React.ReactElement {
-        return (
-            <LoadingIndicator
-                title={this.manager.whatAreWeWaitingFor}
-                bounds={this.bounds}
-            />
-        )
+        return <LoadingIndicator title="Loading data..." bounds={this.bounds} />
     }
 
     private renderTimeline(): React.ReactElement {

--- a/packages/@ourworldindata/grapher/src/chart/ChartAreaContent.tsx
+++ b/packages/@ourworldindata/grapher/src/chart/ChartAreaContent.tsx
@@ -64,7 +64,7 @@ export class ChartAreaContent extends React.Component<ChartAreaContentProps> {
     private renderLoadingIndicatorIntoSvg(): React.ReactElement {
         return (
             <foreignObject {...this.bounds.toProps()}>
-                <LoadingIndicator title={this.manager.whatAreWeWaitingFor} />
+                <LoadingIndicator title="Loading data..." />
             </foreignObject>
         )
     }
@@ -135,9 +135,7 @@ export class ChartAreaContent extends React.Component<ChartAreaContentProps> {
                 {this.manager.isReady ? (
                     <DataTable bounds={bounds} manager={this.manager} />
                 ) : (
-                    <LoadingIndicator
-                        title={this.manager.whatAreWeWaitingFor}
-                    />
+                    <LoadingIndicator title="Loading data..." />
                 )}
             </div>
         )

--- a/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
@@ -1762,7 +1762,7 @@ export class GrapherState
         }
         if (dimensions.length > 0 && this.loadingDimensions.length === 0)
             return ""
-        return `Waiting for dimensions ${this.loadingDimensions.join(",")}.`
+        return `Waiting for dimensions ${this.loadingDimensions.map((dim) => dim.columnSlug).join(", ")}.`
     }
 
     @computed get newSlugs(): string[] {


### PR DESCRIPTION
Fixes an error in `whatAreWeWaitingFor` which was outputting `"Waiting for dimensions [object Object], [object Object]"` and also replaces the `LoadingIndicator` tooltip for grapher charts to say `Loading data...` instead.