### PR TITLE
🔨🤖 (featured-viz) share the cite and license sections between gdoc pages

### DIFF
--- a/site/gdocs/components/CitationSection.tsx
+++ b/site/gdocs/components/CitationSection.tsx
@@ -1,0 +1,46 @@
+import { CITATION_ID } from "@ourworldindata/utils"
+import { CodeSnippet } from "@ourworldindata/components"
+
+/** The "Cite this work" section at the foot of a gdoc page */
+export function CitationSection({
+    citationText,
+    bibtex,
+    description,
+    isDeprecated,
+}: {
+    citationText: string
+    bibtex: string
+    description: string
+    isDeprecated?: boolean
+}) {
+    return (
+        <section
+            id={CITATION_ID}
+            className="grid grid-cols-12-full-width col-start-1 col-end-limit no-dividers"
+        >
+            <div className="col-start-4 span-cols-8 col-md-start-3 span-md-cols-10 col-sm-start-2 span-sm-cols-12">
+                <h3 className={isDeprecated ? "align-left" : "align-center"}>
+                    Cite this work
+                </h3>
+                {isDeprecated && (
+                    <p className="citation-deprecated-notice">
+                        <span className="citation-deprecated-notice__highlight">
+                            This content is outdated
+                        </span>
+                        , but if you would still like to use it, here is how to
+                        cite it:
+                        <br />
+                    </p>
+                )}
+                <p>{description}</p>
+                <div>
+                    <CodeSnippet code={citationText} />
+                </div>
+                <p>BibTeX citation</p>
+                <div>
+                    <CodeSnippet code={bibtex} />
+                </div>
+            </div>
+        </section>
+    )
+}

--- a/site/gdocs/components/LicenseSection.tsx
+++ b/site/gdocs/components/LicenseSection.tsx
@@ -1,0 +1,60 @@
+import { LICENSE_ID } from "@ourworldindata/utils"
+import { IS_ARCHIVE } from "../../../settings/clientSettings.js"
+import { PROD_URL } from "../../SiteConstants.js"
+
+const BASE_URL = IS_ARCHIVE ? PROD_URL : ""
+
+/** The "Reuse this work freely" section at the foot of a gdoc page */
+export function LicenseSection({ isDeprecated }: { isDeprecated?: boolean }) {
+    return (
+        <section
+            id={LICENSE_ID}
+            className="grid grid-cols-12-full-width col-start-1 col-end-limit"
+        >
+            <div className="col-start-4 span-cols-8 col-md-start-3 span-md-cols-10 col-sm-start-2 span-sm-cols-12">
+                {!isDeprecated && (
+                    <>
+                        <img
+                            src="/owid-logo.svg"
+                            alt="Our World in Data logo"
+                            loading="lazy"
+                            width={104}
+                            height={57}
+                        />
+                        <h3>Reuse this work freely</h3>
+                    </>
+                )}
+
+                <p>
+                    All visualizations, data, and articles produced by Our World
+                    in Data are completely open access under the{" "}
+                    <a href="https://creativecommons.org/licenses/by/4.0/">
+                        Creative Commons BY license
+                    </a>
+                    . You have the permission to use, distribute, and reproduce
+                    these in any medium, provided the source and authors are
+                    credited.
+                </p>
+                <p>
+                    The data produced by third parties and made available by Our
+                    World in Data is subject to the license terms from the
+                    original third-party authors. We will always indicate the
+                    original source of the data in our documentation, so you
+                    should always check the license of any such third-party data
+                    before use and redistribution.
+                </p>
+                {!isDeprecated && (
+                    <p>
+                        All of{" "}
+                        <a
+                            href={`${BASE_URL}/faqs#how-can-i-embed-one-of-your-interactive-charts-in-my-website`}
+                        >
+                            our charts can be embedded
+                        </a>{" "}
+                        in any site.
+                    </p>
+                )}
+            </div>
+        </section>
+    )
+}

--- a/site/gdocs/pages/GdocPost.tsx
+++ b/site/gdocs/pages/GdocPost.tsx
@@ -7,23 +7,18 @@ import { ArticleBlocks } from "../components/ArticleBlocks.js"
 import Footnotes from "../components/Footnotes.js"
 import {
     OwidGdocPostInterface,
-    CITATION_ID,
-    LICENSE_ID,
     OwidGdocType,
-    formatAuthorsForBibtex,
     EnrichedBlockText,
     getPhraseForArchivalDate,
 } from "@ourworldindata/utils"
