### PR TITLE
🎉🤖 (bespoke) add a page stacking every project's demo

### DIFF
--- a/bespoke/readme.md
+++ b/bespoke/readme.md
@@ -278,7 +278,7 @@ A dev server at [bespoke/server/](server/) provides a local environment for work
 yarn startBespokeDevServer
 ```
 
-Visit `http://localhost:8089/<project>/demo` to see a demo page that mounts all of a project's variants inside Shadow DOM — matching the production embedding behavior.
+Visit `http://localhost:8089/<project>/demo` to see a demo page that mounts all of a project's variants inside Shadow DOM — matching the production embedding behavior. `http://localhost:8089/__all` stacks every project's demo page below each other (except `example`), for comparing across projects.
 
 Pass `--build` to build each project and serve the production output via `vite preview` instead of `vite dev`:
 

--- a/bespoke/server/all-demos.html
+++ b/bespoke/server/all-demos.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>All bespoke demos</title>
+        <style>
+            body {
+                margin: 0;
+            }
+
+            .all-demos-frame {
+                display: block;
+                width: 100%;
+                border: 0;
+                border-bottom: 1px solid #dadada;
+
+                /*
+                 * A non-zero starting height is required for loading="lazy" to
+                 * stagger: zero-height frames all count as being in the
+                 * viewport, so every project would start building at once.
+                 * Overridden per frame once its content can be measured.
+                 */
+                height: 600px;
+            }
+        </style>
+    </head>
+    <body>
+        <script type="module">
+            const projects = {{PROJECTS_JSON}}
+
+            for (const project of projects) {
+                const frame = document.createElement("iframe")
+                frame.className = "all-demos-frame"
+                frame.src = `/${project}/demo`
+                frame.title = project
+                frame.loading = "lazy"
+                frame.scrolling = "no"
+
+                // Same origin, so the frame can be sized to its content — and
+                // kept in sync as the viz re-lays out or the window resizes.
+                frame.addEventListener("load", () => {
+                    const body = frame.contentDocument?.body
+                    if (!body) return
+                    const fit = () => {
+                        frame.style.height = `${body.scrollHeight}px`
+                    }
+                    fit()
+                    new ResizeObserver(fit).observe(body)
+                })
+
+                document.body.appendChild(frame)
+            }
+        </script>
+    </body>
+</html>

