### PR TITLE
🔨🤖 ignore the plans/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,9 @@ playwright-report/
 # Claude
 .claude/settings.local.json
 
+# Plans
+/plans/
+
 # Auto Claude
 .auto-claude/
 .auto-claude-security.json


### PR DESCRIPTION
> _Written by Anthropic Claude Opus 5 — @sophiamersmann at the wheel._

Adds `plans/` to `.gitignore`. Nothing in the repo reads or writes that directory, so the ignore entry is the whole change.