### PR TITLE
🔨🤖 (chart-configs) camel-case Uuid in identifier names

### DIFF
--- a/adminSiteServer/apiRoutes/chartConfigs.ts
+++ b/adminSiteServer/apiRoutes/chartConfigs.ts
@@ -2,7 +2,7 @@ import { Request } from "express"
 import { HandlerResponse } from "../FunctionalRouter.js"
 import { JsonError } from "@ourworldindata/utils"
 import * as db from "../../db/db.js"
-import { getChartConfigByUUID } from "../../db/model/ChartConfigs.js"
+import { getChartConfigByUuid } from "../../db/model/ChartConfigs.js"
 
 export async function getChartConfig(
     req: Request,
@@ -10,7 +10,7 @@ export async function getChartConfig(
     trx: db.KnexReadonlyTransaction
 ) {
     const { chartConfigId } = req.params
-    const config = await getChartConfigByUUID(trx, chartConfigId)
+    const config = await getChartConfigByUuid(trx, chartConfigId)
     if (config) return config
     throw new JsonError(`No chart config found for id ${chartConfigId}`, 404)
 }

--- a/adminSiteServer/apiRoutes/narrativeCharts.ts
+++ b/adminSiteServer/apiRoutes/narrativeCharts.ts
@@ -46,7 +46,7 @@ import { Request } from "../authentication.js"
 import { HandlerResponse } from "../FunctionalRouter.js"
 import { getPublishedLinksTo } from "../../db/model/Link.js"
 import { triggerStaticBuild } from "../../baker/GrapherBakingUtils.js"
-import { getChartConfigByUUID } from "../../db/model/ChartConfigs.js"
+import { getChartConfigByUuid } from "../../db/model/ChartConfigs.js"
 import { narrativeChartExists } from "../../db/model/NarrativeChart.js"
 import { getMultiDimDataPageById } from "../../db/model/MultiDimDataPage.js"
 
@@ -98,11 +98,11 @@ function makeParentUrl(
     return null
 }
 
-async function expectChartConfigByUUID(
+async function expectChartConfigByUuid(
     trx: db.KnexReadonlyTransaction,
     id: string
 ) {
-    const chartConfig = await getChartConfigByUUID(trx, id)
+    const chartConfig = await getChartConfigByUuid(trx, id)
     if (!chartConfig) {
         throw new JsonError(`No chart config found for id ${id}`, 404)
     }
@@ -378,7 +378,7 @@ async function createNarrativeChartFromMultiDimView(
     | { narrativeChartId: number; success: boolean }
     | { success: false; errorMsg: string }
 > {
-    const parentChartConfig = await expectChartConfigByUUID(
+    const parentChartConfig = await expectChartConfigByUuid(
         trx,
         parentChartConfigId
     )

--- a/adminSiteServer/apiRoutes/variables.ts
+++ b/adminSiteServer/apiRoutes/variables.ts
@@ -43,7 +43,7 @@ import { expectInt } from "../../serverUtils/serverUtil.js"
 import { triggerStaticBuild } from "../../baker/GrapherBakingUtils.js"
 import {
     saveGrapherConfigToR2,
-    saveGrapherConfigToR2ByUUID,
+    saveGrapherConfigToR2ByUuid,
 } from "../../serverUtils/r2/chartConfigR2Helpers.js"
 import { Request } from "../authentication.js"
 import { HandlerResponse } from "../FunctionalRouter.js"
@@ -420,7 +420,7 @@ async function updateGrapherConfigsInR2(
         .select("id", "slug", "config", "configMd5")
         .whereIn("id", idsToUpdate)
     for await (const { id, slug, config, configMd5 } of builder.stream()) {
-        await saveGrapherConfigToR2ByUUID(id, config, configMd5)
+        await saveGrapherConfigToR2ByUuid(id, config, configMd5)
         if (publishedChartConfigIds.has(id) && slug)
             await saveGrapherConfigToR2(
                 config,

--- a/adminSiteServer/chartConfigHelpers.ts
+++ b/adminSiteServer/chartConfigHelpers.ts
@@ -10,9 +10,9 @@ import {
     updateChartConfig,
 } from "../db/model/ChartConfigs.js"
 import {
-    deleteGrapherConfigFromR2ByUUID,
+    deleteGrapherConfigFromR2ByUuid,
     saveGrapherConfigToR2,
-    saveGrapherConfigToR2ByUUID,
+    saveGrapherConfigToR2ByUuid,
 } from "../serverUtils/r2/chartConfigR2Helpers.js"
 
 export interface ChartConfigPair {
@@ -58,7 +58,7 @@ export const retrieveChartConfigFromDbAndSaveToR2 = async (
         )
 
     if (!r2Path) {
-        await saveGrapherConfigToR2ByUUID(
+        await saveGrapherConfigToR2ByUuid(
             chartConfigId,
             row.config,
             row.configMd5
@@ -152,5 +152,5 @@ export const deleteChartConfigPairFromDbAndR2 = async (
         .whereIn("id", [pair.configId, pair.patchConfigId])
         .delete()
     // Only the resolved config was published
-    await deleteGrapherConfigFromR2ByUUID(pair.configId)
+    await deleteGrapherConfigFromR2ByUuid(pair.configId)
 }

--- a/adminSiteServer/mockSiteRouter.ts
+++ b/adminSiteServer/mockSiteRouter.ts
@@ -30,7 +30,7 @@ import {
 import { expectInt, renderToHtmlPage } from "../serverUtils/serverUtil.js"
 import { makeSitemap } from "../baker/sitemap.js"
 import { getChartConfigBySlug } from "../db/model/Chart.js"
-import { getChartConfigByUUID } from "../db/model/ChartConfigs.js"
+import { getChartConfigByUuid } from "../db/model/ChartConfigs.js"
 import { ExplorerAdminServer } from "../explorerAdminServer/ExplorerAdminServer.js"
 import { getVariableData, getVariableMetadata } from "../db/model/Variable.js"
 import { MultiEmbedderTestPage } from "../site/multiembedder/MultiEmbedderTestPage.js"
@@ -224,7 +224,7 @@ getPlainRouteWithROTransaction(
     mockSiteRouter,
     "/grapher/by-uuid/:uuid.config.json",
     async (req, res, trx) => {
-        const config = await getChartConfigByUUID(trx, req.params.uuid)
+        const config = await getChartConfigByUuid(trx, req.params.uuid)
         if (!config) throw new JsonError("No such chart", 404)
         res.json(config)
     }
@@ -255,7 +255,7 @@ getPlainRouteWithROTransaction(
                 multiDim.config,
                 searchParams
             )
-            const config = await getChartConfigByUUID(trx, view.fullConfigId)
+            const config = await getChartConfigByUuid(trx, view.fullConfigId)
             if (config) {
                 res.json(config)
                 return

--- a/adminSiteServer/multiDim.ts
+++ b/adminSiteServer/multiDim.ts
@@ -34,7 +34,7 @@ import {
 } from "../db/model/Variable.js"
 import {
     deleteGrapherConfigFromR2,
-    deleteGrapherConfigFromR2ByUUID,
+    deleteGrapherConfigFromR2ByUuid,
     saveMultiDimConfigToR2,
 } from "../serverUtils/r2/chartConfigR2Helpers.js"
 import {
@@ -225,7 +225,7 @@ async function cleanUpOrphanedChartConfigs(
         .whereIn("id", orphanedChartConfigIds)
         .delete()
     for (const id of orphanedChartConfigIds) {
-        await deleteGrapherConfigFromR2ByUUID(id)
+        await deleteGrapherConfigFromR2ByUuid(id)
     }
 }
 

--- a/baker/MultiDimBaker.tsx
+++ b/baker/MultiDimBaker.tsx
@@ -43,7 +43,7 @@ import {
 import { MultiDimArchivalManifest } from "../serverUtils/archivalUtils.js"
 import { getLatestArchivedMultiDimPageVersions } from "../db/model/ArchivedMultiDimVersion.js"
 import { getDatapageDataV2 } from "../site/dataPage.js"
-import { getChartConfigByUUID } from "../db/model/ChartConfigs.js"
+import { getChartConfigByUuid } from "../db/model/ChartConfigs.js"
 
 const getLatestMultiDimArchivedVersionsIfEnabled = async (
     knex: db.KnexReadonlyTransaction,
@@ -143,7 +143,7 @@ export async function renderMultiDimDataPageFromConfig({
             getVariableMetadata(initialViewIndicatorId, {
                 noCache: isPreviewing,
             }),
-            getChartConfigByUUID(knex, initialView.fullConfigId),
+            getChartConfigByUuid(knex, initialView.fullConfigId),
         ])
         if (!fullGrapherConfig) {
             throw new Error(

--- a/db/model/ChartConfigs.ts
+++ b/db/model/ChartConfigs.ts
@@ -11,7 +11,7 @@ import { v7 as uuidv7 } from "uuid"
 
 import * as db from "../db.js"
 
-export async function getChartConfigByUUID(
+export async function getChartConfigByUuid(
     knex: db.KnexReadonlyTransaction,
     id: string
 ): Promise<GrapherInterface | undefined> {

--- a/db/model/Gdoc/dataCallouts.ts
+++ b/db/model/Gdoc/dataCallouts.ts
@@ -41,7 +41,7 @@ import { getIndicatorChartConfig } from "../Variable.js"
 import { getExplorerBySlug } from "../Explorer.js"
 import { transformExplorerProgramToResolveCatalogPaths } from "../ExplorerCatalogResolver.js"
 import { getMultiDimDataPageBySlug } from "../MultiDimDataPage.js"
-import { getChartConfigByUUID } from "../ChartConfigs.js"
+import { getChartConfigByUuid } from "../ChartConfigs.js"
 
 /**
  * Extract all data-callout blocks from an array of enriched blocks.
@@ -115,7 +115,7 @@ export async function prepareCalloutTableForUrl(
             multiDimPage.config,
             searchParams
         )
-        config = await getChartConfigByUUID(knex, view.fullConfigId)
+        config = await getChartConfigByUuid(knex, view.fullConfigId)
         if (!config) return undefined
     }
 

--- a/devTools/refreshExplorerViews.ts
+++ b/devTools/refreshExplorerViews.ts
@@ -3,8 +3,8 @@ import { DbPlainExplorer } from "@ourworldindata/types"
 import { refreshExplorerViewsForSlug } from "../db/model/ExplorerViews.js"
 import { updateExplorerRefreshStatus } from "../db/model/Jobs.js"
 import {
-    saveGrapherConfigToR2ByUUID,
-    deleteGrapherConfigFromR2ByUUID,
+    saveGrapherConfigToR2ByUuid,
+    deleteGrapherConfigFromR2ByUuid,
 } from "../serverUtils/r2/chartConfigR2Helpers.js"
 import { logErrorAndMaybeCaptureInSentry } from "../serverUtils/errorLog.js"
 import pMap from "p-map"
@@ -120,7 +120,7 @@ async function prepareGrapherConfigsForExplorerViews(
                     refreshResult.removedChartConfigIds,
                     async (configId) => {
                         try {
-                            await deleteGrapherConfigFromR2ByUUID(configId)
+                            await deleteGrapherConfigFromR2ByUuid(configId)
                         } catch (error) {
                             void logErrorAndMaybeCaptureInSentry(
                                 new Error(
@@ -162,7 +162,7 @@ async function prepareGrapherConfigsForExplorerViews(
                     chartConfigs,
                     async (config) => {
                         try {
-                            await saveGrapherConfigToR2ByUUID(
+                            await saveGrapherConfigToR2ByUuid(
                                 config.id,
                                 config.config,
                                 config.configMd5

--- a/devTools/syncGraphersToR2/syncGraphersToR2.ts
+++ b/devTools/syncGraphersToR2/syncGraphersToR2.ts
@@ -237,7 +237,7 @@ async function main(parsedArgs: parseArgs.ParsedArgs, dryRun: boolean) {
 
     const pathPrefixByUuid = excludeUndefined([
         GRAPHER_CONFIG_R2_BUCKET_PATH,
-        R2GrapherConfigDirectory.byUUID,
+        R2GrapherConfigDirectory.byUuid,
     ]).join("/")
 
     await knexReadonlyTransaction(async (trx) => {

--- a/functions/_common/grapherTools.ts
+++ b/functions/_common/grapherTools.ts
@@ -62,7 +62,7 @@ export interface MultiDimSlug {
 export type GrapherIdentifier = GrapherSlug | GrapherUuid | MultiDimSlug
 
 const directoryMap = {
-    uuid: R2GrapherConfigDirectory.byUUID,
+    uuid: R2GrapherConfigDirectory.byUuid,
     slug: R2GrapherConfigDirectory.publishedGrapherBySlug,
     "multi-dim-slug": R2GrapherConfigDirectory.multiDim,
 }

--- a/jobQueue/explorerJobProcessor.ts
+++ b/jobQueue/explorerJobProcessor.ts
@@ -9,8 +9,8 @@ import {
 import { refreshExplorerViewsForSlug } from "../db/model/ExplorerViews.js"
 import { knexReadWriteTransaction, knexReadonlyTransaction } from "../db/db.js"
 import {
-    saveGrapherConfigToR2ByUUID,
-    deleteGrapherConfigFromR2ByUUID,
+    saveGrapherConfigToR2ByUuid,
+    deleteGrapherConfigFromR2ByUuid,
 } from "../serverUtils/r2/chartConfigR2Helpers.js"
 import { triggerStaticBuild } from "../baker/GrapherBakingUtils.js"
 import { logErrorAndMaybeCaptureInSentry } from "../serverUtils/errorLog.js"
@@ -152,7 +152,7 @@ export async function processExplorerViewsJob(
             await pMap(
                 refreshResult.removedChartConfigIds,
                 async (configId) => {
-                    await deleteGrapherConfigFromR2ByUUID(configId)
+                    await deleteGrapherConfigFromR2ByUuid(configId)
                 },
                 { concurrency: CONCURRENCY }
             )
@@ -170,7 +170,7 @@ export async function processExplorerViewsJob(
             await pMap(
                 chartConfigs,
                 async (config) => {
-                    await saveGrapherConfigToR2ByUUID(
+                    await saveGrapherConfigToR2ByUuid(
                         config.id,
                         config.config,
                         config.configMd5

--- a/packages/@ourworldindata/types/src/domainTypes/Various.ts
+++ b/packages/@ourworldindata/types/src/domainTypes/Various.ts
@@ -74,7 +74,7 @@ export interface QueryParams {
 }
 
 export enum R2GrapherConfigDirectory {
-    byUUID = "config/by-uuid",
+    byUuid = "config/by-uuid",
     publishedGrapherBySlug = "config/by-slug-published",
     multiDim = "multi-dim-config",
 }

--- a/serverUtils/r2/chartConfigR2Helpers.ts
+++ b/serverUtils/r2/chartConfigR2Helpers.ts
@@ -22,7 +22,7 @@ const getChartConfigS3Client = lazy(() =>
     })
 )
 
-export async function saveGrapherConfigToR2ByUUID(
+export async function saveGrapherConfigToR2ByUuid(
     uuid: string,
     chartConfigStringified: string,
     configMd5FromDb: Base64String
@@ -30,15 +30,15 @@ export async function saveGrapherConfigToR2ByUUID(
     console.log("Saving grapher config to R2 by UUID:", uuid)
     await saveGrapherConfigToR2(
         chartConfigStringified,
-        R2GrapherConfigDirectory.byUUID,
+        R2GrapherConfigDirectory.byUuid,
         `${uuid}.json`,
         configMd5FromDb
     )
 }
 
-export async function deleteGrapherConfigFromR2ByUUID(id: string) {
+export async function deleteGrapherConfigFromR2ByUuid(id: string) {
     await deleteGrapherConfigFromR2(
-        R2GrapherConfigDirectory.byUUID,
+        R2GrapherConfigDirectory.byUuid,
         `${id}.json`
     )
 }


### PR DESCRIPTION
> _Written by Claude Opus 5 — @sophiamersmann at the wheel._

Review feedback on #6979: camel-case the UUID acronym in identifiers so it reads as one word, avoiding `XMLHttpRequest`-style names. Pure rename — no behaviour change, no schema change.

The R2 directory *value* stays `config/by-uuid`; only the enum member is renamed, so nothing moves in the bucket.

<details><summary>Details</summary>

15 files, 37 lines changed. Renamed:

- `R2GrapherConfigDirectory.byUUID` → `byUuid` (`packages/@ourworldindata/types/src/domainTypes/Various.ts`) — the string value `"config/by-uuid"` is unchanged
- `saveGrapherConfigToR2ByUUID` → `saveGrapherConfigToR2ByUuid` and `deleteGrapherConfigFromR2ByUUID` → `deleteGrapherConfigFromR2ByUuid` (`serverUtils/r2/chartConfigR2Helpers.ts`) plus their callers in `adminSiteServer/`, `baker/`, `devTools/`, `jobQueue/`, `functions/`
- `getChartConfigByUUID` → `getChartConfigByUuid` (`db/model/ChartConfigs.ts`) and `expectChartConfigByUUID` → `expectChartConfigByUuid`

Deliberately left alone:

- prose and log strings keep the acronym
- `tmpUUIDxVariableId` in an already-applied migration — renaming an identifier inside migration SQL that has run buys nothing

</details>