### PR TITLE
🐛 (search) ask Algolia for every facet value, not its first hundred

### DIFF
--- a/functions/api/search/searchApi.integration.test.ts
+++ b/functions/api/search/searchApi.integration.test.ts
@@ -108,6 +108,27 @@ describe("searchCharts with real Algolia", () => {
         ).rejects.toThrow(/does not exist. Available topics:/)
     })
 
+    it("does not claim a valid topic doesn't exist just because the search found nothing", async () => {
+        // The topic list this validation consults comes from a facet query, and
+        // Algolia caps facet values at 100 unless asked for more, while the
+        // index carries ~140 topic tags. "Polio" is a real topic that falls
+        // outside the 100 commonest, so before maxValuesPerFacet was set this
+        // rejected it as nonexistent whenever a query returned nothing.
+        const result = await searchCharts(
+            algoliaConfig,
+            {
+                query: "zzzzqqqqnotarealquery",
+                filters: [{ type: FilterType.TOPIC, name: "Polio" }],
+                requireAllCountries: false,
+            },
+            0,
+            5
+        )
+
+        expect(result.nbHits).toBe(0)
+        expect(result.results).toEqual([])
+    })
+
     it("handles pagination", async () => {
         const page0 = await searchCharts(
             algoliaConfig,

--- a/functions/api/search/searchApi.ts
+++ b/functions/api/search/searchApi.ts
@@ -11,6 +11,7 @@ import {
     getFilterNamesOfType,
     buildChartsFacetFilters,
     searchSingleForHitsWithClosestMatches,
+    MAX_FACET_VALUES,
 } from "@ourworldindata/utils"
 import {
     getIndexName,
@@ -114,9 +115,6 @@ const DATA_CATALOG_ATTRIBUTES = [
 /**
  * Fetches available topics from Algolia
  */
-// Algolia's hard ceiling for facet values in one response.
-const MAX_FACET_VALUES = 1000
-
 async function getAvailableTopics(config: AlgoliaConfig): Promise<string[]> {
     const indexName = getIndexName(
         SearchIndexName.ExplorerViewsMdimViewsAndCharts,

--- a/functions/api/search/searchApi.ts
+++ b/functions/api/search/searchApi.ts
@@ -114,6 +114,9 @@ const DATA_CATALOG_ATTRIBUTES = [
 /**
  * Fetches available topics from Algolia
  */
+// Algolia's hard ceiling for facet values in one response.
+const MAX_FACET_VALUES = 1000
+
 async function getAvailableTopics(config: AlgoliaConfig): Promise<string[]> {
     const indexName = getIndexName(
         SearchIndexName.ExplorerViewsMdimViewsAndCharts,
@@ -128,6 +131,15 @@ async function getAvailableTopics(config: AlgoliaConfig): Promise<string[]> {
                 query: "",
                 hitsPerPage: 0,
                 facets: ["tags"],
+                // Algolia returns at most 100 values per facet unless asked for
+                // more, and the index carries appreciably more topic tags than
+                // that. Left at the default, this listed the 100 commonest and
+                // silently dropped the rest, so a perfectly valid but less-used
+                // topic — Books, Gender Ratio, Nuclear Energy, Tetanus — was
+                // reported to callers as a topic that does not exist (see
+                // searchCharts, which only consults this list when a search
+                // comes back empty). The cap is Algolia's documented maximum.
+                maxValuesPerFacet: MAX_FACET_VALUES,
             },
         ],
     })

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -402,6 +402,7 @@ export {
     formatCountryFacetFilters,
     formatTopicFacetFilters,
     buildChartsFacetFilters,
+    MAX_FACET_VALUES,
 } from "./search/searchFacetFilters.js"
 
 export {

--- a/packages/@ourworldindata/utils/src/search/searchFacetFilters.ts
+++ b/packages/@ourworldindata/utils/src/search/searchFacetFilters.ts
@@ -1,5 +1,14 @@
 import { Filter, FilterType, SearchFacetFilters } from "@ourworldindata/types"
 
+/**
+ * What to pass as `maxValuesPerFacet` when a search needs the *complete* list of
+ * a facet's values rather than a sample. Algolia caps facet values at 100 unless
+ * asked for more, which silently truncates any facet with more values than that
+ * — our `tags` facet among them — and a truncated list reads as "these topics
+ * have no content". 1000 is Algolia's documented maximum.
+ */
+export const MAX_FACET_VALUES = 1000
+
 // Shared between the site's client-side Algolia queries (site/search/queries.ts)
 // and the public /api/search Cloudflare function (functions/api/search/searchApi.ts)
 // so that identical filters produce identical Algolia requests in both places.

--- a/site/search/queries.ts
+++ b/site/search/queries.ts
@@ -32,6 +32,7 @@ import {
     buildChartsFacetFilters,
     searchSingleForHits,
     searchSingleForHitsWithClosestMatches,
+    MAX_FACET_VALUES,
 } from "@ourworldindata/utils"
 import { RichDataComponentVariant } from "./SearchChartHitRichDataTypes.js"
 
@@ -425,6 +426,16 @@ export async function queryLatestPages(
             offset: 0,
             length: 0,
             facets: ["tags"],
+            // Algolia returns at most 100 values per facet unless asked for
+            // more, and this index carries appreciably more topic tags than
+            // that. Today the caller only looks up the tag graph's ~10
+            // top-level areas, all of which are common enough to survive the
+            // truncation, so nothing is visibly wrong — but a tag absent from
+            // these counts reads as "0 results" and disables its pill (see
+            // LatestSearch), and the same hook already exposes the full
+            // searchable-topic list next to the areas. Ask for the lot rather
+            // than leave that waiting to happen.
+            maxValuesPerFacet: MAX_FACET_VALUES,
         },
     ]
 


### PR DESCRIPTION
> _Written by Anthropic Claude Opus 5 — @Marigold at the wheel._

`/api/search` rejects perfectly valid topics as nonexistent:

```
GET /api/search?q=printing&topics=Books
400 {"error":"No results found. The topic \"Books\" does not exist.
     Available topics: Age Structure, Agricultural Production, …"}

GET /api/search?q=manuscripts&topics=Books
200 {"results":[{"title":"Manuscript production per century, 6th to 15th century",…}]}
```

Same topic, two answers. When a topic-filtered search comes back empty, `searchCharts` checks the topic against the index's topic tags and, if it doesn't find it, reports it as nonexistent. That list comes from a facet query left at Algolia's default, which returns **at most 100 values per facet** — the index carries **140** topic tags.

So the 40 least-used topics are missing from the list the check consults, and any query returning nothing inside one of them 400s with a list of 100 topics that pointedly excludes the valid one just asked for. A query that *does* find something is never checked, which is why the same topic works or doesn't depending on the search term.

Affected topics include Books, Gender Ratio, Nuclear Energy, Tetanus, Working Hours, Literacy, Energy Mix, Lead Pollution and Space Exploration & Satellites.

The fix asks for Algolia's documented maximum instead.

## It's in two places

Grepping for the pattern, every search in the repo that reads a facet's values does so in three spots, and two of them are the `tags` facet:

| | consumer | status |
| --- | --- | --- |
| `functions/api/search/searchApi.ts` | topic validation on an empty result set | **actively broken**, above |
| `site/search/queries.ts` (`/latest`) | topic-pill counts, used to disable pills | **latent** |
| `site/search/queries.ts` (`latestType`) | type dropdown counts | fine — 4 possible values |

The `/latest` one is the same truncation with no symptom today: the caller only looks up the tag graph's **10 top-level areas**, and I confirmed all 10 survive the cut. But a tag missing from those counts reads as "0 results" and disables its pill, and `useTagGraphTopics` hands out the full ~140-topic searchable list right next to the areas — so switching the pills to those would make it live and silent. Fixed here rather than left waiting.

The cap is now a shared `MAX_FACET_VALUES` in `@ourworldindata/utils`, alongside the facet-filter helpers both layers already share, so the two can't drift apart on it.

## How to test it

```bash
curl 'https://ourworldindata.org/api/search?q=printing&topics=Books'
```

400 today; 200 with an empty `results` array on this branch's staging server.

<details><summary>Details</summary>

Found while using `/api/search` to measure what a suggested search term actually returns, for owid/owid-grapher#7016. It matters beyond that: any API consumer filtering by one of those 40 topics gets a misleading 400 the moment their query has no hits, and the error names the topic as the culprit.

`getAvailableTopics` now passes `maxValuesPerFacet: MAX_FACET_VALUES` (1000, Algolia's documented maximum). Verified against the live index used by the integration test: 100 tag values at the default, 140 with the cap raised, with `Polio`, `Books` and `Gender Ratio` among the ones that only appear once raised.

The integration test covers it with a real query — a nonsense search inside `Polio` (outside the 100 commonest tags) must come back empty rather than throwing. I checked it fails without the change:

```
SearchValidationError: No results found. The topic "Polio" does not exist. …
Tests  1 failed | 18 passed
```

and passes with it (19/19). `yarn typecheck`, `yarn testLintChanged` and `yarn testFormatChanged` are clean.

Not changed: the validation itself, which is genuinely useful for a typo'd topic — only the list it consults. An alternative would be dropping the empty-result check entirely and always returning 200 with `results: []`, which is arguably the more conventional API shape; that's a bigger behavioural call than this bug needs, so I left it.

</details>
