### PR TITLE
✨🤖 colour the swipe view halves in the SVG tester

### DIFF
--- a/adminSiteClient/SvgTesterSuitePage.scss
+++ b/adminSiteClient/SvgTesterSuitePage.scss
@@ -358,10 +358,37 @@ $svg-tester-error-frame: #dda4a0;
 }
 
 .SvgTesterSlider__images {
-    border: 1px solid $gray-10;
     cursor: ew-resize;
     line-height: 0;
     position: relative;
+}
+
+// Frame each side of the divider in the reference/current colours, so it's
+// obvious which rendering you're looking at
+.SvgTesterSlider__images::before,
+.SvgTesterSlider__images::after {
+    border: 2px solid;
+    bottom: 0;
+    content: "";
+    pointer-events: none;
+    position: absolute;
+    top: 0;
+    z-index: 1;
+}
+
+// No border where the two halves meet: that's the handle's line
+.SvgTesterSlider__images::before {
+    border-color: $svg-tester-reference-frame;
+    border-right: 0;
+    left: 0;
+    right: calc(100% - var(--position));
+}
+
+.SvgTesterSlider__images::after {
+    border-color: $svg-tester-current-frame;
+    border-left: 0;
+    left: var(--position);
+    right: 0;
 }
 
 .SvgTesterSlider__images img {


### PR DESCRIPTION
> _Written by Claude Opus 5 — @sophiamersmann at the wheel._

The swipe view in the SVG tester results gave no hint which side of the divider was the reference and which was the current build. Each half now gets a coloured frame — red for the reference, green for the current — reusing the same colours as the side-by-side captions.

<details><summary>Details</summary>

- `adminSiteClient/SvgTesterSuitePage.scss`: replaced the neutral 1px frame on `.SvgTesterSlider__images` with two absolutely positioned pseudo-element frames keyed off the existing `--position` custom property (`::before` spans 0 → position, `::after` spans position → 100%), coloured with the existing `$svg-tester-reference-frame` / `$svg-tester-current-frame` variables.
- Each frame drops its border on the side that meets the divider, so the divider stays the plain gray handle rather than a red/green stripe.
- `z-index: 1` and `pointer-events: none` keep the frames below the range input (`z-index: 2`) and handle (`z-index: 3`), so dragging is unaffected.
- No JS/TSX change: the frames follow the `--position` variable the component already sets.

</details>
