### PR TITLE
🔨🤖 fingerprint MySQL errors in Sentry by error code and route

### DIFF
--- a/serverUtils/instrument.ts
+++ b/serverUtils/instrument.ts
@@ -2,7 +2,7 @@ import { SENTRY_ADMIN_DSN } from "../settings/clientSettings.js"
 import * as Sentry from "@sentry/node"
 import { nodeProfilingIntegration } from "@sentry/profiling-node"
 import { openAIIntegration } from "@sentry/node"
-import { mysqlErrorFingerprint } from "./mysqlErrorFingerprint.js"
+import { fingerprintMysqlErrors } from "./mysqlErrorFingerprint.js"
 
 if (!process.env.VITEST) {
     // Ensure to call this before importing any other modules!
@@ -18,11 +18,7 @@ if (!process.env.VITEST) {
             // "automatic chart tagging".
             openAIIntegration(),
         ],
-        beforeSend: (event, hint) => {
-            const fingerprint = mysqlErrorFingerprint(hint.originalException)
-            if (fingerprint) event.fingerprint = fingerprint
-            return event
-        },
+        beforeSend: fingerprintMysqlErrors,
         tracesSampleRate: 0.1,
         profileLifecycle: "trace", // only profile requests that are traced
         profileSessionSampleRate: 1.0, // This is relative to tracesSampleRate

--- a/serverUtils/instrument.ts
+++ b/serverUtils/instrument.ts
@@ -2,6 +2,7 @@ import { SENTRY_ADMIN_DSN } from "../settings/clientSettings.js"
 import * as Sentry from "@sentry/node"
 import { nodeProfilingIntegration } from "@sentry/profiling-node"
 import { openAIIntegration } from "@sentry/node"
+import { mysqlErrorFingerprint } from "./mysqlErrorFingerprint.js"
 
 if (!process.env.VITEST) {
     // Ensure to call this before importing any other modules!
@@ -17,6 +18,11 @@ if (!process.env.VITEST) {
             // "automatic chart tagging".
             openAIIntegration(),
         ],
+        beforeSend: (event, hint) => {
+            const fingerprint = mysqlErrorFingerprint(hint.originalException)
+            if (fingerprint) event.fingerprint = fingerprint
+            return event
+        },
         tracesSampleRate: 0.1,
         profileLifecycle: "trace", // only profile requests that are traced
         profileSessionSampleRate: 1.0, // This is relative to tracesSampleRate

--- a/serverUtils/mysqlErrorFingerprint.test.ts
+++ b/serverUtils/mysqlErrorFingerprint.test.ts
@@ -1,0 +1,72 @@
+import { expect, it, describe } from "vitest"
+
+import { mysqlErrorFingerprint } from "./mysqlErrorFingerprint.js"
+
+const mysqlError = (fields: Record<string, unknown>) =>
+    Object.assign(new Error("mysql said no"), fields)
+
+// the three kinds of error that shared one Sentry issue (ADMIN-73)
+const accessDenied = mysqlError({
+    code: "ER_ACCESS_DENIED_ERROR",
+    errno: 1045,
+    sqlState: "28000",
+})
+const deadlock = mysqlError({
+    code: "ER_LOCK_DEADLOCK",
+    errno: 1213,
+    sqlState: "40001",
+})
+const unknownColumn = mysqlError({
+    code: "ER_BAD_FIELD_ERROR",
+    errno: 1054,
+    sqlState: "42S22",
+})
+
+describe(mysqlErrorFingerprint, () => {
+    it("fingerprints a server-side error by code and route", () => {
+        expect(mysqlErrorFingerprint(accessDenied)).toEqual([
+            "mysql",
+            "ER_ACCESS_DENIED_ERROR",
+            "{{ transaction }}",
+        ])
+    })
+
+    it("gives the errors that shared one issue distinct fingerprints", () => {
+        const fingerprints = [accessDenied, deadlock, unknownColumn].map(
+            (error) => mysqlErrorFingerprint(error)?.join("|")
+        )
+        expect(new Set(fingerprints).size).toBe(3)
+    })
+
+    it("falls back to the errno when mysql2 has no name for it", () => {
+        const error = mysqlError({ errno: 99999, sqlState: "HY000" })
+        expect(mysqlErrorFingerprint(error)).toEqual([
+            "mysql",
+            "errno-99999",
+            "{{ transaction }}",
+        ])
+    })
+
+    it("falls back to the sqlState when there is no errno either", () => {
+        const error = mysqlError({ sqlState: "HY000" })
+        expect(mysqlErrorFingerprint(error)).toEqual([
+            "mysql",
+            "HY000",
+            "{{ transaction }}",
+        ])
+    })
+
+    it("leaves client-side errors to Sentry's default grouping", () => {
+        // no sqlState: the server never answered, so these keep a real stack
+        const connectionRefused = mysqlError({
+            code: "ECONNREFUSED",
+            errno: -61,
+        })
+        expect(mysqlErrorFingerprint(connectionRefused)).toBeUndefined()
+        expect(
+            mysqlErrorFingerprint(new Error("something else"))
+        ).toBeUndefined()
+        expect(mysqlErrorFingerprint(undefined)).toBeUndefined()
+        expect(mysqlErrorFingerprint("a string")).toBeUndefined()
+    })
+})

--- a/serverUtils/mysqlErrorFingerprint.test.ts
+++ b/serverUtils/mysqlErrorFingerprint.test.ts
@@ -1,11 +1,15 @@
 import { expect, it, describe } from "vitest"
 
-import { mysqlErrorFingerprint } from "./mysqlErrorFingerprint.js"
+import {
+    fingerprintMysqlErrors,
+    mysqlErrorFingerprint,
+} from "./mysqlErrorFingerprint.js"
 
 const mysqlError = (fields: Record<string, unknown>) =>
     Object.assign(new Error("mysql said no"), fields)
 
-// the three kinds of error that shared one Sentry issue (ADMIN-73)
+// the three kinds of error that shared one Sentry issue (ADMIN-73), with the
+// code/errno/sqlState triples mysql2 actually produces
 const accessDenied = mysqlError({
     code: "ER_ACCESS_DENIED_ERROR",
     errno: 1045,
@@ -22,13 +26,27 @@ const unknownColumn = mysqlError({
     sqlState: "42S22",
 })
 
+// `type: undefined` is what makes an ErrorEvent an error rather than a transaction
+const send = (originalException: unknown, transaction?: string) =>
+    fingerprintMysqlErrors(
+        { type: undefined, transaction },
+        {
+            originalException,
+        }
+    )
+
 describe(mysqlErrorFingerprint, () => {
-    it("fingerprints a server-side error by code and route", () => {
+    it("fingerprints a server-side error by code", () => {
         expect(mysqlErrorFingerprint(accessDenied)).toEqual([
             "mysql",
             "ER_ACCESS_DENIED_ERROR",
-            "{{ transaction }}",
         ])
+    })
+
+    it("adds the route when the error came out of a request", () => {
+        expect(
+            mysqlErrorFingerprint(deadlock, "PUT /admin/api/gdocs/:id")
+        ).toEqual(["mysql", "ER_LOCK_DEADLOCK", "PUT /admin/api/gdocs/:id"])
     })
 
     it("gives the errors that shared one issue distinct fingerprints", () => {
@@ -38,22 +56,23 @@ describe(mysqlErrorFingerprint, () => {
         expect(new Set(fingerprints).size).toBe(3)
     })
 
+    it("splits the same error code across routes", () => {
+        const one = mysqlErrorFingerprint(deadlock, "PUT /admin/api/gdocs/:id")
+        const other = mysqlErrorFingerprint(
+            deadlock,
+            "PUT /admin/api/charts/:id"
+        )
+        expect(one).not.toEqual(other)
+    })
+
     it("falls back to the errno when mysql2 has no name for it", () => {
         const error = mysqlError({ errno: 99999, sqlState: "HY000" })
-        expect(mysqlErrorFingerprint(error)).toEqual([
-            "mysql",
-            "errno-99999",
-            "{{ transaction }}",
-        ])
+        expect(mysqlErrorFingerprint(error)).toEqual(["mysql", "errno-99999"])
     })
 
     it("falls back to the sqlState when there is no errno either", () => {
         const error = mysqlError({ sqlState: "HY000" })
-        expect(mysqlErrorFingerprint(error)).toEqual([
-            "mysql",
-            "HY000",
-            "{{ transaction }}",
-        ])
+        expect(mysqlErrorFingerprint(error)).toEqual(["mysql", "HY000"])
     })
 
     it("leaves client-side errors to Sentry's default grouping", () => {
@@ -68,5 +87,34 @@ describe(mysqlErrorFingerprint, () => {
         ).toBeUndefined()
         expect(mysqlErrorFingerprint(undefined)).toBeUndefined()
         expect(mysqlErrorFingerprint("a string")).toBeUndefined()
+    })
+})
+
+describe(fingerprintMysqlErrors, () => {
+    it("sets the fingerprint from the event's own transaction", () => {
+        expect(
+            send(accessDenied, "PUT /admin/api/gdocs/:id").fingerprint
+        ).toEqual([
+            "mysql",
+            "ER_ACCESS_DENIED_ERROR",
+            "PUT /admin/api/gdocs/:id",
+        ])
+    })
+
+    it("leaves the event untouched when it isn't a MySQL server error", () => {
+        expect(send(new Error("nope")).fingerprint).toBeUndefined()
+    })
+
+    // A route that wraps a query failure — `throw new JsonError(msg, 500, {
+    // cause: error })` — was thrown from app code, so the event carries app
+    // frames and Sentry groups it by where it happened, which is more specific
+    // than this fingerprint. Only the unwrapped rejections need help.
+    it("does not follow the cause chain of a wrapped error", () => {
+        const wrapped = new Error("Failed to fetch multi-dims", {
+            cause: accessDenied,
+        })
+        expect(
+            send(wrapped, "GET /admin/api/multi-dims.json").fingerprint
+        ).toBeUndefined()
     })
 })

--- a/serverUtils/mysqlErrorFingerprint.ts
+++ b/serverUtils/mysqlErrorFingerprint.ts
@@ -1,0 +1,49 @@
+interface MysqlServerError {
+    sqlState: string
+    code?: string
+    errno?: number
+}
+
+/**
+ * mysql2 sets `sqlState` only on errors the MySQL server itself sent back, which
+ * is what distinguishes them from client-side failures (ECONNREFUSED and friends
+ * carry a `code` too, but no `sqlState`).
+ */
+function isMysqlServerError(error: unknown): error is MysqlServerError {
+    return (
+        typeof error === "object" &&
+        error !== null &&
+        typeof (error as { sqlState?: unknown }).sqlState === "string"
+    )
+}
+
+/**
+ * A Sentry fingerprint that groups MySQL errors by what actually went wrong.
+ *
+ * mysql2 raises every server-side error from one place — `Packet.asError`, deep
+ * in its packet parser — and by the time the promise rejects, the app frames
+ * that led there are gone. So Sentry has nothing but that one stack to group on,
+ * and unrelated failures pile into a single issue: a container whose MySQL
+ * account went missing, a staging branch whose code is ahead of its schema, and
+ * a genuine deadlock in the production admin all land together. Whichever is
+ * loudest hides the rest — and a crash-looping staging container is much louder
+ * than production.
+ *
+ * The MySQL error code plus the route splits them into issues that each mean one
+ * thing. Returns undefined for anything that isn't a MySQL server error, leaving
+ * Sentry's default grouping alone.
+ */
+export function mysqlErrorFingerprint(error: unknown): string[] | undefined {
+    if (!isMysqlServerError(error)) return undefined
+
+    // `code` is mysql2's name for the errno, looked up in a table it bundles, so
+    // it is missing for errnos newer than the mysql2 version we run.
+    const label =
+        error.code ??
+        (error.errno !== undefined ? `errno-${error.errno}` : error.sqlState)
+
+    // `{{ transaction }}` is substituted server-side by Sentry, and is empty for
+    // errors thrown outside a request — which groups all of a process's startup
+    // failures together, as intended.
+    return ["mysql", label, "{{ transaction }}"]
+}

--- a/serverUtils/mysqlErrorFingerprint.ts
+++ b/serverUtils/mysqlErrorFingerprint.ts
@@ -1,3 +1,5 @@
+import type { ErrorEvent, EventHint } from "@sentry/node"
+
 interface MysqlServerError {
     sqlState: string
     code?: string
@@ -33,7 +35,10 @@ function isMysqlServerError(error: unknown): error is MysqlServerError {
  * thing. Returns undefined for anything that isn't a MySQL server error, leaving
  * Sentry's default grouping alone.
  */
-export function mysqlErrorFingerprint(error: unknown): string[] | undefined {
+export function mysqlErrorFingerprint(
+    error: unknown,
+    transaction?: string
+): string[] | undefined {
     if (!isMysqlServerError(error)) return undefined
 
     // `code` is mysql2's name for the errno, looked up in a table it bundles, so
@@ -42,8 +47,30 @@ export function mysqlErrorFingerprint(error: unknown): string[] | undefined {
         error.code ??
         (error.errno !== undefined ? `errno-${error.errno}` : error.sqlState)
 
-    // `{{ transaction }}` is substituted server-side by Sentry, and is empty for
-    // errors thrown outside a request — which groups all of a process's startup
-    // failures together, as intended.
-    return ["mysql", label, "{{ transaction }}"]
+    // Sentry substitutes `{{ transaction }}` at ingest, but resolving it here
+    // means the group key is whatever this function returns — testable, and
+    // visible in the event itself. Errors thrown outside a request have no
+    // transaction, which groups a process's startup failures together.
+    return transaction ? ["mysql", label, transaction] : ["mysql", label]
+}
+
+/**
+ * Sentry `beforeSend` hook.
+ *
+ * Scope note: this deliberately looks at the thrown error only, not at its
+ * `cause` chain. An error a route wrapped in a `JsonError` was thrown from app
+ * code and carries app frames, so Sentry already groups it by where it happened
+ * — which is more specific than anything this function could produce. Only the
+ * unwrapped mysql2 rejections, the ones with no app frames at all, need help.
+ */
+export function fingerprintMysqlErrors(
+    event: ErrorEvent,
+    hint: EventHint
+): ErrorEvent {
+    const fingerprint = mysqlErrorFingerprint(
+        hint.originalException,
+        event.transaction
+    )
+    if (fingerprint) event.fingerprint = fingerprint
+    return event
 }


### PR DESCRIPTION
> _Written by Claude Opus 5 — @Marigold at the wheel._

Every server-side MySQL error in the admin, the deploy queue and the bakers currently lands in a **single** Sentry issue ([ADMIN-73](https://our-world-in-data.sentry.io/issues/42537980/), 30k events), because mysql2 raises all of them from one place — `Packet.asError` in its packet parser — and when the rejection is unhandled there are no app frames left for Sentry to group on. `beforeSend` now fingerprints those errors by MySQL error code and route instead. No runtime behaviour changes; only how events are grouped once they reach Sentry.

_Skim — one hook, one pure function, one test file._

## How it works

`sqlState` is the discriminator: mysql2 sets it only on errors the MySQL server itself sent back. Client-side failures carry a `code` too (`ECONNREFUSED`), but no `sqlState`, and they still have a real stack, so they keep Sentry's default grouping. The fingerprint is `["mysql", <code>, <route>]`, with the route omitted outside a request.

Three decisions worth knowing:

- **The route is resolved here, not left to `{{ transaction }}`.** Sentry does substitute that placeholder in an SDK-supplied fingerprint — `resolve_fingerprint_values` in `sentry/grouping/api.py` runs on any non-default fingerprint, client-supplied ones included — but resolving it in `beforeSend` makes the group key exactly what the function returns, which a test can assert. The placeholder version could only be verified by shipping it and reading production issues.
- **It does not walk the `cause` chain.** Routes that wrap query failures (`throw new JsonError(msg, 500, { cause: error })`, e.g. `mdims.ts:330`) throw from app code, so those events carry app frames and Sentry already groups them by where they happened — more specific than this fingerprint. Following the chain would merge distinct wrapped failures that share a route and an error code. Only the unwrapped rejections, with no app frames at all, need a synthetic key.
- **Falling back `code` → `errno` → `sqlState`.** mysql2 derives `code` from an errno table it bundles, so it is `undefined` for errnos newer than our mysql2. Without the fallback those would fingerprint as `["mysql", undefined, …]` and re-merge into one bucket — the exact failure being fixed.

I did not add a filter to drop staging DB errors before they're sent. It would cut the event volume too, but that's a policy call about what staging is allowed to report, and grouping is enough to stop prod being buried.

## Verified

Against a **live MySQL**, driving real mysql2 errors through a real Sentry client running this hook with the envelope captured instead of sent:

| Real error | Resulting fingerprint |
|---|---|
| `ER_ACCESS_DENIED_ERROR` (1045/28000), outside a request | `["mysql", "ER_ACCESS_DENIED_ERROR"]` |
| the same, inside a route | `["mysql", "ER_ACCESS_DENIED_ERROR", "PUT /admin/api/gdocs/:id"]` |
| `ER_BAD_FIELD_ERROR` (1054/42S22) | `["mysql", "ER_BAD_FIELD_ERROR", "PUT /admin/api/charts/:id"]` |
| `ER_PARSE_ERROR` (1064/42000) | `["mysql", "ER_PARSE_ERROR", …]` |
| `ER_DBACCESS_DENIED_ERROR` (1044/42000) | `["mysql", "ER_DBACCESS_DENIED_ERROR", …]` |
| `ECONNREFUSED` (no `sqlState`) | none — Sentry's default |
| `ER_BAD_FIELD_ERROR` wrapped in `{ cause }` | none — 2-entry exception chain, 3 `in_app` frames |

Five distinct fingerprints out of five, and the same error code on two different routes splits.

**Not verified:** that Sentry's ingest then groups by those keys as expected — the first real proof is a MySQL error after deploy opening an issue titled by its code rather than joining ADMIN-73. Every `serverUtils/instrument.js` importer is affected — admin server, deploy queue, SiteBaker, the algolia indexers: `rg -l 'serverUtils/instrument' --type ts`.

## Note for whoever triages ADMIN-73

Existing events stay where they are; only new ones get the new grouping. ADMIN-73 can be resolved once it stops receiving traffic. The three clusters inside it, for reference:

| Error | 30 d | Where |
|---|---|---|
| `Access denied for user 'owid'@'localhost'` | 7,182 | one staging container whose MySQL accounts were overwritten by a prod restore drill; it crash-looped 7,225 times over three days and has been destroyed |
| `Unknown column 'code' in 'field list'` (also `c.configIdETL`) | 2,973 | five staging containers running branch code ahead of their schema; resolved itself the same day |
| `Deadlock found when trying to get lock` | ~50 | the real signal — staging fleet plus `owid-admin-prod`, on `jobs`, `chart_slug_redirects`, `archived_chart_versions`, `multi_dim_x_chart_configs`, `posts_gdocs_links` |
