### PR TITLE
🐛🤖 don't report an unchecked SVG pair as a visual difference

### DIFF
--- a/adminSiteClient/SvgTesterSuitePage.tsx
+++ b/adminSiteClient/SvgTesterSuitePage.tsx
@@ -42,6 +42,7 @@ import pMap from "p-map"
 import {
     compareSvgsVisually,
     VISUAL_DIFF_CONCURRENCY,
+    type VisualVerdict,
 } from "./svgVisualDiff.js"
 
 const LIVE_URL = "https://ourworldindata.org"
@@ -63,15 +64,25 @@ const KIND_LABELS: Record<SvgTesterVerifyErrorEntry["kind"], string> = {
 
 const CHART_TYPE_PARAM = "chartType"
 
+/** Ordered as the list shows them: what to review first comes first */
+const VISUAL_VERDICT_LABELS: Record<VisualVerdict, string> = {
+    changed: "Visible change",
+    unknown: "Couldn't check",
+    identical: "No visible change",
+}
+
+const VISUAL_VERDICTS = Object.keys(VISUAL_VERDICT_LABELS) as VisualVerdict[]
+
 /** Which differences to list, once we know which ones only changed in markup */
-type VisualFilter = "changed" | "identical" | "all"
+type VisualFilter = VisualVerdict | "all"
 
 const DEFAULT_VISUAL_FILTER: VisualFilter = "changed"
 
 /** How many of a run's differences turned out to be markup-only */
 interface VisualSummary {
     total: number
-    identicalCount: number
+    /** Partial while the check is still going, empty before it starts */
+    counts: Partial<Record<VisualVerdict, number>>
     remainingCount: number
     /** False while the check is still going, when the counts are partial */
     isComplete: boolean
@@ -84,7 +95,7 @@ const IDLE_REFRESH_INTERVAL_MS = 30_000
 const VISUAL_DIFF_PROGRESS_MS = 250
 
 /** Stable identity, so holding results back doesn't itself rebuild the list */
-const NO_VISUAL_RESULTS: Record<string, boolean> = {}
+const NO_VISUAL_RESULTS: Record<string, VisualVerdict> = {}
 
 export function SvgTesterSuitePage() {
     const { admin } = useContext(AdminAppContext)
@@ -154,45 +165,57 @@ export function SvgTesterSuitePage() {
     const isReported = data ? hasReportedResult(data) : false
 
     // Check visual differences once the run has reported
-    const { identicalBySvg, remainingCount } = useVisualDiffs(
+    const { verdictBySvg, remainingCount } = useVisualDiffs(
         suite,
         differences,
         isReported ? results?.startedAt : undefined
     )
 
-    const applied = identicalBySvg ?? NO_VISUAL_RESULTS
+    const applied = verdictBySvg ?? NO_VISUAL_RESULTS
 
-    const [looksDifferent, rendersIdentically] = useMemo(
-        () => _.partition(visible, (entry) => !applied[entry.svgFilename]),
-        [visible, applied]
+    const grouped = useMemo(() => {
+        const byVerdict = _.groupBy(
+            visible,
+            (entry) => applied[entry.svgFilename] ?? "changed"
+        )
+        return {
+            changed: byVerdict.changed ?? [],
+            unknown: byVerdict.unknown ?? [],
+            identical: byVerdict.identical ?? [],
+        }
+    }, [visible, applied])
+
+    const populatedVerdicts = VISUAL_VERDICTS.filter(
+        (verdict) => grouped[verdict].length > 0
     )
-
-    const showVisualFilter =
-        looksDifferent.length > 0 && rendersIdentically.length > 0
-    const effectiveVisualFilter: VisualFilter = showVisualFilter
-        ? visualFilter
-        : "all"
-
-    const shown = useMemo(() => {
-        if (effectiveVisualFilter === "changed") return looksDifferent
-        if (effectiveVisualFilter === "identical") return rendersIdentically
-        return [...looksDifferent, ...rendersIdentically]
-    }, [effectiveVisualFilter, looksDifferent, rendersIdentically])
+    // Nothing to filter when every difference is in the same bucket
+    const showVisualFilter = populatedVerdicts.length > 1
 
     const visualFilterOptions = [
-        {
-            value: "changed" as const,
-            label: `Visible change (${looksDifferent.length.toLocaleString()})`,
-        },
-        {
-            value: "identical" as const,
-            label: `No visible change (${rendersIdentically.length.toLocaleString()})`,
-        },
+        ...populatedVerdicts.map((verdict) => ({
+            value: verdict,
+            label: `${VISUAL_VERDICT_LABELS[verdict]} (${grouped[verdict].length.toLocaleString()})`,
+        })),
         {
             value: "all" as const,
             label: `All (${visible.length.toLocaleString()})`,
         },
     ]
+
+    // The selection sticks, so it can name a bucket since emptied
+    const effectiveVisualFilter: VisualFilter = visualFilterOptions.some(
+        (option) => option.value === visualFilter
+    )
+        ? visualFilter
+        : "all"
+
+    const shown = useMemo(
+        () =>
+            effectiveVisualFilter === "all"
+                ? VISUAL_VERDICTS.flatMap((verdict) => grouped[verdict])
+                : grouped[effectiveVisualFilter],
+        [effectiveVisualFilter, grouped]
+    )
 
     const cards = useMemo(
         () =>
@@ -201,7 +224,7 @@ export function SvgTesterSuitePage() {
                     key={anchorId(entry.viewId, entry.queryStr)}
                     suite={suite}
                     entry={entry}
-                    visuallyIdentical={applied[entry.svgFilename]}
+                    verdict={applied[entry.svgFilename] ?? "changed"}
                 />
             )),
         [shown, suite, applied]
@@ -210,9 +233,11 @@ export function SvgTesterSuitePage() {
     const visualSummary = differences.length
         ? {
               total: differences.length,
-              identicalCount: Object.values(applied).filter(Boolean).length,
+              counts: _.countBy(Object.values(applied)) as Partial<
+                  Record<VisualVerdict, number>
+              >,
               remainingCount,
-              isComplete: identicalBySvg !== undefined,
+              isComplete: verdictBySvg !== undefined,
           }
         : undefined
 
@@ -409,17 +434,28 @@ function VisualHeadlineClause({
         return (
             <span className="SvgTesterSuitePage__visual-note">
                 {" · "}
-                {visual.remainingCount.toLocaleString()} left to check for
-                visible changes…
+                {visual.remainingCount > 0
+                    ? `${visual.remainingCount.toLocaleString()} left to check for visible changes…`
+                    : "rechecking what couldn't be checked…"}
             </span>
         )
 
-    const changedCount = visual.total - visual.identicalCount
+    const changedCount = visual.counts.changed ?? 0
+    const unknownCount = visual.counts.unknown ?? 0
+
+    // "none changed visibly" would be a finding, and there isn't one to report
+    if (unknownCount === visual.total)
+        return (
+            <span className="SvgTesterSuitePage__visual-note">
+                {" — "}
+                none could be checked for visible changes
+            </span>
+        )
 
     return (
         <>
             {" — "}
-            {!visual.identicalCount ? (
+            {changedCount === visual.total ? (
                 "all changed visibly"
             ) : changedCount ? (
                 <>
@@ -428,6 +464,12 @@ function VisualHeadlineClause({
                 </>
             ) : (
                 "none changed visibly"
+            )}
+            {unknownCount > 0 && (
+                <span className="SvgTesterSuitePage__visual-note">
+                    {", "}
+                    {unknownCount.toLocaleString()} couldn't be checked
+                </span>
             )}
         </>
     )
@@ -577,11 +619,11 @@ function CommitLabel({
 function DifferenceCard({
     suite,
     entry,
-    visuallyIdentical,
+    verdict,
 }: {
     suite: string
     entry: SvgTesterVerifyDifferenceEntry
-    visuallyIdentical: boolean | undefined
+    verdict: VisualVerdict
 }) {
     const [mode, setMode] = useState<ViewMode>("side-by-side")
     const beforeUrl = svgUrl(suite, "references", entry)
@@ -616,9 +658,16 @@ function DifferenceCard({
                             {entry.chartType}
                         </Tag>
                     )}
-                    {visuallyIdentical && (
-                        <Tag className="SvgTesterSuitePage__chart-type">
-                            No visible change
+                    {verdict !== "changed" && (
+                        <Tag
+                            className="SvgTesterSuitePage__chart-type"
+                            title={
+                                verdict === "unknown"
+                                    ? "The comparison failed or timed out, so this chart may not have changed at all"
+                                    : undefined
+                            }
+                        >
+                            {VISUAL_VERDICT_LABELS[verdict]}
                         </Tag>
                     )}
                 </span>
@@ -925,22 +974,22 @@ function useVisualDiffs(
     differences: SvgTesterVerifyDifferenceEntry[],
     runKey: string | undefined
 ): {
-    identicalBySvg: Record<string, boolean> | undefined
+    verdictBySvg: Record<string, VisualVerdict> | undefined
     remainingCount: number
 } {
-    const [identicalBySvg, setIdenticalBySvg] =
-        useState<Record<string, boolean>>()
+    const [verdictBySvg, setVerdictBySvg] =
+        useState<Record<string, VisualVerdict>>()
     const [checkedCount, setCheckedCount] = useState(0)
 
     useEffect(() => {
-        setIdenticalBySvg(undefined)
+        setVerdictBySvg(undefined)
         setCheckedCount(0)
         if (!suite || !runKey || !differences.length) return
 
         // Leaving the suite abandons whatever has not started: those answers are
         // for a report nobody is looking at any more.
         const abandon = new AbortController()
-        const identical: Record<string, boolean> = {}
+        const verdicts: Record<string, VisualVerdict> = {}
         let checked = 0
         // Thousands of answers, and only the countdown shows them arriving
         const publishProgress = _.throttle(
@@ -949,27 +998,50 @@ function useVisualDiffs(
             { leading: false }
         )
 
+        const check = async (
+            entry: SvgTesterVerifyDifferenceEntry
+        ): Promise<void> => {
+            verdicts[entry.svgFilename] = await compareSvgsVisually(
+                svgUrl(suite, "references", entry),
+                svgUrl(suite, "differences", entry),
+                runKey
+            )
+        }
+        const options = {
+            concurrency: VISUAL_DIFF_CONCURRENCY,
+            signal: abandon.signal,
+        }
+
         void pMap(
             differences,
             async (entry) => {
-                identical[entry.svgFilename] = await compareSvgsVisually(
-                    svgUrl(suite, "references", entry),
-                    svgUrl(suite, "differences", entry),
-                    runKey
-                )
+                await check(entry)
                 checked++
                 publishProgress()
             },
-            { concurrency: VISUAL_DIFF_CONCURRENCY, signal: abandon.signal }
-        ).then(
-            () => {
-                publishProgress.cancel()
-                setIdenticalBySvg(identical)
-            },
-            () => {
-                // Abandoned, so there is nothing to report
-            }
+            options
         )
+            // Whatever couldn't be checked gets one more go once the rest has
+            // drained: a pair that stalled behind the check's own traffic says
+            // nothing about the chart, and this is the quiet moment to ask again
+            .then(() =>
+                pMap(
+                    differences.filter(
+                        (entry) => verdicts[entry.svgFilename] === "unknown"
+                    ),
+                    check,
+                    options
+                )
+            )
+            .then(
+                () => {
+                    publishProgress.cancel()
+                    setVerdictBySvg(verdicts)
+                },
+                () => {
+                    // Abandoned, so there is nothing to report
+                }
+            )
 
         return () => {
             publishProgress.cancel()
@@ -978,7 +1050,7 @@ function useVisualDiffs(
     }, [suite, runKey, differences])
 
     return {
-        identicalBySvg,
+        verdictBySvg,
         remainingCount: differences.length - checkedCount,
     }
 }

--- a/adminSiteClient/svgVisualDiff.test.ts
+++ b/adminSiteClient/svgVisualDiff.test.ts
@@ -47,20 +47,20 @@ describe("the visual diff checker", () => {
 
         const result = checker.compare("before.svg", "after.svg", "run-1")
         await runIdleWork()
-        await expect(result).resolves.toBe(true)
+        await expect(result).resolves.toBe("identical")
     })
 
-    it("reports a pair whose pixels differ as different", async () => {
+    it("reports a pair whose pixels differ as changed", async () => {
         const checker = createVisualDiffChecker((url) =>
             Promise.resolve(pixels(2, 2, url.startsWith("before") ? 7 : 9))
         )
 
         const result = checker.compare("before.svg", "after.svg", "run-1")
         await runIdleWork()
-        await expect(result).resolves.toBe(false)
+        await expect(result).resolves.toBe("changed")
     })
 
-    it("reports a pair as different when the chart changed size", async () => {
+    it("reports a pair as changed when the chart changed size", async () => {
         const checker = createVisualDiffChecker((url) =>
             Promise.resolve(
                 url.startsWith("before") ? pixels(2, 2) : pixels(4, 4)
@@ -69,33 +69,36 @@ describe("the visual diff checker", () => {
 
         await expect(
             checker.compare("before.svg", "after.svg", "run-1")
-        ).resolves.toBe(false)
+        ).resolves.toBe("changed")
     })
 
-    it("reports a pair as different when an SVG cannot be rasterized", async () => {
+    it("says nothing about a pair it cannot rasterize", async () => {
         const checker = createVisualDiffChecker(() =>
             Promise.resolve(undefined)
         )
 
+        // Not "changed": a chart nothing is known about is not one that changed
         await expect(
             checker.compare("before.svg", "after.svg", "run-1")
-        ).resolves.toBe(false)
+        ).resolves.toBe("unknown")
     })
 
-    it("does not remember a pair it could not rasterize as changed", async () => {
-        let attempts = 0
+    it("does not remember a pair it could not rasterize", async () => {
+        let loads = 0
         // Fails once, the way a transient error would, then works
         const checker = createVisualDiffChecker(() =>
-            Promise.resolve(attempts++ < 2 ? undefined : pixels(2, 2))
+            Promise.resolve(loads++ < 2 ? undefined : pixels(2, 2))
         )
 
         await expect(
             checker.compare("before.svg", "after.svg", "run-1")
-        ).resolves.toBe(false)
+        ).resolves.toBe("unknown")
 
+        // Asking again does the work again, which is what the caller's retry
+        // pass relies on
         const retried = checker.compare("before.svg", "after.svg", "run-1")
         await runIdleWork()
-        await expect(retried).resolves.toBe(true)
+        await expect(retried).resolves.toBe("identical")
     })
 
     it("stops the work behind a pair it has given up on", async () => {
@@ -109,7 +112,7 @@ describe("the visual diff checker", () => {
         ])
 
         await vi.advanceTimersByTimeAsync(20_000)
-        await expect(timedOut).resolves.toBe(false)
+        await expect(timedOut).resolves.toBe("unknown")
         expect(pending.map(({ abandoned }) => abandoned?.aborted)).toEqual([
             true,
             true,
@@ -125,12 +128,12 @@ describe("the visual diff checker", () => {
 
         const first = checker.compare("before.svg", "after.svg", "run-1")
         await runIdleWork()
-        await expect(first).resolves.toBe(true)
+        await expect(first).resolves.toBe("identical")
         expect(loads).toBe(2)
 
         await expect(
             checker.compare("before.svg", "after.svg", "run-1")
-        ).resolves.toBe(true)
+        ).resolves.toBe("identical")
         expect(loads).toBe(2)
     })
 
@@ -154,16 +157,16 @@ describe("the visual diff checker", () => {
 
         const timedOut = checker.compare("before.svg", "after.svg", "run-1")
         await vi.advanceTimersByTimeAsync(20_000)
-        await expect(timedOut).resolves.toBe(false)
+        await expect(timedOut).resolves.toBe("unknown")
     })
 
-    it("does not remember a pair that timed out as changed", async () => {
+    it("does not remember a pair that timed out", async () => {
         const { pending, loadPixels } = deferredLoader()
         const checker = createVisualDiffChecker(loadPixels)
 
         const timedOut = checker.compare("before.svg", "after.svg", "run-1")
         await vi.advanceTimersByTimeAsync(20_000)
-        await expect(timedOut).resolves.toBe(false)
+        await expect(timedOut).resolves.toBe("unknown")
 
         // Asked again it has to do the work, rather than repeat a non-answer
         pending.length = 0
@@ -172,7 +175,7 @@ describe("the visual diff checker", () => {
         expect(pending).toHaveLength(2)
         pending.forEach(({ resolve }) => resolve(pixels(2, 2)))
         await runIdleWork()
-        await expect(retried).resolves.toBe(true)
+        await expect(retried).resolves.toBe("identical")
     })
 
     it("forgets the answers for runs nobody is looking at any more", async () => {
@@ -184,7 +187,7 @@ describe("the visual diff checker", () => {
 
         const first = checker.compare("before.svg", "after.svg", "run-1")
         await runIdleWork()
-        await expect(first).resolves.toBe(true)
+        await expect(first).resolves.toBe("identical")
         expect(loads).toBe(2)
 
         // Four more runs push run-1 out of the cache, so it is checked again

--- a/adminSiteClient/svgVisualDiff.ts
+++ b/adminSiteClient/svgVisualDiff.ts
@@ -21,6 +21,14 @@ export const VISUAL_DIFF_CONCURRENCY = 8
 const COMPARISON_TIMEOUT_MS = 20_000
 
 /**
+ * How long a yield may wait for an idle moment before going ahead anyway. The
+ * report re-renders throughout the check, so idle moments are scarce, and a pair
+ * needs several yields to get through: without a deadline one can sit long
+ * enough to be given up on even though nothing is wrong with it.
+ */
+const IDLE_DEADLINE_MS = 100
+
+/**
  * How many runs' worth of answers to keep. Revisiting the suite you just left is
  * then free, without holding every answer for every run the tab has ever shown.
  */
@@ -39,33 +47,31 @@ export type LoadPixels = (
 ) => Promise<RasterizedSvg | undefined>
 
 /**
- * A pair nothing could be said about — it failed, or it never came back. Kept
- * apart from "changed" so it can be shown as one without being remembered as
- * one.
+ * What a comparison came to. Not a boolean plus undefined: `!identical` would
+ * read a pair nothing is known about as one that changed.
  */
-const UNANSWERED = "unanswered"
-type Outcome = boolean | typeof UNANSWERED
+export type VisualVerdict = "identical" | "changed" | "unknown"
 
 export function createVisualDiffChecker(loadPixels: LoadPixels): {
     /**
-     * Whether the two SVGs paint the same pixels. Never rejects, and never
-     * hangs: a pair that can't be answered for resolves false, which leaves the
-     * chart in plain view. `runKey` scopes the cache, since the next run serves
-     * different files from the same URLs.
+     * What the two SVGs' pixels came to. Never rejects, and never hangs.
+     * `runKey` scopes the cache, since the next run serves different files from
+     * the same URLs. A pair that couldn't be checked isn't remembered, so asking
+     * again does the work again.
      */
     compare: (
         beforeUrl: string,
         afterUrl: string,
         runKey: string
-    ) => Promise<boolean>
+    ) => Promise<VisualVerdict>
 } {
-    const cachesByRun = new Map<string, Map<string, Promise<boolean>>>()
+    const cachesByRun = new Map<string, Map<string, Promise<VisualVerdict>>>()
 
-    function cacheFor(runKey: string): Map<string, Promise<boolean>> {
+    function cacheFor(runKey: string): Map<string, Promise<VisualVerdict>> {
         const existing = cachesByRun.get(runKey)
         if (existing) return existing
 
-        const cache = new Map<string, Promise<boolean>>()
+        const cache = new Map<string, Promise<VisualVerdict>>()
         cachesByRun.set(runKey, cache)
         // Insertion-ordered, so this drops the runs left longest ago
         for (const stale of [...cachesByRun.keys()].slice(0, -MAX_CACHED_RUNS))
@@ -77,27 +83,27 @@ export function createVisualDiffChecker(loadPixels: LoadPixels): {
         beforeUrl: string,
         afterUrl: string,
         abandoned: AbortSignal
-    ): Promise<Outcome> {
+    ): Promise<VisualVerdict> {
         const [before, after] = await Promise.all([
             loadPixels(beforeUrl, abandoned),
             loadPixels(afterUrl, abandoned),
         ])
-        if (!before || !after) return UNANSWERED
+        if (!before || !after) return "unknown"
         // A chart that changed size has visibly changed
         if (before.width !== after.width || before.height !== after.height)
-            return false
+            return "changed"
         // Comparing a few million bytes is the one long stretch left, so let
         // anything the user is doing go first
         await yieldToPage()
-        if (abandoned.aborted) return UNANSWERED
-        return pixelsEqual(before.data, after.data)
+        if (abandoned.aborted) return "unknown"
+        return pixelsEqual(before.data, after.data) ? "identical" : "changed"
     }
 
     function compare(
         beforeUrl: string,
         afterUrl: string,
         runKey: string
-    ): Promise<boolean> {
+    ): Promise<VisualVerdict> {
         const cache = cacheFor(runKey)
         const key = `${beforeUrl}\n${afterUrl}`
 
@@ -112,12 +118,11 @@ export function createVisualDiffChecker(loadPixels: LoadPixels): {
         const result = withTimeout(
             compareNow(beforeUrl, afterUrl, giveUp.signal),
             () => giveUp.abort()
-        ).then((outcome) => {
-            if (outcome !== UNANSWERED) return outcome
-            // Forgotten rather than remembered as changed: never hold a pair to
-            // an answer that never arrived
-            cache.delete(key)
-            return false
+        ).then((verdict) => {
+            // Forgotten rather than remembered: never hold a pair to an answer
+            // that never arrived
+            if (verdict === "unknown") cache.delete(key)
+            return verdict
         })
         cache.set(key, result)
         return result
@@ -136,22 +141,22 @@ function pixelsEqual(a: Uint8ClampedArray, b: Uint8ClampedArray): boolean {
 
 /** Reports a comparison that never came back, rather than never resolving */
 function withTimeout(
-    comparison: Promise<Outcome>,
+    comparison: Promise<VisualVerdict>,
     onTimeout: () => void
-): Promise<Outcome> {
-    return new Promise<Outcome>((resolve) => {
+): Promise<VisualVerdict> {
+    return new Promise<VisualVerdict>((resolve) => {
         const timer = setTimeout(() => {
             onTimeout()
-            resolve(UNANSWERED)
+            resolve("unknown")
         }, COMPARISON_TIMEOUT_MS)
         void comparison.then(
-            (outcome) => {
+            (verdict) => {
                 clearTimeout(timer)
-                resolve(outcome)
+                resolve(verdict)
             },
             () => {
                 clearTimeout(timer)
-                resolve(UNANSWERED)
+                resolve("unknown")
             }
         )
     })
@@ -171,7 +176,7 @@ function yieldToPage(): Promise<void> {
         return nextMacrotask()
     return new Promise((resolve) => {
         if (typeof requestIdleCallback === "function")
-            requestIdleCallback(() => resolve())
+            requestIdleCallback(() => resolve(), { timeout: IDLE_DEADLINE_MS })
         else setTimeout(resolve, 0)
     })
 }


### PR DESCRIPTION
> _Written by Claude Opus 5 — @sophiamersmann at the wheel._

The SVG tester's visual diff reported two charts as rendering differently when they provably could not: their only markup difference was an unreferenced `<pattern>` inside `<defs>`, which paints nothing, and both SVGs were the same size. So the pixel comparison never said "different" — the comparison went *unanswered* (a failed rasterization or a timeout) and the code mapped that to `false`, i.e. "changed". Another chart carrying the byte-identical change was reported as identical, which is what gives it away as sporadic rather than content-driven.

Three parts: `compare()` now returns a verdict with `"unknown"` as its own answer instead of a boolean that folds "couldn't check" into "changed"; the report counts and lists unknowns separately; and two changes make unknowns rarer in the first place (an idle deadline on the yields, and one recheck of the unknowns after the first pass drains).

Two things worth a look:

- **Which trigger fired is inferred, not confirmed.** Either the 20s per-pair timeout expired, or `loadPixelsFromDom` threw. The latter logs `[svg visual diff] could not rasterize`, so opening a report with the console visible settles it. Both funnel into the same defect, and both are addressed, so this doesn't block the fix — but it does mean the idle deadline may be treating a symptom that wasn't the one at play.
- **An unknown pair is no longer in the default view.** It used to land in "Visible change" (which is how the bug showed up); now it's named in the headline and behind its own filter segment. That's a different fail-safe from "always in plain view" — happy to switch to a combined "needs a look" bucket if you'd rather they stayed in the default list.

<details><summary>Details</summary>

### Root cause

`svgVisualDiff.ts` had an internal `UNANSWERED` sentinel that was deliberately kept apart from "changed", then flattened to `false` at the module boundary — so the distinction the module worked to preserve was discarded on the way out. Every consumer then read an unanswerable pair as a visible change.

Both flagged charts differ from their reference only by:

```
+ <pattern id="inapplicablePattern" patternUnits="userSpaceOnUse" width="4" height="4" …>
+   <rect width="4" height="4" fill="#ccc"/>
+   <path d="M -1,2 l 6,0" stroke="#fff" stroke-width="0.7"/>
+ </pattern>
```

Unreferenced (the only `url(#…)` refs in the file are `boundsClip-1` / `scatterBounds-1`), and `<pattern>` is a never-rendered element. Dimensions are `850×600` on both sides. `pixelsEqual` therefore cannot have returned false and the size check cannot have returned false, which leaves the unanswered path as the only way to reach `false`.

### Why a pair goes unanswered

Two candidates, both plausible under the report page's load, both now handled:

1. **Starved yields.** A pair needs three `yieldToPage()` turns inside one 20s budget, and with the tab visible those went through `requestIdleCallback` *with no `timeout` option* — so they only ran in an idle period. The page keeps thousands of cards mounted and re-renders on a 250ms throttle for the whole check. Now `requestIdleCallback(cb, { timeout: IDLE_DEADLINE_MS })`; the hidden-tab branch already used an unthrottleable MessageChannel macrotask and needs no deadline.
2. **A fetch queued behind the check's own traffic.** Handled by the recheck rather than by extending the timeout.

### The recheck

Deliberately *not* an inline retry. Retrying immediately puts the second attempt into exactly the congestion blamed for the first stall, holds a 1-of-8 `pMap` slot for up to 40s, and keeps both attempts' pixel buffers alive (`loadPixelsFromDom` can't cancel an in-flight `decode()`). Instead the first pass records `"unknown"` and a second `pMap` re-checks just those entries once the first has drained. It relies on the existing behaviour that unknown answers are never cached, so asking again does the work again — that invariant is covered by a test.

While the second pass runs, the countdown has already reached zero, so the progress note says "rechecking what couldn't be checked…" rather than "0 left to check".

### Files

- **`adminSiteClient/svgVisualDiff.ts`** — `UNANSWERED`/`Outcome` replaced by an exported `VisualVerdict = "identical" | "changed" | "unknown"`; `compare` returns it. `boolean | undefined` was avoided deliberately: `!identical` would read the two falsy states as one, reinstating the bug in a shape callers can't see. Adds `IDLE_DEADLINE_MS`; net 33 lines shorter.
- **`adminSiteClient/SvgTesterSuitePage.tsx`** — `VisualSummary` carries `_.countBy`'s map rather than flat counts, so no verdict count is derived by subtraction (the old `total - identical - unknown` had the same "everything I haven't subtracted is changed" shape as the bug). One ordered `VISUAL_VERDICT_LABELS` literal supplies labels, list order and `VISUAL_VERDICTS`. Two-way `_.partition` becomes a three-way `_.groupBy`; the filter fallback asks one question against the on-screen options.
- **`adminSiteClient/svgVisualDiff.test.ts`** — assertions move to verdict strings; adds coverage that an unrasterizable pair reports `"unknown"` and is not remembered.

### Verification

- 11 unit tests pass; `yarn typecheck`, `yarn testLintChanged`, `yarn testFormatChanged` clean.
- The headline clause was rendered through `renderToStaticMarkup` across eight count combinations to confirm the existing strings are unchanged and the new ones read correctly. That pass also caught two things before they shipped: `.SvgTesterSuitePage__headline strong` is 22px, so a `<strong>` inside the 14px muted clause rendered as a shouting number (dropped, matching the sibling progress note); and "none changed visibly, N couldn't be checked" claimed a finding that doesn't exist when *nothing* could be checked, which now reads "none could be checked for visible changes".
- Not exercised in a browser, so the end-to-end behaviour on a real report is unverified.

</details>