### PR TITLE
📜 note how a full-page screenshot interacts with the resize handler

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -684,6 +684,14 @@ export class Grapher extends React.Component<GrapherProps> {
     }
 
     @action.bound private setUpWindowResizeEventHandler(): void {
+        // Worth knowing for anything driving the page: taking a full-page screenshot in
+        // Chromium resizes the viewport to 1x1 and restores it ~175ms later, so this
+        // handler runs with window.innerWidth === 1 and, because the debounce below fires
+        // on the leading edge, redraws the chart in its narrow layout straight away. The
+        // redraw at the restored width is 400ms behind, which is long enough for the
+        // screenshot to catch a narrow chart inside a full-width figure.
+        // owid/site-screenshots pins the chart containers and freezes these dimensions
+        // before it captures, for that reason.
         const updateWindowDimensions = action((): void => {
             this.grapherState.windowInnerWidth = window.innerWidth
             this.grapherState.windowInnerHeight = window.innerHeight


### PR DESCRIPTION
> _Written by Anthropic Claude Opus 5 — @Marigold at the wheel._

A comment next to `setUpWindowResizeEventHandler`, recording something that cost a while to track down: taking a full-page screenshot in Chromium resizes the viewport to 1×1 and restores it ~175ms later, so the handler runs with `window.innerWidth === 1`, the leading edge of its debounce redraws the chart narrow immediately, and the redraw at the restored width is 400ms behind — long enough for the screenshot to capture a narrow chart inside a full-width figure. owid/site-screenshots#7 pins the containers and freezes the dimensions before capturing, for that reason.

*Skim — comment only, no behaviour change.*

## Why it's also a test

A comment-only branch should render byte-identically to production, so **any** difference the site-screenshots job reports on this PR is noise by construction. That makes it a clean check on owid/site-screenshots#6 and #7, which were meant to remove three classes of it: host names and archive links in citations, charts caught mid-load, and charts redrawn narrow by the capture itself.

One caveat on reading the result: the reference screenshots on site-screenshots master were taken *before* #7 landed, so a chart that happened to be captured narrow on the reference side will still show up until the next master build refreshes them.
