### PR TITLE
🎉🤖 (chart-configs) delete indicators the ETL no longer produces

### DIFF
--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -122,6 +122,7 @@ import {
     getVariableJson,
     putIndicatorChartConfig,
     deleteIndicatorChartConfig,
+    postVariablesDelete,
 } from "./apiRoutes/variables.js"
 import { FunctionalRouter } from "./FunctionalRouter.js"
 import {
@@ -607,6 +608,7 @@ getRouteWithROTransaction(
     getVariableMetadataJson
 )
 getRouteWithROTransaction(apiRouter, "/variables.json", getVariablesJson)
+postRouteWithRWTransaction(apiRouter, "/variables/delete", postVariablesDelete)
 getRouteWithROTransaction(
     apiRouter,
     "/variables.usages.json",

--- a/adminSiteServer/apiRoutes/variables.ts
+++ b/adminSiteServer/apiRoutes/variables.ts
@@ -48,6 +48,7 @@ import {
 } from "../../serverUtils/r2/chartConfigR2Helpers.js"
 import { Request } from "../authentication.js"
 import { HandlerResponse } from "../FunctionalRouter.js"
+import * as z from "zod"
 
 export async function getEditorVariablesJson(
     req: Request,
@@ -432,6 +433,10 @@ async function updateGrapherConfigsInR2(
     }
 }
 
+const deleteVariablesSchema = z.object({
+    variableIds: z.array(z.number().int()),
+})
+
 /**
  * Delete a set of indicators.
  *
@@ -444,19 +449,15 @@ export async function postVariablesDelete(
     _res: HandlerResponse,
     trx: db.KnexReadWriteTransaction
 ) {
-    const { variableIds } = req.body ?? {}
-
-    if (
-        !Array.isArray(variableIds) ||
-        !variableIds.every((id) => Number.isInteger(id))
-    ) {
-        throw new JsonError(
-            "`variableIds` must be an array of indicator ids",
-            400
-        )
+    const parseResult = deleteVariablesSchema.safeParse(req.body)
+    if (!parseResult.success) {
+        throw new JsonError(`Invalid request: ${parseResult.error}`, 400)
     }
 
-    const { deleted, blocked } = await deleteIndicators(trx, variableIds)
+    const { deleted, blocked } = await deleteIndicators(
+        trx,
+        parseResult.data.variableIds
+    )
 
     return { success: true, deleted, blocked }
 }

--- a/adminSiteServer/apiRoutes/variables.ts
+++ b/adminSiteServer/apiRoutes/variables.ts
@@ -26,6 +26,7 @@ import {
     updateAllChartsThatInheritFromIndicator,
     updateAllMultiDimViewsThatInheritFromIndicator,
     updateIndicatorChartConfig,
+    deleteIndicators,
 } from "../../db/model/Variable.js"
 import { enqueueExplorerRefreshJobsForDependencies } from "../../db/model/Explorer.js"
 import { DATA_API_URL } from "../../settings/clientSettings.js"
@@ -429,4 +430,33 @@ async function updateGrapherConfigsInR2(
                 configMd5
             )
     }
+}
+
+/**
+ * Delete a set of indicators.
+ *
+ * An indicator a chart, a published explorer or a live multi-dim view still
+ * uses is never deleted; it comes back in `blocked` instead (but it doesn't
+ * fail the whole request).
+ */
+export async function postVariablesDelete(
+    req: Request,
+    _res: HandlerResponse,
+    trx: db.KnexReadWriteTransaction
+) {
+    const { variableIds } = req.body ?? {}
+
+    if (
+        !Array.isArray(variableIds) ||
+        !variableIds.every((id) => Number.isInteger(id))
+    ) {
+        throw new JsonError(
+            "`variableIds` must be an array of indicator ids",
+            400
+        )
+    }
+
+    const { deleted, blocked } = await deleteIndicators(trx, variableIds)
+
+    return { success: true, deleted, blocked }
 }

--- a/adminSiteServer/tests/fixtures.ts
+++ b/adminSiteServer/tests/fixtures.ts
@@ -1,4 +1,10 @@
-import { DatasetsTableName, VariablesTableName } from "@ourworldindata/types"
+import {
+    DatasetsTableName,
+    IndicatorsBeforePreProcessing,
+    VariablesTableName,
+    View,
+} from "@ourworldindata/types"
+import { latestGrapherConfigSchema } from "@ourworldindata/grapher"
 import type { TestEnv } from "./testEnv.js"
 
 export const datasetId = 1
@@ -30,4 +36,27 @@ export async function seedDatasetAndVariables(env: TestEnv): Promise<void> {
         { ...dummyVariable, id: variableId },
         { ...dummyVariable, id: otherVariableId },
     ])
+}
+
+export const catalogPath = "test/catalog#path"
+
+/** A multi-dim page config for the given views */
+export function multiDimConfig(
+    views: View<IndicatorsBeforePreProcessing>[]
+): object {
+    return {
+        grapherConfigSchema: latestGrapherConfigSchema,
+        title: { title: "Energy use", titleVariant: "by energy source" },
+        views,
+        dimensions: [
+            {
+                name: "Metric",
+                slug: "metric",
+                choices: views.map((view) => ({
+                    name: view.dimensions.metric,
+                    slug: view.dimensions.metric,
+                })),
+            },
+        ],
+    }
 }

