### PR TITLE
🎉🤖 tell apart svg differences that render identically

### DIFF
--- a/adminSiteClient/SvgTesterSuitePage.scss
+++ b/adminSiteClient/SvgTesterSuitePage.scss
@@ -79,6 +79,12 @@ $svg-tester-error-frame: #dda4a0;
     color: $svg-tester-error;
 }
 
+.SvgTesterSuitePage__visual-note {
+    color: $gray-70;
+    font-size: 14px;
+    font-variant-numeric: tabular-nums;
+}
+
 .SvgTesterSuitePage__progress {
     margin-top: 4px;
     max-width: 480px;
@@ -106,6 +112,10 @@ $svg-tester-error-frame: #dda4a0;
 
 .SvgTesterSuitePage__controls {
     margin-bottom: 20px;
+
+    .ant-segmented-item {
+        margin-bottom: 0;
+    }
 }
 
 .SvgTesterSuitePage__card {
@@ -113,6 +123,11 @@ $svg-tester-error-frame: #dda4a0;
     border-radius: 2px;
     margin-bottom: 20px;
     padding: 12px;
+
+    // Skip rendering off-screen cards
+    content-visibility: auto;
+    // Roughly a card's height, so the scrollbar doesn't lurch as they render
+    contain-intrinsic-size: auto 700px;
 
     &:target {
         border-color: $blue-40;

--- a/adminSiteClient/SvgTesterSuitePage.tsx
+++ b/adminSiteClient/SvgTesterSuitePage.tsx
@@ -3,6 +3,7 @@ import {
     Alert,
     FloatButton,
     Progress,
+    Segmented,
     Select,
     Space,
     Spin,
@@ -37,6 +38,11 @@ import {
     isUnderway,
     runProgress,
 } from "./svgTesterHelpers.js"
+import pMap from "p-map"
+import {
+    compareSvgsVisually,
+    VISUAL_DIFF_CONCURRENCY,
+} from "./svgVisualDiff.js"
 
 const LIVE_URL = "https://ourworldindata.org"
 
@@ -57,8 +63,28 @@ const KIND_LABELS: Record<SvgTesterVerifyErrorEntry["kind"], string> = {
 
 const CHART_TYPE_PARAM = "chartType"
 
+/** Which differences to list, once we know which ones only changed in markup */
+type VisualFilter = "changed" | "identical" | "all"
+
+const DEFAULT_VISUAL_FILTER: VisualFilter = "changed"
+
+/** How many of a run's differences turned out to be markup-only */
+interface VisualSummary {
+    total: number
+    identicalCount: number
+    remainingCount: number
+    /** False while the check is still going, when the counts are partial */
+    isComplete: boolean
+}
+
 /** How often to look for a new run when the last one has already reported */
 const IDLE_REFRESH_INTERVAL_MS = 30_000
+
+/** How often the countdown is allowed to move, out of thousands of answers */
+const VISUAL_DIFF_PROGRESS_MS = 250
+
+/** Stable identity, so holding results back doesn't itself rebuild the list */
+const NO_VISUAL_RESULTS: Record<string, boolean> = {}
 
 export function SvgTesterSuitePage() {
     const { admin } = useContext(AdminAppContext)
@@ -75,6 +101,12 @@ export function SvgTesterSuitePage() {
         else params.set(CHART_TYPE_PARAM, value)
         history.replace({ search: params.toString(), hash: "" })
     }
+
+    // Not in the URL, unlike the chart type: which differences render
+    // identically is only known once this session has checked them
+    const [visualFilter, setVisualFilter] = useState<VisualFilter>(
+        DEFAULT_VISUAL_FILTER
+    )
 
     const { data, isLoading, isError, dataUpdatedAt } = useQuery({
         queryKey: ["svgtester-results", suite],
@@ -95,7 +127,14 @@ export function SvgTesterSuitePage() {
     })
 
     const results = data?.results
-    const differences = useMemo(() => results?.differences ?? [], [results])
+
+    // Deduplicated: the pipeline lists some views twice, and rows that are equal
+    // collide on their React key. Remove once it stops emitting them.
+    const differences = useMemo(
+        () =>
+            _.uniqBy(results?.differences ?? [], (entry) => entry.svgFilename),
+        [results?.differences]
+    )
 
     const chartTypeCounts = useMemo(
         () => _.countBy(differences, (entry) => entry.chartType ?? "Unknown"),
@@ -112,16 +151,79 @@ export function SvgTesterSuitePage() {
         [differences, chartType]
     )
 
-    const status = data ? displayStatus(data) : undefined
-
     const isReported = data ? hasReportedResult(data) : false
+
+    // Check visual differences once the run has reported
+    const { identicalBySvg, remainingCount } = useVisualDiffs(
+        suite,
+        differences,
+        isReported ? results?.startedAt : undefined
+    )
+
+    const applied = identicalBySvg ?? NO_VISUAL_RESULTS
+
+    const [looksDifferent, rendersIdentically] = useMemo(
+        () => _.partition(visible, (entry) => !applied[entry.svgFilename]),
+        [visible, applied]
+    )
+
+    const showVisualFilter =
+        looksDifferent.length > 0 && rendersIdentically.length > 0
+    const effectiveVisualFilter: VisualFilter = showVisualFilter
+        ? visualFilter
+        : "all"
+
+    const shown = useMemo(() => {
+        if (effectiveVisualFilter === "changed") return looksDifferent
+        if (effectiveVisualFilter === "identical") return rendersIdentically
+        return [...looksDifferent, ...rendersIdentically]
+    }, [effectiveVisualFilter, looksDifferent, rendersIdentically])
+
+    const visualFilterOptions = [
+        {
+            value: "changed" as const,
+            label: `Visible change (${looksDifferent.length.toLocaleString()})`,
+        },
+        {
+            value: "identical" as const,
+            label: `No visible change (${rendersIdentically.length.toLocaleString()})`,
+        },
+        {
+            value: "all" as const,
+            label: `All (${visible.length.toLocaleString()})`,
+        },
+    ]
+
+    const cards = useMemo(
+        () =>
+            shown.map((entry) => (
+                <DifferenceCard
+                    key={anchorId(entry.viewId, entry.queryStr)}
+                    suite={suite}
+                    entry={entry}
+                    visuallyIdentical={applied[entry.svgFilename]}
+                />
+            )),
+        [shown, suite, applied]
+    )
+
+    const visualSummary = differences.length
+        ? {
+              total: differences.length,
+              identicalCount: Object.values(applied).filter(Boolean).length,
+              remainingCount,
+              isComplete: identicalBySvg !== undefined,
+          }
+        : undefined
+
+    const status = data ? displayStatus(data) : undefined
 
     // The browser jumps to the fragment before the cards it names exist: they
     // only render once the results have loaded.
     useEffect(() => {
         if (!location.hash) return
         document.getElementById(location.hash.slice(1))?.scrollIntoView()
-    }, [location.hash, results])
+    }, [location.hash, differences])
 
     return (
         <AdminLayout title={pageTitle(suite, data)}>
@@ -135,7 +237,10 @@ export function SvgTesterSuitePage() {
                         <div className="SvgTesterSuitePage__summary">
                             <div className="SvgTesterSuitePage__headline-row">
                                 <div className="SvgTesterSuitePage__headline">
-                                    <SuiteHeadline status={data} />
+                                    <SuiteHeadline
+                                        status={data}
+                                        visual={visualSummary}
+                                    />
                                 </div>
                                 <SuiteSwitcher currentSuite={suite} />
                             </div>
@@ -195,7 +300,7 @@ export function SvgTesterSuitePage() {
                     {!!differences.length && (
                         <>
                             <div className="SvgTesterSuitePage__controls">
-                                <Space size="middle" wrap>
+                                <Space size="middle" align="center" wrap>
                                     <Select
                                         value={chartType}
                                         onChange={setChartType}
@@ -214,21 +319,21 @@ export function SvgTesterSuitePage() {
                                             })),
                                         ]}
                                     />
+                                    {showVisualFilter && (
+                                        <Segmented<VisualFilter>
+                                            value={effectiveVisualFilter}
+                                            onChange={setVisualFilter}
+                                            options={visualFilterOptions}
+                                        />
+                                    )}
                                     <Typography.Text type="secondary">
-                                        Showing{" "}
-                                        {visible.length.toLocaleString()} of{" "}
-                                        {differences.length.toLocaleString()}
+                                        Showing {shown.length.toLocaleString()}{" "}
+                                        of {differences.length.toLocaleString()}
                                     </Typography.Text>
                                 </Space>
                             </div>
 
-                            {visible.map((entry) => (
-                                <DifferenceCard
-                                    key={anchorId(entry.viewId, entry.queryStr)}
-                                    suite={suite}
-                                    entry={entry}
-                                />
-                            ))}
+                            {cards}
                         </>
                     )}
                 </Spin>
@@ -247,7 +352,13 @@ export function SvgTesterSuitePage() {
 }
 
 /** What the run has found, or how far it has got if it is still going */
-function SuiteHeadline({ status }: { status: SvgTesterSuiteStatus }) {
+function SuiteHeadline({
+    status,
+    visual,
+}: {
+    status: SvgTesterSuiteStatus
+    visual: VisualSummary | undefined
+}) {
     const results = status.results
     const display = displayStatus(status)
 
@@ -257,6 +368,7 @@ function SuiteHeadline({ status }: { status: SvgTesterSuiteStatus }) {
                 <strong>{results.counts.differences.toLocaleString()}</strong>{" "}
                 of {results.counts.total.toLocaleString()} charts rendered
                 differently
+                <VisualHeadlineClause visual={visual} />
                 {results.counts.errors > 0 && (
                     <span className="SvgTesterSuitePage__errors">
                         {", "}
@@ -277,6 +389,46 @@ function SuiteHeadline({ status }: { status: SvgTesterSuiteStatus }) {
             {DISPLAY_STATUS_LABELS[display]} ·{" "}
             <strong>{progress.done.toLocaleString()}</strong> of{" "}
             {progress.total.toLocaleString()} charts checked
+        </>
+    )
+}
+
+/**
+ * How many of the flagged charts actually look different. Markup can change
+ * without moving a pixel, so this is the number that says how much there is to
+ * review.
+ */
+function VisualHeadlineClause({
+    visual,
+}: {
+    visual: VisualSummary | undefined
+}) {
+    if (!visual) return null
+
+    if (!visual.isComplete)
+        return (
+            <span className="SvgTesterSuitePage__visual-note">
+                {" · "}
+                {visual.remainingCount.toLocaleString()} left to check for
+                visible changes…
+            </span>
+        )
+
+    const changedCount = visual.total - visual.identicalCount
+
+    return (
+        <>
+            {" — "}
+            {!visual.identicalCount ? (
+                "all changed visibly"
+            ) : changedCount ? (
+                <>
+                    only <strong>{changedCount.toLocaleString()}</strong>{" "}
+                    changed visibly
+                </>
+            ) : (
+                "none changed visibly"
+            )}
         </>
     )
 }
@@ -425,9 +577,11 @@ function CommitLabel({
 function DifferenceCard({
     suite,
     entry,
+    visuallyIdentical,
 }: {
     suite: string
     entry: SvgTesterVerifyDifferenceEntry
+    visuallyIdentical: boolean | undefined
 }) {
     const [mode, setMode] = useState<ViewMode>("side-by-side")
     const beforeUrl = svgUrl(suite, "references", entry)
@@ -460,6 +614,11 @@ function DifferenceCard({
                     {entry.chartType && (
                         <Tag className="SvgTesterSuitePage__chart-type">
                             {entry.chartType}
+                        </Tag>
+                    )}
+                    {visuallyIdentical && (
+                        <Tag className="SvgTesterSuitePage__chart-type">
+                            No visible change
                         </Tag>
                     )}
                 </span>
@@ -758,6 +917,70 @@ function pageTitle(
     if (display === "differences")
         return `${base} (${data.results!.counts.differences.toLocaleString()} differences)`
     return `${base} (${DISPLAY_STATUS_LABELS[display].toLowerCase()})`
+}
+
+/** Checks every difference for a real visual change */
+function useVisualDiffs(
+    suite: string | undefined,
+    differences: SvgTesterVerifyDifferenceEntry[],
+    runKey: string | undefined
+): {
+    identicalBySvg: Record<string, boolean> | undefined
+    remainingCount: number
+} {
+    const [identicalBySvg, setIdenticalBySvg] =
+        useState<Record<string, boolean>>()
+    const [checkedCount, setCheckedCount] = useState(0)
+
+    useEffect(() => {
+        setIdenticalBySvg(undefined)
+        setCheckedCount(0)
+        if (!suite || !runKey || !differences.length) return
+
+        // Leaving the suite abandons whatever has not started: those answers are
+        // for a report nobody is looking at any more.
+        const abandon = new AbortController()
+        const identical: Record<string, boolean> = {}
+        let checked = 0
+        // Thousands of answers, and only the countdown shows them arriving
+        const publishProgress = _.throttle(
+            () => setCheckedCount(checked),
+            VISUAL_DIFF_PROGRESS_MS,
+            { leading: false }
+        )
+
+        void pMap(
+            differences,
+            async (entry) => {
+                identical[entry.svgFilename] = await compareSvgsVisually(
+                    svgUrl(suite, "references", entry),
+                    svgUrl(suite, "differences", entry),
+                    runKey
+                )
+                checked++
+                publishProgress()
+            },
+            { concurrency: VISUAL_DIFF_CONCURRENCY, signal: abandon.signal }
+        ).then(
+            () => {
+                publishProgress.cancel()
+                setIdenticalBySvg(identical)
+            },
+            () => {
+                // Abandoned, so there is nothing to report
+            }
+        )
+
+        return () => {
+            publishProgress.cancel()
+            abandon.abort()
+        }
+    }, [suite, runKey, differences])
+
+    return {
+        identicalBySvg,
+        remainingCount: differences.length - checkedCount,
+    }
 }
 
 function svgUrl(

--- a/adminSiteClient/svgVisualDiff.test.ts
+++ b/adminSiteClient/svgVisualDiff.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import {
+    createVisualDiffChecker,
+    LoadPixels,
+    RasterizedSvg,
+} from "./svgVisualDiff.js"
+
+function pixels(width: number, height: number, fill = 0): RasterizedSvg {
+    return {
+        width,
+        height,
+        data: new Uint8ClampedArray(width * height * 4).fill(fill),
+    }
+}
+
+interface PendingLoad {
+    url: string
+    resolve: (svg: RasterizedSvg) => void
+}
+
+/** Lets a test decide when each SVG finishes rasterizing */
+function deferredLoader(): { pending: PendingLoad[]; loadPixels: LoadPixels } {
+    const pending: PendingLoad[] = []
+    return {
+        pending,
+        loadPixels: (url) =>
+            new Promise<RasterizedSvg>((resolve) =>
+                pending.push({ url, resolve })
+            ),
+    }
+}
+
+/** Comparing waits for an idle moment before it walks the buffers */
+async function runIdleWork(): Promise<void> {
+    await vi.advanceTimersByTimeAsync(1)
+}
+
+describe("the visual diff checker", () => {
+    beforeEach(() => vi.useFakeTimers())
+    afterEach(() => vi.useRealTimers())
+
+    it("reports a pair whose pixels match as identical", async () => {
+        const checker = createVisualDiffChecker(() =>
+            Promise.resolve(pixels(2, 2, 7))
+        )
+
+        const result = checker.compare("before.svg", "after.svg", "run-1")
+        await runIdleWork()
+        await expect(result).resolves.toBe(true)
+    })
+
+    it("reports a pair whose pixels differ as different", async () => {
+        const checker = createVisualDiffChecker((url) =>
+            Promise.resolve(pixels(2, 2, url.startsWith("before") ? 7 : 9))
+        )
+
+        const result = checker.compare("before.svg", "after.svg", "run-1")
+        await runIdleWork()
+        await expect(result).resolves.toBe(false)
+    })
+
+    it("reports a pair as different when the chart changed size", async () => {
+        const checker = createVisualDiffChecker((url) =>
+            Promise.resolve(
+                url.startsWith("before") ? pixels(2, 2) : pixels(4, 4)
+            )
+        )
+
+        await expect(
+            checker.compare("before.svg", "after.svg", "run-1")
+        ).resolves.toBe(false)
+    })
+
+    it("reports a pair as different when an SVG cannot be rasterized", async () => {
+        const checker = createVisualDiffChecker(() =>
+            Promise.resolve(undefined)
+        )
+
+        await expect(
+            checker.compare("before.svg", "after.svg", "run-1")
+        ).resolves.toBe(false)
+    })
+
+    it("reuses the answer for a pair it has already compared", async () => {
+        let loads = 0
+        const checker = createVisualDiffChecker(() => {
+            loads++
+            return Promise.resolve(pixels(2, 2))
+        })
+
+        const first = checker.compare("before.svg", "after.svg", "run-1")
+        await runIdleWork()
+        await expect(first).resolves.toBe(true)
+        expect(loads).toBe(2)
+
+        await expect(
+            checker.compare("before.svg", "after.svg", "run-1")
+        ).resolves.toBe(true)
+        expect(loads).toBe(2)
+    })
+
+    it("recompares when a new run has rewritten the same filenames", async () => {
+        let loads = 0
+        const checker = createVisualDiffChecker(() => {
+            loads++
+            return Promise.resolve(pixels(2, 2))
+        })
+
+        void checker.compare("before.svg", "after.svg", "run-1")
+        void checker.compare("before.svg", "after.svg", "run-2")
+        await runIdleWork()
+
+        expect(loads).toBe(4)
+    })
+
+    it("gives up on a pair that never comes back", async () => {
+        const { loadPixels } = deferredLoader()
+        const checker = createVisualDiffChecker(loadPixels)
+
+        const timedOut = checker.compare("before.svg", "after.svg", "run-1")
+        await vi.advanceTimersByTimeAsync(20_000)
+        await expect(timedOut).resolves.toBe(false)
+    })
+
+    it("does not remember a pair that timed out as changed", async () => {
+        const { pending, loadPixels } = deferredLoader()
+        const checker = createVisualDiffChecker(loadPixels)
+
+        const timedOut = checker.compare("before.svg", "after.svg", "run-1")
+        await vi.advanceTimersByTimeAsync(20_000)
+        await expect(timedOut).resolves.toBe(false)
+
+        // Asked again it has to do the work, rather than repeat a non-answer
+        pending.length = 0
+        const retried = checker.compare("before.svg", "after.svg", "run-1")
+        await runIdleWork()
+        expect(pending).toHaveLength(2)
+        pending.forEach(({ resolve }) => resolve(pixels(2, 2)))
+        await runIdleWork()
+        await expect(retried).resolves.toBe(true)
+    })
+
+    it("forgets the answers for runs nobody is looking at any more", async () => {
+        let loads = 0
+        const checker = createVisualDiffChecker(() => {
+            loads++
+            return Promise.resolve(pixels(2, 2))
+        })
+
+        const first = checker.compare("before.svg", "after.svg", "run-1")
+        await runIdleWork()
+        await expect(first).resolves.toBe(true)
+        expect(loads).toBe(2)
+
+        // Four more runs push run-1 out of the cache, so it is checked again
+        for (const run of ["run-2", "run-3", "run-4", "run-5"]) {
+            void checker.compare("before.svg", "after.svg", run)
+            await runIdleWork()
+        }
+        void checker.compare("before.svg", "after.svg", "run-1")
+        await runIdleWork()
+        expect(loads).toBe(12)
+    })
+})

--- a/adminSiteClient/svgVisualDiff.test.ts
+++ b/adminSiteClient/svgVisualDiff.test.ts
@@ -15,6 +15,7 @@ function pixels(width: number, height: number, fill = 0): RasterizedSvg {
 
 interface PendingLoad {
     url: string
+    abandoned?: AbortSignal
     resolve: (svg: RasterizedSvg) => void
 }
 
@@ -23,9 +24,9 @@ function deferredLoader(): { pending: PendingLoad[]; loadPixels: LoadPixels } {
     const pending: PendingLoad[] = []
     return {
         pending,
-        loadPixels: (url) =>
+        loadPixels: (url, abandoned) =>
             new Promise<RasterizedSvg>((resolve) =>
-                pending.push({ url, resolve })
+                pending.push({ url, abandoned, resolve })
             ),
     }
 }
@@ -79,6 +80,40 @@ describe("the visual diff checker", () => {
         await expect(
             checker.compare("before.svg", "after.svg", "run-1")
         ).resolves.toBe(false)
+    })
+
+    it("does not remember a pair it could not rasterize as changed", async () => {
+        let attempts = 0
+        // Fails once, the way a transient error would, then works
+        const checker = createVisualDiffChecker(() =>
+            Promise.resolve(attempts++ < 2 ? undefined : pixels(2, 2))
+        )
+
+        await expect(
+            checker.compare("before.svg", "after.svg", "run-1")
+        ).resolves.toBe(false)
+
+        const retried = checker.compare("before.svg", "after.svg", "run-1")
+        await runIdleWork()
+        await expect(retried).resolves.toBe(true)
+    })
+
+    it("stops the work behind a pair it has given up on", async () => {
+        const { pending, loadPixels } = deferredLoader()
+        const checker = createVisualDiffChecker(loadPixels)
+
+        const timedOut = checker.compare("before.svg", "after.svg", "run-1")
+        expect(pending.map(({ abandoned }) => abandoned?.aborted)).toEqual([
+            false,
+            false,
+        ])
+
+        await vi.advanceTimersByTimeAsync(20_000)
+        await expect(timedOut).resolves.toBe(false)
+        expect(pending.map(({ abandoned }) => abandoned?.aborted)).toEqual([
+            true,
+            true,
+        ])
     })
 
     it("reuses the answer for a pair it has already compared", async () => {

--- a/adminSiteClient/svgVisualDiff.ts
+++ b/adminSiteClient/svgVisualDiff.ts
@@ -1,0 +1,215 @@
+/**
+ * Whether two SVGs paint the same pixels.
+ *
+ * The pipeline compares markup, which is the right call for a pass/fail gate but
+ * flags charts that paint identically all the same — reordered attributes,
+ * generated ids, an empty group. This is what tells those apart, so the report
+ * can set them aside.
+ */
+
+/**
+ * How many pairs to work on at once. Each holds two pixel buffers of a couple of
+ * megabytes, so this is a memory bound; it is also a throughput one, since each
+ * pair spends most of its life waiting to be handed control back.
+ */
+export const VISUAL_DIFF_CONCURRENCY = 8
+
+/**
+ * When to give up on a single pair. A decode that never settles would otherwise
+ * hold its place forever and stall everything behind it.
+ */
+const COMPARISON_TIMEOUT_MS = 20_000
+
+/**
+ * How many runs' worth of answers to keep. Revisiting the suite you just left is
+ * then free, without holding every answer for every run the tab has ever shown.
+ */
+const MAX_CACHED_RUNS = 4
+
+/** An SVG's pixels, ready to compare */
+export interface RasterizedSvg {
+    width: number
+    height: number
+    data: Uint8ClampedArray
+}
+
+export type LoadPixels = (url: string) => Promise<RasterizedSvg | undefined>
+
+export function createVisualDiffChecker(loadPixels: LoadPixels): {
+    /**
+     * Whether the two SVGs paint the same pixels. Never rejects, and never
+     * hangs: a pair that can't be answered for resolves false, which leaves the
+     * chart in plain view. `runKey` scopes the cache, since the next run serves
+     * different files from the same URLs.
+     */
+    compare: (
+        beforeUrl: string,
+        afterUrl: string,
+        runKey: string
+    ) => Promise<boolean>
+} {
+    const cachesByRun = new Map<string, Map<string, Promise<boolean>>>()
+
+    function cacheFor(runKey: string): Map<string, Promise<boolean>> {
+        const existing = cachesByRun.get(runKey)
+        if (existing) return existing
+
+        const cache = new Map<string, Promise<boolean>>()
+        cachesByRun.set(runKey, cache)
+        // Insertion-ordered, so this drops the runs left longest ago
+        for (const stale of [...cachesByRun.keys()].slice(0, -MAX_CACHED_RUNS))
+            cachesByRun.delete(stale)
+        return cache
+    }
+
+    async function compareNow(
+        beforeUrl: string,
+        afterUrl: string
+    ): Promise<boolean> {
+        const [before, after] = await Promise.all([
+            loadPixels(beforeUrl),
+            loadPixels(afterUrl),
+        ])
+        if (!before || !after) return false
+        // A chart that changed size has visibly changed
+        if (before.width !== after.width || before.height !== after.height)
+            return false
+        // Comparing a few million bytes is the one long stretch left, so let
+        // anything the user is doing go first
+        await yieldToPage()
+        return pixelsEqual(before.data, after.data)
+    }
+
+    function compare(
+        beforeUrl: string,
+        afterUrl: string,
+        runKey: string
+    ): Promise<boolean> {
+        const cache = cacheFor(runKey)
+        const key = `${beforeUrl}\n${afterUrl}`
+
+        const cached = cache.get(key)
+        // Caching the promise rather than the answer also collapses duplicate
+        // requests for a pair that is still being compared
+        if (cached) return cached
+
+        const result = withTimeout(compareNow(beforeUrl, afterUrl))
+            .then((outcome) => {
+                if (outcome !== "timeout") return outcome
+                // Forgotten rather than remembered as changed: never hold a pair
+                // to an answer that never arrived
+                cache.delete(key)
+                return false
+            })
+            .catch(() => false)
+        cache.set(key, result)
+        return result
+    }
+
+    return { compare }
+}
+
+function pixelsEqual(a: Uint8ClampedArray, b: Uint8ClampedArray): boolean {
+    if (a.length !== b.length) return false
+    for (let i = 0; i < a.length; i++) {
+        if (a[i] !== b[i]) return false
+    }
+    return true
+}
+
+/** Reports a comparison that never came back, rather than never resolving */
+function withTimeout(
+    comparison: Promise<boolean>
+): Promise<boolean | "timeout"> {
+    return new Promise<boolean | "timeout">((resolve) => {
+        const timer = setTimeout(
+            () => resolve("timeout"),
+            COMPARISON_TIMEOUT_MS
+        )
+        void comparison.then(
+            (identical) => {
+                clearTimeout(timer)
+                resolve(identical)
+            },
+            () => {
+                clearTimeout(timer)
+                resolve(false)
+            }
+        )
+    })
+}
+
+/**
+ * Hands control back between pieces of work.
+ *
+ * With the tab in front that means waiting for an idle moment, so checking a big
+ * suite doesn't make the report sluggish. With it behind, idle callbacks stop
+ * firing altogether and timers are throttled to about once a minute, which would
+ * stall the check — so it hands back through a message channel instead, which is
+ * not throttled. There is nobody interacting to yield to in that case anyway.
+ */
+function yieldToPage(): Promise<void> {
+    if (typeof document !== "undefined" && document.hidden)
+        return nextMacrotask()
+    return new Promise((resolve) => {
+        if (typeof requestIdleCallback === "function")
+            requestIdleCallback(() => resolve())
+        else setTimeout(resolve, 0)
+    })
+}
+
+let channel: MessageChannel | undefined
+const macrotaskWaiting: (() => void)[] = []
+
+/** One shared channel: a fresh one per yield would be tens of thousands of them */
+function nextMacrotask(): Promise<void> {
+    if (typeof MessageChannel === "undefined")
+        return new Promise((resolve) => setTimeout(resolve, 0))
+    return new Promise((resolve) => {
+        if (!channel) {
+            channel = new MessageChannel()
+            channel.port1.onmessage = () => macrotaskWaiting.shift()?.()
+        }
+        macrotaskWaiting.push(resolve)
+        channel.port2.postMessage(undefined)
+    })
+}
+
+/** Draws an SVG to a canvas and reads its pixels back */
+async function loadPixelsFromDom(
+    url: string
+): Promise<RasterizedSvg | undefined> {
+    try {
+        const image = new Image()
+        image.src = url
+        // Yields on its own, and doesn't block while it decodes
+        await image.decode()
+
+        const { naturalWidth: width, naturalHeight: height } = image
+        if (!width || !height) return undefined
+
+        const canvas = document.createElement("canvas")
+        canvas.width = width
+        canvas.height = height
+        const ctx = canvas.getContext("2d", { willReadFrequently: true })
+        if (!ctx) return undefined
+
+        // Drawing is where the SVG actually gets rasterized, so yield first
+        await yieldToPage()
+        ctx.drawImage(image, 0, 0)
+        return {
+            width,
+            height,
+            data: ctx.getImageData(0, 0, width, height).data,
+        }
+    } catch (error) {
+        // Logged rather than swallowed, so a check that is failing can't pass
+        // for one that found nothing
+        console.warn("[svg visual diff] could not rasterize", url, error)
+        return undefined
+    }
+}
+
+/** Whether the two SVGs paint the same pixels */
+export const { compare: compareSvgsVisually } =
+    createVisualDiffChecker(loadPixelsFromDom)

--- a/adminSiteClient/svgVisualDiff.ts
+++ b/adminSiteClient/svgVisualDiff.ts
@@ -33,7 +33,18 @@ export interface RasterizedSvg {
     data: Uint8ClampedArray
 }
 
-export type LoadPixels = (url: string) => Promise<RasterizedSvg | undefined>
+export type LoadPixels = (
+    url: string,
+    abandoned?: AbortSignal
+) => Promise<RasterizedSvg | undefined>
+
+/**
+ * A pair nothing could be said about — it failed, or it never came back. Kept
+ * apart from "changed" so it can be shown as one without being remembered as
+ * one.
+ */
+const UNANSWERED = "unanswered"
+type Outcome = boolean | typeof UNANSWERED
 
 export function createVisualDiffChecker(loadPixels: LoadPixels): {
     /**
@@ -64,19 +75,21 @@ export function createVisualDiffChecker(loadPixels: LoadPixels): {
 
     async function compareNow(
         beforeUrl: string,
-        afterUrl: string
-    ): Promise<boolean> {
+        afterUrl: string,
+        abandoned: AbortSignal
+    ): Promise<Outcome> {
         const [before, after] = await Promise.all([
-            loadPixels(beforeUrl),
-            loadPixels(afterUrl),
+            loadPixels(beforeUrl, abandoned),
+            loadPixels(afterUrl, abandoned),
         ])
-        if (!before || !after) return false
+        if (!before || !after) return UNANSWERED
         // A chart that changed size has visibly changed
         if (before.width !== after.width || before.height !== after.height)
             return false
         // Comparing a few million bytes is the one long stretch left, so let
         // anything the user is doing go first
         await yieldToPage()
+        if (abandoned.aborted) return UNANSWERED
         return pixelsEqual(before.data, after.data)
     }
 
@@ -93,15 +106,19 @@ export function createVisualDiffChecker(loadPixels: LoadPixels): {
         // requests for a pair that is still being compared
         if (cached) return cached
 
-        const result = withTimeout(compareNow(beforeUrl, afterUrl))
-            .then((outcome) => {
-                if (outcome !== "timeout") return outcome
-                // Forgotten rather than remembered as changed: never hold a pair
-                // to an answer that never arrived
-                cache.delete(key)
-                return false
-            })
-            .catch(() => false)
+        // Giving up on a pair stops the work behind it too, so a decode that
+        // stalled doesn't carry on rasterizing once its slot has moved on
+        const giveUp = new AbortController()
+        const result = withTimeout(
+            compareNow(beforeUrl, afterUrl, giveUp.signal),
+            () => giveUp.abort()
+        ).then((outcome) => {
+            if (outcome !== UNANSWERED) return outcome
+            // Forgotten rather than remembered as changed: never hold a pair to
+            // an answer that never arrived
+            cache.delete(key)
+            return false
+        })
         cache.set(key, result)
         return result
     }
@@ -119,21 +136,22 @@ function pixelsEqual(a: Uint8ClampedArray, b: Uint8ClampedArray): boolean {
 
 /** Reports a comparison that never came back, rather than never resolving */
 function withTimeout(
-    comparison: Promise<boolean>
-): Promise<boolean | "timeout"> {
-    return new Promise<boolean | "timeout">((resolve) => {
-        const timer = setTimeout(
-            () => resolve("timeout"),
-            COMPARISON_TIMEOUT_MS
-        )
+    comparison: Promise<Outcome>,
+    onTimeout: () => void
+): Promise<Outcome> {
+    return new Promise<Outcome>((resolve) => {
+        const timer = setTimeout(() => {
+            onTimeout()
+            resolve(UNANSWERED)
+        }, COMPARISON_TIMEOUT_MS)
         void comparison.then(
-            (identical) => {
+            (outcome) => {
                 clearTimeout(timer)
-                resolve(identical)
+                resolve(outcome)
             },
             () => {
                 clearTimeout(timer)
-                resolve(false)
+                resolve(UNANSWERED)
             }
         )
     })
@@ -177,13 +195,15 @@ function nextMacrotask(): Promise<void> {
 
 /** Draws an SVG to a canvas and reads its pixels back */
 async function loadPixelsFromDom(
-    url: string
+    url: string,
+    abandoned?: AbortSignal
 ): Promise<RasterizedSvg | undefined> {
     try {
         const image = new Image()
         image.src = url
         // Yields on its own, and doesn't block while it decodes
         await image.decode()
+        if (abandoned?.aborted) return undefined
 
         const { naturalWidth: width, naturalHeight: height } = image
         if (!width || !height) return undefined
@@ -194,8 +214,10 @@ async function loadPixelsFromDom(
         const ctx = canvas.getContext("2d", { willReadFrequently: true })
         if (!ctx) return undefined
 
-        // Drawing is where the SVG actually gets rasterized, so yield first
+        // Drawing is where the SVG actually gets rasterized, so yield first —
+        // and check afterwards, since this is the expensive part to skip
         await yieldToPage()
+        if (abandoned?.aborted) return undefined
         ctx.drawImage(image, 0, 0)
         return {
             width,


### PR DESCRIPTION
> _Written by Claude Sonnet 5 — @sophiamersmann at the wheel._

The svgtest pipeline compares SVG markup. That is the right call for a pass/fail gate, but it flags plenty of charts whose markup changed without moving a pixel — reordered attributes, generated ids, an empty group. On the `graphers` suite that can mean thousands of cards to eyeball for nothing.

The report page now rasterizes each before/after pair to a canvas, compares the pixels, and splits the list into **Visible change** / **No visible change**, so only the first group needs reviewing. The headline reports the split, and cards that render identically are tagged.

Worth knowing:

- **It runs on the main thread.** A worker is the obvious home, but no browser will rasterize an SVG in one: Firefox refuses SVG sources outright, and Chrome stalls on the fonts these charts are full of. So it yields between pairs instead — `requestIdleCallback` when the tab is in front, a `MessageChannel` when it is behind (not throttled, so the check keeps going in the background).
- **A check that fails or times out counts as "changed", and is never cached.** Being unable to check is never allowed to look like a finding. If you ever see "all of them changed visibly", suspect the check rather than the charts and have a look at the console.
- **This is per-viewer, per-visit work** — a few minutes of rasterizing on a big suite. The deeper fix is for the pipeline to decide it once: it already has both files on disk and `sharp` is already a dependency. Worth doing if the waiting starts to grate.
- **Entries are deduplicated to work around a pipeline defect** (diagnosed below, deliberately not fixed here). Because of it, the headline's total — which comes from the run's own counts — can read 2 higher than the filter's "All" on `grapher-views`.

<details><summary>Details</summary>

### How it works

`adminSiteClient/svgVisualDiff.ts` — `loadPixelsFromDom` draws an SVG into a canvas via `<img>` + `img.decode()` and reads the pixels back; `compareNow` early-outs when the two differ in size (so neither gets rasterized), otherwise walks the two buffers. `createVisualDiffChecker(loadPixels)` takes the loader as a parameter purely so the tests can run without a browser.

- **Concurrency** is `pMap(..., { concurrency: 8 })` in the hook. Each pair holds two pixel buffers of ~2 MB, so the bound caps peak memory (~32 MB) as well as throughput.
- **Abandonment** is an `AbortController` tied to the effect cleanup, so navigating to another suite drops whatever has not started rather than making the suite you are now looking at queue behind ~4,000 pairs of dead work. The eight pairs in flight do finish — that is the bound, not a leak.
- **Caching** is per run (`startedAt`), since the next run serves different files from the same URLs, and bounded to the last 4 runs so a long admin session does not accumulate them.
- **Non-answers** — a pair that failed to rasterize, timed out (20 s), or threw — share one `UNANSWERED` outcome. It resolves as "changed", so the chart stays in plain view, but is evicted from the cache, so the next visit does the work again rather than repeating a non-answer.
- **Giving up cancels.** Each pair carries its own `AbortController`, fired by the timeout, that the loader and the buffer walk check between async steps. Without it a stalled decode kept rasterizing after `pMap` had handed its slot to the next pair, so repeated timeouts could put far more than eight pixel buffers in flight. A `decode()` that never settles at all is still not interrupted — the checkpoints only bite between steps — which is left as is.
- Failures are `console.warn`ed rather than swallowed.

### Why it does not apply results progressively

Answers are held back until every pair is done. Publishing them as they arrive pulled cards out of the list — or reordered them, in the "All" view — every few hundred milliseconds, which made the page jump while you were reading it. Only the countdown updates during the check, throttled to 250 ms. Completion is tracked explicitly (`identicalBySvg !== undefined`) rather than inferred from a count reaching a total, which is brittle if any entry fails to record one.

The check only starts once the run has reported: mid-run the pipeline is still rewriting the very files this reads.

### The duplicate-entry defect this works around

`grapher-views` reports 1,058 differences but only 1,056 unique files. The view generator emits a `focus=<none>` and a `focus=<firstSeries>` variant per view. In `resolveFocusPlaceholderInQueryString` (`devTools/svgTester/utils.ts`), `<none>` deletes the focus param — and `<firstSeries>` falls into the *same* branch and deletes it too whenever `series[0]?.seriesName` is missing, which happens for e.g. a Dumbbell chart at a single time point. Both variants then share a `resolvedQueryStr`, and since the output filename hashes the resolved query string, both render to the same file: the same chart rendered twice, written twice, and counted twice.

Two byte-identical rows gave two `DifferenceCard`s the same React key, which broke the filter after one switch. Hence `_.uniqBy(..., entry => entry.svgFilename)`. The upstream fix — skipping the `<firstSeries>` variant when the placeholder cannot resolve — is left for a follow-up; the dedup should go when that lands.

### Performance notes

- `useMemo` on `differences` keys off `results.differences`, not `results`. Polling replaces the results object every few seconds even when nothing changed; react-query's structural sharing keeps the nested array stable, so this avoids rebuilding all ~4,300 cards on every poll. Same fix applied to the pre-existing `scrollIntoView` effect.
- The rendered card list is memoized so a countdown tick does not re-create thousands of elements.
- `content-visibility: auto` on the cards lets the browser skip layout and paint for off-screen ones — a progressive enhancement (Chrome 85+, Firefox 125+, Safari 18+) that simply does nothing where unsupported.

### UI

The filter is antd `Segmented`, with `.ant-segmented-item { margin-bottom: 0 }` to undo the bootstrap reboot the admin imports — same approach as `adminSiteClient/slideshows/SlideshowAdmin.scss`. It is hidden when every chart falls on one side of the check, since there is then nothing to filter, and the headline says so instead. The filter is component state rather than a URL param: which charts render identically is only known once the session has checked them, so a shared link would land on an empty list.

### Test plan

- `yarn test run adminSiteClient/svgVisualDiff.test.ts` — 11 tests over the checker: identical/differing pixels, size change, unrasterizable SVG, cache reuse, per-run cache busting, timeout behaviour, neither a timeout nor a failed rasterization cached, giving up aborting the work behind it, and cache eviction.
- `yarn typecheck`, `yarn testLintChanged`, `yarn testFormatChanged`, `yarn buildViteAdmin` all clean.
- Exercised by hand on `graphers` and `grapher-views` in both Chrome and Firefox, including switching suites mid-check and backgrounding the tab — but note that predates the final cleanup pass, which replaced the hand-rolled concurrency limiter with `pMap`, the cancellation with an `AbortController`, and the hand-built filter with antd `Segmented`. Those are covered by unit tests and the build, not by a fresh manual run, so they deserve a click-through when reviewing.
- No `make svgtest` run; this changes only how existing results are presented.

</details>
