### PR TITLE
🎉🤖 tell map colours apart from chart colours in the admin

### DIFF
--- a/adminSiteClient/AdminColorPicker.scss
+++ b/adminSiteClient/AdminColorPicker.scss
@@ -10,6 +10,20 @@
     overflow: auto;
 }
 
+/* Banner */
+.AdminColorPicker__banner {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: baseline;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-bottom: 10px;
+}
+
+.AdminColorPicker__banner-label {
+    font-weight: 700;
+}
+
 /* Search */
 .AdminColorPicker__search {
     flex: 0 0 auto;

--- a/adminSiteClient/AdminColorPicker.tsx
+++ b/adminSiteClient/AdminColorPicker.tsx
@@ -21,21 +21,16 @@ import {
     Tooltip,
     OverlayArrow,
 } from "react-aria-components"
-import { ColorSchemeName, lastOfNonEmptyArray } from "@ourworldindata/utils"
 import {
-    ColorSchemes,
-    ContinentColors,
-    EnergyColors,
-    OwidDistinctColors,
-    OwidDistinctLinesColors,
-    OwidMapColors,
-} from "@ourworldindata/grapher"
+    getAdminColorPalette,
+    type ColorPaletteKey,
+    type PaletteGroup,
+} from "./colorPalettes.js"
 import "./AdminColorPicker.scss"
 
 interface AdminColorPickerProps {
     color?: string
-    showLineChartColors: boolean
-    baseColorScheme?: ColorSchemeName
+    palette: ColorPaletteKey
     onColor: (color: string | undefined) => void
     /** Called when the picker's intrinsic size changes (e.g. on details toggle). */
     onResize?: () => void
@@ -43,11 +38,11 @@ interface AdminColorPickerProps {
 
 type TabKey = "all" | "regions" | "energy" | "hue"
 
-interface ColorMeta {
+interface SwatchInfo {
     hex: string
     name?: string
     regions: string[]
-    energy?: string
+    energy: string[]
 }
 
 const DEFAULT_COLOR = "#000000"
@@ -57,34 +52,6 @@ const DEFAULT_COLOR = "#000000"
 // every show, sibling pickers can't drift out of sync.
 let lastSelectedTab: TabKey = "all"
 let isCustomSectionOpen = false
-
-/** Turn camelCase identifiers ("SubSaharanAfrica") into readable labels. */
-function humanizeName(name: string): string {
-    if (name.includes(" ")) return name
-    return name.replace(/([a-z])([A-Z])/g, "$1 $2")
-}
-
-/** Build a case-insensitive hex → name lookup (last match wins, like remeda's invert). */
-function invertColorMap(map: Record<string, string>): Record<string, string> {
-    const result: Record<string, string> = {}
-    for (const [name, hex] of Object.entries(map))
-        result[hex.toUpperCase()] = name
-    return result
-}
-
-/** Build a case-insensitive hex → all (deduped, humanized) names mapping. */
-function groupNamesByHex(
-    map: Record<string, string>
-): Record<string, string[]> {
-    const result: Record<string, string[]> = {}
-    for (const [name, hex] of Object.entries(map)) {
-        const key = hex.toUpperCase()
-        const label = humanizeName(name)
-        const list = (result[key] ??= [])
-        if (!list.includes(label)) list.push(label)
-    }
-    return result
-}
 
 /** Parse a hex string into an HSB color so the area/slider channels line up. */
 function toHsbColor(hex: string): Color {
@@ -103,34 +70,19 @@ function hueOf(hex: string): number {
     }
 }
 
-/**
- * The context-aware OWID Distinct palette, mirroring the previous react-color
- * picker: special map colors for the categorical map scheme, otherwise the
- * distinct (or distinct-lines) palette.
- */
-function getGridColors(
-    showLineChartColors: boolean,
-    baseColorScheme?: ColorSchemeName
-): string[] {
-    if (baseColorScheme === ColorSchemeName.OwidCategoricalMap)
-        return Object.values(OwidMapColors)
-
-    const scheme = showLineChartColors
-        ? ColorSchemes.get(ColorSchemeName.OwidDistinctLines)
-        : ColorSchemes.get(ColorSchemeName["owid-distinct"])
-    return lastOfNonEmptyArray(scheme.colorSets)
-}
-
 export function AdminColorPicker({
     color,
-    showLineChartColors,
-    baseColorScheme,
+    palette: paletteKey,
     onColor,
     onResize,
 }: AdminColorPickerProps): ReactElement {
+    const palette = getAdminColorPalette(paletteKey)
+
     // The picker remounts on every popover open (Tippy `lazy`), so these
     // initializers always pick up the latest shared UI state.
+    const hasEnergyTab = palette.energy.entries.length > 0
     const [tab, setTab] = useState<TabKey>(lastSelectedTab)
+    const effectiveTab = tab === "energy" && !hasEnergyTab ? "all" : tab
     const selectTab = (key: TabKey): void => {
         lastSelectedTab = key
         setTab(key)
@@ -160,52 +112,19 @@ export function AdminColorPicker({
         )
     }, [color])
 
-    const nameByHex = useMemo(
-        () =>
-            invertColorMap({
-                ...OwidDistinctColors,
-                ...OwidDistinctLinesColors,
-                ...OwidMapColors,
-            }),
-        []
-    )
-    const regionsByHex = useMemo(() => groupNamesByHex(ContinentColors), [])
-    const energyByHex = useMemo(() => invertColorMap(EnergyColors), [])
-
-    // The line-chart palette swaps in darker variants (PeachDarker, etc.) that
-    // aren't keys in ContinentColors/EnergyColors. Map each darker hex back to
-    // its base hex so region/energy metadata still resolves.
-    const baseHexByDarkerHex = useMemo(() => {
-        const result: Record<string, string> = {}
-        const distinct = OwidDistinctColors as Record<string, string>
-        for (const [name, hex] of Object.entries(OwidDistinctLinesColors)) {
-            if (!name.endsWith("Darker")) continue
-            const baseHex = distinct[name.replace(/Darker$/, "")]
-            if (baseHex) result[hex.toUpperCase()] = baseHex.toUpperCase()
-        }
-        return result
-    }, [])
-
-    const metaFor = (hex: string): ColorMeta => {
+    const infoFor = (hex: string): SwatchInfo => {
         const key = hex.toUpperCase()
-        const baseKey = baseHexByDarkerHex[key] ?? key
         return {
             hex,
-            name: nameByHex[key] ? humanizeName(nameByHex[key]) : undefined,
-            regions: regionsByHex[baseKey] ?? [],
-            energy: energyByHex[baseKey]
-                ? humanizeName(energyByHex[baseKey])
-                : undefined,
+            name: palette.nameByHex[key],
+            regions: palette.regions.labelsByHex[key] ?? [],
+            energy: palette.energy.labelsByHex[key] ?? [],
         }
     }
 
-    const gridColors = useMemo(
-        () => getGridColors(showLineChartColors, baseColorScheme),
-        [showLineChartColors, baseColorScheme]
-    )
     const hueSortedColors = useMemo(
-        () => [...gridColors].sort((a, b) => hueOf(a) - hueOf(b)),
-        [gridColors]
+        () => [...palette.swatches].sort((a, b) => hueOf(a) - hueOf(b)),
+        [palette]
     )
     const queryTokens = query.trim().toLowerCase().split(/\s+/).filter(Boolean)
     const matches = (...texts: (string | undefined)[]): boolean => {
@@ -249,7 +168,7 @@ export function AdminColorPicker({
         }
     }
 
-    const renderTooltip = (meta: ColorMeta): ReactElement => (
+    const renderTooltip = (info: SwatchInfo): ReactElement => (
         <Tooltip
             className="AdminColorPicker__tooltip"
             placement="bottom"
@@ -260,23 +179,23 @@ export function AdminColorPicker({
                     <path d="M0 0 L4 4 L8 0" />
                 </svg>
             </OverlayArrow>
-            {meta.name && (
+            {info.name && (
                 <div className="AdminColorPicker__tooltip-row AdminColorPicker__tooltip-row--name">
-                    {meta.name}
+                    {info.name}
                 </div>
             )}
-            {meta.regions.map((region) => (
+            {info.regions.map((region) => (
                 <div key={region} className="AdminColorPicker__tooltip-row">
                     🌍 {region}
                 </div>
             ))}
-            {meta.energy && (
-                <div className="AdminColorPicker__tooltip-row">
-                    ⚡ {meta.energy}
+            {info.energy.map((energy) => (
+                <div key={energy} className="AdminColorPicker__tooltip-row">
+                    ⚡ {energy}
                 </div>
-            )}
+            ))}
             <div className="AdminColorPicker__tooltip-row AdminColorPicker__tooltip-row--hex">
-                {meta.hex.toUpperCase()}
+                {info.hex.toUpperCase()}
             </div>
         </Tooltip>
     )
@@ -284,8 +203,8 @@ export function AdminColorPicker({
     const isSelected = (hex: string): boolean =>
         color?.toLowerCase() === hex.toLowerCase()
 
-    const renderTile = (meta: ColorMeta, key: string): ReactElement => {
-        const { hex } = meta
+    const renderTile = (info: SwatchInfo, key: string): ReactElement => {
+        const { hex } = info
         return (
             <TooltipTrigger key={key} delay={0} closeDelay={0}>
                 <Button
@@ -293,10 +212,10 @@ export function AdminColorPicker({
                         "AdminColorPicker__tile--selected": isSelected(hex),
                     })}
                     style={{ backgroundColor: hex }}
-                    aria-label={`${meta.name ?? hex} (${hex})`}
+                    aria-label={`${info.name ?? hex} (${hex})`}
                     onPress={() => onColor(hex)}
                 />
-                {renderTooltip(meta)}
+                {renderTooltip(info)}
             </TooltipTrigger>
         )
     }
@@ -306,7 +225,7 @@ export function AdminColorPicker({
         hex: string,
         key: string
     ): ReactElement => {
-        const meta = metaFor(hex)
+        const info = infoFor(hex)
         return (
             <TooltipTrigger key={key} delay={0} closeDelay={0}>
                 <Button
@@ -324,16 +243,16 @@ export function AdminColorPicker({
                         {displayName}
                     </span>
                 </Button>
-                {renderTooltip(meta)}
+                {renderTooltip(info)}
             </TooltipTrigger>
         )
     }
 
     const renderGrid = (colors: string[]): ReactElement => {
         const visible = colors
-            .map(metaFor)
-            .filter((meta) =>
-                matches(meta.name, ...meta.regions, meta.energy, meta.hex)
+            .map(infoFor)
+            .filter((info) =>
+                matches(info.name, ...info.regions, ...info.energy, info.hex)
             )
         if (visible.length === 0)
             return (
@@ -341,23 +260,14 @@ export function AdminColorPicker({
             )
         return (
             <div className="AdminColorPicker__grid">
-                {visible.map((meta, i) => renderTile(meta, `${meta.hex}-${i}`))}
+                {visible.map((info, i) => renderTile(info, `${info.hex}-${i}`))}
             </div>
         )
     }
 
-    const renderCards = (entries: [string, string][]): ReactElement => {
-        // Deduplicate by displayed region name (e.g. "NorthAmerica" and
-        // "North America" collapse to a single card).
-        const seenNames = new Set<string>()
-        const deduped = entries.filter(([name]) => {
-            const label = humanizeName(name)
-            if (seenNames.has(label)) return false
-            seenNames.add(label)
-            return true
-        })
-        const visible = deduped.filter(([name, hex]) =>
-            matches(humanizeName(name), name, hex)
+    const renderCards = (group: PaletteGroup): ReactElement => {
+        const visible = group.entries.filter((entry) =>
+            matches(entry.label, entry.name, entry.hex)
         )
         if (visible.length === 0)
             return (
@@ -365,8 +275,8 @@ export function AdminColorPicker({
             )
         return (
             <div className="AdminColorPicker__cards">
-                {visible.map(([name, hex]) =>
-                    renderCard(humanizeName(name), hex, name)
+                {visible.map((entry) =>
+                    renderCard(entry.label, entry.hex, entry.name)
                 )}
             </div>
         )
@@ -374,6 +284,12 @@ export function AdminColorPicker({
 
     return (
         <div className="AdminColorPicker">
+            <div className="AdminColorPicker__banner">
+                <span className="AdminColorPicker__banner-label">
+                    {palette.label}
+                </span>
+            </div>
+
             <SearchField
                 className="AdminColorPicker__search"
                 aria-label="Search colors"
@@ -388,7 +304,7 @@ export function AdminColorPicker({
 
             <Tabs
                 className="AdminColorPicker__tabs"
-                selectedKey={tab}
+                selectedKey={effectiveTab}
                 onSelectionChange={(key: Key) => selectTab(key as TabKey)}
             >
                 <TabList
@@ -401,23 +317,27 @@ export function AdminColorPicker({
                     <Tab id="regions" className="AdminColorPicker__chip">
                         🌍 Regions
                     </Tab>
-                    <Tab id="energy" className="AdminColorPicker__chip">
-                        ⚡ Energy
-                    </Tab>
+                    {hasEnergyTab && (
+                        <Tab id="energy" className="AdminColorPicker__chip">
+                            ⚡ Energy
+                        </Tab>
+                    )}
                     <Tab id="hue" className="AdminColorPicker__chip">
                         🎨 By hue
                     </Tab>
                 </TabList>
 
                 <TabPanel id="all" className="AdminColorPicker__panel">
-                    {renderGrid(gridColors)}
+                    {renderGrid(palette.swatches)}
                 </TabPanel>
                 <TabPanel id="regions" className="AdminColorPicker__panel">
-                    {renderCards(Object.entries(ContinentColors))}
+                    {renderCards(palette.regions)}
                 </TabPanel>
-                <TabPanel id="energy" className="AdminColorPicker__panel">
-                    {renderCards(Object.entries(EnergyColors))}
-                </TabPanel>
+                {hasEnergyTab && (
+                    <TabPanel id="energy" className="AdminColorPicker__panel">
+                        {renderCards(palette.energy)}
+                    </TabPanel>
+                )}
                 <TabPanel id="hue" className="AdminColorPicker__panel">
                     {renderGrid(hueSortedColors)}
                 </TabPanel>

--- a/adminSiteClient/ColorSchemeDropdown.tsx
+++ b/adminSiteClient/ColorSchemeDropdown.tsx
@@ -1,7 +1,7 @@
 import { Component } from "react"
 import { computed, action, makeObservable } from "mobx"
 import { Select } from "antd"
-import { GrapherChartOrMapType } from "@ourworldindata/types"
+import { Color, GrapherChartOrMapType } from "@ourworldindata/types"
 import {
     ColorScheme,
     getColorSchemeForChartType,
@@ -22,10 +22,11 @@ interface ColorSchemeSelectOption {
     searchLabel: string
 }
 
+const MAX_PREVIEW_BANDS = 6
+
 interface ColorSchemeDropdownProps {
     additionalOptions: ColorSchemeOption[]
     value?: string
-    gradientColorCount: number
     invertedColorScheme: boolean
     chartType: GrapherChartOrMapType
     onChange: (selected: ColorSchemeOption) => void
@@ -36,7 +37,6 @@ interface ColorSchemeDropdownProps {
 export class ColorSchemeDropdown extends Component<ColorSchemeDropdownProps> {
     static defaultProps = {
         additionalOptions: [],
-        gradientColorCount: 6,
         invertedColorScheme: false,
     }
 
@@ -49,19 +49,14 @@ export class ColorSchemeDropdown extends Component<ColorSchemeDropdownProps> {
         return this.props.additionalOptions
     }
 
-    @computed get gradientColorCount() {
-        return this.props.gradientColorCount
-    }
-
     @computed get colorSchemeOptions() {
         return Object.entries(getColorSchemeForChartType(this.props.chartType))
             .filter(([, v]) => v !== undefined)
             .map(([key, scheme]) => {
                 return {
                     colorScheme: scheme,
-                    gradient: this.createLinearGradient(
-                        scheme,
-                        this.gradientColorCount
+                    gradient: createLinearGradient(
+                        scheme.getColors(this.getPreviewColorCount(scheme))
                     ),
                     label: scheme.name,
                     value: key,
@@ -75,15 +70,10 @@ export class ColorSchemeDropdown extends Component<ColorSchemeDropdownProps> {
         return additionalOptions.concat(this.colorSchemeOptions)
     }
 
-    createLinearGradient(colorScheme: ColorScheme, count: number) {
-        const colors = colorScheme.getColors(count)
-
-        const step = 100 / count
-        const gradientEntries = colors.map(
-            (color, i) => `${color} ${i * step}%, ${color} ${(i + 1) * step}%`
-        )
-
-        return `linear-gradient(90deg, ${gradientEntries.join(", ")})`
+    getPreviewColorCount(colorScheme: ColorScheme): number {
+        const { isDistinct, paletteSize } = colorScheme
+        if (!isDistinct || paletteSize === 0) return MAX_PREVIEW_BANDS
+        return Math.min(MAX_PREVIEW_BANDS, paletteSize)
     }
 
     @action.bound onChange(value: ColorSchemeOption | null) {
@@ -149,4 +139,13 @@ export class ColorSchemeDropdown extends Component<ColorSchemeDropdownProps> {
             />
         )
     }
+}
+
+/** One hard-edged band per color, as a CSS background-image value. */
+function createLinearGradient(colors: Color[]): string {
+    const step = 100 / colors.length
+    const bands = colors.map(
+        (color, i) => `${color} ${i * step}%, ${color} ${(i + 1) * step}%`
+    )
+    return `linear-gradient(90deg, ${bands.join(", ")})`
 }

--- a/adminSiteClient/DimensionCard.tsx
+++ b/adminSiteClient/DimensionCard.tsx
@@ -145,7 +145,11 @@ export class DimensionCard<
                         <ColorBox
                             color={this.color}
                             onColor={this.onColor}
-                            showLineChartColors={grapherState.isLineChart}
+                            palette={
+                                grapherState.isLineChart
+                                    ? "chartLines"
+                                    : "chart"
+                            }
                         />
                     </div>
                     <Link

--- a/adminSiteClient/EditorColorScaleSection.tsx
+++ b/adminSiteClient/EditorColorScaleSection.tsx
@@ -38,6 +38,7 @@ import {
 } from "./ColorSchemeDropdown.js"
 import { match } from "ts-pattern"
 import { ErrorMessages } from "./ChartEditorTypes.js"
+import { getColorPaletteKey, type ColorPaletteKey } from "./colorPalettes.js"
 
 interface EditorColorScaleSectionFeatures {
     legendDescription: boolean
@@ -47,7 +48,6 @@ interface EditorColorScaleSectionProps {
     scale: ColorScale
     chartType: GrapherChartOrMapType
     features: EditorColorScaleSectionFeatures
-    showLineChartColors: boolean
     onChange?: () => void
     errorMessages?: ErrorMessages
     errorMessagesKey?: string
@@ -63,7 +63,7 @@ export class EditorColorScaleSection extends Component<EditorColorScaleSectionPr
                     scale={this.props.scale}
                     onChange={this.props.onChange}
                     chartType={this.props.chartType}
-                    showLineChartColors={this.props.showLineChartColors}
+                    palette={getColorPaletteKey(this.props.chartType)}
                     errorMessages={this.props.errorMessages}
                     errorMessagesKey={this.props.errorMessagesKey}
                     lastEditedNote={this.props.lastEditedNote}
@@ -136,7 +136,7 @@ class ColorLegendSection extends Component<ColorLegendSectionProps> {
 interface ColorsSectionProps {
     scale: ColorScale
     chartType: GrapherChartOrMapType
-    showLineChartColors: boolean
+    palette: ColorPaletteKey
     onChange?: () => void
     errorMessages?: ErrorMessages
     errorMessagesKey?: string
@@ -355,8 +355,7 @@ class ColorsSection extends Component<ColorsSectionProps> {
                 <ColorSchemeEditor
                     scale={scale}
                     onChange={this.props.onChange}
-                    showLineChartColors={this.props.showLineChartColors}
-                    baseColorScheme={scale.baseColorScheme}
+                    palette={this.props.palette}
                 />
             </Section>
         )
@@ -365,8 +364,7 @@ class ColorsSection extends Component<ColorsSectionProps> {
 
 interface ColorSchemeEditorProps {
     scale: ColorScale
-    showLineChartColors: boolean
-    baseColorScheme?: ColorSchemeName
+    palette: ColorPaletteKey
     onChange?: () => void
 }
 
@@ -385,10 +383,7 @@ class ColorSchemeEditor extends Component<ColorSchemeEditorProps> {
                                     scale={scale}
                                     bin={bin}
                                     index={index}
-                                    showLineChartColors={
-                                        this.props.showLineChartColors
-                                    }
-                                    baseColorScheme={this.props.baseColorScheme}
+                                    palette={this.props.palette}
                                     onChange={this.props.onChange}
                                 />
                             )
@@ -398,10 +393,7 @@ class ColorSchemeEditor extends Component<ColorSchemeEditorProps> {
                                 key={index}
                                 scale={scale}
                                 bin={bin}
-                                showLineChartColors={
-                                    this.props.showLineChartColors
-                                }
-                                baseColorScheme={this.props.baseColorScheme}
+                                palette={this.props.palette}
                                 onChange={this.props.onChange}
                             />
                         )
@@ -481,8 +473,7 @@ interface NumericBinViewProps {
     scale: ColorScale
     bin: NumericBin
     index: number
-    showLineChartColors: boolean
-    baseColorScheme?: ColorSchemeName
+    palette: ColorPaletteKey
     onChange?: () => void
 }
 
@@ -571,8 +562,7 @@ class NumericBinView extends Component<NumericBinViewProps> {
                 <ColorBox
                     color={bin.color}
                     onColor={this.onColor}
-                    showLineChartColors={this.props.showLineChartColors}
-                    baseColorScheme={this.props.baseColorScheme}
+                    palette={this.props.palette}
                 />
                 <div className="range">
                     <span>
@@ -616,8 +606,7 @@ class NumericBinView extends Component<NumericBinViewProps> {
 interface CategoricalBinViewProps {
     scale: ColorScale
     bin: CategoricalBin
-    showLineChartColors: boolean
-    baseColorScheme?: ColorSchemeName
+    palette: ColorPaletteKey
     onChange?: () => void
 }
 
@@ -672,8 +661,7 @@ class CategoricalBinView extends Component<CategoricalBinViewProps> {
                 <ColorBox
                     color={bin.color}
                     onColor={this.onColor}
-                    showLineChartColors={this.props.showLineChartColors}
-                    baseColorScheme={this.props.baseColorScheme}
+                    palette={this.props.palette}
                 />
                 <TextField value={bin.value} disabled={true} onValue={_.noop} />
                 <Toggle

--- a/adminSiteClient/EditorCustomizeTab.tsx
+++ b/adminSiteClient/EditorCustomizeTab.tsx
@@ -740,7 +740,7 @@ class TrendColorField extends React.Component<{
                 <ColorBox
                     color={color}
                     onColor={this.onColor}
-                    showLineChartColors={false}
+                    palette="chart"
                 />
                 <span>{_.capitalize(field)}</span>
             </>
@@ -1044,7 +1044,6 @@ export class EditorCustomizeTab<
                             grapherState.chartType ??
                             GRAPHER_CHART_TYPES.LineChart
                         }
-                        showLineChartColors={grapherState.isLineChart}
                         features={{
                             legendDescription: true,
                         }}

--- a/adminSiteClient/EditorDataTab.tsx
+++ b/adminSiteClient/EditorDataTab.tsx
@@ -104,7 +104,11 @@ class EntityListItem extends React.Component<EntityListItemProps> {
                     <ColorBox
                         color={color}
                         onColor={this.onColor}
-                        showLineChartColors={editor.grapherState.isLineChart}
+                        palette={
+                            editor.grapherState.isLineChart
+                                ? "chartLines"
+                                : "chart"
+                        }
                     />
                     {entityName}
                 </div>

--- a/adminSiteClient/EditorMapTab.tsx
+++ b/adminSiteClient/EditorMapTab.tsx
@@ -360,7 +360,6 @@ export class EditorMapTab<Editor extends AbstractChartEditor> extends Component<
                         <EditorColorScaleSection
                             scale={colorScale}
                             chartType={GRAPHER_MAP_TYPE}
-                            showLineChartColors={false}
                             features={{
                                 legendDescription: false,
                             }}

--- a/adminSiteClient/Forms.tsx
+++ b/adminSiteClient/Forms.tsx
@@ -7,19 +7,14 @@
 import * as _ from "lodash-es"
 import * as React from "react"
 import { useState } from "react"
-import {
-    bind,
-    dayjs,
-    Tippy,
-    copyToClipboard,
-    ColorSchemeName,
-} from "@ourworldindata/utils"
+import { bind, dayjs, Tippy, copyToClipboard } from "@ourworldindata/utils"
 import { action, makeObservable } from "mobx"
 import { observer } from "mobx-react"
 import cx from "clsx"
 import { useTimeout } from "usehooks-ts"
 
 import { AdminColorPicker } from "./AdminColorPicker.js"
+import type { ColorPaletteKey } from "./colorPalettes.js"
 import {
     faCog,
     faLink,
@@ -676,8 +671,7 @@ export class EditableListItem extends React.Component<EditableListItemProps> {
 interface ColorBoxProps {
     color: string | undefined
     onColor: (color: string | undefined) => void
-    showLineChartColors: boolean
-    baseColorScheme?: ColorSchemeName
+    palette: ColorPaletteKey
 }
 
 @observer
@@ -702,8 +696,7 @@ export class ColorBox extends React.Component<ColorBoxProps> {
                         <AdminColorPicker
                             color={color}
                             onColor={this.props.onColor}
-                            showLineChartColors={this.props.showLineChartColors}
-                            baseColorScheme={this.props.baseColorScheme}
+                            palette={this.props.palette}
                             onResize={this.handleResize}
                         />
                         <div

--- a/adminSiteClient/GrapherConfigGridEditor.tsx
+++ b/adminSiteClient/GrapherConfigGridEditor.tsx
@@ -510,7 +510,6 @@ export class GrapherConfigGridEditor extends React.Component<GrapherConfigGridEd
                             features={{
                                 legendDescription: false,
                             }}
-                            showLineChartColors={false}
                             onChange={this.onGenericRichEditorChange}
                         />
                     ) : undefined
@@ -536,7 +535,6 @@ export class GrapherConfigGridEditor extends React.Component<GrapherConfigGridEd
                                 features={{
                                     legendDescription: false,
                                 }}
-                                showLineChartColors={grapherState.isLineChart}
                                 onChange={this.onGenericRichEditorChange}
                             />
                         )

--- a/adminSiteClient/colorPalettes.ts
+++ b/adminSiteClient/colorPalettes.ts
@@ -1,0 +1,163 @@
+import {
+    Color,
+    ColorSchemeName,
+    GrapherChartOrMapType,
+    GRAPHER_CHART_TYPES,
+    GRAPHER_MAP_TYPE,
+    lastOfNonEmptyArray,
+    lazy,
+} from "@ourworldindata/utils"
+import {
+    ColorSchemes,
+    ContinentColors,
+    DarkerHexByBaseHex,
+    EnergyColors,
+    MapContinentColors,
+    OwidDistinctColors,
+    OwidDistinctLinesColors,
+    OwidMapColors,
+} from "@ourworldindata/grapher"
+
+export type ColorPaletteKey = "chart" | "chartLines" | "map"
+
+/** Whether an OWID colour is designed for chart marks or for map fills. */
+export type ColorSurface = "chart" | "map"
+
+export interface PaletteEntry {
+    /** Humanized, e.g. "North America" */
+    label: string
+    /** Raw vocabulary name, kept so a search for "NorthAmerica" still matches */
+    name: string
+    hex: Color
+}
+
+/** One tab's worth of named colours */
+export interface PaletteGroup {
+    /** Card order, deduplicated by label */
+    entries: PaletteEntry[]
+    /** Uppercased hex -> every label that maps to it */
+    labelsByHex: Record<string, string[]>
+}
+
+export interface AdminColorPalette {
+    key: ColorPaletteKey
+    surface: ColorSurface
+    /** Shown in the picker's banner, e.g. "Map colours" */
+    label: string
+    /** Grid order */
+    swatches: Color[]
+    /** Uppercased hex -> humanized colour name */
+    nameByHex: Record<string, string>
+    /** The 🌍 Regions tab */
+    regions: PaletteGroup
+    /** The ⚡ Energy tab; empty means the tab is hidden */
+    energy: PaletteGroup
+}
+
+const palettesByKey: Record<ColorPaletteKey, AdminColorPalette> = {
+    map: {
+        key: "map",
+        surface: "map",
+        label: "Map colours",
+        swatches: Object.values(OwidMapColors),
+        nameByHex: humanizedNameByHex(OwidMapColors),
+        regions: toPaletteGroup(MapContinentColors),
+        energy: toPaletteGroup({}),
+    },
+    chart: {
+        key: "chart",
+        surface: "chart",
+        label: "Chart colours",
+        swatches: lastOfNonEmptyArray(
+            ColorSchemes.get(ColorSchemeName["owid-distinct"]).colorSets
+        ),
+        nameByHex: humanizedNameByHex(OwidDistinctColors),
+        regions: toPaletteGroup(ContinentColors),
+        energy: toPaletteGroup(EnergyColors),
+    },
+    chartLines: {
+        key: "chartLines",
+        surface: "chart",
+        label: "Chart colours (line charts)",
+        swatches: lastOfNonEmptyArray(
+            ColorSchemes.get(ColorSchemeName.OwidDistinctLines).colorSets
+        ),
+        nameByHex: humanizedNameByHex(OwidDistinctLinesColors),
+        regions: toPaletteGroup(withDarkerHexes(ContinentColors)),
+        energy: toPaletteGroup(withDarkerHexes(EnergyColors)),
+    },
+}
+
+/** Turn camelCase identifiers ("SubSaharanAfrica") into readable labels */
+export function humanizeName(name: string): string {
+    if (name.includes(" ")) return name
+    return name.replace(/([a-z])([A-Z])/g, "$1 $2")
+}
+
+/** Build a case-insensitive hex -> humanized name lookup */
+function humanizedNameByHex(
+    map: Record<string, Color>
+): Record<string, string> {
+    const result: Record<string, string> = {}
+    for (const [name, hex] of Object.entries(map))
+        result[hex.toUpperCase()] = humanizeName(name)
+    return result
+}
+
+/**
+ * Index a name -> hex vocabulary for one tab: cards deduplicated by label
+ * (e.g. "NorthAmerica" and "North America" collapse into one), plus the reverse
+ * lookup the tooltips need, since many names share a hex.
+ */
+function toPaletteGroup(map: Record<string, Color>): PaletteGroup {
+    const entries: PaletteEntry[] = []
+    const labelsByHex: Record<string, string[]> = {}
+    const seen = new Set<string>()
+    for (const [name, hex] of Object.entries(map)) {
+        const label = humanizeName(name)
+        const labels = (labelsByHex[hex.toUpperCase()] ??= [])
+        if (!labels.includes(label)) labels.push(label)
+        if (seen.has(label)) continue
+        seen.add(label)
+        entries.push({ label, name, hex })
+    }
+    return { entries, labelsByHex }
+}
+
+/** Swap in the darker line-chart variant of a colour where one exists. */
+function withDarkerHexes(map: Record<string, Color>): Record<string, Color> {
+    return Object.fromEntries(
+        Object.entries(map).map(([name, hex]) => [
+            name,
+            DarkerHexByBaseHex[hex] ?? hex,
+        ])
+    )
+}
+
+export function getAdminColorPalette(key: ColorPaletteKey): AdminColorPalette {
+    return palettesByKey[key]
+}
+
+export function getColorPaletteKey(
+    chartType: GrapherChartOrMapType
+): ColorPaletteKey {
+    if (chartType === GRAPHER_MAP_TYPE) return "map"
+    if (chartType === GRAPHER_CHART_TYPES.LineChart) return "chartLines"
+    return "chart"
+}
+
+export function getColorSurface(hex: Color): ColorSurface | undefined {
+    return surfaceByHex()[hex.toUpperCase()]
+}
+
+const surfaceByHex = lazy((): Record<string, ColorSurface> => {
+    const index: Record<string, ColorSurface> = {}
+    for (const hex of [
+        ...Object.values(OwidDistinctColors),
+        ...Object.values(OwidDistinctLinesColors),
+    ])
+        index[hex.toUpperCase()] = "chart"
+    for (const hex of Object.values(OwidMapColors))
+        index[hex.toUpperCase()] = "map"
+    return index
+})

--- a/packages/@ourworldindata/grapher/src/color/ColorScheme.ts
+++ b/packages/@ourworldindata/grapher/src/color/ColorScheme.ts
@@ -27,6 +27,12 @@ export class ColorScheme implements ColorSchemeInterface {
         colorSets.forEach((set) => (this.colorSets[set.length] = set))
     }
 
+    /** How many colors the scheme defines, before any interpolation */
+    get paletteSize(): number {
+        if (this.colorSets.length === 0) return 0
+        return lastOfNonEmptyArray(this.colorSets).length
+    }
+
     improviseGradientFromShorter(
         shortColors: Color[],
         numColors: number

--- a/packages/@ourworldindata/grapher/src/color/CustomSchemes.ts
+++ b/packages/@ourworldindata/grapher/src/color/CustomSchemes.ts
@@ -1,11 +1,9 @@
 import * as _ from "lodash-es"
-import { lazy } from "@ourworldindata/utils"
 import {
     Color,
     ColorSchemeInterface,
     ColorSchemeName,
 } from "@ourworldindata/types"
-import * as R from "remeda"
 
 // TODO: Initialize CustomColorSchemes lazily
 export const CustomColorSchemes: ColorSchemeInterface[] = []
@@ -37,8 +35,6 @@ export const OwidDistinctColors = {
     Coral: "#d73c50",
 } as const
 
-const OwidDistinctColorsNames = lazy(() => R.invert(OwidDistinctColors))
-
 // These are variations of some of the colors above where the original color would have too little
 // contrast against a white background for thin lines or text elements
 export const DarkerOwidDistinctColors: Record<string, string> = {
@@ -50,7 +46,7 @@ export const DarkerOwidDistinctColors: Record<string, string> = {
     LimeDarker: "#338711",
 }
 
-const darkerColorReplacementsHexToReplacementColorName = {
+export const DarkerHexByBaseHex = {
     [OwidDistinctColors.DarkOrange]: DarkerOwidDistinctColors.DarkOrangeDarker,
     [OwidDistinctColors.Peach]: DarkerOwidDistinctColors.PeachDarker,
     [OwidDistinctColors.LightTeal]: DarkerOwidDistinctColors.LightTealDarker,
@@ -64,11 +60,6 @@ export const OwidDistinctLinesColors = {
     ..._.omit(OwidDistinctColors, Object.keys(DarkerOwidDistinctColors)),
     ...DarkerOwidDistinctColors,
 }
-
-// Used for looking up names from color hex values
-const OwidDistinctLinesColorNames = lazy(() =>
-    R.invert(OwidDistinctLinesColors)
-)
 
 // Below are 5 variations of the same colors in different permutations
 export const CategoricalColorsPaletteA = [
@@ -260,9 +251,6 @@ export const EnergyColors = {
     OtherRenewables: OwidDistinctColors.OliveGreen,
 }
 
-// Used for looking up color names from hex values
-const EnergyColorsNames = lazy(() => R.invert(EnergyColors))
-
 const EnergyColorPalette = [
     EnergyColors.Coal,
     EnergyColors.Oil,
@@ -284,23 +272,6 @@ export const OwidEnergy = {
     colorMap: EnergyColors,
 }
 CustomColorSchemes.push(OwidEnergy)
-
-function getModifiedLinesNames(
-    colorNames: Record<string, string>
-): Record<string, string> {
-    return Object.fromEntries(
-        Object.entries(colorNames).map(([k, v]) => [
-            k in darkerColorReplacementsHexToReplacementColorName
-                ? darkerColorReplacementsHexToReplacementColorName[k]
-                : k,
-            v,
-        ])
-    )
-}
-
-const EnergyColorsLinesNames = lazy(() =>
-    getModifiedLinesNames(EnergyColorsNames())
-)
 
 export const OwidEnergyLines = getModifiedLinesColorScheme(OwidEnergy)
 CustomColorSchemes.push(OwidEnergyLines)
@@ -626,9 +597,6 @@ export const ContinentColors = {
     "Low-income countries": IncomeGroupColors.LowIncome,
 } as const
 
-// Used for looking up color names from hex values
-const ContinentColorsNames = lazy(() => R.invert(ContinentColors))
-
 const ContinentColorPalette = [
     ContinentColors.Africa,
     ContinentColors.Asia,
@@ -670,17 +638,13 @@ function getModifiedLinesColorScheme(
 ): ColorSchemeInterface {
     const colors = colorScheme.colorSets[0]
     const modifiedColors = colors.map((color) =>
-        color in darkerColorReplacementsHexToReplacementColorName
-            ? darkerColorReplacementsHexToReplacementColorName[color]
-            : color
+        color in DarkerHexByBaseHex ? DarkerHexByBaseHex[color] : color
     )
 
     // If the scheme has a colorMap, we need to create a modified version with darker colors
     const modifiedColorMap = colorScheme.colorMap
         ? _.mapValues(colorScheme.colorMap, (color) =>
-              color in darkerColorReplacementsHexToReplacementColorName
-                  ? darkerColorReplacementsHexToReplacementColorName[color]
-                  : color
+              color in DarkerHexByBaseHex ? DarkerHexByBaseHex[color] : color
           )
         : undefined
 
@@ -692,10 +656,6 @@ function getModifiedLinesColorScheme(
         displayName: (colorScheme.displayName ?? "") + " (Lines)",
     }
 }
-
-const ContinentColorsLinesNames = lazy(() =>
-    getModifiedLinesNames(ContinentColorsNames())
-)
 
 export const ContinentColorsLinesColorScheme = getModifiedLinesColorScheme(
     ContinentColorsColorScheme
@@ -905,16 +865,6 @@ export const BinaryMapPaletteE = {
 }
 
 CustomColorSchemes.push(BinaryMapPaletteE)
-
-export const BinaryMapPaletteF = {
-    name: ColorSchemeName.BinaryMapPaletteF,
-    displayName: "Binary map palette F",
-    singleColorScale: false,
-    isDistinct: true,
-    colorSets: [[OwidDistinctColors.TealishGreen, OwidDistinctColors.Coral]],
-}
-
-CustomColorSchemes.push(BinaryMapPaletteF)
 
 const CategoricalMapPalette10 = [
     OwidMapColors.MutedDenim,
@@ -1210,52 +1160,6 @@ export const OwidCategoricalMapScheme = {
 CustomColorSchemes.push(OwidCategoricalMapScheme)
 
 export const DefaultColorScheme = OwidDistinctColorScheme
-
-export function getColorNameAndSemanticPalettes(
-    color: string,
-    baseColorSchemeNames: Record<string, string>,
-    continentsColorSchemeNames: Record<string, string>,
-    energyColorSchemeNames: Record<string, string>
-): string[] {
-    const colorNameStandardized = color.toUpperCase()
-    const owidDistinct =
-        colorNameStandardized in baseColorSchemeNames
-            ? `🎨 ${baseColorSchemeNames[colorNameStandardized]}`
-            : ""
-    const continents =
-        colorNameStandardized in continentsColorSchemeNames
-            ? `🌍 ${continentsColorSchemeNames[colorNameStandardized]}`
-            : ""
-    const energy =
-        colorNameStandardized in energyColorSchemeNames
-            ? `⚡ ${energyColorSchemeNames[colorNameStandardized]}`
-            : ""
-    const lines = [owidDistinct, continents, energy].filter((x) => x !== "")
-
-    return lines
-}
-
-export function getColorNameOwidDistinctAndSemanticPalettes(
-    color: string
-): string[] {
-    return getColorNameAndSemanticPalettes(
-        color,
-        OwidDistinctColorsNames(),
-        ContinentColorsNames(),
-        EnergyColorsNames()
-    )
-}
-
-export function getColorNameOwidDistinctLinesAndSemanticPalettes(
-    color: string
-): string[] {
-    return getColorNameAndSemanticPalettes(
-        color,
-        OwidDistinctLinesColorNames(),
-        ContinentColorsLinesNames(),
-        EnergyColorsLinesNames()
-    )
-}
 
 // Perceptual color scales from https://github.com/politiken-journalism/scale-color-perceptual
 CustomColorSchemes.push({

--- a/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChartConstants.ts
+++ b/packages/@ourworldindata/grapher/src/dumbbellCharts/DumbbellChartConstants.ts
@@ -16,7 +16,7 @@ import {
     GRAPHER_LIGHT_TEXT,
     OWID_NO_DATA_GRAY,
 } from "../color/ColorConstants.js"
-import { BinaryMapPaletteF } from "../color/CustomSchemes.js"
+import { OwidDistinctColors } from "../color/CustomSchemes.js"
 
 /** Horizontal gap between the value label and the dumbbell */
 export const VALUE_LABEL_DOT_GAP = 6
@@ -33,8 +33,8 @@ export const MIN_LEGEND_LABEL_GAP = 8
 export const NO_CHANGE_COLOR = OWID_NO_DATA_GRAY
 
 export const DEFAULT_DUMBBELL_TREND_COLOR_MAP = {
-    increase: BinaryMapPaletteF.colorSets[0][0],
-    decrease: BinaryMapPaletteF.colorSets[0][1],
+    increase: OwidDistinctColors.TealishGreen,
+    decrease: OwidDistinctColors.Coral,
 } satisfies DumbbellTrendColorMap
 
 export const START_COLUMN_COLOR = GRAPHER_DENIM

--- a/packages/@ourworldindata/grapher/src/index.ts
+++ b/packages/@ourworldindata/grapher/src/index.ts
@@ -65,14 +65,13 @@ export {
 } from "./color/ColorConstants"
 export { darkenColorForText } from "./color/ColorUtils"
 export {
-    getColorNameOwidDistinctAndSemanticPalettes,
-    getColorNameOwidDistinctLinesAndSemanticPalettes,
     OwidDistinctColors,
     OwidMapColors,
     OwidDistinctLinesColors,
     EnergyColors,
     ContinentColors,
     MapContinentColors,
+    DarkerHexByBaseHex,
 } from "./color/CustomSchemes"
 export { ColorSchemes } from "./color/ColorSchemes"
 export { DimensionSlot } from "./chart/DimensionSlot"

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.011.yaml
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.011.yaml
@@ -793,7 +793,6 @@ $defs:
       - BinaryMapPaletteC
       - BinaryMapPaletteD
       - BinaryMapPaletteE
-      - BinaryMapPaletteF
       - SingleColorGradientDenim
       - SingleColorGradientTeal
       - SingleColorGradientPurple

--- a/packages/@ourworldindata/grapher/src/stackedCharts/AbstractStackedChartState.ts
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/AbstractStackedChartState.ts
@@ -34,14 +34,13 @@ import {
     CategoricalColorAssigner,
     CategoricalColorMap,
 } from "../color/CategoricalColorAssigner.js"
-import { BinaryMapPaletteE } from "../color/CustomSchemes.js"
 import { FocusArray } from "../focus/FocusArray.js"
 import { AxisConfig } from "../axis/AxisConfig.js"
 import { HorizontalAxis, VerticalAxis } from "../axis/Axis.js"
 
-// used in StackedBar charts to color negative and positive bars
-const POSITIVE_COLOR = BinaryMapPaletteE.colorSets[0][0] // orange
-const NEGATIVE_COLOR = BinaryMapPaletteE.colorSets[0][1] // blue
+// Used in StackedBar charts to color negative and positive bars
+const POSITIVE_COLOR = "#f4a582" // orange
+const NEGATIVE_COLOR = "#92c5de" // blue
 
 export abstract class AbstractStackedChartState implements ChartState {
     manager: ChartManager

--- a/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
+++ b/packages/@ourworldindata/types/src/grapherTypes/GrapherTypes.ts
@@ -558,7 +558,6 @@ export enum ColorSchemeName {
     BinaryMapPaletteC = "BinaryMapPaletteC",
     BinaryMapPaletteD = "BinaryMapPaletteD",
     BinaryMapPaletteE = "BinaryMapPaletteE",
-    BinaryMapPaletteF = "BinaryMapPaletteF",
     SingleColorGradientDenim = "SingleColorGradientDenim",
     SingleColorGradientTeal = "SingleColorGradientTeal",
     SingleColorGradientPurple = "SingleColorGradientPurple",


### PR DESCRIPTION
> _Written by Claude Opus 5 — @sophiamersmann at the wheel._

The admin colour picker merged the chart and map vocabularies into one flat hex-to-name lookup, so nothing in it said which surface a colour was meant for. Two visibly different swatches both called themselves "Light Teal", and the Regions tab always read `ContinentColors` even on a categorical map, where 194 of 199 region names paint a different hex than the one it showed. The picker now follows the surface the colour scale actually paints. Every tab comes from one palette registry, the popover names the palette, and a swatch tooltip carries the colour's name along with the regions and energy types it is the default for. The surface comes from `chartType`, which every colour-scale call site already passed, so `baseColorScheme` no longer gets threaded through four component layers to answer the same question.

Two smaller things ride along. The scheme dropdown drew six gradient bands for every scheme, so a two-colour palette advertised six shades that `getDistinctColors` had invented; a distinct scheme now previews with as many bands as it defines. And `BinaryMapPaletteF` is deleted, because despite the name its two colours are chart colours, nothing in `chart_configs` references it, and it existed only to hand the dumbbell chart a pair of hexes that the dumbbell now holds itself.

## Worth a reviewer's attention

- **No published output changes.** An earlier version of this branch recoloured binary map palettes A to E with the designed map vocabulary. Design asked to keep them as they are for now, so that work is out and the five palettes are byte-identical to master. The mapping it had picked is recorded, and either landing route stays open.
- The stacked bar sign colours used to read palette E's `colorSets`. They are inline now with the same hexes, so stacked bars render unchanged, but that leaves a chart-side pair sitting on two hexes that belong to no OWID vocabulary. Deliberate, and the one loose thread here.
- The picker offers one vocabulary per chart type but no longer flags a value from another one, so `getColorSurface` and `AdminColorPalette.surface` are left with no readers. They need a consumer or a delete before this lands. For scale: in the local snapshot, 330 colour entries across map colour scales use chart-vocabulary hexes, against 190 using the map vocabulary.
- Dropping `BinaryMapPaletteF` from the schema enum is formally a breaking schema change. `JSON_SEARCH` over all of `chart_configs` returns zero references, so no config can fail validation.
- The map tab now offers map colours for every binning strategy rather than only `OwidCategoricalMap`.
- I did not run `make svgtest`. This touches the dumbbell and stacked-chart colour constants, and although the values are identical, the files did change.

<details><summary>Details</summary>

### Also in here

- The colour-name lookup helpers that served the react-color picker `AdminColorPicker` replaced are deleted: `getColorNameOwidDistinctAndSemanticPalettes`, its lines sibling, the shared `getColorNameAndSemanticPalettes`, their six lazy hex-to-name maps and `getModifiedLinesNames`. `darkerColorReplacementsHexToReplacementColorName` becomes the exported `DarkerHexByBaseHex`, since it maps a hex to a hex rather than to a name and the admin needs it for the line-chart region palette.
- The palette registry is keyed by `chart` / `chartLines` / `map` and derived from `chartType` alone. The map palette has no energy vocabulary, so that tab is omitted rather than rendering empty.
- Scheme previews derive band width from the colours returned rather than the number requested, so a scheme yielding fewer than asked no longer produces a gradient that stops short.

### Binary palette usage in the local DB

| palette | map colour scales | chart-level |
| --- | --- | --- |
| A | 7 | 0 |
| B | 2 | 0 |
| C | 10 | 2 |
| D | 35 | 2 |
| E | 61 | 0 |
| F | 0 | 0 |

### Notes

- `grapher-schema.011.json` is generated and gitignored, so only the yaml needed editing. `defaultGrapherConfig.ts` is unaffected, as removing an enum member changes no default.
- `ColorSchemes.ts` has a zero diff against master. The map preferred list is still A to E and there is no retired-schemes set.
- `OwidMapColors` stays imported in `CustomSchemes.ts` for `CategoricalMapPalette10`.
- The five `functions/test/grapher-config-r2.e2e.test.ts` cases time out on local R2 bindings, here as on master.

</details>

