### PR TITLE
✨ (all-charts) suggest searches from the OWID vocabulary

### DIFF
--- a/functions/api/search/searchApi.integration.test.ts
+++ b/functions/api/search/searchApi.integration.test.ts
@@ -108,6 +108,27 @@ describe("searchCharts with real Algolia", () => {
         ).rejects.toThrow(/does not exist. Available topics:/)
     })
 
+    it("does not claim a valid topic doesn't exist just because the search found nothing", async () => {
+        // The topic list this validation consults comes from a facet query, and
+        // Algolia caps facet values at 100 unless asked for more, while the
+        // index carries ~140 topic tags. "Polio" is a real topic that falls
+        // outside the 100 commonest, so before maxValuesPerFacet was set this
+        // rejected it as nonexistent whenever a query returned nothing.
+        const result = await searchCharts(
+            algoliaConfig,
+            {
+                query: "zzzzqqqqnotarealquery",
+                filters: [{ type: FilterType.TOPIC, name: "Polio" }],
+                requireAllCountries: false,
+            },
+            0,
+            5
+        )
+
+        expect(result.nbHits).toBe(0)
+        expect(result.results).toEqual([])
+    })
+
     it("handles pagination", async () => {
         const page0 = await searchCharts(
             algoliaConfig,

--- a/functions/api/search/searchApi.ts
+++ b/functions/api/search/searchApi.ts
@@ -11,6 +11,7 @@ import {
     getFilterNamesOfType,
     buildChartsFacetFilters,
     searchSingleForHitsWithClosestMatches,
+    MAX_FACET_VALUES,
 } from "@ourworldindata/utils"
 import {
     getIndexName,
@@ -128,6 +129,15 @@ async function getAvailableTopics(config: AlgoliaConfig): Promise<string[]> {
                 query: "",
                 hitsPerPage: 0,
                 facets: ["tags"],
+                // Algolia returns at most 100 values per facet unless asked for
+                // more, and the index carries appreciably more topic tags than
+                // that. Left at the default, this listed the 100 commonest and
+                // silently dropped the rest, so a perfectly valid but less-used
+                // topic — Books, Gender Ratio, Nuclear Energy, Tetanus — was
+                // reported to callers as a topic that does not exist (see
+                // searchCharts, which only consults this list when a search
+                // comes back empty). The cap is Algolia's documented maximum.
+                maxValuesPerFacet: MAX_FACET_VALUES,
             },
         ],
     })

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -401,6 +401,7 @@ export {
     formatCountryFacetFilters,
     formatTopicFacetFilters,
     buildChartsFacetFilters,
+    MAX_FACET_VALUES,
 } from "./search/searchFacetFilters.js"
 
 export {

--- a/packages/@ourworldindata/utils/src/search/searchFacetFilters.ts
+++ b/packages/@ourworldindata/utils/src/search/searchFacetFilters.ts
@@ -1,5 +1,14 @@
 import { Filter, FilterType, SearchFacetFilters } from "@ourworldindata/types"
 
+/**
+ * What to pass as `maxValuesPerFacet` when a search needs the *complete* list of
+ * a facet's values rather than a sample. Algolia caps facet values at 100 unless
+ * asked for more, which silently truncates any facet with more values than that
+ * — our `tags` facet among them — and a truncated list reads as "these topics
+ * have no content". 1000 is Algolia's documented maximum.
+ */
+export const MAX_FACET_VALUES = 1000
+
 // Shared between the site's client-side Algolia queries (site/search/queries.ts)
 // and the public /api/search Cloudflare function (functions/api/search/searchApi.ts)
 // so that identical filters produce identical Algolia requests in both places.

--- a/settings/clientSettings.ts
+++ b/settings/clientSettings.ts
@@ -59,6 +59,22 @@ export const DATA_API_URL: string =
 export const CATALOG_URL: string =
     process.env.CATALOG_URL ?? "https://catalog.ourworldindata.org"
 
+// The OWID topic vocabulary: per-topic search terms, used for the suggested
+// searches in the all-charts block. It lives in the `owid-public` R2 bucket and
+// is served through files.ourworldindata.org, whose worker adds CORS and a
+// 5-minute edge cache (see the owid-public worker in the cloudflare-workers
+// repo), so the browser can read it directly.
+export const DEFAULT_TOPIC_VOCABULARY_URL =
+    "https://files.ourworldindata.org/topic_vocabulary.json"
+
+// Point this at a different key in that bucket to try a freshly generated
+// vocabulary on a staging server without overwriting the production one, e.g.
+// TOPIC_VOCABULARY_URL=https://files.ourworldindata.org/topic_vocabulary/my-branch.json
+// If that key isn't there, suggestions fall back to the production vocabulary
+// rather than disappearing.
+export const TOPIC_VOCABULARY_URL: string =
+    process.env.TOPIC_VOCABULARY_URL ?? DEFAULT_TOPIC_VOCABULARY_URL
+
 export const ALGOLIA_ID: string = process.env.ALGOLIA_ID ?? ""
 export const ALGOLIA_SEARCH_KEY: string = process.env.ALGOLIA_SEARCH_KEY ?? ""
 export const ALGOLIA_INDEX_PREFIX: string =

--- a/site/AllChartsBlock.test.ts
+++ b/site/AllChartsBlock.test.ts
@@ -1,225 +1,33 @@
 import { expect, it, describe } from "vitest"
-import { SearchChartHit } from "@ourworldindata/types"
 import {
     indexTopicVocabularyByName,
-    rankSuggestedKeywords,
-    type TopicVocabularyEntry,
+    suggestedKeywords,
 } from "./search/topicVocabulary.js"
 
-const makeHits = (...texts: string[]): SearchChartHit[] =>
-    texts.map((title) => ({ title }) as SearchChartHit)
-
-// A vocabulary entry the generator did not check against the search API, so the
-// ranking has to work its own coverage out. See `refined` entries at the bottom.
-const unrefined = (...keywords: string[]): TopicVocabularyEntry => ({
-    keywords,
-    refined: false,
-})
-
-describe(rankSuggestedKeywords, () => {
-    const hits = makeHits(
-        "Share of women in parliament",
-        "Women in managerial positions",
-        "Sex ratio at birth"
-    )
-
-    it("puts the terms describing more of the topic's charts first", () => {
-        expect(
-            rankSuggestedKeywords(unrefined("Sex ratio", "Women"), hits)
-        ).toEqual(["Women", "Sex ratio"])
-    })
-
-    it("keeps the vocabulary's order between terms describing equally many charts", () => {
-        expect(
-            rankSuggestedKeywords(unrefined("Sex ratio", "Parliament"), hits)
-        ).toEqual(["Sex ratio", "Parliament"])
-    })
-
-    it("drops a term no chart on the page matches, rather than offering a chip that empties the list", () => {
-        // Clicking a chip searches, and the block then keeps only the rows whose
-        // own text contains the query — so a term nothing on the page matches is
-        // a dead end whatever Algolia would have returned. 25 of the 620 terms
-        // the production vocabulary has been showing behave this way.
-        expect(
-            rankSuggestedKeywords(unrefined("Missing women", "Sex ratio"), hits)
-        ).toEqual(["Sex ratio"])
-    })
-
-    it("counts whole words, not substrings, so a short term isn't credited with charts it can't reach", () => {
-        // "Men" occurs inside "Women" and "employment"; searching for it
-        // returns neither, so it must not outrank a term that does reach them.
-        const menHits = makeHits(
-            "Women in employment",
-            "Women in parliament",
-            "Men and women in unpaid care work"
-        )
-        expect(
-            rankSuggestedKeywords(unrefined("Men", "Women"), menHits)
-        ).toEqual(["Women", "Men"])
-    })
-
-    it("offers at most five terms", () => {
-        const keywords = [
-            "Women",
-            "Sex ratio",
-            "Parliament",
-            "Managerial positions",
-            "Birth",
-            "Missing women",
-            "Infanticide",
-        ]
-        expect(
-            rankSuggestedKeywords(unrefined(...keywords), hits)
-        ).toHaveLength(5)
-    })
-
-    it("ignores candidates past the head of the vocabulary list, so a broad term deep in it can't outrank a specific one", () => {
-        // The real failure this guards: "Men"/"Women" sit late in the Gender
-        // Ratio vocabulary but occur in more of its charts than any specific
-        // term, so an uncapped pool opens the line with them.
-        const specific = "Sex-selective abortion"
-        const broad = "Women"
-        const keywords = [
-            specific,
-            ...Array.from({ length: 12 }, (_, i) => `Filler ${i}`),
-            broad,
-        ]
-        const skewedHits = makeHits(
-            "Women in parliament",
-            "Women in work",
-            "Sex-selective abortion by birth order"
-        )
-        expect(
-            rankSuggestedKeywords(unrefined(...keywords), skewedHits)
-        ).not.toContain(broad)
-    })
-
-    it("drops a term that only reaches charts an earlier term already reached", () => {
-        // The real failure: Gender Ratio offered "missing women",
-        // "sex-selective abortion" and "excess female mortality" — three chips,
-        // the same two charts.
-        const hits = makeHits(
-            "Number of 'missing women' in the world",
-            "Annual number of missing female births and excess mortality",
-            "Representation of women in the judiciary"
-        )
-        expect(
-            rankSuggestedKeywords(
-                unrefined("missing", "excess mortality", "judiciary"),
-                hits
-            )
-        ).toEqual(["missing", "judiciary", "excess mortality"])
-    })
-
-    it("fills a leftover slot with a duplicate rather than a dead end", () => {
-        const hits = makeHits("Sex ratio at birth", "Sex ratio by age")
-        // "sex ratio" reaches both charts, so "at birth" adds no destination —
-        // but it does lead somewhere, which "infanticide" doesn't.
-        expect(
-            rankSuggestedKeywords(
-                unrefined("sex ratio", "sex ratio at birth", "infanticide"),
-                hits
-            )
-        ).toEqual(["sex ratio", "sex ratio at birth"])
+describe(suggestedKeywords, () => {
+    it("suggests the vocabulary's terms in the vocabulary's own order", () => {
+        // Deliberately not re-ordered here: the generator picked this order by
+        // measuring what each term reveals of this very chart list, weighted by
+        // how much each chart is viewed. See suggestedKeywords.
+        const keywords = ["sex ratio", "female population", "missing women"]
+        expect(suggestedKeywords(keywords)).toEqual(keywords)
     })
 
     it("never suggests a place, however the vocabulary names it", () => {
-        const hits = makeHits(
-            "Child labor in the United States",
-            "Child labor in the UK",
-            "School attendance"
-        )
         expect(
-            rankSuggestedKeywords(
-                unrefined(
-                    "United States",
-                    "UK",
-                    "Africa",
-                    "World",
-                    "school attendance"
-                ),
-                hits
-            )
+            suggestedKeywords([
+                "United States",
+                "UK",
+                "Africa",
+                "World",
+                "school attendance",
+            ])
         ).toEqual(["school attendance"])
-    })
-
-    it("offers a term the topic's own name contains, since on some topics nothing narrower reaches the charts", () => {
-        // These used to be refused, on the reasoning that a reader already on
-        // the page has applied them. True for most topics; on Religion, whose
-        // biggest chart is "Share of the population who are religious", only
-        // "religious" reaches it — and allowing it took that topic from covering
-        // 39% of its traffic to 97%.
-        const religionHits = makeHits(
-            "Share of the population who are religious",
-            "Number of people by religion",
-            "How often people pray"
-        )
-        expect(
-            rankSuggestedKeywords(unrefined("religious", "pray"), religionHits)
-        ).toEqual(["religious", "pray"])
-    })
-
-    it("matches case-insensitively", () => {
-        expect(rankSuggestedKeywords(unrefined("SEX RATIO"), hits)).toEqual([
-            "SEX RATIO",
-        ])
-    })
-
-    it("suggests nothing before the topic's charts have loaded", () => {
-        expect(rankSuggestedKeywords(unrefined("Sex ratio"), [])).toEqual([])
     })
 
     it("suggests nothing for a topic the vocabulary doesn't cover", () => {
-        expect(rankSuggestedKeywords(unrefined(), hits)).toEqual([])
-    })
-    it("takes a refined vocabulary's order as given, since its generator checked it against real search results", () => {
-        // "sex ratio at birth" looks like a narrower spelling of "sex ratio"
-        // and matches a subset of the same charts, so the unrefined path
-        // demotes it — but a refined list has already been checked against
-        // what each term actually returns, so it stays put.
-        const keywords = ["sex ratio", "sex ratio at birth", "missing women"]
-        const hits = makeHits(
-            "Sex ratio at birth",
-            "Sex ratio by age",
-            "Number of 'missing women' in the world"
-        )
-        expect(
-            rankSuggestedKeywords({ keywords, refined: true }, hits)
-        ).toEqual(keywords)
-        expect(rankSuggestedKeywords(unrefined(...keywords), hits)).toEqual([
-            "sex ratio",
-            "missing women",
-            "sex ratio at birth",
-        ])
-    })
-
-    it("offers a refined vocabulary's terms before the chart list has arrived", () => {
-        // Nothing about a refined order depends on the charts, so the line
-        // doesn't have to wait for them.
-        expect(
-            rankSuggestedKeywords(
-                { keywords: ["sex ratio", "missing women"], refined: true },
-                []
-            )
-        ).toEqual(["sex ratio", "missing women"])
-    })
-
-    it("still refuses to suggest a place from a refined vocabulary", () => {
-        expect(
-            rankSuggestedKeywords(
-                {
-                    keywords: ["United States", "school attendance"],
-                    refined: true,
-                },
-                []
-            )
-        ).toEqual(["school attendance"])
-    })
-
-    it("suggests nothing when the vocabulary has no entry for the topic", () => {
-        expect(rankSuggestedKeywords(undefined, makeHits("Sex ratio"))).toEqual(
-            []
-        )
+        expect(suggestedKeywords(undefined)).toEqual([])
+        expect(suggestedKeywords([])).toEqual([])
     })
 })
 
@@ -234,10 +42,7 @@ describe(indexTopicVocabularyByName, () => {
 
     it("re-keys the published vocabulary by topic name", () => {
         expect(indexTopicVocabularyByName(published)).toEqual({
-            "Gender Ratio": {
-                keywords: ["Sex ratio", "Missing women"],
-                refined: false,
-            },
+            "Gender Ratio": ["Sex ratio", "Missing women"],
         })
     })
 
@@ -255,23 +60,9 @@ describe(indexTopicVocabularyByName, () => {
                 nothing: null,
             })
         ).toEqual({
-            "Gender Ratio": {
-                keywords: ["Sex ratio", "Missing women"],
-                refined: false,
-            },
-            "Junk Keywords": { keywords: ["Kept"], refined: false },
+            "Gender Ratio": ["Sex ratio", "Missing women"],
+            "Junk Keywords": ["Kept"],
         })
-    })
-
-    it("reads whether the generator refined the entry against real search results", () => {
-        const refined = indexTopicVocabularyByName({
-            "gender-ratio": {
-                topic_name: "Gender Ratio",
-                keywords: ["Sex ratio"],
-                stats: { refined: true },
-            },
-        })
-        expect(refined["Gender Ratio"].refined).toBe(true)
     })
 
     it("tolerates a response that isn't an object at all", () => {

--- a/site/AllChartsBlock.test.ts
+++ b/site/AllChartsBlock.test.ts
@@ -1,0 +1,149 @@
+import { expect, it, describe } from "vitest"
+import { SearchChartHit } from "@ourworldindata/types"
+import {
+    indexTopicVocabularyByName,
+    rankSuggestedKeywords,
+} from "./search/topicVocabulary.js"
+
+
+const makeHits = (...texts: string[]): SearchChartHit[] =>
+    texts.map((title) => ({ title }) as SearchChartHit)
+
+describe(rankSuggestedKeywords.name, () => {
+    const hits = makeHits(
+        "Share of women in parliament",
+        "Women in managerial positions",
+        "Sex ratio at birth"
+    )
+
+    it("puts the terms describing more of the topic's charts first", () => {
+        expect(
+            rankSuggestedKeywords(["Sex ratio", "Women"], hits, "Gender Ratio")
+        ).toEqual(["Women", "Sex ratio"])
+    })
+
+    it("keeps the vocabulary's order between terms describing equally many charts", () => {
+        expect(
+            rankSuggestedKeywords(
+                ["Sex ratio", "Parliament"],
+                hits,
+                "Gender Ratio"
+            )
+        ).toEqual(["Sex ratio", "Parliament"])
+    })
+
+    it("fills the remaining slots with terms it couldn't match rather than shortening the line", () => {
+        // "Missing women" matches no chart above, but Algolia matches more
+        // generously than the substring test does, so it is offered last
+        // instead of dropped.
+        expect(
+            rankSuggestedKeywords(
+                ["Missing women", "Sex ratio"],
+                hits,
+                "Gender Ratio"
+            )
+        ).toEqual(["Sex ratio", "Missing women"])
+    })
+
+    it("offers at most five terms", () => {
+        const keywords = [
+            "Women",
+            "Sex ratio",
+            "Parliament",
+            "Managerial positions",
+            "Birth",
+            "Missing women",
+            "Infanticide",
+        ]
+        expect(rankSuggestedKeywords(keywords, hits, "Gender Ratio")).toHaveLength(
+            5
+        )
+    })
+
+    it("ignores candidates past the head of the vocabulary list, so a broad term deep in it can't outrank a specific one", () => {
+        // The real failure this guards: "Men"/"Women" sit late in the Gender
+        // Ratio vocabulary but occur in more of its charts than any specific
+        // term, so an uncapped pool opens the line with them.
+        const specific = "Sex-selective abortion"
+        const broad = "Women"
+        const keywords = [
+            specific,
+            ...Array.from({ length: 12 }, (_, i) => `Filler ${i}`),
+            broad,
+        ]
+        const skewedHits = makeHits(
+            "Women in parliament",
+            "Women in work",
+            "Sex-selective abortion by birth order"
+        )
+        expect(
+            rankSuggestedKeywords(keywords, skewedHits, "Gender Ratio")
+        ).not.toContain(broad)
+    })
+
+    it("drops terms the topic's own name already contains", () => {
+        expect(
+            rankSuggestedKeywords(
+                ["Gender", "ratio", "Sex ratio"],
+                hits,
+                "Gender Ratio"
+            )
+        ).toEqual(["Sex ratio"])
+    })
+
+    it("matches case-insensitively", () => {
+        expect(
+            rankSuggestedKeywords(["SEX RATIO"], hits, "Gender Ratio")
+        ).toEqual(["SEX RATIO"])
+    })
+
+    it("suggests nothing before the topic's charts have loaded", () => {
+        expect(rankSuggestedKeywords(["Sex ratio"], [], "Gender Ratio")).toEqual(
+            []
+        )
+    })
+
+    it("suggests nothing for a topic the vocabulary doesn't cover", () => {
+        expect(rankSuggestedKeywords([], hits, "Gender Ratio")).toEqual([])
+    })
+})
+
+describe(indexTopicVocabularyByName.name, () => {
+    const published = {
+        "gender-ratio": {
+            topic_name: "Gender Ratio",
+            keywords: ["Sex ratio", "Missing women"],
+            stats: { num_keywords: 2 },
+        },
+    }
+
+    it("re-keys the published vocabulary by topic name", () => {
+        expect(indexTopicVocabularyByName(published)).toEqual({
+            "Gender Ratio": ["Sex ratio", "Missing women"],
+        })
+    })
+
+    it("skips entries a regeneration could have left malformed", () => {
+        expect(
+            indexTopicVocabularyByName({
+                ...published,
+                "no-name": { keywords: ["Orphaned"] },
+                "no-keywords": { topic_name: "No Keywords" },
+                "wrong-type": { topic_name: "Wrong Type", keywords: "nope" },
+                "junk-keywords": {
+                    topic_name: "Junk Keywords",
+                    keywords: ["Kept", "", null, 7],
+                },
+                nothing: null,
+            })
+        ).toEqual({
+            "Gender Ratio": ["Sex ratio", "Missing women"],
+            "Junk Keywords": ["Kept"],
+        })
+    })
+
+    it("tolerates a response that isn't an object at all", () => {
+        expect(indexTopicVocabularyByName(null)).toEqual({})
+        expect(indexTopicVocabularyByName("nope")).toEqual({})
+    })
+})

--- a/site/AllChartsBlock.test.ts
+++ b/site/AllChartsBlock.test.ts
@@ -5,7 +5,6 @@ import {
     rankSuggestedKeywords,
 } from "./search/topicVocabulary.js"
 
-
 const makeHits = (...texts: string[]): SearchChartHit[] =>
     texts.map((title) => ({ title }) as SearchChartHit)
 
@@ -55,9 +54,9 @@ describe(rankSuggestedKeywords.name, () => {
             "Missing women",
             "Infanticide",
         ]
-        expect(rankSuggestedKeywords(keywords, hits, "Gender Ratio")).toHaveLength(
-            5
-        )
+        expect(
+            rankSuggestedKeywords(keywords, hits, "Gender Ratio")
+        ).toHaveLength(5)
     })
 
     it("ignores candidates past the head of the vocabulary list, so a broad term deep in it can't outrank a specific one", () => {
@@ -81,6 +80,52 @@ describe(rankSuggestedKeywords.name, () => {
         ).not.toContain(broad)
     })
 
+    it("drops a term that only reaches charts an earlier term already reached", () => {
+        // The real failure: Gender Ratio offered "missing women",
+        // "sex-selective abortion" and "excess female mortality" — three chips,
+        // the same two charts.
+        const hits = makeHits(
+            "Number of 'missing women' in the world",
+            "Annual number of missing female births and excess mortality",
+            "Representation of women in the judiciary"
+        )
+        expect(
+            rankSuggestedKeywords(
+                ["missing", "excess mortality", "judiciary"],
+                hits,
+                "Gender Ratio"
+            )
+        ).toEqual(["missing", "judiciary", "excess mortality"])
+    })
+
+    it("prefers an unproven term over a known duplicate when filling the line", () => {
+        const hits = makeHits("Sex ratio at birth", "Sex ratio by age")
+        // "sex ratio" covers both charts, so "at birth" is a duplicate;
+        // "infanticide" matches nothing here but Algolia may still find it.
+        expect(
+            rankSuggestedKeywords(
+                ["sex ratio", "sex ratio at birth", "infanticide"],
+                hits,
+                "Gender Ratio"
+            )
+        ).toEqual(["sex ratio", "infanticide", "sex ratio at birth"])
+    })
+
+    it("never suggests a place, however the vocabulary names it", () => {
+        const hits = makeHits(
+            "Child labor in the United States",
+            "Child labor in the UK",
+            "School attendance"
+        )
+        expect(
+            rankSuggestedKeywords(
+                ["United States", "UK", "Africa", "World", "school attendance"],
+                hits,
+                "Child Labor"
+            )
+        ).toEqual(["school attendance"])
+    })
+
     it("drops terms the topic's own name already contains", () => {
         expect(
             rankSuggestedKeywords(
@@ -98,9 +143,9 @@ describe(rankSuggestedKeywords.name, () => {
     })
 
     it("suggests nothing before the topic's charts have loaded", () => {
-        expect(rankSuggestedKeywords(["Sex ratio"], [], "Gender Ratio")).toEqual(
-            []
-        )
+        expect(
+            rankSuggestedKeywords(["Sex ratio"], [], "Gender Ratio")
+        ).toEqual([])
     })
 
     it("suggests nothing for a topic the vocabulary doesn't cover", () => {

--- a/site/AllChartsBlock.test.ts
+++ b/site/AllChartsBlock.test.ts
@@ -3,10 +3,18 @@ import { SearchChartHit } from "@ourworldindata/types"
 import {
     indexTopicVocabularyByName,
     rankSuggestedKeywords,
+    type TopicVocabularyEntry,
 } from "./search/topicVocabulary.js"
 
 const makeHits = (...texts: string[]): SearchChartHit[] =>
     texts.map((title) => ({ title }) as SearchChartHit)
+
+// A vocabulary entry the generator did not check against the search API, so the
+// ranking has to work its own coverage out. See `refined` entries at the bottom.
+const unrefined = (...keywords: string[]): TopicVocabularyEntry => ({
+    keywords,
+    refined: false,
+})
 
 describe(rankSuggestedKeywords, () => {
     const hits = makeHits(
@@ -17,14 +25,18 @@ describe(rankSuggestedKeywords, () => {
 
     it("puts the terms describing more of the topic's charts first", () => {
         expect(
-            rankSuggestedKeywords(["Sex ratio", "Women"], hits, "Gender Ratio")
+            rankSuggestedKeywords(
+                unrefined("Sex ratio", "Women"),
+                hits,
+                "Gender Ratio"
+            )
         ).toEqual(["Women", "Sex ratio"])
     })
 
     it("keeps the vocabulary's order between terms describing equally many charts", () => {
         expect(
             rankSuggestedKeywords(
-                ["Sex ratio", "Parliament"],
+                unrefined("Sex ratio", "Parliament"),
                 hits,
                 "Gender Ratio"
             )
@@ -37,7 +49,7 @@ describe(rankSuggestedKeywords, () => {
         // instead of dropped.
         expect(
             rankSuggestedKeywords(
-                ["Missing women", "Sex ratio"],
+                unrefined("Missing women", "Sex ratio"),
                 hits,
                 "Gender Ratio"
             )
@@ -55,7 +67,7 @@ describe(rankSuggestedKeywords, () => {
             "Infanticide",
         ]
         expect(
-            rankSuggestedKeywords(keywords, hits, "Gender Ratio")
+            rankSuggestedKeywords(unrefined(...keywords), hits, "Gender Ratio")
         ).toHaveLength(5)
     })
 
@@ -76,7 +88,11 @@ describe(rankSuggestedKeywords, () => {
             "Sex-selective abortion by birth order"
         )
         expect(
-            rankSuggestedKeywords(keywords, skewedHits, "Gender Ratio")
+            rankSuggestedKeywords(
+                unrefined(...keywords),
+                skewedHits,
+                "Gender Ratio"
+            )
         ).not.toContain(broad)
     })
 
@@ -91,7 +107,7 @@ describe(rankSuggestedKeywords, () => {
         )
         expect(
             rankSuggestedKeywords(
-                ["missing", "excess mortality", "judiciary"],
+                unrefined("missing", "excess mortality", "judiciary"),
                 hits,
                 "Gender Ratio"
             )
@@ -104,7 +120,7 @@ describe(rankSuggestedKeywords, () => {
         // "infanticide" matches nothing here but Algolia may still find it.
         expect(
             rankSuggestedKeywords(
-                ["sex ratio", "sex ratio at birth", "infanticide"],
+                unrefined("sex ratio", "sex ratio at birth", "infanticide"),
                 hits,
                 "Gender Ratio"
             )
@@ -119,7 +135,13 @@ describe(rankSuggestedKeywords, () => {
         )
         expect(
             rankSuggestedKeywords(
-                ["United States", "UK", "Africa", "World", "school attendance"],
+                unrefined(
+                    "United States",
+                    "UK",
+                    "Africa",
+                    "World",
+                    "school attendance"
+                ),
                 hits,
                 "Child Labor"
             )
@@ -129,7 +151,7 @@ describe(rankSuggestedKeywords, () => {
     it("drops terms the topic's own name already contains", () => {
         expect(
             rankSuggestedKeywords(
-                ["Gender", "ratio", "Sex ratio"],
+                unrefined("Gender", "ratio", "Sex ratio"),
                 hits,
                 "Gender Ratio"
             )
@@ -138,18 +160,77 @@ describe(rankSuggestedKeywords, () => {
 
     it("matches case-insensitively", () => {
         expect(
-            rankSuggestedKeywords(["SEX RATIO"], hits, "Gender Ratio")
+            rankSuggestedKeywords(unrefined("SEX RATIO"), hits, "Gender Ratio")
         ).toEqual(["SEX RATIO"])
     })
 
     it("suggests nothing before the topic's charts have loaded", () => {
         expect(
-            rankSuggestedKeywords(["Sex ratio"], [], "Gender Ratio")
+            rankSuggestedKeywords(unrefined("Sex ratio"), [], "Gender Ratio")
         ).toEqual([])
     })
 
     it("suggests nothing for a topic the vocabulary doesn't cover", () => {
-        expect(rankSuggestedKeywords([], hits, "Gender Ratio")).toEqual([])
+        expect(
+            rankSuggestedKeywords(unrefined(), hits, "Gender Ratio")
+        ).toEqual([])
+    })
+    it("takes a refined vocabulary's order as given, since its generator checked it against real search results", () => {
+        // "sex ratio at birth" looks like a narrower spelling of "sex ratio"
+        // and matches a subset of the same charts, so the unrefined path
+        // demotes it — but a refined list has already been checked against
+        // what each term actually returns, so it stays put.
+        const keywords = ["sex ratio", "sex ratio at birth", "missing women"]
+        const hits = makeHits(
+            "Sex ratio at birth",
+            "Sex ratio by age",
+            "Number of 'missing women' in the world"
+        )
+        expect(
+            rankSuggestedKeywords(
+                { keywords, refined: true },
+                hits,
+                "Gender Ratio"
+            )
+        ).toEqual(keywords)
+        expect(
+            rankSuggestedKeywords(unrefined(...keywords), hits, "Gender Ratio")
+        ).toEqual(["sex ratio", "missing women", "sex ratio at birth"])
+    })
+
+    it("offers a refined vocabulary's terms before the chart list has arrived", () => {
+        // Nothing about a refined order depends on the charts, so the line
+        // doesn't have to wait for them.
+        expect(
+            rankSuggestedKeywords(
+                { keywords: ["sex ratio", "missing women"], refined: true },
+                [],
+                "Gender Ratio"
+            )
+        ).toEqual(["sex ratio", "missing women"])
+    })
+
+    it("still refuses to suggest a place from a refined vocabulary", () => {
+        expect(
+            rankSuggestedKeywords(
+                {
+                    keywords: ["United States", "school attendance"],
+                    refined: true,
+                },
+                [],
+                "Child Labor"
+            )
+        ).toEqual(["school attendance"])
+    })
+
+    it("suggests nothing when the vocabulary has no entry for the topic", () => {
+        expect(
+            rankSuggestedKeywords(
+                undefined,
+                makeHits("Sex ratio"),
+                "Gender Ratio"
+            )
+        ).toEqual([])
     })
 })
 
@@ -164,7 +245,10 @@ describe(indexTopicVocabularyByName, () => {
 
     it("re-keys the published vocabulary by topic name", () => {
         expect(indexTopicVocabularyByName(published)).toEqual({
-            "Gender Ratio": ["Sex ratio", "Missing women"],
+            "Gender Ratio": {
+                keywords: ["Sex ratio", "Missing women"],
+                refined: false,
+            },
         })
     })
 
@@ -182,9 +266,23 @@ describe(indexTopicVocabularyByName, () => {
                 nothing: null,
             })
         ).toEqual({
-            "Gender Ratio": ["Sex ratio", "Missing women"],
-            "Junk Keywords": ["Kept"],
+            "Gender Ratio": {
+                keywords: ["Sex ratio", "Missing women"],
+                refined: false,
+            },
+            "Junk Keywords": { keywords: ["Kept"], refined: false },
         })
+    })
+
+    it("reads whether the generator refined the entry against real search results", () => {
+        const refined = indexTopicVocabularyByName({
+            "gender-ratio": {
+                topic_name: "Gender Ratio",
+                keywords: ["Sex ratio"],
+                stats: { refined: true },
+            },
+        })
+        expect(refined["Gender Ratio"].refined).toBe(true)
     })
 
     it("tolerates a response that isn't an object at all", () => {

--- a/site/AllChartsBlock.test.ts
+++ b/site/AllChartsBlock.test.ts
@@ -25,21 +25,13 @@ describe(rankSuggestedKeywords, () => {
 
     it("puts the terms describing more of the topic's charts first", () => {
         expect(
-            rankSuggestedKeywords(
-                unrefined("Sex ratio", "Women"),
-                hits,
-                "Gender Ratio"
-            )
+            rankSuggestedKeywords(unrefined("Sex ratio", "Women"), hits)
         ).toEqual(["Women", "Sex ratio"])
     })
 
     it("keeps the vocabulary's order between terms describing equally many charts", () => {
         expect(
-            rankSuggestedKeywords(
-                unrefined("Sex ratio", "Parliament"),
-                hits,
-                "Gender Ratio"
-            )
+            rankSuggestedKeywords(unrefined("Sex ratio", "Parliament"), hits)
         ).toEqual(["Sex ratio", "Parliament"])
     })
 
@@ -48,11 +40,7 @@ describe(rankSuggestedKeywords, () => {
         // generously than the substring test does, so it is offered last
         // instead of dropped.
         expect(
-            rankSuggestedKeywords(
-                unrefined("Missing women", "Sex ratio"),
-                hits,
-                "Gender Ratio"
-            )
+            rankSuggestedKeywords(unrefined("Missing women", "Sex ratio"), hits)
         ).toEqual(["Sex ratio", "Missing women"])
     })
 
@@ -67,7 +55,7 @@ describe(rankSuggestedKeywords, () => {
             "Infanticide",
         ]
         expect(
-            rankSuggestedKeywords(unrefined(...keywords), hits, "Gender Ratio")
+            rankSuggestedKeywords(unrefined(...keywords), hits)
         ).toHaveLength(5)
     })
 
@@ -88,11 +76,7 @@ describe(rankSuggestedKeywords, () => {
             "Sex-selective abortion by birth order"
         )
         expect(
-            rankSuggestedKeywords(
-                unrefined(...keywords),
-                skewedHits,
-                "Gender Ratio"
-            )
+            rankSuggestedKeywords(unrefined(...keywords), skewedHits)
         ).not.toContain(broad)
     })
 
@@ -108,8 +92,7 @@ describe(rankSuggestedKeywords, () => {
         expect(
             rankSuggestedKeywords(
                 unrefined("missing", "excess mortality", "judiciary"),
-                hits,
-                "Gender Ratio"
+                hits
             )
         ).toEqual(["missing", "judiciary", "excess mortality"])
     })
@@ -121,8 +104,7 @@ describe(rankSuggestedKeywords, () => {
         expect(
             rankSuggestedKeywords(
                 unrefined("sex ratio", "sex ratio at birth", "infanticide"),
-                hits,
-                "Gender Ratio"
+                hits
             )
         ).toEqual(["sex ratio", "infanticide", "sex ratio at birth"])
     })
@@ -142,38 +124,39 @@ describe(rankSuggestedKeywords, () => {
                     "World",
                     "school attendance"
                 ),
-                hits,
-                "Child Labor"
+                hits
             )
         ).toEqual(["school attendance"])
     })
 
-    it("drops terms the topic's own name already contains", () => {
+    it("offers a term the topic's own name contains, since on some topics nothing narrower reaches the charts", () => {
+        // These used to be refused, on the reasoning that a reader already on
+        // the page has applied them. True for most topics; on Religion, whose
+        // biggest chart is "Share of the population who are religious", only
+        // "religious" reaches it — and allowing it took that topic from covering
+        // 39% of its traffic to 97%.
+        const religionHits = makeHits(
+            "Share of the population who are religious",
+            "Number of people by religion",
+            "How often people pray"
+        )
         expect(
-            rankSuggestedKeywords(
-                unrefined("Gender", "ratio", "Sex ratio"),
-                hits,
-                "Gender Ratio"
-            )
-        ).toEqual(["Sex ratio"])
+            rankSuggestedKeywords(unrefined("religious", "pray"), religionHits)
+        ).toEqual(["religious", "pray"])
     })
 
     it("matches case-insensitively", () => {
-        expect(
-            rankSuggestedKeywords(unrefined("SEX RATIO"), hits, "Gender Ratio")
-        ).toEqual(["SEX RATIO"])
+        expect(rankSuggestedKeywords(unrefined("SEX RATIO"), hits)).toEqual([
+            "SEX RATIO",
+        ])
     })
 
     it("suggests nothing before the topic's charts have loaded", () => {
-        expect(
-            rankSuggestedKeywords(unrefined("Sex ratio"), [], "Gender Ratio")
-        ).toEqual([])
+        expect(rankSuggestedKeywords(unrefined("Sex ratio"), [])).toEqual([])
     })
 
     it("suggests nothing for a topic the vocabulary doesn't cover", () => {
-        expect(
-            rankSuggestedKeywords(unrefined(), hits, "Gender Ratio")
-        ).toEqual([])
+        expect(rankSuggestedKeywords(unrefined(), hits)).toEqual([])
     })
     it("takes a refined vocabulary's order as given, since its generator checked it against real search results", () => {
         // "sex ratio at birth" looks like a narrower spelling of "sex ratio"
@@ -187,15 +170,13 @@ describe(rankSuggestedKeywords, () => {
             "Number of 'missing women' in the world"
         )
         expect(
-            rankSuggestedKeywords(
-                { keywords, refined: true },
-                hits,
-                "Gender Ratio"
-            )
+            rankSuggestedKeywords({ keywords, refined: true }, hits)
         ).toEqual(keywords)
-        expect(
-            rankSuggestedKeywords(unrefined(...keywords), hits, "Gender Ratio")
-        ).toEqual(["sex ratio", "missing women", "sex ratio at birth"])
+        expect(rankSuggestedKeywords(unrefined(...keywords), hits)).toEqual([
+            "sex ratio",
+            "missing women",
+            "sex ratio at birth",
+        ])
     })
 
     it("offers a refined vocabulary's terms before the chart list has arrived", () => {
@@ -204,8 +185,7 @@ describe(rankSuggestedKeywords, () => {
         expect(
             rankSuggestedKeywords(
                 { keywords: ["sex ratio", "missing women"], refined: true },
-                [],
-                "Gender Ratio"
+                []
             )
         ).toEqual(["sex ratio", "missing women"])
     })
@@ -217,20 +197,15 @@ describe(rankSuggestedKeywords, () => {
                     keywords: ["United States", "school attendance"],
                     refined: true,
                 },
-                [],
-                "Child Labor"
+                []
             )
         ).toEqual(["school attendance"])
     })
 
     it("suggests nothing when the vocabulary has no entry for the topic", () => {
-        expect(
-            rankSuggestedKeywords(
-                undefined,
-                makeHits("Sex ratio"),
-                "Gender Ratio"
-            )
-        ).toEqual([])
+        expect(rankSuggestedKeywords(undefined, makeHits("Sex ratio"))).toEqual(
+            []
+        )
     })
 })
 

--- a/site/AllChartsBlock.test.ts
+++ b/site/AllChartsBlock.test.ts
@@ -35,13 +35,27 @@ describe(rankSuggestedKeywords, () => {
         ).toEqual(["Sex ratio", "Parliament"])
     })
 
-    it("fills the remaining slots with terms it couldn't match rather than shortening the line", () => {
-        // "Missing women" matches no chart above, but Algolia matches more
-        // generously than the substring test does, so it is offered last
-        // instead of dropped.
+    it("drops a term no chart on the page matches, rather than offering a chip that empties the list", () => {
+        // Clicking a chip searches, and the block then keeps only the rows whose
+        // own text contains the query — so a term nothing on the page matches is
+        // a dead end whatever Algolia would have returned. 25 of the 620 terms
+        // the production vocabulary has been showing behave this way.
         expect(
             rankSuggestedKeywords(unrefined("Missing women", "Sex ratio"), hits)
-        ).toEqual(["Sex ratio", "Missing women"])
+        ).toEqual(["Sex ratio"])
+    })
+
+    it("counts whole words, not substrings, so a short term isn't credited with charts it can't reach", () => {
+        // "Men" occurs inside "Women" and "employment"; searching for it
+        // returns neither, so it must not outrank a term that does reach them.
+        const menHits = makeHits(
+            "Women in employment",
+            "Women in parliament",
+            "Men and women in unpaid care work"
+        )
+        expect(
+            rankSuggestedKeywords(unrefined("Men", "Women"), menHits)
+        ).toEqual(["Women", "Men"])
     })
 
     it("offers at most five terms", () => {
@@ -97,16 +111,16 @@ describe(rankSuggestedKeywords, () => {
         ).toEqual(["missing", "judiciary", "excess mortality"])
     })
 
-    it("prefers an unproven term over a known duplicate when filling the line", () => {
+    it("fills a leftover slot with a duplicate rather than a dead end", () => {
         const hits = makeHits("Sex ratio at birth", "Sex ratio by age")
-        // "sex ratio" covers both charts, so "at birth" is a duplicate;
-        // "infanticide" matches nothing here but Algolia may still find it.
+        // "sex ratio" reaches both charts, so "at birth" adds no destination —
+        // but it does lead somewhere, which "infanticide" doesn't.
         expect(
             rankSuggestedKeywords(
                 unrefined("sex ratio", "sex ratio at birth", "infanticide"),
                 hits
             )
-        ).toEqual(["sex ratio", "infanticide", "sex ratio at birth"])
+        ).toEqual(["sex ratio", "sex ratio at birth"])
     })
 
     it("never suggests a place, however the vocabulary names it", () => {

--- a/site/AllChartsBlock.test.ts
+++ b/site/AllChartsBlock.test.ts
@@ -8,7 +8,7 @@ import {
 const makeHits = (...texts: string[]): SearchChartHit[] =>
     texts.map((title) => ({ title }) as SearchChartHit)
 
-describe(rankSuggestedKeywords.name, () => {
+describe(rankSuggestedKeywords, () => {
     const hits = makeHits(
         "Share of women in parliament",
         "Women in managerial positions",
@@ -153,7 +153,7 @@ describe(rankSuggestedKeywords.name, () => {
     })
 })
 
-describe(indexTopicVocabularyByName.name, () => {
+describe(indexTopicVocabularyByName, () => {
     const published = {
         "gender-ratio": {
             topic_name: "Gender Ratio",

--- a/site/AllChartsBlock.tsx
+++ b/site/AllChartsBlock.tsx
@@ -230,12 +230,7 @@ export const AllChartsBlock = ({
     })
 
     const vocabularyChips = useMemo(
-        () =>
-            rankSuggestedKeywords(
-                vocabulary?.[topicName],
-                baseHits ?? [],
-                topicName
-            ),
+        () => rankSuggestedKeywords(vocabulary?.[topicName], baseHits ?? []),
         [vocabulary, baseHits, topicName]
     )
 

--- a/site/AllChartsBlock.tsx
+++ b/site/AllChartsBlock.tsx
@@ -15,13 +15,15 @@ import {
     FilterType,
     ALL_CHARTS_ID,
 } from "@ourworldindata/types"
-import {
-    getRegionByNameOrVariantName,
-    listedRegionsNames,
-} from "@ourworldindata/utils"
+import { listedRegionsNames } from "@ourworldindata/utils"
 import { Button } from "@ourworldindata/components"
 import { GrapherWithFallback } from "./GrapherWithFallback.js"
 import { useDocumentContext } from "./gdocs/DocumentContext.js"
+import {
+    fetchTopicVocabulary,
+    rankSuggestedKeywords,
+    topicVocabularyQueryKey,
+} from "./search/topicVocabulary.js"
 import { getDirectLiteSearchClient } from "./search/searchClients.js"
 import { queryAllCharts, searchQueryKeys } from "./search/queries.js"
 import {
@@ -49,6 +51,7 @@ import { SearchDataResultsSkeleton } from "./search/SearchDataResultsSkeleton.js
 import { SearchFilterPill } from "./search/SearchFilterPill.js"
 import { useVisibleChartHits } from "./useVisibleChartHits.js"
 import { MEDIUM_BREAKPOINT_MEDIA_QUERY } from "./SiteConstants.js"
+import { TOPIC_VOCABULARY_URL } from "../settings/clientSettings.js"
 
 const SEARCH_DEBOUNCE_MS = 200
 
@@ -61,308 +64,17 @@ const ACCORDION_LAYOUT_MEDIA_QUERY = MEDIUM_BREAKPOINT_MEDIA_QUERY
 const SEARCH_PLACEHOLDER =
     "Search indicators by name, keyword, country, or source…"
 
-// A "suggested" chip must recur across at least this many charts on the
-// topic to be worth surfacing — otherwise it's just noise from a single
-// indicator rather than a genuine shortcut into the topic's chart list.
-const MIN_SUGGESTED_CHIP_COUNT = 2
-const MAX_SUGGESTED_CHIPS = 5
-
-// Shortest a keyword must be to be worth suggesting on its own (drops noise
-// like short acronyms picked up mid-title).
-const MIN_KEYWORD_LENGTH = 3
-
-// General English stop words, plus words that are technically accurate but
-// too generic/boilerplate in OWID chart titles & subtitles to read as a
-// meaningful search suggestion on their own (e.g. every chart on a topic
-// might say "rate" or "number", but that's not a useful way to search
-// within it — "deaths" or "fertility" is). Deliberately erring towards
-// excluding borderline words: a shorter, higher-signal chip list beats a
-// longer, noisier one.
-const KEYWORD_STOP_WORDS = new Set([
-    // general English stop words / connectives
-    "the",
-    "a",
-    "an",
-    "of",
-    "and",
-    "or",
-    "in",
-    "on",
-    "at",
-    "by",
-    "to",
-    "for",
-    "with",
-    "from",
-    "per",
-    "vs",
-    "is",
-    "are",
-    "was",
-    "were",
-    "be",
-    "been",
-    "being",
-    "as",
-    "it",
-    "its",
-    "this",
-    "that",
-    "these",
-    "those",
-    "than",
-    "then",
-    "so",
-    "such",
-    "which",
-    "who",
-    "whom",
-    "what",
-    "when",
-    "where",
-    "how",
-    "why",
-    "all",
-    "any",
-    "each",
-    "other",
-    "some",
-    "most",
-    "more",
-    "less",
-    "least",
-    "much",
-    "many",
-    "few",
-    "between",
-    "among",
-    "during",
-    "after",
-    "before",
-    "above",
-    "below",
-    "up",
-    "down",
-    "out",
-    "off",
-    "over",
-    "under",
-    "again",
-    "further",
-    "once",
-    "here",
-    "there",
-    "own",
-    "same",
-    "if",
-    "because",
-    "while",
-    "about",
-    "not",
-    "no",
-    "yes",
-    "their",
-    "our",
-    "you",
-    "your",
-    // OWID chart-title/subtitle boilerplate: technically descriptive, but too
-    // generic to be a useful search shortcut within an already-filtered topic
-    "rate",
-    "rates",
-    "number",
-    "numbers",
-    "share",
-    "shares",
-    "total",
-    "totals",
-    "average",
-    "averages",
-    "annual",
-    "annually",
-    "data",
-    "world",
-    "global",
-    "country",
-    "countries",
-    "region",
-    "regions",
-    "population",
-    "level",
-    "levels",
-    "value",
-    "values",
-    "index",
-    "indicator",
-    "indicators",
-    "estimate",
-    "estimates",
-    "estimated",
-    "projection",
-    "projections",
-    "projected",
-    "million",
-    "millions",
-    "thousand",
-    "thousands",
-    "billion",
-    "billions",
-    "measure",
-    "measured",
-    "measurement",
-    "capita",
-    "year",
-    "years",
-    "group",
-    "groups",
-    "type",
-    "types",
-])
-
-type SuggestedChipCandidate = {
-    dimension: "producer" | "keyword"
-    name: string
-    count: number
-}
-
-// True for anything that names a place: a country, a continent, an aggregate
-// like "World", or a variant name for one of those ("US", "UK", "Czech
-// Republic"). Suggested searches deliberately don't include places — see
-// computeAutoSuggestedChips — and this is the same lookup the rest of the site
-// uses to recognise one, so variants and non-country regions are covered
-// without a hand-written list of names here.
-function isPlaceName(name: string): boolean {
-    return getRegionByNameOrVariantName(name) !== undefined
-}
-
-// Splits free text into lowercase word tokens, keeping only alphabetic runs
-// (numbers/punctuation are dropped entirely, so "1950-2023" or "(%)" never
-// become spurious "tokens").
-function splitIntoLowercaseWords(text: string): string[] {
-    return text.toLowerCase().match(/[a-z]+/g) ?? []
-}
-
 export type SuggestedChip = {
     key: string
     label: string
     onClick: () => void
 }
 
-function rankByFrequency(
-    counts: Map<string, number>,
-    dimension: SuggestedChipCandidate["dimension"]
-): SuggestedChipCandidate[] {
-    return Array.from(counts.entries())
-        .filter(([, count]) => count >= MIN_SUGGESTED_CHIP_COUNT)
-        .sort(
-            ([nameA, countA], [nameB, countB]) =>
-                countB - countA || nameA.localeCompare(nameB)
-        )
-        .map(([name, count]) => ({ dimension, name, count }))
-}
-
-/**
- * Client-side pass over a topic's full chart list, deriving ~4-5 "suggested
- * search" chips from per-chart data Algolia already returns for this block (see
- * DATA_CATALOG_ATTRIBUTES): significant keywords pulled from each chart's
- * `title`/`subtitle` text, plus its data producers (`datasetProducers`).
- *
- * An earlier version of this used the chart's topic `tags` for its chips, but
- * those tend to read as generic category labels (dataset/producer names, broad
- * sub-topics) rather than the kind of specific, human search term a visitor
- * would actually type — the design brief's own examples ("deaths", "births")
- * are words you'd find in a chart *title*, not in its tag list. Extracting
- * frequent significant words straight from titles/subtitles gets much closer
- * to that: for a topic like "Population Growth", a chart titled "Births and
- * deaths per year" now contributes "births" and "deaths" as candidate chips,
- * rather than a tag like "Life Expectancy" or a producer like "UN WPP".
- *
- * Places are deliberately not suggested. Chips used to include up to two of
- * the countries a topic's charts have data for, which put names like "China"
- * or "Finland" in a line that otherwise offers ways of narrowing *what* the
- * charts are about, and — being derived from the whole topic rather than from
- * the current query — left an unrelated country sitting there while the
- * visitor searched for a different one. Country entities are no longer counted
- * at all, and any candidate that happens to name a place is dropped (see
- * isPlaceName), so a title mentioning "China" can't reintroduce one through
- * the keyword route either. Searching by country still works — typing one
- * filters the list and preselects that entity in the chart — it just isn't
- * suggested here.
- *
- * Keywords fill the chip budget first, most frequent first, with producers only
- * used to top the list up when there isn't enough keyword variety. That budget
- * is unchanged at MAX_SUGGESTED_CHIPS, so dropping places doesn't shorten the
- * line: the slots the countries used to occupy are backfilled with the next
- * ranked keywords instead. If a topic is small enough that nothing clears the
- * frequency threshold the list comes back empty, and the caller renders no
- * "Suggested:" line at all.
- */
-function computeAutoSuggestedChips(
-    hits: SearchChartHit[],
-    topicName: string
-): SuggestedChipCandidate[] {
-    if (hits.length === 0) return []
-
-    const producerCounts = new Map<string, number>()
-    const keywordCounts = new Map<string, number>()
-
-    // Words already in the topic's own name shouldn't turn back around as a
-    // suggested chip — searching "Age" on the "Age Structure" topic page
-    // wouldn't narrow anything down.
-    const topicNameWords = new Set(splitIntoLowercaseWords(topicName))
-
-    for (const hit of hits) {
-        const producersOnChart = new Set(hit.datasetProducers ?? [])
-        for (const producer of producersOnChart) {
-            if (isPlaceName(producer)) continue
-            producerCounts.set(
-                producer,
-                (producerCounts.get(producer) ?? 0) + 1
-            )
-        }
-
-        // Significant words from the chart's own title/subtitle — the most
-        // specific, human-readable description of what the chart actually
-        // shows. Counted as a set per chart (like the producers above) so a
-        // single title repeating a word doesn't outweigh many different
-        // charts mentioning it once each.
-        const text = [hit.title, hit.subtitle].filter(Boolean).join(" ")
-        const keywordsOnChart = new Set(
-            splitIntoLowercaseWords(text).filter(
-                (word) =>
-                    word.length >= MIN_KEYWORD_LENGTH &&
-                    !KEYWORD_STOP_WORDS.has(word) &&
-                    !topicNameWords.has(word) &&
-                    !isPlaceName(word)
-            )
-        )
-        for (const keyword of keywordsOnChart) {
-            keywordCounts.set(keyword, (keywordCounts.get(keyword) ?? 0) + 1)
-        }
-    }
-
-    const topProducers = rankByFrequency(producerCounts, "producer")
-    const topKeywords = rankByFrequency(keywordCounts, "keyword")
-
-    const chips: SuggestedChipCandidate[] = []
-
-    for (const keyword of topKeywords) {
-        if (chips.length >= MAX_SUGGESTED_CHIPS) break
-        chips.push(keyword)
-    }
-
-    for (const producer of topProducers) {
-        if (chips.length >= MAX_SUGGESTED_CHIPS) break
-        chips.push(producer)
-    }
-
-    return chips
-}
-
 export type AllChartsBlockProps = {
     topicName: string
     // Editorially curated search-suggestion chips (from the gdoc block).
-    // Optional — when omitted, chips are auto-generated from the topic's
-    // chart data instead (see `computeAutoSuggestedChips`).
+    // Optional — when omitted, chips come from the topic's OWID vocabulary
+    // terms instead (see `rankSuggestedKeywords`).
     suggested?: string[]
     className?: string
     id?: string
@@ -395,10 +107,9 @@ export const AllChartsBlock = ({
     // Active producer ("source") filters, mirroring the global search's
     // `datasetProducers` facet as a removable pill below the search input.
     // Nothing in this block currently adds to this list — suggested chips
-    // (including producer-derived ones) now populate the search input
-    // instead of applying a structured filter — but the state and its
-    // removal handler stay in place in case a future manually-applied
-    // filter UI needs them.
+    // populate the search input instead of applying a structured filter, and
+    // no longer offer producers at all — but the state and its removal handler
+    // stay in place in case a future manually-applied filter UI needs them.
     const [producerFilters, setProducerFilters] = useState<string[]>([])
     const removeProducerFilter = (producer: string) =>
         setProducerFilters((prev) => prev.filter((p) => p !== producer))
@@ -497,8 +208,8 @@ export const AllChartsBlock = ({
 
     const { data: baseHits, isError: isBaseError } = useQuery({
         queryKey: searchQueryKeys.charts(baseSearchState),
-        // `title`/`subtitle` (used by computeAutoSuggestedChips for its
-        // keyword chips) are already part of the shared
+        // `title`/`subtitle` (used by rankSuggestedKeywords to rank the
+        // topic's vocabulary terms) are already part of the shared
         // DATA_CATALOG_ATTRIBUTES, so no extra attributes need requesting
         // here (contrast the old tag-based chips, which needed an explicit
         // extra `tags` attribute).
@@ -507,9 +218,25 @@ export const AllChartsBlock = ({
         placeholderData: keepPreviousData,
     })
 
-    const autoSuggestedChips = useMemo(
-        () => computeAutoSuggestedChips(baseHits ?? [], topicName),
-        [baseHits, topicName]
+    // The vocabulary is a single file shared by every topic, fetched rather than
+    // bundled so that regenerating it is an upload rather than a deploy (and so
+    // a staging server can be pointed at its own copy). One request per page
+    // load at most: react-query dedupes it across blocks, and the CDN in front
+    // of it caches for 5 minutes.
+    const { data: vocabulary } = useQuery({
+        queryKey: topicVocabularyQueryKey(TOPIC_VOCABULARY_URL),
+        queryFn: fetchTopicVocabulary,
+        staleTime: Infinity,
+    })
+
+    const vocabularyChips = useMemo(
+        () =>
+            rankSuggestedKeywords(
+                vocabulary?.[topicName] ?? [],
+                baseHits ?? [],
+                topicName
+            ),
+        [vocabulary, baseHits, topicName]
     )
 
     // Searching must narrow this list without ever re-ordering it.
@@ -562,37 +289,26 @@ export const AllChartsBlock = ({
 
     // Editorially curated suggestions (set on the gdoc block) take precedence
     // when present, preserving the pre-existing authoring workflow — including
-    // any place name an author has deliberately listed there, which the
-    // auto-generated chips no longer offer (see computeAutoSuggestedChips).
-    // Every chip — curated or auto-generated, keyword or producer — does
-    // exactly one thing when clicked:
-    // populate the search input with its label, so it drives the same
-    // full-text search path as if the visitor had typed it themselves. This
-    // used to differ by dimension (a producer chip applied a structured
-    // `datasetProducers` filter shown as a separate pill below the input
-    // instead), which made suggestion clicks behave inconsistently; now
-    // they're uniform. Chips whose term is already reflected in the current
-    // query/filters are hidden rather than shown a second time.
+    // any term an author has deliberately listed there that the vocabulary
+    // wouldn't offer, a place name among them. Every chip, curated or from the
+    // vocabulary, does exactly one thing when clicked: populate the search
+    // input with its label, so it drives the same full-text search path as if
+    // the visitor had typed it themselves. A vocabulary chip whose term the
+    // visitor has already typed is hidden rather than offered back to them.
     const suggestedChips: SuggestedChip[] = useMemo(() => {
-        if (suggested.length > 0) {
-            return suggested.map((text) => ({
-                key: `query:${text}`,
-                label: text,
-                onClick: () => setQuery(text),
-            }))
-        }
-        return autoSuggestedChips
-            .filter((chip) => {
-                if (chip.dimension === "producer")
-                    return !producerFilters.includes(chip.name)
-                return query.trim().toLowerCase() !== chip.name.toLowerCase()
-            })
-            .map((chip) => ({
-                key: `${chip.dimension}:${chip.name}`,
-                label: chip.name,
-                onClick: () => setQuery(chip.name),
-            }))
-    }, [suggested, autoSuggestedChips, producerFilters, query])
+        const labels =
+            suggested.length > 0
+                ? suggested
+                : vocabularyChips.filter(
+                      (keyword) =>
+                          query.trim().toLowerCase() !== keyword.toLowerCase()
+                  )
+        return labels.map((label) => ({
+            key: `query:${label}`,
+            label,
+            onClick: () => setQuery(label),
+        }))
+    }, [suggested, vocabularyChips, query])
 
     // The heading and the search bar stick to the top of the viewport as a
     // single unit on desktop (see .all-charts-block__sticky-header), which means

--- a/site/AllChartsBlock.tsx
+++ b/site/AllChartsBlock.tsx
@@ -208,11 +208,11 @@ export const AllChartsBlock = ({
 
     const { data: baseHits, isError: isBaseError } = useQuery({
         queryKey: searchQueryKeys.charts(baseSearchState),
-        // `title`/`subtitle` (used by rankSuggestedKeywords to rank the
-        // topic's vocabulary terms) are already part of the shared
-        // DATA_CATALOG_ATTRIBUTES, so no extra attributes need requesting
-        // here (contrast the old tag-based chips, which needed an explicit
-        // extra `tags` attribute).
+        // The row texts rankSuggestedKeywords measures its terms against
+        // (`title`, `subtitle`, `datasetProducers` — see getChartHitRowTexts)
+        // are already part of the shared DATA_CATALOG_ATTRIBUTES, so no extra
+        // attributes need requesting here (contrast the old tag-based chips,
+        // which needed an explicit extra `tags` attribute).
         queryFn: () => queryAllCharts(liteSearchClient, baseSearchState),
         enabled: Boolean(topicName),
         placeholderData: keepPreviousData,

--- a/site/AllChartsBlock.tsx
+++ b/site/AllChartsBlock.tsx
@@ -232,7 +232,7 @@ export const AllChartsBlock = ({
     const vocabularyChips = useMemo(
         () =>
             rankSuggestedKeywords(
-                vocabulary?.[topicName] ?? [],
+                vocabulary?.[topicName],
                 baseHits ?? [],
                 topicName
             ),

--- a/site/AllChartsBlock.tsx
+++ b/site/AllChartsBlock.tsx
@@ -21,7 +21,7 @@ import { GrapherWithFallback } from "./GrapherWithFallback.js"
 import { useDocumentContext } from "./gdocs/DocumentContext.js"
 import {
     fetchTopicVocabulary,
-    rankSuggestedKeywords,
+    suggestedKeywords,
     topicVocabularyQueryKey,
 } from "./search/topicVocabulary.js"
 import { getDirectLiteSearchClient } from "./search/searchClients.js"
@@ -74,7 +74,7 @@ export type AllChartsBlockProps = {
     topicName: string
     // Editorially curated search-suggestion chips (from the gdoc block).
     // Optional — when omitted, chips come from the topic's OWID vocabulary
-    // terms instead (see `rankSuggestedKeywords`).
+    // terms instead (see `suggestedKeywords`).
     suggested?: string[]
     className?: string
     id?: string
@@ -189,13 +189,11 @@ export const AllChartsBlock = ({
         placeholderData: keepPreviousData,
     })
 
-    // A second, stable "topic only" query (no text/country/producer filters)
-    // used purely to derive the suggested chips below the search box. Basing
-    // the chips on this baseline rather than the live, filtered `hits` above
-    // means they stay put as shortcuts back into the full list instead of
-    // shrinking or reordering as the visitor narrows their search. When no
-    // filters are active yet (the common initial state), this shares its
-    // cache entry — and network request — with the query above.
+    // A second, stable "topic only" query (no text/country/producer filters).
+    // It fixes the order the rows are listed in, whatever the visitor has typed
+    // — see sortHitsByBaselineOrder below. When no filters are active yet (the
+    // common initial state), this shares its cache entry — and network request
+    // — with the query above.
     const baseSearchState = useMemo(
         () => ({
             query: "",
@@ -208,11 +206,9 @@ export const AllChartsBlock = ({
 
     const { data: baseHits, isError: isBaseError } = useQuery({
         queryKey: searchQueryKeys.charts(baseSearchState),
-        // The row texts rankSuggestedKeywords measures its terms against
-        // (`title`, `subtitle`, `datasetProducers` — see getChartHitRowTexts)
-        // are already part of the shared DATA_CATALOG_ATTRIBUTES, so no extra
-        // attributes need requesting here (contrast the old tag-based chips,
-        // which needed an explicit extra `tags` attribute).
+        // Every attribute this needs is part of the shared
+        // DATA_CATALOG_ATTRIBUTES, so nothing extra is requested here
+        // (contrast the old tag-based chips, which needed `tags`).
         queryFn: () => queryAllCharts(liteSearchClient, baseSearchState),
         enabled: Boolean(topicName),
         placeholderData: keepPreviousData,
@@ -229,9 +225,12 @@ export const AllChartsBlock = ({
         staleTime: Infinity,
     })
 
+    // Shown in the order the vocabulary publishes them — see suggestedKeywords.
+    // Independent of the chart list, so the line appears as soon as the
+    // vocabulary does rather than waiting for a second request.
     const vocabularyChips = useMemo(
-        () => rankSuggestedKeywords(vocabulary?.[topicName], baseHits ?? []),
-        [vocabulary, baseHits, topicName]
+        () => suggestedKeywords(vocabulary?.[topicName]),
+        [vocabulary, topicName]
     )
 
     // Searching must narrow this list without ever re-ordering it.
@@ -241,8 +240,8 @@ export const AllChartsBlock = ({
     // block that reads as the rows jumping around unprompted while you type,
     // so the block's *default* order is pinned instead: rows always appear in
     // the relative order they have in `baseHits`, the unfiltered topic-only
-    // result set already fetched above for the suggested chips (so this needs
-    // no extra request). That holds for every query — a country, a keyword, or
+    // result set fetched above (so this needs no extra request). That holds for
+    // every query — a country, a keyword, or
     // a half-typed prefix on the way to either — because a prefix like "chi"
     // is just as much a query as "china" is, and an order that only settles
     // once the text happens to resolve to something recognised is exactly the

--- a/site/AllChartsBlock.tsx
+++ b/site/AllChartsBlock.tsx
@@ -35,7 +35,7 @@ import {
     getEntityQueryStr,
     extractFiltersFromQuery,
     pickEntitiesForChartHit,
-    filterChartHitsByPhrase,
+    filterChartHitsByQueryWords,
     removeMatchedWordsWithStopWords,
     splitIntoWords,
     sortHitsByBaselineOrder,
@@ -262,18 +262,18 @@ export const AllChartsBlock = ({
     // read as new rows and land at the bottom of the list — the top of the
     // list appearing to empty out. See getChartHitIdentity.
     //
-    // The rows are also narrowed to the ones whose own text contains the typed
-    // phrase, which is a "find" within the topic rather than a relevance search:
+    // The rows are also narrowed to the ones whose own text contains every word
+    // typed, which is a "find" within the topic rather than a relevance search:
     // Algolia requires every word of the query to appear *somewhere* in a
     // record, but each word may come from a different searchable attribute (tags,
-    // producers, entity names, the slug) and may be a typo away from what was
-    // typed, so "national poverty line" came back with 34 charts on the Poverty
-    // topic — including "Mean income or consumption per day", which contains
-    // none of the three words. See filterChartHitsByPhrase for the mechanism and
-    // for why the narrowing happens here rather than in the query.
+    // producers, entity names, the slug) and may be a typo or a synonym away from
+    // what was typed, so "national poverty line" came back with 34 charts on the
+    // Poverty topic — including "Mean income or consumption per day", which
+    // contains none of the three words. See filterChartHitsByQueryWords for the
+    // mechanism and for why the narrowing happens here rather than in the query.
     const isBaselinePending = !baseHits && !isBaseError
     const hits = useMemo(() => {
-        const rawHits = filterChartHitsByPhrase(data ?? [], searchPhrase)
+        const rawHits = filterChartHitsByQueryWords(data ?? [], searchPhrase)
         // No baseline and none coming: with nothing to pin the order to, fall
         // back to Algolia's order rather than blanking the block for good. No
         // later reshuffle can follow, since no baseline will arrive.

--- a/site/search/queries.ts
+++ b/site/search/queries.ts
@@ -32,6 +32,7 @@ import {
     buildChartsFacetFilters,
     searchSingleForHits,
     searchSingleForHitsWithClosestMatches,
+    MAX_FACET_VALUES,
 } from "@ourworldindata/utils"
 import { RichDataComponentVariant } from "./SearchChartHitRichDataTypes.js"
 
@@ -466,6 +467,16 @@ export async function queryLatestPages(
             offset: 0,
             length: 0,
             facets: ["tags"],
+            // Algolia returns at most 100 values per facet unless asked for
+            // more, and this index carries appreciably more topic tags than
+            // that. Today the caller only looks up the tag graph's ~10
+            // top-level areas, all of which are common enough to survive the
+            // truncation, so nothing is visibly wrong — but a tag absent from
+            // these counts reads as "0 results" and disables its pill (see
+            // LatestSearch), and the same hook already exposes the full
+            // searchable-topic list next to the areas. Ask for the lot rather
+            // than leave that waiting to happen.
+            maxValuesPerFacet: MAX_FACET_VALUES,
         },
     ]
 

--- a/site/search/searchUtils.test.ts
+++ b/site/search/searchUtils.test.ts
@@ -13,8 +13,8 @@ import {
     getChartHitIdentity,
     getVisibleChartHits,
     hasHiddenChartHits,
-    filterChartHitsByPhrase,
-    textContainsPhrase,
+    filterChartHitsByQueryWords,
+    textContainsAllQueryWords,
     ALL_CHARTS_INITIAL_ROW_COUNT,
 } from "./searchUtils"
 
@@ -1161,7 +1161,7 @@ describe(resolveSelectedChartIndex, () => {
     })
 })
 
-describe(filterChartHitsByPhrase, () => {
+describe(filterChartHitsByQueryWords, () => {
     // The rows the Poverty topic returned for "national poverty line", with the
     // text each row actually shows. The first four are the charts the search is
     // asking for; the rest are what Algolia added because each word of the query
@@ -1212,7 +1212,7 @@ describe(filterChartHitsByPhrase, () => {
 
     it("keeps only the rows whose own text contains the whole phrase", () => {
         expect(
-            filterChartHitsByPhrase(povertyHits, "national poverty line")
+            filterChartHitsByQueryWords(povertyHits, "national poverty line")
         ).toEqual([nationalPovertyLine, nationalPovertyLinesPlural])
     })
 
@@ -1220,7 +1220,7 @@ describe(filterChartHitsByPhrase, () => {
         // "national poverty lines" is the most relevant chart of all for this
         // search, and Algolia's own "exactPhrase" operator drops it.
         expect(
-            filterChartHitsByPhrase(
+            filterChartHitsByQueryWords(
                 [nationalPovertyLinesPlural],
                 "national poverty line"
             )
@@ -1231,44 +1231,53 @@ describe(filterChartHitsByPhrase, () => {
         // "International Poverty Line" contains "national poverty line" as a
         // substring, but "international" is not the word that was typed.
         expect(
-            filterChartHitsByPhrase([extremePoverty], "national poverty line")
+            filterChartHitsByQueryWords(
+                [extremePoverty],
+                "national poverty line"
+            )
         ).toEqual([])
         // Whereas the phrase the row does show is found.
         expect(
-            filterChartHitsByPhrase(
+            filterChartHitsByQueryWords(
                 [extremePoverty],
                 "international poverty line"
             )
         ).toEqual([extremePoverty])
     })
 
-    it("requires the words to be adjacent, not merely all present", () => {
+    it("never gathers a query's words from more than one of a row's fields", () => {
         // Every word of the query appears on this row — across the title, the
-        // subtitle and the producer list — but never as the phrase.
+        // subtitle and the producer list — but no single one of them holds them
+        // all. That boundary, not word adjacency, is what keeps the noise out.
         expect(
-            filterChartHitsByPhrase(
+            filterChartHitsByQueryWords(
                 [meanIncome],
                 "united nations poverty platform"
             )
         ).toEqual([])
     })
 
-    it("never matches a phrase across two separate fields", () => {
-        // The title ends with "emissions" and the subtitle opens with "per
-        // capita", so the concatenation of the two contains "emissions per
-        // capita" although neither line does.
+    it("matches the words in any order, and with words in between", () => {
+        // Requiring adjacency rejected rows that plainly answer the query: this
+        // is the shape that made "clean cooking" find nothing on Air Pollution,
+        // whose charts all read "access to clean fuels *for* cooking".
         const methane = {
             slug: "per-capita-methane-emissions",
             title: "Per capita methane emissions",
-            subtitle: "Per capita methane emissions are measured in tonnes.",
+            subtitle: "Measured in tonnes.",
             datasetProducers: ["Climate Watch"],
         }
         expect(
-            filterChartHitsByPhrase([methane], "emissions per capita")
-        ).toEqual([])
-        expect(
-            filterChartHitsByPhrase([methane], "per capita methane")
+            filterChartHitsByQueryWords([methane], "emissions per capita")
         ).toEqual([methane])
+        expect(
+            filterChartHitsByQueryWords([methane], "methane capita")
+        ).toEqual([methane])
+        // …but the words still have to share a field: "emissions" is only in the
+        // title and "tonnes" only in the subtitle.
+        expect(
+            filterChartHitsByQueryWords([methane], "emissions tonnes")
+        ).toEqual([])
     })
 
     it("finds subscript digits typed as plain ones", () => {
@@ -1279,14 +1288,16 @@ describe(filterChartHitsByPhrase, () => {
             subtitle: "Carbon dioxide (CO₂) emissions from fossil fuels.",
             datasetProducers: ["Global Carbon Project"],
         }
-        expect(filterChartHitsByPhrase([co2], "co2 emissions")).toEqual([co2])
+        expect(filterChartHitsByQueryWords([co2], "co2 emissions")).toEqual([
+            co2,
+        ])
         expect(
-            filterChartHitsByPhrase([co2], "co₂ emissions per capita")
+            filterChartHitsByQueryWords([co2], "co₂ emissions per capita")
         ).toEqual([co2])
     })
 
     it("matches the source line as well as the title and subtitle", () => {
-        expect(filterChartHitsByPhrase(povertyHits, "world bank")).toEqual(
+        expect(filterChartHitsByQueryWords(povertyHits, "world bank")).toEqual(
             povertyHits
         )
     })
@@ -1300,7 +1311,7 @@ describe(filterChartHitsByPhrase, () => {
             "national poverty l",
             "national poverty line",
         ])
-            expect(filterChartHitsByPhrase(povertyHits, prefix)).toEqual([
+            expect(filterChartHitsByQueryWords(povertyHits, prefix)).toEqual([
                 nationalPovertyLine,
                 nationalPovertyLinesPlural,
             ])
@@ -1311,10 +1322,16 @@ describe(filterChartHitsByPhrase, () => {
         // empty, or consists only of a country name — which filters by the
         // entity facet instead, and must not additionally require the country's
         // name to be printed on the row.
-        expect(filterChartHitsByPhrase(povertyHits, "")).toEqual(povertyHits)
-        expect(filterChartHitsByPhrase(povertyHits, "   ")).toEqual(povertyHits)
+        expect(filterChartHitsByQueryWords(povertyHits, "")).toEqual(
+            povertyHits
+        )
+        expect(filterChartHitsByQueryWords(povertyHits, "   ")).toEqual(
+            povertyHits
+        )
         // Punctuation-only input normalises to no words at all.
-        expect(filterChartHitsByPhrase(povertyHits, "-")).toEqual(povertyHits)
+        expect(filterChartHitsByQueryWords(povertyHits, "-")).toEqual(
+            povertyHits
+        )
     })
 
     it("drops every hit for a misspelled phrase", () => {
@@ -1322,34 +1339,42 @@ describe(filterChartHitsByPhrase, () => {
         // the typo-matched hits, but none of them shows the typed phrase, so the
         // block falls through to its empty state ("Search all charts").
         expect(
-            filterChartHitsByPhrase(povertyHits, "national povery line")
+            filterChartHitsByQueryWords(povertyHits, "national povery line")
         ).toEqual([])
     })
 })
 
-describe(textContainsPhrase, () => {
+describe(textContainsAllQueryWords, () => {
     it("ignores case, punctuation and repeated whitespace", () => {
         expect(
-            textContainsPhrase(
+            textContainsAllQueryWords(
                 "Share of population living\nin poverty",
                 "IN POVERTY"
             )
         ).toBe(true)
         expect(
-            textContainsPhrase("Poverty: share of population", "poverty share")
+            textContainsAllQueryWords(
+                "Poverty: share of population",
+                "poverty share"
+            )
         ).toBe(true)
     })
 
     it("matches at the start and at the end of the text", () => {
-        expect(textContainsPhrase("Annual CO₂ emissions", "annual")).toBe(true)
         expect(
-            textContainsPhrase("Annual CO₂ emissions", "co2 emissions")
+            textContainsAllQueryWords("Annual CO₂ emissions", "annual")
+        ).toBe(true)
+        expect(
+            textContainsAllQueryWords("Annual CO₂ emissions", "co2 emissions")
         ).toBe(true)
     })
 
     it("returns false when the text runs out mid-phrase", () => {
         expect(
-            textContainsPhrase("Annual CO₂ emissions", "emissions by sector")
+            textContainsAllQueryWords(
+                "Annual CO₂ emissions",
+                "emissions by sector"
+            )
         ).toBe(false)
     })
 })

--- a/site/search/searchUtils.tsx
+++ b/site/search/searchUtils.tsx
@@ -125,7 +125,7 @@ export function getChartHitIdentity(hit: ChartHitIdentityFields): string {
     return `${hit.slug}${hit.queryParams ?? ""}`
 }
 
-export type ChartHitPhraseFields = {
+export type ChartHitMatchFields = {
     title?: string
     subtitle?: string
     datasetProducers?: string[]
@@ -134,17 +134,19 @@ export type ChartHitPhraseFields = {
 /**
  * The text of a chart hit as the all-charts block actually renders it: the row's
  * title, its subtitle, and each producer named in its "Source:" line — kept as
- * separate strings rather than joined, so a phrase can never be matched across
- * the boundary between two of them. (Concatenated, a row titled "Per capita
- * methane emissions" whose subtitle opens "Per capita …" would match the phrase
- * "emissions per capita", which appears nowhere on it.)
+ * separate strings rather than joined, so a query can never be satisfied by
+ * words gathered from two of them. That boundary is what keeps the matching
+ * honest now that the words need not be adjacent: "united nations poverty
+ * platform" finds every one of its words on a row about mean income — "poverty"
+ * and "platform" in its producer, "nations" in another field — but never all of
+ * them in the same one.
  *
  * Deliberately *only* the visible text. The index makes far more searchable than
  * this — `slug`, `tags`, `datasetProducers`, `availableEntities` — and matching a
  * typed phrase against fields the row doesn't show is exactly what makes results
- * look arbitrary (see filterChartHitsByPhrase).
+ * look arbitrary (see filterChartHitsByQueryWords).
  */
-function getChartHitRowTexts(hit: ChartHitPhraseFields): string[] {
+function getChartHitRowTexts(hit: ChartHitMatchFields): string[] {
     return [
         hit.title ?? "",
         hit.subtitle ?? "",
@@ -166,19 +168,19 @@ function getChartHitRowTexts(hit: ChartHitPhraseFields): string[] {
  * *spaces* into separators: a newline or tab is instead removed as punctuation,
  * which would weld the words on either side of it into one.
  */
-function splitIntoPhraseMatchWords(text: string): string[] {
+function splitIntoMatchWords(text: string): string[] {
     return slugify(text.replace(/\s+/g, " "))
         .split("-")
         .filter((word) => word !== "")
 }
 
 /**
- * True when `text` contains `phrase` as a run of consecutive whole words, with
- * the last word of the phrase allowed to match a prefix.
+ * True when every word of `query` appears in `text`, in any order, with the last
+ * word of the query allowed to match a prefix.
  *
  * Whole words, not raw substrings: a substring test would report
  * "national poverty line" as found in "…below the International Poverty Line",
- * which is how a search for the phrase ends up returning charts about extreme
+ * which is how a search for those words ends up returning charts about extreme
  * poverty (17 of them on the Poverty topic).
  *
  * Prefix on the final word only, which covers two things at once: the visitor is
@@ -187,36 +189,37 @@ function splitIntoPhraseMatchWords(text: string): string[] {
  * the chart titled "Share of population living below national poverty lines",
  * which is the single most relevant result for that search and which Algolia's
  * own `"exactPhrase"` operator drops.
+ *
+ * Any order, and with gaps allowed, because requiring the words to be adjacent
+ * rejected rows that plainly answer the query: "clean cooking" found nothing on
+ * Air Pollution, whose charts all say "access to clean fuels *for* cooking", and
+ * "emissions per capita" missed a row titled "Per capita methane emissions".
+ * What stops this from letting the noise back in is not adjacency but the field
+ * boundary — every word has to be in *one* of the row's texts, and the row's
+ * texts are only what it displays. See getChartHitRowTexts and
+ * filterChartHitsByQueryWords.
  */
-export function textContainsPhrase(text: string, phrase: string): boolean {
-    const phraseWords = splitIntoPhraseMatchWords(phrase)
-    if (phraseWords.length === 0) return true
+export function textContainsAllQueryWords(
+    text: string,
+    query: string
+): boolean {
+    const queryWords = splitIntoMatchWords(query)
+    if (queryWords.length === 0) return true
 
-    const textWords = splitIntoPhraseMatchWords(text)
-    const leadingWords = phraseWords.slice(0, -1)
-    const lastWord = phraseWords[phraseWords.length - 1]
+    const textWords = splitIntoMatchWords(text)
+    const leadingWords = queryWords.slice(0, -1)
+    const lastWord = queryWords[queryWords.length - 1]
 
-    for (
-        let start = 0;
-        start + phraseWords.length <= textWords.length;
-        start++
-    ) {
-        const leadingWordsMatch = leadingWords.every(
-            (word, offset) => textWords[start + offset] === word
-        )
-        if (
-            leadingWordsMatch &&
-            textWords[start + leadingWords.length].startsWith(lastWord)
-        )
-            return true
-    }
-    return false
+    return (
+        leadingWords.every((word) => textWords.includes(word)) &&
+        textWords.some((word) => word.startsWith(lastWord))
+    )
 }
 
 /**
- * Keeps only the hits whose own visible text contains `phrase` — the
+ * Keeps only the hits whose own visible text contains every word of `query` — the
  * "find"-like narrowing the all-charts block applies on top of its Algolia
- * results (site/AllChartsBlock.tsx). An empty phrase keeps everything.
+ * results (site/AllChartsBlock.tsx). An empty query keeps everything.
  *
  * Why the block needs this at all: Algolia does require every word of the query
  * to be present, but each word may be found in a *different* searchable
@@ -230,18 +233,18 @@ export function textContainsPhrase(text: string, phrase: string): boolean {
  *
  * The filter runs client-side rather than as a query parameter for two reasons:
  * Algolia's `"exactPhrase"` operator is token-exact, so quoting the query drops
- * the plural-titled chart (see textContainsPhrase); and the caller already holds
+ * the plural-titled chart (see textContainsAllQueryWords); and the caller already holds
  * the complete result set for its topic (queryAllCharts walks every page), so
  * narrowing it locally can't hide a match on a page that wasn't fetched.
  */
-export function filterChartHitsByPhrase<T extends ChartHitPhraseFields>(
+export function filterChartHitsByQueryWords<T extends ChartHitMatchFields>(
     hits: readonly T[],
-    phrase: string
+    query: string
 ): T[] {
-    if (splitIntoPhraseMatchWords(phrase).length === 0) return [...hits]
+    if (splitIntoMatchWords(query).length === 0) return [...hits]
     return hits.filter((hit) =>
         getChartHitRowTexts(hit).some((text) =>
-            textContainsPhrase(text, phrase)
+            textContainsAllQueryWords(text, query)
         )
     )
 }

--- a/site/search/topicVocabulary.ts
+++ b/site/search/topicVocabulary.ts
@@ -1,0 +1,169 @@
+import { SearchChartHit } from "@ourworldindata/types"
+import {
+    DEFAULT_TOPIC_VOCABULARY_URL,
+    TOPIC_VOCABULARY_URL,
+} from "../../settings/clientSettings.js"
+
+// The vocabulary as published: keyed by topic slug, each entry carrying the
+// topic's name, its keywords, and generation stats we have no use for here.
+interface PublishedTopicVocabularyEntry {
+    topic_name?: string
+    keywords?: string[]
+}
+
+/** Topic name → the vocabulary's search terms for that topic. */
+export type TopicVocabulary = Record<string, string[]>
+
+export const topicVocabularyQueryKey = (url: string): [string, string] => [
+    "topicVocabulary",
+    url,
+]
+
+/**
+ * Re-keys the published vocabulary by topic *name*.
+ *
+ * It is published keyed by slug, because that's what generated it, but its
+ * consumers know a topic by the tag name their gdoc carries — an all-charts
+ * block receives only `topicName`, and builds its Algolia filter from that name
+ * too. Every topic tag with a published chart has exactly one entry whose
+ * `topic_name` matches that tag's name, since both sides come from `tags.name`.
+ *
+ * Entries are read defensively: this is a file in a bucket, regenerated out of
+ * band by a script in another repo (and pointed at a different key entirely on
+ * a staging server), so a malformed or half-written entry should cost that one
+ * topic its suggestions rather than throw inside a render.
+ */
+export function indexTopicVocabularyByName(data: unknown): TopicVocabulary {
+    if (typeof data !== "object" || data === null) return {}
+
+    const vocabulary: TopicVocabulary = {}
+    for (const entry of Object.values(data)) {
+        const { topic_name: topicName, keywords } =
+            (entry as PublishedTopicVocabularyEntry) ?? {}
+        if (typeof topicName !== "string" || !topicName) continue
+        if (!Array.isArray(keywords)) continue
+        vocabulary[topicName] = keywords.filter(
+            (keyword): keyword is string =>
+                typeof keyword === "string" && keyword.length > 0
+        )
+    }
+    return vocabulary
+}
+
+async function fetchVocabularyFrom(url: string): Promise<TopicVocabulary> {
+    const response = await fetch(url)
+    if (!response.ok)
+        throw new Error(
+            `Failed to fetch the topic vocabulary from ${url}: ${response.status}`
+        )
+    return indexTopicVocabularyByName(await response.json())
+}
+
+/**
+ * Fetches the topic vocabulary, falling back to the production one when a
+ * staging server has been pointed at a key that isn't there (see
+ * TOPIC_VOCABULARY_URL). Suggestions are a nice-to-have on the page, so an
+ * override that hasn't been generated yet should leave them looking like
+ * production rather than empty.
+ */
+export async function fetchTopicVocabulary(): Promise<TopicVocabulary> {
+    try {
+        return await fetchVocabularyFrom(TOPIC_VOCABULARY_URL)
+    } catch (error) {
+        if (TOPIC_VOCABULARY_URL === DEFAULT_TOPIC_VOCABULARY_URL) throw error
+        console.warn(
+            `${String(error)} — falling back to ${DEFAULT_TOPIC_VOCABULARY_URL}`
+        )
+        return await fetchVocabularyFrom(DEFAULT_TOPIC_VOCABULARY_URL)
+    }
+}
+
+const MAX_SUGGESTED_CHIPS = 5
+
+// How far down a topic's vocabulary list to look for candidates.
+//
+// The vocabulary lists its terms roughly most- to least-central to the topic,
+// and that ordering carries real judgment: the deeper terms drift towards the
+// broad and obvious. Ranking the *whole* list by chart coverage below therefore
+// hands the line straight back to the generic words this replaced, because
+// "Men" and "Women" sit late in the Gender Ratio list but occur in far more of
+// its charts than "Sex-selective abortion" does — at a cap of 20 that topic
+// suggests "Men, Sex ratio, Missing women", and uncapped it opens with "Men,
+// Women". Cutting the pool first keeps the two signals in their proper order:
+// the vocabulary decides which terms are worth suggesting at all, coverage only
+// decides between the ones that are. Measured over every topic, 12 leaves just
+// two whose line opens on a word that generic, while still offering more than
+// twice the candidates there are slots.
+const MAX_VOCABULARY_CANDIDATES = 12
+
+/**
+ * Picks the all-charts block's "Suggested:" terms for a topic out of the
+ * vocabulary's terms for it.
+ *
+ * The block used to derive these itself, by counting word frequencies across
+ * the topic's chart titles and subtitles and offering the commonest words. That
+ * reliably surfaced a topic's filler rather than its subject matter — Gender
+ * Ratio suggested "women, sex, birth, men, female" — and, a frequency count
+ * having no notion of a phrase or a word form, it would offer "births" and
+ * "birth" side by side, or a word like "have" that the hand-written stop-word
+ * list hadn't anticipated. The vocabulary is the same source material read by
+ * something that understands it, so that topic now offers "Sex ratio, Missing
+ * women, Sex discrimination, Sex-selective abortion" — multi-word terms among
+ * them, which the old tokeniser could not represent at all.
+ *
+ * The vocabulary lists more candidates per topic than there are slots, so
+ * `hits` decides which of the leading MAX_VOCABULARY_CANDIDATES make the line. A term that occurs in more of the
+ * topic's charts describes more of the list the visitor is looking at, and is
+ * likelier to lead somewhere: a chip runs a search, so one that matches nothing
+ * is a dead end. Terms found in the charts' own text therefore come first,
+ * most-matched first, and terms found nowhere in it fill whatever slots are
+ * left rather than shortening the line — Algolia matches far more generously
+ * than the substring test here does, so "found nowhere" means unproven, not
+ * useless.
+ *
+ * Comes back empty while either the baseline chart list or the vocabulary is
+ * still in flight (the caller then renders no "Suggested:" line at all) rather
+ * than showing an unranked guess that would visibly reshuffle a moment later.
+ */
+export function rankSuggestedKeywords(
+    vocabularyKeywords: string[],
+    hits: SearchChartHit[],
+    topicName: string
+): string[] {
+    if (hits.length === 0) return []
+
+    const lowerCaseTopicName = topicName.toLowerCase()
+    const keywords = vocabularyKeywords
+        .slice(0, MAX_VOCABULARY_CANDIDATES)
+        .filter(
+            // A term the topic's own name already contains ("population" on
+            // "Population Growth") narrows nothing down.
+            (keyword) => !lowerCaseTopicName.includes(keyword.toLowerCase())
+        )
+    if (keywords.length === 0) return []
+
+    const chartTexts = hits.map((hit) =>
+        [hit.title, hit.subtitle].filter(Boolean).join(" ").toLowerCase()
+    )
+
+    const matched: { keyword: string; count: number }[] = []
+    const unmatched: string[] = []
+    for (const keyword of keywords) {
+        const lowerCaseKeyword = keyword.toLowerCase()
+        const count = chartTexts.filter((text) =>
+            text.includes(lowerCaseKeyword)
+        ).length
+        if (count > 0) matched.push({ keyword, count })
+        else unmatched.push(keyword)
+    }
+
+    // `sort` is stable, so terms matching the same number of charts keep the
+    // order the vocabulary listed them in instead of being shuffled against
+    // each other.
+    matched.sort((a, b) => b.count - a.count)
+
+    return [...matched.map(({ keyword }) => keyword), ...unmatched].slice(
+        0,
+        MAX_SUGGESTED_CHIPS
+    )
+}

--- a/site/search/topicVocabulary.ts
+++ b/site/search/topicVocabulary.ts
@@ -10,10 +10,22 @@ import {
 interface PublishedTopicVocabularyEntry {
     topic_name?: string
     keywords?: string[]
+    stats?: { refined?: boolean }
 }
 
-/** Topic name → the vocabulary's search terms for that topic. */
-export type TopicVocabulary = Record<string, string[]>
+export interface TopicVocabularyEntry {
+    keywords: string[]
+    /**
+     * Whether the generator checked each term against the site's search and
+     * re-picked the list from what came back, rather than proposing it from
+     * chart text alone. When it did, its ordering is better informed than
+     * anything this file can work out — see rankSuggestedKeywords.
+     */
+    refined: boolean
+}
+
+/** Topic name → the vocabulary's entry for that topic. */
+export type TopicVocabulary = Record<string, TopicVocabularyEntry>
 
 export const topicVocabularyQueryKey = (url: string): [string, string] => [
     "topicVocabulary",
@@ -38,15 +50,19 @@ export function indexTopicVocabularyByName(data: unknown): TopicVocabulary {
     if (typeof data !== "object" || data === null) return {}
 
     const vocabulary: TopicVocabulary = {}
-    for (const entry of Object.values(data)) {
+    for (const entry_ of Object.values(data)) {
         const { topic_name: topicName, keywords } =
-            (entry as PublishedTopicVocabularyEntry) ?? {}
+            (entry_ as PublishedTopicVocabularyEntry) ?? {}
         if (typeof topicName !== "string" || !topicName) continue
         if (!Array.isArray(keywords)) continue
-        vocabulary[topicName] = keywords.filter(
-            (keyword): keyword is string =>
-                typeof keyword === "string" && keyword.length > 0
-        )
+        const entry = entry_ as PublishedTopicVocabularyEntry
+        vocabulary[topicName] = {
+            keywords: keywords.filter(
+                (keyword): keyword is string =>
+                    typeof keyword === "string" && keyword.length > 0
+            ),
+            refined: entry.stats?.refined === true,
+        }
     }
     return vocabulary
 }
@@ -142,27 +158,44 @@ function isPlaceName(name: string): boolean {
  * substring test here does, so "found nowhere" means unproven, while "reaches
  * only what's already covered" is a duplicate for certain.
  *
- * Comes back empty while either the baseline chart list or the vocabulary is
- * still in flight (the caller then renders no "Suggested:" line at all) rather
- * than showing an unranked guess that would visibly reshuffle a moment later.
+ * None of this applies to a vocabulary the generator has already refined
+ * against the search API: its ordering is better informed than anything
+ * measurable here, so it is taken as given. See the note in the body.
+ *
+ * Comes back empty until the vocabulary arrives, and — for an unrefined
+ * vocabulary only — until the baseline chart list does too, rather than showing
+ * an unranked guess that would visibly reshuffle a moment later.
  */
 export function rankSuggestedKeywords(
-    vocabularyKeywords: string[],
+    entry: TopicVocabularyEntry | undefined,
     hits: SearchChartHit[],
     topicName: string
 ): string[] {
-    if (hits.length === 0) return []
-
     const lowerCaseTopicName = topicName.toLowerCase()
-    const candidates = vocabularyKeywords
-        .slice(0, MAX_VOCABULARY_CANDIDATES)
-        .filter((keyword) => {
-            // A term the topic's own name already contains ("population" on
-            // "Population Growth") narrows nothing down.
-            if (lowerCaseTopicName.includes(keyword.toLowerCase())) return false
-            return !isPlaceName(keyword)
-        })
-    if (candidates.length === 0) return []
+    const offerable = (entry?.keywords ?? []).filter((keyword) => {
+        // A term the topic's own name already contains ("population" on
+        // "Population Growth") narrows nothing down.
+        if (lowerCaseTopicName.includes(keyword.toLowerCase())) return false
+        return !isPlaceName(keyword)
+    })
+    if (offerable.length === 0) return []
+
+    // A refined vocabulary has already been through this exercise with better
+    // evidence: its generator asked the search API what each term actually
+    // returns and re-picked the list from the answers, so its order encodes
+    // real destinations rather than the substring guess below. Second-guessing
+    // it makes the line worse — running the guess over one refined vocabulary
+    // rewrote 115 of 125 topics, dropping "indoor air pollution" and "clean
+    // cooking" from Air Pollution because a chart matching "outdoor air
+    // pollution" contains them as substrings too, when the search shows they
+    // lead somewhere else entirely.
+    //
+    // It also means the line stops waiting on the chart list, since nothing
+    // about the order depends on it any more.
+    if (entry?.refined) return offerable.slice(0, MAX_SUGGESTED_CHIPS)
+
+    if (hits.length === 0) return []
+    const candidates = offerable.slice(0, MAX_VOCABULARY_CANDIDATES)
 
     const chartTexts = hits.map((hit) =>
         [hit.title, hit.subtitle].filter(Boolean).join(" ").toLowerCase()

--- a/site/search/topicVocabulary.ts
+++ b/site/search/topicVocabulary.ts
@@ -1,32 +1,18 @@
-import { SearchChartHit } from "@ourworldindata/types"
 import { getRegionByNameOrVariantName } from "@ourworldindata/utils"
 import {
     DEFAULT_TOPIC_VOCABULARY_URL,
     TOPIC_VOCABULARY_URL,
 } from "../../settings/clientSettings.js"
-import { filterChartHitsByQueryWords } from "./searchUtils.js"
 
 // The vocabulary as published: keyed by topic slug, each entry carrying the
 // topic's name, its keywords, and generation stats we have no use for here.
 interface PublishedTopicVocabularyEntry {
     topic_name?: string
     keywords?: string[]
-    stats?: { refined?: boolean }
 }
 
-export interface TopicVocabularyEntry {
-    keywords: string[]
-    /**
-     * Whether the generator checked each term against the site's search and
-     * re-picked the list from what came back, rather than proposing it from
-     * chart text alone. When it did, its ordering is better informed than
-     * anything this file can work out — see rankSuggestedKeywords.
-     */
-    refined: boolean
-}
-
-/** Topic name → the vocabulary's entry for that topic. */
-export type TopicVocabulary = Record<string, TopicVocabularyEntry>
+/** Topic name → the terms to suggest for it, in the order to suggest them. */
+export type TopicVocabulary = Record<string, string[]>
 
 export const topicVocabularyQueryKey = (url: string): [string, string] => [
     "topicVocabulary",
@@ -51,19 +37,15 @@ export function indexTopicVocabularyByName(data: unknown): TopicVocabulary {
     if (typeof data !== "object" || data === null) return {}
 
     const vocabulary: TopicVocabulary = {}
-    for (const entry_ of Object.values(data)) {
+    for (const entry of Object.values(data)) {
         const { topic_name: topicName, keywords } =
-            (entry_ as PublishedTopicVocabularyEntry) ?? {}
+            (entry as PublishedTopicVocabularyEntry) ?? {}
         if (typeof topicName !== "string" || !topicName) continue
         if (!Array.isArray(keywords)) continue
-        const entry = entry_ as PublishedTopicVocabularyEntry
-        vocabulary[topicName] = {
-            keywords: keywords.filter(
-                (keyword): keyword is string =>
-                    typeof keyword === "string" && keyword.length > 0
-            ),
-            refined: entry.stats?.refined === true,
-        }
+        vocabulary[topicName] = keywords.filter(
+            (keyword): keyword is string =>
+                typeof keyword === "string" && keyword.length > 0
+        )
     }
     return vocabulary
 }
@@ -96,23 +78,6 @@ export async function fetchTopicVocabulary(): Promise<TopicVocabulary> {
     }
 }
 
-const MAX_SUGGESTED_CHIPS = 5
-
-// How far down a topic's vocabulary list to look for candidates.
-//
-// The vocabulary lists its terms roughly most- to least-central to the topic,
-// and that ordering carries real judgment: the deeper terms drift towards the
-// broad and obvious. Ranking the *whole* list therefore risks handing the line
-// back to the generic words this replaced — "Men" and "Women" sit near the end
-// of the published vocabulary's Gender Ratio list but occur in more of its
-// charts than any specific term, so uncapped that topic opens with "Women, Men"
-// instead of "Sex ratio, Missing women". Removing the cap moves 78 of the 125
-// topics' lines and 23 of their opening terms, in that direction. Cutting the
-// pool first keeps the two signals in their proper order: the vocabulary decides
-// which terms are worth suggesting at all, the charts decide between the ones
-// that are.
-const MAX_VOCABULARY_CANDIDATES = 12
-
 // True for anything that names a place: a country, a continent, an aggregate
 // like "World", or a variant name for one of those ("US", "UK"). Suggested
 // searches deliberately don't include places — they offer ways of narrowing
@@ -122,127 +87,37 @@ const MAX_VOCABULARY_CANDIDATES = 12
 // rest of the site uses to recognise one, so variants and non-country regions
 // are covered without a hand-written list of names.
 //
-// The vocabulary is asked not to name places, but it is regenerated out of band
-// by a script in another repo, and successive generations have drifted in and
-// out of offering "United States" or "Ukraine" as a keyword. Enforcing it here
-// keeps that drift out of the page.
+// The vocabulary is asked not to name places, and currently names none, but it
+// is regenerated out of band by a script in another repo and successive
+// generations have drifted in and out of offering "United States" or "Ukraine".
+// Enforcing it here keeps that drift off the page, at the cost of one shorter
+// line on whichever topic drifts.
 function isPlaceName(name: string): boolean {
     return getRegionByNameOrVariantName(name) !== undefined
 }
 
 /**
- * Picks the all-charts block's "Suggested:" terms for a topic out of the
- * vocabulary's terms for it.
+ * The all-charts block's "Suggested:" terms for a topic, in the order they are
+ * shown.
  *
- * The block used to derive these itself, by counting word frequencies across
- * the topic's chart titles and subtitles and offering the commonest words. That
- * reliably surfaced a topic's filler rather than its subject matter — Gender
- * Ratio suggested "women, sex, birth, men, female" — and, a frequency count
- * having no notion of a phrase or a word form, it would offer "births" and
- * "birth" side by side, or a word like "have" that the hand-written stop-word
- * list hadn't anticipated.
+ * The vocabulary decides both which terms those are and what order they go in,
+ * and this deliberately does nothing to either. Its generator
+ * (`scripts/vocabulary/vocabulary.py` in owid/etl) chooses them by measuring
+ * what each one actually reveals of the very chart list this block renders,
+ * weighted by how much each chart is viewed, taking the term that reveals the
+ * most and then whichever adds the most that is still hidden. It publishes as
+ * many as the line shows.
  *
- * The vocabulary offers more candidates than the line has slots, so the topic's
- * own chart list picks between them, on two counts:
+ * This block used to re-rank them, from the topic's default result set, back
+ * when the vocabulary was an unordered pile of ~30 candidates per topic. That
+ * is worth remembering as a thing not to reintroduce: the block can only see
+ * one topic's rows, unweighted, and cannot see what a search would return, so
+ * re-ranking a measured list from here made it worse — it rewrote 100 of 125
+ * topics and 54 of their opening terms, for no gain that could be measured.
  *
- * - **Reach.** A chip runs a search, and the block narrows those results to the
- *   rows whose own visible text contains the query, so a term no row on the page
- *   matches empties the list. Reach is therefore measured with that same filter
- *   (filterChartHitsByQueryWords), a term reaching more rows is offered first,
- *   and a term reaching none is not offered at all.
- * - **Distinctness.** A term is only kept while it reaches a chart the terms
- *   before it didn't. Without this the line spends its slots several times over
- *   on the same destination — Gender Ratio offered "missing women",
- *   "sex-selective abortion" and "excess female mortality", three chips leading
- *   to the same two charts, so five suggestions were really two. Near-synonyms
- *   are hard to spot as text but obvious in what they match, which is why this
- *   is decided here rather than asked of whoever generates the vocabulary.
- *
- * A term held back as a duplicate still fills a leftover slot, since it does
- * lead somewhere; a term that reaches nothing cannot. Measured against the
- * production vocabulary and the live index, 25 of the 620 terms it has been
- * showing (4%) run a search that renders an empty list, and dropping them
- * shortens only 3 topics' lines and empties none.
- *
- * None of this applies to a vocabulary the generator has already refined
- * against the search API: its ordering is better informed than anything
- * measurable here, so it is taken as given. See the note in the body.
- *
- * Comes back empty until the vocabulary arrives, and — for an unrefined
- * vocabulary only — until the baseline chart list does too, rather than showing
- * an unranked guess that would visibly reshuffle a moment later.
+ * Place names are the one exception, and the reason this isn't just a property
+ * access. See isPlaceName.
  */
-export function rankSuggestedKeywords(
-    entry: TopicVocabularyEntry | undefined,
-    hits: SearchChartHit[]
-): string[] {
-    // Only places are refused outright. A term the topic's own name contains was
-    // refused too, on the reasoning that a reader already on the page has
-    // applied it — which is true for most topics and badly wrong for a minority
-    // whose charts are simply called after the topic. Measured over all 125
-    // topics, allowing it changes the median topic's reach by 0.3% and
-    // transforms thirty of them: Religion goes from covering 39% of its topic's
-    // traffic to 97%, Life Expectancy from 21% to 98%, because half of that
-    // topic is one chart titled "Life expectancy" and nothing narrower reaches
-    // it. The generator applies the same rule, and its report shows what each
-    // term reaches, so an over-broad first term is visible rather than guessed
-    // at.
-    //
-    // Filtering before the candidate cap below, so a refused term doesn't eat a
-    // candidate slot. It widens the window a little where a place does sit in
-    // the vocabulary's head, but that is rare (6 terms across 3 topics of 125)
-    // and the one topic whose line it changes is better for it: Poverty ends on
-    // "relative poverty" rather than "nutrition".
-    const offerable = (entry?.keywords ?? []).filter(
-        (keyword) => !isPlaceName(keyword)
-    )
-    if (offerable.length === 0) return []
-
-    // A refined vocabulary has already been through this exercise with better
-    // evidence: its generator asked the search API what each term actually
-    // returns, weighted the results by how much each chart is viewed, and
-    // re-picked the list from the answers. Second-guessing that from the
-    // topic's default list — unweighted, and blind to everything the search
-    // would have found — makes the line worse: re-ranking one refined
-    // vocabulary rewrote 100 of 125 topics and 54 of their opening terms, while
-    // not one of its 541 published terms rendered an empty list.
-    //
-    // It also means the line stops waiting on the chart list, since nothing
-    // about the order depends on it any more.
-    if (entry?.refined) return offerable.slice(0, MAX_SUGGESTED_CHIPS)
-
-    if (hits.length === 0) return []
-    const candidates = offerable.slice(0, MAX_VOCABULARY_CANDIDATES)
-
-    // The rows each term would leave standing, by the block's own filter, so a
-    // term ranked here reaches exactly what clicking it renders. Terms reaching
-    // nothing are dropped rather than offered as a dead end.
-    const matched = candidates
-        .map((keyword) => ({
-            keyword,
-            charts: new Set(filterChartHitsByQueryWords(hits, keyword)),
-        }))
-        .filter(({ charts }) => charts.size > 0)
-
-    // `sort` is stable, so terms reaching the same number of charts keep the
-    // order the vocabulary listed them in instead of being shuffled against
-    // each other.
-    matched.sort((a, b) => b.charts.size - a.charts.size)
-
-    const covered = new Set<SearchChartHit>()
-    const distinct: string[] = []
-    const duplicates: string[] = []
-    for (const { keyword, charts } of matched) {
-        const reachesSomethingNew = [...charts].some(
-            (chart) => !covered.has(chart)
-        )
-        if (!reachesSomethingNew) {
-            duplicates.push(keyword)
-            continue
-        }
-        distinct.push(keyword)
-        for (const chart of charts) covered.add(chart)
-    }
-
-    return [...distinct, ...duplicates].slice(0, MAX_SUGGESTED_CHIPS)
+export function suggestedKeywords(keywords: string[] | undefined): string[] {
+    return (keywords ?? []).filter((keyword) => !isPlaceName(keyword))
 }

--- a/site/search/topicVocabulary.ts
+++ b/site/search/topicVocabulary.ts
@@ -4,6 +4,7 @@ import {
     DEFAULT_TOPIC_VOCABULARY_URL,
     TOPIC_VOCABULARY_URL,
 } from "../../settings/clientSettings.js"
+import { filterChartHitsByQueryWords } from "./searchUtils.js"
 
 // The vocabulary as published: keyed by topic slug, each entry carrying the
 // topic's name, its keywords, and generation stats we have no use for here.
@@ -102,12 +103,14 @@ const MAX_SUGGESTED_CHIPS = 5
 // The vocabulary lists its terms roughly most- to least-central to the topic,
 // and that ordering carries real judgment: the deeper terms drift towards the
 // broad and obvious. Ranking the *whole* list therefore risks handing the line
-// back to the generic words this replaced — "Men" and "Women" sat late in the
-// Gender Ratio list of an earlier vocabulary but occurred in far more of its
-// charts than "Sex-selective abortion" did, and uncapped that topic opened with
-// "Men, Women". Cutting the pool first keeps the two signals in their proper
-// order: the vocabulary decides which terms are worth suggesting at all, the
-// charts decide between the ones that are.
+// back to the generic words this replaced — "Men" and "Women" sit near the end
+// of the published vocabulary's Gender Ratio list but occur in more of its
+// charts than any specific term, so uncapped that topic opens with "Women, Men"
+// instead of "Sex ratio, Missing women". Removing the cap moves 78 of the 125
+// topics' lines and 23 of their opening terms, in that direction. Cutting the
+// pool first keeps the two signals in their proper order: the vocabulary decides
+// which terms are worth suggesting at all, the charts decide between the ones
+// that are.
 const MAX_VOCABULARY_CANDIDATES = 12
 
 // True for anything that names a place: a country, a continent, an aggregate
@@ -142,9 +145,11 @@ function isPlaceName(name: string): boolean {
  * The vocabulary offers more candidates than the line has slots, so the topic's
  * own chart list picks between them, on two counts:
  *
- * - **Reach.** A term occurring in more of the topic's charts describes more of
- *   the list the visitor is looking at, and is likelier to lead somewhere: a
- *   chip runs a search, so one that matches nothing is a dead end.
+ * - **Reach.** A chip runs a search, and the block narrows those results to the
+ *   rows whose own visible text contains the query, so a term no row on the page
+ *   matches empties the list. Reach is therefore measured with that same filter
+ *   (filterChartHitsByQueryWords), a term reaching more rows is offered first,
+ *   and a term reaching none is not offered at all.
  * - **Distinctness.** A term is only kept while it reaches a chart the terms
  *   before it didn't. Without this the line spends its slots several times over
  *   on the same destination — Gender Ratio offered "missing women",
@@ -153,10 +158,11 @@ function isPlaceName(name: string): boolean {
  *   are hard to spot as text but obvious in what they match, which is why this
  *   is decided here rather than asked of whoever generates the vocabulary.
  *
- * Terms found nowhere in the charts' text fill any slots left over, ahead of
- * ones held back as duplicates: Algolia matches far more generously than the
- * substring test here does, so "found nowhere" means unproven, while "reaches
- * only what's already covered" is a duplicate for certain.
+ * A term held back as a duplicate still fills a leftover slot, since it does
+ * lead somewhere; a term that reaches nothing cannot. Measured against the
+ * production vocabulary and the live index, 25 of the 620 terms it has been
+ * showing (4%) run a search that renders an empty list, and dropping them
+ * shortens only 3 topics' lines and empties none.
  *
  * None of this applies to a vocabulary the generator has already refined
  * against the search API: its ordering is better informed than anything
@@ -181,6 +187,12 @@ export function rankSuggestedKeywords(
     // it. The generator applies the same rule, and its report shows what each
     // term reaches, so an over-broad first term is visible rather than guessed
     // at.
+    //
+    // Filtering before the candidate cap below, so a refused term doesn't eat a
+    // candidate slot. It widens the window a little where a place does sit in
+    // the vocabulary's head, but that is rare (6 terms across 3 topics of 125)
+    // and the one topic whose line it changes is better for it: Poverty ends on
+    // "relative poverty" rather than "nutrition".
     const offerable = (entry?.keywords ?? []).filter(
         (keyword) => !isPlaceName(keyword)
     )
@@ -188,13 +200,12 @@ export function rankSuggestedKeywords(
 
     // A refined vocabulary has already been through this exercise with better
     // evidence: its generator asked the search API what each term actually
-    // returns and re-picked the list from the answers, so its order encodes
-    // real destinations rather than the substring guess below. Second-guessing
-    // it makes the line worse — running the guess over one refined vocabulary
-    // rewrote 115 of 125 topics, dropping "indoor air pollution" and "clean
-    // cooking" from Air Pollution because a chart matching "outdoor air
-    // pollution" contains them as substrings too, when the search shows they
-    // lead somewhere else entirely.
+    // returns, weighted the results by how much each chart is viewed, and
+    // re-picked the list from the answers. Second-guessing that from the
+    // topic's default list — unweighted, and blind to everything the search
+    // would have found — makes the line worse: re-ranking one refined
+    // vocabulary rewrote 100 of 125 topics and 54 of their opening terms, while
+    // not one of its 541 published terms rendered an empty list.
     //
     // It also means the line stops waiting on the chart list, since nothing
     // about the order depends on it any more.
@@ -203,28 +214,22 @@ export function rankSuggestedKeywords(
     if (hits.length === 0) return []
     const candidates = offerable.slice(0, MAX_VOCABULARY_CANDIDATES)
 
-    const chartTexts = hits.map((hit) =>
-        [hit.title, hit.subtitle].filter(Boolean).join(" ").toLowerCase()
-    )
-
-    const matched: { keyword: string; charts: Set<number> }[] = []
-    const unmatched: string[] = []
-    for (const keyword of candidates) {
-        const lowerCaseKeyword = keyword.toLowerCase()
-        const charts = new Set<number>()
-        chartTexts.forEach((text, index) => {
-            if (text.includes(lowerCaseKeyword)) charts.add(index)
-        })
-        if (charts.size > 0) matched.push({ keyword, charts })
-        else unmatched.push(keyword)
-    }
+    // The rows each term would leave standing, by the block's own filter, so a
+    // term ranked here reaches exactly what clicking it renders. Terms reaching
+    // nothing are dropped rather than offered as a dead end.
+    const matched = candidates
+        .map((keyword) => ({
+            keyword,
+            charts: new Set(filterChartHitsByQueryWords(hits, keyword)),
+        }))
+        .filter(({ charts }) => charts.size > 0)
 
     // `sort` is stable, so terms reaching the same number of charts keep the
     // order the vocabulary listed them in instead of being shuffled against
     // each other.
     matched.sort((a, b) => b.charts.size - a.charts.size)
 
-    const covered = new Set<number>()
+    const covered = new Set<SearchChartHit>()
     const distinct: string[] = []
     const duplicates: string[] = []
     for (const { keyword, charts } of matched) {
@@ -239,8 +244,5 @@ export function rankSuggestedKeywords(
         for (const chart of charts) covered.add(chart)
     }
 
-    return [...distinct, ...unmatched, ...duplicates].slice(
-        0,
-        MAX_SUGGESTED_CHIPS
-    )
+    return [...distinct, ...duplicates].slice(0, MAX_SUGGESTED_CHIPS)
 }

--- a/site/search/topicVocabulary.ts
+++ b/site/search/topicVocabulary.ts
@@ -168,16 +168,22 @@ function isPlaceName(name: string): boolean {
  */
 export function rankSuggestedKeywords(
     entry: TopicVocabularyEntry | undefined,
-    hits: SearchChartHit[],
-    topicName: string
+    hits: SearchChartHit[]
 ): string[] {
-    const lowerCaseTopicName = topicName.toLowerCase()
-    const offerable = (entry?.keywords ?? []).filter((keyword) => {
-        // A term the topic's own name already contains ("population" on
-        // "Population Growth") narrows nothing down.
-        if (lowerCaseTopicName.includes(keyword.toLowerCase())) return false
-        return !isPlaceName(keyword)
-    })
+    // Only places are refused outright. A term the topic's own name contains was
+    // refused too, on the reasoning that a reader already on the page has
+    // applied it — which is true for most topics and badly wrong for a minority
+    // whose charts are simply called after the topic. Measured over all 125
+    // topics, allowing it changes the median topic's reach by 0.3% and
+    // transforms thirty of them: Religion goes from covering 39% of its topic's
+    // traffic to 97%, Life Expectancy from 21% to 98%, because half of that
+    // topic is one chart titled "Life expectancy" and nothing narrower reaches
+    // it. The generator applies the same rule, and its report shows what each
+    // term reaches, so an over-broad first term is visible rather than guessed
+    // at.
+    const offerable = (entry?.keywords ?? []).filter(
+        (keyword) => !isPlaceName(keyword)
+    )
     if (offerable.length === 0) return []
 
     // A refined vocabulary has already been through this exercise with better

--- a/site/search/topicVocabulary.ts
+++ b/site/search/topicVocabulary.ts
@@ -1,4 +1,5 @@
 import { SearchChartHit } from "@ourworldindata/types"
+import { getRegionByNameOrVariantName } from "@ourworldindata/utils"
 import {
     DEFAULT_TOPIC_VOCABULARY_URL,
     TOPIC_VOCABULARY_URL,
@@ -84,17 +85,31 @@ const MAX_SUGGESTED_CHIPS = 5
 //
 // The vocabulary lists its terms roughly most- to least-central to the topic,
 // and that ordering carries real judgment: the deeper terms drift towards the
-// broad and obvious. Ranking the *whole* list by chart coverage below therefore
-// hands the line straight back to the generic words this replaced, because
-// "Men" and "Women" sit late in the Gender Ratio list but occur in far more of
-// its charts than "Sex-selective abortion" does — at a cap of 20 that topic
-// suggests "Men, Sex ratio, Missing women", and uncapped it opens with "Men,
-// Women". Cutting the pool first keeps the two signals in their proper order:
-// the vocabulary decides which terms are worth suggesting at all, coverage only
-// decides between the ones that are. Measured over every topic, 12 leaves just
-// two whose line opens on a word that generic, while still offering more than
-// twice the candidates there are slots.
+// broad and obvious. Ranking the *whole* list therefore risks handing the line
+// back to the generic words this replaced — "Men" and "Women" sat late in the
+// Gender Ratio list of an earlier vocabulary but occurred in far more of its
+// charts than "Sex-selective abortion" did, and uncapped that topic opened with
+// "Men, Women". Cutting the pool first keeps the two signals in their proper
+// order: the vocabulary decides which terms are worth suggesting at all, the
+// charts decide between the ones that are.
 const MAX_VOCABULARY_CANDIDATES = 12
+
+// True for anything that names a place: a country, a continent, an aggregate
+// like "World", or a variant name for one of those ("US", "UK"). Suggested
+// searches deliberately don't include places — they offer ways of narrowing
+// *what* the charts are about, and a country derived from the whole topic just
+// sits there while the visitor searches for a different one. Searching by
+// country still works, it just isn't suggested. This is the same lookup the
+// rest of the site uses to recognise one, so variants and non-country regions
+// are covered without a hand-written list of names.
+//
+// The vocabulary is asked not to name places, but it is regenerated out of band
+// by a script in another repo, and successive generations have drifted in and
+// out of offering "United States" or "Ukraine" as a keyword. Enforcing it here
+// keeps that drift out of the page.
+function isPlaceName(name: string): boolean {
+    return getRegionByNameOrVariantName(name) !== undefined
+}
 
 /**
  * Picks the all-charts block's "Suggested:" terms for a topic out of the
@@ -106,20 +121,26 @@ const MAX_VOCABULARY_CANDIDATES = 12
  * Ratio suggested "women, sex, birth, men, female" — and, a frequency count
  * having no notion of a phrase or a word form, it would offer "births" and
  * "birth" side by side, or a word like "have" that the hand-written stop-word
- * list hadn't anticipated. The vocabulary is the same source material read by
- * something that understands it, so that topic now offers "Sex ratio, Missing
- * women, Sex discrimination, Sex-selective abortion" — multi-word terms among
- * them, which the old tokeniser could not represent at all.
+ * list hadn't anticipated.
  *
- * The vocabulary lists more candidates per topic than there are slots, so
- * `hits` decides which of the leading MAX_VOCABULARY_CANDIDATES make the line. A term that occurs in more of the
- * topic's charts describes more of the list the visitor is looking at, and is
- * likelier to lead somewhere: a chip runs a search, so one that matches nothing
- * is a dead end. Terms found in the charts' own text therefore come first,
- * most-matched first, and terms found nowhere in it fill whatever slots are
- * left rather than shortening the line — Algolia matches far more generously
- * than the substring test here does, so "found nowhere" means unproven, not
- * useless.
+ * The vocabulary offers more candidates than the line has slots, so the topic's
+ * own chart list picks between them, on two counts:
+ *
+ * - **Reach.** A term occurring in more of the topic's charts describes more of
+ *   the list the visitor is looking at, and is likelier to lead somewhere: a
+ *   chip runs a search, so one that matches nothing is a dead end.
+ * - **Distinctness.** A term is only kept while it reaches a chart the terms
+ *   before it didn't. Without this the line spends its slots several times over
+ *   on the same destination — Gender Ratio offered "missing women",
+ *   "sex-selective abortion" and "excess female mortality", three chips leading
+ *   to the same two charts, so five suggestions were really two. Near-synonyms
+ *   are hard to spot as text but obvious in what they match, which is why this
+ *   is decided here rather than asked of whoever generates the vocabulary.
+ *
+ * Terms found nowhere in the charts' text fill any slots left over, ahead of
+ * ones held back as duplicates: Algolia matches far more generously than the
+ * substring test here does, so "found nowhere" means unproven, while "reaches
+ * only what's already covered" is a duplicate for certain.
  *
  * Comes back empty while either the baseline chart list or the vocabulary is
  * still in flight (the caller then renders no "Suggested:" line at all) rather
@@ -133,36 +154,53 @@ export function rankSuggestedKeywords(
     if (hits.length === 0) return []
 
     const lowerCaseTopicName = topicName.toLowerCase()
-    const keywords = vocabularyKeywords
+    const candidates = vocabularyKeywords
         .slice(0, MAX_VOCABULARY_CANDIDATES)
-        .filter(
+        .filter((keyword) => {
             // A term the topic's own name already contains ("population" on
             // "Population Growth") narrows nothing down.
-            (keyword) => !lowerCaseTopicName.includes(keyword.toLowerCase())
-        )
-    if (keywords.length === 0) return []
+            if (lowerCaseTopicName.includes(keyword.toLowerCase())) return false
+            return !isPlaceName(keyword)
+        })
+    if (candidates.length === 0) return []
 
     const chartTexts = hits.map((hit) =>
         [hit.title, hit.subtitle].filter(Boolean).join(" ").toLowerCase()
     )
 
-    const matched: { keyword: string; count: number }[] = []
+    const matched: { keyword: string; charts: Set<number> }[] = []
     const unmatched: string[] = []
-    for (const keyword of keywords) {
+    for (const keyword of candidates) {
         const lowerCaseKeyword = keyword.toLowerCase()
-        const count = chartTexts.filter((text) =>
-            text.includes(lowerCaseKeyword)
-        ).length
-        if (count > 0) matched.push({ keyword, count })
+        const charts = new Set<number>()
+        chartTexts.forEach((text, index) => {
+            if (text.includes(lowerCaseKeyword)) charts.add(index)
+        })
+        if (charts.size > 0) matched.push({ keyword, charts })
         else unmatched.push(keyword)
     }
 
-    // `sort` is stable, so terms matching the same number of charts keep the
+    // `sort` is stable, so terms reaching the same number of charts keep the
     // order the vocabulary listed them in instead of being shuffled against
     // each other.
-    matched.sort((a, b) => b.count - a.count)
+    matched.sort((a, b) => b.charts.size - a.charts.size)
 
-    return [...matched.map(({ keyword }) => keyword), ...unmatched].slice(
+    const covered = new Set<number>()
+    const distinct: string[] = []
+    const duplicates: string[] = []
+    for (const { keyword, charts } of matched) {
+        const reachesSomethingNew = [...charts].some(
+            (chart) => !covered.has(chart)
+        )
+        if (!reachesSomethingNew) {
+            duplicates.push(keyword)
+            continue
+        }
+        distinct.push(keyword)
+        for (const chart of charts) covered.add(chart)
+    }
+
+    return [...distinct, ...unmatched, ...duplicates].slice(
         0,
         MAX_SUGGESTED_CHIPS
     )


### PR DESCRIPTION
> _Written by Anthropic Claude Opus 5 — @Marigold at the wheel._

Stacked on #6870. Replaces the source of the all-charts block's `SUGGESTED:` terms.

Those terms were being computed by counting word frequencies across the topic's chart titles and subtitles and offering the commonest words. That surfaces each topic's filler rather than its subject matter — Gender Ratio suggested **"women, sex, birth, men, female"** — and a frequency count has no notion of a phrase or a word form, so it would also offer "births" and "birth" side by side, or a word like "have" that the hand-written stop-word list hadn't anticipated. No model was involved at any point, despite how the output reads.

The terms now come from the **OWID vocabulary**: the same chart titles and subtitles, but read by an LLM that was asked for the terms a visitor would plausibly search for. Same page, same topic:

| Topic | Before | After |
| --- | --- | --- |
| Gender Ratio | women, sex, birth, men, female | Sex ratio, Missing women, Life expectancy, Unemployment, Judiciary |

A spread of others:

| Topic | Suggested |
| --- | --- |
| Energy | solar, wind, coal, oil, nuclear |
| Air Pollution | PM2.5, ozone, sulphur dioxide, fossil fuels, coal |
| Causes of Death | diabetes, cancer, air pollution, tuberculosis, Alzheimer's |
| Child Labor | economic activity, labor rights, economic sector, household chores, school attendance |
| Artificial Intelligence | generative AI, computation, parameters, funding, data centers |
| Population Growth | projections, births, deaths, fertility, demographic transition |

Most of the vocabulary's terms are multi-word phrases, which the old tokeniser could not represent at all.

## Each suggestion has to lead somewhere different

The first version of this had a bug worth describing, because it's the thing that makes or breaks the line. Gender Ratio was suggesting:

> sex ratio, **sex ratio at birth**, missing women, **sex-selective abortion**, **excess female mortality**

Five chips, but the last three all land on the same two charts and the second is a narrower spelling of the first — so the line offered two destinations out of five. Measured across every topic, **22% of the terms shown were duplicates** in that sense.

A term is now kept only while it reaches a chart the terms before it didn't. Near-synonyms are hard to recognise as text but obvious in what they match, which is why the chart list decides it here rather than the prompt. The vocabulary is asked for distinctness too (owid/etl#6727), and the two together:

| | duplicate chips | median charts the line reaches |
| --- | --- | --- |
| March vocabulary, no distinctness check | 26% | 17 |
| March vocabulary, distinctness on | 7% | 18 |
| Regenerated vocabulary, no distinctness check | 8% | 16 |
| **Regenerated vocabulary, distinctness on** | **2%** | 16 |

Gender Ratio now reaches 13 of its 16 charts, where the redundant version reached 8.

### And it has to lead somewhere at all

A term the page has nothing for is dropped rather than offered. Clicking a chip searches, and the block then keeps only the rows whose own visible text contains the query — so Algolia's more generous matching can't rescue a term that filter rejects, and the list simply comes back empty. **25 of the 620 terms the production vocabulary has been showing (4%) behave that way**: "solar" and "hydropower" on Energy Mix, "prayer" on Religion, "childcare" on Time Use.

Reach is therefore measured with that same filter (`filterChartHitsByQueryWords`) rather than a substring test of its own, so a term's measured reach is exactly what clicking it renders — and whole words rather than substrings, so "Men" is no longer credited with "Women" and "employment". Dropping the dead terms shortens 3 of the 125 topics' lines and empties none. A term held back as a *duplicate* still fills a leftover slot, since it does lead somewhere.

**Except where the vocabulary already knows better.** owid/etl#6727 now checks each candidate against the search API during generation and re-picks the list from the real results, marking the entry `refined`. That ordering beats anything measurable here — it weights each chart by how much it is actually viewed, and it can see what the search returns rather than only the topic's default list — so where the flag is set the order is taken as given. Re-ranking a refined vocabulary locally would rewrite 100 of 125 topics and 54 of their opening terms, while not one of its 541 published terms renders an empty list, which the local guess can't manage. The guess stays for an unrefined vocabulary, which is what production still serves (26% → 7% duplicates there), and retires itself once a refined one is published. Both paths are live today: the production key is unrefined, the branch key is refined.

A refined line also stops waiting on the chart list, since nothing about its order depends on it, so the suggestions appear as soon as the vocabulary does.

## Fetched, not bundled

The vocabulary lives in the **`owid-public` R2 bucket** (key `topic_vocabulary.json`) and is served through `files.ourworldindata.org`, whose worker adds `Access-Control-Allow-Origin: *` and a 5-minute edge cache. So the browser reads it directly — no Pages Function, no R2 binding, no `_routes.json` entry, and nothing in the bundle. The repo already depends on this host for grapher schemas.

That means **regenerating the vocabulary is an upload, not a deploy**, and a staging server can be pointed at its own copy:

```
TOPIC_VOCABULARY_URL=https://files.ourworldindata.org/topic_vocabulary/my-branch.json
```

The worker proxies the whole bucket, so any key works, nested prefixes included — no second bucket or worker needed. If the override key isn't there, suggestions fall back to the production vocabulary rather than disappearing.

Net bundle effect is **−0.6kB** (796.4kB vs 797.0kB on the base branch): the deleted heuristic outweighs the added fetch, so no bundlemon change.

The trade-off to name: the chips now depend on a network fetch, so on a cold edge cache they appear a beat after the chart list. The curated-`suggested` path stays synchronous.

## Two things worth a decision, neither of which blocks the change

- **The published vocabulary is from 3 March 2026 and its quality is uneven** — "Artificial Intelligence" offering `NVIDIA` and `petaFLOP` is that snapshot's ceiling, not the intended one. **owid/etl#6727 fixes this**: it rewrites term selection as weighted maximum coverage — each topic's terms are chosen to reveal as much of its charts as possible, weighted by how much each chart is viewed, first term revealing the most — adds `--upload-path` (the script until now hardcoded the prod key, so a staging run would clobber production), and regenerates with `gemini-3.7-flash`. That version drops all 23 bare generic terms (`Men`, `Women`, `Children`, …) to zero and turns Artificial Intelligence into "generative AI, artificial neural network, data centers, machine learning, computer vision". It is uploaded to a non-default key, so nothing here changes until someone points at it:

    ```
    TOPIC_VOCABULARY_URL=https://files.ourworldindata.org/topic_vocabulary/<branch>.json
    ```

    Verified both ways through this code: the override reads the new vocabulary, and an override pointing at a missing key logs and falls back to production. **owid/ops#636 sets that variable on every staging server to a per-branch key**, so a branch that has uploaded a vocabulary shows it and every other branch falls back to production. All three PRs use the branch name `search-suggestions` so they land on the same staging server.
- **Place names are filtered out in code**, restoring what 38ac2545 added on the base branch. The vocabulary is asked not to name places, but successive generations have drifted in and out of offering "United States" or "Ukraine" as keywords (12 such terms in one regeneration, 0 in the next), so the guarantee sits here rather than in the prompt.
- **Producer ("source") chips are gone** along with the frequency code that ranked them. They only ever appeared as a top-up when keyword variety ran short, which the vocabulary makes impossible, so they were dead weight — but if suggesting a source is wanted in its own right (the original brief mentioned it), that is now a deliberate thing to add rather than something this PR removed.

## Carries the facet fix

This branch cherry-picks #7026 (`60fd96ea`, squash-merged to master) rather than merging master, so `/api/search` on this branch's staging server doesn't reject valid topics. Merging master instead would have added its 97 commits — 245 files, +10.9k lines — to this PR's diff, because the base (#6870) is that far behind. That base wants master merged in on its own account; until it is, cherry-picking keeps this PR readable.

## How to test it

On the staging server, open any topic page with an all-charts block — [Gender Ratio](http://staging-site-search-suggestions/gender-ratio#all-charts) is the one from the screenshots — and read the `SUGGESTED:` line under the search box. Clicking a term should put it in the search box and narrow the list rather than empty it. A topic whose gdoc block sets `suggested` explicitly should still show exactly what the author wrote.

The PR carries the `staging-algolia` label, without which the block's Algolia queries have no per-branch index to hit.

<details><summary>Details</summary>

### What changed

- **`site/search/topicVocabulary.ts`** (new) — fetches the vocabulary, re-keys it by topic *name*, and ranks a topic's terms. It is published keyed by slug, but consumers know a topic by the tag name their gdoc carries (an all-charts block receives only `topicName`, and builds its Algolia filter from that name too). Verified locally against `tags`/`chart_tags`/`charts`: all 125 topic tags with a published chart have exactly one entry, matching 125/125 by slug *and* by name, with no name mismatches. Entries are parsed defensively — it's a file in a bucket, regenerated out of band by a script in another repo, so a malformed entry costs that one topic its suggestions instead of throwing in a render.
- **`site/AllChartsBlock.tsx`** — deleted `computeAutoSuggestedChips`, `rankByFrequency`, `splitIntoLowercaseWords`, `isPlaceName`, the 138-entry `KEYWORD_STOP_WORDS` set, `MIN_KEYWORD_LENGTH`, `MIN_SUGGESTED_CHIP_COUNT` and `SuggestedChipCandidate`; added the vocabulary query. Net −336 lines in this file.
- **`settings/clientSettings.ts`** — `DEFAULT_TOPIC_VOCABULARY_URL` and the `TOPIC_VOCABULARY_URL` override.
- **`site/AllChartsBlock.test.ts`** (new) — 21 cases over the ranking and the parser.

### Ranking

The vocabulary offers ~30 candidates for 5 slots, so the topic's own chart list picks between them, using the unfiltered baseline result set the block already fetches (no extra request):

1. Drop place names, then take only the leading 12 of what's left (`MAX_VOCABULARY_CANDIDATES`, see below).
2. For each, count the rows `filterChartHitsByQueryWords` would leave standing — the block's own row filter, over the row's title, subtitle and producer.
3. Drop the terms reaching nothing: their chip would empty the list.
4. Most-reaching first. `Array.sort` is stable, so equally-reaching terms keep the vocabulary's own ordering.
5. A term reaching only rows an earlier term already reached is held back and fills a leftover slot behind the distinct ones.

Rationale for (3): a chip runs a full-text search, so a chip reaching nothing is a dead end, and the old code's `MIN_SUGGESTED_CHIP_COUNT = 2` was guarding the same property. Ranking is the replacement for that guard.

A term the topic's *own name* contains is offered, having previously been refused on the reasoning that a reader already on the page has applied it. True for most topics and badly wrong for the minority whose charts are simply called after the topic: allowing it takes Religion from covering 39% of its topic's traffic to 97%, and Life Expectancy from 21% to 98%, because half of that topic is one chart titled "Life expectancy" and nothing narrower reaches it.

Step (1) is the non-obvious one, and it is load-bearing rather than a size optimisation. The vocabulary orders its terms roughly most- to least-central to the topic, and the deeper terms drift towards the broad and obvious — so ranking the *whole* list by chart coverage hands the line straight back to the words this PR replaces. Measured on real chart data:

| Candidate pool | Gender Ratio suggests |
| --- | --- |
| leading 12 | Sex ratio, Missing women, Drug use, Life expectancy, Judiciary |
| uncapped | **Women, Men**, Sex ratio, Missing women, Sex discrimination |

"Men" and "Women" sit near the end of that topic's list but occur in more of its charts than any specific term. Removing the cap moves 78 of the 125 topics' lines and 23 of their opening terms, in that direction.

Dropping the coverage sort instead of capping the pool doesn't work either — it trusts an ordering that is sometimes alphabetical (Agricultural Production: "Animal feed, Arable land, Banana, Biofuel, Cassava") or leads with producer acronyms (Child Labor: "ILO, ILO-IPEC, ILO-EPEAP"). The cap keeps the two signals in their proper order: the vocabulary decides which terms are worth suggesting at all, coverage decides between the ones that are. There's a regression test for it.

Returns `[]` while either the baseline query or the vocabulary is in flight, so the line renders once, ranked, instead of appearing unranked and reshuffling a moment later.

### Behaviour that did not change

- Editorially curated `suggested` on the gdoc block still takes precedence and renders exactly as authored, place names included.
- Every chip still just populates the search input.
- Country detection, order pinning, the producer-filter pill and its removal handler are untouched — only the chips stopped offering producers.

### Verified

`yarn typecheck`, `yarn testLintChanged`, `yarn testFormatChanged` and the test file all pass. Bundle numbers are from real builds of both branches (`yarn buildViteSite`, `brotli -q 11` on `dist/assets/owid.mjs`). The fetch-and-index path was run against the live R2 file: 125 topics indexed, Gender Ratio ranking as above.

Not verified: how the line actually looks in a browser. That needs the staging build.

</details>

