### PR TITLE
🐛🤖 don't draw tick labels for hidden facet axes

### DIFF
--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChartThumbnail.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChartThumbnail.tsx
@@ -246,11 +246,13 @@ export class StackedAreaChartThumbnail
                     axis={this.dualAxis.verticalAxis}
                     bounds={this.dualAxis.innerBounds}
                 />
-                <HorizontalAxisComponent
-                    axis={this.dualAxis.horizontalAxis}
-                    bounds={this.dualAxis.bounds}
-                    showEndpointsOnly
-                />
+                {!this.dualAxis.horizontalAxis.hideAxis && (
+                    <HorizontalAxisComponent
+                        axis={this.dualAxis.horizontalAxis}
+                        bounds={this.dualAxis.bounds}
+                        showEndpointsOnly
+                    />
+                )}
                 <StackedAreas series={this.renderSeries} />
                 {this.anchoredLabelsState && (
                     <AnchoredLabels state={this.anchoredLabelsState} />

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChartThumbnail.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedBarChartThumbnail.tsx
@@ -252,11 +252,13 @@ export class StackedBarChartThumbnail
                     axis={this.dualAxis.verticalAxis}
                     bounds={this.dualAxis.innerBounds}
                 />
-                <HorizontalAxisComponent
-                    axis={this.dualAxis.horizontalAxis}
-                    bounds={this.dualAxis.bounds}
-                    showEndpointsOnly
-                />
+                {!this.dualAxis.horizontalAxis.hideAxis && (
+                    <HorizontalAxisComponent
+                        axis={this.dualAxis.horizontalAxis}
+                        bounds={this.dualAxis.bounds}
+                        showEndpointsOnly
+                    />
+                )}
                 <StackedBars series={this.renderSeries} />
                 {this.anchoredLabelsState && (
                     <AnchoredLabels state={this.anchoredLabelsState} />


### PR DESCRIPTION
> _Written by Anthropic Claude Opus 5 — @sophiamersmann at the wheel._

In a faceted chart with a shared x axis, only the bottom-row facets should show the axis. The stacked bar and stacked area thumbnails were drawing the top row's tick labels anyway, right on top of the domain line.

Before / after, `share-companies-using-artificial-intelligence.svg?time=2021..2025&tab=stacked-bar&imType=thumbnail`: the top row's `2021` / `2025` labels sat on the zero line at `y=68`; now only the bottom row's labels are rendered.

The guard is added at the call site rather than inside `HorizontalAxisComponent`, to stay consistent with `DualAxisComponent` and `LineChartThumbnail`, which already do it that way.

<details><summary>Details</summary>

### Root cause

1. `FacetChart.placedSeries` sets `xAxisConfig.hideAxis = shouldHideFacetAxis(...)`, which is `true` for every facet not on the axis' edge when the axis is shared.
2. `HorizontalAxis.height` returns `0` when `hideAxis`, so `DualAxis.innerBounds.bottom === bounds.bottom`.
3. `StackedBarChartThumbnail` / `StackedAreaChartThumbnail` rendered `<HorizontalAxisComponent>` unconditionally, and that component only checks `config.hideTickLabels`, never `hideAxis`. The labels were therefore placed at `bounds.bottom - labelOffset`, i.e. with their baseline exactly on the domain line.

`LineChartThumbnail` already had the `!hideAxis` guard, so line chart facets were unaffected.

### Audit of the other chart types

No other chart type has this problem:

| Path | Status |
|---|---|
| `DualAxisComponent` — LineChart, StackedBarChart, StackedAreaChart, ScatterPlotChart(+Thumbnail), MarimekkoChart(+Thumbnail) | Safe, guards `hideAxis` itself |
| `LineChartThumbnail` | Already guarded |
| `StackedBarChartThumbnail`, `StackedAreaChartThumbnail` | Fixed here |
| `DumbbellChart` | Unreachable — exposes its value axis as `axis`, not `xAxis`/`yAxis`, so `shouldHideFacetAxis` never sees it |
| `StackedDiscreteBarChart` | Unreachable — `isSharedYAxis` excludes `StackedDiscreteBar` |
| `SlopeChart` / `SlopeChartThumbnail` | Safe — `getXAxisConfigSettings` reinterprets `hideAxis` as `hideTickLabels` so the vertical time lines stay visible, and `xAxisHeight`, `SlopeChartXAxis` and the log notice all key off that |
| `DiscreteBarChartThumbnail`, `StackedDiscreteBarChartThumbnail`, `DumbbellChartThumbnail`, `MapChart(+Thumbnail)` | Render no axis at all |

The one cost of guarding per call site: a future caller of `HorizontalAxisComponent` can hit this again, and `DumbbellChart` / `StackedDiscreteBarChart` would break the same way if someone set `hideAxis` directly in the chart config. Putting `if (axis.hideAxis) return null` inside the component would close that off for good, if we'd rather have it there.

### Testing

- `yarn typecheck`, `yarn testLintChanged`, `yarn testFormatChanged` clean.
- `yarn test run FacetChart.test.ts StackedBarChart.test.ts LineChart.test.ts` — 38 passed.
- Verified against the local functions server for both `tab=stacked-bar` and `tab=stacked-area`: the six duplicated top-row tick labels are gone, the bottom row's six remain.
- `make svgtest` not run.

</details>