### PR TITLE
🐛🤖 keep entity selection when saving a narrative chart

### DIFF
--- a/adminSiteClient/ChartEditor.ts
+++ b/adminSiteClient/ChartEditor.ts
@@ -13,7 +13,6 @@ import {
     GrapherInterface,
     getParentIndicatorIdFromChartConfig,
     mergeGrapherConfigs,
-    NARRATIVE_CHART_PROPS_TO_OMIT,
 } from "@ourworldindata/utils"
 import { DbChartTagJoin } from "@ourworldindata/types"
 import { action, computed, observable, runInAction, makeObservable } from "mobx"
@@ -24,6 +23,7 @@ import {
     EditorTab,
     References,
 } from "./AbstractChartEditor.js"
+import { makeNarrativeChartPatchConfig } from "./narrativeChartConfig.js"
 import { Admin } from "./Admin.js"
 import { MinimalTagWithMetadata } from "./TagGraphMetadata.js"
 
@@ -253,9 +253,12 @@ export class ChartEditor extends AbstractChartEditor<ChartEditorManager> {
     async saveAsNarrativeChart(
         name: string
     ): Promise<{ success: boolean; errorMsg?: string }> {
-        const { patchConfig, grapherState } = this
+        const { grapherState } = this
 
-        const chartJson = _.omit(patchConfig, NARRATIVE_CHART_PROPS_TO_OMIT)
+        const chartJson = makeNarrativeChartPatchConfig(
+            this.liveConfigWithDefaults,
+            this.activeParentConfigWithDefaults
+        )
 
         const body = {
             type: "chart",

--- a/adminSiteClient/NarrativeChartEditor.ts
+++ b/adminSiteClient/NarrativeChartEditor.ts
@@ -1,4 +1,3 @@
-import * as _ from "lodash-es"
 import type { History } from "history"
 import { computed, runInAction, makeObservable } from "mobx"
 import {
@@ -7,12 +6,8 @@ import {
     References,
     type EditorTab,
 } from "./AbstractChartEditor.js"
-import {
-    NARRATIVE_CHART_PROPS_TO_OMIT,
-    NARRATIVE_CHART_PROPS_TO_PERSIST,
-    GrapherInterface,
-} from "@ourworldindata/types"
-import { diffGrapherConfigs } from "@ourworldindata/utils"
+import { makeNarrativeChartPatchConfig } from "./narrativeChartConfig.js"
+import { GrapherInterface } from "@ourworldindata/types"
 
 export interface Chart {
     id: number
@@ -56,28 +51,10 @@ export class NarrativeChartEditor extends AbstractChartEditor<NarrativeChartEdit
     }
 
     override get patchConfig(): GrapherInterface {
-        const config = _.omit(
+        return makeNarrativeChartPatchConfig(
             this.liveConfigWithDefaults,
-            NARRATIVE_CHART_PROPS_TO_OMIT
+            this.activeParentConfigWithDefaults
         )
-
-        const patchToParentChart = diffGrapherConfigs(
-            config,
-            this.activeParentConfigWithDefaults || {}
-        )
-
-        return {
-            ...patchToParentChart,
-
-            // We want to make sure we're explicitly persisting some props like entity selection
-            // always, so they never change when the parent chart changes.
-            // For this, we need to ensure we include the default layer, so that we even
-            // persist these props when they are the same as the default.
-            ..._.pick(
-                this.liveConfigWithDefaults,
-                NARRATIVE_CHART_PROPS_TO_PERSIST
-            ),
-        }
     }
 
     @computed get narrativeChartId(): number | undefined {

--- a/adminSiteClient/narrativeChartConfig.ts
+++ b/adminSiteClient/narrativeChartConfig.ts
@@ -1,0 +1,40 @@
+import * as _ from "lodash-es"
+import {
+    GrapherInterface,
+    NARRATIVE_CHART_PROPS_TO_OMIT,
+    NARRATIVE_CHART_PROPS_TO_PERSIST,
+} from "@ourworldindata/types"
+import { diffGrapherConfigs } from "@ourworldindata/utils"
+import { defaultGrapherConfig } from "@ourworldindata/grapher"
+
+/**
+ * The patch config a narrative chart is saved with: what the live config adds
+ * on top of its parent, plus an explicit snapshot of the props a narrative
+ * chart always owns.
+ */
+export function makeNarrativeChartPatchConfig(
+    liveConfigWithDefaults: GrapherInterface,
+    // Diff against the defaults if no parent layer is applied
+    parentConfigWithDefaults: GrapherInterface = defaultGrapherConfig
+): GrapherInterface {
+    // The live config without the props that are always omitted from a narrative chart's config
+    const liveConfig = _.omit(
+        liveConfigWithDefaults,
+        NARRATIVE_CHART_PROPS_TO_OMIT
+    )
+
+    // What the live config adds on top of its parent
+    const patchToParent = diffGrapherConfigs(
+        liveConfig,
+        parentConfigWithDefaults
+    )
+
+    // The props that are always persisted in a narrative chart's config,
+    // even if they match the parent chart's config
+    const alwaysPersistedProps = _.pick(
+        liveConfigWithDefaults,
+        NARRATIVE_CHART_PROPS_TO_PERSIST
+    )
+
+    return { ...patchToParent, ...alwaysPersistedProps }
+}


### PR DESCRIPTION
> _Written by Claude Opus 5 — @sophiamersmann at the wheel._

Saving a chart as a narrative chart wiped its entity selection whenever the selection was inherited from the indicator config.

Narrative charts persist a few props explicitly (entity selection, time, focus) so a later parent edit can't move them. That snapshot was taken on the server, from the submitted patch merged with the grapher defaults — but the chart editor submits the chart's *patch*, so anything inherited isn't in it and got snapshotted as the default. The snapshot now happens in the editor, off the live config.

To check it: [chart 189](https://staging-site-narrative-chart-selection.owid.io/admin/charts/189/edit) has inheritance enabled and inherits its entity selection from the indicator config. Switch to the line tab and save it as a narrative chart — before, the narrative chart came out with the default selection; now it keeps all entities.

<details><summary>Details</summary>

- New `adminSiteClient/narrativeChartConfig.ts`: `makeNarrativeChartPatchConfig(liveConfigWithDefaults, parentConfigWithDefaults?)` returns the diff to the parent plus an explicit `_.pick` of `NARRATIVE_CHART_PROPS_TO_PERSIST` off the live config.
- `ChartEditor.saveAsNarrativeChart` now goes through it — that path sent a bare diff before, which is where the bug was. `NarrativeChartEditor.patchConfig` already did the same pick inline and now delegates, so both create paths are identical.
- The fallback for "no parent layer applied" lives in the helper, so both editors diff against `defaultGrapherConfig`. `NarrativeChartEditor` previously diffed against `{}`, which inlines every default into the patch; only reachable in the window before the parent config loads.
- The server is unchanged: it still snapshots from `mergeGrapherConfigs(defaultGrapherConfig, config)`, which is a pass-through for props the editors now always send explicitly.

</details>

