### PR TITLE
Exclude timeout errors from Sentry

### DIFF
--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -603,6 +603,8 @@ export async function fetchJson<TResult>(
     return response.json()
 }
 
+export class TimeoutError extends Error {}
+
 // Adapted from https://github.com/sindresorhus/ky/blob/main/source/utils/timeout.ts
 export async function fetchWithTimeout(
     url: string,
@@ -614,7 +616,7 @@ export async function fetchWithTimeout(
     return new Promise((resolve, reject) => {
         const timeoutId = setTimeout(() => {
             abortController.abort()
-            reject(new Error(`Request timed out: ${url}`))
+            reject(new TimeoutError(`Request timed out: ${url}`))
         }, timeoutMs)
 
         void fetch(url, { ...options, signal: abortController.signal })

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -40,6 +40,7 @@ export {
     fetchText,
     fetchJson,
     fetchWithTimeout,
+    TimeoutError,
     getUserCountryInformation,
     stripHTML,
     getRandomNumberGenerator,

--- a/site/instrument.ts
+++ b/site/instrument.ts
@@ -6,6 +6,7 @@
  */
 
 import * as Sentry from "@sentry/react"
+import { TimeoutError } from "@ourworldindata/utils"
 import {
     COMMIT_SHA,
     ENV,
@@ -47,6 +48,10 @@ if (LOAD_SENTRY) {
         tracesSampleRate: 0.1,
         replaysSessionSampleRate: sampleRate,
         replaysOnErrorSampleRate: 0,
+        beforeSend(event, hint) {
+            if (hint.originalException instanceof TimeoutError) return null
+            return event
+        },
     })
     updateSentryTags()
     updateSentryUser()


### PR DESCRIPTION
This happens a lot and it's not really useful to log the errors.