-import { CodeSnippet } from "@ourworldindata/components"
-import { BAKED_BASE_URL, IS_ARCHIVE } from "../../../settings/clientSettings.js"
+import { BAKED_BASE_URL } from "../../../settings/clientSettings.js"
 import { OwidGdocHeader } from "../components/OwidGdocHeader.js"
 import StickyNav from "../../blocks/StickyNav.js"
-import { getShortPageCitation } from "../utils.js"
+import { buildGdocCitation } from "../utils.js"
+import { CitationSection } from "../components/CitationSection.js"
+import { LicenseSection } from "../components/LicenseSection.js"
 import { SidebarTableOfContents } from "../../SidebarTableOfContents.js"
 import { useDocumentContext } from "../DocumentContext.js"
-import { PROD_URL } from "../../SiteConstants.js"
-
-const BASE_URL = IS_ARCHIVE ? PROD_URL : ""
 
 const citationDescriptionsByArticleType: Record<
     | OwidGdocType.Article
@@ -65,17 +60,16 @@ export function GdocPost({
     const { archiveContext } = useDocumentContext()
     const postType = content.type ?? OwidGdocType.Article
     const citationDescription = citationDescriptionsByArticleType[postType]
-    const shortPageCitation = getShortPageCitation(
-        content.authors,
-        content.title ?? "",
-        publishedAt
-    )
     const citationUrl =
         archiveContext?.archiveUrl ?? `${BAKED_BASE_URL}/${slug}`
-    const archivalPhrase = getPhraseForArchivalDate(
-        archiveContext?.archivalDate
-    )
-    const citationText = `${shortPageCitation} Published online at OurWorldinData.org. Retrieved from: '${citationUrl}' [Online Resource]${archivalPhrase ? ` ${archivalPhrase}` : ""}`
+    const { citationText, bibtex } = buildGdocCitation({
+        authors: content.authors,
+        title: content.title ?? "",
+        publishedAt,
+        slug,
+        canonicalUrl: citationUrl,
+        archivalPhrase: getPhraseForArchivalDate(archiveContext?.archivalDate),
+    })
     const hasSidebarToc = content["sidebar-toc"]
     const sidebarHeadings =
         content.toc && content["sidebar-toc-h1-only"]
@@ -87,14 +81,6 @@ export function GdocPost({
     const isDeprecated =
         postType === OwidGdocType.Article &&
         Boolean(content["deprecation-notice"])
-    const bibtex = `@article{owid-${slug.replace(/\//g, "-")},
-    author = {${formatAuthorsForBibtex(content.authors)}},
-    title = {${content.title}},
-    journal = {Our World in Data},
-    year = {${publishedAt?.getFullYear()}},
-    note = {${citationUrl}}
-}`
-
     const stickyNavLinks = content["sticky-nav"]
 
     return (
@@ -143,88 +129,14 @@ export function GdocPost({
                 <Footnotes definitions={content.refs.definitions} />
             ) : null}
             {!content["hide-citation"] && (
-                <section
-                    id={CITATION_ID}
-                    className="grid grid-cols-12-full-width col-start-1 col-end-limit no-dividers"
-                >
-                    <div className="col-start-4 span-cols-8 col-md-start-3 span-md-cols-10 col-sm-start-2 span-sm-cols-12">
-                        <h3
-                            className={
-                                isDeprecated ? "align-left" : "align-center"
-                            }
-                        >
-                            Cite this work
-                        </h3>
-                        {isDeprecated && (
-                            <p className="citation-deprecated-notice">
-                                <span className="citation-deprecated-notice__highlight">
-                                    This content is outdated
-                                </span>
-                                , but if you would still like to use it, here is
-                                how to cite it:
-                                <br />
-                            </p>
-                        )}
-                        <p>{citationDescription}</p>
-                        <div>
-                            <CodeSnippet code={citationText} />
-                        </div>
-                        <p>BibTeX citation</p>
-                        <div>
-                            <CodeSnippet code={bibtex} />
-                        </div>
-                    </div>
-                </section>
+                <CitationSection
+                    citationText={citationText}
+                    bibtex={bibtex}
+                    description={citationDescription}
+                    isDeprecated={isDeprecated}
+                />
             )}
-            <section
-                id={LICENSE_ID}
-                className="grid grid-cols-12-full-width col-start-1 col-end-limit"
-            >
-                <div className="col-start-4 span-cols-8 col-md-start-3 span-md-cols-10 col-sm-start-2 span-sm-cols-12">
-                    {!isDeprecated && (
-                        <>
-                            <img
-                                src="/owid-logo.svg"
-                                alt="Our World in Data logo"
-                                loading="lazy"
-                                width={104}
-                                height={57}
-                            />
-                            <h3>Reuse this work freely</h3>
-                        </>
-                    )}
-
-                    <p>
-                        All visualizations, data, and articles produced by Our
-                        World in Data are completely open access under the{" "}
-                        <a href="https://creativecommons.org/licenses/by/4.0/">
-                            Creative Commons BY license
-                        </a>
-                        . You have the permission to use, distribute, and
-                        reproduce these in any medium, provided the source and
-                        authors are credited.
-                    </p>
-                    <p>
-                        The data produced by third parties and made available by
-                        Our World in Data is subject to the license terms from
-                        the original third-party authors. We will always
-                        indicate the original source of the data in our
-                        documentation, so you should always check the license of
-                        any such third-party data before use and redistribution.
-                    </p>
-                    {!isDeprecated && (
-                        <p>
-                            All of{" "}
-                            <a
-                                href={`${BASE_URL}/faqs#how-can-i-embed-one-of-your-interactive-charts-in-my-website`}
-                            >
-                                our charts can be embedded
-                            </a>{" "}
-                            in any site.
-                        </p>
-                    )}
-                </div>
-            </section>
+            <LicenseSection isDeprecated={isDeprecated} />
         </article>
     )
 }

--- a/site/gdocs/pages/Profile.tsx
+++ b/site/gdocs/pages/Profile.tsx
@@ -5,17 +5,21 @@ import {
     OwidGdocProfileInterface,
     CITATION_ID,
     LICENSE_ID,
-    formatAuthorsForBibtex,
 } from "@ourworldindata/utils"
-import { CodeSnippet, getCanonicalUrl } from "@ourworldindata/components"
+import { getCanonicalUrl } from "@ourworldindata/components"
 import { BAKED_BASE_URL } from "../../../settings/clientSettings.js"
 import { OwidGdocType } from "@ourworldindata/types"
-import { getShortPageCitation } from "../utils.js"
+import { buildGdocCitation } from "../utils.js"
+import { CitationSection } from "../components/CitationSection.js"
+import { LicenseSection } from "../components/LicenseSection.js"
 import { Byline } from "../components/Byline.js"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faBook } from "@fortawesome/free-solid-svg-icons"
 import { faCreativeCommons } from "@fortawesome/free-brands-svg-icons"
 import { SidebarTableOfContents } from "../../SidebarTableOfContents.js"
+
+const CITATION_DESCRIPTION =
+    "Our articles and data visualizations rely on work from many different people and organizations. When citing this profile page, please also cite the underlying data sources. This profile page can be cited as:"
 
 type ProfileProps = Omit<
     OwidGdocProfileInterface,
@@ -32,24 +36,16 @@ export function Profile({ content, publishedAt, slug, tags }: ProfileProps) {
             : content.toc
     const instantiatedEntity = content.instantiatedEntity
 
-    const shortPageCitation = getShortPageCitation(
-        content.authors,
-        content.title ?? "",
-        publishedAt
-    )
-    const profileUrl = getCanonicalUrl(BAKED_BASE_URL, {
+    const { citationText, bibtex } = buildGdocCitation({
+        authors: content.authors,
+        title: content.title ?? "",
+        publishedAt,
         slug,
-        content: { type: OwidGdocType.Profile },
+        canonicalUrl: getCanonicalUrl(BAKED_BASE_URL, {
+            slug,
+            content: { type: OwidGdocType.Profile },
+        }),
     })
-    const citationText = `${shortPageCitation} Published online at OurWorldinData.org. Retrieved from: '${profileUrl}' [Online Resource]`
-
-    const bibtex = `@article{owid-${slug.replace(/\//g, "-")},
-    author = {${formatAuthorsForBibtex(content.authors)}},
-    title = {${content.title}},
-    journal = {Our World in Data},
-    year = {${publishedAt?.getFullYear()}},
-    note = {${profileUrl}}
-}`
 
     return (
         <article className="centered-article-container grid grid-cols-12-full-width centered-article-container--profile">
@@ -105,68 +101,12 @@ export function Profile({ content, publishedAt, slug, tags }: ProfileProps) {
             {content.refs && !_.isEmpty(content.refs.definitions) ? (
                 <Footnotes definitions={content.refs.definitions} />
             ) : null}
-            <section
-                id={CITATION_ID}
-                className="grid grid-cols-12-full-width col-start-1 col-end-limit"
-            >
-                <div className="col-start-4 span-cols-8 col-md-start-3 span-md-cols-10 col-sm-start-2 span-sm-cols-12">
-                    <h3 className="align-center">Cite this work</h3>
-                    <p>
-                        Our articles and data visualizations rely on work from
-                        many different people and organizations. When citing
-                        this profile page, please also cite the underlying data
-                        sources. This profile page can be cited as:
-                    </p>
-                    <div>
-                        <CodeSnippet code={citationText} />
-                    </div>
-                    <p>BibTeX citation</p>
-                    <div>
-                        <CodeSnippet code={bibtex} />
-                    </div>
-                </div>
-            </section>
-            <section
-                id={LICENSE_ID}
-                className="grid grid-cols-12-full-width col-start-1 col-end-limit"
-            >
-                <div className="col-start-4 span-cols-8 col-md-start-3 span-md-cols-10 col-sm-start-2 span-sm-cols-12">
-                    <img
-                        src="/owid-logo.svg"
-                        alt="Our World in Data logo"
-                        loading="lazy"
-                        width={104}
-                        height={57}
-                    />
-                    <h3>Reuse this work freely</h3>
-                    <p>
-                        All visualizations, data, and articles produced by Our
-                        World in Data are completely open access under the{" "}
-                        <a
-                            href="https://creativecommons.org/licenses/by/4.0/"
-                            target="_blank"
-                            rel="noopener"
-                        >
-                            Creative Commons BY license
-                        </a>
-                        . You have the permission to use, distribute, and
-                        reproduce these in any medium, provided the source and
-                        authors are credited.
-                    </p>
-                    <p>
-                        The data produced by third parties and made available by
-                        Our World in Data is subject to the license terms from
-                        the original third-party authors. We will always
-                        indicate the original source of the data in our
-                        documentation, so you should always check the license of
-                        any such third-party data before use and redistribution.
-                    </p>
-                    <p>
-                        All of <a href="https://github.com/owid">our charts</a>{" "}
-                        can be embedded in any site.
-                    </p>
-                </div>
-            </section>
+            <CitationSection
+                citationText={citationText}
+                bibtex={bibtex}
+                description={CITATION_DESCRIPTION}
+            />
+            <LicenseSection />
         </article>
     )
 }

--- a/site/gdocs/utils.ts
+++ b/site/gdocs/utils.ts
@@ -22,6 +22,7 @@ import {
 } from "@ourworldindata/components"
 import {
     formatAuthors,
+    formatAuthorsForBibtex,
     getCalloutValue,
     getRegionByNameOrVariantName,
     makeLinkedCalloutKey,
@@ -322,6 +323,39 @@ export function getShortPageCitation(
     publishedAt: Date | null
 ) {
     return `${formatAuthors(authors)} (${publishedAt?.getFullYear()}) - “${title}”`
+}
+
+/**
+ * Build the citation string and BibTeX entry shown in a gdoc page's
+ * "Cite this work" section.
+ */
+export function buildGdocCitation({
+    authors,
+    title,
+    publishedAt,
+    slug,
+    canonicalUrl,
+    archivalPhrase,
+}: {
+    authors: string[]
+    title: string
+    publishedAt: Date | null
+    slug: string
+    canonicalUrl: string
+    archivalPhrase?: string
+}): { citationText: string; bibtex: string } {
+    const shortPageCitation = getShortPageCitation(authors, title, publishedAt)
+    const citationText = `${shortPageCitation} Published online at OurWorldinData.org. Retrieved from: '${canonicalUrl}' [Online Resource]${archivalPhrase ? ` ${archivalPhrase}` : ""}`
+
+    const bibtex = `@article{owid-${slug.replace(/\//g, "-")},
+    author = {${formatAuthorsForBibtex(authors)}},
+    title = {${title}},
+    journal = {Our World in Data},
+    year = {${publishedAt?.getFullYear()}},
+    note = {${canonicalUrl}}
+}`
+
+    return { citationText, bibtex }
 }
 
 /**


### PR DESCRIPTION
> _Written by Anthropic Claude Opus 5 — @sophiamersmann at the wheel._

`GdocPost` and `Profile` each carried a near-copy of the "Cite this work" and "Reuse this work freely" sections at the foot of the page, plus their own copy of the citation and BibTeX strings that feed them. A third page type is coming (the `featured-viz` gdoc) and would have been a third copy, so I pulled `GdocPost`'s version out into shared `CitationSection` and `LicenseSection` components and a `buildGdocCitation` helper.

- **Fix.** The "our charts can be embedded" link on profile pages pointed at `https://github.com/owid`, which says nothing about embedding. I read that as an old copy-paste. It now points at the embedding FAQ, where every other page already sent it, and goes through `IS_ARCHIVE` so it resolves on archived pages too.
- **Behaviour change.** The Creative Commons license link on profile pages no longer opens in a new tab. Profile was the only page setting `target="_blank"` on it, so I made the minority conform rather than add the attribute to every article, topic and about page.

