### PR TITLE
Admin: antd foundation (theme provider, modular Bootstrap import, no deep imports)

### DIFF
--- a/adminSiteClient/AdminApp.tsx
+++ b/adminSiteClient/AdminApp.tsx
@@ -1,4 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { App, ConfigProvider, ThemeConfig } from "antd"
 import * as React from "react"
 import { Admin } from "./Admin.js"
 import { ChartEditorPage } from "./ChartEditorPage.js"
@@ -59,6 +60,19 @@ import { SvgTesterSuitePage } from "./SvgTesterSuitePage.js"
 import { StaticVizEditPage } from "./StaticVizEditPage.js"
 import { SlideshowsIndexPage } from "./slideshows/SlideshowsIndexPage.js"
 import { SlideshowEditorPage } from "./slideshows/SlideshowEditorPage.js"
+
+const adminTheme: ThemeConfig = {
+    token: {
+        // Matches `html { font-size: 14px }` in `admin.scss`, which antd's
+        // default of 14px would otherwise be measured against as 1rem.
+        fontSize: 14,
+        // OWID's $blue-90, from
+        // `packages/@ourworldindata/components/src/styles/colors.scss`. It's
+        // also what `$text-color` resolves to there.
+        colorPrimary: "#1d3d63",
+        colorText: "#1d3d63",
+    },
+}
 
 const queryClient = new QueryClient({
     defaultOptions: {
@@ -134,340 +148,384 @@ export class AdminApp extends React.Component<{
         const { admin } = this.props
 
         return (
-            <QueryClientProvider client={queryClient}>
-                <AdminAppContext.Provider value={this.childContext}>
-                    <Router basename={admin.basePath}>
-                        <div className="AdminApp">
-                            <AdminErrorMessage admin={admin} />
-                            <AdminLoader admin={admin} />
-                            <Switch>
-                                <Route
-                                    exact
-                                    path="/charts/create"
-                                    render={({ location }) => {
-                                        const params = new URLSearchParams(
-                                            location.search
-                                        )
-                                        const configParam = params.get("config")
-                                        const grapherConfig = configParam
-                                            ? JSON.parse(configParam)
-                                            : undefined
-                                        return (
-                                            <ChartEditorPage
-                                                grapherConfig={grapherConfig}
-                                            />
-                                        )
-                                    }}
-                                />
-                                <Route
-                                    exact
-                                    path="/charts/:chartId/edit"
-                                    render={({ match }) => {
-                                        return (
-                                            <ChartEditorPage
-                                                key={match.params.chartId}
-                                                grapherId={parseInt(
-                                                    match.params.chartId
-                                                )}
-                                            />
-                                        )
-                                    }}
-                                />
-                                <Route
-                                    exact
-                                    path="/charts"
-                                    component={ChartIndexPage}
-                                />
-                                <Route
-                                    exact
-                                    path="/narrative-charts"
-                                    component={NarrativeChartIndexPage}
-                                />
-                                <Route
-                                    exact
-                                    path="/narrative-charts/create"
-                                    component={CreateNarrativeChartEditorPage}
-                                />
-                                <Route
-                                    exact
-                                    path="/narrative-charts/:narrativeChartId/edit"
-                                    render={({ match, history }) => (
-                                        <NarrativeChartEditorPage
-                                            narrativeChartId={parseInt(
-                                                match.params.narrativeChartId
+            <ConfigProvider theme={adminTheme}>
+                {/* `component={false}` keeps `<App>` from wrapping
+                everything in a `div.ant-app`, which would impose antd's
+                font, text colour and line height on the Bootstrap half of
+                the admin and break the `height: 100%` chain from `#app`
+                down to `.AdminApp`. We only want the context it provides. */}
+                <App component={false}>
+                    <QueryClientProvider client={queryClient}>
+                        <AdminAppContext.Provider value={this.childContext}>
+                            <Router basename={admin.basePath}>
+                                <div className="AdminApp">
+                                    <AdminErrorMessage admin={admin} />
+                                    <AdminLoader admin={admin} />
+                                    <Switch>
+                                        <Route
+                                            exact
+                                            path="/charts/create"
+                                            render={({ location }) => {
+                                                const params =
+                                                    new URLSearchParams(
+                                                        location.search
+                                                    )
+                                                const configParam =
+                                                    params.get("config")
+                                                const grapherConfig =
+                                                    configParam
+                                                        ? JSON.parse(
+                                                              configParam
+                                                          )
+                                                        : undefined
+                                                return (
+                                                    <ChartEditorPage
+                                                        grapherConfig={
+                                                            grapherConfig
+                                                        }
+                                                    />
+                                                )
+                                            }}
+                                        />
+                                        <Route
+                                            exact
+                                            path="/charts/:chartId/edit"
+                                            render={({ match }) => {
+                                                return (
+                                                    <ChartEditorPage
+                                                        key={
+                                                            match.params.chartId
+                                                        }
+                                                        grapherId={parseInt(
+                                                            match.params.chartId
+                                                        )}
+                                                    />
+                                                )
+                                            }}
+                                        />
+                                        <Route
+                                            exact
+                                            path="/charts"
+                                            component={ChartIndexPage}
+                                        />
+                                        <Route
+                                            exact
+                                            path="/narrative-charts"
+                                            component={NarrativeChartIndexPage}
+                                        />
+                                        <Route
+                                            exact
+                                            path="/narrative-charts/create"
+                                            component={
+                                                CreateNarrativeChartEditorPage
+                                            }
+                                        />
+                                        <Route
+                                            exact
+                                            path="/narrative-charts/:narrativeChartId/edit"
+                                            render={({ match, history }) => (
+                                                <NarrativeChartEditorPage
+                                                    narrativeChartId={parseInt(
+                                                        match.params
+                                                            .narrativeChartId
+                                                    )}
+                                                    history={history}
+                                                />
                                             )}
-                                            history={history}
                                         />
-                                    )}
-                                />
-                                <Route
-                                    exact
-                                    path="/featured-metrics"
-                                    component={FeaturedMetricsPage}
-                                />
-                                <Route
-                                    exact
-                                    path="/multi-dims"
-                                    component={MultiDimIndexPage}
-                                />
-                                <Route
-                                    exact
-                                    path="/multi-dims/:id"
-                                    render={({ match }) => (
-                                        <MultiDimDetailPage
-                                            id={parseInt(match.params.id)}
+                                        <Route
+                                            exact
+                                            path="/featured-metrics"
+                                            component={FeaturedMetricsPage}
                                         />
-                                    )}
-                                />
-                                <Route
-                                    exact
-                                    path="/multi-dim-redirects"
-                                    component={MultiDimRedirectsIndexPage}
-                                />
-                                <Route path="/dods" component={DodsIndexPage} />
+                                        <Route
+                                            exact
+                                            path="/multi-dims"
+                                            component={MultiDimIndexPage}
+                                        />
+                                        <Route
+                                            exact
+                                            path="/multi-dims/:id"
+                                            render={({ match }) => (
+                                                <MultiDimDetailPage
+                                                    id={parseInt(
+                                                        match.params.id
+                                                    )}
+                                                />
+                                            )}
+                                        />
+                                        <Route
+                                            exact
+                                            path="/multi-dim-redirects"
+                                            component={
+                                                MultiDimRedirectsIndexPage
+                                            }
+                                        />
+                                        <Route
+                                            path="/dods"
+                                            component={DodsIndexPage}
+                                        />
 
-                                <Route
-                                    path="/images"
-                                    component={ImageIndexPage}
-                                />
-                                <Route
-                                    path="/files"
-                                    component={FilesIndexPage}
-                                />
-                                <Route
-                                    exact
-                                    path="/svgtester"
-                                    component={SvgTesterIndexPage}
-                                />
-                                <Route
-                                    exact
-                                    path="/svgtester/:suite"
-                                    render={({ match }) => (
-                                        <SvgTesterSuitePage
-                                            key={match.params.suite}
+                                        <Route
+                                            path="/images"
+                                            component={ImageIndexPage}
                                         />
-                                    )}
-                                />
-                                <Route
-                                    exact
-                                    path="/static-viz"
-                                    component={StaticVizIndexPage}
-                                />
-                                <Route
-                                    exact
-                                    path="/static-viz/:staticVizId"
-                                    component={StaticVizEditPage}
-                                />
-                                <Route
-                                    exact
-                                    path="/slideshows"
-                                    component={SlideshowsIndexPage}
-                                />
-                                <Route
-                                    exact
-                                    path="/slideshows/create"
-                                    component={SlideshowEditorPage}
-                                />
-                                <Route
-                                    exact
-                                    path="/slideshows/:slideshowId/edit"
-                                    render={({ match }) => (
-                                        <SlideshowEditorPage
-                                            slideshowId={parseInt(
-                                                match.params.slideshowId
+                                        <Route
+                                            path="/files"
+                                            component={FilesIndexPage}
+                                        />
+                                        <Route
+                                            exact
+                                            path="/svgtester"
+                                            component={SvgTesterIndexPage}
+                                        />
+                                        <Route
+                                            exact
+                                            path="/svgtester/:suite"
+                                            render={({ match }) => (
+                                                <SvgTesterSuitePage
+                                                    key={match.params.suite}
+                                                />
                                             )}
                                         />
-                                    )}
-                                />
-                                <Route
-                                    exact
-                                    path={`/${EXPLORERS_ROUTE_FOLDER}/:slug`}
-                                    render={({ match }) => (
-                                        <AdminLayout title="Create Explorer">
-                                            <ExplorerCreatePage
-                                                slug={match.params.slug}
-                                                manager={admin}
-                                            />
-                                        </AdminLayout>
-                                    )}
-                                />
-                                <Route
-                                    exact
-                                    path={`/${EXPLORERS_ROUTE_FOLDER}`}
-                                    render={() => (
-                                        <AdminLayout title="Explorers">
-                                            <ExplorersIndexPage />
-                                        </AdminLayout>
-                                    )}
-                                />
-                                <Route
-                                    exact
-                                    path={`/bulk-grapher-config-editor`}
-                                    render={() => (
-                                        <BulkGrapherConfigEditorPage />
-                                    )}
-                                />
-                                <Route
-                                    exact
-                                    path="/users/:userId"
-                                    render={({ match }) => (
-                                        <UserEditPage
-                                            userId={parseInt(
-                                                match.params.userId
+                                        <Route
+                                            exact
+                                            path="/static-viz"
+                                            component={StaticVizIndexPage}
+                                        />
+                                        <Route
+                                            exact
+                                            path="/static-viz/:staticVizId"
+                                            component={StaticVizEditPage}
+                                        />
+                                        <Route
+                                            exact
+                                            path="/slideshows"
+                                            component={SlideshowsIndexPage}
+                                        />
+                                        <Route
+                                            exact
+                                            path="/slideshows/create"
+                                            component={SlideshowEditorPage}
+                                        />
+                                        <Route
+                                            exact
+                                            path="/slideshows/:slideshowId/edit"
+                                            render={({ match }) => (
+                                                <SlideshowEditorPage
+                                                    slideshowId={parseInt(
+                                                        match.params.slideshowId
+                                                    )}
+                                                />
                                             )}
                                         />
-                                    )}
-                                />
-                                <Route
-                                    exact
-                                    path="/users"
-                                    component={UsersIndexPage}
-                                />
-                                <Route
-                                    exact
-                                    path="/variables/:variableId"
-                                    render={({ match }) => (
-                                        <VariableEditPage
-                                            variableId={parseInt(
-                                                match.params.variableId
+                                        <Route
+                                            exact
+                                            path={`/${EXPLORERS_ROUTE_FOLDER}/:slug`}
+                                            render={({ match }) => (
+                                                <AdminLayout title="Create Explorer">
+                                                    <ExplorerCreatePage
+                                                        slug={match.params.slug}
+                                                        manager={admin}
+                                                    />
+                                                </AdminLayout>
                                             )}
                                         />
-                                    )}
-                                />
-                                <Route
-                                    exact
-                                    path="/variables"
-                                    component={VariablesIndexPage}
-                                />
-                                <Route
-                                    exact
-                                    path="/datasets/:datasetId"
-                                    render={({ match }) => (
-                                        <DatasetEditPage
-                                            datasetId={parseInt(
-                                                match.params.datasetId
+                                        <Route
+                                            exact
+                                            path={`/${EXPLORERS_ROUTE_FOLDER}`}
+                                            render={() => (
+                                                <AdminLayout title="Explorers">
+                                                    <ExplorersIndexPage />
+                                                </AdminLayout>
                                             )}
                                         />
-                                    )}
-                                />
-                                <Route
-                                    exact
-                                    path="/datasets"
-                                    component={DatasetsIndexPage}
-                                />
-                                <Route
-                                    exact
-                                    path="/sources/:sourceId"
-                                    render={({ match }) => (
-                                        <SourceEditPage
-                                            sourceId={parseInt(
-                                                match.params.sourceId
+                                        <Route
+                                            exact
+                                            path={`/bulk-grapher-config-editor`}
+                                            render={() => (
+                                                <BulkGrapherConfigEditorPage />
                                             )}
                                         />
-                                    )}
-                                />
-                                <Route
-                                    exact
-                                    path="/redirects"
-                                    component={RedirectsIndexPage}
-                                />
-                                <Route
-                                    exact
-                                    path="/site-redirects"
-                                    component={SiteRedirectsIndexPage}
-                                />
-                                <Route
-                                    exact
-                                    path="/tags/:tagId"
-                                    render={({ match }) => (
-                                        <TagEditPage
-                                            tagId={parseInt(match.params.tagId)}
+                                        <Route
+                                            exact
+                                            path="/users/:userId"
+                                            render={({ match }) => (
+                                                <UserEditPage
+                                                    userId={parseInt(
+                                                        match.params.userId
+                                                    )}
+                                                />
+                                            )}
                                         />
-                                    )}
-                                />
-                                <Route
-                                    exact
-                                    path="/tag-graph"
-                                    component={TagGraphPage}
-                                />
-                                <Route
-                                    exact
-                                    path="/tags"
-                                    component={TagsIndexPage}
-                                />
-                                <Route
-                                    exact
-                                    path="/orphaned-articles"
-                                    component={OrphanedArticlesIndexPage}
-                                />
-                                <Route
-                                    exact
-                                    path="/gdocs/:id/preview"
-                                    render={(props: GdocsMatchProps) => (
-                                        <GdocsStoreProvider>
-                                            <GdocsPreviewPage {...props} />
-                                        </GdocsStoreProvider>
-                                    )}
-                                />
-                                <Route
-                                    exact
-                                    path="/gdocs/:id/coverage"
-                                    render={(props: GdocsMatchProps) => (
-                                        <GdocsStoreProvider>
-                                            <GdocsCoverageMatrixPage
-                                                {...props}
-                                            />
-                                        </GdocsStoreProvider>
-                                    )}
-                                />
-                                <Route
-                                    exact
-                                    path="/callout-functions"
-                                    component={CalloutFunctionsPage}
-                                />
-                                <Route
-                                    path="/gdocs"
-                                    render={(props: RouteComponentProps) => (
-                                        <GdocsStoreProvider>
-                                            <GdocsIndexPage {...props} />
-                                        </GdocsStoreProvider>
-                                    )}
-                                />
-                                <Route
-                                    path="/data-insights"
-                                    component={DataInsightIndexPage}
-                                />
-                                <Route
-                                    exact
-                                    path="/test"
-                                    component={TestIndexPage}
-                                />
-                                <Route
-                                    exact
-                                    path="/test-region-maps"
-                                    component={TestRegionMapsPage}
-                                />
-                                <Route
-                                    exact
-                                    path="/deploys"
-                                    component={DeployStatusPage}
-                                />
-                                <Route
-                                    exact
-                                    path="/explorer-tags"
-                                    component={ExplorerTagsPage}
-                                />
-                                <Route
-                                    exact
-                                    path="/"
-                                    render={() => <Redirect to="/charts" />}
-                                />
-                                <Route component={NotFoundPage} />
-                            </Switch>
-                        </div>
-                    </Router>
-                </AdminAppContext.Provider>
-            </QueryClientProvider>
+                                        <Route
+                                            exact
+                                            path="/users"
+                                            component={UsersIndexPage}
+                                        />
+                                        <Route
+                                            exact
+                                            path="/variables/:variableId"
+                                            render={({ match }) => (
+                                                <VariableEditPage
+                                                    variableId={parseInt(
+                                                        match.params.variableId
+                                                    )}
+                                                />
+                                            )}
+                                        />
+                                        <Route
+                                            exact
+                                            path="/variables"
+                                            component={VariablesIndexPage}
+                                        />
+                                        <Route
+                                            exact
+                                            path="/datasets/:datasetId"
+                                            render={({ match }) => (
+                                                <DatasetEditPage
+                                                    datasetId={parseInt(
+                                                        match.params.datasetId
+                                                    )}
+                                                />
+                                            )}
+                                        />
+                                        <Route
+                                            exact
+                                            path="/datasets"
+                                            component={DatasetsIndexPage}
+                                        />
+                                        <Route
+                                            exact
+                                            path="/sources/:sourceId"
+                                            render={({ match }) => (
+                                                <SourceEditPage
+                                                    sourceId={parseInt(
+                                                        match.params.sourceId
+                                                    )}
+                                                />
+                                            )}
+                                        />
+                                        <Route
+                                            exact
+                                            path="/redirects"
+                                            component={RedirectsIndexPage}
+                                        />
+                                        <Route
+                                            exact
+                                            path="/site-redirects"
+                                            component={SiteRedirectsIndexPage}
+                                        />
+                                        <Route
+                                            exact
+                                            path="/tags/:tagId"
+                                            render={({ match }) => (
+                                                <TagEditPage
+                                                    tagId={parseInt(
+                                                        match.params.tagId
+                                                    )}
+                                                />
+                                            )}
+                                        />
+                                        <Route
+                                            exact
+                                            path="/tag-graph"
+                                            component={TagGraphPage}
+                                        />
+                                        <Route
+                                            exact
+                                            path="/tags"
+                                            component={TagsIndexPage}
+                                        />
+                                        <Route
+                                            exact
+                                            path="/orphaned-articles"
+                                            component={
+                                                OrphanedArticlesIndexPage
+                                            }
+                                        />
+                                        <Route
+                                            exact
+                                            path="/gdocs/:id/preview"
+                                            render={(
+                                                props: GdocsMatchProps
+                                            ) => (
+                                                <GdocsStoreProvider>
+                                                    <GdocsPreviewPage
+                                                        {...props}
+                                                    />
+                                                </GdocsStoreProvider>
+                                            )}
+                                        />
+                                        <Route
+                                            exact
+                                            path="/gdocs/:id/coverage"
+                                            render={(
+                                                props: GdocsMatchProps
+                                            ) => (
+                                                <GdocsStoreProvider>
+                                                    <GdocsCoverageMatrixPage
+                                                        {...props}
+                                                    />
+                                                </GdocsStoreProvider>
+                                            )}
+                                        />
+                                        <Route
+                                            exact
+                                            path="/callout-functions"
+                                            component={CalloutFunctionsPage}
+                                        />
+                                        <Route
+                                            path="/gdocs"
+                                            render={(
+                                                props: RouteComponentProps
+                                            ) => (
+                                                <GdocsStoreProvider>
+                                                    <GdocsIndexPage
+                                                        {...props}
+                                                    />
+                                                </GdocsStoreProvider>
+                                            )}
+                                        />
+                                        <Route
+                                            path="/data-insights"
+                                            component={DataInsightIndexPage}
+                                        />
+                                        <Route
+                                            exact
+                                            path="/test"
+                                            component={TestIndexPage}
+                                        />
+                                        <Route
+                                            exact
+                                            path="/test-region-maps"
+                                            component={TestRegionMapsPage}
+                                        />
+                                        <Route
+                                            exact
+                                            path="/deploys"
+                                            component={DeployStatusPage}
+                                        />
+                                        <Route
+                                            exact
+                                            path="/explorer-tags"
+                                            component={ExplorerTagsPage}
+                                        />
+                                        <Route
+                                            exact
+                                            path="/"
+                                            render={() => (
+                                                <Redirect to="/charts" />
+                                            )}
+                                        />
+                                        <Route component={NotFoundPage} />
+                                    </Switch>
+                                </div>
+                            </Router>
+                        </AdminAppContext.Provider>
+                    </QueryClientProvider>
+                </App>
+            </ConfigProvider>
         )
     }
 }

--- a/adminSiteClient/AdminApp.tsx
+++ b/adminSiteClient/AdminApp.tsx
@@ -166,7 +166,12 @@ export class AdminApp extends React.Component<{
                 everything in a `div.ant-app`, which would impose antd's
                 font, text colour and line height on the Bootstrap half of
                 the admin and break the `height: 100%` chain from `#app`
-                down to `.AdminApp`. We only want the context it provides. */}
+                down to `.AdminApp`. We only want the context it provides.
+                antd logs a dev-only warning about `component={false}` with
+                css variables enabled; it's harmless here — every antd
+                component carries its own css-var scope class, so the
+                ConfigProvider theme still reaches all of them (verified:
+                `--ant-color-primary` resolves on rendered buttons). */}
                 <App component={false}>
                     <AdminAppInstancesBridge />
                     <QueryClientProvider client={queryClient}>

--- a/adminSiteClient/AdminApp.tsx
+++ b/adminSiteClient/AdminApp.tsx
@@ -2,6 +2,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { App, ConfigProvider, ThemeConfig } from "antd"
 import * as React from "react"
 import { Admin } from "./Admin.js"
+import { setAdminAppInstances } from "./adminAppInstances.js"
 import { ChartEditorPage } from "./ChartEditorPage.js"
 import { action } from "mobx"
 import { observer } from "mobx-react"
@@ -128,6 +129,18 @@ class AdminErrorMessage extends React.Component<{ admin: Admin }> {
     }
 }
 
+/**
+ * Renders nothing. Lifts the `message` / `notification` / `modal` instances
+ * antd's `<App>` provides into module scope, so that MobX class components —
+ * which can't call `App.useApp()` themselves — can still raise notifications
+ * that pick up the `<ConfigProvider>` theme. Must be rendered inside `<App>`,
+ * and above everything that uses them.
+ */
+function AdminAppInstancesBridge(): null {
+    setAdminAppInstances(App.useApp())
+    return null
+}
+
 @observer
 class AdminLoader extends React.Component<{ admin: Admin }> {
     override render(): React.ReactElement | null {
@@ -155,6 +168,7 @@ export class AdminApp extends React.Component<{
                 the admin and break the `height: 100%` chain from `#app`
                 down to `.AdminApp`. We only want the context it provides. */}
                 <App component={false}>
+                    <AdminAppInstancesBridge />
                     <QueryClientProvider client={queryClient}>
                         <AdminAppContext.Provider value={this.childContext}>
                             <Router basename={admin.basePath}>

--- a/adminSiteClient/AdminApp.tsx
+++ b/adminSiteClient/AdminApp.tsx
@@ -68,10 +68,10 @@ const adminTheme: ThemeConfig = {
         // default of 14px would otherwise be measured against as 1rem.
         fontSize: 14,
         // OWID's $blue-90, from
-        // `packages/@ourworldindata/components/src/styles/colors.scss`. It's
-        // also what `$text-color` resolves to there.
+        // `packages/@ourworldindata/components/src/styles/colors.scss`.
+        // Text color stays antd's near-black default (rgba(0, 0, 0, 0.88))
+        // for better contrast.
         colorPrimary: "#1d3d63",
-        colorText: "#1d3d63",
     },
 }
 

--- a/adminSiteClient/CreateDataInsightModal.tsx
+++ b/adminSiteClient/CreateDataInsightModal.tsx
@@ -18,7 +18,6 @@ import {
     Select,
     FormItemProps,
 } from "antd"
-import { ValidateStatus } from "antd/es/form/FormItem"
 import {
     Fragment,
     useCallback,
@@ -949,7 +948,7 @@ function FeedbackTag({ progress }: { progress: Progress }) {
     )
 }
 
-function validate(progress: Progress): ValidateStatus {
+function validate(progress: Progress): FormItemProps["validateStatus"] {
     if (progress.status === "idle") return "success"
     if (progress.status === "running") return "validating"
     return progress.success ? "success" : "error"

--- a/adminSiteClient/DataInsightIndexPage.tsx
+++ b/adminSiteClient/DataInsightIndexPage.tsx
@@ -18,6 +18,7 @@ import {
     Select,
     Space,
     Table,
+    TableColumnsType,
     Tooltip,
 } from "antd"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
@@ -33,7 +34,6 @@ import { faFigma } from "@fortawesome/free-brands-svg-icons"
 
 import { AdminLayout } from "./AdminLayout.js"
 import { Timeago } from "./Forms.js"
-import { ColumnsType } from "antd/es/table/InternalTable.js"
 import {
     buildSearchWordsFromSearchString,
     filterFunctionForSearchWords,
@@ -105,7 +105,7 @@ function createColumns(ctx: {
     triggerImageUploadFlow: (
         dataInsight: DataInsightIndexItemThatCanBeUploaded
     ) => void
-}): ColumnsType<OwidGdocDataInsightIndexItem> {
+}): TableColumnsType<OwidGdocDataInsightIndexItem> {
     return [
         {
             title: "Preview",

--- a/adminSiteClient/DodsIndexPage.tsx
+++ b/adminSiteClient/DodsIndexPage.tsx
@@ -7,7 +7,16 @@ import {
 import { useContext, useEffect, useMemo, useState } from "react"
 import cx from "clsx"
 import tippy, { type ReferenceElement } from "tippy.js"
-import { Button, Flex, Form, Input, Modal, Popconfirm, Table } from "antd"
+import {
+    Button,
+    Flex,
+    Form,
+    Input,
+    Modal,
+    Popconfirm,
+    Table,
+    TableColumnsType,
+} from "antd"
 import { AdminLayout } from "./AdminLayout.js"
 import { AdminAppContext } from "./AdminAppContext.js"
 import {
@@ -16,7 +25,6 @@ import {
     DodUsageRecord,
     DodUsageTypes,
 } from "@ourworldindata/types"
-import { ColumnsType } from "antd/es/table/InternalTable.js"
 import { EditableTextarea } from "./EditableTextarea.js"
 import * as R from "remeda"
 import { Admin } from "./Admin.js"
@@ -27,7 +35,6 @@ import {
     initializeDetailsOnDemand,
     renderDodContentHtml,
 } from "@ourworldindata/components"
-import TextArea from "antd/es/input/TextArea.js"
 import { match } from "ts-pattern"
 import { BAKED_BASE_URL } from "../settings/clientSettings.js"
 import { extractDetailsFromSyntax } from "@ourworldindata/utils"
@@ -161,7 +168,7 @@ function createColumns({
     patchDodMutation: PatchDodMutationType
     setActiveDodForUsageModal: (name: string) => void
     users: Record<string, DbPlainUser> | undefined
-}): ColumnsType<DbPlainDod> {
+}): TableColumnsType<DbPlainDod> {
     return [
         {
             title: "Name",
@@ -425,7 +432,7 @@ function CreateDodModal({
                     name="content"
                     rules={[{ required: true }]}
                 >
-                    <TextArea rows={8} />
+                    <Input.TextArea rows={8} />
                 </Form.Item>
                 <Form.Item>
                     <Button

--- a/adminSiteClient/EditableTextarea.tsx
+++ b/adminSiteClient/EditableTextarea.tsx
@@ -1,9 +1,8 @@
 import React, { useState, useCallback } from "react"
-import { Button } from "antd"
+import { Button, Input } from "antd"
 import cx from "clsx"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faSave } from "@fortawesome/free-solid-svg-icons"
-import TextArea from "antd/es/input/TextArea.js"
 
 interface EditableTextareaProps {
     value: string
@@ -48,7 +47,7 @@ export function EditableTextarea({
 
     return (
         <div className={cx("EditableTextarea", className)}>
-            <TextArea
+            <Input.TextArea
                 autoSize={autoResize}
                 value={value}
                 onChange={(e) => {

--- a/adminSiteClient/FeaturedMetricsPage.tsx
+++ b/adminSiteClient/FeaturedMetricsPage.tsx
@@ -4,7 +4,6 @@ import { useContext, useEffect, useMemo, useState } from "react"
 import {
     Input,
     Popconfirm,
-    notification,
     Dropdown,
     Button,
     Flex,
@@ -12,6 +11,7 @@ import {
     Checkbox,
     Tooltip,
 } from "antd"
+import { notification } from "./adminAppInstances.js"
 import { AdminLayout } from "./AdminLayout.js"
 import { AdminAppContext } from "./AdminAppContext.js"
 import {

--- a/adminSiteClient/GdocsMoreMenu.tsx
+++ b/adminSiteClient/GdocsMoreMenu.tsx
@@ -1,6 +1,7 @@
 import * as _ from "lodash-es"
 import { useState } from "react"
 import { Dropdown, Button, Modal, Form, Checkbox, Input } from "antd"
+import { modal } from "./adminAppInstances.js"
 import {
     faEllipsisVertical,
     faTrash,
@@ -50,7 +51,7 @@ export const GdocsMoreMenu = ({
     const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
 
     const confirmUnpublish = () => {
-        Modal.confirm({
+        modal.confirm({
             title: "Are you sure you want to unpublish this article?",
             content: "The article will no longer be visible to the public.",
             okText: "Unpublish",

--- a/adminSiteClient/GdocsSaveButtons.tsx
+++ b/adminSiteClient/GdocsSaveButtons.tsx
@@ -1,4 +1,5 @@
-import { Badge, Button, Modal, Space } from "antd"
+import { Badge, Button, Space } from "antd"
+import { modal } from "./adminAppInstances.js"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import {
     faExclamationTriangle,
@@ -40,7 +41,7 @@ export const GdocsSaveButtons = ({
         const widthModal = hasChanges ? { width: "80vw" } : {}
         const centeredModal = hasChanges ? { centered: true } : {}
 
-        Modal.confirm({
+        modal.confirm({
             title: `Are you sure you want to publish ${
                 hasChanges ? "these changes" : "this article"
             }?`,

--- a/adminSiteClient/GdocsSettingsContentField.tsx
+++ b/adminSiteClient/GdocsSettingsContentField.tsx
@@ -1,6 +1,6 @@
 import * as _ from "lodash-es"
 import * as React from "react"
-import { Input, InputProps, Space } from "antd"
+import { GetProps, Input, InputProps, Space } from "antd"
 import {
     OwidGdocErrorMessage,
     OwidGdocErrorMessageType,
@@ -10,7 +10,6 @@ import {
 import { GdocsEditLink } from "./GdocsEditLink.js"
 import { GdocsErrorHelp } from "./GdocsErrorHelp.js"
 import { getPropertyMostCriticalError } from "./gdocsValidation.js"
-import { TextAreaProps } from "antd/lib/input/TextArea.js"
 import { Help } from "./Forms.js"
 import { makeImageSrc } from "./imagesHelpers.js"
 
@@ -114,7 +113,7 @@ export const GdocsSettingsTextArea = ({
     name: string
     value: string
     errorType?: OwidGdocErrorMessageType
-    inputProps?: TextAreaProps
+    inputProps?: GetProps<typeof Input.TextArea>
 }) => (
     <Input.TextArea
         value={value}

--- a/adminSiteClient/ImagesIndexPage.tsx
+++ b/adminSiteClient/ImagesIndexPage.tsx
@@ -39,12 +39,12 @@ import {
 import {
     ACCEPTED_IMG_TYPES,
     type File,
+    type UploadFileType,
     fileToBase64,
     type ImageUploadResponse,
 } from "./imagesHelpers.js"
-import { RcFile } from "antd/es/upload/interface.js"
 import { CLOUDFLARE_IMAGES_URL } from "../settings/clientSettings.js"
-import { NotificationInstance } from "antd/es/notification/interface.js"
+import { type NotificationInstance } from "./adminAppInstances.js"
 import { EditableTextarea } from "./EditableTextarea.js"
 
 type ImageMap = Record<string, DbEnrichedImageWithPageviews>
@@ -536,7 +536,7 @@ function ImageReplaceConfirmModal({
     onCancel: () => void
     onConfirm: () => void
     currentImage: DbEnrichedImageWithPageviews
-    newImageFile: RcFile | null
+    newImageFile: UploadFileType | null
 }) {
     const currentImageSrc =
         currentImage.cloudflareId && currentImage.originalWidth
@@ -643,10 +643,12 @@ function PutImageButton({
     notificationApi: NotificationInstance
 }) {
     const [showConfirmModal, setShowConfirmModal] = useState(false)
-    const [selectedFile, setSelectedFile] = useState<RcFile | null>(null)
+    const [selectedFile, setSelectedFile] = useState<UploadFileType | null>(
+        null
+    )
 
-    const handleFileSelect = (options: { file: RcFile | File }) => {
-        const file = options.file as RcFile
+    const handleFileSelect = (options: { file: UploadFileType | File }) => {
+        const file = options.file as UploadFileType
         if (!file) return
         setSelectedFile(file)
         setShowConfirmModal(true)

--- a/adminSiteClient/OrphanedArticlesIndexPage.tsx
+++ b/adminSiteClient/OrphanedArticlesIndexPage.tsx
@@ -1,8 +1,7 @@
 import { useContext } from "react"
 import { useQuery } from "@tanstack/react-query"
 import { Link } from "react-router-dom"
-import { Collapse, Empty, Progress, Table, Tag } from "antd"
-import { ColumnsType } from "antd/es/table/InternalTable.js"
+import { Collapse, Empty, Progress, Table, TableColumnsType, Tag } from "antd"
 import {
     OrphanedTopicArticle,
     TopicPageOrphanReport,
@@ -31,7 +30,7 @@ function OrphanTable({
 }: {
     orphans: OrphanedTopicArticle[]
 }): React.ReactElement {
-    const columns: ColumnsType<OrphanedTopicArticle> = [
+    const columns: TableColumnsType<OrphanedTopicArticle> = [
         {
             title: "Article",
             dataIndex: "title",

--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -1,7 +1,45 @@
 /* Chart editor styling */
 
 @import "../public/fonts.css";
-@import "bootstrap/scss/bootstrap";
+// Bootstrap 4, imported module by module rather than as the full
+// `bootstrap/scss/bootstrap` build, so that individual modules can be dropped
+// as the admin migrates to antd. Modules that no admin markup uses are left
+// out; see the commented list at the bottom of this block.
+//
+// Required infrastructure (no output of its own):
+@import "bootstrap/scss/functions";
+@import "bootstrap/scss/variables";
+@import "bootstrap/scss/mixins";
+// Global element styling the whole admin sits on:
+@import "bootstrap/scss/reboot";
+@import "bootstrap/scss/type";
+@import "bootstrap/scss/code";
+// Layout:
+@import "bootstrap/scss/grid";
+@import "bootstrap/scss/tables";
+// Form controls (`admin.scss` also `@extend`s `.form-control`):
+@import "bootstrap/scss/forms";
+@import "bootstrap/scss/buttons";
+@import "bootstrap/scss/button-group";
+@import "bootstrap/scss/input-group";
+// Chrome and navigation:
+@import "bootstrap/scss/nav";
+@import "bootstrap/scss/navbar";
+@import "bootstrap/scss/breadcrumb";
+@import "bootstrap/scss/pagination";
+// Components:
+@import "bootstrap/scss/badge";
+@import "bootstrap/scss/alert";
+@import "bootstrap/scss/list-group";
+@import "bootstrap/scss/modal";
+// Helpers:
+@import "bootstrap/scss/utilities";
+@import "bootstrap/scss/print";
+//
+// Deliberately not imported, because nothing in the admin uses them:
+//   root (only defines `--blue`-style custom properties, never read via var()),
+//   images, transitions, dropdown, custom-forms, card, jumbotron, progress,
+//   media, close, toasts, tooltip, popover, carousel, spinners.
 
 @mixin draft-background {
     background: repeating-linear-gradient(

--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -41,6 +41,11 @@
 //   images, transitions, dropdown, custom-forms, card, jumbotron, progress,
 //   media, close, toasts, tooltip, popover, carousel, spinners.
 
+// Our own copy of the parts of Bootstrap's reboot the admin depends on, so that
+// removing `bootstrap/scss/reboot` above stays a small, deliberate step rather
+// than a cliff. Inert for now: every rule duplicates one Bootstrap just emitted.
+@import "./reboot";
+
 @mixin draft-background {
     background: repeating-linear-gradient(
         135deg,

--- a/adminSiteClient/adminAppInstances.ts
+++ b/adminSiteClient/adminAppInstances.ts
@@ -1,0 +1,55 @@
+import {
+    App,
+    message as staticMessage,
+    Modal as staticModal,
+    notification as staticNotification,
+} from "antd"
+
+/**
+ * antd's static `notification.*` / `message.*` / `Modal.confirm` entry points
+ * render outside the React tree, so they don't see our `<ConfigProvider>` and
+ * come out unthemed. The instances `App.useApp()` hands out do — but most of
+ * our call sites are MobX class components, which can't use hooks.
+ *
+ * This module bridges the two: a small component rendered inside antd's `<App>`
+ * (see `AdminAppInstancesBridge` in `AdminApp.tsx`) passes the instances to
+ * `setAdminAppInstances`, and the `notification` / `message` / `modal` exports
+ * below forward to them. Call sites keep the ergonomics they had — they just
+ * import from here rather than from `antd`.
+ */
+
+type AppInstances = ReturnType<typeof App.useApp>
+
+export type NotificationInstance = AppInstances["notification"]
+export type MessageInstance = AppInstances["message"]
+export type ModalInstance = AppInstances["modal"]
+
+let instances: AppInstances | undefined
+
+export function setAdminAppInstances(next: AppInstances): void {
+    instances = next
+}
+
+/**
+ * A stand-in for one of the `App.useApp()` instances that resolves on every
+ * property access, falling back to antd's static API while the bridge hasn't
+ * rendered yet (module-level calls, tests) — i.e. to the unthemed-but-working
+ * behaviour we had before.
+ */
+function bridge<K extends keyof AppInstances>(
+    key: K,
+    fallback: object
+): AppInstances[K] {
+    const handler: ProxyHandler<object> = {
+        get(_target, property) {
+            const api = instances?.[key] ?? fallback
+            const value = Reflect.get(api, property)
+            return typeof value === "function" ? value.bind(api) : value
+        },
+    }
+    return new Proxy({}, handler) as AppInstances[K]
+}
+
+export const notification = bridge("notification", staticNotification)
+export const message = bridge("message", staticMessage)
+export const modal = bridge("modal", staticModal)

--- a/adminSiteClient/gdocsNotifications.tsx
+++ b/adminSiteClient/gdocsNotifications.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { notification } from "antd"
+import { notification } from "./adminAppInstances.js"
 import { OwidGdocErrorMessageType } from "@ourworldindata/utils"
 import { match } from "ts-pattern"
 

--- a/adminSiteClient/imagesHelpers.ts
+++ b/adminSiteClient/imagesHelpers.ts
@@ -1,9 +1,16 @@
-import { RcFile } from "antd/es/upload/interface.js"
+import type { GetProp, UploadProps } from "antd"
 import { Admin } from "./Admin"
 import { DbEnrichedImageWithUserId } from "@ourworldindata/types"
 import { CLOUDFLARE_IMAGES_URL } from "../settings/clientSettings"
 
-export type File = string | Blob | RcFile
+/**
+ * The raw browser `File` antd hands to `<Upload>`'s callbacks, with the `uid`
+ * rc-upload tacks onto it. antd doesn't export the type by name, so derive it
+ * from a public prop rather than deep-importing `antd/es/upload/interface`.
+ */
+export type UploadFileType = Parameters<GetProp<UploadProps, "beforeUpload">>[0]
+
+export type File = string | Blob | UploadFileType
 
 type FigmaResponse =
     | { success: true; imageUrl: string }
@@ -43,7 +50,7 @@ export function fileToBase64(
 
     // Awkward solution to union type shenanigans
     function getFilename(
-        file: Blob | RcFile,
+        file: Blob | UploadFileType,
         filename?: string
     ): string | undefined {
         if ("name" in file) return file.name

--- a/adminSiteClient/reboot.scss
+++ b/adminSiteClient/reboot.scss
@@ -1,0 +1,149 @@
+// A hand-extracted subset of Bootstrap 4's `_reboot.scss` — exactly the global
+// element normalisation the admin actually depends on.
+//
+// Bootstrap's reboot is what the whole admin currently sits on: box-sizing,
+// the body font, heading/paragraph/list margin resets, `border-collapse` on
+// tables, and font inheritance for form controls. antd 6 ships no global reset
+// (its components are self-contained CSS-in-JS), so once Bootstrap is gone
+// there would be nothing left providing these. This file is that replacement.
+//
+// While `bootstrap/scss/reboot` is still imported (it is, from `admin.scss`,
+// just above this file) every declaration here duplicates one Bootstrap
+// already emits with the same value, so including it is a rendering no-op.
+// Values are deliberately kept identical to Bootstrap 4's output rather than
+// "modernised" — modernising them is a separate, visible change.
+
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+}
+
+// `font-size` is deliberately not set here: `admin.scss` sets `html`'s font
+// size to 14px itself, further down.
+html {
+    font-family: sans-serif;
+    line-height: 1.15;
+    -webkit-text-size-adjust: 100%;
+    -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+}
+
+body {
+    margin: 0;
+    font-family:
+        -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue",
+        Arial, "Noto Sans", "Liberation Sans", sans-serif, "Apple Color Emoji",
+        "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+    font-size: 1rem;
+    font-weight: 400;
+    line-height: 1.5;
+    color: #212529;
+    text-align: left;
+    background-color: #fff;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+    margin-top: 0;
+    margin-bottom: 0.5rem;
+}
+
+p {
+    margin-top: 0;
+    margin-bottom: 1rem;
+}
+
+ol,
+ul,
+dl {
+    margin-top: 0;
+    margin-bottom: 1rem;
+}
+
+ol ol,
+ul ul,
+ol ul,
+ul ol {
+    margin-bottom: 0;
+}
+
+a {
+    color: #007bff;
+    text-decoration: none;
+    background-color: transparent;
+}
+
+a:hover {
+    color: #0056b3;
+    text-decoration: underline;
+}
+
+img {
+    vertical-align: middle;
+    border-style: none;
+}
+
+svg {
+    overflow: hidden;
+    vertical-align: middle;
+}
+
+table {
+    border-collapse: collapse;
+}
+
+th {
+    text-align: inherit;
+    text-align: -webkit-match-parent;
+}
+
+label {
+    display: inline-block;
+    margin-bottom: 0.5rem;
+}
+
+button {
+    border-radius: 0;
+}
+
+button:focus:not(:focus-visible) {
+    outline: 0;
+}
+
+input,
+button,
+select,
+optgroup,
+textarea {
+    margin: 0;
+    font-family: inherit;
+    font-size: inherit;
+    line-height: inherit;
+}
+
+button,
+[type="button"],
+[type="reset"],
+[type="submit"] {
+    -webkit-appearance: button;
+}
+
+button:not(:disabled),
+[type="button"]:not(:disabled),
+[type="reset"]:not(:disabled),
+[type="submit"]:not(:disabled) {
+    cursor: pointer;
+}
+
+textarea {
+    overflow: auto;
+    resize: vertical;
+}
+
+[hidden] {
+    display: none !important;
+}

--- a/adminSiteClient/slideshows/SlideshowEditorPage.tsx
+++ b/adminSiteClient/slideshows/SlideshowEditorPage.tsx
@@ -9,7 +9,8 @@ import {
 import * as React from "react"
 import { useHistory } from "react-router-dom"
 import cx from "clsx"
-import { Button, Dropdown, Modal, Popconfirm, Tabs, Tooltip } from "antd"
+import { Button, Dropdown, Popconfirm, Tabs, Tooltip } from "antd"
+import { modal } from "../adminAppInstances.js"
 import type { MenuProps } from "antd"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import {
@@ -341,7 +342,7 @@ export function SlideshowEditorPage(props: {
     }, [admin, isCreate, props.slideshowId, history])
 
     const confirmDeleteSlideshow = useCallback(() => {
-        Modal.confirm({
+        modal.confirm({
             title: "Delete this entire slideshow?",
             content:
                 "All slides in this deck will be permanently deleted. This cannot be undone.",

--- a/adminSiteClient/slideshows/SlideshowsIndexPage.tsx
+++ b/adminSiteClient/slideshows/SlideshowsIndexPage.tsx
@@ -1,15 +1,8 @@
 import { useCallback, useContext, useEffect, useMemo, useState } from "react"
 import * as React from "react"
-import {
-    Button,
-    Flex,
-    Input,
-    Modal,
-    Space,
-    Table,
-    TableColumnsType,
-} from "antd"
+import { Button, Flex, Input, Space, Table, TableColumnsType } from "antd"
 
+import { modal } from "../adminAppInstances.js"
 import { AdminLayout } from "../AdminLayout.js"
 import { AdminAppContext } from "../AdminAppContext.js"
 import { Timeago } from "../Forms.js"
@@ -130,7 +123,7 @@ export function SlideshowsIndexPage() {
 
     const deleteFn = useCallback(
         (slideshowId: number) => {
-            Modal.confirm({
+            modal.confirm({
                 title: "Delete this entire slideshow?",
                 content:
                     "All slides in this deck will be permanently deleted. This cannot be undone.",


### PR DESCRIPTION
> _Written by Anthropic Claude Fable 5 — @marcelgerber at the wheel._

First step of migrating the admin off Bootstrap 4 (EOL upstream) and onto antd, which the newer half of the admin already uses. This PR is pure foundation — the only intended visible change is that antd components now pick up an OWID-colored theme instead of antd's default blue.

- Bootstrap is now imported module by module, dropping the ~15 modules nothing in the admin uses (built CSS: 467 KB → 439 KB). Verified against the built bundle that every kept rule is byte-identical — later migration PRs can now delete modules one by one as pages move to antd.
- New `reboot.scss` mirroring exactly what Bootstrap's reboot gives us, inert for now, so the eventual "remove Bootstrap" PR won't reflow the app.
- antd `ConfigProvider` + `App` at the root with theme tokens: `colorPrimary`/`colorText` `#1d3d63` ($blue-90), `fontSize: 14`.
- Static `notification.*`/`message.*`/`Modal.confirm` call sites now go through a small bridge backed by `App.useApp()`, so they render themed (and work identically before the app mounts).
- The 10 deep imports into `antd/es/*`/`antd/lib/*` (internal paths that break on antd upgrades) are replaced with public exports.

<details><summary>Details</summary>

**CSS no-op verification:** built `admin.css` on the pre-change commit and at branch tip, parsed both into (at-rule, selector, declarations) tuples: 4330 → 4070 rules, 261 removed / 1 added (a minifier regrouping of `p` into `dl, ol, ul` with identical declarations) / 0 changed. Each removed rule's class tokens were checked against all `className`/SCSS usage in admin code plus `site/`/`packages/` (which render inside admin previews); the near-misses (`.card-footer`, `.custom-file-input`, `.close`, `.tooltip`, `.arrow`) were run down individually and none can match admin markup.

**Kept modules:** functions, variables, mixins, reboot, type, code, grid, tables, forms, buttons, button-group, input-group, nav, navbar, breadcrumb, pagination, badge, alert, list-group, modal, utilities, print. `print` stays because it targets `.table`/`.navbar`/`.badge` etc. which are in active use; `code` stays because ~10 pages render `code`/`pre` elements. Dropped: root, images, transitions, dropdown, custom-forms, card, jumbotron, progress, media, close, toasts, tooltip, popover, carousel, spinners.

**`<App component={false}>`:** the default `div.ant-app` wrapper would impose antd's font/color/line-height on the Bootstrap half of the admin and break the `height: 100%` chain from `#app` down to `.AdminApp`. antd 6 logs a dev-only warning for this combination (css variables need a wrapper element to class); it's harmless — every antd component carries its own css-var scope class, verified by checking `--ant-color-primary: #1d3d63` resolves on rendered buttons in a running admin.

**Notification bridge (`adminAppInstances.ts`):** exports `notification`/`message`/`modal` proxies forwarding to the instances a tiny `AdminAppInstancesBridge` component (inside `<App>`) captures from `App.useApp()`, falling back to antd's static API before mount. Migrated call sites: `gdocsNotifications.tsx`, `FeaturedMetricsPage.tsx`, and the four `Modal.confirm` sites (gdocs publish/unpublish, slideshow deck delete in editor and index). Existing `notification.useNotification()` hook sites were left alone — they already render inside the provider.

**Deep-import replacements:** `ColumnsType` → `TableColumnsType`; `TextArea` → `Input.TextArea`; `TextAreaProps` → `GetProps<typeof Input.TextArea>`; `ValidateStatus` → `FormItemProps["validateStatus"]`; `RcFile` → an `UploadFileType` alias derived from `UploadProps` in `imagesHelpers`; `NotificationInstance` → re-exported from the bridge.

**Verification:** `yarn typecheck`, oxlint, oxfmt, and unit tests (2298 passed) all clean. Headless-browser pass over six admin pages (charts, gdocs, images, DoDs, datasets, users) on a running dev stack: no console errors beyond the documented antd dev warning and pre-existing local-dev image-thumbnail 404s; Bootstrap-heavy pages pixel-normal; antd `type="primary"` buttons render in `#1d3d63`.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