--- a/adminSiteServer/tests/fixtures.ts
+++ b/adminSiteServer/tests/fixtures.ts
@@ -5,7 +5,7 @@ export const datasetId = 1
 export const variableId = 1
 export const otherVariableId = 2
 
-/** Inserts the dataset and the two indicators that the chart config tests share */
+/** Inserts the dataset and the two indicators that the admin API tests share */
 export async function seedDatasetAndVariables(env: TestEnv): Promise<void> {
     await env.testKnex(DatasetsTableName).insert({
         id: datasetId,

--- a/adminSiteServer/tests/multi-dim-views.test.ts
+++ b/adminSiteServer/tests/multi-dim-views.test.ts
@@ -11,6 +11,8 @@ import {
 } from "@ourworldindata/types"
 import { latestGrapherConfigSchema } from "@ourworldindata/grapher"
 import {
+    catalogPath,
+    multiDimConfig,
     otherVariableId,
     seedDatasetAndVariables,
     variableId,
@@ -19,8 +21,6 @@ import {
 const env = getAdminTestEnv()
 
 describe("Multi-dim views", { timeout: 20000 }, () => {
-    const catalogPath = "test/catalog#path"
-
     const totalView: View<IndicatorsBeforePreProcessing> = {
         config: { title: "Total energy use" },
         dimensions: { metric: "total" },
@@ -30,26 +30,6 @@ describe("Multi-dim views", { timeout: 20000 }, () => {
         config: { title: "Energy use per capita" },
         dimensions: { metric: "per_capita" },
         indicators: { y: otherVariableId },
-    }
-
-    function multiDimConfig(
-        views: View<IndicatorsBeforePreProcessing>[]
-    ): object {
-        return {
-            grapherConfigSchema: latestGrapherConfigSchema,
-            title: { title: "Energy use", titleVariant: "by energy source" },
-            views,
-            dimensions: [
-                {
-                    name: "Metric",
-                    slug: "metric",
-                    choices: views.map((view) => ({
-                        name: view.dimensions.metric,
-                        slug: view.dimensions.metric,
-                    })),
-                },
-            ],
-        }
     }
 
     async function upsertMultiDim(

--- a/adminSiteServer/tests/narrative-charts.test.ts
+++ b/adminSiteServer/tests/narrative-charts.test.ts
@@ -7,7 +7,12 @@ import {
     NarrativeChartsTableName,
 } from "@ourworldindata/types"
 import { latestGrapherConfigSchema } from "@ourworldindata/grapher"
-import { seedDatasetAndVariables, variableId } from "./fixtures.js"
+import {
+    catalogPath,
+    multiDimConfig,
+    seedDatasetAndVariables,
+    variableId,
+} from "./fixtures.js"
 import type { NarrativeChartResponse } from "../apiRoutes/narrativeCharts.js"
 
 const env = getAdminTestEnv()
@@ -29,25 +34,13 @@ describe("Narrative charts API", { timeout: 20000 }, () => {
         title: "Narrative title",
     }
 
-    const catalogPath = "test/catalog#path"
-    const testMultiDimConfig = {
-        grapherConfigSchema: latestGrapherConfigSchema,
-        title: { title: "Energy use", titleVariant: "by energy source" },
-        views: [
-            {
-                config: { title: "Total energy use" },
-                dimensions: { metric: "total" },
-                indicators: { y: variableId },
-            },
-        ],
-        dimensions: [
-            {
-                name: "Metric",
-                slug: "metric",
-                choices: [{ name: "Total consumption", slug: "total" }],
-            },
-        ],
-    }
+    const testMultiDimConfig = multiDimConfig([
+        {
+            config: { title: "Total energy use" },
+            dimensions: { metric: "total" },
+            indicators: { y: variableId },
+        },
+    ])
 
     async function createParentChart(): Promise<{
         chartId: number

--- a/adminSiteServer/tests/testEnv.ts
+++ b/adminSiteServer/tests/testEnv.ts
@@ -99,17 +99,7 @@ export function getAdminTestEnv(): TestEnv {
         serverKnex = knex(dbTestConfig)
         seededUserId = await seedBaselineData()
         // Ensure we start from a clean slate for non-user tables
-        await knexReadWriteTransaction(
-            async (trx) => {
-                const tables = TABLES_IN_USE.filter(
-                    (t) => t !== UsersTableName && t !== AdminApiKeysTableName
-                )
-                for (const table of tables)
-                    await trx.raw(`DELETE FROM ??`, [table])
-            },
-            TransactionCloseMode.KeepOpen,
-            testKnex
-        )
+        await resetDbButKeepBaselines()
         setKnexInstance(serverKnex)
 
         app = new OwidAdminApp({ isDev: true, isTest: true, quiet: true })

--- a/adminSiteServer/tests/variables.test.ts
+++ b/adminSiteServer/tests/variables.test.ts
@@ -1,0 +1,318 @@
+import { describe, it, expect, beforeEach } from "vitest"
+import { getAdminTestEnv } from "./testEnv.js"
+import {
+    ChartConfigsTableName,
+    DbPlainMultiDimXChartConfig,
+    ExplorerVariablesTableName,
+    IndicatorsBeforePreProcessing,
+    MultiDimDataPagesTableName,
+    MultiDimXChartConfigsTableName,
+    OriginsTableName,
+    OriginsVariablesTableName,
+    SourcesTableName,
+    VariablesTableName,
+    View,
+} from "@ourworldindata/types"
+import { latestGrapherConfigSchema } from "@ourworldindata/grapher"
+import {
+    datasetId,
+    otherVariableId,
+    seedDatasetAndVariables,
+    variableId,
+} from "./fixtures.js"
+import { DeleteIndicatorsResult } from "../../db/model/Variable.js"
+
+const env = getAdminTestEnv()
+
+describe("Bulk indicator deletion", { timeout: 15000 }, () => {
+    async function deleteIndicators(
+        indicatorIds: number[]
+    ): Promise<DeleteIndicatorsResult & { success: boolean }> {
+        return await env.request({
+            method: "POST",
+            path: "/variables/delete",
+            body: JSON.stringify({ variableIds: indicatorIds }),
+        })
+    }
+
+    async function remainingIndicatorIds(): Promise<number[]> {
+        return await env
+            .testKnex(VariablesTableName)
+            .where({ datasetId })
+            .orderBy("id")
+            .pluck<number[]>("id")
+    }
+
+    const catalogPath = "test/catalog#path"
+
+    async function seedMultiDim(): Promise<void> {
+        const views: View<IndicatorsBeforePreProcessing>[] = [
+            {
+                config: { title: "Kept view" },
+                dimensions: { metric: "total" },
+                indicators: { y: variableId },
+            },
+            {
+                config: { title: "View of the deleted indicator" },
+                dimensions: { metric: "per_capita" },
+                indicators: { y: otherVariableId },
+            },
+        ]
+        await env.request({
+            method: "PUT",
+            path: `/multi-dims/${encodeURIComponent(catalogPath)}`,
+            body: JSON.stringify({
+                config: {
+                    grapherConfigSchema: latestGrapherConfigSchema,
+                    title: { title: "Energy use" },
+                    views,
+                    dimensions: [
+                        {
+                            name: "Metric",
+                            slug: "metric",
+                            choices: views.map((view) => ({
+                                name: view.dimensions.metric,
+                                slug: view.dimensions.metric,
+                            })),
+                        },
+                    ],
+                },
+            }),
+        })
+    }
+
+    /** The view row showing the indicator we delete. */
+    async function viewForDeletedIndicator(): Promise<DbPlainMultiDimXChartConfig> {
+        const view = await env
+            .testKnex(MultiDimXChartConfigsTableName)
+            .where({ variableId: otherVariableId })
+            .first()
+        if (!view) throw new Error("The multi-dim page has no view to delete")
+        return view
+    }
+
+    const explorerSlug = "test-explorer"
+
+    /** An explorer offering the indicator we delete, published or not. */
+    async function seedExplorer(isPublished: boolean): Promise<void> {
+        const put = async (): Promise<void> =>
+            await env.request({
+                method: "PUT",
+                path: `/explorers/${explorerSlug}`,
+                body: JSON.stringify({
+                    tsv: [
+                        "explorerTitle\tTest explorer",
+                        `isPublished\t${isPublished}`,
+                        "graphers",
+                        "\tyVariableIds\tMetric Radio",
+                        `\t${otherVariableId}\tDeleted`,
+                    ].join("\n"),
+                    commitMessage: "Explorer naming the indicator we delete",
+                }),
+            })
+
+        await put()
+        // `upsertExplorer` stores a newly created explorer unpublished whatever
+        // its TSV says, so publishing one takes a second write
+        if (isPublished) await put()
+    }
+
+    beforeEach(async () => {
+        await seedDatasetAndVariables(env)
+    })
+
+    it("deletes the indicators it is given and leaves the rest", async () => {
+        const response = await deleteIndicators([otherVariableId])
+
+        expect(response.deleted).toEqual([otherVariableId])
+        expect(response.blocked).toEqual([])
+        expect(await remainingIndicatorIds()).toEqual([variableId])
+    })
+
+    it("deletes every indicator it is given", async () => {
+        const response = await deleteIndicators([variableId, otherVariableId])
+
+        expect(response.deleted).toEqual([variableId, otherVariableId])
+        expect(await remainingIndicatorIds()).toEqual([])
+    })
+
+    it("reports an indicator a chart still uses as blocked instead of deleting it", async () => {
+        await env.request({
+            method: "POST",
+            path: "/charts",
+            body: JSON.stringify({
+                $schema: latestGrapherConfigSchema,
+                slug: "chart-using-the-indicator",
+                title: "Chart using the indicator",
+                chartTypes: ["LineChart"],
+                dimensions: [{ property: "y", variableId: otherVariableId }],
+            }),
+        })
+
+        const response = await deleteIndicators([otherVariableId])
+
+        expect(response.deleted).toEqual([])
+        expect(response.blocked).toEqual([
+            {
+                variableId: otherVariableId,
+                variableName: null,
+                usedBy: "chart",
+                ref: "chart-using-the-indicator",
+            },
+        ])
+        expect(await remainingIndicatorIds()).toEqual([
+            variableId,
+            otherVariableId,
+        ])
+    })
+
+    it("deletes an indicator's leftover chart config", async () => {
+        await env.request({
+            method: "PUT",
+            path: `/variables/${otherVariableId}/grapherConfigETL`,
+            body: JSON.stringify({
+                $schema: latestGrapherConfigSchema,
+                title: "Indicator-level config",
+            }),
+        })
+        expect(await env.getCount(ChartConfigsTableName)).toBe(1)
+
+        const response = await deleteIndicators([otherVariableId])
+
+        expect(response.deleted).toEqual([otherVariableId])
+        expect(await env.getCount(ChartConfigsTableName)).toBe(0)
+    })
+
+    it("deletes the origins nothing else cites and leaves the shared ones", async () => {
+        await env.testKnex(OriginsTableName).insert([
+            { id: 1, title: "Cited only by the deleted indicator" },
+            { id: 2, title: "Cited by the surviving indicator too" },
+        ])
+        await env.testKnex(OriginsVariablesTableName).insert([
+            { originId: 1, variableId: otherVariableId, displayOrder: 0 },
+            { originId: 2, variableId: otherVariableId, displayOrder: 1 },
+            { originId: 2, variableId, displayOrder: 0 },
+        ])
+
+        const response = await deleteIndicators([otherVariableId])
+
+        expect(response.deleted).toEqual([otherVariableId])
+        expect(
+            await env.testKnex(OriginsTableName).orderBy("id").pluck("title")
+        ).toEqual(["Cited by the surviving indicator too"])
+    })
+
+    it("deletes the sources nothing else cites and leaves the shared ones", async () => {
+        await env.testKnex(SourcesTableName).insert([
+            {
+                id: 1,
+                name: "Cited only by the deleted indicator",
+                description: "{}",
+            },
+            {
+                id: 2,
+                name: "Cited by the surviving indicator too",
+                description: "{}",
+            },
+        ])
+        await env
+            .testKnex(VariablesTableName)
+            .where({ id: otherVariableId })
+            .update({ sourceId: 1 })
+        await env
+            .testKnex(VariablesTableName)
+            .where({ id: variableId })
+            .update({ sourceId: 2 })
+
+        const response = await deleteIndicators([otherVariableId])
+
+        expect(response.deleted).toEqual([otherVariableId])
+        expect(
+            await env.testKnex(SourcesTableName).orderBy("id").pluck("name")
+        ).toEqual(["Cited by the surviving indicator too"])
+    })
+
+    it("deletes the multi-dim view chart configs that go with a deleted indicator", async () => {
+        await seedMultiDim()
+        expect(await env.getCount(MultiDimXChartConfigsTableName)).toBe(2)
+        expect(await env.getCount(ChartConfigsTableName)).toBe(2)
+
+        const response = await deleteIndicators([otherVariableId])
+
+        expect(response.deleted).toEqual([otherVariableId])
+        expect(await env.getCount(MultiDimXChartConfigsTableName)).toBe(1)
+        expect(await env.getCount(ChartConfigsTableName)).toBe(1)
+    })
+
+    it("reports an indicator a published multi-dim page shows as blocked", async () => {
+        await seedMultiDim()
+        const view = await viewForDeletedIndicator()
+        await env
+            .testKnex(MultiDimDataPagesTableName)
+            .where({ catalogPath })
+            .update({ slug: "energy-use", published: true })
+
+        const response = await deleteIndicators([otherVariableId])
+
+        expect(response.deleted).toEqual([])
+        expect(response.blocked).toEqual([
+            {
+                variableId: otherVariableId,
+                variableName: null,
+                usedBy: "multiDimView",
+                ref: `${catalogPath}#${view.viewId}`,
+            },
+        ])
+        expect(await env.getCount(MultiDimXChartConfigsTableName)).toBe(2)
+    })
+
+    it("reports an indicator a narrative chart is parented on as blocked", async () => {
+        await seedMultiDim()
+        const view = await viewForDeletedIndicator()
+        await env.request({
+            method: "POST",
+            path: "/narrative-charts",
+            body: JSON.stringify({
+                type: "multiDim",
+                name: "narrative-chart-on-the-view",
+                parentChartConfigId: view.chartConfigId,
+                config: {
+                    $schema: latestGrapherConfigSchema,
+                    title: "Narrative title",
+                    chartTypes: ["LineChart"],
+                    selectedEntityNames: [],
+                },
+            }),
+        })
+
+        const response = await deleteIndicators([otherVariableId])
+
+        expect(response.deleted).toEqual([])
+        expect(response.blocked).toEqual([
+            {
+                variableId: otherVariableId,
+                variableName: null,
+                usedBy: "multiDimView",
+                ref: `${catalogPath}#${view.viewId}`,
+            },
+        ])
+    })
+
+    it("reports an indicator a published explorer offers as blocked", async () => {
+        await seedExplorer(true)
+        expect(await env.getCount(ExplorerVariablesTableName)).toBe(1)
+
+        const response = await deleteIndicators([otherVariableId])
+
+        expect(response.deleted).toEqual([])
+        expect(response.blocked).toEqual([
+            {
+                variableId: otherVariableId,
+                variableName: null,
+                usedBy: "explorer",
+                ref: explorerSlug,
+            },
+        ])
+        expect(await env.getCount(ExplorerVariablesTableName)).toBe(1)
+    })
+})

--- a/adminSiteServer/tests/variables.test.ts
+++ b/adminSiteServer/tests/variables.test.ts
@@ -15,7 +15,9 @@ import {
 } from "@ourworldindata/types"
 import { latestGrapherConfigSchema } from "@ourworldindata/grapher"
 import {
+    catalogPath,
     datasetId,
+    multiDimConfig,
     otherVariableId,
     seedDatasetAndVariables,
     variableId,
@@ -43,8 +45,6 @@ describe("Bulk indicator deletion", { timeout: 15000 }, () => {
             .pluck<number[]>("id")
     }
 
-    const catalogPath = "test/catalog#path"
-
     async function seedMultiDim(): Promise<void> {
         const views: View<IndicatorsBeforePreProcessing>[] = [
             {
@@ -61,23 +61,7 @@ describe("Bulk indicator deletion", { timeout: 15000 }, () => {
         await env.request({
             method: "PUT",
             path: `/multi-dims/${encodeURIComponent(catalogPath)}`,
-            body: JSON.stringify({
-                config: {
-                    grapherConfigSchema: latestGrapherConfigSchema,
-                    title: { title: "Energy use" },
-                    views,
-                    dimensions: [
-                        {
-                            name: "Metric",
-                            slug: "metric",
-                            choices: views.map((view) => ({
-                                name: view.dimensions.metric,
-                                slug: view.dimensions.metric,
-                            })),
-                        },
-                    ],
-                },
-            }),
+            body: JSON.stringify({ config: multiDimConfig(views) }),
         })
     }
 

--- a/db/migration/1787229552132-DeleteOrphanedConfigsOriginsAndSources.ts
+++ b/db/migration/1787229552132-DeleteOrphanedConfigsOriginsAndSources.ts
@@ -1,0 +1,59 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+/** Delete orphaned rows from `chart_configs`, `origins`, and `sources` */
+export class DeleteOrphanedConfigsOriginsAndSources1787229552132 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        // Delete orphaned chart configs
+        const configs = await queryRunner.query(`-- sql
+            DELETE cc FROM chart_configs cc
+            WHERE NOT EXISTS (
+                    SELECT 1 FROM charts c
+                    WHERE c.configId = cc.id OR c.patchConfigId = cc.id
+                )
+                AND NOT EXISTS (
+                    SELECT 1 FROM multi_dim_x_chart_configs mdxcc
+                    WHERE mdxcc.chartConfigId = cc.id
+                )
+                AND NOT EXISTS (
+                    SELECT 1 FROM narrative_charts nc
+                    WHERE nc.chartConfigId = cc.id OR nc.patchConfigId = cc.id
+                )
+                AND NOT EXISTS (
+                    SELECT 1 FROM explorer_views ev
+                    WHERE ev.chartConfigId = cc.id
+                )
+                AND NOT EXISTS (
+                    SELECT 1 FROM variables v WHERE v.patchConfigIdETL = cc.id
+                )
+                AND NOT EXISTS (
+                    SELECT 1 FROM multi_dim_redirects mdr
+                    WHERE mdr.viewConfigId = cc.id
+                )
+        `)
+
+        // `origins_variables` is the only way to reach an origin
+        const origins = await queryRunner.query(`-- sql
+            DELETE FROM origins
+            WHERE NOT EXISTS (
+                SELECT 1 FROM origins_variables ov WHERE ov.originId = origins.id
+            )
+        `)
+
+        // ...and `variables.sourceId` the only way to reach a source
+        const sources = await queryRunner.query(`-- sql
+            DELETE FROM sources
+            WHERE NOT EXISTS (
+                SELECT 1 FROM variables v WHERE v.sourceId = sources.id
+            )
+        `)
+
+        console.log(
+            `Deleted ${configs.affectedRows} orphaned chart configs, ` +
+                `${origins.affectedRows} origins, ${sources.affectedRows} sources`
+        )
+    }
+
+    public async down(): Promise<void> {
+        // Deleted rows can't be brought back
+    }
+}

--- a/db/model/Explorer.ts
+++ b/db/model/Explorer.ts
@@ -8,6 +8,7 @@ import {
     DbInsertExplorer,
     DbPlainExplorer,
     ExplorersTableName,
+    JsonError,
 } from "@ourworldindata/types"
 import { areSetsEqual } from "@ourworldindata/utils"
 import { parseExplorer } from "../explorerParser.js"
@@ -162,8 +163,8 @@ export async function upsertExplorerCharts(
 
 async function validateVariableIds(
     knex: KnexReadWriteTransaction,
-    proposed: number[],
-    isPublished: boolean
+    slug: string,
+    proposed: number[]
 ): Promise<number[]> {
     if (proposed.length === 0) return []
     const foundRows = await knex("variables")
@@ -172,10 +173,10 @@ async function validateVariableIds(
     const found = foundRows.map((row) => row.id)
     const missing = proposed.filter((id) => !found.includes(id))
     if (missing.length > 0) {
-        console.error("missing variables in db", {
-            missing_variables: missing,
-            isPublished,
-        })
+        throw new JsonError(
+            `${missing.length} indicator(s) named by explorer ${slug} don't exist: ${missing.join(", ")}.`,
+            400
+        )
     }
     return found
 }
@@ -207,7 +208,6 @@ export async function upsertExplorerVariables(
             "Mismatch: proposed size does not equal the sum of proposedCatalogPaths and proposedVariableIds sizes"
         )
     }
-    const isPublished = config["isPublished"] === "true"
 
     // Resolve catalog paths to variable ids via a knex query.
     const resolvedRows = await knex("variables")
@@ -224,10 +224,9 @@ export async function upsertExplorerVariables(
         .filter((x) => !foundCatalogPaths.has(x))
         .toArray()
     if (missing.length > 0) {
-        console.error(
-            `Couldn't resolve ${missing.length} catalog paths:`,
-            missing,
-            isPublished
+        throw new JsonError(
+            `${missing.length} catalog path(s) named by explorer ${slug} cannot be resolved: ${missing.join(", ")}.`,
+            400
         )
     }
     // Merge proposed variable ids and resolved variable ids.
@@ -246,8 +245,8 @@ export async function upsertExplorerVariables(
         })
         const validIds = await validateVariableIds(
             knex,
-            Array.from(proposedUnion),
-            isPublished
+            slug,
+            Array.from(proposedUnion)
         )
         await knex("explorer_variables").where({ explorerSlug: slug }).delete()
         await knex("explorer_variables").insert(

--- a/db/model/Variable.ts
+++ b/db/model/Variable.ts
@@ -13,6 +13,8 @@ import {
 } from "@ourworldindata/grapher"
 import pl from "nodejs-polars"
 import { DATA_API_URL } from "../../settings/serverSettings.js"
+import { deleteGrapherConfigFromR2ByUuid } from "../../serverUtils/r2/chartConfigR2Helpers.js"
+import pMap from "p-map"
 import { escape } from "mysql2"
 import {
     MultipleOwidVariableDataDimensionsMap,
@@ -1111,4 +1113,189 @@ export const getLatestIndicatorIdsByCatalogPath = async (
     )
 
     return new Map(entries)
+}
+
+/**
+ * Tables holding one or more rows per indicator that have to be cleared before
+ * the indicator row itself can be deleted
+ */
+const INDICATOR_CHILD_TABLES = [
+    "origins_variables",
+    "tags_variables_topic_tags",
+    "posts_gdocs_variables_faqs",
+    "explorer_variables",
+    "multi_dim_x_chart_configs",
+] as const
+
+/** One indicator a chart, an explorer or a multi-dim view still uses, and what uses it. */
+export interface BlockedIndicator {
+    variableId: number
+    variableName: string | null
+    usedBy: "chart" | "explorer" | "multiDimView"
+    /** Chart slug or id, explorer slug, or `catalogPath#viewId` */
+    ref: string | null
+}
+
+export interface DeleteIndicatorsResult {
+    deleted: number[]
+    blocked: BlockedIndicator[]
+}
+
+/**
+ * Delete indicators, refusing any a chart, an explorer or a multi-dim view
+ * still uses.
+ *
+ * An indicator in use is never deleted, but it also doesn't result in a failed
+ * transaction: the caller can report the blocked indicators to the user and
+ * let them decide what to do.
+ */
+export async function deleteIndicators(
+    trx: db.KnexReadWriteTransaction,
+    indicatorIds: number[]
+): Promise<DeleteIndicatorsResult> {
+    if (indicatorIds.length === 0) return { deleted: [], blocked: [] }
+
+    const existingIndicators = await trx<DbRawVariable>(VariablesTableName)
+        .whereIn("id", indicatorIds)
+        .select("id", "sourceId", "patchConfigIdETL")
+
+    if (existingIndicators.length === 0) return { deleted: [], blocked: [] }
+    const existingIndicatorIds = existingIndicators.map(
+        (indicator) => indicator.id
+    )
+
+    // Check if any of the indicators are still in use by a chart, an explorer
+    // or a multi-dim view
+    const blocked = await db.knexRaw<BlockedIndicator>(
+        trx,
+        `-- sql
+        SELECT DISTINCT
+            cd.variableId,
+            v.name AS variableName,
+            'chart' AS usedBy,
+            -- Fall back to the chart ID if the slug is missing
+            COALESCE(cc.slug, c.id) AS ref
+        FROM chart_dimensions cd
+        JOIN variables v ON v.id = cd.variableId
+        JOIN charts c ON c.id = cd.chartId
+        JOIN chart_configs cc ON cc.id = c.configId
+        WHERE cd.variableId IN (?)
+
+        UNION ALL
+
+        SELECT DISTINCT
+            ev.variableId,
+            v.name AS variableName,
+            'explorer' AS usedBy,
+            ev.explorerSlug AS ref
+        FROM explorer_variables ev
+        JOIN variables v ON v.id = ev.variableId
+        JOIN explorers e ON e.slug = ev.explorerSlug
+        WHERE ev.variableId IN (?) AND e.isPublished
+
+        UNION ALL
+
+        SELECT DISTINCT
+            mdxcc.variableId,
+            v.name AS variableName,
+            'multiDimView' AS usedBy,
+            CONCAT(mddp.catalogPath, '#', mdxcc.viewId) AS ref
+        FROM multi_dim_x_chart_configs mdxcc
+        JOIN variables v ON v.id = mdxcc.variableId
+        JOIN multi_dim_data_pages mddp ON mddp.id = mdxcc.multiDimId
+        WHERE mdxcc.variableId IN (?) AND (
+            mddp.published
+            -- Both of these reference the view (or its config) with a RESTRICT foreign key:
+            -- deleting it throws and takes the whole transaction with it.
+            OR EXISTS (
+                SELECT 1 FROM narrative_charts nc
+                WHERE nc.parentMultiDimXChartConfigId = mdxcc.id
+            )
+            OR EXISTS (
+                SELECT 1 FROM multi_dim_redirects mdr
+                WHERE mdr.viewConfigId = mdxcc.chartConfigId
+            )
+        )
+
+        ORDER BY variableId, usedBy, ref
+        `,
+        [existingIndicatorIds, existingIndicatorIds, existingIndicatorIds]
+    )
+
+    const blockedIndicatorIds = new Set(blocked.map((row) => row.variableId))
+    const deletableIndicators = existingIndicators.filter(
+        (indicator) => !blockedIndicatorIds.has(indicator.id)
+    )
+    const deletableIndicatorIds = deletableIndicators.map(
+        (indicator) => indicator.id
+    )
+
+    if (deletableIndicatorIds.length === 0) return { deleted: [], blocked }
+
+    // Collect the IDs of the chart configs for the indicators being deleted
+    const indicatorConfigIds = _.compact(
+        deletableIndicators.map((indicator) => indicator.patchConfigIdETL)
+    )
+    const multiDimConfigIds = await trx<DbPlainMultiDimXChartConfig>(
+        MultiDimXChartConfigsTableName
+    )
+        .whereIn("variableId", deletableIndicatorIds)
+        .pluck("chartConfigId")
+    const chartConfigIds = _.uniq([...indicatorConfigIds, ...multiDimConfigIds])
+
+    // Collect origin and source IDs for the indicators being deleted
+    const originIds = await trx("origins_variables")
+        .whereIn("variableId", deletableIndicatorIds)
+        .pluck("originId")
+    const sourceIds = _.compact(
+        deletableIndicators.map((indicator) => indicator.sourceId)
+    )
+
+    // Delete all child rows of the indicators being deleted
+    for (const table of INDICATOR_CHILD_TABLES) {
+        await trx(table).whereIn("variableId", deletableIndicatorIds).delete()
+    }
+
+    // Delete the indicators themselves
+    await trx(VariablesTableName).whereIn("id", deletableIndicatorIds).delete()
+
+    // Delete now-orphaned origins and sources
+    if (originIds.length > 0) {
+        await db.knexRaw(
+            trx,
+            `-- sql
+            DELETE o FROM origins o
+            LEFT JOIN origins_variables ov ON ov.originId = o.id
+            WHERE o.id IN (?) AND ov.originId IS NULL
+            `,
+            [originIds]
+        )
+    }
+    if (sourceIds.length > 0) {
+        await db.knexRaw(
+            trx,
+            `-- sql
+            DELETE s FROM sources s
+            LEFT JOIN variables v ON v.sourceId = s.id
+            WHERE s.id IN (?) AND v.sourceId IS NULL
+            `,
+            [sourceIds]
+        )
+    }
+
+    // Delete chart configs from the DB and from R2
+    if (chartConfigIds.length > 0) {
+        await trx("chart_configs").whereIn("id", chartConfigIds).delete()
+
+        // Only multi dim chart configs are stored in R2
+        await pMap(
+            multiDimConfigIds,
+            // A failed delete should not roll this transaction back.
+            // The next sync to R2 will clean up any orphaned objects.
+            (id) => deleteGrapherConfigFromR2ByUuid(id).catch(console.error),
+            { concurrency: 20 }
+        )
+    }
+
+    return { deleted: deletableIndicatorIds, blocked }
 }

--- a/db/tests/testHelpers.ts
+++ b/db/tests/testHelpers.ts
@@ -20,7 +20,10 @@ import {
     MultiDimViewDimensionsTableName,
     MultiDimXChartConfigsTableName,
     NarrativeChartsTableName,
+    OriginsTableName,
+    OriginsVariablesTableName,
     PostsGdocsTableName,
+    SourcesTableName,
     TagGraphTableName,
     TagsTableName,
     UsersTableName,
@@ -46,7 +49,10 @@ export const TABLES_IN_USE = [
     ExplorersTableName,
     JobsTableName,
     ChartsTableName,
-    VariablesTableName,
+    OriginsVariablesTableName, // Must come before VariablesTableName and OriginsTableName due to foreign keys
+    VariablesTableName, // Must come before SourcesTableName due to foreign key
+    OriginsTableName,
+    SourcesTableName,
     ChartConfigsTableName,
     DatasetsTableName,
     PostsGdocsTableName,
@@ -96,12 +102,4 @@ export async function insertTestChart(
     }
     const [chartId] = await knexInstance(ChartsTableName).insert(row)
     return { chartId, configId, patchConfigId }
-}
-
-export function sleep(time: number, value: unknown): Promise<any> {
-    return new Promise((resolve) => {
-        setTimeout(() => {
-            return resolve(value)
-        }, time)
-    })
 }


### PR DESCRIPTION
> _Written by Claude Opus 5 — @sophiamersmann at the wheel._

`POST /api/variables/delete` takes a list of indicator ids and deletes them along with everything that hangs off them, so the ETL can drop an indicator without stranding rows behind ([etl#6672](https://github.com/owid/etl/pull/6672)).

An indicator that a chart (including drafts), a published explorer or a live multi-dim view still uses is reported back as `blocked` instead of being deleted, and doesn't fail the request.

**Open question:** Only _published_ explorers and multi-dims are checked. Variables that are used by _draft_ explorers and multi-dims can be deleted, and the explorer/multi-dim would then complain the next time it's updated. I made the distinction because I don't want to annoyingly refuse to delete something that's not currently live, but I'm also wondering if it's worth the complexity.

Per deleted indicator it clears:

- the `variables` row itself
- the `chart_configs` row holding the indicator's own ETL-authored config
- `explorer_variables` — only for draft explorers; a published one blocks instead
- `multi_dim_x_chart_configs` — the materialized view rows, and the `chart_configs` row each one owns, in the DB and in R2 (also only for draft mdims)
- `origins_variables`, `tags_variables_topic_tags` and `posts_gdocs_variables_faqs` — ETL projections rebuilt from the indicator's metadata
- any `origins` and `sources` rows left unreachable afterwards, since `origins_variables` and `variables.sourceId` are the only ways to reach them

It also carries a migration for the orphans already in the table: 7,267 `chart_configs`, 8,280 `origins` and 3,038 `sources` rows on the current snapshot.

@Marigold's #6996, rebased onto this stack and adapted to it.


