### PR TITLE
🔨🤖 Tell owid/etl when the grapher schema is published

### DIFF
--- a/.github/workflows/sync-grapher-schema-to-r2.yml
+++ b/.github/workflows/sync-grapher-schema-to-r2.yml
@@ -66,3 +66,21 @@ jobs:
         run: |
           aws s3 sync packages/@ourworldindata/grapher/src/schema s3://owid-public/schemas \
             --endpoint-url https://${{ secrets.CLOUDFLARE_R2_ACCOUNT_ID }}.r2.cloudflarestorage.com
+
+      # The etl repo vendors this schema and its integration tests compare the vendored copy
+      # against the published one, so until etl re-vendors, every etl branch's staging build
+      # fails on a change made here. Telling etl the moment we publish gets its sync PR opened
+      # in minutes; it also polls daily, but that left a Friday publish red until Monday.
+      # Needs a token with contents:write on owid/etl — GITHUB_TOKEN cannot dispatch across
+      # repos. A failure here must not fail the upload that already succeeded.
+      - name: Tell owid/etl the schema was published
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.ETL_SCHEMA_SYNC_TOKEN }}
+        run: |
+          gh api repos/owid/etl/dispatches --input - <<EOF
+          {
+            "event_type": "grapher-schema-published",
+            "client_payload": { "commit": "$GITHUB_SHA" }
+          }
+          EOF


### PR DESCRIPTION
> _Written by Claude Opus 5 — @Marigold at the wheel._

The etl repo vendors `grapher-schema.*.json` and its integration suite asserts the vendored copy still matches the published one. So when we change the schema in place, **every** etl branch's staging build goes red until etl re-vendors — the failure shows up on unrelated PRs, which is how it usually gets noticed.

etl polls `files.ourworldindata.org` for that once a day, weekdays at 07:00 UTC. That is a bad fit for a publish that happens whenever a PR merges: the `inapplicableEntityNames` change published Friday 2026-08-21 14:12 UTC (#6892) and, without someone spotting it, would have stayed red until Monday morning.

This adds one step at the end of the upload: dispatch `owid/etl` once the files are in R2, so its sync PR opens minutes later. etl keeps its cron as a backstop.

**Needs a secret before it does anything:** `ETL_SCHEMA_SYNC_TOKEN`, a token with `contents: write` on `owid/etl`. `GITHUB_TOKEN` cannot dispatch across repositories. Until that exists the step fails, which is why it is `continue-on-error` — a failed notification must never fail an upload that already succeeded. The etl side is owid/etl#6745.

<details><summary>Details</summary>

- Payload is `{"event_type": "grapher-schema-published", "client_payload": {"commit": "$GITHUB_SHA"}}`. etl puts that commit URL in its sync PR body, which is the one genuinely laborious part of servicing these syncs — tracing which upstream change caused the drift.
- The existing `paths` filter on `packages/@ourworldindata/grapher/src/schema/**` is unchanged, so the dispatch also fires for pushes that touch only `.ts` files in that directory and leave the published JSON identical. etl handles that: it finds no difference and exits without opening a PR.
- The etl side polls for up to 7 minutes after a dispatch before concluding nothing changed, because this host is Cloudflare-fronted with `s-maxage=300` and can serve the pre-change object for up to five minutes after `aws s3 sync` completes. Without that wait the dispatch would just relocate the race instead of closing it.
- Verified locally: the workflow YAML parses, the heredoc produces the payload above, and `oxfmt --check` passes on the file. Not verified end to end — the dispatch cannot be exercised until the secret exists and both sides are on their default branches.

</details>
