### PR TITLE
Admin: rebuild Forms.tsx on antd primitives

### DIFF
--- a/adminSiteClient/AdminApp.tsx
+++ b/adminSiteClient/AdminApp.tsx
@@ -94,6 +94,10 @@ class AdminErrorMessage extends React.Component<{ admin: Admin }> {
         return error ? (
             <Modal
                 className="errorMessage"
+                width="80%"
+                // Above antd's static `Modal.confirm`-style dialogs, so a
+                // fatal error is never hidden behind one.
+                zIndex={2001}
                 onClose={action(() => {
                     if (error.isFatal) {
                         window.location.reload()

--- a/adminSiteClient/EditorFAQ.tsx
+++ b/adminSiteClient/EditorFAQ.tsx
@@ -6,7 +6,11 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 export class EditorFAQ extends Component<{ onClose: () => void }> {
     override render() {
         return (
-            <Modal onClose={this.props.onClose} className="EditorFAQ">
+            <Modal
+                onClose={this.props.onClose}
+                className="EditorFAQ"
+                width={800}
+            >
                 <div className="modal-header">
                     <h3 className="modal-title">Frequently Asked Questions</h3>
                 </div>

--- a/adminSiteClient/Forms.scss
+++ b/adminSiteClient/Forms.scss
@@ -1,0 +1,119 @@
+// Styles for the shared admin form kit in `Forms.tsx`, which renders antd
+// primitives inside our own label / help-text / error chrome.
+//
+// The wrapper elements still carry Bootstrap's `form-group` and `list-group`
+// classes next to the ones below, because raw Bootstrap form and list markup
+// lives on in ~30 other admin files and is frequently interleaved with these
+// components. The rules here only cover the parts that used to come from
+// Bootstrap's form/input-group/modal markup that `Forms.tsx` no longer emits.
+
+.form-field__label {
+    display: block;
+}
+
+// Replaces Bootstrap's `.form-text`.
+.form-field__help {
+    display: block;
+    margin-top: 0.25rem;
+}
+
+.form-field__error {
+    color: red;
+}
+
+.form-field__character-limit {
+    color: rgba(0, 0, 0, 0.3);
+}
+
+.form-field__character-limit--exceeded {
+    color: #d17d05;
+}
+
+// The control row of a field that has a trailing button — an antd
+// `Space.Compact`, replacing Bootstrap's `.input-group` + `.input-group-append`.
+.form-field__control {
+    display: flex;
+    width: 100%;
+
+    > *:first-child {
+        flex: 1 1 auto;
+        min-width: 0;
+    }
+
+    > .form-field__button {
+        flex: 0 0 auto;
+    }
+}
+
+// antd selects are inline-block by default; ours stand in for a `.form-control`
+// and so fill the field.
+.form-field__select {
+    width: 100%;
+}
+
+.toggle-field {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 0.5rem;
+}
+
+.toggle-field__label {
+    cursor: pointer;
+    user-select: none;
+}
+
+.catalog-path-field__value {
+    margin: 0;
+    padding: 4px 11px;
+    border: 1px solid #d9d9d9;
+    border-radius: 6px 0 0 6px;
+    background: #e9ecef;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    height: auto;
+}
+
+// `EditableList` / `EditableListItem`. These deliberately mirror what
+// Bootstrap's list-group gives the hand-written `list-group-item` markup they
+// are mixed with; they exist as grep-able hooks for the phase that removes it.
+.editable-list {
+    margin-top: 0;
+    margin-bottom: 0.5em;
+}
+
+// The `Modal` component renders whatever it is handed inside an antd modal
+// with its own padding zeroed out, so these three carry the chrome — same
+// class names, same look as the Bootstrap modal they replace.
+.admin-modal {
+    .modal-header {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        padding: 1rem;
+        border-bottom: 1px solid #dee2e6;
+    }
+
+    .modal-title {
+        margin-bottom: 0;
+        line-height: 1.5;
+    }
+
+    .modal-body {
+        position: relative;
+        flex: 1 1 auto;
+        padding: 1rem;
+    }
+
+    .modal-footer {
+        display: flex;
+        align-items: center;
+        justify-content: flex-end;
+        padding: 1rem;
+        border-top: 1px solid #dee2e6;
+
+        > * {
+            margin: 0.25rem;
+        }
+    }
+}

--- a/adminSiteClient/Forms.test.tsx
+++ b/adminSiteClient/Forms.test.tsx
@@ -1,0 +1,549 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+/**
+ * Behavioural coverage for the shared admin form kit. These specs deliberately
+ * avoid asserting on markup or class names: they exist so the internals can be
+ * swapped (Bootstrap markup -> antd primitives) without silently changing what
+ * the 46 call sites depend on — `value`/`onValue` plumbing, trim-on-blur, the
+ * intermediately-unparsable number states, and the `Bind*` two-way binding.
+ */
+
+import * as React from "react"
+import { useState } from "react"
+import { describe, expect, it, vi } from "vitest"
+import { fireEvent, render, screen } from "@testing-library/react"
+import { observable } from "mobx"
+import {
+    BindAutoString,
+    BindFloat,
+    BindString,
+    NumberField,
+    RadioGroup,
+    SelectField,
+    TextField,
+    Toggle,
+} from "./Forms.js"
+
+function noop(): void {
+    return undefined
+}
+
+type TextFieldProps = React.ComponentProps<typeof TextField>
+type NumberFieldProps = React.ComponentProps<typeof NumberField>
+
+function ControlledTextField({
+    initialValue = "",
+    onValue,
+    ...rest
+}: Omit<TextFieldProps, "value" | "onValue"> & {
+    initialValue?: string
+    onValue?: (value: string) => void
+}) {
+    const [value, setValue] = useState(initialValue)
+    return (
+        <TextField
+            {...rest}
+            value={value}
+            onValue={(next) => {
+                setValue(next)
+                onValue?.(next)
+            }}
+        />
+    )
+}
+
+function ControlledNumberField({
+    initialValue,
+    onValue,
+    ...rest
+}: Omit<NumberFieldProps, "value" | "onValue"> & {
+    initialValue?: number
+    onValue?: (value: number | undefined) => void
+}) {
+    const [value, setValue] = useState<number | undefined>(initialValue)
+    return (
+        <NumberField
+            {...rest}
+            value={value}
+            onValue={(next) => {
+                setValue(next)
+                onValue?.(next)
+            }}
+        />
+    )
+}
+
+function getTextbox(): HTMLInputElement {
+    return screen.getByRole("textbox") as HTMLInputElement
+}
+
+/**
+ * `Toggle` renders a native checkbox today and an antd `Switch`
+ * (`role="switch"`) once migrated, so accept either.
+ */
+function getToggle(): HTMLElement {
+    return screen.queryByRole("checkbox") ?? screen.getByRole("switch")
+}
+
+function isToggleOn(element: HTMLElement): boolean {
+    if (element instanceof HTMLInputElement) return element.checked
+    return element.getAttribute("aria-checked") === "true"
+}
+
+/**
+ * `SelectField` renders a native `<select>` today and an antd `Select` once
+ * migrated; both expose the `combobox` role, but only one of them can be
+ * driven with a `change` event.
+ */
+function getSelect(): HTMLElement {
+    return screen.queryByRole("combobox") ?? screen.getByRole("listbox")
+}
+
+function chooseOption(select: HTMLElement, value: string, label: string) {
+    if (select instanceof HTMLSelectElement) {
+        fireEvent.change(select, { target: { value } })
+    } else {
+        fireEvent.mouseDown(select)
+        fireEvent.click(screen.getByTitle(label))
+    }
+}
+
+describe(TextField, () => {
+    it("round-trips its value and reports every keystroke", () => {
+        const onValue = vi.fn()
+        render(<ControlledTextField initialValue="hello" onValue={onValue} />)
+
+        const input = getTextbox()
+        expect(input).toHaveValue("hello")
+
+        fireEvent.change(input, { target: { value: "hello world" } })
+
+        expect(onValue).toHaveBeenCalledWith("hello world")
+        expect(input).toHaveValue("hello world")
+    })
+
+    it("leaves whitespace alone while typing but trims it on blur", () => {
+        const onValue = vi.fn()
+        render(<ControlledTextField onValue={onValue} />)
+
+        const input = getTextbox()
+        fireEvent.change(input, { target: { value: "  padded  " } })
+        expect(onValue).toHaveBeenLastCalledWith("  padded  ")
+        expect(input).toHaveValue("  padded  ")
+
+        fireEvent.blur(input)
+        expect(onValue).toHaveBeenLastCalledWith("padded")
+        expect(input).toHaveValue("padded")
+    })
+
+    it("forwards blur to the consumer's own onBlur handler", () => {
+        const onBlur = vi.fn()
+        render(<ControlledTextField initialValue="a" onBlur={onBlur} />)
+
+        fireEvent.blur(getTextbox())
+
+        expect(onBlur).toHaveBeenCalledOnce()
+    })
+
+    it("calls onEnter and onEscape for those keys only", () => {
+        const onEnter = vi.fn()
+        const onEscape = vi.fn()
+        render(<ControlledTextField onEnter={onEnter} onEscape={onEscape} />)
+
+        const input = getTextbox()
+        fireEvent.keyDown(input, { key: "a" })
+        expect(onEnter).not.toHaveBeenCalled()
+        expect(onEscape).not.toHaveBeenCalled()
+
+        fireEvent.keyDown(input, { key: "Enter" })
+        expect(onEnter).toHaveBeenCalledOnce()
+        expect(onEscape).not.toHaveBeenCalled()
+
+        fireEvent.keyDown(input, { key: "Escape" })
+        expect(onEscape).toHaveBeenCalledOnce()
+    })
+
+    it("renders label, help text and placeholder", () => {
+        render(
+            <ControlledTextField
+                label="Chart title"
+                helpText="Shown above the chart"
+                placeholder="Type a title"
+            />
+        )
+
+        expect(screen.getByText("Chart title")).toBeInTheDocument()
+        expect(screen.getByText("Shown above the chart")).toBeInTheDocument()
+        expect(screen.getByPlaceholderText("Type a title")).toBeInTheDocument()
+    })
+
+    it("can be disabled", () => {
+        render(<ControlledTextField initialValue="x" disabled />)
+        expect(getTextbox()).toBeDisabled()
+    })
+
+    it("shows the soft character limit only once there is a value", () => {
+        const { rerender } = render(
+            <TextField value="" onValue={noop} softCharacterLimit={5} />
+        )
+        expect(screen.queryByText("0 / 5")).not.toBeInTheDocument()
+
+        rerender(<TextField value="ab" onValue={noop} softCharacterLimit={5} />)
+        expect(screen.getByText("2 / 5")).toBeInTheDocument()
+
+        rerender(
+            <TextField value="abcdef" onValue={noop} softCharacterLimit={5} />
+        )
+        expect(screen.getByText(/^6 \/ 5/)).toBeInTheDocument()
+        expect(
+            screen.getByText(/may cause rendering issues/)
+        ).toBeInTheDocument()
+    })
+
+    it("renders an error message when given one", () => {
+        render(<ControlledTextField errorMessage="Something is wrong" />)
+        expect(screen.getByText("Something is wrong")).toBeInTheDocument()
+    })
+
+    it("renders a button that reports clicks and can be disabled", () => {
+        const onButtonClick = vi.fn()
+        const { rerender } = render(
+            <TextField
+                value="x"
+                onValue={noop}
+                buttonContent="Go"
+                onButtonClick={onButtonClick}
+            />
+        )
+
+        const button = screen.getByRole("button", { name: "Go" })
+        expect(button).not.toBeDisabled()
+        fireEvent.click(button)
+        expect(onButtonClick).toHaveBeenCalledOnce()
+
+        rerender(
+            <TextField
+                value="x"
+                onValue={noop}
+                buttonContent="Go"
+                onButtonClick={onButtonClick}
+                buttonDisabled
+            />
+        )
+        expect(screen.getByRole("button", { name: "Go" })).toBeDisabled()
+    })
+
+    it("renders no button when there is no button content", () => {
+        render(<ControlledTextField initialValue="x" />)
+        expect(screen.queryByRole("button")).not.toBeInTheDocument()
+    })
+})
+
+describe(NumberField, () => {
+    it("round-trips numbers", () => {
+        const onValue = vi.fn()
+        render(
+            <ControlledNumberField
+                initialValue={42}
+                onValue={onValue}
+                allowDecimal
+                allowNegative
+            />
+        )
+
+        const input = getTextbox()
+        expect(input).toHaveValue("42")
+
+        fireEvent.change(input, { target: { value: "43" } })
+        expect(onValue).toHaveBeenLastCalledWith(43)
+        expect(input).toHaveValue("43")
+    })
+
+    it("keeps intermediately unparsable input editable without emitting NaN", () => {
+        const onValue = vi.fn()
+        render(
+            <ControlledNumberField
+                onValue={onValue}
+                allowDecimal
+                allowNegative
+            />
+        )
+        const input = getTextbox()
+
+        // A lone minus sign: the user is halfway through typing a negative
+        // number, so the field has no value yet but must keep the "-".
+        fireEvent.change(input, { target: { value: "-" } })
+        expect(onValue).toHaveBeenLastCalledWith(undefined)
+        expect(input).toHaveValue("-")
+
+        fireEvent.change(input, { target: { value: "-1" } })
+        expect(onValue).toHaveBeenLastCalledWith(-1)
+        expect(input).toHaveValue("-1")
+
+        // A trailing decimal point: the value is already 1, but the "." has to
+        // survive so the user can type "1.5".
+        fireEvent.change(input, { target: { value: "1." } })
+        expect(onValue).toHaveBeenLastCalledWith(1)
+        expect(input).toHaveValue("1.")
+
+        fireEvent.change(input, { target: { value: "1.5" } })
+        expect(onValue).toHaveBeenLastCalledWith(1.5)
+        expect(input).toHaveValue("1.5")
+
+        // Clearing the field means "no value", not NaN.
+        fireEvent.change(input, { target: { value: "" } })
+        expect(onValue).toHaveBeenLastCalledWith(undefined)
+        expect(input).toHaveValue("")
+
+        for (const [value] of onValue.mock.calls)
+            expect(value === undefined || !isNaN(value)).toBe(true)
+    })
+
+    it("drops the intermediate input state on blur", () => {
+        render(<ControlledNumberField allowDecimal allowNegative />)
+        const input = getTextbox()
+
+        fireEvent.change(input, { target: { value: "1." } })
+        expect(input).toHaveValue("1.")
+
+        fireEvent.blur(input)
+        expect(input).toHaveValue("1")
+    })
+
+    it("rejects characters the field does not allow", () => {
+        const onValue = vi.fn()
+        render(<ControlledNumberField initialValue={1} onValue={onValue} />)
+        const input = getTextbox()
+
+        // Neither decimals nor negative numbers are allowed here.
+        fireEvent.change(input, { target: { value: "1.5" } })
+        fireEvent.change(input, { target: { value: "-1" } })
+        fireEvent.change(input, { target: { value: "abc" } })
+
+        expect(onValue).not.toHaveBeenCalled()
+        expect(input).toHaveValue("1")
+
+        fireEvent.change(input, { target: { value: "12" } })
+        expect(onValue).toHaveBeenLastCalledWith(12)
+    })
+
+    it("renders a reset button alongside the field", () => {
+        const onClick = vi.fn()
+        render(
+            <ControlledNumberField
+                initialValue={1}
+                allowDecimal
+                resetButton={{ onClick, content: "Reset me" }}
+            />
+        )
+
+        const button = screen.getByRole("button", { name: "Reset me" })
+        fireEvent.click(button)
+        expect(onClick).toHaveBeenCalledOnce()
+        expect(getTextbox()).toHaveValue("1")
+    })
+})
+
+describe(SelectField, () => {
+    const options = [
+        { value: "a", label: "Option A" },
+        { value: "b", label: "Option B" },
+    ]
+
+    it("shows the selected option and reports changes", () => {
+        const onValue = vi.fn()
+        render(
+            <SelectField
+                label="Pick one"
+                value="a"
+                options={options}
+                onValue={onValue}
+            />
+        )
+
+        expect(screen.getByText("Pick one")).toBeInTheDocument()
+        expect(screen.getByText("Option A")).toBeInTheDocument()
+
+        chooseOption(getSelect(), "b", "Option B")
+        expect(onValue).toHaveBeenCalledWith("b")
+    })
+})
+
+describe(RadioGroup, () => {
+    const options = [
+        { value: "linear", label: "Linear" },
+        { value: "log", label: "Logarithmic" },
+    ]
+
+    it("marks the selected option and reports changes", () => {
+        const onChange = vi.fn()
+        render(
+            <RadioGroup
+                label="Axis scale"
+                options={options}
+                value="linear"
+                onChange={onChange}
+            />
+        )
+
+        expect(screen.getByRole("radio", { name: "Linear" })).toBeChecked()
+        const log = screen.getByRole("radio", { name: "Logarithmic" })
+        expect(log).not.toBeChecked()
+
+        fireEvent.click(log)
+        expect(onChange).toHaveBeenCalledWith("log")
+    })
+})
+
+describe(Toggle, () => {
+    it("reflects its value and reports the flipped one", () => {
+        const onValue = vi.fn()
+        const { rerender } = render(
+            <Toggle label="Hide legend" value={false} onValue={onValue} />
+        )
+
+        expect(screen.getByText("Hide legend")).toBeInTheDocument()
+        const toggle = getToggle()
+        expect(isToggleOn(toggle)).toBe(false)
+
+        fireEvent.click(toggle)
+        expect(onValue).toHaveBeenCalledWith(true)
+
+        rerender(<Toggle label="Hide legend" value={true} onValue={onValue} />)
+        expect(isToggleOn(getToggle())).toBe(true)
+
+        fireEvent.click(getToggle())
+        expect(onValue).toHaveBeenLastCalledWith(false)
+    })
+
+    it("can be disabled", () => {
+        const onValue = vi.fn()
+        render(
+            <Toggle
+                label="Hide legend"
+                value={false}
+                onValue={onValue}
+                disabled
+            />
+        )
+
+        fireEvent.click(getToggle())
+        expect(onValue).not.toHaveBeenCalled()
+    })
+})
+
+describe(BindString, () => {
+    it("binds an observable field in both directions", () => {
+        const store = observable({ title: "Life expectancy" })
+        render(<BindString field="title" store={store} />)
+
+        const input = getTextbox()
+        expect(input).toHaveValue("Life expectancy")
+
+        fireEvent.change(input, { target: { value: "  Child mortality  " } })
+        expect(store.title).toBe("  Child mortality  ")
+
+        fireEvent.blur(input)
+        expect(store.title).toBe("Child mortality")
+        expect(getTextbox()).toHaveValue("Child mortality")
+    })
+
+    it("defaults the label to the capitalised field name", () => {
+        const store = observable({ subtitle: "" })
+        render(<BindString field="subtitle" store={store} />)
+        expect(screen.getByText("Subtitle")).toBeInTheDocument()
+    })
+
+    it("renders a textarea when asked to", () => {
+        const store = observable({ note: "hello" })
+        render(<BindString field="note" store={store} textarea />)
+
+        const textarea = screen.getByRole("textbox")
+        expect(textarea.tagName).toBe("TEXTAREA")
+        expect(textarea).toHaveValue("hello")
+
+        fireEvent.change(textarea, { target: { value: "  bye  " } })
+        expect(store.note).toBe("  bye  ")
+        fireEvent.blur(textarea)
+        expect(store.note).toBe("bye")
+    })
+})
+
+describe(BindFloat, () => {
+    it("binds a numeric field, tolerating intermediate input", () => {
+        const store: { someNumber: number | undefined } = observable({
+            someNumber: 5,
+        })
+        render(<BindFloat field="someNumber" store={store} />)
+
+        const input = getTextbox()
+        expect(input).toHaveValue("5")
+
+        fireEvent.change(input, { target: { value: "-" } })
+        expect(store.someNumber).toBeUndefined()
+        expect(input).toHaveValue("-")
+
+        fireEvent.change(input, { target: { value: "-3.5" } })
+        expect(store.someNumber).toBe(-3.5)
+        expect(input).toHaveValue("-3.5")
+    })
+})
+
+describe(BindAutoString, () => {
+    it("shows the automatic value until the field is overridden", () => {
+        const store: { subtitle: string | undefined } = observable({
+            subtitle: undefined,
+        })
+        render(
+            <BindAutoString
+                field="subtitle"
+                store={store}
+                auto="Automatic subtitle"
+            />
+        )
+
+        const input = getTextbox()
+        expect(input).toHaveValue("Automatic subtitle")
+        // While automatic, the link/unlink button is inert — you override the
+        // value by editing the field, not by clicking the button.
+        expect(screen.getByRole("button")).toBeDisabled()
+
+        fireEvent.change(input, { target: { value: "Manual subtitle" } })
+        expect(store.subtitle).toBe("Manual subtitle")
+        expect(getTextbox()).toHaveValue("Manual subtitle")
+        expect(screen.getByRole("button")).not.toBeDisabled()
+    })
+
+    it("resets back to the automatic value when the button is clicked", () => {
+        const store: { subtitle: string | undefined } = observable({
+            subtitle: "Manual subtitle",
+        })
+        render(
+            <BindAutoString
+                field="subtitle"
+                store={store}
+                auto="Automatic subtitle"
+            />
+        )
+
+        fireEvent.click(screen.getByRole("button"))
+
+        expect(store.subtitle).toBeUndefined()
+        expect(getTextbox()).toHaveValue("Automatic subtitle")
+    })
+
+    it("trims the overridden value on blur", () => {
+        const store: { subtitle: string | undefined } = observable({
+            subtitle: undefined,
+        })
+        render(<BindAutoString field="subtitle" store={store} auto="Auto" />)
+
+        const input = getTextbox()
+        fireEvent.change(input, { target: { value: "  spaced  " } })
+        fireEvent.blur(input)
+
+        expect(store.subtitle).toBe("spaced")
+    })
+})

--- a/adminSiteClient/Forms.tsx
+++ b/adminSiteClient/Forms.tsx
@@ -2,6 +2,11 @@
  * ================
  *
  * Reusable React components to keep admin UI succint and consistent
+ *
+ * The internals are built on *controlled* antd primitives (`Input`, `Select`,
+ * `Radio.Group`, `Switch`, `Modal`, `Button`). antd's own `<Form>` is
+ * deliberately not used anywhere: it is uncontrolled (rc-field-form) and would
+ * fight the MobX stores that the `Bind*` wrappers below write straight into.
  */
 
 import * as _ from "lodash-es"
@@ -18,6 +23,15 @@ import { action, makeObservable } from "mobx"
 import { observer } from "mobx-react"
 import cx from "clsx"
 import { useTimeout } from "usehooks-ts"
+import {
+    Button as AntdButton,
+    Input,
+    Modal as AntdModal,
+    Radio,
+    Select,
+    Space,
+    Switch,
+} from "antd"
 
 import { AdminColorPicker } from "./AdminColorPicker.js"
 import {
@@ -35,6 +49,64 @@ export class FieldsRow extends React.Component<{ children: React.ReactNode }> {
     override render() {
         return <div className="FieldsRow">{this.props.children}</div>
     }
+}
+
+/**
+ * The wrapper every field renders. It keeps Bootstrap's `form-group` class
+ * alongside our own `form-field` one: raw `form-group` markup still exists in
+ * ~30 other admin files, and a good number of `admin.scss` rules key layout
+ * off `.form-group` inside the chart editor. Dropping it belongs to the phase
+ * that migrates those pages.
+ */
+function FormField(props: {
+    className?: string
+    innerRef?: React.Ref<HTMLDivElement>
+    label?: React.ReactNode
+    secondaryLabel?: string
+    helpText?: string
+    errorMessage?: string
+    softCharacterLimit?: number
+    value?: string
+    children: React.ReactNode
+}): React.ReactElement {
+    return (
+        <div
+            className={cx("form-field", "form-group", props.className)}
+            ref={props.innerRef}
+        >
+            {props.label !== undefined && props.label !== "" && (
+                <label className="form-field__label">
+                    {props.label}
+                    {props.secondaryLabel && (
+                        <>
+                            <span> </span>
+                            <span title={props.secondaryLabel}>
+                                <FontAwesomeIcon
+                                    icon={faCircleInfo}
+                                    className="text-muted"
+                                />
+                            </span>
+                        </>
+                    )}
+                </label>
+            )}
+            {props.children}
+            {props.helpText && (
+                <small className="form-field__help text-muted">
+                    {props.helpText}
+                </small>
+            )}
+            {props.softCharacterLimit && props.value && (
+                <SoftCharacterLimit
+                    text={props.value}
+                    limit={props.softCharacterLimit}
+                />
+            )}
+            {props.errorMessage && (
+                <ErrorMessage message={props.errorMessage} />
+            )}
+        </div>
+    )
 }
 
 interface TextFieldProps extends React.HTMLAttributes<HTMLInputElement> {
@@ -58,6 +130,40 @@ interface TextFieldProps extends React.HTMLAttributes<HTMLInputElement> {
     buttonContent?: React.ReactNode
     buttonTooltipContent?: React.ReactNode
     buttonDisabled?: boolean
+}
+
+/**
+ * The trailing button some fields carry (the link/unlink toggle, "copy",
+ * "reset"). It sits in a `Space.Compact` next to the control, which is antd's
+ * equivalent of Bootstrap's `input-group` + `input-group-append`.
+ */
+function renderFieldButton(props: {
+    buttonContent?: React.ReactNode
+    buttonTooltipContent?: React.ReactNode
+    buttonDisabled?: boolean
+    onButtonClick?: () => void
+}): React.ReactElement | null {
+    if (!props.buttonContent) return null
+
+    const button = (
+        <AntdButton
+            className="form-field__button"
+            onClick={props.onButtonClick}
+            disabled={props.buttonDisabled}
+        >
+            {props.buttonContent}
+        </AntdButton>
+    )
+
+    if (props.buttonTooltipContent) {
+        return (
+            <Tippy content={props.buttonTooltipContent} maxWidth={180}>
+                {button}
+            </Tippy>
+        )
+    }
+
+    return button
 }
 
 export class TextField extends React.Component<TextFieldProps> {
@@ -105,91 +211,44 @@ export class TextField extends React.Component<TextFieldProps> {
         }
     }
 
-    renderButton() {
-        const { props } = this
-        if (!props.buttonContent) return null
-
-        const button = (
-            <div className="input-group-append">
-                <button
-                    className="btn btn-outline-secondary"
-                    type="button"
-                    onClick={props.onButtonClick}
-                    disabled={props.buttonDisabled}
-                >
-                    {props.buttonContent}
-                </button>
-            </div>
-        )
-
-        if (props.buttonTooltipContent) {
-            return (
-                <Tippy content={props.buttonTooltipContent} maxWidth={180}>
-                    {button}
-                </Tippy>
-            )
-        }
-
-        return button
-    }
-
     override render() {
         const { props } = this
-        const passthroughProps = _.pick(props, [
-            "placeholder",
-            "title",
-            "disabled",
-            "required",
-        ])
+
+        const input = (
+            <Input
+                value={props.value || ""}
+                onChange={(e) => this.onChange(e.currentTarget.value)}
+                onBlur={this.onBlur}
+                onKeyDown={this.onKeyDown}
+                placeholder={props.placeholder}
+                title={props.title}
+                disabled={props.disabled}
+                required={props.required}
+            />
+        )
+
+        const button = renderFieldButton(props)
 
         return (
-            <div
-                className={cx("form-group", this.props.className)}
-                ref={this.base}
+            <FormField
+                className={props.className}
+                innerRef={this.base}
+                label={props.label}
+                secondaryLabel={props.secondaryLabel}
+                helpText={props.helpText}
+                errorMessage={props.errorMessage}
+                softCharacterLimit={props.softCharacterLimit}
+                value={props.value}
             >
-                {props.label && (
-                    <label>
-                        {props.label}
-                        {props.secondaryLabel && (
-                            <>
-                                <span> </span>
-                                <span title={props.secondaryLabel}>
-                                    <FontAwesomeIcon
-                                        icon={faCircleInfo}
-                                        className="text-muted"
-                                    />
-                                </span>
-                            </>
-                        )}
-                    </label>
+                {button ? (
+                    <Space.Compact className="form-field__control" block>
+                        {input}
+                        {button}
+                    </Space.Compact>
+                ) : (
+                    input
                 )}
-                <div className="input-group">
-                    <input
-                        className="form-control"
-                        type="text"
-                        value={props.value || ""}
-                        onChange={(e) => this.onChange(e.currentTarget.value)}
-                        onBlur={this.onBlur}
-                        onKeyDown={this.onKeyDown}
-                        {...passthroughProps}
-                    />
-                    {this.renderButton()}
-                </div>
-                {props.helpText && (
-                    <small className="form-text text-muted">
-                        {props.helpText}
-                    </small>
-                )}
-                {props.softCharacterLimit && props.value && (
-                    <SoftCharacterLimit
-                        text={props.value}
-                        limit={props.softCharacterLimit}
-                    />
-                )}
-                {props.errorMessage && (
-                    <ErrorMessage message={props.errorMessage} />
-                )}
-            </div>
+            </FormField>
         )
     }
 }
@@ -200,94 +259,51 @@ export class TextAreaField extends React.Component<TextFieldProps> {
         this.props.onValue?.(value)
     }
 
+    // NOTE: unlike `TextField`, this deliberately does not forward
+    // `props.onBlur` — it never has, and a number of chart-editor call sites
+    // pass an `onBlur` that triggers a save.
     @bind onBlur() {
         const { value = "" } = this.props
         const trimmedValue = value.trim()
         this.props.onValue?.(trimmedValue)
     }
 
-    renderButton() {
-        const { props } = this
-        if (!props.buttonContent) return null
-
-        const button = (
-            <div className="input-group-append">
-                <button
-                    className="btn btn-outline-secondary"
-                    type="button"
-                    onClick={props.onButtonClick}
-                    disabled={props.buttonDisabled}
-                >
-                    {props.buttonContent}
-                </button>
-            </div>
-        )
-
-        if (props.buttonTooltipContent) {
-            return (
-                <Tippy content={props.buttonTooltipContent} maxWidth={180}>
-                    {button}
-                </Tippy>
-            )
-        }
-
-        return button
-    }
-
     override render() {
         const { props } = this
-        const passthroughProps = _.pick(props, [
-            "placeholder",
-            "title",
-            "disabled",
-            "label",
-            "rows",
-        ])
+
+        const textArea = (
+            <Input.TextArea
+                value={props.value}
+                onChange={this.onChange}
+                onBlur={this.onBlur}
+                rows={props.rows ?? 5}
+                placeholder={props.placeholder}
+                title={props.title}
+                disabled={props.disabled}
+            />
+        )
+
+        const button = renderFieldButton(props)
 
         return (
-            <div className="form-group">
-                {props.label && (
-                    <label>
-                        {props.label}
-                        {props.secondaryLabel && (
-                            <>
-                                <span> </span>
-                                <span title={props.secondaryLabel}>
-                                    <FontAwesomeIcon
-                                        icon={faCircleInfo}
-                                        className="text-muted"
-                                    />
-                                </span>
-                            </>
-                        )}
-                    </label>
+            <FormField
+                className={props.className}
+                label={props.label}
+                secondaryLabel={props.secondaryLabel}
+                helpText={props.helpText}
+                errorMessage={props.errorMessage}
+                softCharacterLimit={props.softCharacterLimit}
+                value={props.value}
+            >
+                {button ? (
+                    <Space.Compact className="form-field__control" block>
+                        {textArea}
+                        {button}
+                    </Space.Compact>
+                ) : (
+                    textArea
                 )}
-                <div className="input-group">
-                    <textarea
-                        className="form-control"
-                        value={props.value}
-                        onChange={this.onChange}
-                        onBlur={this.onBlur}
-                        rows={5}
-                        {...passthroughProps}
-                    />
-                    {this.renderButton()}
-                </div>
-                {props.helpText && (
-                    <small className="form-text text-muted">
-                        {props.helpText}
-                    </small>
-                )}
-                {props.softCharacterLimit && props.value && (
-                    <SoftCharacterLimit
-                        text={props.value}
-                        limit={props.softCharacterLimit}
-                    />
-                )}
-                {props.errorMessage && (
-                    <ErrorMessage message={props.errorMessage} />
-                )}
-            </div>
+            </FormField>
         )
     }
 }
@@ -389,8 +405,9 @@ class WithResetButton extends React.Component<WithResetButtonProps> {
         return (
             <div className="WithResetButton">
                 {props.children}
-                <button
-                    className="btn btn-link ResetToDefaultButton"
+                <AntdButton
+                    type="link"
+                    className="ResetToDefaultButton"
                     onClick={props.onClick}
                     disabled={props.disabled}
                 >
@@ -398,7 +415,7 @@ class WithResetButton extends React.Component<WithResetButtonProps> {
                         (props.disabled
                             ? "Bound to data. Edit to unbind"
                             : "Bind to data")}
-                </button>
+                </AntdButton>
             </div>
         )
     }
@@ -414,37 +431,52 @@ interface SelectFieldProps {
     onBlur?: () => void
 }
 
+/**
+ * A native `<select>` displays its first option whenever the bound value
+ * matches none of them (unless there's a placeholder option to fall back to),
+ * and several chart-editor fields rely on that: they leave the config value
+ * `undefined` and let Grapher apply its own default, which is the first option.
+ * antd's `Select` would render those fields blank instead, so mirror what the
+ * browser did. Nothing is written back either way — this only affects display.
+ */
+function selectDisplayValue(
+    value: string | undefined,
+    options: { value: string }[],
+    placeholder?: string
+): string | undefined {
+    if (options.some((opt) => opt.value === value)) return value
+    if (placeholder !== undefined) return undefined
+    return options[0]?.value
+}
+
 export class SelectField extends React.Component<SelectFieldProps> {
     override render() {
         const { props } = this
 
+        const options = props.options.map((opt) => ({
+            value: opt.value,
+            label: opt.label || opt.value,
+        }))
+
         return (
-            <div className="form-group">
-                {props.label && <label>{props.label}</label>}
-                <select
-                    className="form-control"
-                    onChange={(e) => props.onValue(e.currentTarget.value)}
-                    onBlur={this.props.onBlur}
-                    value={props.value}
-                    defaultValue={undefined}
-                >
-                    {props.placeholder ? (
-                        <option key={undefined} value={undefined} hidden={true}>
-                            {props.placeholder}
-                        </option>
-                    ) : null}
-                    {props.options.map((opt) => (
-                        <option key={opt.value} value={opt.value}>
-                            {opt.label || opt.value}
-                        </option>
-                    ))}
-                </select>
-                {props.helpText && (
-                    <small className="form-text text-muted">
-                        {props.helpText}
-                    </small>
-                )}
-            </div>
+            <FormField label={props.label} helpText={props.helpText}>
+                <Select
+                    className="form-field__select"
+                    value={selectDisplayValue(
+                        props.value,
+                        options,
+                        props.placeholder
+                    )}
+                    onChange={(value: string) => props.onValue(value)}
+                    onBlur={props.onBlur}
+                    placeholder={props.placeholder}
+                    // The chart editor puts these in narrow columns, where
+                    // clipping long option labels to the field width would
+                    // make them unreadable.
+                    popupMatchSelectWidth={false}
+                    options={options}
+                />
+            </FormField>
         )
     }
 }
@@ -472,35 +504,40 @@ export class SelectGroupsField extends React.Component<SelectGroupsFieldProps> {
     override render() {
         const { props } = this
 
+        const ungroupedOptions = props.options.map((opt) => ({
+            value: opt.value,
+            label: opt.label,
+        }))
+        const groupedOptions = props.groups.flatMap((group) =>
+            group.options.map((opt) => ({
+                value: opt.value,
+                label: opt.label || opt.value,
+            }))
+        )
+
         return (
-            <div className="form-group">
-                {props.label && <label>{props.label}</label>}
-                <select
-                    className="form-control"
-                    onChange={(e) => props.onValue(e.currentTarget.value)}
-                    value={props.value}
-                >
-                    {props.options.map((opt) => (
-                        <option key={opt.value} value={opt.value}>
-                            {opt.label}
-                        </option>
-                    ))}
-                    {props.groups.map((group) => (
-                        <optgroup key={group.title} label={group.title}>
-                            {group.options.map((opt) => (
-                                <option key={opt.value} value={opt.value}>
-                                    {opt.label || opt.value}
-                                </option>
-                            ))}
-                        </optgroup>
-                    ))}
-                </select>
-                {props.helpText && (
-                    <small className="form-text text-muted">
-                        {props.helpText}
-                    </small>
-                )}
-            </div>
+            <FormField label={props.label} helpText={props.helpText}>
+                <Select
+                    className="form-field__select"
+                    value={selectDisplayValue(props.value, [
+                        ...ungroupedOptions,
+                        ...groupedOptions,
+                    ])}
+                    onChange={(value: string) => props.onValue(value)}
+                    popupMatchSelectWidth={false}
+                    options={[
+                        ...ungroupedOptions,
+                        ...props.groups.map((group) => ({
+                            label: group.title,
+                            title: group.title,
+                            options: group.options.map((opt) => ({
+                                value: opt.value,
+                                label: opt.label || opt.value,
+                            })),
+                        })),
+                    ]}
+                />
+            </FormField>
         )
     }
 }
@@ -519,36 +556,18 @@ interface RadioGroupProps {
 
 export class RadioGroup extends React.Component<RadioGroupProps> {
     override render() {
+        const { props } = this
         return (
-            <div className="form-group">
-                {this.props.label && <label>{this.props.label}</label>}
-                <div>
-                    {this.props.options.map((option) => {
-                        return (
-                            <div
-                                key={option.value}
-                                className="form-check form-check-inline"
-                            >
-                                <input
-                                    type="radio"
-                                    className="form-check-input"
-                                    id={option.value}
-                                    checked={option.value === this.props.value}
-                                    onChange={() =>
-                                        this.props.onChange(option.value)
-                                    }
-                                />
-                                <label
-                                    className="form-check-label"
-                                    htmlFor={option.value}
-                                >
-                                    {option.label || option.value}
-                                </label>
-                            </div>
-                        )
-                    })}
-                </div>
-            </div>
+            <FormField label={props.label}>
+                <Radio.Group
+                    value={props.value}
+                    onChange={(ev) => props.onChange(ev.target.value)}
+                    options={props.options.map((option) => ({
+                        value: option.value,
+                        label: option.label || option.value,
+                    }))}
+                />
+            </FormField>
         )
     }
 }
@@ -596,30 +615,43 @@ interface ToggleProps {
     secondaryLabel?: string
 }
 
+let toggleIdCounter = 0
+
 export class Toggle extends React.Component<ToggleProps> {
+    // antd's `Switch` renders a `<button>`, which a wrapping `<label>` cannot
+    // reliably activate, so the label is wired up explicitly instead.
+    private readonly labelId = `toggle-label-${++toggleIdCounter}`
+
     constructor(props: ToggleProps) {
         super(props)
         makeObservable(this)
     }
 
-    @action.bound onChange(e: React.ChangeEvent<HTMLInputElement>) {
-        this.props.onValue(!!e.currentTarget.checked)
+    @action.bound onChange(checked: boolean) {
+        this.props.onValue(checked)
+    }
+
+    @action.bound onLabelClick() {
+        if (this.props.disabled) return
+        this.props.onValue(!this.props.value)
     }
 
     override render() {
         const { props } = this
-        const passthroughProps = _.pick(props, ["label", "disabled", "title"])
 
         return (
-            <div className="form-check">
-                <label className="form-check-label">
-                    <input
-                        className="form-check-input"
-                        type="checkbox"
-                        checked={props.value}
-                        onChange={this.onChange}
-                        {...passthroughProps}
-                    />
+            <div className="toggle-field" title={props.title}>
+                <Switch
+                    checked={props.value}
+                    disabled={props.disabled}
+                    onChange={this.onChange}
+                    aria-labelledby={this.labelId}
+                />
+                <span
+                    id={this.labelId}
+                    className="toggle-field__label"
+                    onClick={this.onLabelClick}
+                >
                     {props.label}
                     {props.secondaryLabel && (
                         <>
@@ -632,12 +664,18 @@ export class Toggle extends React.Component<ToggleProps> {
                             </span>
                         </>
                     )}
-                </label>
+                </span>
             </div>
         )
     }
 }
 
+/**
+ * Keeps Bootstrap's `list-group` classes alongside our own: several call sites
+ * mix `EditableListItem`s with hand-written `list-group-item` markup in the
+ * same list, so the two have to keep looking the same until those pages move
+ * over too.
+ */
 export class EditableList extends React.Component<{
     className?: string
     children?: React.ReactNode
@@ -646,10 +684,11 @@ export class EditableList extends React.Component<{
         return this.props.children ? (
             <ul
                 {...this.props}
-                className={
-                    "list-group" +
-                    (this.props.className ? ` ${this.props.className}` : "")
-                }
+                className={cx(
+                    "editable-list",
+                    "list-group",
+                    this.props.className
+                )}
             />
         ) : null
     }
@@ -664,10 +703,11 @@ export class EditableListItem extends React.Component<EditableListItemProps> {
         return (
             <li
                 {...this.props}
-                className={
-                    "list-group-item" +
-                    (this.props.className ? ` ${this.props.className}` : "")
-                }
+                className={cx(
+                    "editable-list__item",
+                    "list-group-item",
+                    this.props.className
+                )}
             />
         )
     }
@@ -782,7 +822,7 @@ type AutoTextFieldProps = TextFieldProps & {
 }
 
 const ErrorMessage = ({ message }: { message: string }) => (
-    <div style={{ color: "red" }}>{message}</div>
+    <div className="form-field__error">{message}</div>
 )
 
 interface SoftCharacterLimitProps {
@@ -796,11 +836,10 @@ class SoftCharacterLimit extends React.Component<SoftCharacterLimitProps> {
         const { text, limit } = this.props
         return (
             <div
-                style={
-                    text.length > limit
-                        ? { color: "#D17D05" }
-                        : { color: "rgba(0,0,0,0.3)" }
-                }
+                className={cx("form-field__character-limit", {
+                    "form-field__character-limit--exceeded":
+                        text.length > limit,
+                })}
             >
                 {text.length} / {limit}
                 {text.length > limit && (
@@ -1264,51 +1303,37 @@ interface ModalProps {
     children: React.ReactNode
     className?: string
     onClose: () => void
+    /** Passed straight to antd; defaults to antd's 520px. */
+    width?: string | number
+    /** Only needed to stack above antd's static `Modal.confirm`-style dialogs. */
+    zIndex?: number
 }
 
+/**
+ * A thin wrapper over antd's `Modal` that renders whatever it's given, with no
+ * chrome of its own — consumers bring their own `.modal-header` /
+ * `.modal-body` / `.modal-footer` markup, which is why the content padding is
+ * zeroed out here.
+ */
 @observer
 export class Modal extends React.Component<ModalProps> {
-    base = React.createRef<HTMLDivElement>()
-    dismissable: boolean = true
-
-    constructor(props: ModalProps) {
-        super(props)
-        makeObservable(this)
-    }
-
-    @action.bound onClickOutside() {
-        if (this.dismissable) this.props.onClose()
-    }
-
-    override componentDidMount() {
-        // HACK (Mispy): The normal ways of doing this (stopPropagation etc) don't seem to work here
-        this.base.current!.addEventListener("click", () => {
-            this.dismissable = false
-            setTimeout(() => (this.dismissable = true), 100)
-        })
-        setTimeout(
-            () => document.body.addEventListener("click", this.onClickOutside),
-            0
-        )
-    }
-
-    override componentWillUnmount() {
-        document.body.removeEventListener("click", this.onClickOutside)
-    }
-
     override render() {
         const { props } = this
         return (
-            <div
-                className={
-                    "modal" + (props.className ? ` ${props.className}` : "")
-                }
-                style={{ display: "block" }}
+            <AntdModal
+                open
+                className={cx("admin-modal", props.className)}
+                onCancel={props.onClose}
+                footer={null}
+                width={props.width}
+                zIndex={props.zIndex}
+                styles={{
+                    container: { padding: 0, overflow: "hidden" },
+                    body: { padding: 0 },
+                }}
             >
-                <div ref={this.base} className="modal-dialog" role="document">
-                    <div className="modal-content">{this.props.children}</div>
-                </div>
-            </div>
+                {props.children}
+            </AntdModal>
         )
     }
 }
@@ -1359,23 +1384,21 @@ export const CatalogPathField = ({
     }
 
     return (
-        <div className="form-group catalog-path-field">
-            <label>Catalog path</label>
-            <div className="input-group">
-                <pre className="form-control">{tokenizedCatalogPath}</pre>
-                <div className="input-group-append">
-                    <button
-                        className="btn btn-outline-secondary"
-                        onClick={async () =>
-                            catalogPath && (await copyToClipboard(catalogPath))
-                        }
-                        disabled={!catalogPath}
-                    >
-                        <FontAwesomeIcon icon={faCopy} />
-                    </button>
-                </div>
-            </div>
-        </div>
+        <FormField className="catalog-path-field" label="Catalog path">
+            <Space.Compact className="form-field__control" block>
+                <pre className="catalog-path-field__value">
+                    {tokenizedCatalogPath}
+                </pre>
+                <AntdButton
+                    className="form-field__button"
+                    onClick={async () =>
+                        catalogPath && (await copyToClipboard(catalogPath))
+                    }
+                    disabled={!catalogPath}
+                    icon={<FontAwesomeIcon icon={faCopy} />}
+                />
+            </Space.Compact>
+        </FormField>
     )
 }
 
@@ -1418,13 +1441,13 @@ interface ButtonProps {
 export class Button extends React.Component<ButtonProps> {
     override render() {
         return (
-            <button className="btn btn-link" onClick={this.props.onClick}>
+            <AntdButton type="link" onClick={this.props.onClick}>
                 {this.props.children}
-            </button>
+            </AntdButton>
         )
     }
 }
 
 export const Help = ({ children }: { children: React.ReactNode }) => (
-    <small className="form-text text-muted mb-4">{children}</small>
+    <small className="form-field__help text-muted mb-4">{children}</small>
 )

--- a/adminSiteClient/VariableSelector.tsx
+++ b/adminSiteClient/VariableSelector.tsx
@@ -242,7 +242,11 @@ export class VariableSelector<
         )
 
         return (
-            <Modal onClose={this.onDismiss} className="VariableSelector">
+            <Modal
+                onClose={this.onDismiss}
+                className="VariableSelector"
+                width="min(90vw, 1000px)"
+            >
                 <div className="modal-header">
                     <h5 className="modal-title">
                         Set indicator{slot.allowMultiple && "s"} for {slot.name}

--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -17,10 +17,14 @@
 // Layout:
 @import "bootstrap/scss/grid";
 @import "bootstrap/scss/tables";
-// Form controls (`admin.scss` also `@extend`s `.form-control`):
+// Form controls. `Forms.tsx` is on antd now, but raw `form-group` /
+// `form-control` / `form-check` / `form-text` markup is still hand-written in
+// the editor tabs, ExplorerCreatePage, UsersIndexPage, GdocsAdd and others,
+// and `admin.scss` also `@extend`s `.form-control`:
 @import "bootstrap/scss/forms";
 @import "bootstrap/scss/buttons";
 @import "bootstrap/scss/button-group";
+// still used by EditorReferencesTab (`input-group-prepend`/`input-group-text`):
 @import "bootstrap/scss/input-group";
 // Chrome and navigation:
 @import "bootstrap/scss/nav";
@@ -30,8 +34,9 @@
 // Components:
 @import "bootstrap/scss/badge";
 @import "bootstrap/scss/alert";
+// still used by EditorReferencesTab, EditorHistoryTab, EditorDataTab and
+// DimensionCard, which interleave `list-group-item`s with `EditableListItem`s:
 @import "bootstrap/scss/list-group";
-@import "bootstrap/scss/modal";
 // Helpers:
 @import "bootstrap/scss/utilities";
 @import "bootstrap/scss/print";
@@ -39,7 +44,9 @@
 // Deliberately not imported, because nothing in the admin uses them:
 //   root (only defines `--blue`-style custom properties, never read via var()),
 //   images, transitions, dropdown, custom-forms, card, jumbotron, progress,
-//   media, close, toasts, tooltip, popover, carousel, spinners.
+//   media, close, toasts, tooltip, popover, carousel, spinners,
+//   modal (`Forms.tsx`'s `Modal` is antd's; the `.modal-header`/`.modal-body`/
+//   `.modal-footer` markup its consumers pass in is styled in `Forms.scss`).
 
 // Our own copy of the parts of Bootstrap's reboot the admin depends on, so that
 // removing `bootstrap/scss/reboot` above stays a small, deliberate step rather

--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -68,6 +68,7 @@
 @import "../packages/@ourworldindata/components/src/styles/typography-constants.scss";
 @import "../packages/@ourworldindata/components/src/styles/typography.scss";
 
+@import "./Forms.scss";
 @import "./GdocsIndexPage.scss";
 @import "./FeaturedMetricsPage.scss";
 @import "./FilesIndexPage.scss";
@@ -268,10 +269,6 @@ $nav-height: 45px;
 }
 
 .EditorFAQ {
-    .modal-dialog {
-        max-width: 800px;
-    }
-
     .modal-body {
         max-height: 80vh;
         overflow-y: scroll;
@@ -429,15 +426,6 @@ $nav-height: 45px;
     margin-bottom: 0.5em;
 }
 
-.catalog-path-field {
-    pre {
-        white-space: pre-wrap;
-        overflow-wrap: anywhere;
-        height: auto;
-        background: #e9ecef;
-    }
-}
-
 .EditorBasicTab {
     .DimensionCard {
         header {
@@ -559,11 +547,6 @@ $nav-height: 45px;
 }
 
 .VariableSelector {
-    .modal-dialog {
-        min-width: 800px;
-        max-width: 90vw;
-    }
-
     .modal-body > div {
         display: flex !important;
         justify-content: space-between;
@@ -602,7 +585,7 @@ $nav-height: 45px;
         min-height: 32px;
     }
 
-    li > .form-check {
+    li > .toggle-field {
         width: 100%;
         margin-bottom: 0;
     }
@@ -839,19 +822,6 @@ $nav-height: 45px;
     user-select: none;
 }
 
-.modalContainer {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: rgba(0, 0, 0, 0.3);
-    z-index: 1040;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-}
-
 .FieldsRow {
     display: flex;
     align-items: center;
@@ -862,14 +832,6 @@ $nav-height: 45px;
         margin-bottom: 0 !important;
         flex-grow: 1;
         flex-basis: 0;
-    }
-}
-
-.AutoTextField {
-    .input-group-addon {
-        cursor: pointer;
-        padding-left: 8px;
-        padding-top: 6px;
     }
 }
 
@@ -884,6 +846,7 @@ $nav-height: 45px;
     }
 
     .ResetToDefaultButton {
+        height: auto;
         padding: 0;
         font-size: 0.8em;
         color: inherit;
@@ -930,19 +893,6 @@ $nav-height: 45px;
     color: white;
     align-items: center;
     justify-content: center;
-}
-
-.modal {
-    background-color: rgba(0, 0, 0, 0.5);
-    overflow-y: auto;
-}
-
-.errorMessage {
-    // 1 above .ant-modal-mask
-    z-index: 2001;
-    .modal-dialog {
-        max-width: 80%;
-    }
 }
 
 main:not(.ChartEditorPage):not(.GdocsEditPage):not(.MultiDimDetailPage) {
@@ -1590,7 +1540,6 @@ main:not(.ChartEditorPage):not(.GdocsEditPage):not(.MultiDimDetailPage) {
     }
 }
 
-.input-group-append,
 .input-group-prepend {
     .btn {
         z-index: 0;


### PR DESCRIPTION
> _Written by Anthropic Claude Fable 5 — @marcelgerber at the wheel._

**Stacked on #7044.** Phase 1 of the admin's Bootstrap→antd migration: `Forms.tsx` — the shared form kit behind 46 admin files — now renders controlled antd primitives instead of Bootstrap markup. Public APIs (`value`/`onValue`, the MobX `Bind*` wrappers) are unchanged, so call sites don't churn; the `Bind*` and `NumberField` logic is untouched. antd's `<Form>` is deliberately not used — it's uncontrolled and fights MobX two-way binding.

Worth a look in review:
- **Toggle is now an antd Switch** (visual change across many editor panes — intended modernization).
- **SelectField is antd's Select, not a native `<select>`**: a new `selectDisplayValue` prop covers chart-editor fields that relied on a native select displaying its first option when the value matches none (Map indicator, tolerance strategy).
- **Modal is antd's Modal**: mask click/Esc/× dismissal with focus trap, replacing a hand-rolled document click listener. Consumers' `.modal-header/-body/-footer` children keep working via CSS.
- Behavior was pinned by 26 new vitest specs written against the *old* implementation first, then re-run unchanged against the rewrite.

<details><summary>Details</summary>

**Commits:** tests first (`05d4ae278b`, green on old implementation), rewrite (`88cac5ae77`), Bootstrap module pruning (`ee72df56f9`).

**Component mapping:** TextField/TextAreaField → `Input`/`Input.TextArea` with `buttonContent` via `Space.Compact` (antd's Compact uses context, not `cloneElement`, so Tippy-wrapped buttons keep working); NumberField keeps its string-state logic (intermediate `"-"`/`"1."`/`""` never emit NaN) over a plain `Input`; SelectField/SelectGroupsField/NumericSelectField → `Select` with `popupMatchSelectWidth={false}` for narrow editor columns; RadioGroup → `Radio.Group`; Toggle → `Switch` (label is a clickable span wired via `aria-labelledby`, since a wrapping `<label>` can't activate antd's button-based switch); Button → `Button type="link"`; EditableList keeps `<ul>/<li>` with own `.editable-list` classes.

**Modal:** `open` + `footer={null}` + `onCancel`; new optional `width`/`zIndex` props replaced three `.modal-dialog` scss overrides (one-line changes in EditorFAQ, VariableSelector, AdminApp). z-index audit: antd Modal 1100, static confirm 2000, Tippy 9999 — the ColorBox colorpicker still opens above modals; the old `.errorMessage { z-index: 2001 }` hack became `zIndex={2001}` on the fatal-error modal so it also clears confirm dialogs. Only 5 files import Forms' Modal (AdminApp, VariableSelector, EditorFAQ, GdocsIndexPage, UsersIndexPage); the rest use antd's directly.

**SCSS:** new `Forms.scss` (`.form-field__*`, `.toggle-field`, `.editable-list`, `.admin-modal` chrome reimplementing the modal header/body/footer). Deleted from `admin.scss` only rules that exclusively targeted the old internals (`.modalContainer`, BS3-era `.input-group-addon`, modal backdrop, `.catalog-path-field pre`). All `.form-group`/`.form-control`/`.btn` rules stay — raw Bootstrap markup still exists in ~20 files until later phases.

**Bootstrap modules:** deleted `modal` (zero remaining references, grep-verified). Kept `forms` (raw form-control ×16 / form-group ×30 / form-check ×12 in editor tabs, ExplorerCreatePage, UsersIndexPage, …), `input-group` (EditorReferencesTab), `list-group` (EditorReferencesTab, EditorHistoryTab, EditorDataTab, DimensionCard interleave `list-group-item` markup with `EditableListItem`s) — each annotated with `// still used by …` in the import block. Forms.tsx emits both old and new class families (`form-field form-group`) so chart-editor layout rules keying off `.form-group` and mixed lists stay consistent; droppable when those pages migrate.

**Known quirk preserved:** `TextAreaField` doesn't forward `props.onBlur` (so `BindString textarea` onBlur never fires) — pre-existing behavior, kept and commented; several chart-editor call sites pass an onBlur that triggers a save, so changing it is a separate decision.

**Verification:** `yarn typecheck`, oxlint (`--deny-warnings`), oxfmt clean; vitest 2336 passed / 5 skipped including the 26 new Forms specs. Headless-browser QA on a running dev stack: chart editor Basic/Text/Customize/Map/Data tabs, FAQ modal, VariableSelector modal, Users add-user modal, GdocsAdd modal, entity EditableLists, color-scale bins, ColorBox Tippy colorpicker above modals — no new console errors.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
