### PR TITLE
🔨🤖 (chart-configs) prefer "indicator" over "variable" in code

### DIFF
--- a/adminSiteClient/ChartEditor.ts
+++ b/adminSiteClient/ChartEditor.ts
@@ -11,7 +11,7 @@ import {
     ChartRedirect,
     Json,
     GrapherInterface,
-    getParentVariableIdFromChartConfig,
+    getParentIndicatorIdFromChartConfig,
     mergeGrapherConfigs,
     NARRATIVE_CHART_PROPS_TO_OMIT,
 } from "@ourworldindata/utils"
@@ -115,9 +115,9 @@ export class ChartEditor extends AbstractChartEditor<ChartEditorManager> {
         return this.manager.forceDatapage ?? false
     }
 
-    /** parent variable id, derived from the config */
-    @computed get parentVariableId(): number | undefined {
-        return getParentVariableIdFromChartConfig(this.liveConfig)
+    /** parent indicator id, derived from the config */
+    @computed get parentIndicatorId(): number | undefined {
+        return getParentIndicatorIdFromChartConfig(this.liveConfig)
     }
 
     @computed get availableTabs(): EditorTab[] {
@@ -139,7 +139,7 @@ export class ChartEditor extends AbstractChartEditor<ChartEditorManager> {
     @action.bound async updateParentConfig() {
         const currentParentIndicatorId =
             this.parentConfig?.dimensions?.[0].variableId
-        const newParentIndicatorId = getParentVariableIdFromChartConfig(
+        const newParentIndicatorId = getParentIndicatorIdFromChartConfig(
             this.grapherState.object
         )
 
@@ -185,7 +185,7 @@ export class ChartEditor extends AbstractChartEditor<ChartEditorManager> {
 
         // it only makes sense to enable inheritance if the chart has a parent
         const shouldEnableInheritance =
-            !!this.parentVariableId && this.isInheritanceEnabled
+            !!this.parentIndicatorId && this.isInheritanceEnabled
 
         const query = new URLSearchParams({
             inheritance: shouldEnableInheritance ? "enable" : "disable",
@@ -231,7 +231,7 @@ export class ChartEditor extends AbstractChartEditor<ChartEditorManager> {
 
         // it only makes sense to enable inheritance if the chart has a parent
         const shouldEnableInheritance =
-            !!this.parentVariableId && this.isInheritanceEnabled
+            !!this.parentIndicatorId && this.isInheritanceEnabled
 
         const query = new URLSearchParams({
             inheritance: shouldEnableInheritance ? "enable" : "disable",

--- a/adminSiteClient/ChartEditorPage.tsx
+++ b/adminSiteClient/ChartEditorPage.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { observer } from "mobx-react"
 import { observable, computed, runInAction, action, makeObservable } from "mobx"
-import { getParentVariableIdFromChartConfig } from "@ourworldindata/utils"
+import { getParentIndicatorIdFromChartConfig } from "@ourworldindata/utils"
 import {
     type AnalyticsGrapherViewWithRank,
     GrapherInterface,
@@ -94,7 +94,7 @@ export class ChartEditorPage
             this.forceDatapage = settings?.forceDatapage ?? false
         } else if (grapherConfig) {
             const parentIndicatorId =
-                getParentVariableIdFromChartConfig(grapherConfig)
+                getParentIndicatorIdFromChartConfig(grapherConfig)
             if (parentIndicatorId) {
                 this.parentConfig = await fetchChartConfigByIndicatorId(
                     this.context.admin,

--- a/adminSiteClient/EditorDebugTab.tsx
+++ b/adminSiteClient/EditorDebugTab.tsx
@@ -85,21 +85,21 @@ class EditorDebugTabForChart extends Component<{
             parentConfig,
             isInheritanceEnabled,
             fullConfig,
-            parentVariableId,
+            parentIndicatorId,
             grapherState,
         } = this.props.editor
 
-        const column = parentVariableId
-            ? grapherState.inputTable.get(parentVariableId.toString())
+        const column = parentIndicatorId
+            ? grapherState.inputTable.get(parentIndicatorId.toString())
             : undefined
 
-        const variableLink = (
+        const indicatorLink = (
             <a
-                href={`/admin/variables/${parentVariableId}`}
+                href={`/admin/variables/${parentIndicatorId}`}
                 target="_blank"
                 rel="noopener"
             >
-                {column?.name ?? parentVariableId}
+                {column?.name ?? parentIndicatorId}
             </a>
         )
 
@@ -120,13 +120,13 @@ class EditorDebugTabForChart extends Component<{
                     </button>
                 </Section>
 
-                {parentVariableId && (
+                {parentIndicatorId && (
                     <>
                         <Section name="Parent indicator">
                             {isInheritanceEnabled ? (
                                 <p>
                                     This chart is configured to inherit settings
-                                    from its parent indicator, {variableLink}.
+                                    from its parent indicator, {indicatorLink}.
                                     {!parentConfig && (
                                         <>
                                             {" "}
@@ -139,7 +139,7 @@ class EditorDebugTabForChart extends Component<{
                             ) : (
                                 <p>
                                     This chart may inherit chart settings from
-                                    the indicator {variableLink}, but
+                                    the indicator {indicatorLink}, but
                                     inheritance is currently disabled. Toggle
                                     the option below to enable inheritance.
                                 </p>

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -116,7 +116,7 @@ import {
     getVariableDataJson,
     getVariableMetadataJson,
     getVariablesJson,
-    getLatestVariableIdsByCatalogPathJson,
+    getLatestIndicatorIdsByCatalogPathJson,
     getVariablesUsagesJson,
     getIndicatorChartConfigJson,
     getVariableJson,
@@ -615,7 +615,7 @@ getRouteWithROTransaction(
 getRouteWithROTransaction(
     apiRouter,
     "/variables.latestByCatalogPath.json",
-    getLatestVariableIdsByCatalogPathJson
+    getLatestIndicatorIdsByCatalogPathJson
 )
 getRouteWithROTransaction(
     apiRouter,

--- a/adminSiteServer/apiRoutes/variables.ts
+++ b/adminSiteServer/apiRoutes/variables.ts
@@ -19,7 +19,7 @@ import {
 import {
     fetchS3DataValuesByPath,
     fetchS3MetadataByPath,
-    getLatestVariableIdsByCatalogPath,
+    getLatestIndicatorIdsByCatalogPath,
     getIndicatorChartConfigRecord,
     getIndicatorChartConfig,
     searchVariables,
@@ -31,7 +31,7 @@ import { enqueueExplorerRefreshJobsForDependencies } from "../../db/model/Explor
 import { DATA_API_URL } from "../../settings/clientSettings.js"
 import * as db from "../../db/db.js"
 import {
-    getParentVariableIdFromChartConfig,
+    getParentIndicatorIdFromChartConfig,
     parseIntOrUndefined,
 } from "@ourworldindata/utils"
 import {
@@ -123,13 +123,13 @@ export async function getVariableDataJson(
     _trx: db.KnexReadonlyTransaction
 ) {
     const variableStr = req.params.variableStr
-    if (!variableStr) throw new JsonError("No variable id given")
+    if (!variableStr) throw new JsonError("No indicator id given")
     if (variableStr.includes("+"))
         throw new JsonError(
-            "Requesting multiple variables at the same time is no longer supported"
+            "Requesting multiple indicators at the same time is no longer supported"
         )
     const variableId = parseInt(variableStr)
-    if (isNaN(variableId)) throw new JsonError("Invalid variable id")
+    if (isNaN(variableId)) throw new JsonError("Invalid indicator id")
     return await fetchS3DataValuesByPath(
         getVariableDataRoute(DATA_API_URL, variableId, { noCache: true })
     )
@@ -141,13 +141,13 @@ export async function getVariableMetadataJson(
     _trx: db.KnexReadonlyTransaction
 ) {
     const variableStr = req.params.variableStr
-    if (!variableStr) throw new JsonError("No variable id given")
+    if (!variableStr) throw new JsonError("No indicator id given")
     if (variableStr.includes("+"))
         throw new JsonError(
-            "Requesting multiple variables at the same time is no longer supported"
+            "Requesting multiple indicators at the same time is no longer supported"
         )
     const variableId = parseInt(variableStr)
-    if (isNaN(variableId)) throw new JsonError("Invalid variable id")
+    if (isNaN(variableId)) throw new JsonError("Invalid indicator id")
     return await fetchS3MetadataByPath(
         getVariableMetadataRoute(DATA_API_URL, variableId, { noCache: true })
     )
@@ -184,7 +184,7 @@ export async function getVariablesUsagesJson(
     return rows
 }
 
-export async function getLatestVariableIdsByCatalogPathJson(
+export async function getLatestIndicatorIdsByCatalogPathJson(
     req: Request,
     _res: HandlerResponse,
     trx: db.KnexReadonlyTransaction
@@ -203,7 +203,10 @@ export async function getLatestVariableIdsByCatalogPathJson(
         )
     }
 
-    const idsByPath = await getLatestVariableIdsByCatalogPath(catalogPaths, trx)
+    const idsByPath = await getLatestIndicatorIdsByCatalogPath(
+        catalogPaths,
+        trx
+    )
     return Object.fromEntries(idsByPath)
 }
 
@@ -259,7 +262,7 @@ export async function getVariableJson(
 
     // check for parent indicators
     const charts = rawCharts.map((chart) => {
-        const parentIndicatorId = getParentVariableIdFromChartConfig(
+        const parentIndicatorId = getParentIndicatorIdFromChartConfig(
             parseChartConfig(chart.config)
         )
         const hasParentIndicator = parentIndicatorId !== undefined
@@ -301,13 +304,13 @@ export async function putIndicatorChartConfig(
         }
     }
 
-    const variable = await getIndicatorChartConfigRecord(trx, variableId)
-    if (!variable) {
-        throw new JsonError(`Variable with id ${variableId} not found`, 500)
+    const indicator = await getIndicatorChartConfigRecord(trx, variableId)
+    if (!indicator) {
+        throw new JsonError(`Indicator with id ${variableId} not found`, 500)
     }
 
     const { savedPatch, updatedCharts, updatedMultiDimViews } =
-        await updateIndicatorChartConfig(trx, variable, validConfig)
+        await updateIndicatorChartConfig(trx, indicator, validConfig)
 
     await updateGrapherConfigsInR2(trx, updatedCharts, updatedMultiDimViews)
     const chartIdsForRefresh = Array.from(
@@ -322,7 +325,7 @@ export async function putIndicatorChartConfig(
     if (allUpdatedConfigs.some(({ isPublished }) => isPublished)) {
         await triggerStaticBuild(
             res.locals.user,
-            `Updating ETL config for variable ${variableId}`
+            `Updating ETL config for indicator ${variableId}`
         )
     }
 
@@ -336,13 +339,13 @@ export async function deleteIndicatorChartConfig(
 ) {
     const variableId = expectInt(req.params.variableId)
 
-    const variable = await getIndicatorChartConfigRecord(trx, variableId)
-    if (!variable) {
-        throw new JsonError(`Variable with id ${variableId} not found`, 500)
+    const indicator = await getIndicatorChartConfigRecord(trx, variableId)
+    if (!indicator) {
+        throw new JsonError(`Indicator with id ${variableId} not found`, 500)
     }
 
-    // no-op if the variable doesn't have an ETL config
-    if (!variable.configId) return { success: true }
+    // no-op if the indicator doesn't have an ETL config
+    if (!indicator.configId) return { success: true }
 
     const now = new Date()
 
@@ -364,7 +367,7 @@ export async function deleteIndicatorChartConfig(
                 DELETE FROM chart_configs
                 WHERE id = ?
             `,
-        [variable.configId]
+        [indicator.configId]
     )
 
     const updatedCharts = await updateAllChartsThatInheritFromIndicator(
@@ -393,7 +396,7 @@ export async function deleteIndicatorChartConfig(
     if (allUpdatedConfigs.some(({ isPublished }) => isPublished)) {
         await triggerStaticBuild(
             res.locals.user,
-            `Updating ETL config for variable ${variableId}`
+            `Updating ETL config for indicator ${variableId}`
         )
     }
 

--- a/adminSiteServer/multiDim.ts
+++ b/adminSiteServer/multiDim.ts
@@ -30,7 +30,7 @@ import {
 import { upsertMultiDimXChartConfigs } from "../db/model/MultiDimXChartConfigs.js"
 import {
     getIndicatorChartConfigs,
-    getVariableIdsByCatalogPath,
+    getIndicatorIdsByCatalogPath,
 } from "../db/model/Variable.js"
 import {
     deleteGrapherConfigFromR2,
@@ -76,7 +76,7 @@ async function resolveMultiDimDataPageCatalogPathsToIndicatorIds(
 ): Promise<MultiDimDataPageConfigPreProcessed> {
     const allCatalogPaths = getAllCatalogPaths(rawConfig.views)
 
-    const catalogPathToIndicatorIdMap = await getVariableIdsByCatalogPath(
+    const catalogPathToIndicatorIdMap = await getIndicatorIdsByCatalogPath(
         allCatalogPaths,
         knex
     )
@@ -239,7 +239,7 @@ export async function upsertMultiDim(
         rawConfig
     )
     validateViewConfigSchemas(config)
-    const variableConfigs = await getIndicatorChartConfigs(
+    const indicatorConfigs = await getIndicatorChartConfigs(
         knex,
         _.uniq(config.views.map((view) => view.indicators.y[0].id))
     )
@@ -267,7 +267,7 @@ export async function upsertMultiDim(
                 existingIsPublished
             )
             const fullGrapherConfig = mergeGrapherConfigs(
-                variableConfigs.get(variableId) ?? {},
+                indicatorConfigs.get(variableId) ?? {},
                 patchGrapherConfig
             )
             const existingChartConfigId = existingViewIdsToChartConfigIds.get(

--- a/baker/MultiDimBaker.tsx
+++ b/baker/MultiDimBaker.tsx
@@ -54,10 +54,10 @@ const getLatestMultiDimArchivedVersionsIfEnabled = async (
     return await getLatestArchivedMultiDimPageVersions(knex, multiDimIds)
 }
 
-export function getRelevantVariableIds(
+export function getRelevantIndicatorIds(
     config: MultiDimDataPageConfigPreProcessed
 ) {
-    // A "relevant" variable id is the first y indicator of each view
+    // A "relevant" indicator id is the first y indicator of each view
     const allIndicatorIds = config.views
         .map((view) => view.indicators.y?.[0]?.id)
         .filter((id) => id !== undefined)
@@ -65,7 +65,7 @@ export function getRelevantVariableIds(
     return new Set(allIndicatorIds)
 }
 
-export async function getRelevantVariableMetadata(
+export async function getRelevantIndicatorMetadata(
     variableIds: Iterable<number>
 ) {
     const metadata = await pMap(
@@ -131,16 +131,16 @@ export async function renderMultiDimDataPageFromConfig({
     archiveContext?: ArchiveContext
 }) {
     const pageConfig = MultiDimDataPageConfig.fromObject(config)
-    const variableIds = getRelevantVariableIds(config)
-    const faqEntries = await getFaqEntries(knex, variableIds)
+    const indicatorIds = getRelevantIndicatorIds(config)
+    const faqEntries = await getFaqEntries(knex, indicatorIds)
     const initialViewDimensions = pageConfig.getDefaultSelectedChoices()
     const initialView = pageConfig.findViewByDimensions(initialViewDimensions)
 
     let initialViewData: MultiDimDataPageInitialViewData | undefined
-    const initialViewVariableId = initialView?.indicators?.y?.[0]?.id
-    if (initialView && initialViewVariableId) {
+    const initialViewIndicatorId = initialView?.indicators?.y?.[0]?.id
+    if (initialView && initialViewIndicatorId) {
         const [variableMetadata, fullGrapherConfig] = await Promise.all([
-            getVariableMetadata(initialViewVariableId, {
+            getVariableMetadata(initialViewIndicatorId, {
                 noCache: isPreviewing,
             }),
             getChartConfigByUUID(knex, initialView.fullConfigId),
@@ -177,9 +177,9 @@ export async function renderMultiDimDataPageFromConfig({
 
         // Related research
         relatedResearchCandidates =
-            variableIds.size > 0
+            indicatorIds.size > 0
                 ? await getRelatedResearchAndWritingForVariables(knex, [
-                      ...variableIds,
+                      ...indicatorIds,
                   ])
                 : []
 

--- a/baker/algolia/utils/mdimViews.ts
+++ b/baker/algolia/utils/mdimViews.ts
@@ -26,8 +26,8 @@ import {
     dimensionsToSortedQueryStr,
 } from "./mdimViewsLogic.js"
 import {
-    getRelevantVariableIds,
-    getRelevantVariableMetadata,
+    getRelevantIndicatorIds,
+    getRelevantIndicatorMetadata,
 } from "../../MultiDimBaker.js"
 import { GrapherState } from "@ourworldindata/grapher"
 import {
@@ -98,11 +98,11 @@ async function getRecords(
         trx,
         multiDim.config.views.map((view) => view.fullConfigId)
     )
-    const relevantVariableIds = getRelevantVariableIds(multiDim.config)
+    const relevantIndicatorIds = getRelevantIndicatorIds(multiDim.config)
     const relevantVariableMetadata =
-        await getRelevantVariableMetadata(relevantVariableIds)
+        await getRelevantIndicatorMetadata(relevantIndicatorIds)
     const datasetDimensionsByVariableId =
-        await getDatasetDimensionsByVariableIds(trx, [...relevantVariableIds])
+        await getDatasetDimensionsByVariableIds(trx, [...relevantIndicatorIds])
     const linksFromGdocs = await getPublishedLinksTo(
         trx,
         [slug],

--- a/db/model/Chart.ts
+++ b/db/model/Chart.ts
@@ -9,7 +9,7 @@ import {
     KeyChartLevel,
     MultipleOwidVariableDataDimensionsMap,
     DbChartTagJoin,
-    getParentVariableIdFromChartConfig,
+    getParentIndicatorIdFromChartConfig,
 } from "@ourworldindata/utils"
 import {
     GrapherInterface,
@@ -338,7 +338,7 @@ export async function isInheritanceEnabledForChart(
     return row?.isInheritanceEnabled ?? false
 }
 
-async function getParentVariableIdByChartId(
+async function getParentIndicatorIdByChartId(
     trx: db.KnexReadonlyTransaction,
     chartId: number
 ): Promise<number | undefined> {
@@ -358,11 +358,11 @@ export async function getParentByChartId(
     trx: db.KnexReadonlyTransaction,
     chartId: number
 ): Promise<{ variableId?: number; config?: GrapherInterface }> {
-    const parentVariableId = await getParentVariableIdByChartId(trx, chartId)
-    if (!parentVariableId) return {}
+    const parentIndicatorId = await getParentIndicatorIdByChartId(trx, chartId)
+    if (!parentIndicatorId) return {}
     return {
-        variableId: parentVariableId,
-        config: await getIndicatorChartConfig(trx, parentVariableId),
+        variableId: parentIndicatorId,
+        config: await getIndicatorChartConfig(trx, parentIndicatorId),
     }
 }
 
@@ -373,11 +373,11 @@ export async function getParentByChartConfig(
     variableId?: number
     config?: GrapherInterface
 }> {
-    const parentVariableId = getParentVariableIdFromChartConfig(config)
-    if (!parentVariableId) return {}
+    const parentIndicatorId = getParentIndicatorIdFromChartConfig(config)
+    if (!parentIndicatorId) return {}
     return {
-        variableId: parentVariableId,
-        config: await getIndicatorChartConfig(trx, parentVariableId),
+        variableId: parentIndicatorId,
+        config: await getIndicatorChartConfig(trx, parentIndicatorId),
     }
 }
 

--- a/db/model/ExplorerCatalogResolver.ts
+++ b/db/model/ExplorerCatalogResolver.ts
@@ -4,7 +4,7 @@ import {
     ColumnGrammar,
 } from "@ourworldindata/explorer"
 import { KnexReadonlyTransaction } from "../db.js"
-import { getVariableIdsByCatalogPath } from "./Variable.js"
+import { getIndicatorIdsByCatalogPath } from "./Variable.js"
 import {
     CoreTable,
     ErrorValueTypes,
@@ -25,7 +25,7 @@ export const transformExplorerProgramToResolveCatalogPaths = async (
 
     if (requiredCatalogPaths.size === 0) return { program }
 
-    const catalogPathToIndicatorIdMap = await getVariableIdsByCatalogPath(
+    const catalogPathToIndicatorIdMap = await getIndicatorIdsByCatalogPath(
         [...requiredCatalogPaths],
         knex
     )

--- a/db/model/Variable.ts
+++ b/db/model/Variable.ts
@@ -329,14 +329,14 @@ export async function updateAllMultiDimViewsThatInheritFromIndicator(
 
 export async function updateIndicatorChartConfig(
     trx: db.KnexReadWriteTransaction,
-    variable: IndicatorChartConfigRecord,
+    indicator: IndicatorChartConfigRecord,
     config: GrapherInterface
 ): Promise<{
     savedPatch: GrapherInterface
     updatedCharts: UpdatedChartInheritanceRecord[]
     updatedMultiDimViews: { chartConfigId: string; isPublished: boolean }[]
 }> {
-    const { variableId } = variable
+    const { variableId } = indicator
 
     const configETL = makeConfigValidForIndicator({
         config,
@@ -348,9 +348,9 @@ export async function updateIndicatorChartConfig(
     // past in chart-sync.
     const now = new Date()
 
-    if (variable.configId) {
+    if (indicator.configId) {
         await updateChartConfig(trx, {
-            configId: variable.configId,
+            configId: indicator.configId,
             config: configETL,
             updatedAt: now,
         })
@@ -1032,7 +1032,7 @@ export interface VariableResultView {
     shortName: string
 }
 
-export const getVariableIdsByCatalogPath = async (
+export const getIndicatorIdsByCatalogPath = async (
     catalogPaths: string[],
     knex: db.KnexReadonlyTransaction
 ): Promise<Map<string, number | null>> => {
@@ -1062,7 +1062,7 @@ export const getVariableIdsByCatalogPath = async (
  * e.g. `grapher/worldbank_wdi/latest/wdi/wdi#ny_gdp_pcap_pp_kd`) and returns
  * the id of the most recent version
  */
-export const getLatestVariableIdsByCatalogPath = async (
+export const getLatestIndicatorIdsByCatalogPath = async (
     catalogPaths: string[],
     knex: db.KnexReadonlyTransaction
 ): Promise<Map<string, number | null>> => {

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -2447,7 +2447,7 @@ export function traverseObjects<T extends Record<string, any>>(
     return result
 }
 
-export function getParentVariableIdFromChartConfig(
+export function getParentIndicatorIdFromChartConfig(
     config: GrapherInterface
 ): number | undefined {
     const { chartTypes, dimensions } = config

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -125,7 +125,7 @@ export {
     flattenNonTopicNodes,
     formatInlineList,
     lazy,
-    getParentVariableIdFromChartConfig,
+    getParentIndicatorIdFromChartConfig,
     isArrayDifferentFromReference,
     readFromAssetMap,
     getUniqueNamesFromTagHierarchies,


### PR DESCRIPTION
> _Written by Anthropic Claude Opus 5 — @sophiamersmann at the wheel._

The admin UI, the mdim config schema and the data API already say "indicator" — the sidebar links to `/variables` under the label **Indicators**, mdim configs carry an `indicators` key, and the data API lives at `/v1/indicators/{id}.data.json`. The code around them still said "variable", frequently for the same concept in the same file:

- `ChartEditor` exposed a `parentVariableId` getter sitting twenty lines above `newParentIndicatorId`, both derived from the same helper.
- `multiDim.ts` assigned the result of `getIndicatorChartConfigs()` to a local named `variableConfigs`.
- `EditorDebugTab` rendered a `variableLink` into the sentence "inherits settings from its parent indicator, …".

This renames the concept names only. **`variableId` / `variableIds` stay wherever they reference a DB column or a config schema key**, so the `variables` table, the `/api/variables*` routes (including the `grapherConfigETL` contract the ETL depends on), and `dimensions[].variableId` are all untouched. No migration, no API change.

Stacked on #6988.

### Deliberately left for a follow-up

The `getVariableMetadata` / `getVariableData` / `getVariableDataRoute` family and the `OwidVariable*` type family. Each is a coherent unit spanning 13+ files, and renaming half of either would relocate the inconsistency rather than remove it. `OwidVariable*` in particular names things whose identity *is* the `variables` table, so it's only worth revisiting if that table is ever renamed.

<details><summary>Details</summary>

### Renamed symbols

| old | new |
|---|---|
| `getParentVariableIdFromChartConfig` | `getParentIndicatorIdFromChartConfig` |
| `getParentVariableIdByChartId` | `getParentIndicatorIdByChartId` |
| `parentVariableId` (getter + locals) | `parentIndicatorId` |
| `getVariableIdsByCatalogPath` | `getIndicatorIdsByCatalogPath` |
| `getLatestVariableIdsByCatalogPath` | `getLatestIndicatorIdsByCatalogPath` |
| `getRelevantVariableIds` | `getRelevantIndicatorIds` |
| `getRelevantVariableMetadata` | `getRelevantIndicatorMetadata` |
| `variableConfigs` | `indicatorConfigs` |
| `variableLink` | `indicatorLink` |
| `initialViewVariableId` | `initialViewIndicatorId` |
| `relevantVariableIds` | `relevantIndicatorIds` |
| `updateIndicatorChartConfig(…, variable, …)` | `…, indicator, …` |
| `const variable = await getIndicatorChartConfigRecord()` (×2) | `const indicator = …` |

Prose also updated: `"Variable with id … not found"` → `Indicator`, `"No/Invalid variable id"`, `"Requesting multiple variables at the same time…"`, `"Updating ETL config for variable …"`, plus three code comments.

### The rule applied

Concept names become `indicator`; column and schema-key references stay `variableId`. So these were left alone as correct-as-written:

- `.whereIn("variableId", variableIds)` in `getFaqRelationsFromDb` / `getDatasetDimensionsByVariableIds`
- `{ property: "y", variableId }` and `dimensions[].variableId` (grapher schema 011)
- `indicators: { y: variableId }` in mdim configs and tests — schema key plus DB id, both halves already correct
- `collectVariableIdsFromIndicators` and `for (const variableId of indicatorIds)` in the archival code — these genuinely collect `variables.id` values out of indicator checksum maps
- `getVariableJson`'s `{ variable: … }` response shape, consumed by `VariableEditPage`

### Files

13 files. `packages/@ourworldindata/utils/src/{Util,index}.ts` holds the shared definition that five of the call sites reach through, so it moves with them; `db/model/ExplorerCatalogResolver.ts` and `adminSiteServer/apiRouter.ts` are updated to keep their call sites compiling.

```
adminSiteClient/{ChartEditor.ts,ChartEditorPage.tsx,EditorDebugTab.tsx}
adminSiteServer/{apiRouter.ts,multiDim.ts,apiRoutes/variables.ts}
baker/{MultiDimBaker.tsx,algolia/utils/mdimViews.ts}
db/model/{Chart.ts,Variable.ts,ExplorerCatalogResolver.ts}
packages/@ourworldindata/utils/src/{Util.ts,index.ts}
```

A stale reference to the old helper name in `docs/map-dimension-plan.md` was absorbed into the commit that introduced it, on a separate docs branch.

### Test plan

- `yarn typecheck` — clean
- `yarn testLintChanged`, `yarn testFormatChanged` — clean
- `yarn test run` — 2287 passed, 5 failed. All five failures are in `functions/test/grapher-config-r2.e2e.test.ts`, a wrangler/R2 end-to-end suite timing out in its `clearBuckets()` hook. Nothing in this PR touches `functions/`, and that file references none of the renamed symbols. Not verified against a clean tree, so this is an inference rather than a confirmed pre-existing failure.

Pure rename with no behavioural change, so no new tests.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)