--- a/bespoke/server/devServer.ts
+++ b/bespoke/server/devServer.ts
@@ -6,7 +6,7 @@
  *
  * Requests to /<project>/* are routed to the corresponding Vite instance.
  * WebSocket upgrades (for Vite HMR) are proxied at the TCP level.
- * Visiting / lists all available projects.
+ * Visiting / lists all available projects, /__all stacks every project's demo page.
  *
  * Usage:  npx tsx devServer.ts
  * Port:   defaults to 8089, override with PORT env var
@@ -327,6 +327,11 @@ const demoTemplate = fs.readFileSync(
     path.join(dirname, "component-demo.html"),
     "utf-8"
 )
+const allDemosTemplate = fs.readFileSync(
+    path.join(dirname, "all-demos.html"),
+    "utf-8"
+)
+
 function serveDemoPage(
     projectName: string,
     res: http.ServerResponse,
@@ -426,11 +431,12 @@ function getProjectName(rawUrl: string): string | null {
     }
 }
 
+function listProjects(): string[] {
+    return fs.readdirSync(PROJECTS_DIR).filter((d: string) => isProject(d))
+}
+
 function listProjectsPage(): string {
-    const dirs = fs
-        .readdirSync(PROJECTS_DIR)
-        .filter((d: string) => isProject(d))
-    const links = dirs
+    const links = listProjects()
         .map((p: string) => `<li><a href="/${p}/demo">${p}</a></li>`)
         .join("\n")
     return `<!doctype html>
@@ -439,8 +445,22 @@ function listProjectsPage(): string {
 <body>
   <h2>Bespoke Projects</h2>
   <ul>${links}</ul>
+  <p><a href="/__all">View all demos on one page</a></p>
 </body>
 </html>`
+}
+
+// Serve a page that stacks every project's demo page in a lazily loaded
+// iframe. Starts no Vite instance itself; each project boots when its own
+// frame loads. "example" is left out: it's the starter template, not a viz.
+function serveAllDemosPage(res: http.ServerResponse): void {
+    const projects = listProjects().filter((p: string) => p !== "example")
+    const html = allDemosTemplate.replaceAll(
+        "{{PROJECTS_JSON}}",
+        JSON.stringify(projects)
+    )
+    res.writeHead(200, { "Content-Type": "text/html" })
+    res.end(html)
 }
 
 const CORS_HEADERS: Record<string, string> = {
@@ -467,6 +487,11 @@ const server = http.createServer(
         if (rawPathname.startsWith("/__bespoke/")) {
             const internal = await getOrStartBespokeInternalServer()
             await proxyRequest(req, res, internal.port)
+            return
+        }
+
+        if (rawPathname === "/__all" || rawPathname === "/__all/") {
+            serveAllDemosPage(res)
             return
         }
 

--- a/bespoke/server/readme.md
+++ b/bespoke/server/readme.md
@@ -34,6 +34,8 @@ In build mode, the demo page uses the built output files (`index.js`, `index.css
 
 Visiting `/<project>/demo` serves a demo page that imports the project's `VARIANTS` list and mounts each variant inside its own Shadow DOM using `mountBespokeComponentInShadow` from `bespoke/shared`. This mirrors the production embedding behavior.
 
+`/__all` stacks every project's demo page below each other (except `example`, the starter template), one lazily loaded iframe each — iframes keep each project's Vite client, React copy and `dev-only-global-css` isolated from the others. The frames load as you scroll, which matters on staging, where each project is built on first request.
+
 ### Entrypoints
 
 The demo page reads the `entrypoints` field from each project's `package.json` to know which source files to load:
@@ -51,8 +53,13 @@ Only `js` is required. If `css` is omitted, the demo page won't load a separate 
 
 In dev mode, requests for `/<project>/index.js` and `/<project>/index.css` are redirected to the corresponding source entrypoints so Vite can serve them. In build mode, these files exist as-is in the build output.
 
+## Staging
+
+Staging servers run this server too, under pm2 as `yarn startBespokeDevServer --build`, and their `BESPOKE_BASE_URL` points at it — so the bundles a staging article embeds are the ones this server builds. Reach it at `http://staging-site-<branch>:8089/` over Tailscale. (Production is different: there `BESPOKE_BASE_URL` is the statically baked `/assets/bespoke`, and no dev server runs.)
+
 ## Files
 
 - **devServer.ts** — The dev server itself
 - **component-demo.html** — Demo page template (mounts variants inside Shadow DOM)
+- **all-demos.html** — `/__all` page template (stacks every project's demo page in an iframe)
 - **component-demo.css** / **demo-grid.css** — Styles for the demo page, served via the `/__bespoke/` Vite instance


### PR DESCRIPTION
> _Written by Anthropic Claude Opus 5 — @sophiamersmann at the wheel._

Adds `/__all` to the bespoke dev server: every project's existing `/<project>/demo` page stacked below each other, so you can compare vizzes across projects in one scroll. Since staging runs this server under pm2 (and its `BESPOKE_BASE_URL` points at it), the page works there too: `http://staging-site-<branch>:8089/__all`.

Each project gets its own same-origin iframe rather than everything sharing one document — that keeps each project's Vite client, React copy and `dev-only-global-css` isolated, and one broken project shows an error in its own frame instead of taking the page down. Frames are `loading="lazy"`, which matters on staging, where each project is built on first request. The `example` starter template is left out.

<details><summary>Details</summary>

### Changes

- **`bespoke/server/all-demos.html`** (new) — page template. Loops an injected project list, appends one lazily loaded iframe per project, sizes each frame to its content's `body.scrollHeight` on load and keeps it in sync with a `ResizeObserver`. The frames start at `height: 600px`; that is load-bearing, since zero-height iframes all count as being in the viewport and would start every project's build at once.
- **`bespoke/server/devServer.ts`** — extracted `listProjects()` (was inline in `listProjectsPage()`), added `serveAllDemosPage()`, routed `/__all`, and linked the page from `/`.
- **`bespoke/server/readme.md`**, **`bespoke/readme.md`** — document the page; the server readme gains a short section on the fact that staging runs this server, which wasn't written down anywhere.

### Notes

- The `/__all` route deliberately starts no Vite instance itself, so the page responds immediately and each project boots when its own frame scrolls into view.
- `/` still lists `example`, since that's the project you copy when starting a new viz; it's only excluded from the stacked page.
- No `staging-bespoke` PR label needed to see this on staging. That label gates `yarn buildBespoke` for the Cloudflare content preview; the pm2 dev server builds projects on demand regardless.

### Testing

`tsc -p bespoke/server/tsconfig.json`, lint and format are clean. Ran the server on a spare port and checked that `/__all` injects the five non-`example` projects and that `/` still renders. The iframe height syncing has not been eyeballed in a browser yet.

</details>