### PR TITLE
Admin: move all buttons and alerts to antd

### DIFF
--- a/adminSiteClient/CalloutFunctionsPage.tsx
+++ b/adminSiteClient/CalloutFunctionsPage.tsx
@@ -2,7 +2,7 @@ import { useContext, useState, useEffect, useCallback } from "react"
 import { useLocation, useHistory } from "react-router-dom"
 import { AdminAppContext } from "./AdminAppContext.js"
 import { AdminLayout } from "./AdminLayout.js"
-import { Spin } from "antd"
+import { Alert, Button, Spin } from "antd"
 
 type CalloutFunctionsResponse = {
     url: string
@@ -85,9 +85,9 @@ export const CalloutFunctionsPage = () => {
                             placeholder="https://ourworldindata.org/grapher/life-expectancy"
                             className="form-control"
                         />
-                        <button
-                            type="submit"
-                            className="btn btn-primary"
+                        <Button
+                            type="primary"
+                            htmlType="submit"
                             disabled={isLoading || !chartUrl.trim()}
                         >
                             {isLoading ? (
@@ -95,13 +95,11 @@ export const CalloutFunctionsPage = () => {
                             ) : (
                                 "Get Functions"
                             )}
-                        </button>
+                        </Button>
                     </div>
                 </form>
 
-                {error && (
-                    <div className="alert alert-danger mt-3">{error}</div>
-                )}
+                {error && <Alert className="mt-3" type="error" title={error} />}
 
                 {data && (
                     <div className="CalloutFunctionsPage__results mt-4">
@@ -121,8 +119,9 @@ export const CalloutFunctionsPage = () => {
                                             {fns.map((fn) => (
                                                 <li key={fn}>
                                                     <code>{fn}</code>
-                                                    <button
-                                                        className="btn btn-sm btn-outline-secondary ms-2"
+                                                    <Button
+                                                        className="ms-2"
+                                                        size="small"
                                                         onClick={() =>
                                                             navigator.clipboard.writeText(
                                                                 fn
@@ -131,7 +130,7 @@ export const CalloutFunctionsPage = () => {
                                                         title="Copy to clipboard"
                                                     >
                                                         Copy
-                                                    </button>
+                                                    </Button>
                                                 </li>
                                             ))}
                                         </ul>

--- a/adminSiteClient/ChartEditorView.scss
+++ b/adminSiteClient/ChartEditorView.scss
@@ -1,0 +1,13 @@
+// The mobile/desktop preview toggle underneath the chart preview. Used to be a
+// Bootstrap `.btn-group` sized by a `.ChartEditorPage .btn-group .btn` rule in
+// `admin.scss`; it is an antd `Radio.Group` now, so the width lives here.
+// The rest of `.ChartEditorPage`'s styling still lives in `admin.scss` and gets
+// moved here when the chart editor tabs themselves are migrated.
+.ChartEditorPage__preview-mode {
+    white-space: nowrap;
+
+    .ant-radio-button-wrapper {
+        text-align: center;
+        width: 50px;
+    }
+}

--- a/adminSiteClient/ChartEditorView.tsx
+++ b/adminSiteClient/ChartEditorView.tsx
@@ -63,6 +63,7 @@ import {
     FieldWithDetailReferences,
 } from "./ChartEditorTypes.js"
 import { Dataset, EditorDatabase } from "./EditorDatabase.js"
+import { Radio } from "antd"
 
 export type DetailReferences = Record<FieldWithDetailReferences, string[]>
 
@@ -527,48 +528,34 @@ export class ChartEditorView<
                         <Grapher grapherState={this.grapherState} />
                     </figure>
                     <div>
-                        <div
-                            className="btn-group"
-                            data-toggle="buttons"
-                            style={{ whiteSpace: "nowrap" }}
-                        >
-                            <label
-                                className={
-                                    "btn btn-light" +
-                                    (this.isMobilePreview ? " active" : "")
-                                }
-                                title="Mobile preview"
-                            >
-                                <input
-                                    type="radio"
-                                    onChange={action(() => {
-                                        editor.previewMode = "mobile"
-                                    })}
-                                    name="previewSize"
-                                    id="mobile"
-                                    checked={this.isMobilePreview}
-                                />{" "}
-                                <FontAwesomeIcon icon={faMobile} />
-                            </label>
-                            <label
-                                className={
-                                    "btn btn-light" +
-                                    (!this.isMobilePreview ? " active" : "")
-                                }
-                                title="Desktop preview"
-                            >
-                                <input
-                                    onChange={action(() => {
-                                        editor.previewMode = "desktop"
-                                    })}
-                                    type="radio"
-                                    name="previewSize"
-                                    id="desktop"
-                                    checked={!this.isMobilePreview}
-                                />{" "}
-                                <FontAwesomeIcon icon={faDesktop} />
-                            </label>
-                        </div>
+                        <Radio.Group
+                            className="ChartEditorPage__preview-mode"
+                            optionType="button"
+                            buttonStyle="solid"
+                            value={this.isMobilePreview ? "mobile" : "desktop"}
+                            onChange={action((event) => {
+                                editor.previewMode = event.target
+                                    .value as typeof editor.previewMode
+                            })}
+                            options={[
+                                {
+                                    value: "mobile",
+                                    label: (
+                                        <span title="Mobile preview">
+                                            <FontAwesomeIcon icon={faMobile} />
+                                        </span>
+                                    ),
+                                },
+                                {
+                                    value: "desktop",
+                                    label: (
+                                        <span title="Desktop preview">
+                                            <FontAwesomeIcon icon={faDesktop} />
+                                        </span>
+                                    ),
+                                },
+                            ]}
+                        />
                         <div
                             className="form-group d-inline-block"
                             style={{ width: 250, marginLeft: 15 }}

--- a/adminSiteClient/ChartList.tsx
+++ b/adminSiteClient/ChartList.tsx
@@ -26,7 +26,7 @@ import {
     highlightFunctionForSearchWords,
 } from "../adminShared/search.js"
 import { TextField } from "./Forms.js"
-import { Tooltip } from "antd"
+import { Button, Tooltip } from "antd"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faInfoCircle } from "@fortawesome/free-solid-svg-icons"
 import { deleteChart } from "./ChartEditor.js"
@@ -356,12 +356,9 @@ export class ChartList extends React.Component<ChartListProps> {
                     </tbody>
                 </table>
                 {hasMoreCharts && (
-                    <button
-                        className="btn btn-secondary"
-                        onClick={this.onShowMore}
-                    >
+                    <Button onClick={this.onShowMore}>
                         Show more charts...
-                    </button>
+                    </Button>
                 )}
             </div>
         )

--- a/adminSiteClient/ChartRow.tsx
+++ b/adminSiteClient/ChartRow.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 import { observer } from "mobx-react"
 import { action, runInAction, makeObservable } from "mobx"
 import * as lodash from "lodash-es"
-import { Link } from "./Link.js"
+import { LinkButton } from "./Link.js"
 import { Timeago } from "./Forms.js"
 import { EditableTags } from "./EditableTags.js"
 import { AdminAppContext, AdminAppContextType } from "./AdminAppContext.js"
@@ -22,7 +22,7 @@ import {
     copyToClipboard,
     excludeUndefined,
 } from "@ourworldindata/utils"
-import { Dropdown } from "antd"
+import { Button, Dropdown } from "antd"
 import {
     getTagGraphRolesById,
     MinimalTagWithMetadata,
@@ -178,12 +178,9 @@ export class ChartRow extends React.Component<ChartRowProps> {
                 <td>{chart.narrativeChartsCount?.toLocaleString() ?? "0"}</td>
                 <td>{chart.referencesCount?.toLocaleString() ?? "0"}</td>
                 <td>
-                    <Link
-                        to={`/charts/${chart.id}/edit`}
-                        className="btn btn-primary"
-                    >
+                    <LinkButton type="primary" to={`/charts/${chart.id}/edit`}>
                         Edit
-                    </Link>
+                    </LinkButton>
                     <Dropdown.Button
                         className="mt-1"
                         onClick={() =>
@@ -203,12 +200,13 @@ export class ChartRow extends React.Component<ChartRowProps> {
                     </Dropdown.Button>
                 </td>
                 <td>
-                    <button
-                        className="btn btn-danger"
+                    <Button
+                        color="danger"
+                        variant="solid"
                         onClick={() => this.props.onDelete(chart)}
                     >
                         Delete
-                    </button>
+                    </Button>
                 </td>
             </tr>
         )

--- a/adminSiteClient/DatasetEditPage.tsx
+++ b/adminSiteClient/DatasetEditPage.tsx
@@ -658,11 +658,13 @@ class DatasetEditor extends Component<DatasetEditorProps> {
                                     />
                                 </div>
                             </div>
-                            <input
-                                type="submit"
-                                className="btn btn-success"
-                                value="Update dataset"
-                            />
+                            <Button
+                                color="green"
+                                variant="solid"
+                                htmlType="submit"
+                            >
+                                Update dataset
+                            </Button>
                         </form>
 
                         {/* ORIGINS */}
@@ -722,14 +724,14 @@ class DatasetEditor extends Component<DatasetEditorProps> {
                             )}
                         />
                         {filteredVariables.length > this.maxVisibleRows && (
-                            <button
-                                className="btn btn-secondary mt-3"
+                            <Button
+                                className="mt-3"
                                 onClick={action(() => {
                                     this.maxVisibleRows += 200
                                 })}
                             >
                                 Show more indicators...
-                            </button>
+                            </Button>
                         )}
                     </section>
                 )
@@ -737,12 +739,13 @@ class DatasetEditor extends Component<DatasetEditorProps> {
             case "charts":
                 return (
                     <section>
-                        <button
-                            className="btn btn-primary float-right"
+                        <Button
+                            className="float-right"
+                            type="primary"
                             onClick={() => this.republishCharts()}
                         >
                             Republish all charts
-                        </button>
+                        </Button>
                         <h3>Charts</h3>
                         <ChartList charts={dataset.charts} />
                     </section>
@@ -797,8 +800,9 @@ class DatasetEditor extends Component<DatasetEditorProps> {
                                         </code>
                                     </p>
                                 )}
-                                <button
-                                    className="btn btn-outline-danger"
+                                <Button
+                                    color="danger"
+                                    variant="outlined"
                                     onClick={() => this.archive()}
                                     disabled={
                                         dataset.charts &&
@@ -806,7 +810,7 @@ class DatasetEditor extends Component<DatasetEditorProps> {
                                     }
                                 >
                                     Archive dataset
-                                </button>
+                                </Button>
                             </>
                         )}
                     </section>

--- a/adminSiteClient/DatasetsIndexPage.tsx
+++ b/adminSiteClient/DatasetsIndexPage.tsx
@@ -13,6 +13,7 @@ import {
     highlightFunctionForSearchWords,
     SearchWord,
 } from "../adminShared/search.js"
+import { Button } from "antd"
 
 @observer
 export class DatasetsIndexPage extends Component {
@@ -103,12 +104,9 @@ export class DatasetsIndexPage extends Component {
                         searchHighlight={highlight}
                     />
                     {!searchInput && (
-                        <button
-                            className="btn btn-secondary"
-                            onClick={this.onShowMore}
-                        >
+                        <Button onClick={this.onShowMore}>
                             Show more datasets...
-                        </button>
+                        </Button>
                     )}
                 </main>
             </AdminLayout>

--- a/adminSiteClient/DeployStatusPage.tsx
+++ b/adminSiteClient/DeployStatusPage.tsx
@@ -9,6 +9,7 @@ import { AdminLayout } from "./AdminLayout.js"
 import { AdminAppContext, AdminAppContextType } from "./AdminAppContext.js"
 import { Deploy, DeployStatus } from "@ourworldindata/utils"
 import { Timeago } from "./Forms.js"
+import { Button } from "antd"
 
 const statusLabel: Record<DeployStatus, string> = {
     [DeployStatus.queued]: "Next up",
@@ -55,9 +56,7 @@ export class DeployStatusPage extends Component {
                 <main className="DeploysPage">
                     <div className="topbar">
                         <h2>Deploy status</h2>
-                        <button
-                            className="btn btn-secondary"
-                            type="button"
+                        <Button
                             disabled={!this.canManuallyDeploy}
                             onClick={async () => {
                                 this.canManuallyDeploy = false
@@ -66,7 +65,7 @@ export class DeployStatusPage extends Component {
                             }}
                         >
                             Manually enqueue a deploy
-                        </button>
+                        </Button>
                     </div>
                     {this.deploys.length > 0 ? (
                         <table className="DeploysTable">

--- a/adminSiteClient/EditableTags.scss
+++ b/adminSiteClient/EditableTags.scss
@@ -1,0 +1,7 @@
+// The "Suggest" / "Edit tags" actions next to a row of tag badges. They are
+// antd link buttons now, which bring their own icon gap and focus ring, so the
+// only thing left from the `admin.scss` rule this replaces is the tighter
+// horizontal padding that keeps them close to the badges.
+.EditableTags__action {
+    padding-inline: 6px;
+}

--- a/adminSiteClient/EditableTags.tsx
+++ b/adminSiteClient/EditableTags.tsx
@@ -18,6 +18,7 @@ import {
 import { AdminAppContext, AdminAppContextType } from "./AdminAppContext.js"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faEdit, faWandMagicSparkles } from "@fortawesome/free-solid-svg-icons"
+import { Button } from "antd"
 
 interface TaggableItem {
     id?: number
@@ -189,26 +190,30 @@ export class EditableTags extends React.Component<EditableTagsProps> {
                     {!disabled && (
                         <>
                             {hasSuggestionsSupport && (
-                                <button
-                                    className="btn btn-link EditableTags__action"
+                                <Button
+                                    type="link"
+                                    className="EditableTags__action"
+                                    icon={
+                                        <FontAwesomeIcon
+                                            icon={faWandMagicSparkles}
+                                        />
+                                    }
                                     onClick={this.onSuggest}
                                 >
-                                    <FontAwesomeIcon
-                                        icon={faWandMagicSparkles}
-                                    />
                                     Suggest
-                                </button>
+                                </Button>
                             )}
-                            <button
-                                className="btn btn-link EditableTags__action"
+                            <Button
+                                type="link"
+                                className="EditableTags__action"
+                                icon={<FontAwesomeIcon icon={faEdit} />}
                                 onClick={(event) => {
                                     this.onToggleEdit()
                                     event.stopPropagation()
                                 }}
                             >
-                                <FontAwesomeIcon icon={faEdit} />
                                 Edit tags
-                            </button>
+                            </Button>
                         </>
                     )}
                 </div>

--- a/adminSiteClient/EditorBasicTab.tsx
+++ b/adminSiteClient/EditorBasicTab.tsx
@@ -67,7 +67,7 @@ import { SortableList } from "./SortableList.js"
 import { CodeSnippet, GrapherTabIcon } from "@ourworldindata/components"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faFile, faArrowsUpDown } from "@fortawesome/free-solid-svg-icons"
-import { Tag } from "antd"
+import { Button, Tag } from "antd"
 
 interface DimensionSlotViewProps<Editor> {
     slot: DimensionSlot
@@ -354,13 +354,14 @@ export class DimensionSlotView<
                 <div className="DimensionSlotHeader">
                     <h5>{slot.name}</h5>
                     {showSwapButton && (
-                        <button
-                            className="btn btn-sm"
+                        <Button
+                            size="small"
+                            icon={<FontAwesomeIcon icon={faArrowsUpDown} />}
                             onClick={onSwapXAndY}
                             title="Swap X and Y axes"
                         >
-                            <FontAwesomeIcon icon={faArrowsUpDown} /> Swap axes
-                        </button>
+                            Swap axes
+                        </Button>
                     )}
                 </div>
                 <SortableList<SortableListItemType>

--- a/adminSiteClient/EditorColorScaleSection.tsx
+++ b/adminSiteClient/EditorColorScaleSection.tsx
@@ -4,7 +4,7 @@ import * as React from "react"
 import { Component, Fragment } from "react"
 import { action, computed, runInAction, makeObservable } from "mobx"
 import { observer } from "mobx-react"
-import { Select } from "antd"
+import { Button, Select } from "antd"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faPlus, faMinus } from "@fortawesome/free-solid-svg-icons"
 import {
@@ -121,12 +121,9 @@ class ColorLegendSection extends Component<ColorLegendSectionProps> {
                         ))}
                     </EditableList>
                 ) : (
-                    <button
-                        className="btn btn-primary"
-                        onClick={this.onManualBins}
-                    >
+                    <Button type="primary" onClick={this.onManualBins}>
                         Assign custom labels
-                    </button>
+                    </Button>
                 )}
             </Section>
         )

--- a/adminSiteClient/EditorDataTab.scss
+++ b/adminSiteClient/EditorDataTab.scss
@@ -1,0 +1,84 @@
+// Moved out of `admin.scss` when the tab's buttons were migrated to antd. The
+// `.btn { font-size: 0.85rem; padding: 0.25rem 0.5rem }` rules that used to sit
+// inside the button rows are gone: those buttons are antd `size="small"` now.
+.EditorDataTab {
+    ul.excludedEntities,
+    ul.includedEntities {
+        padding: 0;
+
+        li {
+            list-style-type: none;
+            display: inline-flex;
+            align-items: center;
+            padding: 1em;
+            background: white;
+            border-radius: 0.5em;
+            margin-right: 0.5em;
+        }
+
+        .clickable {
+            margin-right: 0.2em;
+        }
+    }
+
+    .EditorDataTab__clear-selection {
+        margin-bottom: 0.7rem;
+    }
+
+    .QuickAddSection {
+        margin-bottom: 1rem;
+
+        .quick-add-label {
+            font-size: 0.85rem;
+            color: #666;
+            white-space: nowrap;
+            padding-top: 0.3rem; // align with button text
+
+            .quick-add-hint {
+                font-size: 0.8rem;
+                color: #999;
+            }
+        }
+
+        .quick-add-buttons {
+            margin-top: 0.3rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+        }
+    }
+
+    .AddPeersSection {
+        margin-top: 1rem;
+        padding: 0.75rem;
+        background: #fdfdfd;
+        border-radius: 3px;
+        border: 1px solid #e9ecef;
+
+        .add-peers-header {
+            font-size: 0.9rem;
+            margin-bottom: 0.5rem;
+
+            .add-peers-country-select {
+                display: inline-block;
+                width: auto;
+                font-weight: 600;
+                padding: 0.1rem 0.4rem;
+                font-size: 0.9rem;
+            }
+        }
+
+        .add-peers-buttons {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+        }
+    }
+
+    .SelectionResetButtons {
+        display: flex;
+        justify-content: flex-end;
+        gap: 0.5rem;
+        margin-top: 0.75rem;
+    }
+}

--- a/adminSiteClient/EditorDataTab.tsx
+++ b/adminSiteClient/EditorDataTab.tsx
@@ -4,6 +4,7 @@ import { getRegionByName, checkIsCountry } from "@ourworldindata/utils"
 import { computed, action, observable, makeObservable } from "mobx"
 import { observer } from "mobx-react"
 import cx from "clsx"
+import { Button } from "antd"
 import {
     EntitySelectionMode,
     MissingDataStrategy,
@@ -228,23 +229,24 @@ class QuickAddSection extends React.Component<{
                 </span>
                 <div className="quick-add-buttons">
                     {this.availablePresets.map(({ preset, entities }) => (
-                        <button
+                        <Button
                             key={preset.id}
-                            className="btn btn-outline-secondary"
+                            size="small"
                             onClick={() => this.onSelectPreset(entities)}
                             title={`Replace current selection with ${preset.description}`}
                         >
                             {preset.label}
-                        </button>
+                        </Button>
                     ))}
                     {this.shouldShowDataRangeButton && (
-                        <button
-                            className="btn btn-outline-secondary"
+                        <Button
+                            size="small"
+                            icon={<FontAwesomeIcon icon={faDice} />}
                             onClick={this.onSetDataRange}
                             title="Replace current selection with countries representing the data range. Click multiple times for different results."
                         >
-                            <FontAwesomeIcon icon={faDice} /> Data range
-                        </button>
+                            Data range
+                        </Button>
                     )}
                 </div>
             </div>
@@ -432,37 +434,22 @@ class AddPeersSection extends React.Component<{
                     :
                 </div>
                 <div className="add-peers-buttons">
-                    <button
-                        className="btn btn-outline-secondary"
-                        onClick={this.onAddParentRegionPeers}
-                    >
+                    <Button size="small" onClick={this.onAddParentRegionPeers}>
                         + Parent regions
-                    </button>
-                    <button
-                        className="btn btn-outline-secondary"
-                        onClick={this.onAddGdpPerCapitaPeers}
-                    >
+                    </Button>
+                    <Button size="small" onClick={this.onAddGdpPerCapitaPeers}>
                         + Similar by GDP
-                    </button>
-                    <button
-                        className="btn btn-outline-secondary"
-                        onClick={this.onAddPopulationPeers}
-                    >
+                    </Button>
+                    <Button size="small" onClick={this.onAddPopulationPeers}>
                         + Similar by population
-                    </button>
-                    <button
-                        className="btn btn-outline-secondary"
-                        onClick={this.onAddNeighborsPeers}
-                    >
+                    </Button>
+                    <Button size="small" onClick={this.onAddNeighborsPeers}>
                         + Neighbors
-                    </button>
+                    </Button>
                     {this.shouldShowDataRangeButton && (
-                        <button
-                            className="btn btn-outline-secondary"
-                            onClick={this.onAddDataRangePeers}
-                        >
+                        <Button size="small" onClick={this.onAddDataRangePeers}>
                             + Data range
-                        </button>
+                        </Button>
                     )}
                 </div>
             </div>
@@ -570,22 +557,21 @@ export class EntitySelectionSection extends React.Component<{
                             .map((key) => ({ value: key }))}
                     />
                     {editor.canPropertyBeInherited("selectedEntityNames") && (
-                        <button
-                            className="btn btn-outline-secondary"
-                            type="button"
+                        <Button
                             style={{ maxWidth: "min-content" }}
                             title="Reset to parent selection"
+                            icon={
+                                <FontAwesomeIcon
+                                    icon={
+                                        isEntitySelectionInherited
+                                            ? faLink
+                                            : faUnlink
+                                    }
+                                />
+                            }
                             onClick={this.setEntitySelectionToParentValue}
                             disabled={isEntitySelectionInherited}
-                        >
-                            <FontAwesomeIcon
-                                icon={
-                                    isEntitySelectionInherited
-                                        ? faLink
-                                        : faUnlink
-                                }
-                            />
-                        </button>
+                        />
                     )}
                 </FieldsRow>
                 <QuickAddSection editor={editor} />
@@ -610,22 +596,22 @@ export class EntitySelectionSection extends React.Component<{
                 <div className="SelectionResetButtons">
                     {this.liveSelection.length > 0 &&
                         this.isSelectionDifferentFromLive && (
-                            <button
-                                className="btn btn-secondary"
+                            <Button
+                                size="small"
                                 onClick={this.onResetToLive}
                                 title="Reset to the published selection"
                             >
                                 Reset to live
-                            </button>
+                            </Button>
                         )}
                     {!selection.isEmpty && (
-                        <button
-                            className="btn btn-secondary"
+                        <Button
+                            size="small"
                             onClick={this.onClearSelection}
                             title="Clear current selection"
                         >
                             Clear
-                        </button>
+                        </Button>
                     )}
                 </div>
                 {isEntitySelectionInherited && (
@@ -708,18 +694,17 @@ export class FocusSection extends React.Component<{
                             .map((key) => ({ value: key }))}
                     />
                     {editor.canPropertyBeInherited("focusedSeriesNames") && (
-                        <button
-                            className="btn btn-outline-secondary"
-                            type="button"
+                        <Button
                             style={{ maxWidth: "min-content" }}
                             title="Reset to parent focus"
+                            icon={
+                                <FontAwesomeIcon
+                                    icon={isFocusInherited ? faLink : faUnlink}
+                                />
+                            }
                             onClick={this.setFocusedSeriesNamesToParentValue}
                             disabled={isFocusInherited}
-                        >
-                            <FontAwesomeIcon
-                                icon={isFocusInherited ? faLink : faUnlink}
-                            />
-                        </button>
+                        />
                     )}
                 </FieldsRow>
                 {focusedSeriesNames.map((seriesName) => (
@@ -992,12 +977,13 @@ class EntityFilterSection<
                     </ul>
                 )}
                 {this.includedEntityNames && (
-                    <button
-                        className="btn btn-light btn-clear-selection"
+                    <Button
+                        className="EditorDataTab__clear-selection"
+                        icon={<FontAwesomeIcon icon={faTrash} />}
                         onClick={this.onClearIncludedEntities}
                     >
-                        <FontAwesomeIcon icon={faTrash} /> Clear start selection
-                    </button>
+                        Clear start selection
+                    </Button>
                 )}
                 <SelectField
                     label="Exclude individual entities"
@@ -1026,12 +1012,13 @@ class EntityFilterSection<
                     </ul>
                 )}
                 {this.excludedEntityNames && (
-                    <button
-                        className="btn btn-light btn-clear-selection"
+                    <Button
+                        className="EditorDataTab__clear-selection"
+                        icon={<FontAwesomeIcon icon={faTrash} />}
                         onClick={this.onClearExcludedEntities}
                     >
-                        <FontAwesomeIcon icon={faTrash} /> Clear exclude list
-                    </button>
+                        Clear exclude list
+                    </Button>
                 )}
             </Section>
         )

--- a/adminSiteClient/EditorDebugTab.tsx
+++ b/adminSiteClient/EditorDebugTab.tsx
@@ -10,7 +10,7 @@ import {
     mergeGrapherConfigs,
 } from "@ourworldindata/utils"
 import YAML from "yaml"
-import { Modal, notification } from "antd"
+import { Button, Modal, notification, Space } from "antd"
 import { AbstractChartEditor } from "./AbstractChartEditor.js"
 import {
     NarrativeChartEditor,
@@ -112,12 +112,13 @@ class EditorDebugTabForChart extends Component<{
                         className="form-control"
                         value={YAML.stringify(patchConfig)}
                     />
-                    <button
-                        className="btn btn-primary mt-2"
+                    <Button
+                        className="mt-2"
+                        type="primary"
                         onClick={this.copyYamlToClipboard}
                     >
                         Copy YAML for ETL
-                    </button>
+                    </Button>
                 </Section>
 
                 {parentIndicatorId && (
@@ -284,21 +285,19 @@ class EditorDebugTabForNarrativeChart extends Component<{
                         className="form-control"
                         value={YAML.stringify(patchConfig)}
                     />
-                    <button
-                        className="btn btn-primary mt-2"
-                        onClick={this.copyYamlToClipboard}
-                    >
-                        Copy YAML for ETL
-                    </button>
+                    <Space className="mt-2" wrap>
+                        <Button
+                            type="primary"
+                            onClick={this.copyYamlToClipboard}
+                        >
+                            Copy YAML for ETL
+                        </Button>
+                        <Button onClick={() => (this.diffModalOpen = true)}>
+                            Show diff to parent chart
+                        </Button>
+                    </Space>
 
                     {this.diffModal}
-
-                    <button
-                        className="btn btn-secondary mt-2"
-                        onClick={() => (this.diffModalOpen = true)}
-                    >
-                        Show diff to parent chart
-                    </button>
                 </Section>
 
                 <Section name="Parent chart">

--- a/adminSiteClient/EditorExportTab.tsx
+++ b/adminSiteClient/EditorExportTab.tsx
@@ -338,37 +338,34 @@ export class EditorExportTab<
 
                 <Section name="Export static chart">
                     <div className="DownloadButtons">
-                        <button
-                            className="btn btn-primary"
+                        <Button
+                            type="primary"
+                            icon={<FontAwesomeIcon icon={faDownload} />}
                             onClick={this.onDownloadPNG}
                         >
-                            {<FontAwesomeIcon icon={faDownload} />} Download PNG
-                        </button>
-                        <button
-                            className="btn btn-primary"
+                            Download PNG
+                        </Button>
+                        <Button
+                            type="primary"
+                            icon={<FontAwesomeIcon icon={faDownload} />}
                             onClick={this.onDownloadSVG}
                         >
-                            {<FontAwesomeIcon icon={faDownload} />} Download SVG
-                        </button>
+                            Download SVG
+                        </Button>
                     </div>
                 </Section>
 
                 {/* Link to Wizard dataset preview */}
                 {this.grapherState.isPublished && (
                     <Section name="Animate chart">
-                        <a
+                        <Button
                             href={chartAnimationUrl.toString()}
                             target="_blank"
-                            className="btn btn-tertiary"
                             rel="noopener"
+                            icon={<FontAwesomeIcon icon={faHatWizard} />}
                         >
-                            <Button
-                                type="default"
-                                icon={<FontAwesomeIcon icon={faHatWizard} />}
-                            >
-                                Animate with Wizard
-                            </Button>
-                        </a>
+                            Animate with Wizard
+                        </Button>
                     </Section>
                 )}
             </div>

--- a/adminSiteClient/EditorHistoryTab.tsx
+++ b/adminSiteClient/EditorHistoryTab.tsx
@@ -3,7 +3,7 @@ import { observer } from "mobx-react"
 import { ChartEditor, Log } from "./ChartEditor.js"
 import { Timeago } from "./Forms.js"
 import { computed, observable, makeObservable } from "mobx"
-import { Modal } from "antd"
+import { Button, Modal } from "antd"
 import ReactDiffViewer, { DiffMethod } from "react-diff-viewer-continued"
 
 function LogCompareModal({
@@ -99,12 +99,11 @@ class LogRenderer extends Component<LogRendererProps> {
                 <span>{title}</span>
                 <div className="d-flex" style={{ gap: 6 }}>
                     {hasCompareButton && (
-                        <button
-                            className="btn btn-secondary"
+                        <Button
                             onClick={() => (this.isCompareModalOpen = true)}
                         >
                             Compare <br /> to previous
-                        </button>
+                        </Button>
                     )}
                 </div>
             </li>

--- a/adminSiteClient/EditorMapTab.tsx
+++ b/adminSiteClient/EditorMapTab.tsx
@@ -17,7 +17,7 @@ import {
     mappableCountries,
     ToleranceStrategy,
 } from "@ourworldindata/utils"
-import { Select } from "antd"
+import { Button, Select } from "antd"
 import { action, computed, makeObservable } from "mobx"
 import { observer } from "mobx-react"
 import * as React from "react"
@@ -289,14 +289,12 @@ class InheritanceSection<Editor extends AbstractChartEditor> extends Component<{
 
                 {!areMapSettingsInherited && (
                     <div className="mt-2">
-                        <button
-                            className="btn btn-outline-secondary"
-                            type="button"
+                        <Button
+                            icon={<FontAwesomeIcon icon={faLink} />}
                             onClick={this.resetToParent}
                         >
-                            <FontAwesomeIcon icon={faLink} className="mr-2" />
                             Reset all map settings
-                        </button>
+                        </Button>
                     </div>
                 )}
             </Section>

--- a/adminSiteClient/EditorReferencesTab.tsx
+++ b/adminSiteClient/EditorReferencesTab.tsx
@@ -27,7 +27,7 @@ import {
 import { ReuploadImageForDataInsightModal } from "./ReuploadImageForDataInsightModal.js"
 import { ImageUploadResponse } from "./imagesHelpers.js"
 import { DataInsightMinimalInformation } from "../adminShared/AdminTypes.js"
-import { notification } from "antd"
+import { Alert, Button, notification } from "antd"
 import { getCanonicalUrl } from "@ourworldindata/components"
 
 const BASE_URL = BAKED_GRAPHER_URL.replace(/^https?:\/\//, "")
@@ -355,18 +355,16 @@ class AddRedirectForm<Editor extends AbstractChartEditor> extends Component<
                     />
                 </div>
                 <div className="text-right mb-3">
-                    <button
-                        className="btn btn-primary"
-                        type="submit"
+                    <Button
+                        type="primary"
+                        htmlType="submit"
                         disabled={!this.slug || this.isLoading}
                     >
                         Add redirect
-                    </button>
+                    </Button>
                 </div>
                 {this.errorMessage && (
-                    <div className="alert alert-danger">
-                        {this.errorMessage}
-                    </div>
+                    <Alert type="error" title={this.errorMessage} />
                 )}
             </form>
         )
@@ -574,14 +572,13 @@ const ReferencesDataInsights = (props: {
                                     <strong>{dataInsight.title}</strong>
                                 </a>
                                 {props.canReuploadImage?.(dataInsight) && (
-                                    <button
-                                        className="btn btn-secondary"
+                                    <Button
                                         onClick={() =>
                                             setDataInsightForUpload(dataInsight)
                                         }
                                     >
                                         Upload static export as DI image
-                                    </button>
+                                    </Button>
                                 )}
                             </li>
                         </Fragment>

--- a/adminSiteClient/ExplorerCreatePage.tsx
+++ b/adminSiteClient/ExplorerCreatePage.tsx
@@ -6,7 +6,6 @@ import {
     slugify,
     toRectangularMatrix,
 } from "@ourworldindata/utils"
-import classNames from "clsx"
 import Handsontable from "handsontable"
 import { registerAllModules } from "handsontable/registry"
 import { action, computed, observable, makeObservable } from "mobx"
@@ -29,6 +28,7 @@ import {
 } from "./ExplorerCommands.js"
 import { AdminAppContext, AdminAppContextType } from "./AdminAppContext.js"
 import { ENV } from "../settings/clientSettings.js"
+import { Button } from "antd"
 
 const RESERVED_NAMES = [DefaultNewExplorerSlug, "index", "new", "create"] // don't allow authors to save explorers with these names, otherwise might create some annoying situations.
 
@@ -245,19 +245,19 @@ export class ExplorerCreatePage extends Component<ExplorerCreatePageProps> {
         const buttons = []
 
         buttons.push(
-            <button
+            <Button
                 key="save"
+                type="primary"
                 disabled={!isModified && !isNewFile}
-                className={classNames("btn", "btn-primary")}
                 onClick={this.onSave}
                 title="Saves explorer"
             >
                 Save
-            </button>
+            </Button>
         )
 
         buttons.push(
-            <button
+            <Button
                 key="saveAs"
                 disabled={isNewFile}
                 title={
@@ -265,23 +265,21 @@ export class ExplorerCreatePage extends Component<ExplorerCreatePageProps> {
                         ? "You need to save this file first."
                         : "Saves as a new explorer"
                 }
-                className={classNames("btn", "btn-secondary")}
                 onClick={this.saveAs}
             >
                 Save As
-            </button>
+            </Button>
         )
 
         buttons.push(
-            <button
+            <Button
                 key="clear"
                 disabled={!isModified}
                 title={isModified ? "" : "No changes"}
-                className={classNames("btn", "btn-secondary")}
                 onClick={this.clearChanges}
             >
                 Clear Changes
-            </button>
+            </Button>
         )
 
         const modifiedMessage = isModified

--- a/adminSiteClient/ExplorerTagsPage.tsx
+++ b/adminSiteClient/ExplorerTagsPage.tsx
@@ -16,6 +16,7 @@ import {
     MinimalTagWithMetadata,
 } from "./TagGraphMetadata.js"
 import cx from "clsx"
+import { Button } from "antd"
 
 type ExplorerWithTags = {
     slug: string
@@ -123,8 +124,9 @@ export class ExplorerTagsPage extends Component {
                                             />
                                         </td>
                                         <td>
-                                            <button
-                                                className="btn btn-danger"
+                                            <Button
+                                                color="danger"
+                                                variant="solid"
                                                 onClick={() =>
                                                     this.deleteExplorerTags(
                                                         explorer.slug
@@ -132,7 +134,7 @@ export class ExplorerTagsPage extends Component {
                                                 }
                                             >
                                                 Delete
-                                            </button>
+                                            </Button>
                                         </td>
                                     </tr>
                                 )
@@ -181,8 +183,8 @@ export class ExplorerTagsPage extends Component {
                                     />
                                 </td>
                                 <td>
-                                    <button
-                                        className="btn btn-primary"
+                                    <Button
+                                        type="primary"
                                         disabled={
                                             !this.newExplorerSlug ||
                                             !this.newExplorerTags.length
@@ -191,7 +193,7 @@ export class ExplorerTagsPage extends Component {
                                         onClick={() => this.saveNewExplorer()}
                                     >
                                         Save
-                                    </button>
+                                    </Button>
                                 </td>
                             </tr>
                         </tbody>

--- a/adminSiteClient/ExplorersListPage.tsx
+++ b/adminSiteClient/ExplorersListPage.tsx
@@ -25,6 +25,7 @@ import {
 import { BAKED_BASE_URL } from "../settings/clientSettings.js"
 import { AdminManager } from "./AdminManager.js"
 import { AdminAppContext, AdminAppContextType } from "./AdminAppContext.js"
+import { Button } from "antd"
 
 interface ExplorerRowProps {
     explorer: ExplorerProgram
@@ -124,29 +125,31 @@ class ExplorerRow extends Component<ExplorerRowProps> {
                 </td>
 
                 <td>
-                    <a
+                    <Button
+                        type="primary"
                         href={`${EXPLORERS_ROUTE_FOLDER}/${slug}`}
-                        className="btn btn-primary"
                         title={hasEdits ? "*You have local edits" : ""}
                     >
                         Edit{hasEdits ? "*" : ""}
-                    </a>
+                    </Button>
                 </td>
                 <td>
-                    <button
-                        className="btn btn-danger"
+                    <Button
+                        color="danger"
+                        variant="solid"
                         onClick={() => indexPage.togglePublishedStatus(slug)}
                     >
                         {isPublished ? "Unpublish" : "Publish"}
-                    </button>
+                    </Button>
                 </td>
                 <td>
-                    <button
-                        className="btn btn-danger"
+                    <Button
+                        color="danger"
+                        variant="solid"
                         onClick={() => indexPage.deleteExplorer(slug)}
                     >
-                        Delete{" "}
-                    </button>
+                        Delete
+                    </Button>
                 </td>
             </tr>
         )
@@ -321,12 +324,12 @@ export class ExplorersIndexPage extends Component<{
                         </label>
                     </div>
                     {/* <div style={{ textAlign: "right" }}>
-                        <a
-                            className="btn btn-primary"
+                        <Button
+                            type="primary"
                             href={`/admin/${EXPLORERS_ROUTE_FOLDER}/${DefaultNewExplorerSlug}`}
                         >
                             Create
-                        </a>
+                        </Button>
                     </div> */}
                 </div>
                 <ExplorerList

--- a/adminSiteClient/GdocsAdd.tsx
+++ b/adminSiteClient/GdocsAdd.tsx
@@ -7,6 +7,7 @@ import {
     GDOCS_ANNOUNCEMENT_DUPLICATION_TEMPLATE_ID,
 } from "../settings/clientSettings.js"
 import { useGdocsStore } from "./GdocsStoreContext.js"
+import { Button } from "antd"
 
 export const GdocsAdd = ({ onAdd }: { onAdd: (id: string) => void }) => {
     const [documentUrl, setDocumentUrl] = React.useState("")
@@ -89,9 +90,9 @@ export const GdocsAdd = ({ onAdd }: { onAdd: (id: string) => void }) => {
                 </div>
             </div>
             <div className="modal-footer">
-                <button type="submit" className="btn btn-primary">
+                <Button type="primary" htmlType="submit">
                     Add document
-                </button>
+                </Button>
             </div>
         </form>
     )

--- a/adminSiteClient/GdocsIndexPage.scss
+++ b/adminSiteClient/GdocsIndexPage.scss
@@ -77,8 +77,11 @@
     width: 100%;
 }
 
-.gdoc-index__help-link {
-    margin-right: 8px;
+// "Open documentation" / "Add document" sit next to the search bar in a flex
+// row; without this they get squeezed by the full-width filter block and wrap.
+.gdoc-index__actions {
+    flex-shrink: 0;
+    align-self: flex-start;
 }
 
 .gdoc-index__load-more {

--- a/adminSiteClient/GdocsIndexPage.tsx
+++ b/adminSiteClient/GdocsIndexPage.tsx
@@ -18,6 +18,7 @@ import {
     faTriangleExclamation,
 } from "@fortawesome/free-solid-svg-icons"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import { Button, Space } from "antd"
 import {
     DbChartTagJoin,
     OwidGdocType,
@@ -466,28 +467,27 @@ class GdocsIndexPageContent extends React.Component<GdocsIndexPageContentProps> 
                             onToggleGdocTypeFilter={this.onToggleGdocTypeFilter}
                             onPublishStatusChange={this.onPublishStatusChange}
                         />
-                        <div>
-                            <a
-                                className="btn btn-secondary gdoc-index__help-link"
-                                target="_blank"
+                        <Space className="gdoc-index__actions" wrap>
+                            <Button
                                 href="https://docs.google.com/document/d/1OLoTWloy4VecOjKTjB1wLV6tEphHJIMXfexrf1ZYJzU/edit"
+                                target="_blank"
                                 rel="noopener"
+                                icon={<FontAwesomeIcon icon={faQuestion} />}
                             >
-                                <FontAwesomeIcon icon={faQuestion} /> Open
-                                documentation
-                            </a>
-                            <button
-                                className="btn btn-primary"
+                                Open documentation
+                            </Button>
+                            <Button
+                                type="primary"
+                                icon={<FontAwesomeIcon icon={faCirclePlus} />}
                                 onClick={() =>
                                     this.props.history.push(
                                         `${this.props.match.path}/add`
                                     )
                                 }
                             >
-                                <FontAwesomeIcon icon={faCirclePlus} /> Add
-                                document
-                            </button>
-                        </div>
+                                Add document
+                            </Button>
+                        </Space>
                     </div>
 
                     {this.allGdocsToShow
@@ -515,13 +515,9 @@ class GdocsIndexPageContent extends React.Component<GdocsIndexPageContentProps> 
                         </p>
                         {this.props.visibleResultCount <
                             this.allGdocsToShow.length && (
-                            <button
-                                type="button"
-                                className="btn btn-secondary"
-                                onClick={this.props.onLoadMore}
-                            >
+                            <Button onClick={this.props.onLoadMore}>
                                 Load more
-                            </button>
+                            </Button>
                         )}
                     </div>
 

--- a/adminSiteClient/GrapherConfigGridEditor.tsx
+++ b/adminSiteClient/GrapherConfigGridEditor.tsx
@@ -104,6 +104,7 @@ import { EditorColorScaleSection } from "./EditorColorScaleSection.js"
 import { Operation } from "../adminShared/SqlFilterSExpression.js"
 import { CATALOG_URL, DATA_API_URL } from "../settings/clientSettings.js"
 import { SortableList } from "./SortableList.js"
+import { Button } from "antd"
 
 type Disposer = () => void
 
@@ -1312,19 +1313,16 @@ export class GrapherConfigGridEditor extends React.Component<GrapherConfigGridEd
                 <div className="container">{editControl}</div>
                 {hasUncommitedRichEditorChanges ? (
                     <div className="container rich-editor-confirm-buttons">
-                        <button
-                            className="btn btn-primary"
+                        <Button
+                            type="primary"
                             onClick={() => this.commitRichEditorChanges()}
                         >
                             Commit
-                        </button>
+                        </Button>
 
-                        <button
-                            className="btn btn-secondary"
-                            onClick={() => this.cancelRichEditorChanges()}
-                        >
+                        <Button onClick={() => this.cancelRichEditorChanges()}>
                             Cancel
-                        </button>
+                        </Button>
                     </div>
                 ) : null}
             </section>
@@ -1562,14 +1560,13 @@ export class GrapherConfigGridEditor extends React.Component<GrapherConfigGridEd
                             label: item.label,
                         }))}
                     />
-                    <button
-                        className="btn btn-secondary"
+                    <Button
                         onClick={this.onShowOnlyColumnsWithValuesInCurrentRow}
                         title="Show only columns where the current row has a set value"
                         disabled={this.selectedRow === undefined}
                     >
                         Show only columns with values in current row
-                    </button>
+                    </Button>
                     <BindString
                         field="columnFilter"
                         store={this}

--- a/adminSiteClient/IconToggleComponent.tsx
+++ b/adminSiteClient/IconToggleComponent.tsx
@@ -1,5 +1,6 @@
 import type { IconDefinition } from "@fortawesome/fontawesome-common-types"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import { Button } from "antd"
 
 export interface IconToggleProps {
     isOn: boolean
@@ -9,10 +10,11 @@ export interface IconToggleProps {
 }
 
 export const IconToggleComponent = (props: IconToggleProps) => (
-    <button
-        className="btn btn-light btn-sm"
+    <Button
+        size="small"
+        icon={
+            <FontAwesomeIcon icon={props.isOn ? props.onIcon : props.offIcon} />
+        }
         onClick={() => props.onClick(!props.isOn)}
-    >
-        <FontAwesomeIcon icon={props.isOn ? props.onIcon : props.offIcon} />
-    </button>
+    />
 )

--- a/adminSiteClient/Link.tsx
+++ b/adminSiteClient/Link.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
-import { NavLink } from "react-router-dom"
+import { NavLink, useHistory } from "react-router-dom"
+import { Button, ButtonProps } from "antd"
 import { AdminAppContext, AdminAppContextType } from "./AdminAppContext.js"
 
 interface LinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
@@ -17,4 +18,45 @@ export class Link extends React.Component<LinkProps> {
         if (native) return <a href={this.context.admin.url(to)} {...rest} />
         else return <NavLink to={to} {...rest} />
     }
+}
+
+/**
+ * An antd `Button` that navigates within the admin SPA — the replacement for
+ * the `<Link className="btn btn-*">` markup the admin used under Bootstrap.
+ *
+ * antd's `Button` renders a real `<a href>` when given `href`, so this keeps
+ * cmd/ctrl-click, middle-click and "copy link address" working; a plain
+ * left-click is intercepted and handed to React Router so that it stays a
+ * client-side navigation rather than a full page load.
+ */
+export function LinkButton({
+    to,
+    replace,
+    onClick,
+    ...buttonProps
+}: { to: string; replace?: boolean } & Omit<
+    ButtonProps,
+    "href"
+>): React.ReactElement {
+    const history = useHistory()
+    return (
+        <Button
+            href={history.createHref({ pathname: to })}
+            onClick={(event) => {
+                onClick?.(event)
+                const isModified =
+                    event.defaultPrevented ||
+                    event.metaKey ||
+                    event.ctrlKey ||
+                    event.shiftKey ||
+                    event.altKey ||
+                    (event as React.MouseEvent).button !== 0
+                if (isModified) return
+                event.preventDefault()
+                if (replace) history.replace(to)
+                else history.push(to)
+            }}
+            {...buttonProps}
+        />
+    )
 }

--- a/adminSiteClient/MultiDimDetailPage.tsx
+++ b/adminSiteClient/MultiDimDetailPage.tsx
@@ -469,31 +469,14 @@ export function MultiDimDetailPage({ id }: { id: number }) {
                         </Space>
                     </Col>
                     <Col>
-                        {liveUrl ? (
-                            <a
-                                className="ant-btn ant-btn-default"
-                                href={liveUrl}
-                                target="_blank"
-                                rel="noopener"
-                            >
-                                <Space>
-                                    <FontAwesomeIcon icon={faExternalLink} />
-                                    View live
-                                </Space>
-                            </a>
-                        ) : (
-                            <a
-                                className="ant-btn ant-btn-default"
-                                href={previewUrl}
-                                target="_blank"
-                                rel="noopener"
-                            >
-                                <Space>
-                                    <FontAwesomeIcon icon={faExternalLink} />
-                                    View preview
-                                </Space>
-                            </a>
-                        )}
+                        <Button
+                            href={liveUrl ?? previewUrl}
+                            target="_blank"
+                            rel="noopener"
+                            icon={<FontAwesomeIcon icon={faExternalLink} />}
+                        >
+                            {liveUrl ? "View live" : "View preview"}
+                        </Button>
                     </Col>
                 </Row>
 

--- a/adminSiteClient/NarrativeChartNameModal.tsx
+++ b/adminSiteClient/NarrativeChartNameModal.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react"
-import { Form, Input, InputRef, Modal } from "antd"
+import { Alert, Form, Input, InputRef, Modal } from "antd"
 import {
     NARRATIVE_CHART_KEBAB_CASE_ERROR_MSG,
     KEBAB_CASE_REGEX,
@@ -79,12 +79,14 @@ export const NarrativeChartNameModal = (props: {
                     <Input ref={inputRef} />
                 </Form.Item>
                 {props.errorMsg && (
-                    <div
-                        className="alert alert-danger"
-                        style={{ whiteSpace: "pre-wrap" }}
-                    >
-                        {props.errorMsg}
-                    </div>
+                    <Alert
+                        type="error"
+                        title={
+                            <span style={{ whiteSpace: "pre-wrap" }}>
+                                {props.errorMsg}
+                            </span>
+                        }
+                    />
                 )}
             </div>
         </Modal>

--- a/adminSiteClient/RedirectsIndexPage.tsx
+++ b/adminSiteClient/RedirectsIndexPage.tsx
@@ -3,6 +3,7 @@ import { AdminLayout } from "./AdminLayout.js"
 import { FieldsRow } from "./Forms.js"
 import { Link } from "./Link.js"
 import { AdminAppContext } from "./AdminAppContext.js"
+import { Button } from "antd"
 
 interface RedirectListItem {
     id: number
@@ -30,12 +31,13 @@ function RedirectRow({ redirect, onDelete }: RedirectRowProps) {
                 </Link>
             </td>
             <td>
-                <button
-                    className="btn btn-danger"
+                <Button
+                    color="danger"
+                    variant="solid"
                     onClick={() => onDelete(redirect)}
                 >
                     Delete
-                </button>
+                </Button>
             </td>
         </tr>
     )

--- a/adminSiteClient/SaveButtons.scss
+++ b/adminSiteClient/SaveButtons.scss
@@ -1,0 +1,14 @@
+// Footer of the chart editor sidebar: the save/publish/delete row plus the
+// list of blocking editing errors. Moved out of `admin.scss`'s
+// `.ChartEditorPage` block when the buttons were migrated to antd.
+.SaveButtons {
+    padding: 24px;
+}
+
+.SaveButtons__secondary-row {
+    margin-top: 8px;
+}
+
+.SaveButtons__error {
+    margin-top: 8px;
+}

--- a/adminSiteClient/SaveButtons.tsx
+++ b/adminSiteClient/SaveButtons.tsx
@@ -15,6 +15,7 @@ import {
 } from "./NarrativeChartEditor.js"
 import { NarrativeChartNameModal } from "./NarrativeChartNameModal.js"
 import { CreateDataInsightModal } from "./CreateDataInsightModal.js"
+import { Alert, Button, Space } from "antd"
 
 interface SaveButtonsProps<Editor extends AbstractChartEditor> {
     editor: Editor
@@ -107,9 +108,10 @@ class SaveButtonsForChart extends Component<SaveButtonsProps<ChartEditor>> {
 
         return (
             <div className="SaveButtons">
-                <div>
-                    <button
-                        className="btn btn-success"
+                <Space wrap>
+                    <Button
+                        color="green"
+                        variant="solid"
                         onClick={this.onSaveChart}
                         disabled={isSavingDisabled}
                     >
@@ -118,38 +120,39 @@ class SaveButtonsForChart extends Component<SaveButtonsProps<ChartEditor>> {
                             : isNewGrapher
                               ? "Create draft"
                               : "Save draft"}
-                    </button>{" "}
+                    </Button>
                     {!isNewGrapher && (
                         <>
-                            <button
-                                className="btn btn-secondary"
+                            <Button
                                 onClick={this.onSaveAsNew}
                                 disabled={isSavingDisabled}
                             >
                                 Save as new
-                            </button>{" "}
-                            <button
-                                className="btn btn-danger"
+                            </Button>
+                            <Button
+                                color="danger"
+                                variant="solid"
                                 onClick={this.onPublishToggle}
                                 disabled={isSavingDisabled}
                             >
                                 {grapherState.isPublished
                                     ? "Unpublish"
                                     : "Publish"}
-                            </button>{" "}
-                            <button
-                                className="btn btn-danger"
+                            </Button>
+                            <Button
+                                color="danger"
+                                variant="solid"
                                 onClick={this.onDeleteChart}
                             >
                                 Delete
-                            </button>
+                            </Button>
                         </>
                     )}
-                </div>
+                </Space>
                 {!isNewGrapher && (
-                    <div className="mt-2">
-                        <button
-                            className="btn btn-primary"
+                    <div className="SaveButtons__secondary-row">
+                        <Button
+                            type="primary"
                             onClick={() => {
                                 this.isNarrativeChartNameModalOpen = true
                                 this.narrativeChartNameModalError = undefined
@@ -157,7 +160,7 @@ class SaveButtonsForChart extends Component<SaveButtonsProps<ChartEditor>> {
                             disabled={isSavingDisabled}
                         >
                             Save as narrative chart
-                        </button>
+                        </Button>
                     </div>
                 )}
                 <NarrativeChartNameModal
@@ -171,9 +174,12 @@ class SaveButtonsForChart extends Component<SaveButtonsProps<ChartEditor>> {
                 />
                 {grapherState.isReady &&
                     editingErrors.map((error, i) => (
-                        <div key={i} className="alert alert-danger mt-2">
-                            {error}
-                        </div>
+                        <Alert
+                            key={i}
+                            className="SaveButtons__error"
+                            type="error"
+                            title={error}
+                        />
                     ))}
             </div>
         )
@@ -233,49 +239,52 @@ class SaveButtonsForNarrativeChart extends Component<
 
         return (
             <div className="SaveButtons">
-                {isNewGrapher ? (
-                    <button
-                        className="btn btn-success"
-                        onClick={this.onCreateChart}
-                        disabled={isSavingDisabled}
-                    >
-                        Create narrative chart
-                    </button>
-                ) : (
-                    <button
-                        className="btn btn-success"
-                        onClick={this.onSaveChart}
-                        disabled={isSavingDisabled}
-                    >
-                        Save narrative chart
-                    </button>
-                )}{" "}
-                {editor.parentUrl && (
-                    <>
-                        <a
-                            className="btn btn-secondary"
+                <Space wrap>
+                    {isNewGrapher ? (
+                        <Button
+                            color="green"
+                            variant="solid"
+                            onClick={this.onCreateChart}
+                            disabled={isSavingDisabled}
+                        >
+                            Create narrative chart
+                        </Button>
+                    ) : (
+                        <Button
+                            color="green"
+                            variant="solid"
+                            onClick={this.onSaveChart}
+                            disabled={isSavingDisabled}
+                        >
+                            Save narrative chart
+                        </Button>
+                    )}
+                    {editor.parentUrl && (
+                        <Button
                             href={`/admin${editor.parentUrl}`}
                             target="_blank"
                             rel="noopener"
                         >
                             Go to parent chart
-                        </a>{" "}
-                    </>
-                )}
-                {!editor.isNewGrapher && (
-                    <button
-                        className="btn btn-secondary"
-                        onClick={this.onCreateDataInsight}
-                        disabled={isSavingDisabled}
-                    >
-                        Create DI
-                    </button>
-                )}
+                        </Button>
+                    )}
+                    {!editor.isNewGrapher && (
+                        <Button
+                            onClick={this.onCreateDataInsight}
+                            disabled={isSavingDisabled}
+                        >
+                            Create DI
+                        </Button>
+                    )}
+                </Space>
                 {grapherState.isReady &&
                     editingErrors.map((error, i) => (
-                        <div key={i} className="alert alert-danger mt-2">
-                            {error}
-                        </div>
+                        <Alert
+                            key={i}
+                            className="SaveButtons__error"
+                            type="error"
+                            title={error}
+                        />
                     ))}
                 {this.isCreateDataInsightModalOpen && (
                     <CreateDataInsightModal

--- a/adminSiteClient/SourceEditPage.tsx
+++ b/adminSiteClient/SourceEditPage.tsx
@@ -7,6 +7,7 @@ import { AdminAppContext, AdminAppContextType } from "./AdminAppContext.js"
 import { AdminLayout } from "./AdminLayout.js"
 import { BindString, Timeago } from "./Forms.js"
 import { VariableList, VariableListItem } from "./VariableList.js"
+import { Button } from "antd"
 
 interface SourcePageData {
     id: number
@@ -160,12 +161,14 @@ class SourceEditor extends Component<{ source: SourcePageData }> {
                             textarea
                             disabled={true}
                         />
-                        <input
-                            type="submit"
-                            className="btn btn-success"
-                            value="Update source"
+                        <Button
+                            color="green"
+                            variant="solid"
+                            htmlType="submit"
                             disabled={true}
-                        />
+                        >
+                            Update source
+                        </Button>
                     </form>
                 </section>
                 <section>

--- a/adminSiteClient/SourceList.tsx
+++ b/adminSiteClient/SourceList.tsx
@@ -1,4 +1,5 @@
 import { OwidSource } from "@ourworldindata/utils"
+import { Alert } from "antd"
 import { BindString } from "./Forms.js"
 
 const MAX_SOURCES = 10
@@ -10,11 +11,12 @@ export function SourceList({ sources }: { sources: OwidSource[] }) {
     return (
         <div>
             {sources.length > MAX_SOURCES && (
-                <div className="alert alert-warning">
-                    <strong>Warning:</strong> There are {sources.length} sources
-                    for this dataset. Only the first {MAX_SOURCES} will be
-                    displayed.
-                </div>
+                <Alert
+                    type="warning"
+                    showIcon
+                    title="Warning"
+                    description={`There are ${sources.length} sources for this dataset. Only the first ${MAX_SOURCES} will be displayed.`}
+                />
             )}
             {limitedSources.map((source, index) => (
                 <div key={index}>

--- a/adminSiteClient/TagEditPage.tsx
+++ b/adminSiteClient/TagEditPage.tsx
@@ -9,7 +9,7 @@ import { ChartList, ChartListItem } from "./ChartList.js"
 import { TagBadge } from "./TagBadge.js"
 import { MinimalTagWithMetadata } from "./TagGraphMetadata.js"
 import { AdminAppContext, AdminAppContextType } from "./AdminAppContext.js"
-import { AutoComplete } from "antd"
+import { AutoComplete, Button, Space } from "antd"
 
 interface TagPageData {
     id: number
@@ -207,25 +207,27 @@ class TagEditor extends Component<{
                                     : "When enabled, charts with this tag will be indexed in Algolia even without matching a published topic page"
                             }
                         />
-                        <div style={{ marginTop: 16 }}>
-                            <input
-                                type="submit"
+                        <Space style={{ marginTop: 16 }} wrap>
+                            <Button
+                                color="green"
+                                variant="solid"
+                                htmlType="submit"
                                 disabled={!this.isModified || !newtag.name}
-                                className="btn btn-success"
-                                value="Update tag"
-                            />{" "}
+                            >
+                                Update tag
+                            </Button>
                             {tag.datasets.length === 0 &&
                                 tag.children.length === 0 &&
                                 !tag.specialType && (
-                                    <button
-                                        className="btn btn-danger"
-                                        type="button"
+                                    <Button
+                                        color="danger"
+                                        variant="solid"
                                         onClick={() => this.deleteTag()}
                                     >
                                         Delete tag
-                                    </button>
+                                    </Button>
                                 )}
-                        </div>
+                        </Space>
                     </form>
                 </section>
                 {tag.children.length > 0 && (

--- a/adminSiteClient/UserEditPage.tsx
+++ b/adminSiteClient/UserEditPage.tsx
@@ -6,6 +6,7 @@ import { Redirect } from "react-router-dom"
 import { AdminLayout } from "./AdminLayout.js"
 import { AdminAppContext, AdminAppContextType } from "./AdminAppContext.js"
 import { UserIndexMeta } from "./UserMeta.js"
+import { Button } from "antd"
 
 @observer
 export class UserEditPage extends Component<{ userId: number }> {
@@ -42,12 +43,13 @@ export class UserEditPage extends Component<{ userId: number }> {
                         value={user.isActive}
                         onValue={(v) => (user.isActive = v)}
                     />
-                    <button
-                        className="btn btn-success"
+                    <Button
+                        color="green"
+                        variant="solid"
                         onClick={() => this.save()}
                     >
                         Update user
-                    </button>
+                    </Button>
                 </main>
             </AdminLayout>
         )

--- a/adminSiteClient/UsersIndexPage.tsx
+++ b/adminSiteClient/UsersIndexPage.tsx
@@ -2,8 +2,9 @@ import * as React from "react"
 import { observer } from "mobx-react"
 import { observable, action, runInAction, makeObservable } from "mobx"
 
+import { Alert, Button } from "antd"
 import { Modal, Timeago } from "./Forms.js"
-import { Link } from "./Link.js"
+import { LinkButton } from "./Link.js"
 import { AdminLayout } from "./AdminLayout.js"
 import { AdminAppContext, AdminAppContextType } from "./AdminAppContext.js"
 import { UserIndexMeta } from "./UserMeta.js"
@@ -83,17 +84,15 @@ class InviteModal extends React.Component<{ onClose: () => void }> {
                         </div>
                     </div>
                     <div className="modal-footer">
-                        <input
-                            type="submit"
-                            className="btn btn-primary"
-                            value="Add user"
-                        />
+                        <Button type="primary" htmlType="submit">
+                            Add user
+                        </Button>
                     </div>
                     {this.responseSuccess && (
-                        <div className="alert alert-success" role="alert">
-                            User added! They can now log in with their G Suite
-                            account.
-                        </div>
+                        <Alert
+                            type="success"
+                            title="User added! They can now log in with their G Suite account."
+                        />
                     )}
                 </form>
             </Modal>
@@ -151,14 +150,14 @@ export class UsersIndexPage extends React.Component {
                     <div className="topbar">
                         <h2>Users</h2>
                         {isSuperuser && (
-                            <button
+                            <Button
+                                type="primary"
                                 onClick={action(
                                     () => (this.isInviteModal = true)
                                 )}
-                                className="btn btn-primary"
                             >
                                 Add a user
-                            </button>
+                            </Button>
                         )}
                     </div>
                     <table className="table table-bordered">
@@ -189,24 +188,25 @@ export class UsersIndexPage extends React.Component {
                                     )}
                                     {isSuperuser && (
                                         <td>
-                                            <Link
+                                            <LinkButton
+                                                type="primary"
                                                 to={`/users/${user.id}`}
-                                                className="btn btn-primary"
                                             >
                                                 Edit
-                                            </Link>
+                                            </LinkButton>
                                         </td>
                                     )}
                                     {isSuperuser && (
                                         <td>
-                                            <button
-                                                className="btn btn-danger"
+                                            <Button
+                                                color="danger"
+                                                variant="solid"
                                                 onClick={() =>
                                                     this.onDelete(user)
                                                 }
                                             >
                                                 Delete
-                                            </button>
+                                            </Button>
                                         </td>
                                     )}
                                 </tr>

--- a/adminSiteClient/VariableEditPage.tsx
+++ b/adminSiteClient/VariableEditPage.tsx
@@ -11,7 +11,7 @@ import {
 import YAML from "yaml"
 import * as _ from "lodash-es"
 import { AdminLayout } from "./AdminLayout.js"
-import { Link } from "./Link.js"
+import { Link, LinkButton } from "./Link.js"
 import { FieldsRow, TextAreaField, CatalogPathField } from "./Forms.js"
 import {
     OwidVariableWithDataAndSource,
@@ -248,12 +248,11 @@ class VariableEditor extends Component<{
                         <div className="col">
                             <div className="topbar">
                                 <h3>Preview</h3>
-                                <Link
-                                    className="btn btn-secondary"
+                                <LinkButton
                                     to={`/charts/create?${this.configUrlParams}`}
                                 >
                                     Edit as new chart
-                                </Link>
+                                </LinkButton>
                             </div>
                             <Grapher grapherState={this.grapherState} />
                         </div>

--- a/adminSiteClient/VariableSelector.tsx
+++ b/adminSiteClient/VariableSelector.tsx
@@ -15,7 +15,7 @@ import {
     makeObservable,
 } from "mobx"
 import { observer } from "mobx-react"
-import { Select } from "antd"
+import { Button, Select } from "antd"
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faArchive } from "@fortawesome/free-solid-svg-icons"
@@ -449,15 +449,14 @@ export class VariableSelector<
                     </div>
                 </div>
                 <div className="modal-footer">
-                    <button className="btn" onClick={this.onDismiss}>
-                        Close
-                    </button>
-                    <button
-                        className="btn btn-success"
+                    <Button onClick={this.onDismiss}>Close</Button>
+                    <Button
+                        color="green"
+                        variant="solid"
                         onClick={this.onComplete}
                     >
                         Set variable{slot.allowMultiple && "s"}
-                    </button>
+                    </Button>
                 </div>
             </Modal>
         )

--- a/adminSiteClient/VariablesIndexPage.tsx
+++ b/adminSiteClient/VariablesIndexPage.tsx
@@ -17,6 +17,7 @@ import { VariableList, VariableListItem } from "./VariableList.js"
 import { AdminAppContext, AdminAppContextType } from "./AdminAppContext.js"
 import { ETL_WIZARD_URL } from "../settings/clientSettings.js"
 import urljoin from "url-join"
+import { Button } from "antd"
 
 @observer
 export class VariablesIndexPage extends Component {
@@ -116,12 +117,9 @@ export class VariablesIndexPage extends Component {
                         searchHighlight={highlight}
                     />
                     {!searchInput && (
-                        <button
-                            className="btn btn-secondary"
-                            onClick={this.onShowMore}
-                        >
+                        <Button onClick={this.onShowMore}>
                             Show more indicators...
-                        </button>
+                        </Button>
                     )}
                 </main>
             </AdminLayout>

--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -78,6 +78,9 @@
 
 @import "./Forms.scss";
 @import "./AdminLayout.scss";
+@import "./SaveButtons.scss";
+@import "./ChartEditorView.scss";
+@import "./EditorDataTab.scss";
 @import "./AdminSidebar.scss";
 @import "./GdocsIndexPage.scss";
 @import "./FeaturedMetricsPage.scss";
@@ -243,10 +246,6 @@ button {
     display: flex;
     flex-grow: 1;
 
-    .btn-group .btn {
-        width: 50px;
-    }
-
     .form-group > label {
         margin-bottom: 0;
     }
@@ -273,10 +272,6 @@ button {
     .innerForm {
         overflow-y: scroll;
         flex-grow: 1;
-    }
-
-    .SaveButtons {
-        padding: 24px;
     }
 
     > .chart-editor-view {
@@ -592,103 +587,6 @@ button {
 .EditorDataTab {
     .form-group > label {
         margin-bottom: 0.3rem;
-    }
-}
-
-.EditorDataTab {
-    ul.excludedEntities,
-    ul.includedEntities {
-        padding: 0;
-
-        li {
-            list-style-type: none;
-            display: inline-flex;
-            align-items: center;
-            padding: 1em;
-            background: white;
-            border-radius: 0.5em;
-            margin-right: 0.5em;
-        }
-
-        .clickable {
-            margin-right: 0.2em;
-        }
-    }
-
-    .btn-clear-selection {
-        margin-bottom: 0.7rem;
-    }
-
-    .QuickAddSection {
-        margin-bottom: 1rem;
-
-        .quick-add-label {
-            font-size: 0.85rem;
-            color: #666;
-            white-space: nowrap;
-            padding-top: 0.3rem; // align with button text
-
-            .quick-add-hint {
-                font-size: 0.8rem;
-                color: #999;
-            }
-        }
-
-        .quick-add-buttons {
-            margin-top: 0.3rem;
-            display: flex;
-            flex-wrap: wrap;
-            gap: 0.5rem;
-
-            .btn {
-                font-size: 0.85rem;
-                padding: 0.25rem 0.5rem;
-            }
-        }
-    }
-
-    .AddPeersSection {
-        margin-top: 1rem;
-        padding: 0.75rem;
-        background: #fdfdfd;
-        border-radius: 3px;
-        border: 1px solid #e9ecef;
-
-        .add-peers-header {
-            font-size: 0.9rem;
-            margin-bottom: 0.5rem;
-
-            .add-peers-country-select {
-                display: inline-block;
-                width: auto;
-                font-weight: 600;
-                padding: 0.1rem 0.4rem;
-                font-size: 0.9rem;
-            }
-        }
-
-        .add-peers-buttons {
-            display: flex;
-            flex-wrap: wrap;
-            gap: 0.5rem;
-
-            .btn {
-                font-size: 0.85rem;
-                padding: 0.25rem 0.5rem;
-            }
-        }
-    }
-
-    .SelectionResetButtons {
-        display: flex;
-        justify-content: flex-end;
-        gap: 0.5rem;
-        margin-top: 0.75rem;
-
-        .btn {
-            font-size: 0.85rem;
-            padding: 0.25rem 0.5rem;
-        }
     }
 }
 

--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -81,6 +81,7 @@
 @import "./SaveButtons.scss";
 @import "./ChartEditorView.scss";
 @import "./EditorDataTab.scss";
+@import "./EditableTags.scss";
 @import "./AdminSidebar.scss";
 @import "./GdocsIndexPage.scss";
 @import "./FeaturedMetricsPage.scss";
@@ -956,16 +957,6 @@ main:not(.ChartEditorPage):not(.GdocsEditPage):not(.MultiDimDetailPage) {
 
     &:hover {
         color: #000;
-    }
-}
-
-.EditableTags__action {
-    padding-left: 6px;
-    &:focus {
-        box-shadow: none;
-    }
-    svg {
-        margin-right: 5px;
     }
 }
 

--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -217,7 +217,7 @@ button {
         border: lightgray 1px solid;
         border-radius: 4px;
 
-        .btn {
+        button {
             margin-right: 0.5rem;
         }
     }

--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -22,8 +22,6 @@
 // the editor tabs, ExplorerCreatePage, UsersIndexPage, GdocsAdd and others,
 // and `admin.scss` also `@extend`s `.form-control`:
 @import "bootstrap/scss/forms";
-@import "bootstrap/scss/buttons";
-@import "bootstrap/scss/button-group";
 // still used by EditorReferencesTab (`input-group-prepend`/`input-group-text`):
 @import "bootstrap/scss/input-group";
 // Chrome and navigation. `nav` is still used by the `nav nav-tabs` chrome of
@@ -33,7 +31,6 @@
 @import "bootstrap/scss/pagination";
 // Components:
 @import "bootstrap/scss/badge";
-@import "bootstrap/scss/alert";
 // still used by EditorReferencesTab, EditorHistoryTab, EditorDataTab and
 // DimensionCard, which interleave `list-group-item`s with `EditableListItem`s:
 @import "bootstrap/scss/list-group";
@@ -47,7 +44,9 @@
 //   media, close, toasts, tooltip, popover, carousel, spinners,
 //   modal (`Forms.tsx`'s `Modal` is antd's; the `.modal-header`/`.modal-body`/
 //   `.modal-footer` markup its consumers pass in is styled in `Forms.scss`),
-//   navbar (the admin chrome is an antd `Layout` — see `AdminLayout.tsx`).
+//   navbar (the admin chrome is an antd `Layout` — see `AdminLayout.tsx`),
+//   buttons + button-group (every button in the admin is an antd `Button`),
+//   alert (every alert in the admin is an antd `Alert`).
 
 // Our own copy of the parts of Bootstrap's reboot the admin depends on, so that
 // removing `bootstrap/scss/reboot` above stays a small, deliberate step rather
@@ -124,14 +123,9 @@ button {
 
     button,
     a,
-    .btn,
     .form-group > label,
     .form-check > label {
         @extend .clickable;
-    }
-
-    .btn:disabled {
-        cursor: default;
     }
 
     section {
@@ -151,10 +145,6 @@ button {
             border: 0;
             background: none;
             padding: 0;
-        }
-
-        > .btn {
-            margin-right: 10px;
         }
     }
 
@@ -1317,12 +1307,6 @@ main:not(.ChartEditorPage):not(.GdocsEditPage):not(.MultiDimDetailPage) {
         &:hover a {
             opacity: 1;
         }
-    }
-}
-
-.input-group-prepend {
-    .btn {
-        z-index: 0;
     }
 }
 


### PR DESCRIPTION
> _Written by Anthropic Claude Fable 5 — @marcelgerber at the wheel._

**Stacked on #7047** (← #7046 ← #7044). Phase 3 of the admin's Bootstrap→antd migration: every Bootstrap-classed button (~174 sites) and alert (9 sites) in the admin is now an antd `<Button>`/`<Alert>`, and the `buttons`, `button-group` and `alert` Bootstrap modules are deleted. Semantic colors are preserved — "Update chart" stays green, destructive actions stay red — rather than flattening everything to primary.

One new shared component worth reviewing: `LinkButton` in `Link.tsx` — an antd Button rendering a real `<a href>` for router links (SPA navigation on plain click, cmd-/middle-click and copy-link-address keep working, no `<button>`-in-`<a>` nesting).

<details><summary>Details</summary>

**Commits by page family:** chart editor + save buttons (`94175ab1c0`), CRUD/index pages (`c9ae90770a`), gdocs/explorers/misc (`4e721a1133`), module pruning (`c25bb89512`).

**Mapping:** `btn-primary` → `type="primary"`; `btn-secondary`/`btn-light`/`btn-outline-secondary` → default; `btn-danger` → `color="danger" variant="solid"`; `btn-outline-danger` → `color="danger" variant="outlined"` (dataset archive); `btn-success` → `color="green" variant="solid"`; `btn-link` → `type="link"`; `btn-sm` → `size="small"` (dropping the scss that faked it). External anchors styled as buttons became `<Button href target="_blank">`. `ChartEditorView`'s `btn-group data-toggle="buttons"` mobile/desktop toggle → `Radio.Group optionType="button" buttonStyle="solid"` (state was already a two-value radio). antd 6 `Alert` conversions use `title` (not the deprecated `message`). `{" "}`/`mr-*` spacing hacks → antd `Space wrap`.

**SCSS (standing component-scoped rule):** new `SaveButtons.scss`, `ChartEditorView.scss`, `EditorDataTab.scss`, `EditableTags.scss`; `GdocsIndexPage.scss` adjusted (`.gdoc-index__actions { flex-shrink: 0 }` to keep header buttons on one line). `admin.scss` −143 lines net, including the dead `.btn` rules (`@extend .clickable` entry, `.btn:disabled`, `section > .btn`) and `.column-list-item .btn` → `button`.

**Module pruning:** `buttons`, `button-group`, `alert` deleted after grep-verifying zero `.btn`/`btn-*`/`.alert` references in admin TSX/SCSS (kept modules' internal `.btn` descendant selectors can no longer match). Still imported and annotated: `forms`, `input-group`, `nav`, `list-group`, `badge`, `breadcrumb`, `pagination`, `grid`, `tables`, `type`, `code`, `utilities`, `print`, `reboot` — Phases 4–6 territory. `adminSiteServer/testPageRouter.tsx` untouched (server-rendered without the admin bundle).

**Verification:** typecheck/lint/format clean; vitest 2336 passed. Headless-browser QA on a running dev stack: all chart-editor tabs with footer buttons in all three SaveButtons variants, a forced editing-error `Alert` with correctly disabled saves, the preview-mode toggle resizing the preview, users index (add-user modal, `LinkButton` Edit navigating client-side with a real href), dataset edit incl. archived state, variable edit, explorers list + TSV editor header, gdocs index + add-document modal, explorer tags, multi-dims, bulk chart editor — re-checked after module deletion; `document.querySelectorAll(".btn, .alert").length === 0` on the heaviest pages; no new console errors.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
