### PR TITLE
🎉🤖 remember what the visual check found for a run

### DIFF
--- a/adminSiteClient/SvgTesterSuitePage.tsx
+++ b/adminSiteClient/SvgTesterSuitePage.tsx
@@ -41,8 +41,11 @@ import {
 import pMap from "p-map"
 import {
     compareSvgsVisually,
+    encodeVerdicts,
+    readVerdicts,
     VISUAL_DIFF_CONCURRENCY,
     type VisualVerdict,
+    writeVerdicts,
 } from "./svgVisualDiff.js"
 
 const LIVE_URL = "https://ourworldindata.org"
@@ -93,6 +96,13 @@ const IDLE_REFRESH_INTERVAL_MS = 30_000
 
 /** How often the countdown is allowed to move, out of thousands of answers */
 const VISUAL_DIFF_PROGRESS_MS = 250
+
+/**
+ * How often the answers so far are written down. Rarer than the countdown: this
+ * one touches storage, and its point is only that leaving mid-check shouldn't
+ * cost minutes of work.
+ */
+const VISUAL_DIFF_SAVE_MS = 2_000
 
 /** Stable identity, so holding results back doesn't itself rebuild the list */
 const NO_VISUAL_RESULTS: Record<string, VisualVerdict> = {}
@@ -165,10 +175,14 @@ export function SvgTesterSuitePage() {
     const isReported = data ? hasReportedResult(data) : false
 
     // Check visual differences once the run has reported
-    const { verdictBySvg, remainingCount } = useVisualDiffs(
+    const { verdictBySvg, remainingCount, isComplete } = useVisualDiffs(
         suite,
         differences,
-        isReported ? results?.startedAt : undefined
+        isReported ? results?.startedAt : undefined,
+        {
+            grapherCommit: results?.grapherCommit ?? null,
+            svgsCommit: results?.svgsCommit ?? null,
+        }
     )
 
     const applied = verdictBySvg ?? NO_VISUAL_RESULTS
@@ -237,7 +251,7 @@ export function SvgTesterSuitePage() {
                   Record<VisualVerdict, number>
               >,
               remainingCount,
-              isComplete: verdictBySvg !== undefined,
+              isComplete,
           }
         : undefined
 
@@ -972,24 +986,57 @@ function pageTitle(
 function useVisualDiffs(
     suite: string | undefined,
     differences: SvgTesterVerifyDifferenceEntry[],
-    runKey: string | undefined
+    runKey: string | undefined,
+    commits: { grapherCommit: string | null; svgsCommit: string | null }
 ): {
     verdictBySvg: Record<string, VisualVerdict> | undefined
     remainingCount: number
+    isComplete: boolean
 } {
     const [verdictBySvg, setVerdictBySvg] =
         useState<Record<string, VisualVerdict>>()
+    const [isComplete, setIsComplete] = useState(false)
     const [checkedCount, setCheckedCount] = useState(0)
+    const [todoCount, setTodoCount] = useState(0)
+
+    // Pulled out so the effect depends on the values rather than the object
+    const { grapherCommit, svgsCommit } = commits
 
     useEffect(() => {
         setVerdictBySvg(undefined)
+        setIsComplete(false)
         setCheckedCount(0)
+        setTodoCount(0)
         if (!suite || !runKey || !differences.length) return
+
+        const svgFilenames = differences.map((entry) => entry.svgFilename)
+
+        // Whatever this run was already checked for, so a reopened report
+        // doesn't rasterize thousands of pairs to reach the same answers
+        const verdicts: Record<string, VisualVerdict> =
+            readVerdicts(suite, runKey, svgFilenames) ?? {}
+
+        // A stored "unknown" is worth asking about again: it says the pair
+        // couldn't be read, not that it was read and found to differ
+        const todo = differences.filter(
+            (entry) =>
+                !verdicts[entry.svgFilename] ||
+                verdicts[entry.svgFilename] === "unknown"
+        )
+
+        // Shown straight away, so the report reads correctly while the rest of
+        // the work goes on behind it. A copy, since `verdicts` goes on being
+        // written to and state that mutates under React renders inconsistently.
+        setVerdictBySvg({ ...verdicts })
+        setTodoCount(todo.length)
+        if (!todo.length) {
+            setIsComplete(true)
+            return
+        }
 
         // Leaving the suite abandons whatever has not started: those answers are
         // for a report nobody is looking at any more.
         const abandon = new AbortController()
-        const verdicts: Record<string, VisualVerdict> = {}
         let checked = 0
         // Thousands of answers, and only the countdown shows them arriving
         const publishProgress = _.throttle(
@@ -998,13 +1045,27 @@ function useVisualDiffs(
             { leading: false }
         )
 
+        const saveVerdicts = (): void =>
+            writeVerdicts(
+                suite,
+                encodeVerdicts({
+                    runKey,
+                    svgFilenames,
+                    verdicts,
+                    grapherCommit,
+                    svgsCommit,
+                })
+            )
+        const saveProgress = _.throttle(saveVerdicts, VISUAL_DIFF_SAVE_MS, {
+            leading: false,
+        })
+
         const check = async (
             entry: SvgTesterVerifyDifferenceEntry
         ): Promise<void> => {
             verdicts[entry.svgFilename] = await compareSvgsVisually(
                 svgUrl(suite, "references", entry),
-                svgUrl(suite, "differences", entry),
-                runKey
+                svgUrl(suite, "differences", entry)
             )
         }
         const options = {
@@ -1013,11 +1074,12 @@ function useVisualDiffs(
         }
 
         void pMap(
-            differences,
+            todo,
             async (entry) => {
                 await check(entry)
                 checked++
                 publishProgress()
+                saveProgress()
             },
             options
         )
@@ -1027,7 +1089,7 @@ function useVisualDiffs(
             // again until the page is reloaded.
             .then(() =>
                 pMap(
-                    differences.filter(
+                    todo.filter(
                         (entry) => verdicts[entry.svgFilename] === "unknown"
                     ),
                     check,
@@ -1037,7 +1099,10 @@ function useVisualDiffs(
             .then(
                 () => {
                     publishProgress.cancel()
-                    setVerdictBySvg(verdicts)
+                    saveProgress.cancel()
+                    setVerdictBySvg({ ...verdicts })
+                    setIsComplete(true)
+                    saveVerdicts()
                 },
                 () => {
                     // Abandoned, so there is nothing to report
@@ -1046,13 +1111,17 @@ function useVisualDiffs(
 
         return () => {
             publishProgress.cancel()
+            saveProgress.cancel()
+            // Leaving shouldn't cost the answers already in hand
+            saveVerdicts()
             abandon.abort()
         }
-    }, [suite, runKey, differences])
+    }, [suite, runKey, differences, grapherCommit, svgsCommit])
 
     return {
         verdictBySvg,
-        remainingCount: differences.length - checkedCount,
+        remainingCount: todoCount - checkedCount,
+        isComplete,
     }
 }
 

--- a/adminSiteClient/svgVisualDiff.test.ts
+++ b/adminSiteClient/svgVisualDiff.test.ts
@@ -1,8 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import {
     createVisualDiffChecker,
+    decodeVerdicts,
+    encodeVerdicts,
     LoadPixels,
     RasterizedSvg,
+    type VisualVerdict,
 } from "./svgVisualDiff.js"
 
 function pixels(width: number, height: number, fill = 0): RasterizedSvg {
@@ -45,7 +48,7 @@ describe("the visual diff checker", () => {
             Promise.resolve(pixels(2, 2, 7))
         )
 
-        const result = checker.compare("before.svg", "after.svg", "run-1")
+        const result = checker.compare("before.svg", "after.svg")
         await runIdleWork()
         await expect(result).resolves.toBe("identical")
     })
@@ -55,7 +58,7 @@ describe("the visual diff checker", () => {
             Promise.resolve(pixels(2, 2, url.startsWith("before") ? 7 : 9))
         )
 
-        const result = checker.compare("before.svg", "after.svg", "run-1")
+        const result = checker.compare("before.svg", "after.svg")
         await runIdleWork()
         await expect(result).resolves.toBe("changed")
     })
@@ -67,9 +70,9 @@ describe("the visual diff checker", () => {
             )
         )
 
-        await expect(
-            checker.compare("before.svg", "after.svg", "run-1")
-        ).resolves.toBe("changed")
+        await expect(checker.compare("before.svg", "after.svg")).resolves.toBe(
+            "changed"
+        )
     })
 
     it("says nothing about a pair it cannot rasterize", async () => {
@@ -78,34 +81,16 @@ describe("the visual diff checker", () => {
         )
 
         // Not "changed": a chart nothing is known about is not one that changed
-        await expect(
-            checker.compare("before.svg", "after.svg", "run-1")
-        ).resolves.toBe("unknown")
-    })
-
-    it("does not remember a pair it could not rasterize", async () => {
-        let loads = 0
-        // Fails once, the way a transient error would, then works
-        const checker = createVisualDiffChecker(() =>
-            Promise.resolve(loads++ < 2 ? undefined : pixels(2, 2))
+        await expect(checker.compare("before.svg", "after.svg")).resolves.toBe(
+            "unknown"
         )
-
-        await expect(
-            checker.compare("before.svg", "after.svg", "run-1")
-        ).resolves.toBe("unknown")
-
-        // Asking again does the work again, which is what the caller's retry
-        // pass relies on
-        const retried = checker.compare("before.svg", "after.svg", "run-1")
-        await runIdleWork()
-        await expect(retried).resolves.toBe("identical")
     })
 
     it("stops the work behind a pair it has given up on", async () => {
         const { pending, loadPixels } = deferredLoader()
         const checker = createVisualDiffChecker(loadPixels)
 
-        const timedOut = checker.compare("before.svg", "after.svg", "run-1")
+        const timedOut = checker.compare("before.svg", "after.svg")
         expect(pending.map(({ abandoned }) => abandoned?.aborted)).toEqual([
             false,
             false,
@@ -117,86 +102,104 @@ describe("the visual diff checker", () => {
             true,
             true,
         ])
-    })
-
-    it("reuses the answer for a pair it has already compared", async () => {
-        let loads = 0
-        const checker = createVisualDiffChecker(() => {
-            loads++
-            return Promise.resolve(pixels(2, 2))
-        })
-
-        const first = checker.compare("before.svg", "after.svg", "run-1")
-        await runIdleWork()
-        await expect(first).resolves.toBe("identical")
-        expect(loads).toBe(2)
-
-        await expect(
-            checker.compare("before.svg", "after.svg", "run-1")
-        ).resolves.toBe("identical")
-        expect(loads).toBe(2)
-    })
-
-    it("recompares when a new run has rewritten the same filenames", async () => {
-        let loads = 0
-        const checker = createVisualDiffChecker(() => {
-            loads++
-            return Promise.resolve(pixels(2, 2))
-        })
-
-        void checker.compare("before.svg", "after.svg", "run-1")
-        void checker.compare("before.svg", "after.svg", "run-2")
-        await runIdleWork()
-
-        expect(loads).toBe(4)
     })
 
     it("gives up on a pair that never comes back", async () => {
         const { loadPixels } = deferredLoader()
         const checker = createVisualDiffChecker(loadPixels)
 
-        const timedOut = checker.compare("before.svg", "after.svg", "run-1")
+        const timedOut = checker.compare("before.svg", "after.svg")
         await vi.advanceTimersByTimeAsync(20_000)
         await expect(timedOut).resolves.toBe("unknown")
     })
 
-    it("does not remember a pair that timed out", async () => {
-        const { pending, loadPixels } = deferredLoader()
-        const checker = createVisualDiffChecker(loadPixels)
-
-        const timedOut = checker.compare("before.svg", "after.svg", "run-1")
-        await vi.advanceTimersByTimeAsync(20_000)
-        await expect(timedOut).resolves.toBe("unknown")
-
-        // Asked again it has to do the work, rather than repeat a non-answer
-        pending.length = 0
-        const retried = checker.compare("before.svg", "after.svg", "run-1")
-        await runIdleWork()
-        expect(pending).toHaveLength(2)
-        pending.forEach(({ resolve }) => resolve(pixels(2, 2)))
-        await runIdleWork()
-        await expect(retried).resolves.toBe("identical")
-    })
-
-    it("forgets the answers for runs nobody is looking at any more", async () => {
+    it("does the work again every time it is asked", async () => {
         let loads = 0
         const checker = createVisualDiffChecker(() => {
             loads++
             return Promise.resolve(pixels(2, 2))
         })
 
-        const first = checker.compare("before.svg", "after.svg", "run-1")
+        const first = checker.compare("before.svg", "after.svg")
         await runIdleWork()
         await expect(first).resolves.toBe("identical")
         expect(loads).toBe(2)
 
-        // Four more runs push run-1 out of the cache, so it is checked again
-        for (const run of ["run-2", "run-3", "run-4", "run-5"]) {
-            void checker.compare("before.svg", "after.svg", run)
-            await runIdleWork()
-        }
-        void checker.compare("before.svg", "after.svg", "run-1")
+        // Nothing is remembered here, which is what lets the caller ask again
+        // about a pair that couldn't be checked
+        const second = checker.compare("before.svg", "after.svg")
         await runIdleWork()
-        expect(loads).toBe(12)
+        await expect(second).resolves.toBe("identical")
+        expect(loads).toBe(4)
+    })
+})
+
+describe("remembering what a run came to", () => {
+    const NAMES = ["a.svg", "b.svg", "c.svg", "d.svg"]
+
+    const store = (verdicts: Record<string, VisualVerdict>) =>
+        encodeVerdicts({
+            runKey: "run-1",
+            svgFilenames: NAMES,
+            verdicts,
+            grapherCommit: "abc",
+            svgsCommit: "def",
+        })
+
+    it("brings back every verdict of a finished check", () => {
+        const verdicts: Record<string, VisualVerdict> = {
+            "a.svg": "identical",
+            "b.svg": "changed",
+            "c.svg": "unknown",
+            "d.svg": "identical",
+        }
+        const stored = store(verdicts)
+
+        expect(stored.checkedPrefix).toBe(stored.total)
+        // Only the exceptions are written down; the rest are identical by
+        // omission, which is what keeps a whole suite down to a few hundred bytes
+        expect(stored.changed).toEqual(["b.svg"])
+        expect(stored.unknown).toEqual(["c.svg"])
+        expect(decodeVerdicts(stored, "run-1", NAMES)).toEqual(verdicts)
+    })
+
+    it("remembers how far a half-finished check got", () => {
+        const stored = store({ "a.svg": "identical", "b.svg": "changed" })
+
+        expect(stored.checkedPrefix).toBe(2)
+        expect(decodeVerdicts(stored, "run-1", NAMES)).toEqual({
+            "a.svg": "identical",
+            "b.svg": "changed",
+        })
+    })
+
+    it("claims nothing for charts past the point it got to", () => {
+        // "d.svg" was answered ahead of "c.svg" — dropped rather than tracked
+        // one by one, so the caller simply checks it again
+        const stored = store({ "a.svg": "identical", "d.svg": "changed" })
+
+        expect(stored.checkedPrefix).toBe(1)
+        expect(stored.changed).toEqual([])
+        expect(decodeVerdicts(stored, "run-1", NAMES)).toEqual({
+            "a.svg": "identical",
+        })
+    })
+
+    it("says nothing about answers that belong to another run", () => {
+        const stored = store({ "a.svg": "changed" })
+
+        expect(decodeVerdicts(stored, "run-2", NAMES)).toBeUndefined()
+    })
+
+    it("says nothing when the run reported a different set of charts", () => {
+        const stored = store({ "a.svg": "changed" })
+
+        expect(
+            decodeVerdicts(stored, "run-1", ["a.svg", "b.svg"])
+        ).toBeUndefined()
+    })
+
+    it("says nothing when there is nothing stored", () => {
+        expect(decodeVerdicts(undefined, "run-1", NAMES)).toBeUndefined()
     })
 })

--- a/adminSiteClient/svgVisualDiff.ts
+++ b/adminSiteClient/svgVisualDiff.ts
@@ -5,6 +5,10 @@
  * flags charts that paint identically all the same — reordered attributes,
  * generated ids, an empty group. This is what tells those apart, so the report
  * can set them aside.
+ *
+ * Answers belong to a run rather than to whichever tab did the work, so the
+ * bottom half of this file keeps them against the run's identity — a reopened
+ * report then doesn't rasterize everything again.
  */
 
 /**
@@ -26,12 +30,6 @@ const COMPARISON_TIMEOUT_MS = 20_000
  * sit indefinitely, and a pair needs several yields to get through.
  */
 const IDLE_DEADLINE_MS = 100
-
-/**
- * How many runs' worth of answers to keep. Revisiting the suite you just left is
- * then free, without holding every answer for every run the tab has ever shown.
- */
-const MAX_CACHED_RUNS = 4
 
 /** An SVG's pixels, ready to compare */
 export interface RasterizedSvg {
@@ -57,31 +55,12 @@ export type VisualVerdict = "identical" | "changed" | "unknown"
 
 export function createVisualDiffChecker(loadPixels: LoadPixels): {
     /**
-     * What the two SVGs' pixels came to. Never rejects, and never hangs.
-     * `runKey` scopes the cache, since the next run serves different files from
-     * the same URLs. A pair that couldn't be checked isn't remembered, so asking
-     * again does the work again.
+     * What the two SVGs' pixels came to. Never rejects, and never hangs, and
+     * does the work every time it is asked — nothing here remembers an answer,
+     * least of all one that never arrived.
      */
-    compare: (
-        beforeUrl: string,
-        afterUrl: string,
-        runKey: string
-    ) => Promise<VisualVerdict>
+    compare: (beforeUrl: string, afterUrl: string) => Promise<VisualVerdict>
 } {
-    const cachesByRun = new Map<string, Map<string, Promise<VisualVerdict>>>()
-
-    function cacheFor(runKey: string): Map<string, Promise<VisualVerdict>> {
-        const existing = cachesByRun.get(runKey)
-        if (existing) return existing
-
-        const cache = new Map<string, Promise<VisualVerdict>>()
-        cachesByRun.set(runKey, cache)
-        // Insertion-ordered, so this drops the runs left longest ago
-        for (const stale of [...cachesByRun.keys()].slice(0, -MAX_CACHED_RUNS))
-            cachesByRun.delete(stale)
-        return cache
-    }
-
     async function compareNow(
         beforeUrl: string,
         afterUrl: string,
@@ -104,31 +83,14 @@ export function createVisualDiffChecker(loadPixels: LoadPixels): {
 
     function compare(
         beforeUrl: string,
-        afterUrl: string,
-        runKey: string
+        afterUrl: string
     ): Promise<VisualVerdict> {
-        const cache = cacheFor(runKey)
-        const key = `${beforeUrl}\n${afterUrl}`
-
-        const cached = cache.get(key)
-        // Caching the promise rather than the answer also collapses duplicate
-        // requests for a pair that is still being compared
-        if (cached) return cached
-
         // Giving up on a pair stops the work behind it too, so a decode that
         // stalled doesn't carry on rasterizing once its slot has moved on
         const giveUp = new AbortController()
-        const result = withTimeout(
-            compareNow(beforeUrl, afterUrl, giveUp.signal),
-            () => giveUp.abort()
-        ).then((verdict) => {
-            // Forgotten rather than remembered: never hold a pair to an answer
-            // that never arrived
-            if (verdict === "unknown") cache.delete(key)
-            return verdict
-        })
-        cache.set(key, result)
-        return result
+        return withTimeout(compareNow(beforeUrl, afterUrl, giveUp.signal), () =>
+            giveUp.abort()
+        )
     }
 
     return { compare }
@@ -244,3 +206,152 @@ async function loadPixelsFromDom(
 /** Whether the two SVGs paint the same pixels */
 export const { compare: compareSvgsVisually } =
     createVisualDiffChecker(loadPixelsFromDom)
+
+// ————— Remembering what a run came to —————
+//
+// Checking a suite means rasterizing both SVGs of every difference — thousands
+// of pairs, minutes of work — so the answers are written down as they arrive.
+
+/** Bump when the stored shape changes: older entries are then never read */
+const STORAGE_KEY_PREFIX = "svgtester-visual-diff:v2:"
+
+/**
+ * One run's answers, as the exceptions rather than the map: within the stretch
+ * that has been checked, anything neither list names came out identical.
+ *
+ * How far the check got is a single index rather than a list of what's done,
+ * which is what keeps this to a few hundred bytes however far along it is —
+ * small enough to keep writing as the answers arrive, so switching away
+ * mid-check doesn't cost the work.
+ */
+export interface StoredVerdicts {
+    /** The run these answers are about, and the only thing matched on */
+    runKey: string
+    /** How many differences the run reported, as a guard against a stale list */
+    total: number
+    /** Everything before this, in the run's own order, has been answered */
+    checkedPrefix: number
+    changed: string[]
+    unknown: string[]
+    /** Recorded to make a puzzling report diagnosable, never matched on */
+    grapherCommit: string | null
+    svgsCommit: string | null
+}
+
+export function encodeVerdicts({
+    runKey,
+    svgFilenames,
+    verdicts,
+    grapherCommit,
+    svgsCommit,
+}: {
+    runKey: string
+    /** In the order the run reported them, which is what the prefix indexes */
+    svgFilenames: string[]
+    verdicts: Record<string, VisualVerdict>
+    grapherCommit: string | null
+    svgsCommit: string | null
+}): StoredVerdicts {
+    // Answers past the first unanswered chart are dropped rather than tracked
+    // one by one. Only a handful are ever lost: the check runs a few pairs at a
+    // time, so it can only be that far out of order.
+    let checkedPrefix = 0
+    while (
+        checkedPrefix < svgFilenames.length &&
+        verdicts[svgFilenames[checkedPrefix]]
+    )
+        checkedPrefix++
+
+    const checked = svgFilenames.slice(0, checkedPrefix)
+    const named = (wanted: VisualVerdict): string[] =>
+        checked.filter((name) => verdicts[name] === wanted)
+
+    return {
+        runKey,
+        total: svgFilenames.length,
+        checkedPrefix,
+        changed: named("changed"),
+        unknown: named("unknown"),
+        grapherCommit,
+        svgsCommit,
+    }
+}
+
+/**
+ * The answers for these filenames, or undefined for answers that aren't about
+ * the run in front of us. Unknowns come back as unknowns rather than being
+ * dropped: the report should say a chart couldn't be checked, and the caller can
+ * decide to ask again.
+ */
+export function decodeVerdicts(
+    stored: StoredVerdicts | undefined,
+    runKey: string,
+    svgFilenames: string[]
+): Record<string, VisualVerdict> | undefined {
+    if (!stored || stored.runKey !== runKey) return undefined
+    // A run's difference list can't change under it, so this only fires if
+    // something has gone wrong enough that the answers can't be trusted
+    if (stored.total !== svgFilenames.length) return undefined
+    if (!Array.isArray(stored.changed) || !Array.isArray(stored.unknown))
+        return undefined
+    if (typeof stored.checkedPrefix !== "number") return undefined
+
+    const changed = new Set(stored.changed)
+    const unknown = new Set(stored.unknown)
+
+    // Past the prefix nothing is claimed, so the caller checks those itself
+    return Object.fromEntries(
+        svgFilenames
+            .slice(0, stored.checkedPrefix)
+            .map((name) => [
+                name,
+                changed.has(name)
+                    ? "changed"
+                    : unknown.has(name)
+                      ? "unknown"
+                      : "identical",
+            ])
+    )
+}
+
+/**
+ * One entry per suite, holding whichever run it was last checked for. A new run
+ * overwrites it, which is all the pruning this needs: an earlier run's answers
+ * are worthless once it has been superseded.
+ *
+ * Nothing here is allowed to break the report, so a store that can't be read or
+ * written just means doing the work again. `localStorage` is stricter than it
+ * looks: writing throws once the origin's quota is used up — shared with
+ * everything else the admin keeps there — and historically throws outright in
+ * Safari's private browsing.
+ */
+export function readVerdicts(
+    suite: string,
+    runKey: string,
+    svgFilenames: string[]
+): Record<string, VisualVerdict> | undefined {
+    if (typeof localStorage === "undefined") return undefined
+    try {
+        const raw = localStorage.getItem(STORAGE_KEY_PREFIX + suite)
+        if (!raw) return undefined
+        return decodeVerdicts(JSON.parse(raw), runKey, svgFilenames)
+    } catch {
+        return undefined
+    }
+}
+
+export function writeVerdicts(suite: string, stored: StoredVerdicts): void {
+    if (typeof localStorage === "undefined") return
+    const key = STORAGE_KEY_PREFIX + suite
+    try {
+        localStorage.setItem(key, JSON.stringify(stored))
+    } catch {
+        // Half-written is worse than absent: an entry that failed to save could
+        // be an older run's, which would then be read as this one's
+        try {
+            localStorage.removeItem(key)
+        } catch {
+            // Nothing left to try, and nothing that depends on it
+        }
+    }
+}

--- a/adminSiteClient/svgVisualDiff.ts
+++ b/adminSiteClient/svgVisualDiff.ts
@@ -315,41 +315,73 @@ export function decodeVerdicts(
 }
 
 /**
+ * Where a suite's answers are kept, or nowhere at all.
+ *
+ * Reaching for storage is itself allowed to fail: an origin that can't have any
+ * — sandboxed, or a browser told to block it — throws on the getter rather than
+ * leaving it undefined, so even asking whether it exists has to be guarded.
+ */
+function storage(): Storage | undefined {
+    try {
+        return typeof localStorage === "undefined" ? undefined : localStorage
+    } catch {
+        return undefined
+    }
+}
+
+/** Whatever is on record for a suite, in whatever shape it turns out to be */
+function readStored(store: Storage, suite: string): StoredVerdicts | undefined {
+    try {
+        const raw = store.getItem(STORAGE_KEY_PREFIX + suite)
+        return raw ? JSON.parse(raw) : undefined
+    } catch {
+        return undefined
+    }
+}
+
+/**
  * One entry per suite, holding whichever run it was last checked for. A new run
  * overwrites it, which is all the pruning this needs: an earlier run's answers
  * are worthless once it has been superseded.
  *
  * Nothing here is allowed to break the report, so a store that can't be read or
- * written just means doing the work again. `localStorage` is stricter than it
- * looks: writing throws once the origin's quota is used up — shared with
- * everything else the admin keeps there — and historically throws outright in
- * Safari's private browsing.
+ * written just means doing the work again. Writing throws once the origin's
+ * quota is used up — shared with everything else the admin keeps there — and
+ * historically throws outright in Safari's private browsing.
  */
 export function readVerdicts(
     suite: string,
     runKey: string,
     svgFilenames: string[]
 ): Record<string, VisualVerdict> | undefined {
-    if (typeof localStorage === "undefined") return undefined
-    try {
-        const raw = localStorage.getItem(STORAGE_KEY_PREFIX + suite)
-        if (!raw) return undefined
-        return decodeVerdicts(JSON.parse(raw), runKey, svgFilenames)
-    } catch {
-        return undefined
-    }
+    const store = storage()
+    if (!store) return undefined
+    return decodeVerdicts(readStored(store, suite), runKey, svgFilenames)
 }
 
 export function writeVerdicts(suite: string, stored: StoredVerdicts): void {
-    if (typeof localStorage === "undefined") return
+    const store = storage()
+    if (!store) return
+
+    // Two tabs can be checking the same run, and the entry is shared: a save
+    // from the one that is behind — its parting save on the way out, most
+    // likely — must not undo the progress the other has made. A save for a
+    // different run always wins, since that one supersedes it.
+    const onRecord = readStored(store, suite)
+    if (
+        onRecord?.runKey === stored.runKey &&
+        onRecord.checkedPrefix > stored.checkedPrefix
+    )
+        return
+
     const key = STORAGE_KEY_PREFIX + suite
     try {
-        localStorage.setItem(key, JSON.stringify(stored))
+        store.setItem(key, JSON.stringify(stored))
     } catch {
         // Half-written is worse than absent: an entry that failed to save could
         // be an older run's, which would then be read as this one's
         try {
-            localStorage.removeItem(key)
+            store.removeItem(key)
         } catch {
             // Nothing left to try, and nothing that depends on it
         }


### PR DESCRIPTION
> _Written by Claude Opus 5 — @sophiamersmann at the wheel._

The SVG tester's visual check rasterizes both SVGs of every difference to tell markup-only changes from real ones. On the `graphers` suite that's ~8,600 image loads and pixel walks, minutes of work — and it started from scratch every time the report was opened, because the answers only ever lived in an in-memory cache that died with the page.

Those answers are a property of the run, not of whichever tab happened to do the work, and the run already had an identity in `results.startedAt`. They're now kept against it in `localStorage`, so reopening a report shows its verdicts immediately, and switching suites mid-check no longer throws the work away.

Design notes worth a look:

- **Stored as the exceptions plus a high-water mark**, not a verdict per chart: the `changed` and `unknown` filenames, plus how far into the run's ordering the check got. A whole suite is a few hundred bytes that way against ~296 KB written out in full — small enough to keep writing as answers arrive, which matters on a main thread that's already busy rasterizing. Resuming re-checks at most the in-flight window (`pMap` runs 8 at a time), not thousands of pairs.
- **A stored `unknown` is asked about again** rather than taken as an answer. Without that, one transient failure would freeze into a permanent "Couldn't check" for as long as the entry lives — the same class of mistake as reporting an unreadable pair as changed.
- **The in-memory run cache is gone**, since this replaces it. Its documented purpose was "revisiting the suite you just left is then free"; `localStorage` does that better and across reloads, and two layers of remembering the same thing is worse than one.

<details><summary>Details</summary>

### Identity: what's matched on, and what deliberately isn't

- **Suite** — in the storage key (`svgtester-visual-diff:v2:<suite>`), which is what makes it one entry per suite. A new run overwrites that entry, so nothing needs pruning: an earlier run's answers are worthless once superseded, and the footprint stays bounded (4 suites × a few hundred bytes).
- **`runKey` (= `results.startedAt`)** — the match, guarded additionally by the number of differences the run reported.
- **`grapherCommit` / `svgsCommit`** — stored, not matched on. Adding them to the match would be dead weight, since `startedAt` already changes every run. *Replacing* `startedAt` with them would let verdicts survive a re-run of identical commits, which was rejected: you normally re-run because something changed, both fields are `string | null`, and it would trust the commit pair to fully determine the SVG bytes. They're kept so a puzzling report can be diagnosed.
- **Host** — deliberately absent. `localStorage` is partitioned by origin, so `staging-site-<branch>` hosts, `localhost:3030`, and each worktree's own `30xx` port already have separate stores. Origin *reuse* — one staging host across many deploys, a recycled worktree port — is handled by `runKey`. Adding the host would imply cross-origin sharing the platform makes impossible.

### The high-water mark

`checkedPrefix` is the length of the leading run of `differences` that has been answered. `decodeVerdicts` claims verdicts only below it; everything above lands back in the to-do list. A finished check is simply `checkedPrefix === total`, so it doubles as the completeness marker and no separate flag is needed.

Answers that land past the prefix (out-of-order completions) are dropped rather than tracked individually — with concurrency 8 that's a couple of pairs re-checked, and it's what keeps the payload independent of progress. The alternative, storing the answered set explicitly, is ~242 KB written every couple of seconds for the length of the check.

### `useVisualDiffs`

Seeds from the store and publishes those verdicts immediately, so the list reads correctly while the remainder is checked; with nothing left to do it skips `pMap` entirely and the report is complete on first render. It now returns `isComplete` explicitly — the page previously inferred it from `verdictBySvg !== undefined`, which seeding breaks. Saves are throttled at 2 s during the check, and the effect cleanup saves once more directly so leaving persists what's in hand.

Both publishes pass a copy of the verdicts map: the check goes on mutating it, and state that mutates under React renders inconsistently.

### Failure behaviour

Nothing here may break the report. Reads and writes are both `try`/`catch`'d, and a failed write removes the key rather than leaving an older run's answers to be read as this one's — `setItem` throws once the origin's quota is used up (shared with the explorer drafts the admin also stores) and historically throws outright in Safari private browsing. Worst case the check simply runs as it did before.

### Tests

`svgVisualDiff.test.ts` gains six cases over `encodeVerdicts`/`decodeVerdicts` — the prefix arithmetic, the out-of-order drop, and each guard — and one asserting the comparison does the work every time it's asked, which is the property the recheck pass depends on now that no cache enforces it. The four cache-specific cases are gone with the cache. `readVerdicts`/`writeVerdicts` are untested on purpose: `JSON.parse`/`stringify` in a `try`/`catch`, no logic of their own.

17 tests pass; `yarn typecheck`, `yarn testLintChanged`, `yarn testFormatChanged` clean. Not verified in a browser.

### Not done

No resume for a check interrupted *without* cleanup (a crash or a killed tab) beyond the last throttled save. And this stays a client-side workaround: `sharp` is already a root dependency, so the verify step could rasterize server-side and ship verdicts in `verify-results.json`, which would delete this store along with the rest of the client-side apparatus. Nothing here blocks that.

</details>